### PR TITLE
Generates cell method "area" from axis methods

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3245,7 +3245,7 @@ subroutine write_static_fields(G, diag)
         'Surface area of tracer (T) cells', 'm2',                    &
         cmor_field_name='areacello', cmor_standard_name='cell_area', &
         cmor_long_name='Ocean Grid-Cell Area',      &
-        x_cell_method='sum', y_cell_method='sum')
+        x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
   if (id > 0) then
     call post_data(id, G%areaT, diag, .true., mask=G%mask2dT)
     call diag_register_area_ids(diag, id_area_t=id)
@@ -3255,7 +3255,7 @@ subroutine write_static_fields(G, diag)
         'Surface area of x-direction flow (U) cells', 'm2',             &
         cmor_field_name='areacello_cu', cmor_standard_name='cell_area', &
         cmor_long_name='Ocean Grid-Cell Area',         &
-        x_cell_method='sum', y_cell_method='sum')
+        x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
   if (id > 0) then
     call post_data(id, G%areaCu, diag, .true., mask=G%mask2dCu)
   endif
@@ -3264,7 +3264,7 @@ subroutine write_static_fields(G, diag)
         'Surface area of y-direction flow (V) cells', 'm2',             &
         cmor_field_name='areacello_cv', cmor_standard_name='cell_area', &
         cmor_long_name='Ocean Grid-Cell Area',         &
-        x_cell_method='sum', y_cell_method='sum')
+        x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
   if (id > 0) then
     call post_data(id, G%areaCv, diag, .true., mask=G%mask2dCv)
   endif
@@ -3273,7 +3273,7 @@ subroutine write_static_fields(G, diag)
         'Surface area of B-grid flow (Q) cells', 'm2',                  &
         cmor_field_name='areacello_bu', cmor_standard_name='cell_area', &
         cmor_long_name='Ocean Grid-Cell Area',         &
-        x_cell_method='sum', y_cell_method='sum')
+        x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
   if (id > 0) then
     call post_data(id, G%areaBu, diag, .true., mask=G%mask2dBu)
   endif
@@ -3283,7 +3283,8 @@ subroutine write_static_fields(G, diag)
         standard_name='sea_floor_depth_below_geoid',                     &
         cmor_field_name='deptho', cmor_long_name='Sea Floor Depth',      &
         cmor_standard_name='sea_floor_depth_below_geoid',&
-        area=diag%axesT1%id_area, x_cell_method='mean', y_cell_method='mean')
+        area=diag%axesT1%id_area, &
+        x_cell_method='mean', y_cell_method='mean', area_cell_method='mean')
   if (id > 0) call post_data(id, G%bathyT, diag, .true., mask=G%mask2dT)
 
   id = register_static_field('ocean_model', 'wet', diag%axesT1, &
@@ -3336,7 +3337,7 @@ subroutine write_static_fields(G, diag)
         'Percentage of cell area covered by ocean', '%', &
         cmor_field_name='sftof', cmor_standard_name='SeaAreaFraction', &
         cmor_long_name='Sea Area Fraction', &
-        x_cell_method='mean', y_cell_method='mean')
+        x_cell_method='mean', y_cell_method='mean', area_cell_method='mean')
   if (id > 0) then
     tmp_h(:,:) = 0.
     tmp_h(G%isc:G%iec,G%jsc:G%jec) = 100. * G%mask2dT(G%isc:G%iec,G%jsc:G%jec)

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -447,7 +447,8 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
         'Geothermal heat flux into ocean', 'W m-2',                    &
         cmor_field_name='hfgeou', cmor_units='W m-2',                  &
         cmor_standard_name='upward_geothermal_heat_flux_at_sea_floor', &
-        cmor_long_name='Upward geothermal heat flux at sea floor')
+        cmor_long_name='Upward geothermal heat flux at sea floor', &
+        x_cell_method='mean', y_cell_method='mean', area_cell_method='mean')
   if (id > 0) call post_data(id, CS%geo_heat, diag, .true.)
 
 end subroutine geothermal_init


### PR DESCRIPTION
- We had coded up a general implementation of the cell methods per axis
  from which anything could be done. Apparently CMIP wants an area
  cell method which is not general.
- This commit adds an area cell method based on the x,y methods:
  - "x:mean y:mean" generates "area:mean";
  - "x:sum y:sum" generates "area:sum";
  - other methods for x,y do not generate and area method.
- I also hand coded the area methods for the static variables since we have
  not generalized the approach for static diagnostics.
- Also added methods for hfgeo which is static and had been missed.