### PR TITLE
Restore missing constant in seamount initialization

### DIFF
--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -267,6 +267,7 @@ subroutine seamount_initialize_temperature_salinity ( T, S, h, G, GV, param_file
               S(i,j,k) = S_surf + S_range * (2.0 / 3.0) * (xi1**3 - xi0**3) / (xi1 - xi0)
               T(i,j,k) = T_surf + T_range * (2.0 / 3.0) * (xi1**3 - xi0**3) / (xi1 - xi0)
             case ('exponential')
+              r = 0.8 ! small values give sharp profiles
               S(i,j,k) = S_surf + S_range * (exp(xi1/r)-exp(xi0/r)) / (xi1 - xi0)
               T(i,j,k) = T_surf + T_range * (exp(xi1/r)-exp(xi0/r)) / (xi1 - xi0)
             case default


### PR DESCRIPTION
Just caught this one while compiling locally with warnings enabled: during [this refactor 2 years ago](https://github.com/NOAA-GFDL/MOM6/commit/c1b62ba65c58772bda4782e223af806ee14c1a29#diff-b32e8b22aec0f833d85227a84391ed6dL241), the line initializing the `r` variable was dropped, leading to the following warning:

```
../../src/MOM6/src/user/seamount_initialization.F90:271:0:

               S(i,j,k) = S_surf + S_range * (exp(xi1/r)-exp(xi0/r)) / (xi1 - xi0)

Warning: ‘r’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```