### PR TITLE
All members of diabatic_CS and diabatic_aux_CS private

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2482,7 +2482,7 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
   if(present(offline_tracer_mode)) offline_tracer_mode=CS%offline_tracer_mode
 
   if(CS%offline_tracer_mode) then
-    call offline_transport_init(param_file, CS%offline_CSp, CS%diabatic_CSp%diabatic_aux_CSp, G, GV)
+    call offline_transport_init(param_file, CS%offline_CSp, CS%diabatic_CSp, G, GV)
     CS%offline_CSp%debug = CS%debug
     if (mod(first_direction,2)==0) then
       CS%offline_CSp%x_before_y = .true.

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -89,18 +89,12 @@ implicit none ; private
 public diabatic_aux_init, diabatic_aux_end
 public make_frazil, adjust_salt, insert_brine, differential_diffuse_T_S, triDiagTS
 public find_uv_at_h, diagnoseMLDbyDensityDifference, applyBoundaryFluxesInOut
-
 !> Control structure for diabatic_aux
 type, public :: diabatic_aux_CS ; private
   logical :: do_rivermix = .false. !< Provide additional TKE to mix river runoff
                                    !! at the river mouths to "rivermix_depth" meters
   real    :: rivermix_depth = 0.0  !< The depth to which rivers are mixed if
                                    !! do_rivermix = T, in m.
-  real, public    :: minimum_forcing_depth = 0.001 !< The smallest depth over which forcing is
-                                   !! applied, in m.
-  real, public    :: evap_CFL_limit = 0.8  !< The largest fraction of a layer that can be
-                                   !! evaporated in one time-step (non-dim).
-
   logical :: reclaim_frazil  !<   If true, try to use any frazil heat deficit to
                              !! to cool the topmost layer down to the freezing
                              !! point.  The default is false.
@@ -805,10 +799,11 @@ end subroutine diagnoseMLDbyDensityDifference
 !! boundary forcing (contained in fluxes type) applied to h, tv%T and tv%S,
 !! and calculate the TKE implications of this heating.
 subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
-                                    aggregate_FW_forcing, cTKE, dSV_dT, dSV_dS)
+                                    aggregate_FW_forcing, evap_CFL_limit, &
+                                    minimum_forcing_depth, cTKE, dSV_dT, dSV_dS)
   type(diabatic_aux_CS),                 pointer       :: CS !< Control structure for diabatic_aux
   type(ocean_grid_type),                 intent(in)    :: G  !< Grid structure
-  type(verticalGrid_type),               intent(in)    :: GV        !< ocean vertical grid structure
+  type(verticalGrid_type),               intent(in)    :: GV !< ocean vertical grid structure
   real,                                  intent(in)    :: dt !< Time-step over which forcing is applied (s)
   type(forcing),                         intent(inout) :: fluxes !< Surface fluxes container
   type(optics_type),                     pointer       :: optics !< Optical properties container
@@ -816,6 +811,10 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
   type(thermo_var_ptrs),                 intent(inout) :: tv !< Thermodynamics container
   !> If False, treat in/out fluxes separately.
   logical,                               intent(in)    :: aggregate_FW_forcing
+  !> The largest fraction of a layer that can be evaporated in one time-step (non-dim).
+  real,                                  intent(in)   :: evap_CFL_limit
+  !> The smallest depth over which heat and freshwater fluxes is applied, in m.
+  real,                                  intent(in)   :: minimum_forcing_depth
   !> Turbulent kinetic energy requirement to mix forcing through each layer, in W m-2
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), optional, intent(out) :: cTKE
   !> Partial derivative of specific volume with potential temperature, in m3 kg-1 K-1.
@@ -1038,15 +1037,15 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
           ! Place forcing into this layer if this layer has nontrivial thickness.
           ! For layers thin relative to 1/IforcingDepthScale, then distribute
           ! forcing into deeper layers.
-          IforcingDepthScale = 1. / max(GV%H_subroundoff, CS%minimum_forcing_depth*GV%m_to_H - netMassOut(i) )
+          IforcingDepthScale = 1. / max(GV%H_subroundoff, minimum_forcing_depth*GV%m_to_H - netMassOut(i) )
           ! fractionOfForcing = 1.0, unless h2d is less than IforcingDepthScale.
           fractionOfForcing = min(1.0, h2d(i,k)*IforcingDepthScale)
 
           ! In the case with (-1)*netMassOut*fractionOfForcing greater than cfl*h, we
           ! limit the forcing applied to this cell, leaving the remaining forcing to
           ! be distributed downwards.
-          if (-fractionOfForcing*netMassOut(i) > CS%evap_CFL_limit*h2d(i,k)) then
-            fractionOfForcing = -CS%evap_CFL_limit*h2d(i,k)/netMassOut(i)
+          if (-fractionOfForcing*netMassOut(i) > evap_CFL_limit*h2d(i,k)) then
+            fractionOfForcing = -evap_CFL_limit*h2d(i,k)/netMassOut(i)
           endif
 
           ! Change in state due to forcing
@@ -1229,7 +1228,6 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
 
 end subroutine applyBoundaryFluxesInOut
 
-
 subroutine diabatic_aux_init(Time, G, GV, param_file, diag, CS, useALEalgorithm, use_ePBL)
   type(time_type),         intent(in)    :: Time
   type(ocean_grid_type),   intent(in)    :: G
@@ -1285,17 +1283,6 @@ subroutine diabatic_aux_init(Time, G, GV, param_file, diag, CS, useALEalgorithm,
                  "when making frazil. The default is false, which will be \n"//&
                  "faster but is inappropriate with ice-shelf cavities.", &
                  default=.false.)
-  call get_param(param_file, mod, "MINIMUM_FORCING_DEPTH", CS%minimum_forcing_depth, &
-                 "The smallest depth over which forcing can be applied. This\n"//&
-                 "only takes effect when near-surface layers become thin\n"//&
-                 "relative to this scale, in which case the forcing tendencies\n"//&
-                 "scaled down by distributing the forcing over this depth scale.", &
-                 units="m", default=0.001)
-  call get_param(param_file, mod, "EVAP_CFL_LIMIT", CS%evap_CFL_limit, &
-                 "The largest fraction of a layer than can be lost to forcing\n"//&
-                 "(e.g. evaporation, sea-ice formation) in one time-step. The unused\n"//&
-                 "mass loss is passed down through the column.", &
-                 units="nondim", default=0.8)
 
   if (use_ePBL) then
     call get_param(param_file, mod, "IGNORE_FLUXES_OVER_LAND", CS%ignore_fluxes_over_land,&

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1476,6 +1476,26 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
 
 end subroutine diabatic
 
+!> Returns pointers or values of members within the diabatic_CS type. For extensibility,
+!! each returned argument is an optional argument
+subroutine extract_diabatic_member(CS, opacity_CSp, optics_CSp, &
+                                   evap_CFL_limit, minimum_forcing_depth)
+  type(diabatic_CS),  intent(in   ) :: CS
+  ! All output arguments are optional
+  type(opacity_CS),   pointer, optional, intent(  out) :: opacity_CSp
+  type(optics_type),  pointer, optional, intent(  out) :: optics_CSp
+  real,                        optional, intent(  out) :: evap_CFL_limit
+  real,                        optional, intent(  out) :: minimum_forcing_depth
+
+  ! Pointers to control structures
+  if (present(opacity_CSp)) opacity_CSp => CS%opacity_CSp
+  if (present(optics_CSp))  optics_CSp  => CS%optics
+
+  ! Constants within diabatic_CS
+  if (present(evap_CFL_limit))        evap_CFL_limit = CS%evap_CFL_limit
+  if (present(minimum_forcing_depth)) minimum_forcing_depth = CS%minimum_forcing_depth
+
+end subroutine
 
 !> Routine called for adiabatic physics
 subroutine adiabatic(h, tv, fluxes, dt, G, GV, CS)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -70,11 +70,12 @@ implicit none ; private
 public diabatic
 public diabatic_driver_init
 public diabatic_driver_end
+public extract_diabatic_member
 public adiabatic
 public adiabatic_driver_init
 
 !> Control structure for this module
-type, public :: diabatic_CS ;
+type, public:: diabatic_CS ; private
   logical :: bulkmixedlayer          !< If true, a refined bulk mixed layer is used with
                                      !! nkml sublayers (and additional buffer layers).
   logical :: use_energetic_PBL       !< If true, use the implicit energetics planetary
@@ -135,6 +136,10 @@ type, public :: diabatic_CS ;
   real    :: Kd_min_tr               !< A minimal diffusivity that should always be
                                      !! applied to tracers, especially in massless layers
                                      !! near the bottom, in m2 s-1.
+  real    :: minimum_forcing_depth = 0.001 !< The smallest depth over which heat and freshwater
+                                           !! fluxes is applied, in m.
+  real    :: evap_CFL_limit = 0.8    !< The largest fraction of a layer that can be
+                                     !! evaporated in one time-step (non-dim).
 
   logical :: useKPP                  !< use CVmix/KPP diffusivities and non-local transport
   logical :: salt_reject_below_ML    !< If true, add salt below mixed layer (layer mode only)
@@ -741,7 +746,9 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
     enddo ; enddo ; enddo
     if (CS%use_energetic_PBL) then
       call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, dt, fluxes, CS%optics, &
-                          h, tv, CS%aggregate_FW_forcing, cTKE, dSV_dT, dSV_dS)
+                          h, tv, CS%aggregate_FW_forcing, CS%evap_CFL_limit, &
+                          CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS)
+
       call calculateBuoyancyFlux2d(G, GV, fluxes, CS%optics, h, tv%T, tv%S, tv, &
            CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux)
 
@@ -793,7 +800,8 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
 
     else
       call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, dt, fluxes, CS%optics, &
-                                    h, tv, CS%aggregate_FW_forcing)
+                                    h, tv, CS%aggregate_FW_forcing, &
+                                    CS%evap_CFL_limit, CS%minimum_forcing_depth)
 
     endif   ! endif for CS%use_energetic_PBL
 
@@ -1146,8 +1154,8 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
     ! so hold should be h_orig
       call call_tracer_column_fns(h_prebound, h, ea, eb, fluxes, dt, G, GV, tv, &
                                 CS%optics, CS%tracer_flow_CSp, CS%debug, &
-                                evap_CFL_limit = CS%diabatic_aux_CSp%evap_CFL_limit, &
-                                minimum_forcing_depth = CS%diabatic_aux_CSp%minimum_forcing_depth)
+                                evap_CFL_limit = CS%evap_CFL_limit, &
+                                minimum_forcing_depth = CS%minimum_forcing_depth)
     else
       call call_tracer_column_fns(hold, h, eatr, ebtr, fluxes, dt, G, GV, tv, &
                                 CS%optics, CS%tracer_flow_CSp, CS%debug)
@@ -1177,8 +1185,8 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
     ! For passive tracers, the changes in thickness due to boundary fluxes has yet to be applied
       call call_tracer_column_fns(h_prebound, h, eatr, ebtr, fluxes, dt, G, GV, tv, &
                                   CS%optics, CS%tracer_flow_CSp, CS%debug,&
-                                  evap_CFL_limit = CS%diabatic_aux_CSp%evap_CFL_limit, &
-                                  minimum_forcing_depth = CS%diabatic_aux_CSp%minimum_forcing_depth)
+                                  evap_CFL_limit = CS%evap_CFL_limit, &
+                                  minimum_forcing_depth = CS%minimum_forcing_depth)
     else
       call call_tracer_column_fns(hold, h, eatr, ebtr, fluxes, dt, G, GV, tv, &
                                   CS%optics, CS%tracer_flow_CSp, CS%debug)
@@ -1189,8 +1197,8 @@ subroutine diabatic(u, v, h, tv, fluxes, visc, ADp, CDp, dt, G, GV, CS)
     ! For passive tracers, the changes in thickness due to boundary fluxes has yet to be applied
       call call_tracer_column_fns(h_prebound, h, eatr, ebtr, fluxes, dt, G, GV, tv, &
                                   CS%optics, CS%tracer_flow_CSp, CS%debug, &
-                                  evap_CFL_limit = CS%diabatic_aux_CSp%evap_CFL_limit, &
-                                  minimum_forcing_depth = CS%diabatic_aux_CSp%minimum_forcing_depth)
+                                  evap_CFL_limit = CS%evap_CFL_limit, &
+                                  minimum_forcing_depth = CS%minimum_forcing_depth)
     else
       call call_tracer_column_fns(hold, h, ea, eb, fluxes, dt, G, GV, tv, &
                                   CS%optics, CS%tracer_flow_CSp, CS%debug)
@@ -1922,6 +1930,18 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
   call get_param(param_file, mod, "TRACER_TRIDIAG", CS%tracer_tridiag, &
                  "If true, use the passive tracer tridiagonal solver for T and S\n", &
                  default=.false.)
+
+  call get_param(param_file, mod, "MINIMUM_FORCING_DEPTH", CS%minimum_forcing_depth, &
+                 "The smallest depth over which forcing can be applied. This\n"//&
+                 "only takes effect when near-surface layers become thin\n"//&
+                 "relative to this scale, in which case the forcing tendencies\n"//&
+                 "scaled down by distributing the forcing over this depth scale.", &
+                 units="m", default=0.001)
+  call get_param(param_file, mod, "EVAP_CFL_LIMIT", CS%evap_CFL_limit, &
+                 "The largest fraction of a layer than can be lost to forcing\n"//&
+                 "(e.g. evaporation, sea-ice formation) in one time-step. The unused\n"//&
+                 "mass loss is passed down through the column.", &
+                 units="nondim", default=0.8)
 
 
   ! Register all available diagnostics for this module.


### PR DESCRIPTION
This PR is comprised of two commits which makes all members of diabatic_CS and diabatic_aux_CS private. diabatic_CS was made public in commit ae78ec37498089c045abdf1247c52836b9067cc2 to avoid reinitializing lower level modules. Two members of diabatic_aux_CS were made public in dfd22a2ba453f6960804f3320957f70399f23ddb because tracerBoundaryFluxesInOut needed to access two runtime parameters. 
- This PR should not change answers (and has been verified to reproduce answers on a small subset of test cases)
- MOM_parameter_doc.all does change because EVAP_CFL_LIMIT and MINIMUM_FORCING_DEPTH are now read in during the diabatic module initialization.
- No new parameters are added 

### Changes for diabatic_CS
- Extractor routine (extract_diabatic_member) for diabatic module was written which consists of optional output arguments. The subroutine returns pointers to other control structures within the diabatic control structure and the value of other parameters within the diabatic_CS type
- offline_transport_CS now contains pointers to optics and opacity substructures which are assigned using the extractor routine

### Changes for diabatic_aux_CS
- evap_CFL_limit and minimum_forcing_depth were moved from diabatic_aux_CS to diabatic_CS
- These two parameters are now read at runtime during the initialization of the diabatic module instead of the diabatic_aux module.
- The subroutine applyBoundaryFluxesInOut now has two additional arguments evap_CFL_limit and minimum_forcing_depth