### PR TITLE
Additional Wind-sea Langmuir number vertical mixing enhancement added…

### DIFF
--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -74,8 +74,6 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use CVmix_kpp, only : cvmix_kpp_efactor_model
-use CVmix_kinds_and_types, only : cvmix_global_params_type
 ! use MOM_EOS, only : calculate_density, calculate_density_derivs
 
 implicit none ; private
@@ -152,9 +150,10 @@ type, public :: energetic_PBL_CS ; private
   real    :: MSTAR_AT_XINT   ! Intercept value of MSTAR at value where function
                              ! changes to linear transition.
   type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+  integer :: LT_Enhance_Form = 0 ! Option for Langmuir enhancement function
   logical :: Use_Mstar_Fixed = .true. ! A logical to revert to a fixed m*
   logical :: TKE_diagnostics = .false.
-  logical :: Use_LT_LiFunction = .false.
+  logical :: Use_LA_windsea = .false.
   logical :: orig_PE_calc = .true.
   logical :: Use_MLD_iteration=.false. ! False to use old ePBL method.
   logical :: Orig_MLD_iteration=.false. ! False to use old MLD value
@@ -358,6 +357,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
   real :: U_10      ! An approximate (neutral) wind speed backed out of the friction velocity
   real :: vstar     ! An in-situ turbulent velocity, in m s-1.
   real :: Enhance_V ! An enhancement factor for vstar, based here on Langmuir impact.
+  real :: LA        ! The Langmuir number (non-dim)
   real :: hbs_here  ! The local minimum of hb_hs and MixLen_shape, times a
                     ! conversion factor from H to M, in m H-1.
   real :: nstar_FC  ! The fraction of conv_PErel that can be converted to mixing, nondim.
@@ -479,7 +479,6 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
   real :: MSTAR_MIX ! The value of mstar (Proportionality of TKE to drive mixing to ustar
                     ! cubed) which is computed as a function of latitude, boundary layer depth,
                     ! and the Monin-Obhukov depth.
-  type(cvmix_global_params_type) :: CVMIX_gravity
   logical :: debug=.false.  ! Change this hard-coded value for debugging.
 !  The following arrays are used only for debugging purposes.
   real :: dPE_debug, mixing_debug
@@ -603,8 +602,6 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
                     fluxes%frac_shelf_h(i,j) * fluxes%ustar_shelf(i,j)
       endif
       if (U_Star < CS%ustar_min) U_Star = CS%ustar_min
-      ! Computing u10 based on u_star and COARE 3.5 relationships
-      call ust_2_u10_coare3p5(U_STAR*sqrt(GV%Rho0/1.225),U_10)
       ! Computing B_Star, or the Buoyancy flux over the friction velocity.
       B_Star = min(0.0,-buoy_Flux(i,j)/U_Star)
       if (CS%omega_frac >= 1.0) then ; absf(i) = 2.0*CS%omega
@@ -701,8 +698,15 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
       ! Initialize ENHANCE_V to 1
       ENHANCE_V=1.e0
       do OBL_IT=1,MAX_OBL_IT ; if (.not. OBL_CONVERGED) then
-        if (CS%Use_LT_LiFunction) then
-          ENHANCE_V = cvmix_kpp_efactor_model ( u_10, u_star, MLD_guess, cvmix_gravity)
+        if (CS%Use_LA_windsea) then
+          call get_LA_windsea( u_star, MLD_guess, GV, LA)
+          if (CS%LT_Enhance_Form==1) then
+            !Original w'/ust scaling
+            ENHANCE_V = (1+(1.4*LA)**(-2)+(5.4*LA)**(-4))**(1.5)
+          elseif (CS%LT_Enhance_Form==2) then
+            !New Mix_LT/Mix_ST scaling
+            ENHANCE_V = (1.+(0.74*LA)**-1.5)
+          endif
         endif
         CS%ML_depth(i,j) = h(i,1)*GV%H_to_m
         !CS%ML_depth2(i,j) = h(i,1)*GV%H_to_m
@@ -724,7 +728,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
             MSTAR_mix = (MSTAR_B*(MLD_over_Stab-CS%MSTAR_XINT)+MSTAR_A)**(MSTAR_N)
           endif
           !Reset mech_tke and conv_perel values (based on new mstar)
-          mech_TKE(i) = (dt*MSTAR_mix*GV%Rho0)*((U_Star**3))
+          mech_TKE(i) = (dt*MSTAR_mix*ENHANCE_V*GV%Rho0)*((U_Star**3))
           conv_PErel(i) = 0.0
           if (CS%TKE_diagnostics) then
             CS%diag_TKE_wind(i,j) = CS%diag_TKE_wind(i,j) + mech_TKE(i) * IdtdR0
@@ -745,7 +749,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
             conv_PErel(i) = conv_PErel(i) + TKE_forced(i,j,1)
           endif
         else
-          mech_TKE(i) = mech_TKE_top(i)*ENHANCE_V**(3.) ; conv_PErel(i) = conv_PErel_top(i)
+          mech_TKE(i) = mech_TKE_top(i)*ENHANCE_V ; conv_PErel(i) = conv_PErel_top(i)
         endif
 
         if (CS%TKE_diagnostics) then
@@ -1740,12 +1744,12 @@ subroutine energetic_PBL_get_MLD(CS, MLD, G)
 end subroutine energetic_PBL_get_MLD
 
 !> Computes wind speed from ustar_air based on COARE 3.5 Cd relationship
-subroutine ust_2_u10_coare3p5(USTair,U10)
+subroutine ust_2_u10_coare3p5(USTair,U10,GV)
   real, intent(in)  :: USTair
+  type(verticalGrid_type), intent(in) :: GV  
   real, intent(out) :: U10
   real, parameter :: vonkar = 0.4
   real, parameter :: nu=1e-6
-  real, parameter :: grav = 9.81
   real :: z0sm, z0, z0rough, u10a, alpha, CD
   integer :: CT
 
@@ -1764,7 +1768,7 @@ subroutine ust_2_u10_coare3p5(USTair,U10)
     CT=CT+1
     u10a = u10
     alpha = min(0.028,0.0017 * u10 - 0.005)
-    z0rough = alpha * USTair**2/grav ! Compute z0rough from ustar guess
+    z0rough = alpha * USTair**2/GV%g_Earth ! Compute z0rough from ustar guess
     z0=z0sm+z0rough
     CD = ( vonkar / log(10/z0) )**2 ! Compute CD from derived roughness
     u10 = USTair/sqrt(CD);!Compute new u10 from derived CD, while loop
@@ -1781,6 +1785,98 @@ subroutine ust_2_u10_coare3p5(USTair,U10)
   enddo
   return
 end subroutine ust_2_u10_coare3p5
+
+subroutine get_LA_windsea(ustar, hbl, GV, LA)
+! Original description:
+! This function returns the enhancement factor, given the 10-meter
+! wind (m/s), friction velocity (m/s) and the boundary layer depth (m).
+! Update (Jan/25):
+! Converted from function to subroutine, now returns Langmuir number.
+! Computs 10m wind internally, so only ustar and hbl need passed to
+! subroutine.
+!
+! Qing Li, 160606
+! BGR port from CVMix to MOM6 Jan/25/2017
+! BGR change output to LA from Efactor
+! BGR remove u10 input
+
+! Input
+  real, intent(in) :: &
+       ! water-side surface friction velocity (m/s)
+       ustar, &
+       ! boundary layer depth (m)
+       hbl
+  type(verticalGrid_type), intent(in) :: GV
+  real, intent(out) :: LA 
+! Local variables
+  ! parameters
+  real, parameter :: &
+       ! ratio of U19.5 to U10 (Holthuijsen, 2007)
+       u19p5_to_u10 = 1.075, &
+       ! ratio of mean frequency to peak frequency for
+       ! Pierson-Moskowitz spectrum (Webb, 2011)
+       fm_to_fp = 1.296, &
+       ! ratio of surface Stokes drift to U10
+       us_to_u10 = 0.0162, &
+       ! loss ratio of Stokes transport
+       r_loss = 0.667
+  real :: us, hm0, fm, fp, vstokes, kphil, kstar
+  real :: z0, z0i, r1, r2, r3, r4, tmp, us_sl, lasl_sqr_i
+  real :: pi, u10
+  pi = 4.0*atan(1.0) 
+  ! Computing u10 based on u_star and COARE 3.5 relationships
+  call ust_2_u10_coare3p5(ustar*sqrt(GV%Rho0/1.225),U10,GV)
+  if (u10 .gt. 0.0 .and. ustar .gt. 0.0) then
+    ! surface Stokes drift
+    us = us_to_u10*u10
+    !
+    ! significant wave height from Pierson-Moskowitz
+    ! spectrum (Bouws, 1998)
+    hm0 = 0.0246 *u10**2
+    !
+    ! peak frequency (PM, Bouws, 1998)
+    tmp = 2.0 * PI * u19p5_to_u10 * u10
+    fp = 0.877 * GV%g_Earth / tmp
+    !
+    ! mean frequency
+    fm = fm_to_fp * fp
+    !
+    ! total Stokes transport (a factor r_loss is applied to account
+    !  for the effect of directional spreading, multidirectional waves
+    !  and the use of PM peak frequency and PM significant wave height
+    !  on estimating the Stokes transport)
+    vstokes = 0.125 * PI * r_loss * fm * hm0**2
+    !
+    ! the general peak wavenumber for Phillips' spectrum
+    ! (Breivik et al., 2016) with correction of directional spreading
+    kphil = 0.176 * us / vstokes
+    !
+    ! surface layer averaged Stokes dirft with Stokes drift profile
+    ! estimated from Phillips' spectrum (Breivik et al., 2016)
+    ! the directional spreading effect from Webb and Fox-Kemper, 2015
+    ! is also included
+    kstar = kphil * 2.56
+    ! surface layer
+    z0 = 0.2 * abs(hbl)
+    z0i = 1.0 / z0
+    ! term 1 to 4
+    r1 = ( 0.151 / kphil * z0i -0.84 ) &
+         * ( 1.0 - exp(-2.0 * kphil * z0) )
+    r2 = -( 0.84 + 0.0591 / kphil * z0i ) &
+         *sqrt( 2.0 * PI * kphil * z0 ) &
+         *erfc( sqrt( 2.0 * kphil * z0 ) )
+    r3 = ( 0.0632 / kstar * z0i + 0.125 ) &
+         * (1.0 - exp(-2.0 * kstar * z0) )
+    r4 = ( 0.125 + 0.0946 / kstar * z0i ) &
+         *sqrt( 2.0 * PI *kstar * z0) &
+         *erfc( sqrt( 2.0 * kstar * z0 ) )
+    us_sl = us * (0.715 + r1 + r2 + r3 + r4)
+    !
+    LA = sqrt(ustar / us_sl)
+  else
+    LA=1.e8
+  endif
+endsubroutine Get_LA_windsea
 
 subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
   type(time_type), target, intent(in)    :: Time
@@ -1932,10 +2028,21 @@ subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
                  "in the boundary layer, applied when local stratification \n"//&
                  "is negative.  The default is 0, but should probably be ~1.", &
                  units="nondim", default=0.0)
-   call get_param(param_file, mod, "USE_LT_LI2016", CS%USE_LT_LiFunction, &
+   call get_param(param_file, mod, "USE_LA_LI2016", CS%USE_LA_Windsea, &
                  "A logical to use the Li et al. 2016 (submitted) formula to \n"//&
-                 " determine the enhancement of velocity due to Langmuir \n"//&
-                 " turbulence.", units="nondim", default=.false.)
+                 " determine the Langmuir number.",&
+                 units="nondim", default=.false.)
+   call get_param(param_file, mod, "LT_ENHANCE", CS%LT_ENHANCE_FORM, &
+                 "Integer for LT enhancement function mode. \n"//&
+                 " *Requires USE_LA_LI2016 to be set to True. \n"//&
+                 "Options: 0 - no LT enhancement \n"//&
+                 "         1 - Van Roekel et al. 2014/Li et al., 2016  \n"//&
+                 "         2 - New LES net mixing based derivation",&
+                 units="nondim", default=0)
+   if (CS%LT_ENHANCE_FORM.gt.0 .and. (.not.CS%USE_LA_Windsea)) then
+      call MOM_error(FATAL, "If flag USE_LA_LI2016 is false, then "//&
+                 " LT_ENHANCE must be 0.")
+  endif
   ! This gives a minimum decay scale that is typically much less than Angstrom.
   CS%ustar_min = 2e-4*CS%omega*(GV%Angstrom_z + GV%H_to_m*GV%H_subroundoff)
   call log_param(param_file, mod, "EPBL_USTAR_MIN", CS%ustar_min, &

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -1746,7 +1746,7 @@ end subroutine energetic_PBL_get_MLD
 !> Computes wind speed from ustar_air based on COARE 3.5 Cd relationship
 subroutine ust_2_u10_coare3p5(USTair,U10,GV)
   real, intent(in)  :: USTair
-  type(verticalGrid_type), intent(in) :: GV  
+  type(verticalGrid_type), intent(in) :: GV
   real, intent(out) :: U10
   real, parameter :: vonkar = 0.4
   real, parameter :: nu=1e-6
@@ -1807,7 +1807,7 @@ subroutine get_LA_windsea(ustar, hbl, GV, LA)
        ! boundary layer depth (m)
        hbl
   type(verticalGrid_type), intent(in) :: GV
-  real, intent(out) :: LA 
+  real, intent(out) :: LA
 ! Local variables
   ! parameters
   real, parameter :: &
@@ -1823,7 +1823,7 @@ subroutine get_LA_windsea(ustar, hbl, GV, LA)
   real :: us, hm0, fm, fp, vstokes, kphil, kstar
   real :: z0, z0i, r1, r2, r3, r4, tmp, us_sl, lasl_sqr_i
   real :: pi, u10
-  pi = 4.0*atan(1.0) 
+  pi = 4.0*atan(1.0)
   ! Computing u10 based on u_star and COARE 3.5 relationships
   call ust_2_u10_coare3p5(ustar*sqrt(GV%Rho0/1.225),U10,GV)
   if (u10 .gt. 0.0 .and. ustar .gt. 0.0) then


### PR DESCRIPTION
… to EPBL.

 - Moving Langmuir number function from CVMix into MOM6: this makes it easier to change enhancement function.  When CVMix function is modified to output Langmuir number we can undo this.
 - MOM6 Input logical USE_LT_LI2016 removed
 - MOM6 Input logical USE_LA_LI2016 added
 - MOM6 Input integer LT_ENHANCE added
 - Two options now available for enhancement (Set by LT_ENHANCE ), including previous version (LT_ENHANCE=1) and updated version (LT_ENHANCE=2).  Defaults to no enhancement (LT_ENHANCE=0)