### PR TITLE
Bugfix to reintroduce group halo pass check removed in 282a1601c9b

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -566,7 +566,7 @@ subroutine step_MOM(fluxes, state, Time_start, time_interval, CS)
     call create_group_pass(CS%pass_tau_ustar_psurf, fluxes%ustar(:,:), G%Domain)
   if (ASSOCIATED(fluxes%p_surf)) &
     call create_group_pass(CS%pass_tau_ustar_psurf, fluxes%p_surf(:,:), G%Domain)
-  if (CS%thickness_diffuse .OR. CS%mixedlayer_restrat) &
+  if ((CS%thickness_diffuse .and. (.not.CS%thickness_diffuse_first .or. CS%t_dyn_rel_adv == 0)) .OR. CS%mixedlayer_restrat) &
     call create_group_pass(CS%pass_h, h, G%Domain) !###, halo=max(2,cont_stensil))
 
   if (CS%diabatic_first) then


### PR DESCRIPTION

Runs fail with
FATAL from PE   107: MPP_RESET_GROUP_UPDATE_FIELD_3D_: group%reset_index_s > group%nscalar
etc.

" .and. (.not.CS%thickness_diffuse_first .or. CS%t_dyn_rel_adv == 0)) " was removed in a previous update.