### PR TITLE
Map tracers and velocities into depth space under an ice shelf

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1159,7 +1159,7 @@ subroutine step_MOM(fluxes, state, Time_start, time_interval, CS)
       if (Time_local + set_time(int(0.5*dt_therm)) > CS%Z_diag_time) then
         call enable_averaging(real(time_type_to_real(CS%Z_diag_interval)), &
                               CS%Z_diag_time, CS%diag)
-        call calculate_Z_diag_fields(u, v, h, CS%dt_trans, &
+        call calculate_Z_diag_fields(u, v, h, ssh, CS%dt_trans, &
                                      G, GV, CS%diag_to_Z_CSp)
         CS%Z_diag_time = CS%Z_diag_time + CS%Z_diag_interval
         call disable_averaging(CS%diag)

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -42,7 +42,7 @@ module MOM_diag_to_Z
 !*  The boundaries always run through q grid points (x).               *
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
-
+use MOM_domains,       only : pass_var
 use MOM_coms,          only : reproducing_sum
 use MOM_diag_mediator, only : post_data, post_data_1d_k, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl, time_type, diag_axis_init
@@ -162,27 +162,30 @@ function global_z_mean(var,G,CS,tracer)
 
 end function global_z_mean
 
-subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
+subroutine calculate_Z_diag_fields(u, v, h, ssh_in, dt, G, GV, CS)
   type(ocean_grid_type),                     intent(inout) :: G
   type(verticalGrid_type),                   intent(in)    :: GV
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: u
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: v
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h
+  real, dimension(SZI_(G),SZJ_(G)),          intent(in)    :: ssh_in
   real,                                      intent(in)    :: dt
   type(diag_to_Z_CS),                        pointer       :: CS
 
 ! This subroutine maps tracers and velocities into depth space for diagnostics. 
 
 ! Arguments: 
-!  (in)  u  - zonal velocity component (m/s)
-!  (in)  v  - meridional velocity component (m/s)
-!  (in)  h  - layer thickness (meter or kg/m2)
-!  (in)  dt - time difference in sec since last call to this subroutine
-!  (in)  G  - ocean grid structure
-!  (in)  GV - The ocean's vertical grid structure.
-!  (in)  CS - control structure returned by previous call to diagnostics_init
+!  (in)  u   - zonal velocity component (m/s)
+!  (in)  v   - meridional velocity component (m/s)
+!  (in)  h   - layer thickness (meter or kg/m2)
+!  (in)  ssh_in - sea surface height (meter or kg/m2) 
+!  (in)  dt  - time difference in sec since last call to this subroutine
+!  (in)  G   - ocean grid structure
+!  (in)  GV  - The ocean's vertical grid structure.
+!  (in)  CS  - control structure returned by previous call to diagnostics_init
 
   ! Note the deliberately reversed axes in h_f, u_f, v_f, and tr_f.
+  real :: ssh(SZI_(G),SZJ_(G))   ! copy of ssh_in (meter or kg/m2)
   real :: e(SZK_(G)+2)           ! z-star interface heights (meter or kg/m2)
   real :: h_f(SZK_(G)+1,SZI_(G)) ! thicknesses of massive layers (meter or kg/m2)
   real :: u_f(SZK_(G)+1,SZIB_(G))! zonal velocity component in any massive layer
@@ -191,7 +194,8 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
   real :: tr_f(SZK_(G),max(CS%num_tr_used,1),SZI_(G)) ! tracer concentration in massive layers
   integer :: nk_valid(SZIB_(G))  ! number of massive layers in a column
 
-  real :: D_pt(SZIB_(G)) ! bottom depth (meter or kg/m2)
+  real :: D_pt(SZIB_(G))        ! bottom depth (meter or kg/m2)
+  real :: shelf_depth(SZIB_(G)) ! ice shelf depth (meter or kg/m2)
   real :: htot           ! summed layer thicknesses (meter or kg/m2)
   real :: dilate         ! proportion by which to dilate every layer
   real :: wt(SZK_(G)+1)  ! fractional weight for each layer in the
@@ -212,11 +216,15 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
 
   integer :: k_top, k_bot, k_bot_prev
   integer :: i, j, k, k2, kz, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nk, m, nkml
-
+  integer :: IsgB, IegB, JsgB, JegB
   is   = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nk = G%ke
   Isq  = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
+  IsgB = G%IsgB ; IegB = G%IegB ; JsgB = G%JsgB ; JegB = G%JegB
   nkml = max(GV%nkml, 1)
   Angstrom = GV%Angstrom
+  ssh(:,:) = ssh_in
+  ! Update the halos
+  call pass_var(ssh, G%Domain)
 
   if (.not.associated(CS)) call MOM_error(FATAL, &
          "diagnostic_fields_zstar: Module must be initialized before it is used.")
@@ -231,10 +239,21 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
       CS%u_z(I,j,kz) = CS%missing_vel
     enddo ; enddo ; enddo
 
+    
     do j=js,je
       ! Remove all massless layers.
       do I=Isq,Ieq
-        nk_valid(I) = 0 ; D_pt(I) = 0.5*(G%bathyT(i+1,j)+G%bathyT(i,j))
+        nk_valid(I) = 0
+        D_pt(I) = 0.5*(G%bathyT(i+1,j)+G%bathyT(i,j))
+        ! GM: The following is workaround to make this subroutine works under an ice shelf
+        ! Zero ssh in the open ocean and get the depth of ice shelf (hence the abs below) 
+        ! I am not sure if -0.1 is the best choice
+        shelf_depth(I) = 0.5*(ssh(i+1,j)+ssh(i,j))
+        if (shelf_depth(I) > -0.1) then ! open ocean
+           shelf_depth(I) = 0.0
+        else ! ice shelf
+           shelf_depth(I) = abs(shelf_depth(I))
+        endif
       enddo
       do k=1,nk ; do I=Isq,Ieq
         if ((G%mask2dCu(I,j) > 0.5) .and. (h(i,j,k)+h(i+1,j,k) > 4.0*Angstrom)) then
@@ -247,13 +266,22 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
         ! no-slip BBC in the output, if anything but piecewise constant is used.
         nk_valid(I) = nk_valid(I) + 1 ; k2 = nk_valid(I)
         h_f(k2,I) = Angstrom ; u_f(k2,I) = 0.0
+        ! GM: D_pt is always slightly larger (by 1E-6 or so) than shelf_depth, so 
+        ! I consider that the ice shelf is grounded when 
+        ! shelf_depth(I) + 1.0E-3 > D_pt(i)
+        if (shelf_depth(I) + 1.0E-3 > D_pt(i)) nk_valid(I)=0
       endif ; enddo
+
 
       do I=Isq,Ieq ; if (nk_valid(I) > 0) then
       ! Calculate the z* interface heights for tracers.
         htot = 0.0 ; do k=1,nk_valid(i) ; htot = htot + h_f(k,i) ; enddo
-        dilate = 0.0 ; if (htot*GV%H_to_m > 2.0*Angstrom) dilate = (D_pt(i) - 0.0) / htot
-
+        dilate = 0.0  
+        if (htot*GV%H_to_m > 2.0*Angstrom) then
+           dilate = MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot
+           !dilate = (D_pt(i) - 0.0)/htot
+           !write(*,*)MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot
+        endif
         e(nk_valid(i)+1) = -D_pt(i)
         do k=nk_valid(i),1,-1 ; e(K) = e(K+1) + h_f(k,i)*dilate ; enddo
 
@@ -264,39 +292,44 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
                             k_bot, k_top, k_bot, wt, z1, z2)
           if (k_top>nk_valid(I)) exit
 
-          if (linear_velocity_profiles) then
-            k = k_top
-            if (k /= k_bot_prev) then
-              ! Calculate the intra-cell profile.
-              slope = 0.0 ! ; curv = 0.0
-              if ((k < nk_valid(I)) .and. (k > nkml)) call &
-                find_limited_slope(u_f(:,I), e, slope, k)
-            endif
-            ! This is the piecewise linear form.
-            CS%u_z(I,j,kz) = wt(k) * (u_f(k,I) + 0.5*slope*(z2(k) + z1(k)))
-            ! For the piecewise parabolic form add the following...
-            !     + C1_3*curv*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
-            do k=k_top+1,k_bot-1
-              CS%u_z(I,j,kz) = CS%u_z(I,j,kz) + wt(k)*u_f(k,I)
-            enddo
-            if (k_bot > k_top) then ; k = k_bot
-              ! Calculate the intra-cell profile.
-              slope = 0.0 ! ; curv = 0.0
-              if ((k < nk_valid(I)) .and. (k > nkml)) call &
-                find_limited_slope(u_f(:,I), e, slope, k)
-               ! This is the piecewise linear form.
-              CS%u_z(I,j,kz) = CS%u_z(I,j,kz) + wt(k) * &
-                  (u_f(k,I) + 0.5*slope*(z2(k) + z1(k)))
-              ! For the piecewise parabolic form add the following...
-              !     + C1_3*curv*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
-            endif
-            k_bot_prev = k_bot
-          else ! Use piecewise constant profiles.
-            CS%u_z(I,j,kz) = wt(k_top)*u_f(k_top,I)
-            do k=k_top+1,k_bot
-              CS%u_z(I,j,kz) = CS%u_z(I,j,kz) + wt(k)*u_f(k,I)
-            enddo
-          endif ! linear profiles
+	  !GM if top range that is being map is below the shelf, interpolate
+          ! otherwise keep missing_vel
+	  if (CS%Z_int(kz)<=-shelf_depth(I)) then
+
+	    if (linear_velocity_profiles) then
+	      k = k_top
+	      if (k /= k_bot_prev) then
+		! Calculate the intra-cell profile.
+		slope = 0.0 ! ; curv = 0.0
+		if ((k < nk_valid(I)) .and. (k > nkml)) call &
+		  find_limited_slope(u_f(:,I), e, slope, k)
+	      endif
+	      ! This is the piecewise linear form.
+	      CS%u_z(I,j,kz) = wt(k) * (u_f(k,I) + 0.5*slope*(z2(k) + z1(k)))
+	      ! For the piecewise parabolic form add the following...
+	      !     + C1_3*curv*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
+	      do k=k_top+1,k_bot-1
+		CS%u_z(I,j,kz) = CS%u_z(I,j,kz) + wt(k)*u_f(k,I)
+	      enddo
+	      if (k_bot > k_top) then ; k = k_bot
+		! Calculate the intra-cell profile.
+		slope = 0.0 ! ; curv = 0.0
+		if ((k < nk_valid(I)) .and. (k > nkml)) call &
+		  find_limited_slope(u_f(:,I), e, slope, k)
+		 ! This is the piecewise linear form.
+		CS%u_z(I,j,kz) = CS%u_z(I,j,kz) + wt(k) * &
+		    (u_f(k,I) + 0.5*slope*(z2(k) + z1(k)))
+		! For the piecewise parabolic form add the following...
+		!     + C1_3*curv*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
+	      endif
+	      k_bot_prev = k_bot
+	    else ! Use piecewise constant profiles.
+	      CS%u_z(I,j,kz) = wt(k_top)*u_f(k_top,I)
+	      do k=k_top+1,k_bot
+		CS%u_z(I,j,kz) = CS%u_z(I,j,kz) + wt(k)*u_f(k,I)
+	      enddo
+	    endif ! linear profiles
+          endif ! below shelf
         enddo ! kz-loop
       endif ; enddo ! I-loop and mask
     enddo ! j-loop
@@ -314,6 +347,12 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
       ! Remove all massless layers.
       do i=is,ie
         nk_valid(i) = 0 ; D_pt(i) = 0.5*(G%bathyT(i,j)+G%bathyT(i,j+1))
+        shelf_depth(I) = 0.5*(ssh(i,j)+ssh(i,j+1))
+        if (shelf_depth(I) > -0.1) then ! open ocean
+           shelf_depth(I) = 0.0
+        else ! ice shelf
+           shelf_depth(I) = abs(shelf_depth(I))
+        endif
       enddo
       do k=1,nk ; do i=is,ie
         if ((G%mask2dCv(i,j) > 0.5) .and. (h(i,j,k)+h(i,j+1,k) > 4.0*Angstrom)) then
@@ -326,13 +365,16 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
         ! no-slip BBC in the output, if anything but piecewise constant is used.
         nk_valid(i) = nk_valid(i) + 1 ; k2 = nk_valid(i)
         h_f(k2,i) = Angstrom ; v_f(k2,i) = 0.0
+        if (shelf_depth(I) + 1.0E-3 > D_pt(i)) nk_valid(I)=0
       endif ; enddo
 
       do i=is,ie ; if (nk_valid(i) > 0) then
       ! Calculate the z* interface heights for tracers.
         htot = 0.0 ; do k=1,nk_valid(i) ; htot = htot + h_f(k,i) ; enddo
-        dilate = 0.0 ; if (htot > 2.0*Angstrom) dilate = (D_pt(i) - 0.0) / htot
-
+        dilate = 0.0 
+        if (htot > 2.0*Angstrom) then
+           dilate = MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot 
+        endif
         e(nk_valid(i)+1) = -D_pt(i)
         do k=nk_valid(i),1,-1 ; e(K) = e(K+1) + h_f(k,i)*dilate ; enddo
 
@@ -342,41 +384,44 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
           call find_overlap(e, CS%Z_int(kz), CS%Z_int(kz+1), nk_valid(i), &
                             k_bot, k_top, k_bot, wt, z1, z2)
           if (k_top>nk_valid(i)) exit
-
-          if (linear_velocity_profiles) then
-            k = k_top
-            if (k /= k_bot_prev) then
-              ! Calculate the intra-cell profile.
-              slope = 0.0 ! ; curv = 0.0
-              if ((k < nk_valid(i)) .and. (k > nkml)) call &
-                find_limited_slope(v_f(:,i), e, slope, k)
-            endif
-            ! This is the piecewise linear form.
-            CS%v_z(i,J,kz) = wt(k) * (v_f(k,i) + 0.5*slope*(z2(k) + z1(k)))
-            ! For the piecewise parabolic form add the following...
-            !     + C1_3*curv*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
-            do k=k_top+1,k_bot-1
-              CS%v_z(i,J,kz) = CS%v_z(i,J,kz) + wt(k)*v_f(k,i)
-            enddo
-            if (k_bot > k_top) then ; k = k_bot
-              ! Calculate the intra-cell profile.
-              slope = 0.0 ! ; curv = 0.0
-              if ((k < nk_valid(i)) .and. (k > nkml)) call &
-                find_limited_slope(v_f(:,i), e, slope, k)
-               ! This is the piecewise linear form.
-              CS%v_z(i,J,kz) = CS%v_z(i,J,kz) + wt(k) * &
-                  (v_f(k,i) + 0.5*slope*(z2(k) + z1(k)))
-              ! For the piecewise parabolic form add the following...
-              !     + C1_3*curv*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
-            endif
-            k_bot_prev = k_bot
-          else ! Use piecewise constant profiles.
-            CS%v_z(i,J,kz) = wt(k_top)*v_f(k_top,i)
-            do k=k_top+1,k_bot
-              CS%v_z(i,J,kz) = CS%v_z(i,J,kz) + wt(k)*v_f(k,i)
-            enddo
-          endif ! linear profiles
-        enddo ! kz-loop
+          !GM if top range that is being map is below the shelf, interpolate
+          ! otherwise keep missing_vel
+	  if (CS%Z_int(kz)<=-shelf_depth(I)) then
+	    if (linear_velocity_profiles) then
+	      k = k_top
+	      if (k /= k_bot_prev) then
+		! Calculate the intra-cell profile.
+		slope = 0.0 ! ; curv = 0.0
+		if ((k < nk_valid(i)) .and. (k > nkml)) call &
+		  find_limited_slope(v_f(:,i), e, slope, k)
+	      endif
+	      ! This is the piecewise linear form.
+	      CS%v_z(i,J,kz) = wt(k) * (v_f(k,i) + 0.5*slope*(z2(k) + z1(k)))
+	      ! For the piecewise parabolic form add the following...
+	      !     + C1_3*curv*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
+	      do k=k_top+1,k_bot-1
+		CS%v_z(i,J,kz) = CS%v_z(i,J,kz) + wt(k)*v_f(k,i)
+	      enddo
+	      if (k_bot > k_top) then ; k = k_bot
+		! Calculate the intra-cell profile.
+		slope = 0.0 ! ; curv = 0.0
+		if ((k < nk_valid(i)) .and. (k > nkml)) call &
+		  find_limited_slope(v_f(:,i), e, slope, k)
+		 ! This is the piecewise linear form.
+		CS%v_z(i,J,kz) = CS%v_z(i,J,kz) + wt(k) * &
+		    (v_f(k,i) + 0.5*slope*(z2(k) + z1(k)))
+		! For the piecewise parabolic form add the following...
+		!     + C1_3*curv*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
+	      endif
+	      k_bot_prev = k_bot
+	    else ! Use piecewise constant profiles.
+	      CS%v_z(i,J,kz) = wt(k_top)*v_f(k_top,i)
+	      do k=k_top+1,k_bot
+		CS%v_z(i,J,kz) = CS%v_z(i,J,kz) + wt(k)*v_f(k,i)
+	      enddo
+	    endif ! linear profiles
+          endif ! below shelf
+	  enddo ! kz-loop
       endif ; enddo ! i-loop and mask
     enddo ! J-loop
     
@@ -392,11 +437,20 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
 
     do j=js,je
       ! Remove all massless layers.
-      do i=is,ie ; nk_valid(i) = 0 ; D_pt(i) = G%bathyT(i,j) ; enddo
+      do i=is,ie  
+        nk_valid(i) = 0 ; D_pt(i) = G%bathyT(i,j) 
+        shelf_depth(I) = ssh(i,j)
+        if (shelf_depth(I) > -0.1) then ! open ocean
+           shelf_depth(I) = 0.0
+        else ! ice shelf
+           shelf_depth(I) = abs(shelf_depth(I))
+        endif
+      enddo
       do k=1,nk ; do i=is,ie
         if ((G%mask2dT(i,j) > 0.5) .and. (h(i,j,k) > 2.0*Angstrom)) then
           nk_valid(i) = nk_valid(i) + 1 ; k2 = nk_valid(i)
           h_f(k2,i) = h(i,j,k)
+          if (shelf_depth(I) + 1.0E-3 > D_pt(i)) nk_valid(I)=0
           do m=1,CS%num_tr_used ; tr_f(k2,m,i) = CS%tr_model(m)%p(i,j,k) ; enddo
         endif
       enddo ; enddo
@@ -404,8 +458,10 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
       do i=is,ie ; if (nk_valid(i) > 0) then
       ! Calculate the z* interface heights for tracers.
         htot = 0.0 ;  do k=1,nk_valid(i) ; htot = htot + h_f(k,i) ; enddo
-        dilate = 0.0 ; if (htot > 2.0*Angstrom) dilate = (D_pt(i) - 0.0) / htot
-
+        dilate = 0.0 
+        if (htot > 2.0*Angstrom) then
+           dilate = MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot   
+        endif
         e(nk_valid(i)+1) = -D_pt(i)
         do k=nk_valid(i),1,-1 ; e(K) = e(K+1) + h_f(k,i)*dilate ; enddo
 
@@ -415,38 +471,39 @@ subroutine calculate_Z_diag_fields(u, v, h, dt, G, GV, CS)
           call find_overlap(e, CS%Z_int(kz), CS%Z_int(kz+1), nk_valid(i), &
                             k_bot, k_top, k_bot, wt, z1, z2)
           if (k_top>nk_valid(i)) exit
-
-          do m=1,CS%num_tr_used
-            k = k_top
-            if (k /= k_bot_prev) then
-              ! Calculate the intra-cell profile.
-              sl_tr(m) = 0.0 ! ; cur_tr(m) = 0.0
-              if ((k < nk_valid(i)) .and. (k > nkml)) call &
-                find_limited_slope(tr_f(:,m,i), e, sl_tr(m), k)
-            endif
-            ! This is the piecewise linear form.
-            CS%tr_z(m)%p(i,j,kz) = wt(k) * &
-                (tr_f(k,m,i) + 0.5*sl_tr(m)*(z2(k) + z1(k)))
-            ! For the piecewise parabolic form add the following...
-            !     + C1_3*cur_tr(m)*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
-            do k=k_top+1,k_bot-1
-              CS%tr_z(m)%p(i,j,kz) = CS%tr_z(m)%p(i,j,kz) + wt(k)*tr_f(k,m,i)
-            enddo
-            if (k_bot > k_top) then
-              k = k_bot
-              ! Calculate the intra-cell profile.
-              sl_tr(m) = 0.0 ! ; cur_tr(m) = 0.0
-              if ((k < nk_valid(i)) .and. (k > nkml)) call &
-                find_limited_slope(tr_f(:,m,i), e, sl_tr(m), k)
-              ! This is the piecewise linear form.
-              CS%tr_z(m)%p(i,j,kz) = CS%tr_z(m)%p(i,j,kz) + wt(k) * &
-                  (tr_f(k,m,i) + 0.5*sl_tr(m)*(z2(k) + z1(k)))
-              ! For the piecewise parabolic form add the following...
-              !     + C1_3*cur_tr(m)*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
-            endif
-          enddo
-          k_bot_prev = k_bot
-        enddo ! kz-loop
+          if (CS%Z_int(kz)<=-shelf_depth(I)) then
+	    do m=1,CS%num_tr_used
+	      k = k_top
+	      if (k /= k_bot_prev) then
+		! Calculate the intra-cell profile.
+		sl_tr(m) = 0.0 ! ; cur_tr(m) = 0.0
+		if ((k < nk_valid(i)) .and. (k > nkml)) call &
+		  find_limited_slope(tr_f(:,m,i), e, sl_tr(m), k)
+	      endif
+	      ! This is the piecewise linear form.
+	      CS%tr_z(m)%p(i,j,kz) = wt(k) * &
+		  (tr_f(k,m,i) + 0.5*sl_tr(m)*(z2(k) + z1(k)))
+	      ! For the piecewise parabolic form add the following...
+	      !     + C1_3*cur_tr(m)*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
+	      do k=k_top+1,k_bot-1
+		CS%tr_z(m)%p(i,j,kz) = CS%tr_z(m)%p(i,j,kz) + wt(k)*tr_f(k,m,i)
+	      enddo
+	      if (k_bot > k_top) then
+		k = k_bot
+		! Calculate the intra-cell profile.
+		sl_tr(m) = 0.0 ! ; cur_tr(m) = 0.0
+		if ((k < nk_valid(i)) .and. (k > nkml)) call &
+		  find_limited_slope(tr_f(:,m,i), e, sl_tr(m), k)
+		! This is the piecewise linear form.
+		CS%tr_z(m)%p(i,j,kz) = CS%tr_z(m)%p(i,j,kz) + wt(k) * &
+		    (tr_f(k,m,i) + 0.5*sl_tr(m)*(z2(k) + z1(k)))
+		! For the piecewise parabolic form add the following...
+		!     + C1_3*cur_tr(m)*(z2(k)**2 + z2(k)*z1(k) + z1(k)**2))
+	      endif
+	    enddo
+	    k_bot_prev = k_bot
+          endif ! below shelf
+	  enddo ! kz-loop
       endif ; enddo ! i-loop and mask
 
     enddo ! j-loop


### PR DESCRIPTION
This is a work around to map tracers and  velocities into depth space under an ice shelf. The base of the ice shelf is determined based on the SSH field. The total water column is then dilated using SSH and the ocean depth. It fixes issue #343   