### PR TITLE
Bug fix for CCS1

### DIFF
--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -589,7 +589,7 @@ subroutine initialize_segment_data(G, OBC, PF)
               allocate(segment%field(m)%buffer_src(IsdB:IedB,jsd:jed,siz2(3)))
             endif
           else
-            if (segment%field(m)%name == 'V') then
+            if (segment%field(m)%name == 'U') then
               allocate(segment%field(m)%buffer_src(IsdB:IedB,JsdB:JedB,siz2(3)))
             else
               allocate(segment%field(m)%buffer_src(isd:ied,JsdB:JedB,siz2(3)))
@@ -608,7 +608,7 @@ subroutine initialize_segment_data(G, OBC, PF)
                 allocate(segment%field(m)%dz_src(IsdB:IedB,jsd:jed,siz(3)))
               endif
             else
-              if (segment%field(m)%name == 'V') then
+              if (segment%field(m)%name == 'U') then
                 allocate(segment%field(m)%dz_src(IsdB:IedB,JsdB:JedB,siz(3)))
               else
                 allocate(segment%field(m)%dz_src(isd:ied,JsdB:JedB,siz(3)))
@@ -2077,7 +2077,7 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
   real, dimension(:,:), pointer :: seg_vel => NULL()  ! pointer to segment velocity array
   real, dimension(:,:), pointer :: seg_trans => NULL()  ! pointer to segment transport array
   real, dimension(:,:,:), allocatable :: tmp_buffer
-  integer :: subsample_factor
+  real, dimension(:), allocatable :: h_stack
   integer :: is_obc2, js_obc2
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -2087,11 +2087,6 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
 
   if (.not. associated(OBC)) return
 
-  if (OBC%brushcutter_mode) then
-    subsample_factor = 2
-  else
-    subsample_factor = 1
-  endif
   do n = 1, OBC%number_of_segments
     segment => OBC%segment(n)
 
@@ -2103,16 +2098,6 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
     ie_obc = min(segment%ie_obc,ied)
     js_obc = max(segment%js_obc,jsd-1)
     je_obc = min(segment%je_obc,jed)
-
-    if (OBC%brushcutter_mode) then
-      if (segment%is_E_or_W) then
-        nj_seg=nj_seg-1
-        js_obc=js_obc+1
-      else
-        ni_seg=ni_seg-1
-        is_obc=is_obc+1
-      endif
-    endif
 
 ! Calculate auxiliary fields at staggered locations.
 ! Segment indices are on q points:
@@ -2158,6 +2143,8 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
       enddo
     endif
 
+    allocate(h_stack(G%ke))
+    h_stack(:) = 0.0
     do m = 1,segment%num_fields
       if (segment%field(m)%fid > 0) then
         siz(1)=size(segment%field(m)%buffer_src,1)
@@ -2166,111 +2153,280 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
         if (.not.associated(segment%field(m)%buffer_dst)) then
           if (siz(3) /= segment%field(m)%nk_src) call MOM_error(FATAL,'nk_src inconsistency')
           if (segment%field(m)%nk_src > 1) then
-            if (OBC%brushcutter_mode) then
-              allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc:je_obc,G%ke))
-            else
-              if (segment%is_E_or_W) then
+            if (segment%is_E_or_W) then
+              if (segment%field(m)%name == 'V') then
+                allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc:je_obc,G%ke))
+              else
                 allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc+1:je_obc,G%ke))
+              endif
+              if (segment%field(m)%name == 'U') then
+                allocate(segment%field(m)%bt_vel(is_obc:ie_obc,js_obc+1:je_obc))
+                segment%field(m)%bt_vel(:,:)=0.0
+              endif
+            else
+              if (segment%field(m)%name == 'U') then
+                allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc:je_obc,G%ke))
               else
                 allocate(segment%field(m)%buffer_dst(is_obc+1:ie_obc,js_obc:je_obc,G%ke))
               endif
+              if (segment%field(m)%name == 'V') then
+                allocate(segment%field(m)%bt_vel(is_obc+1:ie_obc,js_obc:je_obc))
+                segment%field(m)%bt_vel(:,:)=0.0
+              endif
             endif
           else
-            if (OBC%brushcutter_mode) then
-              allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc:je_obc,1))
-            else
-              if (segment%is_E_or_W) then
+            if (segment%is_E_or_W) then
+              if (segment%field(m)%name == 'V') then
+                allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc:je_obc,1))
+              else
                 allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc+1:je_obc,1))
+              endif
+              if (segment%field(m)%name == 'U') then
+                allocate(segment%field(m)%bt_vel(is_obc:ie_obc,js_obc+1:je_obc))
+                segment%field(m)%bt_vel(:,:)=0.0
+              endif
+            else
+              if (segment%field(m)%name == 'U') then
+                allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc:je_obc,1))
               else
                 allocate(segment%field(m)%buffer_dst(is_obc+1:ie_obc,js_obc:je_obc,1))
+              endif
+              if (segment%field(m)%name == 'V') then
+                allocate(segment%field(m)%bt_vel(is_obc+1:ie_obc,js_obc:je_obc))
+                segment%field(m)%bt_vel(:,:)=0.0
               endif
             endif
           endif
           segment%field(m)%buffer_dst(:,:,:)=0.0
-          if (trim(segment%field(m)%name) == 'U' .or. trim(segment%field(m)%name) == 'V') then
-            allocate(segment%field(m)%bt_vel(is_obc:ie_obc,js_obc:je_obc))
-            segment%field(m)%bt_vel(:,:)=0.0
-          endif
         endif
         ! read source data interpolated to the current model time
         if (siz(1)==1) then
-          allocate(tmp_buffer(1,(nj_seg+1)*subsample_factor-1,segment%field(m)%nk_src))  ! segment data is currrently on supergrid
+          if (OBC%brushcutter_mode) then
+            allocate(tmp_buffer(1,nj_seg*2-1,segment%field(m)%nk_src))  ! segment data is currrently on supergrid
+          else
+            allocate(tmp_buffer(1,nj_seg,segment%field(m)%nk_src))  ! segment data is currrently on supergrid
+          endif
         else
-          allocate(tmp_buffer((ni_seg+1)*subsample_factor-1,1,segment%field(m)%nk_src))  ! segment data is currrently on supergrid
+          if (OBC%brushcutter_mode) then
+            allocate(tmp_buffer(ni_seg*2-1,1,segment%field(m)%nk_src))  ! segment data is currrently on supergrid
+          else
+            allocate(tmp_buffer(ni_seg,1,segment%field(m)%nk_src))  ! segment data is currrently on supergrid
+          endif
         endif
 
         call time_interp_external(segment%field(m)%fid,Time, tmp_buffer)
         if (OBC%brushcutter_mode) then
-          if (siz(1)==1) then
-            segment%field(m)%buffer_src(is_obc,:,:)=tmp_buffer(1,2*(js_obc+G%jdg_offset)-1:2*(je_obc+G%jdg_offset)-1:2,:)
+          if (segment%is_E_or_W) then
+            if (segment%field(m)%name == 'V') then
+              segment%field(m)%buffer_src(is_obc,:,:)=tmp_buffer(1,2*(js_obc+G%jdg_offset)+1:2*(je_obc+G%jdg_offset)+1:2,:)
+            else
+              segment%field(m)%buffer_src(is_obc,:,:)=tmp_buffer(1,2*(js_obc+G%jdg_offset)+1:2*(je_obc+G%jdg_offset):2,:)
+            endif
           else
-            segment%field(m)%buffer_src(:,js_obc,:)=tmp_buffer(2*(is_obc+G%idg_offset)-1:2*(ie_obc+G%idg_offset)-1:2,1,:)
+            if (segment%field(m)%name == 'U') then
+              segment%field(m)%buffer_src(:,js_obc,:)=tmp_buffer(2*(is_obc+G%idg_offset)+1:2*(ie_obc+G%idg_offset)+1:2,1,:)
+            else
+              segment%field(m)%buffer_src(:,js_obc,:)=tmp_buffer(2*(is_obc+G%idg_offset)+1:2*(ie_obc+G%idg_offset):2,1,:)
+            endif
           endif
         else
-          if (siz(1)==1) then
-            segment%field(m)%buffer_src(is_obc,:,:)=tmp_buffer(1,js_obc+G%jdg_offset+1:je_obc+G%jdg_offset,:)
+          if (segment%is_E_or_W) then
+            if (segment%field(m)%name == 'V') then
+              segment%field(m)%buffer_src(is_obc,:,:)=tmp_buffer(1,js_obc+G%jdg_offset+1:je_obc+G%jdg_offset+1,:)
+            else
+              segment%field(m)%buffer_src(is_obc,:,:)=tmp_buffer(1,js_obc+G%jdg_offset+1:je_obc+G%jdg_offset,:)
+            endif
           else
-            segment%field(m)%buffer_src(:,js_obc,:)=tmp_buffer(is_obc+G%idg_offset+1:ie_obc+G%idg_offset,1,:)
+            if (segment%field(m)%name == 'U') then
+              segment%field(m)%buffer_src(:,js_obc,:)=tmp_buffer(is_obc+G%idg_offset+1:ie_obc+G%idg_offset+1,1,:)
+            else
+              segment%field(m)%buffer_src(:,js_obc,:)=tmp_buffer(is_obc+G%idg_offset+1:ie_obc+G%idg_offset,1,:)
+            endif
           endif
         endif
         if (segment%field(m)%nk_src > 1) then
           call time_interp_external(segment%field(m)%fid_dz,Time, tmp_buffer)
           if (OBC%brushcutter_mode) then
-            if (siz(1)==1) then
-              segment%field(m)%dz_src(is_obc,:,:)=tmp_buffer(1,2*(js_obc+G%jdg_offset)-1:2*(je_obc+G%jdg_offset)-1:2,:)
+            if (segment%is_E_or_W) then
+              if (segment%field(m)%name == 'V') then
+                segment%field(m)%dz_src(is_obc,:,:)=tmp_buffer(1,2*(js_obc+G%jdg_offset)+1:2*(je_obc+G%jdg_offset)+1:2,:)
+              else
+                segment%field(m)%dz_src(is_obc,:,:)=tmp_buffer(1,2*(js_obc+G%jdg_offset)+1:2*(je_obc+G%jdg_offset):2,:)
+              endif
             else
-              segment%field(m)%dz_src(:,js_obc,:)=tmp_buffer(2*(is_obc+G%idg_offset)-1:2*(ie_obc+G%idg_offset)-1:2,1,:)
+              if (segment%field(m)%name == 'U') then
+                segment%field(m)%dz_src(:,js_obc,:)=tmp_buffer(2*(is_obc+G%idg_offset)+1:2*(ie_obc+G%idg_offset)+1:2,1,:)
+              else
+                segment%field(m)%dz_src(:,js_obc,:)=tmp_buffer(2*(is_obc+G%idg_offset)+1:2*(ie_obc+G%idg_offset):2,1,:)
+              endif
             endif
           else
-            if (siz(1)==1) then
-              segment%field(m)%dz_src(is_obc,:,:)=tmp_buffer(1,js_obc+G%jdg_offset+1:je_obc+G%jdg_offset,:)
+            if (segment%is_E_or_W) then
+              if (segment%field(m)%name == 'V') then
+                segment%field(m)%dz_src(is_obc,:,:)=tmp_buffer(1,js_obc+G%jdg_offset+1:je_obc+G%jdg_offset+1,:)
+              else
+                segment%field(m)%dz_src(is_obc,:,:)=tmp_buffer(1,js_obc+G%jdg_offset+1:je_obc+G%jdg_offset,:)
+              endif
             else
-              segment%field(m)%dz_src(:,js_obc,:)=tmp_buffer(is_obc+G%idg_offset+1:ie_obc+G%idg_offset,1,:)
+              if (segment%field(m)%name == 'U') then
+                segment%field(m)%dz_src(:,js_obc,:)=tmp_buffer(is_obc+G%idg_offset+1:ie_obc+G%idg_offset+1,1,:)
+              else
+                segment%field(m)%dz_src(:,js_obc,:)=tmp_buffer(is_obc+G%idg_offset+1:ie_obc+G%idg_offset,1,:)
+              endif
             endif
           endif
 
           if (segment%is_E_or_W) then
             ishift=1
             if (segment%direction == OBC_DIRECTION_E) ishift=0
-            do j=js_obc+1,je_obc
-              I=is_obc
-              ! Using the h remapping approach
-              ! Pretty sure we need to check for source/target grid consistency here
-              segment%field(m)%buffer_dst(I,j,:)=0.0  ! initialize remap destination buffer
-              if (G%mask2dCu(I,j)>0.) then
-                call remapping_core_h(OBC%remap_CS, &
-                     segment%field(m)%nk_src,segment%field(m)%dz_src(I,j,:), &
-                     segment%field(m)%buffer_src(I,j,:), &
-                     G%ke, h(i+ishift,j,:), segment%field(m)%buffer_dst(I,j,:))
-              endif
-            enddo
+            I=is_obc
+            if (segment%field(m)%name == 'V') then
+              ! Only do q points within the segment
+              do J=js_obc+1,je_obc-1
+                ! Using the h remapping approach
+                ! Pretty sure we need to check for source/target grid consistency here
+                segment%field(m)%buffer_dst(I,J,:)=0.0  ! initialize remap destination buffer
+                if (G%mask2dCu(I,j)>0. .and. G%mask2dCu(I,j+1)>0.) then
+                  h_stack(:) = 0.5*(h(i+ishift,j,:) + h(i+ishift,j+1,:))
+                  call remapping_core_h(OBC%remap_CS, &
+                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%buffer_src(I,J,:), &
+                       G%ke, h_stack, segment%field(m)%buffer_dst(I,J,:))
+                else if (G%mask2dCu(I,j)>0.) then
+                  h_stack(:) = h(i+ishift,j,:)
+                  call remapping_core_h(OBC%remap_CS, &
+                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%buffer_src(I,J,:), &
+                       G%ke, h_stack, segment%field(m)%buffer_dst(I,J,:))
+                else if (G%mask2dCu(I,j+1)>0.) then
+                  h_stack(:) = h(i+ishift,j+1,:)
+                  call remapping_core_h(OBC%remap_CS, &
+                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,j,:), &
+                       segment%field(m)%buffer_src(I,J,:), &
+                       G%ke, h_stack, segment%field(m)%buffer_dst(I,J,:))
+                endif
+              enddo
+            else
+              do j=js_obc+1,je_obc
+                ! Using the h remapping approach
+                ! Pretty sure we need to check for source/target grid consistency here
+                segment%field(m)%buffer_dst(I,j,:)=0.0  ! initialize remap destination buffer
+                if (G%mask2dCu(I,j)>0.) then
+                  call remapping_core_h(OBC%remap_CS, &
+                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,j,:), &
+                       segment%field(m)%buffer_src(I,j,:), &
+                       G%ke, h(i+ishift,j,:), segment%field(m)%buffer_dst(I,j,:))
+                endif
+              enddo
+            endif
           else
             jshift=1
             if (segment%direction == OBC_DIRECTION_N) jshift=0
-            do i=is_obc+1,ie_obc
-              J=js_obc
+            J=js_obc
+            if (segment%field(m)%name == 'U') then
+              ! Only do q points within the segment
+              do I=is_obc+1,ie_obc-1
+                segment%field(m)%buffer_dst(I,J,:)=0.0  ! initialize remap destination buffer
+                if (G%mask2dCv(i,J)>0. .and. G%mask2dCv(i+1,J)>0.) then
               ! Using the h remapping approach
               ! Pretty sure we need to check for source/target grid consistency here
-              segment%field(m)%buffer_dst(i,J,:)=0.0  ! initialize remap destination buffer
-              if (G%mask2dCv(i,J)>0.) then
-                call remapping_core_h(OBC%remap_CS, &
-                     segment%field(m)%nk_src,segment%field(m)%dz_src(i,J,:), &
-                     segment%field(m)%buffer_src(i,J,:), &
-                     G%ke, h(i,j+jshift,:), segment%field(m)%buffer_dst(i,J,:))
-              endif
-            enddo
+                  h_stack(:) = 0.5*(h(i,j+jshift,:) + h(i+1,j+jshift,:))
+                  call remapping_core_h(OBC%remap_CS, &
+                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%buffer_src(I,J,:), &
+                       G%ke, h_stack, segment%field(m)%buffer_dst(I,J,:))
+                else if (G%mask2dCv(i,J)>0.) then
+                  h_stack(:) = h(i,j+jshift,:)
+                  call remapping_core_h(OBC%remap_CS, &
+                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%buffer_src(I,J,:), &
+                       G%ke, h_stack, segment%field(m)%buffer_dst(I,J,:))
+                else if (G%mask2dCv(i+1,J)>0.) then
+                  h_stack(:) = h(i+1,j+jshift,:)
+                  call remapping_core_h(OBC%remap_CS, &
+                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%buffer_src(I,J,:), &
+                       G%ke, h_stack, segment%field(m)%buffer_dst(I,J,:))
+                endif
+              enddo
+            else
+              do i=is_obc+1,ie_obc
+              ! Using the h remapping approach
+              ! Pretty sure we need to check for source/target grid consistency here
+                segment%field(m)%buffer_dst(i,J,:)=0.0  ! initialize remap destination buffer
+                if (G%mask2dCv(i,J)>0.) then
+                  call remapping_core_h(OBC%remap_CS, &
+                       segment%field(m)%nk_src,segment%field(m)%dz_src(i,J,:), &
+                       segment%field(m)%buffer_src(i,J,:), &
+                       G%ke, h(i,j+jshift,:), segment%field(m)%buffer_dst(i,J,:))
+                endif
+              enddo
+            endif
           endif
         else  ! 2d data
           segment%field(m)%buffer_dst(:,:,1)=segment%field(m)%buffer_src(:,:,1)  ! initialize remap destination buffer
         endif
         deallocate(tmp_buffer)
-      else ! fid <= 0
+      else ! fid <= 0 (Uniform value)
         if (.not. ASSOCIATED(segment%field(m)%buffer_dst)) then
-          allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc:je_obc,G%ke))
+          if (segment%is_E_or_W) then
+            if (segment%field(m)%name == 'V') then
+              allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc:je_obc,G%ke))
+              allocate(segment%field(m)%bt_vel(is_obc:ie_obc,js_obc:je_obc))
+            else if (segment%field(m)%name == 'U') then
+              allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc+1:je_obc,G%ke))
+              allocate(segment%field(m)%bt_vel(is_obc:ie_obc,js_obc+1:je_obc))
+            else
+              allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc+1:je_obc,G%ke))
+            endif
+          else
+            if (segment%field(m)%name == 'U') then
+              allocate(segment%field(m)%buffer_dst(is_obc:ie_obc,js_obc:je_obc,G%ke))
+              allocate(segment%field(m)%bt_vel(is_obc:ie_obc,js_obc:je_obc))
+            else if (segment%field(m)%name == 'V') then
+              allocate(segment%field(m)%buffer_dst(is_obc+1:ie_obc,js_obc:je_obc,G%ke))
+              allocate(segment%field(m)%bt_vel(is_obc+1:ie_obc,js_obc:je_obc))
+            else
+              allocate(segment%field(m)%buffer_dst(is_obc+1:ie_obc,js_obc:je_obc,G%ke))
+            endif
+          endif
           segment%field(m)%buffer_dst(:,:,:)=segment%field(m)%value
           if (trim(segment%field(m)%name) == 'U' .or. trim(segment%field(m)%name) == 'V') then
-            allocate(segment%field(m)%bt_vel(is_obc:ie_obc,js_obc:je_obc))
             segment%field(m)%bt_vel(:,:)=segment%field(m)%value
+          endif
+        endif
+      endif
+
+      if (trim(segment%field(m)%name) == 'U' .or. trim(segment%field(m)%name) == 'V') then
+        if (segment%field(m)%fid>0) then ! calculate external BT velocity and transport if needed
+          if (trim(segment%field(m)%name) == 'U' .and. segment%is_E_or_W) then
+            I=is_obc
+            do j=js_obc+1,je_obc
+              segment%normal_trans_bt(I,j) = 0.0
+              do k=1,G%ke
+                segment%normal_vel(I,j,k) = segment%field(m)%buffer_dst(I,j,k)
+                segment%normal_trans(I,j,k) = segment%field(m)%buffer_dst(I,j,k)*segment%h(I,j,k) * &
+                          G%dyCu(I,j)
+                segment%normal_trans_bt(I,j)= segment%normal_trans_bt(I,j)+segment%normal_trans(I,j,k)
+              enddo
+              segment%normal_vel_bt(I,j) = segment%normal_trans_bt(I,j)/(max(segment%Htot(I,j),1.e-12) * &
+                          G%dyCu(I,j))
+              if (associated(segment%nudged_normal_vel)) segment%nudged_normal_vel(I,j,:) = segment%normal_vel(I,j,:)
+            enddo
+          elseif (trim(segment%field(m)%name) == 'V' .and. segment%is_N_or_S) then
+            J=js_obc
+            do i=is_obc+1,ie_obc
+              segment%normal_trans_bt(i,J) = 0.0
+              do k=1,G%ke
+                segment%normal_vel(i,J,k) = segment%field(m)%buffer_dst(i,J,k)
+                segment%normal_trans(i,J,k) = segment%field(m)%buffer_dst(i,J,k)*segment%h(i,J,k) * &
+                          G%dxCv(i,J)
+                segment%normal_trans_bt(i,J)= segment%normal_trans_bt(i,J)+segment%normal_trans(i,J,k)
+              enddo
+              segment%normal_vel_bt(i,J) = segment%normal_trans_bt(i,J)/(max(segment%Htot(i,J),1.e-12) * &
+                          G%dxCv(i,J))
+              if (associated(segment%nudged_normal_vel)) segment%nudged_normal_vel(i,J,:) = segment%normal_vel(i,J,:)
+            enddo
           endif
         endif
       endif
@@ -2292,42 +2448,6 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
         js_obc2 = js_obc+1
       endif
 
-      if (trim(segment%field(m)%name) == 'U' .or. trim(segment%field(m)%name) == 'V') then
-        if (segment%field(m)%fid>0) then ! calculate external BT velocity and transport if needed
-          if (trim(segment%field(m)%name) == 'U' .and. segment%is_E_or_W) then
-            do j=js_obc2,je_obc
-              do i=is_obc2,ie_obc
-                segment%normal_trans_bt(i,j) = 0.0
-                do k=1,G%ke
-                  segment%normal_vel(i,j,k) = segment%field(m)%buffer_dst(i,j,k)
-                  segment%normal_trans(i,j,k) = segment%field(m)%buffer_dst(i,j,k)*segment%h(i,j,k) * &
-                            G%dyCu(I,j)
-                  segment%normal_trans_bt(i,j)= segment%normal_trans_bt(i,j)+segment%normal_trans(i,j,k)
-                enddo
-                segment%normal_vel_bt(i,j) = segment%normal_trans_bt(i,j)/(max(segment%Htot(i,j),1.e-12) * &
-                            G%dyCu(I,j))
-                if (associated(segment%nudged_normal_vel)) segment%nudged_normal_vel(i,j,:) = segment%normal_vel(i,j,:)
-              enddo
-            enddo
-          elseif (trim(segment%field(m)%name) == 'V' .and. segment%is_N_or_S) then
-            do j=js_obc2,je_obc
-              do i=is_obc2,ie_obc
-                segment%normal_trans_bt(i,j) = 0.0
-                do k=1,G%ke
-                  segment%normal_vel(i,j,k) = segment%field(m)%buffer_dst(i,j,k)
-                  segment%normal_trans(i,j,k) = segment%field(m)%buffer_dst(i,j,k)*segment%h(i,j,k) * &
-                            G%dxCv(i,J)
-                  segment%normal_trans_bt(i,j)= segment%normal_trans_bt(i,j)+segment%normal_trans(i,j,k)
-                enddo
-                segment%normal_vel_bt(i,j) = segment%normal_trans_bt(i,j)/(max(segment%Htot(i,j),1.e-12) * &
-                            G%dxCv(i,J))
-                if (associated(segment%nudged_normal_vel)) segment%nudged_normal_vel(i,j,:) = segment%normal_vel(i,j,:)
-              enddo
-            enddo
-          endif
-        endif
-      endif
-
       if (trim(segment%field(m)%name) == 'SSH') then
         do j=js_obc2,je_obc
           do i=is_obc2,ie_obc
@@ -2338,13 +2458,12 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
 
       if (trim(segment%field(m)%name) == 'TEMP') then
         if (associated(segment%field(m)%buffer_dst)) then
-          do k=1,nz; do j=js_obc2, je_obc;do i=is_obc2,ie_obc
+          do k=1,nz; do j=js_obc2, je_obc; do i=is_obc2,ie_obc
             segment%tr_Reg%Tr(1)%t(i,j,k) = segment%field(m)%buffer_dst(i,j,k)
-! if the tracer reservoir has not yet been initialized, then set to external value.
-! Am using negative values here, which will not work for temperature in degC.
           enddo; enddo; enddo
           if (.not. segment%tr_Reg%Tr(1)%is_initialized) then
-            do k=1,nz; do j=js_obc2, je_obc;do i=is_obc2,ie_obc
+            ! if the tracer reservoir has not yet been initialized, then set to external value.
+            do k=1,nz; do j=js_obc2, je_obc; do i=is_obc2,ie_obc
               segment%tr_Reg%Tr(1)%tres(i,j,k) = segment%tr_Reg%Tr(1)%t(i,j,k)
             enddo; enddo; enddo
             segment%tr_Reg%Tr(1)%is_initialized=.true.
@@ -2354,12 +2473,12 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
         endif
       elseif (trim(segment%field(m)%name) == 'SALT') then
         if (associated(segment%field(m)%buffer_dst)) then
-          do k=1,nz; do j=js_obc2, je_obc;do i=is_obc2,ie_obc
+          do k=1,nz; do j=js_obc2, je_obc; do i=is_obc2,ie_obc
             segment%tr_Reg%Tr(2)%t(i,j,k) = segment%field(m)%buffer_dst(i,j,k)
           enddo; enddo; enddo
           if (.not. segment%tr_Reg%Tr(1)%is_initialized) then
-            !if the tracer reservoir has not yet been initialized, then set to external value
-            do k=1,nz; do j=js_obc2, je_obc;do i=is_obc2,ie_obc
+            !if the tracer reservoir has not yet been initialized, then set to external value.
+            do k=1,nz; do j=js_obc2, je_obc; do i=is_obc2,ie_obc
               segment%tr_Reg%Tr(2)%tres(i,j,k) = segment%tr_Reg%Tr(2)%t(i,j,k)
             enddo; enddo; enddo
             segment%tr_Reg%Tr(1)%is_initialized=.true.
@@ -2369,7 +2488,8 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
         endif
       endif
 
-    enddo
+    enddo ! end field loop
+    deallocate(h_stack)
 
   enddo ! end segment loop
 


### PR DESCRIPTION
Changes answers for CCS1 - there was something funky about the brushcutter-mode indexing.

One can now read in the tangential velocity at OBC segments, but we're not yet using it. The vertical remapping is not at this time happening on the two end q-points of the segment.