### PR TITLE
Fixes the intent of argument updated by data_override

### DIFF
--- a/config_src/solo_driver/coupler_types.F90
+++ b/config_src/solo_driver/coupler_types.F90
@@ -3106,9 +3106,9 @@ end subroutine CT_restore_state_3d
 
 !> This subroutine potentially overrides the values in a coupler_2d_bc_type
 subroutine CT_data_override_2d(gridname, var, Time)
-  character(len=3),         intent(in) :: gridname !< 3-character long model grid ID
-  type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure to override
-  type(time_type),          intent(in) :: time !< The current model time
+  character(len=3),         intent(in)    :: gridname !< 3-character long model grid ID
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to override
+  type(time_type),          intent(in)    :: time !< The current model time
 
   integer :: m, n
 
@@ -3120,9 +3120,9 @@ end subroutine CT_data_override_2d
 
 !> This subroutine potentially overrides the values in a coupler_3d_bc_type
 subroutine CT_data_override_3d(gridname, var, Time)
-  character(len=3),         intent(in) :: gridname !< 3-character long model grid ID
-  type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure to override
-  type(time_type),          intent(in) :: time !< The current model time
+  character(len=3),         intent(in)    :: gridname !< 3-character long model grid ID
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to override
+  type(time_type),          intent(in)    :: time !< The current model time
 
   integer :: m, n
 


### PR DESCRIPTION
- In CT_data_override_2d() and CT_data_override_3d(), a call to data_override()
  updates a dummy argument with intent(in). This commit changes it to intent(inout).
- Related to NOAA-GFDL/FMS#41.
- Reported by @jiandewang.