### PR TITLE
Fix obc restarts on many pes

### DIFF
--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -1715,22 +1715,21 @@ subroutine set_tracer_data(OBC, tv, h, G, PF, tracer_Reg)
 
 end subroutine set_tracer_data
 
+!> Needs documentation
 function lookup_seg_field(OBC_seg,field)
-  type(OBC_segment_type), pointer :: OBC_seg
-  character(len=32), intent(in) :: field ! The field name
+  type(OBC_segment_type), pointer :: OBC_seg !< OBC segment
+  character(len=32), intent(in) :: field !< The field name
   integer :: lookup_seg_field
-
-  integer :: n,m
+  ! Local variables
+  integer :: n
 
   lookup_seg_field=-1
   do n=1,OBC_seg%num_fields
-   if (trim(field) == OBC_seg%field(m)%name) then
+   if (trim(field) == OBC_seg%field(n)%name) then
      lookup_seg_field=n
      return
    endif
   enddo
-
-  return
 
 end function lookup_seg_field
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -2646,6 +2646,10 @@ subroutine open_boundary_register_restarts(HI, GV, OBC_CS,restart_CSp)
        call MOM_error(FATAL, "open_boundary_register_restarts: Restart "//&
                       "arrays were previously allocated")
 
+  ! *** This is a temporary work around for restarts with OBC segments.
+  ! This implementation uses 3D arrays solely for restarts. We need
+  ! to be able to add 2D ( x,z or y,z ) data to restarts to avoid using
+  ! so much memory and disk space. ***
   if (OBC_CS%radiation_BCs_exist_globally) then
     allocate(OBC_CS%rx_normal(HI%isdB:HI%iedB,HI%jsd:HI%jed,GV%ke))
     OBC_CS%rx_normal(:,:,:) = 0.0

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -718,9 +718,10 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg)
                      "String '"//trim(action_str(a_loop))//"' not understood.")
     endif
 
-    if (I_obc<=G%HI%IsdB .or. I_obc>=G%HI%IedB) return ! Boundary is not on tile
-    if (Je_obc<=G%HI%JsdB .or. Js_obc>=G%HI%JedB) return ! Segment is not on tile
   enddo ! a_loop
+
+  if (I_obc<=G%HI%IsdB .or. I_obc>=G%HI%IedB) return ! Boundary is not on tile
+  if (Je_obc<=G%HI%JsdB .or. Js_obc>=G%HI%JedB) return ! Segment is not on tile
 
   OBC%segment(l_seg)%on_pe = .true.
   OBC%segment(l_seg)%is_E_or_W = .true.
@@ -820,9 +821,10 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg)
                      "String '"//trim(action_str(a_loop))//"' not understood.")
     endif
 
-    if (J_obc<=G%HI%JsdB .or. J_obc>=G%HI%JedB) return ! Boundary is not on tile
-    if (Ie_obc<=G%HI%IsdB .or. Is_obc>=G%HI%IedB) return ! Segment is not on tile
   enddo ! a_loop
+
+  if (J_obc<=G%HI%JsdB .or. J_obc>=G%HI%JedB) return ! Boundary is not on tile
+  if (Ie_obc<=G%HI%IsdB .or. Is_obc>=G%HI%IedB) return ! Segment is not on tile
 
   OBC%segment(l_seg)%on_pe = .true.
   OBC%segment(l_seg)%is_N_or_S = .true.


### PR DESCRIPTION
circle_obcs has been failing (e.g. [see here](https://accessdev.nci.org.au/jenkins/job/mom-ocean.org/job/MOM6_fast_run/build=REPRO,compiler=intel,experiment=ocean_only-circle_obcs,label=nah599,memory_type=dynamic_symmetric/lastBuild/console) ) in the Jenkins-orchestrated tests at NCI (thanks @nicjhan) for the right reason:
- NCI is running with 16 cores while our local tests are using 4 cores. On 4 cores, all cores have an OBC segment while with 16 cores the four interior-cores have no OBC segments. Any core without an OBC segment was failing during writing of restarts when trying to use global data that is not allocated.
- This PR allows circle_obcs to run on more than 4 cores.
- The relevant code is using 3D arrays to implement restarts for 2D non-distributed data which is inefficient. The code has been flagged as a work around until we have implemented the same through FMS.