### PR TITLE
Travis trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 # This is a not a c-language project but we use the same environment.
 language: c
-dist: precise
+dist: trusty
 sudo: false
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,68 +3,47 @@
 
 # This is a not a c-language project but we use the same environment.
 language: c
+dist: precise
+sudo: false
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - tcsh pkg-config netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran
 
 # For saving time...
 cache:
   directories:
-    - my_cache
+    - MOM6-examples
+    - build
 
-# Environment
+# Install tools and clone the configurations repository
 before_install:
- - sudo apt-get install tcsh pkg-config gfortran netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev
-
-# Install tools and dependencies
-install:
  - git clone https://github.com/adcroft/house_cleaning.git
- - test -d MOM6-examples || git clone https://github.com/NOAA-GFDL/MOM6-examples.git
- - (cd MOM6-examples/ ; git checkout dev/master ; git pull)
+ # This line clones MOM6-examples when there is no cache
+ - test -f MOM6-examples/README.md || (rm -rf MOM6-examples && git clone https://github.com/NOAA-GFDL/MOM6-examples.git)
+
+install:
+ # This restores all files in MOM6-examples and updates
+ - (cd MOM6-examples/ && git checkout . && git pull)
+ # Update submodules mkmf and FMS
  - (cd MOM6-examples/src/ && git submodule init mkmf FMS && git submodule update mkmf FMS)
- - test -f my_cache/FMS-src.tgz && tar zxf my_cache/FMS-src.tgz || echo "No cache of FMS src"
- - (cd MOM6-examples/src/ && git submodule update FMS)
- - test -f my_cache/FMS-obj.tgz && (tar zxf my_cache/FMS-obj.tgz) || echo "No cache of FMS objects"
 
 # Build FMS
 before_script:
- - echo "Building FMS library"
-   && mkdir -p build/FMS && (cd build/FMS
-   && rm -f path_names
-   && ../../MOM6-examples/src/mkmf/bin/list_paths ../../MOM6-examples/src/FMS/{platform,include,memutils,constants,mpp,fms,time_manager,diag_manager,data_override,coupler/ensemble_manager.F90,axis_utils,horiz_interp,time_interp,astronomy,mosaic} 
-   && ../../MOM6-examples/src/mkmf/bin/mkmf -t ../../MOM6-examples/src/mkmf/templates/linux-gnu.mk -p libfms.a -c '-Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO -DMAXFIELDMETHODS_=500 -Duse_AM3_physics' path_names
-   && make FC=mpif90 CC=mpicc NETCDF=3 REPRO=1 libfms.a)
- - echo -e '#override DAYMAX=0.125\n#override ENERGYSAVEDAYS=0.01\n#override NIGLOBAL=120\n#override NJGLOBAL=60' > MOM6-examples/ocean_only/benchmark/MOM_override
+ - bash MOM6-examples/tools/tests/Travis-MOM6/build_fms.sh
+ - bash MOM6-examples/tools/tests/Travis-MOM6/before_script.sh
 
 # Tests to run
 script:
  - ./house_cleaning/trailer.py -e TEOS10 src config_src
- - echo "Compiling non-symmetric MOM6"
-   && mkdir -p build/ocn && (cd build/ocn
-   && ../../MOM6-examples/src/mkmf/bin/list_paths ../../{config_src/dynamic,config_src/solo_driver,src/{*,*/*}}/
-   && ../../MOM6-examples/src/mkmf/bin/mkmf -t ../../MOM6-examples/src/mkmf/templates/linux-gnu.mk -o '-I../FMS' -p MOM6 -l '-L../FMS -lfms' -c '-Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO -DMAXFIELDMETHODS_=500 -Duse_AM3_physics' path_names
-   && make FC=mpif90 CC=mpicc LD=mpif90 NETCDF=3 REPRO=1 MOM6)
- - echo "Compiling symmetric MOM6"
-   && mkdir -p build/symocn && (cd build/symocn
-   && ../../MOM6-examples/src/mkmf/bin/list_paths ../../{config_src/dynamic_symmetric,config_src/solo_driver,src/{*,*/*}}/
-   && ../../MOM6-examples/src/mkmf/bin/mkmf -t ../../MOM6-examples/src/mkmf/templates/linux-gnu.mk -o '-I../FMS' -p MOM6 -l '-L../FMS -lfms' -c '-Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO -DMAXFIELDMETHODS_=500 -Duse_AM3_physics' path_names
-   && make FC=mpif90 CC=mpicc LD=mpif90 NETCDF=3 REPRO=1 MOM6)
- - (cd MOM6-examples/ocean_only/double_gyre && mkdir -p RESTART && mpirun -n 1 ../../../build/ocn/MOM6 1> log)
- - (cd MOM6-examples/ocean_only/flow_downslope/layer && mkdir -p RESTART && mpirun -n 1 ../../../../build/ocn/MOM6 1>log)
- - (cd MOM6-examples/ocean_only/flow_downslope/rho && mkdir -p RESTART && mpirun -n 1 ../../../../build/ocn/MOM6 1>log)
- - (cd MOM6-examples/ocean_only/flow_downslope/sigma && mkdir -p RESTART && mpirun -n 1 ../../../../build/ocn/MOM6 1>log)
- - (cd MOM6-examples/ocean_only/flow_downslope/z && mkdir -p RESTART && mpirun -n 1 ../../../../build/ocn/MOM6 1>log)
- - (cd MOM6-examples/ocean_only/benchmark && mkdir -p RESTART && mpirun -n 1 ../../../build/ocn/MOM6 1> log)
- - (cd MOM6-examples/ocean_only/circle_obcs && mkdir -p RESTART && mpirun -n 1 ../../../build/symocn/MOM6 1> log)
- - md5sum MOM6-examples/ocean_only/{*,*/*}/ocean.stats > stats.md5
- - (cd MOM6-examples/ocean_only/unit_tests && mkdir -p RESTART && mpirun -n 1 ../../../build/ocn/MOM6 1> log)
- - (cd MOM6-examples/ocean_only/double_gyre && mkdir -p RESTART && mpirun -n 2 ../../../build/symocn/MOM6 1> log)
- - (cd MOM6-examples/ocean_only/flow_downslope/layer && mkdir -p RESTART && mpirun -n 2 ../../../../build/symocn/MOM6 1>log)
- - (cd MOM6-examples/ocean_only/flow_downslope/rho && mkdir -p RESTART && mpirun -n 2 ../../../../build/symocn/MOM6 1>log)
- - (cd MOM6-examples/ocean_only/flow_downslope/sigma && mkdir -p RESTART && mpirun -n 2 ../../../../build/symocn/MOM6 1>log)
- - (cd MOM6-examples/ocean_only/flow_downslope/z && mkdir -p RESTART && mpirun -n 2 ../../../../build/symocn/MOM6 1>log)
- - (cd MOM6-examples/ocean_only/benchmark && mkdir -p RESTART && mpirun -n 4 ../../../build/symocn/MOM6 1> log)
- - (cd MOM6-examples/ocean_only/circle_obcs && mkdir -p RESTART && mpirun -n 4 ../../../build/symocn/MOM6 1> log)
- - md5sum -c stats.md5
+ - bash MOM6-examples/tools/tests/Travis-MOM6/build_ocean_only.sh
+ - bash MOM6-examples/tools/tests/Travis-MOM6/build_symmetric_ocean_only.sh
+ - bash MOM6-examples/tools/tests/Travis-MOM6/run_tests.sh
 
-# Move items into cache
 before_cache:
- - tar zcf my_cache/FMS-src.tgz MOM6-examples/src/FMS
- - tar zcf my_cache/FMS-obj.tgz build/FMS
+- rm -rf build/ocn build/symocn
+- (cd MOM6-examples; rm -rf ocean_only; git checkout .)
+- find MOM6-examples -type l -exec rm {} \;


### PR DESCRIPTION
This is a re-shaping of the Travis testing process:
- Moves most tests to a script inside MOM6-examples (to avoid the two repositories being out of sync).
- Switches to "trusty" which is the latest Ubuntu image used by Travis, since "precise" is losing support soon.