### PR TITLE
Added diag to the initialize_ISOMIP_tracer call 

### DIFF
--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -166,13 +166,15 @@ end function register_ISOMIP_tracer
 
 !> Initializes the NTR tracer fields in tr(:,:,:,:)
 ! and it sets up the tracer output. 
-subroutine initialize_ISOMIP_tracer(restart, day, G, GV, h, OBC, CS, ALE_sponge_CSp, &
-                                  diag_to_Z_CSp)
+subroutine initialize_ISOMIP_tracer(restart, day, G, GV, h, diag, OBC, CS, &
+                                    ALE_sponge_CSp, diag_to_Z_CSp)
+
   type(ocean_grid_type),                 intent(in) :: G !< Grid structure.
   type(verticalGrid_type),               intent(in) :: GV !< The ocean's vertical grid structure.
   logical,                               intent(in) :: restart !< .true. if the fields have already been read from a restart file.
   type(time_type), target,               intent(in) :: day !< Time of the start of the run.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h !< Layer thickness, in m or kg m-2.
+  type(diag_ctrl), target,               intent(in) :: diag
   type(ocean_OBC_type),                  pointer    :: OBC !< This open boundary condition type specifies whether, where, and what open boundary conditions are used. This is not being used for now.
   type(ISOMIP_tracer_CS),                pointer    :: CS !< The control structure returned by a previous call to ISOMIP_register_tracer.
   type(ALE_sponge_CS),                   pointer    :: ALE_sponge_CSp !< A pointer to the control structure for the sponges, if they are in use.  Otherwise this may be unassociated.
@@ -206,6 +208,7 @@ subroutine initialize_ISOMIP_tracer(restart, day, G, GV, h, OBC, CS, ALE_sponge_
   h_neglect = GV%H_subroundoff
 
   CS%Time => day
+  CS%diag => diag
 
   if (.not.restart) then
     if (len_trim(CS%tracer_IC_file) >= 1) then
@@ -340,7 +343,7 @@ subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, G
       if (fluxes%iceshelf_melt(i,j) > 0.0) then
 !        CS%tr(i,j,1,m) = (dt*fluxes%iceshelf_melt(i,j)/(365.0 * 86400.0)  &
 !                       + h_old(i,j,1)*CS%tr(i,j,1,m))/h_new(i,j,1)
-         CS%tr(i,j,1,m) = 1.0
+         CS%tr(i,j,1:3,m) = 1.0
       endif
     enddo ; enddo
   enddo

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -256,7 +256,7 @@ subroutine tracer_flow_control_init(restart, day, G, GV, h, param_file, diag, OB
     call initialize_DOME_tracer(restart, day, G, GV, h, diag, OBC, CS%DOME_tracer_CSp, &
                                 sponge_CSp, diag_to_Z_CSp)
   if (CS%use_ISOMIP_tracer) &
-    call initialize_ISOMIP_tracer(restart, day, G, GV, h, OBC, CS%ISOMIP_tracer_CSp, &
+    call initialize_ISOMIP_tracer(restart, day, G, GV, h, diag, OBC, CS%ISOMIP_tracer_CSp, &
                                 ALE_sponge_CSp, diag_to_Z_CSp)
   if (CS%use_ideal_age) &
     call initialize_ideal_age_tracer(restart, day, G, GV, h, diag, OBC, CS%ideal_age_tracer_CSp, &


### PR DESCRIPTION
The structure diag was not been passed to initialize_ISOMIP_tracer, so the model was blowing up when USE_ISOMIP_TRACER = True. This structure needs to be passed so CS%diag can be used during the register_diag_field calls. The model runs fine now.