### PR TITLE
Accelerated regridding initialisation (and adaptive coordinate fixes)

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -606,25 +606,25 @@ end subroutine ALE_build_grid
 !> For a state-based coordinate, accelerate the process of regridding by
 !! repeatedly applying the grid calculation algorithm
 subroutine ALE_regrid_accelerated(CS, G, GV, h_orig, tv, n, h_new, u, v)
-  type(ALE_CS),                               intent(in)    :: CS
-  type(ocean_grid_type),                      intent(inout) :: G
-  type(verticalGrid_type),                    intent(in)    :: GV
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h_orig
-  type(thermo_var_ptrs),                      intent(inout) :: tv
-  integer,                                    intent(in)    :: n
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(out)   :: h_new
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(inout) :: u
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(inout) :: v
+  type(ALE_CS),                               intent(in)    :: CS     !< ALE control structure
+  type(ocean_grid_type),                      intent(inout) :: G      !< Ocean grid
+  type(verticalGrid_type),                    intent(in)    :: GV     !< Vertical grid
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h_orig !< Original thicknesses
+  type(thermo_var_ptrs),                      intent(inout) :: tv     !< Thermo vars (T/S/EOS)
+  integer,                                    intent(in)    :: n      !< Number of times to regrid
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(out)   :: h_new  !< Thicknesses after regridding
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(inout) :: u      !< Zonal velocity
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(inout) :: v      !< Meridional velocity
 
   ! Local variables
   integer :: i, j, k, nz
   type(thermo_var_ptrs) :: tv_local ! local/intermediate temp/salt
   type(group_pass_type) :: pass_T_S_h ! group pass if the coordinate has a stencil
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G))         :: h
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), target :: T, S ! temporary state
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV))         :: h
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), target :: T, S ! temporary state
   ! we have to keep track of the total dzInterface if for some reason
   ! we're using the old remapping algorithm for u/v
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: dzInterface, dzIntTotal
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: dzInterface, dzIntTotal
 
   nz = GV%ke
 

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -1426,7 +1426,7 @@ subroutine build_grid_adaptive(G, GV, h, tv, dzInterface, remapCS, CS)
   zInt(:,:,1) = 0.
 
   ! work on interior interfaces
-  do K = 2, nz ; do j = G%jsc-1,G%jec+1 ; do i = G%isc-1,G%iec+1
+  do K = 2, nz ; do j = G%jsc-2,G%jec+2 ; do i = G%isc-2,G%iec+2
     tInt(i,j,K) = 0.5 * (tv%T(i,j,k-1) + tv%T(i,j,k))
     sInt(i,j,K) = 0.5 * (tv%S(i,j,k-1) + tv%S(i,j,k))
     zInt(i,j,K) = zInt(i,j,K-1) + h(i,j,k-1) ! zInt in [H]
@@ -1442,7 +1442,7 @@ subroutine build_grid_adaptive(G, GV, h, tv, dzInterface, remapCS, CS)
 
   ! calculate horizontal density derivatives (alpha/beta)
   ! between cells in a 5-point stencil, columnwise
-  do j = G%jsc,G%jec ; do i = G%isc,G%iec
+  do j = G%jsc-1,G%jec+1 ; do i = G%isc-1,G%iec+1
     if (G%mask2dT(i,j) < 0.5) then
       dzInterface(i,j,:) = 0. ! land point, don't move interfaces, and skip
       cycle

--- a/src/ALE/coord_adapt.F90
+++ b/src/ALE/coord_adapt.F90
@@ -101,7 +101,7 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
   ! Local variables
   integer :: k, nz
   real :: h_up, b1, b_denom_1, d1, depth, drdz, nominal_z, stretching
-  real, dimension(SZK_(GV)+1) :: alpha, beta, dzInterface ! drho/dT and drho/dS
+  real, dimension(SZK_(GV)+1) :: alpha, beta, del2sigma ! drho/dT and drho/dS
   real, dimension(SZK_(GV)) :: kGrid, c1 ! grid diffusivity on layers, and tridiagonal work array
 
   nz = CS%nk
@@ -113,6 +113,13 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
   ! local depth for scaling diffusivity
   depth = G%bathyT(i,j) * GV%m_to_H
 
+  ! initialize del2sigma to zero
+  del2sigma(:) = 0.
+
+  ! calculate del-squared of neutral density by a
+  ! stencilled finite difference
+  ! TODO: this needs to be adjusted to account for vanished layers near topography
+
   ! up (j-1)
   if (G%mask2dT(i,j-1) > 0.) then
     call calculate_density_derivs( &
@@ -121,7 +128,7 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
          0.5 * (zInt(i,j,2:nz) + zInt(i,j-1,2:nz)) * GV%H_to_Pa, &
          alpha, beta, 2, nz - 1, tv%eqn_of_state)
 
-    dzInterface(2:nz) = dzInterface(2:nz) + &
+    del2sigma(2:nz) = del2sigma(2:nz) + &
          (alpha(2:nz) * (tInt(i,j-1,2:nz) - tInt(i,j,2:nz)) + &
           beta(2:nz)  * (sInt(i,j-1,2:nz) - sInt(i,j,2:nz)))
   endif
@@ -133,7 +140,7 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
          0.5 * (zInt(i,j,2:nz) + zInt(i,j+1,2:nz)) * GV%H_to_Pa, &
          alpha, beta, 2, nz - 1, tv%eqn_of_state)
 
-    dzInterface(2:nz) = dzInterface(2:nz) + &
+    del2sigma(2:nz) = del2sigma(2:nz) + &
          (alpha(2:nz) * (tInt(i,j+1,2:nz) - tInt(i,j,2:nz)) + &
           beta(2:nz)  * (sInt(i,j+1,2:nz) - sInt(i,j,2:nz)))
   endif
@@ -145,7 +152,7 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
          0.5 * (zInt(i,j,2:nz) + zInt(i-1,j,2:nz)) * GV%H_to_Pa, &
          alpha, beta, 2, nz - 1, tv%eqn_of_state)
 
-    dzInterface(2:nz) = dzInterface(2:nz) + &
+    del2sigma(2:nz) = del2sigma(2:nz) + &
          (alpha(2:nz) * (tInt(i-1,j,2:nz) - tInt(i,j,2:nz)) + &
           beta(2:nz)  * (sInt(i-1,j,2:nz) - sInt(i,j,2:nz)))
   endif
@@ -157,34 +164,34 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
          0.5 * (zInt(i,j,2:nz) + zInt(i+1,j,2:nz)) * GV%H_to_Pa, &
          alpha, beta, 2, nz - 1, tv%eqn_of_state)
 
-    dzInterface(2:nz) = dzInterface(2:nz) + &
+    del2sigma(2:nz) = del2sigma(2:nz) + &
          (alpha(2:nz) * (tInt(i+1,j,2:nz) - tInt(i,j,2:nz)) + &
           beta(2:nz)  * (sInt(i+1,j,2:nz) - sInt(i,j,2:nz)))
   endif
 
-  ! at this point, dzInterface contains the local neutral density curvature at
+  ! at this point, del2sigma contains the local neutral density curvature at
   ! h-points, on interfaces
   ! we need to divide by drho/dz to give an interfacial displacement
   !
   ! a positive curvature means we're too light relative to adjacent columns,
-  ! so dzInterface needs to be positive too (push the interface deeper)
+  ! so del2sigma needs to be positive too (push the interface deeper)
   call calculate_density_derivs(tInt(i,j,:), sInt(i,j,:), zInt(i,j,:) * GV%H_to_Pa, &
        alpha, beta, 1, nz + 1, tv%eqn_of_state)
   do K = 2, nz
     ! TODO make lower bound here configurable
-    dzInterface(K) = dzInterface(K) * (0.5 * (h(i,j,k-1) + h(i,j,k))) / &
+    del2sigma(K) = del2sigma(K) * (0.5 * (h(i,j,k-1) + h(i,j,k))) / &
          max(alpha(K) * (tv%T(i,j,k) - tv%T(i,j,k-1)) + &
              beta(K)  * (tv%S(i,j,k) - tv%S(i,j,k-1)), 1e-20)
 
     ! don't move the interface so far that it would tangle with another
     ! interface in the direction we're moving (or exceed a Nyquist limit
     ! that could cause oscillations of the interface)
-    h_up = merge(h(i,j,k), h(i,j,k-1), dzInterface(K) > 0.)
-    dzInterface(K) = 0.5 * CS%adaptAlpha * &
-         sign(min(abs(dzInterface(K)), 0.5 * h_up), dzInterface(K))
+    h_up = merge(h(i,j,k), h(i,j,k-1), del2sigma(K) > 0.)
+    del2sigma(K) = 0.5 * CS%adaptAlpha * &
+         sign(min(abs(del2sigma(K)), 0.5 * h_up), del2sigma(K))
 
     ! update interface positions so we can diffuse them
-    zNext(K) = zInt(i,j,K) + dzInterface(K)
+    zNext(K) = zInt(i,j,K) + del2sigma(K)
   enddo
 
   ! solve diffusivity equation to smooth grid

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -398,7 +398,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
              "an initial grid that is consistent with the initial conditions.", &
              default=1)
 
-        call ALE_regrid_accelerated(ALE_CSp, G, GV, h, tv, regrid_iterations, h)
+        call ALE_regrid_accelerated(ALE_CSp, G, GV, h, tv, regrid_iterations, h, u, v)
       endif
     endif
 

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -81,7 +81,7 @@ use midas_vertmap, only : find_interfaces, tracer_Z_init
 use midas_vertmap, only : determine_temperature
 
 use MOM_ALE, only : ALE_initRegridding, ALE_CS, ALE_initThicknessToCoord
-use MOM_ALE, only : ALE_remap_scalar, ALE_build_grid
+use MOM_ALE, only : ALE_remap_scalar, ALE_build_grid, ALE_regrid_accelerated
 use MOM_regridding, only : regridding_CS, set_regrid_params, getCoordinateResolution
 use MOM_remapping, only : remapping_CS, initialize_remapping
 use MOM_remapping, only : remapping_core_h
@@ -148,6 +148,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                          ! by a large surface pressure by squeezing the column.
   logical :: trim_ic_for_p_surf ! If true, remove the mass that would be displaced
                          ! by a large surface pressure, such as with an ice sheet.
+  logical :: regrid_accelerate
+  integer :: regrid_iterations
   logical :: Analytic_FV_PGF, obsol_test
   logical :: convert
   type(EOS_type), pointer :: eos => NULL()
@@ -381,6 +383,24 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
              "DEPRESS_INITIAL_SURFACE and TRIM_IC_FOR_P_SURF are exclusive and cannot both be True")
     if (depress_sfc) call depress_surface(h, G, GV, PF, tv)
     if (trim_ic_for_p_surf) call trim_for_ice(PF, G, GV, ALE_CSp, tv, h)
+
+    ! Perhaps we want to run the regridding coordinate generator for multiple
+    ! iterations here so the initial grid is consistent with the coordinate
+    if (useALE) then
+      call get_param(PF, mod, "REGRID_ACCELERATE_INIT", regrid_accelerate, &
+           "If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding\n"//&
+           "algorithm to push the initial grid to be consistent with the initial\n"//&
+           "condition. Useful only for state-based and iterative coordinates.", &
+           default=.false.)
+      if (regrid_accelerate) then
+        call get_param(PF, mod, "REGRID_ACCELERATE_ITERATIONS", regrid_iterations, &
+             "The number of regridding iterations to perform to generate\n"//&
+             "an initial grid that is consistent with the initial conditions.", &
+             default=1)
+
+        call ALE_regrid_accelerated(ALE_CSp, G, GV, h, tv, regrid_iterations, h)
+      endif
+    endif
 
   else ! Previous block for new_sim=.T., this block restores state
 !    This line calls a subroutine that reads the initial conditions  !


### PR DESCRIPTION
This is a couple of separate but related changes related to regridding.

## Adaptive coordinate
- The Fortran compiler didn't catch me (or I didn't look closely enough) using an uninitialised stack array in the `build_adapt_column()` routine. Because it's kernelised, it was not junk often enough for me to realise straight away.
  - Related to this, the `dzInterface` variable in the aforementioned routine was renamed to make more sense given its context
- I had missed that regridding needs to calculate one extra point outside the computational domain, so that the new grid can be interpolated onto velocity points.

## Regridding initialisation
Because the adaptive coordinate is state-based and iterative, it could take a while to align with the initial condition. I've added the `REGRID_ACCELERATE_INIT` option in `MOM_initialize_state()`, which, if true will run `REGRID_ACCELERATE_ITERATIONS` of regridding on the initial condition and then remap onto this (hopefully refined) grid.