### PR TITLE
More doxygenization

### DIFF
--- a/config_src/dynamic/MOM_memory.h
+++ b/config_src/dynamic/MOM_memory.h
@@ -1,50 +1,39 @@
-!********+*********+*********+*********+*********+*********+*********+*
-!*   This include file determines the compile-time memory settings    *
-!*  for the Modular Ocean Model (MOM), versions 6 and later.          *
-!********+*********+*********+*********+*********+*********+*********+*
+!/// \brief Compile-time memory settings
+!/// \details This include file determines the compile-time memory settings.
+!/// There are several variants of this file and only one should be in the search path for compilation.
+!/// \file MOM_memory.h
 
-!  Specify the numerical domain.
+!/// The number of thickness grid points in the i-direction of the global domain.
 #define NIGLOBAL_ NONSENSE_NIGLOBAL
+!/// The number of thickness grid points in the j-direction of the global domain.
 #define NJGLOBAL_ NONSENSE_NJGLOBAL
-                               !    NIGLOBAL_ and NJGLOBAL_ are the number of thickness
-                               !  grid points in the zonal and meridional
-                               !  directions of the physical domain.
+!/// The number of layers in the vertical direction.
 #define NK_ NONSENSE_NK
-                               !    The number of layers.
 
-#undef STATIC_MEMORY_
-                               !    If STATIC_MEMORY_ is defined, the principle
-                               !  variables will have sizes that are statically
-                               !  determined at compile time.  Otherwise the
-                               !  sizes are not determined until run time. The
-                               !  STATIC option is substantially faster, but
-                               !  does not allow the PE count to be changed at
-                               !  run time.
-#undef  SYMMETRIC_MEMORY_
-                               !    If defined, the velocity point data domain
-                               !  includes every face of the thickness points.
-                               !  In other words, some arrays are larger than
-                               !  others, depending on where they are on the 
-                               !  staggered grid.
-
+!/// The number of processors in the i-direction.
 #define NIPROC_ NONSENSE_NIPROC
-                               !    NIPROC_ is the number of processors in the
-                               !  x-direction.
-#define NJPROC_ NONSENSE_NJPROC
-                               !    NJPROC_ is the number of processors in the
-                               !  y-direction.
 
+!/// The number of processors in the j-direction.
+#define NJPROC_ NONSENSE_NJPROC
+
+!/// The maximum permitted number (each) of restart variables, time derivatives, etc.
+!/// This is mostly used for the size of pointer arrays, so it should be set generously.
 #ifndef MAX_FIELDS_
 #define MAX_FIELDS_ 50
 #endif
-                               !    The maximum permitted number (each) of
-                               !  restart variables, time derivatives, etc.
-                               !  This is mostly used for the size of pointer
-                               !  arrays, so it should be set generously.
 
+!/// The number of memory halo cells on each side of the computational domain in the i-direction.
 #define NIHALO_ 2
+
+!/// The number of memory halo cells on each side of the computational domain in the j-direction.
 #define NJHALO_ 2
-                               !   NIHALO_ and NJHALO_ are the sizes of the
-                               ! memory halos on each side.
+
+!/// If SYMMETRIC_MEMORY_() is defined, the velocity point data domain includes every face of the thickness points.
+!/// In other words, some arrays are larger than others, depending on where they are on the staggered grid.
+#undef  SYMMETRIC_MEMORY_
+
+!/// If STATIC_MEMORY_ is defined, the principle variables have sizes that are statically determined at compile time.
+!/// Otherwise the sizes are not determined until run time.
+#undef STATIC_MEMORY_
 
 #include <MOM_memory_macros.h>

--- a/config_src/dynamic_symmetric/MOM_memory.h
+++ b/config_src/dynamic_symmetric/MOM_memory.h
@@ -1,33 +1,39 @@
-!/*! \brief Compile-time memory settings */
-!/*! \details This include file determines the compile-time memory settings. There are several variants of this file and only one should be in the search path for compilation. */
-!/*! \file MOM_memory.h */
+!/// \brief Compile-time memory settings
+!/// \details This include file determines the compile-time memory settings.
+!/// There are several variants of this file and only one should be in the search path for compilation.
+!/// \file MOM_memory.h
 
-!/*! The number of thickness grid points in the i-direction of the global domain. */
+!/// The number of thickness grid points in the i-direction of the global domain.
 #define NIGLOBAL_ NONSENSE_NIGLOBAL
-!/*! The number of thickness grid points in the j-direction of the global domain. */
+!/// The number of thickness grid points in the j-direction of the global domain.
 #define NJGLOBAL_ NONSENSE_NJGLOBAL
-!/*! The number of layers in the vertical direction. */
+!/// The number of layers in the vertical direction.
 #define NK_ NONSENSE_NK
 
-!/*! \def STATIC_MEMORY_ If STATIC_MEMORY_ is defined, the principle variables will have sizes that are statically determined at compile time. Otherwise the sizes are not determined until run time. */
-#undef STATIC_MEMORY_
-
-!/*! If SYMMETRIC_MEMORY_ is defined, the velocity point data domain includes every face of the thickness points. In other words, some arrays are larger than others, depending on where they are on the staggered grid. */
-#define SYMMETRIC_MEMORY_
-
-!/*! The number of processors in the i-direction. */
+!/// The number of processors in the i-direction.
 #define NIPROC_ NONSENSE_NIPROC
 
-!/*! The number of processors in the j-direction. */
+!/// The number of processors in the j-direction.
 #define NJPROC_ NONSENSE_NJPROC
 
-!/*! The maximum permitted number (each) of restart variables, time derivatives, etc. This is mostly used for the size of pointer arrays, so it should be set generously. */
+!/// The maximum permitted number (each) of restart variables, time derivatives, etc.
+!/// This is mostly used for the size of pointer arrays, so it should be set generously.
+#ifndef MAX_FIELDS_
 #define MAX_FIELDS_ 50
+#endif
 
-!/*! The number of memory halo cells on each side of the computational domain in the i-direction */
+!/// The number of memory halo cells on each side of the computational domain in the i-direction.
 #define NIHALO_ 2
 
-!/*! The number of memory halo cells on each side of the computational domain in the j-direction */
+!/// The number of memory halo cells on each side of the computational domain in the j-direction.
 #define NJHALO_ 2
+
+!/// If SYMMETRIC_MEMORY_() is defined, the velocity point data domain includes every face of the thickness points.
+!/// In other words, some arrays are larger than others, depending on where they are on the staggered grid.
+#define SYMMETRIC_MEMORY_
+
+!/// If STATIC_MEMORY_ is defined, the principle variables have sizes that are statically determined at compile time.
+!/// Otherwise the sizes are not determined until run time.
+#undef STATIC_MEMORY_
 
 #include <MOM_memory_macros.h>

--- a/docs/Doxyfile_nortd
+++ b/docs/Doxyfile_nortd
@@ -425,7 +425,7 @@ LOOKUP_CACHE_SIZE      = 0
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = YES
+EXTRACT_ALL            = NO
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.

--- a/src/ALE/coord_adapt.F90
+++ b/src/ALE/coord_adapt.F90
@@ -104,7 +104,8 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
   type(verticalGrid_type),                     intent(in)    :: GV   !< The ocean's vertical grid structure
   type(thermo_var_ptrs),                       intent(in)    :: tv   !< A structure pointing to various
                                                                      !! thermodynamic variables
-  integer,                                     intent(in)    :: i, j !< The indices of the column to work on
+  integer,                                     intent(in)    :: i    !< The i-index of the column to work on
+  integer,                                     intent(in)    :: j    !< The j-index of the column to work on
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)    :: zInt !< Interface heights, in H (m or kg m-2).
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)    :: tInt !< Interface temperatures, in C
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)    :: sInt !< Interface salinities, in psu

--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -172,27 +172,27 @@ subroutine build_rho_column(CS, nz, depth, h, T, S, eqn_of_state, z_interface, &
 
 end subroutine build_rho_column
 
+!> Iteratively build a rho coordinate column
+!!
+!! The algorithm operates as follows within each column:
+!!
+!! 1. Given T & S within each layer, the layer densities are computed.
+!! 2. Based on these layer densities, a global density profile is reconstructed
+!!    (this profile is monotonically increasing and may be discontinuous)
+!! 3. The new grid interfaces are determined based on the target interface
+!!    densities.
+!! 4. T & S are remapped onto the new grid.
+!! 5. Return to step 1 until convergence or until the maximum number of
+!!    iterations is reached, whichever comes first.
 subroutine build_rho_column_iteratively(CS, remapCS, nz, depth, h, T, S, eqn_of_state, &
                                zInterface, h_neglect, h_neglect_edge)
-  !< Iteratively build a rho coordinate column
-  !!
-  !! The algorithm operates as follows within each column:
-  !!
-  !! 1. Given T & S within each layer, the layer densities are computed.
-  !! 2. Based on these layer densities, a global density profile is reconstructed
-  !!    (this profile is monotonically increasing and may be discontinuous)
-  !! 3. The new grid interfaces are determined based on the target interface
-  !!    densities.
-  !! 4. T & S are remapped onto the new grid.
-  !! 5. Return to step 1 until convergence or until the maximum number of
-  !!    iterations is reached, whichever comes first.
-
   type(rho_CS),          intent(in)    :: CS !< Regridding control structure
   type(remapping_CS),    intent(in)    :: remapCS !< Remapping parameters and options
   integer,               intent(in)    :: nz !< Number of levels
   real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in m)
   real, dimension(nz),   intent(in)    :: h  !< Layer thicknesses, in m
-  real, dimension(nz),   intent(in)    :: T, S !< T and S for column
+  real, dimension(nz),   intent(in)    :: T  !< T for column
+  real, dimension(nz),   intent(in)    :: S  !< S for column
   type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
   real, dimension(nz+1), intent(inout) :: zInterface !< Absolute positions of interfaces
   real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the
@@ -201,7 +201,6 @@ subroutine build_rho_column_iteratively(CS, remapCS, nz, depth, h, T, S, eqn_of_
   real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width
                                              !! for the purpose of edge value calculations
                                              !! in the same units as h
-
   ! Local variables
   integer   :: k, m
   integer   :: count_nonzero_layers

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -173,7 +173,8 @@ subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff,
   real,                  intent(in)    :: H_subroundoff !< GV%H_subroundoff
   integer,               intent(in)    :: nz !< Number of levels
   real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in m)
-  real, dimension(nz),   intent(in)    :: T_col, S_col !< T and S for column
+  real, dimension(nz),   intent(in)    :: T_col !< T for column
+  real, dimension(nz),   intent(in)    :: S_col !< S for column
   real, dimension(nz),   intent(in)    :: h_col !< Layer thicknesses, in m
   real, dimension(nz),   intent(in)    :: p_col !< Layer quantities
   real, dimension(nz+1), intent(in)    :: z_col !< Interface positions relative to the surface in H units (m or kg m-2)
@@ -184,7 +185,6 @@ subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff,
   real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width
                                              !! for the purpose of edge value calculations
                                              !! in the same units as h_col.
-
   ! Local variables
   real, dimension(nz) :: rho_col ! Layer quantities
   real, dimension(nz) :: T_f, S_f  ! Filtered ayer quantities

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3547,7 +3547,8 @@ end subroutine BT_cont_to_face_areas
 
 !> Swap the values of two real variables
 subroutine swap(a,b)
-  real, intent(inout) :: a, b !< The varaibles to be swapped.
+  real, intent(inout) :: a !< The first variable to be swapped.
+  real, intent(inout) :: b !< The second variable to be swapped.
   real :: tmp
   tmp = a ; a = b ; b = tmp
 end subroutine swap

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1053,34 +1053,29 @@ subroutine meridional_mass_flux(v, h_in, vh, dt, G, GV, CS, LB, vhbt, OBC, &
   real,                                      intent(in)    :: dt   !< Time increment in s.
   type(continuity_PPM_CS),                   pointer       :: CS   !< This module's control structure.
   type(loop_bounds_type),                    intent(in)    :: LB   !< Loop bounds structure.
-  type(ocean_OBC_type),            optional, pointer       :: OBC   !<
-         !! This open boundary condition type specifies whether, where,
-         !! and what open boundary conditions are used.
+  type(ocean_OBC_type),            optional, pointer       :: OBC  !< Open boundary condition type
+                                   !! specifies whether, where, and what open boundary conditions are used.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                                   optional, intent(in)    :: visc_rem_v !<
-         !! Both the fraction of the momentum originally in a
-         !! layer that remains after a time-step of viscosity,
-         !! and the fraction of a time-step's worth of a
-         !! barotropic acceleration that a layer experiences
-         !! after viscosity is applied.  Nondimensional between
-         !! 0 (at the bottom) and 1 (far above the bottom).
+                                   optional, intent(in)    :: visc_rem_v !< Both the fraction of the momentum
+                                   !! originally in a layer that remains after a time-step of viscosity,
+                                   !! and the fraction of a time-step's worth of a barotropic acceleration
+                                   !! that a layer experiences after viscosity is applied.  Nondimensional between
+                                   !! 0 (at the bottom) and 1 (far above the bottom).
   real, dimension(SZI_(G),SZJB_(G)), &
-                                   optional, intent(in)    :: vhbt !<
-         !! The summed volume flux through meridional faces, H m2 s-1.
+                                   optional, intent(in)    :: vhbt !< The summed volume flux through meridional
+                                   !! faces, H m2 s-1.
   real, dimension(SZI_(G),SZJB_(G)), &
-                                   optional, intent(in)    :: vhbt_aux !<
-         !! A second set of summed volume fluxes through meridional
-         !! faces, in H m2 s-1.
+                                   optional, intent(in)    :: vhbt_aux !< A second set of summed volume fluxes
+                                   !! through meridional faces, in H m2 s-1.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                                   optional, intent(out)   :: v_cor !<
-         !! The meridional velocitiess (v with a barotropic correction)
-         !! that give vhbt as the depth-integrated transport, m s-1.
+                                   optional, intent(out)   :: v_cor !< The meridional velocitiess (v with a
+                                   !! barotropic correction) that give vhbt as the depth-integrated transport, m s-1.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                                   optional, intent(out)   :: v_cor_aux !<
-         !! The meridional velocities (v with a barotropic correction)
-         !! that give vhbt_aux as the depth-integrated transports, in m s-1.
-  type(BT_cont_type),              optional, pointer       :: BT_cont !<
-         !! A structure with elements that describe the effective
+                                   optional, intent(out)   :: v_cor_aux !< The meridional velocities (v with a
+                                   !! barotropic correction) that give vhbt_aux as the depth-integrated transports,
+                                   !! in m s-1.
+  type(BT_cont_type),              optional, pointer       :: BT_cont !< A structure with elements that describe
+                                   !! the effective open face areas as a function of barotropic flow.
   ! Local variables
   real, dimension(SZI_(G),SZK_(G)) :: &
     dvhdv      ! Partial derivative of vh with v, in m2.

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -2412,11 +2412,8 @@ subroutine update_OBC_segment_data(G, GV, OBC, tv, h, Time)
   type(ocean_OBC_type),                      pointer       :: OBC  !< Open boundary structure
   type(thermo_var_ptrs),                     intent(in)    :: tv   !< Thermodynamics structure
   real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(inout) :: h    !< Thickness
-! real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(inout) :: e    !< Layer interface height
-! real, dimension(SZI_(G),SZJ_(G))         , intent(inout) :: eta  !< Thickness
-  type(time_type),                           intent(in)    :: Time !< Time
+  type(time_type),                           intent(in)    :: Time !< Model time
   ! Local variables
-
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed
   integer :: IsdB, IedB, JsdB, JedB, n, m, nz
   character(len=40)  :: mdl = "set_OBC_segment_data" ! This subroutine's name.

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -680,7 +680,7 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
 
 end subroutine calculate_Z_transport
 
-!>   This subroutine determines the layers bounded by interfaces e that overlap
+!> Determines the layers bounded by interfaces e that overlap
 !! with the depth range between Z_top and Z_bot, and the fractional weights
 !! of each layer. It also calculates the normalized relative depths of the range
 !! of each layer that overlaps that depth range.
@@ -695,31 +695,13 @@ subroutine find_overlap(e, Z_top, Z_bot, k_max, k_start, k_top, k_bot, wt, z1, z
   integer,            intent(inout) :: k_bot  !< Indices of bottom layers that overlap with the
                                               !! depth range.
   real, dimension(:), intent(out)   :: wt     !< Relative weights of each layer from k_top to k_bot.
-  real, dimension(:), intent(out)   :: z1, z2 !< Depths of the top and bottom limits of the part of
+  real, dimension(:), intent(out)   :: z1     !< Depth of the top limits of the part of
        !! a layer that contributes to a depth level, relative to the cell center and normalized
        !! by the cell thickness (nondim).  Note that -1/2 <= z1 < z2 <= 1/2.
-
-!   This subroutine determines the layers bounded by interfaces e that overlap
-! with the depth range between Z_top and Z_bot, and the fractional weights
-! of each layer. It also calculates the normalized relative depths of the range
-! of each layer that overlaps that depth range.
-
-!   Note that by convention, e decreases with increasing k and Z_top > Z_bot.
-!
-! Arguments:
-!  (in)          e        - column interface heights (meter or kg/m2)
-!  (in)      Z_top        - top of range being mapped to (meter or kg/m2)
-!  (in)      Z_bot        - bottom of range being mapped to (meter or kg/m2)
-!  (in)      k_max        - number of valid layers
-!  (in)      k_start      - layer at which to start searching
-!  (out)     k_top, k_bot - indices of top and bottom layers that
-!                           overlap with the depth range
-!  (out)     wt           - relative weights of each layer from k_top to k_bot
-!  (out)     z1, z2       - depths of the top and bottom limits of
-!                           the part of a layer that contributes to a depth level,
-!                           relative to the cell center and normalized by the cell
-!                           thickness (nondim).  Note that -1/2 <= z1 < z2 <= 1/2.
-
+  real, dimension(:), intent(out)   :: z2     !< Depths of the bottom limit of the part of
+       !! a layer that contributes to a depth level, relative to the cell center and normalized
+       !! by the cell thickness (nondim).  Note that -1/2 <= z1 < z2 <= 1/2.
+  ! Local variables
   real    :: Ih, e_c, tot_wt, I_totwt
   integer :: k
 

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -1,11 +1,7 @@
+!> A simple linear equation of state for sea water with constant coefficients
 module MOM_EOS_linear
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!***********************************************************************
-!*  The subroutines in this file implement a simple linear equation of *
-!*  state for sea water with constant coefficients set as parameters.  *
-!***********************************************************************
 
 use MOM_hor_index, only : hor_index_type
 
@@ -54,20 +50,6 @@ subroutine calculate_density_scalar_linear(T, S, pressure, rho, &
                                           !! in kg m-3 psu-1.
   real, optional, intent(in)  :: rho_ref  !< A reference density in kg m-3.
 
-! *  This subroutine computes the density of sea water with a trivial  *
-! *  linear equation of state (in kg/m^3) from salinity (sal in psu),  *
-! *  potential temperature (T in deg C), and pressure in Pa.           *
-! *                                                                    *
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in PSU.                                    *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     rho - in situ density in kg m-3.                        *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
-! *  (in)      Rho_T0_S0 - The density at T=0, S=0, in kg m-3.         *
-! *  (in)      dRho_dT - The derivatives of density with temperature   *
-! *  (in)      dRho_dS - and salinity, in kg m-3 C-1 and kg m-3 psu-1. *
-
   if (present(rho_ref)) then
     rho = (Rho_T0_S0 - rho_ref) + (dRho_dT*T + dRho_dS*S)
   else
@@ -93,7 +75,7 @@ subroutine calculate_density_array_linear(T, S, pressure, rho, start, npts, &
   real,               intent(in)  :: dRho_dS  !< The derivatives of density with salinity
                                               !! in kg m-3 psu-1.
   real,     optional, intent(in)  :: rho_ref  !< A reference density in kg m-3.
-
+  ! Local variables
   integer :: j
 
   if (present(rho_ref)) then ; do j=start,start+npts-1
@@ -116,11 +98,10 @@ subroutine calculate_spec_vol_scalar_linear(T, S, pressure, specvol, &
   real,    intent(in)  :: pressure !< pressure in Pa.
   real,    intent(out) :: specvol  !< in situ specific volume in m3 kg-1.
   real,    intent(in)  :: Rho_T0_S0 !< The density at T=0, S=0, in kg m-3.
-  real,    intent(in)  :: dRho_dT, dRho_dS !< The derivatives of density with
-                                    !! temperature and salinity, in kg m-3 C-1
-                                    !! and kg m-3 psu-1.
+  real,    intent(in)  :: dRho_dT  !< The derivatives of density with temperature in kg m-3 C-1.
+  real,    intent(in)  :: dRho_dS  !< The derivatives of density with salinity in kg m-3 psu-1.
   real, optional, intent(in)  :: spv_ref  !< A reference specific volume in m3 kg-1.
-
+  ! Local variables
   integer :: j
 
   if (present(spv_ref)) then
@@ -146,11 +127,10 @@ subroutine calculate_spec_vol_array_linear(T, S, pressure, specvol, start, npts,
   integer,            intent(in)  :: start    !< the starting point in the arrays.
   integer,            intent(in)  :: npts     !< the number of values to calculate.
   real,               intent(in)  :: Rho_T0_S0 !< The density at T=0, S=0, in kg m-3.
-  real,               intent(in)  :: dRho_dT, dRho_dS !< The derivatives of density with
-                                               !! temperature and salinity, in kg m-3 C-1
-                                               !! and kg m-3 psu-1.
+  real,               intent(in)  :: dRho_dT  !< The derivatives of density with temperature in kg m-3 C-1.
+  real,               intent(in)  :: dRho_dS  !< The derivatives of density with salinity in kg m-3 psu-1.
   real,     optional, intent(in)  :: spv_ref  !< A reference specific volume in m3 kg-1.
-
+  ! Local variables
   integer :: j
 
   if (present(spv_ref)) then ; do j=start,start+npts-1
@@ -175,27 +155,11 @@ subroutine calculate_density_derivs_array_linear(T, S, pressure, drho_dT_out, &
   real,    intent(out), dimension(:) :: drho_dS_out !< The partial derivative of density with
                                                     !! salinity, in kg m-3 psu-1.
   real,    intent(in)                :: Rho_T0_S0   !< The density at T=0, S=0, in kg m-3.
-  real,    intent(in)                :: dRho_dT, dRho_dS !< The derivatives of density with
-                                                    !! temperature and salinity, in kg m-3 C-1
-                                                    !! and kg m-3 psu-1.
+  real,    intent(in)                :: dRho_dT     !< The derivatives of density with temperature in kg m-3 C-1.
+  real,    intent(in)                :: dRho_dS     !< The derivatives of density with salinity in kg m-3 psu-1.
   integer, intent(in)                :: start       !< The starting point in the arrays.
   integer, intent(in)                :: npts        !< The number of values to calculate.
-
-! *   This subroutine calculates the partial derivatives of density    *
-! * with potential temperature and salinity.                           *
-! *                                                                    *
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in PSU.                                    *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     drho_dT_out - the partial derivative of density with    *
-! *                      potential temperature, in kg m-3 K-1.         *
-! *  (out)     drho_dS_out - the partial derivative of density with    *
-! *                      salinity, in kg m-3 psu-1.                    *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
-! *  (in)      Rho_T0_S0 - The density at T=0, S=0, in kg m-3.         *
-! *  (in)      dRho_dT - The derivatives of density with temperature   *
-! *  (in)      dRho_dS - and salinity, in kg m-3 C-1 and kg m-3 psu-1. *
+  ! Local variables
   integer :: j
 
   do j=start,start+npts-1
@@ -218,9 +182,8 @@ subroutine calculate_density_derivs_scalar_linear(T, S, pressure, drho_dT_out, &
   real,    intent(out) :: drho_dS_out !< The partial derivative of density with
                                       !! salinity, in kg m-3 psu-1.
   real,    intent(in)  :: Rho_T0_S0   !< The density at T=0, S=0, in kg m-3.
-  real,    intent(in)  :: dRho_dT, dRho_dS !< The derivatives of density with
-                                           !! temperature and salinity, in kg m-3 C-1
-                                           !! and kg m-3 psu-1.
+  real,    intent(in)  :: dRho_dT     !< The derivatives of density with temperature in kg m-3 C-1.
+  real,    intent(in)  :: dRho_dS     !< The derivatives of density with salinity in kg m-3 psu-1.
   drho_dT_out = dRho_dT
   drho_dS_out = dRho_dS
 
@@ -263,6 +226,7 @@ subroutine calculate_density_second_derivs_array_linear(T, S,pressure,  drho_dS_
   real, dimension(:), intent(out) :: drho_dT_dP  !< The partial derivative of density with
   integer, intent(in)  :: start       !< The starting point in the arrays.
   integer, intent(in)  :: npts        !< The number of values to calculate.
+  ! Local variables
   integer :: j
   do j=start,start+npts-1
     drho_dS_dS(j) = 0.
@@ -292,7 +256,7 @@ subroutine calculate_specvol_derivs_linear(T, S, pressure, dSV_dT, dSV_dS, &
                                                   !! temperature, in kg m-3 C-1.
   real,    intent(in)                :: dRho_dS   !< The derivative of density with
                                                   !! salinity, in kg m-3 psu-1.
-
+  ! Local variables
   real :: I_rho2
   integer :: j
 
@@ -321,27 +285,11 @@ subroutine calculate_compress_linear(T, S, pressure, rho, drho_dp, start, npts,&
   integer, intent(in)                :: start     !< The starting point in the arrays.
   integer, intent(in)                :: npts      !< The number of values to calculate.
   real,    intent(in)                :: Rho_T0_S0 !< The density at T=0, S=0, in kg m-3.
-  real,    intent(in)                :: dRho_dT, dRho_dS !< The derivatives of density with
-                                                  !! temperature and salinity, in kg m-3 C-1
-                                                  !! and kg m-3 psu-1.
-
-! *  This subroutine computes the in situ density of sea water (rho)   *
-! *  and the compressibility (drho/dp == C_sound^-2) at the given      *
-! *  salinity, potential temperature, and pressure.                    *
-! *                                                                    *
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in PSU.                                    *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     rho - in situ density in kg m-3.                        *
-! *  (out)     drho_dp - the partial derivative of density with        *
-! *                      pressure (also the inverse of the square of   *
-! *                      sound speed) in s2 m-2.                       *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
-! *  (in)      Rho_T0_S0 - The density at T=0, S=0, in kg m-3.         *
-! *  (in)      dRho_dT - The derivatives of density with temperature   *
-! *  (in)      dRho_dS - and salinity, in kg m-3 C-1 and kg m-3 psu-1. *
-
+  real,    intent(in)                :: dRho_dT   !< The derivative of density with
+                                                  !! temperature, in kg m-3 C-1.
+  real,    intent(in)                :: dRho_dS   !< The derivative of density with
+                                                  !! salinity, in kg m-3 psu-1.
+  !  Local variables
   integer :: j
 
   do j=start,start+npts-1
@@ -402,7 +350,7 @@ subroutine int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0_pres, G_e, HII, 
                                           !! same units as z_t
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
                                           !! interpolate T/S for top and bottom integrals.
-
+  ! Local variables
   real :: rho_anom      ! The density anomaly from rho_ref, in kg m-3.
   real :: raL, raR      ! rho_anom to the left and right, in kg m-3.
   real :: dz, dzL, dzR  ! Layer thicknesses in m.
@@ -525,7 +473,7 @@ subroutine int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0_pres, G_e, HII, 
   enddo ; enddo ; endif
 end subroutine int_density_dz_linear
 
-!>   This subroutine calculates analytical and nearly-analytical integrals in
+!> Calculates analytical and nearly-analytical integrals in
 !! pressure across layers of geopotential anomalies, which are required for
 !! calculating the finite-volume form pressure accelerations in a non-Boussinesq
 !! model.  Specific volume is assumed to vary linearly between adjacent points.
@@ -575,36 +523,7 @@ subroutine int_spec_vol_dp_linear(T, S, p_t, p_b, alpha_ref, HI, Rho_T0_S0, &
                                              !! the same units as p_t (Pa?)
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
                             !! to interpolate T/S for top and bottom integrals.
-
-!   This subroutine calculates analytical and nearly-analytical integrals in
-! pressure across layers of geopotential anomalies, which are required for
-! calculating the finite-volume form pressure accelerations in a non-Boussinesq
-! model.  Specific volume is assumed to vary linearly between adjacent points.
-!
-! Arguments: T - potential temperature relative to the surface in C.
-!  (in)      S - salinity in PSU.
-!  (in)      p_t - pressure at the top of the layer in Pa.
-!  (in)      p_b - pressure at the top of the layer in Pa.
-!  (in)      alpha_ref - A mean specific volume that is subtracted out to reduce
-!                        the magnitude of each of the integrals, m3 kg-1.
-!                        The calculation is mathematically identical with
-!                        different values of alpha_ref, but this reduces the
-!                        effects of roundoff.
-!  (in)      HI - The ocean's horizontal index type.
-!  (in)      Rho_T0_S0 - The density at T=0, S=0, in kg m-3.
-!  (in)      dRho_dT - The derivative of density with temperature in kg m-3 C-1.
-!  (in)      dRho_dS - The derivative of density with salinity, in kg m-3 psu-1.
-!  (out)     dza - The change in the geopotential anomaly across the layer,
-!                  in m2 s-2.
-!  (out,opt) intp_dza - The integral in pressure through the layer of the
-!                       geopotential anomaly relative to the anomaly at the
-!                       bottom of the layer, in Pa m2 s-2.
-!  (out,opt) intx_dza - The integral in x of the difference between the
-!                       geopotential anomaly at the top and bottom of the layer
-!                       divided by the x grid spacing, in m2 s-2.
-!  (out,opt) inty_dza - The integral in y of the difference between the
-!                       geopotential anomaly at the top and bottom of the layer
-!                       divided by the y grid spacing, in m2 s-2.
+  ! Local variables
   real :: dRho_TS       ! The density anomaly due to T and S, in kg m-3.
   real :: alpha_anom    ! The specific volume anomaly from 1/rho_ref, in m3 kg-1.
   real :: aaL, aaR      ! rho_anom to the left and right, in kg m-3.

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -78,7 +78,8 @@ contains
 subroutine chksum_pair_h_2d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, scale)
   character(len=*),                 intent(in) :: mesg !< Identifying messages
   type(hor_index_type),             intent(in) :: HI     !< A horizontal index type
-  real, dimension(HI%isd:,HI%jsd:), intent(in) :: arrayA, arrayB !< The arrays to be checksummed
+  real, dimension(HI%isd:,HI%jsd:), intent(in) :: arrayA !< The first array to be checksummed
+  real, dimension(HI%isd:,HI%jsd:), intent(in) :: arrayB !< The second array to be checksummed
   integer,                optional, intent(in) :: haloshift !< The width of halos to check (default 0)
   logical,                optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,                   optional, intent(in) :: scale     !< A scaling factor for this array.
@@ -96,7 +97,8 @@ end subroutine chksum_pair_h_2d
 subroutine chksum_pair_h_3d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, scale)
   character(len=*),                    intent(in) :: mesg !< Identifying messages
   type(hor_index_type),                intent(in) :: HI   !< A horizontal index type
-  real, dimension(HI%isd:,HI%jsd:, :), intent(in) :: arrayA, arrayB !< The arrays to be checksummed
+  real, dimension(HI%isd:,HI%jsd:, :), intent(in) :: arrayA !< The first array to be checksummed
+  real, dimension(HI%isd:,HI%jsd:, :), intent(in) :: arrayB !< The second array to be checksummed
   integer,                   optional, intent(in) :: haloshift !< The width of halos to check (default 0)
   logical,                   optional, intent(in) :: omit_corners !< If true, avoid checking diagonal shifts
   real,                      optional, intent(in) :: scale     !< A scaling factor for this array.
@@ -191,8 +193,9 @@ subroutine chksum_h_2d(array, mesg, HI, haloshift, omit_corners, scale)
   integer function subchk(array, HI, di, dj, scale)
     type(hor_index_type), intent(in) ::  HI     !< A horizontal index type
     real, dimension(HI%isd:,HI%jsd:), intent(in) :: array !< The array to be checksummed
-    integer, intent(in) :: di, dj  !< i- and j- direction array shifts for this checksum
-    real, intent(in) ::  scale     !< A scaling factor for this array.
+    integer, intent(in) :: di    !< i- direction array shift for this checksum
+    integer, intent(in) :: dj    !< j- direction array shift for this checksum
+    real, intent(in)    :: scale !< A scaling factor for this array.
     integer :: i, j, bc
     subchk = 0
     do j=HI%jsc+dj,HI%jec+dj; do i=HI%isc+di,HI%iec+di
@@ -234,7 +237,8 @@ end subroutine chksum_h_2d
 subroutine chksum_pair_B_2d(mesg, arrayA, arrayB, HI, haloshift, symmetric, omit_corners, scale)
   character(len=*),                 intent(in) :: mesg   !< Identifying messages
   type(hor_index_type),             intent(in) :: HI     !< A horizontal index type
-  real, dimension(HI%isd:,HI%jsd:), intent(in) :: arrayA, arrayB !< The arrays to be checksummed
+  real, dimension(HI%isd:,HI%jsd:), intent(in) :: arrayA !< The first array to be checksummed
+  real, dimension(HI%isd:,HI%jsd:), intent(in) :: arrayB !< The second array to be checksummed
   logical,                optional, intent(in) :: symmetric !< If true, do the checksums on the full
                                                             !! symmetric computational domain.
   integer,                optional, intent(in) :: haloshift !< The width of halos to check (default 0)
@@ -260,7 +264,8 @@ end subroutine chksum_pair_B_2d
 subroutine chksum_pair_B_3d(mesg, arrayA, arrayB, HI, haloshift, symmetric, omit_corners, scale)
   character(len=*),                    intent(in) :: mesg !< Identifying messages
   type(hor_index_type),                intent(in) :: HI     !< A horizontal index type
-  real, dimension(HI%IsdB:,HI%JsdB:, :), intent(in) :: arrayA, arrayB !< The arrays to be checksummed
+  real, dimension(HI%IsdB:,HI%JsdB:, :), intent(in) :: arrayA !< The first array to be checksummed
+  real, dimension(HI%IsdB:,HI%JsdB:, :), intent(in) :: arrayB !< The second array to be checksummed
   integer,                   optional, intent(in) :: haloshift !< The width of halos to check (default 0)
   logical,                   optional, intent(in) :: symmetric !< If true, do the checksums on the full
                                                                !! symmetric computational domain.
@@ -377,8 +382,9 @@ subroutine chksum_B_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   integer function subchk(array, HI, di, dj, scale)
     type(hor_index_type), intent(in) ::  HI     !< A horizontal index type
     real, dimension(HI%IsdB:,HI%JsdB:), intent(in) :: array !< The array to be checksummed
-    integer, intent(in) :: di, dj  !< i- and j- direction array shifts for this checksum
-    real, intent(in) ::  scale     !< A scaling factor for this array.
+    integer, intent(in) :: di    !< i- direction array shift for this checksum
+    integer, intent(in) :: dj    !< j- direction array shift for this checksum
+    real, intent(in)    :: scale !< A scaling factor for this array.
     integer :: i, j, bc
     subchk = 0
     ! This line deliberately uses the h-point computational domain.
@@ -565,8 +571,9 @@ subroutine chksum_u_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   integer function subchk(array, HI, di, dj, scale)
     type(hor_index_type), intent(in) ::  HI     !< A horizontal index type
     real, dimension(HI%IsdB:,HI%jsd:), intent(in) :: array !< The array to be checksummed
-    integer, intent(in) :: di, dj  !< i- and j- direction array shifts for this checksum
-    real, intent(in) ::  scale     !< A scaling factor for this array.
+    integer, intent(in) :: di    !< i- direction array shift for this checksum
+    integer, intent(in) :: dj    !< j- direction array shift for this checksum
+    real, intent(in)    :: scale !< A scaling factor for this array.
     integer :: i, j, bc
     subchk = 0
     ! This line deliberately uses the h-point computational domain.
@@ -710,8 +717,9 @@ subroutine chksum_v_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   integer function subchk(array, HI, di, dj, scale)
     type(hor_index_type), intent(in) ::  HI     !< A horizontal index type
     real, dimension(HI%isd:,HI%JsdB:), intent(in) :: array !< The array to be checksummed
-    integer, intent(in) :: di, dj  !< i- and j- direction array shifts for this checksum
-    real, intent(in) ::  scale     !< A scaling factor for this array.
+    integer, intent(in) :: di    !< i- direction array shift for this checksum
+    integer, intent(in) :: dj    !< j- direction array shift for this checksum
+    real, intent(in)    :: scale !< A scaling factor for this array.
     integer :: i, j, bc
     subchk = 0
     ! This line deliberately uses the h-point computational domain.
@@ -837,8 +845,9 @@ subroutine chksum_h_3d(array, mesg, HI, haloshift, omit_corners, scale)
   integer function subchk(array, HI, di, dj, scale)
     type(hor_index_type), intent(in) ::  HI     !< A horizontal index type
     real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: array !< The array to be checksummed
-    integer, intent(in) :: di, dj  !< i- and j- direction array shifts for this checksum
-    real, intent(in) ::  scale     !< A scaling factor for this array.
+    integer, intent(in) :: di    !< i- direction array shift for this checksum
+    integer, intent(in) :: dj    !< j- direction array shift for this checksum
+    real, intent(in)    :: scale !< A scaling factor for this array.
     integer :: i, j, k, bc
     subchk = 0
     do k=LBOUND(array,3),UBOUND(array,3) ; do j=HI%jsc+dj,HI%jec+dj ; do i=HI%isc+di,HI%iec+di
@@ -978,8 +987,9 @@ subroutine chksum_B_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   integer function subchk(array, HI, di, dj, scale)
     type(hor_index_type), intent(in) ::  HI     !< A horizontal index type
     real, dimension(HI%IsdB:,HI%JsdB:,:), intent(in) :: array !< The array to be checksummed
-    integer, intent(in) :: di, dj  !< i- and j- direction array shifts for this checksum
-    real, intent(in) ::  scale     !< A scaling factor for this array.
+    integer, intent(in) :: di    !< i- direction array shift for this checksum
+    integer, intent(in) :: dj    !< j- direction array shift for this checksum
+    real, intent(in)    :: scale !< A scaling factor for this array.
     integer :: i, j, k, bc
     subchk = 0
     ! This line deliberately uses the h-point computational domain.
@@ -1123,8 +1133,9 @@ subroutine chksum_u_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   integer function subchk(array, HI, di, dj, scale)
     type(hor_index_type), intent(in) ::  HI     !< A horizontal index type
     real, dimension(HI%IsdB:,HI%jsd:,:), intent(in) :: array !< The array to be checksummed
-    integer, intent(in) :: di, dj  !< i- and j- direction array shifts for this checksum
-    real, intent(in) ::  scale     !< A scaling factor for this array.
+    integer, intent(in) :: di    !< i- direction array shift for this checksum
+    integer, intent(in) :: dj    !< j- direction array shift for this checksum
+    real, intent(in)    :: scale !< A scaling factor for this array.
     integer :: i, j, k, bc
     subchk = 0
     ! This line deliberately uses the h-point computational domain.
@@ -1341,8 +1352,9 @@ subroutine chksum_v_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
   integer function subchk(array, HI, di, dj, scale)
     type(hor_index_type), intent(in) ::  HI     !< A horizontal index type
     real, dimension(HI%isd:,HI%JsdB:,:), intent(in) :: array !< The array to be checksummed
-    integer, intent(in) :: di, dj  !< i- and j- direction array shifts for this checksum
-    real, intent(in) ::  scale     !< A scaling factor for this array.
+    integer, intent(in) :: di    !< i- direction array shift for this checksum
+    integer, intent(in) :: dj    !< j- direction array shift for this checksum
+    real, intent(in)    :: scale !< A scaling factor for this array.
     integer :: i, j, k, bc
     subchk = 0
     ! This line deliberately uses the h-point computational domain.
@@ -1603,7 +1615,10 @@ subroutine chk_sum_msg5(fmsg,bc0,bcSW,bcSE,bcNW,bcNE,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
   character(len=*), intent(in) :: mesg !< An identifying message supplied by top-level caller
   integer,          intent(in) :: bc0  !< The bitcount of the non-shifted array
-  integer,          intent(in) :: bcSW,bcSE,bcNW,bcNE !< The bitcounts for 4 diagonal array shifts
+  integer,          intent(in) :: bcSW !< The bitcount for SW shifted array
+  integer,          intent(in) :: bcSE !< The bitcount for SE shifted array
+  integer,          intent(in) :: bcNW !< The bitcount for NW shifted array
+  integer,          intent(in) :: bcNE !< The bitcount for NE shifted array
   if (is_root_pe()) write(0,'(A,5(A,I10,1X),A)') &
      fmsg," c=",bc0,"sw=",bcSW,"se=",bcSE,"nw=",bcNW,"ne=",bcNE,trim(mesg)
 end subroutine chk_sum_msg5
@@ -1614,7 +1629,10 @@ subroutine chk_sum_msg_NSEW(fmsg,bc0,bcN,bcS,bcE,bcW,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
   character(len=*), intent(in) :: mesg !< An identifying message supplied by top-level caller
   integer,          intent(in) :: bc0  !< The bitcount of the non-shifted array
-  integer,          intent(in) :: bcN, bcS, bcE, bcW !< The bitcounts including 4 lateral array shifts
+  integer,          intent(in) :: bcN !< The bitcount for N shifted array
+  integer,          intent(in) :: bcS !< The bitcount for S shifted array
+  integer,          intent(in) :: bcE !< The bitcount for E shifted array
+  integer,          intent(in) :: bcW !< The bitcount for W shifted array
   if (is_root_pe()) write(0,'(A,5(A,I10,1X),A)') &
      fmsg," c=",bc0,"N=",bcN,"S=",bcS,"E=",bcE,"W=",bcW,trim(mesg)
 end subroutine chk_sum_msg_NSEW
@@ -1657,7 +1675,9 @@ end subroutine chk_sum_msg2
 subroutine chk_sum_msg3(fmsg,aMean,aMin,aMax,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
   character(len=*), intent(in) :: mesg !< An identifying message supplied by top-level caller
-  real,             intent(in) :: aMean,aMin,aMax !< The mean, minimum and maximum of the array
+  real,             intent(in) :: aMean !< The mean value of the array
+  real,             intent(in) :: aMin !< The minimum value of the array
+  real,             intent(in) :: aMax !< The maximum value of the array
   if (is_root_pe()) write(0,'(A,3(A,ES25.16,1X),A)') &
      fmsg," mean=",aMean,"min=",aMin,"max=",aMax,trim(mesg)
 end subroutine chk_sum_msg3

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -16,51 +16,62 @@ public :: hchksum_pair, uvchksum, Bchksum_pair
 public :: chksum_general
 public :: MOM_checksums_init
 
+!> Checksums a pair of arrays (2d or 3d) staggered at tracer points
 interface hchksum_pair
   module procedure chksum_pair_h_2d, chksum_pair_h_3d
 end interface
 
+!> Checksums a pair velocity arrays (2d or 3d) staggered at C-grid locations
 interface uvchksum
   module procedure chksum_uv_2d, chksum_uv_3d
 end interface
 
+!> Checksums an array (2d or 3d) staggered at C-grid u points.
 interface uchksum
   module procedure chksum_u_2d, chksum_u_3d
 end interface
 
+!> Checksums an array (2d or 3d) staggered at C-grid v points.
 interface vchksum
   module procedure chksum_v_2d, chksum_v_3d
 end interface
 
+!> Checksums a pair of arrays (2d or 3d) staggered at corner points
 interface Bchksum_pair
   module procedure chksum_pair_B_2d, chksum_pair_B_3d
 end interface
 
+!> Checksums an array (2d or 3d) staggered at tracer points.
 interface hchksum
   module procedure chksum_h_2d, chksum_h_3d
 end interface
 
+!> Checksums an array (2d or 3d) staggered at corner points.
 interface Bchksum
   module procedure chksum_B_2d, chksum_B_3d
 end interface
 
-! This is an older interface that has been renamed Bchksum
+!> This is an older interface that has been renamed Bchksum
 interface qchksum
   module procedure chksum_B_2d, chksum_B_3d
 end interface
 
+!> This is an older interface for 1-, 2-, or 3-D checksums
 interface chksum
   module procedure chksum1d, chksum2d, chksum3d
 end interface
 
+!> Write a message with either checksums or numerical statistics of arrays
 interface chk_sum_msg
   module procedure chk_sum_msg1, chk_sum_msg2, chk_sum_msg3, chk_sum_msg5
 end interface
 
+!> Returns .true. if any element of x is a NaN, and .false. otherwise.
 interface is_NaN
   module procedure is_NaN_0d, is_NaN_1d, is_NaN_2d, is_NaN_3d
 end interface
 
+!> Return the bitcount of an array
 interface chksum_general
   module procedure chksum_general_1d, chksum_general_2d, chksum_general_3d
 end interface
@@ -73,8 +84,7 @@ logical :: checkForNaNs=.true. ! If true, checks array for NaNs and cause
 
 contains
 
-! =====================================================================
-
+!> Checksums on a pair of 2d arrays staggered at tracer points.
 subroutine chksum_pair_h_2d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, scale)
   character(len=*),                 intent(in) :: mesg !< Identifying messages
   type(hor_index_type),             intent(in) :: HI     !< A horizontal index type
@@ -94,6 +104,7 @@ subroutine chksum_pair_h_2d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, s
 
 end subroutine chksum_pair_h_2d
 
+!> Checksums on a pair of 3d arrays staggered at tracer points.
 subroutine chksum_pair_h_3d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, scale)
   character(len=*),                    intent(in) :: mesg !< Identifying messages
   type(hor_index_type),                intent(in) :: HI   !< A horizontal index type
@@ -113,7 +124,7 @@ subroutine chksum_pair_h_3d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, s
 
 end subroutine chksum_pair_h_3d
 
-!> chksum_h_2d performs checksums on a 2d array staggered at tracer points.
+!> Checksums a 2d array staggered at tracer points.
 subroutine chksum_h_2d(array, mesg, HI, haloshift, omit_corners, scale)
   type(hor_index_type),            intent(in) :: HI     !< A horizontal index type
   real, dimension(HI%isd:,HI%jsd:), intent(in) :: array !< The array to be checksummed
@@ -232,8 +243,7 @@ subroutine chksum_h_2d(array, mesg, HI, haloshift, omit_corners, scale)
 
 end subroutine chksum_h_2d
 
-! =====================================================================
-
+!> Checksums on a pair of 2d arrays staggered at q-points.
 subroutine chksum_pair_B_2d(mesg, arrayA, arrayB, HI, haloshift, symmetric, omit_corners, scale)
   character(len=*),                 intent(in) :: mesg   !< Identifying messages
   type(hor_index_type),             intent(in) :: HI     !< A horizontal index type
@@ -261,6 +271,7 @@ subroutine chksum_pair_B_2d(mesg, arrayA, arrayB, HI, haloshift, symmetric, omit
 
 end subroutine chksum_pair_B_2d
 
+!> Checksums on a pair of 3d arrays staggered at q-points.
 subroutine chksum_pair_B_3d(mesg, arrayA, arrayB, HI, haloshift, symmetric, omit_corners, scale)
   character(len=*),                    intent(in) :: mesg !< Identifying messages
   type(hor_index_type),                intent(in) :: HI     !< A horizontal index type
@@ -286,7 +297,7 @@ subroutine chksum_pair_B_3d(mesg, arrayA, arrayB, HI, haloshift, symmetric, omit
 
 end subroutine chksum_pair_B_3d
 
-!> chksum_B_2d performs checksums on a 2d array staggered at corner points.
+!> Checksums a 2d array staggered at corner points.
 subroutine chksum_B_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scale)
   type(hor_index_type), intent(in) :: HI     !< A horizontal index type
   real, dimension(HI%IsdB:,HI%JsdB:), &
@@ -426,8 +437,7 @@ subroutine chksum_B_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 
 end subroutine chksum_B_2d
 
-! =====================================================================
-
+!> Checksums a pair of 2d velocity arrays staggered at C-grid locations
 subroutine chksum_uv_2d(mesg, arrayU, arrayV, HI, haloshift, symmetric, omit_corners, scale)
   character(len=*),                  intent(in) :: mesg   !< Identifying messages
   type(hor_index_type),              intent(in) :: HI     !< A horizontal index type
@@ -449,6 +459,7 @@ subroutine chksum_uv_2d(mesg, arrayU, arrayV, HI, haloshift, symmetric, omit_cor
 
 end subroutine chksum_uv_2d
 
+!> Checksums a pair of 3d velocity arrays staggered at C-grid locations
 subroutine chksum_uv_3d(mesg, arrayU, arrayV, HI, haloshift, symmetric, omit_corners, scale)
   character(len=*),                    intent(in) :: mesg   !< Identifying messages
   type(hor_index_type),                intent(in) :: HI     !< A horizontal index type
@@ -470,7 +481,7 @@ subroutine chksum_uv_3d(mesg, arrayU, arrayV, HI, haloshift, symmetric, omit_cor
 
 end subroutine chksum_uv_3d
 
-!> chksum_u_2d performs checksums on a 2d array staggered at C-grid u points.
+!> Checksums a 2d array staggered at C-grid u points.
 subroutine chksum_u_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scale)
   type(hor_index_type),           intent(in) :: HI     !< A horizontal index type
   real, dimension(HI%IsdB:,HI%jsd:), intent(in) :: array !< The array to be checksummed
@@ -614,9 +625,7 @@ subroutine chksum_u_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 
 end subroutine chksum_u_2d
 
-! =====================================================================
-
-!> chksum_v_2d performs checksums on a 2d array staggered at C-grid v points.
+!> Checksums a 2d array staggered at C-grid v points.
 subroutine chksum_v_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scale)
   type(hor_index_type),           intent(in) :: HI     !< A horizontal index type
   real, dimension(HI%isd:,HI%JsdB:), intent(in) :: array !< The array to be checksummed
@@ -760,9 +769,7 @@ subroutine chksum_v_2d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 
 end subroutine chksum_v_2d
 
-! =====================================================================
-
-!> chksum_h_3d performs checksums on a 3d array staggered at tracer points.
+!> Checksums a 3d array staggered at tracer points.
 subroutine chksum_h_3d(array, mesg, HI, haloshift, omit_corners, scale)
   type(hor_index_type),             intent(in) :: HI !< A horizontal index type
   real, dimension(HI%isd:,HI%jsd:,:),  intent(in) :: array !< The array to be checksummed
@@ -884,9 +891,7 @@ subroutine chksum_h_3d(array, mesg, HI, haloshift, omit_corners, scale)
 
 end subroutine chksum_h_3d
 
-! =====================================================================
-
-!> chksum_B_3d performs checksums on a 3d array staggered at corner points.
+!> Checksums a 3d array staggered at corner points.
 subroutine chksum_B_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scale)
   type(hor_index_type),              intent(in) :: HI !< A horizontal index type
   real, dimension(HI%IsdB:,HI%JsdB:,:), intent(in) :: array !< The array to be checksummed
@@ -1030,9 +1035,7 @@ subroutine chksum_B_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 
 end subroutine chksum_B_3d
 
-! =====================================================================
-
-!> chksum_u_3d performs checksums on a 3d array staggered at C-grid u points.
+!> Checksums a 3d array staggered at C-grid u points.
 subroutine chksum_u_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scale)
   type(hor_index_type),             intent(in) :: HI !< A horizontal index type
   real, dimension(HI%isdB:,HI%Jsd:,:), intent(in) :: array !< The array to be checksummed
@@ -1176,7 +1179,6 @@ subroutine chksum_u_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 
 end subroutine chksum_u_3d
 
-!---chksum_general interface routines
 !> Return the bitcount of an arbitrarily sized 3d array
 integer function chksum_general_3d( array, scale_factor, istart, iend, jstart, jend, kstart, kend ) &
                             result(subchk)
@@ -1249,9 +1251,7 @@ integer function chksum_general_1d( array_1d, scale_factor, istart, iend )
   deallocate(array_3d)
 end function chksum_general_1d
 
-! =====================================================================
-
-!> chksum_v_3d performs checksums on a 3d array staggered at C-grid v points.
+!> Checksums a 3d array staggered at C-grid v points.
 subroutine chksum_v_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scale)
   type(hor_index_type),             intent(in) :: HI !< A horizontal index type
   real, dimension(HI%isd:,HI%JsdB:,:), intent(in) :: array !< The array to be checksummed
@@ -1395,9 +1395,6 @@ subroutine chksum_v_3d(array, mesg, HI, haloshift, symmetric, omit_corners, scal
 
 end subroutine chksum_v_3d
 
-
-! =====================================================================
-
 !   These are the older version of chksum that do not take the grid staggering
 ! into account.
 
@@ -1456,7 +1453,6 @@ subroutine chksum1d(array, mesg, start_i, end_i, compare_PEs)
 
 end subroutine chksum1d
 
-! =====================================================================
 !   These are the older version of chksum that do not take the grid staggering
 ! into account.
 
@@ -1517,8 +1513,6 @@ subroutine chksum3d(array, mesg)
 
 end subroutine chksum3d
 
-! =====================================================================
-
 !> This function returns .true. if x is a NaN, and .false. otherwise.
 function is_NaN_0d(x)
   real, intent(in) :: x !< The value to be checked for NaNs.
@@ -1535,9 +1529,7 @@ function is_NaN_0d(x)
 
 end function is_NaN_0d
 
-! =====================================================================
-
-!> This function returns .true. if any element of x is a NaN, and .false. otherwise.
+!> Returns .true. if any element of x is a NaN, and .false. otherwise.
 function is_NaN_1d(x, skip_mpp)
   real, dimension(:), intent(in) :: x !< The array to be checked for NaNs.
   logical,  optional, intent(in) :: skip_mpp  !< If true, only check this array only
@@ -1560,9 +1552,7 @@ function is_NaN_1d(x, skip_mpp)
 
 end function is_NaN_1d
 
-! =====================================================================
-
-!> This function returns .true. if any element of x is a NaN, and .false. otherwise.
+!> Returns .true. if any element of x is a NaN, and .false. otherwise.
 function is_NaN_2d(x)
   real, dimension(:,:), intent(in) :: x !< The array to be checked for NaNs.
   logical :: is_NaN_2d
@@ -1579,9 +1569,7 @@ function is_NaN_2d(x)
 
 end function is_NaN_2d
 
-! =====================================================================
-
-!> This function returns .true. if any element of x is a NaN, and .false. otherwise.
+!> Returns .true. if any element of x is a NaN, and .false. otherwise.
 function is_NaN_3d(x)
   real, dimension(:,:,:), intent(in) :: x !< The array to be checked for NaNs.
   logical :: is_NaN_3d
@@ -1600,7 +1588,6 @@ function is_NaN_3d(x)
 
 end function is_NaN_3d
 
-! =====================================================================
 !> Write a message including the checksum of the non-shifted array
 subroutine chk_sum_msg1(fmsg,bc0,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
@@ -1609,7 +1596,6 @@ subroutine chk_sum_msg1(fmsg,bc0,mesg)
   if (is_root_pe()) write(0,'(A,1(A,I10,X),A)') fmsg," c=",bc0,trim(mesg)
 end subroutine chk_sum_msg1
 
-! =====================================================================
 !> Write a message including checksums of non-shifted and diagonally shifted arrays
 subroutine chk_sum_msg5(fmsg,bc0,bcSW,bcSE,bcNW,bcNE,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
@@ -1623,7 +1609,6 @@ subroutine chk_sum_msg5(fmsg,bc0,bcSW,bcSE,bcNW,bcNE,mesg)
      fmsg," c=",bc0,"sw=",bcSW,"se=",bcSE,"nw=",bcNW,"ne=",bcNE,trim(mesg)
 end subroutine chk_sum_msg5
 
-! =====================================================================
 !> Write a message including checksums of non-shifted and laterally shifted arrays
 subroutine chk_sum_msg_NSEW(fmsg,bc0,bcN,bcS,bcE,bcW,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
@@ -1637,7 +1622,6 @@ subroutine chk_sum_msg_NSEW(fmsg,bc0,bcN,bcS,bcE,bcW,mesg)
      fmsg," c=",bc0,"N=",bcN,"S=",bcS,"E=",bcE,"W=",bcW,trim(mesg)
 end subroutine chk_sum_msg_NSEW
 
-! =====================================================================
 !> Write a message including checksums of non-shifted and southward shifted arrays
 subroutine chk_sum_msg_S(fmsg,bc0,bcS,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
@@ -1648,7 +1632,6 @@ subroutine chk_sum_msg_S(fmsg,bc0,bcS,mesg)
      fmsg," c=",bc0,"S=",bcS,trim(mesg)
 end subroutine chk_sum_msg_S
 
-! =====================================================================
 !> Write a message including checksums of non-shifted and westward shifted arrays
 subroutine chk_sum_msg_W(fmsg,bc0,bcW,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
@@ -1659,7 +1642,6 @@ subroutine chk_sum_msg_W(fmsg,bc0,bcW,mesg)
      fmsg," c=",bc0,"W=",bcW,trim(mesg)
 end subroutine chk_sum_msg_W
 
-! =====================================================================
 !> Write a message including checksums of non-shifted and southwestward shifted arrays
 subroutine chk_sum_msg2(fmsg,bc0,bcSW,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
@@ -1670,7 +1652,6 @@ subroutine chk_sum_msg2(fmsg,bc0,bcSW,mesg)
      fmsg," c=",bc0,"s/w=",bcSW,trim(mesg)
 end subroutine chk_sum_msg2
 
-! =====================================================================
 !> Write a message including the global mean, maximum and minimum of an array
 subroutine chk_sum_msg3(fmsg,aMean,aMin,aMax,mesg)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
@@ -1681,8 +1662,6 @@ subroutine chk_sum_msg3(fmsg,aMean,aMin,aMax,mesg)
   if (is_root_pe()) write(0,'(A,3(A,ES25.16,1X),A)') &
      fmsg," mean=",aMean,"min=",aMin,"max=",aMax,trim(mesg)
 end subroutine chk_sum_msg3
-
-! =====================================================================
 
 !> MOM_checksums_init initializes the MOM_checksums module. As it happens, the
 !! only thing that it does is to log the version of this module.
@@ -1696,7 +1675,6 @@ subroutine MOM_checksums_init(param_file)
 
 end subroutine MOM_checksums_init
 
-! =====================================================================
 !> A wrapper for MOM_error used in the checksum code
 subroutine chksum_error(signal, message)
   ! Wrapper for MOM_error to help place specific break points in debuggers
@@ -1723,6 +1701,5 @@ integer function bitcount( x )
   enddo
 
 end function bitcount
-! =====================================================================
 
 end module MOM_checksums

--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -456,7 +456,7 @@ end function ints_to_real
 subroutine increment_ints(int_sum, int2, prec_error)
   integer(kind=8), dimension(ni), intent(inout) :: int_sum !< The array of EFP integers being incremented
   integer(kind=8), dimension(ni), intent(in)    :: int2    !< The array of EFP integers being added
-  integer(kind=8), optional,      intent(in)    :: prec_error  !!< The PE-count dependent precision of the
+  integer(kind=8), optional,      intent(in)    :: prec_error !< The PE-count dependent precision of the
                                               !! integers that is safe from overflows during global
                                               !! sums.  This will be larger than the compile-time
                                               !! precision parameter, and is used to detect overflows.

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -225,7 +225,9 @@ subroutine diag_remap_update(remap_cs, G, GV, h, T, S, eqn_of_state)
   type(diag_remap_ctrl), intent(inout) :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),    pointer    :: G  !< The ocean's grid type
   type(verticalGrid_type),  intent(in) :: GV !< ocean vertical grid structure
-  real, dimension(:, :, :), intent(in) :: h, T, S !< New thickness, T and S
+  real, dimension(:, :, :), intent(in) :: h  !< New thickness
+  real, dimension(:, :, :), intent(in) :: T  !< New T
+  real, dimension(:, :, :), intent(in) :: S  !< New S
   type(EOS_type),           pointer    :: eqn_of_state !< A pointer to the equation of state
 
   ! Local variables

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -2002,43 +2002,40 @@ subroutine clone_MD_to_d2D(MD_in, mpp_domain, min_halo, halo_size, symmetric, &
 
 end subroutine clone_MD_to_d2D
 
-!> get_domain_extent returns various data that has been stored in a MOM_domain_type.
+!> Returns various data that has been stored in a MOM_domain_type
 subroutine get_domain_extent(Domain, isc, iec, jsc, jec, isd, ied, jsd, jed, &
                              isg, ieg, jsg, jeg, idg_offset, jdg_offset, &
                              symmetric, local_indexing, index_offset)
   type(MOM_domain_type), &
-           intent(in)  :: Domain                 !< The MOM domain from which to extract information
-  integer, intent(out) :: isc, iec, jsc, jec     !< The start & end indices of the computational
-                                                 !! domain.
-  integer, intent(out) :: isd, ied, jsd, jed     !< The start & end indices of the data domain.
-  integer, intent(out) :: isg, ieg, jsg, jeg     !< The start & end indices of the global domain.
-  integer, intent(out) :: idg_offset, jdg_offset !< The offset between the corresponding global and
-                                                 !! data index spaces.
-  logical, intent(out) :: symmetric              !< True if symmetric memory is used.
+           intent(in)  :: Domain         !< The MOM domain from which to extract information
+  integer, intent(out) :: isc            !< The start i-index of the computational domain
+  integer, intent(out) :: iec            !< The end i-index of the computational domain
+  integer, intent(out) :: jsc            !< The start j-index of the computational domain
+  integer, intent(out) :: jec            !< The end j-index of the computational domain
+  integer, intent(out) :: isd            !< The start i-index of the data domain
+  integer, intent(out) :: ied            !< The end i-index of the data domain
+  integer, intent(out) :: jsd            !< The start j-index of the data domain
+  integer, intent(out) :: jed            !< The end j-index of the data domain
+  integer, intent(out) :: isg            !< The start i-index of the global domain
+  integer, intent(out) :: ieg            !< The end i-index of the global domain
+  integer, intent(out) :: jsg            !< The start j-index of the global domain
+  integer, intent(out) :: jeg            !< The end j-index of the global domain
+  integer, intent(out) :: idg_offset     !< The offset between the corresponding global and
+                                         !! data i-index spaces.
+  integer, intent(out) :: jdg_offset     !< The offset between the corresponding global and
+                                         !! data j-index spaces.
+  logical, intent(out) :: symmetric      !< True if symmetric memory is used.
   logical, optional, &
-            intent(in) :: local_indexing         !< If true, local tracer array indices start at 1,
-                                                 !! as in most MOM6 or GOLD code.
+           intent(in)  :: local_indexing !< If true, local tracer array indices start at 1,
+                                         !! as in most MOM6 code.
   integer, optional, &
-            intent(in) :: index_offset           !< A fixed additional offset to all indices. This
-                                                 !! can be useful for some types of debugging with
-                                                 !! dynamic memory allocation.
-
-! Arguments: Domain - The MOM_domain_type from which the indices are extracted.
-!  (out)     isc, iec, jsc, jec - the start & end indices of the
-!                                 computational domain.
-!  (out)     isd, ied, jsd, jed - the start & end indices of the data domain.
-!  (out)     isg, ieg, jsg, jeg - the start & end indices of the global domain.
-!  (out)     idg_offset, jdg_offset - the offset between the corresponding
-!                                     global and data index spaces.
-!  (out)     symmetric - true if symmetric memory is used.
-!  (in,opt)  local_indexing - if true, local tracer array indices start at 1, as
-!                             in most MOM6 or GOLD code.
-!  (in,opt)  index_offset - A fixed additional offset to all indices.  This can
-!                           be useful for some types of debugging with dynamic
-!                           memory allocation.
-
+           intent(in)  :: index_offset   !< A fixed additional offset to all indices. This
+                                         !! can be useful for some types of debugging with
+                                         !! dynamic memory allocation.
+  ! Local variables
   integer :: ind_off
   logical :: local
+
   local = .true. ; if (present(local_indexing)) local = local_indexing
   ind_off = 0 ; if (present(index_offset)) ind_off = index_offset
 

--- a/src/framework/MOM_memory_macros.h
+++ b/src/framework/MOM_memory_macros.h
@@ -7,127 +7,185 @@
 !//! \file MOM_memory_macros.h
 
 #ifdef STATIC_MEMORY_
+!/* Static memory allocation section */
+
+!/// Deallocates array x when using dynamic memory mode. Does nothing in static memory mode.
 #  define DEALLOC_(x)
+!/// Allocates array x when using dynamic memory mode. Does nothing in static memory mode.
 #  define ALLOC_(x)
+!/// Attaches the ALLOCATABLE attribute to an array in dynamic memory mode. Does nothing in static memory mode.
 #  define ALLOCABLE_
+!/// Attaches the POINTER attribute to an array in dynamic memory mode. Does nothing in static memory mode.
 #  define PTR_
+!/// Nullify a pointer in dynamic memory mode. Does nothing in static memory mode.
 #  define TO_NULL_
 
-! NIMEM and NJMEM are the maximum number of grid points in the
-! x- and y-directions on each processsor.
+!/* These are the macros that should be used when setting up ALLOCABLE_ or PTR_ (heap) variables. */
+
+!/// Expands to : in dynamic memory mode, or is the i-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at h- or v- points.
 #  define NIMEM_ (((NIGLOBAL_-1)/NIPROC_)+1+2*NIHALO_)
+!/// Expands to : in dynamic memory mode, or is the j-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at h- or u- points.
 #  define NJMEM_ (((NJGLOBAL_-1)/NJPROC_)+1+2*NJHALO_)
 
-! These are the macros that should be used when setting up ALLOCABLE_ or
-! PTR_ (heap) variables.
 #  ifdef SYMMETRIC_MEMORY_
+!/// Expands to : or 0: in dynamic memory mode, or is the staggered i-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at q- or u- points.
 #    define NIMEMB_   0:NIMEM_
+!/// Expands to : or 0: in dynamic memory mode, or is the staggered j-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at q- or v- points.
 #    define NJMEMB_   0:NJMEM_
 #  else
+!/// Expands to : or 0: in dynamic memory mode, or is the staggered i-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at q- or u- points.
 #    define NIMEMB_   NIMEM_
+!/// Expands to : or 0: in dynamic memory mode, or is the staggered j-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at q- or v- points.
 #    define NJMEMB_   NJMEM_
 #  endif
+!/// Expands to : in dynamic memory mode, or to NIMEMB_ in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at h- or v- points.
 #  define NIMEMB_PTR_ NIMEMB_
+!/// Expands to : in dynamic memory mode, or to NJMEMB_ in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at h- or u- points.
 #  define NJMEMB_PTR_ NJMEMB_
+!/// Expands to 0: in dynamic memory mode, or is the staggered i-shape of a tile in static memory mode.
+!/// Use for always-symmetric heap (ALLOCABLE_ or PTR_) variables at q- or u- points.
 #  define NIMEMB_SYM_ 0:NIMEM_
+!/// Expands to 0: in dynamic memory mode, or is the staggered j-shape of a tile in static memory mode.
+!/// Use for always-symmetric heap (ALLOCABLE_ or PTR_) variables at q- or v- points.
 #  define NJMEMB_SYM_ 0:NJMEM_
+!/// Expands to : in dynamic memory mode or is to the number of layers in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) layer variables.
 #  define NKMEM_      NK_
+!/// Expands to 0: in dynamic memory mode or to 0:NK_ in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) interface variables.
 #  define NKMEM0_     0:NK_
+!/// Expands to : in dynamic memory mode or to NK_+1 in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) interface variables.
 #  define NK_INTERFACE_ NK_+1
+!/// Expands to : or 1. UNKNOWN PURPOSE!
 #  define C1_         1
+!/// Expands to : or 2. UNKNOWN PURPOSE!
 #  define C2_         2
+!/// Expands to : or 3. UNKNOWN PURPOSE!
 #  define C3_         3
-! These are the macros that should be used for subroutine arguments
-! or for automatically allocated (stack) variables.
+
+!/* These are the macros that should be used for subroutine arguments or for automatically allocated (stack) variables. */
+
+!/// The i-shape of a dummy argument staggered at h- or v-points.
 #  define SZI_(G)     NIMEM_
+!/// The j-shape of a dummy argument staggered at h- or u-points.
 #  define SZJ_(G)     NJMEM_
+!/// The k-shape of a layer dummy argument.
 #  define SZK_(G)     NK_
+!/// The k-shape of an interface dummy argument.
 #  define SZK0_(G)    0:NK_
+!/// The i-shape of a dummy argument staggered at q- or u-points.
 #  define SZIB_(G)    NIMEMB_
+!/// The j-shape of a dummy argument staggered at q- or v-points.
 #  define SZJB_(G)    NJMEMB_
+!/// The i-shape of a symmetric dummy argument staggered at q- or u-points.
 #  define SZIBS_(G)   0:NIMEM_
+!/// The j-shape of a symmetric dummy argument staggered at q- or v-points.
 #  define SZJBS_(G)   0:NJMEM_
 
 #else
 !/* Dynamic memory allocation section */
 
-!/*! Deallocates array x when using dynamic memory mode. Does nothing in static memory mode.*/
+!/// Deallocates array x when using dynamic memory mode. Does nothing in static memory mode.
 #  define DEALLOC_(x) deallocate(x)
-!/*! Allocates array x when using dynamic memory mode. Does nothing in static memory mode.*/
+!/// Allocates array x when using dynamic memory mode. Does nothing in static memory mode.
 #  define ALLOC_(x)   allocate(x)
-!/*! Attaches the ALLOCATABLE attribute to an array in dynamic memory mode. Does nothing in static memory mode.*/
+!/// Attaches the ALLOCATABLE attribute to an array in dynamic memory mode. Does nothing in static memory mode.
 #  define ALLOCABLE_ ,allocatable
-!/*! Attaches the POINTER attribute to an array in dynamic memory mode. Does nothing in static memory mode.*/
+!/// Attaches the POINTER attribute to an array in dynamic memory mode. Does nothing in static memory mode.
 #  define PTR_       ,pointer
-!/*! Nullify a pointer in dynamic memory mode. Does nothing in static memory mode.*/
+!/// Nullify a pointer in dynamic memory mode. Does nothing in static memory mode.
 #  define TO_NULL_   =>NULL()
 
 !/* These are the macros that should be used when setting up ALLOCABLE_ or PTR_ (heap) variables. */
 
-!/*! Expands to : in dynamic memory mode, or is the i-shape of a tile in static memory mode. Use for heap (ALLOCABLE_ or PTR_) variables at h- or v- points. */
+!/// Expands to : in dynamic memory mode, or is the i-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at h- or v- points.
 #  define NIMEM_      :
-!/*! Expands to : in dynamic memory mode, or is the j-shape of a tile in static memory mode. Use for heap (ALLOCABLE_ or PTR_) variables at h- or u- points. */
+!/// Expands to : in dynamic memory mode, or is the j-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at h- or u- points.
 #  define NJMEM_      :
-!/*! Expands to : in dynamic memory mode, or to NIMEMB_ in static memory mode. Use for heap (ALLOCABLE_ or PTR_) variables at h- or v- points. */
+!/// Expands to : in dynamic memory mode, or to NIMEMB_ in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at h- or v- points.
 #  define NIMEMB_PTR_ :
-!/*! Expands to : in dynamic memory mode, or to NJMEMB_ in static memory mode. Use for heap (ALLOCABLE_ or PTR_) variables at h- or u- points. */
+!/// Expands to : in dynamic memory mode, or to NJMEMB_ in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at h- or u- points.
 #  define NJMEMB_PTR_ :
 #  ifdef SYMMETRIC_MEMORY_
-!/*! Expands to : or 0: in dynamic memory mode, or is the staggered i-shape of a tile in static memory mode. Use for heap (ALLOCABLE_ or PTR_) variables at q- or u- points. */
+!/// Expands to : or 0: in dynamic memory mode, or is the staggered i-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at q- or u- points.
 #    define NIMEMB_   0:
-!/*! Expands to : or 0: in dynamic memory mode, or is the staggered j-shape of a tile in static memory mode. Use for heap (ALLOCABLE_ or PTR_) variables at q- or v- points. */
+!/// Expands to : or 0: in dynamic memory mode, or is the staggered j-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at q- or v- points.
 #    define NJMEMB_   0:
 #  else
+!/// Expands to : or 0: in dynamic memory mode, or is the staggered i-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at q- or u- points.
 #    define NIMEMB_   :
+!/// Expands to : or 0: in dynamic memory mode, or is the staggered j-shape of a tile in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) variables at q- or v- points.
 #    define NJMEMB_   :
 #  endif
-!/*! Expands to 0: in dynamic memory mode, or is the staggered i-shape of a tile in static memory mode. Use for always-symmetric heap (ALLOCABLE_ or PTR_) variables at q- or u- points. */
+!/// Expands to 0: in dynamic memory mode, or is the staggered i-shape of a tile in static memory mode.
+!/// Use for always-symmetric heap (ALLOCABLE_ or PTR_) variables at q- or u- points.
 #  define NIMEMB_SYM_ 0:
-!/*! Expands to 0: in dynamic memory mode, or is the staggered j-shape of a tile in static memory mode. Use for always-symmetric heap (ALLOCABLE_ or PTR_) variables at q- or v- points. */
+!/// Expands to 0: in dynamic memory mode, or is the staggered j-shape of a tile in static memory mode.
+!/// Use for always-symmetric heap (ALLOCABLE_ or PTR_) variables at q- or v- points.
 #  define NJMEMB_SYM_ 0:
-!/*! Expands to : in dynamic memory mode or is to the number of layers in static memory mode. Use for heap (ALLOCABLE_ or PTR_) layer variables. */
+!/// Expands to : in dynamic memory mode or is to the number of layers in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) layer variables.
 #  define NKMEM_      :
-!/*! Expands to 0: in dynamic memory mode or to 0:NK_ in static memory mode. Use for heap (ALLOCABLE_ or PTR_) interface variables. */
+!/// Expands to 0: in dynamic memory mode or to 0:NK_ in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) interface variables.
 #  define NKMEM0_     0:
-!/*! Expands to : in dynamic memory mode or to NK_+1 in static memory mode. Use for heap (ALLOCABLE_ or PTR_) interface variables. */
+!/// Expands to : in dynamic memory mode or to NK_+1 in static memory mode.
+!/// Use for heap (ALLOCABLE_ or PTR_) interface variables.
 #  define NK_INTERFACE_  :
-!/*! Expands to : or 1. UNKNOWN PURPOSE! */
+!/// Expands to : or 1. UNKNOWN PURPOSE!
 #  define C1_         :
-!/*! Expands to : or 2. UNKNOWN PURPOSE! */
+!/// Expands to : or 2. UNKNOWN PURPOSE!
 #  define C2_         :
-!/*! Expands to : or 3. UNKNOWN PURPOSE! */
+!/// Expands to : or 3. UNKNOWN PURPOSE!
 #  define C3_         :
 
-!/*! \todo Explain or remove C1_, C2_ and C3_ */
+!/// \todo Explain or remove C1_, C2_ and C3_
 
 !/* These are the macros that should be used for subroutine arguments or for automatically allocated (stack) variables. */
 
-!/*! The i-shape of a dummy argument staggered at h- or v-points. */
+!/// The i-shape of a dummy argument staggered at h- or v-points.
 #  define SZI_(G)     G%isd:G%ied
-!/*! The j-shape of a dummy argument staggered at h- or u-points. */
+!/// The j-shape of a dummy argument staggered at h- or u-points.
 #  define SZJ_(G)     G%jsd:G%jed
-!/*! The k-shape of a layer dummy argument. */
+!/// The k-shape of a layer dummy argument.
 #  define SZK_(G)     G%ke
-!/*! The k-shape of an interface dummy argument. */
+!/// The k-shape of an interface dummy argument.
 #  define SZK0_(G)    0:G%ke
-!/*! The i-shape of a dummy argument staggered at q- or u-points. */
+!/// The i-shape of a dummy argument staggered at q- or u-points.
 #  define SZIB_(G)    G%IsdB:G%IedB
-!/*! The j-shape of a dummy argument staggered at q- or v-points. */
+!/// The j-shape of a dummy argument staggered at q- or v-points.
 #  define SZJB_(G)    G%JsdB:G%JedB
-!/*! The i-shape of a symmetric dummy argument staggered at q- or u-points. */
+!/// The i-shape of a symmetric dummy argument staggered at q- or u-points.
 #  define SZIBS_(G)   G%isd-1:G%ied
-!/*! The j-shape of a symmetric dummy argument staggered at q- or v-points. */
+!/// The j-shape of a symmetric dummy argument staggered at q- or v-points.
 #  define SZJBS_(G)   G%jsd-1:G%jed
 
 #endif
 
 !/* These dynamic size macros always give the same results (for now). */
 
-!/*! The i-shape of a dynamic dummy argument staggered at h- or v-points. */
+!/// The i-shape of a dynamic dummy argument staggered at h- or v-points.
 #define SZDI_(G)  G%isd:G%ied
-!/*! The i-shape of a dynamic dummy argument staggered at q- or u-points. */
+!/// The i-shape of a dynamic dummy argument staggered at q- or u-points.
 #define SZDIB_(G) G%IsdB:G%IedB
-!/*! The j-shape of a dynamic dummy argument staggered at h- or u-points. */
+!/// The j-shape of a dynamic dummy argument staggered at h- or u-points.
 #define SZDJ_(G)  G%jsd:G%jed
-!/*! The j-shape of a dynamic dummy argument staggered at q- or v-points. */
+!/// The j-shape of a dynamic dummy argument staggered at q- or v-points.
 #define SZDJB_(G) G%JsdB:G%JedB

--- a/src/framework/MOM_safe_alloc.F90
+++ b/src/framework/MOM_safe_alloc.F90
@@ -1,14 +1,8 @@
+!> Convenience functions for safely allocating memory without
+!! accidentally reallocating pointer and causing memory leaks.
 module MOM_safe_alloc
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*    The subroutines here provide a convenient way to safely allocate *
-!*  memory without accidentally reallocating a pointer and causing a   *
-!*  memory leak.                                                       *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 
 implicit none ; private
 
@@ -54,7 +48,8 @@ end subroutine safe_alloc_ptr_1d
 !> Allocate a pointer to a 2-d array based on its dimension sizes
 subroutine safe_alloc_ptr_2d_2arg(ptr, ni, nj)
   real, dimension(:,:), pointer :: ptr !< A pointer to allocate
-  integer, intent(in) :: ni, nj !< The sizes of the 1st and 2nd dimensions of the array
+  integer, intent(in) :: ni !< The size of the 1st dimension of the array
+  integer, intent(in) :: nj !< The size of the 2nd dimension of the array
   if (.not.associated(ptr)) then
     allocate(ptr(ni,nj))
     ptr(:,:) = 0.0
@@ -64,8 +59,9 @@ end subroutine safe_alloc_ptr_2d_2arg
 !> Allocate a pointer to a 3-d array based on its dimension sizes
 subroutine safe_alloc_ptr_3d_2arg(ptr, ni, nj, nk)
   real, dimension(:,:,:), pointer :: ptr !< A pointer to allocate
-  integer, intent(in) :: ni, nj !< The sizes of the 1st and 2nd dimensions of the array
-  integer, intent(in) :: nk !< The size to allocate for the 3rd dimension
+  integer, intent(in) :: ni !< The size of the 1st dimension of the array
+  integer, intent(in) :: nj !< The size of the 2nd dimension of the array
+  integer, intent(in) :: nk !< The size of the 3rd dimension of the array
   if (.not.associated(ptr)) then
     allocate(ptr(ni,nj,nk))
     ptr(:,:,:) = 0.0
@@ -75,8 +71,10 @@ end subroutine safe_alloc_ptr_3d_2arg
 !> Allocate a pointer to a 2-d array based on its index starting and ending values
 subroutine safe_alloc_ptr_2d(ptr, is, ie, js, je)
   real, dimension(:,:), pointer :: ptr !< A pointer to allocate
-  integer, intent(in) :: is, ie !< The start and end indices to allocate for the 1st dimension
-  integer, intent(in) :: js, je !< The start and end indices to allocate for the 2nd dimension
+  integer, intent(in) :: is !< The start index to allocate for the 1st dimension
+  integer, intent(in) :: ie !< The end index to allocate for the 1st dimension
+  integer, intent(in) :: js !< The start index to allocate for the 2nd dimension
+  integer, intent(in) :: je !< The end index to allocate for the 2nd dimension
   if (.not.associated(ptr)) then
     allocate(ptr(is:ie,js:je))
     ptr(:,:) = 0.0
@@ -86,8 +84,10 @@ end subroutine safe_alloc_ptr_2d
 !> Allocate a pointer to a 3-d array based on its index starting and ending values
 subroutine safe_alloc_ptr_3d(ptr, is, ie, js, je, nk)
   real, dimension(:,:,:), pointer :: ptr !< A pointer to allocate
-  integer, intent(in) :: is, ie !< The start and end indices to allocate for the 1st dimension
-  integer, intent(in) :: js, je !< The start and end indices to allocate for the 2nd dimension
+  integer, intent(in) :: is !< The start index to allocate for the 1st dimension
+  integer, intent(in) :: ie !< The end index to allocate for the 1st dimension
+  integer, intent(in) :: js !< The start index to allocate for the 2nd dimension
+  integer, intent(in) :: je !< The end index to allocate for the 2nd dimension
   integer, intent(in) :: nk !< The size to allocate for the 3rd dimension
   if (.not.associated(ptr)) then
     allocate(ptr(is:ie,js:je,nk))
@@ -98,8 +98,10 @@ end subroutine safe_alloc_ptr_3d
 !> Allocate a 2-d allocatable array based on its index starting and ending values
 subroutine safe_alloc_allocatable_2d(ptr, is, ie, js, je)
   real, dimension(:,:), allocatable :: ptr !< An allocatable array to allocate
-  integer, intent(in) :: is, ie !< The start and end indices to allocate for the 1st dimension
-  integer, intent(in) :: js, je !< The start and end indices to allocate for the 2nd dimension
+  integer, intent(in) :: is !< The start index to allocate for the 1st dimension
+  integer, intent(in) :: ie !< The end index to allocate for the 1st dimension
+  integer, intent(in) :: js !< The start index to allocate for the 2nd dimension
+  integer, intent(in) :: je !< The end index to allocate for the 2nd dimension
   if (.not.allocated(ptr)) then
     allocate(ptr(is:ie,js:je))
     ptr(:,:) = 0.0
@@ -109,8 +111,10 @@ end subroutine safe_alloc_allocatable_2d
 !> Allocate a 3-d allocatable array based on its index starting and ending values
 subroutine safe_alloc_allocatable_3d(ptr, is, ie, js, je, nk)
   real, dimension(:,:,:), allocatable :: ptr !< An allocatable array to allocate
-  integer, intent(in) :: is, ie !< The start and end indices to allocate for the 1st dimension
-  integer, intent(in) :: js, je !< The start and end indices to allocate for the 2nd dimension
+  integer, intent(in) :: is !< The start index to allocate for the 1st dimension
+  integer, intent(in) :: ie !< The end index to allocate for the 1st dimension
+  integer, intent(in) :: js !< The start index to allocate for the 2nd dimension
+  integer, intent(in) :: je !< The end index to allocate for the 2nd dimension
   integer, intent(in) :: nk !< The size to allocate for the 3rd dimension
   if (.not.allocated(ptr)) then
     allocate(ptr(is:ie,js:je,nk))

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -1,6 +1,5 @@
-!> Implements the thermodynamic aspects of ocean / ice-shelf interactions,
-!!  along with a crude placeholder for a later implementation of full
-!!  ice shelf dynamics, all using the MOM framework and coding style.
+!> Implements a crude placeholder for a later implementation of full
+!! ice shelf dynamics.
 module MOM_ice_shelf_dynamics
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -4067,95 +4066,5 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
   enddo ! i loop
 
 end subroutine ice_shelf_advect_temp_y
-
-!> \namespace mom_ice_shelf_dynamics
-!!
-!! \section section_ICE_SHELF_dynamics
-!!
-!! This module implements the thermodynamic aspects of ocean/ice-shelf
-!! inter-actions, along with a crude placeholder for a later implementation of full
-!! ice shelf dynamics, all using the MOM framework and coding style.
-!!
-!! Derived from code by Chris Little, early 2010.
-!!
-!!   The ice-sheet dynamics subroutines do the following:
-!!  initialize_shelf_mass - Initializes the ice shelf mass distribution.
-!!      - Initializes h_shelf, h_mask, area_shelf_h
-!!      - CURRENTLY: initializes mass_shelf as well, but this is unnecessary, as mass_shelf is initialized based on
-!!             h_shelf and density_ice immediately afterwards. Possibly subroutine should be renamed
-!!  update_shelf_mass - updates ice shelf mass via netCDF file
-!!                      USER_update_shelf_mass (TODO).
-!!  ice_shelf_solve_outer - Orchestrates the calls to calculate the shelf
-!!      - outer loop calls ice_shelf_solve_inner
-!!         stresses and checks for error tolerances.
-!!         Max iteration count for outer loop currently fixed at 100 iteration
-!!      - tolerance (and error evaluation) can be set through input file
-!!      - updates u_shelf, v_shelf, ice_visc, taub_beta_eff
-!!  ice_shelf_solve_inner - Conjugate Gradient solve of matrix solve for ice_shelf_solve_outer
-!!      - Jacobi Preconditioner - basically diagonal of matrix (not sure if it is effective at all)
-!!      - modifies u_shelf and v_shelf only
-!!      - max iteration count can be set through input file
-!!      - tolerance (and error evaluation) can be set through input file
-!!                  (ISSUE:  Too many sum_across_PEs calls?)
-!!    calc_shelf_driving_stress - Determine the driving stresses using h_shelf, (water) column thickness, bathymetry
-!!            - does not modify any permanent arrays
-!!    init_boundary_values -
-!!    bilinear_shape_functions - shape function for FEM solve using (convex) quadrilateral elements and
-!!                               bilinear nodal basis
-!!    calc_shelf_visc - Glen's law viscosity and nonlinear sliding law (called by ice_shelf_solve_outer)
-!!    apply_boundary_values - same as CG_action, but input is zero except for dirichlet bdry conds
-!!    CG_action - Effect of matrix (that is never explicitly constructed)
-!!        on vector space of Degrees of Freedom (DoFs) in velocity solve
-!!  ice_shelf_advect - Given the melt rate and velocities, it advects the ice shelf THICKNESS
-!!      - modified h_shelf, area_shelf_h, hmask
-!!        (maybe should updater mass_shelf as well ???)
-!!    ice_shelf_advect_thickness_x, ice_shelf_advect_thickness_y - These
-!!        subroutines determine the mass fluxes through the faces.
-!!                  (ISSUE: duplicative flux calls for shared faces?)
-!!    ice_shelf_advance_front - Iteratively determine the ice-shelf front location.
-!!           - IF ice_shelf_advect_thickness_x,y are modified to avoid
-!!       dupe face processing, THIS NEEDS TO BE MODIFIED TOO
-!!       as it depends on arrays modified in those functions
-!!       (if in doubt consult DNG)
-!!    update_velocity_masks - Controls which elements of u_shelf and v_shelf are considered DoFs in linear solve
-!!    solo_time_step - called only in ice-only mode.
-!!    shelf_calc_flux - after melt rate & fluxes are calculated, ice dynamics are done. currently mass_shelf is
-!! updated immediately after ice_shelf_advect.
-!!
-!!
-!!   NOTES: be aware that hmask(:,:) has a number of functions; it is used for front advancement,
-!! for subroutines in the velocity solve, and for thickness boundary conditions (this last one may be removed).
-!! in other words, interfering with its updates will have implications you might not expect.
-!!
-!!  Overall issues: Many variables need better documentation and units and the
-!!                  subgrid on which they are discretized.
-!!
-!! \subsection section_ICE_SHELF_equations ICE_SHELF equations
-!!
-!! The three fundamental equations are:
-!! Heat flux
-!! \f[ \qquad \rho_w  C_{pw} \gamma_T (T_w - T_b) = \rho_i  \dot{m}  L_f \f]
-!! Salt flux
-!! \f[  \qquad \rho_w \gamma_s (S_w - S_b) =  \rho_i \dot{m} S_b \f]
-!! Freezing temperature
-!! \f[  \qquad T_b = a S_b + b + c P \f]
-!!
-!! where ....
-!!
-!! \subsection section_ICE_SHELF_references References
-!!
-!! Asay-Davis, Xylar S., Stephen L. Cornford, Benjamin K. Galton-Fenzi, Rupert M. Gladstone, G. Hilmar Gudmundsson,
-!! David M. Holland, Paul R. Holland, and Daniel F. Martin. Experimental design for three interrelated marine ice sheet
-!! and ocean model intercomparison projects: MISMIP v. 3 (MISMIP+), ISOMIP v. 2 (ISOMIP+) and MISOMIP v. 1 (MISOMIP1).
-!! Geoscientific Model Development 9, no. 7 (2016): 2471.
-!!
-!! Goldberg, D. N., et al. Investigation of land ice-ocean interaction with a fully coupled ice-ocean model: 1.
-!!  Model description and behavior. Journal of Geophysical Research: Earth Surface 117.F2 (2012).
-!!
-!! Goldberg, D. N., et al. Investigation of land ice-ocean interaction with a fully coupled ice-ocean model: 2.
-!! Sensitivity to external forcings. Journal of Geophysical Research: Earth Surface 117.F2 (2012).
-!!
-!! Holland, David M., and Adrian Jenkins. Modeling thermodynamic ice-ocean interactions at the base of an ice shelf.
-!! Journal of Physical Oceanography 29.8 (1999): 1787-1800.
 
 end module MOM_ice_shelf_dynamics

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1,4 +1,4 @@
-!> Initialize state variables, u, v, h, T and S.
+!> Initialization functions for state variables, u, v, h, T and S.
 module MOM_state_initialization
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -1382,9 +1382,13 @@ subroutine initialize_velocity_circular(u, v, G, param_file, just_read_params)
 
   contains
 
-  real function my_psi(ig,jg) ! in-line function
-    integer :: ig, jg
+  !> Returns the value of a circular stream function at (ig,jg)
+  real function my_psi(ig,jg)
+    integer :: ig !< Global i-index
+    integer :: jg !< Global j-index
+    ! Local variables
     real :: x, y, r
+
     x = 2.0*(G%geoLonBu(ig,jg)-G%west_lon)/G%len_lon-1.0  ! -1<x<1
     y = 2.0*(G%geoLatBu(ig,jg)-G%south_lat)/G%len_lat-1.0 ! -1<y<1
     r = sqrt( x**2 + y**2 ) ! Circulat stream fn nis fn of radius only

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -110,7 +110,6 @@ character(len=40)  :: mdl = "MOM_state_initialization" ! This module's name.
 
 contains
 
-! -----------------------------------------------------------------------------
 !> Initialize temporally evolving fields, either as initial
 !! conditions or by reading them from a restart (or saves) file.
 subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
@@ -143,8 +142,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
   type(ocean_OBC_type),       pointer       :: OBC   !< The open boundary condition control structure.
   type(time_type), optional,  intent(in)    :: Time_in !< Time at the start of the run segment.
                                                      !! Time_in overrides any value set for Time.
-
-! Local variables
+  ! Local variables
   character(len=200) :: filename   ! The name of an input file.
   character(len=200) :: filename2  ! The name of an input files.
   character(len=200) :: inputdir   ! The directory where NetCDF input files are.
@@ -599,10 +597,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
   call callTree_leave('MOM_initialize_state()')
 
 end subroutine MOM_initialize_state
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
-!>  This subroutine reads the layer thicknesses or interface heights from a file.
+!> Reads the layer thicknesses or interface heights from a file.
 subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickness, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure
@@ -688,24 +684,20 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
   endif
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_thickness_from_file
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
 !> Adjust interface heights to fit the bathymetry and diagnose layer thickness.
+!!
 !! If the bottom most interface is below the topography then the bottom-most
 !! layers are contracted to GV%Angstrom_z.
 !! If the bottom most interface is above the topography then the entire column
 !! is dilated (expanded) to fill the void.
 !!   @remark{There is a (hard-wired) "tolerance" parameter such that the
 !! criteria for adjustment must equal or exceed 10cm.}
-!!   @param[in]     G   Grid type
-!!   @param[in,out] eta Interface heights
-!!   @param[out]    h   Layer thicknesses
 subroutine adjustEtaToFitBathymetry(G, GV, eta, h)
-  type(ocean_grid_type),                          intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),                        intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1),    intent(inout) :: eta  !< Interface heights, in m
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),      intent(inout) :: h    !< Layer thicknesses, in H
+  type(ocean_grid_type),                      intent(in)    :: G   !< The ocean's grid structure
+  type(verticalGrid_type),                    intent(in)    :: GV  !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: eta !< Interface heights, in m
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(inout) :: h   !< Layer thicknesses, in H
   ! Local variables
   integer :: i, j, k, is, ie, js, je, nz, contractions, dilations
   real, parameter :: hTolerance = 0.1 !<  Tolerance to exceed adjustment criteria (m)
@@ -771,9 +763,8 @@ subroutine adjustEtaToFitBathymetry(G, GV, eta, h)
   endif
 
 end subroutine adjustEtaToFitBathymetry
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
+!> Initializes thickness to be uniform
 subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
@@ -783,8 +774,7 @@ subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-
-!  This subroutine initializes the layer thicknesses to be uniform.
+  ! Local variables
   character(len=40)  :: mdl = "initialize_thickness_uniform" ! This subroutine's name.
   real :: e0(SZK_(G)+1)   ! The resting interface heights, in m, usually !
                           ! negative because it is positive upward.      !
@@ -828,9 +818,8 @@ subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_thickness_uniform
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
+!> Initialize thickness from a 1D list
 subroutine initialize_thickness_list(h, G, GV, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
@@ -840,14 +829,7 @@ subroutine initialize_thickness_list(h, G, GV, param_file, just_read_params)
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-
-! Arguments: h - The thickness that is being initialized.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-
-!  This subroutine initializes the layer thicknesses to be uniform.
+  ! Local variables
   character(len=40)  :: mdl = "initialize_thickness_list" ! This subroutine's name.
   real :: e0(SZK_(G)+1)   ! The resting interface heights, in m, usually !
                           ! negative because it is positive upward.      !
@@ -914,27 +896,23 @@ subroutine initialize_thickness_list(h, G, GV, param_file, just_read_params)
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_thickness_list
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
+!> Search density space for location of layers (not implemented!)
 subroutine initialize_thickness_search
-! search density space for location of layers
   call MOM_error(FATAL,"  MOM_state_initialization.F90, initialize_thickness_search: NOT IMPLEMENTED")
 end subroutine initialize_thickness_search
-! -----------------------------------------------------------------------------
 
+!> Converts thickness from geometric to pressure units
 subroutine convert_thickness(h, G, GV, tv)
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                           intent(inout) :: h    !< Input eometric layer thicknesses (in H units),
+                           intent(inout) :: h    !< Input geometric layer thicknesses (in H units),
                                                  !! being converted to layer pressure
                                                  !! thicknesses (also in H units).
   type(thermo_var_ptrs),   intent(in)    :: tv   !< A structure pointing to various
                                                  !! thermodynamic variables
-! Arguments: h - The thickness that is being initialized.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     p_top, p_bot
   real :: dz_geo(SZI_(G),SZJ_(G))      ! The change in geopotential height
@@ -1002,6 +980,7 @@ subroutine convert_thickness(h, G, GV, tv)
 
 end subroutine convert_thickness
 
+!> Depress the sea-surface based on an initial condition file
 subroutine depress_surface(h, G, GV, param_file, tv, just_read_params)
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
@@ -1011,12 +990,7 @@ subroutine depress_surface(h, G, GV, param_file, tv, just_read_params)
   type(thermo_var_ptrs),   intent(in)    :: tv   !< A structure pointing to various thermodynamic variables
   logical,       optional, intent(in)    :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-! Arguments: h - The thickness that is being initialized.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     eta_sfc  ! The free surface height that the model should use, in m.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: &
@@ -1104,7 +1078,6 @@ subroutine trim_for_ice(PF, G, GV, ALE_CSp, tv, h, just_read_params)
                            intent(inout) :: h !< Layer thickness (H units, m or Pa)
   logical,       optional, intent(in)    :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-
   ! Local variables
   character(len=200) :: mdl = "trim_for_ice"
   real, dimension(SZI_(G),SZJ_(G)) :: p_surf ! Imposed pressure on ocean at surface (Pa)
@@ -1251,9 +1224,9 @@ subroutine cut_off_column_top(nk, tv, Rho0, G_earth, depth, min_thickness, &
 
 end subroutine cut_off_column_top
 
-! -----------------------------------------------------------------------------
+!> Initialize horizontal velocity components from file
 subroutine initialize_velocity_from_file(u, v, G, param_file, just_read_params)
-  type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure
+  type(ocean_grid_type),   intent(in)  :: G  !< The ocean's grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                            intent(out) :: u  !< The zonal velocity that is being initialized, in m s-1
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -1262,12 +1235,7 @@ subroutine initialize_velocity_from_file(u, v, G, param_file, just_read_params)
                                                       !! parse for modelparameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-! Arguments: u - The zonal velocity that is being initialized.
-!  (out)     v - The meridional velocity that is being initialized.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file -  parameter file type
-
-!   This subroutine reads the initial velocity components from file
+  ! Local variables
   character(len=40)  :: mdl = "initialize_velocity_from_file" ! This subroutine's name.
   character(len=200) :: filename,velocity_file,inputdir ! Strings for file/path
   logical :: just_read    ! If true, just read parameters but set nothing.
@@ -1295,11 +1263,10 @@ subroutine initialize_velocity_from_file(u, v, G, param_file, just_read_params)
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_velocity_from_file
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
+!> Initialize horizontal velocity components to zero.
 subroutine initialize_velocity_zero(u, v, G, param_file, just_read_params)
-  type(ocean_grid_type),                   intent(in)  :: G    !< The ocean's grid structure
+  type(ocean_grid_type),   intent(in)  :: G  !< The ocean's grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                            intent(out) :: u  !< The zonal velocity that is being initialized, in m s-1
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -1308,12 +1275,7 @@ subroutine initialize_velocity_zero(u, v, G, param_file, just_read_params)
                                                       !! parse for modelparameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-! Arguments: u - The zonal velocity that is being initialized.
-!  (out)     v - The meridional velocity that is being initialized.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file -  parameter file type
-
-!   This subroutine sets the initial velocity components to zero
+  ! Local variables
   character(len=200) :: mdl = "initialize_velocity_zero" ! This subroutine's name.
   logical :: just_read    ! If true, just read parameters but set nothing.
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
@@ -1335,11 +1297,10 @@ subroutine initialize_velocity_zero(u, v, G, param_file, just_read_params)
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_velocity_zero
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
+!> Sets the initial velocity components to uniform
 subroutine initialize_velocity_uniform(u, v, G, param_file, just_read_params)
-  type(ocean_grid_type),                   intent(in)  :: G    !< The ocean's grid structure
+  type(ocean_grid_type),   intent(in)  :: G  !< The ocean's grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                            intent(out) :: u  !< The zonal velocity that is being initialized, in m s-1
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -1348,12 +1309,7 @@ subroutine initialize_velocity_uniform(u, v, G, param_file, just_read_params)
                                                       !! parse for modelparameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-! Arguments: u - The zonal velocity that is being initialized.
-!  (out)     v - The meridional velocity that is being initialized.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file -  parameter file type
-
-!   This subroutine sets the initial velocity components to uniform
+  ! Local variables
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   real    :: initial_u_const, initial_v_const
   logical :: just_read    ! If true, just read parameters but set nothing.
@@ -1380,11 +1336,11 @@ subroutine initialize_velocity_uniform(u, v, G, param_file, just_read_params)
   enddo ; enddo ; enddo
 
 end subroutine initialize_velocity_uniform
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
+!> Sets the initial velocity components to be circular with
+!! no flow at edges of domain and center.
 subroutine initialize_velocity_circular(u, v, G, param_file, just_read_params)
-  type(ocean_grid_type),                   intent(in)  :: G    !< The ocean's grid structure
+  type(ocean_grid_type),   intent(in)  :: G  !< The ocean's grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                            intent(out) :: u  !< The zonal velocity that is being initialized, in m s-1
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -1393,13 +1349,7 @@ subroutine initialize_velocity_circular(u, v, G, param_file, just_read_params)
                                                       !! parse for modelparameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-! Arguments: u - The zonal velocity that is being initialized.
-!  (out)     v - The meridional velocity that is being initialized.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file -  parameter file type
-
-!   This subroutine sets the initial velocity components to be circular with
-! no flow at edges of domain and center.
+  ! Local variables
   character(len=200) :: mdl = "initialize_velocity_circular"
   real :: circular_max_u
   real :: dpi, psi1, psi2
@@ -1444,9 +1394,8 @@ subroutine initialize_velocity_circular(u, v, G, param_file, just_read_params)
   end function my_psi
 
 end subroutine initialize_velocity_circular
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
+!> Initializes temperature and salinity from file
 subroutine initialize_temp_salt_from_file(T, S, G, param_file, just_read_params)
   type(ocean_grid_type),                  intent(in)  :: G    !< The ocean's grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out) :: T !< The potential temperature that is being initialized.
@@ -1454,17 +1403,7 @@ subroutine initialize_temp_salt_from_file(T, S, G, param_file, just_read_params)
   type(param_file_type),                  intent(in)  :: param_file !< A structure to parse for run-time parameters
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-!  This function puts the initial layer temperatures and salinities  !
-! into T(:,:,:) and S(:,:,:).                                        !
-
-! Arguments: T - The potential temperature that is being initialized.
-!  (out)     S - The salinity that is being initialized.
-!  (in)      from_file - .true. if the variables that are set here are to
-!                        be read from a file; .false. to be set internally.
-!  (in)      filename - The name of the file to read.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
+  ! Local variables
   logical :: just_read    ! If true, just read parameters but set nothing.
   character(len=200) :: filename, salt_filename ! Full paths to input files
   character(len=200) :: ts_file, salt_file, inputdir ! Strings for file/path
@@ -1509,9 +1448,8 @@ subroutine initialize_temp_salt_from_file(T, S, G, param_file, just_read_params)
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_temp_salt_from_file
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
+!> Initializes temperature and salinity from a 1D profile
 subroutine initialize_temp_salt_from_profile(T, S, G, param_file, just_read_params)
   type(ocean_grid_type),                  intent(in)  :: G    !< The ocean's grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out) :: T !< The potential temperature that is being initialized.
@@ -1519,17 +1457,7 @@ subroutine initialize_temp_salt_from_profile(T, S, G, param_file, just_read_para
   type(param_file_type),                  intent(in)  :: param_file !< A structure to parse for run-time parameters
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-!  This function puts the initial layer temperatures and salinities  !
-! into T(:,:,:) and S(:,:,:).                                        !
-
-! Arguments: T - The potential temperature that is being initialized.
-!  (out)     S - The salinity that is being initialized.
-!  (in)      from_file - .true. if the variables that are set here are to
-!                        be read from a file; .false. to be set internally.
-!  (in)      filename - The name of the file to read.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
+  ! Local variables
   real, dimension(SZK_(G)) :: T0, S0
   integer :: i, j, k
   logical :: just_read    ! If true, just read parameters but set nothing.
@@ -1563,10 +1491,8 @@ subroutine initialize_temp_salt_from_profile(T, S, G, param_file, just_read_para
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_temp_salt_from_profile
-! -----------------------------------------------------------------------------
 
-
-! -----------------------------------------------------------------------------
+!> Initializes temperature and salinity by fitting to density
 subroutine initialize_temp_salt_fit(T, S, G, GV, param_file, eqn_of_state, P_Ref, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G            !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV           !< The ocean's vertical grid structure.
@@ -1579,17 +1505,7 @@ subroutine initialize_temp_salt_fit(T, S, G, GV, param_file, eqn_of_state, P_Ref
                                                        !! in Pa.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                        !! only read parameters without changing h.
-!  This function puts the initial layer temperatures and salinities  !
-! into T(:,:,:) and S(:,:,:).                                        !
-
-! Arguments: T - The potential temperature that is being initialized.
-!  (out)     S - The salinity that is being initialized.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      eqn_of_state - integer that selects the equatio of state
-!  (in)      P_Ref - The coordinate-density reference pressure in Pa.
+  ! Local variables
   real :: T0(SZK_(G)), S0(SZK_(G))
   real :: T_Ref         ! Reference Temperature
   real :: S_Ref         ! Reference Salinity
@@ -1661,9 +1577,12 @@ subroutine initialize_temp_salt_fit(T, S, G, GV, param_file, eqn_of_state, P_Ref
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_temp_salt_fit
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
+!> Initializes T and S with linear profiles according to reference surface
+!! layer salinity and temperature and a specified range.
+!!
+!! \remark Note that the linear distribution is set up with respect to the layer
+!! number, not the physical position).
 subroutine initialize_temp_salt_linear(T, S, G, param_file, just_read_params)
   type(ocean_grid_type),                    intent(in)  :: G          !< The ocean's grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out) :: T !< The potential temperature that is being initialized.
@@ -1675,10 +1594,6 @@ subroutine initialize_temp_salt_linear(T, S, G, param_file, just_read_params)
                                                                       !! parameters without
                                                                       !! changing h.
 
-  ! This subroutine initializes linear profiles for T and S according to
-  ! reference surface layer salinity and temperature and a specified range.
-  ! Note that the linear distribution is set up with respect to the layer
-  ! number, not the physical position).
   integer :: k
   real  :: delta_S, delta_T
   real  :: S_top, T_top ! Reference salinity and temerature within surface layer
@@ -1727,13 +1642,11 @@ subroutine initialize_temp_salt_linear(T, S, G, param_file, just_read_params)
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_temp_salt_linear
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
 !> This subroutine sets the inverse restoration time (Idamp), and
 !! the values towards which the interface heights and an arbitrary
 !! number of tracers should be restored within each sponge. The
-!!interface height is always subject to damping, and must always be
+!! interface height is always subject to damping, and must always be
 !! the first registered field.
 subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp, ALE_CSp, Time)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
@@ -1748,8 +1661,7 @@ subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp, 
                                                   !! structure for this module (in ALE mode).
   type(time_type),         intent(in) :: Time !< Time at the start of the run segment. Time_in
                                               !! overrides any value set for Time.
-
-! Local variables
+  ! Local variables
   real, allocatable, dimension(:,:,:) :: eta ! The target interface heights, in m.
   real, allocatable, dimension(:,:,:) :: h   ! The target interface thicknesses, in m.
 
@@ -1916,16 +1828,13 @@ subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp, 
     call set_up_ALE_sponge_field(filename, salin_var, Time, G, tv%S, ALE_CSp)
   endif
 
-
-
 end subroutine initialize_sponges_file
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
 !> This subroutine sets the 4 bottom depths at velocity points to be the
 !! maximum of the adjacent depths.
 subroutine set_velocity_depth_max(G)
-  type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure
+  type(ocean_grid_type), intent(inout) :: G !< The ocean's grid structure
+  ! Local variables
   integer :: i, j
 
   do I=G%isd,G%ied-1 ; do j=G%jsd,G%jed
@@ -1937,13 +1846,12 @@ subroutine set_velocity_depth_max(G)
     G%Dopen_v(I,J) = G%Dblock_v(I,J)
   enddo ; enddo
 end subroutine set_velocity_depth_max
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
 !> Subroutine to pre-compute global integrals of grid quantities for
 !! later use in reporting diagnostics
 subroutine compute_global_grid_integrals(G)
-  type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure
+  type(ocean_grid_type), intent(inout) :: G !< The ocean's grid structure
+  ! Local variables
   real, dimension(G%isc:G%iec, G%jsc:G%jec) :: tmpForSumming
   integer :: i,j
 
@@ -1956,11 +1864,11 @@ subroutine compute_global_grid_integrals(G)
   G%IareaT_global = 1. / G%areaT_global
 end subroutine compute_global_grid_integrals
 
-! -----------------------------------------------------------------------------
 !> This subroutine sets the 4 bottom depths at velocity points to be the
 !! minimum of the adjacent depths.
 subroutine set_velocity_depth_min(G)
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure
+  ! Local variables
   integer :: i, j
 
   do I=G%isd,G%ied-1 ; do j=G%jsd,G%jed
@@ -1972,9 +1880,7 @@ subroutine set_velocity_depth_min(G)
     G%Dopen_v(I,J) = G%Dblock_v(I,J)
   enddo ; enddo
 end subroutine set_velocity_depth_min
-! -----------------------------------------------------------------------------
 
-! -----------------------------------------------------------------------------
 !> This subroutine determines the isopycnal or other coordinate interfaces and
 !! layer potential temperatures and salinities directly from a z-space file on
 !! a latitude-longitude grid.
@@ -1991,7 +1897,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
                                                  !! to parse for model parameter values.
   logical,       optional, intent(in)    :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-
+  ! Local variables
   character(len=200) :: filename   !< The name of an input file containing temperature
                                    !! and salinity in z-space; also used for  ice shelf area.
   character(len=200) :: tfilename  !< The name of an input file containing only temperature
@@ -2046,7 +1952,6 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: zi  ! Interface heights in m.
   real, dimension(SZI_(G),SZJ_(G))  :: nlevs
   real, dimension(SZI_(G))   :: press
-
 
   ! Local variables for ALE remapping
   real, dimension(:), allocatable :: hTarget

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -38,18 +38,18 @@ real, parameter :: epsln=1.e-10
 
 contains
 
-!> MOM_initialize_tracer_from_Z initializes a tracer from a z-space data file.
+!> Initializes a tracer from a z-space data file.
 subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam, &
                           src_var_unit_conversion, src_var_record, homogenize, &
                           useALEremapping, remappingScheme, src_var_gridspec )
-
   type(ocean_grid_type),      intent(inout) :: G   !< Ocean grid structure.
   type(verticalGrid_type),    intent(in)    :: GV  !< Ocean vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                               intent(in)    :: h   !< Layer thickness, in m.
   real, dimension(:,:,:),     pointer       :: tr  !< Pointer to array to be initialized
   type(param_file_type),      intent(in)    :: PF  !< parameter file
-  character(len=*),           intent(in)    :: src_file, src_var_nam !< source filename and variable name on disk
+  character(len=*),           intent(in)    :: src_file !< source filename
+  character(len=*),           intent(in)    :: src_var_nam !< variable name in file
   real,             optional, intent(in)    :: src_var_unit_conversion !< optional multiplicative unit conversion
   integer,          optional, intent(in)    :: src_var_record  !< record to read for multiple time-level files
   logical,          optional, intent(in)    :: homogenize !< optionally homogenize to mean value
@@ -57,7 +57,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
   character(len=*), optional, intent(in)    :: remappingScheme !< remapping scheme to use.
   character(len=*), optional, intent(in)    :: src_var_gridspec !< Source variable name in a gridspec file.
                                                                 !! This is not implemented yet.
-
+  ! Local variables
   real :: land_fill = 0.0
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
   character(len=200) :: mesg

--- a/src/initialization/midas_vertmap.F90
+++ b/src/initialization/midas_vertmap.F90
@@ -166,12 +166,14 @@ contains
     real, dimension(size(tr_in,3)+1), intent(in) :: z_edges !< The depths of the cell edges in the input z* data (m)
     integer, intent(in)                          :: nlay !< The number of vertical layers in the target grid
     real, dimension(size(tr_in,1),size(tr_in,2),nlay+1), intent(in) :: e !< The depths of the target layer interfaces (m)
-    integer, intent(in)                          :: nkml,nkbl !< The number of mixed and buffer layers respectively
+    integer, intent(in)                          :: nkml !< The number of mixed layers
+    integer, intent(in)                          :: nkbl !< The number of buffer layers
     real, intent(in)                             :: land_fill !< fill in data over land (1)
     real, dimension(size(tr_in,1),size(tr_in,2)), intent(in) :: wet !< The wet mask for the source data (valid points)
     real, dimension(size(tr_in,1),size(tr_in,2)), optional, intent(in) ::nlevs !< The number of input levels with valid data
     logical, optional, intent(in)                :: debug !< optional debug flag
-    integer, optional, intent(in)                :: i_debug, j_debug !< points for debugging
+    integer, optional, intent(in)                :: i_debug !< i-index of point for debugging
+    integer, optional, intent(in)                :: j_debug !< j-index of point for debugging
     real, dimension(size(tr_in,1),size(tr_in,2),nlay) :: tr !< tracers in layer space
 
     real, dimension(size(tr_in,3)) :: tr_1d !< a copy of the input tracer concentrations in a column.
@@ -336,9 +338,10 @@ contains
 !>  Optional args lo (default 1) and hi (default len(a)) bound the
 !>  slice of a to be searched.
   function bisect_fast(a, x, lo, hi) result(bi_r)
-    real, dimension(:,:), intent(in) :: a !< a - sorted list
-    real, dimension(:), intent(in) :: x !< x - item to be inserted
-    integer, dimension(size(a,1)), optional, intent(in) :: lo,hi !< lo, hi - optional range to search
+    real, dimension(:,:), intent(in) :: a !< Sorted list
+    real, dimension(:), intent(in) :: x !< Item to be inserted
+    integer, dimension(size(a,1)), optional, intent(in) :: lo !< Lower bracket of optional range to search
+    integer, dimension(size(a,1)), optional, intent(in) :: hi !< Upper bracket of optional range to search
     integer, dimension(size(a,1),size(x,1))  :: bi_r
 
     integer :: mid,num_x,num_a,i
@@ -536,12 +539,12 @@ contains
     real, intent(in)   :: Z_bot !< The bottom of the range being mapped to, in m.
     integer, intent(in) :: k_max !< The number of valid layers.
     integer, intent(in) :: k_start !< The layer at which to start searching.
-    integer, intent(out) :: k_top, k_bot !< The indices of the top and bottom layers that overlap with the depth range.
+    integer, intent(out) :: k_top !< The index of the top layer that overlap with the depth range.
+    integer, intent(out) :: k_bot !< The index of the bottom layer that overlap with the depth range.
     real, dimension(:), intent(out) :: wt !< The relative weights of each layer from k_top to k_bot.
-    real, dimension(:), intent(out) :: z1, z2 !< z1 and z2 are the depths of the top and bottom limits of
-    !! the part of a layer that contributes to a depth level,
-    !! relative to the cell center and normalized by the cell
-    !! thickness, nondim.  Note that -1/2 <= z1 < z2 <= 1/2.
+    real, dimension(:), intent(out) :: z1 !< Depth of the top limit of layer that contributes to a level
+    real, dimension(:), intent(out) :: z2 !< Depth of the bottom limit of layer that contributes to a level
+
     real :: Ih, e_c, tot_wt, I_totwt
     integer :: k
 
@@ -755,10 +758,12 @@ contains
 
   end function find_interfaces
 
-!>  create a 2d-mesh of grid coordinates from 1-d arrays
+!> Create a 2d-mesh of grid coordinates from 1-d arrays
   subroutine meshgrid(x,y,x_T,y_T)
-    real, dimension(:), intent(in) :: x,y !< input x,y coordinates
-    real, dimension(size(x,1),size(y,1)), intent(inout) :: x_T,y_T !< output 2-d version
+    real, dimension(:), intent(in) :: x !< input x coordinates
+    real, dimension(:), intent(in) :: y !< input y coordinates
+    real, dimension(size(x,1),size(y,1)), intent(inout) :: x_T !< output 2-d version
+    real, dimension(size(x,1),size(y,1)), intent(inout) :: y_T !< output 2-d version
 
     integer :: ni,nj,i,j
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1847,7 +1847,7 @@ end subroutine hor_visc_end
 !! approach was generalized in Smith and McWilliams, 2003. We use the second form of their
 !! two coefficient anisotropic viscosity (section 4.3). We also replace their
 !! \f$A^\prime\f$ nd $D$ such that \f$2A^\prime = 2 \kappa_h + D\f$ and
-!! \f$\kappa_a = D$ so that \f$\kappa_h\f$ can be considered the isotropic
+!! \f$\kappa_a = D\f$ so that \f$\kappa_h\f$ can be considered the isotropic
 !! viscosity and \f$\kappa_a=D\f$ can be consider the anisotropic viscosity. The
 !! direction of anisotropy is defined by a unit vector \f$\hat{\bf
 !! n}=(n_1,n_2)\f$.

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -1,29 +1,9 @@
+!> Subroutines that use the ray-tracing equations to propagate the internal tide energy density.
+!!
+!! \author Benjamin Mater & Robert Hallberg, 2015
 module MOM_internal_tides
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*  By Benjamin Mater & Robert Hallberg, 2015                          *
-!*                                                                     *
-!*    This program contains the subroutines that use the ray-tracing   *
-!*  equations to propagate the internal tide energy density.           *
-!*                                                                     *
-!*  Macros written all in capital letters are defined in MOM_memory.h. *
-!*                                                                     *
-!*     A small fragment of the grid is shown below:                    *
-!*                                                                     *
-!*    j+1  x ^ x ^ x   At x:  q                                        *
-!*    j+1  > o > o >   At ^:  v, tauy                                  *
-!*    j    x ^ x ^ x   At >:  u, taux                                  *
-!*    j    > o > o >   At o:  h, fluxes.                               *
-!*    j-1  x ^ x ^ x                                                   *
-!*        i-1  i  i+1  At x & ^:                                       *
-!*           i  i+1    At > & o:                                       *
-!*                                                                     *
-!*  The boundaries always run through q grid points (x).               *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_debugging,     only : is_NaN
 use MOM_diag_mediator, only : post_data, query_averaging_enabled, diag_axis_init
@@ -44,11 +24,6 @@ use MOM_time_manager, only  : time_type_to_real
 use MOM_variables, only     : surface, thermo_var_ptrs
 use MOM_verticalGrid, only  : verticalGrid_type
 use MOM_wave_structure, only: wave_structure_init, wave_structure, wave_structure_CS
-
-!   Forcing is a structure containing pointers to the forcing fields
-! which may be used to drive MOM.  All fluxes are positive downward.
-!   Surface is a structure containing pointers to various fields that
-! may be used describe the surface state of MOM.
 
 !use, intrinsic :: IEEE_ARITHMETIC
 
@@ -180,8 +155,8 @@ end type loop_bounds_type
 
 contains
 
-!> This subroutine calls other subroutines in this file that are needed to
-!! refract, propagate, and dissipate energy density of the internal tide.
+!> Calls subroutines in this file that are needed to refract, propagate,
+!! and dissipate energy density of the internal tide.
 subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
                               G, GV, CS)
   type(ocean_grid_type),            intent(inout) :: G  !< The ocean's grid structure.
@@ -202,22 +177,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
                                                         !! previous call to int_tide_init.
   real, dimension(SZI_(G),SZJ_(G),CS%nMode), &
                                     intent(in)    :: cn !< The internal wave speeds of each mode, in m s-1.
-
-  ! This subroutine calls other subroutines in this file that are needed to
-  ! refract, propagate, and dissipate energy density of the internal tide.
-  !
-  ! Arguments:
-  !  (in)      h -  Layer thickness, in m or kg m-2  (needed for wave structure).
-  !  (in)      tv - Pointer to thermodynamic variables (needed for wave structure).
-  !  (in)      cn - Internal gravity wave speeds of modes, in m s-1.
-  !  (in)      TKE_itidal_input - The energy input to the internal waves, in W m-2.
-  !  (in)      vel_btTide - Barotropic velocity read from file, in m s-1
-  !  (in)      Nb - Near-bottom buoyancy frequency, in s-1
-  !  (in)      dt - Length of time over which these fluxes will be applied, in s.
-  !  (in)      G - The ocean's grid structure.
-  !  (in)      GV - The ocean's vertical grid structure.
-  !  (in)      CS - A pointer to the control structure returned by a previous
-  !                 call to int_tide_init.
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G),2) :: &
     test
   real, dimension(SZI_(G),SZJ_(G),CS%nFreq,CS%nMode) :: &
@@ -625,7 +585,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
 
 end subroutine propagate_int_tide
 
-!> This subroutine checks for energy conservation on computational domain
+!> Checks for energy conservation on computational domain
 subroutine sum_En(G, CS, En, label)
   type(ocean_grid_type),  intent(in) :: G  !< The ocean's grid structure.
   type(int_tide_CS),      pointer    :: CS !< The control structure returned by a
@@ -633,8 +593,7 @@ subroutine sum_En(G, CS, En, label)
   real, dimension(G%isd:G%ied,G%jsd:G%jed,CS%NAngle), &
                           intent(in) :: En !< The energy density of the internal tides, in J m-2.
   character(len=*),       intent(in) :: label !< A label to use in error messages
-
-  ! This subroutine checks for energy conservation on computational domain
+  ! Local variables
   integer :: m,fr,a
   real :: En_sum, tmpForSumming, En_sum_diff, En_sum_pdiff
   character(len=160) :: mesg  ! The text of an error message
@@ -669,7 +628,7 @@ subroutine sum_En(G, CS, En, label)
 
 end subroutine sum_En
 
-!> This subroutine calculates the energy lost from the propagating internal tide due to
+!> Calculates the energy lost from the propagating internal tide due to
 !! scattering over small-scale roughness along the lines of Jayne & St. Laurent (2001).
 subroutine itidal_lowmode_loss(G, CS, Nb, Ub, En, TKE_loss_fixed, TKE_loss, dt, full_halos)
   type(ocean_grid_type),     intent(in)    :: G  !< The ocean's grid structure.
@@ -691,20 +650,7 @@ subroutine itidal_lowmode_loss(G, CS, Nb, Ub, En, TKE_loss_fixed, TKE_loss, dt, 
   real,                      intent(in)    :: dt !< Time increment, in s.
   logical,optional,          intent(in)    :: full_halos  !< If true, do the calculation over the
                                                  !! entirecomputational domain.
-
-  ! This subroutine calculates the energy lost from the propagating internal tide due to
-  ! scattering over small-scale roughness along the lines of Jayne & St. Laurent (2001).
-  !
-  ! Arguments:
-  !  (in)      Nb - near-bottom stratification, in s-1.
-  !  (in)      Ub - rms (over one period) near-bottom horizontal mode velocity , in m s-1.
-  !  (inout)   En - energy density of the internal waves, in J m-2.
-  !  (in)      TKE_loss_fixed - fixed part of energy loss, in kg m-2 (rho*kappa*h^2)
-  !  (out)     TKE_loss - energy loss rate, in W m-2 (q*rho*kappa*h^2*N*U^2)
-  !  (in)      dt - time increment, in s
-  !  (in,opt)  full_halos - If true, do the calculation over the entire
-  !                         computational domain.
-
+  ! Local variables
   integer :: j,i,m,fr,a, is, ie, js, je
   real    :: En_tot          ! energy for a given mode, frequency, and point summed over angles
   real    :: TKE_loss_tot    ! dissipation for a given mode, frequency, and point summed over angles
@@ -772,6 +718,7 @@ end subroutine itidal_lowmode_loss
 
 !> This subroutine extracts the energy lost from the propagating internal which has
 !> been summed across all angles, frequencies, and modes for a given mechanism and location.
+!!
 !> It can be called from another module to get values from this module's (private) CS.
 subroutine get_lowmode_loss(i,j,G,CS,mechanism,TKE_loss_sum)
   integer,               intent(in)  :: i   !< The i-index of the value to be reported.
@@ -783,13 +730,6 @@ subroutine get_lowmode_loss(i,j,G,CS,mechanism,TKE_loss_sum)
   real,                  intent(out) :: TKE_loss_sum !< Total energy loss rate due to specified
                                                      !! mechanism, in W m-2.
 
-  ! This subroutine extracts the energy lost from the propagating internal which has
-  ! been summed across all angles, frequencies, and modes for a given mechanism and location.
-  ! It can be called from another module to get values from this module's (private) CS.
-  !
-  ! Arguments:
-  !  (out)      TKE_loss_sum - total energy loss rate due to specified mechanism, in W m-2.
-
   if (mechanism == 'LeakDrag') TKE_loss_sum = CS%tot_leak_loss(i,j)   ! not used for mixing yet
   if (mechanism == 'QuadDrag') TKE_loss_sum = CS%tot_quad_loss(i,j)   ! not used for mixing yet
   if (mechanism == 'WaveDrag') TKE_loss_sum = CS%tot_itidal_loss(i,j) ! currently used for mixing
@@ -797,7 +737,7 @@ subroutine get_lowmode_loss(i,j,G,CS,mechanism,TKE_loss_sum)
 
 end subroutine get_lowmode_loss
 
-!> This subroutine does refraction on the internal waves at a single frequency.
+!> Implements refraction on the internal waves at a single frequency.
 subroutine refract(En, cn, freq, dt, G, NAngle, use_PPMang)
   type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure.
   integer,               intent(in)    :: NAngle !< The number of wave orientations in the
@@ -812,16 +752,7 @@ subroutine refract(En, cn, freq, dt, G, NAngle, use_PPMang)
   real,                  intent(in)    :: dt   !< Time step, in s.
   logical,               intent(in)    :: use_PPMang !< If true, use PPM for advection rather
                                                !! than upwind.
-  !  This subroutine does refraction on the internal waves at a single frequency.
-
-  ! Arguments:
-  ! (inout) En - the internal gravity wave energy density as a function of space
-  !              and angular resolution, in J m-2 radian-1.
-  ! (in)    cn - baroclinic mode speed, in m s-1
-  ! (in)    freq - wave frequency, in s-1
-  ! (in)    dt - time step, in s
-  ! (in)    use_PPMang - if true, use PPM for advection rather than upwind
-
+  ! Local variables
   integer, parameter :: stencil = 2
   real, dimension(SZI_(G),1-stencil:NAngle+stencil) :: &
     En2d
@@ -958,10 +889,7 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
                              intent(in)    :: CFL_ang !< The CFL number of the energy advection across angles
   real, dimension(0:NAngle), intent(out)   :: Flux_En !< The time integrated internal wave energy flux
                                                       !! across angles, in J m-2 radian-1.
-
-  !   This subroutine calculates the 1-d flux for advection in angular space
-  ! using a monotonic piecewise parabolic scheme. Should be within i and j spatial
-  ! loops
+  ! Local variables
   real :: flux
   real :: u_ang
   real :: Angle_size
@@ -1029,7 +957,7 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
   enddo
 end subroutine PPM_angular_advect
 
-!> This subroutine does refraction on the internal waves at a single frequency.
+!> Propagates internal waves at a single frequency.
 subroutine propagate(En, cn, freq, dt, G, CS, NAngle)
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure.
   integer,               intent(in)    :: NAngle !< The number of wave orientations in the
@@ -1044,15 +972,7 @@ subroutine propagate(En, cn, freq, dt, G, CS, NAngle)
   real,                  intent(in)    :: dt   !< Time step, in s.
   type(int_tide_CS),     pointer       :: CS   !< The control structure returned by a
                                                !! previous call to int_tide_init.
-  !  This subroutine does refraction on the internal waves at a single frequency.
-
-  ! Arguments:
-  ! (inout) En - the internal gravity wave energy density as a function of space
-  !              and angular resolution, in J m-2 radian-1.
-  ! (in)    cn - baroclinic mode speed, in m s-1
-  ! (in)    freq - wave frequency, in s-1
-  ! (in)    dt - time step, in s
-
+  ! Local variables
   real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB) :: &
     speed  ! The magnitude of the group velocity at the q points for corner adv, in m s-1.
   integer, parameter :: stencil = 2
@@ -1179,22 +1099,7 @@ subroutine propagate_corner_spread(En, energized_wedge, NAngle, speed, dt, G, CS
   type(int_tide_CS),      pointer       :: CS    !< The control structure returned by a previous
                                                  !! call to continuity_PPM_init.
   type(loop_bounds_type), intent(in)    :: LB    !< A structure with the active energy loop bounds.
-
-  !   This subroutine does first-order corner advection. It was written with the hopes
-  ! of smoothing out the garden sprinkler effect, but is too numerically diffusive to
-  ! be of much use as of yet. It is not yet compatible with reflection schemes (BDM).
-
-  ! Arguments: En - The energy density integrated over an angular band, in W m-2,
-  !                 intent in/out.
-  !  (in)      energized_wedge - index of current ray direction
-  !  (in)      speed - The magnitude of the group velocity at the cell corner
-  !                      points, in m s-1.
-  !  (in)      dt - Time increment in s.
-  !  (in)      G - The ocean's grid structure.
-  !  (in)      CS - The control structure returned by a previous call to
-  !                 continuity_PPM_init.
-  !  (in)      LB - A structure with the active energy loop bounds.
-
+  ! Local variables
   integer :: i, j, k, ish, ieh, jsh, jeh, m
   real :: TwoPi, Angle_size
   real :: energized_angle ! angle through center of current wedge
@@ -1439,7 +1344,7 @@ subroutine propagate_corner_spread(En, energized_wedge, NAngle, speed, dt, G, CS
   enddo ; enddo
 end subroutine propagate_corner_spread
 
-!> This subroutine propicates the internal wave energy in the logical x-direction.
+!> Propagates the internal wave energy in the logical x-direction.
 subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, Nangle, CS, LB)
   type(ocean_grid_type),   intent(in)    :: G  !< The ocean's grid structure.
   integer,                 intent(in)    :: NAngle !< The number of wave orientations in the
@@ -1457,16 +1362,7 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, Nangle, CS, LB)
   type(int_tide_CS),       pointer       :: CS !< The control structure returned by a previous call
                                                !! to continuity_PPM_init.
   type(loop_bounds_type),  intent(in)    :: LB !< A structure with the active energy loop bounds.
-
-  ! Arguments: En - The energy density integrated over an angular band, in J m-2,
-  !                 intent in/out.
-  !  (in)      speed_x - The magnitude of the group velocity at the Cu
-  !                      points, in m s-1.
-  !  (in)      dt - Time increment in s.
-  !  (in)      G - The ocean's grid structure.
-  !  (in)      CS - The control structure returned by a previous call to
-  !                 continuity_PPM_init.
-  !  (in)      LB - A structure with the active energy loop bounds.
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     EnL, EnR    ! Left and right face energy densities, in J m-2.
   real, dimension(SZIB_(G),SZJ_(G)) :: &
@@ -1531,7 +1427,7 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, Nangle, CS, LB)
 
 end subroutine propagate_x
 
-!> This subroutine propicates the internal wave energy in the logical y-direction.
+!> Propagates the internal wave energy in the logical y-direction.
 subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, Nangle, CS, LB)
   type(ocean_grid_type),   intent(in)    :: G  !< The ocean's grid structure.
   integer,                 intent(in)    :: NAngle !< The number of wave orientations in the
@@ -1549,16 +1445,7 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, Nangle, CS, LB)
   type(int_tide_CS),       pointer       :: CS !< The control structure returned by a previous call
                                                !! to continuity_PPM_init.
   type(loop_bounds_type),  intent(in)    :: LB !< A structure with the active energy loop bounds.
-
-  ! Arguments: En - The energy density integrated over an angular band, in J m-2,
-  !                 intent in/out.
-  !  (in)      speed_y - The magnitude of the group velocity at the Cv
-  !                      points, in m s-1.
-  !  (in)      dt - Time increment in s.
-  !  (in)      G - The ocean's grid structure.
-  !  (in)      CS - The control structure returned by a previous call to
-  !                 continuity_PPM_init.
-  !  (in)      LB - A structure with the active energy loop bounds.
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     EnL, EnR    ! South and north face energy densities, in J m-2.
   real, dimension(SZI_(G),SZJB_(G)) :: &
@@ -1630,7 +1517,7 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, Nangle, CS, LB)
 
 end subroutine propagate_y
 
-!> This subroutines evaluates the zonal mass or volume fluxes in a layer.
+!> Evaluates the zonal mass or volume fluxes in a layer.
 subroutine zonal_flux_En(u, h, hL, hR, uh, dt, G, j, ish, ieh, vol_CFL)
   type(ocean_grid_type),     intent(in)    :: G  !< The ocean's grid structure.
   real, dimension(SZIB_(G)), intent(in)    :: u  !< The zonal velocity, in m s-1.
@@ -1643,21 +1530,12 @@ subroutine zonal_flux_En(u, h, hL, hR, uh, dt, G, j, ish, ieh, vol_CFL)
   real, dimension(SZIB_(G)), intent(inout) :: uh !< The zonal energy transport,
                                                  !! in J s-1.
   real,                      intent(in)    :: dt !< Time increment in s.
-  integer,                   intent(in)    :: j, ish, ieh !< The index range to work on.
+  integer,                   intent(in)    :: j  !< The j-index to work on.
+  integer,                   intent(in)    :: ish !< The start i-index range to work on.
+  integer,                   intent(in)    :: ieh !< The end i-index range to work on.
   logical,                   intent(in)    :: vol_CFL !< If true, rescale the ratio of face areas to
                                                  !! the cell areas when estimating the CFL number.
-
-  !   This subroutines evaluates the zonal mass or volume fluxes in a layer.
-  !
-  ! Arguments: u - Zonal velocity, in m s-1.
-  !  (in)      h - Energy density used to calculate the fluxes, in J m-2.
-  !  (in)      hL, hR - Left- and right- Energy densities in the reconstruction, in J m-2.
-  !  (out)     uh - The zonal energy transport, in J s-1.
-  !  (in)      dt - Time increment in s.
-  !  (in)      G - The ocean's grid structure.
-  !  (in)      j, ish, ieh - The index range to work on.
-  !  (in)      vol_CFL - If true, rescale the ratio of face areas to the cell
-  !                      areas when estimating the CFL number.
+  ! Local variables
   real :: CFL  ! The CFL number based on the local velocity and grid spacing, ND.
   real :: curv_3 ! A measure of the thickness curvature over a grid length,
                  ! with the same units as h_in.
@@ -1683,7 +1561,7 @@ subroutine zonal_flux_En(u, h, hL, hR, uh, dt, G, j, ish, ieh, vol_CFL)
   enddo
 end subroutine zonal_flux_En
 
-!> This subroutines evaluates the meridional mass or volume fluxes in a layer.
+!> Evaluates the meridional mass or volume fluxes in a layer.
 subroutine merid_flux_En(v, h, hL, hR, vh, dt, G, J, ish, ieh, vol_CFL)
   type(ocean_grid_type),            intent(in)    :: G  !< The ocean's grid structure.
   real, dimension(SZI_(G)),         intent(in)    :: v  !< The meridional velocity, in m s-1.
@@ -1696,21 +1574,13 @@ subroutine merid_flux_En(v, h, hL, hR, vh, dt, G, J, ish, ieh, vol_CFL)
   real, dimension(SZI_(G)),         intent(inout) :: vh !< The meridional energy transport,
                                                         !! in J s-1.
   real,                             intent(in)    :: dt !< Time increment in s.
-  integer,                          intent(in)    :: J, ish, ieh !< The index range to work on.
+  integer,                          intent(in)    :: J  !< The j-index to work on.
+  integer,                          intent(in)    :: ish !< The start i-index range to work on.
+  integer,                          intent(in)    :: ieh !< The end i-index range to work on.
   logical,                          intent(in)    :: vol_CFL !< If true, rescale the ratio of face
                                                         !! areas to the cell areas when estimating
                                                         !! the CFL number.
-  !   This subroutines evaluates the meridional mass or volume fluxes in a layer.
-  !
-  ! Arguments: v - Meridional velocity, in m s-1.
-  !  (in)      h - Energy density used to calculate the fluxes, in J m-2.
-  !  (in)      hL, hR - Left- and right- Energy densities in the reconstruction, in J m-2.
-  !  (out)     vh - The meridional energy transport, in J s-1.
-  !  (in)      dt - Time increment in s.
-  !  (in)      G - The ocean's grid structure.
-  !  (in)      J, ish, ieh - The index range to work on.
-  !  (in)      vol_CFL - If true, rescale the ratio of face areas to the cell
-  !                       areas when estimating the CFL number.
+  ! Local variables
   real :: CFL ! The CFL number based on the local velocity and grid spacing, ND.
   real :: curv_3 ! A measure of the thickness curvature over a grid length,
                  ! with the same units as h_in.
@@ -1735,7 +1605,7 @@ subroutine merid_flux_En(v, h, hL, hR, vh, dt, G, J, ish, ieh, vol_CFL)
   enddo
 end subroutine merid_flux_En
 
-!> This subroutine does reflection of the internal waves at a single frequency.
+!> Reflection of the internal waves at a single frequency.
 subroutine reflect(En, NAngle, CS, G, LB)
   type(ocean_grid_type),  intent(in)    :: G  !< The ocean's grid structure
   integer,                intent(in)    :: NAngle !< The number of wave orientations in the
@@ -1747,9 +1617,7 @@ subroutine reflect(En, NAngle, CS, G, LB)
   type(int_tide_CS),      pointer       :: CS !< The control structure returned by a
                                               !! previous call to int_tide_init.
   type(loop_bounds_type), intent(in)    :: LB !< A structure with the active energy loop bounds.
-
-  !  This subroutine does reflection of the internal waves at a single frequency.
-
+  ! Local variables
   real, dimension(G%isd:G%ied,G%jsd:G%jed) :: angle_c
                                            ! angle of boudary wrt equator
   real, dimension(G%isd:G%ied,G%jsd:G%jed) :: part_refl
@@ -1850,7 +1718,7 @@ subroutine reflect(En, NAngle, CS, G, LB)
 
 end subroutine reflect
 
-!> This subroutine moves energy across lines of partial reflection to prevent
+!> Moves energy across lines of partial reflection to prevent
 !! reflection of energy that is supposed to get across.
 subroutine teleport(En, NAngle, CS, G, LB)
   type(ocean_grid_type),  intent(in)    :: G  !< The ocean's grid structure.
@@ -1863,9 +1731,7 @@ subroutine teleport(En, NAngle, CS, G, LB)
   type(int_tide_CS),      pointer       :: CS !< The control structure returned by a
                                               !! previous call to int_tide_init.
   type(loop_bounds_type), intent(in)    :: LB !< A structure with the active energy loop bounds.
-
-  ! This subroutine moves energy across lines of partial reflection to prevent
-  ! reflection of energy that is supposed to get across.
+  ! Local variables
   real, dimension(G%isd:G%ied,G%jsd:G%jed)    :: angle_c
                                               ! angle of boudary wrt equator
   real, dimension(G%isd:G%ied,G%jsd:G%jed)    :: part_refl
@@ -1954,7 +1820,7 @@ subroutine teleport(En, NAngle, CS, G, LB)
 
 end subroutine teleport
 
-!> This subroutine rotates points in the halos where required to accomodate
+!> Rotates points in the halos where required to accomodate
 !! changes in grid orientation, such as at the tripolar fold.
 subroutine correct_halo_rotation(En, test, G, NAngle)
   type(ocean_grid_type),      intent(in)    :: G    !< The ocean's grid structure
@@ -1967,9 +1833,7 @@ subroutine correct_halo_rotation(En, test, G, NAngle)
                                        !! wave energies in the halo region to be corrected.
   integer,                    intent(in)    :: NAngle !< The number of wave orientations in the
                                                       !! discretized wave energy spectrum.
-  !   This subroutine rotates points in the halos where required to accomodate
-  ! changes in grid orientation, such as at the tripolar fold.
-
+  ! Local variables
   real, dimension(G%isd:G%ied,NAngle) :: En2d
   integer, dimension(G%isd:G%ied) :: a_shift
   integer :: i_first, i_last, a_new
@@ -2014,7 +1878,7 @@ subroutine correct_halo_rotation(En, test, G, NAngle)
   enddo
 end subroutine correct_halo_rotation
 
-!> This subroutine calculates left/right edge values for PPM reconstruction.
+!> Calculates left/right edge values for PPM reconstruction in x-direction.
 subroutine PPM_reconstruction_x(h_in, h_l, h_r, G, LB, simple_2nd)
   type(ocean_grid_type),            intent(in)  :: G    !< The ocean's grid structure.
   real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D).
@@ -2024,16 +1888,7 @@ subroutine PPM_reconstruction_x(h_in, h_l, h_r, G, LB, simple_2nd)
   logical, optional,                intent(in)  :: simple_2nd !< If true, use the arithmetic mean
                                                         !! energy densities as default edge values
                                                         !! for a simple 2nd order scheme.
-
-  ! This subroutine calculates left/right edge values for PPM reconstruction.
-  ! Arguments: h_in    - Energy density in a sector (2D)
-  !  (out)     h_l,h_r - left/right edge value of reconstruction (2D)
-  !  (in)      G - The ocean's grid structure.
-  !  (in)      LB - A structure with the active loop bounds.
-  !  (in, opt) simple_2nd - If true, use the arithmetic mean energy densities as
-  !                         default edge values for a simple 2nd order scheme.
-
-  ! Local variables with useful mnemonic names.
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slopes.
   real, parameter :: oneSixth = 1./6.
   real :: h_ip1, h_im1
@@ -2099,7 +1954,7 @@ subroutine PPM_reconstruction_x(h_in, h_l, h_r, G, LB, simple_2nd)
   call PPM_limit_pos(h_in, h_l, h_r, 0.0, G, isl, iel, jsl, jel)
 end subroutine PPM_reconstruction_x
 
-!> This subroutine calculates left/right edge valus for PPM reconstruction.
+!> Calculates left/right edge valus for PPM reconstruction in y-direction.
 subroutine PPM_reconstruction_y(h_in, h_l, h_r, G, LB, simple_2nd)
   type(ocean_grid_type),            intent(in)  :: G    !< The ocean's grid structure.
   real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D).
@@ -2109,16 +1964,7 @@ subroutine PPM_reconstruction_y(h_in, h_l, h_r, G, LB, simple_2nd)
   logical, optional,                intent(in)  :: simple_2nd !< If true, use the arithmetic mean
                                                         !! energy densities as default edge values
                                                         !! for a simple 2nd order scheme.
-
-  ! This subroutine calculates left/right edge valus for PPM reconstruction.
-  ! Arguments: h_in    - Energy density in a sector (2D)
-  !  (out)     h_l,h_r - left/right edge value of reconstruction (2D)
-  !  (in)      G - The ocean's grid structure.
-  !  (in)      LB - A structure with the active loop bounds.
-  !  (in, opt) simple_2nd - If true, use the arithmetic mean energy densities as
-  !                         default edge values for a simple 2nd order scheme.
-
-  ! Local variables with useful mnemonic names.
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slopes.
   real, parameter :: oneSixth = 1./6.
   real :: h_jp1, h_jm1
@@ -2193,21 +2039,10 @@ subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, iis, iie, jis, jie)
   real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_R   !< Right edge value (2D).
   real,                             intent(in)     :: h_min !< The minimum thickness that can be
                                                             !! obtained by a concave parabolic fit.
-  integer,                          intent(in)     :: iis, iie, jis, jie !< Index range for
-                                                            !! computation.
-
-  ! This subroutine limits the left/right edge values of the PPM reconstruction
-  ! to give a reconstruction that is positive-definite.  Here this is
-  ! reinterpreted as giving a constant thickness if the mean thickness is less
-  ! than h_min, with a minimum of h_min otherwise.
-  ! Arguments: h_in    - thickness of layer (2D)
-  !  (inout)   h_L     - left edge value (2D)
-  !  (inout)   h_R     - right edge value (2D)
-  !  (in)      h_min   - The minimum thickness that can be obtained by a
-  !                      concave parabolic fit.
-  !  (in)      iis, iie, jis, jie - Index range for computation.
-  !  (in)      G - The ocean's grid structure.
-
+  integer,                          intent(in)     :: iis   !< Start i-index for computations
+  integer,                          intent(in)     :: iie   !< End i-index for computations
+  integer,                          intent(in)     :: jis   !< Start j-index for computations
+  integer,                          intent(in)     :: jie   !< End j-index for computations
   ! Local variables
   real    :: curv, dh, scale
   character(len=256) :: mesg  ! The text of an error message
@@ -2293,15 +2128,7 @@ subroutine internal_tides_init(Time, G, GV, param_file, diag, CS)
                                                    !! diagnostic output.
   type(int_tide_CS),pointer                :: CS   !< A pointer that is set to point to the control
                                                    !! structure for this module.
-
-  ! Arguments: Time - The current model time.
-  !  (in)      G - The ocean's grid structure.
-  !  (in)      GV - The ocean's vertical grid structure.
-  !  (in)      param_file - A structure indicating the open file to parse for
-  !                         model parameter values.
-  !  (in)      diag - A structure that is used to regulate diagnostic output.
-  !  (in/out)  CS - A pointer that is set to point to the control structure
-  !                 for this module
+  ! Local variables
   real                              :: Angle_size ! size of wedges, rad
   real, allocatable                 :: angles(:)  ! orientations of wedge centers, rad
   real, allocatable, dimension(:,:) :: h2         ! topographic roughness scale, m^2
@@ -2734,6 +2561,5 @@ subroutine internal_tides_end(CS)
   endif
   CS => NULL()
 end subroutine internal_tides_end
-
 
 end module MOM_internal_tides

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -937,7 +937,7 @@ end subroutine mixedlayer_restrat_register_restarts
 
 !> \namespace mom_mixed_layer_restrat
 !!
-!! \section mle-module Mixed-layer eddy parameterization module
+!! \section section_mle Mixed-layer eddy parameterization module
 !!
 !! The subroutines in this file implement a parameterization of unresolved viscous
 !! mixed layer restratification of the mixed layer as described in Fox-Kemper et
@@ -956,7 +956,7 @@ end subroutine mixedlayer_restrat_register_restarts
 !! grid scale (whichever is smaller to the dominant horizontal length-scale of the
 !! sub-meso-scale mixed layer instabilities.
 !!
-!! \subsection section-submeso-nutshell "Sub-meso" in a nutshell
+!! \subsection section_mle_nutshell "Sub-meso" in a nutshell
 !!
 !! The parameterization is colloquially referred to as "sub-meso".
 !!
@@ -995,7 +995,7 @@ end subroutine mixedlayer_restrat_register_restarts
 !! \f$ C_e \f$ is hard-coded as 0.0625. \f$ \tau \f$ is calculated from the surface friction velocity \f$ u^* \f$.
 !! \todo Explain expression for momentum mixing time-scale.
 !!
-!! \subsection section-mle-filtering Time-filtering of mixed-layer depth
+!! \subsection section_mle_filtering Time-filtering of mixed-layer depth
 !!
 !! Using the instantaneous mixed-layer depth is inconsistent with the finite life-time of
 !! mixed-layer instabilities. We provide a one-sided running-mean filter of mixed-layer depth, \f$ H \f$, of the form:
@@ -1006,7 +1006,7 @@ end subroutine mixedlayer_restrat_register_restarts
 !! but to decay with time-scale \f$ \tau_h \f$.
 !! \f$ \bar{H} \f$ is substituted for \f$ H \f$ in the above equations.
 !!
-!! \subsection section-mle-mld Defining the mixed-layer-depth
+!! \subsection section_mle_mld Defining the mixed-layer-depth
 !!
 !! If the parameter MLE_USE_PBL_MLD=True then the mixed-layer depth is defined/diagnosed by the
 !! boundary-layer parameterization (e.g. ePBL, KPP, etc.).
@@ -1015,7 +1015,7 @@ end subroutine mixedlayer_restrat_register_restarts
 !! as the depth of a given density difference, \f$ \Delta \rho \f$, with the surface where the
 !! density difference is the parameter MLE_DENSITY_DIFF.
 !!
-!! \subsection section-mle-ref References
+!! \subsection section_mle_ref References
 !!
 !! Fox-Kemper, B., Ferrari, R. and Hallberg, R., 2008:
 !! Parameterization of Mixed Layer Eddies. Part I: Theory and Diagnosis

--- a/src/parameterizations/vertical/MOM_KPP.F90
+++ b/src/parameterizations/vertical/MOM_KPP.F90
@@ -176,7 +176,7 @@ logical function KPP_init(paramFile, G, diag, Time, CS, passive, Waves)
   type(param_file_type),   intent(in)    :: paramFile !< File parser
   type(ocean_grid_type),   intent(in)    :: G         !< Ocean grid
   type(diag_ctrl), target, intent(in)    :: diag      !< Diagnostics
-  type(time_type),         intent(in)    :: Time      !< Time
+  type(time_type),         intent(in)    :: Time      !< Model time
   type(KPP_CS),            pointer       :: CS        !< Control structure
   logical,       optional, intent(out)   :: passive   !< Copy of %passiveMode
   type(wave_parameters_CS), optional, pointer :: Waves !< Wave CS

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -487,7 +487,10 @@ end subroutine insert_brine
 subroutine triDiagTS(G, GV, is, ie, js, je, hold, ea, eb, T, S)
   type(ocean_grid_type),                    intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),                  intent(in)    :: GV   !< The ocean's vertical grid structure
-  integer,                                  intent(in)    :: is, ie, js, je !< The range of indices to work on.
+  integer,                                  intent(in)    :: is   !< The start i-index to work on.
+  integer,                                  intent(in)    :: ie   !< The end i-index to work on.
+  integer,                                  intent(in)    :: js   !< The start j-index to work on.
+  integer,                                  intent(in)    :: je   !< The end j-index to work on.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: hold !< The layer thicknesses before entrainment, in H.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: ea !< The amount of fluid entrained from the layer
                                                  !! above within this time step, in units of H.

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -1269,7 +1269,8 @@ subroutine determine_dSkb(h_bl, Sref, Ent_bl, E_kb, is, ie, kmb, G, GV, limit, &
                                                               !! around the buffer layers, in H.
   real, dimension(SZI_(G)),           intent(in)    :: E_kb   !< The entrainment by the top interior
                                                               !! layer, in H.
-  integer,                            intent(in)    :: is, ie !< The range of i-indices to work on.
+  integer,                            intent(in)    :: is     !< The start of the i-index range to work on.
+  integer,                            intent(in)    :: ie     !< The end of the i-index range to work on.
   integer,                            intent(in)    :: kmb    !< The number of mixed and buffer layers.
   logical,                            intent(in)    :: limit  !< If true, limit dSkb and dSlay to
                                                               !! avoid negative values.
@@ -1672,7 +1673,8 @@ subroutine determine_Ea_kb(h_bl, dtKd_kb, Sref, I_dSkbp1, Ent_bl, ea_kbp1, &
   real, dimension(SZI_(G)),         intent(in)  :: max_eakb !< The maximum permissible rate of
                                                             !! entrainment, in H.
   integer,                          intent(in)  :: kmb      !< The number of mixed and buffer layers.
-  integer,                          intent(in)  :: is, ie   !< The range of i-indices to work on.
+  integer,                          intent(in)  :: is       !< The start of the i-index range to work on.
+  integer,                          intent(in)  :: ie       !< The end of the i-index range to work on.
   logical, dimension(SZI_(G)),      intent(in)  :: do_i     !< A logical variable indicating which
                                                             !! i-points to work on.
   type(entrain_diffusive_CS),       pointer     :: CS       !< This module's control structure.
@@ -1682,11 +1684,12 @@ subroutine determine_Ea_kb(h_bl, dtKd_kb, Sref, I_dSkbp1, Ent_bl, ea_kbp1, &
   real, dimension(SZI_(G)), optional, intent(out) :: error  !< The error (locally defined in this
                                                             !! routine) associated with the returned
                                                             !! solution.
-  real, dimension(SZI_(G)), optional, intent(in)  :: err_min_eakb0, err_max_eakb0 !< The errors
-                                                            !! (locally defined) associated with
-                                                            !! min_eakb and max_eakb when ea_kbp1
-                                                            !! = 0, returned from a previous call
-                                                            !! to this routine.
+  real, dimension(SZI_(G)), optional, intent(in)  :: err_min_eakb0 !< The errors (locally defined)
+                                                            !! associated with min_eakb when ea_kbp1 = 0,
+                                                            !! returned from a previous call to this fn.
+  real, dimension(SZI_(G)), optional, intent(in)  :: err_max_eakb0 !< The errors (locally defined)
+                                                            !! associated with min_eakb when ea_kbp1 = 0,
+                                                            !! returned from a previous call to this fn.
   real, dimension(SZI_(G)), optional, intent(out) :: F_kb   !< The entrainment from below by the
                                                             !! uppermost interior layer
                                                             !! corresponding to the returned
@@ -1904,7 +1907,8 @@ subroutine find_maxF_kb(h_bl, Sref, Ent_bl, I_dSkbp1, min_ent_in, max_ent_in, &
   real, dimension(SZI_(G)),   intent(in)  :: max_ent_in !< The maximum value of ent to search,
                                                       !! in H.
   integer,                    intent(in)  :: kmb      !< The number of mixed and buffer layers.
-  integer,                    intent(in)  :: is, ie   !< The range of i-indices to work on.
+  integer,                    intent(in)  :: is       !< The start of the i-index range to work on.
+  integer,                    intent(in)  :: ie       !< The end of the i-index range to work on.
   type(entrain_diffusive_CS), pointer     :: CS       !< This module's control structure.
   real, dimension(SZI_(G)),   intent(out) :: maxF     !< The maximum value of F
                                                       !! = ent*ds_kb*I_dSkbp1 found in the range

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -1,27 +1,7 @@
+!> Calculates energy input to the internal tides
 module MOM_int_tide_input
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*  By Robert Hallberg, January 2013                                   *
-!*                                                                     *
-!*    This file contains the subroutines that sets the energy input    *
-!*  to the internal tides.                                             *
-!*                                                                     *
-!*     A small fragment of the grid is shown below:                    *
-!*                                                                     *
-!*    j+1  x ^ x ^ x   At x:  q                                        *
-!*    j+1  > o > o >   At ^:  v                                        *
-!*    j    x ^ x ^ x   At >:  u                                        *
-!*    j    > o > o >   At o:  h, buoy, ustar, T, S, Kd, ea, eb, etc.   *
-!*    j-1  x ^ x ^ x                                                   *
-!*        i-1  i  i+1  At x & ^:                                       *
-!*           i  i+1    At > & o:                                       *
-!*                                                                     *
-!*  The boundaries always run through q grid points (x).               *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock, only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
@@ -71,7 +51,7 @@ end type int_tide_input_type
 
 contains
 
-!> This subroutine sets the model-state dependent internal tide energy sources.
+!> Sets the model-state dependent internal tide energy sources.
 subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, CS)
   type(ocean_grid_type),                     intent(in)    :: G  !< The ocean's grid structure
   type(verticalGrid_type),                   intent(in)    :: GV !< The ocean's vertical grid structure
@@ -85,20 +65,7 @@ subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, CS)
                                                                  !! to the internal tide sources.
   real,                                      intent(in)    :: dt !< The time increment in s.
   type(int_tide_input_CS),                   pointer       :: CS !< This module's control structure.
-
-! Arguments: u - Zonal velocity, in m s-1.
-!  (in)      v - Meridional velocity, in m s-1.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      tv - A structure containing pointers to any available
-!                 thermodynamic fields. Absent fields have NULL ptrs.
-!  (in)      fluxes - A structure of surface fluxes that may be used.
-!  (inout)   itide - A structure containing fields related to the internal
-!                    tide sources.
-!  (in)      dt - The time increment in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - This module's control structure.
-
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     N2_bot        ! The bottom squared buoyancy frequency, in s-2.
 
@@ -148,7 +115,7 @@ subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, CS)
 
 end subroutine set_int_tide_input
 
-!> This subroutine estimates the near-bottom buoyancy frequency (N^2).
+!> Estimates the near-bottom buoyancy frequency (N^2).
 subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, N2_bot)
   type(ocean_grid_type),                    intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type),                  intent(in)  :: GV   !< The ocean's vertical grid structure
@@ -164,7 +131,7 @@ subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, N2_bot)
   type(int_tide_input_CS),                  pointer     :: CS    !<  This module's control structure.
   real, dimension(SZI_(G),SZJ_(G)),         intent(out) :: N2_bot !< The squared buoyancy freqency at the
                                                                  !! ocean bottom, in s-2.
-
+  ! Local variables
   real, dimension(SZI_(G),SZK_(G)+1) :: &
     dRho_int      ! The unfiltered density differences across interfaces.
   real, dimension(SZI_(G)) :: &
@@ -262,7 +229,7 @@ subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, N2_bot)
 
 end subroutine find_N2_bottom
 
-!> This subroutine initializes the data related to the internal tide input module
+!> Initializes the data related to the internal tide input module
 subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
   type(time_type),           intent(in)    :: Time !< The current model time
   type(ocean_grid_type),     intent(in)    :: G    !< The ocean's grid structure
@@ -272,15 +239,7 @@ subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
   type(int_tide_input_CS),   pointer       :: CS   !< This module's control structure, which is initialized here.
   type(int_tide_input_type), pointer       :: itide !< A structure containing fields related
                                                    !! to the internal tide sources.
-! Arguments: Time - The current model time.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
-!  (in)      diag_to_Z_CSp - A pointer to the Z-diagnostics control structure.
+  ! Local variables
   type(vardesc) :: vd
   logical :: read_tideamp
 ! This include declares and sets the variable "version".
@@ -397,7 +356,7 @@ subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
 
 end subroutine int_tide_input_init
 
-!> This subroutine deallocates any memory related to the internal tide input module.
+!> Deallocates any memory related to the internal tide input module.
 subroutine int_tide_input_end(CS)
   type(int_tide_input_CS), pointer :: CS !< This module's control structure, which is deallocated here.
 

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -934,7 +934,9 @@ function set_v_at_u(v, h, G, i, j, k, mask2dCv, OBC)
                          intent(in) :: v    !< The meridional velocity, in m s-1
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                          intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  integer,               intent(in) :: i, j, k !< The indices of the u-location to work on.
+  integer,               intent(in) :: i    !< The i-index of the u-location to work on.
+  integer,               intent(in) :: j    !< The j-index of the u-location to work on.
+  integer,               intent(in) :: k    !< The k-index of the u-location to work on.
   real, dimension(SZI_(G),SZJB_(G)),&
                          intent(in) :: mask2dCv !< A multiplicative mask of the v-points
   type(ocean_OBC_type),  pointer    :: OBC  !< A pointer to an open boundary condition structure
@@ -975,7 +977,9 @@ function set_u_at_v(u, h, G, i, j, k, mask2dCu, OBC)
                          intent(in) :: u    !< The zonal velocity, in m s-1
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                          intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-  integer,               intent(in) :: i, j, k !< The indices of the v-location to work on.
+  integer,               intent(in) :: i    !< The i-index of the u-location to work on.
+  integer,               intent(in) :: j    !< The j-index of the u-location to work on.
+  integer,               intent(in) :: k    !< The k-index of the u-location to work on.
   real, dimension(SZIB_(G),SZJ_(G)), &
                          intent(in) :: mask2dCu !< A multiplicative mask of the u-points
   type(ocean_OBC_type),  pointer    :: OBC  !< A pointer to an open boundary condition structure

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -1268,9 +1268,9 @@ real function absolute_position(n,ns,Pint,Karr,NParr,k_surface)
   real,    intent(in) :: Pint(n+1)    !< Position of interfaces (Pa)
   integer, intent(in) :: Karr(ns)     !< Index of interface above position
   real,    intent(in) :: NParr(ns)    !< Non-dimensional position within layer Karr(:)
-
+  integer, intent(in) :: k_surface    !< k-interface to query
   ! Local variables
-  integer :: k_surface, k
+  integer :: k
 
   k = Karr(k_surface)
   if (k>n) stop 'absolute_position: k>nk is out of bounds!'

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -439,7 +439,8 @@ subroutine boundary_impulse_tracer_end(CS)
 end subroutine boundary_impulse_tracer_end
 
 !> \namespace boundary_impulse_tracer
-!! \section Boundary Impulse Response Tracer and Transit Time Distributions
+!!
+!! \section section_BIT_desc Boundary Impulse Response Tracer and Transit Time Distributions
 !! Transit time distributions (TTD) are the Green's function solution of the passive tracer equation between
 !! the oceanic surface and interior. The name derives from the idea that the 'age' (e.g. time since last
 !! contact with the atmosphere) of a water parcel is best characterized as a distribution of ages
@@ -456,18 +457,18 @@ end subroutine boundary_impulse_tracer_end
 !! In the References section, both the theoretical discussion of TTDs and BIRs are listed along with
 !! modeling studies which have this used framework in scientific investigations
 !!
-!! \section Run-time parameters
+!! \section section_BIT_params Run-time parameters
 !! -DO_BOUNDARY_IMPULSE_TRACER: Enables the boundary impulse tracer model
 !! -IMPULSE_SOURCE_TIME: Length of time that the surface layer acts as a source of the BIR tracer
 !!
-!! \section References
+!! \section section_BIT_refs References
 !! \subsection TTD and BIR Theory
 !!  -Holzer, M., and T.M. Hall, 2000: Transit-time and tracer-age distributions in geophysical flows.
 !!    J. Atmos. Sci., 57, 3539-3558, doi:10.1175/1520-0469(2000)057<3539:TTATAD>2.0.CO;2.
 !!  -T.W.N. Haine, H. Zhang, D.W. Waugh, M. Holzer, On transit-time distributions in unsteady circulation
 !!    models, Ocean Modelling, Volume 21, Issues 1–2, 2008, Pages 35-45, ISSN 1463-5003
 !!    http://dx.doi.org/10.1016/j.ocemod.2007.11.004.
-!! \subsection BIR Modelling applications
+!! \subsection section_BIT_apps Modelling applications
 !!  -Peacock, S., and M. Maltrud (2006), Transit-time distributions in a global ocean model,
 !!    J. Phys. Oceanogr., 36(3), 474–495, doi:10.1175/JPO2860.1.
 !!  -Maltrud, M., Bryan, F. & Peacock, Boundary impulse response functions in a century-long eddying global

--- a/src/user/SCM_CVmix_tests.F90
+++ b/src/user/SCM_CVmix_tests.F90
@@ -122,9 +122,9 @@ end subroutine SCM_CVMix_tests_TS_init
 
 !> Initializes surface forcing for the CVMix test case suite
 subroutine SCM_CVMix_tests_surface_forcing_init(Time, G, param_file, CS)
-  type(time_type),              intent(in) :: Time       !< Time
-  type(ocean_grid_type),        intent(in) :: G          !< Grid structure
-  type(param_file_type),        intent(in) :: param_file !< Input parameter structure
+  type(time_type),          intent(in) :: Time       !< Model time
+  type(ocean_grid_type),    intent(in) :: G          !< Grid structure
+  type(param_file_type),    intent(in) :: param_file !< Input parameter structure
   type(SCM_CVMix_tests_CS), pointer    :: CS         !< Parameter container
 
 ! This include declares and sets the variable "version".

--- a/src/user/SCM_idealized_hurricane.F90
+++ b/src/user/SCM_idealized_hurricane.F90
@@ -95,9 +95,9 @@ end subroutine SCM_idealized_hurricane_TS_init
 
 !> Initializes wind profile for the SCM idealized hurricane example
 subroutine SCM_idealized_hurricane_wind_init(Time, G, param_file, CS)
-  type(time_type),              intent(in) :: Time       !< Time
-  type(ocean_grid_type),        intent(in) :: G          !< Grid structure
-  type(param_file_type),        intent(in) :: param_file !< Input parameter structure
+  type(time_type),                  intent(in) :: Time       !< Model time
+  type(ocean_grid_type),            intent(in) :: G          !< Grid structure
+  type(param_file_type),            intent(in) :: param_file !< Input parameter structure
   type(SCM_idealized_hurricane_CS), pointer    :: CS         !< Parameter container
 
 ! This include declares and sets the variable "version".

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -1,3 +1,4 @@
+!> Configures the model for the geostrophic adjustment test case.
 module adjustment_initialization
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -15,27 +16,17 @@ use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA
 
 implicit none ; private
 
-character(len=40) :: mdl = "adjustment_initialization" ! This module's name.
+character(len=40) :: mdl = "adjustment_initialization" !< This module's name.
 
 #include <MOM_memory.h>
 
-! -----------------------------------------------------------------------------
-! The following routines are visible to the outside world
-! -----------------------------------------------------------------------------
 public adjustment_initialize_thickness
 public adjustment_initialize_temperature_salinity
 
-! -----------------------------------------------------------------------------
-! This module contains the following routines
-! -----------------------------------------------------------------------------
 contains
 
-!------------------------------------------------------------------------------
-!> Initialization of thicknesses.
-!! This subroutine initializes the layer thicknesses to be uniform.
-!------------------------------------------------------------------------------
+!> Initializes the layer thicknesses in the adjustment test case
 subroutine adjustment_initialize_thickness ( h, G, GV, param_file, just_read_params)
-
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
@@ -44,7 +35,7 @@ subroutine adjustment_initialize_thickness ( h, G, GV, param_file, just_read_par
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-
+  ! Local variables
   real :: e0(SZK_(G)+1)   ! The resting interface heights, in m, usually !
                           ! negative because it is positive upward.      !
   real :: eta1D(SZK_(G)+1)! Interface height relative to the sea surface !
@@ -57,7 +48,6 @@ subroutine adjustment_initialize_thickness ( h, G, GV, param_file, just_read_par
   character(len=20) :: verticalCoordinate
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mdl = "adjustment_initialization"   ! This module's name.
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -183,10 +173,7 @@ subroutine adjustment_initialize_thickness ( h, G, GV, param_file, just_read_par
 
 end subroutine adjustment_initialize_thickness
 
-
-!------------------------------------------------------------------------------
-!> Initialization of temperature and salinity.
-!------------------------------------------------------------------------------
+!> Initialization of temperature and salinity in the adjustment test case
 subroutine adjustment_initialize_temperature_salinity ( T, S, h, G, GV, param_file, &
                                                     eqn_of_state, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
@@ -297,8 +284,4 @@ subroutine adjustment_initialize_temperature_salinity ( T, S, h, G, GV, param_fi
 
 end subroutine adjustment_initialize_temperature_salinity
 
-!> \namespace adjustment_initialization
-!!
-!! The module configures the model for the geostrophic adjustment
-!! test case.
 end module adjustment_initialization

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -22,7 +22,7 @@ public dense_water_initialize_topography
 public dense_water_initialize_TS
 public dense_water_initialize_sponges
 
-character(len=40) :: mdl = "dense_water_initialization"
+character(len=40) :: mdl = "dense_water_initialization" !< Module name
 
 real, parameter :: default_sill  = 0.2 !< Default depth of the sill [nondim]
 real, parameter :: default_shelf = 0.4 !< Default depth of the shelf [nondim]
@@ -36,7 +36,7 @@ subroutine dense_water_initialize_topography(D, G, param_file, max_depth)
   real, dimension(SZI_(G),SZJ_(G)), intent(out) :: D !< Output topography field
   type(param_file_type),            intent(in)  :: param_file !< Parameter file structure
   real,                             intent(in)  :: max_depth !< Maximum depth of the model
-
+  ! Local variables
   real, dimension(5) :: domain_params ! nondimensional widths of all domain sections
   real :: sill_frac, shelf_frac
   integer :: i, j
@@ -101,7 +101,7 @@ subroutine dense_water_initialize_TS(G, GV, param_file, eqn_of_state, T, S, h, j
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thicknesses
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
-
+  ! Local variables
   real :: mld, S_ref, S_range, T_ref
   real :: zi, zmid
   logical :: just_read    ! If true, just read parameters but set nothing.
@@ -154,7 +154,6 @@ subroutine dense_water_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, A
   logical,                 intent(in) :: use_ALE !< ALE flag
   type(sponge_CS),         pointer    :: CSp !< Layered sponge control structure pointer
   type(ALE_sponge_CS),     pointer    :: ACSp !< ALE sponge control structure pointer
-
   ! Local variables
   real :: west_sponge_time_scale, west_sponge_width
   real :: east_sponge_time_scale, east_sponge_width
@@ -279,7 +278,7 @@ end subroutine dense_water_initialize_sponges
 
 end module dense_water_initialization
 
-!! \namespace dense_water_initialization
+!> \namespace dense_water_initialization
 !!
 !! This experiment consists of a shelf accumulating dense water, which spills
 !! over an upward slope and a sill, before flowing down a slope into an open

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -96,7 +96,8 @@ subroutine dense_water_initialize_TS(G, GV, param_file, eqn_of_state, T, S, h, j
   type(verticalGrid_type),                   intent(in)  :: GV !< Vertical grid control structure
   type(param_file_type),                     intent(in)  :: param_file !< Parameter file structure
   type(EOS_type),                            pointer     :: eqn_of_state !< EOS structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T, S !< Output state
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T !< Output temperature (degC)
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S !< Output salinity (ppt)
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thicknesses
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -1,3 +1,4 @@
+!> Configures the model for the idealized dumbbell test case.
 module dumbbell_initialization
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -22,18 +23,13 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-character(len=40) :: mdl = "dumbbell_initialization" ! This module's name.
+character(len=40) :: mdl = "dumbbell_initialization" !< This module's name.
 
-! -----------------------------------------------------------------------------
-! The following routines are visible to the outside world
-! -----------------------------------------------------------------------------
 public dumbbell_initialize_topography
 public dumbbell_initialize_thickness
 public dumbbell_initialize_temperature_salinity
 public dumbbell_initialize_sponges
-! -----------------------------------------------------------------------------
-! This module contains the following routines
-! -----------------------------------------------------------------------------
+
 contains
 
 !> Initialization of topography.
@@ -44,7 +40,6 @@ subroutine dumbbell_initialize_topography ( D, G, param_file, max_depth )
                                       intent(out) :: D !< Ocean bottom depth in m
   type(param_file_type),              intent(in)  :: param_file !< Parameter file structure
   real,                               intent(in)  :: max_depth  !< Maximum depth of model in m
-
   ! Local variables
   integer   :: i, j
   real      :: x, y, delta, dblen, dbfrac
@@ -74,8 +69,7 @@ subroutine dumbbell_initialize_topography ( D, G, param_file, max_depth )
 
 end subroutine dumbbell_initialize_topography
 
-!> Initialization of thicknesses.
-!! This subroutine initializes the layer thicknesses to be uniform.
+!> Initializes the layer thicknesses to be uniform in the dumbbell test case
 subroutine dumbbell_initialize_thickness ( h, G, GV, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
@@ -183,7 +177,7 @@ end select
 
 end subroutine dumbbell_initialize_thickness
 
-!> Initial values for temperature and salinity
+!> Initial values for temperature and salinity for the dumbbell test case
 subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, param_file, &
                                                   eqn_of_state, just_read_params)
   type(ocean_grid_type),                     intent(in)  :: G !< Ocean grid structure
@@ -251,7 +245,7 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, param_file
 
 end subroutine dumbbell_initialize_temperature_salinity
 
-!> Initialize the restoring sponges for the dense water experiment
+!> Initialize the restoring sponges for the dumbbell test case
 subroutine dumbbell_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
   type(ocean_grid_type),   intent(in) :: G !< Horizontal grid control structure
   type(verticalGrid_type), intent(in) :: GV !< Vertical grid control structure
@@ -349,8 +343,4 @@ subroutine dumbbell_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp
 
 end subroutine dumbbell_initialize_sponges
 
-!> \namespace dumbbell_initialization
-!!
-!! The module configures the model for the idealized dumbbell
-!! test case.
 end module dumbbell_initialization

--- a/src/user/dumbbell_surface_forcing.F90
+++ b/src/user/dumbbell_surface_forcing.F90
@@ -1,14 +1,8 @@
+!> Surface forcing for the dumbbell test case
 module dumbbell_surface_forcing
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*                                                                     *
-!*  This file contains subroutines for specifying surface dynamic      *
-!*  forcing for the dumbbell case.                                     *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 use MOM_diag_mediator, only : post_data, query_averaging_enabled
 use MOM_diag_mediator, only : register_diag_field, diag_ctrl
 use MOM_domains, only : pass_var, pass_vector, AGRID
@@ -27,75 +21,45 @@ implicit none ; private
 
 public dumbbell_dynamic_forcing, dumbbell_buoyancy_forcing, dumbbell_surface_forcing_init
 
+!> Control structure for the dumbbell test case forcing
 type, public :: dumbbell_surface_forcing_CS ; private
-  !   This control structure should be used to store any run-time variables
-  ! associated with the user-specified forcing.  It can be readily modified
-  ! for a specific case, and because it is private there will be no changes
-  ! needed in other code (although they will have to be recompiled).
-  !   The variables in the cannonical example are used for some common
-  ! cases, but do not need to be used.
-
-  logical :: use_temperature ! If true, temperature and salinity are used as
-                             ! state variables.
-  logical :: restorebuoy     ! If true, use restoring surface buoyancy forcing.
-  real :: Rho0               !   The density used in the Boussinesq
-                             ! approximation, in kg m-3.
-  real :: G_Earth            !   The gravitational acceleration in m s-2.
-  real :: Flux_const         !   The restoring rate at the surface, in m s-1.
-  real :: gust_const         !   A constant unresolved background gustiness
-                             ! that contributes to ustar, in Pa.
-  real :: slp_amplitude      ! The amplitude of pressure loading (in Pa) applied
-                             ! to the reservoirs
-  real :: slp_period         ! Period of sinusoidal pressure wave
+  logical :: use_temperature !< If true, temperature and salinity are used as
+                             !! state variables.
+  logical :: restorebuoy     !< If true, use restoring surface buoyancy forcing.
+  real :: Rho0               !<   The density used in the Boussinesq
+                             !! approximation, in kg m-3.
+  real :: G_Earth            !<   The gravitational acceleration in m s-2.
+  real :: Flux_const         !<   The restoring rate at the surface, in m s-1.
+  real :: gust_const         !<   A constant unresolved background gustiness
+                             !! that contributes to ustar, in Pa.
+  real :: slp_amplitude      !< The amplitude of pressure loading (in Pa) applied
+                             !! to the reservoirs
+  real :: slp_period         !< Period of sinusoidal pressure wave
   real, dimension(:,:), allocatable :: &
-    forcing_mask             ! A mask regulating where forcing occurs
+    forcing_mask             !< A mask regulating where forcing occurs
   real, dimension(:,:), allocatable :: &
-    S_restore                ! The surface salinity field toward which to
-                             ! restore, in PSU.
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+    S_restore                !< The surface salinity field toward which to
+                             !! restore, in PSU.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to regulate the
+                             !! timing of diagnostic output.
 end type dumbbell_surface_forcing_CS
 
 contains
 
+!> Surface buoyancy (heat and fresh water) fluxes for the dumbbell test case
 subroutine dumbbell_buoyancy_forcing(state, fluxes, day, dt, G, CS)
   type(surface),                 intent(inout) :: state  !< A structure containing fields that
-                                                       !! describe the surface state of the ocean.
+                                                         !! describe the surface state of the ocean.
   type(forcing),                 intent(inout) :: fluxes !< A structure containing pointers to any
-                                                       !! possible forcing fields. Unused fields
-                                                       !! have NULL ptrs.
-  type(time_type),               intent(in)    :: day  !< Time of the fluxes.
-  real,                          intent(in)    :: dt   !< The amount of time over which
-                                                       !! the fluxes apply, in s
-  type(ocean_grid_type),         intent(in)    :: G    !< The ocean's grid structure
-  type(dumbbell_surface_forcing_CS),  pointer  :: CS   !< A control structure returned by a previous
-                                                       !! call to dumbbell_surface_forcing_init
-
-!    This subroutine specifies the current surface fluxes of buoyancy or
-!  temperature and fresh water.  It may also be modified to add
-!  surface fluxes of user provided tracers.
-
-!    When temperature is used, there are long list of fluxes that need to be
-!  set - essentially the same as for a full coupled model, but most of these
-!  can be simply set to zero.  The net fresh water flux should probably be
-!  set in fluxes%evap and fluxes%lprec, with any salinity restoring
-!  appearing in fluxes%vprec, and the other water flux components
-!  (fprec, lrunoff and frunoff) left as arrays full of zeros.
-!  Evap is usually negative and precip is usually positive.  All heat fluxes
-!  are in W m-2 and positive for heat going into the ocean.  All fresh water
-!  fluxes are in kg m-2 s-1 and positive for water moving into the ocean.
-
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (out)     fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      day_start - Start time of the fluxes.
-!  (in)      day_interval - Length of time over which these fluxes
-!                           will be applied.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - A pointer to the control structure returned by a previous
-!                 call to user_surface_forcing_init
-
+                                                         !! possible forcing fields. Unused fields
+                                                         !! have NULL ptrs.
+  type(time_type),               intent(in)    :: day    !< Time of the fluxes.
+  real,                          intent(in)    :: dt     !< The amount of time over which
+                                                         !! the fluxes apply, in s
+  type(ocean_grid_type),         intent(in)    :: G      !< The ocean's grid structure
+  type(dumbbell_surface_forcing_CS),  pointer  :: CS     !< A control structure returned by a previous
+                                                         !! call to dumbbell_surface_forcing_init
+  ! Local variables
   real :: Temp_restore   ! The temperature that is being restored toward, in C.
   real :: Salin_restore  ! The salinity that is being restored toward, in PSU.
   real :: density_restore  ! The potential density that is being restored
@@ -109,13 +73,8 @@ subroutine dumbbell_buoyancy_forcing(state, fluxes, day, dt, G, CS)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
-  !   When modifying the code, comment out this error message.  It is here
-  ! so that the original (unmodified) version is not accidentally used.
-  ! call MOM_error(FATAL, "User_buoyancy_surface_forcing: " // &
-  !   "User forcing routine called without modification." )
 
-  ! Allocate and zero out the forcing arrays, as necessary.  This portion is
-  ! usually not changed.
+  ! Allocate and zero out the forcing arrays, as necessary.
   if (CS%use_temperature) then
     call safe_alloc_ptr(fluxes%evap, isd, ied, jsd, jed)
     call safe_alloc_ptr(fluxes%lprec, isd, ied, jsd, jed)
@@ -162,21 +121,21 @@ subroutine dumbbell_buoyancy_forcing(state, fluxes, day, dt, G, CS)
   endif
 
   if (CS%use_temperature .and. CS%restorebuoy) then
-      do j=js,je ; do i=is,ie
-       !   Set density_restore to an expression for the surface potential
-       ! density in kg m-3 that is being restored toward.
-        if (CS%forcing_mask(i,j)>0.) then
-          fluxes%vprec(i,j) = - (G%mask2dT(i,j) * (CS%Rho0*CS%Flux_const)) * &
-            ((CS%S_restore(i,j) - state%SSS(i,j)) / &
-             (0.5 * (CS%S_restore(i,j) + state%SSS(i,j))))
+    do j=js,je ; do i=is,ie
+      !   Set density_restore to an expression for the surface potential
+      ! density in kg m-3 that is being restored toward.
+      if (CS%forcing_mask(i,j)>0.) then
+        fluxes%vprec(i,j) = - (G%mask2dT(i,j) * (CS%Rho0*CS%Flux_const)) * &
+          ((CS%S_restore(i,j) - state%SSS(i,j)) / &
+           (0.5 * (CS%S_restore(i,j) + state%SSS(i,j))))
 
-        endif
-      enddo ; enddo
+      endif
+    enddo ; enddo
   endif
-      ! end RESTOREBUOY
 
 end subroutine dumbbell_buoyancy_forcing
 
+!> Dynamic forcing for the dumbbell test case
 subroutine dumbbell_dynamic_forcing(state, fluxes, day, dt, G, CS)
   type(surface),                 intent(inout) :: state  !< A structure containing fields that
                                                        !! describe the surface state of the ocean.
@@ -189,33 +148,7 @@ subroutine dumbbell_dynamic_forcing(state, fluxes, day, dt, G, CS)
   type(ocean_grid_type),         intent(in)    :: G    !< The ocean's grid structure
   type(dumbbell_surface_forcing_CS),  pointer  :: CS   !< A control structure returned by a previous
                                                        !! call to dumbbell_surface_forcing_init
-
-
-!    This subroutine specifies the current surface fluxes of buoyancy or
-!  temperature and fresh water.  It may also be modified to add
-!  surface fluxes of user provided tracers.
-
-!    When temperature is used, there are long list of fluxes that need to be
-!  set - essentially the same as for a full coupled model, but most of these
-!  can be simply set to zero.  The net fresh water flux should probably be
-!  set in fluxes%evap and fluxes%lprec, with any salinity restoring
-!  appearing in fluxes%vprec, and the other water flux components
-!  (fprec, lrunoff and frunoff) left as arrays full of zeros.
-!  Evap is usually negative and precip is usually positive.  All heat fluxes
-!  are in W m-2 and positive for heat going into the ocean.  All fresh water
-!  fluxes are in kg m-2 s-1 and positive for water moving into the ocean.
-
-! Arguments: state - A structure containing fields that describe the
-!                    surface state of the ocean.
-!  (out)     fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      day_start - Start time of the fluxes.
-!  (in)      day_interval - Length of time over which these fluxes
-!                           will be applied.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - A pointer to the control structure returned by a previous
-!                 call to user_surface_forcing_init
-
+  ! Local variables
   integer :: i, j, is, ie, js, je
   integer :: isd, ied, jsd, jed
   integer :: idays, isecs
@@ -229,18 +162,10 @@ subroutine dumbbell_dynamic_forcing(state, fluxes, day, dt, G, CS)
 
   call get_time(day,isecs,idays)
   rdays = real(idays) + real(isecs)/8.64e4
-  !   When modifying the code, comment out this error message.  It is here
-  ! so that the original (unmodified) version is not accidentally used.
-  ! call MOM_error(FATAL, "User_buoyancy_surface_forcing: " // &
-  !   "User forcing routine called without modification." )
 
-  ! Allocate and zero out the forcing arrays, as necessary.  This portion is
-  ! usually not changed.
+  ! Allocate and zero out the forcing arrays, as necessary.
   call safe_alloc_ptr(fluxes%p_surf, isd, ied, jsd, jed)
   call safe_alloc_ptr(fluxes%p_surf_full, isd, ied, jsd, jed)
-
-
-  ! MODIFY THE CODE IN THE FOLLOWING LOOPS TO SET THE BUOYANCY FORCING TERMS.
 
   do j=js,je ; do i=is,ie
     fluxes%p_surf(i,j) = CS%forcing_mask(i,j)* CS%slp_amplitude * &
@@ -249,11 +174,9 @@ subroutine dumbbell_dynamic_forcing(state, fluxes, day, dt, G, CS)
                          G%mask2dT(i,j) * sin(deg_rad*(rdays/CS%slp_period))
   enddo ; enddo
 
-
-
 end subroutine dumbbell_dynamic_forcing
 
-
+!> Reads and sets up the forcing for the dumbbell test case
 subroutine dumbbell_surface_forcing_init(Time, G, param_file, diag, CS)
   type(time_type),              intent(in) :: Time !< The current model time.
   type(ocean_grid_type),        intent(in) :: G    !< The ocean's grid structure
@@ -262,12 +185,10 @@ subroutine dumbbell_surface_forcing_init(Time, G, param_file, diag, CS)
                                                    !! regulate diagnostic output.
   type(dumbbell_surface_forcing_CS), &
                                 pointer    :: CS   !< A pointer to the control structure for this module
-
- ! This include declares and sets the variable "version".
+  ! Local variables
   real :: S_surf, S_range
   real :: x, y
   integer :: i, j
-
 #include "version_variable.h"
   character(len=40)  :: mdl = "dumbbell_surface_forcing" ! This module's name.
 
@@ -323,26 +244,27 @@ subroutine dumbbell_surface_forcing_init(Time, G, param_file, diag, CS)
     CS%Flux_const = CS%Flux_const / 86400.0
 
 
-  allocate(CS%forcing_mask(G%isd:G%ied, G%jsd:G%jed)); CS%forcing_mask(:,:)=0.0
-  allocate(CS%S_restore(G%isd:G%ied, G%jsd:G%jed))
+    allocate(CS%forcing_mask(G%isd:G%ied, G%jsd:G%jed)); CS%forcing_mask(:,:)=0.0
+    allocate(CS%S_restore(G%isd:G%ied, G%jsd:G%jed))
 
-  do j=G%jsc,G%jec
-    do i=G%isc,G%iec
-      ! Compute normalized zonal coordinates (x,y=0 at center of domain)
-      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon - 0.5
-      y = ( G%geoLatT(i,j) - G%south_lat ) / G%len_lat - 0.5
-      CS%forcing_mask(i,j)=0
-      CS%S_restore(i,j) = S_surf
-      if ((x>0.25)) then
-        CS%forcing_mask(i,j) = 1
-        CS%S_restore(i,j) = S_surf + S_range
-      elseif ((x<-0.25)) then
-        CS%forcing_mask(i,j) = 1
-        CS%S_restore(i,j) = S_surf - S_range
-      endif
+    do j=G%jsc,G%jec
+      do i=G%isc,G%iec
+        ! Compute normalized zonal coordinates (x,y=0 at center of domain)
+        x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon - 0.5
+        y = ( G%geoLatT(i,j) - G%south_lat ) / G%len_lat - 0.5
+        CS%forcing_mask(i,j)=0
+        CS%S_restore(i,j) = S_surf
+        if ((x>0.25)) then
+          CS%forcing_mask(i,j) = 1
+          CS%S_restore(i,j) = S_surf + S_range
+        elseif ((x<-0.25)) then
+          CS%forcing_mask(i,j) = 1
+          CS%S_restore(i,j) = S_surf - S_range
+        endif
+      enddo
     enddo
-  enddo
   endif
+
 end subroutine dumbbell_surface_forcing_init
 
 end module dumbbell_surface_forcing


### PR DESCRIPTION
This PR corrects all doxygen errors (reported in doxygen.log following instructions at https://github.com/NOAA-GFDL/MOM6/blob/dev/gfdl/docs/README.md).

- Numerous single line declarations for multiple variables
- Various formatting mistakes
- Several undocumented functions.

This means we can soon make running doxygen part of the pass/fail for pull/requests.