### PR TITLE
Framework for writing parameters to netCDF format

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2110,6 +2110,7 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
 
   ! Diagnose static fields AND associate areas/volumes with axes
   call write_static_fields(G, CS%diag)
+  call write_parameter_fields(G, CS)
   call callTree_waypoint("static fields written (initialize_MOM)")
 
   ! Register the volume cell measure (must be one of first diagnostics)
@@ -3346,6 +3347,26 @@ subroutine write_static_fields(G, diag)
 
 end subroutine write_static_fields
 
+subroutine write_parameter_fields(G, CS)
+  type(ocean_grid_type),   intent(in)    :: G      !< ocean grid structure
+  type(MOM_control_struct),pointer       :: CS     !< pointer set in this routine to MOM control structure
+  ! Local variables
+  integer :: id
+
+  id = register_static_field('ocean_model','Rho_0', CS%diag%axesNull, &
+       'mean ocean density used with the Boussinesq approximation', &
+       'kg m-3', cmor_field_name='rhozero', &
+       cmor_standard_name='reference_sea_water_density_for_boussinesq_approximation', &
+       cmor_long_name='reference sea water density for boussinesq approximation')
+  if (id > 0) call post_data(id, CS%GV%Rho0, CS%diag, .true.)
+
+  id = register_static_field('ocean_model','C_p', CS%diag%axesNull, &
+       'heat capacity of sea water', 'J kg-1 K-1', cmor_field_name='cpocean', &
+       cmor_standard_name='specific_heat_capacity_of_sea_water', &
+       cmor_long_name='specific_heat_capacity_of_sea_water')
+  if (id > 0) call post_data(id, CS%tv%C_p, CS%diag, .true.)
+
+end subroutine write_parameter_fields
 
 !> Set the fields that are needed for bitwise identical restarting
 !! the time stepping scheme.  In addition to those specified here

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -31,6 +31,7 @@ use MOM_diag_remap,       only : diag_remap_diag_registration_closed
 use MOM_diag_remap,       only : horizontally_average_diag_field
 
 use diag_axis_mod, only : get_diag_axis_name
+use diag_data_mod, only : null_axis_id
 use diag_manager_mod, only : diag_manager_init, diag_manager_end
 use diag_manager_mod, only : send_data, diag_axis_init, diag_field_add_attribute
 ! The following module is needed for PGI since the following line does not compile with PGI 6.5.0
@@ -136,7 +137,7 @@ type, public :: diag_ctrl
   type(axes_grp) :: axesBL, axesTL, axesCuL, axesCvL
   type(axes_grp) :: axesBi, axesTi, axesCui, axesCvi
   type(axes_grp) :: axesB1, axesT1, axesCu1, axesCv1
-  type(axes_grp) :: axesZi, axesZL
+  type(axes_grp) :: axesZi, axesZL, axesNull
 
   ! Mask arrays for diagnostics
   real, dimension(:,:),   pointer :: mask2dT   => null()
@@ -283,6 +284,9 @@ subroutine set_axes_info(G, GV, param_file, diag_cs, set_vertical)
        x_cell_method='point', y_cell_method='mean', is_u_point=.true.)
   call define_axes_group(diag_cs, (/ id_xh, id_yq /), diag_cs%axesCv1, &
        x_cell_method='mean', y_cell_method='point', is_v_point=.true.)
+
+  ! Axis group for special null axis from diag manager
+  call define_axes_group(diag_cs, (/ null_axis_id /), diag_cs%axesNull)
 
   if (diag_cs%num_diag_coords>0) then
     allocate(diag_cs%remap_axesZL(diag_cs%num_diag_coords))


### PR DESCRIPTION
This PR introduces a framework to write useful parameters to a netCDF file.  Several of us have run into instances where offline analyses and scripts have used hard-coded values for Rho0 and Cp that differ from those used in the model simulation.  The introduction of this “ocean_parameters.nc” file will help ameliorate some of those issues and allow scripts/analyses to load these values on a per-experiment basis.

@StephenGriffies also specifies CMOR names and attributes for these in the 2016 OMIP description paper - specifically for ‘rhozero’ and ‘cpocean’.   These attributes are included in the register_diag calls.

In this commit:
  - Added write_parameter_fields subroutine to MOM.F90
  - Makes use of the FMS Diag Manager "scalar_axis", which
    is added as axes%axesNull

And a sample diag_table used for testing:
```
"ocean_model", "C_p", "C_p", "ocean_parameters", "all", .false., "none", 1 
"ocean_model", "Rho_0", "Rho_0"," ocean_parameters", "all", .false., "none", 1 
"ocean_model", "cpocean", "cpocean", "ocean_parameters", "all", .false., "none", 1 
"ocean_model", "rhozero", "rhozero", "ocean_parameters", "all", .false., "none", 1
```