### PR TITLE
OMP bug fix

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -808,7 +808,7 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
   ! Remap tracer
   if (ntr>0) then
     if (show_call_tree) call callTree_waypoint("remapping tracers (remap_all_state_vars)")
-    !$OMP parallel do default(shared) private(h1,h2,u_column)
+    !$OMP parallel do default(shared) private(h1,h2,u_column,Tr)
     do m=1,ntr ! For each tracer
       Tr => Reg%Tr(m)
       do j = G%jsc,G%jec


### PR DESCRIPTION
- A pointer variable should have been declared private since it changes inside the OMP loop
  and OMP threads access it inside the loop. This caused a "extreme values" FATAL condition
  in global_ALE_z  running with 2 threads on theta.