### PR TITLE
Reorder mom init

### DIFF
--- a/src/core/MOM_continuity.F90
+++ b/src/core/MOM_continuity.F90
@@ -45,7 +45,7 @@ subroutine continuity(u, v, hin, h, uh, vh, dt, G, GV, CS, uhbt, vhbt, OBC, &
   type(verticalGrid_type), intent(in)                      :: GV  !< Vertical grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: u   !< Zonal velocity, in m/s.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: v   !< Meridional velocity, in m/s.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: hin !< Initial layer thickness, in m or kg/m2.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: hin !< Initial layer thickness, in m or kg/m2.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h   !< Final layer thickness, in m or kg/m2.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(out)   :: uh  !< Volume flux through zonal faces =
                                                                   !! u*h*dy, in m3/s.

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -325,6 +325,8 @@ subroutine zonal_mass_flux(u, h_in, uh, dt, G, GV, CS, LB, uhbt, OBC, &
   logical, dimension(SZIB_(G)) :: do_I
   real, dimension(SZIB_(G),SZK_(G)) :: &
     visc_rem      ! A 2-D copy of visc_rem_u or an array of 1's.
+  real, dimension(SZIB_(G)) :: FAuI  ! A list of sums of zonal face areas, in H m.
+  real :: FA_u    ! A sum of zonal face areas, in H m.
   real :: I_vrm   ! 1.0 / visc_rem_max, nondim.
   real :: CFL_dt  ! The maximum CFL ratio of the adjusted velocities divided by
                   ! the time step, in s-1.
@@ -374,8 +376,7 @@ subroutine zonal_mass_flux(u, h_in, uh, dt, G, GV, CS, LB, uhbt, OBC, &
 !$OMP                                  uh,dt,G,GV,CS,local_specified_BC,OBC,uhbt,do_aux,set_BT_cont,    &
 !$OMP                                  CFL_dt,I_dt,u_cor,uhbt_aux,u_cor_aux,BT_cont, local_Flather_OBC) &
 !$OMP                          private(do_I,duhdu,du,du_max_CFL,du_min_CFL,uh_tot_0,duhdu_tot_0, &
-!$OMP                                  is_simple, &
-!$OMP                                  visc_rem_max, I_vrm, du_lim, dx_E, dx_W, any_simple_OBC ) &
+!$OMP                                  is_simple,FAuI,visc_rem_max,I_vrm,du_lim,dx_E,dx_W,any_simple_OBC ) &
 !$OMP      firstprivate(visc_rem)
   do j=jsh,jeh
     do I=ish-1,ieh ; do_I(I) = .true. ; visc_rem_max(I) = 0.0 ; enddo
@@ -527,18 +528,17 @@ subroutine zonal_mass_flux(u, h_in, uh, dt, G, GV, CS, LB, uhbt, OBC, &
         if (any_simple_OBC) then
           do I=ish-1,ieh
             do_I(I) = OBC%segment(OBC%segnum_u(I,j))%specified
-            if (do_I(I)) BT_cont%Fa_u_W0(I,j) = GV%H_subroundoff*G%dy_Cu(I,j)
+            if (do_I(I)) FAuI(I) = GV%H_subroundoff*G%dy_Cu(I,j)
           enddo
           do k=1,nz ; do I=ish-1,ieh ; if (do_I(I)) then
             if (abs(OBC%segment(OBC%segnum_u(I,j))%normal_vel(I,j,k)) > 0.0) &
-              BT_cont%Fa_u_W0(I,j) = BT_cont%Fa_u_W0(I,j) + &
-                   OBC%segment(OBC%segnum_u(I,j))%normal_trans(I,j,k) / &
-                   OBC%segment(OBC%segnum_u(I,j))%normal_vel(I,j,k)
+              FAuI(I) = FAuI(I) + OBC%segment(OBC%segnum_u(I,j))%normal_trans(I,j,k) / &
+                                  OBC%segment(OBC%segnum_u(I,j))%normal_vel(I,j,k)
           endif ; enddo ; enddo
           do I=ish-1,ieh ; if (do_I(I)) then
-            BT_cont%Fa_u_E0(I,j) = BT_cont%Fa_u_W0(I,j)
-            BT_cont%Fa_u_WW(I,j) = BT_cont%Fa_u_W0(I,j)
-            BT_cont%Fa_u_EE(I,j) = BT_cont%Fa_u_W0(I,j)
+            BT_cont%Fa_u_W0(I,j) = FAuI(I) ; BT_cont%Fa_u_E0(I,j) = FAuI(I)
+            BT_cont%Fa_u_WW(I,j) = FAuI(I) ; BT_cont%Fa_u_EE(I,j) = FAuI(I)
+            BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
           endif ; enddo
         endif
       endif ! set_BT_cont
@@ -551,23 +551,19 @@ subroutine zonal_mass_flux(u, h_in, uh, dt, G, GV, CS, LB, uhbt, OBC, &
         I = OBC%segment(n)%HI%IsdB
         if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
           do J = OBC%segment(n)%HI%Jsd, OBC%segment(n)%HI%Jed
-            BT_cont%Fa_u_W0(I,j) = 0.0
-            do k=1,nz
-              BT_cont%Fa_u_W0(I,j) = BT_cont%Fa_u_W0(I,j) + h_in(i,j,k)*G%dy_Cu(I,j)
-            enddo
-            BT_cont%Fa_u_E0(I,j) = BT_cont%Fa_u_W0(I,j)
-            BT_cont%Fa_u_WW(I,j) = BT_cont%Fa_u_W0(I,j)
-            BT_cont%Fa_u_EE(I,j) = BT_cont%Fa_u_W0(I,j)
+            FA_u = 0.0
+            do k=1,nz ; FA_u = FA_u + h_in(i,j,k)*G%dy_Cu(I,j) ; enddo
+            BT_cont%Fa_u_W0(I,j) = FA_u ; BT_cont%Fa_u_E0(I,j) = FA_u
+            BT_cont%Fa_u_WW(I,j) = FA_u ; BT_cont%Fa_u_EE(I,j) = FA_u
+            BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
           enddo
         else
           do J = OBC%segment(n)%HI%Jsd, OBC%segment(n)%HI%Jed
-            BT_cont%Fa_u_W0(I,j) = 0.0
-            do k=1,nz
-              BT_cont%Fa_u_W0(I,j) = BT_cont%Fa_u_W0(I,j) + h_in(i+1,j,k)*G%dy_Cu(I,j)
-            enddo
-            BT_cont%Fa_u_E0(I,j) = BT_cont%Fa_u_W0(I,j)
-            BT_cont%Fa_u_WW(I,j) = BT_cont%Fa_u_W0(I,j)
-            BT_cont%Fa_u_EE(I,j) = BT_cont%Fa_u_W0(I,j)
+            FA_u = 0.0
+            do k=1,nz ; FA_u = FA_u + h_in(i+1,j,k)*G%dy_Cu(I,j) ; enddo
+            BT_cont%Fa_u_W0(I,j) = FA_u ; BT_cont%Fa_u_E0(I,j) = FA_u
+            BT_cont%Fa_u_WW(I,j) = FA_u ; BT_cont%Fa_u_EE(I,j) = FA_u
+            BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
           enddo
         endif
       endif
@@ -578,10 +574,10 @@ subroutine zonal_mass_flux(u, h_in, uh, dt, G, GV, CS, LB, uhbt, OBC, &
   if  (set_BT_cont) then ; if (associated(BT_cont%h_u)) then
     if (present(u_cor)) then
       call zonal_face_thickness(u_cor, h_in, h_L, h_R, BT_cont%h_u, dt, G, LB, &
-                                CS%vol_CFL, CS%marginal_faces, visc_rem_u)
+                                CS%vol_CFL, CS%marginal_faces, visc_rem_u, OBC)
     else
       call zonal_face_thickness(u, h_in, h_L, h_R, BT_cont%h_u, dt, G, LB, &
-                                CS%vol_CFL, CS%marginal_faces, visc_rem_u)
+                                CS%vol_CFL, CS%marginal_faces, visc_rem_u, OBC)
     endif
   endif ; endif
 
@@ -665,7 +661,7 @@ end subroutine zonal_flux_layer
 
 !> Sets the effective interface thickness at each zonal velocity point.
 subroutine zonal_face_thickness(u, h, h_L, h_R, h_u, dt, G, LB, vol_CFL, &
-                                marginal, visc_rem_u)
+                                marginal, visc_rem_u, OBC)
   type(ocean_grid_type),                     intent(inout) :: G    !< Ocean's grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: u    !< Zonal velocity, in m s-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h    !< Layer thickness used to
@@ -691,19 +687,19 @@ subroutine zonal_face_thickness(u, h, h_L, h_R, h_u, dt, G, LB, vol_CFL, &
                           !! barotropic acceleration that a layer experiences
                           !! after viscosity is applied. Non-dimensional between
                           !! 0 (at the bottom) and 1 (far above the bottom).
+  type(ocean_OBC_type),                      pointer,     optional :: OBC !< Open boundaries control structure.
+
   ! Local variables
   real :: CFL  ! The CFL number based on the local velocity and grid spacing, ND.
   real :: curv_3 ! A measure of the thickness curvature over a grid length,
                  ! with the same units as h_in.
   real :: h_avg  ! The average thickness of a flux, in H.
   real :: h_marg ! The marginal thickness of a flux, in H.
-  integer :: i, j, k, ish, ieh, jsh, jeh, nz
+  logical :: local_open_BC
+  integer :: i, j, k, ish, ieh, jsh, jeh, nz, n
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = G%ke
 
-!$OMP parallel default(none) shared(ish,ieh,jsh,jeh,nz,u,vol_CFL,dt,G, &
-!$OMP                               h_L,h_R,h,h_u,visc_rem_u,marginal) &
-!$OMP                       private(CFL,curv_3,h_marg,h_avg)
-!$OMP do
+  !$OMP parallel do default(shared) private(CFL,curv_3,h_marg,h_avg)
   do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
     if (u(I,j,k) > 0.0) then
       if (vol_CFL) then ; CFL = (u(I,j,k) * dt) * (G%dy_Cu(I,j) * G%IareaT(i,j))
@@ -731,12 +727,44 @@ subroutine zonal_face_thickness(u, h, h_L, h_R, h_u, dt, G, LB, vol_CFL, &
     else ; h_u(I,j,k) = h_avg ; endif
   enddo; enddo ; enddo
   if (present(visc_rem_u)) then
-!$OMP do
+    !$OMP parallel do default(shared)
     do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
       h_u(I,j,k) = h_u(I,j,k) * visc_rem_u(I,j,k)
     enddo ; enddo ; enddo
   endif
-!$OMP end parallel
+
+  local_open_BC = .false.
+  if (present(OBC)) then ; if (associated(OBC)) then
+    local_open_BC = OBC%open_u_BCs_exist_globally
+  endif ; endif
+  if (local_open_BC) then
+    do n = 1, OBC%number_of_segments
+      if (OBC%segment(n)%open .and. OBC%segment(n)%is_E_or_W) then
+        I = OBC%segment(n)%HI%IsdB
+        if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+          if (present(visc_rem_u)) then ; do k=1,nz
+            do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
+              h_u(I,j,k) = h(i,j,k) * visc_rem_u(I,j,k)
+            enddo
+          enddo ; else ; do k=1,nz
+            do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
+              h_u(I,j,k) = h(i,j,k)
+            enddo
+          enddo ; endif
+        else
+          if (present(visc_rem_u)) then ; do k=1,nz
+            do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
+              h_u(I,j,k) = h(i+1,j,k) * visc_rem_u(I,j,k)
+            enddo
+          enddo ; else ; do k=1,nz
+            do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
+              h_u(I,j,k) = h(i+1,j,k)
+            enddo
+          enddo ; endif
+        endif
+      endif
+    enddo
+  endif
 
 end subroutine zonal_face_thickness
 
@@ -1002,9 +1030,8 @@ subroutine set_zonal_BT_cont(u, h_in, h_L, h_R, BT_cont, uh_tot_0, duhdu_tot_0, 
   if (.not.domore) then
     do k=1,nz ; do I=ish-1,ieh
       BT_cont%FA_u_W0(I,j) = 0.0 ; BT_cont%FA_u_WW(I,j) = 0.0
-      BT_cont%uBT_WW(I,j) = 0.0
       BT_cont%FA_u_E0(I,j) = 0.0 ; BT_cont%FA_u_EE(I,j) = 0.0
-      BT_cont%uBT_EE(I,j) = 0.0
+      BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
     enddo ; enddo
     return
   endif
@@ -1068,9 +1095,8 @@ subroutine set_zonal_BT_cont(u, h_in, h_L, h_R, BT_cont, uh_tot_0, duhdu_tot_0, 
     endif
   else
     BT_cont%FA_u_W0(I,j) = 0.0 ; BT_cont%FA_u_WW(I,j) = 0.0
-    BT_cont%uBT_WW(I,j) = 0.0
     BT_cont%FA_u_E0(I,j) = 0.0 ; BT_cont%FA_u_EE(I,j) = 0.0
-    BT_cont%uBT_EE(I,j) = 0.0
+    BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
   endif ; enddo
 
 end subroutine set_zonal_BT_cont
@@ -1124,6 +1150,8 @@ subroutine meridional_mass_flux(v, h_in, vh, dt, G, GV, CS, LB, vhbt, OBC, &
     vh_tot_0, &   ! Summed transport with no barotropic correction in H m2 s-1.
     visc_rem_max  ! The column maximum of visc_rem.
   logical, dimension(SZI_(G)) :: do_I
+  real, dimension(SZI_(G)) :: FAvi  ! A list of sums of meridional face areas, in H m.
+  real :: FA_v    ! A sum of meridional face areas, in H m.
   real, dimension(SZI_(G),SZK_(G)) :: &
     visc_rem      ! A 2-D copy of visc_rem_v or an array of 1's.
   real :: I_vrm   ! 1.0 / visc_rem_max, nondim.
@@ -1177,8 +1205,7 @@ subroutine meridional_mass_flux(v, h_in, vh, dt, G, GV, CS, LB, vhbt, OBC, &
 !$OMP                                  v_cor_aux,BT_cont, local_Flather_OBC )           &
 !$OMP                          private(do_I,dvhdv,dv,dv_max_CFL,dv_min_CFL,vh_tot_0,    &
 !$OMP                                  dvhdv_tot_0,visc_rem_max,I_vrm,dv_lim,dy_N,      &
-!$OMP                                  is_simple, &
-!$OMP                                  dy_S,any_simple_OBC ) &
+!$OMP                                  is_simple,FAvi,dy_S,any_simple_OBC ) &
 !$OMP                     firstprivate(visc_rem)
   do J=jsh-1,jeh
     do i=ish,ieh ; do_I(i) = .true. ; visc_rem_max(I) = 0.0 ; enddo
@@ -1325,18 +1352,18 @@ subroutine meridional_mass_flux(v, h_in, vh, dt, G, GV, CS, LB, vhbt, OBC, &
         if (any_simple_OBC) then
           do i=ish,ieh
             do_I(i) = (OBC%segment(OBC%segnum_v(i,J))%specified)
-            if (do_I(i)) BT_cont%Fa_v_S0(i,J) = GV%H_subroundoff*G%dx_Cv(i,J)
+            if (do_I(i)) FAvi(i) = GV%H_subroundoff*G%dx_Cv(i,J)
           enddo
           do k=1,nz ; do i=ish,ieh ; if (do_I(i)) then
             if (abs(OBC%segment(OBC%segnum_v(i,J))%normal_vel(i,J,k)) > 0.0) &
-              BT_cont%Fa_v_S0(i,J) = BT_cont%Fa_v_S0(i,J) + &
+              FAvi(i) = FAvi(i) + &
                    OBC%segment(OBC%segnum_v(i,J))%normal_trans(i,J,k) / &
                    OBC%segment(OBC%segnum_v(i,J))%normal_vel(i,J,k)
           endif ; enddo ; enddo
           do i=ish,ieh ; if (do_I(i)) then
-            BT_cont%Fa_v_N0(i,J) = BT_cont%Fa_v_S0(i,J)
-            BT_cont%Fa_v_SS(i,J) = BT_cont%Fa_v_S0(i,J)
-            BT_cont%Fa_v_NN(i,J) = BT_cont%Fa_v_S0(i,J)
+            BT_cont%FA_v_S0(i,J) = FAvi(i) ; BT_cont%FA_v_N0(i,J) = FAvi(i)
+            BT_cont%FA_v_SS(i,J) = FAvi(i) ; BT_cont%FA_v_NN(i,J) = FAvi(i)
+            BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
           endif ; enddo
         endif
       endif ! set_BT_cont
@@ -1349,24 +1376,20 @@ subroutine meridional_mass_flux(v, h_in, vh, dt, G, GV, CS, LB, vhbt, OBC, &
       if (OBC%segment(n)%open .and. OBC%segment(n)%is_N_or_S) then
         J = OBC%segment(n)%HI%JsdB
         if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-          do I = OBC%segment(n)%HI%Isd, OBC%segment(n)%HI%Ied
-            BT_cont%Fa_v_S0(i,J) = 0.0
-            do k=1,nz
-              BT_cont%Fa_v_S0(i,J) = BT_cont%Fa_v_S0(i,J) + h_in(i,j,k)*G%dx_Cv(i,J)
-            enddo
-            BT_cont%Fa_v_N0(i,J) = BT_cont%Fa_v_S0(i,J)
-            BT_cont%Fa_v_SS(i,J) = BT_cont%Fa_v_S0(i,J)
-            BT_cont%Fa_v_NN(i,J) = BT_cont%Fa_v_S0(i,J)
+          do i = OBC%segment(n)%HI%Isd, OBC%segment(n)%HI%Ied
+            FA_v = 0.0
+            do k=1,nz ; FA_v = FA_v + h_in(i,j,k)*G%dx_Cv(i,J) ; enddo
+            BT_cont%Fa_v_S0(i,J) = FA_v ; BT_cont%Fa_v_N0(i,J) = FA_v
+            BT_cont%Fa_v_SS(i,J) = FA_v ; BT_cont%Fa_v_NN(i,J) = FA_v
+            BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
           enddo
         else
-          do I = OBC%segment(n)%HI%Isd, OBC%segment(n)%HI%Ied
-            BT_cont%Fa_v_S0(i,J) = 0.0
-            do k=1,nz
-              BT_cont%Fa_v_S0(i,J) = BT_cont%Fa_v_S0(i,J) + h_in(i,j+1,k)*G%dx_Cv(i,J)
-            enddo
-            BT_cont%Fa_v_N0(i,J) = BT_cont%Fa_v_S0(i,J)
-            BT_cont%Fa_v_SS(i,J) = BT_cont%Fa_v_S0(i,J)
-            BT_cont%Fa_v_NN(i,J) = BT_cont%Fa_v_S0(i,J)
+          do i = OBC%segment(n)%HI%Isd, OBC%segment(n)%HI%Ied
+            FA_v = 0.0
+            do k=1,nz ; FA_v = FA_v + h_in(i,j+1,k)*G%dx_Cv(i,J) ; enddo
+            BT_cont%Fa_v_S0(i,J) = FA_v ; BT_cont%Fa_v_N0(i,J) = FA_v
+            BT_cont%Fa_v_SS(i,J) = FA_v ; BT_cont%Fa_v_NN(i,J) = FA_v
+            BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
           enddo
         endif
       endif
@@ -1377,10 +1400,10 @@ subroutine meridional_mass_flux(v, h_in, vh, dt, G, GV, CS, LB, vhbt, OBC, &
   if (set_BT_cont) then ; if (associated(BT_cont%h_v)) then
     if (present(v_cor)) then
       call merid_face_thickness(v_cor, h_in, h_L, h_R, BT_cont%h_v, dt, G, LB, &
-                                CS%vol_CFL, CS%marginal_faces, visc_rem_v)
+                                CS%vol_CFL, CS%marginal_faces, visc_rem_v, OBC)
     else
       call merid_face_thickness(v, h_in, h_L, h_R, BT_cont%h_v, dt, G, LB, &
-                                CS%vol_CFL, CS%marginal_faces, visc_rem_v)
+                                CS%vol_CFL, CS%marginal_faces, visc_rem_v, OBC)
     endif
   endif ; endif
 
@@ -1468,7 +1491,7 @@ end subroutine merid_flux_layer
 
 !> Sets the effective interface thickness at each meridional velocity point.
 subroutine merid_face_thickness(v, h, h_L, h_R, h_v, dt, G, LB, vol_CFL, &
-                                marginal, visc_rem_v)
+                                marginal, visc_rem_v, OBC)
   type(ocean_grid_type),                     intent(inout) :: G    !< Ocean's grid structure.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: v    !< Meridional velocity, in m s-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h    !< Layer thickness used to
@@ -1494,19 +1517,19 @@ subroutine merid_face_thickness(v, h, h_L, h_R, h_v, dt, G, LB, vol_CFL, &
                           !! barotropic acceleration that a layer experiences
                           !! after viscosity is applied. Non-dimensional between
                           !! 0 (at the bottom) and 1 (far above the bottom).
+  type(ocean_OBC_type),                      pointer,     optional :: OBC !< Open boundaries control structure.
+
   ! Local variables
   real :: CFL ! The CFL number based on the local velocity and grid spacing, ND.
   real :: curv_3 ! A measure of the thickness curvature over a grid length,
                  ! with the same units as h_in.
   real :: h_avg  ! The average thickness of a flux, in H.
   real :: h_marg ! The marginal thickness of a flux, in H.
-  integer :: i, j, k, ish, ieh, jsh, jeh, nz
+  logical :: local_open_BC
+  integer :: i, j, k, ish, ieh, jsh, jeh, n, nz
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = G%ke
 
-!$OMP parallel default(none) shared(ish,ieh,jsh,jeh,nz,v,vol_CFL,dt,G, &
-!$OMP                               h_L,h_R,h,h_v,visc_rem_v,marginal) &
-!$OMP                       private(CFL,curv_3,h_marg,h_avg)
-!$OMP do
+  !$OMP parallel do default(shared) private(CFL,curv_3,h_marg,h_avg)
   do k=1,nz ; do J=jsh-1,jeh ; do i=ish,ieh
     if (v(i,J,k) > 0.0) then
       if (vol_CFL) then ; CFL = (v(i,J,k) * dt) * (G%dx_Cv(i,J) * G%IareaT(i,j))
@@ -1536,12 +1559,44 @@ subroutine merid_face_thickness(v, h, h_L, h_R, h_v, dt, G, LB, vol_CFL, &
   enddo ; enddo ; enddo
 
   if (present(visc_rem_v)) then
-!$OMP do
+    !$OMP parallel do default(shared)
     do k=1,nz ; do J=jsh-1,jeh ; do i=ish,ieh
       h_v(i,J,k) = h_v(i,J,k) * visc_rem_v(i,J,k)
     enddo ; enddo ; enddo
   endif
-!$OMP end parallel
+
+  local_open_BC = .false.
+  if (present(OBC)) then ; if (associated(OBC)) then
+    local_open_BC = OBC%open_u_BCs_exist_globally
+  endif ; endif
+  if (local_open_BC) then
+    do n = 1, OBC%number_of_segments
+      if (OBC%segment(n)%open .and. OBC%segment(n)%is_N_or_S) then
+        J = OBC%segment(n)%HI%JsdB
+        if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+          if (present(visc_rem_v)) then ; do k=1,nz
+            do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
+              h_v(i,J,k) = h(i,j,k) * visc_rem_v(i,J,k)
+            enddo
+          enddo ; else ; do k=1,nz
+            do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
+              h_v(i,J,k) = h(i,j,k)
+            enddo
+          enddo ; endif
+        else
+          if (present(visc_rem_v)) then ; do k=1,nz
+            do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
+              h_v(i,J,k) = h(i,j+1,k) * visc_rem_v(i,J,k)
+            enddo
+          enddo ; else ; do k=1,nz
+            do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
+              h_v(i,J,k) = h(i,j+1,k)
+            enddo
+          enddo ; endif
+        endif
+      endif
+    enddo
+  endif
 
 end subroutine merid_face_thickness
 
@@ -1869,9 +1924,8 @@ subroutine set_merid_BT_cont(v, h_in, h_L, h_R, BT_cont, vh_tot_0, dvhdv_tot_0, 
     endif
   else
     BT_cont%FA_v_S0(i,J) = 0.0 ; BT_cont%FA_v_SS(i,J) = 0.0
-    BT_cont%vBT_SS(i,J) = 0.0
     BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
-    BT_cont%vBT_NN(i,J) = 0.0
+    BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
   endif ; enddo
 
 end subroutine set_merid_BT_cont

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -583,7 +583,13 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
     call do_group_pass(CS%pass_hp_uv, G%Domain)
     call cpu_clock_end(id_clock_pass)
 
+    if (CS%debug) &
+      call uvchksum("Pre OBC avg [uv]", u_av, v_av, G%HI, haloshift=1, symmetric=sym)
+
     call radiation_open_bdry_conds(CS%OBC, u_av, u_old_rad_OBC, v_av, v_old_rad_OBC, G, dt_pred)
+
+    if (CS%debug) &
+      call uvchksum("Post OBC avg [uv]", u_av, v_av, G%HI, haloshift=1, symmetric=sym)
   endif
 
   call cpu_clock_begin(id_clock_pass)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -132,6 +132,7 @@ type, public :: MOM_dyn_split_RK2_CS ; private
                      !! is forward-backward (0) or simulated backward
                      !! Euler (1).  0 is almost always used.
   logical :: debug   !< If true, write verbose checksums for debugging purposes.
+  logical :: debug_OBC !< If true, do debugging calls for open boundary conditions.
 
   logical :: module_is_initialized = .false.
 
@@ -322,7 +323,8 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   endif
 
   if (associated(CS%OBC)) then
-!   call open_boundary_test_extern_h(G, CS%OBC, h)
+    if (CS%debug_OBC) call open_boundary_test_extern_h(G, CS%OBC, h)
+
     do k=1,nz ; do j=js-1,je+1 ; do I=is-2,ie+1
       u_old_rad_OBC(I,j,k) = u_av(I,j,k)
     enddo ; enddo ; enddo
@@ -382,6 +384,8 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   if (associated(CS%OBC)) then; if (CS%OBC%update_OBC) then
     call update_OBC_data(CS%OBC, G, GV, tv, h, CS%update_OBC_CSp, Time_local)
   endif; endif
+  if (associated(CS%OBC) .and. CS%debug_OBC) &
+    call open_boundary_zero_normal_flow(CS%OBC, G, CS%PFu, CS%PFv)
 
   if (G%nonblocking_updates) then
     call cpu_clock_begin(id_clock_pass)
@@ -1005,6 +1009,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
                  "in the barotropic continuity equation.", default=.true.)
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", default=.false.)
+  call get_param(param_file, mdl, "DEBUG_OBC", CS%debug_OBC, default=.false.)
   call get_param(param_file, mdl, "DEBUG_TRUNCATIONS", debug_truncations, &
                  default=.false.)
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -336,6 +336,28 @@ subroutine open_boundary_config(G, param_file, OBC)
 
     !    if (open_boundary_query(OBC, needs_ext_seg_data=.true.)) &
     call initialize_segment_data(G, OBC, param_file)
+
+    if ( OBC%Flather_u_BCs_exist_globally .or. OBC%Flather_v_BCs_exist_globally ) then
+      call get_param(param_file, mdl, "OBC_RADIATION_MAX", OBC%rx_max, &
+                   "The maximum magnitude of the baroclinic radiation \n"//&
+                   "velocity (or speed of characteristics).  This is only \n"//&
+                   "used if one of the open boundary segments is using Orlanski.", &
+                   units="m s-1", default=10.0)
+      call get_param(param_file, mdl, "OBC_RAD_VEL_WT", OBC%gamma_uv, &
+                   "The relative weighting for the baroclinic radiation \n"//&
+                   "velocities (or speed of characteristics) at the new \n"//&
+                   "time level (1) or the running mean (0) for velocities. \n"//&
+                   "Valid values range from 0 to 1. This is only used if \n"//&
+                   "one of the open boundary segments is using Orlanski.", &
+                   units="nondim",  default=0.3)
+      call get_param(param_file, mdl, "OBC_RAD_THICK_WT", OBC%gamma_h, &
+                   "The relative weighting for the baroclinic radiation \n"//&
+                   "velocities (or speed of characteristics) at the new \n"//&
+                   "time level (1) or the running mean (0) for thicknesses. \n"//&
+                   "Valid values range from 0 to 1. This is only used if \n"//&
+                   "one of the open boundary segments is using Orlanski.", &
+                   units="nondim",  default=0.2)
+    endif
   endif
 
     ! Safety check
@@ -975,28 +997,6 @@ subroutine open_boundary_init(G, param_file, OBC)
   ! Local variables
 
   if (.not.associated(OBC)) return
-
-  if ( OBC%Flather_u_BCs_exist_globally .or. OBC%Flather_v_BCs_exist_globally ) then
-    call get_param(param_file, mdl, "OBC_RADIATION_MAX", OBC%rx_max, &
-                   "The maximum magnitude of the baroclinic radiation \n"//&
-                   "velocity (or speed of characteristics).  This is only \n"//&
-                   "used if one of the open boundary segments is using Orlanski.", &
-                   units="m s-1", default=10.0)
-    call get_param(param_file, mdl, "OBC_RAD_VEL_WT", OBC%gamma_uv, &
-                   "The relative weighting for the baroclinic radiation \n"//&
-                   "velocities (or speed of characteristics) at the new \n"//&
-                   "time level (1) or the running mean (0) for velocities. \n"//&
-                   "Valid values range from 0 to 1. This is only used if \n"//&
-                   "one of the open boundary segments is using Orlanski.", &
-                   units="nondim",  default=0.3)
-    call get_param(param_file, mdl, "OBC_RAD_THICK_WT", OBC%gamma_h, &
-                   "The relative weighting for the baroclinic radiation \n"//&
-                   "velocities (or speed of characteristics) at the new \n"//&
-                   "time level (1) or the running mean (0) for thicknesses. \n"//&
-                   "Valid values range from 0 to 1. This is only used if \n"//&
-                   "one of the open boundary segments is using Orlanski.", &
-                   units="nondim",  default=0.2)
-  endif
 
   id_clock_pass = cpu_clock_id('(Ocean OBC halo updates)', grain=CLOCK_ROUTINE)
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -286,7 +286,7 @@ subroutine open_boundary_config(G, param_file, OBC)
       call log_param(param_file, mdl, "DEBUG_OBC", debug_OBC, &
                  "If true, do additional calls to help debug the performance \n"//&
                  "of the open boundary condition code.", default=.false.)
-      
+
     call get_param(param_file, mdl, "OBC_SILLY_THICK", OBC%silly_h, &
                  "A silly value of thicknesses used outside of open boundary \n"//&
                  "conditions for debugging.", units="m", default=0.0, &

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -176,6 +176,13 @@ type, public :: ocean_OBC_type
   logical :: OBC_pe !< Is there an open boundary on this tile?
   type(remapping_CS),      pointer :: remap_CS   !< ALE remapping control structure for segments only
   type(OBC_registry_type), pointer :: OBC_Reg => NULL()  !< Registry type for boundaries
+
+  real :: silly_h  !< A silly value of thickness outside of the domain that
+                   !! can be used to test the independence of the OBCs to
+                   !! this external data, in m.
+  real :: silly_u  !< A silly value of velocity outside of the domain that
+                   !! can be used to test the independence of the OBCs to
+                   !! this external data, in m/s.
 end type ocean_OBC_type
 
 !> Control structure for open boundaries that read from files.
@@ -218,6 +225,7 @@ subroutine open_boundary_config(G, param_file, OBC)
   type(ocean_OBC_type),    pointer       :: OBC !< Open boundary control structure
   ! Local variables
   integer :: l ! For looping over segments
+  logical :: debug_OBC, debug
   character(len=15) :: segment_param_str ! The run-time parameter name for each segment
   character(len=100) :: segment_str      ! The contents (rhs) for parameter "segment_param_str"
   character(len=200) :: config1          ! String for OBC_USER_CONFIG
@@ -271,6 +279,23 @@ subroutine open_boundary_config(G, param_file, OBC)
     call get_param(param_file, mdl, "OBC_ZERO_BIHARMONIC", OBC%zero_biharmonic, &
          "If true, zeros the Laplacian of flow on open boundaries in the biharmonic\n"//&
          "viscosity term.", default=.false.)
+
+    call get_param(param_file, mdl, "DEBUG", debug, default=.false.)
+    call get_param(param_file, mdl, "DEBUG_OBC", debug_OBC, default=.false.)
+    if (debug_OBC .or. debug) &
+      call log_param(param_file, mdl, "DEBUG_OBC", debug_OBC, &
+                 "If true, do additional calls to help debug the performance \n"//&
+                 "of the open boundary condition code.", default=.false.)
+      
+    call get_param(param_file, mdl, "OBC_SILLY_THICK", OBC%silly_h, &
+                 "A silly value of thicknesses used outside of open boundary \n"//&
+                 "conditions for debugging.", units="m", default=0.0, &
+                 do_not_log=.not.debug_OBC)
+    call get_param(param_file, mdl, "OBC_SILLY_VEL", OBC%silly_u, &
+                 "A silly value of velocities used outside of open boundary \n"//&
+                 "conditions for debugging.", units="m/s", default=0.0, &
+                 do_not_log=.not.debug_OBC)
+
     ! Allocate everything
     ! Note the 0-segment is needed when %segnum_u/v(:,:) = 0
     allocate(OBC%segment(0:OBC%number_of_segments))
@@ -1733,7 +1758,6 @@ subroutine open_boundary_test_extern_uv(G, OBC, u, v)
   real, dimension(SZI_(G),SZJB_(G), SZK_(G)),intent(inout) :: v !< Meridional velocity (m/s)
   ! Local variables
   integer :: i, j, k, n
-  real, parameter :: silly_value = 1.E40
 
   if (.not. associated(OBC)) return
 
@@ -1743,22 +1767,22 @@ subroutine open_boundary_test_extern_uv(G, OBC, u, v)
         J = OBC%segment(n)%HI%JsdB
         if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
           do I = OBC%segment(n)%HI%IsdB, OBC%segment(n)%HI%IedB
-            u(I,j+1,k) = silly_value
+            u(I,j+1,k) = OBC%silly_u
           enddo
         else
           do I = OBC%segment(n)%HI%IsdB, OBC%segment(n)%HI%IedB
-            u(I,j,k) = silly_value
+            u(I,j,k) = OBC%silly_u
           enddo
         endif
       elseif (OBC%segment(n)%is_E_or_W) then
         I = OBC%segment(n)%HI%IsdB
         if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
           do J = OBC%segment(n)%HI%JsdB, OBC%segment(n)%HI%JedB
-            v(i+1,J,k) = silly_value
+            v(i+1,J,k) = OBC%silly_u
           enddo
         else
           do J = OBC%segment(n)%HI%JsdB, OBC%segment(n)%HI%JedB
-            v(i,J,k) = silly_value
+            v(i,J,k) = OBC%silly_u
           enddo
         endif
       endif
@@ -1776,7 +1800,6 @@ subroutine open_boundary_test_extern_h(G, OBC, h)
   real, dimension(SZI_(G),SZJ_(G), SZK_(G)),intent(inout) :: h   !< Layer thickness (m or kg/m2)
   ! Local variables
   integer :: i, j, k, n
-  real, parameter :: silly_value = 1.E40
 
   if (.not. associated(OBC)) return
 
@@ -1786,22 +1809,22 @@ subroutine open_boundary_test_extern_h(G, OBC, h)
         J = OBC%segment(n)%HI%JsdB
         if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
           do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
-            h(i,j+1,k) = silly_value
+            h(i,j+1,k) = OBC%silly_h
           enddo
         else
           do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
-            h(i,j,k) = silly_value
+            h(i,j,k) = OBC%silly_h
           enddo
         endif
       elseif (OBC%segment(n)%is_E_or_W) then
         I = OBC%segment(n)%HI%IsdB
         if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
           do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
-            h(i+1,j,k) = silly_value
+            h(i+1,j,k) = OBC%silly_h
           enddo
         else
           do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
-            h(i,j,k) = silly_value
+            h(i,j,k) = OBC%silly_h
           enddo
         endif
       endif

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -171,7 +171,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                         ! is a run from a restart file; this option
                         ! allows the use of Fatal unused parameters.
   type(EOS_type), pointer :: eos => NULL()
-  logical :: debug    ! indicates whether to write debugging output
+  logical :: debug      ! If true, write debugging output.
+  logical :: debug_obc  ! If true, do debugging calls related to OBCs.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
@@ -185,6 +186,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
   call callTree_enter("MOM_initialize_state(), MOM_state_initialization.F90")
   call log_version(PF, mdl, version, "")
   call get_param(PF, mdl, "DEBUG", debug, default=.false.)
+  call get_param(PF, mdl, "DEBUG_OBC", debug_obc, default=.false.)
 
   new_sim = .false.
   if ((dirs%input_filename(1:1) == 'n') .and. &
@@ -574,7 +576,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
     call qchksum(G%mask2dBu, 'MOM_initialize_state: mask2dBu ', G%HI)
   endif
 
-! call open_boundary_test_extern_h(G, OBC, h)
+  if (debug_OBC) call open_boundary_test_extern_h(G, OBC, h)
   call callTree_leave('MOM_initialize_state()')
 
 end subroutine MOM_initialize_state


### PR DESCRIPTION
This pull request follows on from MOM6 PR #581 . It changes the order of some of the initialization calls in preparation for changing how the open boundary condition specification is handled for tracers, and it
also collects together the logging of all of the open boundary condition parameters.