### PR TITLE
Fix divide by zero in surface diagnostics

### DIFF
--- a/src/core/MOM_unit_tests.F90
+++ b/src/core/MOM_unit_tests.F90
@@ -10,6 +10,10 @@ use MOM_remapping,         only : remapping_unit_tests
 use MOM_neutral_diffusion, only : neutral_diffusion_unit_tests
 use MOM_diag_vkernels,     only : diag_vkernels_unit_tests
 
+implicit none ; private
+
+public unit_tests
+
 contains
 
 !> Calls unit tests for other modules.

--- a/src/framework/MOM_diag_manager_wrapper.F90
+++ b/src/framework/MOM_diag_manager_wrapper.F90
@@ -6,6 +6,8 @@ module MOM_diag_manager_wrapper
 use MOM_time_manager, only : time_type
 use diag_manager_mod, only : register_diag_field
 
+implicit none ; private
+
 public register_diag_field_fms
 
 !> A wrapper for register_diag_field_array()

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -66,8 +66,7 @@ module MOM_oda_driver_mod
   use MOM_regridding, only : regridding_CS, initialize_regridding
   use MOM_regridding, only : regridding_main, set_regrid_params
 
-  implicit none
-  private
+  implicit none ; private
 
   public :: init_oda, oda_end, set_prior_tracer, get_posterior_tracer
   public :: set_analysis_time, oda, save_obs_diff, apply_oda_tracer_increments

--- a/src/tracer/MOM_OCMIP2_CO2calc.F90
+++ b/src/tracer/MOM_OCMIP2_CO2calc.F90
@@ -29,9 +29,7 @@ module MOM_ocmip2_co2calc_mod  !{
 !------------------------------------------------------------------
 !
 
-implicit none
-
-private
+implicit none ; private
 
 public  :: MOM_ocmip2_co2calc, CO2_dope_vector
 

--- a/src/tracer/MOM_offline_aux.F90
+++ b/src/tracer/MOM_offline_aux.F90
@@ -22,7 +22,7 @@ use MOM_shortwave_abs,    only : optics_type
 use MOM_diag_mediator,    only : post_data
 use MOM_forcing_type,     only : forcing
 
-implicit none
+implicit none ; private
 
 public update_offline_from_files
 public update_offline_from_arrays


### PR DESCRIPTION
Split post_surface_diagnostics into post_surface_dyn_diags and post_surface_thermo_diags, and call each of them only if appropriate.  All solutions are bitwise identical, but this code change can increase the frequencey with which the dynamics surface diagnostics are sent for output.

- This fixes a divide by zero as discussed in issue #767 and detected by @nicjhan at NCI.
- Closes #767 