### PR TITLE
Fix for a LOAR2 model crash

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -517,8 +517,9 @@ subroutine step_MOM(fluxes, state, Time_start, time_interval, CS)
     call create_group_pass(CS%pass_tau_ustar_psurf, fluxes%ustar(:,:), G%Domain)
   if (ASSOCIATED(fluxes%p_surf)) &
     call create_group_pass(CS%pass_tau_ustar_psurf, fluxes%p_surf(:,:), G%Domain)
-  if (CS%thickness_diffuse .OR. CS%mixedlayer_restrat) &
+  if ((CS%thickness_diffuse  .and. (.not.CS%thickness_diffuse_first .or. CS%dt_trans == 0) )  .OR. CS%mixedlayer_restrat) &
     call create_group_pass(CS%pass_h, h, G%Domain)
+
   if (CS%diabatic_first) then
     if (associated(CS%visc%Ray_u) .and. associated(CS%visc%Ray_v)) &
       call create_group_pass(CS%pass_ray, CS%visc%Ray_u, CS%visc%Ray_v, G%Domain, &


### PR DESCRIPTION
- LOAR2 model crashed with the following traceback with a particular
  combination of paramter overrides

THERMO_SPANS_COUPLING = True

FATAL from PE   294: MPP_RESET_GROUP_UPDATE_FIELD_3D_: group%reset_index_s > group%nscalar
Image              PC                Routine            Line        Source
fms_LOAR2G_exec.x  0000000002F0F106  mpp_mod_mp_mpp_er          50  mpp_util_mpi.inc
fms_LOAR2G_exec.x  0000000002CA7DE7  mpp_domains_mod_m         887  mpp_group_update.h
fms_LOAR2G_exec.x  0000000002227039  mom_domains_mp_cr         711  MOM_domains.F90
fms_LOAR2G_exec.x  00000000022655DA  mom_mp_step_mom_          521  MOM.F90
fms_LOAR2G_exec.x  000000000216894E  ocean_model_mod_m         426  ocean_model_MOM.F90
fms_LOAR2G_exec.x  0000000000401CE8  MAIN__                    916  coupler_main.F90

- Zhi found a mismatch between the logic for calling group_create and group_update
  that would cause this issue. He also made the fix. The model does not crash with the fix.