### PR TITLE
Fix OMP issue similar to 588

### DIFF
--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -906,8 +906,9 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
 !$OMP                                  netMassIn,pres,d_pres,p_lay,dSV_dT_2d,            &
 !$OMP                                  netmassinout_rate,netheat_rate,netsalt_rate,      &
 !$OMP                                  drhodt,drhods,pen_sw_bnd_rate,SurfPressure,       &
-!$OMP                                  start,npts,                                       &
-!$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst)
+!$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst)        &
+!$OMP                     firstprivate(start,npts)
+
 
   ! Work in vertical slices for efficiency
   do j=js,je


### PR DESCRIPTION
- Fixes an issue with firstprivate vs. private OMP declaration
fms_MOM6_SIS2_com  000000000143FA22  mom_diabatic_aux_         895  MOM_diabatic_aux.F90
fms_MOM6_SIS2_com  0000000000F841F6  mom_diabatic_driv         752  MOM_diabatic_driver.F90
fms_MOM6_SIS2_com  000000000097AE0F  mom_mp_step_mom_t        1156  MOM.F90
fms_MOM6_SIS2_com  000000000097029C  mom_mp_step_mom_          999  MOM.F90
fms_MOM6_SIS2_com  00000000007CF136  ocean_model_mod_m         541  ocean_model_MOM.F90
fms_MOM6_SIS2_com  000000000040B95F  MAIN__                   1020  coupler_main.F90

- Came in after the fix for 588