### PR TITLE
Changed default missing value

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1865,7 +1865,7 @@ subroutine diag_mediator_init(G, nz, param_file, diag_cs, doc_file_dir)
 
   call get_param(param_file, mod, 'DIAG_MISVAL', diag_cs%missing_value, &
                  'Set the default missing value to use for diagnostics.', &
-                 default=-1.e34)
+                 default=1.e20)
 
   ! Keep pointers grid, h, T, S needed diagnostic remapping
   diag_cs%G => G


### PR DESCRIPTION
- We were using -1e.34 for the missing value for netcdf output
  but CMOR specifies the missing value to be 1.e20.
- Closes NOAA-GFDL/MOM6-examples#160.