### PR TITLE
*remove out of bounds reference in visc mask for OBC

### DIFF
--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1671,25 +1671,21 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
       if (segment%direction == OBC_DIRECTION_E) then
         I=segment%HI%IscB
         do j=segment%HI%jsd,segment%HI%jed
-          CS%mask2dCv(i+1,J-1)=0.0
           CS%mask2dCv(i+1,J)=0.0
         enddo
       else if (segment%direction == OBC_DIRECTION_W) then
         I=segment%HI%IscB
         do j=segment%HI%jsd,segment%HI%jed
-          CS%mask2dCv(i,J-1)=0.0
           CS%mask2dCv(i,J)=0.0
         enddo
       else if (segment%direction == OBC_DIRECTION_N) then
         J=segment%HI%JscB
         do i=segment%HI%isd,segment%HI%ied
-          CS%mask2dCu(I-1,j+1)=0.0
           CS%mask2dCu(I,j+1)=0.0
         enddo
       else if (segment%direction == OBC_DIRECTION_S) then
         J=segment%HI%JscB
         do i=segment%HI%isd,segment%HI%ied
-          CS%mask2dCu(I-1,j)=0.0
           CS%mask2dCu(I,j)=0.0
         enddo
       endif


### PR DESCRIPTION
  -unpredictable answer changes due to writing outside of array bounds.