### PR TITLE
Update to timelevel being used in OBCs

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -324,10 +324,10 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
 
   if (associated(CS%OBC)) then
     do k=1,nz ; do j=js-1,je+1 ; do I=is-2,ie+1
-      u_old_rad_OBC(I,j,k) = u(I,j,k)  !### Should be u_av(I,j,k)?
+      u_old_rad_OBC(I,j,k) = u_av(I,j,k)
     enddo ; enddo ; enddo
     do k=1,nz ; do J=js-2,je+1 ; do i=is-1,ie+1
-      v_old_rad_OBC(i,J,k) = v(i,J,k)  !### Should be u_av(I,j,k)?
+      v_old_rad_OBC(i,J,k) = v_av(i,J,k)
     enddo ; enddo ; enddo
   endif
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -62,7 +62,7 @@ type, public :: OBC_segment_data_type
   integer                         :: nk_src     !< Number of vertical levels in the source data
   real, dimension(:,:,:), pointer :: dz_src=>NULL()     !< vertical grid cell spacing of the incoming segment data (m)
   real, dimension(:,:,:), pointer :: buffer_dst=>NULL() !< buffer src data remapped to the target vertical grid
-  real, dimension(:,:), pointer   :: bt_vel=>NULL() !< barotropic velocity (m s-1)
+  real, dimension(:,:), pointer   :: bt_vel=>NULL()     !< barotropic velocity (m s-1)
   real                            :: value              !< constant value if fid is equal to -1
 end type OBC_segment_data_type
 
@@ -173,9 +173,8 @@ type, public :: ocean_OBC_type
                    !! velocity (or speed of characteristics), in m s-1.  The
                    !! default value is 10 m s-1.
   logical :: OBC_pe !< Is there an open boundary on this tile?
-  character(len=200) :: OBC_user_config
-  type(remapping_CS), pointer         :: remap_CS   ! ALE remapping control structure for segments only
-  type(OBC_registry_type),       pointer :: OBC_Reg                => NULL()
+  type(remapping_CS),      pointer :: remap_CS   !< ALE remapping control structure for segments only
+  type(OBC_registry_type), pointer :: OBC_Reg => NULL()  !< Registry type for boundaries
 end type ocean_OBC_type
 
 !> Control structure for open boundaries that read from files.
@@ -193,7 +192,7 @@ end type OBC_struct_type
 type, public :: OBC_registry_type
   integer               :: nobc = 0          !< number of registered open boundary types.
   type(OBC_struct_type) :: OB(MAX_FIELDS_)   !< array of registered boundary types.
-  logical               :: locked = .false.  !< New tracers may be registered if locked=.false.
+  logical               :: locked = .false.  !< New OBC types may be registered if locked=.false.
                                              !! When locked=.true.,no more boundaries can be registered.
 end type OBC_registry_type
 
@@ -567,7 +566,7 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg)
   integer,                 intent(in) :: l_seg !< which segment is this?
   ! Local variables
   integer :: I_obc, Js_obc, Je_obc ! Position of segment in global index space
-  integer :: j, this_kind, a_loop
+  integer :: j, a_loop
   character(len=32) :: action_str(5)
 
   ! This returns the global indices for the segment
@@ -578,8 +577,6 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg)
   I_obc = I_obc - G%idg_offset ! Convert to local tile indices on this tile
   Js_obc = Js_obc - G%jdg_offset ! Convert to local tile indices on this tile
   Je_obc = Je_obc - G%jdg_offset ! Convert to local tile indices on this tile
-
-  this_kind = OBC_NONE
 
   ! Hack to extend segment by one point
   if (OBC%extend_segments) then
@@ -603,7 +600,6 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg)
     if (len_trim(action_str(a_loop)) == 0) then
       cycle
     elseif (trim(action_str(a_loop)) == 'FLATHER') then
-      this_kind = OBC_FLATHER
       OBC%segment(l_seg)%Flather = .true.
       OBC%Flather_u_BCs_exist_globally = .true.
       OBC%open_u_BCs_exist_globally = .true.
@@ -623,7 +619,6 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg)
       OBC%segment(l_seg)%gradient = .true.
       OBC%open_u_BCs_exist_globally = .true.
     elseif (trim(action_str(a_loop)) == 'LEGACY') then
-      this_kind = OBC_FLATHER
       OBC%segment(l_seg)%Flather = .true.
       OBC%segment(l_seg)%radiation = .true.
       OBC%Flather_u_BCs_exist_globally = .true.
@@ -670,7 +665,7 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg)
   integer,                 intent(in) :: l_seg !< which segment is this?
   ! Local variables
   integer :: J_obc, Is_obc, Ie_obc ! Position of segment in global index space
-  integer :: i, this_kind, a_loop
+  integer :: i, a_loop
   character(len=32) :: action_str(5)
 
   ! This returns the global indices for the segment
@@ -681,7 +676,6 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg)
   J_obc = J_obc - G%jdg_offset ! Convert to local tile indices on this tile
   Is_obc = Is_obc - G%idg_offset ! Convert to local tile indices on this tile
   Ie_obc = Ie_obc - G%idg_offset ! Convert to local tile indices on this tile
-  this_kind = OBC_NONE
 
   ! Hack to extend segment by one point
   if (OBC%extend_segments) then
@@ -705,7 +699,6 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg)
     if (len_trim(action_str(a_loop)) == 0) then
       cycle
     elseif (trim(action_str(a_loop)) == 'FLATHER') then
-      this_kind = OBC_FLATHER
       OBC%segment(l_seg)%Flather = .true.
       OBC%Flather_v_BCs_exist_globally = .true.
       OBC%open_v_BCs_exist_globally = .true.
@@ -725,7 +718,6 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg)
       OBC%segment(l_seg)%gradient = .true.
       OBC%open_v_BCs_exist_globally = .true.
     elseif (trim(action_str(a_loop)) == 'LEGACY') then
-      this_kind = OBC_FLATHER
       OBC%segment(l_seg)%radiation = .true.
       OBC%segment(l_seg)%Flather = .true.
       OBC%Flather_v_BCs_exist_globally = .true.
@@ -1800,15 +1792,16 @@ subroutine open_boundary_test_extern_h(G, OBC, h)
 
 end subroutine open_boundary_test_extern_h
 
+!> Update the OBC values on the segments.
 subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
-  type(ocean_grid_type),                     intent(in)    :: G   !< Ocean grid structure
-  type(verticalGrid_type),                   intent(in)    :: GV  !<  Ocean vertical grid structure
-  type(ocean_OBC_type),                      pointer       :: OBC !< Open boundary structure
-  type(thermo_var_ptrs),                     intent(in)    :: tv  !< Thermodynamics structure
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(inout) :: h   !< Thickness
-! real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(inout) :: e   !< Layer interface height
-! real, dimension(SZI_(G),SZJ_(G))         , intent(inout) :: eta !< Thickness
-  type(time_type),                           intent(in)    :: Time
+  type(ocean_grid_type),                     intent(in)    :: G    !< Ocean grid structure
+  type(verticalGrid_type),                   intent(in)    :: GV   !<  Ocean vertical grid structure
+  type(ocean_OBC_type),                      pointer       :: OBC  !< Open boundary structure
+  type(thermo_var_ptrs),                     intent(in)    :: tv   !< Thermodynamics structure
+  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(inout) :: h    !< Thickness
+! real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(inout) :: e    !< Layer interface height
+! real, dimension(SZI_(G),SZJ_(G))         , intent(inout) :: eta  !< Thickness
+  type(time_type),                           intent(in)    :: Time !< Time
   ! Local variables
 
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed
@@ -1854,26 +1847,6 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
       is_obc=is_obc+1
     endif
 
-!    do j=jsd,jed ; do I=isd,ied-1
-!      if (segment%direction == OBC_DIRECTION_E .and. OBC%segnum_u(I,j) /= OBC_NONE ) then
-!        do k=1,nz
-!          tv%T(i+1,j,k) = tv%T(i,j,k) ; tv%S(i+1,j,k) = tv%S(i,j,k); h(i+1,j,k) = h(i,j,k)
-!        enddo
-!      else if (segment%direction == OBC_DIRECTION_W .and. OBC%segnum_u(I,j) /= OBC_NONE ) then
-!        tv%T(i,j,k) = tv%T(i+1,j,k) ; tv%S(i,j,k) = tv%S(i+1,j,k); h(i,j,k) = h(i+1,j,k)
-!      endif
-!    enddo ; enddo
-
-!    do j=jsd,jed-1 ; do I=isd,ied-1
-!      if (segment%direction == OBC_DIRECTION_N .and. OBC%segnum_v(I,j) /= OBC_NONE ) then
-!        do k=1,nz
-!          tv%T(i,j+1,k) = tv%T(i,j,k) ; tv%S(i,j+1,k) = tv%S(i,j,k); h(i,j+1,k) = h(i,j,k)
-!        enddo
-!      else if (segment%direction == OBC_DIRECTION_S .and. OBC%segnum_v(I,j) /= OBC_NONE ) then
-!        tv%T(i,j,k) = tv%T(i,j+1,k) ; tv%S(i,j,k) = tv%S(i,j+1,k); h(i,j,k) = h(i,j+1,k)
-!      endif
-!    enddo ; enddo
-
 ! Calculate auxiliary fields at staggered locations.
 ! Segment indices are on q points:
 !
@@ -1889,10 +1862,6 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
       if (segment%direction == OBC_DIRECTION_W) ishift=1
       I=segment%HI%IscB
       do j=segment%HI%jsd,segment%HI%jed
-!        i2 =  segment%Is_obc + i - 1
-!        j2 =  segment%Js_obc + j - 1
-!        if ((i2 .gt. ied .or. i2 .lt. isd) .or. (j2 .gt. jed .or. j2 .lt. jsd)) cycle
-!        if (OBC%segnum_u(i2,j2) /= n) cycle
         segment%Cg(I,j) = sqrt(GV%g_prime(1)*G%bathyT(i+ishift,j))
  !       if (GV%Boussinesq) then
         segment%Htot(I,j) = G%bathyT(i+ishift,j)*GV%m_to_H! + eta(i+ishift,j)

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -474,7 +474,6 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                  "   Kelvin - barotropic Kelvin wave forcing on the western boundary\n"//&
                  "   shelfwave - Flather with shelf wave forcing on western boundary\n"//&
                  "   USER - user specified", default="none")
-    if (trim(config) /= "none") OBC%OBC_user_config = trim(config)
     if (trim(config) == "DOME") then
       call DOME_set_OBC_data(OBC, tv, G, GV, PF, tracer_Reg)
     elseif (lowercase(trim(config)) == "supercritical") then

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -74,9 +74,12 @@ function register_Kelvin_OBC(param_file, CS, OBC_Reg)
   call get_param(param_file, mod, "TOPO_CONFIG", config, do_not_log=.true.)
   if (trim(config) == "Kelvin") then
     call get_param(param_file, mod, "KELVIN_COAST_OFFSET", CS%coast_offset, &
-                 default=100.0, do_not_log=.true.)
+                   "The distance along the southern and northern boundaries \n"//&
+                   "at which the coasts angle in.", &
+                   units="km", default=100.0)
     call get_param(param_file, mod, "KELVIN_COAST_ANGLE", CS%coast_angle, &
-                 default=11.3, do_not_log=.true.)
+                   "The angle of the southern bondary beyond X=KELVIN_COAST_OFFSET.", &
+                   units="degrees", default=11.3)
     CS%coast_angle = CS%coast_angle * (atan(1.0)/45.) ! Convert to radians
   endif
 
@@ -111,16 +114,12 @@ subroutine Kelvin_initialize_topography(D, G, param_file, max_depth)
 
   call MOM_mesg("  Kelvin_initialization.F90, Kelvin_initialize_topography: setting topography", 5)
 
-  call log_version(param_file, mod, version, "")
   call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
   call get_param(param_file, mod, "KELVIN_COAST_OFFSET", coast_offset, &
-                 "The distance along the southern and northern boundaries \n"//&
-                 "at which the coasts angle in.", &
-                 units="km", default=100.0)
+                 default=100.0, do_not_log=.true.)
   call get_param(param_file, mod, "KELVIN_COAST_ANGLE", coast_angle, &
-                 "The angle of the southern bondary beyond X=KELVIN_COAST_OFFSET.", &
-                 units="degrees", default=11.3)
+                 default=11.3, do_not_log=.true.)
 
   coast_angle = coast_angle * (atan(1.0)/45.) ! Convert to radians
   right_angle = 2 * atan(1.0)

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -44,8 +44,8 @@ public register_shelfwave_OBC, shelfwave_OBC_end
 
 !> Control structure for shelfwave open boundaries.
 type, public :: shelfwave_OBC_CS ; private
-  real :: Lx = 20.0         !< Long-shore length scale of bathymetry.
-  real :: Ly = 10.0         !< Cross-shore length scale.
+  real :: Lx = 100.0        !< Long-shore length scale of bathymetry.
+  real :: Ly = 50.0         !< Cross-shore length scale.
   real :: f0 = 1.e-4        !< Coriolis parameter.
   real :: jj = 1            !< Cross-shore wave mode.
   real :: kk                !< Parameter.
@@ -88,7 +88,7 @@ function register_shelfwave_OBC(param_file, CS, OBC_Reg)
   call get_param(param_file,mod,"SHELFWAVE_Y_LENGTH_SCALE",CS%Ly, &
                  "Length scale of exponential dropoff of topography\n"//&
                  "in the y-direction.", &
-                 units="Same as x,y", default=10.)
+                 units="Same as x,y", default=50.)
   call get_param(param_file,mod,"SHELFWAVE_Y_MODE",CS%jj, &
                  "Cross-shore wave mode.",               &
                  units="nondim", default=1.)
@@ -124,7 +124,7 @@ subroutine shelfwave_initialize_topography ( D, G, param_file, max_depth )
   real      :: y, rLy, Ly, H0
 
   call get_param(param_file,mod,"SHELFWAVE_Y_LENGTH_SCALE",Ly, &
-                 default=10., do_not_log=.true.)
+                 default=50., do_not_log=.true.)
   call get_param(param_file,mod,"MINIMUM_DEPTH",H0, &
                  default=10., do_not_log=.true.)
 
@@ -179,8 +179,8 @@ subroutine shelfwave_set_OBC_data(OBC, CS, G, h, Time)
     IsdB = segment%HI%IsdB ; IedB = segment%HI%IedB
     jsd = segment%HI%jsd ; jed = segment%HI%jed
     do j=jsd,jed ; do I=IsdB,IedB
-      x = G%geoLonCu(i,j) - G%west_lon
-      y = G%geoLatCu(i,j) - G%south_lat
+      x = G%geoLonCu(I,j) - G%west_lon
+      y = G%geoLatCu(I,j) - G%south_lat
       sin_wt = sin(ll*x - omega*time_sec)
       cos_wt = cos(ll*x - omega*time_sec)
       sin_ky = sin(kk * y)


### PR DESCRIPTION
Use u_av, v_av instead of u, v for "old time level" in radiation OBCs.

- Changes answers for cases using ORLANSKI and OBLIQUE - for the better in at least one test problem (the ESMG layer seamount).
- Other little changes which were in the queue, cleaning up OBC code.