### PR TITLE
Fix 1/4 degree runs with COBALT and/or BLING

### DIFF
--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -200,7 +200,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
       hSrc(i,j,:) = h1(:)
     enddo ; enddo
 
-    call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.true. )
+    call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false. )
 
     deallocate( hSrc )
     deallocate( h1 )


### PR DESCRIPTION
1/4 degree model runs with COBALT and/or BLING got broken by the  commit fd91c16 to update the remapping scheme.
Some of the tracers (O2,PO4,NO3,...) show large unphysical values at the bottom layer when they are initialized from source files.
Matt suspects it's because the default value for call ALE_remap_scalar(all_cells=.true. ) is not compatible with the updated remapping scheme. 

This mod fixes the above issues for both ocean-ice and fully coupled models with COBALT and BLING (which otherwise crash).