### PR TITLE
Avoid allocation/execution in horizontal_viscosity()

### DIFF
--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1229,7 +1229,8 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
                           "at the same time in MOM.")
 
   if (.not.(CS%Laplacian .or. CS%biharmonic)) then
-    call MOM_error(WARNING, &
+    ! Only issue inviscid warning if not in single column mode (usually 2x2 domain) 
+    if ( max(G%domain%niglobal, G%domain%njglobal)>2 ) call MOM_error(WARNING, &
       "hor_visc_init:  It is usually a very bad idea not to use either "//&
       "LAPLACIAN or BIHARMONIC viscosity.")
     return ! We are not using either Laplacian or Bi-harmonic lateral viscosity

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1229,7 +1229,7 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
                           "at the same time in MOM.")
 
   if (.not.(CS%Laplacian .or. CS%biharmonic)) then
-    ! Only issue inviscid warning if not in single column mode (usually 2x2 domain) 
+    ! Only issue inviscid warning if not in single column mode (usually 2x2 domain)
     if ( max(G%domain%niglobal, G%domain%njglobal)>2 ) call MOM_error(WARNING, &
       "hor_visc_init:  It is usually a very bad idea not to use either "//&
       "LAPLACIAN or BIHARMONIC viscosity.")


### PR DESCRIPTION
- When parameters LAPLACIAN and BIHARMONIC are both False, the code
  was still allocating memory and making some computations for no
  good reason.
- The single column experiments (that actually have a 2x2 grid) have
  LAPLACIAN=BIHARMONIC=False but were still getting out-of-bounds
  references because of this unnecessary computation.
- This commit avoids both allocation and execution if there is no
  both Laplacian and biharmonic viscosity are unused.
- No answers change.