### PR TITLE
Restructure step mom

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -18,7 +18,7 @@ module ocean_model_mod
 !</OVERVIEW>
 
 use MOM, only : initialize_MOM, step_MOM, MOM_control_struct, MOM_state_type, MOM_end
-use MOM, only : calculate_surface_state, allocate_surface_state, finish_MOM_initialization
+use MOM, only : extract_surface_state, allocate_surface_state, finish_MOM_initialization
 use MOM, only : step_offline
 use MOM_constants, only : CELSIUS_KELVIN_OFFSET, hlf
 use MOM_diag_mediator, only : diag_ctrl, enable_averaging, disable_averaging
@@ -367,9 +367,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
     call coupler_type_set_diags(Ocean_sfc%fields, "ocean_sfc", &
                                 Ocean_sfc%axes(1:2), Time_in)
 
-    call calculate_surface_state(OS%sfc_state, OS%MSp%u, &
-             OS%MSp%v, OS%MSp%h, OS%MSp%ave_ssh,&
-             OS%grid, OS%GV, OS%MSp, OS%MOM_CSp)
+    call extract_surface_state(OS%MSp, OS%sfc_state, OS%MOM_CSp)
 
     call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid)
 
@@ -958,9 +956,7 @@ subroutine ocean_model_init_sfc(OS, Ocean_sfc)
   call coupler_type_spawn(Ocean_sfc%fields, OS%sfc_state%tr_fields, &
                           (/is,is,ie,ie/), (/js,js,je,je/), as_needed=.true.)
 
-  call calculate_surface_state(OS%sfc_state, OS%MSp%u, &
-           OS%MSp%v, OS%MSp%h, OS%MSp%ave_ssh,&
-           OS%grid, OS%GV, OS%MSp, OS%MOM_CSp)
+  call extract_surface_state(OS%MSp, OS%sfc_state, OS%MOM_CSp)
 
   call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid)
 

--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -36,6 +36,7 @@ use MOM_cpu_clock,        only : CLOCK_SUBCOMPONENT
 use MOM,                  only: initialize_MOM, step_MOM, MOM_control_struct, MOM_state_type, MOM_end
 use MOM,                  only: extract_surface_state, allocate_surface_state
 use MOM,                  only: finish_MOM_initialization, step_offline
+use MOM,                 only : get_MOM_state_elements, MOM_state_is_synchronized
 use MOM_forcing_type,     only: forcing, forcing_diags, register_forcing_type_diags
 use MOM_forcing_type,     only: allocate_forcing_type, deallocate_forcing_type
 use MOM_forcing_type,     only: mech_forcing_diags, forcing_accumulate, forcing_diagnostics
@@ -810,10 +811,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                       OS%restart_CSp, Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       input_restart_file=input_restart_file, diag_ptr=OS%diag, &
                       count_calls=.true.)
-  OS%grid => OS%MSp%G ; OS%GV => OS%MSp%GV
-  OS%C_p = OS%MSp%tv%C_p
-  OS%fluxes%C_p = OS%MSp%tv%C_p
-  use_temperature = ASSOCIATED(OS%MSp%tv%T)
+  call get_MOM_state_elements(OS%MSp, G=OS%grid, GV=OS%GV, C_p=OS%fluxes%C_p, &
+                              use_temp=use_temperature)
+  OS%C_p = OS%fluxes%C_p
 
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")

--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -34,7 +34,7 @@ use MOM_coms,             only : reproducing_sum
 use MOM_cpu_clock,        only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,        only : CLOCK_SUBCOMPONENT
 use MOM,                  only: initialize_MOM, step_MOM, MOM_control_struct, MOM_state_type, MOM_end
-use MOM,                  only: calculate_surface_state, allocate_surface_state
+use MOM,                  only: extract_surface_state, allocate_surface_state
 use MOM,                  only: finish_MOM_initialization, step_offline
 use MOM_forcing_type,     only: forcing, forcing_diags, register_forcing_type_diags
 use MOM_forcing_type,     only: allocate_forcing_type, deallocate_forcing_type
@@ -903,9 +903,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   ! This call can only occur here if the coupler_bc_type variables have been
   ! initialized already using the information from gas_fields_ocn.
   if (present(gas_fields_ocn)) then
-    call calculate_surface_state(OS%sfc_state, OS%MSp%u, &
-             OS%MSp%v, OS%MSp%h, OS%MSp%ave_ssh,&
-             OS%grid, OS%GV, OS%MSp, OS%MOM_CSp)
+    call extract_surface_state(OS%MSp, OS%sfc_state, OS%MOM_CSp)
 
     call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid)
   endif
@@ -933,9 +931,7 @@ subroutine ocean_model_init_sfc(OS, Ocean_sfc)
   call coupler_type_spawn(Ocean_sfc%fields, OS%sfc_state%tr_fields, &
                           (/is,is,ie,ie/), (/js,js,je,je/), as_needed=.true.)
 
-  call calculate_surface_state(OS%sfc_state, OS%MSp%u, &
-           OS%MSp%v, OS%MSp%h, OS%MSp%ave_ssh,&
-           OS%grid, OS%GV, OS%Msp, OS%MOM_CSp)
+  call extract_surface_state(OS%MSp, OS%sfc_state, OS%MOM_CSp)
 
   call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid)
 

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -29,7 +29,7 @@ program MOM_main
   use MOM_diag_mediator,   only : enable_averaging, disable_averaging, diag_mediator_end
   use MOM_diag_mediator,   only : diag_ctrl, diag_mediator_close_registration
   use MOM,                 only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
-  use MOM,                 only : calculate_surface_state, finish_MOM_initialization
+  use MOM,                 only : extract_surface_state, finish_MOM_initialization
   use MOM,                 only : MOM_state_type, step_offline
   use MOM_domains,         only : MOM_infra_init, MOM_infra_end
   use MOM_error_handler,   only : MOM_error, MOM_mesg, WARNING, FATAL, is_root_pe
@@ -302,8 +302,7 @@ program MOM_main
   GV   => MSp%GV
   call callTree_waypoint("done initialize_MOM")
 
-  call calculate_surface_state(sfc_state, MSp%u, MSp%v, MSp%h, &
-                               MSp%ave_ssh, grid, GV, MSp, MOM_CSp)
+  call extract_surface_state(MSp, sfc_state, MOM_CSp)
 
   call surface_forcing_init(Time, grid, param_file, diag, &
                             surface_forcing_CSp, tracer_flow_CSp)

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -489,7 +489,7 @@ program MOM_main
 
       nts = MAX(1,MIN(n_max,floor(dt_therm/dt_dyn + 0.001)))
       n_last_thermo = 0
-      
+
       Time2 = Time1 ; t_elapsed_seg = 0.0
       do n=1,n_max
         if (diabatic_first) then
@@ -499,7 +499,7 @@ program MOM_main
                           do_dynamics=.false., do_thermodynamics=.true., &
                           start_cycle=(n==1), end_cycle=.false.)
           endif
-          
+
           call step_MOM(forces, fluxes, sfc_state, Time2, dt_dyn, MSp, MOM_CSp, &
                         do_dynamics=.true., do_thermodynamics=.false., &
                         start_cycle=.false., end_cycle=(n==n_max))

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -56,11 +56,12 @@ use MOM_CoriolisAdv,           only : CorAdCalc, CoriolisAdv_init, CoriolisAdv_C
 use MOM_diabatic_driver,       only : diabatic, diabatic_driver_init, diabatic_CS
 use MOM_diabatic_driver,       only : adiabatic, adiabatic_driver_init, diabatic_driver_end
 use MOM_diagnostics,           only : calculate_diagnostic_fields, MOM_diagnostics_init
-use MOM_diagnostics,           only : write_static_fields, diagnostics_CS, surface_diag_IDs
+use MOM_diagnostics,           only : register_transport_diags, post_transport_diagnostics
 use MOM_diagnostics,           only : register_surface_diags, post_surface_diagnostics
-use MOM_diag_to_Z,             only : calculate_Z_diag_fields, calculate_Z_transport
-use MOM_diag_to_Z,             only : MOM_diag_to_Z_init, register_Z_tracer, diag_to_Z_CS
-use MOM_diag_to_Z,             only : MOM_diag_to_Z_end
+use MOM_diagnostics,           only : write_static_fields, transport_remap_grid_needed
+use MOM_diagnostics,           only : diagnostics_CS, surface_diag_IDs, transport_diag_IDs
+use MOM_diag_to_Z,             only : calculate_Z_diag_fields, register_Z_tracer
+use MOM_diag_to_Z,             only : MOM_diag_to_Z_init, MOM_diag_to_Z_end, diag_to_Z_CS
 use MOM_dynamics_unsplit,      only : step_MOM_dyn_unsplit, register_restarts_dyn_unsplit
 use MOM_dynamics_unsplit,      only : initialize_dyn_unsplit, end_dyn_unsplit
 use MOM_dynamics_unsplit,      only : MOM_dyn_unsplit_CS
@@ -140,13 +141,6 @@ type MOM_diag_IDs
   ! 2-d state field
   integer :: id_ssh_inst = -1
 end type MOM_diag_IDs
-
-!> A structure with diagnostic IDs of mass transport related diagnostics
-type transport_diag_IDs
-  ! Diagnostics for tracer horizontal transport
-  integer :: id_uhtr = -1, id_umo = -1, id_umo_2d = -1
-  integer :: id_vhtr = -1, id_vmo = -1, id_vmo_2d = -1
-end type transport_diag_IDs
 
 !> Structure describing the state of the ocean.
 type, public :: MOM_state_type ; private
@@ -2355,47 +2349,6 @@ subroutine register_diags(Time, G, GV, IDs, diag, missing)
       Time, 'Instantaneous Sea Surface Height', 'm', missing)
 end subroutine register_diags
 
-!> Register certain diagnostics related to transports
-subroutine register_transport_diags(Time, G, GV, IDs, diag, missing)
-  type(time_type),          intent(in)    :: Time  !< current model time
-  type(ocean_grid_type),    intent(in)    :: G     !< ocean grid structure
-  type(verticalGrid_type),  intent(in)    :: GV    !< ocean vertical grid structure
-  type(transport_diag_IDs), intent(inout) :: IDs   !< A structure with the diagnostic IDs.
-  type(diag_ctrl),          intent(inout) :: diag  !< regulates diagnostic output
-  real,                     intent(in)    :: missing !< The value to use to fill in missing data
-
-  real :: H_convert
-  character(len=48) :: thickness_units
-
-  thickness_units = get_thickness_units(GV)
-  if (GV%Boussinesq) then
-    H_convert = GV%H_to_m
-  else
-    H_convert = GV%H_to_kg_m2
-  endif
-
-  ! Diagnostics related to tracer and mass transport
-  IDs%id_uhtr = register_diag_field('ocean_model', 'uhtr', diag%axesCuL, Time, &
-      'Accumulated zonal thickness fluxes to advect tracers', 'kg', &
-      y_cell_method='sum', v_extensive=.true., conversion=H_convert)
-  IDs%id_vhtr = register_diag_field('ocean_model', 'vhtr', diag%axesCvL, Time, &
-      'Accumulated meridional thickness fluxes to advect tracers', 'kg', &
-      x_cell_method='sum', v_extensive=.true., conversion=H_convert)
-  IDs%id_umo = register_diag_field('ocean_model', 'umo', &
-      diag%axesCuL, Time, 'Ocean Mass X Transport', 'kg s-1', &
-      standard_name='ocean_mass_x_transport', y_cell_method='sum', v_extensive=.true.)
-  IDs%id_vmo = register_diag_field('ocean_model', 'vmo', &
-      diag%axesCvL, Time, 'Ocean Mass Y Transport', 'kg s-1', &
-      standard_name='ocean_mass_y_transport', x_cell_method='sum', v_extensive=.true.)
-  IDs%id_umo_2d = register_diag_field('ocean_model', 'umo_2d', &
-      diag%axesCu1, Time, 'Ocean Mass X Transport Vertical Sum', 'kg s-1', &
-      standard_name='ocean_mass_x_transport_vertical_sum', y_cell_method='sum')
-  IDs%id_vmo_2d = register_diag_field('ocean_model', 'vmo_2d', &
-      diag%axesCv1, Time, 'Ocean Mass Y Transport Vertical Sum', 'kg s-1', &
-      standard_name='ocean_mass_y_transport_vertical_sum', x_cell_method='sum')
-
-end subroutine register_transport_diags
-
 !> This subroutine sets up clock IDs for timing various subroutines.
 subroutine MOM_timing_init(CS)
   type(MOM_control_struct), intent(in) :: CS  !< control structure set up by initialize_MOM.
@@ -2425,95 +2378,6 @@ subroutine MOM_timing_init(CS)
  endif
 
 end subroutine MOM_timing_init
-
-!> This routine posts diagnostics of the transports, including the subgridscale
-!! contributions.
-subroutine post_transport_diagnostics(G, GV, uhtr, vhtr, h, IDs, diag, dt_trans, &
-                                      diag_to_Z_CSp, h_pre_dyn, T_pre_dyn, S_pre_dyn)
-  type(ocean_grid_type),    intent(inout) :: G   !< ocean grid structure
-  type(verticalGrid_type),  intent(in)    :: GV  !< ocean vertical grid structure
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
-                            intent(in)    :: uhtr !< Accumulated zonal thickness fluxes used
-                                                  !! to advect tracers (m3 or kg)
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                            intent(in)    :: vhtr !< Accumulated meridional thickness fluxes
-                                                  !! used to advect tracers (m3 or kg)
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                            intent(in)    :: h   !< The updated layer thicknesses, in H
-  type(transport_diag_IDs), intent(in)    :: IDs !< A structure with the diagnostic IDs.
-  type(diag_ctrl),          intent(inout) :: diag !< regulates diagnostic output
-  real,                     intent(in)    :: dt_trans !< total time step associated with the transports, in s.
-  type(diag_to_Z_CS),       pointer       :: diag_to_Z_CSp !< A control structure for remapping
-                                                 !! the transports to depth space
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                            intent(in)    :: h_pre_dyn !< The thickness before the transports, in H.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                            intent(in)    :: T_pre_dyn !< Temperature before the transports, in H.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                            intent(in)    :: S_pre_dyn !< Salinity before the transports, in H.
-
-  real, dimension(SZIB_(G), SZJ_(G)) :: umo2d ! Diagnostics of integrated mass transport, in kg s-1
-  real, dimension(SZI_(G), SZJB_(G)) :: vmo2d ! Diagnostics of integrated mass transport, in kg s-1
-  real, dimension(SZIB_(G), SZJ_(G), SZK_(G)) :: umo ! Diagnostics of layer mass transport, in kg s-1
-  real, dimension(SZI_(G), SZJB_(G), SZK_(G)) :: vmo ! Diagnostics of layer mass transport, in kg s-1
-  real :: H_to_kg_m2_dt   ! A conversion factor from accumulated transports to fluxes, in kg m-2 H-1 s-1.
-  integer :: i, j, k, is, ie, js, je, nz
-  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
-
-  call cpu_clock_begin(id_clock_Z_diag)
-  call calculate_Z_transport(uhtr, vhtr, h, dt_trans, G, GV, diag_to_Z_CSp)
-  call cpu_clock_end(id_clock_Z_diag)
-
-  ! Post mass transports, including SGS
-  ! Build the remap grids using the layer thicknesses from before the dynamics
-  if (transport_remap_grid_needed(IDs)) &
-    call diag_update_remap_grids(diag, alt_h = h_pre_dyn, alt_T = T_pre_dyn, alt_S = S_pre_dyn)
-
-  H_to_kg_m2_dt = GV%H_to_kg_m2 / dt_trans
-  if (IDs%id_umo_2d > 0) then
-    umo2d(:,:) = 0.0
-    do k=1,nz ; do j=js,je ; do I=is-1,ie
-      umo2d(I,j) = umo2d(I,j) + uhtr(I,j,k) * H_to_kg_m2_dt
-    enddo ; enddo ; enddo
-    call post_data(IDs%id_umo_2d, umo2d, diag)
-  endif
-  if (IDs%id_umo > 0) then
-    ! Convert to kg/s. Modifying the array for diagnostics is allowed here since it is set to zero immediately below
-    do k=1,nz ; do j=js,je ; do I=is-1,ie
-      umo(I,j,k) = uhtr(I,j,k) * H_to_kg_m2_dt
-    enddo ; enddo ; enddo
-    call post_data(IDs%id_umo, umo, diag, alt_h = h_pre_dyn)
-  endif
-  if (IDs%id_vmo_2d > 0) then
-    vmo2d(:,:) = 0.0
-    do k=1,nz ; do J=js-1,je ; do i=is,ie
-      vmo2d(i,J) = vmo2d(i,J) + vhtr(i,J,k) * H_to_kg_m2_dt
-    enddo ; enddo ; enddo
-    call post_data(IDs%id_vmo_2d, vmo2d, diag)
-  endif
-  if (IDs%id_vmo > 0) then
-    ! Convert to kg/s. Modifying the array for diagnostics is allowed here since it is set to zero immediately below
-    do k=1,nz ; do J=js-1,je ; do i=is,ie
-      vmo(i,J,k) = vhtr(i,J,k) * H_to_kg_m2_dt
-    enddo ; enddo ; enddo
-    call post_data(IDs%id_vmo, vmo, diag, alt_h = h_pre_dyn)
-  endif
-
-  if (IDs%id_uhtr > 0) call post_data(IDs%id_uhtr, uhtr, diag, alt_h = h_pre_dyn)
-  if (IDs%id_vhtr > 0) call post_data(IDs%id_vhtr, vhtr, diag, alt_h = h_pre_dyn)
-
-end subroutine post_transport_diagnostics
-
-!> Indicate whether it is necessary to save and recalculate the grid for finding
-!! remapped transports.
-function transport_remap_grid_needed(IDs) result(needed)
-  type(transport_diag_IDs), intent(in)    :: IDs !< A structure with transport-related diagnostic IDs
-  logical :: needed
-
-  needed = .false.
-  needed = needed .or. (IDs%id_uhtr > 0) .or. (IDs%id_vhtr > 0)
-  needed = needed .or. (IDs%id_umo > 0)  .or. (IDs%id_vmo > 0)
-end function transport_remap_grid_needed
 
 
 !> Set the fields that are needed for bitwise identical restarting

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -773,7 +773,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, MS, CS
       mass_src_time = MS%t_dyn_rel_thermo
       call step_MOM_dyn_split_RK2(u, v, h, MS%tv, CS%visc, &
                   Time_local, dt, forces, CS%p_surf_begin, CS%p_surf_end, &
-                  mass_src_time, dt_therm, MS%uh, MS%vh, MS%uhtr, MS%vhtr, &
+                  MS%uh, MS%vh, MS%uhtr, MS%vhtr, &
                   eta_av, G, GV, CS%dyn_split_RK2_CSp, calc_dtbt, CS%VarMix, CS%MEKE)
       if (showCallTree) call callTree_waypoint("finished step_MOM_dyn_split (step_MOM)")
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3737,12 +3737,11 @@ end subroutine find_face_areas
 !! the barotropic solver, along with a corrective fictitious mass source that
 !! will drive the barotropic estimate of the free surface height toward the
 !! baroclinic estimate.
-subroutine bt_mass_source(h, eta, forces, set_cor, G, GV, CS)
+subroutine bt_mass_source(h, eta, set_cor, G, GV, CS)
   type(ocean_grid_type),              intent(in) :: G        !< The ocean's grid structure.
   type(verticalGrid_type),            intent(in) :: GV       !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h  !< Layer thicknesses, in H (usually m or kg m-2).
   real, dimension(SZI_(G),SZJ_(G)),   intent(in) :: eta      !< The free surface height that is to be corrected, in m.
-  type(mech_forcing),                 intent(in) :: forces   !< A structure with the driving mechanical forces
   logical,                            intent(in) :: set_cor  !< A flag to indicate whether to set the corrective
                                                              !! fluxes (and update the slowly varying part of eta_cor)
                                                              !! (.true.) or whether to incrementally update the

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -461,7 +461,7 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   ! Calculate the relative layer weights for determining barotropic quantities.
   if (.not.BT_cont_BT_thick) &
     call btcalc(h, G, GV, CS%barotropic_CSp, OBC=CS%OBC)
-  call bt_mass_source(h, eta, forces, .true., G, GV, CS%barotropic_CSp)
+  call bt_mass_source(h, eta, .true., G, GV, CS%barotropic_CSp)
   call cpu_clock_end(id_clock_btcalc)
 
   if (G%nonblocking_updates) &
@@ -600,7 +600,7 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   ! hp can be changed if CS%begw /= 0.
   ! eta_cor = ...                 (hidden inside CS%barotropic_CSp)
   call cpu_clock_begin(id_clock_btcalc)
-  call bt_mass_source(hp, eta_pred, forces, .false., G, GV, CS%barotropic_CSp)
+  call bt_mass_source(hp, eta_pred, .false., G, GV, CS%barotropic_CSp)
   call cpu_clock_end(id_clock_btcalc)
 
   if (CS%begw /= 0.0) then

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -203,7 +203,7 @@ contains
 !> RK2 splitting for time stepping MOM adiabatic dynamics
 subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
                  Time_local, dt, forces, p_surf_begin, p_surf_end, &
-                 dt_since_flux, dt_therm, uh, vh, uhtr, vhtr, eta_av, &
+                 uh, vh, uhtr, vhtr, eta_av, &
                  G, GV, CS, calc_dtbt, VarMix, MEKE)
   type(ocean_grid_type),                     intent(inout) :: G             !< ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV            !< ocean vertical grid structure
@@ -217,8 +217,6 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   type(mech_forcing),                        intent(in)    :: forces        !< A structure with the driving mechanical forces
   real, dimension(:,:),                      pointer       :: p_surf_begin  !< surf pressure at start of this dynamic time step (Pa)
   real, dimension(:,:),                      pointer       :: p_surf_end    !< surf pressure at end   of this dynamic time step (Pa)
-  real,                                      intent(in)    :: dt_since_flux !< elapsed time since fluxes were applied (sec)
-  real,                                      intent(in)    :: dt_therm      !< thermodynamic time step (sec)
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), target, intent(inout) :: uh    !< zonal volume/mass transport (m3/s or kg/s)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), target, intent(inout) :: vh    !< merid volume/mass transport (m3/s or kg/s)
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uhtr          !< accumulatated zonal volume/mass transport since last tracer advection (m3 or kg)
@@ -463,8 +461,7 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   ! Calculate the relative layer weights for determining barotropic quantities.
   if (.not.BT_cont_BT_thick) &
     call btcalc(h, G, GV, CS%barotropic_CSp, OBC=CS%OBC)
-  call bt_mass_source(h, eta, forces, .true., dt_therm, dt_since_flux, &
-                      G, GV, CS%barotropic_CSp)
+  call bt_mass_source(h, eta, forces, .true., G, GV, CS%barotropic_CSp)
   call cpu_clock_end(id_clock_btcalc)
 
   if (G%nonblocking_updates) &
@@ -603,8 +600,7 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   ! hp can be changed if CS%begw /= 0.
   ! eta_cor = ...                 (hidden inside CS%barotropic_CSp)
   call cpu_clock_begin(id_clock_btcalc)
-  call bt_mass_source(hp, eta_pred, forces, .false., dt_therm, &
-                      dt_since_flux+dt, G, GV, CS%barotropic_CSp)
+  call bt_mass_source(hp, eta_pred, forces, .false., G, GV, CS%barotropic_CSp)
   call cpu_clock_end(id_clock_btcalc)
 
   if (CS%begw /= 0.0) then

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -45,96 +45,100 @@ type, public :: forcing
 
   ! surface stress components and turbulent velocity scale
   real, pointer, dimension(:,:) :: &
-  ustar         => NULL(), & !< surface friction velocity scale (m/s)
-  ustar_gustless => NULL()   !< surface friction velocity scale without any
-                             !! any augmentation for gustiness (m/s)
+    ustar         => NULL(), & !< surface friction velocity scale (m/s)
+    ustar_gustless => NULL()   !< surface friction velocity scale without any
+                               !! any augmentation for gustiness (m/s)
 
-  ! surface buoyancy force
+  ! surface buoyancy force, used when temperature is not a state variable
   real, pointer, dimension(:,:) :: &
-  buoy          => NULL()  !< buoyancy flux (m^2/s^3)
+    buoy          => NULL()  !< buoyancy flux (m^2/s^3)
 
   ! radiative heat fluxes into the ocean (W/m^2)
   real, pointer, dimension(:,:) :: &
-  sw            => NULL(), & !< shortwave (W/m^2)
-  sw_vis_dir    => NULL(), & !< visible, direct shortwave (W/m^2)
-  sw_vis_dif    => NULL(), & !< visible, diffuse shortwave (W/m^2)
-  sw_nir_dir    => NULL(), & !< near-IR, direct shortwave (W/m^2)
-  sw_nir_dif    => NULL(), & !< near-IR, diffuse shortwave (W/m^2)
-  lw            => NULL()    !< longwave (W/m^2) (typically negative)
+    sw         => NULL(), & !< shortwave (W/m^2)
+    sw_vis_dir => NULL(), & !< visible, direct shortwave (W/m^2)
+    sw_vis_dif => NULL(), & !< visible, diffuse shortwave (W/m^2)
+    sw_nir_dir => NULL(), & !< near-IR, direct shortwave (W/m^2)
+    sw_nir_dif => NULL(), & !< near-IR, diffuse shortwave (W/m^2)
+    lw         => NULL()    !< longwave (W/m^2) (typically negative)
 
   ! turbulent heat fluxes into the ocean (W/m^2)
   real, pointer, dimension(:,:) :: &
-  latent         => NULL(), & !< latent (W/m^2)   (typically < 0)
-  sens           => NULL(), & !< sensible (W/m^2) (typically negative)
-  heat_added     => NULL()    !< additional heat flux from SST restoring or flux adjustments (W/m^2)
+    latent     => NULL(), & !< latent (W/m^2)   (typically < 0)
+    sens       => NULL(), & !< sensible (W/m^2) (typically negative)
+    heat_added => NULL()    !< additional heat flux from SST restoring or flux adjustments (W/m^2)
 
   ! components of latent heat fluxes used for diagnostic purposes
   real, pointer, dimension(:,:) :: &
-  latent_evap_diag    => NULL(), & !< latent (W/m^2) from evaporating liquid water (typically < 0)
-  latent_fprec_diag   => NULL(), & !< latent (W/m^2) from melting fprec  (typically < 0)
-  latent_frunoff_diag => NULL()    !< latent (W/m^2) from melting frunoff (calving) (typically < 0)
+    latent_evap_diag    => NULL(), & !< latent (W/m^2) from evaporating liquid water (typically < 0)
+    latent_fprec_diag   => NULL(), & !< latent (W/m^2) from melting fprec  (typically < 0)
+    latent_frunoff_diag => NULL()    !< latent (W/m^2) from melting frunoff (calving) (typically < 0)
 
   ! water mass fluxes into the ocean ( kg/(m^2 s) ); these fluxes impact the ocean mass
   real, pointer, dimension(:,:) :: &
-  evap          => NULL(), & !< (-1)*fresh water flux evaporated out of the ocean ( kg/(m^2 s) )
-  lprec         => NULL(), & !< precipitating liquid water into the ocean ( kg/(m^2 s) )
-  fprec         => NULL(), & !< precipitating frozen water into the ocean ( kg/(m^2 s) )
-  vprec         => NULL(), & !< virtual liquid precip associated w/ SSS restoring ( kg/(m^2 s) )
-  lrunoff       => NULL(), & !< liquid river runoff entering ocean ( kg/(m^2 s) )
-  frunoff       => NULL(), & !< frozen river runoff (calving) entering ocean ( kg/(m^2 s) )
-  seaice_melt   => NULL(), & !< seaice melt (positive) or formation (negative) ( kg/(m^2 s) )
-  netMassIn     => NULL(), & !< Sum of water mass flux out of the ocean ( kg/(m^2 s) )
-  netMassOut    => NULL(), & !< Net water mass flux into of the ocean ( kg/(m^2 s) )
-  netSalt       => NULL()    !< Net salt entering the ocean
+    evap        => NULL(), & !< (-1)*fresh water flux evaporated out of the ocean ( kg/(m^2 s) )
+    lprec       => NULL(), & !< precipitating liquid water into the ocean ( kg/(m^2 s) )
+    fprec       => NULL(), & !< precipitating frozen water into the ocean ( kg/(m^2 s) )
+    vprec       => NULL(), & !< virtual liquid precip associated w/ SSS restoring ( kg/(m^2 s) )
+    lrunoff     => NULL(), & !< liquid river runoff entering ocean ( kg/(m^2 s) )
+    frunoff     => NULL(), & !< frozen river runoff (calving) entering ocean ( kg/(m^2 s) )
+    seaice_melt => NULL(), & !< seaice melt (positive) or formation (negative) ( kg/(m^2 s) )
+    netMassIn   => NULL(), & !< Sum of water mass flux out of the ocean ( kg/(m^2 s) )
+    netMassOut  => NULL(), & !< Net water mass flux into of the ocean ( kg/(m^2 s) )
+    netSalt     => NULL()    !< Net salt entering the ocean
 
   ! heat associated with water crossing ocean surface
   real, pointer, dimension(:,:) :: &
-  heat_content_cond    => NULL(), & !< heat content associated with condensating water (W/m^2)
-  heat_content_lprec   => NULL(), & !< heat content associated with liquid >0 precip   (W/m^2) (diagnostic)
-  heat_content_fprec   => NULL(), & !< heat content associated with frozen precip      (W/m^2)
-  heat_content_vprec   => NULL(), & !< heat content associated with virtual >0 precip  (W/m^2)
-  heat_content_lrunoff => NULL(), & !< heat content associated with liquid runoff      (W/m^2)
-  heat_content_frunoff => NULL(), & !< heat content associated with frozen runoff      (W/m^2)
-  heat_content_icemelt => NULL(), & !< heat content associated with liquid sea ice     (W/m^2)
-  heat_content_massout => NULL(), & !< heat content associated with mass leaving ocean (W/m^2)
-  heat_content_massin  => NULL()    !< heat content associated with mass entering ocean (W/m^2)
+    heat_content_cond    => NULL(), & !< heat content associated with condensating water (W/m^2)
+    heat_content_lprec   => NULL(), & !< heat content associated with liquid >0 precip   (W/m^2) (diagnostic)
+    heat_content_fprec   => NULL(), & !< heat content associated with frozen precip      (W/m^2)
+    heat_content_vprec   => NULL(), & !< heat content associated with virtual >0 precip  (W/m^2)
+    heat_content_lrunoff => NULL(), & !< heat content associated with liquid runoff      (W/m^2)
+    heat_content_frunoff => NULL(), & !< heat content associated with frozen runoff      (W/m^2)
+    heat_content_icemelt => NULL(), & !< heat content associated with liquid sea ice     (W/m^2)
+    heat_content_massout => NULL(), & !< heat content associated with mass leaving ocean (W/m^2)
+    heat_content_massin  => NULL()    !< heat content associated with mass entering ocean (W/m^2)
 
   ! salt mass flux (contributes to ocean mass only if non-Bouss )
   real, pointer, dimension(:,:) :: &
-  salt_flux         => NULL(), & !< net salt flux into the ocean ( kg salt/(m^2 s) )
-  salt_flux_in      => NULL(), & !< salt flux provided to the ocean from coupler ( kg salt/(m^2 s) )
-  salt_flux_added => NULL()    !< additional salt flux from restoring or flux adjustment before adjustment
+    salt_flux       => NULL(), & !< net salt flux into the ocean ( kg salt/(m^2 s) )
+    salt_flux_in    => NULL(), & !< salt flux provided to the ocean from coupler ( kg salt/(m^2 s) )
+    salt_flux_added => NULL()    !< additional salt flux from restoring or flux adjustment before adjustment
                                  !! to net zero ( kg salt/(m^2 s) )
 
   ! applied surface pressure from other component models (e.g., atmos, sea ice, land ice)
   real, pointer, dimension(:,:) :: &
-  p_surf_full   => NULL(), & !< Pressure at the top ocean interface (Pa).
-                             !! if there is sea-ice, then p_surf_flux is at ice-ocean interface
-  p_surf        => NULL()    !< Pressure at the top ocean interface (Pa) as used
-                             !! to drive the ocean model. If p_surf is limited,
-                             !! p_surf may be smaller than p_surf_full,
-                             !! otherwise they are the same.
+    p_surf_full   => NULL(), & !< Pressure at the top ocean interface (Pa).
+                               !! if there is sea-ice, then p_surf_flux is at ice-ocean interface
+    p_surf        => NULL(), & !< Pressure at the top ocean interface (Pa) as used
+                               !! to drive the ocean model. If p_surf is limited,
+                               !! p_surf may be smaller than p_surf_full,
+                               !! otherwise they are the same.
+    p_surf_SSH    => NULL()    !< Pressure at the top ocean interface that is used
+                               !! in corrections to the sea surface height field
+                               !! that is passed back to the calling routines.
+                               !! This may point to p_surf or to p_surf_full.
 
   ! tide related inputs
   real, pointer, dimension(:,:) :: &
-  TKE_tidal     => NULL(), & !< tidal energy source driving mixing in bottom boundary layer (W/m^2)
-  ustar_tidal   => NULL()    !< tidal contribution to bottom ustar (m/s)
+    TKE_tidal     => NULL(), & !< tidal energy source driving mixing in bottom boundary layer (W/m^2)
+    ustar_tidal   => NULL()    !< tidal contribution to bottom ustar (m/s)
 
   ! iceberg related inputs
   real, pointer, dimension(:,:) :: &
-  ustar_berg   => NULL(),&    !< iceberg contribution to top ustar (m/s)
-  area_berg   => NULL(),&     !< area of ocean surface covered by icebergs (m2/m2)
-  mass_berg   => NULL()     !< mass of icebergs (kg/m2)
+    ustar_berg => NULL(), &   !< iceberg contribution to top ustar (m/s)
+    area_berg  => NULL(), &   !< area of ocean surface covered by icebergs (m2/m2)
+    mass_berg  => NULL()      !< mass of icebergs (kg/m2)
 
   ! land ice-shelf related inputs
   real, pointer, dimension(:,:) :: &
-  ustar_shelf   => NULL(), &   !< friction velocity under ice-shelves (m/s)
-                               !! as computed by the ocean at the previous time step.
-  frac_shelf_h  => NULL(), &   !! Fractional ice shelf coverage of h-cells, nondimensional
-                               !! cells, nondimensional from 0 to 1. This is only
-                               !! associated if ice shelves are enabled, and are
-                               !! exactly 0 away from shelves or on land.
-  iceshelf_melt   => NULL()    !< ice shelf melt rate (positive) or freezing (negative) ( m/year )
+    ustar_shelf   => NULL(), &   !< friction velocity under ice-shelves (m/s)
+                                 !! as computed by the ocean at the previous time step.
+    frac_shelf_h  => NULL(), &   !! Fractional ice shelf coverage of h-cells, nondimensional
+                                 !! cells, nondimensional from 0 to 1. This is only
+                                 !! associated if ice shelves are enabled, and are
+                                 !! exactly 0 away from shelves or on land.
+    iceshelf_melt   => NULL()    !< ice shelf melt rate (positive) or freezing (negative) ( m/year )
 
   ! Scalars set by surface forcing modules
   real :: vPrecGlobalAdj     !< adjustment to restoring vprec to zero out global net ( kg/(m^2 s) )
@@ -1882,6 +1886,12 @@ subroutine copy_common_forcing_fields(forces, fluxes, G)
     do j=js,je ; do i=is,ie
       fluxes%p_surf_full(i,j) = forces%p_surf_full(i,j)
     enddo ; enddo
+  endif
+
+  if (associated(forces%p_surf_SSH, forces%p_surf_full)) then
+    fluxes%p_surf_SSH => fluxes%p_surf_full
+  elseif (associated(forces%p_surf_SSH, forces%p_surf)) then
+    fluxes%p_surf_SSH => fluxes%p_surf
   endif
 
 end subroutine copy_common_forcing_fields

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -8,13 +8,14 @@ use MOM_error_handler, only : MOM_error, FATAL
 use MOM_grid, only : ocean_grid_type
 use MOM_EOS, only : EOS_type
 
-use coupler_types_mod, only : coupler_2d_bc_type
+use coupler_types_mod, only : coupler_1d_bc_type, coupler_2d_bc_type
+use coupler_types_mod, only : coupler_type_spawn, coupler_type_destructor
 
 implicit none ; private
 
 #include <MOM_memory.h>
 
-public MOM_thermovar_chksum
+public allocate_surface_state, deallocate_surface_state, MOM_thermovar_chksum
 public ocean_grid_type, alloc_BT_cont_type, dealloc_BT_cont_type
 
 type, public :: p3d
@@ -268,6 +269,89 @@ type, public :: BT_cont_type
 end type BT_cont_type
 
 contains
+
+
+!> This subroutine allocates the fields for the surface (return) properties of
+!! the ocean model.  Unused fields are unallocated.
+subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
+                                  gas_fields_ocn)
+  type(ocean_grid_type), intent(in)    :: G                !< ocean grid structure
+  type(surface),         intent(inout) :: sfc_state        !< ocean surface state type to be allocated.
+  logical,     optional, intent(in)    :: use_temperature  !< If true, allocate the space for thermodynamic variables.
+  logical,     optional, intent(in)    :: do_integrals     !< If true, allocate the space for vertically integrated fields.
+  type(coupler_1d_bc_type), &
+               optional, intent(in)    :: gas_fields_ocn   !< If present, this type describes the ocean
+                                              !! ocean and surface-ice fields that will participate
+                                              !! in the calculation of additional gas or other
+                                              !! tracer fluxes, and can be used to spawn related
+                                              !! internal variables in the ice model.
+
+  logical :: use_temp, alloc_integ
+  integer :: is, ie, js, je, isd, ied, jsd, jed
+  integer :: isdB, iedB, jsdB, jedB
+
+  is  = G%isc ; ie  = G%iec ; js  = G%jsc ; je  = G%jec
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
+  isdB = G%isdB ; iedB = G%iedB; jsdB = G%jsdB ; jedB = G%jedB
+
+  use_temp = .true. ; if (present(use_temperature)) use_temp = use_temperature
+  alloc_integ = .true. ; if (present(do_integrals)) alloc_integ = do_integrals
+
+  if (sfc_state%arrays_allocated) return
+
+  if (use_temp) then
+    allocate(sfc_state%SST(isd:ied,jsd:jed)) ; sfc_state%SST(:,:) = 0.0
+    allocate(sfc_state%SSS(isd:ied,jsd:jed)) ; sfc_state%SSS(:,:) = 0.0
+  else
+    allocate(sfc_state%sfc_density(isd:ied,jsd:jed)) ; sfc_state%sfc_density(:,:) = 0.0
+  endif
+  allocate(sfc_state%sea_lev(isd:ied,jsd:jed)) ; sfc_state%sea_lev(:,:) = 0.0
+  allocate(sfc_state%Hml(isd:ied,jsd:jed)) ; sfc_state%Hml(:,:) = 0.0
+  allocate(sfc_state%u(IsdB:IedB,jsd:jed)) ; sfc_state%u(:,:) = 0.0
+  allocate(sfc_state%v(isd:ied,JsdB:JedB)) ; sfc_state%v(:,:) = 0.0
+
+  if (alloc_integ) then
+    ! Allocate structures for the vertically integrated ocean_mass, ocean_heat,
+    ! and ocean_salt.
+    allocate(sfc_state%ocean_mass(isd:ied,jsd:jed)) ; sfc_state%ocean_mass(:,:) = 0.0
+    if (use_temp) then
+      allocate(sfc_state%ocean_heat(isd:ied,jsd:jed)) ; sfc_state%ocean_heat(:,:) = 0.0
+      allocate(sfc_state%ocean_salt(isd:ied,jsd:jed)) ; sfc_state%ocean_salt(:,:) = 0.0
+    endif
+    allocate(sfc_state%salt_deficit(isd:ied,jsd:jed)) ; sfc_state%salt_deficit(:,:) = 0.0
+  endif
+
+  if (present(gas_fields_ocn)) &
+    call coupler_type_spawn(gas_fields_ocn, sfc_state%tr_fields, &
+                            (/isd,is,ie,ied/), (/jsd,js,je,jed/), as_needed=.true.)
+
+  sfc_state%arrays_allocated = .true.
+
+end subroutine allocate_surface_state
+
+!> This subroutine deallocates the elements of a surface state type.
+subroutine deallocate_surface_state(sfc_state)
+  type(surface),         intent(inout) :: sfc_state        !< ocean surface state type to be deallocated.
+
+  if (.not.sfc_state%arrays_allocated) return
+
+  if (allocated(sfc_state%SST)) deallocate(sfc_state%SST)
+  if (allocated(sfc_state%SSS)) deallocate(sfc_state%SSS)
+  if (allocated(sfc_state%sfc_density)) deallocate(sfc_state%sfc_density)
+  if (allocated(sfc_state%sea_lev)) deallocate(sfc_state%sea_lev)
+  if (allocated(sfc_state%Hml)) deallocate(sfc_state%Hml)
+  if (allocated(sfc_state%u)) deallocate(sfc_state%u)
+  if (allocated(sfc_state%v)) deallocate(sfc_state%v)
+  if (allocated(sfc_state%ocean_mass)) deallocate(sfc_state%ocean_mass)
+  if (allocated(sfc_state%ocean_heat)) deallocate(sfc_state%ocean_heat)
+  if (allocated(sfc_state%ocean_salt)) deallocate(sfc_state%ocean_salt)
+  if (allocated(sfc_state%salt_deficit)) deallocate(sfc_state%salt_deficit)
+
+  call coupler_type_destructor(sfc_state%tr_fields)
+
+  sfc_state%arrays_allocated = .false.
+
+end subroutine deallocate_surface_state
 
 !> alloc_BT_cont_type allocates the arrays contained within a BT_cont_type and
 !! initializes them to 0.

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -27,6 +27,7 @@ module MOM_diagnostics
 use MOM_coms,              only : reproducing_sum
 use MOM_diag_mediator,     only : post_data, post_data_1d_k, get_diag_time_end
 use MOM_diag_mediator,     only : register_diag_field, register_scalar_field
+use MOM_diag_mediator,     only : register_static_field, diag_register_area_ids
 use MOM_diag_mediator,     only : diag_ctrl, time_type, safe_alloc_ptr
 use MOM_diag_mediator,     only : diag_get_volume_cell_measure_dm_id
 use MOM_domains,           only : create_group_pass, do_group_pass, group_pass_type
@@ -50,8 +51,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public calculate_diagnostic_fields
-public register_time_deriv
+public calculate_diagnostic_fields, register_time_deriv, write_static_fields
 public find_eta
 public MOM_diagnostics_init, MOM_diagnostics_end
 public register_surface_diags, post_surface_diagnostics
@@ -1691,6 +1691,176 @@ subroutine register_surface_diags(Time, G, IDs, diag, missing, tv)
          'Heat flux into ocean from geothermal or other internal sources', 'W m-2')
 
 end subroutine register_surface_diags
+
+
+!> Offers the static fields in the ocean grid type for output via the diag_manager.
+subroutine write_static_fields(G, GV, tv, diag)
+  type(ocean_grid_type),   intent(in)    :: G    !< ocean grid structure
+  type(verticalGrid_type), intent(in)    :: GV   !< ocean vertical grid structure
+  type(thermo_var_ptrs),   intent(in)    :: tv   !< A structure pointing to various thermodynamic variables
+  type(diag_ctrl), target, intent(inout) :: diag !< regulates diagnostic output
+  ! Local variables
+  real    :: tmp_h(SZI_(G),SZJ_(G))
+  integer :: id, i, j
+
+  id = register_static_field('ocean_model', 'geolat', diag%axesT1, &
+        'Latitude of tracer (T) points', 'degrees_north')
+  if (id > 0) call post_data(id, G%geoLatT, diag, .true.)
+
+  id = register_static_field('ocean_model', 'geolon', diag%axesT1, &
+        'Longitude of tracer (T) points', 'degrees_east')
+  if (id > 0) call post_data(id, G%geoLonT, diag, .true.)
+
+  id = register_static_field('ocean_model', 'geolat_c', diag%axesB1, &
+        'Latitude of corner (Bu) points', 'degrees_north', interp_method='none')
+  if (id > 0) call post_data(id, G%geoLatBu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'geolon_c', diag%axesB1, &
+        'Longitude of corner (Bu) points', 'degrees_east', interp_method='none')
+  if (id > 0) call post_data(id, G%geoLonBu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'geolat_v', diag%axesCv1, &
+        'Latitude of meridional velocity (Cv) points', 'degrees_north', interp_method='none')
+  if (id > 0) call post_data(id, G%geoLatCv, diag, .true.)
+
+  id = register_static_field('ocean_model', 'geolon_v', diag%axesCv1, &
+        'Longitude of meridional velocity (Cv) points', 'degrees_east', interp_method='none')
+  if (id > 0) call post_data(id, G%geoLonCv, diag, .true.)
+
+  id = register_static_field('ocean_model', 'geolat_u', diag%axesCu1, &
+        'Latitude of zonal velocity (Cu) points', 'degrees_north', interp_method='none')
+  if (id > 0) call post_data(id, G%geoLatCu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'geolon_u', diag%axesCu1, &
+        'Longitude of zonal velocity (Cu) points', 'degrees_east', interp_method='none')
+  if (id > 0) call post_data(id, G%geoLonCu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'area_t', diag%axesT1,   &
+        'Surface area of tracer (T) cells', 'm2',                    &
+        cmor_field_name='areacello', cmor_standard_name='cell_area', &
+        cmor_long_name='Ocean Grid-Cell Area',      &
+        x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
+  if (id > 0) then
+    call post_data(id, G%areaT, diag, .true.)
+    call diag_register_area_ids(diag, id_area_t=id)
+  endif
+
+  id = register_static_field('ocean_model', 'area_u', diag%axesCu1,     &
+        'Surface area of x-direction flow (U) cells', 'm2',             &
+        cmor_field_name='areacello_cu', cmor_standard_name='cell_area', &
+        cmor_long_name='Ocean Grid-Cell Area',         &
+        x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
+  if (id > 0) then
+    call post_data(id, G%areaCu, diag, .true.)
+  endif
+
+  id = register_static_field('ocean_model', 'area_v', diag%axesCv1,     &
+        'Surface area of y-direction flow (V) cells', 'm2',             &
+        cmor_field_name='areacello_cv', cmor_standard_name='cell_area', &
+        cmor_long_name='Ocean Grid-Cell Area',         &
+        x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
+  if (id > 0) then
+    call post_data(id, G%areaCv, diag, .true.)
+  endif
+
+  id = register_static_field('ocean_model', 'area_q', diag%axesB1,      &
+        'Surface area of B-grid flow (Q) cells', 'm2',                  &
+        cmor_field_name='areacello_bu', cmor_standard_name='cell_area', &
+        cmor_long_name='Ocean Grid-Cell Area',         &
+        x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
+  if (id > 0) then
+    call post_data(id, G%areaBu, diag, .true.)
+  endif
+
+  id = register_static_field('ocean_model', 'depth_ocean', diag%axesT1,  &
+        'Depth of the ocean at tracer points', 'm',                      &
+        standard_name='sea_floor_depth_below_geoid',                     &
+        cmor_field_name='deptho', cmor_long_name='Sea Floor Depth',      &
+        cmor_standard_name='sea_floor_depth_below_geoid',&
+        area=diag%axesT1%id_area, &
+        x_cell_method='mean', y_cell_method='mean', area_cell_method='mean')
+  if (id > 0) call post_data(id, G%bathyT, diag, .true., mask=G%mask2dT)
+
+  id = register_static_field('ocean_model', 'wet', diag%axesT1, &
+        '0 if land, 1 if ocean at tracer points', 'none', area=diag%axesT1%id_area)
+  if (id > 0) call post_data(id, G%mask2dT, diag, .true.)
+
+  id = register_static_field('ocean_model', 'wet_c', diag%axesB1, &
+        '0 if land, 1 if ocean at corner (Bu) points', 'none', interp_method='none')
+  if (id > 0) call post_data(id, G%mask2dBu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'wet_u', diag%axesCu1, &
+        '0 if land, 1 if ocean at zonal velocity (Cu) points', 'none', interp_method='none')
+  if (id > 0) call post_data(id, G%mask2dCu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'wet_v', diag%axesCv1, &
+        '0 if land, 1 if ocean at meridional velocity (Cv) points', 'none', interp_method='none')
+  if (id > 0) call post_data(id, G%mask2dCv, diag, .true.)
+
+  id = register_static_field('ocean_model', 'Coriolis', diag%axesB1, &
+        'Coriolis parameter at corner (Bu) points', 's-1', interp_method='none')
+  if (id > 0) call post_data(id, G%CoriolisBu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'dxt', diag%axesT1, &
+        'Delta(x) at thickness/tracer points (meter)', 'm', interp_method='none')
+  if (id > 0) call post_data(id, G%dxt, diag, .true.)
+
+  id = register_static_field('ocean_model', 'dyt', diag%axesT1, &
+        'Delta(y) at thickness/tracer points (meter)', 'm', interp_method='none')
+  if (id > 0) call post_data(id, G%dyt, diag, .true.)
+
+  id = register_static_field('ocean_model', 'dxCu', diag%axesCu1, &
+        'Delta(x) at u points (meter)', 'm', interp_method='none')
+  if (id > 0) call post_data(id, G%dxCu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'dyCu', diag%axesCu1, &
+        'Delta(y) at u points (meter)', 'm', interp_method='none')
+  if (id > 0) call post_data(id, G%dyCu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'dxCv', diag%axesCv1, &
+        'Delta(x) at v points (meter)', 'm', interp_method='none')
+  if (id > 0) call post_data(id, G%dxCv, diag, .true.)
+
+  id = register_static_field('ocean_model', 'dyCv', diag%axesCv1, &
+        'Delta(y) at v points (meter)', 'm', interp_method='none')
+  if (id > 0) call post_data(id, G%dyCv, diag, .true.)
+
+  id = register_static_field('ocean_model', 'dyCuo', diag%axesCu1, &
+        'Open meridional grid spacing at u points (meter)', 'm', interp_method='none')
+  if (id > 0) call post_data(id, G%dy_Cu, diag, .true.)
+
+  id = register_static_field('ocean_model', 'dxCvo', diag%axesCv1, &
+        'Open zonal grid spacing at v points (meter)', 'm', interp_method='none')
+  if (id > 0) call post_data(id, G%dx_Cv, diag, .true.)
+
+
+  ! This static diagnostic is from CF 1.8, and is the fraction of a cell
+  ! covered by ocean, given as a percentage (poorly named).
+  id = register_static_field('ocean_model', 'area_t_percent', diag%axesT1, &
+        'Percentage of cell area covered by ocean', '%', &
+        cmor_field_name='sftof', cmor_standard_name='SeaAreaFraction', &
+        cmor_long_name='Sea Area Fraction', &
+        x_cell_method='mean', y_cell_method='mean', area_cell_method='mean')
+  if (id > 0) then
+    tmp_h(:,:) = 0.
+    tmp_h(G%isc:G%iec,G%jsc:G%jec) = 100. * G%mask2dT(G%isc:G%iec,G%jsc:G%jec)
+    call post_data(id, tmp_h, diag, .true.)
+  endif
+
+  id = register_static_field('ocean_model','Rho_0', diag%axesNull, &
+       'mean ocean density used with the Boussinesq approximation', &
+       'kg m-3', cmor_field_name='rhozero', &
+       cmor_standard_name='reference_sea_water_density_for_boussinesq_approximation', &
+       cmor_long_name='reference sea water density for boussinesq approximation')
+  if (id > 0) call post_data(id, GV%Rho0, diag, .true.)
+
+  id = register_static_field('ocean_model','C_p', diag%axesNull, &
+       'heat capacity of sea water', 'J kg-1 K-1', cmor_field_name='cpocean', &
+       cmor_standard_name='specific_heat_capacity_of_sea_water', &
+       cmor_long_name='specific_heat_capacity_of_sea_water')
+  if (id > 0) call post_data(id, tv%C_p, diag, .true.)
+
+end subroutine write_static_fields
 
 
 !> This subroutine sets up diagnostics upon which other diagnostics depend.

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -187,6 +187,7 @@ subroutine find_obsolete_params(param_file)
   call obsolete_logical(param_file, "READJUST_BT_TRANS", .false.)
   call obsolete_logical(param_file, "RESCALE_BT_FACE_AREAS", .false.)
   call obsolete_logical(param_file, "APPLY_BT_DRAG", .true.)
+  call obsolete_real(param_file, "BT_MASS_SOURCE_LIMIT", 0.0)
 
   call obsolete_int(param_file, "SEAMOUNT_LENGTH_SCALE", hint="Use SEAMOUNT_X_LENGTH_SCALE instead.")
 

--- a/src/framework/MOM_spatial_means.F90
+++ b/src/framework/MOM_spatial_means.F90
@@ -18,7 +18,7 @@ implicit none ; private
 public :: global_i_mean, global_j_mean
 public :: global_area_mean, global_layer_mean
 public :: global_area_integral
-public :: global_volume_mean
+public :: global_volume_mean, global_mass_integral
 public :: adjust_area_mean_to_zero
 
 contains
@@ -86,12 +86,15 @@ function global_layer_mean(var, h, G, GV)
 
 end function global_layer_mean
 
+!> Find the global thickness-weighted mean of a variable.
 function global_volume_mean(var, h, G, GV)
-  type(ocean_grid_type),                     intent(in)  :: G    !< The ocean's grid structure
-  type(verticalGrid_type),                   intent(in)  :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: var
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  real :: global_volume_mean
+  type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)  :: var  !< The variable being averaged
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)  :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  real :: global_volume_mean  !< The thickness-weighted average of var
 
   real :: weight_here
   real, dimension(SZI_(G), SZJ_(G)) :: tmpForSumming, sum_weight
@@ -109,6 +112,50 @@ function global_volume_mean(var, h, G, GV)
                        (reproducing_sum(sum_weight))
 
 end function global_volume_mean
+
+
+!> Find the global mass-weighted integral of a variable
+function global_mass_integral(h, G, GV, var, on_PE_only)
+  type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)  :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                 optional, intent(in)  :: var  !< The variable being integrated
+  logical,       optional, intent(in)  :: on_PE_only  !< If present and true, the sum is only
+                                !! done on the local PE, and it is _not_ order invariant.
+  real :: global_mass_integral  !< The mass-weighted integral of var (or 1) in
+                                !! kg times the units of var
+
+  real, dimension(SZI_(G), SZJ_(G)) :: tmpForSumming
+  logical :: global_sum
+  integer :: i, j, k, is, ie, js, je, nz
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+
+  tmpForSumming(:,:) = 0.0
+
+  if (present(var)) then
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      tmpForSumming(i,j) = tmpForSumming(i,j) + var(i,j,k) * &
+                ((GV%H_to_kg_m2 * h(i,j,k)) * (G%areaT(i,j) * G%mask2dT(i,j)))
+    enddo ; enddo ; enddo
+  else
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      tmpForSumming(i,j) = tmpForSumming(i,j) + &
+                ((GV%H_to_kg_m2 * h(i,j,k)) * (G%areaT(i,j) * G%mask2dT(i,j)))
+    enddo ; enddo ; enddo
+  endif
+  global_sum = .true. ; if (present(on_PE_only)) global_sum = .not.on_PE_only
+  if (global_sum) then
+    global_mass_integral = reproducing_sum(tmpForSumming)
+  else
+    global_mass_integral = 0.0
+    do j=js,je ; do i=is,ie
+      global_mass_integral = global_mass_integral + tmpForSumming(i,j)
+    enddo ; enddo
+  endif
+
+end function global_mass_integral
 
 
 subroutine global_i_mean(array, i_mean, G, mask)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -38,9 +38,6 @@ use MOM_debugging, only : uvchksum, hchksum
 use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
 use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl, time_type
-use MOM_domains, only : pass_vector
-use MOM_domains, only : To_North, To_East, Omit_corners, CGRID_NE, SCALAR_PAIR
-use MOM_domains, only : create_group_pass, do_group_pass, group_pass_type
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing, mech_forcing
@@ -146,8 +143,8 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, CS, symmetrize)
   type(set_visc_CS),        pointer       :: CS   !< The control structure returned by a previous
                                                   !! call to vertvisc_init.
   logical,        optional, intent(in)    :: symmetrize !< If present and true, do extra calculations
-                                                  !! or halo updates to fill in those values in visc
-                                                  !! that would be calculated with symmetric memory.
+                                                  !! of those values in visc that would be
+                                                  !! calculated with symmetric memory.
 !   The following subroutine calculates the thickness of the bottom
 ! boundary layer and the viscosity within that layer.  A drag law is
 ! used, either linearized about an assumed bottom velocity or using
@@ -301,7 +298,6 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, CS, symmetrize)
   real :: C2pi_3           ! An irrational constant, 2/3 pi.
   real :: tmp              ! A temporary variable.
   real :: tmp_val_m1_to_p1
-  type(group_pass_type) :: pass_bbl
   logical :: use_BBL_EOS, do_i(SZIB_(G))
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, m, n, K2, nkmb, nkml
   integer :: itt, maxitt=20
@@ -319,6 +315,10 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, CS, symmetrize)
   if (.not.associated(CS)) call MOM_error(FATAL,"MOM_vert_friction(BBL): "//&
          "Module must be initialized before it is used.")
   if (.not.CS%bottomdraglaw) return
+
+  if (present(symmetrize)) then ; if (symmetrize) then
+    Jsq = js-1 ; Isq = is-1
+  endif ; endif
 
   if (CS%debug) then
     call uvchksum("Start set_viscous_BBL [uv]", u, v, G%HI, haloshift=1)
@@ -338,7 +338,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, CS, symmetrize)
 !  if (CS%linear_drag) ustar(:) = cdrag_sqrt*CS%drag_bg_vel
 
   if ((nkml>0) .and. .not.use_BBL_EOS) then
-    do i=G%IscB,G%IecB+1 ; p_ref(i) = tv%P_ref ; enddo
+    do i=Isq,Ieq+1 ; p_ref(i) = tv%P_ref ; enddo
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1 ; do k=1,nkmb
       call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p_ref, &
@@ -414,11 +414,11 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, CS, symmetrize)
 !$OMP                                  BBL_visc_frac,h_vel,L0,Vol_0,dV_dL2,dVol,L_max,     &
 !$OMP                                  L_min,Vol_err_min,Vol_err_max,BBL_frac,Cell_width,  &
 !$OMP                                  gam,Rayleigh, Vol_tol, tmp_val_m1_to_p1)
-  do j=G%JscB,G%JecB ; do m=1,2
+  do j=Jsq,Jeq ; do m=1,2
 
     if (m==1) then
       if (j<G%Jsc) cycle
-      is = G%IscB ; ie = G%IecB
+      is = Isq ; ie = Ieq
       do i=is,ie
         do_i(i) = .false.
         if (G%mask2dCu(I,j) > 0) do_i(i) = .true.
@@ -930,23 +930,6 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, CS, symmetrize)
     endif ; enddo ! end of i loop
   enddo ; enddo ! end of m & j loops
 
-  if (present(symmetrize)) then ; if (symmetrize .and. .not.G%Domain%symmetric) then
-    if (associated(visc%Ray_u) .and. associated(visc%Ray_v)) &
-      call pass_vector(visc%Ray_u, visc%Ray_v, G%Domain, &
-                       To_North+To_East+SCALAR_PAIR+Omit_corners, CGRID_NE, &
-                       halo=1) !, clock=id_clock_pass)
-    if ((associated(visc%bbl_thick_u) .and. associated(visc%bbl_thick_v)) .or. &
-        (associated(visc%kv_bbl_u) .and. associated(visc%kv_bbl_v))) then
-      if (associated(visc%bbl_thick_u) .and. associated(visc%bbl_thick_v)) &
-        call create_group_pass(pass_bbl, visc%bbl_thick_u, visc%bbl_thick_v, G%Domain, &
-                               To_North+To_East+SCALAR_PAIR+Omit_corners, CGRID_NE, halo=1)
-      if (associated(visc%kv_bbl_u) .and. associated(visc%kv_bbl_v)) &
-        call create_group_pass(pass_bbl, visc%kv_bbl_u, visc%kv_bbl_v, G%Domain, &
-                               To_North+To_East+SCALAR_PAIR+Omit_corners, CGRID_NE, halo=1)
-      call do_group_pass(pass_bbl, G%Domain) !, clock=id_clock_pass)
-    endif
-  endif ; endif
-
 ! Offer diagnostics for averaging
   if (CS%id_bbl_thick_u > 0) &
     call post_data(CS%id_bbl_thick_u, visc%bbl_thick_u, CS%diag)
@@ -1054,7 +1037,7 @@ end function set_u_at_v
 !! the thickness of the topmost NKML layers (with a bulk mixed layer) are
 !! currently used.  The thicknesses are given in terms of fractional layers, so
 !! that this thickness will move as the thickness of the topmost layers change.
-subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, CS)
+subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, CS, symmetrize)
   type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
@@ -1072,6 +1055,9 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, CS)
   real,                    intent(in)    :: dt   !< Time increment in s.
   type(set_visc_CS),       pointer       :: CS   !< The control structure returned by a previous
                                                  !! call to vertvisc_init.
+  logical,        optional, intent(in)    :: symmetrize !< If present and true, do extra calculations
+                                                  !! of those values in visc that would be
+                                                  !! calculated with symmetric memory.
 
 !   The following subroutine calculates the thickness of the surface boundary
 ! layer for applying an elevated viscosity.  A bulk Richardson criterion or
@@ -1198,6 +1184,10 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, CS)
          "Module must be initialized before it is used.")
   if (.not.(CS%dynamic_viscous_ML .or. associated(forces%frac_shelf_u) .or. &
             associated(forces%frac_shelf_v)) ) return
+
+  if (present(symmetrize)) then ; if (symmetrize) then
+    Jsq = js-1 ; Isq = is-1
+  endif ; endif
 
   Rho0x400_G = 400.0*(GV%Rho0/GV%g_Earth)*GV%m_to_H
   U_bg_sq = CS%drag_bg_vel * CS%drag_bg_vel

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -1324,14 +1324,13 @@ end subroutine tracer_epipycnal_ML_diff
 
 
 !> Initialize lateral tracer diffusion module
-subroutine tracer_hor_diff_init(Time, G, param_file, diag, EOS, CS, CSnd)
+subroutine tracer_hor_diff_init(Time, G, param_file, diag, EOS, CS)
   type(time_type), target,    intent(in)    :: Time       !< current model time
   type(ocean_grid_type),      intent(in)    :: G          !< ocean grid structure
   type(diag_ctrl), target,    intent(inout) :: diag       !< diagnostic control
   type(EOS_type),  target,    intent(in)    :: EOS        !< Equation of state CS
   type(param_file_type),      intent(in)    :: param_file !< parameter file
   type(tracer_hor_diff_CS),   pointer       :: CS         !< horz diffusion control structure
-  type(neutral_diffusion_CS), pointer       :: CSnd       !< pointer to neutral diffusion CS
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -1392,7 +1391,6 @@ subroutine tracer_hor_diff_init(Time, G, param_file, diag, EOS, CS, CSnd)
   endif
 
   CS%use_neutral_diffusion = neutral_diffusion_init(Time, G, param_file, diag, EOS, CS%neutral_diffusion_CSp)
-  CSnd => CS%neutral_diffusion_CSp
   if (CS%use_neutral_diffusion .and. CS%Diffuse_ML_interior) call MOM_error(FATAL, "MOM_tracer_hor_diff: "// &
        "USE_NEUTRAL_DIFFUSION and DIFFUSE_ML_TO_INTERIOR are mutually exclusive!")
 


### PR DESCRIPTION
  Made a series of changes that substantially restructure step_MOM, adding the
ability to do updates of the dynamics and thermodynamics separately and making
all types defined within MOM.F90 to be opaque.  This also includes new options
that can be used to verify that for ocean-only test cases, the solutions are
identical regardless of whether the dynamics and thermodyanmics are updated
together or via separate calls to step_MOM with the equivalent sequence order.
The MOM_parameter_doc.all files are changed by these commits.The solutions agree
with the current version of dev/gfdl, having included the changes that recently
changed the answers with that branch.