### PR TITLE
Adds the option to ignore fluxes applied over land

### DIFF
--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -960,7 +960,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
         fluxes%netMassIn(i,j) = 0.0
       endif
     enddo
- 
+
     ! Apply the surface boundary fluxes in three steps:
     ! A/ update mass, temp, and salinity due to all terms except mass leaving
     !    ocean (and corresponding outward heat content), and ignoring penetrative SW.
@@ -1108,7 +1108,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
 
       ! Check if trying to apply fluxes over land points
       elseif((abs(netHeat(i))+abs(netSalt(i))+abs(netMassIn(i))+abs(netMassOut(i)))>0.) then
-        
+
         if (.not. CS%ignore_fluxes_over_land) then
            call forcing_SinglePointPrint(fluxes,G,i,j,'applyBoundaryFluxesInOut (land)')
            write(0,*) 'applyBoundaryFluxesInOut(): lon,lat=',G%geoLonT(i,j),G%geoLatT(i,j)
@@ -1117,7 +1117,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
 
            call MOM_error(FATAL, "MOM_diabatic_driver.F90, applyBoundaryFluxesInOut(): "//&
                                  "Mass loss over land?")
-        endif   
+        endif
 
       endif
 
@@ -1141,7 +1141,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
     ! SW penetrative heating uses the updated thickness from above.
 
     ! Save temperature before increment with SW heating
-    ! and initialize CS%penSWflux_diag to zero.  
+    ! and initialize CS%penSWflux_diag to zero.
     if(CS%id_penSW_diag > 0 .or. CS%id_penSWflux_diag > 0) then
       do k=1,nz ; do i=is,ie
         CS%penSW_diag(i,j,k)     = T2d(i,k)
@@ -1173,25 +1173,25 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
     enddo ; enddo
 
     ! Diagnose heating (W/m2) applied to a grid cell from SW penetration
-    ! Also diagnose the penetrative SW heat flux at base of layer.  
+    ! Also diagnose the penetrative SW heat flux at base of layer.
     if(CS%id_penSW_diag > 0 .or. CS%id_penSWflux_diag > 0) then
 
-      ! convergence of SW into a layer 
+      ! convergence of SW into a layer
       do k=1,nz ; do i=is,ie
         CS%penSW_diag(i,j,k) = (T2d(i,k)-CS%penSW_diag(i,j,k))*h(i,j,k) * Idt * tv%C_p * GV%H_to_kg_m2
       enddo ; enddo
 
-      ! Perform a cumulative sum upwards from bottom to 
-      ! diagnose penetrative SW flux at base of tracer cell. 
-      ! CS%penSWflux_diag(i,j,k=1)    is penetrative shortwave at top of ocean.  
-      ! CS%penSWflux_diag(i,j,k=kbot+1) is zero, since assume no SW penetrates rock. 
+      ! Perform a cumulative sum upwards from bottom to
+      ! diagnose penetrative SW flux at base of tracer cell.
+      ! CS%penSWflux_diag(i,j,k=1)    is penetrative shortwave at top of ocean.
+      ! CS%penSWflux_diag(i,j,k=kbot+1) is zero, since assume no SW penetrates rock.
       ! CS%penSWflux_diag = rsdo  and CS%penSW_diag = rsdoabsorb
       ! rsdoabsorb(k) = rsdo(k) - rsdo(k+1), so that rsdo(k) = rsdo(k+1) + rsdoabsorb(k)
       if(CS%id_penSWflux_diag > 0) then
         do k=nz,1,-1 ; do i=is,ie
           CS%penSWflux_diag(i,j,k) = CS%penSW_diag(i,j,k) + CS%penSWflux_diag(i,j,k+1)
         enddo ; enddo
-      endif 
+      endif
 
     endif
 

--- a/src/tracer/MOM_tracer_diabatic.F90
+++ b/src/tracer/MOM_tracer_diabatic.F90
@@ -213,11 +213,11 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, &
 !       flux of the tracer does not get applied again during a subsequent call to tracer_vertdif
 
   type(ocean_grid_type),                 intent(in)    :: G  !< Grid structure
-  type(verticalGrid_type),               intent(in)    :: GV        !< ocean vertical grid structure  
+  type(verticalGrid_type),               intent(in)    :: GV        !< ocean vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: Tr  !< Tracer concentration on T-cell
-  real,                                  intent(in)    :: dt !< Time-step over which forcing is applied (s)  
+  real,                                  intent(in)    :: dt !< Time-step over which forcing is applied (s)
   type(forcing),                         intent(in) :: fluxes !< Surface fluxes container
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h  !< Layer thickness in H units 
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h  !< Layer thickness in H units
   real,                                       intent(in)  :: evap_CFL_limit
   real,                                       intent(in)  :: minimum_forcing_depth
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: in_flux_optional ! The total time-integrated amount of tracer!
@@ -256,13 +256,13 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, &
     do j=js,je ; do i=is,ie
       in_flux(i,j) = in_flux_optional(i,j)
     enddo; enddo
-  endif    
+  endif
   if(present(out_flux_optional)) then
-    do j=js,je ; do i=is,ie 
+    do j=js,je ; do i=is,ie
       out_flux(i,j) = out_flux_optional(i,j)
     enddo ; enddo
-  endif    
-  
+  endif
+
   Idt = 1.0/dt
   numberOfGroundings = 0
 
@@ -317,7 +317,7 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, &
 
           ! Update the forcing by the part to be consumed within the present k-layer.
           ! If fractionOfForcing = 1, then updated netMassIn, netHeat, and netSalt vanish.
-          netMassIn(i) = netMassIn(i) - dThickness          
+          netMassIn(i) = netMassIn(i) - dThickness
           dTracer = dTracer + in_flux_1d(i)
           in_flux_1d(i) = 0.0
 

--- a/src/tracer/MOM_tracer_diabatic.F90
+++ b/src/tracer/MOM_tracer_diabatic.F90
@@ -213,11 +213,11 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, &
 !       flux of the tracer does not get applied again during a subsequent call to tracer_vertdif
 
   type(ocean_grid_type),                 intent(in)    :: G  !< Grid structure
-  type(verticalGrid_type),               intent(in)    :: GV        !< ocean vertical grid structure
+  type(verticalGrid_type),               intent(in)    :: GV        !< ocean vertical grid structure  
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: Tr  !< Tracer concentration on T-cell
-  real,                                  intent(in)    :: dt !< Time-step over which forcing is applied (s)
+  real,                                  intent(in)    :: dt !< Time-step over which forcing is applied (s)  
   type(forcing),                         intent(in) :: fluxes !< Surface fluxes container
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h  !< Layer thickness in H units
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h  !< Layer thickness in H units 
   real,                                       intent(in)  :: evap_CFL_limit
   real,                                       intent(in)  :: minimum_forcing_depth
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: in_flux_optional ! The total time-integrated amount of tracer!
@@ -256,13 +256,13 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, &
     do j=js,je ; do i=is,ie
       in_flux(i,j) = in_flux_optional(i,j)
     enddo; enddo
-  endif
+  endif    
   if(present(out_flux_optional)) then
-    do j=js,je ; do i=is,ie
+    do j=js,je ; do i=is,ie 
       out_flux(i,j) = out_flux_optional(i,j)
     enddo ; enddo
-  endif
-
+  endif    
+  
   Idt = 1.0/dt
   numberOfGroundings = 0
 
@@ -317,7 +317,7 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, &
 
           ! Update the forcing by the part to be consumed within the present k-layer.
           ! If fractionOfForcing = 1, then updated netMassIn, netHeat, and netSalt vanish.
-          netMassIn(i) = netMassIn(i) - dThickness
+          netMassIn(i) = netMassIn(i) - dThickness          
           dTracer = dTracer + in_flux_1d(i)
           in_flux_1d(i) = 0.0
 
@@ -365,23 +365,10 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, &
           if (h2d(i,k) > 0.) then
             Ithickness  = 1.0/h2d(i,k) ! Inverse of new thickness
             Tr2d(i,k)    = (hOld*Tr2d(i,k) + dTracer)*Ithickness
-          elseif (h2d(i,k) < 0.0) then ! h2d==0 is a special limit that needs no extra handling
-            write(0,*) 'applyTracerBoundaryFluxesInOut(): lon,lat=',G%geoLonT(i,j),G%geoLatT(i,j)
-            write(0,*) 'applyTracerBoundaryFluxesInOut(): netTr,netH=',in_flux_1d(i)-out_flux_1d(i),netMassInOut(i)
-            write(0,*) 'applyTracerBoundaryFluxesInOut(): h(n),h(n+1),k=',hOld,h2d(i,k),k
-            call MOM_error(FATAL, "MOM_tracer_vertical.F90, applyTracerBoundaryFluxesInOut(): "//&
-                           "Complete mass loss in column!")
           endif
 
         enddo ! k
 
-      ! Check if trying to apply fluxes over land points
-      elseif((abs(in_flux_1d(i))+abs(out_flux_1d(i))+abs(netMassIn(i))+abs(netMassOut(i)))>0.) then
-        write(0,*) 'applyTracerBoundaryFluxesInOut(): lon,lat=',G%geoLonT(i,j),G%geoLatT(i,j)
-        write(0,*) 'applyTracerBoundaryFluxesInOut(): in_flux, out_flux, netMassIn,netMassOut=',&
-                   in_flux_1d(i), out_flux_1d(i),netMassIn(i),netMassOut(i)
-        call MOM_error(FATAL, "MOM_tracer_vertical.F90, applyTracerBoundaryFluxesInOut(): "//&
-                              "Mass loss over land?")
       endif
 
       ! If anything remains after the k-loop, then we have grounded out, which is a problem.


### PR DESCRIPTION
This commit adds the option to ignore if fluxes are being applied over land points (IGNORE_FLUXES_OVER_LAND = True, default is False). This flag must be true when the ALE algorithm is used and the ocean is coupled with ice shelves and sea ice, since the sea ice mask needs to be different than the ocean mask to avoid sea ice formation under ice shelves. This flag only works when use_ePBL = True.

This commit also removes two redundant checks (mass loss and fluxes over land) in MOM_tracer_diabatic.F90. These checks are already being performed in MOM_diabatic_aux.F90.