### PR TITLE
Kernelise regridding coordinates

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -14,16 +14,6 @@ use MOM_EOS,           only : EOS_type, calculate_density, calculate_density_der
 use MOM_EOS,           only : calculate_compress
 use MOM_string_functions,only : uppercase, extractWord, extract_integer, extract_real
 
-use regrid_edge_values, only : edge_values_explicit_h2, edge_values_explicit_h4
-use regrid_edge_values, only : edge_values_implicit_h4, edge_values_implicit_h6
-use regrid_edge_slopes, only : edge_slopes_implicit_h3, edge_slopes_implicit_h5
-
-use PLM_functions, only : PLM_reconstruction, PLM_boundary_extrapolation
-use PPM_functions, only : PPM_reconstruction, PPM_boundary_extrapolation
-use PQM_functions, only : PQM_reconstruction, PQM_boundary_extrapolation_v1
-
-use P1M_functions, only : P1M_interpolation, P1M_boundary_extrapolation
-use P3M_functions, only : P3M_interpolation, P3M_boundary_extrapolation
 use MOM_remapping, only : remapping_core_h
 use MOM_remapping, only : remapping_CS
 use regrid_consts, only : state_dependent, coordinateUnits
@@ -32,6 +22,8 @@ use regrid_consts, only : REGRIDDING_LAYER, REGRIDDING_ZSTAR
 use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA
 use regrid_consts, only : REGRIDDING_ARBITRARY, REGRIDDING_SIGMA_SHELF_ZSTAR
 use regrid_consts, only : REGRIDDING_HYCOM1, REGRIDDING_SLIGHT
+use regrid_interp, only : regridding_set_ppolys, interpolate_grid, interpolation_scheme
+use regrid_interp, only : NR_ITERATIONS, NR_TOLERANCE
 
 use netcdf ! Used by check_grid_def()
 
@@ -181,39 +173,12 @@ character(len=6), parameter, public :: regriddingDefaultInterpScheme = "P1M_H2"
 logical, parameter, public :: regriddingDefaultBoundaryExtrapolation = .false.
 real, parameter, public :: regriddingDefaultMinThickness = 1.e-3
 
-! The following are private constants
-
-! List of interpolation schemes
-integer, parameter :: INTERPOLATION_P1M_H2     = 0 !< O(h^2)
-integer, parameter :: INTERPOLATION_P1M_H4     = 1 !< O(h^2)
-integer, parameter :: INTERPOLATION_P1M_IH4    = 2 !< O(h^2)
-integer, parameter :: INTERPOLATION_PLM        = 3 !< O(h^2)
-integer, parameter :: INTERPOLATION_PPM_H4     = 4 !< O(h^3)
-integer, parameter :: INTERPOLATION_PPM_IH4    = 5 !< O(h^3)
-integer, parameter :: INTERPOLATION_P3M_IH4IH3 = 6 !< O(h^4)
-integer, parameter :: INTERPOLATION_P3M_IH6IH5 = 7 !< O(h^4)
-integer, parameter :: INTERPOLATION_PQM_IH4IH3 = 8 !< O(h^4)
-integer, parameter :: INTERPOLATION_PQM_IH6IH5 = 9 !< O(h^5)
-
-!> List of interpolant degrees
-integer, parameter :: DEGREE_1 = 1, DEGREE_2 = 2, DEGREE_3 = 3, DEGREE_4 = 4
-
 !> Maximum number of regridding iterations
 integer, parameter :: NB_REGRIDDING_ITERATIONS = 1
 !> Deviation tolerance between succesive grids in regridding iterations
 real, parameter    :: DEVIATION_TOLERANCE = 1e-10
-!> Maximum number of Newton-Raphson iterations. Newton-Raphson iterations are
-!! used to build the new grid by finding the coordinates associated with
-!! target densities and interpolations of degree larger than 1.
-integer, parameter :: NR_ITERATIONS = 8
-!> Tolerance for Newton-Raphson iterations (stop when increment falls below this)
-real, parameter    :: NR_TOLERANCE = 1e-12
-!> When the N-R algorithm produces an estimate that lies outside [0,1], the
-!! estimate is set to be equal to the boundary location, 0 or 1, plus or minus
-!! an offset, respectively, when the derivative is zero at the boundary.
-real, parameter    :: NR_OFFSET = 1e-6
-
 ! This CPP macro embeds some safety checks
+
 #undef __DO_SAFETY_CHECKS__
 
 contains
@@ -775,27 +740,6 @@ subroutine end_regridding(CS)
   if (allocated(CS%max_layer_thickness) ) deallocate( CS%max_layer_thickness )
 
 end subroutine end_regridding
-
-!> Numeric value of interpolation_scheme corresponding to scheme name
-integer function interpolation_scheme(interp_scheme)
-  character(len=*), intent(in) :: interp_scheme !< Name of interpolation scheme
-
-  select case ( uppercase(trim(interp_scheme)) )
-    case ("P1M_H2");     interpolation_scheme = INTERPOLATION_P1M_H2
-    case ("P1M_H4");     interpolation_scheme = INTERPOLATION_P1M_H4
-    case ("P1M_IH2");    interpolation_scheme = INTERPOLATION_P1M_IH4
-    case ("PLM");        interpolation_scheme = INTERPOLATION_PLM
-    case ("PPM_H4");     interpolation_scheme = INTERPOLATION_PPM_H4
-    case ("PPM_IH4");    interpolation_scheme = INTERPOLATION_PPM_IH4
-    case ("P3M_IH4IH3"); interpolation_scheme = INTERPOLATION_P3M_IH4IH3
-    case ("P3M_IH6IH5"); interpolation_scheme = INTERPOLATION_P3M_IH6IH5
-    case ("PQM_IH4IH3"); interpolation_scheme = INTERPOLATION_PQM_IH4IH3
-    case ("PQM_IH6IH5"); interpolation_scheme = INTERPOLATION_PQM_IH6IH5
-    case default ; call MOM_error(FATAL, "MOM_regridding: "//&
-     "Unrecognized choice for INTERPOLATION_SCHEME ("//trim(interp_scheme)//").")
-  end select
-
-end function interpolation_scheme
 
 !------------------------------------------------------------------------------
 ! Dispatching regridding routine: regridding & remapping
@@ -1591,8 +1535,9 @@ subroutine build_rho_column(CS, remapCS, nz, depth, h, T, S, eqn_of_state, zInte
     end do
 
     ! One regridding iteration
-    call regridding_set_ppolys(densities, CS, count_nonzero_layers, hTmp, &
-                               ppoly_i_E, ppoly_i_S, ppoly_i_coefficients, ppoly_degree)
+    call regridding_set_ppolys(densities, count_nonzero_layers, hTmp, &
+         ppoly_i_E, ppoly_i_S, ppoly_i_coefficients, &
+         ppoly_degree, CS%interpolation_scheme, CS%boundary_extrapolation)
     ! Based on global density profile, interpolate to generate a new grid
     call interpolate_grid(count_nonzero_layers, hTmp, xTmp, ppoly_i_E, ppoly_i_coefficients, &
                           CS%target_density, ppoly_degree, nz, h1, x1 )
@@ -1744,8 +1689,8 @@ subroutine build_hycom1_column(CS, remapCS, eqn_of_state, nz, depth, h, T, S, p_
   enddo
 
   ! Interpolates for the target interface position with the rho_col profile
-  call regridding_set_ppolys(rho_col, CS, nz, h(:), ppoly_i_E, ppoly_i_S, &
-                             ppoly_i_coefficients, ppoly_degree)
+  call regridding_set_ppolys(rho_col, nz, h(:), ppoly_i_E, ppoly_i_S, ppoly_i_coefficients, &
+       ppoly_degree, CS%interpolation_scheme, CS%boundary_extrapolation)
   ! Based on global density profile, interpolate to generate a new grid
   call interpolate_grid(nz, h(:), z_col, ppoly_i_E, ppoly_i_coefficients, &
                         CS%target_density, ppoly_degree, nz, h_col_new, z_col_new)
@@ -2188,8 +2133,9 @@ subroutine rho_interfaces_col(rho_col, h_col, z_col, rho_tgt, nz, z_col_new, &
   endif
 
   ! This sets up the piecewise polynomials based on the rho_col profile.
-  call regridding_set_ppolys(rho_col, CS, nz, h_col, ppoly_i_E, ppoly_i_S, &
-                             ppoly_i_coefficients, ppoly_degree)
+  call regridding_set_ppolys(rho_col, nz, h_col, ppoly_i_E, ppoly_i_S, &
+       ppoly_i_coefficients, ppoly_degree, &
+       CS%interpolation_scheme, CS%boundary_extrapolation)
 
   ! Determine the density ranges of unstably stratified segments.
   ! Interfaces that start out in an unstably stratified segment can
@@ -2519,386 +2465,6 @@ stop 'OOOOOOPS' ! For some reason the gnu compiler will not let me delete this
 
 end subroutine build_grid_arbitrary
 
-
-!> Given the set of target values and cell densities, this routine
-!! builds an interpolated profile for the densities within each grid cell.
-!! It may happen that, given a high-order interpolator, the number of
-!! available layers is insufficient (e.g., there are two available layers for
-!! a third-order PPM ih4 scheme). In these cases, we resort to the simplest
-!! continuous linear scheme (P1M h2).
-subroutine regridding_set_ppolys( densities, CS, n0, h0, ppoly0_E, ppoly0_S, &
-                                  ppoly0_coefficients, degree)
-
-  real, dimension(:),  intent(in)    :: densities !< Actual cell densities
-  integer,             intent(in)    :: n0 !< Number of cells on source grid
-  real, dimension(:),  intent(in)    :: h0 !< cell widths on source grid
-  real, dimension(:,:),intent(inout) :: ppoly0_E            !< Edge value of polynomial
-  real, dimension(:,:),intent(inout) :: ppoly0_S            !< Edge slope of polynomial
-  real, dimension(:,:),intent(inout) :: ppoly0_coefficients !< Coefficients of polynomial
-  integer,             intent(inout) :: degree  !< The degree of the polynomials
-  type(regridding_CS), intent(in)    :: CS !< Parameters used for regridding
-
-  ! Reset piecewise polynomials
-  ppoly0_E(:,:) = 0.0
-  ppoly0_S(:,:) = 0.0
-  ppoly0_coefficients(:,:) = 0.0
-
-  ! Compute the interpolated profile of the density field and build grid
-  select case ( CS%interpolation_scheme )
-
-    case ( INTERPOLATION_P1M_H2 )
-      degree = DEGREE_1
-      call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-      if ( CS%boundary_extrapolation) then
-        call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-      end if
-
-    case ( INTERPOLATION_P1M_H4 )
-      degree = DEGREE_1
-      if ( n0 >= 4 ) then
-        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E )
-      else
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-      end if
-      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-      if ( CS%boundary_extrapolation) then
-        call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-      end if
-
-    case ( INTERPOLATION_P1M_IH4 )
-      degree = DEGREE_1
-      if ( n0 >= 4 ) then
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E )
-      else
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-      end if
-      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-      if ( CS%boundary_extrapolation) then
-        call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-      end if
-
-    case ( INTERPOLATION_PLM )
-      degree = DEGREE_1
-      call PLM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-      if ( CS%boundary_extrapolation) then
-        call PLM_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-      end if
-
-    case ( INTERPOLATION_PPM_H4 )
-      if ( n0 >= 4 ) then
-        degree = DEGREE_2
-        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E )
-        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        end if
-      else
-        degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        end if
-      end if
-
-    case ( INTERPOLATION_PPM_IH4 )
-
-      if ( n0 >= 4 ) then
-        degree = DEGREE_2
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E )
-        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        end if
-      else
-        degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        end if
-      end if
-
-    case ( INTERPOLATION_P3M_IH4IH3 )
-
-      if ( n0 >= 4 ) then
-        degree = DEGREE_3
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E )
-        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S )
-        call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call P3M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
-        end if
-      else
-        degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        end if
-      end if
-
-    case ( INTERPOLATION_P3M_IH6IH5 )
-      if ( n0 >= 6 ) then
-        degree = DEGREE_3
-        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E )
-        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S )
-        call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call P3M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
-        end if
-      else
-        degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        end if
-      end if
-
-    case ( INTERPOLATION_PQM_IH4IH3 )
-
-      if ( n0 >= 4 ) then
-        degree = DEGREE_4
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E )
-        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S )
-        call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call PQM_boundary_extrapolation_v1( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
-        end if
-      else
-        degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        end if
-      end if
-
-    case ( INTERPOLATION_PQM_IH6IH5 )
-      if ( n0 >= 6 ) then
-        degree = DEGREE_4
-        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E )
-        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S )
-        call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call PQM_boundary_extrapolation_v1( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
-        end if
-      else
-        degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        if ( CS%boundary_extrapolation) then
-          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
-        end if
-      end if
-
-  end select
-
-end subroutine regridding_set_ppolys
-
-
-!------------------------------------------------------------------------------
-! Given target values (e.g., density), build new grid based on polynomial
-!------------------------------------------------------------------------------
-subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefficients, target_values, degree, n1, h1, x1 )
-! ------------------------------------------------------------------------------
-! Given the grid 'grid0' and the piecewise polynomial interpolant
-! 'ppoly0' (possibly discontinuous), the coordinates of the new grid 'grid1'
-! are determined by finding the corresponding target interface densities.
-! ------------------------------------------------------------------------------
-
-  ! Arguments
-  integer,            intent(in)    :: n0
-  real, dimension(:), intent(in)    :: h0
-  real, dimension(:), intent(in)    :: x0
-  real, dimension(:,:), intent(in)  :: ppoly0_E            !Edge value of polynomial
-  real, dimension(:,:), intent(in)  :: ppoly0_coefficients !Coefficients of polynomial
-  real, dimension(:), intent(in)    :: target_values
-  integer,            intent(in)    :: degree
-  integer,            intent(in)    :: n1
-  real, dimension(:), intent(inout) :: h1
-  real, dimension(:), intent(inout) :: x1
-
-  ! Local variables
-  integer        :: k   ! loop index
-  real           :: t   ! current interface target density
-
-  ! Make sure boundary coordinates of new grid coincide with boundary
-  ! coordinates of previous grid
-  x1(1) = x0(1)
-  x1(n1+1) = x0(n0+1)
-
-  ! Find coordinates for interior target values
-  do k = 2,n1
-    t = target_values(k)
-    x1(k) = get_polynomial_coordinate ( n0, h0, x0, ppoly0_E, ppoly0_coefficients, t, degree )
-    h1(k-1) = x1(k) - x1(k-1)
-  end do
-  h1(n1) = x1(n1+1) - x1(n1)
-
-end subroutine interpolate_grid
-
-
-!------------------------------------------------------------------------------
-! Given target value, find corresponding coordinate for given polynomial
-!------------------------------------------------------------------------------
-function get_polynomial_coordinate ( N, h, x_g, ppoly_E, ppoly_coefficients, &
-                                     target_value, degree ) result ( x_tgt )
-! ------------------------------------------------------------------------------
-! Here, 'ppoly' is assumed to be a piecewise discontinuous polynomial of degree
-! 'degree' throughout the domain defined by 'grid'. A target value is given
-! and we need to determine the corresponding grid coordinate to define the
-! new grid.
-!
-! If the target value is out of range, the grid coordinate is simply set to
-! be equal to one of the boundary coordinates, which results in vanished layers
-! near the boundaries.
-!
-! IT IS ASSUMED THAT THE PIECEWISE POLYNOMIAL IS MONOTONICALLY INCREASING.
-! IF THIS IS NOT THE CASE, THE NEW GRID MAY BE ILL-DEFINED.
-!
-! It is assumed that the number of cells defining 'grid' and 'ppoly' are the
-! same.
-! ------------------------------------------------------------------------------
-
-  ! Arguments
-  integer,              intent(in) :: N     ! The number of grid cells
-  real, dimension(:),   intent(in) :: h     ! Grid cell thicknesses    (size N)
-  real, dimension(:),   intent(in) :: x_g   ! Grid interface locations (size N+1)
-  real, dimension(:,:), intent(in) :: ppoly_E  !Edge value of polynomial
-  real, dimension(:,:), intent(in) :: ppoly_coefficients !Coefficients of polynomial
-  real,                 intent(in) :: target_value
-  integer,              intent(in) :: degree ! The degree of the polynomials
-
-  real :: x_tgt      !< The position of x_g at which target_value is found.
-
-  ! Local variables
-  integer            :: i, k            ! loop indices
-  integer            :: k_found         ! index of target cell
-  integer            :: iter
-  real               :: xi0             ! normalized target coordinate
-  real, dimension(5) :: a               ! polynomial coefficients
-  real               :: numerator
-  real               :: denominator
-  real               :: delta           ! Newton-Raphson increment
-  real               :: x               ! global target coordinate
-  real               :: eps                 ! offset used to get away from
-                                        ! boundaries
-  real               :: grad            ! gradient during N-R iterations
-
-  eps = NR_OFFSET
-
-  k_found = -1
-
-  ! If the target value is outside the range of all values, we
-  ! force the target coordinate to be equal to the lowest or
-  ! largest value, depending on which bound is overtaken
-  if ( target_value <= ppoly_E(1,1) ) then
-    x_tgt = x_g(1)
-    return  ! return because there is no need to look further
-  end if
-
-  ! Since discontinuous edge values are allowed, we check whether the target
-  ! value lies between two discontinuous edge values at interior interfaces
-  do k = 2,N
-    if ( ( target_value >= ppoly_E(k-1,2) ) .AND. &
-      ( target_value <= ppoly_E(k,1) ) ) then
-      x_tgt = x_g(k)
-      return   ! return because there is no need to look further
-      exit
-    end if
-  end do
-
-  ! If the target value is outside the range of all values, we
-  ! force the target coordinate to be equal to the lowest or
-  ! largest value, depending on which bound is overtaken
-  if ( target_value >= ppoly_E(N,2) ) then
-    x_tgt = x_g(N+1)
-    return  ! return because there is no need to look further
-  end if
-
-  ! At this point, we know that the target value is bounded and does not
-  ! lie between discontinuous, monotonic edge values. Therefore,
-  ! there is a unique solution. We loop on all cells and find which one
-  ! contains the target value. The variable k_found holds the index value
-  ! of the cell where the taregt value lies.
-  do k = 1,N
-    if ( ( target_value > ppoly_E(k,1) ) .AND. &
-         ( target_value < ppoly_E(k,2) ) ) then
-      k_found = k
-      exit
-    end if
-  end do
-
-  ! At this point, 'k_found' should be strictly positive. If not, this is
-  ! a major failure because it means we could not find any target cell
-  ! despite the fact that the target value lies between the extremes. It
-  ! means there is a major problem with the interpolant. This needs to be
-  ! reported.
-  if ( k_found == -1 ) then
-      write(*,*) target_value, ppoly_E(1,1), ppoly_E(N,2)
-      write(*,*) 'Could not find target coordinate in ' //&
-                 '"get_polynomial_coordinate". This is caused by an '//&
-                 'inconsistent interpolant (perhaps not monotonically '//&
-                 'increasing)'
-      call MOM_error( FATAL, 'Aborting execution' )
-  end if
-
-  ! Reset all polynomial coefficients to 0 and copy those pertaining to
-  ! the found cell
-  a(:) = 0.0
-  do i = 1,degree+1
-    a(i) = ppoly_coefficients(k_found,i)
-  end do
-
-  ! Guess value to start Newton-Raphson iterations (middle of cell)
-  xi0 = 0.5
-  iter = 1
-  delta = 1e10
-
-  ! Newton-Raphson iterations
-  do
-    if ( ( iter > NR_ITERATIONS ) .OR. &
-         ( abs(delta) < NR_TOLERANCE ) ) then
-      exit
-    end if
-
-    numerator = a(1) + a(2)*xi0 + a(3)*xi0*xi0 + a(4)*xi0*xi0*xi0 + &
-                a(5)*xi0*xi0*xi0*xi0 - target_value
-
-    denominator = a(2) + 2*a(3)*xi0 + 3*a(4)*xi0*xi0 + 4*a(5)*xi0*xi0*xi0
-
-    delta = - ( numerator ) / &
-              ( denominator )
-
-    xi0 = xi0 + delta
-
-    ! Check whether new estimate is out of bounds. If the new estimate is
-    ! indeed out of bounds, we manually set it to be equal to the overtaken
-    ! bound with a small offset towards the interior when the gradient of
-    ! the function at the boundary is zero (in which case, the Newton-Raphson
-    ! algorithm does not converge).
-    if ( xi0 < 0.0 ) then
-      xi0 = 0.0
-      grad = a(2)
-      if ( grad == 0.0 ) xi0 = xi0 + eps
-    end if
-
-    if ( xi0 > 1.0 ) then
-      xi0 = 1.0
-      grad = a(2) + 2*a(3) + 3*a(4) + 4*a(5)
-      if ( grad == 0.0 ) xi0 = xi0 - eps
-    end if
-
-    iter = iter + 1
-
-  end do ! end Newton-Raphson iterations
-
-  x_tgt = x_g(k_found) + xi0 * h(k_found)
-
-end function get_polynomial_coordinate
 
 
 !------------------------------------------------------------------------------

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -1980,40 +1980,28 @@ subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_gri
                      'set_regrid_params: depth_of_time_filter_deep<depth_of_time_filter_shallow!')
   endif
 
-  if (present(min_thickness)) then
-    CS%min_thickness = min_thickness
+  if (present(min_thickness)) CS%min_thickness = min_thickness
+  if (present(compress_fraction)) CS%compressibility_fraction = compress_fraction
 
-    select case (CS%regridding_scheme)
-    case (REGRIDDING_ZSTAR)
-      call set_zlike_params(CS%zlike_CS, min_thickness=min_thickness)
-    case (REGRIDDING_SIGMA)
-      call set_sigma_params(CS%sigma_CS, min_thickness=min_thickness)
-    case (REGRIDDING_RHO)
-      call set_rho_params(CS%rho_CS, min_thickness=min_thickness)
-    case (REGRIDDING_SLIGHT)
-      call set_slight_params(CS%slight_CS, min_thickness=min_thickness)
-    end select
-  endif
-
-  if (present(compress_fraction)) then
-    CS%compressibility_fraction = compress_fraction
-
-    ! SLight additionally needs compressibility fraction within its build_column method
-    if (CS%regridding_scheme == REGRIDDING_SLIGHT) &
-      call set_slight_params(CS%slight_CS, compressibility_fraction=compress_fraction)
-  endif
-
-  ! SLight-specific parameters
-  if (present(dz_min_surface))      call set_slight_params(CS%slight_CS, dz_ml_min=dz_min_surface)
-  if (present(nz_fixed_surface))    call set_slight_params(CS%slight_CS, nz_fixed_surface=nz_fixed_surface)
-  if (present(Rho_ML_avg_depth))    call set_slight_params(CS%slight_CS, Rho_ML_avg_depth=Rho_ML_avg_depth)
-  if (present(nlay_ML_to_interior)) call set_slight_params(CS%slight_CS, nlay_ML_offset=nlay_ML_to_interior)
-  if (present(fix_haloclines))      call set_slight_params(CS%slight_CS, fix_haloclines=fix_haloclines)
-  if (present(halocline_filt_len))  call set_slight_params(CS%slight_CS, halocline_filter_length=halocline_filt_len)
-  if (present(halocline_strat_tol)) call set_slight_params(CS%slight_CS, halocline_strat_tol=halocline_strat_tol)
-
-  ! rho-specific parameters
-  if (present(integrate_downward_for_e)) call set_rho_params(CS%rho_CS, integrate_downward_for_e=integrate_downward_for_e)
+  select case (CS%regridding_scheme)
+  case (REGRIDDING_ZSTAR)
+    if (present(min_thickness)) call set_zlike_params(CS%zlike_CS, min_thickness=min_thickness)
+  case (REGRIDDING_SIGMA)
+    if (present(min_thickness)) call set_sigma_params(CS%sigma_CS, min_thickness=min_thickness)
+  case (REGRIDDING_RHO)
+    if (present(min_thickness)) call set_rho_params(CS%rho_CS, min_thickness=min_thickness)
+    if (present(integrate_downward_for_e)) call set_rho_params(CS%rho_CS, integrate_downward_for_e=integrate_downward_for_e)
+  case (REGRIDDING_SLIGHT)
+    if (present(min_thickness))       call set_slight_params(CS%slight_CS, min_thickness=min_thickness)
+    if (present(dz_min_surface))      call set_slight_params(CS%slight_CS, dz_ml_min=dz_min_surface)
+    if (present(nz_fixed_surface))    call set_slight_params(CS%slight_CS, nz_fixed_surface=nz_fixed_surface)
+    if (present(Rho_ML_avg_depth))    call set_slight_params(CS%slight_CS, Rho_ML_avg_depth=Rho_ML_avg_depth)
+    if (present(nlay_ML_to_interior)) call set_slight_params(CS%slight_CS, nlay_ML_offset=nlay_ML_to_interior)
+    if (present(fix_haloclines))      call set_slight_params(CS%slight_CS, fix_haloclines=fix_haloclines)
+    if (present(halocline_filt_len))  call set_slight_params(CS%slight_CS, halocline_filter_length=halocline_filt_len)
+    if (present(halocline_strat_tol)) call set_slight_params(CS%slight_CS, halocline_strat_tol=halocline_strat_tol)
+    if (present(compress_fraction))   call set_slight_params(CS%slight_CS, compressibility_fraction=compress_fraction)
+  end select
 
 end subroutine set_regrid_params
 

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -466,11 +466,7 @@ subroutine initialize_regridding(CS, GV, max_depth, param_file, mod, coord_mode,
 
   if (allocated(dz)) call setCoordinateResolution(dz, CS)
 
-  if ((coordinateMode(coord_mode) == REGRIDDING_RHO) .and. (allocated(rho_target))) then
-    call set_target_densities(CS, rho_target)
-    deallocate(rho_target)
-
-  elseif (allocated(rho_target)) then
+  if (allocated(rho_target)) then
     call set_target_densities(CS, rho_target)
     deallocate(rho_target)
 

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -1982,6 +1982,7 @@ subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_gri
 
   if (present(min_thickness)) CS%min_thickness = min_thickness
   if (present(compress_fraction)) CS%compressibility_fraction = compress_fraction
+  if (present(integrate_downward_for_e)) CS%integrate_downward_for_e = integrate_downward_for_e
 
   select case (CS%regridding_scheme)
   case (REGRIDDING_ZSTAR)

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -10,11 +10,9 @@ use MOM_io,            only : vardesc, var_desc, fieldtype, SINGLE_FILE
 use MOM_io,            only : create_file, write_field, close_file, slasher
 use MOM_variables,     only : ocean_grid_type, thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type
-use MOM_EOS,           only : EOS_type, calculate_density, calculate_density_derivs
-use MOM_EOS,           only : calculate_compress
+use MOM_EOS,           only : EOS_type, calculate_density
 use MOM_string_functions,only : uppercase, extractWord, extract_integer, extract_real
 
-use MOM_remapping, only : remapping_core_h
 use MOM_remapping, only : remapping_CS
 use regrid_consts, only : state_dependent, coordinateUnits
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE
@@ -22,15 +20,14 @@ use regrid_consts, only : REGRIDDING_LAYER, REGRIDDING_ZSTAR
 use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA
 use regrid_consts, only : REGRIDDING_ARBITRARY, REGRIDDING_SIGMA_SHELF_ZSTAR
 use regrid_consts, only : REGRIDDING_HYCOM1, REGRIDDING_SLIGHT
-use regrid_interp, only : regridding_set_ppolys, interpolate_grid
 use regrid_interp, only : interp_CS_type, set_interp_scheme, set_interp_extrap
-use regrid_interp, only : NR_ITERATIONS, NR_TOLERANCE, DEGREE_MAX
 
-use coord_zlike, only : init_coord_zlike, zlike_CS, build_zstar_column
-use coord_sigma, only : init_coord_sigma, sigma_CS, build_sigma_column
-use coord_rho,   only : init_coord_rho, rho_CS, build_rho_column
-use coord_rho,   only : old_inflate_layers_1d
-use coord_hycom, only : init_coord_hycom, hycom_CS, build_hycom1_column
+use coord_zlike,  only : init_coord_zlike, zlike_CS, build_zstar_column
+use coord_sigma,  only : init_coord_sigma, sigma_CS, build_sigma_column
+use coord_rho,    only : init_coord_rho, rho_CS, build_rho_column
+use coord_rho,    only : old_inflate_layers_1d
+use coord_hycom,  only : init_coord_hycom, hycom_CS, build_hycom1_column
+use coord_slight, only : init_coord_slight, slight_CS, build_slight_column
 
 use netcdf ! Used by check_grid_def()
 
@@ -131,10 +128,11 @@ type, public :: regridding_CS
   !! If false, integrate from the bottom upward, as does the rest of the model.
   logical :: integrate_downward_for_e = .true.
 
-  type(zlike_CS), pointer :: zlike_CS => null()
-  type(sigma_CS), pointer :: sigma_CS => null()
-  type(rho_CS),   pointer :: rho_CS   => null()
-  type(hycom_CS), pointer :: hycom_CS => null()
+  type(zlike_CS),  pointer :: zlike_CS  => null()
+  type(sigma_CS),  pointer :: sigma_CS  => null()
+  type(rho_CS),    pointer :: rho_CS    => null()
+  type(hycom_CS),  pointer :: hycom_CS  => null()
+  type(slight_CS), pointer :: slight_CS => null()
 
 end type
 
@@ -685,6 +683,11 @@ subroutine initialize_regridding(CS, GV, max_depth, param_file, mod, coord_mode,
   case (REGRIDDING_HYCOM1)
     call init_coord_hycom(CS%hycom_CS, CS%interp_CS, CS%target_density, CS%coordinateResolution, &
          CS%max_interface_depths, CS%max_layer_thickness)
+  case (REGRIDDING_SLIGHT)
+    call init_coord_slight(CS%slight_CS, CS%min_thickness, CS%Rho_ml_avg_depth, CS%nz_fixed_surface, &
+         CS%nlay_ml_offset, CS%fix_haloclines, CS%halocline_filter_length, CS%ref_pressure, &
+         CS%compressibility_fraction, CS%halocline_strat_tol, CS%dz_ml_min, CS%max_interface_depths, &
+         CS%max_layer_thickness, CS%target_density, CS%interp_CS)
   end select
 
   if (allocated(dz)) deallocate(dz)
@@ -747,6 +750,7 @@ subroutine end_regridding(CS)
   if (associated(CS%sigma_CS)) deallocate(CS%sigma_CS)
   if (associated(CS%rho_CS)) deallocate(CS%rho_CS)
   if (associated(CS%hycom_CS)) deallocate(CS%hycom_CS)
+  if (associated(CS%slight_CS)) deallocate(CS%slight_CS)
 
   deallocate( CS%coordinateResolution )
   if (allocated(CS%target_density)) deallocate( CS%target_density )
@@ -827,7 +831,7 @@ subroutine regridding_main( remapCS, CS, G, GV, h, tv, h_new, dzInterface, frac_
       call calc_h_new_by_dz(G, GV, h, dzInterface, h_new)
 
     case ( REGRIDDING_SLIGHT )
-      call build_grid_SLight( G, GV, h, tv, dzInterface, remapCS, CS )
+      call build_grid_SLight( G, GV, h, tv, dzInterface, CS )
       call calc_h_new_by_dz(G, GV, h, dzInterface, h_new)
 
     case default
@@ -1416,13 +1420,12 @@ end subroutine build_grid_HyCOM1
 !! shallow topography, this will tend to give a uniform sigma-like coordinate.
 !! For sufficiently shallow water, a minimum grid spacing is used to avoid
 !! certain instabilities.
-subroutine build_grid_SLight( G, GV, h, tv, dzInterface, remapCS, CS )
+subroutine build_grid_SLight( G, GV, h, tv, dzInterface, CS )
   type(ocean_grid_type),                       intent(in)    :: G  !< Grid structure
   type(verticalGrid_type),                     intent(in)    :: GV !< Ocean vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   intent(in)    :: h  !< Existing model thickness, in H units
   type(thermo_var_ptrs),                       intent(in)    :: tv !< Thermodynamics structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: dzInterface !< Changes in interface position
-  type(remapping_CS),                          intent(in)    :: remapCS !< Remapping control structure
   type(regridding_CS),                         intent(in)    :: CS !< Regridding control structure
 
   real, dimension(SZK_(GV)+1) :: z_col, z_col_new ! Interface positions relative to the surface in H units (m or kg m-2)
@@ -1448,7 +1451,7 @@ subroutine build_grid_SLight( G, GV, h, tv, dzInterface, remapCS, CS )
                     ( 0.5 * ( z_col(K) + z_col(K+1) ) * GV%H_to_Pa - CS%ref_pressure )
       enddo
 
-      call build_slight_column(CS, remapCS, tv%eqn_of_state, GV%H_to_Pa, GV%m_to_H, &
+      call build_slight_column(CS%slight_CS, tv%eqn_of_state, GV%H_to_Pa, GV%m_to_H, &
                           GV%H_subroundoff, nz, depth, &
                           h(i, j, :), tv%T(i, j, :), tv%S(i, j, :), p_col, z_col, z_col_new)
 
@@ -1469,542 +1472,6 @@ subroutine build_grid_SLight( G, GV, h, tv, dzInterface, remapCS, CS )
   enddo; enddo ! i,j
 
 end subroutine build_grid_SLight
-
-subroutine build_slight_column(CS, remapCS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff, &
-                                nz, depth, h_col, T_col, S_col, p_col, z_col, z_col_new)
-  type(regridding_CS),   intent(in)    :: CS !< Regridding control structure
-  type(remapping_CS),    intent(in)    :: remapCS !< Remapping parameters and options
-  type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
-  real,                  intent(in)    :: H_to_Pa !< GV%H_to_Pa
-  real,                  intent(in)    :: m_to_H  !< GV%m_to_H
-  real,                  intent(in)    :: H_subroundoff !< GV%H_subroundoff
-  integer,               intent(in)    :: nz !< Number of levels
-  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in m)
-  real, dimension(nz),   intent(in)    :: T_col, S_col !< T and S for column
-  real, dimension(nz),   intent(in)    :: h_col !< Layer thicknesses, in m
-  real, dimension(nz),   intent(in)    :: p_col !< Layer quantities
-  real, dimension(nz+1), intent(in)    :: z_col !< Interface positions relative to the surface in H units (m or kg m-2)
-  real, dimension(nz+1), intent(inout) :: z_col_new !< Absolute positions of interfaces
-
-  ! Local variables
-  real, dimension(nz) :: rho_col ! Layer quantities
-  real, dimension(nz) :: T_f, S_f  ! Filtered ayer quantities
-  logical, dimension(nz+1) :: reliable  ! If true, this interface is in a reliable position.
-  real, dimension(nz+1) :: T_int, S_int ! Temperature and salinity interpolated to interfaces.
-  real, dimension(nz+1) :: rho_tmp, drho_dp, p_IS, p_R
-  real, dimension(nz+1) :: drhoIS_dT, drhoIS_dS
-  real, dimension(nz+1) :: drhoR_dT, drhoR_dS
-  real, dimension(nz+1) :: strat_rat
-  real :: H_to_cPa
-  real :: drIS, drR, Fn_now, I_HStol, Fn_zero_val
-  real :: z_int_unst
-  real :: dz      ! A uniform layer thickness in very shallow water, in H.
-  real :: dz_ur   ! The total thickness of an unstable region, in H.
-  real :: wgt, cowgt  ! A weight and its complement, nondim.
-  real :: rho_ml_av ! The average potential density in a near-surface region, in kg m-3.
-  real :: H_ml_av ! A thickness to try to use in taking the near-surface average, in H.
-  real :: rho_x_z ! A cumulative integral of a density, in kg m-3 H.
-  real :: z_wt    ! The thickness actually used in taking the near-surface average, in H.
-  real :: k_interior  ! The (real) value of k where the interior grid starts.
-  real :: k_int2      ! The (real) value of k where the interior grid starts.
-  real :: z_interior  ! The depth where the interior grid starts, in H.
-  real :: z_ml_fix    ! The depth at which the fixed-thickness near-surface layers end, in H.
-  real :: dz_dk       ! The thickness of layers between the fixed-thickness
-                      ! near-surface layars and the interior, in H.
-  real :: Lfilt       ! A filtering lengthscale, in H.
-  logical :: maximum_depths_set ! If true, the maximum depths of interface have been set.
-  logical :: maximum_h_set      ! If true, the maximum layer thicknesses have been set.
-  real :: k2_used, k2here, dz_sum, z_max
-  integer :: k2
-  real :: h_tr, b_denom_1, b1, d1 ! Temporary variables used by the tridiagonal solver.
-  real, dimension(nz) :: c1  ! Temporary variables used by the tridiagonal solver.
-  integer :: kur1, kur2  ! The indicies at the top and bottom of an unreliable region.
-  integer :: kur_ss      ! The index to start with in the search for the next unstable region.
-  integer :: i, j, k, nkml
-
-  maximum_depths_set = allocated(CS%max_interface_depths)
-  maximum_h_set = allocated(CS%max_layer_thickness)
-
-  if (z_col(nz+1) - z_col(1) < nz*CS%min_thickness) then
-    ! This is a nearly massless total depth, so distribute the water evenly.
-    dz = (z_col(nz+1) - z_col(1)) / real(nz)
-    do K=2,nz ; z_col_new(K) = z_col(1) + dz*real(K-1) ; enddo
-  else
-    call calculate_density(T_col, S_col, p_col, rho_col, 1, nz, &
-                           eqn_of_state)
-
-    ! Find the locations of the target potential densities, flagging
-    ! locations in apparently unstable regions as not reliable.
-    call rho_interfaces_col(rho_col, h_col, z_col, CS%target_density, nz, &
-                            z_col_new, CS, reliable, debug=.true.)
-
-    ! Ensure that the interfaces are at least CS%min_thickness apart.
-    if (CS%min_thickness > 0.0) then
-      ! Move down interfaces below overly thin layers.
-      do K=2,nz ; if (z_col_new(K) < z_col_new(K-1) + CS%min_thickness) then
-        z_col_new(K) = z_col_new(K-1) + CS%min_thickness
-      endif ; enddo
-      ! Now move up any interfaces that are too close to the bottom.
-      do K=nz,2,-1 ; if (z_col_new(K) > z_col_new(K+1) - CS%min_thickness) then
-        z_col_new(K) = z_col_new(K+1) - CS%min_thickness
-      else
-        exit ! No more interfaces can be too close to the bottom.
-      endif ; enddo
-    endif
-
-    ! Fix up the unreliable regions.
-    kur_ss = 2 ! reliable(1) and reliable(nz+1) must always be true.
-    do
-      ! Search for the uppermost unreliable interface postion.
-      kur1 = nz+2
-      do K=kur_ss,nz ; if (.not.reliable(K)) then
-        kur1 = K ; exit
-      endif ; enddo
-      if (kur1 > nz) exit ! Everything is now reliable.
-
-      kur2 = kur1-1 ! For error checking.
-      do K=kur1+1,nz+1 ; if (reliable(K)) then
-        kur2 = K-1 ; kur_ss = K ; exit
-      endif ; enddo
-      if (kur2 < kur1) call MOM_error(FATAL, "Bad unreliable range.")
-
-      dz_ur = z_col_new(kur2+1) - z_col_new(kur1-1)
-  !        drho = CS%target_density(kur2+1) - CS%target_density(kur1-1)
-      ! Perhaps reset the wgt and cowgt depending on how bad the old interface
-      ! locations were.
-      wgt = 1.0 ; cowgt = 0.0 ! = 1.0-wgt
-      do K=kur1,kur2
-        z_col_new(K) = cowgt*z_col_new(K) + &
-              wgt * (z_col_new(kur1-1) + dz_ur*(K - (kur1-1)) / ((kur2 - kur1) + 2))
-      enddo
-    enddo
-
-    ! Determine which interfaces are in the s-space region and the depth extent
-    ! of this region.
-    z_wt = 0.0 ; rho_x_z = 0.0
-    H_ml_av = m_to_H*CS%Rho_ml_avg_depth
-    do k=1,nz
-      if (z_wt + h_col(k) >= H_ml_av) then
-        rho_x_z = rho_x_z + rho_col(k) * (H_ml_av - z_wt)
-        z_wt = H_ml_av
-        exit
-      else
-        rho_x_z =  rho_x_z + rho_col(k) * h_col(k)
-        z_wt = z_wt + h_col(k)
-      endif
-    enddo
-    if (z_wt > 0.0) rho_ml_av = rho_x_z / z_wt
-
-    nkml = CS%nz_fixed_surface
-    ! Find the interface that matches rho_ml_av.
-    if (rho_ml_av <= CS%target_density(nkml)) then
-      k_interior = CS%nlay_ml_offset + real(nkml)
-    elseif (rho_ml_av > CS%target_density(nz+1)) then
-      k_interior = real(nz+1)
-    else ; do K=nkml,nz
-      if ((rho_ml_av >= CS%target_density(K)) .and. &
-          (rho_ml_av <  CS%target_density(K+1))) then
-        k_interior = (CS%nlay_ml_offset + K) + &
-                (rho_ml_av - CS%target_density(K)) / &
-                (CS%target_density(K+1) - CS%target_density(K))
-        exit
-      endif
-    enddo ; endif
-    if (k_interior > real(nz+1)) k_interior = real(nz+1)
-
-    ! Linearly interpolate to find z_interior.  This could be made more sophisticated.
-    K = int(ceiling(k_interior))
-    z_interior = (K-k_interior)*z_col_new(K-1) + (1.0+(k_interior-K))*z_col_new(K)
-
-    if (CS%fix_haloclines) then
-  !       ! Identify regions above the reference pressure where the chosen
-  !       ! potential density significantly underestimates the actual
-  !       ! stratification, and use these to find a second estimate of
-  !       ! z_int_unst and k_interior.
-
-      if (CS%halocline_filter_length > 0.0) then
-        Lfilt = CS%halocline_filter_length*m_to_H
-
-        ! Filter the temperature and salnity with a fixed lengthscale.
-        h_tr = h_col(1) + H_subroundoff
-        b1 = 1.0 / (h_tr + Lfilt) ; d1 = h_tr * b1
-        T_f(1) = (b1*h_tr)*T_col(1) ;  S_f(1) = (b1*h_tr)*S_col(1)
-        do k=2,nz
-          c1(k) = Lfilt * b1
-          h_tr = h_col(k) + H_subroundoff ; b_denom_1 = h_tr + d1*Lfilt
-          b1 = 1.0 / (b_denom_1 + Lfilt) ; d1 = b_denom_1 * b1
-          T_f(k) = b1 * (h_tr*T_col(k) + Lfilt*T_f(k-1))
-          S_f(k) = b1 * (h_tr*S_col(k) + Lfilt*S_f(k-1))
-        enddo
-        do k=nz-1,1,-1
-          T_f(k) = T_f(k) + c1(k+1)*T_f(k+1) ; S_f(k) = S_f(k) + c1(k+1)*S_f(k+1)
-        enddo
-      else
-        do k=1,nz ; T_f(k) = T_col(k) ; S_f(k) = S_col(k) ; enddo
-      endif
-
-      T_int(1) = T_f(1) ; S_int(1) = S_f(1)
-      do K=2,nz
-        T_int(K) = 0.5*(T_f(k-1) + T_f(k)) ; S_int(K) = 0.5*(S_f(k-1) + S_f(k))
-        p_IS(K) = z_col(K) * H_to_Pa
-        p_R(K) = CS%ref_pressure + CS%compressibility_fraction * ( p_IS(K) - CS%ref_pressure )
-      enddo
-      T_int(nz+1) = T_f(nz) ; S_int(nz+1) = S_f(nz)
-      p_IS(nz+1) = z_col(nz+1) * H_to_Pa
-      call calculate_density_derivs(T_int, S_int, p_IS, drhoIS_dT, drhoIS_dS, 2, nz-1, &
-                                    eqn_of_state)
-      call calculate_density_derivs(T_int, S_int, p_R, drhoR_dT, drhoR_dS, 2, nz-1, &
-                                    eqn_of_state)
-      if (CS%compressibility_fraction > 0.0) then
-        call calculate_compress(T_int, S_int, p_R, rho_tmp, drho_dp, 2, nz-1, &
-                                      eqn_of_state)
-      else
-        do K=2,nz ; drho_dp(K) = 0.0 ; enddo
-      endif
-
-      H_to_cPa = CS%compressibility_fraction*H_to_Pa
-      strat_rat(1) = 1.0
-      do K=2,nz
-        drIS = drhoIS_dT(K) * (T_f(k) - T_f(k-1)) + &
-               drhoIS_dS(K) * (S_f(k) - S_f(k-1))
-        drR = (drhoR_dT(K) * (T_f(k) - T_f(k-1)) + &
-               drhoR_dS(K) * (S_f(k) - S_f(k-1))) + &
-              drho_dp(K) * (H_to_cPa*0.5*(h_col(k) + h_col(k-1)))
-
-        if (drIS <= 0.0) then
-          strat_rat(K) = 2.0 ! Maybe do this? => ; if (drR < 0.0) strat_rat(K) = -2.0
-        else
-          strat_rat(K) = 2.0*max(drR,0.0) / (drIS + abs(drR))
-        endif
-      enddo
-      strat_rat(nz+1) = 1.0
-
-      z_int_unst = 0.0 ; Fn_now = 0.0
-      Fn_zero_val = min(2.0*CS%halocline_strat_tol, &
-                        0.5*(1.0 + CS%halocline_strat_tol))
-      if (CS%halocline_strat_tol > 0.0) then
-        ! Use Adcroft's reciprocal rule.
-        I_HStol = 0.0 ; if (Fn_zero_val - CS%halocline_strat_tol > 0.0) &
-          I_HStol = 1.0 / (Fn_zero_val - CS%halocline_strat_tol)
-        do k=nz,1,-1 ; if (CS%ref_pressure > p_IS(k+1)) then
-          z_int_unst = z_int_unst + Fn_now * h_col(k)
-          if (strat_rat(K) <= Fn_zero_val) then
-            if (strat_rat(K) <= CS%halocline_strat_tol) then ; Fn_now = 1.0
-            else
-              Fn_now = max(Fn_now, (Fn_zero_val - strat_rat(K)) * I_HStol)
-            endif
-          endif
-        endif ; enddo
-      else
-        do k=nz,1,-1 ; if (CS%ref_pressure > p_IS(k+1)) then
-          z_int_unst = z_int_unst + Fn_now * h_col(k)
-          if (strat_rat(K) <= CS%halocline_strat_tol) Fn_now = 1.0
-        endif ; enddo
-      endif
-
-      if (z_interior < z_int_unst) then
-        ! Find a second estimate of the extent of the s-coordinate region.
-        kur1 = max(int(ceiling(k_interior)),2)
-        if (z_col_new(kur1-1) < z_interior) then
-          k_int2 = kur1
-          do K = kur1,nz+1 ; if (z_col_new(K) >= z_int_unst) then
-            ! This is linear interpolation again.
-            if (z_col_new(K-1) >= z_int_unst) &
-              call MOM_error(FATAL,"build_grid_SLight, bad halocline structure.")
-            k_int2 = real(K-1) + (z_int_unst - z_col_new(K-1)) / &
-                                     (z_col_new(K) - z_col_new(K-1))
-            exit
-          endif ; enddo
-          if (z_col_new(nz+1) < z_int_unst) then
-            ! This should be unnecessary.
-            z_int_unst = z_col_new(nz+1) ; k_int2 = real(nz+1)
-          endif
-
-          ! Now take the larger values.
-          if (k_int2 > k_interior) then
-            k_interior = k_int2 ; z_interior = z_int_unst
-          endif
-        endif
-      endif
-    endif  ! fix_haloclines
-
-    z_col_new(1) = 0.0
-    do K=2,nkml+1
-      z_col_new(K) = min((K-1)*CS%dz_ml_min, &
-                         z_col_new(nz+1) - CS%min_thickness*(nz+1-K))
-    enddo
-    z_ml_fix = z_col_new(nkml+1)
-    if (z_interior > z_ml_fix) then
-      dz_dk = (z_interior - z_ml_fix) / (k_interior - (nkml+1))
-      do K=nkml+2,int(floor(k_interior))
-        z_col_new(K) = z_ml_fix + dz_dk * (K - (nkml+1))
-      enddo
-    else ! The fixed-thickness z-region penetrates into the interior.
-      do K=nkml+2,nz
-        if (z_col_new(K) <= z_col_new(CS%nz_fixed_surface+1)) then
-          z_col_new(K) = z_col_new(CS%nz_fixed_surface+1)
-        else ; exit ; endif
-      enddo
-    endif
-
-    if (maximum_depths_set .and. maximum_h_set) then ; do k=2,nz
-      ! The loop bounds are 2 & nz so the top and bottom interfaces do not move.
-      ! Recall that z_col_new is positive downward.
-      z_col_new(K) = min(z_col_new(K), CS%max_interface_depths(K), &
-                            z_col_new(K-1) + CS%max_layer_thickness(k-1))
-    enddo ; elseif (maximum_depths_set) then ; do K=2,nz
-      z_col_new(K) = min(z_col_new(K), CS%max_interface_depths(K))
-    enddo ; elseif (maximum_h_set) then ; do k=2,nz
-      z_col_new(K) = min(z_col_new(K), z_col_new(K-1) + CS%max_layer_thickness(k-1))
-    enddo ; endif
-
-  endif ! Total thickness exceeds nz*CS%min_thickness.
-
-end subroutine build_slight_column
-
-!> Finds the new interface locations in a column of water that match the
-!! prescribed target densities.
-subroutine rho_interfaces_col(rho_col, h_col, z_col, rho_tgt, nz, z_col_new, &
-                              CS, reliable, debug)
-  integer,               intent(in)    :: nz      !< Number of layers
-  real, dimension(nz),   intent(in)    :: rho_col !< Initial layer reference densities.
-  real, dimension(nz),   intent(in)    :: h_col   !< Initial layer thicknesses.
-  real, dimension(nz+1), intent(in)    :: z_col   !< Initial interface heights.
-  real, dimension(nz+1), intent(in)    :: rho_tgt !< Interface target densities.
-  real, dimension(nz+1), intent(inout) :: z_col_new !< New interface heights.
-  type(regridding_CS),   intent(in)    :: CS      !< Regridding control structure
-  logical, dimension(nz+1), intent(inout) :: reliable !< If true, the interface positions
-                                                  !! are well defined from a stable region.
-  logical, optional,     intent(in) :: debug      !< If present and true, do debugging checks.
-
-  real, dimension(nz+1) :: ru_max_int ! The maximum and minimum densities in
-  real, dimension(nz+1) :: ru_min_int ! an unstable region around an interface.
-  real, dimension(nz)   :: ru_max_lay ! The maximum and minimum densities in
-  real, dimension(nz)   :: ru_min_lay ! an unstable region containing a layer.
-  real, dimension(nz,2) :: ppoly_i_E ! Edge value of polynomial
-  real, dimension(nz,2) :: ppoly_i_S ! Edge slope of polynomial
-  real, dimension(nz,DEGREE_MAX+1) :: ppoly_i_coefficients ! Coefficients of polynomial
-  logical, dimension(nz)   :: unstable_lay ! If true, this layer is in an unstable region.
-  logical, dimension(nz+1) :: unstable_int ! If true, this interface is in an unstable region.
-  real :: rt  ! The current target density, in kg m-3.
-  real :: zf  ! The fractional z-position within a layer of the target density.
-  real :: rfn
-  real :: a(5) ! Coefficients of a local polynomial minus the target density.
-  real :: zf1, zf2, rfn1, rfn2
-  real :: drfn_dzf, sgn, delta_zf, zf_prev
-  real :: tol
-  logical :: k_found ! If true, the position has been found.
-  integer :: k_layer ! The index of the stable layer containing an interface.
-  integer :: ppoly_degree
-  integer :: k, k1, k1_min, itt, max_itt, m
-
-  real :: z_sgn  ! 1 or -1, depending on whether z increases with increasing K.
-  logical :: debugging
-
-  debugging = .false. ; if (present(debug)) debugging = debug
-  max_itt = NR_ITERATIONS
-  tol = NR_TOLERANCE
-
-  z_sgn = 1.0 ; if ( z_col(1) > z_col(nz+1) ) z_sgn = -1.0
-  if (debugging) then
-    do K=1,nz
-      if (abs((z_col(K+1) - z_col(K)) - z_sgn*h_col(k)) > &
-          1.0e-14*(abs(z_col(K+1)) + abs(z_col(K)) + abs(h_col(k))) ) &
-        call MOM_error(FATAL, "rho_interfaces_col: Inconsistent z_col and h_col")
-    enddo
-  endif
-
-  if ( z_col(1) == z_col(nz+1) ) then
-    ! This is a massless column!
-    do K=1,nz+1 ; z_col_new(K) = z_col(1) ; reliable(K) = .true. ; enddo
-    return
-  endif
-
-  ! This sets up the piecewise polynomials based on the rho_col profile.
-  call regridding_set_ppolys(CS%interp_CS, rho_col, nz, h_col, ppoly_i_E, ppoly_i_S, &
-       ppoly_i_coefficients, ppoly_degree)
-
-  ! Determine the density ranges of unstably stratified segments.
-  ! Interfaces that start out in an unstably stratified segment can
-  ! only escape if they are outside of the bounds of that segment, and no
-  ! interfaces are ever mapped into an unstable segment.
-  unstable_int(1) = .false.
-  ru_max_int(1) = ppoly_i_E(1,1)
-
-  unstable_lay(1) = (ppoly_i_E(1,1) > ppoly_i_E(1,2))
-  ru_max_lay(1) = max(ppoly_i_E(1,1), ppoly_i_E(1,2))
-
-  do K=2,nz
-    unstable_int(K) = (ppoly_i_E(k-1,2) > ppoly_i_E(k,1))
-    ru_max_int(K) = max(ppoly_i_E(k-1,2), ppoly_i_E(k,1))
-    ru_min_int(K) = min(ppoly_i_E(k-1,2), ppoly_i_E(k,1))
-    if (unstable_int(K) .and. unstable_lay(k-1)) &
-      ru_max_int(K) = max(ru_max_lay(k-1), ru_max_int(K))
-
-    unstable_lay(k) = (ppoly_i_E(k,1) > ppoly_i_E(k,2))
-    ru_max_lay(k) = max(ppoly_i_E(k,1), ppoly_i_E(k,2))
-    ru_min_lay(k) = min(ppoly_i_E(k,1), ppoly_i_E(k,2))
-    if (unstable_lay(k) .and. unstable_int(K)) &
-      ru_max_lay(k) = max(ru_max_int(K), ru_max_lay(k))
-  enddo
-  unstable_int(nz+1) = .false.
-  ru_min_int(nz+1) = ppoly_i_E(nz,2)
-
-  do K=nz,1,-1
-    if (unstable_lay(k) .and. unstable_int(K+1)) &
-      ru_min_lay(k) = min(ru_min_int(K+1), ru_min_lay(k))
-
-    if (unstable_int(K) .and. unstable_lay(k)) &
-      ru_min_int(K) = min(ru_min_lay(k), ru_min_int(K))
-  enddo
-
-  z_col_new(1) = z_col(1) ; reliable(1) = .true.
-  k1_min = 1
-  do K=2,nz ! Find the locations of the various target densities for the interfaces.
-    rt = rho_tgt(K)
-    k_layer = -1
-    k_found = .false.
-
-    ! Many light layers are found at the top, so start there.
-    if (rt <= ppoly_i_E(k1_min,1)) then
-      z_col_new(K) = z_col(k1_min)
-      k_found = .true.
-      ! Do not change k1_min for the next layer.
-    elseif (k1_min == nz+1) then
-      z_col_new(K) = z_col(nz+1)
-    else
-      ! Start with the previous location and search outward.
-      if (unstable_int(K) .and. (rt >= ru_min_int(K)) .and. (rt <= ru_max_int(K))) then
-        ! This interface started in an unstable region and should not move due to remapping.
-        z_col_new(K) = z_col(K) ; reliable(K) = .false.
-        k1_min = K ; k_found = .true.
-      elseif ((rt >= ppoly_i_E(k-1,2)) .and. (rt <= ppoly_i_E(k,1))) then
-        ! This interface is already in the right place and does not move.
-        z_col_new(K) = z_col(K) ; reliable(K) = .true.
-        k1_min = K ; k_found = .true.
-      elseif (rt < ppoly_i_E(k-1,2)) then   ! Search upward
-        do k1=K-1,k1_min,-1
-          ! Check whether rt is in layer k.
-          if ((rt < ppoly_i_E(k1,2)) .and. (rt > ppoly_i_E(k1,1))) then
-            ! rt is in layer k.
-            k_layer = k1
-            k1_min = k1 ; k_found = .true. ; exit
-          elseif (unstable_lay(k1) .and. (rt >= ru_min_lay(k1)) .and. (rt <= ru_max_lay(K1))) then
-            ! rt would be found at unstable layer that it can not penetrate.
-            !   It is possible that this can never happen?
-            z_col_new(K) = z_col(K1+1) ; reliable(K) = .false.
-            k1_min = k1 ; k_found = .true. ; exit
-          endif
-          ! Check whether rt is at interface K.
-          if (k1 > 1) then ; if ((rt <= ppoly_i_E(k1,1)) .and. (rt >= ppoly_i_E(k1-1,2))) then
-            ! rt is at interface K1
-            z_col_new(K) = z_col(K1) ; reliable(K) = .true.
-            k1_min = k1 ; k_found = .true. ; exit
-          elseif (unstable_int(K1) .and. (rt >= ru_min_int(k1)) .and. (rt <= ru_max_int(K1))) then
-            ! rt would be found at an unstable interface that it can not pass.
-            !   It is possible that this can never happen?
-            z_col_new(K) = z_col(K1) ; reliable(K) = .false.
-            k1_min = k1 ; k_found = .true. ; exit
-          endif ; endif
-        enddo
-
-        if (.not.k_found) then
-          ! This should not happen unless k1_min = 1.
-          if (k1_min < 2) then
-            z_col_new(K) = z_col(k1_min)
-          else
-            z_col_new(K) = z_col(k1_min)
-          endif
-        endif
-
-      else  ! Search downward
-        do k1=K,nz
-          if ((rt < ppoly_i_E(k1,2)) .and. (rt > ppoly_i_E(k1,1))) then
-            ! rt is in layer k.
-            k_layer = k1
-            k1_min = k1 ; k_found = .true. ; exit
-          elseif (unstable_lay(k1) .and. (rt >= ru_min_lay(k1)) .and. (rt <= ru_max_lay(K1))) then
-            ! rt would be found at unstable layer that it can not penetrate.
-            !   It is possible that this can never happen?
-            z_col_new(K) = z_col(K1)
-            reliable(K) = .false.
-            k1_min = k1 ; k_found = .true. ; exit
-          endif
-          if (k1 < nz) then ; if ((rt <= ppoly_i_E(k1+1,1)) .and. (rt >= ppoly_i_E(k1,2))) then
-            ! rt is at interface K1+1
-
-            z_col_new(K) = z_col(K1+1) ; reliable(K) = .true.
-            k1_min = k1+1 ; k_found = .true. ; exit
-          elseif (unstable_int(K1+1) .and. (rt >= ru_min_int(k1+1)) .and. (rt <= ru_max_int(K1+1))) then
-            ! rt would be found at an unstable interface that it can not pass.
-            !   It is possible that this can never happen?
-            z_col_new(K) = z_col(K1+1)
-            reliable(K) = .false.
-            k1_min = k1+1 ; k_found = .true. ; exit
-          endif ; endif
-        enddo
-        if (.not.k_found) then
-          z_col_new(K) = z_col(nz+1)
-          if (rt >= ppoly_i_E(nz,2)) then
-            reliable(K) = .true.
-          else
-            reliable(K) = .false.
-          endif
-        endif
-      endif
-
-      if (k_layer > 0) then  ! The new location is inside of layer k_layer.
-        ! Note that this is coded assuming that this layer is stably stratified.
-        if (.not.(ppoly_i_E(k1,2) > ppoly_i_E(k1,1))) call MOM_error(FATAL, &
-          "build_grid_SLight: Erroneously searching for an interface in an unstratified layer.") !### COMMENT OUT LATER?
-
-        ! Use the false position method to find the location (degree <= 1) or the first guess.
-        zf = (rt - ppoly_i_E(k1,1)) / (ppoly_i_E(k1,2) - ppoly_i_E(k1,1))
-
-        if (ppoly_degree > 1) then ! Iterate to find the solution.
-          a(:) = 0.0 ; a(1) = ppoly_i_coefficients(k_layer,1) - rt
-          do m=2,ppoly_degree+1 ; a(m) = ppoly_i_coefficients(k_layer,m) ; enddo
-          ! Bracket the root.
-          zf1 = 0.0 ; rfn1 = a(1)
-          zf2 = 1.0 ; rfn2 =  a(1) + (a(2) + (a(3) + (a(4) + a(5))))
-          if (rfn1 * rfn2 > 0.0) call MOM_error(FATAL, "build_grid_SLight: Bad bracketing.") !### COMMENT OUT LATER?
-
-          do itt=1,max_itt
-            rfn = a(1) + zf*(a(2) + zf*(a(3) + zf*(a(4) + zf*a(5))))
-            ! Reset one of the ends of the bracket.
-            if (rfn * rfn1 > 0.0) then
-              zf1 = zf ; rfn1 = rfn
-            else
-              zf2 = zf ; rfn2 = rfn
-            endif
-            if (rfn1 == rfn2) exit
-
-            drfn_dzf = (a(2) + zf*(2.0*a(3) + zf*(3.0*a(4) + zf*4.0*a(5))))
-            sgn = 1.0 ; if (drfn_dzf < 0.0) sgn = -1.0
-
-            if ((sgn*(zf - rfn) >= zf1 * abs(drfn_dzf)) .and. &
-                (sgn*(zf - rfn) <= zf2 * abs(drfn_dzf))) then
-              delta_zf = -rfn / drfn_dzf
-              zf = zf + delta_zf
-            else ! Newton's method goes out of bounds, so use a false position method estimate
-              zf_prev = zf
-              zf = ( rfn2 * zf1 - rfn1 * zf2 ) / (rfn2 - rfn1)
-              delta_zf = zf - zf_prev
-            endif
-
-            if (abs(delta_zf) < tol) exit
-          enddo
-        endif
-        z_col_new(K) = z_col(k_layer) + zf * z_sgn * h_col(k_layer)
-        reliable(K) = .true.
-      endif
-
-    endif
-
-  enddo
-  z_col_new(nz+1) = z_col(nz+1) ; reliable(nz+1) = .true.
-
-end subroutine rho_interfaces_col
 
 !> Adjust dz_Interface to ensure non-negative future thicknesses
 subroutine adjust_interface_motion( nk, min_thickness, h_old, dz_int )

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -22,12 +22,12 @@ use regrid_consts, only : REGRIDDING_ARBITRARY, REGRIDDING_SIGMA_SHELF_ZSTAR
 use regrid_consts, only : REGRIDDING_HYCOM1, REGRIDDING_SLIGHT
 use regrid_interp, only : interp_CS_type, set_interp_scheme, set_interp_extrap
 
-use coord_zlike,  only : init_coord_zlike, zlike_CS, set_zlike_params, build_zstar_column
-use coord_sigma,  only : init_coord_sigma, sigma_CS, set_sigma_params, build_sigma_column
-use coord_rho,    only : init_coord_rho, rho_CS, set_rho_params, build_rho_column
+use coord_zlike,  only : init_coord_zlike, zlike_CS, set_zlike_params, build_zstar_column, end_coord_zlike
+use coord_sigma,  only : init_coord_sigma, sigma_CS, set_sigma_params, build_sigma_column, end_coord_sigma
+use coord_rho,    only : init_coord_rho, rho_CS, set_rho_params, build_rho_column, end_coord_rho
 use coord_rho,    only : old_inflate_layers_1d
-use coord_hycom,  only : init_coord_hycom, hycom_CS, set_hycom_params, build_hycom1_column
-use coord_slight, only : init_coord_slight, slight_CS, set_slight_params, build_slight_column
+use coord_hycom,  only : init_coord_hycom, hycom_CS, set_hycom_params, build_hycom1_column, end_coord_hycom
+use coord_slight, only : init_coord_slight, slight_CS, set_slight_params, build_slight_column, end_coord_slight
 
 use netcdf ! Used by check_grid_def()
 
@@ -704,11 +704,11 @@ end subroutine check_grid_def
 subroutine end_regridding(CS)
   type(regridding_CS), intent(inout) :: CS !< Regridding control structure
 
-  if (associated(CS%zlike_CS)) deallocate(CS%zlike_CS)
-  if (associated(CS%sigma_CS)) deallocate(CS%sigma_CS)
-  if (associated(CS%rho_CS)) deallocate(CS%rho_CS)
-  if (associated(CS%hycom_CS)) deallocate(CS%hycom_CS)
-  if (associated(CS%slight_CS)) deallocate(CS%slight_CS)
+  if (associated(CS%zlike_CS))  call end_coord_zlike(CS%zlike_CS)
+  if (associated(CS%sigma_CS))  call end_coord_sigma(CS%sigma_CS)
+  if (associated(CS%rho_CS))    call end_coord_rho(CS%rho_CS)
+  if (associated(CS%hycom_CS))  call end_coord_hycom(CS%hycom_CS)
+  if (associated(CS%slight_CS)) call end_coord_slight(CS%slight_CS)
 
   deallocate( CS%coordinateResolution )
   if (allocated(CS%target_density)) deallocate( CS%target_density )

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -1991,6 +1991,11 @@ subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_gri
   case (REGRIDDING_RHO)
     if (present(min_thickness)) call set_rho_params(CS%rho_CS, min_thickness=min_thickness)
     if (present(integrate_downward_for_e)) call set_rho_params(CS%rho_CS, integrate_downward_for_e=integrate_downward_for_e)
+    if (associated(CS%rho_CS) .and. (present(interp_scheme) .or. present(boundary_extrapolation))) &
+      call set_rho_params(CS%rho_CS, interp_CS=CS%interp_CS)
+  case (REGRIDDING_HYCOM1)
+    if (associated(CS%hycom_CS) .and. (present(interp_scheme) .or. present(boundary_extrapolation))) &
+      call set_hycom_params(CS%hycom_CS, interp_CS=CS%interp_CS)
   case (REGRIDDING_SLIGHT)
     if (present(min_thickness))       call set_slight_params(CS%slight_CS, min_thickness=min_thickness)
     if (present(dz_min_surface))      call set_slight_params(CS%slight_CS, dz_ml_min=dz_min_surface)
@@ -2001,6 +2006,8 @@ subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_gri
     if (present(halocline_filt_len))  call set_slight_params(CS%slight_CS, halocline_filter_length=halocline_filt_len)
     if (present(halocline_strat_tol)) call set_slight_params(CS%slight_CS, halocline_strat_tol=halocline_strat_tol)
     if (present(compress_fraction))   call set_slight_params(CS%slight_CS, compressibility_fraction=compress_fraction)
+    if (associated(CS%slight_CS) .and. (present(interp_scheme) .or. present(boundary_extrapolation))) &
+      call set_slight_params(CS%slight_CS, interp_CS=CS%interp_CS)
   end select
 
 end subroutine set_regrid_params

--- a/src/ALE/coord_hycom.F90
+++ b/src/ALE/coord_hycom.F90
@@ -1,0 +1,98 @@
+module coord_hycom
+
+use MOM_error_handler, only : MOM_error, FATAL
+use MOM_EOS,           only : EOS_type, calculate_density
+use regrid_interp,     only : interp_CS_type, build_and_interpolate_grid
+
+implicit none ; private
+
+type, public :: hycom_CS
+  private
+
+  type(interp_CS_type), pointer :: interp_CS
+  real, dimension(:),   pointer :: target_density
+  real, dimension(:),   pointer :: coordinateResolution
+  real, dimension(:),   pointer :: max_interface_depths
+  real, dimension(:),   pointer :: max_layer_thickness
+end type hycom_CS
+
+public init_coord_hycom, build_hycom1_column
+
+contains
+
+subroutine init_coord_hycom(CS, interp_CS, target_density, coordinateResolution, &
+     max_interface_depths, max_layer_thickness)
+  type(hycom_CS),       pointer :: CS
+  type(interp_CS_type), target  :: interp_CS
+  real, dimension(:),   target  :: target_density, coordinateResolution, &
+       max_interface_depths, max_layer_thickness
+
+  if (associated(CS)) call MOM_error(FATAL, "init_coord_hycom: CS already associated!")
+  allocate(CS)
+
+  CS%interp_CS            => interp_CS
+  CS%target_density       => target_density
+  CS%coordinateResolution => coordinateResolution
+  CS%max_interface_depths => max_interface_depths
+  CS%max_layer_thickness  => max_layer_thickness
+end subroutine init_coord_hycom
+
+subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, z_col, z_col_new)
+  type(hycom_CS),        intent(in)    :: CS !< Regridding control structure
+  type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
+  integer,               intent(in)    :: nz !< Number of levels
+  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in H)
+  real, dimension(nz),   intent(in)    :: T, S !< T and S for column
+  real, dimension(nz),   intent(in)    :: h  !< Layer thicknesses, in m
+  real, dimension(nz),   intent(in)    :: p_col !< Layer pressure in Pa
+  real, dimension(nz+1), intent(in)    :: z_col ! Interface positions relative to the surface in H units (m or kg m-2)
+  real, dimension(nz+1), intent(inout) :: z_col_new !< Absolute positions of interfaces
+
+  ! Local variables
+  integer   :: k
+  real, dimension(nz) :: rho_col, h_col_new ! Layer quantities
+  real :: stretching ! z* stretching, converts z* to z.
+  real :: nominal_z ! Nominal depth of interface is using z* (m or Pa)
+  real :: hNew
+  logical :: maximum_depths_set ! If true, the maximum depths of interface have been set.
+  logical :: maximum_h_set      ! If true, the maximum layer thicknesses have been set.
+
+  maximum_depths_set = allocated(CS%max_interface_depths)
+  maximum_h_set = allocated(CS%max_layer_thickness)
+
+  ! Work bottom recording potential density
+  call calculate_density(T, S, p_col, rho_col, 1, nz, eqn_of_state)
+  ! This ensures the potential density profile is monotonic
+  ! although not necessarily single valued.
+  do k = nz-1, 1, -1
+    rho_col(k) = min( rho_col(k), rho_col(k+1) )
+  enddo
+
+  ! Interpolates for the target interface position with the rho_col profile
+  ! Based on global density profile, interpolate to generate a new grid
+  call build_and_interpolate_grid(CS%interp_CS, rho_col, nz, h(:), z_col, &
+       CS%target_density, nz, h_col_new, z_col_new)
+
+  ! Sweep down the interfaces and make sure that the interface is at least
+  ! as deep as a nominal target z* grid
+  nominal_z = 0.
+  stretching = z_col(nz+1) / depth ! Stretches z* to z
+  do k = 2, nz+1
+    nominal_z = nominal_z + CS%coordinateResolution(k-1) * stretching
+    z_col_new(k) = max( z_col_new(k), nominal_z )
+    z_col_new(k) = min( z_col_new(k), z_col(nz+1) )
+  enddo
+
+  if (maximum_depths_set .and. maximum_h_set) then ; do k=2,nz
+    ! The loop bounds are 2 & nz so the top and bottom interfaces do not move.
+    ! Recall that z_col_new is positive downward.
+    z_col_new(K) = min(z_col_new(K), CS%max_interface_depths(K), &
+                       z_col_new(K-1) + CS%max_layer_thickness(k-1))
+  enddo ; elseif (maximum_depths_set) then ; do K=2,nz
+    z_col_new(K) = min(z_col_new(K), CS%max_interface_depths(K))
+  enddo ; elseif (maximum_h_set) then ; do k=2,nz
+    z_col_new(K) = min(z_col_new(K), z_col_new(K-1) + CS%max_layer_thickness(k-1))
+  enddo ; endif
+end subroutine build_hycom1_column
+
+end module coord_hycom

--- a/src/ALE/coord_hycom.F90
+++ b/src/ALE/coord_hycom.F90
@@ -65,10 +65,11 @@ subroutine end_coord_hycom(CS)
   deallocate(CS)
 end subroutine end_coord_hycom
 
-subroutine set_hycom_params(CS, max_interface_depths, max_layer_thickness)
-  type(hycom_CS),               pointer    :: CS
-  real, optional, dimension(:), intent(in) :: max_interface_depths
-  real, optional, dimension(:), intent(in) :: max_layer_thickness
+subroutine set_hycom_params(CS, max_interface_depths, max_layer_thickness, interp_CS)
+  type(hycom_CS),                 pointer    :: CS
+  real, optional, dimension(:),   intent(in) :: max_interface_depths
+  real, optional, dimension(:),   intent(in) :: max_layer_thickness
+  type(interp_CS_type), optional, intent(in) :: interp_CS
 
   if (.not. associated(CS)) call MOM_error(FATAL, "set_hycom_params: CS not associated")
 
@@ -85,6 +86,8 @@ subroutine set_hycom_params(CS, max_interface_depths, max_layer_thickness)
     allocate(CS%max_layer_thickness(CS%nk))
     CS%max_layer_thickness(:) = max_layer_thickness(:)
   endif
+
+  if (present(interp_CS)) CS%interp_CS = interp_CS
 end subroutine set_hycom_params
 
 !> Build a HyCOM coordinate column

--- a/src/ALE/coord_hycom.F90
+++ b/src/ALE/coord_hycom.F90
@@ -37,19 +37,20 @@ contains
 !> Initialise a hycom_CS with pointers to parameters
 subroutine init_coord_hycom(CS, nk, coordinateResolution, target_density, interp_CS)
   type(hycom_CS),       pointer    :: CS !< Unassociated pointer to hold the control structure
-  integer,              intent(in) :: nk
-  real, dimension(:),   intent(in) :: coordinateResolution, target_density
-  type(interp_CS_type), intent(in) :: interp_CS
+  integer,              intent(in) :: nk !< Number of layers in generated grid
+  real, dimension(:),   intent(in) :: coordinateResolution !< Z-space thicknesses (m)
+  real, dimension(:),   intent(in) :: target_density !< Interface target densities (kg/m3)
+  type(interp_CS_type), intent(in) :: interp_CS !< Controls for interpolation
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_hycom: CS already associated!")
   allocate(CS)
   allocate(CS%coordinateResolution(nk))
-  allocate(CS%target_density(nk))
+  allocate(CS%target_density(nk+1))
 
-  CS%nk                   = nk
-  CS%coordinateResolution = coordinateResolution
-  CS%target_density       = target_density
-  CS%interp_CS            = interp_CS
+  CS%nk                      = nk
+  CS%coordinateResolution(:) = coordinateResolution(:)
+  CS%target_density(:)       = target_density(:)
+  CS%interp_CS               = interp_CS
 end subroutine init_coord_hycom
 
 subroutine end_coord_hycom(CS)
@@ -72,17 +73,17 @@ subroutine set_hycom_params(CS, max_interface_depths, max_layer_thickness)
   if (.not. associated(CS)) call MOM_error(FATAL, "set_hycom_params: CS not associated")
 
   if (present(max_interface_depths)) then
-    if (size(max_interface_depths) /= CS%nk) &
+    if (size(max_interface_depths) /= CS%nk+1) &
       call MOM_error(FATAL, "set_hycom_params: max_interface_depths inconsistent size")
-    allocate(CS%max_interface_depths(CS%nk))
-    CS%max_interface_depths = max_interface_depths
+    allocate(CS%max_interface_depths(CS%nk+1))
+    CS%max_interface_depths(:) = max_interface_depths(:)
   endif
 
   if (present(max_layer_thickness)) then
     if (size(max_layer_thickness) /= CS%nk) &
       call MOM_error(FATAL, "set_hycom_params: max_layer_thickness inconsistent size")
     allocate(CS%max_layer_thickness(CS%nk))
-    CS%max_layer_thickness = max_layer_thickness
+    CS%max_layer_thickness(:) = max_layer_thickness(:)
   endif
 end subroutine set_hycom_params
 

--- a/src/ALE/coord_hycom.F90
+++ b/src/ALE/coord_hycom.F90
@@ -30,7 +30,7 @@ type, public :: hycom_CS
   type(interp_CS_type) :: interp_CS
 end type hycom_CS
 
-public init_coord_hycom, set_hycom_params, build_hycom1_column
+public init_coord_hycom, set_hycom_params, build_hycom1_column, end_coord_hycom
 
 contains
 
@@ -51,6 +51,18 @@ subroutine init_coord_hycom(CS, nk, coordinateResolution, target_density, interp
   CS%target_density       = target_density
   CS%interp_CS            = interp_CS
 end subroutine init_coord_hycom
+
+subroutine end_coord_hycom(CS)
+  type(hycom_CS), pointer :: CS
+
+  ! nothing to do
+  if (.not. associated(CS)) return
+  deallocate(CS%coordinateResolution)
+  deallocate(CS%target_density)
+  if (allocated(CS%max_interface_depths)) deallocate(CS%max_interface_depths)
+  if (allocated(CS%max_layer_thickness)) deallocate(CS%max_layer_thickness)
+  deallocate(CS)
+end subroutine end_coord_hycom
 
 subroutine set_hycom_params(CS, max_interface_depths, max_layer_thickness)
   type(hycom_CS),               pointer    :: CS

--- a/src/ALE/coord_hycom.F90
+++ b/src/ALE/coord_hycom.F90
@@ -1,3 +1,4 @@
+!> Regrid columns for the HyCOM coordinate
 module coord_hycom
 
 use MOM_error_handler, only : MOM_error, FATAL
@@ -6,13 +7,23 @@ use regrid_interp,     only : interp_CS_type, build_and_interpolate_grid
 
 implicit none ; private
 
+!> Control structure containing required parameters for the HyCOM coordinate
 type, public :: hycom_CS
   private
 
+  !> Interpolation control structure
   type(interp_CS_type), pointer :: interp_CS
+
+  !> Nominal density of interfaces
   real, dimension(:),   pointer :: target_density
+
+  !> Nominal near-surface resolution
   real, dimension(:),   pointer :: coordinateResolution
+
+  !> Maximum depths of interfaces
   real, dimension(:),   pointer :: max_interface_depths
+
+  !> Maximum thicknessoes of layers
   real, dimension(:),   pointer :: max_layer_thickness
 end type hycom_CS
 
@@ -20,9 +31,10 @@ public init_coord_hycom, build_hycom1_column
 
 contains
 
+!> Initialise a hycom_CS with pointers to parameters
 subroutine init_coord_hycom(CS, interp_CS, target_density, coordinateResolution, &
      max_interface_depths, max_layer_thickness)
-  type(hycom_CS),       pointer :: CS
+  type(hycom_CS),       pointer :: CS !< Unassociated pointer to hold the control structure
   type(interp_CS_type), target  :: interp_CS
   real, dimension(:),   target  :: target_density, coordinateResolution, &
        max_interface_depths, max_layer_thickness
@@ -37,8 +49,9 @@ subroutine init_coord_hycom(CS, interp_CS, target_density, coordinateResolution,
   CS%max_layer_thickness  => max_layer_thickness
 end subroutine init_coord_hycom
 
+!> Build a HyCOM coordinate column
 subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, z_col, z_col_new)
-  type(hycom_CS),        intent(in)    :: CS !< Regridding control structure
+  type(hycom_CS),        intent(in)    :: CS !< Coordinate control structure
   type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
   integer,               intent(in)    :: nz !< Number of levels
   real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in H)

--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -1,0 +1,274 @@
+module coord_rho
+
+use MOM_error_handler, only : MOM_error, FATAL
+use MOM_remapping,     only : remapping_CS, remapping_core_h
+use MOM_EOS,           only : EOS_type, calculate_density
+use regrid_interp,     only : interp_CS_type, regridding_set_ppolys, interpolate_grid, DEGREE_MAX
+
+implicit none ; private
+
+type, public :: rho_CS
+  private
+
+  real,                 pointer :: min_thickness
+  real,                 pointer :: ref_pressure
+  logical,              pointer :: integrate_downward_for_e
+  real, dimension(:),   pointer :: target_density
+  type(interp_CS_type), pointer :: interp_CS
+end type rho_CS
+
+!> Maximum number of regridding iterations
+integer, parameter :: NB_REGRIDDING_ITERATIONS = 1
+!> Deviation tolerance between succesive grids in regridding iterations
+real, parameter    :: DEVIATION_TOLERANCE = 1e-10
+! This CPP macro embeds some safety checks
+
+public init_coord_rho, build_rho_column, old_inflate_layers_1d
+
+contains
+
+subroutine init_coord_rho(CS, min_thickness, ref_pressure, integrate_downward_for_e, &
+     target_density, interp_CS)
+  type(rho_CS),         pointer :: CS
+  real,                 target  :: min_thickness, ref_pressure
+  logical,              target  :: integrate_downward_for_e
+  real, dimension(:),   target  :: target_density
+  type(interp_CS_type), target  :: interp_CS
+
+  if (associated(CS)) call MOM_error(FATAL, "init_coord_rho: CS already associated!")
+  allocate(CS)
+
+  CS%min_thickness            => min_thickness
+  CS%ref_pressure             => ref_pressure
+  CS%integrate_downward_for_e => integrate_downward_for_e
+  CS%target_density => target_density
+
+  CS%interp_CS => interp_CS
+end subroutine init_coord_rho
+
+subroutine build_rho_column(CS, remapCS, nz, depth, h, T, S, eqn_of_state, zInterface)
+! The algorithn operates as follows within each
+! column:
+! 1. Given T & S within each layer, the layer densities are computed.
+! 2. Based on these layer densities, a global density profile is reconstructed
+!    (this profile is monotonically increasing and may be discontinuous)
+! 3. The new grid interfaces are determined based on the target interface
+!    densities.
+! 4. T & S are remapped onto the new grid.
+! 5. Return to step 1 until convergence or until the maximum number of
+!    iterations is reached, whichever comes first.
+!------------------------------------------------------------------------------
+
+  type(rho_CS),          intent(in)    :: CS !< Regridding control structure
+  type(remapping_CS),    intent(in)    :: remapCS !< Remapping parameters and options
+  integer,               intent(in)    :: nz !< Number of levels
+  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in m)
+  real, dimension(nz),   intent(in)    :: h  !< Layer thicknesses, in m
+  real, dimension(nz),   intent(in)    :: T, S !< T and S for column
+  type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
+  real, dimension(nz+1), intent(inout) :: zInterface !< Absolute positions of interfaces
+
+  ! Local variables
+  integer   :: k, m
+  integer   :: map_index
+  integer   :: k_found
+  integer   :: count_nonzero_layers
+  real      :: deviation            ! When iterating to determine the final
+                                    ! grid, this is the deviation between two
+                                    ! successive grids.
+  real      :: threshold
+  real      :: max_thickness
+  real      :: correction
+  real, dimension(nz,2) :: ppoly_i_E            !Edge value of polynomial
+  real, dimension(nz,2) :: ppoly_i_S            !Edge slope of polynomial
+  real, dimension(nz,DEGREE_MAX+1) :: ppoly_i_coefficients !Coefficients of polynomial
+  integer   :: ppoly_degree         ! The actual degree of the polynomials.
+  real, dimension(nz) :: p, densities, T_tmp, S_tmp, Tmp
+  integer, dimension(nz) :: mapping
+  real :: dh
+  real, dimension(nz) :: h0, h1, hTmp
+  real, dimension(nz+1) :: x0, x1, xTmp
+
+  threshold = CS%min_thickness
+  p(:) = CS%ref_pressure
+  T_tmp(:) = T(:)
+  S_tmp(:) = S(:)
+  h0(:) = h(:)
+
+  ! Start iterations to build grid
+  m = 1
+  deviation = 1e10
+  do while ( ( m <= NB_REGRIDDING_ITERATIONS ) .and. &
+             ( deviation > DEVIATION_TOLERANCE ) )
+
+    ! Count number of nonzero layers within current water column
+    count_nonzero_layers = 0
+    do k = 1,nz
+      if ( h0(k) > threshold ) then
+        count_nonzero_layers = count_nonzero_layers + 1
+      end if
+    end do
+
+    ! If there is at most one nonzero layer, stop here (no regridding)
+    if ( count_nonzero_layers <= 1 ) then
+      h1(:) = h0(:)
+      exit  ! stop iterations here
+    end if
+
+    ! Build new grid containing only nonzero layers
+    map_index = 1
+    correction = 0.0
+    do k = 1,nz
+      if ( h0(k) > threshold ) then
+        mapping(map_index) = k
+        hTmp(map_index) = h0(k)
+        map_index = map_index + 1
+      else
+        correction = correction + h0(k)
+      end if
+    end do
+
+    max_thickness = hTmp(1)
+    k_found = 1
+    do k = 1,count_nonzero_layers
+      if ( hTmp(k) > max_thickness ) then
+        max_thickness = hTmp(k)
+        k_found = k
+      end if
+    end do
+
+    hTmp(k_found) = hTmp(k_found) + correction
+
+    xTmp(1) = 0.0
+    do k = 1,count_nonzero_layers
+      xTmp(k+1) = xTmp(k) + hTmp(k)
+    end do
+
+    ! Compute densities within current water column
+    call calculate_density( T_tmp, S_tmp, p, densities,&
+                             1, nz, eqn_of_state )
+
+    do k = 1,count_nonzero_layers
+      densities(k) = densities(mapping(k))
+    end do
+
+    ! One regridding iteration
+    call regridding_set_ppolys(CS%interp_CS, densities, count_nonzero_layers, hTmp, &
+         ppoly_i_E, ppoly_i_S, ppoly_i_coefficients, ppoly_degree)
+    ! Based on global density profile, interpolate to generate a new grid
+    call interpolate_grid(count_nonzero_layers, hTmp, xTmp, ppoly_i_E, ppoly_i_coefficients, &
+                          CS%target_density, ppoly_degree, nz, h1, x1 )
+
+    call old_inflate_layers_1d( CS%min_thickness, nz, h1 )
+    x1(1) = 0.0 ; do k = 1,nz ; x1(k+1) = x1(k) + h1(k) ; end do
+
+    ! Remap T and S from previous grid to new grid
+    do k = 1,nz
+      h1(k) = x1(k+1) - x1(k)
+    end do
+
+    call remapping_core_h(nz, h0, S, nz, h1, Tmp, remapCS)
+    S_tmp(:) = Tmp(:)
+
+    call remapping_core_h(nz, h0, T, nz, h1, Tmp, remapCS)
+    T_tmp(:) = Tmp(:)
+
+    ! Compute the deviation between two successive grids
+    deviation = 0.0
+    x0(1) = 0.0
+    x1(1) = 0.0
+    do k = 2,nz
+      x0(k) = x0(k-1) + h0(k-1)
+      x1(k) = x1(k-1) + h1(k-1)
+      deviation = deviation + (x0(k)-x1(k))**2
+    end do
+    deviation = sqrt( deviation / (nz-1) )
+
+    m = m + 1
+
+    ! Copy final grid onto start grid for next iteration
+    h0(:) = h1(:)
+
+  end do ! end regridding iterations
+
+  if (CS%integrate_downward_for_e) then
+    zInterface(1) = 0.
+    do k = 1,nz
+      zInterface(k+1) = zInterface(k) - h1(k)
+      ! Adjust interface position to accomodate inflating layers
+      ! without disturbing the interface above
+    enddo
+  else
+    ! The rest of the model defines grids integrating up from the bottom
+    zInterface(nz+1) = -depth
+    do k = nz,1,-1
+      zInterface(k) = zInterface(k+1) + h1(k)
+      ! Adjust interface position to accomodate inflating layers
+      ! without disturbing the interface above
+    enddo
+  endif
+
+end subroutine build_rho_column
+
+!------------------------------------------------------------------------------
+! Inflate vanished layers to finite (nonzero) width
+!------------------------------------------------------------------------------
+subroutine old_inflate_layers_1d( minThickness, N, h )
+
+  ! Argument
+  real,                intent(in) :: minThickness
+  integer,             intent(in) :: N
+  real,                intent(inout) :: h(:)
+
+  ! Local variable
+  integer   :: k
+  integer   :: k_found
+  integer   :: count_nonzero_layers
+  real      :: delta
+  real      :: correction
+  real      :: maxThickness
+
+  ! Count number of nonzero layers
+  count_nonzero_layers = 0
+  do k = 1,N
+    if ( h(k) > minThickness ) then
+      count_nonzero_layers = count_nonzero_layers + 1
+    end if
+  end do
+
+  ! If all layer thicknesses are greater than the threshold, exit routine
+  if ( count_nonzero_layers == N ) return
+
+  ! If all thicknesses are zero, inflate them all and exit
+  if ( count_nonzero_layers == 0 ) then
+    do k = 1,N
+      h(k) = minThickness
+    end do
+    return
+  end if
+
+  ! Inflate zero layers
+  correction = 0.0
+  do k = 1,N
+    if ( h(k) <= minThickness ) then
+      delta = minThickness - h(k)
+      correction = correction + delta
+      h(k) = h(k) + delta
+    end if
+  end do
+
+  ! Modify thicknesses of nonzero layers to ensure volume conservation
+  maxThickness = h(1)
+  k_found = 1
+  do k = 1,N
+    if ( h(k) > maxThickness ) then
+      maxThickness = h(k)
+      k_found = k
+    end if
+  end do
+
+  h(k_found) = h(k_found) - correction
+
+end subroutine old_inflate_layers_1d
+
+end module coord_rho

--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -69,15 +69,17 @@ subroutine end_coord_rho(CS)
   deallocate(CS)
 end subroutine end_coord_rho
 
-subroutine set_rho_params(CS, min_thickness, integrate_downward_for_e)
-  type(rho_CS),      pointer    :: CS
-  real,    optional, intent(in) :: min_thickness
-  logical, optional, intent(in) :: integrate_downward_for_e
+subroutine set_rho_params(CS, min_thickness, integrate_downward_for_e, interp_CS)
+  type(rho_CS),                   pointer    :: CS
+  real,                 optional, intent(in) :: min_thickness
+  logical,              optional, intent(in) :: integrate_downward_for_e
+  type(interp_CS_type), optional, intent(in) :: interp_CS
 
   if (.not. associated(CS)) call MOM_error(FATAL, "set_rho_params: CS not associated")
 
   if (present(min_thickness)) CS%min_thickness = min_thickness
   if (present(integrate_downward_for_e)) CS%integrate_downward_for_e = integrate_downward_for_e
+  if (present(interp_CS)) CS%interp_CS = interp_CS
 end subroutine set_rho_params
 
 subroutine build_rho_column(CS, remapCS, nz, depth, h, T, S, eqn_of_state, zInterface)

--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -52,12 +52,12 @@ subroutine init_coord_rho(CS, nk, ref_pressure, target_density, interp_CS)
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_rho: CS already associated!")
   allocate(CS)
-  allocate(CS%target_density(nk))
+  allocate(CS%target_density(nk+1))
 
-  CS%nk             = nk
-  CS%ref_pressure   = ref_pressure
-  CS%target_density = target_density
-  CS%interp_CS      = interp_CS
+  CS%nk                = nk
+  CS%ref_pressure      = ref_pressure
+  CS%target_density(:) = target_density(:)
+  CS%interp_CS         = interp_CS
 end subroutine init_coord_rho
 
 subroutine end_coord_rho(CS)

--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -38,7 +38,7 @@ integer, parameter :: NB_REGRIDDING_ITERATIONS = 1
 real, parameter    :: DEVIATION_TOLERANCE = 1e-10
 ! This CPP macro embeds some safety checks
 
-public init_coord_rho, set_rho_params, build_rho_column, old_inflate_layers_1d
+public init_coord_rho, set_rho_params, build_rho_column, old_inflate_layers_1d, end_coord_rho
 
 contains
 
@@ -59,6 +59,15 @@ subroutine init_coord_rho(CS, nk, ref_pressure, target_density, interp_CS)
   CS%target_density = target_density
   CS%interp_CS      = interp_CS
 end subroutine init_coord_rho
+
+subroutine end_coord_rho(CS)
+  type(rho_CS), pointer :: CS
+
+  ! nothing to do
+  if (.not. associated(CS)) return
+  deallocate(CS%target_density)
+  deallocate(CS)
+end subroutine end_coord_rho
 
 subroutine set_rho_params(CS, min_thickness, integrate_downward_for_e)
   type(rho_CS),      pointer    :: CS

--- a/src/ALE/coord_sigma.F90
+++ b/src/ALE/coord_sigma.F90
@@ -1,0 +1,51 @@
+module coord_sigma
+
+use MOM_error_handler, only : MOM_error, FATAL
+
+implicit none ; private
+
+type, public :: sigma_CS
+  private
+
+  real,               pointer :: min_thickness
+  real, dimension(:), pointer :: coordinateResolution
+end type sigma_CS
+
+public init_coord_sigma, build_sigma_column
+
+contains
+
+subroutine init_coord_sigma(CS, min_thickness, coordinateResolution)
+  type(sigma_CS),     pointer :: CS
+  real,               target  :: min_thickness
+  real, dimension(:), target  :: coordinateResolution
+
+  if (associated(CS)) call MOM_error(FATAL, "init_coord_sigma: CS already associated!")
+  allocate(CS)
+
+  CS%min_thickness => min_thickness
+  CS%coordinateResolution => coordinateResolution
+end subroutine init_coord_sigma
+
+subroutine build_sigma_column(CS, nz, depth, totalThickness, zInterface)
+  type(sigma_CS),        intent(in)    :: CS !< Coordinate control structure
+  integer,               intent(in)    :: nz !< Number of levels
+  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in m)
+  real,                  intent(in)    :: totalThickness !< Column thickness (positive in m)
+  real, dimension(nz+1), intent(inout) :: zInterface !< Absolute positions of interfaces
+
+  ! Local variables
+  integer :: k
+
+  zInterface(nz+1) = -depth
+  do k = nz,1,-1
+    zInterface(k) = zInterface(k+1) + (totalThickness * CS%coordinateResolution(k))
+    ! Adjust interface position to accomodate inflating layers
+    ! without disturbing the interface above
+    if (zInterface(k) < (zInterface(k+1) + CS%min_thickness)) then
+      zInterface(k) = zInterface(k+1) + CS%min_thickness
+    endif
+  enddo
+end subroutine build_sigma_column
+
+end module coord_sigma

--- a/src/ALE/coord_sigma.F90
+++ b/src/ALE/coord_sigma.F90
@@ -9,29 +9,43 @@ implicit none ; private
 type, public :: sigma_CS
   private
 
+  !> Number of levels
+  integer :: nk
+
   !> Minimum thickness allowed for layers
-  real,               pointer :: min_thickness
+  real :: min_thickness
 
   !> Target coordinate resolution
-  real, dimension(:), pointer :: coordinateResolution
+  real, allocatable, dimension(:) :: coordinateResolution
 end type sigma_CS
 
-public init_coord_sigma, build_sigma_column
+public init_coord_sigma, set_sigma_params, build_sigma_column
 
 contains
 
 !> Initialise a sigma_CS with pointers to parameters
-subroutine init_coord_sigma(CS, min_thickness, coordinateResolution)
-  type(sigma_CS),     pointer :: CS !< Unassociated pointer to hold the control structure
-  real,               target  :: min_thickness
-  real, dimension(:), target  :: coordinateResolution
+subroutine init_coord_sigma(CS, nk, coordinateResolution)
+  type(sigma_CS),     pointer    :: CS !< Unassociated pointer to hold the control structure
+  integer,            intent(in) :: nk
+  real, dimension(:), intent(in) :: coordinateResolution
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_sigma: CS already associated!")
   allocate(CS)
+  allocate(CS%coordinateResolution(nk))
 
-  CS%min_thickness => min_thickness
-  CS%coordinateResolution => coordinateResolution
+  CS%nk                   = nk
+  CS%coordinateResolution = coordinateResolution
 end subroutine init_coord_sigma
+
+subroutine set_sigma_params(CS, min_thickness)
+  type(sigma_CS), pointer    :: CS
+  real, optional, intent(in) :: min_thickness
+
+  if (.not. associated(CS)) call MOM_error(FATAL, "set_sigma_params: CS not associated")
+
+  if (present(min_thickness)) CS%min_thickness = min_thickness
+end subroutine set_sigma_params
+
 
 !> Build a sigma coordinate column
 subroutine build_sigma_column(CS, nz, depth, totalThickness, zInterface)

--- a/src/ALE/coord_sigma.F90
+++ b/src/ALE/coord_sigma.F90
@@ -19,7 +19,7 @@ type, public :: sigma_CS
   real, allocatable, dimension(:) :: coordinateResolution
 end type sigma_CS
 
-public init_coord_sigma, set_sigma_params, build_sigma_column
+public init_coord_sigma, set_sigma_params, build_sigma_column, end_coord_sigma
 
 contains
 
@@ -36,6 +36,15 @@ subroutine init_coord_sigma(CS, nk, coordinateResolution)
   CS%nk                   = nk
   CS%coordinateResolution = coordinateResolution
 end subroutine init_coord_sigma
+
+subroutine end_coord_sigma(CS)
+  type(sigma_CS), pointer :: CS
+
+  ! nothing to do
+  if (.not. associated(CS)) return
+  deallocate(CS%coordinateResolution)
+  deallocate(CS)
+end subroutine end_coord_sigma
 
 subroutine set_sigma_params(CS, min_thickness)
   type(sigma_CS), pointer    :: CS

--- a/src/ALE/coord_sigma.F90
+++ b/src/ALE/coord_sigma.F90
@@ -1,13 +1,18 @@
+!> Regrid columns for the sigma coordinate
 module coord_sigma
 
 use MOM_error_handler, only : MOM_error, FATAL
 
 implicit none ; private
 
+!> Control structure containing required parameters for the sigma coordinate
 type, public :: sigma_CS
   private
 
+  !> Minimum thickness allowed for layers
   real,               pointer :: min_thickness
+
+  !> Target coordinate resolution
   real, dimension(:), pointer :: coordinateResolution
 end type sigma_CS
 
@@ -15,8 +20,9 @@ public init_coord_sigma, build_sigma_column
 
 contains
 
+!> Initialise a sigma_CS with pointers to parameters
 subroutine init_coord_sigma(CS, min_thickness, coordinateResolution)
-  type(sigma_CS),     pointer :: CS
+  type(sigma_CS),     pointer :: CS !< Unassociated pointer to hold the control structure
   real,               target  :: min_thickness
   real, dimension(:), target  :: coordinateResolution
 
@@ -27,6 +33,7 @@ subroutine init_coord_sigma(CS, min_thickness, coordinateResolution)
   CS%coordinateResolution => coordinateResolution
 end subroutine init_coord_sigma
 
+!> Build a sigma coordinate column
 subroutine build_sigma_column(CS, nz, depth, totalThickness, zInterface)
   type(sigma_CS),        intent(in)    :: CS !< Coordinate control structure
   integer,               intent(in)    :: nz !< Number of levels

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -97,19 +97,20 @@ end subroutine end_coord_slight
 subroutine set_slight_params(CS, max_interface_depths, max_layer_thickness, &
      min_thickness, compressibility_fraction, &
      dz_ml_min, nz_fixed_surface, Rho_ML_avg_depth, nlay_ML_offset, fix_haloclines, &
-     halocline_filter_length, halocline_strat_tol)
-  type(slight_CS),                 pointer     :: CS
-  real,    optional, dimension(:), intent(in)  :: max_interface_depths
-  real,    optional, dimension(:), intent(in)  :: max_layer_thickness
-  real,    optional,               intent(in)  :: min_thickness
-  real,    optional,               intent(in)  :: compressibility_fraction
-  real,    optional,               intent(in)  :: dz_ml_min
-  integer, optional,               intent(in)  :: nz_fixed_surface
-  real,    optional,               intent(in)  :: Rho_ML_avg_depth
-  real,    optional,               intent(in)  :: nlay_ML_offset
-  logical, optional,               intent(in)  :: fix_haloclines
-  real,    optional,               intent(in)  :: halocline_filter_length
-  real,    optional,               intent(in)  :: halocline_strat_tol
+     halocline_filter_length, halocline_strat_tol, interp_CS)
+  type(slight_CS),                 pointer    :: CS
+  real,    optional, dimension(:), intent(in) :: max_interface_depths
+  real,    optional, dimension(:), intent(in) :: max_layer_thickness
+  real,    optional,               intent(in) :: min_thickness
+  real,    optional,               intent(in) :: compressibility_fraction
+  real,    optional,               intent(in) :: dz_ml_min
+  integer, optional,               intent(in) :: nz_fixed_surface
+  real,    optional,               intent(in) :: Rho_ML_avg_depth
+  real,    optional,               intent(in) :: nlay_ML_offset
+  logical, optional,               intent(in) :: fix_haloclines
+  real,    optional,               intent(in) :: halocline_filter_length
+  real,    optional,               intent(in) :: halocline_strat_tol
+  type(interp_CS_type), optional,  intent(in) :: interp_CS
 
   if (.not. associated(CS)) call MOM_error(FATAL, "set_slight_params: CS not associated")
 
@@ -141,6 +142,8 @@ subroutine set_slight_params(CS, max_interface_depths, max_layer_thickness, &
         "HALOCLINE_STRAT_TOL must not exceed 1.0.")
     CS%halocline_strat_tol = halocline_strat_tol
   endif
+
+  if (present(interp_CS)) CS%interp_CS = interp_CS
 end subroutine set_slight_params
 
 !> Build a SLight coordinate column

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -1,3 +1,4 @@
+!> Regrid columns for the SLight coordinate
 module coord_slight
 
 use MOM_error_handler, only : MOM_error, FATAL
@@ -8,6 +9,7 @@ use regrid_interp,     only : NR_ITERATIONS, NR_TOLERANCE, DEGREE_MAX
 
 implicit none ; private
 
+!> Control structure containing required parameters for the SLight coordinate
 type, public :: slight_CS
   private
 
@@ -33,12 +35,13 @@ public init_coord_slight, build_slight_column
 
 contains
 
+!> Initialise a slight_CS with pointers to parameters
 subroutine init_coord_slight(CS, min_thickness, Rho_ml_avg_depth, nz_fixed_surface, &
      nlay_ml_offset, fix_haloclines, halocline_filter_length, ref_pressure, &
      compressibility_fraction, halocline_strat_tol, dz_ml_min, max_interface_depths, &
      max_layer_thickness, target_density, interp_CS)
 
-  type(slight_CS), pointer :: CS
+  type(slight_CS), pointer :: CS !< Unassociated pointer to hold the control structure
   real, target :: min_thickness, Rho_ml_avg_depth, nlay_ml_offset, halocline_filter_length, &
        ref_pressure, compressibility_fraction, halocline_strat_tol, dz_ml_min
   integer, target :: nz_fixed_surface
@@ -67,9 +70,10 @@ subroutine init_coord_slight(CS, min_thickness, Rho_ml_avg_depth, nz_fixed_surfa
   CS%interp_CS => interp_CS
 end subroutine init_coord_slight
 
+!> Build a SLight coordinate column
 subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff, &
                                 nz, depth, h_col, T_col, S_col, p_col, z_col, z_col_new)
-  type(slight_CS),       intent(in)    :: CS !< Regridding control structure
+  type(slight_CS),       intent(in)    :: CS !< Coordinate control structure
   type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
   real,                  intent(in)    :: H_to_Pa !< GV%H_to_Pa
   real,                  intent(in)    :: m_to_H  !< GV%m_to_H
@@ -368,7 +372,7 @@ subroutine rho_interfaces_col(rho_col, h_col, z_col, rho_tgt, nz, z_col_new, &
   real, dimension(nz+1), intent(in)    :: z_col   !< Initial interface heights.
   real, dimension(nz+1), intent(in)    :: rho_tgt !< Interface target densities.
   real, dimension(nz+1), intent(inout) :: z_col_new !< New interface heights.
-  type(slight_CS),       intent(in)    :: CS      !< Regridding control structure
+  type(slight_CS),       intent(in)    :: CS      !< Coordinate control structure
   logical, dimension(nz+1), intent(inout) :: reliable !< If true, the interface positions
                                                   !! are well defined from a stable region.
   logical, optional,     intent(in) :: debug      !< If present and true, do debugging checks.

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -63,7 +63,7 @@ type, public :: slight_CS
   type(interp_CS_type) :: interp_CS
 end type slight_CS
 
-public init_coord_slight, set_slight_params, build_slight_column
+public init_coord_slight, set_slight_params, build_slight_column, end_coord_slight
 
 contains
 
@@ -84,6 +84,15 @@ subroutine init_coord_slight(CS, nk, ref_pressure, target_density, interp_CS)
   CS%target_density = target_density
   CS%interp_CS      = interp_CS
 end subroutine init_coord_slight
+
+subroutine end_coord_slight(CS)
+  type(slight_CS), pointer :: CS
+
+  ! nothing to do
+  if (.not. associated(CS)) return
+  deallocate(CS%target_density)
+  deallocate(CS)
+end subroutine end_coord_slight
 
 subroutine set_slight_params(CS, max_interface_depths, max_layer_thickness, &
      min_thickness, compressibility_fraction, &

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -77,12 +77,12 @@ subroutine init_coord_slight(CS, nk, ref_pressure, target_density, interp_CS)
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_slight: CS already associated!")
   allocate(CS)
-  allocate(CS%target_density(nk))
+  allocate(CS%target_density(nk+1))
 
-  CS%nk             = nk
-  CS%ref_pressure   = ref_pressure
-  CS%target_density = target_density
-  CS%interp_CS      = interp_CS
+  CS%nk                = nk
+  CS%ref_pressure      = ref_pressure
+  CS%target_density(:) = target_density(:)
+  CS%interp_CS         = interp_CS
 end subroutine init_coord_slight
 
 subroutine end_coord_slight(CS)
@@ -114,17 +114,17 @@ subroutine set_slight_params(CS, max_interface_depths, max_layer_thickness, &
   if (.not. associated(CS)) call MOM_error(FATAL, "set_slight_params: CS not associated")
 
   if (present(max_interface_depths)) then
-    if (size(max_interface_depths) /= CS%nk) &
+    if (size(max_interface_depths) /= CS%nk+1) &
       call MOM_error(FATAL, "set_slight_params: max_interface_depths inconsistent size")
-    allocate(CS%max_interface_depths(CS%nk))
-    CS%max_interface_depths = max_interface_depths
+    allocate(CS%max_interface_depths(CS%nk+1))
+    CS%max_interface_depths(:) = max_interface_depths(:)
   endif
 
   if (present(max_layer_thickness)) then
     if (size(max_layer_thickness) /= CS%nk) &
       call MOM_error(FATAL, "set_slight_params: max_layer_thickness inconsistent size")
     allocate(CS%max_layer_thickness(CS%nk))
-    CS%max_layer_thickness = max_layer_thickness
+    CS%max_layer_thickness(:) = max_layer_thickness(:)
   endif
 
   if (present(min_thickness)) CS%min_thickness = min_thickness

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -1,0 +1,605 @@
+module coord_slight
+
+use MOM_error_handler, only : MOM_error, FATAL
+use MOM_EOS,           only : EOS_type, calculate_compress
+use MOM_EOS,           only : calculate_density, calculate_density_derivs
+use regrid_interp,     only : interp_CS_type, regridding_set_ppolys
+use regrid_interp,     only : NR_ITERATIONS, NR_TOLERANCE, DEGREE_MAX
+
+implicit none ; private
+
+type, public :: slight_CS
+  private
+
+  real,    pointer :: min_thickness
+  real,    pointer :: Rho_ml_avg_depth
+  integer, pointer :: nz_fixed_surface
+  real,    pointer :: nlay_ml_offset
+  logical, pointer :: fix_haloclines
+  real,    pointer :: halocline_filter_length
+  real,    pointer :: ref_pressure
+  real,    pointer :: compressibility_fraction
+  real,    pointer :: halocline_strat_tol
+  real,    pointer :: dz_ml_min
+
+  real, dimension(:), pointer :: max_interface_depths
+  real, dimension(:), pointer :: max_layer_thickness
+  real, dimension(:), pointer :: target_density
+
+  type(interp_CS_type), pointer :: interp_CS
+end type slight_CS
+
+public init_coord_slight, build_slight_column
+
+contains
+
+subroutine init_coord_slight(CS, min_thickness, Rho_ml_avg_depth, nz_fixed_surface, &
+     nlay_ml_offset, fix_haloclines, halocline_filter_length, ref_pressure, &
+     compressibility_fraction, halocline_strat_tol, dz_ml_min, max_interface_depths, &
+     max_layer_thickness, target_density, interp_CS)
+
+  type(slight_CS), pointer :: CS
+  real, target :: min_thickness, Rho_ml_avg_depth, nlay_ml_offset, halocline_filter_length, &
+       ref_pressure, compressibility_fraction, halocline_strat_tol, dz_ml_min
+  integer, target :: nz_fixed_surface
+  logical, target :: fix_haloclines
+  real, dimension(:), target :: max_interface_depths, max_layer_thickness, target_density
+  type(interp_CS_type), target :: interp_CS
+
+  if (associated(CS)) call MOM_error(FATAL, "init_coord_slight: CS already associated!")
+  allocate(CS)
+
+  CS%min_thickness            => min_thickness
+  CS%Rho_ml_avg_depth         => Rho_ml_avg_depth
+  CS%nz_fixed_surface         => nz_fixed_surface
+  CS%nlay_ml_offset           => nlay_ml_offset
+  CS%fix_haloclines           => fix_haloclines
+  CS%halocline_filter_length  => halocline_filter_length
+  CS%ref_pressure             => ref_pressure
+  CS%compressibility_fraction => compressibility_fraction
+  CS%halocline_strat_tol      => halocline_strat_tol
+  CS%dz_ml_min                => dz_ml_min
+
+  CS%max_interface_depths => max_interface_depths
+  CS%max_layer_thickness  => max_layer_thickness
+  CS%target_density       => target_density
+
+  CS%interp_CS => interp_CS
+end subroutine init_coord_slight
+
+subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff, &
+                                nz, depth, h_col, T_col, S_col, p_col, z_col, z_col_new)
+  type(slight_CS),       intent(in)    :: CS !< Regridding control structure
+  type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
+  real,                  intent(in)    :: H_to_Pa !< GV%H_to_Pa
+  real,                  intent(in)    :: m_to_H  !< GV%m_to_H
+  real,                  intent(in)    :: H_subroundoff !< GV%H_subroundoff
+  integer,               intent(in)    :: nz !< Number of levels
+  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in m)
+  real, dimension(nz),   intent(in)    :: T_col, S_col !< T and S for column
+  real, dimension(nz),   intent(in)    :: h_col !< Layer thicknesses, in m
+  real, dimension(nz),   intent(in)    :: p_col !< Layer quantities
+  real, dimension(nz+1), intent(in)    :: z_col !< Interface positions relative to the surface in H units (m or kg m-2)
+  real, dimension(nz+1), intent(inout) :: z_col_new !< Absolute positions of interfaces
+
+  ! Local variables
+  real, dimension(nz) :: rho_col ! Layer quantities
+  real, dimension(nz) :: T_f, S_f  ! Filtered ayer quantities
+  logical, dimension(nz+1) :: reliable  ! If true, this interface is in a reliable position.
+  real, dimension(nz+1) :: T_int, S_int ! Temperature and salinity interpolated to interfaces.
+  real, dimension(nz+1) :: rho_tmp, drho_dp, p_IS, p_R
+  real, dimension(nz+1) :: drhoIS_dT, drhoIS_dS
+  real, dimension(nz+1) :: drhoR_dT, drhoR_dS
+  real, dimension(nz+1) :: strat_rat
+  real :: H_to_cPa
+  real :: drIS, drR, Fn_now, I_HStol, Fn_zero_val
+  real :: z_int_unst
+  real :: dz      ! A uniform layer thickness in very shallow water, in H.
+  real :: dz_ur   ! The total thickness of an unstable region, in H.
+  real :: wgt, cowgt  ! A weight and its complement, nondim.
+  real :: rho_ml_av ! The average potential density in a near-surface region, in kg m-3.
+  real :: H_ml_av ! A thickness to try to use in taking the near-surface average, in H.
+  real :: rho_x_z ! A cumulative integral of a density, in kg m-3 H.
+  real :: z_wt    ! The thickness actually used in taking the near-surface average, in H.
+  real :: k_interior  ! The (real) value of k where the interior grid starts.
+  real :: k_int2      ! The (real) value of k where the interior grid starts.
+  real :: z_interior  ! The depth where the interior grid starts, in H.
+  real :: z_ml_fix    ! The depth at which the fixed-thickness near-surface layers end, in H.
+  real :: dz_dk       ! The thickness of layers between the fixed-thickness
+                      ! near-surface layars and the interior, in H.
+  real :: Lfilt       ! A filtering lengthscale, in H.
+  logical :: maximum_depths_set ! If true, the maximum depths of interface have been set.
+  logical :: maximum_h_set      ! If true, the maximum layer thicknesses have been set.
+  real :: k2_used, k2here, dz_sum, z_max
+  integer :: k2
+  real :: h_tr, b_denom_1, b1, d1 ! Temporary variables used by the tridiagonal solver.
+  real, dimension(nz) :: c1  ! Temporary variables used by the tridiagonal solver.
+  integer :: kur1, kur2  ! The indicies at the top and bottom of an unreliable region.
+  integer :: kur_ss      ! The index to start with in the search for the next unstable region.
+  integer :: i, j, k, nkml
+
+  maximum_depths_set = allocated(CS%max_interface_depths)
+  maximum_h_set = allocated(CS%max_layer_thickness)
+
+  if (z_col(nz+1) - z_col(1) < nz*CS%min_thickness) then
+    ! This is a nearly massless total depth, so distribute the water evenly.
+    dz = (z_col(nz+1) - z_col(1)) / real(nz)
+    do K=2,nz ; z_col_new(K) = z_col(1) + dz*real(K-1) ; enddo
+  else
+    call calculate_density(T_col, S_col, p_col, rho_col, 1, nz, &
+                           eqn_of_state)
+
+    ! Find the locations of the target potential densities, flagging
+    ! locations in apparently unstable regions as not reliable.
+    call rho_interfaces_col(rho_col, h_col, z_col, CS%target_density, nz, &
+                            z_col_new, CS, reliable, debug=.true.)
+
+    ! Ensure that the interfaces are at least CS%min_thickness apart.
+    if (CS%min_thickness > 0.0) then
+      ! Move down interfaces below overly thin layers.
+      do K=2,nz ; if (z_col_new(K) < z_col_new(K-1) + CS%min_thickness) then
+        z_col_new(K) = z_col_new(K-1) + CS%min_thickness
+      endif ; enddo
+      ! Now move up any interfaces that are too close to the bottom.
+      do K=nz,2,-1 ; if (z_col_new(K) > z_col_new(K+1) - CS%min_thickness) then
+        z_col_new(K) = z_col_new(K+1) - CS%min_thickness
+      else
+        exit ! No more interfaces can be too close to the bottom.
+      endif ; enddo
+    endif
+
+    ! Fix up the unreliable regions.
+    kur_ss = 2 ! reliable(1) and reliable(nz+1) must always be true.
+    do
+      ! Search for the uppermost unreliable interface postion.
+      kur1 = nz+2
+      do K=kur_ss,nz ; if (.not.reliable(K)) then
+        kur1 = K ; exit
+      endif ; enddo
+      if (kur1 > nz) exit ! Everything is now reliable.
+
+      kur2 = kur1-1 ! For error checking.
+      do K=kur1+1,nz+1 ; if (reliable(K)) then
+        kur2 = K-1 ; kur_ss = K ; exit
+      endif ; enddo
+      if (kur2 < kur1) call MOM_error(FATAL, "Bad unreliable range.")
+
+      dz_ur = z_col_new(kur2+1) - z_col_new(kur1-1)
+  !        drho = CS%target_density(kur2+1) - CS%target_density(kur1-1)
+      ! Perhaps reset the wgt and cowgt depending on how bad the old interface
+      ! locations were.
+      wgt = 1.0 ; cowgt = 0.0 ! = 1.0-wgt
+      do K=kur1,kur2
+        z_col_new(K) = cowgt*z_col_new(K) + &
+              wgt * (z_col_new(kur1-1) + dz_ur*(K - (kur1-1)) / ((kur2 - kur1) + 2))
+      enddo
+    enddo
+
+    ! Determine which interfaces are in the s-space region and the depth extent
+    ! of this region.
+    z_wt = 0.0 ; rho_x_z = 0.0
+    H_ml_av = m_to_H*CS%Rho_ml_avg_depth
+    do k=1,nz
+      if (z_wt + h_col(k) >= H_ml_av) then
+        rho_x_z = rho_x_z + rho_col(k) * (H_ml_av - z_wt)
+        z_wt = H_ml_av
+        exit
+      else
+        rho_x_z =  rho_x_z + rho_col(k) * h_col(k)
+        z_wt = z_wt + h_col(k)
+      endif
+    enddo
+    if (z_wt > 0.0) rho_ml_av = rho_x_z / z_wt
+
+    nkml = CS%nz_fixed_surface
+    ! Find the interface that matches rho_ml_av.
+    if (rho_ml_av <= CS%target_density(nkml)) then
+      k_interior = CS%nlay_ml_offset + real(nkml)
+    elseif (rho_ml_av > CS%target_density(nz+1)) then
+      k_interior = real(nz+1)
+    else ; do K=nkml,nz
+      if ((rho_ml_av >= CS%target_density(K)) .and. &
+          (rho_ml_av <  CS%target_density(K+1))) then
+        k_interior = (CS%nlay_ml_offset + K) + &
+                (rho_ml_av - CS%target_density(K)) / &
+                (CS%target_density(K+1) - CS%target_density(K))
+        exit
+      endif
+    enddo ; endif
+    if (k_interior > real(nz+1)) k_interior = real(nz+1)
+
+    ! Linearly interpolate to find z_interior.  This could be made more sophisticated.
+    K = int(ceiling(k_interior))
+    z_interior = (K-k_interior)*z_col_new(K-1) + (1.0+(k_interior-K))*z_col_new(K)
+
+    if (CS%fix_haloclines) then
+  !       ! Identify regions above the reference pressure where the chosen
+  !       ! potential density significantly underestimates the actual
+  !       ! stratification, and use these to find a second estimate of
+  !       ! z_int_unst and k_interior.
+
+      if (CS%halocline_filter_length > 0.0) then
+        Lfilt = CS%halocline_filter_length*m_to_H
+
+        ! Filter the temperature and salnity with a fixed lengthscale.
+        h_tr = h_col(1) + H_subroundoff
+        b1 = 1.0 / (h_tr + Lfilt) ; d1 = h_tr * b1
+        T_f(1) = (b1*h_tr)*T_col(1) ;  S_f(1) = (b1*h_tr)*S_col(1)
+        do k=2,nz
+          c1(k) = Lfilt * b1
+          h_tr = h_col(k) + H_subroundoff ; b_denom_1 = h_tr + d1*Lfilt
+          b1 = 1.0 / (b_denom_1 + Lfilt) ; d1 = b_denom_1 * b1
+          T_f(k) = b1 * (h_tr*T_col(k) + Lfilt*T_f(k-1))
+          S_f(k) = b1 * (h_tr*S_col(k) + Lfilt*S_f(k-1))
+        enddo
+        do k=nz-1,1,-1
+          T_f(k) = T_f(k) + c1(k+1)*T_f(k+1) ; S_f(k) = S_f(k) + c1(k+1)*S_f(k+1)
+        enddo
+      else
+        do k=1,nz ; T_f(k) = T_col(k) ; S_f(k) = S_col(k) ; enddo
+      endif
+
+      T_int(1) = T_f(1) ; S_int(1) = S_f(1)
+      do K=2,nz
+        T_int(K) = 0.5*(T_f(k-1) + T_f(k)) ; S_int(K) = 0.5*(S_f(k-1) + S_f(k))
+        p_IS(K) = z_col(K) * H_to_Pa
+        p_R(K) = CS%ref_pressure + CS%compressibility_fraction * ( p_IS(K) - CS%ref_pressure )
+      enddo
+      T_int(nz+1) = T_f(nz) ; S_int(nz+1) = S_f(nz)
+      p_IS(nz+1) = z_col(nz+1) * H_to_Pa
+      call calculate_density_derivs(T_int, S_int, p_IS, drhoIS_dT, drhoIS_dS, 2, nz-1, &
+                                    eqn_of_state)
+      call calculate_density_derivs(T_int, S_int, p_R, drhoR_dT, drhoR_dS, 2, nz-1, &
+                                    eqn_of_state)
+      if (CS%compressibility_fraction > 0.0) then
+        call calculate_compress(T_int, S_int, p_R, rho_tmp, drho_dp, 2, nz-1, &
+                                      eqn_of_state)
+      else
+        do K=2,nz ; drho_dp(K) = 0.0 ; enddo
+      endif
+
+      H_to_cPa = CS%compressibility_fraction*H_to_Pa
+      strat_rat(1) = 1.0
+      do K=2,nz
+        drIS = drhoIS_dT(K) * (T_f(k) - T_f(k-1)) + &
+               drhoIS_dS(K) * (S_f(k) - S_f(k-1))
+        drR = (drhoR_dT(K) * (T_f(k) - T_f(k-1)) + &
+               drhoR_dS(K) * (S_f(k) - S_f(k-1))) + &
+              drho_dp(K) * (H_to_cPa*0.5*(h_col(k) + h_col(k-1)))
+
+        if (drIS <= 0.0) then
+          strat_rat(K) = 2.0 ! Maybe do this? => ; if (drR < 0.0) strat_rat(K) = -2.0
+        else
+          strat_rat(K) = 2.0*max(drR,0.0) / (drIS + abs(drR))
+        endif
+      enddo
+      strat_rat(nz+1) = 1.0
+
+      z_int_unst = 0.0 ; Fn_now = 0.0
+      Fn_zero_val = min(2.0*CS%halocline_strat_tol, &
+                        0.5*(1.0 + CS%halocline_strat_tol))
+      if (CS%halocline_strat_tol > 0.0) then
+        ! Use Adcroft's reciprocal rule.
+        I_HStol = 0.0 ; if (Fn_zero_val - CS%halocline_strat_tol > 0.0) &
+          I_HStol = 1.0 / (Fn_zero_val - CS%halocline_strat_tol)
+        do k=nz,1,-1 ; if (CS%ref_pressure > p_IS(k+1)) then
+          z_int_unst = z_int_unst + Fn_now * h_col(k)
+          if (strat_rat(K) <= Fn_zero_val) then
+            if (strat_rat(K) <= CS%halocline_strat_tol) then ; Fn_now = 1.0
+            else
+              Fn_now = max(Fn_now, (Fn_zero_val - strat_rat(K)) * I_HStol)
+            endif
+          endif
+        endif ; enddo
+      else
+        do k=nz,1,-1 ; if (CS%ref_pressure > p_IS(k+1)) then
+          z_int_unst = z_int_unst + Fn_now * h_col(k)
+          if (strat_rat(K) <= CS%halocline_strat_tol) Fn_now = 1.0
+        endif ; enddo
+      endif
+
+      if (z_interior < z_int_unst) then
+        ! Find a second estimate of the extent of the s-coordinate region.
+        kur1 = max(int(ceiling(k_interior)),2)
+        if (z_col_new(kur1-1) < z_interior) then
+          k_int2 = kur1
+          do K = kur1,nz+1 ; if (z_col_new(K) >= z_int_unst) then
+            ! This is linear interpolation again.
+            if (z_col_new(K-1) >= z_int_unst) &
+              call MOM_error(FATAL,"build_grid_SLight, bad halocline structure.")
+            k_int2 = real(K-1) + (z_int_unst - z_col_new(K-1)) / &
+                                     (z_col_new(K) - z_col_new(K-1))
+            exit
+          endif ; enddo
+          if (z_col_new(nz+1) < z_int_unst) then
+            ! This should be unnecessary.
+            z_int_unst = z_col_new(nz+1) ; k_int2 = real(nz+1)
+          endif
+
+          ! Now take the larger values.
+          if (k_int2 > k_interior) then
+            k_interior = k_int2 ; z_interior = z_int_unst
+          endif
+        endif
+      endif
+    endif  ! fix_haloclines
+
+    z_col_new(1) = 0.0
+    do K=2,nkml+1
+      z_col_new(K) = min((K-1)*CS%dz_ml_min, &
+                         z_col_new(nz+1) - CS%min_thickness*(nz+1-K))
+    enddo
+    z_ml_fix = z_col_new(nkml+1)
+    if (z_interior > z_ml_fix) then
+      dz_dk = (z_interior - z_ml_fix) / (k_interior - (nkml+1))
+      do K=nkml+2,int(floor(k_interior))
+        z_col_new(K) = z_ml_fix + dz_dk * (K - (nkml+1))
+      enddo
+    else ! The fixed-thickness z-region penetrates into the interior.
+      do K=nkml+2,nz
+        if (z_col_new(K) <= z_col_new(CS%nz_fixed_surface+1)) then
+          z_col_new(K) = z_col_new(CS%nz_fixed_surface+1)
+        else ; exit ; endif
+      enddo
+    endif
+
+    if (maximum_depths_set .and. maximum_h_set) then ; do k=2,nz
+      ! The loop bounds are 2 & nz so the top and bottom interfaces do not move.
+      ! Recall that z_col_new is positive downward.
+      z_col_new(K) = min(z_col_new(K), CS%max_interface_depths(K), &
+                            z_col_new(K-1) + CS%max_layer_thickness(k-1))
+    enddo ; elseif (maximum_depths_set) then ; do K=2,nz
+      z_col_new(K) = min(z_col_new(K), CS%max_interface_depths(K))
+    enddo ; elseif (maximum_h_set) then ; do k=2,nz
+      z_col_new(K) = min(z_col_new(K), z_col_new(K-1) + CS%max_layer_thickness(k-1))
+    enddo ; endif
+
+  endif ! Total thickness exceeds nz*CS%min_thickness.
+
+end subroutine build_slight_column
+
+!> Finds the new interface locations in a column of water that match the
+!! prescribed target densities.
+subroutine rho_interfaces_col(rho_col, h_col, z_col, rho_tgt, nz, z_col_new, &
+                              CS, reliable, debug)
+  integer,               intent(in)    :: nz      !< Number of layers
+  real, dimension(nz),   intent(in)    :: rho_col !< Initial layer reference densities.
+  real, dimension(nz),   intent(in)    :: h_col   !< Initial layer thicknesses.
+  real, dimension(nz+1), intent(in)    :: z_col   !< Initial interface heights.
+  real, dimension(nz+1), intent(in)    :: rho_tgt !< Interface target densities.
+  real, dimension(nz+1), intent(inout) :: z_col_new !< New interface heights.
+  type(slight_CS),       intent(in)    :: CS      !< Regridding control structure
+  logical, dimension(nz+1), intent(inout) :: reliable !< If true, the interface positions
+                                                  !! are well defined from a stable region.
+  logical, optional,     intent(in) :: debug      !< If present and true, do debugging checks.
+
+  real, dimension(nz+1) :: ru_max_int ! The maximum and minimum densities in
+  real, dimension(nz+1) :: ru_min_int ! an unstable region around an interface.
+  real, dimension(nz)   :: ru_max_lay ! The maximum and minimum densities in
+  real, dimension(nz)   :: ru_min_lay ! an unstable region containing a layer.
+  real, dimension(nz,2) :: ppoly_i_E ! Edge value of polynomial
+  real, dimension(nz,2) :: ppoly_i_S ! Edge slope of polynomial
+  real, dimension(nz,DEGREE_MAX+1) :: ppoly_i_coefficients ! Coefficients of polynomial
+  logical, dimension(nz)   :: unstable_lay ! If true, this layer is in an unstable region.
+  logical, dimension(nz+1) :: unstable_int ! If true, this interface is in an unstable region.
+  real :: rt  ! The current target density, in kg m-3.
+  real :: zf  ! The fractional z-position within a layer of the target density.
+  real :: rfn
+  real :: a(5) ! Coefficients of a local polynomial minus the target density.
+  real :: zf1, zf2, rfn1, rfn2
+  real :: drfn_dzf, sgn, delta_zf, zf_prev
+  real :: tol
+  logical :: k_found ! If true, the position has been found.
+  integer :: k_layer ! The index of the stable layer containing an interface.
+  integer :: ppoly_degree
+  integer :: k, k1, k1_min, itt, max_itt, m
+
+  real :: z_sgn  ! 1 or -1, depending on whether z increases with increasing K.
+  logical :: debugging
+
+  debugging = .false. ; if (present(debug)) debugging = debug
+  max_itt = NR_ITERATIONS
+  tol = NR_TOLERANCE
+
+  z_sgn = 1.0 ; if ( z_col(1) > z_col(nz+1) ) z_sgn = -1.0
+  if (debugging) then
+    do K=1,nz
+      if (abs((z_col(K+1) - z_col(K)) - z_sgn*h_col(k)) > &
+          1.0e-14*(abs(z_col(K+1)) + abs(z_col(K)) + abs(h_col(k))) ) &
+        call MOM_error(FATAL, "rho_interfaces_col: Inconsistent z_col and h_col")
+    enddo
+  endif
+
+  if ( z_col(1) == z_col(nz+1) ) then
+    ! This is a massless column!
+    do K=1,nz+1 ; z_col_new(K) = z_col(1) ; reliable(K) = .true. ; enddo
+    return
+  endif
+
+  ! This sets up the piecewise polynomials based on the rho_col profile.
+  call regridding_set_ppolys(CS%interp_CS, rho_col, nz, h_col, ppoly_i_E, ppoly_i_S, &
+       ppoly_i_coefficients, ppoly_degree)
+
+  ! Determine the density ranges of unstably stratified segments.
+  ! Interfaces that start out in an unstably stratified segment can
+  ! only escape if they are outside of the bounds of that segment, and no
+  ! interfaces are ever mapped into an unstable segment.
+  unstable_int(1) = .false.
+  ru_max_int(1) = ppoly_i_E(1,1)
+
+  unstable_lay(1) = (ppoly_i_E(1,1) > ppoly_i_E(1,2))
+  ru_max_lay(1) = max(ppoly_i_E(1,1), ppoly_i_E(1,2))
+
+  do K=2,nz
+    unstable_int(K) = (ppoly_i_E(k-1,2) > ppoly_i_E(k,1))
+    ru_max_int(K) = max(ppoly_i_E(k-1,2), ppoly_i_E(k,1))
+    ru_min_int(K) = min(ppoly_i_E(k-1,2), ppoly_i_E(k,1))
+    if (unstable_int(K) .and. unstable_lay(k-1)) &
+      ru_max_int(K) = max(ru_max_lay(k-1), ru_max_int(K))
+
+    unstable_lay(k) = (ppoly_i_E(k,1) > ppoly_i_E(k,2))
+    ru_max_lay(k) = max(ppoly_i_E(k,1), ppoly_i_E(k,2))
+    ru_min_lay(k) = min(ppoly_i_E(k,1), ppoly_i_E(k,2))
+    if (unstable_lay(k) .and. unstable_int(K)) &
+      ru_max_lay(k) = max(ru_max_int(K), ru_max_lay(k))
+  enddo
+  unstable_int(nz+1) = .false.
+  ru_min_int(nz+1) = ppoly_i_E(nz,2)
+
+  do K=nz,1,-1
+    if (unstable_lay(k) .and. unstable_int(K+1)) &
+      ru_min_lay(k) = min(ru_min_int(K+1), ru_min_lay(k))
+
+    if (unstable_int(K) .and. unstable_lay(k)) &
+      ru_min_int(K) = min(ru_min_lay(k), ru_min_int(K))
+  enddo
+
+  z_col_new(1) = z_col(1) ; reliable(1) = .true.
+  k1_min = 1
+  do K=2,nz ! Find the locations of the various target densities for the interfaces.
+    rt = rho_tgt(K)
+    k_layer = -1
+    k_found = .false.
+
+    ! Many light layers are found at the top, so start there.
+    if (rt <= ppoly_i_E(k1_min,1)) then
+      z_col_new(K) = z_col(k1_min)
+      k_found = .true.
+      ! Do not change k1_min for the next layer.
+    elseif (k1_min == nz+1) then
+      z_col_new(K) = z_col(nz+1)
+    else
+      ! Start with the previous location and search outward.
+      if (unstable_int(K) .and. (rt >= ru_min_int(K)) .and. (rt <= ru_max_int(K))) then
+        ! This interface started in an unstable region and should not move due to remapping.
+        z_col_new(K) = z_col(K) ; reliable(K) = .false.
+        k1_min = K ; k_found = .true.
+      elseif ((rt >= ppoly_i_E(k-1,2)) .and. (rt <= ppoly_i_E(k,1))) then
+        ! This interface is already in the right place and does not move.
+        z_col_new(K) = z_col(K) ; reliable(K) = .true.
+        k1_min = K ; k_found = .true.
+      elseif (rt < ppoly_i_E(k-1,2)) then   ! Search upward
+        do k1=K-1,k1_min,-1
+          ! Check whether rt is in layer k.
+          if ((rt < ppoly_i_E(k1,2)) .and. (rt > ppoly_i_E(k1,1))) then
+            ! rt is in layer k.
+            k_layer = k1
+            k1_min = k1 ; k_found = .true. ; exit
+          elseif (unstable_lay(k1) .and. (rt >= ru_min_lay(k1)) .and. (rt <= ru_max_lay(K1))) then
+            ! rt would be found at unstable layer that it can not penetrate.
+            !   It is possible that this can never happen?
+            z_col_new(K) = z_col(K1+1) ; reliable(K) = .false.
+            k1_min = k1 ; k_found = .true. ; exit
+          endif
+          ! Check whether rt is at interface K.
+          if (k1 > 1) then ; if ((rt <= ppoly_i_E(k1,1)) .and. (rt >= ppoly_i_E(k1-1,2))) then
+            ! rt is at interface K1
+            z_col_new(K) = z_col(K1) ; reliable(K) = .true.
+            k1_min = k1 ; k_found = .true. ; exit
+          elseif (unstable_int(K1) .and. (rt >= ru_min_int(k1)) .and. (rt <= ru_max_int(K1))) then
+            ! rt would be found at an unstable interface that it can not pass.
+            !   It is possible that this can never happen?
+            z_col_new(K) = z_col(K1) ; reliable(K) = .false.
+            k1_min = k1 ; k_found = .true. ; exit
+          endif ; endif
+        enddo
+
+        if (.not.k_found) then
+          ! This should not happen unless k1_min = 1.
+          if (k1_min < 2) then
+            z_col_new(K) = z_col(k1_min)
+          else
+            z_col_new(K) = z_col(k1_min)
+          endif
+        endif
+
+      else  ! Search downward
+        do k1=K,nz
+          if ((rt < ppoly_i_E(k1,2)) .and. (rt > ppoly_i_E(k1,1))) then
+            ! rt is in layer k.
+            k_layer = k1
+            k1_min = k1 ; k_found = .true. ; exit
+          elseif (unstable_lay(k1) .and. (rt >= ru_min_lay(k1)) .and. (rt <= ru_max_lay(K1))) then
+            ! rt would be found at unstable layer that it can not penetrate.
+            !   It is possible that this can never happen?
+            z_col_new(K) = z_col(K1)
+            reliable(K) = .false.
+            k1_min = k1 ; k_found = .true. ; exit
+          endif
+          if (k1 < nz) then ; if ((rt <= ppoly_i_E(k1+1,1)) .and. (rt >= ppoly_i_E(k1,2))) then
+            ! rt is at interface K1+1
+
+            z_col_new(K) = z_col(K1+1) ; reliable(K) = .true.
+            k1_min = k1+1 ; k_found = .true. ; exit
+          elseif (unstable_int(K1+1) .and. (rt >= ru_min_int(k1+1)) .and. (rt <= ru_max_int(K1+1))) then
+            ! rt would be found at an unstable interface that it can not pass.
+            !   It is possible that this can never happen?
+            z_col_new(K) = z_col(K1+1)
+            reliable(K) = .false.
+            k1_min = k1+1 ; k_found = .true. ; exit
+          endif ; endif
+        enddo
+        if (.not.k_found) then
+          z_col_new(K) = z_col(nz+1)
+          if (rt >= ppoly_i_E(nz,2)) then
+            reliable(K) = .true.
+          else
+            reliable(K) = .false.
+          endif
+        endif
+      endif
+
+      if (k_layer > 0) then  ! The new location is inside of layer k_layer.
+        ! Note that this is coded assuming that this layer is stably stratified.
+        if (.not.(ppoly_i_E(k1,2) > ppoly_i_E(k1,1))) call MOM_error(FATAL, &
+          "build_grid_SLight: Erroneously searching for an interface in an unstratified layer.") !### COMMENT OUT LATER?
+
+        ! Use the false position method to find the location (degree <= 1) or the first guess.
+        zf = (rt - ppoly_i_E(k1,1)) / (ppoly_i_E(k1,2) - ppoly_i_E(k1,1))
+
+        if (ppoly_degree > 1) then ! Iterate to find the solution.
+          a(:) = 0.0 ; a(1) = ppoly_i_coefficients(k_layer,1) - rt
+          do m=2,ppoly_degree+1 ; a(m) = ppoly_i_coefficients(k_layer,m) ; enddo
+          ! Bracket the root.
+          zf1 = 0.0 ; rfn1 = a(1)
+          zf2 = 1.0 ; rfn2 =  a(1) + (a(2) + (a(3) + (a(4) + a(5))))
+          if (rfn1 * rfn2 > 0.0) call MOM_error(FATAL, "build_grid_SLight: Bad bracketing.") !### COMMENT OUT LATER?
+
+          do itt=1,max_itt
+            rfn = a(1) + zf*(a(2) + zf*(a(3) + zf*(a(4) + zf*a(5))))
+            ! Reset one of the ends of the bracket.
+            if (rfn * rfn1 > 0.0) then
+              zf1 = zf ; rfn1 = rfn
+            else
+              zf2 = zf ; rfn2 = rfn
+            endif
+            if (rfn1 == rfn2) exit
+
+            drfn_dzf = (a(2) + zf*(2.0*a(3) + zf*(3.0*a(4) + zf*4.0*a(5))))
+            sgn = 1.0 ; if (drfn_dzf < 0.0) sgn = -1.0
+
+            if ((sgn*(zf - rfn) >= zf1 * abs(drfn_dzf)) .and. &
+                (sgn*(zf - rfn) <= zf2 * abs(drfn_dzf))) then
+              delta_zf = -rfn / drfn_dzf
+              zf = zf + delta_zf
+            else ! Newton's method goes out of bounds, so use a false position method estimate
+              zf_prev = zf
+              zf = ( rfn2 * zf1 - rfn1 * zf2 ) / (rfn2 - rfn1)
+              delta_zf = zf - zf_prev
+            endif
+
+            if (abs(delta_zf) < tol) exit
+          enddo
+        endif
+        z_col_new(K) = z_col(k_layer) + zf * z_sgn * h_col(k_layer)
+        reliable(K) = .true.
+      endif
+
+    endif
+
+  enddo
+  z_col_new(nz+1) = z_col(nz+1) ; reliable(nz+1) = .true.
+
+end subroutine rho_interfaces_col
+
+end module coord_slight

--- a/src/ALE/coord_zlike.F90
+++ b/src/ALE/coord_zlike.F90
@@ -1,0 +1,102 @@
+module coord_zlike
+
+use MOM_error_handler, only : MOM_error, FATAL
+
+implicit none ; private
+
+type, public :: zlike_CS
+  private
+
+  real,               pointer :: min_thickness
+  real, dimension(:), pointer :: coordinateResolution
+end type zlike_CS
+
+public init_coord_zlike, build_zstar_column
+
+contains
+
+subroutine init_coord_zlike(CS, min_thickness, coordinateResolution)
+  type(zlike_CS),     pointer :: CS
+  real,               target  :: min_thickness
+  real, dimension(:), target  :: coordinateResolution
+
+  if (associated(CS)) call MOM_error(FATAL, "init_coord_zlike: CS already associated!")
+  allocate(CS)
+
+  CS%min_thickness => min_thickness
+  CS%coordinateResolution => coordinateResolution
+end subroutine init_coord_zlike
+
+!> Builds a z* coordinate with a minimum thickness
+subroutine build_zstar_column(CS, nz, depth, total_thickness, zInterface, z_rigid_top, eta_orig)
+  type(zlike_CS),        intent(in)    :: CS !< Coordinate control structure
+  integer,               intent(in)    :: nz !< Number of levels
+  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in m)
+  real,                  intent(in)    :: total_thickness !< Column thickness (positive in m)
+  real, dimension(nz+1), intent(inout) :: zInterface !< Absolute positions of interfaces
+  real, optional,        intent(in)    :: z_rigid_top !< The height of a rigid top (negative in m)
+  real, optional,        intent(in)    :: eta_orig !< The actual original height of the top (m)
+  ! Local variables
+  real :: eta, stretching, dh, min_thickness, z0_top, z_star
+  integer :: k
+  logical :: new_zstar_def
+
+  new_zstar_def = .false.
+  min_thickness = min( CS%min_thickness, total_thickness/real(nz) )
+  z0_top = 0.
+  if (present(z_rigid_top)) then
+    z0_top = z_rigid_top
+    new_zstar_def = .true.
+  endif
+
+  ! Position of free-surface (or the rigid top, for which eta ~ z0_top)
+  eta = total_thickness - depth
+  if (present(eta_orig)) eta = eta_orig
+
+  ! Conventional z* coordinate:
+  !   z* = (z-eta) / stretching   where stretching = (H+eta)/H
+  !   z = eta + stretching * z*
+  ! The above gives z*(z=eta) = 0, z*(z=-H) = -H.
+  ! With a rigid top boundary at eta = z0_top then
+  !   z* = z0 + (z-eta) / stretching   where stretching = (H+eta)/(H+z0)
+  !   z = eta + stretching * (z*-z0) * stretching
+  stretching = total_thickness / ( depth + z0_top )
+
+  if (new_zstar_def) then
+    ! z_star is the notional z* coordinate in absence of upper/lower topography
+    z_star = 0. ! z*=0 at the free-surface
+    zInterface(1) = eta ! The actual position of the top of the column
+    do k = 2,nz
+      z_star = z_star - CS%coordinateResolution(k-1)
+      ! This ensures that z is below a rigid upper surface (ice shelf bottom)
+      zInterface(k) = min( eta + stretching * ( z_star - z0_top ), z0_top )
+      ! This ensures that the layer in inflated
+      zInterface(k) = min( zInterface(k), zInterface(k-1) - min_thickness )
+      ! This ensures that z is above or at the topography
+      zInterface(k) = max( zInterface(k), -depth + real(nz+1-k) * min_thickness )
+    enddo
+    zInterface(nz+1) = -depth
+
+  else
+    ! Integrate down from the top for a notional new grid, ignoring topography
+    ! The starting position is offset by z0_top which, if z0_top<0, will place
+    ! interfaces above the rigid boundary.
+    zInterface(1) = eta
+    do k = 1,nz
+      dh = stretching * CS%coordinateResolution(k) ! Notional grid spacing
+      zInterface(k+1) = zInterface(k) - dh
+    enddo
+
+    ! Integrating up from the bottom adjusting interface position to accommodate
+    ! inflating layers without disturbing the interface above
+    zInterface(nz+1) = -depth
+    do k = nz,1,-1
+      if ( zInterface(k) < (zInterface(k+1) + min_thickness) ) then
+        zInterface(k) = zInterface(k+1) + min_thickness
+      endif
+    enddo
+  endif
+
+end subroutine build_zstar_column
+
+end module coord_zlike

--- a/src/ALE/coord_zlike.F90
+++ b/src/ALE/coord_zlike.F90
@@ -9,29 +9,42 @@ implicit none ; private
 type, public :: zlike_CS
   private
 
+  !> Number of levels
+  integer :: nk
+
   !> Minimum thickness allowed for layers
-  real,               pointer :: min_thickness
+  real :: min_thickness
 
   !> Target coordinate resolution
-  real, dimension(:), pointer :: coordinateResolution
+  real, allocatable, dimension(:) :: coordinateResolution
 end type zlike_CS
 
-public init_coord_zlike, build_zstar_column
+public init_coord_zlike, set_zlike_params, build_zstar_column
 
 contains
 
 !> Initialise a zlike_CS with pointers to parameters
-subroutine init_coord_zlike(CS, min_thickness, coordinateResolution)
-  type(zlike_CS),     pointer :: CS !< Unassociated pointer to hold the control structure
-  real,               target  :: min_thickness
-  real, dimension(:), target  :: coordinateResolution
+subroutine init_coord_zlike(CS, nk, coordinateResolution)
+  type(zlike_CS),     pointer    :: CS !< Unassociated pointer to hold the control structure
+  integer,            intent(in) :: nk
+  real, dimension(:), intent(in) :: coordinateResolution
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_zlike: CS already associated!")
   allocate(CS)
+  allocate(CS%coordinateResolution(nk))
 
-  CS%min_thickness => min_thickness
-  CS%coordinateResolution => coordinateResolution
+  CS%nk                   = nk
+  CS%coordinateResolution = coordinateResolution
 end subroutine init_coord_zlike
+
+subroutine set_zlike_params(CS, min_thickness)
+  type(zlike_CS), pointer    :: CS
+  real, optional, intent(in) :: min_thickness
+
+  if (.not. associated(CS)) call MOM_error(FATAL, "set_zlike_params: CS not associated")
+
+  if (present(min_thickness)) CS%min_thickness = min_thickness
+end subroutine set_zlike_params
 
 !> Builds a z* coordinate with a minimum thickness
 subroutine build_zstar_column(CS, nz, depth, total_thickness, zInterface, z_rigid_top, eta_orig)

--- a/src/ALE/coord_zlike.F90
+++ b/src/ALE/coord_zlike.F90
@@ -1,13 +1,18 @@
+!> Regrid columns for a z-like coordinate (z-star, z-level)
 module coord_zlike
 
 use MOM_error_handler, only : MOM_error, FATAL
 
 implicit none ; private
 
+!> Control structure containing required parameters for a z-like coordinate
 type, public :: zlike_CS
   private
 
+  !> Minimum thickness allowed for layers
   real,               pointer :: min_thickness
+
+  !> Target coordinate resolution
   real, dimension(:), pointer :: coordinateResolution
 end type zlike_CS
 
@@ -15,8 +20,9 @@ public init_coord_zlike, build_zstar_column
 
 contains
 
+!> Initialise a zlike_CS with pointers to parameters
 subroutine init_coord_zlike(CS, min_thickness, coordinateResolution)
-  type(zlike_CS),     pointer :: CS
+  type(zlike_CS),     pointer :: CS !< Unassociated pointer to hold the control structure
   real,               target  :: min_thickness
   real, dimension(:), target  :: coordinateResolution
 

--- a/src/ALE/coord_zlike.F90
+++ b/src/ALE/coord_zlike.F90
@@ -19,7 +19,7 @@ type, public :: zlike_CS
   real, allocatable, dimension(:) :: coordinateResolution
 end type zlike_CS
 
-public init_coord_zlike, set_zlike_params, build_zstar_column
+public init_coord_zlike, set_zlike_params, build_zstar_column, end_coord_zlike
 
 contains
 
@@ -36,6 +36,15 @@ subroutine init_coord_zlike(CS, nk, coordinateResolution)
   CS%nk                   = nk
   CS%coordinateResolution = coordinateResolution
 end subroutine init_coord_zlike
+
+subroutine end_coord_zlike(CS)
+  type(zlike_CS), pointer :: CS
+
+  ! nothing to do
+  if (.not. associated(CS)) return
+  deallocate(CS%coordinateResolution)
+  deallocate(CS)
+end subroutine end_coord_zlike
 
 subroutine set_zlike_params(CS, min_thickness)
   type(zlike_CS), pointer    :: CS

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -1,0 +1,446 @@
+module regrid_interp
+
+use MOM_error_handler, only : MOM_error, FATAL
+use MOM_string_functions, only : uppercase
+
+use regrid_edge_values, only : edge_values_explicit_h2, edge_values_explicit_h4
+use regrid_edge_values, only : edge_values_implicit_h4, edge_values_implicit_h6
+use regrid_edge_slopes, only : edge_slopes_implicit_h3, edge_slopes_implicit_h5
+
+use PLM_functions, only : PLM_reconstruction, PLM_boundary_extrapolation
+use PPM_functions, only : PPM_reconstruction, PPM_boundary_extrapolation
+use PQM_functions, only : PQM_reconstruction, PQM_boundary_extrapolation_v1
+
+use P1M_functions, only : P1M_interpolation, P1M_boundary_extrapolation
+use P3M_functions, only : P3M_interpolation, P3M_boundary_extrapolation
+
+implicit none ; private
+
+public regridding_set_ppolys, interpolate_grid
+public interpolation_scheme
+
+! List of interpolation schemes
+integer, parameter :: INTERPOLATION_P1M_H2     = 0 !< O(h^2)
+integer, parameter :: INTERPOLATION_P1M_H4     = 1 !< O(h^2)
+integer, parameter :: INTERPOLATION_P1M_IH4    = 2 !< O(h^2)
+integer, parameter :: INTERPOLATION_PLM        = 3 !< O(h^2)
+integer, parameter :: INTERPOLATION_PPM_H4     = 4 !< O(h^3)
+integer, parameter :: INTERPOLATION_PPM_IH4    = 5 !< O(h^3)
+integer, parameter :: INTERPOLATION_P3M_IH4IH3 = 6 !< O(h^4)
+integer, parameter :: INTERPOLATION_P3M_IH6IH5 = 7 !< O(h^4)
+integer, parameter :: INTERPOLATION_PQM_IH4IH3 = 8 !< O(h^4)
+integer, parameter :: INTERPOLATION_PQM_IH6IH5 = 9 !< O(h^5)
+
+!> List of interpolant degrees
+integer, parameter :: DEGREE_1 = 1, DEGREE_2 = 2, DEGREE_3 = 3, DEGREE_4 = 4
+
+!> When the N-R algorithm produces an estimate that lies outside [0,1], the
+!! estimate is set to be equal to the boundary location, 0 or 1, plus or minus
+!! an offset, respectively, when the derivative is zero at the boundary.
+real, public, parameter    :: NR_OFFSET = 1e-6
+!> Maximum number of Newton-Raphson iterations. Newton-Raphson iterations are
+!! used to build the new grid by finding the coordinates associated with
+!! target densities and interpolations of degree larger than 1.
+integer, public, parameter :: NR_ITERATIONS = 8
+!> Tolerance for Newton-Raphson iterations (stop when increment falls below this)
+real, public, parameter    :: NR_TOLERANCE = 1e-12
+
+contains
+
+!> Given the set of target values and cell densities, this routine
+!! builds an interpolated profile for the densities within each grid cell.
+!! It may happen that, given a high-order interpolator, the number of
+!! available layers is insufficient (e.g., there are two available layers for
+!! a third-order PPM ih4 scheme). In these cases, we resort to the simplest
+!! continuous linear scheme (P1M h2).
+subroutine regridding_set_ppolys(densities, n0, h0, ppoly0_E, ppoly0_S, &
+     ppoly0_coefficients, degree, scheme, extrapolate)
+  real, dimension(:),  intent(in)    :: densities !< Actual cell densities
+  integer,             intent(in)    :: n0 !< Number of cells on source grid
+  real, dimension(:),  intent(in)    :: h0 !< cell widths on source grid
+  real, dimension(:,:),intent(inout) :: ppoly0_E            !< Edge value of polynomial
+  real, dimension(:,:),intent(inout) :: ppoly0_S            !< Edge slope of polynomial
+  real, dimension(:,:),intent(inout) :: ppoly0_coefficients !< Coefficients of polynomial
+  integer,             intent(inout) :: degree  !< The degree of the polynomials
+  integer,             intent(in)    :: scheme !< Interpolation scheme to use
+  logical,             intent(in)    :: extrapolate !< If true, perform boundary extrapolation
+
+  ! Reset piecewise polynomials
+  ppoly0_E(:,:) = 0.0
+  ppoly0_S(:,:) = 0.0
+  ppoly0_coefficients(:,:) = 0.0
+
+  ! Compute the interpolated profile of the density field and build grid
+  select case (scheme)
+
+    case ( INTERPOLATION_P1M_H2 )
+      degree = DEGREE_1
+      call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+      if (extrapolate) then
+        call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+      end if
+
+    case ( INTERPOLATION_P1M_H4 )
+      degree = DEGREE_1
+      if ( n0 >= 4 ) then
+        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E )
+      else
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+      end if
+      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+      if (extrapolate) then
+        call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+      end if
+
+    case ( INTERPOLATION_P1M_IH4 )
+      degree = DEGREE_1
+      if ( n0 >= 4 ) then
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E )
+      else
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+      end if
+      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+      if (extrapolate) then
+        call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+      end if
+
+    case ( INTERPOLATION_PLM )
+      degree = DEGREE_1
+      call PLM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+      if (extrapolate) then
+        call PLM_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+      end if
+
+    case ( INTERPOLATION_PPM_H4 )
+      if ( n0 >= 4 ) then
+        degree = DEGREE_2
+        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E )
+        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        if (extrapolate) then
+          call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        end if
+      else
+        degree = DEGREE_1
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        if (extrapolate) then
+          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        end if
+      end if
+
+    case ( INTERPOLATION_PPM_IH4 )
+      if ( n0 >= 4 ) then
+        degree = DEGREE_2
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E )
+        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        if (extrapolate) then
+          call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        end if
+      else
+        degree = DEGREE_1
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        if (extrapolate) then
+          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        end if
+      end if
+
+    case ( INTERPOLATION_P3M_IH4IH3 )
+      if ( n0 >= 4 ) then
+        degree = DEGREE_3
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E )
+        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S )
+        call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
+        if (extrapolate) then
+          call P3M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
+        end if
+      else
+        degree = DEGREE_1
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        if (extrapolate) then
+          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        end if
+      end if
+
+    case ( INTERPOLATION_P3M_IH6IH5 )
+      if ( n0 >= 6 ) then
+        degree = DEGREE_3
+        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E )
+        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S )
+        call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
+        if (extrapolate) then
+          call P3M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
+        end if
+      else
+        degree = DEGREE_1
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        if (extrapolate) then
+          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        end if
+      end if
+
+    case ( INTERPOLATION_PQM_IH4IH3 )
+      if ( n0 >= 4 ) then
+        degree = DEGREE_4
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E )
+        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S )
+        call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
+        if (extrapolate) then
+          call PQM_boundary_extrapolation_v1( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
+        end if
+      else
+        degree = DEGREE_1
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        if (extrapolate) then
+          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        end if
+      end if
+
+    case ( INTERPOLATION_PQM_IH6IH5 )
+      if ( n0 >= 6 ) then
+        degree = DEGREE_4
+        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E )
+        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S )
+        call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
+        if (extrapolate) then
+          call PQM_boundary_extrapolation_v1( n0, h0, densities, ppoly0_E, ppoly0_S, ppoly0_coefficients )
+        end if
+      else
+        degree = DEGREE_1
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        if (extrapolate) then
+          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefficients )
+        end if
+      end if
+  end select
+end subroutine regridding_set_ppolys
+
+
+!------------------------------------------------------------------------------
+! Given target values (e.g., density), build new grid based on polynomial
+!------------------------------------------------------------------------------
+subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefficients, target_values, degree, n1, h1, x1 )
+! ------------------------------------------------------------------------------
+! Given the grid 'grid0' and the piecewise polynomial interpolant
+! 'ppoly0' (possibly discontinuous), the coordinates of the new grid 'grid1'
+! are determined by finding the corresponding target interface densities.
+! ------------------------------------------------------------------------------
+
+  ! Arguments
+  integer,            intent(in)    :: n0
+  real, dimension(:), intent(in)    :: h0
+  real, dimension(:), intent(in)    :: x0
+  real, dimension(:,:), intent(in)  :: ppoly0_E            !Edge value of polynomial
+  real, dimension(:,:), intent(in)  :: ppoly0_coefficients !Coefficients of polynomial
+  real, dimension(:), intent(in)    :: target_values
+  integer,            intent(in)    :: degree
+  integer,            intent(in)    :: n1
+  real, dimension(:), intent(inout) :: h1
+  real, dimension(:), intent(inout) :: x1
+
+  ! Local variables
+  integer        :: k   ! loop index
+  real           :: t   ! current interface target density
+
+  ! Make sure boundary coordinates of new grid coincide with boundary
+  ! coordinates of previous grid
+  x1(1) = x0(1)
+  x1(n1+1) = x0(n0+1)
+
+  ! Find coordinates for interior target values
+  do k = 2,n1
+    t = target_values(k)
+    x1(k) = get_polynomial_coordinate ( n0, h0, x0, ppoly0_E, ppoly0_coefficients, t, degree )
+    h1(k-1) = x1(k) - x1(k-1)
+  end do
+  h1(n1) = x1(n1+1) - x1(n1)
+
+end subroutine interpolate_grid
+
+
+!------------------------------------------------------------------------------
+! Given target value, find corresponding coordinate for given polynomial
+!------------------------------------------------------------------------------
+function get_polynomial_coordinate ( N, h, x_g, ppoly_E, ppoly_coefficients, &
+                                     target_value, degree ) result ( x_tgt )
+! ------------------------------------------------------------------------------
+! Here, 'ppoly' is assumed to be a piecewise discontinuous polynomial of degree
+! 'degree' throughout the domain defined by 'grid'. A target value is given
+! and we need to determine the corresponding grid coordinate to define the
+! new grid.
+!
+! If the target value is out of range, the grid coordinate is simply set to
+! be equal to one of the boundary coordinates, which results in vanished layers
+! near the boundaries.
+!
+! IT IS ASSUMED THAT THE PIECEWISE POLYNOMIAL IS MONOTONICALLY INCREASING.
+! IF THIS IS NOT THE CASE, THE NEW GRID MAY BE ILL-DEFINED.
+!
+! It is assumed that the number of cells defining 'grid' and 'ppoly' are the
+! same.
+! ------------------------------------------------------------------------------
+
+  ! Arguments
+  integer,              intent(in) :: N     ! The number of grid cells
+  real, dimension(:),   intent(in) :: h     ! Grid cell thicknesses    (size N)
+  real, dimension(:),   intent(in) :: x_g   ! Grid interface locations (size N+1)
+  real, dimension(:,:), intent(in) :: ppoly_E  !Edge value of polynomial
+  real, dimension(:,:), intent(in) :: ppoly_coefficients !Coefficients of polynomial
+  real,                 intent(in) :: target_value
+  integer,              intent(in) :: degree ! The degree of the polynomials
+
+  real :: x_tgt      !< The position of x_g at which target_value is found.
+
+  ! Local variables
+  integer            :: i, k            ! loop indices
+  integer            :: k_found         ! index of target cell
+  integer            :: iter
+  real               :: xi0             ! normalized target coordinate
+  real, dimension(5) :: a               ! polynomial coefficients
+  real               :: numerator
+  real               :: denominator
+  real               :: delta           ! Newton-Raphson increment
+  real               :: x               ! global target coordinate
+  real               :: eps                 ! offset used to get away from
+                                        ! boundaries
+  real               :: grad            ! gradient during N-R iterations
+
+  eps = NR_OFFSET
+
+  k_found = -1
+
+  ! If the target value is outside the range of all values, we
+  ! force the target coordinate to be equal to the lowest or
+  ! largest value, depending on which bound is overtaken
+  if ( target_value <= ppoly_E(1,1) ) then
+    x_tgt = x_g(1)
+    return  ! return because there is no need to look further
+  end if
+
+  ! Since discontinuous edge values are allowed, we check whether the target
+  ! value lies between two discontinuous edge values at interior interfaces
+  do k = 2,N
+    if ( ( target_value >= ppoly_E(k-1,2) ) .AND. &
+      ( target_value <= ppoly_E(k,1) ) ) then
+      x_tgt = x_g(k)
+      return   ! return because there is no need to look further
+      exit
+    end if
+  end do
+
+  ! If the target value is outside the range of all values, we
+  ! force the target coordinate to be equal to the lowest or
+  ! largest value, depending on which bound is overtaken
+  if ( target_value >= ppoly_E(N,2) ) then
+    x_tgt = x_g(N+1)
+    return  ! return because there is no need to look further
+  end if
+
+  ! At this point, we know that the target value is bounded and does not
+  ! lie between discontinuous, monotonic edge values. Therefore,
+  ! there is a unique solution. We loop on all cells and find which one
+  ! contains the target value. The variable k_found holds the index value
+  ! of the cell where the taregt value lies.
+  do k = 1,N
+    if ( ( target_value > ppoly_E(k,1) ) .AND. &
+         ( target_value < ppoly_E(k,2) ) ) then
+      k_found = k
+      exit
+    end if
+  end do
+
+  ! At this point, 'k_found' should be strictly positive. If not, this is
+  ! a major failure because it means we could not find any target cell
+  ! despite the fact that the target value lies between the extremes. It
+  ! means there is a major problem with the interpolant. This needs to be
+  ! reported.
+  if ( k_found == -1 ) then
+      write(*,*) target_value, ppoly_E(1,1), ppoly_E(N,2)
+      write(*,*) 'Could not find target coordinate in ' //&
+                 '"get_polynomial_coordinate". This is caused by an '//&
+                 'inconsistent interpolant (perhaps not monotonically '//&
+                 'increasing)'
+      call MOM_error( FATAL, 'Aborting execution' )
+  end if
+
+  ! Reset all polynomial coefficients to 0 and copy those pertaining to
+  ! the found cell
+  a(:) = 0.0
+  do i = 1,degree+1
+    a(i) = ppoly_coefficients(k_found,i)
+  end do
+
+  ! Guess value to start Newton-Raphson iterations (middle of cell)
+  xi0 = 0.5
+  iter = 1
+  delta = 1e10
+
+  ! Newton-Raphson iterations
+  do
+    if ( ( iter > NR_ITERATIONS ) .OR. &
+         ( abs(delta) < NR_TOLERANCE ) ) then
+      exit
+    end if
+
+    numerator = a(1) + a(2)*xi0 + a(3)*xi0*xi0 + a(4)*xi0*xi0*xi0 + &
+                a(5)*xi0*xi0*xi0*xi0 - target_value
+
+    denominator = a(2) + 2*a(3)*xi0 + 3*a(4)*xi0*xi0 + 4*a(5)*xi0*xi0*xi0
+
+    delta = - ( numerator ) / &
+              ( denominator )
+
+    xi0 = xi0 + delta
+
+    ! Check whether new estimate is out of bounds. If the new estimate is
+    ! indeed out of bounds, we manually set it to be equal to the overtaken
+    ! bound with a small offset towards the interior when the gradient of
+    ! the function at the boundary is zero (in which case, the Newton-Raphson
+    ! algorithm does not converge).
+    if ( xi0 < 0.0 ) then
+      xi0 = 0.0
+      grad = a(2)
+      if ( grad == 0.0 ) xi0 = xi0 + eps
+    end if
+
+    if ( xi0 > 1.0 ) then
+      xi0 = 1.0
+      grad = a(2) + 2*a(3) + 3*a(4) + 4*a(5)
+      if ( grad == 0.0 ) xi0 = xi0 - eps
+    end if
+
+    iter = iter + 1
+
+  end do ! end Newton-Raphson iterations
+
+  x_tgt = x_g(k_found) + xi0 * h(k_found)
+
+end function get_polynomial_coordinate
+
+!> Numeric value of interpolation_scheme corresponding to scheme name
+integer function interpolation_scheme(interp_scheme)
+  character(len=*), intent(in) :: interp_scheme !< Name of interpolation scheme
+
+  select case ( uppercase(trim(interp_scheme)) )
+    case ("P1M_H2");     interpolation_scheme = INTERPOLATION_P1M_H2
+    case ("P1M_H4");     interpolation_scheme = INTERPOLATION_P1M_H4
+    case ("P1M_IH2");    interpolation_scheme = INTERPOLATION_P1M_IH4
+    case ("PLM");        interpolation_scheme = INTERPOLATION_PLM
+    case ("PPM_H4");     interpolation_scheme = INTERPOLATION_PPM_H4
+    case ("PPM_IH4");    interpolation_scheme = INTERPOLATION_PPM_IH4
+    case ("P3M_IH4IH3"); interpolation_scheme = INTERPOLATION_P3M_IH4IH3
+    case ("P3M_IH6IH5"); interpolation_scheme = INTERPOLATION_P3M_IH6IH5
+    case ("PQM_IH4IH3"); interpolation_scheme = INTERPOLATION_PQM_IH4IH3
+    case ("PQM_IH6IH5"); interpolation_scheme = INTERPOLATION_PQM_IH6IH5
+    case default ; call MOM_error(FATAL, "MOM_regridding: "//&
+     "Unrecognized choice for INTERPOLATION_SCHEME ("//trim(interp_scheme)//").")
+  end select
+
+end function interpolation_scheme
+
+end module regrid_interp

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -32,7 +32,7 @@ integer, parameter :: INTERPOLATION_PQM_IH4IH3 = 8 !< O(h^4)
 integer, parameter :: INTERPOLATION_PQM_IH6IH5 = 9 !< O(h^5)
 
 !> List of interpolant degrees
-integer, parameter :: DEGREE_1 = 1, DEGREE_2 = 2, DEGREE_3 = 3, DEGREE_4 = 4
+integer, parameter :: DEGREE_1 = 1, DEGREE_2 = 2, DEGREE_3 = 3, DEGREE_4 = 4, DEGREE_MAX = 5
 
 !> When the N-R algorithm produces an estimate that lies outside [0,1], the
 !! estimate is set to be equal to the boundary location, 0 or 1, plus or minus
@@ -301,7 +301,6 @@ function get_polynomial_coordinate ( N, h, x_g, ppoly_E, ppoly_coefficients, &
   integer            :: k_found         ! index of target cell
   integer            :: iter
   real               :: xi0             ! normalized target coordinate
-  real, dimension(5) :: a               ! polynomial coefficients
   real               :: numerator
   real               :: denominator
   real               :: delta           ! Newton-Raphson increment
@@ -309,6 +308,7 @@ function get_polynomial_coordinate ( N, h, x_g, ppoly_E, ppoly_coefficients, &
   real               :: eps                 ! offset used to get away from
                                         ! boundaries
   real               :: grad            ! gradient during N-R iterations
+  real, dimension(DEGREE_MAX) :: a               ! polynomial coefficients
 
   eps = NR_OFFSET
 

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -30,6 +30,7 @@ type, public :: interp_CS_type
 end type interp_CS_type
 
 public regridding_set_ppolys, interpolate_grid
+public build_and_interpolate_grid
 public set_interp_scheme, set_interp_extrap
 
 ! List of interpolation schemes
@@ -273,6 +274,23 @@ subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefficients, target_v
   h1(n1) = x1(n1+1) - x1(n1)
 
 end subroutine interpolate_grid
+
+subroutine build_and_interpolate_grid(CS, densities, n0, h0, x0, target_values, n1, h1, x1)
+  type(interp_CS_type), intent(in) :: CS
+  real, dimension(:), intent(in) :: densities, target_values
+  integer, intent(in) :: n0, n1
+  real, dimension(:), intent(in) :: h0, x0
+  real, dimension(:), intent(inout) :: h1, x1
+
+  real, dimension(n0,2) :: ppoly0_E, ppoly0_S
+  real, dimension(n0,DEGREE_MAX+1) :: ppoly0_C
+  integer :: degree
+
+  call regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, ppoly0_C, &
+       degree)
+  call interpolate_grid(n0, h0, x0, ppoly0_E, ppoly0_C, target_values, degree, &
+       n1, h1, x1)
+end subroutine build_and_interpolate_grid
 
 !> Given a target value, find corresponding coordinate for given polynomial
 !!

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -29,13 +29,13 @@ use MOM_EOS,              only : EOS_type
 use MOM_remapping,        only : remapping_CS, initialize_remapping
 use MOM_remapping,        only : remapping_core_h
 use MOM_regridding,       only : regridding_CS, initialize_regridding
-use MOM_regridding,       only : build_rho_column
 use MOM_regridding,       only : set_regrid_params, get_regrid_size, uniformResolution
 use MOM_regridding,       only : getCoordinateInterfaces
-use MOM_regridding,       only : get_zlike_CS, get_sigma_CS
+use MOM_regridding,       only : get_zlike_CS, get_sigma_CS, get_rho_CS
 use regrid_consts,        only : coordinateMode
 use coord_zlike,          only : build_zstar_column
 use coord_sigma,          only : build_sigma_column
+use coord_rho,            only : build_rho_column
 
 use diag_axis_mod,     only : get_diag_axis_name
 use diag_manager_mod,  only : diag_axis_init
@@ -262,7 +262,7 @@ subroutine diag_remap_update(remap_cs, G, h, T, S, eqn_of_state)
         call build_sigma_column(get_sigma_CS(remap_cs%regrid_cs), nz, &
                                 G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
       elseif (remap_cs%vertical_coord == coordinateMode('RHO')) then
-        call build_rho_column(remap_cs%regrid_cs, remap_cs%remap_cs, nz, &
+        call build_rho_column(get_rho_CS(remap_cs%regrid_cs), remap_cs%remap_cs, nz, &
                               G%bathyT(i,j), h(i,j,:), T(i, j, :), S(i, j, :), &
                               eqn_of_state, zInterfaces)
       elseif (remap_cs%vertical_coord == coordinateMode('SLIGHT')) then

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -29,12 +29,13 @@ use MOM_EOS,              only : EOS_type
 use MOM_remapping,        only : remapping_CS, initialize_remapping
 use MOM_remapping,        only : remapping_core_h
 use MOM_regridding,       only : regridding_CS, initialize_regridding
-use MOM_regridding,       only : build_rho_column, build_sigma_column
+use MOM_regridding,       only : build_rho_column
 use MOM_regridding,       only : set_regrid_params, get_regrid_size, uniformResolution
 use MOM_regridding,       only : getCoordinateInterfaces
-use MOM_regridding,       only : get_zlike_CS
+use MOM_regridding,       only : get_zlike_CS, get_sigma_CS
 use regrid_consts,        only : coordinateMode
 use coord_zlike,          only : build_zstar_column
+use coord_sigma,          only : build_sigma_column
 
 use diag_axis_mod,     only : get_diag_axis_name
 use diag_manager_mod,  only : diag_axis_init
@@ -258,7 +259,7 @@ subroutine diag_remap_update(remap_cs, G, h, T, S, eqn_of_state)
         call build_zstar_column(get_zlike_CS(remap_cs%regrid_cs), nz, &
                               G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
       elseif (remap_cs%vertical_coord == coordinateMode('SIGMA')) then
-        call build_sigma_column(remap_cs%regrid_cs, nz, &
+        call build_sigma_column(get_sigma_CS(remap_cs%regrid_cs), nz, &
                                 G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
       elseif (remap_cs%vertical_coord == coordinateMode('RHO')) then
         call build_rho_column(remap_cs%regrid_cs, remap_cs%remap_cs, nz, &

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -29,10 +29,12 @@ use MOM_EOS,              only : EOS_type
 use MOM_remapping,        only : remapping_CS, initialize_remapping
 use MOM_remapping,        only : remapping_core_h
 use MOM_regridding,       only : regridding_CS, initialize_regridding
-use MOM_regridding,       only : build_zstar_column, build_rho_column, build_sigma_column
+use MOM_regridding,       only : build_rho_column, build_sigma_column
 use MOM_regridding,       only : set_regrid_params, get_regrid_size, uniformResolution
 use MOM_regridding,       only : getCoordinateInterfaces
+use MOM_regridding,       only : get_zlike_CS
 use regrid_consts,        only : coordinateMode
+use coord_zlike,          only : build_zstar_column
 
 use diag_axis_mod,     only : get_diag_axis_name
 use diag_manager_mod,  only : diag_axis_init
@@ -253,7 +255,7 @@ subroutine diag_remap_update(remap_cs, G, h, T, S, eqn_of_state)
       endif
 
       if (remap_cs%vertical_coord == coordinateMode('ZSTAR')) then
-        call build_zstar_column(remap_cs%regrid_cs, nz, &
+        call build_zstar_column(get_zlike_CS(remap_cs%regrid_cs), nz, &
                               G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
       elseif (remap_cs%vertical_coord == coordinateMode('SIGMA')) then
         call build_sigma_column(remap_cs%regrid_cs, nz, &


### PR DESCRIPTION
In order to start simplifying the MOM_regridding module and allow for more targeted testing, I've split out the `build_*_column()` routines (and some of their accompanying support code) to separate modules. Their interfaces remain basically the same, but because they no longer have access to the `regridding_CS` type, each coordinate has its own control structure containing *pointers* to the parameters that it uses.

When the regridding coordinate is initialised in `init_coord_*()`, the pointers are in effect associated with the fields in the main `regridding_CS` for which the coordinate was initialised. This is because the coordinate is initialised at the end of `initialize_regridding()`, but there may be subsequent calls to `set_regrid_params()` that then update the parameters. I haven't begun tackling a more elegant solution to the initialisation of regridding, which could end up tidying up this process.

In addition to splitting out coordinates to their own modules, the interpolation used for the grid has also been moved to its own module. This exposes three routines: `regridding_set_ppolys()` and `interpolate_grid()`, which were previously present and wrap the process of computing and using a polynomial interpolation (particularly for calculating the position of interfaces according to their target density). The third routine, `build_and_interpolate_grid()` combines these two steps, removing the need for the caller to store the polynomial coefficients, edge values, and degree.

This changeset shouldn't change answers since it's just a refactor. However, I'm not sure of the semantic effects of using pointers instead of allocatable arrays within the control structures. In particular, does `allocated(<pointer>)` return the same result as `allocated(<target>)`?