### PR TITLE
User/nnz/zdiag4cobalt

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1134,7 +1134,7 @@ function register_diag_field(module_name, field_name, axes, init_time,         &
   ! Remap to z vertical coordinate, note that only diagnostics on layers
   ! (not interfaces) are supported, also B axes are not supported yet
   if (is_layer_axes(axes, diag_cs) .and. (.not. is_B_axes(axes, diag_cs)) .and. axes%rank == 3) then
-    if (get_diag_field_id_fms(module_name//'_z_new', field_name) /= DIAG_FIELD_NOT_FOUND) then
+    if (get_diag_field_id_fms(trim(module_name)//'_z_new', field_name) /= DIAG_FIELD_NOT_FOUND) then
       if (.not. allocated(diag_cs%zi_remap)) then
         call MOM_error(FATAL, 'register_diag_field: Request to regrid but no '// &
                        'destination grid spec provided, see param DIAG_REMAP_Z_GRID_DEF')

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -429,9 +429,13 @@ contains
 
     ! Register generic tracer modules diagnostics
 
+#ifdef _USE_MOM6_DIAG
     call g_tracer_set_csdiag(CS%diag)
+#endif
     call generic_tracer_register_diag()
+#ifdef _USE_MOM6_DIAG
     call g_tracer_set_csdiag(CS%diag)
+#endif
 
 
     ! Register Z diagnostic output.
@@ -540,8 +544,6 @@ contains
          trim(sub_name)//": No tracer in the list.")
 
     call enable_averaging(dt, get_diag_time_end(CS%diag), CS%diag) !Niki: This call is not needed since avaraging is already enabled. This is jjust to ensure it. 
-    call g_tracer_set_csdiag(CS%diag)
-  
     !
     !Extract the tracer surface fields from coupler and update tracer fields from sources
     !
@@ -619,9 +621,13 @@ contains
     call generic_tracer_update_from_bottom(dt, 1, get_diag_time_end(CS%diag)) !Second arg is tau which is always 1 for MOM
 
     !Output diagnostics via diag_manager for all generic tracers and their fluxes
-    call g_tracer_send_diag(CS%g_tracer_list, get_diag_time_end(CS%diag), tau=1)
-
+#ifdef _USE_MOM6_DIAG
     call g_tracer_set_csdiag(CS%diag)
+#endif
+    call g_tracer_send_diag(CS%g_tracer_list, get_diag_time_end(CS%diag), tau=1)
+#ifdef _USE_MOM6_DIAG
+    call g_tracer_set_csdiag(CS%diag)
+#endif
 
 !!!    call disable_averaging(CS%diag) !Niki: This interrupts and STOPS the diagnostics output for all modules!!!
 

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -623,7 +623,7 @@ contains
 
     call g_tracer_set_csdiag(CS%diag)
 
-    call disable_averaging(CS%diag)
+!!!    call disable_averaging(CS%diag) !Niki: This interrupts and STOPS the diagnostics output for all modules!!!
 
   end subroutine MOM_generic_tracer_column_physics
 

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -544,6 +544,10 @@ contains
          trim(sub_name)//": No tracer in the list.")
 
     call enable_averaging(dt, get_diag_time_end(CS%diag), CS%diag) !Niki: This call is not needed since avaraging is already enabled. This is jjust to ensure it. 
+#ifdef _USE_MOM6_DIAG
+    call g_tracer_set_csdiag(CS%diag)
+#endif
+
     !
     !Extract the tracer surface fields from coupler and update tracer fields from sources
     !
@@ -621,9 +625,6 @@ contains
     call generic_tracer_update_from_bottom(dt, 1, get_diag_time_end(CS%diag)) !Second arg is tau which is always 1 for MOM
 
     !Output diagnostics via diag_manager for all generic tracers and their fluxes
-#ifdef _USE_MOM6_DIAG
-    call g_tracer_set_csdiag(CS%diag)
-#endif
     call g_tracer_send_diag(CS%g_tracer_list, get_diag_time_end(CS%diag), tau=1)
 #ifdef _USE_MOM6_DIAG
     call g_tracer_set_csdiag(CS%diag)

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -539,7 +539,7 @@ contains
     if(.NOT. associated(CS%g_tracer_list)) call mpp_error(FATAL,&
          trim(sub_name)//": No tracer in the list.")
 
-    call enable_averaging(dt, get_diag_time_end(CS%diag), CS%diag) 
+    call enable_averaging(dt, get_diag_time_end(CS%diag), CS%diag) !Niki: This call is not needed since avaraging is already enabled. This is jjust to ensure it. 
     call g_tracer_set_csdiag(CS%diag)
   
     !

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -53,7 +53,6 @@ module MOM_generic_tracer
 
   use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
   use MOM_diag_mediator, only : diag_ctrl, get_diag_time_end
-  use MOM_diag_mediator, only : enable_averaging, disable_averaging
   use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
   use MOM_error_handler, only : MOM_error, FATAL, WARNING, NOTE, is_root_pe
   use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
@@ -543,7 +542,6 @@ contains
     if(.NOT. associated(CS%g_tracer_list)) call mpp_error(FATAL,&
          trim(sub_name)//": No tracer in the list.")
 
-    call enable_averaging(dt, get_diag_time_end(CS%diag), CS%diag) !Niki: This call is not needed since avaraging is already enabled. This is jjust to ensure it. 
 #ifdef _USE_MOM6_DIAG
     call g_tracer_set_csdiag(CS%diag)
 #endif
@@ -630,7 +628,6 @@ contains
     call g_tracer_set_csdiag(CS%diag)
 #endif
 
-!!!    call disable_averaging(CS%diag) !Niki: This interrupts and STOPS the diagnostics output for all modules!!!
 
   end subroutine MOM_generic_tracer_column_physics
 


### PR DESCRIPTION
This (in addition to updates to ocean_shared modules) enables generic tracers such a COBALT to call MOM6 diagnostics routines so that their results could be remapped to z-coordinates (if it is requested in diag_table via MOM6 "_z_new" method).

These updates do not affect MOM6 runs. Neither do these depend on the ocean_shared updates unless MOM6 is compiled with -D_USE_MOM6_DIAG .

If the z-coordinate remapping and/or MOM6 CMIP renaming scheme  is desired for generic tracers, then MOM6 and ocean_shared modules should be compiled as one and the same library and they should both be compiled with a cpp switch "-D_USE_MOM6_DIAG" . Then the diag_table for generic tracers modules should be modified to request the remapped diagnostics (via _z_new methodology of MOM6).