### PR TITLE
Add missing H_TO_M factor to SCM T/S profile initialization

### DIFF
--- a/src/user/SCM_CVmix_tests.F90
+++ b/src/user/SCM_CVmix_tests.F90
@@ -102,17 +102,17 @@ subroutine SCM_CVmix_tests_TS_init(T, S, h, G, GV, param_file, just_read_params)
     do k=1,nz
       eta(K+1) = eta(K) - h(i,j,k)*GV%H_to_m ! Interface below layer (in m)
       zC = 0.5*( eta(K) + eta(K+1) )        ! Z of middle of layer (in m)
-      DZ = min(0., zC+UpperLayerTempMLD)
+      DZ = min(0., zC+UpperLayerTempMLD*GV%H_to_m)
       if (DZ.ge.0.0) then ! in Layer 1
         T(i,j,k) = UpperLayerTemp
       else ! in Layer 2
-        T(i,j,k) = LowerLayerTemp + LowerLayerdTdZ * DZ
+        T(i,j,k) = LowerLayerTemp + LowerLayerdTdZ/GV%H_to_m * DZ
       endif
       DZ = min(0., zC+UpperLayerSaltMLD)
       if (DZ.ge.0.0) then ! in Layer 1
         S(i,j,k) = UpperLayerSalt
       else ! in Layer 2
-        S(i,j,k) = LowerLayerSalt + LowerLayerdSdZ * DZ
+        S(i,j,k) = LowerLayerSalt + LowerLayerdSdZ/GV%H_to_m * DZ
       endif
     enddo ! k
   enddo ; enddo

--- a/src/user/SCM_idealized_hurricane.F90
+++ b/src/user/SCM_idealized_hurricane.F90
@@ -86,7 +86,8 @@ subroutine SCM_idealized_hurricane_TS_init(T, S, h, G, GV, param_file, just_read
     do k=1,nz
       eta(K+1) = eta(K) - h(i,j,k)*GV%H_to_m ! Interface below layer (in m)
       zC = 0.5*( eta(K) + eta(K+1) )        ! Z of middle of layer (in m)
-      T(i,j,k) = SST_ref + dTdz*min(0., zC+MLD)
+      T(i,j,k) = SST_ref + dTdz/GV%H_to_m &
+                 * min(0., zC+MLD*GV%H_to_m)
       S(i,j,k) = S_ref
     enddo ! k
   enddo ; enddo


### PR DESCRIPTION
- The input dT/dz and dS/dz gradients in the SCM T/S profile initializations did not include H_TO_M factor, thereby answers were not maintained for different H_TO_M values.  These factors are introduced with this fix.
- This fix has been tested to fix the issue for various H_TO_M values using both TS_CONFIG=SCM_CVmix_tests and TS_CONFIG=SCM_ideal_hurr
- All test cases were checked with this code change using the intel compiler and answers were not changed.