### PR TITLE
Register forcing diags later so that registration and post can be don…

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -57,7 +57,7 @@ use MOM_domains,          only : global_field_sum, BITWISE_EXACT_SUM
 use MOM_domains,          only : AGRID, BGRID_NE, CGRID_NE, To_All
 use MOM_error_handler,    only : MOM_error, WARNING, FATAL, is_root_pe, MOM_mesg
 use MOM_file_parser,      only : get_param, log_version, param_file_type
-use MOM_forcing_type,     only : forcing, forcing_diags, register_forcing_type_diags
+use MOM_forcing_type,     only : forcing, forcing_diags, forcing_type_init
 use MOM_forcing_type,     only : allocate_forcing_type, deallocate_forcing_type
 use MOM_get_input,        only : Get_MOM_Input, directories
 use MOM_grid,             only : ocean_grid_type
@@ -1128,7 +1128,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
                  "starts to exhibit rigidity", units="kg m-2", default=1000.0)
   endif
 
-  call register_forcing_type_diags(Time, diag, CS%use_temperature, CS%handles)
+  call forcing_type_init(CS%use_temperature)
 
   call get_param(param_file, mod, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
                  "If true, allows flux adjustments to specified via the \n"//&

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -460,13 +460,13 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   OS%nstep = OS%nstep + 1
 
   call enable_averaging(time_step, OS%Time, OS%MOM_CSp%diag)
-  call mech_forcing_diags(OS%fluxes, time_step, OS%grid, &
+  call mech_forcing_diags(OS%Time, OS%fluxes, time_step, OS%grid, &
                           OS%MOM_CSp%diag, OS%forcing_CSp%handles)
   call disable_averaging(OS%MOM_CSp%diag)
 
   if (OS%fluxes%fluxes_used) then
     call enable_averaging(OS%fluxes%dt_buoy_accum, OS%Time, OS%MOM_CSp%diag)
-    call forcing_diagnostics(OS%fluxes, OS%state, OS%fluxes%dt_buoy_accum, &
+    call forcing_diagnostics(OS%Time, OS%fluxes, OS%state, OS%fluxes%dt_buoy_accum, &
                              OS%grid, OS%MOM_CSp%diag, OS%forcing_CSp%handles)
     call accumulate_net_input(OS%fluxes, OS%state, OS%fluxes%dt_buoy_accum, &
                               OS%grid, OS%sum_output_CSp)

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -468,14 +468,14 @@ program MOM_main
     Time = Master_Time
 
     call enable_averaging(time_step, Time, MOM_CSp%diag)
-    call mech_forcing_diags(fluxes, time_step, grid, MOM_CSp%diag, &
+    call mech_forcing_diags(Time, fluxes, time_step, grid, MOM_CSp%diag, &
                             surface_forcing_CSp%handles)
     call disable_averaging(MOM_CSp%diag)
 
     if (.not. offline_tracer_mode) then
       if (fluxes%fluxes_used) then
         call enable_averaging(fluxes%dt_buoy_accum, Time, MOM_CSp%diag)
-        call forcing_diagnostics(fluxes, state, fluxes%dt_buoy_accum, grid, &
+        call forcing_diagnostics(Time, fluxes, state, fluxes%dt_buoy_accum, grid, &
                                  MOM_CSp%diag, surface_forcing_CSp%handles)
         call accumulate_net_input(fluxes, state, fluxes%dt_buoy_accum, grid, sum_output_CSp)
         call disable_averaging(MOM_CSp%diag)

--- a/config_src/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/solo_driver/MOM_surface_forcing.F90
@@ -76,7 +76,7 @@ use MOM_error_handler,       only : MOM_error, FATAL, WARNING, MOM_mesg, is_root
 use MOM_error_handler,       only : callTree_enter, callTree_leave
 use MOM_file_parser,         only : get_param, log_version, param_file_type
 use MOM_string_functions,    only : uppercase
-use MOM_forcing_type,        only : forcing, forcing_diags, register_forcing_type_diags, deallocate_forcing_type
+use MOM_forcing_type,        only : forcing, forcing_diags, forcing_type_init, deallocate_forcing_type
 use MOM_forcing_type,        only : allocate_forcing_type, deallocate_forcing_type
 use MOM_grid,                only : ocean_grid_type
 use MOM_get_input,           only : Get_MOM_Input, directories
@@ -1850,7 +1850,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
     CS%SCM_CVmix_tests_CSp%Rho0 = CS%Rho0 !copy reference density for pass
   endif
 
-  call register_forcing_type_diags(Time, diag, CS%use_temperature, CS%handles)
+  call forcing_type_init(CS%use_temperature)
 
   ! Set up any restart fields associated with the forcing.
   call restart_init(param_file, CS%restart_CSp, "MOM_forcing.res")


### PR DESCRIPTION
…e under

the same conditions.

The advantage of this is that these diags will only registered if the model
configuration also allows a post. Registering when a post is not possible has
several downsides:

1) the registration was unnecessary
2) the available_diags file ends up being wrong so user doesn't know what's
   available
3) we have no way of testing which diags can/should be written for a given
   model configuration.

Closes #381