### PR TITLE
User/ksh/legacy

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2396,14 +2396,14 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
               (BT_OBC%Cg_u(I,j)/H_u) * (h_in-BT_OBC%eta_outer_u(I,j)))
 
           vel_trans = (1.0-bebt)*vel_prev + bebt*ubt(I,j)
-        elseif (OBC%segment(OBC%OBC_segment_u(I,j))%radiation) then
+        elseif (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
           grad(I,J) = (ubt_old(I,j+1) - ubt_old(I,j)) * G%mask2dBu(I,J)
           grad(I,J-1) = (ubt_old(I,j) - ubt_old(I,j-1)) * G%mask2dBu(I,J-1)
           grad(I-1,J) = (ubt_old(I-1,j+1) - ubt_old(I-1,j)) * G%mask2dBu(I-1,J)
           grad(I-1,J-1) = (ubt_old(I-1,j) - ubt_old(I-1,j-1)) * G%mask2dBu(I-1,J-1)
           dhdt = ubt_old(I-1,j)-ubt(I-1,j) !old-new
           dhdx = ubt(I-1,j)-ubt(I-2,j) !in new time backward sasha for I-1
-          if (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
+!         if (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
             if (dhdt*(grad(I-1,J) + grad(I-1,J-1)) > 0.0) then
               dhdy = grad(I-1,J-1)
             elseif (dhdt*(grad(I-1,J) + grad(I-1,J-1)) == 0.0) then
@@ -2411,17 +2411,17 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
             else
               dhdy = grad(I-1,J)
             endif
-          endif
+!         endif
           if (dhdt*dhdx < 0.0) dhdt = 0.0
           if (dhdx == 0.0) dhdx=eps  ! avoid segv
           Cx = min(dhdt/dhdx,rx_max) ! default to normal flow only
-          Cy = 0
+!         Cy = 0
           cff = max(dhdx*dhdx, eps)
-          if (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
+!         if (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
             cff = max(dhdx*dhdx + dhdy*dhdy, eps)
             if (dhdy==0.) dhdy=eps ! avoid segv
             Cy = min(cff, max(dhdt/dhdy, -cff))
-          endif
+!         endif
           ubt(I,j) = ((cff*ubt_old(I,j) + Cx*ubt(I-1,j)) - &
               (max(Cy,0.0)*grad(I,J-1) + min(Cy,0.0)*grad(I,J))) / (cff + Cx)
           vel_trans = ubt(I,j)
@@ -2442,14 +2442,14 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
               (BT_OBC%Cg_u(I,j)/H_u) * (BT_OBC%eta_outer_u(I,j)-h_in))
 
           vel_trans = (1.0-bebt)*vel_prev + bebt*ubt(I,j)
-        elseif (OBC%segment(OBC%OBC_segment_u(I,j))%radiation) then
+        elseif (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
           grad(I,J) = (ubt_old(I,j+1) - ubt_old(I,j)) * G%mask2dBu(I,J)
           grad(I,J-1) = (ubt_old(I,j) - ubt_old(I,j-1)) * G%mask2dBu(I,J-1)
           grad(I+1,J) = (ubt_old(I+1,j+1) - ubt_old(I+1,j)) * G%mask2dBu(I+1,J)
           grad(I+1,J-1) = (ubt_old(I+1,j) - ubt_old(I+1,j-1)) * G%mask2dBu(I+1,J-1)
           dhdt = ubt_old(I+1,j)-ubt(I+1,j) !old-new
           dhdx = ubt(I+1,j)-ubt(I+2,j) !in new time backward sasha for I+1
-          if (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
+!         if (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
             if (dhdt*(grad(I+1,J) + grad(I+1,J-1)) > 0.0) then
               dhdy = grad(I+1,J-1)
             elseif (dhdt*(grad(I+1,J) + grad(I+1,J-1)) == 0.0) then
@@ -2457,17 +2457,17 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
             else
               dhdy = grad(I+1,J)
             endif
-          endif
+!         endif
           if (dhdt*dhdx < 0.0) dhdt = 0.0
           if (dhdx == 0.0) dhdx=eps  ! avoid segv
           Cx = min(dhdt/dhdx,rx_max) ! default to normal flow only
-          Cy = 0
+!         Cy = 0
           cff = max(dhdx*dhdx, eps)
-          if (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
+!         if (OBC%segment(OBC%OBC_segment_u(I,j))%oblique) then
             cff = max(dhdx*dhdx + dhdy*dhdy, eps)
             if (dhdy==0.) dhdy=eps ! avoid segv
             Cy = min(cff,max(dhdt/dhdy,-cff))
-          endif
+!         endif
           ubt(I,j) = ((cff*ubt_old(I,j) + Cx*ubt(I+1,j)) - &
               (max(Cy,0.0)*grad(I,J-1) + min(Cy,0.0)*grad(I,J))) / (cff + Cx)
 !         vel_trans = (1.0-bebt)*vel_prev + bebt*ubt(I,j)
@@ -2509,14 +2509,14 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
               (BT_OBC%Cg_v(i,J)/H_v) * (h_in-BT_OBC%eta_outer_v(i,J)))
 
           vel_trans = (1.0-bebt)*vel_prev + bebt*vbt(i,J)
-        elseif (OBC%segment(OBC%OBC_segment_v(i,J))%radiation) then
+        elseif (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
           grad(I,J) = (vbt_old(i+1,J) - vbt_old(i,J)) * G%mask2dBu(I,J)
           grad(I-1,J) = (vbt_old(i,J) - vbt_old(i-1,J)) * G%mask2dBu(I-1,J)
           grad(I,J-1) = (vbt_old(i+1,J-1) - vbt_old(i,J-1)) * G%mask2dBu(I,J-1)
           grad(I-1,J-1) = (vbt_old(i,J-1) - vbt_old(i-1,J-1)) * G%mask2dBu(I-1,J-1)
           dhdt = vbt_old(i,J-1)-vbt(i,J-1) !old-new
           dhdy = vbt(i,J-1)-vbt(i,J-2) !in new time backward sasha for J-1
-          if (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
+!         if (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
             if (dhdt*(grad(I,J-1) + grad(I-1,J-1)) > 0.0) then
               dhdx = grad(I-1,J-1)
             elseif (dhdt*(grad(I,J-1) + grad(I-1,J-1)) == 0.0) then
@@ -2524,17 +2524,17 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
             else
               dhdx = grad(I,J-1)
             endif
-          endif
+!         endif
           if (dhdt*dhdy < 0.0) dhdt = 0.0
           if (dhdy == 0.0) dhdy=eps  ! avoid segv
           Cy = min(dhdt/dhdy,rx_max) ! default to normal flow only
-          Cx = 0
+!         Cx = 0
           cff = max(dhdy*dhdy, eps)
-          if (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
+!         if (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
             cff = max(dhdx*dhdx + dhdy*dhdy, eps)
             if (dhdx==0.) dhdx=eps ! avoid segv
             Cx = min(cff,max(dhdt/dhdx,-cff))
-          endif
+!         endif
           vbt(i,J) = ((cff*vbt_old(i,J) + Cy*vbt(i,J-1)) - &
             (max(Cx,0.0)*grad(I-1,J) + min(Cx,0.0)*grad(I,J))) / (cff + Cy)
 !         vel_trans = (1.0-bebt)*vel_prev + bebt*vbt(i,J)
@@ -2556,14 +2556,14 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
               (BT_OBC%Cg_v(i,J)/H_v) * (BT_OBC%eta_outer_v(i,J)-h_in))
 
           vel_trans = (1.0-bebt)*vel_prev + bebt*vbt(i,J)
-        elseif (OBC%segment(OBC%OBC_segment_v(i,J))%radiation) then
+        elseif (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
           grad(I,J) = (vbt_old(i+1,J) - vbt_old(i,J)) * G%mask2dBu(I,J)
           grad(I-1,J) = (vbt_old(i,J) - vbt_old(i-1,J)) * G%mask2dBu(I-1,J)
           grad(I,J+1) = (vbt_old(i+1,J+1) - vbt_old(i,J+1)) * G%mask2dBu(I,J+1)
           grad(I-1,J+1) = (vbt_old(i,J+1) - vbt_old(i-1,J+1)) * G%mask2dBu(I-1,J+1)
           dhdt = vbt_old(i,J+1)-vbt(i,J+1) !old-new
           dhdy = vbt(i,J+1)-vbt(i,J+2) !in new time backward sasha for J+1
-          if (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
+!         if (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
             if (dhdt*(grad(I,J+1) + grad(I-1,J+1)) > 0.0) then
               dhdx = grad(I-1,J+1)
             elseif (dhdt*(grad(I,J+1) + grad(I-1,J+1)) == 0.0) then
@@ -2571,17 +2571,17 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
             else
               dhdx = grad(I,J+1)
             endif
-          endif
+!         endif
           if (dhdt*dhdy < 0.0) dhdt = 0.0
           if (dhdy == 0.0) dhdy=eps  ! avoid segv
           Cy = min(dhdt/dhdy,rx_max) ! default to normal flow only
-          Cx = 0
+!         Cx = 0
           cff = max(dhdy*dhdy, eps)
-          if (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
+!         if (OBC%segment(OBC%OBC_segment_v(i,J))%oblique) then
             cff = max(dhdx*dhdx + dhdy*dhdy, eps)
             if (dhdx==0.) dhdx=eps ! avoid segv
             Cx = min(cff,max(dhdt/dhdx,-cff))
-          endif
+!         endif
           vbt(i,J) = ((cff*vbt_old(i,J) + Cy*vbt(i,J+1)) - &
             (max(Cx,0.0)*grad(I-1,J) + min(Cx,0.0)*grad(I,J))) / (cff + Cy)
 !         vel_trans = (1.0-bebt)*vel_prev + bebt*vbt(i,J)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -1000,7 +1000,6 @@ subroutine open_boundary_impose_normal_slope(OBC, G, depth)
   real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: depth !< Bathymetry at h-points
   ! Local variables
   integer :: i, j, n
-  logical :: bc_north, bc_south, bc_east, bc_west
   type(OBC_segment_type), pointer :: segment
 
   if (.not.associated(OBC)) return
@@ -1034,31 +1033,6 @@ subroutine open_boundary_impose_normal_slope(OBC, G, depth)
     endif
   enddo
 
-! do J=G%jsd+1,G%jed-1 ; do i=G%isd+1,G%ied-1
-!   bc_north = .false. ; bc_south = .false. ; bc_east = .false. ; bc_west = .false.
-!   if (associated(OBC%OBC_segment_u)) then
-!     if (OBC%segment(OBC%OBC_segment_u(I,j))%direction == OBC_DIRECTION_E &
-!         .and. .not. OBC%segment(OBC%OBC_segment_u(I,j))%specified) bc_east = .true.
-!     if (OBC%segment(OBC%OBC_segment_u(I-1,j))%direction == OBC_DIRECTION_W &
-!         .and. .not. OBC%segment(OBC%OBC_segment_u(I-1,j))%specified) bc_west = .true.
-!   endif
-!   if (associated(OBC%OBC_segment_v)) then
-!     if (OBC%segment(OBC%OBC_segment_v(i,J))%direction == OBC_DIRECTION_N &
-!         .and. .not. OBC%segment(OBC%OBC_segment_v(i,J))%specified) bc_north = .true.
-!     if (OBC%segment(OBC%OBC_segment_v(i,J-1))%direction == OBC_DIRECTION_S &
-!         .and. .not. OBC%segment(OBC%OBC_segment_v(i,J-1))%specified) bc_south = .true.
-!   endif
-!   if (bc_north) depth(i,j+1) = depth(i,j)
-!   if (bc_south) depth(i,j-1) = depth(i,j)
-!   if (bc_east) depth(i+1,j) = depth(i,j)
-!   if (bc_west) depth(i-1,j) = depth(i,j)
-    ! Convex corner cases
-!   if (bc_north.and.bc_east) depth(i+1,j+1) = depth(i,j)
-!   if (bc_north.and.bc_west) depth(i-1,j+1) = depth(i,j)
-!   if (bc_south.and.bc_east) depth(i+1,j-1) = depth(i,j)
-!   if (bc_south.and.bc_west) depth(i-1,j-1) = depth(i,j)
-! enddo ; enddo
-
 end subroutine open_boundary_impose_normal_slope
 
 !> Reconcile masks and open boundaries, deallocate OBC on PEs where it is not needed.
@@ -1069,74 +1043,68 @@ subroutine open_boundary_impose_land_mask(OBC, G, areaCu, areaCv)
   real, dimension(SZIB_(G),SZJ_(G)), intent(inout) :: areaCu !< Area of a u-cell (m2)
   real, dimension(SZI_(G),SZJB_(G)), intent(inout) :: areaCv !< Area of a u-cell (m2)
   ! Local variables
-  integer :: i, j
+  integer :: i, j, n
+  type(OBC_segment_type), pointer :: segment
   logical :: any_U, any_V
 
   if (.not.associated(OBC)) return
 
-  ! Sweep along u-segments and delete the OBC for blocked points.
-  if (associated(OBC%OBC_segment_u)) then
-    do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB
-      if (G%mask2dCu(I,j) == 0 .and. (OBC%OBC_segment_u(I,j) /= OBC_NONE)) then
-        if (.not. OBC%segment(OBC%OBC_segment_u(I,j))%specified) then
-          OBC%OBC_segment_u(I,j) = OBC_NONE
-        endif
-      endif
-    enddo ; enddo
-  endif
+  do n=1,OBC%number_of_segments
+    segment=>OBC%segment(n)
+    if (.not. segment%on_pe .or. segment%specified) cycle
+    if (segment%is_E_or_W) then
+      ! Sweep along u-segments and delete the OBC for blocked points.
+      I=segment%HI%IsdB
+      do j=segment%HI%jsd,segment%HI%jed
+        if (G%mask2dCu(I,j) == 0) OBC%OBC_segment_u(I,j) = OBC_NONE
+      enddo
+    else
+      ! Sweep along v-segments and delete the OBC for blocked points.
+      J=segment%HI%JsdB
+      do i=segment%HI%isd,segment%HI%ied
+        if (G%mask2dCv(i,J) == 0) OBC%OBC_segment_v(i,J) = OBC_NONE
+      enddo
+    endif
+  enddo
 
-  ! Sweep along v-segments and delete the OBC for blocked points.
-  if (associated(OBC%OBC_segment_v)) then
-    do J=G%JsdB,G%JedB ; do i=G%isd,G%ied
-      if (G%mask2dCv(i,J) == 0 .and. (OBC%OBC_segment_v(i,J) /= OBC_NONE)) then
-        if (.not. OBC%segment(OBC%OBC_segment_v(i,J))%specified) then
-          OBC%OBC_segment_v(I,j) = OBC_NONE
-        endif
-      endif
-    enddo ; enddo
-  endif
+  do n=1,OBC%number_of_segments
+    segment=>OBC%segment(n)
+    if (.not. segment%on_pe .or. .not. segment%specified) cycle
+    if (segment%is_E_or_W) then
+      ! Sweep along u-segments and for %specified BC points reset the u-point area which was masked out
+      I=segment%HI%IsdB
+      do j=segment%HI%jsd,segment%HI%jed
+        if (segment%direction == OBC_DIRECTION_E) then
+          areaCu(I,j) = G%areaT(i,j)
+         !G%IareaCu(I,j) = G%IareaT(i,j) ?
+	else   ! West
+          areaCu(I,j) = G%areaT(i+1,j)
+         !G%IareaCu(I,j) = G%IareaT(i+1,j) ?
+	endif
+      enddo
+    else
+      ! Sweep along v-segments and for %specified BC points reset the v-point area which was masked out
+      J=segment%HI%JsdB
+      do i=segment%HI%isd,segment%HI%ied
+        if (segment%direction == OBC_DIRECTION_S) then
+          areaCv(i,J) = G%areaT(i,j+1)
+         !G%IareaCv(i,J) = G%IareaT(i,j+1) ?
+        else      ! North
+          areaCu(i,J) = G%areaT(i,j)
+         !G%IareaCu(i,J) = G%IareaT(i,j) ?
+	endif
+      enddo
+    endif
+  enddo
 
-  ! Sweep along u-segments and for %specified BC points reset the u-point area which was masked out
-  if (associated(OBC%OBC_segment_u)) then
-    do j=G%jsd,G%jed ; do I=G%isd,G%ied-1
-      if (OBC%OBC_segment_u(I,j) /= OBC_NONE) then
-        if (OBC%segment(OBC%OBC_segment_u(I,j))%specified) then
-          if (OBC%segment(OBC%OBC_segment_u(I,j))%direction == OBC_DIRECTION_W) then
-            areaCu(I,j) = G%areaT(i+1,j)
-           !G%IareaCu(I,j) = G%IareaT(i+1,j) ?
-          elseif (OBC%segment(OBC%OBC_segment_u(I,j))%direction == OBC_DIRECTION_E) then
-            areaCu(I,j) = G%areaT(i,j)
-           !G%IareaCu(I,j) = G%IareaT(i,j) ?
-          endif
-        endif
-      endif
-    enddo ; enddo
-  endif
-
-  ! Sweep along v-segments and for %specified BC points reset the v-point area which was masked out
-  if (associated(OBC%OBC_segment_v)) then
-    do J=G%jsd,G%jed-1 ; do i=G%isd,G%ied
-      if (OBC%OBC_segment_v(i,J) /= OBC_NONE) then
-        if (OBC%segment(OBC%OBC_segment_v(i,J))%specified) then
-          if (OBC%segment(OBC%OBC_segment_v(i,J))%direction == OBC_DIRECTION_S) then
-            areaCv(i,J) = G%areaT(i,j+1)
-           !G%IareaCv(i,J) = G%IareaT(i,j+1) ?
-          elseif (OBC%segment(OBC%OBC_segment_v(i,J))%direction == OBC_DIRECTION_N) then
-            areaCu(i,J) = G%areaT(i,j)
-           !G%IareaCu(i,J) = G%IareaT(i,j) ?
-          endif
-        endif
-      endif
-    enddo ; enddo
-  endif
-
+  !! Clean this up too?
   any_U = .false.
   if (associated(OBC%OBC_segment_u)) then
     do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB
       ! G%mask2du will be open wherever bathymetry allows it.
       ! Bathymetry outside of the open boundary was adjusted to match
       ! the bathymetry inside so these points will be open unless the
-      ! bathymetry inside the boundary was do shallow and flagged as land.
+      ! bathymetry inside the boundary was too shallow and flagged as land.
       if (OBC%OBC_segment_u(I,j) /= OBC_NONE) any_U = .true.
     enddo ; enddo
   endif

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -88,10 +88,6 @@ type, public :: OBC_segment_type
   real, pointer, dimension(:,:)   :: Htot=>NULL()   !< The total column thickness (m) at OBC-points.
   real, pointer, dimension(:,:,:) :: h=>NULL()      !< The cell thickness (m) at OBC-points.
   real, pointer, dimension(:,:,:) :: e=>NULL()      !< The interface height (m?) at OBC-points.
-  real, pointer, dimension(:,:,:) :: tangent_vel=>NULL()    !< The layer velocity tangential to the
-                                                            !! OB segment (m s-1).
-  real, pointer, dimension(:,:)   :: tangent_vel_bt=>NULL() !< The barotropic velocity tangential
-                                                            !! to the OB segment (m s-1).
   real, pointer, dimension(:,:,:) :: normal_vel=>NULL()     !< The layer velocity normal to the OB
                                                             !! segment (m s-1).
   real, pointer, dimension(:,:,:) :: normal_trans=>NULL()   !< The layer transport normal to the OB
@@ -1820,43 +1816,43 @@ subroutine allocate_OBC_segment_data(OBC, segment)
     allocate(segment%Htot(IsdB:IedB,jsd:jed));                  segment%Htot(:,:)=0.0
     allocate(segment%h(IsdB:IedB,jsd:jed,OBC%ke));              segment%h(:,:,:)=0.0
     if (segment%Flather) then
-!     allocate(segment%e(IsdB:IedB,jsd:jed,OBC%ke));              segment%e(:,:,:)=0.0
-      allocate(segment%eta(IsdB:IedB,jsd:jed));                   segment%eta(:,:)=0.0
-      allocate(segment%rx_normal(IsdB:IedB,jsd:jed,OBC%ke));      segment%rx_normal(:,:,:)=0.0
-!     allocate(segment%normal_trans_bt(IsdB:IedB,jsd:jed));       segment%normal_trans_bt(:,:)=0.0
+      allocate(segment%eta(IsdB:IedB,jsd:jed));                 segment%eta(:,:)=0.0
+    endif
+    if (segment%radiation) then
+      allocate(segment%rx_normal(IsdB:IedB,jsd:jed,OBC%ke));    segment%rx_normal(:,:,:)=0.0
+!     allocate(segment%e(IsdB:IedB,jsd:jed,OBC%ke));            segment%e(:,:,:)=0.0
+!     allocate(segment%normal_trans_bt(IsdB:IedB,jsd:jed));     segment%normal_trans_bt(:,:)=0.0
     endif
     if (segment%Flather .or. segment%specified) then
-      allocate(segment%normal_vel_bt(IsdB:IedB,jsd:jed));         segment%normal_vel_bt(:,:)=0.0
+      allocate(segment%normal_vel_bt(IsdB:IedB,jsd:jed));       segment%normal_vel_bt(:,:)=0.0
     endif
     if (segment%nudged .or. segment%specified) then
-      allocate(segment%normal_vel(IsdB:IedB,jsd:jed,OBC%ke));     segment%normal_vel(:,:,:)=0.0
+      allocate(segment%normal_vel(IsdB:IedB,jsd:jed,OBC%ke));   segment%normal_vel(:,:,:)=0.0
     endif
     if (segment%specified) then
-      allocate(segment%normal_trans(IsdB:IedB,jsd:jed,OBC%ke));   segment%normal_trans(:,:,:)=0.0
+      allocate(segment%normal_trans(IsdB:IedB,jsd:jed,OBC%ke)); segment%normal_trans(:,:,:)=0.0
     endif
-!   allocate(segment%tangent_vel(IsdB:IedB,JsdB:JedB,OBC%ke));  segment%tangent_vel(:,:,:)=0.0
-!   allocate(segment%tangent_vel_bt(IsdB:IedB,JsdB:JedB));      segment%tangent_vel_bt(:,:)=0.0
   else
     allocate(segment%Cg(isd:ied,JsdB:JedB));                    segment%Cg(:,:)=0.
     allocate(segment%Htot(isd:ied,JsdB:JedB));                  segment%Htot(:,:)=0.0
     allocate(segment%h(isd:ied,JsdB:JedB,OBC%ke));              segment%h(:,:,:)=0.0
     if (segment%Flather) then
-!     allocate(segment%e(isd:ied,JsdB:JedB,OBC%ke));              segment%e(:,:,:)=0.0
-      allocate(segment%eta(isd:ied,JsdB:JedB));                   segment%eta(:,:)=0.0
-      allocate(segment%rx_normal(isd:ied,JsdB:JedB,OBC%ke));      segment%rx_normal(:,:,:)=0.0
-!     allocate(segment%normal_trans_bt(isd:ied,JsdB:JedB));       segment%normal_trans_bt(:,:)=0.0
+      allocate(segment%eta(isd:ied,JsdB:JedB));                 segment%eta(:,:)=0.0
+    endif
+    if (segment%radiation) then
+      allocate(segment%rx_normal(isd:ied,JsdB:JedB,OBC%ke));    segment%rx_normal(:,:,:)=0.0
+!     allocate(segment%e(isd:ied,JsdB:JedB,OBC%ke));            segment%e(:,:,:)=0.0
+!     allocate(segment%normal_trans_bt(isd:ied,JsdB:JedB));     segment%normal_trans_bt(:,:)=0.0
     endif
     if (segment%Flather .or. segment%specified) then
-      allocate(segment%normal_vel_bt(isd:ied,JsdB:JedB));         segment%normal_vel_bt(:,:)=0.0
+      allocate(segment%normal_vel_bt(isd:ied,JsdB:JedB));       segment%normal_vel_bt(:,:)=0.0
     endif
     if (segment%nudged .or. segment%specified) then
-      allocate(segment%normal_vel(isd:ied,JsdB:JedB,OBC%ke));     segment%normal_vel(:,:,:)=0.0
+      allocate(segment%normal_vel(isd:ied,JsdB:JedB,OBC%ke));   segment%normal_vel(:,:,:)=0.0
     endif
     if (segment%specified) then
-      allocate(segment%normal_trans(isd:ied,JsdB:JedB,OBC%ke));   segment%normal_trans(:,:,:)=0.0
+      allocate(segment%normal_trans(isd:ied,JsdB:JedB,OBC%ke)); segment%normal_trans(:,:,:)=0.0
     endif
-!   allocate(segment%tangent_vel(IsdB:IedB,JsdB:JedB,OBC%ke));  segment%tangent_vel(:,:,:)=0.0
-!   allocate(segment%tangent_vel_bt(IsdB:IedB,JsdB:JedB));      segment%tangent_vel_bt(:,:)=0.0
   endif
 end subroutine allocate_OBC_segment_data
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -70,7 +70,6 @@ type, public :: OBC_segment_type
   logical :: specified      !< Boundary fixed to external value.
   logical :: gradient       !< Zero gradient at boundary.
   logical :: values_needed  !< Whether or not external OBC fields are needed.
-  logical :: legacy         !< Old code for tangential BT velocities.
   integer :: direction      !< Boundary faces one of the four directions.
   logical :: is_N_or_S      !< True is the OB is facing North or South and exists on this PE.
   logical :: is_E_or_W      !< True is the OB is facing East or West and exists on this PE.
@@ -273,7 +272,6 @@ subroutine open_boundary_config(G, param_file, OBC)
       OBC%segment(l)%specified = .false.
       OBC%segment(l)%gradient = .false.
       OBC%segment(l)%values_needed = .false.
-      OBC%segment(l)%legacy = .false.
       OBC%segment(l)%direction = OBC_NONE
       OBC%segment(l)%is_N_or_S = .false.
       OBC%segment(l)%is_E_or_W = .false.
@@ -581,7 +579,6 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg)
       OBC%segment(l_seg)%radiation = .true.
       OBC%open_u_BCs_exist_globally = .true.
     elseif (trim(action_str(a_loop)) == 'OBLIQUE') then
-      OBC%segment(l_seg)%radiation = .true.
       OBC%segment(l_seg)%oblique = .true.
       OBC%oblique_BCs_exist_globally = .true.
       OBC%open_u_BCs_exist_globally = .true.
@@ -595,7 +592,6 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg)
       OBC%open_u_BCs_exist_globally = .true.
     elseif (trim(action_str(a_loop)) == 'LEGACY') then
       this_kind = OBC_FLATHER
-      OBC%segment(l_seg)%legacy = .true.
       OBC%segment(l_seg)%Flather = .true.
       OBC%segment(l_seg)%radiation = .true.
       OBC%Flather_u_BCs_exist_globally = .true.
@@ -685,7 +681,6 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg)
       OBC%segment(l_seg)%radiation = .true.
       OBC%open_v_BCs_exist_globally = .true.
     elseif (trim(action_str(a_loop)) == 'OBLIQUE') then
-      OBC%segment(l_seg)%radiation = .true.
       OBC%segment(l_seg)%oblique = .true.
       OBC%oblique_BCs_exist_globally = .true.
       OBC%open_v_BCs_exist_globally = .true.
@@ -699,7 +694,6 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg)
       OBC%open_v_BCs_exist_globally = .true.
     elseif (trim(action_str(a_loop)) == 'LEGACY') then
       this_kind = OBC_FLATHER
-      OBC%segment(l_seg)%legacy = .true.
       OBC%segment(l_seg)%radiation = .true.
       OBC%segment(l_seg)%Flather = .true.
       OBC%Flather_v_BCs_exist_globally = .true.
@@ -1157,11 +1151,11 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
   do n=1,OBC%number_of_segments
      segment=>OBC%segment(n)
      if (.not. segment%on_pe) cycle
-     if (segment%radiation) call gradient_at_q_points(G,segment,u_old,v_old)
+     if (segment%oblique) call gradient_at_q_points(G,segment,u_old,v_old)
      if (segment%direction == OBC_DIRECTION_E) then
        I=segment%HI%IscB
        do k=1,nz ;  do j=segment%HI%jsc,segment%HI%jec
-         if (segment%legacy) then
+         if (segment%radiation) then
            dhdt = u_old(I-1,j,k)-u_new(I-1,j,k) !old-new
            dhdx = u_new(I-1,j,k)-u_new(I-2,j,k) !in new time backward sasha for I-1
            rx_new = 0.0
@@ -1169,10 +1163,10 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
            rx_avg = (1.0-gamma_u)*segment%rx_normal(I,j,k) + gamma_u*rx_new
            segment%rx_normal(I,j,k) = rx_avg
            u_new(I,j,k) = (u_old(I,j,k) + rx_avg*u_new(I-1,j,k)) / (1.0+rx_avg)
-         elseif (segment%radiation) then
+         elseif (segment%oblique) then
            dhdt = u_old(I-1,j,k)-u_new(I-1,j,k) !old-new
            dhdx = u_new(I-1,j,k)-u_new(I-2,j,k) !in new time backward sasha for I-1
-           if (segment%oblique) then
+!          if (segment%oblique) then
              if (dhdt*(segment%grad_normal(J,1,k) + segment%grad_normal(J-1,1,k)) > 0.0) then
                dhdy = segment%grad_normal(J-1,1,k)
              elseif (dhdt*(segment%grad_normal(J,1,k) + segment%grad_normal(J-1,1,k)) == 0.0) then
@@ -1180,28 +1174,27 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
              else
                dhdy = segment%grad_normal(J,1,k)
              endif
-           endif
+!          endif
            if (dhdt*dhdx < 0.0) dhdt = 0.0
            if (dhdx == 0.0) dhdx=eps  ! avoid segv
            Cx = min(dhdt/dhdx,rx_max) ! default to normal radiation
-           Cy = 0.0
+!          Cy = 0.0
            cff = max(dhdx*dhdx,eps)
-           if (segment%oblique) then
+!          if (segment%oblique) then
              cff = max(dhdx*dhdx + dhdy*dhdy, eps)
              if (dhdy==0.) dhdy=eps ! avoid segv
              Cy = min(cff,max(dhdt/dhdy,-cff))
-           endif
+!          endif
            u_new(I,j,k) = ((cff*u_old(I,j,k) + Cx*u_new(I-1,j,k)) - &
               (max(Cy,0.0)*segment%grad_normal(J-1,2,k) + min(Cy,0.0)*segment%grad_normal(J,2,k))) / (cff + Cx)
          endif
-         if ((segment%radiation .or. segment%legacy) .and. segment%nudged) then
+         if ((segment%radiation .or. segment%oblique) .and. segment%nudged) then
            if (dhdt*dhdx < 0.0) then
              tau = segment%Tnudge_in
            else
              tau = segment%Tnudge_out
            endif
            u_new(I,j,k) = u_new(I,j,k) + dt*tau*(segment%normal_vel(I,j,k) - u_old(I,j,k))
-!          u_new(I,j,k) = u_new(I,j,k) + dt*tau*(OBC%u(I,j,k) - u_old(I,j,k))
          endif
        enddo; enddo
      endif
@@ -1209,7 +1202,7 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
      if (segment%direction == OBC_DIRECTION_W) then
        I=segment%HI%IscB
        do k=1,nz ;  do j=segment%HI%jsc,segment%HI%jec
-         if (segment%legacy) then
+         if (segment%radiation) then
            dhdt = u_old(I+1,j,k)-u_new(I+1,j,k) !old-new
            dhdx = u_new(I+1,j,k)-u_new(I+2,j,k) !in new time forward sasha for I+1
            rx_new = 0.0
@@ -1217,10 +1210,10 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
            rx_avg = (1.0-gamma_u)*segment%rx_normal(I,j,k) + gamma_u*rx_new
            segment%rx_normal(I,j,k) = rx_avg
            u_new(I,j,k) = (u_old(I,j,k) + rx_avg*u_new(I+1,j,k)) / (1.0+rx_avg)
-         elseif (segment%radiation) then
+         elseif (segment%oblique) then
            dhdt = u_old(I+1,j,k)-u_new(I+1,j,k) !old-new
            dhdx = u_new(I+1,j,k)-u_new(I+2,j,k) !in new time forward sasha for I+1
-           if (segment%oblique) then
+!          if (segment%oblique) then
              if (dhdt*(segment%grad_normal(J,1,k) + segment%grad_normal(J-1,1,k)) > 0.0) then
                dhdy = segment%grad_normal(J-1,1,k)
              elseif (dhdt*(segment%grad_normal(J,1,k) + segment%grad_normal(J-1,1,k)) == 0.0) then
@@ -1228,28 +1221,27 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
              else
                dhdy = segment%grad_normal(J,1,k)
              endif
-           endif
+!          endif
            if (dhdt*dhdx < 0.0) dhdt = 0.0
            if (dhdx == 0.0) dhdx=eps  ! avoid segv
            Cx = min(dhdt/dhdx,rx_max) ! default to normal flow only
-           Cy = 0.
+!          Cy = 0.
            cff = max(dhdx*dhdx, eps)
-           if (segment%oblique) then
+!          if (segment%oblique) then
              cff = max(dhdx*dhdx + dhdy*dhdy, eps)
              if (dhdy==0.) dhdy=eps ! avoid segv
              Cy = min(cff,max(dhdt/dhdy,-cff))
-           endif
+!          endif
            u_new(I,j,k) = ((cff*u_old(I,j,k) + Cx*u_new(I+1,j,k)) - &
              (max(Cy,0.0)*segment%grad_normal(J-1,2,k) + min(Cy,0.0)*segment%grad_normal(J,2,k))) / (cff + Cx)
          endif
-         if ((segment%radiation .or. segment%legacy) .and. segment%nudged) then
+         if ((segment%radiation .or. segment%oblique) .and. segment%nudged) then
            if (dhdt*dhdx < 0.0) then
              tau = segment%Tnudge_in
            else
              tau = segment%Tnudge_out
            endif
            u_new(I,j,k) = u_new(I,j,k) + dt*tau*(segment%normal_vel(I,j,k) - u_old(I,j,k))
-!          u_new(I,j,k) = u_new(I,j,k) + dt*tau*(OBC%u(I,j,k) - u_old(I,j,k))
          endif
        enddo; enddo
      endif
@@ -1257,7 +1249,7 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
      if (segment%direction == OBC_DIRECTION_N) then
        J=segment%HI%JscB
        do k=1,nz ;  do i=segment%HI%isc,segment%HI%iec
-         if (segment%legacy) then
+         if (segment%radiation) then
            dhdt = v_old(i,J-1,k)-v_new(i,J-1,k) !old-new
            dhdy = v_new(i,J-1,k)-v_new(i,J-2,k) !in new time backward sasha for J-1
            ry_new = 0.0
@@ -1265,10 +1257,10 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
            ry_avg = (1.0-gamma_v)*segment%rx_normal(I,j,k) + gamma_v*ry_new
            segment%rx_normal(i,J,k) = ry_avg
            v_new(i,J,k) = (v_old(i,J,k) + ry_avg*v_new(i,J-1,k)) / (1.0+ry_avg)
-         elseif (segment%radiation) then
+         elseif (segment%oblique) then
            dhdt = v_old(i,J-1,k)-v_new(i,J-1,k) !old-new
            dhdy = v_new(i,J-1,k)-v_new(i,J-2,k) !in new time backward sasha for J-1
-           if (segment%oblique) then
+!          if (segment%oblique) then
              if (dhdt*(segment%grad_normal(I,1,k) + segment%grad_normal(I-1,1,k)) > 0.0) then
                dhdx = segment%grad_normal(I-1,1,k)
              elseif (dhdt*(segment%grad_normal(I,1,k) + segment%grad_normal(I-1,1,k)) == 0.0) then
@@ -1276,28 +1268,27 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
              else
                dhdx = segment%grad_normal(I,1,k)
              endif
-           endif
+!          endif
            if (dhdt*dhdy < 0.0) dhdt = 0.0
            if (dhdy == 0.0) dhdy=eps  ! avoid segv
            Cy = min(dhdt/dhdy,rx_max) ! default to normal flow only
-           Cx = 0
+!          Cx = 0
            cff = max(dhdy*dhdy, eps)
-           if (segment%oblique) then
+!          if (segment%oblique) then
              cff = max(dhdx*dhdx + dhdy*dhdy, eps)
              if (dhdx==0.) dhdx=eps ! avoid segv
              Cx = min(cff,max(dhdt/dhdx,-cff))
-           endif
+!          endif
            v_new(i,J,k) = ((cff*v_old(i,J,k) + Cy*v_new(i,J-1,k)) - &
               (max(Cx,0.0)*segment%grad_normal(I-1,2,k) + min(Cx,0.0)*segment%grad_normal(I,2,k))) / (cff + Cy)
          endif
-         if ((segment%radiation .or. segment%legacy) .and. segment%nudged) then
+         if ((segment%radiation .or. segment%oblique) .and. segment%nudged) then
            if (dhdt*dhdy < 0.0) then
              tau = segment%Tnudge_in
            else
              tau = segment%Tnudge_out
            endif
            v_new(i,J,k) = v_new(i,J,k) + dt*tau*(segment%normal_vel(i,J,k) - v_old(i,J,k))
-!          v_new(i,J,k) = v_new(i,J,k) + dt*tau*(OBC%v(i,J,k) - v_old(i,J,k))
          endif
        enddo; enddo
      endif
@@ -1306,7 +1297,7 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
      if (segment%direction == OBC_DIRECTION_S) then
        J=segment%HI%JscB
        do k=1,nz ;  do i=segment%HI%isc,segment%HI%iec
-         if (segment%legacy) then
+         if (segment%radiation) then
            dhdt = v_old(i,J+1,k)-v_new(i,J+1,k) !old-new
            dhdy = v_new(i,J+1,k)-v_new(i,J+2,k) !in new time backward sasha for J-1
            ry_new = 0.0
@@ -1314,10 +1305,10 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
            ry_avg = (1.0-gamma_v)*segment%rx_normal(I,j,k) + gamma_v*ry_new
            segment%rx_normal(i,J,k) = ry_avg
            v_new(i,J,k) = (v_old(i,J,k) + ry_avg*v_new(i,J+1,k)) / (1.0+ry_avg)
-         elseif (segment%radiation) then
+         elseif (segment%oblique) then
            dhdt = v_old(i,J+1,k)-v_new(i,J+1,k) !old-new
            dhdy = v_new(i,J+1,k)-v_new(i,J+2,k) !in new time backward sasha for J-1
-           if (segment%oblique) then
+!          if (segment%oblique) then
              if (dhdt*(segment%grad_normal(I,1,k) + segment%grad_normal(I-1,1,k)) > 0.0) then
                dhdx = segment%grad_normal(I-1,1,k)
              elseif (dhdt*(segment%grad_normal(I,1,k) + segment%grad_normal(I-1,1,k)) == 0.0) then
@@ -1325,28 +1316,27 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, &
              else
                dhdx = segment%grad_normal(I,1,k)
              endif
-           endif
+!          endif
            if (dhdt*dhdy < 0.0) dhdt = 0.0
            if (dhdy == 0.0) dhdy=eps  ! avoid segv
            Cy = min(dhdt/dhdy,rx_max) ! default to normal flow only
-           Cx = 0
+!          Cx = 0
            cff = max(dhdy*dhdy, eps)
-           if (segment%oblique) then
+!          if (segment%oblique) then
              cff = max(dhdx*dhdx + dhdy*dhdy, eps)
              if (dhdx==0.) dhdx=eps ! avoid segv
              Cx = min(cff,max(dhdt/dhdx,-cff))
-           endif
+!          endif
            v_new(i,J,k) = ((cff*v_old(i,J,k) + Cy*v_new(i,J+1,k)) - &
               (max(Cx,0.0)*segment%grad_normal(I-1,2,k) + min(Cx,0.0)*segment%grad_normal(I,2,k))) / (cff + Cy)
          endif
-         if ((segment%radiation .or. segment%legacy) .and. segment%nudged) then
+         if ((segment%radiation .or. segment%oblique) .and. segment%nudged) then
            if (dhdt*dhdy < 0.0) then
              tau = segment%Tnudge_in
            else
              tau = segment%Tnudge_out
            endif
            v_new(i,J,k) = v_new(i,J,k) + dt*tau*(segment%normal_vel(i,J,k) - v_old(i,J,k))
-!          v_new(i,J,k) = v_new(i,J,k) + dt*tau*(OBC%v(i,J,k) - v_old(i,J,k))
          endif
        enddo; enddo
      end if

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -1077,10 +1077,10 @@ subroutine open_boundary_impose_land_mask(OBC, G, areaCu, areaCv)
         if (segment%direction == OBC_DIRECTION_E) then
           areaCu(I,j) = G%areaT(i,j)
          !G%IareaCu(I,j) = G%IareaT(i,j) ?
-	else   ! West
+        else   ! West
           areaCu(I,j) = G%areaT(i+1,j)
          !G%IareaCu(I,j) = G%IareaT(i+1,j) ?
-	endif
+        endif
       enddo
     else
       ! Sweep along v-segments and for %specified BC points reset the v-point area which was masked out
@@ -1092,7 +1092,7 @@ subroutine open_boundary_impose_land_mask(OBC, G, areaCu, areaCv)
         else      ! North
           areaCu(i,J) = G%areaT(i,j)
          !G%IareaCu(i,J) = G%IareaT(i,j) ?
-	endif
+        endif
       enddo
     endif
   enddo

--- a/src/user/supercritical_initialization.F90
+++ b/src/user/supercritical_initialization.F90
@@ -53,7 +53,7 @@ subroutine supercritical_set_OBC_data(OBC, G, param_file)
     segment => OBC%segment(l)
     if (.not. segment%on_pe) cycle
     if (segment%gradient) cycle
-    if (segment%radiation .and. .not. segment%nudged .and. .not. segment%Flather) cycle
+    if (segment%oblique .and. .not. segment%nudged .and. .not. segment%Flather) cycle
 
     if (segment%is_E_or_W) then
       jsd = segment%HI%jsd ; jed = segment%HI%jed


### PR DESCRIPTION
The prior code used LEGACY to enable the Flather barotropic OBC and an Orlanski baroclinic OBC. There was no way to get that Orlanski OBC without using Flather. The new way has these radiation-like options:

Barotropic:
   FLATHER
   OBLIQUE

Baroclinic:
   ORLANSKI
   OBLIQUE

The non-oblique option from ROMS is no longer an option (it was obtained before with ORLANSKI).