### PR TITLE
Reorder diag grid updates with group passes

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1282,14 +1282,14 @@ subroutine step_MOM(fluxes, state, Time_start, time_interval, CS)
           endif
         endif
 
+        call cpu_clock_begin(id_clock_pass)
+        call do_group_pass(CS%pass_uv_T_S_h, G%Domain)
+        call cpu_clock_end(id_clock_pass)
+
         ! Whenever thickness changes let the diag manager know, target grids
         ! for vertical remapping may need to be regenerated. This needs to
         ! happen after the H update and before the next post_data.
         call diag_update_target_grids(CS%diag)
-
-        call cpu_clock_begin(id_clock_pass)
-        call do_group_pass(CS%pass_uv_T_S_h, G%Domain)
-        call cpu_clock_end(id_clock_pass)
 
         if (CS%debug) then
           call uchksum(u,"Post-diabatic u", G, haloshift=2)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -915,12 +915,12 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
                   CS%continuity_CSp, CS%uhbt, CS%vhbt, CS%OBC, &
                   CS%visc_rem_u, CS%visc_rem_v, u_av, v_av)
   call cpu_clock_end(id_clock_continuity)
-  ! Whenever thickness changes let the diag manager know, target grids
-  ! for vertical remapping may need to be regenerated.
-  call diag_update_target_grids(CS%diag)
   call cpu_clock_begin(id_clock_pass)
   call do_group_pass(CS%pass_h, G%Domain)
   call cpu_clock_end(id_clock_pass)
+  ! Whenever thickness changes let the diag manager know, target grids
+  ! for vertical remapping may need to be regenerated.
+  call diag_update_target_grids(CS%diag)
   if (showCallTree) call callTree_wayPoint("done with continuity (step_MOM_dyn_split_RK2)")
 
   call cpu_clock_begin(id_clock_pass)

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -439,13 +439,13 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, fluxes, &
   call continuity(upp, vpp, hp, h, uh, vh, &
                   (dt*0.5), G, CS%continuity_CSp, OBC=CS%OBC)
   call cpu_clock_end(id_clock_continuity)
-  ! Whenever thickness changes let the diag manager know, target grids
-  ! for vertical remapping may need to be regenerated.
-  call diag_update_target_grids(CS%diag)
   call cpu_clock_begin(id_clock_pass)
   call pass_var(h, G%Domain)
   call pass_vector(uh, vh, G%Domain)
   call cpu_clock_end(id_clock_pass)
+  ! Whenever thickness changes let the diag manager know, target grids
+  ! for vertical remapping may need to be regenerated.
+  call diag_update_target_grids(CS%diag)
 
   call enable_averaging(0.5*dt, Time_local, CS%diag)
 !   Here the second half of the thickness fluxes are offered for averaging.


### PR DESCRIPTION
It is possible to hit the error "remap_diag_to_z: H has changed since remapping grids were updated" when running using MPI. This appears to occur after locations where `diag_update_target_grids` is called before a group pass of thickness. The errors occur because the check that `h_old` is equal to `h` includes halos, which aren't updated until after the group pass. Instead of adjusting the indices over which `h_old` is defined, we rearrange calls to `diag_update_target_grids` so that they are performed after group passes, to ensure consistency and avoid remapping errors.