### PR TITLE
Max depth calculation without mpp_global_field

### DIFF
--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -32,6 +32,7 @@ use MOM_verticalGrid,     only : verticalGrid_type
 
 use mpp_domains_mod, only  : mpp_global_field, mpp_get_compute_domain
 use mpp_mod, only          : mpp_broadcast,mpp_root_pe,mpp_sync,mpp_sync_self
+use mpp_mod, only          : mpp_max
 use horiz_interp_mod, only : horiz_interp_new, horiz_interp,horiz_interp_type
 use horiz_interp_mod, only : horiz_interp_init, horiz_interp_del
 
@@ -99,7 +100,6 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
   integer :: i, j, k, kd
 
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: zi
-  real, dimension(:,:), allocatable :: Depth
   real, allocatable, dimension(:,:,:), target :: tr_z, mask_z
   real, allocatable, dimension(:), target :: z_edges_in, z_in
 
@@ -483,7 +483,6 @@ subroutine horiz_interp_and_extrap_tracer(filename, varnam,  conversion, recnum,
   character(len=12)  :: dim_name(4)
   logical :: debug=.false.
   real :: npoints,varAvg
-  real, dimension(:,:), allocatable :: Depth
   real, dimension(SZI_(G),SZJ_(G)) :: lon_out, lat_out, tr_out, mask_out
   real, dimension(SZI_(G),SZJ_(G)) :: good, fill
   real, dimension(SZI_(G),SZJ_(G)) :: tr_outf,tr_prev
@@ -612,14 +611,9 @@ subroutine horiz_interp_and_extrap_tracer(filename, varnam,  conversion, recnum,
   allocate(mask_in(id,jdp)) ; mask_in(:,:)=0.0
   allocate(last_row(id))    ; last_row(:)=0.0
 
-  ni=ieg-isg+1 ; nj = jeg-jsg+1
-  allocate(Depth(ni,nj))
+  max_depth = maxval(G%bathyT)
+  call mpp_max(max_depth)
 
-! get the global depth array
-
-  call mpp_global_field(G%domain%mpp_domain, G%bathyT, Depth)    
-
-  max_depth = maxval(Depth)
   if (z_edges_in(kd+1)<max_depth) z_edges_in(kd+1)=max_depth
 
 


### PR DESCRIPTION
The `mpp_global_field` call in `horiz_interp_and_extrap_tracer`, used to
calculate the maximum depth (`max_depth`), caused a model hang on our
system beyond ~4000 CPUs.

This patch calculates `max_depth` by calculating the local maximum
depth, followed by a `mpp_max` collective.  This avoids the
`mpp_global_field` requirement.

----

As best I can tell, checksums were unchanged after this patch for a 10-day OM4_025 job using 960 CPUs.  (stdout diffs were identical, aside from timings and some out-of-order initialization)