### PR TITLE
Fixes sequence of times generated by ENERGYSAVEDAYS_GEOMETRIC

### DIFF
--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -451,7 +451,6 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
     return  ! Do not write this step
   else ! Determine the next write time before proceeding
     if (CS%energysave_geometric) then
-      CS%energysavedays_geometric = CS%energysavedays_geometric*2
       if (CS%write_energy_time + CS%energysavedays_geometric >= &
           CS%geometric_end_time) then
         CS%write_energy_time = CS%geometric_end_time
@@ -459,6 +458,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
       else
         CS%write_energy_time = CS%write_energy_time + CS%energysavedays_geometric
       endif
+      CS%energysavedays_geometric = CS%energysavedays_geometric*2
     else
       CS%write_energy_time = CS%write_energy_time + CS%energysavedays
     endif


### PR DESCRIPTION
- The times generated used to be 1,3,7,15 in which the interval between
  samples was doubling and because of the odd numbers makes it hard
  to end on a day boundary.
- This commit generates 1,2,4,8,16 and is much easier to align with
  a day boundary and is slightly finer grained.
- No answers changes since no regression experiments used this option (yet).