### PR TITLE
Update diagnostic target grid for ALE remapping tendencies

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -9,7 +9,8 @@ module MOM_ALE
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_debugging,        only : check_column_integrals
-use MOM_diag_mediator,    only : register_diag_field, post_data, diag_ctrl, time_type
+use MOM_diag_mediator,    only : register_diag_field, post_data, diag_ctrl
+use MOM_diag_mediator,    only : time_type, diag_update_remap_grids
 use MOM_diag_vkernels,    only : interpolate_column, reintegrate_column
 use MOM_domains,          only : create_group_pass, do_group_pass, group_pass_type
 use MOM_EOS,              only : calculate_density

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -416,6 +416,7 @@ subroutine ALE_main( G, GV, h, u, v, tv, Reg, CS, dt, frac_shelf_h)
   if (CS%show_call_tree) call callTree_waypoint("new grid generated (ALE_main)")
 
   ! Remap all variables from old grid h onto new grid h_new
+  call diag_update_remap_grids(CS%diag, alt_h = h_new)
 
   call remap_all_state_vars( CS%remapCS, CS, G, GV, h, h_new, Reg, -dzRegrid, &
                              u, v, CS%show_call_tree, dt )
@@ -861,7 +862,7 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
         if(CS_ALE%do_tendency_diag(m)) then
 
           if(CS_ALE%id_tracer_remap_tendency(m) > 0) then
-            call post_data(CS_ALE%id_tracer_remap_tendency(m), work_conc, CS_ALE%diag)
+            call post_data(CS_ALE%id_tracer_remap_tendency(m), work_conc, CS_ALE%diag, alt_h = h_new)
           endif
 
           if (CS_ALE%id_Htracer_remap_tendency(m) > 0 .or. CS_ALE%id_Htracer_remap_tendency_2d(m) > 0) then
@@ -885,7 +886,7 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
           endif
 
           if (CS_ALE%id_Htracer_remap_tendency(m) > 0) then
-            call post_data(CS_ALE%id_Htracer_remap_tendency(m), work_cont, CS_ALE%diag)
+            call post_data(CS_ALE%id_Htracer_remap_tendency(m), work_cont, CS_ALE%diag, alt_h = h_new)
           endif
           if (CS_ALE%id_Htracer_remap_tendency_2d(m) > 0) then
             do j = G%jsc,G%jec

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -416,9 +416,12 @@ subroutine ALE_main( G, GV, h, u, v, tv, Reg, CS, dt, frac_shelf_h)
 
   if (CS%show_call_tree) call callTree_waypoint("new grid generated (ALE_main)")
 
+  ! The presence of dt is used for expediency to distinguish whether ALE_main is being called during init
+  ! or in the main loop. Tendency diagnostics in remap_all_state_vars also rely on this logic.
+  if (present(dt)) then
+    call diag_update_remap_grids(CS%diag, alt_h = h_new)
+  endif
   ! Remap all variables from old grid h onto new grid h_new
-  call diag_update_remap_grids(CS%diag, alt_h = h_new)
-
   call remap_all_state_vars( CS%remapCS, CS, G, GV, h, h_new, Reg, -dzRegrid, &
                              u, v, CS%show_call_tree, dt )
 


### PR DESCRIPTION
Diagnostics in remap_all_state_vars were using the pointer to the main
state variable 'h' which is not updated until the end of ALE_main. To fix
this, first a call to diag_update_remap_grids is made using the new
thicknesses. Second, post_data calls also needed to have the new layer
thicknesses.