### PR TITLE
Fixes TS tendencies being output to 0

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1273,7 +1273,7 @@ subroutine step_MOM(fluxes, state, Time_start, time_interval, CS)
       if (CS%id_uhtr > 0) call post_data(CS%id_uhtr, CS%uhtr, CS%diag)
       if (CS%id_vhtr > 0) call post_data(CS%id_vhtr, CS%vhtr, CS%diag)
 
-      call post_diags_TS_tendency(G,GV,CS,dtdia)
+      call post_diags_TS_tendency(G,GV,CS,CS%dt_trans)
 
       call disable_averaging(CS%diag)
 


### PR DESCRIPTION
All tendency diagnostics were being set to zero when (CS%diabatic_first .and. CS%dt_trans==0.0) because dtdia would never be set. In any case, the tendency terms should be calculated using the same timestep that the averaging interval uses (CS%dt_trans).