### PR TITLE
Fix non-inputdir path for DIAG_REMAP_Z_GRID_DEF

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -279,7 +279,8 @@ subroutine set_axes_info(G, param_file, diag_cs, set_vertical)
          "Found '"//trim(string)//"'")
     else
       if (string(6:6)=='.' .or. string(6:6)=='/') then
-        filename = trim(inputdir) // trim(extractWord(trim(string(1:200)), 1))
+        inputdir = "."
+        filename = trim(extractWord(trim(string(6:200)), 1))
       else
         call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
         inputdir = slasher(inputdir)


### PR DESCRIPTION
The previous code erroneously used an uninitialised input directory, as well as taking the wrong string slice for the filename if it was specified as a path relative to the current directory, rather than `INPUTDIR`.