### PR TITLE
Mods for generic abiotic tracer routine

### DIFF
--- a/config_src/dynamic/MOM_memory.h
+++ b/config_src/dynamic/MOM_memory.h
@@ -34,7 +34,9 @@
                                !    NJPROC_ is the number of processors in the
                                !  y-direction.
 
+#ifndef MAX_FIELDS_
 #define MAX_FIELDS_ 50
+#endif
                                !    The maximum permitted number (each) of
                                !  restart variables, time derivatives, etc.
                                !  This is mostly used for the size of pointer

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -60,6 +60,7 @@ module MOM_generic_tracer
   use MOM_grid, only : ocean_grid_type
   use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc
   use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
+  use MOM_spatial_means, only : global_area_mean
   use MOM_sponge, only : set_up_sponge_field, sponge_CS
   use MOM_ALE_sponge, only : set_up_ALE_sponge_field, ALE_sponge_CS
   use MOM_time_manager, only : time_type, get_time
@@ -373,6 +374,15 @@ contains
             endif
          enddo; enddo ; enddo
 
+         !jgj: Reset CASED to 0 below K=1 
+         if(trim(g_tracer_name) .eq. 'cased') then
+            do k=2,nk ; do j=jsc,jec ; do i=isc,iec
+               if(tr_ptr(i,j,k) .ne. CS%tracer_land_val) then
+                 tr_ptr(i,j,k) = 0.0
+               endif
+            enddo; enddo ; enddo
+         endif
+
        else !Do it old way if the tracer is not registered to start from a specific source file.  
             !This path should be deprecated if all generic tracers are required to start from specified sources.
         if (len_trim(CS%IC_file) > 0) then
@@ -536,6 +546,9 @@ contains
     character(len=fm_string_len)  :: g_tracer_name
     real, dimension(:,:), pointer :: stf_array,trunoff_array,runoff_tracer_flux_array
 
+    real :: surface_field(SZI_(G),SZJ_(G))
+    real :: sosga
+
     real, dimension(G%isd:G%ied,G%jsd:G%jed,G%ke) :: rho_dzt, dzt
     real, dimension(G%isd:G%ied,G%jsd:G%jed)      :: hblt_depth
     integer :: i, j, k, isc, iec, jsc, jec, nk
@@ -605,11 +618,16 @@ contains
     enddo; enddo ; enddo
 
 
+    do j=jsc,jec ; do i=isc,iec 
+       surface_field(i,j) = tv%S(i,j,1)
+    enddo ; enddo 
+    sosga = global_area_mean(surface_field, G)
+
     !
     !Calculate tendencies (i.e., field changes at dt) from the sources / sinks
     !
 
-    call generic_tracer_source(tv%T,tv%S,rho_dzt,dzt,hblt_depth,G%isd,G%jsd,1,dt,&
+    call generic_tracer_source(tv%T,tv%S,sosga,rho_dzt,dzt,hblt_depth,G%isd,G%jsd,1,dt,&
          G%areaT,get_diag_time_end(CS%diag),&
          optics%nbands, optics%max_wavelength_band, optics%sw_pen_band, optics%opacity_band)
 
@@ -742,7 +760,7 @@ contains
     real, dimension(:),                 intent(out)   :: gmin,gmax
     real, dimension(:),                 intent(out)   :: xgmin, ygmin, zgmin, xgmax, ygmax, zgmax
     type(ocean_grid_type),              intent(in)    :: G
-    type(MOM_generic_tracer_CS),        pointer       :: CS
+    type(MOM_generic_tracer_CS),       pointer       :: CS
     character(len=*), dimension(:),     intent(out)   :: names
     character(len=*), dimension(:),     intent(out)   :: units
     integer                                           :: MOM_generic_tracer_min_max
@@ -846,6 +864,8 @@ contains
     !  (in)      CS - The control structure returned by a previous call to
     !                 register_MOM_generic_tracer.
 
+    real :: sosga
+
     character(len=fm_string_len), parameter :: sub_name = 'MOM_generic_tracer_surface_state'
     real, dimension(G%isd:G%ied,G%jsd:G%jed,1:G%ke,1) :: rho0
     type(g_tracer_type), pointer :: g_tracer
@@ -854,12 +874,15 @@ contains
     !nnz: fake rho0
     rho0=1.0
 
+    sosga = global_area_mean(state%SSS, G)
+
     call generic_tracer_coupler_set(state%tr_fields,&
          ST=state%SST,&
          SS=state%SSS,&
+         sosga=sosga, &
          rho=rho0,& !nnz: required for MOM
          ilb=G%isd, jlb=G%jsd,&
-         tau=1)
+         tau=1,model_time=get_diag_time_end(CS%diag))
 
     !Output diagnostics via diag_manager for all tracers in this module
 !    if(.NOT. associated(CS%g_tracer_list)) call mpp_error(FATAL, trim(sub_name)//&


### PR DESCRIPTION
  - Compute sosga and pass to generic_tracer_source()
    since routine normalizes global alkalinity by the
    ratio of local to global SSS.
  - Add model time to generic_tracer_coupler_set call
  - Wrap MAX_FIELDS in ifndef block so that it can
    be modified via CPPDEFS
  - Include block from Jasmin John to reset the COBALT
    'cased' tracer to 0. for all layers k>=2