### PR TITLE
Fix answer mismatch between regular and openmp runs

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -673,8 +673,8 @@ subroutine ALE_remap_scalar(CS, G, nk_src, h_src, s_src, h_dst, s_dst, all_cells
   if (present(old_remap)) use_remapping_core_w = old_remap
   n_points = nk_src
 
-!$OMP parallel default(none) shared(CS,G,h_src,s_src,h_dst,s_dst,use_remapping_core_w &
-!$OMP                               ,ignore_vanished_layers, nk_src,dx ) &
+!$OMP parallel default(none) shared(CS,G,h_src,s_src,h_dst,s_dst &
+!$OMP                               ,ignore_vanished_layers, use_remapping_core_w, nk_src,dx ) &
 !$OMP                        firstprivate(n_points)
 !$OMP do
   do j = G%jsc,G%jec

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -133,11 +133,11 @@ subroutine calc_isoneutral_slopes(G, GV, h, e, tv, dt_kappa_smooth, &
 
 !$OMP parallel do default(none) shared(nz,is,ie,js,je,use_EOS,G,GV,pres,T,S, &
 !$OMP                                  IsdB,tv,h,h_neglect,e,dz_neglect,  &
-!$OMP                                  h_neglect2,present_N2_u,G_Rho0,N2_u) &
+!$OMP                                  h_neglect2,present_N2_u,G_Rho0,N2_u,slope_x) &
 !$OMP                          private(drdiA,drdiB,drdkL,drdkR,pres_u,T_u,S_u,      &
 !$OMP                                  drho_dT_u,drho_dS_u,hg2A,hg2B,hg2L,hg2R,haA, &
 !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
-!$OMP                                  drdx,mag_grad2,Slope,slope2_Ratio,slope_x)
+!$OMP                                  drdx,mag_grad2,Slope,slope2_Ratio)
   do j=js,je ; do K=nz,2,-1
     if (.not.(use_EOS)) then
       drdiA = 0.0 ; drdiB = 0.0
@@ -220,11 +220,11 @@ subroutine calc_isoneutral_slopes(G, GV, h, e, tv, dt_kappa_smooth, &
     ! Calculate the meridional isopycnal slope.
 !$OMP parallel do default(none) shared(nz,is,ie,js,je,use_EOS,G,GV,pres,T,S, &
 !$OMP                                  IsdB,tv,h,h_neglect,e,dz_neglect,  &
-!$OMP                                  h_neglect2,present_N2_v,G_Rho0,N2_v)         &
+!$OMP                                  h_neglect2,present_N2_v,G_Rho0,N2_v,slope_y) &
 !$OMP                          private(drdjA,drdjB,drdkL,drdkR,pres_v,T_v,S_v,      &
 !$OMP                                  drho_dT_v,drho_dS_v,hg2A,hg2B,hg2L,hg2R,haA, &
 !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
-!$OMP                                  drdy,mag_grad2,Slope,slope2_Ratio,slope_y)
+!$OMP                                  drdy,mag_grad2,Slope,slope2_Ratio)
   do j=js-1,je ; do K=nz,2,-1
     if (.not.(use_EOS)) then
       drdjA = 0.0 ; drdjB = 0.0

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -374,9 +374,9 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
     reset_diags = .false.  ! This is the second call to mixedlayer.
 
   if (reset_diags) then
-!$OMP parallel default(none) shared(is,ie,js,je,CS)
+!!OMP parallel default(none) shared(is,ie,js,je,CS)
     if (CS%TKE_diagnostics) then
-!$OMP do
+!!OMP do
       do j=js,je ; do i=is,ie
         CS%diag_TKE_wind(i,j) = 0.0 ; CS%diag_TKE_MKE(i,j) = 0.0
         CS%diag_TKE_conv(i,j) = 0.0 ; CS%diag_TKE_forcing(i,j) = 0.0
@@ -384,37 +384,37 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
         CS%diag_TKE_conv_decay(i,j) = 0.0
       enddo ; enddo
     endif
-!$OMP end parallel
+!!OMP end parallel
   endif
 
 
-!$OMP parallel do default(none) shared(js,je,nz,is,ie,h_3d,u_3d,v_3d,tv,dt,      &
-!$OMP                                  CS,G,GV,sfc_connected,fluxes,IdtdR0,         &
-!$OMP                                  TKE_forced,debug,H_neglect,dSV_dT,        &
-!$OMP                                  dSV_dS,I_dtmrho,C1_3,h_tt_min,vonKar,     &
-!$OMP                                  max_itt,Kd_int)                           &
-!$OMP                           private(h,u,v,T,S,Kd,mech_TKE_k,conv_PErel_k,    &
-!$OMP                                   U_Star,absf,mech_TKE,conv_PErel,nstar_k, &
-!$OMP                                   h_sum,I_hs,h_bot,hb_hs,T0,S0,num_itts,   &
-!$OMP                                   pres,dMass,dPres,dT_to_dPE,dS_to_dPE,    &
-!$OMP                                   dT_to_dColHt,dS_to_dColHt,Kddt_h,        &
-!$OMP                                   b_den_1,dT_to_dPE_a,dT_to_dColHt_a,      &
-!$OMP                                   dS_to_dColHt_a,htot,uhtot,vhtot,         &
-!$OMP                                   Idecay_len_TKE,exp_kh,nstar_FC,tot_TKE,  &
-!$OMP                                   TKE_reduc,dTe_t2,dSe_t2,dTe,dSe,dt_h,    &
-!$OMP                                   Convectively_stable,sfc_disconnect,b1,   &
-!$OMP                                   c1,dT_km1_t2,dS_km1_t2,dTe_term,         &
-!$OMP                                   dSe_term,MKE2_Hharm,vstar,h_tt,          &
-!$OMP                                   Kd_guess0,Kddt_h_g0,dPEc_dKd_Kd0,        &
-!$OMP                                   PE_chg_max,dPEa_dKd_g0,PE_chg_g0,        &
-!$OMP                                   MKE_src,dPE_conv,Kddt_h_max,Kddt_h_min,  &
-!$OMP                                   TKE_left_max,TKE_left_min,Kddt_h_guess,  &
-!$OMP                                   TKE_left_itt,dPEa_dKd_itt,PE_chg_itt,    &
-!$OMP                                   MKE_src_itt,Kddt_h_itt,dPEc_dKd,PE_chg,  &
-!$OMP                                   dMKE_src_dK,TKE_left,use_Newt,           &
-!$OMP                                   dKddt_h_Newt,Kddt_h_Newt,Kddt_h_next,    &
-!$OMP                                   dKddt_h,Te,Se,Hsfc_used,dS_to_dPE_a,     &
-!$OMP                                   dMKE_max,TKE_here)
+!!OMP parallel do default(none) shared(js,je,nz,is,ie,h_3d,u_3d,v_3d,tv,dt,      &
+!!OMP                                  CS,G,GV,fluxes,IdtdR0,                    &
+!!OMP                                  TKE_forced,debug,H_neglect,dSV_dT,        &
+!!OMP                                  dSV_dS,I_dtmrho,C1_3,h_tt_min,vonKar,     &
+!!OMP                                  max_itt,Kd_int)                           &
+!!OMP                           private(i,j,k,h,u,v,T,S,Kd,mech_TKE_k,conv_PErel_k,    &
+!!OMP                                   U_Star,absf,mech_TKE,conv_PErel,nstar_k, &
+!!OMP                                   h_sum,I_hs,h_bot,hb_hs,T0,S0,num_itts,   &
+!!OMP                                   pres,dMass,dPres,dT_to_dPE,dS_to_dPE,    &
+!!OMP                                   dT_to_dColHt,dS_to_dColHt,Kddt_h,        &
+!!OMP                                   b_den_1,dT_to_dPE_a,dT_to_dColHt_a,      &
+!!OMP                                   dS_to_dColHt_a,htot,uhtot,vhtot,         &
+!!OMP                                   Idecay_len_TKE,exp_kh,nstar_FC,tot_TKE,  &
+!!OMP                                   TKE_reduc,dTe_t2,dSe_t2,dTe,dSe,dt_h,    &
+!!OMP                                   Convectively_stable,sfc_disconnect,b1,   &
+!!OMP                                   c1,dT_km1_t2,dS_km1_t2,dTe_term,         &
+!!OMP                                   dSe_term,MKE2_Hharm,vstar,h_tt,          &
+!!OMP                                   Kd_guess0,Kddt_h_g0,dPEc_dKd_Kd0,        &
+!!OMP                                   PE_chg_max,dPEa_dKd_g0,PE_chg_g0,        &
+!!OMP                                   MKE_src,dPE_conv,Kddt_h_max,Kddt_h_min,  &
+!!OMP                                   TKE_left_max,TKE_left_min,Kddt_h_guess,  &
+!!OMP                                   TKE_left_itt,dPEa_dKd_itt,PE_chg_itt,    &
+!!OMP                                   MKE_src_itt,Kddt_h_itt,dPEc_dKd,PE_chg,  &
+!!OMP                                   dMKE_src_dK,TKE_left,use_Newt,           &
+!!OMP                                   dKddt_h_Newt,Kddt_h_Newt,Kddt_h_next,    &
+!!OMP                                   dKddt_h,Te,Se,Hsfc_used,dS_to_dPE_a,     &
+!!OMP                                   dMKE_max,sfc_connected,TKE_here)
   do j=js,je
     ! Copy the thicknesses and other fields to 2-d arrays.
     do k=1,nz ; do i=is,ie


### PR DESCRIPTION
- global_ALE/z was not reproducing ocean.stats when compiled with -openmp
- This branch fixes issue # 290 , partially.
- The remaining issue is that OMP directives in MOM_energetic_PBL.F90
  still cause answer change and I cannot find anything wrong with them.
  In this update I just commented out the OMP directives in  MOM_energetic_PBL.F90
  and hopefully myself or Zhi can come back to it later to find the issue.