### PR TITLE
Nearly completed dOxyGenization of arguments

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -61,9 +61,6 @@ type, public :: surface_forcing_CS ; private
   logical :: use_temperature    ! If true, temp and saln used as state variables
   real :: wind_stress_multiplier !< A multiplier applied to incoming wind stress (nondim).
 
-  ! smg: remove when have A=B code reconciled
-  logical :: bulkmixedlayer     ! If true, model based on bulk mixed layer code
-
   real :: Rho0                  ! Boussinesq reference density (kg/m^3)
   real :: area_surf = -1.0      ! total ocean surface area (m^2)
   real :: latent_heat_fusion    ! latent heat of fusion (J/kg)
@@ -114,7 +111,7 @@ type, public :: surface_forcing_CS ; private
   logical :: adjust_net_srestore_by_scaling ! adjust srestore w/o moving zero contour
   logical :: adjust_net_fresh_water_to_zero ! adjust net surface fresh-water (w/ restoring) to zero
   logical :: use_net_FW_adjustment_sign_bug ! use the wrong sign when adjusting net FW
-  logical :: adjust_net_fresh_water_by_scaling ! adjust net surface fresh-water  w/o moving zero contour
+  logical :: adjust_net_fresh_water_by_scaling ! adjust net surface fresh-water w/o moving zero contour
   logical :: mask_srestore_under_ice        ! If true, use an ice mask defined by frazil
                                             ! criteria for salinity restoring.
   real    :: ice_salt_concentration         ! salt concentration for sea ice (kg/kg)
@@ -151,7 +148,7 @@ type, public :: surface_forcing_CS ; private
 end type surface_forcing_CS
 
 
-! ice_ocean_boundary_type is a structure corresponding to forcing, but with
+! ice_ocean_boundary_type is a structure corresponding to forcing, but with 
 ! the elements, units, and conventions that exactly conform to the use for
 ! MOM-based coupled models.
 type, public :: ice_ocean_boundary_type
@@ -203,8 +200,8 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
   type(ice_ocean_boundary_type), &
                    target, intent(in)    :: IOB    !< An ice-ocean boundary type with fluxes to drive
                                                    !! the ocean in a coupled model
-  type(forcing),           intent(inout) :: fluxes !< A structure containing pointers to
-                                                   !! all possible mass, heat or salt flux forcing fields.
+  type(forcing),           intent(inout) :: fluxes !< A structure containing pointers to all
+                                                   !! possible mass, heat or salt flux forcing fields.
                                                    !!  Unused fields have NULL ptrs.
   integer, dimension(4),   intent(in)    :: index_bounds !< The i- and j- size of the arrays in IOB.
   type(time_type),         intent(in)    :: Time   !< The time of the fluxes, used for interpolating the
@@ -950,23 +947,19 @@ subroutine apply_force_adjustments(G, CS, Time, forces)
 
 end subroutine apply_force_adjustments
 
+!> Save any restart files associated with the surface forcing.
 subroutine forcing_save_restart(CS, G, Time, directory, time_stamped, &
                                 filename_suffix)
-  type(surface_forcing_CS),   pointer       :: CS
+  type(surface_forcing_CS),   pointer       :: CS   !< A pointer to the control structure returned
+                                                    !! by a previous call to surface_forcing_init
   type(ocean_grid_type),      intent(inout) :: G    !< The ocean's grid structure
-  type(time_type),            intent(in)    :: Time
-  character(len=*),           intent(in)    :: directory
-  logical,          optional, intent(in)    :: time_stamped
-  character(len=*), optional, intent(in)    :: filename_suffix
-! Arguments: CS - A pointer to the control structure returned by a previous
-!                 call to surface_forcing_init.
-!  (in)      G - The ocean's grid structure.
-!  (in)      Time - The model time at this call.  This is needed for mpp_write calls.
-!  (in, opt) directory - An optional directory into which to write these restart files.
-!  (in, opt) time_stamped - If true, the restart file names include
-!                           a unique time stamp.  The default is false.
-!  (in, opt) filename_suffix - An optional suffix (e.g., a time-stamp) to append
-!                              to the restart file names.
+  type(time_type),            intent(in)    :: Time !< The current model time
+  character(len=*),           intent(in)    :: directory !< The directory into which to write the
+                                                    !! restart files
+  logical,          optional, intent(in)    :: time_stamped !< If true, the restart file names include
+                                                    !! a unique time stamp.  The default is false.
+  character(len=*), optional, intent(in)    :: filename_suffix !< An optional suffix (e.g., a time-
+                                                    !! stamp) to append to the restart file names.
 
   if (.not.associated(CS)) return
   if (.not.associated(CS%restart_CSp)) return
@@ -974,22 +967,21 @@ subroutine forcing_save_restart(CS, G, Time, directory, time_stamped, &
 
 end subroutine forcing_save_restart
 
+!> Initialize the surface forcing, including setting parameters and allocating permanent memory.
 subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, restore_temp)
-  type(time_type),          intent(in)    :: Time
+  type(time_type),          intent(in)    :: Time !< The current model time
   type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
   type(param_file_type),    intent(in)    :: param_file !< A structure to parse for run-time parameters
-  type(diag_ctrl), target,  intent(inout) :: diag
-  type(surface_forcing_CS), pointer       :: CS
-  logical, optional,        intent(in)    :: restore_salt, restore_temp
-! Arguments: Time - The current model time.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
-!  (in)      restore_salt - If present and true, salinity restoring will be
-!                           applied in this model.
+  type(diag_ctrl), target,  intent(inout) :: diag !< A structure that is used to regulate
+                                                  !! diagnostic output
+  type(surface_forcing_CS), pointer       :: CS   !< A pointer that is set to point to the control
+                                                  !! structure for this module
+  logical, optional,        intent(in)    :: restore_salt !< If present and true surface salinity
+                                                  !! restoring will be applied in this model.
+  logical, optional,        intent(in)    :: restore_temp !< If present and true surface temperature
+                                                  !! restoring will be applied in this model.
+
+  ! Local variables
   real :: utide  ! The RMS tidal velocity, in m s-1.
   type(directories)  :: dirs
   logical            :: new_sim, iceberg_flux_diags
@@ -1081,11 +1073,6 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
                  "limited by max_p_surf instead of the full atmospheric \n"//&
                  "pressure.", default=.true.)
 
-! smg: should get_param call should be removed when have A=B code reconciled.
-! this param is used to distinguish how to diagnose surface heat content from water.
-  call get_param(param_file, mdl, "BULKMIXEDLAYER", CS%bulkmixedlayer, &
-                 default=CS%use_temperature,do_not_log=.true.)
-
   call get_param(param_file, mdl, "WIND_STAGGER", stagger, &
                  "A case-insensitive character string to indicate the \n"//&
                  "staggering of the input wind stress field.  Valid \n"//&
@@ -1161,7 +1148,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
                  "The name of the surface temperature variable to read from "//&
                  "SST_RESTORE_FILE for restoring sst.", &
                  default="temp")
-! Convert CS%Flux_const from m day-1 to m s-1.
+  ! Convert CS%Flux_const from m day-1 to m s-1.
     CS%Flux_const = CS%Flux_const / 86400.0
 
     call get_param(param_file, mdl, "MAX_DELTA_TRESTORE", CS%max_delta_trestore, &
@@ -1312,13 +1299,14 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
   call cpu_clock_end(id_clock_forcing)
 end subroutine surface_forcing_init
 
+!> Clean up and deallocate any memory associated with this module and its children.
 subroutine surface_forcing_end(CS, fluxes)
-  type(surface_forcing_CS), pointer       :: CS
-  type(forcing), optional,  intent(inout) :: fluxes
-! Arguments:  CS - A pointer to the control structure returned by a previous
-!                  call to surface_forcing_init, it will be deallocated here.
-!  (inout)    fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
+  type(surface_forcing_CS), pointer       :: CS !< A pointer to the control structure returned by
+                                                !! a previous call to surface_forcing_init, it will
+                                                !! be deallocated here.
+  type(forcing), optional,  intent(inout) :: fluxes !< A structure containing pointers to all
+                                                !! possible mass, heat or salt flux forcing fields.
+                                                !! If present, it will be deallocated here.
 
   if (present(fluxes)) call deallocate_forcing_type(fluxes)
 
@@ -1329,40 +1317,43 @@ subroutine surface_forcing_end(CS, fluxes)
 
 end subroutine surface_forcing_end
 
+!> Write out a set of messages with checksums of the fields in an ice_ocen_boundary type
 subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
 
-    character(len=*), intent(in) :: id
-    integer         , intent(in) :: timestep
-    type(ice_ocean_boundary_type), intent(in) :: iobt
-    integer ::   n,m, outunit
+  character(len=*), intent(in) :: id     !< An identifying string for this call
+  integer,          intent(in) :: timestep !< The number of elapsed timesteps
+  type(ice_ocean_boundary_type), &
+                    intent(in) :: iobt   !< An ice-ocean boundary type with fluxes to drive the
+                                         !! ocean in a coupled model whose checksums are reported
+  integer ::   n,m, outunit
 
-    outunit = stdout()
+  outunit = stdout()
 
-    write(outunit,*) "BEGIN CHECKSUM(ice_ocean_boundary_type):: ", id, timestep
-    write(outunit,100) 'iobt%u_flux         ', mpp_chksum( iobt%u_flux         )
-    write(outunit,100) 'iobt%v_flux         ', mpp_chksum( iobt%v_flux         )
-    write(outunit,100) 'iobt%t_flux         ', mpp_chksum( iobt%t_flux         )
-    write(outunit,100) 'iobt%q_flux         ', mpp_chksum( iobt%q_flux         )
-    write(outunit,100) 'iobt%salt_flux      ', mpp_chksum( iobt%salt_flux      )
-    write(outunit,100) 'iobt%lw_flux        ', mpp_chksum( iobt%lw_flux        )
-    write(outunit,100) 'iobt%sw_flux_vis_dir', mpp_chksum( iobt%sw_flux_vis_dir)
-    write(outunit,100) 'iobt%sw_flux_vis_dif', mpp_chksum( iobt%sw_flux_vis_dif)
-    write(outunit,100) 'iobt%sw_flux_nir_dir', mpp_chksum( iobt%sw_flux_nir_dir)
-    write(outunit,100) 'iobt%sw_flux_nir_dif', mpp_chksum( iobt%sw_flux_nir_dif)
-    write(outunit,100) 'iobt%lprec          ', mpp_chksum( iobt%lprec          )
-    write(outunit,100) 'iobt%fprec          ', mpp_chksum( iobt%fprec          )
-    write(outunit,100) 'iobt%runoff         ', mpp_chksum( iobt%runoff         )
-    write(outunit,100) 'iobt%calving        ', mpp_chksum( iobt%calving        )
-    write(outunit,100) 'iobt%p              ', mpp_chksum( iobt%p              )
-    if (associated(iobt%ustar_berg)) &
-      write(outunit,100) 'iobt%ustar_berg     ', mpp_chksum( iobt%ustar_berg )
-    if (associated(iobt%area_berg)) &
-      write(outunit,100) 'iobt%area_berg      ', mpp_chksum( iobt%area_berg  )
-    if (associated(iobt%mass_berg)) &
-      write(outunit,100) 'iobt%mass_berg      ', mpp_chksum( iobt%mass_berg  )
+  write(outunit,*) "BEGIN CHECKSUM(ice_ocean_boundary_type):: ", id, timestep
+  write(outunit,100) 'iobt%u_flux         ', mpp_chksum( iobt%u_flux         )
+  write(outunit,100) 'iobt%v_flux         ', mpp_chksum( iobt%v_flux         )
+  write(outunit,100) 'iobt%t_flux         ', mpp_chksum( iobt%t_flux         )
+  write(outunit,100) 'iobt%q_flux         ', mpp_chksum( iobt%q_flux         )
+  write(outunit,100) 'iobt%salt_flux      ', mpp_chksum( iobt%salt_flux      )
+  write(outunit,100) 'iobt%lw_flux        ', mpp_chksum( iobt%lw_flux        )
+  write(outunit,100) 'iobt%sw_flux_vis_dir', mpp_chksum( iobt%sw_flux_vis_dir)
+  write(outunit,100) 'iobt%sw_flux_vis_dif', mpp_chksum( iobt%sw_flux_vis_dif)
+  write(outunit,100) 'iobt%sw_flux_nir_dir', mpp_chksum( iobt%sw_flux_nir_dir)
+  write(outunit,100) 'iobt%sw_flux_nir_dif', mpp_chksum( iobt%sw_flux_nir_dif)
+  write(outunit,100) 'iobt%lprec          ', mpp_chksum( iobt%lprec          )
+  write(outunit,100) 'iobt%fprec          ', mpp_chksum( iobt%fprec          )
+  write(outunit,100) 'iobt%runoff         ', mpp_chksum( iobt%runoff         )
+  write(outunit,100) 'iobt%calving        ', mpp_chksum( iobt%calving        )
+  write(outunit,100) 'iobt%p              ', mpp_chksum( iobt%p              )
+  if (associated(iobt%ustar_berg)) &
+    write(outunit,100) 'iobt%ustar_berg     ', mpp_chksum( iobt%ustar_berg )
+  if (associated(iobt%area_berg)) &
+    write(outunit,100) 'iobt%area_berg      ', mpp_chksum( iobt%area_berg  )
+  if (associated(iobt%mass_berg)) &
+    write(outunit,100) 'iobt%mass_berg      ', mpp_chksum( iobt%mass_berg  )
 100 FORMAT("   CHECKSUM::",A20," = ",Z20)
 
-    call coupler_type_write_chksums(iobt%fluxes, outunit, 'iobt%')
+  call coupler_type_write_chksums(iobt%fluxes, outunit, 'iobt%')
 
 end subroutine ice_ocn_bnd_type_chksum
 

--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -148,7 +148,7 @@ type, public :: surface_forcing_CS ; private
 end type surface_forcing_CS
 
 
-! ice_ocean_boundary_type is a structure corresponding to forcing, but with 
+! ice_ocean_boundary_type is a structure corresponding to forcing, but with
 ! the elements, units, and conventions that exactly conform to the use for
 ! MOM-based coupled models.
 type, public :: ice_ocean_boundary_type

--- a/config_src/unit_drivers/MOM_sum_driver.F90
+++ b/config_src/unit_drivers/MOM_sum_driver.F90
@@ -166,17 +166,13 @@ program MOM_main
 contains
 
 subroutine benchmark_init_topog_local(D, G, param_file, max_depth)
-  type(ocean_grid_type), intent(in)             :: G    !< The ocean's grid structure
-  real, intent(out), dimension(SZI_(G),SZJ_(G)) :: D
-  type(param_file_type), intent(in)             :: param_file !< A structure to parse for run-time parameters
-  real,                  intent(in)             :: max_depth
-! Arguments: D          - the bottom depth in m. Intent out.
-!  (in)      G          - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
+  type(ocean_grid_type),            intent(in)  :: G    !< The ocean's grid structure
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: D    !< The ocean bottom depth in m
+  type(param_file_type),            intent(in)  :: param_file !< A structure to parse for run-time parameters
+  real,                             intent(in)  :: max_depth !< The maximum ocean depth in m
 
 ! This subroutine sets up the benchmark test case topography
-  real :: min_depth            ! The minimum and maximum depths in m.
+  real :: min_depth            ! The minimum ocean depth in m.
   real :: PI                   ! 3.1415926... calculated as 4*atan(1)
   real :: D0                   ! A constant to make the maximum     !
                                ! basin depth MAXIMUM_DEPTH.         !

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -1163,9 +1163,9 @@ end subroutine ALE_update_regrid_weights
 !> Update the vertical grid type with ALE information.
 !! This subroutine sets information in the verticalGrid_type to be
 !! consistent with the use of ALE mode.
-subroutine ALE_updateVerticalGridType( CS, GV )
-  type(ALE_CS),            pointer :: CS  ! module control structure
-  type(verticalGrid_type), pointer :: GV  ! vertical grid information
+subroutine ALE_updateVerticalGridType(CS, GV)
+  type(ALE_CS),            pointer :: CS  !< ALE control structure
+  type(verticalGrid_type), pointer :: GV  !< vertical grid information
 
   integer :: nk
 

--- a/src/core/MOM_PressureForce_analytic_FV.F90
+++ b/src/core/MOM_PressureForce_analytic_FV.F90
@@ -846,7 +846,8 @@ end subroutine PressureForce_AFV_init
 
 !> Deallocates the finite volume pressure gradient control structure
 subroutine PressureForce_AFV_end(CS)
-  type(PressureForce_AFV_CS), pointer :: CS
+  type(PressureForce_AFV_CS), pointer :: CS !< Finite volume pressure control structure that
+                                            !! will be deallocated in this subroutine.
   if (associated(CS)) deallocate(CS)
 end subroutine PressureForce_AFV_end
 

--- a/src/core/MOM_PressureForce_blocked_AFV.F90
+++ b/src/core/MOM_PressureForce_blocked_AFV.F90
@@ -839,7 +839,8 @@ end subroutine PressureForce_blk_AFV_init
 
 !> Deallocates the finite volume pressure gradient control structure
 subroutine PressureForce_blk_AFV_end(CS)
-  type(PressureForce_blk_AFV_CS), pointer :: CS
+  type(PressureForce_blk_AFV_CS), pointer :: CS !< Blocked AFV pressure control structure that
+                                                !! will be deallocated in this subroutine.
   if (associated(CS)) deallocate(CS)
 end subroutine PressureForce_blk_AFV_end
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -278,7 +278,7 @@ subroutine zonal_mass_flux(u, h_in, uh, dt, G, GV, CS, LB, uhbt, OBC, &
   integer :: i, j, k, ish, ieh, jsh, jeh, n, nz
   logical :: do_aux, local_specified_BC, use_visc_rem, set_BT_cont, any_simple_OBC
   logical :: local_Flather_OBC, local_open_BC, is_simple
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   do_aux = (present(uhbt_aux) .and. present(u_cor_aux))
   use_visc_rem = present(visc_rem_u)
@@ -1108,7 +1108,7 @@ subroutine meridional_mass_flux(v, h_in, vh, dt, G, GV, CS, LB, vhbt, OBC, &
   integer :: i, j, k, ish, ieh, jsh, jeh, n, nz
   logical :: do_aux, local_specified_BC, use_visc_rem, set_BT_cont, any_simple_OBC
   logical :: local_Flather_OBC, is_simple, local_open_BC
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   do_aux = (present(vhbt_aux) .and. present(v_cor_aux))
   use_visc_rem = present(visc_rem_v)
@@ -1900,7 +1900,7 @@ subroutine PPM_reconstruction_x(h_in, h_L, h_R, G, LB, h_min, monotonic, simple_
   character(len=256) :: mesg
   integer :: i, j, isl, iel, jsl, jel, n, stencil
   logical :: local_open_BC
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   use_CW84 = .false. ; if (present(monotonic)) use_CW84 = monotonic
   use_2nd = .false. ; if (present(simple_2nd)) use_2nd = simple_2nd
@@ -2039,7 +2039,7 @@ subroutine PPM_reconstruction_y(h_in, h_L, h_R, G, LB, h_min, monotonic, simple_
   character(len=256) :: mesg
   integer :: i, j, isl, iel, jsl, jel, n, stencil
   logical :: local_open_BC
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   use_CW84 = .false. ; if (present(monotonic)) use_CW84 = monotonic
   use_2nd = .false. ; if (present(simple_2nd)) use_2nd = simple_2nd

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -123,14 +123,14 @@ type, public :: MOM_dyn_unsplit_CS ; private
   integer :: id_uh = -1, id_vh = -1
   integer :: id_PFu = -1, id_PFv = -1, id_CAu = -1, id_CAv = -1
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                                   ! timing of diagnostic output.
-  type(accel_diag_ptrs), pointer :: ADp ! A structure pointing to the various
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
+  type(accel_diag_ptrs), pointer :: ADp => NULL() ! A structure pointing to the
                                    ! accelerations in the momentum equations,
                                    ! which can later be used to calculate
                                    ! derived diagnostics like energy budgets.
-  type(cont_diag_ptrs), pointer :: CDp ! A structure with pointers to various
-                                   ! terms in the continuity equations,
+  type(cont_diag_ptrs), pointer :: CDp => NULL() ! A structure with pointers to
+                                   ! various terms in the continuity equations,
                                    ! which can later be used to calculate
                                    ! derived diagnostics like energy budgets.
 ! The remainder of the structure is pointers to child subroutines' control strings.
@@ -246,7 +246,7 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_av, hp
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)) :: up, upp
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)) :: vp, vpp
-  real, dimension(:,:), pointer :: p_surf
+  real, dimension(:,:), pointer :: p_surf => NULL()
   real :: dt_pred   ! The time step for the predictor part of the baroclinic
                     ! time stepping.
   logical :: dyn_p_surf
@@ -583,6 +583,7 @@ subroutine register_restarts_dyn_unsplit(HI, GV, param_file, CS, restart_CS)
 
 end subroutine register_restarts_dyn_unsplit
 
+!> Initialize parameters and allocate memory associated with the unsplit dynamics module.
 subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, param_file, diag, CS, &
                                   restart_CS, Accel_diag, Cont_diag, MIS, &
                                   OBC, update_OBC_CSp, ALE_CSp, setVisc_CSp, &
@@ -748,9 +749,10 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, param_file, diag, CS, &
 
 end subroutine initialize_dyn_unsplit
 
+!> Clean up and deallocate memory associated with the unsplit dynamics module.
 subroutine end_dyn_unsplit(CS)
-  type(MOM_dyn_unsplit_CS), pointer :: CS
-!  (inout)    CS - The control structure set up by initialize_dyn_unsplit.
+  type(MOM_dyn_unsplit_CS), pointer :: CS !< unsplit dynamics control structure that
+                                          !! will be deallocated in this subroutine.
 
   DEALLOC_(CS%diffu) ; DEALLOC_(CS%diffv)
   DEALLOC_(CS%CAu)   ; DEALLOC_(CS%CAv)

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -126,14 +126,14 @@ type, public :: MOM_dyn_unsplit_RK2_CS ; private
   integer :: id_uh = -1, id_vh = -1
   integer :: id_PFu = -1, id_PFv = -1, id_CAu = -1, id_CAv = -1
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                                   ! timing of diagnostic output.
-  type(accel_diag_ptrs), pointer :: ADp ! A structure pointing to the various
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
+  type(accel_diag_ptrs), pointer :: ADp => NULL() ! A structure pointing to the
                                    ! accelerations in the momentum equations,
                                    ! which can later be used to calculate
                                    ! derived diagnostics like energy budgets.
-  type(cont_diag_ptrs), pointer :: CDp ! A structure with pointers to various
-                                   ! terms in the continuity equations,
+  type(cont_diag_ptrs), pointer :: CDp => NULL() ! A structure with pointers to
+                                   ! various terms in the continuity equations,
                                    ! which can later be used to calculate
                                    ! derived diagnostics like energy budgets.
 
@@ -258,7 +258,7 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_av, hp
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)) :: up
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)) :: vp
-  real, dimension(:,:), pointer :: p_surf
+  real, dimension(:,:), pointer :: p_surf => NULL()
   real :: dt_pred   ! The time step for the predictor part of the baroclinic
                     ! time stepping.
   logical :: dyn_p_surf
@@ -526,6 +526,7 @@ subroutine register_restarts_dyn_unsplit_RK2(HI, GV, param_file, CS, restart_CS)
 
 end subroutine register_restarts_dyn_unsplit_RK2
 
+!> Initialize parameters and allocate memory associated with the unsplit RK2 dynamics module.
 subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, param_file, diag, CS, &
                                       restart_CS, Accel_diag, Cont_diag, MIS, &
                                       OBC, update_OBC_CSp, ALE_CSp, setVisc_CSp, &
@@ -704,9 +705,10 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, param_file, diag, CS
 
 end subroutine initialize_dyn_unsplit_RK2
 
+!> Clean up and deallocate memory associated with the dyn_unsplit_RK2 module.
 subroutine end_dyn_unsplit_RK2(CS)
-  type(MOM_dyn_unsplit_RK2_CS), pointer :: CS
-!  (inout)   CS - The control structure set up by initialize_dyn_unsplit_RK2.
+  type(MOM_dyn_unsplit_RK2_CS), pointer :: CS !< dyn_unsplit_RK2 control structure that
+                                              !! will be deallocated in this subroutine.
 
   DEALLOC_(CS%diffu) ; DEALLOC_(CS%diffv)
   DEALLOC_(CS%CAu)   ; DEALLOC_(CS%CAv)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -501,9 +501,9 @@ end subroutine open_boundary_config
 subroutine initialize_segment_data(G, OBC, PF)
   use mpp_mod, only : mpp_pe, mpp_set_current_pelist, mpp_get_current_pelist,mpp_npes
 
-  type(dyn_horgrid_type),  intent(in) :: G   !< Ocean grid structure
-  type(ocean_OBC_type), intent(inout) :: OBC !< Open boundary control structure
-  type(param_file_type), intent(in)   :: PF  !< Parameter file handle
+  type(dyn_horgrid_type), intent(in)    :: G   !< Ocean grid structure
+  type(ocean_OBC_type),   intent(inout) :: OBC !< Open boundary control structure
+  type(param_file_type),  intent(in)    :: PF  !< Parameter file handle
 
   integer :: n,m,num_fields
   character(len=256) :: segstr, filename
@@ -513,7 +513,7 @@ subroutine initialize_segment_data(G, OBC, PF)
   integer            :: orient
   character(len=32), dimension(MAX_OBC_FIELDS) :: fields  ! segment field names
   character(len=128) :: inputdir
-  type(OBC_segment_type), pointer :: segment ! pointer to segment type list
+  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
   character(len=32)  :: remappingScheme
   logical :: check_reconstruction, check_remapping, force_bounds_in_subcell
   integer, dimension(4) :: siz,siz2
@@ -1289,7 +1289,7 @@ end function open_boundary_query
 !> Deallocate open boundary data
 subroutine open_boundary_dealloc(OBC)
   type(ocean_OBC_type), pointer :: OBC !< Open boundary control structure
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
   integer :: n
 
   if (.not. associated(OBC)) return
@@ -1317,7 +1317,7 @@ subroutine open_boundary_impose_normal_slope(OBC, G, depth)
   real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: depth !< Bathymetry at h-points
   ! Local variables
   integer :: i, j, n
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   if (.not.associated(OBC)) return
 
@@ -1362,7 +1362,7 @@ subroutine open_boundary_impose_land_mask(OBC, G, areaCu, areaCv)
   real, dimension(SZI_(G),SZJB_(G)), intent(inout) :: areaCv !< Area of a u-cell (m2)
   ! Local variables
   integer :: i, j, n
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
   logical :: any_U, any_V
 
   if (.not.associated(OBC)) return
@@ -1484,7 +1484,7 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, dt)
   real, pointer, dimension(:,:,:) :: rx_tangential=>NULL()
   real, pointer, dimension(:,:,:) :: ry_tangential=>NULL()
   real, parameter :: eps = 1.0e-20
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
   integer :: i, j, k, is, ie, js, je, nz, n
   integer :: is_obc, ie_obc, js_obc, je_obc
 
@@ -2000,7 +2000,7 @@ subroutine open_boundary_apply_normal_flow(OBC, G, u, v)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: v   !< v field to update on open boundaries
   ! Local variables
   integer :: i, j, k, n
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   if (.not.associated(OBC)) return ! Bail out if OBC is not available
 
@@ -2034,7 +2034,7 @@ subroutine open_boundary_zero_normal_flow(OBC, G, u, v)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: v   !< v field to update on open boundaries
   ! Local variables
   integer :: i, j, k, n
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   if (.not.associated(OBC)) return ! Bail out if OBC is not available
 
@@ -2058,7 +2058,7 @@ subroutine open_boundary_zero_normal_flow(OBC, G, u, v)
 end subroutine open_boundary_zero_normal_flow
 
 !> Calculate the tangential gradient of the normal flow at the boundary q-points.
-subroutine gradient_at_q_points(G,segment,uvel,vvel)
+subroutine gradient_at_q_points(G, segment, uvel, vvel)
   type(ocean_grid_type), intent(in) :: G !< Ocean grid structure
   type(OBC_segment_type), pointer :: segment !< OBC segment structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: uvel !< zonal velocity
@@ -2121,7 +2121,7 @@ subroutine set_tracer_data(OBC, tv, h, G, PF, tracer_Reg)
   integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, nz, n
   integer :: isd_off, jsd_off
   integer :: IsdB, IedB, JsdB, JedB
-  type(OBC_segment_type), pointer :: segment ! pointer to segment type list
+  type(OBC_segment_type), pointer :: segment  => NULL() ! pointer to segment type list
   character(len=40)  :: mdl = "set_tracer_data" ! This subroutine's name.
   character(len=200) :: filename, OBC_file, inputdir ! Strings for file/path
 
@@ -2439,7 +2439,7 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
   integer :: IsdB, IedB, JsdB, JedB, n, m, nz
   character(len=40)  :: mdl = "set_OBC_segment_data" ! This subroutine's name.
   character(len=200) :: filename, OBC_file, inputdir ! Strings for file/path
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
   integer, dimension(4) :: siz,siz2
   real :: sumh ! column sum of thicknesses (m)
   integer :: ni_seg, nj_seg  ! number of src gridpoints along the segments
@@ -3114,7 +3114,7 @@ subroutine register_temp_salt_segments(GV, OBC, tr_Reg, param_file)
   integer :: i, j, k, n
   character(len=32)  :: name
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
-  type(tracer_type), pointer      :: tr_ptr
+  type(tracer_type), pointer      :: tr_ptr => NULL()
 
   if (.not. associated(OBC)) return
 
@@ -3145,7 +3145,7 @@ subroutine fill_temp_salt_segments(G, OBC, tv)
 ! Local variables
   integer :: isd, ied, IsdB, IedB, jsd, jed, JsdB, JedB, n, nz
   integer :: i, j, k
-  type(OBC_segment_type), pointer :: segment ! pointer to segment type list
+  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
 
   if (.not. associated(OBC)) return
   if (.not. associated(tv%T) .and. associated(tv%S)) return
@@ -3209,7 +3209,7 @@ subroutine mask_outside_OBCs(G, param_file, OBC)
   real    :: min_depth
   integer, parameter  :: cin = 3, cout = 4, cland = -1, cedge = -2
   character(len=256) :: mesg    ! Message for error messages.
-  type(OBC_segment_type), pointer :: segment ! pointer to segment type list
+  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
   real, allocatable, dimension(:,:) :: color, color2  ! For sorting inside from outside,
                                                       ! two different ways
 

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -399,7 +399,7 @@ end subroutine alloc_BT_cont_type
 
 !> dealloc_BT_cont_type deallocates the arrays contained within a BT_cont_type.
 subroutine dealloc_BT_cont_type(BT_cont)
-  type(BT_cont_type), pointer :: BT_cont
+  type(BT_cont_type), pointer :: BT_cont !< The BT_cont_type whose elements will be deallocated.
 
   if (.not.associated(BT_cont)) return
 

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -54,9 +54,9 @@ type, public :: PointAccel_CS ; private
                             ! written by this PE during the current run.
   integer :: max_writes     ! The maximum number of times any PE can write out
                             ! a column's worth of accelerations during a run.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
-  type(diag_ctrl), pointer :: diag ! A pointer to a structure of shareable
-                            ! ocean diagnostic fields.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
 ! The following are pointers to many of the state variables and accelerations
 ! that are used to step the physical model forward.  They all use the same
 ! names as the variables they point to in MOM.F90
@@ -439,25 +439,6 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 ! that have been applied to a column of meridional velocities over
 ! the previous timestep.  This subroutine is called from vertvisc.
 
-! Arguments: i - The zonal index of the column to be documented.
-!  (in)      J - The meridional index of the column to be documented.
-!  (in)      vm - The new meridional velocity, in m s-1.
-!  (in)      hin - The layer thickness, in m.
-!  (in)      ADp - A structure pointing to the various accelerations in
-!                  the momentum equations.
-!  (in)      CDp - A structure with pointers to various terms in the continuity
-!                  equations.
-!  (in)      dt - The model's dynamics time step.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 PointAccel_init.
-!  (in)      str - The surface wind stress integrated over a time
-!                  step, in m2 s-1.
-!  (in)      a - The layer coupling coefficients from vertvisc, m.
-!  (in)      hv - The layer thicknesses at velocity grid points, from
-!                 vertvisc, in m.
-
   real    :: f_eff, CFL
   real    :: Angstrom
   real    :: truncvel, dv
@@ -757,7 +738,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 
 end subroutine write_v_accel
 
-! #@# This subroutine needs a doxygen description
+!> This subroutine initializes the parameters regulating how truncations are logged.
 subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
   type(ocean_internal_state), &
                         target, intent(in)    :: MIS  !< For "MOM Internal State" a set of pointers
@@ -774,16 +755,6 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
   type(PointAccel_CS),          pointer       :: CS   !< A pointer that is set to point to the
                                                       !! control structure for this module.
 
-! Arguments: MIS - For "MOM Internal State" a set of pointers to the fields and
-!                  accelerations that make up the ocean's physical state.
-!  (in)      Time - The current model time.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in)      dirs - A structure containing several relevant directory paths.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_PointAccel" ! This module's name.

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -89,7 +89,8 @@ type, public :: diag_to_Z_CS ; private
   type(axes_grp) :: axesZ
   integer, dimension(1) :: axesz_out
 
-  type(diag_ctrl), pointer :: diag ! structure to regulate diagnostic output timing
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
 
 end type diag_to_Z_CS
 
@@ -150,19 +151,20 @@ end function global_z_mean
 
 !> This subroutine maps tracers and velocities into depth space for diagnostics.
 subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
-  type(ocean_grid_type),                     intent(inout) :: G    !< The ocean's grid structure.
-  type(verticalGrid_type),                   intent(in)    :: GV   !< The ocean's vertical grid
-                                                                   !! structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: u    !< The zonal velocity, in m s-1.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: v    !< The meridional velocity,
-                                                                   !! in m s-1.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h    !< Layer thicknesses, in H
-                                                                   !! (usually m or kg m-2).
-  real, dimension(SZI_(G),SZJ_(G)),          intent(in)    :: ssh_in !< Sea surface height
-                                                                   !! (meter or kg/m2).
-  real, dimension(:,:),                      pointer       :: frac_shelf_h
-  type(diag_to_Z_CS),                        pointer       :: CS   !< Control structure returned by
-                                                                   !! previous call to diag_to_Z_init.
+  type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: u    !< The zonal velocity, in m s-1.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                           intent(in)    :: v    !< The meridional velocity, in m s-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2).
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)    :: ssh_in !< Sea surface height in meters.
+  real, dimension(:,:),    pointer       :: frac_shelf_h !< The fraction of the cell area covered by
+                                                 !! ice shelf, or unassocatiaed if there is no shelf
+  type(diag_to_Z_CS),      pointer       :: CS   !< Control structure returned by a previous call
+                                                 !! to diag_to_Z_init.
 
 ! This subroutine maps tracers and velocities into depth space for diagnostics.
 
@@ -791,7 +793,7 @@ subroutine find_limited_slope(val, e, slope, k)
 
 end subroutine find_limited_slope
 
-! #@# This subroutine needs a doxygen description
+!> This subroutine calculates interface diagnostics in z-space.
 subroutine calc_Zint_diags(h, in_ptrs, ids, num_diags, G, GV, CS)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
@@ -1027,7 +1029,7 @@ subroutine register_Z_tracer_low(tr_ptr, name, long_name, units, standard_name, 
 
 end subroutine register_Z_tracer_low
 
-! #@# This subroutine needs a doxygen comment.
+!> This subroutine sets parameters that control Z-space diagnostic output.
 subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
   type(time_type),         intent(in)    :: Time !< Current model time.
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure.
@@ -1036,15 +1038,8 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
                                                  !! parameters.
   type(diag_ctrl), target, intent(inout) :: diag !< Struct to regulate diagnostic output.
   type(diag_to_Z_CS),      pointer       :: CS   !< Pointer to point to control structure for
-                                                 !! this module.
-
-! Arguments:
-!  (in)      Time       - current model time
-!  (in)      G          - ocean grid structure
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - struct indicating open file to parse for model param values
-!  (in)      diag       - struct to regulate diagnostic output
-!  (in/out)  CS         - pointer to point to control structure for this module
+                                                 !! this module, which is allocated and
+                                                 !! populated here.
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -1348,7 +1343,7 @@ function register_Z_diag(var_desc, CS, day, missing)
   character(len=48) :: units            ! A variable's units.
   character(len=240) :: longname        ! A variable's longname.
   character(len=8) :: hor_grid, z_grid  ! Variable grid info.
-  type(axes_grp), pointer :: axes
+  type(axes_grp), pointer :: axes => NULL()
 
   call query_vardesc(var_desc, name=var_name, units=units, longname=longname, &
                      hor_grid=hor_grid, z_grid=z_grid, caller="register_Zint_diag")
@@ -1401,7 +1396,7 @@ function register_Zint_diag(var_desc, CS, day)
   character(len=48) :: units            ! A variable's units.
   character(len=240) :: longname        ! A variable's longname.
   character(len=8) :: hor_grid          ! Variable grid info.
-  type(axes_grp), pointer :: axes
+  type(axes_grp), pointer :: axes => NULL()
 
   call query_vardesc(var_desc, name=var_name, units=units, longname=longname, &
                      hor_grid=hor_grid, caller="register_Zint_diag")

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -98,37 +98,41 @@ integer, parameter :: NO_ZSPACE = -1
 contains
 
 function global_z_mean(var,G,CS,tracer)
-  type(ocean_grid_type),                           intent(in)  :: G    !< The ocean's grid structure
-  type(diag_to_Z_CS),                              intent(in)  :: CS
-  real, dimension(SZI_(G), SZJ_(G), CS%nk_zspace), intent(in)  :: var
+  type(ocean_grid_type), intent(in)  :: G    !< The ocean's grid structure
+  type(diag_to_Z_CS),    pointer     :: CS   !< Control structure returned by
+                                             !! previous call to diag_to_Z_init.
+  real, dimension(SZI_(G), SZJ_(G), CS%nk_zspace), &
+                         intent(in)  :: var    !< An array with the variable to average
+  integer,               intent(in)  :: tracer !< The tracer index being worked on
+
   real, dimension(SZI_(G), SZJ_(G), CS%nk_zspace)  :: tmpForSumming, weight
-  real, dimension(SZI_(G), SZJ_(G), CS%nk_zspace)  :: localVar, valid_point, depth_weight
   real, dimension(CS%nk_zspace)                    :: global_z_mean, scalarij, weightij
   real, dimension(CS%nk_zspace)                    :: global_temp_scalar, global_weight_scalar
-  integer :: i, j, k, is, ie, js, je, nz, tracer
+  real :: valid_point, depth_weight
+  integer :: i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   nz = CS%nk_zspace
 
   ! Initialize local arrays
-  valid_point = 1. ; depth_weight = 0.
   tmpForSumming(:,:,:) = 0. ; weight(:,:,:) = 0.
 
-  ! Local array copy of tracer field pointer
-  localVar = var
-
-  do k=1, nz ; do j=js,je ; do i=is, ie
+  do k=1,nz ; do j=js,je ; do i=is,ie
+    valid_point = 1.0
     ! Weight factor for partial bottom cells
-    depth_weight(i,j,k) = min( max( (-1.*G%bathyT(i,j)), CS%Z_int(k+1) ) - CS%Z_int(k), 0.)
+    depth_weight = min( max( (-1.*G%bathyT(i,j)), CS%Z_int(k+1) ) - CS%Z_int(k), 0.)
 
     ! Flag the point as invalid if it contains missing data, or is below the bathymetry
-    if (var(i,j,k) == CS%missing_tr(tracer)) valid_point(i,j,k) = 0.
-    if (depth_weight(i,j,k) == 0.) valid_point(i,j,k) = 0.
+    if (var(i,j,k) == CS%missing_tr(tracer)) valid_point = 0.
+    if (depth_weight == 0.) valid_point = 0.
+
+    weight(i,j,k) = depth_weight * ( (valid_point * (G%areaT(i,j) * G%mask2dT(i,j))) )
 
     ! If the point is flagged, set the variable itsef to zero to avoid NaNs
-    if (valid_point(i,j,k) == 0.) localVar(i,j,k) = 0.
-
-    weight(i,j,k)  =  depth_weight(i,j,k) * ( (valid_point(i,j,k) * (G%areaT(i,j) * G%mask2dT(i,j))) )
-    tmpForSumming(i,j,k) =  localVar(i,j,k) * weight(i,j,k)
+    if (valid_point == 0.) then
+      tmpForSumming(i,j,k) = 0.0
+    else
+      tmpForSumming(i,j,k) = var(i,j,k) * weight(i,j,k)
+    endif
   enddo ; enddo ; enddo
 
   global_temp_scalar   = reproducing_sum(tmpForSumming,sums=scalarij)
@@ -158,8 +162,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
                                                                    !! (meter or kg/m2).
   real, dimension(:,:),                      pointer       :: frac_shelf_h
   type(diag_to_Z_CS),                        pointer       :: CS   !< Control structure returned by
-                                                                   !! previous call to
-                                                                   !! diagnostics_init.
+                                                                   !! previous call to diag_to_Z_init.
 
 ! This subroutine maps tracers and velocities into depth space for diagnostics.
 
@@ -170,7 +173,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
 !  (in)  ssh_in - sea surface height (meter or kg/m2)
 !  (in)  G   - ocean grid structure
 !  (in)  GV  - The ocean's vertical grid structure.
-!  (in)  CS  - control structure returned by previous call to diagnostics_init
+!  (in)  CS  - control structure returned by previous call to diag_to_Z_init
 
   ! Note the deliberately reversed axes in h_f, u_f, v_f, and tr_f.
   real :: ssh(SZI_(G),SZJ_(G))   ! copy of ssh_in (meter or kg/m2)
@@ -521,7 +524,7 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
                                                                    !! subroutine.
   type(diag_to_Z_CS),                        pointer       :: CS   !< Control structure returned by
                                                                    !! previous call to
-                                                                   !! diagnostics_init.
+                                                                   !! diag_to_Z_init.
 
 !   This subroutine maps horizontal transport into depth space for diagnostic output.
 
@@ -532,7 +535,7 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
 !  (in)      dt     - time difference (sec) since last call to this routine
 !  (in)      G      - ocean grid structure
 !  (in)      GV     - The ocean's vertical grid structure
-!  (in)      CS     - control structure returned by previous call to diagnostics_init
+!  (in)      CS     - control structure returned by previous call to diag_to_Z_init
 
   real, dimension(SZI_(G), SZJ_(G)) :: &
     htot, &        ! total layer thickness (meter or kg/m2)
@@ -790,15 +793,15 @@ end subroutine find_limited_slope
 
 ! #@# This subroutine needs a doxygen description
 subroutine calc_Zint_diags(h, in_ptrs, ids, num_diags, G, GV, CS)
-  type(ocean_grid_type),                    intent(in) :: G    !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h    !< Layer thicknesses, in H
-                                                               !! (usually m or kg m-2).
-  type(p3d), dimension(:),                  intent(in) :: in_ptrs
-  integer,   dimension(:),                  intent(in) :: ids
-  integer,                                  intent(in) :: num_diags
-  type(verticalGrid_type),                  intent(in) :: GV   !< The ocean's vertical grid
-                                                               !! structure.
-  type(diag_to_Z_CS),                       pointer    :: CS
+  type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2).
+  type(p3d), dimension(:), intent(in) :: in_ptrs !< Pointers to the diagnostics to be regridded
+  integer,   dimension(:), intent(in) :: ids  !< The diagnostic IDs of the diagnostics
+  integer,                 intent(in) :: num_diags !< The number of diagnostics to regrid
+  type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure.
+  type(diag_to_Z_CS),      pointer    :: CS   !< Control structure returned by
+                                              !! previous call to diag_to_Z_init.
 
   real, dimension(SZI_(G),SZJ_(G),max(CS%nk_zspace+1,1),max(num_diags,1)) :: &
     diag_on_Z  ! diagnostics interpolated to depth space
@@ -889,21 +892,21 @@ end subroutine calc_Zint_diags
 !> This subroutine registers a tracer to be output in depth space.
 subroutine register_Z_tracer(tr_ptr, name, long_name, units, Time, G, CS, standard_name,   &
      cmor_field_name, cmor_long_name, cmor_units, cmor_standard_name)
-  type(ocean_grid_type),            intent(in) :: G      !< The ocean's grid structure.
+  type(ocean_grid_type),      intent(in) :: G      !< The ocean's grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                    target,         intent(in) :: tr_ptr !< Tracer for translation to Z-space.
-  character(len=*),                 intent(in) :: name   !< name for the output tracer.
-  character(len=*),                 intent(in) :: long_name !< Long name for the output tracer.
-  character(len=*),                 intent(in) :: units  !< Units of output tracer.
-  character(len=*), optional,       intent(in) :: standard_name
-  type(time_type),                  intent(in) :: Time   !< Current model time.
-  type(diag_to_Z_CS),               pointer    :: CS     !< Control struct returned by previous
-                                                         !! call to diagnostics_init.
-  character(len=*), optional,       intent(in) :: cmor_field_name !< cmor name of a field.
-  character(len=*), optional,       intent(in) :: cmor_long_name  !< cmor long name of a field.
-  character(len=*), optional,       intent(in) :: cmor_units      !< cmor units of a field.
-  character(len=*), optional,       intent(in) :: cmor_standard_name !< cmor standardized name
-                                                                  !! associated with a field.
+                    target,   intent(in) :: tr_ptr !< Tracer for translation to Z-space.
+  character(len=*),           intent(in) :: name   !< name for the output tracer.
+  character(len=*),           intent(in) :: long_name !< Long name for the output tracer.
+  character(len=*),           intent(in) :: units  !< Units of output tracer.
+  character(len=*), optional, intent(in) :: standard_name !< The CMOR standard name of this variable.
+  type(time_type),            intent(in) :: Time   !< Current model time.
+  type(diag_to_Z_CS),         pointer    :: CS     !< Control struct returned by previous
+                                                   !! call to diag_to_Z_init.
+  character(len=*), optional, intent(in) :: cmor_field_name !< cmor name of a field.
+  character(len=*), optional, intent(in) :: cmor_long_name  !< cmor long name of a field.
+  character(len=*), optional, intent(in) :: cmor_units      !< cmor units of a field.
+  character(len=*), optional, intent(in) :: cmor_standard_name !< cmor standardized name
+                                                            !! associated with a field.
 
 !   This subroutine registers a tracer to be output in depth space.
 ! Arguments:
@@ -913,7 +916,7 @@ subroutine register_Z_tracer(tr_ptr, name, long_name, units, Time, G, CS, standa
 !  (in)      units     - units of output tracer
 !  (in)      Time      - current model time
 !  (in)      G         - ocean grid structure
-!  (in)      CS        - control struct returned by previous call to diagnostics_init
+!  (in)      CS        - control struct returned by previous call to diag_to_Z_init
 !  (in,opt)  cmor_field_name    - cmor name of a field
 !  (in,opt)  cmor_long_name     - cmor long name of a field
 !  (in,opt)  cmor_units         - cmor units of a field
@@ -960,16 +963,16 @@ end subroutine register_Z_tracer
 
 !> This subroutine registers a tracer to be output in depth space.
 subroutine register_Z_tracer_low(tr_ptr, name, long_name, units, standard_name, Time, G, CS)
-  type(ocean_grid_type),      intent(in) :: G      !< The ocean's grid structure.
+  type(ocean_grid_type), intent(in) :: G      !< The ocean's grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                      target, intent(in) :: tr_ptr !< Tracer for translation to Z-space.
-  character(len=*),           intent(in) :: name   !< Name for the output tracer.
-  character(len=*),           intent(in) :: long_name !< Long name for output tracer.
-  character(len=*),           intent(in) :: units  !< Units of output tracer.
-  character(len=*),           intent(in) :: standard_name
-  type(time_type),            intent(in) :: Time   !< Current model time.
-  type(diag_to_Z_CS),         pointer    :: CS     !< Control struct returned by previous call to
-                                                   !! diagnostics_init.
+                 target, intent(in) :: tr_ptr !< Tracer for translation to Z-space.
+  character(len=*),      intent(in) :: name   !< Name for the output tracer.
+  character(len=*),      intent(in) :: long_name !< Long name for output tracer.
+  character(len=*),      intent(in) :: units  !< Units of output tracer.
+  character(len=*),      intent(in) :: standard_name !< The CMOR standard name of this variable.
+  type(time_type),       intent(in) :: Time   !< Current model time.
+  type(diag_to_Z_CS),    pointer    :: CS     !< Control struct returned by previous call to
+                                              !! diag_to_Z_init.
 
 !   This subroutine registers a tracer to be output in depth space.
 
@@ -980,7 +983,7 @@ subroutine register_Z_tracer_low(tr_ptr, name, long_name, units, standard_name, 
 !  (in)      units     - units of output tracer
 !  (in)      Time      - current model time
 !  (in)      G         - ocean grid structure
-!  (in)      CS        - control struct returned by previous call to diagnostics_init
+!  (in)      CS        - control struct returned by previous call to diag_to_Z_init
 
   character(len=256) :: posted_standard_name
   integer :: isd, ied, jsd, jed, nk, m, id_test
@@ -1134,13 +1137,14 @@ end subroutine MOM_diag_to_Z_init
 !! up with the same information as this axis.
 subroutine get_Z_depths(depth_file, int_depth_name, int_depth, cell_depth_name, &
                         z_axis_index, edge_index, nk_out)
-  character(len=*),   intent(in)  :: depth_file
-  character(len=*),   intent(in)  :: int_depth_name
-  real, dimension(:), pointer     :: int_depth
-  character(len=*),   intent(in)  :: cell_depth_name
-  integer,            intent(out) :: z_axis_index
-  integer,            intent(out) :: edge_index
-  integer,            intent(out) :: nk_out
+  character(len=*),   intent(in)  :: depth_file  !< The file to read for the depths
+  character(len=*),   intent(in)  :: int_depth_name !< The interface depth variable name
+  real, dimension(:), pointer     :: int_depth   !< A pointer that will be allocated and
+                                                 !! returned with the interface depths
+  character(len=*),   intent(in)  :: cell_depth_name !< The cell-center depth variable name
+  integer,            intent(out) :: z_axis_index !< The cell-center z-axis diagnostic index handle
+  integer,            intent(out) :: edge_index  !< The interface z-axis diagnostic index handle
+  integer,            intent(out) :: nk_out      !< The number of layers in the output grid
 
 !   This subroutine reads the depths of the interfaces bounding the intended
 ! layers from a NetCDF file.  If no appropriate file is found, -1 is returned
@@ -1254,7 +1258,7 @@ subroutine get_Z_depths(depth_file, int_depth_name, int_depth, cell_depth_name, 
 end subroutine get_Z_depths
 
 subroutine MOM_diag_to_Z_end(CS)
-  type(diag_to_Z_CS), pointer :: CS
+  type(diag_to_Z_CS), pointer :: CS !< Control structure returned by a previous call to diag_to_Z_init.
   integer :: m
 
   if (associated(CS%u_z))   deallocate(CS%u_z)
@@ -1274,7 +1278,7 @@ function ocean_register_diag_with_z(tr_ptr, vardesc_tr, G, Time, CS)
   type(vardesc),                     intent(in) :: vardesc_tr !< Variable descriptor.
   type(time_type),                   intent(in) :: Time   !< Current model time.
   type(diag_to_Z_CS),                pointer    :: CS     !< Control struct returned by a previous
-                                                          !! call to diagnostics_init.
+                                                          !! call to diag_to_Z_init.
   integer                                       :: ocean_register_diag_with_z
 
 !   This subroutine registers a tracer to be output in depth space.
@@ -1283,7 +1287,7 @@ function ocean_register_diag_with_z(tr_ptr, vardesc_tr, G, Time, CS)
 !  (in)      vardesc_tr - variable descriptor
 !  (in)      Time       - current model time
 !  (in)      G          - ocean grid structure
-!  (in)      CS         - control struct returned by a previous call to diagnostics_init
+!  (in)      CS         - control struct returned by a previous call to diag_to_Z_init
 
   type(vardesc) :: vardesc_z
   character(len=64) :: var_name         ! A variable's name.
@@ -1333,11 +1337,12 @@ function ocean_register_diag_with_z(tr_ptr, vardesc_tr, G, Time, CS)
 end function ocean_register_diag_with_z
 
 function register_Z_diag(var_desc, CS, day, missing)
-  integer                         :: register_Z_diag
-  type(vardesc),       intent(in) :: var_desc
-  type(diag_to_Z_CS),  pointer    :: CS
-  type(time_type),     intent(in) :: day
-  real,                intent(in) :: missing
+  integer                        :: register_Z_diag !< The returned z-layer diagnostic index
+  type(vardesc),      intent(in) :: var_desc !< A type with metadata for this diagnostic
+  type(diag_to_Z_CS), pointer    :: CS   !< Control structure returned by
+                                         !! previous call to diag_to_Z_init.
+  type(time_type),    intent(in) :: day  !< The current model time
+  real,               intent(in) :: missing !< The missing value for this diagnostic
 
   character(len=64) :: var_name         ! A variable's name.
   character(len=48) :: units            ! A variable's units.
@@ -1386,10 +1391,11 @@ function register_Z_diag(var_desc, CS, day, missing)
 end function register_Z_diag
 
 function register_Zint_diag(var_desc, CS, day)
-  integer                         :: register_Zint_diag
-  type(vardesc),       intent(in) :: var_desc
-  type(diag_to_Z_CS),  pointer    :: CS
-  type(time_type),     intent(in) :: day
+  integer                        :: register_Zint_diag !< The returned z-interface diagnostic index
+  type(vardesc),      intent(in) :: var_desc !< A type with metadata for this diagnostic
+  type(diag_to_Z_CS), pointer    :: CS   !< Control structure returned by
+                                         !! previous call to diag_to_Z_init.
+  type(time_type),    intent(in) :: day  !< The current model time
 
   character(len=64) :: var_name         ! A variable's name.
   character(len=48) :: units            ! A variable's units.

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -67,7 +67,8 @@ type, public :: diagnostics_CS ; private
   real :: mono_N2_depth = -1.          !< The depth below which N2 is limited as monotonic for the purposes of
                                        !! calculating the equivalent barotropic wave speed. (m)
 
-  type(diag_ctrl), pointer :: diag ! structure to regulate diagnostics timing
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
 
   ! following arrays store diagnostics calculated here and unavailable outside.
 

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -134,7 +134,7 @@ type, public :: sum_output_CS ; private
   logical :: date_stamped_output ! If true, use dates (not times) in messages to stdout.
   type(time_type) :: Start_time ! The start time of the simulation.
                                 ! Start_time is set in MOM_initialization.F90
-  integer, pointer :: ntrunc    ! The number of times the velocity has been
+  integer, pointer :: ntrunc => NULL() ! The number of times the velocity has been
                                 ! truncated since the last call to write_energy.
   real    :: max_Energy         ! The maximum permitted energy per unit mass
                                 ! If there is more energy than this, the model
@@ -426,7 +426,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
   integer :: pe_num
   integer :: iyear, imonth, iday, ihour, iminute, isecond, itick ! For call to get_date()
   logical :: local_open_BC
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
  ! A description for output of each of the fields.
   type(vardesc) :: vars(NUM_FIELDS+MAX_FIELDS_)

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -86,7 +86,7 @@ subroutine wave_speed(h, tv, G, GV, cg1, CS, full_halos, use_ebt_mode, &
   real :: speed2_tot
   real :: I_Hnew, drxh_sum
   real, parameter :: tol1  = 0.0001, tol2 = 0.001
-  real, pointer, dimension(:,:,:) :: T, S
+  real, pointer, dimension(:,:,:) :: T => NULL(), S => NULL()
   real :: g_Rho0  ! G_Earth/Rho0 in m4 s-2 kg-1.
   real :: rescale, I_rescale
   integer :: kf(SZI_(G))
@@ -566,7 +566,7 @@ subroutine wave_speeds(h, tv, G, GV, nmodes, cn, CS, full_halos)
                      ! factor used in setting speed2_min
   real :: I_Hnew, drxh_sum
   real, parameter :: tol1  = 0.0001, tol2 = 0.001
-  real, pointer, dimension(:,:,:) :: T, S
+  real, pointer, dimension(:,:,:) :: T => NULL(), S => NULL()
   real :: g_Rho0  ! G_Earth/Rho0 in m4 s-2 kg-1.
   integer :: kf(SZI_(G))
   integer, parameter :: max_itt = 10

--- a/src/diagnostics/MOM_wave_structure.F90
+++ b/src/diagnostics/MOM_wave_structure.F90
@@ -44,8 +44,8 @@ implicit none ; private
 public wave_structure, wave_structure_init
 
 type, public :: wave_structure_CS ; !private
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                                   ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   real, allocatable, dimension(:,:,:) :: w_strct
                                    ! Vertical structure of vertical velocity (normalized), in m s-1.
   real, allocatable, dimension(:,:,:) :: u_strct
@@ -160,7 +160,7 @@ subroutine wave_structure(h, tv, G, GV, cn, ModeNum, freq, CS, En, full_halos)
   real :: speed2_tot
   real :: I_Hnew, drxh_sum
   real, parameter :: tol1  = 0.0001, tol2 = 0.001
-  real, pointer, dimension(:,:,:) :: T, S
+  real, pointer, dimension(:,:,:) :: T => NULL(), S => NULL()
   real :: g_Rho0  ! G_Earth/Rho0 in m4 s-2 kg-1.
   real :: rescale, I_rescale
   integer :: kf(SZI_(G))

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -81,17 +81,16 @@ type, public :: EOS_type ; private
                              !! of the freezing point.
   logical :: EOS_quadrature  !< If true, always use the generic (quadrature)
                              !! code for the integrals of density.
-  logical :: Compressible = .true. !< If true, in situ density is a function
-                             !! of pressure.
+  logical :: Compressible = .true. !< If true, in situ density is a function of pressure.
 ! The following parameters are used with the linear equation of state only.
-  real :: Rho_T0_S0   !< The density at T=0, S=0, in kg m-3.
-  real :: dRho_dT     !< The partial derivatives of density with temperature
-  real :: dRho_dS     !< and salinity, in kg m-3 K-1 and kg m-3 psu-1.
+  real :: Rho_T0_S0 !< The density at T=0, S=0, in kg m-3.
+  real :: dRho_dT   !< The partial derivatives of density with temperature
+  real :: dRho_dS   !< and salinity, in kg m-3 K-1 and kg m-3 psu-1.
 ! The following parameters are use with the linear expression for the freezing
 ! point only.
-  real :: TFr_S0_P0   !< The freezing potential temperature at S=0, P=0 in deg C.
-  real :: dTFr_dS !< The derivative of freezing point with salinity, in deg C PSU-1.
-  real :: dTFr_dp !< The derivative of freezing point with pressure, in deg C Pa-1.
+  real :: TFr_S0_P0 !< The freezing potential temperature at S=0, P=0 in deg C.
+  real :: dTFr_dS   !< The derivative of freezing point with salinity, in deg C PSU-1.
+  real :: dTFr_dp   !< The derivative of freezing point with pressure, in deg C Pa-1.
 
   logical :: test_EOS = .true.
 end type EOS_type
@@ -547,39 +546,40 @@ end subroutine calculate_compress
 subroutine int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
                                dza, intp_dza, intx_dza, inty_dza, halo_size, &
                                bathyP, dP_tiny, useMassWghtInterp)
-  !> The horizontal index structure
-    type(hor_index_type),                          intent(in)  :: HI
-  !> Potential temperature referenced to the surface (degC)
-    real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  intent(in)  :: T
-  !> Salinity (PSU)
-    real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  intent(in)  :: S
-  !> Pressure at the top of the layer in Pa.
-    real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  intent(in)  :: p_t
-  !> Pressure at the bottom of the layer in Pa.
-    real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  intent(in)  :: p_b
-  !> A mean specific volume that is subtracted out to reduce the magnitude of
-  !! each of the integrals, m3 kg-1. The calculation is mathematically identical
-  !! with different values of alpha_ref, but this reduces the effects of roundoff.
-    real,                                          intent(in)  :: alpha_ref
-  !> Equation of state structure
-    type(EOS_type),                                pointer     :: EOS
-  !> The change in the geopotential anomaly across the layer, in m2 s-2.
-    real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  intent(out) :: dza
-  !> The integral in pressure through the layer of the geopotential anomaly
-  !! relative to the anomaly at the bottom of the layer, in Pa m2 s-2.
-    real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  optional, intent(out) :: intp_dza
-  !> The integral in x of the difference between the geopotential anomaly at the
-  !! top and bottom of the layer divided by the x grid spacing, in m2 s-2.
-    real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), optional, intent(out) :: intx_dza
-  !> The integral in y of the difference between the geopotential anomaly at the
-  !! top and bottom of the layer divided by the y grid spacing, in m2 s-2.
-    real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), optional, intent(out) :: inty_dza
-  !> The width of halo points on which to calculate dza.
-    integer,                             optional, intent(in)  :: halo_size
+  type(hor_index_type), intent(in)  :: HI  !< The horizontal index structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-              optional, intent(in)  :: bathyP !< The pressure at the bathymetry in Pa
+                        intent(in)  :: T   !< Potential temperature referenced to the surface (degC)
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: S   !< Salinity (PSU)
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: p_t !< Pressure at the top of the layer in Pa.
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: p_b !< Pressure at the bottom of the layer in Pa.
+  real,                 intent(in)  :: alpha_ref !< A mean specific volume that is subtracted out
+                            !! to reduce the magnitude of each of the integrals, m3 kg-1. The
+                            !! calculation is mathematically identical with different values of
+                            !! alpha_ref, but this reduces the effects of roundoff.
+  type(EOS_type),       pointer     :: EOS !< Equation of state structure
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(out) :: dza !< The change in the geopotential anomaly across
+                            !! the layer, in m2 s-2.
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(out) :: intp_dza !< The integral in pressure through the layer of the
+                            !! geopotential anomaly relative to the anomaly at the bottom of the
+                            !! layer, in Pa m2 s-2.
+  real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), &
+              optional, intent(out) :: intx_dza !< The integral in x of the difference between the
+                            !! geopotential anomaly at the top and bottom of the layer divided by
+                            !! the x grid spacing, in m2 s-2.
+  real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), &
+              optional, intent(out) :: inty_dza !< The integral in y of the difference between the
+                            !! geopotential anomaly at the top and bottom of the layer divided by
+                            !! the y grid spacing, in m2 s-2.
+  integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate dza.
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(in)  :: bathyP  !< The pressure at the bathymetry in Pa
   real,       optional, intent(in)  :: dP_tiny !< A miniscule pressure change with
-                                             !! the same units as p_t (Pa?)
+                                               !! the same units as p_t (Pa?)
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
                             !! to interpolate T/S for top and bottom integrals.
 
@@ -614,45 +614,42 @@ end subroutine int_specific_vol_dp
 subroutine int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HII, HIO, EOS, &
                           dpa, intz_dpa, intx_dpa, inty_dpa, &
                           bathyT, dz_neglect, useMassWghtInterp)
-  !> Ocean horizontal index structures for the input arrays
-    type(hor_index_type),            intent(in)  :: HII
-  !> Ocean horizontal index structures for the output arrays
-    type(hor_index_type),            intent(in)  :: HIO
-  !> Potential temperature referenced to the surface (degC)
-    real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), intent(in)  :: T
-  !> Salinity (PSU)
-    real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), intent(in)  :: S
-  !> Height at the top of the layer in m.
-    real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), intent(in)  :: z_t
-  !> Height at the bottom of the layer in m.
-    real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), intent(in)  :: z_b
-  !> A mean density, in kg m-3, that is subtracted out to reduce the magnitude
-  !! of each of the integrals. (The pressure is calculated as p~=-z*rho_0*G_e.)
-    real,                            intent(in)  :: rho_ref
-  !> A density, in kg m-3, that is used to calculate the pressure
-  !! (as p~=-z*rho_0*G_e) used in the equation of state.
-    real,                            intent(in)  :: rho_0
-  !> The Earth's gravitational acceleration, in m s-2.
-    real,                            intent(in)  :: G_e
-  !> Equation of state structure
-    type(EOS_type),                  pointer     :: EOS
-  !> The change in the pressure anomaly across the layer, in Pa.
-    real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), intent(out) :: dpa
-  !> The integral through the thickness of the layer of the pressure anomaly
-  !! relative to the anomaly at the top of the layer, in Pa m.
-    real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed),  optional, intent(out) :: intz_dpa
-  !> The integral in x of the difference between the pressure anomaly at the
-  !! top and bottom of the layer divided by the x grid spacing, in Pa.
-    real, dimension(HIO%IsdB:HIO%IedB,HIO%jsd:HIO%jed), optional, intent(out) :: intx_dpa
-  !> The integral in y of the difference between the pressure anomaly at the
-  !! top and bottom of the layer divided by the y grid spacing, in Pa.
-    real, dimension(HIO%isd:HIO%ied,HIO%JsdB:HIO%JedB), optional, intent(out) :: inty_dpa
+  type(hor_index_type), intent(in)  :: HII !< Ocean horizontal index structures for the input arrays
+  type(hor_index_type), intent(in)  :: HIO !< Ocean horizontal index structures for the output arrays
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: T   !< Potential temperature referenced to the surface (degC)
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: S   !< Salinity (PSU)
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: z_t !< Height at the top of the layer in m.
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: z_b !< Height at the bottom of the layer in m.
+  real,                 intent(in)  :: rho_ref !< A mean density, in kg m-3, that is subtracted out to
+                                           !! reduce the magnitude of each of the integrals.
+  real,                 intent(in)  :: rho_0 !< A density, in kg m-3, that is used to calculate the
+                                           !! pressure (as p~=-z*rho_0*G_e) used in the equation of state.
+  real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration, in m s-2.
+  type(EOS_type),       pointer     :: EOS !< Equation of state structure
+  real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
+                        intent(out) :: dpa !< The change in the pressure anomaly across the layer, in Pa.
+  real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
+              optional, intent(out) :: intz_dpa !< The integral through the thickness of the layer of
+                                           !! the pressure anomaly relative to the anomaly at the
+                                           !! top of the layer, in Pa m.
+  real, dimension(HIO%IsdB:HIO%IedB,HIO%jsd:HIO%jed), &
+              optional, intent(out) :: intx_dpa !< The integral in x of the difference between the
+                                           !! pressure anomaly at the top and bottom of the layer
+                                           !! divided by the x grid spacing, in Pa.
+  real, dimension(HIO%isd:HIO%ied,HIO%JsdB:HIO%JedB), &
+              optional, intent(out) :: inty_dpa !< The integral in y of the difference between the
+                                           !! pressure anomaly at the top and bottom of the layer
+                                           !! divided by the y grid spacing, in Pa.
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
               optional, intent(in)  :: bathyT !< The depth of the bathymetry in m
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change with the
-                                          !! same units as z_t
+                                           !! same units as z_t
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
-                                          !! interpolate T/S for top and bottom integrals.
+                                           !! interpolate T/S for top and bottom integrals.
 
   if (.not.associated(EOS)) call MOM_error(FATAL, &
     "int_density_dz called with an unassociated EOS_type EOS.")
@@ -792,17 +789,23 @@ end subroutine EOS_init
 !> Manually initialized an EOS type (intended for unit testing of routines which need a specific EOS)
 subroutine EOS_manual_init(EOS, form_of_EOS, form_of_TFreeze, EOS_quadrature, Compressible, &
                            Rho_T0_S0, drho_dT, dRho_dS, TFr_S0_P0, dTFr_dS, dTFr_dp)
-  type(EOS_type),    pointer       :: EOS
-  integer, optional, intent(in   ) :: form_of_EOS
-  integer, optional, intent(in   ) :: form_of_TFreeze
-  logical, optional, intent(in   ) :: EOS_quadrature
-  logical, optional, intent(in   ) :: Compressible
-  real   , optional, intent(in   ) :: Rho_T0_S0
-  real   , optional, intent(in   ) :: drho_dT
-  real   , optional, intent(in   ) :: dRho_dS
-  real   , optional, intent(in   ) :: TFr_S0_P0
-  real   , optional, intent(in   ) :: dTFr_dS
-  real   , optional, intent(in   ) :: dTFr_dp
+  type(EOS_type),    pointer    :: EOS !< Equation of state structure
+  integer, optional, intent(in) :: form_of_EOS !< A coded integer indicating the equation of state to use.
+  integer, optional, intent(in) :: form_of_TFreeze !< A coded integer indicating the expression for
+                                       !! the potential temperature of the freezing point.
+  logical, optional, intent(in) :: EOS_quadrature !< If true, always use the generic (quadrature)
+                                       !! code for the integrals of density.
+  logical, optional, intent(in) :: Compressible  !< If true, in situ density is a function of pressure.
+  real   , optional, intent(in) :: Rho_T0_S0 !< Density at T=0 degC and S=0 ppt (kg m-3)
+  real   , optional, intent(in) :: drho_dT   !< Partial derivative of density with temperature
+                                             !! in (kg m-3 degC-1)
+  real   , optional, intent(in) :: dRho_dS   !< Partial derivative of density with salinity
+                                             !! in (kg m-3 ppt-1)
+  real   , optional, intent(in) :: TFr_S0_P0 !< The freezing potential temperature at S=0, P=0 in deg C.
+  real   , optional, intent(in) :: dTFr_dS   !< The derivative of freezing point with salinity,
+                                             !! in deg C PSU-1.
+  real   , optional, intent(in) :: dTFr_dp   !< The derivative of freezing point with pressure,
+                                             !! in deg C Pa-1.
 
   if (present(form_of_EOS    ))  EOS%form_of_EOS     = form_of_EOS
   if (present(form_of_TFreeze))  EOS%form_of_TFreeze = form_of_TFreeze
@@ -840,7 +843,8 @@ subroutine EOS_use_linear(Rho_T0_S0, dRho_dT, dRho_dS, EOS, use_quadrature)
   real,              intent(in) :: Rho_T0_S0 !< Density at T=0 degC and S=0 ppt (kg m-3)
   real,              intent(in) :: dRho_dT   !< Partial derivative of density with temperature (kg m-3 degC-1)
   real,              intent(in) :: dRho_dS   !< Partial derivative of density with salinity (kg m-3 ppt-1)
-  logical, optional, intent(in) :: use_quadrature !< Partial derivative of density with salinity (kg m-3 ppt-1)
+  logical, optional, intent(in) :: use_quadrature !< If true, always use the generic (quadrature)
+                                             !! code for the integrals of density.
   type(EOS_type),    pointer    :: EOS       !< Equation of state structure
 
   if (.not.associated(EOS)) call MOM_error(FATAL, &
@@ -1051,30 +1055,48 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
                                        rho_0, G_e, dz_subroundoff, bathyT, HII, HIO, EOS, dpa, &
                                        intz_dpa, intx_dpa, inty_dpa, &
                                        useMassWghtInterp)
-  type(hor_index_type),   intent(in)  :: HII, HIO
+  type(hor_index_type), intent(in)  :: HII !< Ocean horizontal index structures for the input arrays
+  type(hor_index_type), intent(in)  :: HIO !< Ocean horizontal index structures for the output arrays
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
-                          intent(in)  :: T_t, T_b, S_t, S_b
+                        intent(in)  :: T_t !< Potential temperatue at the cell top (degC)
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
-                          intent(in)  :: z_t !< The geometric height at the top
-                                             !! of the layer, usually in m
+                        intent(in)  :: T_b !< Potential temperatue at the cell bottom (degC)
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
-                          intent(in)  :: z_b !< The geometric height at the bpttom
-                                             !! of the layer, usually in m
-  real,                   intent(in)  :: rho_ref, rho_0, G_e
-  real,                   intent(in)  :: dz_subroundoff !< A miniscule thickness
-                                             !! change with the same units as z_t
+                        intent(in)  :: S_t !< Salinity at the cell top (ppt)
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
-                          intent(in)  :: bathyT !< The depth of the bathymetry in m
-  type(EOS_type),         pointer     :: EOS !< Equation of state structure
+                        intent(in)  :: S_b !< Salinity at the cell bottom (ppt)
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: z_t !< The geometric height at the top
+                                           !! of the layer, usually in m
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: z_b !< The geometric height at the bottom
+                                           !! of the layer, usually in m
+  real,                 intent(in)  :: rho_ref !< A mean density, in kg m-3, that is subtracted out to
+                                           !! reduce the magnitude of each of the integrals.
+  real,                 intent(in)  :: rho_0 !< A density, in kg m-3, that is used to calculate the
+                                           !! pressure (as p~=-z*rho_0*G_e) used in the equation of state.
+  real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration, in m s-2.
+  real,                 intent(in)  :: dz_subroundoff !< A miniscule thickness
+                                           !! change with the same units as z_t
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: bathyT !< The depth of the bathymetry in m
+  type(EOS_type),       pointer     :: EOS !< Equation of state structure
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-                          intent(out) :: dpa
+                        intent(out) :: dpa !< The change in the pressure anomaly across the layer, in Pa.
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-                optional, intent(out) :: intz_dpa
+              optional, intent(out) :: intz_dpa !< The integral through the thickness of the layer of
+                                           !! the pressure anomaly relative to the anomaly at the
+                                           !! top of the layer, in Pa m.
   real, dimension(HIO%IsdB:HIO%IedB,HIO%jsd:HIO%jed), &
-                optional, intent(out) :: intx_dpa
+              optional, intent(out) :: intx_dpa !< The integral in x of the difference between the
+                                           !! pressure anomaly at the top and bottom of the layer
+                                           !! divided by the x grid spacing, in Pa.
   real, dimension(HIO%isd:HIO%ied,HIO%JsdB:HIO%JedB), &
-                optional, intent(out) :: inty_dpa
-  logical,      optional, intent(in)  :: useMassWghtInterp
+              optional, intent(out) :: inty_dpa !< The integral in y of the difference between the
+                                           !! pressure anomaly at the top and bottom of the layer
+                                           !! divided by the y grid spacing, in Pa.
+  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
+                                           !! interpolate T/S for top and bottom integrals.
 ! This subroutine calculates (by numerical quadrature) integrals of
 ! pressure anomalies across layers, which are required for calculating the
 ! finite-volume form pressure accelerations in a Boussinesq model.  The one
@@ -1423,8 +1445,17 @@ end subroutine find_depth_of_pressure_in_cell
 !> Returns change in anomalous pressure change from top to non-dimensional
 !! position pos between z_t and z_b
 real function frac_dp_at_pos(T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, G_e, pos, EOS)
-  real,           intent(in) :: T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, G_e, pos
-  type(EOS_type), pointer    :: EOS !< Equation of state structure
+  real,           intent(in)  :: T_t !< Potential temperatue at the cell top (degC)
+  real,           intent(in)  :: T_b !< Potential temperatue at the cell bottom (degC)
+  real,           intent(in)  :: S_t !< Salinity at the cell top (ppt)
+  real,           intent(in)  :: S_b !< Salinity at the cell bottom (ppt)
+  real,           intent(in)  :: z_t !< The geometric height at the top of the layer, usually in m
+  real,           intent(in)  :: z_b !< The geometric height at the bottom of the layer, usually in m
+  real,           intent(in)  :: rho_ref !< A mean density, in kg m-3, that is subtracted out to
+                                     !! reduce the magnitude of each of the integrals.
+  real,           intent(in)  :: G_e !< The Earth's gravitational acceleration, in m s-2.
+  real,           intent(in)  :: pos !< The fractional vertical position, nondim.
+  type(EOS_type), pointer     :: EOS !< Equation of state structure
   ! Local variables
   real, parameter :: C1_90 = 1.0/90.0  ! Rational constants.
   real :: dz, top_weight, bottom_weight, rho_ave
@@ -1452,26 +1483,51 @@ end function frac_dp_at_pos
 
 
 ! ==========================================================================
-! Compute pressure gradient force integrals for the case where T and S
-! are parabolic profiles
-! ==========================================================================
+!> Compute pressure gradient force integrals for the case where T and S
+!! are parabolic profiles
 subroutine int_density_dz_generic_ppm (T, T_t, T_b, S, S_t, S_b, &
                                        z_t, z_b, rho_ref, rho_0, G_e, HII, HIO, &
                                        EOS, dpa, intz_dpa, intx_dpa, inty_dpa)
 
-  type(hor_index_type), intent(in)  :: HII, HIO
+  type(hor_index_type), intent(in)  :: HII !< Ocean horizontal index structures for the input arrays
+  type(hor_index_type), intent(in)  :: HIO !< Ocean horizontal index structures for the output arrays
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
-                        intent(in)  :: T, T_t, T_b, S, S_t, S_b, z_t, z_b
-  real,                                    intent(in)  :: rho_ref, rho_0, G_e
+                        intent(in)  :: T   !< Potential temperature referenced to the surface (degC)
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: T_t !< Potential temperatue at the cell top (degC)
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: T_b !< Potential temperatue at the cell bottom (degC)
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: S   !< Salinity (PSU)
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: S_t !< Salinity at the cell top (ppt)
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: S_b !< Salinity at the cell bottom (ppt)
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: z_t !< Height at the top of the layer in m.
+  real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
+                        intent(in)  :: z_b !< Height at the bottom of the layer in m.
+  real,                 intent(in)  :: rho_ref !< A mean density, in kg m-3, that is subtracted out to
+                                           !! reduce the magnitude of each of the integrals.
+  real,                 intent(in)  :: rho_0 !< A density, in kg m-3, that is used to calculate the
+                                           !! pressure (as p~=-z*rho_0*G_e) used in the equation of state.
+  real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration, in m s-2.
   type(EOS_type),       pointer     :: EOS !< Equation of state structure
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-                        intent(out) :: dpa
+                        intent(out) :: dpa !< The change in the pressure anomaly across the layer, in Pa.
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intz_dpa
-  real, dimension(HIO%IsdB:HIO%IedB,HIO%JsdB:HIO%JedB), &
-              optional, intent(out) :: intx_dpa
+              optional, intent(out) :: intz_dpa !< The integral through the thickness of the layer of
+                                           !! the pressure anomaly relative to the anomaly at the
+                                           !! top of the layer, in Pa m.
+  real, dimension(HIO%IsdB:HIO%IedB,HIO%jsd:HIO%jed), &
+              optional, intent(out) :: intx_dpa !< The integral in x of the difference between the
+                                           !! pressure anomaly at the top and bottom of the layer
+                                           !! divided by the x grid spacing, in Pa.
   real, dimension(HIO%isd:HIO%ied,HIO%JsdB:HIO%JedB), &
-              optional, intent(out) :: inty_dpa
+              optional, intent(out) :: inty_dpa !< The integral in y of the difference between the
+                                           !! pressure anomaly at the top and bottom of the layer
+                                           !! divided by the y grid spacing, in Pa.
+
 ! This subroutine calculates (by numerical quadrature) integrals of
 ! pressure anomalies across layers, which are required for calculating the
 ! finite-volume form pressure accelerations in a Boussinesq model.  The one
@@ -1706,14 +1762,12 @@ end subroutine int_density_dz_generic_ppm
 
 
 ! =============================================================================
-! Compute integral of quadratic function
-! =============================================================================
-subroutine compute_integral_quadratic ( x, y, f, integral )
-
-  ! Arguments
-  real, intent(in), dimension(4)    :: x, y
-  real, intent(in), dimension(9)    :: f
-  real, intent(out)                 :: integral
+!> Compute the integral of the quadratic function
+subroutine compute_integral_quadratic( x, y, f, integral )
+  real, dimension(4), intent(in)  :: x  !< The x-position of the corners
+  real, dimension(4), intent(in)  :: y  !< The y-position of the corners
+  real, dimension(9), intent(in)  :: f  !< The function at the quadrature points
+  real,               intent(out) :: integral !< The returned integral
 
   ! Local variables
   integer               :: i, k
@@ -1791,16 +1845,17 @@ end subroutine compute_integral_quadratic
 
 
 ! =============================================================================
-! Evaluation of the four bilinear shape fn and their gradients at (xi,eta)
-! =============================================================================
-subroutine evaluate_shape_bilinear ( xi, eta, phi, dphidxi, dphideta )
+!> Evaluation of the four bilinear shape fn and their gradients at (xi,eta)
+subroutine evaluate_shape_bilinear( xi, eta, phi, dphidxi, dphideta )
+  real,               intent(in)  :: xi  !< The x position to evaluate
+  real,               intent(in)  :: eta !< The z position to evaluate
+  real, dimension(4), intent(out) :: phi !< The weights of the four corners at this point
+  real, dimension(4), intent(out) :: dphidxi  !< The x-gradient of the weights of the four
+                                         !! corners at this point
+  real, dimension(4), intent(out) :: dphideta !< The z-gradient of the weights of the four
+                                         !! corners at this point
 
-  ! Arguments
-  real, intent(in)                  :: xi, eta
-  real, dimension(4), intent(out)   :: phi, dphidxi, dphideta
-
-  ! The shape functions within the parent element are defined as shown
-  ! here:
+  ! The shape functions within the parent element are defined as shown here:
   !
   !    (-1,1) 2 o------------o 1 (1,1)
   !             |            |
@@ -1829,16 +1884,20 @@ end subroutine evaluate_shape_bilinear
 
 
 ! =============================================================================
-! Evaluation of the nine quadratic shape fn and their gradients at (xi,eta)
-! =============================================================================
+!> Evaluation of the nine quadratic shape fn weights and their gradients at (xi,eta)
 subroutine evaluate_shape_quadratic ( xi, eta, phi, dphidxi, dphideta )
 
   ! Arguments
-  real, intent(in)                  :: xi, eta
-  real, dimension(9), intent(out)   :: phi, dphidxi, dphideta
+  real,               intent(in)  :: xi  !< The x position to evaluate
+  real,               intent(in)  :: eta !< The z position to evaluate
+  real, dimension(9), intent(out) :: phi !< The weights of the 9 bilinear quadrature points
+                                         !! at this point
+  real, dimension(9), intent(out) :: dphidxi  !< The x-gradient of the weights of the 9 bilinear
+                                         !! quadrature points corners at this point
+  real, dimension(9), intent(out) :: dphideta !< The z-gradient of the weights of the 9 bilinear
+                                         !! quadrature points corners at this point
 
-  ! The quadratic shape functions within the parent element are
-  ! defined as shown here:
+  ! The quadratic shape functions within the parent element are defined as shown here:
   !
   !                 5 (0,1)
   !    (-1,1) 2 o------o------o 1 (1,1)
@@ -1851,9 +1910,9 @@ subroutine evaluate_shape_quadratic ( xi, eta, phi, dphidxi, dphideta )
   !                 7 (0,-1)
   !
 
-  phi      = 0.0
-  dphidxi  = 0.0
-  dphideta = 0.0
+  phi(:)   = 0.0
+  dphidxi(:)  = 0.0
+  dphideta(:) = 0.0
 
   phi(1) = 0.25 * xi * ( 1 + xi ) * eta * ( 1 + eta )
   phi(2) = - 0.25 * xi * ( 1 - xi ) * eta * ( 1 + eta )
@@ -2310,21 +2369,18 @@ end subroutine int_spec_vol_dp_generic_plm
 !> Convert T&S to Absolute Salinity and Conservative Temperature if using TEOS10
 subroutine convert_temp_salt_for_TEOS10(T, S, press, G, kd, mask_z, EOS)
   use MOM_grid, only : ocean_grid_type
-  !> The horizontal index structure
-  type(ocean_grid_type),                      intent(in)  :: G    !< The ocean's grid structure
 
-  !> Potential temperature referenced to the surface (degC)
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)),  intent(inout)  :: T
-  !> Salinity (PSU)
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)),  intent(inout)  :: S
-  !> Pressure at the top of the layer in Pa.
-  real, dimension(:),                            intent(in)  :: press
-  !> Equation of state structure
-  type(EOS_type), pointer                                 :: EOS
-  !> 3d mask
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)),  intent(in)  :: mask_z
-  integer,                                    intent(in)  :: kd
-  !
+  type(ocean_grid_type), intent(in)    :: G   !< The ocean's grid structure
+  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), &
+                         intent(inout) :: T   !< Potential temperature referenced to the surface (degC)
+  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), &
+                         intent(inout) :: S   !< Salinity (PSU)
+  real, dimension(:),    intent(in)    :: press !< Pressure at the top of the layer in Pa.
+  type(EOS_type),        pointer       :: EOS !< Equation of state structure
+  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), &
+                         intent(in)    :: mask_z !< 3d mask regulating which points to convert.
+  integer,               intent(in)    :: kd  !< The number of layers to work on
+
   integer :: i,j,k
   real :: gsw_sr_from_sp, gsw_ct_from_pt, gsw_sa_from_sp
   real :: p
@@ -2344,20 +2400,26 @@ subroutine convert_temp_salt_for_TEOS10(T, S, press, G, kd, mask_z, EOS)
   enddo ; enddo ; enddo
 end subroutine convert_temp_salt_for_TEOS10
 
-! Extractor routine for the EOS type if the members need to be accessed outside this module
+!> Extractor routine for the EOS type if the members need to be accessed outside this module
 subroutine extract_member_EOS(EOS, form_of_EOS, form_of_TFreeze, EOS_quadrature, Compressible, &
                               Rho_T0_S0, drho_dT, dRho_dS, TFr_S0_P0, dTFr_dS, dTFr_dp)
-  type(EOS_type), pointer :: EOS
-  integer, optional, intent(out) :: form_of_EOS
-  integer, optional, intent(out) :: form_of_TFreeze
-  logical, optional, intent(out) :: EOS_quadrature
-  logical, optional, intent(out) :: Compressible
-  real   , optional, intent(out) :: Rho_T0_S0
-  real   , optional, intent(out) :: drho_dT
-  real   , optional, intent(out) :: dRho_dS
-  real   , optional, intent(out) :: TFr_S0_P0
-  real   , optional, intent(out) :: dTFr_dS
-  real   , optional, intent(out) :: dTFr_dp
+  type(EOS_type),    pointer     :: EOS !< Equation of state structure
+  integer, optional, intent(out) :: form_of_EOS !< A coded integer indicating the equation of state to use.
+  integer, optional, intent(out) :: form_of_TFreeze !< A coded integer indicating the expression for
+                                       !! the potential temperature of the freezing point.
+  logical, optional, intent(out) :: EOS_quadrature !< If true, always use the generic (quadrature)
+                                       !! code for the integrals of density.
+  logical, optional, intent(out) :: Compressible !< If true, in situ density is a function of pressure.
+  real   , optional, intent(out) :: Rho_T0_S0 !< Density at T=0 degC and S=0 ppt (kg m-3)
+  real   , optional, intent(out) :: drho_dT   !< Partial derivative of density with temperature
+                                              !! in (kg m-3 degC-1)
+  real   , optional, intent(out) :: dRho_dS   !< Partial derivative of density with salinity
+                                              !! in (kg m-3 ppt-1)
+  real   , optional, intent(out) :: TFr_S0_P0 !< The freezing potential temperature at S=0, P=0 in deg C.
+  real   , optional, intent(out) :: dTFr_dS   !< The derivative of freezing point with salinity,
+                                              !! in deg C PSU-1.
+  real   , optional, intent(out) :: dTFr_dp   !< The derivative of freezing point with pressure,
+                                              !! in deg C Pa-1.
 
   if (present(form_of_EOS    ))  form_of_EOS     = EOS%form_of_EOS
   if (present(form_of_TFreeze))  form_of_TFreeze = EOS%form_of_TFreeze

--- a/src/equation_of_state/MOM_EOS_NEMO.F90
+++ b/src/equation_of_state/MOM_EOS_NEMO.F90
@@ -337,9 +337,13 @@ end subroutine calculate_density_derivs_array_nemo
 
 !> Wrapper to calculate_density_derivs_array for scalar inputs
 subroutine calculate_density_derivs_scalar_nemo(T, S, pressure, drho_dt, drho_ds)
-  real,    intent(in)  :: T, S, pressure
-  real,    intent(out) :: drho_dt
-  real,    intent(out) :: drho_ds
+  real,    intent(in)  :: T        !< Potential temperature relative to the surface in C.
+  real,    intent(in)  :: S        !< Salinity in PSU.
+  real,    intent(in)  :: pressure !< Pressure in Pa.
+  real,    intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                   !! temperature, in kg m-3 K-1.
+  real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                   !! in kg m-3 psu-1.
   ! Local variables
   real :: al0, p0, lambda
   integer :: j

--- a/src/equation_of_state/MOM_EOS_TEOS10.F90
+++ b/src/equation_of_state/MOM_EOS_TEOS10.F90
@@ -187,8 +187,13 @@ subroutine calculate_density_derivs_array_teos10(T, S, pressure, drho_dT, drho_d
 end subroutine calculate_density_derivs_array_teos10
 
 subroutine calculate_density_derivs_scalar_teos10(T, S, pressure, drho_dT, drho_dS)
-  real,    intent(in)  ::  T, S, pressure
-  real,    intent(out) :: drho_dT, drho_dS
+  real,    intent(in)  :: T        !< Conservative temperature in C
+  real,    intent(in)  :: S        !< Absolute Salinity in g/kg
+  real,    intent(in)  :: pressure !< Pressure in Pa.
+  real,    intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                   !! temperature, in kg m-3 K-1.
+  real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                   !! in kg m-3 psu-1.
   ! Local variables
   real :: zs,zt,zp
   !Conversions
@@ -238,7 +243,9 @@ end subroutine calculate_specvol_derivs_teos10
 !> Calculate the 5 second derivatives of the equation of state for scalar inputs
 subroutine calculate_density_second_derivs_scalar_teos10(T, S, pressure, drho_dS_dS, drho_dS_dT, &
                                                          drho_dT_dT, drho_dS_dP, drho_dT_dP)
-  real, intent(in)     :: T, S, pressure
+  real, intent(in)     :: T          !< Conservative temperature in C
+  real, intent(in)     :: S          !< Absolute Salinity in g/kg
+  real, intent(in)     :: pressure   !< Pressure in Pa.
   real, intent(out)    :: drho_dS_dS !< Partial derivative of beta with respect to S
   real, intent(out)    :: drho_dS_dT !< Partial derivative of beta with resepct to T
   real, intent(out)    :: drho_dT_dT !< Partial derivative of alpha with respect to T
@@ -266,7 +273,9 @@ end subroutine calculate_density_second_derivs_scalar_teos10
 !> Calculate the 5 second derivatives of the equation of state for scalar inputs
 subroutine calculate_density_second_derivs_array_teos10(T, S, pressure, drho_dS_dS, drho_dS_dT, &
                                                         drho_dT_dT, drho_dS_dP, drho_dT_dP, start, npts)
-  real, dimension(:), intent(in)     :: T, S, pressure
+  real, dimension(:), intent(in)     :: T          !< Conservative temperature in C
+  real, dimension(:), intent(in)     :: S          !< Absolute Salinity in g/kg
+  real, dimension(:), intent(in)     :: pressure   !< Pressure in Pa.
   real, dimension(:), intent(out)    :: drho_dS_dS !< Partial derivative of beta with respect to S
   real, dimension(:), intent(out)    :: drho_dS_dT !< Partial derivative of beta with resepct to T
   real, dimension(:), intent(out)    :: drho_dT_dT !< Partial derivative of alpha with respect to T

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -219,10 +219,9 @@ end subroutine calculate_density_derivs_array_wright
 !> The scalar version of calculate_density_derivs which promotes scalar inputs to a 1-element array and then
 !! demotes the output back to a scalar
 subroutine calculate_density_derivs_scalar_wright(T, S, pressure, drho_dT, drho_dS)
-  real,    intent(in) :: T        !< Potential temperature relative to the surface
-                                  !! in C.
-  real,    intent(in) :: S        !< Salinity in PSU.
-  real,    intent(in) :: pressure !< Pressure in Pa.
+  real,    intent(in)  :: T        !< Potential temperature relative to the surface in C.
+  real,    intent(in)  :: S        !< Salinity in PSU.
+  real,    intent(in)  :: pressure !< Pressure in Pa.
   real,    intent(out) :: drho_dT  !< The partial derivative of density with potential
                                    !! temperature, in kg m-3 K-1.
   real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
@@ -409,7 +408,8 @@ end subroutine calculate_compress_wright
 subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HII, HIO, &
                                  dpa, intz_dpa, intx_dpa, inty_dpa, &
                                  bathyT, dz_neglect, useMassWghtInterp)
-  type(hor_index_type), intent(in)  :: HII, HIO
+  type(hor_index_type), intent(in)  :: HII      !< The horizontal index type for the input arrays.
+  type(hor_index_type), intent(in)  :: HIO      !< The horizontal index type for the output arrays.
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
                         intent(in)  :: T        !< Potential temperature relative to the surface
                                                 !! in C.
@@ -613,7 +613,7 @@ end subroutine int_density_dz_wright
 subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
                                   intp_dza, intx_dza, inty_dza, halo_size, &
                                   bathyP, dP_neglect, useMassWghtInterp)
-  type(hor_index_type), intent(in)  :: HI
+  type(hor_index_type), intent(in)  :: HI        !< The ocean's horizontal index type.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T         !< Potential temperature relative to the surface
                                                  !! in C.

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -364,7 +364,8 @@ end subroutine calculate_compress_linear
 subroutine int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0_pres, G_e, HII, HIO, &
                  Rho_T0_S0, dRho_dT, dRho_dS, dpa, intz_dpa, intx_dpa, inty_dpa, &
                  bathyT, dz_neglect, useMassWghtInterp)
-  type(hor_index_type), intent(in)  :: HII, HIO
+  type(hor_index_type), intent(in)  :: HII       !< The horizontal index type for the input arrays.
+  type(hor_index_type), intent(in)  :: HIO       !< The horizontal index type for the output arrays.
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
                         intent(in)  :: T         !< Potential temperature relative to the surface
                                                  !! in C.

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -274,7 +274,7 @@ subroutine calculate_density_second_derivs_array_linear(T, S,pressure,  drho_dS_
 
 end subroutine calculate_density_second_derivs_array_linear
 
-! #@# This subroutine needs a doxygen description.
+!> Calculate the derivatives of specific volume with temperature and salinity
 subroutine calculate_specvol_derivs_linear(T, S, pressure, dSV_dT, dSV_dS, &
                              start, npts, Rho_T0_S0, dRho_dT, dRho_dS)
   real,    intent(in),  dimension(:) :: T         !< Potential temperature relative to the surface
@@ -288,19 +288,11 @@ subroutine calculate_specvol_derivs_linear(T, S, pressure, dSV_dT, dSV_dS, &
   integer, intent(in)                :: start     !< The starting point in the arrays.
   integer, intent(in)                :: npts      !< The number of values to calculate.
   real,    intent(in)                :: Rho_T0_S0 !< The density at T=0, S=0, in kg m-3.
-  real,    intent(in)                :: dRho_dT, dRho_dS !< The derivatives of density with
-                                                  !! temperature and salinity, in kg m-3 C-1
-                                                  !! and kg m-3 psu-1.
+  real,    intent(in)                :: dRho_dT   !< The derivative of density with
+                                                  !! temperature, in kg m-3 C-1.
+  real,    intent(in)                :: dRho_dS   !< The derivative of density with
+                                                  !! salinity, in kg m-3 psu-1.
 
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in g/kg.                                   *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     dSV_dT - the partial derivative of specific volume with *
-! *                     potential temperature, in m3 kg-1 K-1.         *
-! *  (out)     dSV_dS - the partial derivative of specific volume with *
-! *                      salinity, in m3 kg-1 / (g/kg).                *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
   real :: I_rho2
   integer :: j
 

--- a/src/equation_of_state/MOM_TFreeze.F90
+++ b/src/equation_of_state/MOM_TFreeze.F90
@@ -26,11 +26,20 @@ end interface calculate_TFreeze_teos10
 
 contains
 
+!>  This subroutine computes the freezing point potential temparature
+!!  (in deg C) from salinity (in psu), and pressure (in Pa) using a simple
+!!  linear expression, with coefficients passed in as arguments.
 subroutine calculate_TFreeze_linear_scalar(S, pres, T_Fr, TFr_S0_P0, &
                                            dTFr_dS, dTFr_dp)
-  real,    intent(in)  :: S, pres
-  real,    intent(out) :: T_Fr
-  real,    intent(in)  :: TFr_S0_P0, dTFr_dS, dTFr_dp
+  real,  intent(in)  :: S         !< salinity in PSU.
+  real,  intent(in)  :: pres      !< pressure in Pa.
+  real,  intent(out) :: T_Fr      !< Freezing point potential temperature in deg C.
+  real,  intent(in)  :: TFr_S0_P0 !< The freezing point at S=0, p=0, in deg C.
+  real,  intent(in)  :: dTFr_dS   !< The derivative of freezing point with salinity,
+                                  !! in deg C PSU-1.
+  real,  intent(in)  :: dTFr_dp   !< The derivative of freezing point with pressure,
+                                  !! in deg C Pa-1.
+
 !    This subroutine computes the freezing point potential temparature
 !  (in deg C) from salinity (in psu), and pressure (in Pa) using a simple
 !  linear expression, with coefficients passed in as arguments.
@@ -48,7 +57,7 @@ subroutine calculate_TFreeze_linear_scalar(S, pres, T_Fr, TFr_S0_P0, &
 
 end subroutine calculate_TFreeze_linear_scalar
 
-!>  This subroutine computes the freezing point potential temparature
+!>  This subroutine computes an array of freezing point potential temparatures
 !!  (in deg C) from salinity (in psu), and pressure (in Pa) using a simple
 !!  linear expression, with coefficients passed in as arguments.
 subroutine calculate_TFreeze_linear_array(S, pres, T_Fr, start, npts, &

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -416,7 +416,7 @@ subroutine set_masks_for_axes(G, diag_cs)
                                                        !! used for diagnostics
   ! Local variables
   integer :: c, nk, i, j, k
-  type(axes_grp), pointer :: axes, h_axes ! Current axes, for convenience
+  type(axes_grp), pointer :: axes => NULL(), h_axes => NULL() ! Current axes, for convenience
 
   do c=1, diag_cs%num_diag_coords
     ! This vertical coordinate has been configured so can be used.
@@ -555,7 +555,7 @@ subroutine diag_associate_volume_cell_measure(diag_cs, id_h_volume)
   type(diag_ctrl),   intent(inout) :: diag_cs     !< Diagnostics control structure
   integer,           intent(in)    :: id_h_volume !< Diag_manager id for volume of h-cells
   ! Local variables
-  type(diag_type), pointer :: tmp
+  type(diag_type), pointer :: tmp => NULL()
 
   if (id_h_volume<=0) return ! Do nothing
   diag_cs%volume_cell_measure_dm_id = id_h_volume ! Record for diag_get_volume_cell_measure_dm_id()
@@ -959,7 +959,7 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
   integer :: nz, i, j, k
   real, dimension(:,:,:), allocatable :: remapped_field
   logical :: staggered_in_x, staggered_in_y
-  real, dimension(:,:,:), pointer :: h_diag
+  real, dimension(:,:,:), pointer :: h_diag => NULL()
 
   if (present(alt_h)) then
     h_diag => alt_h
@@ -2128,7 +2128,7 @@ function ocean_register_diag(var_desc, G, diag_CS, day)
   character(len=48) :: units            ! A variable's units.
   character(len=240) :: longname        ! A variable's longname.
   character(len=8) :: hor_grid, z_grid  ! Variable grid info.
-  type(axes_grp), pointer :: axes
+  type(axes_grp), pointer :: axes => NULL()
 
   call query_vardesc(var_desc, units=units, longname=longname, hor_grid=hor_grid, &
                      z_grid=z_grid, caller="ocean_register_diag")
@@ -2426,7 +2426,8 @@ subroutine diag_update_remap_grids(diag_cs, alt_h, alt_T, alt_S)
                                                         !! the current salinity
   ! Local variables
   integer :: i
-  real, dimension(:,:,:), pointer :: h_diag, T_diag, S_diag
+  real, dimension(:,:,:), pointer :: h_diag => NULL()
+  real, dimension(:,:,:), pointer :: T_diag => NULL(), S_diag => NULL()
 
   if (present(alt_h)) then
     h_diag => alt_h
@@ -2637,7 +2638,7 @@ subroutine alloc_diag_with_id(diag_id, diag_cs, diag)
   type(diag_ctrl), target, intent(inout) :: diag_cs !< structure used to regulate diagnostic output
   type(diag_type),         pointer       :: diag    !< structure representing a diagnostic (inout)
 
-  type(diag_type), pointer :: tmp
+  type(diag_type), pointer :: tmp => NULL()
 
   if (.not. diag_cs%diags(diag_id)%in_use) then
     diag => diag_cs%diags(diag_id)

--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -884,7 +884,7 @@ end function find_unused_unit_number
 subroutine doc_end(doc)
   type(doc_type), pointer :: doc !< A pointer to a structure that controls where the
                                  !! documentation occurs and its formatting
-  type(link_msg), pointer :: this, next
+  type(link_msg), pointer :: this => NULL(), next => NULL()
 
   if (.not.associated(doc)) return
 
@@ -929,7 +929,7 @@ function mesgHasBeenDocumented(doc,varName,mesg)
                                         !! to compare with the message that was written previously
   logical                       :: mesgHasBeenDocumented
 ! Returns true if documentation has already been written
-  type(link_msg), pointer :: newLink, this, last
+  type(link_msg), pointer :: newLink => NULL(), this => NULL(), last => NULL()
 
   mesgHasBeenDocumented = .false.
 

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -146,7 +146,7 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
   logical :: file_exists, unit_in_use, Netcdf_file, may_check
   integer :: ios, iounit, strlen, i
   character(len=240) :: doc_path
-  type(parameter_block), pointer :: block
+  type(parameter_block), pointer :: block => NULL()
 
   may_check = .true. ; if (present(checkable)) may_check = checkable
 
@@ -1248,11 +1248,12 @@ end subroutine flag_line_as_read
 
 !> Returns true if an override warning has been issued for the variable varName
 function overrideWarningHasBeenIssued(chain, varName)
-  type(link_parameter), pointer    :: chain
+  type(link_parameter), pointer    :: chain   !< The linked list of variables that have already had
+                                              !! override warnings issued
   character(len=*),     intent(in) :: varName !< The name of the variable being queried for warnings
   logical                          :: overrideWarningHasBeenIssued
 ! Returns true if an override warning has been issued for the variable varName
-  type(link_parameter), pointer :: newLink, this
+  type(link_parameter), pointer :: newLink => NULL(), this => NULL()
   overrideWarningHasBeenIssued = .false.
   this => chain
   do while( associated(this) )
@@ -2023,7 +2024,7 @@ subroutine clearParameterBlock(CS)
   type(param_file_type), intent(in) :: CS      !< The control structure for the file_parser module,
                                          !! it is also a structure to parse for run-time parameters
 ! Resets the parameter block name to blank
-  type(parameter_block), pointer :: block
+  type(parameter_block), pointer :: block => NULL()
   if (associated(CS%blockName)) then
     block => CS%blockName
     block%name = ''
@@ -2040,7 +2041,7 @@ subroutine openParameterBlock(CS,blockName,desc)
   character(len=*),           intent(in) :: blockName !< The name of a parameter block being added
   character(len=*), optional, intent(in) :: desc    !< A description of the parameter block being added
 ! Tags blockName onto the end of the active parameter block name
-  type(parameter_block), pointer :: block
+  type(parameter_block), pointer :: block => NULL()
   if (associated(CS%blockName)) then
     block => CS%blockName
     block%name = pushBlockLevel(block%name,blockName)
@@ -2056,7 +2057,7 @@ subroutine closeParameterBlock(CS)
   type(param_file_type), intent(in) :: CS      !< The control structure for the file_parser module,
                                          !! it is also a structure to parse for run-time parameters
 ! Remove the lowest level of recursion from the active block name
-  type(parameter_block), pointer :: block
+  type(parameter_block), pointer :: block => NULL()
 
   if (associated(CS%blockName)) then
     block => CS%blockName

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -55,7 +55,8 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
   logical,          optional, intent(in)    :: homogenize !< optionally homogenize to mean value
   logical,          optional, intent(in)    :: useALEremapping !< to remap or not (optional)
   character(len=*), optional, intent(in)    :: remappingScheme !< remapping scheme to use.
-  character(len=*), optional, intent(in)    :: src_var_gridspec ! Not implemented yet.
+  character(len=*), optional, intent(in)    :: src_var_gridspec !< Source variable name in a gridspec file.
+                                                                !! This is not implemented yet.
 
   real :: land_fill = 0.0
   character(len=200) :: inputdir ! The directory where NetCDF input files are.

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -535,12 +535,12 @@ contains
 
   !> Apply increments to tracers
   subroutine apply_oda_tracer_increments(dt,G,tv,h,CS)
-    real, intent(in) :: dt ! the tracer timestep (seconds)
-    type(ocean_grid_type),    intent(in)    :: G      !< ocean grid structure
-    type(thermo_var_ptrs),    intent(inout) :: tv     !< A structure pointing to various thermodynamic variables
+    real,                     intent(in)    :: dt !< The tracer timestep (seconds)
+    type(ocean_grid_type),    intent(in)    :: G  !< ocean grid structure
+    type(thermo_var_ptrs),    intent(inout) :: tv !< A structure pointing to various thermodynamic variables
     real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
-                              intent(in)    :: h      !< layer thickness (m or kg/m2)
-    type(ODA_CS),              intent(inout) :: CS     !< the data assimilation structure
+                              intent(in)    :: h  !< layer thickness (m or kg/m2)
+    type(ODA_CS),             intent(inout) :: CS !< the data assimilation structure
 
   end subroutine apply_oda_tracer_increments
 

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -64,7 +64,7 @@ module MOM_oda_driver_mod
                                                                      !! or increments to prior in DA space
      integer :: nk !< number of vertical layers used for DA
      type(ocean_grid_type), pointer :: Grid => NULL() !< MOM6 grid type and decomposition for the DA
-     type(pointer_mpp_domain), pointer, dimension(:) :: domains => NULL() !< Pointer to mpp_domain objects
+     type(ptr_mpp_domain), pointer, dimension(:) :: domains => NULL() !< Pointer to mpp_domain objects
                                                                           !! for ensemble members
      type(verticalGrid_type), pointer :: GV => NULL() !< vertical grid for DA
      type(domain2d), pointer :: mpp_domain => NULL() !< Pointer to a mpp domain object for DA
@@ -85,7 +85,7 @@ module MOM_oda_driver_mod
      ! Profiles local to the analysis domain
      type(ocean_profile_type), pointer :: Profiles => NULL() !< pointer to linked list of all available profiles
      type(ocean_profile_type), pointer :: CProfiles => NULL()!< pointer to linked list of current profiles
-     type(kd_root), pointer :: kdroot
+     type(kd_root), pointer :: kdroot => NULL()
      type(ALE_CS), pointer :: ALE_CS=>NULL() !< ALE control structure for DA
      logical :: use_ALE_algorithm !< true is using ALE remapping
      type(regridding_CS) :: regridCS !< ALE control structure for regridding
@@ -95,9 +95,9 @@ module MOM_oda_driver_mod
   end type ODA_CS
 
   !> pointer to a mpp_domain object
-  type :: pointer_mpp_domain
-     type(domain2d), pointer :: mpp_domain => NULL()
-  end type pointer_mpp_domain
+  type :: ptr_mpp_domain
+    type(domain2d), pointer :: mpp_domain => NULL()
+  end type ptr_mpp_domain
 
   !>@{
   !! DA parameters

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -193,7 +193,7 @@ type, public :: hor_visc_CS ; private
     Laplac3_Const_xy, & ! Laplacian  metric-dependent constants (nondim)
     Biharm5_Const_xy    ! Biharmonic metric-dependent constants (nondim)
 
-  type(diag_ctrl), pointer :: diag ! structure to regulate diagnostic timing
+  type(diag_ctrl), pointer :: diag => NULL() ! structure to regulate diagnostics
 
   ! diagnostic ids
   integer :: id_diffu     = -1, id_diffv         = -1
@@ -1639,11 +1639,10 @@ subroutine hor_visc_init(Time, G, param_file, diag, CS)
 
 end subroutine hor_visc_init
 
+!> This subroutine deallocates any variables allocated in hor_visc_init.
 subroutine hor_visc_end(CS)
-! This subroutine deallocates any variables allocated in hor_visc_init.
-! Argument:  CS - The control structure returned by a previous call to
-!                 hor_visc_init.
-  type(hor_visc_CS), pointer :: CS
+  type(hor_visc_CS), pointer :: CS !< The control structure returned by a
+                                   !! previous call to hor_visc_init.
 
   if (CS%Laplacian .or. CS%biharmonic) then
     DEALLOC_(CS%dx2h) ; DEALLOC_(CS%dx2q) ; DEALLOC_(CS%dy2h) ; DEALLOC_(CS%dy2q)

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -52,7 +52,7 @@ type, public :: thickness_diffuse_CS ; private
                                  !! longer than DT, or 0 (the default) to use DT.
   integer :: nkml                !< number of layers within mixed layer
   logical :: debug               !< write verbose checksums for debugging purposes
-  type(diag_ctrl), pointer :: diag ! structure used to regulate timing of diagnostics
+  type(diag_ctrl), pointer :: diag => NULL() !< structure used to regulate timing of diagnostics
   real, pointer :: GMwork(:,:)       => NULL()  !< Work by thickness diffusivity (W m-2)
   real, pointer :: diagSlopeX(:,:,:) => NULL()  !< Diagnostic: zonal neutral slope (nondim)
   real, pointer :: diagSlopeY(:,:,:) => NULL()  !< Diagnostic: zonal neutral slope (nondim)
@@ -1829,7 +1829,8 @@ end subroutine thickness_diffuse_init
 
 !> Deallocate the thickness diffusion control structure
 subroutine thickness_diffuse_end(CS)
-  type(thickness_diffuse_CS), pointer :: CS   !< Control structure for thickness diffusion
+  type(thickness_diffuse_CS), pointer :: CS !< Control structure for thickness diffusion
+
   if (associated(CS)) deallocate(CS)
 end subroutine thickness_diffuse_end
 

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -512,10 +512,11 @@ end subroutine initialize_ALE_sponge_varying
 !> Initialize diagnostics for the ALE_sponge module.
 ! GMM: this routine is not being used for now.
 subroutine init_ALE_sponge_diags(Time, G, diag, CS)
-  type(time_type),       target, intent(in)    :: Time
-  type(ocean_grid_type),         intent(in)    :: G    !< The ocean's grid structure
-  type(diag_ctrl),       target, intent(inout) :: diag
-  type(ALE_sponge_CS),           pointer       :: CS
+  type(time_type), target, intent(in)    :: Time !< The current model time
+  type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
+  type(diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic
+                                                 !! output.
+  type(ALE_sponge_CS),     pointer       :: CS   !< ALE sponge control structure
 
   if (.not.associated(CS)) return
 
@@ -527,7 +528,7 @@ end subroutine init_ALE_sponge_diags
 !! whose address is given by f_ptr.
 subroutine set_up_ALE_sponge_field_fixed(sp_val, G, f_ptr, CS)
   type(ocean_grid_type), intent(in) :: G  !< Grid structure
-  type(ALE_sponge_CS),   pointer    :: CS !< Sponge structure (in/out).
+  type(ALE_sponge_CS),   pointer    :: CS !< ALE sponge control structure (in/out).
   real, dimension(SZI_(G),SZJ_(G),CS%nz_data), &
                          intent(in) :: sp_val !< Field to be used in the sponge, it has arbritary number of layers.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
@@ -561,15 +562,17 @@ subroutine set_up_ALE_sponge_field_fixed(sp_val, G, f_ptr, CS)
 end subroutine set_up_ALE_sponge_field_fixed
 
 !> This subroutine stores the reference profile at h points for the variable
-! whose address is given by filename and fieldname.
+!! whose address is given by filename and fieldname.
 subroutine set_up_ALE_sponge_field_varying(filename, fieldname, Time, G, f_ptr, CS)
-  character(len=*),      intent(in) :: filename
-  character(len=*),      intent(in) :: fieldname
-  type(time_type),       intent(in) :: Time
-  type(ocean_grid_type), intent(in) :: G !< Grid structure (in).
+  character(len=*),      intent(in) :: filename !< The name of the file with the
+                                                !! time varying field data
+  character(len=*),      intent(in) :: fieldname !< The name of the field in the file
+                                                !! with the time varying field data
+  type(time_type),       intent(in) :: Time  !< The current model time
+  type(ocean_grid_type), intent(in) :: G     !< Grid structure (in).
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                  target, intent(in) :: f_ptr !< Pointer to the field to be damped (in).
-  type(ALE_sponge_CS),   pointer    :: CS !< Sponge structure (in/out).
+  type(ALE_sponge_CS),   pointer    :: CS    !< Sponge control structure (in/out).
 
   real, allocatable, dimension(:,:,:) :: sp_val !< Field to be used in the sponge
   real, allocatable, dimension(:,:,:) :: mask_z !< Field mask for the sponge data
@@ -1011,12 +1014,13 @@ subroutine apply_ALE_sponge(h, dt, G, CS, Time)
 
 end subroutine apply_ALE_sponge
 
-!> GMM: I could not find where sponge_end is being called, but I am keeping
+! GMM: I could not find where sponge_end is being called, but I am keeping
 !  ALE_sponge_end here so we can add that if needed.
+!> This subroutine deallocates any memory associated with the ALE_sponge module.
 subroutine ALE_sponge_end(CS)
-  type(ALE_sponge_CS),              pointer       :: CS
-!  (in)      CS - A pointer to the control structure for this module that is
-!                 set by a previous call to initialize_sponge.
+  type(ALE_sponge_CS), pointer :: CS !< A pointer to the control structure that is
+                                     !! set by a previous call to initialize_sponge.
+
   integer :: m
 
   if (.not.associated(CS)) return

--- a/src/parameterizations/vertical/MOM_CVMix_conv.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_conv.F90
@@ -258,7 +258,8 @@ end function CVMix_conv_is_used
 
 !> Clear pointers and dealocate memory
 subroutine CVMix_conv_end(CS)
-  type(CVMix_conv_cs), pointer :: CS ! Control structure
+  type(CVMix_conv_cs), pointer :: CS !< Control structure for this module that
+                                     !! will be deallocated in this subroutine
 
   if (.not. associated(CS)) return
 

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -291,7 +291,8 @@ end function CVMix_ddiff_is_used
 
 !> Clear pointers and dealocate memory
 subroutine CVMix_ddiff_end(CS)
-  type(CVMix_ddiff_cs), pointer :: CS ! Control structure
+  type(CVMix_ddiff_cs), pointer :: CS !< Control structure for this module that
+                                      !! will be deallocated in this subroutine
 
   deallocate(CS)
 

--- a/src/parameterizations/vertical/MOM_CVMix_shear.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_shear.F90
@@ -280,7 +280,8 @@ end function CVMix_shear_is_used
 
 !> Clear pointers and dealocate memory
 subroutine CVMix_shear_end(CS)
-  type(CVMix_shear_cs), pointer :: CS ! Control structure
+  type(CVMix_shear_cs), pointer :: CS !< Control structure for this module that
+                                      !! will be deallocated in this subroutine
 
   if (.not. associated(CS)) return
 

--- a/src/parameterizations/vertical/MOM_KPP.F90
+++ b/src/parameterizations/vertical/MOM_KPP.F90
@@ -1158,10 +1158,8 @@ subroutine KPP_compute_BLD(CS, G, GV, h, Temp, Salt, u, v, EOS, uStar, buoyFlux,
   GoRho = GV%g_Earth / GV%Rho0
   nonLocalTrans(:,:) = 0.0
 
-!$OMP parallel do default(private) shared(G,GV,CS,EOS,uStar,Temp,Salt,u,v,h,GoRho, &
-!$OMP                                  Waves,buoyFlux)                             &
-
   ! loop over horizontal points on processor
+  !$OMP parallel do default(shared)
   do j = G%jsc, G%jec
     do i = G%isc, G%iec
 

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -437,7 +437,10 @@ end function CVMix_bkgnd_is_used
 
 !> Clear pointers and dealocate memory
 subroutine bkgnd_mixing_end(CS)
-  type(bkgnd_mixing_cs), pointer :: CS ! Control structure
+  type(bkgnd_mixing_cs), pointer :: CS !< Control structure for this module that
+                                       !! will be deallocated in this subroutine
+
+  if (.not. associated(CS)) return
 
   deallocate(CS%kd_bkgnd)
   deallocate(CS%kv_bkgnd)

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -60,7 +60,6 @@ use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_forcing_type,  only : forcing, extractFluxes1d, forcing_SinglePointPrint
 use MOM_grid,          only : ocean_grid_type
-use MOM_io,            only : vardesc
 use MOM_shortwave_abs, only : absorbRemainingSW, optics_type, sumSWoverBands
 use MOM_variables,     only : thermo_var_ptrs, vertvisc_type! , accel_diag_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type
@@ -117,13 +116,21 @@ integer :: id_clock_uv_at_h, id_clock_frazil
 
 contains
 
+!> Frazil formation keeps the temperature above the freezing point.
+!! This subroutine warms any water that is colder than the (currently
+!! surface) freezing point up to the freezing point and accumulates
+!! the required heat (in J m-2) in tv%frazil.
 subroutine make_frazil(h, tv, G, GV, CS, p_surf)
-  type(ocean_grid_type),                 intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),               intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(thermo_var_ptrs),                 intent(inout) :: tv
-  type(diabatic_aux_CS),                 intent(in)    :: CS
-  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: p_surf
+  type(ocean_grid_type),   intent(in)    :: G  !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)    :: GV !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h  !< Layer thicknesses, in H (usually m or kg m-2)
+  type(thermo_var_ptrs),   intent(inout) :: tv !< Structure containing pointers to any available
+                                               !! thermodynamic fields.
+  type(diabatic_aux_CS),   intent(in)    :: CS !< The control structure returned by a previous
+                                               !! call to diabatic_aux_init.
+  real, dimension(SZI_(G),SZJ_(G)), &
+                 optional, intent(in)    :: p_surf !< The pressure at the ocean surface, in Pa.
 
 !   Frazil formation keeps the temperature above the freezing point.
 ! This subroutine warms any water that is colder than the (currently
@@ -239,13 +246,18 @@ subroutine make_frazil(h, tv, G, GV, CS, p_surf)
 
 end subroutine make_frazil
 
+!> This subroutine applies double diffusion to T & S, assuming no diapycal mass
+!! fluxes, using a simple triadiagonal solver.
 subroutine differential_diffuse_T_S(h, tv, visc, dt, G, GV)
-  type(ocean_grid_type),                 intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),               intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(thermo_var_ptrs),                 intent(inout) :: tv
-  type(vertvisc_type),                   intent(in)    :: visc
-  real,                                  intent(in)    :: dt
+  type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  type(thermo_var_ptrs),   intent(inout) :: tv   !< Structure containing pointers to any
+                                                 !! available thermodynamic fields.
+  type(vertvisc_type),     intent(in)    :: visc !< Structure containing vertical viscosities, bottom
+                                                 !! boundary layer properies, and related fields.
+  real,                    intent(in)    :: dt   !<  Time increment, in s.
 
 ! This subroutine applies double diffusion to T & S, assuming no diapycal mass
 ! fluxes, using a simple triadiagonal solver.
@@ -277,7 +289,8 @@ subroutine differential_diffuse_T_S(h, tv, visc, dt, G, GV)
   real :: b_denom_S    ! for b1_T and b1_S, both in m or kg m-2.
 
   integer :: i, j, k, is, ie, js, je, nz
-  real, pointer :: T(:,:,:), S(:,:,:), Kd_T(:,:,:), Kd_S(:,:,:)
+  real, dimension(:,:,:), pointer :: T=>NULL(), S=>NULL()
+  real, dimension(:,:,:), pointer :: Kd_T=>NULL(), Kd_S=>NULL()
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   h_neglect = GV%H_subroundoff
 
@@ -348,12 +361,18 @@ subroutine differential_diffuse_T_S(h, tv, visc, dt, G, GV)
 
 end subroutine differential_diffuse_T_S
 
+!> This subroutine keeps salinity from falling below a small but positive threshold.
+!! This usually occurs when the ice model attempts to extract more salt then
+!! is actually available to it from the ocean.
 subroutine adjust_salt(h, tv, G, GV, CS)
-  type(ocean_grid_type),                 intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),               intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(thermo_var_ptrs),                 intent(inout) :: tv
-  type(diabatic_aux_CS),                 intent(in)    :: CS
+  type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  type(thermo_var_ptrs),   intent(inout) :: tv   !< Structure containing pointers to any
+                                                 !! available thermodynamic fields.
+  type(diabatic_aux_CS),   intent(in)    :: CS   !< The control structure returned by a previous
+                                                 !! call to diabatic_aux_init.
 
 !  Keep salinity from falling below a small but positive threshold
 !  This occurs when the ice model attempts to extract more salt then
@@ -374,6 +393,7 @@ subroutine adjust_salt(h, tv, G, GV, CS)
 
 !  call cpu_clock_begin(id_clock_adjust_salt)
 
+!### MAKE THIS A RUN_TIME PARAMETER.  COULD IT BE 0?
   S_min = 0.01
 
   salt_add_col(:,:) = 0.0
@@ -410,16 +430,23 @@ subroutine adjust_salt(h, tv, G, GV, CS)
 
 end subroutine adjust_salt
 
+!> Insert salt from brine rejection into the first layer below the mixed layer
+!! which both contains mass and in which the change in layer density remains
+!! stable after the addition of salt via brine rejection.
 subroutine insert_brine(h, tv, G, GV, fluxes, nkmb, CS, dt, id_brine_lay)
-  type(ocean_grid_type),                 intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),               intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  type(thermo_var_ptrs),                 intent(inout) :: tv
-  type(forcing),                         intent(in)    :: fluxes
-  integer,                               intent(in)    :: nkmb
-  type(diabatic_aux_CS),                 intent(in)    :: CS
-  real,                                  intent(in)    :: dt
-  integer,                               intent(in)    :: id_brine_lay
+  type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  type(thermo_var_ptrs),   intent(inout) :: tv   !< Structure containing pointers to any
+                                                 !! available thermodynamic fields
+  type(forcing),           intent(in)    :: fluxes !< A structure of thermodynamic surface fluxes
+  integer,                 intent(in)    :: nkmb !< The number of layers in the mixed and buffer layers
+  type(diabatic_aux_CS),   intent(in)    :: CS   !< The control structure returned by a previous
+                                                 !! call to diabatic_aux_init
+  real,                    intent(in)    :: dt   !< The thermodyanmic time step, in s.
+  integer,                 intent(in)    :: id_brine_lay !< The handle for a diagnostic
+                                                 !! which layer receivees the brine.
 
 ! Insert salt from brine rejection into the first layer below
 ! the mixed layer which both contains mass and in which the
@@ -460,7 +487,7 @@ subroutine insert_brine(h, tv, G, GV, fluxes, nkmb, CS, dt, id_brine_lay)
 
   p_ref_cv(:)  = tv%P_ref
 
-  inject_layer = nz
+  inject_layer(:,:) = nz
 
   do j=js,je
 
@@ -535,26 +562,32 @@ subroutine insert_brine(h, tv, G, GV, fluxes, nkmb, CS, dt, id_brine_lay)
 
   enddo
 
-  if (CS%id_brine_lay > 0) call post_data(CS%id_brine_lay,inject_layer,CS%diag)
+  if (CS%id_brine_lay > 0) call post_data(CS%id_brine_lay, inject_layer, CS%diag)
 
 end subroutine insert_brine
 
+!> This is a simple tri-diagonal solver for T and S.
+!! "Simple" means it only uses arrays hold, ea and eb.
 subroutine triDiagTS(G, GV, is, ie, js, je, hold, ea, eb, T, S)
-! Simple tri-diagnonal solver for T and S
-! "Simple" means it only uses arrays hold, ea and eb
-  ! Arguments
+
   type(ocean_grid_type),                    intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),                  intent(in)    :: GV   !< The ocean's vertical grid structure
-  integer,                                  intent(in)    :: is, ie, js, je
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: hold, ea, eb
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: T, S
+  integer,                                  intent(in)    :: is, ie, js, je !< The range of indices to work on.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: hold !< The layer thicknesses before entrainment, in H.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: ea !< The amount of fluid entrained from the layer
+                                                 !! above within this time step, in units of H.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: eb !< The amount of fluid entrained from the layer
+                                                 !! below within this time step, in units of H.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: T  !< Layer potential temperatures, in degC.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: S  !< Layer salinities, in PSU.
+
   ! Local variables
   real :: b1(SZIB_(G)), d1(SZIB_(G)) ! b1, c1, and d1 are variables used by the
   real :: c1(SZIB_(G),SZK_(G))       ! tridiagonal solver.
   real :: h_tr, b_denom_1
   integer :: i, j, k
-!$OMP parallel do default(none) shared(is,ie,js,je,G,GV,hold,eb,T,S,ea) &
-!$OMP                          private(h_tr,b1,d1,c1,b_denom_1)
+
+  !$OMP parallel do default(shared) private(h_tr,b1,d1,c1,b_denom_1)
   do j=js,je
     do i=is,ie
       h_tr = hold(i,j,1) + GV%H_subroundoff
@@ -579,36 +612,31 @@ subroutine triDiagTS(G, GV, is, ie, js, je, hold, ea, eb, T, S)
   enddo
 end subroutine triDiagTS
 
-
+!>   This subroutine calculates u_h and v_h (velocities at thickness
+!! points), optionally using the entrainment amounts passed in as arguments.
 subroutine find_uv_at_h(u, v, h, u_h, v_h, G, GV, ea, eb)
-  type(ocean_grid_type),                     intent(in)  :: G    !< The ocean's grid structure
-  type(verticalGrid_type),                   intent(in)  :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)  :: u    !< The zonal velocity, in m s-1
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)  :: v    !< The meridional velocity, in m s-1
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)  :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(out) :: u_h
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(out) :: v_h
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  optional, intent(in)  :: ea
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  optional, intent(in)  :: eb
+  type(ocean_grid_type),     intent(in)  :: G    !< The ocean's grid structure
+  type(verticalGrid_type),   intent(in)  :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                             intent(in)  :: u    !< The zonal velocity, in m s-1
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                             intent(in)  :: v    !< The meridional velocity, in m s-1
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                             intent(in)  :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                             intent(out)   :: u_h !< Zonal velocity interpolated to h points, in m s-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                             intent(out)   :: v_h !< Meridional velocity interpolated to h points, in m s-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                     optional, intent(in)  :: ea !< The amount of fluid entrained from the layer
+                                                 !! above within this time step, in units of H.
+                                                 !! Omitting ea is the same as setting it to 0.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                     optional, intent(in)  :: eb !< The amount of fluid entrained from the layer
+                                                 !! below within this time step, in units of H.
+                                                 !! Omitting eb is the same as setting it to 0.
 !   This subroutine calculates u_h and v_h (velocities at thickness
 ! points), optionally using the entrainments (in m) passed in as arguments.
-
-! Arguments: u - Zonal velocity, in m s-1.
-!  (in)      v - Meridional velocity, in m s-1.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (out)     u_h - The zonal velocity at thickness points after
-!                  entrainment, in m s-1.
-!  (out)     v_h - The meridional velocity at thickness points after
-!                  entrainment, in m s-1.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in, opt) ea - The amount of fluid entrained from the layer above within
-!                 this time step, in units of m or kg m-2.  Omitting ea is the
-!                 same as setting it to 0.
-!  (in, opt) eb - The amount of fluid entrained from the layer below within
-!                 this time step, in units of m or kg m-2.  Omitting eb is the
-!                 same as setting it to 0.  ea and eb must either be both
-!                 present or both absent.
 
   real :: b_denom_1    ! The first term in the denominator of b1 in m or kg m-2.
   real :: h_neglect    ! A thickness that is so small it is usually lost
@@ -689,15 +717,17 @@ end subroutine find_uv_at_h
 !> Diagnose a mixed layer depth (MLD) determined by a given density difference with the surface.
 !> This routine is appropriate in MOM_diabatic_driver due to its position within the time stepping.
 subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, diagPtr, id_N2subML, id_MLDsq)
-  type(ocean_grid_type),                 intent(in) :: G           !< Grid type
-  type(verticalGrid_type),               intent(in) :: GV          !< ocean vertical grid structure
-  integer,                               intent(in) :: id_MLD      !< Handle (ID) of MLD diagnostic
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h        !< Layer thickness
-  type(thermo_var_ptrs),                 intent(in) :: tv          !< Thermodynamics type
-  real,                                  intent(in) :: densityDiff !< Density difference to determine MLD (kg/m3)
-  type(diag_ctrl),                       pointer    :: diagPtr     !< Diagnostics structure
-  integer,                     optional, intent(in) :: id_N2subML  !< Optional handle (ID) of subML stratification
-  integer,                     optional, intent(in) :: id_MLDsq    !< Optional handle (ID) of squared MLD
+  type(ocean_grid_type),   intent(in) :: G           !< Grid type
+  type(verticalGrid_type), intent(in) :: GV          !< ocean vertical grid structure
+  integer,                 intent(in) :: id_MLD      !< Handle (ID) of MLD diagnostic
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in) :: h           !< Layer thickness, in H (usually m or kg m-3)
+  type(thermo_var_ptrs),   intent(in) :: tv          !< Structure containing pointers to any
+                                                     !! available thermodynamic fields.
+  real,                    intent(in) :: densityDiff !< Density difference to determine MLD (kg/m3)
+  type(diag_ctrl),         pointer    :: diagPtr     !< Diagnostics structure
+  integer,       optional, intent(in) :: id_N2subML  !< Optional handle (ID) of subML stratification
+  integer,       optional, intent(in) :: id_MLDsq    !< Optional handle (ID) of squared MLD
 
   ! Local variables
   real, dimension(SZI_(G))          :: rhoSurf, deltaRhoAtKm1, deltaRhoAtK, dK, dKm1, pRef_MLD
@@ -799,28 +829,32 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
                                     aggregate_FW_forcing, evap_CFL_limit, &
                                     minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, &
                                     SkinBuoyFlux )
-  type(diabatic_aux_CS),                 pointer       :: CS !< Control structure for diabatic_aux
-  type(ocean_grid_type),                 intent(in)    :: G  !< Grid structure
-  type(verticalGrid_type),               intent(in)    :: GV !< ocean vertical grid structure
-  real,                                  intent(in)    :: dt !< Time-step over which forcing is applied (s)
-  type(forcing),                         intent(inout) :: fluxes !< Surface fluxes container
-  type(optics_type),                     pointer       :: optics !< Optical properties container
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h  !< Layer thickness in H units
-  type(thermo_var_ptrs),                 intent(inout) :: tv !< Thermodynamics container
-  !> If False, treat in/out fluxes separately.
-  logical,                               intent(in)    :: aggregate_FW_forcing
-  !> The largest fraction of a layer that can be evaporated in one time-step (non-dim).
-  real,                                  intent(in)   :: evap_CFL_limit
-  !> The smallest depth over which heat and freshwater fluxes is applied, in m.
-  real,                                  intent(in)   :: minimum_forcing_depth
-  !> Turbulent kinetic energy requirement to mix forcing through each layer, in W m-2
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), optional, intent(out) :: cTKE
-  !> Partial derivative of specific volume with potential temperature, in m3 kg-1 K-1.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), optional, intent(out) :: dSV_dT
-  !> Partial derivative of specific a volume with potential salinity, in m3 kg-1 / (g kg-1).
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), optional, intent(out) :: dSV_dS
-  !> Buoyancy flux at surface in m2 s-3
-  real, dimension(SZI_(G),SZJ_(G)), optional, intent(out) :: SkinBuoyFlux
+  type(diabatic_aux_CS),   pointer       :: CS !< Control structure for diabatic_aux
+  type(ocean_grid_type),   intent(in)    :: G  !< Grid structure
+  type(verticalGrid_type), intent(in)    :: GV !< ocean vertical grid structure
+  real,                    intent(in)    :: dt !< Time-step over which forcing is applied (s)
+  type(forcing),           intent(inout) :: fluxes !< Surface fluxes container
+  type(optics_type),       pointer       :: optics !< Optical properties container
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(inout) :: h  !< Layer thickness in H units
+  type(thermo_var_ptrs),   intent(inout) :: tv !< Structure containing pointers to any
+                                               !! available thermodynamic fields.
+  logical,                 intent(in)    :: aggregate_FW_forcing !< If False, treat in/out fluxes separately.
+  real,                    intent(in)    :: evap_CFL_limit !< The largest fraction of a layer that
+                                               !! can be evaporated in one time-step (non-dim).
+  real,                    intent(in)    :: minimum_forcing_depth !< The smallest depth over which
+                                               !! heat and freshwater fluxes is applied, in m.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                 optional, intent(out)   :: cTKE !< Turbulent kinetic energy requirement to mix
+                                               !! forcing through each layer, in W m-2
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                 optional, intent(out)   :: dSV_dT !< Partial derivative of specific volume with
+                                               !! potential temperature, in m3 kg-1 K-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                 optional, intent(out)   :: dSV_dS !< Partial derivative of specific volume with
+                                               !! salinity, in m3 kg-1 / (g kg-1).
+  real, dimension(SZI_(G),SZJ_(G)), &
+                 optional, intent(out) :: SkinBuoyFlux !< Buoyancy flux at surface in m2 s-3
 
   ! Local variables
   integer, parameter :: maxGroundings = 5
@@ -1318,27 +1352,21 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, dt, fluxes, optics, h, tv, &
 
 end subroutine applyBoundaryFluxesInOut
 
+!> This subroutine initializes the parameters and control structure of the
+!! diabatic_aux module.
 subroutine diabatic_aux_init(Time, G, GV, param_file, diag, CS, useALEalgorithm, use_ePBL)
-  type(time_type),         intent(in)    :: Time
+  type(time_type),         intent(in)    :: Time !< The current model time
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
-  type(diag_ctrl), target, intent(inout) :: diag
-  type(diabatic_aux_CS),   pointer       :: CS
-  logical,                 intent(in)    :: useALEalgorithm
-  logical,                 intent(in)    :: use_ePBL
-
-! Arguments:
-!  (in)     Time       = current model time
-!  (in)     G          = ocean grid structure
-!  (in)     GV - The ocean's vertical grid structure.
-!  (in)     param_file = structure indicating the open file to parse for parameter values
-!  (in)     diag       = structure used to regulate diagnostic output
-!  (in/out) CS         = pointer set to point to the control structure for this module
-!  (in)     use_ePBL   = If true, use the implicit energetics planetary boundary
-!                        layer scheme to determine the diffusivity in the
-!                        surface boundary layer.
-  type(vardesc) :: vd
+  type(diag_ctrl), target, intent(inout) :: diag !< A structure used to regulate diagnostic output
+  type(diabatic_aux_CS),   pointer       :: CS   !< A pointer to the control structure for the
+                                                 !! diabatic_aux module, which is initialized here.
+  logical,                 intent(in)    :: useALEalgorithm !< If true, use the ALE algorithm rather
+                                                 !! than layered mode.
+  logical,                 intent(in)    :: use_ePBL !< If true, use the implicit energetics planetary
+                                                 !! boundary layer scheme to determine the diffusivity
+                                                 !! in the surface boundary layer.
 
 ! This "include" declares and sets the variable "version".
 #include "version_variable.h"
@@ -1445,9 +1473,11 @@ subroutine diabatic_aux_init(Time, G, GV, param_file, diag, CS, useALEalgorithm,
 
 end subroutine diabatic_aux_init
 
-
+!> This subroutine initializes the control structure and any related memory
+!! for the diabatic_aux module.
 subroutine diabatic_aux_end(CS)
-  type(diabatic_aux_CS), pointer :: CS
+  type(diabatic_aux_CS), pointer :: CS !< The control structure returned by a previous
+                                       !! call to diabatic_aux_init; it is deallocated here.
 
   if (.not.associated(CS)) return
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -150,7 +150,7 @@ type, public:: diabatic_CS; private
                                      !! applied to tracers, especially in massless layers
                                      !! near the bottom, in m2 s-1.
   real    :: minimum_forcing_depth = 0.001 !< The smallest depth over which heat and freshwater
-                                           !! fluxes is applied, in m.
+                                           !! fluxes are applied, in m.
   real    :: evap_CFL_limit = 0.8    !< The largest fraction of a layer that can be
                                      !! evaporated in one time-step (non-dim).
 
@@ -2855,12 +2855,14 @@ end subroutine legacy_diabatic
 !! each returned argument is an optional argument
 subroutine extract_diabatic_member(CS, opacity_CSp, optics_CSp, &
                                    evap_CFL_limit, minimum_forcing_depth)
-  type(diabatic_CS),           intent(in   ) :: CS
+  type(diabatic_CS),           intent(in   ) :: CS !< module control structure
   ! All output arguments are optional
-  type(opacity_CS),  optional, pointer       :: opacity_CSp
-  type(optics_type), optional, pointer       :: optics_CSp
-  real,              optional, intent(  out) :: evap_CFL_limit
-  real,              optional, intent(  out) :: minimum_forcing_depth
+  type(opacity_CS),  optional, pointer       :: opacity_CSp !< A pointer to be set to the opacity control structure
+  type(optics_type), optional, pointer       :: optics_CSp  !< A pointer to be set to the optics control structure
+  real,              optional, intent(  out) :: evap_CFL_limit !<The largest fraction of a layer that can be
+                                                            !! evaporated in one time-step (non-dim).
+  real,              optional, intent(  out) :: minimum_forcing_depth !< The smallest depth over which heat
+                                                            !! and freshwater fluxes are applied, in m.
 
   ! Pointers to control structures
   if (present(opacity_CSp)) opacity_CSp => CS%opacity_CSp

--- a/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
+++ b/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
@@ -31,7 +31,8 @@ type, public :: diapyc_energy_req_CS ; private
   logical :: use_test_Kh_profile   ! If true, use the internal test diffusivity
                                ! profile in place of any that might be passed
                                ! in as an argument.
-  type(diag_ctrl), pointer :: diag ! Structure used to regulate timing of diagnostic output
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                               ! regulate the timing of diagnostic output.
   integer :: id_ERt=-1, id_ERb=-1, id_ERc=-1, id_ERh=-1, id_Kddt=-1, id_Kd=-1
   integer :: id_CHCt=-1, id_CHCb=-1, id_CHCc=-1, id_CHCh=-1
   integer :: id_T0=-1, id_Tf=-1, id_S0=-1, id_Sf=-1, id_N2_0=-1, id_N2_f=-1
@@ -40,7 +41,8 @@ end type diapyc_energy_req_CS
 
 contains
 
-! #@# This subroutine needs a doxygen description
+!> This subroutine helps test the accuracy of the diapycnal mixing energy requirement code
+!! by writing diagnostics, possibly using an intensely mixing test profile of diffusivity
 subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
   type(ocean_grid_type),          intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type),        intent(in)    :: GV   !< The ocean's vertical grid structure.
@@ -56,15 +58,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
   real, dimension(G%isd:G%ied,G%jsd:G%jed,GV%ke+1), &
                         optional, intent(in)    :: Kd_int !< Interface diffusivities.
 
-! Arguments: h_3d -  Layer thickness before entrainment, in m or kg m-2.
-!  (in)      tv - A structure containing pointers to any available
-!                 thermodynamic fields. Absent fields have NULL ptrs.
-!  (in)      dt - The amount of time covered by this call, in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - This module's control structure
-!  (in,opt)  Kd_int -  Interface diffusivities.
-
+  ! Local variables
   real, dimension(GV%ke) :: &
     T0, S0, &   ! T0 & S0 are columns of initial temperatures and salinities, in degC and g/kg.
     h_col       ! h_col is a column of thicknesses h at tracer points, in H (m or kg m-2).
@@ -142,20 +136,6 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
                                                   !! of energy use.
   type(diapyc_energy_req_CS), &
                   optional, pointer        :: CS  !< This module's control structure.
-
-! Arguments: h_in -  Layer thickness before entrainment, in m or kg m-2.
-!  (in)      T_in - The layer temperatures, in degC.
-!  (in)      S_in - The layer salinities, in g kg-1.
-!  (in)      Kd - The interfaces diapycnal diffusivities, in m2 s-1.
-!  (in/out)  tv - A structure containing pointers to any available
-!                 thermodynamic fields. Absent fields have NULL ptrs.
-!  (in)      dt - The amount of time covered by this call, in s.
-!  (out)     energy_Kd - The column-integrated rate of energy consumption
-!                 by diapycnal diffusion, in W m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in,opt)  may_print - If present and true, write out diagnostics of energy use.
-!  (in,opt)  CS - This module's control structure
 
 !   This subroutine uses a substantially refactored tridiagonal equation for
 ! diapycnal mixing of temperature and salinity to estimate the potential energy
@@ -1278,15 +1258,14 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
 
 end subroutine find_PE_chg_orig
 
+!> Initialize parameters and allocate memory associated with the diapycnal energy requirement module.
 subroutine diapyc_energy_req_init(Time, G, param_file, diag, CS)
   type(time_type),            intent(in)    :: Time        !< model time
   type(ocean_grid_type),      intent(in)    :: G           !< model grid structure
   type(param_file_type),      intent(in)    :: param_file  !< file to parse for parameter values
   type(diag_ctrl),    target, intent(inout) :: diag        !< structure to regulate diagnostic output
   type(diapyc_energy_req_CS), pointer       :: CS          !< module control structure
-! Arguments: param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in/out)  Reg - A pointer that is set to point to the tracer registry.
+
   integer, save :: init_calls = 0
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -1351,8 +1330,10 @@ subroutine diapyc_energy_req_init(Time, G, param_file, diag, CS)
 
 end subroutine diapyc_energy_req_init
 
+!> Clean up and deallocate memory associated with the diapycnal energy requirement module.
 subroutine diapyc_energy_req_end(CS)
-  type(diapyc_energy_req_CS), pointer :: CS
+  type(diapyc_energy_req_CS), pointer :: CS !< Diapycnal energy requirement control structure that
+                                            !! will be deallocated in this subroutine.
   if (associated(CS)) deallocate(CS)
 end subroutine diapyc_energy_req_end
 

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -76,8 +76,8 @@ type, public :: entrain_diffusive_CS ; private
                              ! used to calculate the diapycnal entrainment.
   real    :: Tolerance_Ent   ! The tolerance with which to solve for entrainment
                              ! values, in m.
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                             ! regulate the timing of diagnostic output.
   integer :: id_Kd = -1, id_diff_work = -1
 end type entrain_diffusive_CS
 

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -83,12 +83,11 @@ end type entrain_diffusive_CS
 
 contains
 
-!> This subroutine calculates ea and eb, the rates at which a layer
-!! entrains from the layers above and below.  The entrainment rates
-!! are proportional to the buoyancy flux in a layer and inversely
-!! proportional to the density differences between layers.  The
-!! scheme that is used here is described in detail in Hallberg, Mon.
-!! Wea. Rev. 2000.
+!> This subroutine calculates ea and eb, the rates at which a layer entrains
+!! from the layers above and below.  The entrainment rates are proportional to
+!! the buoyancy flux in a layer and inversely proportional to the density
+!! differences between layers.  The scheme that is used here is described in
+!! detail in Hallberg, Mon. Wea. Rev. 2000.
 subroutine entrainment_diffusive(u, v, h, tv, fluxes, dt, G, GV, CS, ea, eb, &
                                  kb_out, Kd_Lay, Kd_int)
   type(ocean_grid_type),      intent(in)  :: G  !< The ocean's grid structure.
@@ -117,8 +116,8 @@ subroutine entrainment_diffusive(u, v, h, tv, fluxes, dt, G, GV, CS, ea, eb, &
                                                 !! as h, m or kg m-2.
   integer, dimension(SZI_(G),SZJ_(G)),        &
                   optional, intent(inout) :: kb_out !< The index of the lightest layer denser than
-                                                !! the buffer layer. At least one of the two
-                                                !! arguments must be present.
+                                                !! the buffer layer.
+  ! At least one of the two following arguments must be present.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   &
                   optional, intent(in)    :: Kd_Lay !< The diapycnal diffusivity of layers,
                                                 !! in m2 s-1.
@@ -126,34 +125,11 @@ subroutine entrainment_diffusive(u, v, h, tv, fluxes, dt, G, GV, CS, ea, eb, &
                   optional, intent(in)    :: Kd_int !< The diapycnal diffusivity of interfaces,
                                                 !! in m2 s-1.
 
-!   This subroutine calculates ea and eb, the rates at which a layer
-! entrains from the layers above and below.  The entrainment rates
-! are proportional to the buoyancy flux in a layer and inversely
-! proportional to the density differences between layers.  The
-! scheme that is used here is described in detail in Hallberg, Mon.
-! Wea. Rev. 2000.
-
-! Arguments: u - Zonal velocity, in m s-1.
-!  (in)      v - Meridional velocity, in m s-1.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      fluxes - A structure of surface fluxes that may be used.
-!  (in)      kb_out - The index of the lightest layer denser than the
-!                     buffer layers.
-!  (in)      tv - A structure containing pointers to any available
-!                 thermodynamic fields. Absent fields have NULL ptrs.
-!  (in)      dt - The time increment in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 entrain_diffusive_init.
-!  (out)     ea - The amount of fluid entrained from the layer above within
-!                 this time step, in the same units as h, m or kg m-2.
-!  (out)     eb - The amount of fluid entrained from the layer below within
-!                 this time step, in the same units as h, m or kg m-2.
-!  (out,opt) kb - The index of the lightest layer denser than the buffer layer.
-! At least one of the two arguments must be present.
-!  (in,opt)  Kd_Lay - The diapycnal diffusivity of layers, in m2 s-1.
-!  (in,opt)  Kd_int - The diapycnal diffusivity of interfaces, in m2 s-1.
+!   This subroutine calculates ea and eb, the rates at which a layer entrains
+! from the layers above and below.  The entrainment rates are proportional to
+! the buoyancy flux in a layer and inversely proportional to the density
+! differences between layers.  The scheme that is used here is described in
+! detail in Hallberg, Mon. Wea. Rev. 2000.
 
 ! In the comments below, H is used as shorthand for the units of h, m or kg m-2.
   real, dimension(SZI_(G),SZK_(G)) :: &
@@ -959,18 +935,34 @@ end subroutine entrainment_diffusive
 !! amount of surface forcing that is applied to each layer if there is no bulk
 !! mixed layer.
 subroutine F_to_ent(F, h, kb, kmb, j, G, GV, CS, dsp1_ds, eakb, Ent_bl, ea, eb, do_i_in)
-  type(ocean_grid_type),                    intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),                  intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZK_(G)),         intent(in)    :: F
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  integer, dimension(SZI_(G)),              intent(in)    :: kb
-  integer,                                  intent(in)    :: kmb, j
-  type(entrain_diffusive_CS),               intent(in)    :: CS
-  real, dimension(SZI_(G),SZK_(G)),         intent(in)    :: dsp1_ds
-  real, dimension(SZI_(G)),                 intent(in)    :: eakb
-  real, dimension(SZI_(G),SZK_(G)),         intent(in)    :: Ent_bl
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: ea, eb
-  logical, dimension(SZI_(G)),    optional, intent(in)    :: do_i_in
+  type(ocean_grid_type),            intent(in)    :: G    !< The ocean's grid structure
+  type(verticalGrid_type),          intent(in)    :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: F    !< The density flux through a layer within a time step divided by the
+            ! density difference across the interface below the layer, in H.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                    intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  integer, dimension(SZI_(G)),      intent(in)    :: kb   !< The index of the lightest layer denser than
+                                                          !! the deepest buffer layer.
+  integer,                          intent(in)    :: kmb  !< The number of mixed and buffer layers.
+  integer,                          intent(in)    :: j    !< The meridional index upon which to work.
+  type(entrain_diffusive_CS),       intent(in)    :: CS   !< This module's control structure.
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: dsp1_ds !< The ratio of coordinate variable
+                                                          !! differences across the interfaces below
+                                                          !! a layer over the difference across the
+                                                          !! interface above the layer.
+  real, dimension(SZI_(G)),         intent(in)    :: eakb !< The entrainment from above by the layer
+                                                          !! below the buffer layer, in H.
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: Ent_bl !< The average entrainment upward and
+                                                          !! downward across each interface around
+                                                          !! the buffer layers, in H.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                    intent(inout) :: ea   !< The amount of fluid entrained from the layer
+                                                          !! above within this time step, in H.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                    intent(inout) :: eb   !< The amount of fluid entrained from the layer
+                                                          !! below within this time step, in H.
+  logical, dimension(SZI_(G)), &
+                          optional, intent(in)    :: do_i_in !< Indicates which i-points to work on.
 !   This subroutine calculates the actual entrainments (ea and eb) and the
 ! amount of surface forcing that is applied to each layer if there is no bulk
 ! mixed layer.
@@ -1086,12 +1078,11 @@ subroutine set_Ent_bl(h, dtKd_int, tv, kb, kmb, do_i, G, GV, CS, j, Ent_bl, Sref
   integer, dimension(SZI_(G)),      intent(inout) :: kb   !< The index of the lightest layer denser
                                                           !! than the buffer layer or 1 if there is
                                                           !! no buffer layer.
-  integer,                          intent(in)    :: kmb
+  integer,                          intent(in)    :: kmb  !< The number of mixed and buffer layers.
   logical, dimension(SZI_(G)),      intent(in)    :: do_i !< A logical variable indicating which
                                                           !! i-points to work on.
   type(entrain_diffusive_CS),       pointer       :: CS   !< This module's control structure.
-  integer,                          intent(in)    :: j    !< The meridional index upon which
-                                                          !! to work.
+  integer,                          intent(in)    :: j    !< The meridional index upon which to work.
   real, dimension(SZI_(G),SZK_(G)+1),       &
                                     intent(out)   :: Ent_bl !< The average entrainment upward and
                                                           !! downward across each interface around
@@ -1277,8 +1268,7 @@ subroutine determine_dSkb(h_bl, Sref, Ent_bl, E_kb, is, ie, kmb, G, GV, limit, &
   real, dimension(SZI_(G)),           intent(in)    :: E_kb   !< The entrainment by the top interior
                                                               !! layer, in H.
   integer,                            intent(in)    :: is, ie !< The range of i-indices to work on.
-  integer,                            intent(in)    :: kmb    !< The number of mixed and buffer
-                                                              !! layers.
+  integer,                            intent(in)    :: kmb    !< The number of mixed and buffer layers.
   logical,                            intent(in)    :: limit  !< If true, limit dSkb and dSlay to
                                                               !! avoid negative values.
   real, dimension(SZI_(G)),           intent(inout) :: dSkb   !< The limited potential density
@@ -1286,15 +1276,17 @@ subroutine determine_dSkb(h_bl, Sref, Ent_bl, E_kb, is, ie, kmb, G, GV, limit, &
                                                               !! between the bottommost buffer layer
                                                               !! and the topmost interior layer.
                                                               !! dSkb > 0.
-  real, dimension(SZI_(G)), optional, intent(inout) :: ddSkb_dE  !< The partial derivative of dSkb
+  real, dimension(SZI_(G)), optional, intent(inout) :: ddSkb_dE !< The partial derivative of dSkb
                                                               !! with E, in kg m-3 H-1.
-  real, dimension(SZI_(G)), optional, intent(inout) :: dSlay     !< The limited potential density
+  real, dimension(SZI_(G)), optional, intent(inout) :: dSlay  !< The limited potential density
                                                               !! difference across the topmost
                                                               !! interior layer. 0 < dSkb
   real, dimension(SZI_(G)), optional, intent(inout) :: ddSlay_dE !< The partial derivative of dSlay
                                                               !! with E, in kg m-3 H-1.
-  real, dimension(SZI_(G)), optional, intent(inout) :: dS_anom_lim
-  logical, dimension(SZI_(G)), optional, intent(in) :: do_i_in   !< If present, determines which
+  real, dimension(SZI_(G)), optional, intent(inout) :: dS_anom_lim !< A limiting value to use for
+                                                              !! the density anomalies below the
+                                                              !! buffer layer, in kg m-3.
+  logical, dimension(SZI_(G)), optional, intent(in) :: do_i_in !< If present, determines which
                                                               !! columns are worked on.
 ! Arguments: h_bl - Layer thickness, in m or kg m-2 (abbreviated as H below).
 !  (in)      Sref - Reference potential vorticity (in kg m-3?)
@@ -1315,7 +1307,7 @@ subroutine determine_dSkb(h_bl, Sref, Ent_bl, E_kb, is, ie, kmb, G, GV, limit, &
 !  (out,opt) ddSlay_dE - The partial derivative of dSlay with E, in kg m-3 H-1.
 !  (in,opt)  do_i_in - If present, determines which columns are worked on.
 ! Note that dSkb, ddSkb_dE, dSlay, ddSlay_dE, and dS_anom_lim are declared
-! intent(inout) because they should not change where do_i_in is false.
+! intent inout  because they should not change where do_i_in is false.
 
 !   This subroutine determines the reference density difference between the
 ! bottommost buffer layer and the first interior after the mixing between mixed
@@ -1519,14 +1511,31 @@ end subroutine determine_dSkb
 !! guess of the iterations.  Ideally ea_kb should be an under-estimate
 subroutine F_kb_to_ea_kb(h_bl, Sref, Ent_bl, I_dSkbp1, F_kb, kmb, i, &
                          G, GV, CS, ea_kb, tol_in)
-  type(ocean_grid_type),         intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),       intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZK_(G)), intent(in) :: h_bl, Sref, Ent_bl
-  real, dimension(SZI_(G)),      intent(in)    :: I_dSkbp1, F_kb
-  integer,                       intent(in)    :: kmb, i
-  type(entrain_diffusive_CS),    pointer       :: CS
-  real, dimension(SZI_(G)),      intent(inout) :: ea_kb
-  real,                optional, intent(in)    :: tol_in
+  type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
+  type(verticalGrid_type),  intent(in)    :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZK_(G)), &
+                            intent(in)    :: h_bl !< Layer thickness, with the top interior
+                                                  !! layer at k-index kmb+1, in units of m
+                                                  !! or kg m-2  (abbreviated as H below).
+  real, dimension(SZI_(G),SZK_(G)), &
+                            intent(in)    :: Sref !< The coordinate reference potential density,
+                                                  !! with the value of the topmost interior layer
+                                                  !! at index kmb+1, in units of kg m-3.
+  real, dimension(SZI_(G),SZK_(G)), &
+                            intent(in)    :: Ent_bl !< The average entrainment upward and downward
+                                                  !! across each interface around the buffer layers, in H.
+  real, dimension(SZI_(G)), intent(in)    :: I_dSkbp1 !< The inverse of the difference in reference
+                                                  !! potential density across the base of the
+                                                  !! uppermost interior layer, in units of m3 kg-1.
+  real, dimension(SZI_(G)), intent(in)    :: F_kb !< The entrainment from below by the
+                                                  !! uppermost interior layer, in H
+  integer,                  intent(in)    :: kmb  !< The number of mixed and buffer layers.
+  integer,                  intent(in)    :: i    !< The i-index to work on
+  type(entrain_diffusive_CS), pointer     :: CS   !< This module's control structure.
+  real, dimension(SZI_(G)), intent(inout) :: ea_kb !< The entrainment from above by the layer below
+                                                  !! the buffer layer (i.e. layer kb), in H.
+  real,           optional, intent(in)    :: tol_in !< A tolerance for the iterative determination
+                                                  !! of the entrainment, in H.
 
   real :: max_ea, min_ea
   real :: err, err_min, err_max
@@ -1637,10 +1646,9 @@ subroutine determine_Ea_kb(h_bl, dtKd_kb, Sref, I_dSkbp1, Ent_bl, ea_kbp1, &
                            error, err_min_eakb0, err_max_eakb0, F_kb, dFdfm_kb)
   type(ocean_grid_type),            intent(in)  :: G        !< The ocean's grid structure.
   type(verticalGrid_type),          intent(in)  :: GV       !< The ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZK_(G)), intent(in)  :: h_bl     !< Layer thickness, with the top
-                                                            !! interior layer at k-index kmb+1, in
-                                                            !! units of m or kg m-2
-                                                            !! (abbreviated as H below).
+  real, dimension(SZI_(G),SZK_(G)), intent(in)  :: h_bl     !< Layer thickness, with the top interior
+                                                            !! layer at k-index kmb+1, in units of m
+                                                            !! or kg m-2  (abbreviated as H below).
   real, dimension(SZI_(G),SZK_(G)), intent(in)  :: Sref     !< The coordinate reference potential
                                                             !! density, with the value of the
                                                             !! topmost interior layer at layer
@@ -1661,7 +1669,7 @@ subroutine determine_Ea_kb(h_bl, dtKd_kb, Sref, I_dSkbp1, Ent_bl, ea_kbp1, &
                                                             !! entrainment, in H.
   real, dimension(SZI_(G)),         intent(in)  :: max_eakb !< The maximum permissible rate of
                                                             !! entrainment, in H.
-  integer,                          intent(in)  :: kmb
+  integer,                          intent(in)  :: kmb      !< The number of mixed and buffer layers.
   integer,                          intent(in)  :: is, ie   !< The range of i-indices to work on.
   logical, dimension(SZI_(G)),      intent(in)  :: do_i     !< A logical variable indicating which
                                                             !! i-points to work on.
@@ -1893,7 +1901,7 @@ subroutine find_maxF_kb(h_bl, Sref, Ent_bl, I_dSkbp1, min_ent_in, max_ent_in, &
                                                       !! in H.
   real, dimension(SZI_(G)),   intent(in)  :: max_ent_in !< The maximum value of ent to search,
                                                       !! in H.
-  integer,                    intent(in)  :: kmb
+  integer,                    intent(in)  :: kmb      !< The number of mixed and buffer layers.
   integer,                    intent(in)  :: is, ie   !< The range of i-indices to work on.
   type(entrain_diffusive_CS), pointer     :: CS       !< This module's control structure.
   real, dimension(SZI_(G)),   intent(out) :: maxF     !< The maximum value of F
@@ -2166,6 +2174,8 @@ subroutine find_maxF_kb(h_bl, Sref, Ent_bl, I_dSkbp1, min_ent_in, max_ent_in, &
 
 end subroutine find_maxF_kb
 
+!> This subroutine initializes the parameters and memory associated with the
+!! entrain_diffusive module.
 subroutine entrain_diffusive_init(Time, G, GV, param_file, diag, CS)
   type(time_type),         intent(in)    :: Time !< The current model time.
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure.
@@ -2228,9 +2238,11 @@ subroutine entrain_diffusive_init(Time, G, GV, param_file, diag, CS)
 
 end subroutine entrain_diffusive_init
 
+!> This subroutine cleans up and deallocates any memory associated with the
+!! entrain_diffusive module.
 subroutine entrain_diffusive_end(CS)
-  type(entrain_diffusive_CS), pointer :: CS
-
+  type(entrain_diffusive_CS), pointer :: CS !< A pointer to the control structure for this
+                                            !! module that will be deallocated.
   if (associated(CS)) deallocate(CS)
 
 end subroutine entrain_diffusive_end

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -61,9 +61,9 @@ type, public :: geothermal_CS ; private
                              ! otherwise GEOTHERMAL_SCALE has been set to 0 and
                              ! there is no heat to apply.
 
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
 end type geothermal_CS
 
 contains
@@ -362,6 +362,7 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, CS)
 
 end subroutine geothermal
 
+!> Initialize parameters and allocate memory associated with the geothermal heating module.
 subroutine geothermal_init(Time, G, param_file, diag, CS)
   type(time_type), target, intent(in)    :: Time !< Current model time.
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure.
@@ -370,14 +371,6 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
   type(diag_ctrl), target, intent(inout) :: diag !< Structure used to regulate diagnostic output.
   type(geothermal_CS),     pointer       :: CS   !< Pointer pointing to the module control
                                                  !! structure.
-
-! Arguments:
-!  (in)      Time       - current model time
-!  (in)      G          - ocean grid structure
-!  (in)      param_file - structure indicating the open file to parse for
-!                         model parameter values
-!  (in)      diag       - structure used to regulate diagnostic output
-!  (in/out)  CS         - pointer pointing to the module control structure
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -452,8 +445,10 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
 
 end subroutine geothermal_init
 
+!> Clean up and deallocate memory associated with the geothermal heating module.
 subroutine geothermal_end(CS)
-  type(geothermal_CS), pointer :: CS
+  type(geothermal_CS), pointer :: CS !< Geothermal heating control structure that
+                                     !! will be deallocated in this subroutine.
 
   if (associated(CS%geo_heat)) deallocate(CS%geo_heat)
   if (associated(CS)) deallocate(CS)

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -46,9 +46,9 @@ implicit none ; private
 public set_int_tide_input, int_tide_input_init, int_tide_input_end
 
 type, public :: int_tide_input_CS ; private
-  logical :: debug           ! If true, write verbose checksums for debugging.
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  logical :: debug      ! If true, write verbose checksums for debugging.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                        ! regulate the timing of diagnostic output.
   real :: TKE_itide_max ! Maximum Internal tide conversion (W m-2)
                         ! available to mix above the BBL
 

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -85,8 +85,8 @@ type, public :: Kappa_shear_CS ; private
                              ! no good reason why this should be false.
   logical :: layer_stagger = .false.
   logical :: debug = .false.
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                            ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                             ! regulate the timing of diagnostic output.
   integer :: id_Kd_shear = -1, id_TKE = -1
   integer :: id_ILd2 = -1, id_dz_Int = -1
 end type Kappa_shear_CS

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -129,8 +129,8 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
                            intent(inout) :: kv_io  !< The vertical viscosity at each interface
                                                    !! (not layer!) in m2 s-1. This discards any
-                                                   !! previous value i.e. intent(out) and simply
-                                                   !! sets Kv = Prandtl * Kd_shear
+                                                   !! previous value (i.e. it is intent out) and
+                                                   !! simply sets Kv = Prandtl * Kd_shear
   real,                    intent(in)    :: dt     !< Time increment, in s.
   type(Kappa_shear_CS),    pointer       :: CS     !< The control structure returned by a previous
                                                    !! call to kappa_shear_init.
@@ -156,7 +156,7 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
 !                     the iteration toward convergence.
 !  (in/out)  kv_io - The vertical viscosity at each interface
 !                    (not layer!) in m2 s-1. This discards any previous value
-!                    i.e. intent(out) and simply sets Kv = Prandtl * Kd_shear
+!                    (i.e. it is intent out) and simply sets Kv = Prandtl * Kd_shear
 !  (in)      dt - Time increment, in s.
 !  (in)      G - The ocean's grid structure.
 !  (in)      GV - The ocean's vertical grid structure.

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -79,9 +79,9 @@ type, public :: opacity_CS ; private
   integer :: sbc_chl         ! An integer handle used in time interpolation of
                              ! chlorophyll read from a file.
   logical ::  chl_from_file  !   If true, chl_a is read from a file.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                             ! regulate the timing of diagnostic output.
   type(tracer_flow_control_CS), pointer  :: tracer_flow_CSp => NULL()
                     ! A pointer to the control structure of the tracer modules.
 

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -99,6 +99,7 @@ character*(10), parameter :: DOUBLE_EXP_STRING = "DOUBLE_EXP"
 
 contains
 
+!> This sets the opacity of sea water based based on one of several different schemes.
 subroutine set_opacity(optics, fluxes, G, GV, CS)
   type(optics_type),       intent(inout) :: optics !< An optics structure that has values
                                                    !! set based on the opacities.
@@ -227,6 +228,8 @@ subroutine set_opacity(optics, fluxes, G, GV, CS)
 end subroutine set_opacity
 
 
+!> This sets the "blue" band opacity based on chloophyll A concencentrations
+!! The red portion is lumped into the net heating at the surface.
 subroutine opacity_from_chl(optics, fluxes, G, CS, chl_in)
   type(optics_type),     intent(inout)  :: optics !< An optics structure that has values
                                                   !! set based on the opacities.
@@ -260,7 +263,7 @@ subroutine opacity_from_chl(optics, fluxes, G, CS, chl_in)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
 !   In this model, the Morel (modified) and Manizza (modified) schemes
-! use the "blue" band in the paramterizations to determine the e-folding
+! use the "blue" band in the parameterizations to determine the e-folding
 ! depth of the incoming shortwave attenuation. The red portion is lumped
 ! into the net heating at the surface.
 !
@@ -413,8 +416,10 @@ subroutine opacity_from_chl(optics, fluxes, G, CS, chl_in)
 
 end subroutine opacity_from_chl
 
+!> This sets the blue-wavelength opacity according to the scheme proposed by
+!! Morel and Antoine (1994).
 function opacity_morel(chl_data)
-  real, intent(in)  :: chl_data
+  real, intent(in)  :: chl_data !< The chlorophyll-A concentration in mg m-3.
   real :: opacity_morel
 ! Argument : chl_data - The chlorophyll-A concentration in mg m-3.
 !   The following are coefficients for the optical model taken from Morel and
@@ -431,8 +436,10 @@ function opacity_morel(chl_data)
       ((Z2_coef(3) + Chl*Z2_coef(4)) + Chl2*(Z2_coef(5) + Chl*Z2_coef(6))) )
 end function
 
+!> This sets the penetrating shortwave fraction according to the scheme proposed by
+!! Morel and Antoine (1994).
 function SW_pen_frac_morel(chl_data)
-  real, intent(in)  :: chl_data
+  real, intent(in)  :: chl_data !< The chlorophyll-A concentration in mg m-3.
   real :: SW_pen_frac_morel
 ! Argument : chl_data - The chlorophyll-A concentration in mg m-3.
 !   The following are coefficients for the optical model taken from Morel and
@@ -449,8 +456,10 @@ function SW_pen_frac_morel(chl_data)
        ((V1_coef(3) + Chl*V1_coef(4)) + Chl2*(V1_coef(5) + Chl*V1_coef(6))) )
 end function SW_pen_frac_morel
 
+!>   This sets the blue-wavelength opacity according to the scheme proposed by
+!! Manizza, M. et al, 2005.
 function opacity_manizza(chl_data)
-  real, intent(in)  :: chl_data
+  real, intent(in)  :: chl_data !< The chlorophyll-A concentration in mg m-3.
   real :: opacity_manizza
 ! Argument : chl_data - The chlorophyll-A concentration in mg m-3.
 !   This sets the blue-wavelength opacity according to the scheme proposed by
@@ -467,7 +476,8 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
   type(diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic
                                                  !! output.
   type(tracer_flow_control_CS), &
-                  target, intent(in)     :: tracer_flow
+                   target, intent(in)    :: tracer_flow !< A pointer to the tracer flow control
+                                                 !! module's control structure
   type(opacity_CS),        pointer       :: CS   !< A pointer that is set to point to the control
                                                  !! structure for this module.
   type(optics_type),       pointer       :: optics !< An optics structure that has parameters

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -67,9 +67,9 @@ type, public :: regularize_layers_CS ; private
                              ! intensity.  Now 30% and 50% of the way from
                              ! h_def_tol1 to 1.
   real    :: Hmix_min        ! The minimum mixed layer thickness in m.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                             ! regulate the timing of diagnostic output.
   logical :: debug           ! If true, do more thorough checks for debugging purposes.
 
   integer :: id_def_rat = -1

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -959,13 +959,16 @@ end subroutine set_viscous_BBL
 
 !> This subroutine finds a thickness-weighted value of v at the u-points.
 function set_v_at_u(v, h, G, i, j, k, mask2dCv, OBC)
-  type(ocean_grid_type),                     intent(in) :: G    !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in) :: v    !< The meridional velocity, in m s-1
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  integer,                                   intent(in) :: i, j, k
-  real, dimension(SZI_(G),SZJB_(G)),         intent(in) :: mask2dCv
-  type(ocean_OBC_type),                      pointer    :: OBC
-  real                                                  :: set_v_at_u
+  type(ocean_grid_type), intent(in) :: G    !< The ocean's grid structure
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                         intent(in) :: v    !< The meridional velocity, in m s-1
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                         intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  integer,               intent(in) :: i, j, k !< The indices of the u-location to work on.
+  real, dimension(SZI_(G),SZJB_(G)),&
+                         intent(in) :: mask2dCv !< A multiplicative mask of the v-points
+  type(ocean_OBC_type),  pointer    :: OBC  !< A pointer to an open boundary condition structure
+  real                              :: set_v_at_u !< The retur value of v at u points, in m s-1.
 
   ! This subroutine finds a thickness-weighted value of v at the u-points.
   real :: hwt(0:1,-1:0)    ! Masked weights used to average u onto v, in H.
@@ -998,12 +1001,15 @@ end function set_v_at_u
 !> This subroutine finds a thickness-weighted value of u at the v-points.
 function set_u_at_v(u, h, G, i, j, k, mask2dCu, OBC)
   type(ocean_grid_type),                     intent(in) :: G    !< The ocean's grid structure
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in) :: u    !< The zonal velocity, in m s-1
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  integer,                                   intent(in) :: i, j, k
-  real, dimension(SZIB_(G),SZJ_(G)),         intent(in) :: mask2dCu
-  type(ocean_OBC_type),                      pointer    :: OBC
-  real                                                  :: set_u_at_v
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                         intent(in) :: u    !< The zonal velocity, in m s-1
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                         intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  integer,               intent(in) :: i, j, k !< The indices of the v-location to work on.
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                         intent(in) :: mask2dCu !< A multiplicative mask of the u-points
+  type(ocean_OBC_type),  pointer    :: OBC  !< A pointer to an open boundary condition structure
+  real                              :: set_u_at_v !< The return value of u at v points, in m s-1.
 
   ! This subroutine finds a thickness-weighted value of u at the v-points.
   real :: hwt(-1:0,0:1)    ! Masked weights used to average u onto v, in H.
@@ -1853,7 +1859,7 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
                                                  !! related fields.  Allocated here.
   type(set_visc_CS),       pointer       :: CS   !< A pointer that is set to point to the control
                                                  !! structure for this module
-  type(ocean_OBC_type),    pointer       :: OBC
+  type(ocean_OBC_type),    pointer       :: OBC  !< A pointer to an open boundary condition structure
 ! Arguments: Time - The current model time.
 !  (in)      G - The ocean's grid structure.
 !  (in)      GV - The ocean's vertical grid structure.
@@ -2084,9 +2090,12 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
 
 end subroutine set_visc_init
 
+!> This subroutine dellocates any memory in the set_visc control structure.
 subroutine set_visc_end(visc, CS)
-  type(vertvisc_type), intent(inout) :: visc
-  type(set_visc_CS),   pointer       :: CS
+  type(vertvisc_type), intent(inout) :: visc !< A structure containing vertical viscosities and
+                                             !! related fields.  Elements are deallocated here.
+  type(set_visc_CS),   pointer       :: CS   !< The control structure returned by a previous
+                                             !! call to vertvisc_init.
   if (CS%bottomdraglaw) then
     deallocate(visc%bbl_thick_u) ; deallocate(visc%bbl_thick_v)
     deallocate(visc%kv_bbl_u) ; deallocate(visc%kv_bbl_v)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -76,8 +76,8 @@ type, public :: set_visc_CS ; private
                             ! this fraction of the absolute rotation rate blended
                             ! with the local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
   logical :: debug          ! If true, write verbose checksums for debugging purposes.
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                            ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                            ! regulate the timing of diagnostic output.
   integer :: id_bbl_thick_u = -1, id_kv_bbl_u = -1
   integer :: id_bbl_thick_v = -1, id_kv_bbl_v = -1
   integer :: id_Ray_u = -1, id_Ray_v = -1
@@ -1841,7 +1841,7 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz, i, j, n
   logical :: use_kappa_shear, adiabatic, use_omega
   logical :: use_CVMix_ddiff, differential_diffusion
-  type(OBC_segment_type), pointer :: segment  ! pointer to OBC segment type
+  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to OBC segment type
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_set_visc"  ! This module's name.

--- a/src/parameterizations/vertical/MOM_shortwave_abs.F90
+++ b/src/parameterizations/vertical/MOM_shortwave_abs.F90
@@ -27,7 +27,7 @@ type, public :: optics_type
                             ! the nbands bands that penetrates beyond the surface.
                             ! The most rapidly varying dimension is the band.
 
-  real, pointer, dimension(:) ::   &
+  real, pointer, dimension(:) :: &
     min_wavelength_band => NULL(), & ! The range of wavelengths in each band of
     max_wavelength_band => NULL()    ! penetrating shortwave radiation (nm)
 

--- a/src/parameterizations/vertical/MOM_shortwave_abs.F90
+++ b/src/parameterizations/vertical/MOM_shortwave_abs.F90
@@ -346,21 +346,29 @@ subroutine sumSWoverBands(G, GV, h, opacity_band, nsw, j, dt, &
 !< This subroutine calculates the total shortwave heat flux integrated over
 !! bands as a function of depth.  This routine is only called for computing
 !! buoyancy fluxes for use in KPP. This routine does not updat e the state.
-  type(ocean_grid_type),              intent(in)    :: G   !< The ocean's grid structure.
-  type(verticalGrid_type),            intent(in)    :: GV  !< The ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZK_(G)),   intent(in)    :: h   !< Layer thicknesses, in H (usually m
-                                                           !! or kg m-2).
-  real, dimension(:,:,:),             intent(in)    :: opacity_band !< opacity in each band of
-                                                           !! penetrating shortwave radiation,
-                                                           !! in m-1. The indicies are band, i, k.
-  integer,                            intent(in)    :: nsw !< number of bands of penetrating
-                                                           !! shortwave radiation.
-  integer,                            intent(in)    :: j   !< j-index to work on.
-  real,                               intent(in)    :: dt  !< Time step (seconds).
-  real,                               intent(in)    :: H_limit_fluxes
-  logical,                            intent(in)    :: absorbAllSW
-  real, dimension(:,:),               intent(in)    :: iPen_SW_bnd
-  real, dimension(SZI_(G),SZK_(G)+1), intent(inout) :: netPen ! Units of K H.
+  type(ocean_grid_type),    intent(in)    :: G   !< The ocean's grid structure.
+  type(verticalGrid_type),  intent(in)    :: GV  !< The ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZK_(G)), &
+                            intent(in)    :: h   !< Layer thicknesses, in H (usually m or kg m-2).
+  real, dimension(:,:,:),   intent(in)    :: opacity_band !< opacity in each band of
+                                                 !! penetrating shortwave radiation,
+                                                 !! in m-1. The indicies are band, i, k.
+  integer,                  intent(in)    :: nsw !< number of bands of penetrating
+                                                 !! shortwave radiation.
+  integer,                  intent(in)    :: j   !< j-index to work on.
+  real,                     intent(in)    :: dt  !< Time step (seconds).
+  real,                     intent(in)    :: H_limit_fluxes !< the total depth at which the
+                                                 !! surface fluxes start to be limited to avoid
+                                                 !! excessive heating of a thin ocean (H units)
+  logical,                  intent(in)    :: absorbAllSW !< If true, ensure that all shortwave
+                                                 !! radiation is absorbed in the ocean water column.
+  real, dimension(:,:),     intent(in)    :: iPen_SW_bnd !< The incident penetrating shortwave
+                                                 !! heating in each band that hits the bottom and
+                                                 !! will be redistributed through the water column
+                                                 !! (K H units); size nsw x SZI_(G).
+  real, dimension(SZI_(G),SZK_(G)+1), &
+                             intent(inout) :: netPen !< Net penetrating shortwave heat flux at each
+                                                 !! interface, summed across all bands, in K H.
 
 ! Arguments:
 !  (in)      G             = ocean grid structure

--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -112,8 +112,8 @@ type, public :: sponge_CS ; private
   type(p2d) :: Ref_val_im(MAX_FIELDS_)  ! The values toward which the i-means of
                              ! fields are damped.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                             ! regulate the timing of diagnostic output.
   integer :: id_w_sponge = -1
 
 end type sponge_CS

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -643,18 +643,32 @@ end function tidal_mixing_init
 !! diffusivities.
 subroutine calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS, &
                                     N2_lay, N2_int, Kd, Kd_int, Kd_max)
-  type(ocean_grid_type),                    intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),                  intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  real, dimension(SZI_(G)),                 intent(in)    :: N2_bot
-  real, dimension(SZI_(G),SZK_(G)),         intent(in)    :: N2_lay
-  real, dimension(SZI_(G),SZK_(G)+1),       intent(in)    :: N2_int
-  integer,                                  intent(in)    :: j
-  real, dimension(SZI_(G),SZK_(G)),         intent(in)    :: TKE_to_Kd, max_TKE
-  type(tidal_mixing_cs),                    pointer       :: CS
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: Kd
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), optional, intent(inout) :: Kd_int
-  real,                                     intent(inout) :: Kd_max
+  type(ocean_grid_type),            intent(in)    :: G      !< The ocean's grid structure
+  type(verticalGrid_type),          intent(in)    :: GV     !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                    intent(in)    :: h      !< Layer thicknesses, in H (usually m or kg m-2)
+  real, dimension(SZI_(G)),         intent(in)    :: N2_bot !< The near-bottom squared buoyancy
+                                                            !! frequency, in s-2.
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: N2_lay !< The squared buoyancy frequency of the
+                                                            !! layers, in s-2.
+  real, dimension(SZI_(G),SZK_(G)+1), intent(in)  :: N2_int !< The squared buoyancy frequency at the
+                                                            !! interfaces, in s-2.
+  integer,                          intent(in)    :: j      !< The j-index to work on
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: TKE_to_Kd !< The conversion rate between the TKE
+                                                            !! TKE dissipated within  a layer and the
+                                                            !! diapycnal diffusivity witin that layer,
+                                                            !! usually (~Rho_0 / (G_Earth * dRho_lay)),
+                                                            !! in m2 s-1 / m3 s-3 = s2 m-1
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: max_TKE !< The energy required to for a layer to entrain
+                                                            !! to its maximum realizable thickness, in m3 s-3
+  type(tidal_mixing_cs),            pointer       :: CS     !< The control structure for this module
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                    intent(inout) :: Kd     !< The diapycnal diffusvity in layers, in m2 s-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
+                          optional, intent(inout) :: Kd_int !< The diapycnal diffusvity at interfaces, in m2 s-1.
+  real,                             intent(in)    :: Kd_max !< The maximum increment for diapycnal
+                                                            !! diffusivity due to TKE-based processes, in m2 s-1.
+                                                            !! Set this to a negative value to have no limit.
 
   if (CS%Int_tide_dissipation .or. CS%Lee_wave_dissipation .or. CS%Lowmode_itidal_dissipation) then
     if (CS%use_CVMix_tidal) then
@@ -670,13 +684,14 @@ end subroutine
 !> Calls the CVMix routines to compute tidal dissipation and to add the effect of internal-tide-driven
 !! mixing to the interface diffusivities.
 subroutine calculate_CVMix_tidal(h, j, G, GV, CS, N2_int, Kd)
-  integer,                                  intent(in)    :: j
+  integer,                                  intent(in)    :: j     !< The j-index to work on
   type(ocean_grid_type),                    intent(in)    :: G     !< Grid structure.
   type(verticalGrid_type),                  intent(in)    :: GV    !< ocean vertical grid structure
   type(tidal_mixing_cs),                    pointer       :: CS    !< This module's control structure.
-  real, dimension(SZI_(G),SZK_(G)+1),       intent(in)    :: N2_int
+  real, dimension(SZI_(G),SZK_(G)+1),       intent(in)    :: N2_int !< The squared buoyancy frequency at the
+                                                                   !! interfaces, in s-2.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h     !< Layer thicknesses, in H (usually m or kg m-2).
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: Kd
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: Kd    !< The diapycnal diffusivities in the layers, in m2 s-1
 
   ! local
   real, dimension(SZK_(G)+1) :: Kd_tidal    !< tidal diffusivity [m2/s]
@@ -695,7 +710,7 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, CS, N2_int, Kd)
   real, parameter :: rho_fw = 1000.0 ! fresh water density [kg/m^3]
                                      ! TODO: when coupled, get this from CESM (SHR_CONST_RHOFW)
   real :: h_neglect, h_neglect_edge
-  type(tidal_mixing_diags), pointer :: dd
+  type(tidal_mixing_diags), pointer :: dd => NULL()
 
   is  = G%isc ; ie  = G%iec
   dd => CS%dd
@@ -877,17 +892,30 @@ end subroutine calculate_CVMix_tidal
 !! Froude-number-depending breaking, PSI, etc.).
 subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS, &
                                     N2_lay, Kd, Kd_int, Kd_max)
-  type(ocean_grid_type),                      intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),                    intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  real, dimension(SZI_(G)),                   intent(in)    :: N2_bot
-  real, dimension(SZI_(G),SZK_(G)),           intent(in)    :: N2_lay
-  integer,                                    intent(in)    :: j
-  real, dimension(SZI_(G),SZK_(G)),           intent(in)    :: TKE_to_Kd, max_TKE
-  type(tidal_mixing_cs),                      pointer       :: CS
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(inout) :: Kd
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), optional, intent(inout) :: Kd_int
-  real,                                       intent(inout) :: Kd_max
+  type(ocean_grid_type),            intent(in)    :: G      !< The ocean's grid structure
+  type(verticalGrid_type),          intent(in)    :: GV     !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                    intent(in)    :: h      !< Layer thicknesses, in H (usually m or kg m-2)
+  real, dimension(SZI_(G)),         intent(in)    :: N2_bot !< The near-bottom squared buoyancy frequency
+                                                            !! frequency, in s-2.
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: N2_lay !< The squared buoyancy frequency of the
+                                                            !! layers, in s-2.
+  integer,                          intent(in)    :: j      !< The j-index to work on
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: TKE_to_Kd !< The conversion rate between the TKE
+                                                            !! TKE dissipated within  a layer and the
+                                                            !! diapycnal diffusivity witin that layer,
+                                                            !! usually (~Rho_0 / (G_Earth * dRho_lay)),
+                                                            !! in m2 s-1 / m3 s-3 = s2 m-1
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: max_TKE !< The energy required to for a layer to entrain
+                                                            !! to its maximum realizable thickness, in m3 s-3
+  type(tidal_mixing_cs),            pointer       :: CS     !< The control structure for this module
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                    intent(inout) :: Kd     !< The diapycnal diffusvity in layers, in m2 s-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
+                          optional, intent(inout) :: Kd_int !< The diapycnal diffusvity at interfaces, in m2 s-1.
+  real,                             intent(in)    :: Kd_max !< The maximum increment for diapycnal
+                                                            !! diffusivity due to TKE-based processes, in m2 s-1.
+                                                            !! Set this to a negative value to have no limit.
 
   ! This subroutine adds the effect of internal-tide-driven mixing to the layer diffusivities.
   ! The mechanisms considered are (1) local dissipation of internal waves generated by the
@@ -936,7 +964,7 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS,
   logical :: use_Polzin, use_Simmons
   integer :: i, k, is, ie, nz
   integer :: a, fr, m
-  type(tidal_mixing_diags), pointer :: dd
+  type(tidal_mixing_diags), pointer :: dd => NULL()
 
   is = G%isc ; ie = G%iec ; nz = G%ke
   dd => CS%dd
@@ -1269,12 +1297,12 @@ end subroutine add_int_tide_diffusivity
 
 !> Sets up diagnostics arrays for tidal mixing.
 subroutine setup_tidal_diagnostics(G,CS)
-  type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
-  type(tidal_mixing_cs),    pointer       :: CS
+  type(ocean_grid_type), intent(in) :: G  !< The ocean's grid structure
+  type(tidal_mixing_cs), pointer    :: CS !< The control structure for this module
 
   ! local
   integer :: isd, ied, jsd, jed, nz
-  type(tidal_mixing_diags), pointer :: dd
+  type(tidal_mixing_diags), pointer :: dd => NULL()
 
   isd = G%isd; ied = G%ied; jsd = G%jsd; jed = G%jed; nz = G%ke
   dd => CS%dd
@@ -1355,18 +1383,19 @@ subroutine setup_tidal_diagnostics(G,CS)
   endif
 end subroutine setup_tidal_diagnostics
 
-subroutine post_tidal_diagnostics(G,GV,h,CS)
-  type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),   intent(in)   :: GV   !< The ocean's vertical grid structure.
+!> This subroutine offers up diagnostics of the tidal mixing.
+subroutine post_tidal_diagnostics(G, GV, h ,CS)
+  type(ocean_grid_type),    intent(in)   :: G   !< The ocean's grid structure
+  type(verticalGrid_type),  intent(in)   :: GV  !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
-                             intent(in)   :: h   !< Layer thicknesses, in H (usually m or kg m-2).
-  type(tidal_mixing_cs),    pointer       :: CS
+                            intent(in)   :: h   !< Layer thicknesses, in H (usually m or kg m-2).
+  type(tidal_mixing_cs),    pointer      :: CS  !< The control structure for this module
 
   ! local
   integer :: num_z_diags
   integer   :: z_ids(6)     ! id numbers of diagns to be interpolated to depth space
   type(p3d) :: z_ptrs(6)    ! pointers to diagns to be interpolated into depth space
-  type(tidal_mixing_diags), pointer :: dd
+  type(tidal_mixing_diags), pointer :: dd => NULL()
 
   num_z_diags = 0
   dd => CS%dd
@@ -1446,11 +1475,12 @@ subroutine post_tidal_diagnostics(G,GV,h,CS)
 end subroutine post_tidal_diagnostics
 
 ! TODO: move this subroutine to MOM_internal_tide_input module (?)
+!> This subroutine read tidal energy inputs from a file.
 subroutine read_tidal_energy(G, tidal_energy_type, tidal_energy_file, CS)
-  type(ocean_grid_type),  intent(in)  :: G    !< The ocean's grid structure
-  character(len=20),      intent(in)  :: tidal_energy_type
-  character(len=200),     intent(in)  :: tidal_energy_file
-  type(tidal_mixing_cs),  pointer     :: CS
+  type(ocean_grid_type), intent(in) :: G    !< The ocean's grid structure
+  character(len=20),     intent(in) :: tidal_energy_type !< The type of tidal energy inputs to read
+  character(len=200),    intent(in) :: tidal_energy_file !< The file from which to read tidalinputs
+  type(tidal_mixing_cs), pointer    :: CS   !< The control structure for this module
   ! local
   integer :: isd, ied, jsd, jed, nz
   real, allocatable, dimension(:,:) :: tidal_energy_flux_2d ! input tidal energy flux at T-grid points (W/m^2)
@@ -1465,19 +1495,18 @@ subroutine read_tidal_energy(G, tidal_energy_type, tidal_energy_file, CS)
     CS%tidal_qe_2d = (CS%Gamma_itides) * tidal_energy_flux_2d
     deallocate(tidal_energy_flux_2d)
   case ('ER03') ! Egbert & Ray 2003
-    call read_tidal_constituents(G, tidal_energy_type, tidal_energy_file, CS)
+    call read_tidal_constituents(G, tidal_energy_file, CS)
   case default
     call MOM_error(FATAL, "read_tidal_energy: Unknown tidal energy file type.")
   end select
 
 end subroutine read_tidal_energy
 
-
-subroutine read_tidal_constituents(G, tidal_energy_type, tidal_energy_file, CS)
-  type(ocean_grid_type),  intent(in)  :: G    !< The ocean's grid structure
-  character(len=20),      intent(in)  :: tidal_energy_type
-  character(len=200),     intent(in)  :: tidal_energy_file
-  type(tidal_mixing_cs),  pointer     :: CS
+!> This subroutine reads tidal input energy from a file by constituent.
+subroutine read_tidal_constituents(G, tidal_energy_file, CS)
+  type(ocean_grid_type), intent(in) :: G    !< The ocean's grid structure
+  character(len=200),    intent(in) :: tidal_energy_file !< The file from which to read tidal energy inputs
+  type(tidal_mixing_cs), pointer    :: CS   !< The control structure for this module
 
   ! local
   integer               :: k, isd, ied, jsd, jed, i,j
@@ -1579,10 +1608,10 @@ subroutine read_tidal_constituents(G, tidal_energy_type, tidal_energy_file, CS)
 
 end subroutine read_tidal_constituents
 
-
 !> Clear pointers and deallocate memory
 subroutine tidal_mixing_end(CS)
-  type(tidal_mixing_cs), pointer :: CS ! This module's control structure
+  type(tidal_mixing_cs), pointer :: CS !< This module's control structure, which
+                                       !! will be deallocated in this routine.
 
   if (.not.associated(CS)) return
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -142,12 +142,12 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, CS, &
                     taux_bot, tauy_bot, Waves)
   type(ocean_grid_type),   intent(in)    :: G      !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV     !< Ocean vertical grid structure
-  real, intent(inout), &
-    dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: u      !< Zonal velocity in m s-1
-  real, intent(inout), &
-    dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: v      !< Meridional velocity in m s-1
-  real, intent(in), &
-    dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: h      !< Layer thickness in H
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                           intent(inout) :: u      !< Zonal velocity in m s-1
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                           intent(inout) :: v      !< Meridional velocity in m s-1
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: h      !< Layer thickness in H
   type(mech_forcing),    intent(in)      :: forces !< A structure with the driving mechanical forces
   type(vertvisc_type),   intent(inout)   :: visc   !< Viscosities and bottom drag
   real,                  intent(in)      :: dt     !< Time increment in s
@@ -459,15 +459,17 @@ end subroutine vertvisc
 subroutine vertvisc_remnant(visc, visc_rem_u, visc_rem_v, dt, G, GV, CS)
   type(ocean_grid_type), intent(in)   :: G    !< Ocean grid structure
   type(verticalGrid_type), intent(in) :: GV   !< Ocean vertical grid structure
-  type(vertvisc_type), intent(in)     :: visc !< Viscosities and bottom drag
-  !> Fraction of a time-step's worth of a barotopic acceleration that
-  !! a layer experiences after viscosity is applied in the zonal direction
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(inout) :: visc_rem_u
-  !> Fraction of a time-step's worth of a barotopic acceleration that
-  !! a layer experiences after viscosity is applied in the meridional direction
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(inout) :: visc_rem_v
-  real, intent(in)           :: dt !< Time increment in s
-  type(vertvisc_CS), pointer :: CS !< Vertical viscosity control structure
+  type(vertvisc_type),   intent(in)   :: visc !< Viscosities and bottom drag
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                         intent(inout) :: visc_rem_u !< Fraction of a time-step's worth of a
+                                              !! barotopic acceleration that a layer experiences
+                                              !! after viscosity is applied in the zonal direction
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                         intent(inout) :: visc_rem_v !< Fraction of a time-step's worth of a
+                                              !! barotopic acceleration that a layer experiences
+                                              !! after viscosity is applied in the meridional direction
+  real,                  intent(in)    :: dt  !< Time increment in s
+  type(vertvisc_CS),     pointer       :: CS  !< Vertical viscosity control structure
 
   ! Local variables
 
@@ -564,19 +566,19 @@ end subroutine vertvisc_remnant
 !! and effective layer thicknesses (CS%h_u and CS%h_v) for later use in the
 !! applying the implicit vertical viscosity via vertvisc().
 subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, CS, OBC)
-  type(ocean_grid_type), intent(in)      :: G      !< Ocean grid structure
+  type(ocean_grid_type),   intent(in)    :: G      !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV     !< Ocean vertical grid structure
-  real, intent(in), &
-    dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: u      !< Zonal velocity in m s-1
-  real, intent(in), &
-    dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: v      !< Meridional velocity in m s-1
-  real, intent(in), &
-    dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: h      !< Layer thickness in H
-  type(mech_forcing),  intent(in)        :: forces !< A structure with the driving mechanical forces
-  type(vertvisc_type), intent(in)        :: visc   !< Viscosities and bottom drag
-  real, intent(in)                       :: dt     !< Time increment in s
-  type(vertvisc_CS), pointer             :: CS     !< Vertical viscosity control structure
-  type(ocean_OBC_type),  pointer         :: OBC    !< Open boundary condition structure
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: u      !< Zonal velocity in m s-1
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                           intent(in)    :: v      !< Meridional velocity in m s-1
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: h      !< Layer thickness in H
+  type(mech_forcing),      intent(in)    :: forces !< A structure with the driving mechanical forces
+  type(vertvisc_type),     intent(in)    :: visc   !< Viscosities and bottom drag
+  real,                    intent(in)    :: dt     !< Time increment in s
+  type(vertvisc_CS),       pointer       :: CS     !< Vertical viscosity control structure
+  type(ocean_OBC_type),    pointer       :: OBC    !< Open boundary condition structure
 
   ! Field from forces used in this subroutine:
   !   ustar: the friction velocity in m s-1, used here as the mixing
@@ -1014,41 +1016,33 @@ end subroutine vertvisc_coef
 !! adjacent layer thicknesses are used to calculate a[k] near the bottom.
 subroutine find_coupling_coef(a, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i, h_ml, &
                               dt, j, G, GV, CS, visc, forces, work_on_u, OBC, shelf)
-  type(ocean_grid_type), intent(in)                 :: G  !< Ocean grid structure
-  type(verticalGrid_type),               intent(in) :: GV !< Ocean vertical grid structure
-  !> Coupling coefficient across interfaces, in m s-1
-  real,    dimension(SZIB_(G),SZK_(GV)+1), intent(out) :: a
-  !> Thickness at velocity points, in H
-  real,    dimension(SZIB_(G),SZK_(GV)),   intent(in)  :: hvel
-  !> If true, determine coupling coefficient for a column
-  logical, dimension(SZIB_(G)),            intent(in)  :: do_i
-  !> Harmonic mean of thicknesses around a velocity grid point, in H
-  real,    dimension(SZIB_(G),SZK_(GV)),   intent(in)  :: h_harm
-  !> Bottom boundary layer thickness, in H
-  real,    dimension(SZIB_(G)),            intent(in)  :: bbl_thick
-  !> Bottom boundary layer viscosity, in m2 s-1
-  real,    dimension(SZIB_(G)),            intent(in)  :: kv_bbl
-  !> Estimate of interface heights above the bottom,
-  !! normalised by the bottom boundary layer thickness
-  real,    dimension(SZIB_(G),SZK_(GV)+1), intent(in)  :: z_i
-  !> Mixed layer depth, in H
-  real,    dimension(SZIB_(G)),         intent(out) :: h_ml
-  !> j-index to find coupling coefficient for
-  integer,                              intent(in)  :: j
-  !> Time increment, in s
-  real,                                 intent(in)  :: dt
-  !> Vertical viscosity control structure
-  type(vertvisc_CS), pointer                        :: CS
-  !> Structure containing viscosities and bottom drag
-  type(vertvisc_type), intent(in)                   :: visc
-  type(mech_forcing),      intent(in)    :: forces !< A structure with the driving mechanical forces
-  !> If true, u-points are being calculated, otherwise v-points
-  logical,                              intent(in)  :: work_on_u
-  !> Open boundary condition structure
-  type(ocean_OBC_type),  pointer         :: OBC
-  !> If present and true, use a surface boundary condition
-  !! appropriate for an ice shelf.
-  logical, optional,                    intent(in)  :: shelf
+  type(ocean_grid_type),     intent(in)  :: G  !< Ocean grid structure
+  type(verticalGrid_type),   intent(in)  :: GV !< Ocean vertical grid structure
+  real, dimension(SZIB_(G),SZK_(GV)+1), &
+                             intent(out) :: a  !< Coupling coefficient across interfaces, in m s-1
+  real, dimension(SZIB_(G),SZK_(GV)), &
+                             intent(in)  :: hvel !< Thickness at velocity points, in H
+  logical, dimension(SZIB_(G)), &
+                             intent(in)  :: do_i !< If true, determine coupling coefficient for a column
+  real, dimension(SZIB_(G),SZK_(GV)), &
+                             intent(in)  :: h_harm !< Harmonic mean of thicknesses around a velocity
+                                                   !! grid point, in H
+  real, dimension(SZIB_(G)), intent(in)  :: bbl_thick !< Bottom boundary layer thickness, in H
+  real, dimension(SZIB_(G)), intent(in)  :: kv_bbl !< Bottom boundary layer viscosity, in m2 s-1
+  real, dimension(SZIB_(G),SZK_(GV)+1), &
+                             intent(in)  :: z_i  !< Estimate of interface heights above the bottom,
+                                                 !! normalized by the bottom boundary layer thickness
+  real, dimension(SZIB_(G)), intent(out) :: h_ml !< Mixed layer depth, in H
+  integer,                   intent(in)  :: j    !< j-index to find coupling coefficient for
+  real,                      intent(in)  :: dt   !< Time increment, in s
+  type(vertvisc_CS),         pointer     :: CS   !< Vertical viscosity control structure
+  type(vertvisc_type),       intent(in)  :: visc !< Structure containing viscosities and bottom drag
+  type(mech_forcing),        intent(in)  :: forces !< A structure with the driving mechanical forces
+  logical,                   intent(in)  :: work_on_u !< If true, u-points are being calculated,
+                                                  !! otherwise they are v-points
+  type(ocean_OBC_type),      pointer     :: OBC   !< Open boundary condition structure
+  logical,         optional, intent(in)  :: shelf !< If present and true, use a surface boundary
+                                                  !! condition appropriate for an ice shelf.
 
   ! Local variables
 
@@ -1497,21 +1491,22 @@ subroutine vertvisc_limit_vel(u, v, h, ADp, CDp, forces, visc, dt, G, GV, CS)
 
 end subroutine vertvisc_limit_vel
 
-!> Initialise the vertical friction module
+!> Initialize the vertical friction module
 subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
                          ntrunc, CS)
-  !> "MOM Internal State", a set of pointers to the fields and accelerations
-  !! that make up the ocean's physical state
-  type(ocean_internal_state), target, intent(in) :: MIS
-  type(time_type), target, intent(in)    :: Time       !< Current model time
-  type(ocean_grid_type),   intent(in)    :: G          !< Ocean grid structure
-  type(verticalGrid_type), intent(in)    :: GV         !< Ocean vertical grid structure
+  type(ocean_internal_state), &
+                   target, intent(in)    :: MIS    !< The "MOM Internal State", a set of pointers
+                                                   !! to the fields and accelerations that make
+                                                   !! up the ocean's physical state
+  type(time_type), target, intent(in)    :: Time   !< Current model time
+  type(ocean_grid_type),   intent(in)    :: G      !< Ocean grid structure
+  type(verticalGrid_type), intent(in)    :: GV     !< Ocean vertical grid structure
   type(param_file_type),   intent(in)    :: param_file !< File to parse for parameters
-  type(diag_ctrl), target, intent(inout) :: diag       !< Diagnostic control structure
-  type(accel_diag_ptrs),   intent(inout) :: ADp        !< Acceleration diagnostic pointers
-  type(directories),       intent(in)    :: dirs       !< Relevant directory paths
-  integer, target,         intent(inout) :: ntrunc     !< Number of velocity truncations
-  type(vertvisc_CS),       pointer       :: CS         !< Vertical viscosity control structure
+  type(diag_ctrl), target, intent(inout) :: diag   !< Diagnostic control structure
+  type(accel_diag_ptrs),   intent(inout) :: ADp    !< Acceleration diagnostic pointers
+  type(directories),       intent(in)    :: dirs   !< Relevant directory paths
+  integer, target,         intent(inout) :: ntrunc !< Number of velocity truncations
+  type(vertvisc_CS),       pointer       :: CS     !< Vertical viscosity control structure
 
   ! Local variables
 
@@ -1708,8 +1703,8 @@ end subroutine vertvisc_init
 subroutine updateCFLtruncationValue(Time, CS, activate)
   type(time_type), target, intent(in)    :: Time     !< Current model time
   type(vertvisc_CS),       pointer       :: CS       !< Vertical viscosity control structure
-  !> Whether to record the value of Time as the beginning of the ramp period
-  logical, optional,       intent(in)    :: activate
+  logical, optional,       intent(in)    :: activate !< Specifiy whether to record the value of
+                                                     !! Time as the beginning of the ramp period
 
   ! Local variables
   real :: deltaTime, wghtA
@@ -1744,7 +1739,9 @@ end subroutine updateCFLtruncationValue
 
 !> Clean up and deallocate the vertical friction module
 subroutine vertvisc_end(CS)
-  type(vertvisc_CS),   pointer       :: CS
+  type(vertvisc_CS), pointer :: CS !< Vertical viscosity control structure that
+                                   !! will be deallocated in this subroutine.
+
   DEALLOC_(CS%a_u) ; DEALLOC_(CS%h_u)
   DEALLOC_(CS%a_v) ; DEALLOC_(CS%h_v)
   if (associated(CS%a1_shelf_u)) deallocate(CS%a1_shelf_u)

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -34,11 +34,10 @@ public DOME_tracer_column_physics, DOME_tracer_surface_state, DOME_tracer_end
 integer, parameter :: ntr = 11
 
 type, public :: DOME_tracer_CS ; private
-  logical :: coupled_tracers = .false.  ! These tracers are not offered to the
-                                        ! coupler.
+  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
   character(len=200) :: tracer_IC_file ! The full path to the IC file, or " "
-                                   ! to initialize internally.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+                                       ! to initialize internally.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
@@ -49,8 +48,8 @@ type, public :: DOME_tracer_CS ; private
              ! if it is used and the surface tracer concentrations are to be
              ! provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
 
   type(vardesc) :: tr_desc(NTR)
 end type DOME_tracer_CS

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -85,7 +85,7 @@ type, public :: OCMIP2_CFC_CS ; private
   character(len=200) :: IC_file ! The file in which the CFC initial values can
                     ! be found, or an empty string for internal initilaization.
   logical :: Z_IC_file ! If true, the IC_file is in Z-space.  The default is false..
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer, dimension(:,:,:) :: &
     CFC11 => NULL(), &     ! The CFC11 concentration in mol m-3.
@@ -113,8 +113,8 @@ type, public :: OCMIP2_CFC_CS ; private
   integer :: ind_cfc_12_flux  ! are used to pack and unpack surface boundary
                               ! condition arrays.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
   ! The following vardesc types contain a package of metadata about each tracer.
@@ -146,7 +146,7 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_OCMIP2_CFC" ! This module's name.
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
-  real, dimension(:,:,:), pointer :: tr_ptr
+  real, dimension(:,:,:), pointer :: tr_ptr => NULL()
   real :: a11_dflt(4), a12_dflt(4) ! Default values of the various coefficients
   real :: d11_dflt(4), d12_dflt(4) ! In the expressions for the solubility and
   real :: e11_dflt(3), e12_dflt(3) ! Schmidt numbers.
@@ -518,7 +518,7 @@ subroutine OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS
   real, dimension(SZI_(G),SZJ_(G)) :: &
     CFC11_flux, &    ! The fluxes of CFC11 and CFC12 into the ocean, in the
     CFC12_flux       ! units of CFC concentrations times meters per second.
-  real, pointer, dimension(:,:,:) :: CFC11, CFC12
+  real, pointer, dimension(:,:,:) :: CFC11 => NULL(), CFC12 => NULL()
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
   integer :: i, j, k, m, is, ie, js, je, nz, idim(4), jdim(4)
 

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -66,8 +66,8 @@ module MOM_generic_tracer
                               ! initialization code if they are not found in the
                               ! restart files.
 
-     type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+     type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
      type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
      !   The following pointer will be directed to the first element of the

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -435,28 +435,29 @@ contains
   !! flux as a source.
   subroutine MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, CS, tv, optics, &
         evap_CFL_limit, minimum_forcing_depth)
-    type(ocean_grid_type),                 intent(in) :: G    !< The ocean's grid structure
-    type(verticalGrid_type),               intent(in) :: GV   !< The ocean's vertical grid structure
-    real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h_old !< Layer thickness before entrainment,
-                                                                !! in m or kg !m-2.
-    real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h_new !< Layer thickness after entrainment,
-                                                                !! in m or kg !m-2.
-    real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: ea    !< an array to which the amount of
-                                              !! fluid entrained from the layer !above during this
-                                              !! call will be added, in m or kg !m-2.
-    real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: eb    !< an array to which the amount of
-                                              !! fluid entrained from the layer !below during this
-                                              !! call will be added, in m or kg !m-2.
-    type(forcing),                         intent(in) :: fluxes
+    type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
+    type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
+    real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                             intent(in) :: h_old !< Layer thickness before entrainment, in m or kg m-2.
+    real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                             intent(in) :: h_new !< Layer thickness after entrainment, in m or kg m-2.
+    real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                             intent(in) :: ea    !< The amount of fluid entrained from the layer
+                                                 !! above during this call, in m or kg m-2.
+    real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                             intent(in) :: eb    !< The amount of fluid entrained from the layer
+                                                 !! below during this call, in m or kg m-2.
+    type(forcing),           intent(in) :: fluxes !< A structure containing pointers to thermodynamic
+                                                 !! and tracer forcing fields.
     real, dimension(SZI_(G),SZJ_(G)),      intent(in) :: Hml  !< Mixed layer depth
-    real,                                  intent(in) :: dt   !< The amount of time covered by this call, in s
-    type(MOM_generic_tracer_CS),           pointer    :: CS   !< Pointer to the control structure for this module.
-    type(thermo_var_ptrs),                 intent(in) :: tv   !< A structure pointing to various thermodynamic variables
-    type(optics_type),                     intent(in) :: optics
-    real,                        optional,intent(in)  :: evap_CFL_limit !< Limits how much water can be fluxed out of
-                                                              !! the top layer Stored previously in diabatic CS.
-    real,                        optional,intent(in)  :: minimum_forcing_depth !< The smallest depth over which fluxes
-                                                              !!  can be applied Stored previously in diabatic CS.
+    real,                    intent(in) :: dt   !< The amount of time covered by this call, in s
+    type(MOM_generic_tracer_CS), pointer :: CS   !< Pointer to the control structure for this module.
+    type(thermo_var_ptrs),   intent(in) :: tv   !< A structure pointing to various thermodynamic variables
+    type(optics_type),       intent(in) :: optics !< The structure containing optical properties.
+    real,          optional, intent(in) :: evap_CFL_limit !< Limits how much water can be fluxed out of
+                                                !! the top layer Stored previously in diabatic CS.
+    real,          optional, intent(in) :: minimum_forcing_depth !< The smallest depth over which fluxes
+                                                !!  can be applied Stored previously in diabatic CS.
     ! The arguments to this subroutine are redundant in that
     !     h_new[k] = h_old[k] + ea[k] - eb[k-1] + eb[k] - ea[k+1]
 
@@ -661,7 +662,7 @@ contains
   function MOM_generic_tracer_min_max(ind_start, got_minmax, gmin, gmax, xgmin, ygmin, zgmin, &
                                       xgmax, ygmax, zgmax , G, CS, names, units)
     use mpp_utilities_mod, only: mpp_array_global_min_max
-    integer,                        intent(in)    :: ind_start
+    integer,                        intent(in)    :: ind_start !< The index of the tracer to start with
     logical, dimension(:),          intent(out)   :: got_minmax !< Indicates whether the global min and
                                                             !! max are found for each tracer
     real, dimension(:),             intent(out)   :: gmin   !< Global minimum of each tracer, in kg
@@ -708,7 +709,6 @@ contains
     allocate(geo_z(nk))
     do k=1,nk ; geo_z(k) = real(k) ; enddo
 
-
     m=ind_start ; g_tracer=>CS%g_tracer_list
     do
       call g_tracer_get_alias(g_tracer,names(m))
@@ -721,13 +721,11 @@ contains
 
       tr_ptr => tr_field(:,:,:,1)
 
-
       call mpp_array_global_min_max(tr_ptr, grid_tmask,isd,jsd,isc,iec,jsc,jec,nk , gmin(m), gmax(m), &
                                     G%geoLonT,G%geoLatT,geo_z,xgmin(m), ygmin(m), zgmin(m), &
                                     xgmax(m), ygmax(m), zgmax(m))
 
       got_minmax(m) = .true.
-
 
       !traverse the linked list till hit NULL
       call g_tracer_get_next(g_tracer, g_tracer_next)
@@ -824,8 +822,9 @@ contains
   end subroutine MOM_generic_flux_init
 
   subroutine MOM_generic_tracer_fluxes_accumulate(flux_tmp, weight)
-    type(forcing),         intent(in)    :: flux_tmp
-    real,                  intent(in)    :: weight
+    type(forcing), intent(in)    :: flux_tmp  !< A structure containing pointers to
+                                              !! thermodynamic and tracer forcing fields.
+    real,          intent(in)    :: weight    !< A weight for accumulating this flux
 
    call generic_tracer_coupler_accumulate(flux_tmp%tr_fluxes, weight)
 
@@ -834,7 +833,7 @@ contains
   !> Copy the requested tracer into an array.
   subroutine MOM_generic_tracer_get(name,member,array, CS)
     character(len=*),         intent(in)  :: name   !< Name of requested tracer.
-    character(len=*),         intent(in)  :: member !< ??
+    character(len=*),         intent(in)  :: member !< The tracer element to return.
     real, dimension(:,:,:),   intent(out) :: array  !< Array filled by this routine.
     type(MOM_generic_tracer_CS), pointer :: CS   !< Pointer to the control structure for this module.
 

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -80,8 +80,8 @@ type, public :: neutral_diffusion_CS ; private
   integer, allocatable, dimension(:,:)     :: ns     ! Number of interfacs in a column
   logical, allocatable, dimension(:,:,:) :: stable_cell  ! True if the cell is stably stratified wrt
                                                          ! to the next cell
-
-  type(diag_ctrl), pointer :: diag ! structure to regulate output
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   integer :: id_uhEff_2d = -1
   integer :: id_vhEff_2d = -1
 

--- a/src/tracer/MOM_offline_aux.F90
+++ b/src/tracer/MOM_offline_aux.F90
@@ -44,12 +44,16 @@ contains
 !> This updates thickness based on the convergence of horizontal mass fluxes
 !! NOTE: Only used in non-ALE mode
 subroutine update_h_horizontal_flux(G, GV, uhtr, vhtr, h_pre, h_new)
-  type(ocean_grid_type),    pointer                           :: G
-  type(verticalGrid_type),  pointer                           :: GV
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)       :: uhtr
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)       :: vhtr
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) , intent(in)       :: h_pre
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) , intent(inout)    :: h_new
+  type(ocean_grid_type),   pointer       :: G     !< ocean grid structure
+  type(verticalGrid_type), pointer       :: GV    !< ocean vertical grid structure
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: uhtr  !< Accumulated mass flux through zonal face, in kg
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                           intent(in)    :: vhtr  !< Accumulated mass flux through meridional face, in kg
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h_pre !< Previous layer thicknesses, in kg m-2.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(inout) :: h_new !< Updated layer thicknesses, in kg m-2.
 
   ! Local variables
   integer :: i, j, k, m, is, ie, js, je, nz
@@ -78,12 +82,19 @@ end subroutine update_h_horizontal_flux
 !> Updates layer thicknesses due to vertical mass transports
 !! NOTE: Only used in non-ALE configuration
 subroutine update_h_vertical_flux(G, GV, ea, eb, h_pre, h_new)
-  type(ocean_grid_type),    pointer                           :: G
-  type(verticalGrid_type),  pointer                           :: GV
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) , intent(in)       :: ea
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) , intent(in)       :: eb
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) , intent(in)       :: h_pre
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) , intent(inout)    :: h_new
+  type(ocean_grid_type),   pointer       :: G     !< ocean grid structure
+  type(verticalGrid_type), pointer       :: GV    !< ocean vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: ea    !< Mass of fluid entrained from the layer
+                                                  !! above within this timestep, in kg m-2
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: eb    !< Mass of fluid entrained from the layer
+                                                  !! below within this timestep, in kg m-2
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h_pre !< Layer thicknesses at the end of the previous
+                                                  !! step, in kg m-2.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(inout) :: h_new !< Updated layer thicknesses, in kg m-2.
 
   ! Local variables
   integer :: i, j, k, m, is, ie, js, je, nz
@@ -124,13 +135,21 @@ end subroutine update_h_vertical_flux
 !> This routine limits the mass fluxes so that the a layer cannot be completely depleted.
 !! NOTE: Only used in non-ALE mode
 subroutine limit_mass_flux_3d(G, GV, uh, vh, ea, eb, h_pre)
-  type(ocean_grid_type),    pointer                           :: G
-  type(verticalGrid_type),  pointer                           :: GV
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout)    :: uh
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout)    :: vh
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) , intent(inout)    :: ea
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) , intent(inout)    :: eb
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) , intent(in)       :: h_pre
+  type(ocean_grid_type),   pointer       :: G     !< ocean grid structure
+  type(verticalGrid_type), pointer       :: GV    !< ocean vertical grid structure
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                           intent(inout) :: uh    !< Mass flux through zonal face, in kg
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                           intent(inout) :: vh    !< Mass flux through meridional face, in kg
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(inout) :: ea    !< Mass of fluid entrained from the layer
+                                                  !! above within this timestep, in kg m-2
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(inout) :: eb    !< Mass of fluid entrained from the layer
+                                                  !! below within this timestep, in kg m-2
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h_pre !< Layer thicknesses at the end of the previous
+                                                  !! step, in kg m-2.
 
   ! Local variables
   integer :: i, j, k, m, is, ie, js, je, nz
@@ -219,10 +238,13 @@ end subroutine limit_mass_flux_3d
 !> In the case where offline advection has failed to converge, redistribute the u-flux
 !! into remainder of the water column as a barotropic equivalent
 subroutine distribute_residual_uh_barotropic(G, GV, hvol, uh)
-  type(ocean_grid_type),    pointer                           :: G
-  type(verticalGrid_type),  pointer                           :: GV
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in   )    :: hvol
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout)    :: uh
+  type(ocean_grid_type),   pointer       :: G    !< ocean grid structure
+  type(verticalGrid_type), pointer       :: GV   !< ocean vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
+                           intent(in   ) :: hvol !< Mass of water in the cells at the end
+                                                 !! of the previous timestep, in kg
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                           intent(inout) :: uh   !< Zonal mass transport within a timestep, in kg
 
   real, dimension(SZIB_(G),SZK_(G))   :: uh2d
   real, dimension(SZIB_(G))           :: uh2d_sum
@@ -287,10 +309,13 @@ end subroutine distribute_residual_uh_barotropic
 
 !> Redistribute the v-flux as a barotropic equivalent
 subroutine distribute_residual_vh_barotropic(G, GV, hvol, vh)
-  type(ocean_grid_type),    pointer                           :: G
-  type(verticalGrid_type),  pointer                           :: GV
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in   )    :: hvol
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout)    :: vh
+  type(ocean_grid_type),   pointer       :: G    !< ocean grid structure
+  type(verticalGrid_type), pointer       :: GV   !< ocean vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
+                           intent(in   ) :: hvol !< Mass of water in the cells at the end
+                                                 !! of the previous timestep, in kg
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                           intent(inout) :: vh   !< Meridional mass transport within a timestep, in kg
 
   real, dimension(SZJB_(G),SZK_(G))   :: vh2d
   real, dimension(SZJB_(G))           :: vh2d_sum
@@ -357,10 +382,13 @@ end subroutine distribute_residual_vh_barotropic
 !> In the case where offline advection has failed to converge, redistribute the u-flux
 !! into layers above
 subroutine distribute_residual_uh_upwards(G, GV, hvol, uh)
-  type(ocean_grid_type),    pointer                           :: G
-  type(verticalGrid_type),  pointer                           :: GV
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in   )    :: hvol
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout)    :: uh
+  type(ocean_grid_type),   pointer       :: G     !< ocean grid structure
+  type(verticalGrid_type), pointer       :: GV    !< ocean vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
+                           intent(in   ) :: hvol  !< Mass of water in the cells at the end
+                                                  !! of the previous timestep, in kg
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                           intent(inout) :: uh    !< Zonal mass transport within a timestep, in kg
 
   real, dimension(SZIB_(G),SZK_(G))   :: uh2d
   real, dimension(SZI_(G),SZK_(G))    :: h2d
@@ -450,10 +478,13 @@ end subroutine distribute_residual_uh_upwards
 !> In the case where offline advection has failed to converge, redistribute the u-flux
 !! into layers above
 subroutine distribute_residual_vh_upwards(G, GV, hvol, vh)
-  type(ocean_grid_type),    pointer                          :: G
-  type(verticalGrid_type),  pointer                          :: GV
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in   )   :: hvol
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout)   :: vh
+  type(ocean_grid_type),   pointer       :: G     !< ocean grid structure
+  type(verticalGrid_type), pointer       :: GV    !< ocean vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
+                           intent(in   ) :: hvol  !< Mass of water in the cells at the end
+                                                  !! of the previous timestep, in kg
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                           intent(inout) :: vh    !< Meridional mass transport within a timestep, in kg
 
   real, dimension(SZJB_(G),SZK_(G))   :: vh2d
   real, dimension(SZJB_(G))           :: vh2d_sum
@@ -544,10 +575,10 @@ end subroutine distribute_residual_vh_upwards
 !> add_diurnal_SW adjusts the shortwave fluxes in an forcying_type variable
 !! to add a synthetic diurnal cycle. Adapted from SIS2
 subroutine offline_add_diurnal_SW(fluxes, G, Time_start, Time_end)
-  type(forcing),                 intent(inout) :: fluxes !< The type with atmospheric fluxes to be adjusted.
-  type(ocean_grid_type),         intent(in)    :: G   !< The sea-ice lateral grid type.
-  type(time_type),               intent(in)    :: Time_start !< The start time for this step.
-  type(time_type),               intent(in)    :: Time_end   !< The ending time for this step.
+  type(forcing),         intent(inout) :: fluxes !< The type with atmospheric fluxes to be adjusted.
+  type(ocean_grid_type), intent(in)    :: G      !< The ocean lateral grid type.
+  type(time_type),       intent(in)    :: Time_start !< The start time for this step.
+  type(time_type),       intent(in)    :: Time_end   !< The ending time for this step.
 
   real :: diurnal_factor, time_since_ae, rad
   real :: fracday_dt, fracday_day
@@ -606,9 +637,9 @@ subroutine update_offline_from_files(G, GV, nk_input, mean_file, sum_file, snap_
   character(len=*),        intent(in   ) :: snap_file !< Name of file with snapshot fields
   character(len=*),        intent(in   ) :: surf_file !< Name of file with surface fields
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
-                           intent(inout) :: uhtr      !< Zonal mass fluxes
+                           intent(inout) :: uhtr      !< Zonal mass fluxes in kg
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                           intent(inout) :: vhtr      !< Meridional mass fluxes
+                           intent(inout) :: vhtr      !< Meridional mass fluxes in kg
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
                            intent(inout) :: h_end     !< End of timestep layer thickness
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
@@ -739,12 +770,12 @@ subroutine update_offline_from_arrays(G, GV, nk_input, ridx_sum, mean_file, sum_
   character(len=200),                        intent(in   ) :: mean_file !< Name of file with averages fields
   character(len=200),                        intent(in   ) :: sum_file  !< Name of file with summed fields
   character(len=200),                        intent(in   ) :: snap_file !< Name of file with snapshot fields
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uhtr      !< Zonal mass fluxes
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: vhtr      !< Meridional mass fluxes
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: hend      !< End of timestep layer thickness
-  real, dimension(:,:,:,:), allocatable,     intent(inout) :: uhtr_all  !< Zonal mass fluxes
-  real, dimension(:,:,:,:), allocatable,     intent(inout) :: vhtr_all  !< Meridional mass fluxes
-  real, dimension(:,:,:,:), allocatable,     intent(inout) :: hend_all  !< End of timestep layer thickness
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uhtr      !< Zonal mass fluxes in kg
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: vhtr      !< Meridional mass fluxes in kg
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: hend      !< End of timestep layer thickness in kg m-2
+  real, dimension(:,:,:,:), allocatable,     intent(inout) :: uhtr_all  !< Zonal mass fluxes in kg
+  real, dimension(:,:,:,:), allocatable,     intent(inout) :: vhtr_all  !< Meridional mass fluxes in kg
+  real, dimension(:,:,:,:), allocatable,     intent(inout) :: hend_all  !< End of timestep layer thickness in kg m-2
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: temp      !< Temperature array
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: salt      !< Salinity array
   real, dimension(:,:,:,:), allocatable,     intent(inout) :: temp_all  !< Temperature array

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -39,26 +39,24 @@ public tracer_Z_init
 
 contains
 
+!>   This function initializes a tracer by reading a Z-space file, returning
+!! .true. if this appears to have been successful, and false otherwise.
 function tracer_Z_init(tr, h, filename, tr_name, G, missing_val, land_val)
-  logical :: tracer_Z_init
-  type(ocean_grid_type),                 intent(in)    :: G    !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out)   :: tr
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  character(len=*),                      intent(in)    :: filename, tr_name
-! type(param_file_type),                 intent(in)    :: param_file !< A structure to parse for run-time parameters
-  real,                        optional, intent(in)    :: missing_val
-  real,                        optional, intent(in)    :: land_val
-!   This function initializes a tracer by reading a Z-space file, returning
-! .true. if this appears to have been successful, and false otherwise.
-! Arguments: tr - The tracer to initialize.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      filename - The name of the file to read from.
-!  (in)      tr_name - The name of the tracer in the file.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in,opt)  missing_val - The missing value for the tracer.
-!  (in,opt)  land_val - The value to use to fill in land points.
+  logical :: tracer_Z_init !< A return code indicating if the initialization has been successful
+  type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                         intent(out)   :: tr   !< The tracer to initialize
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                         intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  character(len=*),      intent(in)    :: filename !< The name of the file to read from
+  character(len=*),      intent(in)    :: tr_name !< The name of the tracer in the file
+! type(param_file_type), intent(in)    :: param_file !< A structure to parse for run-time parameters
+  real,        optional, intent(in)    :: missing_val !< The missing value for the tracer
+  real,        optional, intent(in)    :: land_val !< A value to use to fill in land points
+
+  !   This function initializes a tracer by reading a Z-space file, returning true if this
+  ! appears to have been successful, and false otherwise.
+!
   integer, save :: init_calls = 0
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -288,28 +286,23 @@ function tracer_Z_init(tr, h, filename, tr_name, G, missing_val, land_val)
 
 end function tracer_Z_init
 
-
+!> This subroutine reads the vertical coordinate data for a field from a NetCDF file.
+!! It also might read the missing value attribute for that same field.
 subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
                         use_missing, missing)
-  character(len=*),                intent(in)    :: filename, tr_name
-  real, allocatable, dimension(:), intent(out)   :: z_edges
-  integer,                         intent(out)   :: nz_out
-  logical,                         intent(out)   :: has_edges
-  logical,                         intent(inout) :: use_missing
-  real,                            intent(inout) :: missing
-!   This subroutine reads the vertical coordinate data for a field from a
-! NetCDF file.  It also might read the missing value attribute for that
-! same field.
-! Arguments: filename - The file to be read from.
-!  (in)      tr_name - The name of the tracer to be read.
-!  (out)     z_edges - The depths of the vertical edges of the tracer array.
-!  (out)     nz_out - The number of vertical layers in the tracer array.
-!  (out)     has_edges - If true, the values in z_edges are the edges of the
-!                        tracer cells, otherwise they are the cell centers.
-!  (inout)   use_missing - If false on input, see whether the tracer has a
-!                          missing value, and if so return true.
-!  (inout)   missing - The missing value, if one has been found.
+  character(len=*), intent(in)    :: filename !< The name of the file to read from.
+  character(len=*), intent(in)    :: tr_name !< The name of the tracer in the file.
+  real, dimension(:), allocatable, &
+                    intent(out)   :: z_edges !< The depths of the vertical edges of the tracer array
+  integer,          intent(out)   :: nz_out  !< The number of vertical layers in the tracer array
+  logical,          intent(out)   :: has_edges !< If true the values in z_edges are the edges of the
+                                             !! tracer cells, otherwise they are the cell centers
+  logical,          intent(inout) :: use_missing !< If false on input, see whether the tracer has a
+                                             !! missing value, and if so return true
+  real,             intent(inout) :: missing !< The missing value, if one has been found
 
+  !   This subroutine reads the vertical coordinate data for a field from a
+  ! NetCDF file.  It also might read the missing value attribute for that same field.
   character(len=32) :: mdl
   character(len=120) :: dim_name, edge_name, tr_msg, dim_msg
   logical :: monotonic

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -341,21 +341,14 @@ subroutine tracer_flow_control_init(restart, day, G, GV, h, param_file, diag, OB
 
 end subroutine tracer_flow_control_init
 
-! #@# This subroutine needs a doxygen description
+!> This subroutine extracts the chlorophyll concentrations from the model state, if possible
 subroutine get_chl_from_model(Chl_array, G, CS)
-  real, dimension(NIMEM_,NJMEM_,NKMEM_), intent(out) :: Chl_array !< The array into which the
-                                                                  !! model's Chlorophyll-A
-                                                                  !! concentrations in mg m-3 are
-                                                                  !! to be read.
-  type(ocean_grid_type),                 intent(in)  :: G         !< The ocean's grid structure.
-  type(tracer_flow_control_CS),          pointer     :: CS        !< The control structure returned
-                                                                  !! by a previous call to
-                                                                  !! call_tracer_register.
-! Arguments: Chl_array - The array into which the model's Chlorophyll-A
-!                        concentrations in mg m-3 are to be read.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 call_tracer_register.
+  real, dimension(NIMEM_,NJMEM_,NKMEM_), &
+                                intent(out) :: Chl_array !< The array in which to store the model's
+                                                         !! Chlorophyll-A concentrations in mg m-3.
+  type(ocean_grid_type),        intent(in)  :: G         !< The ocean's grid structure.
+  type(tracer_flow_control_CS), pointer     :: CS        !< The control structure returned by a
+                                                         !! previous call to call_tracer_register.
 
 #ifdef _USE_GENERIC_TRACER
   if (CS%use_MOM_generic_tracer) then

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -56,7 +56,8 @@ type, public :: tracer_hor_diff_CS ; private
   logical :: use_neutral_diffusion ! If true, use the neutral_diffusion module from within
                                    ! tracer_hor_diff.
   type(neutral_diffusion_CS), pointer :: neutral_diffusion_CSp => NULL() ! Control structure for neutral diffusion.
-  type(diag_ctrl), pointer :: diag ! structure to regulate timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   logical :: debug                 ! If true, write verbose checksums for debugging purposes.
   logical :: show_call_tree        ! Display the call tree while running. Set by VERBOSITY level.
   logical :: first_call = .true.

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -792,7 +792,7 @@ end subroutine tracer_registry_init
 
 !> This routine closes the tracer registry module.
 subroutine tracer_registry_end(Reg)
-  type(tracer_registry_type), pointer :: Reg
+  type(tracer_registry_type), pointer :: Reg !< The tracer registry that will be deallocated
   if (associated(Reg)) deallocate(Reg)
 end subroutine tracer_registry_end
 

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -68,12 +68,11 @@ public advection_test_tracer_column_physics, advection_test_stock
 integer, parameter :: NTR = 11
 
 type, public :: advection_test_tracer_CS ; private
-  integer :: ntr = NTR                  ! Number of tracers in this module
-  logical :: coupled_tracers = .false.  ! These tracers are not offered to the
-                                        ! coupler.
+  integer :: ntr = NTR                 ! Number of tracers in this module
+  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
   character(len=200) :: tracer_IC_file ! The full path to the IC file, or " "
-                                   ! to initialize internally.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+                                       ! to initialize internally.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
@@ -88,8 +87,8 @@ type, public :: advection_test_tracer_CS ; private
              ! if it is used and the surface tracer concentrations are to be
              ! provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
   type(vardesc) :: tr_desc(NTR)

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -38,9 +38,8 @@ integer, parameter :: NTR_MAX = 1
 
 type, public :: boundary_impulse_tracer_CS ; private
   integer :: ntr=NTR_MAX    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false.  ! These tracers are not offered to the
-                                        ! coupler.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+  logical :: coupled_tracers = .false. ! These tracers are not offered to the  coupler.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
@@ -56,8 +55,8 @@ type, public :: boundary_impulse_tracer_CS ; private
   real :: remaining_source_time ! How much longer (same units as the timestep) to
                                 ! inject the tracer at the surface
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
   type(vardesc) :: tr_desc(NTR_MAX)

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -50,8 +50,8 @@ type, public :: dye_tracer_CS ; private
     ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
                ! surface tracer concentrations are to be provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
   type(vardesc), allocatable :: tr_desc(:)

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -30,11 +30,10 @@ public dyed_obc_tracer_column_physics, dyed_obc_tracer_end
 
 type, public :: dyed_obc_tracer_CS ; private
   integer :: ntr    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false.  ! These tracers are not offered to the
-                                        ! coupler.
+  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
   character(len=200) :: tracer_IC_file ! The full path to the IC file, or " "
-                                   ! to initialize internally.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+                                       ! to initialize internally.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
@@ -43,8 +42,8 @@ type, public :: dyed_obc_tracer_CS ; private
     ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
                ! surface tracer concentrations are to be provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
   type(vardesc), allocatable :: tr_desc(:)

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -71,14 +71,13 @@ integer, parameter :: NTR_MAX = 3
 
 type, public :: ideal_age_tracer_CS ; private
   integer :: ntr    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false.  ! These tracers are not offered to the
-                                        ! coupler.
-  integer :: nkml       ! The number of layers in the mixed layer.  The ideal
-                        ! age tracers are reset in the top nkml layers.
+  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
+  integer :: nkml   ! The number of layers in the mixed layer.  The ideal
+                    ! age tracers are reset in the top nkml layers.
   character(len=200) :: IC_file ! The file in which the age-tracer initial values
                     ! can be found, or an empty string for internal initialization.
   logical :: Z_IC_file ! If true, the IC_file is in Z-space.  The default is false.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
@@ -99,8 +98,8 @@ type, public :: ideal_age_tracer_CS ; private
     ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
                ! surface tracer concentrations are to be provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
   type(vardesc) :: tr_desc(NTR_MAX)

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -72,8 +72,7 @@ integer, parameter :: NTR_MAX = 20
 
 type, public :: oil_tracer_CS ; private
   integer :: ntr    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false.  ! These tracers are not offered to the
-                                        ! coupler.
+  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
   character(len=200) :: IC_file ! The file in which the age-tracer initial values
                     ! can be found, or an empty string for internal initialization.
   logical :: Z_IC_file ! If true, the IC_file is in Z-space.  The default is false.
@@ -84,7 +83,7 @@ type, public :: oil_tracer_CS ; private
                               ! surface value equals young_val, in years.
   real :: oil_end_year        ! The year in which tracers start aging, or at which the
                               ! surface value equals young_val, in years.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
@@ -104,8 +103,8 @@ type, public :: oil_tracer_CS ; private
     ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
                ! surface tracer concentrations are to be provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
   type(vardesc) :: tr_desc(NTR_MAX)

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -68,7 +68,7 @@ public pseudo_salt_tracer_column_physics, pseudo_salt_tracer_surface_state
 public pseudo_salt_stock, pseudo_salt_tracer_end
 
 type, public :: pseudo_salt_tracer_CS ; private
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: ps(:,:,:) => NULL()   ! The array of pseudo-salt tracer used in this
                                          ! subroutine, in psu
@@ -78,8 +78,8 @@ type, public :: pseudo_salt_tracer_CS ; private
 
   integer :: id_psd = -1
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
   type(vardesc) :: tr_desc
@@ -284,12 +284,9 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
   real :: year, h_total, scale, htot, Ih_limit
   integer :: secs, days
   integer :: i, j, k, is, ie, js, je, nz, k_max
-  real, allocatable :: local_tr(:,:,:)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
-  real, dimension(:,:), pointer :: net_salt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-  net_salt=>fluxes%netSalt
 
   if (.not.associated(CS)) return
   if (.not.associated(CS%diff)) return
@@ -301,11 +298,11 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
 
   ! This uses applyTracerBoundaryFluxesInOut, usually in ALE mode
   if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
-    do k=1,nz ;do j=js,je ; do i=is,ie
+    do k=1,nz ; do j=js,je ; do i=is,ie
       h_work(i,j,k) = h_old(i,j,k)
     enddo ; enddo ; enddo
     call applyTracerBoundaryFluxesInOut(G, GV, CS%ps, dt, fluxes, h_work, &
-      evap_CFL_limit, minimum_forcing_depth, out_flux_optional=net_salt)
+      evap_CFL_limit, minimum_forcing_depth, out_flux_optional=fluxes%netSalt)
     call tracer_vertdiff(h_work, ea, eb, dt, CS%ps, G, GV)
   else
     call tracer_vertdiff(h_old, ea, eb, dt, CS%ps, G, GV)

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -63,11 +63,11 @@ public tracer_column_physics, USER_tracer_surface_state, USER_tracer_example_end
 integer, parameter :: NTR = 1
 
 type, public :: USER_tracer_example_CS ; private
-  logical :: coupled_tracers = .false.  ! These tracers are not offered to the
-                                        ! coupler.
+  logical :: coupled_tracers = .false. ! These tracers are not offered to the
+                                       ! coupler.
   character(len=200) :: tracer_IC_file ! The full path to the IC file, or " "
-                                   ! to initialize internally.
-  type(time_type), pointer :: Time ! A pointer to the ocean model's clock.
+                                       ! to initialize internally.
+  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL()
   real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
                                            ! subroutine, in g m-3?
@@ -78,8 +78,8 @@ type, public :: USER_tracer_example_CS ; private
              ! if it is used and the surface tracer concentrations are to be
              ! provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag ! A pointer to a structure of shareable
-                             ! ocean diagnostic fields and control variables.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                                   ! regulate the timing of diagnostic output.
 
   type(vardesc) :: tr_desc(NTR)
 end type USER_tracer_example_CS

--- a/src/user/BFB_initialization.F90
+++ b/src/user/BFB_initialization.F90
@@ -47,10 +47,15 @@ contains
 !! southern edge of the domain. The temperatures are then converted to densities of the top and bottom layers
 !! and linearly interpolated for the intermediate layers.
 subroutine BFB_set_coord(Rlay, g_prime, GV, param_file, eqn_of_state)
-  real, dimension(NKMEM_), intent(out) :: Rlay, g_prime
+  real, dimension(NKMEM_), intent(out) :: Rlay !< Layer potential density.
+  real, dimension(NKMEM_), intent(out) :: g_prime !< The reduced gravity at
+                                                  !! each interface, in m s-2.
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
-  type(EOS_type),          pointer     :: eqn_of_state
+  type(EOS_type),          pointer     :: eqn_of_state !< Integer that selects the
+                                                     !! equation of state.
+
+
   real                                 :: drho_dt, SST_s, T_bot, rho_top, rho_bot
   integer                              :: k, nz
   character(len=40)  :: mdl = "BFB_set_coord" ! This subroutine's name.
@@ -87,12 +92,14 @@ end subroutine BFB_set_coord
 !> This subroutine sets up the sponges for the southern bouundary of the domain. Maximum damping occurs
 !! within 2 degrees lat of the boundary. The damping linearly decreases northward over the next 2 degrees.
 subroutine BFB_initialize_sponges_southonly(G, use_temperature, tv, param_file, CSp, h)
-  type(ocean_grid_type), intent(in)                   :: G    !< The ocean's grid structure
-  logical,               intent(in)                   :: use_temperature
-  type(thermo_var_ptrs), intent(in)                   :: tv   !< A structure pointing to various thermodynamic variables
-  type(param_file_type), intent(in)                   :: param_file !< A structure to parse for run-time parameters
-  type(sponge_CS),       pointer                      :: CSp
-  real, dimension(NIMEM_, NJMEM_, NKMEM_), intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  type(ocean_grid_type), intent(in) :: G    !< The ocean's grid structure
+  logical,               intent(in) :: use_temperature !< If true, temperature and salinity are used as
+                                            !! state variables.
+  type(thermo_var_ptrs), intent(in) :: tv   !< A structure pointing to various thermodynamic variables
+  type(param_file_type), intent(in) :: param_file !< A structure to parse for run-time parameters
+  type(sponge_CS),       pointer    :: CSp  !< A pointer to the sponge control structure
+  real, dimension(NIMEM_, NJMEM_, NKMEM_), &
+                         intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   !call MOM_error(FATAL, &
   ! "BFB_initialization.F90, BFB_initialize_sponges: " // &
   ! "Unmodified user routine called - you must edit the routine to use it")

--- a/src/user/BFB_surface_forcing.F90
+++ b/src/user/BFB_surface_forcing.F90
@@ -23,6 +23,7 @@ use MOM_file_parser, only : get_param, param_file_type, log_version
 use MOM_forcing_type, only : forcing, allocate_forcing_type
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : file_exists, read_data
+use MOM_safe_alloc, only : safe_alloc_ptr
 use MOM_time_manager, only : time_type, operator(+), operator(/), get_time
 use MOM_tracer_flow_control, only : call_tracer_set_forcing
 use MOM_tracer_flow_control, only : tracer_flow_control_CS
@@ -69,13 +70,18 @@ end type BFB_surface_forcing_CS
 contains
 
 subroutine BFB_buoyancy_forcing(state, fluxes, day, dt, G, CS)
-  type(surface),                 intent(inout) :: state
-  type(forcing),                 intent(inout) :: fluxes
-  type(time_type),               intent(in)    :: day
-  real,                          intent(in)    :: dt   !< The amount of time over which
-                                                       !! the fluxes apply, in s
-  type(ocean_grid_type),         intent(in)    :: G    !< The ocean's grid structure
-  type(BFB_surface_forcing_CS),  pointer       :: CS
+  type(surface),                intent(inout) :: state  !< A structure containing fields that
+                                                      !! describe the surface state of the ocean.
+  type(forcing),                intent(inout) :: fluxes !< A structure containing pointers to any
+                                                      !! possible forcing fields. Unused fields
+                                                      !! have NULL ptrs.
+  type(time_type),              intent(in)    :: day  !< Time of the fluxes.
+  real,                         intent(in)    :: dt   !< The amount of time over which
+                                                      !! the fluxes apply, in s
+  type(ocean_grid_type),        intent(in)    :: G    !< The ocean's grid structure
+  type(BFB_surface_forcing_CS), pointer       :: CS   !< A pointer to the control structure
+                                                      !! returned by a previous call to
+                                                      !! BFB_surface_forcing_init.
 
 !    This subroutine specifies the current surface fluxes of buoyancy or
 !  temperature and fresh water.  It may also be modified to add
@@ -123,19 +129,19 @@ subroutine BFB_buoyancy_forcing(state, fluxes, day, dt, G, CS)
   ! Allocate and zero out the forcing arrays, as necessary.  This portion is
   ! usually not changed.
   if (CS%use_temperature) then
-    call alloc_if_needed(fluxes%evap, isd, ied, jsd, jed)
-    call alloc_if_needed(fluxes%lprec, isd, ied, jsd, jed)
-    call alloc_if_needed(fluxes%fprec, isd, ied, jsd, jed)
-    call alloc_if_needed(fluxes%lrunoff, isd, ied, jsd, jed)
-    call alloc_if_needed(fluxes%frunoff, isd, ied, jsd, jed)
-    call alloc_if_needed(fluxes%vprec, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%evap, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%lprec, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%fprec, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%lrunoff, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%frunoff, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%vprec, isd, ied, jsd, jed)
 
-    call alloc_if_needed(fluxes%sw, isd, ied, jsd, jed)
-    call alloc_if_needed(fluxes%lw, isd, ied, jsd, jed)
-    call alloc_if_needed(fluxes%latent, isd, ied, jsd, jed)
-    call alloc_if_needed(fluxes%sens, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%sw, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%lw, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%latent, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%sens, isd, ied, jsd, jed)
   else ! This is the buoyancy only mode.
-    call alloc_if_needed(fluxes%buoy, isd, ied, jsd, jed)
+    call safe_alloc_ptr(fluxes%buoy, isd, ied, jsd, jed)
   endif
 
 
@@ -169,7 +175,7 @@ subroutine BFB_buoyancy_forcing(state, fluxes, day, dt, G, CS)
 
   if (CS%restorebuoy) then
     if (CS%use_temperature) then
-      call alloc_if_needed(fluxes%heat_added, isd, ied, jsd, jed)
+      call safe_alloc_ptr(fluxes%heat_added, isd, ied, jsd, jed)
       !   When modifying the code, comment out this error message.  It is here
       ! so that the original (unmodified) version is not accidentally used.
       call MOM_error(FATAL, "User_buoyancy_surface_forcing: " // &
@@ -219,24 +225,13 @@ subroutine BFB_buoyancy_forcing(state, fluxes, day, dt, G, CS)
 
 end subroutine BFB_buoyancy_forcing
 
-subroutine alloc_if_needed(ptr, isd, ied, jsd, jed)
-  ! If ptr is not associated, this routine allocates it with the given size
-  ! and zeros out its contents.  This is equivalent to safe_alloc_ptr in
-  ! MOM_diag_mediator, but is here so as to be completely transparent.
-  real, pointer :: ptr(:,:)
-  integer :: isd, ied, jsd, jed
-  if (.not.associated(ptr)) then
-    allocate(ptr(isd:ied,jsd:jed))
-    ptr(:,:) = 0.0
-  endif
-end subroutine alloc_if_needed
-
 subroutine BFB_surface_forcing_init(Time, G, param_file, diag, CS)
-  type(time_type),                            intent(in) :: Time
-  type(ocean_grid_type),                      intent(in) :: G    !< The ocean's grid structure
-  type(param_file_type),                      intent(in) :: param_file !< A structure to parse for run-time parameters
-  type(diag_ctrl), target,                    intent(in) :: diag
-  type(BFB_surface_forcing_CS), pointer    :: CS
+  type(time_type),              intent(in) :: Time !< The current model time.
+  type(ocean_grid_type),        intent(in) :: G    !< The ocean's grid structure
+  type(param_file_type),        intent(in) :: param_file !< A structure to parse for run-time parameters
+  type(diag_ctrl), target,      intent(in) :: diag !< A structure that is used to
+                                                   !! regulate diagnostic output.
+  type(BFB_surface_forcing_CS), pointer    :: CS   !< A pointer to the control structure for this module
 ! Arguments: Time - The current model time.
 !  (in)      G - The ocean's grid structure.
 !  (in)      param_file - A structure indicating the open file to parse for

--- a/src/user/BFB_surface_forcing.F90
+++ b/src/user/BFB_surface_forcing.F90
@@ -54,17 +54,17 @@ type, public :: BFB_surface_forcing_CS ; private
                              ! forcing ramp
   real :: SST_n              ! SST at the northern edge of the linear
                              ! forcing ramp
-  real :: lfrslat              ! Southern latitude where the linear forcing ramp
+  real :: lfrslat            ! Southern latitude where the linear forcing ramp
                              ! begins
-  real :: lfrnlat              ! Northern latitude where the linear forcing ramp
+  real :: lfrnlat            ! Northern latitude where the linear forcing ramp
                              ! ends
   real :: drho_dt            ! Rate of change of density with temperature.
                              ! Note that temperature is being used as a dummy
                              ! variable here. All temperatures are converted
                              ! into density.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                             ! regulate the timing of diagnostic output.
 end type BFB_surface_forcing_CS
 
 contains

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -261,8 +261,8 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, param_file, tr_Reg)
   character(len=32)  :: name
   integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, m, nz, NTR
   integer :: IsdB, IedB, JsdB, JedB
-  type(OBC_segment_type), pointer :: segment
-  type(tracer_type), pointer      :: tr_ptr
+  type(OBC_segment_type), pointer :: segment => NULL()
+  type(tracer_type), pointer      :: tr_ptr => NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -171,7 +171,7 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, h, Time)
   integer :: IsdB, IedB, JsdB, JedB
   real    :: fac, x, y, x1, y1
   real    :: val1, val2, sina, cosa
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed

--- a/src/user/MOM_controlled_forcing.F90
+++ b/src/user/MOM_controlled_forcing.F90
@@ -62,9 +62,9 @@ type, public :: ctrl_forcing_CS ; private
     avg_SST_anom => NULL(), &
     avg_SSS_anom => NULL(), &
     avg_SSS => NULL()
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
-  integer :: id_heat_0 = -1 ! See if these are neede later...
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                            ! regulate the timing of diagnostic output.
+  integer :: id_heat_0 = -1 ! See if these are needed later...
 end type ctrl_forcing_CS
 
 contains

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -7,7 +7,7 @@ module MOM_wave_interface
 !*  By Brandon Reichl, 2018.                                           *
 !*                                                                     *
 !*   This module should be moved as wave coupling progresses and       *
-!* likely will should mirror the iceberg or sea-ice model set-up.       *
+!* likely will should mirror the iceberg or sea-ice model set-up.      *
 !*                                                                     *
 !*   This module is meant to contain the routines to read in and       *
 !* interpret surface wave data for MOM6. In its original form, the     *

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -92,8 +92,8 @@ subroutine dyed_channel_set_OBC_tracer_data(OBC, G, GV, param_file, tr_Reg)
   integer :: i, j, k, l, itt, isd, ied, jsd, jed, m, n
   integer :: IsdB, IedB, JsdB, JedB
   real :: dye
-  type(OBC_segment_type), pointer :: segment
-  type(tracer_type), pointer      :: tr_ptr
+  type(OBC_segment_type), pointer :: segment => NULL()
+  type(tracer_type), pointer      :: tr_ptr => NULL()
 
   if (.not.associated(OBC)) call MOM_error(FATAL, 'dyed_channel_initialization.F90: '// &
         'dyed_channel_set_OBC_data() was called but OBC type was not initialized!')
@@ -143,7 +143,7 @@ subroutine dyed_channel_update_flow(OBC, CS, G, Time)
   real :: flow, time_sec, PI
   integer :: i, j, k, l, itt, isd, ied, jsd, jed, m, n
   integer :: IsdB, IedB, JsdB, JedB
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   if (.not.associated(OBC)) call MOM_error(FATAL, 'dyed_channel_initialization.F90: '// &
         'dyed_channel_update_flow() was called but OBC type was not initialized!')

--- a/src/user/dyed_obcs_initialization.F90
+++ b/src/user/dyed_obcs_initialization.F90
@@ -41,8 +41,8 @@ subroutine dyed_obcs_set_OBC_data(OBC, G, GV, param_file, tr_Reg)
   integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, m, n, nz
   integer :: IsdB, IedB, JsdB, JedB
   real :: dye
-  type(OBC_segment_type), pointer :: segment
-  type(tracer_type), pointer      :: tr_ptr
+  type(OBC_segment_type), pointer :: segment => NULL()
+  type(tracer_type), pointer      :: tr_ptr => NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -139,7 +139,7 @@ subroutine shelfwave_set_OBC_data(OBC, CS, G, h, Time)
   character(len=40)  :: mdl = "shelfwave_set_OBC_data" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, n
   integer :: IsdB, IedB, JsdB, JedB
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed

--- a/src/user/supercritical_initialization.F90
+++ b/src/user/supercritical_initialization.F90
@@ -34,7 +34,7 @@ subroutine supercritical_set_OBC_data(OBC, G, param_file)
   real :: zonal_flow
   integer :: i, j, k, l
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
-  type(OBC_segment_type), pointer :: segment ! pointer to segment type list
+  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
 
   if (.not.associated(OBC)) call MOM_error(FATAL, 'supercritical_initialization.F90: '// &
         'supercritical_set_OBC_data() was called but OBC type was not initialized!')

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -75,7 +75,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, h, Time)
   character(len=40)  :: mdl = "tidal_bay_set_OBC_data" ! This subroutine's name.
   integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, nz, n
   integer :: IsdB, IedB, JsdB, JedB
-  type(OBC_segment_type), pointer :: segment
+  type(OBC_segment_type), pointer :: segment => NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed

--- a/src/user/user_change_diffusivity.F90
+++ b/src/user/user_change_diffusivity.F90
@@ -26,8 +26,8 @@ type, public :: user_change_diff_CS ; private
                         ! Kd_add is added, in kg m-3.
   logical :: use_abs_lat  ! If true, use the absolute value of latitude when
                           ! setting lat_range.
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
+                          ! regulate the timing of diagnostic output.
 end type user_change_diff_CS
 
 contains


### PR DESCRIPTION
  This pull request adds dOxyGen comments to almost all of the MOM6 subroutine arguments and many of the subroutines themselves. In addition, many of the non-argument pointers are explicitly initialized to NULL(). After this PR, the only code that has not had its arguments dOxyGenized are midas_vertmap.F90 (which @MJHarrison-GFDL will be handling) and the two copies of coupler_util.F90 in the config_src/*_driver directories, and these files will disappear when we move over to the Xanadu branch of FMS.

  No answers or parameter_doc files are changed with this PR.