### PR TITLE
Move posting of diagnostics prior to thickness updates

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -2032,7 +2032,7 @@ subroutine diag_masks_set(G, nz, missing_value, diag_cs)
     diag_cs%mask3dCvi(:,:,k) = diag_cs%mask2dCv(:,:)
   enddo
 
-  diag_cs%missing_value = missing_value
+!  diag_cs%missing_value = missing_value
 
 end subroutine diag_masks_set
 

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1960,10 +1960,20 @@ end subroutine
 !> Build/update vertical grids for diagnostic remapping.
 !! \note The target grids need to be updated whenever sea surface
 !! height changes.
-subroutine diag_update_remap_grids(diag_cs)
-  type(diag_ctrl), intent(inout) :: diag_cs !< Diagnostics control structure
+subroutine diag_update_remap_grids(diag_cs, alt_h)
+  type(diag_ctrl),        intent(inout) :: diag_cs      !< Diagnostics control structure
+  real, target, optional, intent(in   ) :: alt_h(:,:,:) !< Used if remapped grids should be
+                                                        !! something other than the current
+                                                        !! thicknesses
   ! Local variables
   integer :: i
+  real, dimension(:,:,:), pointer :: h_diag
+
+  if(present(alt_h)) then
+    h_diag => alt_h
+  else
+    h_diag => diag_cs%h
+  endif
 
   if (id_clock_diag_grid_updates>0) call cpu_clock_begin(id_clock_diag_grid_updates)
 

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1881,6 +1881,10 @@ subroutine diag_mediator_init(G, nz, param_file, diag_cs, doc_file_dir)
     deallocate(diag_coords)
   endif
 
+  call get_param(param_file, mod, 'DIAG_MISVAL', diag_cs%missing_value, &
+                 'Set the default missing value to use for diagnostics.', &
+                 default=-1.e34)
+
   ! Keep pointers grid, h, T, S needed diagnostic remapping
   diag_cs%G => G
   diag_cs%h => null()

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1983,7 +1983,7 @@ subroutine diag_update_remap_grids(diag_cs, alt_h)
 
   do i=1, diag_cs%num_diag_coords
     call diag_remap_update(diag_cs%diag_remap_cs(i), &
-                           diag_cs%G, diag_cs%h, diag_cs%T, diag_cs%S, &
+                           diag_cs%G, h_diag, diag_cs%T, diag_cs%S, &
                            diag_cs%eqn_of_state)
   enddo
 

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -367,18 +367,6 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, fluxes, dt, MLD, G, GV,
     vDml_diag(i,J) = vDml(i)
   enddo ; enddo
 
-!$OMP do
-  do j=js,je ; do k=1,nz ; do i=is,ie
-    h(i,j,k) = h(i,j,k) - dt*G%IareaT(i,j) * &
-        ((uhml(I,j,k) - uhml(I-1,j,k)) + (vhml(i,J,k) - vhml(i,J-1,k)))
-  enddo ; enddo ; enddo
-!$OMP end parallel
-
-  ! Whenever thickness changes let the diag manager know, target grids
-  ! for vertical remapping may need to be regenerated.
-  ! This needs to happen after the H update and before the next post_data.
-  call diag_update_remap_grids(CS%diag)
-
   ! Offer diagnostic fields for averaging.
   if (query_averaging_enabled(CS%diag)) then
     if (CS%id_urestrat_time > 0) call post_data(CS%id_urestrat_time, utimescale_diag, CS%diag)
@@ -405,6 +393,18 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, fluxes, dt, MLD, G, GV,
       call post_data(CS%id_vml, vDml_diag, CS%diag)
     endif
   endif
+
+!$OMP do
+  do j=js,je ; do k=1,nz ; do i=is,ie
+    h(i,j,k) = h(i,j,k) - dt*G%IareaT(i,j) * &
+        ((uhml(I,j,k) - uhml(I-1,j,k)) + (vhml(i,J,k) - vhml(i,J-1,k)))
+  enddo ; enddo ; enddo
+!$OMP end parallel
+
+  ! Whenever thickness changes let the diag manager know, target grids
+  ! for vertical remapping may need to be regenerated.
+  ! This needs to happen after the H update and before the next post_data.
+  call diag_update_remap_grids(CS%diag)
 
 end subroutine mixedlayer_restrat_general
 

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -322,17 +322,6 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, MEKE, VarMix, CDp, CS
     endif
   endif
 
-  do k=1,nz
-    do j=js,je ; do I=is-1,ie
-      uhtr(I,j,k) = uhtr(I,j,k) + uhD(I,j,k)*dt
-      if (ASSOCIATED(CDp%uhGM)) CDp%uhGM(I,j,k) = uhD(I,j,k)
-    enddo ; enddo
-    do J=js-1,je ; do i=is,ie
-      vhtr(i,J,k) = vhtr(i,J,k) + vhD(i,J,k)*dt
-      if (ASSOCIATED(CDp%vhGM)) CDp%vhGM(i,J,k) = vhD(i,J,k)
-    enddo ; enddo
-  enddo
-
   ! offer diagnostic fields for averaging
   if (query_averaging_enabled(CS%diag)) then
     if (CS%id_uhGM > 0)   call post_data(CS%id_uhGM, uhD, CS%diag)
@@ -377,6 +366,14 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, MEKE, VarMix, CDp, CS
 
   !$OMP parallel do default(none) shared(is,ie,js,je,nz,uhtr,uhD,dt,vhtr,CDp,vhD,h,G,GV)
   do k=1,nz
+    do j=js,je ; do I=is-1,ie
+      uhtr(I,j,k) = uhtr(I,j,k) + uhD(I,j,k)*dt
+      if (ASSOCIATED(CDp%uhGM)) CDp%uhGM(I,j,k) = uhD(I,j,k)
+    enddo ; enddo
+    do J=js-1,je ; do i=is,ie
+      vhtr(i,J,k) = vhtr(i,J,k) + vhD(i,J,k)*dt
+      if (ASSOCIATED(CDp%vhGM)) CDp%vhGM(i,J,k) = vhD(i,J,k)
+    enddo ; enddo
     do j=js,je ; do i=is,ie
       h(i,j,k) = h(i,j,k) - dt * G%IareaT(i,j) * &
           ((uhD(I,j,k) - uhD(I-1,j,k)) + (vhD(i,J,k) - vhD(i,J-1,k)))

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -56,9 +56,6 @@ type, public :: thickness_diffuse_CS ; private
   real, pointer :: GMwork(:,:)       => NULL()  !< Work by thickness diffusivity (W m-2)
   real, pointer :: diagSlopeX(:,:,:) => NULL()  !< Diagnostic: zonal neutral slope (nondim)
   real, pointer :: diagSlopeY(:,:,:) => NULL()  !< Diagnostic: zonal neutral slope (nondim)
-  real, dimension(:,:,:), allocatable :: h_pre  !< If the mass tranports associated with this
-                                                !! routine are remapped in the diag manager, the
-                                                !< starting layer thicknesses will need to be saved
 
   !>@{
   !! Diagnostic identifier
@@ -124,8 +121,6 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, MEKE, VarMix, CDp, CS
   real :: hv(SZI_(G), SZJ_(G))       ! v-thickness (H)
   real :: KH_u_lay(SZI_(G), SZJ_(G)) ! layer ave thickness diffusivities (m2/sec)
   real :: KH_v_lay(SZI_(G), SZJ_(G)) ! layer ave thickness diffusivities (m2/sec)
-  real, dimension(:,:,:), allocatable :: h_pre ! h at the beginning of this routine may need to be
-                                               ! stored if transports are being remapped
 
   if (.not. ASSOCIATED(CS)) call MOM_error(FATAL, "MOM_thickness_diffuse:"// &
          "Module must be initialized before it is used.")
@@ -141,12 +136,6 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, MEKE, VarMix, CDp, CS
     if (ASSOCIATED(MEKE%GM_src)) then
       do j=js,je ; do i=is,ie ; MEKE%GM_src(i,j) = 0. ; enddo ; enddo
     endif
-  endif
-
-  if ((CS%id_uhGM > 0) .or. (CS%id_vhGM > 0)) then
-    do k=1,nz ; do j=G%jsd,G%jed ; do i=G%isd,G%ied
-      CS%h_pre(i,j,k) = h(i,j,k)
-    enddo ; enddo ; enddo ;
   endif
 
   use_VarMix = .false. ; Resoln_scaled = .false. ; use_stored_slopes = .false.
@@ -323,27 +312,6 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, MEKE, VarMix, CDp, CS
     call thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV, MEKE, CS, &
                                 int_slope_u, int_slope_v)
   endif
-!$OMP parallel do default(none) shared(is,ie,js,je,nz,uhtr,uhD,dt,vhtr,CDp,vhD,h,G,GV)
-  do k=1,nz
-    do j=js,je ; do I=is-1,ie
-      uhtr(I,j,k) = uhtr(I,j,k) + uhD(I,j,k)*dt
-      if (ASSOCIATED(CDp%uhGM)) CDp%uhGM(I,j,k) = uhD(I,j,k)
-    enddo ; enddo
-    do J=js-1,je ; do i=is,ie
-      vhtr(i,J,k) = vhtr(i,J,k) + vhD(i,J,k)*dt
-      if (ASSOCIATED(CDp%vhGM)) CDp%vhGM(i,J,k) = vhD(i,J,k)
-    enddo ; enddo
-    do j=js,je ; do i=is,ie
-      h(i,j,k) = h(i,j,k) - dt * G%IareaT(i,j) * &
-          ((uhD(I,j,k) - uhD(I-1,j,k)) + (vhD(i,J,k) - vhD(i,J-1,k)))
-      if (h(i,j,k) < GV%Angstrom) h(i,j,k) = GV%Angstrom
-    enddo ; enddo
-  enddo
-
-  ! Whenever thickness changes let the diag manager know, target grids
-  ! for vertical remapping may need to be regenerated.
-  ! This needs to happen after the H update and before the next post_data.
-  call diag_update_remap_grids(CS%diag)
 
   if (associated(MEKE) .AND. ASSOCIATED(VarMix)) then
     if (ASSOCIATED(MEKE%Rd_dx_h) .and. ASSOCIATED(VarMix%Rd_dx_h)) then
@@ -354,18 +322,21 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, MEKE, VarMix, CDp, CS
     endif
   endif
 
-  if (CS%debug) then
-    call uchksum(uhD(:,:,:)*H_to_m,"thickness_diffuse uhD",G%HI,haloshift=0)
-    call vchksum(vhD(:,:,:)*H_to_m,"thickness_diffuse vhD",G%HI,haloshift=0)
-    call uchksum(uhtr(:,:,:)*H_to_m,"thickness_diffuse uhtr",G%HI,haloshift=0)
-    call vchksum(vhtr(:,:,:)*H_to_m,"thickness_diffuse vhtr",G%HI,haloshift=0)
-    call hchksum(h(:,:,:)*H_to_m,"thickness_diffuse h",G%HI,haloshift=0)
-  endif
+  do k=1,nz
+    do j=js,je ; do I=is-1,ie
+      uhtr(I,j,k) = uhtr(I,j,k) + uhD(I,j,k)*dt
+      if (ASSOCIATED(CDp%uhGM)) CDp%uhGM(I,j,k) = uhD(I,j,k)
+    enddo ; enddo
+    do J=js-1,je ; do i=is,ie
+      vhtr(i,J,k) = vhtr(i,J,k) + vhD(i,J,k)*dt
+      if (ASSOCIATED(CDp%vhGM)) CDp%vhGM(i,J,k) = vhD(i,J,k)
+    enddo ; enddo
+  enddo
 
   ! offer diagnostic fields for averaging
   if (query_averaging_enabled(CS%diag)) then
-    if (CS%id_uhGM > 0)   call post_data(CS%id_uhGM, CDp%uhGM, CS%diag, alt_h = CS%h_pre)
-    if (CS%id_vhGM > 0)   call post_data(CS%id_vhGM, CDp%vhGM, CS%diag, alt_h = CS%h_pre)
+    if (CS%id_uhGM > 0)   call post_data(CS%id_uhGM, uhD, CS%diag)
+    if (CS%id_vhGM > 0)   call post_data(CS%id_vhGM, vhD, CS%diag)
     if (CS%id_GMwork > 0) call post_data(CS%id_GMwork, CS%GMwork, CS%diag)
     if (CS%id_KH_u > 0)   call post_data(CS%id_KH_u, KH_u, CS%diag)
     if (CS%id_KH_v > 0)   call post_data(CS%id_KH_v, KH_v, CS%diag)
@@ -402,6 +373,28 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, MEKE, VarMix, CDp, CS
       if(CS%id_KH_t1 > 0) call post_data(CS%id_KH_t1, KH_t(:,:,1), CS%diag)
     endif
 
+  endif
+
+  !$OMP parallel do default(none) shared(is,ie,js,je,nz,uhtr,uhD,dt,vhtr,CDp,vhD,h,G,GV)
+  do k=1,nz
+    do j=js,je ; do i=is,ie
+      h(i,j,k) = h(i,j,k) - dt * G%IareaT(i,j) * &
+          ((uhD(I,j,k) - uhD(I-1,j,k)) + (vhD(i,J,k) - vhD(i,J-1,k)))
+      if (h(i,j,k) < GV%Angstrom) h(i,j,k) = GV%Angstrom
+    enddo ; enddo
+  enddo
+
+  ! Whenever thickness changes let the diag manager know, target grids
+  ! for vertical remapping may need to be regenerated.
+  ! This needs to happen after the H update and before the next post_data.
+  call diag_update_remap_grids(CS%diag)
+
+  if (CS%debug) then
+    call uchksum(uhD(:,:,:)*H_to_m,"thickness_diffuse uhD",G%HI,haloshift=0)
+    call vchksum(vhD(:,:,:)*H_to_m,"thickness_diffuse vhD",G%HI,haloshift=0)
+    call uchksum(uhtr(:,:,:)*H_to_m,"thickness_diffuse uhtr",G%HI,haloshift=0)
+    call vchksum(vhtr(:,:,:)*H_to_m,"thickness_diffuse vhtr",G%HI,haloshift=0)
+    call hchksum(h(:,:,:)*H_to_m,"thickness_diffuse h",G%HI,haloshift=0)
   endif
 
 end subroutine thickness_diffuse
@@ -1776,10 +1769,6 @@ subroutine thickness_diffuse_init(Time, G, GV, param_file, diag, CDp, CS)
            'Time Mean Diffusive Meridional Thickness Flux', flux_units, &
            x_cell_method='sum', v_extensive=.true.)
   if (CS%id_vhGM > 0) call safe_alloc_ptr(CDp%vhGM,G%isd,G%ied,G%JsdB,G%JedB,G%ke)
-
-  if ((CS%id_uhGM > 0) .or. (CS%id_vhGM>0)) then
-    allocate(CS%h_pre(G%isd:G%ied,G%jsd:G%jed,G%ke)) ; CS%h_pre(:,:,:) = 0.0
-  endif
 
   CS%id_GMwork = register_diag_field('ocean_model', 'GMwork', diag%axesT1, Time,                     &
    'Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection',               &

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -2011,7 +2011,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
 
   !call set_diffusivity_init(Time, G, param_file, diag, CS%set_diff_CSp, diag_to_Z_CSp, CS%int_tide_CSp)
   CS%id_Kd_interface = register_diag_field('ocean_model', 'Kd_interface', diag%axesTi, Time, &
-      'Total diapycnal diffusivity at interfaces', 'meter2 second-1')
+      'Total diapycnal diffusivity at interfaces', 'meter2 second-1', v_extensive = .false.)
   if (CS%use_energetic_PBL) then
       CS%id_Kd_ePBL = register_diag_field('ocean_model', 'Kd_ePBL', diag%axesTi, Time, &
           'ePBL diapycnal diffusivity at interfaces', 'meter2 second-1')


### PR DESCRIPTION
This is a followup which splits PR #443 into two. This PR contains the changes that moves the calls of post_data for transport-related diagnostics to before layer thicknesses are updated. The additional runtime parameter DIAG_MISVAL which allows the override of the missing value used in the diagnostic manager is included in this PR. These changes should not affect answers. The relevant portion of the original PR's description is included below.

### Major changes
- Within mixed_layer_restrat_general and thickness_diffuse, code was rearranged so that diagnostics are posted prior to the update to the layer thicknesses
- For the umo, vmo, uhtr, and vhtr diagnostics, a copy of the layer thicknesses before the dynamics step needed to be stored. These thicknesses are then used to rebuild the remapping grid using a call to diag_update_remap_diag which now accepts an optional argument to set the source grid.