### PR TITLE
Fix compilation with OPENMP=1

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1010,7 +1010,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
 !$OMP                               ubt,vhbt,vbt,uh0,u_uh0,vh0,v_vh0,         &
 !$OMP                               use_BT_cont,uhbt0,BTCL_u,vhbt0,BTCL_v,    &
 !$OMP                               Datu,Datv,jsvf,jevf,isvf,ievf,u_accel_bt, &
-!$OMP                               v_accel_bt,U_in,V_in,Idt)
+!$OMP                               v_accel_bt,U_in,V_in,Idt,MS,G)
 !$OMP do
   do j=js,je ; do I=is-1,ie
     ! ### IDatu here should be replaced with 1/D+eta(Bous) or 1/eta(non-Bous).

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -699,8 +699,8 @@ subroutine zonal_face_thickness(u, h, hL, hR, h_u, dt, G, LB, vol_CFL, &
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = G%ke
 
 !$OMP parallel default(none) shared(ish,ieh,jsh,jeh,nz,u,vol_CFL,dt,G, &
-!$OMP                               hL,hR,h,h_u,visc_rem_u) &
-!$OMP                       private(CFL,curv_3,h_marg)
+!$OMP                               hL,hR,h,h_u,visc_rem_u,marginal) &
+!$OMP                       private(CFL,curv_3,h_marg,h_avg)
 !$OMP do
   do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
     if (u(I,j,k) > 0.0) then
@@ -1450,8 +1450,8 @@ subroutine merid_face_thickness(v, h, hL, hR, h_v, dt, G, LB, vol_CFL, &
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = G%ke
 
 !$OMP parallel default(none) shared(ish,ieh,jsh,jeh,nz,v,vol_CFL,dt,G, &
-!$OMP                               hL,hR,h,h_v,visc_rem_v) &
-!$OMP                       private(CFL,curv_3,h_marg)
+!$OMP                               hL,hR,h,h_v,visc_rem_v,marginal) &
+!$OMP                       private(CFL,curv_3,h_marg,h_avg)
 !$OMP do
   do k=1,nz ; do J=jsh-1,jeh ; do i=ish,ieh
     if (v(i,J,k) > 0.0) then

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -2414,11 +2414,13 @@ subroutine applyBoundaryFluxesInOut(CS, G, dt, fluxes, optics, ea, h, tv, &
 !$OMP                                  H_limit_fluxes,use_riverHeatContent,              &
 !$OMP                                  useCalvingHeatContent,ea,IforcingDepthScale,      &
 !$OMP                                  numberOfGroundings,iGround,jGround,               &
-!$OMP                                  hGrounding,CS,Idt,aggregate_FW_forcing)           &
+!$OMP                                  hGrounding,CS,Idt,aggregate_FW_forcing,           &
+!$OMP                                  calculate_energetics,dSV_dT,dSV_dS,cTKE,g_Hconv2) &
 !$OMP                          private(opacityBand,h2d,T2d,netMassInOut,netMassOut,      &
 !$OMP                                  netHeat,netSalt,Pen_SW_bnd,fractionOfForcing,     &
 !$OMP                                  dThickness,dTemp,dSalt,hOld,Ithickness,           &
-!$OMP                                  netMassIn)
+!$OMP                                  netMassIn,pres,d_pres,p_lay,dSV_dT_2d,            &
+!$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst)
 
   ! work in vertical slices for efficiency 
   do j=js,je 

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -372,6 +372,33 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, CS, &
   endif
 
 
+!$OMP parallel do default(none) shared(js,je,nz,is,ie,h_3d,u_3d,v_3d,tv,dt,      &
+!$OMP                                  CS,G,sfc_connected,fluxes,IdtdR0,         &
+!$OMP                                  TKE_forced,debug,H_neglect,dSV_dT,        &
+!$OMP                                  dSV_dS,I_dtmrho,C1_3,h_tt_min,vonKar,     &
+!$OMP                                  max_itt,Kd_int)                           &
+!$OMP                           private(h,u,v,T,S,Kd,mech_TKE_k,conv_PErel_k,    &
+!$OMP                                   U_Star,absf,mech_TKE,conv_PErel,nstar_k, &
+!$OMP                                   h_sum,I_hs,h_bot,hb_hs,T0,S0,num_itts,   &
+!$OMP                                   pres,dMass,dPres,dT_to_dPE,dS_to_dPE,    &
+!$OMP                                   dT_to_dColHt,dS_to_dColHt,Kddt_h,        &
+!$OMP                                   b_den_1,dT_to_dPE_a,dT_to_dColHt_a,      &
+!$OMP                                   dS_to_dColHt_a,htot,uhtot,vhtot,         &
+!$OMP                                   Idecay_len_TKE,exp_kh,nstar_FC,tot_TKE,  &
+!$OMP                                   TKE_reduc,dTe_t2,dSe_t2,dTe,dSe,dt_h,    &
+!$OMP                                   Convectively_stable,sfc_disconnect,b1,   &
+!$OMP                                   c1,dT_km1_t2,dS_km1_t2,dTe_term,         &
+!$OMP                                   dSe_term,MKE2_Hharm,vstar,h_tt,          &
+!$OMP                                   Kd_guess0,Kddt_h_g0,dPEc_dKd_Kd0,        &
+!$OMP                                   PE_chg_max,dPEa_dKd_g0,PE_chg_g0,        &
+!$OMP                                   MKE_src,dPE_conv,Kddt_h_max,Kddt_h_min,  &
+!$OMP                                   TKE_left_max,TKE_left_min,Kddt_h_guess,  &
+!$OMP                                   TKE_left_itt,dPEa_dKd_itt,PE_chg_itt,    &
+!$OMP                                   MKE_src_itt,Kddt_h_itt,dPEc_dKd,PE_chg,  &
+!$OMP                                   dMKE_src_dK,TKE_left,use_Newt,           &
+!$OMP                                   dKddt_h_Newt,Kddt_h_Newt,Kddt_h_next,    &
+!$OMP                                   dKddt_h,Te,Se,Hsfc_used,dS_to_dPE_a,     &
+!$OMP                                   dMKE_max)
   do j=js,je
     ! Copy the thicknesses and other fields to 2-d arrays.
     do k=1,nz ; do i=is,ie
@@ -847,8 +874,6 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, CS, &
     enddo ; enddo
 
   enddo ! j-loop
-
-!$OMP end parallel
 
   if (write_diags) then
     if (CS%id_ML_depth > 0) &


### PR DESCRIPTION
The compilation errors are mostly due to `OMP parallel` clauses with `default(none)` not being updated when new code is added that references new variables. The `OMP parallel do` clause in MOM_energetic_PBL.F90 uses `default(private)` because of the very large number of private variables relative to shared variables.