### PR TITLE
Print the correct array element for diagnosis

### DIFF
--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -280,7 +280,7 @@ subroutine opacity_from_chl(optics, fluxes, G, CS, chl_in)
       if ((G%mask2dT(i,j) > 0.5) .and. (chl_in(i,j,k) < 0.0)) then
           write(mesg,'(" Negative chl_in of ",(1pe12.4)," found at i,j,k = ", &
                     & 3(1x,i3), " lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
-                     chl_data(i,j), i, j, k, G%geoLonT(i,j), G%geoLatT(i,j)
+                     chl_in(i,j,k), i, j, k, G%geoLonT(i,j), G%geoLatT(i,j)
           call MOM_error(FATAL,"MOM_opacity opacity_from_chl: "//trim(mesg))
       endif
     enddo; enddo; enddo


### PR DESCRIPTION
- This fixes a bug that would print an incorrect array element when
  an error is caught when that array element beocmes negative.