### PR TITLE
Adds cell methods to static variables

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3226,10 +3226,38 @@ subroutine write_static_fields(G, diag)
   id = register_static_field('ocean_model', 'area_t', diag%axesT1,   &
         'Surface area of tracer (T) cells', 'm2',                    &
         cmor_field_name='areacello', cmor_standard_name='cell_area', &
-        cmor_units='m2', cmor_long_name='Ocean Grid-Cell Area')
+        cmor_units='m2', cmor_long_name='Ocean Grid-Cell Area',      &
+        x_cell_method='sum', y_cell_method='sum')
   if (id > 0) then
     call post_data(id, G%areaT, diag, .true., mask=G%mask2dT)
     call diag_register_area_ids(diag, id_area_t=id)
+  endif
+
+  id = register_static_field('ocean_model', 'area_u', diag%axesCu1,     &
+        'Surface area of x-direction flow (U) cells', 'm2',             &
+        cmor_field_name='areacello_cu', cmor_standard_name='cell_area', &
+        cmor_units='m2', cmor_long_name='Ocean Grid-Cell Area',         &
+        x_cell_method='sum', y_cell_method='sum')
+  if (id > 0) then
+    call post_data(id, G%areaCu, diag, .true., mask=G%mask2dCu)
+  endif
+
+  id = register_static_field('ocean_model', 'area_v', diag%axesCv1,     &
+        'Surface area of y-direction flow (V) cells', 'm2',             &
+        cmor_field_name='areacello_cv', cmor_standard_name='cell_area', &
+        cmor_units='m2', cmor_long_name='Ocean Grid-Cell Area',         &
+        x_cell_method='sum', y_cell_method='sum')
+  if (id > 0) then
+    call post_data(id, G%areaCv, diag, .true., mask=G%mask2dCv)
+  endif
+
+  id = register_static_field('ocean_model', 'area_q', diag%axesB1,      &
+        'Surface area of B-grid flow (Q) cells', 'm2',                  &
+        cmor_field_name='areacello_bu', cmor_standard_name='cell_area', &
+        cmor_units='m2', cmor_long_name='Ocean Grid-Cell Area',         &
+        x_cell_method='sum', y_cell_method='sum')
+  if (id > 0) then
+    call post_data(id, G%areaBu, diag, .true., mask=G%mask2dBu)
   endif
 
   id = register_static_field('ocean_model', 'depth_ocean', diag%axesT1,  &
@@ -3237,7 +3265,7 @@ subroutine write_static_fields(G, diag)
         standard_name='sea_floor_depth_below_geoid',                     &
         cmor_field_name='deptho', cmor_long_name='Sea Floor Depth',      &
         cmor_units='m', cmor_standard_name='sea_floor_depth_below_geoid',&
-        area=diag%axesT1%id_area)
+        area=diag%axesT1%id_area, x_cell_method='mean', y_cell_method='mean')
   if (id > 0) call post_data(id, G%bathyT, diag, .true., mask=G%mask2dT)
 
   id = register_static_field('ocean_model', 'wet', diag%axesT1, &

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1569,10 +1569,11 @@ end function register_scalar_field
 function register_static_field(module_name, field_name, axes, &
      long_name, units, missing_value, range, mask_variant, standard_name, &
      do_not_log, interp_method, tile_count, &
-     cmor_field_name, cmor_long_name, cmor_units, cmor_standard_name, area)
+     cmor_field_name, cmor_long_name, cmor_units, cmor_standard_name, area, &
+     x_cell_method, y_cell_method)
   integer :: register_static_field
   character(len=*), intent(in) :: module_name, field_name
-  type(axes_grp),   intent(in) :: axes
+  type(axes_grp),   target,   intent(in) :: axes
   character(len=*), optional, intent(in) :: long_name, units, standard_name
   real,             optional, intent(in) :: missing_value, range(2)
   logical,          optional, intent(in) :: mask_variant, do_not_log
@@ -1581,6 +1582,8 @@ function register_static_field(module_name, field_name, axes, &
   character(len=*), optional, intent(in) :: cmor_field_name, cmor_long_name
   character(len=*), optional, intent(in) :: cmor_units, cmor_standard_name
   integer,          optional, intent(in) :: area !< fms_id for area_t
+  character(len=*), optional, intent(in) :: x_cell_method !< Specifies the cell method for the x-direction.
+  character(len=*), optional, intent(in) :: y_cell_method !< Specifies the cell method for the y-direction.
 
   ! Output:    An integer handle for a diagnostic array.
   ! Arguments:
@@ -1604,6 +1607,7 @@ function register_static_field(module_name, field_name, axes, &
   type(diag_type), pointer :: diag => null(), cmor_diag => null()
   integer :: dm_id, fms_id, cmor_id
   character(len=256) :: posted_cmor_units, posted_cmor_standard_name, posted_cmor_long_name
+  character(len=9) :: axis_name
 
   MOM_missing_value = axes%diag_cs%missing_value
   if(present(missing_value)) MOM_missing_value = missing_value
@@ -1624,6 +1628,14 @@ function register_static_field(module_name, field_name, axes, &
     call assert(associated(diag), 'register_static_field: diag allocation failed')
     diag%fms_diag_id = fms_id
     diag%debug_str = trim(module_name)//"-"//trim(field_name)
+    if (present(x_cell_method)) then
+      call get_diag_axis_name(axes%handles(1), axis_name)
+      call diag_field_add_attribute(fms_id, 'cell_methods', trim(axis_name)//':'//trim(x_cell_method))
+    endif
+    if (present(y_cell_method)) then
+      call get_diag_axis_name(axes%handles(2), axis_name)
+      call diag_field_add_attribute(fms_id, 'cell_methods', trim(axis_name)//':'//trim(y_cell_method))
+    endif
   endif
 
   if (present(cmor_field_name)) then
@@ -1655,6 +1667,14 @@ function register_static_field(module_name, field_name, axes, &
       call alloc_diag_with_id(dm_id, diag_cs, cmor_diag)
       cmor_diag%fms_diag_id = fms_id
       cmor_diag%debug_str = trim(module_name)//"-"//trim(cmor_field_name)
+      if (present(x_cell_method)) then
+        call get_diag_axis_name(axes%handles(1), axis_name)
+        call diag_field_add_attribute(fms_id, 'cell_methods', trim(axis_name)//':'//trim(x_cell_method))
+      endif
+      if (present(y_cell_method)) then
+        call get_diag_axis_name(axes%handles(2), axis_name)
+        call diag_field_add_attribute(fms_id, 'cell_methods', trim(axis_name)//':'//trim(y_cell_method))
+      endif
     endif
   endif
 


### PR DESCRIPTION
- Cell methods were not implemented for static variables which
  do not use the diag_mediator types internally.
- Also adds areas for u, v, and q locations.
- Closes NOAA-GFDL/MOM6-examples#155 .