### PR TITLE
comments out the omp directives inside barotropic time step loop. 

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1603,30 +1603,30 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
         call find_face_areas(Datu, Datv, G, CS, MS, eta, 1+iev-ie)
     endif
 
-!$OMP parallel default(none) shared(CS,isv,iev,jsv,jev,project_velocity,use_BT_cont, &
-!$OMP                               uhbt,vhbt,ubt,BTCL_u,uhbt0,vbt,BTCL_v,vhbt0,     &
-!$OMP                               eta_pred,eta,eta_src,dtbt,Datu,Datv,p_surf_dyn,  &
-!$OMP                               dyn_coef_eta,find_etaav,is,ie,js,je,eta_sum,     &
-!$OMP                               wt_accel2,n,eta_PF_BT,interp_eta_PF,wt_end,      &
-!$OMP                               Instep,eta_PF,eta_PF_1,d_eta_PF,                 &
-!$OMP                               apply_OBC_flather,ubt_old,vbt_old )
+!GOMP parallel default(none) shared(CS,isv,iev,jsv,jev,project_velocity,use_BT_cont, &
+!GOMP                               uhbt,vhbt,ubt,BTCL_u,uhbt0,vbt,BTCL_v,vhbt0,     &
+!GOMP                               eta_pred,eta,eta_src,dtbt,Datu,Datv,p_surf_dyn,  &
+!GOMP                               dyn_coef_eta,find_etaav,is,ie,js,je,eta_sum,     &
+!GOMP                               wt_accel2,n,eta_PF_BT,interp_eta_PF,wt_end,      &
+!GOMP                               Instep,eta_PF,eta_PF_1,d_eta_PF,                 &
+!GOMP                               apply_OBC_flather,ubt_old,vbt_old )
     if (CS%dynamic_psurf .or. .not.project_velocity) then
       if (use_BT_cont) then
-!$OMP do
+!GOMP do
         do j=jsv-1,jev+1 ; do I=isv-2,iev+1
           uhbt(I,j) = find_uhbt(ubt(I,j),BTCL_u(I,j)) + uhbt0(I,j)
         enddo ; enddo
-!$OMP do
+!GOMP do
         do J=jsv-2,jev+1 ; do i=isv-1,iev+1
           vhbt(i,J) = find_vhbt(vbt(i,J),BTCL_v(i,J)) + vhbt0(i,J)
         enddo ; enddo
-!$OMP do
+!GOMP do
         do j=jsv-1,jev+1 ; do i=isv-1,iev+1
           eta_pred(i,j) = (eta(i,j) + eta_src(i,j)) + (dtbt * CS%IareaT(i,j)) * &
                      ((uhbt(I-1,j) - uhbt(I,j)) + (vhbt(i,J-1) - vhbt(i,J)))
         enddo ; enddo
       else
-!$OMP do
+!GOMP do
         do j=jsv-1,jev+1 ; do i=isv-1,iev+1
           eta_pred(i,j) = (eta(i,j) + eta_src(i,j)) + (dtbt * CS%IareaT(i,j)) * &
               (((Datu(I-1,j)*ubt(I-1,j) + uhbt0(I-1,j)) - &
@@ -1637,7 +1637,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       endif
 
       if (CS%dynamic_psurf) then
-!$OMP do
+!GOMP do
         do j=jsv-1,jev+1 ; do i=isv-1,iev+1
           p_surf_dyn(i,j) = dyn_coef_eta(I,j) * (eta_pred(i,j) - eta(i,j))
         enddo ; enddo
@@ -1648,7 +1648,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
     !  eta_PF_BT => eta_pred ; if (project_velocity) eta_PF_BT => eta
 
     if (find_etaav) then
-!$OMP do
+!GOMP do
       do j=js,je ; do i=is,ie
         eta_sum(i,j) = eta_sum(i,j) + wt_accel2(n) * eta_PF_BT(i,j)
       enddo ; enddo
@@ -1656,23 +1656,23 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
 
     if (interp_eta_PF) then
       wt_end = n*Instep  ! This could be (n-0.5)*Instep.
-!$OMP do
+!GOMP do
       do j=jsv-1,jev+1 ; do i=isv-1,iev+1
         eta_PF(i,j) = eta_PF_1(i,j) + wt_end*d_eta_PF(i,j)
       enddo ; enddo
     endif
 
     if (apply_OBC_flather) then
-!$OMP do
+!GOMP do
       do j=jsv,jev ; do I=isv-2,iev+1
         ubt_old(I,j) = ubt(I,j)
       enddo ; enddo
-!$OMP do
+!GOMP do
       do J=jsv-2,jev+1 ; do i=isv,iev
         vbt_old(i,J) = vbt(i,J)
       enddo ; enddo
     endif
-!$OMP end parallel
+!GOMP end parallel
 
     if (apply_OBCs) then
       if (MOD(n+G%first_direction,2)==1) then
@@ -1682,9 +1682,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       endif
 
       if (apply_u_OBCs) then  ! save the old value of vbt and vhbt
-!$OMP parallel do default(none) shared(isv,iev,jsv,jev,ioff,joff,ubt_prev,ubt,uhbt_prev,  &
-!$OMP                                  uhbt,ubt_sum_prev,ubt_sum,uhbt_sum_prev, &
-!$OMP                                  uhbt_sum,ubt_wtd_prev,ubt_wtd)
+!GOMP parallel do default(none) shared(isv,iev,jsv,jev,ioff,joff,ubt_prev,ubt,uhbt_prev,  &
+!GOMP                                  uhbt,ubt_sum_prev,ubt_sum,uhbt_sum_prev, &
+!GOMP                                  uhbt_sum,ubt_wtd_prev,ubt_wtd)
         do J=jsv-joff,jev+joff ; do i=isv-1,iev
           ubt_prev(i,J) = ubt(i,J); uhbt_prev(i,J) = uhbt(i,J)
           ubt_sum_prev(i,J)=ubt_sum(i,J); uhbt_sum_prev(i,J)=uhbt_sum(i,J) ; ubt_wtd_prev(i,J)=ubt_wtd(i,J)
@@ -1692,9 +1692,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       endif
 
       if (apply_v_OBCs) then  ! save the old value of vbt and vhbt
-!$OMP parallel do default(none) shared(isv,iev,jsv,jev,ioff,joff,vbt_prev,vbt,vhbt_prev,  &
-!$OMP                                  vhbt,vbt_sum_prev,vbt_sum,vhbt_sum_prev, &
-!$OMP                                  vhbt_sum,vbt_wtd_prev,vbt_wtd)
+!GOMP parallel do default(none) shared(isv,iev,jsv,jev,ioff,joff,vbt_prev,vbt,vhbt_prev,  &
+!GOMP                                  vhbt,vbt_sum_prev,vbt_sum,vhbt_sum_prev, &
+!GOMP                                  vhbt_sum,vbt_wtd_prev,vbt_wtd)
         do J=jsv-1,jev ; do i=isv-ioff,iev+ioff
           vbt_prev(i,J) = vbt(i,J); vhbt_prev(i,J) = vhbt(i,J)
           vbt_sum_prev(i,J)=vbt_sum(i,J); vhbt_sum_prev(i,J)=vhbt_sum(i,J) ; vbt_wtd_prev(i,J) = vbt_wtd(i,J)
@@ -1702,19 +1702,19 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       endif
     endif
 
-!$OMP parallel default(none) shared(isv,iev,jsv,jev,G,amer,ubt,cmer,bmer,dmer,eta_PF_BT, &
-!$OMP                               eta_PF,gtot_N,gtot_S,dgeo_de,CS,p_surf_dyn,n,        &
-!$OMP                               v_accel_bt,wt_accel,wt_accel2,vbt,bt_rem_v,          &
-!$OMP                               BT_force_v,vhbt,Cor_ref_v,dtbt,trans_wt1,trans_wt2,  &
-!$OMP                               use_BT_cont,BTCL_v,vhbt0,Datv,wt_vel,azon,bzon,czon, &
-!$OMP                               dzon,Cor_ref_u,gtot_E,gtot_W,u_accel_bt,bt_rem_u,    &
-!$OMP                               BT_force_u,uhbt,BTCL_u,uhbt0,Datu,Cor_u,Cor_v,       &
-!$OMP                               PFu,PFv,ubt_trans,vbt_trans,apply_v_OBCs,BT_OBC,     &
-!$OMP                               vbt_prev,vhbt_prev,apply_u_OBCs,ubt_prev,uhbt_prev ) &
-!$OMP                       private(vel_prev)
+!GOMP parallel default(none) shared(isv,iev,jsv,jev,G,amer,ubt,cmer,bmer,dmer,eta_PF_BT, &
+!GOMP                               eta_PF,gtot_N,gtot_S,dgeo_de,CS,p_surf_dyn,n,        &
+!GOMP                               v_accel_bt,wt_accel,wt_accel2,vbt,bt_rem_v,          &
+!GOMP                               BT_force_v,vhbt,Cor_ref_v,dtbt,trans_wt1,trans_wt2,  &
+!GOMP                               use_BT_cont,BTCL_v,vhbt0,Datv,wt_vel,azon,bzon,czon, &
+!GOMP                               dzon,Cor_ref_u,gtot_E,gtot_W,u_accel_bt,bt_rem_u,    &
+!GOMP                               BT_force_u,uhbt,BTCL_u,uhbt0,Datu,Cor_u,Cor_v,       &
+!GOMP                               PFu,PFv,ubt_trans,vbt_trans,apply_v_OBCs,BT_OBC,     &
+!GOMP                               vbt_prev,vhbt_prev,apply_u_OBCs,ubt_prev,uhbt_prev ) &
+!GOMP                       private(vel_prev)
     if (MOD(n+G%first_direction,2)==1) then
       ! On odd-steps, update v first.
-!$OMP do
+!GOMP do
       do J=jsv-1,jev ; do i=isv-1,iev+1
         Cor_v(i,J) = -1.0*((amer(I-1,j) * ubt(I-1,j) + cmer(I,j+1) * ubt(I,j+1)) + &
                (bmer(I,j) * ubt(I,j) + dmer(I-1,j+1) * ubt(I-1,j+1))) - Cor_ref_v(i,J)
@@ -1723,12 +1723,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
                    dgeo_de * CS%IdyCv(i,J)
       enddo ; enddo
       if (CS%dynamic_psurf) then
-!$OMP do
+!GOMP do
         do J=jsv-1,jev ; do i=isv-1,iev+1
           PFv(i,J) = PFv(i,J) + (p_surf_dyn(i,j) - p_surf_dyn(i,j+1)) * CS%IdyCv(i,J)
         enddo ; enddo
       endif
-!$OMP do
+!GOMP do
       do J=jsv-1,jev ; do i=isv-1,iev+1
         v_accel_bt(i,J) = v_accel_bt(i,J) + wt_accel(n) * (Cor_v(i,J) + PFv(i,J))
         vel_prev = vbt(i,J)
@@ -1738,24 +1738,24 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       enddo ; enddo
 
       if (use_BT_cont) then
-!$OMP do
+!GOMP do
         do J=jsv-1,jev ; do i=isv-1,iev+1
           vhbt(i,J) = find_vhbt(vbt_trans(i,J),BTCL_v(i,J)) + vhbt0(i,J)
         enddo ; enddo
       else
-!$OMP do
+!GOMP do
         do J=jsv-1,jev ; do i=isv-1,iev+1
           vhbt(i,J) = Datv(i,J)*vbt_trans(i,J) + vhbt0(i,J)
         enddo ; enddo
       endif
       if(apply_v_OBCs) then  ! copy back the value for the points that OBC_mask_v is true.
-!$OMP do
+!GOMP do
         do J=jsv-1,jev ; do i=isv-1,iev+1 ; if (BT_OBC%OBC_mask_v(i,J)) then
           vbt(i,J) = vbt_prev(i,J); vhbt(i,J) = vhbt_prev(i,J)
         endif ; enddo ; enddo
       endif
       ! Now update the zonal velocity.
-!$OMP do
+!GOMP do
       do j=jsv,jev ; do I=isv-1,iev
         Cor_u(I,j) = ((azon(I,j) * vbt(i+1,J) + czon(I,j) * vbt(i,J-1)) + &
                       (bzon(I,j) * vbt(i,J) + dzon(I,j) * vbt(i+1,J-1))) - &
@@ -1766,12 +1766,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       enddo ; enddo
 
       if (CS%dynamic_psurf) then
-!$OMP do
+!GOMP do
         do j=jsv,jev ; do I=isv-1,iev
           PFu(I,j) = PFu(I,j) + (p_surf_dyn(i,j) - p_surf_dyn(i+1,j)) * CS%IdxCu(I,j)
         enddo ; enddo
       endif
-!$OMP do
+!GOMP do
       do j=jsv,jev ; do I=isv-1,iev
         u_accel_bt(I,j) = u_accel_bt(I,j) + wt_accel(n) * (Cor_u(I,j) + PFu(I,j))
         vel_prev = ubt(I,j)
@@ -1781,25 +1781,25 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       enddo ; enddo
 
       if (use_BT_cont) then
-!$OMP do
+!GOMP do
         do j=jsv,jev ; do I=isv-1,iev
           uhbt(I,j) = find_uhbt(ubt_trans(I,j), BTCL_u(I,j)) + uhbt0(I,j)
         enddo ; enddo
       else
-!$OMP do
+!GOMP do
         do j=jsv,jev ; do I=isv-1,iev
           uhbt(I,j) = Datu(I,j)*ubt_trans(I,j) + uhbt0(I,j)
         enddo ; enddo
       endif
      if(apply_u_OBCs) then  ! copy back the value for the points that OBC_mask_v is true.
-!$OMP do
+!GOMP do
         do j=jsv,jev ; do I=isv-1,iev ; if (BT_OBC%OBC_mask_u(I,j)) then
           ubt(I,j) = ubt_prev(I,j); uhbt(I,j) = uhbt_prev(I,j)
         endif ; enddo ; enddo
       endif
     else
       ! On even steps, update u first.
-!$OMP do
+!GOMP do
       do j=jsv-1,jev+1 ; do I=isv-1,iev
         Cor_u(I,j) = ((azon(I,j) * vbt(i+1,J) + czon(I,j) * vbt(i,J-1)) + &
                       (bzon(I,j) * vbt(i,J) +  dzon(I,j) * vbt(i+1,J-1))) - &
@@ -1810,12 +1810,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       enddo ; enddo
 
       if (CS%dynamic_psurf) then
-!$OMP do
+!GOMP do
         do j=jsv-1,jev+1 ; do I=isv-1,iev
           PFu(I,j) = PFu(I,j) + (p_surf_dyn(i,j) - p_surf_dyn(i+1,j)) * CS%IdxCu(I,j)
         enddo ; enddo
       endif
-!$OMP do
+!GOMP do
       do j=jsv-1,jev+1 ; do I=isv-1,iev
         u_accel_bt(I,j) = u_accel_bt(I,j) + wt_accel(n) * (Cor_u(I,j) + PFu(I,j))
         vel_prev = ubt(I,j)
@@ -1825,25 +1825,25 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       enddo ; enddo
 
       if (use_BT_cont) then
-!$OMP do
+!GOMP do
         do j=jsv-1,jev+1 ; do I=isv-1,iev
           uhbt(I,j) = find_uhbt(ubt_trans(I,j),BTCL_u(I,j)) + uhbt0(I,j)
         enddo ; enddo
       else
-!$OMP do
+!GOMP do
         do j=jsv-1,jev+1 ; do I=isv-1,iev
           uhbt(I,j) = Datu(I,j)*ubt_trans(I,j) + uhbt0(I,j)
         enddo ; enddo
       endif
       if(apply_u_OBCs) then  ! copy back the value for the points that OBC_mask_v is true.
-!$OMP do
+!GOMP do
         do j=jsv-1,jev+1 ; do I=isv-1,iev ; if (BT_OBC%OBC_mask_u(I,j)) then
           ubt(I,j) = ubt_prev(I,j); uhbt(I,j) = uhbt_prev(I,j)
         endif ; enddo ; enddo
       endif
 
       ! Now update the meridional velocity.
-!$OMP do
+!GOMP do
       do J=jsv-1,jev ; do i=isv,iev
         Cor_v(i,J) = -1.0*((amer(I-1,j) * ubt(I-1,j) + bmer(I,j) * ubt(I,j)) + &
                 (cmer(I,j+1) * ubt(I,j+1) + dmer(I-1,j+1) * ubt(I-1,j+1))) - Cor_ref_v(i,J)
@@ -1853,12 +1853,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       enddo ; enddo
 
       if (CS%dynamic_psurf) then
-!$OMP do
+!GOMP do
         do J=jsv-1,jev ; do i=isv,iev
           PFv(i,J) = PFv(i,J) + (p_surf_dyn(i,j) - p_surf_dyn(i,j+1)) * CS%IdyCv(i,J)
         enddo ; enddo
       endif
-!$OMP do
+!GOMP do
       do J=jsv-1,jev ; do i=isv,iev
         v_accel_bt(I,j) = v_accel_bt(I,j) + wt_accel(n) * (Cor_v(i,J) + PFv(i,J))
         vel_prev = vbt(i,J)
@@ -1867,70 +1867,70 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
         vbt_trans(i,J) = trans_wt1*vbt(i,J) + trans_wt2*vel_prev
       enddo ; enddo
       if (use_BT_cont) then
-!$OMP do
+!GOMP do
         do J=jsv-1,jev ; do i=isv,iev
           vhbt(i,J) = find_vhbt(vbt_trans(i,J),BTCL_v(i,J)) + vhbt0(i,J)
         enddo ; enddo
       else
-!$OMP do
+!GOMP do
         do J=jsv-1,jev ; do i=isv,iev
           vhbt(i,J) = Datv(i,J)*vbt_trans(i,J) + vhbt0(i,J)
         enddo ; enddo
       endif
       if(apply_v_OBCs) then  ! copy back the value for the points that OBC_mask_v is true.
-!$OMP do
+!GOMP do
         do J=jsv-1,jev ; do i=isv,iev ; if (BT_OBC%OBC_mask_v(i,J)) then
           vbt(i,J) = vbt_prev(i,J); vhbt(i,J) = vhbt_prev(i,J)
         endif ; enddo ; enddo
       endif
     endif
-!$OMP end parallel
+!GOMP end parallel
 
-!$OMP parallel default(none) shared(is,ie,js,je,find_PF,PFu_bt_sum,wt_accel2, &
-!$OMP                               PFu,PFv_bt_sum,PFv,find_Cor,Coru_bt_sum,  &
-!$OMP                               Cor_u,Corv_bt_sum,Cor_v,ubt_sum,wt_trans, &
-!$OMP                               ubt_trans,uhbt_sum,uhbt,ubt_wtd,wt_vel,   &
-!$OMP                               ubt,vbt_sum,vbt_trans,vhbt_sum,vhbt,      &
-!$OMP                               vbt_wtd,vbt,n )
+!GOMP parallel default(none) shared(is,ie,js,je,find_PF,PFu_bt_sum,wt_accel2, &
+!GOMP                               PFu,PFv_bt_sum,PFv,find_Cor,Coru_bt_sum,  &
+!GOMP                               Cor_u,Corv_bt_sum,Cor_v,ubt_sum,wt_trans, &
+!GOMP                               ubt_trans,uhbt_sum,uhbt,ubt_wtd,wt_vel,   &
+!GOMP                               ubt,vbt_sum,vbt_trans,vhbt_sum,vhbt,      &
+!GOMP                               vbt_wtd,vbt,n )
     if (find_PF) then
-!$OMP do
+!GOMP do
       do j=js,je ; do I=is-1,ie
         PFu_bt_sum(I,j)  = PFu_bt_sum(I,j) + wt_accel2(n) * PFu(I,j)
       enddo ; enddo
-!$OMP do
+!GOMP do
       do J=js-1,je ; do i=is,ie
         PFv_bt_sum(i,J)  = PFv_bt_sum(i,J) + wt_accel2(n) * PFv(i,J)
       enddo ; enddo
     endif
     if (find_Cor) then
-!$OMP do
+!GOMP do
       do j=js,je ; do I=is-1,ie
         Coru_bt_sum(I,j) = Coru_bt_sum(I,j) + wt_accel2(n) * Cor_u(I,j)
       enddo ; enddo
-!$OMP do
+!GOMP do
       do J=js-1,je ; do i=is,ie
         Corv_bt_sum(i,J) = Corv_bt_sum(i,J) + wt_accel2(n) * Cor_v(i,J)
       enddo ; enddo
     endif
 
-!$OMP do
+!GOMP do
     do j=js,je ; do I=is-1,ie
       ubt_sum(I,j) = ubt_sum(I,j) + wt_trans(n) * ubt_trans(I,j)
       uhbt_sum(I,j) = uhbt_sum(I,j) + wt_trans(n) * uhbt(I,j)
       ubt_wtd(I,j) = ubt_wtd(I,j) + wt_vel(n) * ubt(I,j)
     enddo ; enddo
-!$OMP do
+!GOMP do
     do J=js-1,je ; do i=is,ie
       vbt_sum(i,J) = vbt_sum(i,J) + wt_trans(n) * vbt_trans(i,J)
       vhbt_sum(i,J) = vhbt_sum(i,J) + wt_trans(n) * vhbt(i,J)
       vbt_wtd(i,J) = vbt_wtd(i,J) + wt_vel(n) * vbt(i,J)
     enddo ; enddo
-!$OMP end parallel
+!GOMP end parallel
 
     if (apply_OBCs) then
       if (apply_u_OBCs) then  ! copy back the value for the points that OBC_mask_v is true.
-!$OMP parallel do default(none) shared(is,ie,js,je,ubt_sum_prev,ubt_sum,uhbt_sum_prev,&
-!$OMP                                  uhbt_sum,ubt_wtd_prev,ubt_wtd,BT_OBC)
+!GOMP parallel do default(none) shared(is,ie,js,je,ubt_sum_prev,ubt_sum,uhbt_sum_prev,&
+!GOMP                                  uhbt_sum,ubt_wtd_prev,ubt_wtd,BT_OBC)
         do j=js,je ; do I=is-1,ie
           if (BT_OBC%OBC_mask_u(i,J)) then
             ubt_sum(i,J)=ubt_sum_prev(i,J); uhbt_sum(i,J)=uhbt_sum_prev(i,J) ; ubt_wtd(i,J)=ubt_wtd_prev(i,J)
@@ -1939,8 +1939,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       endif
 
       if (apply_v_OBCs) then  ! copy back the value for the points that OBC_mask_v is true.
-!$OMP parallel do default(none) shared(is,ie,js,je,vbt_sum_prev,vbt_sum,vhbt_sum_prev, &
-!$OMP                                  vhbt_sum,vbt_wtd_prev,vbt_wtd,BT_OBC)
+!GOMP parallel do default(none) shared(is,ie,js,je,vbt_sum_prev,vbt_sum,vhbt_sum_prev, &
+!GOMP                                  vhbt_sum,vbt_wtd_prev,vbt_wtd,BT_OBC)
         do J=js-1,je ; do I=is,ie
           if (BT_OBC%OBC_mask_v(i,J)) then
             vbt_sum(i,J)=vbt_sum_prev(i,J); vhbt_sum(i,J)=vhbt_sum_prev(i,J) ; vbt_wtd(i,J)=vbt_wtd_prev(i,J)


### PR DESCRIPTION
Comments out the omp directives inside barotropic time step loop for openmp performance issue with low local grid size. Tests shows that 2 thread is much slower than 1 thread for the barotropic time step calculation when the local grid size is small (like 24x16). This is possibly due to the openmp overmp overlap or synchronization and computation inside barotropic time step is not big enough.