### PR TITLE
Closes issue #383, fixes an openmp crash

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -801,12 +801,20 @@ subroutine convert_state_to_ocean_type(state, Ocean_sfc, G, use_conT_absS, patm,
 
   do j=jsc_bnd,jec_bnd ; do i=isc_bnd,iec_bnd
     Ocean_sfc%sea_lev(i,j) = state%sea_lev(i+i0,j+j0)
-    if (present(patm)) &
-      Ocean_sfc%sea_lev(i,j) = Ocean_sfc%sea_lev(i,j) + patm(i,j) * press_to_z
-      if (associated(state%frazil)) &
-      Ocean_sfc%frazil(i,j) = state%frazil(i+i0,j+j0)
     Ocean_sfc%area(i,j)   =  G%areaT(i+i0,j+j0)
   enddo ; enddo
+
+  if (present(patm)) then
+    do j=jsc_bnd,jec_bnd ; do i=isc_bnd,iec_bnd
+       Ocean_sfc%sea_lev(i,j) = Ocean_sfc%sea_lev(i,j) + patm(i,j) * press_to_z
+    enddo ; enddo
+  endif
+
+  if (associated(state%frazil)) then
+    do j=jsc_bnd,jec_bnd ; do i=isc_bnd,iec_bnd
+      Ocean_sfc%frazil(i,j) = state%frazil(i+i0,j+j0)
+    enddo ; enddo
+  endif
 
   if (Ocean_sfc%stagger == AGRID) then
     do j=jsc_bnd,jec_bnd ; do i=isc_bnd,iec_bnd


### PR DESCRIPTION
- Coupled models in which MOM6 is compiled with -openmp are crashing with a traceback

  forrtl: severe (174): SIGSEGV, segmentation fault occurred
Image              PC                Routine            Line        Source
fms_MOM6_SIS2_com  000000000073C880  ocean_model_mod_m         803  ocean_model_MOM.F90
fms_MOM6_SIS2_com  00000000007381B2  ocean_model_mod_m         507  ocean_model_MOM.F90

- The problem seems to be the "present(patm)" statement inside an ij loop
  even when the source file that has no !$OMP directives!!
  Although it's apparently the compiler being confused,
  taking the "present" outside the loop seems to fix the problem.
  And one might argue is more efficient.

- I also took the if (associated(state%frazil)) statement outside the loop to be more efficient,
  although the compiler did not have problem with that one.

- The crash occured with all versions of Intel on c3/c4 and theta.