### PR TITLE
 Add initialization routines for dense overflow experiment

### DIFF
--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -25,6 +25,7 @@ use MOM_shared_initialization, only : set_rotation_planetary, set_rotation_beta_
 use MOM_shared_initialization, only : reset_face_lengths_named, reset_face_lengths_file, reset_face_lengths_list
 use MOM_shared_initialization, only : read_face_length_list, set_velocity_depth_max, set_velocity_depth_min
 use MOM_shared_initialization, only : compute_global_grid_integrals, write_ocean_geometry_file
+
 use user_initialization, only : user_initialize_topography
 use DOME_initialization, only : DOME_initialize_topography
 use ISOMIP_initialization, only : ISOMIP_initialize_topography
@@ -36,6 +37,7 @@ use seamount_initialization, only : seamount_initialize_topography
 use shelfwave_initialization, only : shelfwave_initialize_topography
 use supercritical_initialization, only : supercritical_initialize_topography
 use Phillips_initialization, only : Phillips_initialize_topography
+use dense_water_initialization, only : dense_water_initialize_topography
 
 use netcdf
 
@@ -200,6 +202,7 @@ subroutine MOM_initialize_topography(D, max_depth, G, PF)
                  " \t shelfwave - exponential slope for shelfwave test case.\n"//&
                  " \t supercritical - flat but with 8.95 degree land mask.\n"//&
                  " \t Phillips - ACC-like idealized topography used in the Phillips config.\n"//&
+                 " \t dense - Denmark Strait-like dense water formation and overflow.\n"//&
                  " \t USER - call a user modified routine.", &
                  fail_if_missing=.true.)
   max_depth = -1.e9; call read_param(PF, "MAXIMUM_DEPTH", max_depth)
@@ -219,6 +222,7 @@ subroutine MOM_initialize_topography(D, max_depth, G, PF)
     case ("shelfwave"); call shelfwave_initialize_topography(D, G, PF, max_depth)
     case ("supercritical");  call supercritical_initialize_topography(D, G, PF, max_depth)
     case ("Phillips");  call Phillips_initialize_topography(D, G, PF, max_depth)
+    case ("dense");     call dense_water_initialize_topography(D, G, PF, max_depth)
     case ("USER");      call user_initialize_topography(D, G, PF, max_depth)
     case default ;      call MOM_error(FATAL,"MOM_initialize_topography: "// &
       "Unrecognized topography setup '"//trim(config)//"'")

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -76,6 +76,8 @@ use supercritical_initialization, only : supercritical_set_OBC_data
 use soliton_initialization, only : soliton_initialize_velocity
 use soliton_initialization, only : soliton_initialize_thickness
 use BFB_initialization, only : BFB_initialize_sponges_southonly
+use dense_water_initialization, only : dense_water_initialize_TS
+use dense_water_initialization, only : dense_water_initialize_sponges
 
 use midas_vertmap, only : find_interfaces, tracer_Z_init
 use midas_vertmap, only : determine_temperature
@@ -316,6 +318,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                                 tv%S, h, G, GV, PF)
           case ("SCM_CVmix_tests"); call SCM_CVmix_tests_TS_init (tv%T, &
                                 tv%S, h, G, GV, PF)
+          case ("dense"); call dense_water_initialize_TS(G, GV, PF, eos, tv%T, tv%S, h)
           case ("USER"); call user_init_temperature_salinity(tv%T, tv%S, G, PF, eos)
           case default ; call MOM_error(FATAL,  "MOM_initialize_state: "//&
                  "Unrecognized Temp & salt configuration "//trim(config))
@@ -453,6 +456,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                                                PF, sponge_CSp, h)
       case ("phillips"); call Phillips_initialize_sponges(G, use_temperature, tv, &
                                                PF, sponge_CSp, h)
+      case ("dense"); call dense_water_initialize_sponges(G, GV, tv, PF, useALE, &
+           sponge_CSp, ALE_sponge_CSp)
       case ("file"); call initialize_sponges_file(G, GV, use_temperature, tv, &
                                                PF, sponge_CSp)
       case default ; call MOM_error(FATAL,  "MOM_initialize_state: "//&

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -1,0 +1,293 @@
+!> Initialization routines for the dense water formation
+!! and overflow experiment.
+module dense_water_initialization
+
+use MOM_ALE_sponge,    only : ALE_sponge_CS, set_up_ALE_sponge_field, initialize_ALE_sponge
+use MOM_dyn_horgrid,   only : dyn_horgrid_type
+use MOM_EOS,           only : EOS_type
+use MOM_error_handler, only : MOM_error, FATAL
+use MOM_file_parser,   only : get_param, param_file_type
+use MOM_grid,          only : ocean_grid_type
+use MOM_sponge,        only : sponge_CS
+use MOM_variables,     only : thermo_var_ptrs
+use MOM_verticalGrid,  only : verticalGrid_type
+
+implicit none ; private
+
+#include <MOM_memory.h>
+
+public dense_water_initialize_topography
+public dense_water_initialize_TS
+public dense_water_initialize_sponges
+
+character(len=40) :: mod = "dense_water_initialization"
+
+real, parameter :: default_sill  = 0.2 !< Default depth of the sill [nondim]
+real, parameter :: default_shelf = 0.4 !< Default depth of the shelf [nondim]
+real, parameter :: default_mld   = 0.25 !< Default depth of the mixed layer [nondim]
+
+contains
+
+!> Initialize the topography field for the dense water experiment
+subroutine dense_water_initialize_topography(D, G, param_file, max_depth)
+  type(dyn_horgrid_type),           intent(in)  :: G !< Grid control structure
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: D !< Output topography field
+  type(param_file_type),            intent(in)  :: param_file !< Parameter file structure
+  real,                             intent(in)  :: max_depth !< Maximum depth of the model
+
+  real, dimension(5) :: domain_params ! nondimensional widths of all domain sections
+  real :: sill_frac, shelf_frac
+  integer :: i, j
+  real :: x
+
+  call get_param(param_file, mod, "DENSE_WATER_DOMAIN_PARAMS", domain_params, &
+       "Fractional widths of all the domain sections for the dense water experiment.\n"//&
+       "As a 5-element vector:\n"//&
+       "  - open ocean, the section at maximum depth\n"//&
+       "  - downslope, the downward overflow slope\n"//&
+       "  - sill separating downslope from upslope\n"//&
+       "  - upslope, the upward slope accumulating dense water\n"//&
+       "  - the shelf in the dense formation region.", &
+       units="nondim", fail_if_missing=.true.)
+  call get_param(param_file, mod, "DENSE_WATER_SILL_DEPTH", sill_frac, &
+       "Depth of the sill separating downslope from upslope, as fraction of basin depth.", &
+       units="nondim", default=default_sill)
+  call get_param(param_file, mod, "DENSE_WATER_SHELF_DEPTH", shelf_frac, &
+       "Depth of the shelf region accumulating dense water for overflow, as fraction of basin depth.", &
+       units="nondim", default=default_shelf)
+
+  do i = 2, 5
+    ! turn widths into positions
+    domain_params(i) = domain_params(i-1) + domain_params(i)
+  enddo
+
+  do i = G%isc,G%iec
+    do j = G%jsc,G%jec
+      ! compute normalised zonal coordinate
+      x = (G%geoLonT(i,j) - G%west_lon) / G%len_lon
+
+      if (x <= domain_params(1)) then
+        ! open ocean region
+        D(i,j) = max_depth
+      else if (x <= domain_params(2)) then
+        ! downslope region, linear
+        D(i,j) = max_depth - (1.0 - sill_frac) * max_depth * &
+             (x - domain_params(1)) / (domain_params(2) - domain_params(1))
+      else if (x <= domain_params(3)) then
+        ! sill region
+        D(i,j) = sill_frac * max_depth
+      else if (x <= domain_params(4)) then
+        ! upslope region
+        D(i,j) = sill_frac * max_depth + (shelf_frac - sill_frac) * max_depth * &
+             (x - domain_params(3)) / (domain_params(4) - domain_params(3))
+      else
+        ! shelf region
+        D(i,j) = shelf_frac * max_depth
+      endif
+    enddo
+  enddo
+end subroutine dense_water_initialize_topography
+
+!> Initialize the temperature and salinity for the dense water experiment
+subroutine dense_water_initialize_TS(G, GV, param_file, eqn_of_state, T, S, h)
+  type(ocean_grid_type),                     intent(in)  :: G !< Horizontal grid control structure
+  type(verticalGrid_type),                   intent(in)  :: GV !< Vertical grid control structure
+  type(param_file_type),                     intent(in)  :: param_file !< Parameter file structure
+  type(EOS_type),                            pointer     :: eqn_of_state !< EOS structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T, S !< Output state
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thicknesses
+
+  real :: mld, S_ref, S_range, T_ref
+  real :: zi, zmid
+  integer :: i, j, k, nz
+
+  nz = GV%ke
+
+  call get_param(param_file, mod, "DENSE_WATER_MLD", mld, &
+       "Depth of unstratified mixed layer as a fraction of the water column.", &
+       units="nondim", default=default_mld)
+
+  call get_param(param_file, mod, "S_REF", S_ref, do_not_log=.true.)
+  call get_param(param_file, mod, "S_RANGE", S_range, do_not_log=.true.)
+  call get_param(param_file, mod, "T_REF", T_ref, do_not_log=.true.)
+
+  ! uniform temperature everywhere
+  T(:,:,:) = T_ref
+
+  do j = G%jsc,G%jec
+    do i = G%isc,G%iec
+      zi = 0.
+      do k = 1,nz
+        ! nondimensional middle of layer
+        zmid = zi + 0.5 * h(i,j,k) / G%max_depth
+
+        if (zmid < mld) then
+          ! use reference salinity in the mixed layer
+          S(i,j,k) = S_ref
+        else
+          ! linear between bottom of mixed layer and bottom
+          S(i,j,k) = S_ref + S_range * (zmid - mld) / (1.0 - mld)
+        endif
+
+        zi = zi + h(i,j,k) / G%max_depth
+      enddo
+    enddo
+  enddo
+end subroutine dense_water_initialize_TS
+
+!> Initialize the restoring sponges for the dense water experiment
+subroutine dense_water_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
+  type(ocean_grid_type),   intent(in) :: G !< Horizontal grid control structure
+  type(verticalGrid_type), intent(in) :: GV !< Vertical grid control structure
+  type(thermo_var_ptrs),   intent(in) :: tv !< Thermodynamic variables
+  type(param_file_type),   intent(in) :: param_file !< Parameter file structure
+  logical,                 intent(in) :: use_ALE !< ALE flag
+  type(sponge_CS),         pointer    :: CSp !< Layered sponge control structure pointer
+  type(ALE_sponge_CS),     pointer    :: ACSp !< ALE sponge control structure pointer
+
+  ! Local variables
+  real :: west_sponge_time_scale, west_sponge_width
+  real :: east_sponge_time_scale, east_sponge_width
+
+  real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h, T, S ! sponge thicknesses, temp and salt
+  real, dimension(SZK_(GV)+1) :: e0, eta1D ! interface positions for ALE sponge
+
+  integer :: i, j, k, nz
+  real :: x, zi, zmid, dist
+  real :: mld, S_ref, S_range, S_dense, T_ref, sill_height
+
+  nz = GV%ke
+
+  call get_param(param_file, mod, "DENSE_WATER_WEST_SPONGE_TIME_SCALE", west_sponge_time_scale, &
+       "The time scale on the west (outflow) of the domain for restoring. If zero, the sponge is disabled.", &
+       units="s", default=0.)
+  call get_param(param_file, mod, "DENSE_WATER_WEST_SPONGE_WIDTH", west_sponge_width, &
+       "The fraction of the domain in which the western (outflow) sponge is active.", &
+       units="nondim", default=0.1)
+  call get_param(param_file, mod, "DENSE_WATER_EAST_SPONGE_TIME_SCALE", east_sponge_time_scale, &
+       "The time scale on the east (outflow) of the domain for restoring. If zero, the sponge is disabled.", &
+       units="s", default=0.)
+  call get_param(param_file, mod, "DENSE_WATER_EAST_SPONGE_WIDTH", east_sponge_width, &
+       "The fraction of the domain in which the eastern (outflow) sponge is active.", &
+       units="nondim", default=0.1)
+
+  call get_param(param_file, mod, "DENSE_WATER_EAST_SPONGE_SALT", S_dense, &
+       "Salt anomaly of the dense water being formed in the overflow region.", &
+       units="1e-3", default=4.0)
+
+  call get_param(param_file, mod, "DENSE_WATER_MLD", mld, default=default_mld, do_not_log=.true.)
+  call get_param(param_file, mod, "DENSE_WATER_SILL_HEIGHT", sill_height, default=default_sill, do_not_log=.true.)
+
+  call get_param(param_file, mod, "S_REF", S_ref, do_not_log=.true.)
+  call get_param(param_file, mod, "S_RANGE", S_range, do_not_log=.true.)
+  call get_param(param_file, mod, "T_REF", T_ref, do_not_log=.true.)
+
+  ! no active sponges
+  if (west_sponge_time_scale <= 0. .and. east_sponge_time_scale <= 0.) return
+
+  ! everywhere is initially unsponged
+  Idamp(:,:) = 0.0
+
+  do j = G%jsc, G%jec
+    do i = G%isc,G%iec
+      if (G%mask2dT(i,j) > 0.) then
+        ! nondimensional x position
+        x = (G%geoLonT(i,j) - G%west_lon) / G%len_lon
+
+        if (west_sponge_time_scale > 0. .and. x < west_sponge_width) then
+          dist = 1. - x / west_sponge_width
+          ! scale restoring by depth into sponge
+          Idamp(i,j) = 1. / west_sponge_time_scale * max(0., min(1., dist))
+        else if (east_sponge_time_scale > 0. .and. x > (1. - east_sponge_width)) then
+          dist = 1. - (1. - x) / east_sponge_width
+          Idamp(i,j) = 1. / east_sponge_time_scale * max(0., min(1., dist))
+        endif
+      endif
+    enddo
+  enddo
+
+  if (use_ALE) then
+    ! construct a uniform grid for the sponge
+    do k = 1,nz
+      e0(k) = -GV%max_depth * (real(k - 1) / real(nz))
+    enddo
+    e0(nz+1) = -GV%max_depth
+
+    do j = G%jsc,G%jec
+      do i = G%isc,G%iec
+        eta1D(nz+1) = -G%bathyT(i,j)
+        do k = nz,1,-1
+          eta1D(k) = e0(k)
+
+          if (eta1D(k) < (eta1D(k+1) + GV%Angstrom_z)) then
+            ! is this layer vanished?
+            eta1D(k) = eta1D(k+1) + GV%Angstrom_z
+            h(i,j,k) = GV%Angstrom_z
+          else
+            h(i,j,k) = eta1D(k) - eta1D(k+1)
+          endif
+        enddo
+      enddo
+    enddo
+
+    call initialize_ALE_sponge(Idamp, h, nz, G, param_file, ACSp)
+
+    ! construct temperature and salinity for the sponge
+    ! start with initial condition
+    T(:,:,:) = T_ref
+    S(:,:,:) = S_ref
+
+    do j = G%jsc,G%jec
+      do i = G%isc,G%iec
+        zi = 0.
+        x = (G%geoLonT(i,j) - G%west_lon) / G%len_lon
+        do k = 1,nz
+          ! nondimensional middle of layer
+          zmid = zi + 0.5 * h(i,j,k) / GV%max_depth
+
+          if (x > (1. - east_sponge_width)) then
+            !if (zmid >= 0.9 * sill_height) &
+                 S(i,j,k) = S_ref + S_dense
+          else
+            ! linear between bottom of mixed layer and bottom
+            if (zmid >= mld) &
+                 S(i,j,k) = S_ref + S_range * (zmid - mld) / (1.0 - mld)
+          endif
+
+          zi = zi + h(i,j,k) / GV%max_depth
+        enddo
+      enddo
+    enddo
+
+    if (associated(tv%T)) call set_up_ALE_sponge_field(T, G, tv%T, ACSp)
+    if (associated(tv%S)) call set_up_ALE_sponge_field(S, G, tv%S, ACSp)
+  else
+    call MOM_error(FATAL, "dense_water_initialize_sponges: trying to use non ALE sponge")
+  endif
+end subroutine dense_water_initialize_sponges
+
+end module dense_water_initialization
+
+!! \namespace dense_water_initialization
+!!
+!! This experiment consists of a shelf accumulating dense water, which spills
+!! over an upward slope and a sill, before flowing down a slope into an open
+!! ocean region. It's intended as a test of one of the motivating situations
+!! for the adaptive coordinate.
+!!
+!! The nondimensional widths of the 5 regions are controlled by the
+!! <code>DENSE_WATER_DOMAIN_PARAMS</code>, and the heights of the sill and shelf
+!! as a fraction of the total domain depth are controlled by
+!! <code>DENSE_WATER_SILL_HEIGHT</code> and <code>DENSE_WATER_SHELF_HEIGHT</code>.
+!!
+!! The density in the domain is governed by a linear equation of state, and
+!! is set up with a mixed layer of non-dimensional depth <code>DENSE_WATER_MLD</code>
+!! below which there is a linear stratification from <code>S_REF</code>, increasing
+!! by <code>S_RANGE</code> to the bottom.
+!!
+!! To force the experiment, there are sponges on the inflow and outflow of the
+!! domain. The inflow sponge has a salinity anomaly of
+!! <code>DENSE_WATER_EAST_SPONGE_SALT</code> through the entire depth. The outflow
+!! sponge simply restores to the initial condition. Both sponges have controllable
+!! widths and restoring timescales.


### PR DESCRIPTION
This experiment involves a continuous forced overflow by inflow and outflow sponges. It's intended to simulate the Denmark Strait overflow, and provide a testbed for different vertical coordinates.

There currently isn't any layered-mode initialisation. Since I've just been using it for the adaptive coordinate development, I think it basically assumes a uniform thickness initial condition.