### PR TITLE
Renamed variables "mod" to "mdl"

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -885,7 +885,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
   character(len=200) :: TideAmp_file, gust_file, salt_file, temp_file ! Input file names.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_surface_forcing"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_surface_forcing"  ! This module's name.
   character(len=48)  :: stagger
   character(len=240) :: basin_file
   integer :: i, j, isd, ied, jsd, jed
@@ -906,26 +906,26 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
 
   call write_version_number (version)
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mod, "INPUTDIR", CS%inputdir, &
+  call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, &
                  "The directory in which all input files are found.", &
                  default=".")
   CS%inputdir = slasher(CS%inputdir)
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
                  "If true, Temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
+  call get_param(param_file, mdl, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
                  "The latent heat of fusion.", units="J/kg", default=hlf)
-  call get_param(param_file, mod, "LATENT_HEAT_VAPORIZATION", CS%latent_heat_vapor, &
+  call get_param(param_file, mdl, "LATENT_HEAT_VAPORIZATION", CS%latent_heat_vapor, &
                  "The latent heat of fusion.", units="J/kg", default=hlv)
-  call get_param(param_file, mod, "MAX_P_SURF", CS%max_p_surf, &
+  call get_param(param_file, mdl, "MAX_P_SURF", CS%max_p_surf, &
                  "The maximum surface pressure that can be exerted by the \n"//&
                  "atmosphere and floating sea-ice or ice shelves. This is \n"//&
                  "needed because the FMS coupling structure does not \n"//&
@@ -933,31 +933,31 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
                  "the ice-ocean heat fluxes are treated explicitly.  No \n"//&
                  "limit is applied if a negative value is used.", units="Pa", &
                  default=-1.0)
-  call get_param(param_file, mod, "ADJUST_NET_SRESTORE_TO_ZERO", &
+  call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_TO_ZERO", &
                  CS%adjust_net_srestore_to_zero, &
                  "If true, adjusts the salinity restoring seen to zero\n"//&
                  "whether restoring is via a salt flux or virtual precip.",&
                  default=restore_salt)
-  call get_param(param_file, mod, "ADJUST_NET_SRESTORE_BY_SCALING", &
+  call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_BY_SCALING", &
                  CS%adjust_net_srestore_by_scaling, &
                  "If true, adjustments to salt restoring to achieve zero net are\n"//&
                  "made by scaling values without moving the zero contour.",&
                  default=.false.)
-  call get_param(param_file, mod, "ADJUST_NET_FRESH_WATER_TO_ZERO", &
+  call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_TO_ZERO", &
                  CS%adjust_net_fresh_water_to_zero, &
                  "If true, adjusts the net fresh-water forcing seen \n"//&
                  "by the ocean (including restoring) to zero.", default=.false.)
-  call get_param(param_file, mod, "ADJUST_NET_FRESH_WATER_BY_SCALING", &
+  call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_BY_SCALING", &
                  CS%adjust_net_fresh_water_by_scaling, &
                  "If true, adjustments to net fresh water to achieve zero net are\n"//&
                  "made by scaling values without moving the zero contour.",&
                  default=.false.)
-  call get_param(param_file, mod, "ICE_SALT_CONCENTRATION", &
+  call get_param(param_file, mdl, "ICE_SALT_CONCENTRATION", &
                  CS%ice_salt_concentration, &
                  "The assumed sea-ice salinity needed to reverse engineer the \n"//&
                  "melt flux (or ice-ocean fresh-water flux).", &
                  units="kg/kg", default=0.005)
-  call get_param(param_file, mod, "USE_LIMITED_PATM_SSH", CS%use_limited_P_SSH, &
+  call get_param(param_file, mdl, "USE_LIMITED_PATM_SSH", CS%use_limited_P_SSH, &
                  "If true, return the sea surface height with the \n"//&
                  "correction for the atmospheric (and sea-ice) pressure \n"//&
                  "limited by max_p_surf instead of the full atmospheric \n"//&
@@ -965,10 +965,10 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
 
 ! smg: should get_param call should be removed when have A=B code reconciled.
 ! this param is used to distinguish how to diagnose surface heat content from water.
-  call get_param(param_file, mod, "BULKMIXEDLAYER", CS%bulkmixedlayer, &
+  call get_param(param_file, mdl, "BULKMIXEDLAYER", CS%bulkmixedlayer, &
                  default=CS%use_temperature,do_not_log=.true.)
 
-  call get_param(param_file, mod, "WIND_STAGGER", stagger, &
+  call get_param(param_file, mdl, "WIND_STAGGER", stagger, &
                  "A case-insensitive character string to indicate the \n"//&
                  "staggering of the input wind stress field.  Valid \n"//&
                  "values are 'A', 'B', or 'C'.", default="C")
@@ -977,43 +977,43 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
   elseif (uppercase(stagger(1:1)) == 'C') then ; CS%wind_stagger = CGRID_NE
   else ; call MOM_error(FATAL,"surface_forcing_init: WIND_STAGGER = "// &
                         trim(stagger)//" is invalid.") ; endif
-  call get_param(param_file, mod, "WIND_STRESS_MULTIPLIER", CS%wind_stress_multiplier, &
+  call get_param(param_file, mdl, "WIND_STRESS_MULTIPLIER", CS%wind_stress_multiplier, &
                  "A factor multiplying the wind-stress given to the ocean by the\n"//&
                  "coupler. This is used for testing and should be =1.0 for any\n"//&
                  "production runs.", default=1.0)
 
   if (restore_salt) then
-    call get_param(param_file, mod, "FLUXCONST", CS%Flux_const, &
+    call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
-    call get_param(param_file, mod, "SALT_RESTORE_FILE", CS%salt_restore_file, &
+    call get_param(param_file, mdl, "SALT_RESTORE_FILE", CS%salt_restore_file, &
                  "A file in which to find the surface salinity to use for restoring.", &
                  default="salt_restore.nc")
-    call get_param(param_file, mod, "SALT_RESTORE_VARIABLE", CS%salt_restore_var_name, &
+    call get_param(param_file, mdl, "SALT_RESTORE_VARIABLE", CS%salt_restore_var_name, &
                  "The name of the surface salinity variable to read from "//&
                  "SALT_RESTORE_FILE for restoring salinity.", &
                  default="salt")
 ! Convert CS%Flux_const from m day-1 to m s-1.
     CS%Flux_const = CS%Flux_const / 86400.0
 
-    call get_param(param_file, mod, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
+    call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
                  "If true, the restoring of salinity is applied as a salt \n"//&
                  "flux instead of as a freshwater flux.", default=.false.)
-    call get_param(param_file, mod, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
+    call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
                  "The maximum salinity difference used in restoring terms.", &
                  units="PSU or g kg-1", default=999.0)
-    call get_param(param_file, mod, "MASK_SRESTORE_UNDER_ICE", &
+    call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", &
                  CS%mask_srestore_under_ice, &
                  "If true, disables SSS restoring under sea-ice based on a frazil\n"//&
                  "criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.",      &
                  default=.false.)
-    call get_param(param_file, mod, "MASK_SRESTORE_MARGINAL_SEAS", &
+    call get_param(param_file, mdl, "MASK_SRESTORE_MARGINAL_SEAS", &
                  CS%mask_srestore_marginal_seas, &
                  "If true, disable SSS restoring in marginal seas. Only used when\n"//&
                  "RESTORE_SALINITY is True.", default=.false.)
-    call get_param(param_file, mod, "BASIN_FILE", basin_file, &
+    call get_param(param_file, mdl, "BASIN_FILE", basin_file, &
                  "A file in which to find the basin masks, in variable 'basin'.", &
                  default="basin.nc")
     basin_file = trim(CS%inputdir) // trim(basin_file)
@@ -1028,22 +1028,22 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
   endif
 
   if (restore_temp) then
-    call get_param(param_file, mod, "FLUXCONST", CS%Flux_const, &
+    call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
-    call get_param(param_file, mod, "SST_RESTORE_FILE", CS%temp_restore_file, &
+    call get_param(param_file, mdl, "SST_RESTORE_FILE", CS%temp_restore_file, &
                  "A file in which to find the surface temperature to use for restoring.", &
                  default="temp_restore.nc")
-    call get_param(param_file, mod, "SST_RESTORE_VARIABLE", CS%temp_restore_var_name, &
+    call get_param(param_file, mdl, "SST_RESTORE_VARIABLE", CS%temp_restore_var_name, &
                  "The name of the surface temperature variable to read from "//&
                  "SST_RESTORE_FILE for restoring sst.", &
                  default="temp")
 ! Convert CS%Flux_const from m day-1 to m s-1.
     CS%Flux_const = CS%Flux_const / 86400.0
 
-    call get_param(param_file, mod, "MAX_DELTA_TRESTORE", CS%max_delta_trestore, &
+    call get_param(param_file, mdl, "MAX_DELTA_TRESTORE", CS%max_delta_trestore, &
                  "The maximum sst difference used in restoring terms.", &
                  units="degC ", default=999.0)
 
@@ -1053,20 +1053,20 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
 ! Otherwise use default tidal amplitude for bottom frictionally-generated
 ! dissipation. Default cd_tides is chosen to yield approx 1 TWatt of
 ! work done against tides globally using OSU tidal amplitude.
-  call get_param(param_file, mod, "CD_TIDES", CS%cd_tides, &
+  call get_param(param_file, mdl, "CD_TIDES", CS%cd_tides, &
                  "The drag coefficient that applies to the tides.", &
                  units="nondim", default=1.0e-4)
-  call get_param(param_file, mod, "READ_TIDEAMP", CS%read_TIDEAMP, &
+  call get_param(param_file, mdl, "READ_TIDEAMP", CS%read_TIDEAMP, &
                  "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
                  "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
   if (CS%read_TIDEAMP) then
-    call get_param(param_file, mod, "TIDEAMP_FILE", TideAmp_file, &
+    call get_param(param_file, mdl, "TIDEAMP_FILE", TideAmp_file, &
                  "The path to the file containing the spatially varying \n"//&
                  "tidal amplitudes with INT_TIDE_DISSIPATION.", &
                  default="tideamp.nc")
     CS%utide=0.0
   else
-    call get_param(param_file, mod, "UTIDE", CS%utide, &
+    call get_param(param_file, mdl, "UTIDE", CS%utide, &
                  "The constant tidal amplitude used with INT_TIDE_DISSIPATION.", &
                  units="m s-1", default=0.0)
   endif
@@ -1095,14 +1095,14 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
 ! Optionally read a x-y gustiness field in place of a global
 ! constant.
 
-  call get_param(param_file, mod, "READ_GUST_2D", CS%read_gust_2d, &
+  call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
                  "If true, use a 2-dimensional gustiness supplied from \n"//&
                  "an input file", default=.false.)
-  call get_param(param_file, mod, "GUST_CONST", CS%gust_const, &
+  call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                "The background gustiness in the winds.", units="Pa", &
                default=0.02)
   if (CS%read_gust_2d) then
-    call get_param(param_file, mod, "GUST_2D_FILE", gust_file, &
+    call get_param(param_file, mdl, "GUST_2D_FILE", gust_file, &
                  "The file in which the wind gustiness is found in \n"//&
                  "variable gustiness.")
 
@@ -1113,31 +1113,31 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
   endif
 
 ! See whether sufficiently thick sea ice should be treated as rigid.
-  call get_param(param_file, mod, "USE_RIGID_SEA_ICE", CS%rigid_sea_ice, &
+  call get_param(param_file, mdl, "USE_RIGID_SEA_ICE", CS%rigid_sea_ice, &
                  "If true, sea-ice is rigid enough to exert a \n"//&
                  "nonhydrostatic pressure that resist vertical motion.", &
                  default=.false.)
   if (CS%rigid_sea_ice) then
-    call get_param(param_file, mod, "SEA_ICE_MEAN_DENSITY", CS%density_sea_ice, &
+    call get_param(param_file, mdl, "SEA_ICE_MEAN_DENSITY", CS%density_sea_ice, &
                  "A typical density of sea ice, used with the kinematic \n"//&
                  "viscosity, when USE_RIGID_SEA_ICE is true.", units="kg m-3", &
                  default=900.0)
-    call get_param(param_file, mod, "SEA_ICE_VISCOSITY", CS%Kv_sea_ice, &
+    call get_param(param_file, mdl, "SEA_ICE_VISCOSITY", CS%Kv_sea_ice, &
                  "The kinematic viscosity of sufficiently thick sea ice \n"//&
                  "for use in calculating the rigidity of sea ice.", &
                  units="m2 s-1", default=1.0e9)
-    call get_param(param_file, mod, "SEA_ICE_RIGID_MASS", CS%rigid_sea_ice_mass, &
+    call get_param(param_file, mdl, "SEA_ICE_RIGID_MASS", CS%rigid_sea_ice_mass, &
                  "The mass of sea-ice per unit area at which the sea-ice \n"//&
                  "starts to exhibit rigidity", units="kg m-2", default=1000.0)
   endif
 
-  call get_param(param_file, mod, "ALLOW_ICEBERG_FLUX_DIAGNOSTICS", iceberg_flux_diags, &
+  call get_param(param_file, mdl, "ALLOW_ICEBERG_FLUX_DIAGNOSTICS", iceberg_flux_diags, &
                  "If true, makes available diagnostics of fluxes from icebergs\n"//&
                  "as seen by MOM6.", default=.false.)
   call register_forcing_type_diags(Time, diag, CS%use_temperature, CS%handles, &
                                    use_berg_fluxes=iceberg_flux_diags)
 
-  call get_param(param_file, mod, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
+  call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
                  "If true, allows flux adjustments to specified via the \n"//&
                  "data_table using the component name 'OCN'.", default=.false.)
   if (CS%allow_flux_adjustments) then

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -220,7 +220,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in)
   real :: G_Earth     ! The gravitational acceleration in m s-2.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "ocean_model_init"  ! This module's name.
+  character(len=40)  :: mdl = "ocean_model_init"  ! This module's name.
   character(len=48)  :: stagger
   integer :: secs, days
   type(param_file_type) :: param_file !< A structure to parse for run-time parameters
@@ -246,22 +246,22 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in)
   OS%fluxes%C_p = OS%MOM_CSp%tv%C_p
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "RESTART_CONTROL", OS%Restart_control, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "RESTART_CONTROL", OS%Restart_control, &
                  "An integer whose bits encode which restart files are \n"//&
                  "written. Add 2 (bit 1) for a time-stamped file, and odd \n"//&
                  "(bit 0) for a non-time-stamped file.  A restart file \n"//&
                  "will be saved at the end of the run segment for any \n"//&
                  "non-negative value.", default=1)
-  call get_param(param_file, mod, "TIMEUNIT", Time_unit, &
+  call get_param(param_file, mdl, "TIMEUNIT", Time_unit, &
                  "The time unit for ENERGYSAVEDAYS.", &
                  units="s", default=86400.0)
-  call get_param(param_file, mod, "ENERGYSAVEDAYS",OS%energysavedays, &
+  call get_param(param_file, mdl, "ENERGYSAVEDAYS",OS%energysavedays, &
                  "The interval in units of TIMEUNIT between saves of the \n"//&
                  "energies of the run and other globally summed diagnostics.", &
                  default=set_time(0,days=1), timeunit=Time_unit)
 
-  call get_param(param_file, mod, "OCEAN_SURFACE_STAGGER", stagger, &
+  call get_param(param_file, mdl, "OCEAN_SURFACE_STAGGER", stagger, &
                  "A case-insensitive character string to indicate the \n"//&
                  "staggering of the surface velocity field that is \n"//&
                  "returned to the coupler.  Valid values include \n"//&
@@ -272,38 +272,38 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in)
   else ; call MOM_error(FATAL,"ocean_model_init: OCEAN_SURFACE_STAGGER = "// &
                         trim(stagger)//" is invalid.") ; endif
 
-  call get_param(param_file, mod, "RESTORE_SALINITY",OS%restore_salinity, &
+  call get_param(param_file, mdl, "RESTORE_SALINITY",OS%restore_salinity, &
                  "If true, the coupled driver will add a globally-balanced \n"//&
                  "fresh-water flux that drives sea-surface salinity \n"//&
                  "toward specified values.", default=.false.)
-  call get_param(param_file, mod, "RESTORE_TEMPERATURE",OS%restore_temp, &
+  call get_param(param_file, mdl, "RESTORE_TEMPERATURE",OS%restore_temp, &
                  "If true, the coupled driver will add a  \n"//&
                  "heat flux that drives sea-surface temperauture \n"//&
                  "toward specified values.", default=.false.)
-  call get_param(param_file, mod, "RHO_0", Rho0, &
+  call get_param(param_file, mdl, "RHO_0", Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "G_EARTH", G_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
 
-  call get_param(param_file, mod, "ICE_SHELF",  OS%use_ice_shelf, &
+  call get_param(param_file, mdl, "ICE_SHELF",  OS%use_ice_shelf, &
                  "If true, enables the ice shelf model.", default=.false.)
 
-  call get_param(param_file, mod, "ICEBERGS_APPLY_RIGID_BOUNDARY",  OS%icebergs_apply_rigid_boundary, &
+  call get_param(param_file, mdl, "ICEBERGS_APPLY_RIGID_BOUNDARY",  OS%icebergs_apply_rigid_boundary, &
                  "If true, allows icebergs to change boundary condition felt by ocean", default=.false.)
 
   if (OS%icebergs_apply_rigid_boundary) then
-    call get_param(param_file, mod, "KV_ICEBERG",  OS%kv_iceberg, &
+    call get_param(param_file, mdl, "KV_ICEBERG",  OS%kv_iceberg, &
                  "The viscosity of the icebergs",  units="m2 s-1",default=1.0e10)
-    call get_param(param_file, mod, "DENSITY_ICEBERGS",  OS%density_iceberg, &
+    call get_param(param_file, mdl, "DENSITY_ICEBERGS",  OS%density_iceberg, &
                   "A typical density of icebergs.", units="kg m-3", default=917.0)
-    call get_param(param_file, mod, "LATENT_HEAT_FUSION", OS%latent_heat_fusion, &
+    call get_param(param_file, mdl, "LATENT_HEAT_FUSION", OS%latent_heat_fusion, &
                  "The latent heat of fusion.", units="J/kg", default=hlf)
-    call get_param(param_file, mod, "BERG_AREA_THRESHOLD", OS%berg_area_threshold, &
+    call get_param(param_file, mdl, "BERG_AREA_THRESHOLD", OS%berg_area_threshold, &
                  "Fraction of grid cell which iceberg must occupy, so that fluxes \n"//&
                   "below berg are set to zero. Not applied for negative \n"//&
                  " values.", units="non-dim", default=-1.0)
@@ -881,7 +881,7 @@ subroutine ocean_model_flux_init(OS)
 
   integer :: dummy
   character(len=128) :: default_ice_restart_file, default_ocean_restart_file
-  character(len=40)  :: mod = "ocean_model_flux_init"  ! This module's name.
+  character(len=40)  :: mdl = "ocean_model_flux_init"  ! This module's name.
   type(param_file_type) :: param_file !< A structure to parse for run-time parameters
   type(directories) :: dirs_tmp  ! A structure containing several relevant directory paths.
   logical :: use_OCMIP_CFCs, use_MOM_generic_tracer
@@ -891,9 +891,9 @@ subroutine ocean_model_flux_init(OS)
 
   call get_MOM_Input(param_file, dirs_tmp, check_params=.false.)
 
-  call get_param(param_file, mod, "USE_OCMIP2_CFC", use_OCMIP_CFCs, &
+  call get_param(param_file, mdl, "USE_OCMIP2_CFC", use_OCMIP_CFCs, &
                  default=.false., do_not_log=.true.)
-  call get_param(param_file, mod, "USE_generic_tracer", use_MOM_generic_tracer,&
+  call get_param(param_file, mdl, "USE_generic_tracer", use_MOM_generic_tracer,&
                  default=.false., do_not_log=.true.)
 
   call close_param_file(param_file, quiet_close=.true.)

--- a/config_src/ice_solo_driver/MOM_surface_forcing.F90
+++ b/config_src/ice_solo_driver/MOM_surface_forcing.F90
@@ -1113,7 +1113,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
   type(time_type)    :: Time_frc
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_surface_forcing" ! This module's name.
+  character(len=40)  :: mdl = "MOM_surface_forcing" ! This module's name.
   character(len=60)  :: axis_units
   character(len=200) :: filename, gust_file ! The name of the gustiness input file.
 
@@ -1131,128 +1131,128 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
   if (associated(tracer_flow_CSp)) CS%tracer_flow_CSp => tracer_flow_CSp
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
                  "If true, Temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
-  call get_param(param_file, mod, "INPUTDIR", CS%inputdir, &
+  call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, &
                  "The directory in which all input files are found.", &
                  default=".")
   CS%inputdir = slasher(CS%inputdir)
 
-  call get_param(param_file, mod, "ADIABATIC", CS%adiabatic, &
+  call get_param(param_file, mdl, "ADIABATIC", CS%adiabatic, &
                  "There are no diapycnal mass fluxes if ADIABATIC is \n"//&
                  "true. This assumes that KD = KDML = 0.0 and that \n"//&
                  "there is no buoyancy forcing, but makes the model \n"//&
                  "faster by eliminating subroutine calls.", default=.false.)
-  call get_param(param_file, mod, "VARIABLE_WINDS", CS%variable_winds, &
+  call get_param(param_file, mdl, "VARIABLE_WINDS", CS%variable_winds, &
                  "If true, the winds vary in time after the initialization.", &
                  default=.true.)
-  call get_param(param_file, mod, "VARIABLE_BUOYFORCE", CS%variable_buoyforce, &
+  call get_param(param_file, mdl, "VARIABLE_BUOYFORCE", CS%variable_buoyforce, &
                  "If true, the buoyancy forcing varies in time after the \n"//&
                  "initialization of the model.", default=.true.)
 
-  call get_param(param_file, mod, "BUOY_CONFIG", CS%buoy_config, &
+  call get_param(param_file, mdl, "BUOY_CONFIG", CS%buoy_config, &
                  "The character string that indicates how buoyancy forcing \n"//&
                  "is specified. Valid options include (file), (zero), \n"//&
                  "(linear), (USER), and (NONE).", fail_if_missing=.true.)
   if (trim(CS%buoy_config) == "file") then
-    call get_param(param_file, mod, "LONGWAVEDOWN_FILE", CS%longwavedown_file, &
+    call get_param(param_file, mdl, "LONGWAVEDOWN_FILE", CS%longwavedown_file, &
                  "The file with the downward longwave heat flux, in \n"//&
                  "variable lwdn_sfc.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "LONGWAVEUP_FILE", CS%longwaveup_file, &
+    call get_param(param_file, mdl, "LONGWAVEUP_FILE", CS%longwaveup_file, &
                  "The file with the upward longwave heat flux, in \n"//&
                  "variable lwup_sfc.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "EVAPORATION_FILE", CS%evaporation_file, &
+    call get_param(param_file, mdl, "EVAPORATION_FILE", CS%evaporation_file, &
                  "The file with the evaporative moisture flux, in \n"//&
                  "variable evap.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "SENSIBLEHEAT_FILE", CS%sensibleheat_file, &
+    call get_param(param_file, mdl, "SENSIBLEHEAT_FILE", CS%sensibleheat_file, &
                  "The file with the sensible heat flux, in \n"//&
                  "variable shflx.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "SHORTWAVEUP_FILE", CS%shortwaveup_file, &
+    call get_param(param_file, mdl, "SHORTWAVEUP_FILE", CS%shortwaveup_file, &
                  "The file with the upward shortwave heat flux.", &
                  fail_if_missing=.true.)
-    call get_param(param_file, mod, "SHORTWAVEDOWN_FILE", CS%shortwavedown_file, &
+    call get_param(param_file, mdl, "SHORTWAVEDOWN_FILE", CS%shortwavedown_file, &
                  "The file with the downward shortwave heat flux.", &
                  fail_if_missing=.true.)
-    call get_param(param_file, mod, "SNOW_FILE", CS%snow_file, &
+    call get_param(param_file, mdl, "SNOW_FILE", CS%snow_file, &
                  "The file with the downward frozen precip flux, in \n"//&
                  "variable snow.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "PRECIP_FILE", CS%precip_file, &
+    call get_param(param_file, mdl, "PRECIP_FILE", CS%precip_file, &
                  "The file with the downward total precip flux, in \n"//&
                  "variable precip.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "FRESHDISCHARGE_FILE", CS%freshdischarge_file, &
+    call get_param(param_file, mdl, "FRESHDISCHARGE_FILE", CS%freshdischarge_file, &
                  "The file with the fresh and frozen runoff/calving fluxes, \n"//&
                  "invariables disch_w and disch_s.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "SSTRESTORE_FILE", CS%SSTrestore_file, &
+    call get_param(param_file, mdl, "SSTRESTORE_FILE", CS%SSTrestore_file, &
                  "The file with the SST toward which to restore in \n"//&
                  "variable TEMP.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "SALINITYRESTORE_FILE", CS%salinityrestore_file, &
+    call get_param(param_file, mdl, "SALINITYRESTORE_FILE", CS%salinityrestore_file, &
                  "The file with the surface salinity toward which to \n"//&
                  "restore in variable SALT.", fail_if_missing=.true.)
   endif
-  call get_param(param_file, mod, "WIND_CONFIG", CS%wind_config, &
+  call get_param(param_file, mdl, "WIND_CONFIG", CS%wind_config, &
                  "The character string that indicates how wind forcing \n"//&
                  "is specified. Valid options include (file), (2gyre), \n"//&
                  "(1gyre), (gyres), (zero), and (USER).", fail_if_missing=.true.)
   if (trim(CS%wind_config) == "file") then
-    call get_param(param_file, mod, "WIND_FILE", CS%wind_file, &
+    call get_param(param_file, mdl, "WIND_FILE", CS%wind_file, &
                  "The file in which the wind stresses are found in \n"//&
                  "variables STRESS_X and STRESS_Y.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "WINDSTRESS_X_VAR",CS%stress_x_var, &
+    call get_param(param_file, mdl, "WINDSTRESS_X_VAR",CS%stress_x_var, &
                  "The name of the x-wind stress variable in WIND_FILE.", &
                  default="STRESS_X")
-    call get_param(param_file, mod, "WINDSTRESS_Y_VAR", CS%stress_y_var, &
+    call get_param(param_file, mdl, "WINDSTRESS_Y_VAR", CS%stress_y_var, &
                  "The name of the y-wind stress variable in WIND_FILE.", &
                  default="STRESS_Y")
-    call get_param(param_file, mod, "WINDSTRESS_STAGGER",CS%wind_stagger, &
+    call get_param(param_file, mdl, "WINDSTRESS_STAGGER",CS%wind_stagger, &
                  "A character indicating how the wind stress components \n"//&
                  "are staggered in WIND_FILE.  This may be A or C for now.", &
                  default="A")
-    call get_param(param_file, mod, "WINDSTRESS_SCALE", CS%wind_scale, &
+    call get_param(param_file, mdl, "WINDSTRESS_SCALE", CS%wind_scale, &
                  "A value by which the wind stresses in WIND_FILE are rescaled.", &
                  default=1.0, units="nondim")
   endif
   if (trim(CS%wind_config) == "gyres") then
-    call get_param(param_file, mod, "TAUX_CONST", CS%gyres_taux_const, &
+    call get_param(param_file, mdl, "TAUX_CONST", CS%gyres_taux_const, &
                  "With the gyres wind_config, the constant offset in the \n"//&
                  "zonal wind stress profile: \n"//&
                  "  A in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
-    call get_param(param_file, mod, "TAUX_SIN_AMP",CS%gyres_taux_sin_amp, &
+    call get_param(param_file, mdl, "TAUX_SIN_AMP",CS%gyres_taux_sin_amp, &
                  "With the gyres wind_config, the sine amplitude in the \n"//&
                  "zonal wind stress profile: \n"//&
                  "  B in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
-    call get_param(param_file, mod, "TAUX_COS_AMP",CS%gyres_taux_cos_amp, &
+    call get_param(param_file, mdl, "TAUX_COS_AMP",CS%gyres_taux_cos_amp, &
                  "With the gyres wind_config, the cosine amplitude in \n"//&
                  "the zonal wind stress profile: \n"//&
                  "  C in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
-    call get_param(param_file, mod, "TAUX_N_PIS",CS%gyres_taux_n_pis, &
+    call get_param(param_file, mdl, "TAUX_N_PIS",CS%gyres_taux_n_pis, &
                  "With the gyres wind_config, the number of gyres in \n"//&
                  "the zonal wind stress profile: \n"//&
                  "  n in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="nondim", default=0.0)
   endif
-  call get_param(param_file, mod, "SOUTHLAT", CS%south_lat, &
+  call get_param(param_file, mdl, "SOUTHLAT", CS%south_lat, &
                  "The southern latitude of the domain or the equivalent \n"//&
                  "starting value for the y-axis.", units=axis_units, default=0.)
-  call get_param(param_file, mod, "LENLAT", CS%len_lat, &
+  call get_param(param_file, mdl, "LENLAT", CS%len_lat, &
                  "The latitudinal or y-direction length of the domain.", &
                  units=axis_units, fail_if_missing=.true.)
-   call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "RESTOREBUOY", CS%restorebuoy, &
+  call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back \n"//&
                  "toward some specified surface state with a rate \n"//&
                  "given by FLUXCONST.", default= .false.)
   if (CS%restorebuoy) then
-    call get_param(param_file, mod, "FLUXCONST", CS%Flux_const, &
+    call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
@@ -1260,36 +1260,36 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
     ! Convert CS%Flux_const from m day-1 to m s-1.
     CS%Flux_const = CS%Flux_const / 86400.0
     if (trim(CS%buoy_config) == "linear") then
-      call get_param(param_file, mod, "SST_NORTH", CS%T_north, &
+      call get_param(param_file, mdl, "SST_NORTH", CS%T_north, &
                  "With buoy_config linear, the sea surface temperature \n"//&
                  "at the northern end of the domain toward which to \n"//&
                  "to restore.", units="deg C", default=0.0)
-      call get_param(param_file, mod, "SST_SOUTH", CS%T_south, &
+      call get_param(param_file, mdl, "SST_SOUTH", CS%T_south, &
                  "With buoy_config linear, the sea surface temperature \n"//&
                  "at the southern end of the domain toward which to \n"//&
                  "to restore.", units="deg C", default=0.0)
-      call get_param(param_file, mod, "SSS_NORTH", CS%S_north, &
+      call get_param(param_file, mdl, "SSS_NORTH", CS%S_north, &
                  "With buoy_config linear, the sea surface salinity \n"//&
                  "at the northern end of the domain toward which to \n"//&
                  "to restore.", units="PSU", default=35.0)
-      call get_param(param_file, mod, "SSS_SOUTH", CS%S_south, &
+      call get_param(param_file, mdl, "SSS_SOUTH", CS%S_south, &
                  "With buoy_config linear, the sea surface salinity \n"//&
                  "at the southern end of the domain toward which to \n"//&
                  "to restore.", units="PSU", default=35.0)
     endif
   endif
-  call get_param(param_file, mod, "G_EARTH", CS%G_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
 
-  call get_param(param_file, mod, "GUST_CONST", CS%gust_const, &
+  call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", units="Pa", &
                  default=0.02)
-  call get_param(param_file, mod, "READ_GUST_2D", CS%read_gust_2d, &
+  call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
                  "If true, use a 2-dimensional gustiness supplied from \n"//&
                  "an input file", default=.false.)
   if (CS%read_gust_2d) then
-    call get_param(param_file, mod, "GUST_2D_FILE", gust_file, &
+    call get_param(param_file, mdl, "GUST_2D_FILE", gust_file, &
                  "The file in which the wind gustiness is found in \n"//&
                  "variable gustiness.", fail_if_missing=.true.)
     call safe_alloc_ptr(CS%gust,G%isd,G%ied,G%jsd,G%jed) ; CS%gust(:,:) = 0.0
@@ -1297,7 +1297,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
     call read_data(filename,'gustiness',CS%gust,domain=G%domain%mpp_domain, &
                    timelevel=1) ! units should be Pa
   endif
-  call get_param(param_file, mod, "AXIS_UNITS", axis_units, default="degrees")
+  call get_param(param_file, mdl, "AXIS_UNITS", axis_units, default="degrees")
 
 !  All parameter settings are now known.
 

--- a/config_src/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/ice_solo_driver/ice_shelf_driver.F90
@@ -161,7 +161,7 @@ program SHELF_main
   character(len=4), parameter :: vers_num = 'v2.0'
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SHELF_main (ice_shelf_driver)" ! This module's name.
+  character(len=40)  :: mdl = "SHELF_main (ice_shelf_driver)" ! This module's name.
 
   namelist /ice_solo_nml/ date_init, calendar, months, days, hours, minutes, seconds
 
@@ -223,16 +223,16 @@ program SHELF_main
   call Get_MOM_Input(param_file, dirs)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mod, "ICE_SHELF", use_ice_shelf, &
+  call get_param(param_file, mdl, "ICE_SHELF", use_ice_shelf, &
                  "If true, call the code to apply an ice shelf model over \n"//&
                  "some of the domain.", default=.false.)
 
   if (.not.use_ice_shelf) call MOM_error(FATAL, &
         "shelf_driver: ICE_SHELF must be defined.")
 
-  call get_param(param_file, mod, "ICE_VELOCITY_TIMESTEP", time_step, &
+  call get_param(param_file, mdl, "ICE_VELOCITY_TIMESTEP", time_step, &
                  "The time step for changing forcing, coupling with other \n"//&
                  "components, or potentially writing certain diagnostics.", &
                  units="s", fail_if_missing=.true.)
@@ -260,20 +260,20 @@ program SHELF_main
     call MOM_mesg("Using real elapsed time for the master clock.")
 
   ! Determine the segment end time, either from the namelist file or parsed input file.
-  call get_param(param_file, mod, "TIMEUNIT", Time_unit, &
+  call get_param(param_file, mdl, "TIMEUNIT", Time_unit, &
                  "The time unit for DAYMAX and RESTINT.", &
                  units="s", default=86400.0)
   if (years+months+days+hours+minutes+seconds > 0) then
     Time_end = increment_date(Time, years, months, days, hours, minutes, seconds)
     call MOM_mesg('Segment run length determied from ice_solo_nml.', 2)
-    call get_param(param_file, mod, "DAYMAX", daymax, &
+    call get_param(param_file, mdl, "DAYMAX", daymax, &
                  "The final time of the whole simulation, in units of \n"//&
                  "TIMEUNIT seconds.  This also sets the potential end \n"//&
                  "time of the present run segment if the end time is \n"//&
                  "not set (as it was here) via ocean_solo_nml in input.nml.", &
                  timeunit=Time_unit, default=Time_end)
   else
-    call get_param(param_file, mod, "DAYMAX", daymax, &
+    call get_param(param_file, mdl, "DAYMAX", daymax, &
                  "The final time of the whole simulation, in units of \n"//&
                  "TIMEUNIT seconds.  This also sets the potential end \n"//&
                  "time of the present run segment if the end time is \n"//&
@@ -286,18 +286,18 @@ program SHELF_main
   if (Time >= Time_end) call MOM_error(FATAL, &
     "MOM_driver: The run has been started at or after the end time of the run.")
 
-  call get_param(param_file, mod, "RESTART_CONTROL", Restart_control, &
+  call get_param(param_file, mdl, "RESTART_CONTROL", Restart_control, &
                  "An integer whose bits encode which restart files are \n"//&
                  "written. Add 2 (bit 1) for a time-stamped file, and odd \n"//&
                  "(bit 0) for a non-time-stamped file. A non-time-stamped \n"//&
                  "restart file is saved at the end of the run segment \n"//&
                  "for any non-negative value.", default=1)
-  call get_param(param_file, mod, "RESTINT", restint, &
+  call get_param(param_file, mdl, "RESTINT", restint, &
                  "The interval between saves of the restart file in units \n"//&
                  "of TIMEUNIT.  Use 0 (the default) to not save \n"//&
                  "incremental restart files at all.", default=set_time(0), &
                  timeunit=Time_unit)
-  call log_param(param_file, mod, "ELAPSED TIME AS MASTER", elapsed_time_master)
+  call log_param(param_file, mdl, "ELAPSED TIME AS MASTER", elapsed_time_master)
 
 !   i don't think we'll use this...
 !   call MOM_sum_output_init(grid, param_file, dirs%output_directory, &

--- a/config_src/ice_solo_driver/user_surface_forcing.F90
+++ b/config_src/ice_solo_driver/user_surface_forcing.F90
@@ -332,7 +332,7 @@ subroutine USER_surface_forcing_init(Time, G, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "user_surface_forcing" ! This module's name.
+  character(len=40)  :: mdl = "user_surface_forcing" ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "USER_surface_forcing_init called with an associated "// &
@@ -343,28 +343,28 @@ subroutine USER_surface_forcing_init(Time, G, param_file, diag, CS)
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
                  "If true, Temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
-  call get_param(param_file, mod, "G_EARTH", CS%G_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
-  call get_param(param_file, mod, "GUST_CONST", CS%gust_const, &
+  call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", units="Pa", &
                  default=0.02)
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "RESTOREBUOY", CS%restorebuoy, &
+  call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back \n"//&
                  "toward some specified surface state with a rate \n"//&
                  "given by FLUXCONST.", default= .false.)
   if (CS%restorebuoy) then
-    call get_param(param_file,mod, "FLUXCONST", CS%Flux_const, &
+    call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &

--- a/config_src/solo_driver/MESO_surface_forcing.F90
+++ b/config_src/solo_driver/MESO_surface_forcing.F90
@@ -364,7 +364,7 @@ subroutine MESO_surface_forcing_init(Time, G, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MESO_surface_forcing" ! This module's name.
+  character(len=40)  :: mdl = "MESO_surface_forcing" ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "MESO_surface_forcing_init called with an associated "// &
@@ -375,31 +375,31 @@ subroutine MESO_surface_forcing_init(Time, G, param_file, diag, CS)
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
                  "If true, Temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
 
-  call get_param(param_file, mod, "G_EARTH", CS%G_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "GUST_CONST", CS%gust_const, &
+  call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", units="Pa", &
                  default=0.02)
 
-  call get_param(param_file, mod, "RESTOREBUOY", CS%restorebuoy, &
+  call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back \n"//&
                  "toward some specified surface state with a rate \n"//&
                  "given by FLUXCONST.", default= .false.)
 
   if (CS%restorebuoy) then
-    call get_param(param_file, mod, "FLUXCONST", CS%Flux_const, &
+    call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
@@ -407,22 +407,22 @@ subroutine MESO_surface_forcing_init(Time, G, param_file, diag, CS)
     ! Convert CS%Flux_const from m day-1 to m s-1.
     CS%Flux_const = CS%Flux_const / 86400.0
 
-    call get_param(param_file, mod, "SSTRESTORE_FILE", CS%SSTrestore_file, &
+    call get_param(param_file, mdl, "SSTRESTORE_FILE", CS%SSTrestore_file, &
                  "The file with the SST toward which to restore in \n"//&
                  "variable TEMP.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "SALINITYRESTORE_FILE", CS%salinityrestore_file, &
+    call get_param(param_file, mdl, "SALINITYRESTORE_FILE", CS%salinityrestore_file, &
                  "The file with the surface salinity toward which to \n"//&
                  "restore in variable SALT.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "SENSIBLEHEAT_FILE", CS%heating_file, &
+    call get_param(param_file, mdl, "SENSIBLEHEAT_FILE", CS%heating_file, &
                  "The file with the non-shortwave heat flux in \n"//&
                  "variable Heat.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "PRECIP_FILE", CS%PmE_file, &
+    call get_param(param_file, mdl, "PRECIP_FILE", CS%PmE_file, &
                  "The file with the net precipiation minus evaporation \n"//&
                  "in variable PmE.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "SHORTWAVE_FILE", CS%Solar_file, &
+    call get_param(param_file, mdl, "SHORTWAVE_FILE", CS%Solar_file, &
                  "The file with the shortwave heat flux in \n"//&
                  "variable NET_SOL.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "INPUTDIR", CS%inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
     CS%inputdir = slasher(CS%inputdir)
 
    endif

--- a/config_src/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/solo_driver/MOM_surface_forcing.F90
@@ -1535,7 +1535,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
   type(time_type)    :: Time_frc
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_surface_forcing" ! This module's name.
+  character(len=40)  :: mdl = "MOM_surface_forcing" ! This module's name.
   character(len=200) :: filename, gust_file ! The name of the gustiness input file.
 
   if (associated(CS)) then
@@ -1552,63 +1552,63 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
   if (associated(tracer_flow_CSp)) CS%tracer_flow_CSp => tracer_flow_CSp
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, '')
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
+  call log_version(param_file, mdl, version, '')
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
                  "If true, Temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
-  call get_param(param_file, mod, "INPUTDIR", CS%inputdir, &
+  call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, &
                  "The directory in which all input files are found.", &
                  default=".")
   CS%inputdir = slasher(CS%inputdir)
 
-  call get_param(param_file, mod, "ADIABATIC", CS%adiabatic, &
+  call get_param(param_file, mdl, "ADIABATIC", CS%adiabatic, &
                  "There are no diapycnal mass fluxes if ADIABATIC is \n"//&
                  "true. This assumes that KD = KDML = 0.0 and that \n"//&
                  "there is no buoyancy forcing, but makes the model \n"//&
                  "faster by eliminating subroutine calls.", default=.false.)
-  call get_param(param_file, mod, "VARIABLE_WINDS", CS%variable_winds, &
+  call get_param(param_file, mdl, "VARIABLE_WINDS", CS%variable_winds, &
                  "If true, the winds vary in time after the initialization.", &
                  default=.true.)
-  call get_param(param_file, mod, "VARIABLE_BUOYFORCE", CS%variable_buoyforce, &
+  call get_param(param_file, mdl, "VARIABLE_BUOYFORCE", CS%variable_buoyforce, &
                  "If true, the buoyancy forcing varies in time after the \n"//&
                  "initialization of the model.", default=.true.)
 
-  call get_param(param_file, mod, "BUOY_CONFIG", CS%buoy_config, &
+  call get_param(param_file, mdl, "BUOY_CONFIG", CS%buoy_config, &
                  "The character string that indicates how buoyancy forcing \n"//&
                  "is specified. Valid options include (file), (zero), \n"//&
                  "(linear), (USER), (BFB) and (NONE).", fail_if_missing=.true.)
   if (trim(CS%buoy_config) == "file") then
-    call get_param(param_file, mod, "ARCHAIC_OMIP_FORCING_FILE", CS%archaic_OMIP_file, &
+    call get_param(param_file, mdl, "ARCHAIC_OMIP_FORCING_FILE", CS%archaic_OMIP_file, &
                  "If true, use the forcing variable decomposition from \n"//&
                  "the old German OMIP prescription that predated CORE. If \n"//&
                  "false, use the variable groupings available from MOM \n"//&
                  "output diagnostics of forcing variables.", default=.true.)
     if (CS%archaic_OMIP_file) then
-      call get_param(param_file, mod, "LONGWAVEDOWN_FILE", CS%longwave_file, &
+      call get_param(param_file, mdl, "LONGWAVEDOWN_FILE", CS%longwave_file, &
                  "The file with the downward longwave heat flux, in \n"//&
                  "variable lwdn_sfc.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "LONGWAVEUP_FILE", CS%longwaveup_file, &
+      call get_param(param_file, mdl, "LONGWAVEUP_FILE", CS%longwaveup_file, &
                  "The file with the upward longwave heat flux, in \n"//&
                  "variable lwup_sfc.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "EVAPORATION_FILE", CS%evaporation_file, &
+      call get_param(param_file, mdl, "EVAPORATION_FILE", CS%evaporation_file, &
                  "The file with the evaporative moisture flux, in \n"//&
                  "variable evap.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "SENSIBLEHEAT_FILE", CS%sensibleheat_file, &
+      call get_param(param_file, mdl, "SENSIBLEHEAT_FILE", CS%sensibleheat_file, &
                  "The file with the sensible heat flux, in \n"//&
                  "variable shflx.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "SHORTWAVEUP_FILE", CS%shortwaveup_file, &
+      call get_param(param_file, mdl, "SHORTWAVEUP_FILE", CS%shortwaveup_file, &
                  "The file with the upward shortwave heat flux.", &
                  fail_if_missing=.true.)
-      call get_param(param_file, mod, "SHORTWAVEDOWN_FILE", CS%shortwave_file, &
+      call get_param(param_file, mdl, "SHORTWAVEDOWN_FILE", CS%shortwave_file, &
                  "The file with the downward shortwave heat flux.", &
                  fail_if_missing=.true.)
-      call get_param(param_file, mod, "SNOW_FILE", CS%snow_file, &
+      call get_param(param_file, mdl, "SNOW_FILE", CS%snow_file, &
                  "The file with the downward frozen precip flux, in \n"//&
                  "variable snow.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "PRECIP_FILE", CS%rain_file, &
+      call get_param(param_file, mdl, "PRECIP_FILE", CS%rain_file, &
                  "The file with the downward total precip flux, in \n"//&
                  "variable precip.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "FRESHDISCHARGE_FILE", CS%runoff_file, &
+      call get_param(param_file, mdl, "FRESHDISCHARGE_FILE", CS%runoff_file, &
                  "The file with the fresh and frozen runoff/calving fluxes, \n"//&
                  "invariables disch_w and disch_s.", fail_if_missing=.true.)
 
@@ -1619,66 +1619,66 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
       CS%lrunoff_var = "disch_w"; CS%frunoff_var = "disch_s"
 
     else
-      call get_param(param_file, mod, "LONGWAVE_FILE", CS%longwave_file, &
+      call get_param(param_file, mdl, "LONGWAVE_FILE", CS%longwave_file, &
                  "The file with the longwave heat flux, in the variable \n"//&
                  "given by LONGWAVE_FORCING_VAR.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "LONGWAVE_FORCING_VAR", CS%LW_var, &
+      call get_param(param_file, mdl, "LONGWAVE_FORCING_VAR", CS%LW_var, &
                  "The variable with the longwave forcing field.", default="LW")
 
-      call get_param(param_file, mod, "SHORTWAVE_FILE", CS%shortwave_file, &
+      call get_param(param_file, mdl, "SHORTWAVE_FILE", CS%shortwave_file, &
                  "The file with the shortwave heat flux, in the variable \n"//&
                  "given by SHORTWAVE_FORCING_VAR.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "SHORTWAVE_FORCING_VAR", CS%SW_var, &
+      call get_param(param_file, mdl, "SHORTWAVE_FORCING_VAR", CS%SW_var, &
                  "The variable with the shortwave forcing field.", default="SW")
 
-      call get_param(param_file, mod, "EVAPORATION_FILE", CS%evaporation_file, &
+      call get_param(param_file, mdl, "EVAPORATION_FILE", CS%evaporation_file, &
                  "The file with the evaporative moisture flux, in the \n"//&
                  "variable given by EVAP_FORCING_VAR.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "EVAP_FORCING_VAR", CS%evap_var, &
+      call get_param(param_file, mdl, "EVAP_FORCING_VAR", CS%evap_var, &
                  "The variable with the evaporative moisture flux.", &
                  default="evap")
 
-      call get_param(param_file, mod, "LATENTHEAT_FILE", CS%latentheat_file, &
+      call get_param(param_file, mdl, "LATENTHEAT_FILE", CS%latentheat_file, &
                  "The file with the latent heat flux, in the variable \n"//&
                  "given by LATENT_FORCING_VAR.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "LATENT_FORCING_VAR", CS%latent_var, &
+      call get_param(param_file, mdl, "LATENT_FORCING_VAR", CS%latent_var, &
                  "The variable with the latent heat flux.", default="latent")
 
-      call get_param(param_file, mod, "SENSIBLEHEAT_FILE", CS%sensibleheat_file, &
+      call get_param(param_file, mdl, "SENSIBLEHEAT_FILE", CS%sensibleheat_file, &
                  "The file with the sensible heat flux, in the variable \n"//&
                  "given by SENSIBLE_FORCING_VAR.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "SENSIBLE_FORCING_VAR", CS%sens_var, &
+      call get_param(param_file, mdl, "SENSIBLE_FORCING_VAR", CS%sens_var, &
                  "The variable with the sensible heat flux.", default="sensible")
 
-      call get_param(param_file, mod, "RAIN_FILE", CS%rain_file, &
+      call get_param(param_file, mdl, "RAIN_FILE", CS%rain_file, &
                  "The file with the liquid precipitation flux, in the \n"//&
                  "variable given by RAIN_FORCING_VAR.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "RAIN_FORCING_VAR", CS%rain_var, &
+      call get_param(param_file, mdl, "RAIN_FORCING_VAR", CS%rain_var, &
                  "The variable with the liquid precipitation flux.", &
                  default="liq_precip")
-      call get_param(param_file, mod, "SNOW_FILE", CS%snow_file, &
+      call get_param(param_file, mdl, "SNOW_FILE", CS%snow_file, &
                  "The file with the frozen precipitation flux, in the \n"//&
                  "variable given by SNOW_FORCING_VAR.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "SNOW_FORCING_VAR", CS%snow_var, &
+      call get_param(param_file, mdl, "SNOW_FORCING_VAR", CS%snow_var, &
                  "The variable with the frozen precipitation flux.", &
                  default="froz_precip")
 
-      call get_param(param_file, mod, "RUNOFF_FILE", CS%runoff_file, &
+      call get_param(param_file, mdl, "RUNOFF_FILE", CS%runoff_file, &
                  "The file with the fresh and frozen runoff/calving \n"//&
                  "fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR \n"//&
                  "and FROZ_RUNOFF_FORCING_VAR.", fail_if_missing=.true.)
-      call get_param(param_file, mod, "LIQ_RUNOFF_FORCING_VAR", CS%lrunoff_var, &
+      call get_param(param_file, mdl, "LIQ_RUNOFF_FORCING_VAR", CS%lrunoff_var, &
                  "The variable with the liquid runoff flux.", &
                  default="liq_runoff")
-      call get_param(param_file, mod, "FROZ_RUNOFF_FORCING_VAR", CS%frunoff_var, &
+      call get_param(param_file, mdl, "FROZ_RUNOFF_FORCING_VAR", CS%frunoff_var, &
                  "The variable with the frozen runoff flux.", &
                  default="froz_runoff")
     endif
 
-    call get_param(param_file, mod, "SSTRESTORE_FILE", CS%SSTrestore_file, &
+    call get_param(param_file, mdl, "SSTRESTORE_FILE", CS%SSTrestore_file, &
                  "The file with the SST toward which to restore in the \n"//&
                  "variable given by SST_RESTORE_VAR.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "SALINITYRESTORE_FILE", CS%salinityrestore_file, &
+    call get_param(param_file, mdl, "SALINITYRESTORE_FILE", CS%salinityrestore_file, &
                  "The file with the surface salinity toward which to \n"//&
                  "restore in the variable given by SSS_RESTORE_VAR.", &
                  fail_if_missing=.true.)
@@ -1686,10 +1686,10 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
     if (CS%archaic_OMIP_file) then
       CS%SST_restore_var = "TEMP" ; CS%SSS_restore_var = "SALT"
     else
-      call get_param(param_file, mod, "SST_RESTORE_VAR", CS%SST_restore_var, &
+      call get_param(param_file, mdl, "SST_RESTORE_VAR", CS%SST_restore_var, &
                  "The variable with the SST toward which to restore.", &
                  default="SST")
-      call get_param(param_file, mod, "SSS_RESTORE_VAR", CS%SSS_restore_var, &
+      call get_param(param_file, mdl, "SSS_RESTORE_VAR", CS%SSS_restore_var, &
                  "The variable with the SSS toward which to restore.", &
                  default="SSS")
     endif
@@ -1710,55 +1710,55 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
     CS%SSTrestore_file = trim(CS%inputdir)//trim(CS%SSTrestore_file)
     CS%salinityrestore_file = trim(CS%inputdir)//trim(CS%salinityrestore_file)
   elseif (trim(CS%buoy_config) == "const") then
-    call get_param(param_file, mod, "SENSIBLE_HEAT_FLUX", CS%constantHeatForcing, &
+    call get_param(param_file, mdl, "SENSIBLE_HEAT_FLUX", CS%constantHeatForcing, &
                  "A constant heat forcing (positive into ocean) applied \n"//&
                  "through the sensible heat flux field. ", &
                  units='W/m2', fail_if_missing=.true.)
   endif
-  call get_param(param_file, mod, "WIND_CONFIG", CS%wind_config, &
+  call get_param(param_file, mdl, "WIND_CONFIG", CS%wind_config, &
                  "The character string that indicates how wind forcing \n"//&
                  "is specified. Valid options include (file), (2gyre), \n"//&
                  "(1gyre), (gyres), (zero), and (USER).", fail_if_missing=.true.)
   if (trim(CS%wind_config) == "file") then
-    call get_param(param_file, mod, "WIND_FILE", CS%wind_file, &
+    call get_param(param_file, mdl, "WIND_FILE", CS%wind_file, &
                  "The file in which the wind stresses are found in \n"//&
                  "variables STRESS_X and STRESS_Y.", fail_if_missing=.true.)
-    call get_param(param_file, mod, "WINDSTRESS_X_VAR",CS%stress_x_var, &
+    call get_param(param_file, mdl, "WINDSTRESS_X_VAR",CS%stress_x_var, &
                  "The name of the x-wind stress variable in WIND_FILE.", &
                  default="STRESS_X")
-    call get_param(param_file, mod, "WINDSTRESS_Y_VAR", CS%stress_y_var, &
+    call get_param(param_file, mdl, "WINDSTRESS_Y_VAR", CS%stress_y_var, &
                  "The name of the y-wind stress variable in WIND_FILE.", &
                  default="STRESS_Y")
-    call get_param(param_file, mod, "WINDSTRESS_STAGGER",CS%wind_stagger, &
+    call get_param(param_file, mdl, "WINDSTRESS_STAGGER",CS%wind_stagger, &
                  "A character indicating how the wind stress components \n"//&
                  "are staggered in WIND_FILE.  This may be A or C for now.", &
                  default="A")
-    call get_param(param_file, mod, "WINDSTRESS_SCALE", CS%wind_scale, &
+    call get_param(param_file, mdl, "WINDSTRESS_SCALE", CS%wind_scale, &
                  "A value by which the wind stresses in WIND_FILE are rescaled.", &
                  default=1.0, units="nondim")
-    call get_param(param_file, mod, "USTAR_FORCING_VAR", CS%ustar_var, &
+    call get_param(param_file, mdl, "USTAR_FORCING_VAR", CS%ustar_var, &
                  "The name of the friction velocity variable in WIND_FILE \n"//&
                  "or blank to get ustar from the wind stresses plus the \n"//&
                  "gustiness.", default=" ", units="nondim")
     CS%wind_file = trim(CS%inputdir) // trim(CS%wind_file)
   endif
   if (trim(CS%wind_config) == "gyres") then
-    call get_param(param_file, mod, "TAUX_CONST", CS%gyres_taux_const, &
+    call get_param(param_file, mdl, "TAUX_CONST", CS%gyres_taux_const, &
                  "With the gyres wind_config, the constant offset in the \n"//&
                  "zonal wind stress profile: \n"//&
                  "  A in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
-    call get_param(param_file, mod, "TAUX_SIN_AMP",CS%gyres_taux_sin_amp, &
+    call get_param(param_file, mdl, "TAUX_SIN_AMP",CS%gyres_taux_sin_amp, &
                  "With the gyres wind_config, the sine amplitude in the \n"//&
                  "zonal wind stress profile: \n"//&
                  "  B in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
-    call get_param(param_file, mod, "TAUX_COS_AMP",CS%gyres_taux_cos_amp, &
+    call get_param(param_file, mdl, "TAUX_COS_AMP",CS%gyres_taux_cos_amp, &
                  "With the gyres wind_config, the cosine amplitude in \n"//&
                  "the zonal wind stress profile: \n"//&
                  "  C in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
-    call get_param(param_file, mod, "TAUX_N_PIS",CS%gyres_taux_n_pis, &
+    call get_param(param_file, mdl, "TAUX_N_PIS",CS%gyres_taux_n_pis, &
                  "With the gyres wind_config, the number of gyres in \n"//&
                  "the zonal wind stress profile: \n"//&
                  "  n in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
@@ -1771,22 +1771,22 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
     CS%south_lat = G%south_lat
     CS%len_lat = G%len_lat
   endif
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "RESTOREBUOY", CS%restorebuoy, &
+  call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back \n"//&
                  "toward some specified surface state with a rate \n"//&
                  "given by FLUXCONST.", default= .false.)
-  call get_param(param_file, mod, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
+  call get_param(param_file, mdl, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
                  "The latent heat of fusion.", units="J/kg", default=hlf)
-  call get_param(param_file, mod, "LATENT_HEAT_VAPORIZATION", CS%latent_heat_vapor, &
+  call get_param(param_file, mdl, "LATENT_HEAT_VAPORIZATION", CS%latent_heat_vapor, &
                  "The latent heat of fusion.", units="J/kg", default=hlv)
   if (CS%restorebuoy) then
-    call get_param(param_file, mod, "FLUXCONST", CS%Flux_const, &
+    call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
@@ -1794,36 +1794,36 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
     ! Convert CS%Flux_const from m day-1 to m s-1.
     CS%Flux_const = CS%Flux_const / 86400.0
     if (trim(CS%buoy_config) == "linear") then
-      call get_param(param_file, mod, "SST_NORTH", CS%T_north, &
+      call get_param(param_file, mdl, "SST_NORTH", CS%T_north, &
                  "With buoy_config linear, the sea surface temperature \n"//&
                  "at the northern end of the domain toward which to \n"//&
                  "to restore.", units="deg C", default=0.0)
-      call get_param(param_file, mod, "SST_SOUTH", CS%T_south, &
+      call get_param(param_file, mdl, "SST_SOUTH", CS%T_south, &
                  "With buoy_config linear, the sea surface temperature \n"//&
                  "at the southern end of the domain toward which to \n"//&
                  "to restore.", units="deg C", default=0.0)
-      call get_param(param_file, mod, "SSS_NORTH", CS%S_north, &
+      call get_param(param_file, mdl, "SSS_NORTH", CS%S_north, &
                  "With buoy_config linear, the sea surface salinity \n"//&
                  "at the northern end of the domain toward which to \n"//&
                  "to restore.", units="PSU", default=35.0)
-      call get_param(param_file, mod, "SSS_SOUTH", CS%S_south, &
+      call get_param(param_file, mdl, "SSS_SOUTH", CS%S_south, &
                  "With buoy_config linear, the sea surface salinity \n"//&
                  "at the southern end of the domain toward which to \n"//&
                  "to restore.", units="PSU", default=35.0)
     endif
   endif
-  call get_param(param_file, mod, "G_EARTH", CS%G_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
 
-  call get_param(param_file, mod, "GUST_CONST", CS%gust_const, &
+  call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", units="Pa", &
                  default=0.02)
-  call get_param(param_file, mod, "READ_GUST_2D", CS%read_gust_2d, &
+  call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
                  "If true, use a 2-dimensional gustiness supplied from \n"//&
                  "an input file", default=.false.)
   if (CS%read_gust_2d) then
-    call get_param(param_file, mod, "GUST_2D_FILE", gust_file, &
+    call get_param(param_file, mdl, "GUST_2D_FILE", gust_file, &
                  "The file in which the wind gustiness is found in \n"//&
                  "variable gustiness.", fail_if_missing=.true.)
     call safe_alloc_ptr(CS%gust,G%isd,G%ied,G%jsd,G%jed)
@@ -1843,10 +1843,10 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, tracer_flow_CSp)
   elseif (trim(CS%wind_config) == "SCM_ideal_hurr") then
     call SCM_idealized_hurricane_wind_init(Time, G, param_file, CS%SCM_idealized_hurricane_CSp)
   elseif (trim(CS%wind_config) == "const") then
-    call get_param(param_file, mod, "CONST_WIND_TAUX", CS%tau_x0, &
+    call get_param(param_file, mdl, "CONST_WIND_TAUX", CS%tau_x0, &
                  "With wind_config const, this is the constant zonal\n"//&
                  "wind-stress", units="Pa", fail_if_missing=.true.)
-    call get_param(param_file, mod, "CONST_WIND_TAUY", CS%tau_y0, &
+    call get_param(param_file, mdl, "CONST_WIND_TAUY", CS%tau_y0, &
                  "With wind_config const, this is the constant zonal\n"//&
                  "wind-stress", units="Pa", fail_if_missing=.true.)
   elseif (trim(CS%wind_config) == "SCM_CVmix_tests" .or. &

--- a/config_src/solo_driver/user_surface_forcing.F90
+++ b/config_src/solo_driver/user_surface_forcing.F90
@@ -332,7 +332,7 @@ subroutine USER_surface_forcing_init(Time, G, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "user_surface_forcing" ! This module's name.
+  character(len=40)  :: mdl = "user_surface_forcing" ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "USER_surface_forcing_init called with an associated "// &
@@ -343,30 +343,30 @@ subroutine USER_surface_forcing_init(Time, G, param_file, diag, CS)
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
                  "If true, Temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
 
-  call get_param(param_file, mod, "G_EARTH", CS%G_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "GUST_CONST", CS%gust_const, &
+  call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", units="Pa", &
                  default=0.02)
 
-  call get_param(param_file, mod, "RESTOREBUOY", CS%restorebuoy, &
+  call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back \n"//&
                  "toward some specified surface state with a rate \n"//&
                  "given by FLUXCONST.", default= .false.)
   if (CS%restorebuoy) then
-    call get_param(param_file, mod, "FLUXCONST", CS%Flux_const, &
+    call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &

--- a/config_src/unit_drivers/MOM_sum_driver.F90
+++ b/config_src/unit_drivers/MOM_sum_driver.F90
@@ -74,7 +74,7 @@ program MOM_main
   character(len=4), parameter :: vers_num = 'v2.0'
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_main (MOM_sum_driver)" ! This module's name.
+  character(len=40)  :: mdl = "MOM_main (MOM_sum_driver)" ! This module's name.
   character(len=200) :: mesg
 
   !#######################################################################
@@ -200,15 +200,15 @@ subroutine benchmark_init_topog_local(D, G, param_file, max_depth)
   real :: x, y
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "benchmark_initialize_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "benchmark_initialize_topography" ! This subroutine's name.
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   call MOM_mesg("  benchmark_initialization.F90, benchmark_initialize_topography: setting topography", 5)
 
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
 
   PI = 4.0*atan(1.0)

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -142,7 +142,7 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
 
   ! Local variables
   real, dimension(:), allocatable :: dz
-  character(len=40)               :: mod = "MOM_ALE" ! This module's name.
+  character(len=40)               :: mdl = "MOM_ALE" ! This module's name.
   character(len=80)               :: string ! Temporary strings
   real                            :: filter_shallow_depth, filter_deep_depth
   logical                         :: check_reconstruction
@@ -163,7 +163,7 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
   ! --- BOUNDARY EXTRAPOLATION --
   ! This sets whether high-order (rather than PCM) reconstruction schemes
   ! should be used within boundary cells
-  call get_param(param_file, mod, "BOUNDARY_EXTRAPOLATION_PRESSURE", &
+  call get_param(param_file, mdl, "BOUNDARY_EXTRAPOLATION_PRESSURE", &
                  CS%boundary_extrapolation_for_pressure, &
                  "When defined, the reconstruction is extrapolated\n"//&
                  "within boundary cells rather than assume PCM for the.\n"//&
@@ -172,7 +172,7 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
                  "boundary cells.", default=.true.)
 
   ! --- PRESSURE GRADIENT CALCULATION ---
-  call get_param(param_file, mod, "RECONSTRUCT_FOR_PRESSURE", &
+  call get_param(param_file, mdl, "RECONSTRUCT_FOR_PRESSURE", &
                  CS%reconstructForPressure , &
                  "If True, use vertical reconstruction of T/S within\n"//&
                  "the integrals of teh FV pressure gradient calculation.\n"//&
@@ -180,14 +180,14 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
                  "By default, this is True when using ALE and False otherwise.", &
                  default=.true. )
 
-  call get_param(param_file, mod, "PRESSURE_RECONSTRUCTION_SCHEME", &
+  call get_param(param_file, mdl, "PRESSURE_RECONSTRUCTION_SCHEME", &
                  CS%pressureReconstructionScheme, &
                  "Type of vertical reconstruction of T/S to use in integrals\n"//&
                  "within the FV pressure gradient calculation."//&
                  " 1: PLM reconstruction.\n"//&
                  " 2: PPM reconstruction.", default=PRESSURE_RECONSTRUCTION_PLM)
 
-  call get_param(param_file, mod, "REMAP_UV_USING_OLD_ALG", &
+  call get_param(param_file, mdl, "REMAP_UV_USING_OLD_ALG", &
                  CS%remap_uv_using_old_alg, &
                  "If true, uses the old remapping-via-a-delta-z method for\n"//&
                  "remapping u and v. If false, uses the new method that remaps\n"//&
@@ -195,23 +195,23 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
                  default=.true.)
 
   ! Initialize and configure regridding
-  call ALE_initRegridding( GV, max_depth, param_file, mod, CS%regridCS)
+  call ALE_initRegridding( GV, max_depth, param_file, mdl, CS%regridCS)
 
   ! Initialize and configure remapping
-  call get_param(param_file, mod, "REMAPPING_SCHEME", string, &
+  call get_param(param_file, mdl, "REMAPPING_SCHEME", string, &
                  "This sets the reconstruction scheme used\n"//&
                  "for vertical remapping for all variables.\n"//&
                  "It can be one of the following schemes:\n"//&
                  trim(remappingSchemesDoc), default=remappingDefaultScheme)
-  call get_param(param_file, mod, "FATAL_CHECK_RECONSTRUCTIONS", check_reconstruction, &
+  call get_param(param_file, mdl, "FATAL_CHECK_RECONSTRUCTIONS", check_reconstruction, &
                  "If true, cell-by-cell reconstructions are checked for\n"//&
                  "consistency and if non-monotonicty or an inconsistency is\n"//&
                  "detected then a FATAL error is issued.", default=.false.)
-  call get_param(param_file, mod, "FATAL_CHECK_REMAPPING", check_remapping, &
+  call get_param(param_file, mdl, "FATAL_CHECK_REMAPPING", check_remapping, &
                  "If true, the results of remapping are checked for\n"//&
                  "conservation and new extrema and if an inconsistency is\n"//&
                  "detected then a FATAL error is issued.", default=.false.)
-  call get_param(param_file, mod, "REMAP_BOUND_INTERMEDIATE_VALUES", force_bounds_in_subcell, &
+  call get_param(param_file, mdl, "REMAP_BOUND_INTERMEDIATE_VALUES", force_bounds_in_subcell, &
                  "If true, the values on the intermediate grid used for remapping\n"//&
                  "are forced to be bounded, which might not be the case due to\n"//&
                  "round off.", default=.false.)
@@ -221,29 +221,29 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
                              check_remapping=check_remapping, &
                              force_bounds_in_subcell=force_bounds_in_subcell)
 
-  call get_param(param_file, mod, "REMAP_AFTER_INITIALIZATION", CS%remap_after_initialization, &
+  call get_param(param_file, mdl, "REMAP_AFTER_INITIALIZATION", CS%remap_after_initialization, &
                  "If true, applies regridding and remapping immediately after\n"//&
                  "initialization so that the state is ALE consistent. This is a\n"//&
                  "legacy step and should not be needed if the initialization is\n"//&
                  "consistent with the coordinate mode.", default=.true.)
 
-  call get_param(param_file, mod, "REGRID_TIME_SCALE", CS%regrid_time_scale, &
+  call get_param(param_file, mdl, "REGRID_TIME_SCALE", CS%regrid_time_scale, &
                  "The time-scale used in blending between the current (old) grid\n"//&
                  "and the target (new) grid. A short time-scale favors the target\n"//&
                  "grid (0. or anything less than DT_THERM) has no memory of the old\n"//&
                  "grid. A very long time-scale makes the model more Lagrangian.", &
                  units="s", default=0.)
-  call get_param(param_file, mod, "REGRID_FILTER_SHALLOW_DEPTH", filter_shallow_depth, &
+  call get_param(param_file, mdl, "REGRID_FILTER_SHALLOW_DEPTH", filter_shallow_depth, &
                  "The depth above which no time-filtering is applied. Above this depth\n"//&
                  "final grid exactly matches the target (new) grid.", units="m", default=0.)
-  call get_param(param_file, mod, "REGRID_FILTER_DEEP_DEPTH", filter_deep_depth, &
+  call get_param(param_file, mdl, "REGRID_FILTER_DEEP_DEPTH", filter_deep_depth, &
                  "The depth below which full time-filtering is applied with time-scale\n"//&
                  "REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and\n"//&
                  "REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.", &
                  units="m", default=0.)
   call set_regrid_params(CS%regridCS, depth_of_time_filter_shallow=filter_shallow_depth*GV%m_to_H, &
                                       depth_of_time_filter_deep=filter_deep_depth*GV%m_to_H)
-  call get_param(param_file, mod, "REGRID_USE_OLD_DIRECTION", local_logical, &
+  call get_param(param_file, mdl, "REGRID_USE_OLD_DIRECTION", local_logical, &
                  "If true, the regridding ntegrates upwards from the bottom for\n"//&
                  "interface positions, much as the main model does. If false\n"//&
                  "regridding integrates downward, consistant with the remapping\n"//&
@@ -1184,22 +1184,22 @@ integer function pressureReconstructionScheme(CS)
 end function pressureReconstructionScheme
 
 !> Initializes regridding for the main ALE algorithm
-subroutine ALE_initRegridding(GV, max_depth, param_file, mod, regridCS)
+subroutine ALE_initRegridding(GV, max_depth, param_file, mdl, regridCS)
   type(verticalGrid_type), intent(in)  :: GV         !< Ocean vertical grid structure
   real,                    intent(in)  :: max_depth  !< The maximum depth of the ocean, in m.
   type(param_file_type),   intent(in)  :: param_file !< parameter file
-  character(len=*),        intent(in)  :: mod        !< Name of calling module
+  character(len=*),        intent(in)  :: mdl        !< Name of calling module
   type(regridding_CS),     intent(out) :: regridCS   !< Regridding parameters and work arrays
   ! Local variables
   character(len=30) :: coord_mode
 
-  call get_param(param_file, mod, "REGRIDDING_COORDINATE_MODE", coord_mode, &
+  call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", coord_mode, &
                  "Coordinate mode for vertical regridding.\n"//&
                  "Choose among the following possibilities:\n"//&
                  trim(regriddingCoordinateModeDoc), &
                  default=DEFAULT_COORDINATE_MODE, fail_if_missing=.true.)
 
-  call initialize_regridding(regridCS, GV, max_depth, param_file, mod, coord_mode, '', '')
+  call initialize_regridding(regridCS, GV, max_depth, param_file, mdl, coord_mode, '', '')
 
 end subroutine ALE_initRegridding
 

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -54,7 +54,7 @@ integer, parameter  :: INTEGRATION_PLM = 1  !< Piecewise Linear Method
 integer, parameter  :: INTEGRATION_PPM = 3  !< Piecewise Parabolic Method
 integer, parameter  :: INTEGRATION_PQM = 5  !< Piecewise Quartic Method
 
-character(len=40)  :: mod = "MOM_remapping" !< This module's name.
+character(len=40)  :: mdl = "MOM_remapping" !< This module's name.
 
 !> Documentation for external callers
 character(len=256), public :: remappingSchemesDoc = &

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -881,7 +881,7 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
   ! Local variables
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_CoriolisAdv" ! This module's name.
+  character(len=40)  :: mdl = "MOM_CoriolisAdv" ! This module's name.
   character(len=20)  :: tmpstr
   character(len=400) :: mesg
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
@@ -898,8 +898,8 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
   CS%diag => diag ; CS%Time => Time
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "NOSLIP", CS%no_slip, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "NOSLIP", CS%no_slip, &
                  "If true, no slip boundary conditions are used; otherwise \n"//&
                  "free slip boundary conditions are assumed. The \n"//&
                  "implementation of the free slip BCs on a C-grid is much \n"//&
@@ -907,7 +907,7 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
                  "is strongly encouraged, and no slip BCs are not used with \n"//&
                  "the biharmonic viscosity.", default=.false.)
 
-  call get_param(param_file, mod, "CORIOLIS_EN_DIS", CS%Coriolis_En_Dis, &
+  call get_param(param_file, mdl, "CORIOLIS_EN_DIS", CS%Coriolis_En_Dis, &
                  "If true, two estimates of the thickness fluxes are used \n"//&
                  "to estimate the Coriolis term, and the one that \n"//&
                  "dissipates energy relative to the other one is used.", &
@@ -915,7 +915,7 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
 
   ! Set %Coriolis_Scheme
   ! (Select the baseline discretization for the Coriolis term)
-  call get_param(param_file, mod, "CORIOLIS_SCHEME", tmpstr, &
+  call get_param(param_file, mdl, "CORIOLIS_SCHEME", tmpstr, &
                  "CORIOLIS_SCHEME selects the discretization for the \n"//&
                  "Coriolis terms. Valid values are: \n"//&
                  "\t SADOURNY75_ENERGY - Sadourny, 1975; energy cons. \n"//&
@@ -946,13 +946,13 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
             "#define CORIOLIS_SCHEME "//trim(tmpstr)//" found in input file.")
   end select
   if (CS%Coriolis_Scheme == AL_BLEND) then
-    call get_param(param_file, mod, "CORIOLIS_BLEND_WT_LIN", CS%wt_lin_blend, &
+    call get_param(param_file, mdl, "CORIOLIS_BLEND_WT_LIN", CS%wt_lin_blend, &
                  "A weighting value for the ratio of inverse thicknesses, \n"//&
                  "beyond which the blending between Sadourny Energy and \n"//&
                  "Arakawa & Hsu goes linearly to 0 when CORIOLIS_SCHEME \n"//&
                  "is ARAWAKA_LAMB_BLEND. This must be between 1 and 1e-16.", &
                  units="nondim", default=0.125)
-    call get_param(param_file, mod, "CORIOLIS_BLEND_F_EFF_MAX", CS%F_eff_max_blend, &
+    call get_param(param_file, mdl, "CORIOLIS_BLEND_F_EFF_MAX", CS%F_eff_max_blend, &
                  "The factor by which the maximum effective Coriolis \n"//&
                  "acceleration from any point can be increased when \n"//&
                  "blending different discretizations with the \n"//&
@@ -976,13 +976,13 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
                  "have no effect on the SADOURNY Coriolis scheme if it \n"//&
                  "were possible to use centered difference thickness fluxes."
   endif
-  call get_param(param_file, mod, "BOUND_CORIOLIS", CS%bound_Coriolis, mesg, &
+  call get_param(param_file, mdl, "BOUND_CORIOLIS", CS%bound_Coriolis, mesg, &
                  default=.false.)
   if ((CS%Coriolis_En_Dis .and. (CS%Coriolis_Scheme == SADOURNY75_ENERGY)) .or. &
       (CS%Coriolis_Scheme == ROBUST_ENSTRO)) CS%bound_Coriolis = .false.
 
   ! Set KE_Scheme (selects discretization of KE)
-  call get_param(param_file, mod, "KE_SCHEME", tmpstr, &
+  call get_param(param_file, mdl, "KE_SCHEME", tmpstr, &
                  "KE_SCHEME selects the discretization for acceleration \n"//&
                  "due to the kinetic energy gradient. Valid values are: \n"//&
                  "\t KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV", &
@@ -999,7 +999,7 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
   end select
 
   ! Set PV_Adv_Scheme (selects discretization of PV advection)
-  call get_param(param_file, mod, "PV_ADV_SCHEME", tmpstr, &
+  call get_param(param_file, mdl, "PV_ADV_SCHEME", tmpstr, &
                  "PV_ADV_SCHEME selects the discretization for PV \n"//&
                  "advection. Valid values are: \n"//&
                  "\t PV_ADV_CENTERED - centered (aka Sadourny, 75) \n"//&

--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -78,7 +78,7 @@ subroutine PressureForce_init(Time, G, GV, param_file, diag, CS, tides_CSp)
   type(PressureForce_CS),  pointer       :: CS   !< Pressure force control structure
   type(tidal_forcing_CS), optional, pointer :: tides_CSp !< Tide control structure
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_PressureForce" ! This module's name.
+  character(len=40)  :: mdl = "MOM_PressureForce" ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "PressureForce_init called with an associated "// &
@@ -87,8 +87,8 @@ subroutine PressureForce_init(Time, G, GV, param_file, diag, CS, tides_CSp)
   else ; allocate(CS) ; endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "ANALYTIC_FV_PGF", CS%Analytic_FV_PGF, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "ANALYTIC_FV_PGF", CS%Analytic_FV_PGF, &
                  "If true the pressure gradient forces are calculated \n"//&
                  "with a finite volume form that analytically integrates \n"//&
                  "the equations of state in pressure to avoid any \n"//&

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -847,7 +847,7 @@ subroutine PressureForce_Mont_init(Time, G, GV, param_file, diag, CS, tides_CSp)
   logical :: use_temperature, use_EOS
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod   ! This module's name.
+  character(len=40)  :: mdl   ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "PressureForce_init called with an associated "// &
@@ -860,17 +860,17 @@ subroutine PressureForce_Mont_init(Time, G, GV, param_file, diag, CS, tides_CSp)
     if (associated(tides_CSp)) CS%tides_CSp => tides_CSp
   endif
 
-  mod = "MOM_PressureForce_Mont"
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  mdl = "MOM_PressureForce_Mont"
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "TIDES", CS%tides, &
+  call get_param(param_file, mdl, "TIDES", CS%tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
-  call get_param(param_file, mod, "USE_EOS", use_EOS, default=.true., &
+  call get_param(param_file, mdl, "USE_EOS", use_EOS, default=.true., &
                  do_not_log=.true.) ! Input for diagnostic use only.
 
   if (use_EOS) then
@@ -896,7 +896,7 @@ subroutine PressureForce_Mont_init(Time, G, GV, param_file, diag, CS, tides_CSp)
   CS%GFS_scale = 1.0
   if (GV%g_prime(1) /= GV%g_Earth) CS%GFS_scale = GV%g_prime(1) / GV%g_Earth
 
-  call log_param(param_file, mod, "GFS / G_EARTH", CS%GFS_scale)
+  call log_param(param_file, mdl, "GFS / G_EARTH", CS%GFS_scale)
 
 end subroutine PressureForce_Mont_init
 

--- a/src/core/MOM_PressureForce_analytic_FV.F90
+++ b/src/core/MOM_PressureForce_analytic_FV.F90
@@ -777,7 +777,7 @@ subroutine PressureForce_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
   type(tidal_forcing_CS), optional, pointer :: tides_CSp !< Tides control structure
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod  ! This module's name.
+  character(len=40)  :: mdl  ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "PressureForce_init called with an associated "// &
@@ -790,17 +790,17 @@ subroutine PressureForce_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
     if (associated(tides_CSp)) CS%tides_CSp => tides_CSp
   endif
 
-  mod = "MOM_PressureForce_AFV"
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  mdl = "MOM_PressureForce_AFV"
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "TIDES", CS%tides, &
+  call get_param(param_file, mdl, "TIDES", CS%tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
-  call get_param(param_file, mod, "MASS_WEIGHT_IN_PRESSURE_GRADIENT", CS%useMassWghtInterp, &
+  call get_param(param_file, mdl, "MASS_WEIGHT_IN_PRESSURE_GRADIENT", CS%useMassWghtInterp, &
                  "If true, use mass weighting when interpolation T/S for\n"//&
                  "top/bottom integrals in AFV pressure gradient calculation.", default=.false.)
 
@@ -812,7 +812,7 @@ subroutine PressureForce_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
   CS%GFS_scale = 1.0
   if (GV%g_prime(1) /= GV%g_Earth) CS%GFS_scale = GV%g_prime(1) / GV%g_Earth
 
-  call log_param(param_file, mod, "GFS / G_EARTH", CS%GFS_scale)
+  call log_param(param_file, mdl, "GFS / G_EARTH", CS%GFS_scale)
 
 end subroutine PressureForce_AFV_init
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3897,7 +3897,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   ! Local variables
-  character(len=40)  :: mod = "MOM_barotropic"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_barotropic"  ! This module's name.
   real :: Datu(SZIBS_(G),SZJ_(G)), Datv(SZI_(G),SZJBS_(G))
   real :: gtot_estimate ! Summing GV%g_prime gives an upper-bound estimate for pbce.
   real :: SSH_extra     ! An estimate of how much higher SSH might get, for use
@@ -3933,41 +3933,41 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "SPLIT", CS%split, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "SPLIT", CS%split, &
                  "Use the split time stepping if true.", default=.true.)
   if (.not.CS%split) return
 
-  call get_param(param_file, mod, "BOUND_BT_CORRECTION", CS%bound_BT_corr, &
+  call get_param(param_file, mdl, "BOUND_BT_CORRECTION", CS%bound_BT_corr, &
                  "If true, the corrective pseudo mass-fluxes into the \n"//&
                  "barotropic solver are limited to values that require \n"//&
                  "less than maxCFL_BT_cont to be accommodated.",default=.false.)
-  call get_param(param_file, mod, "BT_CONT_CORR_BOUNDS", CS%BT_cont_bounds, &
+  call get_param(param_file, mdl, "BT_CONT_CORR_BOUNDS", CS%BT_cont_bounds, &
                  "If true, and BOUND_BT_CORRECTION is true, use the \n"//&
                  "BT_cont_type variables to set limits determined by \n"//&
                  "MAXCFL_BT_CONT on the CFL number of the velocites \n"//&
                  "that are likely to be driven by the corrective mass fluxes.", &
                  default=.true.) !, do_not_log=.not.CS%bound_BT_corr)
-  call get_param(param_file, mod, "ADJUST_BT_CONT", CS%adjust_BT_cont, &
+  call get_param(param_file, mdl, "ADJUST_BT_CONT", CS%adjust_BT_cont, &
                  "If true, adjust the curve fit to the BT_cont type \n"//&
                  "that is used by the barotropic solver to match the \n"//&
                  "transport about which the flow is being linearized.", default=.false.)
-  call get_param(param_file, mod, "GRADUAL_BT_ICS", CS%gradual_BT_ICs, &
+  call get_param(param_file, mdl, "GRADUAL_BT_ICS", CS%gradual_BT_ICs, &
                  "If true, adjust the initial conditions for the \n"//&
                  "barotropic solver to the values from the layered \n"//&
                  "solution over a whole timestep instead of instantly. \n"//&
                  "This is a decent approximation to the inclusion of \n"//&
                  "sum(u dh_dt) while also correcting for truncation errors.", &
                  default=.false.)
-  call get_param(param_file, mod, "BT_USE_VISC_REM_U_UH0", CS%visc_rem_u_uh0, &
+  call get_param(param_file, mdl, "BT_USE_VISC_REM_U_UH0", CS%visc_rem_u_uh0, &
                  "If true, use the viscous remnants when estimating the \n"//&
                  "barotropic velocities that were used to calculate uh0 \n"//&
                  "and vh0.  False is probably the better choice.", default=.false.)
-  call get_param(param_file, mod, "BT_USE_WIDE_HALOS", CS%use_wide_halos, &
+  call get_param(param_file, mdl, "BT_USE_WIDE_HALOS", CS%use_wide_halos, &
                  "If true, use wide halos and march in during the \n"//&
                  "barotropic time stepping for efficiency.", default=.true., &
                  layoutParam=.true.)
-  call get_param(param_file, mod, "BTHALO", bt_halo_sz, &
+  call get_param(param_file, mdl, "BTHALO", bt_halo_sz, &
                  "The minimum halo size for the barotropic solver.", default=0, &
                  layoutParam=.true.)
 #ifdef STATIC_MEMORY_
@@ -3978,38 +3978,38 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
 #else
   wd_halos(1) = bt_halo_sz; wd_halos(2) =  bt_halo_sz
 #endif
-  call log_param(param_file, mod, "!BT x-halo", wd_halos(1), &
+  call log_param(param_file, mdl, "!BT x-halo", wd_halos(1), &
                  "The barotropic x-halo size that is actually used.", &
                  layoutParam=.true.)
-  call log_param(param_file, mod, "!BT y-halo", wd_halos(2), &
+  call log_param(param_file, mdl, "!BT y-halo", wd_halos(2), &
                  "The barotropic y-halo size that is actually used.", &
                  layoutParam=.true.)
 
-  call get_param(param_file, mod, "USE_BT_CONT_TYPE", use_BT_cont_type, &
+  call get_param(param_file, mdl, "USE_BT_CONT_TYPE", use_BT_cont_type, &
                "If true, use a structure with elements that describe \n"//&
                "effective face areas from the summed continuity solver \n"//&
                "as a function the barotropic flow in coupling between \n"//&
                "the barotropic and baroclinic flow.  This is only used \n"//&
                "if SPLIT is true. \n", default=.true.)
-  call get_param(param_file, mod, "NONLINEAR_BT_CONTINUITY", &
+  call get_param(param_file, mdl, "NONLINEAR_BT_CONTINUITY", &
                                 CS%Nonlinear_continuity, &
                  "If true, use nonlinear transports in the barotropic \n"//&
                  "continuity equation.  This does not apply if \n"//&
                  "USE_BT_CONT_TYPE is true.", default=.false.)
   CS%Nonlin_cont_update_period = 1
   if (CS%Nonlinear_continuity) &
-    call get_param(param_file, mod, "NONLIN_BT_CONT_UPDATE_PERIOD", &
+    call get_param(param_file, mdl, "NONLIN_BT_CONT_UPDATE_PERIOD", &
                                   CS%Nonlin_cont_update_period, &
                  "If NONLINEAR_BT_CONTINUITY is true, this is the number \n"//&
                  "of barotropic time steps between updates to the face \n"//&
                  "areas, or 0 to update only before the barotropic stepping.",&
                  units="nondim", default=1)
-  call get_param(param_file, mod, "BT_MASS_SOURCE_LIMIT", CS%eta_source_limit, &
+  call get_param(param_file, mdl, "BT_MASS_SOURCE_LIMIT", CS%eta_source_limit, &
                  "The fraction of the initial depth of the ocean that can \n"//&
                  "be added to or removed from the bartropic solution \n"//&
                  "within a thermodynamic time step.  By default this is 0 \n"//&
                  "for no correction.", units="nondim", default=0.0)
-  call get_param(param_file, mod, "BT_PROJECT_VELOCITY", CS%BT_project_velocity,&
+  call get_param(param_file, mdl, "BT_PROJECT_VELOCITY", CS%BT_project_velocity,&
                  "If true, step the barotropic velocity first and project \n"//&
                  "out the velocity tendancy by 1+BEBT when calculating the \n"//&
                  "transport.  The default (false) is to use a predictor \n"//&
@@ -4018,36 +4018,36 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
                  "average of the old and new velocities, with weights \n"//&
                  "of (1-BEBT) and BEBT.", default=.false.)
 
-  call get_param(param_file, mod, "DYNAMIC_SURFACE_PRESSURE", CS%dynamic_psurf, &
+  call get_param(param_file, mdl, "DYNAMIC_SURFACE_PRESSURE", CS%dynamic_psurf, &
                  "If true, add a dynamic pressure due to a viscous ice \n"//&
                  "shelf, for instance.", default=.false.)
   if (CS%dynamic_psurf) then
-    call get_param(param_file, mod, "ICE_LENGTH_DYN_PSURF", CS%ice_strength_length, &
+    call get_param(param_file, mdl, "ICE_LENGTH_DYN_PSURF", CS%ice_strength_length, &
                  "The length scale at which the Rayleigh damping rate due \n"//&
                  "to the ice strength should be the same as if a Laplacian \n"//&
                  "were applied, if DYNAMIC_SURFACE_PRESSURE is true.", &
                  units="m", default=1.0e4)
-    call get_param(param_file, mod, "DEPTH_MIN_DYN_PSURF", CS%Dmin_dyn_psurf, &
+    call get_param(param_file, mdl, "DEPTH_MIN_DYN_PSURF", CS%Dmin_dyn_psurf, &
                   "The minimum depth to use in limiting the size of the \n"//&
                   "dynamic surface pressure for stability, if \n"//&
                   "DYNAMIC_SURFACE_PRESSURE is true..", units="m", &
                   default=1.0e-6)
-    call get_param(param_file, mod, "CONST_DYN_PSURF", CS%const_dyn_psurf, &
+    call get_param(param_file, mdl, "CONST_DYN_PSURF", CS%const_dyn_psurf, &
                  "The constant that scales the dynamic surface pressure, \n"//&
                  "if DYNAMIC_SURFACE_PRESSURE is true.  Stable values \n"//&
                  "are < ~1.0.", units="nondim", default=0.9)
   endif
 
-  call get_param(param_file, mod, "TIDES", CS%tides, &
+  call get_param(param_file, mdl, "TIDES", CS%tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
-  call get_param(param_file, mod, "SADOURNY", CS%Sadourny, &
+  call get_param(param_file, mdl, "SADOURNY", CS%Sadourny, &
                  "If true, the Coriolis terms are discretized with the \n"//&
                  "Sadourny (1975) energy conserving scheme, otherwise \n"//&
                  "the Arakawa & Hsu scheme is used.  If the internal \n"//&
                  "deformation radius is not resolved, the Sadourny scheme \n"//&
                  "should probably be used.", default=.true.)
 
-  call get_param(param_file, mod, "BT_THICK_SCHEME", hvel_str, &
+  call get_param(param_file, mdl, "BT_THICK_SCHEME", hvel_str, &
                  "A string describing the scheme that is used to set the \n"//&
                  "open face areas used for barotropic transport and the \n"//&
                  "relative weights of the accelerations. Valid values are:\n"//&
@@ -4074,55 +4074,55 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
     call MOM_error(FATAL, "barotropic_init: BT_THICK_SCHEME FROM_BT_CONT "//&
                            "can only be used if USE_BT_CONT_TYPE is defined.")
 
-  call get_param(param_file, mod, "BT_STRONG_DRAG", CS%strong_drag, &
+  call get_param(param_file, mdl, "BT_STRONG_DRAG", CS%strong_drag, &
                  "If true, use a stronger estimate of the retarding \n"//&
                  "effects of strong bottom drag, by making it implicit \n"//&
                  "with the barotropic time-step instead of implicit with \n"//&
                  "the baroclinic time-step and dividing by the number of \n"//&
                  "barotropic steps.", default=.false.)
 
-  call get_param(param_file, mod, "CLIP_BT_VELOCITY", CS%clip_velocity, &
+  call get_param(param_file, mdl, "CLIP_BT_VELOCITY", CS%clip_velocity, &
                  "If true, limit any velocity components that exceed \n"//&
                  "CFL_TRUNCATE.  This should only be used as a desperate \n"//&
                  "debugging measure.", default=.false.)
-  call get_param(param_file, mod, "CFL_TRUNCATE", CS%CFL_trunc, &
+  call get_param(param_file, mdl, "CFL_TRUNCATE", CS%CFL_trunc, &
                  "The value of the CFL number that will cause velocity \n"//&
                  "components to be truncated; instability can occur past 0.5.", &
                  units="nondim", default=0.5, do_not_log=.not.CS%clip_velocity)
-  call get_param(param_file, mod, "MAXVEL", CS%maxvel, &
+  call get_param(param_file, mdl, "MAXVEL", CS%maxvel, &
                  "The maximum velocity allowed before the velocity \n"//&
                  "components are truncated.", units="m s-1", default=3.0e8, &
                  do_not_log=.not.CS%clip_velocity)
-  call get_param(param_file, mod, "MAXCFL_BT_CONT", CS%maxCFL_BT_cont, &
+  call get_param(param_file, mdl, "MAXCFL_BT_CONT", CS%maxCFL_BT_cont, &
                  "The maximum permitted CFL number associated with the \n"//&
                  "barotropic accelerations from the summed velocities \n"//&
                  "times the time-derivatives of thicknesses.", units="nondim", &
                  default=0.25)
 
-  call get_param(param_file, mod, "DT_BT_FILTER", CS%dt_bt_filter, &
+  call get_param(param_file, mdl, "DT_BT_FILTER", CS%dt_bt_filter, &
                  "A time-scale over which the barotropic mode solutions \n"//&
                  "are filtered, in seconds if positive, or as a fraction \n"//&
                  "of DT if negative. When used this can never be taken to \n"//&
                  "be longer than 2*dt.  Set this to 0 to apply no filtering.", &
                  units="sec or nondim", default=-0.25)
-  call get_param(param_file, mod, "G_BT_EXTRA", CS%G_extra, &
+  call get_param(param_file, mdl, "G_BT_EXTRA", CS%G_extra, &
                  "A nondimensional factor by which gtot is enhanced.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "SSH_EXTRA", SSH_extra, &
+  call get_param(param_file, mdl, "SSH_EXTRA", SSH_extra, &
                  "An estimate of how much higher SSH might get, for use \n"//&
                  "in calculating the safe external wave speed. The \n"//&
                  "default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.", &
                  units="m", default=min(10.0,0.05*G%max_depth))
 
-  call get_param(param_file, mod, "DEBUG", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_BT", CS%debug_bt, &
+  call get_param(param_file, mdl, "DEBUG_BT", CS%debug_bt, &
                  "If true, write out verbose debugging data within the \n"//&
                  "barotropic time-stepping loop. The data volume can be \n"//&
                  "quite large if this is true.", default=CS%debug)
 
   CS%linearized_BT_PV = .true.
-  call get_param(param_file, mod, "BEBT", CS%bebt, &
+  call get_param(param_file, mdl, "BEBT", CS%bebt, &
                  "BEBT determines whether the barotropic time stepping \n"//&
                  "uses the forward-backward time-stepping scheme or a \n"//&
                  "backward Euler scheme. BEBT is valid in the range from \n"//&
@@ -4130,7 +4130,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
                  "gravity waves) to 1 (for a backward Euler treatment). \n"//&
                  "In practice, BEBT must be greater than about 0.05.", &
                  units="nondim", default=0.1)
-  call get_param(param_file, mod, "DTBT", CS%dtbt, &
+  call get_param(param_file, mdl, "DTBT", CS%dtbt, &
                  "The barotropic time step, in s. DTBT is only used with \n"//&
                  "the split explicit time stepping. To set the time step \n"//&
                  "automatically based the maximum stable value use 0, or \n"//&
@@ -4265,8 +4265,8 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
   call set_dtbt(G, GV, CS, gtot_est = gtot_estimate, SSH_add = SSH_extra)
   if (dtbt_input > 0.0) CS%dtbt = dtbt_input
 
-  call log_param(param_file, mod, "DTBT as used", CS%dtbt)
-  call log_param(param_file, mod, "estimated maximum DTBT", CS%dtbt_max)
+  call log_param(param_file, mdl, "DTBT as used", CS%dtbt)
+  call log_param(param_file, mdl, "estimated maximum DTBT", CS%dtbt_max)
 
   ! ubtav, vbtav, ubt_IC, vbt_IC, uhbt_IC, and vhbt_IC are allocated and
   ! initialized in register_barotropic_restarts.

--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -43,7 +43,7 @@ end type update_OBC_CS
 
 integer :: id_clock_pass
 
-character(len=40)  :: mod = "MOM_boundary_update" ! This module's name.
+character(len=40)  :: mdl = "MOM_boundary_update" ! This module's name.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
@@ -56,7 +56,7 @@ subroutine call_OBC_register(param_file, CS, OBC)
   type(param_file_type),     intent(in) :: param_file !< Parameter file to parse
   type(update_OBC_CS),       pointer    :: CS         !< Control structure for OBCs
   type(ocean_OBC_type),      pointer    :: OBC        !< Open boundary structure
-  character(len=40)  :: mod = "MOM_boundary_update" ! This module's name.
+  character(len=40)  :: mdl = "MOM_boundary_update" ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "call_OBC_register called with an associated "// &
@@ -64,18 +64,18 @@ subroutine call_OBC_register(param_file, CS, OBC)
     return
   else ; allocate(CS) ; endif
 
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mod, "USE_FILE_OBC", CS%use_files, &
+  call get_param(param_file, mdl, "USE_FILE_OBC", CS%use_files, &
                  "If true, use external files for the open boundary.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_TIDAL_BAY_OBC", CS%use_tidal_bay, &
+  call get_param(param_file, mdl, "USE_TIDAL_BAY_OBC", CS%use_tidal_bay, &
                  "If true, use the tidal_bay open boundary.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_KELVIN_WAVE_OBC", CS%use_Kelvin, &
+  call get_param(param_file, mdl, "USE_KELVIN_WAVE_OBC", CS%use_Kelvin, &
                  "If true, use the Kelvin wave open boundary.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_SHELFWAVE_OBC", CS%use_shelfwave, &
+  call get_param(param_file, mdl, "USE_SHELFWAVE_OBC", CS%use_shelfwave, &
                  "If true, use the shelfwave open boundary.", &
                  default=.false.)
 
@@ -110,7 +110,7 @@ subroutine update_OBC_data(OBC, G, GV, tv, h, CS, Time)
   integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: isd_off, jsd_off
   integer :: IsdB, IedB, JsdB, JedB
-  character(len=40)  :: mod = "update_OBC_data" ! This subroutine's name.
+  character(len=40)  :: mdl = "update_OBC_data" ! This subroutine's name.
   character(len=200) :: filename, OBC_file, inputdir ! Strings for file/path
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke

--- a/src/core/MOM_continuity.F90
+++ b/src/core/MOM_continuity.F90
@@ -118,7 +118,7 @@ subroutine continuity_init(Time, G, GV, param_file, diag, CS)
   type(continuity_CS),     pointer       :: CS         !< Control structure for mom_continuity.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_continuity" ! This module's name.
+  character(len=40)  :: mdl = "MOM_continuity" ! This module's name.
   character(len=20)  :: tmpstr
 
   if (associated(CS)) then
@@ -128,8 +128,8 @@ subroutine continuity_init(Time, G, GV, param_file, diag, CS)
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "CONTINUITY_SCHEME", tmpstr, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "CONTINUITY_SCHEME", tmpstr, &
                  "CONTINUITY_SCHEME selects the discretization for the \n"//&
                  "continuity solver. The only valid value currently is: \n"//&
                  "\t PPM - use a positive-definite (or monotonic) \n"//&

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2112,7 +2112,7 @@ subroutine continuity_PPM_init(Time, G, GV, param_file, diag, CS)
   type(continuity_PPM_CS), pointer       :: CS   !< Module's control structure.
 !> This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_continuity_PPM" ! This module's name.
+  character(len=40)  :: mdl = "MOM_continuity_PPM" ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "continuity_PPM_init called with associated control structure.")
@@ -2121,12 +2121,12 @@ subroutine continuity_PPM_init(Time, G, GV, param_file, diag, CS)
   allocate(CS)
 
 ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "MONOTONIC_CONTINUITY", CS%monotonic, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "MONOTONIC_CONTINUITY", CS%monotonic, &
                  "If true, CONTINUITY_PPM uses the Colella and Woodward \n"//&
                  "monotonic limiter.  The default (false) is to use a \n"//&
                  "simple positive definite limiter.", default=.false.)
-  call get_param(param_file, mod, "SIMPLE_2ND_PPM_CONTINUITY", CS%simple_2nd, &
+  call get_param(param_file, mdl, "SIMPLE_2ND_PPM_CONTINUITY", CS%simple_2nd, &
                  "If true, CONTINUITY_PPM uses a simple 2nd order \n"//&
                  "(arithmetic mean) interpolation of the edge values. \n"//&
                  "This may give better PV conservation propterties. While \n"//&
@@ -2134,12 +2134,12 @@ subroutine continuity_PPM_init(Time, G, GV, param_file, diag, CS)
                  "solver itself in the strongly advective limit, it does \n"//&
                  "not reduce the overall order of accuracy of the dynamic \n"//&
                  "core.", default=.false.)
-  call get_param(param_file, mod, "UPWIND_1ST_CONTINUITY", CS%upwind_1st, &
+  call get_param(param_file, mdl, "UPWIND_1ST_CONTINUITY", CS%upwind_1st, &
                  "If true, CONTINUITY_PPM becomes a 1st-order upwind \n"//&
                  "continuity solver.  This scheme is highly diffusive \n"//&
                  "but may be useful for debugging or in single-column \n"//&
                  "mode where its minimal stencil is useful.", default=.false.)
-  call get_param(param_file, mod, "ETA_TOLERANCE", CS%tol_eta, &
+  call get_param(param_file, mdl, "ETA_TOLERANCE", CS%tol_eta, &
                  "The tolerance for the differences between the \n"//&
                  "barotropic and baroclinic estimates of the sea surface \n"//&
                  "height due to the fluxes through each face.  The total \n"//&
@@ -2148,39 +2148,39 @@ subroutine continuity_PPM_init(Time, G, GV, param_file, diag, CS)
                  "than about 10^-15*MAXIMUM_DEPTH.", units="m", &
                  default=0.5*G%ke*GV%Angstrom_z)
 
-  call get_param(param_file, mod, "ETA_TOLERANCE_AUX", CS%tol_eta_aux, &
+  call get_param(param_file, mdl, "ETA_TOLERANCE_AUX", CS%tol_eta_aux, &
                  "The tolerance for free-surface height discrepancies \n"//&
                  "between the barotropic solution and the sum of the \n"//&
                  "layer thicknesses when calculating the auxiliary \n"//&
                  "corrected velocities. By default, this is the same as \n"//&
                  "ETA_TOLERANCE, but can be made larger for efficiency.", &
                  units="m", default=CS%tol_eta)
-  call get_param(param_file, mod, "VELOCITY_TOLERANCE", CS%tol_vel, &
+  call get_param(param_file, mdl, "VELOCITY_TOLERANCE", CS%tol_vel, &
                  "The tolerance for barotropic velocity discrepancies \n"//&
                  "between the barotropic solution and  the sum of the \n"//&
                  "layer thicknesses.", units="m s-1", default=3.0e8) ! The speed of light is the default.
 
-  call get_param(param_file, mod, "CONT_PPM_AGGRESS_ADJUST", CS%aggress_adjust,&
+  call get_param(param_file, mdl, "CONT_PPM_AGGRESS_ADJUST", CS%aggress_adjust,&
                  "If true, allow the adjusted velocities to have a \n"//&
                  "relative CFL change up to 0.5.", default=.false.)
   CS%vol_CFL = CS%aggress_adjust
-  call get_param(param_file, mod, "CONT_PPM_VOLUME_BASED_CFL", CS%vol_CFL, &
+  call get_param(param_file, mdl, "CONT_PPM_VOLUME_BASED_CFL", CS%vol_CFL, &
                  "If true, use the ratio of the open face lengths to the \n"//&
                  "tracer cell areas when estimating CFL numbers.  The \n"//&
                  "default is set by CONT_PPM_AGGRESS_ADJUST.", &
                  default=CS%aggress_adjust, do_not_read=CS%aggress_adjust)
-  call get_param(param_file, mod, "CONTINUITY_CFL_LIMIT", CS%CFL_limit_adjust, &
+  call get_param(param_file, mdl, "CONTINUITY_CFL_LIMIT", CS%CFL_limit_adjust, &
                  "The maximum CFL of the adjusted velocities.", units="nondim", &
                  default=0.5)
-  call get_param(param_file, mod, "CONT_PPM_BETTER_ITER", CS%better_iter, &
+  call get_param(param_file, mdl, "CONT_PPM_BETTER_ITER", CS%better_iter, &
                  "If true, stop corrective iterations using a velocity \n"//&
                  "based criterion and only stop if the iteration is \n"//&
                  "better than all predecessors.", default=.true.)
-  call get_param(param_file, mod, "CONT_PPM_USE_VISC_REM_MAX", &
+  call get_param(param_file, mdl, "CONT_PPM_USE_VISC_REM_MAX", &
                                  CS%use_visc_rem_max, &
                  "If true, use more appropriate limiting bounds for \n"//&
                  "corrections in strongly viscous columns.", default=.true.)
-  call get_param(param_file, mod, "CONT_PPM_MARGINAL_FACE_AREAS", CS%marginal_faces, &
+  call get_param(param_file, mdl, "CONT_PPM_MARGINAL_FACE_AREAS", CS%marginal_faces, &
                  "If true, use the marginal face areas from the continuity \n"//&
                  "solver for use as the weights in the barotropic solver. \n"//&
                  "Otherwise use the transport averaged areas.", default=.true.)

--- a/src/core/MOM_dynamics_legacy_split.F90
+++ b/src/core/MOM_dynamics_legacy_split.F90
@@ -1128,7 +1128,7 @@ subroutine register_restarts_dyn_legacy_split(HI, GV, param_file, CS, restart_CS
 !  (inout)   vh - The meridional volume or mass transport, in m3 s-1 or kg s-1.
 
   type(vardesc) :: vd
-  character(len=40)  :: mod = "MOM_dynamics_legacy_split" ! This module's name.
+  character(len=40)  :: mdl = "MOM_dynamics_legacy_split" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   logical :: adiabatic, flux_BT_coupling, readjust_BT_trans
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
@@ -1312,7 +1312,7 @@ subroutine initialize_dyn_legacy_split(u, v, h, uh, vh, eta, Time, G, GV, param_
   !   This subroutine initializes any variables that are specific to this time
   ! stepping scheme, including the cpu clocks.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_tmp
-  character(len=40)  :: mod = "MOM_dynamics_legacy_split" ! This module's name.
+  character(len=40)  :: mdl = "MOM_dynamics_legacy_split" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   logical :: adiabatic, use_tides, debug_truncations
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
@@ -1332,9 +1332,9 @@ subroutine initialize_dyn_legacy_split(u, v, h, uh, vh, eta, Time, G, GV, param_
 
   CS%diag => diag
 
-  call get_param(param_file, mod, "TIDES", use_tides, &
+  call get_param(param_file, mdl, "TIDES", use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
-  call get_param(param_file, mod, "BE", CS%be, &
+  call get_param(param_file, mdl, "BE", CS%be, &
                  "If SPLIT is true, BE determines the relative weighting \n"//&
                  "of a  2nd-order Runga-Kutta baroclinic time stepping \n"//&
                  "scheme (0.5) and a backward Euler scheme (1) that is \n"//&
@@ -1342,7 +1342,7 @@ subroutine initialize_dyn_legacy_split(u, v, h, uh, vh, eta, Time, G, GV, param_
                  "from 0.5 to 1, but instability may occur near 0.5. \n"//&
                  "BE is also applicable if SPLIT is false and USE_RK2 \n"//&
                  "is true.", units="nondim", default=0.6)
-  call get_param(param_file, mod, "BEGW", CS%begw, &
+  call get_param(param_file, mdl, "BEGW", CS%begw, &
                  "If SPLIT is true, BEGW is a number from 0 to 1 that \n"//&
                  "controls the extent to which the treatment of gravity \n"//&
                  "waves is forward-backward (0) or simulated backward \n"//&
@@ -1351,29 +1351,29 @@ subroutine initialize_dyn_legacy_split(u, v, h, uh, vh, eta, Time, G, GV, param_
                  "between 0 and 0.5 to damp gravity waves.", &
                  units="nondim", default=0.0)
 
-  call get_param(param_file, mod, "FLUX_BT_COUPLING", CS%flux_BT_coupling, &
+  call get_param(param_file, mdl, "FLUX_BT_COUPLING", CS%flux_BT_coupling, &
                  "If true, use mass fluxes to ensure consistency between \n"//&
                  "the baroclinic and barotropic modes. This is only used \n"//&
                  "if SPLIT is true.", default=.false.)
-  call get_param(param_file, mod, "READJUST_BT_TRANS", CS%readjust_BT_trans, &
+  call get_param(param_file, mdl, "READJUST_BT_TRANS", CS%readjust_BT_trans, &
                  "If true, make a barotropic adjustment to the layer \n"//&
                  "velocities after the thermodynamic part of the step \n"//&
                  "to ensure that the interaction between the thermodynamics \n"//&
                  "and the continuity solver do not change the barotropic \n"//&
                  "transport.  This is only used if FLUX_BT_COUPLING and \n"//&
                  "SPLIT are true.", default=.false.)
-  call get_param(param_file, mod, "SPLIT_BOTTOM_STRESS", CS%split_bottom_stress, &
+  call get_param(param_file, mdl, "SPLIT_BOTTOM_STRESS", CS%split_bottom_stress, &
                  "If true, provide the bottom stress calculated by the \n"//&
                  "vertical viscosity to the barotropic solver.", default=.false.)
-  call get_param(param_file, mod, "BT_USE_LAYER_FLUXES", CS%BT_use_layer_fluxes, &
+  call get_param(param_file, mdl, "BT_USE_LAYER_FLUXES", CS%BT_use_layer_fluxes, &
                  "If true, use the summed layered fluxes plus an \n"//&
                  "adjustment due to the change in the barotropic velocity \n"//&
                  "in the barotropic continuity equation.", default=.true.)
-  call get_param(param_file, mod, "DEBUG", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "ADIABATIC", adiabatic, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "ADIABATIC", adiabatic, default=.false., do_not_log=.true.)
   if (.not.CS%flux_BT_coupling .or. adiabatic) CS%readjust_BT_trans = .false.
-  call get_param(param_file, mod, "DEBUG_TRUNCATIONS", debug_truncations, &
+  call get_param(param_file, mdl, "DEBUG_TRUNCATIONS", debug_truncations, &
                  default=.false.)
 
   allocate(CS%taux_bot(IsdB:IedB,jsd:jed)) ; CS%taux_bot(:,:) = 0.0

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -859,7 +859,7 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, param_file, CS, restart_CS, u
   real, dimension(SZI_(HI),SZJB_(HI),SZK_(GV)), target, intent(inout) :: vh !< merid volume/mass transport (m3/s or kg/s)
 
   type(vardesc)      :: vd
-  character(len=40)  :: mod = "MOM_dynamics_split_RK2" ! This module's name.
+  character(len=40)  :: mdl = "MOM_dynamics_split_RK2" ! This module's name.
   character(len=48)  :: thickness_units, flux_units
 
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
@@ -953,7 +953,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
                                                                           !! the velocity is truncated (this should be 0).
 
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_tmp
-  character(len=40) :: mod = "MOM_dynamics_split_RK2" ! This module's name.
+  character(len=40) :: mdl = "MOM_dynamics_split_RK2" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   type(group_pass_type) :: pass_h_tmp, pass_av_h_uvh
   logical :: use_tides, debug_truncations
@@ -975,9 +975,9 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
 
   CS%diag => diag
 
-  call get_param(param_file, mod, "TIDES", use_tides, &
+  call get_param(param_file, mdl, "TIDES", use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
-  call get_param(param_file, mod, "BE", CS%be, &
+  call get_param(param_file, mdl, "BE", CS%be, &
                  "If SPLIT is true, BE determines the relative weighting \n"//&
                  "of a  2nd-order Runga-Kutta baroclinic time stepping \n"//&
                  "scheme (0.5) and a backward Euler scheme (1) that is \n"//&
@@ -985,7 +985,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
                  "from 0.5 to 1, but instability may occur near 0.5. \n"//&
                  "BE is also applicable if SPLIT is false and USE_RK2 \n"//&
                  "is true.", units="nondim", default=0.6)
-  call get_param(param_file, mod, "BEGW", CS%begw, &
+  call get_param(param_file, mdl, "BEGW", CS%begw, &
                  "If SPLIT is true, BEGW is a number from 0 to 1 that \n"//&
                  "controls the extent to which the treatment of gravity \n"//&
                  "waves is forward-backward (0) or simulated backward \n"//&
@@ -994,16 +994,16 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
                  "between 0 and 0.5 to damp gravity waves.", &
                  units="nondim", default=0.0)
 
-  call get_param(param_file, mod, "SPLIT_BOTTOM_STRESS", CS%split_bottom_stress, &
+  call get_param(param_file, mdl, "SPLIT_BOTTOM_STRESS", CS%split_bottom_stress, &
                  "If true, provide the bottom stress calculated by the \n"//&
                  "vertical viscosity to the barotropic solver.", default=.false.)
-  call get_param(param_file, mod, "BT_USE_LAYER_FLUXES", CS%BT_use_layer_fluxes, &
+  call get_param(param_file, mdl, "BT_USE_LAYER_FLUXES", CS%BT_use_layer_fluxes, &
                  "If true, use the summed layered fluxes plus an \n"//&
                  "adjustment due to the change in the barotropic velocity \n"//&
                  "in the barotropic continuity equation.", default=.true.)
-  call get_param(param_file, mod, "DEBUG", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_TRUNCATIONS", debug_truncations, &
+  call get_param(param_file, mdl, "DEBUG_TRUNCATIONS", debug_truncations, &
                  default=.false.)
 
   allocate(CS%taux_bot(IsdB:IedB,jsd:jed)) ; CS%taux_bot(:,:) = 0.0

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -583,7 +583,7 @@ subroutine register_restarts_dyn_unsplit(HI, GV, param_file, CS, restart_CS)
 !  (inout)   restart_CS - A pointer to the restart control structure.
 
   type(vardesc) :: vd
-  character(len=40)  :: mod = "MOM_dynamics_unsplit" ! This module's name.
+  character(len=40)  :: mdl = "MOM_dynamics_unsplit" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
@@ -695,7 +695,7 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, param_file, diag, CS, &
 
   !   This subroutine initializes all of the variables that are used by this
   ! dynamic core, including diagnostics and the cpu clocks.
-  character(len=40) :: mod = "MOM_dynamics_unsplit" ! This module's name.
+  character(len=40) :: mdl = "MOM_dynamics_unsplit" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   logical :: use_tides
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
@@ -713,9 +713,9 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, param_file, diag, CS, &
 
   CS%diag => diag
 
-  call get_param(param_file, mod, "DEBUG", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "TIDES", use_tides, &
+  call get_param(param_file, mdl, "TIDES", use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
 
   allocate(CS%taux_bot(IsdB:IedB,jsd:jed)) ; CS%taux_bot(:,:) = 0.0

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -643,7 +643,7 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, param_file, diag, CS
 
   !   This subroutine initializes all of the variables that are used by this
   ! dynamic core, including diagnostics and the cpu clocks.
-  character(len=40) :: mod = "MOM_dynamics_unsplit_RK2" ! This module's name.
+  character(len=40) :: mdl = "MOM_dynamics_unsplit_RK2" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   logical :: use_tides
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
@@ -661,7 +661,7 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, param_file, diag, CS
 
   CS%diag => diag
 
-  call get_param(param_file, mod, "BE", CS%be, &
+  call get_param(param_file, mdl, "BE", CS%be, &
                  "If SPLIT is true, BE determines the relative weighting \n"//&
                  "of a  2nd-order Runga-Kutta baroclinic time stepping \n"//&
                  "scheme (0.5) and a backward Euler scheme (1) that is \n"//&
@@ -669,7 +669,7 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, param_file, diag, CS
                  "from 0.5 to 1, but instability may occur near 0.5. \n"//&
                  "BE is also applicable if SPLIT is false and USE_RK2 \n"//&
                  "is true.", units="nondim", default=0.6)
-  call get_param(param_file, mod, "BEGW", CS%begw, &
+  call get_param(param_file, mdl, "BEGW", CS%begw, &
                  "If SPLIT is true, BEGW is a number from 0 to 1 that \n"//&
                  "controls the extent to which the treatment of gravity \n"//&
                  "waves is forward-backward (0) or simulated backward \n"//&
@@ -677,9 +677,9 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, param_file, diag, CS
                  "If SPLIT is false and USE_RK2 is true, BEGW can be \n"//&
                  "between 0 and 0.5 to damp gravity waves.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "DEBUG", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "TIDES", use_tides, &
+  call get_param(param_file, mdl, "TIDES", use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
 
   allocate(CS%taux_bot(IsdB:IedB,jsd:jed)) ; CS%taux_bot(:,:) = 0.0

--- a/src/core/MOM_legacy_barotropic.F90
+++ b/src/core/MOM_legacy_barotropic.F90
@@ -3669,7 +3669,7 @@ subroutine legacy_barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, C
 !  (in)      tides_CSp - a pointer to the control structure of the tide module.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_barotropic"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_barotropic"  ! This module's name.
   real :: Datu(SZIBS_(G),SZJ_(G)), Datv(SZI_(G),SZJBS_(G))
   real :: gtot_estimate ! Summing GV%g_prime gives an upper-bound estimate for pbce.
   real :: SSH_extra     ! An estimate of how much higher SSH might get, for use
@@ -3703,28 +3703,28 @@ subroutine legacy_barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, C
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "SPLIT", CS%split, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "SPLIT", CS%split, &
                  "Use the split time stepping if true.", default=.true.)
   if (.not.CS%split) return
 
   ! ### USE SOMETHING OTHER THAN MAXVEL FOR THIS...
-  call get_param(param_file, mod, "BOUND_BT_CORRECTION", CS%bound_BT_corr, &
+  call get_param(param_file, mdl, "BOUND_BT_CORRECTION", CS%bound_BT_corr, &
                  "If true, the corrective pseudo mass-fluxes into the \n"//&
                  "barotropic solver are limited to values that require \n"//&
                  "less than 0.1*MAXVEL to be accommodated.",default=.false.)
-  call get_param(param_file, mod, "GRADUAL_BT_ICS", CS%gradual_BT_ICs, &
+  call get_param(param_file, mdl, "GRADUAL_BT_ICS", CS%gradual_BT_ICs, &
                  "If true, adjust the initial conditions for the \n"//&
                  "barotropic solver to the values from the layered \n"//&
                  "solution over a whole timestep instead of instantly. \n"//&
                  "This is a decent approximation to the inclusion of \n"//&
                  "sum(u dh_dt) while also correcting for truncation errors.", &
                  default=.false.)
-  call get_param(param_file, mod, "BT_USE_WIDE_HALOS", CS%use_wide_halos, &
+  call get_param(param_file, mdl, "BT_USE_WIDE_HALOS", CS%use_wide_halos, &
                  "If true, use wide halos and march in during the \n"//&
                  "barotropic time stepping for efficiency.", default=.true., &
                  layoutParam=.true.)
-  call get_param(param_file, mod, "BTHALO", bt_halo_sz, &
+  call get_param(param_file, mdl, "BTHALO", bt_halo_sz, &
                  "The minimum halo size for the barotropic solver.", default=0, &
                  layoutParam=.true.)
 #ifdef STATIC_MEMORY_
@@ -3735,44 +3735,44 @@ subroutine legacy_barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, C
 #else
   wd_halos(1) = bt_halo_sz; wd_halos(2) =  bt_halo_sz
 #endif
-  call log_param(param_file, mod, "!BT x-halo", wd_halos(1), &
+  call log_param(param_file, mdl, "!BT x-halo", wd_halos(1), &
                  "The barotropic x-halo size that is actually used.", &
                  layoutParam=.true.)
-  call log_param(param_file, mod, "!BT y-halo", wd_halos(2), &
+  call log_param(param_file, mdl, "!BT y-halo", wd_halos(2), &
                  "The barotropic y-halo size that is actually used.", &
                  layoutParam=.true.)
 
-  call get_param(param_file, mod, "USE_BT_CONT_TYPE", use_BT_cont_type, &
+  call get_param(param_file, mdl, "USE_BT_CONT_TYPE", use_BT_cont_type, &
                "If true, use a structure with elements that describe \n"//&
                "effective face areas from the summed continuity solver \n"//&
                "as a function the barotropic flow in coupling between \n"//&
                "the barotropic and baroclinic flow.  This is only used \n"//&
                "if SPLIT is true. \n", default=.true.)
-  call get_param(param_file, mod, "NONLINEAR_BT_CONTINUITY", &
+  call get_param(param_file, mdl, "NONLINEAR_BT_CONTINUITY", &
                                 CS%Nonlinear_continuity, &
                  "If true, use nonlinear transports in the barotropic \n"//&
                  "continuity equation.  This does not apply if \n"//&
                  "USE_BT_CONT_TYPE is true.", default=.false.)
   CS%Nonlin_cont_update_period = 1
   if (CS%Nonlinear_continuity) &
-    call get_param(param_file, mod, "NONLIN_BT_CONT_UPDATE_PERIOD", &
+    call get_param(param_file, mdl, "NONLIN_BT_CONT_UPDATE_PERIOD", &
                                   CS%Nonlin_cont_update_period, &
                  "If NONLINEAR_BT_CONTINUITY is true, this is the number \n"//&
                  "of barotropic time steps between updates to the face \n"//&
                  "areas, or 0 to update only before the barotropic stepping.",&
                  units="nondim", default=1)
-  call get_param(param_file, mod, "RESCALE_BT_FACE_AREAS", CS%rescale_D_bt, &
+  call get_param(param_file, mdl, "RESCALE_BT_FACE_AREAS", CS%rescale_D_bt, &
                  "If true, the face areas used by the barotropic solver \n"//&
                  "are rescaled to approximately reflect the open face \n"//&
                  "areas of the interior layers.  This probably requires \n"//&
                  "FLUX_BT_COUPLING to work, and should not be used with \n"//&
                  "USE_BT_CONT_TYPE.", default=.false.)
-  call get_param(param_file, mod, "BT_MASS_SOURCE_LIMIT", CS%eta_source_limit, &
+  call get_param(param_file, mdl, "BT_MASS_SOURCE_LIMIT", CS%eta_source_limit, &
                  "The fraction of the initial depth of the ocean that can \n"//&
                  "be added to or removed from the bartropic solution \n"//&
                  "within a thermodynamic time step.  By default this is 0 \n"//&
                  "for no correction.", units="nondim", default=0.0)
-  call get_param(param_file, mod, "BT_PROJECT_VELOCITY", CS%BT_project_velocity,&
+  call get_param(param_file, mdl, "BT_PROJECT_VELOCITY", CS%BT_project_velocity,&
                  "If true, step the barotropic velocity first and project \n"//&
                  "out the velocity tendancy by 1+BEBT when calculating the \n"//&
                  "transport.  The default (false) is to use a predictor \n"//&
@@ -3781,36 +3781,36 @@ subroutine legacy_barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, C
                  "average of the old and new velocities, with weights \n"//&
                  "of (1-BEBT) and BEBT.", default=.false.)
 
-  call get_param(param_file, mod, "DYNAMIC_SURFACE_PRESSURE", CS%dynamic_psurf, &
+  call get_param(param_file, mdl, "DYNAMIC_SURFACE_PRESSURE", CS%dynamic_psurf, &
                  "If true, add a dynamic pressure due to a viscous ice \n"//&
                  "shelf, for instance.", default=.false.)
   if (CS%dynamic_psurf) then
-    call get_param(param_file, mod, "ICE_LENGTH_DYN_PSURF", CS%ice_strength_length, &
+    call get_param(param_file, mdl, "ICE_LENGTH_DYN_PSURF", CS%ice_strength_length, &
                  "The length scale at which the Rayleigh damping rate due \n"//&
                  "to the ice strength should be the same as if a Laplacian \n"//&
                  "were applied, if DYNAMIC_SURFACE_PRESSURE is true.", &
                  units="m", default=1.0e4)
-    call get_param(param_file, mod, "DEPTH_MIN_DYN_PSURF", CS%Dmin_dyn_psurf, &
+    call get_param(param_file, mdl, "DEPTH_MIN_DYN_PSURF", CS%Dmin_dyn_psurf, &
                   "The minimum depth to use in limiting the size of the \n"//&
                   "dynamic surface pressure for stability, if \n"//&
                   "DYNAMIC_SURFACE_PRESSURE is true..", units="m", &
                   default=1.0e-6)
-    call get_param(param_file, mod, "CONST_DYN_PSURF", CS%const_dyn_psurf, &
+    call get_param(param_file, mdl, "CONST_DYN_PSURF", CS%const_dyn_psurf, &
                  "The constant that scales the dynamic surface pressure, \n"//&
                  "if DYNAMIC_SURFACE_PRESSURE is true.  Stable values \n"//&
                  "are < ~1.0.", units="nondim", default=0.9)
   endif
 
-  call get_param(param_file, mod, "TIDES", CS%tides, &
+  call get_param(param_file, mdl, "TIDES", CS%tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
-  call get_param(param_file, mod, "SADOURNY", CS%Sadourny, &
+  call get_param(param_file, mdl, "SADOURNY", CS%Sadourny, &
                  "If true, the Coriolis terms are discretized with the \n"//&
                  "Sadourny (1975) energy conserving scheme, otherwise \n"//&
                  "the Arakawa & Hsu scheme is used.  If the internal \n"//&
                  "deformation radius is not resolved, the Sadourny scheme \n"//&
                  "should probably be used.", default=.true.)
 
-  call get_param(param_file, mod, "BT_THICK_SCHEME", hvel_str, &
+  call get_param(param_file, mdl, "BT_THICK_SCHEME", hvel_str, &
                  "A string describing the scheme that is used to set the \n"//&
                  "open face areas used for barotropic transport and the \n"//&
                  "relative weights of the accelerations. Valid values are:\n"//&
@@ -3837,54 +3837,54 @@ subroutine legacy_barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, C
     call MOM_error(FATAL, "barotropic_init: BT_THICK_SCHEME FROM_BT_CONT "//&
                            "can only be used if USE_BT_CONT_TYPE is defined.")
 
-  call get_param(param_file, mod, "APPLY_BT_DRAG", apply_bt_drag, &
+  call get_param(param_file, mdl, "APPLY_BT_DRAG", apply_bt_drag, &
                  "If defined, bottom drag is applied within the \n"//&
                  "barotropic solver.", default=.true.)
-  call get_param(param_file, mod, "BT_STRONG_DRAG", CS%strong_drag, &
+  call get_param(param_file, mdl, "BT_STRONG_DRAG", CS%strong_drag, &
                  "If true, use a stronger estimate of the retarding \n"//&
                  "effects of strong bottom drag, by making it implicit \n"//&
                  "with the barotropic time-step instead of implicit with \n"//&
                  "the baroclinic time-step and dividing by the number of \n"//&
                  "barotropic steps.", default=.true.)
 
-  call get_param(param_file, mod, "CLIP_BT_VELOCITY", CS%clip_velocity, &
+  call get_param(param_file, mdl, "CLIP_BT_VELOCITY", CS%clip_velocity, &
                  "If true, limit any velocity components that exceed \n"//&
                  "MAXVEL.  This should only be used as a desperate \n"//&
                  "debugging measure.", default=.false.)
-  call get_param(param_file, mod, "MAXVEL", CS%maxvel, &
+  call get_param(param_file, mdl, "MAXVEL", CS%maxvel, &
                  "The maximum velocity allowed before the velocity \n"//&
                  "components are truncated.", units="m s-1", default=3.0e8, &
                  do_not_log=.not.CS%clip_velocity)
-  call get_param(param_file, mod, "MAXCFL_BT_CONT", CS%maxCFL_BT_cont, &
+  call get_param(param_file, mdl, "MAXCFL_BT_CONT", CS%maxCFL_BT_cont, &
                  "The maximum permitted CFL number associated with the \n"//&
                  "barotropic accelerations from the summed velocities \n"//&
                  "times the time-derivatives of thicknesses.", units="nondim", &
                  default=0.1)
 
-  call get_param(param_file, mod, "DT_BT_FILTER", CS%dt_bt_filter, &
+  call get_param(param_file, mdl, "DT_BT_FILTER", CS%dt_bt_filter, &
                  "A time-scale over which the barotropic mode solutions \n"//&
                  "are filtered, in seconds if positive, or as a fraction \n"//&
                  "of DT if negative. When used this can never be taken to \n"//&
                  "be longer than 2*dt.  Set this to 0 to apply no filtering.", &
                  units="sec or nondim", default=-0.25)
-  call get_param(param_file, mod, "G_BT_EXTRA", CS%G_extra, &
+  call get_param(param_file, mdl, "G_BT_EXTRA", CS%G_extra, &
                  "A nondimensional factor by which gtot is enhanced.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "SSH_EXTRA", SSH_extra, &
+  call get_param(param_file, mdl, "SSH_EXTRA", SSH_extra, &
                  "An estimate of how much higher SSH might get, for use \n"//&
                  "in calculating the safe external wave speed. The \n"//&
                  "default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.", &
                  units="m", default=min(10.0,0.05*G%max_depth))
 
-  call get_param(param_file, mod, "DEBUG", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_BT", CS%debug_bt, &
+  call get_param(param_file, mdl, "DEBUG_BT", CS%debug_bt, &
                  "If true, write out verbose debugging data within the \n"//&
                  "barotropic time-stepping loop. The data volume can be \n"//&
                  "quite large if this is true.", default=CS%debug)
 
   CS%linearized_BT_PV = .true.
-  call get_param(param_file, mod, "BEBT", CS%bebt, &
+  call get_param(param_file, mdl, "BEBT", CS%bebt, &
                  "BEBT determines whether the barotropic time stepping \n"//&
                  "uses the forward-backward time-stepping scheme or a \n"//&
                  "backward Euler scheme. BEBT is valid in the range from \n"//&
@@ -3892,7 +3892,7 @@ subroutine legacy_barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, C
                  "gravity waves) to 1 (for a backward Euler treatment). \n"//&
                  "In practice, BEBT must be greater than about 0.05.", &
                  units="nondim", default=0.1)
-  call get_param(param_file, mod, "DTBT", CS%dtbt, &
+  call get_param(param_file, mdl, "DTBT", CS%dtbt, &
                  "The barotropic time step, in s. DTBT is only used with \n"//&
                  "the split explicit time stepping. To set the time step \n"//&
                  "automatically based the maximum stable value use 0, or \n"//&
@@ -4024,8 +4024,8 @@ subroutine legacy_barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, C
   call legacy_set_dtbt(G, GV, CS, gtot_est = gtot_estimate, SSH_add = SSH_extra)
   if (dtbt_input > 0.0) CS%dtbt = dtbt_input
 
-  call log_param(param_file, mod, "!DTBT as used", CS%dtbt)
-  call log_param(param_file, mod, "!estimated maximum DTBT", CS%dtbt_max)
+  call log_param(param_file, mdl, "!DTBT as used", CS%dtbt)
+  call log_param(param_file, mdl, "!estimated maximum DTBT", CS%dtbt_max)
 
   ! ubtav, vbtav, ubt_IC, vbt_IC, uhbt_IC, and vhbt_IC are allocated and
   ! initialized in register_barotropic_restarts.

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -199,7 +199,7 @@ end type OBC_registry_type
 
 integer :: id_clock_pass
 
-character(len=40)  :: mod = "MOM_open_boundary" ! This module's name.
+character(len=40)  :: mdl = "MOM_open_boundary" ! This module's name.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
@@ -224,51 +224,51 @@ subroutine open_boundary_config(G, param_file, OBC)
 
   allocate(OBC)
 
-  call log_version(param_file, mod, version, "Controls where open boundaries are located, what "//&
+  call log_version(param_file, mdl, version, "Controls where open boundaries are located, what "//&
                  "kind of boundary condition to impose, and what data to apply, if any.")
-  call get_param(param_file, mod, "OBC_NUMBER_OF_SEGMENTS", OBC%number_of_segments, &
+  call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", OBC%number_of_segments, &
                  "The number of open boundary segments.", &
                  default=0)
-  call get_param(param_file, mod, "G_EARTH", OBC%g_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", OBC%g_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
-  call get_param(param_file, mod, "OBC_USER_CONFIG", config1, &
+  call get_param(param_file, mdl, "OBC_USER_CONFIG", config1, &
                  "A string that sets how the open boundary conditions are \n"//&
                  " configured: \n", default="none", do_not_log=.true.)
-  call get_param(param_file, mod, "NK", OBC%ke, &
+  call get_param(param_file, mdl, "NK", OBC%ke, &
                  "The number of model layers", default=0, do_not_log=.true.)
 
   if (config1 .ne. "none") OBC%user_BCs_set_globally = .true.
   ! It's in state initialization...
 !  if (config1 .eq. "tidal_bay") OBC%update_OBC = .true.
 
-  call get_param(param_file, mod, "EXTEND_OBC_SEGMENTS", OBC%extend_segments, &
+  call get_param(param_file, mdl, "EXTEND_OBC_SEGMENTS", OBC%extend_segments, &
                    "If true, extend OBC segments. This option is used to recover\n"//&
                    "legacy solutions dependent on an incomplete implementaion of OBCs.\n"//&
                    "This option will be obsoleted in the future.", default=.false.)
 
   if (OBC%number_of_segments > 0) then
-    call get_param(param_file, mod, "OBC_ZERO_VORTICITY", OBC%zero_vorticity, &
+    call get_param(param_file, mdl, "OBC_ZERO_VORTICITY", OBC%zero_vorticity, &
          "If true, sets relative vorticity to zero on open boundaries.", &
          default=.false.)
-    call get_param(param_file, mod, "OBC_FREESLIP_VORTICITY", OBC%freeslip_vorticity, &
+    call get_param(param_file, mdl, "OBC_FREESLIP_VORTICITY", OBC%freeslip_vorticity, &
          "If true, sets the normal gradient of tangential velocity to\n"// &
          "zero in the relative vorticity on open boundaries. This cannot\n"// &
          "be true if OBC_ZERO_VORTICITY is True.", default=.false.)
     if (OBC%zero_vorticity .and. OBC%freeslip_vorticity) call MOM_error(FATAL, &
          "MOM_open_boundary.F90, open_boundary_config: "//&
          "Only one of OBC_ZERO_VORTICITY and OBC_FREESLIP_VORTICITY can be True at once.")
-    call get_param(param_file, mod, "OBC_ZERO_STRAIN", OBC%zero_strain, &
+    call get_param(param_file, mdl, "OBC_ZERO_STRAIN", OBC%zero_strain, &
          "If true, sets the strain used in the stress tensor to zero on open boundaries.", &
          default=.false.)
-    call get_param(param_file, mod, "OBC_FREESLIP_STRAIN", OBC%freeslip_strain, &
+    call get_param(param_file, mdl, "OBC_FREESLIP_STRAIN", OBC%freeslip_strain, &
          "If true, sets the normal gradient of tangential velocity to\n"// &
          "zero in the strain use in the stress tensor on open boundaries. This cannot\n"// &
          "be true if OBC_ZERO_STRAIN is True.", default=.false.)
     if (OBC%zero_strain .and. OBC%freeslip_strain) call MOM_error(FATAL, &
          "MOM_open_boundary.F90, open_boundary_config: "//&
          "Only one of OBC_ZERO_STRAIN and OBC_FREESLIP_STRAIN can be True at once.")
-    call get_param(param_file, mod, "OBC_ZERO_BIHARMONIC", OBC%zero_biharmonic, &
+    call get_param(param_file, mdl, "OBC_ZERO_BIHARMONIC", OBC%zero_biharmonic, &
          "If true, zeros the Laplacian of flow on open boundaries in the biharmonic\n"//&
          "viscosity term.", default=.false.)
     ! Allocate everything
@@ -295,7 +295,7 @@ subroutine open_boundary_config(G, param_file, OBC)
 
     do l = 1, OBC%number_of_segments
       write(segment_param_str(1:15),"('OBC_SEGMENT_',i3.3)") l
-      call get_param(param_file, mod, segment_param_str, segment_str, &
+      call get_param(param_file, mdl, segment_param_str, segment_str, &
            "Documentation needs to be dynamic?????", &
            fail_if_missing=.true.)
       segment_str = remove_spaces(segment_str)
@@ -360,23 +360,23 @@ subroutine initialize_segment_data(G, OBC, PF)
   ! param file so that I can use it later in step_MOM in order to finish
   ! initializing segments on the first step.
 
-  call get_param(PF, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(PF, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
 
-  call get_param(PF, mod, "REMAPPING_SCHEME", remappingScheme, &
+  call get_param(PF, mdl, "REMAPPING_SCHEME", remappingScheme, &
           "This sets the reconstruction scheme used\n"//&
           "for vertical remapping for all variables.\n"//&
           "It can be one of the following schemes:\n"//&
           trim(remappingSchemesDoc), default=remappingDefaultScheme,do_not_log=.true.)
-  call get_param(PF, mod, "FATAL_CHECK_RECONSTRUCTIONS", check_reconstruction, &
+  call get_param(PF, mdl, "FATAL_CHECK_RECONSTRUCTIONS", check_reconstruction, &
           "If true, cell-by-cell reconstructions are checked for\n"//&
           "consistency and if non-monotonicity or an inconsistency is\n"//&
           "detected then a FATAL error is issued.", default=.false.,do_not_log=.true.)
-  call get_param(PF, mod, "FATAL_CHECK_REMAPPING", check_remapping, &
+  call get_param(PF, mdl, "FATAL_CHECK_REMAPPING", check_remapping, &
           "If true, the results of remapping are checked for\n"//&
           "conservation and new extrema and if an inconsistency is\n"//&
           "detected then a FATAL error is issued.", default=.false.,do_not_log=.true.)
-  call get_param(PF, mod, "REMAP_BOUND_INTERMEDIATE_VALUES", force_bounds_in_subcell, &
+  call get_param(PF, mdl, "REMAP_BOUND_INTERMEDIATE_VALUES", force_bounds_in_subcell, &
           "If true, the values on the intermediate grid used for remapping\n"//&
           "are forced to be bounded, which might not be the case due to\n"//&
           "round off.", default=.false.,do_not_log=.true.)
@@ -402,7 +402,7 @@ subroutine initialize_segment_data(G, OBC, PF)
 
     write(segnam,"('OBC_SEGMENT_',i3.3,'_DATA')") n
     write(suffix,"('_segment_',i3.3)") n
-    call get_param(PF, mod, segnam, segstr)
+    call get_param(PF, mdl, segnam, segstr)
 
     call parse_segment_data_str(trim(segstr), fields=fields, num_fields=num_fields)
     if (num_fields == 0) then
@@ -952,19 +952,19 @@ subroutine open_boundary_init(G, param_file, OBC)
   if (.not.associated(OBC)) return
 
   if ( OBC%Flather_u_BCs_exist_globally .or. OBC%Flather_v_BCs_exist_globally ) then
-    call get_param(param_file, mod, "OBC_RADIATION_MAX", OBC%rx_max, &
+    call get_param(param_file, mdl, "OBC_RADIATION_MAX", OBC%rx_max, &
                    "The maximum magnitude of the baroclinic radiation \n"//&
                    "velocity (or speed of characteristics).  This is only \n"//&
                    "used if one of the open boundary segments is using Orlanski.", &
                    units="m s-1", default=10.0)
-    call get_param(param_file, mod, "OBC_RAD_VEL_WT", OBC%gamma_uv, &
+    call get_param(param_file, mdl, "OBC_RAD_VEL_WT", OBC%gamma_uv, &
                    "The relative weighting for the baroclinic radiation \n"//&
                    "velocities (or speed of characteristics) at the new \n"//&
                    "time level (1) or the running mean (0) for velocities. \n"//&
                    "Valid values range from 0 to 1. This is only used if \n"//&
                    "one of the open boundary segments is using Orlanski.", &
                    units="nondim",  default=0.3)
-    call get_param(param_file, mod, "OBC_RAD_THICK_WT", OBC%gamma_h, &
+    call get_param(param_file, mdl, "OBC_RAD_THICK_WT", OBC%gamma_h, &
                    "The relative weighting for the baroclinic radiation \n"//&
                    "velocities (or speed of characteristics) at the new \n"//&
                    "time level (1) or the running mean (0) for thicknesses. \n"//&
@@ -1526,7 +1526,7 @@ subroutine set_tracer_data(OBC, tv, h, G, PF, tracer_Reg)
   integer :: isd_off, jsd_off
   integer :: IsdB, IedB, JsdB, JedB
   type(OBC_segment_type), pointer :: segment ! pointer to segment type list
-  character(len=40)  :: mod = "set_tracer_data" ! This subroutine's name.
+  character(len=40)  :: mdl = "set_tracer_data" ! This subroutine's name.
   character(len=200) :: filename, OBC_file, inputdir ! Strings for file/path
 
   real :: temp_u(G%domain%niglobal+1,G%domain%njglobal)
@@ -1672,7 +1672,7 @@ subroutine allocate_OBC_segment_data(OBC, segment)
   ! Local variables
   integer :: isd, ied, jsd, jed
   integer :: IsdB, IedB, JsdB, JedB
-  character(len=40)  :: mod = "allocate_OBC_segment_data" ! This subroutine's name.
+  character(len=40)  :: mdl = "allocate_OBC_segment_data" ! This subroutine's name.
 
   isd = segment%HI%isd ; ied = segment%HI%ied
   jsd = segment%HI%jsd ; jed = segment%HI%jed
@@ -1816,7 +1816,7 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
 
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed
   integer :: IsdB, IedB, JsdB, JedB, n, m, nz
-  character(len=40)  :: mod = "set_OBC_segment_data" ! This subroutine's name.
+  character(len=40)  :: mdl = "set_OBC_segment_data" ! This subroutine's name.
   character(len=200) :: filename, OBC_file, inputdir ! Strings for file/path
   type(OBC_segment_type), pointer :: segment
   integer, dimension(4) :: siz,siz2
@@ -2035,14 +2035,14 @@ subroutine OBC_registry_init(param_file, Reg)
   integer, save :: init_calls = 0
 
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_open_boundary" ! This module's name.
+  character(len=40)  :: mdl = "MOM_open_boundary" ! This module's name.
   character(len=256) :: mesg    ! Message for error messages.
 
   if (.not.associated(Reg)) then ; allocate(Reg)
   else ; return ; endif
 
   ! Read all relevant parameters and write them to the model log.
-! call log_version(param_file, mod, version, "")
+! call log_version(param_file, mdl,s version, "")
 
   init_calls = init_calls + 1
   if (init_calls > 1) then

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -91,49 +91,49 @@ subroutine verticalGridInit( param_file, GV )
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   integer :: nk
-  character(len=16) :: mod = 'MOM_verticalGrid'
+  character(len=16) :: mdl = 'MOM_verticalGrid'
 
   if (associated(GV)) call MOM_error(FATAL, &
      'verticalGridInit: called with an associated GV pointer.')
   allocate(GV)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
                    "Parameters providing information about the vertical grid.")
-  call get_param(param_file, mod, "G_EARTH", GV%g_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", GV%g_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
-  call get_param(param_file, mod, "RHO_0", GV%Rho0, &
+  call get_param(param_file, mdl, "RHO_0", GV%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "BOUSSINESQ", GV%Boussinesq, &
+  call get_param(param_file, mdl, "BOUSSINESQ", GV%Boussinesq, &
                  "If true, make the Boussinesq approximation.", default=.true.)
-  call get_param(param_file, mod, "ANGSTROM", GV%Angstrom_z, &
+  call get_param(param_file, mdl, "ANGSTROM", GV%Angstrom_z, &
                  "The minumum layer thickness, usually one-Angstrom.", &
                  units="m", default=1.0e-10)
   if (.not.GV%Boussinesq) then
-    call get_param(param_file, mod, "H_TO_KG_M2", GV%H_to_kg_m2,&
+    call get_param(param_file, mdl, "H_TO_KG_M2", GV%H_to_kg_m2,&
                  "A constant that translates thicknesses from the model's \n"//&
                  "internal units of thickness to kg m-2.", units="kg m-2 H-1", &
                  default=1.0)
   else
-    call get_param(param_file, mod, "H_TO_M", GV%H_to_m, &
+    call get_param(param_file, mdl, "H_TO_M", GV%H_to_m, &
                  "A constant that translates the model's internal \n"//&
                  "units of thickness into m.", units="m H-1", default=1.0)
   endif
 #ifdef STATIC_MEMORY_
   ! Here NK_ is a macro, while nk is a variable.
-  call get_param(param_file, mod, "NK", nk, &
+  call get_param(param_file, mdl, "NK", nk, &
                  "The number of model layers.", units="nondim", &
                  static_value=NK_)
   if (nk /= NK_) call MOM_error(FATAL, "verticalGridInit: " // &
        "Mismatched number of layers NK_ between MOM_memory.h and param_file")
 
 #else
-  call get_param(param_file, mod, "NK", nk, &
+  call get_param(param_file, mdl, "NK", nk, &
                  "The number of model layers.", units="nondim", fail_if_missing=.true.)
 #endif
   GV%ke = nk
@@ -153,7 +153,7 @@ subroutine verticalGridInit( param_file, GV )
   GV%H_to_Pa = GV%g_Earth * GV%H_to_kg_m2
 
 ! Log derivative values.
-  call log_param(param_file, mod, "M to THICKNESS", GV%m_to_H)
+  call log_param(param_file, mdl, "M to THICKNESS", GV%m_to_H)
 
   ALLOC_( GV%sInterface(nk+1) )
   ALLOC_( GV%sLayer(nk) )

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -828,7 +828,7 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
 !                 for this module
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_PointAccel" ! This module's name.
+  character(len=40)  :: mdl = "MOM_PointAccel" ! This module's name.
 
   if (associated(CS)) return
   allocate(CS)
@@ -842,18 +842,18 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
   CS%v_av => MIS%v_av; if (.not.associated(MIS%v_av)) CS%v_av => MIS%v(:,:,:)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "U_TRUNC_FILE", CS%u_trunc_file, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "U_TRUNC_FILE", CS%u_trunc_file, &
                  "The absolute path to the file where the accelerations \n"//&
                  "leading to zonal velocity truncations are written. \n"//&
                  "Leave this empty for efficiency if this diagnostic is \n"//&
                  "not needed.", default="")
-  call get_param(param_file, mod, "V_TRUNC_FILE", CS%v_trunc_file, &
+  call get_param(param_file, mdl, "V_TRUNC_FILE", CS%v_trunc_file, &
                  "The absolute path to the file where the accelerations \n"//&
                  "leading to meridional velocity truncations are written. \n"//&
                  "Leave this empty for efficiency if this diagnostic is \n"//&
                  "not needed.", default="")
-  call get_param(param_file, mod, "MAX_TRUNC_FILE_SIZE_PER_PE", CS%max_writes, &
+  call get_param(param_file, mdl, "MAX_TRUNC_FILE_SIZE_PER_PE", CS%max_writes, &
                  "The maximum number of colums of truncations that any PE \n"//&
                  "will write out during a run.", default=50)
 
@@ -862,8 +862,8 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
       CS%u_trunc_file = trim(dirs%output_directory)//trim(CS%u_trunc_file)
     if (len_trim(CS%v_trunc_file) > 0) &
       CS%v_trunc_file = trim(dirs%output_directory)//trim(CS%v_trunc_file)
-    call log_param(param_file, mod, "output_dir/U_TRUNC_FILE", CS%u_trunc_file)
-    call log_param(param_file, mod, "output_dir/V_TRUNC_FILE", CS%v_trunc_file)
+    call log_param(param_file, mdl, "output_dir/U_TRUNC_FILE", CS%u_trunc_file)
+    call log_param(param_file, mdl, "output_dir/V_TRUNC_FILE", CS%v_trunc_file)
   endif
   CS%u_file = -1 ; CS%v_file = -1 ; CS%cols_written = 0
 

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -93,15 +93,15 @@ subroutine MOM_debugging_init(param_file)
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_debugging" ! This module's name.
+  character(len=40)  :: mdl = "MOM_debugging" ! This module's name.
 
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "DEBUG", debug, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_CHKSUMS", debug_chksums, &
+  call get_param(param_file, mdl, "DEBUG_CHKSUMS", debug_chksums, &
                  "If true, checksums are performed on arrays in the \n"//&
                  "various vec_chksum routines.", default=debug)
-  call get_param(param_file, mod, "DEBUG_REDUNDANT", debug_redundant, &
+  call get_param(param_file, mdl, "DEBUG_REDUNDANT", debug_redundant, &
                  "If true, debug redundant data points during calls to \n"//&
                  "the various vec_chksum routines.", default=debug)
 

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -1064,7 +1064,7 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
-  character(len=40)  :: mod = "MOM_diag_to_Z" ! module name
+  character(len=40)  :: mdl = "MOM_diag_to_Z" ! module name
   character(len=200) :: in_dir, zgrid_file    ! strings for directory/file
   character(len=48)  :: flux_units, string
   integer :: z_axis, zint_axis
@@ -1085,22 +1085,22 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
   CS%diag => diag
 
   ! Read parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
   ! Read in z-space info from a NetCDF file.
-  call get_param(param_file, mod, "Z_OUTPUT_GRID_FILE", zgrid_file, &
+  call get_param(param_file, mdl, "Z_OUTPUT_GRID_FILE", zgrid_file, &
                  "The file that specifies the vertical grid for \n"//&
                  "depth-space diagnostics, or blank to disable \n"//&
                  "depth-space output.", default="")
 
   if (len_trim(zgrid_file) > 0) then
-    call get_param(param_file, mod, "INPUTDIR", in_dir, &
+    call get_param(param_file, mdl, "INPUTDIR", in_dir, &
                  "The directory in which input files are found.", default=".")
     in_dir = slasher(in_dir)
     call get_Z_depths(trim(in_dir)//trim(zgrid_file), "zw", CS%Z_int, "zt", &
                       z_axis, zint_axis, CS%nk_zspace)
-    call log_param(param_file, mod, "!INPUTDIR/Z_OUTPUT_GRID_FILE", &
+    call log_param(param_file, mdl, "!INPUTDIR/Z_OUTPUT_GRID_FILE", &
                    trim(in_dir)//trim(zgrid_file))
-    call log_param(param_file, mod, "!NK_ZSPACE (from file)", CS%nk_zspace, &
+    call log_param(param_file, mdl, "!NK_ZSPACE (from file)", CS%nk_zspace, &
                  "The number of depth-space levels.  This is determined \n"//&
                  "from the size of the variable zw in the output grid file.", &
                  units="nondim")

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1145,7 +1145,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, param_file, diag, CS
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
-  character(len=40)  :: mod = "MOM_diagnostics" ! This module's name.
+  character(len=40)  :: mdl = "MOM_diagnostics" ! This module's name.
   real :: omega, f2_min
   character(len=48) :: thickness_units, flux_units
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz, nkml, nkbl
@@ -1166,12 +1166,12 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, param_file, diag, CS
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "DIAG_EBT_MONO_N2_COLUMN_FRACTION", CS%mono_N2_column_fraction, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "DIAG_EBT_MONO_N2_COLUMN_FRACTION", CS%mono_N2_column_fraction, &
                  "The lower fraction of water column over which N2 is limited as monotonic\n"// &
                  "for the purposes of calculating the equivalent barotropic wave speed.", &
                  units='nondim', default=0.)
-  call get_param(param_file, mod, "DIAG_EBT_MONO_N2_DEPTH", CS%mono_N2_depth, &
+  call get_param(param_file, mdl, "DIAG_EBT_MONO_N2_DEPTH", CS%mono_N2_depth, &
                  "The depth below which N2 is limited as monotonic for the\n"// &
                  "purposes of calculating the equivalent barotropic wave speed.", &
                  units='m', default=-1.)

--- a/src/diagnostics/MOM_obsolete_diagnostics.F90
+++ b/src/diagnostics/MOM_obsolete_diagnostics.F90
@@ -25,12 +25,12 @@ subroutine register_obsolete_diagnostics(param_file, diag)
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   ! Local variables
-  character(len=40)  :: mod = "MOM_obsolete_diagnostics"  !< This module's name.
+  character(len=40)  :: mdl = "MOM_obsolete_diagnostics"  !< This module's name.
   logical :: foundEntry, causeFatal
   integer :: errType
 
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "OBSOLETE_DIAGNOSTIC_IS_FATAL", causeFatal,              &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "OBSOLETE_DIAGNOSTIC_IS_FATAL", causeFatal,              &
                  "If an obsolete diagnostic variable appears in the diag_table\n"//        &
                  "then cause a FATAL error rather than issue a WARNING.", default=.true.)
 

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -20,7 +20,7 @@ contains
 subroutine find_obsolete_params(param_file)
   type(param_file_type), intent(in) :: param_file !< Structure containing parameter file data.
   ! Local variables
-  character(len=40)  :: mod = "find_obsolete_params" ! This module's name.
+  character(len=40)  :: mdl = "find_obsolete_params" ! This module's name.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   integer :: test_int
@@ -190,7 +190,7 @@ subroutine find_obsolete_params(param_file)
   call obsolete_logical(param_file, "MSTAR_FIXED", hint="Instead use MSTAR_MODE.")
 
   ! Write the file version number to the model log.
-  call log_version(param_file, mod, version)
+  call log_version(param_file, mdl, version)
 
 end subroutine find_obsolete_params
 

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -183,7 +183,7 @@ subroutine MOM_sum_output_init(G, param_file, directory, ntrnc, &
   real :: Rho_0, maxvel
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_sum_output" ! This module's name.
+  character(len=40)  :: mdl = "MOM_sum_output" ! This module's name.
   character(len=200) :: energyfile  ! The name of the energy file.
   character(len=32) :: filename_appendix = '' !fms appendix to filename for ensemble runs
 
@@ -194,42 +194,42 @@ subroutine MOM_sum_output_init(G, param_file, directory, ntrnc, &
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "CALCULATE_APE", CS%do_APE_calc, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "CALCULATE_APE", CS%do_APE_calc, &
                  "If true, calculate the available potential energy of \n"//&
                  "the interfaces.  Setting this to false reduces the \n"//&
                  "memory footprint of high-PE-count models dramatically.", &
                  default=.true.)
-  call get_param(param_file, mod, "WRITE_STOCKS", CS%write_stocks, &
+  call get_param(param_file, mdl, "WRITE_STOCKS", CS%write_stocks, &
                  "If true, write the integrated tracer amounts to stdout \n"//&
                  "when the energy files are written.", default=.true.)
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
                  "If true, Temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
-  call get_param(param_file, mod, "DT", CS%dt, &
+  call get_param(param_file, mdl, "DT", CS%dt, &
                  "The (baroclinic) dynamics time step.", units="s", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "MAXTRUNC", CS%maxtrunc, &
+  call get_param(param_file, mdl, "MAXTRUNC", CS%maxtrunc, &
                  "The run will be stopped, and the day set to a very \n"//&
                  "large value if the velocity is truncated more than \n"//&
                  "MAXTRUNC times between energy saves.  Set MAXTRUNC to 0 \n"//&
                  "to stop if there is any truncation of velocities.", &
                  units="truncations save_interval-1", default=0)
 
-  call get_param(param_file, mod, "MAX_ENERGY", CS%max_Energy, &
+  call get_param(param_file, mdl, "MAX_ENERGY", CS%max_Energy, &
                  "The maximum permitted average energy per unit mass; the \n"//&
                  "model will be stopped if there is more energy than \n"//&
                  "this.  If zero or negative, this is set to 10*MAXVEL^2.", &
                  units="m2 s-2", default=0.0)
   if (CS%max_Energy <= 0.0) then
-    call get_param(param_file, mod, "MAXVEL", maxvel, &
+    call get_param(param_file, mdl, "MAXVEL", maxvel, &
                  "The maximum velocity allowed before the velocity \n"//&
                  "components are truncated.", units="m s-1", default=3.0e8)
     CS%max_Energy = 10.0 * maxvel**2
-    call log_param (param_file, mod, "MAX_ENERGY as used", CS%max_Energy)
+    call log_param (param_file, mdl, "MAX_ENERGY as used", CS%max_Energy)
   endif
 
-  call get_param(param_file, mod, "ENERGYFILE", energyfile, &
+  call get_param(param_file, mdl, "ENERGYFILE", energyfile, &
                  "The file to use to write the energies and globally \n"//&
                  "summed diagnostics.", default="ocean.stats")
 
@@ -240,15 +240,15 @@ subroutine MOM_sum_output_init(G, param_file, directory, ntrnc, &
   end if
 
   CS%energyfile = trim(slasher(directory))//trim(energyfile)
-  call log_param(param_file, mod, "output_path/ENERGYFILE", CS%energyfile)
+  call log_param(param_file, mdl, "output_path/ENERGYFILE", CS%energyfile)
 #ifdef STATSLABEL
   CS%energyfile = trim(CS%energyfile)//"."//trim(adjustl(STATSLABEL))
 #endif
 
-  call get_param(param_file, mod, "DATE_STAMPED_STDOUT", CS%date_stamped_output, &
+  call get_param(param_file, mdl, "DATE_STAMPED_STDOUT", CS%date_stamped_output, &
                  "If true, use dates (not times) in messages to stdout", &
                  default=.true.)
-  call get_param(param_file, mod, "TIMEUNIT", CS%Timeunit, &
+  call get_param(param_file, mdl, "TIMEUNIT", CS%Timeunit, &
                  "The time unit in seconds a number of input fields", &
                  units="s", default=86400.0)
   if (CS%Timeunit < 0.0) CS%Timeunit = 86400.0
@@ -256,15 +256,15 @@ subroutine MOM_sum_output_init(G, param_file, directory, ntrnc, &
 
 
   if (CS%do_APE_calc) then
-    call get_param(param_file, mod, "READ_DEPTH_LIST", CS%read_depth_list, &
+    call get_param(param_file, mdl, "READ_DEPTH_LIST", CS%read_depth_list, &
                    "Read the depth list from a file if it exists or \n"//&
                    "create that file otherwise.", default=.false.)
-    call get_param(param_file, mod, "DEPTH_LIST_MIN_INC", CS%D_list_min_inc, &
+    call get_param(param_file, mdl, "DEPTH_LIST_MIN_INC", CS%D_list_min_inc, &
                    "The minimum increment between the depths of the \n"//&
                    "entries in the depth-list file.", units="m", &
                    default=1.0E-10)
     if (CS%read_depth_list) then
-      call get_param(param_file, mod, "DEPTH_LIST_FILE", CS%depth_list_file, &
+      call get_param(param_file, mdl, "DEPTH_LIST_FILE", CS%depth_list_file, &
                    "The name of the depth list file.", default="Depth_list.nc")
       if (scan(CS%depth_list_file,'/') == 0) &
         CS%depth_list_file = trim(slasher(directory))//trim(CS%depth_list_file)
@@ -1260,39 +1260,39 @@ subroutine read_depth_list(G, CS, filename)
 
 ! This subroutine reads in the depth list to the specified file
 ! and allocates and sets up CS%DL and CS%list_size .
-  character(len=32) :: mod
+  character(len=32) :: mdl
   character(len=240) :: var_name, var_msg
   real, allocatable :: tmp(:)
   integer :: ncid, status, varid, list_size, k
   integer :: ndim, len, var_dim_ids(NF90_MAX_VAR_DIMS)
 
-  mod = "MOM_sum_output read_depth_list:"
+  mdl = "MOM_sum_output read_depth_list:"
 
   status = NF90_OPEN(filename, NF90_NOWRITE, ncid);
   if (status /= NF90_NOERR) then
-    call MOM_error(FATAL,mod//" Difficulties opening "//trim(filename)// &
+    call MOM_error(FATAL,mdl//" Difficulties opening "//trim(filename)// &
         " - "//trim(NF90_STRERROR(status)))
   endif
 
   var_name = "depth"
   var_msg = trim(var_name)//" in "//trim(filename)//" - "
   status = NF90_INQ_VARID(ncid, var_name, varid)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mod// &
+  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
         " Difficulties finding variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
 
   status = NF90_INQUIRE_VARIABLE(ncid, varid, ndims=ndim, dimids=var_dim_ids)
   if (status /= NF90_NOERR) then
-    call MOM_ERROR(FATAL,mod//" cannot inquire about "//trim(var_msg)//&
+    call MOM_ERROR(FATAL,mdl//" cannot inquire about "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
   elseif (ndim > 1) then
-    call MOM_ERROR(FATAL,mod//" "//trim(var_msg)//&
+    call MOM_ERROR(FATAL,mdl//" "//trim(var_msg)//&
          " has too many or too few dimensions.")
   endif
 
   ! Get the length of the list.
   status = NF90_INQUIRE_DIMENSION(ncid, var_dim_ids(1), len=list_size)
-  if (status /= NF90_NOERR) call MOM_ERROR(FATAL,mod// &
+  if (status /= NF90_NOERR) call MOM_ERROR(FATAL,mdl// &
         " cannot inquire about dimension(1) of "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
 
@@ -1301,7 +1301,7 @@ subroutine read_depth_list(G, CS, filename)
   allocate(tmp(list_size))
 
   status = NF90_GET_VAR(ncid, varid, tmp)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mod// &
+  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
         " Difficulties reading variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
 
@@ -1310,11 +1310,11 @@ subroutine read_depth_list(G, CS, filename)
   var_name = "area"
   var_msg = trim(var_name)//" in "//trim(filename)//" - "
   status = NF90_INQ_VARID(ncid, var_name, varid)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mod// &
+  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
         " Difficulties finding variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
   status = NF90_GET_VAR(ncid, varid, tmp)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mod// &
+  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
         " Difficulties reading variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
 
@@ -1323,18 +1323,18 @@ subroutine read_depth_list(G, CS, filename)
   var_name = "vol_below"
   var_msg = trim(var_name)//" in "//trim(filename)
   status = NF90_INQ_VARID(ncid, var_name, varid)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mod// &
+  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
         " Difficulties finding variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
   status = NF90_GET_VAR(ncid, varid, tmp)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mod// &
+  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
         " Difficulties reading variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
 
   do k=1,list_size ; CS%DL(k)%vol_below = tmp(k) ; enddo
 
   status = NF90_CLOSE(ncid)
-  if (status /= NF90_NOERR) call MOM_error(WARNING, mod// &
+  if (status /= NF90_NOERR) call MOM_error(WARNING, mdl// &
     " Difficulties closing "//trim(filename)//" - "//trim(NF90_STRERROR(status)))
 
   deallocate(tmp)

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -1091,7 +1091,7 @@ subroutine wave_speed_init(CS, use_ebt_mode, mono_N2_column_fraction, mono_N2_de
                                       !! as monotonic for the purposes of calculating vertical modal structure.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_wave_speed"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_wave_speed"  ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "wave_speed_init called with an "// &
@@ -1100,7 +1100,7 @@ subroutine wave_speed_init(CS, use_ebt_mode, mono_N2_column_fraction, mono_N2_de
   else ; allocate(CS) ; endif
 
   ! Write all relevant parameters to the model log.
-  call log_version(mod, version)
+  call log_version(mdl, version)
 
   call wave_speed_set_param(CS, use_ebt_mode=use_ebt_mode, mono_N2_column_fraction=mono_N2_column_fraction)
 

--- a/src/diagnostics/MOM_wave_structure.F90
+++ b/src/diagnostics/MOM_wave_structure.F90
@@ -774,7 +774,7 @@ subroutine wave_structure_init(Time, G, param_file, diag, CS)
 !                  for this module
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_wave_structure"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_wave_structure"  ! This module's name.
   integer :: isd, ied, jsd, jed, nz
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = G%ke
@@ -785,9 +785,9 @@ subroutine wave_structure_init(Time, G, param_file, diag, CS)
     return
   else ; allocate(CS) ; endif
 
-  call get_param(param_file, mod, "INTERNAL_TIDE_SOURCE_X", CS%int_tide_source_x, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_X", CS%int_tide_source_x, &
                  "X Location of generation site for internal tide", default=1.)
-  call get_param(param_file, mod, "INTERNAL_TIDE_SOURCE_Y", CS%int_tide_source_y, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_Y", CS%int_tide_source_y, &
                  "Y Location of generation site for internal tide", default=1.)
 
   CS%diag => diag
@@ -803,7 +803,7 @@ subroutine wave_structure_init(Time, G, param_file, diag, CS)
   allocate(CS%num_intfaces(isd:ied,jsd:jed))
 
   ! Write all relevant parameters to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
 end subroutine wave_structure_init
 

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -460,15 +460,15 @@ subroutine EOS_init(param_file, EOS)
   type(EOS_type),        pointer    :: EOS !< Equation of state structure
   ! Local variables
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_EOS" ! This module's name.
+  character(len=40)  :: mdl = "MOM_EOS" ! This module's name.
   character(len=40)  :: tmpstr
 
   if (.not.associated(EOS)) call EOS_allocate(EOS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mod, "EQN_OF_STATE", tmpstr, &
+  call get_param(param_file, mdl, "EQN_OF_STATE", tmpstr, &
                  "EQN_OF_STATE determines which ocean equation of state \n"//&
                  "should be used.  Currently, the valid choices are \n"//&
                  '"LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10". \n'//&
@@ -493,25 +493,25 @@ subroutine EOS_init(param_file, EOS)
 
   if (EOS%form_of_EOS == EOS_LINEAR) then
     EOS%Compressible = .false.
-    call get_param(param_file, mod, "RHO_T0_S0", EOS%Rho_T0_S0, &
+    call get_param(param_file, mdl, "RHO_T0_S0", EOS%Rho_T0_S0, &
                  "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", \n"//&
                  "this is the density at T=0, S=0.", units="kg m-3", &
                  default=1000.0)
-    call get_param(param_file, mod, "DRHO_DT", EOS%dRho_dT, &
+    call get_param(param_file, mdl, "DRHO_DT", EOS%dRho_dT, &
                  "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", \n"//&
                  "this is the partial derivative of density with \n"//&
                  "temperature.", units="kg m-3 K-1", default=-0.2)
-    call get_param(param_file, mod, "DRHO_DS", EOS%dRho_dS, &
+    call get_param(param_file, mdl, "DRHO_DS", EOS%dRho_dS, &
                  "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", \n"//&
                  "this is the partial derivative of density with \n"//&
                  "salinity.", units="kg m-3 PSU-1", default=0.8)
   endif
 
-  call get_param(param_file, mod, "EOS_QUADRATURE", EOS%EOS_quadrature, &
+  call get_param(param_file, mdl, "EOS_QUADRATURE", EOS%EOS_quadrature, &
                  "If true, always use the generic (quadrature) code \n"//&
                  "code for the integrals of density.", default=.false.)
 
-  call get_param(param_file, mod, "TFREEZE_FORM", tmpstr, &
+  call get_param(param_file, mdl, "TFREEZE_FORM", tmpstr, &
                  "TFREEZE_FORM determines which expression should be \n"//&
                  "used for the freezing point.  Currently, the valid \n"//&
                  'choices are "LINEAR", "MILLERO_78", "TEOS10"', &
@@ -529,16 +529,16 @@ subroutine EOS_init(param_file, EOS)
   end select
 
   if (EOS%form_of_TFreeze == TFREEZE_LINEAR) then
-    call get_param(param_file, mod, "TFREEZE_S0_P0",EOS%TFr_S0_P0, &
+    call get_param(param_file, mdl, "TFREEZE_S0_P0",EOS%TFr_S0_P0, &
                  "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", \n"//&
                  "this is the freezing potential temperature at \n"//&
                  "S=0, P=0.", units="deg C", default=0.0)
-    call get_param(param_file, mod, "DTFREEZE_DS",EOS%dTFr_dS, &
+    call get_param(param_file, mdl, "DTFREEZE_DS",EOS%dTFr_dS, &
                  "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", \n"//&
                  "this is the derivative of the freezing potential \n"//&
                  "temperature with salinity.", &
                  units="deg C PSU-1", default=-0.054)
-    call get_param(param_file, mod, "DTFREEZE_DP",EOS%dTFr_dP, &
+    call get_param(param_file, mdl, "DTFREEZE_DP",EOS%dTFr_dP, &
                  "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", \n"//&
                  "this is the derivative of the freezing potential \n"//&
                  "temperature with pressure.", &

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -1467,9 +1467,9 @@ subroutine MOM_checksums_init(param_file)
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_checksums" ! This module's name.
+  character(len=40)  :: mdl = "MOM_checksums" ! This module's name.
 
-  call log_version(param_file, mod, version)
+  call log_version(param_file, mdl, version)
 
 end subroutine MOM_checksums_init
 

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -270,7 +270,7 @@ subroutine close_param_file(CS, quiet_close, component)
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=128) :: docfile_default
-  character(len=40)  :: mod   ! This module's name.
+  character(len=40)  :: mdl   ! This module's name.
   integer :: i, n, num_unused
 
   if (present(quiet_close)) then ; if (quiet_close) then
@@ -287,33 +287,33 @@ subroutine close_param_file(CS, quiet_close, component)
   endif ; endif
 
   ! Log the parameters for the parser.
-  mod = "MOM_file_parser"
-  call log_version(CS, mod, version, "")
-  call log_param(CS, mod, "SEND_LOG_TO_STDOUT", &
+  mdl = "MOM_file_parser"
+  call log_version(CS, mdl, version, "")
+  call log_param(CS, mdl, "SEND_LOG_TO_STDOUT", &
                         CS%log_to_stdout, &
                  "If true, all log messages are also sent to stdout.", &
                  default=log_to_stdout_default)
-  call log_param(CS, mod, "REPORT_UNUSED_PARAMS", &
+  call log_param(CS, mdl, "REPORT_UNUSED_PARAMS", &
                         CS%report_unused, &
                  "If true, report any parameter lines that are not used \n"//&
                  "in the run.", default=report_unused_default)
-  call log_param(CS, mod, "FATAL_UNUSED_PARAMS", &
+  call log_param(CS, mdl, "FATAL_UNUSED_PARAMS", &
                         CS%unused_params_fatal, &
                  "If true, kill the run if there are any unused \n"//&
                  "parameters.", default=unused_params_fatal_default)
   docfile_default = "MOM_parameter_doc"
   if (present(component)) docfile_default = trim(component)//"_parameter_doc"
-  call log_param(CS, mod, "DOCUMENT_FILE", CS%doc_file, &
+  call log_param(CS, mdl, "DOCUMENT_FILE", CS%doc_file, &
                  "The basename for files where run-time parameters, their\n"//&
                  "settings, units and defaults are documented. Blank will\n"//&
                  "disable all parameter documentation.", default=docfile_default)
   if (len_trim(CS%doc_file) > 0) then
-    call log_param(CS, mod, "COMPLETE_DOCUMENTATION", &
+    call log_param(CS, mdl, "COMPLETE_DOCUMENTATION", &
                    CS%complete_doc, &
                   "If true, all run-time parameters are\n"//&
                   "documented in "//trim(CS%doc_file)//&
                   ".all .", default=complete_doc_default)
-    call log_param(CS, mod, "MINIMAL_DOCUMENTATION", &
+    call log_param(CS, mdl, "MINIMAL_DOCUMENTATION", &
                    CS%minimal_doc, &
                   "If true, non-default run-time parameters are\n"//&
                   "documented in "//trim(CS%doc_file)//&

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -842,9 +842,9 @@ subroutine MOM_io_init(param_file)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_io" ! This module's name.
+  character(len=40)  :: mdl = "MOM_io" ! This module's name.
 
-  call log_version(param_file, mod, version)
+  call log_version(param_file, mdl, version)
 
 end subroutine MOM_io_init
 

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1257,7 +1257,7 @@ subroutine restart_init(param_file, CS, restart_root)
 !                           module by other components.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_restart"   ! This module's name.
+  character(len=40)  :: mdl = "MOM_restart"   ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "restart_init called with an associated control structure.")
@@ -1266,8 +1266,8 @@ subroutine restart_init(param_file, CS, restart_root)
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "PARALLEL_RESTARTFILES", &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "PARALLEL_RESTARTFILES", &
                                 CS%parallel_restartfiles, &
                  "If true, each processor writes its own restart file, \n"//&
                  "otherwise a single restart file is generated", &
@@ -1275,16 +1275,16 @@ subroutine restart_init(param_file, CS, restart_root)
 
   if (present(restart_root)) then
     CS%restartfile = restart_root
-    call log_param(param_file, mod, "RESTARTFILE from argument", CS%restartfile)
+    call log_param(param_file, mdl, "RESTARTFILE from argument", CS%restartfile)
   else
-    call get_param(param_file, mod, "RESTARTFILE", CS%restartfile, &
+    call get_param(param_file, mdl, "RESTARTFILE", CS%restartfile, &
                  "The name-root of the restart file.", default="MOM.res")
   endif
-  call get_param(param_file, mod, "LARGE_FILE_SUPPORT", CS%large_file_support, &
+  call get_param(param_file, mdl, "LARGE_FILE_SUPPORT", CS%large_file_support, &
                  "If true, use the file-size limits with NetCDF large \n"//&
                  "file support (4Gb), otherwise the limit is 2Gb.", &
                  default=.true.)
-  call get_param(param_file, mod, "MAX_FIELDS", CS%max_fields, &
+  call get_param(param_file, mdl, "MAX_FIELDS", CS%max_fields, &
                  "The maximum number of restart fields that can be used.", &
                  default=100)
 

--- a/src/framework/MOM_write_cputime.F90
+++ b/src/framework/MOM_write_cputime.F90
@@ -91,7 +91,7 @@ subroutine MOM_write_cputime_init(param_file, directory, Input_start_time, CS)
   integer :: new_cputime   ! The CPU time returned by SYSTEM_CLOCK
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = 'MOM_write_cputime'  ! This module's name.
+  character(len=40)  :: mdl = 'MOM_write_cputime'  ! This module's name.
 
   if (.not.associated(CS)) then
     allocate(CS)
@@ -100,8 +100,8 @@ subroutine MOM_write_cputime_init(param_file, directory, Input_start_time, CS)
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "MAXCPU", CS%maxcpu, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "MAXCPU", CS%maxcpu, &
                  "The maximum amount of cpu time per processor for which \n"//&
                  "MOM should run before saving a restart file and \n"//&
                  "quitting with a return value that indicates that a \n"//&
@@ -111,10 +111,10 @@ subroutine MOM_write_cputime_init(param_file, directory, Input_start_time, CS)
                  "seconds, so the actual CPU time used is larger by a \n"//&
                  "factor of the number of processors used.", &
                  units="wall-clock seconds", default=-1.0)
-  call get_param(param_file, mod, "CPU_TIME_FILE", CS%CPUfile, &
+  call get_param(param_file, mdl, "CPU_TIME_FILE", CS%CPUfile, &
                  "The file into which CPU time is written.",default="CPU_stats")
   CS%CPUfile = trim(directory)//trim(CS%CPUfile)
-  call log_param(param_file, mod, "directory/CPU_TIME_FILE", CS%CPUfile)
+  call log_param(param_file, mdl, "directory/CPU_TIME_FILE", CS%CPUfile)
 #ifdef STATSLABEL
   CS%CPUfile = trim(CS%CPUfile)//"."//trim(adjustl(STATSLABEL))
 #endif

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1208,7 +1208,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, fluxes, Ti
   character(len=200) :: config
   character(len=200) :: IC_file,filename,inputdir
   character(len=40)  :: var_name
-  character(len=40)  :: mod = "MOM_ice_shelf"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_ice_shelf"  ! This module's name.
   character(len=2)   :: procnum
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed, Isdq, Iedq, Jsdq, Jedq, iters
   integer :: wd_halos(2)
@@ -1273,42 +1273,42 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, fluxes, Ti
   CS%use_reproducing_sums = .false.
   CS%switch_var = .false.
 
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "DEBUG_IS", CS%debug, default=.false.)
-  call get_param(param_file, mod, "DYNAMIC_SHELF_MASS", CS%shelf_mass_is_dynamic, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "DEBUG_IS", CS%debug, default=.false.)
+  call get_param(param_file, mdl, "DYNAMIC_SHELF_MASS", CS%shelf_mass_is_dynamic, &
                  "If true, the ice sheet mass can evolve with time.", &
                  default=.false.)
   if (CS%shelf_mass_is_dynamic) then
-    call get_param(param_file, mod, "OVERRIDE_SHELF_MOVEMENT", CS%override_shelf_movement, &
+    call get_param(param_file, mdl, "OVERRIDE_SHELF_MOVEMENT", CS%override_shelf_movement, &
                  "If true, user provided code specifies the ice-shelf \n"//&
                  "movement instead of the dynamic ice model.", default=.false.)
-    call get_param(param_file, mod, "GROUNDING_LINE_INTERPOLATE", CS%GL_regularize, &
+    call get_param(param_file, mdl, "GROUNDING_LINE_INTERPOLATE", CS%GL_regularize, &
                  "THIS PARAMETER NEEDS A DESCRIPTION.", default=.false.)
-    call get_param(param_file, mod, "GROUNDING_LINE_INTERP_SUBGRID_N", CS%n_sub_regularize, &
+    call get_param(param_file, mdl, "GROUNDING_LINE_INTERP_SUBGRID_N", CS%n_sub_regularize, &
                  "THIS PARAMETER NEEDS A DESCRIPTION.", default=0)
-    call get_param(param_file, mod, "GROUNDING_LINE_COUPLE", CS%GL_couple, &
+    call get_param(param_file, mdl, "GROUNDING_LINE_COUPLE", CS%GL_couple, &
                  "THIS PARAMETER NEEDS A DESCRIPTION.", default=.false.)
     if (CS%GL_regularize) CS%GL_couple = .false.
     if (CS%GL_regularize .and. (CS%n_sub_regularize.eq.0)) call MOM_error (FATAL, &
       "GROUNDING_LINE_INTERP_SUBGRID_N must be a positive integer if GL regularization is used")
   endif
-  call get_param(param_file, mod, "SHELF_THERMO", CS%isthermo, &
+  call get_param(param_file, mdl, "SHELF_THERMO", CS%isthermo, &
                  "If true, use a thermodynamically interactive ice shelf.", &
                  default=.false.)
-  call get_param(param_file, mod, "SHELF_THREE_EQN", CS%threeeq, &
+  call get_param(param_file, mdl, "SHELF_THREE_EQN", CS%threeeq, &
                  "If true, use the three equation expression of \n"//&
                  "consistency to calculate the fluxes at the ice-ocean \n"//&
                  "interface.", default=.true.)
-  call get_param(param_file, mod, "SHELF_INSULATOR", CS%insulator, &
+  call get_param(param_file, mdl, "SHELF_INSULATOR", CS%insulator, &
                  "If true, the ice shelf is a perfect insulatior \n"//&
                  "(no conduction).", default=.false.)
-  call get_param(param_file, mod, "MELTING_CUTOFF_DEPTH", CS%cutoff_depth, &
+  call get_param(param_file, mdl, "MELTING_CUTOFF_DEPTH", CS%cutoff_depth, &
                  "Depth above which the melt is set to zero (it must be >= 0) \n"//&
                  "Default value won't affect the solution.", default=0.0)
   if (CS%cutoff_depth < 0.) &
      call MOM_error(WARNING,"Initialize_ice_shelf: MELTING_CUTOFF_DEPTH must be >= 0.")
 
-  call get_param(param_file, mod, "CONST_SEA_LEVEL", CS%constant_sea_level, &
+  call get_param(param_file, mdl, "CONST_SEA_LEVEL", CS%constant_sea_level, &
                  "If true, apply evaporative, heat and salt fluxes in \n"//&
                   "the sponge region. This will avoid a large increase \n"//&
                  "in sea level. This option is needed for some of the \n"//&
@@ -1316,40 +1316,40 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, fluxes, Ti
                  "IMPORTANT: it is not currently possible to do \n"//&
                  "prefect restarts using this flag.", default=.false.)
 
-  call get_param(param_file, mod, "ISOMIP_S_SUR_SPONGE", &
+  call get_param(param_file, mdl, "ISOMIP_S_SUR_SPONGE", &
                 CS%S0, "Surface salinity in the resoring region.", &
                 default=33.8, do_not_log=.true.)
 
-  call get_param(param_file, mod, "ISOMIP_T_SUR_SPONGE", &
+  call get_param(param_file, mdl, "ISOMIP_T_SUR_SPONGE", &
                 CS%T0, "Surface temperature in the resoring region.", &
                 default=-1.9, do_not_log=.true.)
 
-  call get_param(param_file, mod, "SHELF_3EQ_GAMMA", CS%const_gamma, &
+  call get_param(param_file, mdl, "SHELF_3EQ_GAMMA", CS%const_gamma, &
                  "If true, user specifies a constant nondimensional heat-transfer coefficient \n"//&
                  "(GAMMA_T_3EQ), from which the salt-transfer coefficient is then computed \n"//&
                  " as GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.", default=.false.)
-  if (CS%const_gamma) call get_param(param_file, mod, "SHELF_3EQ_GAMMA_T", CS%Gamma_T_3EQ, &
+  if (CS%const_gamma) call get_param(param_file, mdl, "SHELF_3EQ_GAMMA_T", CS%Gamma_T_3EQ, &
                  "Nondimensional heat-transfer coefficient.",default=2.2E-2, &
                   units="nondim.", fail_if_missing=.true.)
 
-  call get_param(param_file, mod, "ICE_SHELF_MASS_FROM_FILE", &
+  call get_param(param_file, mdl, "ICE_SHELF_MASS_FROM_FILE", &
                 CS%mass_from_file, "Read the mass of the &
                 ice shelf (every time step) from a file.", default=.false.)
 
   if (CS%threeeq) &
-    call get_param(param_file, mod, "SHELF_S_ROOT", CS%find_salt_root, &
+    call get_param(param_file, mdl, "SHELF_S_ROOT", CS%find_salt_root, &
                  "If SHELF_S_ROOT = True, salinity at the ice/ocean interface (Sbdry) \n "//&
                  "is computed from a quadratic equation. Otherwise, the previous \n"//&
                  "interactive method to estimate Sbdry is used.", default=.false.)
   if (CS%find_salt_root) then ! read liquidus coeffs.
-     call get_param(param_file, mod, "TFREEZE_S0_P0",CS%lambda1, &
+     call get_param(param_file, mdl, "TFREEZE_S0_P0",CS%lambda1, &
                  "this is the freezing potential temperature at \n"//&
                  "S=0, P=0.", units="deg C", default=0.0, do_not_log=.true.)
-    call get_param(param_file, mod, "DTFREEZE_DS",CS%lambda1, &
+    call get_param(param_file, mdl, "DTFREEZE_DS",CS%lambda1, &
                  "this is the derivative of the freezing potential \n"//&
                  "temperature with salinity.", &
                  units="deg C PSU-1", default=-0.054, do_not_log=.true.)
-    call get_param(param_file, mod, "DTFREEZE_DP",CS%lambda3, &
+    call get_param(param_file, mdl, "DTFREEZE_DP",CS%lambda3, &
                  "this is the derivative of the freezing potential \n"//&
                  "temperature with pressure.", &
                  units="deg C Pa-1", default=0.0, do_not_log=.true.)
@@ -1357,79 +1357,79 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, fluxes, Ti
   endif
 
   if (.not.CS%threeeq) &
-    call get_param(param_file, mod, "SHELF_2EQ_GAMMA_T", CS%gamma_t, &
+    call get_param(param_file, mdl, "SHELF_2EQ_GAMMA_T", CS%gamma_t, &
                  "If SHELF_THREE_EQN is false, this the fixed turbulent \n"//&
                  "exchange velocity at the ice-ocean interface.", &
                  units="m s-1", fail_if_missing=.true.)
 
-  call get_param(param_file, mod, "G_EARTH", CS%g_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", CS%g_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
-  call get_param(param_file, mod, "C_P", CS%Cp, &
+  call get_param(param_file, mdl, "C_P", CS%Cp, &
                  "The heat capacity of sea water.", units="J kg-1 K-1", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0) !### MAKE THIS A SEPARATE PARAMETER.
-  call get_param(param_file, mod, "C_P_ICE", CS%Cp_ice, &
+  call get_param(param_file, mdl, "C_P_ICE", CS%Cp_ice, &
                  "The heat capacity of ice.", units="J kg-1 K-1", &
                  default=2.10e3)
 
-  call get_param(param_file, mod, "ICE_SHELF_FLUX_FACTOR", CS%flux_factor, &
+  call get_param(param_file, mdl, "ICE_SHELF_FLUX_FACTOR", CS%flux_factor, &
                  "Non-dimensional factor applied to shelf thermodynamic \n"//&
                  "fluxes.", units="none", default=1.0)
 
-  call get_param(param_file, mod, "KV_ICE", CS%kv_ice, &
+  call get_param(param_file, mdl, "KV_ICE", CS%kv_ice, &
                  "The viscosity of the ice.", units="m2 s-1", default=1.0e10)
-  call get_param(param_file, mod, "KV_MOLECULAR", CS%kv_molec, &
+  call get_param(param_file, mdl, "KV_MOLECULAR", CS%kv_molec, &
                  "The molecular kinimatic viscosity of sea water at the \n"//&
                  "freezing temperature.", units="m2 s-1", default=1.95e-6)
-  call get_param(param_file, mod, "ICE_SHELF_SALINITY", CS%Salin_ice, &
+  call get_param(param_file, mdl, "ICE_SHELF_SALINITY", CS%Salin_ice, &
                  "The salinity of the ice inside the ice shelf.", units="PSU", &
                  default=0.0)
-  call get_param(param_file, mod, "ICE_SHELF_TEMPERATURE", CS%Temp_ice, &
+  call get_param(param_file, mdl, "ICE_SHELF_TEMPERATURE", CS%Temp_ice, &
                  "The temperature at the center of the ice shelf.", &
                  units = "degC", default=-15.0)
-  call get_param(param_file, mod, "KD_SALT_MOLECULAR", CS%kd_molec_salt, &
+  call get_param(param_file, mdl, "KD_SALT_MOLECULAR", CS%kd_molec_salt, &
                  "The molecular diffusivity of salt in sea water at the \n"//&
                  "freezing point.", units="m2 s-1", default=8.02e-10)
-  call get_param(param_file, mod, "KD_TEMP_MOLECULAR", CS%kd_molec_temp, &
+  call get_param(param_file, mdl, "KD_TEMP_MOLECULAR", CS%kd_molec_temp, &
                  "The molecular diffusivity of heat in sea water at the \n"//&
                  "freezing point.", units="m2 s-1", default=1.41e-7)
-  call get_param(param_file, mod, "RHO_0", CS%density_ocean_avg, &
+  call get_param(param_file, mdl, "RHO_0", CS%density_ocean_avg, &
                  "avg ocean density used in floatation cond", &
                  units="kg m-3", default=1035.)
-  call get_param(param_file, mod, "DT_FORCING", CS%time_step, &
+  call get_param(param_file, mdl, "DT_FORCING", CS%time_step, &
                  "The time step for changing forcing, coupling with other \n"//&
                  "components, or potentially writing certain diagnostics. \n"//&
                  "The default value is given by DT.", units="s", default=0.0)
-  call get_param(param_file, mod, "SHELF_DIAG_TIMESTEP", CS%velocity_update_time_step, &
+  call get_param(param_file, mdl, "SHELF_DIAG_TIMESTEP", CS%velocity_update_time_step, &
                  "A timestep to use for diagnostics of the shelf.", default=0.0)
 
-  call get_param(param_file, mod, "COL_THICK_MELT_THRESHOLD", CS%col_thick_melt_threshold, &
+  call get_param(param_file, mdl, "COL_THICK_MELT_THRESHOLD", CS%col_thick_melt_threshold, &
                  "The minimum ML thickness where melting is allowed.", units="m", &
                  default=0.0)
 
-  call get_param(param_file, mod, "READ_TIDEAMP", read_TIDEAMP, &
+  call get_param(param_file, mdl, "READ_TIDEAMP", read_TIDEAMP, &
                  "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
                  "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
 
   call safe_alloc_ptr(CS%utide,isd,ied,jsd,jed)   ; CS%utide(:,:) = 0.0
 
   if (read_TIDEAMP) then
-    call get_param(param_file, mod, "TIDEAMP_FILE", TideAmp_file, &
+    call get_param(param_file, mdl, "TIDEAMP_FILE", TideAmp_file, &
                  "The path to the file containing the spatially varying \n"//&
                  "tidal amplitudes.", &
                  default="tideamp.nc")
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     inputdir = slasher(inputdir)
     TideAmp_file = trim(inputdir) // trim(TideAmp_file)
     call read_data(TideAmp_file,'tideamp',CS%utide,domain=G%domain%mpp_domain,timelevel=1)
   else
-    call get_param(param_file, mod, "UTIDE", utide, &
+    call get_param(param_file, mdl, "UTIDE", utide, &
                  "The constant tidal amplitude used with INT_TIDE_DISSIPATION.", &
                  units="m s-1", default=0.0)
     CS%utide = utide
@@ -1441,54 +1441,54 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, fluxes, Ti
 
   if (CS%shelf_mass_is_dynamic .and. .not.CS%override_shelf_movement) then
 
-    call get_param(param_file, mod, "A_GLEN_ISOTHERM", CS%A_glen_isothermal, &
+    call get_param(param_file, mdl, "A_GLEN_ISOTHERM", CS%A_glen_isothermal, &
                  "Ice viscosity parameter in Glen's Law", &
                  units="Pa -1/3 a", default=9.461e-18)
-    call get_param(param_file, mod, "GLEN_EXPONENT", CS%n_glen, &
+    call get_param(param_file, mdl, "GLEN_EXPONENT", CS%n_glen, &
                  "nonlinearity exponent in Glen's Law", &
                   units="none", default=3.)
-    call get_param(param_file, mod, "MIN_STRAIN_RATE_GLEN", CS%eps_glen_min, &
+    call get_param(param_file, mdl, "MIN_STRAIN_RATE_GLEN", CS%eps_glen_min, &
                  "min. strain rate to avoid infinite Glen's law viscosity", &
                  units="a-1", default=1.e-12)
-    call get_param(param_file, mod, "BASAL_FRICTION_COEFF", CS%C_basal_friction, &
+    call get_param(param_file, mdl, "BASAL_FRICTION_COEFF", CS%C_basal_friction, &
                  "ceofficient in sliding law \tau_b = C u^(n_basal_friction)", &
                  units="Pa (m-a)-(n_basal_friction)", fail_if_missing=.true.)
-    call get_param(param_file, mod, "BASAL_FRICTION_EXP", CS%n_basal_friction, &
+    call get_param(param_file, mdl, "BASAL_FRICTION_EXP", CS%n_basal_friction, &
                  "exponent in sliding law \tau_b = C u^(m_slide)", &
                  units="none", fail_if_missing=.true.)
-    call get_param(param_file, mod, "DENSITY_ICE", CS%density_ice, &
+    call get_param(param_file, mdl, "DENSITY_ICE", CS%density_ice, &
                  "A typical density of ice.", units="kg m-3", default=917.0)
 
-    call get_param(param_file, mod, "INPUT_FLUX_ICE_SHELF", CS%input_flux, &
+    call get_param(param_file, mdl, "INPUT_FLUX_ICE_SHELF", CS%input_flux, &
                  "volume flux at upstream boundary", &
                  units="m2 s-1", default=0.)
-    call get_param(param_file, mod, "INPUT_THICK_ICE_SHELF", CS%input_thickness, &
+    call get_param(param_file, mdl, "INPUT_THICK_ICE_SHELF", CS%input_thickness, &
                  "flux thickness at upstream boundary", &
                  units="m", default=1000.)
-    call get_param(param_file, mod, "ICE_VELOCITY_TIMESTEP", CS%velocity_update_time_step, &
+    call get_param(param_file, mdl, "ICE_VELOCITY_TIMESTEP", CS%velocity_update_time_step, &
                  "seconds between ice velocity calcs", units="s", &
                  fail_if_missing=.true.)
 
-    call get_param(param_file, mod, "CONJUGATE_GRADIENT_TOLERANCE", CS%cg_tolerance, &
+    call get_param(param_file, mdl, "CONJUGATE_GRADIENT_TOLERANCE", CS%cg_tolerance, &
         "tolerance in CG solver, relative to initial residual", default=1.e-6)
-    call get_param(param_file, mod, "ICE_NONLINEAR_TOLERANCE", &
+    call get_param(param_file, mdl, "ICE_NONLINEAR_TOLERANCE", &
         CS%nonlinear_tolerance,"nonlin tolerance in iterative velocity solve",default=1.e-6)
-    call get_param(param_file, mod, "CONJUGATE_GRADIENT_MAXIT", CS%cg_max_iterations, &
+    call get_param(param_file, mdl, "CONJUGATE_GRADIENT_MAXIT", CS%cg_max_iterations, &
         "max iteratiions in CG solver", default=2000)
-    call get_param(param_file, mod, "THRESH_FLOAT_COL_DEPTH", CS%thresh_float_col_depth, &
+    call get_param(param_file, mdl, "THRESH_FLOAT_COL_DEPTH", CS%thresh_float_col_depth, &
         "min ocean thickness to consider ice *floating*; \n"// &
         "will only be important with use of tides", &
         units="m",default=1.e-3)
 
-    call get_param(param_file, mod, "SHELF_MOVING_FRONT", CS%moving_shelf_front, &
+    call get_param(param_file, mdl, "SHELF_MOVING_FRONT", CS%moving_shelf_front, &
                  "whether or not to advance shelf front (and calve..)")
-    call get_param(param_file, mod, "CALVE_TO_MASK", CS%calve_to_mask, &
+    call get_param(param_file, mdl, "CALVE_TO_MASK", CS%calve_to_mask, &
                  "if true, do not allow an ice shelf where prohibited by a mask")
-    call get_param(param_file, mod, "ICE_SHELF_CFL_FACTOR", CS%CFL_factor, &
+    call get_param(param_file, mdl, "ICE_SHELF_CFL_FACTOR", CS%CFL_factor, &
         "limit timestep as a factor of min (\Delta x / u); \n"// &
         "only important for ice-only model", &
         default=0.25)
-    call get_param(param_file, mod, "NONLIN_SOLVE_ERR_MODE", CS%nonlin_solve_err_mode, &
+    call get_param(param_file, mdl, "NONLIN_SOLVE_ERR_MODE", CS%nonlin_solve_err_mode, &
         "choose whether nonlin error in vel solve is based on nonlinear residual (1) \n"// &
         "or relative change since last iteration (2)", &
         default=1)
@@ -1502,28 +1502,28 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, fluxes, Ti
   else
     CS%nstep_velocity = 0
     ! This is here because of inconsistent defaults.  I don't know why.  RWH
-    call get_param(param_file, mod, "DENSITY_ICE", CS%density_ice, &
+    call get_param(param_file, mdl, "DENSITY_ICE", CS%density_ice, &
                  "A typical density of ice.", units="kg m-3", default=900.0)
   endif
 
-  call get_param(param_file, mod, "MIN_THICKNESS_SIMPLE_CALVE", &
+  call get_param(param_file, mdl, "MIN_THICKNESS_SIMPLE_CALVE", &
                 CS%min_thickness_simple_calve, &
                  "min thickness rule for VERY simple calving law",&
                  units="m", default=0.0)
 
-  call get_param(param_file, mod, "WRITE_OUTPUT_TO_FILE", &
+  call get_param(param_file, mdl, "WRITE_OUTPUT_TO_FILE", &
         CS%write_output_to_file, "for debugging purposes",default=.false.)
 
-  call get_param(param_file, mod, "USTAR_SHELF_BG", CS%ustar_bg, &
+  call get_param(param_file, mdl, "USTAR_SHELF_BG", CS%ustar_bg, &
                  "The minimum value of ustar under ice sheves.", units="m s-1", &
                  default=0.0)
-  call get_param(param_file, mod, "CDRAG_SHELF", cdrag, &
+  call get_param(param_file, mdl, "CDRAG_SHELF", cdrag, &
        "CDRAG is the drag coefficient relating the magnitude of \n"//&
        "the velocity field to the surface stress.", units="nondim", &
        default=0.003)
   CS%cdrag = cdrag
   if (CS%ustar_bg <= 0.0) then
-    call get_param(param_file, mod, "DRAG_BG_VEL_SHELF", drag_bg_vel, &
+    call get_param(param_file, mdl, "DRAG_BG_VEL_SHELF", drag_bg_vel, &
                  "DRAG_BG_VEL is either the assumed bottom velocity (with \n"//&
                  "LINEAR_DRAG) or an unresolved  velocity that is \n"//&
                  "combined with the resolved velocity to estimate the \n"//&
@@ -1843,17 +1843,17 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, fluxes, Ti
 
     call MOM_mesg("  MOM_ice_shelf.F90, initialize_ice_shelf: reading calving_mask")
 
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     inputdir = slasher(inputdir)
-    call get_param(param_file, mod, "CALVING_MASK_FILE", IC_file, &
+    call get_param(param_file, mdl, "CALVING_MASK_FILE", IC_file, &
                  "The file with a mask for where calving might occur.", &
                  default="ice_shelf_h.nc")
-    call get_param(param_file, mod, "CALVING_MASK_VARNAME", var_name, &
+    call get_param(param_file, mdl, "CALVING_MASK_VARNAME", var_name, &
                  "The variable to use in masking calving.", &
                  default="area_shelf_h")
 
     filename = trim(inputdir)//trim(IC_file)
-    call log_param(param_file, mod, "INPUTDIR/CALVING_MASK_FILE", filename)
+    call log_param(param_file, mdl, "INPUTDIR/CALVING_MASK_FILE", filename)
     if (.not.file_exists(filename, G%Domain)) call MOM_error(FATAL, &
        " calving mask file: Unable to open "//trim(filename))
 
@@ -1887,10 +1887,10 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, fluxes, Ti
     endif
   endif
 
-  call get_param(param_file, mod, "SAVE_INITIAL_CONDS", save_IC, &
+  call get_param(param_file, mdl, "SAVE_INITIAL_CONDS", save_IC, &
                  "If true, save the ice shelf initial conditions.", &
                  default=.false.)
-  if (save_IC) call get_param(param_file, mod, "SHELF_IC_OUTPUT_FILE", IC_file,&
+  if (save_IC) call get_param(param_file, mdl, "SHELF_IC_OUTPUT_FILE", IC_file,&
                  "The name-root of the output file for the ice shelf \n"//&
                  "initial conditions.", default="MOM_Shelf_IC")
 
@@ -1984,7 +1984,7 @@ subroutine initialize_shelf_mass(G, param_file, CS, new_sim)
   character(len=240) :: config, inputdir, shelf_file, filename
   character(len=120) :: shelf_mass_var  ! The name of shelf mass in the file.
   character(len=120) :: shelf_area_var ! The name of shelf area in the file.
-  character(len=40)  :: mod = "MOM_ice_shelf"
+  character(len=40)  :: mdl = "MOM_ice_shelf"
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
   if (.not. present(new_sim)) then
@@ -1993,7 +1993,7 @@ subroutine initialize_shelf_mass(G, param_file, CS, new_sim)
     new_sim_2 = .false.
   endif
 
-  call get_param(param_file, mod, "ICE_SHELF_CONFIG", config, &
+  call get_param(param_file, mdl, "ICE_SHELF_CONFIG", config, &
                  "A string that specifies how the ice shelf is \n"//&
                  "initialized. Valid options include:\n"//&
                  " \tfile\t Read from a file.\n"//&
@@ -2006,23 +2006,23 @@ subroutine initialize_shelf_mass(G, param_file, CS, new_sim)
 
       call time_interp_external_init()
 
-      call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+      call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
       inputdir = slasher(inputdir)
 
-      call get_param(param_file, mod, "SHELF_FILE", shelf_file, &
+      call get_param(param_file, mdl, "SHELF_FILE", shelf_file, &
               "If DYNAMIC_SHELF_MASS = True, OVERRIDE_SHELF_MOVEMENT = True \n"//&
               "and ICE_SHELF_MASS_FROM_FILE = True, this is the file from \n"//&
               "which to read the shelf mass and area.", &
                default="shelf_mass.nc")
-      call get_param(param_file, mod, "SHELF_MASS_VAR", shelf_mass_var, &
+      call get_param(param_file, mdl, "SHELF_MASS_VAR", shelf_mass_var, &
                  "The variable in SHELF_FILE with the shelf mass.", &
                  default="shelf_mass")
-      call get_param(param_file, mod, "READ_SHELF_AREA", read_shelf_area, &
+      call get_param(param_file, mdl, "READ_SHELF_AREA", read_shelf_area, &
                  "If true, also read the area covered by ice-shelf from SHELF_FILE.", &
                  default=.false.)
 
       filename = trim(slasher(inputdir))//trim(shelf_file)
-      call log_param(param_file, mod, "INPUTDIR/SHELF_FILE", filename)
+      call log_param(param_file, mdl, "INPUTDIR/SHELF_FILE", filename)
 
       if (CS%DEBUG) then
          CS%id_read_mass = init_external_field(filename,shelf_mass_var, &
@@ -2034,7 +2034,7 @@ subroutine initialize_shelf_mass(G, param_file, CS, new_sim)
       endif
 
       if (read_shelf_area) then
-         call get_param(param_file, mod, "SHELF_AREA_VAR", shelf_area_var, &
+         call get_param(param_file, mdl, "SHELF_AREA_VAR", shelf_area_var, &
                   "The variable in SHELF_FILE with the shelf area.", &
                   default="shelf_area")
 

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -54,10 +54,10 @@ subroutine initialize_ice_thickness (h_shelf, area_shelf_h, hmask, G, PF)
   type(ocean_grid_type), intent(in)            :: G    !< The ocean's grid structure
   type(param_file_type), intent(in)            :: PF
 
-  character(len=40)  :: mod = "initialize_ice_thickness" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_ice_thickness" ! This subroutine's name.
   character(len=200) :: config
 
-  call get_param(PF, mod, "ICE_PROFILE_CONFIG", config, &
+  call get_param(PF, mdl, "ICE_PROFILE_CONFIG", config, &
                  "This specifies how the initial ice profile is specified. \n"//&
                  "Valid values are: CHANNEL, FILE, and USER.", &
                  fail_if_missing=.true.)
@@ -83,27 +83,27 @@ subroutine initialize_ice_thickness_from_file (h_shelf, area_shelf_h, hmask, G, 
   !  h_shelf and area_shelf_h in m (and dimensionless) and updates hmask
   character(len=200) :: filename,thickness_file,inputdir ! Strings for file/path
   character(len=200) :: thickness_varname, area_varname! Variable name in file
-  character(len=40)  :: mod = "initialize_ice_thickness_from_file" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_ice_thickness_from_file" ! This subroutine's name.
   integer :: i, j, isc, jsc, iec, jec
   real :: len_sidestress, mask, udh
 
   call MOM_mesg("  MOM_ice_shelf_init_profile.F90, initialize_thickness_from_file: reading thickness")
 
-  call get_param(PF, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(PF, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
-  call get_param(PF, mod, "ICE_THICKNESS_FILE", thickness_file, &
+  call get_param(PF, mdl, "ICE_THICKNESS_FILE", thickness_file, &
                  "The file from which the bathymetry is read.", &
                  default="ice_shelf_h.nc")
-  call get_param(PF, mod, "LEN_SIDE_STRESS", len_sidestress, &
+  call get_param(PF, mdl, "LEN_SIDE_STRESS", len_sidestress, &
                  "position past which shelf sides are stress free.", &
                  default=0.0, units="axis_units")
 
   filename = trim(inputdir)//trim(thickness_file)
-  call log_param(PF, mod, "INPUTDIR/THICKNESS_FILE", filename)
-  call get_param(PF, mod, "ICE_THICKNESS_VARNAME", thickness_varname, &
+  call log_param(PF, mdl, "INPUTDIR/THICKNESS_FILE", filename)
+  call get_param(PF, mdl, "ICE_THICKNESS_VARNAME", thickness_varname, &
                  "The name of the thickness variable in ICE_THICKNESS_FILE.", &
                  default="h_shelf")
-  call get_param(PF, mod, "ICE_AREA_VARNAME", area_varname, &
+  call get_param(PF, mdl, "ICE_AREA_VARNAME", area_varname, &
                  "The name of the area variable in ICE_THICKNESS_FILE.", &
                  default="area_shelf_h")
 
@@ -113,7 +113,7 @@ subroutine initialize_ice_thickness_from_file (h_shelf, area_shelf_h, hmask, G, 
   call read_data(filename,trim(thickness_varname),h_shelf,domain=G%Domain%mpp_domain)
   call read_data(filename,trim(area_varname),area_shelf_h,domain=G%Domain%mpp_domain)
 
-!  call get_param(PF, mod, "ICE_BOUNDARY_CONFIG", config, &
+!  call get_param(PF, mdl, "ICE_BOUNDARY_CONFIG", config, &
 !                 "This specifies how the ice domain boundary is specified", &
 !                 fail_if_missing=.true.)
 
@@ -145,7 +145,7 @@ subroutine initialize_ice_thickness_from_file (h_shelf, area_shelf_h, hmask, G, 
       elseif ((area_shelf_h(i,j) .gt. 0) .and. (area_shelf_h(i,j) .le. G%areaT(i,j))) then
         hmask(i,j) = 2.
       else
-        call MOM_error(FATAL,mod// " AREA IN CELL OUT OF RANGE")
+        call MOM_error(FATAL,mdl// " AREA IN CELL OUT OF RANGE")
       endif
     enddo
   enddo
@@ -160,7 +160,7 @@ subroutine initialize_ice_thickness_channel (h_shelf, area_shelf_h, hmask, G, PF
   type(ocean_grid_type), intent(in)            :: G    !< The ocean's grid structure
   type(param_file_type), intent(in)            :: PF
 
-  character(len=40)  :: mod = "initialize_ice_shelf_thickness_channel" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_ice_shelf_thickness_channel" ! This subroutine's name.
   real :: max_draft, min_draft, flat_shelf_width, c1, slope_pos
   real :: edge_pos, shelf_slope_scale, Rho_ocean
   integer :: i, j, jsc, jec, jsd, jed, jedg, nyh, isc, iec, isd, ied
@@ -171,17 +171,17 @@ subroutine initialize_ice_thickness_channel (h_shelf, area_shelf_h, hmask, G, PF
   nyh = G%domain%njhalo ; jedg = G%domain%njglobal+nyh
   j_off = G%jdg_offset
 
-  call MOM_mesg(mod//": setting thickness")
+  call MOM_mesg(mdl//": setting thickness")
 
-  call get_param(PF, mod, "SHELF_MAX_DRAFT", max_draft, &
+  call get_param(PF, mdl, "SHELF_MAX_DRAFT", max_draft, &
                  units="m", default=1.0)
-  call get_param(PF, mod, "SHELF_MIN_DRAFT", min_draft, &
+  call get_param(PF, mdl, "SHELF_MIN_DRAFT", min_draft, &
                  units="m", default=1.0)
-  call get_param(PF, mod, "FLAT_SHELF_WIDTH", flat_shelf_width, &
+  call get_param(PF, mdl, "FLAT_SHELF_WIDTH", flat_shelf_width, &
                  units="axis_units", default=0.0)
-  call get_param(PF, mod, "SHELF_SLOPE_SCALE", shelf_slope_scale, &
+  call get_param(PF, mdl, "SHELF_SLOPE_SCALE", shelf_slope_scale, &
                  units="axis_units", default=0.0)
-  call get_param(PF, mod, "SHELF_EDGE_POS_0", edge_pos, &
+  call get_param(PF, mdl, "SHELF_EDGE_POS_0", edge_pos, &
                  units="axis_units", default=0.0)
 
   slope_pos = edge_pos - flat_shelf_width
@@ -252,15 +252,15 @@ end subroutine initialize_ice_thickness_channel
 !   real, intent(inout), dimension(:,:)               :: hmask, h_boundary_values
 !   type(param_file_type), intent(in)                 :: PF
 
-!   character(len=40)  :: mod = "initialize_ice_shelf_boundary" ! This subroutine's name.
+!   character(len=40)  :: mdl = "initialize_ice_shelf_boundary" ! This subroutine's name.
 !   character(len=200) :: config
 !   logical flux_bdry
 
-!   call get_param(PF, mod, "ICE_BOUNDARY_CONFIG", config, &
+!   call get_param(PF, mdl, "ICE_BOUNDARY_CONFIG", config, &
 !                  "This specifies how the ice domain boundary is specified. \n"//&
 !                  "valid values include CHANNEL, FILE and USER.", &
 !                  fail_if_missing=.true.)
-!   call get_param(PF, mod, "ICE_BOUNDARY_FLUX_CONDITION", flux_bdry, &
+!   call get_param(PF, mdl, "ICE_BOUNDARY_FLUX_CONDITION", flux_bdry, &
 !                  "This specifies whether mass input is a dirichlet or \n"//&
 !                  "flux condition", default=.true.)
 
@@ -299,23 +299,23 @@ end subroutine initialize_ice_thickness_channel
 !   logical, intent(in)                               :: flux_bdry
 !   type (param_file_type), intent(in)                :: PF
 
-!   character(len=40)  :: mod = "initialize_ice_shelf_boundary_channel" ! This subroutine's name.
+!   character(len=40)  :: mdl = "initialize_ice_shelf_boundary_channel" ! This subroutine's name.
 !   integer :: i, j, isd, jsd, is, js, iegq, jegq, giec, gjec, gisc, gjsc, isc, jsc, iec, jec, ied, jed
 !   real                                                  :: lenlat, input_thick, input_flux, len_stress
 
-!   call get_param(PF, mod, "LENLAT", lenlat, fail_if_missing=.true.)
+!   call get_param(PF, mdl, "LENLAT", lenlat, fail_if_missing=.true.)
 
-!   call get_param(PF, mod, "INPUT_FLUX_ICE_SHELF", input_flux, &
+!   call get_param(PF, mdl, "INPUT_FLUX_ICE_SHELF", input_flux, &
 !                  "volume flux at upstream boundary", &
 !                  units="m2 s-1", default=0.)
-!   call get_param(PF, mod, "INPUT_THICK_ICE_SHELF", input_thick, &
+!   call get_param(PF, mdl, "INPUT_THICK_ICE_SHELF", input_thick, &
 !                  "flux thickness at upstream boundary", &
 !                  units="m", default=1000.)
-!   call get_param(PF, mod, "LEN_SIDE_STRESS", len_stress, &
+!   call get_param(PF, mdl, "LEN_SIDE_STRESS", len_stress, &
 !                  "maximum position of no-flow condition in along-flow direction", &
 !                  units="km", default=0.)
 
-!   call MOM_mesg(mod//": setting boundary")
+!   call MOM_mesg(mdl//": setting boundary")
 
 !   isd = G%isd ; ied = G%ied
 !   jsd = G%jsd ; jed = G%jed

--- a/src/ice_shelf/user_shelf_init.F90
+++ b/src/ice_shelf/user_shelf_init.F90
@@ -135,7 +135,7 @@ subroutine USER_initialize_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, 
   real :: min_draft  ! The minimum ocean draft of the ice shelf, in m.
   real :: flat_shelf_width ! The range over which the shelf is min_draft thick.
   real :: c1 ! The maximum depths in m.
-  character(len=40) :: mod = "USER_initialize_shelf_mass" ! This subroutine's name.
+  character(len=40) :: mdl = "USER_initialize_shelf_mass" ! This subroutine's name.
   integer :: i, j
 
   ! call MOM_error(FATAL, "USER_shelf_init.F90, USER_set_shelf_mass: " // &
@@ -145,23 +145,23 @@ subroutine USER_initialize_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, 
 
   ! Read all relevant parameters and write them to the model log.
   if (first_call) call write_user_log(param_file)
-  call get_param(param_file, mod, "RHO_0", CS%Rho_ocean, &
+  call get_param(param_file, mdl, "RHO_0", CS%Rho_ocean, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "SHELF_MAX_DRAFT", CS%max_draft, &
+  call get_param(param_file, mdl, "SHELF_MAX_DRAFT", CS%max_draft, &
                  units="m", default=1.0)
-  call get_param(param_file, mod, "SHELF_MIN_DRAFT", CS%min_draft, &
+  call get_param(param_file, mdl, "SHELF_MIN_DRAFT", CS%min_draft, &
                  units="m", default=1.0)
-  call get_param(param_file, mod, "FLAT_SHELF_WIDTH", CS%flat_shelf_width, &
+  call get_param(param_file, mdl, "FLAT_SHELF_WIDTH", CS%flat_shelf_width, &
                  units="axis_units", default=0.0)
-  call get_param(param_file, mod, "SHELF_SLOPE_SCALE", CS%shelf_slope_scale, &
+  call get_param(param_file, mdl, "SHELF_SLOPE_SCALE", CS%shelf_slope_scale, &
                  units="axis_units", default=0.0)
-  call get_param(param_file, mod, "SHELF_EDGE_POS_0", CS%pos_shelf_edge_0, &
+  call get_param(param_file, mdl, "SHELF_EDGE_POS_0", CS%pos_shelf_edge_0, &
                  units="axis_units", default=0.0)
-  call get_param(param_file, mod, "SHELF_SPEED", CS%shelf_speed, &
+  call get_param(param_file, mdl, "SHELF_SPEED", CS%shelf_speed, &
                  units="axis_units day-1", default=0.0)
 
   call USER_update_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, G, CS, set_time(0,0), new_sim)
@@ -262,9 +262,9 @@ subroutine write_user_log(param_file)
 
   character(len=128) :: version = '$Id: user_shelf_init.F90,v 1.1.2.7 2012/06/19 22:15:52 Robert.Hallberg Exp $'
   character(len=128) :: tagname = '$Name: MOM_ogrp $'
-  character(len=40)  :: mod = "user_shelf_init" ! This module's name.
+  character(len=40)  :: mdl = "user_shelf_init" ! This module's name.
 
-  call log_version(param_file, mod, version, tagname)
+  call log_version(param_file, mdl, version, tagname)
   first_call = .false.
 
 end subroutine write_user_log

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -24,7 +24,7 @@ implicit none ; private
 
 public MOM_initialize_coord
 
-character(len=40) :: mod = "MOM_coord_initialization" ! This module's name.
+character(len=40) :: mdl = "MOM_coord_initialization" ! This module's name.
 
 contains
 
@@ -52,11 +52,11 @@ subroutine MOM_initialize_coord(GV, PF, write_geom, output_dir, tv, max_depth)
   nz = GV%ke
 
   call callTree_enter("MOM_initialize_coord(), MOM_coord_initialization.F90")
-  call log_version(PF, mod, version, "")
-  call get_param(PF, mod, "DEBUG", debug, default=.false.)
+  call log_version(PF, mdl, version, "")
+  call get_param(PF, mdl, "DEBUG", debug, default=.false.)
 
 ! Set-up the layer densities, GV%Rlay, and reduced gravities, GV%g_prime.
-  call get_param(PF, mod, "COORD_CONFIG", config, &
+  call get_param(PF, mdl, "COORD_CONFIG", config, &
                  "This specifies how layers are to be defined: \n"//&
                  " \t file - read coordinate information from the file \n"//&
                  " \t\t specified by (COORD_FILE).\n"//&
@@ -128,16 +128,16 @@ subroutine set_coord_from_gprime(Rlay, g_prime, GV, param_file)
 ! reduced gravities (g).                                             !
   real :: g_int   ! Reduced gravities across the internal interfaces, in m s-2.
   real :: g_fs    ! Reduced gravity across the free surface, in m s-2.
-  character(len=40)  :: mod = "set_coord_from_gprime" ! This subroutine's name.
+  character(len=40)  :: mdl = "set_coord_from_gprime" ! This subroutine's name.
   integer :: k, nz
   nz = GV%ke
 
-  call callTree_enter(trim(mod)//"(), MOM_coord_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")
 
-  call get_param(param_file, mod, "GFS" , g_fs, &
+  call get_param(param_file, mdl, "GFS" , g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=GV%g_Earth)
-  call get_param(param_file, mod, "GINT", g_int, &
+  call get_param(param_file, mdl, "GINT", g_int, &
                  "The reduced gravity across internal interfaces.", &
                  units="m s-2", fail_if_missing=.true.)
 
@@ -146,7 +146,7 @@ subroutine set_coord_from_gprime(Rlay, g_prime, GV, param_file)
   Rlay(1) = GV%Rho0
   do k=2,nz ; Rlay(k) = Rlay(k-1) + g_prime(k)*(GV%Rho0/GV%g_Earth) ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 
 end subroutine set_coord_from_gprime
 ! -----------------------------------------------------------------------------
@@ -167,19 +167,19 @@ subroutine set_coord_from_layer_density(Rlay, g_prime, GV, param_file)
   real :: g_fs    ! Reduced gravity across the free surface, in m s-2.
   real :: Rlay_Ref! The surface layer's target density, in kg m-3.
   real :: RLay_range ! The range of densities, in kg m-3.
-  character(len=40)  :: mod = "set_coord_from_layer_density" ! This subroutine's name.
+  character(len=40)  :: mdl = "set_coord_from_layer_density" ! This subroutine's name.
   integer :: k, nz
   nz = GV%ke
 
-  call callTree_enter(trim(mod)//"(), MOM_coord_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")
 
-  call get_param(param_file, mod, "GFS", g_fs, &
+  call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=GV%g_Earth)
-  call get_param(param_file, mod, "LIGHTEST_DENSITY", Rlay_Ref, &
+  call get_param(param_file, mdl, "LIGHTEST_DENSITY", Rlay_Ref, &
                  "The reference potential density used for layer 1.", &
                  units="kg m-3", default=GV%Rho0)
-  call get_param(param_file, mod, "DENSITY_RANGE", Rlay_range, &
+  call get_param(param_file, mdl, "DENSITY_RANGE", Rlay_range, &
                  "The range of reference potential densities in the layers.", &
                  units="kg m-3", default=2.0)
 
@@ -193,7 +193,7 @@ subroutine set_coord_from_layer_density(Rlay, g_prime, GV, param_file)
      g_prime(k) = (GV%g_Earth/GV%Rho0) * (Rlay(k) - Rlay(k-1))
   enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine set_coord_from_layer_density
 ! -----------------------------------------------------------------------------
 
@@ -219,21 +219,21 @@ subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, param_file, eqn_of_state, &
   real :: S_ref   ! Reference salinity
   real :: g_int   ! Reduced gravities across the internal interfaces, in m s-2.
   real :: g_fs    ! Reduced gravity across the free surface, in m s-2.
-  character(len=40)  :: mod = "set_coord_from_TS_ref" ! This subroutine's name.
+  character(len=40)  :: mdl = "set_coord_from_TS_ref" ! This subroutine's name.
   integer :: k, nz
   nz = GV%ke
 
-  call callTree_enter(trim(mod)//"(), MOM_coord_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")
 
-  call get_param(param_file, mod, "T_REF", T_Ref, &
+  call get_param(param_file, mdl, "T_REF", T_Ref, &
                  "The initial temperature of the lightest layer.", units="degC", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "S_REF", S_Ref, &
+  call get_param(param_file, mdl, "S_REF", S_Ref, &
                  "The initial salinities.", units="PSU", default=35.0)
-  call get_param(param_file, mod, "GFS", g_fs, &
+  call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=GV%g_Earth)
-  call get_param(param_file, mod, "GINT", g_int, &
+  call get_param(param_file, mdl, "GINT", g_int, &
                  "The reduced gravity across internal interfaces.", &
                  units="m s-2", fail_if_missing=.true.)
                                       !
@@ -249,7 +249,7 @@ subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, param_file, eqn_of_state, &
 !    These statements set the layer densities.                       !
   do k=2,nz ; Rlay(k) = Rlay(k-1) + g_prime(k)*(GV%Rho0/GV%g_Earth) ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine set_coord_from_TS_ref
 ! -----------------------------------------------------------------------------
 
@@ -274,22 +274,22 @@ subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, param_file, &
   real, dimension(GV%ke) :: T0, S0,  Pref
   real :: g_fs    ! Reduced gravity across the free surface, in m s-2.
   integer :: k, nz
-  character(len=40)  :: mod = "set_coord_from_TS_profile" ! This subroutine's name.
+  character(len=40)  :: mdl = "set_coord_from_TS_profile" ! This subroutine's name.
   character(len=200) :: filename, coord_file, inputdir ! Strings for file/path
   nz = GV%ke
 
-  call callTree_enter(trim(mod)//"(), MOM_coord_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")
 
-  call get_param(param_file, mod, "GFS", g_fs, &
+  call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=GV%g_Earth)
-  call get_param(param_file, mod, "COORD_FILE", coord_file, &
+  call get_param(param_file, mdl, "COORD_FILE", coord_file, &
                  "The file from which the coordinate temperatures and \n"//&
                  "salnities are read.", fail_if_missing=.true.)
 
-  call get_param(param_file,  mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file,  mdl, "INPUTDIR", inputdir, default=".")
   filename = trim(slasher(inputdir))//trim(coord_file)
-  call log_param(param_file, mod, "INPUTDIR/COORD_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/COORD_FILE", filename)
 
   call read_data(filename,"PTEMP",T0(:))
   call read_data(filename,"SALT",S0(:))
@@ -302,7 +302,7 @@ subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, param_file, &
   call calculate_density(T0, S0, Pref, Rlay, 1,nz,eqn_of_state)
   do k=2,nz; g_prime(k) = (GV%g_Earth/GV%Rho0) * (Rlay(k) - Rlay(k-1)); enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine set_coord_from_TS_profile
 ! -----------------------------------------------------------------------------
 
@@ -334,38 +334,38 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, param_file, &
   real :: g_fs    ! Reduced gravity across the free surface, in m s-2.
   real :: a1, frac_dense, k_frac
   integer :: k, nz, k_light
-  character(len=40)  :: mod = "set_coord_from_TS_range" ! This subroutine's name.
+  character(len=40)  :: mdl = "set_coord_from_TS_range" ! This subroutine's name.
   character(len=200) :: filename, coord_file, inputdir ! Strings for file/path
   nz = GV%ke
 
-  call callTree_enter(trim(mod)//"(), MOM_coord_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")
 
-  call get_param(param_file, mod, "T_REF", T_Ref, &
+  call get_param(param_file, mdl, "T_REF", T_Ref, &
                  "The default initial temperatures.", units="degC", default=10.0)
-  call get_param(param_file, mod, "TS_RANGE_T_LIGHT", T_Light, &
+  call get_param(param_file, mdl, "TS_RANGE_T_LIGHT", T_Light, &
                  "The initial temperature of the lightest layer when \n"//&
                  "COORD_CONFIG is set to ts_range.", units="degC", default=T_Ref)
-  call get_param(param_file, mod, "TS_RANGE_T_DENSE", T_Dense, &
+  call get_param(param_file, mdl, "TS_RANGE_T_DENSE", T_Dense, &
                  "The initial temperature of the densest layer when \n"//&
                  "COORD_CONFIG is set to ts_range.", units="degC", default=T_Ref)
 
-  call get_param(param_file, mod, "S_REF", S_Ref, &
+  call get_param(param_file, mdl, "S_REF", S_Ref, &
                  "The default initial salinities.", units="PSU", default=35.0)
-  call get_param(param_file, mod, "TS_RANGE_S_LIGHT", S_Light, &
+  call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_Light, &
                  "The initial lightest salinities when COORD_CONFIG \n"//&
                  "is set to ts_range.", default = S_Ref, units="PSU")
-  call get_param(param_file, mod, "TS_RANGE_S_DENSE", S_Dense, &
+  call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_Dense, &
                  "The initial densest salinities when COORD_CONFIG \n"//&
                  "is set to ts_range.", default = S_Ref, units="PSU")
 
-  call get_param(param_file, mod, "TS_RANGE_RESOLN_RATIO", res_rat, &
+  call get_param(param_file, mdl, "TS_RANGE_RESOLN_RATIO", res_rat, &
                  "The ratio of density space resolution in the densest \n"//&
                  "part of the range to that in the lightest part of the \n"//&
                  "range when COORD_CONFIG is set to ts_range. Values \n"//&
                  "greater than 1 increase the resolution of the denser water.",&
                  default=1.0, units="nondim")
 
-  call get_param(param_file, mod, "GFS", g_fs, &
+  call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=GV%g_Earth)
 
@@ -390,7 +390,7 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, param_file, &
   enddo
   do k=2,nz; g_prime(k) = (GV%g_Earth/GV%Rho0) * (Rlay(k) - Rlay(k-1)); enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine set_coord_from_TS_range
 ! -----------------------------------------------------------------------------
 
@@ -409,26 +409,26 @@ subroutine set_coord_from_file(Rlay, g_prime, GV, param_file)
 ! reduced gravities (g).                                             !
   real :: g_fs    ! Reduced gravity across the free surface, in m s-2.
   integer :: k, nz
-  character(len=40)  :: mod = "set_coord_from_file" ! This subroutine's name.
+  character(len=40)  :: mdl = "set_coord_from_file" ! This subroutine's name.
   character(len=40)  :: coord_var
   character(len=200) :: filename,coord_file,inputdir ! Strings for file/path
   nz = GV%ke
 
-  call callTree_enter(trim(mod)//"(), MOM_coord_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")
 
-  call get_param(param_file, mod, "GFS", g_fs, &
+  call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=GV%g_Earth)
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
-  call get_param(param_file, mod, "COORD_FILE", coord_file, &
+  call get_param(param_file, mdl, "COORD_FILE", coord_file, &
                  "The file from which the coordinate densities are read.", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "COORD_VAR", coord_var, &
+  call get_param(param_file, mdl, "COORD_VAR", coord_var, &
                  "The variable in COORD_FILE that is to be used for the \n"//&
                  "coordinate densities.", default="Layer")
   filename = trim(inputdir)//trim(coord_file)
-  call log_param(param_file, mod, "INPUTDIR/COORD_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/COORD_FILE", filename)
   if (.not.file_exists(filename)) call MOM_error(FATAL, &
       " set_coord_from_file: Unable to open "//trim(filename))
 
@@ -441,7 +441,7 @@ subroutine set_coord_from_file(Rlay, g_prime, GV, param_file)
        trim(filename))
   endif ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine set_coord_from_file
 ! -----------------------------------------------------------------------------
 
@@ -461,20 +461,20 @@ subroutine set_coord_linear(Rlay, g_prime, GV, param_file)
 ! reference surface layer density and spanning a range of densities
 ! to the bottom defined by the parameter RLAY_RANGE
 ! (defaulting to 2.0 if not defined)
-  character(len=40)  :: mod = "set_coord_linear" ! This subroutine
+  character(len=40)  :: mdl = "set_coord_linear" ! This subroutine
   real :: Rlay_ref, Rlay_range, g_fs
   integer :: k, nz
   nz = GV%ke
 
-  call callTree_enter(trim(mod)//"(), MOM_coord_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")
 
-  call get_param(param_file, mod, "LIGHTEST_DENSITY", Rlay_Ref, &
+  call get_param(param_file, mdl, "LIGHTEST_DENSITY", Rlay_Ref, &
                  "The reference potential density used for the surface \n"// &
                  "interface.", units="kg m-3", default=GV%Rho0)
-  call get_param(param_file, mod, "DENSITY_RANGE", Rlay_range, &
+  call get_param(param_file, mdl, "DENSITY_RANGE", Rlay_range, &
                  "The range of reference potential densities across \n"// &
                  "all interfaces.", units="kg m-3", default=2.0)
-  call get_param(param_file, mod, "GFS", g_fs, &
+  call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=GV%g_Earth)
 
@@ -490,7 +490,7 @@ subroutine set_coord_linear(Rlay, g_prime, GV, param_file)
      g_prime(k) = (GV%g_Earth/GV%Rho0) * (Rlay(k) - Rlay(k-1))
   enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine set_coord_linear
 
 ! -----------------------------------------------------------------------------

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -61,16 +61,16 @@ subroutine MOM_initialize_fixed(G, OBC, PF, write_geom, output_dir)
   ! Local
   character(len=200) :: inputdir   ! The directory where NetCDF input files are.
   character(len=200) :: config
-  character(len=40)  :: mod = "MOM_fixed_initialization" ! This module's name.
+  character(len=40)  :: mdl = "MOM_fixed_initialization" ! This module's name.
   logical :: debug
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
   call callTree_enter("MOM_initialize_fixed(), MOM_fixed_initialization.F90")
-  call log_version(PF, mod, version, "")
-  call get_param(PF, mod, "DEBUG", debug, default=.false.)
+  call log_version(PF, mdl, version, "")
+  call get_param(PF, mdl, "DEBUG", debug, default=.false.)
 
-  call get_param(PF, mod, "INPUTDIR", inputdir, &
+  call get_param(PF, mdl, "INPUTDIR", inputdir, &
          "The directory in which input files are found.", default=".")
   inputdir = slasher(inputdir)
 
@@ -106,7 +106,7 @@ subroutine MOM_initialize_fixed(G, OBC, PF, write_geom, output_dir)
   endif
 
 ! Modulate geometric scales according to geography.
-  call get_param(PF, mod, "CHANNEL_CONFIG", config, &
+  call get_param(PF, mdl, "CHANNEL_CONFIG", config, &
                  "A parameter that determines which set of channels are \n"//&
                  "restricted to specific  widths.  Options are:\n"//&
                  " \t none - All channels have the grid width.\n"//&
@@ -129,7 +129,7 @@ subroutine MOM_initialize_fixed(G, OBC, PF, write_geom, output_dir)
 
 !   This call sets the topography at velocity points.
   if (G%bathymetry_at_vel) then
-    call get_param(PF, mod, "VELOCITY_DEPTH_CONFIG", config, &
+    call get_param(PF, mdl, "VELOCITY_DEPTH_CONFIG", config, &
                    "A string that determines how the topography is set at \n"//&
                    "velocity points. This may be 'min' or 'max'.", &
                    default="max")
@@ -176,10 +176,10 @@ subroutine MOM_initialize_topography(D, max_depth, G, PF)
 !  This is a separate subroutine so that it can be made public and shared with
 !  the ice-sheet code or other components.
 ! Set up the bottom depth, G%bathyT either analytically or from file
-  character(len=40)  :: mod = "MOM_initialize_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "MOM_initialize_topography" ! This subroutine's name.
   character(len=200) :: config
 
-  call get_param(PF, mod, "TOPO_CONFIG", config, &
+  call get_param(PF, mdl, "TOPO_CONFIG", config, &
                  "This specifies how bathymetry is specified: \n"//&
                  " \t file - read bathymetric information from the file \n"//&
                  " \t\t specified by (TOPO_FILE).\n"//&
@@ -228,11 +228,11 @@ subroutine MOM_initialize_topography(D, max_depth, G, PF)
       "Unrecognized topography setup '"//trim(config)//"'")
   end select
   if (max_depth>0.) then
-    call log_param(PF, mod, "MAXIMUM_DEPTH", max_depth, &
+    call log_param(PF, mdl, "MAXIMUM_DEPTH", max_depth, &
                    "The maximum depth of the ocean.", units="m")
   else
     max_depth = diagnoseMaximumDepth(D,G)
-    call log_param(PF, mod, "!MAXIMUM_DEPTH", max_depth, &
+    call log_param(PF, mdl, "!MAXIMUM_DEPTH", max_depth, &
                    "The (diagnosed) maximum depth of the ocean.", units="m")
   endif
   if (trim(config) .ne. "DOME") then

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -247,7 +247,7 @@ subroutine set_grid_metrics_from_mosaic(G, param_file)
   real, dimension(2*G%isd-3:2*G%ied+1,2*G%jsd-3:2*G%jed+1) :: tmpZ
   real, dimension(:,:), allocatable :: tmpGlbl
   character(len=200) :: filename, grid_file, inputdir
-  character(len=64)  :: mod="MOM_grid_init set_grid_metrics_from_mosaic"
+  character(len=64)  :: mdl = "MOM_grid_init set_grid_metrics_from_mosaic"
   integer :: err=0, ni, nj, global_indices(4)
   type(MOM_domain_type) :: SGdom ! Supergrid domain
   integer :: i, j, i2, j2
@@ -257,13 +257,13 @@ subroutine set_grid_metrics_from_mosaic(G, param_file)
 
   call callTree_enter("set_grid_metrics_from_mosaic(), MOM_grid_initialize.F90")
 
-  call get_param(param_file, mod, "GRID_FILE", grid_file, &
+  call get_param(param_file, mdl, "GRID_FILE", grid_file, &
                  "Name of the file from which to read horizontal grid data.", &
                  fail_if_missing=.true.)
-  call get_param(param_file,  mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file,  mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
   filename = trim(adjustl(inputdir)) // trim(adjustl(grid_file))
-  call log_param(param_file, mod, "INPUTDIR/GRID_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/GRID_FILE", filename)
   if (.not.file_exists(filename)) &
     call MOM_error(FATAL," set_grid_metrics_from_mosaic: Unable to open "//&
                            trim(filename))
@@ -484,7 +484,7 @@ subroutine set_grid_metrics_cartesian(G, param_file)
   real :: I_dx, I_dy                   ! Inverse grid spacings in m.
   real :: PI
   character(len=80) :: units_temp
-  character(len=48) :: mod  = "MOM_grid_init set_grid_metrics_cartesian"
+  character(len=48) :: mdl  = "MOM_grid_init set_grid_metrics_cartesian"
 
   niglobal = G%Domain%niglobal ; njglobal = G%Domain%njglobal
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -495,25 +495,25 @@ subroutine set_grid_metrics_cartesian(G, param_file)
 
   PI = 4.0*atan(1.0) ;
 
-  call get_param(param_file, mod, "AXIS_UNITS", units_temp, &
+  call get_param(param_file, mdl, "AXIS_UNITS", units_temp, &
                  "The units for the Cartesian axes. Valid entries are: \n"//&
                  " \t degrees - degrees of latitude and longitude \n"//&
                  " \t m - meters \n \t k - kilometers", default="degrees")
-  call get_param(param_file, mod, "SOUTHLAT", G%south_lat, &
+  call get_param(param_file, mdl, "SOUTHLAT", G%south_lat, &
                  "The southern latitude of the domain or the equivalent \n"//&
                  "starting value for the y-axis.", units=units_temp, &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "LENLAT", G%len_lat, &
+  call get_param(param_file, mdl, "LENLAT", G%len_lat, &
                  "The latitudinal or y-direction length of the domain.", &
                  units=units_temp, fail_if_missing=.true.)
-  call get_param(param_file, mod, "WESTLON", G%west_lon, &
+  call get_param(param_file, mdl, "WESTLON", G%west_lon, &
                  "The western longitude of the domain or the equivalent \n"//&
                  "starting value for the x-axis.", units=units_temp, &
                  default=0.0)
-  call get_param(param_file, mod, "LENLON", G%len_lon, &
+  call get_param(param_file, mdl, "LENLON", G%len_lon, &
                  "The longitudinal or x-direction length of the domain.", &
                  units=units_temp, fail_if_missing=.true.)
-  call get_param(param_file, mod, "RAD_EARTH", G%Rad_Earth, &
+  call get_param(param_file, mdl, "RAD_EARTH", G%Rad_Earth, &
                  "The radius of the Earth.", units="m", default=6.378e6)
 
   if (units_temp(1:1) == 'k') then
@@ -521,7 +521,7 @@ subroutine set_grid_metrics_cartesian(G, param_file)
   elseif (units_temp(1:1) == 'm') then
     G%x_axis_units = "meters" ; G%y_axis_units = "meters"
   endif
-  call log_param(param_file, mod, "explicit AXIS_UNITS", G%x_axis_units)
+  call log_param(param_file, mdl, "explicit AXIS_UNITS", G%x_axis_units)
 
   ! Note that the dynamic grid always uses symmetric memory for the global
   ! arrays G%gridLatB and G%gridLonB.
@@ -620,7 +620,7 @@ subroutine set_grid_metrics_spherical(G, param_file)
   real :: grid_latT(G%jsd:G%jed), grid_latB(G%JsdB:G%JedB)
   real :: grid_lonT(G%isd:G%ied), grid_lonB(G%IsdB:G%IedB)
   real :: dLon,dLat,latitude,longitude,dL_di
-  character(len=48)  :: mod  = "MOM_grid_init set_grid_metrics_spherical"
+  character(len=48)  :: mdl  = "MOM_grid_init set_grid_metrics_spherical"
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -634,19 +634,19 @@ subroutine set_grid_metrics_spherical(G, param_file)
 !  and save them in arrays.
   PI = 4.0*atan(1.0); PI_180 = atan(1.0)/45.
 
-  call get_param(param_file, mod, "SOUTHLAT", G%south_lat, &
+  call get_param(param_file, mdl, "SOUTHLAT", G%south_lat, &
                  "The southern latitude of the domain.", units="degrees", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "LENLAT", G%len_lat, &
+  call get_param(param_file, mdl, "LENLAT", G%len_lat, &
                  "The latitudinal length of the domain.", units="degrees", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "WESTLON", G%west_lon, &
+  call get_param(param_file, mdl, "WESTLON", G%west_lon, &
                  "The western longitude of the domain.", units="degrees", &
                  default=0.0)
-  call get_param(param_file, mod, "LENLON", G%len_lon, &
+  call get_param(param_file, mdl, "LENLON", G%len_lon, &
                  "The longitudinal length of the domain.", units="degrees", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "RAD_EARTH", G%Rad_Earth, &
+  call get_param(param_file, mdl, "RAD_EARTH", G%Rad_Earth, &
                  "The radius of the Earth.", units="m", default=6.378e6)
 
   dLon = G%len_lon/G%Domain%niglobal
@@ -759,7 +759,7 @@ subroutine set_grid_metrics_mercator(G, param_file)
   integer :: I_off, J_off
   type(GPS) :: GP
   character(len=128) :: warnmesg
-  character(len=48)  :: mod = "MOM_grid_init set_grid_metrics_mercator"
+  character(len=48)  :: mdl = "MOM_grid_init set_grid_metrics_mercator"
   real :: PI, PI_2! PI = 3.1415926... as 4*atan(1), PI_2 = (PI) /2.0
 
 
@@ -799,24 +799,24 @@ subroutine set_grid_metrics_mercator(G, param_file)
 !  and save them in arrays.
   PI = 4.0*atan(1.0) ; PI_2 = 0.5*PI
 
-  call get_param(param_file, mod, "SOUTHLAT", GP%south_lat, &
+  call get_param(param_file, mdl, "SOUTHLAT", GP%south_lat, &
                  "The southern latitude of the domain.", units="degrees", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "LENLAT", GP%len_lat, &
+  call get_param(param_file, mdl, "LENLAT", GP%len_lat, &
                  "The latitudinal length of the domain.", units="degrees", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "WESTLON", GP%west_lon, &
+  call get_param(param_file, mdl, "WESTLON", GP%west_lon, &
                  "The western longitude of the domain.", units="degrees", &
                  default=0.0)
-  call get_param(param_file, mod, "LENLON", GP%len_lon, &
+  call get_param(param_file, mdl, "LENLON", GP%len_lon, &
                  "The longitudinal length of the domain.", units="degrees", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "RAD_EARTH", GP%Rad_Earth, &
+  call get_param(param_file, mdl, "RAD_EARTH", GP%Rad_Earth, &
                  "The radius of the Earth.", units="m", default=6.378e6)
   G%south_lat = GP%south_lat ; G%len_lat = GP%len_lat
   G%west_lon = GP%west_lon ; G%len_lon = GP%len_lon
   G%Rad_Earth = GP%Rad_Earth
-  call get_param(param_file, mod, "ISOTROPIC", GP%isotropic, &
+  call get_param(param_file, mdl, "ISOTROPIC", GP%isotropic, &
                  "If true, an isotropic grid on a sphere (also known as \n"//&
                  "a Mercator grid) is used. With an isotropic grid, the \n"//&
                  "meridional extent of the domain (LENLAT), the zonal \n"//&
@@ -825,15 +825,15 @@ subroutine set_grid_metrics_mercator(G, param_file)
                  "extent is determined to fit the zonal extent and the \n"//&
                  "number of grid points, while grid is perfectly isotropic.", &
                  default=.false.)
-  call get_param(param_file, mod, "EQUATOR_REFERENCE", GP%equator_reference, &
+  call get_param(param_file, mdl, "EQUATOR_REFERENCE", GP%equator_reference, &
                  "If true, the grid is defined to have the equator at the \n"//&
                  "nearest q- or h- grid point to (-LOWLAT*NJGLOBAL/LENLAT).", &
                  default=.true.)
-  call get_param(param_file, mod, "LAT_ENHANCE_FACTOR", GP%Lat_enhance_factor, &
+  call get_param(param_file, mdl, "LAT_ENHANCE_FACTOR", GP%Lat_enhance_factor, &
                  "The amount by which the meridional resolution is \n"//&
                  "enhanced within LAT_EQ_ENHANCE of the equator.", &
                  units="nondim", default=1.0)
-  call get_param(param_file, mod, "LAT_EQ_ENHANCE", GP%Lat_eq_enhance, &
+  call get_param(param_file, mdl, "LAT_EQ_ENHANCE", GP%Lat_eq_enhance, &
                  "The latitude range to the north and south of the equator \n"//&
                  "over which the resolution is enhanced.", units="degrees", &
                  default=0.0)
@@ -1297,17 +1297,17 @@ subroutine initialize_masks(G, PF)
 ! mask2dCv, and mask2dBu are all 1.0.
 
   real :: Dmin, min_depth, mask_depth
-  character(len=40)  :: mod = "MOM_grid_init initialize_masks"
+  character(len=40)  :: mdl = "MOM_grid_init initialize_masks"
   integer :: i, j
 
   call callTree_enter("initialize_masks(), MOM_grid_initialize.F90")
-  call get_param(PF, mod, "MINIMUM_DEPTH", min_depth, &
+  call get_param(PF, mdl, "MINIMUM_DEPTH", min_depth, &
                  "If MASKING_DEPTH is unspecified, then anything shallower than\n"//&
                  "MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.\n"//&
                  "If MASKING_DEPTH is specified, then all depths shallower than\n"//&
                  "MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.", &
                  units="m", default=0.0)
-  call get_param(PF, mod, "MASKING_DEPTH", mask_depth, &
+  call get_param(PF, mdl, "MASKING_DEPTH", mask_depth, &
                  "The depth below which to mask points as land points, for which all\n"//&
                  "fluxes are zeroed out. MASKING_DEPTH is ignored if negative.", &
                  units="m", default=-9999.0)

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -37,11 +37,11 @@ subroutine MOM_shared_init_init(PF)
   type(param_file_type),   intent(in)    :: PF   !< A structure indicating the open file
                                                  !! to parse for model parameter values.
 
-  character(len=40)  :: mod = "MOM_shared_initialization" ! This module's name.
+  character(len=40)  :: mdl = "MOM_shared_initialization" ! This module's name.
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  call log_version(PF, mod, version, &
+  call log_version(PF, mdl, version, &
    "Sharable code to initialize time-invariant fields, like bathymetry and Coriolis parameters.")
 
 end subroutine MOM_shared_init_init
@@ -57,11 +57,11 @@ subroutine MOM_initialize_rotation(f, G, PF)
 ! This is a separate subroutine so that it can be made public and shared with
 ! the ice-sheet code or other components.
 ! Set up the Coriolis parameter, f, either analytically or from file.
-  character(len=40)  :: mod = "MOM_initialize_rotation" ! This subroutine's name.
+  character(len=40)  :: mdl = "MOM_initialize_rotation" ! This subroutine's name.
   character(len=200) :: config
 
-  call callTree_enter(trim(mod)//"(), MOM_shared_initialization.F90")
-  call get_param(PF, mod, "ROTATION", config, &
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
+  call get_param(PF, mdl, "ROTATION", config, &
                  "This specifies how the Coriolis parameter is specified: \n"//&
                  " \t 2omegasinlat - Use twice the planetary rotation rate \n"//&
                  " \t\t times the sine of latitude.\n"//&
@@ -76,7 +76,7 @@ subroutine MOM_initialize_rotation(f, G, PF)
     case default ; call MOM_error(FATAL,"MOM_initialize: "// &
       "Unrecognized rotation setup "//trim(config))
   end select
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine MOM_initialize_rotation
 
 !> Calculates the components of grad f (Coriolis parameter)
@@ -135,21 +135,21 @@ subroutine initialize_topography_from_file(D, G, param_file)
   ! Local variables
   character(len=200) :: filename, topo_file, inputdir ! Strings for file/path
   character(len=200) :: topo_varname                  ! Variable name in file
-  character(len=40)  :: mod = "initialize_topography_from_file" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_topography_from_file" ! This subroutine's name.
 
-  call callTree_enter(trim(mod)//"(), MOM_shared_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
-  call get_param(param_file, mod, "TOPO_FILE", topo_file, &
+  call get_param(param_file, mdl, "TOPO_FILE", topo_file, &
                  "The file from which the bathymetry is read.", &
                  default="topog.nc")
-  call get_param(param_file, mod, "TOPO_VARNAME", topo_varname, &
+  call get_param(param_file, mdl, "TOPO_VARNAME", topo_varname, &
                  "The name of the bathymetry variable in TOPO_FILE.", &
                  default="depth")
 
   filename = trim(inputdir)//trim(topo_file)
-  call log_param(param_file, mod, "INPUTDIR/TOPO_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/TOPO_FILE", filename)
 
   if (.not.file_exists(filename, G%Domain)) call MOM_error(FATAL, &
        " initialize_topography_from_file: Unable to open "//trim(filename))
@@ -165,7 +165,7 @@ subroutine initialize_topography_from_file(D, G, param_file)
 
   call apply_topography_edits_from_file(D, G, param_file)
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_topography_from_file
 
 !> Applies a list of topography overrides read from a netcdf file
@@ -177,16 +177,16 @@ subroutine apply_topography_edits_from_file(D, G, param_file)
 
   ! Local variables
   character(len=200) :: topo_edits_file, inputdir ! Strings for file/path
-  character(len=40)  :: mod = "apply_topography_edits_from_file" ! This subroutine's name.
+  character(len=40)  :: mdl = "apply_topography_edits_from_file" ! This subroutine's name.
   integer :: n_edits, n, ashape(5), i, j, ncid, id, ncstatus, iid, jid, zid
   integer, dimension(:), allocatable :: ig, jg
   real, dimension(:), allocatable :: new_depth
 
-  call callTree_enter(trim(mod)//"(), MOM_shared_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
-  call get_param(param_file, mod, "TOPO_EDITS_FILE", topo_edits_file, &
+  call get_param(param_file, mdl, "TOPO_EDITS_FILE", topo_edits_file, &
                  "The file from which to read a list of i,j,z topography overrides.", &
                  default="")
 
@@ -276,7 +276,7 @@ subroutine apply_topography_edits_from_file(D, G, param_file)
 
   deallocate( ig, jg, new_depth )
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine apply_topography_edits_from_file
 
 !> initialize the bathymetry based on one of several named idealized configurations
@@ -306,38 +306,38 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
   real :: Dedge                ! The depth in m at the basin edge.  !
 ! real :: south_lat, west_lon, len_lon, len_lat, Rad_earth
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
-  character(len=40)  :: mod = "initialize_topography_named" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_topography_named" ! This subroutine's name.
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
-  call callTree_enter(trim(mod)//"(), MOM_shared_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
   call MOM_mesg("  MOM_shared_initialization.F90, initialize_topography_named: "//&
                  "TOPO_CONFIG = "//trim(topog_config), 5)
 
-  call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
+  call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
   if (max_depth<=0.) call MOM_error(FATAL,"initialize_topography_named: "// &
       "MAXIMUM_DEPTH has a non-sensical value! Was it set?")
 
   if (trim(topog_config) /= "flat") then
-    call get_param(param_file, mod, "EDGE_DEPTH", Dedge, &
+    call get_param(param_file, mdl, "EDGE_DEPTH", Dedge, &
                    "The depth at the edge of one of the named topographies.", &
                    units="m", default=100.0)
-!   call get_param(param_file, mod, "SOUTHLAT", south_lat, &
+!   call get_param(param_file, mdl, "SOUTHLAT", south_lat, &
 !                  "The southern latitude of the domain.", units="degrees", &
 !                  fail_if_missing=.true.)
-!   call get_param(param_file, mod, "LENLAT", len_lat, &
+!   call get_param(param_file, mdl, "LENLAT", len_lat, &
 !                  "The latitudinal length of the domain.", units="degrees", &
 !                  fail_if_missing=.true.)
-!   call get_param(param_file, mod, "WESTLON", west_lon, &
+!   call get_param(param_file, mdl, "WESTLON", west_lon, &
 !                  "The western longitude of the domain.", units="degrees", &
 !                  default=0.0)
-!   call get_param(param_file, mod, "LENLON", len_lon, &
+!   call get_param(param_file, mdl, "LENLON", len_lon, &
 !                  "The longitudinal length of the domain.", units="degrees", &
 !                  fail_if_missing=.true.)
-!   call get_param(param_file, mod, "RAD_EARTH", Rad_Earth, &
+!   call get_param(param_file, mdl, "RAD_EARTH", Rad_Earth, &
 !                  "The radius of the Earth.", units="m", default=6.378e6)
-    call get_param(param_file, mod, "TOPOG_SLOPE_SCALE", expdecay, &
+    call get_param(param_file, mdl, "TOPOG_SLOPE_SCALE", expdecay, &
                    "The exponential decay scale used in defining some of \n"//&
                    "the named topographies.", units="m", default=400000.0)
   endif
@@ -390,7 +390,7 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
     if (D(i,j) < min_depth) D(i,j) = 0.5*min_depth
   enddo ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_topography_named
 ! -----------------------------------------------------------------------------
 
@@ -410,18 +410,18 @@ subroutine limit_topography(D, G, param_file, max_depth)
 
 ! This subroutine ensures that    min_depth < D(x,y) < max_depth
   integer :: i, j
-  character(len=40)  :: mod = "limit_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "limit_topography" ! This subroutine's name.
   real :: min_depth, mask_depth
 
-  call callTree_enter(trim(mod)//"(), MOM_shared_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
-  call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
+  call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "If MASKING_DEPTH is unspecified, then anything shallower than\n"//&
                  "MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.\n"//&
                  "If MASKING_DEPTH is specified, then all depths shallower than\n"//&
                  "MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.", &
                  units="m", default=0.0)
-  call get_param(param_file, mod, "MASKING_DEPTH", mask_depth, &
+  call get_param(param_file, mdl, "MASKING_DEPTH", mask_depth, &
                  "The depth below which to mask the ocean as land.", units="m", &
                  default=-9999.0, do_not_log=.true.)
 
@@ -440,7 +440,7 @@ subroutine limit_topography(D, G, param_file, max_depth)
     enddo ; enddo
   endif
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine limit_topography
 ! -----------------------------------------------------------------------------
 
@@ -454,11 +454,11 @@ subroutine set_rotation_planetary(f, G, param_file)
 !     (in)   param_file - parameter file type
 
 ! This subroutine sets up the Coriolis parameter for a sphere
-  character(len=30) :: mod = "set_rotation_planetary" ! This subroutine's name.
+  character(len=30) :: mdl = "set_rotation_planetary" ! This subroutine's name.
   integer :: I, J
   real    :: PI, omega
 
-  call callTree_enter(trim(mod)//"(), MOM_shared_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
   call get_param(param_file, "set_rotation_planetary", "OMEGA", omega, &
                  "The rotation rate of the earth.", units="s-1", &
@@ -469,7 +469,7 @@ subroutine set_rotation_planetary(f, G, param_file)
     f(I,J) = ( 2.0 * omega ) * sin( ( PI * G%geoLatBu(I,J) ) / 180.)
   enddo ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine set_rotation_planetary
 ! -----------------------------------------------------------------------------
 
@@ -485,23 +485,23 @@ subroutine set_rotation_beta_plane(f, G, param_file)
 ! This subroutine sets up the Coriolis parameter for a beta-plane
   integer :: I, J
   real    :: f_0, beta, y_scl, Rad_Earth, PI
-  character(len=40)  :: mod = "set_rotation_beta_plane" ! This subroutine's name.
+  character(len=40)  :: mdl = "set_rotation_beta_plane" ! This subroutine's name.
   character(len=200) :: axis_units
 
-  call callTree_enter(trim(mod)//"(), MOM_shared_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
-  call get_param(param_file, mod, "F_0", f_0, &
+  call get_param(param_file, mdl, "F_0", f_0, &
                  "The reference value of the Coriolis parameter with the \n"//&
                  "betaplane option.", units="s-1", default=0.0)
-  call get_param(param_file, mod, "BETA", beta, &
+  call get_param(param_file, mdl, "BETA", beta, &
                  "The northward gradient of the Coriolis parameter with \n"//&
                  "the betaplane option.", units="m-1 s-1", default=0.0)
-  call get_param(param_file, mod, "AXIS_UNITS", axis_units, default="degrees")
+  call get_param(param_file, mdl, "AXIS_UNITS", axis_units, default="degrees")
 
   PI = 4.0*atan(1.0)
   select case (axis_units(1:1))
     case ("d")
-      call get_param(param_file, mod, "RAD_EARTH", Rad_Earth, &
+      call get_param(param_file, mdl, "RAD_EARTH", Rad_Earth, &
                    "The radius of the Earth.", units="m", default=6.378e6)
       y_scl = Rad_Earth/PI
     case ("k"); y_scl = 1.E3
@@ -515,7 +515,7 @@ subroutine set_rotation_beta_plane(f, G, param_file)
     f(I,J) = f_0 + beta * ( G%geoLatBu(I,J) * y_scl )
   enddo ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine set_rotation_beta_plane
 
 !> initialize_grid_rotation_angle initializes the arrays with the sine and
@@ -680,7 +680,7 @@ subroutine reset_face_lengths_file(G, param_file)
 ! Arguments: G - The ocean's grid structure.
 !  (in)      param_file - A structure indicating the open file to parse for
 !                         model parameter values.
-  character(len=40)  :: mod = "reset_face_lengths_file" ! This subroutine's name.
+  character(len=40)  :: mdl = "reset_face_lengths_file" ! This subroutine's name.
   character(len=256) :: mesg    ! Message for error messages.
   character(len=200) :: filename, chan_file, inputdir ! Strings for file/path
   integer :: i, j, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -688,15 +688,15 @@ subroutine reset_face_lengths_file(G, param_file)
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
   ! These checks apply regardless of the chosen option.
 
-  call callTree_enter(trim(mod)//"(), MOM_shared_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
-  call get_param(param_file, mod, "CHANNEL_WIDTH_FILE", chan_file, &
+  call get_param(param_file, mdl, "CHANNEL_WIDTH_FILE", chan_file, &
                  "The file from which the list of narrowed channels is read.", &
                  default="ocean_geometry.nc")
-  call get_param(param_file,  mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file,  mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
   filename = trim(inputdir)//trim(chan_file)
-  call log_param(param_file, mod, "INPUTDIR/CHANNEL_WIDTH_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/CHANNEL_WIDTH_FILE", filename)
 
   if (is_root_pe()) then ; if (.not.file_exists(filename)) &
     call MOM_error(FATAL," reset_face_lengths_file: Unable to open "//&
@@ -734,7 +734,7 @@ subroutine reset_face_lengths_file(G, param_file)
     if (G%areaCv(i,J) > 0.0) G%IareaCv(i,J) = G%mask2dCv(i,J) / G%areaCv(i,J)
   enddo ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine reset_face_lengths_file
 ! -----------------------------------------------------------------------------
 
@@ -751,7 +751,7 @@ subroutine reset_face_lengths_list(G, param_file)
   character(len=120), pointer, dimension(:) :: lines => NULL()
   character(len=120) :: line
   character(len=200) :: filename, chan_file, inputdir ! Strings for file/path
-  character(len=40)  :: mod = "reset_face_lengths_list" ! This subroutine's name.
+  character(len=40)  :: mdl = "reset_face_lengths_list" ! This subroutine's name.
   real, pointer, dimension(:,:) :: &
     u_lat => NULL(), u_lon => NULL(), v_lat => NULL(), v_lon => NULL()
   real, pointer, dimension(:) :: &
@@ -768,16 +768,16 @@ subroutine reset_face_lengths_list(G, param_file)
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
-  call callTree_enter(trim(mod)//"(), MOM_shared_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
-  call get_param(param_file, mod, "CHANNEL_LIST_FILE", chan_file, &
+  call get_param(param_file, mdl, "CHANNEL_LIST_FILE", chan_file, &
                  "The file from which the list of narrowed channels is read.", &
                  default="MOM_channel_list")
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
   filename = trim(inputdir)//trim(chan_file)
-  call log_param(param_file, mod, "INPUTDIR/CHANNEL_LIST_FILE", filename)
-  call get_param(param_file, mod, "CHANNEL_LIST_360_LON_CHECK", check_360, &
+  call log_param(param_file, mdl, "INPUTDIR/CHANNEL_LIST_FILE", filename)
+  call get_param(param_file, mdl, "CHANNEL_LIST_360_LON_CHECK", check_360, &
                  "If true, the channel configuration list works for any \n"//&
                  "longitudes in the range of -360 to 360.", default=.true.)
 
@@ -941,7 +941,7 @@ subroutine reset_face_lengths_list(G, param_file)
     deallocate(v_lat) ; deallocate(v_lon) ; deallocate(v_width)
   endif
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine reset_face_lengths_list
 ! -----------------------------------------------------------------------------
 
@@ -1078,7 +1078,7 @@ subroutine write_ocean_geometry_file(G, param_file, directory, geom_file)
 !                         model parameter values.
 !  (in)      directory - The directory into which to place the file.
   character(len=240) :: filepath
-  character(len=40)  :: mod = "write_ocean_geometry_file"
+  character(len=40)  :: mdl = "write_ocean_geometry_file"
   integer, parameter :: nFlds=23
   type(vardesc) :: vars(nFlds)
   type(fieldtype) :: fields(nFlds)
@@ -1148,7 +1148,7 @@ subroutine write_ocean_geometry_file(G, param_file, directory, geom_file)
   out_v(:,:) = 0.0
   out_q(:,:) = 0.0
 
-  call get_param(param_file, mod, "PARALLEL_RESTARTFILES", multiple_files, &
+  call get_param(param_file, mdl, "PARALLEL_RESTARTFILES", multiple_files, &
                  "If true, each processor writes its own restart file, \n"//&
                  "otherwise a single restart file is generated", &
                  default=.false.)

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -95,7 +95,7 @@ implicit none ; private
 
 public MOM_initialize_state
 
-character(len=40)  :: mod = "MOM_state_initialization" ! This module's name.
+character(len=40)  :: mdl = "MOM_state_initialization" ! This module's name.
 
 contains
 
@@ -170,8 +170,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
   call callTree_enter("MOM_initialize_state(), MOM_state_initialization.F90")
-  call log_version(PF, mod, version, "")
-  call get_param(PF, mod, "DEBUG", debug, default=.false.)
+  call log_version(PF, mdl, version, "")
+  call get_param(PF, mdl, "DEBUG", debug, default=.false.)
 
   new_sim = .false.
   if ((dirs%input_filename(1:1) == 'n') .and. &
@@ -179,7 +179,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
 
   just_read = .not.new_sim
 
-  call get_param(PF, mod, "INPUTDIR", inputdir, &
+  call get_param(PF, mdl, "INPUTDIR", inputdir, &
          "The directory in which input files are found.", default=".")
   inputdir = slasher(inputdir)
 
@@ -207,7 +207,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
   ! fields are actually initialized here (if just_read=.false.) or whether it
   ! is just to make sure that all valid parameters are read to enable the
   ! detection of unused parameters.
-  call get_param(PF, mod, "INIT_LAYERS_FROM_Z_FILE", from_Z_file, &
+  call get_param(PF, mdl, "INIT_LAYERS_FROM_Z_FILE", from_Z_file, &
              "If true, intialize the layer thicknesses, temperatures, \n"//&
              "and salnities from a Z-space file on a latitude- \n"//&
              "longitude grid.", default=.false., do_not_log=just_read)
@@ -221,7 +221,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
 
   else
 !     Initialize thickness, h.
-    call get_param(PF, mod, "THICKNESS_CONFIG", config, &
+    call get_param(PF, mdl, "THICKNESS_CONFIG", config, &
              "A string that determines how the initial layer \n"//&
              "thicknesses are specified for a new run: \n"//&
              " \t file - read interface heights from the file specified \n"//&
@@ -292,7 +292,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
 
 !     Initialize temperature and salinity (T and S).
     if ( use_temperature ) then
-      call get_param(PF, mod, "TS_CONFIG", config, &
+      call get_param(PF, mdl, "TS_CONFIG", config, &
              "A string that determines how the initial tempertures \n"//&
              "and salinities are specified for a new run: \n"//&
              " \t file - read velocities from the file specified \n"//&
@@ -357,7 +357,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
   if (new_sim) call pass_var(h, G%Domain)
 
 !   Initialize velocity components, u and v
-  call get_param(PF, mod, "VELOCITY_CONFIG", config, &
+  call get_param(PF, mdl, "VELOCITY_CONFIG", config, &
        "A string that determines how the initial velocities \n"//&
        "are specified for a new run: \n"//&
        " \t file - read velocities from the file specified \n"//&
@@ -396,7 +396,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
 
 !   Optionally convert the thicknesses from m to kg m-2.  This is particularly
 ! useful in a non-Boussinesq model.
-  call get_param(PF, mod, "CONVERT_THICKNESS_UNITS", convert, &
+  call get_param(PF, mdl, "CONVERT_THICKNESS_UNITS", convert, &
                "If true,  convert the thickness initial conditions from \n"//&
                "units of m to kg m-2 or vice versa, depending on whether \n"//&
                "BOUSSINESQ is defined. This does not apply if a restart \n"//&
@@ -414,11 +414,11 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
   endif
 
 !  Remove the mass that would be displaced by an ice shelf or inverse barometer.
-  call get_param(PF, mod, "DEPRESS_INITIAL_SURFACE", depress_sfc, &
+  call get_param(PF, mdl, "DEPRESS_INITIAL_SURFACE", depress_sfc, &
                "If true,  depress the initial surface to avoid huge \n"//&
                "tsunamis when a large surface pressure is applied.", &
                default=.false., do_not_log=just_read)
-  call get_param(PF, mod, "TRIM_IC_FOR_P_SURF", trim_ic_for_p_surf, &
+  call get_param(PF, mdl, "TRIM_IC_FOR_P_SURF", trim_ic_for_p_surf, &
                "If true, cuts way the top of the column for initial conditions\n"//&
                "at the depth where the hydrostatic presure matches the imposed\n"//&
                "surface pressure which is read from file.", default=.false., &
@@ -431,13 +431,13 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
   ! Perhaps we want to run the regridding coordinate generator for multiple
   ! iterations here so the initial grid is consistent with the coordinate
   if (useALE) then
-    call get_param(PF, mod, "REGRID_ACCELERATE_INIT", regrid_accelerate, &
+    call get_param(PF, mdl, "REGRID_ACCELERATE_INIT", regrid_accelerate, &
          "If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding\n"//&
          "algorithm to push the initial grid to be consistent with the initial\n"//&
          "condition. Useful only for state-based and iterative coordinates.", &
          default=.false., do_not_log=just_read)
     if (regrid_accelerate) then
-      call get_param(PF, mod, "REGRID_ACCELERATE_ITERATIONS", regrid_iterations, &
+      call get_param(PF, mdl, "REGRID_ACCELERATE_ITERATIONS", regrid_iterations, &
            "The number of regridding iterations to perform to generate\n"//&
            "an initial grid that is consistent with the initial conditions.", &
            default=1, do_not_log=just_read)
@@ -469,12 +469,12 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
     if ( use_temperature ) call hchksum(tv%S, "MOM_initialize_state: S ", G%HI, haloshift=1)
   endif
 
-  call get_param(PF, mod, "SPONGE", use_sponge, &
+  call get_param(PF, mdl, "SPONGE", use_sponge, &
                  "If true, sponges may be applied anywhere in the domain. \n"//&
                  "The exact location and properties of those sponges are \n"//&
                  "specified via SPONGE_CONFIG.", default=.false.)
   if ( use_sponge ) then
-    call get_param(PF, mod, "SPONGE_CONFIG", config, &
+    call get_param(PF, mdl, "SPONGE_CONFIG", config, &
                  "A string that sets how the sponges are configured: \n"//&
                  " \t file - read sponge properties from the file \n"//&
                  " \t\t specified by (SPONGE_FILE).\n"//&
@@ -510,7 +510,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
 
   ! This controls user code for setting open boundary data
   if (associated(OBC)) then
-    call get_param(PF, mod, "OBC_USER_CONFIG", config, &
+    call get_param(PF, mdl, "OBC_USER_CONFIG", config, &
                  "A string that sets how the user code is invoked to set open\n"//&
                  " boundary data: \n"//&
                  "   DOME - specified inflow on northern boundary\n"//&
@@ -585,7 +585,7 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
                      ! with the bottom depth and free surface height, nondim.
   logical :: correct_thickness
   logical :: just_read    ! If true, just read parameters but set nothing.  character(len=20) :: verticalCoordinate
-  character(len=40)  :: mod = "initialize_thickness_from_file" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_thickness_from_file" ! This subroutine's name.
   character(len=200) :: filename, thickness_file, inputdir, mesg ! Strings for file/path
   integer :: i, j, k, is, ie, js, je, nz
 
@@ -594,16 +594,16 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
   if (.not.just_read) &
-    call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
+    call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".", do_not_log=just_read)
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".", do_not_log=just_read)
   inputdir = slasher(inputdir)
-  call get_param(param_file, mod, "THICKNESS_FILE", thickness_file, &
+  call get_param(param_file, mdl, "THICKNESS_FILE", thickness_file, &
                  "The name of the thickness file.", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
 
   filename = trim(inputdir)//trim(thickness_file)
-  if (.not.just_read) call log_param(param_file, mod, "INPUTDIR/THICKNESS_FILE", filename)
+  if (.not.just_read) call log_param(param_file, mdl, "INPUTDIR/THICKNESS_FILE", filename)
 
   if ((.not.just_read) .and. (.not.file_exists(filename, G%Domain))) call MOM_error(FATAL, &
          " initialize_thickness_from_file: Unable to open "//trim(filename))
@@ -612,7 +612,7 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
     if (just_read) return ! All run-time parameters have been read, so return.
     call read_data(filename,"h",h(:,:,:),domain=G%Domain%mpp_domain)
   else
-    call get_param(param_file, mod, "ADJUST_THICKNESS", correct_thickness, &
+    call get_param(param_file, mdl, "ADJUST_THICKNESS", correct_thickness, &
                  "If true, all mass below the bottom removed if the \n"//&
                  "topography is shallower than the thickness input file \n"//&
                  "would indicate.", default=.false., do_not_log=just_read)
@@ -646,7 +646,7 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
     endif
 
   endif
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_thickness_from_file
 ! -----------------------------------------------------------------------------
 
@@ -743,7 +743,7 @@ subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
 !                         model parameter values.
 
 !  This subroutine initializes the layer thicknesses to be uniform.
-  character(len=40)  :: mod = "initialize_thickness_uniform" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_thickness_uniform" ! This subroutine's name.
   real :: e0(SZK_(G)+1)   ! The resting interface heights, in m, usually !
                           ! negative because it is positive upward.      !
   real :: eta1D(SZK_(G)+1)! Interface height relative to the sea surface !
@@ -757,7 +757,7 @@ subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
 
   if (just_read) return ! This subroutine has no run-time parameters.
 
-  call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
   if (G%max_depth<=0.) call MOM_error(FATAL,"initialize_thickness_uniform: "// &
       "MAXIMUM_DEPTH has a non-sensical value! Was it set?")
@@ -784,7 +784,7 @@ subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
     enddo
   enddo ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_thickness_uniform
 ! -----------------------------------------------------------------------------
 
@@ -886,7 +886,7 @@ subroutine depress_surface(h, G, GV, param_file, tv, just_read_params)
   real :: dilate  ! A ratio by which layers are dilated, nondim.
   real :: scale_factor ! A scaling factor for the eta_sfc values that are read
                        ! in, which can be used to change units, for example.
-  character(len=40)  :: mod = "depress_surface" ! This subroutine's name.
+  character(len=40)  :: mdl = "depress_surface" ! This subroutine's name.
   character(len=200) :: inputdir, eta_srf_file ! Strings for file/path
   character(len=200) :: filename, eta_srf_var  ! Strings for file/path
   logical :: just_read    ! If true, just read parameters but set nothing.
@@ -897,19 +897,19 @@ subroutine depress_surface(h, G, GV, param_file, tv, just_read_params)
 
   ! Read the surface height (or pressure) from a file.
 
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
-  call get_param(param_file, mod, "SURFACE_HEIGHT_IC_FILE", eta_srf_file,&
+  call get_param(param_file, mdl, "SURFACE_HEIGHT_IC_FILE", eta_srf_file,&
                  "The initial condition file for the surface height.", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "SURFACE_HEIGHT_IC_VAR", eta_srf_var, &
+  call get_param(param_file, mdl, "SURFACE_HEIGHT_IC_VAR", eta_srf_var, &
                  "The initial condition variable for the surface height.",&
                  default="SSH", do_not_log=just_read)
   filename = trim(inputdir)//trim(eta_srf_file)
   if (.not.just_read) &
-    call log_param(param_file,  mod, "INPUTDIR/SURFACE_HEIGHT_IC_FILE", filename)
+    call log_param(param_file,  mdl, "INPUTDIR/SURFACE_HEIGHT_IC_FILE", filename)
 
-  call get_param(param_file, mod, "SURFACE_HEIGHT_IC_SCALE", scale_factor, &
+  call get_param(param_file, mdl, "SURFACE_HEIGHT_IC_SCALE", scale_factor, &
                  "A scaling factor to convert SURFACE_HEIGHT_IC_VAR into \n"//&
                  "units of m", units="variable", default=1.0, do_not_log=just_read)
 
@@ -968,7 +968,7 @@ subroutine trim_for_ice(PF, G, GV, ALE_CSp, tv, h, just_read_params)
                                                       !! only read parameters without changing h.
 
   ! Local variables
-  character(len=200) :: mod = "trim_for_ice"
+  character(len=200) :: mdl = "trim_for_ice"
   real, dimension(SZI_(G),SZJ_(G)) :: p_surf ! Imposed pressure on ocean at surface (Pa)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: S_t, S_b, T_t, T_b ! Top and bottom edge values for reconstructions
                                                                  ! of salinity and temperature within each layer.
@@ -981,23 +981,23 @@ subroutine trim_for_ice(PF, G, GV, ALE_CSp, tv, h, just_read_params)
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(PF, mod, "SURFACE_PRESSURE_FILE", p_surf_file, &
+  call get_param(PF, mdl, "SURFACE_PRESSURE_FILE", p_surf_file, &
                  "The initial condition file for the surface height.", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(PF, mod, "SURFACE_PRESSURE_VAR", p_surf_var, &
+  call get_param(PF, mdl, "SURFACE_PRESSURE_VAR", p_surf_var, &
                  "The initial condition variable for the surface height.", &
                  units="kg m-2", default="", do_not_log=just_read)
-  call get_param(PF, mod, "INPUTDIR", inputdir, default=".", do_not_log=.true.)
+  call get_param(PF, mdl, "INPUTDIR", inputdir, default=".", do_not_log=.true.)
   filename = trim(slasher(inputdir))//trim(p_surf_file)
-  if (.not.just_read) call log_param(PF,  mod, "!INPUTDIR/SURFACE_HEIGHT_IC_FILE", filename)
+  if (.not.just_read) call log_param(PF,  mdl, "!INPUTDIR/SURFACE_HEIGHT_IC_FILE", filename)
 
-  call get_param(PF, mod, "SURFACE_PRESSURE_SCALE", scale_factor, &
+  call get_param(PF, mdl, "SURFACE_PRESSURE_SCALE", scale_factor, &
                  "A scaling factor to convert SURFACE_PRESSURE_VAR from\n"//&
                  "file SURFACE_PRESSURE_FILE into a surface pressure.", &
                  units="file dependent", default=1., do_not_log=just_read)
-  call get_param(PF, mod, "MIN_THICKNESS", min_thickness, 'Minimum layer thickness', &
+  call get_param(PF, mdl, "MIN_THICKNESS", min_thickness, 'Minimum layer thickness', &
                  units='m', default=1.e-3, do_not_log=just_read)
-  call get_param(PF, mod, "TRIMMING_USES_REMAPPING", use_remapping, &
+  call get_param(PF, mdl, "TRIMMING_USES_REMAPPING", use_remapping, &
                  'When trimming the column, also remap T and S.', &
                  default=.false., do_not_log=just_read)
 
@@ -1131,24 +1131,24 @@ subroutine initialize_velocity_from_file(u, v, G, param_file, just_read_params)
 !  (in)      param_file -  parameter file type
 
 !   This subroutine reads the initial velocity components from file
-  character(len=40)  :: mod = "initialize_velocity_from_file" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_velocity_from_file" ! This subroutine's name.
   character(len=200) :: filename,velocity_file,inputdir ! Strings for file/path
   logical :: just_read    ! If true, just read parameters but set nothing.
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
+  if (.not.just_read) call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
-  call get_param(param_file, mod, "VELOCITY_FILE", velocity_file, &
+  call get_param(param_file, mdl, "VELOCITY_FILE", velocity_file, &
                  "The name of the velocity initial condition file.", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
   filename = trim(inputdir)//trim(velocity_file)
-  call log_param(param_file, mod, "INPUTDIR/VELOCITY_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/VELOCITY_FILE", filename)
 
   if (.not.file_exists(filename, G%Domain)) call MOM_error(FATAL, &
          " initialize_velocity_from_file: Unable to open "//trim(filename))
@@ -1157,7 +1157,7 @@ subroutine initialize_velocity_from_file(u, v, G, param_file, just_read_params)
   call read_data(filename,"u",u(:,:,:),domain=G%Domain%mpp_domain,position=EAST_FACE)
   call read_data(filename,"v",v(:,:,:),domain=G%Domain%mpp_domain,position=NORTH_FACE)
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_velocity_from_file
 ! -----------------------------------------------------------------------------
 
@@ -1176,7 +1176,7 @@ subroutine initialize_velocity_zero(u, v, G, param_file, just_read_params)
 !  (in)      param_file -  parameter file type
 
 !   This subroutine sets the initial velocity components to zero
-  character(len=200) :: mod = "initialize_velocity_zero" ! This subroutine's name.
+  character(len=200) :: mdl = "initialize_velocity_zero" ! This subroutine's name.
   logical :: just_read    ! If true, just read parameters but set nothing.
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -1184,7 +1184,7 @@ subroutine initialize_velocity_zero(u, v, G, param_file, just_read_params)
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
+  if (.not.just_read) call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -1195,7 +1195,7 @@ subroutine initialize_velocity_zero(u, v, G, param_file, just_read_params)
     v(i,J,k) = 0.0
   enddo ; enddo ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_velocity_zero
 ! -----------------------------------------------------------------------------
 
@@ -1217,16 +1217,16 @@ subroutine initialize_velocity_uniform(u, v, G, param_file, just_read_params)
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   real    :: initial_u_const, initial_v_const
   logical :: just_read    ! If true, just read parameters but set nothing.
-  character(len=200) :: mod = "initialize_velocity_uniform" ! This subroutine's name.
+  character(len=200) :: mdl = "initialize_velocity_uniform" ! This subroutine's name.
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(param_file, mod, "INITIAL_U_CONST", initial_u_const, &
+  call get_param(param_file, mdl, "INITIAL_U_CONST", initial_u_const, &
                  "A initial uniform value for the zonal flow.", &
                  units="m s-1", fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "INITIAL_V_CONST", initial_v_const, &
+  call get_param(param_file, mdl, "INITIAL_V_CONST", initial_v_const, &
                  "A initial uniform value for the meridional flow.", &
                  units="m s-1", fail_if_missing=.not.just_read, do_not_log=just_read)
 
@@ -1258,7 +1258,7 @@ subroutine initialize_velocity_circular(u, v, G, param_file, just_read_params)
 
 !   This subroutine sets the initial velocity components to be circular with
 ! no flow at edges of domain and center.
-  character(len=200) :: mod = "initialize_velocity_circular"
+  character(len=200) :: mdl = "initialize_velocity_circular"
   real :: circular_max_u
   real :: dpi, psi1, psi2
   logical :: just_read    ! If true, just read parameters but set nothing.
@@ -1268,7 +1268,7 @@ subroutine initialize_velocity_circular(u, v, G, param_file, just_read_params)
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(param_file, mod, "CIRCULAR_MAX_U", circular_max_u, &
+  call get_param(param_file, mdl, "CIRCULAR_MAX_U", circular_max_u, &
                  "The amplitude of zonal flow from which to scale the\n"// &
                  "circular stream function (m/s).", &
                  units="m s-1", default=0., do_not_log=just_read)
@@ -1325,28 +1325,28 @@ subroutine initialize_temp_salt_from_file(T, S, G, param_file, just_read_params)
   logical :: just_read    ! If true, just read parameters but set nothing.
   character(len=200) :: filename, salt_filename ! Full paths to input files
   character(len=200) :: ts_file, salt_file, inputdir ! Strings for file/path
-  character(len=40)  :: mod = "initialize_temp_salt_from_file"
+  character(len=40)  :: mdl = "initialize_temp_salt_from_file"
   character(len=64)  :: temp_var, salt_var ! Temperature and salinity names in files
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
+  if (.not.just_read) call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
-  call get_param(param_file, mod, "TS_FILE", ts_file, &
+  call get_param(param_file, mdl, "TS_FILE", ts_file, &
                  "The initial condition file for temperature.", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
 
   filename = trim(inputdir)//trim(ts_file)
-  if (.not.just_read) call log_param(param_file, mod, "INPUTDIR/TS_FILE", filename)
-  call get_param(param_file, mod, "TEMP_IC_VAR", temp_var, &
+  if (.not.just_read) call log_param(param_file, mdl, "INPUTDIR/TS_FILE", filename)
+  call get_param(param_file, mdl, "TEMP_IC_VAR", temp_var, &
                  "The initial condition variable for potential temperature.", &
                  default="PTEMP", do_not_log=just_read)
-  call get_param(param_file, mod, "SALT_IC_VAR", salt_var, &
+  call get_param(param_file, mdl, "SALT_IC_VAR", salt_var, &
                  "The initial condition variable for salinity.", &
                  default="SALT", do_not_log=just_read)
-  call get_param(param_file, mod, "SALT_FILE", salt_file, &
+  call get_param(param_file, mdl, "SALT_FILE", salt_file, &
                  "The initial condition file for salinity.", &
                  default=trim(ts_file), do_not_log=just_read)
 
@@ -1364,7 +1364,7 @@ subroutine initialize_temp_salt_from_file(T, S, G, param_file, just_read_params)
 
   call read_data(salt_filename, salt_var, S(:,:,:), domain=G%Domain%mpp_domain)
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_temp_salt_from_file
 ! -----------------------------------------------------------------------------
 
@@ -1390,22 +1390,22 @@ subroutine initialize_temp_salt_from_profile(T, S, G, param_file, just_read_para
   integer :: i, j, k
   logical :: just_read    ! If true, just read parameters but set nothing.
   character(len=200) :: filename, ts_file, inputdir ! Strings for file/path
-  character(len=40)  :: mod = "initialize_temp_salt_from_profile"
+  character(len=40)  :: mdl = "initialize_temp_salt_from_profile"
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
+  if (.not.just_read) call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
-  call get_param(param_file, mod, "TS_FILE", ts_file, &
+  call get_param(param_file, mdl, "TS_FILE", ts_file, &
                  "The file with the reference profiles for temperature \n"//&
                  "and salinity.", fail_if_missing=.not.just_read, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
   filename = trim(inputdir)//trim(ts_file)
-  call log_param(param_file, mod, "INPUTDIR/TS_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/TS_FILE", filename)
   if (.not.file_exists(filename)) call MOM_error(FATAL, &
      " initialize_temp_salt_from_profile: Unable to open "//trim(filename))
 
@@ -1417,7 +1417,7 @@ subroutine initialize_temp_salt_from_profile(T, S, G, param_file, just_read_para
     T(i,j,k) = T0(k) ; S(i,j,k) = S0(k)
   enddo ; enddo ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_temp_salt_from_profile
 ! -----------------------------------------------------------------------------
 
@@ -1452,21 +1452,21 @@ subroutine initialize_temp_salt_fit(T, S, G, GV, param_file, eqn_of_state, P_Ref
   real :: rho_guess(SZK_(G)) ! Potential density at T0 & S0 in kg m-3.
   logical :: fit_salin       ! If true, accept the prescribed temperature and fit the salinity.
   logical :: just_read    ! If true, just read parameters but set nothing.
-  character(len=40)  :: mod = "initialize_temp_salt_fit" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_temp_salt_fit" ! This subroutine's name.
   integer :: i, j, k, itt, nz
   nz = G%ke
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
+  if (.not.just_read) call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
-  call get_param(param_file, mod, "T_REF", T_Ref, &
+  call get_param(param_file, mdl, "T_REF", T_Ref, &
                  "A reference temperature used in initialization.", &
                  units="degC", fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "S_REF", S_Ref, &
+  call get_param(param_file, mdl, "S_REF", S_Ref, &
                  "A reference salinity used in initialization.", units="PSU", &
                  default=35.0, do_not_log=just_read)
-  call get_param(param_file, mod, "FIT_SALINITY", fit_salin, &
+  call get_param(param_file, mdl, "FIT_SALINITY", fit_salin, &
                  "If true, accept the prescribed temperature and fit the \n"//&
                  "salinity; otherwise take salinity and fit temperature.", &
                  default=.false., do_not_log=just_read)
@@ -1512,7 +1512,7 @@ subroutine initialize_temp_salt_fit(T, S, G, GV, param_file, eqn_of_state, P_Ref
     T(i,j,k) = T0(k) ; S(i,j,k) = S0(k)
   enddo ; enddo ; enddo
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_temp_salt_fit
 ! -----------------------------------------------------------------------------
 
@@ -1534,21 +1534,21 @@ subroutine initialize_temp_salt_linear(T, S, G, param_file, just_read_params)
   real  :: S_range, T_range ! Range of salinities and temperatures over the vertical
   real  :: delta
   logical :: just_read    ! If true, just read parameters but set nothing.
-  character(len=40)  :: mod = "initialize_temp_salt_linear" ! This subroutine's name.
+  character(len=40)  :: mdl = "initialize_temp_salt_linear" ! This subroutine's name.
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
-  call get_param(param_file, mod, "T_TOP", T_top, &
+  if (.not.just_read) call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
+  call get_param(param_file, mdl, "T_TOP", T_top, &
                  "Initial temperature of the top surface.", &
                  units="degC", fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "T_RANGE", T_range, &
+  call get_param(param_file, mdl, "T_RANGE", T_range, &
                  "Initial temperature difference (top-bottom).", &
                  units="degC", fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "S_TOP", S_top, &
+  call get_param(param_file, mdl, "S_TOP", S_top, &
                  "Initial salinity of the top surface.", &
                  units="PSU", fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "S_RANGE", S_range, &
+  call get_param(param_file, mdl, "S_RANGE", S_range, &
                  "Initial salinity difference (top-bottom).", &
                  units="PSU", fail_if_missing=.not.just_read, do_not_log=just_read)
 
@@ -1574,7 +1574,7 @@ subroutine initialize_temp_salt_linear(T, S, G, param_file, just_read_params)
 ! delta = 1;
 ! T(:,:,G%ke/2 - (delta-1):G%ke/2 + delta) = 1.0;
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_temp_salt_linear
 ! -----------------------------------------------------------------------------
 
@@ -1620,37 +1620,37 @@ subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp)
 
   integer :: i, j, k, is, ie, js, je, nz
   character(len=40) :: potemp_var, salin_var, Idamp_var, eta_var
-  character(len=40) :: mod = "initialize_sponges_file"
+  character(len=40) :: mdl = "initialize_sponges_file"
   character(len=200) :: damping_file, state_file  ! Strings for filenames
   character(len=200) :: filename, inputdir ! Strings for file/path and path.
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
   pres(:) = 0.0 ; eta(:,:,:) = 0.0 ; tmp(:,:,:) = 0.0 ; Idamp(:,:) = 0.0
 
-  call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
-  call get_param(param_file, mod, "SPONGE_DAMPING_FILE", damping_file, &
+  call get_param(param_file, mdl, "SPONGE_DAMPING_FILE", damping_file, &
                  "The name of the file with the sponge damping rates.", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "SPONGE_STATE_FILE", state_file, &
+  call get_param(param_file, mdl, "SPONGE_STATE_FILE", state_file, &
                  "The name of the file with the state to damp toward.", &
                  default=damping_file)
 
-  call get_param(param_file, mod, "SPONGE_PTEMP_VAR", potemp_var, &
+  call get_param(param_file, mdl, "SPONGE_PTEMP_VAR", potemp_var, &
                  "The name of the potential temperature variable in \n"//&
                  "SPONGE_STATE_FILE.", default="PTEMP")
-  call get_param(param_file, mod, "SPONGE_SALT_VAR", salin_var, &
+  call get_param(param_file, mdl, "SPONGE_SALT_VAR", salin_var, &
                  "The name of the salinity variable in \n"//&
                  "SPONGE_STATE_FILE.", default="SALT")
-  call get_param(param_file, mod, "SPONGE_ETA_VAR", eta_var, &
+  call get_param(param_file, mdl, "SPONGE_ETA_VAR", eta_var, &
                  "The name of the interface height variable in \n"//&
                  "SPONGE_STATE_FILE.", default="ETA")
-  call get_param(param_file, mod, "SPONGE_IDAMP_VAR", Idamp_var, &
+  call get_param(param_file, mdl, "SPONGE_IDAMP_VAR", Idamp_var, &
                  "The name of the inverse damping rate variable in \n"//&
                  "SPONGE_DAMPING_FILE.", default="IDAMP")
 
   filename = trim(inputdir)//trim(damping_file)
-  call log_param(param_file, mod, "INPUTDIR/SPONGE_DAMPING_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/SPONGE_DAMPING_FILE", filename)
   if (.not.file_exists(filename, G%Domain)) &
     call MOM_error(FATAL, " initialize_sponges: Unable to open "//trim(filename))
 
@@ -1662,7 +1662,7 @@ subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp)
 ! momentum is typically not damped within the sponge.                !
 
   filename = trim(inputdir)//trim(state_file)
-  call log_param(param_file, mod, "INPUTDIR/SPONGE_STATE_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/SPONGE_STATE_FILE", filename)
   if (.not.file_exists(filename, G%Domain)) &
     call MOM_error(FATAL, " initialize_sponges: Unable to open "//trim(filename))
 
@@ -1805,7 +1805,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_initialize_layers_from_Z" ! This module's name.
+  character(len=40)  :: mdl = "MOM_initialize_layers_from_Z" ! This module's name.
 
   integer :: is, ie, js, je, nz ! compute domain indices
   integer :: isc,iec,jsc,jec    ! global compute domain indices
@@ -1873,73 +1873,73 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
-  if (.not.just_read) call log_version(PF, mod, version, "")
+  if (.not.just_read) call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
+  if (.not.just_read) call log_version(PF, mdl, version, "")
 
-  inputdir = "." ;  call get_param(PF, mod, "INPUTDIR", inputdir)
+  inputdir = "." ;  call get_param(PF, mdl, "INPUTDIR", inputdir)
   inputdir = slasher(inputdir)
 
   eos => tv%eqn_of_state
 
 ! call mpp_get_compute_domain(G%domain%mpp_domain,isc,iec,jsc,jec)
 
-  reentrant_x = .false. ; call get_param(PF, mod, "REENTRANT_X", reentrant_x,default=.true.)
-  tripolar_n = .false. ;  call get_param(PF, mod, "TRIPOLAR_N", tripolar_n, default=.false.)
-  call get_param(PF, mod, "MINIMUM_DEPTH", min_depth, default=0.0)
+  reentrant_x = .false. ; call get_param(PF, mdl, "REENTRANT_X", reentrant_x,default=.true.)
+  tripolar_n = .false. ;  call get_param(PF, mdl, "TRIPOLAR_N", tripolar_n, default=.false.)
+  call get_param(PF, mdl, "MINIMUM_DEPTH", min_depth, default=0.0)
 
-  call get_param(PF, mod, "NKML",nkml,default=0)
-  call get_param(PF, mod, "NKBL",nkbl,default=0)
+  call get_param(PF, mdl, "NKML",nkml,default=0)
+  call get_param(PF, mdl, "NKBL",nkbl,default=0)
 
-  call get_param(PF, mod, "TEMP_SALT_Z_INIT_FILE",filename, &
+  call get_param(PF, mdl, "TEMP_SALT_Z_INIT_FILE",filename, &
                  "The name of the z-space input file used to initialize \n"//&
                  "the layer thicknesses, temperatures and salinities.", &
                  default="temp_salt_z.nc", do_not_log=just_read)
   filename = trim(inputdir)//trim(filename)
-  call get_param(PF, mod, "Z_INIT_FILE_PTEMP_VAR", potemp_var, &
+  call get_param(PF, mdl, "Z_INIT_FILE_PTEMP_VAR", potemp_var, &
                  "The name of the potential temperature variable in \n"//&
                  "TEMP_SALT_Z_INIT_FILE.", default="ptemp", do_not_log=just_read)
-  call get_param(PF, mod, "Z_INIT_FILE_SALT_VAR", salin_var, &
+  call get_param(PF, mdl, "Z_INIT_FILE_SALT_VAR", salin_var, &
                  "The name of the salinity variable in \n"//&
                  "TEMP_SALT_Z_INIT_FILE.", default="salt", do_not_log=just_read)
-  call get_param(PF, mod, "Z_INIT_HOMOGENIZE", homogenize, &
+  call get_param(PF, mdl, "Z_INIT_HOMOGENIZE", homogenize, &
                  "If True, then horizontally homogenize the interpolated \n"//&
                  "initial conditions.", default=.false., do_not_log=just_read)
-  call get_param(PF, mod, "Z_INIT_ALE_REMAPPING", useALEremapping, &
+  call get_param(PF, mdl, "Z_INIT_ALE_REMAPPING", useALEremapping, &
                  "If True, then remap straight to model coordinate from file.",&
                  default=.false., do_not_log=just_read)
-  call get_param(PF, mod, "Z_INIT_REMAPPING_SCHEME", remappingScheme, &
+  call get_param(PF, mdl, "Z_INIT_REMAPPING_SCHEME", remappingScheme, &
                  "The remapping scheme to use if using Z_INIT_ALE_REMAPPING\n"//&
                  "is True.", default="PPM_IH4", do_not_log=just_read)
-  call get_param(PF, mod, "Z_INIT_REMAP_GENERAL", remap_general, &
+  call get_param(PF, mdl, "Z_INIT_REMAP_GENERAL", remap_general, &
                  "If false, only initializes to z* coordinates.\n"//&
                  "If true, allows initialization directly to general coordinates.",&
                  default=.false., do_not_log=just_read)
-  call get_param(PF, mod, "Z_INIT_REMAP_FULL_COLUMN", remap_full_column, &
+  call get_param(PF, mdl, "Z_INIT_REMAP_FULL_COLUMN", remap_full_column, &
                  "If false, only reconstructs profiles for valid data points.\n"//&
                  "If true, inserts vanished layers below the valid data.",&
                  default=remap_general, do_not_log=just_read)
-  call get_param(PF, mod, "Z_INIT_REMAP_OLD_ALG", remap_old_alg, &
+  call get_param(PF, mdl, "Z_INIT_REMAP_OLD_ALG", remap_old_alg, &
                  "If false, uses the preferred remapping algorithm for initialization.\n"//&
                  "If true, use an older, less robust algorithm for remapping.",&
                  default=.true., do_not_log=just_read)
-  call get_param(PF, mod, "ICE_SHELF", use_ice_shelf, default=.false.)
+  call get_param(PF, mdl, "ICE_SHELF", use_ice_shelf, default=.false.)
   if (use_ice_shelf) then
-    call get_param(PF, mod, "ICE_THICKNESS_FILE", ice_shelf_file, &
+    call get_param(PF, mdl, "ICE_THICKNESS_FILE", ice_shelf_file, &
                  "The file from which the ice bathymetry and area are read.", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
     shelf_file = trim(inputdir)//trim(ice_shelf_file)
-    if (.not.just_read) call log_param(PF, mod, "INPUTDIR/THICKNESS_FILE", shelf_file)
-    call get_param(PF, mod, "ICE_AREA_VARNAME", area_varname, &
+    if (.not.just_read) call log_param(PF, mdl, "INPUTDIR/THICKNESS_FILE", shelf_file)
+    call get_param(PF, mdl, "ICE_AREA_VARNAME", area_varname, &
                  "The name of the area variable in ICE_THICKNESS_FILE.", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
   endif
   if (.not.useALEremapping) then
-    call get_param(PF, mod, "ADJUST_THICKNESS", correct_thickness, &
+    call get_param(PF, mdl, "ADJUST_THICKNESS", correct_thickness, &
                  "If true, all mass below the bottom removed if the \n"//&
                  "topography is shallower than the thickness input file \n"//&
                  "would indicate.", default=.false., do_not_log=just_read)
 
-    call get_param(PF, mod, "FIT_TO_TARGET_DENSITY_IC", adjust_temperature, &
+    call get_param(PF, mdl, "FIT_TO_TARGET_DENSITY_IC", adjust_temperature, &
                  "If true, all the interior layers are adjusted to \n"//&
                  "their target densities using mostly temperature \n"//&
                  "This approach can be problematic, particularly in the \n"//&
@@ -2057,7 +2057,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 
     ! Build the target grid (and set the model thickness to it)
     ! This call can be more general but is hard-coded for z* coordinates...  ????
-    call ALE_initRegridding( GV, G%max_depth, PF, mod, regridCS ) ! sets regridCS
+    call ALE_initRegridding( GV, G%max_depth, PF, mdl, regridCS ) ! sets regridCS
 
     if (.not. remap_general) then
       ! This is the old way of initializing to z* coordinates only
@@ -2202,7 +2202,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
   call pass_var(tv%T, G%Domain)
   call pass_var(tv%S, G%Domain)
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
   call cpu_clock_end(id_clock_routine)
 
 end subroutine MOM_temp_salt_initialize_from_Z

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -43,7 +43,7 @@ implicit none ; private
 
 public :: MOM_initialize_tracer_from_Z, horiz_interp_and_extrap_tracer
 
-character(len=40)  :: mod = "MOM_tracer_initialization_from_Z" ! This module's name.
+character(len=40)  :: mdl = "MOM_tracer_initialization_from_Z" ! This module's name.
 
 interface fill_boundaries
   module procedure fill_boundaries_real
@@ -89,7 +89,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
-  character(len=40)  :: mod = "MOM_initialize_tracers_from_Z" ! This module's name.
+  character(len=40)  :: mdl = "MOM_initialize_tracers_from_Z" ! This module's name.
 
   integer :: is, ie, js, je, nz ! compute domain indices
   integer :: isc,iec,jsc,jec    ! global compute domain indices
@@ -124,24 +124,24 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   isg = G%isg ; ieg = G%ieg ; jsg = G%jsg ; jeg = G%jeg
 
-  call callTree_enter(trim(mod)//"(), MOM_state_initialization.F90")
+  call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
   call mpp_get_compute_domain(G%domain%mpp_domain,isc,iec,jsc,jec)
 
-  call get_param(PF, mod, "Z_INIT_HOMOGENIZE", homog, &
+  call get_param(PF, mdl, "Z_INIT_HOMOGENIZE", homog, &
                  "If True, then horizontally homogenize the interpolated \n"//&
                  "initial conditions.", default=.false.)
-  call get_param(PF, mod, "Z_INIT_ALE_REMAPPING", useALE, &
+  call get_param(PF, mdl, "Z_INIT_ALE_REMAPPING", useALE, &
                  "If True, then remap straight to model coordinate from file.",&
                  default=.true.)
-  call get_param(PF, mod, "Z_INIT_REMAPPING_SCHEME", remapScheme, &
+  call get_param(PF, mdl, "Z_INIT_REMAPPING_SCHEME", remapScheme, &
                  "The remapping scheme to use if using Z_INIT_ALE_REMAPPING\n"//&
                  "is True.", default="PLM")
 
   ! These are model grid properties, but being applied to the data grid for now.
   ! need to revisit this (mjh)
-  reentrant_x = .false. ;  call get_param(PF, mod, "REENTRANT_X", reentrant_x,default=.true.)
-  tripolar_n = .false. ;  call get_param(PF, mod, "TRIPOLAR_N", tripolar_n, default=.false.)
+  reentrant_x = .false. ;  call get_param(PF, mdl, "REENTRANT_X", reentrant_x,default=.true.)
+  tripolar_n = .false. ;  call get_param(PF, mdl, "TRIPOLAR_N", tripolar_n, default=.false.)
 
 
   if (PRESENT(homogenize)) homog=homogenize
@@ -224,7 +224,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
   enddo ; enddo ; enddo
 
 
-  call callTree_leave(trim(mod)//'()')
+  call callTree_leave(trim(mdl)//'()')
   call cpu_clock_end(id_clock_routine)
 
 

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -798,14 +798,14 @@ logical function MEKE_init(Time, G, param_file, diag, CS, MEKE, restart_CS)
   logical :: laplacian, useVarMix, coldStart
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_MEKE" ! This module's name.
+  character(len=40)  :: mdl = "MOM_MEKE" ! This module's name.
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   ! Determine whether this module will be used
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "USE_MEKE", MEKE_init, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "USE_MEKE", MEKE_init, &
                  "If true, turns on the MEKE scheme which calculates\n"// &
                  "a sub-grid mesoscale eddy kinetic energy budget.", &
                  default=.false.)
@@ -826,137 +826,137 @@ logical function MEKE_init(Time, G, param_file, diag, CS, MEKE, restart_CS)
   call MOM_mesg("MEKE_init: reading parameters ", 5)
 
   ! Read all relevant parameters and write them to the model log.
-  call get_param(param_file, mod, "MEKE_DAMPING", CS%MEKE_damping, &
+  call get_param(param_file, mdl, "MEKE_DAMPING", CS%MEKE_damping, &
                  "The local depth-indepented MEKE dissipation rate.", &
                  units="s-1", default=0.0)
-  call get_param(param_file, mod, "MEKE_CD_SCALE", CS%MEKE_Cd_scale, &
+  call get_param(param_file, mdl, "MEKE_CD_SCALE", CS%MEKE_Cd_scale, &
                  "The ratio of the bottom eddy velocity to the column mean\n"//&
                  "eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1\n"//&
                  "to account for the surface intensification of MEKE.", &
                  units="nondim", default=0.)
-  call get_param(param_file, mod, "MEKE_CB", CS%MEKE_Cb, &
+  call get_param(param_file, mdl, "MEKE_CB", CS%MEKE_Cb, &
                  "A coefficient in the expression for the ratio of bottom projected\n"//&
                  "eddy energy and mean column energy (see Jansen et al. 2015).",&
                  units="nondim", default=25.)
-  call get_param(param_file, mod, "MEKE_MIN_GAMMA2", CS%MEKE_min_gamma, &
+  call get_param(param_file, mdl, "MEKE_MIN_GAMMA2", CS%MEKE_min_gamma, &
                  "The minimum allowed value of gamma_b^2.",&
                  units="nondim", default=0.0001)
-  call get_param(param_file, mod, "MEKE_CT", CS%MEKE_Ct, &
+  call get_param(param_file, mdl, "MEKE_CT", CS%MEKE_Ct, &
                  "A coefficient in the expression for the ratio of barotropic\n"//&
                  "eddy energy and mean column energy (see Jansen et al. 2015).",&
                  units="nondim", default=50.)
-  call get_param(param_file, mod, "MEKE_GMCOEFF", CS%MEKE_GMcoeff, &
+  call get_param(param_file, mdl, "MEKE_GMCOEFF", CS%MEKE_GMcoeff, &
                  "The efficiency of the conversion of potential energy \n"//&
                  "into MEKE by the thickness mixing parameterization. \n"//&
                  "If MEKE_GMCOEFF is negative, this conversion is not \n"//&
                  "used or calculated.", units="nondim", default=-1.0)
-  call get_param(param_file, mod, "MEKE_FRCOEFF", CS%MEKE_FrCoeff, &
+  call get_param(param_file, mdl, "MEKE_FRCOEFF", CS%MEKE_FrCoeff, &
                  "The efficiency of the conversion of mean energy into \n"//&
                  "MEKE.  If MEKE_FRCOEFF is negative, this conversion \n"//&
                  "is not used or calculated.", units="nondim", default=-1.0)
-  call get_param(param_file, mod, "MEKE_BGSRC", CS%MEKE_BGsrc, &
+  call get_param(param_file, mdl, "MEKE_BGSRC", CS%MEKE_BGsrc, &
                  "A background energy source for MEKE.", units="W kg-1", &
                  default=0.0)
-  call get_param(param_file, mod, "MEKE_KH", CS%MEKE_Kh, &
+  call get_param(param_file, mdl, "MEKE_KH", CS%MEKE_Kh, &
                  "A background lateral diffusivity of MEKE.\n"//&
                  "Use a negative value to not apply lateral diffusion to MEKE.", &
                  units="m2 s-1", default=-1.0)
-  call get_param(param_file, mod, "MEKE_K4", CS%MEKE_K4, &
+  call get_param(param_file, mdl, "MEKE_K4", CS%MEKE_K4, &
                  "A lateral bi-harmonic diffusivity of MEKE.\n"//&
                  "Use a negative value to not apply bi-harmonic diffusion to MEKE.", &
                  units="m4 s-1", default=-1.0)
-  call get_param(param_file, mod, "MEKE_DTSCALE", CS%MEKE_dtScale, &
+  call get_param(param_file, mdl, "MEKE_DTSCALE", CS%MEKE_dtScale, &
                  "A scaling factor to accelerate the time evolution of MEKE.", &
                  units="nondim", default=1.0)
-  call get_param(param_file, mod, "MEKE_KHCOEFF", CS%MEKE_KhCoeff, &
+  call get_param(param_file, mdl, "MEKE_KHCOEFF", CS%MEKE_KhCoeff, &
                  "A scaling factor in the expression for eddy diffusivity\n"//&
                  "which is otherwise proportional to the MEKE velocity-\n"//&
                  "scale times an eddy mixing-length. This factor\n"//&
                  "must be >0 for MEKE to contribute to the thickness/\n"//&
                  "and tracer diffusivity in the rest of the model.", &
                  units="nondim", default=1.0)
-  call get_param(param_file, mod, "MEKE_USCALE", CS%MEKE_Uscale, &
+  call get_param(param_file, mdl, "MEKE_USCALE", CS%MEKE_Uscale, &
                  "The background velocity that is combined with MEKE to \n"//&
                  "calculate the bottom drag.", units="m s-1", default=0.0)
-  call get_param(param_file, mod, "MEKE_VISC_DRAG", CS%visc_drag, &
+  call get_param(param_file, mdl, "MEKE_VISC_DRAG", CS%visc_drag, &
                  "If true, use the vertvisc_type to calculate the bottom \n"//&
                  "drag acting on MEKE.", default=.true.)
-  call get_param(param_file, mod, "MEKE_KHTH_FAC", MEKE%KhTh_fac, &
+  call get_param(param_file, mdl, "MEKE_KHTH_FAC", MEKE%KhTh_fac, &
                  "A factor that maps MEKE%Kh to KhTh.", units="nondim", &
                  default=0.0)
-  call get_param(param_file, mod, "MEKE_KHTR_FAC", MEKE%KhTr_fac, &
+  call get_param(param_file, mdl, "MEKE_KHTR_FAC", MEKE%KhTr_fac, &
                  "A factor that maps MEKE%Kh to KhTr.", units="nondim", &
                  default=0.0)
-  call get_param(param_file, mod, "MEKE_KHMEKE_FAC", CS%KhMEKE_Fac, &
+  call get_param(param_file, mdl, "MEKE_KHMEKE_FAC", CS%KhMEKE_Fac, &
                  "A factor that maps MEKE%Kh to Kh for MEKE itself.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "MEKE_OLD_LSCALE", CS%use_old_lscale, &
+  call get_param(param_file, mdl, "MEKE_OLD_LSCALE", CS%use_old_lscale, &
                  "If true, use the old formula for length scale which is\n"//&
                  "a function of grid spacing and deformation radius.",  &
                  default=.false.)
-  call get_param(param_file, mod, "MEKE_RD_MAX_SCALE", CS%Rd_as_max_scale, &
+  call get_param(param_file, mdl, "MEKE_RD_MAX_SCALE", CS%Rd_as_max_scale, &
                  "If true, the length scale used by MEKE is the minimum of\n"//&
                  "the deformation radius or grid-spacing. Only used if\n"//&
                  "MEKE_OLD_LSCALE=True", units="nondim", default=.false.)
-  call get_param(param_file, mod, "MEKE_VISCOSITY_COEFF", CS%viscosity_coeff, &
+  call get_param(param_file, mdl, "MEKE_VISCOSITY_COEFF", CS%viscosity_coeff, &
                  "If non-zero, is the scaling coefficient in the expression for\n"//&
                  "viscosity used to parameterize lateral momentum mixing by\n"//&
                  "unresolved eddies represented by MEKE. Can be negative to\n"//&
                  "represent backscatter from the unresolved eddies.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "MEKE_FIXED_MIXING_LENGTH", CS%Lfixed, &
+  call get_param(param_file, mdl, "MEKE_FIXED_MIXING_LENGTH", CS%Lfixed, &
                  "If positive, is a fixed length contribution to the expression\n"//&
                  "for mixing length used in MEKE-derived diffusiviity.", &
                  units="m", default=0.0)
-  call get_param(param_file, mod, "MEKE_ALPHA_DEFORM", CS%aDeform, &
+  call get_param(param_file, mdl, "MEKE_ALPHA_DEFORM", CS%aDeform, &
                  "If positive, is a coefficient weighting the deformation scale\n"//&
                  "in the expression for mixing length used in MEKE-derived diffusiviity.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "MEKE_ALPHA_RHINES", CS%aRhines, &
+  call get_param(param_file, mdl, "MEKE_ALPHA_RHINES", CS%aRhines, &
                  "If positive, is a coefficient weighting the Rhines scale\n"//&
                  "in the expression for mixing length used in MEKE-derived diffusiviity.", &
                  units="nondim", default=0.05)
-  call get_param(param_file, mod, "MEKE_ALPHA_EADY", CS%aEady, &
+  call get_param(param_file, mdl, "MEKE_ALPHA_EADY", CS%aEady, &
                  "If positive, is a coefficient weighting the Eady length scale\n"//&
                  "in the expression for mixing length used in MEKE-derived diffusiviity.", &
                  units="nondim", default=0.05)
-  call get_param(param_file, mod, "MEKE_ALPHA_FRICT", CS%aFrict, &
+  call get_param(param_file, mdl, "MEKE_ALPHA_FRICT", CS%aFrict, &
                  "If positive, is a coefficient weighting the frictional arrest scale\n"//&
                  "in the expression for mixing length used in MEKE-derived diffusiviity.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "MEKE_ALPHA_GRID", CS%aGrid, &
+  call get_param(param_file, mdl, "MEKE_ALPHA_GRID", CS%aGrid, &
                  "If positive, is a coefficient weighting the grid-spacing as a scale\n"//&
                  "in the expression for mixing length used in MEKE-derived diffusiviity.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "MEKE_COLD_START", coldStart, &
+  call get_param(param_file, mdl, "MEKE_COLD_START", coldStart, &
                  "If true, initialize EKE to zero. Otherwise a local equilibrium solution\n"//&
                  "is used as an initial condition for EKE.", default=.false.)
-  call get_param(param_file, mod, "MEKE_BACKSCAT_RO_C", MEKE%backscatter_Ro_c, &
+  call get_param(param_file, mdl, "MEKE_BACKSCAT_RO_C", MEKE%backscatter_Ro_c, &
                  "The coefficient in the Rossby number function for scaling the buharmonic\n"//&
                  "frictional energy source. Setting to non-zero enables the Rossby number function.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "MEKE_BACKSCAT_RO_POW", MEKE%backscatter_Ro_pow, &
+  call get_param(param_file, mdl, "MEKE_BACKSCAT_RO_POW", MEKE%backscatter_Ro_pow, &
                  "The power in the Rossby number function for scaling the biharmomnic\n"//&
                  "frictional energy source.", units="nondim", default=0.0)
-  call get_param(param_file, mod, "MEKE_ADVECTION_FACTOR", CS%MEKE_advection_factor, &
+  call get_param(param_file, mdl, "MEKE_ADVECTION_FACTOR", CS%MEKE_advection_factor, &
                  "A scale factor in front of advection of eddy energy. Zero turns advection off.\n"//&
                  "Using unity would be normal but other values could accomodate a mismatch\n"//&
                  "between the advecting barotropic flow and the vertical structure of MEKE.", &
                  units="nondim", default=0.0)
 
   ! Nonlocal module parameters
-  call get_param(param_file, mod, "CDRAG", CS%cdrag, &
+  call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
                  "CDRAG is the drag coefficient relating the magnitude of \n"//&
                  "the velocity field to the bottom stress.", units="nondim", &
                  default=0.003)
-  call get_param(param_file, mod, "LAPLACIAN", laplacian, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "LAPLACIAN", laplacian, default=.false., do_not_log=.true.)
   if (CS%viscosity_coeff/=0. .and. .not. laplacian) call MOM_error(FATAL, &
                  "LAPLACIAN must be true if MEKE_VISCOSITY_COEFF is true.")
 
-  call get_param(param_file, mod, "USE_VARIABLE_MIXING", useVarMix, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "USE_VARIABLE_MIXING", useVarMix, default=.false., do_not_log=.true.)
   if (.not. useVarMix .and. CS%aEady>0.) call MOM_error(FATAL, &
                  "USE_VARIABLE_MIXING must be true if USE_MEKE is true and MEKE_ALPHA_EADY>0.")
-  call get_param(param_file, mod, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
 
   ! Allocation of storage NOT shared with other modules
   if (CS%MEKE_K4>=0.) then

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1052,7 +1052,7 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_hor_visc"  ! module name
+  character(len=40)  :: mdl = "MOM_hor_visc"  ! module name
 
   is   = G%isc  ; ie   = G%iec  ; js   = G%jsc  ; je   = G%jec ; nz = G%ke
   Isq  = G%IscB ; Ieq  = G%IecB ; Jsq  = G%JscB ; Jeq  = G%JecB
@@ -1069,7 +1069,7 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
   CS%diag => diag
 
   ! Read parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
   !   It is not clear whether these initialization lines are needed for the
   ! cases where the corresponding parameters are not read.
@@ -1082,95 +1082,95 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
 
   !   If GET_ALL_PARAMS is true, all parameters are read in all cases to enable
   ! parameter spelling checks.
-  call get_param(param_file, mod, "GET_ALL_PARAMS", get_all, default=.false.)
+  call get_param(param_file, mdl, "GET_ALL_PARAMS", get_all, default=.false.)
 
-  call get_param(param_file, mod, "LAPLACIAN", CS%Laplacian, &
+  call get_param(param_file, mdl, "LAPLACIAN", CS%Laplacian, &
                  "If true, use a Laplacian horizontal viscosity.", &
                  default=.false.)
   if (CS%Laplacian .or. get_all) then
-    call get_param(param_file, mod, "KH", Kh,                      &
+    call get_param(param_file, mdl, "KH", Kh,                      &
                  "The background Laplacian horizontal viscosity.", &
                  units = "m2 s-1", default=0.0)
-    call get_param(param_file, mod, "KH_BG_MIN", CS%Kh_bg_min, &
+    call get_param(param_file, mdl, "KH_BG_MIN", CS%Kh_bg_min, &
                  "The minimum value allowed for Laplacian horizontal viscosity, KH.", &
                  units = "m2 s-1",  default=0.0)
-    call get_param(param_file, mod, "KH_VEL_SCALE", Kh_vel_scale, &
+    call get_param(param_file, mdl, "KH_VEL_SCALE", Kh_vel_scale, &
                  "The velocity scale which is multiplied by the grid \n"//&
                  "spacing to calculate the Laplacian viscosity. \n"//&
                  "The final viscosity is the largest of this scaled \n"//&
                  "viscosity, the Smagorinsky and Leith viscosities, and KH.", &
                  units="m s-1", default=0.0)
 
-    call get_param(param_file, mod, "SMAGORINSKY_KH", CS%Smagorinsky_Kh, &
+    call get_param(param_file, mdl, "SMAGORINSKY_KH", CS%Smagorinsky_Kh, &
                  "If true, use a Smagorinsky nonlinear eddy viscosity.", &
                  default=.false.)
     if (CS%Smagorinsky_Kh .or. get_all) &
-      call get_param(param_file, mod, "SMAG_LAP_CONST", Smag_Lap_const, &
+      call get_param(param_file, mdl, "SMAG_LAP_CONST", Smag_Lap_const, &
                  "The nondimensional Laplacian Smagorinsky constant, \n"//&
                  "often 0.15.", units="nondim", default=0.0, &
                   fail_if_missing = CS%Smagorinsky_Kh)
 
-    call get_param(param_file, mod, "LEITH_KH", CS%Leith_Kh, &
+    call get_param(param_file, mdl, "LEITH_KH", CS%Leith_Kh, &
                  "If true, use a Leith nonlinear eddy viscosity.", &
                  default=.false.)
 
-    call get_param(param_file, mod, "MODIFIED_LEITH", CS%Modified_Leith, &
+    call get_param(param_file, mdl, "MODIFIED_LEITH", CS%Modified_Leith, &
                  "If true, add a term to Leith viscosity which is \n"//&
                  "proportional to the gradient of divergence.", &
                  default=.false.)
 
     if (CS%Leith_Kh .or. get_all) &
-      call get_param(param_file, mod, "LEITH_LAP_CONST", Leith_Lap_const, &
+      call get_param(param_file, mdl, "LEITH_LAP_CONST", Leith_Lap_const, &
                  "The nondimensional Laplacian Leith constant, \n"//&
                  "often ??", units="nondim", default=0.0, &
                   fail_if_missing = CS%Leith_Kh)
 
-    call get_param(param_file, mod, "BOUND_KH", CS%bound_Kh, &
+    call get_param(param_file, mdl, "BOUND_KH", CS%bound_Kh, &
                  "If true, the Laplacian coefficient is locally limited \n"//&
                  "to be stable.", default=.true.)
-    call get_param(param_file, mod, "BETTER_BOUND_KH", CS%better_bound_Kh, &
+    call get_param(param_file, mdl, "BETTER_BOUND_KH", CS%better_bound_Kh, &
                  "If true, the Laplacian coefficient is locally limited \n"//&
                  "to be stable with a better bounding than just BOUND_KH.", &
                  default=CS%bound_Kh)
   endif
 
-  call get_param(param_file, mod, "BIHARMONIC", CS%biharmonic, &
+  call get_param(param_file, mdl, "BIHARMONIC", CS%biharmonic, &
                  "If true, use a biharmonic horizontal viscosity. \n"//&
                  "BIHARMONIC may be used with LAPLACIAN.", &
                  default=.true.)
   if (CS%biharmonic .or. get_all) then
-    call get_param(param_file, mod, "AH", Ah, &
+    call get_param(param_file, mdl, "AH", Ah, &
                  "The background biharmonic horizontal viscosity.", &
                  units = "m4 s-1", default=0.0)
-    call get_param(param_file, mod, "AH_VEL_SCALE", Ah_vel_scale, &
+    call get_param(param_file, mdl, "AH_VEL_SCALE", Ah_vel_scale, &
                  "The velocity scale which is multiplied by the cube of \n"//&
                  "the grid spacing to calculate the biharmonic viscosity. \n"//&
                  "The final viscosity is the largest of this scaled \n"//&
                  "viscosity, the Smagorinsky and Leith viscosities, and AH.", &
                  units="m s-1", default=0.0)
-    call get_param(param_file, mod, "SMAGORINSKY_AH", CS%Smagorinsky_Ah, &
+    call get_param(param_file, mdl, "SMAGORINSKY_AH", CS%Smagorinsky_Ah, &
                  "If true, use a biharmonic Smagorinsky nonlinear eddy \n"//&
                  "viscosity.", default=.false.)
-    call get_param(param_file, mod, "LEITH_AH", CS%Leith_Ah, &
+    call get_param(param_file, mdl, "LEITH_AH", CS%Leith_Ah, &
                  "If true, use a biharmonic Leith nonlinear eddy \n"//&
                  "viscosity.", default=.false.)
 
-    call get_param(param_file, mod, "BOUND_AH", CS%bound_Ah, &
+    call get_param(param_file, mdl, "BOUND_AH", CS%bound_Ah, &
                  "If true, the biharmonic coefficient is locally limited \n"//&
                  "to be stable.", default=.true.)
-    call get_param(param_file, mod, "BETTER_BOUND_AH", CS%better_bound_Ah, &
+    call get_param(param_file, mdl, "BETTER_BOUND_AH", CS%better_bound_Ah, &
                  "If true, the biharmonic coefficient is locally limited \n"//&
                  "to be stable with a better bounding than just BOUND_AH.", &
                  default=CS%bound_Ah)
 
     if (CS%Smagorinsky_Ah .or. get_all) then
-      call get_param(param_file, mod, "SMAG_BI_CONST",Smag_bi_const, &
+      call get_param(param_file, mdl, "SMAG_BI_CONST",Smag_bi_const, &
                  "The nondimensional biharmonic Smagorinsky constant, \n"//&
                  "typically 0.015 - 0.06.", units="nondim", default=0.0, &
                  fail_if_missing = CS%Smagorinsky_Ah)
 
-      call get_param(param_file, mod, "BOUND_CORIOLIS", bound_Cor_def, default=.false.)
-      call get_param(param_file, mod, "BOUND_CORIOLIS_BIHARM", CS%bound_Coriolis, &
+      call get_param(param_file, mdl, "BOUND_CORIOLIS", bound_Cor_def, default=.false.)
+      call get_param(param_file, mdl, "BOUND_CORIOLIS_BIHARM", CS%bound_Coriolis, &
                  "If true use a viscosity that increases with the square \n"//&
                  "of the velocity shears, so that the resulting viscous \n"//&
                  "drag is of comparable magnitude to the Coriolis terms \n"//&
@@ -1178,9 +1178,9 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
                  "points is 0.5*BOUND_CORIOLIS_VEL.  The default is the \n"//&
                  "value of BOUND_CORIOLIS (or false).", default=bound_Cor_def)
       if (CS%bound_Coriolis .or. get_all) then
-        call get_param(param_file, mod, "MAXVEL", maxvel, default=3.0e8)
+        call get_param(param_file, mdl, "MAXVEL", maxvel, default=3.0e8)
         bound_Cor_vel = maxvel
-        call get_param(param_file, mod, "BOUND_CORIOLIS_VEL", bound_Cor_vel, &
+        call get_param(param_file, mdl, "BOUND_CORIOLIS_VEL", bound_Cor_vel, &
                  "The velocity scale at which BOUND_CORIOLIS_BIHARM causes \n"//&
                  "the biharmonic drag to have comparable magnitude to the \n"//&
                  "Coriolis acceleration.  The default is set by MAXVEL.", &
@@ -1189,7 +1189,7 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
     endif
 
     if (CS%Leith_Ah .or. get_all) then
-      call get_param(param_file, mod, "LEITH_BI_CONST",Leith_bi_const, &
+      call get_param(param_file, mdl, "LEITH_BI_CONST",Leith_bi_const, &
                  "The nondimensional biharmonic Leith constant, \n"//&
                  "typical values are thus far undetermined", units="nondim", default=0.0, &
                  fail_if_missing = CS%Leith_Ah)
@@ -1198,13 +1198,13 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
   endif
 
   if (CS%better_bound_Ah .or. CS%better_bound_Kh .or. get_all) &
-    call get_param(param_file, mod, "HORVISC_BOUND_COEF", CS%bound_coef, &
+    call get_param(param_file, mdl, "HORVISC_BOUND_COEF", CS%bound_coef, &
                  "The nondimensional coefficient of the ratio of the \n"//&
                  "viscosity bounds to the theoretical maximum for \n"//&
                  "stability without considering other terms.", units="nondim", &
                  default=0.8)
 
-  call get_param(param_file, mod, "NOSLIP", CS%no_slip, &
+  call get_param(param_file, mdl, "NOSLIP", CS%no_slip, &
                  "If true, no slip boundary conditions are used; otherwise \n"//&
                  "free slip boundary conditions are assumed. The \n"//&
                  "implementation of the free slip BCs on a C-grid is much \n"//&
@@ -1212,14 +1212,14 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
                  "is strongly encouraged, and no slip BCs are not used with \n"//&
                  "the biharmonic viscosity.", default=.false.)
 
-  call get_param(param_file, mod, "USE_KH_BG_2D", CS%use_Kh_bg_2d, &
+  call get_param(param_file, mdl, "USE_KH_BG_2D", CS%use_Kh_bg_2d, &
                  "If true, read a file containing 2-d background harmonic  \n"//&
                  "viscosities. The final viscosity is the maximum of the other "//&
                  "terms and this background value.", default=.false.)
 
 
   if (CS%bound_Kh .or. CS%bound_Ah .or. CS%better_bound_Kh .or. CS%better_bound_Ah) &
-    call get_param(param_file, mod, "DT", dt, &
+    call get_param(param_file, mdl, "DT", dt, &
                  "The (baroclinic) dynamics time step.", units = "s", &
                  fail_if_missing=.true.)
 
@@ -1262,10 +1262,10 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
 
   if (CS%use_Kh_bg_2d) then
     ALLOC_(CS%Kh_bg_2d(isd:ied,jsd:jed))     ; CS%Kh_bg_2d(:,:) = 0.0
-    call get_param(param_file, mod, "KH_BG_2D_FILENAME", filename, &
+    call get_param(param_file, mdl, "KH_BG_2D_FILENAME", filename, &
                  'The filename containing a 2d map of "Kh".', &
                  default='KH_background_2d.nc')
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     inputdir = slasher(inputdir)
     call read_data(trim(inputdir)//trim(filename), 'Kh', CS%Kh_bg_2d, &
                    domain=G%domain%mpp_domain, timelevel=1)

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -2330,7 +2330,7 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
   type(axes_grp) :: axes_ang
   ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_internal_tides" ! This module's name.
+  character(len=40)  :: mdl = "MOM_internal_tides" ! This module's name.
   character(len=16), dimension(8) :: freq_name
   character(len=40)  :: var_name
   character(len=160) :: var_descript
@@ -2388,18 +2388,18 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
 
   CS%Time => Time ! direct a pointer to the current model time target
 
-  call get_param(param_file, mod, "INPUTDIR", CS%inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
                  CS%inputdir = slasher(CS%inputdir)
 
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mod, "INTERNAL_TIDE_FREQS", num_freq, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_FREQS", num_freq, &
                  "The number of distinct internal tide frequency bands \n"//&
                  "that will be calculated.", default=1)
-  call get_param(param_file, mod, "INTERNAL_TIDE_MODES", num_mode, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_MODES", num_mode, &
                  "The number of distinct internal tide modes \n"//&
                  "that will be calculated.", default=1)
-  call get_param(param_file, mod, "INTERNAL_TIDE_ANGLES", num_angle, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_ANGLES", num_angle, &
                  "The number of angular resolution bands for the internal \n"//&
                  "tide calculations.", default=24)
 
@@ -2429,17 +2429,17 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
 
   CS%diag => diag
 
-  call get_param(param_file, mod, "INTERNAL_TIDE_DECAY_RATE", CS%decay_rate, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_DECAY_RATE", CS%decay_rate, &
                  "The rate at which internal tide energy is lost to the \n"//&
                  "interior ocean internal wave field.", units="s-1", default=0.0)
-  call get_param(param_file, mod, "INTERNAL_TIDE_VOLUME_BASED_CFL", CS%vol_CFL, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_VOLUME_BASED_CFL", CS%vol_CFL, &
                  "If true, use the ratio of the open face lengths to the \n"//&
                  "tracer cell areas when estimating CFL numbers in the \n"//&
                  "internal tide code.", default=.false.)
-  call get_param(param_file, mod, "INTERNAL_TIDE_CORNER_ADVECT", CS%corner_adv, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_CORNER_ADVECT", CS%corner_adv, &
                  "If true, internal tide ray-tracing advection uses a \n"//&
                  " corner-advection scheme rather than PPM.\n", default=.false.)
-  call get_param(param_file, mod, "INTERNAL_TIDE_SIMPLE_2ND_PPM", CS%simple_2nd, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_SIMPLE_2ND_PPM", CS%simple_2nd, &
                  "If true, CONTINUITY_PPM uses a simple 2nd order \n"//&
                  "(arithmetic mean) interpolation of the edge values. \n"//&
                  "This may give better PV conservation propterties. While \n"//&
@@ -2447,44 +2447,44 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
                  "solver itself in the strongly advective limit, it does \n"//&
                  "not reduce the overall order of accuracy of the dynamic \n"//&
                  "core.", default=.false.)
-  call get_param(param_file, mod, "INTERNAL_TIDE_UPWIND_1ST", CS%upwind_1st, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_UPWIND_1ST", CS%upwind_1st, &
                  "If true, the internal tide ray-tracing advection uses \n"//&
                  "1st-order upwind advection.  This scheme is highly \n"//&
                  "continuity solver.  This scheme is highly \n"//&
                  "diffusive but may be useful for debugging.", default=.false.)
-  call get_param(param_file, mod, "INTERNAL_TIDE_BACKGROUND_DRAG", &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_BACKGROUND_DRAG", &
                  CS%apply_background_drag, "If true, the internal tide \n"//&
                  "ray-tracing advection uses a background drag term as a sink.",&
                  default=.false.)
-  call get_param(param_file, mod, "INTERNAL_TIDE_QUAD_DRAG", CS%apply_bottom_drag, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_QUAD_DRAG", CS%apply_bottom_drag, &
                  "If true, the internal tide ray-tracing advection uses \n"//&
                  "a quadratic bottom drag term as a sink.", default=.false.)
-  call get_param(param_file, mod, "INTERNAL_TIDE_WAVE_DRAG", CS%apply_wave_drag, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_WAVE_DRAG", CS%apply_wave_drag, &
                  "If true, apply scattering due to small-scale roughness as a sink.", &
                  default=.false.)
-  call get_param(param_file, mod, "INTERNAL_TIDE_FROUDE_DRAG", CS%apply_Froude_drag, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_FROUDE_DRAG", CS%apply_Froude_drag, &
                  "If true, apply wave breaking as a sink.", &
                  default=.false.)
-  call get_param(param_file, mod, "CDRAG", CS%cdrag, &
+  call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
                  "CDRAG is the drag coefficient relating the magnitude of \n"//&
                  "the velocity field to the bottom stress.", units="nondim", &
                  default=0.003)
-  call get_param(param_file, mod, "INTERNAL_TIDE_ENERGIZED_ANGLE", CS%energized_angle, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_ENERGIZED_ANGLE", CS%energized_angle, &
                  "If positive, only one angular band of the internal tides \n"//&
                  "gets all of the energy.  (This is for debugging.)", default=-1)
-  call get_param(param_file, mod, "USE_PPM_ANGULAR", CS%use_PPMang, &
+  call get_param(param_file, mdl, "USE_PPM_ANGULAR", CS%use_PPMang, &
                  "If true, use PPM for advection of energy in angular  \n"//&
                  "space.", default=.false.)
-  call get_param(param_file, mod, "GAMMA_ITIDES", CS%q_itides, &
+  call get_param(param_file, mdl, "GAMMA_ITIDES", CS%q_itides, &
                  "The fraction of the internal tidal energy that is \n"//&
                  "dissipated locally with INT_TIDE_DISSIPATION.  \n"//&
                  "THIS NAME COULD BE BETTER.", &
                  units="nondim", default=0.3333)
-    call get_param(param_file, mod, "KAPPA_ITIDES", kappa_itides, &
+    call get_param(param_file, mdl, "KAPPA_ITIDES", kappa_itides, &
                "A topographic wavenumber used with INT_TIDE_DISSIPATION. \n"//&
                "The default is 2pi/10 km, as in St.Laurent et al. 2002.", &
                units="m-1", default=8.e-4*atan(1.0))
-  call get_param(param_file, mod, "KAPPA_H2_FACTOR", kappa_h2_factor, &
+  call get_param(param_file, mdl, "KAPPA_H2_FACTOR", kappa_h2_factor, &
                "A scaling factor for the roughness amplitude with n"//&
                "INT_TIDE_DISSIPATION.",  units="nondim", default=1.0)
 
@@ -2506,12 +2506,12 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
   allocate(CS%tot_Froude_loss(isd:ied,jsd:jed)) ; CS%tot_Froude_loss(:,:) = 0.0
 
   ! Compute the fixed part of the bottom drag loss from baroclinic modes
-  call get_param(param_file, mod, "H2_FILE", h2_file, &
+  call get_param(param_file, mdl, "H2_FILE", h2_file, &
           "The path to the file containing the sub-grid-scale \n"//&
           "topographic roughness amplitude with INT_TIDE_DISSIPATION.", &
           fail_if_missing=.true.)
   filename = trim(CS%inputdir) // trim(h2_file)
-  call log_param(param_file, mod, "INPUTDIR/H2_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/H2_FILE", filename)
   call read_data(filename, 'h2', h2, domain=G%domain%mpp_domain, timelevel=1)
   do j=G%jsc,G%jec ; do i=G%isc,G%iec
     ! Restrict rms topo to 10 percent of column depth.
@@ -2523,12 +2523,12 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
   enddo; enddo
 
   ! Read in prescribed coast/ridge/shelf angles from file
-  call get_param(param_file, mod, "REFL_ANGLE_FILE", refl_angle_file, &
+  call get_param(param_file, mdl, "REFL_ANGLE_FILE", refl_angle_file, &
                "The path to the file containing the local angle of \n"//&
                "the coastline/ridge/shelf with respect to the equator.", &
                fail_if_missing=.false.)
   filename = trim(CS%inputdir) // trim(refl_angle_file)
-  call log_param(param_file, mod, "INPUTDIR/REFL_ANGLE_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/REFL_ANGLE_FILE", filename)
   allocate(CS%refl_angle(isd:ied,jsd:jed)) ; CS%refl_angle(:,:) = CS%nullangle
   call read_data(filename, 'refl_angle', CS%refl_angle, &
                  domain=G%domain%mpp_domain, timelevel=1)
@@ -2539,11 +2539,11 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
   call pass_var(CS%refl_angle,G%domain)
 
   ! Read in prescribed partial reflection coefficients from file
-  call get_param(param_file, mod, "REFL_PREF_FILE", refl_pref_file, &
+  call get_param(param_file, mdl, "REFL_PREF_FILE", refl_pref_file, &
                "The path to the file containing the reflection coefficients.", &
                fail_if_missing=.false.)
   filename = trim(CS%inputdir) // trim(refl_pref_file)
-  call log_param(param_file, mod, "INPUTDIR/REFL_PREF_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/REFL_PREF_FILE", filename)
   allocate(CS%refl_pref(isd:ied,jsd:jed)) ; CS%refl_pref(:,:) = 1.0
   call read_data(filename, 'refl_pref', CS%refl_pref, &
                  domain=G%domain%mpp_domain, timelevel=1)
@@ -2563,11 +2563,11 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
   enddo
 
   ! Read in double-reflective (ridge) tags from file
-  call get_param(param_file, mod, "REFL_DBL_FILE", refl_dbl_file, &
+  call get_param(param_file, mdl, "REFL_DBL_FILE", refl_dbl_file, &
                "The path to the file containing the double-reflective ridge tags.", &
                fail_if_missing=.false.)
   filename = trim(CS%inputdir) // trim(refl_dbl_file)
-  call log_param(param_file, mod, "INPUTDIR/REFL_DBL_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/REFL_DBL_FILE", filename)
   allocate(ridge_temp(isd:ied,jsd:jed)) ; ridge_temp(:,:) = 0.0
   call read_data(filename, 'refl_dbl', ridge_temp, &
                  domain=G%domain%mpp_domain, timelevel=1)
@@ -2581,11 +2581,11 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
   ! Read in prescribed land mask from file (if overwriting -BDM).
   ! This should be done in MOM_initialize_topography subroutine
   ! defined in MOM_fixed_initialization.F90 (BDM)
-  !call get_param(param_file, mod, "LAND_MASK_FILE", land_mask_file, &
+  !call get_param(param_file, mdl, "LAND_MASK_FILE", land_mask_file, &
   !             "The path to the file containing the land mask.", &
   !             fail_if_missing=.false.)
   !filename = trim(CS%inputdir) // trim(land_mask_file)
-  !call log_param(param_file, mod, "INPUTDIR/LAND_MASK_FILE", filename)
+  !call log_param(param_file, mdl, "INPUTDIR/LAND_MASK_FILE", filename)
   !G%mask2dCu(:,:) = 1 ; G%mask2dCv(:,:) = 1 ; G%mask2dT(:,:)  = 1
   !call read_data(filename, 'land_mask', G%mask2dCu, &
   !               domain=G%domain%mpp_domain, timelevel=1)
@@ -2598,31 +2598,31 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
   !call pass_var(G%mask2dT,G%domain)
 
   ! Read in prescribed partial east face blockages from file (if overwriting -BDM)
-  !call get_param(param_file, mod, "dy_Cu_FILE", dy_Cu_file, &
+  !call get_param(param_file, mdl, "dy_Cu_FILE", dy_Cu_file, &
   !             "The path to the file containing the east face blockages.", &
   !             fail_if_missing=.false.)
   !filename = trim(CS%inputdir) // trim(dy_Cu_file)
-  !call log_param(param_file, mod, "INPUTDIR/dy_Cu_FILE", filename)
+  !call log_param(param_file, mdl, "INPUTDIR/dy_Cu_FILE", filename)
   !G%dy_Cu(:,:) = 0.0
   !call read_data(filename, 'dy_Cu', G%dy_Cu, &
   !               domain=G%domain%mpp_domain, timelevel=1)
   !call pass_var(G%dy_Cu,G%domain)
 
   ! Read in prescribed partial north face blockages from file (if overwriting -BDM)
-  !call get_param(param_file, mod, "dx_Cv_FILE", dx_Cv_file, &
+  !call get_param(param_file, mdl, "dx_Cv_FILE", dx_Cv_file, &
   !             "The path to the file containing the north face blockages.", &
   !             fail_if_missing=.false.)
   !filename = trim(CS%inputdir) // trim(dx_Cv_file)
-  !call log_param(param_file, mod, "INPUTDIR/dx_Cv_FILE", filename)
+  !call log_param(param_file, mdl, "INPUTDIR/dx_Cv_FILE", filename)
   !G%dx_Cv(:,:) = 0.0
   !call read_data(filename, 'dx_Cv', G%dx_Cv, &
   !               domain=G%domain%mpp_domain, timelevel=1)
   !call pass_var(G%dx_Cv,G%domain)
 
   ! For debugging - delete later
-  call get_param(param_file, mod, "INTERNAL_TIDE_SOURCE_X", CS%int_tide_source_x, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_X", CS%int_tide_source_x, &
                 "X Location of generation site for internal tide", default=1.)
-  call get_param(param_file, mod, "INTERNAL_TIDE_SOURCE_Y", CS%int_tide_source_y, &
+  call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_Y", CS%int_tide_source_y, &
                 "Y Location of generation site for internal tide", default=1.)
 
   ! Register maps of reflection parameters

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -738,7 +738,7 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
   logical :: Resoln_use_ebt, khth_use_ebt_struct
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_lateral_mixing_coeffs" ! This module's name.
+  character(len=40)  :: mdl = "MOM_lateral_mixing_coeffs" ! This module's name.
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -753,44 +753,44 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
   !   This first set of parameters are read into local variables first, in case
   ! the control structure should not be allocated.
-  call get_param(param_file, mod, "USE_VARIABLE_MIXING", use_variable_mixing,&
+  call get_param(param_file, mdl, "USE_VARIABLE_MIXING", use_variable_mixing,&
                  "If true, the variable mixing code will be called.  This \n"//&
                  "allows diagnostics to be created even if the scheme is \n"//&
                  "not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0, \n"//&
                  "this is set to true regardless of what is in the \n"//&
                  "parameter file.", default=.false.)
-  call get_param(param_file, mod, "RESOLN_SCALED_KH", Resoln_scaled_Kh, &
+  call get_param(param_file, mdl, "RESOLN_SCALED_KH", Resoln_scaled_Kh, &
                  "If true, the Laplacian lateral viscosity is scaled away \n"//&
                  "when the first baroclinic deformation radius is well \n"//&
                  "resolved.", default=.false.)
-  call get_param(param_file, mod, "RESOLN_SCALED_KHTH", Resoln_scaled_KhTh, &
+  call get_param(param_file, mdl, "RESOLN_SCALED_KHTH", Resoln_scaled_KhTh, &
                  "If true, the interface depth diffusivity is scaled away \n"//&
                  "when the first baroclinic deformation radius is well \n"//&
                  "resolved.", default=.false.)
-  call get_param(param_file, mod, "RESOLN_SCALED_KHTR", Resoln_scaled_KhTr, &
+  call get_param(param_file, mdl, "RESOLN_SCALED_KHTR", Resoln_scaled_KhTr, &
                  "If true, the epipycnal tracer diffusivity is scaled \n"//&
                  "away when the first baroclinic deformation radius is \n"//&
                  "well resolved.", default=.false.)
-  call get_param(param_file, mod, "RESOLN_USE_EBT", Resoln_use_ebt, &
+  call get_param(param_file, mdl, "RESOLN_USE_EBT", Resoln_use_ebt, &
                  "If true, uses the equivalent barotropic wave speed instead\n"//&
                  "of first baroclinic wave for calculating the resolution fn.",&
                  default=.false.)
-  call get_param(param_file, mod, "KHTH_USE_EBT_STRUCT", khth_use_ebt_struct, &
+  call get_param(param_file, mdl, "KHTH_USE_EBT_STRUCT", khth_use_ebt_struct, &
                  "If true, uses the equivalent barotropic structure\n"//&
                  "as the vertical structure of thickness diffusivity.",&
                  default=.false.)
-  call get_param(param_file, mod, "KHTH_SLOPE_CFF", KhTh_Slope_Cff, &
+  call get_param(param_file, mdl, "KHTH_SLOPE_CFF", KhTh_Slope_Cff, &
                  "The nondimensional coefficient in the Visbeck formula \n"//&
                  "for the interface depth diffusivity", units="nondim", &
                  default=0.0)
-  call get_param(param_file, mod, "KHTR_SLOPE_CFF", KhTr_Slope_Cff, &
+  call get_param(param_file, mdl, "KHTR_SLOPE_CFF", KhTr_Slope_Cff, &
                  "The nondimensional coefficient in the Visbeck formula \n"//&
                  "for the epipycnal tracer diffusivity", units="nondim", &
                  default=0.0)
-  call get_param(param_file, mod, "USE_STORED_SLOPES", use_stored_slopes,&
+  call get_param(param_file, mdl, "USE_STORED_SLOPES", use_stored_slopes,&
                  "If true, the isopycnal slopes are calculated once and\n"//&
                  "stored for re-use. This uses more memory but avoids calling\n"//&
                  "the equation of state more times than should be necessary.", &
@@ -808,12 +808,12 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
     CS%khth_use_ebt_struct = khth_use_ebt_struct
     CS%use_variable_mixing = use_variable_mixing
     CS%use_stored_slopes = use_stored_slopes
-    call get_param(param_file, mod, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
+    call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
   else
     return
   endif
   if (Resoln_use_ebt .or. khth_use_ebt_struct) then
-    call get_param(param_file, mod, "RESOLN_N2_FILTER_DEPTH", N2_filter_depth, &
+    call get_param(param_file, mdl, "RESOLN_N2_FILTER_DEPTH", N2_filter_depth, &
                  "The depth below which N2 is monotonized to avoid stratification\n"//&
                  "artifacts from altering the equivalent barotropic mode structure.",&
                  units='m', default=2000.)
@@ -822,7 +822,7 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
     allocate(CS%ebt_struct(isd:ied,jsd:jed,G%ke)) ; CS%ebt_struct(:,:,:) = 0.0
   endif
   if (use_variable_mixing) then
-    call get_param(param_file, mod, "VISBECK_MAX_SLOPE", CS%Visbeck_S_max, &
+    call get_param(param_file, mdl, "VISBECK_MAX_SLOPE", CS%Visbeck_S_max, &
           "If non-zero, is an upper bound on slopes used in the\n"//       &
           "Visbeck formula for diffusivity. This does not affect the\n"//  &
           "isopycnal slope calculation used within thickness diffusion.",  &
@@ -833,7 +833,7 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
   if (CS%use_stored_slopes) then
     allocate(CS%slope_x(IsdB:IedB,jsd:jed,G%ke+1)) ; CS%slope_x(:,:,:) = 0.0
     allocate(CS%slope_y(isd:ied,JsdB:JedB,G%ke+1)) ; CS%slope_y(:,:,:) = 0.0
-    call get_param(param_file, mod, "KD_SMOOTH", CS%kappa_smooth, &
+    call get_param(param_file, mdl, "KD_SMOOTH", CS%kappa_smooth, &
                  "A diapycnal diffusivity that is used to interpolate \n"//&
                  "more sensible values of T & S into thin layers.", &
                  default=1.0e-6)
@@ -847,11 +847,11 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
     call MOM_mesg("VarMix_init: memory allocated for use_variable_mixing", 5)
 
   ! More run-time parameters
-    call get_param(param_file, mod, "VARMIX_KTOP", CS%VarMix_Ktop, &
+    call get_param(param_file, mdl, "VARMIX_KTOP", CS%VarMix_Ktop, &
                  "The layer number at which to start vertical integration \n"//&
                  "of S*N for purposes of finding the Eady growth rate.", &
                  units="nondim", default=2)
-    call get_param(param_file, mod, "VISBECK_L_SCALE", CS%Visbeck_L_scale, &
+    call get_param(param_file, mdl, "VISBECK_L_SCALE", CS%Visbeck_L_scale, &
                  "The fixed length scale in the Visbeck formula.", units="m", &
                  default=0.0)
 
@@ -901,36 +901,36 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
     CS%id_Rd_dx = register_diag_field('ocean_model', 'Rd_dx', diag%axesT1, Time, &
        'Ratio between deformation radius and grid spacing', 'Nondim')
 
-    call get_param(param_file, mod, "KH_RES_SCALE_COEF", CS%Res_coef_khth, &
+    call get_param(param_file, mdl, "KH_RES_SCALE_COEF", CS%Res_coef_khth, &
                  "A coefficient that determines how KhTh is scaled away if \n"//&
                  "RESOLN_SCALED_... is true, as \n"//&
                  "F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).", &
                  units="nondim", default=1.0)
-    call get_param(param_file, mod, "KH_RES_FN_POWER", CS%Res_fn_power_khth, &
+    call get_param(param_file, mdl, "KH_RES_FN_POWER", CS%Res_fn_power_khth, &
                  "The power of dx/Ld in the Kh resolution function.  Any \n"//&
                  "positive integer may be used, although even integers \n"//&
                  "are more efficient to calculate.  Setting this greater \n"//&
                  "than 100 results in a step-function being used.", &
                  units="nondim", default=2)
-    call get_param(param_file, mod, "VISC_RES_SCALE_COEF", CS%Res_coef_visc, &
+    call get_param(param_file, mdl, "VISC_RES_SCALE_COEF", CS%Res_coef_visc, &
                  "A coefficient that determines how Kh is scaled away if \n"//&
                  "RESOLN_SCALED_... is true, as \n"//&
                  "F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).\n"//&
                  "This function affects lateral viscosity, Kh, and not KhTh.", &
                  units="nondim", default=CS%Res_coef_khth)
-    call get_param(param_file, mod, "VISC_RES_FN_POWER", CS%Res_fn_power_visc, &
+    call get_param(param_file, mdl, "VISC_RES_FN_POWER", CS%Res_fn_power_visc, &
                  "The power of dx/Ld in the Kh resolution function.  Any \n"//&
                  "positive integer may be used, although even integers \n"//&
                  "are more efficient to calculate.  Setting this greater \n"//&
                  "than 100 results in a step-function being used.\n"//&
                  "This function affects lateral viscosity, Kh, and not KhTh.", &
                  units="nondim", default=CS%Res_fn_power_khth)
-    call get_param(param_file, mod, "INTERPOLATE_RES_FN", CS%interpolate_Res_fn, &
+    call get_param(param_file, mdl, "INTERPOLATE_RES_FN", CS%interpolate_Res_fn, &
                  "If true, interpolate the resolution function to the \n"//&
                  "velocity points from the thickness points; otherwise \n"//&
                  "interpolate the wave speed and calculate the resolution \n"//&
                  "function independently at each point.", default=.true.)
-    call get_param(param_file, mod, "USE_VISBECK_SLOPE_BUG", CS%use_Visbeck_slope_bug, &
+    call get_param(param_file, mdl, "USE_VISBECK_SLOPE_BUG", CS%use_Visbeck_slope_bug, &
                  "If true, then retain a legacy bug in the calculation of weights \n"//&
                  "applied to isoneutral slopes. There was an erroneous k-indexing \n"//&
                  "for layer thicknesses. In addition, masking at coastlines was not \n"//&
@@ -944,7 +944,7 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
            "MOM_lateral_mixing_coeffs.F90, VarMix_init:"//&
            "When INTERPOLATE_RES_FN=True, VISC_RES_FN_POWER must equal KH_RES_FN_POWER.")
     endif
-    call get_param(param_file, mod, "GILL_EQUATORIAL_LD", Gill_equatorial_Ld, &
+    call get_param(param_file, mdl, "GILL_EQUATORIAL_LD", Gill_equatorial_Ld, &
                  "If true, uses Gill's definition of the baroclinic\n"//&
                  "equatorial deformation radius, otherwise, if false, use\n"//&
                  "Pedlosky's definition. These definitions differ by a factor\n"//&

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -72,7 +72,7 @@ type, public :: mixedlayer_restrat_CS ; private
 
 end type mixedlayer_restrat_CS
 
-character(len=40)  :: mod = "MOM_mixed_layer_restrat" !< This module's name.
+character(len=40)  :: mdl = "MOM_mixed_layer_restrat" !< This module's name.
 
 contains
 
@@ -751,8 +751,8 @@ logical function mixedlayer_restrat_init(Time, G, GV, param_file, diag, CS)
   character(len=48)  :: flux_units
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "MIXEDLAYER_RESTRAT", mixedlayer_restrat_init, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "MIXEDLAYER_RESTRAT", mixedlayer_restrat_init, &
              "If true, a density-gradient dependent re-stratifying \n"//&
              "flow is imposed in the mixed layer. Can be used in ALE mode\n"//&
              "without restriction but in layer mode can only be used if\n"//&
@@ -771,8 +771,8 @@ logical function mixedlayer_restrat_init(Time, G, GV, param_file, diag, CS)
   CS%MLE_use_PBL_MLD = .false.
   CS%MLE_MLD_stretch = -9.e9
 
-  call get_param(param_file, mod, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
-  call get_param(param_file, mod, "FOX_KEMPER_ML_RESTRAT_COEF", CS%ml_restrat_coef, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "FOX_KEMPER_ML_RESTRAT_COEF", CS%ml_restrat_coef, &
              "A nondimensional coefficient that is proportional to \n"//&
              "the ratio of the deformation radius to the dominant \n"//&
              "lengthscale of the submesoscale mixed layer \n"//&
@@ -784,40 +784,40 @@ logical function mixedlayer_restrat_init(Time, G, GV, param_file, diag, CS)
   ! We use GV%nkml to distinguish between the old and new implementation of MLE.
   ! The old implementation only works for the layer model with nkml>0.
   if (GV%nkml==0) then
-    call get_param(param_file, mod, "FOX_KEMPER_ML_RESTRAT_COEF2", CS%ml_restrat_coef2, &
+    call get_param(param_file, mdl, "FOX_KEMPER_ML_RESTRAT_COEF2", CS%ml_restrat_coef2, &
              "As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application\n"//&
              "of the MLE restratification parameterization.", units="nondim", default=0.0)
   ! We use GV%nkml to distinguish between the old and new implementation of MLE.
-    call get_param(param_file, mod, "MLE_USE_PBL_MLD", CS%MLE_use_PBL_MLD, &
+    call get_param(param_file, mdl, "MLE_USE_PBL_MLD", CS%MLE_use_PBL_MLD, &
              "If true, the MLE parameterization will use the mixed-layer\n"//&
              "depth provided by the active PBL parameterization. If false,\n"//&
              "MLE will estimate a MLD based on a density difference with the\n"//&
              "surface using the parameter MLE_DENSITY_DIFF.", default=.false.)
-    call get_param(param_file, mod, "MLE_MLD_DECAY_TIME", CS%MLE_MLD_decay_time, &
+    call get_param(param_file, mdl, "MLE_MLD_DECAY_TIME", CS%MLE_MLD_decay_time, &
              "The time-scale for a running-mean filter applied to the mixed-layer\n"//&
              "depth used in the MLE restratification parameterization. When\n"//&
              "the MLD deepens below the current running-mean the running-mean\n"//&
              "is instantaneously set to the current MLD.", units="s", default=0.)
-    call get_param(param_file, mod, "MLE_MLD_DECAY_TIME2", CS%MLE_MLD_decay_time2, &
+    call get_param(param_file, mdl, "MLE_MLD_DECAY_TIME2", CS%MLE_MLD_decay_time2, &
              "The time-scale for a running-mean filter applied to the filtered\n"//&
              "mixed-layer depth used in a second MLE restratification parameterization.\n"//&
              "When the MLD deepens below the current running-mean the running-mean\n"//&
              "is instantaneously set to the current MLD.", units="s", default=0.)
     if (.not. CS%MLE_use_PBL_MLD) then
-      call get_param(param_file, mod, "MLE_DENSITY_DIFF", CS%MLE_density_diff, &
+      call get_param(param_file, mdl, "MLE_DENSITY_DIFF", CS%MLE_density_diff, &
              "Density difference used to detect the mixed-layer\n"//&
              "depth used for the mixed-layer eddy parameterization\n"//&
              "by Fox-Kemper et al. (2010)", units="kg/m3", default=0.03)
     endif
-    call get_param(param_file, mod, "MLE_TAIL_DH", CS%MLE_tail_dh, &
+    call get_param(param_file, mdl, "MLE_TAIL_DH", CS%MLE_tail_dh, &
              "Fraction by which to extend the mixed-layer restratification\n"//&
              "depth used for a smoother stream function at the base of\n"//&
              "the mixed-layer.", units="nondim", default=0.0)
-    call get_param(param_file, mod, "MLE_MLD_STRETCH", CS%MLE_MLD_stretch, &
+    call get_param(param_file, mdl, "MLE_MLD_STRETCH", CS%MLE_MLD_stretch, &
              "A scaling coefficient for stretching/shrinking the MLD\n"//&
              "used in the MLE scheme. This simply multiplies MLD wherever used.",&
              units="nondim", default=1.0)
-    call get_param(param_file, mod, "MLE_USE_MLD_AVE_BUG", CS%MLE_use_MLD_ave_bug, &
+    call get_param(param_file, mdl, "MLE_USE_MLD_AVE_BUG", CS%MLE_use_MLD_ave_bug, &
              "If true, do not account for MLD mismatch to interface positions.",&
              default=.false.)
   endif
@@ -867,7 +867,7 @@ subroutine mixedlayer_restrat_register_restarts(HI, param_file, CS, restart_CS)
   logical :: mixedlayer_restrat_init
 
   ! Check to see if this module will be used
-  call get_param(param_file, mod, "MIXEDLAYER_RESTRAT", mixedlayer_restrat_init, &
+  call get_param(param_file, mdl, "MIXEDLAYER_RESTRAT", mixedlayer_restrat_init, &
              default=.false., do_not_log=.true.)
   if (.not. mixedlayer_restrat_init) return
 
@@ -876,9 +876,9 @@ subroutine mixedlayer_restrat_register_restarts(HI, param_file, CS, restart_CS)
        "mixedlayer_restrat_register_restarts called with an associated control structure.")
   allocate(CS)
 
-  call get_param(param_file, mod, "MLE_MLD_DECAY_TIME", CS%MLE_MLD_decay_time, &
+  call get_param(param_file, mdl, "MLE_MLD_DECAY_TIME", CS%MLE_MLD_decay_time, &
                  default=0., do_not_log=.true.)
-  call get_param(param_file, mod, "MLE_MLD_DECAY_TIME2", CS%MLE_MLD_decay_time2, &
+  call get_param(param_file, mdl, "MLE_MLD_DECAY_TIME2", CS%MLE_MLD_decay_time2, &
                  default=0., do_not_log=.true.)
   if (CS%MLE_MLD_decay_time>0. .or. CS%MLE_MLD_decay_time2>0.) then
     ! CS%MLD_filtered is used to keep a running mean of the PBL's actively mixed MLD.

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1673,7 +1673,7 @@ subroutine thickness_diffuse_init(Time, G, GV, param_file, diag, CDp, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_thickness_diffuse" ! This module's name.
+  character(len=40)  :: mdl = "MOM_thickness_diffuse" ! This module's name.
   character(len=48)  :: flux_units
   real :: omega, strat_floor
 
@@ -1686,70 +1686,70 @@ subroutine thickness_diffuse_init(Time, G, GV, param_file, diag, CDp, CS)
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "THICKNESSDIFFUSE", CS%thickness_diffuse, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "THICKNESSDIFFUSE", CS%thickness_diffuse, &
                  "If true, interface heights are diffused with a \n"//&
                  "coefficient of KHTH.", default=.false.)
-  call get_param(param_file, mod, "KHTH", CS%Khth, &
+  call get_param(param_file, mdl, "KHTH", CS%Khth, &
                  "The background horizontal thickness diffusivity.", &
                  units = "m2 s-1", default=0.0)
-  call get_param(param_file, mod, "KHTH_SLOPE_CFF", CS%KHTH_Slope_Cff, &
+  call get_param(param_file, mdl, "KHTH_SLOPE_CFF", CS%KHTH_Slope_Cff, &
                  "The nondimensional coefficient in the Visbeck formula \n"//&
                  "for the interface depth diffusivity", units="nondim", &
                  default=0.0)
-  call get_param(param_file, mod, "KHTH_MIN", CS%KHTH_Min, &
+  call get_param(param_file, mdl, "KHTH_MIN", CS%KHTH_Min, &
                  "The minimum horizontal thickness diffusivity.", &
                  units = "m2 s-1", default=0.0)
-  call get_param(param_file, mod, "KHTH_MAX", CS%KHTH_Max, &
+  call get_param(param_file, mdl, "KHTH_MAX", CS%KHTH_Max, &
                  "The maximum horizontal thickness diffusivity.", &
                  units = "m2 s-1", default=0.0)
-  call get_param(param_file, mod, "KHTH_MAX_CFL", CS%max_Khth_CFL, &
+  call get_param(param_file, mdl, "KHTH_MAX_CFL", CS%max_Khth_CFL, &
                  "The maximum value of the local diffusive CFL ratio that \n"//&
                  "is permitted for the thickness diffusivity. 1.0 is the \n"//&
                  "marginally unstable value in a pure layered model, but \n"//&
                  "much smaller numbers (e.g. 0.1) seem to work better for \n"//&
                  "ALE-based models.", units = "nondimensional", default=0.8)
   if (CS%max_Khth_CFL < 0.0) CS%max_Khth_CFL = 0.0
-  call get_param(param_file, mod, "DETANGLE_INTERFACES", CS%detangle_interfaces, &
+  call get_param(param_file, mdl, "DETANGLE_INTERFACES", CS%detangle_interfaces, &
                  "If defined add 3-d structured enhanced interface height \n"//&
                  "diffusivities to horizonally smooth jagged layers.", &
                  default=.false.)
   CS%detangle_time = 0.0
   if (CS%detangle_interfaces) &
-    call get_param(param_file, mod, "DETANGLE_TIMESCALE", CS%detangle_time, &
+    call get_param(param_file, mdl, "DETANGLE_TIMESCALE", CS%detangle_time, &
                  "A timescale over which maximally jagged grid-scale \n"//&
                  "thickness variations are suppressed.  This must be \n"//&
                  "longer than DT, or 0 to use DT.", units = "s", default=0.0)
-  call get_param(param_file, mod, "KHTH_SLOPE_MAX", CS%slope_max, &
+  call get_param(param_file, mdl, "KHTH_SLOPE_MAX", CS%slope_max, &
                  "A slope beyond which the calculated isopycnal slope is \n"//&
                  "not reliable and is scaled away.", units="nondim", default=0.01)
-  call get_param(param_file, mod, "KD_SMOOTH", CS%kappa_smooth, &
+  call get_param(param_file, mdl, "KD_SMOOTH", CS%kappa_smooth, &
                  "A diapycnal diffusivity that is used to interpolate \n"//&
                  "more sensible values of T & S into thin layers.", &
                  default=1.0e-6)
-  call get_param(param_file, mod, "KHTH_USE_FGNV_STREAMFUNCTION", CS%use_FGNV_streamfn, &
+  call get_param(param_file, mdl, "KHTH_USE_FGNV_STREAMFUNCTION", CS%use_FGNV_streamfn, &
                  "If true, use the streamfunction formulation of\n"//    &
                  "Ferrari et al., 2010, which effectively emphasizes\n"//&
                  "graver vertical modes by smoothing in the vertical.",  &
                  default=.false.)
-  call get_param(param_file, mod, "FGNV_FILTER_SCALE", CS%FGNV_scale, &
+  call get_param(param_file, mdl, "FGNV_FILTER_SCALE", CS%FGNV_scale, &
                  "A coefficient scaling the vertical smoothing term in the\n"//&
                  "Ferrari et al., 2010, streamfunction formulation.", &
                  default=1., do_not_log=.not.CS%use_FGNV_streamfn)
-  call get_param(param_file, mod, "FGNV_C_MIN", CS%FGNV_c_min, &
+  call get_param(param_file, mdl, "FGNV_C_MIN", CS%FGNV_c_min, &
                  "A minium wave speed used in the Ferrari et al., 2010,\n"//&
                  "streamfunction formulation.", &
                  default=0., units="m s-1", do_not_log=.not.CS%use_FGNV_streamfn)
-  call get_param(param_file, mod, "FGNV_STRAT_FLOOR", strat_floor, &
+  call get_param(param_file, mdl, "FGNV_STRAT_FLOOR", strat_floor, &
                  "A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,\n"//&
                  "streamfunction formulation, expressed as a fraction of planetary\n"//&
                  "rotation, OMEGA. This should be tiny but non-zero to avoid degeneracy.", &
                  default=1.e-15, units="nondim", do_not_log=.not.CS%use_FGNV_streamfn)
-  call get_param(param_file, mod, "OMEGA",omega, &
+  call get_param(param_file, mdl, "OMEGA",omega, &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5, do_not_log=.not.CS%use_FGNV_streamfn)
   if (CS%use_FGNV_streamfn) CS%N2_floor = (strat_floor*omega)**2
-  call get_param(param_file, mod, "DEBUG", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", default=.false.)
 
 

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -141,7 +141,7 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
   logical :: FAIL_IF_MISSING = .true.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_tidal_forcing" ! This module's name.
+  character(len=40)  :: mdl = "MOM_tidal_forcing" ! This module's name.
   character(len=128) :: mesg
   character(len=200) :: tidal_input_files(4*MAX_CONSTITUENTS)
   integer :: i, j, c, is, ie, js, je, isd, ied, jsd, jed, nc
@@ -155,8 +155,8 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "TIDES", tides, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "TIDES", tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
 
   if (.not.tides) return
@@ -181,43 +181,43 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
     CS%cos_struct(i,j,3) = (0.5-1.5*sin(lat_rad(i,j))**2)
   enddo ; enddo
 
-  call get_param(param_file, mod, "TIDE_M2", use_M2, &
+  call get_param(param_file, mdl, "TIDE_M2", use_M2, &
                  "If true, apply tidal momentum forcing at the M2 \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
-  call get_param(param_file, mod, "TIDE_S2", use_S2, &
+  call get_param(param_file, mdl, "TIDE_S2", use_S2, &
                  "If true, apply tidal momentum forcing at the S2 \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
-  call get_param(param_file, mod, "TIDE_N2", use_N2, &
+  call get_param(param_file, mdl, "TIDE_N2", use_N2, &
                  "If true, apply tidal momentum forcing at the N2 \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
-  call get_param(param_file, mod, "TIDE_K2", use_K2, &
+  call get_param(param_file, mdl, "TIDE_K2", use_K2, &
                  "If true, apply tidal momentum forcing at the K2 \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
-  call get_param(param_file, mod, "TIDE_K1", use_K1, &
+  call get_param(param_file, mdl, "TIDE_K1", use_K1, &
                  "If true, apply tidal momentum forcing at the K1 \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
-  call get_param(param_file, mod, "TIDE_O1", use_O1, &
+  call get_param(param_file, mdl, "TIDE_O1", use_O1, &
                  "If true, apply tidal momentum forcing at the O1 \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
-  call get_param(param_file, mod, "TIDE_P1", use_P1, &
+  call get_param(param_file, mdl, "TIDE_P1", use_P1, &
                  "If true, apply tidal momentum forcing at the P1 \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
-  call get_param(param_file, mod, "TIDE_Q1", use_Q1, &
+  call get_param(param_file, mdl, "TIDE_Q1", use_Q1, &
                  "If true, apply tidal momentum forcing at the Q1 \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
-  call get_param(param_file, mod, "TIDE_MF", use_MF, &
+  call get_param(param_file, mdl, "TIDE_MF", use_MF, &
                  "If true, apply tidal momentum forcing at the MF \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
-  call get_param(param_file, mod, "TIDE_MM", use_MM, &
+  call get_param(param_file, mdl, "TIDE_MM", use_MM, &
                  "If true, apply tidal momentum forcing at the MM \n"//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
@@ -237,21 +237,21 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
     return
   endif
 
-  call get_param(param_file, mod, "TIDAL_SAL_FROM_FILE", CS%tidal_sal_from_file, &
+  call get_param(param_file, mdl, "TIDAL_SAL_FROM_FILE", CS%tidal_sal_from_file, &
                  "If true, read the tidal self-attraction and loading \n"//&
                  "from input files, specified by TIDAL_INPUT_FILE. \n"//&
                  "This is only used if TIDES is true.", default=.false.)
-  call get_param(param_file, mod, "USE_PREVIOUS_TIDES", CS%use_prev_tides, &
+  call get_param(param_file, mdl, "USE_PREVIOUS_TIDES", CS%use_prev_tides, &
                  "If true, use the SAL from the previous iteration of the \n"//&
                  "tides to facilitate convergent iteration. \n"//&
                  "This is only used if TIDES is true.", default=.false.)
-  call get_param(param_file, mod, "TIDE_USE_SAL_SCALAR", CS%use_sal_scalar, &
+  call get_param(param_file, mdl, "TIDE_USE_SAL_SCALAR", CS%use_sal_scalar, &
                  "If true and TIDES is true, use the scalar approximation \n"//&
                  "when calculating self-attraction and loading.", &
                  default=.not.CS%tidal_sal_from_file)
   ! If it is being used, sal_scalar MUST be specified in param_file.
   if (CS%use_sal_scalar .or. CS%use_prev_tides) &
-    call get_param(param_file, mod, "TIDE_SAL_SCALAR_VALUE", CS%sal_scalar, &
+    call get_param(param_file, mdl, "TIDE_SAL_SCALAR_VALUE", CS%sal_scalar, &
                  "The constant of proportionality between sea surface \n"//&
                  "height (really it should be bottom pressure) anomalies \n"//&
                  "and bottom geopotential anomalies. This is only used if \n"//&
@@ -267,7 +267,7 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
   do c=1,4*MAX_CONSTITUENTS ; tidal_input_files(c) = "" ; enddo
 
   if (CS%tidal_sal_from_file .or. CS%use_prev_tides) then
-    call get_param(param_file, mod, "TIDAL_INPUT_FILE", tidal_input_files, &
+    call get_param(param_file, mdl, "TIDAL_INPUT_FILE", tidal_input_files, &
                    "A list of input files for tidal information.",         &
                    default = "", fail_if_missing=.true.)
   endif
@@ -348,15 +348,15 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
   ! frequency, amplitude and initial phase of each constituent, and log the
   ! values that are actually used.
   do c=1,nc
-    call get_param(param_file, mod, "TIDE_"//trim(CS%const_name(c))//"_FREQ", CS%freq(c), &
+    call get_param(param_file, mdl, "TIDE_"//trim(CS%const_name(c))//"_FREQ", CS%freq(c), &
                    "Frequency of the "//trim(CS%const_name(c))//" tidal constituent. \n"//&
                    "This is only used if TIDES and TIDE_"//trim(CS%const_name(c))// &
                    " are true.", units="s-1", default=freq_def(c))
-    call get_param(param_file, mod, "TIDE_"//trim(CS%const_name(c))//"_AMP", CS%amp(c), &
+    call get_param(param_file, mdl, "TIDE_"//trim(CS%const_name(c))//"_AMP", CS%amp(c), &
                    "Amplitude of the "//trim(CS%const_name(c))//" tidal constituent. \n"//&
                    "This is only used if TIDES and TIDE_"//trim(CS%const_name(c))// &
                    " are true.", units="m", default=amp_def(c))
-    call get_param(param_file, mod, "TIDE_"//trim(CS%const_name(c))//"_PHASE_T0", CS%phase0(c), &
+    call get_param(param_file, mdl, "TIDE_"//trim(CS%const_name(c))//"_PHASE_T0", CS%phase0(c), &
                    "Phase of the "//trim(CS%const_name(c))//" tidal constituent at time 0. \n"//&
                    "This is only used if TIDES and TIDE_"//trim(CS%const_name(c))// &
                    " are true.", units="radians", default=phase0_def(c))

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -101,7 +101,7 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_sponge"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_sponge"  ! This module's name.
   logical :: use_sponge
   real, dimension(SZIB_(G),SZJ_(G),nz_data) :: data_hu !< thickness at u points
   real, dimension(SZI_(G),SZJB_(G),nz_data) :: data_hv !< thickness at v points
@@ -117,8 +117,8 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
   endif
 
 ! Set default, read and log parameters
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "SPONGE", use_sponge, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "SPONGE", use_sponge, &
                  "If true, sponges may be applied anywhere in the domain. \n"//&
                  "The exact location and properties of those sponges are \n"//&
                  "specified from MOM_initialization.F90.", default=.false.)
@@ -127,16 +127,16 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
 
   allocate(CS)
 
-  call get_param(param_file, mod, "SPONGE_UV", CS%sponge_uv, &
+  call get_param(param_file, mdl, "SPONGE_UV", CS%sponge_uv, &
                  "Apply sponges in u and v, in addition to tracers.", &
                  default=.false.)
 
-  call get_param(param_file, mod, "REMAPPING_SCHEME", remapScheme, &
+  call get_param(param_file, mdl, "REMAPPING_SCHEME", remapScheme, &
                  "This sets the reconstruction scheme used \n"//&
                  " for vertical remapping for all variables.", &
                  default="PLM", do_not_log=.true.)
 
-  call get_param(param_file, mod, "BOUNDARY_EXTRAPOLATION", bndExtrapolation, &
+  call get_param(param_file, mdl, "BOUNDARY_EXTRAPOLATION", bndExtrapolation, &
                  "When defined, a proper high-order reconstruction \n"//&
                  "scheme is used within boundary cells rather \n"// &
                  "than PCM. E.g., if PPM is used for remapping, a \n" //&
@@ -187,7 +187,7 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
 ! Call the constructor for remapping control structure
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation)
 
-  call log_param(param_file, mod, "!Total sponge columns at h points", total_sponge_cols, &
+  call log_param(param_file, mdl, "!Total sponge columns at h points", total_sponge_cols, &
                  "The total number of columns where sponges are applied at h points.")
 
   if (CS%sponge_uv) then
@@ -225,7 +225,7 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
      endif
      total_sponge_cols_u = CS%num_col_u
      call sum_across_PEs(total_sponge_cols_u)
-     call log_param(param_file, mod, "!Total sponge columns at u points", total_sponge_cols_u, &
+     call log_param(param_file, mdl, "!Total sponge columns at u points", total_sponge_cols_u, &
                  "The total number of columns where sponges are applied at u points.")
 
      ! v points
@@ -262,7 +262,7 @@ subroutine initialize_ALE_sponge(Iresttime, data_h, nz_data, G, param_file, CS)
      endif
      total_sponge_cols_v = CS%num_col_v
      call sum_across_PEs(total_sponge_cols_v)
-     call log_param(param_file, mod, "!Total sponge columns at v points", total_sponge_cols_v, &
+     call log_param(param_file, mdl, "!Total sponge columns at v points", total_sponge_cols_v, &
                  "The total number of columns where sponges are applied at v points.")
   endif
 

--- a/src/parameterizations/vertical/MOM_KPP.F90
+++ b/src/parameterizations/vertical/MOM_KPP.F90
@@ -141,7 +141,7 @@ logical function KPP_init(paramFile, G, diag, Time, CS, passive)
 
   ! Local variables
 #include "version_variable.h"
-  character(len=40) :: mod = 'MOM_KPP' ! name of this module
+  character(len=40) :: mdl = 'MOM_KPP' ! name of this module
   character(len=20) :: string          ! local temporary string
   logical :: CS_IS_ONE=.false.
 
@@ -150,9 +150,9 @@ logical function KPP_init(paramFile, G, diag, Time, CS, passive)
   allocate(CS)
 
   ! Read parameters
-  call log_version(paramFile, mod, version, 'This is the MOM wrapper to CVmix:KPP\n' // &
+  call log_version(paramFile, mdl, version, 'This is the MOM wrapper to CVmix:KPP\n' // &
             'See http://code.google.com/p/cvmix/')
-  call get_param(paramFile, mod, "USE_KPP", KPP_init, &
+  call get_param(paramFile, mdl, "USE_KPP", KPP_init, &
                  "If true, turns on the [CVmix] KPP scheme of Large et al., 1994,\n"// &
                  "to calculate diffusivities and non-local transport in the OBL.",     &
                  default=.false.)
@@ -160,81 +160,81 @@ logical function KPP_init(paramFile, G, diag, Time, CS, passive)
   if (.not. KPP_init) return
 
   call openParameterBlock(paramFile,'KPP')
-  call get_param(paramFile, mod, 'PASSIVE', CS%passiveMode,           &
+  call get_param(paramFile, mdl, 'PASSIVE', CS%passiveMode,           &
                  'If True, puts KPP into a passive-diagnostic mode.', &
                   default=.False.)
   if (present(passive)) passive=CS%passiveMode ! This is passed back to the caller so
                                                ! the caller knows to not use KPP output
-  call get_param(paramFile, mod, 'APPLY_NONLOCAL_TRANSPORT', CS%applyNonLocalTrans,  &
+  call get_param(paramFile, mdl, 'APPLY_NONLOCAL_TRANSPORT', CS%applyNonLocalTrans,  &
                  'If True, applies the non-local transport to heat and scalars.\n'//  &
                  'If False, calculates the non-local transport and tendencies but\n'//&
                  'purely for diagnostic purposes.',                                   &
                  default=.not. CS%passiveMode)
-  call get_param(paramFile, mod, 'RI_CRIT', CS%Ri_crit,                            &
+  call get_param(paramFile, mdl, 'RI_CRIT', CS%Ri_crit,                            &
                  'Critical bulk Richardson number used to define depth of the\n'// &
                  'surface Ocean Boundary Layer (OBL).',                            &
                  units='nondim', default=0.3)
-  call get_param(paramFile, mod, 'VON_KARMAN', CS%vonKarman, &
+  call get_param(paramFile, mdl, 'VON_KARMAN', CS%vonKarman, &
                  'von Karman constant.',                     &
                  units='nondim', default=0.40)
-  call get_param(paramFile, mod, 'ENHANCE_DIFFUSION', CS%enhance_diffusion,              &
+  call get_param(paramFile, mdl, 'ENHANCE_DIFFUSION', CS%enhance_diffusion,              &
                  'If True, adds enhanced diffusion at the based of the boundary layer.', &
                  default=.true.)
-  call get_param(paramFile, mod, 'INTERP_TYPE', CS%interpType,           &
+  call get_param(paramFile, mdl, 'INTERP_TYPE', CS%interpType,           &
                  'Type of interpolation to determine the OBL depth.\n'// &
                  'Allowed types are: linear, quadratic, cubic.',         &
                  default='cubic')
-  call get_param(paramFile, mod, 'COMPUTE_EKMAN', CS%computeEkman,             &
+  call get_param(paramFile, mdl, 'COMPUTE_EKMAN', CS%computeEkman,             &
                  'If True, limit OBL depth to be no deeper than Ekman depth.', &
                  default=.False.)
-  call get_param(paramFile, mod, 'COMPUTE_MONIN_OBUKHOV', CS%computeMoninObukhov, &
+  call get_param(paramFile, mdl, 'COMPUTE_MONIN_OBUKHOV', CS%computeMoninObukhov, &
                  'If True, limit the OBL depth to be no deeper than\n'//          &
                  'Monin-Obukhov depth.',                                          &
                  default=.False.)
-  call get_param(paramFile, mod, 'CS', CS%cs,                        &
+  call get_param(paramFile, mdl, 'CS', CS%cs,                        &
                  'Parameter for computing velocity scale function.', &
                  units='nondim', default=98.96)
-  call get_param(paramFile, mod, 'CS2', CS%cs2,                        &
+  call get_param(paramFile, mdl, 'CS2', CS%cs2,                        &
                  'Parameter for computing non-local term.', &
                  units='nondim', default=6.32739901508)
-  call get_param(paramFile, mod, 'DEEP_OBL_OFFSET', CS%deepOBLoffset,                             &
+  call get_param(paramFile, mdl, 'DEEP_OBL_OFFSET', CS%deepOBLoffset,                             &
                  'If non-zero, the distance above the bottom to which the OBL is clipped\n'//     &
                  'if it would otherwise reach the bottom. The smaller of this and 0.1D is used.', &
                  units='m',default=0.)
-  call get_param(paramFile, mod, 'FIXED_OBLDEPTH', CS%fixedOBLdepth,       &
+  call get_param(paramFile, mdl, 'FIXED_OBLDEPTH', CS%fixedOBLdepth,       &
                  'If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE\n'//  &
                  'rather than using the OBL depth from CVMix.\n'//         &
                  'This option is just for testing purposes.',              &
                  default=.False.)
-  call get_param(paramFile, mod, 'FIXED_OBLDEPTH_VALUE', CS%fixedOBLdepth_value,  &
+  call get_param(paramFile, mdl, 'FIXED_OBLDEPTH_VALUE', CS%fixedOBLdepth_value,  &
                  'Value for the fixed OBL depth when fixedOBLdepth==True. \n'//   &
                  'This parameter is for just for testing purposes. \n'//          &
                  'It will over-ride the OBLdepth computed from CVMix.',           &
                  units='m',default=30.0)
-  call get_param(paramFile, mod, 'SURF_LAYER_EXTENT', CS%surf_layer_ext,   &
+  call get_param(paramFile, mdl, 'SURF_LAYER_EXTENT', CS%surf_layer_ext,   &
                  'Fraction of OBL depth considered in the surface layer.', &
                  units='nondim',default=0.10)
-  call get_param(paramFile, mod, 'MINIMUM_OBL_DEPTH', CS%minOBLdepth,                            &
+  call get_param(paramFile, mdl, 'MINIMUM_OBL_DEPTH', CS%minOBLdepth,                            &
                  'If non-zero, a minimum depth to use for KPP OBL depth. Independent of\n'//     &
                  'this parameter, the OBL depth is always at least as deep as the first layer.', &
                  units='m',default=0.)
-  call get_param(paramFile, mod, 'MINIMUM_VT2', CS%minVtsqr,                                   &
+  call get_param(paramFile, mdl, 'MINIMUM_VT2', CS%minVtsqr,                                   &
                  'Min of the unresolved velocity Vt2 used in Rib CVMix calculation.     \n'//  &
                  'Scaling: MINIMUM_VT2 = const1*d*N*ws, with d=1m, N=1e-5/s, ws=1e-6 m/s.',    &
                  units='m2/s2',default=1e-10)
 
 ! smg: for removal below
-  call get_param(paramFile, mod, 'CORRECT_SURFACE_LAYER_AVERAGE', CS%correctSurfLayerAvg,   &
+  call get_param(paramFile, mdl, 'CORRECT_SURFACE_LAYER_AVERAGE', CS%correctSurfLayerAvg,   &
                  'If true, applies a correction step to the averaging of surface layer\n'// &
                  'properties. This option is obsolete.', default=.False.)
-  call get_param(paramFile, mod, 'FIRST_GUESS_SURFACE_LAYER_DEPTH', CS%surfLayerDepth,              &
+  call get_param(paramFile, mdl, 'FIRST_GUESS_SURFACE_LAYER_DEPTH', CS%surfLayerDepth,              &
                  'The first guess at the depth of the surface layer used for averaging\n'//         &
                  'the surface layer properties. If =0, the top model level properties\n'//          &
                  'will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a\n'// &
                  'subsequent correction is applied. This parameter is obsolete', units='m', default=0.)
 ! smg: for removal above
 
-  call get_param(paramFile, mod, 'NLT_SHAPE', string, &
+  call get_param(paramFile, mdl, 'NLT_SHAPE', string, &
                  'MOM6 method to set nonlocal transport profile.\n'//                          &
                  'Over-rides the result from CVMix.  Allowed values are: \n'//                 &
                  '\t CVMIX     - Uses the profiles from CVmix specified by MATCH_TECHNIQUE\n'//&
@@ -252,7 +252,7 @@ logical function KPP_init(paramFile, G, diag, Time, CS, passive)
     case default ; call MOM_error(FATAL,"KPP_init: "// &
                    "Unrecognized NLT_SHAPE option"//trim(string))
   end select
-  call get_param(paramFile, mod, 'MATCH_TECHNIQUE', CS%MatchTechnique,                                    &
+  call get_param(paramFile, mdl, 'MATCH_TECHNIQUE', CS%MatchTechnique,                                    &
                  'CVMix method to set profile function for diffusivity and NLT,\n'//                      &
                  'as well as matching across OBL base. Allowed values are: \n'//                          &
                  '\t SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT\n'//              &
@@ -265,14 +265,14 @@ logical function KPP_init(paramFile, G, diag, Time, CS, passive)
      !  May be used during CVmix initialization.
      Cs_is_one=.true.
   endif
-  call get_param(paramFile, mod, 'KPP_ZERO_DIFFUSIVITY', CS%KPPzeroDiffusivity,            &
+  call get_param(paramFile, mdl, 'KPP_ZERO_DIFFUSIVITY', CS%KPPzeroDiffusivity,            &
                  'If True, zeroes the KPP diffusivity and viscosity; for testing purpose.',&
                  default=.False.)
-  call get_param(paramFile, mod, 'KPP_IS_ADDITIVE', CS%KPPisAdditive,                &
+  call get_param(paramFile, mdl, 'KPP_IS_ADDITIVE', CS%KPPisAdditive,                &
                  'If true, adds KPP diffusivity to diffusivity from other schemes.'//&
                  'If false, KPP is the only diffusivity wherever KPP is non-zero.',  &
                  default=.True.)
-  call get_param(paramFile, mod, 'KPP_SHORTWAVE_METHOD',string,                      &
+  call get_param(paramFile, mdl, 'KPP_SHORTWAVE_METHOD',string,                      &
                  'Determines contribution of shortwave radiation to KPP surface '// &
                  'buoyancy flux.  Options include:\n'//                             &
                  '  ALL_SW: use total shortwave radiation\n'//                      &
@@ -286,13 +286,13 @@ logical function KPP_init(paramFile, G, diag, Time, CS, passive)
     case default ; call MOM_error(FATAL,"KPP_init: "// &
                    "Unrecognized KPP_SHORTWAVE_METHOD option"//trim(string))
   end select
-  call get_param(paramFile, mod, 'CVMIX_ZERO_H_WORK_AROUND', CS%min_thickness,                           &
+  call get_param(paramFile, mdl, 'CVMIX_ZERO_H_WORK_AROUND', CS%min_thickness,                           &
                  'A minimum thickness used to avoid division by small numbers in the vicinity\n'//       &
                  'of vanished layers. This is independent of MIN_THICKNESS used in other parts of MOM.', &
                  units='m', default=0.)
 
   call closeParameterBlock(paramFile)
-  call get_param(paramFile, mod, 'DEBUG', CS%debug, default=.False., do_not_log=.True.)
+  call get_param(paramFile, mdl, 'DEBUG', CS%debug, default=.False., do_not_log=.True.)
 
   call CVmix_init_kpp( Ri_crit=CS%Ri_crit,                 &
                        minOBLdepth=CS%minOBLdepth,         &

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -3663,7 +3663,7 @@ subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
 !                  for this module
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_mixed_layer"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_mixed_layer"  ! This module's name.
   real :: omega_frac_dflt, ustar_min_dflt
   integer :: isd, ied, jsd, jed
   logical :: use_temperature, use_omega
@@ -3681,82 +3681,82 @@ subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
   if (GV%nkml < 1) return
 
 ! Set default, read and log parameters
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
   CS%nkml = GV%nkml
-  call log_param(param_file, mod, "NKML", CS%nkml, &
+  call log_param(param_file, mdl, "NKML", CS%nkml, &
                  "The number of sublayers within the mixed layer if \n"//&
                  "BULKMIXEDLAYER is true.", units="nondim", default=2)
   CS%nkbl = GV%nk_rho_varies - GV%nkml
-  call log_param(param_file, mod, "NKBL", CS%nkbl, &
+  call log_param(param_file, mdl, "NKBL", CS%nkbl, &
                  "The number of variable density buffer layers if \n"//&
                  "BULKMIXEDLAYER is true.", units="nondim", default=2)
-  call get_param(param_file, mod, "MSTAR", CS%mstar, &
+  call get_param(param_file, mdl, "MSTAR", CS%mstar, &
                  "The ratio of the friction velocity cubed to the TKE \n"//&
                  "input to the mixed layer.", "units=nondim", default=1.2)
-  call get_param(param_file, mod, "NSTAR", CS%nstar, &
+  call get_param(param_file, mdl, "NSTAR", CS%nstar, &
                  "The portion of the buoyant potential energy imparted by \n"//&
                  "surface fluxes that is available to drive entrainment \n"//&
                  "at the base of mixed layer when that energy is positive.", &
                  units="nondim", default=0.15)
-  call get_param(param_file, mod, "BULK_RI_ML", CS%bulk_Ri_ML, &
+  call get_param(param_file, mdl, "BULK_RI_ML", CS%bulk_Ri_ML, &
                  "The efficiency with which mean kinetic energy released \n"//&
                  "by mechanically forced entrainment of the mixed layer \n"//&
                  "is converted to turbulent kinetic energy.", units="nondim",&
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "ABSORB_ALL_SW", CS%absorb_all_sw, &
+  call get_param(param_file, mdl, "ABSORB_ALL_SW", CS%absorb_all_sw, &
                  "If true,  all shortwave radiation is absorbed by the \n"//&
                  "ocean, instead of passing through to the bottom mud.", &
                  default=.false.)
-  call get_param(param_file, mod, "TKE_DECAY", CS%TKE_decay, &
+  call get_param(param_file, mdl, "TKE_DECAY", CS%TKE_decay, &
                  "TKE_DECAY relates the vertical rate of decay of the \n"//&
                  "TKE available for mechanical entrainment to the natural \n"//&
                  "Ekman depth.", units="nondim", default=2.5)
-  call get_param(param_file, mod, "NSTAR2", CS%nstar2, &
+  call get_param(param_file, mdl, "NSTAR2", CS%nstar2, &
                  "The portion of any potential energy released by \n"//&
                  "convective adjustment that is available to drive \n"//&
                  "entrainment at the base of mixed layer. By default \n"//&
                  "NSTAR2=NSTAR.", units="nondim", default=CS%nstar)
-  call get_param(param_file, mod, "BULK_RI_CONVECTIVE", CS%bulk_Ri_convective, &
+  call get_param(param_file, mdl, "BULK_RI_CONVECTIVE", CS%bulk_Ri_convective, &
                  "The efficiency with which convectively released mean \n"//&
                  "kinetic energy is converted to turbulent kinetic \n"//&
                  "energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.", &
                  units="nondim", default=CS%bulk_Ri_ML)
-  call get_param(param_file, mod, "HMIX_MIN", CS%Hmix_min, &
+  call get_param(param_file, mdl, "HMIX_MIN", CS%Hmix_min, &
                  "The minimum mixed layer depth if the mixed layer depth \n"//&
                  "is determined dynamically.", units="m", default=0.0)
 
-  call get_param(param_file, mod, "LIMIT_BUFFER_DETRAIN", CS%limit_det, &
+  call get_param(param_file, mdl, "LIMIT_BUFFER_DETRAIN", CS%limit_det, &
                  "If true, limit the detrainment from the buffer layers \n"//&
                  "to not be too different from the neighbors.", default=.false.)
-  call get_param(param_file, mod, "ALLOWED_DETRAIN_TEMP_CHG", CS%Allowed_T_chg, &
+  call get_param(param_file, mdl, "ALLOWED_DETRAIN_TEMP_CHG", CS%Allowed_T_chg, &
                  "The amount by which temperature is allowed to exceed \n"//&
                  "previous values during detrainment.", units="K", default=0.5)
-  call get_param(param_file, mod, "ALLOWED_DETRAIN_SALT_CHG", CS%Allowed_S_chg, &
+  call get_param(param_file, mdl, "ALLOWED_DETRAIN_SALT_CHG", CS%Allowed_S_chg, &
                  "The amount by which salinity is allowed to exceed \n"//&
                  "previous values during detrainment.", units="PSU", default=0.1)
-  call get_param(param_file, mod, "ML_DT_DS_WEIGHT", CS%dT_dS_wt, &
+  call get_param(param_file, mdl, "ML_DT_DS_WEIGHT", CS%dT_dS_wt, &
                  "When forced to extrapolate T & S to match the layer \n"//&
                  "densities, this factor (in deg C / PSU) is combined \n"//&
                  "with the derivatives of density with T & S to determine \n"//&
                  "what direction is orthogonal to density contours. It \n"//&
                  "should be a typical value of (dR/dS) / (dR/dT) in \n"//&
                  "oceanic profiles.", units="degC PSU-1", default=6.0)
-  call get_param(param_file, mod, "BUFFER_LAYER_EXTRAP_LIMIT", CS%BL_extrap_lim, &
+  call get_param(param_file, mdl, "BUFFER_LAYER_EXTRAP_LIMIT", CS%BL_extrap_lim, &
                  "A limit on the density range over which extrapolation \n"//&
                  "can occur when detraining from the buffer layers, \n"//&
                  "relative to the density range within the mixed and \n"//&
                  "buffer layers, when the detrainment is going into the \n"//&
                  "lightest interior layer, nondimensional, or a negative \n"//&
                  "value not to apply this limit.", units="nondim", default = -1.0)
-  call get_param(param_file, mod, "DEPTH_LIMIT_FLUXES", CS%H_limit_fluxes, &
+  call get_param(param_file, mdl, "DEPTH_LIMIT_FLUXES", CS%H_limit_fluxes, &
                  "The surface fluxes are scaled away when the total ocean \n"//&
                  "depth is less than DEPTH_LIMIT_FLUXES.", &
                  units="m", default=0.1*CS%Hmix_min)
-  call get_param(param_file, mod, "OMEGA",CS%omega, &
+  call get_param(param_file, mdl, "OMEGA",CS%omega, &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5)
-  call get_param(param_file, mod, "ML_USE_OMEGA", use_omega, &
+  call get_param(param_file, mdl, "ML_USE_OMEGA", use_omega, &
                  "If true, use the absolute rotation rate instead of the \n"//&
                  "vertical component of rotation when setting the decay \n"//&
                  "scale for turbulence.", default=.false., do_not_log=.true.)
@@ -3765,57 +3765,57 @@ subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
     call MOM_error(WARNING, "ML_USE_OMEGA is depricated; use ML_OMEGA_FRAC=1.0 instead.")
     omega_frac_dflt = 1.0
   endif
-  call get_param(param_file, mod, "ML_OMEGA_FRAC", CS%omega_frac, &
+  call get_param(param_file, mdl, "ML_OMEGA_FRAC", CS%omega_frac, &
                  "When setting the decay scale for turbulence, use this \n"//&
                  "fraction of the absolute rotation rate blended with the \n"//&
                  "local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).", &
                  units="nondim", default=omega_frac_dflt)
-  call get_param(param_file, mod, "ML_RESORT", CS%ML_resort, &
+  call get_param(param_file, mdl, "ML_RESORT", CS%ML_resort, &
                  "If true, resort the topmost layers by potential density \n"//&
                  "before the mixed layer calculations.", default=.false.)
   if (CS%ML_resort) &
-    call get_param(param_file, mod, "ML_PRESORT_NK_CONV_ADJ", CS%ML_presort_nz_conv_adj, &
+    call get_param(param_file, mdl, "ML_PRESORT_NK_CONV_ADJ", CS%ML_presort_nz_conv_adj, &
                  "Convectively mix the first ML_PRESORT_NK_CONV_ADJ \n"//&
                  "layers before sorting when ML_RESORT is true.", &
                  units="nondim", default=0, fail_if_missing=.true.) ! Fail added by AJA.
   ! This gives a minimum decay scale that is typically much less than Angstrom.
   ustar_min_dflt = 2e-4*CS%omega*(GV%Angstrom_z + GV%H_to_m*GV%H_subroundoff)
-  call get_param(param_file, mod, "BML_USTAR_MIN", CS%ustar_min, &
+  call get_param(param_file, mdl, "BML_USTAR_MIN", CS%ustar_min, &
                  "The minimum value of ustar that should be used by the \n"//&
                  "bulk mixed layer model in setting vertical TKE decay \n"//&
                  "scales. This must be greater than 0.", units="m s-1", &
                  default=ustar_min_dflt)
   if (CS%ustar_min<=0.0) call MOM_error(FATAL, "BML_USTAR_MIN must be positive.")
 
-  call get_param(param_file, mod, "RESOLVE_EKMAN", CS%Resolve_Ekman, &
+  call get_param(param_file, mdl, "RESOLVE_EKMAN", CS%Resolve_Ekman, &
                  "If true, the NKML>1 layers in the mixed layer are \n"//&
                  "chosen to optimally represent the impact of the Ekman \n"//&
                  "transport on the mixed layer TKE budget.  Otherwise, \n"//&
                  "the sublayers are distributed uniformly through the \n"//&
                  "mixed layer.", default=.false.)
-  call get_param(param_file, mod, "CORRECT_ABSORPTION_DEPTH", CS%correct_absorption, &
+  call get_param(param_file, mdl, "CORRECT_ABSORPTION_DEPTH", CS%correct_absorption, &
                  "If true, the average depth at which penetrating shortwave \n"//&
                  "radiation is absorbed is adjusted to match the average \n"//&
                  "heating depth of an exponential profile by moving some \n"//&
                  "of the heating upward in the water column.", default=.false.)
-  call get_param(param_file, mod, "DO_RIVERMIX", CS%do_rivermix, &
+  call get_param(param_file, mdl, "DO_RIVERMIX", CS%do_rivermix, &
                  "If true, apply additional mixing whereever there is \n"//&
                  "runoff, so that it is mixed down to RIVERMIX_DEPTH, \n"//&
                  "if the ocean is that deep.", default=.false.)
   if (CS%do_rivermix) &
-    call get_param(param_file, mod, "RIVERMIX_DEPTH", CS%rivermix_depth, &
+    call get_param(param_file, mdl, "RIVERMIX_DEPTH", CS%rivermix_depth, &
                  "The depth to which rivers are mixed if DO_RIVERMIX is \n"//&
                  "defined.", units="m", default=0.0)
-  call get_param(param_file, mod, "USE_RIVER_HEAT_CONTENT", CS%use_river_heat_content, &
+  call get_param(param_file, mdl, "USE_RIVER_HEAT_CONTENT", CS%use_river_heat_content, &
                  "If true, use the fluxes%runoff_Hflx field to set the \n"//&
                  "heat carried by runoff, instead of using SST*CP*liq_runoff.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_CALVING_HEAT_CONTENT", CS%use_calving_heat_content, &
+  call get_param(param_file, mdl, "USE_CALVING_HEAT_CONTENT", CS%use_calving_heat_content, &
                  "If true, use the fluxes%calving_Hflx field to set the \n"//&
                  "heat carried by runoff, instead of using SST*CP*froz_runoff.", &
                  default=.false.)
 
-  call get_param(param_file, mod, "ALLOW_CLOCKS_IN_OMP_LOOPS", &
+  call get_param(param_file, mdl, "ALLOW_CLOCKS_IN_OMP_LOOPS", &
                  CS%allow_clocks_in_omp_loops, &
                  "If true, clocks can be called from inside loops that can \n"//&
                  "be threaded. To run with multiple threads, set to False.", &
@@ -3853,22 +3853,22 @@ subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
       Time, 'Minimum surface region thickness', 'meter')
  !CS%lim_det_dH_sfc = 0.5 ; CS%lim_det_dH_bathy = 0.2 ! Technically these should not get used if limit_det is false?
   if (CS%limit_det .or. (CS%id_Hsfc_min > 0)) then
-    call get_param(param_file, mod, "LIMIT_BUFFER_DET_DH_SFC", CS%lim_det_dH_sfc, &
+    call get_param(param_file, mdl, "LIMIT_BUFFER_DET_DH_SFC", CS%lim_det_dH_sfc, &
                  "The fractional limit in the change between grid points \n"//&
                  "of the surface region (mixed & buffer layer) thickness.", &
                  units="nondim", default=0.5)
-    call get_param(param_file, mod, "LIMIT_BUFFER_DET_DH_BATHY", CS%lim_det_dH_bathy, &
+    call get_param(param_file, mdl, "LIMIT_BUFFER_DET_DH_BATHY", CS%lim_det_dH_bathy, &
                  "The fraction of the total depth by which the thickness \n"//&
                  "of the surface region (mixed & buffer layer) is allowed \n"//&
                  "to change between grid points.", units="nondim", default=0.2)
   endif
 
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", use_temperature, &
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", use_temperature, &
                  "If true, temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
   CS%nsw = 0
   if (use_temperature) then
-    call get_param(param_file, mod, "PEN_SW_NBANDS", CS%nsw, default=1)
+    call get_param(param_file, mdl, "PEN_SW_NBANDS", CS%nsw, default=1)
   endif
 
 

--- a/src/parameterizations/vertical/MOM_cvmix_shear.F90
+++ b/src/parameterizations/vertical/MOM_cvmix_shear.F90
@@ -38,7 +38,7 @@ type, public :: CVMix_shear_CS
   character(10) :: Mix_Scheme               !< Mixing scheme name (string)
 end type CVMix_shear_CS
 
-character(len=40)  :: mod = "MOM_CVMix_shear"  !< This module's name.
+character(len=40)  :: mdl = "MOM_CVMix_shear"  !< This module's name.
 
 contains
 
@@ -148,16 +148,16 @@ logical function cvmix_shear_init(Time, G, GV, param_file, diag, CS)
   allocate(CS)
 
 ! Set default, read and log parameters
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
     "Parameterization of shear-driven turbulence via CVMix (various options)")
-  call get_param(param_file, mod, "USE_LMD94", CS%use_LMD94, &
+  call get_param(param_file, mdl, "USE_LMD94", CS%use_LMD94, &
                  "If true, use the Large-McWilliams-Doney (JGR 1994) \n"//&
                  "shear mixing parameterization.", default=.false.)
   if (CS%use_LMD94) then
      NumberTrue=NumberTrue + 1
      CS%Mix_Scheme='KPP'
   endif
-  call get_param(param_file, mod, "USE_PP81", CS%use_PP81, &
+  call get_param(param_file, mdl, "USE_PP81", CS%use_PP81, &
                  "If true, use the Pacanowski and Philander (JPO 1981) \n"//&
                  "shear mixing parameterization.", default=.false.)
   if (CS%use_PP81) then
@@ -177,15 +177,15 @@ logical function cvmix_shear_init(Time, G, GV, param_file, diag, CS)
 
 ! Forego remainder of initialization if not using this scheme
   if (.not. cvmix_shear_init) return
-  call get_param(param_file, mod, "NU_ZERO", CS%Nu_Zero, &
+  call get_param(param_file, mdl, "NU_ZERO", CS%Nu_Zero, &
                  "Leading coefficient in KPP shear mixing.", &
                  units="nondim", default=5.e-3)
-  call get_param(param_file, mod, "RI_ZERO", CS%Ri_Zero, &
+  call get_param(param_file, mdl, "RI_ZERO", CS%Ri_Zero, &
                  "Critical Richardson for KPP shear mixing,"// &
                  " NOTE this the internal mixing and this is"// &
                  " not for setting the boundary layer depth." &
                  ,units="nondim", default=0.7)
-  call get_param(param_file, mod, "KPP_EXP", CS%KPP_exp, &
+  call get_param(param_file, mdl, "KPP_EXP", CS%KPP_exp, &
                  "Exponent of unitless factor of diffusivities,"// &
                  " for KPP internal shear mixing scheme." &
                  ,units="nondim", default=3.0)
@@ -206,9 +206,9 @@ logical function cvmix_shear_is_used(param_file)
   type(param_file_type), intent(in) :: param_file !< Run-time parameter files handle.
   ! Local variables
   logical :: LMD94, PP81
-  call get_param(param_file, mod, "USE_LMD94", LMD94, &
+  call get_param(param_file, mdl, "USE_LMD94", LMD94, &
        default=.false., do_not_log = .true.)
-  call get_param(param_file, mod, "Use_PP81", PP81, &
+  call get_param(param_file, mdl, "Use_PP81", PP81, &
        default=.false., do_not_log = .true.)
   cvmix_shear_is_used = (LMD94 .or. PP81)
 end function cvmix_shear_is_used

--- a/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
+++ b/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
@@ -1305,7 +1305,7 @@ subroutine diapyc_energy_req_init(Time, G, param_file, diag, CS)
   integer, save :: init_calls = 0
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_diapyc_energy_req" ! This module's name.
+  character(len=40)  :: mdl = "MOM_diapyc_energy_req" ! This module's name.
   character(len=256) :: mesg    ! Message for error messages.
 
   if (.not.associated(CS)) then ; allocate(CS)
@@ -1315,14 +1315,14 @@ subroutine diapyc_energy_req_init(Time, G, param_file, diag, CS)
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "ENERGY_REQ_KH_SCALING", CS%test_Kh_scaling, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "ENERGY_REQ_KH_SCALING", CS%test_Kh_scaling, &
                  "A scaling factor for the diapycnal diffusivity used in \n"//&
                  "testing the energy requirements.", default=1.0, units="nondim")
-  call get_param(param_file, mod, "ENERGY_REQ_COL_HT_SCALING", CS%ColHt_scaling, &
+  call get_param(param_file, mdl, "ENERGY_REQ_COL_HT_SCALING", CS%ColHt_scaling, &
                  "A scaling factor for the column height change correction \n"//&
                  "used in testing the energy requirements.", default=1.0, units="nondim")
-  call get_param(param_file, mod, "ENERGY_REQ_USE_TEST_PROFILE", &
+  call get_param(param_file, mdl, "ENERGY_REQ_USE_TEST_PROFILE", &
                  CS%use_test_Kh_profile, &
                  "If true, use the internal test diffusivity profile in \n"//&
                  "place of any that might be passed in as an argument.", default=.false.)

--- a/src/parameterizations/vertical/MOM_diffConvection.F90
+++ b/src/parameterizations/vertical/MOM_diffConvection.F90
@@ -50,17 +50,17 @@ logical function diffConvection_init(paramFile, G, diag, Time, CS)
   type(diffConvection_CS), pointer       :: CS        ! Control structure
 ! Local variables
 #include "version_variable.h"
-  character(len=40) :: mod = 'MOM_diffConvection' ! This module's name.
+  character(len=40) :: mdl = 'MOM_diffConvection' ! This module's name.
 
   if (associated(CS)) call MOM_error(FATAL, 'MOM_diffConvection, diffConvection_init: '// &
            'Control structure has already been initialized')
   allocate(CS)
 
 ! Read parameters
-  call log_version(paramFile, mod, version, &
+  call log_version(paramFile, mdl, version, &
             'This module implements enhanced diffusivity as a\n' // &
             'function of static stability, N^2.')
-  call get_param(paramFile, mod, "USE_CONVECTION", diffConvection_init, &
+  call get_param(paramFile, mdl, "USE_CONVECTION", diffConvection_init, &
                  "If true, turns on the diffusive convection scheme that\n"// &
                  "increases diapycnal diffusivities at statically unstable\n"// &
                  "interfaces. Relevant parameters are contained in the\n"// &
@@ -68,14 +68,14 @@ logical function diffConvection_init(paramFile, G, diag, Time, CS)
                  default=.false.)
 
   call openParameterBlock(paramFile,'CONVECTION')
-  call get_param(paramFile, mod, 'PASSIVE', CS%passiveMode,           &
+  call get_param(paramFile, mdl, 'PASSIVE', CS%passiveMode,           &
                  'If True, puts KPP into a passive-diagnostic mode.', &
                  default=.False.)
-  call get_param(paramFile, mod, 'KD_CONV', CS%Kd_convection,                  &
+  call get_param(paramFile, mdl, 'KD_CONV', CS%Kd_convection,                  &
                  'DIffusivity used in statically unstable regions of column.', &
                  units='m2/s', default=1.00)
   call closeParameterBlock(paramFile)
-  call get_param(paramFile, mod, 'DEBUG', CS%debug, default=.False., do_not_log=.True.)
+  call get_param(paramFile, mdl, 'DEBUG', CS%debug, default=.False., do_not_log=.True.)
 
 ! Forego remainder of initialization if not using this scheme
   if (.not. diffConvection_init) return

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -2034,7 +2034,7 @@ subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
 !                  for this module
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_energetic_PBL"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_energetic_PBL"  ! This module's name.
   real :: omega_frac_dflt
   integer :: isd, ied, jsd, jed
   logical :: use_temperature, use_omega
@@ -2050,75 +2050,75 @@ subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
   CS%Time => Time
 
 ! Set default, read and log parameters
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mod, "MSTAR_MODE", CS%mstar_mode, &
+  call get_param(param_file, mdl, "MSTAR_MODE", CS%mstar_mode, &
                  "An integer switch for how to compute MSTAR. \n"//&
                  "    0 for constant MSTAR\n"//&
                  "    1 for MSTAR w/ MLD in stabilizing limit\n"//&
                  "    2 for MSTAR w/ L_E/L_O in stabilizing limit.",&
                  "units=nondim",default=0)
-  call get_param(param_file, mod, "MSTAR", CS%mstar, &
+  call get_param(param_file, mdl, "MSTAR", CS%mstar, &
                  "The ratio of the friction velocity cubed to the TKE \n"//&
                  "input to the mixed layer.", "units=nondim", default=1.2)
-  call get_param(param_file, mod, "MIX_LEN_EXPONENT", CS%MixLenExponent, &
+  call get_param(param_file, mdl, "MIX_LEN_EXPONENT", CS%MixLenExponent, &
                  "The exponent applied to the ratio of the distance to the MLD \n"//&
                  "and the MLD depth which determines the shape of the mixing length.",&
                  "units=nondim", default=2.0)
-  call get_param(param_file, mod, "MSTAR_CAP", CS%mstar_cap, &
+  call get_param(param_file, mdl, "MSTAR_CAP", CS%mstar_cap, &
                  "Maximum value of mstar allowed in model if non-negative\n"//&
                  "(used if MSTAR_MODE>0).",&
                  "units=nondim", default=-1.0)
-  call get_param(param_file, mod, "MSTAR_CONV_ADJ", CS%cnv_mst_fac, &
+  call get_param(param_file, mdl, "MSTAR_CONV_ADJ", CS%cnv_mst_fac, &
                  "Factor used for reducing mstar during convection \n"//&
                  " due to reduction of stable density gradient.",&
                  "units=nondim", default=0.0)
-  call get_param(param_file, mod, "MSTAR_SLOPE", CS%mstar_slope, &
+  call get_param(param_file, mdl, "MSTAR_SLOPE", CS%mstar_slope, &
                  "The slope of the linear relationship between mstar \n"//&
                  "and the length scale ratio (used if MSTAR_MODE=1).",&
                  "units=nondim", default=0.85)
-  call get_param(param_file, mod, "MSTAR_XINT", CS%mstar_xint, &
+  call get_param(param_file, mdl, "MSTAR_XINT", CS%mstar_xint, &
                  "The value of the length scale ratio where the mstar \n"//&
                  "is linear above (used if MSTAR_MODE=1).",&
                  "units=nondim", default=-0.3)
-  call get_param(param_file, mod, "MSTAR_AT_XINT", CS%mstar_at_xint, &
+  call get_param(param_file, mdl, "MSTAR_AT_XINT", CS%mstar_at_xint, &
                  "The value of mstar at MSTAR_XINT \n"//&
                  "(used if MSTAR_MODE=1).",&
                  "units=nondim", default=0.095)
-  call get_param(param_file, mod, "MSTAR_FLATCAP", CS%MSTAR_FLATCAP, &
+  call get_param(param_file, mdl, "MSTAR_FLATCAP", CS%MSTAR_FLATCAP, &
                  "Set false to use asymptotic cap, defaults to true.\n"//&
                  "(used only if MSTAR_MODE=1)"&
                  ,"units=nondim",default=.true.)
-  call get_param(param_file, mod, "MSTAR2_COEF1", CS%MSTAR_COEF, &
+  call get_param(param_file, mdl, "MSTAR2_COEF1", CS%MSTAR_COEF, &
                  "Coefficient in computing mstar when rotation and \n"//&
                  " stabilizing effects are both important (used if MSTAR_MODE=2)"&
                   ,"units=nondim",default=0.3)
-  call get_param(param_file, mod, "MSTAR2_COEF2", CS%C_EK, &
+  call get_param(param_file, mdl, "MSTAR2_COEF2", CS%C_EK, &
                  "Coefficient in computing mstar when only rotation limits \n"//&
                  " the total mixing. (used only if MSTAR_MODE=2)"&
                   ,"units=nondim",default=0.085)
-  call get_param(param_file, mod, "NSTAR", CS%nstar, &
+  call get_param(param_file, mdl, "NSTAR", CS%nstar, &
                  "The portion of the buoyant potential energy imparted by \n"//&
                  "surface fluxes that is available to drive entrainment \n"//&
                  "at the base of mixed layer when that energy is positive.", &
                  units="nondim", default=0.2)
-  call get_param(param_file, mod, "MKE_TO_TKE_EFFIC", CS%MKE_to_TKE_effic, &
+  call get_param(param_file, mdl, "MKE_TO_TKE_EFFIC", CS%MKE_to_TKE_effic, &
                  "The efficiency with which mean kinetic energy released \n"//&
                  "by mechanically forced entrainment of the mixed layer \n"//&
                  "is converted to turbulent kinetic energy.", units="nondim", &
                  default=0.0)
-  call get_param(param_file, mod, "TKE_DECAY", CS%TKE_decay, &
+  call get_param(param_file, mdl, "TKE_DECAY", CS%TKE_decay, &
                  "TKE_DECAY relates the vertical rate of decay of the \n"//&
                  "TKE available for mechanical entrainment to the natural \n"//&
                  "Ekman depth.", units="nondim", default=2.5)
-!  call get_param(param_file, mod, "HMIX_MIN", CS%Hmix_min, &
+!  call get_param(param_file, mdl, "HMIX_MIN", CS%Hmix_min, &
 !                 "The minimum mixed layer depth if the mixed layer depth \n"//&
 !                 "is determined dynamically.", units="m", default=0.0)
 
-  call get_param(param_file, mod, "OMEGA",CS%omega,              &
+  call get_param(param_file, mdl, "OMEGA",CS%omega,              &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5)
-  call get_param(param_file, mod, "ML_USE_OMEGA", use_omega,                  &
+  call get_param(param_file, mdl, "ML_USE_OMEGA", use_omega,                  &
                  "If true, use the absolute rotation rate instead of the \n"//&
                  "vertical component of rotation when setting the decay \n"// &
                  "scale for turbulence.", default=.false., do_not_log=.true.)
@@ -2127,50 +2127,50 @@ subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
     call MOM_error(WARNING, "ML_USE_OMEGA is depricated; use ML_OMEGA_FRAC=1.0 instead.")
     omega_frac_dflt = 1.0
   endif
-  call get_param(param_file, mod, "ML_OMEGA_FRAC", CS%omega_frac,              &
+  call get_param(param_file, mdl, "ML_OMEGA_FRAC", CS%omega_frac,              &
                  "When setting the decay scale for turbulence, use this \n"//  &
                  "fraction of the absolute rotation rate blended with the \n"//&
                  "local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).",      &
                  units="nondim", default=omega_frac_dflt)
-  call get_param(param_file, mod, "WSTAR_USTAR_COEF", CS%wstar_ustar_coef,     &
+  call get_param(param_file, mdl, "WSTAR_USTAR_COEF", CS%wstar_ustar_coef,     &
                  "A ratio relating the efficiency with which convectively \n"//&
                  "released energy is converted to a turbulent velocity, \n"//  &
                  "relative to mechanically forced TKE. Making this larger \n"//&
                  "increases the BL diffusivity", units="nondim", default=1.0)
-  call get_param(param_file, mod, "VSTAR_SCALE_FACTOR", CS%vstar_scale_fac, &
+  call get_param(param_file, mdl, "VSTAR_SCALE_FACTOR", CS%vstar_scale_fac, &
                  "An overall nondimensional scaling factor for v*. \n"//    &
                  "Making this larger decreases the PBL diffusivity.",       &
                  units="nondim", default=1.0)
-  call get_param(param_file, mod, "EKMAN_SCALE_COEF", CS%Ekman_scale_coef,           &
+  call get_param(param_file, mdl, "EKMAN_SCALE_COEF", CS%Ekman_scale_coef,           &
                  "A nondimensional scaling factor controlling the inhibition \n"//   &
                  "of the diffusive length scale by rotation. Making this larger \n"//&
                  "decreases the PBL diffusivity.", units="nondim", default=1.0)
-  call get_param(param_file, mod, "USE_MLD_ITERATION", CS%USE_MLD_ITERATION,    &
+  call get_param(param_file, mdl, "USE_MLD_ITERATION", CS%USE_MLD_ITERATION,    &
                  "A logical that specifies whether or not to use the \n"//      &
                  "distance to the bottom of the actively turblent boundary \n"//&
                  "layer to help set the EPBL length scale.", default=.false.)
-  call get_param(param_file, mod, "ORIG_MLD_ITERATION", CS%ORIG_MLD_ITERATION,  &
+  call get_param(param_file, mdl, "ORIG_MLD_ITERATION", CS%ORIG_MLD_ITERATION,  &
                  "A logical that specifies whether or not to use the \n"//      &
                  "old method for determining MLD depth in iteration, which \n"//&
                  "is limited to resolution.", default=.true.)
-  call get_param(param_file, mod, "MLD_ITERATION_GUESS", CS%MLD_ITERATION_GUESS,       &
+  call get_param(param_file, mdl, "MLD_ITERATION_GUESS", CS%MLD_ITERATION_GUESS,       &
                  "A logical that specifies whether or not to use the \n"//             &
                  "previous timestep MLD as a first guess in the MLD iteration.\n"//    &
                  "The default is false to facilitate reproducibility.", default=.false.)
-  call get_param(param_file, mod, "EPBL_MLD_TOLERANCE", CS%MLD_tol,         &
+  call get_param(param_file, mdl, "EPBL_MLD_TOLERANCE", CS%MLD_tol,         &
                  "The tolerance for the iteratively determined mixed \n"//  &
                  "layer depth.  This is only used with USE_MLD_ITERATION.", &
                  units="meter", default=1.0)
-  call get_param(param_file, mod, "EPBL_MIN_MIX_LEN", CS%min_mix_len,    &
+  call get_param(param_file, mdl, "EPBL_MIN_MIX_LEN", CS%min_mix_len,    &
                  "The minimum mixing length scale that will be used \n"//&
                  "by ePBL.  The default (0) does not set a minimum.",    &
                  units="meter", default=0.0)
-  call get_param(param_file, mod, "EPBL_ORIGINAL_PE_CALC", CS%orig_PE_calc,         &
+  call get_param(param_file, mdl, "EPBL_ORIGINAL_PE_CALC", CS%orig_PE_calc,         &
                  "If true, the ePBL code uses the original form of the \n"//        &
                  "potential energy change code.  Otherwise, the newer \n"//         &
                  "version that can work with successive increments to the \n"//     &
                  "diffusivity in upward or downward passes is used.", default=.true.)
-  call get_param(param_file, mod, "EPBL_TRANSITION_SCALE", CS%transLay_scale, &
+  call get_param(param_file, mdl, "EPBL_TRANSITION_SCALE", CS%transLay_scale, &
                  "A scale for the mixing length in the transition layer \n"// &
                  "at the edge of the boundary layer as a fraction of the \n"//&
                  "boundary layer thickness.  The default is 0.1.", &
@@ -2179,25 +2179,25 @@ subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
     call MOM_error(FATAL, "If flag USE_MLD_ITERATION is true, then "//       &
                  "EPBL_TRANSITION should be greater than 0 and less than 1.")
   endif
-  call get_param(param_file, mod, "N2_DISSIPATION_POS", CS%N2_Dissipation_Scale_Pos, &
+  call get_param(param_file, mdl, "N2_DISSIPATION_POS", CS%N2_Dissipation_Scale_Pos, &
                  "A scale for the dissipation of TKE due to stratification \n"//     &
                  "in the boundary layer, applied when local stratification \n"//     &
                  "is positive.  The default is 0, but should probably be ~0.4.",     &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "N2_DISSIPATION_NEG", CS%N2_Dissipation_Scale_Neg,&
+  call get_param(param_file, mdl, "N2_DISSIPATION_NEG", CS%N2_Dissipation_Scale_Neg,&
                  "A scale for the dissipation of TKE due to stratification \n"//    &
                  "in the boundary layer, applied when local stratification \n"//    &
                  "is negative.  The default is 0, but should probably be ~1.",      &
                  units="nondim", default=0.0)
-   call get_param(param_file, mod, "USE_LA_LI2016", CS%USE_LA_Windsea,            &
+   call get_param(param_file, mdl, "USE_LA_LI2016", CS%USE_LA_Windsea,            &
                  "A logical to use the Li et al. 2016 (submitted) formula to \n"//&
                  " determine the Langmuir number.",                               &
                  units="nondim", default=.false.)
-   call get_param(param_file, mod, "LA_DEPTH_RATIO", CS%LaDepthRatio,                &
+   call get_param(param_file, mdl, "LA_DEPTH_RATIO", CS%LaDepthRatio,                &
                  "The depth (normalized by BLD) to average Stokes drift over in \n"//&
                  " Lanmguir number calculation, where La = sqrt(ust/Stokes).",       &
                  units="nondim",default=0.04)
-   call get_param(param_file, mod, "LT_ENHANCE", CS%LT_ENHANCE_FORM,        &
+   call get_param(param_file, mdl, "LT_ENHANCE", CS%LT_ENHANCE_FORM,        &
                  "Integer for Langmuir number mode. \n"//                   &
                  " *Requires USE_LA_LI2016 to be set to True. \n"//         &
                  "Options: 0 - No Langmuir \n"//                            &
@@ -2205,29 +2205,29 @@ subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
                  "         2 - Multiplied w/ adjusted La. \n"//             &
                  "         3 - Added w/ adjusted La.",                      &
                  units="nondim", default=0)
-   call get_param(param_file, mod, "LT_ENHANCE_COEF", CS%LT_ENHANCE_COEF, &
+   call get_param(param_file, mdl, "LT_ENHANCE_COEF", CS%LT_ENHANCE_COEF, &
                  "Coefficient for Langmuir enhancement if LT_ENHANCE > 1",&
                  units="nondim", default=0.447)
-   call get_param(param_file, mod, "LT_ENHANCE_EXP", CS%LT_ENHANCE_EXP, &
+   call get_param(param_file, mdl, "LT_ENHANCE_EXP", CS%LT_ENHANCE_EXP, &
                  "Exponent for Langmuir enhancement if LT_ENHANCE > 1", &
                  units="nondim", default=-1.33)
-   call get_param(param_file, mod, "LT_MOD_LAC1", CS%LaC_MLDoEK,             &
+   call get_param(param_file, mdl, "LT_MOD_LAC1", CS%LaC_MLDoEK,             &
                  "Coefficient for modification of Langmuir number due to\n"//&
                  " MLD approaching Ekman depth if LT_ENHANCE=2.",            &
                  units="nondim", default=-0.87)
-   call get_param(param_file, mod, "LT_MOD_LAC2", CS%LaC_MLDoOB_stab,        &
+   call get_param(param_file, mdl, "LT_MOD_LAC2", CS%LaC_MLDoOB_stab,        &
                  "Coefficient for modification of Langmuir number due to\n"//&
                  " MLD approaching stable Obukhov depth if LT_ENHANCE=2.",   &
                   units="nondim", default=0.0)
-   call get_param(param_file, mod, "LT_MOD_LAC3", CS%LaC_MLDoOB_un,          &
+   call get_param(param_file, mdl, "LT_MOD_LAC3", CS%LaC_MLDoOB_un,          &
                  "Coefficient for modification of Langmuir number due to\n"//&
                  " MLD approaching unstable Obukhov depth if LT_ENHANCE=2.", &
                   units="nondim", default=0.0)
-   call get_param(param_file, mod, "LT_MOD_LAC4", CS%Lac_EKoOB_stab,         &
+   call get_param(param_file, mdl, "LT_MOD_LAC4", CS%Lac_EKoOB_stab,         &
                  "Coefficient for modification of Langmuir number due to\n"//&
                  " ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.", &
                   units="nondim", default=0.95)
-   call get_param(param_file, mod, "LT_MOD_LAC5", CS%Lac_EKoOB_un,            &
+   call get_param(param_file, mdl, "LT_MOD_LAC5", CS%Lac_EKoOB_un,            &
                  "Coefficient for modification of Langmuir number due to\n"// &
                  " ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.",&
                   units="nondim", default=0.95)
@@ -2237,7 +2237,7 @@ subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
   endif
   ! This gives a minimum decay scale that is typically much less than Angstrom.
   CS%ustar_min = 2e-4*CS%omega*(GV%Angstrom_z + GV%H_to_m*GV%H_subroundoff)
-  call log_param(param_file, mod, "EPBL_USTAR_MIN", CS%ustar_min, &
+  call log_param(param_file, mdl, "EPBL_USTAR_MIN", CS%ustar_min, &
                  "The (tiny) minimum friction velocity used within the \n"//&
                  "ePBL code, derived from OMEGA and ANGSTROM.", units="meter second-1")
 
@@ -2282,7 +2282,7 @@ subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
       Time, 'Modified Langmuir number.', 'non-dim')
 
 
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", use_temperature, &
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", use_temperature, &
                  "If true, temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
 

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -374,7 +374,7 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
-  character(len=40)  :: mod = "MOM_geothermal"  ! module name
+  character(len=40)  :: mdl = "MOM_geothermal"  ! module name
   character(len=200) :: inputdir, geo_file, filename, geotherm_var
   real :: scale
   integer :: i, j, isd, ied, jsd, jed, id
@@ -390,8 +390,8 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
   CS%Time => Time
 
   ! write parameters to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "GEOTHERMAL_SCALE", scale, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "GEOTHERMAL_SCALE", scale, &
                  "The constant geothermal heat flux, a rescaling \n"//&
                  "factor for the heat flux read from GEOTHERMAL_FILE, or \n"//&
                  "0 to disable the geothermal heating.", &
@@ -401,13 +401,13 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
 
   call safe_alloc_ptr(CS%geo_heat, isd, ied, jsd, jed) ; CS%geo_heat(:,:) = 0.0
 
-  call get_param(param_file, mod, "GEOTHERMAL_FILE", geo_file, &
+  call get_param(param_file, mdl, "GEOTHERMAL_FILE", geo_file, &
                  "The file from which the geothermal heating is to be \n"//&
                  "read, or blank to use a constant heating rate.", default=" ")
-  call get_param(param_file, mod, "GEOTHERMAL_THICKNESS", CS%geothermal_thick, &
+  call get_param(param_file, mdl, "GEOTHERMAL_THICKNESS", CS%geothermal_thick, &
                  "The thickness over which to apply geothermal heating.", &
                  units="m", default=0.1)
-  call get_param(param_file, mod, "GEOTHERMAL_DRHO_DT_INPLACE", CS%dRcv_dT_inplace, &
+  call get_param(param_file, mdl, "GEOTHERMAL_DRHO_DT_INPLACE", CS%dRcv_dT_inplace, &
                  "The value of drho_dT above which geothermal heating \n"//&
                  "simply heats water in place instead of moving it between \n"//&
                  "isopycnal layers.  This must be negative.", &
@@ -416,11 +416,11 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
          "GEOTHERMAL_DRHO_DT_INPLACE must be negative.")
 
   if (len_trim(geo_file) >= 1) then
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     inputdir = slasher(inputdir)
     filename = trim(inputdir)//trim(geo_file)
-    call log_param(param_file, mod, "INPUTDIR/GEOTHERMAL_FILE", filename)
-    call get_param(param_file, mod, "GEOTHERMAL_VARNAME", geotherm_var, &
+    call log_param(param_file, mdl, "INPUTDIR/GEOTHERMAL_FILE", filename)
+    call get_param(param_file, mdl, "GEOTHERMAL_VARNAME", geotherm_var, &
                  "The name of the geothermal heating variable in \n"//&
                  "GEOTHERMAL_FILE.", default="geo_heat")
     call read_data(filename, trim(geotherm_var), CS%geo_heat, &

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -293,7 +293,7 @@ subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
   logical :: read_tideamp
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_int_tide_input"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_int_tide_input"  ! This module's name.
   character(len=20)  :: tmpstr
   character(len=200) :: filename, tideamp_file, h2_file
 
@@ -325,18 +325,18 @@ subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mod, "INPUTDIR", CS%inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
   CS%inputdir = slasher(CS%inputdir)
 
-  call get_param(param_file, mod, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
 
-  call get_param(param_file, mod, "MIN_ZBOT_ITIDES", min_zbot_itides, &
+  call get_param(param_file, mdl, "MIN_ZBOT_ITIDES", min_zbot_itides, &
                "Turn off internal tidal dissipation when the total \n"//&
                "ocean depth is less than this value.", units="m", default=0.0)
 
-  call get_param(param_file, mod, "UTIDE", utide, &
+  call get_param(param_file, mdl, "UTIDE", utide, &
                "The constant tidal amplitude used with INT_TIDE_DISSIPATION.", &
                units="m s-1", default=0.0)
 
@@ -346,38 +346,38 @@ subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
   allocate(itide%tideamp(isd:ied,jsd:jed)) ; itide%tideamp(:,:) = utide
   allocate(CS%TKE_itidal_coef(isd:ied,jsd:jed)) ; CS%TKE_itidal_coef(:,:) = 0.0
 
-  call get_param(param_file, mod, "KAPPA_ITIDES", kappa_itides, &
+  call get_param(param_file, mdl, "KAPPA_ITIDES", kappa_itides, &
                "A topographic wavenumber used with INT_TIDE_DISSIPATION. \n"//&
                "The default is 2pi/10 km, as in St.Laurent et al. 2002.", &
                units="m-1", default=8.e-4*atan(1.0))
 
-  call get_param(param_file, mod, "KAPPA_H2_FACTOR", kappa_h2_factor, &
+  call get_param(param_file, mdl, "KAPPA_H2_FACTOR", kappa_h2_factor, &
                "A scaling factor for the roughness amplitude with n"//&
                "INT_TIDE_DISSIPATION.",  units="nondim", default=1.0)
-  call get_param(param_file, mod, "TKE_ITIDE_MAX", CS%TKE_itide_max, &
+  call get_param(param_file, mdl, "TKE_ITIDE_MAX", CS%TKE_itide_max, &
                "The maximum internal tide energy source availble to mix \n"//&
                "above the bottom boundary layer with INT_TIDE_DISSIPATION.", &
                units="W m-2",  default=1.0e3)
 
-  call get_param(param_file, mod, "READ_TIDEAMP", read_tideamp, &
+  call get_param(param_file, mdl, "READ_TIDEAMP", read_tideamp, &
                "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
                "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
   if (read_tideamp) then
-    call get_param(param_file, mod, "TIDEAMP_FILE", tideamp_file, &
+    call get_param(param_file, mdl, "TIDEAMP_FILE", tideamp_file, &
                "The path to the file containing the spatially varying \n"//&
                "tidal amplitudes with INT_TIDE_DISSIPATION.", default="tideamp.nc")
     filename = trim(CS%inputdir) // trim(tideamp_file)
-    call log_param(param_file, mod, "INPUTDIR/TIDEAMP_FILE", filename)
+    call log_param(param_file, mdl, "INPUTDIR/TIDEAMP_FILE", filename)
     call read_data(filename, 'tideamp', itide%tideamp, &
                    domain=G%domain%mpp_domain, timelevel=1)
   endif
 
-  call get_param(param_file, mod, "H2_FILE", h2_file, &
+  call get_param(param_file, mdl, "H2_FILE", h2_file, &
                "The path to the file containing the sub-grid-scale \n"//&
                "topographic roughness amplitude with INT_TIDE_DISSIPATION.", &
                fail_if_missing=.true.)
   filename = trim(CS%inputdir) // trim(h2_file)
-  call log_param(param_file, mod, "INPUTDIR/H2_FILE", filename)
+  call log_param(param_file, mdl, "INPUTDIR/H2_FILE", filename)
   call read_data(filename, 'h2', itide%h2, domain=G%domain%mpp_domain, &
                  timelevel=1)
 

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -109,7 +109,7 @@ type, public :: Kappa_shear_CS ; private
 end type Kappa_shear_CS
 
 ! integer :: id_clock_project, id_clock_KQ, id_clock_avg, id_clock_setup
-  character(len=40)  :: mod = "MOM_kappa_shear"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_kappa_shear"  ! This module's name.
 
 #undef  DEBUG
 #undef  ADD_DIAGNOSTICS
@@ -1680,77 +1680,77 @@ logical function kappa_shear_init(Time, G, GV, param_file, diag, CS)
   ! subgridscale inhomogeneity into account.
 
 ! Set default, read and log parameters
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
     "Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008")
-  call get_param(param_file, mod, "USE_JACKSON_PARAM", kappa_shear_init, &
+  call get_param(param_file, mdl, "USE_JACKSON_PARAM", kappa_shear_init, &
                  "If true, use the Jackson-Hallberg-Legg (JPO 2008) \n"//&
                  "shear mixing parameterization.", default=.false.)
-  call get_param(param_file, mod, "RINO_CRIT", CS%RiNo_crit, &
+  call get_param(param_file, mdl, "RINO_CRIT", CS%RiNo_crit, &
                  "The critical Richardson number for shear mixing.", &
                  units="nondim", default=0.25)
-  call get_param(param_file, mod, "SHEARMIX_RATE", CS%Shearmix_rate, &
+  call get_param(param_file, mdl, "SHEARMIX_RATE", CS%Shearmix_rate, &
                  "A nondimensional rate scale for shear-driven entrainment.\n"//&
                  "Jackson et al find values in the range of 0.085-0.089.", &
                  units="nondim", default=0.089)
-  call get_param(param_file, mod, "MAX_RINO_IT", CS%max_RiNo_it, &
+  call get_param(param_file, mdl, "MAX_RINO_IT", CS%max_RiNo_it, &
                  "The maximum number of iterations that may be used to \n"//&
                  "estimate the Richardson number driven mixing.", &
                  units="nondim", default=50)
-  call get_param(param_file, mod, "KD", KD_normal, default=1.0e-7, do_not_log=.true.)
-  call get_param(param_file, mod, "KD_KAPPA_SHEAR_0", CS%kappa_0, &
+  call get_param(param_file, mdl, "KD", KD_normal, default=1.0e-7, do_not_log=.true.)
+  call get_param(param_file, mdl, "KD_KAPPA_SHEAR_0", CS%kappa_0, &
                  "The background diffusivity that is used to smooth the \n"//&
                  "density and shear profiles before solving for the \n"//&
                  "diffusivities. Defaults to value of KD.", units="m2 s-1", default=KD_normal)
-  call get_param(param_file, mod, "FRI_CURVATURE", CS%FRi_curvature, &
+  call get_param(param_file, mdl, "FRI_CURVATURE", CS%FRi_curvature, &
                  "The nondimensional curvature of the function of the \n"//&
                  "Richardson number in the kappa source term in the \n"//&
                  "Jackson et al. scheme.", units="nondim", default=-0.97)
-  call get_param(param_file, mod, "TKE_N_DECAY_CONST", CS%C_N, &
+  call get_param(param_file, mdl, "TKE_N_DECAY_CONST", CS%C_N, &
                  "The coefficient for the decay of TKE due to \n"//&
                  "stratification (i.e. proportional to N*tke). \n"//&
                  "The values found by Jackson et al. are 0.24-0.28.", &
                  units="nondim", default=0.24)
-!  call get_param(param_file, mod, "LAYER_KAPPA_STAGGER", CS%layer_stagger, &
+!  call get_param(param_file, mdl, "LAYER_KAPPA_STAGGER", CS%layer_stagger, &
 !                 default=.false.)
-  call get_param(param_file, mod, "TKE_SHEAR_DECAY_CONST", CS%C_S, &
+  call get_param(param_file, mdl, "TKE_SHEAR_DECAY_CONST", CS%C_S, &
                  "The coefficient for the decay of TKE due to shear (i.e. \n"//&
                  "proportional to |S|*tke). The values found by Jackson \n"//&
                  "et al. are 0.14-0.12.", units="nondim", default=0.14)
-  call get_param(param_file, mod, "KAPPA_BUOY_SCALE_COEF", CS%lambda, &
+  call get_param(param_file, mdl, "KAPPA_BUOY_SCALE_COEF", CS%lambda, &
                  "The coefficient for the buoyancy length scale in the \n"//&
                  "kappa equation.  The values found by Jackson et al. are \n"//&
                  "in the range of 0.81-0.86.", units="nondim", default=0.82)
-  call get_param(param_file, mod, "KAPPA_N_OVER_S_SCALE_COEF2", CS%lambda2_N_S, &
+  call get_param(param_file, mdl, "KAPPA_N_OVER_S_SCALE_COEF2", CS%lambda2_N_S, &
                  "The square of the ratio of the coefficients of the \n"//&
                  "buoyancy and shear scales in the diffusivity equation, \n"//&
                  "Set this to 0 (the default) to eliminate the shear scale. \n"//&
                  "This is only used if USE_JACKSON_PARAM is true.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "KAPPA_SHEAR_TOL_ERR", CS%kappa_tol_err, &
+  call get_param(param_file, mdl, "KAPPA_SHEAR_TOL_ERR", CS%kappa_tol_err, &
                  "The fractional error in kappa that is tolerated. \n"//&
                  "Iteration stops when changes between subsequent \n"//&
                  "iterations are smaller than this everywhere in a \n"//&
                  "column.  The peak diffusivities usually converge most \n"//&
                  "rapidly, and have much smaller errors than this.", &
                  units="nondim", default=0.1)
-  call get_param(param_file, mod, "TKE_BACKGROUND", CS%TKE_bg, &
+  call get_param(param_file, mdl, "TKE_BACKGROUND", CS%TKE_bg, &
                  "A background level of TKE used in the first iteration \n"//&
                  "of the kappa equation.  TKE_BACKGROUND could be 0.", &
                  units="m2 s-2", default=0.0)
-  call get_param(param_file, mod, "KAPPA_SHEAR_ELIM_MASSLESS", CS%eliminate_massless, &
+  call get_param(param_file, mdl, "KAPPA_SHEAR_ELIM_MASSLESS", CS%eliminate_massless, &
                  "If true, massless layers are merged with neighboring \n"//&
                  "massive layers in this calculation.  The default is \n"//&
                  "true and I can think of no good reason why it should \n"//&
                  "be false. This is only used if USE_JACKSON_PARAM is true.", &
                  default=.true.)
-  call get_param(param_file, mod, "MAX_KAPPA_SHEAR_IT", CS%max_KS_it, &
+  call get_param(param_file, mdl, "MAX_KAPPA_SHEAR_IT", CS%max_KS_it, &
                  "The maximum number of iterations that may be used to \n"//&
                  "estimate the time-averaged diffusivity.", units="nondim", &
                  default=13)
-  call get_param(param_file, mod, "PRANDTL_TURB", CS%Prandtl_turb, &
+  call get_param(param_file, mdl, "PRANDTL_TURB", CS%Prandtl_turb, &
                  "The turbulent Prandtl number applied to shear \n"//&
                  "instability.", units="nondim", default=1.0, do_not_log=.true.)
-  call get_param(param_file, mod, "DEBUG_KAPPA_SHEAR", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG_KAPPA_SHEAR", CS%debug, &
                  "If true, write debugging data for the kappa-shear code. \n"//&
                  "Caution: this option is _very_ verbose and should only \n"//&
                  "be used in single-column mode!", default=.false.)
@@ -1762,7 +1762,7 @@ logical function kappa_shear_init(Time, G, GV, param_file, diag, CS)
 
   CS%nkml = 1
   if (GV%nkml>0) then
-    call get_param(param_file, mod, "KAPPA_SHEAR_MERGE_ML",merge_mixedlayer, &
+    call get_param(param_file, mdl, "KAPPA_SHEAR_MERGE_ML",merge_mixedlayer, &
                  "If true, combine the mixed layers together before \n"//&
                  "solving the kappa-shear equations.", default=.true.)
     if (merge_mixedlayer) CS%nkml = GV%nkml
@@ -1791,7 +1791,7 @@ logical function kappa_shear_is_used(param_file)
 !   This function allows other modules to know whether this parameterization will
 ! be used without needing to duplicate the log entry.
   type(param_file_type), intent(in) :: param_file !< A structure to parse for run-time parameters
-  call get_param(param_file, mod, "USE_JACKSON_PARAM", kappa_shear_is_used, &
+  call get_param(param_file, mdl, "USE_JACKSON_PARAM", kappa_shear_is_used, &
                  default=.false., do_not_log = .true.)
 end function kappa_shear_is_used
 

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -497,7 +497,7 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
   character(len=200) :: inputdir   ! The directory where NetCDF input files
   character(len=240) :: filename
   character(len=200) :: tmpstr
-  character(len=40)  :: mod = "MOM_opacity"
+  character(len=40)  :: mdl = "MOM_opacity"
   character(len=40)  :: bandnum, shortname
   character(len=200) :: longname
   character(len=40)  :: scheme_string
@@ -516,17 +516,17 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
   CS%tracer_flow_CSp => tracer_flow
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
 ! parameters for CHL_A routines
-  call get_param(param_file, mod, "VAR_PEN_SW", CS%var_pen_sw, &
+  call get_param(param_file, mdl, "VAR_PEN_SW", CS%var_pen_sw, &
                  "If true, use one of the CHL_A schemes specified by \n"//&
                  "OPACITY_SCHEME to determine the e-folding depth of \n"//&
                  "incoming short wave radiation.", default=.false.)
 
   CS%opacity_scheme = NO_SCHEME ; scheme_string = ""
   if (CS%var_pen_sw) then
-    call get_param(param_file, mod, "OPACITY_SCHEME", tmpstr, &
+    call get_param(param_file, mdl, "OPACITY_SCHEME", tmpstr, &
                  "This character string specifies how chlorophyll \n"//&
                  "concentrations are translated into opacities. Currently \n"//&
                  "valid options include:\n"//&
@@ -552,27 +552,27 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
       CS%opacity_scheme = MANIZZA_05 ; scheme_string = MANIZZA_05_STRING
     endif
 
-    call get_param(param_file, mod, "CHL_FROM_FILE", CS%chl_from_file, &
+    call get_param(param_file, mdl, "CHL_FROM_FILE", CS%chl_from_file, &
                  "If true, chl_a is read from a file.", default=.true.)
     if (CS%chl_from_file) then
       call time_interp_external_init()
 
-      call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
-      call get_param(param_file, mod, "CHL_FILE", CS%chl_file, &
+      call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
+      call get_param(param_file, mdl, "CHL_FILE", CS%chl_file, &
                  "CHL_FILE is the file containing chl_a concentrations in \n"//&
                  "the variable CHL_A. It is used when VAR_PEN_SW and \n"//&
                  "CHL_FROM_FILE are true.", fail_if_missing=.true.)
 
       filename = trim(slasher(inputdir))//trim(CS%chl_file)
-      call log_param(param_file, mod, "INPUTDIR/CHL_FILE", filename)
+      call log_param(param_file, mdl, "INPUTDIR/CHL_FILE", filename)
       CS%sbc_chl = init_external_field(filename,'CHL_A',domain=G%Domain%mpp_domain)
     endif
 
-    call get_param(param_file, mod, "BLUE_FRAC_SW", CS%blue_frac, &
+    call get_param(param_file, mdl, "BLUE_FRAC_SW", CS%blue_frac, &
                  "The fraction of the penetrating shortwave radiation \n"//&
                  "that is in the blue band.", default=0.5, units="nondim")
   else
-    call get_param(param_file, mod, "EXP_OPACITY_SCHEME", tmpstr, &
+    call get_param(param_file, mdl, "EXP_OPACITY_SCHEME", tmpstr, &
                  "This character string specifies which exponential \n"//&
                  "opacity scheme to utilize. Currently \n"//&
                  "valid options include:\n"//&
@@ -589,17 +589,17 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
       end select
       call MOM_mesg('opacity_init: opacity scheme set to "'//trim(tmpstr)//'".', 5)
     endif
-    call get_param(param_file, mod, "PEN_SW_SCALE", CS%pen_sw_scale, &
+    call get_param(param_file, mdl, "PEN_SW_SCALE", CS%pen_sw_scale, &
                  "The vertical absorption e-folding depth of the \n"//&
                  "penetrating shortwave radiation.", units="m", default=0.0)
     !BGR/ Added for opacity_scheme==double_exp read in 2nd exp-decay and fraction
     if (CS%Opacity_scheme == DOUBLE_EXP ) then
-      call get_param(param_file, mod, "PEN_SW_SCALE_2ND", CS%pen_sw_scale_2nd, &
+      call get_param(param_file, mdl, "PEN_SW_SCALE_2ND", CS%pen_sw_scale_2nd, &
                  "The (2nd) vertical absorption e-folding depth of the \n"//&
                  "penetrating shortwave radiation \n"//&
                  "(use if SW_EXP_MODE==double.)",&
                  units="m", default=0.0)
-      call get_param(param_file, mod, "SW_1ST_EXP_RATIO", CS%sw_1st_exp_ratio, &
+      call get_param(param_file, mdl, "SW_1ST_EXP_RATIO", CS%sw_1st_exp_ratio, &
                  "The fraction of 1st vertical absorption e-folding depth \n"//&
                  "penetrating shortwave radiation if SW_EXP_MODE==double.",&
                   units="m", default=0.0)
@@ -608,12 +608,12 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
       CS%pen_sw_scale_2nd = 0.0
       CS%sw_1st_exp_ratio = 1.0
     endif
-    call get_param(param_file, mod, "PEN_SW_FRAC", CS%pen_sw_frac, &
+    call get_param(param_file, mdl, "PEN_SW_FRAC", CS%pen_sw_frac, &
                  "The fraction of the shortwave radiation that penetrates \n"//&
                  "below the surface.", units="nondim", default=0.0)
 
   endif
-  call get_param(param_file, mod, "PEN_SW_NBANDS", optics%nbands, &
+  call get_param(param_file, mdl, "PEN_SW_NBANDS", optics%nbands, &
                  "The number of bands of penetrating shortwave radiation.", &
                  default=1)
   if (CS%Opacity_scheme == DOUBLE_EXP ) then
@@ -647,7 +647,7 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
     endif
   endif
 
-  call get_param(param_file, mod, "OPACITY_LAND_VALUE", CS%opacity_land_value, &
+  call get_param(param_file, mdl, "OPACITY_LAND_VALUE", CS%opacity_land_value, &
                  "The value to use for opacity over land. The default is \n"//&
                  "10 m-1 - a value for muddy water.", units="m-1", default=10.0)
 

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -939,7 +939,7 @@ subroutine regularize_layers_init(Time, G, param_file, diag, CS)
 !                  for this module
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_regularize_layers"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_regularize_layers"  ! This module's name.
   logical :: use_temperature
   integer :: isd, ied, jsd, jed
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -954,23 +954,23 @@ subroutine regularize_layers_init(Time, G, param_file, diag, CS)
   CS%Time => Time
 
 ! Set default, read and log parameters
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "REGULARIZE_SURFACE_LAYERS", CS%regularize_surface_layers, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "REGULARIZE_SURFACE_LAYERS", CS%regularize_surface_layers, &
                  "If defined, vertically restructure the near-surface \n"//&
                  "layers when they have too much lateral variations to \n"//&
                  "allow for sensible lateral barotropic transports.", &
                  default=.false.)
   if (CS%regularize_surface_layers) then
-    call get_param(param_file, mod, "REGULARIZE_SURFACE_DETRAIN", CS%reg_sfc_detrain, &
+    call get_param(param_file, mdl, "REGULARIZE_SURFACE_DETRAIN", CS%reg_sfc_detrain, &
                  "If true, allow the buffer layers to detrain into the \n"//&
                  "interior as a part of the restructuring when \n"//&
                  "REGULARIZE_SURFACE_LAYERS is true.", default=.true.)
   endif
 
-  call get_param(param_file, mod, "HMIX_MIN", CS%Hmix_min, &
+  call get_param(param_file, mdl, "HMIX_MIN", CS%Hmix_min, &
                  "The minimum mixed layer depth if the mixed layer depth \n"//&
                  "is determined dynamically.", units="m", default=0.0)
-  call get_param(param_file, mod, "REG_SFC_DEFICIT_TOLERANCE", CS%h_def_tol1, &
+  call get_param(param_file, mdl, "REG_SFC_DEFICIT_TOLERANCE", CS%h_def_tol1, &
                  "The value of the relative thickness deficit at which \n"//&
                  "to start modifying the layer structure when \n"//&
                  "REGULARIZE_SURFACE_LAYERS is true.", units="nondim", &
@@ -979,12 +979,12 @@ subroutine regularize_layers_init(Time, G, param_file, diag, CS)
   CS%h_def_tol3 = 0.3 + 0.7*CS%h_def_tol1
   CS%h_def_tol4 = 0.5 + 0.5*CS%h_def_tol1
 
-  call get_param(param_file, mod, "DEBUG", CS%debug, default=.false.)
+  call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
 !  if (.not. CS%debug) &
-!    call get_param(param_file, mod, "DEBUG_CONSERVATION", CS%debug, &
+!    call get_param(param_file, mdl, "DEBUG_CONSERVATION", CS%debug, &
 !                 "If true, monitor conservation and extrema.", default=.false.)
 
-  call get_param(param_file, mod, "ALLOW_CLOCKS_IN_OMP_LOOPS", &
+  call get_param(param_file, mdl, "ALLOW_CLOCKS_IN_OMP_LOOPS", &
                  CS%allow_clocks_in_omp_loops, &
                  "If true, clocks can be called from inside loops that can \n"//&
                  "be threaded. To run with multiple threads, set to False.", &

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -2527,7 +2527,7 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
   logical :: read_tideamp, ML_use_omega
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_set_diffusivity"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_set_diffusivity"  ! This module's name.
   character(len=20)  :: tmpstr
   character(len=200) :: filename, tideamp_file, h2_file, Niku_TKE_input_file
   real :: Niku_scale ! local variable for scaling the Nikurashin TKE flux data
@@ -2556,20 +2556,20 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
 
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mod, "INPUTDIR", CS%inputdir, default=".")
+  call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
   CS%inputdir = slasher(CS%inputdir)
-  call get_param(param_file, mod, "FLUX_RI_MAX", CS%FluxRi_max, &
+  call get_param(param_file, mdl, "FLUX_RI_MAX", CS%FluxRi_max, &
                  "The flux Richardson number where the stratification is \n"//&
                  "large enough that N2 > omega2.  The full expression for \n"//&
                  "the Flux Richardson number is usually \n"//&
                  "FLUX_RI_MAX*N2/(N2+OMEGA2).", default=0.2)
-  call get_param(param_file, mod, "OMEGA", CS%omega, &
+  call get_param(param_file, mdl, "OMEGA", CS%omega, &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5)
 
-  call get_param(param_file, mod, "ML_RADIATION", CS%ML_radiation, &
+  call get_param(param_file, mdl, "ML_RADIATION", CS%ML_radiation, &
                  "If true, allow a fraction of TKE available from wind \n"//&
                  "work to penetrate below the base of the mixed layer \n"//&
                  "with a vertical decay scale determined by the minimum \n"//&
@@ -2579,33 +2579,33 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
     ! This give a minimum decay scale that is typically much less than Angstrom.
     CS%ustar_min = 2e-4*CS%omega*(GV%Angstrom + GV%H_subroundoff)
 
-    call get_param(param_file, mod, "ML_RAD_EFOLD_COEFF", CS%ML_rad_efold_coeff, &
+    call get_param(param_file, mdl, "ML_RAD_EFOLD_COEFF", CS%ML_rad_efold_coeff, &
                  "A coefficient that is used to scale the penetration \n"//&
                  "depth for turbulence below the base of the mixed layer. \n"//&
                  "This is only used if ML_RADIATION is true.", units="nondim", &
                  default=0.2)
-    call get_param(param_file, mod, "ML_RAD_KD_MAX", CS%ML_rad_kd_max, &
+    call get_param(param_file, mdl, "ML_RAD_KD_MAX", CS%ML_rad_kd_max, &
                  "The maximum diapycnal diffusivity due to turbulence \n"//&
                  "radiated from the base of the mixed layer. \n"//&
                  "This is only used if ML_RADIATION is true.", units="m2 s-1", &
                  default=1.0e-3)
-    call get_param(param_file, mod, "ML_RAD_COEFF", CS%ML_rad_coeff, &
+    call get_param(param_file, mdl, "ML_RAD_COEFF", CS%ML_rad_coeff, &
                  "The coefficient which scales MSTAR*USTAR^3 to obtain \n"//&
                  "the energy available for mixing below the base of the \n"//&
                  "mixed layer. This is only used if ML_RADIATION is true.", &
                  units="nondim", default=0.2)
-    call get_param(param_file, mod, "ML_RAD_APPLY_TKE_DECAY", CS%ML_rad_TKE_decay, &
+    call get_param(param_file, mdl, "ML_RAD_APPLY_TKE_DECAY", CS%ML_rad_TKE_decay, &
                  "If true, apply the same exponential decay to ML_rad as \n"//&
                  "is applied to the other surface sources of TKE in the \n"//&
                  "mixed layer code. This is only used if ML_RADIATION is true.",&
                  default=.true.)
-    call get_param(param_file, mod, "MSTAR", CS%mstar, &
+    call get_param(param_file, mdl, "MSTAR", CS%mstar, &
                  "The ratio of the friction velocity cubed to the TKE \n"//&
                  "input to the mixed layer.", "units=nondim", default=1.2)
-    call get_param(param_file, mod, "TKE_DECAY", CS%TKE_decay, &
+    call get_param(param_file, mdl, "TKE_DECAY", CS%TKE_decay, &
                  "The ratio of the natural Ekman depth to the TKE decay scale.", &
                  units="nondim", default=2.5)
-    call get_param(param_file, mod, "ML_USE_OMEGA", ML_use_omega, &
+    call get_param(param_file, mdl, "ML_USE_OMEGA", ML_use_omega, &
                  "If true, use the absolute rotation rate instead of the \n"//&
                  "vertical component of rotation when setting the decay \n"//&
                  "scale for turbulence.", default=.false., do_not_log=.true.)
@@ -2614,29 +2614,29 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
       call MOM_error(WARNING, "ML_USE_OMEGA is depricated; use ML_OMEGA_FRAC=1.0 instead.")
       omega_frac_dflt = 1.0
     endif
-    call get_param(param_file, mod, "ML_OMEGA_FRAC", CS%ML_omega_frac, &
+    call get_param(param_file, mdl, "ML_OMEGA_FRAC", CS%ML_omega_frac, &
                    "When setting the decay scale for turbulence, use this \n"//&
                    "fraction of the absolute rotation rate blended with the \n"//&
                    "local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).", &
                    units="nondim", default=omega_frac_dflt)
   endif
 
-  call get_param(param_file, mod, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
+  call get_param(param_file, mdl, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
                  "If true, the bottom stress is calculated with a drag \n"//&
                  "law of the form c_drag*|u|*u. The velocity magnitude \n"//&
                  "may be an assumed value or it may be based on the \n"//&
                  "actual velocity in the bottommost HBBL, depending on \n"//&
                  "LINEAR_DRAG.", default=.true.)
   if  (CS%bottomdraglaw) then
-    call get_param(param_file, mod, "CDRAG", CS%cdrag, &
+    call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
                  "The drag coefficient relating the magnitude of the \n"//&
                  "velocity field to the bottom stress. CDRAG is only used \n"//&
                  "if BOTTOMDRAGLAW is true.", units="nondim", default=0.003)
-    call get_param(param_file, mod, "BBL_EFFIC", CS%BBL_effic, &
+    call get_param(param_file, mdl, "BBL_EFFIC", CS%BBL_effic, &
                  "The efficiency with which the energy extracted by \n"//&
                  "bottom drag drives BBL diffusion.  This is only \n"//&
                  "used if BOTTOMDRAGLAW is true.", units="nondim", default=0.20)
-    call get_param(param_file, mod, "BBL_MIXING_MAX_DECAY", decay_length, &
+    call get_param(param_file, mdl, "BBL_MIXING_MAX_DECAY", decay_length, &
                  "The maximum decay scale for the BBL diffusion, or 0 \n"//&
                  "to allow the mixing to penetrate as far as \n"//&
                  "stratification and rotation permit.  The default is 0. \n"//&
@@ -2645,17 +2645,17 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
 
     CS%IMax_decay = 1.0/200.0
     if (decay_length > 0.0) CS%IMax_decay = 1.0/decay_length
-    call get_param(param_file, mod, "BBL_MIXING_AS_MAX", CS%BBL_mixing_as_max, &
+    call get_param(param_file, mdl, "BBL_MIXING_AS_MAX", CS%BBL_mixing_as_max, &
                  "If true, take the maximum of the diffusivity from the \n"//&
                  "BBL mixing and the other diffusivities. Otherwise, \n"//&
                  "diffusiviy from the BBL_mixing is simply added.", &
                  default=.true.)
-    call get_param(param_file, mod, "USE_LOTW_BBL_DIFFUSIVITY", CS%use_LOTW_BBL_diffusivity, &
+    call get_param(param_file, mdl, "USE_LOTW_BBL_DIFFUSIVITY", CS%use_LOTW_BBL_diffusivity, &
                  "If true, uses a simple, imprecise but non-coordinate dependent, model\n"//&
                  "of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses\n"//&
                  "the original BBL scheme.", default=.false.)
     if (CS%use_LOTW_BBL_diffusivity) then
-      call get_param(param_file, mod, "LOTW_BBL_USE_OMEGA", CS%LOTW_BBL_use_omega, &
+      call get_param(param_file, mdl, "LOTW_BBL_USE_OMEGA", CS%LOTW_BBL_use_omega, &
                  "If true, use the maximum of Omega and N for the TKE to diffusion\n"//&
                  "calculation. Otherwise, N is N.", default=.true.)
     endif
@@ -2664,38 +2664,38 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
   endif
   CS%id_Kd_BBL = register_diag_field('ocean_model','Kd_BBL',diag%axesTi,Time, &
        'Bottom Boundary Layer Diffusivity', 'meter2 sec-1')
-  call get_param(param_file, mod, "SIMPLE_TKE_TO_KD", CS%simple_TKE_to_Kd, &
+  call get_param(param_file, mdl, "SIMPLE_TKE_TO_KD", CS%simple_TKE_to_Kd, &
                  "If true, uses a simple estimate of Kd/TKE that will\n"//&
                  "work for arbitrary vertical coordinates. If false,\n"//&
                  "calculates Kd/TKE and bounds based on exact energetics/n"//&
                  "for an isopycnal layer-formulation.", &
                  default=.false.)
 
-  call get_param(param_file, mod, "BRYAN_LEWIS_DIFFUSIVITY", &
+  call get_param(param_file, mdl, "BRYAN_LEWIS_DIFFUSIVITY", &
                                 CS%Bryan_Lewis_diffusivity, &
                  "If true, use a Bryan & Lewis (JGR 1979) like tanh \n"//&
                  "profile of background diapycnal diffusivity with depth.", &
                  default=.false.)
   if (CS%Bryan_Lewis_diffusivity) then
-    call get_param(param_file, mod, "KD_BRYAN_LEWIS_DEEP", &
+    call get_param(param_file, mdl, "KD_BRYAN_LEWIS_DEEP", &
                                   CS%Kd_Bryan_Lewis_deep, &
                  "The abyssal value of a Bryan-Lewis diffusivity profile. \n"//&
                  "KD_BRYAN_LEWIS_DEEP is only used if \n"//&
                  "BRYAN_LEWIS_DIFFUSIVITY is true.", units="m2 s-1", &
                  fail_if_missing=.true.)
-    call get_param(param_file, mod, "KD_BRYAN_LEWIS_SURFACE", &
+    call get_param(param_file, mdl, "KD_BRYAN_LEWIS_SURFACE", &
                                   CS%Kd_Bryan_Lewis_surface, &
                  "The surface value of a Bryan-Lewis diffusivity profile. \n"//&
                  "KD_BRYAN_LEWIS_SURFACE is only used if \n"//&
                  "BRYAN_LEWIS_DIFFUSIVITY is true.", units="m2 s-1", &
                  fail_if_missing=.true.)
-    call get_param(param_file, mod, "BRYAN_LEWIS_DEPTH_CENT", &
+    call get_param(param_file, mdl, "BRYAN_LEWIS_DEPTH_CENT", &
                                   CS%Bryan_Lewis_depth_cent, &
                  "The depth about which the transition in the Bryan-Lewis \n"//&
                  "profile is centered. BRYAN_LEWIS_DEPTH_CENT is only \n"//&
                  "used if BRYAN_LEWIS_DIFFUSIVITY is true.", units="m", &
                  fail_if_missing=.true.)
-    call get_param(param_file, mod, "BRYAN_LEWIS_WIDTH_TRANS", &
+    call get_param(param_file, mdl, "BRYAN_LEWIS_WIDTH_TRANS", &
                                   CS%Bryan_Lewis_width_trans, &
                  "The width of the transition in the Bryan-Lewis \n"//&
                  "profile. BRYAN_LEWIS_WIDTH_TRANS is only \n"//&
@@ -2703,12 +2703,12 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
                  fail_if_missing=.true.)
   endif
 
-  call get_param(param_file, mod, "HENYEY_IGW_BACKGROUND", &
+  call get_param(param_file, mdl, "HENYEY_IGW_BACKGROUND", &
                                 CS%Henyey_IGW_background, &
                  "If true, use a latitude-dependent scaling for the near \n"//&
                  "surface background diffusivity, as described in \n"//&
                  "Harrison & Hallberg, JPO 2008.", default=.false.)
-  call get_param(param_file, mod, "HENYEY_IGW_BACKGROUND_NEW", &
+  call get_param(param_file, mdl, "HENYEY_IGW_BACKGROUND_NEW", &
                                 CS%Henyey_IGW_background_new, &
                  "If true, use a better latitude-dependent scaling for the\n"//&
                  "background diffusivity, as described in \n"//&
@@ -2717,48 +2717,48 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
                  "set_diffusivity_init: HENYEY_IGW_BACKGROUND and HENYEY_IGW_BACKGROUND_NEW "// &
                  "are mutually exclusive. Set only one or none.")
   if (CS%Henyey_IGW_background) &
-    call get_param(param_file, mod, "HENYEY_N0_2OMEGA", CS%N0_2Omega, &
+    call get_param(param_file, mdl, "HENYEY_N0_2OMEGA", CS%N0_2Omega, &
                   "The ratio of the typical Buoyancy frequency to twice \n"//&
                   "the Earth's rotation period, used with the Henyey \n"//&
                   "scaling from the mixing.", units="nondim", default=20.0)
-  call get_param(param_file, mod, "N2_FLOOR_IOMEGA2", CS%N2_FLOOR_IOMEGA2, &
+  call get_param(param_file, mdl, "N2_FLOOR_IOMEGA2", CS%N2_FLOOR_IOMEGA2, &
                   "The floor applied to N2(k) scaled by Omega^2:\n"//&
                   "\tIf =0., N2(k) is simply positive definite.\n"//&
                   "\tIf =1., N2(k) > Omega^2 everywhere.", units="nondim", &
                   default=1.0)
 
-  call get_param(param_file, mod, "KD_TANH_LAT_FN", &
+  call get_param(param_file, mdl, "KD_TANH_LAT_FN", &
                                   CS%Kd_tanh_lat_fn, &
                  "If true, use a tanh dependence of Kd_sfc on latitude, \n"//&
                  "like CM2.1/CM2M.  There is no physical justification \n"//&
                  "for this form, and it can not be used with \n"//&
                  "HENYEY_IGW_BACKGROUND.", default=.false.)
   if (CS%Kd_tanh_lat_fn) &
-    call get_param(param_file, mod, "KD_TANH_LAT_SCALE", &
+    call get_param(param_file, mdl, "KD_TANH_LAT_SCALE", &
                                   CS%Kd_tanh_lat_scale, &
                  "A nondimensional scaling for the range ofdiffusivities \n"//&
                  "with KD_TANH_LAT_FN. Valid values are in the range of \n"//&
                  "-2 to 2; 0.4 reproduces CM2M.", units="nondim", default=0.0)
 
-  call get_param(param_file, mod, "KV", CS%Kv, &
+  call get_param(param_file, mdl, "KV", CS%Kv, &
                  "The background kinematic viscosity in the interior. \n"//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
                  units="m2 s-1", fail_if_missing=.true.)
 
-  call get_param(param_file, mod, "KD", CS%Kd, &
+  call get_param(param_file, mdl, "KD", CS%Kd, &
                  "The background diapycnal diffusivity of density in the \n"//&
                  "interior. Zero or the molecular value, ~1e-7 m2 s-1, \n"//&
                  "may be used.", units="m2 s-1", fail_if_missing=.true.)
-  call get_param(param_file, mod, "KD_MIN", CS%Kd_min, &
+  call get_param(param_file, mdl, "KD_MIN", CS%Kd_min, &
                  "The minimum diapycnal diffusivity.", &
                  units="m2 s-1", default=0.01*CS%Kd)
-  call get_param(param_file, mod, "KD_MAX", CS%Kd_max, &
+  call get_param(param_file, mdl, "KD_MAX", CS%Kd_max, &
                  "The maximum permitted increment for the diapycnal \n"//&
                  "diffusivity from TKE-based parameterizations, or a \n"//&
                  "negative value for no limit.", units="m2 s-1", default=-1.0)
   if (CS%simple_TKE_to_Kd .and. CS%Kd_max<=0.) call MOM_error(FATAL, &
          "set_diffusivity_init: To use SIMPLE_TKE_TO_KD, KD_MAX must be set to >0.")
-  call get_param(param_file, mod, "KD_ADD", CS%Kd_add, &
+  call get_param(param_file, mdl, "KD_ADD", CS%Kd_add, &
                  "A uniform diapycnal diffusivity that is added \n"//&
                  "everywhere without any filtering or scaling.", &
                  units="m2 s-1", default=0.0)
@@ -2768,32 +2768,32 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
 
   if (CS%bulkmixedlayer) then
     ! Check that Kdml is not set when using bulk mixed layer
-    call get_param(param_file, mod, "KDML", CS%Kdml, default=-1.)
+    call get_param(param_file, mdl, "KDML", CS%Kdml, default=-1.)
     if (CS%Kdml>0.) call MOM_error(FATAL, &
                  "set_diffusivity_init: KDML cannot be set when using"// &
                  "bulk mixed layer.")
     CS%Kdml = CS%Kd ! This is not used with a bulk mixed layer, but also
                     ! cannot be a NaN.
   else
-    call get_param(param_file, mod, "KDML", CS%Kdml, &
+    call get_param(param_file, mdl, "KDML", CS%Kdml, &
                  "If BULKMIXEDLAYER is false, KDML is the elevated \n"//&
                  "diapycnal diffusivity in the topmost HMIX of fluid. \n"//&
                  "KDML is only used if BULKMIXEDLAYER is false.", &
                  units="m2 s-1", default=CS%Kd)
-    call get_param(param_file, mod, "HMIX_FIXED", CS%Hmix, &
+    call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
                  "The prescribed depth over which the near-surface \n"//&
                  "viscosity and diffusivity are elevated when the bulk \n"//&
                  "mixed layer is not used.", units="m", fail_if_missing=.true.)
   endif
-  call get_param(param_file, mod, "DEBUG", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", default=.false.)
 
-  call get_param(param_file, mod, "INT_TIDE_DISSIPATION", CS%Int_tide_dissipation, &
+  call get_param(param_file, mdl, "INT_TIDE_DISSIPATION", CS%Int_tide_dissipation, &
                  "If true, use an internal tidal dissipation scheme to \n"//&
                  "drive diapycnal mixing, along the lines of St. Laurent \n"//&
                  "et al. (2002) and Simmons et al. (2004).", default=.false.)
   if (CS%Int_tide_dissipation) then
-    call get_param(param_file, mod, "INT_TIDE_PROFILE", tmpstr, &
+    call get_param(param_file, mdl, "INT_TIDE_PROFILE", tmpstr, &
                  "INT_TIDE_PROFILE selects the vertical profile of energy \n"//&
                  "dissipation with INT_TIDE_DISSIPATION. Valid values are:\n"//&
                  "\t STLAURENT_02 - Use the St. Laurent et al exponential \n"//&
@@ -2811,13 +2811,13 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
     end select
   endif
 
-  call get_param(param_file, mod, "LEE_WAVE_DISSIPATION", CS%Lee_wave_dissipation, &
+  call get_param(param_file, mdl, "LEE_WAVE_DISSIPATION", CS%Lee_wave_dissipation, &
                  "If true, use an lee wave driven dissipation scheme to \n"//&
                  "drive diapycnal mixing, along the lines of Nikurashin \n"//&
                  "(2010) and using the St. Laurent et al. (2002) \n"//&
                  "and Simmons et al. (2004) vertical profile", default=.false.)
   if (CS%lee_wave_dissipation) then
-    call get_param(param_file, mod, "LEE_WAVE_PROFILE", tmpstr, &
+    call get_param(param_file, mdl, "LEE_WAVE_PROFILE", tmpstr, &
                  "LEE_WAVE_PROFILE selects the vertical profile of energy \n"//&
                  "dissipation with LEE_WAVE_DISSIPATION. Valid values are:\n"//&
                  "\t STLAURENT_02 - Use the St. Laurent et al exponential \n"//&
@@ -2835,7 +2835,7 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
     end select
   endif
 
-  call get_param(param_file, mod, "INT_TIDE_LOWMODE_DISSIPATION", CS%Lowmode_itidal_dissipation, &
+  call get_param(param_file, mdl, "INT_TIDE_LOWMODE_DISSIPATION", CS%Lowmode_itidal_dissipation, &
                  "If true, consider mixing due to breaking low modes that \n"//&
                  "have been remotely generated; as with itidal drag on the \n"//&
                  "barotropic tide, use an internal tidal dissipation scheme to \n"//&
@@ -2844,52 +2844,52 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
 
   if ((CS%Int_tide_dissipation .and. (CS%int_tide_profile == POLZIN_09)) .or. &
       (CS%lee_wave_dissipation .and. (CS%lee_wave_profile == POLZIN_09))) then
-    call get_param(param_file, mod, "NU_POLZIN", CS%Nu_Polzin, &
+    call get_param(param_file, mdl, "NU_POLZIN", CS%Nu_Polzin, &
                  "When the Polzin decay profile is used, this is a \n"//&
                  "non-dimensional constant in the expression for the \n"//&
                  "vertical scale of decay for the tidal energy dissipation.", &
                  units="nondim", default=0.0697)
-    call get_param(param_file, mod, "NBOTREF_POLZIN", CS%Nbotref_Polzin, &
+    call get_param(param_file, mdl, "NBOTREF_POLZIN", CS%Nbotref_Polzin, &
                  "When the Polzin decay profile is used, this is the \n"//&
                  "Rreference value of the buoyancy frequency at the ocean \n"//&
                  "bottom in the Polzin formulation for the vertical \n"//&
                  "scale of decay for the tidal energy dissipation.", &
                  units="s-1", default=9.61e-4)
-    call get_param(param_file, mod, "POLZIN_DECAY_SCALE_FACTOR", &
+    call get_param(param_file, mdl, "POLZIN_DECAY_SCALE_FACTOR", &
                  CS%Polzin_decay_scale_factor, &
                  "When the Polzin decay profile is used, this is a \n"//&
                  "scale factor for the vertical scale of decay of the tidal \n"//&
                  "energy dissipation.", default=1.0, units="nondim")
-    call get_param(param_file, mod, "POLZIN_SCALE_MAX_FACTOR", &
+    call get_param(param_file, mdl, "POLZIN_SCALE_MAX_FACTOR", &
                  CS%Polzin_decay_scale_max_factor, &
                  "When the Polzin decay profile is used, this is a factor \n"//&
                  "to limit the vertical scale of decay of the tidal \n"//&
                  "energy dissipation to POLZIN_DECAY_SCALE_MAX_FACTOR \n"//&
                  "times the depth of the ocean.", units="nondim", default=1.0)
-    call get_param(param_file, mod, "POLZIN_MIN_DECAY_SCALE", CS%Polzin_min_decay_scale, &
+    call get_param(param_file, mdl, "POLZIN_MIN_DECAY_SCALE", CS%Polzin_min_decay_scale, &
                  "When the Polzin decay profile is used, this is the \n"//&
                  "minimum vertical decay scale for the vertical profile\n"//&
                  "of internal tide dissipation with the Polzin (2009) formulation", &
                  units="m", default=0.0)
   endif
-  call get_param(param_file, mod, "USER_CHANGE_DIFFUSIVITY", CS%user_change_diff, &
+  call get_param(param_file, mdl, "USER_CHANGE_DIFFUSIVITY", CS%user_change_diff, &
                  "If true, call user-defined code to change the diffusivity.", &
                  default=.false.)
 
-  call get_param(param_file, mod, "DISSIPATION_MIN", CS%dissip_min, &
+  call get_param(param_file, mdl, "DISSIPATION_MIN", CS%dissip_min, &
                  "The minimum dissipation by which to determine a lower \n"//&
                  "bound of Kd (a floor).", units="W m-3", default=0.0)
-  call get_param(param_file, mod, "DISSIPATION_N0", CS%dissip_N0, &
+  call get_param(param_file, mdl, "DISSIPATION_N0", CS%dissip_N0, &
                  "The intercept when N=0 of the N-dependent expression \n"//&
                  "used to set a minimum dissipation by which to determine \n"//&
                  "a lower bound of Kd (a floor): A in eps_min = A + B*N.", &
                  units="W m-3", default=0.0)
-  call get_param(param_file, mod, "DISSIPATION_N1", CS%dissip_N1, &
+  call get_param(param_file, mdl, "DISSIPATION_N1", CS%dissip_N1, &
                  "The coefficient multiplying N, following Gargett, used to \n"//&
                  "set a minimum dissipation by which to determine a lower \n"//&
                  "bound of Kd (a floor): B in eps_min = A + B*N", &
                  units="J m-3", default=0.0)
-  call get_param(param_file, mod, "DISSIPATION_KD_MIN", CS%dissip_Kd_min, &
+  call get_param(param_file, mdl, "DISSIPATION_KD_MIN", CS%dissip_Kd_min, &
                  "The minimum vertical diffusivity applied as a floor.", &
                  units="m2 s-1", default=0.0)
 
@@ -2900,19 +2900,19 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
     CS%dissip_N2 = CS%dissip_Kd_min * GV%Rho0 / CS%FluxRi_max
 
   if (CS%Int_tide_dissipation .or. CS%Lee_wave_dissipation) then
-    call get_param(param_file, mod, "INT_TIDE_DECAY_SCALE", CS%Int_tide_decay_scale, &
+    call get_param(param_file, mdl, "INT_TIDE_DECAY_SCALE", CS%Int_tide_decay_scale, &
                  "The decay scale away from the bottom for tidal TKE with \n"//&
                  "the new coding when INT_TIDE_DISSIPATION is used.", &
                  units="m", default=0.0)
-    call get_param(param_file, mod, "MU_ITIDES", CS%Mu_itides, &
+    call get_param(param_file, mdl, "MU_ITIDES", CS%Mu_itides, &
                  "A dimensionless turbulent mixing efficiency used with \n"//&
                  "INT_TIDE_DISSIPATION, often 0.2.", units="nondim", default=0.2)
-    call get_param(param_file, mod, "GAMMA_ITIDES", CS%Gamma_itides, &
+    call get_param(param_file, mdl, "GAMMA_ITIDES", CS%Gamma_itides, &
                  "The fraction of the internal tidal energy that is \n"//&
                  "dissipated locally with INT_TIDE_DISSIPATION.  \n"//&
                  "THIS NAME COULD BE BETTER.", &
                  units="nondim", default=0.3333)
-    call get_param(param_file, mod, "MIN_ZBOT_ITIDES", CS%min_zbot_itides, &
+    call get_param(param_file, mdl, "MIN_ZBOT_ITIDES", CS%min_zbot_itides, &
                  "Turn off internal tidal dissipation when the total \n"//&
                  "ocean depth is less than this value.", units="m", default=0.0)
 
@@ -2921,43 +2921,43 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
     call safe_alloc_ptr(CS%TKE_itidal,isd,ied,jsd,jed)
     call safe_alloc_ptr(CS%mask_itidal,isd,ied,jsd,jed) ; CS%mask_itidal(:,:) = 1.0
 
-    call get_param(param_file, mod, "KAPPA_ITIDES", CS%kappa_itides, &
+    call get_param(param_file, mdl, "KAPPA_ITIDES", CS%kappa_itides, &
                  "A topographic wavenumber used with INT_TIDE_DISSIPATION. \n"//&
                  "The default is 2pi/10 km, as in St.Laurent et al. 2002.", &
                  units="m-1", default=8.e-4*atan(1.0))
 
-    call get_param(param_file, mod, "UTIDE", CS%utide, &
+    call get_param(param_file, mdl, "UTIDE", CS%utide, &
                  "The constant tidal amplitude used with INT_TIDE_DISSIPATION.", &
                  units="m s-1", default=0.0)
     call safe_alloc_ptr(CS%tideamp,is,ie,js,je) ; CS%tideamp(:,:) = CS%utide
 
-    call get_param(param_file, mod, "KAPPA_H2_FACTOR", CS%kappa_h2_factor, &
+    call get_param(param_file, mdl, "KAPPA_H2_FACTOR", CS%kappa_h2_factor, &
                  "A scaling factor for the roughness amplitude with n"//&
                  "INT_TIDE_DISSIPATION.",  units="nondim", default=1.0)
-    call get_param(param_file, mod, "TKE_ITIDE_MAX", CS%TKE_itide_max, &
+    call get_param(param_file, mdl, "TKE_ITIDE_MAX", CS%TKE_itide_max, &
                  "The maximum internal tide energy source availble to mix \n"//&
                  "above the bottom boundary layer with INT_TIDE_DISSIPATION.", &
                  units="W m-2",  default=1.0e3)
 
-    call get_param(param_file, mod, "READ_TIDEAMP", read_tideamp, &
+    call get_param(param_file, mdl, "READ_TIDEAMP", read_tideamp, &
                  "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
                  "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
     if (read_tideamp) then
-      call get_param(param_file, mod, "TIDEAMP_FILE", tideamp_file, &
+      call get_param(param_file, mdl, "TIDEAMP_FILE", tideamp_file, &
                  "The path to the file containing the spatially varying \n"//&
                  "tidal amplitudes with INT_TIDE_DISSIPATION.", default="tideamp.nc")
       filename = trim(CS%inputdir) // trim(tideamp_file)
-      call log_param(param_file, mod, "INPUTDIR/TIDEAMP_FILE", filename)
+      call log_param(param_file, mdl, "INPUTDIR/TIDEAMP_FILE", filename)
       call read_data(filename, 'tideamp', CS%tideamp, &
                      domain=G%domain%mpp_domain, timelevel=1)
     endif
 
-    call get_param(param_file, mod, "H2_FILE", h2_file, &
+    call get_param(param_file, mdl, "H2_FILE", h2_file, &
                  "The path to the file containing the sub-grid-scale \n"//&
                  "topographic roughness amplitude with INT_TIDE_DISSIPATION.", &
                  fail_if_missing=.true.)
     filename = trim(CS%inputdir) // trim(h2_file)
-    call log_param(param_file, mod, "INPUTDIR/H2_FILE", filename)
+    call log_param(param_file, mdl, "INPUTDIR/H2_FILE", filename)
     call read_data(filename, 'h2', CS%h2, domain=G%domain%mpp_domain, &
                    timelevel=1)
 
@@ -2984,28 +2984,28 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
 
   if (CS%Lee_wave_dissipation) then
 
-    call get_param(param_file, mod, "NIKURASHIN_TKE_INPUT_FILE",Niku_TKE_input_file, &
+    call get_param(param_file, mdl, "NIKURASHIN_TKE_INPUT_FILE",Niku_TKE_input_file, &
                  "The path to the file containing the TKE input from lee \n"//&
                  "wave driven mixing. Used with LEE_WAVE_DISSIPATION.", &
                  fail_if_missing=.true.)
-    call get_param(param_file, mod, "NIKURASHIN_SCALE",Niku_scale, &
+    call get_param(param_file, mdl, "NIKURASHIN_SCALE",Niku_scale, &
                  "A non-dimensional factor by which to scale the lee-wave \n"//&
                  "driven TKE input. Used with LEE_WAVE_DISSIPATION.", &
                  units="nondim", default=1.0)
 
     filename = trim(CS%inputdir) // trim(Niku_TKE_input_file)
-    call log_param(param_file, mod, "INPUTDIR/NIKURASHIN_TKE_INPUT_FILE", &
+    call log_param(param_file, mdl, "INPUTDIR/NIKURASHIN_TKE_INPUT_FILE", &
                    filename)
     call safe_alloc_ptr(CS%TKE_Niku,is,ie,js,je); CS%TKE_Niku(:,:) = 0.0
     call read_data(filename, 'TKE_input', CS%TKE_Niku, &
                    domain=G%domain%mpp_domain, timelevel=1 ) ! ??? timelevel -aja
     CS%TKE_Niku(:,:) = Niku_scale * CS%TKE_Niku(:,:)
 
-    call get_param(param_file, mod, "GAMMA_NIKURASHIN",CS%Gamma_lee, &
+    call get_param(param_file, mdl, "GAMMA_NIKURASHIN",CS%Gamma_lee, &
                  "The fraction of the lee wave energy that is dissipated \n"//&
                  "locally with LEE_WAVE_DISSIPATION.", units="nondim", &
                  default=0.3333)
-    call get_param(param_file, mod, "DECAY_SCALE_FACTOR_LEE",CS%Decay_scale_factor_lee, &
+    call get_param(param_file, mdl, "DECAY_SCALE_FACTOR_LEE",CS%Decay_scale_factor_lee, &
                  "Scaling for the vertical decay scaleof the local \n"//&
                  "dissipation of lee waves dissipation.", units="nondim", &
                  default=1.0)
@@ -3099,18 +3099,18 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
     endif
   endif
 
-  call get_param(param_file, mod, "DOUBLE_DIFFUSION", CS%double_diffusion, &
+  call get_param(param_file, mdl, "DOUBLE_DIFFUSION", CS%double_diffusion, &
                  "If true, increase diffusivitives for temperature or salt \n"//&
                  "based on double-diffusive paramaterization from MOM4/KPP.", &
                  default=.false.)
   if (CS%double_diffusion) then
-    call get_param(param_file, mod, "MAX_RRHO_SALT_FINGERS", CS%Max_Rrho_salt_fingers, &
+    call get_param(param_file, mdl, "MAX_RRHO_SALT_FINGERS", CS%Max_Rrho_salt_fingers, &
                  "Maximum density ratio for salt fingering regime.", &
                  default=2.55, units="nondim")
-    call get_param(param_file, mod, "MAX_SALT_DIFF_SALT_FINGERS", CS%Max_salt_diff_salt_fingers, &
+    call get_param(param_file, mdl, "MAX_SALT_DIFF_SALT_FINGERS", CS%Max_salt_diff_salt_fingers, &
                  "Maximum salt diffusivity for salt fingering regime.", &
                  default=1.e-4, units="m2 s-1")
-    call get_param(param_file, mod, "KV_MOLECULAR", CS%Kv_molecular, &
+    call get_param(param_file, mdl, "KV_MOLECULAR", CS%Kv_molecular, &
                  "Molecular viscosity for calculation of fluxes under \n"//&
                  "double-diffusive convection.", default=1.5e-6, units="m2 s-1")
     ! The default molecular viscosity follows the CCSM4.0 and MOM4p1 defaults.

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1723,21 +1723,21 @@ subroutine set_visc_register_restarts(HI, GV, param_file, visc, restart_CS)
   logical :: use_kappa_shear, adiabatic, useKPP, useEPBL
   logical :: use_CVMix, MLE_use_PBL_MLD
   integer :: isd, ied, jsd, jed, nz
-  character(len=40)  :: mod = "MOM_set_visc"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_set_visc"  ! This module's name.
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
-  call get_param(param_file, mod, "ADIABATIC", adiabatic, default=.false., &
+  call get_param(param_file, mdl, "ADIABATIC", adiabatic, default=.false., &
                  do_not_log=.true.)
   use_kappa_shear = .false. ; use_CVMix = .false. ;
   useKPP = .false. ; useEPBL = .false.
   if (.not.adiabatic) then
     use_kappa_shear = kappa_shear_is_used(param_file)
     use_CVMix = CVMix_shear_is_used(param_file)
-    call get_param(param_file, mod, "USE_KPP", useKPP, &
+    call get_param(param_file, mdl, "USE_KPP", useKPP, &
                  "If true, turns on the [CVmix] KPP scheme of Large et al., 1984,\n"// &
                  "to calculate diffusivities and non-local transport in the OBL.", &
                  default=.false., do_not_log=.true.)
-    call get_param(param_file, mod, "ENERGETICS_SFC_PBL", useEPBL, &
+    call get_param(param_file, mdl, "ENERGETICS_SFC_PBL", useEPBL, &
                  "If true, use an implied energetics planetary boundary \n"//&
                  "layer scheme to determine the diffusivity and viscosity \n"//&
                  "in the surface boundary layer.", default=.false., do_not_log=.true.)
@@ -1761,7 +1761,7 @@ subroutine set_visc_register_restarts(HI, GV, param_file, visc, restart_CS)
   endif
 
   ! visc%MLD is used to communicate the state of the (e)PBL to the rest of the model
-  call get_param(param_file, mod, "MLE_USE_PBL_MLD", MLE_use_PBL_MLD, &
+  call get_param(param_file, mdl, "MLE_USE_PBL_MLD", MLE_use_PBL_MLD, &
                  default=.false., do_not_log=.true.)
   if (MLE_use_PBL_MLD) then
     allocate(visc%MLD(isd:ied,jsd:jed)) ; visc%MLD(:,:) = 0.0
@@ -1799,7 +1799,7 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
   type(OBC_segment_type), pointer :: segment  ! pointer to OBC segment type
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_set_visc"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_set_visc"  ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "set_visc_init called with an associated "// &
@@ -1817,26 +1817,26 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
   CS%diag => diag
 
 ! Set default, read and log parameters
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
   CS%RiNo_mix = .false.
   use_kappa_shear = .false. ; differential_diffusion = .false. !; adiabatic = .false.  ! Needed? -AJA
-  call get_param(param_file, mod, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
+  call get_param(param_file, mdl, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
                  "If true, the bottom stress is calculated with a drag \n"//&
                  "law of the form c_drag*|u|*u. The velocity magnitude \n"//&
                  "may be an assumed value or it may be based on the \n"//&
                  "actual velocity in the bottommost HBBL, depending on \n"//&
                  "LINEAR_DRAG.", default=.true.)
-  call get_param(param_file, mod, "CHANNEL_DRAG", CS%Channel_drag, &
+  call get_param(param_file, mdl, "CHANNEL_DRAG", CS%Channel_drag, &
                  "If true, the bottom drag is exerted directly on each \n"//&
                  "layer proportional to the fraction of the bottom it \n"//&
                  "overlies.", default=.false.)
-  call get_param(param_file, mod, "LINEAR_DRAG", CS%linear_drag, &
+  call get_param(param_file, mdl, "LINEAR_DRAG", CS%linear_drag, &
                  "If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag \n"//&
                  "law is cdrag*DRAG_BG_VEL*u.", default=.false.)
-  call get_param(param_file, mod, "ADIABATIC", adiabatic, default=.false., &
+  call get_param(param_file, mdl, "ADIABATIC", adiabatic, default=.false., &
                  do_not_log=.true.)
   if (adiabatic) then
-    call log_param(param_file, mod, "ADIABATIC",adiabatic, &
+    call log_param(param_file, mdl, "ADIABATIC",adiabatic, &
                  "There are no diapycnal mass fluxes if ADIABATIC is \n"//&
                  "true. This assumes that KD = KDML = 0.0 and that \n"//&
                  "there is no buoyancy forcing, but makes the model \n"//&
@@ -1846,37 +1846,37 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
   if (.not.adiabatic) then
     use_kappa_shear = kappa_shear_is_used(param_file)
     CS%RiNo_mix = use_kappa_shear
-    call get_param(param_file, mod, "DOUBLE_DIFFUSION", differential_diffusion, &
+    call get_param(param_file, mdl, "DOUBLE_DIFFUSION", differential_diffusion, &
                  "If true, increase diffusivitives for temperature or salt \n"//&
                  "based on double-diffusive paramaterization from MOM4/KPP.", &
                  default=.false.)
   endif
-  call get_param(param_file, mod, "PRANDTL_TURB", visc%Prandtl_turb, &
+  call get_param(param_file, mdl, "PRANDTL_TURB", visc%Prandtl_turb, &
                  "The turbulent Prandtl number applied to shear \n"//&
                  "instability.", units="nondim", default=1.0)
-  call get_param(param_file, mod, "DEBUG", CS%debug, default=.false.)
+  call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
 
-  call get_param(param_file, mod, "DYNAMIC_VISCOUS_ML", CS%dynamic_viscous_ML, &
+  call get_param(param_file, mdl, "DYNAMIC_VISCOUS_ML", CS%dynamic_viscous_ML, &
                  "If true, use a bulk Richardson number criterion to \n"//&
                  "determine the mixed layer thickness for viscosity.", &
                  default=.false.)
   if (CS%dynamic_viscous_ML) then
-    call get_param(param_file, mod, "BULK_RI_ML", bulk_Ri_ML_dflt, default=0.0)
-    call get_param(param_file, mod, "BULK_RI_ML_VISC", CS%bulk_Ri_ML, &
+    call get_param(param_file, mdl, "BULK_RI_ML", bulk_Ri_ML_dflt, default=0.0)
+    call get_param(param_file, mdl, "BULK_RI_ML_VISC", CS%bulk_Ri_ML, &
                  "The efficiency with which mean kinetic energy released \n"//&
                  "by mechanically forced entrainment of the mixed layer \n"//&
                  "is converted to turbulent kinetic energy.  By default, \n"//&
                  "BULK_RI_ML_VISC = BULK_RI_ML or 0.", units="nondim", &
                  default=bulk_Ri_ML_dflt)
-    call get_param(param_file, mod, "TKE_DECAY", TKE_decay_dflt, default=0.0)
-    call get_param(param_file, mod, "TKE_DECAY_VISC", CS%TKE_decay, &
+    call get_param(param_file, mdl, "TKE_DECAY", TKE_decay_dflt, default=0.0)
+    call get_param(param_file, mdl, "TKE_DECAY_VISC", CS%TKE_decay, &
                  "TKE_DECAY_VISC relates the vertical rate of decay of \n"//&
                  "the TKE available for mechanical entrainment to the \n"//&
                  "natural Ekman depth for use in calculating the dynamic \n"//&
                  "mixed layer viscosity.  By default, \n"//&
                  "TKE_DECAY_VISC = TKE_DECAY or 0.", units="nondim", &
                  default=TKE_decay_dflt)
-    call get_param(param_file, mod, "ML_USE_OMEGA", use_omega, &
+    call get_param(param_file, mdl, "ML_USE_OMEGA", use_omega, &
                  "If true, use the absolute rotation rate instead of the \n"//&
                  "vertical component of rotation when setting the decay \n"//&
                    "scale for turbulence.", default=.false., do_not_log=.true.)
@@ -1885,78 +1885,78 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
       call MOM_error(WARNING, "ML_USE_OMEGA is depricated; use ML_OMEGA_FRAC=1.0 instead.")
       omega_frac_dflt = 1.0
     endif
-    call get_param(param_file, mod, "ML_OMEGA_FRAC", CS%omega_frac, &
+    call get_param(param_file, mdl, "ML_OMEGA_FRAC", CS%omega_frac, &
                    "When setting the decay scale for turbulence, use this \n"//&
                    "fraction of the absolute rotation rate blended with the \n"//&
                    "local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).", &
                    units="nondim", default=omega_frac_dflt)
-    call get_param(param_file, mod, "OMEGA", CS%omega, &
+    call get_param(param_file, mdl, "OMEGA", CS%omega, &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5)
     ! This give a minimum decay scale that is typically much less than Angstrom.
     CS%ustar_min = 2e-4*CS%omega*(GV%Angstrom_z + GV%H_to_m*GV%H_subroundoff)
   else
-    call get_param(param_file, mod, "OMEGA", CS%omega, &
+    call get_param(param_file, mdl, "OMEGA", CS%omega, &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5)
   endif
 
-  call get_param(param_file, mod, "HBBL", CS%Hbbl, &
+  call get_param(param_file, mdl, "HBBL", CS%Hbbl, &
                  "The thickness of a bottom boundary layer with a \n"//&
                  "viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or \n"//&
                  "the thickness over which near-bottom velocities are \n"//&
                  "averaged for the drag law if BOTTOMDRAGLAW is defined \n"//&
                  "but LINEAR_DRAG is not.", units="m", fail_if_missing=.true.)
   if (CS%bottomdraglaw) then
-    call get_param(param_file, mod, "CDRAG", CS%cdrag, &
+    call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
                  "CDRAG is the drag coefficient relating the magnitude of \n"//&
                  "the velocity field to the bottom stress. CDRAG is only \n"//&
                  "used if BOTTOMDRAGLAW is defined.", units="nondim", &
                  default=0.003)
-    call get_param(param_file, mod, "DRAG_BG_VEL", CS%drag_bg_vel, &
+    call get_param(param_file, mdl, "DRAG_BG_VEL", CS%drag_bg_vel, &
                  "DRAG_BG_VEL is either the assumed bottom velocity (with \n"//&
                  "LINEAR_DRAG) or an unresolved  velocity that is \n"//&
                  "combined with the resolved velocity to estimate the \n"//&
                  "velocity magnitude.  DRAG_BG_VEL is only used when \n"//&
                  "BOTTOMDRAGLAW is defined.", units="m s-1", default=0.0)
-    call get_param(param_file, mod, "BBL_USE_EOS", CS%BBL_use_EOS, &
+    call get_param(param_file, mdl, "BBL_USE_EOS", CS%BBL_use_EOS, &
                  "If true, use the equation of state in determining the \n"//&
                  "properties of the bottom boundary layer.  Otherwise use \n"//&
                  "the layer target potential densities.", default=.false.)
   endif
-  call get_param(param_file, mod, "BBL_THICK_MIN", CS%BBL_thick_min, &
+  call get_param(param_file, mdl, "BBL_THICK_MIN", CS%BBL_thick_min, &
                  "The minimum bottom boundary layer thickness that can be \n"//&
                  "used with BOTTOMDRAGLAW. This might be \n"//&
                  "Kv / (cdrag * drag_bg_vel) to give Kv as the minimum \n"//&
                  "near-bottom viscosity.", units="m", default=0.0)
-  call get_param(param_file, mod, "HTBL_SHELF_MIN", CS%Htbl_shelf_min, &
+  call get_param(param_file, mdl, "HTBL_SHELF_MIN", CS%Htbl_shelf_min, &
                  "The minimum top boundary layer thickness that can be \n"//&
                  "used with BOTTOMDRAGLAW. This might be \n"//&
                  "Kv / (cdrag * drag_bg_vel) to give Kv as the minimum \n"//&
                  "near-top viscosity.", units="m", default=CS%BBL_thick_min)
-  call get_param(param_file, mod, "HTBL_SHELF", CS%Htbl_shelf, &
+  call get_param(param_file, mdl, "HTBL_SHELF", CS%Htbl_shelf, &
                  "The thickness over which near-surface velocities are \n"//&
                  "averaged for the drag law under an ice shelf.  By \n"//&
                  "default this is the same as HBBL", units="m", default=CS%Hbbl)
 
-  call get_param(param_file, mod, "KV", Kv_background, &
+  call get_param(param_file, mdl, "KV", Kv_background, &
                  "The background kinematic viscosity in the interior. \n"//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
                  units="m2 s-1", fail_if_missing=.true.)
-  call get_param(param_file, mod, "KV_BBL_MIN", CS%KV_BBL_min, &
+  call get_param(param_file, mdl, "KV_BBL_MIN", CS%KV_BBL_min, &
                  "The minimum viscosities in the bottom boundary layer.", &
                  units="m2 s-1", default=Kv_background)
-  call get_param(param_file, mod, "KV_TBL_MIN", CS%KV_TBL_min, &
+  call get_param(param_file, mdl, "KV_TBL_MIN", CS%KV_TBL_min, &
                  "The minimum viscosities in the top boundary layer.", &
                  units="m2 s-1", default=Kv_background)
 
   if (CS%Channel_drag) then
-    call get_param(param_file, mod, "SMAG_LAP_CONST", smag_const1, default=-1.0)
+    call get_param(param_file, mdl, "SMAG_LAP_CONST", smag_const1, default=-1.0)
 
     cSmag_chan_dflt = 0.15
     if (smag_const1 >= 0.0) cSmag_chan_dflt = smag_const1
 
-    call get_param(param_file, mod, "SMAG_CONST_CHANNEL", CS%c_Smag, &
+    call get_param(param_file, mdl, "SMAG_CONST_CHANNEL", CS%c_Smag, &
                  "The nondimensional Laplacian Smagorinsky constant used \n"//&
                  "in calculating the channel drag if it is enabled.  The \n"//&
                  "default is to use the same value as SMAG_LAP_CONST if \n"//&

--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -162,7 +162,7 @@ subroutine initialize_sponge(Iresttime, int_height, G, param_file, CS, &
 !                 for this module
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_sponge"  ! This module's name.
+  character(len=40)  :: mdl = "MOM_sponge"  ! This module's name.
   logical :: use_sponge
   integer :: i, j, k, col, total_sponge_cols
 
@@ -173,8 +173,8 @@ subroutine initialize_sponge(Iresttime, int_height, G, param_file, CS, &
   endif
 
 ! Set default, read and log parameters
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "SPONGE", use_sponge, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "SPONGE", use_sponge, &
                  "If true, sponges may be applied anywhere in the domain. \n"//&
                  "The exact location and properties of those sponges are \n"//&
                  "specified from MOM_initialization.F90.", default=.false.)
@@ -238,7 +238,7 @@ subroutine initialize_sponge(Iresttime, int_height, G, param_file, CS, &
   total_sponge_cols = CS%num_col
   call sum_across_PEs(total_sponge_cols)
 
-  call log_param(param_file, mod, "!Total sponge columns", total_sponge_cols, &
+  call log_param(param_file, mdl, "!Total sponge columns", total_sponge_cols, &
                  "The total number of columns where sponges are applied.")
 
 end subroutine initialize_sponge

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1474,7 +1474,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_vert_friction" ! This module's name.
+  character(len=40)  :: mdl = "MOM_vert_friction" ! This module's name.
   character(len=40)  :: thickness_units = "meters or kg m-2"
 
   if (associated(CS)) then
@@ -1490,106 +1490,106 @@ subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
   CS%diag => diag ; CS%ntrunc => ntrunc ; ntrunc = 0
 
 ! Default, read and log parameters
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
                  "If true, the bottom stress is calculated with a drag \n"//&
                  "law of the form c_drag*|u|*u. The velocity magnitude \n"//&
                  "may be an assumed value or it may be based on the \n"//&
                  "actual velocity in the bottommost HBBL, depending on \n"//&
                  "LINEAR_DRAG.", default=.true.)
-  call get_param(param_file, mod, "CHANNEL_DRAG", CS%Channel_drag, &
+  call get_param(param_file, mdl, "CHANNEL_DRAG", CS%Channel_drag, &
                  "If true, the bottom drag is exerted directly on each \n"//&
                  "layer proportional to the fraction of the bottom it \n"//&
                  "overlies.", default=.false.)
-  call get_param(param_file, mod, "DIRECT_STRESS", CS%direct_stress, &
+  call get_param(param_file, mdl, "DIRECT_STRESS", CS%direct_stress, &
                  "If true, the wind stress is distributed over the \n"//&
                  "topmost HMIX_STRESS of fluid (like in HYCOM), and KVML \n"//&
                  "may be set to a very small value.", default=.false.)
-  call get_param(param_file, mod, "DYNAMIC_VISCOUS_ML", CS%dynamic_viscous_ML, &
+  call get_param(param_file, mdl, "DYNAMIC_VISCOUS_ML", CS%dynamic_viscous_ML, &
                  "If true, use a bulk Richardson number criterion to \n"//&
                  "determine the mixed layer thickness for viscosity.", &
                  default=.false.)
-  call get_param(param_file, mod, "U_TRUNC_FILE", CS%u_trunc_file, &
+  call get_param(param_file, mdl, "U_TRUNC_FILE", CS%u_trunc_file, &
                  "The absolute path to a file into which the accelerations \n"//&
                  "leading to zonal velocity truncations are written.  \n"//&
                  "Undefine this for efficiency if this diagnostic is not \n"//&
                  "needed.", default=" ")
-  call get_param(param_file, mod, "V_TRUNC_FILE", CS%v_trunc_file, &
+  call get_param(param_file, mdl, "V_TRUNC_FILE", CS%v_trunc_file, &
                  "The absolute path to a file into which the accelerations \n"//&
                  "leading to meridional velocity truncations are written. \n"//&
                  "Undefine this for efficiency if this diagnostic is not \n"//&
                  "needed.", default=" ")
-  call get_param(param_file, mod, "HARMONIC_VISC", CS%harmonic_visc, &
+  call get_param(param_file, mdl, "HARMONIC_VISC", CS%harmonic_visc, &
                  "If true, use the harmonic mean thicknesses for \n"//&
                  "calculating the vertical viscosity.", default=.false.)
-  call get_param(param_file, mod, "HARMONIC_BL_SCALE", CS%harm_BL_val, &
+  call get_param(param_file, mdl, "HARMONIC_BL_SCALE", CS%harm_BL_val, &
                  "A scale to determine when water is in the boundary \n"//&
                  "layers based solely on harmonic mean thicknesses for \n"//&
                  "the purpose of determining the extent to which the \n"//&
                  "thicknesses used in the viscosities are upwinded.", &
                  default=0.0, units="nondim")
-  call get_param(param_file, mod, "DEBUG", CS%debug, default=.false.)
+  call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
 
   if (GV%nkml < 1) &
-    call get_param(param_file, mod, "HMIX_FIXED", CS%Hmix, &
+    call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
                  "The prescribed depth over which the near-surface \n"//&
                  "viscosity and diffusivity are elevated when the bulk \n"//&
                  "mixed layer is not used.", units="m", fail_if_missing=.true.)
   if (CS%direct_stress) then
     if (GV%nkml < 1) then
-      call get_param(param_file, mod, "HMIX_STRESS", CS%Hmix_stress, &
+      call get_param(param_file, mdl, "HMIX_STRESS", CS%Hmix_stress, &
                  "The depth over which the wind stress is applied if \n"//&
                  "DIRECT_STRESS is true.", units="m", default=CS%Hmix)
     else
-      call get_param(param_file, mod, "HMIX_STRESS", CS%Hmix_stress, &
+      call get_param(param_file, mdl, "HMIX_STRESS", CS%Hmix_stress, &
                  "The depth over which the wind stress is applied if \n"//&
                  "DIRECT_STRESS is true.", units="m", fail_if_missing=.true.)
     endif
     if (CS%Hmix_stress <= 0.0) call MOM_error(FATAL, "vertvisc_init: " // &
        "HMIX_STRESS must be set to a positive value if DIRECT_STRESS is true.")
   endif
-  call get_param(param_file, mod, "KV", CS%Kv, &
+  call get_param(param_file, mdl, "KV", CS%Kv, &
                  "The background kinematic viscosity in the interior. \n"//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
                  units="m2 s-1", fail_if_missing=.true.)
 
 ! CS%Kvml = CS%Kv ; CS%Kvbbl = CS%Kv ! Needed? -AJA
-  if (GV%nkml < 1) call get_param(param_file, mod, "KVML", CS%Kvml, &
+  if (GV%nkml < 1) call get_param(param_file, mdl, "KVML", CS%Kvml, &
                  "The kinematic viscosity in the mixed layer.  A typical \n"//&
                  "value is ~1e-2 m2 s-1. KVML is not used if \n"//&
                  "BULKMIXEDLAYER is true.  The default is set by KV.", &
                  units="m2 s-1", default=CS%Kv)
-  if (.not.CS%bottomdraglaw) call get_param(param_file, mod, "KVBBL", CS%Kvbbl, &
+  if (.not.CS%bottomdraglaw) call get_param(param_file, mdl, "KVBBL", CS%Kvbbl, &
                  "The kinematic viscosity in the benthic boundary layer. \n"//&
                  "A typical value is ~1e-2 m2 s-1. KVBBL is not used if \n"//&
                  "BOTTOMDRAGLAW is true.  The default is set by KV.", &
                  units="m2 s-1", default=CS%Kv)
-  call get_param(param_file, mod, "HBBL", CS%Hbbl, &
+  call get_param(param_file, mdl, "HBBL", CS%Hbbl, &
                  "The thickness of a bottom boundary layer with a \n"//&
                  "viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or \n"//&
                  "the thickness over which near-bottom velocities are \n"//&
                  "averaged for the drag law if BOTTOMDRAGLAW is defined \n"//&
                  "but LINEAR_DRAG is not.", units="m", fail_if_missing=.true.)
-  call get_param(param_file, mod, "MAXVEL", CS%maxvel, &
+  call get_param(param_file, mdl, "MAXVEL", CS%maxvel, &
                  "The maximum velocity allowed before the velocity \n"//&
                  "components are truncated.", units="m s-1", default=3.0e8)
-  call get_param(param_file, mod, "CFL_BASED_TRUNCATIONS", CS%CFL_based_trunc, &
+  call get_param(param_file, mdl, "CFL_BASED_TRUNCATIONS", CS%CFL_based_trunc, &
                  "If true, base truncations on the CFL number, and not an \n"//&
                  "absolute speed.", default=.true.)
-  call get_param(param_file, mod, "CFL_TRUNCATE", CS%CFL_trunc, &
+  call get_param(param_file, mdl, "CFL_TRUNCATE", CS%CFL_trunc, &
                  "The value of the CFL number that will cause velocity \n"//&
                  "components to be truncated; instability can occur past 0.5.", &
                  units="nondim", default=0.5)
-  call get_param(param_file, mod, "CFL_REPORT", CS%CFL_report, &
+  call get_param(param_file, mdl, "CFL_REPORT", CS%CFL_report, &
                  "The value of the CFL number that causes accelerations \n"//&
                  "to be reported; the default is CFL_TRUNCATE.", &
                  units="nondim", default=CS%CFL_trunc)
-  call get_param(param_file, mod, "CFL_TRUNCATE_RAMP_TIME", CS%truncRampTime, &
+  call get_param(param_file, mdl, "CFL_TRUNCATE_RAMP_TIME", CS%truncRampTime, &
                  "The time over which the CFL trunction value is ramped\n"//&
                  "up at the beginning of the run.", &
                  units="s", default=0.)
   CS%CFL_truncE = CS%CFL_trunc
-  call get_param(param_file, mod, "CFL_TRUNCATE_START", CS%CFL_truncS, &
+  call get_param(param_file, mdl, "CFL_TRUNCATE_START", CS%CFL_truncS, &
                  "The start value of the truncation CFL number used when\n"//&
                  "ramping up CFL_TRUNC.", &
                  units="nondim", default=0.)

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -142,7 +142,7 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=80)  :: name, longname
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "DOME_tracer" ! This module's name.
+  character(len=40)  :: mdl = "DOME_tracer" ! This module's name.
   character(len=200) :: inputdir
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_DOME_tracer
@@ -157,19 +157,19 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "DOME_TRACER_IC_FILE", CS%tracer_IC_file, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "DOME_TRACER_IC_FILE", CS%tracer_IC_file, &
                  "The name of a file from which to read the initial \n"//&
                  "conditions for the DOME tracers, or blank to initialize \n"//&
                  "them internally.", default=" ")
   if (len_trim(CS%tracer_IC_file) >= 1) then
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     inputdir = slasher(inputdir)
     CS%tracer_IC_file = trim(inputdir)//trim(CS%tracer_IC_file)
-    call log_param(param_file, mod, "INPUTDIR/DOME_TRACER_IC_FILE", &
+    call log_param(param_file, mdl, "INPUTDIR/DOME_TRACER_IC_FILE", &
                    CS%tracer_IC_file)
   endif
-  call get_param(param_file, mod, "SPONGE", CS%use_sponge, &
+  call get_param(param_file, mdl, "SPONGE", CS%use_sponge, &
                  "If true, sponges may be applied anywhere in the domain. \n"//&
                  "The exact location and properties of those sponges are \n"//&
                  "specified from MOM_initialization.F90.", default=.false.)
@@ -183,7 +183,7 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     if (m < 10) then ; write(name,'("tr_D",I1.1)') m
     else ; write(name,'("tr_D",I2.2)') m ; endif
     write(longname,'("Concentration of DOME Tracer ",I2.2)') m
-    CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mod)
+    CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
 
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -101,7 +101,7 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, &
   character(len=80)  :: name, longname
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "ISOMIP_tracer" ! This module's name.
+  character(len=40)  :: mdl = "ISOMIP_tracer" ! This module's name.
   character(len=200) :: inputdir
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_ISOMIP_tracer
@@ -116,19 +116,19 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, &
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "ISOMIP_TRACER_IC_FILE", CS%tracer_IC_file, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "ISOMIP_TRACER_IC_FILE", CS%tracer_IC_file, &
                  "The name of a file from which to read the initial \n"//&
                  "conditions for the ISOMIP tracers, or blank to initialize \n"//&
                  "them internally.", default=" ")
   if (len_trim(CS%tracer_IC_file) >= 1) then
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     inputdir = slasher(inputdir)
     CS%tracer_IC_file = trim(inputdir)//trim(CS%tracer_IC_file)
-    call log_param(param_file, mod, "INPUTDIR/ISOMIP_TRACER_IC_FILE", &
+    call log_param(param_file, mdl, "INPUTDIR/ISOMIP_TRACER_IC_FILE", &
                    CS%tracer_IC_file)
   endif
-  call get_param(param_file, mod, "SPONGE", CS%use_sponge, &
+  call get_param(param_file, mdl, "SPONGE", CS%use_sponge, &
                  "If true, sponges may be applied anywhere in the domain. \n"//&
                  "The exact location and properties of those sponges are \n"//&
                  "specified from MOM_initialization.F90.", default=.false.)
@@ -142,7 +142,7 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, &
     if (m < 10) then ; write(name,'("tr_D",I1.1)') m
     else ; write(name,'("tr_D",I2.2)') m ; endif
     write(longname,'("Concentration of ISOMIP Tracer ",I2.2)') m
-    CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mod)
+    CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
 
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -178,7 +178,7 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_OCMIP2_CFC" ! This module's name.
+  character(len=40)  :: mdl = "MOM_OCMIP2_CFC" ! This module's name.
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
   ! These can be overridden later in via the field manager?
   character(len=128) :: default_ice_restart_file = 'ice_ocmip2_cfc.res.nc'
@@ -223,24 +223,24 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "CFC_IC_FILE", CS%IC_file, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "CFC_IC_FILE", CS%IC_file, &
                  "The file in which the CFC initial values can be \n"//&
                  "found, or an empty string for internal initialization.", &
                  default=" ")
   if ((len_trim(CS%IC_file) > 0) .and. (scan(CS%IC_file,'/') == 0)) then
     ! Add the directory if CS%IC_file is not already a complete path.
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     CS%IC_file = trim(slasher(inputdir))//trim(CS%IC_file)
-    call log_param(param_file, mod, "INPUTDIR/CFC_IC_FILE", CS%IC_file)
+    call log_param(param_file, mdl, "INPUTDIR/CFC_IC_FILE", CS%IC_file)
   endif
-  call get_param(param_file, mod, "CFC_IC_FILE_IS_Z", CS%Z_IC_file, &
+  call get_param(param_file, mdl, "CFC_IC_FILE_IS_Z", CS%Z_IC_file, &
                  "If true, CFC_IC_FILE is in depth space, not layer space", &
                  default=.false.)
-  call get_param(param_file, mod, "MASK_MASSLESS_TRACERS", CS%mask_tracers, &
+  call get_param(param_file, mdl, "MASK_MASSLESS_TRACERS", CS%mask_tracers, &
                  "If true, the tracers are masked out in massless layer. \n"//&
                  "This can be a problem with time-averages.", default=.false.)
-  call get_param(param_file, mod, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
+  call get_param(param_file, mdl, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
                  "If true, tracers may go through the initialization code \n"//&
                  "if they are not found in the restart files.  Otherwise \n"//&
                  "it is a fatal error if tracers are not found in the \n"//&
@@ -249,8 +249,8 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   !   The following vardesc types contain a package of metadata about each tracer,
   ! including, the name; units; longname; and grid information.
   CS%CFC11_name = "CFC11" ; CS%CFC12_name = "CFC12"
-  CS%CFC11_desc = var_desc(CS%CFC11_name,"mol m-3","CFC-11 Concentration", caller=mod)
-  CS%CFC12_desc = var_desc(CS%CFC12_name,"mol m-3","CFC-12 Concentration", caller=mod)
+  CS%CFC11_desc = var_desc(CS%CFC11_name,"mol m-3","CFC-11 Concentration", caller=mdl)
+  CS%CFC12_desc = var_desc(CS%CFC12_name,"mol m-3","CFC-12 Concentration", caller=mdl)
 
   allocate(CS%CFC11(isd:ied,jsd:jed,nz)) ; CS%CFC11(:,:,:) = 0.0
   allocate(CS%CFC12(isd:ied,jsd:jed,nz)) ; CS%CFC12(:,:,:) = 0.0
@@ -283,29 +283,29 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
 !-----------------------------------------------------------------------
   a11_dflt(:) = (/ 3501.8, -210.31,  6.1851, -0.07513 /)
   a12_dflt(:) = (/ 3845.4, -228.95,  6.1908, -0.06743 /)
-  call get_param(param_file, mod, "CFC11_A1", CS%a1_11, &
+  call get_param(param_file, mdl, "CFC11_A1", CS%a1_11, &
                  "A coefficient in the Schmidt number of CFC11.", &
                  units="nondim", default=a11_dflt(1))
-  call get_param(param_file, mod, "CFC11_A2", CS%a2_11, &
+  call get_param(param_file, mdl, "CFC11_A2", CS%a2_11, &
                  "A coefficient in the Schmidt number of CFC11.", &
                  units="degC-1", default=a11_dflt(2))
-  call get_param(param_file, mod, "CFC11_A3", CS%a3_11, &
+  call get_param(param_file, mdl, "CFC11_A3", CS%a3_11, &
                  "A coefficient in the Schmidt number of CFC11.", &
                  units="degC-2", default=a11_dflt(3))
-  call get_param(param_file, mod, "CFC11_A4", CS%a4_11, &
+  call get_param(param_file, mdl, "CFC11_A4", CS%a4_11, &
                  "A coefficient in the Schmidt number of CFC11.", &
                  units="degC-3", default=a11_dflt(4))
 
-  call get_param(param_file, mod, "CFC12_A1", CS%a1_12, &
+  call get_param(param_file, mdl, "CFC12_A1", CS%a1_12, &
                  "A coefficient in the Schmidt number of CFC12.", &
                  units="nondim", default=a12_dflt(1))
-  call get_param(param_file, mod, "CFC12_A2", CS%a2_12, &
+  call get_param(param_file, mdl, "CFC12_A2", CS%a2_12, &
                  "A coefficient in the Schmidt number of CFC12.", &
                  units="degC-1", default=a12_dflt(2))
-  call get_param(param_file, mod, "CFC12_A3", CS%a3_12, &
+  call get_param(param_file, mdl, "CFC12_A3", CS%a3_12, &
                  "A coefficient in the Schmidt number of CFC12.", &
                  units="degC-2", default=a12_dflt(3))
-  call get_param(param_file, mod, "CFC12_A4", CS%a4_12, &
+  call get_param(param_file, mdl, "CFC12_A4", CS%a4_12, &
                  "A coefficient in the Schmidt number of CFC12.", &
                  units="degC-3", default=a12_dflt(4))
 
@@ -318,47 +318,47 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   d12_dflt(:) = (/ -218.0971, 298.9702, 113.8049, -1.39165 /)
   e12_dflt(:) = (/ -0.143566, 0.091015, -0.0153924 /)
 
-  call get_param(param_file, mod, "CFC11_D1", CS%d1_11, &
+  call get_param(param_file, mdl, "CFC11_D1", CS%d1_11, &
                  "A coefficient in the solubility of CFC11.", &
                  units="none", default=d11_dflt(1))
-  call get_param(param_file, mod, "CFC11_D2", CS%d2_11, &
+  call get_param(param_file, mdl, "CFC11_D2", CS%d2_11, &
                  "A coefficient in the solubility of CFC11.", &
                  units="hK", default=d11_dflt(2))
-  call get_param(param_file, mod, "CFC11_D3", CS%d3_11, &
+  call get_param(param_file, mdl, "CFC11_D3", CS%d3_11, &
                  "A coefficient in the solubility of CFC11.", &
                  units="none", default=d11_dflt(3))
-  call get_param(param_file, mod, "CFC11_D4", CS%d4_11, &
+  call get_param(param_file, mdl, "CFC11_D4", CS%d4_11, &
                  "A coefficient in the solubility of CFC11.", &
                  units="hK-2", default=d11_dflt(4))
-  call get_param(param_file, mod, "CFC11_E1", CS%e1_11, &
+  call get_param(param_file, mdl, "CFC11_E1", CS%e1_11, &
                  "A coefficient in the solubility of CFC11.", &
                  units="PSU-1", default=e11_dflt(1))
-  call get_param(param_file, mod, "CFC11_E2", CS%e2_11, &
+  call get_param(param_file, mdl, "CFC11_E2", CS%e2_11, &
                  "A coefficient in the solubility of CFC11.", &
                  units="PSU-1 hK-1", default=e11_dflt(2))
-  call get_param(param_file, mod, "CFC11_E3", CS%e3_11, &
+  call get_param(param_file, mdl, "CFC11_E3", CS%e3_11, &
                  "A coefficient in the solubility of CFC11.", &
                  units="PSU-1 hK-2", default=e11_dflt(3))
 
-  call get_param(param_file, mod, "CFC12_D1", CS%d1_12, &
+  call get_param(param_file, mdl, "CFC12_D1", CS%d1_12, &
                  "A coefficient in the solubility of CFC12.", &
                  units="none", default=d12_dflt(1))
-  call get_param(param_file, mod, "CFC12_D2", CS%d2_12, &
+  call get_param(param_file, mdl, "CFC12_D2", CS%d2_12, &
                  "A coefficient in the solubility of CFC12.", &
                  units="hK", default=d12_dflt(2))
-  call get_param(param_file, mod, "CFC12_D3", CS%d3_12, &
+  call get_param(param_file, mdl, "CFC12_D3", CS%d3_12, &
                  "A coefficient in the solubility of CFC12.", &
                  units="none", default=d12_dflt(3))
-  call get_param(param_file, mod, "CFC12_D4", CS%d4_12, &
+  call get_param(param_file, mdl, "CFC12_D4", CS%d4_12, &
                  "A coefficient in the solubility of CFC12.", &
                  units="hK-2", default=d12_dflt(4))
-  call get_param(param_file, mod, "CFC12_E1", CS%e1_12, &
+  call get_param(param_file, mdl, "CFC12_E1", CS%e1_12, &
                  "A coefficient in the solubility of CFC12.", &
                  units="PSU-1", default=e12_dflt(1))
-  call get_param(param_file, mod, "CFC12_E2", CS%e2_12, &
+  call get_param(param_file, mdl, "CFC12_E2", CS%e2_12, &
                  "A coefficient in the solubility of CFC12.", &
                  units="PSU-1 hK-1", default=e12_dflt(2))
-  call get_param(param_file, mod, "CFC12_E3", CS%e3_12, &
+  call get_param(param_file, mdl, "CFC12_E3", CS%e3_12, &
                  "A coefficient in the solubility of CFC12.", &
                  units="PSU-1 hK-2", default=e12_dflt(3))
 

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -54,7 +54,7 @@ end type neutral_diffusion_CS
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-character(len=40)  :: mod = "MOM_neutral_diffusion" ! module name
+character(len=40)  :: mdl = "MOM_neutral_diffusion" ! module name
 
 logical, parameter :: debug_this_module = .false.
 
@@ -77,9 +77,9 @@ logical function neutral_diffusion_init(Time, G, param_file, diag, CS)
   endif
 
   ! Log this module and master switch for turning it on/off
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
        "This module implements neutral diffusion of tracers")
-  call get_param(param_file, mod, "USE_NEUTRAL_DIFFUSION", neutral_diffusion_init, &
+  call get_param(param_file, mdl, "USE_NEUTRAL_DIFFUSION", neutral_diffusion_init, &
                  "If true, enables the neutral diffusion module.", &
                  default=.false.)
 
@@ -93,7 +93,7 @@ logical function neutral_diffusion_init(Time, G, param_file, diag, CS)
 
   ! Read all relevant parameters and write them to the model log.
 ! call openParameterBlock(param_file,'NEUTRAL_DIFF')
-! call get_param(param_file, mod, "KHTR", CS%KhTr, &
+! call get_param(param_file, mdl, "KHTR", CS%KhTr, &
 !                "The background along-isopycnal tracer diffusivity.", &
 !                units="m2 s-1", default=0.0)
 ! call closeParameterBlock(param_file)

--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -1222,7 +1222,7 @@ subroutine offline_transport_init(param_file, CS, diabatic_CSp, G, GV)
   type(ocean_grid_type),      pointer, intent(in)     :: G
   type(verticalGrid_type),    pointer, intent(in)     :: GV
 
-  character(len=40)  :: mod = "offline_transport"
+  character(len=40)  :: mdl = "offline_transport"
   character(len=20)  :: redistribute_method
 
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
@@ -1240,35 +1240,35 @@ subroutine offline_transport_init(param_file, CS, diabatic_CSp, G, GV)
     return
   endif
   allocate(CS)
-  call log_version(param_file,mod,version, "This module allows for tracers to be run offline")
+  call log_version(param_file, mdl,version, "This module allows for tracers to be run offline")
 
   ! Parse MOM_input for offline control
-  call get_param(param_file, mod, "OFFLINEDIR", CS%offlinedir, &
+  call get_param(param_file, mdl, "OFFLINEDIR", CS%offlinedir, &
     "Input directory where the offline fields can be found",  fail_if_missing = .true.)
-  call get_param(param_file, mod, "OFF_SUM_FILE", CS%sum_file, &
+  call get_param(param_file, mdl, "OFF_SUM_FILE", CS%sum_file, &
     "Filename where the accumulated fields can be found",     fail_if_missing = .true.)
-  call get_param(param_file, mod, "OFF_SNAP_FILE", CS%snap_file, &
+  call get_param(param_file, mdl, "OFF_SNAP_FILE", CS%snap_file, &
     "Filename where snapshot fields can be found",            fail_if_missing = .true.)
-  call get_param(param_file, mod, "OFF_MEAN_FILE", CS%mean_file, &
+  call get_param(param_file, mdl, "OFF_MEAN_FILE", CS%mean_file, &
     "Filename where averaged fields can be found",            fail_if_missing = .true.)
-  call get_param(param_file, mod, "OFF_SURF_FILE", CS%surf_file, &
+  call get_param(param_file, mdl, "OFF_SURF_FILE", CS%surf_file, &
     "Filename where averaged fields can be found",            fail_if_missing = .true.)
-  call get_param(param_file, mod, "NUMTIME", CS%numtime, &
+  call get_param(param_file, mdl, "NUMTIME", CS%numtime, &
     "Number of timelevels in offline input files",            fail_if_missing = .true.)
-  call get_param(param_file, mod, "NK_INPUT", CS%nk_input, &
+  call get_param(param_file, mdl, "NK_INPUT", CS%nk_input, &
     "Number of vertical levels in offline input files", default = nz)
-  call get_param(param_file, mod, "DT_OFFLINE", CS%dt_offline, &
+  call get_param(param_file, mdl, "DT_OFFLINE", CS%dt_offline, &
     "Length of time between reading in of input fields",      fail_if_missing = .true.)
-  call get_param(param_file, mod, "DT_OFFLINE_VERTICAL", CS%dt_offline_vertical, &
+  call get_param(param_file, mdl, "DT_OFFLINE_VERTICAL", CS%dt_offline_vertical, &
     "Length of the offline timestep for tracer column sources/sinks\n" //&
     "This should be set to the length of the coupling timestep for \n" //&
     "tracers which need shortwave fluxes",                    fail_if_missing = .true.)
-  call get_param(param_file, mod, "START_INDEX", CS%start_index, &
+  call get_param(param_file, mdl, "START_INDEX", CS%start_index, &
     "Which time index to start from", default=1)
-  call get_param(param_file, mod, "FIELDS_ARE_OFFSET", CS%fields_are_offset, &
+  call get_param(param_file, mdl, "FIELDS_ARE_OFFSET", CS%fields_are_offset, &
     "True if the time-averaged fields and snapshot fields\n"//&
     "are offset by one time level", default=.false.)
-  call get_param(param_file, mod, "REDISTRIBUTE_METHOD", redistribute_method, &
+  call get_param(param_file, mdl, "REDISTRIBUTE_METHOD", redistribute_method, &
     "Redistributes any remaining horizontal fluxes throughout\n"    //&
     "the rest of water column. Options are 'barotropic' which\n"    //&
     "evenly distributes flux throughout the entire water column,\n" //&
@@ -1276,39 +1276,39 @@ subroutine offline_transport_init(param_file, CS, diabatic_CSp, G, GV)
     "each layer above, both which first applies upwards and then\n" //&
     "barotropic, and 'none' which does no redistribution", &
     default='barotropic')
-  call get_param(param_file, mod, "NUM_OFF_ITER", CS%num_off_iter, &
+  call get_param(param_file, mdl, "NUM_OFF_ITER", CS%num_off_iter, &
     "Number of iterations to subdivide the offline tracer advection and diffusion", &
     default = 60)
-  call get_param(param_file, mod, "OFF_ALE_MOD", CS%off_ale_mod, &
+  call get_param(param_file, mdl, "OFF_ALE_MOD", CS%off_ale_mod, &
     "Sets how many horizontal advection steps are taken before an ALE\n" //&
     "remapping step is done. 1 would be x->y->ALE, 2 would be"           //&
     "x->y->x->y->ALE", default = 1)
-  call get_param(param_file, mod, "PRINT_ADV_OFFLINE", CS%print_adv_offline, &
+  call get_param(param_file, mdl, "PRINT_ADV_OFFLINE", CS%print_adv_offline, &
     "Print diagnostic output every advection subiteration",default=.false.)
-  call get_param(param_file, mod, "SKIP_DIFFUSION_OFFLINE", CS%skip_diffusion, &
+  call get_param(param_file, mdl, "SKIP_DIFFUSION_OFFLINE", CS%skip_diffusion, &
     "Do not do horizontal diffusion",default=.false.)
-  call get_param(param_file, mod, "READ_SW", CS%read_sw, &
+  call get_param(param_file, mdl, "READ_SW", CS%read_sw, &
     "Read in shortwave radiation field instead of using values from the coupler"//&
     "when in offline tracer mode",default=.false.)
-  call get_param(param_file, mod, "READ_MLD", CS%read_mld, &
+  call get_param(param_file, mdl, "READ_MLD", CS%read_mld, &
     "Read in mixed layer depths for tracers which exchange with the atmosphere"//&
     "when in offline tracer mode",default=.false.)
-  call get_param(param_file, mod, "MLD_VAR_NAME", CS%mld_var_name, &
+  call get_param(param_file, mdl, "MLD_VAR_NAME", CS%mld_var_name, &
     "Name of the variable containing the depth of active mixing",&
     default='ePBL_h_ML')
-  call get_param(param_file, mod, "OFFLINE_ADD_DIURNAL_SW", CS%diurnal_sw, &
+  call get_param(param_file, mdl, "OFFLINE_ADD_DIURNAL_SW", CS%diurnal_sw, &
     "Adds a synthetic diurnal cycle in the same way that the ice\n" // &
     "model would have when time-averaged fields of shortwave\n"    // &
     "radiation are read in", default=.false.)
-  call get_param(param_file, mod, "KD_MAX", CS%Kd_max, &
+  call get_param(param_file, mdl, "KD_MAX", CS%Kd_max, &
     "The maximum permitted increment for the diapycnal \n"//&
     "diffusivity from TKE-based parameterizations, or a \n"//&
     "negative value for no limit.", units="m2 s-1", default=-1.0)
-  call get_param(param_file, mod, "MIN_RESIDUAL_TRANSPORT", CS%min_residual, &
+  call get_param(param_file, mdl, "MIN_RESIDUAL_TRANSPORT", CS%min_residual, &
     "How much remaining transport before the main offline advection\n"// &
     "is exited. The default value corresponds to about 1 meter of\n"  // &
     "difference in a grid cell", default = 1.e9)
-  call get_param(param_file, mod, "READ_ALL_TS_UVH", CS%read_all_ts_uvh,  &
+  call get_param(param_file, mdl, "READ_ALL_TS_UVH", CS%read_all_ts_uvh,  &
     "Reads all time levels of a subset of the fields necessary to run \n"    //      &
     "the model offline. This can require a large amount of memory\n"//      &
     "and will make initialization very slow. However, for offline\n"//      &

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -79,7 +79,7 @@ function tracer_Z_init(tr, h, filename, tr_name, G, missing_val, land_val)
   integer, save :: init_calls = 0
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_tracer_Z_init" ! This module's name.
+  character(len=40)  :: mdl = "MOM_tracer_Z_init" ! This module's name.
   character(len=256) :: mesg    ! Message for error messages.
 
   real, allocatable, dimension(:,:,:) :: &
@@ -327,33 +327,33 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
 !                          missing value, and if so return true.
 !  (inout)   missing - The missing value, if one has been found.
 
-  character(len=32) :: mod
+  character(len=32) :: mdl
   character(len=120) :: dim_name, edge_name, tr_msg, dim_msg
   logical :: monotonic
   integer :: ncid, status, intid, tr_id, layid, k
   integer :: nz_edge, ndim, tr_dim_ids(NF90_MAX_VAR_DIMS)
 
-  mod = "MOM_tracer_Z_init read_Z_edges: "
+  mdl = "MOM_tracer_Z_init read_Z_edges: "
   tr_msg = trim(tr_name)//" in "//trim(filename)
 
   status = NF90_OPEN(filename, NF90_NOWRITE, ncid);
   if (status /= NF90_NOERR) then
-    call MOM_error(WARNING,mod//" Difficulties opening "//trim(filename)//&
+    call MOM_error(WARNING,mdl//" Difficulties opening "//trim(filename)//&
         " - "//trim(NF90_STRERROR(status)))
     nz_out = -1 ; return
   endif
 
   status = NF90_INQ_VARID(ncid, tr_name, tr_id)
   if (status /= NF90_NOERR) then
-    call MOM_error(WARNING,mod//" Difficulties finding variable "//&
+    call MOM_error(WARNING,mdl//" Difficulties finding variable "//&
         trim(tr_msg)//" - "//trim(NF90_STRERROR(status)))
     nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
   endif
   status = NF90_INQUIRE_VARIABLE(ncid, tr_id, ndims=ndim, dimids=tr_dim_ids)
   if (status /= NF90_NOERR) then
-    call MOM_ERROR(WARNING,mod//" cannot inquire about "//trim(tr_msg))
+    call MOM_ERROR(WARNING,mdl//" cannot inquire about "//trim(tr_msg))
   elseif ((ndim < 3) .or. (ndim > 4)) then
-    call MOM_ERROR(WARNING,mod//" "//trim(tr_msg)//&
+    call MOM_ERROR(WARNING,mdl//" "//trim(tr_msg)//&
          " has too many or too few dimensions.")
     nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
   endif
@@ -367,28 +367,28 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
   ! Get the axis name and length.
   status = NF90_INQUIRE_DIMENSION(ncid, tr_dim_ids(3), dim_name, len=nz_out)
   if (status /= NF90_NOERR) then
-    call MOM_ERROR(WARNING,mod//" cannot inquire about dimension(3) of "//&
+    call MOM_ERROR(WARNING,mdl//" cannot inquire about dimension(3) of "//&
                     trim(tr_msg))
   endif
 
   dim_msg = trim(dim_name)//" in "//trim(filename)
   status = NF90_INQ_VARID(ncid, dim_name, layid)
   if (status /= NF90_NOERR) then
-    call MOM_error(WARNING,mod//" Difficulties finding variable "//&
+    call MOM_error(WARNING,mdl//" Difficulties finding variable "//&
         trim(dim_msg)//" - "//trim(NF90_STRERROR(status)))
     nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
   endif
   ! Find out if the Z-axis has an edges attribute
   status = NF90_GET_ATT(ncid, layid, "edges", edge_name)
   if (status /= NF90_NOERR) then
-    call MOM_mesg(mod//" "//trim(dim_msg)//&
+    call MOM_mesg(mdl//" "//trim(dim_msg)//&
          " has no readable edges attribute - "//trim(NF90_STRERROR(status)))
     has_edges = .false.
   else
     has_edges = .true.
     status = NF90_INQ_VARID(ncid, edge_name, intid)
     if (status /= NF90_NOERR) then
-      call MOM_error(WARNING,mod//" Difficulties finding edge variable "//&
+      call MOM_error(WARNING,mdl//" Difficulties finding edge variable "//&
           trim(edge_name)//" in "//trim(filename)//" - "//trim(NF90_STRERROR(status)))
       has_edges = .false.
     endif
@@ -404,21 +404,21 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
     dim_msg = trim(edge_name)//" in "//trim(filename)
     status = NF90_GET_VAR(ncid, intid, z_edges)
     if (status /= NF90_NOERR) then
-      call MOM_error(WARNING,mod//" Difficulties reading variable "//&
+      call MOM_error(WARNING,mdl//" Difficulties reading variable "//&
           trim(dim_msg)//" - "//trim(NF90_STRERROR(status)))
       nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
     endif
   else
     status = NF90_GET_VAR(ncid, layid, z_edges)
     if (status /= NF90_NOERR) then
-      call MOM_error(WARNING,mod//" Difficulties reading variable "//&
+      call MOM_error(WARNING,mdl//" Difficulties reading variable "//&
           trim(dim_msg)//" - "//trim(NF90_STRERROR(status)))
       nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
     endif
   endif
 
   status = NF90_CLOSE(ncid)
-  if (status /= NF90_NOERR) call MOM_error(WARNING, mod// &
+  if (status /= NF90_NOERR) call MOM_error(WARNING, mdl// &
     " Difficulties closing "//trim(filename)//" - "//trim(NF90_STRERROR(status)))
 
   ! z_edges should be montonically decreasing with our sign convention.
@@ -430,7 +430,7 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
   monotonic = .true.
   do k=2,nz_edge ; if (z_edges(k) >= z_edges(k-1)) monotonic = .false. ; enddo
   if (.not.monotonic) &
-    call MOM_error(WARNING,mod//" "//trim(dim_msg)//" is not monotonic.")
+    call MOM_error(WARNING,mdl//" "//trim(dim_msg)//" is not monotonic.")
 
 end subroutine read_Z_edges
 

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -865,7 +865,7 @@ subroutine tracer_advect_init(Time, G, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_tracer_advect" ! This module's name.
+  character(len=40)  :: mdl = "MOM_tracer_advect" ! This module's name.
   character(len=256) :: mesg    ! Message for error messages.
 
   if (associated(CS)) then
@@ -877,11 +877,11 @@ subroutine tracer_advect_init(Time, G, param_file, diag, CS)
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "DT", CS%dt, fail_if_missing=.true., &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "DT", CS%dt, fail_if_missing=.true., &
           desc="The (baroclinic) dynamics time step.", units="s")
-  call get_param(param_file, mod, "DEBUG", CS%debug, default=.false.)
-  call get_param(param_file, mod, "TRACER_ADVECTION_SCHEME", mesg, &
+  call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
+  call get_param(param_file, mdl, "TRACER_ADVECTION_SCHEME", mesg, &
           desc="The horizontal transport scheme for tracers:\n"//&
           "  PLM    - Piecewise Linear Method\n"//&
           "  PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)\n"// &

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -146,7 +146,7 @@ subroutine call_tracer_register(HI, GV, param_file, CS, tr_Reg, restart_CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_tracer_flow_control" ! This module's name.
+  character(len=40)  :: mdl = "MOM_tracer_flow_control" ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "call_tracer_register called with an associated "// &
@@ -155,41 +155,41 @@ subroutine call_tracer_register(HI, GV, param_file, CS, tr_Reg, restart_CS)
   else ; allocate(CS) ; endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "USE_USER_TRACER_EXAMPLE", &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "USE_USER_TRACER_EXAMPLE", &
                                 CS%use_USER_tracer_example, &
                  "If true, use the USER_tracer_example tracer package.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_DOME_TRACER", CS%use_DOME_tracer, &
+  call get_param(param_file, mdl, "USE_DOME_TRACER", CS%use_DOME_tracer, &
                  "If true, use the DOME_tracer tracer package.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_ISOMIP_TRACER", CS%use_ISOMIP_tracer, &
+  call get_param(param_file, mdl, "USE_ISOMIP_TRACER", CS%use_ISOMIP_tracer, &
                  "If true, use the ISOMIP_tracer tracer package.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_IDEAL_AGE_TRACER", CS%use_ideal_age, &
+  call get_param(param_file, mdl, "USE_IDEAL_AGE_TRACER", CS%use_ideal_age, &
                  "If true, use the ideal_age_example tracer package.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_REGIONAL_DYES", CS%use_regional_dyes, &
+  call get_param(param_file, mdl, "USE_REGIONAL_DYES", CS%use_regional_dyes, &
                  "If true, use the regional_dyes tracer package.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_OIL_TRACER", CS%use_oil, &
+  call get_param(param_file, mdl, "USE_OIL_TRACER", CS%use_oil, &
                  "If true, use the oil_tracer tracer package.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_ADVECTION_TEST_TRACER", CS%use_advection_test_tracer, &
+  call get_param(param_file, mdl, "USE_ADVECTION_TEST_TRACER", CS%use_advection_test_tracer, &
                  "If true, use the advection_test_tracer tracer package.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_OCMIP2_CFC", CS%use_OCMIP2_CFC, &
+  call get_param(param_file, mdl, "USE_OCMIP2_CFC", CS%use_OCMIP2_CFC, &
                  "If true, use the MOM_OCMIP2_CFC tracer package.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_generic_tracer", &
+  call get_param(param_file, mdl, "USE_generic_tracer", &
                                 CS%use_MOM_generic_tracer, &
                  "If true and _USE_GENERIC_TRACER is defined as a \n"//&
                  "preprocessor macro, use the MOM_generic_tracer packages.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_PSEUDO_SALT_TRACER", CS%use_pseudo_salt_tracer, &
+  call get_param(param_file, mdl, "USE_PSEUDO_SALT_TRACER", CS%use_pseudo_salt_tracer, &
                  "If true, use the pseudo salt tracer, typically run as a diagnostic.", &
                  default=.false.)
-  call get_param(param_file, mod, "USE_BOUNDARY_IMPULSE_TRACER", CS%use_boundary_impulse_tracer, &
+  call get_param(param_file, mdl, "USE_BOUNDARY_IMPULSE_TRACER", CS%use_boundary_impulse_tracer, &
                  "If true, use the boundary impulse tracer.", &
                  default=.false.)
 

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -1344,7 +1344,7 @@ subroutine tracer_hor_diff_init(Time, G, param_file, diag, CS, CSnd)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_tracer_hor_diff" ! This module's name.
+  character(len=40)  :: mdl = "MOM_tracer_hor_diff" ! This module's name.
   character(len=256) :: mesg    ! Message for error messages.
 
   if (associated(CS)) then
@@ -1357,45 +1357,45 @@ subroutine tracer_hor_diff_init(Time, G, param_file, diag, CS, CSnd)
   CS%show_call_tree = callTree_showQuery()
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "KHTR", CS%KhTr, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "KHTR", CS%KhTr, &
                  "The background along-isopycnal tracer diffusivity.", &
                  units="m2 s-1", default=0.0)
-  call get_param(param_file, mod, "KHTR_SLOPE_CFF", CS%KhTr_Slope_Cff, &
+  call get_param(param_file, mdl, "KHTR_SLOPE_CFF", CS%KhTr_Slope_Cff, &
                  "The scaling coefficient for along-isopycnal tracer \n"//&
                  "diffusivity using a shear-based (Visbeck-like) \n"//&
                  "parameterization.  A non-zero value enables this param.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mod, "KHTR_MIN", CS%KhTr_Min, &
+  call get_param(param_file, mdl, "KHTR_MIN", CS%KhTr_Min, &
                  "The minimum along-isopycnal tracer diffusivity.", &
                  units="m2 s-1", default=0.0)
-  call get_param(param_file, mod, "KHTR_MAX", CS%KhTr_Max, &
+  call get_param(param_file, mdl, "KHTR_MAX", CS%KhTr_Max, &
                  "The maximum along-isopycnal tracer diffusivity.", &
                  units="m2 s-1", default=0.0)
-  call get_param(param_file, mod, "KHTR_PASSIVITY_COEFF", CS%KhTr_passivity_coeff, &
+  call get_param(param_file, mdl, "KHTR_PASSIVITY_COEFF", CS%KhTr_passivity_coeff, &
                "The coefficient that scales deformation radius over \n"//&
                "grid-spacing in passivity, where passiviity is the ratio \n"//&
                "between along isopycnal mxiing of tracers to thickness mixing. \n"//&
                "A non-zero value enables this parameterization.", &
                units="nondim", default=0.0)
-  call get_param(param_file, mod, "KHTR_PASSIVITY_MIN", CS%KhTr_passivity_min, &
+  call get_param(param_file, mdl, "KHTR_PASSIVITY_MIN", CS%KhTr_passivity_min, &
                "The minimum passivity which is the ratio between \n"//&
                "along isopycnal mxiing of tracers to thickness mixing. \n", &
                units="nondim", default=0.5)
-  call get_param(param_file, mod, "DT", CS%dt, fail_if_missing=.true., &
+  call get_param(param_file, mdl, "DT", CS%dt, fail_if_missing=.true., &
           desc="The (baroclinic) dynamics time step.", units="s")
 
 
-  call get_param(param_file, mod, "DIFFUSE_ML_TO_INTERIOR", CS%Diffuse_ML_interior, &
+  call get_param(param_file, mdl, "DIFFUSE_ML_TO_INTERIOR", CS%Diffuse_ML_interior, &
                  "If true, enable epipycnal mixing between the surface \n"//&
                  "boundary layer and the interior.", default=.false.)
-  call get_param(param_file, mod, "CHECK_DIFFUSIVE_CFL", CS%check_diffusive_CFL, &
+  call get_param(param_file, mdl, "CHECK_DIFFUSIVE_CFL", CS%check_diffusive_CFL, &
                  "If true, use enough iterations the diffusion to ensure \n"//&
                  "that the diffusive equivalent of the CFL limit is not \n"//&
                  "violated.  If false, always use 1 iteration.", default=.false.)
   CS%ML_KhTR_scale = 1.0
   if (CS%Diffuse_ML_interior) then
-    call get_param(param_file, mod, "ML_KHTR_SCALE", CS%ML_KhTR_scale, &
+    call get_param(param_file, mdl, "ML_KHTR_SCALE", CS%ML_KhTR_scale, &
                  "With Diffuse_ML_interior, the ratio of the truly \n"//&
                  "horizontal diffusivity in the mixed layer to the \n"//&
                  "epipycnal diffusivity.  The valid range is 0 to 1.", &
@@ -1407,7 +1407,7 @@ subroutine tracer_hor_diff_init(Time, G, param_file, diag, CS, CSnd)
   if (CS%use_neutral_diffusion .and. CS%Diffuse_ML_interior) call MOM_error(FATAL, "MOM_tracer_hor_diff: "// &
        "USE_NEUTRAL_DIFFUSION and DIFFUSE_ML_TO_INTERIOR are mutually exclusive!")
 
-  call get_param(param_file, mod, "DEBUG", CS%debug, default=.false.)
+  call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
 
   id_clock_diffuse = cpu_clock_id('(Ocean diffuse tracer)',          grain=CLOCK_MODULE)
   id_clock_epimix  = cpu_clock_id('(Ocean epipycnal diffuse tracer)',grain=CLOCK_MODULE)

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -297,14 +297,14 @@ subroutine tracer_registry_init(param_file, Reg)
   integer, save :: init_calls = 0
 
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_tracer_registry" ! This module's name.
+  character(len=40)  :: mdl = "MOM_tracer_registry" ! This module's name.
   character(len=256) :: mesg    ! Message for error messages.
 
   if (.not.associated(Reg)) then ; allocate(Reg)
   else ; return ; endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
   init_calls = init_calls + 1
   if (init_calls > 1) then

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -152,7 +152,7 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
   character(len=80)  :: name, longname
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "advection_test_tracer" ! This module's name.
+  character(len=40)  :: mdl = "advection_test_tracer" ! This module's name.
   character(len=200) :: inputdir
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_advection_test_tracer
@@ -167,36 +167,36 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mod, "ADVECTION_TEST_X_ORIGIN", CS%x_origin, &
+  call get_param(param_file, mdl, "ADVECTION_TEST_X_ORIGIN", CS%x_origin, &
         "The x-coorindate of the center of the test-functions.\n", default=0.)
-  call get_param(param_file, mod, "ADVECTION_TEST_Y_ORIGIN", CS%y_origin, &
+  call get_param(param_file, mdl, "ADVECTION_TEST_Y_ORIGIN", CS%y_origin, &
         "The y-coorindate of the center of the test-functions.\n", default=0.)
-  call get_param(param_file, mod, "ADVECTION_TEST_X_WIDTH", CS%x_width, &
+  call get_param(param_file, mdl, "ADVECTION_TEST_X_WIDTH", CS%x_width, &
         "The x-width of the test-functions.\n", default=0.)
-  call get_param(param_file, mod, "ADVECTION_TEST_Y_WIDTH", CS%y_width, &
+  call get_param(param_file, mdl, "ADVECTION_TEST_Y_WIDTH", CS%y_width, &
         "The y-width of the test-functions.\n", default=0.)
-  call get_param(param_file, mod, "ADVECTION_TEST_TRACER_IC_FILE", CS%tracer_IC_file, &
+  call get_param(param_file, mdl, "ADVECTION_TEST_TRACER_IC_FILE", CS%tracer_IC_file, &
                  "The name of a file from which to read the initial \n"//&
                  "conditions for the tracers, or blank to initialize \n"//&
                  "them internally.", default=" ")
 
   if (len_trim(CS%tracer_IC_file) >= 1) then
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     CS%tracer_IC_file = trim(slasher(inputdir))//trim(CS%tracer_IC_file)
-    call log_param(param_file, mod, "INPUTDIR/ADVECTION_TEST_TRACER_IC_FILE", &
+    call log_param(param_file, mdl, "INPUTDIR/ADVECTION_TEST_TRACER_IC_FILE", &
                    CS%tracer_IC_file)
   endif
-  call get_param(param_file, mod, "SPONGE", CS%use_sponge, &
+  call get_param(param_file, mdl, "SPONGE", CS%use_sponge, &
                  "If true, sponges may be applied anywhere in the domain. \n"//&
                  "The exact location and properties of those sponges are \n"//&
                  "specified from MOM_initialization.F90.", default=.false.)
 
-  call get_param(param_file, mod, "MASK_TRACERS_IN_MASSLESS_LAYERS", CS%mask_tracers, &
+  call get_param(param_file, mdl, "MASK_TRACERS_IN_MASSLESS_LAYERS", CS%mask_tracers, &
                  "If true, tracers will be masked out in massless layers. \n", &
                  default=.false.)
-  call get_param(param_file, mod, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
+  call get_param(param_file, mdl, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
                  "If true, tracers may go through the initialization code \n"//&
                  "if they are not found in the restart files.  Otherwise \n"//&
                  "it is a fatal error if the tracers are not found in the \n"//&
@@ -212,7 +212,7 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
     if (m < 10) then ; write(name,'("tr",I1.1)') m
     else ; write(name,'("tr",I2.2)') m ; endif
     write(longname,'("Concentration of Tracer ",I2.2)') m
-    CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mod)
+    CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
 
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -101,7 +101,7 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "boundary_impulse_tracer" ! This module's name.
+  character(len=40)  :: mdl = "boundary_impulse_tracer" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=3)   :: name_tag ! String for creating identifying boundary_impulse
@@ -119,13 +119,13 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "IMPULSE_SOURCE_TIME", CS%remaining_source_time, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "IMPULSE_SOURCE_TIME", CS%remaining_source_time, &
                  "Length of time for the boundary tracer to be injected\n"//&
                  "into the mixed layer. After this time has elapsed, the\n"//&
                  "surface becomes a sink for the boundary impulse tracer.", &
                  default=31536000.0)
-  call get_param(param_file, mod, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
+  call get_param(param_file, mdl, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
                  "If true, tracers may go through the initialization code \n"//&
                  "if they are not found in the restart files.  Otherwise \n"//&
                  "it is a fatal error if the tracers are not found in the \n"//&
@@ -139,7 +139,7 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.
     CS%tr_desc(m) = var_desc(trim("boundary_impulse"), "kg", &
-        "Boundary impulse tracer", caller=mod)
+        "Boundary impulse tracer", caller=mdl)
     tr_ptr => CS%tr(:,:,:,m)
     call query_vardesc(CS%tr_desc(m), name=var_name, caller="register_boundary_impulse_tracer")
     ! Register the tracer for the restart file.
@@ -160,7 +160,7 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
   rem_time_ptr => CS%remaining_source_time
   call register_restart_field(rem_time_ptr,                                                                 &
                               var_desc(trim("bir_remain_time"), "s", "Remaining time to apply BIR source",  &
-                                             hor_grid = "1", z_grid = "1", caller=mod),                     &
+                                             hor_grid = "1", z_grid = "1", caller=mdl),                     &
                               .not. CS%tracers_may_reinit, restart_CS)
 
   CS%tr_Reg => tr_Reg

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -146,7 +146,7 @@ function register_dye_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "regional_dyes" ! This module's name.
+  character(len=40)  :: mdl = "regional_dyes" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=48)  :: desc_name ! The variable's descriptor.
@@ -163,8 +163,8 @@ function register_dye_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "NUM_DYE_TRACERS", CS%ntr, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "NUM_DYE_TRACERS", CS%ntr, &
                  "The number of dye tracers in this run. Each tracer \n"//&
                  "should have a separate region.", default=0)
   allocate(CS%dye_source_minlon(CS%ntr), &
@@ -192,42 +192,42 @@ function register_dye_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   CS%id_tr_dfy(:) = -1
 
   CS%dye_source_minlon(:) = -1.e30
-  call get_param(param_file, mod, "DYE_SOURCE_MINLON", CS%dye_source_minlon, &
+  call get_param(param_file, mdl, "DYE_SOURCE_MINLON", CS%dye_source_minlon, &
                  "This is the starting longitude at which we start injecting dyes.", &
                  fail_if_missing=.true.)
   if (minval(CS%dye_source_minlon(:)) < -1.e29) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MINLON ")
 
   CS%dye_source_maxlon(:) = -1.e30
-  call get_param(param_file, mod, "DYE_SOURCE_MAXLON", CS%dye_source_maxlon, &
+  call get_param(param_file, mdl, "DYE_SOURCE_MAXLON", CS%dye_source_maxlon, &
                  "This is the ending longitude at which we finish injecting dyes.", &
                  fail_if_missing=.true.)
   if (minval(CS%dye_source_maxlon(:)) < -1.e29) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MAXLON ")
 
   CS%dye_source_minlat(:) = -1.e30
-  call get_param(param_file, mod, "DYE_SOURCE_MINLAT", CS%dye_source_minlat, &
+  call get_param(param_file, mdl, "DYE_SOURCE_MINLAT", CS%dye_source_minlat, &
                  "This is the starting latitude at which we start injecting dyes.", &
                  fail_if_missing=.true.)
   if (minval(CS%dye_source_minlat(:)) < -1.e29) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MINLAT ")
 
   CS%dye_source_maxlat(:) = -1.e30
-  call get_param(param_file, mod, "DYE_SOURCE_MAXLAT", CS%dye_source_maxlat, &
+  call get_param(param_file, mdl, "DYE_SOURCE_MAXLAT", CS%dye_source_maxlat, &
                  "This is the ending latitude at which we finish injecting dyes.", &
                  fail_if_missing=.true.)
   if (minval(CS%dye_source_maxlat(:)) < -1.e29) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MAXLAT ")
 
   CS%dye_source_mindepth(:) = -1.e30
-  call get_param(param_file, mod, "DYE_SOURCE_MINDEPTH", CS%dye_source_mindepth, &
+  call get_param(param_file, mdl, "DYE_SOURCE_MINDEPTH", CS%dye_source_mindepth, &
                  "This is the minumum depth at which we inject dyes.", &
                  fail_if_missing=.true.)
   if (minval(CS%dye_source_mindepth(:)) < -1.e29) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MINDEPTH")
 
   CS%dye_source_maxdepth(:) = -1.e30
-  call get_param(param_file, mod, "DYE_SOURCE_MAXDEPTH", CS%dye_source_maxdepth, &
+  call get_param(param_file, mdl, "DYE_SOURCE_MAXDEPTH", CS%dye_source_maxdepth, &
                  "This is the maximum depth at which we inject dyes.", &
                  fail_if_missing=.true.)
   if (minval(CS%dye_source_maxdepth(:)) < -1.e29) &
@@ -236,7 +236,7 @@ function register_dye_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   do m = 1, CS%ntr
     write(var_name(:),'(A,I3.3)') "dye",m
     write(desc_name(:),'(A,I3.3)') "Dye Tracer ",m
-    CS%tr_desc(m) = var_desc(trim(var_name), "conc", trim(desc_name), caller=mod)
+    CS%tr_desc(m) = var_desc(trim(var_name), "conc", trim(desc_name), caller=mdl)
   enddo
 
 

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -164,7 +164,7 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "oil_tracer" ! This module's name.
+  character(len=40)  :: mdl = "oil_tracer" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=3)   :: name_tag ! String for creating identifying oils
@@ -181,51 +181,51 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "OIL_IC_FILE", CS%IC_file, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "OIL_IC_FILE", CS%IC_file, &
                  "The file in which the oil tracer initial values can be \n"//&
                  "found, or an empty string for internal initialization.", &
                  default=" ")
   if ((len_trim(CS%IC_file) > 0) .and. (scan(CS%IC_file,'/') == 0)) then
     ! Add the directory if CS%IC_file is not already a complete path.
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     CS%IC_file = trim(slasher(inputdir))//trim(CS%IC_file)
-    call log_param(param_file, mod, "INPUTDIR/CFC_IC_FILE", CS%IC_file)
+    call log_param(param_file, mdl, "INPUTDIR/CFC_IC_FILE", CS%IC_file)
   endif
-  call get_param(param_file, mod, "OIL_IC_FILE_IS_Z", CS%Z_IC_file, &
+  call get_param(param_file, mdl, "OIL_IC_FILE_IS_Z", CS%Z_IC_file, &
                  "If true, OIL_IC_FILE is in depth space, not layer space", &
                  default=.false.)
 
-  call get_param(param_file, mod, "MASK_MASSLESS_TRACERS", CS%mask_tracers, &
+  call get_param(param_file, mdl, "MASK_MASSLESS_TRACERS", CS%mask_tracers, &
                  "If true, the tracers are masked out in massless layer. \n"//&
                  "This can be a problem with time-averages.", default=.false.)
-  call get_param(param_file, mod, "OIL_MAY_REINIT", CS%oil_may_reinit, &
+  call get_param(param_file, mdl, "OIL_MAY_REINIT", CS%oil_may_reinit, &
                  "If true, oil tracers may go through the initialization \n"//&
                  "code if they are not found in the restart files. \n"//&
                  "Otherwise it is a fatal error if the oil tracers are not \n"//&
                  "found in the restart files of a restarted run.", &
                  default=.false.)
-  call get_param(param_file, mod, "OIL_SOURCE_LONGITUDE", CS%oil_source_longitude, &
+  call get_param(param_file, mdl, "OIL_SOURCE_LONGITUDE", CS%oil_source_longitude, &
                  "The geographic longitude of the oil source.", units="degrees E", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "OIL_SOURCE_LATITUDE", CS%oil_source_latitude, &
+  call get_param(param_file, mdl, "OIL_SOURCE_LATITUDE", CS%oil_source_latitude, &
                  "The geographic latitude of the oil source.", units="degrees N", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "OIL_SOURCE_LAYER", CS%oil_source_k, &
+  call get_param(param_file, mdl, "OIL_SOURCE_LAYER", CS%oil_source_k, &
                  "The layer into which the oil is introduced, or a \n"//&
                  "negative number for a vertically uniform source, \n"//&
                  "or 0 not to use this tracer.", units="Layer", default=0)
-  call get_param(param_file, mod, "OIL_SOURCE_RATE", CS%oil_source_rate, &
+  call get_param(param_file, mdl, "OIL_SOURCE_RATE", CS%oil_source_rate, &
                  "The rate of oil injection.", units="kg s-1", default=1.0)
-  call get_param(param_file, mod, "OIL_DECAY_DAYS", CS%oil_decay_days, &
+  call get_param(param_file, mdl, "OIL_DECAY_DAYS", CS%oil_decay_days, &
                  "The decay timescale in days (if positive), or no decay \n"//&
                  "if 0, or use the temperature dependent decay rate of \n"//&
                  "Adcroft et al. (GRL, 2010) if negative.", units="days", &
                  default=0.0)
-  call get_param(param_file, mod, "OIL_DATED_START_YEAR", CS%oil_start_year, &
+  call get_param(param_file, mdl, "OIL_DATED_START_YEAR", CS%oil_start_year, &
                  "The time at which the oil source starts", units="years", &
                  default=0.0)
-  call get_param(param_file, mod, "OIL_DATED_END_YEAR", CS%oil_end_year, &
+  call get_param(param_file, mdl, "OIL_DATED_END_YEAR", CS%oil_end_year, &
                  "The time at which the oil source ends", units="years", &
                  default=1.0e99)
 
@@ -235,7 +235,7 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     if (CS%oil_source_k(m)/=0) then
       write(name_tag(1:3),'("_",I2.2)') m
       CS%ntr = CS%ntr + 1
-      CS%tr_desc(m) = var_desc("oil"//trim(name_tag), "kg/m3", "Oil Tracer", caller=mod)
+      CS%tr_desc(m) = var_desc("oil"//trim(name_tag), "kg/m3", "Oil Tracer", caller=mdl)
       CS%IC_val(m) = 0.0
       if (CS%oil_decay_days(m)>0.) then
         CS%oil_decay_rate(m)=1./(86400.0*CS%oil_decay_days(m))
@@ -244,7 +244,7 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
       endif
     endif
   enddo
-  call log_param(param_file, mod, "OIL_DECAY_RATE", CS%oil_decay_rate(1:CS%ntr))
+  call log_param(param_file, mdl, "OIL_DECAY_RATE", CS%oil_decay_rate(1:CS%ntr))
 
   allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr)) ; CS%tr(:,:,:,:) = 0.0
 

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -147,7 +147,7 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "pseudo_salt_tracer" ! This module's name.
+  character(len=40)  :: mdl = "pseudo_salt_tracer" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=3)   :: name_tag ! String for creating identifying pseudo_salt
@@ -164,7 +164,7 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
   CS%ntr = NTR_MAX
   allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr)) ; CS%tr(:,:,:,:) = 0.0
@@ -174,7 +174,7 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.
     CS%tr_desc(m) = var_desc(trim("pseudo_salt_diff"), "kg", &
-        "Difference between pseudo salt passive tracer and salt tracer", caller=mod)
+        "Difference between pseudo salt passive tracer and salt tracer", caller=mdl)
     tr_ptr => CS%tr(:,:,:,m)
     call query_vardesc(CS%tr_desc(m), name=var_name, caller="register_pseudo_salt_tracer")
     ! Register the tracer for the restart file.

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -140,7 +140,7 @@ function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS
   character(len=80)  :: name, longname
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "tracer_example" ! This module's name.
+  character(len=40)  :: mdl = "tracer_example" ! This module's name.
   character(len=200) :: inputdir
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: USER_register_tracer_example
@@ -155,18 +155,18 @@ function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "TRACER_EXAMPLE_IC_FILE", CS%tracer_IC_file, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "TRACER_EXAMPLE_IC_FILE", CS%tracer_IC_file, &
                  "The name of a file from which to read the initial \n"//&
                  "conditions for the DOME tracers, or blank to initialize \n"//&
                  "them internally.", default=" ")
   if (len_trim(CS%tracer_IC_file) >= 1) then
-    call get_param(param_file, mod, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     CS%tracer_IC_file = trim(slasher(inputdir))//trim(CS%tracer_IC_file)
-    call log_param(param_file, mod, "INPUTDIR/TRACER_EXAMPLE_IC_FILE", &
+    call log_param(param_file, mdl, "INPUTDIR/TRACER_EXAMPLE_IC_FILE", &
                    CS%tracer_IC_file)
   endif
-  call get_param(param_file, mod, "SPONGE", CS%use_sponge, &
+  call get_param(param_file, mdl, "SPONGE", CS%use_sponge, &
                  "If true, sponges may be applied anywhere in the domain. \n"//&
                  "The exact location and properties of those sponges are \n"//&
                  "specified from MOM_initialization.F90.", default=.false.)
@@ -180,7 +180,7 @@ function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS
     if (m < 10) then ; write(name,'("tr",I1.1)') m
     else ; write(name,'("tr",I2.2)') m ; endif
     write(longname,'("Concentration of Tracer ",I2.2)') m
-    CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mod)
+    CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
 
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.

--- a/src/user/BFB_initialization.F90
+++ b/src/user/BFB_initialization.F90
@@ -72,14 +72,14 @@ subroutine BFB_set_coord(Rlay, g_prime, GV, param_file, eqn_of_state)
   type(EOS_type),          pointer     :: eqn_of_state
   real                                 :: drho_dt, SST_s, T_bot, rho_top, rho_bot
   integer                              :: k, nz
-  character(len=40)  :: mod = "BFB_set_coord" ! This subroutine's name.
+  character(len=40)  :: mdl = "BFB_set_coord" ! This subroutine's name.
 
-  call get_param(param_file, mod, "DRHO_DT", drho_dt, &
+  call get_param(param_file, mdl, "DRHO_DT", drho_dt, &
           "Rate of change of density with temperature.", &
            units="kg m-3 K-1", default=-0.2)
-  call get_param(param_file, mod, "SST_S", SST_s, &
+  call get_param(param_file, mdl, "SST_S", SST_s, &
           "SST at the suothern edge of the domain.", units="C", default=20.0)
-  call get_param(param_file, mod, "T_BOT", T_bot, &
+  call get_param(param_file, mdl, "T_BOT", T_bot, &
                  "Bottom Temp", units="C", default=5.0)
   rho_top = GV%rho0 + drho_dt*SST_s
   rho_bot = GV%rho0 + drho_dt*T_bot
@@ -122,7 +122,7 @@ subroutine BFB_initialize_sponges_southonly(G, use_temperature, tv, param_file, 
   real :: H0(SZK_(G))
   real :: min_depth
   real :: damp, e_dense, damp_new, slat, wlon, lenlat, lenlon, nlat
-  character(len=40)  :: mod = "BFB_initialize_sponges_southonly" ! This subroutine's name.
+  character(len=40)  :: mdl = "BFB_initialize_sponges_southonly" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -136,16 +136,16 @@ subroutine BFB_initialize_sponges_southonly(G, use_temperature, tv, param_file, 
 !  and mask2dT is 1.                                                   !
 
 !   Set up sponges for DOME configuration
-  call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
+  call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
 
-  call get_param(param_file, mod, "SOUTHLAT", slat, &
+  call get_param(param_file, mdl, "SOUTHLAT", slat, &
                  "The southern latitude of the domain.", units="degrees")
-  call get_param(param_file, mod, "LENLAT", lenlat, &
+  call get_param(param_file, mdl, "LENLAT", lenlat, &
                  "The latitudinal length of the domain.", units="degrees")
-  call get_param(param_file, mod, "WESTLON", wlon, &
+  call get_param(param_file, mdl, "WESTLON", wlon, &
                  "The western longitude of the domain.", units="degrees", default=0.0)
-  call get_param(param_file, mod, "LENLON", lenlon, &
+  call get_param(param_file, mdl, "LENLON", lenlon, &
                  "The longitudinal length of the domain.", units="degrees")
   nlat = slat + lenlat
   do k=1,nz ; H0(k) = -G%max_depth * real(k-1) / real(nz) ; enddo
@@ -201,9 +201,9 @@ subroutine write_BFB_log(param_file)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "BFB_initialization" ! This module's name.
+  character(len=40)  :: mdl = "BFB_initialization" ! This module's name.
 
-  call log_version(param_file, mod, version)
+  call log_version(param_file, mdl, version)
   first_call = .false.
 
 end subroutine write_BFB_log

--- a/src/user/BFB_surface_forcing.F90
+++ b/src/user/BFB_surface_forcing.F90
@@ -264,7 +264,7 @@ subroutine BFB_surface_forcing_init(Time, G, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "BFB_surface_forcing" ! This module's name.
+  character(len=40)  :: mdl = "BFB_surface_forcing" ! This module's name.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "BFB_surface_forcing_init called with an associated "// &
@@ -275,45 +275,45 @@ subroutine BFB_surface_forcing_init(Time, G, param_file, diag, CS)
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
                  "If true, Temperature and salinity are used as state \n"//&
                  "variables.", default=.true.)
 
-  call get_param(param_file, mod, "G_EARTH", CS%G_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
-  call get_param(param_file, mod, "LFR_SLAT", CS%lfrslat, &
+  call get_param(param_file, mdl, "LFR_SLAT", CS%lfrslat, &
                  "Southern latitude where the linear forcing ramp begins.", &
                  units="degrees", default = 20.0)
-  call get_param(param_file, mod, "LFR_NLAT", CS%lfrnlat, &
+  call get_param(param_file, mdl, "LFR_NLAT", CS%lfrnlat, &
                  "Northern latitude where the linear forcing ramp ends.", &
                  units="degrees", default = 40.0)
-  call get_param(param_file, mod, "SST_S", CS%SST_s, &
+  call get_param(param_file, mdl, "SST_S", CS%SST_s, &
                  "SST at the southern edge of the linear forcing ramp.", &
                  units="C", default = 20.0)
-  call get_param(param_file, mod, "SST_N", CS%SST_n, &
+  call get_param(param_file, mdl, "SST_N", CS%SST_n, &
                  "SST at the northern edge of the linear forcing ramp.", &
                  units="C", default = 10.0)
-  call get_param(param_file, mod, "DRHO_DT", CS%drho_dt, &
+  call get_param(param_file, mdl, "DRHO_DT", CS%drho_dt, &
                  "The rate of change of density with temperature.", &
                  units="kg m-3 K-1", default = -0.2)
-  call get_param(param_file, mod, "GUST_CONST", CS%gust_const, &
+  call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", units="Pa", &
                  default=0.02)
 
-  call get_param(param_file, mod, "RESTOREBUOY", CS%restorebuoy, &
+  call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back \n"//&
                  "toward some specified surface state with a rate \n"//&
                  "given by FLUXCONST.", default= .false.)
   if (CS%restorebuoy) then
-    call get_param(param_file, mod, "FLUXCONST", CS%Flux_const, &
+    call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -27,7 +27,7 @@ public DOME2d_initialize_thickness
 public DOME2d_initialize_temperature_salinity
 public DOME2d_initialize_sponges
 
-character(len=40) :: mod = "DOME2D_initialization" !< This module's name.
+character(len=40) :: mdl = "DOME2D_initialization" !< This module's name.
 
 contains
 
@@ -46,14 +46,14 @@ subroutine DOME2d_initialize_topography ( D, G, param_file, max_depth )
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &
                  'Width of shelf, as fraction of domain, in 2d DOME configuration.', &
                  units='nondim',default=0.1)
-  call get_param(param_file, mod, "DOME2D_BASIN_WIDTH", dome2d_width_bottom, &
+  call get_param(param_file, mdl, "DOME2D_BASIN_WIDTH", dome2d_width_bottom, &
                  'Width of deep ocean basin, as fraction of domain, in 2d DOME configuration.', &
                  units='nondim',default=0.3)
-  call get_param(param_file, mod, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
+  call get_param(param_file, mdl, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
                  'Depth of shelf, as fraction of basin depth, in 2d DOME configuration.', &
                  units='nondim',default=0.2)
 
@@ -115,15 +115,15 @@ subroutine DOME2d_initialize_thickness ( h, G, GV, param_file, just_read_params 
   if (.not.just_read) &
     call MOM_mesg("MOM_initialization.F90, DOME2d_initialize_thickness: setting thickness")
 
-  call get_param(param_file,mod,"MIN_THICKNESS",min_thickness, &
+  call get_param(param_file, mdl,"MIN_THICKNESS",min_thickness, &
                  default=1.e-3, do_not_log=.true.)
-  call get_param(param_file,mod,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
+  call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=.true.)
-  call get_param(param_file, mod, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &
+  call get_param(param_file, mdl, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &
                  default=0.1, do_not_log=.true.)
-  call get_param(param_file, mod, "DOME2D_BASIN_WIDTH", dome2d_width_bottom, &
+  call get_param(param_file, mdl, "DOME2D_BASIN_WIDTH", dome2d_width_bottom, &
                  default=0.3, do_not_log=.true.)
-  call get_param(param_file, mod, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
+  call get_param(param_file, mdl, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
                  default=0.2, do_not_log=.true.)
 
   if (just_read) return ! All run-time parameters have been read, so return.
@@ -243,21 +243,21 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, param_file, &
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(param_file,mod,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
+  call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=.true.)
-  call get_param(param_file, mod, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &
+  call get_param(param_file, mdl, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &
                  default=0.1, do_not_log=.true.)
-  call get_param(param_file, mod, "DOME2D_BASIN_WIDTH", dome2d_width_bottom, &
+  call get_param(param_file, mdl, "DOME2D_BASIN_WIDTH", dome2d_width_bottom, &
                  default=0.3, do_not_log=.true.)
-  call get_param(param_file, mod, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
+  call get_param(param_file, mdl, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
                  default=0.2, do_not_log=.true.)
-  call get_param(param_file,mod,"S_REF",S_ref,'Reference salinity',units='1e-3', &
+  call get_param(param_file, mdl,"S_REF",S_ref,'Reference salinity',units='1e-3', &
                 fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"T_REF",T_ref,'Refernce temperature',units='C', &
+  call get_param(param_file, mdl,"T_REF",T_ref,'Refernce temperature',units='C', &
                 fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"S_RANGE",S_range,'Initial salinity range', &
+  call get_param(param_file, mdl,"S_RANGE",S_range,'Initial salinity range', &
                 units='1e-3', default=2.0, do_not_log=just_read)
-  call get_param(param_file,mod,"T_RANGE",T_range,'Initial temperature range', &
+  call get_param(param_file, mdl,"T_RANGE",T_range,'Initial temperature range', &
                 units='1e-3', default=0.0, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
@@ -376,19 +376,19 @@ subroutine DOME2d_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
-  call get_param(param_file, mod, "DOME2D_WEST_SPONGE_TIME_SCALE", dome2d_west_sponge_time_scale, &
+  call get_param(param_file, mdl, "DOME2D_WEST_SPONGE_TIME_SCALE", dome2d_west_sponge_time_scale, &
                  'The time-scale on the west edge of the domain for restoring T/S\n' //&
                  'in the sponge. If zero, the western sponge is disabled', &
                  units='s', default=0.)
-  call get_param(param_file, mod, "DOME2D_EAST_SPONGE_TIME_SCALE", dome2d_east_sponge_time_scale, &
+  call get_param(param_file, mdl, "DOME2D_EAST_SPONGE_TIME_SCALE", dome2d_east_sponge_time_scale, &
                  'The time-scale on the east edge of the domain for restoring T/S\n' //&
                  'in the sponge. If zero, the eastern sponge is disabled', &
                  units='s', default=0.)
-  call get_param(param_file, mod, "DOME2D_WEST_SPONGE_WIDTH", dome2d_west_sponge_width, &
+  call get_param(param_file, mdl, "DOME2D_WEST_SPONGE_WIDTH", dome2d_west_sponge_width, &
                  'The fraction of the domain in which the western sponge for restoring T/S\n' //&
                  'is active.', &
                  units='nondim', default=0.1)
-  call get_param(param_file, mod, "DOME2D_EAST_SPONGE_WIDTH", dome2d_east_sponge_width, &
+  call get_param(param_file, mdl, "DOME2D_EAST_SPONGE_WIDTH", dome2d_east_sponge_width, &
                  'The fraction of the domain in which the eastern sponge for restoring T/S\n' //&
                  'is active.', &
                  units='nondim', default=0.1)
@@ -401,16 +401,16 @@ subroutine DOME2d_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
   if (associated(ACSp)) call MOM_error(FATAL, &
      "DOME2d_initialize_sponges called with an associated ALE-sponge control structure.")
 
-  call get_param(param_file, mod, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &
+  call get_param(param_file, mdl, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &
                  default=0.1, do_not_log=.true.)
-  call get_param(param_file, mod, "DOME2D_BASIN_WIDTH", dome2d_width_bottom, &
+  call get_param(param_file, mdl, "DOME2D_BASIN_WIDTH", dome2d_width_bottom, &
                  default=0.3, do_not_log=.true.)
-  call get_param(param_file, mod, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
+  call get_param(param_file, mdl, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
                  default=0.2, do_not_log=.true.)
-  call get_param(param_file,mod,"S_REF",S_ref)
-  call get_param(param_file,mod,"T_REF",T_ref)
-  call get_param(param_file,mod,"S_RANGE",S_range,default=2.0)
-  call get_param(param_file,mod,"T_RANGE",T_range,default=0.0)
+  call get_param(param_file, mdl,"S_REF",S_ref)
+  call get_param(param_file, mdl,"T_REF",T_ref)
+  call get_param(param_file, mdl,"S_RANGE",S_range,default=2.0)
+  call get_param(param_file, mdl,"T_RANGE",T_range,default=0.0)
 
 
   ! Set the inverse damping rate as a function of position

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -55,15 +55,15 @@ subroutine DOME_initialize_topography(D, G, param_file, max_depth)
   real :: min_depth ! The minimum and maximum depths in m.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "DOME_initialize_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "DOME_initialize_topography" ! This subroutine's name.
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   call MOM_mesg("  DOME_initialization.F90, DOME_initialize_topography: setting topography", 5)
 
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
 
   do j=js,je ; do i=is,ie
@@ -105,7 +105,7 @@ subroutine DOME_initialize_thickness(h, G, GV, param_file, just_read_params)
   real :: eta1D(SZK_(GV)+1) ! Interface height relative to the sea surface !
                             ! positive upward, in m.                       !
   logical :: just_read    ! If true, just read parameters but set nothing.
-  character(len=40)  :: mod = "DOME_initialize_thickness" ! This subroutine's name.
+  character(len=40)  :: mdl = "DOME_initialize_thickness" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -166,7 +166,7 @@ subroutine DOME_initialize_sponges(G, GV, tv, PF, CSp)
   real :: H0(SZK_(G))
   real :: min_depth
   real :: damp, e_dense, damp_new
-  character(len=40)  :: mod = "DOME_initialize_sponges" ! This subroutine's name.
+  character(len=40)  :: mdl = "DOME_initialize_sponges" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -180,7 +180,7 @@ subroutine DOME_initialize_sponges(G, GV, tv, PF, CSp)
 !  and mask2dT is 1.                                                   !
 
 !   Set up sponges for DOME configuration
-  call get_param(PF, mod, "MINIMUM_DEPTH", min_depth, &
+  call get_param(PF, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
 
   H0(1) = 0.0
@@ -275,7 +275,7 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, param_file, tr_Reg)
                             ! thickness D_edge, in the same units as lat.
   real :: Ri_trans          ! The shear Richardson number in the transition
                             ! region of the specified shear profile.
-  character(len=40)  :: mod = "DOME_set_OBC_data" ! This subroutine's name.
+  character(len=40)  :: mdl = "DOME_set_OBC_data" ! This subroutine's name.
   integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB
   type(OBC_segment_type), pointer :: segment

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -44,7 +44,7 @@ implicit none ; private
 ! Private (module-wise) parameters
 ! -----------------------------------------------------------------------------
 
-character(len=40) :: mod = "ISOMIP_initialization" ! This module's name.
+character(len=40) :: mdl = "ISOMIP_initialization" ! This module's name.
 
 ! -----------------------------------------------------------------------------
 ! The following routines are visible to the outside world
@@ -87,7 +87,7 @@ subroutine ISOMIP_initialize_topography(D, G, param_file, max_depth)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "ISOMIP_initialize_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "ISOMIP_initialize_topography" ! This subroutine's name.
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -95,10 +95,10 @@ subroutine ISOMIP_initialize_topography(D, G, param_file, max_depth)
 
   call MOM_mesg("  ISOMIP_initialization.F90, ISOMIP_initialize_topography: setting topography", 5)
 
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
-  call get_param(param_file, mod, "ISOMIP_2D",is_2D,'If true, use a 2D setup.', default=.false.)
+  call get_param(param_file, mdl, "ISOMIP_2D",is_2D,'If true, use a 2D setup.', default=.false.)
 
 ! The following variables should be transformed into runtime parameters?
   bmax=720.0; b0=-150.0; b2=-728.8; b4=343.91; b6=-50.57
@@ -183,21 +183,21 @@ subroutine ISOMIP_initialize_thickness ( h, G, GV, param_file, tv, just_read_par
   if (.not.just_read) &
     call MOM_mesg("MOM_initialization.F90, initialize_thickness_uniform: setting thickness")
 
-  call get_param(param_file,mod,"MIN_THICKNESS",min_thickness, &
+  call get_param(param_file, mdl,"MIN_THICKNESS",min_thickness, &
                  'Minimum layer thickness', units='m', default=1.e-3, do_not_log=just_read)
-  call get_param(param_file,mod,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
+  call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
 
   select case ( coordinateMode(verticalCoordinate) )
 
   case ( REGRIDDING_LAYER, REGRIDDING_RHO ) ! Initial thicknesses for isopycnal coordinates
-    call get_param(param_file, mod, "ISOMIP_T_SUR",t_sur, &
+    call get_param(param_file, mdl, "ISOMIP_T_SUR",t_sur, &
                    'Temperature at the surface (interface)', default=-1.9, do_not_log=just_read)
-    call get_param(param_file, mod, "ISOMIP_S_SUR", s_sur, &
+    call get_param(param_file, mdl, "ISOMIP_S_SUR", s_sur, &
                    'Salinity at the surface (interface)',  default=33.8, do_not_log=just_read)
-    call get_param(param_file, mod, "ISOMIP_T_BOT", t_bot, &
+    call get_param(param_file, mdl, "ISOMIP_T_BOT", t_bot, &
                    'Temperature at the bottom (interface)', default=-1.9, do_not_log=just_read)
-    call get_param(param_file, mod, "ISOMIP_S_BOT", s_bot,&
+    call get_param(param_file, mdl, "ISOMIP_S_BOT", s_bot,&
                    'Salinity at the bottom (interface)', default=34.55, do_not_log=just_read)
 
     if (just_read) return ! All run-time parameters have been read, so return.
@@ -298,15 +298,15 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(param_file,mod,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
+  call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
-  call get_param(param_file, mod, "ISOMIP_T_SUR",t_sur, &
+  call get_param(param_file, mdl, "ISOMIP_T_SUR",t_sur, &
                  'Temperature at the surface (interface)', default=-1.9, do_not_log=just_read)
-  call get_param(param_file, mod, "ISOMIP_S_SUR", s_sur, &
+  call get_param(param_file, mdl, "ISOMIP_S_SUR", s_sur, &
                  'Salinity at the surface (interface)',  default=33.8, do_not_log=just_read)
-  call get_param(param_file, mod, "ISOMIP_T_BOT", t_bot, &
+  call get_param(param_file, mdl, "ISOMIP_T_BOT", t_bot, &
                  'Temperature at the bottom (interface)', default=-1.9, do_not_log=just_read)
-  call get_param(param_file, mod, "ISOMIP_S_BOT", s_bot, &
+  call get_param(param_file, mdl, "ISOMIP_S_BOT", s_bot, &
                  'Salinity at the bottom (interface)', default=34.55, do_not_log=just_read)
 
   call calculate_density(t_sur,s_sur,0.0,rho_sur,eqn_of_state)
@@ -336,20 +336,20 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
       enddo ; enddo
 
     case ( REGRIDDING_LAYER )
-     call get_param(param_file, mod, "FIT_SALINITY", fit_salin, &
+     call get_param(param_file, mdl, "FIT_SALINITY", fit_salin, &
                  "If true, accept the prescribed temperature and fit the \n"//&
                  "salinity; otherwise take salinity and fit temperature.", &
                  default=.false., do_not_log=just_read)
-     call get_param(param_file, mod, "DRHO_DS", drho_dS1, &
+     call get_param(param_file, mdl, "DRHO_DS", drho_dS1, &
                  "Partial derivative of density with salinity.", &
                  units="kg m-3 PSU-1", fail_if_missing=.not.just_read, do_not_log=just_read)
-     call get_param(param_file, mod, "DRHO_DT", drho_dT1, &
+     call get_param(param_file, mdl, "DRHO_DT", drho_dT1, &
                  "Partial derivative of density with temperature.", &
                  units="kg m-3 K-1", fail_if_missing=.not.just_read, do_not_log=just_read)
-     call get_param(param_file, mod, "T_REF", T_Ref, &
+     call get_param(param_file, mdl, "T_REF", T_Ref, &
                  "A reference temperature used in initialization.", &
                  units="degC", fail_if_missing=.not.just_read, do_not_log=just_read)
-     call get_param(param_file, mod, "S_REF", S_Ref, &
+     call get_param(param_file, mdl, "S_REF", S_Ref, &
                  "A reference salinity used in initialization.", units="PSU", &
                  default=35.0, do_not_log=just_read)
      if (just_read) return ! All run-time parameters have been read, so return.
@@ -468,39 +468,39 @@ subroutine ISOMIP_initialize_sponges(G, GV, tv, PF, use_ALE, CSp, ACSp)
   character(len=40) :: verticalCoordinate, filename, state_file
   character(len=40) :: temp_var, salt_var, eta_var, inputdir
 
-  character(len=40)  :: mod = "ISOMIP_initialize_sponges" ! This subroutine's name.
+  character(len=40)  :: mdl = "ISOMIP_initialize_sponges" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
-  call get_param(PF,mod,"MIN_THICKNESS",min_thickness,'Minimum layer thickness',units='m',default=1.e-3)
+  call get_param(PF, mdl,"MIN_THICKNESS",min_thickness,'Minimum layer thickness',units='m',default=1.e-3)
 
-  call get_param(PF,mod,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
+  call get_param(PF, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
             default=DEFAULT_COORDINATE_MODE)
 
-  call get_param(PF, mod, "ISOMIP_TNUDG", TNUDG, 'Nudging time scale for sponge layers (days)',  default=0.0)
+  call get_param(PF, mdl, "ISOMIP_TNUDG", TNUDG, 'Nudging time scale for sponge layers (days)',  default=0.0)
 
-  call get_param(PF, mod, "T_REF", t_ref, 'Reference temperature',  default=10.0,&
+  call get_param(PF, mdl, "T_REF", t_ref, 'Reference temperature',  default=10.0,&
                  do_not_log=.true.)
 
-  call get_param(PF, mod, "S_REF", s_ref, 'Reference salinity',  default=35.0,&
+  call get_param(PF, mdl, "S_REF", s_ref, 'Reference salinity',  default=35.0,&
                  do_not_log=.true.)
 
-  call get_param(PF, mod, "ISOMIP_S_SUR_SPONGE", s_sur, 'Surface salinity in sponge layer.',  default=s_ref)
+  call get_param(PF, mdl, "ISOMIP_S_SUR_SPONGE", s_sur, 'Surface salinity in sponge layer.',  default=s_ref)
 
-  call get_param(PF, mod, "ISOMIP_S_BOT_SPONGE", s_bot, 'Bottom salinity in sponge layer.',  default=s_ref)
+  call get_param(PF, mdl, "ISOMIP_S_BOT_SPONGE", s_bot, 'Bottom salinity in sponge layer.',  default=s_ref)
 
-  call get_param(PF, mod, "ISOMIP_T_SUR_SPONGE", t_sur, 'Surface temperature in sponge layer.',  default=t_ref)
+  call get_param(PF, mdl, "ISOMIP_T_SUR_SPONGE", t_sur, 'Surface temperature in sponge layer.',  default=t_ref)
 
-  call get_param(PF, mod, "ISOMIP_T_BOT_SPONGE", t_bot, 'Bottom temperature in sponge layer.',  default=t_ref)
+  call get_param(PF, mdl, "ISOMIP_T_BOT_SPONGE", t_bot, 'Bottom temperature in sponge layer.',  default=t_ref)
 
   T(:,:,:) = 0.0 ; S(:,:,:) = 0.0 ; Idamp(:,:) = 0.0; RHO(:,:,:) = 0.0
   S_range = s_sur - s_bot
   T_range = t_sur - t_bot
 
 !   Set up sponges for ISOMIP configuration
-  call get_param(PF, mod, "MINIMUM_DEPTH", min_depth, &
+  call get_param(PF, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
 
    if (associated(CSp)) call MOM_error(FATAL, &
@@ -630,23 +630,23 @@ subroutine ISOMIP_initialize_sponges(G, GV, tv, PF, use_ALE, CSp, ACSp)
 
   else ! layer mode
        ! 1) Read eta, salt and temp from IC file
-       call get_param(PF, mod, "INPUTDIR", inputdir, default=".")
+       call get_param(PF, mdl, "INPUTDIR", inputdir, default=".")
        inputdir = slasher(inputdir)
        ! GM: get two different files, one with temp and one with salt values
        ! this is work around to avoid having wrong values near the surface
        ! because of the FIT_SALINITY option. To get salt values right in the
        ! sponge, FIT_SALINITY=False. The oposite is true for temp. One can
        ! combined the *correct* temp and salt values in one file instead.
-       call get_param(PF, mod, "ISOMIP_SPONGE_FILE", state_file, &
+       call get_param(PF, mdl, "ISOMIP_SPONGE_FILE", state_file, &
                  "The name of the file with temps., salts. and interfaces to \n"// &
                  " damp toward.", fail_if_missing=.true.)
-       call get_param(PF, mod, "SPONGE_PTEMP_VAR", temp_var, &
+       call get_param(PF, mdl, "SPONGE_PTEMP_VAR", temp_var, &
                  "The name of the potential temperature variable in \n"//&
                  "SPONGE_STATE_FILE.", default="Temp")
-       call get_param(PF, mod, "SPONGE_SALT_VAR", salt_var, &
+       call get_param(PF, mdl, "SPONGE_SALT_VAR", salt_var, &
                  "The name of the salinity variable in \n"//&
                  "SPONGE_STATE_FILE.", default="Salt")
-       call get_param(PF, mod, "SPONGE_ETA_VAR", eta_var, &
+       call get_param(PF, mdl, "SPONGE_ETA_VAR", eta_var, &
                  "The name of the interface height variable in \n"//&
                  "SPONGE_STATE_FILE.", default="eta")
 

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -65,7 +65,7 @@ function register_Kelvin_OBC(param_file, CS, OBC_Reg)
   type(Kelvin_OBC_CS),      pointer    :: CS         !< Kelvin wave control structure.
   type(OBC_registry_type),  pointer    :: OBC_Reg    !< OBC registry.
   logical                              :: register_Kelvin_OBC
-  character(len=40)  :: mod = "register_Kelvin_OBC"  !< This subroutine's name.
+  character(len=40)  :: mdl = "register_Kelvin_OBC"  !< This subroutine's name.
   character(len=32)  :: casename = "Kelvin wave"     !< This case's name.
   character(len=200) :: config
 
@@ -76,30 +76,30 @@ function register_Kelvin_OBC(param_file, CS, OBC_Reg)
   endif
   allocate(CS)
 
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "KELVIN_WAVE_MODE", CS%mode, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "KELVIN_WAVE_MODE", CS%mode, &
                  "Vertical Kelvin wave mode imposed at upstream open boundary.", &
                  default=0)
-  call get_param(param_file, mod, "F_0", CS%F_0, &
+  call get_param(param_file, mdl, "F_0", CS%F_0, &
                  default=0.0, do_not_log=.true.)
-  call get_param(param_file, mod, "TOPO_CONFIG", config, do_not_log=.true.)
+  call get_param(param_file, mdl, "TOPO_CONFIG", config, do_not_log=.true.)
   if (trim(config) == "Kelvin") then
-    call get_param(param_file, mod, "KELVIN_COAST_OFFSET", CS%coast_offset, &
+    call get_param(param_file, mdl, "KELVIN_COAST_OFFSET", CS%coast_offset, &
                    "The distance along the southern and northern boundaries \n"//&
                    "at which the coasts angle in.", &
                    units="km", default=100.0)
-    call get_param(param_file, mod, "KELVIN_COAST_ANGLE", CS%coast_angle, &
+    call get_param(param_file, mdl, "KELVIN_COAST_ANGLE", CS%coast_angle, &
                    "The angle of the southern bondary beyond X=KELVIN_COAST_OFFSET.", &
                    units="degrees", default=11.3)
     CS%coast_angle = CS%coast_angle * (atan(1.0)/45.) ! Convert to radians
     CS%coast_offset = CS%coast_offset * 1.e3          ! Convert to m
   endif
   if (CS%mode /= 0) then
-    call get_param(param_file, mod, "DENSITY_RANGE", CS%rho_range, &
+    call get_param(param_file, mdl, "DENSITY_RANGE", CS%rho_range, &
                    default=2.0, do_not_log=.true.)
-    call get_param(param_file, mod, "RHO_0", CS%rho_0, &
+    call get_param(param_file, mdl, "RHO_0", CS%rho_0, &
                    default=1035.0, do_not_log=.true.)
-    call get_param(param_file, mod, "MAXIMUM_DEPTH", CS%H0, &
+    call get_param(param_file, mdl, "MAXIMUM_DEPTH", CS%H0, &
                    default=1000.0, do_not_log=.true.)
   endif
 
@@ -126,7 +126,7 @@ subroutine Kelvin_initialize_topography(D, G, param_file, max_depth)
   type(param_file_type),            intent(in)  :: param_file !< Parameter file structure
   real,                             intent(in)  :: max_depth  !< Maximum depth of model in m
   ! Local variables
-  character(len=40)  :: mod = "Kelvin_initialize_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "Kelvin_initialize_topography" ! This subroutine's name.
   real :: min_depth ! The minimum and maximum depths in m.
   real :: PI ! 3.1415...
   real :: coast_offset, coast_angle, right_angle
@@ -134,11 +134,11 @@ subroutine Kelvin_initialize_topography(D, G, param_file, max_depth)
 
   call MOM_mesg("  Kelvin_initialization.F90, Kelvin_initialize_topography: setting topography", 5)
 
-  call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
+  call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
-  call get_param(param_file, mod, "KELVIN_COAST_OFFSET", coast_offset, &
+  call get_param(param_file, mdl, "KELVIN_COAST_OFFSET", coast_offset, &
                  default=100.0, do_not_log=.true.)
-  call get_param(param_file, mod, "KELVIN_COAST_ANGLE", coast_angle, &
+  call get_param(param_file, mdl, "KELVIN_COAST_ANGLE", coast_angle, &
                  default=11.3, do_not_log=.true.)
 
   coast_angle = coast_angle * (atan(1.0)/45.) ! Convert to radians

--- a/src/user/MOM_controlled_forcing.F90
+++ b/src/user/MOM_controlled_forcing.F90
@@ -505,7 +505,7 @@ subroutine controlled_forcing_init(Time, G, param_file, diag, CS)
   integer :: num_cycle
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "MOM_controlled_forcing" ! This module's name.
+  character(len=40)  :: mdl = "MOM_controlled_forcing" ! This module's name.
 
   ! These should have already been called.
   ! call read_param(param_file, "CTRL_FORCE_INTEGRATED", CS%do_integrated)
@@ -518,12 +518,12 @@ subroutine controlled_forcing_init(Time, G, param_file, diag, CS)
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call log_param(param_file, mod, "CTRL_FORCE_INTEGRATED", do_integrated, &
+  call log_version(param_file, mdl, version, "")
+  call log_param(param_file, mdl, "CTRL_FORCE_INTEGRATED", do_integrated, &
                  "If true, use a PI controller to determine the surface \n"//&
                  "forcing that is consistent with the observed mean properties.", &
                  default=.false.)
-  call log_param(param_file, mod, "CTRL_FORCE_NUM_CYCLE", num_cycle, &
+  call log_param(param_file, mdl, "CTRL_FORCE_NUM_CYCLE", num_cycle, &
                  "The number of cycles per year in the controlled forcing, \n"//&
                  "or 0 for no cyclic forcing.", default=0)
 
@@ -531,32 +531,32 @@ subroutine controlled_forcing_init(Time, G, param_file, diag, CS)
 
   CS%diag => diag
 
-  call get_param(param_file, mod, "CTRL_FORCE_HEAT_INT_RATE", CS%heat_int_rate, &
+  call get_param(param_file, mdl, "CTRL_FORCE_HEAT_INT_RATE", CS%heat_int_rate, &
                  "The integrated rate at which heat flux anomalies are \n"//&
                  "accumulated.", units="s-1", default=0.0)
-  call get_param(param_file, mod, "CTRL_FORCE_PREC_INT_RATE", CS%prec_int_rate, &
+  call get_param(param_file, mdl, "CTRL_FORCE_PREC_INT_RATE", CS%prec_int_rate, &
                  "The integrated rate at which precipitation anomalies \n"//&
                  "are accumulated.", units="s-1", default=0.0)
-  call get_param(param_file, mod, "CTRL_FORCE_HEAT_CYC_RATE", CS%heat_cyc_rate, &
+  call get_param(param_file, mdl, "CTRL_FORCE_HEAT_CYC_RATE", CS%heat_cyc_rate, &
                  "The integrated rate at which cyclical heat flux \n"//&
                  "anomalies are accumulated.", units="s-1", default=0.0)
-  call get_param(param_file, mod, "CTRL_FORCE_PREC_CYC_RATE", CS%prec_cyc_rate, &
+  call get_param(param_file, mdl, "CTRL_FORCE_PREC_CYC_RATE", CS%prec_cyc_rate, &
                  "The integrated rate at which cyclical precipitation \n"//&
                  "anomalies are accumulated.", units="s-1", default=0.0)
-  call get_param(param_file, mod, "CTRL_FORCE_SMOOTH_LENGTH", smooth_len, &
+  call get_param(param_file, mdl, "CTRL_FORCE_SMOOTH_LENGTH", smooth_len, &
                  "The length scales over which controlled forcing \n"//&
                  "anomalies are smoothed.", units="m", default=0.0)
-  call get_param(param_file, mod, "CTRL_FORCE_LAMDA_HEAT", CS%lam_heat, &
+  call get_param(param_file, mdl, "CTRL_FORCE_LAMDA_HEAT", CS%lam_heat, &
                  "A constant of proportionality between SST anomalies \n"//&
                  "and controlling heat fluxes", "W m-2 K-1", default=0.0)
-  call get_param(param_file, mod, "CTRL_FORCE_LAMDA_PREC", CS%lam_prec, &
+  call get_param(param_file, mdl, "CTRL_FORCE_LAMDA_PREC", CS%lam_prec, &
                  "A constant of proportionality between SSS anomalies \n"//&
                  "(normalised by mean SSS) and controlling precipitation.", &
                  "kg m-2", default=0.0)
-  call get_param(param_file, mod, "CTRL_FORCE_LAMDA_CYC_HEAT", CS%lam_cyc_heat, &
+  call get_param(param_file, mdl, "CTRL_FORCE_LAMDA_CYC_HEAT", CS%lam_cyc_heat, &
                  "A constant of proportionality between SST anomalies \n"//&
                  "and cyclical controlling heat fluxes", "W m-2 K-1", default=0.0)
-  call get_param(param_file, mod, "CTRL_FORCE_LAMDA_CYC_PREC", CS%lam_cyc_prec, &
+  call get_param(param_file, mdl, "CTRL_FORCE_LAMDA_CYC_PREC", CS%lam_cyc_prec, &
                  "A constant of proportionality between SSS anomalies \n"//&
                  "(normalised by mean SSS) and cyclical controlling \n"//&
                  "precipitation.", "kg m-2", default=0.0)

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -65,7 +65,7 @@ subroutine Phillips_initialize_thickness(h, G, GV, param_file, just_read_params)
   real :: damp_rate, jet_width, jet_height, y_2
   real :: half_strat, half_depth
   logical :: just_read    ! If true, just read parameters but set nothing.
-  character(len=40)  :: mod = "Phillips_initialize_thickness" ! This subroutine's name.
+  character(len=40)  :: mdl = "Phillips_initialize_thickness" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -75,14 +75,14 @@ subroutine Phillips_initialize_thickness(h, G, GV, param_file, just_read_params)
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "HALF_STRAT_DEPTH", half_strat, &
+  if (.not.just_read) call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "HALF_STRAT_DEPTH", half_strat, &
                  "The maximum depth of the ocean.", units="nondim", &
                  default = 0.5, do_not_log=just_read)
-  call get_param(param_file, mod, "JET_WIDTH", jet_width, &
+  call get_param(param_file, mdl, "JET_WIDTH", jet_width, &
                  "The width of the zonal-mean jet.", units="km", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "JET_HEIGHT", jet_height, &
+  call get_param(param_file, mdl, "JET_HEIGHT", jet_height, &
                  "The interface height scale associated with the \n"//&
                  "zonal-mean jet.", units="m", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
@@ -145,19 +145,19 @@ subroutine Phillips_initialize_velocity(u, v, G, GV, param_file, just_read_param
   real :: velocity_amplitude, pi
   integer :: i, j, k, is, ie, js, je, nz, m
   logical :: just_read    ! If true, just read parameters but set nothing.
-  character(len=40)  :: mod = "Phillips_initialize_velocity" ! This subroutine's name.
+  character(len=40)  :: mdl = "Phillips_initialize_velocity" ! This subroutine's name.
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "VELOCITY_IC_PERTURB_AMP", velocity_amplitude, &
+  if (.not.just_read) call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "VELOCITY_IC_PERTURB_AMP", velocity_amplitude, &
                  "The magnitude of the initial velocity perturbation.", &
                  units="m s-1", default=0.001, do_not_log=just_read)
-  call get_param(param_file, mod, "JET_WIDTH", jet_width, &
+  call get_param(param_file, mdl, "JET_WIDTH", jet_width, &
                  "The width of the zonal-mean jet.", units="km", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "JET_HEIGHT", jet_height, &
+  call get_param(param_file, mdl, "JET_HEIGHT", jet_height, &
                  "The interface height scale associated with the \n"//&
                  "zonal-mean jet.", units="m", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
@@ -229,7 +229,7 @@ subroutine Phillips_initialize_sponges(G, use_temperature, tv, param_file, CSp, 
   real :: Idamp_im(SZJ_(G))         ! The inverse zonal-mean damping rate, in s-1.
   real :: damp_rate, jet_width, jet_height, y_2
   real :: half_strat, half_depth
-  character(len=40)  :: mod = "Phillips_initialize_sponges" ! This subroutine's name.
+  character(len=40)  :: mdl = "Phillips_initialize_sponges" ! This subroutine's name.
 
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
   logical, save :: first_call = .true.
@@ -240,19 +240,19 @@ subroutine Phillips_initialize_sponges(G, use_temperature, tv, param_file, CSp, 
   eta(:,:,:) = 0.0 ; temp(:,:,:) = 0.0 ; Idamp(:,:) = 0.0
   eta_im(:,:) = 0.0 ; Idamp_im(:) = 0.0
 
-  if (first_call) call log_version(param_file, mod, version)
+  if (first_call) call log_version(param_file, mdl, version)
   first_call = .false.
-  call get_param(param_file, mod, "HALF_STRAT_DEPTH", half_strat, &
+  call get_param(param_file, mdl, "HALF_STRAT_DEPTH", half_strat, &
                  "The maximum depth of the ocean.", units="nondim", &
                  default = 0.5)
-  call get_param(param_file, mod, "SPONGE_RATE", damp_rate, &
+  call get_param(param_file, mdl, "SPONGE_RATE", damp_rate, &
                  "The rate at which the zonal-mean sponges damp.", units="s-1", &
                  default = 1.0/(10.0*86400.0))
 
-  call get_param(param_file, mod, "JET_WIDTH", jet_width, &
+  call get_param(param_file, mdl, "JET_WIDTH", jet_width, &
                  "The width of the zonal-mean jet.", units="km", &
                  fail_if_missing=.true.)
-  call get_param(param_file, mod, "JET_HEIGHT", jet_height, &
+  call get_param(param_file, mdl, "JET_HEIGHT", jet_height, &
                  "The interface height scale associated with the \n"//&
                  "zonal-mean jet.", units="m", &
                  fail_if_missing=.true.)
@@ -305,13 +305,13 @@ subroutine Phillips_initialize_topography(D, G, param_file, max_depth)
   real :: PI, Htop, Wtop, Ltop, offset, dist, &
           x1, x2, x3, x4, y1, y2
   integer :: i,j,is,ie,js,je
-  character(len=40)  :: mod = "Phillips_initialize_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "Phillips_initialize_topography" ! This subroutine's name.
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
   PI = 4.0*atan(1.0)
 
-  call get_param(param_file, mod, "PHILLIPS_HTOP", Htop,             &
+  call get_param(param_file, mdl, "PHILLIPS_HTOP", Htop,             &
                  "The maximum height of the topography.", units="m", &
                  fail_if_missing=.true.)
 ! Htop=0.375*G%max_depth     ! max height of topog. above max_depth

--- a/src/user/Rossby_front_2d_initialization.F90
+++ b/src/user/Rossby_front_2d_initialization.F90
@@ -22,7 +22,7 @@ implicit none ; private
 #include <MOM_memory.h>
 
 ! Private (module-wise) parameters
-character(len=40) :: mod = "Rossby_front_2d_initialization" !< This module's name.
+character(len=40) :: mdl = "Rossby_front_2d_initialization" !< This module's name.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
@@ -61,15 +61,15 @@ subroutine Rossby_front_initialize_thickness(h, G, GV, param_file, just_read_par
   if (.not.just_read) &
     call MOM_mesg("Rossby_front_2d_initialization.F90, Rossby_front_initialize_thickness: setting thickness")
 
-  if (.not.just_read) call log_version(param_file, mod, version, "")
+  if (.not.just_read) call log_version(param_file, mdl, version, "")
   ! Read parameters needed to set thickness
-  call get_param(param_file, mod, "MIN_THICKNESS", min_thickness, &
+  call get_param(param_file, mdl, "MIN_THICKNESS", min_thickness, &
                  'Minimum layer thickness',units='m',default=1.e-3, do_not_log=just_read)
-  call get_param(param_file, mod, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
+  call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
-  call get_param(param_file, mod, "T_RANGE", T_range, 'Initial temperature range', &
+  call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
                  units='C', default=0.0, do_not_log=just_read)
-  call get_param(param_file, mod, "DRHO_DT", dRho_dT, default=-0.2, do_not_log=.true.)
+  call get_param(param_file, mdl, "DRHO_DT", dRho_dT, default=-0.2, do_not_log=.true.)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -132,13 +132,13 @@ subroutine Rossby_front_initialize_temperature_salinity(T, S, h, G, &
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(param_file,mod,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
+  call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
             default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
-  call get_param(param_file,mod,"S_REF",S_ref,'Reference salinity', units='1e-3', &
+  call get_param(param_file, mdl,"S_REF",S_ref,'Reference salinity', units='1e-3', &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"T_REF",T_ref,'Reference temperature',units='C',&
+  call get_param(param_file, mdl,"T_REF",T_ref,'Reference temperature',units='C',&
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"T_RANGE",T_range,'Initial temperature range',&
+  call get_param(param_file, mdl,"T_RANGE",T_range,'Initial temperature range',&
                  units='C', default=0.0, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
@@ -185,11 +185,11 @@ subroutine Rossby_front_initialize_velocity(u, v, h, G, GV, param_file, just_rea
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(param_file, mod, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
+  call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
-  call get_param(param_file, mod, "T_RANGE", T_range, 'Initial temperature range', &
+  call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
                  units='C', default=0.0, do_not_log=just_read)
-  call get_param(param_file, mod, "DRHO_DT", dRho_dT, default=-0.2, do_not_log=.true.)
+  call get_param(param_file, mdl, "DRHO_DT", dRho_dT, default=-0.2, do_not_log=.true.)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 

--- a/src/user/SCM_CVmix_tests.F90
+++ b/src/user/SCM_CVmix_tests.F90
@@ -41,7 +41,7 @@ end type
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
-character(len=40)  :: mod = "SCM_CVmix_tests" ! This module's name.
+character(len=40)  :: mdl = "SCM_CVmix_tests" ! This module's name.
 
 contains
 
@@ -75,23 +75,23 @@ subroutine SCM_CVmix_tests_TS_init(T, S, h, G, GV, param_file, just_read_params)
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call log_version(param_file, mod, version)
-  call get_param(param_file,mod,"SCM_TEMP_MLD",UpperLayerTempMLD, &
+  if (.not.just_read) call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl,"SCM_TEMP_MLD",UpperLayerTempMLD, &
                  'Initial temp mixed layer depth', units='m',default=0.0, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_SALT_MLD",UpperLayerSaltMLD, &
+  call get_param(param_file, mdl,"SCM_SALT_MLD",UpperLayerSaltMLD, &
                  'Initial salt mixed layer depth', units='m',default=0.0, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_L1_SALT",UpperLayerSalt, &
+  call get_param(param_file, mdl,"SCM_L1_SALT",UpperLayerSalt, &
                  'Layer 2 surface salinity', units='1e-3',default=35.0, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_L1_TEMP",UpperLayerTemp, &
+  call get_param(param_file, mdl,"SCM_L1_TEMP",UpperLayerTemp, &
                  'Layer 1 surface temperature', units='C', default=20.0, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_L2_SALT",LowerLayerSalt, &
+  call get_param(param_file, mdl,"SCM_L2_SALT",LowerLayerSalt, &
                  'Layer 2 surface salinity', units='1e-3',default=35.0, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_L2_TEMP",LowerLayerTemp, &
+  call get_param(param_file, mdl,"SCM_L2_TEMP",LowerLayerTemp, &
                  'Layer 2 surface temperature', units='C', default=20.0, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_L2_DTDZ",LowerLayerdTdZ,     &
+  call get_param(param_file, mdl,"SCM_L2_DTDZ",LowerLayerdTdZ,     &
                  'Initial temperature stratification in layer 2', &
                  units='C/m', default=0.00, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_L2_DSDZ",LowerLayerdSdZ,  &
+  call get_param(param_file, mdl,"SCM_L2_DSDZ",LowerLayerdSdZ,  &
                  'Initial salinity stratification in layer 2', &
                  units='PPT/m', default=0.00, do_not_log=just_read)
 
@@ -137,47 +137,47 @@ subroutine SCM_CVmix_tests_surface_forcing_init(Time, G, param_file, CS)
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "SCM_USE_WIND_STRESS",              &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "SCM_USE_WIND_STRESS",              &
                  CS%UseWindStress, "Wind Stress switch "//            &
                  "used in the SCM CVmix surface forcing.",            &
                  units='', default=.false.)
-  call get_param(param_file, mod, "SCM_USE_HEAT_FLUX",                &
+  call get_param(param_file, mdl, "SCM_USE_HEAT_FLUX",                &
                  CS%UseHeatFlux, "Heat flux switch "//                &
                  "used in the SCM CVmix test surface forcing.",       &
                  units='', default=.false.)
-  call get_param(param_file, mod, "SCM_USE_EVAPORATION",              &
+  call get_param(param_file, mdl, "SCM_USE_EVAPORATION",              &
                  CS%UseEvaporation, "Evaporation switch "//           &
                  "used in the SCM CVmix test surface forcing.",       &
                  units='', default=.false.)
-  call get_param(param_file, mod, "SCM_USE_DIURNAL_SW",               &
+  call get_param(param_file, mdl, "SCM_USE_DIURNAL_SW",               &
                  CS%UseDiurnalSW, "Diurnal sw radation switch "//     &
                  "used in the SCM CVmix test surface forcing.",       &
                  units='', default=.false.)
   if (CS%UseWindStress) then
-    call get_param(param_file, mod, "SCM_TAU_X",                      &
+    call get_param(param_file, mdl, "SCM_TAU_X",                      &
                  CS%tau_x, "Constant X-dir wind stress "//            &
                  "used in the SCM CVmix test surface forcing.",       &
                  units='N/m2', fail_if_missing=.true.)
-    call get_param(param_file, mod, "SCM_TAU_Y",                      &
+    call get_param(param_file, mdl, "SCM_TAU_Y",                      &
                  CS%tau_y, "Constant y-dir wind stress "//            &
                  "used in the SCM CVmix test surface forcing.",       &
                  units='N/m2', fail_if_missing=.true.)
   endif
   if (CS%UseHeatFlux) then
-    call get_param(param_file, mod, "SCM_HEAT_FLUX",                  &
+    call get_param(param_file, mdl, "SCM_HEAT_FLUX",                  &
                  CS%surf_HF, "Constant surface heat flux "//          &
                  "used in the SCM CVmix test surface forcing.",       &
                  units='m K/s', fail_if_missing=.true.)
   endif
   if (CS%UseEvaporation) then
-    call get_param(param_file, mod, "SCM_EVAPORATION",                &
+    call get_param(param_file, mdl, "SCM_EVAPORATION",                &
                  CS%surf_evap, "Constant surface evaporation "//      &
                  "used in the SCM CVmix test surface forcing.",       &
                  units='m/s', fail_if_missing=.true.)
   endif
   if (CS%UseDiurnalSW) then
-    call get_param(param_file, mod, "SCM_DIURNAL_SW_MAX",             &
+    call get_param(param_file, mdl, "SCM_DIURNAL_SW_MAX",             &
                  CS%Max_sw, "Maximum diurnal sw radiation "//         &
                  "used in the SCM CVmix test surface forcing.",       &
                  units='m K/s', fail_if_missing=.true.)

--- a/src/user/SCM_idealized_hurricane.F90
+++ b/src/user/SCM_idealized_hurricane.F90
@@ -39,7 +39,7 @@ end type
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
-character(len=40)  :: mod = "SCM_idealized_hurricane" ! This module's name.
+character(len=40)  :: mdl = "SCM_idealized_hurricane" ! This module's name.
 
 contains
 
@@ -65,16 +65,16 @@ subroutine SCM_idealized_hurricane_TS_init(T, S, h, G, GV, param_file, just_read
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  if (.not.just_read) call log_version(param_file, mod, version)
-  call get_param(param_file,mod,"SCM_S_REF",S_ref, &
+  if (.not.just_read) call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl,"SCM_S_REF",S_ref, &
                  'Reference salinity', units='1e-3',default=35.0, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_SST_REF",SST_ref, &
+  call get_param(param_file, mdl,"SCM_SST_REF",SST_ref, &
                  'Reference surface temperature', units='C', &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_DTDZ",dTdZ,                         &
+  call get_param(param_file, mdl,"SCM_DTDZ",dTdZ,                         &
                  'Initial temperature stratification below mixed layer', &
                  units='C/m', fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"SCM_MLD",MLD, &
+  call get_param(param_file, mdl,"SCM_MLD",MLD, &
                  'Initial mixed layer depth', units='m', &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
 
@@ -110,36 +110,36 @@ subroutine SCM_idealized_hurricane_wind_init(Time, G, param_file, CS)
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "SCM_RHO_AIR", CS%rho_a,            &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "SCM_RHO_AIR", CS%rho_a,            &
                  "Air density "//                                     &
                  "used in the SCM idealized hurricane wind profile.", &
                  units='kg/m3', default=1.2)
-  call get_param(param_file, mod, "SCM_AMBIENT_PRESSURE", CS%p_n,     &
+  call get_param(param_file, mdl, "SCM_AMBIENT_PRESSURE", CS%p_n,     &
                  "Ambient pressure "//                                &
                  "used in the SCM idealized hurricane wind profile.", &
                  units='Pa', default=101200.)
-  call get_param(param_file, mod, "SCM_CENTRAL_PRESSURE", CS%p_c,     &
+  call get_param(param_file, mdl, "SCM_CENTRAL_PRESSURE", CS%p_c,     &
                  "Central pressure "//                                &
                  "used in the SCM idealized hurricane wind profile.", &
                  units='Pa', default=96800.)
-  call get_param(param_file, mod, "SCM_RADIUS_MAX_WINDS", CS%r_max,   &
+  call get_param(param_file, mdl, "SCM_RADIUS_MAX_WINDS", CS%r_max,   &
                  "Radius of maximum winds "//                         &
                  "used in the SCM idealized hurricane wind profile.", &
                  units='m', default=50.e3)
-  call get_param(param_file, mod, "SCM_MAX_WIND_SPEED", CS%U_max,     &
+  call get_param(param_file, mdl, "SCM_MAX_WIND_SPEED", CS%U_max,     &
                  "Maximum wind speed "//                              &
                  "used in the SCM idealized hurricane wind profile.", &
                  units='m/s', default=65.)
-  call get_param(param_file, mod, "SCM_YY", CS%YY,     &
+  call get_param(param_file, mdl, "SCM_YY", CS%YY,     &
                  "Y distance of station "//                           &
                  "used in the SCM idealized hurricane wind profile.", &
                  units='m', default=50.e3)
-  call get_param(param_file, mod, "SCM_TRAN_SPEED", CS%TRAN_SPEED,     &
+  call get_param(param_file, mdl, "SCM_TRAN_SPEED", CS%TRAN_SPEED,     &
                  "Translation speed of hurricane"//                   &
                  "used in the SCM idealized hurricane wind profile.", &
                  units='m/s', default=5.0)
-  call get_param(param_file, mod, "RHO_0", CS%Rho0, &
+  call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
                  "properties, or with BOUSSINSEQ false to convert some \n"//&
@@ -148,7 +148,7 @@ subroutine SCM_idealized_hurricane_wind_init(Time, G, param_file, CS)
   ! The following parameter is a model run-time parameter which is used
   ! and logged elsewhere and so should not be logged here. The default
   ! value should be consistent with the rest of the model.
-  call get_param(param_file, mod, "GUST_CONST", CS%gust_const, &
+  call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", units="Pa", &
                  default=0.00, do_not_log=.true.)
 

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -35,7 +35,7 @@ use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA
 
 implicit none ; private
 
-character(len=40) :: mod = "adjustment_initialization" ! This module's name.
+character(len=40) :: mdl = "adjustment_initialization" ! This module's name.
 
 #include <MOM_memory.h>
 
@@ -77,7 +77,7 @@ subroutine adjustment_initialize_thickness ( h, G, GV, param_file, just_read_par
   character(len=20) :: verticalCoordinate
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "adjustment_initialization"   ! This module's name.
+  character(len=40)  :: mdl = "adjustment_initialization"   ! This module's name.
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -88,30 +88,30 @@ subroutine adjustment_initialize_thickness ( h, G, GV, param_file, just_read_par
     call MOM_mesg("initialize_thickness_uniform: setting thickness")
 
   ! Parameters used by main model initialization
-  if (.not.just_read) call log_version(param_file, mod, version, "")
-  call get_param(param_file,mod,"S_REF",S_ref,fail_if_missing=.true.,do_not_log=.true.)
-  call get_param(param_file,mod,"MIN_THICKNESS",min_thickness,'Minimum layer thickness', &
+  if (.not.just_read) call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl,"S_REF",S_ref,fail_if_missing=.true.,do_not_log=.true.)
+  call get_param(param_file, mdl,"MIN_THICKNESS",min_thickness,'Minimum layer thickness', &
          units='m',default=1.0e-3, do_not_log=just_read)
 
   ! Parameters specific to this experiment configuration
-  call get_param(param_file,mod,"REGRIDDING_COORDINATE_MODE",verticalCoordinate, &
+  call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE",verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
-  call get_param(param_file,mod,"ADJUSTMENT_WIDTH",adjustment_width,     &
+  call get_param(param_file, mdl,"ADJUSTMENT_WIDTH",adjustment_width,     &
                  "Width of frontal zone",                                &
                  units="same as x,y", fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"DELTA_S_STRAT",delta_S_strat,           &
+  call get_param(param_file, mdl,"DELTA_S_STRAT",delta_S_strat,           &
                  "Top-to-bottom salinity difference of stratification",  &
                  units="1e-3", fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"ADJUSTMENT_DELTAS",adjustment_deltaS,   &
+  call get_param(param_file, mdl,"ADJUSTMENT_DELTAS",adjustment_deltaS,   &
                  "Salinity difference across front",                     &
                  units="1e-3", fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"FRONT_WAVE_AMP",front_wave_amp,         &
+  call get_param(param_file, mdl,"FRONT_WAVE_AMP",front_wave_amp,         &
                  "Amplitude of trans-frontal wave perturbation",         &
                  units="same as x,y",default=0., do_not_log=just_read)
-  call get_param(param_file,mod,"FRONT_WAVE_LENGTH",front_wave_length,   &
+  call get_param(param_file, mdl,"FRONT_WAVE_LENGTH",front_wave_length,   &
                  "Wave-length of trans-frontal wave perturbation",       &
                  units="same as x,y",default=0., do_not_log=just_read)
-  call get_param(param_file,mod,"FRONT_WAVE_ASYM",front_wave_asym,       &
+  call get_param(param_file, mdl,"FRONT_WAVE_ASYM",front_wave_asym,       &
                  "Amplitude of frontal asymmetric perturbation",         &
                  default=0., do_not_log=just_read)
 
@@ -238,28 +238,28 @@ subroutine adjustment_initialize_temperature_salinity ( T, S, h, G, param_file, 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
   ! Parameters used by main model initialization
-  call get_param(param_file,mod,"S_REF",S_ref,'Reference salinity', units='1e-3', &
+  call get_param(param_file, mdl,"S_REF",S_ref,'Reference salinity', units='1e-3', &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"T_REF",T_ref,'Reference temperature', units='C', &
+  call get_param(param_file, mdl,"T_REF",T_ref,'Reference temperature', units='C', &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"S_RANGE",S_range,'Initial salinity range', units='1e-3', &
+  call get_param(param_file, mdl,"S_RANGE",S_range,'Initial salinity range', units='1e-3', &
                  default=2.0, do_not_log=just_read)
-  call get_param(param_file,mod,"T_RANGE",T_range,'Initial temperature range', units='C', &
+  call get_param(param_file, mdl,"T_RANGE",T_range,'Initial temperature range', units='C', &
                  default=0.0, do_not_log=just_read)
   ! Parameters specific to this experiment configuration BUT logged in previous s/r
-  call get_param(param_file,mod,"REGRIDDING_COORDINATE_MODE",verticalCoordinate, &
+  call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE",verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
-  call get_param(param_file,mod,"ADJUSTMENT_WIDTH", adjustment_width, &
+  call get_param(param_file, mdl,"ADJUSTMENT_WIDTH", adjustment_width, &
                  fail_if_missing=.not.just_read, do_not_log=.true.)
-  call get_param(param_file,mod,"ADJUSTMENT_DELTAS", adjustment_deltaS, &
+  call get_param(param_file, mdl,"ADJUSTMENT_DELTAS", adjustment_deltaS, &
                  fail_if_missing=.not.just_read, do_not_log=.true.)
-  call get_param(param_file,mod,"DELTA_S_STRAT", delta_S_strat, &
+  call get_param(param_file, mdl,"DELTA_S_STRAT", delta_S_strat, &
                  fail_if_missing=.not.just_read, do_not_log=.true.)
-  call get_param(param_file,mod,"FRONT_WAVE_AMP", front_wave_amp, default=0., &
+  call get_param(param_file, mdl,"FRONT_WAVE_AMP", front_wave_amp, default=0., &
                  do_not_log=.true.)
-  call get_param(param_file,mod,"FRONT_WAVE_LENGTH",front_wave_length, &
+  call get_param(param_file, mdl,"FRONT_WAVE_LENGTH",front_wave_length, &
                  default=0.,do_not_log=.true.)
-  call get_param(param_file,mod,"FRONT_WAVE_ASYM", front_wave_asym, default=0., &
+  call get_param(param_file, mdl,"FRONT_WAVE_ASYM", front_wave_asym, default=0., &
                  do_not_log=.true.)
 
   if (just_read) return ! All run-time parameters have been read, so return.

--- a/src/user/baroclinic_zone_initialization.F90
+++ b/src/user/baroclinic_zone_initialization.F90
@@ -13,7 +13,7 @@ implicit none ; private
 #include "version_variable.h"
 
 ! Private (module-wise) parameters
-character(len=40) :: mod = "baroclinic_zone_initialization" !< This module's name.
+character(len=40) :: mdl = "baroclinic_zone_initialization" !< This module's name.
 
 public baroclinic_zone_init_temperature_salinity
 
@@ -40,25 +40,25 @@ subroutine bcz_params(G, param_file, S_ref, dSdz, delta_S, dSdx, T_ref, dTdz, &
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
   if (.not.just_read) &
-    call log_version(param_file, mod, version, 'Initialization of an analytic baroclinic zone')
+    call log_version(param_file, mdl, version, 'Initialization of an analytic baroclinic zone')
   call openParameterBlock(param_file,'BCZIC')
-  call get_param(param_file ,mod, "S_REF", S_ref, 'Reference salinity', units='ppt', &
+  call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', units='ppt', &
                  default=35., do_not_log=just_read)
-  call get_param(param_file,mod,"DSDZ",dSdz,'Salinity stratification',units='ppt/m', &
+  call get_param(param_file, mdl,"DSDZ",dSdz,'Salinity stratification',units='ppt/m', &
                  default=0.0, do_not_log=just_read)
-  call get_param(param_file,mod,"DELTA_S",delta_S,'Salinity difference across baroclinic zone', &
+  call get_param(param_file, mdl,"DELTA_S",delta_S,'Salinity difference across baroclinic zone', &
                  units='ppt', default=0.0, do_not_log=just_read)
-  call get_param(param_file,mod,"DSDX",dSdx,'Meridional salinity difference', &
+  call get_param(param_file, mdl,"DSDX",dSdx,'Meridional salinity difference', &
                  units='ppt/'//trim(G%x_axis_units), default=0.0, do_not_log=just_read)
-  call get_param(param_file,mod,"T_REF",T_ref,'Reference temperature',units='C', &
+  call get_param(param_file, mdl,"T_REF",T_ref,'Reference temperature',units='C', &
                  default=10., do_not_log=just_read)
-  call get_param(param_file,mod,"DTDZ",dTdz,'Temperature stratification',units='C/m', &
+  call get_param(param_file, mdl,"DTDZ",dTdz,'Temperature stratification',units='C/m', &
                  default=0.0, do_not_log=just_read)
-  call get_param(param_file,mod,"DELTA_T",delta_T,'Temperature difference across baroclinic zone', &
+  call get_param(param_file, mdl,"DELTA_T",delta_T,'Temperature difference across baroclinic zone', &
                  units='C', default=0.0, do_not_log=just_read)
-  call get_param(param_file,mod,"DTDX",dTdx,'Meridional temperature difference', &
+  call get_param(param_file, mdl,"DTDX",dTdx,'Meridional temperature difference', &
                  units='C/'//trim(G%x_axis_units), default=0.0, do_not_log=just_read)
-  call get_param(param_file,mod,"L_ZONE",L_zone,'Width of baroclinic zone', &
+  call get_param(param_file, mdl,"L_ZONE",L_zone,'Width of baroclinic zone', &
                  units=G%x_axis_units, default=0.5*G%len_lat, do_not_log=just_read)
   call closeParameterBlock(param_file)
 

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -57,15 +57,15 @@ subroutine benchmark_initialize_topography(D, G, param_file, max_depth)
   real :: x, y
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "benchmark_initialize_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "benchmark_initialize_topography" ! This subroutine's name.
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   call MOM_mesg("  benchmark_initialization.F90, benchmark_initialize_topography: setting topography", 5)
 
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
 
   PI = 4.0*atan(1.0)
@@ -125,7 +125,7 @@ subroutine benchmark_initialize_thickness(h, G, GV, param_file, eqn_of_state, &
                      ! interface temperature for a given z and its derivative.
   real :: pi, z
   logical :: just_read
-  character(len=40)  :: mod = "benchmark_initialize_thickness" ! This subroutine's name.
+  character(len=40)  :: mdl = "benchmark_initialize_thickness" ! This subroutine's name.
   integer :: i, j, k, k1, is, ie, js, je, nz, itt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -244,7 +244,7 @@ subroutine benchmark_init_temperature_salinity(T, S, G, GV, param_file, &
   real :: SST       !  The initial sea surface temperature, in deg C.
   real :: lat
   logical :: just_read    ! If true, just read parameters but set nothing.
-  character(len=40)  :: mod = "benchmark_init_temperature_salinity" ! This subroutine's name.
+  character(len=40)  :: mdl = "benchmark_init_temperature_salinity" ! This subroutine's name.
   integer :: i, j, k, k1, is, ie, js, je, nz, itt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -56,7 +56,7 @@ subroutine circle_obcs_initialize_thickness(h, G, GV, param_file, just_read_para
   logical :: just_read
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "circle_obcs_initialization"   ! This module's name.
+  character(len=40)  :: mdl = "circle_obcs_initialization"   ! This module's name.
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -66,9 +66,9 @@ subroutine circle_obcs_initialize_thickness(h, G, GV, param_file, just_read_para
   if (.not.just_read) &
     call MOM_mesg("  circle_obcs_initialization.F90, circle_obcs_initialize_thickness: setting thickness", 5)
 
-  if (.not.just_read) call log_version(param_file, mod, version, "")
+  if (.not.just_read) call log_version(param_file, mdl, version, "")
   ! Parameters read by cartesian grid initialization
-  call get_param(param_file, mod, "DISK_RADIUS", diskrad, &
+  call get_param(param_file, mdl, "DISK_RADIUS", diskrad, &
                  "The radius of the initially elevated disk in the \n"//&
                  "circle_obcs test case.", units=G%x_axis_units, &
                  fail_if_missing=.not.just_read, do_not_log=just_read)

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -20,7 +20,7 @@ public dense_water_initialize_topography
 public dense_water_initialize_TS
 public dense_water_initialize_sponges
 
-character(len=40) :: mod = "dense_water_initialization"
+character(len=40) :: mdl = "dense_water_initialization"
 
 real, parameter :: default_sill  = 0.2 !< Default depth of the sill [nondim]
 real, parameter :: default_shelf = 0.4 !< Default depth of the shelf [nondim]
@@ -40,7 +40,7 @@ subroutine dense_water_initialize_topography(D, G, param_file, max_depth)
   integer :: i, j
   real :: x
 
-  call get_param(param_file, mod, "DENSE_WATER_DOMAIN_PARAMS", domain_params, &
+  call get_param(param_file, mdl, "DENSE_WATER_DOMAIN_PARAMS", domain_params, &
        "Fractional widths of all the domain sections for the dense water experiment.\n"//&
        "As a 5-element vector:\n"//&
        "  - open ocean, the section at maximum depth\n"//&
@@ -49,10 +49,10 @@ subroutine dense_water_initialize_topography(D, G, param_file, max_depth)
        "  - upslope, the upward slope accumulating dense water\n"//&
        "  - the shelf in the dense formation region.", &
        units="nondim", fail_if_missing=.true.)
-  call get_param(param_file, mod, "DENSE_WATER_SILL_DEPTH", sill_frac, &
+  call get_param(param_file, mdl, "DENSE_WATER_SILL_DEPTH", sill_frac, &
        "Depth of the sill separating downslope from upslope, as fraction of basin depth.", &
        units="nondim", default=default_sill)
-  call get_param(param_file, mod, "DENSE_WATER_SHELF_DEPTH", shelf_frac, &
+  call get_param(param_file, mdl, "DENSE_WATER_SHELF_DEPTH", shelf_frac, &
        "Depth of the shelf region accumulating dense water for overflow, as fraction of basin depth.", &
        units="nondim", default=default_shelf)
 
@@ -108,13 +108,13 @@ subroutine dense_water_initialize_TS(G, GV, param_file, eqn_of_state, T, S, h, j
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(param_file, mod, "DENSE_WATER_MLD", mld, &
+  call get_param(param_file, mdl, "DENSE_WATER_MLD", mld, &
        "Depth of unstratified mixed layer as a fraction of the water column.", &
        units="nondim", default=default_mld, do_not_log=just_read)
 
-  call get_param(param_file, mod, "S_REF", S_ref, do_not_log=.true.)
-  call get_param(param_file, mod, "S_RANGE", S_range, do_not_log=.true.)
-  call get_param(param_file, mod, "T_REF", T_ref, do_not_log=.true.)
+  call get_param(param_file, mdl, "S_REF", S_ref, do_not_log=.true.)
+  call get_param(param_file, mdl, "S_RANGE", S_range, do_not_log=.true.)
+  call get_param(param_file, mdl, "T_REF", T_ref, do_not_log=.true.)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -166,29 +166,29 @@ subroutine dense_water_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, A
 
   nz = GV%ke
 
-  call get_param(param_file, mod, "DENSE_WATER_WEST_SPONGE_TIME_SCALE", west_sponge_time_scale, &
+  call get_param(param_file, mdl, "DENSE_WATER_WEST_SPONGE_TIME_SCALE", west_sponge_time_scale, &
        "The time scale on the west (outflow) of the domain for restoring. If zero, the sponge is disabled.", &
        units="s", default=0.)
-  call get_param(param_file, mod, "DENSE_WATER_WEST_SPONGE_WIDTH", west_sponge_width, &
+  call get_param(param_file, mdl, "DENSE_WATER_WEST_SPONGE_WIDTH", west_sponge_width, &
        "The fraction of the domain in which the western (outflow) sponge is active.", &
        units="nondim", default=0.1)
-  call get_param(param_file, mod, "DENSE_WATER_EAST_SPONGE_TIME_SCALE", east_sponge_time_scale, &
+  call get_param(param_file, mdl, "DENSE_WATER_EAST_SPONGE_TIME_SCALE", east_sponge_time_scale, &
        "The time scale on the east (outflow) of the domain for restoring. If zero, the sponge is disabled.", &
        units="s", default=0.)
-  call get_param(param_file, mod, "DENSE_WATER_EAST_SPONGE_WIDTH", east_sponge_width, &
+  call get_param(param_file, mdl, "DENSE_WATER_EAST_SPONGE_WIDTH", east_sponge_width, &
        "The fraction of the domain in which the eastern (outflow) sponge is active.", &
        units="nondim", default=0.1)
 
-  call get_param(param_file, mod, "DENSE_WATER_EAST_SPONGE_SALT", S_dense, &
+  call get_param(param_file, mdl, "DENSE_WATER_EAST_SPONGE_SALT", S_dense, &
        "Salt anomaly of the dense water being formed in the overflow region.", &
        units="1e-3", default=4.0)
 
-  call get_param(param_file, mod, "DENSE_WATER_MLD", mld, default=default_mld, do_not_log=.true.)
-  call get_param(param_file, mod, "DENSE_WATER_SILL_HEIGHT", sill_height, default=default_sill, do_not_log=.true.)
+  call get_param(param_file, mdl, "DENSE_WATER_MLD", mld, default=default_mld, do_not_log=.true.)
+  call get_param(param_file, mdl, "DENSE_WATER_SILL_HEIGHT", sill_height, default=default_sill, do_not_log=.true.)
 
-  call get_param(param_file, mod, "S_REF", S_ref, do_not_log=.true.)
-  call get_param(param_file, mod, "S_RANGE", S_range, do_not_log=.true.)
-  call get_param(param_file, mod, "T_REF", T_ref, do_not_log=.true.)
+  call get_param(param_file, mdl, "S_REF", S_ref, do_not_log=.true.)
+  call get_param(param_file, mdl, "S_RANGE", S_range, do_not_log=.true.)
+  call get_param(param_file, mdl, "T_REF", T_ref, do_not_log=.true.)
 
   ! no active sponges
   if (west_sponge_time_scale <= 0. .and. east_sponge_time_scale <= 0.) return

--- a/src/user/external_gwave_initialization.F90
+++ b/src/user/external_gwave_initialization.F90
@@ -53,7 +53,7 @@ subroutine external_gwave_initialize_thickness(h, G, param_file, just_read_param
   real :: ssh_anomaly_height ! Vertical height of ssh anomaly
   real :: ssh_anomaly_width ! Lateral width of anomaly
   logical :: just_read    ! If true, just read parameters but set nothing.
-  character(len=40)  :: mod = "external_gwave_initialize_thickness" ! This subroutine's name.
+  character(len=40)  :: mdl = "external_gwave_initialize_thickness" ! This subroutine's name.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   integer :: i, j, k, is, ie, js, je, nz
@@ -66,11 +66,11 @@ subroutine external_gwave_initialize_thickness(h, G, param_file, just_read_param
   if (.not.just_read) &
     call MOM_mesg("  external_gwave_initialization.F90, external_gwave_initialize_thickness: setting thickness", 5)
 
-  if (.not.just_read) call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "SSH_ANOMALY_HEIGHT", ssh_anomaly_height, &
+  if (.not.just_read) call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "SSH_ANOMALY_HEIGHT", ssh_anomaly_height, &
                  "The vertical displacement of the SSH anomaly. ", units="m", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "SSH_ANOMALY_WIDTH", ssh_anomaly_width, &
+  call get_param(param_file, mdl, "SSH_ANOMALY_WIDTH", ssh_anomaly_width, &
                  "The lateral width of the SSH anomaly. ", units="coordinate", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
 

--- a/src/user/lock_exchange_initialization.F90
+++ b/src/user/lock_exchange_initialization.F90
@@ -58,7 +58,7 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, param_file, just_read_pa
   logical :: just_read    ! If true, just read parameters but set nothing.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "lock_exchange_initialize_thickness" ! This subroutine's name.
+  character(len=40)  :: mdl = "lock_exchange_initialize_thickness" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -68,12 +68,12 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, param_file, just_read_pa
   if (.not.just_read) &
     call MOM_mesg("  lock_exchange_initialization.F90, lock_exchange_initialize_thickness: setting thickness", 5)
 
-  if (.not.just_read) call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "FRONT_DISPLACEMENT", front_displacement, &
+  if (.not.just_read) call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "FRONT_DISPLACEMENT", front_displacement, &
                  "The vertical displacement of interfaces across the front. \n"//&
                  "A value larger in magnitude that MAX_DEPTH is truncated,", &
                  units="m", fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file, mod, "THERMOCLINE_THICKNESS", thermocline_thickness, &
+  call get_param(param_file, mdl, "THERMOCLINE_THICKNESS", thermocline_thickness, &
                  "The thickness of the thermocline in the lock exchange \n"//&
                  "experiment.  A value of zero creates a two layer system \n"//&
                  "with vanished layers in between the two inflated layers.", &

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -41,7 +41,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-character(len=40) :: mod = "seamount_initialization" ! This module's name.
+character(len=40) :: mdl = "seamount_initialization" ! This module's name.
 
 ! -----------------------------------------------------------------------------
 ! The following routines are visible to the outside world
@@ -68,14 +68,14 @@ subroutine seamount_initialize_topography ( D, G, param_file, max_depth )
   integer   :: i, j
   real      :: x, y, delta, Lx, rLx, Ly, rLy
 
-  call get_param(param_file,mod,"SEAMOUNT_DELTA",delta, &
+  call get_param(param_file, mdl,"SEAMOUNT_DELTA",delta, &
                  "Non-dimensional height of seamount.", &
                  units="non-dim", default=0.5)
-  call get_param(param_file,mod,"SEAMOUNT_X_LENGTH_SCALE",Lx, &
+  call get_param(param_file, mdl,"SEAMOUNT_X_LENGTH_SCALE",Lx, &
                  "Length scale of seamount in x-direction.\n"//&
                  "Set to zero make topography uniform in the x-direction.", &
                  units="Same as x,y", default=20.)
-  call get_param(param_file,mod,"SEAMOUNT_Y_LENGTH_SCALE",Ly, &
+  call get_param(param_file, mdl,"SEAMOUNT_Y_LENGTH_SCALE",Ly, &
                  "Length scale of seamount in y-direction.\n"//&
                  "Set to zero make topography uniform in the y-direction.", &
                  units="Same as x,y", default=0.)
@@ -125,10 +125,10 @@ subroutine seamount_initialize_thickness ( h, G, GV, param_file, just_read_param
   if (.not.just_read) &
     call MOM_mesg("MOM_initialization.F90, initialize_thickness_uniform: setting thickness")
 
-  call get_param(param_file,mod,"MIN_THICKNESS",min_thickness, &
+  call get_param(param_file, mdl,"MIN_THICKNESS",min_thickness, &
                 'Minimum thickness for layer',&
                  units='m', default=1.0e-3, do_not_log=just_read)
-  call get_param(param_file,mod,"REGRIDDING_COORDINATE_MODE",verticalCoordinate, &
+  call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE",verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
 
   ! WARNING: this routine specifies the interface heights so that the last layer
@@ -145,11 +145,11 @@ subroutine seamount_initialize_thickness ( h, G, GV, param_file, just_read_param
   select case ( coordinateMode(verticalCoordinate) )
 
   case ( REGRIDDING_LAYER, REGRIDDING_RHO ) ! Initial thicknesses for isopycnal coordinates
-    call get_param(param_file,mod,"INITIAL_SSS", S_surf, default=34., do_not_log=.true.)
-    call get_param(param_file,mod,"INITIAL_S_RANGE", S_range, default=2., do_not_log=.true.)
-    call get_param(param_file, mod, "S_REF", S_ref, default=35.0, do_not_log=.true.)
-    call get_param(param_file, mod, "TS_RANGE_S_LIGHT", S_light, default = S_Ref, do_not_log=.true.)
-    call get_param(param_file, mod, "TS_RANGE_S_DENSE", S_dense, default = S_Ref, do_not_log=.true.)
+    call get_param(param_file, mdl,"INITIAL_SSS", S_surf, default=34., do_not_log=.true.)
+    call get_param(param_file, mdl,"INITIAL_S_RANGE", S_range, default=2., do_not_log=.true.)
+    call get_param(param_file, mdl, "S_REF", S_ref, default=35.0, do_not_log=.true.)
+    call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, default = S_Ref, do_not_log=.true.)
+    call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, default = S_Ref, do_not_log=.true.)
     if (just_read) return ! All run-time parameters have been read, so return.
 
     do K=1,nz+1
@@ -227,32 +227,32 @@ subroutine seamount_initialize_temperature_salinity ( T, S, h, G, GV, param_file
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(param_file, mod, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
+  call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
-  call get_param(param_file,mod,"INITIAL_DENSITY_PROFILE", density_profile, &
+  call get_param(param_file, mdl,"INITIAL_DENSITY_PROFILE", density_profile, &
                  'Initial profile shape. Valid values are "linear", "parabolic"\n'// &
                  'and "exponential".', default='linear', do_not_log=just_read)
-  call get_param(param_file,mod,"INITIAL_SSS", S_surf, &
+  call get_param(param_file, mdl,"INITIAL_SSS", S_surf, &
                  'Initial surface salinity', units='1e-3', default=34., do_not_log=just_read)
-  call get_param(param_file,mod,"INITIAL_SST", T_surf, &
+  call get_param(param_file, mdl,"INITIAL_SST", T_surf, &
                  'Initial surface temperature', units='C', default=0., do_not_log=just_read)
-  call get_param(param_file,mod,"INITIAL_S_RANGE", S_range, &
+  call get_param(param_file, mdl,"INITIAL_S_RANGE", S_range, &
                  'Initial salinity range (bottom - surface)', units='1e-3', &
                  default=2., do_not_log=just_read)
-  call get_param(param_file,mod,"INITIAL_T_RANGE", T_range, &
+  call get_param(param_file, mdl,"INITIAL_T_RANGE", T_range, &
                  'Initial temperature range (bottom - surface)', units='C', &
                  default=0., do_not_log=just_read)
 
   select case ( coordinateMode(verticalCoordinate) )
     case ( REGRIDDING_LAYER ) ! Initial thicknesses for layer isopycnal coordinates
       ! These parameters are used in MOM_fixed_initialization.F90 when CONFIG_COORD="ts_range"
-      call get_param(param_file, mod, "T_REF", T_ref, default=10.0, do_not_log=.true.)
-      call get_param(param_file, mod, "TS_RANGE_T_LIGHT", T_light, default=T_Ref, do_not_log=.true.)
-      call get_param(param_file, mod, "TS_RANGE_T_DENSE", T_dense, default=T_Ref, do_not_log=.true.)
-      call get_param(param_file, mod, "S_REF", S_ref, default=35.0, do_not_log=.true.)
-      call get_param(param_file, mod, "TS_RANGE_S_LIGHT", S_light, default = S_Ref, do_not_log=.true.)
-      call get_param(param_file, mod, "TS_RANGE_S_DENSE", S_dense, default = S_Ref, do_not_log=.true.)
-      call get_param(param_file, mod, "TS_RANGE_RESOLN_RATIO", res_rat, default=1.0, do_not_log=.true.)
+      call get_param(param_file, mdl, "T_REF", T_ref, default=10.0, do_not_log=.true.)
+      call get_param(param_file, mdl, "TS_RANGE_T_LIGHT", T_light, default=T_Ref, do_not_log=.true.)
+      call get_param(param_file, mdl, "TS_RANGE_T_DENSE", T_dense, default=T_Ref, do_not_log=.true.)
+      call get_param(param_file, mdl, "S_REF", S_ref, default=35.0, do_not_log=.true.)
+      call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, default = S_Ref, do_not_log=.true.)
+      call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, default = S_Ref, do_not_log=.true.)
+      call get_param(param_file, mdl, "TS_RANGE_RESOLN_RATIO", res_rat, default=1.0, do_not_log=.true.)
       if (just_read) return ! All run-time parameters have been read, so return.
 
       ! Emulate the T,S used in the "ts_range" coordinate configuration code

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -33,7 +33,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-character(len=40) :: mod = "shelfwave_initialization" ! This module's name.
+character(len=40) :: mdl = "shelfwave_initialization" ! This module's name.
 
 ! -----------------------------------------------------------------------------
 ! The following routines are visible to the outside world
@@ -78,18 +78,18 @@ function register_shelfwave_OBC(param_file, CS, OBC_Reg)
 
   ! Register the tracer for horizontal advection & diffusion.
   call register_OBC(casename, param_file, OBC_Reg)
-  call get_param(param_file,mod,"F_0",CS%f0, &
+  call get_param(param_file, mdl,"F_0",CS%f0, &
                  do_not_log=.true.)
-  call get_param(param_file,mod,"LENLAT",len_lat, &
+  call get_param(param_file, mdl,"LENLAT",len_lat, &
                  do_not_log=.true.)
-  call get_param(param_file,mod,"SHELFWAVE_X_WAVELENGTH",CS%Lx, &
+  call get_param(param_file, mdl,"SHELFWAVE_X_WAVELENGTH",CS%Lx, &
                  "Length scale of shelfwave in x-direction.",&
                  units="Same as x,y", default=100.)
-  call get_param(param_file,mod,"SHELFWAVE_Y_LENGTH_SCALE",CS%Ly, &
+  call get_param(param_file, mdl,"SHELFWAVE_Y_LENGTH_SCALE",CS%Ly, &
                  "Length scale of exponential dropoff of topography\n"//&
                  "in the y-direction.", &
                  units="Same as x,y", default=50.)
-  call get_param(param_file,mod,"SHELFWAVE_Y_MODE",CS%jj, &
+  call get_param(param_file, mdl,"SHELFWAVE_Y_MODE",CS%jj, &
                  "Cross-shore wave mode.",               &
                  units="nondim", default=1.)
   CS%alpha = 1. / CS%Ly
@@ -123,9 +123,9 @@ subroutine shelfwave_initialize_topography ( D, G, param_file, max_depth )
   integer   :: i, j
   real      :: y, rLy, Ly, H0
 
-  call get_param(param_file,mod,"SHELFWAVE_Y_LENGTH_SCALE",Ly, &
+  call get_param(param_file, mdl,"SHELFWAVE_Y_LENGTH_SCALE",Ly, &
                  default=50., do_not_log=.true.)
-  call get_param(param_file,mod,"MINIMUM_DEPTH",H0, &
+  call get_param(param_file, mdl,"MINIMUM_DEPTH",H0, &
                  default=10., do_not_log=.true.)
 
   rLy = 0. ; if (Ly>0.) rLy = 1. / Ly
@@ -153,7 +153,7 @@ subroutine shelfwave_set_OBC_data(OBC, CS, G, h, Time)
   real :: my_amp, time_sec
   real :: cos_wt, cos_ky, sin_wt, sin_ky, omega, alpha
   real :: x, y, jj, kk, ll
-  character(len=40)  :: mod = "shelfwave_set_OBC_data" ! This subroutine's name.
+  character(len=40)  :: mdl = "shelfwave_set_OBC_data" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, n
   integer :: IsdB, IedB, JsdB, JedB
   type(OBC_segment_type), pointer :: segment

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -45,7 +45,7 @@ public sloshing_initialize_topography
 public sloshing_initialize_thickness
 public sloshing_initialize_temperature_salinity
 
-character(len=40)  :: mod = "sloshing_initialization" ! This module's name.
+character(len=40)  :: mdl = "sloshing_initialization" ! This module's name.
 
 ! -----------------------------------------------------------------------------
 ! This module contains the following routines
@@ -226,23 +226,23 @@ subroutine sloshing_initialize_temperature_salinity ( T, S, h, G, param_file, &
   real    :: deltah
   real    :: xi0, xi1
   logical :: just_read    ! If true, just read parameters but set nothing.
-  character(len=40)  :: mod = "initialize_temp_salt_linear" ! This subroutine's
+  character(len=40)  :: mdl = "initialize_temp_salt_linear" ! This subroutine's
                                                             ! name.
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call get_param(param_file,mod,"S_REF",S_ref,'Reference value for salinity', &
+  call get_param(param_file, mdl,"S_REF",S_ref,'Reference value for salinity', &
                  units='1e-3', fail_if_missing=.not.just_read, do_not_log=just_read)
-  call get_param(param_file,mod,"T_REF",T_ref,'Refernce value for temperature', &
+  call get_param(param_file, mdl,"T_REF",T_ref,'Refernce value for temperature', &
                  units='C', fail_if_missing=.not.just_read, do_not_log=just_read)
 
   ! The default is to assume an increase by 2 for the salinity and a uniform
   ! temperature
-  call get_param(param_file,mod,"S_RANGE",S_range,'Initial salinity range.', &
+  call get_param(param_file, mdl,"S_RANGE",S_range,'Initial salinity range.', &
                  units='1e-3', default=2.0, do_not_log=just_read)
-  call get_param(param_file,mod,"T_RANGE",T_range,'Initial temperature range', &
+  call get_param(param_file, mdl,"T_RANGE",T_range,'Initial temperature range', &
                  units='C', default=0.0, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.

--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -22,7 +22,7 @@ implicit none ; private
 #include <MOM_memory.h>
 
 ! Private (module-wise) parameters
-character(len=40) :: mod = "soliton_initialization" !< This module's name.
+character(len=40) :: mdl = "soliton_initialization" !< This module's name.
 
 public soliton_initialize_thickness
 public soliton_initialize_velocity

--- a/src/user/supercritical_initialization.F90
+++ b/src/user/supercritical_initialization.F90
@@ -30,7 +30,7 @@ subroutine supercritical_set_OBC_data(OBC, G, param_file)
   type(ocean_grid_type),  intent(in) :: G    !< The ocean's grid structure.
   type(param_file_type),  intent(in) :: param_file !< Parameter file structure
   ! Local variables
-  character(len=40)  :: mod = "supercritical_set_OBC_data" ! This subroutine's name.
+  character(len=40)  :: mdl = "supercritical_set_OBC_data" ! This subroutine's name.
   real :: zonal_flow
   integer :: i, j, k, l
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -39,7 +39,7 @@ subroutine supercritical_set_OBC_data(OBC, G, param_file)
   if (.not.associated(OBC)) call MOM_error(FATAL, 'supercritical_initialization.F90: '// &
         'supercritical_set_OBC_data() was called but OBC type was not initialized!')
 
-  call get_param(param_file, mod, "SUPERCRITICAL_ZONAL_FLOW", zonal_flow, &
+  call get_param(param_file, mdl, "SUPERCRITICAL_ZONAL_FLOW", zonal_flow, &
                  "Constant zonal flow imposed at upstream open boundary.", &
                  units="m/s", default=8.57)
 
@@ -90,7 +90,7 @@ subroutine supercritical_initialize_topography(D, G, param_file, max_depth)
   type(param_file_type),            intent(in)  :: param_file !< Parameter file structure
   real,                             intent(in)  :: max_depth  !< Maximum depth of model in m
   ! Local variables
-  character(len=40)  :: mod = "supercritical_initialize_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "supercritical_initialize_topography" ! This subroutine's name.
   real :: min_depth ! The minimum and maximum depths in m.
   real :: PI ! 3.1415...
   real :: coast_offset, coast_angle
@@ -98,13 +98,13 @@ subroutine supercritical_initialize_topography(D, G, param_file, max_depth)
 
   call MOM_mesg("  supercritical_initialization.F90, supercritical_initialize_topography: setting topography", 5)
 
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "MINIMUM_DEPTH", min_depth, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0)
-  call get_param(param_file, mod, "SUPERCRITICAL_COAST_OFFSET", coast_offset, &
+  call get_param(param_file, mdl, "SUPERCRITICAL_COAST_OFFSET", coast_offset, &
                  "The distance along the southern boundary at which the coasts angles in.", &
                  units="km", default=10.0)
-  call get_param(param_file, mod, "SUPERCRITICAL_COAST_ANGLE", coast_angle, &
+  call get_param(param_file, mdl, "SUPERCRITICAL_COAST_ANGLE", coast_angle, &
                  "The angle of the southern bondary beyond X=SUPERCRITICAL_COAST_OFFSET.", &
                  units="degrees", default=8.95)
 

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -89,7 +89,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, h, Time)
   real :: my_flux, total_area
   real :: PI
   real, allocatable :: my_area(:,:)
-  character(len=40)  :: mod = "tidal_bay_set_OBC_data" ! This subroutine's name.
+  character(len=40)  :: mdl = "tidal_bay_set_OBC_data" ! This subroutine's name.
   integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, nz, n
   integer :: IsdB, IedB, JsdB, JedB
   type(OBC_segment_type), pointer :: segment

--- a/src/user/user_change_diffusivity.F90
+++ b/src/user/user_change_diffusivity.F90
@@ -210,7 +210,7 @@ subroutine user_change_diff_init(Time, G, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "user_set_diffusivity"  ! This module's name.
+  character(len=40)  :: mdl = "user_set_diffusivity"  ! This module's name.
   character(len=200) :: mesg
   integer :: i, j, is, ie, js, je
 
@@ -226,26 +226,26 @@ subroutine user_change_diff_init(Time, G, param_file, diag, CS)
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "USER_KD_ADD", CS%Kd_add, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "USER_KD_ADD", CS%Kd_add, &
                  "A user-specified additional diffusivity over a range of \n"//&
                  "latitude and density.", units="m2 s-1", default=0.0)
   if (CS%Kd_add /= 0.0) then
-    call get_param(param_file, mod, "USER_KD_ADD_LAT_RANGE", CS%lat_range(:), &
+    call get_param(param_file, mdl, "USER_KD_ADD_LAT_RANGE", CS%lat_range(:), &
                  "Four successive values that define a range of latitudes \n"//&
                  "over which the user-specified extra diffusivity is \n"//&
                  "applied.  The four values specify the latitudes at \n"//&
                  "which the extra diffusivity starts to increase from 0, \n"//&
                  "hits its full value, starts to decrease again, and is \n"//&
                  "back to 0.", units="degree", default=-1.0e9)
-    call get_param(param_file, mod, "USER_KD_ADD_RHO_RANGE", CS%rho_range(:), &
+    call get_param(param_file, mdl, "USER_KD_ADD_RHO_RANGE", CS%rho_range(:), &
                  "Four successive values that define a range of potential \n"//&
                  "densities over which the user-given extra diffusivity \n"//&
                  "is applied.  The four values specify the density at \n"//&
                  "which the extra diffusivity starts to increase from 0, \n"//&
                  "hits its full value, starts to decrease again, and is \n"//&
                  "back to 0.", units="kg m-3", default=-1.0e9)
-    call get_param(param_file, mod, "USER_KD_ADD_USE_ABS_LAT", CS%use_abs_lat, &
+    call get_param(param_file, mdl, "USER_KD_ADD_USE_ABS_LAT", CS%use_abs_lat, &
                  "If true, use the absolute value of latitude when \n"//&
                  "checking whether a point fits into range of latitudes.", &
                  default=.false.)

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -240,9 +240,9 @@ subroutine write_user_log(param_file)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "user_initialization" ! This module's name.
+  character(len=40)  :: mdl = "user_initialization" ! This module's name.
 
-  call log_version(param_file, mod, version)
+  call log_version(param_file, mdl, version)
   first_call = .false.
 
 end subroutine write_user_log

--- a/src/user/user_revise_forcing.F90
+++ b/src/user/user_revise_forcing.F90
@@ -72,9 +72,9 @@ subroutine user_revise_forcing_init(param_file,CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "user_revise_forcing" ! This module's name.
+  character(len=40)  :: mdl = "user_revise_forcing" ! This module's name.
 
-  call log_version(param_file, mod, version)
+  call log_version(param_file, mdl, version)
 
 end subroutine user_revise_forcing_init
 


### PR DESCRIPTION
  The name "mod" had been used for various module name variables throughout the
MOM6 code, but this can cause name-space conflicts with the mod intrinsic
function, so "mod" has been renamed "mdl" throughout the MOM6 code.  All answers
are bitwise identical.