### PR TITLE
Changes to support H rescaling

### DIFF
--- a/src/ALE/P1M_functions.F90
+++ b/src/ALE/P1M_functions.F90
@@ -41,7 +41,7 @@ contains
 !------------------------------------------------------------------------------
 ! p1m interpolation
 !------------------------------------------------------------------------------
-subroutine P1M_interpolation( N, h, u, ppoly_E, ppoly_coefficients )
+subroutine P1M_interpolation( N, h, u, ppoly_E, ppoly_coefficients, h_neglect )
 ! ------------------------------------------------------------------------------
 ! Linearly interpolate between edge values.
 ! The resulting piecewise interpolant is stored in 'ppoly'.
@@ -57,18 +57,23 @@ subroutine P1M_interpolation( N, h, u, ppoly_E, ppoly_coefficients )
 ! ------------------------------------------------------------------------------
 
   ! Arguments
-  integer,            intent(in)    :: N ! Number of cells
-  real, dimension(:), intent(in)    :: h ! cell widths (size N)
-  real, dimension(:), intent(in)    :: u ! cell averages (size N)
-  real, dimension(:,:), intent(inout) :: ppoly_E
-  real, dimension(:,:), intent(inout) :: ppoly_coefficients
+  integer,              intent(in)    :: N !< Number of cells
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
+  real, dimension(:),   intent(in)    :: u !< cell average properties (size N)
+  real, dimension(:,:), intent(inout) :: ppoly_E !< Potentially modified edge values,
+                                           !! with the same units as u.
+  real, dimension(:,:), intent(inout) :: ppoly_coefficients !< Potentially modified
+                                           !! piecewise polynomial coefficients, mainly
+                                           !! with the same units as u.
+  real,       optional, intent(in)    :: h_neglect !< A negligibly small width
+                                           !! in the same units as h.
 
   ! Local variables
   integer   :: k            ! loop index
   real      :: u0_l, u0_r   ! edge values (left and right)
 
   ! Bound edge values (routine found in 'edge_values.F90')
-  call bound_edge_values( N, h, u, ppoly_E )
+  call bound_edge_values( N, h, u, ppoly_E, h_neglect )
 
   ! Systematically average discontinuous edge values (routine found in
   ! 'edge_values.F90')

--- a/src/ALE/coord_hycom.F90
+++ b/src/ALE/coord_hycom.F90
@@ -93,20 +93,30 @@ subroutine set_hycom_params(CS, max_interface_depths, max_layer_thickness, inter
 end subroutine set_hycom_params
 
 !> Build a HyCOM coordinate column
-subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, z_col, z_col_new)
+subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, &
+                               z_col, z_col_new, zScale, h_neglect, h_neglect_edge)
   type(hycom_CS),        intent(in)    :: CS !< Coordinate control structure
   type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
   integer,               intent(in)    :: nz !< Number of levels
   real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in H)
   real, dimension(nz),   intent(in)    :: T, S !< T and S for column
-  real, dimension(nz),   intent(in)    :: h  !< Layer thicknesses, in m
+  real, dimension(nz),   intent(in)    :: h  !< Layer thicknesses, (in m or H)
   real, dimension(nz),   intent(in)    :: p_col !< Layer pressure in Pa
   real, dimension(nz+1), intent(in)    :: z_col ! Interface positions relative to the surface in H units (m or kg m-2)
   real, dimension(nz+1), intent(inout) :: z_col_new !< Absolute positions of interfaces
+  real, optional,        intent(in)    :: zScale !< Scaling factor from the input thicknesses in m
+                                                 !! to desired units for zInterface, perhaps m_to_H.
+  real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the
+                                             !! purpose of cell reconstructions
+                                             !! in the same units as h.
+  real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width
+                                             !! for the purpose of edge value calculations
+                                             !! in the same units as h0.
 
   ! Local variables
   integer   :: k
   real, dimension(nz) :: rho_col, h_col_new ! Layer quantities
+  real :: z_scale
   real :: stretching ! z* stretching, converts z* to z.
   real :: nominal_z ! Nominal depth of interface is using z* (m or Pa)
   real :: hNew
@@ -115,6 +125,8 @@ subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, z_co
 
   maximum_depths_set = allocated(CS%max_interface_depths)
   maximum_h_set = allocated(CS%max_layer_thickness)
+
+  z_scale = 1.0 ; if (present(zScale)) z_scale = zScale
 
   ! Work bottom recording potential density
   call calculate_density(T, S, p_col, rho_col, 1, nz, eqn_of_state)
@@ -127,14 +139,14 @@ subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, z_co
   ! Interpolates for the target interface position with the rho_col profile
   ! Based on global density profile, interpolate to generate a new grid
   call build_and_interpolate_grid(CS%interp_CS, rho_col, nz, h(:), z_col, &
-       CS%target_density, nz, h_col_new, z_col_new)
+           CS%target_density, nz, h_col_new, z_col_new, h_neglect, h_neglect_edge)
 
   ! Sweep down the interfaces and make sure that the interface is at least
   ! as deep as a nominal target z* grid
   nominal_z = 0.
   stretching = z_col(nz+1) / depth ! Stretches z* to z
   do k = 2, nz+1
-    nominal_z = nominal_z + CS%coordinateResolution(k-1) * stretching
+    nominal_z = nominal_z + (z_scale * CS%coordinateResolution(k-1)) * stretching
     z_col_new(k) = max( z_col_new(k), nominal_z )
     z_col_new(k) = min( z_col_new(k), z_col(nz+1) )
   enddo

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -873,7 +873,7 @@ subroutine calculateBuoyancyFlux1d(G, GV, fluxes, optics, h, Temp, Salt, tv, j, 
                                 dRhodT, dRhodS, start, npts, tv%eqn_of_state)
 
   ! Adjust netSalt to reflect dilution effect of FW flux
-  netSalt(G%isc:G%iec) = netSalt(G%isc:G%iec) - Salt(G%isc:G%iec,j,1) * netH(G%isc:G%iec) * GV%H_to_m ! ppt H/s
+  netSalt(G%isc:G%iec) = netSalt(G%isc:G%iec) - Salt(G%isc:G%iec,j,1) * netH(G%isc:G%iec) ! ppt H/s
 
   ! Add in the SW heating for purposes of calculating the net
   ! surface buoyancy flux affecting the top layer.

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -34,7 +34,7 @@ type, public :: wave_speed_CS ; private
                                        !! can be overridden by optional arguments.
   type(remapping_CS) :: remapping_CS   !< Used for vertical remapping when calculating equivalent barotropic
                                        !! mode structure.
-  type(diag_ctrl), pointer :: diag !< Diagnostics control structure
+  type(diag_ctrl), pointer :: diag     !< Diagnostics control structure
 end type wave_speed_CS
 
 contains
@@ -42,9 +42,9 @@ contains
 !> Calculates the wave speed of the first baroclinic mode.
 subroutine wave_speed(h, tv, G, GV, cg1, CS, full_halos, use_ebt_mode, &
                       mono_N2_column_fraction, mono_N2_depth, modal_structure)
-  type(ocean_grid_type),                    intent(in)  :: G !< Ocean grid structure
+  type(ocean_grid_type),                    intent(in)  :: G  !< Ocean grid structure
   type(verticalGrid_type),                  intent(in)  :: GV !< Vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)  :: h !< Layer thickness (m or kg/m2)
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)  :: h  !< Layer thickness in units of H (m or kg/m2)
   type(thermo_var_ptrs),                    intent(in)  :: tv !< Thermodynamic variables
   real, dimension(SZI_(G),SZJ_(G)),         intent(out) :: cg1 !< First mode internal wave speed (m/s)
   type(wave_speed_CS),                      pointer     :: CS !< Control structure for MOM_wave_speed
@@ -443,7 +443,10 @@ subroutine wave_speed(h, tv, G, GV, cg1, CS, full_halos, use_ebt_mode, &
             else
               mode_struct(1:kc)=0.
             endif
-            call remapping_core_h(CS%remapping_CS, kc, Hc, mode_struct, nz, h(i,j,:), modal_structure(i,j,:))
+            ! Note that remapping_core_h requires that the same units be used
+            ! for both the source and target grid thicknesses.
+            call remapping_core_h(CS%remapping_CS, kc, Hc, mode_struct, &
+                                  nz, GV%H_to_m*h(i,j,:), modal_structure(i,j,:))
           endif
         else
           cg1(i,j) = 0.0

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1065,18 +1065,27 @@ end subroutine int_density_dz_generic_cell
 
 
 ! ==========================================================================
-! Compute pressure gradient force integrals for the case where T and S
-! are linear profiles.
+!> Compute pressure gradient force integrals by quadrature for the case where
+!! T and S are linear profiles.
 ! ==========================================================================
 subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
-                                       rho_0, G_e, H_subroundoff, bathyT, HII, HIO, EOS, dpa, &
+                                       rho_0, G_e, dz_subroundoff, bathyT, HII, HIO, EOS, dpa, &
                                        intz_dpa, intx_dpa, inty_dpa, &
                                        useMassWghtInterp)
   type(hor_index_type),   intent(in)  :: HII, HIO
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
-                          intent(in)  :: T_t, T_b, S_t, S_b, z_t, z_b
-  real,                   intent(in)  :: rho_ref, rho_0, G_e, H_subroundoff
-  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed),  intent(in)  :: bathyT
+                          intent(in)  :: T_t, T_b, S_t, S_b
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                          intent(in)  :: z_t !< The geometric height at the top
+                                             !! of the layer, usually in m
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                          intent(in)  :: z_b !< The geometric height at the bpttom
+                                             !! of the layer, usually in m
+  real,                   intent(in)  :: rho_ref, rho_0, G_e
+  real,                   intent(in)  :: dz_subroundoff !< A miniscule thickness
+                                             !! change in the same units as z_t
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                          intent(in)  :: bathyT !< The depth of the bathymetry in m
   type(EOS_type),         pointer     :: EOS !< Equation of state structure
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
                           intent(out) :: dpa
@@ -1214,8 +1223,8 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
     hWght = massWeightingToggle * &
             max(0., -bathyT(iin,jin)-z_t(iin+1,jin), -bathyT(iin+1,jin)-z_t(iin,jin))
     if (hWght > 0.) then
-      hL = (z_t(iin,jin) - z_b(iin,jin)) + H_subroundoff
-      hR = (z_t(iin+1,jin) - z_b(iin+1,jin)) + H_subroundoff
+      hL = (z_t(iin,jin) - z_b(iin,jin)) + dz_subroundoff
+      hR = (z_t(iin+1,jin) - z_b(iin+1,jin)) + dz_subroundoff
       hWght = hWght * ( (hL-hR)/(hL+hR) )**2
       iDenom = 1./( hWght*(hR + hL) + hL*hR )
       Ttl = ( (hWght*hR)*T_t(iin+1,jin) + (hWght*hL + hR*hL)*T_t(iin,jin) ) * iDenom
@@ -1295,8 +1304,8 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
       hWght = massWeightingToggle * &
               max(0., -bathyT(i,j)-z_t(iin,jin+1), -bathyT(i,j+1)-z_t(iin,jin))
       if (hWght > 0.) then
-        hL = (z_t(iin,jin) - z_b(iin,jin)) + H_subroundoff
-        hR = (z_t(iin,jin+1) - z_b(iin,jin+1)) + H_subroundoff
+        hL = (z_t(iin,jin) - z_b(iin,jin)) + dz_subroundoff
+        hR = (z_t(iin,jin+1) - z_b(iin,jin+1)) + dz_subroundoff
         hWght = hWght * ( (hL-hR)/(hL+hR) )**2
         iDenom = 1./( hWght*(hR + hL) + hL*hR )
         Ttl = ( (hWght*hR)*T_t(iin,jin+1) + (hWght*hL + hR*hL)*T_t(iin,jin) ) * iDenom
@@ -1791,6 +1800,9 @@ subroutine int_density_dz_generic_plm_analytic (T_t, T_b, S_t, S_b, z_t, &
 
   Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB
 
+  call MOM_error(FATAL, "I believe that int_density_dz_generic_plm_analytic "//&
+    "has serious bugs and should not be used in its current form. - R. Hallberg")
+
   GxRho = G_e * rho_0
   I_Rho = 1.0 / rho_0
 
@@ -1828,6 +1840,10 @@ subroutine int_density_dz_generic_plm_analytic (T_t, T_b, S_t, S_b, z_t, &
     if (present(intz_dpa)) intz_dpa(i,j) = 0.5*G_e*dz**2 * &
           (rho_anom - C1_90*(16.0*(r5(4)-r5(2)) + 7.0*(r5(5)-r5(1))) )
 
+
+    !### The fact that this this expression does not use T and that
+    !### an optional variable is assigned, even if it is not present
+    !### strongly suggests that this code is wrong.
     intz_dpa(i,j) = ( 0.5 * (S_b(i,j)+1000.0-rho_ref) + &
                       (1.0/3.0) * dS ) * G_e * dz**2
 

--- a/src/framework/MOM_spatial_means.F90
+++ b/src/framework/MOM_spatial_means.F90
@@ -73,7 +73,7 @@ function global_layer_mean(var, h, G, GV)
   tmpForSumming(:,:,:) = 0. ; weight(:,:,:) = 0.
 
   do k=1,nz ; do j=js,je ; do i=is,ie
-    weight(i,j,k)  =  h(i,j,k) * (G%areaT(i,j) * G%mask2dT(i,j))
+    weight(i,j,k)  =  (GV%H_to_m * h(i,j,k)) * (G%areaT(i,j) * G%mask2dT(i,j))
     tmpForSumming(i,j,k) =  var(i,j,k) * weight(i,j,k)
   enddo ; enddo ; enddo
 
@@ -101,7 +101,7 @@ function global_volume_mean(var, h, G, GV)
   tmpForSumming(:,:) = 0. ; sum_weight(:,:) = 0.
 
   do k=1,nz ; do j=js,je ; do i=is,ie
-    weight_here  =  h(i,j,k) * (G%areaT(i,j) * G%mask2dT(i,j))
+    weight_here  =  (GV%H_to_m * h(i,j,k)) * (G%areaT(i,j) * G%mask2dT(i,j))
     tmpForSumming(i,j) = tmpForSumming(i,j) + var(i,j,k) * weight_here
     sum_weight(i,j) = sum_weight(i,j) + weight_here
   enddo ; enddo ; enddo

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -76,7 +76,7 @@ type, public :: bulkmixedlayer_CS ; private
                              ! released mean kinetic energy becomes TKE, nondim.
   real    :: Hmix_min        ! The minimum mixed layer thickness in m.
   real    :: H_limit_fluxes  ! When the total ocean depth is less than this
-                             ! value, in H, scale away all surface forcing to
+                             ! value, in m, scale away all surface forcing to
                              ! avoid boiling the ocean.
   real    :: ustar_min       ! A minimum value of ustar to avoid numerical
                              ! problems, in m s-1.  If the value is small enough,
@@ -433,6 +433,8 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
   integer :: i, j, k, is, ie, js, je, nz, nkmb, n
   integer :: nsw    ! The number of bands of penetrating shortwave radiation.
 
+  real    :: H_limit_fluxes ! CS%H_limit fluxes converted to units of H.
+
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   if (.not. associated(CS)) call MOM_error(FATAL, "MOM_mixed_layer: "//&
@@ -451,12 +453,12 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
 
   Irho0 = 1.0 / GV%Rho0
   dt__diag = dt ; if (present(dt_diag)) dt__diag = dt_diag
-  Idt = 1.0/dt
+  Idt = 1.0 / dt
   Idt_diag = 1.0 / dt__diag
   write_diags = .true. ; if (present(last_call)) write_diags = last_call
+  H_limit_fluxes = CS%H_limit_fluxes * GV%m_to_H
 
   p_ref(:) = 0.0 ; p_ref_cv(:) = tv%P_Ref
-
 
   nsw = CS%nsw
 
@@ -522,21 +524,14 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
   endif
   max_BL_det(:) = -1
 
-!$OMP parallel default(none) shared(is,ie,js,je,nz,h_3d,u_3d,v_3d,nkmb,G,GV,nsw,optics,      &
-!$OMP                               CS,tv,fluxes,Irho0,dt,Idt_diag,Ih,write_diags,           &
-!$OMP                               hmbl_prev,h_sum,Hsfc_min,Hsfc_max,dt__diag,              &
-!$OMP                               Hsfc_used,Inkmlm1,Inkml,ea,eb,h_miss,Hml,                &
-!$OMP                               id_clock_EOS,id_clock_resort,id_clock_adjustment,        &
-!$OMP                               id_clock_conv,id_clock_mech,id_clock_detrain,aggregate_FW_forcing ) &
-!$OMP                  firstprivate(dKE_CA,cTKE,h_CA,max_BL_det,p_ref,p_ref_cv)              &
-!$OMP                       private(h,h_orig,u,v,eps,T,S,opacity_band,d_ea,d_eb,             &
-!$OMP                               dR0_dT,dR0_dS,dRcv_dT,dRcv_dS,R0,Rcv,ksort,              &
-!$OMP                               RmixConst,TKE_river,netMassInOut, NetMassOut,            &
-!$OMP                               Net_heat, Net_salt, htot,TKE,Pen_SW_bnd,Ttot,Stot, uhtot,&
-!$OMP                               vhtot, R0_tot, Rcv_tot,Conv_en,dKE_FC,Idecay_len_TKE,    &
-!$OMP                               cMKE,Hsfc,dHsfc,dHD,H_nbr,kU_Star,absf_x_H,              &
-!$OMP                               ebml,eaml)
-!$OMP do
+  !$OMP parallel default(shared) firstprivate(dKE_CA,cTKE,h_CA,max_BL_det,p_ref,p_ref_cv) &
+  !$OMP                 private(h,u,v,h_orig,eps,T,S,opacity_band,d_ea,d_eb,R0,Rcv,ksort, &
+  !$OMP                         dR0_dT,dR0_dS,dRcv_dT,dRcv_dS,htot,Ttot,Stot,TKE,Conv_en, &
+  !$OMP                         RmixConst,TKE_river,Pen_SW_bnd,netMassInOut,NetMassOut,   &
+  !$OMP                         Net_heat,Net_salt,uhtot,vhtot,R0_tot,Rcv_tot,dKE_FC,      &
+  !$OMP                         Idecay_len_TKE,cMKE,Hsfc,dHsfc,dHD,H_nbr,kU_Star,         &
+  !$OMP                         absf_x_H,ebml,eaml)
+  !$OMP do
   do j=js,je
     ! Copy the thicknesses and other fields to 2-d arrays.
     do k=1,nz ; do i=is,ie
@@ -626,7 +621,7 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
     ! net_salt     = salt ( g(salt)/m2 for non-Bouss and ppt*m/s for Bouss ) via surface fluxes
     ! Pen_SW_bnd   = components to penetrative shortwave radiation
     call extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt, &
-                  CS%H_limit_fluxes, CS%use_river_heat_content, CS%use_calving_heat_content, &
+                  H_limit_fluxes, CS%use_river_heat_content, CS%use_calving_heat_content, &
                   h(:,1:), T(:,1:), netMassInOut, netMassOut, Net_heat, Net_salt, Pen_SW_bnd,&
                   tv, aggregate_FW_forcing)
 
@@ -660,7 +655,7 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
                                 cMKE, Idt_diag, nsw, Pen_SW_bnd, opacity_band, TKE, &
                                 Idecay_len_TKE, j, ksort, G, GV, CS)
 
-    call absorbRemainingSW(G, GV, h(:,1:), opacity_band, nsw, j, dt, CS%H_limit_fluxes, &
+    call absorbRemainingSW(G, GV, h(:,1:), opacity_band, nsw, j, dt, H_limit_fluxes, &
                            CS%correct_absorption, CS%absorb_all_SW, &
                            T(:,1:), Pen_SW_bnd, eps, ksort, htot, Ttot)
 
@@ -1824,7 +1819,7 @@ subroutine mechanical_entrainment(h, d_eb, htot, Ttot, Stot, uhtot, vhtot, &
           endif
 
           TKE(i) = TKE_full_ent
-          if (TKE(i) <= 0.0) TKE(i) = 1e-300
+          if (TKE(i) <= 0.0) TKE(i) = 1.0e-150
         else
 ! The layer is only partially entrained.  The amount that will be
 ! entrained is determined iteratively.  No further layers will be
@@ -3736,7 +3731,6 @@ subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
                  "The surface fluxes are scaled away when the total ocean \n"//&
                  "depth is less than DEPTH_LIMIT_FLUXES.", &
                  units="m", default=0.1*CS%Hmix_min)
-  CS%H_limit_fluxes = CS%H_limit_fluxes * GV%m_to_H
   call get_param(param_file, mdl, "OMEGA",CS%omega, &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5)

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -1265,25 +1265,26 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
     !  1) Answers will change due to round-off
     !  2) Be sure to save their values BEFORE fluxes are used.
     if (Calculate_Buoyancy) then
-       drhodt(:) = 0.0
-       drhods(:) = 0.0
-       netPen(:,:) = 0.0
-       ! Sum over bands and attenuate as a function of depth
-       ! netPen is the netSW as a function of depth
-       call sumSWoverBands(G, GV, h2d(:,:), optics%opacity_band(:,:,j,:), nsw, j, dt, &
-            H_limit_fluxes, .true., pen_SW_bnd_rate, netPen)
-       ! Density derivatives
-       call calculate_density_derivs(T2d(:,1), tv%S(:,j,1), SurfPressure, &
-            dRhodT, dRhodS, start, npts, tv%eqn_of_state)
-       ! 1. Adjust netSalt to reflect dilution effect of FW flux
-       ! 2. Add in the SW heating for purposes of calculating the net
-       ! surface buoyancy flux affecting the top layer.
-       ! 3. Convert to a buoyancy flux, excluding penetrating SW heating
-       !    BGR-Jul 5, 2017: The contribution of SW heating here needs investigated for ePBL.
-       SkinBuoyFlux(G%isc:G%iec,j) = - GoRho * ( dRhodS(G%isc:G%iec) * (netSalt_rate(G%isc:G%iec) &
-            - tv%S(G%isc:G%iec,j,1) * netMassInOut_rate(G%isc:G%iec)* GV%H_to_m )&
-            + dRhodT(G%isc:G%iec) * ( netHeat_rate(G%isc:G%iec) +        &
-            netPen(G%isc:G%iec,1))) * GV%H_to_m ! m^2/s^3
+      drhodt(:) = 0.0
+      drhods(:) = 0.0
+      netPen(:,:) = 0.0
+      ! Sum over bands and attenuate as a function of depth
+      ! netPen is the netSW as a function of depth
+      call sumSWoverBands(G, GV, h2d(:,:), optics%opacity_band(:,:,j,:), nsw, j, dt, &
+           H_limit_fluxes, .true., pen_SW_bnd_rate, netPen)
+      ! Density derivatives
+      call calculate_density_derivs(T2d(:,1), tv%S(:,j,1), SurfPressure, &
+           dRhodT, dRhodS, start, npts, tv%eqn_of_state)
+      ! 1. Adjust netSalt to reflect dilution effect of FW flux
+      ! 2. Add in the SW heating for purposes of calculating the net
+      ! surface buoyancy flux affecting the top layer.
+      ! 3. Convert to a buoyancy flux, excluding penetrating SW heating
+      !    BGR-Jul 5, 2017: The contribution of SW heating here needs investigated for ePBL.
+      do i=is,ie
+        SkinBuoyFlux(i,j) = - GoRho * GV%H_to_m * ( &
+            dRhodS(i) * (netSalt_rate(i) - tv%S(i,j,1)*netMassInOut_rate(i)) + &
+            dRhodT(i) * ( netHeat_rate(i) + netPen(i,1)) ) ! m^2/s^3
+      enddo
     endif
 
   enddo ! j-loop finish

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -638,9 +638,9 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
       Kd(i,K) = 0.0
     enddo ; enddo
     do i=is,ie
-       CS%ML_depth(i,j) = h(i,1)*GV%H_to_m
-       !CS%ML_depth2(i,j) = h(i,1)*GV%H_to_m
-       sfc_connected(i) = .true.
+      CS%ML_depth(i,j) = h(i,1)*GV%H_to_m
+      !CS%ML_depth2(i,j) = h(i,1)*GV%H_to_m
+      sfc_connected(i) = .true.
     enddo
 
     if (debug) then
@@ -680,7 +680,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
       iL_Ekman   = absf(i)/U_star
       iL_Obukhov = buoy_flux(i,j)*vonkar/U_Star**3
 
-      if (CS%Mstar_Mode.eq.CS%CONST_MSTAR) then
+      if (CS%Mstar_Mode == CS%CONST_MSTAR) then
         mech_TKE(i) = (dt*CS%mstar*GV%Rho0)*((U_Star**3))
         conv_PErel(i) = 0.0
 
@@ -774,14 +774,14 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
         if (CS%Mstar_Mode.gt.0) then
         ! Note the value of mech_TKE(i) now must be iterated over, so it is moved here
         ! First solve for the TKE to PE length scale
-          if (CS%MSTAR_MODE.eq.CS%MLD_o_OBUKHOV) then
+          if (CS%MSTAR_MODE == CS%MLD_o_OBUKHOV) then
             MLD_over_Stab = MLD_guess / Stab_Scale - CS%MSTAR_XINT
-            if ((MLD_over_Stab) .le. 0.0) then
+            if ((MLD_over_Stab) <= 0.0) then
               !Asymptote to 0 as MLD_over_Stab -> -infinity (always)
               MSTAR_mix = (CS%MSTAR_B*(MLD_over_Stab)+CS%MSTAR_A)**(CS%MSTAR_N)
             else
               if (CS%MSTAR_CAP>=0.) then
-                if (CS%MSTAR_FLATCAP .OR. (MLD_over_Stab .le.CS%MSTAR_XINT_UP)) then
+                if (CS%MSTAR_FLATCAP .OR. (MLD_over_Stab  <= CS%MSTAR_XINT_UP)) then
                 !If using flat cap (or if using asymptotic cap
                 !   but within linear regime we can make use of same code)
                   MSTAR_mix = min(CS%MSTAR_CAP, &
@@ -797,10 +797,11 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
                 MSTAR_mix = CS%MSTAR_SLOPE*(MLD_over_Stab)+CS%MSTAR_AT_XINT
               endif
             endif
-          elseif (CS%MSTAR_MODE.eq.CS%EKMAN_o_OBUKHOV) then
+          elseif (CS%MSTAR_MODE == CS%EKMAN_o_OBUKHOV) then
+            !### Please refrain from using the construct A / B / C in place of A/(B*C).
             mstar_STAB = CS%MSTAR_COEF*sqrt(Bf_Stable/u_star**2/(absf(i)+1.e-10))
             mstar_ROT =  CS%C_EK*log(max(1.,u_star/(absf(i)+1.e-10)/mld_guess))
-            if ( CS%MSTAR_CAP.le.0.0) then !No cap.
+            if ( CS%MSTAR_CAP <= 0.0) then !No cap.
               MSTAR_MIX = max(mstar_STAB,& ! 1st term if balance of rotation and stabilizing
                                     ! the balance is f(L_Ekman,L_Obukhov)
                               min(& ! 2nd term for forced stratification limited
@@ -907,7 +908,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
           I_MLD = 1.0 / MLD_guess ; h_rsum = 0.0
           MixLen_shape(1) = 1.0
           do K=2,nz+1
-            h_rsum = h_rsum + h(i,k-1)
+            h_rsum = h_rsum + h(i,k-1)*GV%H_to_m
             if (CS%MixLenExponent==2.0)then
               MixLen_shape(K) = CS%transLay_scale + (1.0 - CS%transLay_scale) * &
                    (max(0.0, (MLD_guess - h_rsum)*I_MLD) )**2!CS%MixLenExponent
@@ -1417,7 +1418,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, CS, &
           do k=2,nz
             if (FIRST_OBL) then !Breaks when OBL found
               if (Vstar_Used(k) > 1.e-10 .and. k < nz) then
-                MLD_FOUND = MLD_FOUND+h(i,k-1)*GV%H_to_m
+                MLD_FOUND = MLD_FOUND + h(i,k-1)*GV%H_to_m
               else
                 FIRST_OBL = .false.
                 if (MLD_FOUND-CS%MLD_tol > MLD_guess) then

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -1740,7 +1740,7 @@ subroutine determine_Ea_kb(h_bl, dtKd_kb, Sref, I_dSkbp1, Ent_bl, ea_kbp1, &
                             ! method might be used for the next iteration.
   logical, dimension(SZI_(G)) :: redo_i ! If true, more work is needed on this column.
   logical :: do_any
-  real, parameter :: LARGE_VAL = 1.0e30
+  real :: large_err         ! A large error measure, in H2.
   integer :: i, it
   integer, parameter :: MAXIT = 30
 
@@ -1749,6 +1749,7 @@ subroutine determine_Ea_kb(h_bl, dtKd_kb, Sref, I_dSkbp1, Ent_bl, ea_kbp1, &
                            "unless BULKMIXEDLAYER is defined.")
   endif
   tolerance = GV%m_to_H * CS%Tolerance_Ent
+  large_err = GV%m_to_H**2 * 1.0e30
 
   do i=is,ie ; redo_i(i) = do_i(i) ; enddo
 
@@ -1758,7 +1759,7 @@ subroutine determine_Ea_kb(h_bl, dtKd_kb, Sref, I_dSkbp1, Ent_bl, ea_kbp1, &
     !   These were previously calculated and provide good limits and estimates
     ! of the errors there. By construction the errors increase with R*ea_kbp1.
     E_min(i) = min_eakb(i) ; E_max(i) = max_eakb(i)
-    error_minE(i) = -LARGE_VAL ; error_maxE(i) = LARGE_VAL
+    error_minE(i) = -large_err ; error_maxE(i) = large_err
     false_position(i) = .true. ! Used to alternate between false_position and
                                ! bisection when Newton's method isn't working.
     if (present(err_min_eakb0)) error_minE(i) = err_min_eakb0(i) - E_min(i) * ea_kbp1(i)
@@ -1823,7 +1824,7 @@ subroutine determine_Ea_kb(h_bl, dtKd_kb, Sref, I_dSkbp1, Ent_bl, ea_kbp1, &
         ! remain bracketed between Rmin and Rmax.
         Ent(i) = Ent(i) - err(i) / derror_dE(i)
       elseif (false_position(i) .and. &
-              (error_maxE(i) - error_minE(i) < 0.9*LARGE_VAL)) then
+              (error_maxE(i) - error_minE(i) < 0.9*large_err)) then
         ! Use the false postion method if there are decent error estimates.
         Ent(i) = E_min(i) + (E_max(i)-E_min(i)) * &
                 (-error_minE(i)/(error_maxE(i) - error_minE(i)))

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -472,8 +472,10 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, CS, Reg, tv, do_online_fla
   if (CS%debug) then
     call uvchksum("After tracer diffusion khdt_[xy]", khdt_x, khdt_y, &
                   G%HI, haloshift=0, symmetric=.true.)
-    call uvchksum("After tracer diffusion Coef_[xy]", Coef_x, Coef_y, &
-                  G%HI, haloshift=0, symmetric=.true., scale=GV%H_to_m)
+    if (CS%use_neutral_diffusion) then
+      call uvchksum("After tracer diffusion Coef_[xy]", Coef_x, Coef_y, &
+                    G%HI, haloshift=0, symmetric=.true.)
+    endif
   endif
 
   if (CS%id_khdt_x > 0) call post_data(CS%id_khdt_x, khdt_x, CS%diag)


### PR DESCRIPTION
This PR covers a large set of changes that will prevent answers from changing when H_TO_M or H_TO_KG_M2 are rescaled by integer powers of 2.  All answers in the test cases are bitwise identical when H_TO_M is not rescaled.