### PR TITLE
Adds option to apply (ALE) sponges in u and v

### DIFF
--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -94,7 +94,8 @@ use MOM_file_parser,           only : get_param, log_version, param_file_type
 use MOM_grid,                  only : ocean_grid_type
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types,            only : MEKE_type
-use MOM_open_boundary,         only : ocean_OBC_type, OBC_NONE
+use MOM_open_boundary,         only : ocean_OBC_type, OBC_DIRECTION_E, OBC_DIRECTION_W
+use MOM_open_boundary,         only : OBC_DIRECTION_N, OBC_DIRECTION_S, OBC_NONE
 use MOM_verticalGrid,          only : verticalGrid_type
 use MOM_io,                    only : read_data, slasher
 
@@ -249,8 +250,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
 !   v[is-2,is-1,ie+1,ie+2], u[is-2,is-1,ie+1,ie+2], and h[is-1,ie+1],
 !  with a similarly sized halo in the y-direction.
 
-  real, dimension(SZIB_(G),SZJ_(G)) :: u0 ! Laplacian of u (m-1 s-1)
-  real, dimension(SZI_(G),SZJB_(G)) :: v0 ! Laplacian of v (m-1 s-1)
+  real, dimension(SZIB_(G),SZJ_(G)) :: &
+    u0, &   ! Laplacian of u (m-1 s-1)
+    h_u     ! Thickness interpolated to u points, in H.
+  real, dimension(SZI_(G),SZJB_(G)) :: &
+    v0, &   ! Laplacian of v (m-1 s-1)
+    h_v     ! Thickness interpolated to v points, in H.
 
   real, dimension(SZI_(G),SZJ_(G)) :: &
     sh_xx, &      ! horizontal tension (du/dx - dv/dy) (1/sec) including metric terms
@@ -278,10 +283,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
   real :: AhSm       ! Smagorinsky biharmonic viscosity (m4/s)
   real :: KhSm       ! Smagorinsky Laplacian viscosity  (m2/s)
   real :: Shear_mag  ! magnitude of the shear (1/s)
-  real :: huq, hvq   ! temporary variables in units of H^2 (i.e. m2 or kg2 m-4).
-  real :: hu, hv     ! thicknesses at velocity points in units of H (i.e. m or kg m-2).
+  real :: h2uq, h2vq ! temporary variables in units of H^2 (i.e. m2 or kg2 m-4).
+  real :: hu, hv     ! Thicknesses interpolated by arithmetic means to corner
+                     ! points; these are first interpolated to u or v velocity
+                     ! points where masks are applied, in units of H (i.e. m or kg m-2).
   real :: hq         ! harmonic mean of the harmonic means of the u- & v-
-                     ! point thicknesses, in H; guarantees that hq/hu < 4.
+                     ! point thicknesses, in H; This form guarantees that hq/hu < 4.
   real :: h_neglect  ! thickness so small it can be lost in roundoff and so neglected (H)
   real :: h_neglect3 ! h_neglect^3, in H3
   real :: hrat_min   ! minimum thicknesses at the 4 neighboring
@@ -339,8 +346,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
 !$OMP                                  find_FrictWork,FrictWork,use_MEKE_Ku,MEKE)     &
 !$OMP                          private(u0, v0, sh_xx, str_xx, visc_bound_rem,         &
 !$OMP                                  sh_xy, str_xy, Ah, Kh, AhSm, KhSm, dvdx, dudy, &
-!$OMP                                  bhstr_xx, bhstr_xy,FatH,RoScl, hu, hv,         &
-!$OMP                                  Shear_mag, huq, hvq, hq, Kh_scale, hrat_min)
+!$OMP                                  bhstr_xx, bhstr_xy,FatH,RoScl, hu, hv, h_u, h_v, &
+!$OMP                                  Shear_mag, h2uq, h2vq, hq, Kh_scale, hrat_min)
   do k=1,nz
 
 !    This code uses boundary conditions that are consistent with
@@ -367,32 +374,102 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
       dvdx(I,J) = CS%DY_dxBu(I,J)*(v(i+1,J,k)*G%IdyCv(i+1,J) - v(i,J,k)*G%IdyCv(i,J))
       dudy(I,J) = CS%DX_dyBu(I,J)*(u(I,j+1,k)*G%IdxCu(I,j+1) - u(I,j,k)*G%IdxCu(I,j))
     enddo ; enddo
-    ! Adjust contributions to shearing strain on open boundaries.
-    if (apply_OBC) then ; if (OBC%zero_strain .or. OBC%freeslip_strain) then
-      do n=1,OBC%number_of_segments
-        if (OBC%segment(n)%is_N_or_S) then
-          J = OBC%segment(n)%HI%JsdB
+
+    ! Interpolate the thicknesses to velocity points.
+    ! The extra wide halos are to accomodate the cross-corner-point projections
+    ! in OBCs, which are not ordinarily be necessary, and might not be necessary
+    ! even with OBCs if the accelerations are zeroed at OBC points, in which
+    ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
+    do j=js-2,je+2 ; do I=Isq-1,Ieq+1
+      h_u(I,j) = 0.5 * (h(i,j,k) + h(i+1,j,k))
+    enddo ; enddo
+    do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
+      h_v(i,J) = 0.5 * (h(i,j,k) + h(i,j+1,k))
+    enddo ; enddo
+
+    ! Adjust contributions to shearing strain and interpolated values of
+    ! thicknesses on open boundaries.
+    if (apply_OBC) then ; do n=1,OBC%number_of_segments
+      J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
+      if (OBC%zero_strain .or. OBC%freeslip_strain) then
+        if (OBC%segment(n)%is_N_or_S .and. (J >= js-2) .and. (J <= Jeq+1)) then
           do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
             if (OBC%zero_strain) then
-              dvdx(I,J) = 0.
-              dudy(I,J) = 0.
+              dvdx(I,J) = 0. ; dudy(I,J) = 0.
             elseif (OBC%freeslip_strain) then
               dudy(I,J) = 0.
             endif
           enddo
-        elseif (OBC%segment(n)%is_E_or_W) then
-          I = OBC%segment(n)%HI%IsdB
+        elseif (OBC%segment(n)%is_E_or_W .and. (I >= is-2) .and. (I <= Ieq+1)) then
           do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
             if (OBC%zero_strain) then
-              dvdx(I,J) = 0.
-              dudy(I,J) = 0.
+              dvdx(I,J) = 0. ; dudy(I,J) = 0.
             elseif (OBC%freeslip_strain) then
               dvdx(I,J) = 0.
             endif
           enddo
         endif
-      enddo
-    endif ; endif
+      endif
+      if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+        ! There are extra wide halos here to accomodate the cross-corner-point
+        ! OBC projections, but they might not be necessary if the accelerations
+        ! are always zeroed out at OBC points, in which case the i-loop below
+        ! becomes do i=is-1,ie+1. -RWH
+        if ((J >= Jsq-1) .and. (J <= Jeq+1)) then
+          do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
+            h_v(i,J) = h(i,j,k)
+          enddo
+        endif
+      elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
+        if ((J >= Jsq-1) .and. (J <= Jeq+1)) then
+          do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
+            h_v(i,J) = h(i,j+1,k)
+          enddo
+        endif
+      elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+        if ((I >= Isq-1) .and. (I <= Ieq+1)) then
+          do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
+            h_u(I,j) = h(i,j,k)
+          enddo
+        endif
+      elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
+        if ((I >= Isq-1) .and. (I <= Ieq+1)) then
+          do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
+            h_u(I,j) = h(i+1,j,k)
+          enddo
+        endif
+      endif
+    enddo ; endif
+    ! Now project thicknesses across corner points on OBCs.
+    if (apply_OBC) then ; do n=1,OBC%number_of_segments
+      J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
+      if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+        if ((J >= js-2) .and. (J <= je)) then
+          do I = max(Isq-1,OBC%segment(n)%HI%IsdB), min(Ieq+1,OBC%segment(n)%HI%IedB)
+            h_u(I,j+1) = h_u(I,j)
+          enddo
+        endif
+      elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
+        if ((J >= js-1) .and. (J <= je+1)) then
+          do I = max(Isq-1,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
+            h_u(I,j) = h_u(i,j+1)
+          enddo
+        endif
+      elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+        if ((I >= is-2) .and. (I <= ie)) then
+          do J = max(Jsq-1,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
+            h_v(i+1,J) = h_v(i,J)
+          enddo
+        endif
+      elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
+        if ((I >= is-1) .and. (I <= ie+1)) then
+          do J = max(Jsq-1,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
+            h_v(i,J) = h_v(i+1,J)
+          enddo
+        endif
+      endif
+    enddo ; endif
+
     if (CS%no_slip) then
       do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
         sh_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) + dudy(I,J) )
@@ -415,13 +492,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
       enddo ; enddo
       if (apply_OBC .and. OBC%zero_biharmonic) then
         do n=1,OBC%number_of_segments
-          if (OBC%segment(n)%is_N_or_S) then
-            J = OBC%segment(n)%HI%JsdB
+          I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
+          if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
             do I=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
               v0(i,J) = 0.
             enddo
-          elseif (OBC%segment(n)%is_E_or_W) then
-            I = OBC%segment(n)%HI%IsdB
+          elseif (OBC%segment(n)%is_E_or_W .and. (I >= Isq-1) .and. (I <= Ieq+1)) then
             do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
               u0(I,j) = 0.
             enddo
@@ -436,10 +512,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
           0.25*((sh_xy(I-1,J-1)*sh_xy(I-1,J-1) + sh_xy(I,J)*sh_xy(I,J)) + &
                 (sh_xy(I-1,J)*sh_xy(I-1,J) + sh_xy(I,J-1)*sh_xy(I,J-1))))
       if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
-        hrat_min = min(1.0, &
-            0.5*min((h(i+1,j,k) + h(i,j,k)), (h(i,j,k) + h(i-1,j,k)), &
-                    (h(i,j+1,k) + h(i,j,k)), (h(i,j-1,k) + h(i,j,k))) / &
-            (h(i,j,k) + h_neglect) )
+        hrat_min = min(1.0, min(h_u(I,j), h_u(I-1,j), h_v(i,J), h_v(i,J-1)) / &
+                            (h(i,j,k) + h_neglect) )
         visc_bound_rem = 1.0
       endif
 
@@ -521,22 +595,19 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
       ! Adjust contributions to shearing strain on open boundaries.
       if (apply_OBC) then ; if (OBC%zero_strain .or. OBC%freeslip_strain) then
         do n=1,OBC%number_of_segments
-          if (OBC%segment(n)%is_N_or_S) then
-            J = OBC%segment(n)%HI%JsdB
+          J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
+          if (OBC%segment(n)%is_N_or_S .and. (J >= js-1) .and. (J <= Jeq)) then
             do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
               if (OBC%zero_strain) then
-                dvdx(I,J) = 0.
-                dudy(I,J) = 0.
+                dvdx(I,J) = 0. ; dudy(I,J) = 0.
               elseif (OBC%freeslip_strain) then
                 dudy(I,J) = 0.
               endif
             enddo
-          elseif (OBC%segment(n)%is_E_or_W) then
-            I = OBC%segment(n)%HI%IsdB
+          elseif (OBC%segment(n)%is_E_or_W .and. (I >= is-1) .and. (I <= Ieq)) then
             do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
               if (OBC%zero_strain) then
-                dvdx(I,J) = 0.
-                dudy(I,J) = 0.
+                dvdx(I,J) = 0. ; dudy(I,J) = 0.
               elseif (OBC%freeslip_strain) then
                 dvdx(I,J) = 0.
               endif
@@ -545,22 +616,23 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
         enddo
       endif ; endif
     endif
+
     do J=js-1,Jeq ; do I=is-1,Ieq
       if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) &
         Shear_mag = sqrt(sh_xy(I,J)*sh_xy(I,J) + &
             0.25*((sh_xx(i,j)*sh_xx(i,j) + sh_xx(i+1,j+1)*sh_xx(i+1,j+1)) + &
                   (sh_xx(i,j+1)*sh_xx(i,j+1) + sh_xx(i+1,j)*sh_xx(i+1,j))))
 
-      huq = (h(i,j,k) + h(i+1,j,k)) * (h(i,j+1,k) + h(i+1,j+1,k))
-      hvq = (h(i,j,k) + h(i,j+1,k)) * (h(i+1,j,k) + h(i+1,j+1,k))
-      hq = 2.0 * huq * hvq / (h_neglect3 + (huq + hvq) * &
-          ((h(i,j,k) + h(i+1,j+1,k)) + (h(i,j+1,k) + h(i+1,j,k))))
+      h2uq = 4.0 * h_u(I,j) * h_u(I,j+1)
+      h2vq = 4.0 * h_v(i,J) * h_v(i+1,J)
+!      hq = 2.0 * h2uq * h2vq / (h_neglect3 + (h2uq + h2vq) * &
+!          ((h(i,j,k) + h(i+1,j+1,k)) + (h(i,j+1,k) + h(i+1,j,k))))
+      hq = 2.0 * h2uq * h2vq / (h_neglect3 + (h2uq + h2vq) * &
+          ((h_u(I,j) + h_u(I,j+1)) + (h_v(i,J) + h_v(i+1,J))))
 
       if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
-        hrat_min = min(1.0, &
-            0.5*min((h(i,j,k) + h(i+1,j,k)), (h(i,j+1,k) + h(i+1,j+1,k)), &
-                    (h(i,j,k) + h(i,j+1,k)), (h(i+1,j,k) + h(i+1,j+1,k))) / &
-                   (hq + h_neglect) )
+        hrat_min = min(1.0, min(h_u(I,j), h_u(I,j+1), h_v(i,J), h_v(i+1,J)) / &
+                            (hq + h_neglect) )
         visc_bound_rem = 1.0
       endif
 
@@ -569,10 +641,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
             (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) > 0.0) then
           ! This is a coastal vorticity point, so modify hq and hrat_min.
 
-          hu = 0.5 * (G%mask2dCu(I,j)   * (h(i,j,k) + h(i+1,j,k)) + &
-                      G%mask2dCu(I,j+1) * (h(i,j+1,k) + h(i+1,j+1,k)))
-          hv = 0.5 * (G%mask2dCv(i,J)   * (h(i,j,k) + h(i,j+1,k)) + &
-                      G%mask2dCv(i+1,J) * (h(i+1,j,k) + h(i+1,j+1,k)))
+          hu = G%mask2dCu(I,j) * h_u(I,j) + G%mask2dCu(I,j+1) * h_u(I,j+1)
+          hv = G%mask2dCv(i,J) * h_v(i,J) + G%mask2dCv(i+1,J) * h_v(i+1,J)
           if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) * &
               (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) == 0.0) then
             ! Only one of hu and hv is nonzero, so just add them.
@@ -665,7 +735,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
                                     CS%DY2h(i+1,j)*str_xx(i+1,j)) + &
                        G%IdxCu(I,j)*(CS%DX2q(I,J-1)*str_xy(I,J-1) - &
                                     CS%DX2q(I,J) *str_xy(I,J))) * &
-                     G%IareaCu(I,j)) / (0.5*(h(i+1,j,k) + h(i,j,k)) + h_neglect)
+                     G%IareaCu(I,j)) / (h_u(i,j) + h_neglect)
 
     enddo ; enddo
     if (apply_OBC) then
@@ -687,7 +757,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
                                     CS%DY2q(I,J) *str_xy(I,J)) - &
                        G%IdxCv(i,J)*(CS%DX2h(i,j) *str_xx(i,j) - &
                                     CS%DX2h(i,j+1)*str_xx(i,j+1))) * &
-                     G%IareaCv(i,J)) / (0.5*(h(i,j+1,k) + h(i,j,k)) + h_neglect)
+                     G%IareaCv(i,J)) / (h_v(i,J) + h_neglect)
     enddo ; enddo
     if (apply_OBC) then
       ! This is not the right boundary condition. If all the masking of tendencies are done

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -2,10 +2,11 @@
 !! the ALE mode.
 !! Applying sponges requires the following:
 !! (1) initialize_ALE_sponge
-!! (2) set_up_ALE_sponge_field
+!! (2) set_up_ALE_sponge_field (tracers) and set_up_ALE_sponge_vel_field (vel)
 !! (3) apply_ALE_sponge
 !! (4) init_ALE_sponge_diags (not being used for now)
 !! (5) ALE_sponge_end (not being used for now)
+
 module MOM_ALE_sponge
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -27,7 +28,7 @@ implicit none ; private
 #include <MOM_memory.h>
 
 !< Publicly available functions
-public set_up_ALE_sponge_field
+public set_up_ALE_sponge_field, set_up_ALE_sponge_vel_field
 public initialize_ALE_sponge, apply_ALE_sponge, ALE_sponge_end, init_ALE_sponge_diags
 
 type :: p3d
@@ -39,24 +40,43 @@ end type p2d
 
 !> SPONGE control structure
 type, public :: ALE_sponge_CS ; private
-  integer :: nz              !< The total number of layers.
-  integer :: nz_data              !< The total number of arbritary layers.
-  integer :: isc, iec, jsc, jec  !< The index ranges of the computational domain.
-  integer :: isd, ied, jsd, jed  !< The index ranges of the data domain.
-  integer :: num_col         !< The number of sponge points within the
-                             ! computational domain.
+  integer :: nz                      !< The total number of layers.
+  integer :: nz_data                 !< The total number of arbritary layers.
+  integer :: isc, iec, jsc, jec      !< The index ranges of the computational domain at h.
+  integer :: iscB, iecB, jscB, jecB  !< The index ranges of the computational domain at u/v.
+  integer :: isd, ied, jsd, jed      !< The index ranges of the data domain.
+
+  integer :: num_col, num_col_u, num_col_v  !< The number of sponge points within the
+                             !! computational domain.
   integer :: fldno = 0       !< The number of fields which have already been
-                             ! registered by calls to set_up_sponge_field
+                             !! registered by calls to set_up_sponge_field
+  logical :: sponge_uv      !< Control whether u and v are included in sponge
   integer, pointer :: col_i(:) => NULL()  !< Arrays containing the i- and j- indicies
-  integer, pointer :: col_j(:) => NULL()  ! of each of the columns being damped.
+  integer, pointer :: col_j(:) => NULL()  !! of each of the columns being damped.
+  integer, pointer :: col_i_u(:) => NULL()  !< Same as above for u points
+  integer, pointer :: col_j_u(:) => NULL()
+  integer, pointer :: col_i_v(:) => NULL()  !< Same as above for v points
+  integer, pointer :: col_j_v(:) => NULL()
+
   real, pointer :: Iresttime_col(:) => NULL()  !< The inverse restoring time of
-                                                ! each column.
+                                               !! each column.
+  real, pointer :: Iresttime_col_u(:) => NULL()  !< Same as above for u points
+  real, pointer :: Iresttime_col_v(:) => NULL()  !< Same as above for v points
+
   type(p3d) :: var(MAX_FIELDS_)      !< Pointers to the fields that are being damped.
   type(p2d) :: Ref_val(MAX_FIELDS_)  !< The values to which the fields are damped.
+  real, dimension(:,:), pointer :: Ref_val_u => NULL() !< Same as above for u points
+  real, dimension(:,:), pointer :: Ref_val_v => NULL() !< Same as above for v points
+  real, dimension(:,:,:),  pointer :: var_u => NULL() !< Pointers to the u vel. that are
+                                                           !! being damped.
+  real, dimension(:,:,:),  pointer :: var_v => NULL() !< Pointers to the v vel. that are
+                                                           !! being damped.
   real, pointer :: Ref_h(:,:) => NULL() !< Grid on which reference data is provided
+  real, pointer :: Ref_hu(:,:) => NULL() !< Same as above for u points
+  real, pointer :: Ref_hv(:,:) => NULL() !< Same as above for v points
 
   type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the
-                                   ! timing of diagnostic output.
+                                   !! timing of diagnostic output.
 
   type(remapping_cs) :: remap_cs   !< Remapping parameters and work arrays
 
@@ -69,14 +89,13 @@ contains
 ! positive values of Iresttime and which mask2dT indicates are ocean
 ! points are included in the sponges.  It also stores the target interface
 ! heights.
-
 subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
 
   integer,                              intent(in) :: nz_data !< The total number of arbritary layers (in).
   type(ocean_grid_type),                intent(in) :: G !< The ocean's grid structure (in).
   real, dimension(SZI_(G),SZJ_(G)),     intent(in) :: Iresttime !< The inverse of the restoring time, in s-1 (in).
   real, dimension(SZI_(G),SZJ_(G),nz_data), intent(in) :: data_h !< The thickness to be used in the sponge. It has arbritary layers (in).
-  type(param_file_type),                intent(in) :: param_file !< A structure indicating the open file to parse for model parameter values (in). GM: I don't know what this does!
+  type(param_file_type),                intent(in) :: param_file !< A structure indicating the open file to parse for model parameter values (in).
   type(ALE_sponge_CS),                  pointer    :: CS !< A pointer that is set to point to the control structure for this module (in/out).
 
 
@@ -84,8 +103,12 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
 #include "version_variable.h"
   character(len=40)  :: mod = "MOM_sponge"  ! This module's name.
   logical :: use_sponge
+  real, dimension(SZIB_(G),SZJ_(G),nz_data) :: data_hu !< thickness at u points
+  real, dimension(SZI_(G),SZJB_(G),nz_data) :: data_hv !< thickness at v points
+  real, dimension(SZIB_(G),SZJ_(G)) :: Iresttime_u !< inverse of the restoring time at u points, s-1
+  real, dimension(SZI_(G),SZJB_(G)) :: Iresttime_v !< inverse of the restoring time at v points, s-1
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
-  integer :: i, j, k, col, total_sponge_cols
+  integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
   character(len=10)  :: remapScheme
   if (associated(CS)) then
     call MOM_error(WARNING, "initialize_sponge called with an associated "// &
@@ -104,6 +127,10 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
 
   allocate(CS)
 
+  call get_param(param_file, mod, "SPONGE_UV", CS%sponge_uv, &
+                 "Apply sponges in u and v, in addition to tracers.", &
+                 default=.false.)
+
   call get_param(param_file, mod, "REMAPPING_SCHEME", remapScheme, &
                  "This sets the reconstruction scheme used \n"//&
                  " for vertical remapping for all variables.", &
@@ -119,6 +146,7 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
   CS%nz = G%ke
   CS%isc = G%isc ; CS%iec = G%iec ; CS%jsc = G%jsc ; CS%jec = G%jec
   CS%isd = G%isd ; CS%ied = G%ied ; CS%jsd = G%jsd ; CS%jed = G%jed
+  CS%iscB = G%iscB ; CS%iecB = G%iecB; CS%jscB = G%jscB ; CS%jecB = G%jecB
 
   ! number of columns to be restored
   CS%num_col = 0 ; CS%fldno = 0
@@ -159,8 +187,84 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
 ! Call the constructor for remapping control structure
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation)
 
-  call log_param(param_file, mod, "!Total sponge columns", total_sponge_cols, &
-                 "The total number of columns where sponges are applied.")
+  call log_param(param_file, mod, "!Total sponge columns at h points", total_sponge_cols, &
+                 "The total number of columns where sponges are applied at h points.")
+
+  if (CS%sponge_uv) then
+     ! u points
+     CS%num_col_u = 0 ; !CS%fldno_u = 0
+     do j=CS%jsc,CS%jec; do I=CS%iscB,CS%iecB
+        data_hu(I,j,:) = 0.5 * (data_h(i,j,:) + data_h(i+1,j,:))
+        Iresttime_u(I,j) = 0.5 * (Iresttime(i,j) + Iresttime(i+1,j))
+        if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) &
+           CS%num_col_u = CS%num_col_u + 1
+     enddo; enddo
+
+     if (CS%num_col_u > 0) then
+
+        allocate(CS%Iresttime_col_u(CS%num_col_u)) ; CS%Iresttime_col_u = 0.0
+        allocate(CS%col_i_u(CS%num_col_u))         ; CS%col_i_u = 0
+        allocate(CS%col_j_u(CS%num_col_u))         ; CS%col_j_u = 0
+
+        ! pass indices, restoring time to the CS structure
+        col = 1
+        do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+          if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) then
+            CS%col_i_u(col) = i ; CS%col_j_u(col) = j
+            CS%Iresttime_col_u(col) = Iresttime_u(i,j)
+            col = col +1
+          endif
+        enddo ; enddo
+
+        ! same for total number of arbritary layers and correspondent data
+        allocate(CS%Ref_hu(CS%nz_data,CS%num_col_u))
+        do col=1,CS%num_col_u ; do K=1,CS%nz_data
+           CS%Ref_hu(K,col) = data_hu(CS%col_i_u(col),CS%col_j_u(col),K)
+        enddo ; enddo
+
+     endif
+     total_sponge_cols_u = CS%num_col_u
+     call sum_across_PEs(total_sponge_cols_u)
+     call log_param(param_file, mod, "!Total sponge columns at u points", total_sponge_cols_u, &
+                 "The total number of columns where sponges are applied at u points.")
+
+     ! v points
+     CS%num_col_v = 0 ; !CS%fldno_v = 0
+     do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+        data_hu(i,J,:) = 0.5 * (data_h(i,j,:) + data_h(i,j+1,:))
+        Iresttime_v(i,J) = 0.5 * (Iresttime(i,j) + Iresttime(i,j+1))
+        if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) &
+           CS%num_col_v = CS%num_col_v + 1
+     enddo; enddo
+
+     if (CS%num_col_v > 0) then
+
+        allocate(CS%Iresttime_col_v(CS%num_col_v)) ; CS%Iresttime_col_v = 0.0
+        allocate(CS%col_i_v(CS%num_col_v))         ; CS%col_i_v = 0
+        allocate(CS%col_j_v(CS%num_col_v))         ; CS%col_j_v = 0
+
+        ! pass indices, restoring time to the CS structure
+        col = 1
+        do J=CS%jscB,CS%jecB ; do i=CS%isc,CS%iec
+          if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) then
+            CS%col_i_v(col) = i ; CS%col_j_v(col) = j
+            CS%Iresttime_col_v(col) = Iresttime_v(i,j)
+            col = col +1
+          endif
+        enddo ; enddo
+
+        ! same for total number of arbritary layers and correspondent data
+        allocate(CS%Ref_hv(CS%nz_data,CS%num_col_v))
+        do col=1,CS%num_col_v ; do K=1,CS%nz_data
+           CS%Ref_hv(K,col) = data_hv(CS%col_i_v(col),CS%col_j_v(col),K)
+        enddo ; enddo
+
+     endif
+     total_sponge_cols_v = CS%num_col_v
+     call sum_across_PEs(total_sponge_cols_v)
+     call log_param(param_file, mod, "!Total sponge columns at v points", total_sponge_cols_v, &
+                 "The total number of columns where sponges are applied at v points.")
+  endif
 
 end subroutine initialize_ALE_sponge
 
@@ -178,7 +282,7 @@ subroutine init_ALE_sponge_diags(Time, G, diag, CS)
 
 end subroutine init_ALE_sponge_diags
 
-!> This subroutine stores the reference profile for the variable
+!> This subroutine stores the reference profile at h points for the variable
 ! whose address is given by f_ptr.
 subroutine set_up_ALE_sponge_field(sp_val, G, f_ptr, CS)
   type(ocean_grid_type),                   intent(in) :: G !< Grid structure (in).
@@ -213,6 +317,44 @@ subroutine set_up_ALE_sponge_field(sp_val, G, f_ptr, CS)
 
 end subroutine set_up_ALE_sponge_field
 
+!> This subroutine stores the reference profile at uand v points for the variable
+! whose address is given by u_ptr and v_ptr.
+subroutine set_up_ALE_sponge_vel_field(u_val, v_val, G, u_ptr, v_ptr, CS)
+  type(ocean_grid_type),                   intent(in) :: G !< Grid structure (in).
+  type(ALE_sponge_CS),                     pointer  :: CS !< Sponge structure (in/out).
+  real, dimension(SZIB_(G),SZJ_(G),CS%nz_data), intent(in) :: u_val !< u field to be used in the sponge, it has arbritary number of layers (in).
+  real, dimension(SZI_(G),SZJB_(G),CS%nz_data), intent(in) :: v_val !< u field to be used in the sponge, it has arbritary number of layers (in).
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), target, intent(in) :: u_ptr !< u pointer to the field to be damped (in).
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), target, intent(in) :: v_ptr !< v pointer to the field to be damped (in).
+
+  integer :: j, k, col
+  character(len=256) :: mesg ! String for error messages
+
+  if (.not.associated(CS)) return
+
+  ! stores the reference profile
+  allocate(CS%Ref_val_u(CS%nz_data,CS%num_col_u))
+  CS%Ref_val_u(:,:) = 0.0
+  do col=1,CS%num_col_u
+    do k=1,CS%nz_data
+      CS%Ref_val_u(k,col) = u_val(CS%col_i_u(col),CS%col_j_u(col),k)
+    enddo
+  enddo
+
+  CS%var_u => u_ptr
+
+  allocate(CS%Ref_val_v(CS%nz_data,CS%num_col_v))
+  CS%Ref_val_v(:,:) = 0.0
+  do col=1,CS%num_col_v
+    do k=1,CS%nz_data
+      CS%Ref_val_v(k,col) = v_val(CS%col_i_v(col),CS%col_j_v(col),k)
+    enddo
+  enddo
+
+  CS%var_v => v_ptr
+
+end subroutine set_up_ALE_sponge_vel_field
+
 !> This subroutine applies damping to the layers thicknesses, temp, salt and a variety of tracers for every column where there is damping.
 subroutine apply_ALE_sponge(h, dt, G, CS)
   type(ocean_grid_type),                    intent(inout) :: G !< The ocean's grid structure (in).
@@ -225,7 +367,8 @@ subroutine apply_ALE_sponge(h, dt, G, CS)
   real :: Idt                                                !< 1.0/dt, in s-1.
   real :: tmp_val1(cs%nz)                                    !< data values remapped to model grid
   real :: tmp_val2(cs%nz_data)                               ! data values remapped to model grid
-
+  real :: hu(SZIB_(G), SZJ_(G), SZK_(G))                     !> A temporary array for h at u pts
+  real :: hv(SZI_(G), SZJB_(G), SZK_(G))                     !> A temporary array for h at v pts
   integer :: c, m, nkmb, i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
@@ -242,7 +385,7 @@ subroutine apply_ALE_sponge(h, dt, G, CS)
             call remapping_core_h(CS%nz_data, CS%Ref_h(:,c), tmp_val2, &
                   CS%nz, h(i,j,:), tmp_val1, CS%remap_cs)
 
-!Backward Euler method
+            !Backward Euler method
             CS%var(m)%p(i,j,:) = I1pdamp * &
                                  (CS%var(m)%p(i,j,:) + tmp_val1 * damp)
 
@@ -256,6 +399,43 @@ subroutine apply_ALE_sponge(h, dt, G, CS)
   !do m=1,CS%fldno
   !   write(*,*)'APPLY SPONGE,m,CS%Ref_h(:,c),h(i,j,:),tmp_val2,tmp_val1',m,CS%Ref_h(:,c),h(i,j,:),tmp_val2,tmp_val1
   !enddo
+
+  if (CS%sponge_uv) then
+
+    ! u points
+    do j=CS%jsc,CS%jec; do I=CS%iscB,CS%iecB; do k=1,nz
+       hu(I,j,k) = 0.5 * (h(i,j,k) + h(i+1,j,k))
+    enddo; enddo; enddo
+
+    do c=1,CS%num_col_u
+       i = CS%col_i_u(c) ; j = CS%col_j_u(c)
+       damp = dt*CS%Iresttime_col_u(c)
+       I1pdamp = 1.0 / (1.0 + damp)
+       tmp_val2(1:CS%nz_data) = CS%Ref_val_u(1:CS%nz_data,c)
+       call remapping_core_h(CS%nz_data, CS%Ref_hu(:,c), tmp_val2, &
+                  CS%nz, hu(i,j,:), tmp_val1, CS%remap_cs)
+
+       !Backward Euler method
+       CS%var_u(i,j,:) = I1pdamp * (CS%var_u(i,j,:) + tmp_val1 * damp)
+    enddo
+
+    ! v points
+    do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec; do k=1,nz
+       hv(i,J,k) = 0.5 * (h(i,j,k) + h(i,j+1,k))
+    enddo; enddo; enddo
+
+    do c=1,CS%num_col_v
+       i = CS%col_i_v(c) ; j = CS%col_j_v(c)
+       damp = dt*CS%Iresttime_col_v(c)
+       I1pdamp = 1.0 / (1.0 + damp)
+       tmp_val2(1:CS%nz_data) = CS%Ref_val_v(1:CS%nz_data,c)
+       call remapping_core_h(CS%nz_data, CS%Ref_hv(:,c), tmp_val2, &
+                  CS%nz, hv(i,j,:), tmp_val1, CS%remap_cs)
+       !Backward Euler method
+       CS%var_v(i,j,:) = I1pdamp * (CS%var_v(i,j,:) + tmp_val1 * damp)
+    enddo
+
+  endif
 end subroutine apply_ALE_sponge
 
 !> GMM: I could not find where sponge_end is being called, but I am keeping
@@ -269,9 +449,15 @@ subroutine ALE_sponge_end(CS)
   if (.not.associated(CS)) return
 
   if (associated(CS%col_i)) deallocate(CS%col_i)
+  if (associated(CS%col_i_u)) deallocate(CS%col_i_u)
+  if (associated(CS%col_i_v)) deallocate(CS%col_i_v)
   if (associated(CS%col_j)) deallocate(CS%col_j)
+  if (associated(CS%col_j_u)) deallocate(CS%col_j_u)
+  if (associated(CS%col_j_v)) deallocate(CS%col_j_v)
 
   if (associated(CS%Iresttime_col)) deallocate(CS%Iresttime_col)
+  if (associated(CS%Iresttime_col_u)) deallocate(CS%Iresttime_col_u)
+  if (associated(CS%Iresttime_col_v)) deallocate(CS%Iresttime_col_v)
 
   do m=1,CS%fldno
     if (associated(CS%Ref_val(CS%fldno)%p)) deallocate(CS%Ref_val(CS%fldno)%p)


### PR DESCRIPTION
* MOM_ALE_sponge module has been modified to allow sponges in u and v.

* When `SPONGE = True` and `USE_REGRIDDING = True`, a new logical (`SPONGE_UV`, default is False) controls whether sponges also include u and v. If so (`SPONGE_UV = True`), u and v are nudged towards user specified values using the same nudging time scale as tracers.