### PR TITLE
Made MOM_control_struct opaque

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -148,19 +148,6 @@ type, public :: ocean_state_type ; private
                              !! restart file is saved at the end of a run segment
                              !! unless Restart_control is negative.
 
-  type(time_type) :: energysavedays            !< The interval between writing the energies
-                                               !! and other integral quantities of the run.
-  type(time_type) :: energysavedays_geometric  !< The starting interval for computing a geometric
-                                               !! progression of time deltas between calls to
-                                               !! write_energy. This interval will increase by a factor of 2.
-                                               !! after each call to write_energy.
-  logical         :: energysave_geometric      !< Logical to control whether calls to write_energy should
-                                               !! follow a geometric progression
-  type(time_type) :: write_energy_time         !< The next time to write to the energy file.
-  type(time_type) :: geometric_end_time        !< Time at which to stop the geometric progression
-                                               !! of calls to write_energy and revert to the standard
-                                               !! energysavedays interval
-
   integer :: nstep = 0        !< The number of calls to update_ocean.
   logical :: use_ice_shelf    !< If true, the ice shelf model is enabled.
 
@@ -254,7 +241,6 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
 !                    information about the ocean's interior state.
 !  (in)      Time_init - The start time for the coupled model's calendar.
 !  (in)      Time_in - The time at which to initialize the ocean model.
-  real :: Time_unit   ! The time unit in seconds for ENERGYSAVEDAYS.
   real :: Rho0        ! The Boussinesq ocean density, in kg m-3.
   real :: G_Earth     ! The gravitational acceleration in m s-2.
 ! This include declares and sets the variable "version".
@@ -286,6 +272,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
   OS%fluxes%C_p = OS%MSp%tv%C_p
   use_temperature = ASSOCIATED(OS%MSp%tv%T)
 
+  call MOM_sum_output_init(OS%grid, param_file, OS%dirs%output_directory, &
+                            OS%MOM_CSp%ntrunc, Time_init, OS%sum_output_CSp)
+
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "RESTART_CONTROL", OS%Restart_control, &
@@ -294,26 +283,6 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
                  "(bit 0) for a non-time-stamped file.  A restart file \n"//&
                  "will be saved at the end of the run segment for any \n"//&
                  "non-negative value.", default=1)
-
-  call get_param(param_file, mdl, "TIMEUNIT", Time_unit, &
-                 "The time unit for ENERGYSAVEDAYS.", &
-                 units="s", default=86400.0)
-  call get_param(param_file, mdl, "ENERGYSAVEDAYS",OS%energysavedays, &
-                 "The interval in units of TIMEUNIT between saves of the \n"//&
-                 "energies of the run and other globally summed diagnostics.",&
-                 default=set_time(0,days=1), timeunit=Time_unit)
-  call get_param(param_file, mdl, "ENERGYSAVEDAYS_GEOMETRIC",OS%energysavedays_geometric, &
-                 "The starting interval in units of TIMEUNIT for the first call \n"//&
-                 "to save the energies of the run and other globally summed diagnostics. \n"//&
-                 "The interval increases by a factor of 2. after each call to write_energy.",&
-                 default=set_time(seconds=0), timeunit=Time_unit)
-
-  if ((time_type_to_real(OS%energysavedays_geometric) > 0.) .and. &
-     (OS%energysavedays_geometric < OS%energysavedays)) then
-         OS%energysave_geometric = .true.
-  else
-         OS%energysave_geometric = .false.
-  endif
 
   call get_param(param_file, mdl, "OCEAN_SURFACE_STAGGER", stagger, &
                  "A case-insensitive character string to indicate the \n"//&
@@ -384,27 +353,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
       call allocate_forcing_type(OS%grid, OS%fluxes, shelf=.true.)
   endif
 
-  call MOM_sum_output_init(OS%grid, param_file, OS%dirs%output_directory, &
-                            OS%MOM_CSp%ntrunc, Time_init, OS%sum_output_CSp)
-
   ! This call has been moved into the first call to update_ocean_model.
   !  call write_energy(OS%MSp%u, OS%MSp%v, OS%MSp%h, OS%MSp%tv, &
   !             OS%Time, 0, OS%grid, OS%GV, OS%sum_output_CSp, OS%MOM_CSp%tracer_flow_CSp)
-
-  ! write_energy_time is the next integral multiple of energysavedays.
-  if (OS%energysave_geometric) then
-    if (OS%energysavedays_geometric < OS%energysavedays) then
-      OS%write_energy_time = OS%Time + OS%energysavedays_geometric
-      OS%geometric_end_time = Time_init + OS%energysavedays * &
-       (1 + (OS%Time - Time_init) / OS%energysavedays)
-    else
-      OS%write_energy_time = Time_init + OS%energysavedays * &
-        (1 + (OS%Time - Time_init) / OS%energysavedays)
-    endif
-  else
-    OS%write_energy_time = Time_init + OS%energysavedays * &
-      (1 + (OS%Time - Time_init) / OS%energysavedays)
-  endif
 
   if (ASSOCIATED(OS%grid%Domain%maskmap)) then
     call initialize_ocean_public_type(OS%grid%Domain%mpp_domain, Ocean_sfc, &
@@ -497,7 +448,6 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   real :: time_step         ! The time step of a call to step_MOM in seconds.
   integer :: secs, days
   integer :: is, ie, js, je
-  type(time_type) :: write_energy_time_geometric
 
   call callTree_enter("update_ocean_model(), ocean_model_MOM.F90")
   call get_time(Ocean_coupling_time_step, secs, days)
@@ -611,32 +561,10 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
     call disable_averaging(OS%diag)
   endif
 
-!  See if it is time to write out the energy.
-
-  if (OS%energysave_geometric) then
-    if ((OS%Time + ((Ocean_coupling_time_step)/2) > OS%geometric_end_time) .and. &
-        (OS%MSp%t_dyn_rel_adv==0.0)) then
-        call write_energy(OS%MSp%u, OS%MSp%v, OS%MSp%h, OS%MSp%tv, &
-                        OS%Time, OS%nstep, OS%grid, OS%GV, OS%sum_output_CSp, &
-                        OS%MOM_CSp%tracer_flow_CSp)
-        OS%write_energy_time = OS%geometric_end_time + OS%energysavedays
-        OS%energysave_geometric = .false.  ! stop geometric progression
-    endif
-  endif
-
-  if ((OS%Time + ((Ocean_coupling_time_step)/2) > OS%write_energy_time) .and. &
-      (OS%MSp%t_dyn_rel_adv==0.0)) then
+  if (OS%MSp%t_dyn_rel_adv==0.0) &
     call write_energy(OS%MSp%u, OS%MSp%v, OS%MSp%h, OS%MSp%tv, &
                       OS%Time, OS%nstep, OS%grid, OS%GV, OS%sum_output_CSp, &
-                      OS%MOM_CSp%tracer_flow_CSp)
-    if (OS%energysave_geometric) then
-        OS%energysavedays_geometric = OS%energysavedays_geometric*2
-        OS%write_energy_time = OS%write_energy_time + OS%energysavedays_geometric
-    else
-      OS%write_energy_time = OS%write_energy_time + OS%energysavedays
-    endif
-  endif
-
+                      OS%MOM_CSp%tracer_flow_CSp, dt_forcing=Ocean_coupling_time_step)
 
 
 ! Translate state into Ocean.

--- a/config_src/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/ice_solo_driver/ice_shelf_driver.F90
@@ -283,8 +283,6 @@ program SHELF_main
   call log_param(param_file, mdl, "ELAPSED TIME AS MASTER", elapsed_time_master)
 
 !   i don't think we'll use this...
-!   call MOM_sum_output_init(grid, param_file, dirs%output_directory, &
-!                            MOM_CSp%ntrunc, Start_time, sum_output_CSp)
    call MOM_write_cputime_init(param_file, dirs%output_directory, Start_time, &
                                write_CPU_CSp)
    call MOM_mesg("Done MOM_write_cputime_init.", 5)
@@ -292,7 +290,7 @@ program SHELF_main
 
   ! Close the param_file.  No further parsing of input is possible after this.
   call close_param_file(param_file)
-  call diag_mediator_close_registration(MOM_CSp%diag)
+!  call diag_mediator_close_registration(diag)
 
   ! Write out a time stamp file.
   call open_file(unit, 'time_stamp.out', form=ASCII_FILE, action=APPEND_FILE, &

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -284,7 +284,7 @@ type, public :: MOM_control_struct ; private
   integer :: nstep_tot = 0           !< The total number of dynamic timesteps taken
                                      !! so far in this run segment
   logical :: count_calls = .false.   !< If true, count the calls to step_MOM, rather than the
-                                     !! number of dynamics steps in nstep_tot                    
+                                     !! number of dynamics steps in nstep_tot
   integer :: ntrunc                  !< number u,v truncations since last call to write_energy
   logical :: check_bad_surface_vals  !< If true, scan surface state for ridiculous values.
   real    :: bad_val_ssh_max         !< Maximum SSH before triggering bad value message

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -284,7 +284,7 @@ type, public :: MOM_control_struct ; private
   integer :: nstep_tot = 0           !< The total number of dynamic timesteps taken
                                      !! so far in this run segment
   logical :: count_calls = .false.   !< If true, count the calls to step_MOM, rather than the
-                                     !! number of dynamics steps in nstep_tot                     
+                                     !! number of dynamics steps in nstep_tot                    
   integer :: ntrunc                  !< number u,v truncations since last call to write_energy
   logical :: check_bad_surface_vals  !< If true, scan surface state for ridiculous values.
   real    :: bad_val_ssh_max         !< Maximum SSH before triggering bad value message

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -318,7 +318,7 @@ subroutine add_tracer_OBC_values(name, Reg, OBC_inflow, OBC_in_u, OBC_in_v)
 
   integer :: m
 
-  if (.not. associated(Reg)) call MOM_error(FATAL, "add_tracer_OBC_values :"// &
+  if (.not. associated(Reg)) call MOM_error(FATAL, "add_tracer_OBC_values :"//&
        "register_tracer must be called before add_tracer_OBC_values")
 
   do m=1,Reg%ntr ; if (Reg%Tr(m)%name == trim(name)) exit ; enddo
@@ -374,7 +374,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
-  if (.not. associated(Reg)) call MOM_error(FATAL, "register_tracer_diagnostics: "// &
+  if (.not. associated(Reg)) call MOM_error(FATAL, "register_tracer_diagnostics: "//&
        "register_tracer must be called before register_tracer_diagnostics")
 
   nTr_in = Reg%ntr
@@ -486,33 +486,36 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
 
     ! Lateral diffusion convergence tendencies
     if (Tr%diag_form == 1) then
-      Tr%id_dfxy_cont = register_diag_field("ocean_model", trim(shortnm)//'_dfxy_cont_tendency',                    &
-          diag%axesTL, Time, "Lateral or neutral diffusion tracer content tendency for "//trim(shortnm),            &
-          conv_units, conversion = Tr%conv_scale, x_cell_method = 'sum', y_cell_method = 'sum', v_extensive = .true.)
+      Tr%id_dfxy_cont = register_diag_field("ocean_model", trim(shortnm)//'_dfxy_cont_tendency', &
+          diag%axesTL, Time, "Lateral or neutral diffusion tracer content tendency for "//trim(shortnm), &
+          conv_units, conversion=Tr%conv_scale, x_cell_method='sum', y_cell_method='sum', v_extensive=.true.)
 
       Tr%id_dfxy_cont_2d = register_diag_field("ocean_model", trim(shortnm)//'_dfxy_cont_tendency_2d', &
-          diag%axesT1, Time, "Depth integrated lateral or neutral diffusion tracer concentration"//    &
-          "tendency for "//trim(shortnm), conv_units, conversion = Tr%conv_scale,                      &
+          diag%axesT1, Time, "Depth integrated lateral or neutral diffusion tracer concentration "//&
+          "tendency for "//trim(shortnm), conv_units, conversion = Tr%conv_scale, &
           x_cell_method = 'sum', y_cell_method = 'sum')
     else
-      cmor_var_lname = 'Tendency of '//trim(lowercase(cmor_longname))//' expressed as '//&
-                       trim(lowercase(flux_longname))//' content due to parameterized mesoscale diffusion'
-      Tr%id_dfxy_cont = register_diag_field("ocean_model", trim(shortnm)//'_dfxy_cont_tendency',                  &
-          diag%axesTL, Time, "Lateral or neutral diffusion tracer concentration tendency for", conv_units,        &
-          conversion = Tr%conv_scale, cmor_field_name = trim(Tr%cmor_tendname)//'pmdiff',                         &
-          cmor_long_name = trim(cmor_var_lname), cmor_standard_name = trim(cmor_long_std(cmor_var_lname)),        &
+      cmor_var_lname = 'Tendency of '//trim(lowercase(cmor_longname))//&
+           ' expressed as '//trim(lowercase(flux_longname))//&
+           ' content due to parameterized mesoscale diffusion'
+      Tr%id_dfxy_cont = register_diag_field("ocean_model", trim(shortnm)//'_dfxy_cont_tendency', &
+          diag%axesTL, Time, "Lateral or neutral diffusion tracer concentration tendency for "//trim(shortnm), &
+          conv_units, conversion = Tr%conv_scale, cmor_field_name = trim(Tr%cmor_tendname)//'pmdiff', &
+          cmor_long_name = trim(cmor_var_lname), cmor_standard_name = trim(cmor_long_std(cmor_var_lname)), &
           x_cell_method = 'sum', y_cell_method = 'sum', v_extensive = .true.)
 
       cmor_var_lname = 'Tendency of '//trim(lowercase(cmor_longname))//' expressed as '//&
                        trim(lowercase(flux_longname))//' content due to parameterized mesoscale diffusion'
-      Tr%id_dfxy_cont_2d = register_diag_field("ocean_model", trim(shortnm)//'_dfxy_cont_tendency_2d',          &
-          diag%axesT1, Time, "Depth integrated lateral or neutral diffusion tracer concentration tendency for", &
-          conv_units, conversion = Tr%conv_scale, cmor_field_name=trim(Tr%cmor_tendname)//'pmdiff_2d',          &
-          cmor_long_name = trim(cmor_var_lname), cmor_standard_name = trim(cmor_long_std(cmor_var_lname)),      &
-          x_cell_method = 'sum', y_cell_method = 'sum')
+      Tr%id_dfxy_cont_2d = register_diag_field("ocean_model", trim(shortnm)//'_dfxy_cont_tendency_2d', &
+          diag%axesT1, Time, "Depth integrated lateral or neutral diffusion tracer "//&
+          "concentration tendency for "//trim(shortnm), conv_units, &
+          conversion=Tr%conv_scale, cmor_field_name=trim(Tr%cmor_tendname)//'pmdiff_2d', &
+          cmor_long_name=trim(cmor_var_lname), cmor_standard_name=trim(cmor_long_std(cmor_var_lname)), &
+          x_cell_method='sum', y_cell_method='sum')
     endif
     Tr%id_dfxy_conc = register_diag_field("ocean_model", trim(shortnm)//'_dfxy_conc_tendency', &
-        diag%axesTL, Time, "Lateral (neutral) tracer concentration tendency for", units//' s-1')
+        diag%axesTL, Time, "Lateral (neutral) tracer concentration tendency for "//trim(shortnm), &
+        trim(units)//' s-1')
 
     var_lname = "Net time tendency for "//lowercase(flux_longname)
     if (len_trim(Tr%cmor_tendname) == 0) then
@@ -521,7 +524,8 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
       Tr%id_trxh_tendency_2d = register_diag_field('ocean_model', trim(shortnm)//'h_tendency_2d', &
           diag%axesT1, Time, "Vertical sum of "//trim(lowercase(var_lname)), conv_units)
     else
-      cmor_var_lname = "Tendency of "//trim(cmor_longname)//" Expressed as "//trim(flux_longname)//" Content"
+      cmor_var_lname = "Tendency of "//trim(cmor_longname)//" Expressed as "//&
+                        trim(flux_longname)//" Content"
       Tr%id_trxh_tendency = register_diag_field('ocean_model', trim(shortnm)//'h_tendency', &
           diag%axesTL, Time, var_lname, conv_units, &
           cmor_field_name=trim(Tr%cmor_tendname)//"tend", &
@@ -554,14 +558,15 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
       var_lname = "Vertical remapping tracer concentration tendency for "//trim(Reg%Tr(m)%name)
       Tr%id_remap_conc= register_diag_field('ocean_model',                          &
         trim(Tr%flux_nameroot)//'_tendency_vert_remap', diag%axesTL, Time, var_lname, &
-        trim(units)//'s-1')
+        trim(units)//' s-1')
 
       var_lname = "Vertical remapping tracer content tendency for "//trim(Reg%Tr(m)%flux_longname)
       Tr%id_remap_cont = register_diag_field('ocean_model', &
         trim(Tr%flux_nameroot)//'h_tendency_vert_remap',         &
         diag%axesTL, Time, var_lname, flux_units, v_extensive=.true., conversion = Tr%conv_scale)
 
-      var_lname = "Vertical sum of vertical remapping tracer content tendency for "//trim(Reg%Tr(m)%flux_longname)
+      var_lname = "Vertical sum of vertical remapping tracer content tendency for "//&
+                  trim(Reg%Tr(m)%flux_longname)
       Tr%id_remap_cont_2d = register_diag_field('ocean_model', &
         trim(Tr%flux_nameroot)//'h_tendency_vert_remap_2d',         &
         diag%axesT1, Time, var_lname, flux_units, conversion = Tr%conv_scale)
@@ -571,8 +576,8 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
     if (use_ALE .and. (Reg%ntr<MAX_FIELDS_) .and. Tr%remap_tr) then
       unit2 = trim(units)//"2"
       if (index(units(1:len_trim(units))," ") > 0) unit2 = "("//trim(units)//")2"
-      Tr%id_tr_vardec = register_diag_field('ocean_model', trim(shortnm)//"_vardec", diag%axesTL, Time, &
-        "ALE variance decay for "//lowercase(longname), trim(unit2)//" s-1")
+      Tr%id_tr_vardec = register_diag_field('ocean_model', trim(shortnm)//"_vardec", diag%axesTL, &
+        Time, "ALE variance decay for "//lowercase(longname), trim(unit2)//" s-1")
       if (Tr%id_tr_vardec > 0) then
         ! Set up a new tracer for this tracer squared
         m2 = Reg%ntr+1


### PR DESCRIPTION
  Updated MOM6_examples to use a series of commits that eliminate the direct use
of elements of the MOM_control_struct at the driver level, and introduce a
shared MOM_state_type.  This set of commits include changes to the order of
entries in the MOM_parameter_doc files. In a note of caution, this sequence of
commit includes changes to mct_driver/ocn_comp_mct.F90 that mirror changes to
coupled_driver/ocean_model_MOM.F90, but have not been tested even to the point
of compiling due to the unavailability at GFDL of various software used by this
coupler; help is needed from someone who uses the mct_coupler to verify that
these have been done correctly!