### PR TITLE
Updates for KH in hor_visc and CDRAG in MEKE

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -513,7 +513,7 @@ subroutine step_MOM(fluxes, state, Time_start, time_interval, CS)
     call create_group_pass(CS%pass_tau_ustar_psurf, fluxes%ustar(:,:), G%Domain)
   if (ASSOCIATED(fluxes%p_surf)) &
     call create_group_pass(CS%pass_tau_ustar_psurf, fluxes%p_surf(:,:), G%Domain)
-  if (CS%thickness_diffuse .OR. CS%mixedlayer_restrat) &
+  if ((CS%thickness_diffuse  .and. (.not.CS%thickness_diffuse_first .or. CS%dt_trans == 0)) .OR. CS%mixedlayer_restrat) &
     call create_group_pass(CS%pass_h, h, G%Domain)
   if (CS%diabatic_first) then
     if (associated(CS%visc%Ray_u) .and. associated(CS%visc%Ray_v)) &

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -2163,25 +2163,32 @@ subroutine allocate_forcing_type(G, fluxes, stress, ustar, water, heat, shelf, p
   isd  = G%isd   ; ied  = G%ied    ; jsd  = G%jsd   ; jed  = G%jed
   IsdB = G%IsdB  ; IedB = G%IedB   ; JsdB = G%JsdB  ; JedB = G%JedB
 
-  call myAlloc(fluxes%taux,IsdB,IedB,jsd,jed, stress)
-  call myAlloc(fluxes%tauy,isd,ied,JsdB,JedB, stress)
-  call myAlloc(fluxes%ustar,isd,ied,jsd,jed, ustar)
+  if ( present(stress) ) then 
+    call myAlloc(fluxes%taux,IsdB,IedB,jsd,jed, stress)
+    call myAlloc(fluxes%tauy,isd,ied,JsdB,JedB, stress)
+  endif
+  if ( present(ustar) ) &
+     call myAlloc(fluxes%ustar,isd,ied,jsd,jed, ustar)
 
-  call myAlloc(fluxes%evap,isd,ied,jsd,jed, water)
-  call myAlloc(fluxes%lprec,isd,ied,jsd,jed, water)
-  call myAlloc(fluxes%fprec,isd,ied,jsd,jed, water)
-  call myAlloc(fluxes%vprec,isd,ied,jsd,jed, water)
-  call myAlloc(fluxes%lrunoff,isd,ied,jsd,jed, water)
-  call myAlloc(fluxes%frunoff,isd,ied,jsd,jed, water)
-  call myAlloc(fluxes%seaice_melt,isd,ied,jsd,jed, water)
+  if ( present(water) ) then 
+    call myAlloc(fluxes%evap,isd,ied,jsd,jed, water)
+    call myAlloc(fluxes%lprec,isd,ied,jsd,jed, water)
+    call myAlloc(fluxes%fprec,isd,ied,jsd,jed, water)
+    call myAlloc(fluxes%vprec,isd,ied,jsd,jed, water)
+    call myAlloc(fluxes%lrunoff,isd,ied,jsd,jed, water)
+    call myAlloc(fluxes%frunoff,isd,ied,jsd,jed, water)
+    call myAlloc(fluxes%seaice_melt,isd,ied,jsd,jed, water)
+  endif
 
-  call myAlloc(fluxes%sw,isd,ied,jsd,jed, heat)
-  call myAlloc(fluxes%lw,isd,ied,jsd,jed, heat)
-  call myAlloc(fluxes%latent,isd,ied,jsd,jed, heat)
-  call myAlloc(fluxes%sens,isd,ied,jsd,jed, heat)
-  call myAlloc(fluxes%latent_evap_diag,isd,ied,jsd,jed, heat)
-  call myAlloc(fluxes%latent_fprec_diag,isd,ied,jsd,jed, heat)
-  call myAlloc(fluxes%latent_frunoff_diag,isd,ied,jsd,jed, heat)
+  if ( present(heat) ) then 
+    call myAlloc(fluxes%sw,isd,ied,jsd,jed, heat)
+    call myAlloc(fluxes%lw,isd,ied,jsd,jed, heat)
+    call myAlloc(fluxes%latent,isd,ied,jsd,jed, heat)
+    call myAlloc(fluxes%sens,isd,ied,jsd,jed, heat)
+    call myAlloc(fluxes%latent_evap_diag,isd,ied,jsd,jed, heat)
+    call myAlloc(fluxes%latent_fprec_diag,isd,ied,jsd,jed, heat)
+    call myAlloc(fluxes%latent_frunoff_diag,isd,ied,jsd,jed, heat)
+  endif
 
   if (present(heat) .and. present(water)) then ; if (heat .and. water) then
     call myAlloc(fluxes%heat_content_cond,isd,ied,jsd,jed, .true.)
@@ -2194,14 +2201,17 @@ subroutine allocate_forcing_type(G, fluxes, stress, ustar, water, heat, shelf, p
     call myAlloc(fluxes%heat_content_massin,isd,ied,jsd,jed, .true.)
   endif ; endif
 
-  call myAlloc(fluxes%frac_shelf_h,isd,ied,jsd,jed, shelf)
-  call myAlloc(fluxes%frac_shelf_u,IsdB,IedB,jsd,jed, shelf)
-  call myAlloc(fluxes%frac_shelf_v,isd,ied,JsdB,JedB, shelf)
-  call myAlloc(fluxes%ustar_shelf,isd,ied,jsd,jed, shelf)
-  call myAlloc(fluxes%rigidity_ice_u,IsdB,IedB,jsd,jed, shelf)
-  call myAlloc(fluxes%rigidity_ice_v,isd,ied,JsdB,JedB, shelf)
+  if ( present(shelf) ) then 
+    call myAlloc(fluxes%frac_shelf_h,isd,ied,jsd,jed, shelf)
+    call myAlloc(fluxes%frac_shelf_u,IsdB,IedB,jsd,jed, shelf)
+    call myAlloc(fluxes%frac_shelf_v,isd,ied,JsdB,JedB, shelf)
+    call myAlloc(fluxes%ustar_shelf,isd,ied,jsd,jed, shelf)
+    call myAlloc(fluxes%rigidity_ice_u,IsdB,IedB,jsd,jed, shelf)
+    call myAlloc(fluxes%rigidity_ice_v,isd,ied,JsdB,JedB, shelf)
+  endif
 
-  call myAlloc(fluxes%p_surf,isd,ied,jsd,jed, press)
+  if ( present(press) ) &
+    call myAlloc(fluxes%p_surf,isd,ied,jsd,jed, press)
 
   contains
 

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -927,7 +927,11 @@ logical function MEKE_init(Time, G, param_file, diag, CS, MEKE, restart_CS)
   call get_param(param_file, mod, "CDRAG", CS%cdrag, &
                  "CDRAG is the drag coefficient relating the magnitude of \n"//&
                  "the velocity field to the bottom stress.", units="nondim", &
-                 default=0.003)
+                 default=0.003,do_not_log=.true.)
+  call get_param(param_file, mod, "CDRAG_MEKE", CS%cdrag, &
+                 "CDRAG_MEKE is the drag coefficient relating the magnitude of \n"//&
+                 "the velocity field to the bottom stress.", units="nondim", &
+                 default=CS%cdrag)
   call get_param(param_file, mod, "LAPLACIAN", laplacian, default=.false., do_not_log=.true.)
   if (CS%viscosity_coeff/=0. .and. .not. laplacian) call MOM_error(FATAL, &
                  "LAPLACIAN must be true if MEKE_VISCOSITY_COEFF is true.")

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -88,6 +88,7 @@ module MOM_hor_visc
 
 use MOM_diag_mediator,         only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator,         only : diag_ctrl, time_type
+use MOM_domains,               only : pass_var
 use MOM_error_handler,         only : MOM_error, FATAL, WARNING
 use MOM_file_parser,           only : get_param, log_version, param_file_type
 use MOM_grid,                  only : ocean_grid_type
@@ -96,6 +97,7 @@ use MOM_MEKE_types,            only : MEKE_type
 use MOM_variables,             only : ocean_OBC_type, OBC_FLATHER_E, OBC_FLATHER_W
 use MOM_variables,             only : OBC_FLATHER_N, OBC_FLATHER_S
 use MOM_verticalGrid,          only : verticalGrid_type
+use fms_mod,                   only : read_data
 
 implicit none ; private
 
@@ -132,9 +134,15 @@ type, public :: hor_visc_CS ; private
   logical :: bound_Coriolis  ! If true & SMAGORINSKY_AH is used, the biharmonic
                              ! viscosity is modified to include a term that
                              ! scales quadratically with the velocity shears.
+  logical :: use_Kh_bg_2d    ! Read 2d background viscosity from a file. 
+  real    :: Kh_bg_min       ! The minimum value allowed for Laplacian horizontal
+                             ! viscosity. The default is 0.0
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
     Kh_bg_xx,        &! The background Laplacian viscosity at h points, in units
+                      ! of m2 s-1. The actual viscosity may be the larger of this
+                      ! viscosity and the Smagorinsky viscosity.
+    Kh_bg_2d,        &! The background Laplacian viscosity at h points, in units
                       ! of m2 s-1. The actual viscosity may be the larger of this
                       ! viscosity and the Smagorinsky viscosity.
     Ah_bg_xx,        &! The background biharmonic viscosity at h points, in units
@@ -520,6 +528,9 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
           Kh = Kh + 0.25*( (MEKE%Ku(I,J)+MEKE%Ku(I+1,J+1))    &
                           +(MEKE%Ku(I+1,J)+MEKE%Ku(I,J+1)) )
         endif
+        ! Place a floor on the viscosity, if desired.
+        Kh = MAX(Kh,CS%Kh_bg_min)
+        
         if (CS%better_bound_Kh) then
           if (Kh >= hrat_min*CS%Kh_Max_xy(I,J)) then
             visc_bound_rem = 0.0
@@ -789,6 +800,9 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
     call get_param(param_file, mod, "KH", Kh,                      &
                  "The background Laplacian horizontal viscosity.", &
                  units = "m2 s-1", default=0.0)
+    call get_param(param_file, mod, "KH_BG_MIN", CS%Kh_bg_min, &
+                 "The minimum value allowed for Laplacian horizontal viscosity, KH.", &
+                 units = "m2 s-1",  default=0.0)
     call get_param(param_file, mod, "KH_VEL_SCALE", Kh_vel_scale, &
                  "The velocity scale which is multiplied by the grid \n"//&
                  "spacing to calculate the Laplacian viscosity. \n"//&
@@ -881,6 +895,12 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
                  "is strongly encouraged, and no slip BCs are not used with \n"//&
                  "the biharmonic viscosity.", default=.false.)
 
+  call get_param(param_file, mod, "USE_KH_BG_2D", CS%use_Kh_bg_2d, &
+                 "If true, read a file containing 2-d background harmonic  \n"//&
+                 "viscosities. The final viscosity is the maximum of the other "//&
+                 "terms and this background value.", default=.false.)
+
+
   if (CS%bound_Kh .or. CS%bound_Ah .or. CS%better_bound_Kh .or. CS%better_bound_Ah) &
     call get_param(param_file, mod, "DT", dt, &
                  "The (baroclinic) dynamics time step.", units = "s", &
@@ -917,6 +937,13 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
   endif
   ALLOC_(CS%reduction_xx(isd:ied,jsd:jed))     ; CS%reduction_xx(:,:) = 0.0
   ALLOC_(CS%reduction_xy(IsdB:IedB,JsdB:JedB)) ; CS%reduction_xy(:,:) = 0.0
+
+  if (CS%use_Kh_bg_2d) then
+    ALLOC_(CS%Kh_bg_2d(isd:ied,jsd:jed))     ; CS%Kh_bg_2d(:,:) = 0.0
+    call read_data('INPUT/KH_background_2d.nc', 'Kh', CS%Kh_bg_2d, &
+                    domain=G%domain%mpp_domain, timelevel=1)
+    call pass_var(CS%Kh_bg_2d, G%domain)
+  endif
 
   if (CS%biharmonic) then
     ALLOC_(CS%Idx2dyCu(IsdB:IedB,jsd:jed)) ; CS%Idx2dyCu(:,:) = 0.0
@@ -990,6 +1017,9 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
       if (CS%Smagorinsky_Kh) CS%LAPLAC_CONST_xx(i,j) = Smag_Lap_const * grid_sp_h2
 
       CS%Kh_bg_xx(i,j) = MAX(Kh, Kh_vel_scale * sqrt(grid_sp_h2))
+
+      if (CS%use_Kh_bg_2d) CS%Kh_bg_xx(i,j) = MAX(CS%Kh_bg_2d(i,j), CS%Kh_bg_xx(i,j))
+         
       if (CS%bound_Kh .and. .not.CS%better_bound_Kh) then
         CS%Kh_Max_xx(i,j) = Kh_Limit * grid_sp_h2
         CS%Kh_bg_xx(i,j) = MIN(CS%Kh_bg_xx(i,j), CS%Kh_Max_xx(i,j))
@@ -1000,6 +1030,9 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
       if (CS%Smagorinsky_Kh) CS%LAPLAC_CONST_xy(I,J) = Smag_Lap_const * grid_sp_q2
 
       CS%Kh_bg_xy(I,J) = MAX(Kh, Kh_vel_scale * sqrt(grid_sp_q2))
+
+      if (CS%use_Kh_bg_2d) CS%Kh_bg_xy(i,j) = MAX(CS%Kh_bg_2d(i,j), CS%Kh_bg_xy(i,j))
+         
       if (CS%bound_Kh .and. .not.CS%better_bound_Kh) then
         CS%Kh_Max_xy(I,J) = Kh_Limit * grid_sp_q2
         CS%Kh_bg_xy(I,J) = MIN(CS%Kh_bg_xy(I,J), CS%Kh_Max_xy(I,J))


### PR DESCRIPTION
Update to allow read of KH from external file in MOM_hor_visc
Update to allow differentiation of CDRAG and CDRAG_MEKE in MOM_MEKE (not sure of utility of this)
MOM_forcing_type : added checks for presence of optional argument before calling subroutine with it.
(I believe it is handled ok in the called subroutine but just in case. You can take it or leave it.)
MOM.F90 (I don't remember why this was needed but it helped with a crash. Maybe to do with AMIP? Ask Zhi if you need to.)