### PR TITLE
Geometric progression for ENERGYSAVEDAYS

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -283,20 +283,21 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
                  "The time unit for ENERGYSAVEDAYS.", &
                  units="s", default=86400.0)
   call get_param(param_file, mdl, "ENERGYSAVEDAYS",OS%energysavedays, &
-                 "The interval in units of TIMEUNIT between saves of the \n"&
-                 "energies of the run and other globally summed diagnostics.", &
+                 "The interval in units of TIMEUNIT between saves of the \n"//&
+                 "energies of the run and other globally summed diagnostics.",&
                  default=set_time(0,days=1), timeunit=Time_unit)
-
-  call get_param(param_file, mdl, "ENERGYSAVE_GEOMETRIC",OS%energysave_geometric,&
-                 "If true, globally summed diagnostics will be computed for \n"&
-                 "timestep intervals that increase in a geometric progession \n"&
-                 "until the first ENERGYSAVEDAYS interval is reached.", &
-                 default=.true.)
   call get_param(param_file, mdl, "ENERGYSAVEDAYS_GEOMETRIC",OS%energysavedays_geometric, &
-                 "The starting interval in units of TIMEUNIT for the first call \n"&
-                 "to save the energies of the run and other globally summed diagnostics. \n"&
+                 "The starting interval in units of TIMEUNIT for the first call \n"//&
+                 "to save the energies of the run and other globally summed diagnostics. \n"//&
                  "The interval increases by a factor of 2. after each call to write_energy.",&
-                 default=set_time(seconds=43200), timeunit=Time_unit)  ! 12 hours
+                 default=set_time(seconds=0), timeunit=Time_unit)
+
+  if ((time_type_to_real(OS%energysavedays_geometric) > 0.) .and. &
+     (OS%energysavedays_geometric < OS%energysavedays)) then
+         OS%energysave_geometric = .true.
+  else
+         OS%energysave_geometric = .false.
+  endif
 
   call get_param(param_file, mdl, "OCEAN_SURFACE_STAGGER", stagger, &
                  "A case-insensitive character string to indicate the \n"//&
@@ -377,6 +378,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
   ! write_energy_time is the next integral multiple of energysavedays.
   if (OS%energysave_geometric) then
     if (OS%energysavedays_geometric < OS%energysavedays) then
+
       OS%write_energy_time = Time_init + OS%energysavedays_geometric * &
         (1 + (OS%Time - Time_init) / OS%energysavedays_geometric)
 

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -378,20 +378,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
   ! write_energy_time is the next integral multiple of energysavedays.
   if (OS%energysave_geometric) then
     if (OS%energysavedays_geometric < OS%energysavedays) then
-
-      OS%write_energy_time = Time_init + OS%energysavedays_geometric * &
-        (1 + (OS%Time - Time_init) / OS%energysavedays_geometric)
-
-      ! This line below, which patterns the way write_energy_time was originally coded,
-      ! yields inconsistent results depending on the case. Dividing by OS%energysavedays
-      ! introduces decimal values but the operators from FMS time manager are integer ops.
-
-      ! OS%geometric_end_time = Time_init + OS%energysavedays * &
-      !  (1 + (OS%Time - Time_init) / OS%energysavedays)
-
-      ! Algebraically equivalent statement below that yields consistent results
-      OS%geometric_end_time = OS%Time + OS%energysavedays
-
+      OS%write_energy_time = OS%Time + OS%energysavedays_geometric
+      OS%geometric_end_time = Time_init + OS%energysavedays * &
+       (1 + (OS%Time - Time_init) / OS%energysavedays)
     else
       OS%write_energy_time = Time_init + OS%energysavedays * &
         (1 + (OS%Time - Time_init) / OS%energysavedays)


### PR DESCRIPTION
When running the coupled ESM, there is a desire to cut down on the verbosity of stdout of the production runs.  The proposal based on the prototype XMLs is to run with ENERGYSAVEDAYS = 30.

It is highly-beneficial during development of the model to examine the global energies saved out from calls to `write_energy` at the start of a model year.  The high quality of these diagnostics makes them a bellwether of whether or not the model is bit-reproducing an earlier simulation or if something catastrophically is going wrong early in a simulation.

One compromise is to start at a relatively high frequency and double the time interval between calls to `write_energy`

With this code update and following added to MOM_override:

```
#override ENERGYSAVEDAYS = 30.
#override ENERGYSAVEDAYS_GEOMETRIC = 1.
```

Global integrals would be computed at days 1, 2, 4, 8, 16, 30, 60, 90, ...