### PR TITLE
Masking h-point thicknesses for computation of C-grid values

### DIFF
--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -420,10 +420,10 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
     do j=js-2,je+2 ; do I=Isq-1,Ieq+1
-      h_u(I,j) = 0.5 * (h(i,j,k) + h(i+1,j,k))
+      h_u(I,j) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
     enddo ; enddo
     do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
-      h_v(i,J) = 0.5 * (h(i,j,k) + h(i,j+1,k))
+      h_v(i,J) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
     enddo ; enddo
 
     ! Adjust contributions to shearing strain and interpolated values of

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -126,7 +126,11 @@ type, public :: hor_visc_CS ; private
   logical :: use_Kh_bg_2d    ! Read 2d background viscosity from a file.
   real    :: Kh_bg_min       ! The minimum value allowed for Laplacian horizontal
                              ! viscosity. The default is 0.0
-
+  logical :: use_land_mask   ! Use the land mask for the computation of thicknesses
+                             ! at velocity locations. This eliminates the dependence on
+                             ! arbitrary values over land or outside of the domain.
+                             ! Default is False to maintain answers with legacy experiments
+                             ! but should be changed to True for new experiments.
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
     Kh_bg_xx,        &! The background Laplacian viscosity at h points, in units
                       ! of m2 s-1. The actual viscosity may be the larger of this
@@ -419,12 +423,21 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
     ! in OBCs, which are not ordinarily be necessary, and might not be necessary
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
-    do j=js-2,je+2 ; do I=Isq-1,Ieq+1
-      h_u(I,j) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
-    enddo ; enddo
-    do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
-      h_v(i,J) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
-    enddo ; enddo
+    if (CS%use_land_mask) then
+      do j=js-2,je+2 ; do I=Isq-1,Ieq+1
+        h_u(I,j) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
+      enddo ; enddo
+      do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
+        h_v(i,J) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
+      enddo ; enddo
+    else
+      do j=js-2,je+2 ; do I=Isq-1,Ieq+1
+        h_u(I,j) = 0.5 * (h(i,j,k) + h(i+1,j,k))
+      enddo; enddo
+      do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
+        h_v(i,J) = 0.5 * (h(i,j,k) + h(i,j+1,k))
+      enddo ; enddo
+    endif
 
     ! Adjust contributions to shearing strain and interpolated values of
     ! thicknesses on open boundaries.
@@ -1180,6 +1193,13 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
     endif
 
   endif
+
+  call get_param(param_file, mdl, "USE_LAND_MASK_FOR_HVISC", CS%use_land_mask, &
+                 "If true, use Use the land mask for the computation of thicknesses \n"//&
+                 "at velocity locations. This eliminates the dependence on arbitrary \n"//&
+                 "values over land or outside of the domain. Default is False in order to \n"//&
+                 "maintain answers with legacy experiments but should be changed to True \n"//&
+                 "for new experiments.", default=.false.)
 
   if (CS%better_bound_Ah .or. CS%better_bound_Kh .or. get_all) &
     call get_param(param_file, mdl, "HORVISC_BOUND_COEF", CS%bound_coef, &


### PR DESCRIPTION
This modification zeros the land-side values for the computation of cell-face thicknesses used for bounding the viscosity.  Previously, the unmasked thicknesses over land was used (usually MIN_THICKNESS).  This impacts answers for most test cases with BETTER_BOUND_KH and/or BETTER_BOUND_AH enabled and addresses a restart issue present in models with ocean points adjacent to the edge of the domain.    