### PR TITLE
Fix a few bugs in the Ice Shelf module

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -945,7 +945,7 @@ subroutine add_shelf_flux(G, CS, state, fluxes)
     ! This is needed because rigidity is potentially modified in the coupler. Reset
     ! in the ice shelf cavity: MJH
 
-    do j=isd,jed ; do i=isd,ied-1 ! changed stride
+    do j=jsd,jed ; do i=isd,ied-1 ! changed stride
       fluxes%rigidity_ice_u(I,j) = (CS%kv_ice / CS%density_ice) * &
                     min(CS%mass_shelf(i,j), CS%mass_shelf(i+1,j))
     enddo ; enddo
@@ -1751,7 +1751,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, fluxes, Ti
   enddo ; enddo
 
   if (.not. solo_ice_sheet) then
-    do j=isd,jed ; do i=isd,ied-1 ! changed stride
+    do j=jsd,jed ; do i=isd,ied-1 ! changed stride
     !do I=isd,ied-1 ; do j=isd,jed 
     fluxes%frac_shelf_u(I,j) = 0.0
     if ((G%areaT(i,j) + G%areaT(i+1,j) > 0.0)) & ! .and. (G%dxdy_u(I,j) > 0.0)) &


### PR DESCRIPTION
* Two do-loops had wrong indices (j=isd,jed instead of j=jsd,jed). This would not be a problem if isd = jsd. Otherwise, fluxes%rigidity_ice_u would be affected. Thanks to @MJHarrison-GFDL for catching these errors.

* Haline driving, one of the diagnostics used in ISOMIP, was not being compute
 properly. This does not affect the the melting calculation.
    
* The option to set melt to zero above a cutoff depth (MELTING_CUTOFF_DEPTH) was not being done properly. Just iceshelf_melt was being corrected, but freshwater was still being added to the ocean via lprec. Now, lprec and iceshelf_melt are set to zero above the cutoff depth.
    
* I also added a few sanity checks and cleaned parts of the code.