### PR TITLE
Change all diagnostics units to CMIP style

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -288,7 +288,7 @@ subroutine ALE_register_diags(Time, G, diag, C_p, Reg, CS)
   CS%id_Htracer_remap_tendency_2d(:) = -1
 
   CS%id_dzRegrid = register_diag_field('ocean_model','dzRegrid',diag%axesTi,Time, &
-      'Change in interface height due to ALE regridding', 'meter')
+      'Change in interface height due to ALE regridding', 'm')
 
   if(ntr > 0) then
 
@@ -298,24 +298,24 @@ subroutine ALE_register_diags(Time, G, diag, C_p, Reg, CS)
         CS%id_tracer_remap_tendency(m) = register_diag_field('ocean_model',                &
         trim(Reg%Tr(m)%name)//'_tendency_vert_remap', diag%axesTL, Time,                   &
         'Tendency from vertical remapping for tracer concentration '//trim(Reg%Tr(m)%name),&
-        'degC/s')
+        'degC s-1')
 
         CS%id_Htracer_remap_tendency(m) = register_diag_field('ocean_model',&
         trim(Reg%Tr(m)%name)//'h_tendency_vert_remap', diag%axesTL, Time,   &
         'Tendency from vertical remapping for heat',                        &
-         'W/m2',v_extensive=.true.)
+         'W m-2',v_extensive=.true.)
 
         CS%id_Htracer_remap_tendency_2d(m) = register_diag_field('ocean_model',&
         trim(Reg%Tr(m)%name)//'h_tendency_vert_remap_2d', diag%axesT1, Time,   &
         'Vertical sum of tendency from vertical remapping for heat',           &
-         'W/m2')
+         'W m-2')
 
       else
 
         CS%id_tracer_remap_tendency(m) = register_diag_field('ocean_model',                &
         trim(Reg%Tr(m)%name)//'_tendency_vert_remap', diag%axesTL, Time,                   &
         'Tendency from vertical remapping for tracer concentration '//trim(Reg%Tr(m)%name),&
-        'tracer conc / sec')
+        'tracer concentration * s-1')
 
         CS%id_Htracer_remap_tendency(m) = register_diag_field('ocean_model',         &
         trim(Reg%Tr(m)%name)//'h_tendency_vert_remap', diag%axesTL, Time,            &

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1875,10 +1875,10 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
     ALLOC_(CS%S(isd:ied,jsd:jed,nz))   ; CS%S(:,:,:) = 0.0
     CS%tv%T => CS%T ; CS%tv%S => CS%S
     CS%vd_T = var_desc(name="T",units="degC",longname="Potential Temperature", &
-                       cmor_field_name="thetao",cmor_units="C",                &
+                       cmor_field_name="thetao",                               &
                        conversion=CS%tv%C_p)
-    CS%vd_S = var_desc(name="S",units="PPT",longname="Salinity",&
-                       cmor_field_name="so",cmor_units="ppt",   &
+    CS%vd_S = var_desc(name="S",units="psu",longname="Salinity",&
+                       cmor_field_name="so",                    &
                        conversion=0.001)
     if(CS%advect_TS) then
       call register_tracer(CS%tv%T, CS%vd_T, param_file, dG%HI, GV, CS%tracer_Reg, CS%vd_T)
@@ -2204,11 +2204,11 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
                         CS%S_diffx_2d, CS%S_diffy_2d, CS%S_advection_xy)
     endif
     call register_Z_tracer(CS%tv%T, "temp", "Potential Temperature", "degC", Time,   &
-                      G, CS%diag_to_Z_CSp, cmor_field_name="thetao", cmor_units="C", &
+                      G, CS%diag_to_Z_CSp, cmor_field_name="thetao",                 &
                       cmor_standard_name="sea_water_potential_temperature",          &
                       cmor_long_name ="Sea Water Potential Temperature")
-    call register_Z_tracer(CS%tv%S, "salt", "Salinity", "PPT", Time,               &
-                      G, CS%diag_to_Z_CSp, cmor_field_name="so", cmor_units="ppt", &
+    call register_Z_tracer(CS%tv%S, "salt", "Salinity", "psu", Time,               &
+                      G, CS%diag_to_Z_CSp, cmor_field_name="so",                   &
                       cmor_standard_name="sea_water_salinity",                     &
                       cmor_long_name ="Sea Water Salinity")
   endif
@@ -2339,18 +2339,18 @@ subroutine register_diags(Time, G, GV, CS, ADp)
 
   thickness_units = get_thickness_units(GV)
   flux_units      = get_flux_units(GV)
-  T_flux_units    = get_tr_flux_units(GV, "Celsius")
-  S_flux_units    = get_tr_flux_units(GV, "PPT")
+  T_flux_units    = get_tr_flux_units(GV, "degC")
+  S_flux_units    = get_tr_flux_units(GV, "psu")
 
   !Initialize the diagnostics mask arrays.
   !This has to be done after MOM_initialize_state call.
   !call diag_masks_set(G, CS%missing)
 
   CS%id_u = register_diag_field('ocean_model', 'u', diag%axesCuL, Time,              &
-      'Zonal velocity', 'meter  second-1', cmor_field_name='uo', cmor_units='m s-1', &
+      'Zonal velocity', 'm s-1', cmor_field_name='uo', &
       cmor_standard_name='sea_water_x_velocity', cmor_long_name='Sea Water X Velocity')
   CS%id_v = register_diag_field('ocean_model', 'v', diag%axesCvL, Time,                  &
-      'Meridional velocity', 'meter second-1', cmor_field_name='vo', cmor_units='m s-1', &
+      'Meridional velocity', 'm s-1', cmor_field_name='vo', &
       cmor_standard_name='sea_water_y_velocity', cmor_long_name='Sea Water Y Velocity')
   CS%id_h = register_diag_field('ocean_model', 'h', diag%axesTL, Time, &
       'Layer Thickness', thickness_units, v_extensive=.true.)
@@ -2360,81 +2360,81 @@ subroutine register_diags(Time, G, GV, CS, ADp)
       standard_name='sea_water_volume')
   CS%id_zos = register_diag_field('ocean_model', 'zos', diag%axesT1, Time,&
       standard_name = 'sea_surface_height_above_geoid',                   &
-      long_name= 'Sea surface height above geoid', units='meter', missing_value=CS%missing)
+      long_name= 'Sea surface height above geoid', units='m', missing_value=CS%missing)
   CS%id_zossq = register_diag_field('ocean_model', 'zossq', diag%axesT1, Time,&
       standard_name='square_of_sea_surface_height_above_geoid',             &
       long_name='Square of sea surface height above geoid', units='m2', missing_value=CS%missing)
   CS%id_ssh = register_diag_field('ocean_model', 'SSH', diag%axesT1, Time, &
-      'Sea Surface Height', 'meter', CS%missing)
+      'Sea Surface Height', 'm', CS%missing)
   CS%id_ssh_ga = register_scalar_field('ocean_model', 'ssh_ga', Time, diag,&
       long_name='Area averaged sea surface height', units='m',            &
       standard_name='area_averaged_sea_surface_height')
   CS%id_ssh_inst = register_diag_field('ocean_model', 'SSH_inst', diag%axesT1, Time, &
-      'Instantaneous Sea Surface Height', 'meter', CS%missing)
+      'Instantaneous Sea Surface Height', 'm', CS%missing)
   CS%id_ssu = register_diag_field('ocean_model', 'SSU', diag%axesCu1, Time, &
-      'Sea Surface Zonal Velocity', 'meter second-1', CS%missing)
+      'Sea Surface Zonal Velocity', 'm s-1', CS%missing)
   CS%id_ssv = register_diag_field('ocean_model', 'SSV', diag%axesCv1, Time, &
-      'Sea Surface Meridional Velocity', 'meter second-1', CS%missing)
+      'Sea Surface Meridional Velocity', 'm s-1', CS%missing)
   CS%id_speed = register_diag_field('ocean_model', 'speed', diag%axesT1, Time, &
-      'Sea Surface Speed', 'meter second-1', CS%missing)
+      'Sea Surface Speed', 'm s-1', CS%missing)
 
   if (CS%use_temperature) then
     CS%id_T = register_diag_field('ocean_model', 'temp', diag%axesTL, Time, &
-        'Potential Temperature', 'Celsius',                                 &
-         cmor_field_name="thetao", cmor_units="C",                          &
+        'Potential Temperature', 'degC',                                    &
+         cmor_field_name="thetao",                                          &
          cmor_standard_name="sea_water_potential_temperature",              &
          cmor_long_name ="Sea Water Potential Temperature")
     CS%id_S = register_diag_field('ocean_model', 'salt', diag%axesTL, Time, &
-        long_name='Salinity', units='PPT', cmor_field_name='so',            &
-        cmor_long_name='Sea Water Salinity', cmor_units='ppt',              &
+        long_name='Salinity', units='psu', cmor_field_name='so',            &
+        cmor_long_name='Sea Water Salinity',                                &
         cmor_standard_name='sea_water_salinity')
     CS%id_tob = register_diag_field('ocean_model','tob', diag%axesT1, Time,          &
         long_name='Sea Water Potential Temperature at Sea Floor',                    &
         standard_name='sea_water_potential_temperature_at_sea_floor', units='degC')
     CS%id_sob = register_diag_field('ocean_model','sob',diag%axesT1, Time,           &
         long_name='Sea Water Salinity at Sea Floor',                                 &
-        standard_name='sea_water_salinity_at_sea_floor', units='ppt')
+        standard_name='sea_water_salinity_at_sea_floor', units='psu')
     CS%id_sst = register_diag_field('ocean_model', 'SST', diag%axesT1, Time,     &
-        'Sea Surface Temperature', 'Celsius', CS%missing, cmor_field_name='tos', &
-        cmor_long_name='Sea Surface Temperature', cmor_units='degC',             &
+        'Sea Surface Temperature', 'degC', CS%missing, cmor_field_name='tos', &
+        cmor_long_name='Sea Surface Temperature',                                &
         cmor_standard_name='sea_surface_temperature')
     CS%id_sst_sq = register_diag_field('ocean_model', 'SST_sq', diag%axesT1, Time, &
-        'Sea Surface Temperature Squared', 'Celsius**2', CS%missing, cmor_field_name='tossq', &
-        cmor_long_name='Square of Sea Surface Temperature ', cmor_units='degC^2', &
+        'Sea Surface Temperature Squared', 'degC2', CS%missing, cmor_field_name='tossq', &
+        cmor_long_name='Square of Sea Surface Temperature ',                      &
         cmor_standard_name='square_of_sea_surface_temperature')
     CS%id_sss = register_diag_field('ocean_model', 'SSS', diag%axesT1, Time, &
-        'Sea Surface Salinity', 'PPT', CS%missing, cmor_field_name='sos', &
-        cmor_long_name='Sea Surface Salinity', cmor_units='ppt',          &
+        'Sea Surface Salinity', 'psu', CS%missing, cmor_field_name='sos', &
+        cmor_long_name='Sea Surface Salinity',                            &
         cmor_standard_name='sea_surface_salinity')
     CS%id_sss_sq = register_diag_field('ocean_model', 'SSS_sq', diag%axesT1, Time, &
-        'Sea Surface Salinity Squared', 'ppt**2', CS%missing, cmor_field_name='sossq', &
-        cmor_long_name='Square of Sea Surface Salinity ', cmor_units='ppt^2', &
+        'Sea Surface Salinity Squared', 'psu', CS%missing, cmor_field_name='sossq', &
+        cmor_long_name='Square of Sea Surface Salinity ',                     &
         cmor_standard_name='square_of_sea_surface_salinity')
     if (CS%use_conT_absS) then
       CS%id_Tcon = register_diag_field('ocean_model', 'contemp', diag%axesTL, Time, &
           'Conservative Temperature', 'Celsius')
       CS%id_Sabs = register_diag_field('ocean_model', 'abssalt', diag%axesTL, Time, &
-          long_name='Absolute Salinity', units='g/Kg')
+          long_name='Absolute Salinity', units='g kg-1')
       CS%id_sstcon = register_diag_field('ocean_model', 'conSST', diag%axesT1, Time,     &
           'Sea Surface Conservative Temperature', 'Celsius', CS%missing)
       CS%id_sssabs = register_diag_field('ocean_model', 'absSSS', diag%axesT1, Time,     &
-          'Sea Surface Absolute Salinity', 'g/Kg', CS%missing)
+          'Sea Surface Absolute Salinity', 'g kg-1', CS%missing)
     endif
   endif
 
   if (CS%use_temperature .and. CS%use_frazil) then
     CS%id_fraz = register_diag_field('ocean_model', 'frazil', diag%axesT1, Time,                         &
-          'Heat from frazil formation', 'Watt meter-2', cmor_field_name='hfsifrazil',                    &
-          cmor_units='W m-2', cmor_standard_name='heat_flux_into_sea_water_due_to_frazil_ice_formation', &
+          'Heat from frazil formation', 'W m-2', cmor_field_name='hfsifrazil',                    &
+          cmor_standard_name='heat_flux_into_sea_water_due_to_frazil_ice_formation', &
           cmor_long_name='Heat Flux into Sea Water due to Frazil Ice Formation')
   endif
 
   CS%id_salt_deficit = register_diag_field('ocean_model', 'salt_deficit', diag%axesT1, Time, &
-         'Salt sink in ocean due to ice flux', 'g Salt meter-2 s-1')
+         'Salt sink in ocean due to ice flux', 'psu m-2 s-1')
   CS%id_Heat_PmE = register_diag_field('ocean_model', 'Heat_PmE', diag%axesT1, Time, &
-         'Heat flux into ocean from mass flux into ocean', 'Watt meter-2')
+         'Heat flux into ocean from mass flux into ocean', 'W m-2')
   CS%id_intern_heat = register_diag_field('ocean_model', 'internal_heat', diag%axesT1, Time,&
-         'Heat flux into ocean from geothermal or other internal sources', 'Watt meter-2')
+         'Heat flux into ocean from geothermal or other internal sources', 'W m-2')
 
 
   ! lateral heat advective and diffusive fluxes
@@ -2507,33 +2507,33 @@ subroutine register_diags(Time, G, GV, CS, ADp)
 
   ! diagnostics for values prior to diabatic and prior to ALE
   CS%id_u_predia = register_diag_field('ocean_model', 'u_predia', diag%axesCuL, Time, &
-      'Zonal velocity before diabatic forcing', 'meter second-1')
+      'Zonal velocity before diabatic forcing', 'm s-1')
   CS%id_v_predia = register_diag_field('ocean_model', 'v_predia', diag%axesCvL, Time, &
-      'Meridional velocity before diabatic forcing', 'meter second-1')
+      'Meridional velocity before diabatic forcing', 'm s-1')
   CS%id_h_predia = register_diag_field('ocean_model', 'h_predia', diag%axesTL, Time, &
       'Layer Thickness before diabatic forcing', thickness_units, v_extensive=.true.)
   CS%id_e_predia = register_diag_field('ocean_model', 'e_predia', diag%axesTi, Time, &
-      'Interface Heights before diabatic forcing', 'meter')
+      'Interface Heights before diabatic forcing', 'm')
   if (.not. CS%adiabatic) then
     CS%id_u_preale = register_diag_field('ocean_model', 'u_preale', diag%axesCuL, Time, &
-        'Zonal velocity before remapping', 'meter second-1')
+        'Zonal velocity before remapping', 'm s-1')
     CS%id_v_preale = register_diag_field('ocean_model', 'v_preale', diag%axesCvL, Time, &
-        'Meridional velocity before remapping', 'meter second-1')
+        'Meridional velocity before remapping', 'm s-1')
     CS%id_h_preale = register_diag_field('ocean_model', 'h_preale', diag%axesTL, Time, &
         'Layer Thickness before remapping', thickness_units, v_extensive=.true.)
     CS%id_T_preale = register_diag_field('ocean_model', 'T_preale', diag%axesTL, Time, &
         'Temperature before remapping', 'degC')
     CS%id_S_preale = register_diag_field('ocean_model', 'S_preale', diag%axesTL, Time, &
-        'Salinity before remapping', 'ppt')
+        'Salinity before remapping', 'psu')
     CS%id_e_preale = register_diag_field('ocean_model', 'e_preale', diag%axesTi, Time, &
-        'Interface Heights before remapping', 'meter')
+        'Interface Heights before remapping', 'm')
   endif
 
   if (CS%use_temperature) then
     CS%id_T_predia = register_diag_field('ocean_model', 'temp_predia', diag%axesTL, Time, &
-        'Potential Temperature', 'Celsius')
+        'Potential Temperature', 'degC')
     CS%id_S_predia = register_diag_field('ocean_model', 'salt_predia', diag%axesTL, Time, &
-        'Salinity', 'PPT')
+        'Salinity', 'psu')
   endif
 
   ! Diagnostics related to tracer transport
@@ -2544,16 +2544,16 @@ subroutine register_diags(Time, G, GV, CS, ADp)
       'Accumulated meridional thickness fluxes to advect tracers', 'kg', &
       x_cell_method='sum', v_extensive=.true.)
   CS%id_umo = register_diag_field('ocean_model', 'umo', &
-      diag%axesCuL, Time, 'Ocean Mass X Transport', 'kg/s', &
+      diag%axesCuL, Time, 'Ocean Mass X Transport', 'kg s-1', &
       standard_name='ocean_mass_x_transport', y_cell_method='sum', v_extensive=.true.)
   CS%id_vmo = register_diag_field('ocean_model', 'vmo', &
-      diag%axesCvL, Time, 'Ocean Mass Y Transport', 'kg/s', &
+      diag%axesCvL, Time, 'Ocean Mass Y Transport', 'kg s-1', &
       standard_name='ocean_mass_y_transport', x_cell_method='sum', v_extensive=.true.)
   CS%id_umo_2d = register_diag_field('ocean_model', 'umo_2d', &
-      diag%axesCu1, Time, 'Ocean Mass X Transport Vertical Sum', 'kg/s', &
+      diag%axesCu1, Time, 'Ocean Mass X Transport Vertical Sum', 'kg s-1', &
       standard_name='ocean_mass_x_transport_vertical_sum', y_cell_method='sum')
   CS%id_vmo_2d = register_diag_field('ocean_model', 'vmo_2d', &
-      diag%axesCv1, Time, 'Ocean Mass Y Transport Vertical Sum', 'kg/s', &
+      diag%axesCv1, Time, 'Ocean Mass Y Transport Vertical Sum', 'kg s-1', &
       standard_name='ocean_mass_y_transport_vertical_sum', x_cell_method='sum')
 
 end subroutine register_diags
@@ -2577,9 +2577,9 @@ subroutine register_diags_TS_tendency(Time, G, CS)
 
   ! heat tendencies from lateral advection
   CS%id_T_advection_xy = register_diag_field('ocean_model', 'T_advection_xy', diag%axesTL, Time, &
-      'Horizontal convergence of residual mean heat advective fluxes', 'W/m2',v_extensive=.true.)
+      'Horizontal convergence of residual mean heat advective fluxes', 'W m-2',v_extensive=.true.)
   CS%id_T_advection_xy_2d = register_diag_field('ocean_model', 'T_advection_xy_2d', diag%axesT1, Time,&
-      'Vertical sum of horizontal convergence of residual mean heat advective fluxes', 'W/m2')
+      'Vertical sum of horizontal convergence of residual mean heat advective fluxes', 'W m-2')
   if (CS%id_T_advection_xy > 0 .or. CS%id_T_advection_xy_2d > 0) then
     call safe_alloc_ptr(CS%T_advection_xy,isd,ied,jsd,jed,nz)
     CS%tendency_diagnostics = .true.
@@ -2587,16 +2587,16 @@ subroutine register_diags_TS_tendency(Time, G, CS)
 
   ! net temperature and heat tendencies
   CS%id_T_tendency = register_diag_field('ocean_model', 'T_tendency', diag%axesTL, Time, &
-      'Net time tendency for temperature', 'degC/s')
+      'Net time tendency for temperature', 'degC s-1')
   CS%id_Th_tendency = register_diag_field('ocean_model', 'Th_tendency', diag%axesTL, Time,        &
-      'Net time tendency for heat', 'W/m2',                                                       &
-      cmor_field_name="opottemptend", cmor_units="W m-2",                                         &
+      'Net time tendency for heat', 'W m-2',                                                      &
+      cmor_field_name="opottemptend",                                                             &
       cmor_standard_name="tendency_of_sea_water_potential_temperature_expressed_as_heat_content", &
       cmor_long_name ="Tendency of Sea Water Potential Temperature Expressed as Heat Content",    &
       v_extensive=.true.)
   CS%id_Th_tendency_2d = register_diag_field('ocean_model', 'Th_tendency_2d', diag%axesT1, Time,              &
-      'Vertical sum of net time tendency for heat', 'W/m2',                                                   &
-      cmor_field_name="opottemptend_2d", cmor_units="W m-2",                                                   &
+      'Vertical sum of net time tendency for heat', 'W m-2',                                                  &
+      cmor_field_name="opottemptend_2d",                                                                      &
       cmor_standard_name="tendency_of_sea_water_potential_temperature_expressed_as_heat_content_vertical_sum",&
       cmor_long_name ="Tendency of Sea Water Potential Temperature Expressed as Heat Content Vertical Sum")
   if (CS%id_T_tendency > 0) then
@@ -2617,9 +2617,9 @@ subroutine register_diags_TS_tendency(Time, G, CS)
 
   ! salt tendencies from lateral advection
   CS%id_S_advection_xy = register_diag_field('ocean_model', 'S_advection_xy', diag%axesTL, Time, &
-      'Horizontal convergence of residual mean salt advective fluxes', 'kg/(m2 * s)', v_extensive=.true.)
+      'Horizontal convergence of residual mean salt advective fluxes', 'kg m-2 s-1', v_extensive=.true.)
   CS%id_S_advection_xy_2d = register_diag_field('ocean_model', 'S_advection_xy_2d', diag%axesT1, Time,&
-      'Vertical sum of horizontal convergence of residual mean salt advective fluxes', 'kg/(m2 * s)')
+      'Vertical sum of horizontal convergence of residual mean salt advective fluxes', 'kg m-2 s-1')
   if (CS%id_S_advection_xy > 0 .or. CS%id_S_advection_xy_2d > 0) then
     call safe_alloc_ptr(CS%S_advection_xy,isd,ied,jsd,jed,nz)
     CS%tendency_diagnostics = .true.
@@ -2627,16 +2627,16 @@ subroutine register_diags_TS_tendency(Time, G, CS)
 
   ! net salinity and salt tendencies
   CS%id_S_tendency = register_diag_field('ocean_model', 'S_tendency', diag%axesTL, Time, &
-      'Net time tendency for salinity', 'PPT/s')
+      'Net time tendency for salinity', 'psu s-1')
   CS%id_Sh_tendency = register_diag_field('ocean_model', 'Sh_tendency', diag%axesTL, Time,&
-      'Net time tendency for salt', 'kg/(m2 * s)',                                        &
-      cmor_field_name="osalttend", cmor_units="kg m-2 s-1",                               &
+      'Net time tendency for salt', 'kg m-2 s-1',                                         &
+      cmor_field_name="osalttend",                                                        &
       cmor_standard_name="tendency_of_sea_water_salinity_expressed_as_salt_content",      &
       cmor_long_name ="Tendency of Sea Water Salinity Expressed as Salt Content",         &
       v_extensive=.true.)
   CS%id_Sh_tendency_2d = register_diag_field('ocean_model', 'Sh_tendency_2d', diag%axesT1, Time, &
-      'Vertical sum of net time tendency for salt', 'kg/(m2 * s)',                               &
-      cmor_field_name="osalttend_2d", cmor_units="kg m-2 s-1",                                   &
+      'Vertical sum of net time tendency for salt', 'kg m-2 s-1',                                &
+      cmor_field_name="osalttend_2d",                                                            &
       cmor_standard_name="tendency_of_sea_water_salinity_expressed_as_salt_content_vertical_sum",&
       cmor_long_name ="Tendency of Sea Water Salinity Expressed as Salt Content Vertical Sum")
   if (CS%id_S_tendency > 0) then
@@ -2685,12 +2685,12 @@ subroutine register_diags_TS_vardec(Time, HI, GV, param_file, CS)
   endif
 
   CS%id_S_vardec = register_diag_field('ocean_model', 'S_vardec', diag%axesTL, Time, &
-      'ALE variance decay for salinity', 'PPT2 s-1')
+      'ALE variance decay for salinity', 'psu2 s-1')
   if (CS%id_S_vardec > 0) then
     call safe_alloc_ptr(CS%S_squared,isd,ied,jsd,jed,nz)
     CS%S_squared(:,:,:) = 0.
 
-    vd_tmp = var_desc(name="S2", units="PPT2", longname="Squared Salinity")
+    vd_tmp = var_desc(name="S2", units="psu2", longname="Squared Salinity")
     call register_tracer(CS%S_squared, vd_tmp, param_file, HI, GV, CS%tracer_reg)
   endif
 
@@ -3183,41 +3183,41 @@ subroutine write_static_fields(G, diag)
   integer :: id, i, j
 
   id = register_static_field('ocean_model', 'geolat', diag%axesT1, &
-        'Latitude of tracer (T) points', 'degrees_N')
+        'Latitude of tracer (T) points', 'degrees_north')
   if (id > 0) call post_data(id, G%geoLatT, diag, .true.)
 
   id = register_static_field('ocean_model', 'geolon', diag%axesT1, &
-        'Longitude of tracer (T) points', 'degrees_E')
+        'Longitude of tracer (T) points', 'degrees_east')
   if (id > 0) call post_data(id, G%geoLonT, diag, .true.)
 
   id = register_static_field('ocean_model', 'geolat_c', diag%axesB1, &
-        'Latitude of corner (Bu) points', 'degrees_N', interp_method='none')
+        'Latitude of corner (Bu) points', 'degrees_north', interp_method='none')
   if (id > 0) call post_data(id, G%geoLatBu, diag, .true.)
 
   id = register_static_field('ocean_model', 'geolon_c', diag%axesB1, &
-        'Longitude of corner (Bu) points', 'degrees_E', interp_method='none')
+        'Longitude of corner (Bu) points', 'degrees_east', interp_method='none')
   if (id > 0) call post_data(id, G%geoLonBu, diag, .true.)
 
   id = register_static_field('ocean_model', 'geolat_v', diag%axesCv1, &
-        'Latitude of meridional velocity (Cv) points', 'degrees_N', interp_method='none')
+        'Latitude of meridional velocity (Cv) points', 'degrees_north', interp_method='none')
   if (id > 0) call post_data(id, G%geoLatCv, diag, .true.)
 
   id = register_static_field('ocean_model', 'geolon_v', diag%axesCv1, &
-        'Longitude of meridional velocity (Cv) points', 'degrees_E', interp_method='none')
+        'Longitude of meridional velocity (Cv) points', 'degrees_east', interp_method='none')
   if (id > 0) call post_data(id, G%geoLonCv, diag, .true.)
 
   id = register_static_field('ocean_model', 'geolat_u', diag%axesCu1, &
-        'Latitude of zonal velocity (Cu) points', 'degrees_N', interp_method='none')
+        'Latitude of zonal velocity (Cu) points', 'degrees_north', interp_method='none')
   if (id > 0) call post_data(id, G%geoLatCu, diag, .true.)
 
   id = register_static_field('ocean_model', 'geolon_u', diag%axesCu1, &
-        'Longitude of zonal velocity (Cu) points', 'degrees_E', interp_method='none')
+        'Longitude of zonal velocity (Cu) points', 'degrees_east', interp_method='none')
   if (id > 0) call post_data(id, G%geoLonCu, diag, .true.)
 
   id = register_static_field('ocean_model', 'area_t', diag%axesT1,   &
         'Surface area of tracer (T) cells', 'm2',                    &
         cmor_field_name='areacello', cmor_standard_name='cell_area', &
-        cmor_units='m2', cmor_long_name='Ocean Grid-Cell Area',      &
+        cmor_long_name='Ocean Grid-Cell Area',      &
         x_cell_method='sum', y_cell_method='sum')
   if (id > 0) then
     call post_data(id, G%areaT, diag, .true., mask=G%mask2dT)
@@ -3227,7 +3227,7 @@ subroutine write_static_fields(G, diag)
   id = register_static_field('ocean_model', 'area_u', diag%axesCu1,     &
         'Surface area of x-direction flow (U) cells', 'm2',             &
         cmor_field_name='areacello_cu', cmor_standard_name='cell_area', &
-        cmor_units='m2', cmor_long_name='Ocean Grid-Cell Area',         &
+        cmor_long_name='Ocean Grid-Cell Area',         &
         x_cell_method='sum', y_cell_method='sum')
   if (id > 0) then
     call post_data(id, G%areaCu, diag, .true., mask=G%mask2dCu)
@@ -3236,7 +3236,7 @@ subroutine write_static_fields(G, diag)
   id = register_static_field('ocean_model', 'area_v', diag%axesCv1,     &
         'Surface area of y-direction flow (V) cells', 'm2',             &
         cmor_field_name='areacello_cv', cmor_standard_name='cell_area', &
-        cmor_units='m2', cmor_long_name='Ocean Grid-Cell Area',         &
+        cmor_long_name='Ocean Grid-Cell Area',         &
         x_cell_method='sum', y_cell_method='sum')
   if (id > 0) then
     call post_data(id, G%areaCv, diag, .true., mask=G%mask2dCv)
@@ -3245,7 +3245,7 @@ subroutine write_static_fields(G, diag)
   id = register_static_field('ocean_model', 'area_q', diag%axesB1,      &
         'Surface area of B-grid flow (Q) cells', 'm2',                  &
         cmor_field_name='areacello_bu', cmor_standard_name='cell_area', &
-        cmor_units='m2', cmor_long_name='Ocean Grid-Cell Area',         &
+        cmor_long_name='Ocean Grid-Cell Area',         &
         x_cell_method='sum', y_cell_method='sum')
   if (id > 0) then
     call post_data(id, G%areaBu, diag, .true., mask=G%mask2dBu)
@@ -3255,7 +3255,7 @@ subroutine write_static_fields(G, diag)
         'Depth of the ocean at tracer points', 'm',                      &
         standard_name='sea_floor_depth_below_geoid',                     &
         cmor_field_name='deptho', cmor_long_name='Sea Floor Depth',      &
-        cmor_units='m', cmor_standard_name='sea_floor_depth_below_geoid',&
+        cmor_standard_name='sea_floor_depth_below_geoid',&
         area=diag%axesT1%id_area, x_cell_method='mean', y_cell_method='mean')
   if (id > 0) call post_data(id, G%bathyT, diag, .true., mask=G%mask2dT)
 
@@ -3308,7 +3308,7 @@ subroutine write_static_fields(G, diag)
   id = register_static_field('ocean_model', 'area_t_percent', diag%axesT1, &
         'Percentage of cell area covered by ocean', '%', &
         cmor_field_name='sftof', cmor_standard_name='SeaAreaFraction', &
-        cmor_units='%', cmor_long_name='Sea Area Fraction', &
+        cmor_long_name='Sea Area Fraction', &
         x_cell_method='mean', y_cell_method='mean')
   if (id > 0) then
     tmp_h(:,:) = 0.
@@ -3353,10 +3353,10 @@ subroutine set_restart_fields(GV, param_file, CS)
   vd = var_desc("h",thickness_units,"Layer Thickness")
   call register_restart_field(CS%h, vd, .true., CS%restart_CSp)
 
-  vd = var_desc("u","meter second-1","Zonal velocity",'u','L')
+  vd = var_desc("u","m s-1","Zonal velocity",'u','L')
   call register_restart_field(CS%u, vd, .true., CS%restart_CSp)
 
-  vd = var_desc("v","meter second-1","Meridional velocity",'v','L')
+  vd = var_desc("v","m s-1","Meridional velocity",'v','L')
   call register_restart_field(CS%v, vd, .true., CS%restart_CSp)
 
   if (CS%use_frazil) then

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -1017,25 +1017,25 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
   end select
 
   CS%id_rv = register_diag_field('ocean_model', 'RV', diag%axesBL, Time, &
-     'Relative Vorticity', 'second-1')
+     'Relative Vorticity', 's-1')
 
   CS%id_PV = register_diag_field('ocean_model', 'PV', diag%axesBL, Time, &
-     'Potential Vorticity', 'meter-1 second-1')
+     'Potential Vorticity', 'm-1 s-1')
 
   CS%id_gKEu = register_diag_field('ocean_model', 'gKEu', diag%axesCuL, Time, &
-     'Zonal Acceleration from Grad. Kinetic Energy', 'meter-1 second-2')
+     'Zonal Acceleration from Grad. Kinetic Energy', 'm-1 s-2')
   if (CS%id_gKEu > 0) call safe_alloc_ptr(AD%gradKEu,IsdB,IedB,jsd,jed,nz)
 
   CS%id_gKEv = register_diag_field('ocean_model', 'gKEv', diag%axesCvL, Time, &
-     'Meridional Acceleration from Grad. Kinetic Energy', 'meter-1 second-2')
+     'Meridional Acceleration from Grad. Kinetic Energy', 'm-1 s-2')
   if (CS%id_gKEv > 0) call safe_alloc_ptr(AD%gradKEv,isd,ied,JsdB,JedB,nz)
 
   CS%id_rvxu = register_diag_field('ocean_model', 'rvxu', diag%axesCvL, Time, &
-     'Meridional Acceleration from Relative Vorticity', 'meter-1 second-2')
+     'Meridional Acceleration from Relative Vorticity', 'm-1 s-2')
   if (CS%id_rvxu > 0) call safe_alloc_ptr(AD%rv_x_u,isd,ied,JsdB,JedB,nz)
 
   CS%id_rvxv = register_diag_field('ocean_model', 'rvxv', diag%axesCuL, Time, &
-     'Zonal Acceleration from Relative Vorticity', 'meter-1 second-2')
+     'Zonal Acceleration from Relative Vorticity', 'm-1 s-2')
   if (CS%id_rvxv > 0) call safe_alloc_ptr(AD%rv_x_v,IsdB,IedB,jsd,jed,nz)
 
 end subroutine CoriolisAdv_init

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4254,50 +4254,50 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
   ! initialized in register_barotropic_restarts.
 
   if (GV%Boussinesq) then
-    thickness_units = "meter" ; flux_units = "meter3 second-1"
+    thickness_units = "m" ; flux_units = "m3 s-1"
   else
-    thickness_units = "kilogram meter-2" ; flux_units = "kilogram second-1"
+    thickness_units = "kg m-2" ; flux_units = "kg s-1"
   endif
 
   CS%id_PFu_bt = register_diag_field('ocean_model', 'PFuBT', diag%axesCu1, Time, &
-      'Zonal Anomalous Barotropic Pressure Force Force Acceleration', 'meter second-2')
+      'Zonal Anomalous Barotropic Pressure Force Force Acceleration', 'm s-2')
   CS%id_PFv_bt = register_diag_field('ocean_model', 'PFvBT', diag%axesCv1, Time, &
-      'Meridional Anomalous Barotropic Pressure Force Acceleration', 'meter second-2')
+      'Meridional Anomalous Barotropic Pressure Force Acceleration', 'm s-2')
   CS%id_Coru_bt = register_diag_field('ocean_model', 'CoruBT', diag%axesCu1, Time, &
-      'Zonal Barotropic Coriolis Acceleration', 'meter second-2')
+      'Zonal Barotropic Coriolis Acceleration', 'm s-2')
   CS%id_Corv_bt = register_diag_field('ocean_model', 'CorvBT', diag%axesCv1, Time, &
-      'Meridional Barotropic Coriolis Acceleration', 'meter second-2')
+      'Meridional Barotropic Coriolis Acceleration', 'm s-2')
   CS%id_uaccel = register_diag_field('ocean_model', 'u_accel_bt', diag%axesCu1, Time, &
-      'Barotropic zonal acceleration', 'meter second-2')
+      'Barotropic zonal acceleration', 'm s-2')
   CS%id_vaccel = register_diag_field('ocean_model', 'v_accel_bt', diag%axesCv1, Time, &
-      'Barotropic meridional acceleration', 'meter second-2')
+      'Barotropic meridional acceleration', 'm s-2')
   CS%id_ubtforce = register_diag_field('ocean_model', 'ubtforce', diag%axesCu1, Time, &
-      'Barotropic zonal acceleration from baroclinic terms', 'meter second-2')
+      'Barotropic zonal acceleration from baroclinic terms', 'm s-2')
   CS%id_vbtforce = register_diag_field('ocean_model', 'vbtforce', diag%axesCv1, Time, &
-      'Barotropic meridional acceleration from baroclinic terms', 'meter second-2')
+      'Barotropic meridional acceleration from baroclinic terms', 'm s-2')
 
   CS%id_eta_bt = register_diag_field('ocean_model', 'eta_bt', diag%axesT1, Time, &
       'Barotropic end SSH', thickness_units)
   CS%id_ubt = register_diag_field('ocean_model', 'ubt', diag%axesCu1, Time, &
-      'Barotropic end zonal velocity', 'meter second-1')
+      'Barotropic end zonal velocity', 'm s-1')
   CS%id_vbt = register_diag_field('ocean_model', 'vbt', diag%axesCv1, Time, &
-      'Barotropic end meridional velocity', 'meter second-1')
+      'Barotropic end meridional velocity', 'm s-1')
   CS%id_eta_st = register_diag_field('ocean_model', 'eta_st', diag%axesT1, Time, &
       'Barotropic start SSH', thickness_units)
   CS%id_ubt_st = register_diag_field('ocean_model', 'ubt_st', diag%axesCu1, Time, &
-      'Barotropic start zonal velocity', 'meter second-1')
+      'Barotropic start zonal velocity', 'm s-1')
   CS%id_vbt_st = register_diag_field('ocean_model', 'vbt_st', diag%axesCv1, Time, &
-      'Barotropic start meridional velocity', 'meter second-1')
+      'Barotropic start meridional velocity', 'm s-1')
   CS%id_ubtav = register_diag_field('ocean_model', 'ubtav', diag%axesCu1, Time, &
-      'Barotropic time-average zonal velocity', 'meter second-1')
+      'Barotropic time-average zonal velocity', 'm s-1')
   CS%id_vbtav = register_diag_field('ocean_model', 'vbtav', diag%axesCv1, Time, &
-      'Barotropic time-average meridional velocity', 'meter second-1')
+      'Barotropic time-average meridional velocity', 'm s-1')
   CS%id_eta_cor = register_diag_field('ocean_model', 'eta_cor', diag%axesT1, Time, &
-      'Corrective mass flux', 'meter second-1')
+      'Corrective mass flux', 'm s-1')
   CS%id_visc_rem_u = register_diag_field('ocean_model', 'visc_rem_u', diag%axesCuL, Time, &
-      'Viscous remnant at u', 'Nondim')
+      'Viscous remnant at u', 'nondim')
   CS%id_visc_rem_v = register_diag_field('ocean_model', 'visc_rem_v', diag%axesCvL, Time, &
-      'Viscous remnant at v', 'Nondim')
+      'Viscous remnant at v', 'nondim')
   CS%id_gtotn = register_diag_field('ocean_model', 'gtot_n', diag%axesT1, Time, &
       'gtot to North', 'm s-2')
   CS%id_gtots = register_diag_field('ocean_model', 'gtot_s', diag%axesT1, Time, &
@@ -4309,58 +4309,58 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
   CS%id_eta_hifreq = register_diag_field('ocean_model', 'eta_hifreq', diag%axesT1, Time, &
       'High Frequency Barotropic SSH', thickness_units)
   CS%id_ubt_hifreq = register_diag_field('ocean_model', 'ubt_hifreq', diag%axesCu1, Time, &
-      'High Frequency Barotropic zonal velocity', 'meter second-1')
+      'High Frequency Barotropic zonal velocity', 'm s-1')
   CS%id_vbt_hifreq = register_diag_field('ocean_model', 'vbt_hifreq', diag%axesCv1, Time, &
-      'High Frequency Barotropic meridional velocity', 'meter second-1')
+      'High Frequency Barotropic meridional velocity', 'm s-1')
   CS%id_eta_pred_hifreq = register_diag_field('ocean_model', 'eta_pred_hifreq', diag%axesT1, Time, &
       'High Frequency Predictor Barotropic SSH', thickness_units)
   CS%id_uhbt_hifreq = register_diag_field('ocean_model', 'uhbt_hifreq', diag%axesCu1, Time, &
-      'High Frequency Barotropic zonal transport', 'meter3 second-1')
+      'High Frequency Barotropic zonal transport', 'm3 s-1')
   CS%id_vhbt_hifreq = register_diag_field('ocean_model', 'vhbt_hifreq', diag%axesCv1, Time, &
-      'High Frequency Barotropic meridional transport', 'meter3 second-1')
+      'High Frequency Barotropic meridional transport', 'm3 s-1')
   CS%id_frhatu = register_diag_field('ocean_model', 'frhatu', diag%axesCuL, Time, &
-      'Fractional thickness of layers in u-columns', 'Nondim')
+      'Fractional thickness of layers in u-columns', 'nondim')
   CS%id_frhatv = register_diag_field('ocean_model', 'frhatv', diag%axesCvL, Time, &
-      'Fractional thickness of layers in v-columns', 'Nondim')
+      'Fractional thickness of layers in v-columns', 'nondim')
   CS%id_frhatu1 = register_diag_field('ocean_model', 'frhatu1', diag%axesCuL, Time, &
-      'Predictor Fractional thickness of layers in u-columns', 'Nondim')
+      'Predictor Fractional thickness of layers in u-columns', 'nondim')
   CS%id_frhatv1 = register_diag_field('ocean_model', 'frhatv1', diag%axesCvL, Time, &
-      'Predictor Fractional thickness of layers in v-columns', 'Nondim')
+      'Predictor Fractional thickness of layers in v-columns', 'nondim')
   CS%id_uhbt = register_diag_field('ocean_model', 'uhbt', diag%axesCu1, Time, &
-      'Barotropic zonal transport averaged over a baroclinic step', 'meter3 second-1')
+      'Barotropic zonal transport averaged over a baroclinic step', 'm3 s-1')
   CS%id_vhbt = register_diag_field('ocean_model', 'vhbt', diag%axesCv1, Time, &
-      'Barotropic meridional transport averaged over a baroclinic step', 'meter3 second-1')
+      'Barotropic meridional transport averaged over a baroclinic step', 'm3 s-1')
 
   if (use_BT_cont_type) then
     CS%id_BTC_FA_u_EE = register_diag_field('ocean_model', 'BTC_FA_u_EE', diag%axesCu1, Time, &
-        'BTCont type far east face area', 'meter2')
+        'BTCont type far east face area', 'm2')
     CS%id_BTC_FA_u_E0 = register_diag_field('ocean_model', 'BTC_FA_u_E0', diag%axesCu1, Time, &
-        'BTCont type near east face area', 'meter2')
+        'BTCont type near east face area', 'm2')
     CS%id_BTC_FA_u_WW = register_diag_field('ocean_model', 'BTC_FA_u_WW', diag%axesCu1, Time, &
-        'BTCont type far west face area', 'meter2')
+        'BTCont type far west face area', 'm2')
     CS%id_BTC_FA_u_W0 = register_diag_field('ocean_model', 'BTC_FA_u_W0', diag%axesCu1, Time, &
-        'BTCont type near west face area', 'meter2')
+        'BTCont type near west face area', 'm2')
     CS%id_BTC_ubt_EE = register_diag_field('ocean_model', 'BTC_ubt_EE', diag%axesCu1, Time, &
-        'BTCont type far east velocity', 'meter second-1')
+        'BTCont type far east velocity', 'm s-1')
     CS%id_BTC_ubt_WW = register_diag_field('ocean_model', 'BTC_ubt_WW', diag%axesCu1, Time, &
-        'BTCont type far west velocity', 'meter second-1')
+        'BTCont type far west velocity', 'm s-1')
     CS%id_BTC_FA_v_NN = register_diag_field('ocean_model', 'BTC_FA_v_NN', diag%axesCv1, Time, &
-        'BTCont type far north face area', 'meter2')
+        'BTCont type far north face area', 'm2')
     CS%id_BTC_FA_v_N0 = register_diag_field('ocean_model', 'BTC_FA_v_N0', diag%axesCv1, Time, &
-        'BTCont type near north face area', 'meter2')
+        'BTCont type near north face area', 'm2')
     CS%id_BTC_FA_v_SS = register_diag_field('ocean_model', 'BTC_FA_v_SS', diag%axesCv1, Time, &
-        'BTCont type far south face area', 'meter2')
+        'BTCont type far south face area', 'm2')
     CS%id_BTC_FA_v_S0 = register_diag_field('ocean_model', 'BTC_FA_v_S0', diag%axesCv1, Time, &
-        'BTCont type near south face area', 'meter2')
+        'BTCont type near south face area', 'm2')
     CS%id_BTC_vbt_NN = register_diag_field('ocean_model', 'BTC_vbt_NN', diag%axesCv1, Time, &
-        'BTCont type far north velocity', 'meter second-1')
+        'BTCont type far north velocity', 'm s-1')
     CS%id_BTC_vbt_SS = register_diag_field('ocean_model', 'BTC_vbt_SS', diag%axesCv1, Time, &
-        'BTCont type far south velocity', 'meter second-1')
+        'BTCont type far south velocity', 'm s-1')
   endif
   CS%id_uhbt0 = register_diag_field('ocean_model', 'uhbt0', diag%axesCu1, Time, &
-      'Barotropic zonal transport difference', 'meter3 second-1')
+      'Barotropic zonal transport difference', 'm3 s-1')
   CS%id_vhbt0 = register_diag_field('ocean_model', 'vhbt0', diag%axesCv1, Time, &
-      'Barotropic meridional transport difference', 'meter3 second-1')
+      'Barotropic meridional transport difference', 'm3 s-1')
 
   if (CS%id_frhatu1 > 0) call safe_alloc_ptr(CS%frhatu1, IsdB,IedB,jsd,jed,nz)
   if (CS%id_frhatv1 > 0) call safe_alloc_ptr(CS%frhatv1, isd,ied,JsdB,JedB,nz)
@@ -4491,34 +4491,34 @@ subroutine register_barotropic_restarts(HI, GV, param_file, CS, restart_CS)
   ALLOC_(CS%uhbt_IC(IsdB:IedB,jsd:jed))    ; CS%uhbt_IC(:,:) = 0.0
   ALLOC_(CS%vhbt_IC(isd:ied,JsdB:JedB))    ; CS%vhbt_IC(:,:) = 0.0
 
-  vd(2) = var_desc("ubtav","meter second-1","Time mean barotropic zonal velocity", &
+  vd(2) = var_desc("ubtav","m s-1","Time mean barotropic zonal velocity", &
                 hor_grid='u', z_grid='1')
-  vd(3) = var_desc("vbtav","meter second-1","Time mean barotropic meridional velocity",&
+  vd(3) = var_desc("vbtav","m s-1","Time mean barotropic meridional velocity",&
                 hor_grid='v', z_grid='1')
   call register_restart_field(CS%ubtav, vd(2), .false., restart_CS)
   call register_restart_field(CS%vbtav, vd(3), .false., restart_CS)
 
-  vd(2) = var_desc("ubt_IC", "meter second-1", &
+  vd(2) = var_desc("ubt_IC", "m s-1", &
               longname="Next initial condition for the barotropic zonal velocity", &
               hor_grid='u', z_grid='1')
-  vd(3) = var_desc("vbt_IC", "meter second-1", &
+  vd(3) = var_desc("vbt_IC", "m s-1", &
               longname="Next initial condition for the barotropic meridional velocity",&
               hor_grid='v', z_grid='1')
   call register_restart_field(CS%ubt_IC, vd(2), .false., restart_CS)
   call register_restart_field(CS%vbt_IC, vd(3), .false., restart_CS)
 
   if (GV%Boussinesq) then
-   vd(2) = var_desc("uhbt_IC", "meter3 second-1", &
+   vd(2) = var_desc("uhbt_IC", "m3 s-1", &
                 longname="Next initial condition for the barotropic zonal transport", &
                 hor_grid='u', z_grid='1')
-    vd(3) = var_desc("vhbt_IC", "meter3 second-1", &
+    vd(3) = var_desc("vhbt_IC", "m3 s-1", &
                 longname="Next initial condition for the barotropic meridional transport",&
                 hor_grid='v', z_grid='1')
   else
-    vd(2) = var_desc("uhbt_IC", "kg second-1", &
+    vd(2) = var_desc("uhbt_IC", "kg s-1", &
                 longname="Next initial condition for the barotropic zonal transport", &
                 hor_grid='u', z_grid='1')
-    vd(3) = var_desc("vhbt_IC", "kg second-1", &
+    vd(3) = var_desc("vhbt_IC", "kg s-1", &
                 longname="Next initial condition for the barotropic meridional transport",&
                 hor_grid='v', z_grid='1')
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -881,10 +881,10 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, param_file, CS, restart_CS, u
   vd = var_desc("sfc",thickness_units,"Free surface Height",'h','1')
   call register_restart_field(CS%eta, vd, .false., restart_CS)
 
-  vd = var_desc("u2","meter second-1","Auxiliary Zonal velocity",'u','L')
+  vd = var_desc("u2","m s-1","Auxiliary Zonal velocity",'u','L')
   call register_restart_field(CS%u_av, vd, .false., restart_CS)
 
-  vd = var_desc("v2","meter second-1","Auxiliary Meridional velocity",'v','L')
+  vd = var_desc("v2","m s-1","Auxiliary Meridional velocity",'v','L')
   call register_restart_field(CS%v_av, vd, .false., restart_CS)
 
   vd = var_desc("h2",thickness_units,"Auxiliary Layer Thickness",'h','L')
@@ -896,10 +896,10 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, param_file, CS, restart_CS, u
   vd = var_desc("vh",flux_units,"Meridional thickness flux",'v','L')
   call register_restart_field(vh, vd, .false., restart_CS)
 
-  vd = var_desc("diffu","meter second-2","Zonal horizontal viscous acceleration",'u','L')
+  vd = var_desc("diffu","m s-2","Zonal horizontal viscous acceleration",'u','L')
   call register_restart_field(CS%diffu, vd, .false., restart_CS)
 
-  vd = var_desc("diffv","meter second-2","Meridional horizontal viscous acceleration",'v','L')
+  vd = var_desc("diffv","m s-2","Meridional horizontal viscous acceleration",'v','L')
   call register_restart_field(CS%diffv, vd, .false., restart_CS)
 
   call register_barotropic_restarts(HI, GV, param_file, CS%barotropic_CSp, &
@@ -1107,23 +1107,23 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
       'Meridional Thickness Flux', flux_units, x_cell_method='sum', v_extensive=.true.)
 
   CS%id_CAu = register_diag_field('ocean_model', 'CAu', diag%axesCuL, Time, &
-      'Zonal Coriolis and Advective Acceleration', 'meter second-2')
+      'Zonal Coriolis and Advective Acceleration', 'm s-2')
   CS%id_CAv = register_diag_field('ocean_model', 'CAv', diag%axesCvL, Time, &
-      'Meridional Coriolis and Advective Acceleration', 'meter second-2')
+      'Meridional Coriolis and Advective Acceleration', 'm s-2')
   CS%id_PFu = register_diag_field('ocean_model', 'PFu', diag%axesCuL, Time, &
-      'Zonal Pressure Force Acceleration', 'meter second-2')
+      'Zonal Pressure Force Acceleration', 'm s-2')
   CS%id_PFv = register_diag_field('ocean_model', 'PFv', diag%axesCvL, Time, &
-      'Meridional Pressure Force Acceleration', 'meter second-2')
+      'Meridional Pressure Force Acceleration', 'm s-2')
 
   CS%id_uav = register_diag_field('ocean_model', 'uav', diag%axesCuL, Time, &
-      'Barotropic-step Averaged Zonal Velocity', 'meter second-1')
+      'Barotropic-step Averaged Zonal Velocity', 'm s-1')
   CS%id_vav = register_diag_field('ocean_model', 'vav', diag%axesCvL, Time, &
-      'Barotropic-step Averaged Meridional Velocity', 'meter second-1')
+      'Barotropic-step Averaged Meridional Velocity', 'm s-1')
 
   CS%id_u_BT_accel = register_diag_field('ocean_model', 'u_BT_accel', diag%axesCuL, Time, &
-    'Barotropic Anomaly Zonal Acceleration', 'meter second-1')
+    'Barotropic Anomaly Zonal Acceleration', 'm s-1')
   CS%id_v_BT_accel = register_diag_field('ocean_model', 'v_BT_accel', diag%axesCvL, Time, &
-    'Barotropic Anomaly Meridional Acceleration', 'meter second-1')
+    'Barotropic Anomaly Meridional Acceleration', 'm s-1')
 
   id_clock_Cor        = cpu_clock_id('(Ocean Coriolis & mom advection)', grain=CLOCK_MODULE)
   id_clock_continuity = cpu_clock_id('(Ocean continuity equation)',      grain=CLOCK_MODULE)

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1127,50 +1127,50 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
 
 
   handles%id_taux = register_diag_field('ocean_model', 'taux', diag%axesCu1, Time,  &
-        'Zonal surface stress from ocean interactions with atmos and ice', 'Pascal',&
+        'Zonal surface stress from ocean interactions with atmos and ice', 'Pa',    &
         standard_name='surface_downward_x_stress', cmor_field_name='tauuo',         &
         cmor_units='N m-2', cmor_long_name='Surface Downward X Stress',             &
         cmor_standard_name='surface_downward_x_stress')
 
   handles%id_tauy = register_diag_field('ocean_model', 'tauy', diag%axesCv1, Time,  &
-        'Meridional surface stress ocean interactions with atmos and ice', 'Pascal',&
+        'Meridional surface stress ocean interactions with atmos and ice', 'Pa',    &
          standard_name='surface_downward_y_stress', cmor_field_name='tauvo',        &
          cmor_units='N m-2', cmor_long_name='Surface Downward Y Stress',            &
          cmor_standard_name='surface_downward_y_stress')
 
   handles%id_ustar = register_diag_field('ocean_model', 'ustar', diag%axesT1, Time, &
-      'Surface friction velocity = [(gustiness + tau_magnitude)/rho0]^(1/2)', 'meter second-1')
+      'Surface friction velocity = [(gustiness + tau_magnitude)/rho0]^(1/2)', 'm s-1')
 
   if (present(use_berg_fluxes)) then
     if (use_berg_fluxes) then
       handles%id_ustar_berg = register_diag_field('ocean_model', 'ustar_berg', diag%axesT1, Time, &
-          'Friction velocity below iceberg ', 'meter second-1')
+          'Friction velocity below iceberg ', 'm s-1')
 
       handles%id_area_berg = register_diag_field('ocean_model', 'area_berg', diag%axesT1, Time, &
-          'Area of grid cell covered by iceberg ', 'm2/m2')
+          'Area of grid cell covered by iceberg ', 'm2 m-2')
 
       handles%id_mass_berg = register_diag_field('ocean_model', 'mass_berg', diag%axesT1, Time, &
-          'Mass of icebergs ', 'kg/m2')
+          'Mass of icebergs ', 'kg m-2')
 
       handles%id_ustar_ice_cover = register_diag_field('ocean_model', 'ustar_ice_cover', diag%axesT1, Time, &
-          'Friction velocity below iceberg and ice shelf together', 'meter second-1')
+          'Friction velocity below iceberg and ice shelf together', 'm s-1')
 
       handles%id_frac_ice_cover = register_diag_field('ocean_model', 'frac_ice_cover', diag%axesT1, Time, &
-          'Area of grid cell below iceberg and ice shelf together ', 'm2/m2')
+          'Area of grid cell below iceberg and ice shelf together ', 'm2 m-2')
     endif
   endif
 
   handles%id_psurf = register_diag_field('ocean_model', 'p_surf', diag%axesT1, Time,           &
-        'Pressure at ice-ocean or atmosphere-ocean interface', 'Pascal', cmor_field_name='pso',&
-        cmor_long_name='Sea Water Pressure at Sea Water Surface', cmor_units='Pa',             &
+        'Pressure at ice-ocean or atmosphere-ocean interface', 'Pa', cmor_field_name='pso',    &
+        cmor_long_name='Sea Water Pressure at Sea Water Surface',                              &
         cmor_standard_name='sea_water_pressure_at_sea_water_surface')
 
   handles%id_TKE_tidal = register_diag_field('ocean_model', 'TKE_tidal', diag%axesT1, Time, &
-        'Tidal source of BBL mixing', 'Watt/m^2')
+        'Tidal source of BBL mixing', 'W m-2')
 
   if (.not. use_temperature) then
     handles%id_buoy = register_diag_field('ocean_model', 'buoy', diag%axesT1, Time, &
-          'Buoyancy forcing', 'meter^2/second^3')
+          'Buoyancy forcing', 'm2 s-3')
     return
   endif
 
@@ -1179,129 +1179,129 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   ! surface mass flux maps
 
   handles%id_prcme = register_diag_field('ocean_model', 'PRCmE', diag%axesT1, Time,                  &
-        'Net surface water flux (precip+melt+lrunoff+ice calving-evap)', 'kilogram meter-2 second-1',&
-        standard_name='water_flux_into_sea_water', cmor_field_name='wfo', cmor_units='kg m-2 s-1',   &
+        'Net surface water flux (precip+melt+lrunoff+ice calving-evap)', 'kg m-2 s-1',&
+        standard_name='water_flux_into_sea_water', cmor_field_name='wfo',                            &
         cmor_standard_name='water_flux_into_sea_water',cmor_long_name='Water Flux Into Sea Water')
 
   handles%id_evap = register_diag_field('ocean_model', 'evap', diag%axesT1, Time,                         &
-       'Evaporation/condensation at ocean surface (evaporation is negative)', 'kilogram meter-2 second-1',&
-       standard_name='water_evaporation_flux', cmor_field_name='evs', cmor_units='kg m-2 s-1',            &
+       'Evaporation/condensation at ocean surface (evaporation is negative)', 'kg m-2 s-1',&
+       standard_name='water_evaporation_flux', cmor_field_name='evs',                                     &
        cmor_standard_name='water_evaporation_flux',                                                       &
        cmor_long_name='Water Evaporation Flux Where Ice Free Ocean over Sea')
 
   ! smg: seaice_melt field requires updates to the sea ice model
   !handles%id_seaice_melt = register_diag_field('ocean_model', 'seaice_melt',       &
   !   diag%axesT1, Time, 'water flux to ocean from sea ice melt(> 0) or form(< 0)', &
-  !   'kilogram/(meter^2 * second)',                                                &
+  !   'kg m-2 s-1',                                                                 &
   !    standard_name='water_flux_into_sea_water_due_to_sea_ice_thermodynamics',     &
-  !    cmor_field_name='fsitherm', cmor_units='kg m-2 s-1',                         &
+  !    cmor_field_name='fsitherm',                                                  &
   !    cmor_standard_name='water_flux_into_sea_water_due_to_sea_ice_thermodynamics',&
   !    cmor_long_name='water flux to ocean from sea ice melt(> 0) or form(< 0)')
 
   handles%id_precip = register_diag_field('ocean_model', 'precip', diag%axesT1, Time, &
-        'Liquid + frozen precipitation into ocean', 'kilogram/(meter^2 * second)')
+        'Liquid + frozen precipitation into ocean', 'kg m-2 s-1')
 
   handles%id_fprec = register_diag_field('ocean_model', 'fprec', diag%axesT1, Time,     &
-        'Frozen precipitation into ocean', 'kilogram meter-2 second-1',                 &
-        standard_name='snowfall_flux', cmor_field_name='prsn', cmor_units='kg m-2 s-1', &
+        'Frozen precipitation into ocean', 'kg m-2 s-1',                                &
+        standard_name='snowfall_flux', cmor_field_name='prsn',                          &
         cmor_standard_name='snowfall_flux', cmor_long_name='Snowfall Flux where Ice Free Ocean over Sea')
 
   handles%id_lprec = register_diag_field('ocean_model', 'lprec', diag%axesT1, Time,       &
-        'Liquid precipitation into ocean', 'kilogram/(meter^2 * second)',                 &
+        'Liquid precipitation into ocean', 'kg m-2 s-1',                                  &
         standard_name='rainfall_flux',                                                    &
-        cmor_field_name='prlq', cmor_units='kg m-2 s-1', cmor_standard_name='rainfall_flux',&
+        cmor_field_name='prlq', cmor_standard_name='rainfall_flux',                       &
         cmor_long_name='Rainfall Flux where Ice Free Ocean over Sea')
 
   handles%id_vprec = register_diag_field('ocean_model', 'vprec', diag%axesT1, Time, &
-        'Virtual liquid precip into ocean due to SSS restoring', 'kilogram/(meter^2 second)')
+        'Virtual liquid precip into ocean due to SSS restoring', 'kg m-2 s-1')
 
   handles%id_frunoff = register_diag_field('ocean_model', 'frunoff', diag%axesT1, Time,    &
-        'Frozen runoff (calving) and iceberg melt into ocean', 'kilogram/(meter^2 second)',&
+        'Frozen runoff (calving) and iceberg melt into ocean', 'kg m-2 s-1',               &
         standard_name='water_flux_into_sea_water_from_icebergs',                           &
-        cmor_field_name='ficeberg', cmor_units='kg m-2 s-1',                               &
+        cmor_field_name='ficeberg',                                                        &
         cmor_standard_name='water_flux_into_sea_water_from_icebergs',                      &
         cmor_long_name='Water Flux into Seawater from Icebergs')
 
   handles%id_lrunoff = register_diag_field('ocean_model', 'lrunoff', diag%axesT1, Time, &
-        'Liquid runoff (rivers) into ocean', 'kilogram meter-2 second-1',                     &
+        'Liquid runoff (rivers) into ocean', 'kg m-2 s-1',                                    &
         standard_name='water_flux_into_sea_water_from_rivers', cmor_field_name='friver',      &
-        cmor_units='kg m-2 s-1', cmor_standard_name='water_flux_into_sea_water_from_rivers',  &
+        cmor_standard_name='water_flux_into_sea_water_from_rivers',                           &
         cmor_long_name='Water Flux into Sea Water From Rivers')
 
   handles%id_net_massout = register_diag_field('ocean_model', 'net_massout', diag%axesT1, Time, &
-        'Net mass leaving the ocean due to evaporation, seaice formation', 'kilogram meter-2 second-1')
+        'Net mass leaving the ocean due to evaporation, seaice formation', 'kg m-2 s-1')
 
   handles%id_net_massin  = register_diag_field('ocean_model', 'net_massin', diag%axesT1, Time, &
-        'Net mass entering ocean due to precip, runoff, ice melt', 'kilogram meter-2 second-1')
+        'Net mass entering ocean due to precip, runoff, ice melt', 'kg m-2 s-1')
 
   handles%id_massout_flux = register_diag_field('ocean_model', 'massout_flux', diag%axesT1, Time, &
         'Net mass flux of freshwater out of the ocean (used in the boundary flux calculation)', &
-         'kilogram meter-2')
+         'kg m-2')
 
   handles%id_massin_flux  = register_diag_field('ocean_model', 'massin_flux', diag%axesT1, Time, &
-        'Net mass flux of freshwater into the ocean (used in boundary flux calculation)', 'kilogram meter-2')
+        'Net mass flux of freshwater into the ocean (used in boundary flux calculation)', 'kg m-2')
   !=========================================================================
   ! area integrated surface mass transport
 
   handles%id_total_prcme = register_scalar_field('ocean_model', 'total_PRCmE', Time, diag,         &
       long_name='Area integrated net surface water flux (precip+melt+liq runoff+ice calving-evap)',&
-      units='kg/s', standard_name='water_flux_into_sea_water_area_integrated',                     &
-      cmor_field_name='total_wfo', cmor_units='kg s-1',                                            &
+      units='kg s-1', standard_name='water_flux_into_sea_water_area_integrated',                   &
+      cmor_field_name='total_wfo',                                                                 &
       cmor_standard_name='water_flux_into_sea_water_area_integrated',                              &
       cmor_long_name='Water Transport Into Sea Water Area Integrated')
 
   handles%id_total_evap = register_scalar_field('ocean_model', 'total_evap', Time, diag,&
       long_name='Area integrated evap/condense at ocean surface',                       &
-      units='kg/s', standard_name='water_evaporation_flux_area_integrated',             &
-      cmor_field_name='total_evs', cmor_units='kg s-1',                                 &
+      units='kg s-1', standard_name='water_evaporation_flux_area_integrated',           &
+      cmor_field_name='total_evs',                                                      &
       cmor_standard_name='water_evaporation_flux_area_integrated',                      &
       cmor_long_name='Evaporation Where Ice Free Ocean over Sea Area Integrated')
 
   ! seaice_melt field requires updates to the sea ice model
   !handles%id_total_seaice_melt = register_scalar_field('ocean_model', 'total_seaice_melt', Time, diag, &
-  !    long_name='Area integrated sea ice melt (>0) or form (<0)', units='kg/s',                        &
+  !    long_name='Area integrated sea ice melt (>0) or form (<0)', units='kg s-1',                      &
   !    standard_name='water_flux_into_sea_water_due_to_sea_ice_thermodynamics_area_integrated',         &
-  !    cmor_field_name='total_fsitherm', cmor_units='kg s-1',                                           &
+  !    cmor_field_name='total_fsitherm',                                                                &
   !    cmor_standard_name='water_flux_into_sea_water_due_to_sea_ice_thermodynamics_area_integrated',    &
   !    cmor_long_name='Water Melt/Form from Sea Ice Area Integrated')
 
   handles%id_total_precip = register_scalar_field('ocean_model', 'total_precip', Time, diag, &
-      long_name='Area integrated liquid+frozen precip into ocean', units='kg/s')
+      long_name='Area integrated liquid+frozen precip into ocean', units='kg s-1')
 
   handles%id_total_fprec = register_scalar_field('ocean_model', 'total_fprec', Time, diag,&
-      long_name='Area integrated frozen precip into ocean', units='kg/s',                 &
+      long_name='Area integrated frozen precip into ocean', units='kg s-1',               &
       standard_name='snowfall_flux_area_integrated',                                      &
-      cmor_field_name='total_prsn', cmor_units='kg s-1',                                  &
+      cmor_field_name='total_prsn',                                                       &
       cmor_standard_name='snowfall_flux_area_integrated',                                 &
       cmor_long_name='Snowfall Flux where Ice Free Ocean over Sea Area Integrated')
 
   handles%id_total_lprec = register_scalar_field('ocean_model', 'total_lprec', Time, diag,&
-      long_name='Area integrated liquid precip into ocean', units='kg/s',                 &
+      long_name='Area integrated liquid precip into ocean', units='kg s-1',               &
       standard_name='rainfall_flux_area_integrated',                                      &
-      cmor_field_name='total_pr', cmor_units='kg s-1',                                    &
+      cmor_field_name='total_pr',                                                         &
       cmor_standard_name='rainfall_flux_area_integrated',                                 &
       cmor_long_name='Rainfall Flux where Ice Free Ocean over Sea Area Integrated')
 
   handles%id_total_vprec = register_scalar_field('ocean_model', 'total_vprec', Time, diag, &
-      long_name='Area integrated virtual liquid precip due to SSS restoring', units='kg/s')
+      long_name='Area integrated virtual liquid precip due to SSS restoring', units='kg s-1')
 
   handles%id_total_frunoff = register_scalar_field('ocean_model', 'total_frunoff', Time, diag,    &
-      long_name='Area integrated frozen runoff (calving) & iceberg melt into ocean', units='kg/s',&
-      cmor_field_name='total_ficeberg', cmor_units='kg s-1',                                      &
+      long_name='Area integrated frozen runoff (calving) & iceberg melt into ocean', units='kg s-1',&
+      cmor_field_name='total_ficeberg',                                                           &
       cmor_standard_name='water_flux_into_sea_water_from_icebergs_area_integrated',               &
       cmor_long_name='Water Flux into Seawater from Icebergs Area Integrated')
 
   handles%id_total_lrunoff = register_scalar_field('ocean_model', 'total_lrunoff', Time, diag,&
-      long_name='Area integrated liquid runoff into ocean', units='kg/s',                     &
-      cmor_field_name='total_friver', cmor_units='kg s-1',                                    &
+      long_name='Area integrated liquid runoff into ocean', units='kg s-1',                   &
+      cmor_field_name='total_friver',                                                         &
       cmor_standard_name='water_flux_into_sea_water_from_rivers_area_integrated',             &
       cmor_long_name='Water Flux into Sea Water From Rivers Area Integrated')
 
   handles%id_total_net_massout = register_scalar_field('ocean_model', 'total_net_massout', Time, diag, &
-      long_name='Area integrated mass leaving ocean due to evap and seaice form', units='kg/s')
+      long_name='Area integrated mass leaving ocean due to evap and seaice form', units='kg s-1')
 
   handles%id_total_net_massin = register_scalar_field('ocean_model', 'total_net_massin', Time, diag, &
-      long_name='Area integrated mass entering ocean due to predip, runoff, ice melt', units='kg/s')
+      long_name='Area integrated mass entering ocean due to predip, runoff, ice melt', units='kg s-1')
 
   !=========================================================================
   ! area averaged surface mass transport
@@ -1309,28 +1309,28 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_prcme_ga = register_scalar_field('ocean_model', 'PRCmE_ga', Time, diag,             &
       long_name='Area averaged net surface water flux (precip+melt+liq runoff+ice calving-evap)',&
       units='kg m-2 s-1', standard_name='water_flux_into_sea_water_area_averaged',               &
-      cmor_field_name='ave_wfo', cmor_units='kg m-2 s-1',                                        &
+      cmor_field_name='ave_wfo',                                                                 &
       cmor_standard_name='rainfall_flux_area_averaged',                                          &
       cmor_long_name='Water Transport Into Sea Water Area Averaged')
 
   handles%id_evap_ga = register_scalar_field('ocean_model', 'evap_ga', Time, diag,&
       long_name='Area averaged evap/condense at ocean surface',                   &
       units='kg m-2 s-1', standard_name='water_evaporation_flux_area_averaged',   &
-      cmor_field_name='ave_evs', cmor_units='kg m-2 s-1',                         &
+      cmor_field_name='ave_evs',                                                  &
       cmor_standard_name='water_evaporation_flux_area_averaged',                  &
       cmor_long_name='Evaporation Where Ice Free Ocean over Sea Area Averaged')
 
  handles%id_lprec_ga = register_scalar_field('ocean_model', 'lprec_ga', Time, diag,&
       long_name='Area integrated liquid precip into ocean', units='kg m-2 s-1',    &
       standard_name='rainfall_flux_area_averaged',                                 &
-      cmor_field_name='ave_pr', cmor_units='kg m-2 s-1',                           &
+      cmor_field_name='ave_pr',                                                    &
       cmor_standard_name='rainfall_flux_area_averaged',                            &
       cmor_long_name='Rainfall Flux where Ice Free Ocean over Sea Area Averaged')
 
  handles%id_fprec_ga = register_scalar_field('ocean_model', 'fprec_ga', Time, diag,&
       long_name='Area integrated frozen precip into ocean', units='kg m-2 s-1',    &
       standard_name='snowfall_flux_area_averaged',                                 &
-      cmor_field_name='ave_prsn', cmor_units='kg m-2 s-1',                         &
+      cmor_field_name='ave_prsn',                                                  &
       cmor_standard_name='snowfall_flux_area_averaged',                            &
       cmor_long_name='Snowfall Flux where Ice Free Ocean over Sea Area Averaged')
 
@@ -1344,11 +1344,11 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   ! surface heat flux maps
 
   handles%id_heat_content_frunoff = register_diag_field('ocean_model', 'heat_content_frunoff',        &
-        diag%axesT1, Time, 'Heat content (relative to 0C) of solid runoff into ocean', 'Watt meter-2',&
+        diag%axesT1, Time, 'Heat content (relative to 0C) of solid runoff into ocean', 'W m-2',       &
         standard_name='temperature_flux_due_to_solid_runoff_expressed_as_heat_flux_into_sea_water')
 
   handles%id_heat_content_lrunoff = register_diag_field('ocean_model', 'heat_content_lrunoff',         &
-        diag%axesT1, Time, 'Heat content (relative to 0C) of liquid runoff into ocean', 'Watt meter-2',&
+        diag%axesT1, Time, 'Heat content (relative to 0C) of liquid runoff into ocean', 'W m-2',       &
         standard_name='temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water')
 
   handles%id_hfrunoffds = register_diag_field('ocean_model', 'hfrunoffds',                            &
@@ -1357,104 +1357,104 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
 
   handles%id_heat_content_lprec = register_diag_field('ocean_model', 'heat_content_lprec',             &
         diag%axesT1,Time,'Heat content (relative to 0degC) of liquid precip entering ocean',           &
-        'W/m^2')
+        'W m-2')
 
   handles%id_heat_content_fprec = register_diag_field('ocean_model', 'heat_content_fprec',&
         diag%axesT1,Time,'Heat content (relative to 0degC) of frozen prec entering ocean',&
-        'W/m^2')
+        'W m-2')
 
   handles%id_heat_content_vprec = register_diag_field('ocean_model', 'heat_content_vprec',   &
         diag%axesT1,Time,'Heat content (relative to 0degC) of virtual precip entering ocean',&
-        'Watt/m^2')
+        'W m-2')
 
   handles%id_heat_content_cond = register_diag_field('ocean_model', 'heat_content_cond',   &
         diag%axesT1,Time,'Heat content (relative to 0degC) of water condensing into ocean',&
-        'Watt/m^2')
+        'W m-2')
 
   handles%id_hfrainds = register_diag_field('ocean_model', 'hfrainds',                                 &
         diag%axesT1,Time,'Heat content (relative to 0degC) of liquid+frozen precip entering ocean',    &
-        'W/m^2',standard_name='temperature_flux_due_to_rainfall_expressed_as_heat_flux_into_sea_water',&
+        'W m-2',standard_name='temperature_flux_due_to_rainfall_expressed_as_heat_flux_into_sea_water',&
         cmor_long_name='Heat Content (relative to 0degC) of Liquid + Frozen Precipitation')
 
   handles%id_heat_content_surfwater = register_diag_field('ocean_model', 'heat_content_surfwater',&
          diag%axesT1, Time,                                                                       &
         'Heat content (relative to 0degC) of net water crossing ocean surface (frozen+liquid)',   &
-        'Watt/m^2')
+        'W m-2')
 
   handles%id_heat_content_massout = register_diag_field('ocean_model', 'heat_content_massout',                      &
          diag%axesT1, Time,'Heat content (relative to 0degC) of net mass leaving ocean ocean via evap and ice form',&
-        'Watt/m^2',                                                                                                 &
-        cmor_field_name='hfevapds', cmor_units='W m-2',                                                             &
+        'W m-2',                                                                                                 &
+        cmor_field_name='hfevapds',                                                                                 &
         cmor_standard_name='temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water',           &
         cmor_long_name='Heat Content (relative to 0degC) of Water Leaving Ocean via Evaporation and Ice Formation')
 
   handles%id_heat_content_massin = register_diag_field('ocean_model', 'heat_content_massin',   &
          diag%axesT1, Time,'Heat content (relative to 0degC) of net mass entering ocean ocean',&
-        'Watt/m^2')
+        'W m-2')
 
   handles%id_net_heat_coupler = register_diag_field('ocean_model', 'net_heat_coupler',          &
         diag%axesT1,Time,'Surface ocean heat flux from SW+LW+latent+sensible (via the coupler)',&
-        'Watt/m^2')
+        'W m-2')
 
   handles%id_net_heat_surface = register_diag_field('ocean_model', 'net_heat_surface',diag%axesT1,  &
-        Time,'Surface ocean heat flux from SW+LW+lat+sens+mass transfer+frazil+restore or flux adjustments', 'Watt/m^2',&
+        Time,'Surface ocean heat flux from SW+LW+lat+sens+mass transfer+frazil+restore or flux adjustments', 'W m-2',&
         standard_name='surface_downward_heat_flux_in_sea_water', cmor_field_name='hfds',            &
-        cmor_units='W m-2', cmor_standard_name='surface_downward_heat_flux_in_sea_water',           &
+        cmor_standard_name='surface_downward_heat_flux_in_sea_water',           &
         cmor_long_name='Surface ocean heat flux from SW+LW+latent+sensible+masstransfer+frazil')
 
   handles%id_sw = register_diag_field('ocean_model', 'SW', diag%axesT1, Time,  &
-        'Shortwave radiation flux into ocean', 'Watt meter-2',                 &
+        'Shortwave radiation flux into ocean', 'W m-2',                        &
         standard_name='net_downward_shortwave_flux_at_sea_water_surface',      &
-        cmor_field_name='rsntds', cmor_units='W m-2',                          &
+        cmor_field_name='rsntds',                                              &
         cmor_standard_name='net_downward_shortwave_flux_at_sea_water_surface', &
         cmor_long_name='Net Downward Shortwave Radiation at Sea Water Surface')
   handles%id_sw_vis = register_diag_field('ocean_model', 'sw_vis', diag%axesT1, Time,     &
         'Shortwave radiation direct and diffuse flux into the ocean in the visible band', &
-        'Watt/m^2')
+        'W m-2')
   handles%id_sw_nir = register_diag_field('ocean_model', 'sw_nir', diag%axesT1, Time,     &
         'Shortwave radiation direct and diffuse flux into the ocean in the near-infrared band', &
-        'Watt/m^2')
+        'W m-2')
 
   handles%id_LwLatSens = register_diag_field('ocean_model', 'LwLatSens', diag%axesT1, Time, &
-        'Combined longwave, latent, and sensible heating at ocean surface', 'Watt/m^2')
+        'Combined longwave, latent, and sensible heating at ocean surface', 'W m-2')
 
   handles%id_lw = register_diag_field('ocean_model', 'LW', diag%axesT1, Time, &
-        'Longwave radiation flux into ocean', 'Watt meter-2',                 &
+        'Longwave radiation flux into ocean', 'W m-2',                        &
         standard_name='surface_net_downward_longwave_flux',                   &
-        cmor_field_name='rlntds', cmor_units='W m-2',                         &
+        cmor_field_name='rlntds',                                             &
         cmor_standard_name='surface_net_downward_longwave_flux',              &
         cmor_long_name='Surface Net Downward Longwave Radiation')
 
   handles%id_lat = register_diag_field('ocean_model', 'latent', diag%axesT1, Time,                    &
         'Latent heat flux into ocean due to fusion and evaporation (negative means ocean heat loss)', &
-        'Watt meter-2', cmor_field_name='hflso', cmor_units='W m-2',                                  &
+        'W m-2', cmor_field_name='hflso',                                                             &
         cmor_standard_name='surface_downward_latent_heat_flux',                                       &
         cmor_long_name='Surface Downward Latent Heat Flux due to Evap + Melt Snow/Ice')
 
   handles%id_lat_evap = register_diag_field('ocean_model', 'latent_evap', diag%axesT1, Time, &
-        'Latent heat flux into ocean due to evaporation/condensation', 'Watt/m^2')
+        'Latent heat flux into ocean due to evaporation/condensation', 'W m-2')
 
   handles%id_lat_fprec = register_diag_field('ocean_model', 'latent_fprec_diag', diag%axesT1, Time,&
-        'Latent heat flux into ocean due to melting of frozen precipitation', 'Watt meter-2',      &
-        cmor_field_name='hfsnthermds', cmor_units='W m-2',                                         &
+        'Latent heat flux into ocean due to melting of frozen precipitation', 'W m-2',             &
+        cmor_field_name='hfsnthermds',                                                             &
         cmor_standard_name='heat_flux_into_sea_water_due_to_snow_thermodynamics',                  &
         cmor_long_name='Latent Heat to Melt Frozen Precipitation')
 
   handles%id_lat_frunoff = register_diag_field('ocean_model', 'latent_frunoff', diag%axesT1, Time, &
-        'Latent heat flux into ocean due to melting of icebergs', 'Watt/m^2',                      &
-        cmor_field_name='hfibthermds', cmor_units='W m-2',                                         &
+        'Latent heat flux into ocean due to melting of icebergs', 'W m-2',                         &
+        cmor_field_name='hfibthermds',                                                             &
         cmor_standard_name='heat_flux_into_sea_water_due_to_iceberg_thermodynamics',               &
         cmor_long_name='Latent Heat to Melt Frozen Runoff/Iceberg')
 
   handles%id_sens = register_diag_field('ocean_model', 'sensible', diag%axesT1, Time,&
-        'Sensible heat flux into ocean', 'Watt meter-2',                             &
+        'Sensible heat flux into ocean', 'W m-2',                                    &
         standard_name='surface_downward_sensible_heat_flux',                         &
-        cmor_field_name='hfsso', cmor_units='W m-2',                                 &
+        cmor_field_name='hfsso',                                                     &
         cmor_standard_name='surface_downward_sensible_heat_flux',                    &
         cmor_long_name='Surface Downward Sensible Heat Flux')
 
   handles%id_heat_added = register_diag_field('ocean_model', 'heat_added', diag%axesT1, Time, &
-        'Flux Adjustment or restoring surface heat flux into ocean', 'Watt/m^2')
+        'Flux Adjustment or restoring surface heat flux into ocean', 'W m-2')
 
 
   !===============================================================
@@ -1463,7 +1463,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_heat_content_frunoff = register_scalar_field('ocean_model',                     &
       'total_heat_content_frunoff', Time, diag,                                                    &
       long_name='Area integrated heat content (relative to 0C) of solid runoff',                   &
-      units='Watt', cmor_field_name='total_hfsolidrunoffds', cmor_units='W',                       &
+      units='W', cmor_field_name='total_hfsolidrunoffds',                                          &
       cmor_standard_name=                                                                          &
       'temperature_flux_due_to_solid_runoff_expressed_as_heat_flux_into_sea_water_area_integrated',&
       cmor_long_name=                                                                              &
@@ -1472,7 +1472,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_heat_content_lrunoff = register_scalar_field('ocean_model',               &
       'total_heat_content_lrunoff', Time, diag,                                              &
       long_name='Area integrated heat content (relative to 0C) of liquid runoff',            &
-      units='Watt', cmor_field_name='total_hfrunoffds', cmor_units='W',                      &
+      units='W', cmor_field_name='total_hfrunoffds',                                         &
       cmor_standard_name=                                                                    &
       'temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water_area_integrated',&
       cmor_long_name=                                                                        &
@@ -1481,7 +1481,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_heat_content_lprec = register_scalar_field('ocean_model',                   &
       'total_heat_content_lprec', Time, diag,                                                  &
       long_name='Area integrated heat content (relative to 0C) of liquid precip',              &
-      units='Watt', cmor_field_name='total_hfrainds', cmor_units='W',                          &
+      units='W', cmor_field_name='total_hfrainds',                                             &
       cmor_standard_name=                                                                      &
       'temperature_flux_due_to_rainfall_expressed_as_heat_flux_into_sea_water_area_integrated',&
       cmor_long_name=                                                                          &
@@ -1490,28 +1490,28 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_heat_content_fprec = register_scalar_field('ocean_model',     &
       'total_heat_content_fprec', Time, diag,                                    &
       long_name='Area integrated heat content (relative to 0C) of frozen precip',&
-      units='Watt')
+      units='W')
 
   handles%id_total_heat_content_vprec = register_scalar_field('ocean_model',      &
       'total_heat_content_vprec', Time, diag,                                     &
       long_name='Area integrated heat content (relative to 0C) of virtual precip',&
-      units='Watt')
+      units='W')
 
   handles%id_total_heat_content_cond = register_scalar_field('ocean_model',   &
       'total_heat_content_cond', Time, diag,                                  &
       long_name='Area integrated heat content (relative to 0C) of condensate',&
-      units='Watt')
+      units='W')
 
   handles%id_total_heat_content_surfwater = register_scalar_field('ocean_model',          &
       'total_heat_content_surfwater', Time, diag,                                         &
       long_name='Area integrated heat content (relative to 0C) of water crossing surface',&
-      units='Watt')
+      units='W')
 
   handles%id_total_heat_content_massout = register_scalar_field('ocean_model',                      &
       'total_heat_content_massout', Time, diag,                                                     &
       long_name='Area integrated heat content (relative to 0C) of water leaving ocean',             &
-      units='Watt',                                                                                 &
-      cmor_field_name='total_hfevapds', cmor_units='W',                                             &
+      units='W',                                                                                    &
+      cmor_field_name='total_hfevapds',                                                             &
       cmor_standard_name=                                                                           &
       'temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water_area_integrated',&
       cmor_long_name='Heat Flux Out of Sea Water due to Evaporating Water Area Integrated')
@@ -1519,18 +1519,18 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_heat_content_massin = register_scalar_field('ocean_model',           &
       'total_heat_content_massin', Time, diag,                                          &
       long_name='Area integrated heat content (relative to 0C) of water entering ocean',&
-      units='Watt')
+      units='W')
 
   handles%id_total_net_heat_coupler = register_scalar_field('ocean_model',                       &
       'total_net_heat_coupler', Time, diag,                                                      &
       long_name='Area integrated surface heat flux from SW+LW+latent+sensible (via the coupler)',&
-      units='Watt')
+      units='W')
 
   handles%id_total_net_heat_surface = register_scalar_field('ocean_model',                      &
       'total_net_heat_surface', Time, diag,                                                     &
       long_name='Area integrated surface heat flux from SW+LW+lat+sens+mass+frazil+restore or flux adjustments',    &
-      units='Watt',                                                                             &
-      cmor_field_name='total_hfds', cmor_units='W',                                             &
+      units='W',                                                                                &
+      cmor_field_name='total_hfds',                                                             &
       cmor_standard_name='surface_downward_heat_flux_in_sea_water_area_integrated',             &
       cmor_long_name=                                                                           &
       'Surface Ocean Heat Flux from SW+LW+latent+sensible+mass transfer+frazil Area Integrated')
@@ -1538,8 +1538,8 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_sw = register_scalar_field('ocean_model',                                &
       'total_sw', Time, diag,                                                               &
       long_name='Area integrated net downward shortwave at sea water surface',              &
-      units='Watt',                                                                         &
-      cmor_field_name='total_rsntds', cmor_units='W',                                       &
+      units='W',                                                                            &
+      cmor_field_name='total_rsntds',                                                       &
       cmor_standard_name='net_downward_shortwave_flux_at_sea_water_surface_area_integrated',&
       cmor_long_name=                                                                       &
       'Net Downward Shortwave Radiation at Sea Water Surface Area Integrated')
@@ -1547,13 +1547,13 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_LwLatSens = register_scalar_field('ocean_model',&
       'total_LwLatSens', Time, diag,                               &
       long_name='Area integrated longwave+latent+sensible heating',&
-      units='Watt')
+      units='W')
 
   handles%id_total_lw = register_scalar_field('ocean_model',                  &
       'total_lw', Time, diag,                                                 &
       long_name='Area integrated net downward longwave at sea water surface', &
-      units='Watt',                                                           &
-      cmor_field_name='total_rlntds', cmor_units='W',                         &
+      units='W',                                                              &
+      cmor_field_name='total_rlntds',                                         &
       cmor_standard_name='surface_net_downward_longwave_flux_area_integrated',&
       cmor_long_name=                                                         &
       'Surface Net Downward Longwave Radiation Area Integrated')
@@ -1561,8 +1561,8 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_lat = register_scalar_field('ocean_model',                &
       'total_lat', Time, diag,                                               &
       long_name='Area integrated surface downward latent heat flux',         &
-      units='Watt',                                                          &
-      cmor_field_name='total_hflso', cmor_units='W',                         &
+      units='W',                                                             &
+      cmor_field_name='total_hflso',                                         &
       cmor_standard_name='surface_downward_latent_heat_flux_area_integrated',&
       cmor_long_name=                                                        &
       'Surface Downward Latent Heat Flux Area Integrated')
@@ -1570,13 +1570,13 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_lat_evap = register_scalar_field('ocean_model',      &
       'total_lat_evap', Time, diag,                                     &
       long_name='Area integrated latent heat flux due to evap/condense',&
-      units='Watt')
+      units='W')
 
   handles%id_total_lat_fprec = register_scalar_field('ocean_model',                            &
       'total_lat_fprec', Time, diag,                                                           &
       long_name='Area integrated latent heat flux due to melting frozen precip',               &
-      units='Watt',                                                                            &
-      cmor_field_name='total_hfsnthermds', cmor_units='W',                                     &
+      units='W',                                                                               &
+      cmor_field_name='total_hfsnthermds',                                                     &
       cmor_standard_name='heat_flux_into_sea_water_due_to_snow_thermodynamics_area_integrated',&
       cmor_long_name=                                                                          &
       'Latent Heat to Melt Frozen Precipitation Area Integrated')
@@ -1584,8 +1584,8 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_lat_frunoff = register_scalar_field('ocean_model',                             &
       'total_lat_frunoff', Time, diag,                                                            &
       long_name='Area integrated latent heat flux due to melting icebergs',                       &
-      units='Watt',                                                                               &
-      cmor_field_name='total_hfibthermds', cmor_units='W',                                        &
+      units='W',                                                                                  &
+      cmor_field_name='total_hfibthermds',                                                        &
       cmor_standard_name='heat_flux_into_sea_water_due_to_iceberg_thermodynamics_area_integrated',&
       cmor_long_name=                                                                             &
       'Heat Flux into Sea Water due to Iceberg Thermodynamics Area Integrated')
@@ -1593,8 +1593,8 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_sens = register_scalar_field('ocean_model',                 &
       'total_sens', Time, diag,                                                &
       long_name='Area integrated downward sensible heat flux',                 &
-      units='Watt',                                                            &
-      cmor_field_name='total_hfsso', cmor_units='W',                           &
+      units='W',                                                               &
+      cmor_field_name='total_hfsso',                                           &
       cmor_standard_name='surface_downward_sensible_heat_flux_area_integrated',&
       cmor_long_name=                                                          &
       'Surface Downward Sensible Heat Flux Area Integrated')
@@ -1602,7 +1602,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
   handles%id_total_heat_added = register_scalar_field('ocean_model',&
       'total_heat_adjustment', Time, diag,                               &
       long_name='Area integrated surface heat flux from restoring and/or flux adjustment',   &
-      units='Watt')
+      units='W')
 
 
   !===============================================================
@@ -1617,7 +1617,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
       'net_heat_surface_ga', Time, diag,                                                      &
       long_name='Area averaged surface heat flux from SW+LW+lat+sens+mass+frazil+restore or flux adjustments',    &
       units='W m-2',                                                                          &
-      cmor_field_name='ave_hfds', cmor_units='W m-2',                                         &
+      cmor_field_name='ave_hfds',                                                             &
       cmor_standard_name='surface_downward_heat_flux_in_sea_water_area_averaged',             &
       cmor_long_name=                                                                         &
       'Surface Ocean Heat Flux from SW+LW+latent+sensible+mass transfer+frazil Area Averaged')
@@ -1626,7 +1626,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
       'sw_ga', Time, diag,                                                                &
       long_name='Area averaged net downward shortwave at sea water surface',              &
       units='W m-2',                                                                      &
-      cmor_field_name='ave_rsntds', cmor_units='W m-2',                                   &
+      cmor_field_name='ave_rsntds',                                                       &
       cmor_standard_name='net_downward_shortwave_flux_at_sea_water_surface_area_averaged',&
       cmor_long_name=                                                                     &
       'Net Downward Shortwave Radiation at Sea Water Surface Area Averaged')
@@ -1640,7 +1640,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
       'lw_ga', Time, diag,                                                  &
       long_name='Area averaged net downward longwave at sea water surface', &
       units='W m-2',                                                        &
-      cmor_field_name='ave_rlntds', cmor_units='W m-2',                     &
+      cmor_field_name='ave_rlntds',                                         &
       cmor_standard_name='surface_net_downward_longwave_flux_area_averaged',&
       cmor_long_name=                                                       &
       'Surface Net Downward Longwave Radiation Area Averaged')
@@ -1649,7 +1649,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
       'lat_ga', Time, diag,                                                &
       long_name='Area averaged surface downward latent heat flux',         &
       units='W m-2',                                                       &
-      cmor_field_name='ave_hflso', cmor_units='W m-2',                     &
+      cmor_field_name='ave_hflso',                                         &
       cmor_standard_name='surface_downward_latent_heat_flux_area_averaged',&
       cmor_long_name=                                                      &
       'Surface Downward Latent Heat Flux Area Averaged')
@@ -1658,7 +1658,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
       'sens_ga', Time, diag,                                                 &
       long_name='Area averaged downward sensible heat flux',                 &
       units='W m-2',                                                         &
-      cmor_field_name='ave_hfsso', cmor_units='W m-2',                       &
+      cmor_field_name='ave_hfsso',                                           &
       cmor_standard_name='surface_downward_sensible_heat_flux_area_averaged',&
       cmor_long_name=                                                        &
       'Surface Downward Sensible Heat Flux Area Averaged')
@@ -1669,46 +1669,46 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
 
   handles%id_saltflux = register_diag_field('ocean_model', 'salt_flux', diag%axesT1, Time,&
         'Net salt flux into ocean at surface (restoring + sea-ice)',                      &
-        'kilogram meter-2 second-1',cmor_field_name='sfdsi', cmor_units='kg m-2 s-1',     &
+        'kg m-2 s-1',cmor_field_name='sfdsi',                                             &
         cmor_standard_name='downward_sea_ice_basal_salt_flux',                            &
         cmor_long_name='Downward Sea Ice Basal Salt Flux')
 
   handles%id_saltFluxIn = register_diag_field('ocean_model', 'salt_flux_in', diag%axesT1, Time, &
-        'Salt flux into ocean at surface from coupler', 'kilogram/(meter^2 * second)')
+        'Salt flux into ocean at surface from coupler', 'kg m-2 s-1')
 
   handles%id_saltFluxAdded = register_diag_field('ocean_model', 'salt_flux_added', &
-        diag%axesT1,Time,'Salt flux into ocean at surface due to restoring or flux adjustment',           &
-        'kilogram/(meter^2 * second)')
+        diag%axesT1,Time,'Salt flux into ocean at surface due to restoring or flux adjustment', &
+        'kg m-2 s-1')
 
   handles%id_saltFluxGlobalAdj = register_scalar_field('ocean_model',              &
         'salt_flux_global_restoring_adjustment', Time, diag,                       &
         'Adjustment needed to balance net global salt flux into ocean at surface', &
-        'kilogram/(meter^2 * second)')
+        'kg m-2 s-1')
 
   handles%id_vPrecGlobalAdj = register_scalar_field('ocean_model',  &
         'vprec_global_adjustment', Time, diag,                      &
         'Adjustment needed to adjust net vprec into ocean to zero', &
-        'kilogram/(meter^2 * second)')
+        'kg m-2 s-1')
 
   handles%id_netFWGlobalAdj = register_scalar_field('ocean_model',       &
         'net_fresh_water_global_adjustment', Time, diag,                 &
         'Adjustment needed to adjust net fresh water into ocean to zero',&
-        'kilogram/(meter^2 * second)')
+        'kg m-2 s-1')
 
   handles%id_saltFluxGlobalScl = register_scalar_field('ocean_model',            &
         'salt_flux_global_restoring_scaling', Time, diag,                        &
         'Scaling applied to balance net global salt flux into ocean at surface', &
-        '(nondim)')
+        'nondim')
 
   handles%id_vPrecGlobalScl = register_scalar_field('ocean_model',&
         'vprec_global_scaling', Time, diag,                       &
         'Scaling applied to adjust net vprec into ocean to zero', &
-        '(nondim)')
+        'nondim')
 
   handles%id_netFWGlobalScl = register_scalar_field('ocean_model',      &
         'net_fresh_water_global_scaling', Time, diag,                   &
         'Scaling applied to adjust net fresh water into ocean to zero', &
-        '(nondim)')
+        'nondim')
 
   !===============================================================
   ! area integrals of surface salt fluxes

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -157,9 +157,9 @@ function get_thickness_units(GV)
 !  (ret)     get_thickness_units - The model's vertical thickness units.
 
   if (GV%Boussinesq) then
-    get_thickness_units = "meter"
+    get_thickness_units = "m"
   else
-    get_thickness_units = "kilogram meter-2"
+    get_thickness_units = "kg m-2"
   endif
 end function get_thickness_units
 
@@ -175,9 +175,9 @@ function get_flux_units(GV)
 !  (ret)     get_flux_units - The model's thickness flux units.
 
   if (GV%Boussinesq) then
-    get_flux_units = "meter3 second-1"
+    get_flux_units = "m3 s-1"
   else
-    get_flux_units = "kilogram second-1"
+    get_flux_units = "kg s-1"
   endif
 end function get_flux_units
 
@@ -226,14 +226,14 @@ function get_tr_flux_units(GV, tr_units, tr_vol_conc_units, tr_mass_conc_units)
     "tr_units, tr_vol_conc_units, and tr_mass_conc_units may be present.")
   if (present(tr_units)) then
     if (GV%Boussinesq) then
-      get_tr_flux_units = trim(tr_units)//" meter3 second-1"
+      get_tr_flux_units = trim(tr_units)//" m3 s-1"
     else
-      get_tr_flux_units = trim(tr_units)//" kilogram second-1"
+      get_tr_flux_units = trim(tr_units)//" kg s-1"
     endif
   endif
   if (present(tr_vol_conc_units)) then
     if (GV%Boussinesq) then
-      get_tr_flux_units = trim(tr_vol_conc_units)//" second-1"
+      get_tr_flux_units = trim(tr_vol_conc_units)//" s-1"
     else
       get_tr_flux_units = trim(tr_vol_conc_units)//" m-3 kg s-1"
     endif
@@ -242,7 +242,7 @@ function get_tr_flux_units(GV, tr_units, tr_vol_conc_units, tr_mass_conc_units)
     if (GV%Boussinesq) then
       get_tr_flux_units = trim(tr_mass_conc_units)//" kg-1 m3 s-1"
     else
-      get_tr_flux_units = trim(tr_mass_conc_units)//" second-1"
+      get_tr_flux_units = trim(tr_mass_conc_units)//" s-1"
     endif
   endif
 

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -1061,8 +1061,8 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
   endif
   allocate(CS)
 
-  if (GV%Boussinesq) then ; flux_units = "meter3 second-1"
-  else ; flux_units = "kilogram second-1" ; endif
+  if (GV%Boussinesq) then ; flux_units = "m3 s-1"
+  else ; flux_units = "kg s-1" ; endif
 
   CS%diag => diag
 
@@ -1103,13 +1103,13 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
     call define_axes_group(diag, (/ z_axis /),    CS%axesZ)
 
     CS%id_u_z = register_diag_field('ocean_model_zold', 'u', CS%axesCuz, Time,    &
-        'Zonal Velocity in Depth Space', 'meter second-1',                     &
+        'Zonal Velocity in Depth Space', 'm s-1',                     &
         missing_value=CS%missing_vel, cmor_field_name='uo', cmor_units='m s-1',&
         cmor_standard_name='sea_water_x_velocity', cmor_long_name='Sea Water X Velocity')
     if (CS%id_u_z>0) call safe_alloc_ptr(CS%u_z,IsdB,IedB,jsd,jed,CS%nk_zspace)
 
     CS%id_v_z = register_diag_field('ocean_model_zold', 'v', CS%axesCvz, Time,    &
-        'Meridional Velocity in Depth Space', 'meter second-1',                &
+        'Meridional Velocity in Depth Space', 'm s-1',                &
         missing_value=CS%missing_vel, cmor_field_name='vo', cmor_units='m s-1',&
         cmor_standard_name='sea_water_y_velocity', cmor_long_name='Sea Water Y Velocity')
     if (CS%id_v_z>0) call safe_alloc_ptr(CS%v_z,isd,ied,JsdB,JedB,CS%nk_zspace)
@@ -1212,7 +1212,7 @@ subroutine get_Z_depths(depth_file, int_depth_name, int_depth, cell_depth_name, 
       trim(NF90_STRERROR(status))//" Reading variable "//&
       trim(int_depth_name)//" in "//trim(depth_file))
   status = NF90_GET_ATT(ncid, intvid, "units", units)
-  if (status /= NF90_NOERR) units = "meters"
+  if (status /= NF90_NOERR) units = "m"
   status = NF90_GET_ATT(ncid, intvid, "long_name", long_name)
   if (status /= NF90_NOERR) long_name = "Depth of edges"
   edge_index = diag_axis_init(int_depth_name, int_depth, units, 'z', &
@@ -1228,7 +1228,7 @@ subroutine get_Z_depths(depth_file, int_depth_name, int_depth, cell_depth_name, 
       trim(NF90_STRERROR(status))//" Reading variable "//&
       trim(cell_depth_name)//" in "//trim(depth_file))
   status = NF90_GET_ATT(ncid, layvid, "units", units)
-  if (status /= NF90_NOERR) units = "meters"
+  if (status /= NF90_NOERR) units = "m"
   status = NF90_GET_ATT(ncid, layvid, "long_name", long_name)
   if (status /= NF90_NOERR) long_name = "Depth of cell center"
 

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1159,16 +1159,16 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, param_file, diag, CS
                  units='m', default=-1.)
 
   if (GV%Boussinesq) then
-    thickness_units = "meter" ; flux_units = "meter3 second-1"
+    thickness_units = "m" ; flux_units = "m3 s-1"
   else
-    thickness_units = "kilogram meter-2" ; flux_units = "kilogram second-1"
+    thickness_units = "kg m-2" ; flux_units = "kg s-1"
   endif
 
   CS%id_temp_layer_ave = register_diag_field('ocean_model', 'temp_layer_ave', diag%axesZL, Time, &
-      'Layer Average Ocean Temperature', 'Celsius')
+      'Layer Average Ocean Temperature', 'degC')
 
   CS%id_salt_layer_ave = register_diag_field('ocean_model', 'salt_layer_ave', diag%axesZL, Time, &
-      'Layer Average Ocean Salinity', 'ppt')
+      'Layer Average Ocean Salinity', 'psu')
 
   CS%id_masscello = register_diag_field('ocean_model', 'masscello', diag%axesTL,&
       Time, 'Mass per unit area of liquid ocean grid cell', 'kg m-2',           &
@@ -1186,62 +1186,62 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, param_file, diag, CS
   endif
 
   CS%id_thetaoga = register_scalar_field('ocean_model', 'thetaoga',    &
-      Time, diag, 'Global Mean Ocean Potential Temperature', 'Celsius',&
+      Time, diag, 'Global Mean Ocean Potential Temperature', 'degC',&
       standard_name='sea_water_potential_temperature')
 
   CS%id_soga = register_scalar_field('ocean_model', 'soga', &
-      Time, diag, 'Global Mean Ocean Salinity', 'ppt',      &
+      Time, diag, 'Global Mean Ocean Salinity', 'psu',      &
       standard_name='sea_water_salinity')
 
   CS%id_tosga = register_scalar_field('ocean_model', 'sst_global', Time, diag,&
       long_name='Global Area Average Sea Surface Temperature',                &
       units='degC', standard_name='sea_surface_temperature',                  &
       cmor_field_name='tosga', cmor_standard_name='sea_surface_temperature',  &
-      cmor_units='degC', cmor_long_name='Sea Surface Temperature')
+      cmor_long_name='Sea Surface Temperature')
 
   CS%id_sosga = register_scalar_field('ocean_model', 'sss_global', Time, diag,&
       long_name='Global Area Average Sea Surface Salinity',                   &
-      units='ppt', standard_name='sea_surface_salinity',                      &
+      units='psu', standard_name='sea_surface_salinity',                      &
       cmor_field_name='sosga', cmor_standard_name='sea_surface_salinity',     &
-      cmor_units='ppt', cmor_long_name='Sea Surface Salinity')
+      cmor_long_name='Sea Surface Salinity')
 
   CS%id_e = register_diag_field('ocean_model', 'e', diag%axesTi, Time, &
-      'Interface Height Relative to Mean Sea Level', 'meter')
+      'Interface Height Relative to Mean Sea Level', 'm')
   if (CS%id_e>0) call safe_alloc_ptr(CS%e,isd,ied,jsd,jed,nz+1)
 
   CS%id_e_D = register_diag_field('ocean_model', 'e_D', diag%axesTi, Time, &
-      'Interface Height above the Seafloor', 'meter')
+      'Interface Height above the Seafloor', 'm')
   if (CS%id_e_D>0) call safe_alloc_ptr(CS%e_D,isd,ied,jsd,jed,nz+1)
 
   CS%id_Rml = register_diag_field('ocean_model', 'Rml', diag%axesTL, Time, &
-      'Mixed Layer Coordinate Potential Density', 'kg meter-3')
+      'Mixed Layer Coordinate Potential Density', 'kg m-3')
 
   CS%id_Rcv = register_diag_field('ocean_model', 'Rho_cv', diag%axesTL, Time, &
-      'Coordinate Potential Density', 'kg meter-3')
+      'Coordinate Potential Density', 'kg m-3')
 
   CS%id_rhopot0 = register_diag_field('ocean_model', 'rhopot0', diag%axesTL, Time, &
-      'Potential density referenced to surface', 'kg meter-3')
+      'Potential density referenced to surface', 'kg m-3')
   CS%id_rhopot2 = register_diag_field('ocean_model', 'rhopot2', diag%axesTL, Time, &
-      'Potential density referenced to 2000 dbar', 'kg meter-3')
+      'Potential density referenced to 2000 dbar', 'kg m-3')
   CS%id_rhoinsitu = register_diag_field('ocean_model', 'rhoinsitu', diag%axesTL, Time, &
-      'In situ density', 'kg meter-3')
+      'In situ density', 'kg m-3')
 
   CS%id_du_dt = register_diag_field('ocean_model', 'dudt', diag%axesCuL, Time, &
-      'Zonal Acceleration', 'meter second-2')
+      'Zonal Acceleration', 'm s-2')
   if ((CS%id_du_dt>0) .and. .not.ASSOCIATED(CS%du_dt)) then
     call safe_alloc_ptr(CS%du_dt,IsdB,IedB,jsd,jed,nz)
     call register_time_deriv(MIS%u, CS%du_dt, CS)
   endif
 
   CS%id_dv_dt = register_diag_field('ocean_model', 'dvdt', diag%axesCvL, Time, &
-      'Meridional Acceleration', 'meter second-2')
+      'Meridional Acceleration', 'm s-2')
   if ((CS%id_dv_dt>0) .and. .not.ASSOCIATED(CS%dv_dt)) then
     call safe_alloc_ptr(CS%dv_dt,isd,ied,JsdB,JedB,nz)
     call register_time_deriv(MIS%v, CS%dv_dt, CS)
   endif
 
   CS%id_dh_dt = register_diag_field('ocean_model', 'dhdt', diag%axesTL, Time, &
-      'Thickness tendency', trim(thickness_units)//" second-1")
+      'Thickness tendency', trim(thickness_units)//" s-1")
   if ((CS%id_dh_dt>0) .and. .not.ASSOCIATED(CS%dh_dt)) then
     call safe_alloc_ptr(CS%dh_dt,isd,ied,jsd,jed,nz)
     call register_time_deriv(MIS%h, CS%dh_dt, CS)
@@ -1275,43 +1275,43 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, param_file, diag, CS
 
   ! terms in the kinetic energy budget
   CS%id_KE = register_diag_field('ocean_model', 'KE', diag%axesTL, Time, &
-      'Layer kinetic energy per unit mass', 'meter2 second-2')
+      'Layer kinetic energy per unit mass', 'm2 s-2')
   if (CS%id_KE>0) call safe_alloc_ptr(CS%KE,isd,ied,jsd,jed,nz)
 
   CS%id_dKEdt = register_diag_field('ocean_model', 'dKE_dt', diag%axesTL, Time, &
-      'Kinetic Energy Tendency of Layer', 'meter3 second-3')
+      'Kinetic Energy Tendency of Layer', 'm3 s-3')
   if (CS%id_dKEdt>0) call safe_alloc_ptr(CS%dKE_dt,isd,ied,jsd,jed,nz)
 
   CS%id_PE_to_KE = register_diag_field('ocean_model', 'PE_to_KE', diag%axesTL, Time, &
-      'Potential to Kinetic Energy Conversion of Layer', 'meter3 second-3')
+      'Potential to Kinetic Energy Conversion of Layer', 'm3 s-3')
   if (CS%id_PE_to_KE>0) call safe_alloc_ptr(CS%PE_to_KE,isd,ied,jsd,jed,nz)
 
   CS%id_KE_Coradv = register_diag_field('ocean_model', 'KE_Coradv', diag%axesTL, Time, &
-      'Kinetic Energy Source from Coriolis and Advection', 'meter3 second-3')
+      'Kinetic Energy Source from Coriolis and Advection', 'm3 s-3')
   if (CS%id_KE_Coradv>0) call safe_alloc_ptr(CS%KE_Coradv,isd,ied,jsd,jed,nz)
 
   CS%id_KE_adv = register_diag_field('ocean_model', 'KE_adv', diag%axesTL, Time, &
-      'Kinetic Energy Source from Advection', 'meter3 second-3')
+      'Kinetic Energy Source from Advection', 'm3 s-3')
   if (CS%id_KE_adv>0) call safe_alloc_ptr(CS%KE_adv,isd,ied,jsd,jed,nz)
 
   CS%id_KE_visc = register_diag_field('ocean_model', 'KE_visc', diag%axesTL, Time, &
-      'Kinetic Energy Source from Vertical Viscosity and Stresses', 'meter3 second-3')
+      'Kinetic Energy Source from Vertical Viscosity and Stresses', 'm3 s-3')
   if (CS%id_KE_visc>0) call safe_alloc_ptr(CS%KE_visc,isd,ied,jsd,jed,nz)
 
   CS%id_KE_horvisc = register_diag_field('ocean_model', 'KE_horvisc', diag%axesTL, Time, &
-      'Kinetic Energy Source from Horizontal Viscosity', 'meter3 second-3')
+      'Kinetic Energy Source from Horizontal Viscosity', 'm3 s-3')
   if (CS%id_KE_horvisc>0) call safe_alloc_ptr(CS%KE_horvisc,isd,ied,jsd,jed,nz)
 
   CS%id_KE_dia = register_diag_field('ocean_model', 'KE_dia', diag%axesTL, Time, &
-      'Kinetic Energy Source from Diapycnal Diffusion', 'meter3 second-3')
+      'Kinetic Energy Source from Diapycnal Diffusion', 'm3 s-3')
   if (CS%id_KE_dia>0) call safe_alloc_ptr(CS%KE_dia,isd,ied,jsd,jed,nz)
 
 
   ! gravity wave CFLs
   CS%id_cg1 = register_diag_field('ocean_model', 'cg1', diag%axesT1, Time, &
-      'First baroclinic gravity wave speed', 'meter second-1')
+      'First baroclinic gravity wave speed', 'm s-1')
   CS%id_Rd1 = register_diag_field('ocean_model', 'Rd1', diag%axesT1, Time, &
-      'First baroclinic deformation radius', 'meter')
+      'First baroclinic deformation radius', 'm')
   CS%id_cfl_cg1 = register_diag_field('ocean_model', 'CFL_cg1', diag%axesT1, Time, &
       'CFL of first baroclinic gravity wave = dt*cg1*(1/dx+1/dy)', 'nondim')
   CS%id_cfl_cg1_x = register_diag_field('ocean_model', 'CFL_cg1_x', diag%axesT1, Time, &
@@ -1319,9 +1319,9 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, param_file, diag, CS
   CS%id_cfl_cg1_y = register_diag_field('ocean_model', 'CFL_cg1_y', diag%axesT1, Time, &
       'j-component of CFL of first baroclinic gravity wave = dt*cg1*/dy', 'nondim')
   CS%id_cg_ebt = register_diag_field('ocean_model', 'cg_ebt', diag%axesT1, Time, &
-      'Equivalent barotropic gravity wave speed', 'meter second-1')
+      'Equivalent barotropic gravity wave speed', 'm s-1')
   CS%id_Rd_ebt = register_diag_field('ocean_model', 'Rd_ebt', diag%axesT1, Time, &
-      'Equivalent barotropic deformation radius', 'meter')
+      'Equivalent barotropic deformation radius', 'm')
   CS%id_p_ebt = register_diag_field('ocean_model', 'p_ebt', diag%axesTL, Time, &
       'Equivalent barotropic modal strcuture', 'nondim')
 
@@ -1345,13 +1345,13 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, param_file, diag, CS
       'Density weighted column integrated potential temperature', 'degC kg m-2',                    &
       cmor_field_name='opottempmint',                                                               &
       cmor_long_name='integral_wrt_depth_of_product_of_sea_water_density_and_potential_temperature',&
-      cmor_units='degC kg m-2', cmor_standard_name='Depth integrated density times potential temperature')
+      cmor_standard_name='Depth integrated density times potential temperature')
 
   CS%id_salt_int = register_diag_field('ocean_model', 'salt_int', diag%axesT1, Time,   &
-      'Density weighted column integrated salinity', 'ppt kg m-2',                     &
+      'Density weighted column integrated salinity', 'psu kg m-2',                     &
       cmor_field_name='somint',                                                        &
       cmor_long_name='integral_wrt_depth_of_product_of_sea_water_density_and_salinity',&
-      cmor_units='ppt kg m-2', cmor_standard_name='Depth integrated density times salinity')
+      cmor_standard_name='Depth integrated density times salinity')
 
   CS%id_col_mass = register_diag_field('ocean_model', 'col_mass', diag%axesT1, Time, &
       'The column integrated in situ density', 'kg m-2')

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1338,15 +1338,15 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
   if (CS%find_salt_root) then ! read liquidus coeffs.
      call get_param(param_file, mdl, "TFREEZE_S0_P0",CS%lambda1, &
                  "this is the freezing potential temperature at \n"//&
-                 "S=0, P=0.", units="deg C", default=0.0, do_not_log=.true.)
+                 "S=0, P=0.", units="degC", default=0.0, do_not_log=.true.)
     call get_param(param_file, mdl, "DTFREEZE_DS",CS%lambda1, &
                  "this is the derivative of the freezing potential \n"//&
                  "temperature with salinity.", &
-                 units="deg C PSU-1", default=-0.054, do_not_log=.true.)
+                 units="degC psu-1", default=-0.054, do_not_log=.true.)
     call get_param(param_file, mdl, "DTFREEZE_DP",CS%lambda3, &
                  "this is the derivative of the freezing potential \n"//&
                  "temperature with pressure.", &
-                 units="deg C Pa-1", default=0.0, do_not_log=.true.)
+                 units="degC Pa-1", default=0.0, do_not_log=.true.)
 
   endif
 
@@ -1382,7 +1382,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  "The molecular kinimatic viscosity of sea water at the \n"//&
                  "freezing temperature.", units="m2 s-1", default=1.95e-6)
   call get_param(param_file, mdl, "ICE_SHELF_SALINITY", CS%Salin_ice, &
-                 "The salinity of the ice inside the ice shelf.", units="PSU", &
+                 "The salinity of the ice inside the ice shelf.", units="psu", &
                  default=0.0)
   call get_param(param_file, mdl, "ICE_SHELF_TEMPERATURE", CS%Temp_ice, &
                  "The temperature at the center of the ice shelf.", &
@@ -1908,33 +1908,33 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
   CS%id_mass_flux = register_diag_field('ocean_model', 'mass_flux', CS%diag%axesT1,&
      CS%Time,'Total mass flux of freshwater across the ice-ocean interface.', 'kg/s')
   CS%id_melt = register_diag_field('ocean_model', 'melt', CS%diag%axesT1, CS%Time, &
-     'Ice Shelf Melt Rate', 'meter year-1')
+     'Ice Shelf Melt Rate', 'm yr-1')
   CS%id_thermal_driving = register_diag_field('ocean_model', 'thermal_driving', CS%diag%axesT1, CS%Time, &
      'pot. temp. in the boundary layer minus freezing pot. temp. at the ice-ocean interface.', 'Celsius')
   CS%id_haline_driving = register_diag_field('ocean_model', 'haline_driving', CS%diag%axesT1, CS%Time, &
-     'salinity in the boundary layer minus salinity at the ice-ocean interface.', 'PPT')
+     'salinity in the boundary layer minus salinity at the ice-ocean interface.', 'psu')
   CS%id_Sbdry = register_diag_field('ocean_model', 'sbdry', CS%diag%axesT1, CS%Time, &
-     'salinity at the ice-ocean interface.', 'PPT')
+     'salinity at the ice-ocean interface.', 'psu')
   CS%id_u_ml = register_diag_field('ocean_model', 'u_ml', CS%diag%axesT1, CS%Time, &
-     'Eastward vel. in the boundary layer (used to compute ustar)', 'meter second-1')
+     'Eastward vel. in the boundary layer (used to compute ustar)', 'm s-1')
   CS%id_v_ml = register_diag_field('ocean_model', 'v_ml', CS%diag%axesT1, CS%Time, &
-     'Northward vel. in the boundary layer (used to compute ustar)', 'meter second-1')
+     'Northward vel. in the boundary layer (used to compute ustar)', 'm s-1')
   CS%id_exch_vel_s = register_diag_field('ocean_model', 'exch_vel_s', CS%diag%axesT1, CS%Time, &
-     'Sub-shelf salinity exchange velocity', 'meter second-1')
+     'Sub-shelf salinity exchange velocity', 'm s-1')
   CS%id_exch_vel_t = register_diag_field('ocean_model', 'exch_vel_t', CS%diag%axesT1, CS%Time, &
-     'Sub-shelf thermal exchange velocity', 'meter second-1')
+     'Sub-shelf thermal exchange velocity', 'm s-1')
   CS%id_tfreeze = register_diag_field('ocean_model', 'tfreeze', CS%diag%axesT1, CS%Time, &
-     'In Situ Freezing point at ice shelf interface', 'degrees Celsius')
+     'In Situ Freezing point at ice shelf interface', 'degC')
   CS%id_tfl_shelf = register_diag_field('ocean_model', 'tflux_shelf', CS%diag%axesT1, CS%Time, &
-     'Heat conduction into ice shelf', 'Watts meter-2')
+     'Heat conduction into ice shelf', 'W m-2')
   CS%id_ustar_shelf = register_diag_field('ocean_model', 'ustar_shelf', CS%diag%axesT1, CS%Time, &
      'Fric vel under shelf', 'm/s')
 
   if (CS%shelf_mass_is_dynamic .and. .not.CS%override_shelf_movement) then
     CS%id_u_shelf = register_diag_field('ocean_model','u_shelf',CS%diag%axesB1,CS%Time, &
-       'x-velocity of ice', 'm year')
+       'x-velocity of ice', 'm yr')
     CS%id_v_shelf = register_diag_field('ocean_model','v_shelf',CS%diag%axesB1,CS%Time, &
-       'y-velocity of ice', 'm year')
+       'y-velocity of ice', 'm yr')
     CS%id_u_mask = register_diag_field('ocean_model','u_mask',CS%diag%axesB1,CS%Time, &
        'mask for u-nodes', 'none')
     CS%id_v_mask = register_diag_field('ocean_model','v_mask',CS%diag%axesB1,CS%Time, &

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -122,7 +122,7 @@ subroutine set_grid_metrics(G, param_file)
                  "If true, write out verbose debugging data.", default=.false.)
 
   ! These are defaults that may be changed in the next select block.
-  G%x_axis_units = "degrees_E" ; G%y_axis_units = "degrees_N"
+  G%x_axis_units = "degrees_east" ; G%y_axis_units = "degrees_north"
   select case (trim(config))
     case ("mosaic");    call set_grid_metrics_from_mosaic(G, param_file)
     case ("cartesian"); call set_grid_metrics_cartesian(G, param_file)

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -1114,7 +1114,7 @@ subroutine write_ocean_geometry_file(G, param_file, directory, geom_file)
   vars(3) = var_desc("geolat","degree", "latitude at tracer (T) points", 'h','1','1')
   vars(4) = var_desc("geolon","degree","longitude at tracer (T) points",'h','1','1')
   vars(5) = var_desc("D","meter","Basin Depth",'h','1','1')
-  vars(6) = var_desc("f","second-1","Coriolis Parameter",'q','1','1')
+  vars(6) = var_desc("f","s-1","Coriolis Parameter",'q','1','1')
   vars(7) = var_desc("dxCv","m","Zonal grid spacing at v points",'v','1','1')
   vars(8) = var_desc("dyCu","m","Meridional grid spacing at u points",'u','1','1')
   vars(9) = var_desc("dxCu","m","Zonal grid spacing at u points",'u','1','1')
@@ -1128,12 +1128,12 @@ subroutine write_ocean_geometry_file(G, param_file, directory, geom_file)
 
   vars(17)= var_desc("dxCvo","m","Open zonal grid spacing at v points",'v','1','1')
   vars(18)= var_desc("dyCuo","m","Open meridional grid spacing at u points",'u','1','1')
-  vars(19)= var_desc("wet", "none", "land or ocean?", 'h','1','1')
+  vars(19)= var_desc("wet", "nondim", "land or ocean?", 'h','1','1')
 
-  vars(20) = var_desc("Dblock_u","meter","Blocked depth at u points",'u','1','1')
-  vars(21) = var_desc("Dopen_u","meter","Open depth at u points",'u','1','1')
-  vars(22) = var_desc("Dblock_v","meter","Blocked depth at v points",'v','1','1')
-  vars(23) = var_desc("Dopen_v","meter","Open depth at v points",'v','1','1')
+  vars(20) = var_desc("Dblock_u","m","Blocked depth at u points",'u','1','1')
+  vars(21) = var_desc("Dopen_u","m","Open depth at u points",'u','1','1')
+  vars(22) = var_desc("Dblock_v","m","Blocked depth at v points",'v','1','1')
+  vars(23) = var_desc("Dopen_v","m","Open depth at v points",'v','1','1')
 
   nFlds_used = 19 ; if (G%bathymetry_at_vel) nFlds_used = 23
 

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -981,43 +981,43 @@ logical function MEKE_init(Time, G, param_file, diag, CS, MEKE, restart_CS)
 ! Register fields for output from this module.
   CS%diag => diag
   CS%id_MEKE = register_diag_field('ocean_model', 'MEKE', diag%axesT1, Time, &
-     'Mesoscale Eddy Kinetic Energy', 'meter2 second-2')
+     'Mesoscale Eddy Kinetic Energy', 'm2 s-2')
   if (.not. associated(MEKE%MEKE)) CS%id_MEKE = -1
   CS%id_Kh = register_diag_field('ocean_model', 'MEKE_KH', diag%axesT1, Time, &
-     'MEKE derived diffusivity', 'meter2 second-1')
+     'MEKE derived diffusivity', 'm2 s-1')
   if (.not. associated(MEKE%Kh)) CS%id_Kh = -1
   CS%id_Ku = register_diag_field('ocean_model', 'MEKE_KU', diag%axesT1, Time, &
-     'MEKE derived lateral viscosity', 'meter2 second-1')
+     'MEKE derived lateral viscosity', 'm2 s-1')
   if (.not. associated(MEKE%Ku)) CS%id_Ku = -1
   CS%id_Ue = register_diag_field('ocean_model', 'MEKE_Ue', diag%axesT1, Time, &
-     'MEKE derived eddy-velocity scale', 'meter second-1')
+     'MEKE derived eddy-velocity scale', 'm s-1')
   if (.not. associated(MEKE%MEKE)) CS%id_Ue = -1
   CS%id_Ub = register_diag_field('ocean_model', 'MEKE_Ub', diag%axesT1, Time, &
-     'MEKE derived bottom eddy-velocity scale', 'meter second-1')
+     'MEKE derived bottom eddy-velocity scale', 'm s-1')
   if (.not. associated(MEKE%MEKE)) CS%id_Ub = -1
   CS%id_Ut = register_diag_field('ocean_model', 'MEKE_Ut', diag%axesT1, Time, &
-     'MEKE derived barotropic eddy-velocity scale', 'meter second-1')
+     'MEKE derived barotropic eddy-velocity scale', 'm s-1')
   if (.not. associated(MEKE%MEKE)) CS%id_Ut = -1
   CS%id_src = register_diag_field('ocean_model', 'MEKE_src', diag%axesT1, Time, &
-     'MEKE energy source', 'meter2 second-3')
+     'MEKE energy source', 'm2 s-3')
   CS%id_decay = register_diag_field('ocean_model', 'MEKE_decay', diag%axesT1, Time, &
-     'MEKE decay rate', 'second-1')
+     'MEKE decay rate', 's-1')
   CS%id_KhMEKE_u = register_diag_field('ocean_model', 'KHMEKE_u', diag%axesCu1, Time, &
-     'Zonal diffusivity of MEKE', 'meter2 second-1')
+     'Zonal diffusivity of MEKE', 'm2 s-1')
   CS%id_KhMEKE_v = register_diag_field('ocean_model', 'KHMEKE_v', diag%axesCv1, Time, &
-     'Meridional diffusivity of MEKE', 'meter2 second-1')
+     'Meridional diffusivity of MEKE', 'm2 s-1')
   CS%id_GM_src = register_diag_field('ocean_model', 'MEKE_GM_src', diag%axesT1, Time, &
-     'MEKE energy available from thickness mixing', 'Watt meter-2')
+     'MEKE energy available from thickness mixing', 'W m-2')
   if (.not. associated(MEKE%GM_src)) CS%id_GM_src = -1
   CS%id_mom_src = register_diag_field('ocean_model', 'MEKE_mom_src',diag%axesT1, Time, &
-     'MEKE energy available from momentum', 'Watt meter-2')
+     'MEKE energy available from momentum', 'W m-2')
   if (.not. associated(MEKE%mom_src)) CS%id_mom_src = -1
   CS%id_Le = register_diag_field('ocean_model', 'MEKE_Le', diag%axesT1, Time, &
-     'Eddy mixing length used in the MEKE derived eddy diffusivity', 'meter')
+     'Eddy mixing length used in the MEKE derived eddy diffusivity', 'm')
   CS%id_Lrhines = register_diag_field('ocean_model', 'MEKE_Lrhines', diag%axesT1, Time, &
-     'Rhines length scale used in the MEKE derived eddy diffusivity', 'meter')
+     'Rhines length scale used in the MEKE derived eddy diffusivity', 'm')
   CS%id_Leady = register_diag_field('ocean_model', 'MEKE_Leady', diag%axesT1, Time, &
-     'Eady length scale used in the MEKE derived eddy diffusivity', 'meter')
+     'Eady length scale used in the MEKE derived eddy diffusivity', 'm')
   CS%id_gamma_b = register_diag_field('ocean_model', 'MEKE_gamma_b', diag%axesT1, Time, &
      'Ratio of bottom-projected eddy velocity to column-mean eddy velocity', 'nondim')
   CS%id_gamma_t = register_diag_field('ocean_model', 'MEKE_gamma_t', diag%axesT1, Time, &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1513,39 +1513,39 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
   ! Register fields for output from this module.
 
   CS%id_diffu = register_diag_field('ocean_model', 'diffu', diag%axesCuL, Time, &
-      'Zonal Acceleration from Horizontal Viscosity', 'meter second-2')
+      'Zonal Acceleration from Horizontal Viscosity', 'm s-2')
 
   CS%id_diffv = register_diag_field('ocean_model', 'diffv', diag%axesCvL, Time, &
-      'Meridional Acceleration from Horizontal Viscosity', 'meter second-2')
+      'Meridional Acceleration from Horizontal Viscosity', 'm s-2')
 
   if (CS%biharmonic) then
     CS%id_Ah_h = register_diag_field('ocean_model', 'Ahh', diag%axesTL, Time,    &
-        'Biharmonic Horizontal Viscosity at h Points', 'meter4 second-1',        &
-        cmor_field_name='difmxybo', cmor_units='m4 s-1',                        &
+        'Biharmonic Horizontal Viscosity at h Points', 'm4 s-1',        &
+        cmor_field_name='difmxybo',                                             &
         cmor_long_name='Ocean lateral biharmonic viscosity',                     &
         cmor_standard_name='ocean_momentum_xy_biharmonic_diffusivity')
 
     CS%id_Ah_q = register_diag_field('ocean_model', 'Ahq', diag%axesBL, Time, &
-        'Biharmonic Horizontal Viscosity at q Points', 'meter4 second-1')
+        'Biharmonic Horizontal Viscosity at q Points', 'm4 s-1')
   endif
 
   if (CS%Laplacian) then
     CS%id_Kh_h = register_diag_field('ocean_model', 'Khh', diag%axesTL, Time,   &
-        'Laplacian Horizontal Viscosity at h Points', 'meter2 second-1',        &
-        cmor_field_name='difmxylo', cmor_units='m2 s-1',                        &
+        'Laplacian Horizontal Viscosity at h Points', 'm2 s-1',        &
+        cmor_field_name='difmxylo',                                             &
         cmor_long_name='Ocean lateral Laplacian viscosity',                     &
         cmor_standard_name='ocean_momentum_xy_laplacian_diffusivity')
 
     CS%id_Kh_q = register_diag_field('ocean_model', 'Khq', diag%axesBL, Time, &
-        'Laplacian Horizontal Viscosity at q Points', 'meter2 second-1')
+        'Laplacian Horizontal Viscosity at q Points', 'm2 s-1')
   endif
 
   CS%id_FrictWork = register_diag_field('ocean_model','FrictWork',diag%axesTL,Time,&
-      'Integral work done by lateral friction terms', 'Watt meter-2')
+      'Integral work done by lateral friction terms', 'W m-2')
 
   CS%id_FrictWorkIntz = register_diag_field('ocean_model','FrictWorkIntz',diag%axesT1,Time,      &
-      'Depth integrated work done by lateral friction', 'Watt meter-2',                          &
-      cmor_field_name='dispkexyfo', cmor_units='W m-2',                                          &
+      'Depth integrated work done by lateral friction', 'W m-2',                          &
+      cmor_field_name='dispkexyfo',                                                              &
       cmor_long_name='Depth integrated ocean kinetic energy dissipation due to lateral friction',&
       cmor_standard_name='ocean_kinetic_energy_dissipation_per_unit_area_due_to_xy_friction')
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -847,9 +847,9 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
     allocate(CS%SN_u(IsdB:IedB,jsd:jed)) ; CS%SN_u(:,:) = 0.0
     allocate(CS%SN_v(isd:ied,JsdB:JedB)) ; CS%SN_v(:,:) = 0.0
     CS%id_SN_u = register_diag_field('ocean_model', 'SN_u', diag%axesCu1, Time, &
-       'Inverse eddy time-scale, S*N, at u-points', 's^-1')
+       'Inverse eddy time-scale, S*N, at u-points', 's-1')
     CS%id_SN_v = register_diag_field('ocean_model', 'SN_v', diag%axesCv1, Time, &
-       'Inverse eddy time-scale, S*N, at v-points', 's^-1')
+       'Inverse eddy time-scale, S*N, at v-points', 's-1')
     call get_param(param_file, mdl, "VARMIX_KTOP", CS%VarMix_Ktop, &
                  "The layer number at which to start vertical integration \n"//&
                  "of S*N for purposes of finding the Eady growth rate.", &
@@ -865,20 +865,20 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
     allocate(CS%L2v(isd:ied,JsdB:JedB)) ; CS%L2v(:,:) = CS%Visbeck_L_scale**2
 
     CS%id_L2u = register_diag_field('ocean_model', 'L2u', diag%axesCu1, Time, &
-       'Length scale squared for mixing coefficient, at u-points', 'm^2')
+       'Length scale squared for mixing coefficient, at u-points', 'm2')
     CS%id_L2v = register_diag_field('ocean_model', 'L2v', diag%axesCv1, Time, &
-       'Length scale squared for mixing coefficient, at v-points', 'm^2')
+       'Length scale squared for mixing coefficient, at v-points', 'm2')
   endif
 
   if (CS%use_stored_slopes) then
     CS%id_N2_u = register_diag_field('ocean_model', 'N2_u', diag%axesCui, Time, &
-         'Square of Brunt-Vaisala frequency, N^2, at u-points, as used in Visbeck et al.', 's^-2')
+         'Square of Brunt-Vaisala frequency, N^2, at u-points, as used in Visbeck et al.', 's-2')
     CS%id_N2_v = register_diag_field('ocean_model', 'N2_v', diag%axesCvi, Time, &
-         'Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.', 's^-2')
+         'Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.', 's-2')
     CS%id_S2_u = register_diag_field('ocean_model', 'S2_u', diag%axesCu1, Time, &
-         'Depth average square of slope magnitude, S^2, at u-points, as used in Visbeck et al.', 's^-2')
+         'Depth average square of slope magnitude, S^2, at u-points, as used in Visbeck et al.', 's-2')
     CS%id_S2_v = register_diag_field('ocean_model', 'S2_v', diag%axesCv1, Time, &
-         'Depth average square of slope magnitude, S^2, at v-points, as used in Visbeck et al.', 's^-2')
+         'Depth average square of slope magnitude, S^2, at v-points, as used in Visbeck et al.', 's-2')
   endif
 
   if (CS%Resoln_scaled_Kh .or. CS%Resoln_scaled_KhTh .or. CS%Resoln_scaled_KhTr) then
@@ -896,7 +896,7 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
     allocate(CS%f2_dx2_v(isd:ied,JsdB:JedB))     ; CS%f2_dx2_v(:,:) = 0.0
 
     CS%id_Res_fn = register_diag_field('ocean_model', 'Res_fn', diag%axesT1, Time, &
-       'Resolution function for scaling diffusivities', 'Nondim')
+       'Resolution function for scaling diffusivities', 'nondim')
 
     call get_param(param_file, mdl, "KH_RES_SCALE_COEF", CS%Res_coef_khth, &
                  "A coefficient that determines how KhTh is scaled away if \n"//&
@@ -989,7 +989,7 @@ subroutine VarMix_init(Time, G, param_file, diag, CS)
 
   ! Resolution %Rd_dx_h
   CS%id_Rd_dx = register_diag_field('ocean_model', 'Rd_dx', diag%axesT1, Time, &
-       'Ratio between deformation radius and grid spacing', 'Nondim')
+       'Ratio between deformation radius and grid spacing', 'm m-1')
   CS%calculate_Rd_dx = CS%calculate_Rd_dx .or. (CS%id_Rd_dx>0)
 
   if (CS%calculate_Rd_dx) then

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -867,21 +867,21 @@ logical function mixedlayer_restrat_init(Time, G, GV, param_file, diag, CS)
       'Meridional Thickness Flux to Restratify Mixed Layer', 'kg s-1', conversion=flux_to_kg_per_s, &
       x_cell_method='sum', v_extensive=.true.)
   CS%id_urestrat_time = register_diag_field('ocean_model', 'MLu_restrat_time', diag%axesCu1, Time, &
-      'Mixed Layer Zonal Restratification Timescale', 'second')
+      'Mixed Layer Zonal Restratification Timescale', 's')
   CS%id_vrestrat_time = register_diag_field('ocean_model', 'MLv_restrat_time', diag%axesCv1, Time, &
-      'Mixed Layer Meridional Restratification Timescale', 'second')
+      'Mixed Layer Meridional Restratification Timescale', 's')
   CS%id_MLD = register_diag_field('ocean_model', 'MLD_restrat', diag%axesT1, Time, &
-      'Mixed Layer Depth as used in the mixed-layer restratification parameterization', 'meter')
+      'Mixed Layer Depth as used in the mixed-layer restratification parameterization', 'm')
   CS%id_Rml = register_diag_field('ocean_model', 'ML_buoy_restrat', diag%axesT1, Time, &
-      'Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization', 'm/s^2')
+      'Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization', 'm s2')
   CS%id_uDml = register_diag_field('ocean_model', 'udml_restrat', diag%axesCu1, Time, &
-      'Transport stream function amplitude for zonal restratification of mixed layer', 'm3/s')
+      'Transport stream function amplitude for zonal restratification of mixed layer', 'm3 s-1')
   CS%id_vDml = register_diag_field('ocean_model', 'vdml_restrat', diag%axesCv1, Time, &
-      'Transport stream function amplitude for meridional restratification of mixed layer', 'm3/s')
+      'Transport stream function amplitude for meridional restratification of mixed layer', 'm3 s-1')
   CS%id_uml = register_diag_field('ocean_model', 'uml_restrat', diag%axesCu1, Time, &
-      'Surface zonal velocity component of mixed layer restratification', 'm/s')
+      'Surface zonal velocity component of mixed layer restratification', 'm s-1')
   CS%id_vml = register_diag_field('ocean_model', 'vml_restrat', diag%axesCv1, Time, &
-      'Surface meridional velocity component of mixed layer restratification', 'm/s')
+      'Surface meridional velocity component of mixed layer restratification', 'm s-1')
 
   ! If MLD_filtered is being used, we need to update halo regions after a restart
   if (associated(CS%MLD_filtered)) call pass_var(CS%MLD_filtered, G%domain)

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1773,29 +1773,28 @@ subroutine thickness_diffuse_init(Time, G, GV, param_file, diag, CDp, CS)
 
   CS%id_GMwork = register_diag_field('ocean_model', 'GMwork', diag%axesT1, Time,                     &
    'Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection',               &
-   'Watt meter-2', cmor_field_name='tnkebto',                                                        &
+   'W m-2', cmor_field_name='tnkebto',                                                        &
    cmor_long_name='Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection',&
-   cmor_units='W m-2',                                                                               &
    cmor_standard_name='tendency_of_ocean_eddy_kinetic_energy_content_due_to_parameterized_eddy_advection')
   if (CS%id_GMwork > 0) call safe_alloc_ptr(CS%GMwork,G%isd,G%ied,G%jsd,G%jed)
 
   CS%id_KH_u = register_diag_field('ocean_model', 'KHTH_u', diag%axesCui, Time, &
-           'Parameterized mesoscale eddy advection diffusivity at U-point', 'meter second-2')
+           'Parameterized mesoscale eddy advection diffusivity at U-point', 'm s-2')
   CS%id_KH_v = register_diag_field('ocean_model', 'KHTH_v', diag%axesCvi, Time, &
-           'Parameterized mesoscale eddy advection diffusivity at V-point', 'meter second-2')
+           'Parameterized mesoscale eddy advection diffusivity at V-point', 'm s-2')
   CS%id_KH_t = register_diag_field('ocean_model', 'KHTH_t', diag%axesTL, Time,               &
-       'Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection', 'meter second-2',&
+       'Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection', 'm s-2',&
    cmor_field_name='diftrblo',                                                               &
    cmor_long_name='Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection',       &
    cmor_units='m2 s-1',                                                                      &
    cmor_standard_name='ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection')
 
   CS%id_KH_u1 = register_diag_field('ocean_model', 'KHTH_u1', diag%axesCu1, Time,         &
-           'Parameterized mesoscale eddy advection diffusivity at U-points (2-D)', 'meter second-2')
+           'Parameterized mesoscale eddy advection diffusivity at U-points (2-D)', 'm s-2')
   CS%id_KH_v1 = register_diag_field('ocean_model', 'KHTH_v1', diag%axesCv1, Time,         &
-           'Parameterized mesoscale eddy advection diffusivity at V-points (2-D)', 'meter second-2')
+           'Parameterized mesoscale eddy advection diffusivity at V-points (2-D)', 'm s-2')
   CS%id_KH_t1 = register_diag_field('ocean_model', 'KHTH_t1', diag%axesT1, Time,&
-           'Parameterized mesoscale eddy advection diffusivity at T-points (2-D)', 'meter second-2')
+           'Parameterized mesoscale eddy advection diffusivity at T-points (2-D)', 'm s-2')
 
   CS%id_slope_x =  register_diag_field('ocean_model', 'neutral_slope_x', diag%axesCui, Time, &
            'Zonal slope of neutral surface', 'nondim')
@@ -1804,13 +1803,13 @@ subroutine thickness_diffuse_init(Time, G, GV, param_file, diag, CDp, CS)
            'Meridional slope of neutral surface', 'nondim')
   if (CS%id_slope_y > 0) call safe_alloc_ptr(CS%diagSlopeY,G%isd,G%ied,G%JsdB,G%JedB,G%ke+1)
   CS%id_sfn_x =  register_diag_field('ocean_model', 'GM_sfn_x', diag%axesCui, Time, &
-           'Parameterized Zonal Overturning Streamfunction', 'meter3 second-1')
+           'Parameterized Zonal Overturning Streamfunction', 'm3 s-1')
   CS%id_sfn_y =  register_diag_field('ocean_model', 'GM_sfn_y', diag%axesCvi, Time, &
-           'Parameterized Meridional Overturning Streamfunction', 'meter3 second-1')
+           'Parameterized Meridional Overturning Streamfunction', 'm3 s-1')
   CS%id_sfn_unlim_x =  register_diag_field('ocean_model', 'GM_sfn_unlim_x', diag%axesCui, Time, &
-           'Parameterized Zonal Overturning Streamfunction before limiting/smoothing', 'meter3 second-1')
+           'Parameterized Zonal Overturning Streamfunction before limiting/smoothing', 'm3 s-1')
   CS%id_sfn_unlim_y =  register_diag_field('ocean_model', 'GM_sfn_unlim_y', diag%axesCvi, Time, &
-           'Parameterized Meridional Overturning Streamfunction before limiting/smoothing', 'meter3 second-1')
+           'Parameterized Meridional Overturning Streamfunction before limiting/smoothing', 'm3 s-1')
 
 end subroutine thickness_diffuse_init
 

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -3805,35 +3805,35 @@ subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
                  default=.true.)
 
   CS%id_ML_depth = register_diag_field('ocean_model', 'h_ML', diag%axesT1, &
-      Time, 'Surface mixed layer depth', 'meter')
+      Time, 'Surface mixed layer depth', 'm')
   CS%id_TKE_wind = register_diag_field('ocean_model', 'TKE_wind', diag%axesT1, &
-      Time, 'Wind-stirring source of mixed layer TKE', 'meter3 second-3')
+      Time, 'Wind-stirring source of mixed layer TKE', 'm3 s-3')
   CS%id_TKE_RiBulk = register_diag_field('ocean_model', 'TKE_RiBulk', diag%axesT1, &
-      Time, 'Mean kinetic energy source of mixed layer TKE', 'meter3 second-3')
+      Time, 'Mean kinetic energy source of mixed layer TKE', 'm3 s-3')
   CS%id_TKE_conv = register_diag_field('ocean_model', 'TKE_conv', diag%axesT1, &
-      Time, 'Convective source of mixed layer TKE', 'meter3 second-3')
+      Time, 'Convective source of mixed layer TKE', 'm3 s-3')
   CS%id_TKE_pen_SW = register_diag_field('ocean_model', 'TKE_pen_SW', diag%axesT1, &
-      Time, 'TKE consumed by mixing penetrative shortwave radation through the mixed layer', 'meter3 second-3')
+      Time, 'TKE consumed by mixing penetrative shortwave radation through the mixed layer', 'm3 s-3')
   CS%id_TKE_mixing = register_diag_field('ocean_model', 'TKE_mixing', diag%axesT1, &
-      Time, 'TKE consumed by mixing that deepens the mixed layer', 'meter3 second-3')
+      Time, 'TKE consumed by mixing that deepens the mixed layer', 'm3 s-3')
   CS%id_TKE_mech_decay = register_diag_field('ocean_model', 'TKE_mech_decay', diag%axesT1, &
-      Time, 'Mechanical energy decay sink of mixed layer TKE', 'meter3 second-3')
+      Time, 'Mechanical energy decay sink of mixed layer TKE', 'm3 s-3')
   CS%id_TKE_conv_decay = register_diag_field('ocean_model', 'TKE_conv_decay', diag%axesT1, &
-      Time, 'Convective energy decay sink of mixed layer TKE', 'meter3 second-3')
+      Time, 'Convective energy decay sink of mixed layer TKE', 'm3 s-3')
   CS%id_TKE_conv_s2 = register_diag_field('ocean_model', 'TKE_conv_s2', diag%axesT1, &
-      Time, 'Spurious source of mixed layer TKE from sigma2', 'meter3 second-3')
+      Time, 'Spurious source of mixed layer TKE from sigma2', 'm3 s-3')
   CS%id_PE_detrain = register_diag_field('ocean_model', 'PE_detrain', diag%axesT1, &
-      Time, 'Spurious source of potential energy from mixed layer detrainment', 'Watt meter-2')
+      Time, 'Spurious source of potential energy from mixed layer detrainment', 'W m-2')
   CS%id_PE_detrain2 = register_diag_field('ocean_model', 'PE_detrain2', diag%axesT1, &
-      Time, 'Spurious source of potential energy from mixed layer only detrainment', 'Watt meter-2')
+      Time, 'Spurious source of potential energy from mixed layer only detrainment', 'W m-2')
   CS%id_h_mismatch = register_diag_field('ocean_model', 'h_miss_ML', diag%axesT1, &
-      Time, 'Summed absolute mismatch in entrainment terms', 'meter')
+      Time, 'Summed absolute mismatch in entrainment terms', 'm')
   CS%id_Hsfc_used = register_diag_field('ocean_model', 'Hs_used', diag%axesT1, &
-      Time, 'Surface region thickness that is used', 'meter')
+      Time, 'Surface region thickness that is used', 'm')
   CS%id_Hsfc_max = register_diag_field('ocean_model', 'Hs_max', diag%axesT1, &
-      Time, 'Maximum surface region thickness', 'meter')
+      Time, 'Maximum surface region thickness', 'm')
   CS%id_Hsfc_min = register_diag_field('ocean_model', 'Hs_min', diag%axesT1, &
-      Time, 'Minimum surface region thickness', 'meter')
+      Time, 'Minimum surface region thickness', 'm')
  !CS%lim_det_dH_sfc = 0.5 ; CS%lim_det_dH_bathy = 0.2 ! Technically these should not get used if limit_det is false?
   if (CS%limit_det .or. (CS%id_Hsfc_min > 0)) then
     call get_param(param_file, mdl, "LIMIT_BUFFER_DET_DH_SFC", CS%lim_det_dH_sfc, &

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -1402,19 +1402,19 @@ subroutine diabatic_aux_init(Time, G, GV, param_file, diag, CS, useALEalgorithm,
   if (useALEalgorithm) then
     CS%id_createdH = register_diag_field('ocean_model',"created_H",diag%axesT1, &
         Time, "The volume flux added to stop the ocean from drying out and becoming negative in depth", &
-        "meter second-1")
+        "m s-1")
     if (CS%id_createdH>0) allocate(CS%createdH(isd:ied,jsd:jed))
 
     ! diagnostic for heating of a grid cell from convergence of SW heat into the cell
     CS%id_penSW_diag = register_diag_field('ocean_model', 'rsdoabsorb',                     &
           diag%axesTL, Time, 'Convergence of Penetrative Shortwave Flux in Sea Water Layer',&
-          'Watt meter-2', standard_name='net_rate_of_absorption_of_shortwave_energy_in_ocean_layer',v_extensive=.true.)
+          'W m-2', standard_name='net_rate_of_absorption_of_shortwave_energy_in_ocean_layer',v_extensive=.true.)
 
     ! diagnostic for penetrative SW heat flux at top interface of tracer cell (nz+1 interfaces)
     ! k=1 gives penetrative SW at surface; SW(k=nz+1)=0 (no penetration through rock).
     CS%id_penSWflux_diag = register_diag_field('ocean_model', 'rsdo',                               &
           diag%axesTi, Time, 'Downwelling Shortwave Flux in Sea Water at Grid Cell Upper Interface',&
-          'Watt meter-2', standard_name='downwelling_shortwave_flux_in_sea_water')
+          'W m-2', standard_name='downwelling_shortwave_flux_in_sea_water')
 
     ! need both arrays for the SW diagnostics (one for flux, one for convergence)
     if (CS%id_penSW_diag>0 .or. CS%id_penSWflux_diag>0) then
@@ -1428,7 +1428,7 @@ subroutine diabatic_aux_init(Time, G, GV, param_file, diag, CS, useALEalgorithm,
     CS%id_nonpenSW_diag = register_diag_field('ocean_model', 'nonpenSW',                       &
           diag%axesT1, Time,                                                                   &
           'Non-downwelling SW radiation (i.e., SW absorbed in ocean surface with LW,SENS,LAT)',&
-          'Watt meter-2', standard_name='nondownwelling_shortwave_flux_in_sea_water')
+          'W m-2', standard_name='nondownwelling_shortwave_flux_in_sea_water')
     if (CS%id_nonpenSW_diag > 0) then
        allocate(CS%nonpenSW_diag(isd:ied,jsd:jed))
        CS%nonpenSW_diag(:,:) = 0.0

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1973,19 +1973,19 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
 
 
   ! Register all available diagnostics for this module.
-  if (GV%Boussinesq) then ; thickness_units = "meter"
-  else ; thickness_units = "kilogram meter-2" ; endif
+  if (GV%Boussinesq) then ; thickness_units = "m"
+  else ; thickness_units = "kg m-2" ; endif
 
   CS%id_ea = register_diag_field('ocean_model','ea',diag%axesTL,Time, &
-      'Layer entrainment from above per timestep','meter')
+      'Layer entrainment from above per timestep','m')
   CS%id_eb = register_diag_field('ocean_model','eb',diag%axesTL,Time, &
-      'Layer entrainment from below per timestep', 'meter')
+      'Layer entrainment from below per timestep', 'm')
   CS%id_dudt_dia = register_diag_field('ocean_model','dudt_dia',diag%axesCuL,Time, &
-      'Zonal Acceleration from Diapycnal Mixing', 'meter second-2')
+      'Zonal Acceleration from Diapycnal Mixing', 'm s-2')
   CS%id_dvdt_dia = register_diag_field('ocean_model','dvdt_dia',diag%axesCvL,Time, &
-      'Meridional Acceleration from Diapycnal Mixing', 'meter second-2')
+      'Meridional Acceleration from Diapycnal Mixing', 'm s-2')
   CS%id_wd = register_diag_field('ocean_model','wd',diag%axesTi,Time, &
-      'Diapycnal Velocity', 'meter second-1')
+      'Diapycnal Velocity', 'm s-1')
   if (CS%use_int_tides) then
     CS%id_cg1 = register_diag_field('ocean_model','cn1', diag%axesT1, &
                  Time, 'First baroclinic mode (eigen) speed', 'm s-1')
@@ -2001,29 +2001,29 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
 
   CS%id_Tdif = register_diag_field('ocean_model',"Tflx_dia_diff",diag%axesTi, &
       Time, "Diffusive diapycnal temperature flux across interfaces", &
-      "degC meter second-1")
+      "degC m s-1")
   CS%id_Tadv = register_diag_field('ocean_model',"Tflx_dia_adv",diag%axesTi, &
       Time, "Advective diapycnal temperature flux across interfaces", &
-      "degC meter second-1")
+      "degC m s-1")
   CS%id_Sdif = register_diag_field('ocean_model',"Sflx_dia_diff",diag%axesTi, &
       Time, "Diffusive diapycnal salnity flux across interfaces", &
-      "PSU meter second-1")
+      "psu m s-1")
   CS%id_Sadv = register_diag_field('ocean_model',"Sflx_dia_adv",diag%axesTi, &
       Time, "Advective diapycnal salnity flux across interfaces", &
-      "PSU meter second-1")
+      "psu m s-1")
   CS%id_MLD_003 = register_diag_field('ocean_model','MLD_003',diag%axesT1,Time,        &
-      'Mixed layer depth (delta rho = 0.03)', 'meter', cmor_field_name='mlotst',       &
-      cmor_long_name='Ocean Mixed Layer Thickness Defined by Sigma T', cmor_units='m', &
+      'Mixed layer depth (delta rho = 0.03)', 'm', cmor_field_name='mlotst',       &
+      cmor_long_name='Ocean Mixed Layer Thickness Defined by Sigma T', &
       cmor_standard_name='ocean_mixed_layer_thickness_defined_by_sigma_t')
   CS%id_mlotstsq = register_diag_field('ocean_model','mlotstsq',diag%axesT1,Time,      &
       long_name='Square of Ocean Mixed Layer Thickness Defined by Sigma T',            &
       standard_name='square_of_ocean_mixed_layer_thickness_defined_by_sigma_t',units='m2')
   CS%id_MLD_0125 = register_diag_field('ocean_model','MLD_0125',diag%axesT1,Time, &
-      'Mixed layer depth (delta rho = 0.125)', 'meter')
+      'Mixed layer depth (delta rho = 0.125)', 'm')
   CS%id_subMLN2  = register_diag_field('ocean_model','subML_N2',diag%axesT1,Time, &
       'Squared buoyancy frequency below mixed layer', 's-2')
   CS%id_MLD_user = register_diag_field('ocean_model','MLD_user',diag%axesT1,Time, &
-      'Mixed layer depth (used defined)', 'meter')
+      'Mixed layer depth (used defined)', 'm')
   call get_param(param_file, mod, "DIAG_MLD_DENSITY_DIFF", CS%MLDdensityDifference, &
                  "The density difference used to determine a diagnostic mixed\n"//&
                  "layer depth, MLD_user, following the definition of Levitus 1982. \n"//&
@@ -2032,22 +2032,22 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
 
   ! diagnostics making use of the z-gridding code
   if (associated(diag_to_Z_CSp)) then
-    vd = var_desc("Kd_interface", "meter2 second-1", &
+    vd = var_desc("Kd_interface", "m2 s-1", &
                   "Diapycnal diffusivity at interfaces, interpolated to z", z_grid='z')
     CS%id_Kd_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
-    vd = var_desc("Tflx_dia_diff", "degC meter second-1", &
+    vd = var_desc("Tflx_dia_diff", "degC m s-1", &
                   "Diffusive diapycnal temperature flux across interfaces, interpolated to z", &
                   z_grid='z')
     CS%id_Tdif_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
-    vd = var_desc("Tflx_dia_adv", "degC meter second-1", &
+    vd = var_desc("Tflx_dia_adv", "degC m s-1", &
                   "Advective diapycnal temperature flux across interfaces, interpolated to z",&
                   z_grid='z')
     CS%id_Tadv_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
-    vd = var_desc("Sflx_dia_diff", "PSU meter second-1", &
+    vd = var_desc("Sflx_dia_diff", "psu m s-1", &
                   "Diffusive diapycnal salinity flux across interfaces, interpolated to z",&
                   z_grid='z')
     CS%id_Sdif_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
-    vd = var_desc("Sflx_dia_adv", "PSU meter second-1", &
+    vd = var_desc("Sflx_dia_adv", "psu m s-1", &
                   "Advective diapycnal salinity flux across interfaces, interpolated to z",&
                   z_grid='z')
     CS%id_Sadv_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
@@ -2059,20 +2059,20 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
 
   !call set_diffusivity_init(Time, G, param_file, diag, CS%set_diff_CSp, diag_to_Z_CSp, CS%int_tide_CSp)
   CS%id_Kd_interface = register_diag_field('ocean_model', 'Kd_interface', diag%axesTi, Time, &
-      'Total diapycnal diffusivity at interfaces', 'meter2 second-1')
+      'Total diapycnal diffusivity at interfaces', 'm2 s-1')
   if (CS%use_energetic_PBL) then
       CS%id_Kd_ePBL = register_diag_field('ocean_model', 'Kd_ePBL', diag%axesTi, Time, &
-          'ePBL diapycnal diffusivity at interfaces', 'meter2 second-1')
+          'ePBL diapycnal diffusivity at interfaces', 'm2 s-1')
   endif
 
   CS%id_Kd_heat = register_diag_field('ocean_model', 'Kd_heat', diag%axesTi, Time, &
-      'Total diapycnal diffusivity for heat at interfaces', 'meter2 second-1',     &
-       cmor_field_name='difvho', cmor_units='m2 s-1',                              &
+      'Total diapycnal diffusivity for heat at interfaces', 'm2 s-1',     &
+       cmor_field_name='difvho',                                                   &
        cmor_standard_name='ocean_vertical_heat_diffusivity',                       &
        cmor_long_name='Ocean vertical heat diffusivity')
   CS%id_Kd_salt = register_diag_field('ocean_model', 'Kd_salt', diag%axesTi, Time, &
-      'Total diapycnal diffusivity for salt at interfaces', 'meter2 second-1',     &
-       cmor_field_name='difvso', cmor_units='m2 s-1',                              &
+      'Total diapycnal diffusivity for salt at interfaces', 'm2 s-1',     &
+       cmor_field_name='difvso',                                                   &
        cmor_standard_name='ocean_vertical_salt_diffusivity',                       &
        cmor_long_name='Ocean vertical salt diffusivity')
 
@@ -2105,14 +2105,14 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
   if (CS%useALEalgorithm) then
     CS%id_diabatic_diff_temp_tend = register_diag_field('ocean_model', &
         'diabatic_diff_temp_tendency', diag%axesTL, Time,              &
-        'Diabatic diffusion temperature tendency', 'Degree C per second')
+        'Diabatic diffusion temperature tendency', 'degC s-1')
     if (CS%id_diabatic_diff_temp_tend > 0) then
       CS%diabatic_diff_tendency_diag = .true.
     endif
 
     CS%id_diabatic_diff_saln_tend = register_diag_field('ocean_model',&
         'diabatic_diff_saln_tendency', diag%axesTL, Time,             &
-        'Diabatic diffusion salinity tendency', 'PPT per second')
+        'Diabatic diffusion salinity tendency', 'psu s-1')
     if (CS%id_diabatic_diff_saln_tend > 0) then
       CS%diabatic_diff_tendency_diag = .true.
     endif
@@ -2120,7 +2120,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
     CS%id_diabatic_diff_heat_tend = register_diag_field('ocean_model',                                                 &
         'diabatic_heat_tendency', diag%axesTL, Time,                                                                   &
         'Diabatic diffusion heat tendency',                                                                            &
-        'Watts/m2',cmor_field_name='opottempdiff', cmor_units='W m-2',                                                 &
+        'W m-2',cmor_field_name='opottempdiff',                                                                        &
         cmor_standard_name=                                                                                            &
         'tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing',&
         cmor_long_name =                                                                                               &
@@ -2133,7 +2133,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
     CS%id_diabatic_diff_salt_tend = register_diag_field('ocean_model',                                     &
         'diabatic_salt_tendency', diag%axesTL, Time,                                                       &
         'Diabatic diffusion of salt tendency',                                                             &
-        'kg/(m2 * s)',cmor_field_name='osaltdiff', cmor_units='kg m-2 s-1',                                &
+        'kg m-2 s-1',cmor_field_name='osaltdiff',                                                          &
         cmor_standard_name=                                                                                &
         'tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_dianeutral_mixing', &
         cmor_long_name =                                                                                   &
@@ -2147,7 +2147,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
     CS%id_diabatic_diff_heat_tend_2d = register_diag_field('ocean_model',                                                               &
         'diabatic_heat_tendency_2d', diag%axesT1, Time,                                                                                 &
         'Depth integrated diabatic diffusion heat tendency',                                                                            &
-        'Watts/m2',cmor_field_name='opottempdiff_2d', cmor_units='W m-2',                                                               &
+        'W m-2',cmor_field_name='opottempdiff_2d',                                                                                      &
         cmor_standard_name=                                                                                                             &
         'tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing_depth_integrated',&
         cmor_long_name =                                                                                                                &
@@ -2160,7 +2160,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
     CS%id_diabatic_diff_salt_tend_2d = register_diag_field('ocean_model',                                                  &
         'diabatic_salt_tendency_2d', diag%axesT1, Time,                                                                    &
         'Depth integrated diabatic diffusion salt tendency',                                                               &
-        'kg/(m2 * s)',cmor_field_name='osaltdiff_2d', cmor_units='kg m-2 s-1',                                             &
+        'kg m-2 s-1',cmor_field_name='osaltdiff_2d',                                                                       &
         cmor_standard_name=                                                                                                &
         'tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_dianeutral_mixing_depth_integrated',&
         cmor_long_name =                                                                                                   &
@@ -2173,21 +2173,21 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
     ! available only for ALE algorithm.
     CS%id_boundary_forcing_temp_tend = register_diag_field('ocean_model',&
         'boundary_forcing_temp_tendency', diag%axesTL, Time,             &
-        'Boundary forcing temperature tendency', 'Degree C per second')
+        'Boundary forcing temperature tendency', 'degC s-1')
     if (CS%id_boundary_forcing_temp_tend > 0) then
       CS%boundary_forcing_tendency_diag = .true.
     endif
 
     CS%id_boundary_forcing_saln_tend = register_diag_field('ocean_model',&
         'boundary_forcing_saln_tendency', diag%axesTL, Time,             &
-        'Boundary forcing saln tendency', 'PPT per second')
+        'Boundary forcing saln tendency', 'psu s-1')
     if (CS%id_boundary_forcing_saln_tend > 0) then
       CS%boundary_forcing_tendency_diag = .true.
     endif
 
     CS%id_boundary_forcing_heat_tend = register_diag_field('ocean_model',&
         'boundary_forcing_heat_tendency', diag%axesTL, Time,             &
-        'Boundary forcing heat tendency','Watts/m2',                     &
+        'Boundary forcing heat tendency','W m-2',                        &
         v_extensive = .true.)
     if (CS%id_boundary_forcing_heat_tend > 0) then
       CS%boundary_forcing_tendency_diag = .true.
@@ -2204,7 +2204,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
     ! This diagnostic should equal to surface heat flux if all is working well.
     CS%id_boundary_forcing_heat_tend_2d = register_diag_field('ocean_model',&
         'boundary_forcing_heat_tendency_2d', diag%axesT1, Time,             &
-        'Depth integrated boundary forcing of ocean heat','Watts/m2')
+        'Depth integrated boundary forcing of ocean heat','W m-2')
     if (CS%id_boundary_forcing_heat_tend_2d > 0) then
       CS%boundary_forcing_tendency_diag = .true.
     endif
@@ -2223,7 +2223,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
   ! diagnostic for tendency of temp due to frazil
   CS%id_frazil_temp_tend = register_diag_field('ocean_model',&
       'frazil_temp_tendency', diag%axesTL, Time,             &
-      'Temperature tendency due to frazil formation', 'Degree C per second')
+      'Temperature tendency due to frazil formation', 'degC s-1')
   if (CS%id_frazil_temp_tend > 0) then
     CS%frazil_tendency_diag = .true.
   endif
@@ -2231,7 +2231,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
   ! diagnostic for tendency of heat due to frazil
   CS%id_frazil_heat_tend = register_diag_field('ocean_model',&
       'frazil_heat_tendency', diag%axesTL, Time,             &
-      'Heat tendency due to frazil formation','Watts/m2')
+      'Heat tendency due to frazil formation','W m-2')
   if (CS%id_frazil_heat_tend > 0) then
     CS%frazil_tendency_diag = .true.
   endif
@@ -2239,7 +2239,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
   ! if all is working propertly, this diagnostic should equal to hfsifrazil
   CS%id_frazil_heat_tend_2d = register_diag_field('ocean_model',&
       'frazil_heat_tendency_2d', diag%axesT1, Time,             &
-      'Depth integrated heat tendency due to frazil formation','Watts/m2')
+      'Depth integrated heat tendency due to frazil formation','W m-2')
   if (CS%id_frazil_heat_tend_2d > 0) then
     CS%frazil_tendency_diag = .true.
   endif

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -2247,51 +2247,50 @@ subroutine energetic_PBL_init(Time, G, GV, param_file, diag, CS)
   CS%ustar_min = 2e-4*CS%omega*(GV%Angstrom_z + GV%H_to_m*GV%H_subroundoff)
   call log_param(param_file, mdl, "EPBL_USTAR_MIN", CS%ustar_min, &
                  "The (tiny) minimum friction velocity used within the \n"//&
-                 "ePBL code, derived from OMEGA and ANGSTROM.", units="meter second-1")
+                 "ePBL code, derived from OMEGA and ANGSTROM.", units="m s-1")
 
   CS%id_ML_depth = register_diag_field('ocean_model', 'ePBL_h_ML', diag%axesT1, &
-      Time, 'Surface boundary layer depth', 'meter',                            &
-      cmor_long_name='Ocean Mixed Layer Thickness Defined by Mixing Scheme',    &
-      cmor_units='meter')
+      Time, 'Surface boundary layer depth', 'm',                            &
+      cmor_long_name='Ocean Mixed Layer Thickness Defined by Mixing Scheme')
   CS%id_TKE_wind = register_diag_field('ocean_model', 'ePBL_TKE_wind', diag%axesT1, &
-      Time, 'Wind-stirring source of mixed layer TKE', 'meter3 second-3')
+      Time, 'Wind-stirring source of mixed layer TKE', 'm3 s-3')
   CS%id_TKE_MKE = register_diag_field('ocean_model', 'ePBL_TKE_MKE', diag%axesT1, &
-      Time, 'Mean kinetic energy source of mixed layer TKE', 'meter3 second-3')
+      Time, 'Mean kinetic energy source of mixed layer TKE', 'm3 s-3')
   CS%id_TKE_conv = register_diag_field('ocean_model', 'ePBL_TKE_conv', diag%axesT1, &
-      Time, 'Convective source of mixed layer TKE', 'meter3 second-3')
+      Time, 'Convective source of mixed layer TKE', 'm3 s-3')
   CS%id_TKE_forcing = register_diag_field('ocean_model', 'ePBL_TKE_forcing', diag%axesT1, &
       Time, 'TKE consumed by mixing surface forcing or penetrative shortwave radation'//&
-            ' through model layers', 'meter3 second-3')
+            ' through model layers', 'm3 s-3')
   CS%id_TKE_mixing = register_diag_field('ocean_model', 'ePBL_TKE_mixing', diag%axesT1, &
-      Time, 'TKE consumed by mixing that deepens the mixed layer', 'meter3 second-3')
+      Time, 'TKE consumed by mixing that deepens the mixed layer', 'm3 s-3')
   CS%id_TKE_mech_decay = register_diag_field('ocean_model', 'ePBL_TKE_mech_decay', diag%axesT1, &
-      Time, 'Mechanical energy decay sink of mixed layer TKE', 'meter3 second-3')
+      Time, 'Mechanical energy decay sink of mixed layer TKE', 'm3 s-3')
   CS%id_TKE_conv_decay = register_diag_field('ocean_model', 'ePBL_TKE_conv_decay', diag%axesT1, &
-      Time, 'Convective energy decay sink of mixed layer TKE', 'meter3 second-3')
+      Time, 'Convective energy decay sink of mixed layer TKE', 'm3 s-3')
   CS%id_Hsfc_used = register_diag_field('ocean_model', 'ePBL_Hs_used', diag%axesT1, &
-      Time, 'Surface region thickness that is used', 'meter')
+      Time, 'Surface region thickness that is used', 'm')
   CS%id_Mixing_Length = register_diag_field('ocean_model', 'Mixing_Length', diag%axesTi, &
-      Time, 'Mixing Length that is used', 'meter')
+      Time, 'Mixing Length that is used', 'm')
   CS%id_Velocity_Scale = register_diag_field('ocean_model', 'Velocity_Scale', diag%axesTi, &
-      Time, 'Velocity Scale that is used.', 'meter second-1')
+      Time, 'Velocity Scale that is used.', 'm s-1')
   CS%id_LT_enhancement = register_diag_field('ocean_model', 'LT_Enhancement', diag%axesT1, &
-      Time, 'LT enhancement that is used.', 'non-dim')
+      Time, 'LT enhancement that is used.', 'nondim')
   CS%id_MSTAR_mix = register_diag_field('ocean_model', 'MSTAR', diag%axesT1, &
-      Time, 'MSTAR that is used.', 'non-dim')
+      Time, 'MSTAR that is used.', 'nondim')
   CS%id_OSBL = register_diag_field('ocean_model', 'ePBL_OSBL', diag%axesT1, &
-      Time, 'ePBL Surface Boundary layer depth.', 'meter')
+      Time, 'ePBL Surface Boundary layer depth.', 'm')
   ! BGR (9/21/2017) Note that ePBL_OSBL is the guess for iteration step while ePBL_h_ML is
   !                 result from iteration step.
   CS%id_mld_ekman = register_diag_field('ocean_model', 'MLD_EKMAN', diag%axesT1, &
-      Time, 'Boundary layer depth over Ekman length.', 'meter')
+      Time, 'Boundary layer depth over Ekman length.', 'm')
   CS%id_mld_obukhov = register_diag_field('ocean_model', 'MLD_OBUKHOV', diag%axesT1, &
-      Time, 'Boundary layer depth over Obukhov length.', 'meter')
+      Time, 'Boundary layer depth over Obukhov length.', 'm')
   CS%id_ekman_obukhov = register_diag_field('ocean_model', 'EKMAN_OBUKHOV', diag%axesT1, &
-      Time, 'Ekman length over Obukhov length.', 'meter')
+      Time, 'Ekman length over Obukhov length.', 'm')
   CS%id_LA = register_diag_field('ocean_model', 'LA', diag%axesT1, &
-      Time, 'Langmuir number.', 'non-dim')
+      Time, 'Langmuir number.', 'nondim')
   CS%id_LA_mod = register_diag_field('ocean_model', 'LA_MOD', diag%axesT1, &
-      Time, 'Modified Langmuir number.', 'non-dim')
+      Time, 'Modified Langmuir number.', 'nondim')
 
 
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", use_temperature, &

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -2241,7 +2241,7 @@ subroutine entrain_diffusive_init(Time, G, GV, param_file, diag, CS)
                  units="m", default=MAX(100.0*GV%Angstrom_Z,1.0e-4*sqrt(dt*Kd)))
 
   CS%id_Kd = register_diag_field('ocean_model', 'Kd_effective', diag%axesTL, Time, &
-      'Diapycnal diffusivity as applied', 'meter2 second-1')
+      'Diapycnal diffusivity as applied', 'm2 s-1')
   CS%id_diff_work = register_diag_field('ocean_model', 'diff_work', diag%axesTi, Time, &
       'Work actually done by diapycnal diffusion across each interface', 'W m-2')
 

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -380,10 +380,10 @@ subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
 
 
   CS%id_TKE_itidal = register_diag_field('ocean_model','TKE_itidal_itide',diag%axesT1,Time, &
-      'Internal Tide Driven Turbulent Kinetic Energy', 'Watt meter-2')
+      'Internal Tide Driven Turbulent Kinetic Energy', 'W m-2')
 
   CS%id_Nb = register_diag_field('ocean_model','Nb_itide',diag%axesT1,Time, &
-       'Bottom Buoyancy Frequency', 'sec-1')
+       'Bottom Buoyancy Frequency', 's-1')
 
   CS%id_N2_bot = register_diag_field('ocean_model','N2_b_itide',diag%axesT1,Time, &
        'Bottom Buoyancy frequency squared', 's-2')

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -1820,14 +1820,14 @@ logical function kappa_shear_init(Time, G, GV, param_file, diag, CS)
   CS%diag => diag
 
   CS%id_Kd_shear = register_diag_field('ocean_model','Kd_shear',diag%axesTi,Time, &
-      'Shear-driven Diapycnal Diffusivity', 'meter2 second-1')
+      'Shear-driven Diapycnal Diffusivity', 'm2 s-1')
   CS%id_TKE = register_diag_field('ocean_model','TKE_shear',diag%axesTi,Time, &
-      'Shear-driven Turbulent Kinetic Energy', 'meter2 second-2')
+      'Shear-driven Turbulent Kinetic Energy', 'm2 s-2')
 #ifdef ADD_DIAGNOSTICS
   CS%id_ILd2 = register_diag_field('ocean_model','ILd2_shear',diag%axesTi,Time, &
-      'Inverse kappa decay scale at interfaces', 'meter-2')
+      'Inverse kappa decay scale at interfaces', 'm-2')
   CS%id_dz_Int = register_diag_field('ocean_model','dz_Int_shear',diag%axesTi,Time, &
-      'Finite volume thickness of interfaces', 'meter')
+      'Finite volume thickness of interfaces', 'm')
 #endif
 
 end function kappa_shear_init

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -653,19 +653,19 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
   allocate(CS%id_opacity(optics%nbands)) ; CS%id_opacity(:) = -1
 
   CS%id_sw_pen = register_diag_field('ocean_model', 'SW_pen', diag%axesT1, Time, &
-      'Penetrating shortwave radiation flux into ocean', 'Watt meter-2')
+      'Penetrating shortwave radiation flux into ocean', 'W m-2')
   CS%id_sw_vis_pen = register_diag_field('ocean_model', 'SW_vis_pen', diag%axesT1, Time, &
-      'Visible penetrating shortwave radiation flux into ocean', 'Watt meter-2')
+      'Visible penetrating shortwave radiation flux into ocean', 'W m-2')
   do n=1,optics%nbands
     write(bandnum,'(i3)') n
     shortname = 'opac_'//trim(adjustl(bandnum))
     longname = 'Opacity for shortwave radiation in band '//trim(adjustl(bandnum))
     CS%id_opacity(n) = register_diag_field('ocean_model', shortname, diag%axesTL, Time, &
-      longname, 'meter-1')
+      longname, 'm-1')
   enddo
   if (CS%var_pen_sw) &
     CS%id_chl = register_diag_field('ocean_model', 'Chl_opac', diag%axesT1, Time, &
-        'Surface chlorophyll A concentration used to find opacity', 'mg meter-3')
+        'Surface chlorophyll A concentration used to find opacity', 'mg m-3')
 
 
 end subroutine opacity_init

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -1019,13 +1019,13 @@ subroutine regularize_layers_init(Time, G, param_file, diag, CS)
                  default=.true.)
 
   CS%id_def_rat = register_diag_field('ocean_model', 'deficit_ratio', diag%axesT1, &
-      Time, 'Max face thickness deficit ratio', 'Nondim')
+      Time, 'Max face thickness deficit ratio', 'nondim')
 
 #ifdef DEBUG_CODE
   CS%id_def_rat_2 = register_diag_field('ocean_model', 'deficit_rat2', diag%axesT1, &
-      Time, 'Corrected thickness deficit ratio', 'Nondim')
+      Time, 'Corrected thickness deficit ratio', 'nondim')
   CS%id_def_rat_3 = register_diag_field('ocean_model', 'deficit_rat3', diag%axesT1, &
-      Time, 'Filtered thickness deficit ratio', 'Nondim')
+      Time, 'Filtered thickness deficit ratio', 'nondim')
   CS%id_e1 = register_diag_field('ocean_model', 'er_1', diag%axesTi, &
       Time, 'Intial interface depths before remapping', 'm')
   CS%id_e2 = register_diag_field('ocean_model', 'er_2', diag%axesTi, &
@@ -1034,30 +1034,30 @@ subroutine regularize_layers_init(Time, G, param_file, diag, CS)
       Time, 'Intial interface depths filtered', 'm')
 
   CS%id_def_rat_u = register_diag_field('ocean_model', 'defrat_u', diag%axesCu1, &
-      Time, 'U-point thickness deficit ratio', 'Nondim')
+      Time, 'U-point thickness deficit ratio', 'nondim')
   CS%id_def_rat_u_1b = register_diag_field('ocean_model', 'defrat_u_1b', diag%axesCu1, &
-      Time, 'U-point 2-layer thickness deficit ratio', 'Nondim')
+      Time, 'U-point 2-layer thickness deficit ratio', 'nondim')
   CS%id_def_rat_u_2 = register_diag_field('ocean_model', 'defrat_u_2', diag%axesCu1, &
-      Time, 'U-point corrected thickness deficit ratio', 'Nondim')
+      Time, 'U-point corrected thickness deficit ratio', 'nondim')
   CS%id_def_rat_u_2b = register_diag_field('ocean_model', 'defrat_u_2b', diag%axesCu1, &
-      Time, 'U-point corrected 2-layer thickness deficit ratio', 'Nondim')
+      Time, 'U-point corrected 2-layer thickness deficit ratio', 'nondim')
   CS%id_def_rat_u_3 = register_diag_field('ocean_model', 'defrat_u_3', diag%axesCu1, &
-      Time, 'U-point filtered thickness deficit ratio', 'Nondim')
+      Time, 'U-point filtered thickness deficit ratio', 'nondim')
   CS%id_def_rat_u_3b = register_diag_field('ocean_model', 'defrat_u_3b', diag%axesCu1, &
-      Time, 'U-point filtered 2-layer thickness deficit ratio', 'Nondim')
+      Time, 'U-point filtered 2-layer thickness deficit ratio', 'nondim')
 
   CS%id_def_rat_v = register_diag_field('ocean_model', 'defrat_v', diag%axesCv1, &
-      Time, 'V-point thickness deficit ratio', 'Nondim')
+      Time, 'V-point thickness deficit ratio', 'nondim')
   CS%id_def_rat_v_1b = register_diag_field('ocean_model', 'defrat_v_1b', diag%axesCv1, &
-      Time, 'V-point 2-layer thickness deficit ratio', 'Nondim')
+      Time, 'V-point 2-layer thickness deficit ratio', 'nondim')
   CS%id_def_rat_v_2 = register_diag_field('ocean_model', 'defrat_v_2', diag%axesCv1, &
-      Time, 'V-point corrected thickness deficit ratio', 'Nondim')
+      Time, 'V-point corrected thickness deficit ratio', 'nondim')
   CS%id_def_rat_v_2b = register_diag_field('ocean_model', 'defrat_v_2b', diag%axesCv1, &
-      Time, 'V-point corrected 2-layer thickness deficit ratio', 'Nondim')
+      Time, 'V-point corrected 2-layer thickness deficit ratio', 'nondim')
   CS%id_def_rat_v_3 = register_diag_field('ocean_model', 'defrat_v_3', diag%axesCv1, &
-      Time, 'V-point filtered thickness deficit ratio', 'Nondim')
+      Time, 'V-point filtered thickness deficit ratio', 'nondim')
   CS%id_def_rat_v_3b = register_diag_field('ocean_model', 'defrat_v_3b', diag%axesCv1, &
-      Time, 'V-point filtered 2-layer thickness deficit ratio', 'Nondim')
+      Time, 'V-point filtered 2-layer thickness deficit ratio', 'nondim')
 #endif
 
   if(CS%allow_clocks_in_omp_loops) then

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -2699,7 +2699,7 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
     CS%use_LOTW_BBL_diffusivity = .false. ! This parameterization depends on a u* from viscous BBL
   endif
   CS%id_Kd_BBL = register_diag_field('ocean_model','Kd_BBL',diag%axesTi,Time, &
-       'Bottom Boundary Layer Diffusivity', 'meter2 sec-1')
+       'Bottom Boundary Layer Diffusivity', 'm2 s-1')
   call get_param(param_file, mdl, "SIMPLE_TKE_TO_KD", CS%simple_TKE_to_Kd, &
                  "If true, uses a simple estimate of Kd/TKE that will\n"//&
                  "work for arbitrary vertical coordinates. If false,\n"//&
@@ -3016,7 +3016,7 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
   endif
 
   CS%id_Kd_layer = register_diag_field('ocean_model', 'Kd_layer', diag%axesTL, Time, &
-      'Diapycnal diffusivity of layers (as set)', 'meter2 second-1')
+      'Diapycnal diffusivity of layers (as set)', 'm2 s-1')
 
   if (CS%Lee_wave_dissipation) then
 
@@ -3047,9 +3047,9 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
                  default=1.0)
 
     CS%id_TKE_leewave = register_diag_field('ocean_model','TKE_leewave',diag%axesT1,Time, &
-        'Lee wave Driven Turbulent Kinetic Energy', 'Watt meter-2')
+        'Lee wave Driven Turbulent Kinetic Energy', 'W m-2')
     CS%id_Kd_Niku = register_diag_field('ocean_model','Kd_Nikurashin',diag%axesTi,Time, &
-         'Lee Wave Driven Diffusivity', 'meter2 sec-1')
+         'Lee Wave Driven Diffusivity', 'm2 s-1')
   else
     CS%Decay_scale_factor_lee = -9.e99 ! This should never be used if CS%Lee_wave_dissipation = False
   endif
@@ -3058,32 +3058,32 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
       CS%Lowmode_itidal_dissipation) then
 
     CS%id_TKE_itidal = register_diag_field('ocean_model','TKE_itidal',diag%axesT1,Time, &
-        'Internal Tide Driven Turbulent Kinetic Energy', 'Watt meter-2')
+        'Internal Tide Driven Turbulent Kinetic Energy', 'W m-2')
     CS%id_maxTKE = register_diag_field('ocean_model','maxTKE',diag%axesTL,Time, &
-           'Maximum layer TKE', 'meter3 second-3')
+           'Maximum layer TKE', 'm3 s-3')
     CS%id_TKE_to_Kd = register_diag_field('ocean_model','TKE_to_Kd',diag%axesTL,Time, &
-           'Convert TKE to Kd', 'second2 meter')
+           'Convert TKE to Kd', 's2 m')
 
     CS%id_Nb = register_diag_field('ocean_model','Nb',diag%axesT1,Time, &
-         'Bottom Buoyancy Frequency', 'sec-1')
+         'Bottom Buoyancy Frequency', 's-1')
 
     CS%id_Kd_itidal = register_diag_field('ocean_model','Kd_itides',diag%axesTi,Time, &
-         'Internal Tide Driven Diffusivity', 'meter2 sec-1')
+         'Internal Tide Driven Diffusivity', 'm2 s-1')
 
     CS%id_Kd_lowmode = register_diag_field('ocean_model','Kd_lowmode',diag%axesTi,Time, &
-         'Internal Tide Driven Diffusivity (from propagating low modes)', 'meter2 sec-1')
+         'Internal Tide Driven Diffusivity (from propagating low modes)', 'm2 s-1')
 
     CS%id_Fl_itidal = register_diag_field('ocean_model','Fl_itides',diag%axesTi,Time, &
-        'Vertical flux of tidal turbulent dissipation', 'meter3 sec-3')
+        'Vertical flux of tidal turbulent dissipation', 'm3 s-3')
 
     CS%id_Fl_lowmode = register_diag_field('ocean_model','Fl_lowmode',diag%axesTi,Time, &
-         'Vertical flux of tidal turbulent dissipation (from propagating low modes)', 'meter3 sec-3')
+         'Vertical flux of tidal turbulent dissipation (from propagating low modes)', 'm3 s-3')
 
     CS%id_Polzin_decay_scale = register_diag_field('ocean_model','Polzin_decay_scale',diag%axesT1,Time, &
-         'Vertical decay scale for the tidal turbulent dissipation with Polzin scheme', 'meter')
+         'Vertical decay scale for the tidal turbulent dissipation with Polzin scheme', 'm')
 
     CS%id_Polzin_decay_scale_scaled = register_diag_field('ocean_model','Polzin_decay_scale_scaled',diag%axesT1,Time, &
-         'Vertical decay scale for the tidal turbulent dissipation with Polzin scheme, scaled by N2_bot/N2_meanz', 'meter')
+         'Vertical decay scale for the tidal turbulent dissipation with Polzin scheme, scaled by N2_bot/N2_meanz', 'm')
 
     CS%id_N2_bot = register_diag_field('ocean_model','N2_b',diag%axesT1,Time, &
          'Bottom Buoyancy frequency squared', 's-2')
@@ -3092,40 +3092,40 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
          'Buoyancy frequency squared averaged over the water column', 's-2')
 
     CS%id_Kd_Work = register_diag_field('ocean_model','Kd_Work',diag%axesTL,Time, &
-         'Work done by Diapycnal Mixing', 'Watts m-2')
+         'Work done by Diapycnal Mixing', 'W m-2')
 
     CS%id_Kd_Itidal_Work = register_diag_field('ocean_model','Kd_Itidal_Work',diag%axesTL,Time, &
-         'Work done by Internal Tide Diapycnal Mixing', 'Watts m-2')
+         'Work done by Internal Tide Diapycnal Mixing', 'W m-2')
 
     CS%id_Kd_Niku_Work = register_diag_field('ocean_model','Kd_Nikurashin_Work',diag%axesTL,Time, &
-         'Work done by Nikurashin Lee Wave Drag Scheme', 'Watts m-2')
+         'Work done by Nikurashin Lee Wave Drag Scheme', 'W m-2')
 
     CS%id_Kd_Lowmode_Work = register_diag_field('ocean_model','Kd_Lowmode_Work',diag%axesTL,Time, &
-         'Work done by Internal Tide Diapycnal Mixing (low modes)', 'Watts m-2')
+         'Work done by Internal Tide Diapycnal Mixing (low modes)', 'W m-2')
 
     CS%id_N2 = register_diag_field('ocean_model','N2',diag%axesTi,Time,            &
-         'Buoyancy frequency squared', 'sec-2', cmor_field_name='obvfsq',          &
-          cmor_units='s-2', cmor_long_name='Square of seawater buoyancy frequency',&
+         'Buoyancy frequency squared', 's-2', cmor_field_name='obvfsq',          &
+          cmor_long_name='Square of seawater buoyancy frequency',&
           cmor_standard_name='square_of_brunt_vaisala_frequency_in_sea_water')
 
     if (CS%user_change_diff) &
       CS%id_Kd_user = register_diag_field('ocean_model','Kd_user',diag%axesTi,Time, &
-           'User-specified Extra Diffusivity', 'meter2 sec-1')
+           'User-specified Extra Diffusivity', 'm2 s-1')
 
     if (associated(diag_to_Z_CSp)) then
-      vd = var_desc("N2", "second-2",&
+      vd = var_desc("N2", "s-2",&
                     "Buoyancy frequency, interpolated to z", z_grid='z')
       CS%id_N2_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
-      vd = var_desc("Kd_itides","meter2 second-1", &
+      vd = var_desc("Kd_itides","m2 s-1", &
                     "Internal Tide Driven Diffusivity, interpolated to z", z_grid='z')
       CS%id_Kd_itidal_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
       if (CS%Lee_wave_dissipation) then
-         vd = var_desc("Kd_Nikurashin", "meter2 second-1", &
+         vd = var_desc("Kd_Nikurashin", "m2 s-1", &
                        "Lee Wave Driven Diffusivity, interpolated to z", z_grid='z')
          CS%id_Kd_Niku_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
       endif
       if (CS%Lowmode_itidal_dissipation) then
-        vd = var_desc("Kd_lowmode","meter2 second-1", &
+        vd = var_desc("Kd_lowmode","m2 s-1", &
                   "Internal Tide Driven Diffusivity (from low modes), interpolated to z",&
                   z_grid='z')
         CS%id_Kd_lowmode_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
@@ -3152,21 +3152,21 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
     ! The default molecular viscosity follows the CCSM4.0 and MOM4p1 defaults.
 
     CS%id_KT_extra = register_diag_field('ocean_model','KT_extra',diag%axesTi,Time, &
-         'Double-diffusive diffusivity for temperature', 'meter2 sec-1')
+         'Double-diffusive diffusivity for temperature', 'm2 s-1')
 
     CS%id_KS_extra = register_diag_field('ocean_model','KS_extra',diag%axesTi,Time, &
-         'Double-diffusive diffusivity for salinity', 'meter2 sec-1')
+         'Double-diffusive diffusivity for salinity', 'm2 s-1')
 
     if (associated(diag_to_Z_CSp)) then
-      vd = var_desc("KT_extra", "meter2 second-1", &
+      vd = var_desc("KT_extra", "m2 s-1", &
                     "Double-Diffusive Temperature Diffusivity, interpolated to z", &
                     z_grid='z')
       CS%id_KT_extra_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
-      vd = var_desc("KS_extra", "meter2 second-1", &
+      vd = var_desc("KS_extra", "m2 s-1", &
                     "Double-Diffusive Salinity Diffusivity, interpolated to z",&
                     z_grid='z')
       CS%id_KS_extra_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
-      vd = var_desc("Kd_BBL", "meter2 second-1", &
+      vd = var_desc("Kd_BBL", "m2 s-1", &
                     "Bottom Boundary Layer Diffusivity", z_grid='z')
       CS%id_Kd_BBL_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
     endif

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2020,21 +2020,21 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
     allocate(visc%TKE_bbl(isd:ied,jsd:jed)) ; visc%TKE_bbl = 0.0
 
     CS%id_bbl_thick_u = register_diag_field('ocean_model', 'bbl_thick_u', &
-       diag%axesCu1, Time, 'BBL thickness at u points', 'meter')
+       diag%axesCu1, Time, 'BBL thickness at u points', 'm')
     CS%id_kv_bbl_u = register_diag_field('ocean_model', 'kv_bbl_u', diag%axesCu1, &
-       Time, 'BBL viscosity at u points', 'meter2 second-1')
+       Time, 'BBL viscosity at u points', 'm2 s-1')
     CS%id_bbl_thick_v = register_diag_field('ocean_model', 'bbl_thick_v', &
-       diag%axesCv1, Time, 'BBL thickness at v points', 'meter')
+       diag%axesCv1, Time, 'BBL thickness at v points', 'm')
     CS%id_kv_bbl_v = register_diag_field('ocean_model', 'kv_bbl_v', diag%axesCv1, &
-       Time, 'BBL viscosity at v points', 'meter2 second-1')
+       Time, 'BBL viscosity at v points', 'm2 s-1')
   endif
   if (CS%Channel_drag) then
     allocate(visc%Ray_u(IsdB:IedB,jsd:jed,nz)) ; visc%Ray_u = 0.0
     allocate(visc%Ray_v(isd:ied,JsdB:JedB,nz)) ; visc%Ray_v = 0.0
     CS%id_Ray_u = register_diag_field('ocean_model', 'Rayleigh_u', diag%axesCuL, &
-       Time, 'Rayleigh drag velocity at u points', 'meter second-1')
+       Time, 'Rayleigh drag velocity at u points', 'm s-1')
     CS%id_Ray_v = register_diag_field('ocean_model', 'Rayleigh_v', diag%axesCvL, &
-       Time, 'Rayleigh drag velocity at v points', 'meter second-1')
+       Time, 'Rayleigh drag velocity at v points', 'm s-1')
   endif
 
   if (differential_diffusion) then
@@ -2046,9 +2046,9 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
     allocate(visc%nkml_visc_u(IsdB:IedB,jsd:jed)) ; visc%nkml_visc_u = 0.0
     allocate(visc%nkml_visc_v(isd:ied,JsdB:JedB)) ; visc%nkml_visc_v = 0.0
     CS%id_nkml_visc_u = register_diag_field('ocean_model', 'nkml_visc_u', &
-       diag%axesCu1, Time, 'Number of layers in viscous mixed layer at u points', 'meter')
+       diag%axesCu1, Time, 'Number of layers in viscous mixed layer at u points', 'm')
     CS%id_nkml_visc_v = register_diag_field('ocean_model', 'nkml_visc_v', &
-       diag%axesCv1, Time, 'Number of layers in viscous mixed layer at v points', 'meter')
+       diag%axesCv1, Time, 'Number of layers in viscous mixed layer at v points', 'm')
   endif
 
   CS%Hbbl = CS%Hbbl * GV%m_to_H

--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -246,7 +246,7 @@ subroutine init_sponge_diags(Time, G, diag, CS)
 
   CS%diag => diag
   CS%id_w_sponge = register_diag_field('ocean_model', 'w_sponge', diag%axesTi, &
-      Time, 'The diapycnal motion due to the sponges', 'meter second-1')
+      Time, 'The diapycnal motion due to the sponges', 'm s-1')
 
 end subroutine init_sponge_diags
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1473,7 +1473,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_vert_friction" ! This module's name.
-  character(len=40)  :: thickness_units = "meters or kg m-2"
+  character(len=40)  :: thickness_units
 
   if (associated(CS)) then
     call MOM_error(WARNING, "vertvisc_init called with an associated "// &
@@ -1481,6 +1481,9 @@ subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
     return
   endif
   allocate(CS)
+
+  if (GV%Boussinesq) then; thickness_units = "m"
+  else; thickness_units = "kg m-2"; endif
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = G%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -1598,9 +1601,9 @@ subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
   ALLOC_(CS%h_v(isd:ied,JsdB:JedB,nz))   ; CS%h_v(:,:,:) = 0.0
 
   CS%id_au_vv = register_diag_field('ocean_model', 'au_visc', diag%axesCui, Time, &
-     'Zonal Viscous Vertical Coupling Coefficient', 'meter second-1')
+     'Zonal Viscous Vertical Coupling Coefficient', 'm s-1')
   CS%id_av_vv = register_diag_field('ocean_model', 'av_visc', diag%axesCvi, Time, &
-     'Meridional Viscous Vertical Coupling Coefficient', 'meter second-1')
+     'Meridional Viscous Vertical Coupling Coefficient', 'm s-1')
 
   CS%id_h_u = register_diag_field('ocean_model', 'Hu_visc', diag%axesCuL, Time, &
      'Thickness at Zonal Velocity Points for Viscosity', thickness_units)
@@ -1612,10 +1615,10 @@ subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
      'Mixed Layer Thickness at Meridional Velocity Points for Viscosity', thickness_units)
 
   CS%id_du_dt_visc = register_diag_field('ocean_model', 'du_dt_visc', diag%axesCuL, &
-     Time, 'Zonal Acceleration from Vertical Viscosity', 'meter second-2')
+     Time, 'Zonal Acceleration from Vertical Viscosity', 'm s-2')
   if (CS%id_du_dt_visc > 0) call safe_alloc_ptr(ADp%du_dt_visc,IsdB,IedB,jsd,jed,nz)
   CS%id_dv_dt_visc = register_diag_field('ocean_model', 'dv_dt_visc', diag%axesCvL, &
-     Time, 'Meridional Acceleration from Vertical Viscosity', 'meter second-2')
+     Time, 'Meridional Acceleration from Vertical Viscosity', 'm s-2')
   if (CS%id_dv_dt_visc > 0) call safe_alloc_ptr(ADp%dv_dt_visc,isd,ied,JsdB,JedB,nz)
 
   CS%id_taux_bot = register_diag_field('ocean_model', 'taux_bot', diag%axesCu1, &

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -243,12 +243,12 @@ subroutine neutral_diffusion_diag_init(Time, G, diag, C_p, Reg, CS)
       CS%id_neutral_diff_tracer_conc_tend(n) = register_diag_field('ocean_model',  &
       'ndiff_tracer_conc_tendency_'//trim(Reg%Tr(n)%name), diag%axesTL, Time,      &
       'Neutral diffusion tracer concentration tendency for '//trim(Reg%Tr(n)%name),&
-       'Degree C per second')
+      'degC s-1')
 
       CS%id_neutral_diff_tracer_cont_tend(n) = register_diag_field('ocean_model',                                      &
       'ndiff_tracer_cont_tendency_'//trim(Reg%Tr(n)%name), diag%axesTL, Time,                                          &
       'Neutral diffusion tracer content tendency for '//trim(Reg%Tr(n)%name),                                          &
-      'Watts/m2',cmor_field_name='opottemppmdiff', cmor_units='W m-2',                                                 &
+      'W m-2',cmor_field_name='opottemppmdiff',                                                                     &
       cmor_standard_name=                                                                                              &
       'tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesocale_diffusion', &
       cmor_long_name =                                                                                                 &
@@ -258,7 +258,7 @@ subroutine neutral_diffusion_diag_init(Time, G, diag, C_p, Reg, CS)
       CS%id_neutral_diff_tracer_cont_tend_2d(n) = register_diag_field('ocean_model',                                                   &
       'ndiff_tracer_cont_tendency_2d_'//trim(Reg%Tr(n)%name), diag%axesT1, Time,                                                       &
       'Depth integrated neutral diffusion tracer content tendency for '//trim(Reg%Tr(n)%name),                                         &
-      'Watts/m2',cmor_field_name='opottemppmdiff_2d', cmor_units='W m-2',                                                              &
+      'W m-2',cmor_field_name='opottemppmdiff_2d',                                                                                  &
       cmor_standard_name=                                                                                                              &
       'tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesocale_diffusion_depth_integrated',&
       cmor_long_name =                                                                                                                 &
@@ -267,24 +267,24 @@ subroutine neutral_diffusion_diag_init(Time, G, diag, C_p, Reg, CS)
       CS%id_neutral_diff_tracer_trans_x_2d(n) = register_diag_field('ocean_model',           &
       'ndiff_tracer_trans_x_2d_'//trim(Reg%Tr(n)%name), diag%axesCu1, Time,                  &
       'Depth integrated neutral diffusion zonal tracer transport for '//trim(Reg%Tr(n)%name),&
-      'Watts')
+      'W')
 
       CS%id_neutral_diff_tracer_trans_y_2d(n) = register_diag_field('ocean_model',           &
       'ndiff_tracer_trans_y_2d_'//trim(Reg%Tr(n)%name), diag%axesCv1, Time,                  &
       'Depth integrated neutral diffusion merid tracer transport for '//trim(Reg%Tr(n)%name),&
-      'Watts')
+      'W')
 
     elseif(trim(Reg%Tr(n)%name) == 'S') then
 
       CS%id_neutral_diff_tracer_conc_tend(n) = register_diag_field('ocean_model',  &
       'ndiff_tracer_conc_tendency_'//trim(Reg%Tr(n)%name), diag%axesTL, Time,      &
       'Neutral diffusion tracer concentration tendency for '//trim(Reg%Tr(n)%name),&
-       'tracer concentration units per second')
+      'tracer concentration * s-1')
 
       CS%id_neutral_diff_tracer_cont_tend(n) = register_diag_field('ocean_model',                         &
       'ndiff_tracer_cont_tendency_'//trim(Reg%Tr(n)%name), diag%axesTL, Time,                             &
       'Neutral diffusion tracer content tendency for '//trim(Reg%Tr(n)%name),                             &
-      'kg m-2 s-1',cmor_field_name='osaltpmdiff', cmor_units='kg m-2 s-1',                                &
+      'kg m-2 s-1',cmor_field_name='osaltpmdiff',                                                         &
       cmor_standard_name=                                                                                 &
       'tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesocale_diffusion', &
       cmor_long_name =                                                                                    &
@@ -294,7 +294,7 @@ subroutine neutral_diffusion_diag_init(Time, G, diag, C_p, Reg, CS)
       CS%id_neutral_diff_tracer_cont_tend_2d(n) = register_diag_field('ocean_model',                                      &
       'ndiff_tracer_cont_tendency_2d_'//trim(Reg%Tr(n)%name), diag%axesT1, Time,                                          &
       'Depth integrated neutral diffusion tracer content tendency for '//trim(Reg%Tr(n)%name),                            &
-      'kg m-2 s-1',cmor_field_name='osaltpmdiff_2d', cmor_units='kg m-2 s-1',                                             &
+      'kg m-2 s-1',cmor_field_name='osaltpmdiff_2d',                                                                      &
       cmor_standard_name=                                                                                                 &
       'tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesocale_diffusion_depth_integrated',&
       cmor_long_name =                                                                                                    &
@@ -303,12 +303,12 @@ subroutine neutral_diffusion_diag_init(Time, G, diag, C_p, Reg, CS)
       CS%id_neutral_diff_tracer_trans_x_2d(n) = register_diag_field('ocean_model',           &
       'ndiff_tracer_trans_x_2d_'//trim(Reg%Tr(n)%name), diag%axesCu1, Time,                  &
       'Depth integrated neutral diffusion zonal tracer transport for '//trim(Reg%Tr(n)%name),&
-      'kg/s')
+      'kg s-1')
 
       CS%id_neutral_diff_tracer_trans_y_2d(n) = register_diag_field('ocean_model',           &
       'ndiff_tracer_trans_y_2d_'//trim(Reg%Tr(n)%name), diag%axesCv1, Time,                  &
       'Depth integrated neutral diffusion merid tracer transport for '//trim(Reg%Tr(n)%name),&
-      'kg/s')
+      'kg s-1')
 
     else
 
@@ -330,12 +330,12 @@ subroutine neutral_diffusion_diag_init(Time, G, diag, C_p, Reg, CS)
       CS%id_neutral_diff_tracer_trans_x_2d(n) = register_diag_field('ocean_model',           &
       'ndiff_tracer_trans_x_2d_'//trim(Reg%Tr(n)%name), diag%axesCu1, Time,                  &
       'Depth integrated neutral diffusion zonal tracer transport for '//trim(Reg%Tr(n)%name),&
-      'kg/s')
+      'kg s-1')
 
       CS%id_neutral_diff_tracer_trans_y_2d(n) = register_diag_field('ocean_model',           &
       'ndiff_tracer_trans_y_2d_'//trim(Reg%Tr(n)%name), diag%axesCv1, Time,                  &
       'Depth integrated neutral diffusion merid tracer transport for '//trim(Reg%Tr(n)%name),&
-      'kg/s')
+      'kg s-1')
 
     endif
 

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -1412,22 +1412,22 @@ subroutine tracer_hor_diff_init(Time, G, param_file, diag, CS, CSnd)
   CS%id_CFL    = -1
 
   CS%id_KhTr_u = register_diag_field('ocean_model', 'KHTR_u', diag%axesCu1, Time, &
-     'Epipycnal tracer diffusivity at zonal faces of tracer cell', 'meter2 second-1')
+     'Epipycnal tracer diffusivity at zonal faces of tracer cell', 'm2 s-1')
   CS%id_KhTr_v = register_diag_field('ocean_model', 'KHTR_v', diag%axesCv1, Time, &
-     'Epipycnal tracer diffusivity at meridional faces of tracer cell', 'meter2 second-1')
+     'Epipycnal tracer diffusivity at meridional faces of tracer cell', 'm2 s-1')
   CS%id_KhTr_h = register_diag_field('ocean_model', 'KHTR_h', diag%axesT1, Time,&
-     'Epipycnal tracer diffusivity at tracer cell center', 'meter2 second-1',   &
-     cmor_field_name='diftrelo', cmor_units='m2 sec-1',                         &
+     'Epipycnal tracer diffusivity at tracer cell center', 'm2 s-1',   &
+     cmor_field_name='diftrelo',                                                &
      cmor_standard_name= 'ocean_tracer_epineutral_laplacian_diffusivity',       &
      cmor_long_name = 'Ocean Tracer Epineutral Laplacian Diffusivity')
 
   CS%id_khdt_x = register_diag_field('ocean_model', 'KHDT_x', diag%axesCu1, Time, &
-     'Epipycnal tracer diffusivity operator at zonal faces of tracer cell', 'meter2')
+     'Epipycnal tracer diffusivity operator at zonal faces of tracer cell', 'm2')
   CS%id_khdt_y = register_diag_field('ocean_model', 'KHDT_y', diag%axesCv1, Time, &
-     'Epipycnal tracer diffusivity operator at meridional faces of tracer cell', 'meter2')
+     'Epipycnal tracer diffusivity operator at meridional faces of tracer cell', 'm2')
   if (CS%check_diffusive_CFL) then
     CS%id_CFL = register_diag_field('ocean_model', 'CFL_lateral_diff', diag%axesT1, Time,&
-       'Grid CFL number for lateral/neutral tracer diffusion', 'dimensionless')
+       'Grid CFL number for lateral/neutral tracer diffusion', 'nondim')
   endif
 
 

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -203,14 +203,14 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   CS%ntr = 0
   if (do_ideal_age) then
     CS%ntr = CS%ntr + 1 ; m = CS%ntr
-    CS%tr_desc(m) = var_desc("age", "years", "Ideal Age Tracer", cmor_field_name="agessc", caller=mdl)
+    CS%tr_desc(m) = var_desc("age", "yr", "Ideal Age Tracer", cmor_field_name="agessc", caller=mdl)
     CS%tracer_ages(m) = .true. ; CS%sfc_growth_rate(m) = 0.0
     CS%IC_val(m) = 0.0 ; CS%young_val(m) = 0.0 ; CS%tracer_start_year(m) = 0.0
   endif
 
   if (do_vintage) then
     CS%ntr = CS%ntr + 1 ; m = CS%ntr
-    CS%tr_desc(m) = var_desc("vintage", "years", "Exponential Vintage Tracer", &
+    CS%tr_desc(m) = var_desc("vintage", "yr", "Exponential Vintage Tracer", &
                             caller=mdl)
     CS%tracer_ages(m) = .false. ; CS%sfc_growth_rate(m) = 1.0/30.0
     CS%IC_val(m) = 0.0 ; CS%young_val(m) = 1e-20 ; CS%tracer_start_year(m) = 0.0
@@ -221,7 +221,7 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 
   if (do_ideal_age_dated) then
     CS%ntr = CS%ntr + 1 ; m = CS%ntr
-    CS%tr_desc(m) = var_desc("age_dated","years","Ideal Age Tracer with a Start Date",&
+    CS%tr_desc(m) = var_desc("age_dated","yr","Ideal Age Tracer with a Start Date",&
                             caller=mdl)
     CS%tracer_ages(m) = .true. ; CS%sfc_growth_rate(m) = 0.0
     CS%IC_val(m) = 0.0 ; CS%young_val(m) = 0.0 ; CS%tracer_start_year(m) = 0.0
@@ -359,8 +359,8 @@ subroutine initialize_ideal_age_tracer(restart, day, G, GV, h, diag, OBC, CS, &
   endif
 
   ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "years m3 s-1"
-  else ; flux_units = "years kg s-1" ; endif
+  if (GV%Boussinesq) then ; flux_units = "yr m3 s-1"
+  else ; flux_units = "yr kg s-1" ; endif
 
   do m=1,CS%ntr
     call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -366,8 +366,8 @@ subroutine initialize_oil_tracer(restart, day, G, GV, h, diag, OBC, CS, &
   endif
 
   ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "years m3 s-1"
-  else ; flux_units = "years kg s-1" ; endif
+  if (GV%Boussinesq) then ; flux_units = "yr m3 s-1"
+  else ; flux_units = "yr kg s-1" ; endif
 
   do m=1,CS%ntr
     ! Register the tracer for the restart file.


### PR DESCRIPTION
- We were using a mix of styles for the units of diagnostic variables,
  such as "kilogram/(m^3 * sec)", "kg/m3/s", etc.
- All diagnostic output units now follow the style given at
  http://clipc-services.ceda.ac.uk/dreq/index/units.html
  with the exception of the units:
  - "none" and "nondim"
  - mg m-3 (for Chl)
  - tracer concentration * m-2 s-1 (and variants for arbitrary tracers)
- I've left (most) input parameter documented units unchanged.
- Closes NOAA-GFDL/MOM6-examples#165.