### PR TITLE
Fixes GMwork for buoyancy mode

### DIFF
--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -1,51 +1,7 @@
-!> The module calculates interface heights, including free surface height.
+!> Functions for calculating interface heights, including free surface height.
 module MOM_interface_heights
 
-!***********************************************************************
-!*                   GNU General Public License                        *
-!* This file is a part of MOM.                                         *
-!*                                                                     *
-!* MOM is free software; you can redistribute it and/or modify it and  *
-!* are expected to follow the terms of the GNU General Public License  *
-!* as published by the Free Software Foundation; either version 2 of   *
-!* the License, or (at your option) any later version.                 *
-!*                                                                     *
-!* MOM is distributed in the hope that it will be useful, but WITHOUT  *
-!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  *
-!* or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public    *
-!* License for more details.                                           *
-!*                                                                     *
-!* For the full text of the GNU General Public License,                *
-!* write to: Free Software Foundation, Inc.,                           *
-!*           675 Mass Ave, Cambridge, MA 02139, USA.                   *
-!* or see:   http://www.gnu.org/licenses/gpl.html                      *
-!***********************************************************************
-
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*  By Robert Hallberg, February 2001                                  *
-!*                                                                     *
-!*    The subroutines here calculate the heights of interfaces in a    *
-!*  way that is consistent with the calculations in the pressure       *
-!*  gradient acceleration calculation.  In a Boussinseq model this is  *
-!*  pretty simple vertical sum, but in a non-Boussinesq model it uses  *
-!*  integrals of the equation of state.                                *
-!*                                                                     *
-!*  Macros written all in capital letters are defined in MOM_memory.h. *
-!*                                                                     *
-!*     A small fragment of the grid is shown below:                    *
-!*                                                                     *
-!*    j+1  x ^ x ^ x   At x:  q, CoriolisBu                            *
-!*    j+1  > o > o >   At ^:  v                                        *
-!*    j    x ^ x ^ x   At >:  u                                        *
-!*    j    > o > o >   At o:  h, bathyT                                *
-!*    j-1  x ^ x ^ x                                                   *
-!*        i-1  i  i+1  At x & ^:                                       *
-!*           i  i+1    At > & o:                                       *
-!*                                                                     *
-!*  The boundaries always run through q grid points (x).               *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
+! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_error_handler, only : MOM_error, FATAL
 use MOM_file_parser, only : log_version
@@ -60,12 +16,17 @@ implicit none ; private
 
 public find_eta
 
+!> Calculates the heights of sruface or all interfaces from layer thicknesses.
 interface find_eta
   module procedure find_eta_2d, find_eta_3d
 end interface find_eta
 
 contains
 
+!> Calculates the heights of all interfaces between layers, using the appropriate
+!! form for consistency with the calculation of the pressure gradient forces.
+!! Additionally, these height may be dilated for consistency with the
+!! corresponding time-average quantity from the barotropic calculation.
 subroutine find_eta_3d(h, tv, G_Earth, G, GV, eta, eta_bt, halo_size)
   type(ocean_grid_type),                      intent(in)  :: G         !< The ocean's grid
                                                                        !! structure.
@@ -82,31 +43,11 @@ subroutine find_eta_3d(h, tv, G_Earth, G, GV, eta, eta_bt, halo_size)
                                                                        !! (meter).
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)  :: eta_bt    !< optional barotropic
              !! variable that gives the "correct" free surface height (Boussinesq) or total water
-             !! column mass per unit aread (non-Boussinesq).  This is used to dilate the layer.
+             !! column mass per unit area (non-Boussinesq).  This is used to dilate the layer.
              !! thicknesses when calculating interfaceheights, in H (m or kg m-2).
   integer,                          optional, intent(in)  :: halo_size !< width of halo points on
                                                                        !! which to calculate eta.
-
-!   This subroutine determines the heights of all interfaces between layers,
-! using the appropriate form for consistency with the calculation of the
-! pressure gradient forces.  Additionally, these height may be dilated for
-! consistency with the corresponding time-average quantity from the barotropic
-! calculation.
-
-! Arguments:
-!  (in)      h       - layer thickness H (meter or kg/m2)
-!  (in)      tv      - structure pointing to thermodynamic variables
-!  (in)      G_Earth - Earth gravitational acceleration (m/s2)
-!  (in)      G       - ocean grid structure
-!  (in)      GV      - The ocean's vertical grid structure.
-!  (out)     eta     - layer interface heights (meter)
-!  (in,opt)  eta_bt  - optional barotropic variable that gives the "correct"
-!                      free surface height (Boussinesq) or total water column
-!                      mass per unit aread (non-Boussinesq).  This is used to
-!                      dilate the layer thicknesses when calculating interface
-!                      heights, in H (m or kg m-2).
-! (in,opt) halo_size - width of halo points on which to calculate eta
-
+  ! Local variables
   real :: p(SZI_(G),SZJ_(G),SZK_(G)+1)
   real :: dz_geo(SZI_(G),SZJ_(G),SZK_(G)) ! The change in geopotential height
                                           ! across a layer, in m2 s-2.
@@ -195,7 +136,10 @@ subroutine find_eta_3d(h, tv, G_Earth, G, GV, eta, eta_bt, halo_size)
 
 end subroutine find_eta_3d
 
-
+!> Calculates the free surface height, using the appropriate form for consistency
+!! with the calculation of the pressure gradient forces.  Additionally, the sea
+!! surface height may be adjusted for consistency with the corresponding
+!! time-average quantity from the barotropic calculation.
 subroutine find_eta_2d(h, tv, G_Earth, G, GV, eta, eta_bt, halo_size)
   type(ocean_grid_type),                      intent(in)  :: G        !< The ocean's grid structure.
   type(verticalGrid_type),                    intent(in)  :: GV       !< The ocean's vertical grid
@@ -212,27 +156,10 @@ subroutine find_eta_2d(h, tv, G_Earth, G, GV, eta, eta_bt, halo_size)
                                                                       !! level (z=0) (m).
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)  :: eta_bt   !< optional barotropic
                    !! variable that gives the "correct" free surface height (Boussinesq) or total
-                   !! water column mass per unit aread (non-Boussinesq), in H (m or kg m-2).
+                   !! water column mass per unit area (non-Boussinesq), in H (m or kg m-2).
   integer,                          optional, intent(in)  :: halo_size !< width of halo points on
                                                                        !! which to calculate eta.
-
-!   This subroutine determines the free surface height, using the appropriate
-! form for consistency with the calculation of the pressure gradient forces.
-! Additionally, the sea surface height may be adjusted for consistency with the
-! corresponding time-average quantity from the barotropic calculation.
-
-! Arguments:
-!  (in)       h      - layer thickness (meter or kg/m2)
-!  (in)      tv      - structure pointing to various thermodynamic variables
-!  (in)      G_Earth - Earth gravitational acceleration (m/s2)
-!  (in)      G       - ocean grid structure
-!  (in)      GV      - The ocean's vertical grid structure.
-!  (out)     eta     - free surface height relative to mean sea level (z=0) (m)
-!  (in,opt)  eta_bt  - optional barotropic variable that gives the "correct"
-!                      free surface height (Boussinesq) or total water column
-!                      mass per unit aread (non-Boussinesq), in H (m or kg m-2)
-!  (in,opt)  halo_size - width of halo points on which to calculate eta
-
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: &
     p     ! The pressure in Pa.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: &
@@ -291,7 +218,7 @@ subroutine find_eta_2d(h, tv, G_Earth, G, GV, eta, eta_bt, halo_size)
       enddo ; enddo ; enddo
     endif
     if (present(eta_bt)) then
-      !   Dilate the water column to agree with the the time-averaged column
+      !   Dilate the water column to agree with the time-averaged column
       ! mass from the barotropic solution.
 !$OMP do
       do j=js,je

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -212,7 +212,7 @@ subroutine calc_isoneutral_slopes(G, GV, h, e, tv, dt_kappa_smooth, &
         if (present_N2_u) N2_u(I,j,k) = G_Rho0 * drdz * G%mask2dCu(I,j) ! Square of Brunt-Vaisala frequency (s-2)
 
       else ! With .not.use_EOS, the layers are constant density.
-        slope_x(I,j,K) = ((e(i,j,K)-e(i+1,j,K))*G%IdxCu(I,j)) * GV%m_to_H
+        slope_x(I,j,K) = ((e(i,j,K)-e(i+1,j,K))*G%IdxCu(I,j))
       endif
 
     enddo ! I
@@ -296,7 +296,7 @@ subroutine calc_isoneutral_slopes(G, GV, h, e, tv, dt_kappa_smooth, &
         if (present_N2_v) N2_v(i,J,k) = G_Rho0 * drdz * G%mask2dCv(i,J) ! Square of Brunt-Vaisala frequency (s-2)
 
       else ! With .not.use_EOS, the layers are constant density.
-        slope_y(i,J,K) = ((e(i,j,K)-e(i,j+1,K))*G%IdyCv(i,J)) * GV%m_to_H
+        slope_y(i,J,K) = ((e(i,j,K)-e(i,j+1,K))*G%IdyCv(i,J))
       endif
 
     enddo ! i

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -16,20 +16,21 @@ public calc_isoneutral_slopes
 
 contains
 
+!> Calculate isopycnal slopes, and optionally return N2 used in calculation.
 subroutine calc_isoneutral_slopes(G, GV, h, e, tv, dt_kappa_smooth, &
                                   slope_x, slope_y, N2_u, N2_v, halo)
   type(ocean_grid_type),                       intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),                     intent(in)    :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),    intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1),  intent(in)    :: e
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1),  intent(in)    :: e    !< Interface heights (m)
   type(thermo_var_ptrs),                       intent(in)    :: tv   !< A structure pointing to various thermodynamic variables
   real,                                        intent(in)    :: dt_kappa_smooth
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: slope_x
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)+1), intent(inout) :: slope_y
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: N2_u
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)+1), intent(inout) :: N2_v
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: slope_x !< Isopycnal slope in i-direction (nondim)
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)+1), intent(inout) :: slope_y !< Isopycnal slope in j-direction (nondim)
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: N2_u !< Brunt-Vaisala frequency squared at u-points (s-2)
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)+1), intent(inout) :: N2_v !< Brunt-Vaisala frequency squared at u-points (s-2)
   optional                                                   :: N2_u, N2_v
-  integer, optional,                           intent(in)    :: halo
+  integer, optional,                           intent(in)    :: halo !< Halo width over which to compute
   ! Local variables
   real, dimension(SZI_(G), SZJ_(G), SZK_(G)) :: &
     T, &          ! The temperature (or density) in C, with the values in
@@ -303,32 +304,20 @@ subroutine calc_isoneutral_slopes(G, GV, h, e, tv, dt_kappa_smooth, &
 
 end subroutine calc_isoneutral_slopes
 
+!> Returns tracer arrays (nominally T and S) with massless layers filled with
+!! sensible values, by diffusing vertically with a small but constant diffusivity.
 subroutine vert_fill_TS(h, T_in, S_in, kappa, dt, T_f, S_f, G, GV, halo_here)
   type(ocean_grid_type),                    intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),                  intent(in)    :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: T_in
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: S_in
-  real,                                     intent(in)    :: kappa
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: T_in !< Temperature (deg C)
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: S_in !< Salinity (psu)
+  real,                                     intent(in)    :: kappa !< A vertical diffusivity to use for smoothing (m2 s-1)
   real,                                     intent(in)    :: dt   !< The time increment, in s.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out)   :: T_f
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out)   :: S_f
-  integer,                        optional, intent(in)    :: halo_here
-!    This subroutine fills massless layers with sensible values of two
-!*  tracer arrays (nominally temperature and salinity) by diffusing
-!*  vertically with a (small?) constant diffusivity.
-
-! Arguments: h - Layer thickness, in m or kg m-2.
-!  (in)      T_in - The input temperature, in K.
-!  (in)      S_in - The input salinity, in psu.
-!  (in)      kappa - The diapycnal diffusivity, in m2 s-1.
-!  (in)      dt - Time increment in s.
-!  (out)     T_f - The filled temperature, in K.
-!  (out)     S_f - The filled salinity, in psu.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in,opt)  halo_here - the number of halo points to work on, 0 by default.
-
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out)   :: T_f  !< Filled temperature (deg C)
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out)   :: S_f  !< Filed salinity (psu)
+  integer,                        optional, intent(in)    :: halo_here !< Halo width over which to compute
+  ! Local variables
   real :: ent(SZI_(G),SZK_(G)+1)   ! The diffusive entrainment (kappa*dt)/dz
                                    ! between layers in a timestep in m or kg m-2.
   real :: b1(SZI_(G)), d1(SZI_(G)) ! b1, c1, and d1 are variables used by the

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -161,6 +161,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, MEKE, VarMix, CDp, CS
       (dt*(G%IdxCv(i,J)*G%IdxCv(i,J) + G%IdyCv(i,J)*G%IdyCv(i,J)))
   enddo ; enddo
 
+  ! Calculates interface heights, e, in m.
   call find_eta(h, tv, GV%g_Earth, G, GV, e, halo_size=1)
 
   ! Set the diffusivities.
@@ -479,10 +480,10 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   real :: Sfn_unlim_v(SZI_(G), SZK_(G)+1)  ! Streamfunction for v-points (m3 s-1)
   real :: slope2_Ratio_u(SZIB_(G), SZK_(G)+1) ! The ratio of the slope squared to slope_max squared.
   real :: slope2_Ratio_v(SZI_(G), SZK_(G)+1)  ! The ratio of the slope squared to slope_max squared.
-  real :: Sfn           ! The overturning streamfunction, in m3 s-1.
+  real :: Sfn_in_h      ! The overturning streamfunction, in H m2 s-1 (note units different from other Sfn vars).
   real :: Sfn_safe      ! The streamfunction that goes linearly back to 0 at the
                         ! top.  This is a good thing to use when the slope is
-                        ! so large as to be meaningless.
+                        ! so large as to be meaningless (m3 s-1).
   real :: Slope         ! The slope of density surfaces, calculated in a way
                         ! that is always between -1 and 1.
   real :: mag_grad2     ! The squared magnitude of the 3-d density gradient, in kg2 m-8.
@@ -513,7 +514,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   H_to_m = GV%H_to_m ; m_to_H = GV%m_to_H
   I4dt = 0.25 / dt
   I_slope_max2 = 1.0 / (CS%slope_max**2)
-  G_scale = GV%g_Earth * H_to_m
+  G_scale = GV%g_Earth
   h_neglect = GV%H_subroundoff ; h_neglect2 = h_neglect**2
   dz_neglect = GV%H_subroundoff*H_to_m
   G_rho0 = GV%g_Earth / GV%Rho0
@@ -588,7 +589,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
 !$OMP                                  drdx,mag_grad2,Slope,slope2_Ratio_u,hN2_u,   &
 !$OMP                                  Sfn_unlim_u,drdi_u,drdkDe_u,h_harm,c2_h_u,   &
-!$OMP                                  Sfn_safe,Sfn_est,Sfn,calc_derivatives)
+!$OMP                                  Sfn_safe,Sfn_est,Sfn_in_h,calc_derivatives)
   do j=js,je
     do I=is-1,ie ; hN2_u(I,1) = 0. ; hN2_u(I,nz+1) = 0. ; enddo
     do K=nz,2,-1
@@ -692,8 +693,8 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
             endif
             if (CS%id_slope_x > 0) CS%diagSlopeX(I,j,k) = Slope
 
-            ! Estimate the streamfunction at each interface.
-            Sfn_unlim_u(I,K) = -((KH_u(I,j,K)*G%dy_Cu(I,j))*Slope) * m_to_H
+            ! Estimate the streamfunction at each interface (m3 s-1).
+            Sfn_unlim_u(I,K) = -((KH_u(I,j,K)*G%dy_Cu(I,j))*Slope)
 
             ! Avoid moving dense water upslope from below the level of
             ! the bottom on the receiving side.
@@ -719,10 +720,10 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
             if (present_slope_x) then
               Slope = slope_x(I,j,k)
             else
-              Slope = ((e(i,j,K)-e(i+1,j,K))*G%IdxCu(I,j)) * m_to_H * G%mask2dCu(I,j)
+              Slope = ((e(i,j,K)-e(i+1,j,K))*G%IdxCu(I,j)) * G%mask2dCu(I,j)
             endif
             if (CS%id_slope_x > 0) CS%diagSlopeX(I,j,k) = Slope
-            Sfn_unlim_u(I,K) = ((KH_u(I,j,K)*G%dy_Cu(I,j))*Slope) * m_to_H
+            Sfn_unlim_u(I,K) = ((KH_u(I,j,K)*G%dy_Cu(I,j))*Slope)
             hN2_u(I,K) = GV%g_prime(K)
           endif ! if (use_EOS)
         else ! if (k > nk_linear)
@@ -735,7 +736,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
     if (CS%use_FGNV_streamfn) then
       do k=1,nz ; do I=is-1,ie ; if (G%mask2dCu(I,j)>0.) then
-        h_harm = GV%H_to_m * max( h_neglect, &
+        h_harm = H_to_m * max( h_neglect, &
               2. * h(i,j,k) * h(i+1,j,k) / ( ( h(i,j,k) + h(i+1,j,k) ) + h_neglect ) )
         c2_h_u(I,k) = CS%FGNV_scale * ( 0.5*( cg1(i,j) + cg1(i+1,j) ) )**2 / h_harm
       endif ; enddo ; enddo
@@ -758,9 +759,9 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
             if (uhtot(I,j) <= 0.0) then
               ! The transport that must balance the transport below is positive.
-              Sfn_safe = uhtot(I,j) * (1.0 - h_frac(i,j,k))
+              Sfn_safe = uhtot(I,j) * (1.0 - h_frac(i,j,k)) * H_to_m
             else !  (uhtot(I,j) > 0.0)
-              Sfn_safe = uhtot(I,j) * (1.0 - h_frac(i+1,j,k))
+              Sfn_safe = uhtot(I,j) * (1.0 - h_frac(i+1,j,k)) * H_to_m
             endif
 
             ! The actual streamfunction at each interface.
@@ -771,15 +772,15 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
           ! Make sure that there is enough mass above to allow the streamfunction
           ! to satisfy the boundary condition of 0 at the surface.
-          Sfn = min(max(Sfn_est, -h_avail_rsum(i,j,K)), h_avail_rsum(i+1,j,K))
+          Sfn_in_h = min(max(Sfn_est * m_to_H, -h_avail_rsum(i,j,K)), h_avail_rsum(i+1,j,K))
 
           ! The actual transport is limited by the mass available in the two
           ! neighboring grid cells.
-          uhD(I,j,k) = max(min((Sfn - uhtot(I,j)), h_avail(i,j,k)), &
+          uhD(I,j,k) = max(min((Sfn_in_h - uhtot(I,j)), h_avail(i,j,k)), &
                            -h_avail(i+1,j,k))
 
           if (CS%id_sfn_x>0) diag_sfn_x(I,j,K) = diag_sfn_x(I,j,K+1) + uhD(I,j,k)
-!         sfn_x(I,j,K) = max(min(Sfn, uhtot(I,j)+h_avail(i,j,k)), &
+!         sfn_x(I,j,K) = max(min(Sfn_in_h, uhtot(I,j)+h_avail(i,j,k)), &
 !                            uhtot(I,j)-h_avail(i+1,j,K))
 !         sfn_slope_x(I,j,K) = max(uhtot(I,j)-h_avail(i+1,j,k), &
 !                                  min(uhtot(I,j)+h_avail(i,j,k), &
@@ -813,7 +814,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
           !   A second order centered estimate is used for the density transfered
           ! between water columns.
 
-          Work_u(I,j) = Work_u(I,j) + G_scale * &
+          Work_u(I,j) = Work_u(I,j) + ( G_scale * H_to_m ) * &
             ( uhtot(I,j) * drdkDe_u(I,K) - &
               (uhD(I,j,K) * drdi_u(I,K)) * 0.25 * &
               ((e(i,j,K) + e(i,j,K+1)) + (e(i+1,j,K) + e(i+1,j,K+1))) )
@@ -836,7 +837,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
 !$OMP                                  drdy,mag_grad2,Slope,slope2_Ratio_v,hN2_v,   &
 !$OMP                                  Sfn_unlim_v,drdj_v,drdkDe_v,h_harm,c2_h_v,   &
-!$OMP                                  Sfn_safe,Sfn_est,Sfn,calc_derivatives)
+!$OMP                                  Sfn_safe,Sfn_est,Sfn_in_h,calc_derivatives)
   do J=js-1,je
     do K=nz,2,-1
       if (find_work .and. .not.(use_EOS)) then
@@ -937,8 +938,8 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
             endif
             if (CS%id_slope_y > 0) CS%diagSlopeY(I,j,k) = Slope
 
-            ! Estimate the streamfunction at each interface.
-            Sfn_unlim_v(i,K) = -((KH_v(i,J,K)*G%dx_Cv(i,J))*Slope) * m_to_H
+            ! Estimate the streamfunction at each interface (m3 s-1).
+            Sfn_unlim_v(i,K) = -((KH_v(i,J,K)*G%dx_Cv(i,J))*Slope)
 
             ! Avoid moving dense water upslope from below the level of
             ! the bottom on the receiving side.
@@ -964,10 +965,10 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
             if (present_slope_y) then
               Slope = slope_y(i,J,k)
             else
-              Slope = ((e(i,j,K)-e(i,j+1,K))*G%IdyCv(i,J)) * m_to_H * G%mask2dCv(i,J)
+              Slope = ((e(i,j,K)-e(i,j+1,K))*G%IdyCv(i,J)) * G%mask2dCv(i,J)
             endif
             if (CS%id_slope_y > 0) CS%diagSlopeY(I,j,k) = Slope
-            Sfn_unlim_v(i,K) = ((KH_v(i,J,K)*G%dx_Cv(i,J))*Slope) * m_to_H
+            Sfn_unlim_v(i,K) = ((KH_v(i,J,K)*G%dx_Cv(i,J))*Slope)
             hN2_v(i,K) = GV%g_prime(K)
           endif ! if (use_EOS)
         else ! if (k > nk_linear)
@@ -980,7 +981,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
     if (CS%use_FGNV_streamfn) then
       do k=1,nz ; do i=is,ie ; if (G%mask2dCv(i,J)>0.) then
-        h_harm = GV%H_to_m * max( h_neglect, &
+        h_harm = H_to_m * max( h_neglect, &
               2. * h(i,j,k) * h(i,j+1,k) / ( ( h(i,j,k) + h(i,j+1,k) ) + h_neglect ) )
         c2_h_v(i,k) = CS%FGNV_scale * ( 0.5*( cg1(i,j) + cg1(i,j+1) ) )**2 / h_harm
       endif ; enddo ; enddo
@@ -1003,9 +1004,9 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
             if (vhtot(i,J) <= 0.0) then
               ! The transport that must balance the transport below is positive.
-              Sfn_safe = vhtot(i,J) * (1.0 - h_frac(i,j,k))
+              Sfn_safe = vhtot(i,J) * (1.0 - h_frac(i,j,k)) * H_to_m
             else !  (vhtot(I,j) > 0.0)
-              Sfn_safe = vhtot(i,J) * (1.0 - h_frac(i,j+1,k))
+              Sfn_safe = vhtot(i,J) * (1.0 - h_frac(i,j+1,k)) * H_to_m
             endif
 
             ! The actual streamfunction at each interface.
@@ -1016,15 +1017,15 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
           ! Make sure that there is enough mass above to allow the streamfunction
           ! to satisfy the boundary condition of 0 at the surface.
-          Sfn = min(max(Sfn_est, -h_avail_rsum(i,j,K)), h_avail_rsum(i,j+1,K))
+          Sfn_in_h = min(max(Sfn_est * m_to_H, -h_avail_rsum(i,j,K)), h_avail_rsum(i,j+1,K))
 
           ! The actual transport is limited by the mass available in the two
           ! neighboring grid cells.
-          vhD(i,J,k) = max(min((Sfn - vhtot(i,J)), h_avail(i,j,k)), &
+          vhD(i,J,k) = max(min((Sfn_in_h - vhtot(i,J)), h_avail(i,j,k)), &
                            -h_avail(i,j+1,k))
 
           if (CS%id_sfn_y>0) diag_sfn_y(i,J,K) = diag_sfn_y(i,J,K+1) + vhD(i,J,k)
-!         sfn_y(i,J,K) = max(min(Sfn, vhtot(i,J)+h_avail(i,j,k)), &
+!         sfn_y(i,J,K) = max(min(Sfn_in_h, vhtot(i,J)+h_avail(i,j,k)), &
 !                            vhtot(i,J)-h_avail(i,j+1,k))
 !         sfn_slope_y(i,J,K) = max(vhtot(i,J)-h_avail(i,j+1,k), &
 !                                  min(vhtot(i,J)+h_avail(i,j,k), &
@@ -1058,7 +1059,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
           !   A second order centered estimate is used for the density transfered
           ! between water columns.
 
-          Work_v(i,J) = Work_v(i,J) + G_scale * &
+          Work_v(i,J) = Work_v(i,J) + ( G_scale * H_to_m ) * &
             ( vhtot(i,J) * drdkDe_v(i,K) - &
              (vhD(i,J,K) * drdj_v(i,K)) * 0.25 * &
              ((e(i,j,K) + e(i,j,K+1)) + (e(i,j+1,K) + e(i,j+1,K+1))) )


### PR DESCRIPTION
- When the model is in buoyancy mode (stacked shallow water), which has
  no equation of state, the GM work term was not being calculated
  properly.
  - Quantities used in the expression for the work term were left unset
    which has been fixed.
- This commit also fixes the FGNV stream function option when used in
  buoyancy mode: the thickness diffusion code bypassed the used of the
  stream function variables which is used in all the other modes and
  which is necessary for FGNV to work.
  - The buoyancy mode now uses the stream function variables like the
    other modes.
- Tested with and without USE_STORED_SLOPES, USE_VARIABLE_MIXING,
  KHTH_USE_FGNV_STREAMFUNCTION and USE_MEKE (which is a client of GMwork).
- This fixes both the diagnostic and the source used in MEKE.