### PR TITLE
check and bound g_tracer value issue #225

### DIFF
--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -280,7 +280,7 @@ subroutine opacity_from_chl(optics, fluxes, G, CS, chl_in)
       if ((G%mask2dT(i,j) > 0.5) .and. (chl_in(i,j,k) < 0.0)) then
           write(mesg,'(" Negative chl_in of ",(1pe12.4)," found at i,j,k = ", &
                     & 3(1x,i3), " lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
-                     chl_data(i,j), i, j, k, G%geoLonT(i,j), G%geoLatT(i,j)
+                     chl_in(i,j,k), i, j, k, G%geoLonT(i,j), G%geoLatT(i,j)
           call MOM_error(FATAL,"MOM_opacity opacity_from_chl: "//trim(mesg))
       endif
     enddo; enddo; enddo

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -362,6 +362,15 @@ contains
                                 src_var_record = g_tracer%src_var_record,                  &
                                 src_var_gridspec = g_tracer%src_var_gridspec               )
 
+         !Check/apply the bounds for each g_tracer
+         do k=1,nk ; do j=jsc,jec ; do i=isc,iec
+            if(tr_ptr(i,j,k) .ne. CS%tracer_land_val) then
+              if(tr_ptr(i,j,k) .lt. g_tracer%src_var_valid_min) tr_ptr(i,j,k) = g_tracer%src_var_valid_min
+              !Jasmin does not want to apply the maximum for now
+              !if(tr_ptr(i,j,k) .gt. g_tracer%src_var_valid_max) tr_ptr(i,j,k) = g_tracer%src_var_valid_max
+            endif
+         enddo; enddo ; enddo
+
        else !Do it old way if the tracer is not registered to start from a specific source file.  
             !This path should be deprecated if all generic tracers are required to start from specified sources.
         if (len_trim(CS%IC_file) > 0) then


### PR DESCRIPTION
- This fix addresses the occasional negative values for concentration of some generic tracers
  that are initialized from source files with non-native resolutions.
- Generic tracers can have min/max bounds specified in the field_table and this fix
  checks and applies the lower bound for such tracers after they are initilized to
  avoid unphysical (mostly negative underflow) values.
- The mod for MOM_opacity.F90 is a typo fix that causes positive and irrelevant values to be printed in
  error messages  that should catch only negative values.