### PR TITLE
Fix rho coord diagnostics

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -1312,7 +1312,7 @@ subroutine build_rho_grid( G, GV, h, tv, dzInterface, remapCS, CS )
       ! Local depth (G%bathyT is positive)
       nominalDepth = G%bathyT(i,j)*GV%m_to_H
 
-      call build_rho_column(CS%rho_CS, remapCS, nz, nominalDepth, h(i, j, :), &
+      call build_rho_column(CS%rho_CS, nz, nominalDepth, h(i, j, :), &
                             tv%T(i, j, :), tv%S(i, j, :), tv%eqn_of_state, zNew)
 
       if (CS%integrate_downward_for_e) then

--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -18,14 +18,14 @@ type, public :: rho_CS
   integer :: nk
 
   !> Minimum thickness allowed for layers
-  real :: min_thickness
+  real :: min_thickness = 0.
 
   !> Reference pressure for density calculations
   real :: ref_pressure
 
   !> If true, integrate for interface positions from the top downward.
   !! If false, integrate from the bottom upward, as does the rest of the model.
-  logical :: integrate_downward_for_e
+  logical :: integrate_downward_for_e = .false.
 
   !> Nominal density of interfaces
   real, allocatable, dimension(:) :: target_density

--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -88,9 +88,8 @@ end subroutine set_rho_params
 !!
 !! 1. Density profiles are calculated on the source grid.
 !! 2. Positions of target densities (for interfaces) are found by interpolation.
-subroutine build_rho_column(CS, remapCS, nz, depth, h, T, S, eqn_of_state, z_interface)
+subroutine build_rho_column(CS, nz, depth, h, T, S, eqn_of_state, z_interface)
   type(rho_CS),             intent(in)    :: CS !< coord_rho control structure
-  type(remapping_CS),       intent(in)    :: remapCS !< Remapping parameters and options
   integer,                  intent(in)    :: nz !< Number of levels on source grid (i.e. length of  h, T, S)
   real,                     intent(in)    :: depth !< Depth of ocean bottom (positive in m)
   real, dimension(nz),      intent(in)    :: h  !< Layer thicknesses, in m

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -263,7 +263,7 @@ subroutine diag_remap_update(remap_cs, G, h, T, S, eqn_of_state)
         call build_sigma_column(get_sigma_CS(remap_cs%regrid_cs), nz, &
                                 G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
       elseif (remap_cs%vertical_coord == coordinateMode('RHO')) then
-        call build_rho_column(get_rho_CS(remap_cs%regrid_cs), remap_cs%remap_cs, nz, &
+        call build_rho_column(get_rho_CS(remap_cs%regrid_cs), G%ke, &
                               G%bathyT(i,j), h(i,j,:), T(i, j, :), S(i, j, :), &
                               eqn_of_state, zInterfaces)
       elseif (remap_cs%vertical_coord == coordinateMode('SLIGHT')) then


### PR DESCRIPTION
- Fixes an oversight in build_rho_column() that assumed generation of rho coordinates would have the same number of layers on source and target grids. This is what broke in recent OM4 rho-space diagnostics that have 35 diagnostic layers relative to the 75 layers for the model.
- The sum of vmo now agrees to within real*4 between native, z- and rho-space diagnostics.
- Close #639.

![image](https://user-images.githubusercontent.com/5859571/32289856-70627362-bf0e-11e7-9c3c-10f2f861750e.png)

(Note this PR is onto the OM4-maintenance branch but I'll submit the test against dev/gfdl)