### PR TITLE
Bugfix when using passive tracers with diabatic driver but no fluxes

### DIFF
--- a/src/tracer/MOM_tracer_diabatic.F90
+++ b/src/tracer/MOM_tracer_diabatic.F90
@@ -253,8 +253,8 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, evap_CFL_lim
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
-!  ! Only apply forcing if fluxes%sw is associated.
-!  if (.not.ASSOCIATED(fluxes%sw)) return
+  ! If no freshwater fluxes, nothing needs to be done in this routine
+  if ( (.not. ASSOCIATED(fluxes%netMassIn)) .or. (.not. ASSOCIATED(fluxes%netMassOut)) ) return
 
   in_flux(:,:) = 0.0 ; out_flux(:,:) = 0.0
   if(present(in_flux_optional)) then


### PR DESCRIPTION
In TracerBoundaryFluxesInOut, a return-check for fluxes%sw was commented
out because passive tracers probably would never flux with shortwave
radiation. However, this also protected against using the routine if
freshwater fluxes were not needed. In the tracer_mixing test case when a
dye tracer was used, a runtime error was triggered because it would try to
access fluxes%netMassOut and fluxes%netMassIn which were (correctly) never
allocated. Now, the routine checks that these fields exist. If not, the
subroutine returns.