### PR TITLE
4 commits for tide support

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1305,7 +1305,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
       if (GV%Boussinesq) &
         Htot = Htot + 0.5*GV%m_to_H * (CS%bathyT(i,j) + CS%bathyT(i+1,j))
       bt_rem_u(I,j) = bt_rem_u(I,j) * (Htot / (Htot + CS%lin_drag_u(I,j) * dtbt))
-      
+
       Rayleigh_u(I,j) = CS%lin_drag_u(I,j) / Htot
     endif ; enddo ; enddo
     !$OMP do

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -40,7 +40,6 @@ use MOM_boundary_update,       only : update_OBC_data, update_OBC_CS
 use MOM_continuity,            only : continuity, continuity_init, continuity_CS
 use MOM_continuity,            only : continuity_stencil
 use MOM_CoriolisAdv,           only : CorAdCalc, CoriolisAdv_init, CoriolisAdv_CS
-use MOM_diabatic_driver,       only : diabatic, diabatic_driver_init, diabatic_CS
 use MOM_debugging,             only : check_redundant
 use MOM_grid,                  only : ocean_grid_type
 use MOM_hor_index,             only : hor_index_type
@@ -94,7 +93,9 @@ type, public :: MOM_dyn_split_RK2_CS ; private
                   !! that were fed into the barotopic calculation, in m s-2.
 
   ! The following variables are only used with the split time stepping scheme.
-  real ALLOCABLE_, dimension(NIMEM_,NJMEM_)             :: eta     !< Instantaneous free surface height, in m.
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_)             :: eta     !< Instantaneous free surface height (in Boussinesq mode)
+                                                                   !! or column mass anomaly (in non-Boussinesq mode),
+                                                                   !! in units of H (m or kg m-2)
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: u_av    !< layer x-velocity with vertical mean replaced by
                                                                    !! time-mean barotropic velocity over a baroclinic timestep (m s-1)
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: v_av    !< layer y-velocity with vertical mean replaced by
@@ -878,7 +879,11 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, param_file, CS, restart_CS, u
   thickness_units = get_thickness_units(GV)
   flux_units = get_flux_units(GV)
 
-  vd = var_desc("sfc",thickness_units,"Free surface Height",'h','1')
+  if (GV%Boussinesq) then
+    vd = var_desc("sfc",thickness_units,"Free surface Height",'h','1')
+  else
+    vd = var_desc("p_bot",thickness_units,"Bottom Pressure",'h','1')
+  endif
   call register_restart_field(CS%eta, vd, .false., restart_CS)
 
   vd = var_desc("u2","m s-1","Auxiliary Zonal velocity",'u','L')
@@ -943,7 +948,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
 
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_tmp
   character(len=40) :: mdl = "MOM_dynamics_split_RK2" ! This module's name.
-  character(len=48) :: thickness_units, flux_units
+  character(len=48) :: thickness_units, flux_units, eta_rest_name
   type(group_pass_type) :: pass_av_h_uvh
   logical :: use_tides, debug_truncations
 
@@ -1052,7 +1057,8 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
   if (associated(OBC)) CS%OBC => OBC
   if (associated(update_OBC_CSp)) CS%update_OBC_CSp => update_OBC_CSp
 
-  if (.not. query_initialized(CS%eta,"sfc",restart_CS))  then
+  eta_rest_name = "sfc" ; if (.not.GV%Boussinesq) eta_rest_name = "p_bot"
+  if (.not. query_initialized(CS%eta, trim(eta_rest_name), restart_CS)) then
     ! Estimate eta based on the layer thicknesses - h.  With the Boussinesq
     ! approximation, eta is the free surface height anomaly, while without it
     ! eta is the mass of ocean per unit area.  eta always has the same

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -10,7 +10,7 @@ use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser, only : get_param, read_param, log_param, param_file_type
 use MOM_file_parser, only : log_version
 use MOM_io, only : close_file, create_file, fieldtype, file_exists
-use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE, MULTIPLE
+use MOM_io, only : open_file, MOM_read_data, read_axis_data, SINGLE_FILE, MULTIPLE
 use MOM_io, only : slasher, vardesc, write_field, var_desc
 use MOM_string_functions, only : uppercase
 use MOM_variables, only : thermo_var_ptrs
@@ -303,14 +303,14 @@ subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, param_file, &
                  default=GV%g_Earth)
   call get_param(param_file, mdl, "COORD_FILE", coord_file, &
                  "The file from which the coordinate temperatures and \n"//&
-                 "salnities are read.", fail_if_missing=.true.)
+                 "salinities are read.", fail_if_missing=.true.)
 
   call get_param(param_file,  mdl, "INPUTDIR", inputdir, default=".")
   filename = trim(slasher(inputdir))//trim(coord_file)
   call log_param(param_file, mdl, "INPUTDIR/COORD_FILE", filename)
 
-  call read_data(filename,"PTEMP",T0(:))
-  call read_data(filename,"SALT",S0(:))
+  call MOM_read_data(filename,"PTEMP",T0(:))
+  call MOM_read_data(filename,"SALT",S0(:))
 
   if (.not.file_exists(filename)) call MOM_error(FATAL, &
       " set_coord_from_TS_profile: Unable to open " //trim(filename))
@@ -348,7 +348,7 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, param_file, &
 ! This subroutine sets the layer densities (Rlay) and the interface  !
 ! reduced gravities (g).                                             !
   real, dimension(GV%ke) :: T0, S0,  Pref
-  real :: S_Ref, S_Light, S_Dense ! Salnity range parameters in PSU.
+  real :: S_Ref, S_Light, S_Dense ! Salinity range parameters in PSU.
   real :: T_Ref, T_Light, T_Dense ! Temperature range parameters in dec C.
   real :: res_rat ! The ratio of density space resolution in the denser part
                   ! of the range to that in the lighter part of the range.

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -18,9 +18,9 @@ use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type, isPointInCell
 use MOM_interface_heights, only : find_eta
 use MOM_io, only : close_file, fieldtype, file_exists
-use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE, MULTIPLE
+use MOM_io, only : open_file, MOM_read_data, read_data, read_axis_data
 use MOM_io, only : slasher, vardesc, write_field
-use MOM_io, only : EAST_FACE, NORTH_FACE
+use MOM_io, only : EAST_FACE, NORTH_FACE, SINGLE_FILE, MULTIPLE
 use MOM_open_boundary, only : ocean_OBC_type, open_boundary_init
 use MOM_open_boundary, only : OBC_NONE, OBC_SIMPLE
 use MOM_open_boundary, only : open_boundary_query, set_tracer_data
@@ -239,6 +239,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
              " \t coord - determined by ALE coordinate.\n"//&
              " \t uniform - uniform thickness layers evenly distributed \n"//&
              " \t\t between the surface and MAXIMUM_DEPTH. \n"//&
+             " \t list - read a list of positive interface depths. \n"//&
              " \t DOME - use a slope and channel configuration for the \n"//&
              " \t\t DOME sill-overflow test case. \n"//&
              " \t ISOMIP - use a configuration for the \n"//&
@@ -267,6 +268,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                                  "for THICKNESS_CONFIG of 'coord'")
          endif
        case ("uniform"); call initialize_thickness_uniform(h, G, GV, PF, &
+                                  just_read_params=just_read)
+       case ("list"); call initialize_thickness_list(h, G, GV, PF, &
                                   just_read_params=just_read)
        case ("DOME"); call DOME_initialize_thickness(h, G, GV, PF, &
                                just_read_params=just_read)
@@ -414,18 +417,18 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                "If true,  convert the thickness initial conditions from \n"//&
                "units of m to kg m-2 or vice versa, depending on whether \n"//&
                "BOUSSINESQ is defined. This does not apply if a restart \n"//&
-               "file is read.", default=.false., do_not_log=just_read)
+               "file is read.", default=.not.GV%Boussinesq, do_not_log=just_read)
   if (new_sim) then
-    if (convert .and. .not. GV%Boussinesq) then
+    if (convert .and. .not.GV%Boussinesq) then
       ! Convert h from m to kg m-2 then to thickness units (H)
       call convert_thickness(h, G, GV, tv)
     elseif (GV%Boussinesq) then
       ! Convert h from m to thickness units (H)
-      do k = 1, nz; do j = js, je; do i = is, ie
+      do k=1,nz ; do j=js,je ; do i=is,ie
         h(i,j,k) = h(i,j,k)*GV%m_to_H
       enddo ; enddo ; enddo
     else
-      do k = 1, nz; do j = js, je; do i = is, ie
+      do k=1,nz ; do j=js,je ; do i=is,ie
         h(i,j,k) = h(i,j,k)*GV%kg_m2_to_H
       enddo ; enddo ; enddo
     endif
@@ -808,6 +811,92 @@ subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_thickness_uniform
+! -----------------------------------------------------------------------------
+
+! -----------------------------------------------------------------------------
+subroutine initialize_thickness_list(h, G, GV, param_file, just_read_params)
+  type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(out) :: h           !< The thickness that is being initialized, in m.
+  type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
+                                                      !! to parse for model parameter values.
+  logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
+                                                      !! only read parameters without changing h.
+
+! Arguments: h - The thickness that is being initialized.
+!  (in)      G - The ocean's grid structure.
+!  (in)      GV - The ocean's vertical grid structure.
+!  (in)      param_file - A structure indicating the open file to parse for
+!                         model parameter values.
+
+!  This subroutine initializes the layer thicknesses to be uniform.
+  character(len=40)  :: mdl = "initialize_thickness_list" ! This subroutine's name.
+  real :: e0(SZK_(G)+1)   ! The resting interface heights, in m, usually !
+                          ! negative because it is positive upward.      !
+  real :: eta1D(SZK_(G)+1)! Interface height relative to the sea surface !
+                          ! positive upward, in m.                       !
+  logical :: just_read    ! If true, just read parameters but set nothing.  character(len=20) :: verticalCoordinate
+  character(len=200) :: filename, eta_file, inputdir ! Strings for file/path
+  character(len=72)  :: eta_var
+  integer :: i, j, k, is, ie, js, je, nz
+
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
+
+  just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
+
+  call get_param(param_file, mdl, "INTERFACE_IC_FILE", eta_file, &
+                 "The file from which horizontal mean initial conditions \n"//&
+                 "for interface depths can be read.", fail_if_missing=.true.)
+  call get_param(param_file, mdl, "INTERFACE_IC_VAR", eta_var, &
+                 "The variable name for horizontal mean initial conditions \n"//&
+                 "for interface depths relative to mean sea level.", &
+                 default="eta")
+
+  if (just_read) return
+
+  call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
+
+  call get_param(param_file,  mdl, "INPUTDIR", inputdir, default=".")
+  filename = trim(slasher(inputdir))//trim(eta_file)
+  call log_param(param_file, mdl, "INPUTDIR/INTERFACE_IC_FILE", filename)
+
+  e0(:) = 0.0
+  call MOM_read_data(filename, eta_var, e0(:))
+
+  if ((abs(e0(1)) - 0.0) > 0.001) then
+    ! This list probably starts with the interior interface, so shift it up.
+    do k=nz+1,2,-1 ; e0(K) = e0(K-1) ; enddo
+    e0(1) = 0.0
+  endif
+
+  if (e0(2) > e0(1)) then
+    ! Switch to the convention for interface heights increasing upward.
+    do k=1,nz
+      e0(K) = -e0(K)
+    enddo
+  endif
+
+  do j=js,je ; do i=is,ie
+!    This sets the initial thickness (in m) of the layers.  The      !
+!  thicknesses are set to insure that: 1.  each layer is at least an !
+!  Angstrom thick, and 2.  the interfaces are where they should be   !
+!  based on the resting depths and interface height perturbations,   !
+!  as long at this doesn't interfere with 1.                         !
+    eta1D(nz+1) = -1.0*G%bathyT(i,j)
+    do k=nz,1,-1
+      eta1D(K) = e0(K)
+      if (eta1D(K) < (eta1D(K+1) + GV%Angstrom_z)) then
+        eta1D(K) = eta1D(K+1) + GV%Angstrom_z
+        h(i,j,k) = GV%Angstrom_z
+      else
+        h(i,j,k) = eta1D(K) - eta1D(K+1)
+      endif
+    enddo
+  enddo ; enddo
+
+  call callTree_leave(trim(mdl)//'()')
+end subroutine initialize_thickness_list
 ! -----------------------------------------------------------------------------
 
 ! -----------------------------------------------------------------------------


### PR DESCRIPTION
  Made a series of 4 commits to help support the use of MOM6 in idealized non-Boussinesq barotropic tide simulations.  All answers in existing test cases are identical, but each of these 4 commits introduces changes to the MOM_parameter_doc files.