### PR TITLE
Fix GNU build error

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -2063,7 +2063,7 @@ end subroutine initialize_shelf_mass
 
 !> Updates the ice shelf mass using data from a file.
 subroutine update_shelf_mass(G, CS, Time, fluxes)
-  type(ocean_grid_type), intent(in) :: G
+  type(ocean_grid_type), intent(inout) :: G
   type(ice_shelf_CS),         pointer    :: CS
   type(time_type),            intent(in) :: Time
   type(forcing),       intent(inout) :: fluxes


### PR DESCRIPTION
Commit aecb9989 ("Fixes perfect restart issue in the ICE_SHELF module", 2017-04-07) introduced calls to `pass_var()` within a subroutine whose `ocean_grid_type` structure was `intent(in)`. Most compilers seem to be happy with this, but certain versions of gfortran
would fail with the following error:

      call pass_var(CS%area_shelf_h, G%domain)
                                     1
    Error: Procedure argument at (1) is INTENT(IN) while interface specifies INTENT(INOUT)

Changing the argument to `intent(inout)` fixes this.