### PR TITLE
Fixdome

### DIFF
--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -14,7 +14,7 @@ use MOM_open_boundary,         only : ocean_obc_type, update_OBC_segment_data
 use MOM_open_boundary,         only : OBC_registry_type, file_OBC_CS
 use MOM_open_boundary,         only : register_file_OBC, file_OBC_end
 use MOM_verticalGrid,          only : verticalGrid_type
-use MOM_tracer_registry,       only : add_tracer_OBC_values, tracer_registry_type
+use MOM_tracer_registry,       only : tracer_registry_type
 use MOM_variables,             only : thermo_var_ptrs
 use tidal_bay_initialization,  only : tidal_bay_set_OBC_data, register_tidal_bay_OBC
 use tidal_bay_initialization,  only : tidal_bay_OBC_end, tidal_bay_OBC_CS

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -2407,7 +2407,7 @@ subroutine register_segment_tracer(tr_desc, param_file, GV, segment, tr_desc_ptr
   type(verticalGrid_type),        intent(in)    :: GV           !< ocean vertical grid structure
   type(vardesc),         intent(in)             :: tr_desc      !< metadata about the tracer
   type(param_file_type), intent(in)             :: param_file   !< file to parse for  model parameter values
-  type(OBC_segment_type), intent(inout)            :: segment      !< current segment data structure
+  type(OBC_segment_type), intent(inout)         :: segment      !< current segment data structure
   type(vardesc), target, optional               :: tr_desc_ptr  !< A target that can be used to set a pointer to the
                                                                 !! stored value of tr%tr_desc. This target must be
                                                                 !! an enduring part of the control structure,

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -180,7 +180,8 @@ type, public :: ocean_OBC_type
                                                       !! in the strain on open boundaries.
   logical :: zero_biharmonic = .false.                !< If True, zeros the Laplacian of flow on open boundaries for
                                                       !! use in the biharmonic viscosity term.
-  logical :: extend_segments = .false.                !< If True, extend OBC segments (for testing)
+! logical :: extend_segments = .false.                !< If True, extend OBC segments (for testing)
+  logical :: brushcutter_mode = .false.               !< If True, read data on supergrid.
   real :: g_Earth
   ! Properties of the segments used.
   type(OBC_segment_type), pointer, dimension(:) :: &
@@ -278,10 +279,10 @@ subroutine open_boundary_config(G, param_file, OBC)
 
   if (config1 .ne. "none") OBC%user_BCs_set_globally = .true.
 
-  call get_param(param_file, mdl, "EXTEND_OBC_SEGMENTS", OBC%extend_segments, &
-                   "If true, extend OBC segments. This option is used to recover\n"//&
-                   "legacy solutions dependent on an incomplete implementaion of OBCs.\n"//&
-                   "This option will be obsoleted in the future.", default=.false.)
+! call get_param(param_file, mdl, "EXTEND_OBC_SEGMENTS", OBC%extend_segments, &
+!                  "If true, extend OBC segments. This option is used to recover\n"//&
+!                  "legacy solutions dependent on an incomplete implementaion of OBCs.\n"//&
+!                  "This option will be obsoleted in the future.", default=.false.)
 
   if (OBC%number_of_segments > 0) then
     call get_param(param_file, mdl, "OBC_ZERO_VORTICITY", OBC%zero_vorticity, &
@@ -657,13 +658,13 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg)
   Je_obc = Je_obc - G%jdg_offset ! Convert to local tile indices on this tile
 
   ! Hack to extend segment by one point
-  if (OBC%extend_segments) then
-    if (Js_obc<Je_obc) then
-      Js_obc = Js_obc - 1 ; Je_obc = Je_obc + 1
-    else
-      Js_obc = Js_obc + 1 ; Je_obc = Je_obc - 1
-    endif
-  endif
+! if (OBC%extend_segments) then
+!   if (Js_obc<Je_obc) then
+!     Js_obc = Js_obc - 1 ; Je_obc = Je_obc + 1
+!   else
+!     Js_obc = Js_obc + 1 ; Je_obc = Je_obc - 1
+!   endif
+! endif
 
   if (Je_obc>Js_obc) then
     OBC%segment(l_seg)%direction = OBC_DIRECTION_E
@@ -709,10 +710,10 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg)
       OBC%segment(l_seg)%specified = .true.
       OBC%specified_u_BCs_exist_globally = .true. ! This avoids deallocation
       ! Hack to undo the hack above for SIMPLE BCs
-      if (OBC%extend_segments) then
-        Js_obc = Js_obc + 1
-        Je_obc = Je_obc - 1
-      endif
+!     if (OBC%extend_segments) then
+!       Js_obc = Js_obc + 1
+!       Je_obc = Je_obc - 1
+!     endif
     else
       call MOM_error(FATAL, "MOM_open_boundary.F90, setup_u_point_obc: "//&
                      "String '"//trim(action_str(a_loop))//"' not understood.")
@@ -759,13 +760,13 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg)
   Ie_obc = Ie_obc - G%idg_offset ! Convert to local tile indices on this tile
 
   ! Hack to extend segment by one point
-  if (OBC%extend_segments) then
-    if (Is_obc<Ie_obc) then
-      Is_obc = Is_obc - 1 ; Ie_obc = Ie_obc + 1
-    else
-      Is_obc = Is_obc + 1 ; Ie_obc = Ie_obc - 1
-    endif
-  endif
+! if (OBC%extend_segments) then
+!   if (Is_obc<Ie_obc) then
+!     Is_obc = Is_obc - 1 ; Ie_obc = Ie_obc + 1
+!   else
+!     Is_obc = Is_obc + 1 ; Ie_obc = Ie_obc - 1
+!   endif
+! endif
 
   if (Ie_obc>Is_obc) then
      OBC%segment(l_seg)%direction = OBC_DIRECTION_S
@@ -811,10 +812,10 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg)
       OBC%segment(l_seg)%specified = .true.
       OBC%specified_v_BCs_exist_globally = .true. ! This avoids deallocation
       ! Hack to undo the hack above for SIMPLE BCs
-      if (OBC%extend_segments) then
-        Is_obc = Is_obc + 1
-        Ie_obc = Ie_obc - 1
-      endif
+!     if (OBC%extend_segments) then
+!       Is_obc = Is_obc + 1
+!       Ie_obc = Ie_obc - 1
+!     endif
     else
       call MOM_error(FATAL, "MOM_open_boundary.F90, setup_v_point_obc: "//&
                      "String '"//trim(action_str(a_loop))//"' not understood.")

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -40,7 +40,7 @@ public open_boundary_impose_normal_slope
 public open_boundary_impose_land_mask
 public radiation_open_bdry_conds
 public set_tracer_data
-public update_obc_segment_data
+public update_OBC_segment_data
 public open_boundary_test_extern_uv
 public open_boundary_test_extern_h
 public open_boundary_zero_normal_flow

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -66,6 +66,8 @@ subroutine find_obsolete_params(param_file)
        hint="Instead use OBC_SEGMENT_XXX_DATA.")
   call obsolete_char(param_file, "READ_OBC_TS", &
        hint="Instead use OBC_SEGMENT_XXX_DATA.")
+  call obsolete_char(param_file, "EXTEND_OBC_SEGMENTS", &
+       hint="This option is no longer needed, nor supported.")
 
   test_logic3 = .true. ; call read_param(param_file,"ENABLE_THERMODYNAMICS",test_logic3)
   test_logic = .true. ; call read_param(param_file,"TEMPERATURE",test_logic)

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -23,7 +23,8 @@ use MOM_io, only : slasher, vardesc, write_field
 use MOM_io, only : EAST_FACE, NORTH_FACE , SINGLE_FILE, MULTIPLE
 use MOM_open_boundary, only : ocean_OBC_type, open_boundary_init
 use MOM_open_boundary, only : OBC_NONE, OBC_SIMPLE
-use MOM_open_boundary, only : open_boundary_query, set_tracer_data
+use MOM_open_boundary, only : open_boundary_query
+use MOM_open_boundary, only : set_tracer_data
 use MOM_open_boundary, only : open_boundary_test_extern_h
 use MOM_open_boundary, only : fill_temp_salt_segments
 !use MOM_open_boundary, only : set_3D_OBC_data
@@ -35,7 +36,7 @@ use MOM_ALE_sponge, only : set_up_ALE_sponge_field, initialize_ALE_sponge
 use MOM_ALE_sponge, only : ALE_sponge_CS
 use MOM_string_functions, only : uppercase, lowercase
 use MOM_time_manager, only : time_type, set_time
-use MOM_tracer_registry, only : add_tracer_OBC_values, tracer_registry_type
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : setVerticalGridAxes, verticalGrid_type
 use MOM_ALE, only : pressure_gradient_plm

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -2,25 +2,26 @@ module DOME_tracer
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_diag_mediator, only : diag_ctrl
-use MOM_diag_to_Z, only : diag_to_Z_CS
-use MOM_error_handler, only : MOM_error, FATAL, WARNING
-use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
-use MOM_forcing_type, only : forcing
-use MOM_hor_index, only : hor_index_type
-use MOM_grid, only : ocean_grid_type
-use MOM_io, only : file_exists, MOM_read_data, slasher, vardesc, var_desc, query_vardesc
-use MOM_open_boundary, only : ocean_OBC_type
-use MOM_restart, only : MOM_restart_CS
-use MOM_sponge, only : set_up_sponge_field, sponge_CS
-use MOM_time_manager, only : time_type, get_time
+use MOM_diag_mediator,   only : diag_ctrl
+use MOM_diag_to_Z,       only : diag_to_Z_CS
+use MOM_error_handler,   only : MOM_error, FATAL, WARNING
+use MOM_file_parser,     only : get_param, log_param, log_version, param_file_type
+use MOM_forcing_type,    only : forcing
+use MOM_hor_index,       only : hor_index_type
+use MOM_grid,            only : ocean_grid_type
+use MOM_io,              only : file_exists, MOM_read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_open_boundary,   only : ocean_OBC_type, OBC_segment_tracer_type
+use MOM_open_boundary,   only : OBC_segment_type
+use MOM_restart,         only : MOM_restart_CS
+use MOM_sponge,          only : set_up_sponge_field, sponge_CS
+use MOM_time_manager,    only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
-use MOM_variables, only : surface
-use MOM_verticalGrid, only : verticalGrid_type
+use MOM_variables,       only : surface
+use MOM_verticalGrid,    only : verticalGrid_type
 
-use coupler_types_mod, only : coupler_type_set_data, ind_csurf
+use coupler_types_mod,      only : coupler_type_set_data, ind_csurf
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 
 implicit none ; private
@@ -79,6 +80,7 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_DOME_tracer
   integer :: isd, ied, jsd, jed, nz, m
+  type(OBC_segment_type), pointer :: segment
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
@@ -277,11 +279,15 @@ subroutine initialize_DOME_tracer(restart, day, G, GV, h, diag, OBC, CS, &
   if (associated(OBC)) then
     call query_vardesc(CS%tr_desc(1), name, caller="initialize_DOME_tracer")
     if (OBC%specified_v_BCs_exist_globally) then
-      allocate(OBC_tr1_v(G%isd:G%ied,G%jsd:G%jed,nz))
-      do k=1,nz ; do j=G%jsd,G%jed ; do i=G%isd,G%ied
-        if (k < nz/2) then ; OBC_tr1_v(i,j,k) = 0.0
-        else ; OBC_tr1_v(i,j,k) = 1.0 ; endif
+      segment => OBC%segment(1)
+      allocate(segment%field(1)%buffer_src(segment%HI%isd:segment%HI%ied,segment%HI%JsdB:segment%HI%JedB,nz))
+!     allocate(OBC_tr1_v(G%isd:G%ied,G%jsd:G%jed,nz))
+      do k=1,nz ; do j=segment%HI%jsd,segment%HI%jed ; do i=segment%HI%isd,segment%HI%ied
+        if (k < nz/2) then ; segment%field(1)%buffer_src(i,j,k) = 0.0
+        else ; segment%field(1)%buffer_src(i,j,k) = 1.0 ; endif
       enddo ; enddo ; enddo
+      call register_segment_tracer(CS%tr_desc(1), param_file, GV, &
+                                   OBC%segment(1), OBC_scalar=dye)
       call add_tracer_OBC_values(trim(name), CS%tr_Reg, &
                                  0.0, OBC_in_v=OBC_tr1_v)
     else
@@ -293,6 +299,8 @@ subroutine initialize_DOME_tracer(restart, day, G, GV, h, diag, OBC, CS, &
     do m=2,NTR
       call query_vardesc(CS%tr_desc(m), name, caller="initialize_DOME_tracer")
       call add_tracer_OBC_values(trim(name), CS%tr_Reg, 0.0)
+      call register_segment_tracer(tr_desc(m), param_file, GV, &
+                                   OBC%segment(n), OBC_scalar=dye)
     enddo
   endif
 

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -28,7 +28,6 @@ use MOM_restart, only : MOM_restart_CS
 use MOM_ALE_sponge, only : set_up_ALE_sponge_field, ALE_sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_variables, only : surface
 use MOM_open_boundary, only : ocean_OBC_type

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -60,7 +60,6 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
@@ -412,10 +411,7 @@ subroutine initialize_OCMIP2_CFC(restart, day, G, GV, h, diag, OBC, CS, &
                          CS%CFC12_IC_val, G, CS)
 
   if (associated(OBC)) then
-  ! By default, all tracers have 0 concentration in their inflows. This may
-  ! make the following calls are unnecessary.
-  !  call add_tracer_OBC_values(trim(CS%CFC11_desc%name), CS%tr_Reg, 0.0)
-  !  call add_tracer_OBC_values(trim(CS%CFC12_desc%name), CS%tr_Reg, 0.0)
+  ! Steal from updated DOME in the fullness of time.
   endif
 
 end subroutine initialize_OCMIP2_CFC

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -38,7 +38,6 @@ module MOM_generic_tracer
   use MOM_time_manager, only : time_type, get_time, set_time
   use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
   use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-  use MOM_tracer_registry, only : add_tracer_OBC_values
   use MOM_tracer_Z_init, only : tracer_Z_init
   use MOM_tracer_initialization_from_Z, only : MOM_initialize_tracer_from_Z
   use MOM_variables, only : surface, thermo_var_ptrs

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -295,26 +295,7 @@ subroutine tracer_flow_control_init(restart, day, G, GV, h, param_file, diag, OB
                                                !! structure for diagnostics in depth space.
   type(thermo_var_ptrs),                 intent(in)    :: tv      !< A structure pointing to various
                                                                   !! thermodynamic variables
-!   This subroutine calls all registered tracer initialization
-! subroutines.
 
-! Arguments: restart - 1 if the fields have already been read from
-!                     a restart file.
-!  (in)      day - Time of the start of the run.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      h - Layer thickness, in m (Boussinesq) or kg m-2 (non-Boussinesq).
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in)      OBC - This open boundary condition type specifies whether, where,
-!                  and what open boundary conditions are used.
-!  (in)      CS - The control structure returned by a previous call to
-!                 call_tracer_register.
-!  (in/out)  sponge_CSp - A pointer to the control structure for the sponges, if
-!                         they are in use.  Otherwise this may be unassociated.
-!  (in/out)  ALE_sponge_CSp - A pointer to the control structure for the ALE sponges, if they are
-!                             in use.  Otherwise this may be unassociated.
-!  (in/out)  diag_to_Z_Csp - A pointer to the control structure for diagnostics
-!                            in depth space.
   if (.not. associated(CS)) call MOM_error(FATAL, "tracer_flow_control_init: "// &
          "Module must be initialized via call_tracer_register before it is used.")
 
@@ -324,7 +305,7 @@ subroutine tracer_flow_control_init(restart, day, G, GV, h, param_file, diag, OB
                                 sponge_CSp, diag_to_Z_CSp)
   if (CS%use_DOME_tracer) &
     call initialize_DOME_tracer(restart, day, G, GV, h, diag, OBC, CS%DOME_tracer_CSp, &
-                                sponge_CSp, diag_to_Z_CSp)
+                                sponge_CSp, diag_to_Z_CSp, param_file)
   if (CS%use_ISOMIP_tracer) &
     call initialize_ISOMIP_tracer(restart, day, G, GV, h, diag, OBC, CS%ISOMIP_tracer_CSp, &
                                 ALE_sponge_CSp, diag_to_Z_CSp)

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -29,7 +29,6 @@ public register_tracer
 public MOM_tracer_chksum, MOM_tracer_chkinv
 public register_tracer_diagnostics, post_tracer_diagnostics
 public preALE_tracer_diagnostics, postALE_tracer_diagnostics
-public add_tracer_OBC_values
 public tracer_registry_init, lock_tracer_registry, tracer_registry_end
 
 !> The tracer type
@@ -301,40 +300,6 @@ subroutine lock_tracer_registry(Reg)
   Reg%locked = .True.
 
 end subroutine lock_tracer_registry
-
-
-!> This subroutine adds open boundary condition concentrations for a tracer that
-!! has previously been registered by a call to register_tracer.
-subroutine add_tracer_OBC_values(name, Reg, OBC_inflow, OBC_in_u, OBC_in_v)
-  character(len=*), intent(in)               :: name        !< tracer name for which the diagnostic points
-  type(tracer_registry_type), pointer        :: Reg         !< pointer to the tracer registry
-  real, intent(in), optional                 :: OBC_inflow  !< tracer value for all inflows via the OBC
-                                                            !! for which OBC_in_u or OBC_in_v are
-                                                            !! not specified (same units as tracer CONC)
-  real, pointer, dimension(:,:,:), optional  :: OBC_in_u    !< tracer at inflows through u-face of tracer cells
-                                                            !! (same units as tracer CONC)
-  real, pointer, dimension(:,:,:), optional  :: OBC_in_v    !< tracer at inflows through v-face of tracer cells
-                                                            !! (same units as tracer CONC)
-
-  integer :: m
-
-  if (.not. associated(Reg)) call MOM_error(FATAL, "add_tracer_OBC_values :"//&
-       "register_tracer must be called before add_tracer_OBC_values")
-
-  do m=1,Reg%ntr ; if (Reg%Tr(m)%name == trim(name)) exit ; enddo
-
-  if (m <= Reg%ntr) then
-!   if (present(OBC_inflow)) Reg%Tr(m)%OBC_inflow_conc = OBC_inflow
-!   if (present(OBC_in_u)) then ; if (associated(OBC_in_u)) &
-!                                     Reg%Tr(m)%OBC_in_u => OBC_in_u ; endif
-!   if (present(OBC_in_v)) then ; if (associated(OBC_in_v)) &
-!                                     Reg%Tr(m)%OBC_in_v => OBC_in_v ; endif
-  else
-    call MOM_error(FATAL, "MOM_tracer: register_tracer must be called for "//&
-             trim(name)//" before add_tracer_OBC_values is called for it.")
-  endif
-
-end subroutine add_tracer_OBC_values
 
 !> register_tracer_diagnostics does a set of register_diag_field calls for any previously
 !! registered in a tracer registry with a value of registry_diags set to .true.

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -36,11 +36,11 @@ public tracer_registry_init, lock_tracer_registry, tracer_registry_end
 type, public :: tracer_type
 
   real, dimension(:,:,:), pointer :: t              => NULL() !< tracer concentration array
-  real                            :: OBC_inflow_conc=  0.0    !< tracer concentration for generic inflows
-  real, dimension(:,:,:), pointer :: OBC_in_u       => NULL() !< structured values for flow into the domain
-                                                              !! specified in OBCs through u-face of cell
-  real, dimension(:,:,:), pointer :: OBC_in_v       => NULL() !< structured values for flow into the domain
-                                                              !! specified in OBCs through v-face of cell
+! real                            :: OBC_inflow_conc=  0.0    !< tracer concentration for generic inflows
+! real, dimension(:,:,:), pointer :: OBC_in_u       => NULL() !< structured values for flow into the domain
+!                                                             !! specified in OBCs through u-face of cell
+! real, dimension(:,:,:), pointer :: OBC_in_v       => NULL() !< structured values for flow into the domain
+!                                                             !! specified in OBCs through v-face of cell
 
   real, dimension(:,:,:), pointer :: ad_x           => NULL() !< diagnostic array for x-advective tracer flux
   real, dimension(:,:,:), pointer :: ad_y           => NULL() !< diagnostic array for y-advective tracer flux
@@ -259,11 +259,11 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
   if (present(ad_y)) then ; if (associated(ad_y)) Tr%ad_y => ad_y ; endif
   if (present(df_x)) then ; if (associated(df_x)) Tr%df_x => df_x ; endif
   if (present(df_y)) then ; if (associated(df_y)) Tr%df_y => df_y ; endif
-  if (present(OBC_inflow)) Tr%OBC_inflow_conc = OBC_inflow
-  if (present(OBC_in_u)) then ; if (associated(OBC_in_u)) &
-                                    Tr%OBC_in_u => OBC_in_u ; endif
-  if (present(OBC_in_v)) then ; if (associated(OBC_in_v)) &
-                                    Tr%OBC_in_v => OBC_in_v ; endif
+! if (present(OBC_inflow)) Tr%OBC_inflow_conc = OBC_inflow
+! if (present(OBC_in_u)) then ; if (associated(OBC_in_u)) &
+!                                   Tr%OBC_in_u => OBC_in_u ; endif
+! if (present(OBC_in_v)) then ; if (associated(OBC_in_v)) &
+!                                   Tr%OBC_in_v => OBC_in_v ; endif
   if (present(ad_2d_x)) then ; if (associated(ad_2d_x)) Tr%ad2d_x => ad_2d_x ; endif
   if (present(ad_2d_y)) then ; if (associated(ad_2d_y)) Tr%ad2d_y => ad_2d_y ; endif
   if (present(df_2d_x)) then ; if (associated(df_2d_x)) Tr%df2d_x => df_2d_x ; endif
@@ -315,11 +315,11 @@ subroutine add_tracer_OBC_values(name, Reg, OBC_inflow, OBC_in_u, OBC_in_v)
   do m=1,Reg%ntr ; if (Reg%Tr(m)%name == trim(name)) exit ; enddo
 
   if (m <= Reg%ntr) then
-    if (present(OBC_inflow)) Reg%Tr(m)%OBC_inflow_conc = OBC_inflow
-    if (present(OBC_in_u)) then ; if (associated(OBC_in_u)) &
-                                      Reg%Tr(m)%OBC_in_u => OBC_in_u ; endif
-    if (present(OBC_in_v)) then ; if (associated(OBC_in_v)) &
-                                      Reg%Tr(m)%OBC_in_v => OBC_in_v ; endif
+!   if (present(OBC_inflow)) Reg%Tr(m)%OBC_inflow_conc = OBC_inflow
+!   if (present(OBC_in_u)) then ; if (associated(OBC_in_u)) &
+!                                     Reg%Tr(m)%OBC_in_u => OBC_in_u ; endif
+!   if (present(OBC_in_v)) then ; if (associated(OBC_in_v)) &
+!                                     Reg%Tr(m)%OBC_in_v => OBC_in_v ; endif
   else
     call MOM_error(FATAL, "MOM_tracer: register_tracer must be called for "//&
              trim(name)//" before add_tracer_OBC_values is called for it.")

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -49,7 +49,6 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -16,7 +16,6 @@ use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_C
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
@@ -220,11 +219,7 @@ subroutine initialize_boundary_impulse_tracer(restart, day, G, GV, h, diag, OBC,
   enddo ! Tracer loop
 
   if (associated(OBC)) then
-  ! All tracers but the first have 0 concentration in their inflows. As this
-  ! is the default value, the following calls are unnecessary.
-  ! do m=1,CS%ntr
-  !  call add_tracer_OBC_values(trim(CS%tr_desc(m)%name), CS%tr_Reg, 0.0)
-  ! enddo
+  ! Steal from updated DOME in the fullness of time.
   endif
 
 end subroutine initialize_boundary_impulse_tracer

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -15,7 +15,6 @@ use MOM_restart,            only : query_initialized, MOM_restart_CS
 use MOM_sponge,             only : set_up_sponge_field, sponge_CS
 use MOM_time_manager,       only : time_type, get_time
 use MOM_tracer_registry,    only : register_tracer, tracer_registry_type
-use MOM_tracer_registry,    only : add_tracer_OBC_values
 use MOM_tracer_diabatic,    only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init,      only : tracer_Z_init
 use MOM_variables,          only : surface

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -14,7 +14,6 @@ use MOM_open_boundary,      only : ocean_OBC_type
 use MOM_restart,            only : MOM_restart_CS
 use MOM_time_manager,       only : time_type, get_time
 use MOM_tracer_registry,    only : register_tracer, tracer_registry_type
-use MOM_tracer_registry,    only : add_tracer_OBC_values
 use MOM_tracer_diabatic,    only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_variables,          only : surface
 use MOM_verticalGrid,       only : verticalGrid_type

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -50,7 +50,6 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
@@ -327,11 +326,7 @@ subroutine initialize_ideal_age_tracer(restart, day, G, GV, h, diag, OBC, CS, &
   enddo ! Tracer loop
 
   if (associated(OBC)) then
-  ! All tracers but the first have 0 concentration in their inflows. As this
-  ! is the default value, the following calls are unnecessary.
-  ! do m=1,CS%ntr
-  !  call add_tracer_OBC_values(trim(CS%tr_desc(m)%name), CS%tr_Reg, 0.0)
-  ! enddo
+  ! Steal from updated DOME in the fullness of time.
   endif
 
 end subroutine initialize_ideal_age_tracer

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -50,7 +50,6 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
@@ -345,11 +344,7 @@ subroutine initialize_oil_tracer(restart, day, G, GV, h, diag, OBC, CS, &
   enddo ! Tracer loop
 
   if (associated(OBC)) then
-  ! All tracers but the first have 0 concentration in their inflows. As this
-  ! is the default value, the following calls are unnecessary.
-  ! do m=1,CS%ntr
-  !  call add_tracer_OBC_values(trim(CS%tr_desc(m)%name), CS%tr_Reg, 0.0)
-  ! enddo
+  ! Put something here...
   endif
 
 end subroutine initialize_oil_tracer

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -50,7 +50,6 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_variables, only : surface
@@ -206,9 +205,7 @@ subroutine initialize_pseudo_salt_tracer(restart, day, G, GV, h, diag, OBC, CS, 
   endif
 
   if (associated(OBC)) then
-  ! All tracers but the first have 0 concentration in their inflows. As this
-  ! is the default value, the following calls are unnecessary.
-  !  call add_tracer_OBC_values(trim(CS%tr_desc%name), CS%tr_Reg, 0.0)
+  ! Steal from updated DOME in the fullness of time.
   endif
 
   CS%id_psd = register_diag_field("ocean_model", "pseudo_salt_diff", CS%diag%axesTL, &

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -46,7 +46,6 @@ use MOM_restart, only : MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type, get_time
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_tracer_registry, only : add_tracer_OBC_values
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
@@ -289,17 +288,15 @@ subroutine USER_initialize_tracer(restart, day, G, GV, h, diag, OBC, CS, &
         if (k < nz/2) then ; OBC_tr1_v(i,j,k) = 0.0
         else ; OBC_tr1_v(i,j,k) = 1.0 ; endif
       enddo ; enddo ; enddo
-      call add_tracer_OBC_values(trim(name), CS%tr_Reg, &
-                                 0.0, OBC_in_v=OBC_tr1_v)
+      ! Steal from updated DOME in the fullness of time.
     else
-      ! This is not expected in the DOME example.
-      call add_tracer_OBC_values(trim(name), CS%tr_Reg, 0.0)
+      ! Steal from updated DOME in the fullness of time.
     endif
     ! All tracers but the first have 0 concentration in their inflows. As this
     ! is the default value, the following calls are unnecessary.
     do m=2,lntr
       call query_vardesc(CS%tr_desc(m), name, caller="USER_initialize_tracer")
-      call add_tracer_OBC_values(trim(name), CS%tr_Reg, 0.0)
+      ! Steal from updated DOME in the fullness of time.
     enddo
   endif
 

--- a/src/user/BFB_initialization.F90
+++ b/src/user/BFB_initialization.F90
@@ -30,7 +30,7 @@ use MOM_io, only : close_file, create_file, fieldtype, file_exists
 use MOM_io, only : open_file, read_data, read_axis_data, SINGLE_FILE
 use MOM_io, only : write_field, slasher
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use MOM_verticalGrid, only : verticalGrid_type

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -313,6 +313,8 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, param_file, tr_Reg)
       segment%normal_vel(i,J,k) = v_k * exp(-2.0*(G%geoLonCv(i,J) - 1000.0)/Def_Rad)
     enddo ; enddo
   enddo
+! call register_segment_tracer(tr_desc(m), param_file, segment%HI, GV, &
+!                              segment%Reg, m, OBC_scalar=1.0)
 
   !   The inflow values of temperature and salinity also need to be set here if
   ! these variables are used.  The following code is just a naive example.
@@ -342,8 +344,6 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, param_file, tr_Reg)
       OBC_T_v(i,J,k) = T0(k)
     enddo ; enddo ; enddo
     call add_tracer_OBC_values("T", tr_Reg, OBC_in_v=OBC_T_v)
-!   call register_segment_tracer(tr_desc(m), param_file, segment%HI, GV, &
-!                                segment%Reg, m, OBC_scalar=1.0)
   endif
 
 end subroutine DOME_set_OBC_data

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -10,7 +10,7 @@ use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
 use MOM_open_boundary,   only : OBC_segment_type, register_segment_tracer
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -313,14 +313,14 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, param_file, tr_Reg)
       segment%normal_vel(i,J,k) = v_k * exp(-2.0*(G%geoLonCv(i,J) - 1000.0)/Def_Rad)
     enddo ; enddo
   enddo
-! call register_segment_tracer(tr_desc(m), param_file, segment%HI, GV, &
-!                              segment%Reg, m, OBC_scalar=1.0)
 
   !   The inflow values of temperature and salinity also need to be set here if
   ! these variables are used.  The following code is just a naive example.
   if (associated(tv%S)) then
     ! In this example, all S inflows have values of 35 psu.
-    call add_tracer_OBC_values("S", tr_Reg, OBC_inflow=35.0)
+!   call add_tracer_OBC_values("S", tr_Reg, OBC_inflow=35.0)
+!   call register_segment_tracer(CS%tr_desc(m), param_file, GV, &
+!                                segment, OBC_scalar=35.0)
   endif
   if (associated(tv%T)) then
     ! In this example, the T values are set to be consistent with the layer
@@ -343,7 +343,9 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, param_file, tr_Reg)
     do k=1,nz ; do J=JsdB,JedB ; do i=isd,ied
       OBC_T_v(i,J,k) = T0(k)
     enddo ; enddo ; enddo
-    call add_tracer_OBC_values("T", tr_Reg, OBC_in_v=OBC_T_v)
+!   call add_tracer_OBC_values("T", tr_Reg, OBC_in_v=OBC_T_v)
+!   call register_segment_tracer(CS%tr_desc(m), param_file, GV, &
+!                                segment, OBC_array=.true.)
   endif
 
 end subroutine DOME_set_OBC_data

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -12,7 +12,7 @@ use MOM_open_boundary,   only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
 use MOM_open_boundary,   only : OBC_segment_type, register_segment_tracer
 use MOM_open_boundary,   only : OBC_registry_type, register_OBC
 use MOM_time_manager,    only : time_type, set_time, time_type_to_real
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables,       only : thermo_var_ptrs
 use MOM_verticalGrid,    only : verticalGrid_type
 

--- a/src/user/dyed_obcs_initialization.F90
+++ b/src/user/dyed_obcs_initialization.F90
@@ -10,7 +10,7 @@ use MOM_grid,            only : ocean_grid_type
 use MOM_io,              only : vardesc, var_desc
 use MOM_open_boundary,   only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
 use MOM_open_boundary,   only : OBC_segment_type, register_segment_tracer
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables,       only : thermo_var_ptrs
 use MOM_verticalGrid,    only : verticalGrid_type
 

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -14,7 +14,7 @@ use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
 use MOM_open_boundary, only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N
 use MOM_open_boundary, only : OBC_DIRECTION_S
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
-use MOM_tracer_registry, only : tracer_registry_type, add_tracer_OBC_values
+use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type


### PR DESCRIPTION
This sets the DOME boundary dyes so that tracer 1 works again. There's still a problem with T and S OBCs for DOME - were they ever used? Fixing that will require that other change we sort of talked about (clearing out vardesc), so feel free to wait on that for accepting, or accept now if you want the DOME tracer fixed ASAP.