### PR TITLE
Fix ice shelf filename in MOM_temp_salt_initialize_from_Z

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1779,11 +1779,12 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, dirs)
   call pass_var(rho_z,G%Domain)
 
   ! This is needed for building an ALE grid under ice shelves
-  call get_param(PF, mod, "ICE_SHELF", use_ice_shelf, default=.false., do_not_log=.true.)
+  call get_param(PF, mod, "ICE_SHELF", use_ice_shelf, default=.false.)
   if (use_ice_shelf) then
      call get_param(PF, mod, "ICE_THICKNESS_FILE", ice_shelf_file, &
                     "The file from which the ice bathymetry and area are read.", &
                     fail_if_missing=.true.)
+     filename = trim(inputdir)//trim(ice_shelf_file)
      call log_param(PF, mod, "INPUTDIR/THICKNESS_FILE", filename)
      call get_param(PF, mod, "ICE_AREA_VARNAME", area_varname, &
                     "The name of the area variable in ICE_THICKNESS_FILE.", &


### PR DESCRIPTION
I forgot to define the ice shelf "filename" in a [previous commit](https://github.com/NOAA-GFDL/MOM6/commit/136faceb695d06279af8efb82a290679d436e932). This bug just affected runs where MOM_temp_salt_initialize_from_Z = True.