### PR TITLE
Enhance Pressure Gradient Force (3)

### DIFF
--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -937,11 +937,10 @@ subroutine int_density_dz_generic(T, S, z_t, z_b, rho_ref, rho_0, G_e, HII, HIO,
       T5(n) = T(i,j) ; S5(n) = S(i,j)
       p5(n) = -GxRho*(z_t(i,j) - 0.25*real(n-1)*dz)
     enddo
-    call calculate_density(T5, S5, p5, r5, 1, 5, EOS) !, rho_ref)
+    call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref)
 
     ! Use Bode's rule to estimate the pressure anomaly change.
-    rho_anom = C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)) - &
-               rho_ref
+    rho_anom = C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3))
     dpa(i-ioff,j-joff) = G_e*dz*rho_anom
     ! Use a Bode's-rule-like fifth-order accurate estimate of the double integral of
     ! the pressure anomaly.
@@ -980,11 +979,10 @@ subroutine int_density_dz_generic(T, S, z_t, z_b, rho_ref, rho_0, G_e, HII, HIO,
       do n=2,5
         T5(n) = T5(1) ; S5(n) = S5(1) ; p5(n) = p5(n-1) + GxRho*0.25*dz
       enddo
-      call calculate_density(T5, S5, p5, r5, 1, 5, EOS) !, rho_ref)
+      call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref)
 
     ! Use Bode's rule to estimate the pressure anomaly change.
-      intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + &
-                                12.0*r5(3)) - rho_ref)
+      intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)))
     enddo
     ! Use Bode's rule to integrate the bottom pressure anomaly values in x.
     intx_dpa(i-ioff,j-joff) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + &
@@ -1023,11 +1021,10 @@ subroutine int_density_dz_generic(T, S, z_t, z_b, rho_ref, rho_0, G_e, HII, HIO,
         T5(n) = T5(1) ; S5(n) = S5(1)
         p5(n) = p5(n-1) + GxRho*0.25*dz
       enddo
-      call calculate_density(T5, S5, p5, r5, 1, 5, EOS) !, rho_ref)
+      call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref)
 
     ! Use Bode's rule to estimate the pressure anomaly change.
-      intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + &
-                                12.0*r5(3)) - rho_ref)
+      intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)))
     enddo
     ! Use Bode's rule to integrate the values.
     inty_dpa(i-ioff,j-joff) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + &
@@ -1113,7 +1110,6 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
   real :: S5((5*HIO%iscB+1):(5*(HIO%iecB+2)))
   real :: p5((5*HIO%iscB+1):(5*(HIO%iecB+2)))
   real :: r5((5*HIO%iscB+1):(5*(HIO%iecB+2)))
-  real :: u5((5*HIO%iscB+1):(5*(HIO%iecB+2)))
   real :: T15((15*HIO%iscB+1):(15*(HIO%iecB+1)))
   real :: S15((15*HIO%iscB+1):(15*(HIO%iecB+1)))
   real :: p15((15*HIO%iscB+1):(15*(HIO%iecB+1)))
@@ -1161,19 +1157,17 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
         T5(i*5+n) = wt_t(n) * T_t(iin,jin) + wt_b(n) * T_b(iin,jin)
       enddo
     enddo
-    call calculate_density_array(T5, S5, p5, r5, 1, (ieq-isq+2)*5, EOS) !, rho_ref )
-    u5 = r5 - rho_ref
+    call calculate_density_array(T5, S5, p5, r5, 1, (ieq-isq+2)*5, EOS, rho_ref )
 
     do i=isq,ieq+1 ; iin = i+ioff
     ! Use Bode's rule to estimate the pressure anomaly change.
-      rho_anom = C1_90*(7.0*(r5(i*5+1)+r5(i*5+5)) + 32.0*(r5(i*5+2)+r5(i*5+4)) + 12.0*r5(i*5+3)) - &
-           rho_ref
+      rho_anom = C1_90*(7.0*(r5(i*5+1)+r5(i*5+5)) + 32.0*(r5(i*5+2)+r5(i*5+4)) + 12.0*r5(i*5+3))
       dpa(i,j) = G_e*dz(i)*rho_anom
       if (present(intz_dpa)) then
       ! Use a Bode's-rule-like fifth-order accurate estimate of
       ! the double integral of the pressure anomaly.
         intz_dpa(i,j) = 0.5*G_e*dz(i)**2 * &
-                (rho_anom - C1_90*(16.0*(u5(i*5+4)-u5(i*5+2)) + 7.0*(u5(i*5+5)-u5(i*5+1))) )
+                (rho_anom - C1_90*(16.0*(r5(i*5+4)-r5(i*5+2)) + 7.0*(r5(i*5+5)-r5(i*5+1))) )
       endif
     enddo
   enddo ! end loops on j
@@ -1243,7 +1237,7 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
       enddo
     enddo
 
-    call calculate_density(T15, S15, p15, r15, 1, 15*(ieq-isq+1), EOS) !, rho_ref)
+    call calculate_density(T15, S15, p15, r15, 1, 15*(ieq-isq+1), EOS, rho_ref)
 
     do I=Isq,Ieq ; iin = i+ioff
       intz(1) = dpa(i,j) ; intz(5) = dpa(i+1,j)
@@ -1252,7 +1246,7 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
       do m = 2,4
         pos = i*15+(m-2)*5
         intz(m) = G_e*dz_x(m,i)*( C1_90*(7.0*(r15(pos+1)+r15(pos+5)) + 32.0*(r15(pos+2)+r15(pos+4)) + &
-                          12.0*r15(pos+3)) - rho_ref)
+                          12.0*r15(pos+3)))
       enddo
       ! Use Bode's rule to integrate the bottom pressure anomaly values in x.
       intx_dpa(i,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + &
@@ -1323,7 +1317,7 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
     enddo
 
     call calculate_density_array(T15(15*HIO%isc+1:), S15(15*HIO%isc+1:), p15(15*HIO%isc+1:), &
-                                 r15(15*HIO%isc+1:), 1, 15*(HIO%iec-HIO%isc+1), EOS) !, rho_ref)
+                                 r15(15*HIO%isc+1:), 1, 15*(HIO%iec-HIO%isc+1), EOS, rho_ref)
     do i=HIO%isc,HIO%iec ; iin = i+ioff
       intz(1) = dpa(i,j) ; intz(5) = dpa(i,j+1)
 
@@ -1332,7 +1326,7 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
         pos = i*15+(m-2)*5
         intz(m) = G_e*dz_y(m,i)*( C1_90*(7.0*(r15(pos+1)+r15(pos+5)) + &
                                          32.0*(r15(pos+2)+r15(pos+4)) + &
-                                         12.0*r15(pos+3)) - rho_ref)
+                                         12.0*r15(pos+3)))
       enddo
       ! Use Bode's rule to integrate the values.
       inty_dpa(i,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + &

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -100,28 +100,27 @@ subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_
 
   ! Original coded by R. Hallberg, 7/00, anomaly coded in 3/18.
   real :: al0, p0, lambda
-  real :: al_TS, p_TSp, lam_TS
+  real :: al_TS, p_TSp, lam_TS, pa_000
   integer :: j
 
-  do j=start,start+npts-1
-    if (present(rho_ref)) then
-      al_TS = a1*T(j) +a2*S(j)
-      al0 = a0 + al_TS
-      p_TSp = pressure(j) + (b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))))
-      lam_TS = c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j)))
+  if (present(rho_ref)) pa_000 = (b0*(1.0 - a0*rho_ref) - rho_ref*c0)
+  if (present(rho_ref)) then ; do j=start,start+npts-1
+    al_TS = a1*T(j) +a2*S(j)
+    al0 = a0 + al_TS
+    p_TSp = pressure(j) + (b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))))
+    lam_TS = c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j)))
 
-      ! The following two expressions are mathematically equivalent.
-      ! rho(j) = (b0 + p0_TSp) / ((c0 + lam_TS) + al0*(b0 + p0_TSp)) - rho_ref
-      rho(j) = ( (b0*(1.0 - a0*rho_ref) - rho_ref*c0) + &
-                 (p_TSp - rho_ref * (p_TSp*al0 + (b0*al_TS + lam_TS))) ) / &
-               ( (c0 + lam_TS) + al0*(b0 + p_TSp) )
-    else
-      al0 = (a0 + a1*T(j)) +a2*S(j)
-      p0 = (b0 + b4*S(j)) + T(j) * (b1 + T(j)*(b2 + b3*T(j)) + b5*S(j))
-      lambda = (c0 +c4*S(j)) + T(j) * (c1 + T(j)*(c2 + c3*T(j)) + c5*S(j))
-      rho(j) = (pressure(j) + p0) / (lambda + al0*(pressure(j) + p0))
-    endif
-  enddo
+    ! The following two expressions are mathematically equivalent.
+    ! rho(j) = (b0 + p0_TSp) / ((c0 + lam_TS) + al0*(b0 + p0_TSp)) - rho_ref
+    rho(j) = (pa_000 + (p_TSp - rho_ref*(p_TSp*al0 + (b0*al_TS + lam_TS)))) / &
+             ( (c0 + lam_TS) + al0*(b0 + p_TSp) )
+  enddo ; else ; do j=start,start+npts-1
+    al0 = (a0 + a1*T(j)) +a2*S(j)
+    p0 = (b0 + b4*S(j)) + T(j) * (b1 + T(j)*(b2 + b3*T(j)) + b5*S(j))
+    lambda = (c0 +c4*S(j)) + T(j) * (c1 + T(j)*(c2 + c3*T(j)) + c5*S(j))
+    rho(j) = (pressure(j) + p0) / (lambda + al0*(pressure(j) + p0))
+  enddo ; endif
+
 end subroutine calculate_density_array_wright
 
 !> This subroutine computes the in situ specific volume of sea water (specvol in


### PR DESCRIPTION
MOM6: *Use rho_ref in finite volume PGF density calcs

  Use the new rho_ref argument in all of the calls to density in the finite
volume pressure gradient integrals.  This makes the solutions more accurate, but
it does change the solutions in numerous test cases.  New reference solutions
have been checked in for the MOM6_examples test cases at GFDL.
Commit: NOAA-GFDL/MOM6@48e90d0 *Use rho_ref in finite volume PGF density calcs
