### PR TITLE
Tracer package cleanup

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -408,8 +408,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
              OS%MOM_CSp%v, OS%MOM_CSp%h, OS%MOM_CSp%ave_ssh,&
              OS%grid, OS%GV, OS%MOM_CSp)
 
-    call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid, &
-                                     OS%MOM_CSp%use_conT_absS)
+    call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid)
 
   endif
 
@@ -625,8 +624,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
 ! Translate state into Ocean.
 !  call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid, &
 !                                   Ice_ocean_boundary%p, OS%press_to_z)
-  call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid, &
-                                   OS%MOM_CSp%use_conT_absS)
+  call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid)
   call coupler_type_send_data(Ocean_sfc%fields, OS%Time)
 
   call callTree_leave("update_ocean_model()")
@@ -904,14 +902,13 @@ subroutine initialize_ocean_public_type(input_domain, Ocean_sfc, diag, maskmap, 
 
 end subroutine initialize_ocean_public_type
 
-subroutine convert_state_to_ocean_type(sfc_state, Ocean_sfc, G, use_conT_absS, &
+subroutine convert_state_to_ocean_type(sfc_state, Ocean_sfc, G, &
                                        patm, press_to_z)
   type(surface),           intent(inout) :: sfc_state !< A structure containing fields that
                                                       !! describe the surface state of the ocean.
   type(ocean_public_type), &
                    target, intent(inout) :: Ocean_sfc
   type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure
-  logical,                 intent(in)    :: use_conT_absS
   real,          optional, intent(in)    :: patm(:,:)
   real,          optional, intent(in)    :: press_to_z
 ! This subroutine translates the coupler's ocean_data_type into MOM's
@@ -936,17 +933,24 @@ subroutine convert_state_to_ocean_type(sfc_state, Ocean_sfc, G, use_conT_absS, &
   endif
 
   i0 = is - isc_bnd ; j0 = js - jsc_bnd
-  if (use_conT_absS) then
-    !If directed convert the surface T&S from conservative T to potential T and
-    !from absolute (reference) salinity to practical salinity
+  if (sfc_state%T_is_conT) then
+    ! Convert the surface T from conservative T to potential T.
     do j=jsc_bnd,jec_bnd ; do i=isc_bnd,iec_bnd
-      Ocean_sfc%s_surf(i,j) = gsw_sp_from_sr(sfc_state%SSS(i+i0,j+j0))
       Ocean_sfc%t_surf(i,j) = gsw_pt_from_ct(sfc_state%SSS(i+i0,j+j0), &
                                sfc_state%SST(i+i0,j+j0)) + CELSIUS_KELVIN_OFFSET
     enddo ; enddo
   else
     do j=jsc_bnd,jec_bnd ; do i=isc_bnd,iec_bnd
       Ocean_sfc%t_surf(i,j) = sfc_state%SST(i+i0,j+j0) + CELSIUS_KELVIN_OFFSET
+    enddo ; enddo
+  endif
+  if (sfc_state%S_is_absS) then
+    ! Convert the surface S from absolute salinity to practical salinity.
+    do j=jsc_bnd,jec_bnd ; do i=isc_bnd,iec_bnd
+      Ocean_sfc%s_surf(i,j) = gsw_sp_from_sr(sfc_state%SSS(i+i0,j+j0))
+    enddo ; enddo
+  else
+    do j=jsc_bnd,jec_bnd ; do i=isc_bnd,iec_bnd
       Ocean_sfc%s_surf(i,j) = sfc_state%SSS(i+i0,j+j0)
     enddo ; enddo
   endif
@@ -1029,8 +1033,7 @@ subroutine ocean_model_init_sfc(OS, Ocean_sfc)
            OS%MOM_CSp%v, OS%MOM_CSp%h, OS%MOM_CSp%ave_ssh,&
            OS%grid, OS%GV, OS%MOM_CSp)
 
-  call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid, &
-                                   OS%MOM_CSp%use_conT_absS)
+  call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid)
 
 end subroutine ocean_model_init_sfc
 ! </SUBROUTINE NAME="ocean_model_init_sfc">

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -254,7 +254,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
   call callTree_enter("ocean_model_init(), ocean_model_MOM.F90")
   if (associated(OS)) then
     call MOM_error(WARNING, "ocean_model_init called with an associated "// &
-                    "ocean_state_type structure. Model is already initialized.")
+                   "ocean_state_type structure. Model is already initialized.")
     return
   endif
   allocate(OS)
@@ -264,7 +264,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
 
   OS%Time = Time_in
   call initialize_MOM(OS%Time, param_file, OS%dirs, OS%MOM_CSp, Time_in, &
-      offline_tracer_mode=offline_tracer_mode)
+                      offline_tracer_mode=offline_tracer_mode)
   OS%grid => OS%MOM_CSp%G ; OS%GV => OS%MOM_CSp%GV
   OS%C_p = OS%MOM_CSp%tv%C_p
   OS%fluxes%C_p = OS%MOM_CSp%tv%C_p

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -146,6 +146,46 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
+!> A structure with diagnostic IDs
+type MOM_diag_IDs
+  ! diagnostic ids
+
+  ! 3-d state fields
+  integer :: id_u  = -1, id_v  = -1, id_h  = -1
+  integer :: id_Tpot  = -1, id_Sprac  = -1
+
+  ! 2-d surface and bottom fields
+  integer :: id_zos      = -1
+  integer :: id_zossq    = -1
+  integer :: id_volo     = -1
+  integer :: id_ssh      = -1
+  integer :: id_ssh_ga   = -1
+  integer :: id_sst      = -1
+  integer :: id_sst_sq   = -1
+  integer :: id_sss      = -1
+  integer :: id_sss_sq   = -1
+  integer :: id_ssu      = -1
+  integer :: id_ssv      = -1
+  integer :: id_speed    = -1
+  integer :: id_ssh_inst = -1
+  integer :: id_tob      = -1
+  integer :: id_sob      = -1
+  integer :: id_sstcon   = -1
+  integer :: id_sssabs   = -1
+
+  integer :: id_T_vardec = -1, id_S_vardec = -1
+
+  ! heat and salt flux fields
+  integer :: id_fraz         = -1
+  integer :: id_salt_deficit = -1
+  integer :: id_Heat_PmE     = -1
+  integer :: id_intern_heat  = -1
+
+  ! Diagnostics for tracer horizontal transport
+  integer :: id_uhtr = -1, id_umo = -1, id_umo_2d = -1
+  integer :: id_vhtr = -1, id_vmo = -1, id_vmo_2d = -1
+end type MOM_diag_IDs
+
 !> Control structure for this module
 type, public :: MOM_control_struct
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_,NKMEM_) :: &
@@ -284,48 +324,7 @@ type, public :: MOM_control_struct
 
   logical :: tendency_diagnostics = .false.
 
-  ! diagnostic ids
-
-  ! 3-d state fields
-  integer :: id_u  = -1
-  integer :: id_v  = -1
-  integer :: id_h  = -1
-  integer :: id_Tpot  = -1
-  integer :: id_Sprac  = -1
-
-  ! 2-d surface and bottom fields
-  integer :: id_zos      = -1
-  integer :: id_zossq    = -1
-  integer :: id_volo     = -1;
-  integer :: id_ssh      = -1
-  integer :: id_ssh_ga   = -1
-  integer :: id_sst      = -1
-  integer :: id_sst_sq   = -1
-  integer :: id_sss      = -1
-  integer :: id_sss_sq   = -1
-  integer :: id_ssu      = -1
-  integer :: id_ssv      = -1
-  integer :: id_speed    = -1
-  integer :: id_ssh_inst = -1
-  integer :: id_tob      = -1
-  integer :: id_sob      = -1
-  integer :: id_sstcon   = -1
-  integer :: id_sssabs   = -1
-
-  ! heat and salt flux fields
-  integer :: id_fraz         = -1
-  integer :: id_salt_deficit = -1
-  integer :: id_Heat_PmE     = -1
-  integer :: id_intern_heat  = -1
-
-  ! variance decay for temp and heat
-  integer :: id_T_vardec = -1
-  integer :: id_S_vardec = -1
-
-
-  ! Diagnostics for tracer horizontal transport
-  integer :: id_uhtr = -1, id_umo = -1, id_umo_2d = 1
-  integer :: id_vhtr = -1, id_vmo = -1, id_vmo_2d = 1
+  type(MOM_diag_IDs) :: IDs
 
   ! The remainder provides pointers to child module control structures.
   type(MOM_dyn_unsplit_CS),      pointer :: dyn_unsplit_CSp      => NULL()
@@ -410,6 +409,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS)
   type(ocean_grid_type), pointer :: G ! pointer to a structure containing
                                       ! metrics and related information
   type(verticalGrid_type),  pointer :: GV => NULL()
+  type(MOM_diag_IDs), pointer :: IDs => NULL() ! A structure with the diagnostic IDs.
   integer, save :: nt_debug = 1 ! running number of iterations, for debugging only.
   integer       :: ntstep ! time steps between tracer updates or diabatic forcing
   integer       :: n_max  ! number of steps to take in this call
@@ -461,7 +461,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS)
   ! These are used for group halo passes.
   logical :: do_pass_Ray, do_pass_kv_bbl_thick
 
-  G => CS%G ; GV => CS%GV
+  G => CS%G ; GV => CS%GV ; IDs => CS%IDs
   is   = G%isc  ; ie   = G%iec  ; js   = G%jsc  ; je   = G%jec ; nz = G%ke
   Isq  = G%IscB ; Ieq  = G%IecB ; Jsq  = G%JscB ; Jeq  = G%JecB
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed
@@ -721,7 +721,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS)
     endif
 
     ! Store pre-dynamics state for proper diagnostic remapping if mass transports requested
-    if (transport_remap_grid_needed(CS)) then
+    if (transport_remap_grid_needed(IDs)) then
       do k=1,nz ; do j=jsd,jed ; do i=isd,ied
         h_pre_dyn(i,j,k) = h(i,j,k)
         if (associated(CS%tv%T)) T_pre_dyn(i,j,k) = CS%tv%T(i,j,k)
@@ -878,10 +878,10 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS)
 
     call enable_averaging(dt, Time_local, CS%diag)
     ! These diagnostics are available every time step.
-    if (CS%id_u > 0) call post_data(CS%id_u, u, CS%diag)
-    if (CS%id_v > 0) call post_data(CS%id_v, v, CS%diag)
-    if (CS%id_h > 0) call post_data(CS%id_h, h, CS%diag)
-    if (CS%id_ssh_inst > 0) call post_data(CS%id_ssh_inst, ssh, CS%diag)
+    if (IDs%id_u > 0) call post_data(IDs%id_u, u, CS%diag)
+    if (IDs%id_v > 0) call post_data(IDs%id_v, v, CS%diag)
+    if (IDs%id_h > 0) call post_data(IDs%id_h, h, CS%diag)
+    if (IDs%id_ssh_inst > 0) call post_data(IDs%id_ssh_inst, ssh, CS%diag)
     call disable_averaging(CS%diag)
 
     if (CS%t_dyn_rel_adv == 0.0) then
@@ -891,7 +891,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS)
       call calculate_diagnostic_fields(u, v, h, CS%uh, CS%vh, CS%tv, CS%ADp, &
                           CS%CDp, fluxes, CS%t_dyn_rel_diag, G, GV, CS%diagnostics_CSp)
       call post_tracer_diagnostics(CS%Tracer_reg, h, CS%diag, G, GV, CS%t_dyn_rel_diag)
-      call post_TS_diagnostics(CS, G, GV, CS%tv, CS%diag, CS%t_dyn_rel_diag)
+      call post_TS_diagnostics(CS, IDs, G, GV, CS%tv, CS%diag, CS%t_dyn_rel_diag)
       if (showCallTree) call callTree_waypoint("finished calculate_diagnostic_fields (step_MOM)")
       call disable_averaging(CS%diag)
       CS%t_dyn_rel_diag = 0.0
@@ -921,7 +921,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS)
     CS%ave_ssh(i,j) = CS%ave_ssh(i,j)*Itot_wt_ssh
     ssh(i,j) = CS%ave_ssh(i,j)
   enddo ; enddo
-  call adjust_ssh_for_p_atm(CS, G, GV, CS%ave_ssh, forces%p_surf_SSH)
+  call adjust_ssh_for_p_atm(CS%tv, G, GV, CS%ave_ssh, forces%p_surf_SSH, CS%calc_rho_for_sea_lev)
 
   if (CS%interp_p_surf) then ; do j=jsd,jed ; do i=isd,ied
     CS%p_surf_prev(i,j) = forces%p_surf(i,j)
@@ -933,8 +933,8 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS)
   ! Do diagnostics that only occur at the end of a complete forcing step.
   call cpu_clock_begin(id_clock_diagnostics)
   call enable_averaging(dt*n_max, Time_local, CS%diag)
-  call post_integrated_diagnostics(CS, G, GV, CS%diag, dt*n_max, CS%tv, ssh, fluxes)
-  call post_surface_diagnostics(CS, G, CS%diag, sfc_state)
+  call post_integrated_diagnostics(CS, IDs, G, GV, CS%diag, dt*n_max, CS%tv, ssh, fluxes)
+  call post_surface_diagnostics(CS, IDs, G, CS%diag, sfc_state)
   call disable_averaging(CS%diag)
   call cpu_clock_end(id_clock_diagnostics)
 
@@ -993,7 +993,7 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, h, h_pre_dyn, T_pre_dyn, S_pre_dyn, &
   call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
 
   call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)
-  call post_transport_diagnostics(G, GV, CS, CS%diag, CS%t_dyn_rel_adv, h, &
+  call post_transport_diagnostics(G, GV, CS, CS%IDs, CS%diag, CS%t_dyn_rel_adv, h, &
                                   h_pre_dyn, T_pre_dyn, S_pre_dyn)
   ! Rebuild the remap grids now that we've posted the fields which rely on thicknesses
   ! from before the dynamics calls
@@ -1145,7 +1145,8 @@ subroutine step_MOM_thermo(CS, G, GV, u, v, h, tv, fluxes, dtdia, Time_end_therm
     ! happen after the H update and before the next post_data.
     call diag_update_remap_grids(CS%diag)
 
-    call post_diags_TS_vardec(G, CS, dtdia)
+    call post_diags_TS_vardec(G, CS, CS%IDs, CS%diag, dtdia)
+
     if (CS%debug) then
       call uvchksum("Post-diabatic u", u, v, G%HI, haloshift=2)
       call hchksum(h, "Post-diabatic h", G%HI, haloshift=1, scale=GV%H_to_m)
@@ -1364,7 +1365,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
 
   endif
 
-  call adjust_ssh_for_p_atm(CS, G, GV, CS%ave_ssh, forces%p_surf_SSH)
+  call adjust_ssh_for_p_atm(CS%tv, G, GV, CS%ave_ssh, forces%p_surf_SSH, CS%calc_rho_for_sea_lev)
   call calculate_surface_state(sfc_state, CS%u, CS%v, CS%h, CS%ave_ssh, G, GV, CS)
 
   call disable_averaging(CS%diag)
@@ -2168,13 +2169,13 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
   call tracer_hor_diff_init(Time, G, param_file, diag, CS%tracer_diff_CSp, CS%neutral_diffusion_CSp)
 
   if (CS%use_ALE_algorithm) &
-    call register_diags_TS_vardec(Time, G%HI, GV, param_file, CS)
+    call register_diags_TS_vardec(Time, G%HI, GV, param_file, CS, CS%IDs, CS%diag)
 
   call lock_tracer_registry(CS%tracer_Reg)
   call callTree_waypoint("tracer registry now locked (initialize_MOM)")
 
   ! now register some diagnostics since tracer registry is locked
-  call register_diags(Time, G, GV, CS, CS%ADp, CS%tv%C_p)
+  call register_diags(Time, G, GV, CS, CS%IDs, CS%diag, CS%ADp, CS%tv%C_p, CS%missing)
   call register_tracer_diagnostics(CS%tracer_Reg, CS%h, Time, diag, G, GV)
   if (CS%use_ALE_algorithm) then
     call ALE_register_diags(Time, G, GV, diag, CS%tv%C_p, CS%tracer_Reg, CS%ALE_CSp)
@@ -2305,118 +2306,109 @@ subroutine finish_MOM_initialization(Time, dirs, CS, fluxes)
 end subroutine finish_MOM_initialization
 
 !> Register the diagnostics
-subroutine register_diags(Time, G, GV, CS, ADp, C_p)
+subroutine register_diags(Time, G, GV, CS, IDs, diag, ADp, C_p, missing)
   type(time_type),           intent(in)    :: Time  !< current model time
   type(ocean_grid_type),     intent(inout) :: G     !< ocean grid structu
   type(verticalGrid_type),   intent(inout) :: GV    !< ocean vertical grid structure
   type(MOM_control_struct),  pointer       :: CS    !< control structure set up by initialize_MOM
+  type(MOM_diag_IDs),        intent(inout) :: IDs   !< A structure with the diagnostic IDs.
+  type(diag_ctrl),           intent(inout) :: diag  !< regulates diagnostic output
   type(accel_diag_ptrs),     intent(inout) :: ADp   !< structure pointing to accelerations in momentum equation
   real,                      intent(in)    :: C_p   !< Heat capacity used in conversion to watts
+  real,                      intent(in)    :: missing !< The value to use to fill in missing data
 
-  real :: conv2watt, conv2salt, H_convert
-  character(len=48) :: thickness_units, flux_units, S_flux_units
-  type(diag_ctrl), pointer :: diag
+  real :: H_convert
+  character(len=48) :: thickness_units
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nz = G%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
-  diag => CS%diag
-
   thickness_units = get_thickness_units(GV)
-  flux_units      = get_flux_units(GV)
-  S_flux_units    = get_tr_flux_units(GV, "psu") ! Could change to "kg s-1"?
-  conv2watt       = GV%H_to_kg_m2 * C_p
   if (GV%Boussinesq) then
-    conv2salt = GV%H_to_m ! Could change to GV%H_to_kg_m2 * 0.001?
     H_convert = GV%H_to_m
   else
-    conv2salt = GV%H_to_kg_m2
     H_convert = GV%H_to_kg_m2
   endif
 
-  !Initialize the diagnostics mask arrays.
-  !This has to be done after MOM_initialize_state call.
-  !call diag_masks_set(G, CS%missing)
-
-  CS%id_u = register_diag_field('ocean_model', 'u', diag%axesCuL, Time,              &
+  IDs%id_u = register_diag_field('ocean_model', 'u', diag%axesCuL, Time,              &
       'Zonal velocity', 'm s-1', cmor_field_name='uo', &
       cmor_standard_name='sea_water_x_velocity', cmor_long_name='Sea Water X Velocity')
-  CS%id_v = register_diag_field('ocean_model', 'v', diag%axesCvL, Time,                  &
+  IDs%id_v = register_diag_field('ocean_model', 'v', diag%axesCvL, Time,                  &
       'Meridional velocity', 'm s-1', cmor_field_name='vo', &
       cmor_standard_name='sea_water_y_velocity', cmor_long_name='Sea Water Y Velocity')
-  CS%id_h = register_diag_field('ocean_model', 'h', diag%axesTL, Time, &
+  IDs%id_h = register_diag_field('ocean_model', 'h', diag%axesTL, Time, &
       'Layer Thickness', thickness_units, v_extensive=.true., conversion=H_convert)
 
-  CS%id_volo = register_scalar_field('ocean_model', 'volo', Time, diag,&
+  IDs%id_volo = register_scalar_field('ocean_model', 'volo', Time, diag,&
       long_name='Total volume of liquid ocean', units='m3',            &
       standard_name='sea_water_volume')
-  CS%id_zos = register_diag_field('ocean_model', 'zos', diag%axesT1, Time,&
+  IDs%id_zos = register_diag_field('ocean_model', 'zos', diag%axesT1, Time,&
       standard_name = 'sea_surface_height_above_geoid',                   &
-      long_name= 'Sea surface height above geoid', units='m', missing_value=CS%missing)
-  CS%id_zossq = register_diag_field('ocean_model', 'zossq', diag%axesT1, Time,&
+      long_name= 'Sea surface height above geoid', units='m', missing_value=missing)
+  IDs%id_zossq = register_diag_field('ocean_model', 'zossq', diag%axesT1, Time,&
       standard_name='square_of_sea_surface_height_above_geoid',             &
-      long_name='Square of sea surface height above geoid', units='m2', missing_value=CS%missing)
-  CS%id_ssh = register_diag_field('ocean_model', 'SSH', diag%axesT1, Time, &
-      'Sea Surface Height', 'm', CS%missing)
-  CS%id_ssh_ga = register_scalar_field('ocean_model', 'ssh_ga', Time, diag,&
+      long_name='Square of sea surface height above geoid', units='m2', missing_value=missing)
+  IDs%id_ssh = register_diag_field('ocean_model', 'SSH', diag%axesT1, Time, &
+      'Sea Surface Height', 'm', missing)
+  IDs%id_ssh_ga = register_scalar_field('ocean_model', 'ssh_ga', Time, diag,&
       long_name='Area averaged sea surface height', units='m',            &
       standard_name='area_averaged_sea_surface_height')
-  CS%id_ssh_inst = register_diag_field('ocean_model', 'SSH_inst', diag%axesT1, Time, &
-      'Instantaneous Sea Surface Height', 'm', CS%missing)
-  CS%id_ssu = register_diag_field('ocean_model', 'SSU', diag%axesCu1, Time, &
-      'Sea Surface Zonal Velocity', 'm s-1', CS%missing)
-  CS%id_ssv = register_diag_field('ocean_model', 'SSV', diag%axesCv1, Time, &
-      'Sea Surface Meridional Velocity', 'm s-1', CS%missing)
-  CS%id_speed = register_diag_field('ocean_model', 'speed', diag%axesT1, Time, &
-      'Sea Surface Speed', 'm s-1', CS%missing)
+  IDs%id_ssh_inst = register_diag_field('ocean_model', 'SSH_inst', diag%axesT1, Time, &
+      'Instantaneous Sea Surface Height', 'm', missing)
+  IDs%id_ssu = register_diag_field('ocean_model', 'SSU', diag%axesCu1, Time, &
+      'Sea Surface Zonal Velocity', 'm s-1', missing)
+  IDs%id_ssv = register_diag_field('ocean_model', 'SSV', diag%axesCv1, Time, &
+      'Sea Surface Meridional Velocity', 'm s-1', missing)
+  IDs%id_speed = register_diag_field('ocean_model', 'speed', diag%axesT1, Time, &
+      'Sea Surface Speed', 'm s-1', missing)
 
   if (CS%use_temperature) then
-    CS%id_tob = register_diag_field('ocean_model','tob', diag%axesT1, Time,          &
+    IDs%id_tob = register_diag_field('ocean_model','tob', diag%axesT1, Time,          &
         long_name='Sea Water Potential Temperature at Sea Floor',                    &
         standard_name='sea_water_potential_temperature_at_sea_floor', units='degC')
-    CS%id_sob = register_diag_field('ocean_model','sob',diag%axesT1, Time,           &
+    IDs%id_sob = register_diag_field('ocean_model','sob',diag%axesT1, Time,           &
         long_name='Sea Water Salinity at Sea Floor',                                 &
         standard_name='sea_water_salinity_at_sea_floor', units='psu')
-    CS%id_sst = register_diag_field('ocean_model', 'SST', diag%axesT1, Time,     &
-        'Sea Surface Temperature', 'degC', CS%missing, cmor_field_name='tos', &
+    IDs%id_sst = register_diag_field('ocean_model', 'SST', diag%axesT1, Time,     &
+        'Sea Surface Temperature', 'degC', missing, cmor_field_name='tos', &
         cmor_long_name='Sea Surface Temperature',                                &
         cmor_standard_name='sea_surface_temperature')
-    CS%id_sst_sq = register_diag_field('ocean_model', 'SST_sq', diag%axesT1, Time, &
-        'Sea Surface Temperature Squared', 'degC2', CS%missing, cmor_field_name='tossq', &
+    IDs%id_sst_sq = register_diag_field('ocean_model', 'SST_sq', diag%axesT1, Time, &
+        'Sea Surface Temperature Squared', 'degC2', missing, cmor_field_name='tossq', &
         cmor_long_name='Square of Sea Surface Temperature ',                      &
         cmor_standard_name='square_of_sea_surface_temperature')
-    CS%id_sss = register_diag_field('ocean_model', 'SSS', diag%axesT1, Time, &
-        'Sea Surface Salinity', 'psu', CS%missing, cmor_field_name='sos', &
+    IDs%id_sss = register_diag_field('ocean_model', 'SSS', diag%axesT1, Time, &
+        'Sea Surface Salinity', 'psu', missing, cmor_field_name='sos', &
         cmor_long_name='Sea Surface Salinity',                            &
         cmor_standard_name='sea_surface_salinity')
-    CS%id_sss_sq = register_diag_field('ocean_model', 'SSS_sq', diag%axesT1, Time, &
-        'Sea Surface Salinity Squared', 'psu', CS%missing, cmor_field_name='sossq', &
+    IDs%id_sss_sq = register_diag_field('ocean_model', 'SSS_sq', diag%axesT1, Time, &
+        'Sea Surface Salinity Squared', 'psu', missing, cmor_field_name='sossq', &
         cmor_long_name='Square of Sea Surface Salinity ',                     &
         cmor_standard_name='square_of_sea_surface_salinity')
     if (CS%use_conT_absS) then
-      CS%id_Tpot = register_diag_field('ocean_model', 'temp', diag%axesTL, Time, &
+      IDs%id_Tpot = register_diag_field('ocean_model', 'temp', diag%axesTL, Time, &
           'Potential Temperature', 'degC')
-      CS%id_Sprac = register_diag_field('ocean_model', 'salt', diag%axesTL, Time, &
+      IDs%id_Sprac = register_diag_field('ocean_model', 'salt', diag%axesTL, Time, &
           'Salinity', 'psu')
-      CS%id_sstcon = register_diag_field('ocean_model', 'conSST', diag%axesT1, Time,     &
-          'Sea Surface Conservative Temperature', 'Celsius', CS%missing)
-      CS%id_sssabs = register_diag_field('ocean_model', 'absSSS', diag%axesT1, Time,     &
-          'Sea Surface Absolute Salinity', 'g kg-1', CS%missing)
+      IDs%id_sstcon = register_diag_field('ocean_model', 'conSST', diag%axesT1, Time,     &
+          'Sea Surface Conservative Temperature', 'Celsius', missing)
+      IDs%id_sssabs = register_diag_field('ocean_model', 'absSSS', diag%axesT1, Time,     &
+          'Sea Surface Absolute Salinity', 'g kg-1', missing)
     endif
   endif
 
   if (CS%use_temperature .and. CS%use_frazil) then
-    CS%id_fraz = register_diag_field('ocean_model', 'frazil', diag%axesT1, Time,  &
+    IDs%id_fraz = register_diag_field('ocean_model', 'frazil', diag%axesT1, Time, &
           'Heat from frazil formation', 'W m-2', cmor_field_name='hfsifrazil', &
           cmor_standard_name='heat_flux_into_sea_water_due_to_frazil_ice_formation', &
           cmor_long_name='Heat Flux into Sea Water due to Frazil Ice Formation')
   endif
 
-  CS%id_salt_deficit = register_diag_field('ocean_model', 'salt_deficit', diag%axesT1, Time, &
+  IDs%id_salt_deficit = register_diag_field('ocean_model', 'salt_deficit', diag%axesT1, Time, &
          'Salt sink in ocean due to ice flux', 'psu m-2 s-1')
-  CS%id_Heat_PmE = register_diag_field('ocean_model', 'Heat_PmE', diag%axesT1, Time, &
+  IDs%id_Heat_PmE = register_diag_field('ocean_model', 'Heat_PmE', diag%axesT1, Time, &
          'Heat flux into ocean from mass flux into ocean', 'W m-2')
-  CS%id_intern_heat = register_diag_field('ocean_model', 'internal_heat', diag%axesT1, Time,&
+  IDs%id_intern_heat = register_diag_field('ocean_model', 'internal_heat', diag%axesT1, Time,&
          'Heat flux into ocean from geothermal or other internal sources', 'W m-2')
 
   if (CS%debug_truncations) then
@@ -2429,22 +2421,22 @@ subroutine register_diags(Time, G, GV, CS, ADp, C_p)
   endif
 
   ! Diagnostics related to tracer transport
-  CS%id_uhtr = register_diag_field('ocean_model', 'uhtr', diag%axesCuL, Time, &
+  IDs%id_uhtr = register_diag_field('ocean_model', 'uhtr', diag%axesCuL, Time, &
       'Accumulated zonal thickness fluxes to advect tracers', 'kg', &
       y_cell_method='sum', v_extensive=.true., conversion=H_convert)
-  CS%id_vhtr = register_diag_field('ocean_model', 'vhtr', diag%axesCvL, Time, &
+  IDs%id_vhtr = register_diag_field('ocean_model', 'vhtr', diag%axesCvL, Time, &
       'Accumulated meridional thickness fluxes to advect tracers', 'kg', &
       x_cell_method='sum', v_extensive=.true., conversion=H_convert)
-  CS%id_umo = register_diag_field('ocean_model', 'umo', &
+  IDs%id_umo = register_diag_field('ocean_model', 'umo', &
       diag%axesCuL, Time, 'Ocean Mass X Transport', 'kg s-1', &
       standard_name='ocean_mass_x_transport', y_cell_method='sum', v_extensive=.true.)
-  CS%id_vmo = register_diag_field('ocean_model', 'vmo', &
+  IDs%id_vmo = register_diag_field('ocean_model', 'vmo', &
       diag%axesCvL, Time, 'Ocean Mass Y Transport', 'kg s-1', &
       standard_name='ocean_mass_y_transport', x_cell_method='sum', v_extensive=.true.)
-  CS%id_umo_2d = register_diag_field('ocean_model', 'umo_2d', &
+  IDs%id_umo_2d = register_diag_field('ocean_model', 'umo_2d', &
       diag%axesCu1, Time, 'Ocean Mass X Transport Vertical Sum', 'kg s-1', &
       standard_name='ocean_mass_x_transport_vertical_sum', y_cell_method='sum')
-  CS%id_vmo_2d = register_diag_field('ocean_model', 'vmo_2d', &
+  IDs%id_vmo_2d = register_diag_field('ocean_model', 'vmo_2d', &
       diag%axesCv1, Time, 'Ocean Mass Y Transport Vertical Sum', 'kg s-1', &
       standard_name='ocean_mass_y_transport_vertical_sum', x_cell_method='sum')
 
@@ -2453,24 +2445,24 @@ end subroutine register_diags
 
 !> Initialize diagnostics for the variance decay of temp/salt
 !! across regridding/remapping
-subroutine register_diags_TS_vardec(Time, HI, GV, param_file, CS)
+subroutine register_diags_TS_vardec(Time, HI, GV, param_file, CS, IDs, diag)
   type(time_type),         intent(in) :: Time     !< current model time
   type(hor_index_type),    intent(in) :: HI       !< horizontal index type
   type(verticalGrid_type), intent(in) :: GV       !< ocean vertical grid structure
   type(param_file_type),   intent(in) :: param_file !< parameter file
   type(MOM_control_struct), pointer :: CS   !< control structure for MOM
+  type(MOM_diag_IDs),      intent(inout) :: IDs   !< A structure with the diagnostic IDs.
+  type(diag_ctrl),         intent(inout) :: diag !< regulates diagnostic output
 
   integer :: isd, ied, jsd, jed, nz
   type(vardesc) :: vd_tmp
-  type(diag_ctrl), pointer :: diag
 
-  diag => CS%diag
   isd  = HI%isd  ; ied  = HI%ied  ; jsd  = HI%jsd  ; jed  = HI%jed ; nz = GV%ke
 
   ! variancy decay through ALE operation
-  CS%id_T_vardec = register_diag_field('ocean_model', 'T_vardec', diag%axesTL, Time, &
+  IDs%id_T_vardec = register_diag_field('ocean_model', 'T_vardec', diag%axesTL, Time, &
       'ALE variance decay for temperature', 'degC2 s-1')
-  if (CS%id_T_vardec > 0) then
+  if (IDs%id_T_vardec > 0) then
     call safe_alloc_ptr(CS%T_squared,isd,ied,jsd,jed,nz)
     CS%T_squared(:,:,:) = 0.
 
@@ -2478,9 +2470,9 @@ subroutine register_diags_TS_vardec(Time, HI, GV, param_file, CS)
     call register_tracer(CS%T_squared, vd_tmp, param_file, HI, GV, CS%tracer_reg)
   endif
 
-  CS%id_S_vardec = register_diag_field('ocean_model', 'S_vardec', diag%axesTL, Time, &
+  IDs%id_S_vardec = register_diag_field('ocean_model', 'S_vardec', diag%axesTL, Time, &
       'ALE variance decay for salinity', 'psu2 s-1')
-  if (CS%id_S_vardec > 0) then
+  if (IDs%id_S_vardec > 0) then
     call safe_alloc_ptr(CS%S_squared,isd,ied,jsd,jed,nz)
     CS%S_squared(:,:,:) = 0.
 
@@ -2522,10 +2514,12 @@ end subroutine MOM_timing_init
 
 !> This routine posts diagnostics of the transports, including the subgridscale
 !! contributions.
-subroutine post_transport_diagnostics(G, GV, CS, diag, dt_trans, h, h_pre_dyn, T_pre_dyn, S_pre_dyn)
+subroutine post_transport_diagnostics(G, GV, CS, IDs, diag, dt_trans, h, &
+                                      h_pre_dyn, T_pre_dyn, S_pre_dyn)
   type(ocean_grid_type),    intent(inout) :: G   !< ocean grid structure
   type(verticalGrid_type),  intent(in)    :: GV  !< ocean vertical grid structure
   type(MOM_control_struct), intent(in)    :: CS  !< control structure
+  type(MOM_diag_IDs),       intent(in)    :: IDs !< A structure with the diagnostic IDs.
   type(diag_ctrl),          intent(inout) :: diag !< regulates diagnostic output
   real                    , intent(in)    :: dt_trans !< total time step associated with the transports, in s.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
@@ -2552,58 +2546,59 @@ subroutine post_transport_diagnostics(G, GV, CS, diag, dt_trans, h, h_pre_dyn, T
 
   ! Post mass transports, including SGS
   ! Build the remap grids using the layer thicknesses from before the dynamics
-  if (transport_remap_grid_needed(CS)) &
+  if (transport_remap_grid_needed(IDs)) &
     call diag_update_remap_grids(diag, alt_h = h_pre_dyn, alt_T = T_pre_dyn, alt_S = S_pre_dyn)
 
   H_to_kg_m2_dt = GV%H_to_kg_m2 / dt_trans
-  if (CS%id_umo_2d > 0) then
+  if (IDs%id_umo_2d > 0) then
     umo2d(:,:) = 0.0
     do k=1,nz ; do j=js,je ; do I=is-1,ie
       umo2d(I,j) = umo2d(I,j) + CS%uhtr(I,j,k) * H_to_kg_m2_dt
     enddo ; enddo ; enddo
-    call post_data(CS%id_umo_2d, umo2d, diag)
+    call post_data(IDs%id_umo_2d, umo2d, diag)
   endif
-  if (CS%id_umo > 0) then
+  if (IDs%id_umo > 0) then
     ! Convert to kg/s. Modifying the array for diagnostics is allowed here since it is set to zero immediately below
     do k=1,nz ; do j=js,je ; do I=is-1,ie
       umo(I,j,k) =  CS%uhtr(I,j,k) * H_to_kg_m2_dt
     enddo ; enddo ; enddo
-    call post_data(CS%id_umo, umo, diag, alt_h = h_pre_dyn)
+    call post_data(IDs%id_umo, umo, diag, alt_h = h_pre_dyn)
   endif
-  if (CS%id_vmo_2d > 0) then
+  if (IDs%id_vmo_2d > 0) then
     vmo2d(:,:) = 0.0
     do k=1,nz ; do J=js-1,je ; do i=is,ie
       vmo2d(i,J) = vmo2d(i,J) + CS%vhtr(i,J,k) * H_to_kg_m2_dt
     enddo ; enddo ; enddo
-    call post_data(CS%id_vmo_2d, vmo2d, diag)
+    call post_data(IDs%id_vmo_2d, vmo2d, diag)
   endif
-  if (CS%id_vmo > 0) then
+  if (IDs%id_vmo > 0) then
     ! Convert to kg/s. Modifying the array for diagnostics is allowed here since it is set to zero immediately below
     do k=1,nz ; do J=js-1,je ; do i=is,ie
       vmo(i,J,k) = CS%vhtr(i,J,k) * H_to_kg_m2_dt
     enddo ; enddo ; enddo
-    call post_data(CS%id_vmo, vmo, diag, alt_h = h_pre_dyn)
+    call post_data(IDs%id_vmo, vmo, diag, alt_h = h_pre_dyn)
   endif
 
-  if (CS%id_uhtr > 0) call post_data(CS%id_uhtr, CS%uhtr, diag, alt_h = h_pre_dyn)
-  if (CS%id_vhtr > 0) call post_data(CS%id_vhtr, CS%vhtr, diag, alt_h = h_pre_dyn)
+  if (IDs%id_uhtr > 0) call post_data(IDs%id_uhtr, CS%uhtr, diag, alt_h = h_pre_dyn)
+  if (IDs%id_vhtr > 0) call post_data(IDs%id_vhtr, CS%vhtr, diag, alt_h = h_pre_dyn)
 
 end subroutine post_transport_diagnostics
 
 !> Indicate whether it is necessary to save and recalculate the grid for finding
 !! remapped transports.
-function transport_remap_grid_needed(CS) result(needed)
-  type(MOM_control_struct), intent(in)    :: CS  !< control structure
+function transport_remap_grid_needed(IDs) result(needed)
+  type(MOM_diag_IDs),       intent(in)    :: IDs !< A structure with the diagnostic IDs
   logical :: needed
 
   needed = .false.
-  needed = needed .or. (CS%id_uhtr > 0) .or. (CS%id_vhtr > 0)
-  needed = needed .or. (CS%id_umo > 0)  .or. (CS%id_vmo > 0)
+  needed = needed .or. (IDs%id_uhtr > 0) .or. (IDs%id_vhtr > 0)
+  needed = needed .or. (IDs%id_umo > 0)  .or. (IDs%id_vmo > 0)
 end function transport_remap_grid_needed
 
 !> Post diagnostics of temperatures and salinities, their fluxes, and tendencies.
-subroutine post_TS_diagnostics(CS, G, GV, tv, diag, dt)
+subroutine post_TS_diagnostics(CS, IDs, G, GV, tv, diag, dt)
   type(MOM_control_struct), intent(inout) :: CS  !< control structure
+  type(MOM_diag_IDs),       intent(in)    :: IDs !< A structure with the diagnostic IDs.
   type(ocean_grid_type),    intent(in)    :: G   !< ocean grid structure
   type(verticalGrid_type),  intent(in)    :: GV  !< ocean vertical grid structure
   type(thermo_var_ptrs),    intent(in)    :: tv  !< A structure pointing to various thermodynamic variables
@@ -2619,30 +2614,32 @@ subroutine post_TS_diagnostics(CS, G, GV, tv, diag, dt)
 
   if (.NOT. CS%use_conT_absS) then
     ! Internal T&S variables are potential temperature & practical salinity
-    if (CS%id_tob > 0) call post_data(CS%id_tob, tv%T(:,:,G%ke), diag, mask=G%mask2dT)
-    if (CS%id_sob > 0) call post_data(CS%id_sob, tv%S(:,:,G%ke), diag, mask=G%mask2dT)
+    if (IDs%id_tob > 0) call post_data(IDs%id_tob, tv%T(:,:,G%ke), diag, mask=G%mask2dT)
+    if (IDs%id_sob > 0) call post_data(IDs%id_sob, tv%S(:,:,G%ke), diag, mask=G%mask2dT)
   else
     ! Internal T&S variables are conservative temperature & absolute salinity,
     ! so they need to converted to potential temperature and practical salinity
     ! for some diagnostics using TEOS-10 function calls.
-    if ((CS%id_Tpot > 0) .or. (CS%id_tob > 0) .or. (CS%id_Sprac > 0) .or. (CS%id_sob > 0)) then
+    if ((IDs%id_Tpot > 0) .or. (IDs%id_tob > 0) .or. (IDs%id_Sprac > 0) .or. (IDs%id_sob > 0)) then
       do k=1,nz ; do j=js,je ; do i=is,ie
         pracSal(i,j,k) = gsw_sp_from_sr(tv%S(i,j,k))
         potTemp(i,j,k) = gsw_pt_from_ct(tv%S(i,j,k),tv%T(i,j,k))
       enddo; enddo ; enddo
-      if (CS%id_Tpot > 0) call post_data(CS%id_Tpot, potTemp, diag)
-      if (CS%id_Sprac > 0) call post_data(CS%id_Sprac, pracSal, diag)
-      if (CS%id_tob > 0) call post_data(CS%id_tob, potTemp(:,:,G%ke), diag, mask=G%mask2dT)
-      if (CS%id_sob > 0) call post_data(CS%id_sob, pracSal(:,:,G%ke), diag, mask=G%mask2dT)
+      if (IDs%id_Tpot > 0) call post_data(IDs%id_Tpot, potTemp, diag)
+      if (IDs%id_Sprac > 0) call post_data(IDs%id_Sprac, pracSal, diag)
+      if (IDs%id_tob > 0) call post_data(IDs%id_tob, potTemp(:,:,G%ke), diag, mask=G%mask2dT)
+      if (IDs%id_sob > 0) call post_data(IDs%id_sob, pracSal(:,:,G%ke), diag, mask=G%mask2dT)
     endif
   endif
 
 end subroutine post_TS_diagnostics
 
 !> Calculate and post variance decay diagnostics for temp/salt
-subroutine post_diags_TS_vardec(G, CS, dt)
+subroutine post_diags_TS_vardec(G, CS, IDs, diag, dt)
   type(ocean_grid_type),    intent(in) :: G    !< ocean grid structure
   type(MOM_control_struct), intent(in) :: CS   !< control structure
+  type(MOM_diag_IDs),       intent(in) :: IDs  !< A structure with the diagnostic IDs.
+  type(diag_ctrl),          intent(in) :: diag !< regulates diagnostic output
   real, intent(in) :: dt                       !< total time step
 
   real :: work(SZI_(G),SZJ_(G),SZK_(G))
@@ -2652,24 +2649,25 @@ subroutine post_diags_TS_vardec(G, CS, dt)
 
   Idt = 0.; if (dt/=0.) Idt = 1.0 / dt ! The "if" is in case the diagnostic is called for a zero length interval
 
-  if (CS%id_T_vardec > 0) then
+  if (IDs%id_T_vardec > 0) then
     do k=1,nz ; do j=js,je ; do i=is,ie
       work(i,j,k) = (CS%T_squared(i,j,k) - CS%tv%T(i,j,k)**2) * Idt
     enddo ; enddo ; enddo
-    call post_data(CS%id_T_vardec, work, CS%diag)
+    call post_data(IDs%id_T_vardec, work, diag)
   endif
 
-  if (CS%id_S_vardec > 0) then
+  if (IDs%id_S_vardec > 0) then
     do k=1,nz ; do j=js,je ; do i=is,ie
       work(i,j,k) = (CS%S_squared(i,j,k) - CS%tv%S(i,j,k)**2) * Idt
     enddo ; enddo ; enddo
-    call post_data(CS%id_S_vardec, work, CS%diag)
+    call post_data(IDs%id_S_vardec, work, diag)
   endif
 end subroutine post_diags_TS_vardec
 
 !> This routine posts diagnostics of various integrated quantities.
-subroutine post_integrated_diagnostics(CS, G, GV, diag, dt_int, tv, ssh, fluxes)
+subroutine post_integrated_diagnostics(CS, IDs, G, GV, diag, dt_int, tv, ssh, fluxes)
   type(MOM_control_struct), intent(in) :: CS  !< control structure
+  type(MOM_diag_IDs),       intent(in) :: IDs !< A structure with the diagnostic IDs.
   type(ocean_grid_type),    intent(in) :: G   !< ocean grid structure
   type(verticalGrid_type),  intent(in) :: GV  !< ocean vertical grid structure
   type(diag_ctrl),          intent(in) :: diag  !< regulates diagnostic output
@@ -2699,19 +2697,19 @@ subroutine post_integrated_diagnostics(CS, G, GV, diag, dt_int, tv, ssh, fluxes)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
   ! area mean SSH
-  if (CS%id_ssh_ga > 0) then
+  if (IDs%id_ssh_ga > 0) then
     ssh_ga = global_area_mean(ssh, G)
-    call post_data(CS%id_ssh_ga, ssh_ga, diag)
+    call post_data(IDs%id_ssh_ga, ssh_ga, diag)
   endif
 
   I_time_int = 1.0 / dt_int
-  if (CS%id_ssh > 0) &
-    call post_data(CS%id_ssh, ssh, diag, mask=G%mask2dT)
+  if (IDs%id_ssh > 0) &
+    call post_data(IDs%id_ssh, ssh, diag, mask=G%mask2dT)
 
   ! post the dynamic sea level, zos, and zossq.
   ! zos is ave_ssh with sea ice inverse barometer removed,
   ! and with zero global area mean.
-  if(CS%id_zos > 0 .or. CS%id_zossq > 0) then
+  if(IDs%id_zos > 0 .or. IDs%id_zossq > 0) then
      allocate(zos(G%isd:G%ied,G%jsd:G%jed))
      zos(:,:) = 0.0
      do j=js,je ; do i=is,ie
@@ -2727,80 +2725,81 @@ subroutine post_integrated_diagnostics(CS, G, GV, diag, dt_int, tv, ssh, fluxes)
      do j=js,je ; do i=is,ie
        zos(i,j) = zos(i,j) - G%mask2dT(i,j)*zos_area_mean
      enddo ; enddo
-     if(CS%id_zos > 0) then
-       call post_data(CS%id_zos, zos, diag, mask=G%mask2dT)
+     if(IDs%id_zos > 0) then
+       call post_data(IDs%id_zos, zos, diag, mask=G%mask2dT)
      endif
-     if(CS%id_zossq > 0) then
+     if(IDs%id_zossq > 0) then
        allocate(zossq(G%isd:G%ied,G%jsd:G%jed))
        zossq(:,:) = 0.0
        do j=js,je ; do i=is,ie
          zossq(i,j) = zos(i,j)*zos(i,j)
        enddo ; enddo
-       call post_data(CS%id_zossq, zossq, diag, mask=G%mask2dT)
+       call post_data(IDs%id_zossq, zossq, diag, mask=G%mask2dT)
        deallocate(zossq)
      endif
      deallocate(zos)
   endif
 
   ! post total volume of the liquid ocean
-  if(CS%id_volo > 0) then
+  if(IDs%id_volo > 0) then
     allocate(tmp(G%isd:G%ied,G%jsd:G%jed))
     do j=js,je ; do i=is,ie
       tmp(i,j) = G%mask2dT(i,j)*(ssh(i,j) + G%bathyT(i,j))
     enddo ; enddo
     volo = global_area_integral(tmp, G)
-    call post_data(CS%id_volo, volo, diag)
+    call post_data(IDs%id_volo, volo, diag)
     deallocate(tmp)
   endif
 
   ! post frazil
-  if (ASSOCIATED(tv%frazil) .and. (CS%id_fraz > 0)) then
+  if (ASSOCIATED(tv%frazil) .and. (IDs%id_fraz > 0)) then
     allocate(frazil_ave(G%isd:G%ied,G%jsd:G%jed))
     do j=js,je ; do i=is,ie
       frazil_ave(i,j) = tv%frazil(i,j) * I_time_int
     enddo ; enddo
-    call post_data(CS%id_fraz, frazil_ave, diag, mask=G%mask2dT)
+    call post_data(IDs%id_fraz, frazil_ave, diag, mask=G%mask2dT)
     deallocate(frazil_ave)
   endif
 
   ! post the salt deficit
-  if (ASSOCIATED(tv%salt_deficit) .and. (CS%id_salt_deficit > 0)) then
+  if (ASSOCIATED(tv%salt_deficit) .and. (IDs%id_salt_deficit > 0)) then
     allocate(salt_deficit_ave(G%isd:G%ied,G%jsd:G%jed))
     do j=js,je ; do i=is,ie
       salt_deficit_ave(i,j) = tv%salt_deficit(i,j) * I_time_int
     enddo ; enddo
-    call post_data(CS%id_salt_deficit, salt_deficit_ave, diag, mask=G%mask2dT)
+    call post_data(IDs%id_salt_deficit, salt_deficit_ave, diag, mask=G%mask2dT)
     deallocate(salt_deficit_ave)
   endif
 
   ! post temperature of P-E+R
-  if (ASSOCIATED(tv%TempxPmE) .and. (CS%id_Heat_PmE > 0)) then
+  if (ASSOCIATED(tv%TempxPmE) .and. (IDs%id_Heat_PmE > 0)) then
     allocate(Heat_PmE_ave(G%isd:G%ied,G%jsd:G%jed))
     do j=js,je ; do i=is,ie
       Heat_PmE_ave(i,j) = tv%TempxPmE(i,j) * (tv%C_p * I_time_int)
     enddo ; enddo
-    call post_data(CS%id_Heat_PmE, Heat_PmE_ave, diag, mask=G%mask2dT)
+    call post_data(IDs%id_Heat_PmE, Heat_PmE_ave, diag, mask=G%mask2dT)
     deallocate(Heat_PmE_ave)
   endif
 
   ! post geothermal heating or internal heat source/sinks
-  if (ASSOCIATED(tv%internal_heat) .and. (CS%id_intern_heat > 0)) then
+  if (ASSOCIATED(tv%internal_heat) .and. (IDs%id_intern_heat > 0)) then
     allocate(intern_heat_ave(G%isd:G%ied,G%jsd:G%jed))
     do j=js,je ; do i=is,ie
       intern_heat_ave(i,j) = tv%internal_heat(i,j) * (tv%C_p * I_time_int)
     enddo ; enddo
-    call post_data(CS%id_intern_heat, intern_heat_ave, diag, mask=G%mask2dT)
+    call post_data(IDs%id_intern_heat, intern_heat_ave, diag, mask=G%mask2dT)
     deallocate(intern_heat_ave)
   endif
 
 end subroutine post_integrated_diagnostics
 
 !> This routine posts diagnostics of various ocean surface quantities.
-subroutine post_surface_diagnostics(CS, G, diag, sfc_state)
-  type(MOM_control_struct), intent(in)    :: CS  !< control structure
-  type(ocean_grid_type),    intent(in)    :: G   !< ocean grid structure
-  type(diag_ctrl),          intent(in)    :: diag  !< regulates diagnostic output
-  type(surface),            intent(in)    :: sfc_state !< ocean surface state
+subroutine post_surface_diagnostics(CS, IDs, G, diag, sfc_state)
+  type(MOM_control_struct), intent(in) :: CS  !< control structure
+  type(MOM_diag_IDs),       intent(in) :: IDs !< A structure with the diagnostic IDs.
+  type(ocean_grid_type),    intent(in) :: G   !< ocean grid structure
+  type(diag_ctrl),          intent(in) :: diag  !< regulates diagnostic output
+  type(surface),            intent(in) :: sfc_state !< ocean surface state
 
   real, dimension(SZI_(G),SZJ_(G)) :: &
     potTemp, &  ! TEOS10 potential temperature (deg C)
@@ -2815,12 +2814,12 @@ subroutine post_surface_diagnostics(CS, G, diag, sfc_state)
 
   if (.NOT.CS%use_conT_absS) then
     !Internal T&S variables are assumed to be potential&practical
-    if (CS%id_sst > 0) call post_data(CS%id_sst, sfc_state%SST, diag, mask=G%mask2dT)
-    if (CS%id_sss > 0) call post_data(CS%id_sss, sfc_state%SSS, diag, mask=G%mask2dT)
+    if (IDs%id_sst > 0) call post_data(IDs%id_sst, sfc_state%SST, diag, mask=G%mask2dT)
+    if (IDs%id_sss > 0) call post_data(IDs%id_sss, sfc_state%SSS, diag, mask=G%mask2dT)
   else
     !Internal T&S variables are assumed to be conservative&absolute
-    if (CS%id_sstcon > 0) call post_data(CS%id_sstcon, sfc_state%SST, diag, mask=G%mask2dT)
-    if (CS%id_sssabs > 0) call post_data(CS%id_sssabs, sfc_state%SSS, diag, mask=G%mask2dT)
+    if (IDs%id_sstcon > 0) call post_data(IDs%id_sstcon, sfc_state%SST, diag, mask=G%mask2dT)
+    if (IDs%id_sssabs > 0) call post_data(IDs%id_sssabs, sfc_state%SSS, diag, mask=G%mask2dT)
     !Using TEOS-10 function calls convert T&S diagnostics
     !from conservative temp to potential temp and
     !from absolute salinity to practical salinity
@@ -2828,34 +2827,34 @@ subroutine post_surface_diagnostics(CS, G, diag, sfc_state)
       pracSal(i,j) = gsw_sp_from_sr(sfc_state%SSS(i,j))
       potTemp(i,j) = gsw_pt_from_ct(sfc_state%SSS(i,j),sfc_state%SST(i,j))
     enddo ; enddo
-    if (CS%id_sst > 0) call post_data(CS%id_sst, potTemp, diag, mask=G%mask2dT)
-    if (CS%id_sss > 0) call post_data(CS%id_sss, pracSal, diag, mask=G%mask2dT)
+    if (IDs%id_sst > 0) call post_data(IDs%id_sst, potTemp, diag, mask=G%mask2dT)
+    if (IDs%id_sss > 0) call post_data(IDs%id_sss, pracSal, diag, mask=G%mask2dT)
   endif
 
-  if (CS%id_sst_sq > 0) then
+  if (IDs%id_sst_sq > 0) then
     do j=js,je ; do i=is,ie
       SST_sq(i,j) = sfc_state%SST(i,j)*sfc_state%SST(i,j)
     enddo ; enddo
-    call post_data(CS%id_sst_sq, SST_sq, diag, mask=G%mask2dT)
+    call post_data(IDs%id_sst_sq, SST_sq, diag, mask=G%mask2dT)
   endif
-  if (CS%id_sss_sq > 0) then
+  if (IDs%id_sss_sq > 0) then
     do j=js,je ; do i=is,ie
       SSS_sq(i,j) = sfc_state%SSS(i,j)*sfc_state%SSS(i,j)
     enddo ; enddo
-    call post_data(CS%id_sss_sq, SSS_sq, diag, mask=G%mask2dT)
+    call post_data(IDs%id_sss_sq, SSS_sq, diag, mask=G%mask2dT)
   endif
 
-  if (CS%id_ssu > 0) &
-    call post_data(CS%id_ssu, sfc_state%u, diag, mask=G%mask2dCu)
-  if (CS%id_ssv > 0) &
-    call post_data(CS%id_ssv, sfc_state%v, diag, mask=G%mask2dCv)
+  if (IDs%id_ssu > 0) &
+    call post_data(IDs%id_ssu, sfc_state%u, diag, mask=G%mask2dCu)
+  if (IDs%id_ssv > 0) &
+    call post_data(IDs%id_ssv, sfc_state%v, diag, mask=G%mask2dCv)
 
-  if (CS%id_speed > 0) then
+  if (IDs%id_speed > 0) then
     do j=js,je ; do i=is,ie
       sfc_speed(i,j) = sqrt(0.5*(sfc_state%u(I-1,j)**2 + sfc_state%u(I,j)**2) + &
                             0.5*(sfc_state%v(i,J-1)**2 + sfc_state%v(i,J)**2))
     enddo ; enddo
-    call post_data(CS%id_speed, sfc_speed, diag, mask=G%mask2dT)
+    call post_data(IDs%id_speed, sfc_speed, diag, mask=G%mask2dT)
   endif
 
   call coupler_type_send_data(sfc_state%tr_fields, get_diag_time_end(diag))
@@ -3087,33 +3086,38 @@ end subroutine set_restart_fields
 
 !> This subroutine applies a correction to the sea surface height to compensate
 !! for the atmospheric pressure (the inverse barometer).
-subroutine adjust_ssh_for_p_atm(CS, G, GV, ssh, p_atm)
-  type(MOM_control_struct),          intent(in)    :: CS     !< control structure
+subroutine adjust_ssh_for_p_atm(tv, G, GV, ssh, p_atm, use_EOS)
+  type(thermo_var_ptrs),             intent(in)    :: tv  !< A structure pointing to various thermodynamic variables
   type(ocean_grid_type),             intent(in)    :: G      !< ocean grid structure
   type(verticalGrid_type),           intent(in)    :: GV     !< ocean vertical grid structure
   real, dimension(SZI_(G),SZJ_(G)),  intent(inout) :: ssh    !< time mean surface height (m)
   real, dimension(:,:),    optional, pointer       :: p_atm  !< atmospheric pressure (Pascal)
+  logical,                 optional, intent(in)    :: use_EOS !< If true, calculate the density for
+                                                       !! the SSH correction using the equation of state.
 
   real :: Rho_conv    ! The density used to convert surface pressure to
                       ! a corrected effective SSH, in kg m-3.
   real :: IgR0        ! The SSH conversion factor from Pa to m.
+  logical :: calc_rho
   integer :: i, j, is, ie, js, je
 
   is  = G%isc ; ie  = G%iec ; js  = G%jsc ; je  = G%jec
-  if (ASSOCIATED(p_atm)) then
+  if (present(p_atm)) then ; if (ASSOCIATED(p_atm)) then
+    calc_rho = ASSOCIATED(tv%eqn_of_state)
+    if (present(use_EOS) .and. calc_rho) calc_rho = use_EOS
     ! Correct the output sea surface height for the contribution from the
     ! atmospheric pressure
     do j=js,je ; do i=is,ie
-      if ((ASSOCIATED(CS%tv%eqn_of_state)) .and. (CS%calc_rho_for_sea_lev)) then
-        call calculate_density(CS%tv%T(i,j,1), CS%tv%S(i,j,1), p_atm(i,j)/2.0, &
-                               Rho_conv, CS%tv%eqn_of_state)
+      if (calc_rho) then
+        call calculate_density(tv%T(i,j,1), tv%S(i,j,1), p_atm(i,j)/2.0, &
+                               Rho_conv, tv%eqn_of_state)
       else
         Rho_conv=GV%Rho0
       endif
       IgR0 = 1.0 / (Rho_conv * GV%g_Earth)
       ssh(i,j) = ssh(i,j) + p_atm(i,j) * IgR0
     enddo ; enddo
-  endif
+  endif ; endif
 
 end subroutine adjust_ssh_for_p_atm
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2184,23 +2184,12 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
   call lock_tracer_registry(CS%tracer_Reg)
   call callTree_waypoint("tracer registry now locked (initialize_MOM)")
 
-  ! now register some diagnostics since tracer registry is locked
+  ! now register some diagnostics since the tracer registry is now locked
   call register_diags(Time, G, GV, CS%IDs, CS%diag, CS%tv%C_p, CS%missing, CS%tv)
-  call register_tracer_diagnostics(CS%tracer_Reg, CS%h, Time, diag, G, GV)
+  call register_tracer_diagnostics(CS%tracer_Reg, CS%h, Time, diag, G, GV, &
+                                   CS%diag_to_Z_CSp)
   if (CS%use_ALE_algorithm) then
     call ALE_register_diags(Time, G, GV, diag, CS%tv%C_p, CS%tracer_Reg, CS%ALE_CSp)
-  endif
-
-  ! If need a diagnostic field, then would have been allocated in register_diags.
-  if (CS%use_temperature) then
-    call register_Z_tracer(CS%tv%T, "temp", "Potential Temperature", "degC", Time,   &
-                      G, CS%diag_to_Z_CSp, cmor_field_name="thetao",                 &
-                      cmor_standard_name="sea_water_potential_temperature",          &
-                      cmor_long_name ="Sea Water Potential Temperature")
-    call register_Z_tracer(CS%tv%S, "salt", "Salinity", "psu", Time,               &
-                      G, CS%diag_to_Z_CSp, cmor_field_name="so",                   &
-                      cmor_standard_name="sea_water_salinity",                     &
-                      cmor_long_name ="Sea Water Salinity")
   endif
 
   ! This subroutine initializes any tracer packages.

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -42,6 +42,10 @@ type, public :: surface
     ocean_salt, &  !< The total salt content of the ocean in kgSalt m-2.
     salt_deficit   !< The salt needed to maintain the ocean column at a minimum
                    !! salinity of 0.01 PSU over the call to step_MOM, in kgSalt m-2.
+  logical :: T_is_conT = .false. !< If true, the temperature variable SST is
+                         !! actually the conservative temperature, in degC.
+  logical :: S_is_absS = .false. !< If true, the salinity variable SSS is
+                         !! actually the absolute salinity, in g/kg.
   real, pointer, dimension(:,:) :: &
     taux_shelf => NULL(), &  !< The zonal and meridional stresses on the ocean
     tauy_shelf => NULL(), &  !< under shelves, in Pa.
@@ -81,6 +85,10 @@ type, public :: thermo_var_ptrs
   real :: C_p            !<   The heat capacity of seawater, in J K-1 kg-1.
                          !! When conservative temperature is used, this is
                          !! constant and exactly 3991.86795711963 J K kg-1.
+  logical :: T_is_conT = .false. !< If true, the temperature variable tv%T is
+                         !! actually the conservative temperature, in degC.
+  logical :: S_is_absS = .false. !< If true, the salinity variable tv%S is
+                         !! actually the absolute salinity, in g/kg.
   real, pointer, dimension(:,:) :: &
 !  These arrays are accumulated fluxes for communication with other components.
     frazil => NULL(), &  !<   The energy needed to heat the ocean column to the

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -2,9 +2,8 @@ module DOME_tracer
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z, only : diag_to_Z_CS
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
@@ -34,10 +33,6 @@ public DOME_tracer_column_physics, DOME_tracer_surface_state, DOME_tracer_end
 ! ntr is the number of tracers in this module.
 integer, parameter :: ntr = 11
 
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 type, public :: DOME_tracer_CS ; private
   logical :: coupled_tracers = .false.  ! These tracers are not offered to the
                                         ! coupler.
@@ -47,11 +42,6 @@ type, public :: DOME_tracer_CS ; private
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
-  type(p3d), dimension(NTR) :: &
-    tr_adx, &! Tracer zonal advective fluxes in g m-3 m3 s-1.
-    tr_ady, &! Tracer meridional advective fluxes in g m-3 m3 s-1.
-    tr_dfx, &! Tracer zonal diffusive fluxes in g m-3 m3 s-1.
-    tr_dfy   ! Tracer meridional diffusive fluxes in g m-3 m3 s-1.
   real :: land_val(NTR) = -1.0 ! The value of tr used where land is masked out.
   logical :: use_sponge    ! If true, sponges may be applied somewhere in the domain.
 
@@ -61,8 +51,6 @@ type, public :: DOME_tracer_CS ; private
 
   type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
                              ! timing of diagnostic output.
-  integer, dimension(NTR) :: id_tracer = -1, id_tr_adx = -1, id_tr_ady = -1
-  integer, dimension(NTR) :: id_tr_dfx = -1, id_tr_dfy = -1
 
   type(vardesc) :: tr_desc(NTR)
 end type DOME_tracer_CS
@@ -85,6 +73,8 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "DOME_tracer" ! This module's name.
+  character(len=48) :: flux_units ! The units for tracer fluxes, usually
+                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   character(len=200) :: inputdir
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_DOME_tracer
@@ -123,6 +113,8 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     else ; write(name,'("tr_D",I2.2)') m ; endif
     write(longname,'("Concentration of DOME Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
+    if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
+    else ; flux_units = "kg s-1" ; endif
 
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.
@@ -131,7 +123,8 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     call register_restart_field(tr_ptr, CS%tr_desc(m), .true., restart_CS)
     ! Register the tracer for horizontal advection & diffusion.
     call register_tracer(tr_ptr, CS%tr_desc(m), param_file, HI, GV, tr_Reg, &
-                         tr_desc_ptr=CS%tr_desc(m))
+                         tr_desc_ptr=CS%tr_desc(m), registry_diags=.true., &
+                         flux_units=flux_units)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will
@@ -304,43 +297,6 @@ subroutine initialize_DOME_tracer(restart, day, G, GV, h, diag, OBC, CS, &
     enddo
   endif
 
-  ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
-  else ; flux_units = "kg s-1" ; endif
-
-  do m=1,NTR
-    ! Register the tracer for the restart file.
-    call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                       caller="initialize_DOME_tracer")
-    CS%id_tracer(m) = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-        day, trim(longname) , trim(units))
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isd,ied,JsdB,JedB,nz)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,isd,ied,JsdB,JedB,nz)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p, CS%tr_dfx(m)%p, CS%tr_dfy(m)%p)
-
-    call register_Z_tracer(CS%tr(:,:,:,m), trim(name), longname, units, &
-                           day, G, diag_to_Z_CSp)
-  enddo
-
 end subroutine initialize_DOME_tracer
 
 !> This subroutine applies diapycnal diffusion and any other column
@@ -395,19 +351,6 @@ subroutine DOME_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV,
     enddo
   endif
 
-  do m=1,NTR
-    if (CS%id_tracer(m)>0) &
-      call post_data(CS%id_tracer(m),CS%tr(:,:,:,m),CS%diag)
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
-  enddo
-
 end subroutine DOME_tracer_column_physics
 
 !> This subroutine extracts the surface fields from this tracer package that
@@ -450,13 +393,6 @@ subroutine DOME_tracer_end(CS)
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
-    do m=1,NTR
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
-
     deallocate(CS)
   endif
 end subroutine DOME_tracer_end

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -10,14 +10,14 @@ module ISOMIP_tracer
 
 !********+*********+*********+*********+*********+*********+*********+**
 !*                                                                     *
-!*  By Robert Hallberg, 2002                                           *
-!*  Adapted to the ISOMIP test case by Gustavo Marques, May 2016       *            !*                                                                     *
+!*  Original sample tracer package by Robert Hallberg, 2002            *
+!*  Adapted to the ISOMIP test case by Gustavo Marques, May 2016       *
+!*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
 
-use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z, only : diag_to_Z_CS
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
@@ -49,10 +49,6 @@ public ISOMIP_tracer_column_physics, ISOMIP_tracer_surface_state, ISOMIP_tracer_
 !< ntr is the number of tracers in this module.
 integer, parameter :: ntr = 1
 
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 !> tracer control structure
 type, public :: ISOMIP_tracer_CS ; private
   logical :: coupled_tracers = .false.  !< These tracers are not offered to the
@@ -63,11 +59,6 @@ type, public :: ISOMIP_tracer_CS ; private
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this
                                            !< subroutine, in g m-3?
-  type(p3d), dimension(NTR) :: &
-    tr_adx, &!< Tracer zonal advective fluxes in g m-3 m3 s-1.
-    tr_ady, &!< Tracer meridional advective fluxes in g m-3 m3 s-1.
-    tr_dfx, &!< Tracer zonal diffusive fluxes in g m-3 m3 s-1.
-    tr_dfy   !< Tracer meridional diffusive fluxes in g m-3 m3 s-1.
   real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out.
   logical :: use_sponge    ! If true, sponges may be applied somewhere in the domain.
 
@@ -77,8 +68,6 @@ type, public :: ISOMIP_tracer_CS ; private
 
   type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the
                              !< timing of diagnostic output.
-  integer, dimension(NTR) :: id_tracer = -1, id_tr_adx = -1, id_tr_ady = -1
-  integer, dimension(NTR) :: id_tr_dfx = -1, id_tr_dfy = -1
 
   type(vardesc) :: tr_desc(NTR)
 end type ISOMIP_tracer_CS
@@ -101,6 +90,8 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, &
 #include "version_variable.h"
   character(len=40)  :: mdl = "ISOMIP_tracer" ! This module's name.
   character(len=200) :: inputdir
+  character(len=48)  :: flux_units ! The units for tracer fluxes, usually
+                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_ISOMIP_tracer
   integer :: isd, ied, jsd, jed, nz, m
@@ -138,6 +129,8 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, &
     else ; write(name,'("tr_D",I2.2)') m ; endif
     write(longname,'("Concentration of ISOMIP Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
+    if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
+    else ; flux_units = "kg s-1" ; endif
 
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.
@@ -146,7 +139,8 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, &
     call register_restart_field(tr_ptr, CS%tr_desc(m), .true., restart_CS)
     ! Register the tracer for horizontal advection & diffusion.
     call register_tracer(tr_ptr, CS%tr_desc(m), param_file, HI, GV, tr_Reg, &
-                         tr_desc_ptr=CS%tr_desc(m))
+                         tr_desc_ptr=CS%tr_desc(m), registry_diags=.true., &
+                         flux_units=flux_units)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will
@@ -255,43 +249,6 @@ subroutine initialize_ISOMIP_tracer(restart, day, G, GV, h, diag, OBC, CS, &
 !    deallocate(temp)
 !  endif
 
-  ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
-  else ; flux_units = "kg s-1" ; endif
-
-  do m=1,NTR
-    ! Register the tracer for the restart file.
-    call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                       caller="initialize_ISOMIP_tracer")
-    CS%id_tracer(m) = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-        day, trim(longname) , trim(units))
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isd,ied,JsdB,JedB,nz)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,isd,ied,JsdB,JedB,nz)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p, CS%tr_dfx(m)%p, CS%tr_dfy(m)%p)
-
-    call register_Z_tracer(CS%tr(:,:,:,m), trim(name), longname, units, &
-                           day, G, diag_to_Z_CSp)
-  enddo
-
 end subroutine initialize_ISOMIP_tracer
 
 !> This subroutine applies diapycnal diffusion and any other column
@@ -371,19 +328,6 @@ subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, G
     enddo
   endif
 
-  do m=1,NTR
-    if (CS%id_tracer(m)>0) &
-      call post_data(CS%id_tracer(m),CS%tr(:,:,:,m),CS%diag)
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
-  enddo
-
 end subroutine ISOMIP_tracer_column_physics
 
 !> This subroutine extracts the surface fields from this tracer package that
@@ -425,13 +369,6 @@ subroutine ISOMIP_tracer_end(CS)
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
-    do m=1,NTR
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
-
     deallocate(CS)
   endif
 end subroutine ISOMIP_tracer_end

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -36,9 +36,9 @@ module MOM_OCMIP2_CFC
 !*     A small fragment of the horizontal grid is shown below:         *
 !*                                                                     *
 !*    j+1  x ^ x ^ x   At x:  q                                        *
-!*    j+1  > o > o >   At ^:  v, tr_ady, tr_dfy                        *
-!*    j    x ^ x ^ x   At >:  u, tr_adx, tr_dfx                        *
-!*    j    > o > o >   At o:  h, tr, CFC11, CFC12                      *
+!*    j+1  > o > o >   At ^:  v,                                       *
+!*    j    x ^ x ^ x   At >:  u                                        *
+!*    j    > o > o >   At o:  h, CFC11, CFC12                          *
 !*    j-1  x ^ x ^ x                                                   *
 !*        i-1  i  i+1  At x & ^:                                       *
 !*           i  i+1    At > & o:                                       *
@@ -48,7 +48,7 @@ module MOM_OCMIP2_CFC
 !********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z, only : diag_to_Z_CS
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
@@ -203,8 +203,6 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   CS%CFC11_name = "CFC11" ; CS%CFC12_name = "CFC12"
   CS%CFC11_desc = var_desc(CS%CFC11_name,"mol m-3","CFC-11 Concentration", caller=mdl)
   CS%CFC12_desc = var_desc(CS%CFC12_name,"mol m-3","CFC-12 Concentration", caller=mdl)
-
-  ! This needs to be changed if the units of tracer are changed above.
   if (GV%Boussinesq) then ; flux_units = "mol s-1"
   else ; flux_units = "mol m-3 kg s-1" ; endif
 
@@ -220,14 +218,14 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! Register CFC11 for horizontal advection & diffusion.
   call register_tracer(tr_ptr, CS%CFC11_desc, param_file, HI, GV, tr_Reg, &
                        tr_desc_ptr=CS%CFC11_desc, registry_diags=.true., &
-                       flux_units=flux_units, diag_form=1)
+                       flux_units=flux_units)
   ! Do the same for CFC12
   tr_ptr => CS%CFC12
   call register_restart_field(tr_ptr, CS%CFC12_desc, &
                               .not.CS%tracers_may_reinit, restart_CS)
   call register_tracer(tr_ptr, CS%CFC12_desc, param_file, HI, GV, tr_Reg, &
                        tr_desc_ptr=CS%CFC12_desc, registry_diags=.true., &
-                       flux_units=flux_units, diag_form=1)
+                       flux_units=flux_units)
 
   ! Set and read the various empirical coefficients.
 

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -47,7 +47,6 @@ module MOM_OCMIP2_CFC
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
-use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl
 use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
@@ -61,7 +60,7 @@ use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_C
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
@@ -83,10 +82,6 @@ public OCMIP2_CFC_stock, OCMIP2_CFC_end
 ! NTR is the number of tracers in this module.
 integer, parameter :: NTR = 2
 
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 type, public :: OCMIP2_CFC_CS ; private
   character(len=200) :: IC_file ! The file in which the CFC initial values can
                     ! be found, or an empty string for internal initilaization.
@@ -106,11 +101,6 @@ type, public :: OCMIP2_CFC_CS ; private
   real :: e1_11, e2_11, e3_11          ! More coefficients in the calculation of
   real :: e1_12, e2_12, e3_12          ! the CFC11 and CFC12 solubilities, in
                                        ! units of PSU-1, PSU-1 K-1, PSU-1 K-2.
-  type(p3d), dimension(NTR) :: &
-    tr_adx, &       ! Tracer zonal advective fluxes in mol s-1.
-    tr_ady, &       ! Tracer meridional advective fluxes in mol s-1.
-    tr_dfx, &       ! Tracer zonal diffusive fluxes in mol s-1.
-    tr_dfy          ! Tracer meridional diffusive fluxes in mol s-1.
   real :: CFC11_IC_val = 0.0    ! The initial value assigned to CFC11.
   real :: CFC12_IC_val = 0.0    ! The initial value assigned to CFC12.
   real :: CFC11_land_val = -1.0 ! The values of CFC11 and CFC12 used where
@@ -127,9 +117,6 @@ type, public :: OCMIP2_CFC_CS ; private
   type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
                              ! timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
-  integer :: id_CFC11, id_CFC12
-  integer, dimension(NTR) :: id_tr_adx = -1, id_tr_ady = -1
-  integer, dimension(NTR) :: id_tr_dfx = -1, id_tr_dfy = -1
 
   ! The following vardesc types contain a package of metadata about each tracer.
   type(vardesc) :: CFC11_desc, CFC12_desc
@@ -164,6 +151,7 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   real :: a11_dflt(4), a12_dflt(4) ! Default values of the various coefficients
   real :: d11_dflt(4), d12_dflt(4) ! In the expressions for the solubility and
   real :: e11_dflt(3), e12_dflt(3) ! Schmidt numbers.
+  character(len=48) :: flux_units ! The units for tracer fluxes.
   logical :: register_OCMIP2_CFC
   integer :: isd, ied, jsd, jed, nz, m
 
@@ -216,6 +204,10 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   CS%CFC11_desc = var_desc(CS%CFC11_name,"mol m-3","CFC-11 Concentration", caller=mdl)
   CS%CFC12_desc = var_desc(CS%CFC12_name,"mol m-3","CFC-12 Concentration", caller=mdl)
 
+  ! This needs to be changed if the units of tracer are changed above.
+  if (GV%Boussinesq) then ; flux_units = "mol s-1"
+  else ; flux_units = "mol m-3 kg s-1" ; endif
+
   allocate(CS%CFC11(isd:ied,jsd:jed,nz)) ; CS%CFC11(:,:,:) = 0.0
   allocate(CS%CFC12(isd:ied,jsd:jed,nz)) ; CS%CFC12(:,:,:) = 0.0
 
@@ -227,13 +219,15 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
                               .not.CS%tracers_may_reinit, restart_CS)
   ! Register CFC11 for horizontal advection & diffusion.
   call register_tracer(tr_ptr, CS%CFC11_desc, param_file, HI, GV, tr_Reg, &
-                       tr_desc_ptr=CS%CFC11_desc)
+                       tr_desc_ptr=CS%CFC11_desc, registry_diags=.true., &
+                       flux_units=flux_units, diag_form=1)
   ! Do the same for CFC12
   tr_ptr => CS%CFC12
   call register_restart_field(tr_ptr, CS%CFC12_desc, &
                               .not.CS%tracers_may_reinit, restart_CS)
   call register_tracer(tr_ptr, CS%CFC12_desc, param_file, HI, GV, tr_Reg, &
-                       tr_desc_ptr=CS%CFC12_desc)
+                       tr_desc_ptr=CS%CFC12_desc, registry_diags=.true., &
+                       flux_units=flux_units, diag_form=1)
 
   ! Set and read the various empirical coefficients.
 
@@ -406,17 +400,8 @@ subroutine initialize_OCMIP2_CFC(restart, day, G, GV, h, diag, OBC, CS, &
 !  (in/out)  diag_to_Z_Csp - A pointer to the control structure for diagnostics
 !                            in depth space.
   logical :: from_file = .false.
-  character(len=16) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for tracer fluxes.
-  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, m
-  integer :: IsdB, IedB, JsdB, JedB
 
   if (.not.associated(CS)) return
-  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
-  IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
   CS%Time => day
   CS%diag => diag
@@ -438,60 +423,8 @@ subroutine initialize_OCMIP2_CFC(restart, day, G, GV, h, diag, OBC, CS, &
   !  call add_tracer_OBC_values(trim(CS%CFC12_desc%name), CS%tr_Reg, 0.0)
   endif
 
-
-  ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "mol s-1"
-  else ; flux_units = "mol m-3 kg s-1" ; endif
-
-  do m=1,NTR
-    ! Register the tracer advective and diffusive fluxes for potential
-    ! diagnostic output.
-    if (m==1) then
-      ! Register CFC11 for potential diagnostic output.
-      call query_vardesc(CS%CFC11_desc, name, units=units, longname=longname, &
-                         caller="initialize_OCMIP2_CFC")
-      CS%id_CFC11 = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-          day, trim(longname) , trim(units))
-      call register_Z_tracer(CS%CFC11, trim(name), longname, units, &
-                             day, G, diag_to_Z_CSp)
-    elseif (m==2) then
-      ! Register CFC12 for potential diagnostic output.
-      call query_vardesc(CS%CFC12_desc, name, units=units, longname=longname, &
-                         caller="initialize_OCMIP2_CFC")
-      CS%id_CFC12 = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-          day, trim(longname) , trim(units))
-      call register_Z_tracer(CS%CFC12, trim(name), longname, units, &
-                             day, G, diag_to_Z_CSp)
-    else
-      call MOM_error(FATAL,"initialize_OCMIP2_CFC is only set up to work"//&
-                           "with NTR <= 2.")
-    endif
-
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isd,ied,JsdB,JedB,nz)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,isd,ied,JsdB,JedB,nz)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p,CS%tr_dfx(m)%p,CS%tr_dfy(m)%p)
-  enddo
-
 end subroutine initialize_OCMIP2_CFC
+
 !>This subroutine initializes a tracer array.
 subroutine init_tracer_CFC(h, tr, name, land_val, IC_val, G, CS)
   type(ocean_grid_type),                    intent(in)  :: G    !< The ocean's grid structure
@@ -634,19 +567,7 @@ subroutine OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS
     call tracer_vertdiff(h_old, ea, eb, dt, CFC12, G, GV, sfc_flux=CFC12_flux)
   endif
 
-  ! Write out any desired diagnostics.
-  if (CS%id_CFC11>0) call post_data(CS%id_CFC11, CFC11, CS%diag)
-  if (CS%id_CFC12>0) call post_data(CS%id_CFC12, CFC12, CS%diag)
-  do m=1,NTR
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
-  enddo
+  ! Write out any desired diagnostics from tracer sources & sinks here.
 
 end subroutine OCMIP2_CFC_column_physics
 
@@ -798,12 +719,6 @@ subroutine OCMIP2_CFC_end(CS)
   if (associated(CS)) then
     if (associated(CS%CFC11)) deallocate(CS%CFC11)
     if (associated(CS%CFC12)) deallocate(CS%CFC12)
-    do m=1,NTR
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
 
     deallocate(CS)
   endif

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -36,9 +36,8 @@ module advection_test_tracer
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
-use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z, only : diag_to_Z_CS
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
@@ -69,12 +68,8 @@ public advection_test_tracer_column_physics, advection_test_stock
 ! ntr is the number of tracers in this module.
 integer, parameter :: NTR = 11
 
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 type, public :: advection_test_tracer_CS ; private
-  integer :: ntr = NTR                     ! Number of tracers in this module
+  integer :: ntr = NTR                  ! Number of tracers in this module
   logical :: coupled_tracers = .false.  ! These tracers are not offered to the
                                         ! coupler.
   character(len=200) :: tracer_IC_file ! The full path to the IC file, or " "
@@ -83,11 +78,6 @@ type, public :: advection_test_tracer_CS ; private
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
-  type(p3d), dimension(NTR) :: &
-    tr_adx, &! Tracer zonal advective fluxes in g m-3 m3 s-1.
-    tr_ady, &! Tracer meridional advective fluxes in g m-3 m3 s-1.
-    tr_dfx, &! Tracer zonal diffusive fluxes in g m-3 m3 s-1.
-    tr_dfy   ! Tracer meridional diffusive fluxes in g m-3 m3 s-1.
   real :: land_val(NTR) = -1.0 ! The value of tr used where land is masked out.
   logical :: use_sponge    ! If true, sponges may be applied somewhere in the domain.
   logical :: tracers_may_reinit
@@ -102,9 +92,6 @@ type, public :: advection_test_tracer_CS ; private
   type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
                              ! timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
-
-  integer, dimension(NTR) :: id_tracer = -1, id_tr_adx = -1, id_tr_ady = -1
-  integer, dimension(NTR) :: id_tr_dfx = -1, id_tr_dfy = -1
 
   type(vardesc) :: tr_desc(NTR)
 end type advection_test_tracer_CS
@@ -134,6 +121,8 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
 #include "version_variable.h"
   character(len=40)  :: mdl = "advection_test_tracer" ! This module's name.
   character(len=200) :: inputdir
+  character(len=48)  :: flux_units ! The units for tracer fluxes, usually
+                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_advection_test_tracer
   integer :: isd, ied, jsd, jed, nz, m
@@ -187,6 +176,9 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
     else ; write(name,'("tr",I2.2)') m ; endif
     write(longname,'("Concentration of Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
+    if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
+    else ; flux_units = "kg s-1" ; endif
+
 
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.
@@ -196,7 +188,8 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
         .not. CS%tracers_may_reinit, restart_CS)
     ! Register the tracer for horizontal advection & diffusion.
     call register_tracer(tr_ptr, CS%tr_desc(m), param_file, HI, GV, tr_Reg, &
-                         tr_desc_ptr=CS%tr_desc(m))
+                         tr_desc_ptr=CS%tr_desc(m), registry_diags=.true., &
+                         flux_units=flux_units)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will
@@ -312,43 +305,6 @@ subroutine initialize_advection_test_tracer(restart, day, G, GV, h,diag, OBC, CS
   enddo
 
 
-  ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
-  else ; flux_units = "kg s-1" ; endif
-
-  do m=1,NTR
-    ! Register the tracer for the restart file.
-    call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                       caller="initialize_advection_test_tracer")
-    CS%id_tracer(m) = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-        day, trim(longname) , trim(units))
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isd,ied,JsdB,JedB,nz)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,isd,ied,JsdB,JedB,nz)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p,CS%tr_dfx(m)%p,CS%tr_dfy(m)%p)
-
-    call register_Z_tracer(CS%tr(:,:,:,m), trim(name), longname, units, &
-                           day, G, diag_to_Z_CSp)
-  enddo
-
 end subroutine initialize_advection_test_tracer
 
 
@@ -407,18 +363,6 @@ subroutine advection_test_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, 
     enddo
   endif
 
-  do m=1,NTR
-    if (CS%id_tracer(m)>0) &
-      call post_data(CS%id_tracer(m),CS%tr(:,:,:,m),CS%diag)
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
-  enddo
 end subroutine advection_test_tracer_column_physics
 
 !> This subroutine extracts the surface fields from this tracer package that
@@ -513,13 +457,6 @@ subroutine advection_test_tracer_end(CS)
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
-    do m=1,NTR
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
-
     deallocate(CS)
   endif
 end subroutine advection_test_tracer_end

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -3,9 +3,8 @@ module boundary_impulse_tracer
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z, only : diag_to_Z_CS
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
@@ -38,10 +37,6 @@ public boundary_impulse_stock, boundary_impulse_tracer_end
 ! NTR_MAX is the maximum number of tracers in this module.
 integer, parameter :: NTR_MAX = 1
 
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 type, public :: boundary_impulse_tracer_CS ; private
   integer :: ntr=NTR_MAX    ! The number of tracers that are actually used.
   logical :: coupled_tracers = .false.  ! These tracers are not offered to the
@@ -50,20 +45,11 @@ type, public :: boundary_impulse_tracer_CS ; private
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
-  type(p3d), dimension(NTR_MAX) :: &
-    tr_adx, &! Tracer zonal advective fluxes in g m-3 m3 s-1.An Error Has Occurred
-
-
-    tr_ady, &! Tracer meridional advective fluxes in g m-3 m3 s-1.
-    tr_dfx, &! Tracer zonal diffusive fluxes in g m-3 m3 s-1.
-    tr_dfy   ! Tracer meridional diffusive fluxes in g m-3 m3 s-1.
   logical :: tracers_may_reinit  ! If true, boundary_impulse can be initialized if
                                  ! not found in restart file
   integer, dimension(NTR_MAX) :: &
-    ind_tr, &  ! Indices returned by aof_set_coupler_flux if it is used and the
+    ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
                ! surface tracer concentrations are to be provided to the coupler.
-    id_tracer = -1, id_tr_adx = -1, id_tr_ady = -1, &
-    id_tr_dfx = -1, id_tr_dfy = -1
 
   integer :: nkml ! Number of layers in mixed layer
   real, dimension(NTR_MAX)  :: land_val = -1.0
@@ -106,6 +92,8 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=3)   :: name_tag ! String for creating identifying boundary_impulse
+  character(len=48)  :: flux_units ! The units for tracer fluxes, usually
+                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()
   real, pointer :: rem_time_ptr => NULL()
   logical :: register_boundary_impulse_tracer
@@ -139,8 +127,11 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
   do m=1,CS%ntr
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.
-    CS%tr_desc(m) = var_desc(trim("boundary_impulse"), "kg", &
+    CS%tr_desc(m) = var_desc(trim("boundary_impulse"), "kg kg-1", &
         "Boundary impulse tracer", caller=mdl)
+    if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
+    else ; flux_units = "kg s-1" ; endif
+
     tr_ptr => CS%tr(:,:,:,m)
     call query_vardesc(CS%tr_desc(m), name=var_name, caller="register_boundary_impulse_tracer")
     ! Register the tracer for the restart file.
@@ -148,7 +139,8 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
                                 .not. CS%tracers_may_reinit, restart_CS)
     ! Register the tracer for horizontal advection & diffusion.
     call register_tracer(tr_ptr, CS%tr_desc(m), param_file, HI, GV, tr_Reg, &
-                         tr_desc_ptr=CS%tr_desc(m))
+                         tr_desc_ptr=CS%tr_desc(m), registry_diags=.true., &
+                         flux_units=flux_units)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will
@@ -239,43 +231,6 @@ subroutine initialize_boundary_impulse_tracer(restart, day, G, GV, h, diag, OBC,
   ! enddo
   endif
 
-  ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "g salt/(m^2 s)"
-  else ; flux_units = "g salt/(m^2 s)" ; endif
-
-  do m=1,CS%ntr
-    ! Register the tracer for the restart file.
-    call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                       caller="initialize_boundary_impulse_tracer")
-    CS%id_tracer(m) = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-        day, trim(longname) , trim(units))
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isd,ied,JsdB,JedB,nz)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,isd,ied,JsdB,JedB,nz)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p,CS%tr_dfx(m)%p,CS%tr_dfy(m)%p)
-
-    call register_Z_tracer(CS%tr(:,:,:,m), trim(name), longname, units, &
-                           day, G, diag_to_Z_CSp)
-  enddo
-
 end subroutine initialize_boundary_impulse_tracer
 
 ! Apply source or sink at boundary and do vertical diffusion
@@ -357,20 +312,6 @@ subroutine boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, 
       enddo ; enddo ; enddo
     endif
 
-  enddo
-
-  do m=1,1
-    if (CS%id_tracer(m)>0) then
-      call post_data(CS%id_tracer(m), CS%tr(:,:,:,m), CS%diag)
-    endif ! CS%id_tracer(m)>0
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
   enddo
 
 end subroutine boundary_impulse_tracer_column_physics
@@ -470,13 +411,6 @@ subroutine boundary_impulse_tracer_end(CS)
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
-    do m=1,CS%ntr
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
-
     deallocate(CS)
   endif
 end subroutine boundary_impulse_tracer_end

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -2,9 +2,8 @@ module regional_dyes
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_diag_mediator,      only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator,      only : diag_ctrl
-use MOM_diag_to_Z,          only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z,          only : diag_to_Z_CS
 use MOM_error_handler,      only : MOM_error, FATAL, WARNING
 use MOM_file_parser,        only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,       only : forcing
@@ -34,10 +33,6 @@ public dye_tracer_column_physics, dye_tracer_surface_state
 public dye_stock, regional_dyes_end
 
 
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 type, public :: dye_tracer_CS ; private
   integer :: ntr    ! The number of tracers that are actually used.
   logical :: coupled_tracers = .false.  ! These tracers are not offered to the
@@ -51,17 +46,10 @@ type, public :: dye_tracer_CS ; private
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
-  type(p3d), allocatable, dimension(:) :: &
-    tr_adx, &! Tracer zonal advective fluxes in g m-3 m3 s-1.
-    tr_ady, &! Tracer meridional advective fluxes in g m-3 m3 s-1.
-    tr_dfx, &! Tracer zonal diffusive fluxes in g m-3 m3 s-1.
-    tr_dfy   ! Tracer meridional diffusive fluxes in g m-3 m3 s-1.
 
   integer, allocatable, dimension(:) :: &
-    ind_tr, &  ! Indices returned by aof_set_coupler_flux if it is used and the
+    ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
                ! surface tracer concentrations are to be provided to the coupler.
-    id_tracer, id_tr_adx, id_tr_ady, &
-    id_tr_dfx, id_tr_dfy
 
   type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
                              ! timing of diagnostic output.
@@ -115,23 +103,8 @@ function register_dye_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
            CS%dye_source_maxlat(CS%ntr), &
            CS%dye_source_mindepth(CS%ntr), &
            CS%dye_source_maxdepth(CS%ntr))
-  allocate(CS%tr_adx(CS%ntr), &
-           CS%tr_ady(CS%ntr), &
-           CS%tr_dfx(CS%ntr), &
-           CS%tr_dfy(CS%ntr))
-  allocate(CS%ind_tr(CS%ntr), &
-           CS%id_tracer(CS%ntr), &
-           CS%id_tr_adx(CS%ntr), &
-           CS%id_tr_ady(CS%ntr), &
-           CS%id_tr_dfx(CS%ntr), &
-           CS%id_tr_dfy(CS%ntr))
+  allocate(CS%ind_tr(CS%ntr))
   allocate(CS%tr_desc(CS%ntr))
-
-  CS%id_tracer(:) = -1
-  CS%id_tr_adx(:) = -1
-  CS%id_tr_ady(:) = -1
-  CS%id_tr_dfx(:) = -1
-  CS%id_tr_dfy(:) = -1
 
   CS%dye_source_minlon(:) = -1.e30
   call get_param(param_file, mdl, "DYE_SOURCE_MINLON", CS%dye_source_minlon, &
@@ -181,8 +154,6 @@ function register_dye_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     CS%tr_desc(m) = var_desc(trim(var_name), "conc", trim(desc_name), caller=mdl)
   enddo
 
-
-
   allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr)) ; CS%tr(:,:,:,:) = 0.0
 
   do m=1,CS%ntr
@@ -196,7 +167,7 @@ function register_dye_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                                 .not.CS%tracers_may_reinit, restart_CS)
     ! Register the tracer for horizontal advection & diffusion.
     call register_tracer(tr_ptr, CS%tr_desc(m), param_file, HI, GV, tr_Reg, &
-                         tr_desc_ptr=CS%tr_desc(m))
+                         tr_desc_ptr=CS%tr_desc(m), registry_diags=.true.)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will
@@ -267,39 +238,6 @@ subroutine initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_C
         enddo
       endif
     enddo; enddo
-  enddo
-
-  do m=1,CS%ntr
-    ! Register the tracer for the restart file.
-    call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                       caller="initialize_dye_tracer")
-    CS%id_tracer(m) = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-        day, trim(longname) , trim(units))
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,G%IsdB,G%IedB,G%jsd,G%jed,GV%ke)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,G%isd,G%ied,G%JsdB,G%JedB,GV%ke)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,G%IsdB,G%IedB,G%jsd,G%jed,GV%ke)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,G%isd,G%ied,G%JsdB,G%JedB,GV%ke)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p,CS%tr_dfx(m)%p,CS%tr_dfy(m)%p)
-
-    call register_Z_tracer(CS%tr(:,:,:,m), trim(name), longname, units, &
-                           day, G, diag_to_Z_CSp)
   enddo
 
 end subroutine initialize_dye_tracer
@@ -379,20 +317,6 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS
         enddo
       endif
     enddo; enddo
-  enddo
-
-
-  do m=1,CS%ntr
-    if (CS%id_tracer(m)>0) &
-      call post_data(CS%id_tracer(m),CS%tr(:,:,:,m),CS%diag)
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
   enddo
 
 end subroutine dye_tracer_column_physics
@@ -484,13 +408,6 @@ subroutine regional_dyes_end(CS)
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
-    do m=1,CS%ntr
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
-
     deallocate(CS)
   endif
 end subroutine regional_dyes_end

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -2,9 +2,8 @@ module dyed_obc_tracer
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_diag_mediator,      only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator,      only : diag_ctrl
-use MOM_diag_to_Z,          only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z,          only : diag_to_Z_CS
 use MOM_error_handler,      only : MOM_error, FATAL, WARNING
 use MOM_file_parser,        only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,       only : forcing
@@ -30,10 +29,6 @@ implicit none ; private
 public register_dyed_obc_tracer, initialize_dyed_obc_tracer
 public dyed_obc_tracer_column_physics, dyed_obc_tracer_end
 
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 type, public :: dyed_obc_tracer_CS ; private
   integer :: ntr    ! The number of tracers that are actually used.
   logical :: coupled_tracers = .false.  ! These tracers are not offered to the
@@ -44,17 +39,10 @@ type, public :: dyed_obc_tracer_CS ; private
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
-  type(p3d), allocatable, dimension(:) :: &
-    tr_adx, &! Tracer zonal advective fluxes in g m-3 m3 s-1.
-    tr_ady, &! Tracer meridional advective fluxes in g m-3 m3 s-1.
-    tr_dfx, &! Tracer zonal diffusive fluxes in g m-3 m3 s-1.
-    tr_dfy   ! Tracer meridional diffusive fluxes in g m-3 m3 s-1.
 
   integer, allocatable, dimension(:) :: &
-    ind_tr, &  ! Indices returned by aof_set_coupler_flux if it is used and the
+    ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
                ! surface tracer concentrations are to be provided to the coupler.
-    id_tracer, id_tr_adx, id_tr_ady, &
-    id_tr_dfx, id_tr_dfy
 
   type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
                              ! timing of diagnostic output.
@@ -84,6 +72,8 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=200) :: inputdir
   character(len=48)  :: var_name ! The variable's name.
   character(len=48)  :: desc_name ! The variable's descriptor.
+  character(len=48)  :: flux_units ! The units for tracer fluxes, usually
+                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_dyed_obc_tracer
   integer :: isd, ied, jsd, jed, nz, m
@@ -101,23 +91,8 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   call get_param(param_file, mdl, "NUM_DYE_TRACERS", CS%ntr, &
                  "The number of dye tracers in this run. Each tracer \n"//&
                  "should have a separate boundary segment.", default=0)
-  allocate(CS%tr_adx(CS%ntr), &
-           CS%tr_ady(CS%ntr), &
-           CS%tr_dfx(CS%ntr), &
-           CS%tr_dfy(CS%ntr))
-  allocate(CS%ind_tr(CS%ntr), &
-           CS%id_tracer(CS%ntr), &
-           CS%id_tr_adx(CS%ntr), &
-           CS%id_tr_ady(CS%ntr), &
-           CS%id_tr_dfx(CS%ntr), &
-           CS%id_tr_dfy(CS%ntr))
+  allocate(CS%ind_tr(CS%ntr))
   allocate(CS%tr_desc(CS%ntr))
-
-  CS%id_tracer(:) = -1
-  CS%id_tr_adx(:) = -1
-  CS%id_tr_ady(:) = -1
-  CS%id_tr_dfx(:) = -1
-  CS%id_tr_dfy(:) = -1
 
   call get_param(param_file, mdl, "dyed_obc_TRACER_IC_FILE", CS%tracer_IC_file, &
                  "The name of a file from which to read the initial \n"//&
@@ -137,6 +112,8 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     write(name,'("dye_",I2.2)') m
     write(longname,'("Concentration of dyed_obc Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
+    if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
+    else ; flux_units = "kg s-1" ; endif
 
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.
@@ -145,7 +122,8 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     call register_restart_field(tr_ptr, CS%tr_desc(m), .true., restart_CS)
     ! Register the tracer for horizontal advection & diffusion.
     call register_tracer(tr_ptr, CS%tr_desc(m), param_file, HI, GV, tr_Reg, &
-                         tr_desc_ptr=CS%tr_desc(m))
+                         tr_desc_ptr=CS%tr_desc(m), registry_diags=.true., &
+                         flux_units=flux_units)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will
@@ -225,43 +203,6 @@ subroutine initialize_dyed_obc_tracer(restart, day, G, GV, h, diag, OBC, CS, &
     endif
   endif ! restart
 
-  ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
-  else ; flux_units = "kg s-1" ; endif
-
-  do m=1,CS%ntr
-    ! Register the tracer for the restart file.
-    call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                       caller="initialize_dyed_obc_tracer")
-    CS%id_tracer(m) = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-        day, trim(longname) , trim(units))
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isd,ied,JsdB,JedB,nz)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,isd,ied,JsdB,JedB,nz)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p, CS%tr_dfx(m)%p, CS%tr_dfy(m)%p)
-
-    call register_Z_tracer(CS%tr(:,:,:,m), trim(name), longname, units, &
-                           day, G, diag_to_Z_CSp)
-  enddo
-
 end subroutine initialize_dyed_obc_tracer
 
 !> This subroutine applies diapycnal diffusion and any other column
@@ -317,19 +258,6 @@ subroutine dyed_obc_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G,
     enddo
   endif
 
-  do m=1,CS%ntr
-    if (CS%id_tracer(m)>0) &
-      call post_data(CS%id_tracer(m),CS%tr(:,:,:,m),CS%diag)
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
-  enddo
-
 end subroutine dyed_obc_tracer_column_physics
 
 !> Clean up memory allocations, if any.
@@ -339,12 +267,6 @@ subroutine dyed_obc_tracer_end(CS)
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
-    do m=1,CS%ntr
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
 
     deallocate(CS)
   endif

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -37,9 +37,8 @@ module oil_tracer
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
-use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z, only : diag_to_Z_CS
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
@@ -72,10 +71,6 @@ public oil_stock, oil_tracer_end
 ! NTR_MAX is the maximum number of tracers in this module.
 integer, parameter :: NTR_MAX = 20
 
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 type, public :: oil_tracer_CS ; private
   integer :: ntr    ! The number of tracers that are actually used.
   logical :: coupled_tracers = .false.  ! These tracers are not offered to the
@@ -94,11 +89,6 @@ type, public :: oil_tracer_CS ; private
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
-  type(p3d), dimension(NTR_MAX) :: &
-    tr_adx, &! Tracer zonal advective fluxes in g m-3 m3 s-1.
-    tr_ady, &! Tracer meridional advective fluxes in g m-3 m3 s-1.
-    tr_dfx, &! Tracer zonal diffusive fluxes in g m-3 m3 s-1.
-    tr_dfy   ! Tracer meridional diffusive fluxes in g m-3 m3 s-1.
   real, dimension(NTR_MAX) :: &
     IC_val = 0.0, &    ! The (uniform) initial condition value.
     young_val = 0.0, & ! The value assigned to tr at the surface.
@@ -112,10 +102,8 @@ type, public :: oil_tracer_CS ; private
                            ! initialization code if they are not found in the
                            ! restart files.
   integer, dimension(NTR_MAX) :: &
-    ind_tr, &  ! Indices returned by aof_set_coupler_flux if it is used and the
+    ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
                ! surface tracer concentrations are to be provided to the coupler.
-    id_tracer = -1, id_tr_adx = -1, id_tr_ady = -1, &
-    id_tr_dfx = -1, id_tr_dfy = -1
 
   type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
                              ! timing of diagnostic output.
@@ -151,6 +139,8 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=3)   :: name_tag ! String for creating identifying oils
+  character(len=48) :: flux_units ! The units for tracer fluxes, here
+                            ! kg(oil) s-1 or kg(oil) m-3 kg(water) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_oil_tracer
   integer :: isd, ied, jsd, jed, nz, m, i, j
@@ -215,7 +205,7 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     if (CS%oil_source_k(m)/=0) then
       write(name_tag(1:3),'("_",I2.2)') m
       CS%ntr = CS%ntr + 1
-      CS%tr_desc(m) = var_desc("oil"//trim(name_tag), "kg/m3", "Oil Tracer", caller=mdl)
+      CS%tr_desc(m) = var_desc("oil"//trim(name_tag), "kg m-3", "Oil Tracer", caller=mdl)
       CS%IC_val(m) = 0.0
       if (CS%oil_decay_days(m)>0.) then
         CS%oil_decay_rate(m)=1./(86400.0*CS%oil_decay_days(m))
@@ -225,6 +215,10 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     endif
   enddo
   call log_param(param_file, mdl, "OIL_DECAY_RATE", CS%oil_decay_rate(1:CS%ntr))
+
+  ! This needs to be changed if the units of tracer are changed above.
+  if (GV%Boussinesq) then ; flux_units = "kg s-1"
+  else ; flux_units = "kg m-3 kg s-1" ; endif
 
   allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr)) ; CS%tr(:,:,:,:) = 0.0
 
@@ -238,7 +232,8 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                                 .not.CS%oil_may_reinit, restart_CS)
     ! Register the tracer for horizontal advection & diffusion.
     call register_tracer(tr_ptr, CS%tr_desc(m), param_file, HI, GV, tr_Reg, &
-                         tr_desc_ptr=CS%tr_desc(m))
+                         tr_desc_ptr=CS%tr_desc(m), registry_diags=.true., &
+                         flux_units=flux_units)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will
@@ -360,43 +355,6 @@ subroutine initialize_oil_tracer(restart, day, G, GV, h, diag, OBC, CS, &
   ! enddo
   endif
 
-  ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "yr m3 s-1"
-  else ; flux_units = "yr kg s-1" ; endif
-
-  do m=1,CS%ntr
-    ! Register the tracer for the restart file.
-    call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                       caller="initialize_oil_tracer")
-    CS%id_tracer(m) = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-        day, trim(longname) , trim(units))
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isd,ied,JsdB,JedB,nz)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,isd,ied,JsdB,JedB,nz)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p,CS%tr_dfx(m)%p,CS%tr_dfy(m)%p)
-
-    call register_Z_tracer(CS%tr(:,:,:,m), trim(name), longname, units, &
-                           day, G, diag_to_Z_CSp)
-  enddo
-
 end subroutine initialize_oil_tracer
 
 subroutine oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS, tv, &
@@ -506,19 +464,6 @@ subroutine oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS
     enddo
   endif
 
-  do m=1,CS%ntr
-    if (CS%id_tracer(m)>0) &
-      call post_data(CS%id_tracer(m),CS%tr(:,:,:,m),CS%diag)
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
-  enddo
-
 end subroutine oil_tracer_column_physics
 
 function oil_stock(h, stocks, G, GV, CS, names, units, stock_index)
@@ -614,13 +559,6 @@ subroutine oil_tracer_end(CS)
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
-    do m=1,CS%ntr
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
-
     deallocate(CS)
   endif
 end subroutine oil_tracer_end

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -38,7 +38,7 @@ module pseudo_salt_tracer
 use MOM_debugging,     only : hchksum
 use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z, only : diag_to_Z_CS
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
@@ -68,43 +68,22 @@ public register_pseudo_salt_tracer, initialize_pseudo_salt_tracer
 public pseudo_salt_tracer_column_physics, pseudo_salt_tracer_surface_state
 public pseudo_salt_stock, pseudo_salt_tracer_end
 
-! NTR_MAX is the maximum number of tracers in this module.
-integer, parameter :: NTR_MAX = 1
-
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 type, public :: pseudo_salt_tracer_CS ; private
-  integer :: ntr=NTR_MAX    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false.  ! These tracers are not offered to the
-                                        ! coupler.
   type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
-  real, pointer :: diff(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
-  type(p3d), dimension(NTR_MAX) :: &
-    tr_adx, &! Tracer zonal advective fluxes in g m-3 m3 s-1.An Error Has Occurred
-
-
-    tr_ady, &! Tracer meridional advective fluxes in g m-3 m3 s-1.
-    tr_dfx, &! Tracer zonal diffusive fluxes in g m-3 m3 s-1.
-    tr_dfy   ! Tracer meridional diffusive fluxes in g m-3 m3 s-1.
+  real, pointer :: ps(:,:,:) => NULL()   ! The array of pseudo-salt tracer used in this
+                                         ! subroutine, in psu
+  real, pointer :: diff(:,:,:) => NULL() ! The difference between the pseudo-salt
+                                         ! tracer and the real salt, in psu.
   logical :: pseudo_salt_may_reinit = .true. ! Hard coding since this should not matter
-  integer, dimension(NTR_MAX) :: &
-    ind_tr, &  ! Indices returned by aof_set_coupler_flux if it is used and the
-               ! surface tracer concentrations are to be provided to the coupler.
-    id_tracer = -1, id_tr_adx = -1, id_tr_ady = -1, &
-    id_tr_dfx = -1, id_tr_dfy = -1
-  real, dimension(NTR_MAX)  :: land_val = -1.0
+
+  integer :: id_psd = -1
 
   type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
                              ! timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
-  type(vardesc) :: tr_desc(NTR_MAX)
+  type(vardesc) :: tr_desc
 end type pseudo_salt_tracer_CS
 
 contains
@@ -136,7 +115,7 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=3)   :: name_tag ! String for creating identifying pseudo_salt
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_pseudo_salt_tracer
-  integer :: isd, ied, jsd, jed, nz, m, i, j
+  integer :: isd, ied, jsd, jed, nz, i, j
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
@@ -149,31 +128,20 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
 
-  CS%ntr = NTR_MAX
-  allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr)) ; CS%tr(:,:,:,:) = 0.0
-  allocate(CS%diff(isd:ied,jsd:jed,nz,CS%ntr)) ; CS%diff(:,:,:,:) = 0.0
+  allocate(CS%ps(isd:ied,jsd:jed,nz)) ; CS%ps(:,:,:) = 0.0
+  allocate(CS%diff(isd:ied,jsd:jed,nz)) ; CS%diff(:,:,:) = 0.0
 
-  do m=1,CS%ntr
-    ! This is needed to force the compiler not to do a copy in the registration
-    ! calls.  Curses on the designers and implementers of Fortran90.
-    CS%tr_desc(m) = var_desc(trim("pseudo_salt_diff"), "kg", &
-        "Difference between pseudo salt passive tracer and salt tracer", caller=mdl)
-    tr_ptr => CS%tr(:,:,:,m)
-    call query_vardesc(CS%tr_desc(m), name=var_name, caller="register_pseudo_salt_tracer")
-    ! Register the tracer for the restart file.
-    call register_restart_field(tr_ptr, CS%tr_desc(m), &
-                                .not. CS%pseudo_salt_may_reinit, restart_CS)
-    ! Register the tracer for horizontal advection & diffusion.
-    call register_tracer(tr_ptr, CS%tr_desc(m), param_file, HI, GV, tr_Reg, &
-                         tr_desc_ptr=CS%tr_desc(m))
+  CS%tr_desc = var_desc(trim("pseudo_salt"), "psu", &
+                     "Pseudo salt passive tracer", caller=mdl)
 
-    !   Set coupled_tracers to be true (hard-coded above) to provide the surface
-    ! values to the coupler (if any).  This is meta-code and its arguments will
-    ! currently (deliberately) give fatal errors if it is used.
-    if (CS%coupled_tracers) &
-      CS%ind_tr(m) = aof_set_coupler_flux(trim(var_name)//'_flux', &
-          flux_type=' ', implementation=' ', caller="register_pseudo_salt_tracer")
-  enddo
+  tr_ptr => CS%ps(:,:,:)
+  call query_vardesc(CS%tr_desc, name=var_name, caller="register_pseudo_salt_tracer")
+  ! Register the tracer for the restart file.
+  call register_restart_field(tr_ptr, CS%tr_desc, &
+                              .not. CS%pseudo_salt_may_reinit, restart_CS)
+  ! Register the tracer for horizontal advection & diffusion.
+  call register_tracer(tr_ptr, CS%tr_desc, param_file, HI, GV, tr_Reg, &
+                       tr_desc_ptr=CS%tr_desc, registry_diags=.true.)
 
   CS%tr_Reg => tr_Reg
   CS%restart_CSp => restart_CS
@@ -194,8 +162,7 @@ subroutine initialize_pseudo_salt_tracer(restart, day, G, GV, h, diag, OBC, CS, 
   type(sponge_CS),                    pointer    :: sponge_CSp
   type(diag_to_Z_CS),                 pointer    :: diag_to_Z_CSp
   type(thermo_var_ptrs),              intent(in) :: tv   !< A structure pointing to various thermodynamic variables
-!   This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
-! and it sets up the tracer output.
+!   This subroutine initializes the tracer fields in CS%ps(:,:,:).
 
 ! Arguments: restart - .true. if the fields have already been read from
 !                     a restart file.
@@ -218,11 +185,12 @@ subroutine initialize_pseudo_salt_tracer(restart, day, G, GV, h, diag, OBC, CS, 
   character(len=48) :: flux_units ! The units for age tracer fluxes, either
                                 ! years m3 s-1 or years kg s-1.
   logical :: OK
-  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, m
+  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB
 
   if (.not.associated(CS)) return
-  if (CS%ntr < 1) return
+  if (.not.associated(CS%diff)) return
+
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -231,60 +199,21 @@ subroutine initialize_pseudo_salt_tracer(restart, day, G, GV, h, diag, OBC, CS, 
   CS%diag => diag
   name = "pseudo_salt"
 
-  do m=1,CS%ntr
-    call query_vardesc(CS%tr_desc(m), name=name, caller="initialize_pseudo_salt_tracer")
-    if ((.not.restart) .or. (.not. &
-        query_initialized(CS%tr(:,:,:,m), name, CS%restart_CSp))) then
-      do k=1,nz ; do j=jsd,jed ; do i=isd,ied
-        CS%tr(i,j,k,m) = tv%S(i,j,k)
-      enddo ; enddo ; enddo
-    endif
-  enddo ! Tracer loop
+  call query_vardesc(CS%tr_desc, name=name, caller="initialize_pseudo_salt_tracer")
+  if ((.not.restart) .or. (.not.query_initialized(CS%ps, name, CS%restart_CSp))) then
+    do k=1,nz ; do j=jsd,jed ; do i=isd,ied
+      CS%ps(i,j,k) = tv%S(i,j,k)
+    enddo ; enddo ; enddo
+  endif
 
   if (associated(OBC)) then
   ! All tracers but the first have 0 concentration in their inflows. As this
   ! is the default value, the following calls are unnecessary.
-  ! do m=1,CS%ntr
-  !  call add_tracer_OBC_values(trim(CS%tr_desc(m)%name), CS%tr_Reg, 0.0)
-  ! enddo
+  !  call add_tracer_OBC_values(trim(CS%tr_desc%name), CS%tr_Reg, 0.0)
   endif
 
-  ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "g salt/(m^2 s)"
-  else ; flux_units = "g salt/(m^2 s)" ; endif
-
-  do m=1,CS%ntr
-    ! Register the tracer for the restart file.
-    call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                       caller="initialize_pseudo_salt_tracer")
-    CS%id_tracer(m) = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-        day, trim(longname) , trim(units))
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isd,ied,JsdB,JedB,nz)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,isd,ied,JsdB,JedB,nz)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p,CS%tr_dfx(m)%p,CS%tr_dfy(m)%p)
-
-    call register_Z_tracer(CS%tr(:,:,:,m), trim(name), longname, units, &
-                           day, G, diag_to_Z_CSp)
-  enddo
+  CS%id_psd = register_diag_field("ocean_model", "pseudo_salt_diff", CS%diag%axesTL, &
+        day, "Difference between pseudo salt passive tracer and salt tracer", "psu")
 
 end subroutine initialize_pseudo_salt_tracer
 
@@ -333,7 +262,7 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
   real :: Isecs_per_year = 1.0 / (365.0*86400.0)
   real :: year, h_total, scale, htot, Ih_limit
   integer :: secs, days
-  integer :: i, j, k, is, ie, js, je, nz, m, k_max
+  integer :: i, j, k, is, ie, js, je, nz, k_max
   real, allocatable :: local_tr(:,:,:)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
   real, dimension(:,:), pointer :: net_salt
@@ -342,11 +271,11 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
   net_salt=>fluxes%netSalt
 
   if (.not.associated(CS)) return
-  if (CS%ntr < 1) return
+  if (.not.associated(CS%diff)) return
 
   if (debug) then
     call hchksum(tv%S,"salt pre pseudo-salt vertdiff", G%HI)
-    call hchksum(CS%tr(:,:,:,1),"pseudo_salt pre pseudo-salt vertdiff", G%HI)
+    call hchksum(CS%ps,"pseudo_salt pre pseudo-salt vertdiff", G%HI)
   endif
 
   ! This uses applyTracerBoundaryFluxesInOut, usually in ALE mode
@@ -354,40 +283,23 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
     do k=1,nz ;do j=js,je ; do i=is,ie
       h_work(i,j,k) = h_old(i,j,k)
     enddo ; enddo ; enddo;
-    call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,1), dt, fluxes, h_work, &
+    call applyTracerBoundaryFluxesInOut(G, GV, CS%ps, dt, fluxes, h_work, &
       evap_CFL_limit, minimum_forcing_depth, out_flux_optional=net_salt)
-    call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,1), G, GV)
+    call tracer_vertdiff(h_work, ea, eb, dt, CS%ps, G, GV)
   else
-    call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,1), G, GV)
+    call tracer_vertdiff(h_old, ea, eb, dt, CS%ps, G, GV)
   endif
 
   do k=1,nz ; do j=js,je ; do i=is,ie
-    CS%diff(i,j,k,1) = CS%tr(i,j,k,1)-tv%S(i,j,k)
+    CS%diff(i,j,k) = CS%ps(i,j,k)-tv%S(i,j,k)
   enddo ; enddo ; enddo
 
   if(debug) then
     call hchksum(tv%S,"salt post pseudo-salt vertdiff", G%HI)
-    call hchksum(CS%tr(:,:,:,1),"pseudo_salt post pseudo-salt vertdiff", G%HI)
+    call hchksum(CS%ps,"pseudo_salt post pseudo-salt vertdiff", G%HI)
   endif
 
-  allocate(local_tr(G%isd:G%ied,G%jsd:G%jed,nz))
-  do m=1,1
-    if (CS%id_tracer(m)>0) then
-      do k=1,nz ; do j=js,je ; do i=is,ie
-        local_tr(i,j,k) = CS%tr(i,j,k,m)-tv%S(i,j,k)
-      enddo ; enddo ; enddo
-      call post_data(CS%id_tracer(m),local_tr,CS%diag)
-    endif ! CS%id_tracer(m)>0
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
-  enddo
-  deallocate(local_tr)
+  if (CS%id_psd>0) call post_data(CS%id_psd, CS%diff, CS%diag)
 
 end subroutine pseudo_salt_tracer_column_physics
 
@@ -417,12 +329,12 @@ function pseudo_salt_stock(h, stocks, G, GV, CS, names, units, stock_index)
 !  (in,opt)  stock_index - the coded index of a specific stock being sought.
 ! Return value: the number of stocks calculated here.
 
-  integer :: i, j, k, is, ie, js, je, nz, m
+  integer :: i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   pseudo_salt_stock = 0
   if (.not.associated(CS)) return
-  if (CS%ntr < 1) return
+  if (.not.associated(CS%diff)) return
 
   if (present(stock_index)) then ; if (stock_index > 0) then
     ! Check whether this stock is available from this routine.
@@ -431,18 +343,16 @@ function pseudo_salt_stock(h, stocks, G, GV, CS, names, units, stock_index)
     return
   endif ; endif
 
-  do m=1,1
-    call query_vardesc(CS%tr_desc(m), name=names(m), units=units(m), caller="pseudo_salt_stock")
-    units(m) = trim(units(m))//" kg"
-    stocks(m) = 0.0
-    do k=1,nz ; do j=js,je ; do i=is,ie
-      stocks(m) = stocks(m) + CS%diff(i,j,k,m) * &
-                           (G%mask2dT(i,j) * G%areaT(i,j) * h(i,j,k))
-    enddo ; enddo ; enddo
-    stocks(m) = GV%H_to_kg_m2 * stocks(m)
-  enddo
+  call query_vardesc(CS%tr_desc, name=names(1), units=units(1), caller="pseudo_salt_stock")
+  units(1) = trim(units(1))//" kg"
+  stocks(1) = 0.0
+  do k=1,nz ; do j=js,je ; do i=is,ie
+    stocks(1) = stocks(1) + CS%diff(i,j,k) * &
+                         (G%mask2dT(i,j) * G%areaT(i,j) * h(i,j,k))
+  enddo ; enddo ; enddo
+  stocks(1) = GV%H_to_kg_m2 * stocks(1)
 
-  pseudo_salt_stock = CS%ntr
+  pseudo_salt_stock = 1
 
 end function pseudo_salt_stock
 
@@ -467,15 +377,7 @@ subroutine pseudo_salt_tracer_surface_state(state, h, G, CS)
 
   if (.not.associated(CS)) return
 
-  if (CS%coupled_tracers) then
-    do m=1,CS%ntr
-      !   This call loads the surface values into the appropriate array in the
-      ! coupler-type structure.
-      call coupler_type_set_data(CS%tr(:,:,1,m), CS%ind_tr(m), ind_csurf, &
-                   state%tr_fields, idim=(/isd, is, ie, ied/), &
-                   jdim=(/jsd, js, je, jed/) )
-    enddo
-  endif
+  ! By design, this tracer package does not return any surface states.
 
 end subroutine pseudo_salt_tracer_surface_state
 
@@ -484,15 +386,8 @@ subroutine pseudo_salt_tracer_end(CS)
   integer :: m
 
   if (associated(CS)) then
-    if (associated(CS%tr)) deallocate(CS%tr)
-    if (associated(CS%tr)) deallocate(CS%diff)
-    do m=1,CS%ntr
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
-
+    if (associated(CS%ps)) deallocate(CS%ps)
+    if (associated(CS%diff)) deallocate(CS%diff)
     deallocate(CS)
   endif
 end subroutine pseudo_salt_tracer_end

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -33,9 +33,8 @@ module USER_tracer_example
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
-use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : register_Z_tracer, diag_to_Z_CS
+use MOM_diag_to_Z, only : diag_to_Z_CS
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
@@ -64,10 +63,6 @@ public tracer_column_physics, USER_tracer_surface_state, USER_tracer_example_end
 ! NTR is the number of tracers in this module.
 integer, parameter :: NTR = 1
 
-type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
-end type p3d
-
 type, public :: USER_tracer_example_CS ; private
   logical :: coupled_tracers = .false.  ! These tracers are not offered to the
                                         ! coupler.
@@ -77,11 +72,6 @@ type, public :: USER_tracer_example_CS ; private
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
-  type(p3d), dimension(NTR) :: &
-    tr_adx, &! Tracer zonal advective fluxes in g m-3 m3 s-1.
-    tr_ady, &! Tracer meridional advective fluxes in g m-3 m3 s-1.
-    tr_dfx, &! Tracer zonal diffusive fluxes in g m-3 m3 s-1.
-    tr_dfy   ! Tracer meridional diffusive fluxes in g m-3 m3 s-1.
   real :: land_val(NTR) = -1.0 ! The value of tr used where land is masked out.
   logical :: use_sponge    ! If true, sponges may be applied somewhere in the domain.
 
@@ -91,8 +81,6 @@ type, public :: USER_tracer_example_CS ; private
 
   type(diag_ctrl), pointer :: diag ! A pointer to a structure of shareable
                              ! ocean diagnostic fields and control variables.
-  integer, dimension(NTR) :: id_tracer = -1, id_tr_adx = -1, id_tr_ady = -1
-  integer, dimension(NTR) :: id_tr_dfx = -1, id_tr_dfy = -1
 
   type(vardesc) :: tr_desc(NTR)
 end type USER_tracer_example_CS
@@ -118,6 +106,8 @@ function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS
 #include "version_variable.h"
   character(len=40)  :: mdl = "tracer_example" ! This module's name.
   character(len=200) :: inputdir
+  character(len=48) :: flux_units ! The units for tracer fluxes, usually
+                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: USER_register_tracer_example
   integer :: isd, ied, jsd, jed, nz, m
@@ -155,6 +145,10 @@ function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS
     write(longname,'("Concentration of Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
 
+    ! This needs to be changed if the units of tracer are changed above.
+    if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
+    else ; flux_units = "kg s-1" ; endif
+
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.
     tr_ptr => CS%tr(:,:,:,m)
@@ -162,7 +156,8 @@ function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS
     call register_restart_field(tr_ptr, CS%tr_desc(m), .true., restart_CS)
     ! Register the tracer for horizontal advection & diffusion.
     call register_tracer(tr_ptr, CS%tr_desc(m), param_file, HI, GV, tr_Reg, &
-                         tr_desc_ptr=CS%tr_desc(m))
+                         tr_desc_ptr=CS%tr_desc(m), registry_diags=.true., &
+                         flux_units=flux_units)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will
@@ -309,43 +304,6 @@ subroutine USER_initialize_tracer(restart, day, G, GV, h, diag, OBC, CS, &
     enddo
   endif
 
-  ! This needs to be changed if the units of tracer are changed above.
-  if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"
-  else ; flux_units = "kg s-1" ; endif
-
-  do m=1,NTR
-    ! Register the tracer for the restart file.
-    call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                       caller="USER_initialize_tracer")
-    CS%id_tracer(m) = register_diag_field("ocean_model", trim(name), CS%diag%axesTL, &
-        day, trim(longname) , trim(units))
-    CS%id_tr_adx(m) = register_diag_field("ocean_model", trim(name)//"_adx", &
-        CS%diag%axesCuL, day, trim(longname)//" advective zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_ady(m) = register_diag_field("ocean_model", trim(name)//"_ady", &
-        CS%diag%axesCvL, day, trim(longname)//" advective meridional flux" , &
-        trim(flux_units))
-    CS%id_tr_dfx(m) = register_diag_field("ocean_model", trim(name)//"_dfx", &
-        CS%diag%axesCuL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    CS%id_tr_dfy(m) = register_diag_field("ocean_model", trim(name)//"_dfy", &
-        CS%diag%axesCvL, day, trim(longname)//" diffusive zonal flux" , &
-        trim(flux_units))
-    if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isd,ied,JsdB,JedB,nz)
-    if (CS%id_tr_dfx(m) > 0) call safe_alloc_ptr(CS%tr_dfx(m)%p,IsdB,IedB,jsd,jed,nz)
-    if (CS%id_tr_dfy(m) > 0) call safe_alloc_ptr(CS%tr_dfy(m)%p,isd,ied,JsdB,JedB,nz)
-
-!    Register the tracer for horizontal advection & diffusion.
-    if ((CS%id_tr_adx(m) > 0) .or. (CS%id_tr_ady(m) > 0) .or. &
-        (CS%id_tr_dfx(m) > 0) .or. (CS%id_tr_dfy(m) > 0)) &
-      call add_tracer_diagnostics(name, CS%tr_Reg, CS%tr_adx(m)%p, &
-                                  CS%tr_ady(m)%p,CS%tr_dfx(m)%p,CS%tr_dfy(m)%p)
-
-    call register_Z_tracer(CS%tr(:,:,:,m), trim(name), longname, units, &
-                           day, G, diag_to_Z_CSp)
-  enddo
-
 end subroutine USER_initialize_tracer
 
 !> This subroutine applies diapycnal diffusion and any other column
@@ -444,19 +402,6 @@ subroutine tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV, CS)
     enddo ; enddo ; enddo
   enddo
 
-  do m=1,NTR
-    if (CS%id_tracer(m)>0) &
-      call post_data(CS%id_tracer(m),CS%tr(:,:,:,m),CS%diag)
-    if (CS%id_tr_adx(m)>0) &
-      call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_ady(m)>0) &
-      call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfx(m)>0) &
-      call post_data(CS%id_tr_dfx(m),CS%tr_dfx(m)%p(:,:,:),CS%diag)
-    if (CS%id_tr_dfy(m)>0) &
-      call post_data(CS%id_tr_dfy(m),CS%tr_dfy(m)%p(:,:,:),CS%diag)
-  enddo
-
 end subroutine tracer_column_physics
 
 !> This function calculates the mass-weighted integral of all tracer stocks,
@@ -545,13 +490,6 @@ subroutine USER_tracer_example_end(CS)
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
-    do m=1,NTR
-      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-      if (associated(CS%tr_dfx(m)%p)) deallocate(CS%tr_dfx(m)%p)
-      if (associated(CS%tr_dfy(m)%p)) deallocate(CS%tr_dfy(m)%p)
-    enddo
-
     deallocate(CS)
   endif
 end subroutine USER_tracer_example_end


### PR DESCRIPTION
Cleaned up tracer packages and use the tracer registry to handle almost all diagnostics related to tracers.  This both reduces the volume of tracer-related code substantially and adds to the number of tracers available for tracers other that temperature and salinity.