### PR TITLE
Cleaned up code to comply with MOM6 standards

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -26,7 +26,7 @@ use MOM_domains,              only : To_North, To_East, To_South, To_West
 use MOM_domains,              only : To_All, Omit_corners, CGRID_NE, SCALAR_PAIR
 use MOM_domains,              only : create_group_pass, do_group_pass, group_pass_type
 use MOM_domains,              only : start_group_pass, complete_group_pass, Omit_Corners
-use MOM_error_handler,        only : MOM_error, FATAL, WARNING, is_root_pe
+use MOM_error_handler,        only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_error_handler,        only : MOM_set_verbosity, callTree_showQuery
 use MOM_error_handler,        only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,          only : read_param, get_param, log_version, param_file_type
@@ -1349,7 +1349,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
     ! If this is the first iteration in the offline timestep, then we need to read in fields and
     ! perform the main advection.
     if (first_iter) then
-      if (is_root_pe()) print *, "Reading in new offline fields"
+      call MOM_mesg("Reading in new offline fields")
       ! Read in new transport and other fields
       ! call update_transport_from_files(G, GV, CS%offline_CSp, h_end, eatr, ebtr, uhtr, vhtr, &
       !     CS%tv%T, CS%tv%S, fluxes, CS%use_ALE_algorithm)
@@ -1403,7 +1403,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
         endif
       endif
 
-      if (is_root_pe()) print *, "Last iteration of offline interval"
+      call MOM_mesg("Last iteration of offline interval")
 
       ! Apply freshwater fluxes out of the ocean
       call offline_fw_fluxes_out_ocean(G, GV, CS%offline_CSp, fluxes, CS%h)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -583,7 +583,8 @@ subroutine initialize_segment_data(G, OBC, PF)
 
     call parse_segment_data_str(trim(segstr), fields=fields, num_fields=num_fields)
     if (num_fields == 0) then
-        print *,'num_fields = 0';cycle ! cycle to next segment
+      call MOM_mesg('initialize_segment_data: num_fields = 0')
+      cycle ! cycle to next segment
     endif
 
     allocate(segment%field(num_fields))
@@ -1216,7 +1217,6 @@ end subroutine parse_segment_str
         call abort()
      endif
 
-     print *,'00001x'
     ! Process first word which will start with the fieldname
      word3 = extract_word(segment_str,',',m)
 !     word1 = extract_word(word3,':',1)
@@ -1226,7 +1226,6 @@ end subroutine parse_segment_str
         method=trim(extract_word(word1,'=',2))
         lword=len_trim(method)
         read(method(1:lword),*,err=987) param_value
-        print *,'00002x'
         ! if (method(lword-3:lword) == 'file') then
         !    ! raise an error id filename/fieldname not in argument list
         !    word1 = extract_word(word3,':',2)

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -131,6 +131,7 @@ subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug
   real, dimension(SZI_(G),SZJ_(G)) :: b,r
   real, dimension(SZI_(G),SZJ_(G)) :: fill_pts,good_,good_new
 
+  character(len=256) :: mesg  ! The text of an error message
   integer :: i,j,k
   real    :: east,west,north,south,sor
   real    :: ge,gw,gn,gs,ngood
@@ -219,11 +220,12 @@ subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug
            enddo
         enddo
      elseif (nfill == nfill_prev) then
-        print *,&
+        call MOM_error(WARNING, &
              'Unable to fill missing points using either data at the same vertical level from a connected basin'//&
              'or using a point from a previous vertical level.  Make sure that the original data has some valid'//&
-             'data in all basins.'
-        print *,'nfill=',nfill
+             'data in all basins.', .true.)
+        write(mesg,*) 'nfill=',nfill
+        call MOM_error(WARNING, mesg, .true.)
      endif
 
      nfill = sum(fill_pts(is:ie,js:je))
@@ -258,7 +260,8 @@ subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug
   do j=js,je
      do i=is,ie
         if (good_(i,j) == 0.0 .and. fill_pts(i,j) == 1.0) then
-           print *,'in fill_miss, fill, good,i,j= ',fill_pts(i,j),good_(i,j),i,j
+           write(mesg,*) 'In fill_miss, fill, good,i,j= ',fill_pts(i,j),good_(i,j),i,j
+           call MOM_error(WARNING, mesg, .true.)
            call MOM_error(FATAL,"MOM_initialize: "// &
                 "fill is true and good is false after fill_miss, how did this happen? ")
         endif

--- a/src/framework/MOM_write_cputime.F90
+++ b/src/framework/MOM_write_cputime.F90
@@ -15,7 +15,7 @@ module MOM_write_cputime
 !********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_coms, only : sum_across_PEs, pe_here, num_pes
-use MOM_error_handler, only : MOM_error, FATAL, is_root_pe
+use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, is_root_pe
 use MOM_io, only : open_file, APPEND_FILE, ASCII_FILE, WRITEONLY_FILE
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_time_manager, only : time_type, get_time, operator(>)
@@ -134,6 +134,7 @@ subroutine write_cputime(day, n, nmax, CS)
                            ! this subroutine.
   integer :: new_cputime   ! The CPU time returned by SYSTEM_CLOCK
   real    :: reday         ! A real version of day.
+  character(len=256) :: mesg  ! The text of an error message
   integer :: start_of_day, num_days
 
   if (.not.associated(CS)) call MOM_error(FATAL, &
@@ -167,9 +168,8 @@ subroutine write_cputime(day, n, nmax, CS)
       nmax = n + INT( CS%dn_dcpu_min * &
           (0.95*CS%maxcpu * REAL(num_pes())*CLOCKS_PER_SEC - &
            (CS%startup_cputime + CS%cputime2)) )
-!     if (is_root_pe() ) then
-!       write(*,*) "Resetting nmax to ",nmax," at day",reday
-!     endif
+!     write(mesg,*) "Resetting nmax to ",nmax," at day",reday
+!     call MOM_mesg(mesg)
     endif
   endif
   CS%prev_cputime = new_cputime ; CS%prev_n = n

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1694,7 +1694,7 @@ end subroutine hor_visc_end
 !!   - A function of
 !! latitude, \f$\kappa_{\phi}(x,y) = \kappa_{\pi/2} |\sin(\phi)|^n\f$.
 !!   - A dynamic Smagorinsky viscosity, \f$\kappa_{Sm}(x,y,t) = C_{Sm} \Delta^2 \sqrt{\dot{e}_T^2 + \dot{e}_S^2}\f$.
-!!   - A dynamic Leith viscosity, \f$\kappa_{Lth}(x,y,t) = 
+!!   - A dynamic Leith viscosity, \f$\kappa_{Lth}(x,y,t) =
 !!                                    C_{Lth} \Delta^3 \sqrt{|\nabla \zeta|^2 + |\nabla \dot{e}_D|^2}\f$.
 !!
 !! A maximum stable viscosity, \f$\kappa_{max}(x,y)\f$ is calculated based on the

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1694,7 +1694,8 @@ end subroutine hor_visc_end
 !!   - A function of
 !! latitude, \f$\kappa_{\phi}(x,y) = \kappa_{\pi/2} |\sin(\phi)|^n\f$.
 !!   - A dynamic Smagorinsky viscosity, \f$\kappa_{Sm}(x,y,t) = C_{Sm} \Delta^2 \sqrt{\dot{e}_T^2 + \dot{e}_S^2}\f$.
-!!   - A dynamic Leith viscosity, \f$\kappa_{Lth}(x,y,t) = C_{Lth} \Delta^3 \sqrt{|\nabla \zeta|^2 + |\nabla \dot{e}_D|^2}\f$.
+!!   - A dynamic Leith viscosity, \f$\kappa_{Lth}(x,y,t) = 
+!!                                    C_{Lth} \Delta^3 \sqrt{|\nabla \zeta|^2 + |\nabla \dot{e}_D|^2}\f$.
 !!
 !! A maximum stable viscosity, \f$\kappa_{max}(x,y)\f$ is calculated based on the
 !! grid-spacing and time-step and used to clip calculated viscosities.

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -229,7 +229,8 @@ subroutine compute_ddiff_coeffs(h, tv, G, GV, j, Kd_T, Kd_S, CS)
       pRef = pRef + GV%H_to_Pa * h(i,j,k-1)
     enddo ! k-loop finishes
 
-    call calculate_density_derivs(temp_int(:), salt_int(:), pres_int(:), drho_dT(:), drho_dS(:), 1, G%ke, TV%EQN_OF_STATE)
+    call calculate_density_derivs(temp_int(:), salt_int(:), pres_int(:), drho_dT(:), drho_dS(:), 1, &
+                                  G%ke, TV%EQN_OF_STATE)
 
     ! The "-1.0" below is needed so that the following criteria is satisfied:
     ! if ((alpha_dT > beta_dS) .and. (beta_dS > 0.0)) then "salt finger"

--- a/src/parameterizations/vertical/MOM_KPP.F90
+++ b/src/parameterizations/vertical/MOM_KPP.F90
@@ -868,7 +868,8 @@ subroutine KPP_calculate(CS, G, GV, h, Temp, Salt, u, v, EOS, uStar, &
       if (CS%SW_METHOD == SW_METHOD_ALL_SW) then
          surfBuoyFlux = buoyFlux(i,j,1)
       elseif (CS%SW_METHOD == SW_METHOD_MXL_SW) then
-         surfBuoyFlux  = buoyFlux(i,j,1) - buoyFlux(i,j,int(CS%kOBL(i,j))+1) ! We know the actual buoyancy flux into the OBL
+         ! We know the actual buoyancy flux into the OBL
+         surfBuoyFlux  = buoyFlux(i,j,1) - buoyFlux(i,j,int(CS%kOBL(i,j))+1)
       elseif (CS%SW_METHOD == SW_METHOD_LV1_SW) then
          surfBuoyFlux  = buoyFlux(i,j,1) - buoyFlux(i,j,2)
       endif
@@ -1503,8 +1504,10 @@ subroutine KPP_smooth_BLD(CS,G,GV,h)
 
   ! local
   real, dimension(SZI_(G),SZJ_(G)) :: OBLdepth_original ! Original OBL depths computed by CVMix
-  real, dimension( G%ke )          :: cellHeight        ! Cell center heights referenced to surface (m) (negative in ocean)
-  real, dimension( G%ke+1 )        :: iFaceHeight       ! Interface heights referenced to surface (m) (negative in ocean)
+  real, dimension( G%ke )          :: cellHeight        ! Cell center heights referenced to surface (m)
+                                                        ! (negative in the ocean)
+  real, dimension( G%ke+1 )        :: iFaceHeight       ! Interface heights referenced to surface (m)
+                                                        ! (negative in the ocean)
   real :: wc, ww, we, wn, ws ! averaging weights for smoothing
   real :: dh                 ! The local thickness used for calculating interface positions (m)
   real :: hcorr              ! A cumulative correction arising from inflation of vanished layers (m)

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -10,8 +10,7 @@ use MOM_diag_mediator,   only : post_data
 use MOM_EOS,             only : calculate_density, calculate_density_derivs
 use MOM_variables,       only : thermo_var_ptrs
 use MOM_forcing_type,    only : forcing
-use MOM_error_handler,   only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
-use MOM_error_handler,   only : is_root_pe
+use MOM_error_handler,   only : MOM_error, FATAL, WARNING, NOTE
 use MOM_file_parser,     only : openParameterBlock, closeParameterBlock
 use MOM_debugging,       only : hchksum
 use MOM_grid,            only : ocean_grid_type
@@ -349,10 +348,9 @@ subroutine calculate_bkgnd_mixing(h, tv, N2_lay, kd_lay, kv, j, G, GV, CS)
       do k=2,nz+1
         depth_2d(i,k) = depth_2d(i,k-1) + GV%H_to_m*h(i,j,k-1)
       enddo
-      ! if (is_root_pe()) write(*,*)'depth_3d(i,j,:)',depth_3d(i,j,:)
 
       call CVMix_init_bkgnd(max_nlev=nz, &
-                            zw = depth_2d(i,:), &  !< interface depth, must bepositive.
+                            zw = depth_2d(i,:), &  !< interface depth, must be positive.
                             bl1 = CS%Bryan_Lewis_c1, &
                             bl2 = CS%Bryan_Lewis_c2, &
                             bl3 = CS%Bryan_Lewis_c3, &

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -937,8 +937,10 @@ end subroutine entrainment_diffusive
 subroutine F_to_ent(F, h, kb, kmb, j, G, GV, CS, dsp1_ds, eakb, Ent_bl, ea, eb, do_i_in)
   type(ocean_grid_type),            intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),          intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: F    !< The density flux through a layer within a time step divided by the
-            ! density difference across the interface below the layer, in H.
+  real, dimension(SZI_(G),SZK_(G)), intent(in)    :: F    !< The density flux through a layer within
+                                                          !! a time step divided by the density
+                                                          !! difference across the interface below
+                                                          !! the layer, in H.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                                     intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   integer, dimension(SZI_(G)),      intent(in)    :: kb   !< The index of the lightest layer denser than

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -684,14 +684,17 @@ end subroutine
 !> Calls the CVMix routines to compute tidal dissipation and to add the effect of internal-tide-driven
 !! mixing to the interface diffusivities.
 subroutine calculate_CVMix_tidal(h, j, G, GV, CS, N2_int, Kd)
-  integer,                                  intent(in)    :: j     !< The j-index to work on
-  type(ocean_grid_type),                    intent(in)    :: G     !< Grid structure.
-  type(verticalGrid_type),                  intent(in)    :: GV    !< ocean vertical grid structure
-  type(tidal_mixing_cs),                    pointer       :: CS    !< This module's control structure.
-  real, dimension(SZI_(G),SZK_(G)+1),       intent(in)    :: N2_int !< The squared buoyancy frequency at the
+  integer,                 intent(in)    :: j     !< The j-index to work on
+  type(ocean_grid_type),   intent(in)    :: G     !< Grid structure.
+  type(verticalGrid_type), intent(in)    :: GV    !< ocean vertical grid structure
+  type(tidal_mixing_cs),   pointer       :: CS    !< This module's control structure.
+  real, dimension(SZI_(G),SZK_(G)+1), &
+                           intent(in)    :: N2_int !< The squared buoyancy frequency at the
                                                                    !! interfaces, in s-2.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h     !< Layer thicknesses, in H (usually m or kg m-2).
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: Kd    !< The diapycnal diffusivities in the layers, in m2 s-1
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h     !< Layer thicknesses, in H (usually m or kg m-2).
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(inout) :: Kd    !< The diapycnal diffusivities in the layers, in m2 s-1
 
   ! local
   real, dimension(SZK_(G)+1) :: Kd_tidal    !< tidal diffusivity [m2/s]
@@ -700,7 +703,8 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, CS, N2_int, Kd)
   real, dimension(SZK_(G)+1) :: iFaceHeight !< Height of interfaces (m)
   real, dimension(SZK_(G)+1) :: SchmittnerSocn
   real, dimension(SZK_(G))   :: cellHeight  !< Height of cell centers (m)
-  real, dimension(SZK_(G))   :: tidal_qe_md !< Tidal dissipation energy interpolated from 3d input to model coordinates
+  real, dimension(SZK_(G))   :: tidal_qe_md !< Tidal dissipation energy interpolated from 3d input
+                                            !! to model coordinates
   real, dimension(SZK_(G))   :: Schmittner_coeff
   real, dimension(SZK_(G))   :: h_m         !< Cell thickness [m]
   real, allocatable, dimension(:,:) :: exp_hab_zetar
@@ -962,6 +966,7 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS,
   real :: TKE_lowmode_tot ! TKE from all low modes (W/m2) (BDM)
 
   logical :: use_Polzin, use_Simmons
+  character(len=160) :: mesg  ! The text of an error message
   integer :: i, k, is, ie, nz
   integer :: a, fr, m
   type(tidal_mixing_diags), pointer :: dd => NULL()
@@ -1112,8 +1117,8 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS,
 
       ! TODO: uncomment the following call and fix it
       !call get_lowmode_loss(i,j,G,CS%int_tide_CSp,"WaveDrag",TKE_lowmode_tot)
-      print *, "========", __FILE__, __LINE__
-      call MOM_error(FATAL,"this block not supported yet. (aa)")
+      write (mesg,*) "========", __FILE__, __LINE__
+      call MOM_error(FATAL,trim(mesg)//": this block not supported yet. (aa)")
 
       TKE_lowmode_bot(i) = CS%Mu_itides * I_rho0 * TKE_lowmode_tot
     endif
@@ -1571,7 +1576,7 @@ subroutine read_tidal_constituents(G, tidal_energy_file, CS)
   !do j=G%jsd,G%jed
   !  do i=isd,ied
   !    if ( i+G%idg_offset .eq. 90 .and. j+G%jdg_offset .eq. 126) then
-  !      print *, "-------------------------------------------"
+  !      write(1905,*) "-------------------------------------------"
   !      do k=50,nz_in(1)
   !          write(1905,*) i,j,k
   !          write(1905,*) CS%tidal_qe_3d_in(i,j,k), tc_m2(i,j,k)

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -313,6 +313,7 @@ subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, G
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
   real :: melt(SZI_(G),SZJ_(G))  ! melt water (positive for melting
                                  ! negative for freezing)
+  character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
@@ -323,15 +324,15 @@ subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, G
   ! max. melt
   mmax = MAXVAL(melt(is:ie,js:je))
   call max_across_PEs(mmax)
-  !write(*,*)'max melt', mmax
+  ! write(mesg,*) 'max melt = ', mmax
+  ! call MOM_mesg(mesg, 5)
   ! dye melt water (m=1), dye = 1 if melt=max(melt)
   do m=1,NTR
-     do j=js,je ; do i=is,ie
+    do j=js,je ; do i=is,ie
       if (melt(i,j) > 0.0) then ! melting
-         !write(*,*)'i,j,melt,melt/mmax',i,j,melt(i,j),melt(i,j)/mmax
-         CS%tr(i,j,1:2,m) = melt(i,j)/mmax ! inject dye in the ML
+        CS%tr(i,j,1:2,m) = melt(i,j)/mmax ! inject dye in the ML
       else ! freezing
-         CS%tr(i,j,1:2,m) = 0.0
+        CS%tr(i,j,1:2,m) = 0.0
       endif
     enddo ; enddo
   enddo
@@ -339,10 +340,10 @@ subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, G
   if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
     do m=1,NTR
       do k=1,nz ;do j=js,je ; do i=is,ie
-          h_work(i,j,k) = h_old(i,j,k)
+        h_work(i,j,k) = h_old(i,j,k)
       enddo ; enddo ; enddo
       call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m) , dt, fluxes, h_work, &
-          evap_CFL_limit, minimum_forcing_depth)
+               evap_CFL_limit, minimum_forcing_depth)
       call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
     enddo
   else

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -562,13 +562,13 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
             ishift=0 ! ishift+I corresponds to the nearest interior tracer cell index
             idir=1   ! idir switches the sign of the flow so that positive is into the reservoir
             if (segment%direction == OBC_DIRECTION_W) then
-                ishift=1
-                idir=-1
+              ishift=1
+              idir=-1
             endif
             ! update the reservoir tracer concentration implicitly
             ! using Backward-Euler timestep
             do m=1,ntr
-             if (associated(segment%tr_Reg%Tr(m)%tres)) then
+              if (associated(segment%tr_Reg%Tr(m)%tres)) then
                 uhh(I)=uhr(I,j,k)
                 u_L_in=max(idir*uhh(I)*segment%Tr_InvLscale3_in,0.)
                 u_L_out=min(idir*uhh(I)*segment%Tr_InvLscale3_out,0.)
@@ -576,21 +576,18 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
                 segment%tr_Reg%Tr(m)%tres(I,j,k)= (1.0/fac1)*(segment%tr_Reg%Tr(m)%tres(I,j,k) + &
                      dt*(u_L_in*Tr(m)%t(I+ishift,j,k) - &
                      u_L_out*segment%tr_Reg%Tr(m)%t(I,j,k)))
-!                if (j == 10 .and. segment%direction==OBC_DIRECTION_E .and. m==2 .and. k == 1) &
-!                  print *,'tres=',segment%tr_Reg%Tr(m)%tres(I,j,k),&
-!                segment%tr_Reg%Tr(m)%t(I,j,k), fac1
               endif
             enddo
 
             ! Tracer fluxes are set to prescribed values only for inflows from masked areas.
             if ((uhr(I,j,k) > 0.0) .and. (G%mask2dT(i,j) < 0.5) .or. &
                (uhr(I,j,k) < 0.0) .and. (G%mask2dT(i+1,j) < 0.5)) then
-                uhh(I) = uhr(I,j,k)
-                do m=1,ntr
-                  if (associated(segment%tr_Reg%Tr(m)%tres)) then
-                    flux_x(I,m) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
-                  else; flux_x(I,m) = uhh(I)*segment%tr_Reg%Tr(m)%OBC_inflow_conc; endif
-                enddo
+              uhh(I) = uhr(I,j,k)
+              do m=1,ntr
+                if (associated(segment%tr_Reg%Tr(m)%tres)) then
+                  flux_x(I,m) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
+                else; flux_x(I,m) = uhh(I)*segment%tr_Reg%Tr(m)%OBC_inflow_conc; endif
+              enddo
             endif
           endif
         enddo

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -4,7 +4,7 @@ module DOME_initialization
 
 use MOM_sponge, only : sponge_CS, set_up_sponge_field, initialize_sponge
 use MOM_dyn_horgrid, only : dyn_horgrid_type
-use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
+use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
@@ -280,7 +280,7 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, param_file, tr_Reg)
   tr_0 = (-D_edge*sqrt(D_edge*g_prime_tot)*0.5e3*Def_Rad) * GV%m_to_H
 
   if (OBC%number_of_segments /= 1) then
-    print *, 'Error in DOME OBC segment setup'
+    call MOM_error(WARNING, 'Error in DOME OBC segment setup', .true.)
     return   !!! Need a better error message here
   endif
   segment => OBC%segment(1)

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -157,6 +157,7 @@ subroutine ISOMIP_initialize_thickness ( h, G, GV, param_file, tv, just_read_par
   real    :: delta_h, rho_range
   real    :: min_thickness, s_sur, s_bot, t_sur, t_bot, rho_sur, rho_bot
   logical :: just_read    ! If true, just read parameters but set nothing.
+  character(len=256) :: mesg  ! The text of an error message
   character(len=40) :: verticalCoordinate
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -187,11 +188,14 @@ subroutine ISOMIP_initialize_thickness ( h, G, GV, param_file, tv, just_read_par
 
     ! Compute min/max density using T_SUR/S_SUR and T_BOT/S_BOT
     call calculate_density(t_sur,s_sur,0.0,rho_sur,tv%eqn_of_state)
-    !write (*,*)'Surface density is:', rho_sur
+    ! write(mesg,*) 'Surface density is:', rho_sur
+    ! call MOM_mesg(mesg,5)
     call calculate_density(t_bot,s_bot,0.0,rho_bot,tv%eqn_of_state)
-    !write (*,*)'Bottom density is:', rho_bot
+    ! write(mesg,*) 'Bottom density is:', rho_bot
+    ! call MOM_mesg(mesg,5)
     rho_range = rho_bot - rho_sur
-    !write (*,*)'Density range is:', rho_range
+    ! write(mesg,*) 'Density range is:', rho_range
+    ! call MOM_mesg(mesg,5)
 
     ! Construct notional interface positions
     e0(1) = 0.
@@ -199,8 +203,8 @@ subroutine ISOMIP_initialize_thickness ( h, G, GV, param_file, tv, just_read_par
       e0(k) = -G%max_depth * ( 0.5 * ( GV%Rlay(k-1) + GV%Rlay(k) ) - rho_sur ) / rho_range
       e0(k) = min( 0., e0(k) ) ! Bound by surface
       e0(k) = max( -G%max_depth, e0(k) ) ! Bound by possible deepest point in model
-      !write(*,*)'G%max_depth,GV%Rlay(k-1),GV%Rlay(k),e0(k)',G%max_depth,GV%Rlay(k-1),GV%Rlay(k),e0(k)
-
+      ! write(mesg,*) 'G%max_depth,GV%Rlay(k-1),GV%Rlay(k),e0(k)',G%max_depth,GV%Rlay(k-1),GV%Rlay(k),e0(k)
+      ! call MOM_mesg(mesg,5)
     enddo
     e0(nz+1) = -G%max_depth
 
@@ -266,6 +270,7 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
   real      :: x, ds, dt, rho_sur, rho_bot
   real      :: xi0, xi1, dxi, r, S_sur, T_sur, S_bot, T_bot, S_range, T_range
   real      :: z          ! vertical position in z space
+  character(len=256) :: mesg  ! The text of an error message
   character(len=40) :: verticalCoordinate, density_profile
   real :: rho_tmp
   logical :: just_read    ! If true, just read parameters but set nothing.
@@ -293,9 +298,11 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
                  'Salinity at the bottom (interface)', default=34.55, do_not_log=just_read)
 
   call calculate_density(t_sur,s_sur,0.0,rho_sur,eqn_of_state)
-  !write (*,*)'Density in the surface layer:', rho_sur
+  ! write(mesg,*) 'Density in the surface layer:', rho_sur
+  ! call MOM_mesg(mesg,5)
   call calculate_density(t_bot,s_bot,0.0,rho_bot,eqn_of_state)
-  !write (*,*)'Density in the bottom layer::', rho_bot
+  ! write(mesg,*) 'Density in the bottom layer::', rho_bot
+  ! call MOM_mesg(mesg,5)
 
   select case ( coordinateMode(verticalCoordinate) )
 
@@ -304,7 +311,8 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
 
       S_range = s_sur - s_bot
       T_range = t_sur - t_bot
-      !write(*,*)'S_range,T_range',S_range,T_range
+      ! write(mesg,*) 'S_range,T_range',S_range,T_range
+      ! call MOM_mesg(mesg,5)
 
       S_range = S_range / G%max_depth ! Convert S_range into dS/dz
       T_range = T_range / G%max_depth ! Convert T_range into dT/dz
@@ -337,11 +345,13 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
                  default=35.0, do_not_log=just_read)
      if (just_read) return ! All run-time parameters have been read, so return.
 
-     !write(*,*)'read drho_dS, drho_dT', drho_dS1, drho_dT1
+     ! write(mesg,*) 'read drho_dS, drho_dT', drho_dS1, drho_dT1
+     ! call MOM_mesg(mesg,5)
 
      S_range = s_bot - s_sur
      T_range = t_bot - t_sur
-     !write(*,*)'S_range,T_range',S_range,T_range
+     ! write(mesg,*) 'S_range,T_range',S_range,T_range
+     ! call MOM_mesg(mesg,5)
      S_range = S_range / G%max_depth ! Convert S_range into dS/dz
      T_range = T_range / G%max_depth ! Convert T_range into dT/dz
 
@@ -353,11 +363,13 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
           S0(k) = S_sur +  S_range * xi1
           T0(k) = T_sur +  T_range * xi1
           xi0 = xi0 + h(i,j,k) * GV%H_to_m
-          !write(*,*)'S,T,xi0,xi1,k',S0(k),T0(k),xi0,xi1,k
+          ! write(mesg,*) 'S,T,xi0,xi1,k',S0(k),T0(k),xi0,xi1,k
+          ! call MOM_mesg(mesg,5)
        enddo
 
        call calculate_density_derivs(T0,S0,pres,drho_dT,drho_dS,1,1,eqn_of_state)
-       !write(*,*)'computed drho_dS, drho_dT', drho_dS(1), drho_dT(1)
+       ! write(mesg,*) 'computed drho_dS, drho_dT', drho_dS(1), drho_dT(1)
+       ! call MOM_mesg(mesg,5)
        call calculate_density(T0(1),S0(1),0.,rho_guess(1),eqn_of_state)
 
        if (fit_salin) then
@@ -404,8 +416,9 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
   ! for debugging
   !i=G%iec; j=G%jec
   !do k = 1,nz
-  !   call calculate_density(T(i,j,k),S(i,j,k),0.0,rho_tmp,eqn_of_state)
-  !   write(*,*) 'k,h,T,S,rho,Rlay',k,h(i,j,k),T(i,j,k),S(i,j,k),rho_tmp,GV%Rlay(k)
+  !  call calculate_density(T(i,j,k),S(i,j,k),0.0,rho_tmp,eqn_of_state)
+  !  write(mesg,*) 'k,h,T,S,rho,Rlay',k,h(i,j,k),T(i,j,k),S(i,j,k),rho_tmp,GV%Rlay(k)
+  ! call MOM_mesg(mesg,5)
   !enddo
 
 end subroutine ISOMIP_initialize_temperature_salinity
@@ -517,10 +530,13 @@ subroutine ISOMIP_initialize_sponges(G, GV, tv, PF, use_ALE, CSp, ACSp)
   ! Compute min/max density using T_SUR/S_SUR and T_BOT/S_BOT
   call calculate_density(t_sur,s_sur,0.0,rho_sur,tv%eqn_of_state)
   !write (*,*)'Surface density in sponge:', rho_sur
+  ! call MOM_mesg(mesg,5)
   call calculate_density(t_bot,s_bot,0.0,rho_bot,tv%eqn_of_state)
   !write (*,*)'Bottom density in sponge:', rho_bot
+  ! call MOM_mesg(mesg,5)
   rho_range = rho_bot - rho_sur
   !write (*,*)'Density range in sponge:', rho_range
+  ! call MOM_mesg(mesg,5)
 
   if (use_ALE) then
 
@@ -533,8 +549,8 @@ subroutine ISOMIP_initialize_sponges(G, GV, tv, PF, use_ALE, CSp, ACSp)
          e0(k) = -G%max_depth * ( 0.5 * ( GV%Rlay(k-1) + GV%Rlay(k) ) - rho_sur ) / rho_range
          e0(k) = min( 0., e0(k) ) ! Bound by surface
          e0(k) = max( -G%max_depth, e0(k) ) ! Bound by possible deepest point in model
-         !write(*,*)'G%max_depth,GV%Rlay(k-1),GV%Rlay(k),e0(k)',G%max_depth,GV%Rlay(k-1),GV%Rlay(k),e0(k)
-
+         ! write(mesg,*) 'G%max_depth,GV%Rlay(k-1),GV%Rlay(k),e0(k)',G%max_depth,GV%Rlay(k-1),GV%Rlay(k),e0(k)
+         ! call MOM_mesg(mesg,5)
        enddo
        e0(nz+1) = -G%max_depth
 
@@ -596,7 +612,8 @@ subroutine ISOMIP_initialize_sponges(G, GV, tv, PF, use_ALE, CSp, ACSp)
     !i=G%iec; j=G%jec
     !do k = 1,nz
     !  call calculate_density(T(i,j,k),S(i,j,k),0.0,rho_tmp,tv%eqn_of_state)
-    !  write(*,*) 'Sponge - k,h,T,S,rho,Rlay',k,h(i,j,k),T(i,j,k),S(i,j,k),rho_tmp,GV%Rlay(k)
+    !  write(mesg,*) 'Sponge - k,h,T,S,rho,Rlay',k,h(i,j,k),T(i,j,k),S(i,j,k),rho_tmp,GV%Rlay(k)
+    !  call MOM_mesg(mesg,5)
     !enddo
 
     !   Now register all of the fields which are damped in the sponge.   !
@@ -644,9 +661,10 @@ subroutine ISOMIP_initialize_sponges(G, GV, tv, PF, use_ALE, CSp, ACSp)
        ! for debugging
        !i=G%iec; j=G%jec
        !do k = 1,nz
-       !    call calculate_density(T(i,j,k),S(i,j,k),0.0,rho_tmp,tv%eqn_of_state)
-       !    write(*,*) 'Sponge - k,eta,T,S,rho,Rlay',k,eta(i,j,k),T(i,j,k),&
-       !                S(i,j,k),rho_tmp,GV%Rlay(k)
+       !  call calculate_density(T(i,j,k),S(i,j,k),0.0,rho_tmp,tv%eqn_of_state)
+       !  write(mesg,*) 'Sponge - k,eta,T,S,rho,Rlay',k,eta(i,j,k),T(i,j,k),&
+       !              S(i,j,k),rho_tmp,GV%Rlay(k)
+       !  call MOM_mesg(mesg,5)
        !enddo
 
        ! Set the inverse damping rates so that the model will know where to

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -329,25 +329,20 @@ subroutine dumbbell_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp
     ! start with initial condition
     S(:,:,:) = 0.0
 
-    do j=G%jsc,G%jec
-      do i=G%isc,G%iec
-
+    do j=G%jsc,G%jec ; do i=G%isc,G%iec
       ! Compute normalized zonal coordinates (x,y=0 at center of domain)
-         x = ( G%geoLonT(i,j) ) / dblen
-         if (x>=0.25 ) then
-           do k=1,nz
-             S(i,j,k)=S_ref + 0.5*S_range
-           enddo
-         endif
-         if (x<=-0.25 ) then
-           do k=1,nz
-             S(i,j,k)=S_ref - 0.5*S_range
-           enddo
-         endif
-!         if (j == G%jsc) print *,'i,Sponge S= ',i,S(i,1,1)
-       enddo
-
-     enddo
+       x = ( G%geoLonT(i,j) ) / dblen
+       if (x>=0.25 ) then
+         do k=1,nz
+           S(i,j,k)=S_ref + 0.5*S_range
+         enddo
+       endif
+       if (x<=-0.25 ) then
+         do k=1,nz
+           S(i,j,k)=S_ref - 0.5*S_range
+         enddo
+       endif
+     enddo ; enddo
   endif
 
   if (associated(tv%S)) call set_up_ALE_sponge_field(S, G, tv%S, ACSp)


### PR DESCRIPTION
  This PR includes two commits that bring the MOM6 code closer to the MOM6
software standards, without changing answers or parameter_doc files:
- NOAA-GFDL/MOM6@637fee0 Replaced "print *," statements with MOM_mesg
- NOAA-GFDL/MOM6@1b70a40 Shortened excessively long lines
- NOAA-GFDL/MOM6@0bc5be7 Removed trailing white space.
