### PR TITLE
Adds Hml to the RESTART file 

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2857,6 +2857,12 @@ subroutine set_restart_fields(GV, param_file, CS)
   vd = var_desc("ave_ssh","meter","Time average sea surface height",'h','1')
   call register_restart_field(CS%ave_ssh, vd, .false., CS%restart_CSp)
 
+  ! GM, hML is needed when using the ice shelf module 
+  if (associated(CS%tv%Hml)) then
+     vd = var_desc("hML","meter","Mixed layer thickness",'h','1')
+     call register_restart_field(CS%tv%Hml, vd, .false., CS%restart_CSp)
+  endif
+
 end subroutine set_restart_fields
 
 


### PR DESCRIPTION
Hml is needed when doing a restart run with SHELF_THERMO = True ([see here](https://github.com/NOAA-GFDL/MOM6/blob/fd8cf8a459fce38d434e4e0461690adec7c4f4d0/src/ice_shelf/MOM_ice_shelf.F90#L517)). If Hml is not available in the restart file, melting will not be computed during the first time step after the restart and the results will differ from those obtained in an identical run that does not use a RESTART file.