### PR TITLE
User/nnz/accumulate gtracer fluxes 2015.06.03

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -73,6 +73,7 @@ use mpp_mod, only : mpp_chksum
 
 #ifdef _USE_GENERIC_TRACER
 use MOM_generic_tracer, only : MOM_generic_flux_init
+use generic_tracer, only: generic_tracer_coupler_get
 #endif
 
 implicit none ; private
@@ -374,6 +375,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   call mpp_get_compute_domain(Ocean_sfc%Domain, index_bnds(1), index_bnds(2), &
                               index_bnds(3), index_bnds(4))
 
+
   if (OS%fluxes%fluxes_used) then
     call enable_averaging(time_step, OS%Time + Ocean_coupling_time_step, OS%MOM_CSp%diag) ! Needed to allow diagnostics in convert_IOB
     call convert_IOB_to_fluxes(Ice_ocean_boundary, OS%fluxes, index_bnds, OS%Time, &
@@ -384,6 +386,10 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
     if (OS%use_ice_shelf) then
       call shelf_calc_flux(OS%State, OS%fluxes, OS%Time, time_step, OS%Ice_shelf_CSp)
     endif
+
+#ifdef _USE_GENERIC_TRACER
+    call generic_tracer_coupler_get(OS%fluxes%tr_fluxes)
+#endif
 
     ! Indicate that there are new unused fluxes.
     OS%fluxes%fluxes_used = .false.

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -32,9 +32,6 @@ use MOM_spatial_means, only : global_area_integral
 use MOM_variables,     only : surface, thermo_var_ptrs
 
 use coupler_types_mod, only : coupler_2d_bc_type
-#ifdef _USE_GENERIC_TRACER
-  use generic_tracer, only: generic_tracer_coupler_accumulate
-#endif
 
 implicit none ; private
 
@@ -1341,17 +1338,18 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles)
 end subroutine register_forcing_type_diags
 
 
-subroutine forcing_accumulate(flux_tmp, fluxes, dt, G)
+subroutine forcing_accumulate(flux_tmp, fluxes, dt, G, wt2)
   type(forcing),         intent(in)    :: flux_tmp
   type(forcing),         intent(inout) :: fluxes
   real,                  intent(in)    :: dt
   type(ocean_grid_type), intent(inout) :: G
+  real,                  intent(out)   :: wt2
   !   This subroutine copies mechancal forcing from flux_tmp to fluxes and
   ! stores the time-weighted averages of the various buoyancy fluxes in fluxes,
   ! and increments the amount of time over which the buoyancy forcing should be
   ! applied.
 
-  real :: wt1, wt2
+  real :: wt1
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq, i0, j0
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, isr, ier, jsr, jer
   is   = G%isc   ; ie   = G%iec    ; js   = G%jsc   ; je   = G%jec
@@ -1477,15 +1475,8 @@ subroutine forcing_accumulate(flux_tmp, fluxes, dt, G)
   endif
 
   !### This needs to be replaced with an appropriate copy and average.
-   fluxes%tr_fluxes => flux_tmp%tr_fluxes
+  fluxes%tr_fluxes => flux_tmp%tr_fluxes
   
-#ifdef _USE_GENERIC_TRACER
-   !Cannot call MOM_generic_tracer_fluxes_accumulate(wt1, flux_tmp%tr_fluxes) since that model "use"s this one
-   !So, call the geneirc_tracer interface directly.
-   !if (CS%use_MOM_generic_tracer)  !CS is not defined here. 
-   call generic_tracer_coupler_accumulate(wt1, flux_tmp%tr_fluxes)
-#endif
-
 end subroutine forcing_accumulate
 
 

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -518,7 +518,7 @@ contains
     !
     !Extract the tracer surface fields from coupler and update tracer fields from sources
     !
-    call generic_tracer_coupler_get(fluxes%tr_fluxes)
+    !call generic_tracer_coupler_get(fluxes%tr_fluxes) !This is moved out to ocean_model_MOM.F90
 
     !
     !Add contribution of river to surface flux


### PR DESCRIPTION
This adds support for accumulating/averaging the fluxes for generic tracers for the THERMO_SPANS_COUPLING feature of MOM6. 

These updates are isolated by the   #ifdef _USE_GENERIC_TRACER so they will not affect MOM6 developers testcases

To run generic tracers testcases with these updates  in ulm  the generic tracers package should be updated too:

cd ocean_shared; git checkout -b user/nnz/verona_dev_merge

Here's the xml that has these updates:

git clone -b user/nnz/tracer_spanning_timestep http://gitlab.gfdl.noaa.gov/mdt/xml.git xmd_xml_spanning_tracers
cd xmd_xml_spanning_tracers
ls OM4.xml
