### PR TITLE
(*)Fixes implementation of minimum viscosity

### DIFF
--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -566,6 +566,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
         if (rescale_Kh) Kh = VarMix%Res_fn_h(i,j) * Kh
         ! Older method of bounding for stability
         if (legacy_bound) Kh = min(Kh, CS%Kh_Max_xx(i,j))
+        Kh = max( Kh ,CS%Kh_bg_min ) ! Place a floor on the viscosity, if desired.
         if (use_MEKE_Ku) Kh = Kh + MEKE%Ku(i,j) ! *Add* the MEKE contribution (might be negative)
 
         ! Newer method of bounding for stability
@@ -716,11 +717,11 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, CS, 
         if (legacy_bound) Kh = min(Kh, CS%Kh_Max_xy(i,j))
         ! All viscosity contributions above are subject to resolution scaling
         if (rescale_Kh) Kh = VarMix%Res_fn_q(i,j) * Kh
+        Kh = max( Kh ,CS%Kh_bg_min ) ! Place a floor on the viscosity, if desired.
         if (use_MEKE_Ku) then ! *Add* the MEKE contribution (might be negative)
           Kh = Kh + 0.25*( (MEKE%Ku(I,J)+MEKE%Ku(I+1,J+1))    &
                           +(MEKE%Ku(I+1,J)+MEKE%Ku(I,J+1)) )
         endif
-        Kh = max(Kh,CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
 
         ! Newer method of bounding for stability
         if (CS%better_bound_Kh) then


### PR DESCRIPTION
This fixes a bug that:
- meant the minimum viscosity was not doing anything in the tension component;
- was breaking the backscatter parameterization.

While this does not change any of our active tests this will change answers for experiments using KH_BG_MIN or the backscatter scheme.