### PR TITLE
Add vertex shear mixing

### DIFF
--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -224,15 +224,18 @@ type, public :: vertvisc_type
                         ! Kd_extra_S is positive for salt fingering; Kd_extra_T
                         ! is positive for double diffusive convection.  These
                         ! are only allocated if DOUBLE_DIFFUSION is true.
-    Kd_shear => NULL(), &!< The shear-driven turbulent diapycnal diffusivity
-                         !! at the interfaces between each layer, in m2 s-1.
-    Kv_shear => NULL(), &!< The shear-driven turbulent vertical viscosity
-                         !! at the interfaces between each layer, in m2 s-1.
+    Kd_shear => NULL(), &!< The shear-driven turbulent diapycnal diffusivity at the
+                         !! interfaces between layers in tracer columns, in m2 s-1.
+    Kv_shear => NULL(), &!< The shear-driven turbulent vertical viscosity at the
+                         !! interfaces between layers in tracer columns, in m2 s-1.
+    Kv_shear_Bu => NULL(), &!< The shear-driven turbulent vertical viscosity at the
+                         !! interfaces between layers in corner columns, in m2 s-1.
     Kv_slow  => NULL(), &!< The turbulent vertical viscosity component due to
                          !! "slow" processes (e.g., tidal, background,
                          !! convection etc).
-    TKE_turb => NULL()  !< The turbulent kinetic energy per unit mass defined
-                        !! at the interfaces between each layer, in m2 s-2.
+    TKE_turb => NULL()  !< The turbulent kinetic energy per unit mass at the
+                        !! interfaces, in m2 s-2.  This may be at the tracer or
+                        !! corner points
     logical :: add_Kv_slow !< If True, adds Kv_slow when calculating the
                         !! 'coupling coefficient' (a[k]) at the interfaces.
                         !! This is done in find_coupling_coef.

--- a/src/parameterizations/vertical/MOM_full_convection.F90
+++ b/src/parameterizations/vertical/MOM_full_convection.F90
@@ -1,0 +1,424 @@
+!> Does full convective adjustment of unstable regions via a strong diffusivity.
+module MOM_full_convection
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_grid, only : ocean_grid_type
+use MOM_variables, only : thermo_var_ptrs
+use MOM_verticalGrid, only : verticalGrid_type
+use MOM_EOS, only : int_specific_vol_dp, calculate_density_derivs
+
+implicit none ; private
+
+#include <MOM_memory.h>
+
+public full_convection
+
+contains
+
+!> Calculate new temperatures and salinities that have been subject to full convective mixing.
+subroutine full_convection(G, GV, h, tv, T_adj, S_adj, p_surf, Kddt_smooth, &
+                           Kddt_convect, halo)
+  type(ocean_grid_type),   intent(in)    :: G     !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)    :: GV    !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h     !< Layer thicknesses, in H (usually m or kg m-2)
+  type(thermo_var_ptrs),   intent(in)    :: tv    !< A structure pointing to various
+                                                  !! thermodynamic variables
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(out)   :: T_adj !< Adjusted potential temperature in degC.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(out)   :: S_adj !< Adjusted salinity in ppt.
+  real, dimension(:,:),    pointer       :: p_surf !< The pressure at the ocean surface in Pa (or NULL).
+  real,                    intent(in)    :: Kddt_smooth  !< A smoothing vertical
+                                                  !! diffusivity times a timestep, in H2.
+  real,          optional, intent(in)    :: Kddt_convect !< A large convecting vertical
+                                                  !! diffusivity times a timestep, in H2.
+  integer,       optional, intent(in)    :: halo  !< Halo width over which to compute
+
+  ! Local variables
+  real, dimension(SZI_(G),SZK_(G)+1) :: &
+    drho_dT, &  ! The derivatives of density with temperature and
+    drho_dS     ! salinity, in kg m-3 K-1 and kg m-3 psu-1.
+  real :: h_neglect, h0 ! A thickness that is so small it is usually lost
+                        ! in roundoff and can be neglected, in H.
+! logical :: use_EOS    ! If true, density is calculated from T & S using an equation of state.
+  real, dimension(SZI_(G),SZK0_(G)) :: &
+    Te_a, & ! A partially updated temperature estimate including the influnce from
+            ! mixing with layers above rescaled by a factor of d_a, in degC.
+            ! This array is discreted on tracer cells, but contains an extra
+            ! layer at the top for algorithmic convenience.
+    Se_a    ! A partially updated salinity estimate including the influnce from
+            ! mixing with layers above rescaled by a factor of d_a, in ppt.
+            ! This array is discreted on tracer cells, but contains an extra
+            ! layer at the top for algorithmic convenience.
+  real, dimension(SZI_(G),SZK_(G)+1) :: &
+    Te_b, & ! A partially updated temperature estimate including the influnce from
+            ! mixing with layers below rescaled by a factor of d_b, in degC.
+            ! This array is discreted on tracer cells, but contains an extra
+            ! layer at the bottom for algorithmic convenience.
+    Se_b    ! A partially updated salinity estimate including the influnce from
+            ! mixing with layers below rescaled by a factor of d_b, in ppt.
+            ! This array is discreted on tracer cells, but contains an extra
+            ! layer at the bottom for algorithmic convenience.
+  real, dimension(SZI_(G),SZK_(G)+1) :: &
+    c_a, &  ! The fractional influence of the properties of the layer below
+            ! in the final properies with a downward-first solver, nondim.
+    d_a, &  ! The fractional influence of the properties of the layer in question
+            ! and layers above in the final properies with a downward-first solver, nondim.
+            ! d_a = 1.0 - c_a
+    c_b, &  ! The fractional influence of the properties of the layer above
+            ! in the final properies with a upward-first solver, nondim.
+    d_b     ! The fractional influence of the properties of the layer in question
+            ! and layers below in the final properies with a upward-first solver, nondim.
+            ! d_b = 1.0 - c_b
+  real, dimension(SZI_(G),SZK_(G)+1) :: &
+    mix     !< The amount of mixing across the interface between layers, in H.
+  real :: mix_len  ! The length-scale of mixing, when it is active, in H
+  real :: h_b, h_a ! The thicknessses of the layers above and below in interface, in H
+  real :: b_b, b_a ! Inverse pivots used by the tridiagonal solver, in H-1.
+
+  real :: kap_dt_x2 ! The product of 2*kappa*dt in H2 (often m2 or kg2 m-4).
+
+  logical, dimension(SZI_(G)) :: do_i ! Do more work on this column.
+  logical, dimension(SZI_(G)) :: last_down ! The last setup pass was downward.
+  integer, dimension(SZI_(G)) :: change_ct ! The number of interfaces where the
+                         ! mixing has changed this iteration.
+  integer :: changed_col ! The number of colums whose mixing changed.
+  integer :: i, j, k, is, ie, js, je, nz, itt
+
+  if (present(halo)) then
+    is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
+  else
+    is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  endif
+  nz = G%ke
+
+  if (.not.associated(tv%eqn_of_state)) return
+
+  h_neglect = GV%H_subroundoff
+  kap_dt_x2 = 0.0
+  if (present(Kddt_convect)) kap_dt_x2 = 2.0*Kddt_convect
+  mix_len = (1.0e20 * nz) * (GV%max_depth * GV%m_to_H)
+  h0 = 1.0e-16*sqrt(Kddt_smooth) + h_neglect
+
+  do j=js,je
+    mix(:,:) = 0.0 ; d_b(:,:) = 1.0
+    ! These would be Te_b(:,:) = tv%T(:,j,:), etc., but the values are not used
+    Te_b(:,:) = 0.0 ; Se_b(:,:) = 0.0
+
+    call smoothed_dRdT_dRdS(h, tv, Kddt_smooth, drho_dT, drho_dS, G, GV, j, p_surf, halo)
+
+    do i=is,ie
+      do_i(i) = (G%mask2dT(i,j) > 0.0)
+
+      d_a(i,1) = 1.0
+      last_down(i) = .true. ! This is set for debuggers.
+      ! These are extra values are used for convenience in the stability test
+      Te_a(i,0) = 0.0 ; Se_a(i,0) = 0.0
+    enddo
+
+    do itt=1,nz ! At least 2 interfaces will change with each full pass, or the
+                ! iterations stop, so the maximum count of nz is very conservative.
+
+      do i=is,ie ; change_ct(i) = 0 ; enddo
+      ! Move down the water column, finding unstable interfaces, and building up the
+      ! temporary arrays for the tridiagonal solver.
+      do K=2,nz ; do i=is,ie ; if (do_i(i)) then
+
+        h_a = h(i,j,k-1) + h_neglect ; h_b = h(i,j,k) + h_neglect
+        if (mix(i,K) <= 0.0) then
+          if (is_unstable(dRho_dT(i,K), dRho_dS(i,K), h_a, h_b, mix(i,K-1), mix(i,K+1), &
+                          tv%T(i,j,k-1), tv%T(i,j,k), tv%S(i,j,k-1), tv%S(i,j,k), &
+                          Te_a(i,k-2), Te_b(i,k+1), Se_a(i,k-2), Se_b(i,k+1), &
+                          d_a(i,K-1), d_b(i,K+1))) then
+            mix(i,K) = mix_len
+            if (kap_dt_x2 > 0.0) mix(i,K) = kap_dt_x2 / ((h(i,j,k-1)+h(i,j,k)) + h0)
+            change_ct(i) = change_ct(i) + 1
+          endif
+        endif
+
+        b_a = 1.0 / ((h_a + d_a(i,K-1)*mix(i,K-1)) + mix(i,K))
+        if (mix(i,K) <= 0.0) then
+          c_a(i,K) = 0.0 ; d_a(i,K) = 1.0
+        else
+          d_a(i,K) = b_a * (h_a + d_a(i,K-1)*mix(i,K-1)) ! = 1.0-c_a(i,K)
+          c_a(i,K) = 1.0 ; if (d_a(i,K) > epsilon(b_a)) c_a(i,K) = b_a * mix(i,K)
+        endif
+
+        if (K>2) then
+          Te_a(i,k-1) = b_a * (h_a*tv%T(i,j,k-1) + mix(i,K-1)*Te_a(i,k-2))
+          Se_a(i,k-1) = b_a * (h_a*tv%S(i,j,k-1) + mix(i,K-1)*Se_a(i,k-2))
+        else
+          Te_a(i,k-1) = b_a * (h_a*tv%T(i,j,k-1))
+          Se_a(i,k-1) = b_a * (h_a*tv%S(i,j,k-1))
+        endif
+      endif ; enddo ; enddo
+
+      ! Determine which columns might have further instabilities.
+      changed_col = 0
+      do i=is,ie ; if (do_i(i)) then
+        if (change_ct(i) == 0) then
+          last_down(i) = .true. ; do_i(i) = .false.
+        else
+          changed_col = changed_col + 1 ; change_ct(i) = 0
+        endif
+      endif ; enddo
+      if (changed_col == 0) exit ! No more columns are unstable.
+
+      ! This is the same as above, but with the direction reversed (bottom to top)
+      do K=nz,2,-1 ; do i=is,ie ; if (do_i(i)) then
+
+        h_a = h(i,j,k-1) + h_neglect ; h_b = h(i,j,k) + h_neglect
+        if (mix(i,K) <= 0.0) then
+          if (is_unstable(dRho_dT(i,K), dRho_dS(i,K), h_a, h_b, mix(i,K-1), mix(i,K+1), &
+                          tv%T(i,j,k-1), tv%T(i,j,k), tv%S(i,j,k-1), tv%S(i,j,k), &
+                          Te_a(i,k-2), Te_b(i,k+1), Se_a(i,k-2), Se_b(i,k+1), &
+                          d_a(i,K-1), d_b(i,K+1))) then
+            mix(i,K) = mix_len
+            if (kap_dt_x2 > 0.0) mix(i,K) = kap_dt_x2 / ((h(i,j,k-1)+h(i,j,k)) + h0)
+            change_ct(i) = change_ct(i) + 1
+          endif
+        endif
+
+        b_b = 1.0 / ((h_b + d_b(i,K+1)*mix(i,K+1)) + mix(i,K))
+        if (mix(i,K) <= 0.0) then
+          c_b(i,K) = 0.0 ; d_b(i,K) = 1.0
+        else
+          d_b(i,K) = b_b * (h_b + d_b(i,K+1)*mix(i,K+1)) ! = 1.0-c_b(i,K)
+          c_b(i,K) = 1.0 ; if (d_b(i,K) > epsilon(b_b)) c_b(i,K) = b_b * mix(i,K)
+        endif
+
+        if (k<nz) then
+          Te_b(i,k) = b_b * (h_b*tv%T(i,j,k) + mix(i,K+1)*Te_b(i,k+1))
+          Se_b(i,k) = b_b * (h_b*tv%S(i,j,k) + mix(i,K+1)*Se_b(i,k+1))
+        else
+          Te_b(i,k) = b_b * (h_b*tv%T(i,j,k))
+          Se_b(i,k) = b_b * (h_b*tv%S(i,j,k))
+        endif
+      endif ; enddo ; enddo
+
+      ! Determine which columns might have further instabilities.
+      changed_col = 0
+      do i=is,ie ; if (do_i(i)) then
+        if (change_ct(i) == 0) then
+          last_down(i) = .false. ; do_i(i) = .false.
+        else
+          changed_col = changed_col + 1 ; change_ct(i) = 0
+        endif
+      endif ; enddo
+      if (changed_col == 0) exit ! No more columns are unstable.
+
+    enddo  ! End of iterations, all columns are now stable.
+
+    ! Do the final return pass on the columns where the penultimate pass was downward.
+    do i=is,ie ; do_i(i) = ((G%mask2dT(i,j) > 0.0) .and. last_down(i)) ; enddo
+    do i=is,ie ; if (do_i(i)) then
+      h_a = h(i,j,nz) + h_neglect
+      b_a = 1.0 / (h_a + d_a(i,nz)*mix(i,nz))
+      T_adj(i,j,nz) = b_a * (h_a*tv%T(i,j,nz) + mix(i,nz)*Te_a(i,nz-1))
+      S_adj(i,j,nz) = b_a * (h_a*tv%S(i,j,nz) + mix(i,nz)*Se_a(i,nz-1))
+    endif ; enddo
+    do k=nz-1,1,-1 ; do i=is,ie ; if (do_i(i)) then
+      T_adj(i,j,k) = Te_a(i,k) + c_a(i,K+1)*T_adj(i,j,k+1)
+      S_adj(i,j,k) = Se_a(i,k) + c_a(i,K+1)*S_adj(i,j,k+1)
+    endif ; enddo ; enddo
+
+    do i=is,ie ; if (do_i(i)) then
+      k = 1 ! A hook for debugging.
+    endif ; enddo
+
+    ! Do the final return pass on the columns where the penultimate pass was upward.
+    ! Also do a simple copy of T & S values on land points.
+    do i=is,ie
+      do_i(i) = ((G%mask2dT(i,j) > 0.0) .and. .not.last_down(i))
+      if (do_i(i)) then
+        h_b = h(i,j,1) + h_neglect
+        b_b = 1.0 / (h_b + d_b(i,2)*mix(i,2))
+        T_adj(i,j,1) = b_b * (h_b*tv%T(i,j,1) + mix(i,2)*Te_b(i,2))
+        S_adj(i,j,1) = b_b * (h_b*tv%S(i,j,1) + mix(i,2)*Se_b(i,2))
+      elseif (G%mask2dT(i,j) <= 0.0) then
+        T_adj(i,j,1) = tv%T(i,j,1) ; S_adj(i,j,1) = tv%S(i,j,1)
+      endif
+    enddo
+    do k=2,nz ; do i=is,ie
+      if (do_i(i)) then
+        T_adj(i,j,k) = Te_b(i,k) + c_b(i,K)*T_adj(i,j,k-1)
+        S_adj(i,j,k) = Se_b(i,k) + c_b(i,K)*S_adj(i,j,k-1)
+      elseif (G%mask2dT(i,j) <= 0.0) then
+        T_adj(i,j,k) = tv%T(i,j,k) ; S_adj(i,j,k) = tv%S(i,j,k)
+      endif
+    enddo ; enddo
+
+    do i=is,ie ; if (do_i(i)) then
+      k = 1 ! A hook for debugging.
+    endif ; enddo
+
+  enddo ! j-loop
+
+  k = 1 ! A hook for debugging.
+
+  ! The following set of expressions for the final values are derived from the the partial
+  ! updates for the estimated temperatures and salinities around an interface, then directly
+  ! solving for the final temperatures and salinities.  They are here for later reference
+  ! and to document an intermediate step in the stability calculation.
+    ! hp_a = (h_a + d_a(i,K-1)*mix(i,K-1))
+    ! hp_b = (h_b + d_b(i,K+1)*mix(i,K+1))
+    ! b2_c = 1.0 / (hp_a*hp_b + (hp_a + hp_b) * mix(i,K))
+    ! Th_a = h_a*tv%T(i,j,k-1) + mix(i,K-1)*Te_a(i,k-2)
+    ! Th_b = h_b*tv%T(i,j,k)   + mix(i,K+1)*Te_b(i,k+1)
+    ! T_fin(i,k)   = ( (hp_a + mix(i,K)) * Th_b  + Th_a * mix(i,K) ) * b2_c
+    ! T_fin(i,k-1) = ( (hp_b + mix(i,K)) * Th_a  + Th_b * mix(i,K) ) * b2_c
+    ! Sh_a = h_a*tv%S(i,j,k-1) + mix(i,K-1)*Se_a(i,k-2)
+    ! Sh_b = h_b*tv%S(i,j,k)   + mix(i,K+1)*Se_b(i,k+1)
+    ! S_fin(i,k)   = ( (hp_a + mix(i,K)) * Sh_b  + Sh_a * mix(i,K) ) * b2_c
+    ! S_fin(i,k-1) = ( (hp_b + mix(i,K)) * Sh_a  + Sh_b * mix(i,K) ) * b2_c
+
+end subroutine full_convection
+
+!> This function returns True if the profiles around the given interface will be
+!! statically unstable after mixing above below.  The arguments are the ocean state
+!! above and below, including partial calculations from a tridiagonal solver.
+function is_unstable(dRho_dT, dRho_dS, h_a, h_b, mix_A, mix_B, T_a, T_b, S_a, S_b, &
+                     Te_aa, Te_bb, Se_aa, Se_bb, d_A, d_B)
+  real, intent(in) :: dRho_dT !< The derivative of in situ density with temperature in kg m-3 degC-1
+  real, intent(in) :: dRho_dS !< The derivative of in situ density with salinity in kg m-3 ppt-1
+  real, intent(in) :: h_a     !< The thickness of the layer above, in H
+  real, intent(in) :: h_b     !< The thickness of the layer below, in H
+  real, intent(in) :: mix_A   !< The time integrated mixing rate of the interface above, in H
+  real, intent(in) :: mix_B   !< The time integrated mixing rate of the interface below, in H
+  real, intent(in) :: T_a     !< The initial temperature of the layer above, in degC
+  real, intent(in) :: T_b     !< The initial temperature of the layer below, in degC
+  real, intent(in) :: S_a     !< The initial salinity of the layer below, in ppt
+  real, intent(in) :: S_b     !< The initial salinity of the layer below, in ppt
+  real, intent(in) :: Te_aa   !< The estimated temperature two layers above rescaled by d_A, in degC
+  real, intent(in) :: Te_bb   !< The estimated temperature two layers below rescaled by d_B, in degC
+  real, intent(in) :: Se_aa   !< The estimated salinity two layers above rescaled by d_A, in ppt
+  real, intent(in) :: Se_bb   !< The estimated salinity two layers below rescaled by d_B, in ppt
+  real, intent(in) :: d_A     !< The rescaling dependency across the interface above, nondim.
+  real, intent(in) :: d_B     !< The rescaling dependency across the interface below, nondim.
+  logical :: is_unstable !< The return value, true if the profile is statically unstable
+                         !! around the interface in question.
+
+  ! These expressions for the local stability are long, but they have been carefully
+  ! grouped for accuracy even when the mixing rates are huge or tiny, and common
+  ! positive definite factors that would appear in the final expression for the
+  ! locally referenced potential density difference across an interface have been omitted.
+  is_unstable = (dRho_dT * ((h_a * h_b * (T_b - T_a) + &
+                             mix_A*mix_B * (d_A*Te_bb - d_B*Te_aa)) + &
+                            (h_a*mix_B * (Te_bb - d_B*T_a) + &
+                             h_b*mix_A * (d_A*T_b - Te_aa)) ) + &
+                 dRho_dS * ((h_a * h_b * (S_b - S_a) + &
+                             mix_A*mix_B * (d_A*Se_bb - d_B*Se_aa)) + &
+                            (h_a*mix_B * (Se_bb - d_B*S_a) + &
+                             h_b*mix_A * (d_A*S_b - Se_aa)) ) < 0.0)
+end function is_unstable
+
+!> Returns the partial derivatives of locally referenced potential density with
+!! temperature and salinity after the properties have been smoothed with a small
+!! constant diffusivity.
+subroutine smoothed_dRdT_dRdS(h, tv, Kddt, dR_dT, dR_dS, G, GV, j, p_surf, halo)
+  type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)  :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  type(thermo_var_ptrs),   intent(in)  :: tv   !< A structure pointing to various
+                                               !! thermodynamic variables
+  real,                    intent(in)  :: Kddt !< A diffusivity times a time increment, in H2.
+  real, dimension(SZI_(G),SZK_(G)+1), &
+                           intent(out) :: dR_dT !< Derivative of locally referenced
+                                               !! potential density with temperature, kg m-3 K-1
+  real, dimension(SZI_(G),SZK_(G)+1), &
+                           intent(out) :: dR_dS !< Derivative of locally referenced
+                                               !! potential density with salinity, kg m-3 ppt-1
+  integer,                 intent(in)  :: j    !< The j-point to work on.
+  real, dimension(:,:),    pointer     :: p_surf !< The pressure at the ocean surface in Pa (or NULL).
+  integer,       optional, intent(in)  :: halo !< Halo width over which to compute
+  ! Local variables
+  real :: mix(SZI_(G),SZK_(G)+1)   ! The diffusive mixing length (kappa*dt)/dz
+                                   ! between layers within in a timestep in H.
+  real :: b1(SZI_(G)), d1(SZI_(G)) ! b1, c1, and d1 are variables used by the
+  real :: c1(SZI_(G),SZK_(G))      ! tridiagonal solver.
+  real :: T_f(SZI_(G),SZK_(G))     ! Filtered temperatures in degC
+  real :: S_f(SZI_(G),SZK_(G))     ! Filtered salinities in ppt
+  real :: pres(SZI_(G))            ! Interface pressures, in Pa.
+  real :: T_EOS(SZI_(G))           ! Filtered and vertically averaged temperatures in degC
+  real :: S_EOS(SZI_(G))           ! Filtered and vertically averaged salinities in ppt
+  real :: kap_dt_x2                ! The product of 2*kappa*dt in H2 (often m2 or kg2 m-4).
+  real :: h_neglect, h0            ! Negligible thicknesses, in H (m or kg m-2), to
+                                   ! allow for zero thicknesses.
+  real :: h_tr                     ! The thickness at tracer points, plus h_neglect, in H.
+  integer :: i, k, is, ie, nz
+
+  if (present(halo)) then
+    is = G%isc-halo ; ie = G%iec+halo
+  else
+    is = G%isc ; ie = G%iec
+  endif
+  nz = G%ke
+
+  h_neglect = GV%H_subroundoff
+  kap_dt_x2 = 2.0*Kddt
+
+  if (Kddt <= 0.0) then
+    do k=1,nz ; do i=is,ie
+      T_f(i,k) = tv%T(i,j,k) ; S_f(i,k) = tv%S(i,j,k)
+    enddo ; enddo
+  else
+    h0 = 1.0e-16*sqrt(Kddt) + h_neglect
+    do i=is,ie
+      mix(i,2) = kap_dt_x2 / ((h(i,j,1)+h(i,j,2)) + h0)
+
+      h_tr = h(i,j,1) + h_neglect
+      b1(i) = 1.0 / (h_tr + mix(i,2))
+      d1(i) = b1(i) * h(i,j,1)
+      T_f(i,1) = (b1(i)*h_tr)*tv%T(i,j,1)
+      S_f(i,1) = (b1(i)*h_tr)*tv%S(i,j,1)
+    enddo
+    do k=2,nz-1 ; do i=is,ie
+      mix(i,K+1) = kap_dt_x2 / ((h(i,j,k)+h(i,j,k+1)) + h0)
+
+      c1(i,k) = mix(i,K) * b1(i)
+      h_tr = h(i,j,k) + h_neglect
+      b1(i) = 1.0 / ((h_tr + d1(i)*mix(i,K)) + mix(i,K+1))
+      d1(i) = b1(i) * (h_tr + d1(i)*mix(i,K))
+      T_f(i,k) = b1(i) * (h_tr*tv%T(i,j,k) + mix(i,K)*T_f(i,k-1))
+      S_f(i,k) = b1(i) * (h_tr*tv%S(i,j,k) + mix(i,K)*S_f(i,k-1))
+    enddo ; enddo
+    do i=is,ie
+      c1(i,nz) = mix(i,nz) * b1(i)
+      h_tr = h(i,j,nz) + h_neglect
+      b1(i) = 1.0 / (h_tr + d1(i)*mix(i,nz))
+      T_f(i,nz) = b1(i) * (h_tr*tv%T(i,j,nz) + mix(i,nz)*T_f(i,nz-1))
+      S_f(i,nz) = b1(i) * (h_tr*tv%S(i,j,nz) + mix(i,nz)*S_f(i,nz-1))
+    enddo
+    do k=nz-1,1,-1 ; do i=is,ie
+      T_f(i,k) = T_f(i,k) + c1(i,k+1)*T_f(i,k+1)
+      S_f(i,k) = S_f(i,k) + c1(i,k+1)*S_f(i,k+1)
+    enddo ; enddo
+  endif
+
+  if (associated(p_surf)) then
+    do i=is,ie ; pres(i) = p_surf(i,j) ; enddo
+  else
+    do i=is,ie ; pres(i) = 0.0 ; enddo
+  endif
+  call calculate_density_derivs(T_f(:,1), S_f(:,1), pres, dR_dT(:,1), dR_dS(:,1), &
+                                is-G%isd+1, ie-is+1, tv%eqn_of_state)
+  do i=is,ie ; pres(i) = pres(i) + h(i,j,1)*GV%H_to_Pa ; enddo
+  do K=2,nz
+    do i=is,ie
+      T_EOS(i) = 0.5*(T_f(i,k-1) + T_f(i,k))
+      S_EOS(i) = 0.5*(S_f(i,k-1) + S_f(i,k))
+    enddo
+    call calculate_density_derivs(T_EOS, S_EOS, pres, dR_dT(:,K), dR_dS(:,K), &
+                                  is-G%isd+1, ie-is+1, tv%eqn_of_state)
+    do i=is,ie ; pres(i) = pres(i) + h(i,j,k)*GV%H_to_Pa ; enddo
+  enddo
+  call calculate_density_derivs(T_f(:,nz), S_f(:,nz), pres, dR_dT(:,nz+1), dR_dS(:,nz+1), &
+                                is-G%isd+1, ie-is+1, tv%eqn_of_state)
+
+
+end subroutine smoothed_dRdT_dRdS
+
+end module MOM_full_convection

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -28,7 +28,7 @@ use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock, only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
 use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl, time_type
-use MOM_debugging, only : hchksum
+use MOM_debugging, only : hchksum, Bchksum
 use MOM_error_handler, only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
@@ -43,7 +43,8 @@ implicit none ; private
 #include <netcdf.inc>
 #endif
 
-public Calculate_kappa_shear, kappa_shear_init, kappa_shear_is_used
+public Calculate_kappa_shear, Calc_kappa_shear_vertex, kappa_shear_init
+public kappa_shear_is_used, kappa_shear_at_vertex
 
 !> This control structure holds the parameters that regulate shear mixing
 type, public :: Kappa_shear_CS ; private
@@ -81,6 +82,8 @@ type, public :: Kappa_shear_CS ; private
                              !! to estimate the instantaneous shear-driven mixing.
   integer :: max_KS_it       !< The maximum number of iterations that may be used
                              !! to estimate the time-averaged diffusivity.
+  logical :: KS_at_vertex    !< If true, do the calculations of the shear-driven mixing
+                             !! at the cell vertices (i.e., the vorticity points).
   logical :: eliminate_massless !< If true, massless layers are merged with neighboring
                              !! massive layers in this calculation.
                              !  I can think of no good reason why this should be false. - RWH
@@ -206,11 +209,6 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
 #endif
   is = G%isc ; ie = G%iec; js = G%jsc ; je = G%jec ; nz = GV%ke
 
-  ! These are hard-coded for now.  Perhaps these could be made dynamic later?
-  ! tol_dksrc = 0.5*tol_ksrc_chg ; tol_dksrc_low = 1.0 - 1.0/tol_ksrc_chg ?
-!  tol_dksrc = 10.0 ; tol_dksrc_low = 0.95 ; tol2 = 2.0*CS%kappa_tol_err
-!  dt_refinements = 5 ! Selected so that 1/2^dt_refinements < 1-tol_dksrc_low
-
   use_temperature = .false. ; if (associated(tv%T)) use_temperature = .true.
   new_kappa = .true. ; if (present(initialize_all)) new_kappa = initialize_all
 
@@ -222,7 +220,7 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
 
   !$OMP parallel do default(private) shared(js,je,is,ie,nz,h,u_in,v_in,use_temperature,new_kappa, &
 #ifdef ADD_DIAGNOSTICS
-  !$OMP                                I_Ld2_3d,dz_Int_3d, &  
+  !$OMP                                I_Ld2_3d,dz_Int_3d, &
 #endif
   !$OMP                                tv,G,GV,CS,kappa_io,dz_massless,k0dt,p_surf,dt,tke_io,kv_io)
   do j=js,je
@@ -381,8 +379,8 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
   enddo ! end of j-loop
 
   if (CS%debug) then
-    call hchksum(kappa_io,"kappa",G%HI)
-    call hchksum(tke_io,"tke",G%HI)
+    call hchksum(kappa_io, "kappa", G%HI)
+    call hchksum(tke_io, "tke", G%HI)
   endif
 
   if (CS%id_Kd_shear > 0) call post_data(CS%id_Kd_shear, kappa_io, CS%diag)
@@ -393,6 +391,341 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
 #endif
 
 end subroutine Calculate_kappa_shear
+
+
+!> Subroutine for calculating shear-driven diffusivity and TKE in corner columns
+subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_io, tke_io, &
+                                     kv_io, dt, G, GV, CS, initialize_all)
+  type(ocean_grid_type),   intent(in)    :: G      !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV     !< The ocean's vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)),   &
+                           intent(in)    :: u_in   !< Initial zonal velocity, in m s-1. (Intent in)
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)),   &
+                           intent(in)    :: v_in   !< Initial meridional velocity, in m s-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   &
+                           intent(in)    :: h      !< Layer thicknesses, in H (usually m or kg m-2).
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   &
+                           intent(in)    :: T_in   !< Layer potential temperatures in degC
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   &
+                           intent(in)    :: S_in   !< Layer salinities in ppt.
+  type(thermo_var_ptrs),   intent(in)    :: tv     !< A structure containing pointers to any
+                                                   !! available thermodynamic fields. Absent fields
+                                                   !! have NULL ptrs.
+  real, dimension(:,:),    pointer       :: p_surf !< The pressure at the ocean surface in Pa
+                                                   !! (or NULL).
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
+                           intent(out)   :: kappa_io !< The diapycnal diffusivity at each interface
+                                                   !! (not layer!) in m2 s-1.
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)+1), &
+                           intent(inout) :: tke_io !< The turbulent kinetic energy per unit mass at
+                                                   !! each interface (not layer!) in m2 s-2.
+                                                   !! Initially this is the value from the previous
+                                                   !! timestep, which may accelerate the iteration
+                                                   !! toward convergence.
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)+1), &
+                           intent(inout) :: kv_io  !< The vertical viscosity at each interface in m2 s-1.
+                                                   !! The previous value is used to initialize kappa
+                                                   !! in the vertex columes as Kappa = Kv/Prandtl
+                                                   !! to accelerate the iteration toward covergence.
+  real,                    intent(in)    :: dt     !< Time increment, in s.
+  type(Kappa_shear_CS),    pointer       :: CS     !< The control structure returned by a previous
+                                                   !! call to kappa_shear_init.
+  logical,       optional, intent(in)    :: initialize_all !< If present and false, the previous
+                                                   !! value of kappa is used to start the iterations
+
+  ! Local variables
+  real, dimension(SZIB_(G),SZK_(GV)) :: &
+    h_2d, &                         ! A 2-D version of h, but converted to m.
+    u_2d, v_2d, T_2d, S_2d, rho_2d  ! 2-D versions of u_in, v_in, T, S, and rho.
+  real, dimension(SZIB_(G),SZK_(GV)+1,2) :: &
+    kappa_2d    ! Quasi 2-D versions of kappa_io, in m2 s-1.
+  real, dimension(SZIB_(G),SZK_(GV)+1) :: &
+    tke_2d      ! 2-D version tke_io in m2 s-2.
+  real, dimension(SZK_(GV)) :: &
+    u, &        ! The zonal velocity after a timestep of mixing, in m s-1.
+    v, &        ! The meridional velocity after a timestep of mixing, in m s-1.
+    Idz, &      ! The inverse of the distance between TKE points, in m.
+    T, &        ! The potential temperature after a timestep of mixing, in C.
+    Sal, &      ! The salinity after a timestep of mixing, in psu.
+    dz, &       ! The layer thickness, in m.
+    u0xdz, &    ! The initial zonal velocity times dz, in m2 s-1.
+    v0xdz, &    ! The initial meridional velocity times dz, in m2 s-1.
+    T0xdz, &    ! The initial temperature times dz, in C m.
+    S0xdz       ! The initial salinity times dz, in PSU m.
+  real, dimension(SZK_(GV)+1) :: &
+    kappa, &    ! The shear-driven diapycnal diffusivity at an interface, in
+                ! units of m2 s-1.
+    tke, &      ! The Turbulent Kinetic Energy per unit mass at an interface,
+                ! in units of m2 s-2.
+    kappa_avg, & ! The time-weighted average of kappa, in m2 s-1.
+    tke_avg     ! The time-weighted average of TKE, in m2 s-2.
+  real :: f2   ! The squared Coriolis parameter of each column, in s-2.
+  real :: surface_pres  ! The top surface pressure, in Pa.
+
+  real :: dz_in_lay     !   The running sum of the thickness in a layer, in m.
+  real :: k0dt          ! The background diffusivity times the timestep, in m2.
+  real :: dz_massless   ! A layer thickness that is considered massless, in m.
+  real :: I_hwt ! The inverse of the masked thickness weights, in H-1.
+  real :: I_Prandtl
+  logical :: use_temperature  !  If true, temperature and salinity have been
+                        ! allocated and are being used as state variables.
+  logical :: new_kappa = .true. ! If true, ignore the value of kappa from the
+                        ! last call to this subroutine.
+  logical :: do_i       ! If true, work on this column.
+
+  integer, dimension(SZK_(GV)+1) :: kc ! The index map between the original
+                        ! interfaces and the interfaces with massless layers
+                        ! merged into nearby massive layers.
+  real, dimension(SZK_(GV)+1) :: kf ! The fractional weight of interface kc+1 for
+                        ! interpolating back to the original index space, ND.
+  integer :: IsB, IeB, JsB, JeB, i, j, k, nz, nzc, J2, J2m1
+
+  ! Diagnostics that should be deleted?
+#ifdef ADD_DIAGNOSTICS
+  real, dimension(SZK_(GV)+1) :: &  ! Additional diagnostics.
+    I_Ld2_1d
+  real, dimension(SZI_(G),SZK_(GV)+1) :: & ! 2-D versions of diagnostics.
+    I_Ld2_2d, dz_Int_2d
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: & ! 3-D versions of diagnostics.
+    I_Ld2_3d, dz_Int_3d
+#endif
+#ifdef DEBUG
+  integer :: max_debug_itt ; parameter(max_debug_itt=20)
+  real :: wt(SZK_(GV)+1), wt_tot, I_wt_tot, wt_itt
+  real, dimension(SZK_(GV)+1) :: &
+    Ri_k, tke_prev, dtke, dkappa, dtke_norm, &
+    ksrc_av    ! The average through the iterations of k_src, in s-1.
+  real, dimension(SZK_(GV)+1,0:max_debug_itt) :: &
+    tke_it1, N2_it1, Sh2_it1, ksrc_it1, kappa_it1, kprev_it1
+  real, dimension(SZK_(GV)+1,1:max_debug_itt) :: &
+    dkappa_it1, wt_it1, K_Q_it1, d_dkappa_it1, dkappa_norm
+  real, dimension(SZK_(GV),0:max_debug_itt) :: &
+    u_it1, v_it1, rho_it1, T_it1, S_it1
+  real, dimension(0:max_debug_itt) :: &
+    dk_wt_it1, dkpos_wt_it1, dkneg_wt_it1, k_mag
+  real, dimension(max_debug_itt) ::  dt_it1
+#endif
+  isB = G%isc-1 ; ieB = G%iecB ; jsB = G%jsc-1 ; jeB = G%jecB ; nz = GV%ke
+
+  use_temperature = .false. ; if (associated(tv%T)) use_temperature = .true.
+  new_kappa = .true. ; if (present(initialize_all)) new_kappa = initialize_all
+
+!  Ri_crit = CS%Rino_crit
+!  gR0 = GV%Rho0*GV%g_Earth ; g_R0 = GV%g_Earth/GV%Rho0
+
+  k0dt = dt*CS%kappa_0
+  dz_massless = 0.1*sqrt(k0dt)
+  I_Prandtl = 0.0 ; if (CS%Prandtl_turb > 0.0) I_Prandtl = 1.0 / CS%Prandtl_turb
+
+  !$OMP parallel do default(private) shared(jsB,jeB,isB,ieB,nz,h,u_in,v_in,use_temperature,new_kappa, &
+#ifdef ADD_DIAGNOSTICS
+  !$OMP                                I_Ld2_3d,dz_Int_3d, &
+#endif
+  !$OMP                                tv,G,GV,CS,kappa_io,dz_massless,k0dt,p_surf,dt,tke_io,kv_io)
+  do J=JsB,JeB
+    J2 = mod(J,2)+1 ; J2m1 = 3-J2 ! = mod(J-1,2)+1
+
+    ! Interpolate the various quantities to the corners, using masks.
+    do k=1,nz ; do I=IsB,IeB
+      u_2d(I,k) = (u_in(I,j,k)   * (G%mask2dCu(I,j)   * (h(i,j,k)   + h(i+1,j,k))) + &
+                   u_in(I,j+1,k) * (G%mask2dCu(I,j+1) * (h(i,j+1,k) + h(i+1,j+1,k))) ) / &
+                  ((G%mask2dCu(I,j)   * (h(i,j,k)   + h(i+1,j,k)) + &
+                    G%mask2dCu(I,j+1) * (h(i,j+1,k) + h(i+1,j+1,k))) + GV%H_subroundoff)
+      v_2d(I,k) = (v_in(i,J,k)   * (G%mask2dCv(i,J)   * (h(i,j,k)   + h(i,j+1,k))) + &
+                   v_in(i+1,J,k) * (G%mask2dCv(i+1,J) * (h(i+1,j,k) + h(i+1,j+1,k))) ) / &
+                  ((G%mask2dCv(i,J)   * (h(i,j,k)   + h(i,j+1,k)) + &
+                    G%mask2dCv(i+1,J) * (h(i+1,j,k) + h(i+1,j+1,k))) + GV%H_subroundoff)
+      I_hwt = 1.0 / (((G%mask2dT(i,j) * h(i,j,k) + G%mask2dT(i+1,j+1) * h(i+1,j+1,k)) + &
+                      (G%mask2dT(i+1,j) * h(i+1,j,k) + G%mask2dT(i,j+1) * h(i,j+1,k))) + &
+                     GV%H_subroundoff)
+      if (use_temperature) then
+        T_2d(I,k) = ( ((G%mask2dT(i,j) * h(i,j,k)) * T_in(i,j,k) + &
+                       (G%mask2dT(i+1,j+1) * h(i+1,j+1,k)) * T_in(i+1,j+1,k)) + &
+                      ((G%mask2dT(i+1,j) * h(i+1,j,k)) * T_in(i+1,j,k) + &
+                       (G%mask2dT(i,j+1) * h(i,j+1,k)) * T_in(i,j+1,k)) ) * I_hwt
+        S_2d(I,k) = ( ((G%mask2dT(i,j) * h(i,j,k)) * S_in(i,j,k) + &
+                       (G%mask2dT(i+1,j+1) * h(i+1,j+1,k)) * S_in(i+1,j+1,k)) + &
+                      ((G%mask2dT(i+1,j) * h(i+1,j,k)) * S_in(i+1,j,k) + &
+                       (G%mask2dT(i,j+1) * h(i,j+1,k)) * S_in(i,j+1,k)) ) * I_hwt
+      endif
+      h_2d(I,k) = GV%H_to_m * ((G%mask2dT(i,j) * h(i,j,k) + G%mask2dT(i+1,j+1) * h(i+1,j+1,k)) + &
+                               (G%mask2dT(i+1,j) * h(i+1,j,k) + G%mask2dT(i,j+1) * h(i,j+1,k)) ) / &
+                              ((G%mask2dT(i,j) + G%mask2dT(i+1,j+1)) + &
+                               (G%mask2dT(i+1,j) + G%mask2dT(i,j+1)) + 1.0e-36 )
+!      h_2d(I,k) = 0.25*((h(i,j,k) + h(i+1,j+1,k)) + (h(i+1,j,k) + h(i,j+1,k)))*GV%H_to_m
+!      h_2d(I,k) = ((h(i,j,k)**2 + h(i+1,j+1,k)**2) + &
+!                   (h(i+1,j,k)**2 + h(i,j+1,k)**2))*GV%H_to_m * I_hwt
+    enddo ; enddo
+    if (.not.use_temperature) then ; do k=1,nz ; do I=IsB,IeB
+      rho_2d(I,k) = GV%Rlay(k)
+    enddo ; enddo ; endif
+    if (.not.new_kappa) then ; do K=1,nz+1 ; do I=IsB,IeB
+      kappa_2d(I,K,J2) = kv_io(I,J,K)*I_Prandtl
+    enddo ; enddo ; endif
+
+!---------------------------------------
+! Work on each column.
+!---------------------------------------
+    do I=IsB,IeB ; if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) + &
+                       (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) > 0.0) then
+    ! call cpu_clock_begin(Id_clock_setup)
+      ! Store a transposed version of the initial arrays.
+      ! Any elimination of massless layers would occur here.
+      if (CS%eliminate_massless) then
+        nzc = 1
+        do k=1,nz
+          ! Zero out the thicknesses of all layers, even if they are unused.
+          dz(k) = 0.0 ; u0xdz(k) = 0.0 ; v0xdz(k) = 0.0
+          T0xdz(k) = 0.0 ; S0xdz(k) = 0.0
+
+          ! Add a new layer if this one has mass.
+!          if ((dz(nzc) > 0.0) .and. (h_2d(I,k) > dz_massless)) nzc = nzc+1
+          if ((k>CS%nkml) .and. (dz(nzc) > 0.0) .and. &
+              (h_2d(I,k) > dz_massless)) nzc = nzc+1
+
+          ! Only merge clusters of massless layers.
+!         if ((dz(nzc) > dz_massless) .or. &
+!             ((dz(nzc) > 0.0) .and. (h_2d(I,k) > dz_massless))) nzc = nzc+1
+
+          kc(k) = nzc
+          dz(nzc) = dz(nzc) + h_2d(I,k)
+          u0xdz(nzc) = u0xdz(nzc) + u_2d(I,k)*h_2d(I,k)
+          v0xdz(nzc) = v0xdz(nzc) + v_2d(I,k)*h_2d(I,k)
+          if (use_temperature) then
+            T0xdz(nzc) = T0xdz(nzc) + T_2d(I,k)*h_2d(I,k)
+            S0xdz(nzc) = S0xdz(nzc) + S_2d(I,k)*h_2d(I,k)
+          else
+            T0xdz(nzc) = T0xdz(nzc) + rho_2d(I,k)*h_2d(I,k)
+            S0xdz(nzc) = S0xdz(nzc) + rho_2d(I,k)*h_2d(I,k)
+          endif
+        enddo
+        kc(nz+1) = nzc+1
+
+        ! Set up Idz as the inverse of layer thicknesses.
+        do k=1,nzc ; Idz(k) = 1.0 / dz(k) ; enddo
+
+        !   Now determine kf, the fractional weight of interface kc when
+        ! interpolating between interfaces kc and kc+1.
+        kf(1) = 0.0 ; dz_in_lay = h_2d(I,1)
+        do k=2,nz
+          if (kc(k) > kc(k-1)) then
+            kf(k) = 0.0 ; dz_in_lay = h_2d(I,k)
+          else
+            kf(k) = dz_in_lay*Idz(kc(k)) ; dz_in_lay = dz_in_lay + h_2d(I,k)
+          endif
+        enddo
+        kf(nz+1) = 0.0
+      else
+        do k=1,nz
+          dz(k) = h_2d(I,k)
+          u0xdz(k) = u_2d(I,k)*dz(k) ; v0xdz(k) = v_2d(I,k)*dz(k)
+        enddo
+        if (use_temperature) then
+          do k=1,nz
+            T0xdz(k) = T_2d(I,k)*dz(k) ; S0xdz(k) = S_2d(I,k)*dz(k)
+          enddo
+        else
+          do k=1,nz
+            T0xdz(k) = rho_2d(I,k)*dz(k) ; S0xdz(k) = rho_2d(I,k)*dz(k)
+          enddo
+        endif
+        nzc = nz
+        do k=1,nzc+1 ; kc(k) = k ; kf(k) = 0.0 ; enddo
+      endif
+      f2 = G%CoriolisBu(I,J)**2
+      surface_pres = 0.0 ; if (associated(p_surf)) then
+        surface_pres = 0.25 * ((p_surf(i,j) + p_surf(i+1,j+1)) + &
+                               (p_surf(i+1,j) + p_surf(i,j+1)))
+      endif
+
+    ! ----------------------------------------------------
+    ! Set the initial guess for kappa, here defined at interfaces.
+    ! ----------------------------------------------------
+      if (new_kappa) then
+        do K=1,nzc+1 ; kappa(K) = 1.0 ; enddo
+      else
+        do K=1,nzc+1 ; kappa(K) = kappa_2d(I,K,J2) ; enddo
+      endif
+
+      call kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
+                              dz, u0xdz, v0xdz, T0xdz, S0xdz, kappa_avg, &
+                              tke_avg, tv, CS, GV)
+
+    ! call cpu_clock_begin(Id_clock_setup)
+    ! Extrapolate from the vertically reduced grid back to the original layers.
+      if (nz == nzc) then
+        do K=1,nz+1
+          kappa_2d(I,K,J2) = kappa_avg(K)
+          !### Should this be tke_avg?
+          tke_2d(I,K) = tke(K)
+        enddo
+      else
+        do K=1,nz+1
+          if (kf(K) == 0.0) then
+            kappa_2d(I,K,J2) = kappa_avg(kc(K))
+            tke_2d(I,K) = tke_avg(kc(K))
+          else
+            kappa_2d(I,K,J2) = (1.0-kf(K)) * kappa_avg(kc(K)) + &
+                               kf(K) * kappa_avg(kc(K)+1)
+            tke_2d(I,K) = (1.0-kf(K)) * tke_avg(kc(K)) + &
+                           kf(K) * tke_avg(kc(K)+1)
+          endif
+        enddo
+      endif
+#ifdef ADD_DIAGNOSTICS
+      I_Ld2_2d(I,1) = 0.0 ; dz_Int_2d(I,1) = dz_Int(1)
+      do K=2,nzc
+        I_Ld2_2d(I,K) = (N2(K) / CS%lambda**2 + f2) / &
+                         max(TKE(K),1e-30) + I_L2_bdry(K)
+        dz_Int_2d(I,K) = dz_Int(K)
+      enddo
+      I_Ld2_2d(I,nzc+1) = 0.0 ; dz_Int_2d(I,nzc+1) = dz_Int(nzc+1)
+      do K=nzc+2,nz+1
+        I_Ld2_2d(I,K) = 0.0 ; dz_Int_2d(I,K) = 0.0
+      enddo
+#endif
+    ! call cpu_clock_end(Id_clock_setup)
+    else  ! Land points, still inside the i-loop.
+      do K=1,nz+1
+        kappa_2d(I,K,J2) = 0.0 ; tke_2d(I,K) = 0.0
+#ifdef ADD_DIAGNOSTICS
+        I_Ld2_2d(I,K) = 0.0
+        dz_Int_2d(I,K) = dz_Int(K)
+#endif
+      enddo
+    endif ; enddo ! i-loop
+
+    do K=1,nz+1 ; do I=IsB,IeB
+      tke_io(I,J,K) = G%mask2dBu(I,J) * tke_2d(I,K)
+      kv_io(I,J,K) = ( G%mask2dBu(I,J) * kappa_2d(I,K,J2) ) * CS%Prandtl_turb
+#ifdef ADD_DIAGNOSTICS
+      I_Ld2_3d(I,J,K) = I_Ld2_2d(I,K)
+      dz_Int_3d(I,J,K) = dz_Int_2d(I,K)
+#endif
+    enddo ; enddo
+    if (J>=G%jsc) then ; do K=1,nz+1 ; do i=G%isc,G%iec
+      ! Set the diffusivities in tracer columns from the values at vertices.
+      kappa_io(i,j,K) = G%mask2dT(i,j) * 0.25 * &
+                        ((kappa_2d(I-1,K,J2m1) + kappa_2d(I,K,J2)) + &
+                         (kappa_2d(I-1,K,J2)   + kappa_2d(I,K,J2m1)))
+    enddo ; enddo ; endif
+
+  enddo ! end of J-loop
+
+  if (CS%debug) then
+    call hchksum(kappa_io, "kappa", G%HI)
+    call Bchksum(tke_io, "tke", G%HI)
+  endif
+
+  if (CS%id_Kd_shear > 0) call post_data(CS%id_Kd_shear, kappa_io, CS%diag)
+  if (CS%id_TKE > 0) call post_data(CS%id_TKE, tke_io, CS%diag)
+#ifdef ADD_DIAGNOSTICS
+  if (CS%id_ILd2 > 0) call post_data(CS%id_ILd2, I_Ld2_3d, CS%diag)
+  if (CS%id_dz_Int > 0) call post_data(CS%id_dz_Int, dz_Int_3d, CS%diag)
+#endif
+
+end subroutine Calc_kappa_shear_vertex
+
 
 !> This subroutine calculates shear-driven diffusivity and TKE in a single column
 subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
@@ -1690,6 +2023,10 @@ function kappa_shear_init(Time, G, GV, param_file, diag, CS)
   call get_param(param_file, mdl, "USE_JACKSON_PARAM", kappa_shear_init, &
                  "If true, use the Jackson-Hallberg-Legg (JPO 2008) \n"//&
                  "shear mixing parameterization.", default=.false.)
+  call get_param(param_file, mdl, "VERTEX_SHEAR", CS%KS_at_vertex, &
+                 "If true, do the calculations of the shear-driven mixing \n"//&
+                 "at the cell vertices (i.e., the vorticity points).", &
+                 default=.false.)
   call get_param(param_file, mdl, "RINO_CRIT", CS%RiNo_crit, &
                  "The critical Richardson number for shear mixing.", &
                  units="nondim", default=0.25)
@@ -1761,10 +2098,10 @@ function kappa_shear_init(Time, G, GV, param_file, diag, CS)
                  "be used in single-column mode!", &
                  default=.false., debuggingParam=.true.)
 
-!    id_clock_KQ = cpu_clock_id('Ocean KS kappa_shear',grain=CLOCK_ROUTINE)
-!    id_clock_avg = cpu_clock_id('Ocean KS avg',grain=CLOCK_ROUTINE)
-!    id_clock_project = cpu_clock_id('Ocean KS project',grain=CLOCK_ROUTINE)
-!    id_clock_setup = cpu_clock_id('Ocean KS setup',grain=CLOCK_ROUTINE)
+!    id_clock_KQ = cpu_clock_id('Ocean KS kappa_shear', grain=CLOCK_ROUTINE)
+!    id_clock_avg = cpu_clock_id('Ocean KS avg', grain=CLOCK_ROUTINE)
+!    id_clock_project = cpu_clock_id('Ocean KS project', grain=CLOCK_ROUTINE)
+!    id_clock_setup = cpu_clock_id('Ocean KS setup', grain=CLOCK_ROUTINE)
 
   CS%nkml = 1
   if (GV%nkml>0) then
@@ -1802,5 +2139,25 @@ logical function kappa_shear_is_used(param_file)
   call get_param(param_file, mdl, "USE_JACKSON_PARAM", kappa_shear_is_used, &
                  default=.false., do_not_log=.true.)
 end function kappa_shear_is_used
+
+!> This function indicates to other modules whether the Jackson et al shear mixing
+!! parameterization will be used without needing to duplicate the log entry.
+logical function kappa_shear_at_vertex(param_file)
+  type(param_file_type), intent(in) :: param_file !< A structure to parse for run-time parameters
+! Reads the parameter "USE_JACKSON_PARAM" and returns state.
+  character(len=40)  :: mdl = "MOM_kappa_shear"  ! This module's name.
+
+  logical :: do_kappa_shear
+
+  call get_param(param_file, mdl, "USE_JACKSON_PARAM", do_kappa_shear, &
+                 default=.false., do_not_log=.true.)
+  kappa_shear_at_vertex = .false.
+  if (do_Kappa_Shear) &
+    call get_param(param_file, mdl, "VERTEX_SHEAR", kappa_shear_at_vertex, &
+                 "If true, do the calculations of the shear-driven mixing \n"//&
+                 "at the cell vertices (i.e., the vorticity points).", &
+                 default=.false., do_not_log=.true.)
+
+end function kappa_shear_at_vertex
 
 end module MOM_kappa_shear

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -7,13 +7,14 @@ use MOM_cpu_clock,           only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROU
 use MOM_diag_mediator,       only : diag_ctrl, time_type
 use MOM_diag_mediator,       only : post_data, register_diag_field
 use MOM_diag_to_Z,           only : diag_to_Z_CS, register_Zint_diag, calc_Zint_diags
-use MOM_debugging,           only : hchksum, uvchksum
+use MOM_debugging,           only : hchksum, uvchksum, Bchksum
 use MOM_EOS,                 only : calculate_density, calculate_density_derivs
 use MOM_error_handler,       only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_error_handler,       only : callTree_showQuery
 use MOM_error_handler,       only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,         only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,        only : forcing, optics_type
+use MOM_full_convection,     only : full_convection
 use MOM_grid,                only : ocean_grid_type
 use MOM_internal_tides,      only : int_tide_CS, get_lowmode_loss
 use MOM_tidal_mixing,        only : tidal_mixing_CS, calculate_tidal_mixing
@@ -21,6 +22,7 @@ use MOM_tidal_mixing,        only : setup_tidal_diagnostics, post_tidal_diagnost
 use MOM_intrinsic_functions, only : invcosh
 use MOM_io,                  only : slasher, vardesc, var_desc, MOM_read_data
 use MOM_kappa_shear,         only : calculate_kappa_shear, kappa_shear_init, Kappa_shear_CS
+use MOM_kappa_shear,         only : calc_kappa_shear_vertex, kappa_shear_at_vertex
 use MOM_CVMix_shear,         only : calculate_CVMix_shear, CVMix_shear_init, CVMix_shear_cs
 use MOM_CVMix_shear,         only : CVMix_shear_end
 use MOM_CVMix_ddiff,         only : CVMix_ddiff_init, CVMix_ddiff_end, CVMix_ddiff_cs
@@ -128,6 +130,8 @@ type, public :: set_diffusivity_CS ; private
   logical :: user_change_diff !< If true, call user-defined code to change diffusivity.
   logical :: useKappaShear    !< If true, use the kappa_shear module to find the
                               !! shear-driven diapycnal diffusivity.
+  logical :: Vertex_Shear     !< If true, do the calculations of the shear-driven mixing
+                              !! at the cell vertices (i.e., the vorticity points).
   logical :: use_CVMix_shear  !< If true, use one of the CVMix modules to find
                               !! shear-driven diapycnal diffusivity.
   logical :: double_diffusion !< If true, enable double-diffusive mixing using an old method.
@@ -233,8 +237,11 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   type(diffusivity_diags)  :: dd ! structure w/ arrays of pointers to avail diags
 
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: &
-    T_f, S_f      ! temperature and salinity (deg C and ppt)
+    T_f, S_f      ! Temperature and salinity (in deg C and ppt) with
                   ! massless layers filled vertically by diffusion.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: &
+    T_adj, S_adj  ! Temperature and salinity (in deg C and ppt)
+                  ! after full convective adjustment.
 
   real, dimension(SZI_(G),SZK_(G)) :: &
     N2_lay, &     !< squared buoyancy frequency associated with layers (1/s2)
@@ -344,26 +351,40 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
       call hchksum(v_h, "before calc_KS v_h",G%HI)
     endif
     call cpu_clock_begin(id_clock_kappaShear)
-    ! Changes: visc%Kd_shear, visc%TKE_turb (not clear that TKE_turb is used as input ????)
-    ! Sets visc%Kv_shear
-    call calculate_kappa_shear(u_h, v_h, h, tv, fluxes%p_surf, visc%Kd_shear, visc%TKE_turb, &
-                               visc%Kv_shear, dt, G, GV, CS%kappaShear_CSp)
-    call cpu_clock_end(id_clock_kappaShear)
-    if (CS%debug) then
-      call hchksum(visc%Kd_shear, "after calc_KS visc%Kd_shear",G%HI)
-      call hchksum(visc%Kv_shear, "after calc_KS visc%Kv_shear",G%HI)
-      call hchksum(visc%TKE_turb, "after calc_KS visc%TKE_turb",G%HI)
+    if (CS%Vertex_shear) then
+      call full_convection(G, GV, h, tv, T_adj, S_adj, fluxes%p_surf, &
+                           kappa_fill*dt_fill, halo=1)
+
+      call calc_kappa_shear_vertex(u, v, h, T_adj, S_adj, tv, fluxes%p_surf, visc%Kd_shear, &
+                                   visc%TKE_turb, visc%Kv_shear_Bu, dt, G, GV, CS%kappaShear_CSp)
+      if (associated(visc%Kv_shear)) visc%Kv_shear(:,:,:) = 0.0 ! needed for other parameterizations
+      if (CS%debug) then
+        call hchksum(visc%Kd_shear, "after calc_KS_vert visc%Kd_shear",G%HI)
+        call Bchksum(visc%Kv_shear, "after calc_KS_vert visc%Kv_shear_Bu",G%HI)
+        call Bchksum(visc%TKE_turb, "after calc_KS_vert visc%TKE_turb",G%HI)
+      endif
+    else
+      ! Changes: visc%Kd_shear, visc%TKE_turb (not clear that TKE_turb is used as input ????)
+      ! Sets visc%Kv_shear
+      call calculate_kappa_shear(u_h, v_h, h, tv, fluxes%p_surf, visc%Kd_shear, visc%TKE_turb, &
+                                 visc%Kv_shear, dt, G, GV, CS%kappaShear_CSp)
+      if (CS%debug) then
+        call hchksum(visc%Kd_shear, "after calc_KS visc%Kd_shear",G%HI)
+        call hchksum(visc%Kv_shear, "after calc_KS visc%Kv_shear",G%HI)
+        call hchksum(visc%TKE_turb, "after calc_KS visc%TKE_turb",G%HI)
+      endif
     endif
+    call cpu_clock_end(id_clock_kappaShear)
     if (showCallTree) call callTree_waypoint("done with calculate_kappa_shear (set_diffusivity)")
   elseif (CS%use_CVMix_shear) then
     !NOTE{BGR}: this needs to be cleaned up.  It works in 1D case, but has not been tested outside.
-    call calculate_CVMix_shear(u_h, v_h, h, tv, visc%Kd_shear, visc%Kv_shear,G,GV,CS%CVMix_shear_csp)
+    call calculate_CVMix_shear(u_h, v_h, h, tv, visc%Kd_shear, visc%Kv_shear, G, GV, CS%CVMix_shear_CSp)
     if (CS%debug) then
       call hchksum(visc%Kd_shear, "after CVMix_shear visc%Kd_shear",G%HI)
       call hchksum(visc%Kv_shear, "after CVMix_shear visc%Kv_shear",G%HI)
     endif
   elseif (associated(visc%Kv_shear)) then
-    visc%Kv_shear(:,:,:) = 0. ! needed if calculate_kappa_shear is not enabled
+    visc%Kv_shear(:,:,:) = 0.0 ! needed if calculate_kappa_shear is not enabled
   endif
 
   !   Calculate the diffusivity, Kd, for each layer.  This would be
@@ -373,10 +394,8 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   ! set surface diffusivities (CS%bkgnd_mixing_csp%Kd_sfc)
   call sfc_bkgnd_mixing(G, CS%bkgnd_mixing_csp)
 
-!$OMP parallel do default(none) shared(is,ie,js,je,nz,G,GV,CS,h,tv,T_f,S_f,fluxes,dd, &
-!$OMP                                  Kd,visc,Kd_int,dt,u,v,Omega2)   &
-!$OMP                          private(dRho_int, N2_lay, N2_int, N2_bot,        &
-!$OMP                                  KT_extra, KS_extra, TKE_to_Kd,maxTKE,dissip,kb)
+  !$OMP parallel do default(shared) private(dRho_int, N2_lay, N2_int, N2_bot, KT_extra, &
+  !$OMP                                     KS_extra, TKE_to_Kd,maxTKE, dissip, kb)
   do j=js,je
 
     ! Set up variables related to the stratification.
@@ -2200,6 +2219,8 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
          "Bryan-Lewis and internal tidal dissipation are both enabled. Choose one.")
 
   CS%useKappaShear = kappa_shear_init(Time, G, GV, param_file, CS%diag, CS%kappaShear_CSp)
+  if (CS%useKappaShear) CS%Vertex_Shear = kappa_shear_at_vertex(param_file)
+
   if (CS%useKappaShear) &
     id_clock_kappaShear = cpu_clock_id('(Ocean kappa_shear)', grain=CLOCK_MODULE)
 

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1779,7 +1779,7 @@ subroutine set_visc_register_restarts(HI, GV, param_file, visc, restart_CS)
   if (useKPP .or. useEPBL .or. use_CVMix_shear .or. use_CVMix_conv .or. &
       (use_kappa_shear .and. .not.KS_at_vertex )) then
     call safe_alloc_ptr(visc%Kv_shear, isd, ied, jsd, jed, nz+1)
-    call register_restart_field(visc%Kd_shear, "Kv_shear", .false., restart_CS, &
+    call register_restart_field(visc%Kv_shear, "Kv_shear", .false., restart_CS, &
                   "Shear-driven turbulent viscosity at interfaces", "m2 s-1", z_grid='i')
   endif
   if (use_kappa_shear .and. KS_at_vertex) then


### PR DESCRIPTION
  Added the ability to calculate the effects of stratified shear mixing at the tracer vertices. This new
capability dramatically improves mixing-driven gridscale noise in short test cases, especially in the
tropics, and there may be changes to climate. By default, all changes are bitwise identical, but there are multiple new interfaces and runtime parameters.  The MOM6 commits covered by this change include:
- NOAA-GFDL/MOM6@0cde92a Added turbulence halo update during initialization
- NOAA-GFDL/MOM6@8a57f0b Merge branch 'dev/gfdl' into vertex_shearmix
- NOAA-GFDL/MOM6@b8e4321 +Added call to Calc_kappa_shear_vertex
- NOAA-GFDL/MOM6@b49a602 +Added Calc_kappa_shear_vertex and VERTEX_SHEAR
- NOAA-GFDL/MOM6@5edcd54 Add visc%Kv_shear_Bu to viscosity
- NOAA-GFDL/MOM6@5a71941 +Added Kv_shear_Bu to vertvisc_type
- NOAA-GFDL/MOM6@130a32b Cleaned up set_viscosity setup
- NOAA-GFDL/MOM6@37dd39e dOxyGenized Kappa_shear_CS
- NOAA-GFDL/MOM6@8848901 +Added MOM_full_convection