### PR TITLE
Minimum requirement for ensemble runs

### DIFF
--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -63,7 +63,7 @@ use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_interface_heights, only : find_eta
-use MOM_io, only : create_file, fieldtype, flush_file, open_file, reopen_file
+use MOM_io, only : create_file, fieldtype, flush_file, open_file, reopen_file, get_filename_appendix
 use MOM_io, only : file_exists, slasher, vardesc, var_desc, write_field
 use MOM_io, only : APPEND_FILE, ASCII_FILE, SINGLE_FILE, WRITEONLY_FILE
 use MOM_time_manager, only : time_type, get_time, get_date, set_time, operator(>), operator(-)
@@ -181,6 +181,7 @@ subroutine MOM_sum_output_init(G, param_file, directory, ntrnc, &
 #include "version_variable.h"
   character(len=40)  :: mod = "MOM_sum_output" ! This module's name.
   character(len=200) :: energyfile  ! The name of the energy file.
+  character(len=32) :: filename_appendix = '' !fms appendix to filename for ensemble runs 
 
   if (associated(CS)) then
     call MOM_error(WARNING, "MOM_sum_output_init called with associated control structure.")
@@ -231,6 +232,12 @@ subroutine MOM_sum_output_init(G, param_file, directory, ntrnc, &
   call get_param(param_file, mod, "ENERGYFILE", energyfile, &
                  "The file to use to write the energies and globally \n"//&
                  "summed diagnostics.", default="ocean.stats")
+
+  !query fms_io if there is a filename_appendix (for ensemble runs)
+  call get_filename_appendix(filename_appendix)
+  if(len_trim(filename_appendix) > 0) then
+     energyfile = trim(energyfile) //'.'//trim(filename_appendix)
+  end if
 
   CS%energyfile = trim(slasher(directory))//trim(energyfile)
   call log_param(param_file, mod, "output_path/ENERGYFILE", CS%energyfile)

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -16,6 +16,7 @@ use ensemble_manager_mod, only : get_ensemble_id
 use fms_mod,              only : write_version_number, open_namelist_file, check_nml_error
 use fms_io_mod,           only : file_exist, field_size, read_data
 use fms_io_mod,           only : field_exists => field_exist, io_infra_end=>fms_io_exit
+use fms_io_mod,           only : get_filename_appendix => get_filename_appendix
 use mpp_domains_mod,      only : domain1d, mpp_get_domain_components
 use mpp_domains_mod,      only : CENTER, CORNER, NORTH_FACE=>NORTH, EAST_FACE=>EAST
 use mpp_io_mod,           only : open_file => mpp_open, close_file => mpp_close
@@ -35,7 +36,7 @@ use netcdf
 
 implicit none ; private
 
-public :: close_file, create_file, field_exists, field_size, fieldtype
+public :: close_file, create_file, field_exists, field_size, fieldtype, get_filename_appendix
 public :: file_exists, flush_file, get_file_info, get_file_atts, get_file_fields
 public :: get_file_times, open_file, read_axis_data, read_data, read_field
 public :: num_timelevels, MOM_read_data, ensembler

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -66,7 +66,7 @@ use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_string_functions, only : lowercase
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : create_file, fieldtype, file_exists, open_file, close_file
-use MOM_io, only : read_field, write_field, read_data
+use MOM_io, only : read_field, write_field, read_data, get_filename_appendix
 use MOM_io, only : get_file_info, get_file_atts, get_file_fields, get_file_times
 use MOM_io, only : vardesc, query_vardesc, modify_vardesc
 use MOM_io, only : MULTIPLE, NETCDF_FILE, READONLY_FILE, SINGLE_FILE
@@ -747,6 +747,8 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV)
   character(len=8) :: t_grid_read
   character(len=64) :: var_name         ! A variable's name.
   real :: restart_time
+  character(len=32) :: filename_appendix = '' !fms appendix to filename for ensemble runs 
+  integer :: length
 
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "save_restart: Module must be initialized before it is used.")
@@ -818,6 +820,17 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV)
     enddo
     next_var = m
 
+    !query fms_io if there is a filename_appendix (for ensemble runs)
+    call get_filename_appendix(filename_appendix)
+    if(len_trim(filename_appendix) > 0) then
+      length = len_trim(restartname)
+      if(restartname(length-2:length) == '.nc') then
+        restartname = restartname(1:length-3)//'.'//trim(filename_appendix)//'.nc'
+      else
+        restartname = restartname(1:length)  //'.'//trim(filename_appendix)
+      end if
+    end if
+    
     restartpath = trim(directory)// trim(restartname)
 
     if (num_files < 10) then
@@ -918,6 +931,9 @@ subroutine restore_state(filename, directory, day, G, CS)
   integer :: i, missing_fields
   real    :: t1, t2
   integer :: err
+  character(len=32) :: filename_appendix = '' !fms appendix to filename for ensemble runs 
+  character(len=80) :: restartname
+  integer :: length
 
   num_restart = 0 ; n = 1 ; start_char = 1
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
@@ -939,7 +955,20 @@ subroutine restore_state(filename, directory, day, G, CS)
       err = 0
       if (num_restart > 0) err = 1 ! Avoid going through the file list twice.
       do while (err == 0)
-        filepath = trim(directory) // trim(CS%restartfile)
+        restartname = trim(CS%restartfile)
+
+       !query fms_io if there is a filename_appendix (for ensemble runs)
+       call get_filename_appendix(filename_appendix)
+       if(len_trim(filename_appendix) > 0) then
+         length = len_trim(restartname)
+         if(restartname(length-2:length) == '.nc') then
+           restartname = restartname(1:length-3)//'.'//trim(filename_appendix)//'.nc'
+         else
+           restartname = restartname(1:length)  //'.'//trim(filename_appendix)
+         end if
+        end if
+        filepath = trim(directory) // trim(restartname)
+
         if (num_restart < 10) then
           write(suffix,'("_",I1)') num_restart
         else


### PR DESCRIPTION
- These mods let MOM6 run in ensemble mode just like MOM5 does.
- There might be some parts missing. Some MOM6 outputs may be written into the same file for all members.
  E.g., he U and V trunction files.

- These updates require an update to FRE to combine iceberg restarts in ensemble mode. 
@underwoo  icebergs restart combine  do work properly within fre/bronx-11, but it needs a small fix for ensemble runs  [see issue #184 on gitlab](https://gitlab.gfdl.noaa.gov/fre-legacy/fre-commands/issues/184).  