### PR TITLE
New dyed_channel OBC option

### DIFF
--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -22,6 +22,8 @@ use Kelvin_initialization,     only : Kelvin_set_OBC_data, register_Kelvin_OBC
 use Kelvin_initialization,     only : Kelvin_OBC_end, Kelvin_OBC_CS
 use shelfwave_initialization,  only : shelfwave_set_OBC_data, register_shelfwave_OBC
 use shelfwave_initialization,  only : shelfwave_OBC_end, shelfwave_OBC_CS
+use dyed_channel_initialization, only : dyed_channel_update_flow, register_dyed_channel_OBC
+use dyed_channel_initialization, only : dyed_channel_OBC_end, dyed_channel_OBC_CS
 
 implicit none ; private
 
@@ -35,10 +37,12 @@ type, public :: update_OBC_CS ; private
   logical :: use_Kelvin = .false.
   logical :: use_tidal_bay = .false.
   logical :: use_shelfwave = .false.
+  logical :: use_dyed_channel = .false.
   type(file_OBC_CS), pointer :: file_OBC_CSp => NULL()
   type(Kelvin_OBC_CS), pointer :: Kelvin_OBC_CSp => NULL()
   type(tidal_bay_OBC_CS), pointer :: tidal_bay_OBC_CSp => NULL()
   type(shelfwave_OBC_CS), pointer :: shelfwave_OBC_CSp => NULL()
+  type(dyed_channel_OBC_CS), pointer :: dyed_channel_OBC_CSp => NULL()
 end type update_OBC_CS
 
 integer :: id_clock_pass
@@ -78,6 +82,9 @@ subroutine call_OBC_register(param_file, CS, OBC)
   call get_param(param_file, mdl, "USE_SHELFWAVE_OBC", CS%use_shelfwave, &
                  "If true, use the shelfwave open boundary.", &
                  default=.false.)
+  call get_param(param_file, mdl, "USE_DYED_CHANNEL_OBC", CS%use_dyed_channel, &
+                 "If true, use the dyed channel open boundary.", &
+                 default=.false.)
 
   if (CS%use_files) CS%use_files = &
     register_file_OBC(param_file, CS%file_OBC_CSp, &
@@ -91,18 +98,21 @@ subroutine call_OBC_register(param_file, CS, OBC)
   if (CS%use_shelfwave) CS%use_shelfwave = &
     register_shelfwave_OBC(param_file, CS%shelfwave_OBC_CSp, &
                OBC%OBC_Reg)
+  if (CS%use_dyed_channel) CS%use_dyed_channel = &
+    register_dyed_channel_OBC(param_file, CS%dyed_channel_OBC_CSp, &
+               OBC%OBC_Reg)
 
 end subroutine call_OBC_register
 
 !> Calls appropriate routine to update the open boundary conditions.
 subroutine update_OBC_data(OBC, G, GV, tv, h, CS, Time)
-  type(ocean_grid_type),                    intent(in) :: G     !< Ocean grid structure
-  type(verticalGrid_type),                  intent(in)    :: GV !< Ocean vertical grid structure
-  type(thermo_var_ptrs),                    intent(in)    :: tv !< Thermodynamics structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h  !< layer thickness
-  type(ocean_OBC_type),                     pointer    :: OBC   !< Open boundary structure
-  type(update_OBC_CS),                      pointer    :: CS    !< Control structure for OBCs
-  type(time_type),                          intent(in) :: Time  !< Model time
+  type(ocean_grid_type),                    intent(in)    :: G    !< Ocean grid structure
+  type(verticalGrid_type),                  intent(in)    :: GV   !< Ocean vertical grid structure
+  type(thermo_var_ptrs),                    intent(in)    :: tv   !< Thermodynamics structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h    !< layer thickness
+  type(ocean_OBC_type),                     pointer       :: OBC  !< Open boundary structure
+  type(update_OBC_CS),                      pointer       :: CS   !< Control structure for OBCs
+  type(time_type),                          intent(in)    :: Time !< Model time
   ! Local variables
   logical :: read_OBC_eta = .false.
   logical :: read_OBC_uv = .false.
@@ -126,6 +136,8 @@ subroutine update_OBC_data(OBC, G, GV, tv, h, CS, Time)
       call Kelvin_set_OBC_data(OBC, CS%Kelvin_OBC_CSp, G, h, Time)
   if (CS%use_shelfwave) &
       call shelfwave_set_OBC_data(OBC, CS%shelfwave_OBC_CSp, G, h, Time)
+  if (CS%use_dyed_channel) &
+      call dyed_channel_update_flow(OBC, CS%dyed_channel_OBC_CSp, G, Time)
   if (OBC%needs_IO_for_data)  &
       call update_OBC_segment_data(G, GV, OBC, tv, h, Time)
 

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -75,6 +75,7 @@ use Rossby_front_2d_initialization, only : Rossby_front_initialize_temperature_s
 use Rossby_front_2d_initialization, only : Rossby_front_initialize_velocity
 use SCM_idealized_hurricane, only : SCM_idealized_hurricane_TS_init
 use SCM_CVmix_tests, only: SCM_CVmix_tests_TS_init
+use dyed_channel_initialization, only : dyed_channel_set_OBC_tracer_data
 use dyed_obcs_initialization, only : dyed_obcs_set_OBC_data
 use supercritical_initialization, only : supercritical_set_OBC_data
 use soliton_initialization, only : soliton_initialize_velocity
@@ -536,6 +537,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                  "A string that sets how the user code is invoked to set open\n"//&
                  " boundary data: \n"//&
                  "   DOME - specified inflow on northern boundary\n"//&
+                 "   dyed_channel - supercritical with dye on the inflow boundary\n"//&
                  "   dyed_obcs - circle_obcs with dyes on the open boundaries\n"//&
                  "   Kelvin - barotropic Kelvin wave forcing on the western boundary\n"//&
                  "   shelfwave - Flather with shelf wave forcing on western boundary\n"//&
@@ -544,6 +546,9 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                  "   USER - user specified", default="none")
     if (trim(config) == "DOME") then
       call DOME_set_OBC_data(OBC, tv, G, GV, PF, tracer_Reg)
+    elseif (trim(config) == "dyed_channel") then
+      call dyed_channel_set_OBC_tracer_data(OBC, G, GV, PF, tracer_Reg)
+      OBC%update_OBC = .true.
     elseif (trim(config) == "dyed_obcs") then
       call dyed_obcs_set_OBC_data(OBC, G, GV, PF, tracer_Reg)
     elseif (trim(config) == "Kelvin") then

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -2,27 +2,27 @@ module regional_dyes
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
-use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
-use MOM_error_handler, only : MOM_error, FATAL, WARNING
-use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
-use MOM_forcing_type, only : forcing
-use MOM_grid, only : ocean_grid_type
-use MOM_hor_index, only : hor_index_type
-use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
-use MOM_open_boundary, only : ocean_OBC_type
-use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
-use MOM_sponge, only : set_up_sponge_field, sponge_CS
-use MOM_time_manager, only : time_type, get_time
-use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
-use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
-use MOM_tracer_Z_init, only : tracer_Z_init
-use MOM_variables, only : surface
-use MOM_verticalGrid, only : verticalGrid_type
+use MOM_diag_mediator,      only : post_data, register_diag_field, safe_alloc_ptr
+use MOM_diag_mediator,      only : diag_ctrl
+use MOM_diag_to_Z,          only : register_Z_tracer, diag_to_Z_CS
+use MOM_error_handler,      only : MOM_error, FATAL, WARNING
+use MOM_file_parser,        only : get_param, log_param, log_version, param_file_type
+use MOM_forcing_type,       only : forcing
+use MOM_grid,               only : ocean_grid_type
+use MOM_hor_index,          only : hor_index_type
+use MOM_io,                 only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_open_boundary,      only : ocean_OBC_type
+use MOM_restart,            only : register_restart_field, query_initialized, MOM_restart_CS
+use MOM_sponge,             only : set_up_sponge_field, sponge_CS
+use MOM_time_manager,       only : time_type, get_time
+use MOM_tracer_registry,    only : register_tracer, tracer_registry_type
+use MOM_tracer_registry,    only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_diabatic,    only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
+use MOM_tracer_Z_init,      only : tracer_Z_init
+use MOM_variables,          only : surface
+use MOM_verticalGrid,       only : verticalGrid_type
 
-use coupler_types_mod, only : coupler_type_set_data, ind_csurf
+use coupler_types_mod,      only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -25,8 +25,9 @@ public register_dyed_channel_OBC, dyed_channel_update_flow
 
 !> Control structure for tidal bay open boundaries.
 type, public :: dyed_channel_OBC_CS ; private
-  real :: zonal_flow = 8.57         !< Maximum inflow
-  real :: frequency  = 0.0         !< Inflow frequency
+  real :: zonal_flow = 8.57         !< Mean inflow
+  real :: tidal_amp = 0.0           !< Sloshing amplitude
+  real :: frequency  = 0.0          !< Sloshing frequency
 end type dyed_channel_OBC_CS
 
 integer :: ntr = 0
@@ -49,9 +50,12 @@ function register_dyed_channel_OBC(param_file, CS, OBC_Reg)
   endif
   allocate(CS)
 
-  call get_param(param_file, mdl, "SUPERCRITICAL_ZONAL_FLOW", CS%zonal_flow, &
-                 "Constant zonal flow imposed at upstream open boundary.", &
+  call get_param(param_file, mdl, "CHANNEL_MEAN_FLOW", CS%zonal_flow, &
+                 "Mean zonal flow imposed at upstream open boundary.", &
                  units="m/s", default=8.57)
+  call get_param(param_file, mdl, "CHANNEL_TIDAL_AMP", CS%tidal_amp, &
+                 "Sloshing amplitude imposed at upstream open boundary.", &
+                 units="m/s", default=0.0)
   call get_param(param_file, mdl, "CHANNEL_FLOW_FREQUENCY", CS%frequency, &
                  "Frequency of oscillating zonal flow.", &
                  units="s-1", default=0.0)
@@ -161,7 +165,7 @@ subroutine dyed_channel_update_flow(OBC, CS, G, Time)
       if (CS%frequency == 0.0) then
         flow = CS%zonal_flow
       else
-        flow = CS%zonal_flow * cos(2 * PI * CS%frequency * time_sec)
+        flow = CS%zonal_flow + CS%tidal_amp * cos(2 * PI * CS%frequency * time_sec)
       endif
       do k=1,G%ke
         do j=jsd,jed ; do I=IsdB,IedB

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -1,0 +1,192 @@
+module dyed_channel_initialization
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_dyn_horgrid,     only : dyn_horgrid_type
+use MOM_error_handler,   only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
+use MOM_file_parser,     only : get_param, log_version, param_file_type
+use MOM_get_input,       only : directories
+use MOM_grid,            only : ocean_grid_type
+use MOM_io,              only : vardesc, var_desc
+use MOM_open_boundary,   only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
+use MOM_open_boundary,   only : OBC_segment_type, register_segment_tracer
+use MOM_open_boundary,   only : OBC_registry_type, register_OBC
+use MOM_time_manager,    only : time_type, set_time, time_type_to_real
+use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_variables,       only : thermo_var_ptrs
+use MOM_verticalGrid,    only : verticalGrid_type
+
+implicit none ; private
+
+#include <MOM_memory.h>
+
+public dyed_channel_set_OBC_tracer_data, dyed_channel_OBC_end
+public register_dyed_channel_OBC, dyed_channel_update_flow
+
+!> Control structure for tidal bay open boundaries.
+type, public :: dyed_channel_OBC_CS ; private
+  real :: zonal_flow = 8.57         !< Maximum inflow
+  real :: frequency  = 0.0         !< Inflow frequency
+end type dyed_channel_OBC_CS
+
+integer :: ntr = 0
+
+contains
+
+!> Add dyed channel to OBC registry.
+function register_dyed_channel_OBC(param_file, CS, OBC_Reg)
+  type(param_file_type),     intent(in) :: param_file !< parameter file.
+  type(dyed_channel_OBC_CS), pointer    :: CS         !< tidal bay control structure.
+  type(OBC_registry_type),   pointer    :: OBC_Reg    !< OBC registry.
+  logical                               :: register_dyed_channel_OBC
+  character(len=32)  :: casename = "dyed channel"     !< This case's name.
+  character(len=40)  :: mdl = "register_dyed_channel_OBC" ! This subroutine's name.
+
+  if (associated(CS)) then
+    call MOM_error(WARNING, "register_dyed_channel_OBC called with an "// &
+                            "associated control structure.")
+    return
+  endif
+  allocate(CS)
+
+  call get_param(param_file, mdl, "SUPERCRITICAL_ZONAL_FLOW", CS%zonal_flow, &
+                 "Constant zonal flow imposed at upstream open boundary.", &
+                 units="m/s", default=8.57)
+  call get_param(param_file, mdl, "CHANNEL_FLOW_FREQUENCY", CS%frequency, &
+                 "Frequency of oscillating zonal flow.", &
+                 units="s-1", default=0.0)
+
+  ! Register the open boundaries.
+  call register_OBC(casename, param_file, OBC_Reg)
+  register_dyed_channel_OBC = .true.
+
+end function register_dyed_channel_OBC
+
+!> Clean up the dyed_channel OBC from registry.
+subroutine dyed_channel_OBC_end(CS)
+  type(dyed_channel_OBC_CS), pointer :: CS    !< tidal bay control structure.
+
+  if (associated(CS)) then
+    deallocate(CS)
+  endif
+end subroutine dyed_channel_OBC_end
+
+!> This subroutine sets the dye and flow properties at open boundary conditions.
+subroutine dyed_channel_set_OBC_tracer_data(OBC, G, GV, param_file, tr_Reg)
+  type(ocean_OBC_type),       pointer    :: OBC !< This open boundary condition type specifies
+                                                !! whether, where, and what open boundary
+                                                !! conditions are used.
+  type(ocean_grid_type),      intent(in) :: G   !< The ocean's grid structure.
+  type(verticalGrid_type),    intent(in) :: GV  !< The ocean's vertical grid structure.
+  type(param_file_type),      intent(in) :: param_file !< A structure indicating the open file
+                                                !! to parse for model parameter values.
+  type(tracer_registry_type), pointer    :: tr_Reg !< Tracer registry.
+
+! Local variables
+  character(len=40)  :: mdl = "dyed_channel_set_OBC_tracer_data" ! This subroutine's name.
+  character(len=80)  :: name, longname
+  integer :: i, j, k, l, itt, isd, ied, jsd, jed, m, n
+  integer :: IsdB, IedB, JsdB, JedB
+  real :: dye
+  type(OBC_segment_type), pointer :: segment
+  type(vardesc), allocatable, dimension(:) :: tr_desc
+
+  if (.not.associated(OBC)) call MOM_error(FATAL, 'dyed_channel_initialization.F90: '// &
+        'dyed_channel_set_OBC_data() was called but OBC type was not initialized!')
+
+  call get_param(param_file, mdl, "NUM_DYE_TRACERS", ntr, &
+                 "The number of dye tracers in this run. Each tracer \n"//&
+                 "should have a separate boundary segment.", default=0,   &
+                 do_not_log=.true.)
+
+  if (OBC%number_of_segments .lt. ntr) then
+    call MOM_error(WARNING, "Error in dyed_obc segment setup")
+    return   !!! Need a better error message here
+  endif
+  allocate(tr_desc(ntr))
+
+! ! Set the inflow values of the dyes, one per segment.
+! ! We know the order: north, south, east, west
+  do m=1,ntr
+    write(name,'("dye_",I2.2)') m
+    write(longname,'("Concentration of dyed_obc Tracer ",I2.2, " on segment ",I2.2)') m, m
+    tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
+
+    do n=1,OBC%number_of_segments
+      if (n == m) then
+        dye = 1.0
+      else
+        dye = 0.0
+      endif
+      call register_segment_tracer(tr_desc(m), param_file, GV, &
+                                   OBC%segment(n), OBC_scalar=dye)
+    enddo
+  enddo
+  deallocate(tr_desc)
+
+end subroutine dyed_channel_set_OBC_tracer_data
+
+!> This subroutine updates the long-channel flow
+subroutine dyed_channel_update_flow(OBC, CS, G, Time)
+  type(ocean_OBC_type),       pointer    :: OBC !< This open boundary condition type specifies
+                                                !! whether, where, and what open boundary
+                                                !! conditions are used.
+  type(dyed_channel_OBC_CS),  pointer    :: CS  !< tidal bay control structure.
+  type(ocean_grid_type),      intent(in) :: G   !< The ocean's grid structure.
+  type(time_type),            intent(in) :: Time !< model time.
+
+! Local variables
+  character(len=40)  :: mdl = "dyed_channel_update_flow" ! This subroutine's name.
+  character(len=80)  :: name, longname
+  real :: flow, time_sec, PI
+  integer :: i, j, k, l, itt, isd, ied, jsd, jed, m, n
+  integer :: IsdB, IedB, JsdB, JedB
+  type(OBC_segment_type), pointer :: segment
+
+  if (.not.associated(OBC)) call MOM_error(FATAL, 'dyed_channel_initialization.F90: '// &
+        'dyed_channel_update_flow() was called but OBC type was not initialized!')
+
+  time_sec = time_type_to_real(Time)
+  PI = 4.0*atan(1.0)
+
+  do l=1, OBC%number_of_segments
+    segment => OBC%segment(l)
+    if (.not. segment%on_pe) cycle
+    if (segment%gradient) cycle
+    if (segment%oblique .and. .not. segment%nudged .and. .not. segment%Flather) cycle
+
+    if (segment%is_E_or_W) then
+      jsd = segment%HI%jsd ; jed = segment%HI%jed
+      IsdB = segment%HI%IsdB ; IedB = segment%HI%IedB
+      if (CS%frequency == 0.0) then
+        flow = CS%zonal_flow
+      else
+        flow = CS%zonal_flow * cos(2 * PI * CS%frequency * time_sec)
+      endif
+      do k=1,G%ke
+        do j=jsd,jed ; do I=IsdB,IedB
+          if (segment%specified .or. segment%nudged) then
+            segment%normal_vel(I,j,k) = flow
+          endif
+          if (segment%specified) then
+            segment%normal_trans(I,j,k) = flow * G%dyCu(I,j)
+          endif
+        enddo ; enddo
+      enddo
+      do j=jsd,jed ; do I=IsdB,IedB
+        segment%normal_vel_bt(I,j) = flow
+      enddo ; enddo
+    else
+      isd = segment%HI%isd ; ied = segment%HI%ied
+      JsdB = segment%HI%JsdB ; JedB = segment%HI%JedB
+      do J=JsdB,JedB ; do i=isd,ied
+        segment%normal_vel_bt(i,J) = 0.0
+      enddo ; enddo
+    endif
+  enddo
+
+end subroutine dyed_channel_update_flow
+
+!> \namespace dyed_channel_initialization
+!! Setting dyes, one for painting the inflow on each side.
+end module dyed_channel_initialization

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -132,7 +132,7 @@ subroutine shelfwave_set_OBC_data(OBC, CS, G, h, Time)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in) :: h !< layer thickness.
   type(time_type),        intent(in) :: Time !< model time.
 
-  ! The following variables are used to set up the transport in the tidal_bay example.
+  ! The following variables are used to set up the transport in the shelfwave example.
   real :: my_amp, time_sec
   real :: cos_wt, cos_ky, sin_wt, sin_ky, omega, alpha
   real :: x, y, jj, kk, ll

--- a/src/user/supercritical_initialization.F90
+++ b/src/user/supercritical_initialization.F90
@@ -68,11 +68,6 @@ subroutine supercritical_set_OBC_data(OBC, G, param_file)
     else
       isd = segment%HI%isd ; ied = segment%HI%ied
       JsdB = segment%HI%JsdB ; JedB = segment%HI%JedB
-!     do k=1,G%ke
-!       do J=JsdB,JedB ; do i=isd,ied
-!         segment%normal_vel(i,J,k) = 0.0
-!       enddo ; enddo
-!     enddo
       do J=JsdB,JedB ; do i=isd,ied
         segment%normal_vel_bt(i,J) = 0.0
       enddo ; enddo


### PR DESCRIPTION
Dyed_channel option has both dyes on the OBC segments and control of time-dependent flow on the inflow end of a channel.

- Dyed_obc case now works for NUM_DYE_TRACERS (up to 99) instead of being hard-coded for 4.
- More text in MOM_parameter_doc.all for OBC cases.