### PR TITLE
Add call to adjust_salt in block when NOT using BULKMIXEDLAYER

### DIFF
--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1032,7 +1032,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, G, GV, CS)
       !  BOUND_SALINITY=False in MOM.F90.
       if (ASSOCIATED(tv%S) .and. ASSOCIATED(tv%salt_deficit)) &
         call adjust_salt(h, tv, G, GV, CS%diabatic_aux_CSp)
-      
+
       if(CS%diabatic_diff_tendency_diag) then
         do k=1,nz ; do j=js,je ; do i=is,ie
           temp_diag(i,j,k) = tv%T(i,j,k)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1024,6 +1024,15 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, G, GV, CS)
       endif
       call cpu_clock_begin(id_clock_tridiag)
 
+      !  Keep salinity from falling below a small but positive threshold.
+      !  This constraint is needed for SIS1 ice model, which can extract
+      !  more salt than is present in the ocean. SIS2 does not suffer
+      !  from this limitation, in which case we can let salinity=0 and still
+      !  have salt conserved with SIS2 ice. So for SIS2, we can run with
+      !  BOUND_SALINITY=False in MOM.F90.
+      if (ASSOCIATED(tv%S) .and. ASSOCIATED(tv%salt_deficit)) &
+        call adjust_salt(h, tv, G, GV, CS%diabatic_aux_CSp)
+      
       if(CS%diabatic_diff_tendency_diag) then
         do k=1,nz ; do j=js,je ; do i=is,ie
           temp_diag(i,j,k) = tv%T(i,j,k)


### PR DESCRIPTION
In some areas of low salinity, we were getting failures due to negative salinity.
Areas were on Greenland coastline and Gulf of Bothnia.
This was with ICE_BULK_SALINITY = 5.0   in SIS2.