### PR TITLE
Allows MLE parameterization to use ePBL's active mixing depth

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -91,6 +91,7 @@ use MOM_lateral_mixing_coeffs, only : calc_resoln_function, VarMix_CS
 use MOM_MEKE,                  only : MEKE_init, MEKE_alloc_register_restart, step_forward_MEKE, MEKE_CS
 use MOM_MEKE_types,            only : MEKE_type
 use MOM_mixed_layer_restrat,   only : mixedlayer_restrat, mixedlayer_restrat_init, mixedlayer_restrat_CS
+use MOM_mixed_layer_restrat,   only : mixedlayer_restrat_register_restarts
 use MOM_neutral_diffusion,     only : neutral_diffusion_CS, neutral_diffusion_diag_init
 use MOM_obsolete_diagnostics,  only : register_obsolete_diagnostics
 use MOM_open_boundary,         only : Radiation_Open_Bdry_Conds, open_boundary_init
@@ -890,7 +891,8 @@ subroutine step_MOM(fluxes, state, Time_start, time_interval, CS)
         call vchksum(CS%vhtr,"Pre-mixedlayer_restrat vhtr", G, haloshift=0)
       endif
       call cpu_clock_begin(id_clock_ml_restrat)
-      call mixedlayer_restrat(h, CS%uhtr ,CS%vhtr, CS%tv, fluxes, dt, G, CS%mixedlayer_restrat_CSp)
+      call mixedlayer_restrat(h, CS%uhtr ,CS%vhtr, CS%tv, fluxes, dt, CS%visc%MLD, &
+                              G, CS%mixedlayer_restrat_CSp)
       call cpu_clock_end(id_clock_ml_restrat)
       call cpu_clock_begin(id_clock_pass)
       call do_group_pass(CS%pass_h, G%Domain)
@@ -1731,6 +1733,7 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in)
 
   call MEKE_alloc_register_restart(G, param_file, CS%MEKE, CS%restart_CSp)
   call set_visc_register_restarts(G, param_file, CS%visc, CS%restart_CSp)
+  call mixedlayer_restrat_register_restarts(G, param_file, CS%mixedlayer_restrat_CSp, CS%restart_CSp)
 
   ! Initialize fields
   if (associated(CS%tracer_Reg)) init_CS%tracer_Reg => CS%tracer_Reg

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -211,11 +211,12 @@ type, public :: vertvisc_type
     kv_tbl_shelf_u => NULL(), &  ! Viscosity in the viscous top boundary
     kv_tbl_shelf_v => NULL(), &  ! layer under ice shelves, in m2 s-1.
     nkml_visc_u => NULL(), & ! The number of layers in the viscous surface
-    nkml_visc_v => NULL()    ! mixed layer.  These are not integers because
+    nkml_visc_v => NULL(), & ! mixed layer.  These are not integers because
                              ! there may be fractional layers.  This is done
                              ! in terms of layers, not depth, to facilitate
                              ! the movement of the viscous boundary layer with
                              ! the flow.
+    MLD => NULL()            !< Instantaneous active mixing layer depth (H units).
   real, pointer, dimension(:,:,:) :: &
     Ray_u => NULL(), &  ! The Rayleigh drag velocity to be applied to each layer
     Ray_v => NULL(), &  ! at u- and v-points, in m s-1.

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -200,7 +200,10 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, fluxes, dt, MLD, G, CS)
     aFac = CS%MLE_MLD_decay_time / ( dt + CS%MLE_MLD_decay_time )
     bFac = dt / ( dt + CS%MLE_MLD_decay_time )
     do j = js, je ; do i = is, ie
-      CS%MLD_filtered(i,j) = bFac*MLD(i,j) + aFac*CS%MLD_filtered(i,j)
+      ! Expression bFac*MLD(i,j) + aFac*CS%MLD_filtered(i,j) is the time-filtered
+      ! (running mean) of MLD. The max() allows the "running mean" to be reset
+      ! instantly to a deeper MLD.
+      CS%MLD_filtered(i,j) = max( MLD(i,j), bFac*MLD(i,j) + aFac*CS%MLD_filtered(i,j) )
       CS%MLD(i,j) = CS%MLD_filtered(i,j)
     enddo ; enddo
     call pass_var(MLD, G%domain)

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -198,7 +198,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, fluxes, dt, MLD, G, CS)
     if (.not. associated(MLD)) call MOM_error(FATAL, "MOM_mixedlayer_restrat: "// &
          "Argument MLD was not associated!")
     aFac = CS%MLE_MLD_decay_time / ( dt + CS%MLE_MLD_decay_time )
-    bFac = 1. - aFac
+    bFac = dt / ( dt + CS%MLE_MLD_decay_time )
     do j = js, je ; do i = is, ie
       CS%MLD_filtered(i,j) = bFac*MLD(i,j) + aFac*CS%MLD_filtered(i,j)
       CS%MLD(i,j) = CS%MLD_filtered(i,j)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -22,6 +22,7 @@ use MOM_domains,             only : pass_var, To_West, To_South
 use MOM_domains,             only : create_group_pass, do_group_pass, group_pass_type
 use MOM_energetic_PBL,       only : energetic_PBL, energetic_PBL_init
 use MOM_energetic_PBL,       only : energetic_PBL_end, energetic_PBL_CS
+use MOM_energetic_PBL,       only : energetic_PBL_get_MLD
 use MOM_entrain_diffusive,   only : entrainment_diffusive, entrain_diffusive_init
 use MOM_entrain_diffusive,   only : entrain_diffusive_end, entrain_diffusive_CS
 use MOM_EOS,                 only : calculate_density, calculate_2_densities, calculate_TFreeze
@@ -735,6 +736,9 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, CS)
       call find_uv_at_h(u, v, h, u_h, v_h, G)
       call energetic_PBL(h, u_h, v_h, tv, fluxes, dt, Kd_ePBL, G, &
                          CS%energetic_PBL_CSp, dSV_dT, dSV_dS, cTKE)
+
+      ! If visc%MLD exists, copy the ePBL's MLD into it
+      if (associated(visc%MLD)) call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, visc%MLD, G)
 
       ! Augment the diffusivities due to those diagnosed in energetic_PBL.
       do K=2,nz ; do j=js,je ; do i=is,ie

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -81,6 +81,7 @@ implicit none ; private
 #include <MOM_memory.h>
 
 public energetic_PBL, energetic_PBL_init, energetic_PBL_end
+public energetic_PBL_get_MLD
 
 type, public :: energetic_PBL_CS ; private
   real    :: mstar           ! The ratio of the friction velocity cubed to the
@@ -1077,6 +1078,18 @@ subroutine find_PE_chg(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
   endif
 
 end subroutine find_PE_chg
+
+!> Copies the ePBL active mixed layer depth into MLD
+subroutine energetic_PBL_get_MLD(CS, MLD, G)
+  type(energetic_PBL_CS),         pointer     :: CS  !< Control structure for ePBL
+  real, dimension(NIMEM_,NJMEM_), intent(out) :: MLD !< Depth of ePBL active mixing layer
+  type(ocean_grid_type),          intent(in)  :: G   !< Grid structure
+  ! Local variables
+  integer :: i,j
+  do j = G%jsc, G%jec ; do i = G%isc, G%iec
+    MLD(i,j) = CS%ML_depth(i,j)
+  enddo ; enddo
+end subroutine energetic_PBL_get_MLD
 
 subroutine energetic_PBL_init(Time, G, param_file, diag, CS)
   type(time_type), target, intent(in)    :: Time

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1499,7 +1499,7 @@ subroutine set_visc_register_restarts(G, param_file, visc, restart_CS)
 !                   fields.  Allocated here.
 !  (in)      restart_CS - A pointer to the restart control structure.
   type(vardesc) :: vd
-  logical :: use_kappa_shear, adiabatic, useKPP, useEPBL
+  logical :: use_kappa_shear, adiabatic, useKPP, useEPBL, MLE_use_PBL_MLD
   integer :: isd, ied, jsd, jed, nz
   character(len=40)  :: mod = "MOM_set_visc"  ! This module's name.
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = G%ke
@@ -1534,6 +1534,16 @@ subroutine set_visc_register_restarts(G, param_file, visc, restart_CS)
     vd = var_desc("Kv_turb","m2 s-1","Turbulent viscosity at interfaces", &
                   hor_grid='h', z_grid='i')
     call register_restart_field(visc%Kv_turb, vd, .false., restart_CS)
+  endif
+
+  ! visc%MLD is used to communicate the state of the (e)PBL to the rest of the model
+  call get_param(param_file, mod, "MLE_USE_PBL_MLD", MLE_use_PBL_MLD, &
+                 default=.false., do_not_log=.true.)
+  if (MLE_use_PBL_MLD) then
+    allocate(visc%MLD(isd:ied,jsd:jed)) ; visc%MLD(:,:) = 0.0
+    vd = var_desc("MLD","m","Instantaneous active mixing layer depth", &
+                  hor_grid='h', z_grid='1')
+    call register_restart_field(visc%MLD, vd, .false., restart_CS)
   endif
 
 end subroutine set_visc_register_restarts


### PR DESCRIPTION
- This sets up the framework to use the active mixing layer depth
  diagnosed within ePBL for the mixed-layer depth used within the
  mixed-layer eddy restratification parameterization.
- It will also allow us to use ePBL's MLD for other purposes if needed.