### PR TITLE
Apply conversion field for diagnostics only on non-missing values

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -615,7 +615,7 @@ subroutine post_data_2d_low(diag, field, diag_cs, is_static, mask)
 
   real, dimension(:,:), pointer :: locfield => NULL()
   logical :: used, is_stat
-  integer :: isv, iev, jsv, jev
+  integer :: isv, iev, jsv, jev, i, j
 
   is_stat = .false. ; if (present(is_static)) is_stat = is_static
 
@@ -651,6 +651,13 @@ subroutine post_data_2d_low(diag, field, diag_cs, is_static, mask)
 
   if (diag%conversion_factor/=0.) then
     allocate( locfield( lbound(field,1):ubound(field,1), lbound(field,2):ubound(field,2) ) )
+    do j=jsv,jev ; do i=isv,iev
+      if (field(i,j) == diag_cs%missing_value) then
+        locfield(i,j) = diag_cs%missing_value
+      else
+        locfield(i,j) = field(i,j) * diag%conversion_factor
+      endif
+    enddo ; enddo
     locfield(isv:iev,jsv:jev) = field(isv:iev,jsv:jev) * diag%conversion_factor
   else
     locfield => field
@@ -830,7 +837,7 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
   real, dimension(:,:,:), pointer :: locfield => NULL()
   logical :: used  ! The return value of send_data is not used for anything.
   logical :: is_stat
-  integer :: isv, iev, jsv, jev
+  integer :: isv, iev, jsv, jev, ks, ke, i, j, k
 
   is_stat = .false. ; if (present(is_static)) is_stat = is_static
 
@@ -865,9 +872,15 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
   endif
 
   if (diag%conversion_factor/=0.) then
-    allocate( locfield( lbound(field,1):ubound(field,1), lbound(field,2):ubound(field,2), &
-                        lbound(field,3):ubound(field,3) ) )
-    locfield(isv:iev,jsv:jev,:) = field(isv:iev,jsv:jev,:) * diag%conversion_factor
+    ks = lbound(field,3) ; ke = ubound(field,3)
+    allocate( locfield( lbound(field,1):ubound(field,1), lbound(field,2):ubound(field,2), ks:ke ) )
+    do k=ks,ke ; do j=jsv,jev ; do i=isv,iev
+      if (field(i,j,k) == diag_cs%missing_value) then
+        locfield(i,j,k) = diag_cs%missing_value
+      else
+        locfield(i,j,k) = field(i,j,k) * diag%conversion_factor
+      endif
+    enddo ; enddo ; enddo
   else
     locfield => field
   endif


### PR DESCRIPTION
If a diagnostic had a conversion factor associated with it, every value of
the array would be multiplied and then passed to send_data. However
because the remapping routines already fill the arrays with missing values,
this means that the places to be masked would actually have the value
missing_value*conversion leading to the output not being masked correctly.
Now, the locfield array is set to a missing value if the input field is,
and otherwise is the the value in the original array multiplied by the
conversion factor.