### PR TITLE
Call write_energy at ocean_model_end

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -801,6 +801,11 @@ subroutine ocean_model_end(Ocean_sfc, Ocean_state, Time)
 !                          ocean state to be deallocated upon termination.
 !  (in)      Time - The model time, used for writing restarts.
 
+  !Write the checksums at the end of a model run.
+  call write_energy(Ocean_state%MOM_CSp%u, Ocean_state%MOM_CSp%v, Ocean_state%MOM_CSp%h, Ocean_state%MOM_CSp%tv, &
+                    Ocean_state%Time, Ocean_state%nstep, Ocean_state%grid, Ocean_state%GV, Ocean_state%sum_output_CSp, &
+                    Ocean_state%MOM_CSp%tracer_flow_CSp)
+
   call ocean_model_save_restart(Ocean_state, Time)
   call diag_mediator_end(Time, Ocean_state%MOM_CSp%diag)
   call MOM_end(Ocean_state%MOM_CSp)


### PR DESCRIPTION
- write_energy() prints a checksum at the begining of the first timestep.
  It is useful to print this checksum at the end of the last timestep too
  to be able to discover errors in the restart of the models. 
 This is especially desired since unlike other components MOM6 prints 
  only a handful of checksums (of ocean surface values in ocean_public_type)
  to compare before and after a restart.