### PR TITLE
+Added run time parameter MAX_TR_DIFFUSION_CFL

### DIFF
--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -42,14 +42,17 @@ type, public :: tracer_hor_diff_CS ; private
                                   ! where passivity is the ratio between along-isopycnal
                                   ! tracer mixing and thickness mixing
   real    :: KhTr_passivity_min   ! Passivity minimum (default = 1/2)
-  real    :: ML_KhTR_scale  ! With Diffuse_ML_interior, the ratio of the truly
-                            ! horizontal diffusivity in the mixed layer to the
-                            ! epipycnal diffusivity.  Nondim.
+  real    :: ML_KhTR_scale        ! With Diffuse_ML_interior, the ratio of the
+                                  ! truly horizontal diffusivity in the mixed
+                                  ! layer to the epipycnal diffusivity.  Nondim.
+  real    :: max_diff_CFL         ! If positive, locally limit the along-isopycnal
+                                  ! tracer diffusivity to keep the diffusive CFL
+                                  ! locally at or below this value. Nondim.
   logical :: Diffuse_ML_interior  ! If true, diffuse along isopycnals between
                                   ! the mixed layer and the interior.
   logical :: check_diffusive_CFL  ! If true, automatically iterate the diffusion
-                                  ! to ensure that the diffusive equivalent of the CFL
-                                  ! limit is not violated.
+                                  ! to ensure that the diffusive equivalent of
+                                  ! the CFL limit is not violated.
   logical :: use_neutral_diffusion ! If true, use the neutral_diffusion module from within
                                    ! tracer_hor_diff.
   type(neutral_diffusion_CS), pointer :: neutral_diffusion_CSp => NULL() ! Control structure for neutral diffusion.
@@ -125,6 +128,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, CS, Reg, tv, do_online_fla
                   ! to time-integrated fluxes, in m3 or kg.
     Kh_v          ! Tracer mixing coefficient at u-points, in m2 s-1.
 
+  real :: khdt_max ! The local limiting value of khdt_x or khdt_y, in m2.
   real :: max_CFL ! The global maximum of the diffusive CFL number.
   logical :: use_VarMix, Resoln_scaled, do_online, use_Eady
   integer :: S_idx, T_idx ! Indices for temperature and salinity if needed
@@ -187,105 +191,138 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, CS, Reg, tv, do_online_fla
   if (CS%show_call_tree) call callTree_waypoint("Calculating diffusivity (tracer_hordiff)")
 
   if (do_online) then
-      if (use_VarMix) then
-    !$OMP parallel default(none) shared(is,ie,js,je,CS,VarMix,MEKE,Resoln_scaled, &
-    !$OMP                               Kh_u,Kh_v,khdt_x,dt,G,khdt_y,use_Eady)    &
-    !$OMP                       private(Kh_loc,Rd_dx)
-    !$OMP do
-        do j=js,je ; do I=is-1,ie
-          Kh_loc = CS%KhTr
-          if (use_Eady) Kh_loc = Kh_loc + CS%KhTr_Slope_Cff*VarMix%L2u(I,j)*VarMix%SN_u(I,j)
-          if (associated(MEKE%Kh)) &
-            Kh_Loc = Kh_Loc + MEKE%KhTr_fac*sqrt(MEKE%Kh(i,j)*MEKE%Kh(i+1,j))
-          if (CS%KhTr_max > 0.) Kh_loc = min(Kh_loc, CS%KhTr_max)
-          if (Resoln_scaled) &
-            Kh_Loc = Kh_Loc * 0.5*(VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i+1,j))
-          Kh_u(I,j) = max(Kh_loc, CS%KhTr_min)
-          if (CS%KhTr_passivity_coeff>0.) then ! Apply passivity
-            Rd_dx=0.5*( VarMix%Rd_dx_h(i,j)+VarMix%Rd_dx_h(i+1,j) ) ! Rd/dx at u-points
-            Kh_loc=Kh_u(I,j)*max( CS%KhTr_passivity_min, CS%KhTr_passivity_coeff*Rd_dx )
-            if (CS%KhTr_max > 0.) Kh_loc = min(Kh_loc, CS%KhTr_max) ! Re-apply max
-            Kh_u(I,j) = max(Kh_loc, CS%KhTr_min) ! Re-apply min
-          endif
-        enddo ; enddo
-    !$OMP do
-        do J=js-1,je ;  do i=is,ie
-          Kh_loc = CS%KhTr
-          if (use_Eady) Kh_loc = Kh_loc + CS%KhTr_Slope_Cff*VarMix%L2v(i,J)*VarMix%SN_v(i,J)
-          if (associated(MEKE%Kh)) &
-            Kh_Loc = Kh_Loc + MEKE%KhTr_fac*sqrt(MEKE%Kh(i,j)*MEKE%Kh(i,j+1))
-          if (CS%KhTr_max > 0.) Kh_loc = min(Kh_loc, CS%KhTr_max)
-          if (Resoln_scaled) &
-            Kh_Loc = Kh_Loc * 0.5*(VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i,j+1))
-          Kh_v(i,J) = max(Kh_loc, CS%KhTr_min)
-          if (CS%KhTr_passivity_coeff>0.) then ! Apply passivity
-            Rd_dx=0.5*( VarMix%Rd_dx_h(i,j)+VarMix%Rd_dx_h(i,j+1) ) ! Rd/dx at v-points
-            Kh_loc=Kh_v(I,j)*max( CS%KhTr_passivity_min, CS%KhTr_passivity_coeff*Rd_dx )
-            if (CS%KhTr_max > 0.) Kh_loc = min(Kh_loc, CS%KhTr_max) ! Re-apply max
-            Kh_v(i,J) = max(Kh_loc, CS%KhTr_min) ! Re-apply min
-          endif
-        enddo ; enddo
+    if (use_VarMix) then
+      !$OMP parallel do default(shared) private(Kh_loc,Rd_dx)
+      do j=js,je ; do I=is-1,ie
+        Kh_loc = CS%KhTr
+        if (use_Eady) Kh_loc = Kh_loc + CS%KhTr_Slope_Cff*VarMix%L2u(I,j)*VarMix%SN_u(I,j)
+        if (associated(MEKE%Kh)) &
+          Kh_Loc = Kh_Loc + MEKE%KhTr_fac*sqrt(MEKE%Kh(i,j)*MEKE%Kh(i+1,j))
+        if (CS%KhTr_max > 0.) Kh_loc = min(Kh_loc, CS%KhTr_max)
+        if (Resoln_scaled) &
+          Kh_Loc = Kh_Loc * 0.5*(VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i+1,j))
+        Kh_u(I,j) = max(Kh_loc, CS%KhTr_min)
+        if (CS%KhTr_passivity_coeff>0.) then ! Apply passivity
+          Rd_dx=0.5*( VarMix%Rd_dx_h(i,j)+VarMix%Rd_dx_h(i+1,j) ) ! Rd/dx at u-points
+          Kh_loc=Kh_u(I,j)*max( CS%KhTr_passivity_min, CS%KhTr_passivity_coeff*Rd_dx )
+          if (CS%KhTr_max > 0.) Kh_loc = min(Kh_loc, CS%KhTr_max) ! Re-apply max
+          Kh_u(I,j) = max(Kh_loc, CS%KhTr_min) ! Re-apply min
+        endif
+      enddo ; enddo
+      !$OMP parallel do default(shared) private(Kh_loc,Rd_dx)
+      do J=js-1,je ;  do i=is,ie
+        Kh_loc = CS%KhTr
+        if (use_Eady) Kh_loc = Kh_loc + CS%KhTr_Slope_Cff*VarMix%L2v(i,J)*VarMix%SN_v(i,J)
+        if (associated(MEKE%Kh)) &
+          Kh_Loc = Kh_Loc + MEKE%KhTr_fac*sqrt(MEKE%Kh(i,j)*MEKE%Kh(i,j+1))
+        if (CS%KhTr_max > 0.) Kh_loc = min(Kh_loc, CS%KhTr_max)
+        if (Resoln_scaled) &
+          Kh_Loc = Kh_Loc * 0.5*(VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i,j+1))
+        Kh_v(i,J) = max(Kh_loc, CS%KhTr_min)
+        if (CS%KhTr_passivity_coeff>0.) then ! Apply passivity
+          Rd_dx=0.5*( VarMix%Rd_dx_h(i,j)+VarMix%Rd_dx_h(i,j+1) ) ! Rd/dx at v-points
+          Kh_loc=Kh_v(I,j)*max( CS%KhTr_passivity_min, CS%KhTr_passivity_coeff*Rd_dx )
+          if (CS%KhTr_max > 0.) Kh_loc = min(Kh_loc, CS%KhTr_max) ! Re-apply max
+          Kh_v(i,J) = max(Kh_loc, CS%KhTr_min) ! Re-apply min
+        endif
+      enddo ; enddo
 
-    !$OMP do
+      !$OMP parallel do default(shared)
+      do j=js,je ; do I=is-1,ie
+        khdt_x(I,j) = dt*(Kh_u(I,j)*(G%dy_Cu(I,j)*G%IdxCu(I,j)))
+      enddo ; enddo
+      !$OMP parallel do default(shared)
+      do J=js-1,je ; do i=is,ie
+        khdt_y(i,J) = dt*(Kh_v(i,J)*(G%dx_Cv(i,J)*G%IdyCv(i,J)))
+      enddo ; enddo
+    elseif (Resoln_scaled) then
+      !$OMP parallel do default(shared) private(Res_fn)
+      do j=js,je ; do I=is-1,ie
+        Res_fn = 0.5 * (VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i+1,j))
+        Kh_u(I,j) = max(CS%KhTr * Res_fn, CS%KhTr_min)
+        khdt_x(I,j) = dt*(CS%KhTr*(G%dy_Cu(I,j)*G%IdxCu(I,j))) * Res_fn
+      enddo ; enddo
+      !$OMP parallel do default(shared) private(Res_fn)
+      do J=js-1,je ;  do i=is,ie
+        Res_fn = 0.5*(VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i,j+1))
+        Kh_v(i,J) = max(CS%KhTr * Res_fn, CS%KhTr_min)
+        khdt_y(i,J) = dt*(CS%KhTr*(G%dx_Cv(i,J)*G%IdyCv(i,J))) * Res_fn
+      enddo ; enddo
+    else  ! Use a simple constant diffusivity.
+      if (CS%id_KhTr_u > 0) then
+        !$OMP parallel do default(shared)
         do j=js,je ; do I=is-1,ie
-          khdt_x(I,j) = dt*(Kh_u(I,j)*(G%dy_Cu(I,j)*G%IdxCu(I,j)))
+          Kh_u(I,j) = CS%KhTr
+          khdt_x(I,j) = dt*(CS%KhTr*(G%dy_Cu(I,j)*G%IdxCu(I,j)))
         enddo ; enddo
-    !$OMP do
-        do J=js-1,je ; do i=is,ie
-          khdt_y(i,J) = dt*(Kh_v(i,J)*(G%dx_Cv(i,J)*G%IdyCv(i,J)))
-        enddo ; enddo
-    !$OMP end parallel
-      elseif (Resoln_scaled) then
-    !$OMP parallel default(none) shared(is,ie,js,je,VarMix,Kh_u,Kh_v,khdt_x,khdt_y,CS,dt,G) &
-    !$OMP                       private(Res_fn)
-    !$OMP do
-        do j=js,je ; do I=is-1,ie
-          Res_fn = 0.5 * (VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i+1,j))
-          Kh_u(I,j) = max(CS%KhTr * Res_fn, CS%KhTr_min)
-          khdt_x(I,j) = dt*(CS%KhTr*(G%dy_Cu(I,j)*G%IdxCu(I,j))) * Res_fn
-        enddo ; enddo
-    !$OMP do
-        do J=js-1,je ;  do i=is,ie
-          Res_fn = 0.5*(VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i,j+1))
-          Kh_v(i,J) = max(CS%KhTr * Res_fn, CS%KhTr_min)
-          khdt_y(i,J) = dt*(CS%KhTr*(G%dx_Cv(i,J)*G%IdyCv(i,J))) * Res_fn
-        enddo ; enddo
-    !$OMP end parallel
       else
-    !$OMP parallel default(none) shared(is,ie,js,je,Kh_u,Kh_v,khdt_x,khdt_y,CS,G,dt)
-        if (CS%id_KhTr_u > 0) then
-    !$OMP do
-          do j=js,je ; do I=is-1,ie
-            Kh_u(I,j) = CS%KhTr
-            khdt_x(I,j) = dt*(CS%KhTr*(G%dy_Cu(I,j)*G%IdxCu(I,j)))
-          enddo ; enddo
-        else
-    !$OMP do
-          do j=js,je ; do I=is-1,ie
-            khdt_x(I,j) = dt*(CS%KhTr*(G%dy_Cu(I,j)*G%IdxCu(I,j)))
-          enddo ; enddo
-        endif
-        if (CS%id_KhTr_v > 0) then
-    !$OMP do
-          do J=js-1,je ;  do i=is,ie
-            Kh_v(i,J) = CS%KhTr
-            khdt_y(i,J) = dt*(CS%KhTr*(G%dx_Cv(i,J)*G%IdyCv(i,J)))
-          enddo ; enddo
-        else
-    !$OMP do
-          do J=js-1,je ;  do i=is,ie
-            khdt_y(i,J) = dt*(CS%KhTr*(G%dx_Cv(i,J)*G%IdyCv(i,J)))
-          enddo ; enddo
-        endif
-    !$OMP end parallel
-      endif ! VarMix
+        !$OMP parallel do default(shared)
+        do j=js,je ; do I=is-1,ie
+          khdt_x(I,j) = dt*(CS%KhTr*(G%dy_Cu(I,j)*G%IdxCu(I,j)))
+        enddo ; enddo
+      endif
+      if (CS%id_KhTr_v > 0) then
+        !$OMP parallel do default(shared)
+        do J=js-1,je ;  do i=is,ie
+          Kh_v(i,J) = CS%KhTr
+          khdt_y(i,J) = dt*(CS%KhTr*(G%dx_Cv(i,J)*G%IdyCv(i,J)))
+        enddo ; enddo
+      else
+        !$OMP parallel do default(shared)
+        do J=js-1,je ;  do i=is,ie
+          khdt_y(i,J) = dt*(CS%KhTr*(G%dx_Cv(i,J)*G%IdyCv(i,J)))
+        enddo ; enddo
+      endif
+    endif ! VarMix
+
+    if (CS%max_diff_CFL > 0.0) then
+      if ((CS%id_KhTr_u > 0) .or. (CS%id_KhTr_h > 0)) then
+        !$OMP parallel do default(shared) private(khdt_max)
+        do j=js,je ; do I=is-1,ie
+          khdt_max = 0.125*CS%max_diff_CFL * min(G%areaT(i,j), G%areaT(i+1,j))
+          if (khdt_x(I,j) > khdt_max) then
+            khdt_x(I,j) = khdt_max
+            if (dt*(G%dy_Cu(I,j)*G%IdxCu(I,j)) > 0.0) &
+              Kh_u(I,j) = khdt_x(I,j) / (dt*(G%dy_Cu(I,j)*G%IdxCu(I,j)))
+          endif
+        enddo ; enddo
+      else
+        !$OMP parallel do default(shared) private(khdt_max)
+        do j=js,je ; do I=is-1,ie
+          khdt_max = 0.125*CS%max_diff_CFL * min(G%areaT(i,j), G%areaT(i+1,j))
+          khdt_x(I,j) = min(khdt_x(I,j), khdt_max)
+        enddo ; enddo
+      endif
+      if ((CS%id_KhTr_v > 0) .or. (CS%id_KhTr_h > 0)) then
+        !$OMP parallel do default(shared) private(khdt_max)
+        do J=js-1,je ; do i=is,ie
+          khdt_max = 0.125*CS%max_diff_CFL * min(G%areaT(i,j), G%areaT(i,j+1))
+          if (khdt_y(i,J) > khdt_max) then
+            khdt_y(i,J) = khdt_max
+            if (dt*(G%dx_Cv(i,J)*G%IdyCv(i,J)) > 0.0) &
+              Kh_v(i,J) = khdt_y(i,J) / (dt*(G%dx_Cv(i,J)*G%IdyCv(i,J)))
+          endif
+        enddo ; enddo
+      else
+        !$OMP parallel do default(shared) private(khdt_max)
+        do J=js-1,je ; do i=is,ie
+          khdt_max = 0.125*CS%max_diff_CFL * min(G%areaT(i,j), G%areaT(i,j+1))
+          khdt_y(i,J) = min(khdt_y(i,J), khdt_max)
+        enddo ; enddo
+      endif
+    endif
+
   else ! .not. do_online
-    khdt_x = read_khdt_x
-    khdt_y = read_khdt_y
+    !$OMP parallel do default(shared)
+    do j=js,je ; do I=is-1,ie
+      khdt_x(I,j) = read_khdt_x(I,j)
+    enddo ; enddo
+    !$OMP parallel do default(shared)
+    do J=js-1,je ;  do i=is,ie
+      khdt_y(i,J) = read_khdt_y(i,J)
+    enddo ; enddo
     call pass_vector(khdt_x,khdt_y,G%Domain)
   endif ! do_online
-
-
 
   if (CS%check_diffusive_CFL) then
     if (CS%show_call_tree) call callTree_waypoint("Checking diffusive CFL (tracer_hordiff)")
@@ -298,9 +335,12 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, CS, Reg, tv, do_online_fla
     call cpu_clock_begin(id_clock_sync)
     call max_across_PEs(max_CFL)
     call cpu_clock_end(id_clock_sync)
-    num_itts = max(1,ceiling(max_CFL))
-    I_numitts = 1.0 ; if (num_itts > 1) I_numitts = 1.0 / (real(num_itts))
-    if(CS%id_CFL > 0) call post_data(CS%id_CFL, CFL, CS%diag, mask=G%mask2dT)
+    num_itts = max(1, ceiling(max_CFL - 4.0*EPSILON(max_CFL)))
+    I_numitts = 1.0 / (real(num_itts))
+    if (CS%id_CFL > 0) call post_data(CS%id_CFL, CFL, CS%diag, mask=G%mask2dT)
+  elseif (CS%max_diff_CFL > 0.0) then
+    num_itts = max(1, ceiling(CS%max_diff_CFL - 4.0*EPSILON(CS%max_diff_CFL)))
+    I_numitts = 1.0 / (real(num_itts))
   else
     num_itts = 1 ; I_numitts = 1.0
   endif
@@ -356,9 +396,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, CS, Reg, tv, do_online_fla
     if (CS%show_call_tree) call callTree_waypoint("Calculating horizontal diffusion (tracer_hordiff)")
     do itt=1,num_itts
       call do_group_pass(CS%pass_t, G%Domain, clock=id_clock_pass)
-!$OMP parallel do default(none) shared(is,ie,js,je,nz,I_numitts,CS,G,GV,khdt_y,h, &
-!$OMP                                    h_neglect,khdt_x,ntr,Idt,Reg)           &
-!$OMP                            private(scale,Coef_y,Coef_x,Ihdxdy,dTr)
+      !$OMP parallel do default(shared) private(scale,Coef_y,Coef_x,Ihdxdy,dTr)
       do k=1,nz
         scale = I_numitts
         if (CS%Diffuse_ML_interior) then
@@ -1363,24 +1401,31 @@ subroutine tracer_hor_diff_init(Time, G, param_file, diag, EOS, CS)
                  "The maximum along-isopycnal tracer diffusivity.", &
                  units="m2 s-1", default=0.0)
   call get_param(param_file, mdl, "KHTR_PASSIVITY_COEFF", CS%KhTr_passivity_coeff, &
-               "The coefficient that scales deformation radius over \n"//&
-               "grid-spacing in passivity, where passiviity is the ratio \n"//&
-               "between along isopycnal mxiing of tracers to thickness mixing. \n"//&
-               "A non-zero value enables this parameterization.", &
-               units="nondim", default=0.0)
+                 "The coefficient that scales deformation radius over \n"//&
+                 "grid-spacing in passivity, where passiviity is the ratio \n"//&
+                 "between along isopycnal mxiing of tracers to thickness mixing. \n"//&
+                 "A non-zero value enables this parameterization.", &
+                 units="nondim", default=0.0)
   call get_param(param_file, mdl, "KHTR_PASSIVITY_MIN", CS%KhTr_passivity_min, &
-               "The minimum passivity which is the ratio between \n"//&
-               "along isopycnal mxiing of tracers to thickness mixing. \n", &
-               units="nondim", default=0.5)
+                 "The minimum passivity which is the ratio between \n"//&
+                 "along isopycnal mxiing of tracers to thickness mixing. \n", &
+                 units="nondim", default=0.5)
   call get_param(param_file, mdl, "DT", CS%dt, fail_if_missing=.true., &
-          desc="The (baroclinic) dynamics time step.", units="s")
+                 desc="The (baroclinic) dynamics time step.", units="s")
   call get_param(param_file, mdl, "DIFFUSE_ML_TO_INTERIOR", CS%Diffuse_ML_interior, &
                  "If true, enable epipycnal mixing between the surface \n"//&
                  "boundary layer and the interior.", default=.false.)
   call get_param(param_file, mdl, "CHECK_DIFFUSIVE_CFL", CS%check_diffusive_CFL, &
                  "If true, use enough iterations the diffusion to ensure \n"//&
                  "that the diffusive equivalent of the CFL limit is not \n"//&
-                 "violated.  If false, always use 1 iteration.", default=.false.)
+                 "violated.  If false, always use the greater of 1 or \n"//&
+                 "MAX_TR_DIFFUSION_CFL iteration.", default=.false.)
+  call get_param(param_file, mdl, "MAX_TR_DIFFUSION_CFL", CS%max_diff_CFL, &
+                 "If positive, locally limit the along-isopycnal tracer \n"//&
+                 "diffusivity to keep the diffusive CFL locally at or \n"//&
+                 "below this value.  The number of diffusive iterations \n"//&
+                 "is often this value or the next greater integer.", &
+                 units="nondim", default=-1.0)
   CS%ML_KhTR_scale = 1.0
   if (CS%Diffuse_ML_interior) then
     call get_param(param_file, mdl, "ML_KHTR_SCALE", CS%ML_KhTR_scale, &


### PR DESCRIPTION
  Added a new run-time paramter, MAX_TR_DIFFUSION_CFL, that can be used to limit
the values of the along-isopycnal tracer diffusivity based on local CFL considerations.
Also revised a few lines using an array-syntax copy and simplified the openMP
statements in MOM_tracer_hor_diff.F90.  All answers are bitwise identical, but
the MOM_parameter_doc files change.