### PR TITLE
Tracer fluxes use new coupler_type functionalities

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -359,6 +359,15 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, state, 
     fluxes%dt_buoy_accum = 0.0
   endif   ! endif for allocation and initialization
 
+  if ((.not.coupler_type_initialized(fluxes%tr_fluxes)) .and. &
+      coupler_type_initialized(IOB%fluxes)) &
+    call coupler_type_spawn(IOB%fluxes, fluxes%tr_fluxes, &
+                            (/is,is,ie,ie/), (/js,js,je,je/))
+  !   It might prove valuable to use the same array extents as the rest of the
+  ! ocean model, rather than using haloless arrays, in which case the last line
+  ! would be: (             (/isd,is,ie,ied/), (/jsd,js,je,jed/))
+
+
   if (CS%allow_flux_adjustments) then
    fluxes%heat_added(:,:)=0.0
    fluxes%salt_flux_added(:,:)=0.0
@@ -732,15 +741,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, state, 
     enddo ; enddo
   endif
 
-  if (.not.coupler_type_initialized(fluxes%tr_fluxes)) &
-    call coupler_type_spawn(IOB%fluxes, fluxes%tr_fluxes, &
-                            (/is,is,ie,ie/), (/js,js,je,je/))
-
-  call coupler_type_copy_data(IOB%fluxes, fluxes%tr_fluxes)
-  !   At a later time, it might prove valuable to translate this array into the
-  ! index space of the ocean model, rather than leaving it in the (haloless)
-  ! arrays that come in from the surface forcing.
-!###  fluxes%tr_fluxes => IOB%fluxes
+  if (coupler_type_initialized(fluxes%tr_fluxes) .and. &
+      coupler_type_initialized(IOB%fluxes)) &
+    call coupler_type_copy_data(IOB%fluxes, fluxes%tr_fluxes)
 
   if (CS%allow_flux_adjustments) then
     ! Apply adjustments to fluxes

--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -67,12 +67,15 @@ use MOM_restart,          only : restart_init_end, save_restart, restore_state
 use MOM_string_functions, only : uppercase
 use MOM_spatial_means,    only : adjust_area_mean_to_zero
 use MOM_variables,        only : surface
-use user_revise_forcing,  only : user_alter_forcing, user_revise_forcing_init, user_revise_forcing_CS
+use user_revise_forcing,  only : user_alter_forcing, user_revise_forcing_init
+use user_revise_forcing,  only : user_revise_forcing_CS
 
-use coupler_types_mod,        only : coupler_2d_bc_type
-use data_override_mod,        only : data_override_init, data_override
-use fms_mod,                  only : read_data, stdout
-use mpp_mod,                  only : mpp_chksum
+use coupler_types_mod,    only : coupler_2d_bc_type, coupler_type_write_chksums
+use coupler_types_mod,    only : coupler_type_initialized, coupler_type_spawn
+use coupler_types_mod,    only : coupler_type_copy_data
+use data_override_mod,    only : data_override_init, data_override
+use fms_mod,              only : read_data, stdout
+use mpp_mod,              only : mpp_chksum
 use time_interp_external_mod, only : init_external_field, time_interp_external
 use time_interp_external_mod, only : time_interp_external_init
 
@@ -729,10 +732,15 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, state, 
     enddo ; enddo
   endif
 
+  if (.not.coupler_type_initialized(fluxes%tr_fluxes)) &
+    call coupler_type_spawn(IOB%fluxes, fluxes%tr_fluxes, &
+                            (/is,is,ie,ie/), (/js,js,je,je/))
+
+  call coupler_type_copy_data(IOB%fluxes, fluxes%tr_fluxes)
   !   At a later time, it might prove valuable to translate this array into the
   ! index space of the ocean model, rather than leaving it in the (haloless)
   ! arrays that come in from the surface forcing.
-  fluxes%tr_fluxes => IOB%fluxes
+!###  fluxes%tr_fluxes => IOB%fluxes
 
   if (CS%allow_flux_adjustments) then
     ! Apply adjustments to fluxes
@@ -1227,16 +1235,9 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
       write(outunit,100) 'iobt%area_berg      ', mpp_chksum( iobt%area_berg      )
     if (ASSOCIATED(iobt%mass_berg)) &
       write(outunit,100) 'iobt%mass_berg      ', mpp_chksum( iobt%mass_berg      )
-
 100 FORMAT("   CHECKSUM::",A20," = ",Z20)
-    do n = 1, iobt%fluxes%num_bcs  !{
-       do m = 1, iobt%fluxes%bc(n)%num_fields  !{
-          write(outunit,101) 'iobt%',trim(iobt%fluxes%bc(n)%name), &
-               trim(iobt%fluxes%bc(n)%field(m)%name), &
-               mpp_chksum(iobt%fluxes%bc(n)%field(m)%values)
-       enddo  !} m
-    enddo  !} n
-101 FORMAT("   CHECKSUM::",A6,a,'%',a," = ",Z20)
+
+    call coupler_type_write_chksums(iobt%fluxes, outunit, 'iobt%')
 
 end subroutine ice_ocn_bnd_type_chksum
 

--- a/config_src/ice_solo_driver/MOM_surface_forcing.F90
+++ b/config_src/ice_solo_driver/MOM_surface_forcing.F90
@@ -254,7 +254,6 @@ subroutine set_forcing(state, fluxes, day_start, day_interval, G, CS)
     endif
   endif
   if (associated(CS%tracer_flow_CSp)) then
-    if (.not.associated(fluxes%tr_fluxes)) allocate(fluxes%tr_fluxes)
     call call_tracer_set_forcing(state, fluxes, day_start, day_interval, G, CS%tracer_flow_CSp)
   endif
 

--- a/config_src/ice_solo_driver/atmos_ocean_fluxes.F90
+++ b/config_src/ice_solo_driver/atmos_ocean_fluxes.F90
@@ -14,18 +14,25 @@ public :: aof_set_coupler_flux
 
 contains
 
-function aof_set_coupler_flux(name, flux_type, implementation, atm_tr_index, &
-     param, flag, ice_restart_file, ocean_restart_file, &
-     units, caller)  result (coupler_index)
-  character(len=*), intent(in)  :: name, flux_type, implementation
-  integer, intent(in), optional :: atm_tr_index
-  real, intent(in), dimension(:), optional    :: param
-  logical, intent(in), dimension(:), optional :: flag
-  character(len=*), intent(in), optional :: &
-    ice_restart_file, ocean_restart_file, units, caller
-  integer :: coupler_index
+function aof_set_coupler_flux(name, flux_type, implementation, atm_tr_index,     &
+                              param, flag, ice_restart_file, ocean_restart_file, &
+                              units, caller, verbosity)  result (coupler_index)
+
+  character(len=*), intent(in)                          :: name
+  character(len=*), intent(in)                          :: flux_type
+  character(len=*), intent(in)                          :: implementation
+  integer,          intent(in), optional                :: atm_tr_index
+  real,             intent(in), dimension(:), optional  :: param
+  logical,          intent(in), dimension(:), optional  :: flag
+  character(len=*), intent(in), optional                :: ice_restart_file
+  character(len=*), intent(in), optional                :: ocean_restart_file
+  character(len=*), intent(in), optional                :: units
+  character(len=*), intent(in), optional                :: caller
+  integer,          intent(in), optional                :: verbosity
+
   ! None of these arguments are used for anything.
 
+  integer :: coupler_index
   coupler_index = -1
 
 end function aof_set_coupler_flux

--- a/config_src/ice_solo_driver/coupler_types.F90
+++ b/config_src/ice_solo_driver/coupler_types.F90
@@ -639,10 +639,9 @@ subroutine CT_spawn_1d_2d(var_in, var, idim, jdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
-          var%bc(n)%field(m)%values(:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+        var%bc(n)%field(m)%values(:,:) = 0.0
       enddo
     enddo
 
@@ -746,10 +745,9 @@ subroutine CT_spawn_1d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
-          var%bc(n)%field(m)%values(:,:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+        var%bc(n)%field(m)%values(:,:,:) = 0.0
       enddo
     enddo
 
@@ -845,10 +843,9 @@ subroutine CT_spawn_2d_2d(var_in, var, idim, jdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
-          var%bc(n)%field(m)%values(:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+        var%bc(n)%field(m)%values(:,:) = 0.0
       enddo
     enddo
 
@@ -952,10 +949,9 @@ subroutine CT_spawn_2d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
-          var%bc(n)%field(m)%values(:,:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+        var%bc(n)%field(m)%values(:,:,:) = 0.0
       enddo
     enddo
 
@@ -1051,10 +1047,9 @@ subroutine CT_spawn_3d_2d(var_in, var, idim, jdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
-          var%bc(n)%field(m)%values(:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+        var%bc(n)%field(m)%values(:,:) = 0.0
       enddo
     enddo
 
@@ -1157,10 +1152,10 @@ subroutine CT_spawn_3d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
-          var%bc(n)%field(m)%values(:,:,:) = 0.0
-        endif
+
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+        var%bc(n)%field(m)%values(:,:,:) = 0.0
       enddo
     enddo
 

--- a/config_src/ice_solo_driver/coupler_types.F90
+++ b/config_src/ice_solo_driver/coupler_types.F90
@@ -2068,7 +2068,7 @@ subroutine CT_extract_data_2d(var_in, bc_index, field_index, array_out, &
             (2*halo + 1 + var_in%iec - var_in%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var_in%isc-halo)  
+    i_off = 1 - (var_in%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2101,7 +2101,7 @@ subroutine CT_extract_data_2d(var_in, bc_index, field_index, array_out, &
             (2*halo + 1 + var_in%jec - var_in%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var_in%jsc-halo)  
+    j_off = 1 - (var_in%jsc-halo)
   endif
 
   do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
@@ -2187,7 +2187,7 @@ subroutine CT_extract_data_3d_2d(var_in, bc_index, field_index, k_in, array_out,
             (2*halo + 1 + var_in%iec - var_in%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var_in%isc-halo)  
+    i_off = 1 - (var_in%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2220,7 +2220,7 @@ subroutine CT_extract_data_3d_2d(var_in, bc_index, field_index, k_in, array_out,
             (2*halo + 1 + var_in%jec - var_in%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var_in%jsc-halo)  
+    j_off = 1 - (var_in%jsc-halo)
   endif
 
   if ((k_in > var_in%ke) .or. (k_in < var_in%ks)) then
@@ -2311,7 +2311,7 @@ subroutine CT_extract_data_3d(var_in, bc_index, field_index, array_out, &
             (2*halo + 1 + var_in%iec - var_in%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var_in%isc-halo)  
+    i_off = 1 - (var_in%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2344,7 +2344,7 @@ subroutine CT_extract_data_3d(var_in, bc_index, field_index, array_out, &
             (2*halo + 1 + var_in%jec - var_in%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var_in%jsc-halo)  
+    j_off = 1 - (var_in%jsc-halo)
   endif
 
   if (size(array_out,3) /= 1 + var_in%ke - var_in%ks) then
@@ -2435,7 +2435,7 @@ subroutine CT_set_data_2d(array_in, bc_index, field_index, var, &
             (2*halo + 1 + var%iec - var%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var%isc-halo)  
+    i_off = 1 - (var%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2468,7 +2468,7 @@ subroutine CT_set_data_2d(array_in, bc_index, field_index, var, &
             (2*halo + 1 + var%jec - var%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var%jsc-halo)  
+    j_off = 1 - (var%jsc-halo)
   endif
 
   do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
@@ -2551,7 +2551,7 @@ subroutine CT_set_data_2d_3d(array_in, bc_index, field_index, k_out, var, &
             (2*halo + 1 + var%iec - var%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var%isc-halo)  
+    i_off = 1 - (var%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2584,7 +2584,7 @@ subroutine CT_set_data_2d_3d(array_in, bc_index, field_index, k_out, var, &
             (2*halo + 1 + var%jec - var%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var%jsc-halo)  
+    j_off = 1 - (var%jsc-halo)
   endif
 
   if ((k_out > var%ke) .or. (k_out < var%ks)) then
@@ -2672,7 +2672,7 @@ subroutine CT_set_data_3d(array_in, bc_index, field_index, var, &
             (2*halo + 1 + var%iec - var%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var%isc-halo)  
+    i_off = 1 - (var%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2705,7 +2705,7 @@ subroutine CT_set_data_3d(array_in, bc_index, field_index, var, &
             (2*halo + 1 + var%jec - var%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var%jsc-halo)  
+    j_off = 1 - (var%jsc-halo)
   endif
 
   if (size(array_in,3) /= 1 + var%ke - var%ks) then
@@ -2717,7 +2717,7 @@ subroutine CT_set_data_3d(array_in, bc_index, field_index, var, &
   k_off = 1 - var%ks
 
   do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
-    var%bc(bc_index)%field(field_index)%values(i,j,k) = scale * array_in(i+i_off,j+j_off,k+k_off) 
+    var%bc(bc_index)%field(field_index)%values(i,j,k) = scale * array_in(i+i_off,j+j_off,k+k_off)
   enddo ; enddo ; enddo
 
 end subroutine CT_set_data_3d
@@ -3169,7 +3169,7 @@ end subroutine CT_write_chksums_3d
 function CT_initialized_1d(var)
   type(coupler_1d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
   logical :: CT_initialized_1d  !< The return value, indicating whether this type has been initialized
-  
+
   CT_initialized_1d = var%set
 end function CT_initialized_1d
 
@@ -3177,7 +3177,7 @@ end function CT_initialized_1d
 function CT_initialized_2d(var)
   type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
   logical :: CT_initialized_2d  !< The return value, indicating whether this type has been initialized
-  
+
   CT_initialized_2d = var%set
 end function CT_initialized_2d
 
@@ -3185,7 +3185,7 @@ end function CT_initialized_2d
 function CT_initialized_3d(var)
   type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
   logical :: CT_initialized_3d  !< The return value, indicating whether this type has been initialized
-  
+
   CT_initialized_3d = var%set
 end function CT_initialized_3d
 
@@ -3195,7 +3195,7 @@ subroutine CT_destructor_1d(var)
   type(coupler_1d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
 
   integer :: m, n
- 
+
   if (var%num_bcs > 0) then
     do n = 1, var%num_bcs
       do m = 1, var%bc(n)%num_fields
@@ -3215,7 +3215,7 @@ subroutine CT_destructor_2d(var)
   type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
 
   integer :: m, n
- 
+
   if (var%num_bcs > 0) then
     do n = 1, var%num_bcs
       do m = 1, var%bc(n)%num_fields
@@ -3236,7 +3236,7 @@ subroutine CT_destructor_3d(var)
   type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
 
   integer :: m, n
- 
+
   if (var%num_bcs > 0) then
     do n = 1, var%num_bcs
       do m = 1, var%bc(n)%num_fields

--- a/config_src/ice_solo_driver/coupler_types.F90
+++ b/config_src/ice_solo_driver/coupler_types.F90
@@ -1,88 +1,3254 @@
 module coupler_types_mod
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*    This file is a part of MOM.  See MOM.F90 for licensing.          *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
-!
-! This file was modified for use in MOM from MOM4 code by Stephen Griffies.
-!
-! This module contains simplified type declarations for the coupler
-! of an ocean-only model. With mom4, this is used with ocean_solo_mod
-! as the driver, and with MOM it is used with MOM_driver.
-!
-! This module contains simplified type declarations for the coupler
-! of an ocean-only model. With mom4, this is used with ocean_solo_mod
-! as the driver, and with MOM it is used with MOM_driver.
+!-----------------------------------------------------------------------
+! This file is part of MOM6. See LICENSE.md for the license.
+!-----------------------------------------------------------------------
+
+!   This module contains the coupler-type declarations and methods for use in
+! ocean-only configurations of MOM6.  It is intended that the version of
+! coupler_types_mod that is avialable from FMS will conform to this version with
+! the FMS city release after warsaw.
+
+use fms_io_mod,        only: restart_file_type, register_restart_field
+use fms_io_mod,        only: query_initialized, restore_state
+use time_manager_mod,  only: time_type
+use diag_manager_mod,  only: register_diag_field, send_data
+use data_override_mod, only: data_override
+use mpp_domains_mod,   only: domain2D, mpp_redistribute
+use mpp_mod,           only: stdout, mpp_error, FATAL, mpp_chksum
 
 implicit none ; private
 
-type, public :: coupler_2d_bc_type
-  integer    :: num_bcs = 0
+public coupler_type_copy, coupler_type_spawn, coupler_type_set_diags
+public coupler_type_write_chksums, coupler_type_send_data, coupler_type_data_override
+public coupler_type_register_restarts, coupler_type_restore_state
+public coupler_type_increment_data, coupler_type_rescale_data
+public coupler_type_copy_data, coupler_type_redistribute_data
+public coupler_type_destructor, coupler_type_initialized
+public coupler_type_extract_data, coupler_type_set_data
+
+public coupler_type_copy_1d_2d
+public coupler_type_copy_1d_3d
+
+!
+!       3-d fields
+!
+type, public :: coupler_3d_values_type
+  character(len=48)       :: name = ' '  !< The diagnostic name for this array
+  real, pointer, contiguous, dimension(:,:,:) :: values => NULL() !< The pointer to the
+                                         !! array of values for this field; this
+                                         !! should be changed to allocatable
+  logical                 :: mean = .true. !< mean
+  logical                 :: override = .false. !< override
+  integer                 :: id_diag = 0 !< The diagnostic id for this array
+  character(len=128)      :: long_name = ' ' !< The diagnostic long_name for this array
+  character(len=128)      :: units = ' ' !< The units for this array
+  integer                 :: id_rest = 0 !< The id of this array in the restart field
+  logical                 :: may_init = .true. !< If true, there is an internal method
+                                         !! that can be used to initialize this field
+                                         !! if it can not be read from a restart file
+end type coupler_3d_values_type
+
+type, public :: coupler_3d_field_type
+  character(len=48)                 :: name = ' ' !< name
+  integer                           :: num_fields = 0 !< num_fields
+  type(coupler_3d_values_type), pointer, dimension(:) :: field => NULL() !< field
+  character(len=128)                :: flux_type = ' ' !< flux_type
+  character(len=128)                :: implementation = ' ' !< implementation
+  real, pointer, dimension(:)       :: param => NULL() !< param
+  logical, pointer, dimension(:)    :: flag => NULL() !< flag
+  integer                           :: atm_tr_index = 0 !< atm_tr_index
+  character(len=128)                :: ice_restart_file = ' ' !< ice_restart_file
+  character(len=128)                :: ocean_restart_file = ' ' !< ocean_restart_file
+  type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
+                                                           !! that is used for this field.
+  logical                           :: use_atm_pressure !< use_atm_pressure
+  logical                           :: use_10m_wind_speed !< use_10m_wind_speed
+  logical                           :: pass_through_ice !< pass_through_ice
+  real                              :: mol_wt = 0.0 !< mol_wt
+end type coupler_3d_field_type
+
+type, public :: coupler_3d_bc_type
+  integer                                            :: num_bcs = 0  !< The number of boundary condition fields
+  type(coupler_3d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary condition fields
+  logical    :: set = .false.       !< If true, this type has been initialized
+  integer    :: isd, isc, iec, ied  !< The i-direction data and computational domain index ranges for this type
+  integer    :: jsd, jsc, jec, jed  !< The j-direction data and computational domain index ranges for this type
+  integer    :: ks, ke              !< The k-direction index ranges for this type
+end type coupler_3d_bc_type
+
+!
+!       2-d fields
+!
+type, public    :: coupler_2d_values_type
+  character(len=48)       :: name = ' '  !< The diagnostic name for this array
+  real, pointer, contiguous, dimension(:,:) :: values => NULL() !< The pointer to the
+                                         !! array of values for this field; this
+                                         !! should be changed to allocatable
+  logical                 :: mean = .true. !< mean
+  logical                 :: override = .false. !< override
+  integer                 :: id_diag = 0 !< The diagnostic id for this array
+  character(len=128)      :: long_name = ' ' !< The diagnostic long_name for this array
+  character(len=128)      :: units = ' ' !< The units for this array
+  integer                 :: id_rest = 0 !< The id of this array in the restart field
+  logical                 :: may_init = .true. !< If true, there is an internal method
+                                         !! that can be used to initialize this field
+                                         !! if it can not be read from a restart file
+end type coupler_2d_values_type
+
+type, public    :: coupler_2d_field_type
+  character(len=48)                 :: name = ' ' !< name
+  integer                           :: num_fields = 0 !< num_fields
+  type(coupler_2d_values_type), pointer, dimension(:)   :: field => NULL() !< field
+  character(len=128)                :: flux_type = ' ' !< flux_type
+  character(len=128)                :: implementation = ' ' !< implementation
+  real, pointer, dimension(:)       :: param => NULL() !< param
+  logical, pointer, dimension(:)    :: flag => NULL() !< flag
+  integer                           :: atm_tr_index = 0 !< atm_tr_index
+  character(len=128)                :: ice_restart_file = ' ' !< ice_restart_file
+  character(len=128)                :: ocean_restart_file = ' ' !< ocean_restart_file
+  type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
+                                                          !! that is used for this field.
+  logical                           :: use_atm_pressure !< use_atm_pressure
+  logical                           :: use_10m_wind_speed !< use_10m_wind_speed
+  logical                           :: pass_through_ice !< pass_through_ice
+  real                              :: mol_wt = 0.0 !< mol_wt
+end type coupler_2d_field_type
+
+type, public    :: coupler_2d_bc_type
+  integer                                            :: num_bcs = 0  !< The number of boundary condition fields
+  type(coupler_2d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary condition fields
+  logical    :: set = .false.       !< If true, this type has been initialized
+  integer    :: isd, isc, iec, ied  !< The i-direction data and computational domain index ranges for this type
+  integer    :: jsd, jsc, jec, jed  !< The j-direction data and computational domain index ranges for this type
 end type coupler_2d_bc_type
-integer, public :: ind_flux=-1, ind_alpha=-2, ind_csurf=-3
 
-end module coupler_types_mod
+!
+!       1-d fields
+!
+type, public    :: coupler_1d_values_type
+  character(len=48)           :: name = ' '  !< The diagnostic name for this array
+  real, pointer, dimension(:) :: values => NULL() !< The pointer to the array of values
+  logical                     :: mean = .true. !< mean
+  logical                     :: override = .false. !< override
+  integer                     :: id_diag = 0 !< The diagnostic id for this array
+  character(len=128)          :: long_name = ' ' !< The diagnostic long_name for this array
+  character(len=128)          :: units = ' ' !< The units for this array
+  logical                     :: may_init = .true. !< If true, there is an internal method
+                                             !! that can be used to initialize this field
+                                             !! if it can not be read from a restart file
+end type coupler_1d_values_type
 
+type, public    :: coupler_1d_field_type
+  character(len=48)              :: name = ' ' !< name
+  integer                        :: num_fields = 0 !< num_fields
+  type(coupler_1d_values_type), pointer, dimension(:)   :: field => NULL() !< field
+  character(len=128)             :: flux_type = ' ' !< flux_type
+  character(len=128)             :: implementation = ' ' !< implementation
+  real, pointer, dimension(:)    :: param => NULL() !< param
+  logical, pointer, dimension(:) :: flag => NULL() !< flag
+  integer                        :: atm_tr_index = 0 !< atm_tr_index
+  character(len=128)             :: ice_restart_file = ' ' !< ice_restart_file
+  character(len=128)             :: ocean_restart_file = ' ' !< ocean_restart_file
+  logical                        :: use_atm_pressure !< use_atm_pressure
+  logical                        :: use_10m_wind_speed !< use_10m_wind_speed
+  logical                        :: pass_through_ice !< pass_through_ice
+  real                           :: mol_wt = 0.0 !< mol_wt
+end type coupler_1d_field_type
 
-!============= DUMMY VERSION OF coupler_util ===================================
+type, public    :: coupler_1d_bc_type
+  integer                                            :: num_bcs = 0  !< The number of boundary condition fields
+  type(coupler_1d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary condition fields
+  logical    :: set = .false.       !< If true, this type has been initialized
+end type coupler_1d_bc_type
 
-module coupler_util
+!----------------------------------------------------------------------
+!   The following public parameters can help in selecting the sub-elements of a
+! coupler type.  There are duplicate values because different boundary
+! conditions have different sub-elements.
+integer, parameter, public :: ind_pcair = 1 !< The index of the atmospheric concentration
+integer, parameter, public :: ind_u10 = 2   !< The index of the 10 m wind speed
+integer, parameter, public :: ind_psurf = 3 !< The index of the surface atmospheric pressure
+integer, parameter, public :: ind_alpha = 1 !< The index of the solubility array for a tracer
+integer, parameter, public :: ind_csurf = 2 !< The index of the ocean surface concentration
+integer, parameter, public :: ind_sc_no = 3 !< The index for the Schmidt number for a tracer flux
+integer, parameter, public :: ind_flux = 1  !< The index for the tracer flux
+integer, parameter, public :: ind_deltap= 2 !< The index for ocean-air gas partial pressure change
+integer, parameter, public :: ind_kw = 3    !< The index for the piston velocity
+integer, parameter, public :: ind_deposition = 1 !< The index for the atmospheric deposition flux
+integer, parameter, public :: ind_runoff = 1 !< The index for a runoff flux
 
-use MOM_error_handler, only : MOM_error, FATAL, WARNING
-use coupler_types_mod, only : coupler_2d_bc_type, ind_flux, ind_alpha, ind_csurf
+!----------------------------------------------------------------------
+!        Interface definitions for overloaded routines
+!----------------------------------------------------------------------
 
-implicit none ; private
+!> This is the interface to spawn one coupler_bc_type into another and then
+!! register diagnostics associated with the new type.
+interface  coupler_type_copy
+  module procedure coupler_type_copy_1d_2d, coupler_type_copy_1d_3d
+  module procedure coupler_type_copy_2d_2d, coupler_type_copy_2d_3d
+  module procedure coupler_type_copy_3d_2d, coupler_type_copy_3d_3d
+end interface coupler_type_copy
 
-public :: extract_coupler_values, set_coupler_values
-public :: ind_flux, ind_alpha, ind_csurf
+!> This is the interface to spawn one coupler_bc_type into another.
+interface  coupler_type_spawn
+  module procedure CT_spawn_1d_2d, CT_spawn_2d_2d, CT_spawn_3d_2d
+  module procedure CT_spawn_1d_3d, CT_spawn_2d_3d, CT_spawn_3d_3d
+end interface coupler_type_spawn
+
+!> This is the interface to copy the field data from one coupler_bc_type
+!! to another of the same rank, size and decomposition.
+interface coupler_type_copy_data
+  module procedure CT_copy_data_2d, CT_copy_data_3d, CT_copy_data_2d_3d
+end interface coupler_type_copy_data
+
+!> This is the interface to redistribute the field data from one coupler_bc_type
+!! to another of the same rank and global size, but a different decomposition.
+interface coupler_type_redistribute_data
+  module procedure CT_redistribute_data_2d, CT_redistribute_data_3d
+end interface coupler_type_redistribute_data
+
+!> This is the interface to rescale the field data in a coupler_bc_type.
+interface coupler_type_rescale_data
+  module procedure CT_rescale_data_2d, CT_rescale_data_3d
+end interface coupler_type_rescale_data
+
+!> This is the interface to increment the field data from one coupler_bc_type
+!! with the data from another.  Both must have the same horizontal size and
+!! decomposition, but a 2d type may be incremented by a 2d or 3d type
+interface coupler_type_increment_data
+  module procedure CT_increment_data_2d_2d, CT_increment_data_3d_3d, CT_increment_data_2d_3d
+end interface coupler_type_increment_data
+
+!> This is the interface to extract a field in a coupler_bc_type into an array.
+interface coupler_type_extract_data
+  module procedure CT_extract_data_2d, CT_extract_data_3d, CT_extract_data_3d_2d
+end interface coupler_type_extract_data
+
+!> This is the interface to set a field in a coupler_bc_type from an array.
+interface coupler_type_set_data
+  module procedure CT_set_data_2d, CT_set_data_3d, CT_set_data_2d_3d
+end interface coupler_type_set_data
+
+!> This is the interface to set diagnostics for the arrays in a coupler_bc_type.
+interface coupler_type_set_diags
+  module procedure CT_set_diags_2d, CT_set_diags_3d
+end interface coupler_type_set_diags
+
+!> This is the interface to write out checksums for the elements of a coupler_bc_type.
+interface coupler_type_write_chksums
+  module procedure CT_write_chksums_2d, CT_write_chksums_3d
+end interface coupler_type_write_chksums
+
+!> This is the interface to write out diagnostics of the arrays in a coupler_bc_type.
+interface coupler_type_send_data
+  module procedure CT_send_data_2d, CT_send_data_3d
+end interface coupler_type_send_data
+
+!> This is the interface to override the values of the arrays in a coupler_bc_type.
+interface coupler_type_data_override
+  module procedure CT_data_override_2d, CT_data_override_3d
+end interface coupler_type_data_override
+
+!> This is the interface to register the fields in a coupler_bc_type to be saved
+!! in restart files.
+interface coupler_type_register_restarts
+  module procedure CT_register_restarts_2d, CT_register_restarts_3d
+  module procedure CT_register_restarts_to_file_2d, CT_register_restarts_to_file_3d
+end interface coupler_type_register_restarts
+
+!> This is the interface to read in the fields in a coupler_bc_type that have
+!! been saved in restart files.
+interface coupler_type_restore_state
+  module procedure CT_restore_state_2d, CT_restore_state_3d
+end interface coupler_type_restore_state
+
+!> This function interface indicates whether a coupler_bc_type has been initialized.
+interface coupler_type_initialized
+  module procedure CT_initialized_1d, CT_initialized_2d, CT_initialized_3d
+end interface coupler_type_initialized
+
+!> This is the interface to deallocate any data associated with a coupler_bc_type.
+interface coupler_type_destructor
+  module procedure CT_destructor_1d, CT_destructor_2d, CT_destructor_3d
+end interface coupler_type_destructor
 
 contains
 
-subroutine extract_coupler_values(BC_struc, BC_index, BC_element, array_out, &
-                                  is, ie, js, je, conversion)
-  type(coupler_2d_bc_type), intent(in)  :: BC_struc
-  integer,                  intent(in)  :: BC_index, BC_element
-  real, dimension(:,:),     intent(inout) :: array_out
-  integer,        optional, intent(in)  :: is, ie, js, je
-  real,           optional, intent(in)  :: conversion
-! Arguments: BC_struc - The type from which the data is being extracted.
-!  (in)      BC_index - The boundary condition number being extracted.
-!  (in)      BC_element - The element of the boundary condition being extracted.
-!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
-!  (out)     array_out - The array being filled with the input values.
-!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
-!            These must match the size of the corresponding value array or an
-!            error message is issued.
-!  (in, opt) conversion - A number that every element is multiplied by, to
-!                         permit sign convention or unit conversion.
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 1-D to 2-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+subroutine coupler_type_copy_1d_2d(var_in, var_out, is, ie, js, je,     &
+     diag_name, axes, time, suffix)
 
-  call MOM_error(FATAL,"The called version of extract_coupler_values does" // &
-                 " nothing but issue this fatal error message.")
+  type(coupler_1d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_2d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
 
-end subroutine extract_coupler_values
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (coupler_type_copy_1d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
 
-subroutine set_coupler_values(array_in, BC_struc, BC_index, BC_element, &
-                              is, ie, js, je, conversion)
-  real, dimension(:,:),     intent(in)    :: array_in
-  type(coupler_2d_bc_type), intent(inout) :: BC_struc
-  integer,                  intent(in)    :: BC_index, BC_element
-  integer,        optional, intent(in)    :: is, ie, js, je
-  real,           optional, intent(in)    :: conversion
-! Arguments: array_in - The array containing the values to load into the BC.
-!  (out)     BC_struc - The type into which the data is being loaded.
-!  (in)      BC_index - The boundary condition number being extracted.
-!  (in)      BC_element - The element of the boundary condition being extracted.
-!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
-!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
-!            These must match the size of the corresponding value array or an
-!            error message is issued.
-!  (in, opt) conversion - A number that every element is multiplied by, to
-!                         permit sign convention or unit conversion.
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
 
-  call MOM_error(FATAL,"The called version of set_coupler_values does" // &
-                 " nothing but issue this fatal error message.")
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_1d_2d(var_in, var_out, (/ is, is, ie, ie /), (/ js, js, je, je /), suffix)
 
-end subroutine set_coupler_values
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_2d(var_out, diag_name, axes, time)
 
-end module coupler_util
+end subroutine  coupler_type_copy_1d_2d
+
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 1-D to 3-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, kd, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var_out%bc already associated"
+!! \throw FATAL, "var_out%bc([n])%field already associated"
+!! \throw FATAL, "var_out%bc([n])%field([m])%values already associated"
+!! \throw FATAL, "axes less than 3 elements"
+subroutine coupler_type_copy_1d_3d(var_in, var_out, is, ie, js, je, kd, &
+     diag_name, axes, time, suffix)
+
+  type(coupler_1d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_3d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  integer, intent(in)                     :: kd !< third dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (coupler_type_copy_1d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_1d_3d(var_in, var_out,  (/ is, is, ie, ie /), (/ js, js, je, je /), (/1, kd/), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_3d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_1d_3d
+
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 2-D to 2-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+subroutine coupler_type_copy_2d_2d(var_in, var_out, is, ie, js, je,     &
+     diag_name, axes, time, suffix)
+
+  type(coupler_2d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_2d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (coupler_type_copy_2d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_2d_2d(var_in, var_out, (/ is, is, ie, ie /), (/ js, js, je, je /), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_2d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_2d_2d
+
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 2-D to 3-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, kd, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var_out%bc already associated"
+!! \throw FATAL, "var_out%bc([n])%field already associated"
+!! \throw FATAL, "var_out%bc([n])%field([m])%values already associated"
+!! \throw FATAL, "axes less than 3 elements"
+subroutine coupler_type_copy_2d_3d(var_in, var_out, is, ie, js, je, kd, &
+     diag_name, axes, time, suffix)
+
+  type(coupler_2d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_3d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  integer, intent(in)                     :: kd !< third dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (coupler_type_copy_2d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_2d_3d(var_in, var_out,  (/ is, is, ie, ie /), (/ js, js, je, je /), (/1, kd/), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_3d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_2d_3d
+
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 3-D to 2-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+subroutine coupler_type_copy_3d_2d(var_in, var_out, is, ie, js, je,     &
+     diag_name, axes, time, suffix)
+
+  type(coupler_3d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_2d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (coupler_type_copy_3d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_3d_2d(var_in, var_out, (/ is, is, ie, ie /), (/ js, js, je, je /), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_2d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_3d_2d
+
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 3-D to 3-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, kd, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var_out%bc already associated"
+!! \throw FATAL, "var_out%bc([n])%field already associated"
+!! \throw FATAL, "var_out%bc([n])%field([m])%values already associated"
+!! \throw FATAL, "axes less than 3 elements"
+subroutine coupler_type_copy_3d_3d(var_in, var_out, is, ie, js, je, kd, &
+     diag_name, axes, time, suffix)
+
+  type(coupler_3d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_3d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  integer, intent(in)                     :: kd !< third dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (coupler_type_copy_3d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_3d_3d(var_in, var_out,  (/ is, is, ie, ie /), (/ js, js, je, je /), (/1, kd/), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_3d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_3d_3d
+
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 1-D to 2-D version for generic coupler_type_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var_out, idim, jdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var_out%bc already associated"
+!! \throw FATAL, "var_out%bc([n])%field already associated"
+!! \throw FATAL, "var_out%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_1d_2d(var_in, var, idim, jdim, suffix, as_needed)
+
+  type(coupler_1d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_2d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (CT_spawn_1d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+          var%bc(n)%field(m)%values(:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_1d_2d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 1-D to 3-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, kdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_1d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
+
+  type(coupler_1d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_3d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  integer, dimension(2),    intent(in)    :: kdim    !< The array extents of the third dimension in
+                                                     !! a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_spawn_1d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  ! Store the array extents that are to be used with this bc_type.
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if (kdim(1) > kdim(2)) then
+    write (error_msg, *) trim(error_header), ' Disordered k-dimension index bound list  ', kdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+  var%ks  = kdim(1) ; var%ke  = kdim(2)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+          var%bc(n)%field(m)%values(:,:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_1d_3d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 2-D to 2-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_2d_2d(var_in, var, idim, jdim, suffix, as_needed)
+
+  type(coupler_2d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_2d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (CT_spawn_2d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+          var%bc(n)%field(m)%values(:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_2d_2d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 2-D to 3-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, kdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_2d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
+
+  type(coupler_2d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_3d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  integer, dimension(2),    intent(in)    :: kdim    !< The array extents of the third dimension in
+                                                     !! a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_spawn_2d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  ! Store the array extents that are to be used with this bc_type.
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if (kdim(1) > kdim(2)) then
+    write (error_msg, *) trim(error_header), ' Disordered k-dimension index bound list  ', kdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+  var%ks  = kdim(1) ; var%ke = kdim(2)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+          var%bc(n)%field(m)%values(:,:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_2d_3d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 3-D to 2-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_3d_2d(var_in, var, idim, jdim, suffix, as_needed)
+
+  type(coupler_3d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_2d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (CT_spawn_3d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+          var%bc(n)%field(m)%values(:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_3d_2d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 3-D to 3-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, kdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_3d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
+
+  type(coupler_3d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_3d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  integer, dimension(2),    intent(in)    :: kdim    !< The array extents of the third dimension in
+                                                     !! a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_spawn_3d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if (kdim(1) > kdim(2)) then
+    write (error_msg, *) trim(error_header), ' Disordered k-dimension index bound list  ', kdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+  var%ks  = kdim(1) ; var%ke  = kdim(2)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+          var%bc(n)%field(m)%values(:,:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_3d_3d
+
+
+!> This subroutine does a direct copy of the data in all elements of one
+!! coupler_2d_bc_type into another.  Both must have the same array sizes.
+subroutine CT_copy_data_2d(var_in, var, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_2d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to copy
+  type(coupler_2d_bc_type),   intent(inout) :: var !< The recipient BC_type structure
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  logical :: copy_bc
+  integer :: i, j, m, n, n1, n2, halo, i_off, j_off
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_copy_data_2d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_copy_data_2d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_copy_data_2d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: Excessive j-direction halo size for the output structure.")
+
+    i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc
+  endif
+
+  do n = n1, n2
+
+    copy_bc = .true.
+    if (copy_bc .and. present(exclude_flux_type)) &
+      copy_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (copy_bc .and. present(only_flux_type)) &
+      copy_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (copy_bc .and. present(pass_through_ice)) &
+      copy_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.copy_bc) cycle
+
+    do m = 1, var%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j) = var_in%bc(n)%field(m)%values(i+i_off,j+j_off)
+        enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_copy_data_2d
+
+!> This subroutine does a direct copy of the data in all elements of one
+!! coupler_3d_bc_type into another.  Both types must have the same array sizes.
+subroutine CT_copy_data_3d(var_in, var, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to copy
+  type(coupler_3d_bc_type),   intent(inout) :: var !< The recipient BC_type structure
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  logical :: copy_bc
+  integer :: i, j, k, m, n, n1, n2, halo, i_off, j_off, k_off
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_copy_data_3d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_copy_data_3d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_copy_data_3d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%ke-var_in%ks) /= (var%ke-var%ks)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: There is a k-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: Excessive j-direction halo size for the output structure.")
+
+    i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc ; k_off = var_in%ks - var%ks
+  endif
+
+  do n = n1, n2
+
+    copy_bc = .true.
+    if (copy_bc .and. present(exclude_flux_type)) &
+      copy_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (copy_bc .and. present(only_flux_type)) &
+      copy_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (copy_bc .and. present(pass_through_ice)) &
+      copy_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.copy_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j,k) = var_in%bc(n)%field(m)%values(i+i_off,j+j_off,k+k_off)
+        enddo ; enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_copy_data_3d
+
+!> This subroutine does a direct copy of the data in all elements of a
+!! coupler_2d_bc_type into a coupler_3d_bc_type.  Both types must have the same
+!! array sizes for their first two dimensions, while the extent of the 3rd dimension
+!! that is being filled may be specified via optional arguments.
+subroutine CT_copy_data_2d_3d(var_in, var, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice, &
+                           ind3_start, ind3_end)
+  type(coupler_2d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to copy
+  type(coupler_3d_bc_type),   intent(inout) :: var !< The recipient BC_type structure
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  integer,          optional, intent(in)    :: ind3_start  !< The starting value of the 3rd
+                                                       !! index of the 3d type to fill in.
+  integer,          optional, intent(in)    :: ind3_end    !< The ending value of the 3rd
+                                                       !! index of the 3d type to fill in.
+  logical :: copy_bc
+  integer :: i, j, k, m, n, n1, n2, halo, i_off, j_off, ks, ke
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_copy_data_2d_3d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: Excessive j-direction halo size for the output structure.")
+  endif
+
+  i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc
+  do n = n1, n2
+
+    copy_bc = .true.
+    if (copy_bc .and. present(exclude_flux_type)) &
+      copy_bc = .not.(trim(var_in%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (copy_bc .and. present(only_flux_type)) &
+      copy_bc = (trim(var_in%bc(n)%flux_type) == trim(only_flux_type))
+    if (copy_bc .and. present(pass_through_ice)) &
+      copy_bc = (pass_through_ice .eqv. var_in%bc(n)%pass_through_ice)
+    if (.not.copy_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        ks = var%ks ; if (present(ind3_start)) ks = max(ks, ind3_start)
+        ke = var%ke ; if (present(ind3_end)) ke = max(ke, ind3_end)
+        do k=ks,ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j,k) = var_in%bc(n)%field(m)%values(i+i_off,j+j_off)
+        enddo ; enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_copy_data_2d_3d
+
+
+!> This subroutine redistributes the data in all elements of one coupler_2d_bc_type
+!! into another, which may be on different processors with a different decomposition.
+subroutine CT_redistribute_data_2d(var_in, domain_in, var_out, domain_out, complete)
+  type(coupler_2d_bc_type), intent(in)    :: var_in     !< BC_type structure with the data to copy (intent in)
+  type(domain2D),           intent(in)    :: domain_in  !< The FMS domain for the input structure
+  type(coupler_2d_bc_type), intent(inout) :: var_out    !< The recipient BC_type structure (data intent out)
+  type(domain2D),           intent(in)    :: domain_out !< The FMS domain for the output structure
+  logical,        optional, intent(in)    :: complete   !< If true, complete the updates
+
+  real, pointer, dimension(:,:) :: null_ptr2D => NULL()
+  logical :: do_in, do_out, do_complete
+  integer :: m, n, fc, fc_in, fc_out
+
+  do_complete = .true. ; if (present(complete)) do_complete = complete
+
+  ! Figure out whether this PE has valid input or output fields or both.
+  do_in = var_in%set
+  do_out = var_out%set
+
+  fc_in = 0 ; fc_out = 0
+  if (do_in) then ; do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+    if (associated(var_in%bc(n)%field(m)%values)) fc_in = fc_in + 1
+  enddo ; enddo ; endif
+  if (fc_in == 0) do_in = .false.
+  if (do_out) then ; do n = 1, var_out%num_bcs ; do m = 1, var_out%bc(n)%num_fields
+    if (associated(var_out%bc(n)%field(m)%values)) fc_out = fc_out + 1
+  enddo ; enddo ; endif
+  if (fc_out == 0) do_out = .false.
+
+  if (do_in .and. do_out) then
+    if (var_in%num_bcs /= var_out%num_bcs) call mpp_error(FATAL, &
+      "Mismatch in num_bcs in CT_copy_data_2d.")
+    if (fc_in /= fc_out) call mpp_error(FATAL, &
+      "Mismatch in the total number of fields in CT_redistribute_data_2d.")
+  endif
+
+  if (.not.(do_in .or. do_out)) return
+
+  fc = 0
+  if (do_in .and. do_out) then
+    do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+      if ( associated(var_in%bc(n)%field(m)%values) .neqv. &
+           associated(var_out%bc(n)%field(m)%values) ) &
+        call mpp_error(FATAL, &
+          "Mismatch in which fields are associated in CT_redistribute_data_2d.")
+
+      if ( associated(var_in%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, var_in%bc(n)%field(m)%values, &
+                              domain_out, var_out%bc(n)%field(m)%values, &
+                              complete=(do_complete.and.(fc==fc_in)) )
+      endif
+    enddo ; enddo
+  elseif (do_in) then
+    do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+      if ( associated(var_in%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, var_in%bc(n)%field(m)%values, &
+                              domain_out, null_ptr2D, &
+                              complete=(do_complete.and.(fc==fc_in)) )
+      endif
+    enddo ; enddo
+  elseif (do_out) then
+    do n = 1, var_out%num_bcs ; do m = 1, var_out%bc(n)%num_fields
+      if ( associated(var_out%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, null_ptr2D, &
+                              domain_out, var_out%bc(n)%field(m)%values, &
+                              complete=(do_complete.and.(fc==fc_out)) )
+      endif
+    enddo ; enddo
+  endif
+
+end subroutine CT_redistribute_data_2d
+
+!> This subroutine redistributes the data in all elements of one coupler_2d_bc_type
+!! into another, which may be on different processors with a different decomposition.
+subroutine CT_redistribute_data_3d(var_in, domain_in, var_out, domain_out, complete)
+  type(coupler_3d_bc_type), intent(in)    :: var_in     !< BC_type structure with the data to copy (intent in)
+  type(domain2D),           intent(in)    :: domain_in  !< The FMS domain for the input structure
+  type(coupler_3d_bc_type), intent(inout) :: var_out    !< The recipient BC_type structure (data intent out)
+  type(domain2D),           intent(in)    :: domain_out !< The FMS domain for the output structure
+  logical,        optional, intent(in)    :: complete   !< If true, complete the updates
+
+  real, pointer, dimension(:,:,:) :: null_ptr3D => NULL()
+  logical :: do_in, do_out, do_complete
+  integer :: m, n, fc, fc_in, fc_out
+
+  do_complete = .true. ; if (present(complete)) do_complete = complete
+
+  ! Figure out whether this PE has valid input or output fields or both.
+  do_in = var_in%set
+  do_out = var_out%set
+
+  fc_in = 0 ; fc_out = 0
+  if (do_in) then ; do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+    if (associated(var_in%bc(n)%field(m)%values)) fc_in = fc_in + 1
+  enddo ; enddo ; endif
+  if (fc_in == 0) do_in = .false.
+  if (do_out) then ; do n = 1, var_out%num_bcs ; do m = 1, var_out%bc(n)%num_fields
+    if (associated(var_out%bc(n)%field(m)%values)) fc_out = fc_out + 1
+  enddo ; enddo ; endif
+  if (fc_out == 0) do_out = .false.
+
+  if (do_in .and. do_out) then
+    if (var_in%num_bcs /= var_out%num_bcs) call mpp_error(FATAL, &
+      "Mismatch in num_bcs in CT_copy_data_3d.")
+    if (fc_in /= fc_out) call mpp_error(FATAL, &
+      "Mismatch in the total number of fields in CT_redistribute_data_3d.")
+  endif
+
+  if (.not.(do_in .or. do_out)) return
+
+  fc = 0
+  if (do_in .and. do_out) then
+    do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+      if ( associated(var_in%bc(n)%field(m)%values) .neqv. &
+           associated(var_out%bc(n)%field(m)%values) ) &
+        call mpp_error(FATAL, &
+          "Mismatch in which fields are associated in CT_redistribute_data_3d.")
+
+      if ( associated(var_in%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, var_in%bc(n)%field(m)%values, &
+                              domain_out, var_out%bc(n)%field(m)%values, &
+                              complete=(do_complete.and.(fc==fc_in)) )
+      endif
+    enddo ; enddo
+  elseif (do_in) then
+    do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+      if ( associated(var_in%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, var_in%bc(n)%field(m)%values, &
+                              domain_out, null_ptr3D, &
+                              complete=(do_complete.and.(fc==fc_in)) )
+      endif
+    enddo ; enddo
+  elseif (do_out) then
+    do n = 1, var_out%num_bcs ; do m = 1, var_out%bc(n)%num_fields
+      if ( associated(var_out%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, null_ptr3D, &
+                              domain_out, var_out%bc(n)%field(m)%values, &
+                              complete=(do_complete.and.(fc==fc_out)) )
+      endif
+    enddo ; enddo
+  endif
+
+end subroutine CT_redistribute_data_3d
+
+
+!> This subroutine rescales the fields in the elements of a coupler_2d_bc_type
+!! by multiplying by a factor scale.  If scale is 0, this is a direct
+!! assignment to 0, so that NaNs will not persist.
+subroutine CT_rescale_data_2d(var, scale, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_2d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being rescaled
+  real,                       intent(in)    :: scale   !< A scaling factor to multiply fields by
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default or
+                                                         !! the full arrays if scale is 0.
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  logical :: do_bc
+  integer :: i, j, m, n, n1, n2, halo
+
+  if (present(bc_index)) then
+    if (bc_index > var%num_bcs) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: bc_index is present and exceeds var%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: field_index is present and exceeds num_fields for" //&
+                     trim(var%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_rescale_data_2d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: Excessive i-direction halo size.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: Excessive j-direction halo size.")
+  endif
+
+  do n = n1, n2
+
+    do_bc = .true.
+    if (do_bc .and. present(exclude_flux_type)) &
+      do_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (do_bc .and. present(only_flux_type)) &
+      do_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (do_bc .and. present(pass_through_ice)) &
+      do_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.do_bc) cycle
+
+    do m = 1, var%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        if (scale == 0.0) then
+          if (present(halo_size)) then
+            do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+              var%bc(n)%field(m)%values(i,j) = 0.0
+            enddo ; enddo
+          else
+            var%bc(n)%field(m)%values(:,:) = 0.0
+          endif
+        else
+          do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+            var%bc(n)%field(m)%values(i,j) = scale * var%bc(n)%field(m)%values(i,j)
+          enddo ; enddo
+        endif
+      endif
+    enddo
+  enddo
+
+end subroutine CT_rescale_data_2d
+
+!> This subroutine rescales the fields in the elements of a coupler_3d_bc_type
+!! by multiplying by a factor scale.  If scale is 0, this is a direct
+!! assignment to 0, so that NaNs will not persist.
+subroutine CT_rescale_data_3d(var, scale, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_3d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being rescaled
+  real,                       intent(in)    :: scale   !< A scaling factor to multiply fields by
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default or
+                                                         !! the full arrays if scale is 0.
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  logical :: do_bc
+  integer :: i, j, k, m, n, n1, n2, halo
+
+  if (present(bc_index)) then
+    if (bc_index > var%num_bcs) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: bc_index is present and exceeds var%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: field_index is present and exceeds num_fields for" //&
+                     trim(var%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_rescale_data_2d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_rescale_data_3d: Excessive i-direction halo size.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_rescale_data_3d: Excessive j-direction halo size.")
+  endif
+
+  do n = n1, n2
+
+    do_bc = .true.
+    if (do_bc .and. present(exclude_flux_type)) &
+      do_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (do_bc .and. present(only_flux_type)) &
+      do_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (do_bc .and. present(pass_through_ice)) &
+      do_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.do_bc) cycle
+
+    do m = 1, var%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        if (scale == 0.0) then
+          if (present(halo_size)) then
+            do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+              var%bc(n)%field(m)%values(i,j,k) = 0.0
+            enddo ; enddo ; enddo
+          else
+            var%bc(n)%field(m)%values(:,:,:) = 0.0
+          endif
+        else
+          do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+            var%bc(n)%field(m)%values(i,j,k) = scale * var%bc(n)%field(m)%values(i,j,k)
+          enddo ; enddo ; enddo
+        endif
+      endif
+    enddo
+  enddo
+
+end subroutine CT_rescale_data_3d
+
+
+!> This subroutine does a direct increment of the data in all elements of one
+!! coupler_2d_bc_type into another.  Both must have the same array sizes.
+subroutine CT_increment_data_2d_2d(var_in, var, halo_size, bc_index, field_index, &
+                           scale_factor, scale_prev, exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_2d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to add to the other type
+  type(coupler_2d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being incremented
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to increment; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  real,             optional, intent(in)    :: scale_factor  !< A scaling factor for the data that is being added
+  real,             optional, intent(in)    :: scale_prev    !< A scaling factor for the data that is already here
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this increment.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this increment.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only increment BCs whose
+                                                       !! value of pass_through ice matches this
+
+  real :: scale, sc_prev
+  logical :: increment_bc
+  integer :: i, j, m, n, n1, n2, halo, i_off, j_off
+
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+  sc_prev = 1.0 ; if (present(scale_prev)) sc_prev = scale_prev
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_increment_data_2d_2d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_increment_data_2d_2d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_increment_data_2d_2d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: Excessive j-direction halo size for the output structure.")
+
+    i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc
+  endif
+
+  do n = n1, n2
+
+    increment_bc = .true.
+    if (increment_bc .and. present(exclude_flux_type)) &
+      increment_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (increment_bc .and. present(only_flux_type)) &
+      increment_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (increment_bc .and. present(pass_through_ice)) &
+      increment_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.increment_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j) = sc_prev * var%bc(n)%field(m)%values(i,j) + &
+                          scale * var_in%bc(n)%field(m)%values(i+i_off,j+j_off)
+        enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_increment_data_2d_2d
+
+
+!> This subroutine does a direct increment of the data in all elements of one
+!! coupler_3d_bc_type into another.  Both must have the same array sizes.
+subroutine CT_increment_data_3d_3d(var_in, var, halo_size, bc_index, field_index, &
+                           scale_factor, scale_prev, exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to add to the other type
+  type(coupler_3d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being incremented
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  real,             optional, intent(in)    :: scale_factor  !< A scaling factor for the data that is being added
+  real,             optional, intent(in)    :: scale_prev    !< A scaling factor for the data that is already here
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this increment.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this increment.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only increment BCs whose
+                                                       !! value of pass_through ice matches this
+
+  real :: scale, sc_prev
+  logical :: increment_bc
+  integer :: i, j, k, m, n, n1, n2, halo, i_off, j_off, k_off
+
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+  sc_prev = 1.0 ; if (present(scale_prev)) sc_prev = scale_prev
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_increment_data_3d_3d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_increment_data_3d_3d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_increment_data_3d_3d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%ke-var_in%ks) /= (var%ke-var%ks)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: There is a k-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: Excessive j-direction halo size for the output structure.")
+
+    i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc ; k_off = var_in%ks - var%ks
+  endif
+
+  do n = n1, n2
+
+    increment_bc = .true.
+    if (increment_bc .and. present(exclude_flux_type)) &
+      increment_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (increment_bc .and. present(only_flux_type)) &
+      increment_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (increment_bc .and. present(pass_through_ice)) &
+      increment_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.increment_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j,k) = sc_prev * var%bc(n)%field(m)%values(i,j,k) + &
+                       scale * var_in%bc(n)%field(m)%values(i+i_off,j+j_off,k+k_off)
+        enddo ; enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_increment_data_3d_3d
+
+!> This subroutine does increments the data in the elements of a coupler_2d_bc_type
+!! with the weighed average of the elements of a coupler_3d_bc_type. Both must have
+!! the same horizontal array sizes and the normalized weight array must match the
+!! array sizes of the coupler_3d_bc_type.
+subroutine CT_increment_data_2d_3d(var_in, weights, var, halo_size, bc_index, field_index, &
+                           scale_factor, scale_prev, exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to add to the other type
+  real, dimension(:,:,:),     intent(in)    :: weights !< An array of normalized weights for the 3d-data to
+                                                       !! increment the 2d-data.  There is no renormalization,
+                                                       !! so if the weights do not sum to 1 in the 3rd dimension
+                                                       !! there may be adverse consequences!
+  type(coupler_2d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being incremented
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  real,             optional, intent(in)    :: scale_factor  !< A scaling factor for the data that is being added
+  real,             optional, intent(in)    :: scale_prev    !< A scaling factor for the data that is already here
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this increment.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this increment.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only increment BCs whose
+                                                       !! value of pass_through ice matches this
+
+  real :: scale, sc_prev
+  logical :: increment_bc
+  integer :: i, j, k, m, n, n1, n2, halo
+  integer :: io1, jo1, iow, jow, kow  ! Offsets to account for different index conventions.
+
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+  sc_prev = 1.0 ; if (present(scale_prev)) sc_prev = scale_prev
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_increment_data_2d_3d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: There is a j-direction computional domain size mismatch.")
+    if ((1+var_in%ke-var_in%ks) /= size(weights,3)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: There is a k-direction size mismatch with the weights array.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: Excessive j-direction halo size for the output structure.")
+
+    if ((1+var%iec-var%isc) == size(weights,1)) then
+      iow = 1 - var%isc
+    elseif ((1+var%ied-var%isd) == size(weights,1)) then
+      iow = 1 - var%isd
+    elseif ((1+var_in%ied-var_in%isd) == size(weights,1)) then
+      iow = 1 + (var_in%isc - var_in%isd) - var%isc
+    else
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: weights array must be the i-size of a computational or data domain.")
+    endif
+    if ((1+var%jec-var%jsc) == size(weights,2)) then
+      jow = 1 - var%jsc
+    elseif ((1+var%jed-var%jsd) == size(weights,2)) then
+      jow = 1 - var%jsd
+    elseif ((1+var_in%jed-var_in%jsd) == size(weights,2)) then
+      jow = 1 + (var_in%jsc - var_in%jsd) - var%jsc
+    else
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: weights array must be the j-size of a computational or data domain.")
+    endif
+
+    io1 = var_in%isc - var%isc ; jo1 = var_in%jsc - var%jsc ; kow = 1 - var_in%ks
+  endif
+
+  do n = n1, n2
+
+    increment_bc = .true.
+    if (increment_bc .and. present(exclude_flux_type)) &
+      increment_bc = .not.(trim(var_in%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (increment_bc .and. present(only_flux_type)) &
+      increment_bc = (trim(var_in%bc(n)%flux_type) == trim(only_flux_type))
+    if (increment_bc .and. present(pass_through_ice)) &
+      increment_bc = (pass_through_ice .eqv. var_in%bc(n)%pass_through_ice)
+    if (.not.increment_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do k=var_in%ks,var_in%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j) = sc_prev * var%bc(n)%field(m)%values(i,j) + &
+                     (scale * weights(i+iow,j+jow,k+kow)) * var_in%bc(n)%field(m)%values(i+io1,j+io1,k)
+        enddo ; enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_increment_data_2d_3d
+
+
+!> This subroutine extracts a single 2-d field from a coupler_2d_bc_type into
+!! a two-dimensional array.
+subroutine CT_extract_data_2d(var_in, bc_index, field_index, array_out, &
+                              scale_factor, halo_size, idim, jdim)
+  type(coupler_2d_bc_type),   intent(in)    :: var_in    !< BC_type structure with the data to extract
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  real, dimension(1:,1:),     intent(out)   :: array_out !< The recipient array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_extract_data_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, halo, i_off, j_off
+
+  if (bc_index <= 0) then
+    array_out(:,:) = 0.0
+    return
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var_in%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
+  if (field_index > var_in%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var_in%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_out,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%iec-var_in%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var_in%isc)
+  else
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_out,1), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var_in%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_out,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%jec-var_in%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var_in%jsc)
+  else
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_out,2), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var_in%jsc-halo)  
+  endif
+
+  do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
+    array_out(i+i_off,j+j_off) = scale * var_in%bc(bc_index)%field(field_index)%values(i,j)
+  enddo ; enddo
+
+end subroutine CT_extract_data_2d
+
+!> This subroutine extracts a single k-level of a 3-d field from a coupler_3d_bc_type
+!! into a two-dimensional array.
+subroutine CT_extract_data_3d_2d(var_in, bc_index, field_index, k_in, array_out, &
+                                 scale_factor, halo_size, idim, jdim)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in    !< BC_type structure with the data to extract
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  integer,                    intent(in)    :: k_in      !< The k-index to extract
+  real, dimension(1:,1:),     intent(out)   :: array_out !< The recipient array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_extract_data_3d_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, k, halo, i_off, j_off
+
+  if (bc_index <= 0) then
+    array_out(:,:) = 0.0
+    return
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var_in%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
+  if (field_index > var_in%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var_in%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_out,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%iec-var_in%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var_in%isc)
+  else
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_out,1), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var_in%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_out,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%jec-var_in%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var_in%jsc)
+  else
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_out,2), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var_in%jsc-halo)  
+  endif
+
+  if ((k_in > var_in%ke) .or. (k_in < var_in%ks)) then
+    write (error_msg, *) trim(error_header), ' The extracted k-index of ', k_in, &
+           ' is outside of the valid range of ', var_in%ks, ' to ', var_in%ke
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+
+  do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
+    array_out(i+i_off,j+j_off) = scale * var_in%bc(bc_index)%field(field_index)%values(i,j,k_in)
+  enddo ; enddo
+
+end subroutine CT_extract_data_3d_2d
+
+!> This subroutine extracts a single 3-d field from a coupler_3d_bc_type into
+!! a three-dimensional array.
+subroutine CT_extract_data_3d(var_in, bc_index, field_index, array_out, &
+                              scale_factor, halo_size, idim, jdim)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in    !< BC_type structure with the data to extract
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  real, dimension(1:,1:,1:),  intent(out)   :: array_out !< The recipient array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_extract_data_3d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, k, halo, i_off, j_off, k_off
+
+  if (bc_index <= 0) then
+    array_out(:,:,:) = 0.0
+    return
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var_in%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
+  if (field_index > var_in%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var_in%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_out,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%iec-var_in%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var_in%isc)
+  else
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_out,1), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var_in%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_out,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%jec-var_in%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var_in%jsc)
+  else
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_out,2), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var_in%jsc-halo)  
+  endif
+
+  if (size(array_out,3) /= 1 + var_in%ke - var_in%ks) then
+    write (error_msg, *) trim(error_header), ' The target array with k-dimension size ', &
+          size(array_out,3), ' does not match the data of size ', &
+          (1 + var_in%ke - var_in%ks)
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  k_off = 1 - var_in%ks
+
+  do k=var_in%ks,var_in%ke ; do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
+    array_out(i+i_off,j+j_off,k+k_off) = scale * var_in%bc(bc_index)%field(field_index)%values(i,j,k)
+  enddo ; enddo ; enddo
+
+end subroutine CT_extract_data_3d
+
+
+!> This subroutine sets a single 2-d field in a coupler_3d_bc_type from
+!! a two-dimensional array.
+subroutine CT_set_data_2d(array_in, bc_index, field_index, var, &
+                          scale_factor, halo_size, idim, jdim)
+  real, dimension(1:,1:),     intent(in)   :: array_in   !< The source array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  type(coupler_2d_bc_type),   intent(inout) :: var       !< BC_type structure with the data to set
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_set_data_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, halo, i_off, j_off
+
+  if (bc_index <= 0) return
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
+  if (field_index > var%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_in,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%iec-var%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var%isc)
+  else
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_in,1), ' does not match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_in,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%jec-var%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var%jsc)
+  else
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_in,2), ' does not match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var%jsc-halo)  
+  endif
+
+  do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+    var%bc(bc_index)%field(field_index)%values(i,j) = scale * array_in(i+i_off,j+j_off)
+  enddo ; enddo
+
+end subroutine CT_set_data_2d
+
+!> This subroutine sets a one k-level of a single 3-d field in a
+!! coupler_3d_bc_type from a two-dimensional array.
+subroutine CT_set_data_2d_3d(array_in, bc_index, field_index, k_out, var, &
+                             scale_factor, halo_size, idim, jdim)
+  real, dimension(1:,1:),     intent(in)    :: array_in  !< The source array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  integer,                    intent(in)    :: k_out     !< The k-index to set
+  type(coupler_3d_bc_type),   intent(inout) :: var       !< BC_type structure with the data to be set
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_set_data_3d_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, halo, i_off, j_off
+
+  if (bc_index <= 0) return
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
+  if (field_index > var%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_in,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%iec-var%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var%isc)
+  else
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_in,1), ' does not match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_in,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%jec-var%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var%jsc)
+  else
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_in,2), ' does not match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var%jsc-halo)  
+  endif
+
+  if ((k_out > var%ke) .or. (k_out < var%ks)) then
+    write (error_msg, *) trim(error_header), ' The seted k-index of ', k_out, &
+           ' is outside of the valid range of ', var%ks, ' to ', var%ke
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+
+  do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+    var%bc(bc_index)%field(field_index)%values(i,j,k_out) = scale * array_in(i+i_off,j+j_off)
+  enddo ; enddo
+
+end subroutine CT_set_data_2d_3d
+
+!> This subroutine sets a single 3-d field in a coupler_3d_bc_type from
+!! a three-dimensional array.
+subroutine CT_set_data_3d(array_in, bc_index, field_index, var, &
+                          scale_factor, halo_size, idim, jdim)
+  real, dimension(1:,1:,1:),  intent(in)    :: array_in  !< The source array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  type(coupler_3d_bc_type),   intent(inout) :: var       !< BC_type structure with the data to be set
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_set_data_3d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, k, halo, i_off, j_off, k_off
+
+  if (bc_index <= 0) return
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
+  if (field_index > var%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_in,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%iec-var%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var%isc)
+  else
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_in,1), ' does not match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_in,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%jec-var%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var%jsc)
+  else
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_in,2), ' does not match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var%jsc-halo)  
+  endif
+
+  if (size(array_in,3) /= 1 + var%ke - var%ks) then
+    write (error_msg, *) trim(error_header), ' The target array with k-dimension size ', &
+          size(array_in,3), ' does not match the data of size ', &
+          (1 + var%ke - var%ks)
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  k_off = 1 - var%ks
+
+  do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+    var%bc(bc_index)%field(field_index)%values(i,j,k) = scale * array_in(i+i_off,j+j_off,k+k_off) 
+  enddo ; enddo ; enddo
+
+end subroutine CT_set_data_3d
+
+
+!> This routine registers the diagnostics of a coupler_2d_bc_type.
+subroutine CT_set_diags_2d(var, diag_name, axes, time)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure for which to register diagnostics
+  character(len=*),         intent(in)    :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:),    intent(in)    :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type),          intent(in)    :: time !< model time variable for registering diagnostic field
+
+  integer :: m, n
+
+  if (diag_name == ' ') return
+
+  if (size(axes) < 2) then
+    call mpp_error(FATAL, '==>Error from coupler_types_mod' //&
+             '(coupler_types_set_diags_3d): axes has less than 2 elements')
+  endif
+
+  do n = 1, var%num_bcs
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_diag = register_diag_field(diag_name,                &
+           var%bc(n)%field(m)%name, axes(1:2), Time,                             &
+           var%bc(n)%field(m)%long_name, var%bc(n)%field(m)%units )
+    enddo
+  enddo
+
+end subroutine CT_set_diags_2d
+
+!> This routine registers the diagnostics of a coupler_3d_bc_type.
+subroutine CT_set_diags_3d(var, diag_name, axes, time)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure for which to register diagnostics
+  character(len=*),         intent(in)    :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:),    intent(in)    :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type),          intent(in)    :: time !< model time variable for registering diagnostic field
+
+  integer :: m, n
+
+  if (diag_name == ' ') return
+
+  if (size(axes) < 3) then
+    call mpp_error(FATAL, '==>Error from coupler_types_mod' //&
+             '(coupler_types_set_diags_3d): axes has less than 3 elements')
+  endif
+
+  do n = 1, var%num_bcs
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_diag = register_diag_field(diag_name,                &
+           var%bc(n)%field(m)%name, axes(1:3), Time,                             &
+           var%bc(n)%field(m)%long_name, var%bc(n)%field(m)%units )
+    enddo
+  enddo
+
+end subroutine CT_set_diags_3d
+
+
+!> This subroutine writes out all diagnostics of elements of a coupler_2d_bc_type
+subroutine CT_send_data_2d(var, Time)
+  type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure with the diagnostics to write
+  type(time_type),          intent(in) :: time !< The current model time
+
+  integer :: m, n
+  logical :: used
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    used = send_data(var%bc(n)%field(m)%id_diag, var%bc(n)%field(m)%values, Time)
+  enddo ; enddo
+
+end subroutine CT_send_data_2d
+
+!> This subroutine writes out all diagnostics of elements of a coupler_2d_bc_type
+subroutine CT_send_data_3d(var, Time)
+  type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure with the diagnostics to write
+  type(time_type),          intent(in) :: time !< The current model time
+
+  integer :: m, n
+  logical :: used
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    used = send_data(var%bc(n)%field(m)%id_diag, var%bc(n)%field(m)%values, Time)
+  enddo ; enddo
+
+end subroutine CT_send_data_3d
+
+
+!> This subroutine registers the fields in a coupler_2d_bc_type to be saved
+!! in restart files specified in the field table.
+subroutine CT_register_restarts_2d(var, bc_rest_files, num_rest_files, mpp_domain, ocean_restart)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
+  type(restart_file_type),  dimension(:), pointer :: bc_rest_files !< Structures describing the restart files
+  integer,                  intent(out) :: num_rest_files !< The number of restart files to use
+  type(domain2D),           intent(in)  :: mpp_domain     !< The FMS domain to use for this registration call
+  logical,        optional, intent(in)  :: ocean_restart  !< If true, use the ocean restart file name.
+
+  character(len=80), dimension(max(1,var%num_bcs)) :: rest_file_names
+  character(len=80) :: file_nm
+  logical :: ocn_rest
+  integer :: f, n, m
+
+  ocn_rest = .true. ; if (present(ocean_restart)) ocn_rest = ocean_restart
+
+  ! Determine the number and names of the restart files
+  num_rest_files = 0
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+    file_nm = trim(var%bc(n)%ice_restart_file)
+    if (ocn_rest) file_nm = trim(var%bc(n)%ocean_restart_file)
+    do f = 1, num_rest_files
+      if (trim(file_nm) == trim(rest_file_names(f))) exit
+    enddo
+    if (f>num_rest_files) then
+      num_rest_files = num_rest_files + 1
+      rest_file_names(f) = trim(file_nm)
+    endif
+  enddo
+
+  if (num_rest_files == 0) return
+
+  ! Register the fields with the restart files
+  allocate(bc_rest_files(num_rest_files))
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+
+    file_nm = trim(var%bc(n)%ice_restart_file)
+    if (ocn_rest) file_nm = trim(var%bc(n)%ocean_restart_file)
+    do f = 1, num_rest_files
+      if (trim(file_nm) == trim(rest_file_names(f))) exit
+    enddo
+
+    var%bc(n)%rest_type => bc_rest_files(f)
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_rest = register_restart_field(bc_rest_files(f), &
+              rest_file_names(f), var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
+    enddo
+  enddo
+
+end subroutine CT_register_restarts_2d
+
+!> This subroutine registers the fields in a coupler_2d_bc_type to be saved
+!! in the specified restart file.
+subroutine CT_register_restarts_to_file_2d(var, file_name, rest_file, mpp_domain)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
+  character(len=*),         intent(in)    :: file_name !< The name of the restart file
+  type(restart_file_type),  pointer       :: rest_file !< A (possibly associated) structure describing the restart file
+  type(domain2D),           intent(in)    :: mpp_domain !< The FMS domain to use for this registration call
+
+  integer :: n, m
+
+  ! Register the fields with the restart file
+  if (.not.associated(rest_file)) allocate(rest_file)
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+
+    var%bc(n)%rest_type => rest_file
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_rest = register_restart_field(rest_file, &
+              file_name, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
+    enddo
+  enddo
+
+end subroutine CT_register_restarts_to_file_2d
+
+!> This subroutine registers the fields in a coupler_3d_bc_type to be saved
+!! in restart files specified in the field table.
+subroutine CT_register_restarts_3d(var, bc_rest_files, num_rest_files, mpp_domain, ocean_restart)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
+  type(restart_file_type),  dimension(:), pointer :: bc_rest_files !< Structures describing the restart files
+  integer,                  intent(out)   :: num_rest_files !< The number of restart files to use
+  type(domain2D),           intent(in)    :: mpp_domain     !< The FMS domain to use for this registration call
+  logical,        optional, intent(in)    :: ocean_restart  !< If true, use the ocean restart file name.
+
+  character(len=80), dimension(max(1,var%num_bcs)) :: rest_file_names
+  character(len=80) :: file_nm
+  logical :: ocn_rest
+  integer :: f, n, m, id_restart
+
+  ocn_rest = .true. ; if (present(ocean_restart)) ocn_rest = ocean_restart
+
+  ! Determine the number and names of the restart files
+  num_rest_files = 0
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+    file_nm = trim(var%bc(n)%ice_restart_file)
+    if (ocn_rest) file_nm = trim(var%bc(n)%ocean_restart_file)
+    do f = 1, num_rest_files
+      if (trim(file_nm) == trim(rest_file_names(f))) exit
+    enddo
+    if (f>num_rest_files) then
+      num_rest_files = num_rest_files + 1
+      rest_file_names(f) = trim(file_nm)
+    endif
+  enddo
+
+  if (num_rest_files == 0) return
+
+  ! Register the fields with the restart files
+  allocate(bc_rest_files(num_rest_files))
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+    file_nm = trim(var%bc(n)%ice_restart_file)
+    if (ocn_rest) file_nm = trim(var%bc(n)%ocean_restart_file)
+    do f = 1, num_rest_files
+      if (trim(file_nm) == trim(rest_file_names(f))) exit
+    enddo
+
+    var%bc(n)%rest_type => bc_rest_files(f)
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_rest = register_restart_field(bc_rest_files(f), &
+              rest_file_names(f), var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
+    enddo
+  enddo
+
+end subroutine CT_register_restarts_3d
+
+!> This subroutine registers the fields in a coupler_3d_bc_type to be saved
+!! in the specified restart file.
+subroutine CT_register_restarts_to_file_3d(var, file_name, rest_file, mpp_domain)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
+  character(len=*),         intent(in)  :: file_name !< The name of the restart file
+  type(restart_file_type),  pointer     :: rest_file !< A (possibly associated) structure describing the restart file
+  type(domain2D),           intent(in)  :: mpp_domain     !< The FMS domain to use for this registration call
+
+  integer :: n, m
+
+  ! Register the fields with the restart file
+  if (.not.associated(rest_file)) allocate(rest_file)
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+
+    var%bc(n)%rest_type => rest_file
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_rest = register_restart_field(rest_file, &
+              file_name, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
+    enddo
+  enddo
+
+end subroutine CT_register_restarts_to_file_3d
+
+
+!> This subroutine reads in the fields in a coupler_2d_bc_type that have
+!! been saved in restart files.
+subroutine CT_restore_state_2d(var, directory, all_or_nothing, &
+                                         all_required, test_by_field)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to restore from restart files
+  character(len=*), optional, intent(in)  :: directory !< A directory where the restart files should
+                                                  !! be found.  The default for FMS is 'INPUT'.
+  logical,        optional, intent(in)    :: all_or_nothing !< If true and there are non-mandatory
+                                                  !! restart fields, it is still an error if some
+                                                  !! fields are read successfully but others are not.
+  logical,        optional, intent(in)    :: all_required !< If true, all fields must be successfully
+                                                  !! read from the restart file, even if they were
+                                                  !! registered as not mandatory.
+  logical,        optional, intent(in)    :: test_by_field !< If true, all or none of the variables
+                                                  !! in a single field must be read successfully.
+
+  integer :: n, m, num_fld
+  character(len=80) :: unset_varname
+  logical :: any_set, all_set, all_var_set, any_var_set, var_set
+
+  any_set = .false. ; all_set = .true. ; num_fld = 0 ; unset_varname = ""
+
+  do n = 1, var%num_bcs
+    any_var_set = .false. ; all_var_set = .true.
+    do m = 1, var%bc(n)%num_fields
+      var_set = .false.
+      if (var%bc(n)%field(m)%id_rest > 0) then
+        var_set = query_initialized(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest)
+        if (.not.var_set) then
+          call restore_state(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest, &
+                             directory=directory, nonfatal_missing_files=.true.)
+          var_set = query_initialized(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest)
+        endif
+      endif
+
+      if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%name)
+      if (var_set) any_set = .true.
+      if (all_set) all_set = var_set
+      if (var_set) any_var_set = .true.
+      if (all_var_set) all_var_set = var_set
+    enddo
+
+    num_fld = num_fld + var%bc(n)%num_fields
+    if ((var%bc(n)%num_fields > 0) .and. present(test_by_field)) then
+      if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL, &
+             "CT_restore_state_2d: test_by_field is true, and "//&
+             trim(unset_varname)//" was not read but some other fields in "//&
+             trim(trim(var%bc(n)%name))//" were.")
+    endif
+  enddo
+
+  if ((num_fld > 0) .and. present(all_or_nothing)) then
+    if (all_or_nothing .and. (all_set .neqv. any_set)) call mpp_error(FATAL, &
+           "CT_restore_state_2d: all_or_nothing is true, and "//&
+           trim(unset_varname)//" was not read but some other fields were.")
+  endif
+
+  if (present(all_required)) then ; if (all_required .and. .not.all_set) then
+    call mpp_error(FATAL, "CT_restore_state_2d: all_required is true, but "//&
+           trim(unset_varname)//" was not read from its restart file.")
+  endif ; endif
+
+end subroutine CT_restore_state_2d
+
+!> This subroutine reads in the fields in a coupler_3d_bc_type that have
+!! been saved in restart files.
+subroutine CT_restore_state_3d(var, directory, all_or_nothing, &
+                                         all_required, test_by_field)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to restore from restart files
+  character(len=*), optional, intent(in)  :: directory !< A directory where the restart files should
+                                                  !! be found.  The default for FMS is 'INPUT'.
+  logical,        optional, intent(in)    :: all_or_nothing !< If true and there are non-mandatory
+                                                  !! restart fields, it is still an error if some
+                                                  !! fields are read successfully but others are not.
+  logical,        optional, intent(in)    :: all_required !< If true, all fields must be successfully
+                                                  !! read from the restart file, even if they were
+                                                  !! registered as not mandatory.
+  logical,        optional, intent(in)    :: test_by_field !< If true, all or none of the variables
+                                                  !! in a single field must be read successfully.
+
+  integer :: n, m, num_fld
+  character(len=80) :: unset_varname
+  logical :: any_set, all_set, all_var_set, any_var_set, var_set
+
+  any_set = .false. ; all_set = .true. ; num_fld = 0 ; unset_varname = ""
+
+  do n = 1, var%num_bcs
+    any_var_set = .false. ; all_var_set = .true.
+    do m = 1, var%bc(n)%num_fields
+      var_set = .false.
+      if (var%bc(n)%field(m)%id_rest > 0) then
+        var_set = query_initialized(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest)
+        if (.not.var_set) then
+          call restore_state(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest, &
+                             directory=directory, nonfatal_missing_files=.true.)
+          var_set = query_initialized(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest)
+        endif
+      endif
+
+      if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%name)
+
+      if (var_set) any_set = .true.
+      if (all_set) all_set = var_set
+      if (var_set) any_var_set = .true.
+      if (all_var_set) all_var_set = var_set
+    enddo
+
+    num_fld = num_fld + var%bc(n)%num_fields
+    if ((var%bc(n)%num_fields > 0) .and. present(test_by_field)) then
+      if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL, &
+             "CT_restore_state_3d: test_by_field is true, and "//&
+             trim(unset_varname)//" was not read but some other fields in "//&
+             trim(trim(var%bc(n)%name))//" were.")
+    endif
+  enddo
+
+  if ((num_fld > 0) .and. present(all_or_nothing)) then
+    if (all_or_nothing .and. (all_set .neqv. any_set)) call mpp_error(FATAL, &
+           "CT_restore_state_3d: all_or_nothing is true, and "//&
+           trim(unset_varname)//" was not read but some other fields were.")
+  endif
+
+  if (present(all_required)) then ; if (all_required .and. .not.all_set) then
+    call mpp_error(FATAL, "CT_restore_state_3d: all_required is true, but "//&
+           trim(unset_varname)//" was not read from its restart file.")
+  endif ; endif
+
+end subroutine CT_restore_state_3d
+
+
+!> This subroutine potentially overrides the values in a coupler_2d_bc_type
+subroutine CT_data_override_2d(gridname, var, Time)
+  character(len=3),         intent(in) :: gridname !< 3-character long model grid ID
+  type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure to override
+  type(time_type),          intent(in) :: time !< The current model time
+
+  integer :: m, n
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    call data_override(gridname, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, Time)
+  enddo ; enddo
+
+end subroutine CT_data_override_2d
+
+!> This subroutine potentially overrides the values in a coupler_3d_bc_type
+subroutine CT_data_override_3d(gridname, var, Time)
+  character(len=3),         intent(in) :: gridname !< 3-character long model grid ID
+  type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure to override
+  type(time_type),          intent(in) :: time !< The current model time
+
+  integer :: m, n
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    call data_override(gridname, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, Time)
+  enddo ; enddo
+
+end subroutine CT_data_override_3d
+
+
+!> This subroutine writes out checksums for the elements of a coupler_2d_bc_type
+subroutine CT_write_chksums_2d(var, outunit, name_lead)
+  type(coupler_2d_bc_type),   intent(in) :: var  !< BC_type structure for which to register diagnostics
+  integer,                    intent(in) :: outunit !< The index of a open output file
+  character(len=*), optional, intent(in) :: name_lead !< An optional prefix for the variable names
+
+  character(len=120) :: var_name
+  integer :: m, n
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    if (present(name_lead)) then
+      var_name = trim(name_lead)//trim(var%bc(n)%field(m)%name)
+    else
+      var_name = trim(var%bc(n)%field(m)%name)
+    endif
+    write(outunit, '("   CHECKSUM:: ",A40," = ",Z20)') trim(var_name), &
+      mpp_chksum(var%bc(n)%field(m)%values(var%isc:var%iec,var%jsc:var%jec) )
+  enddo ; enddo
+
+end subroutine CT_write_chksums_2d
+
+!> This subroutine writes out checksums for the elements of a coupler_3d_bc_type
+subroutine CT_write_chksums_3d(var, outunit, name_lead)
+  type(coupler_3d_bc_type),   intent(in) :: var  !< BC_type structure for which to register diagnostics
+  integer,                    intent(in) :: outunit !< The index of a open output file
+  character(len=*), optional, intent(in) :: name_lead !< An optional prefix for the variable names
+
+  character(len=120) :: var_name
+  integer :: m, n
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    if (present(name_lead)) then
+      var_name = trim(name_lead)//trim(var%bc(n)%field(m)%name)
+    else
+      var_name = trim(var%bc(n)%field(m)%name)
+    endif
+    write(outunit, '("   CHECKSUM:: ",A40," = ",Z20)') var_name, &
+      mpp_chksum(var%bc(n)%field(m)%values(var%isc:var%iec,var%jsc:var%jec,:) )
+  enddo ; enddo
+
+end subroutine CT_write_chksums_3d
+
+
+!> This function indicates whether a coupler_1d_bc_type has been initialized.
+function CT_initialized_1d(var)
+  type(coupler_1d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
+  logical :: CT_initialized_1d  !< The return value, indicating whether this type has been initialized
+  
+  CT_initialized_1d = var%set
+end function CT_initialized_1d
+
+!> This function indicates whether a coupler_2d_bc_type has been initialized.
+function CT_initialized_2d(var)
+  type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
+  logical :: CT_initialized_2d  !< The return value, indicating whether this type has been initialized
+  
+  CT_initialized_2d = var%set
+end function CT_initialized_2d
+
+!> This function indicates whether a coupler_3d_bc_type has been initialized.
+function CT_initialized_3d(var)
+  type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
+  logical :: CT_initialized_3d  !< The return value, indicating whether this type has been initialized
+  
+  CT_initialized_3d = var%set
+end function CT_initialized_3d
+
+
+!> This subroutine deallocates all data associated with a coupler_1d_bc_type
+subroutine CT_destructor_1d(var)
+  type(coupler_1d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
+
+  integer :: m, n
+ 
+  if (var%num_bcs > 0) then
+    do n = 1, var%num_bcs
+      do m = 1, var%bc(n)%num_fields
+        deallocate ( var%bc(n)%field(m)%values )
+      enddo
+      deallocate ( var%bc(n)%field )
+    enddo
+    deallocate ( var%bc )
+  endif
+
+  var%num_bcs = 0 ; var%set = .false.
+
+end subroutine CT_destructor_1d
+
+!> This subroutine deallocates all data associated with a coupler_2d_bc_type
+subroutine CT_destructor_2d(var)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
+
+  integer :: m, n
+ 
+  if (var%num_bcs > 0) then
+    do n = 1, var%num_bcs
+      do m = 1, var%bc(n)%num_fields
+        deallocate ( var%bc(n)%field(m)%values )
+      enddo
+      deallocate ( var%bc(n)%field )
+    enddo
+    deallocate ( var%bc )
+  endif
+
+  var%num_bcs = 0 ; var%set = .false.
+
+end subroutine CT_destructor_2d
+
+
+!> This subroutine deallocates all data associated with a coupler_3d_bc_type
+subroutine CT_destructor_3d(var)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
+
+  integer :: m, n
+ 
+  if (var%num_bcs > 0) then
+    do n = 1, var%num_bcs
+      do m = 1, var%bc(n)%num_fields
+        deallocate ( var%bc(n)%field(m)%values )
+      enddo
+      deallocate ( var%bc(n)%field )
+    enddo
+    deallocate ( var%bc )
+  endif
+
+  var%num_bcs = 0 ; var%set = .false.
+
+end subroutine CT_destructor_3d
+
+end module coupler_types_mod

--- a/config_src/ice_solo_driver/coupler_util.F90
+++ b/config_src/ice_solo_driver/coupler_util.F90
@@ -1,0 +1,161 @@
+module coupler_util
+!***********************************************************************
+!*                   GNU General Public License                        *
+!* This file is a part of MOM.                                         *
+!*                                                                     *
+!* MOM is free software; you can redistribute it and/or modify it and  *
+!* are expected to follow the terms of the GNU General Public License  *
+!* as published by the Free Software Foundation; either version 2 of   *
+!* the License, or (at your option) any later version.                 *
+!*                                                                     *
+!* MOM is distributed in the hope that it will be useful, but WITHOUT  *
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  *
+!* or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public    *
+!* License for more details.                                           *
+!*                                                                     *
+!* For the full text of the GNU General Public License,                *
+!* write to: Free Software Foundation, Inc.,                           *
+!*           675 Mass Ave, Cambridge, MA 02139, USA.                   *
+!* or see:   http://www.gnu.org/licenses/gpl.html                      *
+!***********************************************************************
+
+!   This code provides a couple of interfaces to allow more transparent and
+! robust extraction of the various fields in the coupler types.
+use MOM_error_handler, only : MOM_error, FATAL, WARNING
+use coupler_types_mod, only : coupler_2d_bc_type, ind_flux, ind_alpha
+use coupler_types_mod, only : ind_csurf
+
+implicit none ; private
+
+public :: extract_coupler_values, set_coupler_values
+public :: ind_flux, ind_alpha, ind_csurf
+
+contains
+
+subroutine extract_coupler_values(BC_struc, BC_index, BC_element, array_out, &
+                                  is, ie, js, je, conversion)
+  type(coupler_2d_bc_type), intent(in)  :: BC_struc
+  integer,                  intent(in)  :: BC_index, BC_element
+  real, dimension(:,:),     intent(out) :: array_out
+  integer,        optional, intent(in)  :: is, ie, js, je
+  real,           optional, intent(in)  :: conversion
+! Arguments: BC_struc - The type from which the data is being extracted.
+!  (in)      BC_index - The boundary condition number being extracted.
+!  (in)      BC_element - The element of the boundary condition being extracted.
+!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
+!  (out)     array_out - The array being filled with the input values.
+!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
+!            These must match the size of the corresponding value array or an
+!            error message is issued.
+!  (in, opt) conversion - A number that every element is multiplied by, to
+!                         permit sign convention or unit conversion.
+
+  real, pointer, dimension(:,:) :: Array_in
+  real :: conv
+  integer :: i, j, is0, ie0, js0, je0, i_offset, j_offset
+
+  if ((BC_element /= ind_flux) .and. (BC_element /= ind_alpha) .and. &
+      (BC_element /= ind_csurf)) then
+    call MOM_error(FATAL,"extract_coupler_values: Unrecognized BC_element.")
+  endif
+
+  ! These error messages should be made more explicit.
+!  if (.not.associated(BC_struc%bc(BC_index))) &
+  if (.not.associated(BC_struc%bc)) &
+    call MOM_error(FATAL,"extract_coupler_values: " // &
+       "The requested boundary condition is not associated.")
+!  if (.not.associated(BC_struc%bc(BC_index)%field(BC_element))) &
+  if (.not.associated(BC_struc%bc(BC_index)%field)) &
+    call MOM_error(FATAL,"extract_coupler_values: " // &
+       "The requested boundary condition element is not associated.")
+  if (.not.associated(BC_struc%bc(BC_index)%field(BC_element)%values)) &
+    call MOM_error(FATAL,"extract_coupler_values: " // &
+       "The requested boundary condition value array is not associated.")
+
+  Array_in => BC_struc%bc(BC_index)%field(BC_element)%values
+
+  if (present(is)) then ; is0 = is ; else ; is0 = LBOUND(array_out,1) ; endif
+  if (present(ie)) then ; ie0 = ie ; else ; ie0 = UBOUND(array_out,1) ; endif
+  if (present(js)) then ; js0 = js ; else ; js0 = LBOUND(array_out,2) ; endif
+  if (present(je)) then ; je0 = je ; else ; je0 = UBOUND(array_out,2) ; endif
+
+  conv = 1.0 ; if (present(conversion)) conv = conversion
+
+  if (size(Array_in,1) /= ie0 - is0 + 1) &
+    call MOM_error(FATAL,"extract_coupler_values: Mismatch in i-size " // &
+                   "between BC array and output array or computational domain.")
+  if (size(Array_in,2) /= je0 - js0 + 1) &
+    call MOM_error(FATAL,"extract_coupler_values: Mismatch in i-size " // &
+                   "between BC array and output array or computational domain.")
+  i_offset = lbound(Array_in,1) - is0
+  j_offset = lbound(Array_in,2) - js0
+  do j=js0,je0 ; do i=is0,ie0
+    array_out(i,j) = conv * Array_in(i+i_offset,j+j_offset)
+  enddo ; enddo
+
+end subroutine extract_coupler_values
+
+subroutine set_coupler_values(array_in, BC_struc, BC_index, BC_element, &
+                              is, ie, js, je, conversion)
+  real, dimension(:,:),     intent(in)    :: array_in
+  type(coupler_2d_bc_type), intent(inout) :: BC_struc
+  integer,                  intent(in)    :: BC_index, BC_element
+  integer,        optional, intent(in)    :: is, ie, js, je
+  real,           optional, intent(in)    :: conversion
+! Arguments: array_in - The array containing the values to load into the BC.
+!  (out)     BC_struc - The type into which the data is being loaded.
+!  (in)      BC_index - The boundary condition number being extracted.
+!  (in)      BC_element - The element of the boundary condition being extracted.
+!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
+!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
+!            These must match the size of the corresponding value array or an
+!            error message is issued.
+!  (in, opt) conversion - A number that every element is multiplied by, to
+!                         permit sign convention or unit conversion.
+
+  real, pointer, dimension(:,:) :: Array_out
+  real :: conv
+  integer :: i, j, is0, ie0, js0, je0, i_offset, j_offset
+
+  if ((BC_element /= ind_flux) .and. (BC_element /= ind_alpha) .and. &
+      (BC_element /= ind_csurf)) then
+    call MOM_error(FATAL,"extract_coupler_values: Unrecognized BC_element.")
+  endif
+
+  ! These error messages should be made more explicit.
+!  if (.not.associated(BC_struc%bc(BC_index))) &
+  if (.not.associated(BC_struc%bc)) &
+    call MOM_error(FATAL,"set_coupler_values: " // &
+       "The requested boundary condition is not associated.")
+!  if (.not.associated(BC_struc%bc(BC_index)%field(BC_element))) &
+  if (.not.associated(BC_struc%bc(BC_index)%field)) &
+    call MOM_error(FATAL,"set_coupler_values: " // &
+       "The requested boundary condition element is not associated.")
+  if (.not.associated(BC_struc%bc(BC_index)%field(BC_element)%values)) &
+    call MOM_error(FATAL,"set_coupler_values: " // &
+       "The requested boundary condition value array is not associated.")
+
+  Array_out => BC_struc%bc(BC_index)%field(BC_element)%values
+
+  if (present(is)) then ; is0 = is ; else ; is0 = LBOUND(array_in,1) ; endif
+  if (present(ie)) then ; ie0 = ie ; else ; ie0 = UBOUND(array_in,1) ; endif
+  if (present(js)) then ; js0 = js ; else ; js0 = LBOUND(array_in,2) ; endif
+  if (present(je)) then ; je0 = je ; else ; je0 = UBOUND(array_in,2) ; endif
+
+  conv = 1.0 ; if (present(conversion)) conv = conversion
+
+  if (size(Array_out,1) /= ie0 - is0 + 1) &
+    call MOM_error(FATAL,"extract_coupler_values: Mismatch in i-size " // &
+                   "between BC array and input array or computational domain.")
+  if (size(Array_out,2) /= je0 - js0 + 1) &
+    call MOM_error(FATAL,"extract_coupler_values: Mismatch in i-size " // &
+                   "between BC array and input array or computational domain.")
+  i_offset = lbound(Array_out,1) - is0
+  j_offset = lbound(Array_out,2) - js0
+  do j=js0,je0 ; do i=is0,ie0
+    Array_out(i+i_offset,j+j_offset) = conv * array_in(i,j)
+  enddo ; enddo
+
+end subroutine set_coupler_values
+
+end module coupler_util

--- a/config_src/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/solo_driver/MOM_surface_forcing.F90
@@ -353,7 +353,6 @@ subroutine set_forcing(state, fluxes, day_start, day_interval, G, CS)
   endif
 
   if (associated(CS%tracer_flow_CSp)) then
-    if (.not.associated(fluxes%tr_fluxes)) allocate(fluxes%tr_fluxes)
     call call_tracer_set_forcing(state, fluxes, day_start, day_interval, G, CS%tracer_flow_CSp)
   endif
 

--- a/config_src/solo_driver/atmos_ocean_fluxes.F90
+++ b/config_src/solo_driver/atmos_ocean_fluxes.F90
@@ -16,7 +16,7 @@ contains
 
 function aof_set_coupler_flux(name, flux_type, implementation, atm_tr_index,     &
                               param, flag, ice_restart_file, ocean_restart_file, &
-                              units, caller)  result (coupler_index)
+                              units, caller, verbosity)  result (coupler_index)
 
   character(len=*), intent(in)                          :: name
   character(len=*), intent(in)                          :: flux_type
@@ -28,6 +28,7 @@ function aof_set_coupler_flux(name, flux_type, implementation, atm_tr_index,    
   character(len=*), intent(in), optional                :: ocean_restart_file
   character(len=*), intent(in), optional                :: units
   character(len=*), intent(in), optional                :: caller
+  integer,          intent(in), optional                :: verbosity
 
   ! None of these arguments are used for anything.
 

--- a/config_src/solo_driver/coupler_types.F90
+++ b/config_src/solo_driver/coupler_types.F90
@@ -1,88 +1,3254 @@
 module coupler_types_mod
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*    This file is a part of MOM.  See MOM.F90 for licensing.          *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
-!
-! This file was modified for use in MOM6 from MOM4/5.
-!
-! This module contains simplified type declarations for the coupler
-! of an ocean-only model. With mom4/5, this is used with ocean_solo_mod
-! as the driver, and with MOM6 it is used with MOM_driver.
-!
+!-----------------------------------------------------------------------
+! This file is part of MOM6. See LICENSE.md for the license.
+!-----------------------------------------------------------------------
+
+!   This module contains the coupler-type declarations and methods for use in
+! ocean-only configurations of MOM6.  It is intended that the version of
+! coupler_types_mod that is avialable from FMS will conform to this version with
+! the FMS city release after warsaw.
+
+use fms_io_mod,        only: restart_file_type, register_restart_field
+use fms_io_mod,        only: query_initialized, restore_state
+use time_manager_mod,  only: time_type
+use diag_manager_mod,  only: register_diag_field, send_data
+use data_override_mod, only: data_override
+use mpp_domains_mod,   only: domain2D, mpp_redistribute
+use mpp_mod,           only: stdout, mpp_error, FATAL, mpp_chksum
 
 implicit none ; private
 
-type, public :: coupler_2d_bc_type
-  integer    :: num_bcs = 0
+public coupler_type_copy, coupler_type_spawn, coupler_type_set_diags
+public coupler_type_write_chksums, coupler_type_send_data, coupler_type_data_override
+public coupler_type_register_restarts, coupler_type_restore_state
+public coupler_type_increment_data, coupler_type_rescale_data
+public coupler_type_copy_data, coupler_type_redistribute_data
+public coupler_type_destructor, coupler_type_initialized
+public coupler_type_extract_data, coupler_type_set_data
+
+public coupler_type_copy_1d_2d
+public coupler_type_copy_1d_3d
+
+!
+!       3-d fields
+!
+type, public :: coupler_3d_values_type
+  character(len=48)       :: name = ' '  !< The diagnostic name for this array
+  real, pointer, contiguous, dimension(:,:,:) :: values => NULL() !< The pointer to the
+                                         !! array of values for this field; this
+                                         !! should be changed to allocatable
+  logical                 :: mean = .true. !< mean
+  logical                 :: override = .false. !< override
+  integer                 :: id_diag = 0 !< The diagnostic id for this array
+  character(len=128)      :: long_name = ' ' !< The diagnostic long_name for this array
+  character(len=128)      :: units = ' ' !< The units for this array
+  integer                 :: id_rest = 0 !< The id of this array in the restart field
+  logical                 :: may_init = .true. !< If true, there is an internal method
+                                         !! that can be used to initialize this field
+                                         !! if it can not be read from a restart file
+end type coupler_3d_values_type
+
+type, public :: coupler_3d_field_type
+  character(len=48)                 :: name = ' ' !< name
+  integer                           :: num_fields = 0 !< num_fields
+  type(coupler_3d_values_type), pointer, dimension(:) :: field => NULL() !< field
+  character(len=128)                :: flux_type = ' ' !< flux_type
+  character(len=128)                :: implementation = ' ' !< implementation
+  real, pointer, dimension(:)       :: param => NULL() !< param
+  logical, pointer, dimension(:)    :: flag => NULL() !< flag
+  integer                           :: atm_tr_index = 0 !< atm_tr_index
+  character(len=128)                :: ice_restart_file = ' ' !< ice_restart_file
+  character(len=128)                :: ocean_restart_file = ' ' !< ocean_restart_file
+  type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
+                                                           !! that is used for this field.
+  logical                           :: use_atm_pressure !< use_atm_pressure
+  logical                           :: use_10m_wind_speed !< use_10m_wind_speed
+  logical                           :: pass_through_ice !< pass_through_ice
+  real                              :: mol_wt = 0.0 !< mol_wt
+end type coupler_3d_field_type
+
+type, public :: coupler_3d_bc_type
+  integer                                            :: num_bcs = 0  !< The number of boundary condition fields
+  type(coupler_3d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary condition fields
+  logical    :: set = .false.       !< If true, this type has been initialized
+  integer    :: isd, isc, iec, ied  !< The i-direction data and computational domain index ranges for this type
+  integer    :: jsd, jsc, jec, jed  !< The j-direction data and computational domain index ranges for this type
+  integer    :: ks, ke              !< The k-direction index ranges for this type
+end type coupler_3d_bc_type
+
+!
+!       2-d fields
+!
+type, public    :: coupler_2d_values_type
+  character(len=48)       :: name = ' '  !< The diagnostic name for this array
+  real, pointer, contiguous, dimension(:,:) :: values => NULL() !< The pointer to the
+                                         !! array of values for this field; this
+                                         !! should be changed to allocatable
+  logical                 :: mean = .true. !< mean
+  logical                 :: override = .false. !< override
+  integer                 :: id_diag = 0 !< The diagnostic id for this array
+  character(len=128)      :: long_name = ' ' !< The diagnostic long_name for this array
+  character(len=128)      :: units = ' ' !< The units for this array
+  integer                 :: id_rest = 0 !< The id of this array in the restart field
+  logical                 :: may_init = .true. !< If true, there is an internal method
+                                         !! that can be used to initialize this field
+                                         !! if it can not be read from a restart file
+end type coupler_2d_values_type
+
+type, public    :: coupler_2d_field_type
+  character(len=48)                 :: name = ' ' !< name
+  integer                           :: num_fields = 0 !< num_fields
+  type(coupler_2d_values_type), pointer, dimension(:)   :: field => NULL() !< field
+  character(len=128)                :: flux_type = ' ' !< flux_type
+  character(len=128)                :: implementation = ' ' !< implementation
+  real, pointer, dimension(:)       :: param => NULL() !< param
+  logical, pointer, dimension(:)    :: flag => NULL() !< flag
+  integer                           :: atm_tr_index = 0 !< atm_tr_index
+  character(len=128)                :: ice_restart_file = ' ' !< ice_restart_file
+  character(len=128)                :: ocean_restart_file = ' ' !< ocean_restart_file
+  type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
+                                                          !! that is used for this field.
+  logical                           :: use_atm_pressure !< use_atm_pressure
+  logical                           :: use_10m_wind_speed !< use_10m_wind_speed
+  logical                           :: pass_through_ice !< pass_through_ice
+  real                              :: mol_wt = 0.0 !< mol_wt
+end type coupler_2d_field_type
+
+type, public    :: coupler_2d_bc_type
+  integer                                            :: num_bcs = 0  !< The number of boundary condition fields
+  type(coupler_2d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary condition fields
+  logical    :: set = .false.       !< If true, this type has been initialized
+  integer    :: isd, isc, iec, ied  !< The i-direction data and computational domain index ranges for this type
+  integer    :: jsd, jsc, jec, jed  !< The j-direction data and computational domain index ranges for this type
 end type coupler_2d_bc_type
 
-integer, public :: ind_flux=-1, ind_alpha=-2, ind_csurf=-3
+!
+!       1-d fields
+!
+type, public    :: coupler_1d_values_type
+  character(len=48)           :: name = ' '  !< The diagnostic name for this array
+  real, pointer, dimension(:) :: values => NULL() !< The pointer to the array of values
+  logical                     :: mean = .true. !< mean
+  logical                     :: override = .false. !< override
+  integer                     :: id_diag = 0 !< The diagnostic id for this array
+  character(len=128)          :: long_name = ' ' !< The diagnostic long_name for this array
+  character(len=128)          :: units = ' ' !< The units for this array
+  logical                     :: may_init = .true. !< If true, there is an internal method
+                                             !! that can be used to initialize this field
+                                             !! if it can not be read from a restart file
+end type coupler_1d_values_type
 
-end module coupler_types_mod
+type, public    :: coupler_1d_field_type
+  character(len=48)              :: name = ' ' !< name
+  integer                        :: num_fields = 0 !< num_fields
+  type(coupler_1d_values_type), pointer, dimension(:)   :: field => NULL() !< field
+  character(len=128)             :: flux_type = ' ' !< flux_type
+  character(len=128)             :: implementation = ' ' !< implementation
+  real, pointer, dimension(:)    :: param => NULL() !< param
+  logical, pointer, dimension(:) :: flag => NULL() !< flag
+  integer                        :: atm_tr_index = 0 !< atm_tr_index
+  character(len=128)             :: ice_restart_file = ' ' !< ice_restart_file
+  character(len=128)             :: ocean_restart_file = ' ' !< ocean_restart_file
+  logical                        :: use_atm_pressure !< use_atm_pressure
+  logical                        :: use_10m_wind_speed !< use_10m_wind_speed
+  logical                        :: pass_through_ice !< pass_through_ice
+  real                           :: mol_wt = 0.0 !< mol_wt
+end type coupler_1d_field_type
 
+type, public    :: coupler_1d_bc_type
+  integer                                            :: num_bcs = 0  !< The number of boundary condition fields
+  type(coupler_1d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary condition fields
+  logical    :: set = .false.       !< If true, this type has been initialized
+end type coupler_1d_bc_type
 
-!============= DUMMY VERSION OF coupler_util ===================================
+!----------------------------------------------------------------------
+!   The following public parameters can help in selecting the sub-elements of a
+! coupler type.  There are duplicate values because different boundary
+! conditions have different sub-elements.
+integer, parameter, public :: ind_pcair = 1 !< The index of the atmospheric concentration
+integer, parameter, public :: ind_u10 = 2   !< The index of the 10 m wind speed
+integer, parameter, public :: ind_psurf = 3 !< The index of the surface atmospheric pressure
+integer, parameter, public :: ind_alpha = 1 !< The index of the solubility array for a tracer
+integer, parameter, public :: ind_csurf = 2 !< The index of the ocean surface concentration
+integer, parameter, public :: ind_sc_no = 3 !< The index for the Schmidt number for a tracer flux
+integer, parameter, public :: ind_flux = 1  !< The index for the tracer flux
+integer, parameter, public :: ind_deltap= 2 !< The index for ocean-air gas partial pressure change
+integer, parameter, public :: ind_kw = 3    !< The index for the piston velocity
+integer, parameter, public :: ind_deposition = 1 !< The index for the atmospheric deposition flux
+integer, parameter, public :: ind_runoff = 1 !< The index for a runoff flux
 
-module coupler_util
+!----------------------------------------------------------------------
+!        Interface definitions for overloaded routines
+!----------------------------------------------------------------------
 
-use MOM_error_handler, only : MOM_error, FATAL, WARNING
-use coupler_types_mod, only : coupler_2d_bc_type, ind_flux, ind_alpha, ind_csurf
+!> This is the interface to spawn one coupler_bc_type into another and then
+!! register diagnostics associated with the new type.
+interface  coupler_type_copy
+  module procedure coupler_type_copy_1d_2d, coupler_type_copy_1d_3d
+  module procedure coupler_type_copy_2d_2d, coupler_type_copy_2d_3d
+  module procedure coupler_type_copy_3d_2d, coupler_type_copy_3d_3d
+end interface coupler_type_copy
 
-implicit none ; private
+!> This is the interface to spawn one coupler_bc_type into another.
+interface  coupler_type_spawn
+  module procedure CT_spawn_1d_2d, CT_spawn_2d_2d, CT_spawn_3d_2d
+  module procedure CT_spawn_1d_3d, CT_spawn_2d_3d, CT_spawn_3d_3d
+end interface coupler_type_spawn
 
-public :: extract_coupler_values, set_coupler_values
-public :: ind_flux, ind_alpha, ind_csurf
+!> This is the interface to copy the field data from one coupler_bc_type
+!! to another of the same rank, size and decomposition.
+interface coupler_type_copy_data
+  module procedure CT_copy_data_2d, CT_copy_data_3d, CT_copy_data_2d_3d
+end interface coupler_type_copy_data
+
+!> This is the interface to redistribute the field data from one coupler_bc_type
+!! to another of the same rank and global size, but a different decomposition.
+interface coupler_type_redistribute_data
+  module procedure CT_redistribute_data_2d, CT_redistribute_data_3d
+end interface coupler_type_redistribute_data
+
+!> This is the interface to rescale the field data in a coupler_bc_type.
+interface coupler_type_rescale_data
+  module procedure CT_rescale_data_2d, CT_rescale_data_3d
+end interface coupler_type_rescale_data
+
+!> This is the interface to increment the field data from one coupler_bc_type
+!! with the data from another.  Both must have the same horizontal size and
+!! decomposition, but a 2d type may be incremented by a 2d or 3d type
+interface coupler_type_increment_data
+  module procedure CT_increment_data_2d_2d, CT_increment_data_3d_3d, CT_increment_data_2d_3d
+end interface coupler_type_increment_data
+
+!> This is the interface to extract a field in a coupler_bc_type into an array.
+interface coupler_type_extract_data
+  module procedure CT_extract_data_2d, CT_extract_data_3d, CT_extract_data_3d_2d
+end interface coupler_type_extract_data
+
+!> This is the interface to set a field in a coupler_bc_type from an array.
+interface coupler_type_set_data
+  module procedure CT_set_data_2d, CT_set_data_3d, CT_set_data_2d_3d
+end interface coupler_type_set_data
+
+!> This is the interface to set diagnostics for the arrays in a coupler_bc_type.
+interface coupler_type_set_diags
+  module procedure CT_set_diags_2d, CT_set_diags_3d
+end interface coupler_type_set_diags
+
+!> This is the interface to write out checksums for the elements of a coupler_bc_type.
+interface coupler_type_write_chksums
+  module procedure CT_write_chksums_2d, CT_write_chksums_3d
+end interface coupler_type_write_chksums
+
+!> This is the interface to write out diagnostics of the arrays in a coupler_bc_type.
+interface coupler_type_send_data
+  module procedure CT_send_data_2d, CT_send_data_3d
+end interface coupler_type_send_data
+
+!> This is the interface to override the values of the arrays in a coupler_bc_type.
+interface coupler_type_data_override
+  module procedure CT_data_override_2d, CT_data_override_3d
+end interface coupler_type_data_override
+
+!> This is the interface to register the fields in a coupler_bc_type to be saved
+!! in restart files.
+interface coupler_type_register_restarts
+  module procedure CT_register_restarts_2d, CT_register_restarts_3d
+  module procedure CT_register_restarts_to_file_2d, CT_register_restarts_to_file_3d
+end interface coupler_type_register_restarts
+
+!> This is the interface to read in the fields in a coupler_bc_type that have
+!! been saved in restart files.
+interface coupler_type_restore_state
+  module procedure CT_restore_state_2d, CT_restore_state_3d
+end interface coupler_type_restore_state
+
+!> This function interface indicates whether a coupler_bc_type has been initialized.
+interface coupler_type_initialized
+  module procedure CT_initialized_1d, CT_initialized_2d, CT_initialized_3d
+end interface coupler_type_initialized
+
+!> This is the interface to deallocate any data associated with a coupler_bc_type.
+interface coupler_type_destructor
+  module procedure CT_destructor_1d, CT_destructor_2d, CT_destructor_3d
+end interface coupler_type_destructor
 
 contains
 
-subroutine extract_coupler_values(BC_struc, BC_index, BC_element, array_out, &
-                                  is, ie, js, je, conversion)
-  type(coupler_2d_bc_type), intent(in)    :: BC_struc
-  integer,                  intent(in)    :: BC_index, BC_element
-  real, dimension(:,:),     intent(inout) :: array_out
-  integer,        optional, intent(in)    :: is, ie, js, je
-  real,           optional, intent(in)    :: conversion
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 1-D to 2-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+subroutine coupler_type_copy_1d_2d(var_in, var_out, is, ie, js, je,     &
+     diag_name, axes, time, suffix)
 
-! Arguments: BC_struc - The type from which the data is being extracted.
-!  (in)      BC_index - The boundary condition number being extracted.
-!  (in)      BC_element - The element of the boundary condition being extracted.
-!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
-!  (out)     array_out - The array being filled with the input values.
-!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
-!            These must match the size of the corresponding value array or an
-!            error message is issued.
-!  (in, opt) conversion - A number that every element is multiplied by, to
-!                         permit sign convention or unit conversion.
+  type(coupler_1d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_2d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
 
-  call MOM_error(FATAL,"The called version of extract_coupler_values does" // &
-                 " nothing but issue this fatal error message.")
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (coupler_type_copy_1d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
 
-end subroutine extract_coupler_values
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
 
-subroutine set_coupler_values(array_in, BC_struc, BC_index, BC_element, &
-                              is, ie, js, je, conversion)
-  real, dimension(:,:),     intent(in)    :: array_in
-  type(coupler_2d_bc_type), intent(inout) :: BC_struc
-  integer,                  intent(in)    :: BC_index, BC_element
-  integer,        optional, intent(in)    :: is, ie, js, je
-  real,           optional, intent(in)    :: conversion
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_1d_2d(var_in, var_out, (/ is, is, ie, ie /), (/ js, js, je, je /), suffix)
 
-! Arguments: array_in - The array containing the values to load into the BC.
-!  (out)     BC_struc - The type into which the data is being loaded.
-!  (in)      BC_index - The boundary condition number being extracted.
-!  (in)      BC_element - The element of the boundary condition being extracted.
-!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
-!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
-!            These must match the size of the corresponding value array or an
-!            error message is issued.
-!  (in, opt) conversion - A number that every element is multiplied by, to
-!                         permit sign convention or unit conversion.
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_2d(var_out, diag_name, axes, time)
 
-  call MOM_error(FATAL,"The called version of set_coupler_values does" // &
-                 " nothing but issue this fatal error message.")
+end subroutine  coupler_type_copy_1d_2d
 
-end subroutine set_coupler_values
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 1-D to 3-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, kd, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var_out%bc already associated"
+!! \throw FATAL, "var_out%bc([n])%field already associated"
+!! \throw FATAL, "var_out%bc([n])%field([m])%values already associated"
+!! \throw FATAL, "axes less than 3 elements"
+subroutine coupler_type_copy_1d_3d(var_in, var_out, is, ie, js, je, kd, &
+     diag_name, axes, time, suffix)
 
-end module coupler_util
+  type(coupler_1d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_3d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  integer, intent(in)                     :: kd !< third dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (coupler_type_copy_1d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_1d_3d(var_in, var_out,  (/ is, is, ie, ie /), (/ js, js, je, je /), (/1, kd/), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_3d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_1d_3d
+
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 2-D to 2-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+subroutine coupler_type_copy_2d_2d(var_in, var_out, is, ie, js, je,     &
+     diag_name, axes, time, suffix)
+
+  type(coupler_2d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_2d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (coupler_type_copy_2d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_2d_2d(var_in, var_out, (/ is, is, ie, ie /), (/ js, js, je, je /), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_2d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_2d_2d
+
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 2-D to 3-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, kd, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var_out%bc already associated"
+!! \throw FATAL, "var_out%bc([n])%field already associated"
+!! \throw FATAL, "var_out%bc([n])%field([m])%values already associated"
+!! \throw FATAL, "axes less than 3 elements"
+subroutine coupler_type_copy_2d_3d(var_in, var_out, is, ie, js, je, kd, &
+     diag_name, axes, time, suffix)
+
+  type(coupler_2d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_3d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  integer, intent(in)                     :: kd !< third dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (coupler_type_copy_2d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_2d_3d(var_in, var_out,  (/ is, is, ie, ie /), (/ js, js, je, je /), (/1, kd/), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_3d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_2d_3d
+
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 3-D to 2-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+subroutine coupler_type_copy_3d_2d(var_in, var_out, is, ie, js, je,     &
+     diag_name, axes, time, suffix)
+
+  type(coupler_3d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_2d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (coupler_type_copy_3d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_3d_2d(var_in, var_out, (/ is, is, ie, ie /), (/ js, js, je, je /), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_2d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_3d_2d
+
+!#######################################################################
+!> \brief Copy fields from one coupler type to another. 3-D to 3-D version for generic coupler_type_copy.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_copy(var_in, var_out, is, ie, js, je, kd, &
+!!        diag_name, axes, time, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var_out%bc already associated"
+!! \throw FATAL, "var_out%bc([n])%field already associated"
+!! \throw FATAL, "var_out%bc([n])%field([m])%values already associated"
+!! \throw FATAL, "axes less than 3 elements"
+subroutine coupler_type_copy_3d_3d(var_in, var_out, is, ie, js, je, kd, &
+     diag_name, axes, time, suffix)
+
+  type(coupler_3d_bc_type), intent(in)    :: var_in !< variable to copy information from
+  type(coupler_3d_bc_type), intent(inout) :: var_out !< variable to copy information to
+  integer, intent(in)                     :: is !< lower bound of first dimension
+  integer, intent(in)                     :: ie !< upper bound of first dimension
+  integer, intent(in)                     :: js !< lower bound of second dimension
+  integer, intent(in)                     :: je !< upper bound of second dimension
+  integer, intent(in)                     :: kd !< third dimension
+  character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
+  character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (coupler_type_copy_3d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+
+  if (var_out%num_bcs > 0) then
+    ! It is an error if the number of output fields exceeds zero, because it means this
+    ! type has already been populated.
+    call mpp_error(FATAL, trim(error_header) // ' Number of output fields exceeds zero')
+  endif
+
+  if (var_in%num_bcs >= 0) &
+    call CT_spawn_3d_3d(var_in, var_out,  (/ is, is, ie, ie /), (/ js, js, je, je /), (/1, kd/), suffix)
+
+  if ((var_out%num_bcs > 0) .and. (diag_name .ne. ' ')) &
+    call CT_set_diags_3d(var_out, diag_name, axes, time)
+
+end subroutine  coupler_type_copy_3d_3d
+
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 1-D to 2-D version for generic coupler_type_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var_out, idim, jdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var_out%bc already associated"
+!! \throw FATAL, "var_out%bc([n])%field already associated"
+!! \throw FATAL, "var_out%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_1d_2d(var_in, var, idim, jdim, suffix, as_needed)
+
+  type(coupler_1d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_2d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (CT_spawn_1d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+          var%bc(n)%field(m)%values(:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_1d_2d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 1-D to 3-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, kdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_1d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
+
+  type(coupler_1d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_3d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  integer, dimension(2),    intent(in)    :: kdim    !< The array extents of the third dimension in
+                                                     !! a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_spawn_1d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  ! Store the array extents that are to be used with this bc_type.
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if (kdim(1) > kdim(2)) then
+    write (error_msg, *) trim(error_header), ' Disordered k-dimension index bound list  ', kdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+  var%ks  = kdim(1) ; var%ke  = kdim(2)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+          var%bc(n)%field(m)%values(:,:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_1d_3d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 2-D to 2-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_2d_2d(var_in, var, idim, jdim, suffix, as_needed)
+
+  type(coupler_2d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_2d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (CT_spawn_2d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+          var%bc(n)%field(m)%values(:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_2d_2d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 2-D to 3-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, kdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_2d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
+
+  type(coupler_2d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_3d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  integer, dimension(2),    intent(in)    :: kdim    !< The array extents of the third dimension in
+                                                     !! a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_spawn_2d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  ! Store the array extents that are to be used with this bc_type.
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if (kdim(1) > kdim(2)) then
+    write (error_msg, *) trim(error_header), ' Disordered k-dimension index bound list  ', kdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+  var%ks  = kdim(1) ; var%ke = kdim(2)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+          var%bc(n)%field(m)%values(:,:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_2d_3d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 3-D to 2-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_3d_2d(var_in, var, idim, jdim, suffix, as_needed)
+
+  type(coupler_3d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_2d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (CT_spawn_3d_2d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+          var%bc(n)%field(m)%values(:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_3d_2d
+
+!#######################################################################
+!> \brief Generate one coupler type using another as a template. 3-D to 3-D version for generic CT_spawn.
+!!
+!! Template:
+!!
+!! ~~~~~~~~~~{.f90}
+!!   call coupler_type_spawn(var_in, var, idim, jdim, kdim, suffix = 'something')
+!! ~~~~~~~~~~
+!!
+!! \throw FATAL, "Number of output fields is non-zero"
+!! \throw FATAL, "var%bc already associated"
+!! \throw FATAL, "var%bc([n])%field already associated"
+!! \throw FATAL, "var%bc([n])%field([m])%values already associated"
+subroutine CT_spawn_3d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
+
+  type(coupler_3d_bc_type), intent(in)    :: var_in  !< structure from which to copy information
+  type(coupler_3d_bc_type), intent(inout) :: var     !< structure into which to copy information
+  integer, dimension(4),    intent(in)    :: idim    !< The data and computational domain extents of
+                                                     !! the first dimension in a non-decreasing list
+  integer, dimension(4),    intent(in)    :: jdim    !< The data and computational domain extents of
+                                                     !! the second dimension in a non-decreasing list
+  integer, dimension(2),    intent(in)    :: kdim    !< The array extents of the third dimension in
+                                                     !! a non-decreasing list
+  character(len=*), optional, intent(in)  :: suffix  !< optional suffix to make the name identifier unique
+  logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
+                                                     !! is not set and the parent type (var_in) is set.
+
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_spawn_3d_3d):'
+  character(len=400)      :: error_msg
+  integer                 :: m, n
+
+  if (present(as_needed)) then ; if (as_needed) then
+    if ((var%set) .or. (.not.var_in%set)) return
+  endif ; endif
+
+  if (var%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The output type has already been initialized.')
+  if (.not.var_in%set) &
+    call mpp_error(FATAL, trim(error_header) // ' The parent type has not been initialized.')
+
+  var%num_bcs = var_in%num_bcs ; var%set = .true.
+
+  if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+    write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list  ', jdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  if (kdim(1) > kdim(2)) then
+    write (error_msg, *) trim(error_header), ' Disordered k-dimension index bound list  ', kdim
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  var%isd = idim(1) ; var%isc = idim(2) ; var%iec = idim(3) ; var%ied = idim(4)
+  var%jsd = jdim(1) ; var%jsc = jdim(2) ; var%jec = jdim(3) ; var%jed = jdim(4)
+  var%ks  = kdim(1) ; var%ke  = kdim(2)
+
+  if (var%num_bcs > 0) then
+    if (associated(var%bc)) then
+      call mpp_error(FATAL, trim(error_header) // ' var%bc already associated')
+    endif
+    allocate ( var%bc(var%num_bcs) )
+    do n = 1, var%num_bcs
+      var%bc(n)%name = var_in%bc(n)%name
+      var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
+      var%bc(n)%flux_type = var_in%bc(n)%flux_type
+      var%bc(n)%implementation = var_in%bc(n)%implementation
+      var%bc(n)%ice_restart_file = var_in%bc(n)%ice_restart_file
+      var%bc(n)%ocean_restart_file = var_in%bc(n)%ocean_restart_file
+      var%bc(n)%use_atm_pressure = var_in%bc(n)%use_atm_pressure
+      var%bc(n)%use_10m_wind_speed = var_in%bc(n)%use_10m_wind_speed
+      var%bc(n)%pass_through_ice = var_in%bc(n)%pass_through_ice
+      var%bc(n)%mol_wt = var_in%bc(n)%mol_wt
+      var%bc(n)%num_fields = var_in%bc(n)%num_fields
+      if (associated(var%bc(n)%field)) then
+        write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field already associated'
+        call mpp_error(FATAL, trim(error_msg))
+      endif
+      allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
+      do m = 1, var%bc(n)%num_fields
+        if (present(suffix)) then
+          var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+        else
+          var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+        endif
+        var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
+        var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
+        var%bc(n)%field(m)%may_init = var_in%bc(n)%field(m)%may_init
+        var%bc(n)%field(m)%mean = var_in%bc(n)%field(m)%mean
+        if (associated(var%bc(n)%field(m)%values)) then
+          write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
+          call mpp_error(FATAL, trim(error_msg))
+        endif
+        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
+          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+          var%bc(n)%field(m)%values(:,:,:) = 0.0
+        endif
+      enddo
+    enddo
+
+  endif
+
+end subroutine  CT_spawn_3d_3d
+
+
+!> This subroutine does a direct copy of the data in all elements of one
+!! coupler_2d_bc_type into another.  Both must have the same array sizes.
+subroutine CT_copy_data_2d(var_in, var, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_2d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to copy
+  type(coupler_2d_bc_type),   intent(inout) :: var !< The recipient BC_type structure
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  logical :: copy_bc
+  integer :: i, j, m, n, n1, n2, halo, i_off, j_off
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_copy_data_2d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_copy_data_2d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_copy_data_2d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d: Excessive j-direction halo size for the output structure.")
+
+    i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc
+  endif
+
+  do n = n1, n2
+
+    copy_bc = .true.
+    if (copy_bc .and. present(exclude_flux_type)) &
+      copy_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (copy_bc .and. present(only_flux_type)) &
+      copy_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (copy_bc .and. present(pass_through_ice)) &
+      copy_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.copy_bc) cycle
+
+    do m = 1, var%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j) = var_in%bc(n)%field(m)%values(i+i_off,j+j_off)
+        enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_copy_data_2d
+
+!> This subroutine does a direct copy of the data in all elements of one
+!! coupler_3d_bc_type into another.  Both types must have the same array sizes.
+subroutine CT_copy_data_3d(var_in, var, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to copy
+  type(coupler_3d_bc_type),   intent(inout) :: var !< The recipient BC_type structure
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  logical :: copy_bc
+  integer :: i, j, k, m, n, n1, n2, halo, i_off, j_off, k_off
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_copy_data_3d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_copy_data_3d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_copy_data_3d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%ke-var_in%ks) /= (var%ke-var%ks)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: There is a k-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_3d: Excessive j-direction halo size for the output structure.")
+
+    i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc ; k_off = var_in%ks - var%ks
+  endif
+
+  do n = n1, n2
+
+    copy_bc = .true.
+    if (copy_bc .and. present(exclude_flux_type)) &
+      copy_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (copy_bc .and. present(only_flux_type)) &
+      copy_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (copy_bc .and. present(pass_through_ice)) &
+      copy_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.copy_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j,k) = var_in%bc(n)%field(m)%values(i+i_off,j+j_off,k+k_off)
+        enddo ; enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_copy_data_3d
+
+!> This subroutine does a direct copy of the data in all elements of a
+!! coupler_2d_bc_type into a coupler_3d_bc_type.  Both types must have the same
+!! array sizes for their first two dimensions, while the extent of the 3rd dimension
+!! that is being filled may be specified via optional arguments.
+subroutine CT_copy_data_2d_3d(var_in, var, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice, &
+                           ind3_start, ind3_end)
+  type(coupler_2d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to copy
+  type(coupler_3d_bc_type),   intent(inout) :: var !< The recipient BC_type structure
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  integer,          optional, intent(in)    :: ind3_start  !< The starting value of the 3rd
+                                                       !! index of the 3d type to fill in.
+  integer,          optional, intent(in)    :: ind3_end    !< The ending value of the 3rd
+                                                       !! index of the 3d type to fill in.
+  logical :: copy_bc
+  integer :: i, j, k, m, n, n1, n2, halo, i_off, j_off, ks, ke
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_copy_data_2d_3d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_copy_data_2d_3d: Excessive j-direction halo size for the output structure.")
+  endif
+
+  i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc
+  do n = n1, n2
+
+    copy_bc = .true.
+    if (copy_bc .and. present(exclude_flux_type)) &
+      copy_bc = .not.(trim(var_in%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (copy_bc .and. present(only_flux_type)) &
+      copy_bc = (trim(var_in%bc(n)%flux_type) == trim(only_flux_type))
+    if (copy_bc .and. present(pass_through_ice)) &
+      copy_bc = (pass_through_ice .eqv. var_in%bc(n)%pass_through_ice)
+    if (.not.copy_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        ks = var%ks ; if (present(ind3_start)) ks = max(ks, ind3_start)
+        ke = var%ke ; if (present(ind3_end)) ke = max(ke, ind3_end)
+        do k=ks,ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j,k) = var_in%bc(n)%field(m)%values(i+i_off,j+j_off)
+        enddo ; enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_copy_data_2d_3d
+
+
+!> This subroutine redistributes the data in all elements of one coupler_2d_bc_type
+!! into another, which may be on different processors with a different decomposition.
+subroutine CT_redistribute_data_2d(var_in, domain_in, var_out, domain_out, complete)
+  type(coupler_2d_bc_type), intent(in)    :: var_in     !< BC_type structure with the data to copy (intent in)
+  type(domain2D),           intent(in)    :: domain_in  !< The FMS domain for the input structure
+  type(coupler_2d_bc_type), intent(inout) :: var_out    !< The recipient BC_type structure (data intent out)
+  type(domain2D),           intent(in)    :: domain_out !< The FMS domain for the output structure
+  logical,        optional, intent(in)    :: complete   !< If true, complete the updates
+
+  real, pointer, dimension(:,:) :: null_ptr2D => NULL()
+  logical :: do_in, do_out, do_complete
+  integer :: m, n, fc, fc_in, fc_out
+
+  do_complete = .true. ; if (present(complete)) do_complete = complete
+
+  ! Figure out whether this PE has valid input or output fields or both.
+  do_in = var_in%set
+  do_out = var_out%set
+
+  fc_in = 0 ; fc_out = 0
+  if (do_in) then ; do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+    if (associated(var_in%bc(n)%field(m)%values)) fc_in = fc_in + 1
+  enddo ; enddo ; endif
+  if (fc_in == 0) do_in = .false.
+  if (do_out) then ; do n = 1, var_out%num_bcs ; do m = 1, var_out%bc(n)%num_fields
+    if (associated(var_out%bc(n)%field(m)%values)) fc_out = fc_out + 1
+  enddo ; enddo ; endif
+  if (fc_out == 0) do_out = .false.
+
+  if (do_in .and. do_out) then
+    if (var_in%num_bcs /= var_out%num_bcs) call mpp_error(FATAL, &
+      "Mismatch in num_bcs in CT_copy_data_2d.")
+    if (fc_in /= fc_out) call mpp_error(FATAL, &
+      "Mismatch in the total number of fields in CT_redistribute_data_2d.")
+  endif
+
+  if (.not.(do_in .or. do_out)) return
+
+  fc = 0
+  if (do_in .and. do_out) then
+    do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+      if ( associated(var_in%bc(n)%field(m)%values) .neqv. &
+           associated(var_out%bc(n)%field(m)%values) ) &
+        call mpp_error(FATAL, &
+          "Mismatch in which fields are associated in CT_redistribute_data_2d.")
+
+      if ( associated(var_in%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, var_in%bc(n)%field(m)%values, &
+                              domain_out, var_out%bc(n)%field(m)%values, &
+                              complete=(do_complete.and.(fc==fc_in)) )
+      endif
+    enddo ; enddo
+  elseif (do_in) then
+    do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+      if ( associated(var_in%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, var_in%bc(n)%field(m)%values, &
+                              domain_out, null_ptr2D, &
+                              complete=(do_complete.and.(fc==fc_in)) )
+      endif
+    enddo ; enddo
+  elseif (do_out) then
+    do n = 1, var_out%num_bcs ; do m = 1, var_out%bc(n)%num_fields
+      if ( associated(var_out%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, null_ptr2D, &
+                              domain_out, var_out%bc(n)%field(m)%values, &
+                              complete=(do_complete.and.(fc==fc_out)) )
+      endif
+    enddo ; enddo
+  endif
+
+end subroutine CT_redistribute_data_2d
+
+!> This subroutine redistributes the data in all elements of one coupler_2d_bc_type
+!! into another, which may be on different processors with a different decomposition.
+subroutine CT_redistribute_data_3d(var_in, domain_in, var_out, domain_out, complete)
+  type(coupler_3d_bc_type), intent(in)    :: var_in     !< BC_type structure with the data to copy (intent in)
+  type(domain2D),           intent(in)    :: domain_in  !< The FMS domain for the input structure
+  type(coupler_3d_bc_type), intent(inout) :: var_out    !< The recipient BC_type structure (data intent out)
+  type(domain2D),           intent(in)    :: domain_out !< The FMS domain for the output structure
+  logical,        optional, intent(in)    :: complete   !< If true, complete the updates
+
+  real, pointer, dimension(:,:,:) :: null_ptr3D => NULL()
+  logical :: do_in, do_out, do_complete
+  integer :: m, n, fc, fc_in, fc_out
+
+  do_complete = .true. ; if (present(complete)) do_complete = complete
+
+  ! Figure out whether this PE has valid input or output fields or both.
+  do_in = var_in%set
+  do_out = var_out%set
+
+  fc_in = 0 ; fc_out = 0
+  if (do_in) then ; do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+    if (associated(var_in%bc(n)%field(m)%values)) fc_in = fc_in + 1
+  enddo ; enddo ; endif
+  if (fc_in == 0) do_in = .false.
+  if (do_out) then ; do n = 1, var_out%num_bcs ; do m = 1, var_out%bc(n)%num_fields
+    if (associated(var_out%bc(n)%field(m)%values)) fc_out = fc_out + 1
+  enddo ; enddo ; endif
+  if (fc_out == 0) do_out = .false.
+
+  if (do_in .and. do_out) then
+    if (var_in%num_bcs /= var_out%num_bcs) call mpp_error(FATAL, &
+      "Mismatch in num_bcs in CT_copy_data_3d.")
+    if (fc_in /= fc_out) call mpp_error(FATAL, &
+      "Mismatch in the total number of fields in CT_redistribute_data_3d.")
+  endif
+
+  if (.not.(do_in .or. do_out)) return
+
+  fc = 0
+  if (do_in .and. do_out) then
+    do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+      if ( associated(var_in%bc(n)%field(m)%values) .neqv. &
+           associated(var_out%bc(n)%field(m)%values) ) &
+        call mpp_error(FATAL, &
+          "Mismatch in which fields are associated in CT_redistribute_data_3d.")
+
+      if ( associated(var_in%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, var_in%bc(n)%field(m)%values, &
+                              domain_out, var_out%bc(n)%field(m)%values, &
+                              complete=(do_complete.and.(fc==fc_in)) )
+      endif
+    enddo ; enddo
+  elseif (do_in) then
+    do n = 1, var_in%num_bcs ; do m = 1, var_in%bc(n)%num_fields
+      if ( associated(var_in%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, var_in%bc(n)%field(m)%values, &
+                              domain_out, null_ptr3D, &
+                              complete=(do_complete.and.(fc==fc_in)) )
+      endif
+    enddo ; enddo
+  elseif (do_out) then
+    do n = 1, var_out%num_bcs ; do m = 1, var_out%bc(n)%num_fields
+      if ( associated(var_out%bc(n)%field(m)%values) ) then
+        fc = fc + 1
+        call mpp_redistribute(domain_in, null_ptr3D, &
+                              domain_out, var_out%bc(n)%field(m)%values, &
+                              complete=(do_complete.and.(fc==fc_out)) )
+      endif
+    enddo ; enddo
+  endif
+
+end subroutine CT_redistribute_data_3d
+
+
+!> This subroutine rescales the fields in the elements of a coupler_2d_bc_type
+!! by multiplying by a factor scale.  If scale is 0, this is a direct
+!! assignment to 0, so that NaNs will not persist.
+subroutine CT_rescale_data_2d(var, scale, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_2d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being rescaled
+  real,                       intent(in)    :: scale   !< A scaling factor to multiply fields by
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default or
+                                                         !! the full arrays if scale is 0.
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  logical :: do_bc
+  integer :: i, j, m, n, n1, n2, halo
+
+  if (present(bc_index)) then
+    if (bc_index > var%num_bcs) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: bc_index is present and exceeds var%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: field_index is present and exceeds num_fields for" //&
+                     trim(var%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_rescale_data_2d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: Excessive i-direction halo size.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: Excessive j-direction halo size.")
+  endif
+
+  do n = n1, n2
+
+    do_bc = .true.
+    if (do_bc .and. present(exclude_flux_type)) &
+      do_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (do_bc .and. present(only_flux_type)) &
+      do_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (do_bc .and. present(pass_through_ice)) &
+      do_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.do_bc) cycle
+
+    do m = 1, var%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        if (scale == 0.0) then
+          if (present(halo_size)) then
+            do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+              var%bc(n)%field(m)%values(i,j) = 0.0
+            enddo ; enddo
+          else
+            var%bc(n)%field(m)%values(:,:) = 0.0
+          endif
+        else
+          do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+            var%bc(n)%field(m)%values(i,j) = scale * var%bc(n)%field(m)%values(i,j)
+          enddo ; enddo
+        endif
+      endif
+    enddo
+  enddo
+
+end subroutine CT_rescale_data_2d
+
+!> This subroutine rescales the fields in the elements of a coupler_3d_bc_type
+!! by multiplying by a factor scale.  If scale is 0, this is a direct
+!! assignment to 0, so that NaNs will not persist.
+subroutine CT_rescale_data_3d(var, scale, halo_size, bc_index, field_index, &
+                           exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_3d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being rescaled
+  real,                       intent(in)    :: scale   !< A scaling factor to multiply fields by
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default or
+                                                         !! the full arrays if scale is 0.
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
+                                                       !! value of pass_through ice matches this
+  logical :: do_bc
+  integer :: i, j, k, m, n, n1, n2, halo
+
+  if (present(bc_index)) then
+    if (bc_index > var%num_bcs) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: bc_index is present and exceeds var%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_rescale_data_2d: field_index is present and exceeds num_fields for" //&
+                     trim(var%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_rescale_data_2d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_rescale_data_3d: Excessive i-direction halo size.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_rescale_data_3d: Excessive j-direction halo size.")
+  endif
+
+  do n = n1, n2
+
+    do_bc = .true.
+    if (do_bc .and. present(exclude_flux_type)) &
+      do_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (do_bc .and. present(only_flux_type)) &
+      do_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (do_bc .and. present(pass_through_ice)) &
+      do_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.do_bc) cycle
+
+    do m = 1, var%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        if (scale == 0.0) then
+          if (present(halo_size)) then
+            do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+              var%bc(n)%field(m)%values(i,j,k) = 0.0
+            enddo ; enddo ; enddo
+          else
+            var%bc(n)%field(m)%values(:,:,:) = 0.0
+          endif
+        else
+          do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+            var%bc(n)%field(m)%values(i,j,k) = scale * var%bc(n)%field(m)%values(i,j,k)
+          enddo ; enddo ; enddo
+        endif
+      endif
+    enddo
+  enddo
+
+end subroutine CT_rescale_data_3d
+
+
+!> This subroutine does a direct increment of the data in all elements of one
+!! coupler_2d_bc_type into another.  Both must have the same array sizes.
+subroutine CT_increment_data_2d_2d(var_in, var, halo_size, bc_index, field_index, &
+                           scale_factor, scale_prev, exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_2d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to add to the other type
+  type(coupler_2d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being incremented
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to increment; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  real,             optional, intent(in)    :: scale_factor  !< A scaling factor for the data that is being added
+  real,             optional, intent(in)    :: scale_prev    !< A scaling factor for the data that is already here
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this increment.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this increment.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only increment BCs whose
+                                                       !! value of pass_through ice matches this
+
+  real :: scale, sc_prev
+  logical :: increment_bc
+  integer :: i, j, m, n, n1, n2, halo, i_off, j_off
+
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+  sc_prev = 1.0 ; if (present(scale_prev)) sc_prev = scale_prev
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_increment_data_2d_2d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_increment_data_2d_2d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_increment_data_2d_2d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d: Excessive j-direction halo size for the output structure.")
+
+    i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc
+  endif
+
+  do n = n1, n2
+
+    increment_bc = .true.
+    if (increment_bc .and. present(exclude_flux_type)) &
+      increment_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (increment_bc .and. present(only_flux_type)) &
+      increment_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (increment_bc .and. present(pass_through_ice)) &
+      increment_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.increment_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j) = sc_prev * var%bc(n)%field(m)%values(i,j) + &
+                          scale * var_in%bc(n)%field(m)%values(i+i_off,j+j_off)
+        enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_increment_data_2d_2d
+
+
+!> This subroutine does a direct increment of the data in all elements of one
+!! coupler_3d_bc_type into another.  Both must have the same array sizes.
+subroutine CT_increment_data_3d_3d(var_in, var, halo_size, bc_index, field_index, &
+                           scale_factor, scale_prev, exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to add to the other type
+  type(coupler_3d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being incremented
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  real,             optional, intent(in)    :: scale_factor  !< A scaling factor for the data that is being added
+  real,             optional, intent(in)    :: scale_prev    !< A scaling factor for the data that is already here
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this increment.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this increment.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only increment BCs whose
+                                                       !! value of pass_through ice matches this
+
+  real :: scale, sc_prev
+  logical :: increment_bc
+  integer :: i, j, k, m, n, n1, n2, halo, i_off, j_off, k_off
+
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+  sc_prev = 1.0 ; if (present(scale_prev)) sc_prev = scale_prev
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_increment_data_3d_3d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_increment_data_3d_3d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_increment_data_3d_3d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: There is a j-direction computional domain size mismatch.")
+    if ((var_in%ke-var_in%ks) /= (var%ke-var%ks)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: There is a k-direction computional domain size mismatch.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_3d: Excessive j-direction halo size for the output structure.")
+
+    i_off = var_in%isc - var%isc ; j_off = var_in%jsc - var%jsc ; k_off = var_in%ks - var%ks
+  endif
+
+  do n = n1, n2
+
+    increment_bc = .true.
+    if (increment_bc .and. present(exclude_flux_type)) &
+      increment_bc = .not.(trim(var%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (increment_bc .and. present(only_flux_type)) &
+      increment_bc = (trim(var%bc(n)%flux_type) == trim(only_flux_type))
+    if (increment_bc .and. present(pass_through_ice)) &
+      increment_bc = (pass_through_ice .eqv. var%bc(n)%pass_through_ice)
+    if (.not.increment_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j,k) = sc_prev * var%bc(n)%field(m)%values(i,j,k) + &
+                       scale * var_in%bc(n)%field(m)%values(i+i_off,j+j_off,k+k_off)
+        enddo ; enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_increment_data_3d_3d
+
+!> This subroutine does increments the data in the elements of a coupler_2d_bc_type
+!! with the weighed average of the elements of a coupler_3d_bc_type. Both must have
+!! the same horizontal array sizes and the normalized weight array must match the
+!! array sizes of the coupler_3d_bc_type.
+subroutine CT_increment_data_2d_3d(var_in, weights, var, halo_size, bc_index, field_index, &
+                           scale_factor, scale_prev, exclude_flux_type, only_flux_type, pass_through_ice)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to add to the other type
+  real, dimension(:,:,:),     intent(in)    :: weights !< An array of normalized weights for the 3d-data to
+                                                       !! increment the 2d-data.  There is no renormalization,
+                                                       !! so if the weights do not sum to 1 in the 3rd dimension
+                                                       !! there may be adverse consequences!
+  type(coupler_2d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being incremented
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer,          optional, intent(in)    :: bc_index  !< The index of the boundary condition
+                                                       !! that is being copied
+  integer,          optional, intent(in)    :: field_index !< The index of the field in the
+                                                       !! boundary condition that is being copied
+  real,             optional, intent(in)    :: scale_factor  !< A scaling factor for the data that is being added
+  real,             optional, intent(in)    :: scale_prev    !< A scaling factor for the data that is already here
+  character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this increment.
+  character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this increment.
+  logical,          optional, intent(in)    :: pass_through_ice !< If true, only increment BCs whose
+                                                       !! value of pass_through ice matches this
+
+  real :: scale, sc_prev
+  logical :: increment_bc
+  integer :: i, j, k, m, n, n1, n2, halo
+  integer :: io1, jo1, iow, jow, kow  ! Offsets to account for different index conventions.
+
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+  sc_prev = 1.0 ; if (present(scale_prev)) sc_prev = scale_prev
+
+  if (present(bc_index)) then
+    if (bc_index > var_in%num_bcs) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: bc_index is present and exceeds var_in%num_bcs.")
+    if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: field_index is present and exceeds num_fields for" //&
+                     trim(var_in%bc(bc_index)%name) )
+    endif
+  elseif (present(field_index)) then
+    call mpp_error(FATAL, "CT_increment_data_2d_3d: bc_index must be present if field_index is present.")
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+
+  n1 = 1 ; n2 = var_in%num_bcs
+  if (present(bc_index)) then ; n1 = bc_index ; n2 = bc_index ; endif
+
+  if (n2 >= n1) then
+    ! A more consciencious implementation would include a more descriptive error messages.
+    if ((var_in%iec-var_in%isc) /= (var%iec-var%isc)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: There is an i-direction computional domain size mismatch.")
+    if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: There is a j-direction computional domain size mismatch.")
+    if ((1+var_in%ke-var_in%ks) /= size(weights,3)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: There is a k-direction size mismatch with the weights array.")
+    if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: Excessive i-direction halo size for the input structure.")
+    if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: Excessive j-direction halo size for the input structure.")
+    if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: Excessive i-direction halo size for the output structure.")
+    if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: Excessive j-direction halo size for the output structure.")
+
+    if ((1+var%iec-var%isc) == size(weights,1)) then
+      iow = 1 - var%isc
+    elseif ((1+var%ied-var%isd) == size(weights,1)) then
+      iow = 1 - var%isd
+    elseif ((1+var_in%ied-var_in%isd) == size(weights,1)) then
+      iow = 1 + (var_in%isc - var_in%isd) - var%isc
+    else
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: weights array must be the i-size of a computational or data domain.")
+    endif
+    if ((1+var%jec-var%jsc) == size(weights,2)) then
+      jow = 1 - var%jsc
+    elseif ((1+var%jed-var%jsd) == size(weights,2)) then
+      jow = 1 - var%jsd
+    elseif ((1+var_in%jed-var_in%jsd) == size(weights,2)) then
+      jow = 1 + (var_in%jsc - var_in%jsd) - var%jsc
+    else
+      call mpp_error(FATAL, "CT_increment_data_2d_3d: weights array must be the j-size of a computational or data domain.")
+    endif
+
+    io1 = var_in%isc - var%isc ; jo1 = var_in%jsc - var%jsc ; kow = 1 - var_in%ks
+  endif
+
+  do n = n1, n2
+
+    increment_bc = .true.
+    if (increment_bc .and. present(exclude_flux_type)) &
+      increment_bc = .not.(trim(var_in%bc(n)%flux_type) == trim(exclude_flux_type))
+    if (increment_bc .and. present(only_flux_type)) &
+      increment_bc = (trim(var_in%bc(n)%flux_type) == trim(only_flux_type))
+    if (increment_bc .and. present(pass_through_ice)) &
+      increment_bc = (pass_through_ice .eqv. var_in%bc(n)%pass_through_ice)
+    if (.not.increment_bc) cycle
+
+    do m = 1, var_in%bc(n)%num_fields
+      if (present(field_index)) then ; if (m /= field_index) cycle ; endif
+      if ( associated(var%bc(n)%field(m)%values) ) then
+        do k=var_in%ks,var_in%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+          var%bc(n)%field(m)%values(i,j) = sc_prev * var%bc(n)%field(m)%values(i,j) + &
+                     (scale * weights(i+iow,j+jow,k+kow)) * var_in%bc(n)%field(m)%values(i+io1,j+io1,k)
+        enddo ; enddo ; enddo
+      endif
+    enddo
+  enddo
+
+end subroutine CT_increment_data_2d_3d
+
+
+!> This subroutine extracts a single 2-d field from a coupler_2d_bc_type into
+!! a two-dimensional array.
+subroutine CT_extract_data_2d(var_in, bc_index, field_index, array_out, &
+                              scale_factor, halo_size, idim, jdim)
+  type(coupler_2d_bc_type),   intent(in)    :: var_in    !< BC_type structure with the data to extract
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  real, dimension(1:,1:),     intent(out)   :: array_out !< The recipient array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_extract_data_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, halo, i_off, j_off
+
+  if (bc_index <= 0) then
+    array_out(:,:) = 0.0
+    return
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var_in%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
+  if (field_index > var_in%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var_in%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_out,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%iec-var_in%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var_in%isc)
+  else
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_out,1), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var_in%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_out,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%jec-var_in%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var_in%jsc)
+  else
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_out,2), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var_in%jsc-halo)  
+  endif
+
+  do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
+    array_out(i+i_off,j+j_off) = scale * var_in%bc(bc_index)%field(field_index)%values(i,j)
+  enddo ; enddo
+
+end subroutine CT_extract_data_2d
+
+!> This subroutine extracts a single k-level of a 3-d field from a coupler_3d_bc_type
+!! into a two-dimensional array.
+subroutine CT_extract_data_3d_2d(var_in, bc_index, field_index, k_in, array_out, &
+                                 scale_factor, halo_size, idim, jdim)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in    !< BC_type structure with the data to extract
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  integer,                    intent(in)    :: k_in      !< The k-index to extract
+  real, dimension(1:,1:),     intent(out)   :: array_out !< The recipient array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_extract_data_3d_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, k, halo, i_off, j_off
+
+  if (bc_index <= 0) then
+    array_out(:,:) = 0.0
+    return
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var_in%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
+  if (field_index > var_in%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var_in%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_out,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%iec-var_in%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var_in%isc)
+  else
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_out,1), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var_in%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_out,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%jec-var_in%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var_in%jsc)
+  else
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_out,2), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var_in%jsc-halo)  
+  endif
+
+  if ((k_in > var_in%ke) .or. (k_in < var_in%ks)) then
+    write (error_msg, *) trim(error_header), ' The extracted k-index of ', k_in, &
+           ' is outside of the valid range of ', var_in%ks, ' to ', var_in%ke
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+
+  do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
+    array_out(i+i_off,j+j_off) = scale * var_in%bc(bc_index)%field(field_index)%values(i,j,k_in)
+  enddo ; enddo
+
+end subroutine CT_extract_data_3d_2d
+
+!> This subroutine extracts a single 3-d field from a coupler_3d_bc_type into
+!! a three-dimensional array.
+subroutine CT_extract_data_3d(var_in, bc_index, field_index, array_out, &
+                              scale_factor, halo_size, idim, jdim)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in    !< BC_type structure with the data to extract
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  real, dimension(1:,1:,1:),  intent(out)   :: array_out !< The recipient array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_extract_data_3d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, k, halo, i_off, j_off, k_off
+
+  if (bc_index <= 0) then
+    array_out(:,:,:) = 0.0
+    return
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var_in%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
+  if (field_index > var_in%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var_in%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_out,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%iec-var_in%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var_in%isc)
+  else
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_out,1), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var_in%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_out,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%jec-var_in%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var_in%jsc)
+  else
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_out,2), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var_in%jsc-halo)  
+  endif
+
+  if (size(array_out,3) /= 1 + var_in%ke - var_in%ks) then
+    write (error_msg, *) trim(error_header), ' The target array with k-dimension size ', &
+          size(array_out,3), ' does not match the data of size ', &
+          (1 + var_in%ke - var_in%ks)
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  k_off = 1 - var_in%ks
+
+  do k=var_in%ks,var_in%ke ; do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
+    array_out(i+i_off,j+j_off,k+k_off) = scale * var_in%bc(bc_index)%field(field_index)%values(i,j,k)
+  enddo ; enddo ; enddo
+
+end subroutine CT_extract_data_3d
+
+
+!> This subroutine sets a single 2-d field in a coupler_3d_bc_type from
+!! a two-dimensional array.
+subroutine CT_set_data_2d(array_in, bc_index, field_index, var, &
+                          scale_factor, halo_size, idim, jdim)
+  real, dimension(1:,1:),     intent(in)   :: array_in   !< The source array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  type(coupler_2d_bc_type),   intent(inout) :: var       !< BC_type structure with the data to set
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_set_data_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, halo, i_off, j_off
+
+  if (bc_index <= 0) return
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
+  if (field_index > var%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_in,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%iec-var%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var%isc)
+  else
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_in,1), ' does not match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_in,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%jec-var%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var%jsc)
+  else
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_in,2), ' does not match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var%jsc-halo)  
+  endif
+
+  do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+    var%bc(bc_index)%field(field_index)%values(i,j) = scale * array_in(i+i_off,j+j_off)
+  enddo ; enddo
+
+end subroutine CT_set_data_2d
+
+!> This subroutine sets a one k-level of a single 3-d field in a
+!! coupler_3d_bc_type from a two-dimensional array.
+subroutine CT_set_data_2d_3d(array_in, bc_index, field_index, k_out, var, &
+                             scale_factor, halo_size, idim, jdim)
+  real, dimension(1:,1:),     intent(in)    :: array_in  !< The source array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  integer,                    intent(in)    :: k_out     !< The k-index to set
+  type(coupler_3d_bc_type),   intent(inout) :: var       !< BC_type structure with the data to be set
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_set_data_3d_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, halo, i_off, j_off
+
+  if (bc_index <= 0) return
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
+  if (field_index > var%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_in,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%iec-var%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var%isc)
+  else
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_in,1), ' does not match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_in,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%jec-var%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var%jsc)
+  else
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_in,2), ' does not match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var%jsc-halo)  
+  endif
+
+  if ((k_out > var%ke) .or. (k_out < var%ks)) then
+    write (error_msg, *) trim(error_header), ' The seted k-index of ', k_out, &
+           ' is outside of the valid range of ', var%ks, ' to ', var%ke
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+
+  do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+    var%bc(bc_index)%field(field_index)%values(i,j,k_out) = scale * array_in(i+i_off,j+j_off)
+  enddo ; enddo
+
+end subroutine CT_set_data_2d_3d
+
+!> This subroutine sets a single 3-d field in a coupler_3d_bc_type from
+!! a three-dimensional array.
+subroutine CT_set_data_3d(array_in, bc_index, field_index, var, &
+                          scale_factor, halo_size, idim, jdim)
+  real, dimension(1:,1:,1:),  intent(in)    :: array_in  !< The source array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  type(coupler_3d_bc_type),   intent(inout) :: var       !< BC_type structure with the data to be set
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_set_data_3d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, k, halo, i_off, j_off, k_off
+
+  if (bc_index <= 0) return
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
+  if (field_index > var%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_in,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%iec-var%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var%isc)
+  else
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_in,1), ' does not match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_in,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%jec-var%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var%jsc)
+  else
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_in,2), ' does not match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var%jsc-halo)  
+  endif
+
+  if (size(array_in,3) /= 1 + var%ke - var%ks) then
+    write (error_msg, *) trim(error_header), ' The target array with k-dimension size ', &
+          size(array_in,3), ' does not match the data of size ', &
+          (1 + var%ke - var%ks)
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  k_off = 1 - var%ks
+
+  do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+    var%bc(bc_index)%field(field_index)%values(i,j,k) = scale * array_in(i+i_off,j+j_off,k+k_off) 
+  enddo ; enddo ; enddo
+
+end subroutine CT_set_data_3d
+
+
+!> This routine registers the diagnostics of a coupler_2d_bc_type.
+subroutine CT_set_diags_2d(var, diag_name, axes, time)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure for which to register diagnostics
+  character(len=*),         intent(in)    :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:),    intent(in)    :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type),          intent(in)    :: time !< model time variable for registering diagnostic field
+
+  integer :: m, n
+
+  if (diag_name == ' ') return
+
+  if (size(axes) < 2) then
+    call mpp_error(FATAL, '==>Error from coupler_types_mod' //&
+             '(coupler_types_set_diags_3d): axes has less than 2 elements')
+  endif
+
+  do n = 1, var%num_bcs
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_diag = register_diag_field(diag_name,                &
+           var%bc(n)%field(m)%name, axes(1:2), Time,                             &
+           var%bc(n)%field(m)%long_name, var%bc(n)%field(m)%units )
+    enddo
+  enddo
+
+end subroutine CT_set_diags_2d
+
+!> This routine registers the diagnostics of a coupler_3d_bc_type.
+subroutine CT_set_diags_3d(var, diag_name, axes, time)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure for which to register diagnostics
+  character(len=*),         intent(in)    :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+  integer, dimension(:),    intent(in)    :: axes !< array of axes identifiers for diagnostic variable registration
+  type(time_type),          intent(in)    :: time !< model time variable for registering diagnostic field
+
+  integer :: m, n
+
+  if (diag_name == ' ') return
+
+  if (size(axes) < 3) then
+    call mpp_error(FATAL, '==>Error from coupler_types_mod' //&
+             '(coupler_types_set_diags_3d): axes has less than 3 elements')
+  endif
+
+  do n = 1, var%num_bcs
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_diag = register_diag_field(diag_name,                &
+           var%bc(n)%field(m)%name, axes(1:3), Time,                             &
+           var%bc(n)%field(m)%long_name, var%bc(n)%field(m)%units )
+    enddo
+  enddo
+
+end subroutine CT_set_diags_3d
+
+
+!> This subroutine writes out all diagnostics of elements of a coupler_2d_bc_type
+subroutine CT_send_data_2d(var, Time)
+  type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure with the diagnostics to write
+  type(time_type),          intent(in) :: time !< The current model time
+
+  integer :: m, n
+  logical :: used
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    used = send_data(var%bc(n)%field(m)%id_diag, var%bc(n)%field(m)%values, Time)
+  enddo ; enddo
+
+end subroutine CT_send_data_2d
+
+!> This subroutine writes out all diagnostics of elements of a coupler_2d_bc_type
+subroutine CT_send_data_3d(var, Time)
+  type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure with the diagnostics to write
+  type(time_type),          intent(in) :: time !< The current model time
+
+  integer :: m, n
+  logical :: used
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    used = send_data(var%bc(n)%field(m)%id_diag, var%bc(n)%field(m)%values, Time)
+  enddo ; enddo
+
+end subroutine CT_send_data_3d
+
+
+!> This subroutine registers the fields in a coupler_2d_bc_type to be saved
+!! in restart files specified in the field table.
+subroutine CT_register_restarts_2d(var, bc_rest_files, num_rest_files, mpp_domain, ocean_restart)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
+  type(restart_file_type),  dimension(:), pointer :: bc_rest_files !< Structures describing the restart files
+  integer,                  intent(out) :: num_rest_files !< The number of restart files to use
+  type(domain2D),           intent(in)  :: mpp_domain     !< The FMS domain to use for this registration call
+  logical,        optional, intent(in)  :: ocean_restart  !< If true, use the ocean restart file name.
+
+  character(len=80), dimension(max(1,var%num_bcs)) :: rest_file_names
+  character(len=80) :: file_nm
+  logical :: ocn_rest
+  integer :: f, n, m
+
+  ocn_rest = .true. ; if (present(ocean_restart)) ocn_rest = ocean_restart
+
+  ! Determine the number and names of the restart files
+  num_rest_files = 0
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+    file_nm = trim(var%bc(n)%ice_restart_file)
+    if (ocn_rest) file_nm = trim(var%bc(n)%ocean_restart_file)
+    do f = 1, num_rest_files
+      if (trim(file_nm) == trim(rest_file_names(f))) exit
+    enddo
+    if (f>num_rest_files) then
+      num_rest_files = num_rest_files + 1
+      rest_file_names(f) = trim(file_nm)
+    endif
+  enddo
+
+  if (num_rest_files == 0) return
+
+  ! Register the fields with the restart files
+  allocate(bc_rest_files(num_rest_files))
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+
+    file_nm = trim(var%bc(n)%ice_restart_file)
+    if (ocn_rest) file_nm = trim(var%bc(n)%ocean_restart_file)
+    do f = 1, num_rest_files
+      if (trim(file_nm) == trim(rest_file_names(f))) exit
+    enddo
+
+    var%bc(n)%rest_type => bc_rest_files(f)
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_rest = register_restart_field(bc_rest_files(f), &
+              rest_file_names(f), var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
+    enddo
+  enddo
+
+end subroutine CT_register_restarts_2d
+
+!> This subroutine registers the fields in a coupler_2d_bc_type to be saved
+!! in the specified restart file.
+subroutine CT_register_restarts_to_file_2d(var, file_name, rest_file, mpp_domain)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
+  character(len=*),         intent(in)    :: file_name !< The name of the restart file
+  type(restart_file_type),  pointer       :: rest_file !< A (possibly associated) structure describing the restart file
+  type(domain2D),           intent(in)    :: mpp_domain !< The FMS domain to use for this registration call
+
+  integer :: n, m
+
+  ! Register the fields with the restart file
+  if (.not.associated(rest_file)) allocate(rest_file)
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+
+    var%bc(n)%rest_type => rest_file
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_rest = register_restart_field(rest_file, &
+              file_name, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
+    enddo
+  enddo
+
+end subroutine CT_register_restarts_to_file_2d
+
+!> This subroutine registers the fields in a coupler_3d_bc_type to be saved
+!! in restart files specified in the field table.
+subroutine CT_register_restarts_3d(var, bc_rest_files, num_rest_files, mpp_domain, ocean_restart)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
+  type(restart_file_type),  dimension(:), pointer :: bc_rest_files !< Structures describing the restart files
+  integer,                  intent(out)   :: num_rest_files !< The number of restart files to use
+  type(domain2D),           intent(in)    :: mpp_domain     !< The FMS domain to use for this registration call
+  logical,        optional, intent(in)    :: ocean_restart  !< If true, use the ocean restart file name.
+
+  character(len=80), dimension(max(1,var%num_bcs)) :: rest_file_names
+  character(len=80) :: file_nm
+  logical :: ocn_rest
+  integer :: f, n, m, id_restart
+
+  ocn_rest = .true. ; if (present(ocean_restart)) ocn_rest = ocean_restart
+
+  ! Determine the number and names of the restart files
+  num_rest_files = 0
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+    file_nm = trim(var%bc(n)%ice_restart_file)
+    if (ocn_rest) file_nm = trim(var%bc(n)%ocean_restart_file)
+    do f = 1, num_rest_files
+      if (trim(file_nm) == trim(rest_file_names(f))) exit
+    enddo
+    if (f>num_rest_files) then
+      num_rest_files = num_rest_files + 1
+      rest_file_names(f) = trim(file_nm)
+    endif
+  enddo
+
+  if (num_rest_files == 0) return
+
+  ! Register the fields with the restart files
+  allocate(bc_rest_files(num_rest_files))
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+    file_nm = trim(var%bc(n)%ice_restart_file)
+    if (ocn_rest) file_nm = trim(var%bc(n)%ocean_restart_file)
+    do f = 1, num_rest_files
+      if (trim(file_nm) == trim(rest_file_names(f))) exit
+    enddo
+
+    var%bc(n)%rest_type => bc_rest_files(f)
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_rest = register_restart_field(bc_rest_files(f), &
+              rest_file_names(f), var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
+    enddo
+  enddo
+
+end subroutine CT_register_restarts_3d
+
+!> This subroutine registers the fields in a coupler_3d_bc_type to be saved
+!! in the specified restart file.
+subroutine CT_register_restarts_to_file_3d(var, file_name, rest_file, mpp_domain)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
+  character(len=*),         intent(in)  :: file_name !< The name of the restart file
+  type(restart_file_type),  pointer     :: rest_file !< A (possibly associated) structure describing the restart file
+  type(domain2D),           intent(in)  :: mpp_domain     !< The FMS domain to use for this registration call
+
+  integer :: n, m
+
+  ! Register the fields with the restart file
+  if (.not.associated(rest_file)) allocate(rest_file)
+  do n = 1, var%num_bcs
+    if (var%bc(n)%num_fields <= 0) cycle
+
+    var%bc(n)%rest_type => rest_file
+    do m = 1, var%bc(n)%num_fields
+      var%bc(n)%field(m)%id_rest = register_restart_field(rest_file, &
+              file_name, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
+    enddo
+  enddo
+
+end subroutine CT_register_restarts_to_file_3d
+
+
+!> This subroutine reads in the fields in a coupler_2d_bc_type that have
+!! been saved in restart files.
+subroutine CT_restore_state_2d(var, directory, all_or_nothing, &
+                                         all_required, test_by_field)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to restore from restart files
+  character(len=*), optional, intent(in)  :: directory !< A directory where the restart files should
+                                                  !! be found.  The default for FMS is 'INPUT'.
+  logical,        optional, intent(in)    :: all_or_nothing !< If true and there are non-mandatory
+                                                  !! restart fields, it is still an error if some
+                                                  !! fields are read successfully but others are not.
+  logical,        optional, intent(in)    :: all_required !< If true, all fields must be successfully
+                                                  !! read from the restart file, even if they were
+                                                  !! registered as not mandatory.
+  logical,        optional, intent(in)    :: test_by_field !< If true, all or none of the variables
+                                                  !! in a single field must be read successfully.
+
+  integer :: n, m, num_fld
+  character(len=80) :: unset_varname
+  logical :: any_set, all_set, all_var_set, any_var_set, var_set
+
+  any_set = .false. ; all_set = .true. ; num_fld = 0 ; unset_varname = ""
+
+  do n = 1, var%num_bcs
+    any_var_set = .false. ; all_var_set = .true.
+    do m = 1, var%bc(n)%num_fields
+      var_set = .false.
+      if (var%bc(n)%field(m)%id_rest > 0) then
+        var_set = query_initialized(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest)
+        if (.not.var_set) then
+          call restore_state(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest, &
+                             directory=directory, nonfatal_missing_files=.true.)
+          var_set = query_initialized(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest)
+        endif
+      endif
+
+      if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%name)
+      if (var_set) any_set = .true.
+      if (all_set) all_set = var_set
+      if (var_set) any_var_set = .true.
+      if (all_var_set) all_var_set = var_set
+    enddo
+
+    num_fld = num_fld + var%bc(n)%num_fields
+    if ((var%bc(n)%num_fields > 0) .and. present(test_by_field)) then
+      if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL, &
+             "CT_restore_state_2d: test_by_field is true, and "//&
+             trim(unset_varname)//" was not read but some other fields in "//&
+             trim(trim(var%bc(n)%name))//" were.")
+    endif
+  enddo
+
+  if ((num_fld > 0) .and. present(all_or_nothing)) then
+    if (all_or_nothing .and. (all_set .neqv. any_set)) call mpp_error(FATAL, &
+           "CT_restore_state_2d: all_or_nothing is true, and "//&
+           trim(unset_varname)//" was not read but some other fields were.")
+  endif
+
+  if (present(all_required)) then ; if (all_required .and. .not.all_set) then
+    call mpp_error(FATAL, "CT_restore_state_2d: all_required is true, but "//&
+           trim(unset_varname)//" was not read from its restart file.")
+  endif ; endif
+
+end subroutine CT_restore_state_2d
+
+!> This subroutine reads in the fields in a coupler_3d_bc_type that have
+!! been saved in restart files.
+subroutine CT_restore_state_3d(var, directory, all_or_nothing, &
+                                         all_required, test_by_field)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to restore from restart files
+  character(len=*), optional, intent(in)  :: directory !< A directory where the restart files should
+                                                  !! be found.  The default for FMS is 'INPUT'.
+  logical,        optional, intent(in)    :: all_or_nothing !< If true and there are non-mandatory
+                                                  !! restart fields, it is still an error if some
+                                                  !! fields are read successfully but others are not.
+  logical,        optional, intent(in)    :: all_required !< If true, all fields must be successfully
+                                                  !! read from the restart file, even if they were
+                                                  !! registered as not mandatory.
+  logical,        optional, intent(in)    :: test_by_field !< If true, all or none of the variables
+                                                  !! in a single field must be read successfully.
+
+  integer :: n, m, num_fld
+  character(len=80) :: unset_varname
+  logical :: any_set, all_set, all_var_set, any_var_set, var_set
+
+  any_set = .false. ; all_set = .true. ; num_fld = 0 ; unset_varname = ""
+
+  do n = 1, var%num_bcs
+    any_var_set = .false. ; all_var_set = .true.
+    do m = 1, var%bc(n)%num_fields
+      var_set = .false.
+      if (var%bc(n)%field(m)%id_rest > 0) then
+        var_set = query_initialized(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest)
+        if (.not.var_set) then
+          call restore_state(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest, &
+                             directory=directory, nonfatal_missing_files=.true.)
+          var_set = query_initialized(var%bc(n)%rest_type, var%bc(n)%field(m)%id_rest)
+        endif
+      endif
+
+      if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%name)
+
+      if (var_set) any_set = .true.
+      if (all_set) all_set = var_set
+      if (var_set) any_var_set = .true.
+      if (all_var_set) all_var_set = var_set
+    enddo
+
+    num_fld = num_fld + var%bc(n)%num_fields
+    if ((var%bc(n)%num_fields > 0) .and. present(test_by_field)) then
+      if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL, &
+             "CT_restore_state_3d: test_by_field is true, and "//&
+             trim(unset_varname)//" was not read but some other fields in "//&
+             trim(trim(var%bc(n)%name))//" were.")
+    endif
+  enddo
+
+  if ((num_fld > 0) .and. present(all_or_nothing)) then
+    if (all_or_nothing .and. (all_set .neqv. any_set)) call mpp_error(FATAL, &
+           "CT_restore_state_3d: all_or_nothing is true, and "//&
+           trim(unset_varname)//" was not read but some other fields were.")
+  endif
+
+  if (present(all_required)) then ; if (all_required .and. .not.all_set) then
+    call mpp_error(FATAL, "CT_restore_state_3d: all_required is true, but "//&
+           trim(unset_varname)//" was not read from its restart file.")
+  endif ; endif
+
+end subroutine CT_restore_state_3d
+
+
+!> This subroutine potentially overrides the values in a coupler_2d_bc_type
+subroutine CT_data_override_2d(gridname, var, Time)
+  character(len=3),         intent(in) :: gridname !< 3-character long model grid ID
+  type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure to override
+  type(time_type),          intent(in) :: time !< The current model time
+
+  integer :: m, n
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    call data_override(gridname, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, Time)
+  enddo ; enddo
+
+end subroutine CT_data_override_2d
+
+!> This subroutine potentially overrides the values in a coupler_3d_bc_type
+subroutine CT_data_override_3d(gridname, var, Time)
+  character(len=3),         intent(in) :: gridname !< 3-character long model grid ID
+  type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure to override
+  type(time_type),          intent(in) :: time !< The current model time
+
+  integer :: m, n
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    call data_override(gridname, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, Time)
+  enddo ; enddo
+
+end subroutine CT_data_override_3d
+
+
+!> This subroutine writes out checksums for the elements of a coupler_2d_bc_type
+subroutine CT_write_chksums_2d(var, outunit, name_lead)
+  type(coupler_2d_bc_type),   intent(in) :: var  !< BC_type structure for which to register diagnostics
+  integer,                    intent(in) :: outunit !< The index of a open output file
+  character(len=*), optional, intent(in) :: name_lead !< An optional prefix for the variable names
+
+  character(len=120) :: var_name
+  integer :: m, n
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    if (present(name_lead)) then
+      var_name = trim(name_lead)//trim(var%bc(n)%field(m)%name)
+    else
+      var_name = trim(var%bc(n)%field(m)%name)
+    endif
+    write(outunit, '("   CHECKSUM:: ",A40," = ",Z20)') trim(var_name), &
+      mpp_chksum(var%bc(n)%field(m)%values(var%isc:var%iec,var%jsc:var%jec) )
+  enddo ; enddo
+
+end subroutine CT_write_chksums_2d
+
+!> This subroutine writes out checksums for the elements of a coupler_3d_bc_type
+subroutine CT_write_chksums_3d(var, outunit, name_lead)
+  type(coupler_3d_bc_type),   intent(in) :: var  !< BC_type structure for which to register diagnostics
+  integer,                    intent(in) :: outunit !< The index of a open output file
+  character(len=*), optional, intent(in) :: name_lead !< An optional prefix for the variable names
+
+  character(len=120) :: var_name
+  integer :: m, n
+
+  do n = 1, var%num_bcs ; do m = 1, var%bc(n)%num_fields
+    if (present(name_lead)) then
+      var_name = trim(name_lead)//trim(var%bc(n)%field(m)%name)
+    else
+      var_name = trim(var%bc(n)%field(m)%name)
+    endif
+    write(outunit, '("   CHECKSUM:: ",A40," = ",Z20)') var_name, &
+      mpp_chksum(var%bc(n)%field(m)%values(var%isc:var%iec,var%jsc:var%jec,:) )
+  enddo ; enddo
+
+end subroutine CT_write_chksums_3d
+
+
+!> This function indicates whether a coupler_1d_bc_type has been initialized.
+function CT_initialized_1d(var)
+  type(coupler_1d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
+  logical :: CT_initialized_1d  !< The return value, indicating whether this type has been initialized
+  
+  CT_initialized_1d = var%set
+end function CT_initialized_1d
+
+!> This function indicates whether a coupler_2d_bc_type has been initialized.
+function CT_initialized_2d(var)
+  type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
+  logical :: CT_initialized_2d  !< The return value, indicating whether this type has been initialized
+  
+  CT_initialized_2d = var%set
+end function CT_initialized_2d
+
+!> This function indicates whether a coupler_3d_bc_type has been initialized.
+function CT_initialized_3d(var)
+  type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
+  logical :: CT_initialized_3d  !< The return value, indicating whether this type has been initialized
+  
+  CT_initialized_3d = var%set
+end function CT_initialized_3d
+
+
+!> This subroutine deallocates all data associated with a coupler_1d_bc_type
+subroutine CT_destructor_1d(var)
+  type(coupler_1d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
+
+  integer :: m, n
+ 
+  if (var%num_bcs > 0) then
+    do n = 1, var%num_bcs
+      do m = 1, var%bc(n)%num_fields
+        deallocate ( var%bc(n)%field(m)%values )
+      enddo
+      deallocate ( var%bc(n)%field )
+    enddo
+    deallocate ( var%bc )
+  endif
+
+  var%num_bcs = 0 ; var%set = .false.
+
+end subroutine CT_destructor_1d
+
+!> This subroutine deallocates all data associated with a coupler_2d_bc_type
+subroutine CT_destructor_2d(var)
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
+
+  integer :: m, n
+ 
+  if (var%num_bcs > 0) then
+    do n = 1, var%num_bcs
+      do m = 1, var%bc(n)%num_fields
+        deallocate ( var%bc(n)%field(m)%values )
+      enddo
+      deallocate ( var%bc(n)%field )
+    enddo
+    deallocate ( var%bc )
+  endif
+
+  var%num_bcs = 0 ; var%set = .false.
+
+end subroutine CT_destructor_2d
+
+
+!> This subroutine deallocates all data associated with a coupler_3d_bc_type
+subroutine CT_destructor_3d(var)
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
+
+  integer :: m, n
+ 
+  if (var%num_bcs > 0) then
+    do n = 1, var%num_bcs
+      do m = 1, var%bc(n)%num_fields
+        deallocate ( var%bc(n)%field(m)%values )
+      enddo
+      deallocate ( var%bc(n)%field )
+    enddo
+    deallocate ( var%bc )
+  endif
+
+  var%num_bcs = 0 ; var%set = .false.
+
+end subroutine CT_destructor_3d
+
+end module coupler_types_mod

--- a/config_src/solo_driver/coupler_types.F90
+++ b/config_src/solo_driver/coupler_types.F90
@@ -639,10 +639,9 @@ subroutine CT_spawn_1d_2d(var_in, var, idim, jdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
-          var%bc(n)%field(m)%values(:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+        var%bc(n)%field(m)%values(:,:) = 0.0
       enddo
     enddo
 
@@ -746,10 +745,9 @@ subroutine CT_spawn_1d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
-          var%bc(n)%field(m)%values(:,:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+        var%bc(n)%field(m)%values(:,:,:) = 0.0
       enddo
     enddo
 
@@ -845,10 +843,9 @@ subroutine CT_spawn_2d_2d(var_in, var, idim, jdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
-          var%bc(n)%field(m)%values(:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+        var%bc(n)%field(m)%values(:,:) = 0.0
       enddo
     enddo
 
@@ -952,10 +949,9 @@ subroutine CT_spawn_2d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
-          var%bc(n)%field(m)%values(:,:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+        var%bc(n)%field(m)%values(:,:,:) = 0.0
       enddo
     enddo
 
@@ -1051,10 +1047,9 @@ subroutine CT_spawn_3d_2d(var_in, var, idim, jdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
-          var%bc(n)%field(m)%values(:,:) = 0.0
-        endif
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed) )
+        var%bc(n)%field(m)%values(:,:) = 0.0
       enddo
     enddo
 
@@ -1157,10 +1152,10 @@ subroutine CT_spawn_3d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
           write (error_msg, *) trim(error_header), ' var%bc(', n, ')%field(', m, ')%values already associated'
           call mpp_error(FATAL, trim(error_msg))
         endif
-        if ((var%isd<=var%ied) .and. (var%jsd<=var%jed) .and. (var%ks<=var%ke)) then
-          allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
-          var%bc(n)%field(m)%values(:,:,:) = 0.0
-        endif
+
+        ! Note that this may be allocating a zero-sized array, which is legal in Fortran.
+        allocate ( var%bc(n)%field(m)%values(var%isd:var%ied,var%jsd:var%jed,var%ks:var%ke) )
+        var%bc(n)%field(m)%values(:,:,:) = 0.0
       enddo
     enddo
 

--- a/config_src/solo_driver/coupler_types.F90
+++ b/config_src/solo_driver/coupler_types.F90
@@ -2068,7 +2068,7 @@ subroutine CT_extract_data_2d(var_in, bc_index, field_index, array_out, &
             (2*halo + 1 + var_in%iec - var_in%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var_in%isc-halo)  
+    i_off = 1 - (var_in%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2101,7 +2101,7 @@ subroutine CT_extract_data_2d(var_in, bc_index, field_index, array_out, &
             (2*halo + 1 + var_in%jec - var_in%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var_in%jsc-halo)  
+    j_off = 1 - (var_in%jsc-halo)
   endif
 
   do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
@@ -2187,7 +2187,7 @@ subroutine CT_extract_data_3d_2d(var_in, bc_index, field_index, k_in, array_out,
             (2*halo + 1 + var_in%iec - var_in%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var_in%isc-halo)  
+    i_off = 1 - (var_in%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2220,7 +2220,7 @@ subroutine CT_extract_data_3d_2d(var_in, bc_index, field_index, k_in, array_out,
             (2*halo + 1 + var_in%jec - var_in%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var_in%jsc-halo)  
+    j_off = 1 - (var_in%jsc-halo)
   endif
 
   if ((k_in > var_in%ke) .or. (k_in < var_in%ks)) then
@@ -2311,7 +2311,7 @@ subroutine CT_extract_data_3d(var_in, bc_index, field_index, array_out, &
             (2*halo + 1 + var_in%iec - var_in%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var_in%isc-halo)  
+    i_off = 1 - (var_in%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2344,7 +2344,7 @@ subroutine CT_extract_data_3d(var_in, bc_index, field_index, array_out, &
             (2*halo + 1 + var_in%jec - var_in%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var_in%jsc-halo)  
+    j_off = 1 - (var_in%jsc-halo)
   endif
 
   if (size(array_out,3) /= 1 + var_in%ke - var_in%ks) then
@@ -2435,7 +2435,7 @@ subroutine CT_set_data_2d(array_in, bc_index, field_index, var, &
             (2*halo + 1 + var%iec - var%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var%isc-halo)  
+    i_off = 1 - (var%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2468,7 +2468,7 @@ subroutine CT_set_data_2d(array_in, bc_index, field_index, var, &
             (2*halo + 1 + var%jec - var%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var%jsc-halo)  
+    j_off = 1 - (var%jsc-halo)
   endif
 
   do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
@@ -2551,7 +2551,7 @@ subroutine CT_set_data_2d_3d(array_in, bc_index, field_index, k_out, var, &
             (2*halo + 1 + var%iec - var%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var%isc-halo)  
+    i_off = 1 - (var%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2584,7 +2584,7 @@ subroutine CT_set_data_2d_3d(array_in, bc_index, field_index, k_out, var, &
             (2*halo + 1 + var%jec - var%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var%jsc-halo)  
+    j_off = 1 - (var%jsc-halo)
   endif
 
   if ((k_out > var%ke) .or. (k_out < var%ks)) then
@@ -2672,7 +2672,7 @@ subroutine CT_set_data_3d(array_in, bc_index, field_index, var, &
             (2*halo + 1 + var%iec - var%isc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    i_off = 1 - (var%isc-halo)  
+    i_off = 1 - (var%isc-halo)
   endif
 
   ! Do error checking on the j-dimension and determine the array offsets.
@@ -2705,7 +2705,7 @@ subroutine CT_set_data_3d(array_in, bc_index, field_index, var, &
             (2*halo + 1 + var%jec - var%jsc)
       call mpp_error(FATAL, trim(error_msg))
     endif
-    j_off = 1 - (var%jsc-halo)  
+    j_off = 1 - (var%jsc-halo)
   endif
 
   if (size(array_in,3) /= 1 + var%ke - var%ks) then
@@ -2717,7 +2717,7 @@ subroutine CT_set_data_3d(array_in, bc_index, field_index, var, &
   k_off = 1 - var%ks
 
   do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
-    var%bc(bc_index)%field(field_index)%values(i,j,k) = scale * array_in(i+i_off,j+j_off,k+k_off) 
+    var%bc(bc_index)%field(field_index)%values(i,j,k) = scale * array_in(i+i_off,j+j_off,k+k_off)
   enddo ; enddo ; enddo
 
 end subroutine CT_set_data_3d
@@ -3169,7 +3169,7 @@ end subroutine CT_write_chksums_3d
 function CT_initialized_1d(var)
   type(coupler_1d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
   logical :: CT_initialized_1d  !< The return value, indicating whether this type has been initialized
-  
+
   CT_initialized_1d = var%set
 end function CT_initialized_1d
 
@@ -3177,7 +3177,7 @@ end function CT_initialized_1d
 function CT_initialized_2d(var)
   type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
   logical :: CT_initialized_2d  !< The return value, indicating whether this type has been initialized
-  
+
   CT_initialized_2d = var%set
 end function CT_initialized_2d
 
@@ -3185,7 +3185,7 @@ end function CT_initialized_2d
 function CT_initialized_3d(var)
   type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure to be deconstructed
   logical :: CT_initialized_3d  !< The return value, indicating whether this type has been initialized
-  
+
   CT_initialized_3d = var%set
 end function CT_initialized_3d
 
@@ -3195,7 +3195,7 @@ subroutine CT_destructor_1d(var)
   type(coupler_1d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
 
   integer :: m, n
- 
+
   if (var%num_bcs > 0) then
     do n = 1, var%num_bcs
       do m = 1, var%bc(n)%num_fields
@@ -3215,7 +3215,7 @@ subroutine CT_destructor_2d(var)
   type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
 
   integer :: m, n
- 
+
   if (var%num_bcs > 0) then
     do n = 1, var%num_bcs
       do m = 1, var%bc(n)%num_fields
@@ -3236,7 +3236,7 @@ subroutine CT_destructor_3d(var)
   type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to be deconstructed
 
   integer :: m, n
- 
+
   if (var%num_bcs > 0) then
     do n = 1, var%num_bcs
       do m = 1, var%bc(n)%num_fields

--- a/config_src/solo_driver/coupler_util.F90
+++ b/config_src/solo_driver/coupler_util.F90
@@ -1,0 +1,161 @@
+module coupler_util
+!***********************************************************************
+!*                   GNU General Public License                        *
+!* This file is a part of MOM.                                         *
+!*                                                                     *
+!* MOM is free software; you can redistribute it and/or modify it and  *
+!* are expected to follow the terms of the GNU General Public License  *
+!* as published by the Free Software Foundation; either version 2 of   *
+!* the License, or (at your option) any later version.                 *
+!*                                                                     *
+!* MOM is distributed in the hope that it will be useful, but WITHOUT  *
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  *
+!* or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public    *
+!* License for more details.                                           *
+!*                                                                     *
+!* For the full text of the GNU General Public License,                *
+!* write to: Free Software Foundation, Inc.,                           *
+!*           675 Mass Ave, Cambridge, MA 02139, USA.                   *
+!* or see:   http://www.gnu.org/licenses/gpl.html                      *
+!***********************************************************************
+
+!   This code provides a couple of interfaces to allow more transparent and
+! robust extraction of the various fields in the coupler types.
+use MOM_error_handler, only : MOM_error, FATAL, WARNING
+use coupler_types_mod, only : coupler_2d_bc_type, ind_flux, ind_alpha
+use coupler_types_mod, only : ind_csurf
+
+implicit none ; private
+
+public :: extract_coupler_values, set_coupler_values
+public :: ind_flux, ind_alpha, ind_csurf
+
+contains
+
+subroutine extract_coupler_values(BC_struc, BC_index, BC_element, array_out, &
+                                  is, ie, js, je, conversion)
+  type(coupler_2d_bc_type), intent(in)  :: BC_struc
+  integer,                  intent(in)  :: BC_index, BC_element
+  real, dimension(:,:),     intent(out) :: array_out
+  integer,        optional, intent(in)  :: is, ie, js, je
+  real,           optional, intent(in)  :: conversion
+! Arguments: BC_struc - The type from which the data is being extracted.
+!  (in)      BC_index - The boundary condition number being extracted.
+!  (in)      BC_element - The element of the boundary condition being extracted.
+!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
+!  (out)     array_out - The array being filled with the input values.
+!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
+!            These must match the size of the corresponding value array or an
+!            error message is issued.
+!  (in, opt) conversion - A number that every element is multiplied by, to
+!                         permit sign convention or unit conversion.
+
+  real, pointer, dimension(:,:) :: Array_in
+  real :: conv
+  integer :: i, j, is0, ie0, js0, je0, i_offset, j_offset
+
+  if ((BC_element /= ind_flux) .and. (BC_element /= ind_alpha) .and. &
+      (BC_element /= ind_csurf)) then
+    call MOM_error(FATAL,"extract_coupler_values: Unrecognized BC_element.")
+  endif
+
+  ! These error messages should be made more explicit.
+!  if (.not.associated(BC_struc%bc(BC_index))) &
+  if (.not.associated(BC_struc%bc)) &
+    call MOM_error(FATAL,"extract_coupler_values: " // &
+       "The requested boundary condition is not associated.")
+!  if (.not.associated(BC_struc%bc(BC_index)%field(BC_element))) &
+  if (.not.associated(BC_struc%bc(BC_index)%field)) &
+    call MOM_error(FATAL,"extract_coupler_values: " // &
+       "The requested boundary condition element is not associated.")
+  if (.not.associated(BC_struc%bc(BC_index)%field(BC_element)%values)) &
+    call MOM_error(FATAL,"extract_coupler_values: " // &
+       "The requested boundary condition value array is not associated.")
+
+  Array_in => BC_struc%bc(BC_index)%field(BC_element)%values
+
+  if (present(is)) then ; is0 = is ; else ; is0 = LBOUND(array_out,1) ; endif
+  if (present(ie)) then ; ie0 = ie ; else ; ie0 = UBOUND(array_out,1) ; endif
+  if (present(js)) then ; js0 = js ; else ; js0 = LBOUND(array_out,2) ; endif
+  if (present(je)) then ; je0 = je ; else ; je0 = UBOUND(array_out,2) ; endif
+
+  conv = 1.0 ; if (present(conversion)) conv = conversion
+
+  if (size(Array_in,1) /= ie0 - is0 + 1) &
+    call MOM_error(FATAL,"extract_coupler_values: Mismatch in i-size " // &
+                   "between BC array and output array or computational domain.")
+  if (size(Array_in,2) /= je0 - js0 + 1) &
+    call MOM_error(FATAL,"extract_coupler_values: Mismatch in i-size " // &
+                   "between BC array and output array or computational domain.")
+  i_offset = lbound(Array_in,1) - is0
+  j_offset = lbound(Array_in,2) - js0
+  do j=js0,je0 ; do i=is0,ie0
+    array_out(i,j) = conv * Array_in(i+i_offset,j+j_offset)
+  enddo ; enddo
+
+end subroutine extract_coupler_values
+
+subroutine set_coupler_values(array_in, BC_struc, BC_index, BC_element, &
+                              is, ie, js, je, conversion)
+  real, dimension(:,:),     intent(in)    :: array_in
+  type(coupler_2d_bc_type), intent(inout) :: BC_struc
+  integer,                  intent(in)    :: BC_index, BC_element
+  integer,        optional, intent(in)    :: is, ie, js, je
+  real,           optional, intent(in)    :: conversion
+! Arguments: array_in - The array containing the values to load into the BC.
+!  (out)     BC_struc - The type into which the data is being loaded.
+!  (in)      BC_index - The boundary condition number being extracted.
+!  (in)      BC_element - The element of the boundary condition being extracted.
+!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
+!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
+!            These must match the size of the corresponding value array or an
+!            error message is issued.
+!  (in, opt) conversion - A number that every element is multiplied by, to
+!                         permit sign convention or unit conversion.
+
+  real, pointer, dimension(:,:) :: Array_out
+  real :: conv
+  integer :: i, j, is0, ie0, js0, je0, i_offset, j_offset
+
+  if ((BC_element /= ind_flux) .and. (BC_element /= ind_alpha) .and. &
+      (BC_element /= ind_csurf)) then
+    call MOM_error(FATAL,"extract_coupler_values: Unrecognized BC_element.")
+  endif
+
+  ! These error messages should be made more explicit.
+!  if (.not.associated(BC_struc%bc(BC_index))) &
+  if (.not.associated(BC_struc%bc)) &
+    call MOM_error(FATAL,"set_coupler_values: " // &
+       "The requested boundary condition is not associated.")
+!  if (.not.associated(BC_struc%bc(BC_index)%field(BC_element))) &
+  if (.not.associated(BC_struc%bc(BC_index)%field)) &
+    call MOM_error(FATAL,"set_coupler_values: " // &
+       "The requested boundary condition element is not associated.")
+  if (.not.associated(BC_struc%bc(BC_index)%field(BC_element)%values)) &
+    call MOM_error(FATAL,"set_coupler_values: " // &
+       "The requested boundary condition value array is not associated.")
+
+  Array_out => BC_struc%bc(BC_index)%field(BC_element)%values
+
+  if (present(is)) then ; is0 = is ; else ; is0 = LBOUND(array_in,1) ; endif
+  if (present(ie)) then ; ie0 = ie ; else ; ie0 = UBOUND(array_in,1) ; endif
+  if (present(js)) then ; js0 = js ; else ; js0 = LBOUND(array_in,2) ; endif
+  if (present(je)) then ; je0 = je ; else ; je0 = UBOUND(array_in,2) ; endif
+
+  conv = 1.0 ; if (present(conversion)) conv = conversion
+
+  if (size(Array_out,1) /= ie0 - is0 + 1) &
+    call MOM_error(FATAL,"extract_coupler_values: Mismatch in i-size " // &
+                   "between BC array and input array or computational domain.")
+  if (size(Array_out,2) /= je0 - js0 + 1) &
+    call MOM_error(FATAL,"extract_coupler_values: Mismatch in i-size " // &
+                   "between BC array and input array or computational domain.")
+  i_offset = lbound(Array_out,1) - is0
+  j_offset = lbound(Array_out,2) - js0
+  do j=js0,je0 ; do i=is0,ie0
+    Array_out(i+i_offset,j+j_offset) = conv * array_in(i,j)
+  enddo ; enddo
+
+end subroutine set_coupler_values
+
+end module coupler_util

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3679,7 +3679,6 @@ subroutine calculate_surface_state(state, u, v, h, ssh, G, GV, CS)
   endif
 
   if (associated(CS%tracer_flow_CSp)) then
-    if (.not.associated(state%tr_fields)) allocate(state%tr_fields)
     call call_tracer_surface_state(state, h, G, CS%tracer_flow_CSp)
   endif
 

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1799,10 +1799,9 @@ subroutine forcing_accumulate(flux_tmp, fluxes, dt, G, wt2)
     enddo ; enddo
   endif
 
-  if (.not.coupler_type_initialized(fluxes%tr_fluxes)) &
-    call coupler_type_spawn(flux_tmp%tr_fluxes, fluxes%tr_fluxes, &
-                            (/is,is,ie,ie/), (/js,js,je,je/))
-  call coupler_type_increment_data(flux_tmp%tr_fluxes, fluxes%tr_fluxes, &
+  if (coupler_type_initialized(fluxes%tr_fluxes) .and. &
+      coupler_type_initialized(flux_tmp%tr_fluxes)) &
+    call coupler_type_increment_data(flux_tmp%tr_fluxes, fluxes%tr_fluxes, &
                               scale_factor=wt2, scale_prev=wt1)
 
 end subroutine forcing_accumulate

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -16,7 +16,9 @@ use MOM_spatial_means, only : global_area_integral, global_area_mean
 use MOM_variables,     only : surface, thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type
 
-use coupler_types_mod, only : coupler_2d_bc_type
+use coupler_types_mod, only : coupler_2d_bc_type, coupler_type_spawn
+use coupler_types_mod, only : coupler_type_increment_data, coupler_type_initialized
+use coupler_types_mod, only : coupler_type_copy_data, coupler_type_destructor
 
 implicit none ; private
 
@@ -156,8 +158,8 @@ type, public :: forcing
                              !! C_p is is the same value as in thermovar_ptrs_type.
 
   ! passive tracer surface fluxes
-  type(coupler_2d_bc_type), pointer :: tr_fluxes => NULL() !< This structure
-     !! may contain an array of named fields used for passive tracer fluxes.
+  type(coupler_2d_bc_type) :: tr_fluxes !< This structure contains arrays of
+     !! of named fields used for passive tracer fluxes.
      !! All arrays in tr_fluxes use the coupler indexing, which has no halos.
      !! This is not a convenient convention, but imposed on MOM6 by the coupler.
 
@@ -1797,8 +1799,11 @@ subroutine forcing_accumulate(flux_tmp, fluxes, dt, G, wt2)
     enddo ; enddo
   endif
 
-  !### This needs to be replaced with an appropriate copy and average.
-  fluxes%tr_fluxes => flux_tmp%tr_fluxes
+  if (.not.coupler_type_initialized(fluxes%tr_fluxes)) &
+    call coupler_type_spawn(flux_tmp%tr_fluxes, fluxes%tr_fluxes, &
+                            (/is,is,ie,ie/), (/js,js,je,je/))
+  call coupler_type_increment_data(flux_tmp%tr_fluxes, fluxes%tr_fluxes, &
+                              scale_factor=wt2, scale_prev=wt1)
 
 end subroutine forcing_accumulate
 
@@ -2466,10 +2471,12 @@ subroutine deallocate_forcing_type(fluxes)
   if (associated(fluxes%frac_shelf_v))         deallocate(fluxes%frac_shelf_v)
   if (associated(fluxes%rigidity_ice_u))       deallocate(fluxes%rigidity_ice_u)
   if (associated(fluxes%rigidity_ice_v))       deallocate(fluxes%rigidity_ice_v)
-  if (associated(fluxes%tr_fluxes))            deallocate(fluxes%tr_fluxes)
   if (associated(fluxes%ustar_berg))           deallocate(fluxes%ustar_berg)
   if (associated(fluxes%area_berg))            deallocate(fluxes%area_berg)
   if (associated(fluxes%mass_berg))            deallocate(fluxes%mass_berg)
+
+  call coupler_type_destructor(fluxes%tr_fluxes)
+
 end subroutine deallocate_forcing_type
 
 

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -75,8 +75,8 @@ type, public :: surface
     internal_heat => NULL() !< Any internal or geothermal heat sources that
                          !! are applied to the ocean integrated over the call
                          !! to step_MOM, in deg C kg m-2.
-  type(coupler_2d_bc_type), pointer :: &
-    tr_fields  => NULL() !< A structure that may contain an  array of named
+  type(coupler_2d_bc_type) :: &
+    tr_fields            !< A structure that may contain an  array of named
                          !! fields describing tracer-related quantities.
        !!! NOTE: ALL OF THE ARRAYS IN TR_FIELDS USE THE COUPLER'S INDEXING
        !!!       CONVENTION AND HAVE NO HALOS!  THIS IS DONE TO CONFORM TO

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -72,7 +72,7 @@ use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
-use coupler_util, only : set_coupler_values, ind_csurf
+use coupler_types_mod, only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private
@@ -503,30 +503,34 @@ subroutine DOME_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV,
 
 end subroutine DOME_tracer_column_physics
 
+!> This subroutine extracts the surface fields from this tracer package that
+!! are to be shared with the atmosphere in coupled configurations.
+!! This particular tracer package does not report anything back to the coupler.
 subroutine DOME_tracer_surface_state(state, h, G, CS)
-  type(ocean_grid_type),                    intent(in)    :: G    !< The ocean's grid structure
-  type(surface),                            intent(inout) :: state
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(DOME_tracer_CS),                     pointer       :: CS
-!   This particular tracer package does not report anything back to the coupler.
-! The code that is here is just a rough guide for packages that would.
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 DOME_register_tracer.
-  integer :: i, j, m, is, ie, js, je
+  type(ocean_grid_type),  intent(in)    :: G  !< The ocean's grid structure.
+  type(surface),          intent(inout) :: state !< A structure containing fields that
+                                              !! describe the surface state of the ocean.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                          intent(in)    :: h  !< Layer thickness, in m or kg m-2.
+  type(DOME_tracer_CS),   pointer       :: CS !< The control structure returned by a previous
+                                              !! call to DOME_register_tracer.
+
+  ! This particular tracer package does not report anything back to the coupler.
+  ! The code that is here is just a rough guide for packages that would.
+
+  integer :: m, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   if (.not.associated(CS)) return
 
   if (CS%coupled_tracers) then
-    do m=1,ntr
-      !   This call loads the surface vlues into the appropriate array in the
+    do m=1,NTR
+      !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
-      call set_coupler_values(CS%tr(:,:,1,1), state%tr_fields, CS%ind_tr(m), &
-                              ind_csurf, is, ie, js, je)
+      call coupler_type_set_data(CS%tr(:,:,1,m), CS%ind_tr(m), ind_csurf, &
+                   state%tr_fields, idim=(/isd, is, ie, ied/), &
+                   jdim=(/jsd, js, je, jed/) )
     enddo
   endif
 

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -923,7 +923,8 @@ contains
   end subroutine MOM_generic_tracer_surface_state
 
 !ALL PE subroutine on Ocean!  Due to otpm design the fluxes should be initialized like this on ALL PE's!
-  subroutine MOM_generic_flux_init
+  subroutine MOM_generic_flux_init(verbosity)
+    integer, intent(in), optional :: verbosity  !< A 0-9 integer indicating a level of verbosity.
 
     integer :: ind
     character(len=fm_string_len)   :: g_tracer_name,longname, package,units,old_package,file_in,file_out
@@ -945,7 +946,7 @@ contains
     g_tracer=>g_tracer_list
     do
 
-       call g_tracer_flux_init(g_tracer)
+       call g_tracer_flux_init(g_tracer) !, verbosity=verbosity) !### Add this after ocean shared is updated.
 
        !traverse the linked list till hit NULL
        call g_tracer_get_next(g_tracer, g_tracer_next)

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -72,7 +72,7 @@ use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
-use coupler_util, only : set_coupler_values, ind_csurf
+use coupler_types_mod, only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private
@@ -464,32 +464,37 @@ subroutine advection_test_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, 
   enddo
 end subroutine advection_test_tracer_column_physics
 
+!> This subroutine extracts the surface fields from this tracer package that
+!! are to be shared with the atmosphere in coupled configurations.
+!! This particular tracer package does not report anything back to the coupler.
 subroutine advection_test_tracer_surface_state(state, h, G, CS)
-  type(ocean_grid_type),                    intent(in)    :: G    !< The ocean's grid structure
-  type(surface),                            intent(inout) :: state
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(advection_test_tracer_CS),           pointer       :: CS
-!   This particular tracer package does not report anything back to the coupler.
-! The code that is here is just a rough guide for packages that would.
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_advection_test_tracer.
-  integer :: i, j, m, is, ie, js, je
+  type(ocean_grid_type),  intent(in)    :: G  !< The ocean's grid structure.
+  type(surface),          intent(inout) :: state !< A structure containing fields that
+                                              !! describe the surface state of the ocean.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                          intent(in)    :: h  !< Layer thickness, in m or kg m-2.
+  type(advection_test_tracer_CS), pointer :: CS !< The control structure returned by a previous
+                                              !! call to register_advection_test_tracer.
+
+  ! This particular tracer package does not report anything back to the coupler.
+  ! The code that is here is just a rough guide for packages that would.
+
+  integer :: m, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   if (.not.associated(CS)) return
 
   if (CS%coupled_tracers) then
-    do m=1,ntr
-      !   This call loads the surface vlues into the appropriate array in the
+    do m=1,CS%ntr
+      !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
-      call set_coupler_values(CS%tr(:,:,1,1), state%tr_fields, CS%ind_tr(m), &
-                              ind_csurf, is, ie, js, je)
+      call coupler_type_set_data(CS%tr(:,:,1,m), CS%ind_tr(m), ind_csurf, &
+                   state%tr_fields, idim=(/isd, is, ie, ied/), &
+                   jdim=(/jsd, js, je, jed/) )
     enddo
   endif
+
 end subroutine advection_test_tracer_surface_state
 
 function advection_test_stock(h, stocks, G, GV, CS, names, units, stock_index)

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -22,7 +22,8 @@ use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use coupler_util, only : set_coupler_values, ind_csurf
+
+use coupler_types_mod, only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private
@@ -445,31 +446,34 @@ function boundary_impulse_stock(h, stocks, G, GV, CS, names, units, stock_index)
 
 end function boundary_impulse_stock
 
-!> Called if returned if coupler needs to know about tracer, currently unused
+!> This subroutine extracts the surface fields from this tracer package that
+!! are to be shared with the atmosphere in coupled configurations.
+!! This particular tracer package does not report anything back to the coupler.
 subroutine boundary_impulse_tracer_surface_state(state, h, G, CS)
-  type(ocean_grid_type),                    intent(in   ) :: G    !< The ocean's grid structure
-  type(surface),                            intent(inout) :: state
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in   ) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(boundary_impulse_tracer_CS), pointer,intent(in   ) :: CS
-!   This particular tracer package does not report anything back to the coupler.
-! The code that is here is just a rough guide for packages that would.
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_boundary_impulse_tracer.
-  integer :: m, is, ie, js, je
+  type(ocean_grid_type),  intent(in)    :: G  !< The ocean's grid structure.
+  type(surface),          intent(inout) :: state !< A structure containing fields that
+                                              !! describe the surface state of the ocean.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                          intent(in)    :: h  !< Layer thickness, in m or kg m-2.
+  type(boundary_impulse_tracer_CS), pointer :: CS !< The control structure returned by a previous
+                                              !! call to register_boundary_impulse_tracer.
+
+  ! This particular tracer package does not report anything back to the coupler.
+  ! The code that is here is just a rough guide for packages that would.
+
+  integer :: m, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   if (.not.associated(CS)) return
 
   if (CS%coupled_tracers) then
     do m=1,CS%ntr
-      !   This call loads the surface vlues into the appropriate array in the
+      !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
-      call set_coupler_values(CS%tr(:,:,1,m), state%tr_fields, CS%ind_tr(m), &
-                              ind_csurf, is, ie, js, je)
+      call coupler_type_set_data(CS%tr(:,:,1,m), CS%ind_tr(m), ind_csurf, &
+                   state%tr_fields, idim=(/isd, is, ie, ied/), &
+                   jdim=(/jsd, js, je, jed/) )
     enddo
   endif
 

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -74,7 +74,7 @@ use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
-use coupler_util, only : set_coupler_values, ind_csurf
+use coupler_types_mod, only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private
@@ -520,30 +520,34 @@ function dye_stock(h, stocks, G, GV, CS, names, units, stock_index)
 
 end function dye_stock
 
+!> This subroutine extracts the surface fields from this tracer package that
+!! are to be shared with the atmosphere in coupled configurations.
+!! This particular tracer package does not report anything back to the coupler.
 subroutine dye_tracer_surface_state(state, h, G, CS)
-  type(surface),                         intent(inout) :: state
-  real, dimension(NIMEM_,NJMEM_,NKMEM_), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(ocean_grid_type),                 intent(in)    :: G    !< The ocean's grid structure
-  type(dye_tracer_CS),                   pointer       :: CS
-!   This particular tracer package does not report anything back to the coupler.
-! The code that is here is just a rough guide for packages that would.
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_dye_tracer.
-  integer :: i, j, m, is, ie, js, je
+  type(ocean_grid_type),  intent(in)    :: G  !< The ocean's grid structure.
+  type(surface),          intent(inout) :: state !< A structure containing fields that
+                                              !! describe the surface state of the ocean.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                          intent(in)    :: h  !< Layer thickness, in m or kg m-2.
+  type(dye_tracer_CS),    pointer       :: CS !< The control structure returned by a previous
+                                              !! call to register_dye_tracer.
+
+  ! This particular tracer package does not report anything back to the coupler.
+  ! The code that is here is just a rough guide for packages that would.
+
+  integer :: m, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   if (.not.associated(CS)) return
 
   if (CS%coupled_tracers) then
     do m=1,CS%ntr
-      !   This call loads the surface vlues into the appropriate array in the
+      !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
-      call set_coupler_values(CS%tr(:,:,1,m), state%tr_fields, CS%ind_tr(m), &
-                              ind_csurf, is, ie, js, je)
+      call coupler_type_set_data(CS%tr(:,:,1,m), CS%ind_tr(m), ind_csurf, &
+                   state%tr_fields, idim=(/isd, is, ie, ied/), &
+                   jdim=(/jsd, js, je, jed/) )
     enddo
   endif
 

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -74,7 +74,7 @@ use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
-use coupler_util, only : set_coupler_values, ind_csurf
+use coupler_types_mod, only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private
@@ -591,30 +591,34 @@ function ideal_age_stock(h, stocks, G, GV, CS, names, units, stock_index)
 
 end function ideal_age_stock
 
+!> This subroutine extracts the surface fields from this tracer package that
+!! are to be shared with the atmosphere in coupled configurations.
+!! This particular tracer package does not report anything back to the coupler.
 subroutine ideal_age_tracer_surface_state(state, h, G, CS)
-  type(ocean_grid_type),                    intent(in)    :: G    !< The ocean's grid structure
-  type(surface),                            intent(inout) :: state
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(ideal_age_tracer_CS),                pointer       :: CS
-!   This particular tracer package does not report anything back to the coupler.
-! The code that is here is just a rough guide for packages that would.
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_ideal_age_tracer.
-  integer :: i, j, m, is, ie, js, je
+  type(ocean_grid_type),  intent(in)    :: G  !< The ocean's grid structure.
+  type(surface),          intent(inout) :: state !< A structure containing fields that
+                                              !! describe the surface state of the ocean.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                          intent(in)    :: h  !< Layer thickness, in m or kg m-2.
+  type(ideal_age_tracer_CS), pointer    :: CS !< The control structure returned by a previous
+                                              !! call to register_ideal_age_tracer.
+
+  ! This particular tracer package does not report anything back to the coupler.
+  ! The code that is here is just a rough guide for packages that would.
+
+  integer :: m, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   if (.not.associated(CS)) return
 
   if (CS%coupled_tracers) then
     do m=1,CS%ntr
-      !   This call loads the surface vlues into the appropriate array in the
+      !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
-      call set_coupler_values(CS%tr(:,:,1,m), state%tr_fields, CS%ind_tr(m), &
-                              ind_csurf, is, ie, js, je)
+      call coupler_type_set_data(CS%tr(:,:,1,m), CS%ind_tr(m), ind_csurf, &
+                   state%tr_fields, idim=(/isd, is, ie, ied/), &
+                   jdim=(/jsd, js, je, jed/) )
     enddo
   endif
 

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -74,7 +74,8 @@ use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use coupler_util, only : set_coupler_values, ind_csurf
+
+use coupler_types_mod, only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private
@@ -613,30 +614,34 @@ function oil_stock(h, stocks, G, GV, CS, names, units, stock_index)
 
 end function oil_stock
 
+!> This subroutine extracts the surface fields from this tracer package that
+!! are to be shared with the atmosphere in coupled configurations.
+!! This particular tracer package does not report anything back to the coupler.
 subroutine oil_tracer_surface_state(state, h, G, CS)
-  type(ocean_grid_type),                 intent(in)    :: G    !< The ocean's grid structure
-  type(surface),                         intent(inout) :: state
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(oil_tracer_CS),                   pointer       :: CS
-!   This particular tracer package does not report anything back to the coupler.
-! The code that is here is just a rough guide for packages that would.
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_oil_tracer.
-  integer :: m, is, ie, js, je
+  type(ocean_grid_type),  intent(in)    :: G  !< The ocean's grid structure.
+  type(surface),          intent(inout) :: state !< A structure containing fields that
+                                              !! describe the surface state of the ocean.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                          intent(in)    :: h  !< Layer thickness, in m or kg m-2.
+  type(oil_tracer_CS),    pointer       :: CS !< The control structure returned by a previous
+                                              !! call to register_oil_tracer.
+
+  ! This particular tracer package does not report anything back to the coupler.
+  ! The code that is here is just a rough guide for packages that would.
+
+  integer :: m, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   if (.not.associated(CS)) return
 
   if (CS%coupled_tracers) then
     do m=1,CS%ntr
-      !   This call loads the surface vlues into the appropriate array in the
+      !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
-      call set_coupler_values(CS%tr(:,:,1,m), state%tr_fields, CS%ind_tr(m), &
-                              ind_csurf, is, ie, js, je)
+      call coupler_type_set_data(CS%tr(:,:,1,m), CS%ind_tr(m), ind_csurf, &
+                   state%tr_fields, idim=(/isd, is, ie, ied/), &
+                   jdim=(/jsd, js, je, jed/) )
     enddo
   endif
 

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -73,7 +73,8 @@ use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use coupler_util, only : set_coupler_values, ind_csurf
+
+use coupler_types_mod, only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private
@@ -473,30 +474,34 @@ function pseudo_salt_stock(h, stocks, G, GV, CS, names, units, stock_index)
 
 end function pseudo_salt_stock
 
+!> This subroutine extracts the surface fields from this tracer package that
+!! are to be shared with the atmosphere in coupled configurations.
+!! This particular tracer package does not report anything back to the coupler.
 subroutine pseudo_salt_tracer_surface_state(state, h, G, CS)
-  type(ocean_grid_type),                 intent(in)    :: G    !< The ocean's grid structure
-  type(surface),                         intent(inout) :: state
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(pseudo_salt_tracer_CS),                   pointer       :: CS
-!   This particular tracer package does not report anything back to the coupler.
-! The code that is here is just a rough guide for packages that would.
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_pseudo_salt_tracer.
-  integer :: m, is, ie, js, je
+  type(ocean_grid_type),  intent(in)    :: G  !< The ocean's grid structure.
+  type(surface),          intent(inout) :: state !< A structure containing fields that
+                                              !! describe the surface state of the ocean.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                          intent(in)    :: h  !< Layer thickness, in m or kg m-2.
+  type(pseudo_salt_tracer_CS), pointer  :: CS !< The control structure returned by a previous
+                                              !! call to register_pseudo_salt_tracer.
+
+  ! This particular tracer package does not report anything back to the coupler.
+  ! The code that is here is just a rough guide for packages that would.
+
+  integer :: m, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   if (.not.associated(CS)) return
 
   if (CS%coupled_tracers) then
     do m=1,CS%ntr
-      !   This call loads the surface vlues into the appropriate array in the
+      !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
-      call set_coupler_values(CS%tr(:,:,1,m), state%tr_fields, CS%ind_tr(m), &
-                              ind_csurf, is, ie, js, je)
+      call coupler_type_set_data(CS%tr(:,:,1,m), CS%ind_tr(m), ind_csurf, &
+                   state%tr_fields, idim=(/isd, is, ie, ied/), &
+                   jdim=(/jsd, js, je, jed/) )
     enddo
   endif
 

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -68,7 +68,7 @@ use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
-use coupler_util, only : set_coupler_values, ind_csurf
+use coupler_types_mod, only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private
@@ -570,30 +570,33 @@ function USER_tracer_stock(h, stocks, G, GV, CS, names, units, stock_index)
 
 end function USER_tracer_stock
 
+!> This subroutine extracts the surface fields from this tracer package that
+!! are to be shared with the atmosphere in coupled configurations.
 subroutine USER_tracer_surface_state(state, h, G, CS)
-  type(ocean_grid_type),              intent(in)    :: G    !< The ocean's grid structure
-  type(surface),                      intent(inout) :: state
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(USER_tracer_example_CS),       pointer       :: CS
-!   This particular tracer package does not report anything back to the coupler.
-! The code that is here is just a rough guide for packages that would.
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_USER_tracer.
-  integer :: i, j, m, is, ie, js, je
+  type(ocean_grid_type),        intent(in)    :: G     !< The ocean's grid structure
+  type(surface),                intent(inout) :: state !< A structure containing fields that
+                                                       !! describe the surface state of the ocean.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                intent(in)    :: h  !< Layer thicknesses, in H (usually m or kg m-2)
+  type(USER_tracer_example_CS), pointer       :: CS !< The control structure returned by a previous
+                                                    !! call to register_USER_tracer.
+
+  ! This particular tracer package does not report anything back to the coupler.
+  ! The code that is here is just a rough guide for packages that would.
+
+  integer :: m, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   if (.not.associated(CS)) return
 
   if (CS%coupled_tracers) then
     do m=1,ntr
-      !   This call loads the surface vlues into the appropriate array in the
+      !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
-      call set_coupler_values(CS%tr(:,:,1,1), state%tr_fields, CS%ind_tr(m), &
-                              ind_csurf, is, ie, js, je)
+      call coupler_type_set_data(CS%tr(:,:,1,m), CS%ind_tr(m), ind_csurf, &
+                   state%tr_fields, idim=(/isd, is, ie, ied/), &
+                   jdim=(/jsd, js, je, jed/) )
     enddo
   endif
 


### PR DESCRIPTION
This series of commits makes use of the new coupler_type funcitonalities to use the same treatment in the code for the surface properties and fluxes associated with gases and other run-time configurable coupled tracers as is already used for physical quantities and fluxes.  None of these changes will change answers, but they do require that the FMS code that MOM6-examples points to to be updated (i.e., that pull request NOAA-GFDL/MOM6-examples PR#140 be acted on) before this pull request is executed.
