### PR TITLE
Consolidate tracer diagnostics in registry

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1829,7 +1829,7 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
       CS%vd_S = var_desc(name="abssalt",units="g kg-1",longname="Absolute Salinity", &
                        cmor_field_name="so", cmor_longname="Sea Water Salinity", &
                        conversion=0.001)
-    else 
+    else
       CS%vd_T = var_desc(name="temp", units="degC", longname="Potential Temperature", &
                        cmor_field_name="thetao", cmor_longname="Sea Water Potential Temperature", &
                        conversion=CS%tv%C_p)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -279,16 +279,7 @@ type, public :: MOM_control_struct
     vd_T, &   !< vardesc array describing potential temperature
     vd_S      !< vardesc array describing salinity
 
-  real, pointer, dimension(:,:,:) :: &  !< diagnostic arrays of advective/diffusive tracer fluxes
-    T_adx => NULL(), T_ady => NULL(), T_diffx => NULL(), T_diffy => NULL(), &
-    S_adx => NULL(), S_ady => NULL(), S_diffx => NULL(), S_diffy => NULL()
-
-  real, pointer, dimension(:,:) :: & !< diagnostic arrays of vertically integrated advective/diffusive fluxes
-    T_adx_2d => NULL(), T_ady_2d => NULL(), T_diffx_2d => NULL(), T_diffy_2d => NULL(), &
-    S_adx_2d => NULL(), S_ady_2d => NULL(), S_diffx_2d => NULL(), S_diffy_2d => NULL()
-
   real, pointer, dimension(:,:,:) :: &  !< diagnostic arrays for advection tendencies and total tendencies
-    T_advection_xy => NULL(), S_advection_xy => NULL(),  &
     T_prev         => NULL(), S_prev         => NULL(),  &
     Th_prev        => NULL(), Sh_prev        => NULL()
 
@@ -303,10 +294,8 @@ type, public :: MOM_control_struct
   integer :: id_u  = -1
   integer :: id_v  = -1
   integer :: id_h  = -1
-  integer :: id_T  = -1
-  integer :: id_S  = -1
-  integer :: id_Tcon  = -1
-  integer :: id_Sabs  = -1
+  integer :: id_Tpot  = -1
+  integer :: id_Sprac  = -1
 
   ! 2-d surface and bottom fields
   integer :: id_zos      = -1
@@ -333,32 +322,10 @@ type, public :: MOM_control_struct
   integer :: id_Heat_PmE     = -1
   integer :: id_intern_heat  = -1
 
-  ! transport of temperature and salinity
-  integer :: id_Tadx      = -1
-  integer :: id_Tady      = -1
-  integer :: id_Tdiffx    = -1
-  integer :: id_Tdiffy    = -1
-  integer :: id_Sadx      = -1
-  integer :: id_Sady      = -1
-  integer :: id_Sdiffx    = -1
-  integer :: id_Sdiffy    = -1
-  integer :: id_Tadx_2d   = -1
-  integer :: id_Tady_2d   = -1
-  integer :: id_Tdiffx_2d = -1
-  integer :: id_Tdiffy_2d = -1
-  integer :: id_Sadx_2d   = -1
-  integer :: id_Sady_2d   = -1
-  integer :: id_Sdiffx_2d = -1
-  integer :: id_Sdiffy_2d = -1
-
   ! tendencies for temp/heat and saln/salt
-  integer :: id_T_advection_xy    = -1
-  integer :: id_T_advection_xy_2d = -1
   integer :: id_T_tendency        = -1
   integer :: id_Th_tendency       = -1
   integer :: id_Th_tendency_2d    = -1
-  integer :: id_S_advection_xy    = -1
-  integer :: id_S_advection_xy_2d = -1
   integer :: id_S_tendency        = -1
   integer :: id_Sh_tendency       = -1
   integer :: id_Sh_tendency_2d    = -1
@@ -1481,6 +1448,8 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
   integer :: nkml, nkbl, verbosity, write_geom
   integer :: dynamics_stencil  ! The computational stencil for the calculations
                                ! in the dynamic core.
+  real :: conv2watt, conv2salt, H_convert
+  character(len=48) :: thickness_units, flux_units, S_flux_units
 
   type(time_type)                 :: Start_time
   type(ocean_internal_state)      :: MOM_internal_state
@@ -1865,15 +1834,42 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
     ALLOC_(CS%T(isd:ied,jsd:jed,nz))   ; CS%T(:,:,:) = 0.0
     ALLOC_(CS%S(isd:ied,jsd:jed,nz))   ; CS%S(:,:,:) = 0.0
     CS%tv%T => CS%T ; CS%tv%S => CS%S
-    CS%vd_T = var_desc(name="T",units="degC",longname="Potential Temperature", &
-                       cmor_field_name="thetao",                               &
+    if (CS%use_conT_absS) then
+      CS%vd_T = var_desc(name="contemp", units="Celsius", longname="Conservative Temperature", &
+                       cmor_field_name="thetao", cmor_longname="Sea Water Potential Temperature", &
                        conversion=CS%tv%C_p)
-    CS%vd_S = var_desc(name="S",units="psu",longname="Salinity",&
-                       cmor_field_name="so",                    &
+      CS%vd_S = var_desc(name="abssalt",units="g kg-1",longname="Absolute Salinity", &
+                       cmor_field_name="so", cmor_longname="Sea Water Salinity", &
                        conversion=0.001)
+    else 
+      CS%vd_T = var_desc(name="temp", units="degC", longname="Potential Temperature", &
+                       cmor_field_name="thetao", cmor_longname="Sea Water Potential Temperature", &
+                       conversion=CS%tv%C_p)
+      CS%vd_S = var_desc(name="salt",units="psu",longname="Salinity", &
+                       cmor_field_name="so", cmor_longname="Sea Water Salinity", &
+                       conversion=0.001)
+    endif
     if(CS%advect_TS) then
-      call register_tracer(CS%tv%T, CS%vd_T, param_file, dG%HI, GV, CS%tracer_Reg, CS%vd_T)
-      call register_tracer(CS%tv%S, CS%vd_S, param_file, dG%HI, GV, CS%tracer_Reg, CS%vd_S)
+
+      S_flux_units = get_tr_flux_units(GV, "psu") ! Could change to "kg m-2 s-1"?
+      conv2watt    = GV%H_to_kg_m2 * CS%tv%C_p
+      if (GV%Boussinesq) then
+        conv2salt = GV%H_to_m ! Could change to GV%H_to_kg_m2 * 0.001?
+        H_convert = GV%H_to_m
+      else
+        conv2salt = GV%H_to_kg_m2
+        H_convert = GV%H_to_kg_m2
+      endif
+      call register_tracer(CS%tv%T, CS%vd_T, param_file, dG%HI, GV, CS%tracer_Reg, &
+                           CS%vd_T, registry_diags=.true., flux_nameroot='T', &
+                           flux_units='W m-2', flux_longname='Heat', &
+                           flux_scale=conv2watt, convergence_units='W m-2', &
+                           convergence_scale=conv2watt, diag_form=2)
+      call register_tracer(CS%tv%S, CS%vd_S, param_file, dG%HI, GV, CS%tracer_Reg, &
+                           CS%vd_S, registry_diags=.true., flux_nameroot='S', &
+                           flux_units=S_flux_units, flux_longname='Salt', &
+                           flux_scale=conv2salt, convergence_units='kg m-2 s-1', &
+                           convergence_scale=0.001*GV%H_to_kg_m2, diag_form=2)
     endif
     if (associated(CS%OBC)) &
       call register_temp_salt_segments(GV, CS%OBC, CS%tv, CS%vd_T, CS%vd_S, param_file)
@@ -2199,14 +2195,6 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
 
   ! If need a diagnostic field, then would have been allocated in register_diags.
   if (CS%use_temperature) then
-    if(CS%advect_TS) then
-      call add_tracer_diagnostics("T", CS%tracer_Reg, CS%T_adx, CS%T_ady, &
-                        CS%T_diffx, CS%T_diffy, CS%T_adx_2d, CS%T_ady_2d, &
-                        CS%T_diffx_2d, CS%T_diffy_2d, CS%T_advection_xy)
-      call add_tracer_diagnostics("S", CS%tracer_Reg, CS%S_adx, CS%S_ady, &
-                        CS%S_diffx, CS%S_diffy, CS%S_adx_2d, CS%S_ady_2d, &
-                        CS%S_diffx_2d, CS%S_diffy_2d, CS%S_advection_xy)
-    endif
     call register_Z_tracer(CS%tv%T, "temp", "Potential Temperature", "degC", Time,   &
                       G, CS%diag_to_Z_CSp, cmor_field_name="thetao",                 &
                       cmor_standard_name="sea_water_potential_temperature",          &
@@ -2349,7 +2337,7 @@ subroutine register_diags(Time, G, GV, CS, ADp, C_p)
 
   thickness_units = get_thickness_units(GV)
   flux_units      = get_flux_units(GV)
-  S_flux_units    = get_tr_flux_units(GV, "psu") ! Could change to "kg m-2 s-1"?
+  S_flux_units    = get_tr_flux_units(GV, "psu") ! Could change to "kg s-1"?
   conv2watt       = GV%H_to_kg_m2 * C_p
   if (GV%Boussinesq) then
     conv2salt = GV%H_to_m ! Could change to GV%H_to_kg_m2 * 0.001?
@@ -2396,15 +2384,6 @@ subroutine register_diags(Time, G, GV, CS, ADp, C_p)
       'Sea Surface Speed', 'm s-1', CS%missing)
 
   if (CS%use_temperature) then
-    CS%id_T = register_diag_field('ocean_model', 'temp', diag%axesTL, Time, &
-        'Potential Temperature', 'degC',                                    &
-         cmor_field_name="thetao",                                          &
-         cmor_standard_name="sea_water_potential_temperature",              &
-         cmor_long_name ="Sea Water Potential Temperature")
-    CS%id_S = register_diag_field('ocean_model', 'salt', diag%axesTL, Time, &
-        long_name='Salinity', units='psu', cmor_field_name='so',            &
-        cmor_long_name='Sea Water Salinity',                                &
-        cmor_standard_name='sea_water_salinity')
     CS%id_tob = register_diag_field('ocean_model','tob', diag%axesT1, Time,          &
         long_name='Sea Water Potential Temperature at Sea Floor',                    &
         standard_name='sea_water_potential_temperature_at_sea_floor', units='degC')
@@ -2428,10 +2407,10 @@ subroutine register_diags(Time, G, GV, CS, ADp, C_p)
         cmor_long_name='Square of Sea Surface Salinity ',                     &
         cmor_standard_name='square_of_sea_surface_salinity')
     if (CS%use_conT_absS) then
-      CS%id_Tcon = register_diag_field('ocean_model', 'contemp', diag%axesTL, Time, &
-          'Conservative Temperature', 'Celsius')
-      CS%id_Sabs = register_diag_field('ocean_model', 'abssalt', diag%axesTL, Time, &
-          long_name='Absolute Salinity', units='g kg-1')
+      CS%id_Tpot = register_diag_field('ocean_model', 'temp', diag%axesTL, Time, &
+          'Potential Temperature', 'degC')
+      CS%id_Sprac = register_diag_field('ocean_model', 'salt', diag%axesTL, Time, &
+          'Salinity', 'psu')
       CS%id_sstcon = register_diag_field('ocean_model', 'conSST', diag%axesT1, Time,     &
           'Sea Surface Conservative Temperature', 'Celsius', CS%missing)
       CS%id_sssabs = register_diag_field('ocean_model', 'absSSS', diag%axesT1, Time,     &
@@ -2452,78 +2431,6 @@ subroutine register_diags(Time, G, GV, CS, ADp, C_p)
          'Heat flux into ocean from mass flux into ocean', 'W m-2')
   CS%id_intern_heat = register_diag_field('ocean_model', 'internal_heat', diag%axesT1, Time,&
          'Heat flux into ocean from geothermal or other internal sources', 'W m-2')
-
-
-  ! lateral heat advective and diffusive fluxes
-  CS%id_Tadx = register_diag_field('ocean_model', 'T_adx', diag%axesCuL, Time, &
-      'Advective (by residual mean) Zonal Flux of Heat', 'W m-2', &
-      v_extensive = .true., conversion = conv2watt)
-  CS%id_Tady = register_diag_field('ocean_model', 'T_ady', diag%axesCvL, Time, &
-      'Advective (by residual mean) Meridional Flux of Heat', 'W m-2', &
-      v_extensive = .true., conversion = conv2watt)
-  CS%id_Tdiffx = register_diag_field('ocean_model', 'T_diffx', diag%axesCuL, Time, &
-      'Diffusive Zonal Flux of Heat', 'W m-2', &
-      v_extensive = .true., conversion = conv2watt)
-  CS%id_Tdiffy = register_diag_field('ocean_model', 'T_diffy', diag%axesCvL, Time, &
-      'Diffusive Meridional Flux of Heat', 'W m-2', &
-      v_extensive = .true., conversion = conv2watt)
-  if (CS%id_Tadx   > 0) call safe_alloc_ptr(CS%T_adx,IsdB,IedB,jsd,jed,nz)
-  if (CS%id_Tady   > 0) call safe_alloc_ptr(CS%T_ady,isd,ied,JsdB,JedB,nz)
-  if (CS%id_Tdiffx > 0) call safe_alloc_ptr(CS%T_diffx,IsdB,IedB,jsd,jed,nz)
-  if (CS%id_Tdiffy > 0) call safe_alloc_ptr(CS%T_diffy,isd,ied,JsdB,JedB,nz)
-
-
-  ! lateral salt advective and diffusive fluxes
-  CS%id_Sadx = register_diag_field('ocean_model', 'S_adx', diag%axesCuL, Time, &
-      'Advective (by residual mean) Zonal Flux of Salt', S_flux_units, &
-      v_extensive = .true., conversion = conv2salt)
-  CS%id_Sady = register_diag_field('ocean_model', 'S_ady', diag%axesCvL, Time, &
-      'Advective (by residual mean) Meridional Flux of Salt', S_flux_units, &
-      v_extensive = .true., conversion = conv2salt)
-  CS%id_Sdiffx = register_diag_field('ocean_model', 'S_diffx', diag%axesCuL, Time, &
-      'Diffusive Zonal Flux of Salt', S_flux_units, &
-      v_extensive = .true., conversion = conv2salt)
-  CS%id_Sdiffy = register_diag_field('ocean_model', 'S_diffy', diag%axesCvL, Time, &
-      'Diffusive Meridional Flux of Salt', S_flux_units, &
-      v_extensive = .true., conversion = conv2salt)
-  if (CS%id_Sadx   > 0) call safe_alloc_ptr(CS%S_adx,IsdB,IedB,jsd,jed,nz)
-  if (CS%id_Sady   > 0) call safe_alloc_ptr(CS%S_ady,isd,ied,JsdB,JedB,nz)
-  if (CS%id_Sdiffx > 0) call safe_alloc_ptr(CS%S_diffx,IsdB,IedB,jsd,jed,nz)
-  if (CS%id_Sdiffy > 0) call safe_alloc_ptr(CS%S_diffy,isd,ied,JsdB,JedB,nz)
-
-
-  ! vertically integrated lateral heat advective and diffusive fluxes
-  CS%id_Tadx_2d = register_diag_field('ocean_model', 'T_adx_2d', diag%axesCu1, Time, &
-      'Vertically Integrated Advective Zonal Flux of Heat', 'W m-2', &
-      conversion = conv2watt)
-  CS%id_Tady_2d = register_diag_field('ocean_model', 'T_ady_2d', diag%axesCv1, Time, &
-      'Vertically Integrated Advective Meridional Flux of Heat', 'W m-2', &
-      conversion = conv2watt)
-  CS%id_Tdiffx_2d = register_diag_field('ocean_model', 'T_diffx_2d', diag%axesCu1, Time, &
-      'Vertically Integrated Diffusive Zonal Flux of Heat', 'W m-2', &
-      conversion = conv2watt)
-  CS%id_Tdiffy_2d = register_diag_field('ocean_model', 'T_diffy_2d', diag%axesCv1, Time, &
-      'Vertically Integrated Diffusive Meridional Flux of Heat', 'W m-2', &
-      conversion = conv2watt)
-  if (CS%id_Tadx_2d   > 0) call safe_alloc_ptr(CS%T_adx_2d,IsdB,IedB,jsd,jed)
-  if (CS%id_Tady_2d   > 0) call safe_alloc_ptr(CS%T_ady_2d,isd,ied,JsdB,JedB)
-  if (CS%id_Tdiffx_2d > 0) call safe_alloc_ptr(CS%T_diffx_2d,IsdB,IedB,jsd,jed)
-  if (CS%id_Tdiffy_2d > 0) call safe_alloc_ptr(CS%T_diffy_2d,isd,ied,JsdB,JedB)
-
-  ! vertically integrated lateral salt advective and diffusive fluxes
-  CS%id_Sadx_2d = register_diag_field('ocean_model', 'S_adx_2d', diag%axesCu1, Time, &
-      'Vertically Integrated Advective Zonal Flux of Salt', S_flux_units, conversion = conv2salt)
-  CS%id_Sady_2d = register_diag_field('ocean_model', 'S_ady_2d', diag%axesCv1, Time, &
-      'Vertically Integrated Advective Meridional Flux of Salt', S_flux_units, conversion = conv2salt)
-  CS%id_Sdiffx_2d = register_diag_field('ocean_model', 'S_diffx_2d', diag%axesCu1, Time, &
-      'Vertically Integrated Diffusive Zonal Flux of Salt', S_flux_units, conversion = conv2salt)
-  CS%id_Sdiffy_2d = register_diag_field('ocean_model', 'S_diffy_2d', diag%axesCv1, Time, &
-      'Vertically Integrated Diffusive Meridional Flux of Salt', S_flux_units, conversion = conv2salt)
-  if (CS%id_Sadx_2d   > 0) call safe_alloc_ptr(CS%S_adx_2d,IsdB,IedB,jsd,jed)
-  if (CS%id_Sady_2d   > 0) call safe_alloc_ptr(CS%S_ady_2d,isd,ied,JsdB,JedB)
-  if (CS%id_Sdiffx_2d > 0) call safe_alloc_ptr(CS%S_diffx_2d,IsdB,IedB,jsd,jed)
-  if (CS%id_Sdiffy_2d > 0) call safe_alloc_ptr(CS%S_diffy_2d,isd,ied,JsdB,JedB)
-
 
   if (CS%debug_truncations) then
     call safe_alloc_ptr(ADp%du_dt_visc,IsdB,IedB,jsd,jed,nz)
@@ -2572,17 +2479,6 @@ subroutine register_diags_TS_tendency(Time, G, CS)
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nz = G%ke
   is   = G%isc  ; ie   = G%iec  ; js   = G%jsc  ; je   = G%jec
 
-
-  ! heat tendencies from lateral advection
-  CS%id_T_advection_xy = register_diag_field('ocean_model', 'T_advection_xy', diag%axesTL, Time, &
-      'Horizontal convergence of residual mean heat advective fluxes', 'W m-2',v_extensive=.true.)
-  CS%id_T_advection_xy_2d = register_diag_field('ocean_model', 'T_advection_xy_2d', diag%axesT1, Time,&
-      'Vertical sum of horizontal convergence of residual mean heat advective fluxes', 'W m-2')
-  if (CS%id_T_advection_xy > 0 .or. CS%id_T_advection_xy_2d > 0) then
-    call safe_alloc_ptr(CS%T_advection_xy,isd,ied,jsd,jed,nz)
-    CS%tendency_diagnostics = .true.
-  endif
-
   ! net temperature and heat tendencies
   CS%id_T_tendency = register_diag_field('ocean_model', 'T_tendency', diag%axesTL, Time, &
       'Net time tendency for temperature', 'degC s-1')
@@ -2610,17 +2506,6 @@ subroutine register_diags_TS_tendency(Time, G, CS)
     do k=1,nz ; do j=js,je ; do i=is,ie
       CS%Th_prev(i,j,k) = CS%tv%T(i,j,k) * CS%h(i,j,k)
     enddo ; enddo ; enddo
-  endif
-
-
-  ! salt tendencies from lateral advection
-  CS%id_S_advection_xy = register_diag_field('ocean_model', 'S_advection_xy', diag%axesTL, Time, &
-      'Horizontal convergence of residual mean salt advective fluxes', 'kg m-2 s-1', v_extensive=.true.)
-  CS%id_S_advection_xy_2d = register_diag_field('ocean_model', 'S_advection_xy_2d', diag%axesT1, Time,&
-      'Vertical sum of horizontal convergence of residual mean salt advective fluxes', 'kg m-2 s-1')
-  if (CS%id_S_advection_xy > 0 .or. CS%id_S_advection_xy_2d > 0) then
-    call safe_alloc_ptr(CS%S_advection_xy,isd,ied,jsd,jed,nz)
-    CS%tendency_diagnostics = .true.
   endif
 
   ! net salinity and salt tendencies
@@ -2822,48 +2707,24 @@ subroutine post_TS_diagnostics(CS, G, GV, tv, diag, dt)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
   if (.NOT. CS%use_conT_absS) then
-    !Internal T&S variables are assumed to be potential&practical
-    if (CS%id_T > 0) call post_data(CS%id_T, tv%T, diag)
-    if (CS%id_S > 0) call post_data(CS%id_S, tv%S, diag)
-
+    ! Internal T&S variables are potential temperature & practical salinity
     if (CS%id_tob > 0) call post_data(CS%id_tob, tv%T(:,:,G%ke), diag, mask=G%mask2dT)
     if (CS%id_sob > 0) call post_data(CS%id_sob, tv%S(:,:,G%ke), diag, mask=G%mask2dT)
   else
-    !Internal T&S variables are assumed to be conservative&absolute
-    if (CS%id_Tcon > 0) call post_data(CS%id_Tcon, tv%T, diag)
-    if (CS%id_Sabs > 0) call post_data(CS%id_Sabs, tv%S, diag)
-    !Using TEOS-10 function calls convert T&S diagnostics
-    !from conservative temp to potential temp and
-    !from absolute salinity to practical salinity
-    do k=1,nz ; do j=js,je ; do i=is,ie
-      pracSal(i,j,k) = gsw_sp_from_sr(tv%S(i,j,k))
-      potTemp(i,j,k) = gsw_pt_from_ct(tv%S(i,j,k),tv%T(i,j,k))
-    enddo; enddo ; enddo
-    if (CS%id_T > 0) call post_data(CS%id_T, potTemp, diag)
-    if (CS%id_S > 0) call post_data(CS%id_S, pracSal, diag)
-    if (CS%id_tob > 0) call post_data(CS%id_tob, potTemp(:,:,G%ke), diag, mask=G%mask2dT)
-    if (CS%id_sob > 0) call post_data(CS%id_sob, pracSal(:,:,G%ke), diag, mask=G%mask2dT)
+    ! Internal T&S variables are conservative temperature & absolute salinity,
+    ! so they need to converted to potential temperature and practical salinity
+    ! for some diagnostics using TEOS-10 function calls.
+    if ((CS%id_Tpot > 0) .or. (CS%id_tob > 0) .or. (CS%id_Sprac > 0) .or. (CS%id_sob > 0)) then
+      do k=1,nz ; do j=js,je ; do i=is,ie
+        pracSal(i,j,k) = gsw_sp_from_sr(tv%S(i,j,k))
+        potTemp(i,j,k) = gsw_pt_from_ct(tv%S(i,j,k),tv%T(i,j,k))
+      enddo; enddo ; enddo
+      if (CS%id_Tpot > 0) call post_data(CS%id_Tpot, potTemp, diag)
+      if (CS%id_Sprac > 0) call post_data(CS%id_Sprac, pracSal, diag)
+      if (CS%id_tob > 0) call post_data(CS%id_tob, potTemp(:,:,G%ke), diag, mask=G%mask2dT)
+      if (CS%id_sob > 0) call post_data(CS%id_sob, pracSal(:,:,G%ke), diag, mask=G%mask2dT)
+    endif
   endif
-
-  if (CS%id_Tadx   > 0) call post_data(CS%id_Tadx,   CS%T_adx,   diag)
-  if (CS%id_Tady   > 0) call post_data(CS%id_Tady,   CS%T_ady,   diag)
-  if (CS%id_Tdiffx > 0) call post_data(CS%id_Tdiffx, CS%T_diffx, diag)
-  if (CS%id_Tdiffy > 0) call post_data(CS%id_Tdiffy, CS%T_diffy, diag)
-
-  if (CS%id_Sadx   > 0) call post_data(CS%id_Sadx,   CS%S_adx,   diag)
-  if (CS%id_Sady   > 0) call post_data(CS%id_Sady,   CS%S_ady,   diag)
-  if (CS%id_Sdiffx > 0) call post_data(CS%id_Sdiffx, CS%S_diffx, diag)
-  if (CS%id_Sdiffy > 0) call post_data(CS%id_Sdiffy, CS%S_diffy, diag)
-
-  if (CS%id_Tadx_2d   > 0) call post_data(CS%id_Tadx_2d,   CS%T_adx_2d,   diag)
-  if (CS%id_Tady_2d   > 0) call post_data(CS%id_Tady_2d,   CS%T_ady_2d,   diag)
-  if (CS%id_Tdiffx_2d > 0) call post_data(CS%id_Tdiffx_2d, CS%T_diffx_2d, diag)
-  if (CS%id_Tdiffy_2d > 0) call post_data(CS%id_Tdiffy_2d, CS%T_diffy_2d, diag)
-
-  if (CS%id_Sadx_2d   > 0) call post_data(CS%id_Sadx_2d,   CS%S_adx_2d,   diag)
-  if (CS%id_Sady_2d   > 0) call post_data(CS%id_Sady_2d,   CS%S_ady_2d,   diag)
-  if (CS%id_Sdiffx_2d > 0) call post_data(CS%id_Sdiffx_2d, CS%S_diffx_2d, diag)
-  if (CS%id_Sdiffy_2d > 0) call post_data(CS%id_Sdiffy_2d, CS%S_diffy_2d, diag)
 
   if(.not. CS%tendency_diagnostics) return
 
@@ -2871,42 +2732,6 @@ subroutine post_TS_diagnostics(CS, G, GV, tv, diag, dt)
   ppt2mks       = 0.001
   work3d(:,:,:) = 0.0
   work2d(:,:)   = 0.0
-
-  ! Diagnose tendency of heat from convergence of lateral advective,
-  ! fluxes, where advective transport arises from residual mean velocity.
-  if (CS%id_T_advection_xy > 0 .or. CS%id_T_advection_xy_2d > 0) then
-    do k=1,nz ; do j=js,je ; do i=is,ie
-      work3d(i,j,k) = CS%T_advection_xy(i,j,k) * GV%H_to_kg_m2 * tv%C_p
-    enddo ; enddo ; enddo
-    if (CS%id_T_advection_xy    > 0) call post_data(CS%id_T_advection_xy, work3d, diag)
-    if (CS%id_T_advection_xy_2d > 0) then
-      do j=js,je ; do i=is,ie
-        work2d(i,j) = 0.0
-        do k=1,nz
-          work2d(i,j) = work2d(i,j) + work3d(i,j,k)
-        enddo
-      enddo ; enddo
-      call post_data(CS%id_T_advection_xy_2d, work2d, diag)
-    endif
-  endif
-
-  ! Diagnose tendency of salt from convergence of lateral advective
-  ! fluxes, where advective transport arises from residual mean velocity.
-  if (CS%id_S_advection_xy > 0 .or. CS%id_S_advection_xy_2d > 0) then
-    do k=1,nz ; do j=js,je ; do i=is,ie
-      work3d(i,j,k) = CS%S_advection_xy(i,j,k) * GV%H_to_kg_m2 * ppt2mks
-    enddo ; enddo ; enddo
-    if (CS%id_S_advection_xy    > 0) call post_data(CS%id_S_advection_xy, work3d, diag)
-    if (CS%id_S_advection_xy_2d > 0) then
-      do j=js,je ; do i=is,ie
-        work2d(i,j) = 0.0
-        do k=1,nz
-          work2d(i,j) = work2d(i,j) + work3d(i,j,k)
-        enddo
-      enddo ; enddo
-      call post_data(CS%id_S_advection_xy_2d, work2d, diag)
-    endif
-  endif
 
   ! diagnose net tendency for temperature over a time step and update T_prev
   if (CS%id_T_tendency > 0) then
@@ -2929,7 +2754,7 @@ subroutine post_TS_diagnostics(CS, G, GV, tv, diag, dt)
   ! diagnose net tendency for heat content of a grid cell over a time step and update Th_prev
   if (CS%id_Th_tendency > 0 .or. CS%id_Th_tendency_2d > 0) then
     do k=1,nz ; do j=js,je ; do i=is,ie
-      work3d(i,j,k)     = (tv%T(i,j,k)*CS%h(i,j,k) - CS%Th_prev(i,j,k)) * Idt * GV%H_to_kg_m2 * tv%C_p
+      work3d(i,j,k)     = (tv%T(i,j,k)*CS%h(i,j,k) - CS%Th_prev(i,j,k)) * Idt * (GV%H_to_kg_m2 * tv%C_p)
       CS%Th_prev(i,j,k) =  tv%T(i,j,k)*CS%h(i,j,k)
     enddo ; enddo ; enddo
     if (CS%id_Th_tendency    > 0) call post_data(CS%id_Th_tendency, work3d, diag)
@@ -2947,7 +2772,7 @@ subroutine post_TS_diagnostics(CS, G, GV, tv, diag, dt)
   ! diagnose net tendency for salt content of a grid cell over a time step and update Sh_prev
   if (CS%id_Sh_tendency > 0 .or. CS%id_Sh_tendency_2d > 0) then
     do k=1,nz ; do j=js,je ; do i=is,ie
-      work3d(i,j,k)     = (tv%S(i,j,k)*CS%h(i,j,k) - CS%Sh_prev(i,j,k)) * Idt * GV%H_to_kg_m2 * ppt2mks
+      work3d(i,j,k)     = (tv%S(i,j,k)*CS%h(i,j,k) - CS%Sh_prev(i,j,k)) * Idt * (GV%H_to_kg_m2 * ppt2mks)
       CS%Sh_prev(i,j,k) =  tv%S(i,j,k)*CS%h(i,j,k)
     enddo ; enddo ; enddo
     if (CS%id_Sh_tendency    > 0) call post_data(CS%id_Sh_tendency, work3d, diag)

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -45,7 +45,7 @@ public :: open_namelist_file, check_nml_error, io_infra_init, io_infra_end
 public :: APPEND_FILE, ASCII_FILE, MULTIPLE, NETCDF_FILE, OVERWRITE_FILE
 public :: READONLY_FILE, SINGLE_FILE, WRITEONLY_FILE
 public :: CENTER, CORNER, NORTH_FACE, EAST_FACE
-public :: var_desc, modify_vardesc, query_vardesc
+public :: var_desc, modify_vardesc, query_vardesc, cmor_long_std
 public :: get_axis_data
 
 !> Type for describing a variable, typically a tracer
@@ -58,6 +58,7 @@ type, public :: vardesc
   character(len=8)   :: t_grid             !< Time description: s, p, or 1
   character(len=64)  :: cmor_field_name    !< CMOR name
   character(len=64)  :: cmor_units         !< CMOR physical dimensions of the variable
+  character(len=240) :: cmor_longname      !< CMOR long name of the variable
   real               :: conversion         !< for unit conversions, such as needed to
                                            !! convert from intensive to extensive
 end type vardesc
@@ -587,7 +588,7 @@ end function num_timelevels
 !! have default values that are empty strings or are appropriate for a 3-d
 !! tracer field at the tracer cell centers.
 function var_desc(name, units, longname, hor_grid, z_grid, t_grid, &
-                  cmor_field_name, cmor_units, conversion, caller) result(vd)
+                  cmor_field_name, cmor_units, cmor_longname, conversion, caller) result(vd)
   character(len=*),           intent(in) :: name               !< variable name
   character(len=*), optional, intent(in) :: units              !< variable units
   character(len=*), optional, intent(in) :: longname           !< variable long name
@@ -596,6 +597,7 @@ function var_desc(name, units, longname, hor_grid, z_grid, t_grid, &
   character(len=*), optional, intent(in) :: t_grid             !< time description: s, p, or 1
   character(len=*), optional, intent(in) :: cmor_field_name    !< CMOR name
   character(len=*), optional, intent(in) :: cmor_units         !< CMOR physical dimensions of variable
+  character(len=*), optional, intent(in) :: cmor_longname      !< CMOR long name
   real            , optional, intent(in) :: conversion         !< for unit conversions, such as needed to
                                                                !! convert from intensive to extensive
   character(len=*), optional, intent(in) :: caller             !< calling routine?
@@ -612,20 +614,21 @@ function var_desc(name, units, longname, hor_grid, z_grid, t_grid, &
 
   vd%cmor_field_name  =  ""
   vd%cmor_units       =  ""
+  vd%cmor_longname    =  ""
   vd%conversion       =  1.0
 
   call modify_vardesc(vd, units=units, longname=longname, hor_grid=hor_grid, &
                       z_grid=z_grid, t_grid=t_grid,                          &
                       cmor_field_name=cmor_field_name,cmor_units=cmor_units, &
-                      conversion=conversion, caller=cllr)
+                      cmor_longname=cmor_longname, conversion=conversion, caller=cllr)
 
 end function var_desc
 
 
 !> This routine modifies the named elements of a vardesc type.
 !! All arguments are optional, except the vardesc type to be modified.
-subroutine modify_vardesc(vd, name, units, longname, hor_grid, z_grid, t_grid,&
-                  cmor_field_name, cmor_units, conversion, caller)
+subroutine modify_vardesc(vd, name, units, longname, hor_grid, z_grid, t_grid, &
+                 cmor_field_name, cmor_units, cmor_longname, conversion, caller)
   type(vardesc),              intent(inout) :: vd                 !< vardesc type that is modified
   character(len=*), optional, intent(in)    :: name               !< name of variable
   character(len=*), optional, intent(in)    :: units              !< units of variable
@@ -635,6 +638,7 @@ subroutine modify_vardesc(vd, name, units, longname, hor_grid, z_grid, t_grid,&
   character(len=*), optional, intent(in)    :: t_grid             !< time description: s, p, or 1
   character(len=*), optional, intent(in)    :: cmor_field_name    !< CMOR name
   character(len=*), optional, intent(in)    :: cmor_units         !< CMOR physical dimensions of variable
+  character(len=*), optional, intent(in)    :: cmor_longname      !< CMOR long name
   real            , optional, intent(in)    :: conversion         !< for unit conversions, such as needed to
                                                                   !! convert from intensive to extensive
   character(len=*), optional, intent(in)    :: caller             !< calling routine?
@@ -656,17 +660,34 @@ subroutine modify_vardesc(vd, name, units, longname, hor_grid, z_grid, t_grid,&
   if (present(t_grid))    call safe_string_copy(t_grid, vd%t_grid,     &
                                "vd%t_grid of "//trim(vd%name), cllr)
 
-  if (present(cmor_field_name))    call safe_string_copy(cmor_field_name, vd%cmor_field_name,      &
-                                   "vd%cmor_field_name of "//trim(vd%name), cllr)
-  if (present(cmor_units))          call safe_string_copy(cmor_units, vd%cmor_units,               &
-                                   "vd%cmor_units of "//trim(vd%name), cllr)
+  if (present(cmor_field_name)) call safe_string_copy(cmor_field_name, vd%cmor_field_name, &
+                                     "vd%cmor_field_name of "//trim(vd%name), cllr)
+  if (present(cmor_units))      call safe_string_copy(cmor_units, vd%cmor_units, &
+                                     "vd%cmor_units of "//trim(vd%name), cllr)
+  if (present(cmor_longname))   call safe_string_copy(cmor_longname, vd%cmor_longname, &
+                                     "vd%cmor_longname of "//trim(vd%name), cllr)
 
 end subroutine modify_vardesc
 
+!> This function returns the CMOR standard name given a CMOR longname, based on
+!! the standard pattern of character conversions.
+function cmor_long_std(longname) result(std_name)
+  character(len=*), intent(in) :: longname  !< The CMOR longname being converted
+  character(len=len(longname)) :: std_name  !< The CMOR standard name generated from longname
+
+  integer :: k
+
+  std_name = lowercase(longname)
+
+  do k=1, len_trim(std_name)
+    if (std_name(k:k) == ' ') std_name(k:k) = '_'
+  enddo
+
+end function cmor_long_std
 
 !> This routine queries vardesc
 subroutine query_vardesc(vd, name, units, longname, hor_grid, z_grid, t_grid, &
-                         cmor_field_name, cmor_units, conversion, caller)
+                         cmor_field_name, cmor_units, cmor_longname, conversion, caller)
   type(vardesc),              intent(in)  :: vd                 !< vardesc type that is queried
   character(len=*), optional, intent(out) :: name               !< name of variable
   character(len=*), optional, intent(out) :: units              !< units of variable
@@ -676,6 +697,7 @@ subroutine query_vardesc(vd, name, units, longname, hor_grid, z_grid, t_grid, &
   character(len=*), optional, intent(out) :: t_grid             !< time description: s, p, or 1
   character(len=*), optional, intent(out) :: cmor_field_name    !< CMOR name
   character(len=*), optional, intent(out) :: cmor_units         !< CMOR physical dimensions of variable
+  character(len=*), optional, intent(out) :: cmor_longname      !< CMOR long name
   real            , optional, intent(out) :: conversion         !< for unit conversions, such as needed to
                                                                 !! convert from intensive to extensive
   character(len=*), optional, intent(in)  :: caller             !< calling routine?
@@ -698,10 +720,12 @@ subroutine query_vardesc(vd, name, units, longname, hor_grid, z_grid, t_grid, &
   if (present(t_grid))    call safe_string_copy(vd%t_grid, t_grid,     &
                                "vd%t_grid of "//trim(vd%name), cllr)
 
-  if (present(cmor_field_name))    call safe_string_copy(vd%cmor_field_name, cmor_field_name,       &
-                                   "vd%cmor_field_name of "//trim(vd%name), cllr)
-  if (present(cmor_units))          call safe_string_copy(vd%cmor_units, cmor_units,                &
-                                   "vd%cmor_units of "//trim(vd%name), cllr)
+  if (present(cmor_field_name)) call safe_string_copy(vd%cmor_field_name, cmor_field_name, &
+                                     "vd%cmor_field_name of "//trim(vd%name), cllr)
+  if (present(cmor_units))      call safe_string_copy(vd%cmor_units, cmor_units,          &
+                                     "vd%cmor_units of "//trim(vd%name), cllr)
+  if (present(cmor_longname))   call safe_string_copy(vd%cmor_longname, cmor_longname, &
+                                     "vd%cmor_longname of "//trim(vd%name), cllr)
 
 end subroutine query_vardesc
 

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -355,7 +355,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV)
   integer :: i, j, k, is, ie, js, je, nz, m
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
-  isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed 
+  isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
   if (.not. associated(Reg)) call MOM_error(FATAL, "add_tracer_diagnostics: "// &

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -14,7 +14,8 @@ use MOM_error_handler, only : MOM_error, FATAL, WARNING, MOM_mesg, is_root_pe
 use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_hor_index,     only : hor_index_type
 use MOM_grid,          only : ocean_grid_type
-use MOM_io,            only : vardesc, query_vardesc
+use MOM_io,            only : vardesc, query_vardesc, cmor_long_std
+use MOM_string_functions, only : lowercase
 use MOM_time_manager,  only : time_type
 use MOM_verticalGrid,  only : verticalGrid_type
 
@@ -62,9 +63,14 @@ type, public :: tracer_type
                                                               !! names of flux diagnostics.
   character(len=64)               :: flux_longname = ""       !< A word or phrase used construct the long
                                                               !! names of flux diagnostics.
-  real                            :: flux_conversion = 1.0    !< A scaling factor used to convert the fluxes
+  real                            :: flux_scale= 1.0          !< A scaling factor used to convert the fluxes
                                                               !! of this tracer to its desired units.
   character(len=48)               :: flux_units = ""          !< The units for fluxes of this variable.
+  character(len=48)               :: conv_units = ""          !< The units for the flux convergence of this tracer.
+  real                            :: conv_scale = 1.0         !< A scaling factor used to convert the flux
+                                                              !! convergence of this tracer to its desired units.
+
+  integer :: diag_form = 1  !< An integer indicating which template is to be used to label diagnostics.
   integer :: id_tr = -1
   integer :: id_adx = -1, id_ady = -1, id_dfx = -1, id_dfy = -1
   integer :: id_adx_2d = -1, id_ady_2d = -1, id_dfx_2d = -1, id_dfy_2d = -1
@@ -88,7 +94,8 @@ contains
 subroutine register_tracer(tr1, tr_desc, param_file, HI, GV, Reg, tr_desc_ptr, ad_x, ad_y,&
                            df_x, df_y, OBC_inflow, OBC_in_u, OBC_in_v,            &
                            ad_2d_x, ad_2d_y, df_2d_x, df_2d_y, advection_xy, registry_diags, &
-                           flux_nameroot, flux_longname, flux_units, flux_conversion)
+                           flux_nameroot, flux_longname, flux_units, flux_scale, &
+                           convergence_units, convergence_scale, diag_form)
   type(hor_index_type),           intent(in)    :: HI           !< horizontal index type
   type(verticalGrid_type),        intent(in)    :: GV           !< ocean vertical grid structure
   real, dimension(SZI_(HI),SZJ_(HI),SZK_(GV)), target :: tr1    !< pointer to the tracer (concentration units)
@@ -125,10 +132,14 @@ subroutine register_tracer(tr1, tr_desc, param_file, HI, GV, Reg, tr_desc_ptr, a
                                                                 !! names of flux diagnostics.
   character(len=*),     optional, intent(in)    :: flux_longname !< A word or phrase used construct the long
                                                                 !! names of flux diagnostics.
-  character(len=*),     optional, intent(in)    :: flux_units   !< A scaling factor used to convert the fluxes
+  character(len=*),     optional, intent(in)    :: flux_units   !< The units for the fluxes of this tracer.
+  real,                 optional, intent(in)    :: flux_scale !< A scaling factor used to convert the fluxes
                                                                 !! of this tracer to its desired units.
-  real,                 optional, intent(in)    :: flux_conversion !< A scaling factor used to convert the fluxes
-                                                                !! of this tracer to its desired units.
+  character(len=*),     optional, intent(in)    :: convergence_units   !< The units for the flux convergence of this tracer.
+  real,                 optional, intent(in)    :: convergence_scale !< A scaling factor used to convert the flux
+                                                                !! convergence of this tracer to its desired units.
+  integer,              optional, intent(in)    :: diag_form    !< An integer (1 or 2, 1 by default) indicating the character
+                                                                !! string template to use in labeling diagnostics
   integer :: ntr
   type(tracer_type) :: temp
   character(len=72) :: longname ! The long name of a variable.
@@ -169,8 +180,21 @@ subroutine register_tracer(tr1, tr_desc, param_file, HI, GV, Reg, tr_desc_ptr, a
   Reg%Tr(ntr)%flux_units = ""
   if (present(flux_units)) Reg%Tr(ntr)%flux_units = flux_units
 
-  Reg%Tr(ntr)%flux_conversion = 1.0
-  if (present(flux_conversion)) Reg%Tr(ntr)%flux_conversion = flux_conversion
+  Reg%Tr(ntr)%flux_scale = 1.0
+  if (present(flux_scale)) Reg%Tr(ntr)%flux_scale = flux_scale
+
+  Reg%Tr(ntr)%conv_units = ""
+  if (present(convergence_units)) Reg%Tr(ntr)%conv_units = convergence_units
+
+  Reg%Tr(ntr)%conv_scale = 1.0
+  if (present(convergence_scale)) then
+    Reg%Tr(ntr)%conv_scale = convergence_scale
+  elseif (present(flux_scale)) then
+    Reg%Tr(ntr)%conv_scale = flux_scale
+  endif
+
+  Reg%Tr(ntr)%diag_form = 1
+  if (present(diag_form)) Reg%Tr(ntr)%diag_form = diag_form
 
   Reg%Tr(ntr)%t => tr1
 
@@ -202,7 +226,7 @@ subroutine lock_tracer_registry(Reg)
   type(tracer_registry_type), pointer    :: Reg    !< pointer to the tracer registry
 
   if (.not. associated(Reg)) call MOM_error(WARNING, &
-    "lock_tracer_registry called with an unassocaited registry.")
+    "lock_tracer_registry called with an unassociated registry.")
 
   Reg%locked = .True.
 
@@ -306,14 +330,15 @@ subroutine register_tracer_diagnostics(Reg, Time, diag, G, GV)
   character(len=48) :: units    ! The dimensions of the variable.
   character(len=48) :: flux_units ! The units for fluxes, either
                                 ! [units] m3 s-1 or [units] kg s-1.
+  character(len=48) :: conv_units ! The units for flux convergences, either
+                                ! [units] m2 s-1 or [units] kg s-1.
   character(len=72) :: cmorname ! The CMOR name of that variable.
+  character(len=120) :: cmor_longname ! The CMOR long name of that variable.
   type(tracer_type), pointer :: Tr=>NULL()
-  integer :: m, form
+  integer :: m
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nz = G%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
-
-  form = 1
 
   if (.not. associated(Reg)) call MOM_error(FATAL, "add_tracer_diagnostics: "// &
        "register_tracer must be called before add_tracer_diagnostics")
@@ -321,7 +346,8 @@ subroutine register_tracer_diagnostics(Reg, Time, diag, G, GV)
   do m=1,Reg%ntr ; if (Reg%Tr(m)%registry_diags) then
     Tr => Reg%Tr(m)
     call query_vardesc(Tr%vd, name, units=units, longname=longname, &
-                       cmor_field_name=cmorname, caller="register_tracer_diagnostics")
+                       cmor_field_name=cmorname, cmor_longname=cmor_longname, &
+                       caller="register_tracer_diagnostics")
     shortnm = Tr%flux_nameroot
     flux_longname = Tr%flux_longname
 
@@ -329,14 +355,19 @@ subroutine register_tracer_diagnostics(Reg, Time, diag, G, GV)
     elseif (GV%Boussinesq) then ; flux_units = trim(units)//" m3 s-1"
     else ; flux_units = trim(units)//" kg s-1" ; endif
 
+    if (len_trim(Tr%conv_units) > 0) then ; conv_units = Tr%conv_units
+    elseif (GV%Boussinesq) then ; conv_units = trim(units)//" m s-1"
+    else ; conv_units = trim(units)//" kg m-2 s-1" ; endif
+
     if (len_trim(cmorname) == 0) then
       Tr%id_tr = register_diag_field("ocean_model", trim(name), diag%axesTL, &
         Time, trim(longname), trim(units))
     else
       Tr%id_tr = register_diag_field("ocean_model", trim(name), diag%axesTL, &
-        Time, trim(longname), trim(units), cmor_field_name=cmorname)
+        Time, trim(longname), trim(units), cmor_field_name=cmorname, &
+        cmor_standard_name=cmor_long_std(cmor_longname), cmor_long_name=cmor_longname)
     endif
-    if (form == 1) then
+    if (Tr%diag_form == 1) then
       Tr%id_adx = register_diag_field("ocean_model", trim(shortnm)//"_adx", &
           diag%axesCuL, Time, trim(flux_longname)//" advective zonal flux" , &
           trim(flux_units))
@@ -352,16 +383,16 @@ subroutine register_tracer_diagnostics(Reg, Time, diag, G, GV)
     else
       Tr%id_adx = register_diag_field("ocean_model", trim(shortnm)//"_adx", &
           diag%axesCuL, Time, "Advective (by residual mean) Zonal Flux of "//trim(flux_longname), &
-          flux_units, v_extensive=.true., conversion=Tr%flux_conversion)
+          flux_units, v_extensive=.true., conversion=Tr%flux_scale)
       Tr%id_ady = register_diag_field("ocean_model", trim(shortnm)//"_ady", &
           diag%axesCvL, Time, "Advective (by residual mean) Meridional Flux of "//trim(flux_longname), &
-          flux_units, v_extensive=.true., conversion=Tr%flux_conversion)
+          flux_units, v_extensive=.true., conversion=Tr%flux_scale)
       Tr%id_dfx = register_diag_field("ocean_model", trim(shortnm)//"_diffx", &
           diag%axesCuL, Time, "Diffusive Zonal Flux of "//trim(flux_longname), &
-          flux_units, v_extensive=.true., conversion=Tr%flux_conversion)
+          flux_units, v_extensive=.true., conversion=Tr%flux_scale)
       Tr%id_dfy = register_diag_field("ocean_model", trim(shortnm)//"_diffy", &
           diag%axesCvL, Time, "Diffusive Meridional Flux of "//trim(flux_longname), &
-          flux_units, v_extensive=.true., conversion=Tr%flux_conversion)
+          flux_units, v_extensive=.true., conversion=Tr%flux_scale)
     endif
     if (Tr%id_adx > 0) call safe_alloc_ptr(Tr%ad_x,IsdB,IedB,jsd,jed,nz)
     if (Tr%id_ady > 0) call safe_alloc_ptr(Tr%ad_y,isd,ied,JsdB,JedB,nz)
@@ -371,19 +402,19 @@ subroutine register_tracer_diagnostics(Reg, Time, diag, G, GV)
     Tr%id_adx_2d = register_diag_field("ocean_model", trim(shortnm)//"_adx_2d", &
         diag%axesCu1, Time, &
         "Vertically Integrated Advective Zonal Flux of "//trim(flux_longname), &
-        flux_units, v_extensive=.true., conversion=Tr%flux_conversion)
+        flux_units, conversion=Tr%flux_scale)
     Tr%id_ady_2d = register_diag_field("ocean_model", trim(shortnm)//"_ady_2d", &
         diag%axesCv1, Time, &
         "Vertically Integrated Advective Meridional Flux of "//trim(flux_longname), &
-        flux_units, v_extensive=.true., conversion=Tr%flux_conversion)
+        flux_units, conversion=Tr%flux_scale)
     Tr%id_dfx_2d = register_diag_field("ocean_model", trim(shortnm)//"_diffx_2d", &
         diag%axesCu1, Time, &
         "Vertically Integrated Diffusive Zonal Flux of "//trim(flux_longname), &
-        flux_units, v_extensive=.true., conversion=Tr%flux_conversion)
+        flux_units, conversion=Tr%flux_scale)
     Tr%id_dfy_2d = register_diag_field("ocean_model", trim(shortnm)//"_diffy_2d", &
         diag%axesCv1, Time, &
         "Vertically Integrated Diffusive Meridional Flux of "//trim(flux_longname), &
-        flux_units, v_extensive=.true., conversion=Tr%flux_conversion)
+        flux_units, conversion=Tr%flux_scale)
 
     if (Tr%id_adx_2d > 0) call safe_alloc_ptr(Tr%ad2d_x,IsdB,IedB,jsd,jed)
     if (Tr%id_ady_2d > 0) call safe_alloc_ptr(Tr%ad2d_y,isd,ied,JsdB,JedB)
@@ -392,12 +423,13 @@ subroutine register_tracer_diagnostics(Reg, Time, diag, G, GV)
 
     Tr%id_adv_xy = register_diag_field('ocean_model', trim(shortnm)//"_advection_xy", &
         diag%axesTL, Time, &
-        'Horizontal convergence of residual mean advective fluxes of '//trim(flux_longname), &
-        flux_units, v_extensive=.true., conversion=Tr%flux_conversion)
+        'Horizontal convergence of residual mean advective fluxes of '//&
+        trim(lowercase(flux_longname)), conv_units, v_extensive=.true., &
+        conversion=Tr%conv_scale)
     Tr%id_adv_xy_2d = register_diag_field('ocean_model', trim(shortnm)//"_advection_xy_2d", &
         diag%axesT1, Time, &
-        'Vertical sum of horizontal convergence of residual mean advective fluxes of'//trim(flux_longname), &
-        flux_units, conversion=Tr%flux_conversion)
+        'Vertical sum of horizontal convergence of residual mean advective fluxes of '//&
+        trim(lowercase(flux_longname)), conv_units, conversion=Tr%conv_scale)
     if ((Tr%id_adv_xy > 0) .or. (Tr%id_adv_xy_2d > 0)) &
       call safe_alloc_ptr(Tr%advection_xy,isd,ied,jsd,jed,nz)
 
@@ -437,7 +469,7 @@ subroutine post_tracer_diagnostics(Reg, diag, G, GV)
       do k=1,nz ; do j=js,je ; do i=is,ie
         work2d(i,j) = work2d(i,j) + Tr%advection_xy(i,j,k)
       enddo ; enddo ; enddo
-      call post_data(Tr%id_adv_xy_2d, Tr%advection_xy, diag)
+      call post_data(Tr%id_adv_xy_2d, work2d, diag)
     endif
   endif ; enddo
 end subroutine post_tracer_diagnostics


### PR DESCRIPTION
This PR includes code changes that move numerous tracer diagnostics into the tracer registry and exercises this capability for temperature and salinity. All diagnostics and solutions reproduce previous values, but there are some minor changes in diagnostic longnames (but not for any CMOR variables).