### PR TITLE
Fixes intent for args being updated in apply_sponge()

### DIFF
--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -364,10 +364,10 @@ subroutine apply_sponge(h, dt, G, GV, ea, eb, CS, Rcv_ml)
   type(verticalGrid_type),                  intent(in)    :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   real,                                     intent(in)    :: dt
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out)   :: ea  !< an array to which the amount of
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: ea  !< an array to which the amount of
                                                     !! fluid entrained from the layer above during
                                                     !! this call will be added, in H.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out)   :: eb !< an array to which the amount of
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: eb !< an array to which the amount of
                                                           !! fluid entrained from the layer below
                                                           !! during this call will be added, in H.
   type(sponge_CS),                          pointer       :: CS


### PR DESCRIPTION
- Issue #659 reported uninitialized values in apply_sponge().
  The pertinent code increments variables passed into apply_sponge()
  as arguments with intent(out). The arguments should be intent(inout)
  in which case the values are properly initialized.
- Note: none of the three compilers we use caught this mismatch
  and they are evidently treating intent(out) as intent(inout). Something
  to be wary of.
- Closes #659. @hlkong Thanks for report.