### PR TITLE
Enhance non-Boussinesq Pressure Gradient Force Calculation

### DIFF
--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -114,7 +114,7 @@ subroutine PressureForce_init(Time, G, GV, param_file, diag, CS, tides_CSp)
   call get_param(param_file, mdl, "BLOCKED_ANALYTIC_FV_PGF", CS%blocked_AFV, &
                  "If true, used the blocked version of the ANALYTIC_FV_PGF \n"//&
                  "code.  The value of this parameter should not change answers.", &
-                 default=.false., do_not_log=.true., debuggingParam=.true.) 
+                 default=.false., do_not_log=.true., debuggingParam=.true.)
 
   if (CS%Analytic_FV_PGF .and. CS%blocked_AFV) then
     call PressureForce_blk_AFV_init(Time, G, GV, param_file, diag, &

--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -8,9 +8,14 @@ use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
 use MOM_PressureForce_AFV, only : PressureForce_AFV_Bouss, PressureForce_AFV_nonBouss
-use MOM_PressureForce_AFV, only : PressureForce_AFV_init, PressureForce_AFV_CS
+use MOM_PressureForce_AFV, only : PressureForce_AFV_init, PressureForce_AFV_end
+use MOM_PressureForce_AFV, only : PressureForce_AFV_CS
+use MOM_PressureForce_blk_AFV, only : PressureForce_blk_AFV_Bouss, PressureForce_blk_AFV_nonBouss
+use MOM_PressureForce_blk_AFV, only : PressureForce_blk_AFV_init, PressureForce_blk_AFV_end
+use MOM_PressureForce_blk_AFV, only : PressureForce_blk_AFV_CS
 use MOM_PressureForce_Mont, only : PressureForce_Mont_Bouss, PressureForce_Mont_nonBouss
-use MOM_PressureForce_Mont, only : PressureForce_Mont_init, PressureForce_Mont_CS
+use MOM_PressureForce_Mont, only : PressureForce_Mont_init, PressureForce_Mont_end
+use MOM_PressureForce_Mont, only : PressureForce_Mont_CS
 use MOM_tidal_forcing, only : calc_tidal_forcing, tidal_forcing_CS
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
@@ -25,8 +30,12 @@ public PressureForce, PressureForce_init, PressureForce_end
 type, public :: PressureForce_CS ; private
   logical :: Analytic_FV_PGF !< If true, use the analytic finite volume form
                              !! (Adcroft et al., Ocean Mod. 2008) of the PGF.
+  logical :: blocked_AFV     !< If true, used the blocked version of the ANALYTIC_FV_PGF
+                             !! code.  The value of this parameter should not change answers.
   !> Control structure for the analytically integrated finite volume pressure force
   type(PressureForce_AFV_CS), pointer :: PressureForce_AFV_CSp => NULL()
+  !> Control structure for the analytically integrated finite volume pressure force
+  type(PressureForce_blk_AFV_CS), pointer :: PressureForce_blk_AFV_CSp => NULL()
   !> Control structure for the Montgomery potential form of pressure force
   type(PressureForce_Mont_CS), pointer :: PressureForce_Mont_CSp => NULL()
 end type PressureForce_CS
@@ -48,7 +57,15 @@ subroutine PressureForce(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
   real, dimension(SZI_(G),SZJ_(G)),         optional, intent(out) :: eta
 
 
-  if (CS%Analytic_FV_PGF) then
+  if (CS%Analytic_FV_PGF .and. CS%blocked_AFV) then
+    if (GV%Boussinesq) then
+      call PressureForce_blk_AFV_Bouss(h, tv, PFu, PFv, G, GV, &
+               CS%PressureForce_blk_AFV_CSp, ALE_CSp, p_atm, pbce, eta)
+    else
+      call PressureForce_blk_AFV_nonBouss(h, tv, PFu, PFv, G, GV, &
+               CS%PressureForce_blk_AFV_CSp, p_atm, pbce, eta)
+    endif
+  elseif (CS%Analytic_FV_PGF) then
     if (GV%Boussinesq) then
       call PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS%PressureForce_AFV_CSp, &
                                    ALE_CSp, p_atm, pbce, eta)
@@ -94,8 +111,15 @@ subroutine PressureForce_init(Time, G, GV, param_file, diag, CS, tides_CSp)
                  "the equations of state in pressure to avoid any \n"//&
                  "possibility of numerical thermobaric instability, as \n"//&
                  "described in Adcroft et al., O. Mod. (2008).", default=.true.)
+  call get_param(param_file, mdl, "BLOCKED_ANALYTIC_FV_PGF", CS%blocked_AFV, &
+                 "If true, used the blocked version of the ANALYTIC_FV_PGF \n"//&
+                 "code.  The value of this parameter should not change answers.", &
+                 default=.false., do_not_log=.true., debuggingParam=.true.) 
 
-  if (CS%Analytic_FV_PGF) then
+  if (CS%Analytic_FV_PGF .and. CS%blocked_AFV) then
+    call PressureForce_blk_AFV_init(Time, G, GV, param_file, diag, &
+             CS%PressureForce_blk_AFV_CSp, tides_CSp)
+  elseif (CS%Analytic_FV_PGF) then
     call PressureForce_AFV_init(Time, G, GV, param_file, diag, &
              CS%PressureForce_AFV_CSp, tides_CSp)
   else
@@ -108,6 +132,15 @@ end subroutine PressureForce_init
 !> Deallocate the pressure force control structure
 subroutine PressureForce_end(CS)
   type(PressureForce_CS), pointer :: CS !< Pressure force control structure
+
+  if (CS%Analytic_FV_PGF .and. CS%blocked_AFV) then
+    call PressureForce_blk_AFV_end(CS%PressureForce_blk_AFV_CSp)
+  elseif (CS%Analytic_FV_PGF) then
+    call PressureForce_AFV_end(CS%PressureForce_AFV_CSp)
+  else
+    call PressureForce_Mont_end(CS%PressureForce_Mont_CSp)
+  endif
+
   if (associated(CS)) deallocate(CS)
 end subroutine PressureForce_end
 

--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -71,7 +71,7 @@ subroutine PressureForce(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
                                    ALE_CSp, p_atm, pbce, eta)
     else
       call PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS%PressureForce_AFV_CSp, &
-                                      p_atm, pbce, eta)
+                                      ALE_CSp, p_atm, pbce, eta)
     endif
   else
     if (GV%Boussinesq) then

--- a/src/core/MOM_PressureForce_blocked_AFV.F90
+++ b/src/core/MOM_PressureForce_blocked_AFV.F90
@@ -1,5 +1,5 @@
 !> Analytically integrated finite volume pressure gradient
-module MOM_PressureForce_AFV
+module MOM_PressureForce_blk_AFV
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
@@ -25,11 +25,11 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public PressureForce_AFV, PressureForce_AFV_init, PressureForce_AFV_end
-public PressureForce_AFV_Bouss, PressureForce_AFV_nonBouss
+public PressureForce_blk_AFV, PressureForce_blk_AFV_init, PressureForce_blk_AFV_end
+public PressureForce_blk_AFV_Bouss, PressureForce_blk_AFV_nonBouss
 
 !> Finite volume pressure gradient control structure
-type, public :: PressureForce_AFV_CS ; private
+type, public :: PressureForce_blk_AFV_CS ; private
   logical :: tides          !< If true, apply tidal momentum forcing.
   real    :: Rho0           !< The density used in the Boussinesq
                             !! approximation, in kg m-3.
@@ -41,20 +41,20 @@ type, public :: PressureForce_AFV_CS ; private
   logical :: useMassWghtInterp !< Use mass weighting in T/S interpolation
   integer :: id_e_tidal = -1 !< Diagnostic identifier
   type(tidal_forcing_CS), pointer :: tides_CSp => NULL() !< Tides control structure
-end type PressureForce_AFV_CS
+end type PressureForce_blk_AFV_CS
 
 contains
 
 !> Thin interface between the model and the Boussinesq and non-Boussinesq
 !! pressure force routines.
-subroutine PressureForce_AFV(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
+subroutine PressureForce_blk_AFV(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
   type(ocean_grid_type),                     intent(in)    :: G   !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV  !< Vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h   !< Layer thickness (m or kg/m2)
   type(thermo_var_ptrs),                     intent(inout) :: tv  !< Thermodynamic variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(out)   :: PFu !< Zonal acceleration (m/s2)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(out)   :: PFv !< Meridional acceleration (m/s2)
-  type(PressureForce_AFV_CS),                pointer       :: CS  !< Finite volume PGF control structure
+  type(PressureForce_blk_AFV_CS),            pointer       :: CS  !< Finite volume PGF control structure
   type(ALE_CS),                              pointer       :: ALE_CSp !< ALE control structure
   real, dimension(:,:),                      optional, pointer :: p_atm !< The pressure at the ice-ocean
                                                            !! or atmosphere-ocean interface in Pa.
@@ -66,31 +66,31 @@ subroutine PressureForce_AFV(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, e
                                                            !! contributions or compressibility compensation.
 
   if (GV%Boussinesq) then
-    call PressureForce_AFV_bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
+    call PressureForce_blk_AFV_bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
   else
-    call PressureForce_AFV_nonbouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, eta)
+    call PressureForce_blk_AFV_nonbouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, eta)
   endif
 
-end subroutine PressureForce_AFV
+end subroutine PressureForce_blk_AFV
 
 !> \brief Non-Boussinesq analytically-integrated finite volume form of pressure gradient
 !!
-!! Determines the acceleration due to hydrostatic pressure forces, using
-!! the analytic finite volume form of the Pressure gradient, and does not
-!! make the Boussinesq approximation.
+!! Determines the acceleration due to hydrostatic pressure forces, using the
+!! analytic finite volume form of the Pressure gradient, and does not make the
+!! Boussinesq approximation.  This version uses code-blocking for threads.
 !!
 !! To work, the following fields must be set outside of the usual
 !! ie to ie, je to je range before this subroutine is called:
 !!  h[ie+1] and h[je+1] and (if tv%eqn_of_state is set) T[ie+1], S[ie+1],
 !!  T[je+1], and S[je+1].
-subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, eta)
+subroutine PressureForce_blk_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, eta)
   type(ocean_grid_type),                     intent(in)    :: G   !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV  !< Vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h   !< Layer thickness (kg/m2)
   type(thermo_var_ptrs),                     intent(in)    :: tv  !< Thermodynamic variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(out)   :: PFu !< Zonal acceleration (m/s2)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(out)   :: PFv !< Meridional acceleration (m/s2)
-  type(PressureForce_AFV_CS),                pointer       :: CS  !< Finite volume PGF control structure
+  type(PressureForce_blk_AFV_CS),                pointer       :: CS  !< Finite volume PGF control structure
   real, dimension(:,:),                      optional, pointer :: p_atm !< The pressure at the ice-ocean
                                                            !! or atmosphere-ocean interface in Pa.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  optional, intent(out) :: pbce !< The baroclinic pressure
@@ -120,17 +120,21 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
                 ! account for a reduced gravity model, in m2 s-2.
     za          ! The geopotential anomaly (i.e. g*e + alpha_0*pressure) at the
                 ! interface atop a layer, in m2 s-2.
+  real, dimension(SZDI_(G%Block(1)),SZDJ_(G%Block(1))) :: & ! on block indices
+    dp_bk, &    ! The (positive) change in pressure across a layer, in Pa.
+    za_bk       ! The geopotential anomaly (i.e. g*e + alpha_0*pressure) at the
+                ! interface atop a layer, in m2 s-2.
 
   real, dimension(SZI_(G)) :: Rho_cv_BL !  The coordinate potential density in the deepest variable
                 ! density near-surface layer, in kg m-3.
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
-    intx_za     ! The zonal integral of the geopotential anomaly along the
-                ! interface below a layer, divided by the grid spacing, m2 s-2.
+  real, dimension(SZDIB_(G%Block(1)),SZDJ_(G%Block(1))) :: & ! on block indices
+    intx_za_bk ! The zonal integral of the geopotential anomaly along the
+               ! interface below a layer, divided by the grid spacing, m2 s-2.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)) :: &
     intx_dza    ! The change in intx_za through a layer, in m2 s-2.
-  real, dimension(SZI_(G),SZJB_(G)) :: &
-    inty_za     ! The meridional integral of the geopotential anomaly along the
-                ! interface below a layer, divided by the grid spacing, m2 s-2.
+  real, dimension(SZDI_(G%Block(1)),SZDJB_(G%Block(1))) :: & ! on block indices
+    inty_za_bk ! The meridional integral of the geopotential anomaly along the
+               ! interface below a layer, divided by the grid spacing, m2 s-2.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)) :: &
     inty_dza    ! The change in inty_za through a layer, in m2 s-2.
   real :: p_ref(SZI_(G))     !   The pressure used to calculate the coordinate
@@ -153,7 +157,8 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
   real :: I_gEarth
   real, parameter :: C1_6 = 1.0/6.0
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, nkmb
-  integer :: i, j, k
+  integer :: is_bk, ie_bk, js_bk, je_bk, Isq_bk, Ieq_bk, Jsq_bk, Jeq_bk
+  integer :: i, j, k, n, ib, jb, ioff_bk, joff_bk
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   nkmb=GV%nk_rho_varies
@@ -169,21 +174,23 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
   dp_neglect = GV%H_to_Pa * GV%H_subroundoff
   alpha_ref = 1.0/CS%Rho0
 
+!$OMP parallel default(none) shared(Isq,Ieq,Jsq,Jeq,nz,use_p_atm,p,p_atm,GV,h)
   if (use_p_atm) then
-    !$OMP parallel do default(shared)
+!$OMP do
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       p(i,j,1) = p_atm(i,j)
     enddo ; enddo
   else
-    !$OMP parallel do default(shared)
+!$OMP do
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       p(i,j,1) = 0.0 ! or oneatm
     enddo ; enddo
   endif
-  !$OMP parallel do default(shared)
+!$OMP do
   do j=Jsq,Jeq+1 ; do k=2,nz+1 ; do i=Isq,Ieq+1
     p(i,j,K) = p(i,j,K-1) + GV%H_to_Pa * h(i,j,k-1)
   enddo ; enddo ; enddo
+!$OMP end parallel
 
   I_gEarth = 1.0 / GV%g_Earth
 
@@ -196,7 +203,8 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
       tv_tmp%T => T_tmp ; tv_tmp%S => S_tmp
       tv_tmp%eqn_of_state => tv%eqn_of_state
       do i=Isq,Ieq+1 ; p_ref(i) = tv%P_Ref ; enddo
-      !$OMP parallel do default(shared) private(Rho_cv_BL)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,nz,nkmb,tv_tmp,tv,p_ref,GV) &
+!$OMP                          private(Rho_cv_BL)
       do j=Jsq,Jeq+1
         do k=1,nkmb ; do i=Isq,Ieq+1
           tv_tmp%T(i,j,k) = tv%T(i,j,k) ; tv_tmp%S(i,j,k) = tv%S(i,j,k)
@@ -217,7 +225,9 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
     endif
   endif
 
-  !$OMP parallel do default(shared) private(alpha_anom,dp)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,nz,is,ie,js,je,tv_tmp,alpha_ref, &
+!$OMP                                  p,h,G,GV,tv,dza,intp_dza,intx_dza,inty_dza,use_EOS) &
+!$OMP                          private(alpha_anom,dp)
   do k=1,nz
     ! Calculate 4 integrals through the layer that are required in the
     ! subsequent calculation.
@@ -250,24 +260,24 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
   ! inty_dza to be 3-D arrays.
 
   ! Sum vertically to determine the surface geopotential anomaly.
-  !$OMP parallel do default(shared)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,nz,za,alpha_ref,p,G,GV,dza)
   do j=Jsq,Jeq+1
     do i=Isq,Ieq+1
       za(i,j) = alpha_ref*p(i,j,nz+1) - GV%g_Earth*G%bathyT(i,j)
     enddo
     do k=nz,1,-1 ; do i=Isq,Ieq+1
-      za(i,j) = za(i,j) + dza(i,j,k)
+    za(i,j) = za(i,j) + dza(i,j,k)
     enddo ; enddo
   enddo
 
   if (CS%tides) then
     ! Find and add the tidal geopotential anomaly.
-    !$OMP parallel do default(shared)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,SSH,za,alpha_ref,p,I_gEarth)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       SSH(i,j) = (za(i,j) - alpha_ref*p(i,j,1)) * I_gEarth
     enddo ; enddo
     call calc_tidal_forcing(CS%Time, SSH, e_tidal, G, CS%tides_CSp)
-    !$OMP parallel do default(shared)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,za,G,GV,e_tidal)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       za(i,j) = za(i,j) - GV%g_Earth*e_tidal(i,j)
     enddo ; enddo
@@ -276,7 +286,8 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
   if (CS%GFS_scale < 1.0) then
     ! Adjust the Montgomery potential to make this a reduced gravity model.
     if (use_EOS) then
-      !$OMP parallel do default(shared) private(rho_in_situ)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,tv_tmp,p,tv,dM,CS,alpha_ref,za) &
+!$OMP                          private(rho_in_situ)
       do j=Jsq,Jeq+1
         call calculate_density(tv_tmp%T(:,j,1), tv_tmp%S(:,j,1), p(:,j,1), &
                                rho_in_situ, Isq, Ieq-Isq+2, tv%eqn_of_state)
@@ -287,7 +298,7 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
         enddo
       enddo
     else
-      !$OMP parallel do default(shared)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,dM,CS,p,GV,alpha_ref,za)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         dM(i,j) = (CS%GFS_scale - 1.0) * &
           (p(i,j,1)*(1.0/GV%Rlay(1) - alpha_ref) + za(i,j))
@@ -302,54 +313,69 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
   ! linearly between the values at thickness points, but the bottom
   ! geopotentials will not now be linear at the sub-grid-scale.  Doing this
   ! ensures no motion with flat isopycnals, even with a nonlinear equation of state.
-  !$OMP parallel do default(shared)
-  do j=js,je ; do I=Isq,Ieq
-    intx_za(I,j) = 0.5*(za(i,j) + za(i+1,j))
-  enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=Jsq,Jeq ; do i=is,ie
-    inty_za(i,J) = 0.5*(za(i,j) + za(i,j+1))
-  enddo ; enddo
-  do k=1,nz
-    ! These expressions for the acceleration have been carefully checked in
-    ! a set of idealized cases, and should be bug-free.
-    !$OMP parallel do default(shared)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      dp(i,j) = GV%H_to_Pa*h(i,j,k)
-      za(i,j) = za(i,j) - dza(i,j,k)
+!$OMP parallel do default(none) shared(nz,za,G,GV,dza,intx_dza,h,PFu, &
+!$OMP                                  intp_dza,p,dp_neglect,inty_dza,PFv,CS,dM) &
+!$OMP                          private(is_bk,ie_bk,js_bk,je_bk,Isq_bk,Ieq_bk,Jsq_bk, &
+!$OMP                                  Jeq_bk,ioff_bk,joff_bk,i,j,za_bk,intx_za_bk,  &
+!$OMP                                  inty_za_bk,dp_bk)
+  do n = 1, G%nblocks
+    is_bk=G%block(n)%isc      ; ie_bk=G%block(n)%iec
+    js_bk=G%block(n)%jsc      ; je_bk=G%block(n)%jec
+    Isq_bk=G%block(n)%IscB    ; Ieq_bk=G%block(n)%IecB
+    Jsq_bk=G%block(n)%JscB    ; Jeq_bk=G%block(n)%JecB
+    ioff_bk = G%Block(n)%idg_offset - G%HI%idg_offset
+    joff_bk = G%Block(n)%jdg_offset - G%HI%jdg_offset
+    do jb=Jsq_bk,Jeq_bk+1 ; do ib=Isq_bk,Ieq_bk+1
+      i = ib+ioff_bk ; j = jb+joff_bk
+      za_bk(ib,jb) = za(i,j)
     enddo ; enddo
-    !$OMP parallel do default(shared)
-    do j=js,je ; do I=Isq,Ieq
-      intx_za(I,j) = intx_za(I,j) - intx_dza(I,j,k)
-      PFu(I,j,k) = (((za(i,j)*dp(i,j) + intp_dza(i,j,k)) - &
-                   (za(i+1,j)*dp(i+1,j) + intp_dza(i+1,j,k))) + &
-                   ((dp(i+1,j) - dp(i,j)) * intx_za(I,j) - &
-                   (p(i+1,j,K) - p(i,j,K)) * intx_dza(I,j,k))) * &
-                   (2.0*G%IdxCu(I,j) / ((dp(i,j) + dp(i+1,j)) + &
-                   dp_neglect))
+    do jb=js_bk,je_bk ; do Ib=Isq_bk,Ieq_bk
+      I = Ib+ioff_bk ; j = jb+joff_bk
+      intx_za_bk(Ib,jb) = 0.5*(za_bk(ib,jb) + za_bk(ib+1,jb))
     enddo ; enddo
-    !$OMP parallel do default(shared)
-    do J=Jsq,Jeq ; do i=is,ie
-      inty_za(i,J) = inty_za(i,J) - inty_dza(i,J,k)
-      PFv(i,J,k) = (((za(i,j)*dp(i,j) + intp_dza(i,j,k)) - &
-                   (za(i,j+1)*dp(i,j+1) + intp_dza(i,j+1,k))) + &
-                   ((dp(i,j+1) - dp(i,j)) * inty_za(i,J) - &
-                   (p(i,j+1,K) - p(i,j,K)) * inty_dza(i,J,k))) * &
-                   (2.0*G%IdyCv(i,J) / ((dp(i,j) + dp(i,j+1)) + &
-                   dp_neglect))
+    do Jb=Jsq_bk,Jeq_bk ; do ib=is_bk,ie_bk
+      i = ib+ioff_bk ; J = Jb+joff_bk
+      inty_za_bk(ib,Jb) = 0.5*(za_bk(ib,jb) + za_bk(ib,jb+1))
     enddo ; enddo
+    do k=1,nz
+      ! These expressions for the acceleration have been carefully checked in
+      ! a set of idealized cases, and should be bug-free.
+      do jb=Jsq_bk,Jeq_bk+1 ; do ib=Isq_bk,Ieq_bk+1
+        i = ib+ioff_bk ; j = jb+joff_bk
+        dp_bk(ib,jb) = GV%H_to_Pa*h(i,j,k)
+        za_bk(ib,jb) = za_bk(ib,jb) - dza(i,j,k)
+      enddo ; enddo
+      do jb=js_bk,je_bk ; do Ib=Isq_bk,Ieq_bk
+        I = Ib+ioff_bk ; j = jb+joff_bk
+        intx_za_bk(Ib,jb) = intx_za_bk(Ib,jb) - intx_dza(I,j,k)
+        PFu(I,j,k) = (((za_bk(ib,jb)*dp_bk(ib,jb) + intp_dza(i,j,k)) - &
+                     (za_bk(ib+1,jb)*dp_bk(ib+1,jb) + intp_dza(i+1,j,k))) + &
+                     ((dp_bk(ib+1,jb) - dp_bk(ib,jb)) * intx_za_bk(Ib,jb) - &
+                     (p(i+1,j,K) - p(i,j,K)) * intx_dza(I,j,k))) * &
+                     (2.0*G%IdxCu(I,j) / ((dp_bk(ib,jb) + dp_bk(ib+1,jb)) + &
+                     dp_neglect))
+      enddo ; enddo
+      do Jb=Jsq_bk,Jeq_bk ; do ib=is_bk,ie_bk
+        i = ib+ioff_bk ; J = Jb+joff_bk
+        inty_za_bk(ib,Jb) = inty_za_bk(ib,Jb) - inty_dza(i,J,k)
+        PFv(i,J,k) = (((za_bk(ib,jb)*dp_bk(ib,jb) + intp_dza(i,j,k)) - &
+                     (za_bk(ib,jb+1)*dp_bk(ib,jb+1) + intp_dza(i,j+1,k))) + &
+                     ((dp_bk(ib,jb+1) - dp_bk(ib,jb)) * inty_za_bk(ib,Jb) - &
+                     (p(i,j+1,K) - p(i,j,K)) * inty_dza(i,J,k))) * &
+                     (2.0*G%IdyCv(i,J) / ((dp_bk(ib,jb) + dp_bk(ib,jb+1)) + &
+                     dp_neglect))
+      enddo ; enddo
 
-    if (CS%GFS_scale < 1.0) then
-      ! Adjust the Montgomery potential to make this a reduced gravity model.
-      !$OMP parallel do default(shared)
-      do j=js,je ; do I=Isq,Ieq
-        PFu(I,j,k) = PFu(I,j,k) - (dM(i+1,j) - dM(i,j)) * G%IdxCu(I,j)
-      enddo ; enddo
-      !$OMP parallel do default(shared)
-      do J=Jsq,Jeq ; do i=is,ie
-        PFv(i,J,k) = PFv(i,J,k) - (dM(i,j+1) - dM(i,j)) * G%IdyCv(i,J)
-      enddo ; enddo
-    endif
+      if (CS%GFS_scale < 1.0) then
+        ! Adjust the Montgomery potential to make this a reduced gravity model.
+        do j=js_bk+joff_bk,je_bk+joff_bk ; do I=Isq_bk+ioff_bk,Ieq_bk+ioff_bk
+          PFu(I,j,k) = PFu(I,j,k) - (dM(i+1,j) - dM(i,j)) * G%IdxCu(I,j)
+        enddo ; enddo
+        do J=Jsq_bk+joff_bk,Jeq_bk+joff_bk ; do i=is_bk+ioff_bk,ie_bk+ioff_bk
+          PFv(i,J,k) = PFv(i,J,k) - (dM(i,j+1) - dM(i,j)) * G%IdyCv(i,J)
+        enddo ; enddo
+      endif
+    enddo
   enddo
 
   if (present(pbce)) then
@@ -359,12 +385,12 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
   if (present(eta)) then
     Pa_to_H = 1.0 / GV%H_to_Pa
     if (use_p_atm) then
-      !$OMP parallel do default(shared)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,nz,eta,p,p_atm,Pa_to_H)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         eta(i,j) = (p(i,j,nz+1) - p_atm(i,j))*Pa_to_H ! eta has the same units as h.
       enddo ; enddo
     else
-      !$OMP parallel do default(shared)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,nz,eta,p,Pa_to_H)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         eta(i,j) = p(i,j,nz+1)*Pa_to_H ! eta has the same units as h.
       enddo ; enddo
@@ -373,25 +399,26 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, e
 
   if (CS%id_e_tidal>0) call post_data(CS%id_e_tidal, e_tidal, CS%diag)
 
-end subroutine PressureForce_AFV_nonBouss
+end subroutine PressureForce_blk_AFV_nonBouss
 
 !> \brief Boussinesq analytically-integrated finite volume form of pressure gradient
 !!
 !! Determines the acceleration due to hydrostatic pressure forces, using
-!! the finite volume form of the terms and analytic integrals in depth.
+!! the finite volume form of the terms and analytic integrals in depth, making
+!! the Boussinesq approximation.  This version uses code-blocking for threads.
 !!
 !! To work, the following fields must be set outside of the usual
 !! ie to ie, je to je range before this subroutine is called:
 !!  h[ie+1] and h[je+1] and (if tv%eqn_of_state is set) T[ie+1], S[ie+1],
 !!  T[je+1], and S[je+1].
-subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
+subroutine PressureForce_blk_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
   type(ocean_grid_type),                     intent(in)  :: G   !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)  :: GV  !< Vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)  :: h   !< Layer thickness (kg/m2)
   type(thermo_var_ptrs),                     intent(in)  :: tv  !< Thermodynamic variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(out) :: PFu !< Zonal acceleration (m/s2)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(out) :: PFv !< Meridional acceleration (m/s2)
-  type(PressureForce_AFV_CS),                pointer     :: CS  !< Finite volume PGF control structure
+  type(PressureForce_blk_AFV_CS),                pointer     :: CS  !< Finite volume PGF control structure
   type(ALE_CS),                              pointer     :: ALE_CSp !< ALE control structure
   real, dimension(:,:),                      optional, pointer :: p_atm !< The pressure at the ice-ocean
                                                          !! or atmosphere-ocean interface in Pa.
@@ -411,22 +438,22 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
   real, dimension(SZI_(G)) :: &
     Rho_cv_BL   !   The coordinate potential density in the deepest variable
                 ! density near-surface layer, in kg m-3.
-  real, dimension(SZI_(G),SZJ_(G)) :: &
-    dz, &       ! The change in geopotential thickness through a layer, m2 s-2.
-    pa, &       ! The pressure anomaly (i.e. pressure + g*RHO_0*e) at the
-                ! the interface atop a layer, in Pa.
-    dpa, &      ! The change in pressure anomaly between the top and bottom
-                ! of a layer, in Pa.
-    intz_dpa    ! The vertical integral in depth of the pressure anomaly less
-                ! the pressure anomaly at the top of the layer, in H Pa (m Pa).
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
-    intx_pa, &  ! The zonal integral of the pressure anomaly along the interface
-                ! atop a layer, divided by the grid spacing, in Pa.
-    intx_dpa    ! The change in intx_pa through a layer, in Pa.
-  real, dimension(SZI_(G),SZJB_(G)) :: &
-    inty_pa, &  ! The meridional integral of the pressure anomaly along the
-                ! interface atop a layer, divided by the grid spacing, in Pa.
-    inty_dpa    ! The change in inty_pa through a layer, in Pa.
+  real, dimension(SZDI_(G%Block(1)),SZDJ_(G%Block(1))) :: &  ! on block indices
+    dz_bk, &     ! The change in geopotential thickness through a layer, m2 s-2.
+    pa_bk, &     ! The pressure anomaly (i.e. pressure + g*RHO_0*e) at the
+                 ! the interface atop a layer, in Pa.
+    dpa_bk, &    ! The change in pressure anomaly between the top and bottom
+                 ! of a layer, in Pa.
+    intz_dpa_bk  ! The vertical integral in depth of the pressure anomaly less
+                 ! the pressure anomaly at the top of the layer, in H Pa (m Pa).
+  real, dimension(SZDIB_(G%Block(1)),SZDJ_(G%Block(1))) :: & ! on block indices
+    intx_pa_bk, & ! The zonal integral of the pressure anomaly along the interface
+                  ! atop a layer, divided by the grid spacing, in Pa.
+    intx_dpa_bk   ! The change in intx_pa through a layer, in Pa.
+  real, dimension(SZDI_(G%Block(1)),SZDJB_(G%Block(1))) :: & ! on block indices
+    inty_pa_bk, & ! The meridional integral of the pressure anomaly along the
+                  ! interface atop a layer, divided by the grid spacing, in Pa.
+    inty_dpa_bk   ! The change in inty_pa through a layer, in Pa.
 
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), target :: &
     T_tmp, &    ! Temporary array of temperatures where layers that are lighter
@@ -454,7 +481,9 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
 
   real, parameter :: C1_6 = 1.0/6.0
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, nkmb
-  integer :: i, j, k
+  integer :: is_bk, ie_bk, js_bk, je_bk, Isq_bk, Ieq_bk, Jsq_bk, Jeq_bk
+  integer :: ioff_bk, joff_bk
+  integer :: i, j, k, n, ib, jb
   integer :: PRScheme
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -483,7 +512,7 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
     ! and loading.  This should really be based on bottom pressure anomalies,
     ! but that is not yet implemented, and the current form is correct for
     ! barotropic tides.
-    !$OMP parallel do default(shared)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,nz,e,G,GV,h)
     do j=Jsq,Jeq+1
       do i=Isq,Ieq+1
         e(i,j,1) = -1.0*G%bathyT(i,j)
@@ -496,21 +525,23 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
   endif
 
 !    Here layer interface heights, e, are calculated.
+!$OMP parallel default(none) shared(Isq,Ieq,Jsq,Jeq,nz,e,G,GV,h,CS,e_tidal)
   if (CS%tides) then
-    !$OMP parallel do default(shared)
+!$OMP do
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       e(i,j,nz+1) = -1.0*G%bathyT(i,j) - e_tidal(i,j)
     enddo ; enddo
   else
-    !$OMP parallel do default(shared)
+!$OM do
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       e(i,j,nz+1) = -1.0*G%bathyT(i,j)
     enddo ; enddo
   endif
-  !$OMP parallel do default(shared)
+!$OMP do
   do j=Jsq,Jeq+1; do k=nz,1,-1 ; do i=Isq,Ieq+1
     e(i,j,K) = e(i,j,K+1) + h(i,j,k)*GV%H_to_m
   enddo ; enddo ; enddo
+!$OMP end parallel
 
 
   if (use_EOS) then
@@ -524,7 +555,8 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
       tv_tmp%eqn_of_state => tv%eqn_of_state
 
       do i=Isq,Ieq+1 ; p_ref(i) = tv%P_Ref ; enddo
-     !$OMP parallel do default(shared) private(Rho_cv_BL)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,nkmb,nz,GV,tv_tmp,tv,p_ref) &
+!$OMP                          private(Rho_cv_BL)
       do j=Jsq,Jeq+1
         do k=1,nkmb ; do i=Isq,Ieq+1
           tv_tmp%T(i,j,k) = tv%T(i,j,k) ; tv_tmp%S(i,j,k) = tv%S(i,j,k)
@@ -546,10 +578,13 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
     endif
   endif
 
+!$OMP parallel default(none) shared(Jsq,Jeq,Isq,Ieq,tv_tmp,p_atm,rho_in_situ,tv, &
+!$OMP                               p0,dM,CS,G_Rho0,e,use_p_atm,use_EOS,GV,    &
+!$OMP                               rho_ref,js,je,is,ie)
   if (CS%GFS_scale < 1.0) then
     ! Adjust the Montgomery potential to make this a reduced gravity model.
     if (use_EOS) then
-      !$OMP parallel do default(shared)
+!$OMP do
       do j=Jsq,Jeq+1
         if (use_p_atm) then
           call calculate_density(tv_tmp%T(:,j,1), tv_tmp%S(:,j,1), p_atm(:,j), &
@@ -563,12 +598,13 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
         enddo
       enddo
     else
-      !$OMP parallel do default(shared)
+!$OMP do
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         dM(i,j) = (CS%GFS_scale - 1.0) * (G_Rho0 * GV%Rlay(1)) * e(i,j,1)
       enddo ; enddo
     endif
   endif
+!$OMP end parallel
 
 ! Have checked that rho_0 drops out and that the 1-layer case is right. RWH.
 
@@ -584,121 +620,129 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
     endif
   endif
 
-  ! Set the surface boundary conditions on pressure anomaly and its horizontal
-  ! integrals, assuming that the surface pressure anomaly varies linearly
-  ! in x and y.
-  if (use_p_atm) then
-    !$OMP parallel do default(shared)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      pa(i,j) = (rho_ref*GV%g_Earth)*e(i,j,1) + p_atm(i,j)
-    enddo ; enddo
-  else
-    !$OMP parallel do default(shared)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      pa(i,j) = (rho_ref*GV%g_Earth)*e(i,j,1)
-    enddo ; enddo
-  endif
-  !$OMP parallel do default(shared)
-  do j=js,je ; do I=Isq,Ieq
-    intx_pa(I,j) = 0.5*(pa(i,j) + pa(i+1,j))
-  enddo ; enddo
-  !$OMP parallel do default(shared)
-  do J=Jsq,Jeq ; do i=is,ie
-    inty_pa(i,J) = 0.5*(pa(i,j) + pa(i,j+1))
-  enddo ; enddo
+!$OMP parallel do default(none) shared(use_p_atm,rho_ref,G,GV,e,p_atm,nz,use_EOS,&
+!$OMP                                  use_ALE,PRScheme,T_t,T_b,S_t,S_b,CS,tv,tv_tmp, &
+!$OMP                                  h,PFu,I_Rho0,h_neglect,dz_neglect,PFv,dM)&
+!$OMP                          private(is_bk,ie_bk,js_bk,je_bk,Isq_bk,Ieq_bk,Jsq_bk,  &
+!$OMP                                  Jeq_bk,ioff_bk,joff_bk,pa_bk,  &
+!$OMP                                  intx_pa_bk,inty_pa_bk,dpa_bk,intz_dpa_bk,      &
+!$OMP                                  intx_dpa_bk,inty_dpa_bk,dz_bk,i,j)
+  do n = 1, G%nblocks
+    is_bk=G%Block(n)%isc      ; ie_bk=G%Block(n)%iec
+    js_bk=G%Block(n)%jsc      ; je_bk=G%Block(n)%jec
+    Isq_bk=G%Block(n)%IscB    ; Ieq_bk=G%Block(n)%IecB
+    Jsq_bk=G%Block(n)%JscB    ; Jeq_bk=G%Block(n)%JecB
+    ioff_bk = G%Block(n)%idg_offset - G%HI%idg_offset
+    joff_bk = G%Block(n)%jdg_offset - G%HI%jdg_offset
 
-  do k=1,nz
-    ! Calculate 4 integrals through the layer that are required in the
-    ! subsequent calculation.
-
-    if (use_EOS) then
-      ! The following routine computes the integrals that are needed to
-      ! calculate the pressure gradient force. Linear profiles for T and S are
-      ! assumed when regridding is activated. Otherwise, the previous version
-      ! is used, whereby densities within each layer are constant no matter
-      ! where the layers are located.
-      if ( use_ALE ) then
-        if ( PRScheme == PRESSURE_RECONSTRUCTION_PLM ) then
-          call int_density_dz_generic_plm ( T_t(:,:,k), T_b(:,:,k), &
-                    S_t(:,:,k), S_b(:,:,k), e(:,:,K), e(:,:,K+1), &
-                    rho_ref, CS%Rho0, GV%g_Earth,    &
-                    dz_neglect, G%bathyT, G%HI, G%HI, &
-                    tv%eqn_of_state, dpa, intz_dpa, intx_dpa, inty_dpa, &
-                    useMassWghtInterp = CS%useMassWghtInterp)
-        elseif ( PRScheme == PRESSURE_RECONSTRUCTION_PPM ) then
-          call int_density_dz_generic_ppm ( tv%T(:,:,k), T_t(:,:,k), T_b(:,:,k), &
-                    tv%S(:,:,k), S_t(:,:,k), S_b(:,:,k), e(:,:,K), e(:,:,K+1), &
-                    rho_ref, CS%Rho0, GV%g_Earth, &
-                    G%HI, G%HI, tv%eqn_of_state, dpa, intz_dpa,    &
-                    intx_dpa, inty_dpa)
-        endif
-      else
-        call int_density_dz(tv_tmp%T(:,:,k), tv_tmp%S(:,:,k), &
-                  e(:,:,K), e(:,:,K+1),             &
-                  rho_ref, CS%Rho0, GV%g_Earth, G%HI, G%HI, tv%eqn_of_state, &
-                  dpa, intz_dpa, intx_dpa, inty_dpa)
-      endif
-      !$OMP parallel do default(shared)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        intz_dpa(i,j) = intz_dpa(i,j)*GV%m_to_H
+    ! Set the surface boundary conditions on pressure anomaly and its horizontal
+    ! integrals, assuming that the surface pressure anomaly varies linearly
+    ! in x and y.
+    if (use_p_atm) then
+      do jb=Jsq_bk,Jeq_bk+1 ; do ib=Isq_bk,Ieq_bk+1
+        i = ib+ioff_bk ; j = jb+joff_bk
+        pa_bk(ib,jb) = (rho_ref*GV%g_Earth)*e(i,j,1) + p_atm(i,j)
       enddo ; enddo
     else
-      !$OMP parallel do default(shared)
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        dz(i,j) = GV%g_Earth*GV%H_to_m*h(i,j,k)
-        dpa(i,j) = (GV%Rlay(k) - rho_ref)*dz(i,j)
-        intz_dpa(i,j) = 0.5*(GV%Rlay(k) - rho_ref)*dz(i,j)*h(i,j,k)
-      enddo ; enddo
-      !$OMP parallel do default(shared)
-      do j=js,je ; do I=Isq,Ieq
-        intx_dpa(I,j) = 0.5*(GV%Rlay(k) - rho_ref) * (dz(i,j)+dz(i+1,j))
-      enddo ; enddo
-      !$OMP parallel do default(shared)
-      do J=Jsq,Jeq ; do i=is,ie
-        inty_dpa(i,J) = 0.5*(GV%Rlay(k) - rho_ref) * (dz(i,j)+dz(i,j+1))
+      do jb=Jsq_bk,Jeq_bk+1 ; do ib=Isq_bk,Ieq_bk+1
+        i = ib+ioff_bk ; j = jb+joff_bk
+        pa_bk(ib,jb) = (rho_ref*GV%g_Earth)*e(i,j,1)
       enddo ; enddo
     endif
+    do jb=js_bk,je_bk ; do Ib=Isq_bk,Ieq_bk
+      intx_pa_bk(Ib,jb) = 0.5*(pa_bk(ib,jb) + pa_bk(ib+1,jb))
+    enddo ; enddo
+    do Jb=Jsq_bk,Jeq_bk ; do ib=is_bk,ie_bk
+      inty_pa_bk(ib,Jb) = 0.5*(pa_bk(ib,jb) + pa_bk(ib,jb+1))
+    enddo ; enddo
 
-    ! Compute pressure gradient in x direction
-    !$OMP parallel do default(shared)
-    do j=js,je ; do I=Isq,Ieq
-      PFu(I,j,k) = (((pa(i,j)*h(i,j,k) + intz_dpa(i,j)) - &
-                   (pa(i+1,j)*h(i+1,j,k) + intz_dpa(i+1,j))) + &
-                   ((h(i+1,j,k) - h(i,j,k)) * intx_pa(I,j) - &
-                   (e(i+1,j,K+1) - e(i,j,K+1)) * intx_dpa(I,j) * GV%m_to_H)) * &
-                   ((2.0*I_Rho0*G%IdxCu(I,j)) / &
-                   ((h(i,j,k) + h(i+1,j,k)) + h_neglect))
-      intx_pa(I,j) = intx_pa(I,j) + intx_dpa(I,j)
-    enddo ; enddo
-    ! Compute pressure gradient in y direction
-    !$OMP parallel do default(shared)
-    do J=Jsq,Jeq ; do i=is,ie
-      PFv(i,J,k) = (((pa(i,j)*h(i,j,k) + intz_dpa(i,j)) - &
-                   (pa(i,j+1)*h(i,j+1,k) + intz_dpa(i,j+1))) + &
-                   ((h(i,j+1,k) - h(i,j,k)) * inty_pa(i,J) - &
-                   (e(i,j+1,K+1) - e(i,j,K+1)) * inty_dpa(i,J) * GV%m_to_H)) * &
-                   ((2.0*I_Rho0*G%IdyCv(i,J)) / &
-                   ((h(i,j,k) + h(i,j+1,k)) + h_neglect))
-      inty_pa(i,J) = inty_pa(i,J) + inty_dpa(i,J)
-    enddo ; enddo
-    !$OMP parallel do default(shared)
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      pa(i,j) = pa(i,j) + dpa(i,j)
-    enddo ; enddo
-  enddo
-
-  if (CS%GFS_scale < 1.0) then
     do k=1,nz
-      !$OMP parallel do default(shared)
-      do j=js,je ; do I=Isq,Ieq
-        PFu(I,j,k) = PFu(I,j,k) - (dM(i+1,j) - dM(i,j)) * G%IdxCu(I,j)
+      ! Calculate 4 integrals through the layer that are required in the
+      ! subsequent calculation.
+
+      if (use_EOS) then
+        ! The following routine computes the integrals that are needed to
+        ! calculate the pressure gradient force. Linear profiles for T and S are
+        ! assumed when regridding is activated. Otherwise, the previous version
+        ! is used, whereby densities within each layer are constant no matter
+        ! where the layers are located.
+        if ( use_ALE ) then
+          if ( PRScheme == PRESSURE_RECONSTRUCTION_PLM ) then
+            call int_density_dz_generic_plm ( T_t(:,:,k), T_b(:,:,k), &
+                      S_t(:,:,k), S_b(:,:,k), e(:,:,K), e(:,:,K+1), &
+                      rho_ref, CS%Rho0, GV%g_Earth,    &
+                      dz_neglect, G%bathyT, G%HI, G%Block(n), &
+                      tv%eqn_of_state, dpa_bk, intz_dpa_bk, intx_dpa_bk, inty_dpa_bk, &
+                      useMassWghtInterp = CS%useMassWghtInterp)
+          elseif ( PRScheme == PRESSURE_RECONSTRUCTION_PPM ) then
+            call int_density_dz_generic_ppm ( tv%T(:,:,k), T_t(:,:,k), T_b(:,:,k), &
+                      tv%S(:,:,k), S_t(:,:,k), S_b(:,:,k), e(:,:,K), e(:,:,K+1), &
+                      rho_ref, CS%Rho0, GV%g_Earth, &
+                      G%HI, G%Block(n), tv%eqn_of_state, dpa_bk, intz_dpa_bk,    &
+                      intx_dpa_bk, inty_dpa_bk)
+          endif
+        else
+          call int_density_dz(tv_tmp%T(:,:,k), tv_tmp%S(:,:,k), &
+                    e(:,:,K), e(:,:,K+1),             &
+                    rho_ref, CS%Rho0, GV%g_Earth, G%HI, G%Block(n), tv%eqn_of_state, &
+                    dpa_bk, intz_dpa_bk, intx_dpa_bk, inty_dpa_bk )
+        endif
+        do jb=Jsq_bk,Jeq_bk+1 ; do ib=Isq_bk,Ieq_bk+1
+          intz_dpa_bk(ib,jb) = intz_dpa_bk(ib,jb)*GV%m_to_H
+        enddo ; enddo
+      else
+        do jb=Jsq_bk,Jeq_bk+1 ; do ib=Isq_bk,Ieq_bk+1
+          i = ib+ioff_bk ; j = jb+joff_bk
+          dz_bk(ib,jb) = GV%g_Earth*GV%H_to_m*h(i,j,k)
+          dpa_bk(ib,jb) = (GV%Rlay(k) - rho_ref)*dz_bk(ib,jb)
+          intz_dpa_bk(ib,jb) = 0.5*(GV%Rlay(k) - rho_ref)*dz_bk(ib,jb)*h(i,j,k)
+        enddo ; enddo
+        do jb=js_bk,je_bk ; do Ib=Isq_bk,Ieq_bk
+          intx_dpa_bk(Ib,jb) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_bk(ib,jb)+dz_bk(ib+1,jb))
+        enddo ; enddo
+        do Jb=Jsq_bk,Jeq_bk ; do ib=is_bk,ie_bk
+          inty_dpa_bk(ib,Jb) = 0.5*(GV%Rlay(k) - rho_ref) * (dz_bk(ib,jb)+dz_bk(ib,jb+1))
+        enddo ; enddo
+      endif
+
+      ! Compute pressure gradient in x direction
+      do jb=js_bk,je_bk ; do Ib=Isq_bk,Ieq_bk
+        I = Ib+ioff_bk ; j = jb+joff_bk
+        PFu(I,j,k) = (((pa_bk(ib,jb)*h(i,j,k) + intz_dpa_bk(ib,jb)) - &
+                     (pa_bk(ib+1,jb)*h(i+1,j,k) + intz_dpa_bk(ib+1,jb))) + &
+                     ((h(i+1,j,k) - h(i,j,k)) * intx_pa_bk(Ib,jb) - &
+                     (e(i+1,j,K+1) - e(i,j,K+1)) * intx_dpa_bk(Ib,jb) * GV%m_to_H)) * &
+                     ((2.0*I_Rho0*G%IdxCu(I,j)) / &
+                     ((h(i,j,k) + h(i+1,j,k)) + h_neglect))
+        intx_pa_bk(Ib,jb) = intx_pa_bk(Ib,jb) + intx_dpa_bk(Ib,jb)
       enddo ; enddo
-      !$OMP parallel do default(shared)
-      do J=Jsq,Jeq ; do i=is,ie
-        PFv(i,J,k) = PFv(i,J,k) - (dM(i,j+1) - dM(i,j)) * G%IdyCv(i,J)
+      ! Compute pressure gradient in y direction
+      do Jb=Jsq_bk,Jeq_bk ; do ib=is_bk,ie_bk
+        i = ib+ioff_bk ; J = Jb+joff_bk
+        PFv(i,J,k) = (((pa_bk(ib,jb)*h(i,j,k) + intz_dpa_bk(ib,jb)) - &
+                     (pa_bk(ib,jb+1)*h(i,j+1,k) + intz_dpa_bk(ib,jb+1))) + &
+                     ((h(i,j+1,k) - h(i,j,k)) * inty_pa_bk(ib,Jb) - &
+                     (e(i,j+1,K+1) - e(i,j,K+1)) * inty_dpa_bk(ib,Jb) * GV%m_to_H)) * &
+                     ((2.0*I_Rho0*G%IdyCv(i,J)) / &
+                     ((h(i,j,k) + h(i,j+1,k)) + h_neglect))
+        inty_pa_bk(ib,Jb) = inty_pa_bk(ib,Jb) + inty_dpa_bk(ib,Jb)
+      enddo ; enddo
+      do jb=Jsq_bk,Jeq_bk+1 ; do ib=Isq_bk,Ieq_bk+1
+        pa_bk(ib,jb) = pa_bk(ib,jb) + dpa_bk(ib,jb)
       enddo ; enddo
     enddo
-  endif
+
+    if (CS%GFS_scale < 1.0) then
+      do k=1,nz
+        do j=js_bk+joff_bk,je_bk+joff_bk ; do I=Isq_bk+ioff_bk,Ieq_bk+ioff_bk
+          PFu(I,j,k) = PFu(I,j,k) - (dM(i+1,j) - dM(i,j)) * G%IdxCu(I,j)
+        enddo ; enddo
+        do J=Jsq_bk+joff_bk,Jeq_bk+joff_bk ; do i=is_bk+ioff_bk,ie_bk+ioff_bk
+          PFv(i,J,k) = PFv(i,J,k) - (dM(i,j+1) - dM(i,j)) * G%IdyCv(i,J)
+        enddo ; enddo
+      enddo
+    endif
+  enddo
 
   if (present(pbce)) then
     call set_pbce_Bouss(e, tv_tmp, G, GV, GV%g_Earth, CS%Rho0, CS%GFS_scale, pbce)
@@ -709,12 +753,12 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
     ! eta is the sea surface height relative to a time-invariant geoid, for
     ! comparison with what is used for eta in btstep.  See how e was calculated
     ! about 200 lines above.
-    !$OMP parallel do default(shared)
+!$OM parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,eta,e,e_tidal)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         eta(i,j) = e(i,j,1)*GV%m_to_H + e_tidal(i,j)*GV%m_to_H
       enddo ; enddo
     else
-    !$OMP parallel do default(shared)
+!$OM parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,eta,e)
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         eta(i,j) = e(i,j,1)*GV%m_to_H
       enddo ; enddo
@@ -723,16 +767,16 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
 
   if (CS%id_e_tidal>0) call post_data(CS%id_e_tidal, e_tidal, CS%diag)
 
-end subroutine PressureForce_AFV_Bouss
+end subroutine PressureForce_blk_AFV_Bouss
 
 !> Initializes the finite volume pressure gradient control structure
-subroutine PressureForce_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
+subroutine PressureForce_blk_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
   type(time_type), target,    intent(in)    :: Time !< Current model time
   type(ocean_grid_type),      intent(in)    :: G  !< Ocean grid structure
   type(verticalGrid_type),    intent(in)    :: GV !< Vertical grid structure
   type(param_file_type),      intent(in)    :: param_file !< Parameter file handles
   type(diag_ctrl), target,    intent(inout) :: diag !< Diagnostics control structure
-  type(PressureForce_AFV_CS), pointer       :: CS !< Finite volume PGF control structure
+  type(PressureForce_blk_AFV_CS), pointer       :: CS !< Finite volume PGF control structure
   type(tidal_forcing_CS), optional, pointer :: tides_CSp !< Tides control structure
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -749,7 +793,7 @@ subroutine PressureForce_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
     if (associated(tides_CSp)) CS%tides_CSp => tides_CSp
   endif
 
-  mdl = "MOM_PressureForce_AFV"
+  mdl = "MOM_PressureForce_blk_AFV"
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
@@ -773,13 +817,13 @@ subroutine PressureForce_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
 
   call log_param(param_file, mdl, "GFS / G_EARTH", CS%GFS_scale)
 
-end subroutine PressureForce_AFV_init
+end subroutine PressureForce_blk_AFV_init
 
 !> Deallocates the finite volume pressure gradient control structure
-subroutine PressureForce_AFV_end(CS)
-  type(PressureForce_AFV_CS), pointer :: CS
+subroutine PressureForce_blk_AFV_end(CS)
+  type(PressureForce_blk_AFV_CS), pointer :: CS
   if (associated(CS)) deallocate(CS)
-end subroutine PressureForce_AFV_end
+end subroutine PressureForce_blk_AFV_end
 
 !> \namespace mom_pressureforce_afv
 !!
@@ -799,4 +843,4 @@ end subroutine PressureForce_AFV_end
 !! ocean models. Ocean Modelling, 8, 279-300.
 !! http://dx.doi.org/10.1016/j.ocemod.2004.01.001
 
-end module MOM_PressureForce_AFV
+end module MOM_PressureForce_blk_AFV

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -314,54 +314,55 @@ subroutine extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt,                   
                   aggregate_FW_forcing, nonpenSW, netmassInOut_rate,net_Heat_Rate,      &
                   net_salt_rate, pen_sw_bnd_Rate, skip_diags)
 
-  type(ocean_grid_type),             intent(in)    :: G                        !< ocean grid structure
-  type(verticalGrid_type),           intent(in)    :: GV                       !< ocean vertical grid structure
-  type(forcing),                     intent(inout) :: fluxes                   !< structure containing pointers to possible
-                                                                               !! forcing fields. NULL unused fields.
-  type(optics_type),                 pointer       :: optics                   !< pointer to optics
-  integer,                           intent(in)    :: nsw                      !< number of bands of penetrating SW
-  integer,                           intent(in)    :: j                        !< j-index to work on
-  real,                              intent(in)    :: dt                       !< time step in seconds
-  real,                              intent(in)    :: DepthBeforeScalingFluxes !< min ocean depth before scale away fluxes (H)
-  logical,                           intent(in)    :: useRiverHeatContent      !< logical for river heat content
-  logical,                           intent(in)    :: useCalvingHeatContent    !< logical for calving heat content
-  real, dimension(SZI_(G),SZK_(G)),  intent(in)    :: h                        !< layer thickness (in H units)
-  real, dimension(SZI_(G),SZK_(G)),  intent(in)    :: T                        !< layer temperatures (deg C)
-  real, dimension(SZI_(G)),          intent(out)   :: netMassInOut             !<  net mass flux (non-Bouss) or volume flux
-                                                                               !! (if Bouss) of water in/out of ocean over
-                                                                               !! a time step (H units)
-  real, dimension(SZI_(G)),          intent(out)   :: netMassOut               !< net mass flux (non-Bouss) or volume flux
-                                                                               !! (if Bouss) of water leaving ocean surface
-                                                                               !! over a time step (H units).
-                                                                               !! netMassOut < 0 means mass leaves ocean.
-  real, dimension(SZI_(G)),          intent(out)   :: net_heat                 !< net heat at the surface accumulated over a
-                                                                               !! time step for coupler + restoring.
-                                                                               !! Exclude two terms from net_heat:
-                                                                               !! (1) downwelling (penetrative) SW,
-                                                                               !! (2) evaporation heat content,
-                                                                               !! (since do not yet know evap temperature).
-                                                                               !! Units of net_heat are (K * H).
-  real, dimension(SZI_(G)),          intent(out)   :: net_salt                 !< surface salt flux into the ocean accumulated
-                                                                               !! over a time step (ppt * H)
-  real, dimension(:,:),              intent(out)   :: pen_SW_bnd               !< penetrating SW flux, split into bands.
-                                                                               !! Units are (deg K * H) and array size
-                                                                               !! nsw x SZI_(G), where nsw=number of SW bands
-                                                                               !! in pen_SW_bnd. This heat flux is not part
-                                                                               !! of net_heat.
-  type(thermo_var_ptrs),             intent(inout) :: tv                       !< structure containing pointers to available
-                                                                               !! thermodynamic fields. Used to keep
-                                                                               !! track of the heat flux associated with net
-                                                                               !! mass fluxes into the ocean.
-  logical,                           intent(in)    :: aggregate_FW_forcing     !< For determining how to aggregate forcing.
-  real, dimension(SZI_(G)), optional, intent(out)  :: nonpenSW                 !< non-downwelling SW; use in net_heat.
-                                                                               !! Sum over SW bands when diagnosing nonpenSW.
-                                                                               !! Units are (K * H).
-  real, dimension(SZI_(G)), optional, intent(out) :: net_Heat_rate             !< Optional outputs of contributions to surface
-  real, dimension(SZI_(G)), optional, intent(out) :: net_salt_rate             !<  buoyancy flux which do not include dt
-  real, dimension(SZI_(G)), optional, intent(out) :: netmassInOut_rate         !<  and therefore are used to compute the rate.
-  real, dimension(:,:), optional, intent(out)     :: pen_sw_bnd_rate           !<  Perhaps just a temporary fix.
-  logical, optional,                 intent(in)    :: skip_diags               !< If present and true, skip calculating
-                                                                               !! diagnostics
+  type(ocean_grid_type),    intent(in)    :: G                        !< ocean grid structure
+  type(verticalGrid_type),  intent(in)    :: GV                       !< ocean vertical grid structure
+  type(forcing),            intent(inout) :: fluxes                   !< structure containing pointers to possible
+                                                                      !! forcing fields. NULL unused fields.
+  type(optics_type),        pointer       :: optics                   !< pointer to optics
+  integer,                  intent(in)    :: nsw                      !< number of bands of penetrating SW
+  integer,                  intent(in)    :: j                        !< j-index to work on
+  real,                     intent(in)    :: dt                       !< time step in seconds
+  real,                     intent(in)    :: DepthBeforeScalingFluxes !< min ocean depth before scale away fluxes (H)
+  logical,                  intent(in)    :: useRiverHeatContent      !< logical for river heat content
+  logical,                  intent(in)    :: useCalvingHeatContent    !< logical for calving heat content
+  real, dimension(SZI_(G),SZK_(G)), &
+                            intent(in)    :: h                        !< layer thickness (in H units)
+  real, dimension(SZI_(G),SZK_(G)), &
+                            intent(in)    :: T                        !< layer temperatures (deg C)
+  real, dimension(SZI_(G)), intent(out)   :: netMassInOut             !< net mass flux (non-Bouss) or volume flux
+                                                                      !! (if Bouss) of water in/out of ocean over
+                                                                      !! a time step (H units)
+  real, dimension(SZI_(G)), intent(out)   :: netMassOut               !< net mass flux (non-Bouss) or volume flux
+                                                                      !! (if Bouss) of water leaving ocean surface
+                                                                      !! over a time step (H units).
+                                                                      !! netMassOut < 0 means mass leaves ocean.
+  real, dimension(SZI_(G)), intent(out)   :: net_heat                 !< net heat at the surface accumulated over a
+                                                                      !! time step for coupler + restoring.
+                                                                      !! Exclude two terms from net_heat:
+                                                                      !! (1) downwelling (penetrative) SW,
+                                                                      !! (2) evaporation heat content,
+                                                                      !! (since do not yet know evap temperature).
+                                                                      !! Units of net_heat are (K * H).
+  real, dimension(SZI_(G)), intent(out)   :: net_salt                 !< surface salt flux into the ocean accumulated
+                                                                      !! over a time step (ppt * H)
+  real, dimension(:,:),     intent(out)   :: pen_SW_bnd               !< penetrating SW flux, split into bands.
+                                                                      !! Units are (deg K * H) and array size
+                                                                      !! nsw x SZI_(G), where nsw=number of SW bands
+                                                                      !! in pen_SW_bnd. This heat flux is not part
+                                                                      !! of net_heat.
+  type(thermo_var_ptrs),    intent(inout) :: tv                       !< structure containing pointers to available
+                                                                      !! thermodynamic fields. Used to keep
+                                                                      !! track of the heat flux associated with net
+                                                                      !! mass fluxes into the ocean.
+  logical,                  intent(in)    :: aggregate_FW_forcing     !< For determining how to aggregate forcing.
+  real, dimension(SZI_(G)), optional, intent(out)  :: nonpenSW        !< non-downwelling SW; use in net_heat.
+                                                                      !! Sum over SW bands when diagnosing nonpenSW.
+                                                                      !! Units are (K * H).
+  real, dimension(SZI_(G)), optional, intent(out)  :: net_Heat_rate   !< Rate of net surface heating in H K s-1.
+  real, dimension(SZI_(G)), optional, intent(out)  :: net_salt_rate   !< Surface salt flux into the ocean in ppt H s-1.
+  real, dimension(SZI_(G)), optional, intent(out)  :: netmassInOut_rate !< Rate of net mass flux into the ocean in H s-1.
+  real, dimension(:,:),     optional, intent(out)  :: pen_sw_bnd_rate !< Rate of penetrative shortwave heating in degC H s-1.
+  logical,                  optional, intent(in)   :: skip_diags      !< If present and true, skip calculating diagnostics
 
   ! local
   real :: htot(SZI_(G))       ! total ocean depth (m for Bouss or kg/m^2 for non-Bouss)
@@ -451,9 +452,7 @@ subroutine extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt,                   
       Pen_SW_bnd(1,i) = 0.0
     endif
 
-    !BGR-Jul 5, 2017{
-    !Repeats above code w/ dt=1. for legacy reason
-    if (do_PSWBR) then
+    if (do_PSWBR) then  ! Repeat the above code w/ dt=1s for legacy reasons
       pen_sw_tot_rate(i) = 0.0
       if (nsw >= 1) then
         do n=1,nsw
@@ -464,7 +463,6 @@ subroutine extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt,                   
         pen_sw_bnd_rate(1,i) = 0.0
       endif
     endif
-    !}BGR
 
     ! net volume/mass of liquid and solid passing through surface boundary fluxes
     netMassInOut(i) = dt * (scale * ((((( fluxes%lprec(i,j)      &
@@ -474,9 +472,7 @@ subroutine extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt,                   
                                         + fluxes%vprec(i,j)   )  &
                                         + fluxes%frunoff(i,j) ) )
 
-    !BGR-Jul 5, 2017{
-    !Repeats above code w/ dt=1. for legacy reason
-    if (do_NMIOr) then
+    if (do_NMIOr) then  ! Repeat the above code w/ dt=1s for legacy reasons
       netMassInOut_rate(i) = (scale * ((((( fluxes%lprec(i,j)      &
                                         + fluxes%fprec(i,j)   )  &
                                         + fluxes%evap(i,j)    )  &
@@ -484,19 +480,15 @@ subroutine extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt,                   
                                         + fluxes%vprec(i,j)   )  &
                                         + fluxes%frunoff(i,j) ) )
     endif
-    !}BGR
 
     ! smg:
     ! for non-Bouss, we add/remove salt mass to total ocean mass. to conserve
-    ! total salt mass ocean+ice, the sea ice model must lose mass when
-    ! salt mass is added to the ocean, which may still need to be coded.
+    ! total salt mass ocean+ice, the sea ice model must lose mass when salt mass
+    ! is added to the ocean, which may still need to be coded.  Not that the units
+    ! of netMassInOut are still kg_m2, so no conversion to H should occur yet.
     if (.not.GV%Boussinesq .and. ASSOCIATED(fluxes%salt_flux)) then
-      netMassInOut(i) = netMassInOut(i) + (dt * GV%kg_m2_to_H) * (scale * fluxes%salt_flux(i,j))
-
-      !BGR-Jul 5, 2017{
-      !Repeats above code w/ dt=1. for legacy reason
-      if (do_NMIOr) netMassInOut_rate(i) = netMassInOut_rate(i) + (GV%kg_m2_to_H) * (scale * fluxes%salt_flux(i,j))
-      !}BGR
+      netMassInOut(i) = netMassInOut(i) + dt * (scale * fluxes%salt_flux(i,j))
+      if (do_NMIOr) netMassInOut_rate(i) = netMassInOut_rate(i) + (scale * fluxes%salt_flux(i,j))
     endif
 
     ! net volume/mass of water leaving the ocean.
@@ -526,21 +518,16 @@ subroutine extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt,                   
 
     ! convert to H units (Bouss=meter or non-Bouss=kg/m^2)
     netMassInOut(i) = GV%kg_m2_to_H * netMassInOut(i)
-    !BGR-Jul 5, 2017{
-    !Repeats above code w/ dt=1. for legacy reason
     if (do_NMIOr) netMassInOut_rate(i) = GV%kg_m2_to_H * netMassInOut_rate(i)
-    !}BGR
     netMassOut(i)   = GV%kg_m2_to_H * netMassOut(i)
 
     ! surface heat fluxes from radiation and turbulent fluxes (K * H)
     ! (H=m for Bouss, H=kg/m2 for non-Bouss)
     net_heat(i) = scale * dt * J_m2_to_H * &
                   ( fluxes%sw(i,j) +  ((fluxes%lw(i,j) + fluxes%latent(i,j)) + fluxes%sens(i,j)) )
-    !BGR-Jul 5, 2017{
     !Repeats above code w/ dt=1. for legacy reason
     if (do_NHR)  net_heat_rate(i) = scale * J_m2_to_H * &
          ( fluxes%sw(i,j) +  ((fluxes%lw(i,j) + fluxes%latent(i,j)) + fluxes%sens(i,j)) )
-    !}BGR
     ! Add heat flux from surface damping (restoring) (K * H) or flux adjustments.
     if (ASSOCIATED(fluxes%heat_added)) then
        net_heat(i) = net_heat(i) + (scale * (dt * J_m2_to_H)) * fluxes%heat_added(i,j)
@@ -612,10 +599,8 @@ subroutine extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt,                   
     ! remove penetrative portion of the SW that is NOT absorbed within a
     ! tiny layer at the top of the ocean.
     net_heat(i) = net_heat(i) - Pen_SW_tot(i)
-    !BGR-Jul 5, 2017{
     !Repeat above code for 'rate' term
     if (do_NHR) net_heat_rate(i) = net_heat_rate(i) - Pen_SW_tot_rate(i)
-    !}BGR
 
     ! diagnose non-downwelling SW
     if (present(nonPenSW)) then
@@ -630,10 +615,8 @@ subroutine extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt,                   
     ! non-Bouss:  (g/m^2)
     if (ASSOCIATED(fluxes%salt_flux)) then
       Net_salt(i) = (scale * dt * (1000.0 * fluxes%salt_flux(i,j))) * GV%kg_m2_to_H
-      !BGR-Jul 5, 2017{
       !Repeat above code for 'rate' term
       if (do_NSR) Net_salt_rate(i) = (scale * 1. * (1000.0 * fluxes%salt_flux(i,j))) * GV%kg_m2_to_H
-      !}BGR
     endif
 
     ! Diagnostics follow...


### PR DESCRIPTION
Enhanced the abilities related to the pressure gradient force calculation in non-Boussinesq mode so they are commensurate with what was previous available in Boussinesq configurations, especially when run in ALE mode.  With this change, ALE-based Boussinesq and non-Boussinesq simulations appear to have very similar stability characteristics in simulations of up to a few months.