### PR TITLE
A small bug in the ocean_model_MOM.F90 has been fixed. When MOM was r…

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -631,7 +631,8 @@ subroutine convert_state_to_ocean_type(state, Ocean_sfc, G, patm, press_to_z)
     Ocean_sfc%sea_lev(i,j) = state%sea_lev(i+i0,j+j0)
     if (present(patm)) &
       Ocean_sfc%sea_lev(i,j) = Ocean_sfc%sea_lev(i,j) + patm(i,j) * press_to_z
-    Ocean_sfc%frazil(i,j) = state%frazil(i+i0,j+j0)
+      if (associated(state%frazil)) &
+      Ocean_sfc%frazil(i,j) = state%frazil(i+i0,j+j0)
     Ocean_sfc%area(i,j)   =  G%areaT(i+i0,j+j0)  
   enddo ; enddo
   


### PR DESCRIPTION
…with Frazil off in ocean-ice mode, the Frazil variable was left unassociated, but was called in the code, causing the model to crash. This has been fixed by added an "if associated..."