### PR TITLE
+Log debugging params to MOM_param_doc.debugging

### DIFF
--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -408,7 +408,8 @@ program MOM_main
                  "the segment run-length can not be set via an elapsed CPU time.", &
                  default=1000)
   call get_param(param_file, "MOM", "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
 
   call log_param(param_file, mod_name, "ELAPSED TIME AS MASTER", elapsed_time_master)
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1527,10 +1527,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "Integer controlling level of messaging\n" // &
                  "\t0 = Only FATAL messages\n" // &
                  "\t2 = Only FATAL, WARNING, NOTE [default]\n" // &
-                 "\t9 = All)", default=2)
+                 "\t9 = All)", default=2, debuggingParam=.true.)
   call get_param(param_file, "MOM", "DO_UNIT_TESTS", do_unit_tests, &
                  "If True, exercises unit tests at model start up.", &
-                 default=.false.)
+                 default=.false., debuggingParam=.true.)
   if (do_unit_tests) then
     call unit_tests(verbosity)
   endif
@@ -1626,10 +1626,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  default=.false.)
 
   call get_param(param_file, "MOM", "DEBUG", CS%debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, "MOM", "DEBUG_TRUNCATIONS", debug_truncations, &
                  "If true, calculate all diagnostics that are useful for \n"//&
-                 "debugging truncations.", default=.false.)
+                 "debugging truncations.", default=.false., debuggingParam=.true.)
 
   call get_param(param_file, "MOM", "DT", CS%dt, &
                  "The (baroclinic) dynamics time step.  The time-step that \n"//&

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4065,11 +4065,13 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
                  units="m", default=min(10.0,0.05*G%max_depth))
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_BT", CS%debug_bt, &
                  "If true, write out verbose debugging data within the \n"//&
                  "barotropic time-stepping loop. The data volume can be \n"//&
-                 "quite large if this is true.", default=CS%debug)
+                 "quite large if this is true.", default=CS%debug, &
+                 debuggingParam=.true.)
 
   CS%linearized_BT_PV = .true.
   call get_param(param_file, mdl, "BEBT", CS%bebt, &

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -994,7 +994,8 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
                  "adjustment due to the change in the barotropic velocity \n"//&
                  "in the barotropic continuity equation.", default=.true.)
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_OBC", CS%debug_OBC, default=.false.)
   call get_param(param_file, mdl, "DEBUG_TRUNCATIONS", debug_truncations, &
                  default=.false.)

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -681,7 +681,8 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, param_file, diag, CS, &
   CS%diag => diag
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "TIDES", use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
 

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -644,7 +644,8 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, param_file, diag, CS
                  "between 0 and 0.5 to damp gravity waves.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "TIDES", use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -320,16 +320,17 @@ subroutine open_boundary_config(G, param_file, OBC)
     if (debug_OBC .or. debug) &
       call log_param(param_file, mdl, "DEBUG_OBC", debug_OBC, &
                  "If true, do additional calls to help debug the performance \n"//&
-                 "of the open boundary condition code.", default=.false.)
+                 "of the open boundary condition code.", default=.false., &
+                 debuggingParam=.true.)
 
     call get_param(param_file, mdl, "OBC_SILLY_THICK", OBC%silly_h, &
                  "A silly value of thicknesses used outside of open boundary \n"//&
                  "conditions for debugging.", units="m", default=0.0, &
-                 do_not_log=.not.debug_OBC)
+                 do_not_log=.not.debug_OBC, debuggingParam=.true.)
     call get_param(param_file, mdl, "OBC_SILLY_VEL", OBC%silly_u, &
                  "A silly value of velocities used outside of open boundary \n"//&
                  "conditions for debugging.", units="m/s", default=0.0, &
-                 do_not_log=.not.debug_OBC)
+                 do_not_log=.not.debug_OBC, debuggingParam=.true.)
 
     ! Allocate everything
     ! Note the 0-segment is needed when %segnum_u/v(:,:) = 0

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -830,15 +830,15 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
                  "The absolute path to the file where the accelerations \n"//&
                  "leading to zonal velocity truncations are written. \n"//&
                  "Leave this empty for efficiency if this diagnostic is \n"//&
-                 "not needed.", default="")
+                 "not needed.", default="", debuggingParam=.true.)
   call get_param(param_file, mdl, "V_TRUNC_FILE", CS%v_trunc_file, &
                  "The absolute path to the file where the accelerations \n"//&
                  "leading to meridional velocity truncations are written. \n"//&
                  "Leave this empty for efficiency if this diagnostic is \n"//&
-                 "not needed.", default="")
+                 "not needed.", default="", debuggingParam=.true.)
   call get_param(param_file, mdl, "MAX_TRUNC_FILE_SIZE_PER_PE", CS%max_writes, &
                  "The maximum number of colums of truncations that any PE \n"//&
-                 "will write out during a run.", default=50)
+                 "will write out during a run.", default=50, debuggingParam=.true.)
 
   if (len_trim(dirs%output_directory) > 0) then
     if (len_trim(CS%u_trunc_file) > 0) &

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -79,13 +79,16 @@ subroutine MOM_debugging_init(param_file)
 
   call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_CHKSUMS", debug_chksums, &
                  "If true, checksums are performed on arrays in the \n"//&
-                 "various vec_chksum routines.", default=debug)
+                 "various vec_chksum routines.", default=debug, &
+                 debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_REDUNDANT", debug_redundant, &
                  "If true, debug redundant data points during calls to \n"//&
-                 "the various vec_chksum routines.", default=debug)
+                 "the various vec_chksum routines.", default=debug, &
+                 debuggingParam=.true.)
 
   call MOM_checksums_init(param_file)
 

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -276,18 +276,17 @@ subroutine close_param_file(CS, quiet_close, component)
   ! Log the parameters for the parser.
   mdl = "MOM_file_parser"
   call log_version(CS, mdl, version, "")
-  call log_param(CS, mdl, "SEND_LOG_TO_STDOUT", &
-                        CS%log_to_stdout, &
+  call log_param(CS, mdl, "SEND_LOG_TO_STDOUT", CS%log_to_stdout, &
                  "If true, all log messages are also sent to stdout.", &
                  default=log_to_stdout_default)
-  call log_param(CS, mdl, "REPORT_UNUSED_PARAMS", &
-                        CS%report_unused, &
+  call log_param(CS, mdl, "REPORT_UNUSED_PARAMS", CS%report_unused, &
                  "If true, report any parameter lines that are not used \n"//&
-                 "in the run.", default=report_unused_default)
-  call log_param(CS, mdl, "FATAL_UNUSED_PARAMS", &
-                        CS%unused_params_fatal, &
+                 "in the run.", default=report_unused_default, &
+                 debuggingParam=.true.)
+  call log_param(CS, mdl, "FATAL_UNUSED_PARAMS", CS%unused_params_fatal, &
                  "If true, kill the run if there are any unused \n"//&
-                 "parameters.", default=unused_params_fatal_default)
+                 "parameters.", default=unused_params_fatal_default, &
+                 debuggingParam=.true.)
   docfile_default = "MOM_parameter_doc"
   if (present(component)) docfile_default = trim(component)//"_parameter_doc"
   call log_param(CS, mdl, "DOCUMENT_FILE", CS%doc_file, &
@@ -295,13 +294,11 @@ subroutine close_param_file(CS, quiet_close, component)
                  "settings, units and defaults are documented. Blank will\n"//&
                  "disable all parameter documentation.", default=docfile_default)
   if (len_trim(CS%doc_file) > 0) then
-    call log_param(CS, mdl, "COMPLETE_DOCUMENTATION", &
-                   CS%complete_doc, &
+    call log_param(CS, mdl, "COMPLETE_DOCUMENTATION",  CS%complete_doc, &
                   "If true, all run-time parameters are\n"//&
                   "documented in "//trim(CS%doc_file)//&
                   ".all .", default=complete_doc_default)
-    call log_param(CS, mdl, "MINIMAL_DOCUMENTATION", &
-                   CS%minimal_doc, &
+    call log_param(CS, mdl, "MINIMAL_DOCUMENTATION", CS%minimal_doc, &
                   "If true, non-default run-time parameters are\n"//&
                   "documented in "//trim(CS%doc_file)//&
                   ".short .", default=minimal_doc_default)
@@ -1586,7 +1583,8 @@ subroutine get_param_int_array(CS, modulename, varname, value, desc, units, &
 end subroutine get_param_int_array
 
 subroutine get_param_real(CS, modulename, varname, value, desc, units, &
-               default, fail_if_missing, do_not_read, do_not_log, static_value)
+               default, fail_if_missing, do_not_read, do_not_log, &
+               static_value, debuggingParam)
   type(param_file_type),      intent(in)    :: CS
   character(len=*),           intent(in)    :: modulename
   character(len=*),           intent(in)    :: varname
@@ -1595,6 +1593,7 @@ subroutine get_param_real(CS, modulename, varname, value, desc, units, &
   real,             optional, intent(in)    :: default, static_value
   logical,          optional, intent(in)    :: fail_if_missing
   logical,          optional, intent(in)    :: do_not_read, do_not_log
+  logical,          optional, intent(in)    :: debuggingParam
 ! This subroutine writes the value of a real parameter to a log file,
 ! along with its name and the module it came from.
   logical :: do_read, do_log
@@ -1610,7 +1609,7 @@ subroutine get_param_real(CS, modulename, varname, value, desc, units, &
 
   if (do_log) then
     call log_param_real(CS, modulename, varname, value, desc, units, &
-                        default)
+                        default, debuggingParam)
   endif
 
 end subroutine get_param_real

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -119,7 +119,8 @@ subroutine set_grid_metrics(G, param_file)
                  " \t mercator - use a Mercator spherical grid.", &
                  fail_if_missing=.true.)
   call get_param(param_file, "MOM_grid_init", "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
 
   ! These are defaults that may be changed in the next select block.
   G%x_axis_units = "degrees_east" ; G%y_axis_units = "degrees_north"

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1759,7 +1759,8 @@ subroutine thickness_diffuse_init(Time, G, GV, param_file, diag, CDp, CS)
                  default=7.2921e-5, do_not_log=.not.CS%use_FGNV_streamfn)
   if (CS%use_FGNV_streamfn) CS%N2_floor = (strat_floor*omega)**2
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
 
 
   if (GV%Boussinesq) then ; flux_to_kg_per_s = GV%Rho0

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1972,9 +1972,11 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
                  default=.true.)
 
   call get_param(param_file, mod, "DEBUG", CS%debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mod, "DEBUG_CONSERVATION", CS%debugConservation, &
-                 "If true, monitor conservation and extrema.", default=.false.)
+                 "If true, monitor conservation and extrema.", &
+                 default=.false., debuggingParam=.true.)
 
   call get_param(param_file, mod, "DEBUG_ENERGY_REQ", CS%debug_energy_req, &
                  "If true, debug the energy requirements.", default=.false., do_not_log=.true.)

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -1839,7 +1839,8 @@ logical function kappa_shear_init(Time, G, GV, param_file, diag, CS)
   call get_param(param_file, mdl, "DEBUG_KAPPA_SHEAR", CS%debug, &
                  "If true, write debugging data for the kappa-shear code. \n"//&
                  "Caution: this option is _very_ verbose and should only \n"//&
-                 "be used in single-column mode!", default=.false.)
+                 "be used in single-column mode!", &
+                 default=.false., debuggingParam=.true.)
 
 !    id_clock_KQ = cpu_clock_id('Ocean KS kappa_shear',grain=CLOCK_ROUTINE)
 !    id_clock_avg = cpu_clock_id('Ocean KS avg',grain=CLOCK_ROUTINE)

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -2821,7 +2821,8 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
                  "mixed layer is not used.", units="m", fail_if_missing=.true.)
   endif
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
 
   call get_param(param_file, mdl, "INT_TIDE_DISSIPATION", CS%Int_tide_dissipation, &
                  "If true, use an internal tidal dissipation scheme to \n"//&

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1532,12 +1532,12 @@ subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
                  "The absolute path to a file into which the accelerations \n"//&
                  "leading to zonal velocity truncations are written.  \n"//&
                  "Undefine this for efficiency if this diagnostic is not \n"//&
-                 "needed.", default=" ")
+                 "needed.", default=" ", debuggingParam=.true.)
   call get_param(param_file, mdl, "V_TRUNC_FILE", CS%v_trunc_file, &
                  "The absolute path to a file into which the accelerations \n"//&
                  "leading to meridional velocity truncations are written. \n"//&
                  "Undefine this for efficiency if this diagnostic is not \n"//&
-                 "needed.", default=" ")
+                 "needed.", default=" ", debuggingParam=.true.)
   call get_param(param_file, mdl, "HARMONIC_VISC", CS%harmonic_visc, &
                  "If true, use the harmonic mean thicknesses for \n"//&
                  "calculating the vertical viscosity.", default=.false.)


### PR DESCRIPTION
  Moved the logging of runtime parameters used only for debugging into
MOM_parameter_doc.debugging, by adding the debuggingParam flag to their
get_param calls.  This is only applied to parameters whose values do not alter
the solutions, if the model is working properly, so the MOM_parameter_doc.all or
MOM_parameter_doc.short are still sufficient to exactly reproduce a simulation.
Also added the missing debuggingParam argument to get_param_real. All answers
are bitwise identical, but the MOM_parameter_doc and SIS_parameter_doc files
change in MOM6_examples.