### PR TITLE
Complete rescaling thickness to H units

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -164,6 +164,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
   type(EOS_type), pointer :: eos => NULL()
   logical :: debug      ! If true, write debugging output.
   logical :: debug_obc  ! If true, do debugging calls related to OBCs.
+  logical :: debug_layers = .false.
+  character(len=80) :: mesg
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
@@ -284,7 +286,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                                       just_read_params=just_read)
        case ("lock_exchange"); call lock_exchange_initialize_thickness(h, G, GV, &
                                         PF, just_read_params=just_read)
-       case ("external_gwave"); call external_gwave_initialize_thickness(h, G, &
+       case ("external_gwave"); call external_gwave_initialize_thickness(h, G, GV, &
                                          PF, just_read_params=just_read)
        case ("DOME2D"); call DOME2d_initialize_thickness(h, G, GV, PF, &
                                  just_read_params=just_read)
@@ -294,12 +296,12 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                                    just_read_params=just_read)
        case ("seamount"); call seamount_initialize_thickness(h, G, GV, PF, &
                                    just_read_params=just_read)
-       case ("soliton"); call soliton_initialize_thickness(h, G)
+       case ("soliton"); call soliton_initialize_thickness(h, G, GV)
        case ("phillips"); call Phillips_initialize_thickness(h, G, GV, PF, &
                                    just_read_params=just_read)
        case ("rossby_front"); call Rossby_front_initialize_thickness(h, G, GV, &
                                        PF, just_read_params=just_read)
-       case ("USER"); call user_initialize_thickness(h, G, PF, tv%T, &
+       case ("USER"); call user_initialize_thickness(h, G, GV, PF, &
                                just_read_params=just_read)
        case default ; call MOM_error(FATAL,  "MOM_initialize_state: "//&
             "Unrecognized layer thickness configuration "//trim(config))
@@ -341,19 +343,19 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
         case ("linear"); call initialize_temp_salt_linear(tv%T, tv%S, G, PF, &
                                   just_read_params=just_read)
         case ("DOME2D"); call DOME2d_initialize_temperature_salinity ( tv%T, &
-                                  tv%S, h, G, PF, eos, just_read_params=just_read)
+                                  tv%S, h, G, GV, PF, eos, just_read_params=just_read)
         case ("ISOMIP"); call ISOMIP_initialize_temperature_salinity ( tv%T, &
                                   tv%S, h, G, GV, PF, eos, just_read_params=just_read)
         case ("adjustment2d"); call adjustment_initialize_temperature_salinity ( tv%T, &
-                                        tv%S, h, G, PF, eos, just_read_params=just_read)
+                                        tv%S, h, G, GV, PF, eos, just_read_params=just_read)
         case ("baroclinic_zone"); call baroclinic_zone_init_temperature_salinity( tv%T, &
-                                           tv%S, h, G, PF, just_read_params=just_read)
+                                           tv%S, h, G, GV, PF, just_read_params=just_read)
         case ("sloshing"); call sloshing_initialize_temperature_salinity(tv%T, &
-                                    tv%S, h, G, PF, eos, just_read_params=just_read)
+                                    tv%S, h, G, GV, PF, eos, just_read_params=just_read)
         case ("seamount"); call seamount_initialize_temperature_salinity(tv%T, &
                                     tv%S, h, G, GV, PF, eos, just_read_params=just_read)
         case ("rossby_front"); call Rossby_front_initialize_temperature_salinity ( tv%T, &
-                                        tv%S, h, G, PF, eos, just_read_params=just_read)
+                                        tv%S, h, G, GV, PF, eos, just_read_params=just_read)
         case ("SCM_ideal_hurr"); call SCM_idealized_hurricane_TS_init ( tv%T, &
                                           tv%S, h, G, GV, PF, just_read_params=just_read)
         case ("SCM_CVmix_tests"); call SCM_CVmix_tests_TS_init (tv%T, &
@@ -418,22 +420,10 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                "units of m to kg m-2 or vice versa, depending on whether \n"//&
                "BOUSSINESQ is defined. This does not apply if a restart \n"//&
                "file is read.", default=.not.GV%Boussinesq, do_not_log=just_read)
-  if (new_sim) then
-    if (GV%Boussinesq .or. convert) then
-      ! Convert h from m to thickness units (H)
-      do k=1,nz ; do j=js,je ; do i=is,ie
-        h(i,j,k) = h(i,j,k)*GV%m_to_H
-      enddo ; enddo ; enddo
-    else
-      do k=1,nz ; do j=js,je ; do i=is,ie
-        h(i,j,k) = h(i,j,k)*GV%kg_m2_to_H
-      enddo ; enddo ; enddo
-    endif
 
-    if (convert .and. .not.GV%Boussinesq) &
-      ! Convert thicknesses from geomtric distances to mass-per-unit-area.
-      call convert_thickness(h, G, GV, tv)
-  endif
+  if (new_sim .and. convert .and. .not.GV%Boussinesq) &
+    ! Convert thicknesses from geomtric distances to mass-per-unit-area.
+    call convert_thickness(h, G, GV, tv)
 
 !  Remove the mass that would be displaced by an ice shelf or inverse barometer.
   call get_param(PF, mdl, "DEPRESS_INITIAL_SURFACE", depress_sfc, &
@@ -489,6 +479,13 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
     call hchksum(h, "MOM_initialize_state: h ", G%HI, haloshift=1, scale=GV%H_to_m)
     if ( use_temperature ) call hchksum(tv%T, "MOM_initialize_state: T ", G%HI, haloshift=1)
     if ( use_temperature ) call hchksum(tv%S, "MOM_initialize_state: S ", G%HI, haloshift=1)
+    if ( use_temperature .and. debug_layers) then ; do k=1,nz
+      write(mesg,'("MOM_IS: T[",I2,"]")') k
+      call hchksum(tv%T(:,:,k), mesg, G%HI, haloshift=1)
+      write(mesg,'("MOM_IS: S[",I2,"]")') k
+      call hchksum(tv%S(:,:,k), mesg, G%HI, haloshift=1)
+    enddo ; endif
+
   endif
 
   call get_param(PF, mdl, "SPONGE", use_sponge, &
@@ -607,8 +604,6 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
 !  This subroutine reads the layer thicknesses from file.
   real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1)
   integer :: inconsistent = 0
-  real :: dilate     ! The amount by which each layer is dilated to agree
-                     ! with the bottom depth and free surface height, nondim.
   logical :: correct_thickness
   logical :: just_read    ! If true, just read parameters but set nothing.  character(len=20) :: verticalCoordinate
   character(len=40)  :: mdl = "initialize_thickness_from_file" ! This subroutine's name.
@@ -635,8 +630,12 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
          " initialize_thickness_from_file: Unable to open "//trim(filename))
 
   if (file_has_thickness) then
+    !### Consider adding a parameter to use to rescale h.
     if (just_read) return ! All run-time parameters have been read, so return.
     call MOM_read_data(filename, "h", h(:,:,:), G%Domain)
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      h(i,j,k) = GV%m_to_H * h(i,j,k)
+    enddo ; enddo ; enddo
   else
     call get_param(param_file, mdl, "ADJUST_THICKNESS", correct_thickness, &
                  "If true, all mass below the bottom removed if the \n"//&
@@ -652,9 +651,9 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
       do k=nz,1,-1 ; do j=js,je ; do i=is,ie
         if (eta(i,j,K) < (eta(i,j,K+1) + GV%Angstrom_z)) then
           eta(i,j,K) = eta(i,j,K+1) + GV%Angstrom_z
-          h(i,j,k) = GV%Angstrom_z
+          h(i,j,k) = GV%Angstrom
         else
-          h(i,j,k) = eta(i,j,K) - eta(i,j,K+1)
+          h(i,j,k) = GV%m_to_H * (eta(i,j,K) - eta(i,j,K+1))
         endif
       enddo ; enddo ; enddo
 
@@ -690,8 +689,8 @@ end subroutine initialize_thickness_from_file
 subroutine adjustEtaToFitBathymetry(G, GV, eta, h)
   type(ocean_grid_type),                          intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),                        intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)+1),    intent(inout) :: eta
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)),      intent(inout) :: h    !< Layer thicknesses, in m
+  real, dimension(SZI_(G),SZJ_(G), SZK_(G)+1),    intent(inout) :: eta  !< Interface heights, in m
+  real, dimension(SZI_(G),SZJ_(G), SZK_(G)),      intent(inout) :: h    !< Layer thicknesses, in H
   ! Local variables
   integer :: i, j, k, is, ie, js, je, nz, contractions, dilations
   real, parameter :: hTolerance = 0.1 !<  Tolerance to exceed adjustment criteria (m)
@@ -714,6 +713,8 @@ subroutine adjustEtaToFitBathymetry(G, GV, eta, h)
     call MOM_error(WARNING, 'adjustEtaToFitBathymetry: '//mesg)
   endif
 
+  !   To preserve previous answers, delay converting thicknesses to units of H
+  ! until the end of this routine.
   do k=nz,1,-1 ; do j=js,je ; do i=is,ie
     ! Collapse layers to thinnest possible if the thickness less than
     ! the thinnest possible (or negative).
@@ -721,7 +722,7 @@ subroutine adjustEtaToFitBathymetry(G, GV, eta, h)
       eta(i,j,K) = eta(i,j,K+1) + GV%Angstrom_z
       h(i,j,k) = GV%Angstrom_z
     else
-      h(i,j,k) = eta(i,j,K) - eta(i,j,K+1)
+      h(i,j,k) = (eta(i,j,K) - eta(i,j,K+1))
     endif
   enddo ; enddo ; enddo
 
@@ -738,9 +739,15 @@ subroutine adjustEtaToFitBathymetry(G, GV, eta, h)
         dilate = (eta(i,j,1)+G%bathyT(i,j)) / (eta(i,j,1)-eta(i,j,nz+1))
         do k=1,nz ; h(i,j,k) = h(i,j,k) * dilate ; enddo
       endif
-      do k=nz, 2, -1; eta(i,j,K) = eta(i,j,K+1) + h(i,j,k); enddo
+      do k=nz,2,-1 ; eta(i,j,K) = eta(i,j,K+1) + h(i,j,k) ; enddo
     endif
   enddo ; enddo
+
+  ! Now convert thicknesses to units of H.
+  do k=1,nz ; do j=js,je ; do i=is,ie
+    h(i,j,k) = h(i,j,k)*GV%m_to_H
+  enddo ; enddo ; enddo
+
   call sum_across_PEs(dilations)
   if ((dilations > 0) .and. (is_root_pe())) then
     write(mesg,'("Thickness initial conditions were dilated ",'// &
@@ -756,7 +763,7 @@ subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized, in m.
+                           intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -803,9 +810,9 @@ subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
       eta1D(K) = e0(K)
       if (eta1D(K) < (eta1D(K+1) + GV%Angstrom_z)) then
         eta1D(K) = eta1D(K+1) + GV%Angstrom_z
-        h(i,j,k) = GV%Angstrom_z
+        h(i,j,k) = GV%Angstrom
       else
-        h(i,j,k) = eta1D(K) - eta1D(K+1)
+        h(i,j,k) = GV%m_to_H * (eta1D(K) - eta1D(K+1))
       endif
     enddo
   enddo ; enddo
@@ -819,7 +826,7 @@ subroutine initialize_thickness_list(h, G, GV, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized, in m.
+                           intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -889,9 +896,9 @@ subroutine initialize_thickness_list(h, G, GV, param_file, just_read_params)
       eta1D(K) = e0(K)
       if (eta1D(K) < (eta1D(K+1) + GV%Angstrom_z)) then
         eta1D(K) = eta1D(K+1) + GV%Angstrom_z
-        h(i,j,k) = GV%Angstrom_z
+        h(i,j,k) = GV%Angstrom
       else
-        h(i,j,k) = eta1D(K) - eta1D(K+1)
+        h(i,j,k) = GV%m_to_H * (eta1D(K) - eta1D(K+1))
       endif
     enddo
   enddo ; enddo
@@ -1959,7 +1966,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 !
   type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                           intent(out)   :: h    !< Layer thicknesses being initialized, in m
+                           intent(out)   :: h    !< Layer thicknesses being initialized, in H
   type(thermo_var_ptrs),   intent(inout) :: tv   !< A structure pointing to various thermodynamic
                                                  !! variables including temperature and salinity
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
@@ -2016,7 +2023,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
   real, dimension(:), allocatable :: z_edges_in, z_in, Rb
   real, dimension(:,:,:), allocatable, target :: temp_z, salt_z, mask_z
   real, dimension(:,:,:), allocatable :: rho_z
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: zi
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: zi  ! Interface heights in m.
   real, dimension(SZI_(G),SZJ_(G))  :: nlevs
   real, dimension(SZI_(G))   :: press
 
@@ -2025,7 +2032,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
   real, dimension(:), allocatable :: hTarget
   real, dimension(:,:), allocatable :: area_shelf_h
   real, dimension(:,:), allocatable, target  :: frac_shelf_h
-  real, dimension(:,:,:), allocatable :: tmpT1dIn, tmpS1dIn, h1, tmp_mask_in
+  real, dimension(:,:,:), allocatable :: tmpT1dIn, tmpS1dIn, tmp_mask_in
+  real, dimension(:,:,:), allocatable :: h1 ! Thicknesses in H.
   real :: zTopOfCell, zBottomOfCell
   type(regridding_CS) :: regridCS ! Regridding parameters and work arrays
   type(remapping_CS) :: remapCS ! Remapping parameters and work arrays
@@ -2229,11 +2237,11 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
             tmpT1dIn(i,j,k) = -99.9
             tmpS1dIn(i,j,k) = -99.9
           endif
-          h1(i,j,k) = zTopOfCell - zBottomOfCell
+          h1(i,j,k) = GV%m_to_H * (zTopOfCell - zBottomOfCell)
           if (h1(i,j,k)>0.) nPoints = nPoints + 1
           zTopOfCell = zBottomOfCell ! Bottom becomes top for next value of k
         enddo
-        h1(i,j,kd) = h1(i,j,kd) + ( zTopOfCell + G%bathyT(i,j) ) ! In case data is deeper than model
+        h1(i,j,kd) = h1(i,j,kd) + GV%m_to_H * ( zTopOfCell + G%bathyT(i,j) ) ! In case data is deeper than model
       endif ! mask2dT
     enddo ; enddo
     deallocate( tmp_mask_in )
@@ -2256,7 +2264,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
           zTopOfCell = 0. ; zBottomOfCell = 0.
           do k = 1, nz
             zBottomOfCell = max( zTopOfCell - hTarget(k), -G%bathyT(i,j) )
-            h(i,j,k) = zTopOfCell - zBottomOfCell
+            h(i,j,k) = GV%m_to_H * (zTopOfCell - zBottomOfCell)
             zTopOfCell = zBottomOfCell ! Bottom becomes top for next value of k
           enddo
         else
@@ -2315,9 +2323,9 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
       do k=nz,1,-1 ; do j=js,je ; do i=is,ie
         if (zi(i,j,K) < (zi(i,j,K+1) + GV%Angstrom_z)) then
           zi(i,j,K) = zi(i,j,K+1) + GV%Angstrom_z
-          h(i,j,k) = GV%Angstrom_z
+          h(i,j,k) = GV%Angstrom
         else
-          h(i,j,k) = zi(i,j,K) - zi(i,j,K+1)
+          h(i,j,k) = GV%m_to_H * (zi(i,j,K) - zi(i,j,K+1))
         endif
       enddo ; enddo ; enddo
       inconsistent=0

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -361,6 +361,14 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, h, T, S, EOS, CS)
   real, dimension(SZK_(G),2) :: ppoly_r_S            ! Reconstruction slopes
   integer :: iMethod
   real, dimension(SZI_(G)) :: ref_pres ! Reference pressure used to calculate alpha/beta
+  real :: h_neglect, h_neglect_edge
+
+  !### Try replacing both of these with GV%H_subroundoff
+  if (GV%Boussinesq) then
+    h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
+  else
+    h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
+  endif
 
   ! If doing along isopycnal diffusion (as opposed to neutral diffusion, set the reference pressure)
   if (CS%ref_pres>=0.) ref_pres(:) = CS%ref_pres
@@ -385,13 +393,13 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, h, T, S, EOS, CS)
     ! Interpolate state to interface
     do i = G%isc-1, G%iec+1
       if (CS%continuous_reconstruction) then
-        call interface_scalar(G%ke, h(i,j,:), T(i,j,:), CS%Tint(i,j,:), 2)
-        call interface_scalar(G%ke, h(i,j,:), S(i,j,:), CS%Sint(i,j,:), 2)
+        call interface_scalar(G%ke, h(i,j,:), T(i,j,:), CS%Tint(i,j,:), 2, h_neglect)
+        call interface_scalar(G%ke, h(i,j,:), S(i,j,:), CS%Sint(i,j,:), 2, h_neglect)
       else
         call build_reconstructions_1d( CS%remap_CS, G%ke, h(i,j,:), T(i,j,:), CS%ppoly_coeffs_T(i,j,:,:), &
-                                       CS%T_i(i,j,:,:), ppoly_r_S, iMethod )
+                                       CS%T_i(i,j,:,:), ppoly_r_S, iMethod, h_neglect, h_neglect_edge )
         call build_reconstructions_1d( CS%remap_CS, G%ke, h(i,j,:), S(i,j,:), CS%ppoly_coeffs_S(i,j,:,:), &
-                                       CS%S_i(i,j,:,:), ppoly_r_S, iMethod )
+                                       CS%S_i(i,j,:,:), ppoly_r_S, iMethod, h_neglect, h_neglect_edge )
       endif
     enddo
 
@@ -491,6 +499,11 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, Tracer, m, dt, name, CS)
   real, dimension(G%ke)                        :: dTracer     ! change in tracer concentration due to ndiffusion
   integer :: i, j, k, ks, nk
   real :: ppt2mks, Idt, convert
+  real :: h_neglect, h_neglect_edge
+
+  !### Try replacing both of these with GV%H_subroundoff
+  h_neglect_edge = GV%m_to_H*1.0e-10
+  h_neglect = GV%m_to_H*1.0e-30
 
   nk = GV%ke
 
@@ -522,7 +535,7 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, Tracer, m, dt, name, CS)
                                 CS%uPoL(I,j,:), CS%uPoR(I,j,:), &
                                 CS%uKoL(I,j,:), CS%uKoR(I,j,:), &
                                 CS%uhEff(I,j,:), uFlx(I,j,:), &
-                                CS%continuous_reconstruction, CS%remap_CS)
+                                CS%continuous_reconstruction, h_neglect, CS%remap_CS, h_neglect_edge)
     endif
   enddo ; enddo
 
@@ -534,7 +547,7 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, Tracer, m, dt, name, CS)
                                 CS%vPoL(i,J,:), CS%vPoR(i,J,:), &
                                 CS%vKoL(i,J,:), CS%vKoR(i,J,:), &
                                 CS%vhEff(i,J,:), vFlx(i,J,:),   &
-                                CS%continuous_reconstruction, CS%remap_CS)
+                                CS%continuous_reconstruction, h_neglect, CS%remap_CS, h_neglect_edge)
     endif
   enddo ; enddo
 
@@ -629,13 +642,14 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, Tracer, m, dt, name, CS)
 end subroutine neutral_diffusion
 
 !> Returns interface scalar, Si, for a column of layer values, S.
-subroutine interface_scalar(nk, h, S, Si, i_method)
+subroutine interface_scalar(nk, h, S, Si, i_method, h_neglect)
   integer,               intent(in)    :: nk       !< Number of levels
   real, dimension(nk),   intent(in)    :: h        !< Layer thickness (H units)
   real, dimension(nk),   intent(in)    :: S        !< Layer scalar (conc, e.g. ppt)
   real, dimension(nk+1), intent(inout) :: Si       !< Interface scalar (conc, e.g. ppt)
   integer,               intent(in)    :: i_method !< =1 use average of PLM edges
                                                    !! =2 use continuous PPM edge interpolation
+  real,                  intent(in)    :: h_neglect !< A negligibly small thickness (H units)
   ! Local variables
   integer :: k, km2, kp1
   real, dimension(nk) :: diff
@@ -657,7 +671,7 @@ subroutine interface_scalar(nk, h, S, Si, i_method)
       ! equation 1.6 in Colella & Woodward, 1984: JCP 54, 174-201.
       km2 = max(1, k-2)
       kp1 = min(nk, k+1)
-      Si(k) = ppm_edge(h(km2), h(k-1), h(k), h(kp1),  S(k-1), S(k), diff(k-1), diff(k))
+      Si(k) = ppm_edge(h(km2), h(k-1), h(k), h(kp1),  S(k-1), S(k), diff(k-1), diff(k), h_neglect)
     enddo
   endif
   Si(nk+1) = S(nk) + 0.5 * diff(nk)
@@ -666,7 +680,7 @@ end subroutine interface_scalar
 
 !> Returns the PPM quasi-fourth order edge value at k+1/2 following
 !! equation 1.6 in Colella & Woodward, 1984: JCP 54, 174-201.
-real function ppm_edge(hkm1, hk, hkp1, hkp2,  Ak, Akp1, Pk, Pkp1)
+real function ppm_edge(hkm1, hk, hkp1, hkp2,  Ak, Akp1, Pk, Pkp1, h_neglect)
   real, intent(in) :: hkm1 !< Width of cell k-1
   real, intent(in) :: hk   !< Width of cell k
   real, intent(in) :: hkp1 !< Width of cell k+1
@@ -675,10 +689,10 @@ real function ppm_edge(hkm1, hk, hkp1, hkp2,  Ak, Akp1, Pk, Pkp1)
   real, intent(in) :: Akp1 !< Average scalar value of cell k+1
   real, intent(in) :: Pk   !< PLM slope for cell k
   real, intent(in) :: Pkp1 !< PLM slope for cell k+1
+  real, intent(in) :: h_neglect !< A negligibly small thickness (H units)
 
   ! Local variables
   real :: R_hk_hkp1, R_2hk_hkp1, R_hk_2hkp1, f1, f2, f3, f4
-  real, parameter :: h_neglect = 1.e-30
 
   R_hk_hkp1 = hk + hkp1
   if (R_hk_hkp1 <= 0.) then
@@ -1769,7 +1783,8 @@ subroutine calc_delta_rho(deg, T_ref, S_ref, alpha_ref, beta_ref, P_top, P_bot, 
 end subroutine calc_delta_rho
 
 !> Returns a single column of neutral diffusion fluxes of a tracer.
-subroutine neutral_surface_flux(nk, nsurf, deg, hl, hr, Tl, Tr, PiL, PiR, KoL, KoR, hEff, Flx, continuous, remap_CS)
+subroutine neutral_surface_flux(nk, nsurf, deg, hl, hr, Tl, Tr, PiL, PiR, KoL, KoR, &
+                                hEff, Flx, continuous, h_neglect, remap_CS, h_neglect_edge)
   integer,                      intent(in)    :: nk    !< Number of levels
   integer,                      intent(in)    :: nsurf !< Number of neutral surfaces
   integer,                      intent(in)    :: deg   !< Degree of polynomial reconstructions
@@ -1786,7 +1801,13 @@ subroutine neutral_surface_flux(nk, nsurf, deg, hl, hr, Tl, Tr, PiL, PiR, KoL, K
   real, dimension(nsurf-1),     intent(in)    :: hEff  !< Effective thickness between two neutral surfaces (Pa)
   real, dimension(nsurf-1),     intent(inout) :: Flx   !< Flux of tracer between pairs of neutral layers (conc H)
   logical,                      intent(in)    :: continuous !< True if using continuous reconstruction
+  real,                         intent(in)    :: h_neglect !< A negligibly small width for the
+                                             !! purpose of cell reconstructions
+                                             !! in the same units as h0.
   type(remapping_CS), optional, intent(in)    :: remap_CS
+  real,               optional, intent(in)    :: h_neglect_edge !< A negligibly small width
+                                             !! for the purpose of edge value calculations
+                                             !! in the same units as h0.
   ! Local variables
   integer :: k_sublayer, klb, klt, krb, krt, k
   real :: T_right_top, T_right_bottom, T_right_layer
@@ -1809,8 +1830,8 @@ subroutine neutral_surface_flux(nk, nsurf, deg, hl, hr, Tl, Tr, PiL, PiR, KoL, K
 
   ! Setup reconstruction edge values
   if (continuous) then
-    call interface_scalar(nk, hl, Tl, Til, 2)
-    call interface_scalar(nk, hr, Tr, Tir, 2)
+    call interface_scalar(nk, hl, Tl, Til, 2, h_neglect)
+    call interface_scalar(nk, hr, Tr, Tir, 2, h_neglect)
     call ppm_left_right_edge_values(nk, Tl, Til, aL_l, aR_l)
     call ppm_left_right_edge_values(nk, Tr, Tir, aL_r, aR_r)
   else
@@ -1819,8 +1840,10 @@ subroutine neutral_surface_flux(nk, nsurf, deg, hl, hr, Tl, Tr, PiL, PiR, KoL, K
     Tid_l(:,:) = 0.
     Tid_r(:,:) = 0.
 
-    call build_reconstructions_1d( remap_CS, nk, hl, Tl, ppoly_r_coeffs_l, Tid_l, ppoly_r_S_l, iMethod )
-    call build_reconstructions_1d( remap_CS, nk, hr, Tr, ppoly_r_coeffs_r, Tid_r, ppoly_r_S_r, iMethod )
+    call build_reconstructions_1d( remap_CS, nk, hl, Tl, ppoly_r_coeffs_l, Tid_l, &
+                                   ppoly_r_S_l, iMethod, h_neglect, h_neglect_edge )
+    call build_reconstructions_1d( remap_CS, nk, hr, Tr, ppoly_r_coeffs_r, Tid_r, &
+                                   ppoly_r_S_r, iMethod, h_neglect, h_neglect_edge )
   endif
 
   do k_sublayer = 1, nsurf-1
@@ -1929,47 +1952,80 @@ logical function ndiff_unit_tests_continuous(verbose)
   real, dimension(2*nk+1)    :: Flx                        ! Test flux
   integer :: k
   logical :: v
+  real :: h_neglect, h_neglect_edge
+
+  h_neglect_edge = 1.0e-10 ; h_neglect = 1.0e-30
 
   v = verbose
 
   ndiff_unit_tests_continuous = .false. ! Normally return false
   write(*,*) '==== MOM_neutral_diffusion: ndiff_unit_tests_continuous ='
 
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fv_diff(v,1.,1.,1., 0.,1.,2., 1., 'FV: Straight line on uniform grid')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fv_diff(v,1.,1.,0., 0.,4.,8., 7., 'FV: Vanished right cell')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fv_diff(v,0.,1.,1., 0.,4.,8., 7., 'FV: Vanished left cell')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fv_diff(v,1.,2.,4., 0.,3.,9., 4., 'FV: Stretched grid')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fv_diff(v,2.,0.,2., 0.,1.,2., 0., 'FV: Vanished middle cell')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fv_diff(v,0.,1.,0., 0.,1.,2., 2., 'FV: Vanished on both sides')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fv_diff(v,1.,0.,0., 0.,1.,2., 0., 'FV: Two vanished cell sides')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fv_diff(v,0.,0.,0., 0.,1.,2., 0., 'FV: All vanished cells')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fv_diff(v,1.,1.,1., 0.,1.,2., 1., 'FV: Straight line on uniform grid')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fv_diff(v,1.,1.,0., 0.,4.,8., 7., 'FV: Vanished right cell')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fv_diff(v,0.,1.,1., 0.,4.,8., 7., 'FV: Vanished left cell')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fv_diff(v,1.,2.,4., 0.,3.,9., 4., 'FV: Stretched grid')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fv_diff(v,2.,0.,2., 0.,1.,2., 0., 'FV: Vanished middle cell')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fv_diff(v,0.,1.,0., 0.,1.,2., 2., 'FV: Vanished on both sides')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fv_diff(v,1.,0.,0., 0.,1.,2., 0., 'FV: Two vanished cell sides')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fv_diff(v,0.,0.,0., 0.,1.,2., 0., 'FV: All vanished cells')
 
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fvlsq_slope(v,1.,1.,1., 0.,1.,2., 1., 'LSQ: Straight line on uniform grid')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fvlsq_slope(v,1.,1.,0., 0.,1.,2., 1., 'LSQ: Vanished right cell')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fvlsq_slope(v,0.,1.,1., 0.,1.,2., 1., 'LSQ: Vanished left cell')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fvlsq_slope(v,1.,2.,4., 0.,3.,9., 2., 'LSQ: Stretched grid')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fvlsq_slope(v,1.,0.,1., 0.,1.,2., 2., 'LSQ: Vanished middle cell')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fvlsq_slope(v,0.,1.,0., 0.,1.,2., 0., 'LSQ: Vanished on both sides')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fvlsq_slope(v,1.,0.,0., 0.,1.,2., 0., 'LSQ: Two vanished cell sides')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_fvlsq_slope(v,0.,0.,0., 0.,1.,2., 0., 'LSQ: All vanished cells')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fvlsq_slope(v,1.,1.,1., 0.,1.,2., 1., 'LSQ: Straight line on uniform grid')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fvlsq_slope(v,1.,1.,0., 0.,1.,2., 1., 'LSQ: Vanished right cell')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fvlsq_slope(v,0.,1.,1., 0.,1.,2., 1., 'LSQ: Vanished left cell')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fvlsq_slope(v,1.,2.,4., 0.,3.,9., 2., 'LSQ: Stretched grid')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fvlsq_slope(v,1.,0.,1., 0.,1.,2., 2., 'LSQ: Vanished middle cell')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fvlsq_slope(v,0.,1.,0., 0.,1.,2., 0., 'LSQ: Vanished on both sides')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fvlsq_slope(v,1.,0.,0., 0.,1.,2., 0., 'LSQ: Two vanished cell sides')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_fvlsq_slope(v,0.,0.,0., 0.,1.,2., 0., 'LSQ: All vanished cells')
 
-  call interface_scalar(4, (/10.,10.,10.,10./), (/24.,18.,12.,6./), Tio, 1)
-  !ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_data1d(5, Tio, (/27.,21.,15.,9.,3./), 'Linear profile, interface temperatures')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_data1d(v,5, Tio, (/24.,22.5,15.,7.5,6./), 'Linear profile, linear interface temperatures')
-  call interface_scalar(4, (/10.,10.,10.,10./), (/24.,18.,12.,6./), Tio, 2)
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_data1d(v,5, Tio, (/24.,22.,15.,8.,6./), 'Linear profile, PPM interface temperatures')
+  call interface_scalar(4, (/10.,10.,10.,10./), (/24.,18.,12.,6./), Tio, 1, h_neglect)
+  !ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+  !  test_data1d(5, Tio, (/27.,21.,15.,9.,3./), 'Linear profile, interface temperatures')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_data1d(v,5, Tio, (/24.,22.5,15.,7.5,6./), 'Linear profile, linear interface temperatures')
+  call interface_scalar(4, (/10.,10.,10.,10./), (/24.,18.,12.,6./), Tio, 2, h_neglect)
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_data1d(v,5, Tio, (/24.,22.,15.,8.,6./), 'Linear profile, PPM interface temperatures')
 
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v,-1.0, 0.,  1.0, 1.0, 0.5, 'Check mid-point')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v, 0.0, 0.,  1.0, 1.0, 0.0, 'Check bottom')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v, 0.1, 0.,  1.1, 1.0, 0.0, 'Check below')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v,-1.0, 0.,  0.0, 1.0, 1.0, 'Check top')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v,-1.0, 0., -0.1, 1.0, 1.0, 'Check above')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v,-1.0, 0.,  3.0, 1.0, 0.25, 'Check 1/4')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v,-3.0, 0.,  1.0, 1.0, 0.75, 'Check 3/4')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v, 1.0, 0.,  1.0, 1.0, 0.0, 'Check dRho=0 below')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v,-1.0, 0., -1.0, 1.0, 1.0, 'Check dRho=0 above')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v, 0.0, 0.,  0.0, 1.0, 0.5, 'Check dRho=0 mid')
-  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_ifndp(v,-2.0, .5,  5.0, 0.5, 0.5, 'Check dP=0')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v,-1.0, 0.,  1.0, 1.0, 0.5, 'Check mid-point')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v, 0.0, 0.,  1.0, 1.0, 0.0, 'Check bottom')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v, 0.1, 0.,  1.1, 1.0, 0.0, 'Check below')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v,-1.0, 0.,  0.0, 1.0, 1.0, 'Check top')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v,-1.0, 0., -0.1, 1.0, 1.0, 'Check above')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v,-1.0, 0.,  3.0, 1.0, 0.25, 'Check 1/4')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v,-3.0, 0.,  1.0, 1.0, 0.75, 'Check 3/4')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v, 1.0, 0.,  1.0, 1.0, 0.0, 'Check dRho=0 below')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v,-1.0, 0., -1.0, 1.0, 1.0, 'Check dRho=0 above')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v, 0.0, 0.,  0.0, 1.0, 0.5, 'Check dRho=0 mid')
+  ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. &
+    test_ifndp(v,-2.0, .5,  5.0, 0.5, 0.5, 'Check dP=0')
 
   ! Identical columns
   call find_neutral_surface_positions_continuous(3, &
@@ -1993,12 +2049,14 @@ logical function ndiff_unit_tests_continuous(verbose)
                                    (/0.,0.,10.,10.,20.,20.,30.,30./), '... right positions')
   call neutral_surface_flux(3, 2*3+2, 2, (/10.,10.,10./), (/10.,10.,10./), & ! nk, hL, hR
                                (/20.,16.,12./), (/20.,16.,12./), & ! Tl, Tr
-                               PiLRo, PiRLo, KoL, KoR, hEff, Flx, .true.)
+                               PiLRo, PiRLo, KoL, KoR, hEff, Flx, .true., &
+                               h_neglect, h_neglect_edge=h_neglect_edge)
   ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_data1d(v, 7, Flx, &
               (/0.,0.,0.,0.,0.,0.,0./), 'Identical columns, rho flux (=0)')
   call neutral_surface_flux(3, 2*3+2, 2, (/10.,10.,10./), (/10.,10.,10./), & ! nk, hL, hR
                                (/-1.,-1.,-1./), (/1.,1.,1./), & ! Sl, Sr
-                               PiLRo, PiRLo, KoL, KoR, hEff, Flx, .true.)
+                               PiLRo, PiRLo, KoL, KoR, hEff, Flx, .true., &
+                               h_neglect, h_neglect_edge=h_neglect_edge)
   ndiff_unit_tests_continuous = ndiff_unit_tests_continuous .or. test_data1d(v, 7, Flx, &
               (/0.,20.,0.,20.,0.,20.,0./), 'Identical columns, S flux')
 
@@ -2163,6 +2221,7 @@ logical function ndiff_unit_tests_discontinuous(verbose)
   real, dimension(nk,2)       :: poly_T_l, poly_T_r, poly_S,  poly_slope    ! Linear reconstruction for T
   real, dimension(nk,2)       :: dRdT, dRdS
   integer                     :: iMethod
+  real                        :: h_neglect, h_neglect_edge
   integer :: k
   logical :: v
 
@@ -2170,6 +2229,8 @@ logical function ndiff_unit_tests_discontinuous(verbose)
 
   ndiff_unit_tests_discontinuous = .false. ! Normally return false
   write(*,*) '==== MOM_neutral_diffusion: ndiff_unit_tests_discontinuous ='
+
+  h_neglect = 1.0e-30 ; h_neglect_edge = 1.0e-10
 
   ! Unit tests for find_neutral_surface_positions_discontinuous
   ! Salinity is 0 for all these tests
@@ -2182,8 +2243,8 @@ logical function ndiff_unit_tests_discontinuous(verbose)
   do k = 1,nk ; Pres_l(k+1) = Pres_l(k) + hL(k) ; Pres_r(k+1) = Pres_r(k) + hR(k) ; enddo
   ! Identical columns
   Tl = (/20.,16.,12./) ; Tr = (/20.,16.,12./)
-  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod )
-  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod )
+  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod, h_neglect, h_neglect_edge )
+  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod, h_neglect, h_neglect_edge )
   call find_neutral_surface_positions_discontinuous(nk, 1, Pres_l, TiL, SiL, dRdT, dRdS, &
             Pres_r, TiR, SiR, dRdT, dRdS, PoL, PoR, KoL, KoR, hEff)
   ndiff_unit_tests_discontinuous = ndiff_unit_tests_discontinuous .or.  test_nsp(v, 12, KoL, KoR, PoL, PoR, hEff, &
@@ -2194,8 +2255,8 @@ logical function ndiff_unit_tests_discontinuous(verbose)
                                    (/0.,10.,0.,0.,0.,10.,0.,0.,0.,10.,0.,0./), & ! hEff
                                    'Identical columns')
   Tl = (/20.,16.,12./) ; Tr = (/18.,14.,10./)
-  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod )
-  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod )
+  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod, h_neglect, h_neglect_edge )
+  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod, h_neglect, h_neglect_edge )
   call find_neutral_surface_positions_discontinuous(nk, 1, Pres_l, TiL, SiL, dRdT, dRdS, &
             Pres_r, TiR, SiR, dRdT, dRdS, PoL, PoR, KoL, KoR, hEff)
   ndiff_unit_tests_discontinuous = ndiff_unit_tests_discontinuous .or.  test_nsp(v, 12, KoL, KoR, PoL, PoR, hEff, &
@@ -2206,8 +2267,8 @@ logical function ndiff_unit_tests_discontinuous(verbose)
                                    (/0.0, 5.0, 0.0, 5.0, 0.0, 5.0, 0.0, 5.0, 0.0, 5.0, 0.0/), & ! hEff
                                    'Right column slightly cooler')
   Tl = (/18.,14.,10./) ; Tr = (/20.,16.,12./) ;
-  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod )
-  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod )
+  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod, h_neglect, h_neglect_edge )
+  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod, h_neglect, h_neglect_edge )
   call find_neutral_surface_positions_discontinuous(nk, 1, Pres_l, TiL, SiL, dRdT, dRdS, &
             Pres_r, TiR, SiR, dRdT, dRdS, PoL, PoR, KoL, KoR, hEff)
   ndiff_unit_tests_discontinuous = ndiff_unit_tests_discontinuous .or.  test_nsp(v, 12, KoL, KoR, PoL, PoR, hEff, &
@@ -2218,8 +2279,8 @@ logical function ndiff_unit_tests_discontinuous(verbose)
                                    (/0.0, 5.0, 0.0, 5.0, 0.0, 5.0, 0.0, 5.0, 0.0, 5.0, 0.0/), & ! hEff
                                    'Left column slightly cooler')
   Tl = (/20.,16.,12./) ; Tr = (/14.,10.,6./)
-  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod )
-  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod )
+  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod, h_neglect, h_neglect_edge )
+  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod, h_neglect, h_neglect_edge )
   call find_neutral_surface_positions_discontinuous(nk, 1, Pres_l, TiL, SiL, dRdT, dRdS, &
             Pres_r, TiR, SiR, dRdT, dRdS, PoL, PoR, KoL, KoR, hEff)
   ndiff_unit_tests_discontinuous = ndiff_unit_tests_discontinuous .or.  test_nsp(v, 12, KoL, KoR, PoL, PoR, hEff, &
@@ -2230,8 +2291,8 @@ logical function ndiff_unit_tests_discontinuous(verbose)
                                    (/0.0, 0.0, 0.0, 5.0, 0.0, 5.0, 0.0, 5.0, 0.0, 0.0, 0.0/), & ! hEff
                                    'Right column somewhat cooler')
   Tl = (/20.,16.,12./) ; Tr = (/8.,6.,4./)
-  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod )
-  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod )
+  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod, h_neglect, h_neglect_edge )
+  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod, h_neglect, h_neglect_edge )
   call find_neutral_surface_positions_discontinuous(nk, 1, Pres_l, TiL, SiL, dRdT, dRdS, &
             Pres_r, TiR, SiR, dRdT, dRdS, PoL, PoR, KoL, KoR, hEff)
   ndiff_unit_tests_discontinuous = ndiff_unit_tests_discontinuous .or.  test_nsp(v, 12, KoL, KoR, PoL, PoR, hEff, &
@@ -2242,8 +2303,8 @@ logical function ndiff_unit_tests_discontinuous(verbose)
                                    (/0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0/), & ! hEff
                                    'Right column much cooler')
   Tl = (/14.,14.,10./) ; Tr = (/14.,14.,10./)
-  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod )
-  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod )
+  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod, h_neglect, h_neglect_edge )
+  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod, h_neglect, h_neglect_edge )
   call find_neutral_surface_positions_discontinuous(nk, 1, Pres_l, TiL, SiL, dRdT, dRdS, &
             Pres_r, TiR, SiR, dRdT, dRdS, PoL, PoR, KoL, KoR, hEff)
   ndiff_unit_tests_discontinuous = ndiff_unit_tests_discontinuous .or.  test_nsp(v, 12, KoL, KoR, PoL, PoR, hEff, &
@@ -2254,8 +2315,8 @@ logical function ndiff_unit_tests_discontinuous(verbose)
                                    (/0.,10.,0.,0.,0.,10.,0.,0.,0.,10.,0.,0./), & ! hEff
                                    'Identical columns with mixed layer')
   Tl = (/20.,16.,12./) ; Tr = (/14.,14.,10./)
-  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod )
-  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod )
+  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod, h_neglect, h_neglect_edge )
+  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod, h_neglect, h_neglect_edge )
   call find_neutral_surface_positions_discontinuous(nk, 1, Pres_l, TiL, SiL, dRdT, dRdS, &
             Pres_r, TiR, SiR, dRdT, dRdS, PoL, PoR, KoL, KoR, hEff)
   ndiff_unit_tests_discontinuous = ndiff_unit_tests_discontinuous .or.  test_nsp(v, 12, KoL, KoR, PoL, PoR, hEff, &
@@ -2266,8 +2327,8 @@ logical function ndiff_unit_tests_discontinuous(verbose)
                                    (/0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5.0, 0.0/), & ! hEff
                                    'Right column with mixed layer')
   Tl = (/14.,14.,6./) ; Tr = (/12.,16.,8./)
-  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod )
-  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod )
+  call build_reconstructions_1d( remap_CS, nk, hL, Tl, poly_T_l, TiL, poly_slope, iMethod, h_neglect, h_neglect_edge )
+  call build_reconstructions_1d( remap_CS, nk, hR, Tr, poly_T_r, TiR, poly_slope, iMethod, h_neglect, h_neglect_edge )
   call find_neutral_surface_positions_discontinuous(nk, 1, Pres_l, TiL, SiL, dRdT, dRdS, &
             Pres_r, TiR, SiR, dRdT, dRdS, PoL, PoR, KoL, KoR, hEff)
   ndiff_unit_tests_discontinuous = ndiff_unit_tests_discontinuous .or.  test_nsp(v, 12, KoL, KoR, PoL, PoR, hEff, &

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -77,7 +77,7 @@ subroutine DOME_initialize_thickness(h, G, GV, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized, in m.
+                           intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -115,9 +115,9 @@ subroutine DOME_initialize_thickness(h, G, GV, param_file, just_read_params)
       eta1D(K) = e0(K)
       if (eta1D(K) < (eta1D(K+1) + GV%Angstrom_z)) then
         eta1D(K) = eta1D(K+1) + GV%Angstrom_z
-        h(i,j,k) = GV%Angstrom_z
+        h(i,j,k) = GV%Angstrom
       else
-        h(i,j,k) = eta1D(K) - eta1D(K+1)
+        h(i,j,k) = GV%m_to_H * (eta1D(K) - eta1D(K+1))
       endif
     enddo
   enddo ; enddo

--- a/src/user/Neverland_initialization.F90
+++ b/src/user/Neverland_initialization.F90
@@ -110,7 +110,7 @@ subroutine Neverland_initialize_thickness(h, G, GV, param_file, eqn_of_state, P_
   type(ocean_grid_type),   intent(in) :: G                    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in) :: GV                   !< The ocean's vertical grid structure.
   real, intent(out), dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h !< The thickness that is being
-                                                              !! initialized.
+                                                              !! initialized, in H.
   type(param_file_type),   intent(in) :: param_file           !< A structure indicating the open
                                                               !! file to parse for model
                                                               !! parameter values.
@@ -141,8 +141,8 @@ subroutine Neverland_initialize_thickness(h, G, GV, param_file, eqn_of_state, P_
   do j=js,je ; do i=is,ie
     e_interface = -G%bathyT(i,j)
     do k=nz,1,-1
-      h(i,j,k) = max( GV%Angstrom_z, e0(k) - e_interface )
-      e_interface = max( e0(k), e_interface - h(i,j,k) )
+      h(i,j,k) = max( GV%Angstrom, GV%m_to_H * (e0(k) - e_interface) )
+      e_interface = max( e0(k), e_interface - GV%H_to_m * h(i,j,k) )
     enddo
 
   enddo ; enddo

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -35,7 +35,7 @@ subroutine Phillips_initialize_thickness(h, G, GV, param_file, just_read_params)
   type(ocean_grid_type),   intent(in) :: G          !< The ocean's grid structure.
   type(verticalGrid_type), intent(in) :: GV         !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h         !< The thickness that is being initialized, in m.
+                           intent(out) :: h         !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -102,9 +102,9 @@ subroutine Phillips_initialize_thickness(h, G, GV, param_file, just_read_params)
       eta1D(K) = eta_im(j,K)
       if (eta1D(K) < (eta1D(K+1) + GV%Angstrom_z)) then
         eta1D(K) = eta1D(K+1) + GV%Angstrom_z
-        h(i,j,k) = GV%Angstrom_z
+        h(i,j,k) = GV%Angstrom
       else
-        h(i,j,k) = eta1D(K) - eta1D(K+1)
+        h(i,j,k) = GV%m_to_H * (eta1D(K) - eta1D(K+1))
       endif
     enddo
   enddo ; enddo

--- a/src/user/SCM_CVmix_tests.F90
+++ b/src/user/SCM_CVmix_tests.F90
@@ -102,17 +102,17 @@ subroutine SCM_CVmix_tests_TS_init(T, S, h, G, GV, param_file, just_read_params)
     do k=1,nz
       eta(K+1) = eta(K) - h(i,j,k)*GV%H_to_m ! Interface below layer (in m)
       zC = 0.5*( eta(K) + eta(K+1) )        ! Z of middle of layer (in m)
-      DZ = min(0., zC+UpperLayerTempMLD*GV%H_to_m)
+      DZ = min(0., zC + UpperLayerTempMLD)
       if (DZ.ge.0.0) then ! in Layer 1
         T(i,j,k) = UpperLayerTemp
       else ! in Layer 2
-        T(i,j,k) = LowerLayerTemp + LowerLayerdTdZ/GV%H_to_m * DZ
+        T(i,j,k) = LowerLayerTemp + LowerLayerdTdZ * DZ
       endif
-      DZ = min(0., zC+UpperLayerSaltMLD)
+      DZ = min(0., zC + UpperLayerSaltMLD)
       if (DZ.ge.0.0) then ! in Layer 1
         S(i,j,k) = UpperLayerSalt
       else ! in Layer 2
-        S(i,j,k) = LowerLayerSalt + LowerLayerdSdZ/GV%H_to_m * DZ
+        S(i,j,k) = LowerLayerSalt + LowerLayerdSdZ * DZ
       endif
     enddo ! k
   enddo ; enddo

--- a/src/user/SCM_idealized_hurricane.F90
+++ b/src/user/SCM_idealized_hurricane.F90
@@ -50,7 +50,7 @@ subroutine SCM_idealized_hurricane_TS_init(T, S, h, G, GV, param_file, just_read
   type(verticalGrid_type),                   intent(in)  :: GV !< Vertical grid structure
   real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(out) :: T !< Potential temperature (degC)
   real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(out) :: S !< Salinity (psu)
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(in)  :: h !< Layer thickness (m or Pa)
+  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(in)  :: h !< Layer thickness in H (m or Pa)
   type(param_file_type),                     intent(in)  :: param_file !< Input parameter structure
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
@@ -86,8 +86,7 @@ subroutine SCM_idealized_hurricane_TS_init(T, S, h, G, GV, param_file, just_read
     do k=1,nz
       eta(K+1) = eta(K) - h(i,j,k)*GV%H_to_m ! Interface below layer (in m)
       zC = 0.5*( eta(K) + eta(K+1) )        ! Z of middle of layer (in m)
-      T(i,j,k) = SST_ref + dTdz/GV%H_to_m &
-                 * min(0., zC+MLD*GV%H_to_m)
+      T(i,j,k) = SST_ref + dTdz * min(0., zC + MLD)
       S(i,j,k) = S_ref
     enddo ! k
   enddo ; enddo

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -79,7 +79,7 @@ subroutine benchmark_initialize_thickness(h, G, GV, param_file, eqn_of_state, &
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized, in m.
+                           intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   type(EOS_type),          pointer     :: eqn_of_state !< integer that selects the
@@ -186,9 +186,9 @@ subroutine benchmark_initialize_thickness(h, G, GV, param_file, eqn_of_state, &
       if (eta1D(K) < eta1D(K+1) + GV%Angstrom_z) &
         eta1D(K) = eta1D(K+1) + GV%Angstrom_z
 
-      h(i,j,k) = max(eta1D(K) - eta1D(K+1), GV%Angstrom_z)
+      h(i,j,k) = max(GV%m_to_H * (eta1D(K) - eta1D(K+1)), GV%Angstrom)
     enddo
-    h(i,j,1) = max(0.0 - eta1D(2), GV%Angstrom_z)
+    h(i,j,1) = max(GV%m_to_H * (0.0 - eta1D(2)), GV%Angstrom)
 
   enddo ; enddo
 

--- a/src/user/external_gwave_initialization.F90
+++ b/src/user/external_gwave_initialization.F90
@@ -8,6 +8,7 @@ use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
+use MOM_verticalGrid, only : verticalGrid_type
 implicit none ; private
 
 #include <MOM_memory.h>
@@ -18,10 +19,11 @@ contains
 
 ! -----------------------------------------------------------------------------
 !> This subroutine initializes layer thicknesses for the external_gwave experiment.
-subroutine external_gwave_initialize_thickness(h, G, param_file, just_read_params)
-  type(ocean_grid_type), intent(in) :: G                      !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                           intent(out) :: h           !< The thickness that is being initialized, in m.
+subroutine external_gwave_initialize_thickness(h, G, GV, param_file, just_read_params)
+  type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -70,7 +72,7 @@ subroutine external_gwave_initialize_thickness(h, G, param_file, just_read_param
     enddo
     eta1D(nz+1) = -G%max_depth ! Force bottom interface to bottom
     do k=1,nz
-      h(i,j,k) = eta1D(K) - eta1D(K+1)
+      h(i,j,k) = GV%m_to_H * (eta1D(K) - eta1D(K+1))
     enddo
   enddo ; enddo
 

--- a/src/user/lock_exchange_initialization.F90
+++ b/src/user/lock_exchange_initialization.F90
@@ -24,7 +24,7 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, param_file, just_read_pa
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized, in m.
+                           intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -83,7 +83,7 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, param_file, just_read_pa
       eta1D(K) = min( eta1D(K), eta1D(K-1) - GV%Angstrom_Z )
     enddo
     do k=nz,1,-1
-      h(i,j,k) = eta1D(K) - eta1D(K+1)
+      h(i,j,k) = GV%m_to_H * (eta1D(K) - eta1D(K+1))
     enddo
   enddo ; enddo
 

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -69,7 +69,7 @@ subroutine sloshing_initialize_thickness ( h, G, GV, param_file, just_read_param
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized, in m.
+                           intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -169,7 +169,7 @@ subroutine sloshing_initialize_thickness ( h, G, GV, param_file, just_read_param
     ! 4. Define layers
     total_height = 0.0
     do k = 1,nz
-      h(i,j,k) = z_inter(k) - z_inter(k+1)
+      h(i,j,k) = GV%m_to_H * (z_inter(k) - z_inter(k+1))
 
       total_height = total_height + h(i,j,k)
     end do
@@ -186,12 +186,13 @@ end subroutine sloshing_initialize_thickness
 !! reference surface layer salinity and temperature and a specified range.
 !! Note that the linear distribution is set up with respect to the layer
 !! number, not the physical position).
-subroutine sloshing_initialize_temperature_salinity ( T, S, h, G, param_file, &
+subroutine sloshing_initialize_temperature_salinity ( T, S, h, G, GV, param_file, &
                                                       eqn_of_state, just_read_params)
   type(ocean_grid_type),                     intent(in)  :: G !< Ocean grid structure.
+  type(verticalGrid_type),                   intent(in)  :: GV !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(out) :: T !< Potential temperature (degC).
   real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(out) :: S !< Salinity (ppt).
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(in)  :: h !< Layer thickness (m or Pa).
+  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(in)  :: h !< Layer thickness in H (m or Pa).
   type(param_file_type),                     intent(in)  :: param_file !< A structure indicating the
                                                             !! open file to parse for model
                                                             !! parameter values.

--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -30,9 +30,11 @@ public soliton_initialize_velocity
 contains
 
 !> Initialization of thicknesses in Equatorial Rossby soliton test
-subroutine soliton_initialize_thickness(h, G)
-  type(ocean_grid_type),   intent(in) :: G                 !< Grid structure
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(out) :: h !< Thickness
+subroutine soliton_initialize_thickness(h, G, GV)
+  type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(out) :: h    !< The thickness that is being initialized, in H.
 
   integer :: i, j, k, is, ie, js, je, nz
   real    :: x, y, x0, y0
@@ -54,8 +56,7 @@ subroutine soliton_initialize_thickness(h, G)
       y = G%geoLatT(i,j)-y0
       val3 = exp(-val1*x)
       val4 = val2*((2.0*val3/(1.0+(val3*val3)))**2)
-      h(i,j,k) = 0.25*val4*(6.0*y*y+3.0)*                 &
-                exp(-0.5*y*y)
+      h(i,j,k) = GV%m_to_H * (0.25*val4 * (6.0*y*y+3.0) * exp(-0.5*y*y))
     enddo
   end do ; end do
 

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -72,16 +72,15 @@ subroutine USER_initialize_topography(D, G, param_file, max_depth)
 end subroutine USER_initialize_topography
 
 !> initialize thicknesses.
-subroutine USER_initialize_thickness(h, G, param_file, T, just_read_params)
-  type(ocean_grid_type), intent(in)           :: G          !< The ocean's grid structure.
-  real, intent(out), dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h !< The thicknesses being
-                                                            !! initialized.
-  type(param_file_type), intent(in)           :: param_file !< A structure indicating the
-                                                            !! open file to parse for model
-                                                            !! parameter values.
-  real, intent(in), dimension(SZI_(G),SZJ_(G), SZK_(G))  :: T !< Potential temperature.
+subroutine USER_initialize_thickness(h, G, GV, param_file, just_read_params)
+  type(ocean_grid_type),   intent(in)  :: G  !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)  :: GV !< The ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(out) :: h  !< The thicknesses being initialized, in H.
+  type(param_file_type),   intent(in)  :: param_file !< A structure indicating the open
+                                             !! file to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
-                                                      !! only read parameters without changing h.
+                                             !! only read parameters without changing h.
 
   logical :: just_read    ! If true, just read parameters but set nothing.
 
@@ -93,7 +92,7 @@ subroutine USER_initialize_thickness(h, G, param_file, T, just_read_params)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
-  h(:,:,1) = 0.0
+  h(:,:,1) = 0.0 * GV%m_to_H
 
   if (first_call) call write_user_log(param_file)
 


### PR DESCRIPTION
Made a number of changes to more robustly change the internal representation of thicknesses to H units, including doing a direct initialization of all thicknesses into H units.  With these changes, almost every test case is giving identical answers for integer-power-of-2 rescaling of the internal thickness representation. No answers in test cases should be changed by these code modifications.