### PR TITLE
OMP bug fix

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -671,7 +671,7 @@ subroutine ALE_remap_scalar(CS, G, nk_src, h_src, s_src, h_dst, s_dst, all_cells
 
 !$OMP parallel default(none) shared(CS,G,h_src,s_src,h_dst,s_dst &
 !$OMP                               ,ignore_vanished_layers, nk_src,dx ) &
-!$OMP                        private(n_points)
+!$OMP                        firstprivate(n_points)
 !$OMP do
   do j = G%jsc,G%jec
     do i = G%isc,G%iec


### PR DESCRIPTION
- Fixes issue #287
- OMP "private" variables are not initialized prior to "private" clause
  that is the job for "firstprivate" clause
- Cause 1/2 degree model crash when compiled with -openmp