### PR TITLE
Numerious changes to support rescaling thickness

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2479,7 +2479,7 @@ subroutine register_diags(Time, G, GV, CS, ADp, C_p)
       'Diffusive Zonal Flux of Salt', S_flux_units, &
       v_extensive = .true., conversion = conv2salt)
   CS%id_Sdiffy = register_diag_field('ocean_model', 'S_diffy', diag%axesCvL, Time, &
-      'Diffusive Meridional Flux of Salinity', S_flux_units, v_extensive = .true.)
+      'Diffusive Meridional Flux of Salt', S_flux_units, v_extensive = .true.)
   if (CS%id_Sadx   > 0) call safe_alloc_ptr(CS%S_adx,IsdB,IedB,jsd,jed,nz)
   if (CS%id_Sady   > 0) call safe_alloc_ptr(CS%S_ady,isd,ied,JsdB,JedB,nz)
   if (CS%id_Sdiffx > 0) call safe_alloc_ptr(CS%S_diffx,IsdB,IedB,jsd,jed,nz)

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -184,7 +184,7 @@ subroutine find_eta_2d(h, tv, G_Earth, G, GV, eta, eta_bt, halo_size)
     if (present(eta_bt)) then
 !$OMP do
       do j=js,je ; do i=is,ie
-        eta(i,j) = eta_bt(i,j)
+        eta(i,j) = GV%H_to_m*eta_bt(i,j)
       enddo ; enddo
     else
 !$OMP do

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -72,7 +72,8 @@ subroutine verticalGridInit( param_file, GV )
   type(verticalGrid_type), pointer    :: GV         ! The container for vertical grid data
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  integer :: nk
+  integer :: nk, H_power
+  real    :: rescale_factor
   character(len=16) :: mdl = 'MOM_verticalGrid'
 
   if (associated(GV)) call MOM_error(FATAL, &
@@ -96,15 +97,25 @@ subroutine verticalGridInit( param_file, GV )
   call get_param(param_file, mdl, "ANGSTROM", GV%Angstrom_z, &
                  "The minumum layer thickness, usually one-Angstrom.", &
                  units="m", default=1.0e-10)
+  call get_param(param_file, mdl, "H_RESCALE_POWER", H_power, &
+                 "An integer power of 2 that is used to rescale the model's \n"//&
+                 "intenal units of thickness.  Valid values range from -300 to 300.", &
+                 units="nondim", default=0, debuggingParam=.true.)
+  if (abs(H_power) > 300) call MOM_error(FATAL, "verticalGridInit: "//&
+                 "H_RESCALE_POWER is outside of the valid range of -300 to 300.")
+  rescale_factor = 1.0
+  if (H_power /= 0) rescale_factor = 2.0**H_power
   if (.not.GV%Boussinesq) then
     call get_param(param_file, mdl, "H_TO_KG_M2", GV%H_to_kg_m2,&
                  "A constant that translates thicknesses from the model's \n"//&
                  "internal units of thickness to kg m-2.", units="kg m-2 H-1", &
                  default=1.0)
+    GV%H_to_kg_m2 = GV%H_to_kg_m2 * rescale_factor
   else
     call get_param(param_file, mdl, "H_TO_M", GV%H_to_m, &
                  "A constant that translates the model's internal \n"//&
                  "units of thickness into m.", units="m H-1", default=1.0)
+    GV%H_to_m = GV%H_to_m * rescale_factor
   endif
 #ifdef STATIC_MEMORY_
   ! Here NK_ is a macro, while nk is a variable.
@@ -135,7 +146,9 @@ subroutine verticalGridInit( param_file, GV )
   GV%H_to_Pa = GV%g_Earth * GV%H_to_kg_m2
 
 ! Log derivative values.
-  call log_param(param_file, mdl, "M to THICKNESS", GV%m_to_H)
+  call log_param(param_file, mdl, "M to THICKNESS", GV%m_to_H*rescale_factor)
+  call log_param(param_file, mdl, "M to THICKNESS rescaled by 2^-n", GV%m_to_H)
+  call log_param(param_file, mdl, "THICKNESS to M rescaled by 2^n", GV%H_to_m)
 
   ALLOC_( GV%sInterface(nk+1) )
   ALLOC_( GV%sLayer(nk) )

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -115,7 +115,9 @@ subroutine chksum_h_2d(array, mesg, HI, haloshift, omit_corners, scale)
   logical,               optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,                  optional, intent(in) :: scale     !< A scaling factor for this array.
 
+  real, allocatable, dimension(:,:) :: rescaled_array
   real :: scaling
+  integer :: i, j
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
   logical :: do_corners
@@ -128,7 +130,18 @@ subroutine chksum_h_2d(array, mesg, HI, haloshift, omit_corners, scale)
   endif
   scaling = 1.0 ; if (present(scale)) scaling = scale
 
-  if (calculateStatistics) call subStats(HI, array, mesg, scaling)
+  if (calculateStatistics) then ; if (present(scale)) then
+    allocate( rescaled_array(LBOUND(array,1):UBOUND(array,1), &
+                             LBOUND(array,2):UBOUND(array,2)) )
+    rescaled_array(:,:) = 0.0
+    do j=HI%jsc,HI%jec ; do i=HI%isc,HI%iec
+      rescaled_array(i,j) = scale*array(i,j)
+    enddo ; enddo
+    call subStats(HI, rescaled_array, mesg)
+    deallocate(rescaled_array)
+  else
+    call subStats(HI, array, mesg)
+  endif ; endif
 
   if (.not.writeChksums) return
 
@@ -186,11 +199,11 @@ subroutine chksum_h_2d(array, mesg, HI, haloshift, omit_corners, scale)
     subchk=mod(subchk,1000000000)
   end function subchk
 
-  subroutine subStats(HI, array, mesg, scale)
+  subroutine subStats(HI, array, mesg)
     type(hor_index_type), intent(in) :: HI
     real, dimension(HI%isd:,HI%jsd:), intent(in) :: array
     character(len=*), intent(in) :: mesg
-    real, intent(in) :: scale
+
     integer :: i, j, n
     real :: aMean, aMin, aMax
 
@@ -207,7 +220,7 @@ subroutine chksum_h_2d(array, mesg, HI, haloshift, omit_corners, scale)
     call min_across_PEs(aMin)
     call max_across_PEs(aMax)
     aMean = aMean / real(n)
-    if (is_root_pe()) call chk_sum_msg("h-point:",aMean*scale,aMin*scale,aMax*scale,mesg)
+    if (is_root_pe()) call chk_sum_msg("h-point:",aMean,aMin,aMax,mesg)
   end subroutine subStats
 
 end subroutine chksum_h_2d
@@ -274,7 +287,9 @@ subroutine chksum_B_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   logical,    optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,       optional, intent(in) :: scale     !< A scaling factor for this array.
 
+  real, allocatable, dimension(:,:) :: rescaled_array
   real :: scaling
+  integer :: i, j, Is, Js
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
   logical :: do_corners, sym, sym_stats
@@ -286,10 +301,23 @@ subroutine chksum_B_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 !     call chksum_error(FATAL, 'NaN detected in halo: '//trim(mesg))
   endif
   scaling = 1.0 ; if (present(scale)) scaling = scale
-
   sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
-  if (calculateStatistics) call subStats(HI, array, mesg, sym_stats, scaling)
+
+  if (calculateStatistics) then ; if (present(scale)) then
+    allocate( rescaled_array(LBOUND(array,1):UBOUND(array,1), &
+                             LBOUND(array,2):UBOUND(array,2)) )
+    rescaled_array(:,:) = 0.0
+    Is = HI%isc ; if (sym_stats) Is = HI%isc-1 
+    Js = HI%jsc ; if (sym_stats) Js = HI%jsc-1
+    do J=Js,HI%JecB ; do I=Is,HI%IecB
+      rescaled_array(I,J) = scale*array(I,J)
+    enddo ; enddo
+    call subStats(HI, rescaled_array, mesg, sym_stats)
+    deallocate(rescaled_array)
+  else
+    call subStats(HI, array, mesg, sym_stats)
+  endif ; endif
 
   if (.not.writeChksums) return
 
@@ -356,12 +384,12 @@ subroutine chksum_B_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     subchk=mod(subchk,1000000000)
   end function subchk
 
-  subroutine subStats(HI, array, mesg, sym_stats, scale)
+  subroutine subStats(HI, array, mesg, sym_stats)
     type(hor_index_type), intent(in) :: HI
     real, dimension(HI%IsdB:,HI%JsdB:), intent(in) :: array
     character(len=*), intent(in) :: mesg
     logical, intent(in) :: sym_stats
-    real, intent(in) :: scale
+
     integer :: i, j, n, IsB, JsB
     real :: aMean, aMin, aMax
 
@@ -380,7 +408,7 @@ subroutine chksum_B_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     call min_across_PEs(aMin)
     call max_across_PEs(aMax)
     aMean = aMean / real(n)
-    if (is_root_pe()) call chk_sum_msg("B-point:",aMean*scale,aMin*scale,aMax*scale,mesg)
+    if (is_root_pe()) call chk_sum_msg("B-point:",aMean,aMin,aMax,mesg)
   end subroutine subStats
 
 end subroutine chksum_B_2d
@@ -437,7 +465,9 @@ subroutine chksum_u_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   logical,               optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,                    optional, intent(in) :: scale     !< A scaling factor for this array.
 
+  real, allocatable, dimension(:,:) :: rescaled_array
   real :: scaling
+  integer :: i, j, Is
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
   logical :: do_corners, sym, sym_stats
@@ -452,7 +482,20 @@ subroutine chksum_u_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 
   sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
-  if (calculateStatistics) call subStats(HI, array, mesg, sym_stats, scaling)
+
+  if (calculateStatistics) then ; if (present(scale)) then
+    allocate( rescaled_array(LBOUND(array,1):UBOUND(array,1), &
+                             LBOUND(array,2):UBOUND(array,2)) )
+    rescaled_array(:,:) = 0.0
+    Is = HI%isc ; if (sym_stats) Is = HI%isc-1
+    do j=HI%jsc,HI%jec ; do I=Is,HI%IecB
+      rescaled_array(I,j) = scale*array(I,j)
+    enddo ; enddo
+    call subStats(HI, rescaled_array, mesg, sym_stats)
+    deallocate(rescaled_array)
+  else
+    call subStats(HI, array, mesg, sym_stats)
+  endif ; endif
 
   if (.not.writeChksums) return
 
@@ -525,12 +568,12 @@ subroutine chksum_u_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     subchk=mod(subchk,1000000000)
   end function subchk
 
-  subroutine subStats(HI, array, mesg, sym_stats, scale)
+  subroutine subStats(HI, array, mesg, sym_stats)
     type(hor_index_type), intent(in) :: HI
     real, dimension(HI%IsdB:,HI%jsd:), intent(in) :: array
     character(len=*), intent(in) :: mesg
     logical, intent(in) :: sym_stats
-    real, intent(in) :: scale
+
     integer :: i, j, n, IsB
     real :: aMean, aMin, aMax
 
@@ -548,7 +591,7 @@ subroutine chksum_u_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     call min_across_PEs(aMin)
     call max_across_PEs(aMax)
     aMean = aMean / real(n)
-    if (is_root_pe()) call chk_sum_msg("u-point:",aMean*scale,aMin*scale,aMax*scale,mesg)
+    if (is_root_pe()) call chk_sum_msg("u-point:",aMean,aMin,aMax,mesg)
   end subroutine subStats
 
 end subroutine chksum_u_2d
@@ -565,7 +608,9 @@ subroutine chksum_v_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   logical,               optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,                  optional, intent(in) :: scale     !< A scaling factor for this array.
 
+  real, allocatable, dimension(:,:) :: rescaled_array
   real :: scaling
+  integer :: i, j, Js
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
   logical :: do_corners, sym, sym_stats
@@ -580,7 +625,20 @@ subroutine chksum_v_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 
   sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
-  if (calculateStatistics) call subStats(HI, array, mesg, sym_stats, scaling)
+
+  if (calculateStatistics) then ; if (present(scale)) then
+    allocate( rescaled_array(LBOUND(array,1):UBOUND(array,1), &
+                             LBOUND(array,2):UBOUND(array,2)) )
+    rescaled_array(:,:) = 0.0
+    Js = HI%jsc ; if (sym_stats) Js = HI%jsc-1
+    do J=Js,HI%JecB ; do i=HI%isc,HI%iec
+      rescaled_array(i,J) = scale*array(i,J)
+    enddo ; enddo
+    call subStats(HI, rescaled_array, mesg, sym_stats)
+    deallocate(rescaled_array)
+  else
+    call subStats(HI, array, mesg, sym_stats)
+  endif ; endif
 
   if (.not.writeChksums) return
 
@@ -653,12 +711,12 @@ subroutine chksum_v_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     subchk=mod(subchk,1000000000)
   end function subchk
 
-  subroutine subStats(HI, array, mesg, sym_stats, scale)
+  subroutine subStats(HI, array, mesg, sym_stats)
     type(hor_index_type), intent(in) :: HI
     real, dimension(HI%isd:,HI%JsdB:), intent(in) :: array
     character(len=*), intent(in) :: mesg
     logical, intent(in) :: sym_stats
-    real, intent(in) :: scale
+
     integer :: i, j, n, JsB
     real :: aMean, aMin, aMax
 
@@ -676,7 +734,7 @@ subroutine chksum_v_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     call min_across_PEs(aMin)
     call max_across_PEs(aMax)
     aMean = aMean / real(n)
-    if (is_root_pe()) call chk_sum_msg("v-point:",aMean*scale,aMin*scale,aMax*scale,mesg)
+    if (is_root_pe()) call chk_sum_msg("v-point:",aMean,aMin,aMax,mesg)
   end subroutine subStats
 
 end subroutine chksum_v_2d
@@ -692,7 +750,9 @@ subroutine chksum_h_3d(array, mesg, HI, haloshift, omit_corners, scale)
   logical,                 optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,                    optional, intent(in) :: scale     !< A scaling factor for this array.
 
+  real, allocatable, dimension(:,:,:) :: rescaled_array
   real :: scaling
+  integer :: i, j, k
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
   logical :: do_corners
@@ -705,7 +765,20 @@ subroutine chksum_h_3d(array, mesg, HI, haloshift, omit_corners, scale)
   endif
   scaling = 1.0 ; if (present(scale)) scaling = scale
 
-  if (calculateStatistics) call subStats(HI, array, mesg, scaling)
+  if (calculateStatistics) then ; if (present(scale)) then
+    allocate( rescaled_array(LBOUND(array,1):UBOUND(array,1), &
+                             LBOUND(array,2):UBOUND(array,2), &
+                             LBOUND(array,3):UBOUND(array,3)) )
+    rescaled_array(:,:,:) = 0.0
+    do k=1,size(array,3) ; do j=HI%jsc,HI%jec ; do i=HI%isc,HI%iec
+      rescaled_array(i,j,k) = scale*array(i,j,k)
+    enddo ; enddo ; enddo
+
+    call subStats(HI, rescaled_array, mesg)
+    deallocate(rescaled_array)
+  else
+    call subStats(HI, array, mesg)
+  endif ; endif
 
   if (.not.writeChksums) return
 
@@ -763,11 +836,11 @@ subroutine chksum_h_3d(array, mesg, HI, haloshift, omit_corners, scale)
     subchk=mod(subchk,1000000000)
   end function subchk
 
-  subroutine subStats(HI, array, mesg, scale)
+  subroutine subStats(HI, array, mesg)
     type(hor_index_type), intent(in) :: HI
     real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: array
     character(len=*), intent(in) :: mesg
-    real, intent(in) :: scale
+
     integer :: i, j, k, n
     real :: aMean, aMin, aMax
 
@@ -784,7 +857,7 @@ subroutine chksum_h_3d(array, mesg, HI, haloshift, omit_corners, scale)
     call min_across_PEs(aMin)
     call max_across_PEs(aMax)
     aMean = aMean / real(n)
-    if (is_root_pe()) call chk_sum_msg("h-point:",aMean*scale,aMin*scale,aMax*scale,mesg)
+    if (is_root_pe()) call chk_sum_msg("h-point:",aMean,aMin,aMax,mesg)
   end subroutine subStats
 
 end subroutine chksum_h_3d
@@ -801,7 +874,9 @@ subroutine chksum_B_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   logical,                  optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,                     optional, intent(in) :: scale     !< A scaling factor for this array.
 
+  real, allocatable, dimension(:,:,:) :: rescaled_array
   real :: scaling
+  integer :: i, j, k, Is, Js
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
   logical :: do_corners, sym, sym_stats
@@ -813,10 +888,24 @@ subroutine chksum_B_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 !     call chksum_error(FATAL, 'NaN detected in halo: '//trim(mesg))
   endif
   scaling = 1.0 ; if (present(scale)) scaling = scale
-
   sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
-  if (calculateStatistics) call subStats(HI, array, mesg, sym_stats, scaling)
+
+  if (calculateStatistics) then ; if (present(scale)) then
+    allocate( rescaled_array(LBOUND(array,1):UBOUND(array,1), &
+                             LBOUND(array,2):UBOUND(array,2), &
+                             LBOUND(array,3):UBOUND(array,3)) )
+    rescaled_array(:,:,:) = 0.0
+    Is = HI%isc ; if (sym_stats) Is = HI%isc-1 
+    Js = HI%jsc ; if (sym_stats) Js = HI%jsc-1
+    do k=1,size(array,3) ; do J=Js,HI%JecB ; do I=Is,HI%IecB
+      rescaled_array(I,J,k) = scale*array(I,J,k)
+    enddo ; enddo ; enddo
+    call subStats(HI, rescaled_array, mesg, sym_stats)
+    deallocate(rescaled_array)
+  else
+    call subStats(HI, array, mesg, sym_stats)
+  endif ; endif
 
   if (.not.writeChksums) return
 
@@ -888,12 +977,12 @@ subroutine chksum_B_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     subchk=mod(subchk,1000000000)
   end function subchk
 
-  subroutine subStats(HI, array, mesg, sym_stats, scale)
+  subroutine subStats(HI, array, mesg, sym_stats)
     type(hor_index_type), intent(in) :: HI
     real, dimension(HI%IsdB:,HI%JsdB:,:), intent(in) :: array
     character(len=*), intent(in) :: mesg
     logical, intent(in) :: sym_stats
-    real, intent(in) :: scale
+
     integer :: i, j, k, n, IsB, JsB
     real :: aMean, aMin, aMax
 
@@ -911,7 +1000,7 @@ subroutine chksum_B_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     call min_across_PEs(aMin)
     call max_across_PEs(aMax)
     aMean = aMean / real(n)
-    if (is_root_pe()) call chk_sum_msg("B-point:",aMean*scale,aMin*scale,aMax*scale,mesg)
+    if (is_root_pe()) call chk_sum_msg("B-point:",aMean,aMin,aMax,mesg)
   end subroutine subStats
 
 end subroutine chksum_B_3d
@@ -928,7 +1017,9 @@ subroutine chksum_u_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   logical,                 optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,                    optional, intent(in) :: scale     !< A scaling factor for this array.
 
+  real, allocatable, dimension(:,:,:) :: rescaled_array
   real :: scaling
+  integer :: i, j, k, Is
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
   logical :: do_corners, sym, sym_stats
@@ -940,10 +1031,23 @@ subroutine chksum_u_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 !     call chksum_error(FATAL, 'NaN detected in halo: '//trim(mesg))
   endif
   scaling = 1.0 ; if (present(scale)) scaling = scale
-
   sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
-  if (calculateStatistics) call subStats(HI, array, mesg, sym_stats, scaling)
+
+  if (calculateStatistics) then ; if (present(scale)) then
+    allocate( rescaled_array(LBOUND(array,1):UBOUND(array,1), &
+                             LBOUND(array,2):UBOUND(array,2), &
+                             LBOUND(array,3):UBOUND(array,3)) )
+    rescaled_array(:,:,:) = 0.0
+    Is = HI%isc ; if (sym_stats) Is = HI%isc-1
+    do k=1,size(array,3) ; do j=HI%jsc,HI%jec ; do I=Is,HI%IecB
+      rescaled_array(I,j,k) = scale*array(I,j,k)
+    enddo ; enddo ; enddo
+    call subStats(HI, rescaled_array, mesg, sym_stats)
+    deallocate(rescaled_array)
+  else
+    call subStats(HI, array, mesg, sym_stats)
+  endif ; endif
 
   if (.not.writeChksums) return
 
@@ -1016,12 +1120,12 @@ subroutine chksum_u_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     subchk=mod(subchk,1000000000)
   end function subchk
 
-  subroutine subStats(HI, array, mesg, sym_stats, scale)
+  subroutine subStats(HI, array, mesg, sym_stats)
     type(hor_index_type), intent(in) :: HI
     real, dimension(HI%IsdB:,HI%jsd:,:), intent(in) :: array
     character(len=*), intent(in) :: mesg
     logical, intent(in) :: sym_stats
-    real, intent(in) :: scale
+
     integer :: i, j, k, n, IsB
     real :: aMean, aMin, aMax
 
@@ -1039,7 +1143,7 @@ subroutine chksum_u_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     call min_across_PEs(aMin)
     call max_across_PEs(aMax)
     aMean = aMean / real(n)
-    if (is_root_pe()) call chk_sum_msg("u-point:",aMean*scale,aMin*scale,aMax*scale,mesg)
+    if (is_root_pe()) call chk_sum_msg("u-point:",aMean,aMin,aMax,mesg)
   end subroutine subStats
 
 end subroutine chksum_u_3d
@@ -1056,7 +1160,9 @@ subroutine chksum_v_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   logical,                 optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,                    optional, intent(in) :: scale     !< A scaling factor for this array.
 
+  real, allocatable, dimension(:,:,:) :: rescaled_array
   real :: scaling
+  integer :: i, j, k, Js
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
   logical :: do_corners, sym, sym_stats
@@ -1068,10 +1174,23 @@ subroutine chksum_v_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 !     call chksum_error(FATAL, 'NaN detected in halo: '//trim(mesg))
   endif
   scaling = 1.0 ; if (present(scale)) scaling = scale
-
   sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
-  if (calculateStatistics) call subStats(HI, array, mesg, sym_stats, scaling)
+
+  if (calculateStatistics) then ; if (present(scale)) then
+    allocate( rescaled_array(LBOUND(array,1):UBOUND(array,1), &
+                             LBOUND(array,2):UBOUND(array,2), &
+                             LBOUND(array,3):UBOUND(array,3)) )
+    rescaled_array(:,:,:) = 0.0
+    Js = HI%jsc ; if (sym_stats) Js = HI%jsc-1
+    do k=1,size(array,3) ; do J=Js,HI%JecB ; do i=HI%isc,HI%iec
+      rescaled_array(i,J,k) = scale*array(i,J,k)
+    enddo ; enddo ; enddo
+    call subStats(HI, rescaled_array, mesg, sym_stats)
+    deallocate(rescaled_array)
+  else
+    call subStats(HI, array, mesg, sym_stats)
+  endif ; endif
 
   if (.not.writeChksums) return
 
@@ -1144,12 +1263,12 @@ subroutine chksum_v_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     subchk=mod(subchk,1000000000)
   end function subchk
 
-  subroutine subStats(HI, array, mesg, sym_stats, scale)
+  subroutine subStats(HI, array, mesg, sym_stats)
     type(hor_index_type), intent(in) :: HI
     real, dimension(HI%isd:,HI%JsdB:,:), intent(in) :: array
     character(len=*), intent(in) :: mesg
     logical, intent(in) :: sym_stats
-    real, intent(in) :: scale
+
     integer :: i, j, k, n, JsB
     real :: aMean, aMin, aMax
 
@@ -1167,7 +1286,7 @@ subroutine chksum_v_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     call min_across_PEs(aMin)
     call max_across_PEs(aMax)
     aMean = aMean / real(n)
-    if (is_root_pe()) call chk_sum_msg("v-point:",aMean*scale,aMin*scale,aMax*scale,mesg)
+    if (is_root_pe()) call chk_sum_msg("v-point:",aMean,aMin,aMax,mesg)
   end subroutine subStats
 
 end subroutine chksum_v_3d

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -308,7 +308,7 @@ subroutine chksum_B_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
     allocate( rescaled_array(LBOUND(array,1):UBOUND(array,1), &
                              LBOUND(array,2):UBOUND(array,2)) )
     rescaled_array(:,:) = 0.0
-    Is = HI%isc ; if (sym_stats) Is = HI%isc-1 
+    Is = HI%isc ; if (sym_stats) Is = HI%isc-1
     Js = HI%jsc ; if (sym_stats) Js = HI%jsc-1
     do J=Js,HI%JecB ; do I=Is,HI%IecB
       rescaled_array(I,J) = scale*array(I,J)
@@ -896,7 +896,7 @@ subroutine chksum_B_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
                              LBOUND(array,2):UBOUND(array,2), &
                              LBOUND(array,3):UBOUND(array,3)) )
     rescaled_array(:,:,:) = 0.0
-    Is = HI%isc ; if (sym_stats) Is = HI%isc-1 
+    Is = HI%isc ; if (sym_stats) Is = HI%isc-1
     Js = HI%jsc ; if (sym_stats) Js = HI%jsc-1
     do k=1,size(array,3) ; do J=Js,HI%JecB ; do I=Is,HI%IecB
       rescaled_array(I,J,k) = scale*array(I,J,k)

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -59,7 +59,7 @@ public diag_axis_init, ocean_register_diag, register_static_field
 public register_scalar_field
 public define_axes_group, diag_masks_set
 public diag_register_area_ids
-public diag_associate_volume_cell_measure
+public register_cell_measure, diag_associate_volume_cell_measure
 public diag_get_volume_cell_measure_dm_id
 public diag_set_state_ptrs, diag_update_remap_grids
 
@@ -503,6 +503,21 @@ subroutine diag_register_area_ids(diag_cs, id_area_t, id_area_q)
     enddo
   endif
 end subroutine diag_register_area_ids
+
+!> Sets a handle inside diagnostics mediator to associate 3d cell measures
+subroutine register_cell_measure(G, diag, Time)
+  type(ocean_grid_type),   intent(in)    :: G    !< Ocean grid structure
+  type(diag_ctrl), target, intent(inout) :: diag !< Regulates diagnostic output
+  type(time_type),         intent(in)    :: Time !< Model time
+  ! Local variables
+  integer :: id
+  id = register_diag_field('ocean_model', 'volcello', diag%axesTL, &
+                           Time, 'Ocean grid-cell volume', 'm3', &
+                           standard_name='ocean_volume', v_extensive=.true., &
+                           x_cell_method='sum', y_cell_method='sum')
+  call diag_associate_volume_cell_measure(diag, id)
+
+end subroutine register_cell_measure
 
 !> Attaches the id of cell volumes to axes groups for use with cell_measures
 subroutine diag_associate_volume_cell_measure(diag_cs, id_h_volume)

--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -32,12 +32,14 @@ type, public :: doc_type ; private
   integer :: unitAll = -1           ! The open unit number for docFileBase + .all.
   integer :: unitShort = -1         ! The open unit number for docFileBase + .short.
   integer :: unitLayout = -1        ! The open unit number for docFileBase + .layout.
+  integer :: unitDebugging  = -1    ! The open unit number for docFileBase + .debugging.
   logical :: filesAreOpen = .false. ! True if any files were successfully opened.
   character(len=mLen) :: docFileBase = '' ! The basename of the files where run-time
                                     ! parameters, settings and defaults are documented.
   logical :: complete = .true.      ! If true, document all parameters.
   logical :: minimal = .true.       ! If true, document non-default parameters.
   logical :: layout = .true.        ! If true, document layout parameters.
+  logical :: debugging = .true.     ! If true, document debugging parameters.
   logical :: defineSyntax = .false. ! If true, use #def syntax instead of a=b syntax
   logical :: warnOnConflicts = .false. ! Cause a WARNING error if defaults differ.
   integer :: commentColumn = 32     ! Number of spaces before the comment marker.
@@ -78,12 +80,14 @@ subroutine doc_param_none(doc, varname, desc, units)
   endif
 end subroutine doc_param_none
 
-subroutine doc_param_logical(doc, varname, desc, units, val, default, layoutParam)
+subroutine doc_param_logical(doc, varname, desc, units, val, default, &
+                             layoutParam, debuggingParam)
   type(doc_type),   pointer    :: doc
   character(len=*), intent(in) :: varname, desc, units
   logical,          intent(in) :: val
   logical,          optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine handles parameter documentation for logicals.
   character(len=mLen) :: mesg
   logical :: equalsDefault
@@ -109,16 +113,19 @@ subroutine doc_param_logical(doc, varname, desc, units, val, default, layoutPara
     endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
-    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, layoutParam=layoutParam)
+    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
+                             layoutParam=layoutParam, debuggingParam=debuggingParam)
   endif
 end subroutine doc_param_logical
 
-subroutine doc_param_logical_array(doc, varname, desc, units, vals, default, layoutParam)
+subroutine doc_param_logical_array(doc, varname, desc, units, vals, default, &
+                                   layoutParam, debuggingParam)
   type(doc_type),   pointer    :: doc
   character(len=*), intent(in) :: varname, desc, units
   logical,          intent(in) :: vals(:)
   logical,          optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine handles parameter documentation for arrays of logicals.
   integer :: i
   character(len=mLen) :: mesg
@@ -152,16 +159,19 @@ subroutine doc_param_logical_array(doc, varname, desc, units, vals, default, lay
     endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
-    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, layoutParam=layoutParam)
+    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
+                             layoutParam=layoutParam, debuggingParam=debuggingParam)
   endif
 end subroutine doc_param_logical_array
 
-subroutine doc_param_int(doc, varname, desc, units, val, default, layoutParam)
+subroutine doc_param_int(doc, varname, desc, units, val, default, &
+                         layoutParam, debuggingParam)
   type(doc_type),   pointer    :: doc
   character(len=*), intent(in) :: varname, desc, units
   integer,          intent(in) :: val
   integer,          optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine handles parameter documentation for integers.
   character(len=mLen) :: mesg
   character(len=doc%commentColumn)  :: valstring
@@ -181,16 +191,19 @@ subroutine doc_param_int(doc, varname, desc, units, val, default, layoutParam)
     endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
-    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, layoutParam=layoutParam)
+    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
+                             layoutParam=layoutParam, debuggingParam=debuggingParam)
   endif
 end subroutine doc_param_int
 
-subroutine doc_param_int_array(doc, varname, desc, units, vals, default, layoutParam)
+subroutine doc_param_int_array(doc, varname, desc, units, vals, default, &
+                               layoutParam, debuggingParam)
   type(doc_type),   pointer    :: doc
   character(len=*), intent(in) :: varname, desc, units
   integer,          intent(in) :: vals(:)
   integer,          optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine handles parameter documentation for arrays of integers.
   integer :: i
   character(len=mLen) :: mesg
@@ -216,16 +229,18 @@ subroutine doc_param_int_array(doc, varname, desc, units, vals, default, layoutP
     endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
-    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, layoutParam=layoutParam)
+    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
+                             layoutParam=layoutParam, debuggingParam=debuggingParam)
   endif
 
 end subroutine doc_param_int_array
 
-subroutine doc_param_real(doc, varname, desc, units, val, default)
+subroutine doc_param_real(doc, varname, desc, units, val, default, debuggingParam)
   type(doc_type),   pointer    :: doc
   character(len=*), intent(in) :: varname, desc, units
   real,             intent(in) :: val
   real,             optional, intent(in) :: default
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine handles parameter documentation for reals.
   character(len=mLen) :: mesg
   character(len=doc%commentColumn)  :: valstring
@@ -245,15 +260,17 @@ subroutine doc_param_real(doc, varname, desc, units, val, default)
     endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
-    call writeMessageAndDesc(doc, mesg, desc, equalsDefault)
+    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
+                             debuggingParam=debuggingParam)
   endif
 end subroutine doc_param_real
 
-subroutine doc_param_real_array(doc, varname, desc, units, vals, default)
+subroutine doc_param_real_array(doc, varname, desc, units, vals, default, debuggingParam)
   type(doc_type),   pointer    :: doc
   character(len=*), intent(in) :: varname, desc, units
   real,             intent(in) :: vals(:)
   real,             optional, intent(in) :: default
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine handles parameter documentation for arrays of reals.
   integer :: i
   character(len=mLen) :: mesg
@@ -276,17 +293,20 @@ subroutine doc_param_real_array(doc, varname, desc, units, vals, default)
     endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
-    call writeMessageAndDesc(doc, mesg, desc, equalsDefault)
+    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
+                             debuggingParam=debuggingParam)
   endif
 
 end subroutine doc_param_real_array
 
-subroutine doc_param_char(doc, varname, desc, units, val, default, layoutParam)
+subroutine doc_param_char(doc, varname, desc, units, val, default, &
+                          layoutParam, debuggingParam)
   type(doc_type),   pointer    :: doc
   character(len=*), intent(in) :: varname, desc, units
   character(len=*), intent(in) :: val
   character(len=*), optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine handles parameter documentation for character strings.
   character(len=mLen) :: mesg
   logical :: equalsDefault
@@ -304,7 +324,8 @@ subroutine doc_param_char(doc, varname, desc, units, val, default, layoutParam)
     endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
-    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, layoutParam=layoutParam)
+    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
+                             layoutParam=layoutParam, debuggingParam=debuggingParam)
   endif
 
 end subroutine doc_param_char
@@ -356,12 +377,14 @@ subroutine doc_closeBlock(doc, blockName)
   endif
 end subroutine doc_closeBlock
 
-subroutine doc_param_time(doc, varname, desc, units, val, default, layoutParam)
+subroutine doc_param_time(doc, varname, desc, units, val, default, &
+                          layoutParam, debuggingParam)
   type(doc_type),   pointer    :: doc
   character(len=*), intent(in) :: varname, desc, units
   type(time_type),  intent(in) :: val
   type(time_type),  optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine handles parameter documentation for time-type variables.
 !  ### This needs to be written properly!
   integer :: numspc
@@ -378,30 +401,34 @@ subroutine doc_param_time(doc, varname, desc, units, val, default, layoutParam)
     if (len_trim(units) > 0) mesg = trim(mesg)//"   ["//trim(units)//"]"
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
-    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, layoutParam=layoutParam)
+    call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
+                             layoutParam=layoutParam, debuggingParam=debuggingParam)
   endif
 
 end subroutine doc_param_time
 
-subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, layoutParam)
+subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, &
+                               layoutParam, debuggingParam)
   type(doc_type),             intent(in) :: doc
   character(len=*),           intent(in) :: vmesg, desc
   logical,          optional, intent(in) :: valueWasDefault
   integer,          optional, intent(in) :: indent
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
   character(len=mLen) :: mesg
   integer :: start_ind = 1, end_ind, indnt, tab, len_tab, len_nl
-  logical :: all, short, layout
+  logical :: all, short, layout, debug
 
-  layout = .false.
-  if (present(layoutParam)) layout = layoutParam
-  all = doc%complete .and. (doc%unitAll > 0) .and. .not. layout
-  short = doc%minimal .and. (doc%unitShort > 0) .and. .not. layout
+  layout = .false. ; if (present(layoutParam)) layout = layoutParam
+  debug = .false. ; if (present(debuggingParam)) debug = debuggingParam
+  all = doc%complete .and. (doc%unitAll > 0) .and. .not. (layout .or. debug)
+  short = doc%minimal .and. (doc%unitShort > 0) .and. .not. (layout .or. debug)
   if (present(valueWasDefault)) short = short .and. (.not. valueWasDefault)
 
   if (all) write(doc%unitAll, '(a)') trim(vmesg)
   if (short) write(doc%unitShort, '(a)') trim(vmesg)
   if (layout) write(doc%unitLayout, '(a)') trim(vmesg)
+  if (debug) write(doc%unitDebugging, '(a)') trim(vmesg)
 
   if (len_trim(desc) == 0) return
 
@@ -426,6 +453,7 @@ subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, layout
       if (all) write(doc%unitAll, '(a)') trim(mesg)
       if (short) write(doc%unitShort, '(a)') trim(mesg)
       if (layout) write(doc%unitLayout, '(a)') trim(mesg)
+      if (debug) write(doc%unitDebugging, '(a)') trim(mesg)
     else
       mesg = repeat(" ",indnt)//"! "//trim(desc(start_ind:))
       do ; tab = index(mesg, "\t")
@@ -435,6 +463,7 @@ subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, layout
       if (all) write(doc%unitAll, '(a)') trim(mesg)
       if (short) write(doc%unitShort, '(a)') trim(mesg)
       if (layout) write(doc%unitLayout, '(a)') trim(mesg)
+      if (debug) write(doc%unitDebugging, '(a)') trim(mesg)
       exit
     endif
 
@@ -632,10 +661,10 @@ end subroutine doc_function
 
 ! ----------------------------------------------------------------------
 
-subroutine doc_init(docFileBase, doc, minimal, complete)
+subroutine doc_init(docFileBase, doc, minimal, complete, layout, debugging)
   character(len=*),  intent(in)  :: docFileBase
   type(doc_type),    pointer     :: doc
-  logical, optional, intent(in)  :: minimal, complete
+  logical, optional, intent(in)  :: minimal, complete, layout, debugging
 ! Arguments: docFileBase - The name of the doc file.
 !  (inout)   doc - The doc_type to populate.
 
@@ -645,7 +674,10 @@ subroutine doc_init(docFileBase, doc, minimal, complete)
 
   doc%docFileBase = docFileBase
   if (present(minimal)) doc%minimal = minimal
-  if (present(minimal)) doc%complete = complete
+  if (present(complete)) doc%complete = complete
+  if (present(layout)) doc%layout = layout
+  if (present(debugging)) doc%debugging = debugging
+
 end subroutine doc_init
 
 subroutine open_doc_file(doc)
@@ -666,7 +698,8 @@ subroutine open_doc_file(doc)
       open(doc%unitAll, file=trim(fileName), access='SEQUENTIAL', form='FORMATTED', &
            action='WRITE', status='REPLACE', iostat=ios)
       write(doc%unitAll, '(a)') &
-       '! This file was written by the model and records all non-layout parameters used at run-time.'
+       '! This file was written by the model and records all non-layout '//&
+       'or debugging parameters used at run-time.'
     else ! This file is being reopened, and should be appended.
       open(doc%unitAll, file=trim(fileName), access='SEQUENTIAL', form='FORMATTED', &
            action='WRITE', status='OLD', position='APPEND', iostat=ios)
@@ -720,6 +753,27 @@ subroutine open_doc_file(doc)
     doc%filesAreOpen = .true.
   endif
 
+  if ((len_trim(doc%docFileBase) > 0) .and. doc%debugging .and. (doc%unitDebugging<0)) then
+    new_file = .true. ; if (doc%unitDebugging /= -1) new_file = .false.
+    doc%unitDebugging = find_unused_unit_number()
+
+    write(fileName(1:240),'(a)') trim(doc%docFileBase)//'.debugging'
+    if (new_file) then
+      open(doc%unitDebugging, file=trim(fileName), access='SEQUENTIAL', form='FORMATTED', &
+           action='WRITE', status='REPLACE', iostat=ios)
+      write(doc%unitDebugging, '(a)') &
+       '! This file was written by the model and records the debugging parameters used at run-time.'
+    else ! This file is being reopened, and should be appended.
+      open(doc%unitDebugging, file=trim(fileName), access='SEQUENTIAL', form='FORMATTED', &
+           action='WRITE', status='OLD', position='APPEND', iostat=ios)
+    endif
+    inquire(doc%unitDebugging, opened=opened)
+    if ((.not.opened) .or. (ios /= 0)) then
+      call MOM_error(FATAL, "Failed to open doc file "//trim(fileName)//".")
+    endif
+    doc%filesAreOpen = .true.
+  endif
+
 end subroutine open_doc_file
 
 function find_unused_unit_number()
@@ -754,6 +808,11 @@ subroutine doc_end(doc)
   if (doc%unitLayout > 0) then
     close(doc%unitLayout)
     doc%unitLayout = -2
+  endif
+
+  if (doc%unitDebugging > 0) then
+    close(doc%unitDebugging)
+    doc%unitDebugging = -2
   endif
 
   doc%filesAreOpen = .false.

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -239,7 +239,8 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
     CS%complete_doc = .false.
     CS%minimal_doc = .false.
   endif
-  call doc_init(doc_path, CS%doc, CS%minimal_doc, CS%complete_doc)
+  call doc_init(doc_path, CS%doc, minimal=CS%minimal_doc, complete=CS%complete_doc, &
+                layout=CS%complete_doc, debugging=CS%complete_doc)
 
 end subroutine open_param_file
 
@@ -1237,7 +1238,7 @@ subroutine log_version_plain(modulename, version)
 end subroutine log_version_plain
 
 subroutine log_param_int(CS, modulename, varname, value, desc, units, &
-                         default, layoutParam)
+                         default, layoutParam, debuggingParam)
   type(param_file_type),      intent(in) :: CS
   character(len=*),           intent(in) :: modulename
   character(len=*),           intent(in) :: varname
@@ -1245,6 +1246,7 @@ subroutine log_param_int(CS, modulename, varname, value, desc, units, &
   character(len=*), optional, intent(in) :: desc, units
   integer,          optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine writes the value of an integer parameter to a log file,
 ! along with its name and the module it came from.
   character(len=240) :: mesg, myunits
@@ -1258,12 +1260,12 @@ subroutine log_param_int(CS, modulename, varname, value, desc, units, &
   myunits=" "; if (present(units)) write(myunits(1:240),'(A)') trim(units)
   if (present(desc)) &
     call doc_param(CS%doc, varname, desc, myunits, value, default, &
-                   layoutParam=layoutParam)
+                   layoutParam=layoutParam, debuggingParam=debuggingParam)
 
 end subroutine log_param_int
 
 subroutine log_param_int_array(CS, modulename, varname, value, desc, &
-                               units, default, layoutParam)
+                               units, default, layoutParam, debuggingParam)
   type(param_file_type),      intent(in) :: CS
   character(len=*),           intent(in) :: modulename
   character(len=*),           intent(in) :: varname
@@ -1271,6 +1273,7 @@ subroutine log_param_int_array(CS, modulename, varname, value, desc, &
   character(len=*), optional, intent(in) :: desc, units
   integer,          optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine writes the value of an integer parameter to a log file,
 ! along with its name and the module it came from.
   character(len=1320) :: mesg
@@ -1285,18 +1288,19 @@ subroutine log_param_int_array(CS, modulename, varname, value, desc, &
   myunits=" "; if (present(units)) write(myunits(1:240),'(A)') trim(units)
   if (present(desc)) &
     call doc_param(CS%doc, varname, desc, myunits, value, default, &
-                   layoutParam=layoutParam)
+                   layoutParam=layoutParam, debuggingParam=debuggingParam)
 
 end subroutine log_param_int_array
 
 subroutine log_param_real(CS, modulename, varname, value, desc, units, &
-                          default)
+                          default, debuggingParam)
   type(param_file_type),      intent(in) :: CS
   character(len=*),           intent(in) :: modulename
   character(len=*),           intent(in) :: varname
   real,                       intent(in) :: value
   character(len=*), optional, intent(in) :: desc, units
   real,             optional, intent(in) :: default
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine writes the value of a real parameter to a log file,
 ! along with its name and the module it came from.
   character(len=240) :: mesg, myunits
@@ -1310,7 +1314,8 @@ subroutine log_param_real(CS, modulename, varname, value, desc, units, &
 
   myunits="not defined"; if (present(units)) write(myunits(1:240),'(A)') trim(units)
   if (present(desc)) &
-    call doc_param(CS%doc, varname, desc, myunits, value, default)
+    call doc_param(CS%doc, varname, desc, myunits, value, default, &
+                   debuggingParam=debuggingParam)
 
 end subroutine log_param_real
 
@@ -1344,7 +1349,7 @@ subroutine log_param_real_array(CS, modulename, varname, value, desc, &
 end subroutine log_param_real_array
 
 subroutine log_param_logical(CS, modulename, varname, value, desc, &
-                             units, default, layoutParam)
+                             units, default, layoutParam, debuggingParam)
   type(param_file_type),      intent(in) :: CS
   character(len=*),           intent(in) :: modulename
   character(len=*),           intent(in) :: varname
@@ -1352,6 +1357,7 @@ subroutine log_param_logical(CS, modulename, varname, value, desc, &
   character(len=*), optional, intent(in) :: desc, units
   logical,          optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine writes the value of a logical parameter to a log file,
 ! along with its name and the module it came from.
   character(len=240) :: mesg, myunits
@@ -1369,12 +1375,12 @@ subroutine log_param_logical(CS, modulename, varname, value, desc, &
   myunits="Boolean"; if (present(units)) write(myunits(1:240),'(A)') trim(units)
   if (present(desc)) &
     call doc_param(CS%doc, varname, desc, myunits, value, default, &
-                   layoutParam=layoutParam)
+                   layoutParam=layoutParam, debuggingParam=debuggingParam)
 
 end subroutine log_param_logical
 
 subroutine log_param_char(CS, modulename, varname, value, desc, units, &
-                          default, layoutParam)
+                          default, layoutParam, debuggingParam)
   type(param_file_type),      intent(in) :: CS
   character(len=*),           intent(in) :: modulename
   character(len=*),           intent(in) :: varname
@@ -1382,6 +1388,7 @@ subroutine log_param_char(CS, modulename, varname, value, desc, units, &
   character(len=*), optional, intent(in) :: desc, units
   character(len=*), optional, intent(in) :: default
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 ! This subroutine writes the value of a character string parameter to a log
 ! file, along with its name and the module it came from.
   character(len=240) :: mesg, myunits
@@ -1396,14 +1403,14 @@ subroutine log_param_char(CS, modulename, varname, value, desc, units, &
   myunits=" "; if (present(units)) write(myunits(1:240),'(A)') trim(units)
   if (present(desc)) &
     call doc_param(CS%doc, varname, desc, myunits, value, default, &
-                   layoutParam=layoutParam)
+                   layoutParam=layoutParam, debuggingParam=debuggingParam)
 
 end subroutine log_param_char
 
 !> This subroutine writes the value of a time-type parameter to a log file,
 !! along with its name and the module it came from.
 subroutine log_param_time(CS, modulename, varname, value, desc, units, &
-                          default, timeunit, layoutParam, log_date)
+                          default, timeunit, layoutParam, debuggingParam, log_date)
   type(param_file_type),      intent(in) :: CS
   character(len=*),           intent(in) :: modulename
   character(len=*),           intent(in) :: varname
@@ -1413,6 +1420,7 @@ subroutine log_param_time(CS, modulename, varname, value, desc, units, &
   real,             optional, intent(in) :: timeunit
   logical,          optional, intent(in) :: log_date   !< If true, log the time_type in date format.
   logical,          optional, intent(in) :: layoutParam
+  logical,          optional, intent(in) :: debuggingParam
 
   real :: real_time, real_default
   logical :: use_timeunit, date_format
@@ -1446,10 +1454,11 @@ subroutine log_param_time(CS, modulename, varname, value, desc, units, &
       if (present(default)) then
         default_string = convert_date_to_string(default)
         call doc_param(CS%doc, varname, desc, myunits, date_string, &
-                       default=default_string, layoutParam=layoutParam)
+                       default=default_string, layoutParam=layoutParam, &
+                       debuggingParam=debuggingParam)
       else
         call doc_param(CS%doc, varname, desc, myunits, date_string, &
-                       layoutParam=layoutParam)
+                       layoutParam=layoutParam, debuggingParam=debuggingParam)
       endif
     elseif (use_timeunit) then
       if (present(units)) then
@@ -1512,7 +1521,7 @@ end function convert_date_to_string
 
 subroutine get_param_int(CS, modulename, varname, value, desc, units, &
                default, fail_if_missing, do_not_read, do_not_log, &
-               static_value, layoutParam)
+               static_value, layoutParam, debuggingParam)
   type(param_file_type),      intent(in)    :: CS
   character(len=*),           intent(in)    :: modulename
   character(len=*),           intent(in)    :: varname
@@ -1522,6 +1531,7 @@ subroutine get_param_int(CS, modulename, varname, value, desc, units, &
   logical,          optional, intent(in)    :: fail_if_missing
   logical,          optional, intent(in)    :: do_not_read, do_not_log
   logical,          optional, intent(in)    :: layoutParam
+  logical,          optional, intent(in)    :: debuggingParam
 ! This subroutine writes the value of a real parameter to a log file,
 ! along with its name and the module it came from.
   logical :: do_read, do_log
@@ -1537,14 +1547,14 @@ subroutine get_param_int(CS, modulename, varname, value, desc, units, &
 
   if (do_log) then
     call log_param_int(CS, modulename, varname, value, desc, units, &
-                       default, layoutParam)
+                       default, layoutParam, debuggingParam)
   endif
 
 end subroutine get_param_int
 
 subroutine get_param_int_array(CS, modulename, varname, value, desc, units, &
                default, fail_if_missing, do_not_read, do_not_log, &
-               static_value, layoutParam)
+               static_value, layoutParam, debuggingParam)
   type(param_file_type),      intent(in)    :: CS
   character(len=*),           intent(in)    :: modulename
   character(len=*),           intent(in)    :: varname
@@ -1554,6 +1564,7 @@ subroutine get_param_int_array(CS, modulename, varname, value, desc, units, &
   logical,          optional, intent(in)    :: fail_if_missing
   logical,          optional, intent(in)    :: do_not_read, do_not_log
   logical,          optional, intent(in)    :: layoutParam
+  logical,          optional, intent(in)    :: debuggingParam
 ! This subroutine writes the value of a real parameter to a log file,
 ! along with its name and the module it came from.
   logical :: do_read, do_log
@@ -1569,7 +1580,7 @@ subroutine get_param_int_array(CS, modulename, varname, value, desc, units, &
 
   if (do_log) then
     call log_param_int_array(CS, modulename, varname, value, desc, &
-                             units, default, layoutParam)
+                             units, default, layoutParam, debuggingParam)
   endif
 
 end subroutine get_param_int_array
@@ -1636,7 +1647,7 @@ end subroutine get_param_real_array
 
 subroutine get_param_char(CS, modulename, varname, value, desc, units, &
                default, fail_if_missing, do_not_read, do_not_log, &
-               static_value, layoutParam)
+               static_value, layoutParam, debuggingParam)
   type(param_file_type),      intent(in)    :: CS
   character(len=*),           intent(in)    :: modulename
   character(len=*),           intent(in)    :: varname
@@ -1646,6 +1657,7 @@ subroutine get_param_char(CS, modulename, varname, value, desc, units, &
   logical,          optional, intent(in)    :: fail_if_missing
   logical,          optional, intent(in)    :: do_not_read, do_not_log
   logical,          optional, intent(in)    :: layoutParam
+  logical,          optional, intent(in)    :: debuggingParam
 ! This subroutine writes the value of a real parameter to a log file,
 ! along with its name and the module it came from.
   logical :: do_read, do_log
@@ -1661,7 +1673,7 @@ subroutine get_param_char(CS, modulename, varname, value, desc, units, &
 
   if (do_log) then
     call log_param_char(CS, modulename, varname, value, desc, units, &
-                        default, layoutParam)
+                        default, layoutParam, debuggingParam)
   endif
 
 end subroutine get_param_char
@@ -1708,7 +1720,7 @@ end subroutine get_param_char_array
 
 subroutine get_param_logical(CS, modulename, varname, value, desc, units, &
                default, fail_if_missing, do_not_read, do_not_log, &
-               static_value, layoutParam)
+               static_value, layoutParam, debuggingParam)
   type(param_file_type),      intent(in)    :: CS
   character(len=*),           intent(in)    :: modulename
   character(len=*),           intent(in)    :: varname
@@ -1718,6 +1730,7 @@ subroutine get_param_logical(CS, modulename, varname, value, desc, units, &
   logical,          optional, intent(in)    :: fail_if_missing
   logical,          optional, intent(in)    :: do_not_read, do_not_log
   logical,          optional, intent(in)    :: layoutParam
+  logical,          optional, intent(in)    :: debuggingParam
 ! This subroutine writes the value of a real parameter to a log file,
 ! along with its name and the module it came from.
   logical :: do_read, do_log
@@ -1733,14 +1746,15 @@ subroutine get_param_logical(CS, modulename, varname, value, desc, units, &
 
   if (do_log) then
     call log_param_logical(CS, modulename, varname, value, desc, &
-                           units, default, layoutParam)
+                           units, default, layoutParam, debuggingParam)
   endif
 
 end subroutine get_param_logical
 
 subroutine get_param_time(CS, modulename, varname, value, desc, units, &
                           default, fail_if_missing, do_not_read, do_not_log, &
-                          timeunit, static_value, layoutParam, log_as_date)
+                          timeunit, static_value, layoutParam, debuggingParam, &
+                          log_as_date)
   type(param_file_type),      intent(in)    :: CS
   character(len=*),           intent(in)    :: modulename
   character(len=*),           intent(in)    :: varname
@@ -1751,6 +1765,7 @@ subroutine get_param_time(CS, modulename, varname, value, desc, units, &
   logical,          optional, intent(in)    :: do_not_read, do_not_log
   real,             optional, intent(in)    :: timeunit
   logical,          optional, intent(in)    :: layoutParam
+  logical,          optional, intent(in)    :: debuggingParam
   logical,          optional, intent(in)    :: log_as_date
 ! This subroutine writes the value of a real parameter to a log file,
 ! along with its name and the module it came from.
@@ -1769,7 +1784,8 @@ subroutine get_param_time(CS, modulename, varname, value, desc, units, &
   if (do_log) then
     if (present(log_as_date)) log_date = log_as_date
     call log_param_time(CS, modulename, varname, value, desc, units, default, &
-                        timeunit, layoutParam=layoutParam, log_date=log_date)
+                        timeunit, layoutParam=layoutParam, &
+                        debuggingParam=debuggingParam, log_date=log_date)
   endif
 
 end subroutine get_param_time

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -88,14 +88,14 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, CS, hu, hv)
   type(MEKE_type),                          pointer       :: MEKE !< MEKE data.
   type(ocean_grid_type),                    intent(inout) :: G    !< Ocean grid.
   type(verticalGrid_type),                  intent(in)    :: GV   !< Ocean vertical grid structure.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thickness (m or kg m-2).
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thickness in H (m or kg m-2).
   real, dimension(SZIB_(G),SZJ_(G)),         intent(in)    :: SN_u !< Eady growth rate at u-points (s-1).
   real, dimension(SZI_(G),SZJB_(G)),         intent(in)    :: SN_v !< Eady growth rate at u-points (s-1).
   type(vertvisc_type),                      intent(in)    :: visc !< The vertical viscosity type.
   real,                                     intent(in)    :: dt   !< Model(baroclinic) time-step (s).
   type(MEKE_CS),                            pointer       :: CS   !< MEKE control structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: hu   !< Zonal flux flux (m3).
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: hv   !< Meridional mass flux (m3).
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: hu   !< Zonal flux flux (H m2 s-1).
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: hv   !< Meridional mass flux (H m2 s-1).
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     mass, &         ! The total mass of the water column, in kg m-2.
@@ -112,13 +112,13 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, CS, hu, hv)
   real, dimension(SZIB_(G),SZJ_(G)) :: &
     MEKE_uflux, &   ! The zonal diffusive flux of MEKE, in kg m2 s-3.
     Kh_u, &         ! The zonal diffusivity that is actually used, in m2 s-1.
-    baroHu, &       ! Depth integrated zonal mass flux (m3).
+    baroHu, &       ! Depth integrated zonal mass flux (H m2 s-1).
     drag_vel_u      ! A (vertical) viscosity associated with bottom drag at
                     ! u-points, in m s-1.
   real, dimension(SZI_(G),SZJB_(G)) :: &
     MEKE_vflux, &   ! The meridional diffusive flux of MEKE, in kg m2 s-3.
     Kh_v, &         ! The meridional diffusivity that is actually used, in m2 s-1.
-    baroHv, &       ! Depth integrated meridional mass flux (m3).
+    baroHv, &       ! Depth integrated meridional mass flux (H m2 s-1).
     drag_vel_v      ! A (vertical) viscosity associated with bottom drag at
                     ! v-points, in m s-1.
   real :: Kh_here, Inv_Kh_max, K4_here
@@ -158,7 +158,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, CS, hu, hv)
       if (associated(MEKE%GM_src)) call hchksum(MEKE%GM_src, 'MEKE GM_src',G%HI)
       if (associated(MEKE%MEKE)) call hchksum(MEKE%MEKE, 'MEKE MEKE',G%HI)
       call uvchksum("MEKE SN_[uv]", SN_u, SN_v, G%HI)
-      call uvchksum("MEKE h[uv]", hu, hv, G%HI, haloshift=1)
+      call uvchksum("MEKE h[uv]", hu, hv, G%HI, haloshift=1, scale=GV%H_to_m)
     endif
 
     ! Why are these 3 lines repeated from above?
@@ -395,7 +395,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, CS, hu, hv)
 !$OMP                               mass,mass_neglect,Kh_v,MEKE_vflux,I_mass, &
 !$OMP                               sdt_damp,drag_rate,Rho0,drag_rate_visc,   &
 !$OMP                               cdrag2,bottomFac2,MEKE_decay,barotrFac2,  &
-!$OMP                               use_drag_rate,dt,baroHu,baroHv) &
+!$OMP                               use_drag_rate,dt,baroHu,baroHv,GV) &
 !$OMP                       private(Kh_here,Inv_Kh_max,ldamping,advFac)
     if (CS%MEKE_KH >= 0.0 .or. CS%KhMEKE_FAC > 0.0 .or. CS%MEKE_advection_factor >0.0) then
       ! Lateral diffusion of MEKE
@@ -428,7 +428,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, CS, hu, hv)
             (MEKE%MEKE(i,j) - MEKE%MEKE(i,j+1))
       enddo ; enddo
       if (CS%MEKE_advection_factor>0.) then
-        advFac = CS%MEKE_advection_factor / dt
+        advFac = GV%H_to_m * CS%MEKE_advection_factor / dt
 !$OMP do
         do j=js,je ; do I=is-1,ie
           if (baroHu(I,j)>0.) then

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -693,7 +693,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, CS, e, calculate_slopes)
     do I=is-1,ie
       !SN_u(I,j) = sqrt( SN_u(I,j) / ( max(G%bathyT(I,j), G%bathyT(I+1,j)) + GV%Angstrom ) )
       !The code below behaves better than the line above. Not sure why? AJA
-      if ( min(G%bathyT(I,j), G%bathyT(I+1,j)) > H_cutoff ) then
+      if ( min(G%bathyT(I,j), G%bathyT(I+1,j)) > H_cutoff*GV%H_to_m ) then
         CS%SN_u(I,j) = G%mask2dCu(I,j) * sqrt( CS%SN_u(I,j) / max(G%bathyT(I,j), G%bathyT(I+1,j)) )
       else
         CS%SN_u(I,j) = 0.0
@@ -708,7 +708,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, CS, e, calculate_slopes)
     do i=is,ie
       !SN_v(i,J) = sqrt( SN_v(i,J) / ( max(G%bathyT(i,J), G%bathyT(i,J+1)) + GV%Angstrom ) )
       !The code below behaves better than the line above. Not sure why? AJA
-      if ( min(G%bathyT(I,j), G%bathyT(I+1,j)) > H_cutoff ) then
+      if ( min(G%bathyT(I,j), G%bathyT(I+1,j)) > H_cutoff*GV%H_to_m ) then
         CS%SN_v(i,J) = G%mask2dCv(i,J) * sqrt( CS%SN_v(i,J) / max(G%bathyT(i,J), G%bathyT(i,J+1)) )
       else
         CS%SN_v(I,j) = 0.0

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -111,17 +111,17 @@ end subroutine mixedlayer_restrat
 !> Calculates a restratifying flow in the mixed layer.
 subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix, G, GV, CS)
   ! Arguments
-  type(ocean_grid_type),                     intent(inout) :: G       !< Ocean grid structure
-  type(verticalGrid_type),                   intent(in)    :: GV      !< Ocean vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h       !< Layer thickness (H units = m or kg/m2)
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uhtr    !< Accumulated zonal mass flux (m3 or kg)
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: vhtr    !< Accumulated meridional mass flux (m3 or kg)
-  type(thermo_var_ptrs),                     intent(in)    :: tv      !< Thermodynamic variables structure
+  type(ocean_grid_type),                     intent(inout) :: G      !< Ocean grid structure
+  type(verticalGrid_type),                   intent(in)    :: GV     !< Ocean vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h      !< Layer thickness (H units = m or kg/m2)
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uhtr   !< Accumulated zonal mass flux (m3 or kg)
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: vhtr   !< Accumulated meridional mass flux (m3 or kg)
+  type(thermo_var_ptrs),                     intent(in)    :: tv     !< Thermodynamic variables structure
   type(mech_forcing),                        intent(in)    :: forces !< A structure with the driving mechanical forces
-  real,                                      intent(in)    :: dt      !< Time increment (sec)
-  real, dimension(:,:),                      pointer       :: MLD_in  !< Mixed layer depth provided by PBL scheme (H units)
-  type(VarMix_CS),                           pointer       :: VarMix  !< Container for derived fields
-  type(mixedlayer_restrat_CS),               pointer       :: CS      !< Module control structure
+  real,                                      intent(in)    :: dt     !< Time increment (sec)
+  real, dimension(:,:),                      pointer       :: MLD_in !< Mixed layer depth provided by PBL scheme, in m (not H)
+  type(VarMix_CS),                           pointer       :: VarMix !< Container for derived fields
+  type(mixedlayer_restrat_CS),               pointer       :: CS     !< Module control structure
   ! Local variables
   real :: uhml(SZIB_(G),SZJ_(G),SZK_(G)) ! zonal mixed layer transport (m3/s or kg/s)
   real :: vhml(SZI_(G),SZJB_(G),SZK_(G)) ! merid mixed layer transport (m3/s or kg/s)
@@ -164,7 +164,9 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
                                             ! arrays for diagnostic purposes.
   real :: uDml_diag(SZIB_(G),SZJ_(G)), vDml_diag(SZI_(G),SZJB_(G))
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
-  real, dimension(SZI_(G)) :: rhoSurf, deltaRhoAtKm1, deltaRhoAtK, dK, dKm1, pRef_MLD ! Used for MLD
+  real, dimension(SZI_(G)) :: rhoSurf, deltaRhoAtKm1, deltaRhoAtK
+  real, dimension(SZI_(G)) :: dK, dKm1 ! Depths of layer centers, in H.
+  real, dimension(SZI_(G)) :: pRef_MLD ! A reference pressure for calculating the mixed layer densities, in Pa.
   real, dimension(SZI_(G)) :: rhoAtK, rho1, d1, pRef_N2 ! Used for N2
   real :: aFac, bFac, ddRho
   real :: hAtVel, zpa, zpb, dh, res_scaling_fac, I_l_f
@@ -191,13 +193,13 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
     !! TODO: use derivatives and mid-MLD pressure. Currently this is sigma-0. -AJA
     pRef_MLD(:) = 0.
     do j = js-1, je+1
-      dK(:) = 0.5 * h(:,j,1) * GV%H_to_m ! Depth of center of surface layer
+      dK(:) = 0.5 * h(:,j,1) ! Depth of center of surface layer
       call calculate_density(tv%T(:,j,1), tv%S(:,j,1), pRef_MLD, rhoSurf, is-1, ie-is+3, tv%eqn_of_state)
       deltaRhoAtK(:) = 0.
       MLD_fast(:,j) = 0.
       do k = 2, nz
         dKm1(:) = dK(:) ! Depth of center of layer K-1
-        dK(:) = dK(:) + 0.5 * ( h(:,j,k) + h(:,j,k-1) ) * GV%H_to_m ! Depth of center of layer K
+        dK(:) = dK(:) + 0.5 * ( h(:,j,k) + h(:,j,k-1) ) ! Depth of center of layer K
         ! Mixed-layer depth, using sigma-0 (surface reference pressure)
         deltaRhoAtKm1(:) = deltaRhoAtK(:) ! Store value from previous iteration of K
         call calculate_density(tv%T(:,j,k), tv%S(:,j,k), pRef_MLD, deltaRhoAtK, is-1, ie-is+3, tv%eqn_of_state)
@@ -220,7 +222,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
     if (.not. associated(MLD_in)) call MOM_error(FATAL, "MOM_mixedlayer_restrat: "// &
          "Argument MLD_in was not associated!")
     do j = js-1, je+1 ; do i = is-1, ie+1
-      MLD_fast(i,j) = CS%MLE_MLD_stretch * MLD_in(i,j)
+      MLD_fast(i,j) = (CS%MLE_MLD_stretch * GV%m_to_H) * MLD_in(i,j)
     enddo ; enddo
   else
     call MOM_error(FATAL, "MOM_mixedlayer_restrat: "// &
@@ -230,7 +232,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
   ! Apply time filter (to remove diurnal cycle)
   if (CS%MLE_MLD_decay_time>0.) then
     if (CS%debug) then
-      call hchksum(CS%MLD_filtered,'mixed_layer_restrat: MLD_filtered',G%HI,haloshift=1)
+      call hchksum(CS%MLD_filtered,'mixed_layer_restrat: MLD_filtered',G%HI,haloshift=1,scale=GV%H_to_m)
       call hchksum(MLD_in,'mixed_layer_restrat: MLD in',G%HI,haloshift=1)
     endif
     aFac = CS%MLE_MLD_decay_time / ( dt + CS%MLE_MLD_decay_time )
@@ -247,8 +249,8 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
   ! Apply slower time filter (to remove seasonal cycle) on already filtered MLD_fast
   if (CS%MLE_MLD_decay_time2>0.) then
     if (CS%debug) then
-      call hchksum(CS%MLD_filtered_slow,'mixed_layer_restrat: MLD_filtered_slow',G%HI,haloshift=1)
-      call hchksum(MLD_fast,'mixed_layer_restrat: MLD fast',G%HI,haloshift=1)
+      call hchksum(CS%MLD_filtered_slow,'mixed_layer_restrat: MLD_filtered_slow',G%HI,haloshift=1,scale=GV%H_to_m)
+      call hchksum(MLD_fast,'mixed_layer_restrat: MLD fast',G%HI,haloshift=1,scale=GV%H_to_m)
     endif
     aFac = CS%MLE_MLD_decay_time2 / ( dt + CS%MLE_MLD_decay_time2 )
     bFac = dt / ( dt + CS%MLE_MLD_decay_time2 )
@@ -330,9 +332,9 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
   enddo
 
   if (CS%debug) then
-    call hchksum(h,'mixed_layer_restrat: h',G%HI,haloshift=1)
+    call hchksum(h,'mixed_layer_restrat: h',G%HI,haloshift=1,scale=GV%H_to_m)
     call hchksum(forces%ustar,'mixed_layer_restrat: u*',G%HI,haloshift=1)
-    call hchksum(MLD_fast,'mixed_layer_restrat: MLD',G%HI,haloshift=1)
+    call hchksum(MLD_fast,'mixed_layer_restrat: MLD',G%HI,haloshift=1,scale=GV%H_to_m)
     call hchksum(Rml_av_fast,'mixed_layer_restrat: rml',G%HI,haloshift=1)
   endif
 

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -472,8 +472,8 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   real :: h_harm        ! Harmonic mean layer thickness, in H.
   real :: c2_h_u(SZIB_(G), SZK_(G)+1) ! Wave speed squared divided by h at u-points, m s-2.
   real :: c2_h_v(SZI_(G), SZK_(G)+1)  ! Wave speed squared divided by h at v-points, m s-2.
-  real :: hN2_u(SZIB_(G), SZK_(G)+1) ! Thickness times N2 at interfaces above u-points, m s-2.
-  real :: hN2_v(SZI_(G), SZK_(G)+1)  ! Thickness times N2 at interfaces above v-points, m s-2.
+  real :: hN2_u(SZIB_(G), SZK_(G)+1) ! Thickness in m times N2 at interfaces above u-points, m s-2.
+  real :: hN2_v(SZI_(G), SZK_(G)+1)  ! Thickness in m times N2 at interfaces above v-points, m s-2.
   real :: Sfn_est       ! Two preliminary estimates (before limiting) of the
                         ! overturning streamfunction, both in m3 s-1.
   real :: Sfn_unlim_u(SZIB_(G), SZK_(G)+1) ! Streamfunction for u-points (m3 s-1)
@@ -659,7 +659,8 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
               haB = 0.5*(h(i,j,k) + h(i+1,j,k)) + h_neglect
 
               ! hN2_u is used with the FGNV streamfunction formulation
-              hN2_u(I,K) = 0.5*( hg2A / haA + hg2B / haB ) * max(drdz*G_rho0 , N2_floor)
+              hN2_u(I,K) = (0.5 * H_to_m * ( hg2A / haA + hg2B / haB )) * &
+                           max(drdz*G_rho0 , N2_floor)
             endif
             if (present_slope_x) then
               Slope = slope_x(I,j,k)
@@ -727,7 +728,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
             hN2_u(I,K) = GV%g_prime(K)
           endif ! if (use_EOS)
         else ! if (k > nk_linear)
-          hN2_u(I,K) = N2_floor * h_neglect
+          hN2_u(I,K) = N2_floor * dz_neglect
           Sfn_unlim_u(I,K) = 0.
         endif ! if (k > nk_linear)
         if (CS%id_sfn_unlim_x>0) diag_sfn_unlim_x(I,j,K) = Sfn_unlim_u(I,K)
@@ -904,7 +905,8 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
               haB = 0.5*(h(i,j,k) + h(i,j+1,k)) + h_neglect
 
               ! hN2_v is used with the FGNV streamfunction formulation
-              hN2_v(i,K) = 0.5*( hg2A / haA + hg2B / haB ) * max(drdz*G_rho0 , N2_floor)
+              hN2_v(i,K) = (0.5 * H_to_m * ( hg2A / haA + hg2B / haB )) * &
+                           max(drdz*G_rho0 , N2_floor)
             endif
             if (present_slope_y) then
               Slope = slope_y(i,J,k)
@@ -972,7 +974,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
             hN2_v(i,K) = GV%g_prime(K)
           endif ! if (use_EOS)
         else ! if (k > nk_linear)
-          hN2_v(i,K) = N2_floor * h_neglect
+          hN2_v(i,K) = N2_floor * dz_neglect
           Sfn_unlim_v(i,K) = 0.
         endif ! if (k > nk_linear)
         if (CS%id_sfn_unlim_y>0) diag_sfn_unlim_y(i,J,K) = Sfn_unlim_v(i,K)

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -76,7 +76,7 @@ type, public :: bulkmixedlayer_CS ; private
                              ! released mean kinetic energy becomes TKE, nondim.
   real    :: Hmix_min        ! The minimum mixed layer thickness in m.
   real    :: H_limit_fluxes  ! When the total ocean depth is less than this
-                             ! value, in m, scale away all surface forcing to
+                             ! value, in H, scale away all surface forcing to
                              ! avoid boiling the ocean.
   real    :: ustar_min       ! A minimum value of ustar to avoid numerical
                              ! problems, in m s-1.  If the value is small enough,
@@ -3736,6 +3736,7 @@ subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
                  "The surface fluxes are scaled away when the total ocean \n"//&
                  "depth is less than DEPTH_LIMIT_FLUXES.", &
                  units="m", default=0.1*CS%Hmix_min)
+  CS%H_limit_fluxes = CS%H_limit_fluxes * GV%m_to_H
   call get_param(param_file, mdl, "OMEGA",CS%omega, &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5)

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -839,6 +839,7 @@ subroutine find_deficit_ratios(e, def_rat_u, def_rat_v, G, GV, CS, &
     h_def2_v
   real :: h_neglect ! A thickness that is so small it is usually lost
                     ! in roundoff and can be neglected, in H.
+  real :: Hmix_min  ! CS%Hmix_min converted to units of H.           
   real :: h1, h2  ! Temporary thicknesses, in H.
   integer :: i, j, k, is, ie, js, je, nz, nkmb
 
@@ -848,6 +849,7 @@ subroutine find_deficit_ratios(e, def_rat_u, def_rat_v, G, GV, CS, &
   endif
   nkmb = GV%nk_rho_varies
   h_neglect = GV%H_subroundoff
+  Hmix_min = CS%Hmix_min * GV%m_to_H
 
   ! Determine which zonal faces are problematic.
   do j=js,je ; do I=is-1,ie
@@ -890,12 +892,12 @@ subroutine find_deficit_ratios(e, def_rat_u, def_rat_v, G, GV, CS, &
   enddo ; enddo ; enddo
   if (present(def_rat_u_2lay)) then ; do j=js,je ; do I=is-1,ie
     def_rat_u(I,j) = G%mask2dCu(I,j) * h_def_u(I,j) / &
-                     (max(CS%Hmix_min, h_norm_u(I,j)) + h_neglect)
+                     (max(Hmix_min, h_norm_u(I,j)) + h_neglect)
     def_rat_u_2lay(I,j) = G%mask2dCu(I,j) * h_def2_u(I,j) / &
-                          (max(CS%Hmix_min, h_norm_u(I,j)) + h_neglect)
+                          (max(Hmix_min, h_norm_u(I,j)) + h_neglect)
   enddo ; enddo ; else ; do j=js,je ; do I=is-1,ie
     def_rat_u(I,j) = G%mask2dCu(I,j) * h_def_u(I,j) / &
-                     (max(CS%Hmix_min, h_norm_u(I,j)) + h_neglect)
+                     (max(Hmix_min, h_norm_u(I,j)) + h_neglect)
   enddo ; enddo ; endif
 
   ! Determine which meridional faces are problematic.
@@ -939,12 +941,12 @@ subroutine find_deficit_ratios(e, def_rat_u, def_rat_v, G, GV, CS, &
   enddo ; enddo ; enddo
   if (present(def_rat_v_2lay)) then ; do J=js-1,je ; do i=is,ie
     def_rat_v(i,J) = G%mask2dCv(i,J) * h_def_v(i,J) / &
-                      (max(CS%Hmix_min, h_norm_v(i,J)) + h_neglect)
+                      (max(Hmix_min, h_norm_v(i,J)) + h_neglect)
     def_rat_v_2lay(i,J) = G%mask2dCv(i,J) * h_def2_v(i,J) / &
-                      (max(CS%Hmix_min, h_norm_v(i,J)) + h_neglect)
+                      (max(Hmix_min, h_norm_v(i,J)) + h_neglect)
   enddo ; enddo ; else ; do J=js-1,je ; do i=is,ie
     def_rat_v(i,J) = G%mask2dCv(i,J) * h_def_v(i,J) / &
-                      (max(CS%Hmix_min, h_norm_v(i,J)) + h_neglect)
+                      (max(Hmix_min, h_norm_v(i,J)) + h_neglect)
   enddo ; enddo ; endif
 
 end subroutine find_deficit_ratios

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -839,7 +839,7 @@ subroutine find_deficit_ratios(e, def_rat_u, def_rat_v, G, GV, CS, &
     h_def2_v
   real :: h_neglect ! A thickness that is so small it is usually lost
                     ! in roundoff and can be neglected, in H.
-  real :: Hmix_min  ! CS%Hmix_min converted to units of H.           
+  real :: Hmix_min  ! CS%Hmix_min converted to units of H.
   real :: h1, h2  ! Temporary thicknesses, in H.
   integer :: i, j, k, is, ie, js, je, nz, nkmb
 

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -36,11 +36,11 @@ contains
 !> Initialize topography with a shelf and slope in a 2D domain
 subroutine DOME2d_initialize_topography ( D, G, param_file, max_depth )
   ! Arguments
-  type(dyn_horgrid_type),             intent(in)  :: G !< The dynamic horizontal grid type
+  type(dyn_horgrid_type), intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                      intent(out) :: D !< Ocean bottom depth in m
-  type(param_file_type),              intent(in)  :: param_file !< Parameter file structure
-  real,                               intent(in)  :: max_depth  !< Maximum depth of model in m
+                          intent(out) :: D !< Ocean bottom depth in m
+  type(param_file_type),  intent(in)  :: param_file !< Parameter file structure
+  real,                   intent(in)  :: max_depth  !< Maximum depth of model in m
   ! Local variables
   integer :: i, j
   real    :: x, bay_depth, l1, l2
@@ -67,23 +67,22 @@ subroutine DOME2d_initialize_topography ( D, G, param_file, max_depth )
 
   bay_depth = dome2d_depth_bay
 
-  do i=G%isc,G%iec
-    do j=G%jsc,G%jec
+  do j=G%jsc,G%jec ; do i=G%isc,G%iec
 
-      ! Compute normalized zonal coordinate
-      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon;
+    ! Compute normalized zonal coordinate
+    x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon
 
-      if ( x .le. l1 ) then
-        D(i,j) = bay_depth * max_depth
-      else if (( x .gt. l1 ) .and. ( x .lt. l2 )) then
-        D(i,j) = bay_depth * max_depth + (1.0-bay_depth) * max_depth * &
-                 ( x - l1 ) / (l2 - l1)
-      else
-        D(i,j) = max_depth
-      end if
+    if ( x <= l1 ) then
+      D(i,j) = bay_depth * max_depth
+    else if (( x > l1 ) .and. ( x < l2 )) then
+      D(i,j) = bay_depth * max_depth + (1.0-bay_depth) * max_depth * &
+               ( x - l1 ) / (l2 - l1)
+    else
+      D(i,j) = max_depth
+    endif
 
-    enddo
-  enddo
+  enddo ; enddo
+
 end subroutine DOME2d_initialize_topography
 
 !> Initialize thicknesses according to coordinate mode
@@ -157,56 +156,56 @@ subroutine DOME2d_initialize_thickness ( h, G, GV, param_file, just_read_params 
           endif
         enddo
 
-         x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon;
-         if ( x .le. dome2d_width_bay ) then
-           h(i,j,1:nz-1) = GV%Angstrom;
-           h(i,j,nz) = dome2d_depth_bay * G%max_depth - (nz-1) * GV%Angstrom;
-         end if
+         x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon
+         if ( x <= dome2d_width_bay ) then
+           h(i,j,1:nz-1) = GV%Angstrom_Z
+           h(i,j,nz) = dome2d_depth_bay * G%max_depth - (nz-1) * GV%Angstrom_Z
+         endif
 
-      end do ; end do
+      enddo ; enddo
 
  !  case ( IC_RHO_C )
  !
  !    do j=js,je ; do i=is,ie
- !        eta1D(nz+1) = -1.0*G%bathyT(i,j)
- !        do k=nz,1,-1
- !          eta1D(k) = e0(k)
- !          if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
- !            eta1D(k) = eta1D(k+1) + min_thickness
- !            h(i,j,k) = min_thickness
- !          else
- !            h(i,j,k) = eta1D(k) - eta1D(k+1)
- !          endif
+ !       eta1D(nz+1) = -1.0*G%bathyT(i,j)
+ !       do k=nz,1,-1
+ !         eta1D(k) = e0(k)
+ !         if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
+ !           eta1D(k) = eta1D(k+1) + min_thickness
+ !           h(i,j,k) = min_thickness
+ !         else
+ !           h(i,j,k) = eta1D(k) - eta1D(k+1)
+ !         endif
  !       enddo
  !
- !       x = G%geoLonT(i,j) / G%len_lon;
- !       if ( x .le. dome2d_width_bay ) then
- !         h(i,j,1:nz-1) = min_thickness;
- !         h(i,j,nz) = dome2d_depth_bay * G%max_depth - (nz-1) * min_thickness;
- !       end if
+ !       x = G%geoLonT(i,j) / G%len_lon
+ !       if ( x <= dome2d_width_bay ) then
+ !         h(i,j,1:nz-1) = min_thickness
+ !         h(i,j,nz) = dome2d_depth_bay * G%max_depth - (nz-1) * min_thickness
+ !       endif
  !
  !    enddo ; enddo
 
     case ( REGRIDDING_ZSTAR )
 
       do j=js,je ; do i=is,ie
-          eta1D(nz+1) = -1.0*G%bathyT(i,j)
-          do k=nz,1,-1
-            eta1D(k) = e0(k)
-            if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
-              eta1D(k) = eta1D(k+1) + min_thickness
-              h(i,j,k) = min_thickness
-            else
-              h(i,j,k) = eta1D(k) - eta1D(k+1)
-            endif
-         enddo
+        eta1D(nz+1) = -1.0*G%bathyT(i,j)
+        do k=nz,1,-1
+          eta1D(k) = e0(k)
+          if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
+            eta1D(k) = eta1D(k+1) + min_thickness
+            h(i,j,k) = min_thickness
+          else
+            h(i,j,k) = eta1D(k) - eta1D(k+1)
+          endif
+        enddo
       enddo ; enddo
 
     case ( REGRIDDING_SIGMA )
       do j=js,je ; do i=is,ie
-        delta_h = G%bathyT(i,j) / nz;
-        h(i,j,:) = delta_h;
-      end do ; end do
+        delta_h = G%bathyT(i,j) / nz
+        h(i,j,:) = delta_h
+      enddo ; enddo
 
     case default
       call MOM_error(FATAL,"dome2d_initialize: "// &
@@ -231,12 +230,12 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, param_file, &
 
   ! Local variables
   integer   :: i, j, k, is, ie, js, je, nz
-  real      :: x;
-  integer   :: index_bay_z;
-  real      :: delta_S, delta_T;
+  real      :: x
+  integer   :: index_bay_z
+  real      :: delta_S, delta_T
   real      :: S_ref, T_ref;        ! Reference salinity and temperature within surface layer
   real      :: S_range, T_range;    ! Range of salinities and temperatures over the vertical
-  real      :: xi0, xi1;
+  real      :: xi0, xi1
   logical :: just_read    ! If true, just read parameters but set nothing.
   character(len=40) :: verticalCoordinate
   real    :: dome2d_width_bay, dome2d_width_bottom, dome2d_depth_bay
@@ -274,35 +273,35 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, param_file, &
     case ( REGRIDDING_ZSTAR, REGRIDDING_SIGMA )
 
       do j=js,je ; do i=is,ie
-        xi0 = 0.0;
+        xi0 = 0.0
         do k = 1,nz
-          xi1 = xi0 + h(i,j,k) / G%max_depth;
-          S(i,j,k) = 34.0 + 0.5 * S_range * (xi0 + xi1);
-          xi0 = xi1;
+          xi1 = xi0 + h(i,j,k) / G%max_depth
+          S(i,j,k) = 34.0 + 0.5 * S_range * (xi0 + xi1)
+          xi0 = xi1
         enddo
       enddo ; enddo
 
     case ( REGRIDDING_RHO )
 
       do j=js,je ; do i=is,ie
-        xi0 = 0.0;
+        xi0 = 0.0
         do k = 1,nz
-          xi1 = xi0 + h(i,j,k) / G%max_depth;
-          S(i,j,k) = 34.0 + 0.5 * S_range * (xi0 + xi1);
-          xi0 = xi1;
+          xi1 = xi0 + h(i,j,k) / G%max_depth
+          S(i,j,k) = 34.0 + 0.5 * S_range * (xi0 + xi1)
+          xi0 = xi1
         enddo
-        x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon;
-        if ( x .le. dome2d_width_bay ) then
-          S(i,j,nz) = 34.0 + S_range;
+        x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon
+        if ( x <= dome2d_width_bay ) then
+          S(i,j,nz) = 34.0 + S_range
         endif
       enddo ; enddo
 
     case ( REGRIDDING_LAYER )
 
-      delta_S = S_range / ( G%ke - 1.0 );
-      S(:,:,1) = S_ref;
+      delta_S = S_range / ( G%ke - 1.0 )
+      S(:,:,1) = S_ref
       do k = 2,G%ke
-        S(:,:,k) = S(:,:,k-1) + delta_S;
+        S(:,:,k) = S(:,:,k-1) + delta_S
       enddo
 
     case default
@@ -313,10 +312,10 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, param_file, &
 
   ! Modify salinity and temperature when z coordinates are used
   if ( coordinateMode(verticalCoordinate) .eq. REGRIDDING_ZSTAR ) then
-    index_bay_z = Nint ( dome2d_depth_bay * G%ke );
+    index_bay_z = Nint ( dome2d_depth_bay * G%ke )
     do j = G%jsc,G%jec ; do i = G%isc,G%iec
-      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon;
-      if ( x .le. dome2d_width_bay ) then
+      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon
+      if ( x <= dome2d_width_bay ) then
         S(i,j,1:index_bay_z) = S_ref + S_range; ! Use for z coordinates
         T(i,j,1:index_bay_z) = 1.0;             ! Use for z coordinates
       endif
@@ -326,8 +325,8 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, param_file, &
   ! Modify salinity and temperature when sigma coordinates are used
   if ( coordinateMode(verticalCoordinate) .eq. REGRIDDING_SIGMA ) then
     do i = G%isc,G%iec ; do j = G%jsc,G%jec
-      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon;
-      if ( x .le. dome2d_width_bay ) then
+      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon
+      if ( x <= dome2d_width_bay ) then
         S(i,j,1:G%ke) = S_ref + S_range;    ! Use for sigma coordinates
         T(i,j,1:G%ke) = 1.0;                ! Use for sigma coordinates
       endif
@@ -335,15 +334,16 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, param_file, &
   endif
 
   ! Modify temperature when rho coordinates are used
-  T(G%isc:G%iec,G%jsc:G%jec,1:G%ke) = 0.0;
-  if (( coordinateMode(verticalCoordinate) .eq. REGRIDDING_RHO ) .or. ( coordinateMode(verticalCoordinate) .eq. REGRIDDING_LAYER )) then
+  T(G%isc:G%iec,G%jsc:G%jec,1:G%ke) = 0.0
+  if (( coordinateMode(verticalCoordinate) .eq. REGRIDDING_RHO ) .or. &
+      ( coordinateMode(verticalCoordinate) .eq. REGRIDDING_LAYER )) then
     do i = G%isc,G%iec ; do j = G%jsc,G%jec
-      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon;
-      if ( x .le. dome2d_width_bay ) then
-        T(i,j,G%ke) = 1.0;
-      end if
-    end do ; end do
-  end if
+      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon
+      if ( x <= dome2d_width_bay ) then
+        T(i,j,G%ke) = 1.0
+      endif
+    enddo ; enddo
+  endif
 
 end subroutine DOME2d_initialize_temperature_salinity
 
@@ -466,7 +466,8 @@ subroutine DOME2d_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
       do k = nz,1,-1
         z = z + 0.5 * h(i,j,k) ! Position of the center of layer k
         S(i,j,k) = 34.0 - 1.0 * (z/G%max_depth)
-        if ( ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon < dome2d_west_sponge_width ) S(i,j,k) = S_ref + S_range
+        if ( ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon < dome2d_west_sponge_width ) &
+          S(i,j,k) = S_ref + S_range
         z = z + 0.5 * h(i,j,k) ! Position of the interface k
       enddo
     enddo ; enddo
@@ -493,11 +494,11 @@ subroutine DOME2d_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
         endif
       enddo
 
-      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon;
-      if ( x .le. dome2d_width_bay ) then
-        h(i,j,1:nz-1) = GV%Angstrom;
-        h(i,j,nz) = dome2d_depth_bay * G%max_depth - (nz-1) * GV%Angstrom;
-      end if
+      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon
+      if ( x <= dome2d_width_bay ) then
+        h(i,j,1:nz-1) = GV%Angstrom
+        h(i,j,nz) = dome2d_depth_bay * G%max_depth - (nz-1) * GV%Angstrom
+      endif
 
       eta(i,j,nz+1) = -G%bathyT(i,j)
       do K=nz,1,-1

--- a/src/user/lock_exchange_initialization.F90
+++ b/src/user/lock_exchange_initialization.F90
@@ -76,11 +76,11 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, param_file, just_read_pa
     enddo
     eta1D(nz+1) = -G%max_depth ! Force bottom interface to bottom
     do k=nz,2,-1 ! Make sure interfaces increase upwards
-      eta1D(K) = max( eta1D(K), eta1D(K+1) + GV%Angstrom )
+      eta1D(K) = max( eta1D(K), eta1D(K+1) + GV%Angstrom_Z )
     enddo
     eta1D(1) = 0. ! Force bottom interface to bottom
     do k=2,nz ! Make sure interfaces decrease downwards
-      eta1D(K) = min( eta1D(K), eta1D(K-1) - GV%Angstrom )
+      eta1D(K) = min( eta1D(K), eta1D(K-1) - GV%Angstrom_Z )
     enddo
     do k=nz,1,-1
       h(i,j,k) = eta1D(K) - eta1D(K+1)

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -160,8 +160,8 @@ subroutine sloshing_initialize_thickness ( h, G, GV, param_file, just_read_param
     ! are strictly positive
     do k = nz,1,-1
 
-      if ( z_inter(k) .LT. (z_inter(k+1) + GV%Angstrom) ) then
-        z_inter(k) = z_inter(k+1) + GV%Angstrom
+      if ( z_inter(k) .LT. (z_inter(k+1) + GV%Angstrom_Z) ) then
+        z_inter(k) = z_inter(k+1) + GV%Angstrom_Z
       end if
 
     end do


### PR DESCRIPTION
Added a number of corrections to give the same answers in a number of test cases when rescaling thicknesses to test for dimensional consistency.  None of these code changes change answers when H_TO_M is 1, but there are a few changes to available parameters within these calls, so the MOM_parameter_doc files change when this new code is used.