### PR TITLE
An attempt to add checksum for restart fields to restart files, Please review critically

### DIFF
--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -325,7 +325,7 @@ subroutine create_file(unit, filename, vars, novars, fields, threading, timeunit
     if(present(checksums)) then
        call mpp_write_meta(unit, fields(k), axes(1:numaxes), vars(k)%name, vars(k)%units, &
            vars(k)%longname, pack = pack, checksum=checksums(k,:))
-    else    
+    else
        call mpp_write_meta(unit, fields(k), axes(1:numaxes), vars(k)%name, vars(k)%units, &
            vars(k)%longname, pack = pack)
     endif

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -953,27 +953,6 @@ subroutine MOM_io_init(param_file)
 
 end subroutine MOM_io_init
 
-!The following won't compile, otherwise I could have used it to write the checksum attribute for each field
-!MOM_io.F90(966): error #6292: The parent type of this field is use associated 
-!with the PRIVATE fields attribute.   [ID]
-!  call mpp_write_meta( unit, field%id, trim(meta_name), cval=meta_char )
-!-----------------------------------^
-!
-!subroutine write_meta(unit, field, meta_name, meta_value)
-!  integer,               intent(out)   :: unit       !< unit id of an open file or -1 on a
-!                                                     !! nonwriting PE with single file output
-!  type(fieldtype),       intent(in)    :: field      !< fieldtype for the variable that meta data should be added
-!  character(len=*),      intent(in)    :: meta_name   !< name of meta data to be added
-!  integer(kind=8),       intent(in)    :: meta_value  !< value of meta data corresponding to meta_name
-!
-!  character(len=64) :: meta_char
-!
-!  write (meta_char,'(Z16)') meta_value  
-!  call mpp_write_meta( unit, field%id, trim(meta_name), cval=meta_char )
-! 
-!end subroutine write_meta
-  
-
 
 !> \namespace mom_io
 !!

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1126,7 +1126,6 @@ subroutine restore_state(filename, directory, day, G, CS)
       end select
 
       call get_MOM_compute_domain(G,isL,ieL,jsL,jeL)
-      
       do i=1, nvar
         call get_file_atts(fields(i),name=varname)
         if (lowercase(trim(varname)) == lowercase(trim(CS%restart_field(m)%var_name))) then
@@ -1139,7 +1138,6 @@ subroutine restore_state(filename, directory, day, G, CS)
             is_there_a_checksum = .true.
           endif
           if (.NOT. checksum_required ) is_there_a_checksum = .false. ! Do not need to do data checksumming.
-           
 
           if (ASSOCIATED(CS%var_ptr1d(m)%p))  then
             ! Read a 1d array, which should be invariant to domain decomposition.
@@ -1622,7 +1620,6 @@ subroutine get_MOM_compute_domain(G,isL,ieL,jsL,jeL)
   ieL=G%iec-G%isd+1
   jsL=G%jsc-G%jsd+1
   jeL=G%jec-G%jsd+1
-  
   !Zhi's way
 !  call query_vardesc(CS%restart_field(m)%vars, hor_grid=hor_grid, caller="save_restart")
 !  select case (hor_grid)
@@ -1642,8 +1639,6 @@ subroutine get_MOM_compute_domain(G,isL,ieL,jsL,jeL)
 !  jadd = G%jec-G%jsc ! Size of the j-dimension on this processor
 !  if(G%iec == G%ieg) iadd = iadd + ishift
 !  if(G%jec == G%jeg) jadd = jadd + jshift
-!  ?  
-
   !Bob's way
   !   NOTE: The index ranges f var_ptrs always start with 1, so with
   ! symmetric memory the staggering is swapped from NE to SW!

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1254,7 +1254,7 @@ subroutine restore_state(filename, directory, day, G, CS)
              write (mesg,'(a,Z16,a,Z16,a)') "Checksum of input field "// trim(varname)//" ",checksum_data,&
                                           " does not match value ", checksum_file(1), &
                                           " stored in "//trim(unit_path(n)//"." )
-             call MOM_error(WARNING, "MOM_restart(restore_state): "//trim(mesg) )
+             call MOM_error(FATAL, "MOM_restart(restore_state): "//trim(mesg) )
           endif
 
           CS%restart_field(m)%initialized = .true.

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -194,13 +194,13 @@ contains
        !!nnz: MOM field is 3D. Does this affect performance? Need it be override field?
        tr_ptr => tr_field(:,:,:,1)
        ! Register prognastic tracer for horizontal advection, diffusion, and restarts.
-       if (g_tracer_is_prog(g_tracer)) &
+       if (g_tracer_is_prog(g_tracer)) then
          call register_tracer(tr_ptr, tr_Reg, param_file, HI, GV, &
                               name=g_tracer_name, longname=longname, units=units, &
                               registry_diags=.false., &   !### CHANGE TO TRUE?
                               restart_CS=restart_CS, mandatory=.not.CS%tracers_may_reinit)
        else
-         call register_restart_field(tr_ptr, name=g_tracer_name, .not.CS%tracers_may_reinit, &
+         call register_restart_field(tr_ptr, g_tracer_name, .not.CS%tracers_may_reinit, &
                                      restart_CS, longname=longname, units=units)
        endif
 


### PR DESCRIPTION
This update tries to add a checksum mechanism to MOM6 restart procedure.
This mechanism can prevent  instances where "junk"  is written to the restart files as a result of hardware failure which causes the model to restart from "junk" without knowing it happened. 
 
1. At restart write time, this adds a checksum of each restart field as a netcdf attribute for that field to the restart file.

2. At restart read time, this tried to read the above checksum attribute and if it exists it then calculate the checksum of that read field. 

3. Compare the calculated checksum with the written checksum attribute and stop the model if they don't match.

Please review critically, especially the assumptions about the array extents for checksums on lines [941](https://github.com/NOAA-GFDL/MOM6/compare/dev/gfdl...nikizadehgfdl:user/nikizadehgfdl/add_restart_checksums?expand=1#diff-c4487cc8cc2e408a9c0d1d48bbd19fc3R941) and [1128](https://github.com/NOAA-GFDL/MOM6/compare/dev/gfdl...nikizadehgfdl:user/nikizadehgfdl/add_restart_checksums?expand=1#diff-c4487cc8cc2e408a9c0d1d48bbd19fc3R1128) . Although I used the simplest "compute domain" extents I could come up with, this seemed to work for all the cases I had, even the symmetric cases!