### PR TITLE
Fix i,j range when updating diagnostic grids

### DIFF
--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -248,8 +248,8 @@ subroutine diag_remap_update(remap_cs, G, h, T, S, eqn_of_state)
   ! Calculate remapping thicknesses for different target grids based on
   ! nominal/target interface locations. This happens for every call on the
   ! assumption that h, T, S has changed.
-  do j=G%jsd, G%jed
-    do i=G%isd, G%ied
+  do j=G%jsc-1, G%jec+1
+    do i=G%isc-1, G%iec+1
       if (G%mask2dT(i,j)==0.) then
         remap_cs%h(i,j,:) = 0.
         cycle


### PR DESCRIPTION
When updating the diagnostic grids for remapping, every column on the data
domain was being updated. This led to a scenario when called from ALE_main,
where there were garbage values 2 steps into the halo. The diagnostic
remapping does not need information more than one step into the halo and
the ranges of i and j have been updated.