### PR TITLE
Restructure MOM diagnostics

### DIFF
--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -25,7 +25,7 @@ module MOM_diagnostics
 !********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_coms,              only : reproducing_sum
-use MOM_diag_mediator,     only : post_data, post_data_1d_k
+use MOM_diag_mediator,     only : post_data, post_data_1d_k, get_diag_time_end
 use MOM_diag_mediator,     only : register_diag_field, register_scalar_field
 use MOM_diag_mediator,     only : diag_ctrl, time_type, safe_alloc_ptr
 use MOM_diag_mediator,     only : diag_get_volume_cell_measure_dm_id
@@ -38,11 +38,13 @@ use MOM_file_parser,       only : get_param, log_version, param_file_type
 use MOM_forcing_type,      only : forcing
 use MOM_grid,              only : ocean_grid_type
 use MOM_interface_heights, only : find_eta
-use MOM_spatial_means,     only : global_area_mean, global_layer_mean, global_volume_mean
+use MOM_spatial_means,     only : global_area_mean, global_layer_mean
+use MOM_spatial_means,     only : global_volume_mean, global_area_integral
 use MOM_variables,         only : thermo_var_ptrs, ocean_internal_state, p3d
-use MOM_variables,         only : accel_diag_ptrs, cont_diag_ptrs
+use MOM_variables,         only : accel_diag_ptrs, cont_diag_ptrs, surface
 use MOM_verticalGrid,      only : verticalGrid_type
 use MOM_wave_speed,        only : wave_speed, wave_speed_CS, wave_speed_init
+use coupler_types_mod,     only : coupler_type_send_data
 
 implicit none ; private
 
@@ -51,9 +53,8 @@ implicit none ; private
 public calculate_diagnostic_fields
 public register_time_deriv
 public find_eta
-public MOM_diagnostics_init
-public MOM_diagnostics_end
-
+public MOM_diagnostics_init, MOM_diagnostics_end
+public register_surface_diags, post_surface_diagnostics
 
 type, public :: diagnostics_CS ; private
   real :: mono_N2_column_fraction = 0. !< The lower fraction of water column over which N2 is limited as
@@ -150,6 +151,33 @@ type, public :: diagnostics_CS ; private
   type(group_pass_type) :: pass_KE_uv
 
 end type diagnostics_CS
+
+
+!> A structure with diagnostic IDs of the surface and integrated variables
+type, public :: surface_diag_IDs ; private
+  ! 2-d surface and bottom fields
+  integer :: id_zos      = -1
+  integer :: id_zossq    = -1
+  integer :: id_volo     = -1
+  integer :: id_ssh      = -1
+  integer :: id_ssh_ga   = -1
+  integer :: id_sst      = -1
+  integer :: id_sst_sq   = -1
+  integer :: id_sss      = -1
+  integer :: id_sss_sq   = -1
+  integer :: id_ssu      = -1
+  integer :: id_ssv      = -1
+  integer :: id_speed    = -1
+  integer :: id_sstcon   = -1
+  integer :: id_sssabs   = -1
+
+  ! heat and salt flux fields
+  integer :: id_fraz         = -1
+  integer :: id_salt_deficit = -1
+  integer :: id_Heat_PmE     = -1
+  integer :: id_intern_heat  = -1
+end type surface_diag_IDs
+
 
 contains
 !> Diagnostics not more naturally calculated elsewhere are computed here.
@@ -1114,6 +1142,167 @@ subroutine calculate_derivs(dt, G, CS)
 
 end subroutine calculate_derivs
 
+!> This routine posts diagnostics of various ocean surface and integrated
+!! quantities at the time the ocean state is reported back to the caller
+subroutine post_surface_diagnostics(IDs, G, GV, diag, dt_int, sfc_state, tv, ssh, fluxes)
+  type(surface_diag_IDs),   intent(in) :: IDs !< A structure with the diagnostic IDs.
+  type(ocean_grid_type),    intent(in) :: G   !< ocean grid structure
+  type(verticalGrid_type),  intent(in) :: GV  !< ocean vertical grid structure
+  type(diag_ctrl),          intent(in) :: diag  !< regulates diagnostic output
+  real,                     intent(in) :: dt_int !< total time step associated with these diagnostics, in s.
+  type(surface),            intent(in) :: sfc_state !< structure describing the ocean surface state
+  type(thermo_var_ptrs),    intent(in) :: tv  !< A structure pointing to various thermodynamic variables
+  real, dimension(SZI_(G),SZJ_(G)), &
+                            intent(in) :: ssh !< Time mean surface height without
+                                              !! corrections for ice displacement(m)
+  type(forcing),            intent(in) :: fluxes !< pointers to forcing fields
+
+  real, dimension(SZI_(G),SZJ_(G)) :: work_2d  ! A 2-d work array
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+    zos  ! dynamic sea lev (zero area mean) from inverse-barometer adjusted ssh (meter)
+  real :: I_time_int    ! The inverse of the time interval in s-1.
+  real :: zos_area_mean, volo, ssh_ga
+  integer :: i, j, is, ie, js, je
+
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+
+  ! area mean SSH
+  if (IDs%id_ssh_ga > 0) then
+    ssh_ga = global_area_mean(ssh, G)
+    call post_data(IDs%id_ssh_ga, ssh_ga, diag)
+  endif
+
+  I_time_int = 1.0 / dt_int
+  if (IDs%id_ssh > 0) &
+    call post_data(IDs%id_ssh, ssh, diag, mask=G%mask2dT)
+
+  ! post the dynamic sea level, zos, and zossq.
+  ! zos is ave_ssh with sea ice inverse barometer removed,
+  ! and with zero global area mean.
+  if (IDs%id_zos > 0 .or. IDs%id_zossq > 0) then
+    zos(:,:) = 0.0
+    do j=js,je ; do i=is,ie
+      zos(i,j) = ssh(i,j)
+    enddo ; enddo
+    if (ASSOCIATED(fluxes%p_surf)) then
+      do j=js,je ; do i=is,ie
+        zos(i,j) = zos(i,j) + G%mask2dT(i,j)*fluxes%p_surf(i,j) / &
+                             (GV%Rho0 * GV%g_Earth)
+      enddo ; enddo
+    endif
+    zos_area_mean = global_area_mean(zos, G)
+    do j=js,je ; do i=is,ie
+      zos(i,j) = zos(i,j) - G%mask2dT(i,j)*zos_area_mean
+    enddo ; enddo
+    if (IDs%id_zos > 0) call post_data(IDs%id_zos, zos, diag, mask=G%mask2dT)
+    if (IDs%id_zossq > 0) then
+      do j=js,je ; do i=is,ie
+        work_2d(i,j) = zos(i,j)*zos(i,j)
+      enddo ; enddo
+      call post_data(IDs%id_zossq, work_2d, diag, mask=G%mask2dT)
+    endif
+  endif
+
+  ! post total volume of the liquid ocean
+  if (IDs%id_volo > 0) then
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = G%mask2dT(i,j)*(ssh(i,j) + G%bathyT(i,j))
+    enddo ; enddo
+    volo = global_area_integral(work_2d, G)
+    call post_data(IDs%id_volo, volo, diag)
+  endif
+
+  ! post time-averaged rate of frazil formation
+  if (ASSOCIATED(tv%frazil) .and. (IDs%id_fraz > 0)) then
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = tv%frazil(i,j) * I_time_int
+    enddo ; enddo
+    call post_data(IDs%id_fraz, work_2d, diag, mask=G%mask2dT)
+  endif
+
+  ! post time-averaged salt deficit
+  if (ASSOCIATED(tv%salt_deficit) .and. (IDs%id_salt_deficit > 0)) then
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = tv%salt_deficit(i,j) * I_time_int
+    enddo ; enddo
+    call post_data(IDs%id_salt_deficit, work_2d, diag, mask=G%mask2dT)
+  endif
+
+  ! post temperature of P-E+R
+  if (ASSOCIATED(tv%TempxPmE) .and. (IDs%id_Heat_PmE > 0)) then
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = tv%TempxPmE(i,j) * (tv%C_p * I_time_int)
+    enddo ; enddo
+    call post_data(IDs%id_Heat_PmE, work_2d, diag, mask=G%mask2dT)
+  endif
+
+  ! post geothermal heating or internal heat source/sinks
+  if (ASSOCIATED(tv%internal_heat) .and. (IDs%id_intern_heat > 0)) then
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = tv%internal_heat(i,j) * (tv%C_p * I_time_int)
+    enddo ; enddo
+    call post_data(IDs%id_intern_heat, work_2d, diag, mask=G%mask2dT)
+  endif
+
+  if (tv%T_is_conT) then
+    ! Internal T&S variables are conservative temperature & absolute salinity
+    if (IDs%id_sstcon > 0) call post_data(IDs%id_sstcon, sfc_state%SST, diag, mask=G%mask2dT)
+    ! Use TEOS-10 function calls convert T&S diagnostics from conservative temp
+    ! to potential temperature.
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = gsw_pt_from_ct(sfc_state%SSS(i,j),sfc_state%SST(i,j))
+    enddo ; enddo
+    if (IDs%id_sst > 0) call post_data(IDs%id_sst, work_2d, diag, mask=G%mask2dT)
+  else
+    ! Internal T&S variables are potential temperature & practical salinity
+    if (IDs%id_sst > 0) call post_data(IDs%id_sst, sfc_state%SST, diag, mask=G%mask2dT)
+  endif
+
+  if (tv%S_is_absS) then
+    ! Internal T&S variables are conservative temperature & absolute salinity
+    if (IDs%id_sssabs > 0) call post_data(IDs%id_sssabs, sfc_state%SSS, diag, mask=G%mask2dT)
+    ! Use TEOS-10 function calls convert T&S diagnostics from absolute salinity
+    ! to practical salinity.
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = gsw_sp_from_sr(sfc_state%SSS(i,j))
+    enddo ; enddo
+    if (IDs%id_sss > 0) call post_data(IDs%id_sss, work_2d, diag, mask=G%mask2dT)
+  else
+    ! Internal T&S variables are potential temperature & practical salinity
+    if (IDs%id_sss > 0) call post_data(IDs%id_sss, sfc_state%SSS, diag, mask=G%mask2dT)
+  endif
+
+  if (IDs%id_sst_sq > 0) then
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = sfc_state%SST(i,j)*sfc_state%SST(i,j)
+    enddo ; enddo
+    call post_data(IDs%id_sst_sq, work_2d, diag, mask=G%mask2dT)
+  endif
+  if (IDs%id_sss_sq > 0) then
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = sfc_state%SSS(i,j)*sfc_state%SSS(i,j)
+    enddo ; enddo
+    call post_data(IDs%id_sss_sq, work_2d, diag, mask=G%mask2dT)
+  endif
+
+  if (IDs%id_ssu > 0) &
+    call post_data(IDs%id_ssu, sfc_state%u, diag, mask=G%mask2dCu)
+  if (IDs%id_ssv > 0) &
+    call post_data(IDs%id_ssv, sfc_state%v, diag, mask=G%mask2dCv)
+
+  if (IDs%id_speed > 0) then
+    do j=js,je ; do i=is,ie
+      work_2d(i,j) = sqrt(0.5*(sfc_state%u(I-1,j)**2 + sfc_state%u(I,j)**2) + &
+                            0.5*(sfc_state%v(i,J-1)**2 + sfc_state%v(i,J)**2))
+    enddo ; enddo
+    call post_data(IDs%id_speed, work_2d, diag, mask=G%mask2dT)
+  endif
+
+  call coupler_type_send_data(sfc_state%tr_fields, get_diag_time_end(diag))
+
+end subroutine post_surface_diagnostics
+
+
 !> This subroutine registers various diagnostics and allocates space for fields
 !! that other diagnostis depend upon.
 subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, param_file, diag, CS, tv)
@@ -1413,6 +1602,81 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, param_file, diag, CS
   call set_dependent_diagnostics(MIS, ADp, CDp, G, CS)
 
 end subroutine MOM_diagnostics_init
+
+
+!> Register diagnostics of the surface state and integrated quantities
+subroutine register_surface_diags(Time, G, IDs, diag, missing, tv)
+  type(time_type),         intent(in)    :: Time  !< current model time
+  type(ocean_grid_type),   intent(in)    :: G     !< ocean grid structure
+  type(surface_diag_IDs),  intent(inout) :: IDs   !< A structure with the diagnostic IDs.
+  type(diag_ctrl),         intent(inout) :: diag  !< regulates diagnostic output
+  real,                    intent(in)    :: missing !< The value to use to fill in missing data
+  type(thermo_var_ptrs),   intent(in)    :: tv    !< A structure pointing to various thermodynamic variables
+
+  ! Vertically integrated, budget, and surface state diagnostics
+  IDs%id_volo = register_scalar_field('ocean_model', 'volo', Time, diag,&
+      long_name='Total volume of liquid ocean', units='m3',            &
+      standard_name='sea_water_volume')
+  IDs%id_zos = register_diag_field('ocean_model', 'zos', diag%axesT1, Time,&
+      standard_name = 'sea_surface_height_above_geoid',                   &
+      long_name= 'Sea surface height above geoid', units='m', missing_value=missing)
+  IDs%id_zossq = register_diag_field('ocean_model', 'zossq', diag%axesT1, Time,&
+      standard_name='square_of_sea_surface_height_above_geoid',             &
+      long_name='Square of sea surface height above geoid', units='m2', missing_value=missing)
+  IDs%id_ssh = register_diag_field('ocean_model', 'SSH', diag%axesT1, Time, &
+      'Sea Surface Height', 'm', missing)
+  IDs%id_ssh_ga = register_scalar_field('ocean_model', 'ssh_ga', Time, diag,&
+      long_name='Area averaged sea surface height', units='m',            &
+      standard_name='area_averaged_sea_surface_height')
+  IDs%id_ssu = register_diag_field('ocean_model', 'SSU', diag%axesCu1, Time, &
+      'Sea Surface Zonal Velocity', 'm s-1', missing)
+  IDs%id_ssv = register_diag_field('ocean_model', 'SSV', diag%axesCv1, Time, &
+      'Sea Surface Meridional Velocity', 'm s-1', missing)
+  IDs%id_speed = register_diag_field('ocean_model', 'speed', diag%axesT1, Time, &
+      'Sea Surface Speed', 'm s-1', missing)
+
+  if (associated(tv%T)) then
+    IDs%id_sst = register_diag_field('ocean_model', 'SST', diag%axesT1, Time,     &
+        'Sea Surface Temperature', 'degC', missing, cmor_field_name='tos', &
+        cmor_long_name='Sea Surface Temperature',                                &
+        cmor_standard_name='sea_surface_temperature')
+    IDs%id_sst_sq = register_diag_field('ocean_model', 'SST_sq', diag%axesT1, Time, &
+        'Sea Surface Temperature Squared', 'degC2', missing, cmor_field_name='tossq', &
+        cmor_long_name='Square of Sea Surface Temperature ',                      &
+        cmor_standard_name='square_of_sea_surface_temperature')
+    IDs%id_sss = register_diag_field('ocean_model', 'SSS', diag%axesT1, Time, &
+        'Sea Surface Salinity', 'psu', missing, cmor_field_name='sos', &
+        cmor_long_name='Sea Surface Salinity',                            &
+        cmor_standard_name='sea_surface_salinity')
+    IDs%id_sss_sq = register_diag_field('ocean_model', 'SSS_sq', diag%axesT1, Time, &
+        'Sea Surface Salinity Squared', 'psu', missing, cmor_field_name='sossq', &
+        cmor_long_name='Square of Sea Surface Salinity ',                     &
+        cmor_standard_name='square_of_sea_surface_salinity')
+    if (tv%T_is_conT) then
+      IDs%id_sstcon = register_diag_field('ocean_model', 'conSST', diag%axesT1, Time,     &
+          'Sea Surface Conservative Temperature', 'Celsius', missing)
+    endif
+    if (tv%S_is_absS) then
+      IDs%id_sssabs = register_diag_field('ocean_model', 'absSSS', diag%axesT1, Time,     &
+          'Sea Surface Absolute Salinity', 'g kg-1', missing)
+    endif
+    if (ASSOCIATED(tv%frazil)) then
+      IDs%id_fraz = register_diag_field('ocean_model', 'frazil', diag%axesT1, Time, &
+            'Heat from frazil formation', 'W m-2', cmor_field_name='hfsifrazil', &
+            cmor_standard_name='heat_flux_into_sea_water_due_to_frazil_ice_formation', &
+            cmor_long_name='Heat Flux into Sea Water due to Frazil Ice Formation')
+    endif
+  endif
+
+  IDs%id_salt_deficit = register_diag_field('ocean_model', 'salt_deficit', diag%axesT1, Time, &
+         'Salt sink in ocean due to ice flux', 'psu m-2 s-1')
+  IDs%id_Heat_PmE = register_diag_field('ocean_model', 'Heat_PmE', diag%axesT1, Time, &
+         'Heat flux into ocean from mass flux into ocean', 'W m-2')
+  IDs%id_intern_heat = register_diag_field('ocean_model', 'internal_heat', diag%axesT1, Time,&
+         'Heat flux into ocean from geothermal or other internal sources', 'W m-2')
+
+end subroutine register_surface_diags
+
 
 !> This subroutine sets up diagnostics upon which other diagnostics depend.
 subroutine set_dependent_diagnostics(MIS, ADp, CDp, G, CS)

--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -504,9 +504,14 @@ function real_string(val)
   elseif (val == 0.) then
     real_string = "0.0"
   else
-    write(real_string(1:32), '(ES23.14)') val
-    if (.not.testFormattedFloatIsReal(real_string,val)) then
-     write(real_string(1:32), '(ES23.15)') val
+    if ((abs(val) <= 1.0e-100) .or. (abs(val) >= 1.0e100)) then
+      write(real_string(1:32), '(ES24.14E3)') val
+      if (.not.testFormattedFloatIsReal(real_string,val)) &
+        write(real_string(1:32), '(ES24.15E3)') val
+    else
+      write(real_string(1:32), '(ES23.14)') val
+      if (.not.testFormattedFloatIsReal(real_string,val)) &
+        write(real_string(1:32), '(ES23.15)') val
     endif
     do
       ind = index(real_string,"0E")

--- a/src/framework/MOM_string_functions.F90
+++ b/src/framework/MOM_string_functions.F90
@@ -124,9 +124,14 @@ function left_real(val)
   elseif (val == 0.) then
     left_real = "0.0"
   else
-    write(left_real(1:32), '(ES23.14)') val
-    if (.not.isFormattedFloatEqualTo(left_real,val)) then
-     write(left_real(1:32), '(ES23.15)') val
+    if ((abs(val) <= 1.0e-100) .or. (abs(val) >= 1.0e100)) then
+      write(left_real(1:32), '(ES24.14E3)') val
+      if (.not.isFormattedFloatEqualTo(left_real,val)) &
+        write(left_real(1:32), '(ES24.15E3)') val
+    else
+      write(left_real(1:32), '(ES23.14)') val
+      if (.not.isFormattedFloatEqualTo(left_real,val)) &
+        write(left_real(1:32), '(ES23.15)') val
     endif
     do
       ind = index(left_real,"0E")

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -28,6 +28,7 @@ implicit none ; private
 public register_tracer
 public MOM_tracer_chksum, MOM_tracer_chkinv
 public register_tracer_diagnostics, post_tracer_diagnostics
+public preALE_tracer_diagnostics, postALE_tracer_diagnostics
 public add_tracer_diagnostics, add_tracer_OBC_values
 public tracer_registry_init, lock_tracer_registry, tracer_registry_end
 
@@ -83,6 +84,12 @@ type, public :: tracer_type
   character(len=48)               :: cmor_tendname = ""       !< The CMOR variable name for tendencies of this
                                                               !! tracer, required because CMOR does not follow any
                                                               !! discernable pattern for these names.
+  integer :: ind_tr_squared = -1
+
+  !### THESE CAPABILITIES HAVE NOT YET BEEN IMPLEMENTED.
+  logical :: advect_tr = .true.     !< If true, this tracer should be advected
+  logical :: hordiff_tr = .true.    !< If true, this tracer should experience epineutral diffusion
+  logical :: remap_tr = .true.      !< If true, this tracer should be vertically remapped
 
   integer :: diag_form = 1  !< An integer indicating which template is to be used to label diagnostics.
   integer :: id_tr = -1
@@ -90,6 +97,7 @@ type, public :: tracer_type
   integer :: id_adx_2d = -1, id_ady_2d = -1, id_dfx_2d = -1, id_dfy_2d = -1
   integer :: id_adv_xy = -1, id_adv_xy_2d = -1
   integer :: id_tendency = -1, id_trxh_tendency = -1, id_trxh_tendency_2d = -1
+  integer :: id_tr_vardec = -1
 end type tracer_type
 
 !> Type to carry basic tracer information
@@ -368,7 +376,7 @@ end subroutine add_tracer_diagnostics
 
 !> register_tracer_diagnostics does a set of register_diag_field calls for any previously
 !! registered in a tracer registry with a value of registry_diags set to .true.
-subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, diag_to_Z_CSp)
+subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_to_Z_CSp)
   type(ocean_grid_type),      intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type),    intent(in) :: GV   !< The ocean's vertical grid structure
   type(tracer_registry_type), pointer    :: Reg  !< pointer to the tracer registry
@@ -376,6 +384,8 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, diag_to_Z_CSp)
                               intent(in) :: h    !< Layer thicknesses
   type(time_type),            intent(in) :: Time !< current model time
   type(diag_ctrl),            intent(in) :: diag !< structure to regulate diagnostic output
+  logical,                    intent(in) :: use_ALE !< If true active diagnostics that only
+                                                 !! apply to ALE configurations
   type(diag_to_Z_CS),         pointer    :: diag_to_Z_CSp !< A pointer to the control structure
                                                  !! for diagnostics in depth space.
 
@@ -395,7 +405,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, diag_to_Z_CSp)
   character(len=120) :: cmor_var_lname ! The temporary CMOR long name for a diagnostic
   character(len=72)  :: cmor_varname ! The temporary CMOR name for a diagnostic
   type(tracer_type), pointer :: Tr=>NULL()
-  integer :: i, j, k, is, ie, js, je, nz, m
+  integer :: i, j, k, is, ie, js, je, nz, m, m2, nTr_in
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed
@@ -404,7 +414,9 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, diag_to_Z_CSp)
   if (.not. associated(Reg)) call MOM_error(FATAL, "add_tracer_diagnostics: "// &
        "register_tracer must be called before add_tracer_diagnostics")
 
-  do m=1,Reg%ntr ; if (Reg%Tr(m)%registry_diags) then
+  nTr_in = Reg%ntr
+
+  do m=1,nTr_in ; if (Reg%Tr(m)%registry_diags) then
     Tr => Reg%Tr(m)
 !    call query_vardesc(Tr%vd, name, units=units, longname=longname, &
 !                       cmor_field_name=cmorname, cmor_longname=cmor_longname, &
@@ -544,9 +556,73 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, diag_to_Z_CSp)
                cmor_field_name=cmorname, cmor_standard_name=cmor_long_std(cmor_longname), &
                cmor_long_name=cmor_longname)
     endif
+
+    if (use_ALE .and. (Reg%ntr<MAX_FIELDS_) .and. Tr%remap_tr) then
+      Tr%id_tr_vardec = register_diag_field('ocean_model', trim(shortnm)//"_vardec", diag%axesTL, Time, &
+        "ALE variance decay for "//lowercase(longname), "("//trim(units)//")2 s-1")
+      if (Tr%id_tr_vardec > 0) then
+        ! Set up a new tracer for this tracer squared
+        m2 = Reg%ntr+1
+        Tr%ind_tr_squared = m2
+        call safe_alloc_ptr(Reg%Tr(m2)%t,isd,ied,jsd,jed,nz) ; Reg%Tr(m2)%t(:,:,:) = 0.0
+        Reg%Tr(m2)%name = trim(shortnm)//"2"
+        Reg%Tr(m2)%longname = "Squared "//trim(longname)
+        Reg%Tr(m2)%units = "("//trim(units)//")2"
+        Reg%Tr(m2)%registry_diags = .false.
+        Reg%Tr(m2)%ind_tr_squared = -1
+        ! Augment the total number of tracers, including the squared tracers.
+        Reg%ntr = Reg%ntr + 1
+      endif
+    endif
+
   endif ; enddo
 
 end subroutine register_tracer_diagnostics
+
+subroutine preALE_tracer_diagnostics(Reg, G, GV)
+  type(tracer_registry_type), pointer    :: Reg  !< pointer to the tracer registry
+  type(ocean_grid_type),      intent(in) :: G    !< The ocean's grid structure
+  type(verticalGrid_type),    intent(in) :: GV   !< ocean vertical grid structure
+
+  integer :: i, j, k, is, ie, js, je, nz, m, m2
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+
+  do m=1,Reg%ntr ; if (Reg%Tr(m)%ind_tr_squared > 0) then
+    m2 = Reg%Tr(m)%ind_tr_squared
+  ! Update squared quantities
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      Reg%Tr(m2)%T(i,j,k) = Reg%Tr(m)%T(i,j,k)**2
+    enddo ; enddo ; enddo
+  endif ; enddo
+
+end subroutine preALE_tracer_diagnostics
+
+subroutine postALE_tracer_diagnostics(Reg, G, GV, diag, dt)
+  type(tracer_registry_type), pointer    :: Reg  !< pointer to the tracer registry
+  type(ocean_grid_type),      intent(in) :: G    !< The ocean's grid structure
+  type(verticalGrid_type),    intent(in) :: GV   !< ocean vertical grid structure
+  type(diag_ctrl),            intent(in) :: diag !< regulates diagnostic output
+  real,                       intent(in) :: dt   !< total time interval for these diagnostics
+
+  real :: work(SZI_(G),SZJ_(G),SZK_(G))
+  real :: Idt
+  integer :: i, j, k, is, ie, js, je, nz, m, m2
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
+
+  ! The "if" is to avoid NaNs if the diagnostic is called for a zero length interval
+  Idt = 0.0 ; if (dt /= 0.0) Idt = 1.0 / dt
+
+  do m=1,Reg%ntr ; if (Reg%Tr(m)%id_tr_vardec > 0) then
+    m2 = Reg%Tr(m)%ind_tr_squared
+    if (m2 < 1) call MOM_error(FATAL, "Bad value of Tr%ind_tr_squared for "//trim(Reg%Tr(m)%name))
+  ! Update squared quantities
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      work(i,j,k) = (Reg%Tr(m2)%T(i,j,k) - Reg%Tr(m)%T(i,j,k)**2) * Idt
+    enddo ; enddo ; enddo
+    call post_data(Reg%Tr(m)%id_tr_vardec, work, diag)
+  endif ; enddo
+
+end subroutine postALE_tracer_diagnostics
 
 !> post_tracer_diagnostics does post_data calls for any diagnostics that are
 !! being handled via the tracer registry.


### PR DESCRIPTION
This PR includes substantial rearrangement of the diagnostics that were formerly in MOM.F90, in preparation for even more dramatic restructuring of MOM.F90 and the addition of alternate time-stepping interfaces to MOM to address coupled instabilities.  All solutions and diagnostics should be unchanged by this PR, but number and order of diagnostics in the MOM available_diags files do change.