### PR TITLE
gitlab: New build stages to test compiling without libraries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,30 @@ gnu:repro:
     - time make -f MRS/Makefile.build MOM6_SRC=../ static_gnu -s -j
     - time tar zvcf $CACHE_DIR/build-gnu-repro-$CI_PIPELINE_ID.tgz `find build/gnu -name MOM6`
 
+gnu:ocean-only-nolibs:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - time tar zxf $CACHE_DIR/tests_$CI_PIPELINE_ID.tgz && cd tests
+    - make -f MRS/Makefile.build build/gnu/env && cd build/gnu
+    # mkdir -p build/gnu/repro/symmetric_dynamic/ocean_only && cd build/gnu/repro/symmetric_dynamic/ocean_only
+    - ../../MOM6-examples/src/mkmf/bin/list_paths -l ../../../config_src/{solo_driver,dynamic_symmetric} ../../../src ../../MOM6-examples/src/FMS
+    - ../../MOM6-examples/src/mkmf/bin/mkmf -t ../../MOM6-examples/src/mkmf/templates/ncrc-gnu.mk -p MOM6 -c"-Duse_libMPI -Duse_netCDF" path_names
+    - time (source ./env ; make NETCDF=3 REPRO=1 MOM6 -s -j)
+
+gnu:ice-ocean-nolibs:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - time tar zxf $CACHE_DIR/tests_$CI_PIPELINE_ID.tgz && cd tests
+    - make -f MRS/Makefile.build build/gnu/env && cd build/gnu
+    # mkdir -p build/gnu/repro/symmetric_dynamic/ocean_only && cd build/gnu/repro/symmetric_dynamic/ocean_only
+    - ../../MOM6-examples/src/mkmf/bin/list_paths -l ../../../config_src/{coupled_driver,dynamic} ../../../src ../../MOM6-examples/src/{FMS,coupler,SIS2,icebergs,ice_ocean_extras,land_null,atmos_null}
+    - ../../MOM6-examples/src/mkmf/bin/mkmf -t ../../MOM6-examples/src/mkmf/templates/ncrc-gnu.mk -p MOM6 -c"-Duse_libMPI -Duse_netCDF -D_USE_LEGACY_LAND_ -Duse_AM3_physics" path_names
+    - time (source ./env ; make NETCDF=3 REPRO=1 MOM6 -s -j)
+
 intel:repro:
   stage: builds
   tags:


### PR DESCRIPTION
- Adds two new jobs to the gitlab pipeline (ocean-only and ice-ocean) that compiles everything in one stage rather than via libraries. This should catch any name space conflicts, as recently encountered, that the libraries approach ignores.
- This is not a code change.
