### PR TITLE
Refactoring to get rid of Hml from tv

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -153,7 +153,7 @@ type, public :: MOM_control_struct
     vhtr      !< accumulated meridional thickness fluxes to advect tracers (m3 or kg)
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
     ave_ssh   !< time-averaged (ave over baroclinic time steps) sea surface height (meter)
-
+  real, pointer, dimension(:,:)   :: Hml !< active mixed layer depth, in m
   real, pointer, dimension(:,:,:) :: &
     u_prev => NULL(), &  !< previous value of u stored for diagnostics
     v_prev => NULL()     !< previous value of v stored for diagnostics
@@ -729,7 +729,7 @@ subroutine step_MOM(fluxes, state, Time_start, time_interval, CS)
         endif
 
         call cpu_clock_begin(id_clock_diabatic)
-        call diabatic(u, v, h, CS%tv, fluxes, CS%visc, CS%ADp, CS%CDp, &
+        call diabatic(u, v, h, CS%tv, CS%Hml, fluxes, CS%visc, CS%ADp, CS%CDp, &
                       dtdia, G, GV, CS%diabatic_CSp)
         fluxes%fluxes_used = .true.
         call cpu_clock_end(id_clock_diabatic)
@@ -1125,7 +1125,7 @@ subroutine step_MOM(fluxes, state, Time_start, time_interval, CS)
           call adjustments_dyn_legacy_split(u, v, h, dt, G, GV, CS%dyn_legacy_split_CSp)
         endif
         call cpu_clock_begin(id_clock_diabatic)
-        call diabatic(u, v, h, CS%tv, fluxes, CS%visc, CS%ADp, CS%CDp, &
+        call diabatic(u, v, h, CS%tv, CS%Hml, fluxes, CS%visc, CS%ADp, CS%CDp, &
                       CS%dt_trans, G, GV, CS%diabatic_CSp)
         fluxes%fluxes_used = .true.
         call cpu_clock_end(id_clock_diabatic)
@@ -2139,9 +2139,12 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
     allocate(CS%tv%salt_deficit(isd:ied,jsd:jed)) ; CS%tv%salt_deficit(:,:)=0.0
   endif
 
+  if (CS%bulkmixedlayer .or. CS%use_temperature) then
+     allocate(CS%Hml(isd:ied,jsd:jed)) ; CS%Hml(:,:) = 0.0
+  endif
+
   if (CS%bulkmixedlayer) then
     GV%nkml = nkml ; GV%nk_rho_varies = nkml + nkbl
-    allocate(CS%tv%Hml(isd:ied,jsd:jed)) ; CS%tv%Hml(:,:) = 0.0
   else
     GV%nkml = 0 ; GV%nk_rho_varies = 0
   endif
@@ -3274,7 +3277,7 @@ subroutine set_restart_fields(GV, param_file, CS)
   type(param_file_type),    intent(in) :: param_file    !< opened file for parsing to get parameters
   type(MOM_control_struct), intent(in) :: CS            !< control structure set up by inialize_MOM
   ! Local variables
-  logical :: use_ice_shelf ! Needed to determine whether to add tv%Hml to restarts
+  logical :: use_ice_shelf ! Needed to determine whether to add CS%Hml to restarts
   type(vardesc) :: vd
   character(len=48) :: thickness_units, flux_units
 
@@ -3314,9 +3317,9 @@ subroutine set_restart_fields(GV, param_file, CS)
   call register_restart_field(CS%ave_ssh, vd, .false., CS%restart_CSp)
 
   ! hML is needed when using the ice shelf module
-  if (use_ice_shelf .and. associated(CS%tv%Hml)) then
+  if (use_ice_shelf .and. associated(CS%Hml)) then
      vd = var_desc("hML","meter","Mixed layer thickness",'h','1')
-     call register_restart_field(CS%tv%Hml, vd, .false., CS%restart_CSp)
+     call register_restart_field(CS%Hml, vd, .false., CS%restart_CSp)
   endif
 
 end subroutine set_restart_fields
@@ -3378,7 +3381,7 @@ subroutine calculate_surface_state(state, u, v, h, ssh, G, GV, CS, p_atm)
     state%u => u(:,:,1)
     state%v => v(:,:,1)
     nullify(state%sfc_density)
-    if (associated(CS%tv%Hml)) state%Hml => CS%tv%Hml
+    if (associated(CS%Hml)) state%Hml => CS%Hml
   else
     if (CS%use_temperature) then
       if (.not.associated(state%SST)) then
@@ -3661,7 +3664,7 @@ subroutine MOM_end(CS)
   endif
   if (associated(CS%tv%frazil)) deallocate(CS%tv%frazil)
   if (associated(CS%tv%salt_deficit)) deallocate(CS%tv%salt_deficit)
-  if (associated(CS%tv%Hml)) deallocate(CS%tv%Hml)
+  if (associated(CS%Hml)) deallocate(CS%Hml)
 
   call tracer_advect_end(CS%tracer_adv_CSp)
   call tracer_hor_diff_end(CS%tracer_diff_CSp)

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -104,8 +104,6 @@ type, public :: thermo_var_ptrs
                          ! When conservative temperature is used, this is
                          ! constant and exactly 3991.86795711963 J K kg-1.
   real, pointer, dimension(:,:) :: &
-    Hml => NULL(), &     !   The surface mixed layer depth in m.
-
 !  These arrays are accumulated fluxes for communication with other components.
     frazil => NULL(), &  !   The energy needed to heat the ocean column to the
                          ! freezing point since calculate_surface_state was

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -193,7 +193,7 @@ integer :: num_msg = 0, max_msg = 2
 contains
 
 subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
-                          optics, aggregate_FW_forcing, dt_diag, last_call)
+                          optics, Hml, aggregate_FW_forcing, dt_diag, last_call)
   type(ocean_grid_type),                     intent(inout) :: G
   type(verticalGrid_type),                   intent(in)    :: GV
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(inout) :: h_3d
@@ -204,6 +204,7 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(inout) :: ea, eb
   type(bulkmixedlayer_CS),                   pointer       :: CS
   type(optics_type),                         pointer       :: optics
+  real, dimension(:,:),                      pointer       :: Hml !< active mixed layer depth
   logical,                                   intent(in)    :: aggregate_FW_forcing
   real,                            optional, intent(in)    :: dt_diag
   logical,                         optional, intent(in)    :: last_call
@@ -639,8 +640,8 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
     if (write_diags .and. ALLOCATED(CS%ML_depth)) then ; do i=is,ie
       CS%ML_depth(i,j) = h(i,0) * GV%H_to_m
     enddo ; endif
-    if (ASSOCIATED(tv%Hml)) then ; do i=is,ie
-      tv%Hml(i,j) = G%mask2dT(i,j) * (h(i,0) * GV%H_to_m)
+    if (ASSOCIATED(Hml)) then ; do i=is,ie
+      Hml(i,j) = G%mask2dT(i,j) * (h(i,0) * GV%H_to_m)
     enddo ; endif
 
 ! At this point, return water to the original layers, but constrained to

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -447,7 +447,7 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
         ! Changes: h, tv%T, tv%S, eaml and ebml  (G is also inout???)
         call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt*CS%ML_mix_first, &
                             eaml,ebml, G, GV, CS%bulkmixedlayer_CSp, CS%optics, &
-                            CS%aggregate_FW_forcing, dt, last_call=.false.)
+                            tv%Hml, CS%aggregate_FW_forcing, dt, last_call=.false.)
         if (CS%salt_reject_below_ML) &
           call insert_brine(h, tv, G, GV, fluxes, nkmb, CS%diabatic_aux_CSp, &
                             dt*CS%ML_mix_first, CS%id_brine_lay)
@@ -455,7 +455,7 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
         ! Changes: h, tv%T, tv%S, eaml and ebml  (G is also inout???)
         call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt, eaml, ebml, &
                         G, GV, CS%bulkmixedlayer_CSp, CS%optics, &
-                        CS%aggregate_FW_forcing, dt, last_call=.true.)
+                        tv%Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
       endif
 
       !  Keep salinity from falling below a small but positive threshold.
@@ -978,7 +978,7 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
       ! Changes: h, tv%T, tv%S, ea and eb  (G is also inout???)
       call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt_mix, ea, eb, &
                       G, GV, CS%bulkmixedlayer_CSp, CS%optics, &
-                      CS%aggregate_FW_forcing, dt, last_call=.true.)
+                      tv%Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
 
       if (CS%salt_reject_below_ML) &
         call insert_brine(h, tv, G, GV, fluxes, nkmb, CS%diabatic_aux_CSp, dt_mix, &

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -226,13 +226,14 @@ contains
 
 !>  This subroutine imposes the diapycnal mass fluxes and the
 !!  accompanying diapycnal advection of momentum and tracers.
-subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
+subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, G, GV, CS)
   type(ocean_grid_type),                     intent(inout) :: G      !< ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV     !< ocean vertical grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: u      !< zonal velocity (m/s)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: v      !< meridional velocity (m/s)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h      !< thickness (m for Bouss / kg/m2 for non-Bouss)
   type(thermo_var_ptrs),                     intent(inout) :: tv     !< points to thermodynamic fields; unused have NULL ptrs
+  real, dimension(:,:),                      pointer       :: Hml    !< active mixed layer depth
   type(forcing),                             intent(inout) :: fluxes !< points to forcing fields; unused fields have NULL ptrs
   type(vertvisc_type),                       intent(inout) :: visc   !< vertical viscosities, BBL properies, and related
   type(accel_diag_ptrs),                     intent(inout) :: ADp    !< points to accelerations in momentum equations,
@@ -447,7 +448,7 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
         ! Changes: h, tv%T, tv%S, eaml and ebml  (G is also inout???)
         call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt*CS%ML_mix_first, &
                             eaml,ebml, G, GV, CS%bulkmixedlayer_CSp, CS%optics, &
-                            tv%Hml, CS%aggregate_FW_forcing, dt, last_call=.false.)
+                            Hml, CS%aggregate_FW_forcing, dt, last_call=.false.)
         if (CS%salt_reject_below_ML) &
           call insert_brine(h, tv, G, GV, fluxes, nkmb, CS%diabatic_aux_CSp, &
                             dt*CS%ML_mix_first, CS%id_brine_lay)
@@ -455,7 +456,7 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
         ! Changes: h, tv%T, tv%S, eaml and ebml  (G is also inout???)
         call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt, eaml, ebml, &
                         G, GV, CS%bulkmixedlayer_CSp, CS%optics, &
-                        tv%Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
+                        Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
       endif
 
       !  Keep salinity from falling below a small but positive threshold.
@@ -761,6 +762,7 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
       if (associated(visc%MLD)) then
         call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, visc%MLD, G)
         call pass_var(visc%MLD, G%domain)
+        if (associated(Hml)) Hml(:,:) = visc%MLD(:,:)
       endif
 
       ! Augment the diffusivities due to those diagnosed in energetic_PBL.
@@ -978,7 +980,7 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
       ! Changes: h, tv%T, tv%S, ea and eb  (G is also inout???)
       call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt_mix, ea, eb, &
                       G, GV, CS%bulkmixedlayer_CSp, CS%optics, &
-                      tv%Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
+                      Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
 
       if (CS%salt_reject_below_ML) &
         call insert_brine(h, tv, G, GV, fluxes, nkmb, CS%diabatic_aux_CSp, dt_mix, &


### PR DESCRIPTION
* Moved reference to tv%Hml out of bulkmixedlayer

* Hml is now part of the control structure in MOM.F90. It just gets allocated when bulkmixedlayer or use_temperature is used.