### PR TITLE
Changed intent for G in tidal_forcing_init()

### DIFF
--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -105,10 +105,10 @@ integer :: id_clock_tides
 contains
 
 subroutine tidal_forcing_init(Time, G, param_file, CS)
-  type(time_type),       intent(in) :: Time
-  type(ocean_grid_type), intent(in) :: G    !< The ocean's grid structure
-  type(param_file_type), intent(in) :: param_file !< A structure to parse for run-time parameters
-  type(tidal_forcing_CS), pointer   :: CS
+  type(time_type),       intent(in)    :: Time
+  type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure
+  type(param_file_type), intent(in)    :: param_file !< A structure to parse for run-time parameters
+  type(tidal_forcing_CS), pointer      :: CS
 
 ! This subroutine allocates space for the static variables used
 ! by this module.  The metrics may be effectively 0, 1, or 2-D arrays,


### PR DESCRIPTION
@Hallberg-NOAA I am a little uneasy that all three compilers, with the newest and only versions we have on c4, happily compiled. How can all three compilers have stopped checking intents?

Commit message:
- The recent introduction of pass_var() calls on some fields in
  tidal_forcing_init() should have caused compile-time errors
  because pass_var() requires the G%Domain argument to be intent(inout).
- Very worryingly, none of the compilers on c3 complained. Nor did gnu
  complain on the "trusty" image but I happened to still be using the older
  "precise" image for testing my scripts and the compiler there
  caught the mistake.