### PR TITLE
Fix for nonzero remapped vertical diffusion tendencies: Issue #162

### DIFF
--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -854,6 +854,9 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, G, GV, CS)
       endif
     enddo ; enddo
   enddo
+  ! Application of boundary forcing and the checks for negative thickness may have changed layer thicknesses
+  call diag_update_remap_grids(CS%diag)
+
   if (CS%debug) then
     call MOM_state_chksum("after negative check ", u, v, h, G, GV, haloshift=0)
     call MOM_forcing_chksum("after negative check ", fluxes, G, haloshift=0)


### PR DESCRIPTION
As raised in https://github.com/NOAA-GFDL/MOM6-examples/issues/162,
column integrals of the vertical diffusive tendences did not sum to zero
when remapped from the model's native coordinate. Another call to
diag_update_remap_grids was added after the call to
applyBoundaryFluxesInOut (which changes the layer thicknesses due to
freshwater fluxes) and the checks for negative thickness.

Original code:
![opottempdiff_osaltdiff_notfixed](https://user-images.githubusercontent.com/3845639/30651092-ae316064-9df2-11e7-92f5-7497e845a3f2.png)

After this commit:
![opottempdiff_osaltdiff_fixed](https://user-images.githubusercontent.com/3845639/30651137-ccae8332-9df2-11e7-8e9e-ef05e6782d66.png)

