### PR TITLE
Added option to calculate sea level using local density.

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -88,6 +88,7 @@ use MOM_dynamics_legacy_split, only : initialize_dyn_legacy_split, end_dyn_legac
 use MOM_dynamics_legacy_split, only : adjustments_dyn_legacy_split, MOM_dyn_legacy_split_CS
 use MOM_dyn_horgrid,           only : dyn_horgrid_type, create_dyn_horgrid, destroy_dyn_horgrid
 use MOM_EOS,                   only : EOS_init
+use MOM_EOS,                   only : calculate_density
 use MOM_error_checking,        only : check_redundant
 use MOM_grid,                  only : ocean_grid_type, set_first_direction
 use MOM_grid,                  only : MOM_grid_init, MOM_grid_end
@@ -3566,7 +3567,7 @@ subroutine calculate_surface_state(state, u, v, h, ssh, G, GV, CS, p_atm)
   if (present(p_atm)) then ; if (ASSOCIATED(p_atm)) then
 
     if ((ASSOCIATED(CS%tv%eqn_of_state))  .and.  (CS%calc_rho_for_sea_lev)) then
-      call calculate_density_scalar(CS%tv%T(i,j,1),CS%tv%S(i,j,1) , (p_atm/2.0) , Rho_conv, CS%tv%eqn_of_state)
+      call calculate_density(CS%tv%T(i,j,1),CS%tv%S(i,j,1) , p_atm(i,j)/2.0 , Rho_conv, CS%tv%eqn_of_state)
     else
       Rho_conv=GV%Rho0
     endif

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3566,15 +3566,13 @@ subroutine calculate_surface_state(state, u, v, h, ssh, G, GV, CS, p_atm)
 
   if (present(p_atm)) then ; if (ASSOCIATED(p_atm)) then
 
-    if ((ASSOCIATED(CS%tv%eqn_of_state))  .and.  (CS%calc_rho_for_sea_lev)) then
-      call calculate_density(CS%tv%T(i,j,1),CS%tv%S(i,j,1) , p_atm(i,j)/2.0 , Rho_conv, CS%tv%eqn_of_state)
-    else
-      Rho_conv=GV%Rho0
-    endif
-    IgR0 = 1.0 / (Rho_conv * GV%g_Earth)
-
-
     do j=js,je ; do i=is,ie
+      if ((ASSOCIATED(CS%tv%eqn_of_state))  .and.  (CS%calc_rho_for_sea_lev)) then
+        call calculate_density(CS%tv%T(i,j,1),CS%tv%S(i,j,1) , p_atm(i,j)/2.0 , Rho_conv, CS%tv%eqn_of_state)
+      else
+        Rho_conv=GV%Rho0
+      endif
+      IgR0 = 1.0 / (Rho_conv * GV%g_Earth)
       ssh(i,j) = ssh(i,j) + p_atm(i,j) * IgR0
     enddo ; enddo
   endif ; endif


### PR DESCRIPTION
An option has been added to convert the surface pressure to sea level, using the locally calculated density. By default, the code uses the boussinesq density Rho0. When the flag CALC_RHO_FOR_SEA_LEVEL is True, the code calculates a local density to use for the conversion. The local density is calculated using the SST, SSS at p_surf/2. This is still an approximation, but does better than using the boussinesq density.

This flag lowers the shadow of iceberg which can be seen in the sea level fields.