### PR TITLE
*Corrected parentheses in APE calculation

### DIFF
--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -620,7 +620,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp)
         hbelow = 0.0
         do k=nz,1,-1
           hbelow = hbelow + h(i,j,k) * H_to_m
-          hint = (H_0APE(K) + hbelow - G%bathyT(i,j))
+          hint = H_0APE(K) + (hbelow - G%bathyT(i,j))
           hbot = H_0APE(K) - G%bathyT(i,j)
           hbot = (hbot + ABS(hbot)) * 0.5
           PE_pt(i,j,K) = 0.5 * areaTm(i,j) * (GV%Rho0*GV%g_prime(K)) * &


### PR DESCRIPTION
  Corrected the parentheses in the calculation of the interface heights relative
to the 0 APE interface heights in MOM_sum_output, to make this calculation
independent of choices by the compiler.  All the solutions themselves are
bitwise identical but the energies reported in the ocean.stats files change at
the level of roundoff.