### PR TITLE
Fix Vertical_coordinate.nc when using RHO in ALE

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -2508,23 +2508,31 @@ function getCoordinateResolution( CS )
 
 end function getCoordinateResolution
 
-!------------------------------------------------------------------------------
-! Query the target coordinate interfaces positions
-!------------------------------------------------------------------------------
+!> Query the target coordinate interface positions
 function getCoordinateInterfaces( CS )
-  type(regridding_CS), intent(in) :: CS
-  real, dimension(CS%nk+1)        :: getCoordinateInterfaces
+  type(regridding_CS), intent(in) :: CS                      !< Regridding control structure
+  real, dimension(CS%nk+1)        :: getCoordinateInterfaces !< Interface positions in target coordinate
 
   integer :: k
 
-  getCoordinateInterfaces(1) = 0.
-  do k = 1, CS%nk
-    getCoordinateInterfaces(k+1) = getCoordinateInterfaces(k) &
-                                  -CS%coordinateResolution(k)
-  enddo
-  ! The following line has an "abs()" to allow ferret users to reference
-  ! data by index. It is a temporary work around...  :(  -AJA
-  getCoordinateInterfaces(:) = abs( getCoordinateInterfaces(:) )
+  ! When using a coordinate with target densities, we need to get the actual
+  ! densities, rather than computing the interfaces based on resolution
+  if (CS%regridding_scheme == REGRIDDING_RHO) then
+    if (.not. CS%target_density_set) &
+      call MOM_error(FATAL, 'MOM_regridding, getCoordinateInterfaces: '//&
+                            'target densities not set!')
+
+    getCoordinateInterfaces = CS%target_density
+  else
+    getCoordinateInterfaces(1) = 0.
+    do k = 1, CS%nk
+      getCoordinateInterfaces(k+1) = getCoordinateInterfaces(k) &
+                                    -CS%coordinateResolution(k)
+    enddo
+    ! The following line has an "abs()" to allow ferret users to reference
+    ! data by index. It is a temporary work around...  :(  -AJA
+    getCoordinateInterfaces(:) = abs( getCoordinateInterfaces(:) )
+  end if
 
 end function getCoordinateInterfaces
 


### PR DESCRIPTION
Previously, the coordinate interfaces (in the `Layer` and `Interface` variables) in the Vertical_coordinate.nc file were incorrect when using a coordinate with target densities, such as `RHO`. In this case, we set the coordinate interfaces from the target densities.

I didn't see any answer changes using the `ocean_only/seamount/rho` case, but I'm not familiar with how the coordinate interfaces are used.

@adcroft Is the "temporary workaround" to force values to be positive is still required (that message is from 2013)?