### PR TITLE
Use \namespace instead of \class for documentation

### DIFF
--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -352,7 +352,7 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, param_file, tr_Reg)
 
 end subroutine DOME_set_OBC_data
 
-!> \class DOME_initialization
+!> \namespace dome_initialization
 !!
 !! The module configures the model for the "DOME" experiment.
 !! DOME = Dynamics of Overflows and Mixing Experiment

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -650,7 +650,7 @@ subroutine ISOMIP_initialize_sponges(G, GV, tv, PF, use_ALE, CSp, ACSp)
 
 end subroutine ISOMIP_initialize_sponges
 
-!> \class ISOMIP_initialization
+!> \namespace isomip_initialization
 !!
 !!  The module configures the ISOMIP test case.
 end module ISOMIP_initialization

--- a/src/user/MOM_controlled_forcing.F90
+++ b/src/user/MOM_controlled_forcing.F90
@@ -591,7 +591,7 @@ subroutine controlled_forcing_end(CS)
 
 end subroutine controlled_forcing_end
 
-!> \class MOM_controlled_forcing
+!> \namespace mom_controlled_forcing
 !!                                                                     *
 !!  By Robert Hallberg, July 2011                                      *
 !!                                                                     *

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -320,7 +320,7 @@ subroutine Phillips_initialize_topography(D, G, param_file, max_depth)
 
 end subroutine Phillips_initialize_topography
 
-!> \class Phillips_initialization
+!> \namespace phillips_initialization
 !!
 !!  By Robert Hallberg, April 1994 - June 2002                         *
 !!                                                                     *

--- a/src/user/Rossby_front_2d_initialization.F90
+++ b/src/user/Rossby_front_2d_initialization.F90
@@ -226,7 +226,7 @@ real function dTdy( G, dT, lat )
 end function dTdy
 
 
-!> \namespace Rossby_front_2d_initialization
+!> \namespace rossby_front_2d_initialization
 !!
 !! \section section_Rossby_front_2d Description of the 2d Rossby front initial conditions
 !!

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -288,7 +288,7 @@ subroutine adjustment_initialize_temperature_salinity ( T, S, h, G, param_file, 
 
 end subroutine adjustment_initialize_temperature_salinity
 
-!> \class adjustment_initialization
+!> \namespace adjustment_initialization
 !!
 !! The module configures the model for the geostrophic adjustment
 !! test case.

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -279,7 +279,7 @@ subroutine benchmark_init_temperature_salinity(T, S, G, GV, param_file, &
 end subroutine benchmark_init_temperature_salinity
 ! -----------------------------------------------------------------------------
 
-!! \class benchmark_initialization
+!! \namespace benchmark_initialization
 !!
 !! The module configures the model for the benchmark experiment.
 end module benchmark_initialization

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -107,7 +107,7 @@ subroutine circle_obcs_initialize_thickness(h, G, GV, param_file)
 
 end subroutine circle_obcs_initialize_thickness
 
-!> \class circle_obcs_initialization
+!> \namespace circle_obcs_initialization
 !!
 !! The module configures the model for the "circle_obcs" experiment.
 !! circle_obcs = Test of Open Boundary Conditions for an SSH anomaly.

--- a/src/user/external_gwave_initialization.F90
+++ b/src/user/external_gwave_initialization.F90
@@ -83,7 +83,7 @@ subroutine external_gwave_initialize_thickness(h, G, param_file)
 end subroutine external_gwave_initialize_thickness
 ! -----------------------------------------------------------------------------
 
-!> \class external_gwave_initialization
+!> \namespace external_gwave_initialization
 !!
 !! The module configures the model for the "external_gwave" experiment.
 !! external_gwave = External Gravity Wave

--- a/src/user/lock_exchange_initialization.F90
+++ b/src/user/lock_exchange_initialization.F90
@@ -95,7 +95,7 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, param_file)
 end subroutine lock_exchange_initialize_thickness
 ! -----------------------------------------------------------------------------
 
-!> \class lock_exchange_initialization
+!> \namespace lock_exchange_initialization
 !!
 !! The module configures the model for the "lock_exchange" experiment.
 !! lock_exchange = A 2-d density driven hydraulic exchange flow.

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -272,7 +272,7 @@ subroutine seamount_initialize_temperature_salinity ( T, S, h, G, GV, param_file
 
 end subroutine seamount_initialize_temperature_salinity
 
-!> \class seamount_initialization
+!> \namespace seamount_initialization
 !!
 !! The module configures the model for the idealized seamount
 !! test case.

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -259,7 +259,7 @@ subroutine sloshing_initialize_temperature_salinity ( T, S, h, G, param_file, &
 
 end subroutine sloshing_initialize_temperature_salinity
 
-!> \class sloshing_initialization
+!> \namespace sloshing_initialization
 !!
 !! The module configures the model for the non-rotating sloshing
 !! test case.

--- a/src/user/supercritical_initialization.F90
+++ b/src/user/supercritical_initialization.F90
@@ -87,7 +87,7 @@ subroutine supercritical_set_OBC_data(OBC, G, param_file)
 
 end subroutine supercritical_set_OBC_data
 
-!> \class supercritical_initialization
+!> \namespace supercritical_initialization
 !!
 !! The module configures the model for the "supercritical" experiment.
 !! https://marine.rutgers.edu/po/index.php?model=test-problems&title=supercritical

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -111,7 +111,7 @@ subroutine tidal_bay_set_OBC_data(OBC, G, h, Time)
 
 end subroutine tidal_bay_set_OBC_data
 
-!> \class tidal_bay_Initialization
+!> \namespace tidal_bay_initialization
 !!
 !! The module configures the model for the "tidal_bay" experiment.
 !! tidal_bay = Tidally resonant bay from Zygmunt Kowalik's class on tides.

--- a/src/user/user_change_diffusivity.F90
+++ b/src/user/user_change_diffusivity.F90
@@ -274,7 +274,7 @@ subroutine user_change_diff_end(CS)
 
 end subroutine user_change_diff_end
 
-!> \class user_change_diffusivity
+!> \namespace user_change_diffusivity
 !!
 !!  By Robert Hallberg, May 2012
 !!

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -247,7 +247,7 @@ subroutine write_user_log(param_file)
 
 end subroutine write_user_log
 
-!> \class user_initialization
+!> \namespace user_initialization
 !!
 !!  By Robert Hallberg, April 1994 - June 2002                         *
 !!                                                                     *


### PR DESCRIPTION
We document Fortran modules as Doxygen "namespaces", which seem to be a pretty good analogue. However, the files in src/user/ were documenting modules as "classes", which was causing fragmentation and confusion in the Doxygen output.

Additionally, because of the case-insensitive nature of Fortran, we need to use the lowercase module name for a documentation block (`\namespace module_name`), otherwise Doxygen thinks you are
documenting a separate module and generates an additional output file accordingly.