### PR TITLE
Liberate preale diagnostic registration

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2805,7 +2805,7 @@ subroutine register_diags(Time, G, GV, CS, ADp)
       'Layer Thickness before diabatic forcing', thickness_units, v_extensive=.true.)
   CS%id_e_predia = register_diag_field('ocean_model', 'e_predia', diag%axesTi, Time, &
       'Interface Heights before diabatic forcing', 'meter')
-  if (CS%diabatic_first .and. (.not. CS%adiabatic)) then
+  if (.not. CS%adiabatic) then
     CS%id_u_preale = register_diag_field('ocean_model', 'u_preale', diag%axesCuL, Time, &
         'Zonal velocity before remapping', 'meter second-1')
     CS%id_v_preale = register_diag_field('ocean_model', 'v_preale', diag%axesCvL, Time, &


### PR DESCRIPTION
At one point in time, the preale diagnostics were being registered, but if `ADIABATIC = True`, they wouldn't be posted. Commit 240c27cf ("Set conditions on *_preale diagnostic registration", 2015-06-03) added too much of a restriction on the registration, requiring that `DIABATIC_FIRST = True` in addition to `ADIABATIC = False`, addressed by this commit.