### PR TITLE
Fix NaN in radiation OBCs

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -326,10 +326,10 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   if (associated(CS%OBC)) then
     if (CS%debug_OBC) call open_boundary_test_extern_h(G, CS%OBC, h)
 
-    do k=1,nz ; do j=js-1,je+1 ; do I=is-2,ie+1
+    do k=1,nz ; do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB
       u_old_rad_OBC(I,j,k) = u_av(I,j,k)
     enddo ; enddo ; enddo
-    do k=1,nz ; do J=js-2,je+1 ; do i=is-1,ie+1
+    do k=1,nz ; do J=G%JsdB,G%JedB ; do i=G%isd,G%ied
       v_old_rad_OBC(i,J,k) = v_av(i,J,k)
     enddo ; enddo ; enddo
   endif


### PR DESCRIPTION
- NCI tests of circle_obcs with Intel debug executable failed with a
  floating invalid:
  https://accessdev.nci.org.au/jenkins/job/mom-ocean.org/job/MOM6_run/build=DEBUG,compiler=intel,experiment=ocean_only-circle_obcs,label=nah599,memory_type=dynamic_symmetric/lastBuild/console
  Thanks to @nicjhan for keeping these going.
- Arrays u_old_rad_OBC abd v_old_rad_OBC were not set in parts of the
  halo which are referenced with in the open boundary code. This commit
  forces a copy of the entire data domain.