### PR TITLE
User/jpk/z layer average diags

### DIFF
--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -137,9 +137,9 @@ function global_z_mean(var,G,CS,tracer)
   do k=1, nz ; do j=js,je ; do i=is, ie
     ! This block below determines the partial cell weights.  It could be moved outside
     ! of the loop for efficiency
-    !if (G%bathyT(i,j) >= CS%Z_int(k+1)) then
-    !  depth_weight(i,j,k) = 1.
-    !else 
+    if (G%bathyT(i,j) >= CS%Z_int(k+1)) then
+      depth_weight(i,j,k) = 1.
+    else 
     if ( (G%bathyT(i,j) > CS%Z_int(k)) .and. (G%bathyT(i,j) < CS%Z_int(k+1))) then
       depth_weight(i,j,k) = (G%bathyT(i,j) - CS%Z_int(k)) / (CS%Z_int(k+1) - CS%Z_int(k))
     else


### PR DESCRIPTION
This pull request adds the capability of sending layer average diagnostics to the 'ocean_model_z' output stream.  The layer averaging is done immediately following the remapping to z.  It is available to all tracers by appending '_xyave' to the field name, e.g. thetao_xyave.