### PR TITLE
Restore cell measures for dynamic variables

### DIFF
--- a/src/framework/MOM_diag_manager_wrapper.F90
+++ b/src/framework/MOM_diag_manager_wrapper.F90
@@ -41,7 +41,7 @@ integer function register_diag_field_array_fms(module_name, field_name, axes, in
              init_time, long_name=long_name, units=units, missing_value=missing_value, &
              mask_variant=mask_variant, standard_name=standard_name,                   &
              verbose=verbose, do_not_log=do_not_log, err_msg=err_msg,                  &
-             interp_method=interp_method)
+             area=area, interp_method=interp_method)
 
 end function register_diag_field_array_fms
 


### PR DESCRIPTION
- Introducing a work around for the PGI 16.5.0 compiler,
  commit 69c643db41634b7cb2, broke cell measures for dynamic
  variables because we did not pass through the area id.