### PR TITLE
Option for boundary extrapolation in main remapping

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -159,6 +159,7 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
   logical                         :: check_remapping
   logical                         :: force_bounds_in_subcell
   logical                         :: local_logical
+  logical                         :: remap_boundary_extrap
 
   if (associated(CS)) then
     call MOM_error(WARNING, "ALE_init called with an associated "// &
@@ -225,8 +226,11 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
                  "If true, the values on the intermediate grid used for remapping\n"//&
                  "are forced to be bounded, which might not be the case due to\n"//&
                  "round off.", default=.false.)
+  call get_param(param_file, mdl, "REMAP_BOUNDARY_EXTRAP", remap_boundary_extrap, &
+                 "If true, values at the interfaces of boundary cells are \n"//&
+                 "extrapolated instead of piecewise constant", default=.false.)
   call initialize_remapping( CS%remapCS, string, &
-                             boundary_extrapolation=.false., &
+                             boundary_extrapolation=remap_boundary_extrap, &
                              check_reconstruction=check_reconstruction, &
                              check_remapping=check_remapping, &
                              force_bounds_in_subcell=force_bounds_in_subcell)


### PR DESCRIPTION
Boundary extrapolation was hardcoded to be false in the main remapping
control structure used during the ALE regridding/remapping step. This
behavior can now be controlled at runtime via REMAP_BOUNDARY_EXTRAP.

- This changes MOM_parameter_doc.all for all test cases with USE_REGRIDDING=True