### PR TITLE
Bug fix for the loop extents that cause NaNs

### DIFF
--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -519,8 +519,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, CS, hu, hv)
 
     ! Calculate viscosity for the main model to use
     if (CS%viscosity_coeff/=0.) then
-!aja: should make range jsq:jeq, isq:ieq
-      do j=js-1,je+1 ; do i=is-1,ie+1
+      do j=js,je ; do i=is,ie
         MEKE%Ku(i,j) = CS%viscosity_coeff*sqrt(2.*max(0.,MEKE%MEKE(i,j)))*LmixScale(i,j)
       enddo ; enddo
       call cpu_clock_begin(CS%id_clock_pass)


### PR DESCRIPTION
- Closes issue #734 and hopefully issue #262
- MEKE%Ku array is allocated on data domain and has a mpp_domain_update
  following the loop so it needs to be calculated only on compute domain
- The problem with larger extents of the loops is Lmixscale array is
  initialized/calculate on compute domain and is NaN beyond compute domain
  extents, causing NaN's to lurk into MEKE%Ku and the model.

-No answer changes