### PR TITLE
Restricts scaling/initialization of h to computational domain

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -199,8 +199,12 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
     if (present(Time_in)) Time = Time_in
     ! Otherwise leave Time at its input value.
 
-    ! h will be converted from m to H below
-    h(:,:,:) = GV%Angstrom_z
+    ! This initialization should not be needed. Certainly restricting it
+    ! to the computational domain helps detect possible uninitialized
+    ! data in halos which should be covered by the pass_var(h) later.
+    !do k = 1, nz; do j = js, je; do i = is, ie
+    !  h(i,j,k) = 0.
+    !enddo
   endif
 
   ! The remaining initialization calls are done, regardless of whether the
@@ -407,9 +411,13 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
       call convert_thickness(h, G, GV, tv)
     elseif (GV%Boussinesq) then
       ! Convert h from m to thickness units (H)
-      h(:,:,:) = h(:,:,:)*GV%m_to_H
+      do k = 1, nz; do j = js, je; do i = is, ie
+        h(i,j,k) = h(i,j,k)*GV%m_to_H
+      enddo ; enddo ; enddo
     else
-      h(:,:,:) = h(:,:,:)*GV%kg_m2_to_H
+      do k = 1, nz; do j = js, je; do i = is, ie
+        h(i,j,k) = h(i,j,k)*GV%kg_m2_to_H
+      enddo ; enddo ; enddo
     endif
   endif
 


### PR DESCRIPTION
- During initialization, h was being set to an angstrom for the entire
  data domain before actually being initialized by the configuration
  specific code (e.g. user code, from file, etc.). This should be
  unnecessary and removes the ability to detect whether the real
  initialization code is actually initializing everywhere.
- The dimensional conversion of h (after initialization) was similarly
  applied on the entire data domain, where the initialization is
  expected to have been applied only for the computational domain. The
  halo are filled in shortly after with a pass_var(h).
- No answer changes.