### PR TITLE
Deallocate Kd_user diag array

### DIFF
--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -920,6 +920,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, G, C
   if (associated(dd%N2_bot)) deallocate(dd%N2_bot)
   if (associated(dd%N2_meanz)) deallocate(dd%N2_meanz)
   if (associated(dd%Kd_work)) deallocate(dd%Kd_work)
+  if (associated(dd%Kd_user)) deallocate(dd%Kd_user)
   if (associated(dd%Kd_Niku)) deallocate(dd%Kd_Niku)
   if (associated(dd%Kd_Niku_work)) deallocate(dd%Kd_Niku_work)
   if (associated(dd%Kd_Itidal_Work))  deallocate(dd%Kd_Itidal_Work)


### PR DESCRIPTION
There was a memory leak when enabling the Kd_user diagnostic. This is because it is allocated at the top of set_diffusivity() without being deallocated.