### PR TITLE
Recalculation of DTBT can span coupled timesteps

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2,7 +2,6 @@ module MOM
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-
 ! Infrastructure modules
 use MOM_debugging,            only : MOM_debugging_init, hchksum, uvchksum
 use MOM_checksum_packages,    only : MOM_thermo_chksum, MOM_state_chksum
@@ -10,7 +9,6 @@ use MOM_checksum_packages,    only : MOM_accel_chksum, MOM_surface_chksum
 use MOM_cpu_clock,            only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,            only : CLOCK_COMPONENT, CLOCK_SUBCOMPONENT
 use MOM_cpu_clock,            only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
-use MOM_coms,                 only : reproducing_sum
 use MOM_coord_initialization, only : MOM_initialize_coord
 use MOM_diag_mediator,        only : diag_mediator_init, enable_averaging
 use MOM_diag_mediator,        only : diag_mediator_infrastructure_init
@@ -41,7 +39,7 @@ use MOM_io,                   only : slasher, file_exists, MOM_read_data
 use MOM_obsolete_params,      only : find_obsolete_params
 use MOM_restart,              only : register_restart_field, query_initialized, save_restart
 use MOM_restart,              only : restart_init, is_new_run, MOM_restart_CS
-use MOM_spatial_means,        only : global_area_mean, global_area_integral, global_mass_integral
+use MOM_spatial_means,        only : global_mass_integral
 use MOM_state_initialization, only : MOM_initialize_state
 use MOM_time_manager,         only : time_type, set_time, time_type_to_real, operator(+)
 use MOM_time_manager,         only : operator(-), operator(>), operator(*), operator(/)
@@ -54,8 +52,6 @@ use MOM_ALE,                   only : ALE_init, ALE_end, ALE_main, ALE_CS, adjus
 use MOM_ALE,                   only : ALE_getCoordinate, ALE_getCoordinateUnits, ALE_writeCoordinateFile
 use MOM_ALE,                   only : ALE_updateVerticalGridType, ALE_remap_init_conds, ALE_register_diags
 use MOM_boundary_update,       only : call_OBC_register, OBC_register_end, update_OBC_CS
-use MOM_continuity,            only : continuity, continuity_init, continuity_CS, continuity_stencil
-use MOM_CoriolisAdv,           only : CorAdCalc, CoriolisAdv_init, CoriolisAdv_CS
 use MOM_diabatic_driver,       only : diabatic, diabatic_driver_init, diabatic_CS
 use MOM_diabatic_driver,       only : adiabatic, adiabatic_driver_init, diabatic_driver_end
 use MOM_diagnostics,           only : calculate_diagnostic_fields, MOM_diagnostics_init
@@ -76,12 +72,10 @@ use MOM_dynamics_unsplit_RK2,  only : initialize_dyn_unsplit_RK2, end_dyn_unspli
 use MOM_dynamics_unsplit_RK2,  only : MOM_dyn_unsplit_RK2_CS
 use MOM_dyn_horgrid,           only : dyn_horgrid_type, create_dyn_horgrid, destroy_dyn_horgrid
 use MOM_EOS,                   only : EOS_init, calculate_density
-use MOM_EOS,                   only : gsw_sp_from_sr, gsw_pt_from_ct
 use MOM_debugging,             only : check_redundant
 use MOM_grid,                  only : ocean_grid_type, set_first_direction
 use MOM_grid,                  only : MOM_grid_init, MOM_grid_end
 use MOM_hor_index,             only : hor_index_type, hor_index_init
-use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_init
 use MOM_interface_heights,     only : find_eta
 use MOM_lateral_mixing_coeffs, only : calc_slope_functions, VarMix_init
 use MOM_lateral_mixing_coeffs, only : calc_resoln_function, VarMix_CS
@@ -89,12 +83,10 @@ use MOM_MEKE,                  only : MEKE_init, MEKE_alloc_register_restart, st
 use MOM_MEKE_types,            only : MEKE_type
 use MOM_mixed_layer_restrat,   only : mixedlayer_restrat, mixedlayer_restrat_init, mixedlayer_restrat_CS
 use MOM_mixed_layer_restrat,   only : mixedlayer_restrat_register_restarts
-use MOM_neutral_diffusion,     only : neutral_diffusion_CS
 use MOM_obsolete_diagnostics,  only : register_obsolete_diagnostics
 use MOM_open_boundary,         only : ocean_OBC_type, OBC_registry_type
 use MOM_open_boundary,         only : register_temp_salt_segments
 use MOM_open_boundary,         only : open_boundary_register_restarts
-use MOM_PressureForce,         only : PressureForce, PressureForce_init, PressureForce_CS
 use MOM_set_visc,              only : set_viscous_BBL, set_viscous_ML, set_visc_init
 use MOM_set_visc,              only : set_visc_register_restarts, set_visc_CS
 use MOM_sponge,                only : init_sponge_diags, sponge_CS
@@ -102,7 +94,6 @@ use MOM_sum_output,            only : write_energy, accumulate_net_input
 use MOM_sum_output,            only : MOM_sum_output_init, sum_output_CS
 use MOM_ALE_sponge,            only : init_ALE_sponge_diags, ALE_sponge_CS
 use MOM_thickness_diffuse,     only : thickness_diffuse, thickness_diffuse_init, thickness_diffuse_CS
-use MOM_tidal_forcing,         only : tidal_forcing_init, tidal_forcing_CS
 use MOM_tracer_advect,         only : advect_tracer, tracer_advect_init
 use MOM_tracer_advect,         only : tracer_advect_end, tracer_advect_CS
 use MOM_tracer_hor_diff,       only : tracer_hordiff, tracer_hor_diff_init
@@ -119,8 +110,6 @@ use MOM_transcribe_grid,       only : copy_dyngrid_to_MOM_grid, copy_MOM_grid_to
 use MOM_variables,             only : surface, allocate_surface_state, deallocate_surface_state
 use MOM_variables,             only : thermo_var_ptrs, vertvisc_type
 use MOM_variables,             only : accel_diag_ptrs, cont_diag_ptrs, ocean_internal_state
-use MOM_vert_friction,         only : vertvisc, vertvisc_remnant
-use MOM_vert_friction,         only : vertvisc_limit_vel, vertvisc_init
 use MOM_verticalGrid,          only : verticalGrid_type, verticalGridInit, verticalGridEnd
 use MOM_verticalGrid,          only : get_thickness_units, get_flux_units, get_tr_flux_units
 use MOM_wave_interface,        only : wave_parameters_CS, waves_end
@@ -134,7 +123,6 @@ use MOM_offline_main,          only : offline_redistribute_residual, offline_dia
 use MOM_offline_main,          only : offline_fw_fluxes_into_ocean, offline_fw_fluxes_out_ocean
 use MOM_offline_main,          only : offline_advection_layer, offline_transport_end
 use MOM_ALE,                   only : ale_offline_tracer_final, ALE_main_offline
-
 
 implicit none ; private
 
@@ -152,28 +140,28 @@ end type MOM_diag_IDs
 !! the state of the ocean.
 type, public :: MOM_control_struct ; private
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_,NKMEM_) :: &
-    h, &      !< layer thickness (m or kg/m2 (H))
-    T, &      !< potential temperature (degrees C)
-    S         !< salinity (ppt)
+    h, &            !< layer thickness (m or kg/m2 (H))
+    T, &            !< potential temperature (degrees C)
+    S               !< salinity (ppt)
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: &
-    u,  &     !< zonal velocity component (m/s)
-    uh, &     !< uh = u * h * dy at u grid points (m3/s or kg/s)
-    uhtr      !< accumulated zonal thickness fluxes to advect tracers (m3 or kg)
+    u,  &           !< zonal velocity component (m/s)
+    uh, &           !< uh = u * h * dy at u grid points (m3/s or kg/s)
+    uhtr            !< accumulated zonal thickness fluxes to advect tracers (m3 or kg)
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: &
-    v,  &     !< meridional velocity (m/s)
-    vh, &     !< vh = v * h * dx at v grid points (m3/s or kg/s)
-    vhtr      !< accumulated meridional thickness fluxes to advect tracers (m3 or kg)
+    v,  &           !< meridional velocity (m/s)
+    vh, &           !< vh = v * h * dx at v grid points (m3/s or kg/s)
+    vhtr            !< accumulated meridional thickness fluxes to advect tracers (m3 or kg)
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
-    ssh_rint, &    !< A running time integral of the sea surface height, in s m.
-    ave_ssh_ibc, & !< time-averaged (over a forcing time step) sea surface height
-              !! with a correction for the inverse barometer (meter)
-    eta_av_bc !< free surface height or column mass time averaged over the last
-              !! baroclinic dynamics time step (m or kg/m2)
+    ssh_rint, &     !< A running time integral of the sea surface height, in s m.
+    ave_ssh_ibc, &  !< time-averaged (over a forcing time step) sea surface height
+                    !! with a correction for the inverse barometer (meter)
+    eta_av_bc       !< free surface height or column mass time averaged over the last
+                    !! baroclinic dynamics time step (m or kg/m2)
   real, pointer, dimension(:,:) :: &
-    Hml => NULL() !< active mixed layer depth, in m
+    Hml => NULL()   !< active mixed layer depth, in m
   real :: time_in_cycle !< The running time of the current time-stepping cycle
-              !! in calls that step the dynamics, and also the length of the
-              !! time integral of ssh_rint, in s.
+                    !! in calls that step the dynamics, and also the length of
+                    !! the time integral of ssh_rint, in s.
 
   type(ocean_grid_type) :: G  !< structure containing metrics and grid info
   type(verticalGrid_type), pointer :: &
@@ -196,11 +184,11 @@ type, public :: MOM_control_struct ; private
   integer :: ndyn_per_adv = 0 !< Number of calls to dynamics since the last call to advection
                               !! Must be saved if thermo spans coupling?
 
-  type(diag_ctrl)       :: diag    !< structure to regulate diagnostic output timing
-  type(vertvisc_type)   :: visc    !< structure containing vertical viscosities,
-                                   !! bottom drag viscosities, and related fields
-  type(MEKE_type), pointer :: MEKE => NULL()  !<  structure containing fields
-                                   !! related to the Mesoscale Eddy Kinetic Energy
+  type(diag_ctrl)     :: diag !< structure to regulate diagnostic output timing
+  type(vertvisc_type) :: visc !< structure containing vertical viscosities,
+                              !! bottom drag viscosities, and related fields
+  type(MEKE_type), pointer :: MEKE => NULL() !<  structure containing fields
+                              !! related to the Mesoscale Eddy Kinetic Energy
 
   logical :: adiabatic               !< If true, there are no diapycnal mass fluxes, and no calls
                                      !! to routines to calculate or apply diapycnal fluxes.
@@ -250,54 +238,52 @@ type, public :: MOM_control_struct ; private
   type(time_type) :: Z_diag_time     !< next time to compute Z-space diagnostics
 
   real, pointer, dimension(:,:,:) :: &
-    h_pre_dyn => NULL(), & !< The thickness before the transports, in H.
-    T_pre_dyn => NULL(), & !< Temperature before the transports, in degC.
-    S_pre_dyn => NULL()    !< Salinity before the transports, in psu.
-  type(accel_diag_ptrs) :: ADp     !< structure containing pointers to accelerations,
-                                   !! for derived diagnostics (e.g., energy budgets)
-  type(cont_diag_ptrs)  :: CDp     !< structure containing pointers to continuity equation
-                                   !! terms, for derived diagnostics (e.g., energy budgets)
+    h_pre_dyn => NULL(), &      !< The thickness before the transports, in H.
+    T_pre_dyn => NULL(), &      !< Temperature before the transports, in degC.
+    S_pre_dyn => NULL()         !< Salinity before the transports, in psu.
+  type(accel_diag_ptrs) :: ADp  !< structure containing pointers to accelerations,
+                                !! for derived diagnostics (e.g., energy budgets)
+  type(cont_diag_ptrs)  :: CDp  !< structure containing pointers to continuity equation
+                                !! terms, for derived diagnostics (e.g., energy budgets)
   real, pointer, dimension(:,:,:) :: &
-    u_prev => NULL(), &  !< previous value of u stored for diagnostics
-    v_prev => NULL()     !< previous value of v stored for diagnostics
+    u_prev => NULL(), &         !< previous value of u stored for diagnostics
+    v_prev => NULL()            !< previous value of v stored for diagnostics
 
-  logical :: interp_p_surf           !< If true, linearly interpolate surface pressure
-                                     !! over the coupling time step, using specified value
-                                     !! at the end of the coupling step. False by default.
-  logical :: p_surf_prev_set         !< If true, p_surf_prev has been properly set from
-                                     !! a previous time-step or the ocean restart file.
-                                     !! This is only valid when interp_p_surf is true.
+  logical :: interp_p_surf      !< If true, linearly interpolate surface pressure
+                                !! over the coupling time step, using specified value
+                                !! at the end of the coupling step. False by default.
+  logical :: p_surf_prev_set    !< If true, p_surf_prev has been properly set from
+                                !! a previous time-step or the ocean restart file.
+                                !! This is only valid when interp_p_surf is true.
   real, pointer, dimension(:,:) :: &
-    p_surf_prev  => NULL(), & !< surface pressure (Pa) at end  previous call to step_MOM
-    p_surf_begin => NULL(), & !< surface pressure (Pa) at start of step_MOM_dyn_...
-    p_surf_end   => NULL()    !< surface pressure (Pa) at end   of step_MOM_dyn_...
-
-  ! Not needed in CS?
-  real :: missing=-1.0e34            !< missing data value for masked fields
+    p_surf_prev  => NULL(), &   !< surface pressure (Pa) at end  previous call to step_MOM
+    p_surf_begin => NULL(), &   !< surface pressure (Pa) at start of step_MOM_dyn_...
+    p_surf_end   => NULL()      !< surface pressure (Pa) at end   of step_MOM_dyn_...
 
   ! Variables needed to reach between start and finish phases of initialization
-  logical :: write_IC                !< If true, then the initial conditions will be written to file
-  character(len=120) :: IC_file      !< A file into which the initial conditions are
-                                     !! written in a new run if SAVE_INITIAL_CONDS is true.
+  logical :: write_IC           !< If true, then the initial conditions will be written to file
+  character(len=120) :: IC_file !< A file into which the initial conditions are
+                                !! written in a new run if SAVE_INITIAL_CONDS is true.
 
-  logical :: calc_rho_for_sea_lev    !< If true, calculate rho to convert pressure to sea level
+  logical :: calc_rho_for_sea_lev !< If true, calculate rho to convert pressure to sea level
 
   ! These elements are used to control the calculation and error checking of the surface state
-  real :: Hmix                       !< Diagnostic mixed layer thickness over which to
-                                     !! average surface tracer properties (in meter) when
-                                     !! bulk mixed layer is not used, or a negative value
-                                     !! if a bulk mixed layer is being used.
-  real :: Hmix_UV                    !< Depth scale over which to average surface flow to
-                                     !! feedback to the coupler/driver (m) when
-                                     !! bulk mixed layer is not used, or a negative value
-                                     !! if a bulk mixed layer is being used.
-  logical :: check_bad_surface_vals  !< If true, scan surface state for ridiculous values.
-  real    :: bad_val_ssh_max         !< Maximum SSH before triggering bad value message
-  real    :: bad_val_sst_max         !< Maximum SST before triggering bad value message
-  real    :: bad_val_sst_min         !< Minimum SST before triggering bad value message
-  real    :: bad_val_sss_max         !< Maximum SSS before triggering bad value message
-  real    :: bad_val_column_thickness!< Minimum column thickness before triggering bad value message
+  real :: Hmix                  !< Diagnostic mixed layer thickness over which to
+                                !! average surface tracer properties (in meter) when
+                                !! bulk mixed layer is not used, or a negative value
+                                !! if a bulk mixed layer is being used.
+  real :: Hmix_UV               !< Depth scale over which to average surface flow to
+                                !! feedback to the coupler/driver (m) when
+                                !! bulk mixed layer is not used, or a negative value
+                                !! if a bulk mixed layer is being used.
+  logical :: check_bad_sfc_vals !< If true, scan surface state for ridiculous values.
+  real    :: bad_val_ssh_max    !< Maximum SSH before triggering bad value message
+  real    :: bad_val_sst_max    !< Maximum SST before triggering bad value message
+  real    :: bad_val_sst_min    !< Minimum SST before triggering bad value message
+  real    :: bad_val_sss_max    !< Maximum SSS before triggering bad value message
+  real    :: bad_vol_col_thick  !< Minimum column thickness before triggering bad value message
 
+  ! Structures and handles used for diagnostics.
   type(MOM_diag_IDs) :: IDs
   type(transport_diag_IDs) :: transport_IDs
   type(surface_diag_IDs) :: sfc_IDs
@@ -363,7 +349,6 @@ integer :: id_clock_offline_tracer
 
 contains
 
-
 !> This subroutine orchestrates the time stepping of MOM.  The adiabatic
 !! dynamics are stepped by calls to one of the step_MOM_dyn_...routines.
 !! The action of lateral processes on tracers occur in calls to
@@ -371,26 +356,26 @@ contains
 !! occur inside of diabatic.
 subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS, Waves, &
                     do_dynamics, do_thermodynamics, start_cycle, end_cycle, cycle_length)
-  type(mech_forcing), intent(inout)  :: forces        !< A structure with the driving mechanical forces
-  type(forcing),      intent(inout)  :: fluxes        !< pointers to forcing fields
-  type(surface),      intent(inout)  :: sfc_state     !< surface ocean state
-  type(time_type),    intent(in)     :: Time_start    !< starting time of a segment, as a time type
-  real,               intent(in)     :: time_interval !< time interval covered by this run segment, in s.
-  type(MOM_control_struct), pointer  :: CS            !< control structure from initialize_MOM
-  type(Wave_parameters_CS), pointer, optional, intent(in) :: &
-       Waves                                          !< point CS with waves
-  logical,  optional, intent(in)     :: do_dynamics   !< Present and false, do not do updates due
-                                                      !! to the dynamics.
-  logical,  optional, intent(in)     :: do_thermodynamics  !< Present and false, do not do updates due
-                                                      !! to the thermodynamics or remapping.
-  logical,  optional, intent(in)     :: start_cycle   !< This indicates whether this call is to be
-                                                      !! treated as the first call to step_MOM in a
-                                                      !! time-stepping cycle; missing is like true.
-  logical,  optional, intent(in)     :: end_cycle     !< This indicates whether this call is to be
-                                                      !! treated as the last call to step_MOM in a
-                                                      !! time-stepping cycle; missing is like true.
-  real,     optional, intent(in)     :: cycle_length  !< The amount of time in a coupled time
-                                                      !! stepping cycle, in s.
+  type(mech_forcing), intent(inout) :: forces        !< A structure with the driving mechanical forces
+  type(forcing),      intent(inout) :: fluxes        !< pointers to forcing fields
+  type(surface),      intent(inout) :: sfc_state     !< surface ocean state
+  type(time_type),    intent(in)    :: Time_start    !< starting time of a segment, as a time type
+  real,               intent(in)    :: time_interval !< time interval covered by this run segment, in s.
+  type(MOM_control_struct), pointer :: CS            !< control structure from initialize_MOM
+  type(Wave_parameters_CS), pointer, &
+            optional, intent(in)    :: Waves         !< An optional pointer to a wave proptery CS
+  logical,  optional, intent(in)    :: do_dynamics   !< Present and false, do not do updates due
+                                                     !! to the dynamics.
+  logical,  optional, intent(in)    :: do_thermodynamics  !< Present and false, do not do updates due
+                                                     !! to the thermodynamics or remapping.
+  logical,  optional, intent(in)    :: start_cycle   !< This indicates whether this call is to be
+                                                     !! treated as the first call to step_MOM in a
+                                                     !! time-stepping cycle; missing is like true.
+  logical,  optional, intent(in)    :: end_cycle     !< This indicates whether this call is to be
+                                                     !! treated as the last call to step_MOM in a
+                                                     !! time-stepping cycle; missing is like true.
+  real,     optional, intent(in)    :: cycle_length  !< The amount of time in a coupled time
+                                                     !! stepping cycle, in s.
 
   ! local
   type(ocean_grid_type), pointer :: G ! pointer to a structure containing
@@ -568,6 +553,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS, Wa
     ! Set the local time to the end of the time step.
     Time_local = Time_start + set_time(int(floor(CS%rel_time+0.5)))
 
+    !### Update_Stokes_Drift must be behind a do_dyn or a do_thermo test.
     if (CS%UseWaves) then
     ! Update wave information, which is presently kept static over each call to step_mom
       !bgr 3/15/18: Need to enable_averaging here to enable output of Stokes drift from the
@@ -727,6 +713,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS, Wa
       ! Diagnostics that require the complete state to be up-to-date can be calculated.
 
       call enable_averaging(CS%t_dyn_rel_diag, Time_local, CS%diag)
+      !### This is the one place where fluxes might used if do_thermo=.false. Is this correct?
       call calculate_diagnostic_fields(u, v, h, CS%uh, CS%vh, CS%tv, CS%ADp,  &
                           CS%CDp, fluxes, CS%t_dyn_rel_diag, CS%diag_pre_sync,&
                           G, GV, CS%diagnostics_CSp)
@@ -1232,12 +1219,12 @@ end subroutine step_MOM_thermo
 !! the work is very preliminary. Some more detail about this capability along with some of the subroutines
 !! called here can be found in tracers/MOM_offline_control.F90
 subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS)
-  type(mech_forcing), intent(in)     :: forces        !< A structure with the driving mechanical forces
-  type(forcing),    intent(inout)    :: fluxes        !< pointers to forcing fields
-  type(surface),    intent(inout)    :: sfc_state     !< surface ocean state
-  type(time_type),  intent(in)       :: Time_start    !< starting time of a segment, as a time type
-  real,             intent(in)       :: time_interval !< time interval
-  type(MOM_control_struct), pointer  :: CS            !< control structure from initialize_MOM
+  type(mech_forcing), intent(in)    :: forces        !< A structure with the driving mechanical forces
+  type(forcing),      intent(inout) :: fluxes        !< pointers to forcing fields
+  type(surface),      intent(inout) :: sfc_state     !< surface ocean state
+  type(time_type),    intent(in)    :: Time_start    !< starting time of a segment, as a time type
+  real,               intent(in)    :: time_interval !< time interval
+  type(MOM_control_struct), pointer :: CS            !< control structure from initialize_MOM
 
   ! Local pointers
   type(ocean_grid_type),      pointer :: G  => NULL() ! Pointer to a structure containing
@@ -1762,11 +1749,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "updates, with even numbers (or 0) used for x- first \n"//&
                  "and odd numbers used for y-first.", default=0)
 
-  call get_param(param_file, "MOM", "CHECK_BAD_SURFACE_VALS", &
-                 CS%check_bad_surface_vals, &
+  call get_param(param_file, "MOM", "CHECK_BAD_SURFACE_VALS", CS%check_bad_sfc_vals, &
                  "If true, check the surface state for ridiculous values.", &
                  default=.false.)
-  if (CS%check_bad_surface_vals) then
+  if (CS%check_bad_sfc_vals) then
     call get_param(param_file, "MOM", "BAD_VAL_SSH_MAX", CS%bad_val_ssh_max, &
                  "The value of SSH above which a bad value message is \n"//&
                  "triggered, if CHECK_BAD_SURFACE_VALS is true.", units="m", &
@@ -1783,10 +1769,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "The value of SST below which a bad value message is \n"//&
                  "triggered, if CHECK_BAD_SURFACE_VALS is true.", &
                  units="deg C", default=-2.1)
-    call get_param(param_file, "MOM", "BAD_VAL_COLUMN_THICKNESS", CS%bad_val_column_thickness, &
-         "The value of column thickness below which a bad value message is \n"//&
-         "triggered, if CHECK_BAD_SURFACE_VALS is true.", units="m", &
-                          default=0.0)
+    call get_param(param_file, "MOM", "BAD_VAL_COLUMN_THICKNESS", CS%bad_vol_col_thick, &
+                 "The value of column thickness below which a bad value message is \n"//&
+                 "triggered, if CHECK_BAD_SURFACE_VALS is true.", units="m", &
+                 default=0.0)
   endif
 
   call get_param(param_file, "MOM", "SAVE_INITIAL_CONDS", save_IC, &
@@ -2793,14 +2779,14 @@ subroutine extract_surface_state(CS, sfc_state)
     call call_tracer_surface_state(sfc_state, h, G, CS%tracer_flow_CSp)
   endif
 
-  if (CS%check_bad_surface_vals) then
+  if (CS%check_bad_sfc_vals) then
     numberOfErrors=0 ! count number of errors
     do j=js,je; do i=is,ie
       if (G%mask2dT(i,j)>0.) then
         localError = sfc_state%sea_lev(i,j)<=-G%bathyT(i,j)       &
                 .or. sfc_state%sea_lev(i,j)>= CS%bad_val_ssh_max  &
                 .or. sfc_state%sea_lev(i,j)<=-CS%bad_val_ssh_max  &
-                .or. sfc_state%sea_lev(i,j)+G%bathyT(i,j) < CS%bad_val_column_thickness
+                .or. sfc_state%sea_lev(i,j)+G%bathyT(i,j) < CS%bad_vol_col_thick
         if (use_temperature) localError = localError &
                 .or. sfc_state%SSS(i,j)<0.                        &
                 .or. sfc_state%SSS(i,j)>=CS%bad_val_sss_max       &

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -649,7 +649,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS, Wa
 
       call step_MOM_dynamics(forces, CS%p_surf_begin, CS%p_surf_end, dt, &
                              dt_therm_here, bbl_time_int, CS, &
-                             Time_local, n, WAVES=Waves)
+                             Time_local, WAVES=Waves)
 
       !===========================================================================
       ! This is the start of the tracer advection part of the algorithm.
@@ -795,7 +795,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS, Wa
 end subroutine step_MOM
 
 subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
-                             bbl_time_int, CS, Time_local, dyn_call, WAVES)
+                             bbl_time_int, CS, Time_local, WAVES)
   type(mech_forcing), intent(in)    :: forces     !< A structure with the driving mechanical forces
   real, dimension(:,:), pointer     :: p_surf_begin !< A pointer (perhaps NULL) to the surface
                                                   !! pressure at the beginning of this dynamic
@@ -811,8 +811,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
                                                   !! in s, or zero not to update the properties.
   type(MOM_control_struct), pointer :: CS         !< control structure from initialize_MOM
   type(time_type),    intent(in)    :: Time_local !< Starting time of a segment, as a time type
-  integer,            intent(in)    :: dyn_call   !< A count of the calls to step_MOM_dynamics
-                                                  !! within this forcing timestep.
   type(wave_parameters_CS), pointer, intent(in), optional :: &
        WAVES                                      !<Container for wave related parameters
 
@@ -885,7 +883,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
         calc_dtbt = .true.
         CS%dtbt_reset_time = CS%dtbt_reset_time + CS%dtbt_reset_interval
       endif
-      if (dyn_call==1) then ; calc_dtbt = .true. ; endif
     endif
 
     call step_MOM_dyn_split_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
@@ -1691,10 +1688,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     call get_param(param_file, "MOM", "DTBT_RESET_PERIOD", CS%dtbt_reset_period, &
                  "The period between recalculations of DTBT (if DTBT <= 0). \n"//&
                  "If DTBT_RESET_PERIOD is negative, DTBT is set based \n"//&
-                 "only on information available at initialization.  If \n"//&
-                 "dynamic, DTBT will be set at least every forcing time \n"//&
-                 "step, and if 0, every dynamics time step.  The default is \n"//&
-                 "set by DT_THERM.  This is only used if SPLIT is true.", &
+                 "only on information available at initialization.  If 0, \n"//&
+                 "DTBT will be set every dynamics time step. The default \n"//&
+                 "is set by DT_THERM.  This is only used if SPLIT is true.", &
                  units="s", default=default_val, do_not_read=(dtbt > 0.0))
   endif
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3799,26 +3799,34 @@ end subroutine bt_mass_source
 !! barotropic calculation and initializes any barotropic fields that have not
 !! already been initialized.
 subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
-                           restart_CS, BT_cont, tides_CSp)
-  type(ocean_grid_type),            intent(inout) :: G          !< The ocean's grid structure.
-  type(verticalGrid_type),          intent(in)    :: GV         !< The ocean's vertical grid structure.
-  real, intent(in), dimension(SZIB_(G),SZJ_(G),SZK_(G)) :: u    !< The zonal velocity, in m s-1.
-  real, intent(in), dimension(SZI_(G),SZJB_(G),SZK_(G)) :: v    !< The meridional velocity, in m s-1.
-  real, intent(in), dimension(SZI_(G),SZJ_(G),SZK_(G))  :: h    !< Layer thicknesses, in H (usually m or kg m-2).
-  real, intent(in), dimension(SZI_(G),SZJ_(G))    :: eta        !< Free surface height or column mass anomaly, in
-                                                                !! m or kg m-2.
-  type(time_type), target,          intent(in)    :: Time       !< The current model time.
-  type(param_file_type),            intent(in)    :: param_file !< A structure to parse for run-time parameters.
-  type(diag_ctrl), target,          intent(inout) :: diag       !< A structure that is used to regulate diagnostic
-                                                                !! output.
-  type(barotropic_CS),              pointer       :: CS         !< A pointer to the control structure for this module
-                                                                !! that is set in register_barotropic_restarts.
-  type(MOM_restart_CS),             pointer       :: restart_CS !< A pointer to the restart control structure.
-  type(BT_cont_type),     optional, pointer       :: BT_cont    !< A structure with elements that describe the
-                                                                !! effective open face areas as a function of
-                                                                !! barotropic flow.
-  type(tidal_forcing_CS), optional, pointer       :: tides_CSp  !< A pointer to the control structure of the tide
-                                                                !! module.
+                           restart_CS, calc_dtbt, BT_cont, tides_CSp)
+  type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: u    !< The zonal velocity, in m s-1.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                           intent(in)    :: v    !< The meridional velocity, in m s-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2).
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)    :: eta  !< Free surface height or column mass anomaly, in
+                                                 !! m or kg m-2.
+  type(time_type), target, intent(in)    :: Time !< The current model time.
+  type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters.
+  type(diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic
+                                                 !! output.
+  type(barotropic_CS),     pointer       :: CS   !< A pointer to the control structure for this module
+                                                 !! that is set in register_barotropic_restarts.
+  type(MOM_restart_CS),    pointer       :: restart_CS !< A pointer to the restart control structure.
+  logical,                 intent(out)   :: calc_dtbt  !< If true, the barotropic time step must
+                                                 !! be recalculated before stepping.
+  type(BT_cont_type), optional, &
+                           pointer       :: BT_cont    !< A structure with elements that describe the
+                                                 !! effective open face areas as a function of
+                                                 !! barotropic flow.
+  type(tidal_forcing_CS), optional, &
+                           pointer       :: tides_CSp  !< A pointer to the control structure of the
+                                                 !! tide module.
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -3828,7 +3836,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
   real :: gtot_estimate ! Summing GV%g_prime gives an upper-bound estimate for pbce.
   real :: SSH_extra     ! An estimate of how much higher SSH might get, for use
                         ! in calculating the safe external wave speed.
-  real :: dtbt_input
+  real :: dtbt_input, dtbt_tmp
   real :: wave_drag_scale ! A scaling factor for the barotropic linear wave drag
                           ! piston velocities.
   character(len=200) :: inputdir       ! The directory in which to find input files.
@@ -4082,7 +4090,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
                  "gravity waves) to 1 (for a backward Euler treatment). \n"//&
                  "In practice, BEBT must be greater than about 0.05.", &
                  units="nondim", default=0.1)
-  call get_param(param_file, mdl, "DTBT", CS%dtbt, &
+  call get_param(param_file, mdl, "DTBT", dtbt_input, &
                  "The barotropic time step, in s. DTBT is only used with \n"//&
                  "the split explicit time stepping. To set the time step \n"//&
                  "automatically based the maximum stable value use 0, or \n"//&
@@ -4239,13 +4247,22 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, param_file, diag, CS, &
     endif
   endif
 
+  CS%dtbt_fraction = 0.98 ; if (dtbt_input < 0.0) CS%dtbt_fraction = -dtbt_input
+  
+  dtbt_tmp = -1.0
+  if (query_initialized(CS%dtbt, "DTBT", restart_CS)) dtbt_tmp = CS%dtbt
+
   ! Estimate the maximum stable barotropic time step.
-  dtbt_input = CS%dtbt
-  CS%dtbt_fraction = 0.98 ; if (CS%dtbt < 0.0) CS%dtbt_fraction = -CS%dtbt
   gtot_estimate = 0.0
   do k=1,G%ke ; gtot_estimate = gtot_estimate + GV%g_prime(K) ; enddo
   call set_dtbt(G, GV, CS, gtot_est = gtot_estimate, SSH_add = SSH_extra)
-  if (dtbt_input > 0.0) CS%dtbt = dtbt_input
+
+  if (dtbt_input > 0.0) then
+    CS%dtbt = dtbt_input
+  elseif (dtbt_tmp > 0.0) then
+    CS%dtbt = dtbt_tmp
+  endif
+  if ((dtbt_tmp > 0.0) .and. (dtbt_input > 0.0)) calc_dtbt = .false.
 
   call log_param(param_file, mdl, "DTBT as used", CS%dtbt)
   call log_param(param_file, mdl, "estimated maximum DTBT", CS%dtbt_max)
@@ -4524,6 +4541,9 @@ subroutine register_barotropic_restarts(HI, GV, param_file, CS, restart_CS)
   endif
   call register_restart_field(CS%uhbt_IC, vd(2), .false., restart_CS)
   call register_restart_field(CS%vhbt_IC, vd(3), .false., restart_CS)
+
+  call register_restart_field(CS%dtbt, "DTBT", .false., restart_CS, &
+                              longname="Barotropic timestep", units="seconds")
 
 end subroutine register_barotropic_restarts
 

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -914,7 +914,7 @@ end subroutine register_restarts_dyn_split_RK2
 subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_file, &
                       diag, CS, restart_CS, dt, Accel_diag, Cont_diag, MIS, &
                       VarMix, MEKE, OBC, update_OBC_CSp, ALE_CSp, setVisc_CSp, &
-                      visc, dirs, ntrunc)
+                      visc, dirs, ntrunc, calc_dtbt)
   type(ocean_grid_type),                     intent(inout) :: G           !< ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV          !< ocean vertical grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: u           !< zonal velocity (m/s)
@@ -942,6 +942,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
   type(directories),                         intent(in)    :: dirs        !< contains directory paths
   integer, target,                           intent(inout) :: ntrunc      !< A target for the variable that records the number of times
                                                                           !! the velocity is truncated (this should be 0).
+  logical,                                   intent(out)   :: calc_dtbt   !< If true, recalculate the barotropic time step
 
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_tmp
   character(len=40) :: mdl = "MOM_dynamics_split_RK2" ! This module's name.
@@ -1074,7 +1075,8 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, param_fil
   do j=js,je ; do i=is,ie ; eta(i,j) = CS%eta(i,j) ; enddo ; enddo
 
   call barotropic_init(u, v, h, CS%eta, Time, G, GV, param_file, diag, &
-                       CS%barotropic_CSp, restart_CS, CS%BT_cont, CS%tides_CSp)
+                       CS%barotropic_CSp, restart_CS, calc_dtbt, CS%BT_cont, &
+                       CS%tides_CSp)
 
   if (.not. query_initialized(CS%diffu,"diffu",restart_CS) .or. &
       .not. query_initialized(CS%diffv,"diffv",restart_CS)) &

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -2496,7 +2496,7 @@ end subroutine forcing_diagnostics
 
 
 !> Conditionally allocate fields within the forcing type
-subroutine allocate_forcing_type(G, fluxes, water, heat, ustar, press, shelf, iceberg)
+subroutine allocate_forcing_type(G, fluxes, water, heat, ustar, press, shelf, iceberg, salt)
   type(ocean_grid_type), intent(in) :: G       !< Ocean grid structure
   type(forcing),      intent(inout) :: fluxes  !< Forcing fields structure
   logical, optional,     intent(in) :: water   !< If present and true, allocate water fluxes
@@ -2505,6 +2505,7 @@ subroutine allocate_forcing_type(G, fluxes, water, heat, ustar, press, shelf, ic
   logical, optional,     intent(in) :: press   !< If present and true, allocate p_surf and related fields
   logical, optional,     intent(in) :: shelf   !< If present and true, allocate fluxes for ice-shelf
   logical, optional,     intent(in) :: iceberg !< If present and true, allocate fluxes for icebergs
+  logical, optional,     intent(in) :: salt    !< If present and true, allocate salt fluxes
 
   ! Local variables
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -2534,6 +2535,8 @@ subroutine allocate_forcing_type(G, fluxes, water, heat, ustar, press, shelf, ic
   call myAlloc(fluxes%latent_evap_diag,isd,ied,jsd,jed, heat)
   call myAlloc(fluxes%latent_fprec_diag,isd,ied,jsd,jed, heat)
   call myAlloc(fluxes%latent_frunoff_diag,isd,ied,jsd,jed, heat)
+
+  call myAlloc(fluxes%salt_flux,isd,ied,jsd,jed, salt)
 
   if (present(heat) .and. present(water)) then ; if (heat .and. water) then
     call myAlloc(fluxes%heat_content_cond,isd,ied,jsd,jed, .true.)

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -115,11 +115,11 @@ contains
 subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_data)
 
   type(ocean_grid_type),                intent(in) :: G !< The ocean's grid structure (in).
+  integer,                              intent(in) :: nz_data !< The total number of sponge input layers  (in).
   real, dimension(SZI_(G),SZJ_(G)),     intent(in) :: Iresttime !< The inverse of the restoring time, in s-1 (in).
   type(param_file_type),                intent(in) :: param_file !< A structure indicating the open file to parse for model parameter values (in).
   type(ALE_sponge_CS),                  pointer    :: CS !< A pointer that is set to point to the control structure for this module (in/out).
   real, dimension(SZI_(G),SZJ_(G),nz_data), intent(in) :: data_h !< The thicknesses of the sponge input layers.  (in).
-  integer,                              intent(in)     :: nz_data !< The total number of sponge input layers  (in).
 
 
 ! This include declares and sets the variable "version".

--- a/src/parameterizations/vertical/MOM_KPP.F90
+++ b/src/parameterizations/vertical/MOM_KPP.F90
@@ -621,20 +621,9 @@ subroutine KPP_calculate(CS, G, GV, h, Temp, Salt, u, v, EOS, uStar, &
 
   if (CS%id_Kd_in > 0) call post_data(CS%id_Kd_in, Kt, CS%diag)
 
-!$OMP parallel do default(none) shared(G,GV,CS,EOS,uStar,Temp,Salt,u,v,h,GoRho,       &
-!$OMP                                  buoyFlux, nonLocalTransHeat,                   &
-!$OMP                                  nonLocalTransScalar,Kt,Ks,Kv)                  &
-!$OMP                     firstprivate(nonLocalTrans)                                 &
-!$OMP                          private(Coriolis,surfFricVel,SLdepth_0d,hTot,surfTemp, &
-!$OMP                                  surfHtemp,surfSalt,surfHsalt,surfU,            &
-!$OMP                                  surfHu,surfV,surfHv,iFaceHeight,               &
-!$OMP                                  pRef,km1,cellHeight,Uk,Vk,deltaU2,             &
-!$OMP                                  rho1,rhoK,rhoKm1,deltaRho,N2_1d,N_1d,delH,     &
-!$OMP                                  surfBuoyFlux,Ws_1d,Vt2_1d,BulkRi_1d,           &
-!$OMP                                  OBLdepth_0d,zBottomMinusOffset,Kdiffusivity,   &
-!$OMP                                  Kviscosity,sigma,kOBL,kk,pres_1D,Temp_1D,      &
-!$OMP                                  Salt_1D,rho_1D,surfBuoyFlux2,ksfc,dh,hcorr)
-
+  !$OMP parallel do default(private) firstprivate(nonLocalTrans) &
+  !$OMP                shared(G,GV,CS,EOS,uStar,Temp,Salt,u,v,h,GoRho,Waves,&
+  !$OMP                       buoyFlux,nonLocalTransHeat,nonLocalTransScalar,Kt,Ks,Kv)
   ! loop over horizontal points on processor
   do j = G%jsc, G%jec
     do i = G%isc, G%iec
@@ -1211,7 +1200,7 @@ subroutine KPP_NonLocalTransport_temp(CS, G, GV, h, nonLocalTrans, surfFlux, &
 
 
   dtracer(:,:,:) = 0.0
-!$OMP parallel do default(none) shared(G,GV,dtracer,nonLocalTrans,h,surfFlux,CS,scalar,dt)
+  !$OMP parallel do default(shared)
   do k = 1, G%ke
     do j = G%jsc, G%jec
       do i = G%isc, G%iec
@@ -1269,7 +1258,7 @@ subroutine KPP_NonLocalTransport_saln(CS, G, GV, h, nonLocalTrans, surfFlux, dt,
 
 
   dtracer(:,:,:) = 0.0
-!$OMP parallel do default(none) shared(G,GV,dtracer,nonLocalTrans,h,surfFlux,CS,scalar,dt)
+  !$OMP parallel do default(shared)
   do k = 1, G%ke
     do j = G%jsc, G%jec
       do i = G%isc, G%iec


### PR DESCRIPTION
  Eliminated the requirement to recalculate DTBT every coupled timestep, and added DTBT
to the restart files to retain reproducibility across restarts.  By default if DTBT is set dynamically,
it is still calculated every coupled timestep, but explicitly setting DTBT_RESET_PERIOD to be
longer than the coupled timestep now results in less frequent updates to DTBT.
Also modified the log_param documentation of DTBT_RESET_PERIOD to reflect this
new behavior.  This could change answers, but it just happens that the values of
DTBT are not changed with the existing suite of test cases.  This PR also includes
several other minor miscellaneous changes. The MOM_parameter_doc files are
altered by this change.
 - NOAA-GFDL/MOM6@a680bf7 (*)Do not recalculate DTBT every coupled timestep
 - NOAA-GFDL/MOM6@5579d26 +Allow DTBT recalculation interval to span steps
 - NOAA-GFDL/MOM6@1efd1f9 +Add optional arg salt to allocate_forcing_type
 - NOAA-GFDL/MOM6@5312ee1 Reordered initialize_ALE_sponge_fixed declarations
 - NOAA-GFDL/MOM6@17a28a6 Corrected openMP calls in vertvisc
 - NOAA-GFDL/MOM6@8e0debd Corrected openMP calls in MOM_KPP.F90
 - NOAA-GFDL/MOM6@e0a2328 (*+) Corrected a bug setting rigidity from icebergs
 - NOAA-GFDL/MOM6@2d07aa0 Removed unused module use statements from MOM.F90