### PR TITLE
Changes variable intents for cray compatibility

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -593,7 +593,7 @@ end subroutine update_ocean_model
 subroutine add_berg_flux_to_shelf(G, forces, fluxes, use_ice_shelf, density_ice, kv_ice, &
                                   latent_heat_fusion, sfc_state, time_step, berg_area_threshold)
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure
-  type(mech_forcing),    intent(in)    :: forces  !< A structure with the driving mechanical forces
+  type(mech_forcing),    intent(inout)    :: forces  !< A structure with the driving mechanical forces
   type(forcing),         intent(inout) :: fluxes
   type(surface),         intent(inout) :: sfc_state !< A structure containing fields that
                                                     !! describe the surface state of the ocean.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -456,7 +456,7 @@ contains
 !! advect_tracer and tracer_hordiff.  Vertical mixing and possibly remapping
 !! occur inside of diabatic.
 subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS)
-  type(mech_forcing), intent(in)     :: forces        !< A structure with the driving mechanical forces
+  type(mech_forcing), intent(inout)     :: forces        !< A structure with the driving mechanical forces
   type(forcing),    intent(inout)    :: fluxes        !< pointers to forcing fields
   type(surface),    intent(inout)    :: sfc_state     !< surface ocean state
   type(time_type),  intent(in)       :: Time_start    !< starting time of a segment, as a time type

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -2271,9 +2271,9 @@ subroutine register_temp_salt_segments(GV, OBC, tv, vd_T, vd_S, param_file)
 end subroutine register_temp_salt_segments
 
 subroutine fill_temp_salt_segments(G, OBC, tv)
-  type(ocean_grid_type),      intent(in)    :: G          !< Ocean grid structure
+  type(ocean_grid_type),      intent(inout)    :: G          !< Ocean grid structure
   type(ocean_OBC_type),       pointer       :: OBC        !< Open boundary structure
-  type(thermo_var_ptrs),      intent(in)    :: tv         !< Thermodynamics structure
+  type(thermo_var_ptrs),      intent(inout)    :: tv         !< Thermodynamics structure
 
 ! Local variables
   integer :: isd, ied, IsdB, IedB, jsd, jed, JsdB, JedB, n, nz

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -105,7 +105,7 @@ subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug
   !
   use MOM_coms, only : sum_across_PEs
 
-  type(ocean_grid_type),            intent(in)    :: G    !< The ocean's grid structure.
+  type(ocean_grid_type),            intent(inout)    :: G    !< The ocean's grid structure.
   real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: aout
   real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: good !< Valid data mask for incoming array
                                                           !! (1==good data; 0==missing data).
@@ -266,7 +266,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   character(len=*),      intent(in)    :: varnam     !< Name of tracer in filee.
   real,                  intent(in)    :: conversion !< Conversion factor for tracer.
   integer,               intent(in)    :: recnum     !< Record number of tracer to be read.
-  type(ocean_grid_type), intent(in)    :: G          !< Grid object
+  type(ocean_grid_type), intent(inout)    :: G          !< Grid object
   real, allocatable, dimension(:,:,:)  :: tr_z       !< pointer to allocatable tracer array on local
                                                      !! model grid and native vertical levels.
   real, allocatable, dimension(:,:,:)  :: mask_z     !< pointer to allocatable tracer mask array on
@@ -581,7 +581,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   integer,               intent(in)    :: fms_id         !< A unique id used by the FMS time interpolator
   type(time_type),       intent(in)    :: Time       !< A FMS time type
   real,                  intent(in)    :: conversion !< Conversion factor for tracer.
-  type(ocean_grid_type), intent(in)    :: G          !< Grid object
+  type(ocean_grid_type), intent(inout)    :: G          !< Grid object
   real, allocatable, dimension(:,:,:)  :: tr_z       !< pointer to allocatable tracer array on local
                                                      !! model grid and native vertical levels.
   real, allocatable, dimension(:,:,:)  :: mask_z     !< pointer to allocatable tracer mask array on

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1327,8 +1327,8 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                   units="nondim.", fail_if_missing=.true.)
 
   call get_param(param_file, mdl, "ICE_SHELF_MASS_FROM_FILE", &
-                CS%mass_from_file, "Read the mass of the &
-                ice shelf (every time step) from a file.", default=.false.)
+                CS%mass_from_file, "Read the mass of the "//&
+                " ice shelf (every time step) from a file.", default=.false.)
 
   if (CS%threeeq) &
     call get_param(param_file, mdl, "SHELF_S_ROOT", CS%find_salt_root, &

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -670,8 +670,8 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u,fieldname_u,filename_v
   character(len=*),  intent(in) :: fieldname_u
   character(len=*), intent(in) :: filename_v
   character(len=*),  intent(in) :: fieldname_v
-  type(time_type),    intent(in) :: Time
-  type(ocean_grid_type), intent(in)  :: G !< Ocean grid (in)
+  type(time_type),    intent(inout) :: Time
+  type(ocean_grid_type), intent(inout)  :: G !< Ocean grid (in)
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), target, intent(in) :: u_ptr !< u pointer to the field to be damped (in).
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), target, intent(in) :: v_ptr !< v pointer to the field to be damped (in).
   type(ALE_sponge_CS),                     pointer  :: CS !< Sponge structure (in/out).


### PR DESCRIPTION
Changes variable intents from intent(in) to intent(inout) to be compatible with the cray compiler.

This has been tested on gaea with the AM4 warsaw_201710 code.

Assigning to @nikizadehgfdl  for testing.