### PR TITLE
Generalize vertical remapping and neutral diffusion diagnostics

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -41,7 +41,7 @@ use MOM_remapping,        only : remapping_core_h, remapping_core_w
 use MOM_remapping,        only : remappingSchemesDoc, remappingDefaultScheme
 use MOM_remapping,        only : remapping_CS, dzFromH1H2
 use MOM_string_functions, only : uppercase, extractWord, extract_integer
-use MOM_tracer_registry,  only : tracer_registry_type, MOM_tracer_chkinv
+use MOM_tracer_registry,  only : tracer_registry_type, tracer_type, MOM_tracer_chkinv
 use MOM_variables,        only : ocean_grid_type, thermo_var_ptrs
 use MOM_verticalGrid,     only : get_thickness_units, verticalGrid_type
 
@@ -93,7 +93,6 @@ type, public :: ALE_CS
   logical :: remap_after_initialization !<   Indicates whether to regrid/remap after initializing the state.
 
   logical :: show_call_tree !< For debugging
-  real    :: C_p            !< seawater heat capacity (J/(kg deg C))
 
   ! for diagnostics
   type(diag_ctrl), pointer           :: diag                          !< structure to regulate output
@@ -271,35 +270,14 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
 end subroutine ALE_init
 
 !> Initialize diagnostics for the ALE module.
-subroutine ALE_register_diags(Time, G, GV, diag, C_p, Reg, CS)
+subroutine ALE_register_diags(Time, G, GV, diag, CS)
   type(time_type),target,     intent(in)  :: Time  !< Time structure
   type(ocean_grid_type),      intent(in)  :: G     !< Grid structure
   type(verticalGrid_type),    intent(in)  :: GV    !< Ocean vertical grid structure
   type(diag_ctrl), target,    intent(in)  :: diag  !< Diagnostics control structure
-  real,                       intent(in)  :: C_p   !< seawater heat capacity (J/(kg deg C))
-  type(tracer_registry_type), pointer     :: Reg   !< Tracer registry
   type(ALE_CS), pointer                   :: CS    !< Module control structure
 
-  integer :: m, ntr, nsize
-
-  if (associated(Reg)) then
-    ntr = Reg%ntr
-  else
-    ntr = 0
-  endif
-  nsize = max(1,ntr)
-
   CS%diag => diag
-  CS%C_p  = C_p
-
-  allocate(CS%id_tracer_remap_tendency(nsize))
-  allocate(CS%id_Htracer_remap_tendency(nsize))
-  allocate(CS%id_Htracer_remap_tendency_2d(nsize))
-  allocate(CS%do_tendency_diag(nsize))
-  CS%do_tendency_diag(:)             = .false.
-  CS%id_tracer_remap_tendency(:)     = -1
-  CS%id_Htracer_remap_tendency(:)    = -1
-  CS%id_Htracer_remap_tendency_2d(:) = -1
 
   ! These diagnostics of the state variables before ALE are useful for
   ! debugging the ALE code.
@@ -318,52 +296,6 @@ subroutine ALE_register_diags(Time, G, GV, diag, C_p, Reg, CS)
 
   CS%id_dzRegrid = register_diag_field('ocean_model','dzRegrid',diag%axesTi,Time, &
       'Change in interface height due to ALE regridding', 'm')
-
-  if (ntr > 0) then
-    do m=1,ntr
-      if (trim(Reg%Tr(m)%name) == 'T') then
-
-        CS%id_tracer_remap_tendency(m) = register_diag_field('ocean_model',                &
-        trim(Reg%Tr(m)%name)//'_tendency_vert_remap', diag%axesTL, Time,                   &
-        'Tendency from vertical remapping for tracer concentration '//trim(Reg%Tr(m)%name),&
-        'degC s-1')
-
-        CS%id_Htracer_remap_tendency(m) = register_diag_field('ocean_model',&
-        trim(Reg%Tr(m)%name)//'h_tendency_vert_remap', diag%axesTL, Time,   &
-        'Tendency from vertical remapping for heat',                        &
-         'W m-2',v_extensive=.true.)
-
-        CS%id_Htracer_remap_tendency_2d(m) = register_diag_field('ocean_model',&
-        trim(Reg%Tr(m)%name)//'h_tendency_vert_remap_2d', diag%axesT1, Time,   &
-        'Vertical sum of tendency from vertical remapping for heat',           &
-         'W m-2')
-
-      else
-
-        CS%id_tracer_remap_tendency(m) = register_diag_field('ocean_model',                &
-        trim(Reg%Tr(m)%name)//'_tendency_vert_remap', diag%axesTL, Time,                   &
-        'Tendency from vertical remapping for tracer concentration '//trim(Reg%Tr(m)%name),&
-        'tracer concentration * s-1')
-
-        CS%id_Htracer_remap_tendency(m) = register_diag_field('ocean_model',         &
-        trim(Reg%Tr(m)%name)//'h_tendency_vert_remap', diag%axesTL, Time,            &
-        'Tendency from vertical remapping for tracer content '//trim(Reg%Tr(m)%name),&
-        'kg m-2 s-1',v_extensive=.true.)
-
-        CS%id_Htracer_remap_tendency_2d(m) = register_diag_field('ocean_model',                      &
-        trim(Reg%Tr(m)%name)//'h_tendency_vert_remap_2d', diag%axesT1, Time,                         &
-        'Vertical sum of tendency from vertical remapping for tracer content '//trim(Reg%Tr(m)%name),&
-        'kg m-2 s-1')
-
-      endif
-
-      if (CS%id_tracer_remap_tendency(m)     > 0) CS%do_tendency_diag(m) = .true.
-      if (CS%id_Htracer_remap_tendency(m)    > 0) CS%do_tendency_diag(m) = .true.
-      if (CS%id_Htracer_remap_tendency_2d(m) > 0) CS%do_tendency_diag(m) = .true.
-
-    enddo   ! m loop over tracers
-
-  endif ! ntr > 0
 
 end subroutine ALE_register_diags
 
@@ -840,6 +772,7 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
   real, dimension(GV%ke)                      :: h2
   real :: h_neglect, h_neglect_edge
   logical                                     :: show_call_tree
+  type(tracer_type), pointer                  :: Tr => NULL()
 
   show_call_tree = .false.
   if (present(debug)) show_call_tree = debug
@@ -869,10 +802,7 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
   endif
 
   if (present(dt)) then
-    work_conc(:,:,:) = 0.0
-    work_cont(:,:,:) = 0.0
-    work_2d(:,:)     = 0.0
-    Idt              = 1.0/dt
+    Idt = 1.0/dt
   endif
 
   ! Remap tracer
@@ -880,7 +810,7 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
     if (show_call_tree) call callTree_waypoint("remapping tracers (remap_all_state_vars)")
     !$OMP parallel do default(shared) private(h1,h2,u_column)
     do m=1,ntr ! For each tracer
-
+      Tr => Reg%Tr(m)
       do j = G%jsc,G%jec
         do i = G%isc,G%iec
 
@@ -889,23 +819,25 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
             ! Build the start and final grids
             h1(:) = h_old(i,j,:)
             h2(:) = h_new(i,j,:)
-            call remapping_core_h(CS_remapping, nz, h1, Reg%Tr(m)%t(i,j,:), nz, h2, &
+            call remapping_core_h(CS_remapping, nz, h1, Tr%t(i,j,:), nz, h2, &
                                   u_column, h_neglect, h_neglect_edge)
 
             ! Intermediate steps for tendency of tracer concentration and tracer content.
-            ! Note: do not merge the two if-tests, since do_tendency_diag(:) is not
-            ! allocated during the time=0 initialization call to this routine.
             if (present(dt)) then
-              if (CS_ALE%do_tendency_diag(m)) then
+              if (Tr%id_remap_conc>0) then
                 do k=1,GV%ke
-                  work_conc(i,j,k) = (u_column(k)    - Reg%Tr(m)%t(i,j,k)      ) * Idt
-                  work_cont(i,j,k) = (u_column(k)*h2(k) - Reg%Tr(m)%t(i,j,k)*h1(k)) * Idt * GV%H_to_kg_m2
+                  work_conc(i,j,k) = (u_column(k)    - Tr%t(i,j,k)      ) * Idt
+                enddo
+              endif
+              if (Tr%id_remap_cont>0. .or. Tr%id_remap_cont_2d>0) then
+                do k=1,GV%ke
+                  work_cont(i,j,k) = (u_column(k)*h2(k) - Tr%t(i,j,k)*h1(k)) * Idt
                 enddo
               endif
             endif
 
             ! update tracer concentration
-            Reg%Tr(m)%t(i,j,:) = u_column(:)
+            Tr%t(i,j,:) = u_column(:)
 
           endif
 
@@ -914,53 +846,22 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
 
 
       ! tendency diagnostics.
-      ! Note: do not merge the two if-tests if (present(dt)) and
-      ! if (CS_ALE%do_tendency_diag(m)).  The reason is that
-      ! do_tendency_diag(:) is not allocated when this routine is called
-      ! during initialization (time=0). So need to keep the if-tests split.
-      if (present(dt)) then
-        if (CS_ALE%do_tendency_diag(m)) then
-
-          if (CS_ALE%id_tracer_remap_tendency(m) > 0) then
-            call post_data(CS_ALE%id_tracer_remap_tendency(m), work_conc, CS_ALE%diag, alt_h = h_new)
-          endif
-
-          if (CS_ALE%id_Htracer_remap_tendency(m) > 0 .or. CS_ALE%id_Htracer_remap_tendency_2d(m) > 0) then
-            if (trim(Reg%Tr(m)%name) == 'T') then
-              do k=1,GV%ke
-                do j = G%jsc,G%jec
-                  do i = G%isc,G%iec
-                    work_cont(i,j,k) = work_cont(i,j,k) * CS_ALE%C_p
-                  enddo
-                enddo
-              enddo
-            elseif (trim(Reg%Tr(m)%name) == 'S') then
-              do k=1,GV%ke
-                do j = G%jsc,G%jec
-                  do i = G%isc,G%iec
-                    work_cont(i,j,k) = work_cont(i,j,k) * ppt2mks
-                  enddo
-                enddo
-              enddo
-            endif
-          endif
-
-          if (CS_ALE%id_Htracer_remap_tendency(m) > 0) then
-            call post_data(CS_ALE%id_Htracer_remap_tendency(m), work_cont, CS_ALE%diag, alt_h = h_new)
-          endif
-          if (CS_ALE%id_Htracer_remap_tendency_2d(m) > 0) then
-            do j = G%jsc,G%jec
-              do i = G%isc,G%iec
-                work_2d(i,j) = 0.0
-                do k = 1,GV%ke
-                  work_2d(i,j) = work_2d(i,j) + work_cont(i,j,k)
-                enddo
-              enddo
+     if (Tr%id_remap_conc > 0) then
+        call post_data(Tr%id_remap_conc, work_conc, CS_ALE%diag, alt_h = h_new)
+      endif
+      if (Tr%id_remap_cont > 0) then
+        call post_data(Tr%id_remap_cont, work_cont, CS_ALE%diag, alt_h = h_new)
+      endif
+      if (Tr%id_remap_cont_2d > 0) then
+        do j = G%jsc,G%jec
+          do i = G%isc,G%iec
+            work_2d(i,j) = 0.0
+            do k = 1,GV%ke
+              work_2d(i,j) = work_2d(i,j) + work_cont(i,j,k)
             enddo
-            call post_data(CS_ALE%id_Htracer_remap_tendency_2d(m), work_2d, CS_ALE%diag)
-          endif
-
-        endif
+          enddo
+        enddo
+        call post_data(Tr%id_remap_cont_2d, work_2d, CS_ALE%diag)
       endif
 
     enddo ! m=1,ntr

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2156,7 +2156,7 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
   call register_tracer_diagnostics(CS%tracer_Reg, CS%h, Time, diag, G, GV, &
                                    CS%use_ALE_algorithm, CS%diag_to_Z_CSp)
   if (CS%use_ALE_algorithm) then
-    call ALE_register_diags(Time, G, GV, diag, CS%tv%C_p, CS%tracer_Reg, CS%ALE_CSp)
+    call ALE_register_diags(Time, G, GV, diag, CS%ALE_CSp)
   endif
 
   ! This subroutine initializes any tracer packages.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -123,7 +123,7 @@ use MOM_tracer_hor_diff,       only : tracer_hor_diff_end, tracer_hor_diff_CS
 use MOM_tracer_registry,       only : register_tracer, tracer_registry_init
 use MOM_tracer_registry,       only : register_tracer_diagnostics, post_tracer_diagnostics
 use MOM_tracer_registry,       only : preALE_tracer_diagnostics, postALE_tracer_diagnostics
-use MOM_tracer_registry,       only : add_tracer_diagnostics, tracer_registry_type
+use MOM_tracer_registry,       only : tracer_registry_type
 use MOM_tracer_registry,       only : lock_tracer_registry, tracer_registry_end
 use MOM_tracer_flow_control,   only : call_tracer_register, tracer_flow_control_CS
 use MOM_tracer_flow_control,   only : tracer_flow_control_init, call_tracer_surface_state

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -105,7 +105,7 @@ use MOM_MEKE,                  only : MEKE_init, MEKE_alloc_register_restart, st
 use MOM_MEKE_types,            only : MEKE_type
 use MOM_mixed_layer_restrat,   only : mixedlayer_restrat, mixedlayer_restrat_init, mixedlayer_restrat_CS
 use MOM_mixed_layer_restrat,   only : mixedlayer_restrat_register_restarts
-use MOM_neutral_diffusion,     only : neutral_diffusion_CS, neutral_diffusion_diag_init
+use MOM_neutral_diffusion,     only : neutral_diffusion_CS
 use MOM_obsolete_diagnostics,  only : register_obsolete_diagnostics
 use MOM_open_boundary,         only : OBC_registry_type, register_temp_salt_segments
 use MOM_open_boundary,         only : open_boundary_register_restarts
@@ -1825,12 +1825,12 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
                            tr_desc=CS%vd_T, registry_diags=.true., flux_nameroot='T', &
                            flux_units='W m-2', flux_longname='Heat', &
                            flux_scale=conv2watt, convergence_units='W m-2', &
-                           convergence_scale=conv2watt, CMOR_tendname="opottemptend", diag_form=2)
+                           convergence_scale=conv2watt, CMOR_tendname="opottemp", diag_form=2)
       call register_tracer(CS%tv%S, CS%tracer_Reg, param_file, dG%HI, GV, &
                            tr_desc=CS%vd_S, registry_diags=.true., flux_nameroot='S', &
                            flux_units=S_flux_units, flux_longname='Salt', &
                            flux_scale=conv2salt, convergence_units='kg m-2 s-1', &
-                           convergence_scale=0.001*GV%H_to_kg_m2, CMOR_tendname="osalttend", diag_form=2)
+                           convergence_scale=0.001*GV%H_to_kg_m2, CMOR_tendname="osalt", diag_form=2)
     endif
     if (associated(CS%OBC)) &
       call register_temp_salt_segments(GV, CS%OBC, CS%tv, CS%vd_T, CS%vd_S, param_file)
@@ -2198,7 +2198,6 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
   call cpu_clock_end(id_clock_pass_init)
 
   call register_obsolete_diagnostics(param_file, CS%diag)
-  call neutral_diffusion_diag_init(Time, G, diag, CS%tv%C_p, CS%tracer_Reg, CS%neutral_diffusion_CSp)
 
   if (CS%use_frazil) then
     if (.not.query_initialized(CS%tv%frazil,"frazil",CS%restart_CSp)) &

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -15,7 +15,7 @@ use MOM_restart, only : MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -28,7 +28,7 @@ use MOM_restart, only : MOM_restart_CS
 use MOM_ALE_sponge, only : set_up_ALE_sponge_field, ALE_sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_variables, only : surface
 use MOM_open_boundary, only : ocean_OBC_type

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -38,7 +38,7 @@ module MOM_generic_tracer
   use MOM_time_manager, only : time_type, get_time, set_time
   use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
   use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-  use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+  use MOM_tracer_registry, only : add_tracer_OBC_values
   use MOM_tracer_Z_init, only : tracer_Z_init
   use MOM_tracer_initialization_from_Z, only : MOM_initialize_tracer_from_Z
   use MOM_variables, only : surface, thermo_var_ptrs

--- a/src/tracer/MOM_neutral_diffusion_aux.F90
+++ b/src/tracer/MOM_neutral_diffusion_aux.F90
@@ -374,6 +374,8 @@ real function refine_nondim_position(CS, T_ref, S_ref, alpha_ref, beta_ref, P_to
   real :: d, e, f, fa, fb, fc, m, p, q, r, s0, sa, sb, tol, machep
 
   real :: P_last
+
+  machep = EPSILON(machep)
   if (CS%ref_pres>=0.) P_ref = CS%ref_pres
   delta_P = P_bot-P_top
   refine_nondim_position = min_bound

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -92,7 +92,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, CS, Reg, tv, do_online_fla
   type(VarMix_CS),                       pointer       :: VarMix  !< Variable mixing type
   type(verticalGrid_type),               intent(in)    :: GV      !< ocean vertical grid structure
   type(tracer_hor_diff_CS),              pointer       :: CS      !< module control structure
-  type(tracer_registry_type),            intent(inout) :: Reg     !< registered tracers
+  type(tracer_registry_type),            pointer       :: Reg     !< registered tracers
   type(thermo_var_ptrs),                 intent(in)    :: tv      !< A structure containing pointers to any available
                                                                   !! thermodynamic fields, including potential temp and
                                                                   !! salinity or mixed layer density. Absent fields have
@@ -349,10 +349,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, CS, Reg, tv, do_online_fla
       if (itt>1) then ! Update halos for subsequent iterations
         call do_group_pass(CS%pass_t, G%Domain, clock=id_clock_pass)
       endif
-      do m=1,ntr ! for each tracer
-        call neutral_diffusion(G, GV,  h, Coef_x, Coef_y, Reg%Tr(m)%t, m, I_numitts*dt, &
-                               Reg%Tr(m)%name, CS%neutral_diffusion_CSp)
-      enddo ! m
+      call neutral_diffusion(G, GV,  h, Coef_x, Coef_y, I_numitts*dt, Reg, CS%neutral_diffusion_CSp)
     enddo ! itt
 
   else    ! following if not using neutral diffusion, but instead along-surface diffusion

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -104,6 +104,7 @@ type, public :: tracer_type
   integer :: id_adx_2d = -1, id_ady_2d = -1, id_dfx_2d = -1, id_dfy_2d = -1
   integer :: id_adv_xy = -1, id_adv_xy_2d = -1
   integer :: id_dfxy_cont = -1, id_dfxy_cont_2d = -1, id_dfxy_conc = -1
+  integer :: id_remap_conc = -1, id_remap_cont = -1, id_remap_cont_2d = -1
   integer :: id_tendency = -1, id_trxh_tendency = -1, id_trxh_tendency_2d = -1
   integer :: id_tr_vardec = -1
 end type tracer_type
@@ -550,6 +551,25 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
       call register_Z_tracer(Tr%t, name, longname, units, Time, G, diag_to_Z_CSp, &
                cmor_field_name=cmorname, cmor_standard_name=cmor_long_std(cmor_longname), &
                cmor_long_name=cmor_longname)
+    endif
+
+    ! Vertical regridding/remapping tendencies
+    if (use_ALE .and. Tr%remap_tr) then
+      var_lname = "Vertical remapping tracer concentration tendency for "//trim(Reg%Tr(m)%name)
+      Tr%id_remap_conc= register_diag_field('ocean_model',                          &
+        trim(Tr%flux_nameroot)//'_tendency_vert_remap', diag%axesTL, Time, var_lname, &
+        trim(units)//'s-1')
+
+      var_lname = "Vertical remapping tracer content tendency for "//trim(Reg%Tr(m)%flux_longname)
+      Tr%id_remap_cont = register_diag_field('ocean_model', &
+        trim(Tr%flux_nameroot)//'h_tendency_vert_remap',         &
+        diag%axesTL, Time, var_lname, flux_units, v_extensive=.true., conversion = Tr%conv_scale)
+
+      var_lname = "Vertical sum of verrtical remapping tracer content tendency for "//trim(Reg%Tr(m)%flux_longname)
+      Tr%id_remap_cont_2d = register_diag_field('ocean_model', &
+        trim(Tr%flux_nameroot)//'h_tendency_vert_remap_2d',         &
+        diag%axesT1, Time, var_lname, flux_units, conversion = Tr%conv_scale)
+
     endif
 
     if (use_ALE .and. (Reg%ntr<MAX_FIELDS_) .and. Tr%remap_tr) then

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -534,7 +534,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
       cmor_var_lname = trim(cmor_var_lname)//" Vertical Sum"
       Tr%id_trxh_tendency_2d = register_diag_field('ocean_model', trim(shortnm)//'h_tendency_2d', &
           diag%axesT1, Time, "Vertical sum of "//trim(lowercase(var_lname)), conv_units, &
-          cmor_field_name=trim(Tr%cmor_tendname)//"_2d", &
+          cmor_field_name=trim(Tr%cmor_tendname)//"tend_2d", &
           cmor_standard_name=cmor_long_std(cmor_var_lname), cmor_long_name=cmor_var_lname, &
           conversion=Tr%conv_scale, x_cell_method = 'sum', y_cell_method = 'sum')
     endif

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -29,7 +29,7 @@ public register_tracer
 public MOM_tracer_chksum, MOM_tracer_chkinv
 public register_tracer_diagnostics, post_tracer_diagnostics
 public preALE_tracer_diagnostics, postALE_tracer_diagnostics
-public add_tracer_diagnostics, add_tracer_OBC_values
+public add_tracer_OBC_values
 public tracer_registry_init, lock_tracer_registry, tracer_registry_end
 
 !> The tracer type
@@ -327,53 +327,6 @@ subroutine add_tracer_OBC_values(name, Reg, OBC_inflow, OBC_in_u, OBC_in_v)
 
 end subroutine add_tracer_OBC_values
 
-
-!> This subroutine adds diagnostic arrays for a tracer that has
-!! previously been registered by a call to register_tracer.
-subroutine add_tracer_diagnostics(name, Reg, ad_x, ad_y, df_x, df_y, &
-                                  ad_2d_x, ad_2d_y, df_2d_x, df_2d_y,&
-                                  advection_xy)
-  character(len=*), intent(in)              :: name         !< name of the tracer for which the diagnostic points
-  type(tracer_registry_type), pointer       :: Reg          !< pointer to the tracer registry
-  real, dimension(:,:,:), pointer, optional :: ad_x         !< diagnostic x-advective flux (CONC m3/s or CONC*kg/s)
-  real, dimension(:,:,:), pointer, optional :: ad_y         !< diagnostic y-advective flux (CONC m3/s or CONC*kg/s)
-  real, dimension(:,:,:), pointer, optional :: df_x         !< diagnostic x-diffusive flux (CONC m3/s or CONC*kg/s)
-  real, dimension(:,:,:), pointer, optional :: df_y         !< diagnostic y-diffusive flux (CONC m3/s or CONC*kg/s)
-  real, dimension(:,:),   pointer, optional :: ad_2d_x      !< vert sum of diagnostic x-advect flux (CONC m3/s or CONC*kg/s)
-  real, dimension(:,:),   pointer, optional :: ad_2d_y      !< vert sum of diagnostic y-advect flux (CONC m3/s or CONC*kg/s)
-  real, dimension(:,:),   pointer, optional :: df_2d_x      !< vert sum of diagnostic x-diffuse flux (CONC m3/s or CONC*kg/s)
-  real, dimension(:,:),   pointer, optional :: df_2d_y      !< vert sum of diagnostic y-diffuse flux (CONC m3/s or CONC*kg/s)
-
-  real, dimension(:,:,:), pointer, optional :: advection_xy !< convergence of lateral advective tracer fluxes
-
-  integer :: m
-
-  if (.not. associated(Reg)) call MOM_error(FATAL, "add_tracer_diagnostics: "// &
-       "register_tracer must be called before add_tracer_diagnostics")
-
-  do m=1,Reg%ntr ; if (Reg%Tr(m)%name == trim(name)) exit ; enddo
-
-  if (m <= Reg%ntr) then
-    if (present(ad_x)) then ; if (associated(ad_x)) Reg%Tr(m)%ad_x => ad_x ; endif
-    if (present(ad_y)) then ; if (associated(ad_y)) Reg%Tr(m)%ad_y => ad_y ; endif
-    if (present(df_x)) then ; if (associated(df_x)) Reg%Tr(m)%df_x => df_x ; endif
-    if (present(df_y)) then ; if (associated(df_y)) Reg%Tr(m)%df_y => df_y ; endif
-
-    if (present(ad_2d_x)) then ; if (associated(ad_2d_x)) Reg%Tr(m)%ad2d_x => ad_2d_x ; endif
-    if (present(ad_2d_y)) then ; if (associated(ad_2d_y)) Reg%Tr(m)%ad2d_y => ad_2d_y ; endif
-    if (present(df_2d_x)) then ; if (associated(df_2d_x)) Reg%Tr(m)%df2d_x => df_2d_x ; endif
-    if (present(df_2d_y)) then ; if (associated(df_2d_y)) Reg%Tr(m)%df2d_y => df_2d_y ; endif
-
-    if (present(advection_xy)) then ; if (associated(advection_xy)) Reg%Tr(m)%advection_xy => advection_xy ; endif
-
-  else
-
-    call MOM_error(FATAL, "MOM_tracer: register_tracer must be called for "//&
-             trim(name)//" before add_tracer_diagnostics is called for it.")
-  endif
-
-end subroutine add_tracer_diagnostics
-
 !> register_tracer_diagnostics does a set of register_diag_field calls for any previously
 !! registered in a tracer registry with a value of registry_diags set to .true.
 subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_to_Z_CSp)
@@ -412,8 +365,8 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
-  if (.not. associated(Reg)) call MOM_error(FATAL, "add_tracer_diagnostics: "// &
-       "register_tracer must be called before add_tracer_diagnostics")
+  if (.not. associated(Reg)) call MOM_error(FATAL, "register_tracer_diagnostics: "// &
+       "register_tracer must be called before register_tracer_diagnostics")
 
   nTr_in = Reg%ntr
 

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -466,12 +466,11 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
         diag%axesTL, Time, &
         'Horizontal convergence of residual mean advective fluxes of '//&
         trim(lowercase(flux_longname)), conv_units, v_extensive=.true., &
-        conversion=Tr%conv_scale, x_cell_method = 'sum', y_cell_method = 'sum')
+        conversion=Tr%conv_scale)
     Tr%id_adv_xy_2d = register_diag_field('ocean_model', trim(shortnm)//"_advection_xy_2d", &
         diag%axesT1, Time, &
         'Vertical sum of horizontal convergence of residual mean advective fluxes of '//&
-        trim(lowercase(flux_longname)), conv_units, conversion=Tr%conv_scale, &
-        x_cell_method = 'sum', y_cell_method = 'sum')
+        trim(lowercase(flux_longname)), conv_units, conversion=Tr%conv_scale)
     if ((Tr%id_adv_xy > 0) .or. (Tr%id_adv_xy_2d > 0)) &
       call safe_alloc_ptr(Tr%advection_xy,isd,ied,jsd,jed,nz)
 
@@ -519,24 +518,22 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
     var_lname = "Net time tendency for "//lowercase(flux_longname)
     if (len_trim(Tr%cmor_tendname) == 0) then
       Tr%id_trxh_tendency = register_diag_field('ocean_model', trim(shortnm)//'h_tendency', &
-          diag%axesTL, Time, var_lname, conv_units, &
-          v_extensive=.true., x_cell_method = 'sum', y_cell_method = 'sum')
+          diag%axesTL, Time, var_lname, conv_units, v_extensive=.true.)
       Tr%id_trxh_tendency_2d = register_diag_field('ocean_model', trim(shortnm)//'h_tendency_2d', &
-          diag%axesT1, Time, "Vertical sum of "//trim(lowercase(var_lname)), conv_units,          &
-          x_cell_method = 'sum', y_cell_method = 'sum')
+          diag%axesT1, Time, "Vertical sum of "//trim(lowercase(var_lname)), conv_units)
     else
       cmor_var_lname = "Tendency of "//trim(cmor_longname)//" Expressed as "//trim(flux_longname)//" Content"
       Tr%id_trxh_tendency = register_diag_field('ocean_model', trim(shortnm)//'h_tendency', &
           diag%axesTL, Time, var_lname, conv_units, &
           cmor_field_name=trim(Tr%cmor_tendname)//"tend", &
           cmor_standard_name=cmor_long_std(cmor_var_lname), cmor_long_name=cmor_var_lname, &
-          v_extensive=.true., conversion=Tr%conv_scale, x_cell_method = 'sum', y_cell_method = 'sum')
+          v_extensive=.true., conversion=Tr%conv_scale)
       cmor_var_lname = trim(cmor_var_lname)//" Vertical Sum"
       Tr%id_trxh_tendency_2d = register_diag_field('ocean_model', trim(shortnm)//'h_tendency_2d', &
           diag%axesT1, Time, "Vertical sum of "//trim(lowercase(var_lname)), conv_units, &
           cmor_field_name=trim(Tr%cmor_tendname)//"tend_2d", &
           cmor_standard_name=cmor_long_std(cmor_var_lname), cmor_long_name=cmor_var_lname, &
-          conversion=Tr%conv_scale, x_cell_method = 'sum', y_cell_method = 'sum')
+          conversion=Tr%conv_scale)
     endif
     if ((Tr%id_trxh_tendency > 0) .or. (Tr%id_trxh_tendency_2d > 0)) then
       call safe_alloc_ptr(Tr%Trxh_prev,isd,ied,jsd,jed,nz)
@@ -565,7 +562,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
         trim(Tr%flux_nameroot)//'h_tendency_vert_remap',         &
         diag%axesTL, Time, var_lname, flux_units, v_extensive=.true., conversion = Tr%conv_scale)
 
-      var_lname = "Vertical sum of verrtical remapping tracer content tendency for "//trim(Reg%Tr(m)%flux_longname)
+      var_lname = "Vertical sum of vertical remapping tracer content tendency for "//trim(Reg%Tr(m)%flux_longname)
       Tr%id_remap_cont_2d = register_diag_field('ocean_model', &
         trim(Tr%flux_nameroot)//'h_tendency_vert_remap_2d',         &
         diag%axesT1, Time, var_lname, flux_units, conversion = Tr%conv_scale)

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -388,7 +388,6 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, use_ALE, diag_
     cmorname = Tr%cmor_name ; cmor_longname = Tr%cmor_longname
     shortnm = Tr%flux_nameroot
     flux_longname = Tr%flux_longname
-    print *, name
     if (len_trim(cmor_longname) == 0) cmor_longname = longname
 
     if (len_trim(Tr%flux_units) > 0) then ; flux_units = Tr%flux_units

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -49,7 +49,7 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -16,7 +16,7 @@ use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_C
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -15,7 +15,7 @@ use MOM_restart,            only : query_initialized, MOM_restart_CS
 use MOM_sponge,             only : set_up_sponge_field, sponge_CS
 use MOM_time_manager,       only : time_type, get_time
 use MOM_tracer_registry,    only : register_tracer, tracer_registry_type
-use MOM_tracer_registry,    only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry,    only : add_tracer_OBC_values
 use MOM_tracer_diabatic,    only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init,      only : tracer_Z_init
 use MOM_variables,          only : surface

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -14,7 +14,7 @@ use MOM_open_boundary,      only : ocean_OBC_type
 use MOM_restart,            only : MOM_restart_CS
 use MOM_time_manager,       only : time_type, get_time
 use MOM_tracer_registry,    only : register_tracer, tracer_registry_type
-use MOM_tracer_registry,    only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry,    only : add_tracer_OBC_values
 use MOM_tracer_diabatic,    only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_variables,          only : surface
 use MOM_verticalGrid,       only : verticalGrid_type

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -50,7 +50,7 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -50,7 +50,7 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -50,7 +50,7 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -46,7 +46,7 @@ use MOM_restart, only : MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_diagnostics, add_tracer_OBC_values
+use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 


### PR DESCRIPTION
This PR continues the reworking of tracer tendencies begun by @Hallberg-NOAA in PR #687 and #689.   
For the tracer content and concentration tendencies due to the vertical remapping and neutral diffusion, unit conversions were done inside those respective modules requiring special tracer-name dependent code. The registration of these diagnostics have been moved into the tracer registry and the conversion argument in register_diag used to handle the conversion.

I have ensured that this PR does not change the actual diagnostics in the model output. Some diagnostic names have changed; neutral diffusion flux diagnostics most notably since the df_x_2d and df_y_2d diagnostics already exist. 

Closes issue #699. 