### PR TITLE
Override T and S for remapped transport diagnostics

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -811,12 +811,14 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS)
       enddo ; enddo ; enddo
     endif
 
-    ! Store pre-dynamics layer thicknesses so that mass fluxes are remapped correctly
-    do k=1,nz ; do j=jsd,jed ; do i=isd,ied
-      h_pre_dyn(i,j,k) = h(i,j,k)
-      T_pre_dyn(i,j,k) = CS%tv%T(i,j,k)
-      S_pre_dyn(i,j,k) = CS%tv%S(i,j,k)
-    enddo ; enddo ; enddo
+    ! Store pre-dynamics state for proper diagnostic remapping if mass transports requested
+    if (CS%id_uhtr > 0 .or. CS%id_vhtr > 0 .or. CS%id_umo > 0 .or. CS%id_vmo > 0) then
+      do k=1,nz ; do j=jsd,jed ; do i=isd,ied
+        h_pre_dyn(i,j,k) = h(i,j,k)
+        if (associated(CS%tv%T)) T_pre_dyn(i,j,k) = CS%tv%T(i,j,k)
+        if (associated(CS%tv%S)) S_pre_dyn(i,j,k) = CS%tv%S(i,j,k)
+      enddo ; enddo ; enddo
+    endif
 
     if (G%nonblocking_updates) then ; if (do_calc_bbl) then
       if (do_pass_Ray) &

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -2063,26 +2063,41 @@ end subroutine
 !> Build/update vertical grids for diagnostic remapping.
 !! \note The target grids need to be updated whenever sea surface
 !! height changes.
-subroutine diag_update_remap_grids(diag_cs, alt_h)
+subroutine diag_update_remap_grids(diag_cs, alt_h, alt_T, alt_S)
   type(diag_ctrl),        intent(inout) :: diag_cs      !< Diagnostics control structure
-  real, target, optional, intent(in   ) :: alt_h(:,:,:) !< Used if remapped grids should be
-                                                        !! something other than the current
-                                                        !! thicknesses
+  real, target, optional, intent(in   ) :: alt_h(:,:,:) !< Used if remapped grids should be something other than
+                                                        !! the current thicknesses
+  real, target, optional, intent(in   ) :: alt_T(:,:,:) !< Used if remapped grids should be something other than
+                                                        !! the current temperatures
+  real, target, optional, intent(in   ) :: alt_S(:,:,:) !< Used if remapped grids should be something other than
+                                                        !! the current salinity
   ! Local variables
   integer :: i
-  real, dimension(:,:,:), pointer :: h_diag
+  real, dimension(:,:,:), pointer :: h_diag, T_diag, S_diag
 
-  if(present(alt_h)) then
+  if (present(alt_h)) then
     h_diag => alt_h
   else
     h_diag => diag_cs%h
+  endif
+
+  if (present(alt_T)) then
+    T_diag => alt_T
+  else
+    T_diag => diag_CS%T
+  endif
+
+  if (present(alt_S)) then
+    S_diag => alt_S
+  else
+    S_diag => diag_CS%S
   endif
 
   if (id_clock_diag_grid_updates>0) call cpu_clock_begin(id_clock_diag_grid_updates)
 
   do i=1, diag_cs%num_diag_coords
     call diag_remap_update(diag_cs%diag_remap_cs(i), &
-                           diag_cs%G, h_diag, diag_cs%T, diag_cs%S, &
+                           diag_cs%G, h_diag, T_diag, S_diag, &
                            diag_cs%eqn_of_state)
   enddo
 


### PR DESCRIPTION
This PR addresses concerns that I raised in #642 

The remapping was working as expected for remapping transport diagnostics
onto a coordinate that does not depend on T/S of the model. However, for
transport on state-dependent coordinates (e.g sigma-2), the target
coordinate was being built using the pre-dynamics thicknesses, but the
current T/S.

This commit adds two optional arguments in diag_update_remap_grids to
override T and S. The override is currently only needed for the transport
diagnostics.