### PR TITLE
Boundary impulse tracer bug fixes

### DIFF
--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -341,7 +341,7 @@ subroutine boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, 
       evap_CFL_limit, minimum_forcing_depth)
     call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,1), G, GV)
   else
-    call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,1), G, GV)
+    call tracer_vertdiff(h_old, ea, eb, dt, CS%tr(:,:,:,1), G, GV)
   endif
 
   ! Set surface conditions

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -106,6 +106,7 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
   character(len=48)  :: var_name ! The variable's name.
   character(len=3)   :: name_tag ! String for creating identifying boundary_impulse
   real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: rem_time_ptr => NULL()
   logical :: register_boundary_impulse_tracer
   integer :: isd, ied, jsd, jed, nz, m, i, j
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
@@ -155,6 +156,12 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
       CS%ind_tr(m) = aof_set_coupler_flux(trim(var_name)//'_flux', &
           flux_type=' ', implementation=' ', caller="register_boundary_impulse_tracer")
   enddo
+  ! Register remaining source time as a restart field
+  rem_time_ptr => CS%remaining_source_time
+  call register_restart_field(rem_time_ptr,                                                                 &
+                              var_desc(trim("bir_remain_time"), "s", "Remaining time to apply BIR source",  &
+                                             hor_grid = "1", z_grid = "1", caller=mod),                     &
+                              .not. CS%tracers_may_reinit, restart_CS)
 
   CS%tr_Reg => tr_Reg
   CS%restart_CSp => restart_CS

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -81,12 +81,12 @@ contains
 
 !> Read in runtime options and add boundary impulse tracer to tracer registry
 function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
-  type(hor_index_type),       intent(in) :: HI
-  type(verticalGrid_type),    intent(in) :: GV
-  type(param_file_type),      intent(in) :: param_file
-  type(boundary_impulse_tracer_CS),        pointer    :: CS
-  type(tracer_registry_type), pointer    :: tr_Reg
-  type(MOM_restart_CS),       pointer    :: restart_CS
+  type(hor_index_type),                       intent(in   ) :: HI
+  type(verticalGrid_type),                    intent(in   ) :: GV
+  type(param_file_type),                      intent(in   ) :: param_file
+  type(boundary_impulse_tracer_CS), pointer,  intent(inout)    :: CS
+  type(tracer_registry_type),       pointer,  intent(inout) :: tr_Reg
+  type(MOM_restart_CS),             pointer,  intent(inout) :: restart_CS
 ! This subroutine is used to register tracer fields and subroutines
 ! to be used with MOM.
 ! Arguments: HI - A horizontal index type structure.
@@ -172,17 +172,17 @@ end function register_boundary_impulse_tracer
 !> Initialize tracer from restart or set to 1 at surface to initialize
 subroutine initialize_boundary_impulse_tracer(restart, day, G, GV, h, diag, OBC, CS, &
                                   sponge_CSp, diag_to_Z_CSp, tv)
-  logical,                            intent(in) :: restart
-  type(time_type), target,            intent(in) :: day
-  type(ocean_grid_type),              intent(in) :: G
-  type(verticalGrid_type),            intent(in) :: GV
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h
-  type(diag_ctrl), target,            intent(in) :: diag
-  type(ocean_OBC_type),               pointer    :: OBC
-  type(boundary_impulse_tracer_CS),          pointer    :: CS
-  type(sponge_CS),                    pointer    :: sponge_CSp
-  type(diag_to_Z_CS),                 pointer    :: diag_to_Z_CSp
-  type(thermo_var_ptrs),              intent(in) :: tv
+  logical,                                  intent(in   ) :: restart
+  type(time_type), target,                  intent(in   ) :: day
+  type(ocean_grid_type),                    intent(in   ) :: G
+  type(verticalGrid_type),                  intent(in   ) :: GV
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in   ) :: h
+  type(diag_ctrl), target,                  intent(in   ) :: diag
+  type(ocean_OBC_type), pointer,            intent(inout) :: OBC
+  type(boundary_impulse_tracer_CS), pointer,intent(inout) :: CS
+  type(sponge_CS), pointer,                 intent(inout) :: sponge_CSp
+  type(diag_to_Z_CS), pointer,              intent(inout) :: diag_to_Z_CSp
+  type(thermo_var_ptrs),                    intent(in   ) :: tv
 !   This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
 ! and it sets up the tracer output.
 
@@ -280,16 +280,16 @@ end subroutine initialize_boundary_impulse_tracer
 ! Apply source or sink at boundary and do vertical diffusion
 subroutine boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS, tv, debug, &
               evap_CFL_limit, minimum_forcing_depth)
-  type(ocean_grid_type),              intent(in) :: G
-  type(verticalGrid_type),            intent(in) :: GV
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h_old, h_new, ea, eb
-  type(forcing),                      intent(in) :: fluxes
-  real,                               intent(in) :: dt
-  type(boundary_impulse_tracer_CS),                pointer    :: CS
-  type(thermo_var_ptrs),              intent(in) :: tv
-  logical,                            intent(in) :: debug
-  real,                             optional,intent(in)  :: evap_CFL_limit
-  real,                             optional,intent(in)  :: minimum_forcing_depth
+  type(ocean_grid_type),                      intent(in   ) :: G
+  type(verticalGrid_type),                    intent(in   ) :: GV
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in   ) :: h_old, h_new, ea, eb
+  type(forcing),                              intent(in   ) :: fluxes
+  real,                                       intent(in   ) :: dt
+  type(boundary_impulse_tracer_CS), pointer,  intent(inout) :: CS
+  type(thermo_var_ptrs),                      intent(in   ) :: tv
+  logical,                                    intent(in   ) :: debug
+  real,                             optional, intent(in   ) :: evap_CFL_limit
+  real,                             optional, intent(in   ) :: minimum_forcing_depth
 
 !   This subroutine applies diapycnal diffusion and any other column
 ! tracer physics or chemistry to the tracers from this file.
@@ -392,15 +392,14 @@ end subroutine boundary_impulse_tracer_column_physics
 
 !> Calculate total inventory of tracer
 function boundary_impulse_stock(h, stocks, G, GV, CS, names, units, stock_index)
-  type(ocean_grid_type),              intent(in)    :: G
-  type(verticalGrid_type),            intent(in)    :: GV
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h
-  real, dimension(:),                 intent(out)   :: stocks
-  type(boundary_impulse_tracer_CS),                pointer       :: CS
-  character(len=*), dimension(:),     intent(out)   :: names
-  character(len=*), dimension(:),     intent(out)   :: units
-  integer, optional,                  intent(in)    :: stock_index
-  integer                                           :: boundary_impulse_stock
+  type(ocean_grid_type),                      intent(in   ) :: G
+  type(verticalGrid_type),                    intent(in   ) :: GV
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in   ) :: h
+  real, dimension(:),                         intent(  out) :: stocks
+  type(boundary_impulse_tracer_CS), pointer,  intent(in   ) :: CS
+  character(len=*), dimension(:),             intent(  out) :: names
+  character(len=*), dimension(:),             intent(  out) :: units
+  integer, optional,                          intent(in   ) :: stock_index
 ! This function calculates the mass-weighted integral of all tracer stocks,
 ! returning the number of stocks it has calculated.  If the stock_index
 ! is present, only the stock corresponding to that coded index is returned.
@@ -416,7 +415,7 @@ function boundary_impulse_stock(h, stocks, G, GV, CS, names, units, stock_index)
 !  (out)     units - the units of the stocks calculated.
 !  (in,opt)  stock_index - the coded index of a specific stock being sought.
 ! Return value: the number of stocks calculated here.
-
+  integer :: boundary_impulse_stock
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -448,10 +447,10 @@ end function boundary_impulse_stock
 
 !> Called if returned if coupler needs to know about tracer, currently unused
 subroutine boundary_impulse_tracer_surface_state(state, h, G, CS)
-  type(ocean_grid_type),                 intent(in)    :: G
-  type(surface),                         intent(inout) :: state
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h
-  type(boundary_impulse_tracer_CS),         pointer       :: CS
+  type(ocean_grid_type),                    intent(in   ) :: G
+  type(surface),                            intent(inout) :: state
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in   ) :: h
+  type(boundary_impulse_tracer_CS), pointer,intent(in   ) :: CS
 !   This particular tracer package does not report anything back to the coupler.
 ! The code that is here is just a rough guide for packages that would.
 ! Arguments: state - A structure containing fields that describe the

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -124,7 +124,11 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
                  "into the mixed layer. After this time has elapsed, the\n"//&
                  "surface becomes a sink for the boundary impulse tracer.", &
                  default=31536000.0)
-
+  call get_param(param_file, mod, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
+                 "If true, tracers may go through the initialization code \n"//&
+                 "if they are not found in the restart files.  Otherwise \n"//&
+                 "it is a fatal error if the tracers are not found in the \n"//&
+                 "restart files of a restarted run.", default=.false.)
   CS%ntr = NTR_MAX
   allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr)) ; CS%tr(:,:,:,:) = 0.0
 


### PR DESCRIPTION
Two separate bugs were found in my initial implementation of the boundary impulse tracer
- The remaining source time needed to be stored in the restart, otherwise the source time was always reset to the amount in MOM_input or the default source time.
- When tracerBoundaryFluxesInOut is not called from tracer_column_fns (e.g. in layer mode), the wrong layer thicknesses were used for vertical diffusion. 

This does not change answers.