### PR TITLE
User/bgr/lmd94

### DIFF
--- a/src/parameterizations/vertical/MOM_KPP.F90
+++ b/src/parameterizations/vertical/MOM_KPP.F90
@@ -721,8 +721,15 @@ subroutine KPP_calculate(CS, G, GV, h, Temp, Salt, u, v, EOS, uStar, &
 
       ! Unlike LMD94, we do not match to interior diffusivities. If using the original
       ! LMD94 shape function, not matching is equivalent to matching to a zero diffusivity.
-      Kdiffusivity(:,:) = 0. ! Diffusivities for heat and salt (m2/s)
-      Kviscosity(:)     = 0. ! Viscosity (m2/s)
+      ! If option "MatchBoth" is selected in CVMix, MOM should be capable of matching.
+      if (.not. (CS%MatchTechnique.eq.'MatchBoth')) then
+         Kdiffusivity(:,:) = 0. ! Diffusivities for heat and salt (m2/s)
+         Kviscosity(:)     = 0. ! Viscosity (m2/s)
+      else
+         Kdiffusivity(:,1) = Kt(i,j,:)
+         Kdiffusivity(:,2) = Ks(i,j,:)
+         Kviscosity(:)=Kv(i,j,:)
+      endif
       surfBuoyFlux  = buoyFlux(i,j,1) - buoyFlux(i,j,int(kOBL)+1) ! We know the actual buoyancy flux into the OBL
       call cvmix_coeffs_kpp(Kviscosity,        & ! (inout) Total viscosity (m2/s)
                             Kdiffusivity(:,1), & ! (inout) Total heat diffusivity (m2/s)

--- a/src/parameterizations/vertical/MOM_cvmix_shear.F90
+++ b/src/parameterizations/vertical/MOM_cvmix_shear.F90
@@ -1,0 +1,249 @@
+module MOM_cvmix_shear
+!***********************************************************************
+!*                   GNU General Public License                        *
+!* This file is a part of MOM.                                         *
+!*                                                                     *
+!* MOM is free software; you can redistribute it and/or modify it and  *
+!* are expected to follow the terms of the GNU General Public License  *
+!* as published by the Free Software Foundation; either version 2 of   *
+!* the License, or (at your option) any later version.                 *
+!*                                                                     *
+!* MOM is distributed in the hope that it will be useful, but WITHOUT  *
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  *
+!* or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public    *
+!* License for more details.                                           *
+!*                                                                     *
+!* For the full text of the GNU General Public License,                *
+!* write to: Free Software Foundation, Inc.,                           *
+!*           675 Mass Ave, Cambridge, MA 02139, USA.                   *
+!* or see:   http://www.gnu.org/licenses/gpl.html                      *
+!***********************************************************************
+
+use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
+use MOM_cpu_clock, only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
+use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
+use MOM_diag_mediator, only : diag_ctrl, time_type
+use MOM_checksums, only : hchksum
+use MOM_error_handler, only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
+use MOM_file_parser, only : get_param, log_version, param_file_type
+use MOM_grid, only : ocean_grid_type
+use MOM_variables, only : thermo_var_ptrs
+use MOM_verticalGrid, only : verticalGrid_type
+use MOM_EOS, only : calculate_density, EOS_type
+use cvmix_shear, only : cvmix_init_shear, cvmix_coeffs_shear
+use MOM_kappa_shear, only : kappa_shear_is_used
+implicit none ; private
+
+#include <MOM_memory.h>
+#ifdef use_netCDF
+#include <netcdf.inc>
+#endif
+
+public Calculate_cvmix_shear, cvmix_shear_init
+
+type, public :: CVMix_shear_CS ! ; private
+  logical :: use_LMD94, use_PP81
+  real    :: Ri_zero
+  real    :: Nu_zero
+  real    :: KPP_exp
+  real, allocatable, dimension(:,:,:) :: N2        !< Squared Brunt-Vaisala frequency (1/s2)
+  real, allocatable, dimension(:,:,:) :: S2        !< Squared shear frequency (1/s2)
+  character(10) :: Mix_Scheme
+end type CVMix_shear_CS
+
+! integer :: id_clock_project, id_clock_KQ, id_clock_avg, id_clock_setup
+  character(len=40)  :: mod = "MOM_CVMix_shear"  ! This module's name.
+
+#undef  DEBUG
+#undef  ADD_DIAGNOSTICS
+
+contains
+
+subroutine Calculate_cvmix_shear(u_in, v_in, h, tv, KH,  &
+                                 KM, G, GV, CS )
+  type(ocean_grid_type),                      intent(in)    :: G
+  type(verticalGrid_type),                    intent(in)    :: GV
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: u_in
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: v_in
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: h
+  type(thermo_var_ptrs),                      intent(in)    :: tv
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(out)   :: KH
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(out)   :: KM
+  type(CVMix_shear_CS),                       pointer       :: CS
+!
+! ----------------------------------------------
+! Subroutine for calculating diffusivity (and TKE?)
+! ----------------------------------------------
+! Arguments: u_in - Initial zonal velocity, in m s-1. (Intent in)
+!  (in)      v_in - Initial meridional velocity, in m s-1.
+!  (in)      h - Layer thickness, in m or kg m-2.
+!  (in)      tv - A structure containing pointers to any available
+!                 thermodynamic fields. Absent fields have NULL ptrs.
+!  (in/out)  KH - The diapycnal diffusivity at each interface
+!                       (not layer!) in m2 s-1.  Initially this is the value
+!                       from the previous timestep, which may accelerate the
+!                       iteration toward convergence.
+!  (in/out)  KM - The vertical viscosity at each interface
+!                    (not layer!) in m2 s-1. This discards any previous value
+!                    i.e. intent(out) and simply sets Kv = Prandtl * Kd_turb
+!  (in)      G - The ocean's grid structure.
+!  (in)      GV - The ocean's vertical grid structure.
+!  (in)      CS - The control structure returned by a previous call to
+!                 CVMix_shear_init.
+
+  integer :: i, j, k, kk, km1
+  real :: gorho
+  real :: pref, DU, DV, DRHO, DZ, N2, S2
+  real, dimension(2*(G%ke)) :: pres_1d, temp_1d, salt_1d, rho_1d 
+  real, dimension(G%ke+1) ::  Ri_Grad !< Gradient Richardson number
+
+  ! some constants
+  GoRho = GV%g_Earth / GV%Rho0
+
+  do j = G%jsc, G%jec
+    do i = G%isc, G%iec
+
+      ! skip calling for land points
+      if (G%mask2dT(i,j)==0.) cycle
+
+      ! Richardson number computed for each cell in a column.
+      pRef = 0.
+      do k=1,G%ke
+
+        ! pressure, temp, and saln for EOS
+        ! kk+1 = k fields
+        ! kk+2 = km1 fields
+        km1  = max(1, k-1)
+        kk   = 2*(k-1)
+        pres_1D(kk+1) = pRef
+        pres_1D(kk+2) = pRef
+        Temp_1D(kk+1) = TV%T(i,j,k)
+        Temp_1D(kk+2) = TV%T(i,j,km1)
+        Salt_1D(kk+1) = TV%S(i,j,k)
+        Salt_1D(kk+2) = TV%S(i,j,km1)
+
+        ! pRef is pressure at interface between k and km1.
+        ! iterate pRef for next pass through k-loop.
+        pRef = pRef + GV%H_to_Pa * h(i,j,k)
+
+      enddo ! k-loop finishes
+
+      ! compute in-situ density
+      call calculate_density(Temp_1D, Salt_1D, pres_1D, rho_1D, 1, 3*G%ke, TV%EQN_OF_STATE)
+
+      ! N2 (can be negative) and N (non-negative) on interfaces.
+      ! deltaRho is non-local rho difference used for bulk Richardson number.
+      ! N_1d is local N (with floor) used for unresolved shear calculation.
+      do k = 1, G%ke
+        km1 = max(1, k-1)
+        kk = 2*(k-1)
+        DU = (u_in(i,j,k)+u_in(i-1,j,k))-(u_in(i,j,km1)+u_in(i-1,j,km1))
+        DV = (v_in(i,j,k)+v_in(i,j-1,k))-(v_in(i,j,km1)+v_in(i,j-1,km1))
+        DRHO = (GoRho * (rho_1D(kk+1) - rho_1D(kk+2)) )
+        DZ = ((0.5*(h(i,j,km1) + h(i,j,k))+GV%H_subroundoff)*GV%H_to_m)
+        N2 = DRHO/DZ
+        S2 = (DU*DU+DV*DV)/(DZ*DZ) 
+        Ri_Grad(G%ke) = N2/max(S2,1.e-8)
+      enddo
+      Ri_Grad(G%ke+1) = 1.e8
+
+      call  cvmix_coeffs_shear(Mdiff_out=KM(i,j,:), &
+                                   Tdiff_out=KH(i,j,:), & 
+                                   RICH=Ri_Grad, &
+                                   nlev=G%ke,    &
+                                   max_nlev=G%ke)
+
+
+    ENDDO;
+  ENDDO;
+
+  return
+
+end subroutine Calculate_cvmix_shear
+
+
+logical function cvmix_shear_init(Time, G, GV, param_file, diag, CS)
+  !
+  ! Initialized the cvmix internal shear mixing routine.
+  !  *tests to make sure multiple internal shear mixing routines
+  !   are not enabled at the same time.
+  !
+  type(time_type),         intent(in)    :: Time
+  type(ocean_grid_type),   intent(in)    :: G
+  type(verticalGrid_type), intent(in)    :: GV
+  type(param_file_type),   intent(in)    :: param_file
+  type(diag_ctrl), target, intent(inout) :: diag
+  type(CVMix_shear_CS),    pointer       :: CS
+! Arguments: Time - The current model time.
+!  (in)      G - The ocean's grid structure.
+!  (in)      GV - The ocean's vertical grid structure.
+!  (in)      param_file - A structure indicating the open file to parse for
+!                         model parameter values.
+!  (in)      diag - A structure that is used to regulate diagnostic output.
+!  (in/out)  CS - A pointer that is set to point to the control structure
+!                 for this module
+!  (returns) cvmix_shear_init - True if module is to be used, False otherwise
+! This include declares and sets the variable "version".
+  INTEGER :: NumberTrue
+  LOGICAL :: use_JHL
+#include "version_variable.h"
+
+  if (associated(CS)) then
+    call MOM_error(WARNING, "cvmix_shear_init called with an associated "// &
+                            "control structure.")
+    return
+  endif
+  allocate(CS)
+
+! Set default, read and log parameters
+  call log_version(param_file, mod, version, &
+    "Parameterization of shear-driven turbulence via CVMix (various options)")
+  call get_param(param_file, mod, "USE_LMD94", CS%use_LMD94, &
+                 "If true, use the Large-McWilliams-Doney (JGR 1994) \n"//&
+                 "shear mixing parameterization.", default=.false.)
+  if (CS%use_LMD94) then
+     NumberTrue=NumberTrue + 1
+     CS%Mix_Scheme='KPP'
+  endif
+  call get_param(param_file, mod, "USE_PP81", CS%use_PP81, &
+                 "If true, use the Pacanowski and Philander (JPO 1981) \n"//&
+                 "shear mixing parameterization.", default=.false.)
+  if (CS%use_PP81) then
+     NumberTrue = NumberTrue + 1
+     CS%Mix_Scheme='PP'
+  endif
+  use_JHL=kappa_shear_is_used(param_file)
+  if (use_JHL) NumberTrue = NumberTrue + 1
+  if ((NumberTrue).gt.1) then
+     call MOM_error(FATAL, 'MOM_cvmix_shear_init: '// &
+           'Multiple shear driven internal mixing schemes selected,'//&
+           ' please disable all but one scheme to proceed.')
+  endif
+  cvmix_shear_init=(CS%use_PP81.or.CS%use_LMD94)
+  print*,CS%use_LMD94
+  stop
+! Forego remainder of initialization if not using this scheme
+  if (.not. cvmix_shear_init) return
+  call get_param(param_file, mod, "NU_ZERO", CS%Nu_Zero, &
+                 "Leading coefficient in KPP shear mixing.", &
+                 units="nondim", default=5.e-3)
+  call get_param(param_file, mod, "RI_ZERO", CS%Nu_Zero, &
+                 "Critical Richardson for KPP shear mixing,"// &
+                 " NOTE this the internal mixing and this is"// &
+                 " not for setting the boundary layer depth." &
+                 ,units="nondim", default=0.7)
+  call get_param(param_file, mod, "KPP_EXP", CS%KPP_exp, &
+                 "Exponent of unitless factor of diffusivities,"// &
+                 " for KPP internal shear mixing scheme." &
+                 ,units="nondim", default=3.0)
+  call cvmix_init_shear(mix_scheme=CS%mix_scheme, &
+                        KPP_nu_zero=CS%Nu_Zero,   &
+                        KPP_Ri_zero=CS%Ri_zero,   &
+                        KPP_exp=CS%KPP_exp)
+  !Allocation and initialization
+  allocate( CS%N2( SZI_(G), SZJ_(G), SZK_(G)+1 ) );CS%N2(:,:,:) = 0.
+  allocate( CS%S2( SZI_(G), SZJ_(G), SZK_(G)+1 ) );CS%S2(:,:,:) = 0.
+
+end function cvmix_shear_init
+
+end module MOM_cvmix_shear

--- a/src/parameterizations/vertical/MOM_cvmix_shear.F90
+++ b/src/parameterizations/vertical/MOM_cvmix_shear.F90
@@ -19,6 +19,14 @@ module MOM_cvmix_shear
 !* or see:   http://www.gnu.org/licenses/gpl.html                      *
 !***********************************************************************
 
+!---------------------------------------------------
+! module MOM_cvmix_shear
+! Author: Brandon Reichl
+! Date: Aug 31, 2016
+! Purpose: Interface to CVMix interior shear schemes
+! Further information to be added at a later time.
+!---------------------------------------------------
+
 use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock, only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
 use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
@@ -39,16 +47,17 @@ implicit none ; private
 #include <netcdf.inc>
 #endif
 
-public Calculate_cvmix_shear, cvmix_shear_init
+public Calculate_cvmix_shear, cvmix_shear_init, cvmix_shear_is_used
 
-type, public :: CVMix_shear_CS ! ; private
-  logical :: use_LMD94, use_PP81
-  real    :: Ri_zero
-  real    :: Nu_zero
-  real    :: KPP_exp
-  real, allocatable, dimension(:,:,:) :: N2        !< Squared Brunt-Vaisala frequency (1/s2)
-  real, allocatable, dimension(:,:,:) :: S2        !< Squared shear frequency (1/s2)
-  character(10) :: Mix_Scheme
+type, public :: CVMix_shear_CS
+! Control structure including parameters for CVMix interior shear schemes.
+  logical :: use_LMD94, use_PP81            !< Flags for various schemes
+  real    :: Ri_zero                        !< LMD94 critical Richardson number
+  real    :: Nu_zero                        !< LMD94 maximum interior diffusivity
+  real    :: KPP_exp                        !<
+  real, allocatable, dimension(:,:,:) :: N2 !< Squared Brunt-Vaisala frequency (1/s2)
+  real, allocatable, dimension(:,:,:) :: S2 !< Squared shear frequency (1/s2)
+  character(10) :: Mix_Scheme               !< Mixing scheme name (string)
 end type CVMix_shear_CS
 
 ! integer :: id_clock_project, id_clock_KQ, id_clock_avg, id_clock_setup
@@ -74,18 +83,16 @@ subroutine Calculate_cvmix_shear(u_H, v_H, h, tv, KH,  &
 ! -------------------------------------------------
 ! Subroutine for calculating (internal) diffusivity
 ! -------------------------------------------------
-! Arguments: u_in - Initial zonal velocity, in m s-1. (Intent in)
-!  (in)      v_in - Initial meridional velocity, in m s-1.
+! Arguments: 
+!  (in)      u_H - Initial zonal velocity on T points, in m s-1.
+!  (in)      v_H - Initial meridional velocity on T points, in m s-1.
 !  (in)      h - Layer thickness, in m or kg m-2.
 !  (in)      tv - A structure containing pointers to any available
 !                 thermodynamic fields. Absent fields have NULL ptrs.
 !  (in/out)  KH - The diapycnal diffusivity at each interface
-!                       (not layer!) in m2 s-1.  Initially this is the value
-!                       from the previous timestep, which may accelerate the
-!                       iteration toward convergence.
+!                       (not layer!) in m2 s-1.
 !  (in/out)  KM - The vertical viscosity at each interface
-!                    (not layer!) in m2 s-1. This discards any previous value
-!                    i.e. intent(out) and simply sets Kv = Prandtl * Kd_turb
+!                    (not layer!) in m2 s-1.
 !  (in)      G - The ocean's grid structure.
 !  (in)      GV - The ocean's vertical grid structure.
 !  (in)      CS - The control structure returned by a previous call to
@@ -107,10 +114,9 @@ subroutine Calculate_cvmix_shear(u_H, v_H, h, tv, KH,  &
       if (G%mask2dT(i,j)==0.) cycle
 
       ! Richardson number computed for each cell in a column.
-      pRef = 0.
-      Ri_Grad(:)=1.e8
+      pRef = 0. 
+      Ri_Grad(:)=1.e8 !Initialize w/ large Richardson value
       do k=1,G%ke
-
         ! pressure, temp, and saln for EOS
         ! kk+1 = k fields
         ! kk+2 = km1 fields
@@ -130,11 +136,9 @@ subroutine Calculate_cvmix_shear(u_H, v_H, h, tv, KH,  &
       enddo ! k-loop finishes
 
       ! compute in-situ density
-      call calculate_density(Temp_1D, Salt_1D, pres_1D, rho_1D, 1, 3*G%ke, TV%EQN_OF_STATE)
+      call calculate_density(Temp_1D, Salt_1D, pres_1D, rho_1D, 1, 2*G%ke, TV%EQN_OF_STATE)
 
-      ! N2 (can be negative) and N (non-negative) on interfaces.
-      ! deltaRho is non-local rho difference used for bulk Richardson number.
-      ! N_1d is local N (with floor) used for unresolved shear calculation.
+      ! N2 (can be negative) on interface
       do k = 1, G%ke
         km1 = max(1, k-1)
         kk = 2*(k-1)
@@ -144,17 +148,15 @@ subroutine Calculate_cvmix_shear(u_H, v_H, h, tv, KH,  &
         DZ = ((0.5*(h(i,j,km1) + h(i,j,k))+GV%H_subroundoff)*GV%H_to_m)
         N2 = DRHO/DZ
         S2 = (DU*DU+DV*DV)/(DZ*DZ) 
-        Ri_Grad(G%ke) = max(0.,N2)/max(S2,1.e-16)
+        Ri_Grad(k) = max(0.,N2)/max(S2,1.e-16)
       enddo
 
-
+      ! Call to CVMix wrapper for computing interior mixing coefficients.
       call  cvmix_coeffs_shear(Mdiff_out=KM(i,j,:), &
                                    Tdiff_out=KH(i,j,:), & 
                                    RICH=Ri_Grad, &
                                    nlev=G%ke,    &
                                    max_nlev=G%ke)
-
-
     enddo;
   enddo;
 
@@ -166,8 +168,8 @@ end subroutine Calculate_cvmix_shear
 logical function cvmix_shear_init(Time, G, GV, param_file, diag, CS)
   !
   ! Initialized the cvmix internal shear mixing routine.
-  !  *tests to make sure multiple internal shear mixing routines
-  !   are not enabled at the same time.
+  !  *This is where we test to make sure multiple internal shear 
+  !   mixing routines (including JHL) are not enabled at the same time.
   !
   type(time_type),         intent(in)    :: Time
   type(ocean_grid_type),   intent(in)    :: G
@@ -215,6 +217,8 @@ logical function cvmix_shear_init(Time, G, GV, param_file, diag, CS)
   endif
   use_JHL=kappa_shear_is_used(param_file)
   if (use_JHL) NumberTrue = NumberTrue + 1
+  ! After testing for interior schemes, make sure only 0 or 1 are enabled.
+  ! Otherwise, warn user and kill job.
   if ((NumberTrue).gt.1) then
      call MOM_error(FATAL, 'MOM_cvmix_shear_init: '// &
            'Multiple shear driven internal mixing schemes selected,'//&
@@ -245,5 +249,18 @@ logical function cvmix_shear_init(Time, G, GV, param_file, diag, CS)
   allocate( CS%S2( SZI_(G), SZJ_(G), SZK_(G)+1 ) );CS%S2(:,:,:) = 0.
 
 end function cvmix_shear_init
+
+logical function cvmix_shear_is_used(param_file)
+  ! Reads the parameter "LMD94" and "PP81" and returns state.
+  !   This function allows other modules to know whether this parameterization wi
+  ! be used without needing to duplicate the log entry.
+  type(param_file_type), intent(in) :: param_file
+  logical :: LMD94, PP81
+  call get_param(param_file, mod, "USE_LMD94", LMD94, &
+       default=.false., do_not_log = .true.)
+  call get_param(param_file, mod, "Use_PP81", PP81, &
+       default=.false., do_not_log = .true.)
+  cvmix_shear_is_used = (LMD94 .or. PP81)
+end function cvmix_shear_is_used
 
 end module MOM_cvmix_shear

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -585,6 +585,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
     endif
     if (showCallTree) call callTree_waypoint("done with calculate_kappa_shear (set_diffusivity)")
  elseif (CS%useCVMix) then
+    !visc%Kd_turb and visc%Kv_turb are on the faces, not the interfaces.
     call calculate_cvmix_shear(u_h, v_h, h, tv, visc%Kd_turb, visc%Kv_turb,G,GV,CS%CVMix_shear_CSp)
   elseif (associated(visc%Kv_turb)) then
     visc%Kv_turb(:,:,:) = 0. ! needed if calculate_kappa_shear is not enabled

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -585,7 +585,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
     endif
     if (showCallTree) call callTree_waypoint("done with calculate_kappa_shear (set_diffusivity)")
  elseif (CS%useCVMix) then
-    !visc%Kd_turb and visc%Kv_turb are on the faces, not the interfaces.
+    !NOTE{BGR}: this needs cleaned up.  Works in 1D case, not tested outside.
     call calculate_cvmix_shear(u_h, v_h, h, tv, visc%Kd_turb, visc%Kv_turb,G,GV,CS%CVMix_shear_CSp)
   elseif (associated(visc%Kv_turb)) then
     visc%Kv_turb(:,:,:) = 0. ! needed if calculate_kappa_shear is not enabled
@@ -712,7 +712,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
     endif
 
   ! Add the input turbulent diffusivity.
-    if (CS%useKappaShear) then
+    if (CS%useKappaShear .or. CS%useCVMix) then
       if (present(Kd_int)) then
         do K=2,nz ; do i=is,ie
           Kd_int(i,j,K) = visc%Kd_turb(i,j,K) + 0.5*(Kd(i,j,k-1) + Kd(i,j,k))

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -61,6 +61,7 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_kappa_shear, only : kappa_shear_is_used
+use MOM_CVMix_shear, only : CVMix_shear_is_used
 use MOM_io, only : vardesc, var_desc
 use MOM_restart, only : register_restart_field, MOM_restart_CS
 use MOM_variables, only : thermo_var_ptrs
@@ -1555,16 +1556,19 @@ subroutine set_visc_register_restarts(HI, GV, param_file, visc, restart_CS)
 !                   fields.  Allocated here.
 !  (in)      restart_CS - A pointer to the restart control structure.
   type(vardesc) :: vd
-  logical :: use_kappa_shear, adiabatic, useKPP, useEPBL, MLE_use_PBL_MLD
+  logical :: use_kappa_shear, adiabatic, useKPP, useEPBL
+  logical :: use_CVMix, MLE_use_PBL_MLD
   integer :: isd, ied, jsd, jed, nz
   character(len=40)  :: mod = "MOM_set_visc"  ! This module's name.
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   call get_param(param_file, mod, "ADIABATIC", adiabatic, default=.false., &
                  do_not_log=.true.)
-  use_kappa_shear = .false. ; useKPP = .false. ; useEPBL = .false.
+  use_kappa_shear = .false. ; use_CVMix = .false. ; 
+  useKPP = .false. ; useEPBL = .false.
   if (.not.adiabatic) then
     use_kappa_shear = kappa_shear_is_used(param_file)
+    use_CVMix = CVMix_shear_is_used(param_file)
     call get_param(param_file, mod, "USE_KPP", useKPP, &
                  "If true, turns on the [CVmix] KPP scheme of Large et al., 1984,\n"// &
                  "to calculate diffusivities and non-local transport in the OBL.", &
@@ -1575,7 +1579,7 @@ subroutine set_visc_register_restarts(HI, GV, param_file, visc, restart_CS)
                  "in the surface boundary layer.", default=.false., do_not_log=.true.)
   endif
 
-  if (use_kappa_shear .or. useKPP .or. useEPBL) then
+  if (use_kappa_shear .or. useKPP .or. useEPBL .or. use_CVMix) then
     allocate(visc%Kd_turb(isd:ied,jsd:jed,nz+1)) ; visc%Kd_turb(:,:,:) = 0.0
     allocate(visc%TKE_turb(isd:ied,jsd:jed,nz+1)) ; visc%TKE_turb(:,:,:) = 0.0
     allocate(visc%Kv_turb(isd:ied,jsd:jed,nz+1)) ; visc%Kv_turb(:,:,:) = 0.0


### PR DESCRIPTION
New module MOM_cvmix_shear added to MOM.

- Adds the ability to use the CVMix interior shear-mixing parameterizations in MOM6 (LMD94 and PP81).
- Checks that only one of CVMix interior shear-mixing and JHL interior shear-mixing is active.
- Allows CVMix MatchBoth to work properly (matches boundary layer base diffusivity to interior diffusivity), preventing MOM from over-riding this feature by zeroing out diffusivity before call to CVMix KPP scheme (only for 'MatchBoth').
- Still a work in progress, but working in 1D (column) mode.