### PR TITLE
Adding capability to bypass initializing a generic tracers

### DIFF
--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -308,7 +308,10 @@ contains
                endif
             enddo; enddo ; enddo
          endif
-
+       elseif(.not. g_tracer%requires_restart) then
+         !Do nothing for this tracer, it is initialized by the tracer package
+          call MOM_error(NOTE,"initialize_MOM_generic_tracer: "//&
+                            "skip initialization of generic tracer "//trim(g_tracer_name))                  
        else !Do it old way if the tracer is not registered to start from a specific source file.
             !This path should be deprecated if all generic tracers are required to start from specified sources.
         if (len_trim(CS%IC_file) > 0) then
@@ -335,7 +338,8 @@ contains
           endif
         else
           call MOM_error(FATAL,"initialize_MOM_generic_tracer: "//&
-                  "check Generic Tracer IC filename "//trim(CS%IC_file)//".")
+                  "check Generic Tracer IC filename "//trim(CS%IC_file)//&
+                  " for tracer "//trim(g_tracer_name))
         endif
 
        endif


### PR DESCRIPTION
- For some generic tracers we need to bypass initialization in MOM6
  and leave it to the tracer package to initialize them.
  E.g., suppose MOM6 restart_flag='n', and we want to initialize
  some tracers to zero without providing a source file full of zeros for them.
  The user can then add the following switches to the field_tablefor cobalt to
  bypass initialize/restart them by MOM6, e.g.,

"namelists","ocean_mod","generic_cobalt"
irr_mem_requires_src_info = f
irr_mem_requires_restart = f
/