### PR TITLE
User/bgr/kvisc fix

### DIFF
--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -995,6 +995,8 @@ subroutine find_coupling_coef(a, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i, h_m
   integer :: nz
   real    :: botfn
 
+  a(:,:) = 0.0
+
   if (work_on_u) then ; is = G%IscB ; ie = G%IecB
   else ; is = G%isc ; ie = G%iec ; endif
   nz = G%ke
@@ -1034,13 +1036,17 @@ subroutine find_coupling_coef(a, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i, h_m
   endif ; enddo
 
   if (associated(visc%Kv_turb)) then
+     ! BGR/ Add factor of 2. * the averaged Kv_turb.
+     !      this is needed to reproduce the analytical solution to
+     !      a simple diffusion problem, likely due to h_shear being
+     !      equal to 2 x \delta z
     if (work_on_u) then
       do K=nz,2,-1 ; do i=is,ie ; if (do_i(i)) then
-        a(i,K) = a(i,K) + 0.5*(visc%Kv_turb(i,j,k) + visc%Kv_turb(i+1,j,k))
+        a(i,K) = a(i,K) + (2.*0.5)*(visc%Kv_turb(i,j,k) + visc%Kv_turb(i+1,j,k))
       endif ; enddo ; enddo
     else
       do K=nz,2,-1 ; do i=is,ie ; if (do_i(i)) then
-        a(i,K) = a(i,K) + 0.5*(visc%Kv_turb(i,j,k) + visc%Kv_turb(i,j+1,k))
+        a(i,K) = a(i,K) + (2.*0.5)*(visc%Kv_turb(i,j,k) + visc%Kv_turb(i,j+1,k))
       endif ; enddo ; enddo
     endif
   endif


### PR DESCRIPTION
In ALE mode MOM_diabatic_aux should not advect momentum via diffusion between layers, since momentum is already mixed by MOM_vert_friction.  We found that when viscosity is disabled, momentum is still mixed due to diffusivity in this part of the code.  Therefore, a flag has been added to disable these lines of codes when in ALE mode.

A simple test case was prepared with constant wind stress forcing and constant viscosity.  When the constant viscosity is set into variable Kv, which is accessed by subroutine find_coupling_coef (in MOM_vertical_friction.F90), the resulting current profile matches the analytical solution.  However, if the constant viscosity is instead set into variable Kv_turb (accessed in the same subroutine), then the resulting current profile is under mixed.  I notice that parameter 'a' (output from find_coupling_coef) is set to 2x Kv and 2x Kvbbl, but for Kv_turb, 'a' is set to (1x) Kv_turb .  I believe that this 2 comes from a reorganization of the factor of 2 in the h_shear calculation, since h_shear is equal to twice the level thickness (but shears are computed over one level difference).  Since this factor of 2 is missing in setting 'a' from Kv_turb, but it is there when setting from Kv, this explains why using Kv gives the correct solution but using Kv_turb does not.  Therefore, a factor of 2 has been introduced when setting 'a' from Kv_turb, and the result now agrees with the analytical solution.  The current profile has also been compared using GOTM for redundancy, which agrees with the profile from the analytical solution, using Kv, and using the Kv_turb with the additional factor of 2.