### PR TITLE
dOxyGenized MOM Equation of State code

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -85,6 +85,7 @@ public ice_ocn_bnd_type_chksum
 public ocean_public_type_chksum
 public ocean_model_data_get
 
+!> This interface extracts a named scalar field or array from the ocean surface or public type
 interface ocean_model_data_get
   module procedure ocean_model_data1D_get
   module procedure ocean_model_data2D_get
@@ -1140,6 +1141,7 @@ subroutine ocean_model_data1D_get(OS, Ocean, name, value)
 
 end subroutine ocean_model_data1D_get
 
+!> Write out FMS-format checsums on fields from the ocean surface state
 subroutine ocean_public_type_chksum(id, timestep, ocn)
 
   character(len=*),        intent(in) :: id  !< An identifying string for this call

--- a/config_src/solo_driver/MESO_surface_forcing.F90
+++ b/config_src/solo_driver/MESO_surface_forcing.F90
@@ -61,39 +61,34 @@ implicit none ; private
 
 public MESO_wind_forcing, MESO_buoyancy_forcing, MESO_surface_forcing_init
 
+!> This control structure is used to store parameters associated with the MESO forcing.
 type, public :: MESO_surface_forcing_CS ; private
-  !   This control structure should be used to store any run-time variables
-  ! associated with the user-specified forcing.  It can be readily modified
-  ! for a specific case, and because it is private there will be no changes
-  ! needed in other code (although they will have to be recompiled).
-  !   The variables in the cannonical example are used for some common
-  ! cases, but do not need to be used.
 
-  logical :: use_temperature ! If true, temperature and salinity are used as
-                             ! state variables.
-  logical :: restorebuoy     ! If true, use restoring surface buoyancy forcing.
-  real :: Rho0               !   The density used in the Boussinesq
-                             ! approximation, in kg m-3.
-  real :: G_Earth            !   The gravitational acceleration in m s-2.
-  real :: Flux_const         !   The restoring rate at the surface, in m s-1.
-  real :: gust_const         !   A constant unresolved background gustiness
-                             ! that contributes to ustar, in Pa.
+  logical :: use_temperature !< If true, temperature and salinity are used as state variables.
+  logical :: restorebuoy     !< If true, use restoring surface buoyancy forcing.
+  real :: Rho0               !< The density used in the Boussinesq approximation, in kg m-3.
+  real :: G_Earth            !< The gravitational acceleration in m s-2.
+  real :: Flux_const         !< The restoring rate at the surface, in m s-1.
+  real :: gust_const         !< A constant unresolved background gustiness
+                             !! that contributes to ustar, in Pa.
   real, dimension(:,:), pointer :: &
-    T_Restore(:,:) => NULL(), & ! The temperature to restore the SST to, in C.
-    S_Restore(:,:) => NULL(), & ! The salinity to restore the sea surface salnity
-                                ! toward, in PSU.
-    PmE(:,:) => NULL(), &       ! The prescribed precip minus evap, in  m s-1.
-    Solar(:,:) => NULL(), &     ! The shortwave forcing into the ocean, in W m-2 m s-1.
-    Heat(:,:) => NULL()         ! The prescribed longwave, latent and sensible
-                                ! heat flux into the ocean, in W m-2.
-  character(len=200) :: inputdir ! The directory where NetCDF input files are.
-  character(len=200) :: salinityrestore_file, SSTrestore_file
-  character(len=200) :: Solar_file, heating_file, PmE_file
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+    T_Restore(:,:) => NULL(), & !< The temperature to restore the SST toward, in C.
+    S_Restore(:,:) => NULL(), & !< The salinity to restore the sea surface salnity toward, in PSU.
+    PmE(:,:) => NULL(), &       !< The prescribed precip minus evap, in  m s-1.
+    Solar(:,:) => NULL()        !< The shortwave forcing into the ocean, in W m-2 m s-1.
+  real, dimension(:,:), pointer :: Heat(:,:) => NULL() !< The prescribed longwave, latent and sensible
+                                !! heat flux into the ocean, in W m-2.
+  character(len=200) :: inputdir !< The directory where NetCDF input files are.
+  character(len=200) :: salinityrestore_file !< The file with the target sea surface salinity
+  character(len=200) :: SSTrestore_file !< The file with the target sea surface temperature
+  character(len=200) :: Solar_file !< The file with the shortwave forcing
+  character(len=200) :: heating_file !< The file with the longwave, latent, and sensible heating
+  character(len=200) :: PmE_file !< The file with precipitation minus evaporation
+  type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the
+                             !! timing of diagnostic output.
 end type MESO_surface_forcing_CS
 
-logical :: first_call = .true.
+logical :: first_call = .true. !< True until after the first call to the MESO forcing routines
 
 contains
 

--- a/config_src/solo_driver/user_surface_forcing.F90
+++ b/config_src/solo_driver/user_surface_forcing.F90
@@ -61,26 +61,24 @@ implicit none ; private
 
 public USER_wind_forcing, USER_buoyancy_forcing, USER_surface_forcing_init
 
+!>   This control structure should be used to store any run-time variables
+!! associated with the user-specified forcing.  It can be readily modified
+!! for a specific case, and because it is private there will be no changes
+!! needed in other code (although they will have to be recompiled).
 type, public :: user_surface_forcing_CS ; private
-  !   This control structure should be used to store any run-time variables
-  ! associated with the user-specified forcing.  It can be readily modified
-  ! for a specific case, and because it is private there will be no changes
-  ! needed in other code (although they will have to be recompiled).
   !   The variables in the cannonical example are used for some common
   ! cases, but do not need to be used.
 
-  logical :: use_temperature ! If true, temperature and salinity are used as
-                             ! state variables.
-  logical :: restorebuoy     ! If true, use restoring surface buoyancy forcing.
-  real :: Rho0               !   The density used in the Boussinesq
-                             ! approximation, in kg m-3.
-  real :: G_Earth            !   The gravitational acceleration in m s-2.
-  real :: Flux_const         !   The restoring rate at the surface, in m s-1.
-  real :: gust_const         !   A constant unresolved background gustiness
-                             ! that contributes to ustar, in Pa.
+  logical :: use_temperature !< If true, temperature and salinity are used as state variables.
+  logical :: restorebuoy     !< If true, use restoring surface buoyancy forcing.
+  real :: Rho0               !< The density used in the Boussinesq approximation, in kg m-3.
+  real :: G_Earth            !< The gravitational acceleration in m s-2.
+  real :: Flux_const         !< The restoring rate at the surface, in m s-1.
+  real :: gust_const         !< A constant unresolved background gustiness
+                             !! that contributes to ustar, in Pa.
 
-  type(diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                             ! timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the
+                             !! timing of diagnostic output.
 end type user_surface_forcing_CS
 
 contains

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -70,11 +70,12 @@ type, public :: CoriolisAdv_CS ; private
                              !! SADOURNY75_ENERGY.
   type(time_type), pointer :: Time !< A pointer to the ocean model's clock.
   type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the timing of diagnostic output.
+  !>@{ Diagnostic IDs
   integer :: id_rv = -1, id_PV = -1, id_gKEu = -1, id_gKEv = -1
-  integer :: id_rvxu = -1, id_rvxv = -1
+  integer :: id_rvxu = -1, id_rvxv = -1   !!@}
 end type CoriolisAdv_CS
 
-! Enumeration values for Coriolis_Scheme
+!>@{ Enumeration values for Coriolis_Scheme
 integer, parameter :: SADOURNY75_ENERGY = 1
 integer, parameter :: ARAKAWA_HSU90     = 2
 integer, parameter :: ROBUST_ENSTRO     = 3
@@ -87,18 +88,21 @@ character*(20), parameter :: ROBUST_ENSTRO_STRING = "ROBUST_ENSTRO"
 character*(20), parameter :: SADOURNY75_ENSTRO_STRING = "SADOURNY75_ENSTRO"
 character*(20), parameter :: ARAKAWA_LAMB_STRING = "ARAKAWA_LAMB81"
 character*(20), parameter :: AL_BLEND_STRING = "ARAKAWA_LAMB_BLEND"
-! Enumeration values for KE_Scheme
+!!@}
+!>@{ Enumeration values for KE_Scheme
 integer, parameter :: KE_ARAKAWA        = 10
 integer, parameter :: KE_SIMPLE_GUDONOV = 11
 integer, parameter :: KE_GUDONOV        = 12
 character*(20), parameter :: KE_ARAKAWA_STRING = "KE_ARAKAWA"
 character*(20), parameter :: KE_SIMPLE_GUDONOV_STRING = "KE_SIMPLE_GUDONOV"
 character*(20), parameter :: KE_GUDONOV_STRING = "KE_GUDONOV"
-! Enumeration values for PV_Adv_Scheme
+!!@}
+!>@{ Enumeration values for PV_Adv_Scheme
 integer, parameter :: PV_ADV_CENTERED   = 21
 integer, parameter :: PV_ADV_UPWIND1    = 22
 character*(20), parameter :: PV_ADV_CENTERED_STRING = "PV_ADV_CENTERED"
 character*(20), parameter :: PV_ADV_UPWIND1_STRING = "PV_ADV_UPWIND1"
+!!@}
 
 contains
 

--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -26,7 +26,7 @@ implicit none ; private
 
 public PressureForce, PressureForce_init, PressureForce_end
 
-! Pressure force control structure
+!> Pressure force control structure
 type, public :: PressureForce_CS ; private
   logical :: Analytic_FV_PGF !< If true, use the analytic finite volume form
                              !! (Adcroft et al., Ocean Mod. 2008) of the PGF.

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -37,8 +37,10 @@ type, public :: PressureForce_Mont_CS ; private
   real, pointer :: PFu_bc(:,:,:) => NULL()   !< Accelerations due to pressure
   real, pointer :: PFv_bc(:,:,:) => NULL()   !< gradients deriving from density
                                              !! gradients within layers, m s-2.
+  !>@{ Diagnostic IDs
   integer :: id_PFu_bc = -1, id_PFv_bc = -1, id_e_tidal = -1
-  type(tidal_forcing_CS), pointer :: tides_CSp => NULL()
+  !!@}
+  type(tidal_forcing_CS), pointer :: tides_CSp => NULL() !< The tidal forcing control structure
 end type PressureForce_Mont_CS
 
 contains

--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -32,24 +32,25 @@ implicit none ; private
 public call_OBC_register, OBC_register_end
 public update_OBC_data
 
+!> The control structure for the MOM_boundary_update module
 type, public :: update_OBC_CS ; private
-  logical :: use_files = .false.
-  logical :: use_Kelvin = .false.
-  logical :: use_tidal_bay = .false.
-  logical :: use_shelfwave = .false.
-  logical :: use_dyed_channel = .false.
+  logical :: use_files = .false.        !< If true, use external files for the open boundary.
+  logical :: use_Kelvin = .false.       !< If true, use the Kelvin wave open boundary.
+  logical :: use_tidal_bay = .false.    !< If true, use the tidal_bay open boundary.
+  logical :: use_shelfwave = .false.    !< If true, use the shelfwave open boundary.
+  logical :: use_dyed_channel = .false. !< If true, use the dyed channel open boundary.
+  !>@{ Pointers to the control structures for named OBC specifications
   type(file_OBC_CS), pointer :: file_OBC_CSp => NULL()
   type(Kelvin_OBC_CS), pointer :: Kelvin_OBC_CSp => NULL()
   type(tidal_bay_OBC_CS), pointer :: tidal_bay_OBC_CSp => NULL()
   type(shelfwave_OBC_CS), pointer :: shelfwave_OBC_CSp => NULL()
   type(dyed_channel_OBC_CS), pointer :: dyed_channel_OBC_CSp => NULL()
+  !!@}
 end type update_OBC_CS
 
-integer :: id_clock_pass
+integer :: id_clock_pass !< A CPU time clock ID
 
-character(len=40)  :: mdl = "MOM_boundary_update" ! This module's name.
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+! character(len=40)  :: mdl = "MOM_boundary_update" ! This module's name.
 
 contains
 
@@ -60,8 +61,11 @@ subroutine call_OBC_register(param_file, CS, OBC)
   type(param_file_type),     intent(in) :: param_file !< Parameter file to parse
   type(update_OBC_CS),       pointer    :: CS         !< Control structure for OBCs
   type(ocean_OBC_type),      pointer    :: OBC        !< Open boundary structure
-  character(len=40)  :: mdl = "MOM_boundary_update" ! This module's name.
 
+  ! Local variables
+  character(len=40)  :: mdl = "MOM_boundary_update" ! This module's name.
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   if (associated(CS)) then
     call MOM_error(WARNING, "call_OBC_register called with an associated "// &
                             "control structure.")
@@ -113,6 +117,7 @@ subroutine update_OBC_data(OBC, G, GV, tv, h, CS, Time)
   type(ocean_OBC_type),                     pointer       :: OBC  !< Open boundary structure
   type(update_OBC_CS),                      pointer       :: CS   !< Control structure for OBCs
   type(time_type),                          intent(in)    :: Time !< Model time
+
   ! Local variables
   logical :: read_OBC_eta = .false.
   logical :: read_OBC_uv = .false.

--- a/src/core/MOM_checksum_packages.F90
+++ b/src/core/MOM_checksum_packages.F90
@@ -17,6 +17,7 @@ implicit none ; private
 public MOM_state_chksum, MOM_thermo_chksum, MOM_accel_chksum
 public MOM_state_stats, MOM_surface_chksum
 
+!> Write out checksums of the MOM6 state variables
 interface MOM_state_chksum
   module procedure MOM_state_chksum_5arg
   module procedure MOM_state_chksum_3arg
@@ -24,15 +25,18 @@ end interface
 
 #include <MOM_memory.h>
 
-type :: stats
-  private
-  real :: minimum = 1.E34, maximum = -1.E34, average = 0.
+!> A type for storing statistica about a variable
+type :: stats ; private
+  real :: minimum = 1.E34  !< The minimum value
+  real :: maximum = -1.E34 !< The maximum value
+  real :: average = 0.     !< The average value
 end type stats
 
 contains
 
 ! =============================================================================
 
+!> Write out chksums for the model's basic state variables, including transports.
 subroutine MOM_state_chksum_5arg(mesg, u, v, h, uh, vh, G, GV, haloshift, symmetric)
   character(len=*),                          &
                            intent(in) :: mesg !< A message that appears on the chksum lines.
@@ -47,20 +51,11 @@ subroutine MOM_state_chksum_5arg(mesg, u, v, h, uh, vh, G, GV, haloshift, symmet
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                            intent(in) :: uh   !< Volume flux through zonal faces = u*h*dy, m3 s-1.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                           intent(in) :: vh   !< Volume flux through meridional
-                                              !! faces = v*h*dx, in m3 s-1.
+                           intent(in) :: vh   !< Volume flux through meridional faces = v*h*dx, in m3 s-1.
   integer,       optional, intent(in) :: haloshift !< The width of halos to check (default 0).
   logical,       optional, intent(in) :: symmetric !< If true, do checksums on the fully symmetric
                                                    !! computationoal domain.
-!   This subroutine writes out chksums for the model's basic state variables.
-! Arguments: mesg - A message that appears on the chksum lines.
-!  (in)      u - Zonal velocity, in m s-1.
-!  (in)      v - Meridional velocity, in m s-1.
-!  (in)      h - Layer thickness, in m.
-!  (in)      uh - Volume flux through zonal faces = u*h*dy, m3 s-1.
-!  (in)      vh - Volume flux through meridional faces = v*h*dx, in m3 s-1.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
+
   integer :: is, ie, js, je, nz, hs
   logical :: sym
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -78,6 +73,7 @@ end subroutine MOM_state_chksum_5arg
 
 ! =============================================================================
 
+!> Write out chksums for the model's basic state variables.
 subroutine MOM_state_chksum_3arg(mesg, u, v, h, G, GV, haloshift, symmetric)
   character(len=*),        intent(in) :: mesg !< A message that appears on the chksum lines.
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
@@ -91,15 +87,7 @@ subroutine MOM_state_chksum_3arg(mesg, u, v, h, G, GV, haloshift, symmetric)
   integer,       optional, intent(in) :: haloshift !< The width of halos to check (default 0).
   logical,       optional, intent(in) :: symmetric !< If true, do checksums on the fully symmetric
                                                    !! computationoal domain.
-!   This subroutine writes out chksums for the model's basic state variables.
-! Arguments: mesg - A message that appears on the chksum lines.
-!  (in)      u - Zonal velocity, in m s-1.
-!  (in)      v - Meridional velocity, in m s-1.
-!  (in)      h - Layer thickness, in m.
-!  (in)      uh - Volume flux through zonal faces = u*h*dy, m3 s-1.
-!  (in)      vh - Volume flux through meridional faces = v*h*dx, in m3 s-1.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
+
   integer :: is, ie, js, je, nz, hs
   logical :: sym
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
@@ -115,14 +103,13 @@ end subroutine MOM_state_chksum_3arg
 
 ! =============================================================================
 
+!> Write out chksums for the model's thermodynamic state variables.
 subroutine MOM_thermo_chksum(mesg, tv, G, haloshift)
   character(len=*),         intent(in) :: mesg !< A message that appears on the chksum lines.
   type(thermo_var_ptrs),    intent(in) :: tv   !< A structure pointing to various
                                                !! thermodynamic variables.
   type(ocean_grid_type),    intent(in) :: G    !< The ocean's grid structure.
   integer,        optional, intent(in) :: haloshift !< The width of halos to check (default 0).
-!   This subroutine writes out chksums for the model's thermodynamic state
-! variables.
 ! Arguments: mesg - A message that appears on the chksum lines.
 !  (in)      tv - A structure containing pointers to any thermodynamic
 !                 fields that are in use.
@@ -140,6 +127,7 @@ end subroutine MOM_thermo_chksum
 
 ! =============================================================================
 
+!> Write out chksums for the ocean surface variables.
 subroutine MOM_surface_chksum(mesg, sfc, G, haloshift, symmetric)
   character(len=*),      intent(in) :: mesg !< A message that appears on the chksum lines.
   type(surface),         intent(inout) :: sfc !< transparent ocean surface state
@@ -149,12 +137,7 @@ subroutine MOM_surface_chksum(mesg, sfc, G, haloshift, symmetric)
   integer,     optional, intent(in) :: haloshift !< The width of halos to check (default 0).
   logical,     optional, intent(in) :: symmetric !< If true, do checksums on the fully symmetric
                                                  !! computationoal domain.
-!   This subroutine writes out chksums for the model's thermodynamic state
-! variables.
-! Arguments: mesg - A message that appears on the chksum lines.
-!  (in)      tv - A structure containing pointers to any thermodynamic
-!                 fields that are in use.
-!  (in)      G - The ocean's grid structure.
+
   integer :: hs
   logical :: sym
 
@@ -174,6 +157,7 @@ end subroutine MOM_surface_chksum
 
 ! =============================================================================
 
+!> Write out chksums for the model's accelerations
 subroutine MOM_accel_chksum(mesg, CAu, CAv, PFu, PFv, diffu, diffv, G, GV, pbce, &
                             u_accel_bt, v_accel_bt, symmetric)
   character(len=*),         intent(in) :: mesg !< A message that appears on the chksum lines.
@@ -199,8 +183,7 @@ subroutine MOM_accel_chksum(mesg, CAu, CAv, PFu, PFv, diffu, diffv, G, GV, pbce,
                                                 !! the along-isopycnal stress tensor, in m s-2.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
                   optional, intent(in) :: pbce !< The baroclinic pressure anomaly in each layer
-                                               !! due to free surface height anomalies, in
-                                               !! m2 s-2 H-1.
+                                               !! due to free surface height anomalies, in m2 s-2 H-1.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                   optional, intent(in) :: u_accel_bt !< The zonal acceleration from terms in the
                                                      !! barotropic solver,in m s-2.
@@ -210,29 +193,6 @@ subroutine MOM_accel_chksum(mesg, CAu, CAv, PFu, PFv, diffu, diffv, G, GV, pbce,
   logical,        optional, intent(in) :: symmetric !< If true, do checksums on the fully symmetric
                                                     !! computationoal domain.
 
-!   This subroutine writes out chksums for the model's accelerations.
-! Arguments: mesg - A message that appears on the chksum lines.
-!  (in)      CAu - Zonal acceleration due to Coriolis and momentum
-!                  advection terms, in m s-2.
-!  (in)      CAv - Meridional acceleration due to Coriolis and
-!                  momentum advection terms, in m s-2.
-!  (in)      PFu - Zonal acceleration due to pressure gradients
-!                  (equal to -dM/dx) in m s-2.
-!  (in)      PFv - Meridional acceleration due to pressure
-!                  gradients (equal to -dM/dy) in m s-2.
-!  (in)      diffu - Zonal acceleration due to convergence of the
-!                    along-isopycnal stress tensor, in m s-2.
-!  (in)      diffv - Meridional acceleration due to convergence of
-!                    the along-isopycnal stress tensor, in m s-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      pbce - the baroclinic pressure anomaly in each layer
-!                   due to free surface height anomalies, in m2 s-2 H-1.
-!                   pbce points to a space with nz layers or NULL.
-!  (in)      u_accel_bt - The zonal acceleration from terms in the barotropic
-!                         solver, in m s-2.
-!  (in)      v_accel_bt - The meridional acceleration from terms in the
-!                         barotropic solver, in m s-2.
   integer :: is, ie, js, je, nz
   logical :: sym
 
@@ -253,6 +213,7 @@ end subroutine MOM_accel_chksum
 
 ! =============================================================================
 
+!> Monitor and write out statistics for the model's state variables.
 subroutine MOM_state_stats(mesg, u, v, h, Temp, Salt, G, allowChange, permitDiminishing)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
   character(len=*),        intent(in) :: mesg !< A message that appears on the chksum lines.
@@ -270,16 +231,7 @@ subroutine MOM_state_stats(mesg, u, v, h, Temp, Salt, G, allowChange, permitDimi
                                                      !! if the statistics change.
   logical,       optional, intent(in) :: permitDiminishing !< do not flag error
                                                            !!if the extrema are diminishing.
-!   This subroutine monitors statistics for the model's state variables.
-! Arguments: mesg - A message that appears on the chksum lines.
-!  (in) u - Zonal velocity, in m s-1.
-!  (in) v - Meridional velocity, in m s-1.
-!  (in) h - Layer thickness, in m.
-!  (in) T - Temperature, in degree C.
-!  (in) S - Salinity, in ppt.
-!  (in) G - The ocean's grid structure.
-!  (in) allowChange - do not flag an error if the statistics change
-!  (in) permitDiminishing - do not flag an error if the extrema are diminishing
+  ! Local variables
   integer :: is, ie, js, je, nz, i, j, k
   real :: Vol, dV, Area, h_minimum
   type(stats) :: T, S, delT, delS

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -63,34 +63,38 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-!> Module control structure
+!> MOM_dynamics_split_RK2 module control structure
 type, public :: MOM_dyn_split_RK2_CS ; private
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: &
-    CAu, &        !< CAu = f*v - u.grad(u) in m s-2.
-    PFu, &        !< PFu = -dM/dx, in m s-2.
-    diffu, &      !< Zonal acceleration due to convergence of the along-isopycnal
-                  !! stress tensor, in m s-2.
-    visc_rem_u, & !< Both the fraction of the zonal momentum originally in a
-                  !! layer that remains after a time-step of viscosity, and the
-                  !! fraction of a time-step's worth of a barotropic acceleration
-                  !! that a layer experiences after viscosity is applied.
-                  !! Nondimensional between 0 (at the bottom) and 1 (far above).
-    u_accel_bt    !< The layers' zonal accelerations due to the difference between
-                  !! the barotropic accelerations and the baroclinic accelerations
-                  !! that were fed into the barotopic calculation, in m s-2.
+    CAu, &    !< CAu = f*v - u.grad(u) in m s-2.
+    PFu, &    !< PFu = -dM/dx, in m s-2.
+    diffu     !< Zonal acceleration due to convergence of the along-isopycnal stress tensor, in m s-2.
+
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: &
-    CAv, &        !< CAv = -f*u - u.grad(v) in m s-2.
-    PFv, &        !< PFv = -dM/dy, in m s-2.
-    diffv, &      !< Meridional acceleration due to convergence of the
-                  !! along-isopycnal stress tensor, in m s-2.
-    visc_rem_v, & !< Both the fraction of the meridional momentum originally in
-                  !! a layer that remains after a time-step of viscosity, and the
-                  !! fraction of a time-step's worth of a barotropic acceleration
-                  !! that a layer experiences after viscosity is applied.
-                  !! Nondimensional between 0 (at the bottom) and 1 (far above).
-    v_accel_bt    !< The layers' meridional accelerations due to the difference between
-                  !! the barotropic accelerations and the baroclinic accelerations
-                  !! that were fed into the barotopic calculation, in m s-2.
+    CAv, &    !< CAv = -f*u - u.grad(v) in m s-2.
+    PFv, &    !< PFv = -dM/dy, in m s-2.
+    diffv     !< Meridional acceleration due to convergence of the along-isopycnal stress tensor, in m s-2.
+
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: &
+    visc_rem_u !< Both the fraction of the zonal momentum originally in a
+               !! layer that remains after a time-step of viscosity, and the
+               !! fraction of a time-step's worth of a barotropic acceleration
+               !! that a layer experiences after viscosity is applied.
+               !! Nondimensional between 0 (at the bottom) and 1 (far above).
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: &
+    u_accel_bt !< The layers' zonal accelerations due to the difference between
+               !! the barotropic accelerations and the baroclinic accelerations
+               !! that were fed into the barotopic calculation, in m s-2.
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: &
+    visc_rem_v !< Both the fraction of the meridional momentum originally in
+               !! a layer that remains after a time-step of viscosity, and the
+               !! fraction of a time-step's worth of a barotropic acceleration
+               !! that a layer experiences after viscosity is applied.
+               !! Nondimensional between 0 (at the bottom) and 1 (far above).
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: &
+    v_accel_bt !< The layers' meridional accelerations due to the difference between
+               !! the barotropic accelerations and the baroclinic accelerations
+               !! that were fed into the barotopic calculation, in m s-2.
 
   ! The following variables are only used with the split time stepping scheme.
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_)             :: eta    !< Instantaneous free surface height (in Boussinesq
@@ -142,8 +146,9 @@ type, public :: MOM_dyn_split_RK2_CS ; private
   logical :: debug   !< If true, write verbose checksums for debugging purposes.
   logical :: debug_OBC !< If true, do debugging calls for open boundary conditions.
 
-  logical :: module_is_initialized = .false.
+  logical :: module_is_initialized = .false. !< Record whether this mouled has been initialzed.
 
+  !>@{ Diagnostic IDs
   integer :: id_uh     = -1, id_vh     = -1
   integer :: id_umo    = -1, id_vmo    = -1
   integer :: id_umo_2d = -1, id_vmo_2d = -1
@@ -153,6 +158,7 @@ type, public :: MOM_dyn_split_RK2_CS ; private
   ! Split scheme only.
   integer :: id_uav        = -1, id_vav        = -1
   integer :: id_u_BT_accel = -1, id_v_BT_accel = -1
+  !!@}
 
   type(diag_ctrl), pointer       :: diag !< A structure that is used to regulate the
                                          !! timing of diagnostic output.
@@ -165,31 +171,40 @@ type, public :: MOM_dyn_split_RK2_CS ; private
                                          !! which can later be used to calculate
                                          !! derived diagnostics like energy budgets.
 
-  ! Remainder of the structure points to child subroutines' control strings.
+  ! The remainder of the structure points to child subroutines' control structures.
+  !> A pointer to the horizontal viscosity control structure
   type(hor_visc_CS),      pointer :: hor_visc_CSp      => NULL()
+  !> A pointer to the continuity control structure
   type(continuity_CS),    pointer :: continuity_CSp    => NULL()
+  !> A pointer to the CoriolisAdv control structure
   type(CoriolisAdv_CS),   pointer :: CoriolisAdv_CSp   => NULL()
+  !> A pointer to the PressureForce control structure
   type(PressureForce_CS), pointer :: PressureForce_CSp => NULL()
+  !> A pointer to the barotropic stepping control structure
   type(barotropic_CS),    pointer :: barotropic_CSp    => NULL()
+  !> A pointer to the vertical viscosity control structure
   type(vertvisc_CS),      pointer :: vertvisc_CSp      => NULL()
+  !> A pointer to the set_visc control structure
   type(set_visc_CS),      pointer :: set_visc_CSp      => NULL()
+  !> A pointer to the tidal forcing control structure
   type(tidal_forcing_CS), pointer :: tides_CSp         => NULL()
+  !> A pointer to the ALE control structure.
+  type(ALE_CS), pointer :: ALE_CSp => NULL()
 
   type(ocean_OBC_type),   pointer :: OBC => NULL() !< A pointer to an open boundary
      !! condition type that specifies whether, where, and  what open boundary
      !! conditions are used.  If no open BCs are used, this pointer stays
      !! nullified.  Flather OBCs use open boundary_CS as well.
+  !> A pointer to the update_OBC control structure
   type(update_OBC_CS),    pointer :: update_OBC_CSp => NULL()
 
-  ! This is a copy of the pointer in the top-level control structure.
-  type(ALE_CS), pointer :: ALE_CSp => NULL()
-
-  ! for group halo pass
-  type(group_pass_type) :: pass_eta
-  type(group_pass_type) :: pass_visc_rem, pass_uvp
-  type(group_pass_type) :: pass_hp_uv
-  type(group_pass_type) :: pass_uv
-  type(group_pass_type) :: pass_h, pass_av_uvh
+  type(group_pass_type) :: pass_eta  !< Structure for group halo pass
+  type(group_pass_type) :: pass_visc_rem  !< Structure for group halo pass
+  type(group_pass_type) :: pass_uvp  !< Structure for group halo pass
+  type(group_pass_type) :: pass_hp_uv  !< Structure for group halo pass
+  type(group_pass_type) :: pass_uv  !< Structure for group halo pass
+  type(group_pass_type) :: pass_h  !< Structure for group halo pass
+  type(group_pass_type) :: pass_av_uvh  !< Structure for group halo pass
 
 end type MOM_dyn_split_RK2_CS
 
@@ -199,11 +214,13 @@ public register_restarts_dyn_split_RK2
 public initialize_dyn_split_RK2
 public end_dyn_split_RK2
 
+!>@{ CPU time clock IDs
 integer :: id_clock_Cor, id_clock_pres, id_clock_vertvisc
 integer :: id_clock_horvisc, id_clock_mom_update
 integer :: id_clock_continuity, id_clock_thick_diff
 integer :: id_clock_btstep, id_clock_btcalc, id_clock_btforce
 integer :: id_clock_pass, id_clock_pass_init
+!!@}
 
 contains
 

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -100,64 +100,77 @@ use MOM_wave_interface, only: wave_parameters_CS
 implicit none ; private
 
 #include <MOM_memory.h>
+
+!> MOM_dynamics_unsplit module control structure
 type, public :: MOM_dyn_unsplit_CS ; private
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: &
-    CAu, &    ! CAu = f*v - u.grad(u) in m s-2.
-    PFu, &    ! PFu = -dM/dx, in m s-2.
-    diffu     ! Zonal acceleration due to convergence of the along-isopycnal
-              ! stress tensor, in m s-2.
+    CAu, &    !< CAu = f*v - u.grad(u) in m s-2.
+    PFu, &    !< PFu = -dM/dx, in m s-2.
+    diffu     !< Zonal acceleration due to convergence of the along-isopycnal stress tensor, in m s-2.
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: &
-    CAv, &    ! CAv = -f*u - u.grad(v) in m s-2.
-    PFv, &    ! PFv = -dM/dy, in m s-2.
-    diffv     ! Meridional acceleration due to convergence of the
-              ! along-isopycnal stress tensor, in m s-2.
+    CAv, &    !< CAv = -f*u - u.grad(v) in m s-2.
+    PFv, &    !< PFv = -dM/dy, in m s-2.
+    diffv     !< Meridional acceleration due to convergence of the along-isopycnal stress tensor, in m s-2.
 
-  real, pointer, dimension(:,:) :: taux_bot => NULL(), tauy_bot => NULL()
-    ! The frictional bottom stresses from the ocean to the seafloor, in Pa.
+  real, pointer, dimension(:,:) :: taux_bot => NULL() !<  frictional x-bottom stress from the ocean to the seafloor (Pa)
+  real, pointer, dimension(:,:) :: tauy_bot => NULL() !<  frictional y-bottom stress from the ocean to the seafloor (Pa)
 
-  logical :: debug           ! If true, write verbose checksums for debugging purposes.
+  logical :: debug           !< If true, write verbose checksums for debugging purposes.
 
-  logical :: module_is_initialized = .false.
+  logical :: module_is_initialized = .false. !< Record whether this mouled has been initialzed.
 
+  !>@{ Diagnostic IDs
   integer :: id_uh = -1, id_vh = -1
   integer :: id_PFu = -1, id_PFv = -1, id_CAu = -1, id_CAv = -1
+  !!@}
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  type(accel_diag_ptrs), pointer :: ADp => NULL() ! A structure pointing to the
-                                   ! accelerations in the momentum equations,
-                                   ! which can later be used to calculate
-                                   ! derived diagnostics like energy budgets.
-  type(cont_diag_ptrs), pointer :: CDp => NULL() ! A structure with pointers to
-                                   ! various terms in the continuity equations,
-                                   ! which can later be used to calculate
-                                   ! derived diagnostics like energy budgets.
-! The remainder of the structure is pointers to child subroutines' control strings.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  type(accel_diag_ptrs), pointer :: ADp => NULL() !< A structure pointing to the
+                                   !! accelerations in the momentum equations,
+                                   !! which can later be used to calculate
+                                   !! derived diagnostics like energy budgets.
+  type(cont_diag_ptrs), pointer :: CDp => NULL() !< A structure with pointers to
+                                   !! various terms in the continuity equations,
+                                   !! which can later be used to calculate
+                                   !! derived diagnostics like energy budgets.
+
+  ! The remainder of the structure points to child subroutines' control structures.
+  !> A pointer to the horizontal viscosity control structure
   type(hor_visc_CS), pointer :: hor_visc_CSp => NULL()
+  !> A pointer to the continuity control structure
   type(continuity_CS), pointer :: continuity_CSp => NULL()
+  !> A pointer to the CoriolisAdv control structure
   type(CoriolisAdv_CS), pointer :: CoriolisAdv_CSp => NULL()
+  !> A pointer to the PressureForce control structure
   type(PressureForce_CS), pointer :: PressureForce_CSp => NULL()
+  !> A pointer to the vertvisc control structure
   type(vertvisc_CS), pointer :: vertvisc_CSp => NULL()
+  !> A pointer to the set_visc control structure
   type(set_visc_CS), pointer :: set_visc_CSp => NULL()
-  type(ocean_OBC_type), pointer :: OBC => NULL() ! A pointer to an open boundary
+  !> A pointer to the tidal forcing control structure
+  type(tidal_forcing_CS), pointer :: tides_CSp => NULL()
+  !> A pointer to the ALE control structure.
+  type(ALE_CS), pointer :: ALE_CSp => NULL()
+
+  type(ocean_OBC_type), pointer :: OBC => NULL() !< A pointer to an open boundary
      ! condition type that specifies whether, where, and  what open boundary
      ! conditions are used.  If no open BCs are used, this pointer stays
      ! nullified.  Flather OBCs use open boundary_CS as well.
+  !> A pointer to the update_OBC control structure
   type(update_OBC_CS),    pointer :: update_OBC_CSp => NULL()
-  type(tidal_forcing_CS), pointer :: tides_CSp => NULL()
-
-! This is a copy of the pointer in the top-level control structure.
-  type(ALE_CS), pointer :: ALE_CSp => NULL()
 
 end type MOM_dyn_unsplit_CS
 
 public step_MOM_dyn_unsplit, register_restarts_dyn_unsplit
 public initialize_dyn_unsplit, end_dyn_unsplit
 
+!>@{ CPU time clock IDs
 integer :: id_clock_Cor, id_clock_pres, id_clock_vertvisc
 integer :: id_clock_continuity, id_clock_horvisc, id_clock_mom_update
 integer :: id_clock_pass, id_clock_pass_init
+!!@}
 
 contains
 

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -97,62 +97,71 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
+!> MOM_dynamics_unsplit_RK2 module control structure
 type, public :: MOM_dyn_unsplit_RK2_CS ; private
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: &
-    CAu, &    ! CAu = f*v - u.grad(u) in m s-2.
-    PFu, &    ! PFu = -dM/dx, in m s-2.
-    diffu     ! Zonal acceleration due to convergence of the along-isopycnal
-              ! stress tensor, in m s-2.
+    CAu, &    !< CAu = f*v - u.grad(u) in m s-2.
+    PFu, &    !< PFu = -dM/dx, in m s-2.
+    diffu     !< Zonal acceleration due to convergence of the along-isopycnal stress tensor, in m s-2.
+
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: &
-    CAv, &    ! CAv = -f*u - u.grad(v) in m s-2.
-    PFv, &    ! PFv = -dM/dy, in m s-2.
-    diffv     ! Meridional acceleration due to convergence of the
-              ! along-isopycnal stress tensor, in m s-2.
+    CAv, &    !< CAv = -f*u - u.grad(v) in m s-2.
+    PFv, &    !< PFv = -dM/dy, in m s-2.
+    diffv     !< Meridional acceleration due to convergence of the along-isopycnal stress tensor, in m s-2.
 
+  real, pointer, dimension(:,:) :: taux_bot => NULL() !< frictional x-bottom stress from the ocean to the seafloor (Pa)
+  real, pointer, dimension(:,:) :: tauy_bot => NULL() !< frictional y-bottom stress from the ocean to the seafloor (Pa)
 
-  real, pointer, dimension(:,:) :: taux_bot => NULL(), tauy_bot => NULL()
-    ! The frictional bottom stresses from the ocean to the seafloor, in Pa.
+  real    :: be      !< A nondimensional number from 0.5 to 1 that controls
+                     !! the backward weighting of the time stepping scheme.
+  real    :: begw    !< A nondimensional number from 0 to 1 that controls
+                     !! the extent to which the treatment of gravity waves
+                     !! is forward-backward (0) or simulated backward
+                     !! Euler (1).  0 is almost always used.
+  logical :: debug   !< If true, write verbose checksums for debugging purposes.
 
-  real    :: be              ! A nondimensional number from 0.5 to 1 that controls
-                             ! the backward weighting of the time stepping scheme.
-  real    :: begw            ! A nondimensional number from 0 to 1 that controls
-                             ! the extent to which the treatment of gravity waves
-                             ! is forward-backward (0) or simulated backward
-                             ! Euler (1).  0 is almost always used.
-  logical :: debug           ! If true, write verbose checksums for debugging purposes.
+  logical :: module_is_initialized = .false. !< Record whether this mouled has been initialzed.
 
-  logical :: module_is_initialized = .false.
-
+  !>@{ Diagnostic IDs
   integer :: id_uh = -1, id_vh = -1
   integer :: id_PFu = -1, id_PFv = -1, id_CAu = -1, id_CAv = -1
+  !!@}
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  type(accel_diag_ptrs), pointer :: ADp => NULL() ! A structure pointing to the
-                                   ! accelerations in the momentum equations,
-                                   ! which can later be used to calculate
-                                   ! derived diagnostics like energy budgets.
-  type(cont_diag_ptrs), pointer :: CDp => NULL() ! A structure with pointers to
-                                   ! various terms in the continuity equations,
-                                   ! which can later be used to calculate
-                                   ! derived diagnostics like energy budgets.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  type(accel_diag_ptrs), pointer :: ADp => NULL() !< A structure pointing to the
+                                   !! accelerations in the momentum equations,
+                                   !! which can later be used to calculate
+                                   !! derived diagnostics like energy budgets.
+  type(cont_diag_ptrs), pointer :: CDp => NULL() !< A structure with pointers to
+                                   !! various terms in the continuity equations,
+                                   !! which can later be used to calculate
+                                   !! derived diagnostics like energy budgets.
 
-! The remainder of the structure is pointers to child subroutines' control strings.
+  ! The remainder of the structure points to child subroutines' control structures.
+  !> A pointer to the horizontal viscosity control structure
   type(hor_visc_CS), pointer :: hor_visc_CSp => NULL()
+  !> A pointer to the continuity control structure
   type(continuity_CS), pointer :: continuity_CSp => NULL()
+  !> A pointer to the CoriolisAdv control structure
   type(CoriolisAdv_CS), pointer :: CoriolisAdv_CSp => NULL()
+  !> A pointer to the PressureForce control structure
   type(PressureForce_CS), pointer :: PressureForce_CSp => NULL()
+  !> A pointer to the vertvisc control structure
   type(vertvisc_CS), pointer :: vertvisc_CSp => NULL()
+  !> A pointer to the set_visc control structure
   type(set_visc_CS), pointer :: set_visc_CSp => NULL()
-  type(ocean_OBC_type), pointer :: OBC => NULL() ! A pointer to an open boundary
-     ! condition type that specifies whether, where, and  what open boundary
-     ! conditions are used.  If no open BCs are used, this pointer stays
-     ! nullified.  Flather OBCs use open boundary_CS as well.
+  !> A pointer to the tidal forcing control structure
   type(tidal_forcing_CS), pointer :: tides_CSp => NULL()
-  type(update_OBC_CS), pointer :: update_OBC_CSp => NULL()
-
-! This is a copy of the pointer in the top-level control structure.
+  !> A pointer to the ALE control structure.
   type(ALE_CS), pointer :: ALE_CSp => NULL()
+
+  type(ocean_OBC_type), pointer :: OBC => NULL() !< A pointer to an open boundary
+     !! condition type that specifies whether, where, and what open boundary
+     !! conditions are used.  If no open BCs are used, this pointer stays
+     !! nullified.  Flather OBCs use open boundary_CS as well.
+  !> A pointer to the update_OBC control structure
+  type(update_OBC_CS), pointer :: update_OBC_CSp => NULL()
 
 end type MOM_dyn_unsplit_RK2_CS
 
@@ -160,9 +169,11 @@ end type MOM_dyn_unsplit_RK2_CS
 public step_MOM_dyn_unsplit_RK2, register_restarts_dyn_unsplit_RK2
 public initialize_dyn_unsplit_RK2, end_dyn_unsplit_RK2
 
+!>@{ CPU time clock IDs
 integer :: id_clock_Cor, id_clock_pres, id_clock_vertvisc
 integer :: id_clock_horvisc, id_clock_continuity, id_clock_mom_update
 integer :: id_clock_pass, id_clock_pass_init
+!!@}
 
 contains
 

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -32,13 +32,11 @@ public register_forcing_type_diags, allocate_forcing_type, deallocate_forcing_ty
 public copy_common_forcing_fields, allocate_mech_forcing, deallocate_mech_forcing
 public set_derived_forcing_fields, copy_back_forcing_fields, set_net_mass_forcing
 
-!> Structure that contains pointers to the boundary forcing
-!! used to drive the liquid ocean simulated by MOM.
-!! Data in this type is allocated in the module
-!! MOM_surface_forcing.F90, of which there are three:
-!! solo, coupled, and ice-shelf. Alternatively, they are
-!! allocated in MESO_surface_forcing.F90, which is a
-!! special case of solo_driver/MOM_surface_forcing.F90.
+!> Structure that contains pointers to the boundary forcing used to drive the
+!! liquid ocean simulated by MOM. Data in this type is allocated in the module
+!! MOM_surface_forcing.F90, of which there are three: solo, coupled, and
+!! ice-shelf. Alternatively, they are allocated in MESO_surface_forcing.F90,
+!! which is a special case of solo_driver/MOM_surface_forcing.F90.
 type, public :: forcing
 
   ! Pointers in this module should be initialized to NULL.
@@ -107,17 +105,16 @@ type, public :: forcing
                                  !! to net zero ( kg salt/(m^2 s) )
 
   ! applied surface pressure from other component models (e.g., atmos, sea ice, land ice)
-  real, pointer, dimension(:,:) :: &
-    p_surf_full   => NULL(), & !< Pressure at the top ocean interface (Pa).
-                               !! if there is sea-ice, then p_surf_flux is at ice-ocean interface
-    p_surf        => NULL(), & !< Pressure at the top ocean interface (Pa) as used
-                               !! to drive the ocean model. If p_surf is limited,
-                               !! p_surf may be smaller than p_surf_full,
-                               !! otherwise they are the same.
-    p_surf_SSH    => NULL()    !< Pressure at the top ocean interface that is used
-                               !! in corrections to the sea surface height field
-                               !! that is passed back to the calling routines.
-                               !! This may point to p_surf or to p_surf_full.
+  real, pointer, dimension(:,:) :: p_surf_full => NULL()
+                !< Pressure at the top ocean interface (Pa).
+                !! if there is sea-ice, then p_surf_flux is at ice-ocean interface
+  real, pointer, dimension(:,:) :: p_surf => NULL()
+                !< Pressure at the top ocean interface (Pa) as used to drive the ocean model.
+                !! If p_surf is limited, p_surf may be smaller than p_surf_full, otherwise they are the same.
+  real, pointer, dimension(:,:) :: p_surf_SSH => NULL()
+                !< Pressure at the top ocean interface that is used in corrections to the sea surface
+                !! height field that is passed back to the calling routines.
+                !! p_surf_SSH may point to p_surf or to p_surf_full.
   logical :: accumulate_p_surf = .false. !< If true, the surface pressure due to the atmosphere
                                  !! and various types of ice needs to be accumulated, and the
                                  !! surface pressure explicitly reset to zero at the driver level
@@ -135,14 +132,14 @@ type, public :: forcing
     mass_berg  => NULL()      !< mass of icebergs (kg/m2)
 
   ! land ice-shelf related inputs
-  real, pointer, dimension(:,:) :: &
-    ustar_shelf   => NULL(), &   !< friction velocity under ice-shelves (m/s)
+  real, pointer, dimension(:,:) :: ustar_shelf => NULL()  !< Friction velocity under ice-shelves (in m/s)
                                  !! as computed by the ocean at the previous time step.
-    frac_shelf_h  => NULL(), &   !! Fractional ice shelf coverage of h-cells, nondimensional
+  real, pointer, dimension(:,:) :: frac_shelf_h => NULL() !< Fractional ice shelf coverage of h-cells, nondimensional
                                  !! cells, nondimensional from 0 to 1. This is only
                                  !! associated if ice shelves are enabled, and are
                                  !! exactly 0 away from shelves or on land.
-    iceshelf_melt   => NULL()    !< ice shelf melt rate (positive) or freezing (negative) ( m/year )
+  real, pointer, dimension(:,:) :: iceshelf_melt => NULL() !< Ice shelf melt rate (positive)
+                                 !! or freezing (negative) (in m/year)
 
   ! Scalars set by surface forcing modules
   real :: vPrecGlobalAdj     !< adjustment to restoring vprec to zero out global net ( kg/(m^2 s) )
@@ -184,48 +181,50 @@ type, public :: mech_forcing
     taux  => NULL(), & !< zonal wind stress (Pa)
     tauy  => NULL(), & !< meridional wind stress (Pa)
     ustar => NULL(), & !< surface friction velocity scale (m/s)
+    net_mass_src => NULL() !< The net mass source to the ocean, in kg m-2 s-1.
 
   ! applied surface pressure from other component models (e.g., atmos, sea ice, land ice)
-    p_surf_full   => NULL(), & !< Pressure at the top ocean interface (Pa).
-                               !! if there is sea-ice, then p_surf_flux is at ice-ocean interface
-    p_surf        => NULL(), & !< Pressure at the top ocean interface (Pa) as used
-                               !! to drive the ocean model. If p_surf is limited,
-                               !! p_surf may be smaller than p_surf_full,
-                               !! otherwise they are the same.
-    p_surf_SSH    => NULL(), & !< Pressure at the top ocean interface that is used
-                               !! in corrections to the sea surface height field
-                               !! that is passed back to the calling routines.
-                               !! This may point to p_surf or to p_surf_full.
-    net_mass_src  => NULL(), & !< The net mass source to the ocean, in kg m-2 s-1.
+  real, pointer, dimension(:,:) :: p_surf_full => NULL()
+                !< Pressure at the top ocean interface (Pa).
+                !! if there is sea-ice, then p_surf_flux is at ice-ocean interface
+  real, pointer, dimension(:,:) :: p_surf => NULL()
+                !< Pressure at the top ocean interface (Pa) as used to drive the ocean model.
+                !! If p_surf is limited, p_surf may be smaller than p_surf_full, otherwise they are the same.
+  real, pointer, dimension(:,:) :: p_surf_SSH => NULL()
+                !< Pressure at the top ocean interface that is used in corrections to the sea surface
+                !! height field that is passed back to the calling routines.
+                !! p_surf_SSH may point to p_surf or to p_surf_full.
 
   ! iceberg related inputs
+  real, pointer, dimension(:,:) :: &
     area_berg  => NULL(), &    !< area of ocean surface covered by icebergs (m2/m2)
-    mass_berg  => NULL(), &    !< mass of icebergs (kg/m2)
+    mass_berg  => NULL()       !< mass of icebergs (kg/m2)
 
   ! land ice-shelf related inputs
-    frac_shelf_u  => NULL(), &   !< Fractional ice shelf coverage of u-cells, nondimensional
-                                 !! from 0 to 1. This is only associated if ice shelves are
-                                 !< enabled, and is exactly 0 away from shelves or on land.
-    frac_shelf_v  => NULL(), &   !< Fractional ice shelf coverage of v-cells, nondimensional
-                                 !! from 0 to 1. This is only associated if ice shelves are
-                                 !< enabled, and is exactly 0 away from shelves or on land.
-    rigidity_ice_u => NULL(), &  !< Depth-integrated lateral viscosity of ice
-    rigidity_ice_v => NULL()     !< shelves or sea ice at u- or v-points (m3/s)
+  real, pointer, dimension(:,:) :: frac_shelf_u  => NULL() !< Fractional ice shelf coverage of u-cells,
+                !! nondimensional from 0 to 1. This is only associated if ice shelves are enabled,
+                !! and is exactly 0 away from shelves or on land.
+  real, pointer, dimension(:,:) :: frac_shelf_v  => NULL() !< Fractional ice shelf coverage of v-cells,
+                !! nondimensional from 0 to 1. This is only associated if ice shelves are enabled,
+                !! and is exactly 0 away from shelves or on land.
+  real, pointer, dimension(:,:) :: &
+    rigidity_ice_u => NULL(), & !< Depth-integrated lateral viscosity of ice shelves or sea ice at u-points (m3/s)
+    rigidity_ice_v => NULL()    !< Depth-integrated lateral viscosity of ice shelves or sea ice at v-points (m3/s)
   logical :: accumulate_p_surf = .false. !< If true, the surface pressure due to the atmosphere
-                                 !! and various types of ice needs to be accumulated, and the
-                                 !! surface pressure explicitly reset to zero at the driver level
-                                 !! when appropriate.
+                                !! and various types of ice needs to be accumulated, and the
+                                !! surface pressure explicitly reset to zero at the driver level
+                                !! when appropriate.
   logical :: accumulate_rigidity = .false. !< If true, the rigidity due to various types of
-                                 !! ice needs to be accumulated, and the rigidity explicitly
-                                 !! reset to zero at the driver level when appropriate.
+                                !! ice needs to be accumulated, and the rigidity explicitly
+                                !! reset to zero at the driver level when appropriate.
 
-  logical :: initialized = .false. !< This indicates whether the appropriate
-                                 !! arrays have been initialized.
+  logical :: initialized = .false. !< This indicates whether the appropriate arrays have been initialized.
 end type mech_forcing
 
 !> Structure that defines the id handles for the forcing type
 type, public :: forcing_diags
 
+  !>@{ Forcing diagnostic handles
   ! mass flux diagnostic handles
   integer :: id_prcme        = -1, id_evap        = -1
   integer :: id_precip       = -1, id_vprec       = -1
@@ -262,7 +261,6 @@ type, public :: forcing_diags
   integer :: id_heat_added          = -1, id_heat_content_massin   = -1
   integer :: id_hfrainds            = -1, id_hfrunoffds            = -1
 
-
   ! global area integrated heat flux diagnostic handles
   integer :: id_total_net_heat_coupler    = -1, id_total_net_heat_surface      = -1
   integer :: id_total_sens                = -1, id_total_LwLatSens             = -1
@@ -297,7 +295,7 @@ type, public :: forcing_diags
   integer :: id_netFWGlobalAdj    = -1
   integer :: id_netFWGlobalScl    = -1
 
-  ! momentum flux diagnostic handls
+  ! momentum flux amd forcing diagnostic handles
   integer :: id_taux  = -1
   integer :: id_tauy  = -1
   integer :: id_ustar = -1
@@ -306,17 +304,17 @@ type, public :: forcing_diags
   integer :: id_TKE_tidal = -1
   integer :: id_buoy      = -1
 
-  ! clock id handle
-  integer :: id_clock_forcing
-
-  ! iceberg id handle
+  ! iceberg diagnostic handles
   integer :: id_ustar_berg = -1
   integer :: id_area_berg = -1
   integer :: id_mass_berg = -1
 
-  !Iceberg + Ice shelf
+  ! Iceberg + Ice shelf diagnostic handles
   integer :: id_ustar_ice_cover = -1
   integer :: id_frac_ice_cover = -1
+  !!@}
+
+  integer :: id_clock_forcing = -1 !< CPU clock id
 
 end type forcing_diags
 
@@ -372,21 +370,19 @@ subroutine extractFluxes1d(G, GV, fluxes, optics, nsw, j, dt,                   
                                                             !! thermodynamic fields. Used to keep
                                                             !! track of the heat flux associated with net
                                                             !! mass fluxes into the ocean.
-  logical,                  intent(in)    :: aggregate_FW     !< For determining how to aggregate forcing.
+  logical,                  intent(in)    :: aggregate_FW   !< For determining how to aggregate forcing.
   real, dimension(SZI_(G)), &
-                  optional, intent(out)  :: nonpenSW        !< non-downwelling SW; use in net_heat.
-                                                            !! Sum over SW bands when diagnosing nonpenSW.
-                                                            !! Units are (K * H).
+                  optional, intent(out)   :: nonpenSW       !< Non-penetrating SW in degC H, used in net_heat.
+                                                            !! Summed over SW bands when diagnosing nonpenSW.
   real, dimension(SZI_(G)), &
-                  optional, intent(out)  :: net_Heat_rate   !< Rate of net surface heating in H K s-1.
+                  optional, intent(out)   :: net_Heat_rate   !< Rate of net surface heating in H K s-1.
   real, dimension(SZI_(G)), &
-                  optional, intent(out)  :: net_salt_rate   !< Surface salt flux into the ocean in ppt H s-1.
+                  optional, intent(out)   :: net_salt_rate   !< Surface salt flux into the ocean in ppt H s-1.
   real, dimension(SZI_(G)), &
-                  optional, intent(out)  :: netmassInOut_rate !< Rate of net mass flux into the ocean in H s-1.
+                  optional, intent(out)   :: netmassInOut_rate !< Rate of net mass flux into the ocean in H s-1.
   real, dimension(:,:),     &
-                  optional, intent(out)  :: pen_sw_bnd_rate !< Rate of penetrative shortwave heating
-                                                            !! in degC H s-1.
-  logical,        optional, intent(in)   :: skip_diags      !< If present and true, skip calculating diagnostics
+                  optional, intent(out)   :: pen_sw_bnd_rate !< Rate of penetrative shortwave heating in degC H s-1.
+  logical,        optional, intent(in)    :: skip_diags      !< If present and true, skip calculating diagnostics
 
   ! local
   real :: htot(SZI_(G))       ! total ocean depth (m for Bouss or kg/m^2 for non-Bouss)
@@ -1044,7 +1040,7 @@ end subroutine MOM_mech_forcing_chksum
 
 !> Write out values of the mechanical forcing arrays at the i,j location. This is a debugging tool.
 subroutine mech_forcing_SinglePointPrint(forces, G, i, j, mesg)
-  type(mech_forcing),      intent(in) :: forces    !< A structure with the driving mechanical forces
+  type(mech_forcing),    intent(in) :: forces !< A structure with the driving mechanical forces
   type(ocean_grid_type), intent(in) :: G      !< Grid type
   character(len=*),      intent(in) :: mesg   !< Message
   integer,               intent(in) :: i      !< i-index

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -145,8 +145,8 @@ type, public :: ocean_grid_type
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &
     CoriolisBu    !< The Coriolis parameter at corner points, in s-1.
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
-    dF_dx, &      !< Derivative d/dx f (Coriolis parameter) at h-points, in s-1 m-1.
-    dF_dy         !< Derivative d/dy f (Coriolis parameter) at h-points, in s-1 m-1.
+    df_dx, &      !< Derivative d/dx f (Coriolis parameter) at h-points, in s-1 m-1.
+    df_dy         !< Derivative d/dy f (Coriolis parameter) at h-points, in s-1 m-1.
   real :: g_Earth !< The gravitational acceleration in m s-2.
 
   ! These variables are global sums that are useful for 1-d diagnostics
@@ -154,8 +154,8 @@ type, public :: ocean_grid_type
   real :: IareaT_global !< Global sum of inverse h-cell area (1/areaT_global) in m2.
 
   ! These variables are for block structures.
-  integer :: nblocks
-  type(hor_index_type), pointer :: Block(:) => NULL() ! store indices for each block
+  integer :: nblocks  !< The number of sub-PE blocks on this PE
+  type(hor_index_type), pointer :: Block(:) => NULL() !< Index ranges for each block
 
   ! These parameters are run-time parameters that are used during some
   ! initialization routines (but not all)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -53,9 +53,11 @@ public register_temp_salt_segments
 public fill_temp_salt_segments
 public open_boundary_register_restarts
 
-integer, parameter, public :: OBC_NONE = 0, OBC_SIMPLE = 1, OBC_WALL = 2
-integer, parameter, public :: OBC_FLATHER = 3
-integer, parameter, public :: OBC_RADIATION = 4
+integer, parameter, public :: OBC_NONE = 0      !< Indicates the use of no open boundary
+integer, parameter, public :: OBC_SIMPLE = 1    !< Indicates the use of a simple inflow open boundary
+integer, parameter, public :: OBC_WALL = 2      !< Indicates the use of a closed sall
+integer, parameter, public :: OBC_FLATHER =  3  !< Indicates the use of a Flather open boundary
+integer, parameter, public :: OBC_RADIATION = 4 !< Indicates the use of a radiation open boundary
 integer, parameter, public :: OBC_DIRECTION_N = 100 !< Indicates the boundary is an effective northern boundary
 integer, parameter, public :: OBC_DIRECTION_S = 200 !< Indicates the boundary is an effective southern boundary
 integer, parameter, public :: OBC_DIRECTION_E = 300 !< Indicates the boundary is an effective eastern boundary
@@ -213,7 +215,7 @@ type, public :: ocean_OBC_type
   logical :: zero_biharmonic = .false.                !< If True, zeros the Laplacian of flow on open boundaries for
                                                       !! use in the biharmonic viscosity term.
   logical :: brushcutter_mode = .false.               !< If True, read data on supergrid.
-  real :: g_Earth
+  real :: g_Earth                                     !< The gravitational acceleration in m s-2.
   ! Properties of the segments used.
   type(OBC_segment_type), pointer, dimension(:) :: &
     segment => NULL()   !< List of segment objects.
@@ -262,9 +264,9 @@ type, public :: OBC_registry_type
                                              !! When locked=.true.,no more boundaries can be registered.
 end type OBC_registry_type
 
-integer :: id_clock_pass
+integer :: id_clock_pass !< A CPU time clock
 
-character(len=40)  :: mdl = "MOM_open_boundary" ! This module's name.
+character(len=40)  :: mdl = "MOM_open_boundary" !< This module's name.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -13,53 +13,43 @@ public verticalGridInit, verticalGridEnd
 public setVerticalGridAxes
 public get_flux_units, get_thickness_units, get_tr_flux_units
 
+!> Describes the ocean's vertical grid, including unit conversion factors
 type, public :: verticalGrid_type
 
   ! Commonly used parameters
   integer :: ke     !< The number of layers/levels in the vertical
   real :: max_depth !< The maximum depth of the ocean in meters.
   real :: g_Earth   !< The gravitational acceleration in m s-2.
-  real :: Rho0      !<   The density used in the Boussinesq approximation or
-                    !! nominal density used to convert depths into mass
-                    !! units, in kg m-3.
+  real :: Rho0      !< The density used in the Boussinesq approximation or nominal
+                    !! density used to convert depths into mass units, in kg m-3.
 
   ! Vertical coordinate descriptions for diagnostics and I/O
-  character(len=40) :: &
-    zAxisUnits, & !< The units that vertical coordinates are written in
-    zAxisLongName !< Coordinate name to appear in files,
-                  !! e.g. "Target Potential Density" or "Height"
+  character(len=40) :: zAxisUnits !< The units that vertical coordinates are written in
+  character(len=40) :: zAxisLongName !< Coordinate name to appear in files,
+                                  !! e.g. "Target Potential Density" or "Height"
   real ALLOCABLE_, dimension(NKMEM_) :: sLayer !< Coordinate values of layer centers
   real ALLOCABLE_, dimension(NK_INTERFACE_) :: sInterface !< Coordinate values on interfaces
   integer :: direction = 1 !< Direction defaults to 1, positive up.
 
   ! The following variables give information about the vertical grid.
-  logical :: Boussinesq     !< If true, make the Boussinesq approximation.
-  real :: Angstrom      !<   A one-Angstrom thickness in the model's thickness
-                        !! units.  (This replaces the old macro EPSILON.)
-  real :: Angstrom_z    !<   A one-Angstrom thickness in m.
-  real :: H_subroundoff !<   A thickness that is so small that it can be added to
-                        !! a thickness of Angstrom or larger without changing it
-                        !! at the bit level, in thickness units.  If Angstrom is
-                        !! 0 or exceedingly small, this is negligible compared to
-                        !! a thickness of 1e-17 m.
+  logical :: Boussinesq !< If true, make the Boussinesq approximation.
+  real :: Angstrom      !< A one-Angstrom thickness in the model's thickness units.
+  real :: Angstrom_z    !< A one-Angstrom thickness in m.
+  real :: H_subroundoff !< A thickness that is so small that it can be added to a thickness of
+                        !! Angstrom or larger without changing it at the bit level, in thickness units.
+                        !! If Angstrom is 0 or exceedingly small, this is negligible compared to 1e-17 m.
   real ALLOCABLE_, dimension(NK_INTERFACE_) :: &
     g_prime, &          !< The reduced gravity at each interface, in m s-2.
-    Rlay                !< The target coordinate value (potential density) in
-                        !! in each layer in kg m-3.
+    Rlay                !< The target coordinate value (potential density) in each layer in kg m-3.
   integer :: nkml = 0   !< The number of layers at the top that should be treated
                         !! as parts of a homogenous region.
   integer :: nk_rho_varies = 0 !< The number of layers at the top where the
                         !! density does not track any target density.
-  real :: H_to_kg_m2    !< A constant that translates thicknesses from the units
-                        !! of thickness to kg m-2.
-  real :: kg_m2_to_H    !< A constant that translates thicknesses from kg m-2 to
-                        !! the units of thickness.
-  real :: m_to_H        !< A constant that translates distances in m to the
-                        !! units of thickness.
-  real :: H_to_m        !< A constant that translates distances in the units of
-                        !! thickness to m.
-  real :: H_to_Pa       !< A constant that translates the units of thickness to
-                        !! to pressure in Pa.
+  real :: H_to_kg_m2    !< A constant that translates thicknesses from the units of thickness to kg m-2.
+  real :: kg_m2_to_H    !< A constant that translates thicknesses from kg m-2 to the units of thickness.
+  real :: m_to_H        !< A constant that translates distances in m to the units of thickness.
+  real :: H_to_m        !< A constant that translates distances in the units of thickness to m.
+  real :: H_to_Pa       !< A constant that translates the units of thickness to pressure in Pa.
 end type verticalGrid_type
 
 contains
@@ -203,7 +193,7 @@ function get_tr_flux_units(GV, tr_units, tr_vol_conc_units, tr_mass_conc_units)
   character(len=*), optional, intent(in) :: tr_units          !< Units for a tracer, for example
                                                               !! Celsius or PSU.
   character(len=*), optional, intent(in) :: tr_vol_conc_units !< The concentration units per unit
-                                                              !! volume, forexample if the units are
+                                                              !! volume, for example if the units are
                                                               !! umol m-3, tr_vol_conc_units would
                                                               !! be umol.
   character(len=*), optional, intent(in) :: tr_mass_conc_units !< The concentration units per unit

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -44,32 +44,36 @@ implicit none ; private
 
 public write_u_accel, write_v_accel, PointAccel_init
 
+!> The control structure for the MOM_PointAccel module
 type, public :: PointAccel_CS ; private
-  character(len=200) :: u_trunc_file ! The complete path to files in which a
-  character(len=200) :: v_trunc_file ! column's worth of accelerations are
-                                     ! written if velocity truncations occur.
-  integer :: u_file, v_file ! The unit numbers for opened u- or v- truncation
-                            ! files, or -1 if they have not yet been opened.
-  integer :: cols_written   ! The number of columns whose output has been
-                            ! written by this PE during the current run.
-  integer :: max_writes     ! The maximum number of times any PE can write out
-                            ! a column's worth of accelerations during a run.
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
+  character(len=200) :: u_trunc_file !< The complete path to the file in which a column's worth of
+                                     !! u-accelerations are written if u-velocity truncations occur.
+  character(len=200) :: v_trunc_file !< The complete path to the file in which a column's worth of
+                                     !! v-accelerations are written if v-velocity truncations occur.
+  integer :: u_file         !< The unit number for an opened u-truncation files, or -1 if it has not yet been opened.
+  integer :: v_file         !< The unit number for an opened v-truncation files, or -1 if it has not yet been opened.
+  integer :: cols_written   !< The number of columns whose output has been
+                            !! written by this PE during the current run.
+  integer :: max_writes     !< The maximum number of times any PE can write out
+                            !! a column's worth of accelerations during a run.
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
 ! The following are pointers to many of the state variables and accelerations
 ! that are used to step the physical model forward.  They all use the same
 ! names as the variables they point to in MOM.F90
   real, pointer, dimension(:,:,:) :: &
-    u_av => NULL(), v_av => NULL(), & ! Time average velocities in m s-1.
-    u_prev => NULL(), v_prev => NULL(), & ! Previous velocities in m s-1.
-    T => NULL(), S => NULL(), &     ! Temperature and salinity in C and psu.
-    pbce => NULL(), &               ! pbce times eta gives the baroclinic
-                                    ! pressure anomaly in each layer due to
-                                    ! free surface height anomalies.
-                                    ! pbce has units of m s-2.
-    u_accel_bt => NULL(), &         ! Barotropic acclerations in m s-2.
-    v_accel_bt => NULL()
+    u_av => NULL(), &       !< Time average u-velocity in m s-1.
+    v_av => NULL(), &       !< Time average velocity in m s-1.
+    u_prev => NULL(), &     !< Previous u-velocity in m s-1.
+    v_prev => NULL(), &     !< Previous v-velocity in m s-1.
+    T => NULL(), &          !< Temperature in deg C.
+    S => NULL(), &          !< Salinity in ppt
+    u_accel_bt => NULL(), & !< Barotropic u-acclerations in m s-2.
+    v_accel_bt => NULL()    !< Barotropic v-acclerations in m s-2.
+  real, pointer, dimension(:,:,:) :: pbce => NULL() !< pbce times eta gives the baroclinic
+                            !! pressure anomaly in each layer due to free surface height anomalies.
+                            !! pbce has units of m s-2.
 
 end type PointAccel_CS
 

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -28,33 +28,40 @@ public :: MOM_debugging_init, totalStuff, totalTandS
 public :: check_column_integral, check_column_integrals
 
 ! These interfaces come from MOM_checksums.
-public :: hchksum, Bchksum, qchksum, is_NaN, chksum
-public :: uvchksum
+public :: hchksum, Bchksum, qchksum, is_NaN, chksum, uvchksum
 
+!> Check for consistency between the duplicated points of a C-grid vector
 interface check_redundant
   module procedure check_redundant_vC3d, check_redundant_vC2d
 end interface check_redundant
+!> Check for consistency between the duplicated points of a C-grid vector
 interface check_redundant_C
   module procedure check_redundant_vC3d, check_redundant_vC2d
 end interface check_redundant_C
+!> Check for consistency between the duplicated points of a B-grid vector or scalar
 interface check_redundant_B
   module procedure check_redundant_vB3d, check_redundant_vB2d
   module procedure check_redundant_sB3d, check_redundant_sB2d
 end interface check_redundant_B
+!> Check for consistency between the duplicated points of an A-grid vector or scalar
 interface check_redundant_T
   module procedure check_redundant_sT3d, check_redundant_sT2d
   module procedure check_redundant_vT3d, check_redundant_vT2d
 end interface check_redundant_T
 
+!> Do checksums on the components of a C-grid vector
 interface vec_chksum
   module procedure chksum_vec_C3d, chksum_vec_C2d
 end interface vec_chksum
+!> Do checksums on the components of a C-grid vector
 interface vec_chksum_C
   module procedure chksum_vec_C3d, chksum_vec_C2d
 end interface vec_chksum_C
+!> Do checksums on the components of a B-grid vector
 interface vec_chksum_B
   module procedure chksum_vec_B3d, chksum_vec_B2d
 end interface vec_chksum_B
+!> Do checksums on the components of an A-grid vector
 interface vec_chksum_A
   module procedure chksum_vec_A3d, chksum_vec_A2d
 end interface vec_chksum_A
@@ -94,6 +101,7 @@ subroutine MOM_debugging_init(param_file)
 
 end subroutine MOM_debugging_init
 
+!> Check for consistency between the duplicated points of a 3-D C-grid vector
 subroutine check_redundant_vC3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
                                 direction)
   character(len=*),                    intent(in)    :: mesg   !< An identifying message
@@ -107,13 +115,7 @@ subroutine check_redundant_vC3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer,                   optional, intent(in)    :: js     !< The starting j-index to check
   integer,                   optional, intent(in)    :: je     !< The ending j-index to check
   integer,                   optional, intent(in)    :: direction !< the direction flag to be
-                                                           !! passed to pass_vector
-! Arguments: u_comp - The u-component of the vector being checked.
-!  (in)      v_comp - The v-component of the vector being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
-!  (in/opt)  direction - the direction flag to be passed to pass_vector.
+                                                               !! passed to pass_vector
 
   character(len=24) :: mesg_k
   integer :: k
@@ -129,6 +131,7 @@ subroutine check_redundant_vC3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   enddo
 end subroutine  check_redundant_vC3d
 
+!> Check for consistency between the duplicated points of a 2-D C-grid vector
 subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
                                 direction)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
@@ -143,13 +146,7 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer,               optional, intent(in)    :: je     !< The ending j-index to check
   integer,               optional, intent(in)    :: direction !< the direction flag to be
                                                            !! passed to pass_vector
-! Arguments: u_comp - The u-component of the vector being checked.
-!  (in)      v_comp - The v-component of the vector being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
-!  (in/opt)  direction - the direction flag to be passed to pass_vector.
-
+  ! Local variables
   real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
   real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
   real :: u_resym(G%IsdB:G%IedB,G%jsd:G%jed)
@@ -210,6 +207,7 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
 
 end subroutine  check_redundant_vC2d
 
+!> Check for consistency between the duplicated points of a 3-D scalar at corner points
 subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je)
   character(len=*),                     intent(in)    :: mesg  !< An identifying message
   type(ocean_grid_type),                intent(inout) :: G     !< The ocean's grid structure
@@ -218,11 +216,8 @@ subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je)
   integer,                    optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                    optional, intent(in)    :: js    !< The starting j-index to check
   integer,                    optional, intent(in)    :: je    !< The ending j-index to check
-! Arguments: array - The array being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
 
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -237,7 +232,7 @@ subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je)
   enddo
 end subroutine  check_redundant_sB3d
 
-
+!> Check for consistency between the duplicated points of a 2-D scalar at corner points
 subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
   character(len=*),                 intent(in)    :: mesg  !< An identifying message
   type(ocean_grid_type),            intent(inout) :: G     !< The ocean's grid structure
@@ -246,11 +241,8 @@ subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
   integer,                optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                optional, intent(in)    :: js    !< The starting j-index to check
   integer,                optional, intent(in)    :: je    !< The ending j-index to check
-! Arguments: array - The array being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
 
+  ! Local variables
   real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)
   real :: a_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
   character(len=128) :: mesg2
@@ -299,7 +291,7 @@ subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
 
 end subroutine  check_redundant_sB2d
 
-
+!> Check for consistency between the duplicated points of a 3-D B-grid vector
 subroutine check_redundant_vB3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
                                 direction)
   character(len=*),                    intent(in)    :: mesg   !< An identifying message
@@ -313,14 +305,9 @@ subroutine check_redundant_vB3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer,                   optional, intent(in)    :: js     !< The starting j-index to check
   integer,                   optional, intent(in)    :: je     !< The ending j-index to check
   integer,                   optional, intent(in)    :: direction !< the direction flag to be
-                                                           !! passed to pass_vector
-! Arguments: u_comp - The u-component of the vector being checked.
-!  (in)      v_comp - The v-component of the vector being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
-!  (in/opt)  direction - the direction flag to be passed to pass_vector.
+                                                               !! passed to pass_vector
 
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -335,6 +322,7 @@ subroutine check_redundant_vB3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   enddo
 end subroutine  check_redundant_vB3d
 
+!> Check for consistency between the duplicated points of a 2-D B-grid vector
 subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
                                 direction)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
@@ -349,13 +337,8 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer,                optional, intent(in)    :: je     !< The ending j-index to check
   integer,                optional, intent(in)    :: direction !< the direction flag to be
                                                             !! passed to pass_vector
-! Arguments: u_comp - The u-component of the vector being checked.
-!  (in)      v_comp - The v-component of the vector being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
-!  (in/opt)  direction - the direction flag to be passed to pass_vector.
 
+  ! Local variables
   real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
   real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
   real :: u_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
@@ -417,6 +400,7 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
 
 end subroutine  check_redundant_vB2d
 
+!> Check for consistency between the duplicated points of a 3-D scalar at tracer points
 subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je)
   character(len=*),                     intent(in)    :: mesg  !< An identifying message
   type(ocean_grid_type),                intent(inout) :: G     !< The ocean's grid structure
@@ -425,11 +409,8 @@ subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je)
   integer,                    optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                    optional, intent(in)    :: js    !< The starting j-index to check
   integer,                    optional, intent(in)    :: je    !< The ending j-index to check
-! Arguments: array - The array being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
 
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -445,6 +426,7 @@ subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je)
 end subroutine  check_redundant_sT3d
 
 
+!> Check for consistency between the duplicated points of a 2-D scalar at tracer points
 subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
   character(len=*),                 intent(in)    :: mesg  !< An identifying message
   type(ocean_grid_type),            intent(inout) :: G     !< The ocean's grid structure
@@ -453,11 +435,8 @@ subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
   integer,                optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                optional, intent(in)    :: js    !< The starting j-index to check
   integer,                optional, intent(in)    :: je    !< The ending j-index to check
-! Arguments: array - The array being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
 
+  ! Local variables
   real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)
   character(len=128) :: mesg2
 
@@ -492,7 +471,7 @@ subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
 
 end subroutine  check_redundant_sT2d
 
-
+!> Check for consistency between the duplicated points of a 3-D A-grid vector
 subroutine check_redundant_vT3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
                                direction)
   character(len=*),                    intent(in)    :: mesg   !< An identifying message
@@ -507,13 +486,7 @@ subroutine check_redundant_vT3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer,                   optional, intent(in)    :: je     !< The ending j-index to check
   integer,                   optional, intent(in)    :: direction !< the direction flag to be
                                                            !! passed to pass_vector
-! Arguments: u_comp - The u-component of the vector being checked.
-!  (in)      v_comp - The v-component of the vector being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
-!  (in/opt)  direction - the direction flag to be passed to pass_vector.
-
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -528,6 +501,7 @@ subroutine check_redundant_vT3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   enddo
 end subroutine  check_redundant_vT3d
 
+!> Check for consistency between the duplicated points of a 2-D A-grid vector
 subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
                                direction)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
@@ -599,7 +573,7 @@ end subroutine  check_redundant_vT2d
 
 ! =====================================================================
 
-! This function does a checksum and redundant point check on a 3d C-grid vector.
+!> Do a checksum and redundant point check on a 3d C-grid vector.
 subroutine chksum_vec_C3d(mesg, u_comp, v_comp, G, halos, scalars)
   character(len=*),                  intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),             intent(inout) :: G      !< The ocean's grid structure
@@ -625,7 +599,7 @@ subroutine chksum_vec_C3d(mesg, u_comp, v_comp, G, halos, scalars)
 
 end subroutine chksum_vec_C3d
 
-! This function does a checksum and redundant point check on a 2d C-grid vector.
+!> Do a checksum and redundant point check on a 2d C-grid vector.
 subroutine chksum_vec_C2d(mesg, u_comp, v_comp, G, halos, scalars)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),           intent(inout) :: G      !< The ocean's grid structure
@@ -651,7 +625,7 @@ subroutine chksum_vec_C2d(mesg, u_comp, v_comp, G, halos, scalars)
 
 end subroutine chksum_vec_C2d
 
-! This function does a checksum and redundant point check on a 3d B-grid vector.
+!> Do a checksum and redundant point check on a 3d B-grid vector.
 subroutine chksum_vec_B3d(mesg, u_comp, v_comp, G, halos, scalars)
   character(len=*),                   intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),              intent(inout) :: G      !< The ocean's grid structure
@@ -678,7 +652,7 @@ subroutine chksum_vec_B3d(mesg, u_comp, v_comp, G, halos, scalars)
 
 end subroutine chksum_vec_B3d
 
-! This function does a checksum and redundant point check on a 2d B-grid vector.
+! Do a checksum and redundant point check on a 2d B-grid vector.
 subroutine chksum_vec_B2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),            intent(inout) :: G      !< The ocean's grid structure
@@ -707,7 +681,7 @@ subroutine chksum_vec_B2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric)
 
 end subroutine chksum_vec_B2d
 
-! This function does a checksum and redundant point check on a 3d C-grid vector.
+!> Do a checksum and redundant point check on a 3d C-grid vector.
 subroutine chksum_vec_A3d(mesg, u_comp, v_comp, G, halos, scalars)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),            intent(inout) :: G      !< The ocean's grid structure
@@ -735,7 +709,7 @@ subroutine chksum_vec_A3d(mesg, u_comp, v_comp, G, halos, scalars)
 end subroutine chksum_vec_A3d
 
 
-! This function does a checksum and redundant point check on a 2d C-grid vector.
+!> Do a checksum and redundant point check on a 2d C-grid vector.
 subroutine chksum_vec_A2d(mesg, u_comp, v_comp, G, halos, scalars)
   character(len=*),               intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),          intent(inout) :: G      !< The ocean's grid structure
@@ -772,7 +746,9 @@ function totalStuff(HI, hThick, areaT, stuff)
   real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: hThick !< The array of thicknesses to use as weights
   real, dimension(HI%isd:,HI%jsd:),   intent(in) :: areaT  !< The array of cell areas in m2
   real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: stuff  !< The array of stuff to be summed
-  real                                         :: totalStuff
+  real                                         :: totalStuff !< the globally integrated amoutn of stuff
+
+  ! Local variables
   integer :: i, j, k, nz
 
   nz = size(hThick,3)

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -1,4 +1,4 @@
-module MOM_diag_to_Z
+Module MOM_diag_to_Z
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
@@ -55,38 +55,42 @@ public find_limited_slope
 public register_Zint_diag
 public calc_Zint_diags
 
+!> The control structure for the MOM_diag_to_Z module
 type, public :: diag_to_Z_CS ; private
   ! The following arrays are used to store diagnostics calculated in this
   ! module and unavailable outside of it.
 
   real, pointer, dimension(:,:,:) :: &
-    u_z  => NULL(), &   ! zonal velocity remapped to depth space (m/s)
-    v_z  => NULL(), &   ! meridional velocity remapped to depth space (m/s)
-    uh_z => NULL(), &   ! zonal transport remapped to depth space (m3/s or kg/s)
-    vh_z => NULL()      ! meridional transport remapped to depth space (m3/s or kg/s)
+    u_z  => NULL(), &   !< zonal velocity remapped to depth space (m/s)
+    v_z  => NULL(), &   !< meridional velocity remapped to depth space (m/s)
+    uh_z => NULL(), &   !< zonal transport remapped to depth space (m3/s or kg/s)
+    vh_z => NULL()      !< meridional transport remapped to depth space (m3/s or kg/s)
 
-  type(p3d) :: tr_z(MAX_FIELDS_)     ! array of tracers, remapped to depth space
-  type(p3d) :: tr_model(MAX_FIELDS_) ! pointers to an array of tracers
+  type(p3d) :: tr_z(MAX_FIELDS_)     !< array of tracers, remapped to depth space
+  type(p3d) :: tr_model(MAX_FIELDS_) !< pointers to an array of tracers
 
-  real    :: missing_vel             = -1.0e34
-  real    :: missing_trans           = -1.0e34
-  real    :: missing_value           = -1.0e34
-  real    :: missing_tr(MAX_FIELDS_) = -1.0e34
+  real :: missing_vel             = -1.0e34 !< Missing variable fill values for velocities
+  real :: missing_trans           = -1.0e34 !< Missing variable fill values for transports
+  real :: missing_tr(MAX_FIELDS_) = -1.0e34 !< Missing variable fill values for tracers
+  real :: missing_value           = -1.0e34 !< Missing variable fill values for other diagnostics
 
-  integer :: id_u_z  = -1
-  integer :: id_v_z  = -1
-  integer :: id_uh_Z = -1
-  integer :: id_vh_Z = -1
-  integer :: id_tr(MAX_FIELDS_) = -1
-  integer :: id_tr_xyave(MAX_FIELDS_) = -1
-  integer :: num_tr_used = 0
-  integer :: nk_zspace = -1
+  integer :: id_u_z  = -1  !< Diagnostic ID for zonal velocity
+  integer :: id_v_z  = -1  !< Diagnostic ID for meridional velocity
+  integer :: id_uh_Z = -1  !< Diagnostic ID for zonal transports
+  integer :: id_vh_Z = -1  !< Diagnostic ID for meridional transports
+  integer :: id_tr(MAX_FIELDS_) = -1  !< Diagnostic IDs for tracers
+  integer :: id_tr_xyave(MAX_FIELDS_) = -1  !< Diagnostic IDs for spatially averaged tracers
 
-  real, pointer :: Z_int(:) => NULL()  ! interface depths of the z-space file (meter)
+  integer :: num_tr_used = 0 !< Th enumber of tracers in use.
+  integer :: nk_zspace = -1 !< The number of levels in the z-space output
 
+  real, pointer :: Z_int(:) => NULL()  !< interface depths of the z-space file (meter)
+
+  !>@{ Axis groups for z-space diagnostic output
   type(axes_grp) :: axesBz,  axesTz,  axesCuz,  axesCvz
   type(axes_grp) :: axesBzi, axesTzi, axesCuzi, axesCvzi
   type(axes_grp) :: axesZ
+  !!@}
   integer, dimension(1) :: axesz_out
 
   type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
@@ -98,6 +102,7 @@ integer, parameter :: NO_ZSPACE = -1
 
 contains
 
+!> Return the global horizontal mean in z-space
 function global_z_mean(var,G,CS,tracer)
   type(ocean_grid_type), intent(in)  :: G    !< The ocean's grid structure
   type(diag_to_Z_CS),    pointer     :: CS   !< Control structure returned by
@@ -168,15 +173,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
 
 ! This subroutine maps tracers and velocities into depth space for diagnostics.
 
-! Arguments:
-!  (in)  u   - zonal velocity component (m/s)
-!  (in)  v   - meridional velocity component (m/s)
-!  (in)  h   - layer thickness (meter or kg/m2)
-!  (in)  ssh_in - sea surface height (meter or kg/m2)
-!  (in)  G   - ocean grid structure
-!  (in)  GV  - The ocean's vertical grid structure.
-!  (in)  CS  - control structure returned by previous call to diag_to_Z_init
-
+  ! Local variables
   ! Note the deliberately reversed axes in h_f, u_f, v_f, and tr_f.
   real :: ssh(SZI_(G),SZJ_(G))   ! copy of ssh_in (meter or kg/m2)
   real :: e(SZK_(G)+2)           ! z-star interface heights (meter or kg/m2)
@@ -530,15 +527,7 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
 
 !   This subroutine maps horizontal transport into depth space for diagnostic output.
 
-! Arguments:
-!  (in)      uh_int - time integrated zonal transport (m3 or kg)
-!  (in)      vh_int - time integrated meridional transport (m3 or kg)
-!  (in)      h      - layer thickness (meter or kg/m2)
-!  (in)      dt     - time difference (sec) since last call to this routine
-!  (in)      G      - ocean grid structure
-!  (in)      GV     - The ocean's vertical grid structure
-!  (in)      CS     - control structure returned by previous call to diag_to_Z_init
-
+  ! Local variables
   real, dimension(SZI_(G), SZJ_(G)) :: &
     htot, &        ! total layer thickness (meter or kg/m2)
     dilate         ! nondimensional factor by which to dilate layers to
@@ -701,6 +690,7 @@ subroutine find_overlap(e, Z_top, Z_bot, k_max, k_start, k_top, k_bot, wt, z1, z
   real, dimension(:), intent(out)   :: z2     !< Depths of the bottom limit of the part of
        !! a layer that contributes to a depth level, relative to the cell center and normalized
        !! by the cell thickness (nondim).  Note that -1/2 <= z1 < z2 <= 1/2.
+
   ! Local variables
   real    :: Ih, e_c, tot_wt, I_totwt
   integer :: k
@@ -750,13 +740,7 @@ subroutine find_limited_slope(val, e, slope, k)
 
 !   This subroutine determines a limited slope for val to be advected with
 ! a piecewise limited scheme.
-
-! Arguments:
-!  (in)      val   - a column of values that are being interpolated
-!  (in)      e     - column interface heights (meter or kg/m2)
-!  (in)      slope - normalized slope in the intracell distribution of val
-!  (in)      k     - layer whose slope is being determined
-
+  ! Local variables
   real :: d1, d2
 
   if ((val(k)-val(k-1)) * (val(k)-val(k+1)) >= 0.0) then
@@ -787,6 +771,7 @@ subroutine calc_Zint_diags(h, in_ptrs, ids, num_diags, G, GV, CS)
   type(diag_to_Z_CS),      pointer    :: CS   !< Control structure returned by
                                               !! previous call to diag_to_Z_init.
 
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G),max(CS%nk_zspace+1,1),max(num_diags,1)) :: &
     diag_on_Z  ! diagnostics interpolated to depth space
   real, dimension(SZI_(G),SZK_(G)+1) :: e
@@ -892,20 +877,7 @@ subroutine register_Z_tracer(tr_ptr, name, long_name, units, Time, G, CS, standa
   character(len=*), optional, intent(in) :: cmor_standard_name !< cmor standardized name
                                                             !! associated with a field.
 
-!   This subroutine registers a tracer to be output in depth space.
-! Arguments:
-!  (in)      tr_ptr    - tracer for translation to Z-space
-!  (in)      name      - name for the output tracer
-!  (in)      long_name - long name for the output tracer
-!  (in)      units     - units of output tracer
-!  (in)      Time      - current model time
-!  (in)      G         - ocean grid structure
-!  (in)      CS        - control struct returned by previous call to diag_to_Z_init
-!  (in,opt)  cmor_field_name    - cmor name of a field
-!  (in,opt)  cmor_long_name     - cmor long name of a field
-!  (in,opt)  cmor_units         - cmor units of a field
-!  (in,opt)  cmor_standard_name - cmor standardized name associated with a field
-
+  ! Local variables
   character(len=256) :: posted_standard_name
   character(len=256) :: posted_cmor_units
   character(len=256) :: posted_cmor_standard_name
@@ -958,17 +930,7 @@ subroutine register_Z_tracer_low(tr_ptr, name, long_name, units, standard_name, 
   type(diag_to_Z_CS),    pointer    :: CS     !< Control struct returned by previous call to
                                               !! diag_to_Z_init.
 
-!   This subroutine registers a tracer to be output in depth space.
-
-! Arguments:
-!  (in)      tr_ptr    - tracer for translation to Z-space
-!  (in)      name      - name for the output tracer
-!  (in)      long_name - long name for output tracer
-!  (in)      units     - units of output tracer
-!  (in)      Time      - current model time
-!  (in)      G         - ocean grid structure
-!  (in)      CS        - control struct returned by previous call to diag_to_Z_init
-
+  ! Local variables
   character(len=256) :: posted_standard_name
   integer :: isd, ied, jsd, jed, nk, m, id_test
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nk = G%ke
@@ -1016,8 +978,7 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
   type(time_type),         intent(in)    :: Time !< Current model time.
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
-  type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time
-                                                 !! parameters.
+  type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters.
   type(diag_ctrl), target, intent(inout) :: diag !< Struct to regulate diagnostic output.
   type(diag_to_Z_CS),      pointer       :: CS   !< Pointer to point to control structure for
                                                  !! this module, which is allocated and
@@ -1026,6 +987,7 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
+  ! Local variables
   character(len=40)  :: mdl = "MOM_diag_to_Z" ! module name
   character(len=200) :: in_dir, zgrid_file    ! strings for directory/file
   character(len=48)  :: flux_units, string
@@ -1123,11 +1085,7 @@ subroutine get_Z_depths(depth_file, int_depth_name, int_depth, cell_depth_name, 
   integer,            intent(out) :: edge_index  !< The interface z-axis diagnostic index handle
   integer,            intent(out) :: nk_out      !< The number of layers in the output grid
 
-!   This subroutine reads the depths of the interfaces bounding the intended
-! layers from a NetCDF file.  If no appropriate file is found, -1 is returned
-! as the number of layers in the output file.  Also, a diag_manager axis is set
-! up with the same information as this axis.
-
+  ! Local variables
   real, allocatable   :: cell_depth(:)
   character (len=200) :: units, long_name
   integer :: ncid, status, intid, intvid, layid, layvid, k, ni
@@ -1234,6 +1192,7 @@ subroutine get_Z_depths(depth_file, int_depth_name, int_depth, cell_depth_name, 
 
 end subroutine get_Z_depths
 
+!> Deallocate memory associated with the MOM_diag_to_Z module
 subroutine MOM_diag_to_Z_end(CS)
   type(diag_to_Z_CS), pointer :: CS !< Control structure returned by a previous call to diag_to_Z_init.
   integer :: m
@@ -1249,23 +1208,16 @@ end subroutine MOM_diag_to_Z_end
 
 !> This subroutine registers a tracer to be output in depth space.
 function ocean_register_diag_with_z(tr_ptr, vardesc_tr, G, Time, CS)
-  type(ocean_grid_type),             intent(in) :: G      !< The ocean's grid structure.
+  type(ocean_grid_type), intent(in) :: G      !< The ocean's grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                             target, intent(in) :: tr_ptr !< Tracer for translation to Z-space.
-  type(vardesc),                     intent(in) :: vardesc_tr !< Variable descriptor.
-  type(time_type),                   intent(in) :: Time   !< Current model time.
-  type(diag_to_Z_CS),                pointer    :: CS     !< Control struct returned by a previous
-                                                          !! call to diag_to_Z_init.
-  integer                                       :: ocean_register_diag_with_z
+                 target, intent(in) :: tr_ptr !< Tracer for translation to Z-space.
+  type(vardesc),         intent(in) :: vardesc_tr !< Variable descriptor.
+  type(time_type),       intent(in) :: Time   !< Current model time.
+  type(diag_to_Z_CS),    pointer    :: CS     !< Control struct returned by a previous
+                                              !! call to diag_to_Z_init.
+  integer                           :: ocean_register_diag_with_z !< The retuned Z-space diagnostic ID
 
-!   This subroutine registers a tracer to be output in depth space.
-! Arguments:
-!  (in)      tr_ptr     - tracer for translation to Z-space
-!  (in)      vardesc_tr - variable descriptor
-!  (in)      Time       - current model time
-!  (in)      G          - ocean grid structure
-!  (in)      CS         - control struct returned by a previous call to diag_to_Z_init
-
+  ! Local variables
   type(vardesc) :: vardesc_z
   character(len=64) :: var_name         ! A variable's name.
   integer :: isd, ied, jsd, jed, nk, m, id_test
@@ -1313,6 +1265,7 @@ function ocean_register_diag_with_z(tr_ptr, vardesc_tr, G, Time, CS)
 
 end function ocean_register_diag_with_z
 
+!> Register a diagnostic to be output in depth space.
 function register_Z_diag(var_desc, CS, day, missing)
   integer                        :: register_Z_diag !< The returned z-layer diagnostic index
   type(vardesc),      intent(in) :: var_desc !< A type with metadata for this diagnostic
@@ -1321,6 +1274,7 @@ function register_Z_diag(var_desc, CS, day, missing)
   type(time_type),    intent(in) :: day  !< The current model time
   real,               intent(in) :: missing !< The missing value for this diagnostic
 
+  ! Local variables
   character(len=64) :: var_name         ! A variable's name.
   character(len=48) :: units            ! A variable's units.
   character(len=240) :: longname        ! A variable's longname.
@@ -1367,6 +1321,7 @@ function register_Z_diag(var_desc, CS, day, missing)
 
 end function register_Z_diag
 
+!> Register a diagnostic to be output at depth space interfaces
 function register_Zint_diag(var_desc, CS, day)
   integer                        :: register_Zint_diag !< The returned z-interface diagnostic index
   type(vardesc),      intent(in) :: var_desc !< A type with metadata for this diagnostic
@@ -1374,6 +1329,7 @@ function register_Zint_diag(var_desc, CS, day)
                                          !! previous call to diag_to_Z_init.
   type(time_type),    intent(in) :: day  !< The current model time
 
+  ! Local variables
   character(len=64) :: var_name         ! A variable's name.
   character(len=48) :: units            ! A variable's units.
   character(len=240) :: longname        ! A variable's longname.

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -60,6 +60,7 @@ public register_surface_diags, post_surface_dyn_diags, post_surface_thermo_diags
 public register_transport_diags, post_transport_diagnostics
 public MOM_diagnostics_init, MOM_diagnostics_end
 
+!> The control structure for the MOM_diagnostics module
 type, public :: diagnostics_CS ; private
   real :: mono_N2_column_fraction = 0. !< The lower fraction of water column over which N2 is limited as
                                        !! monotonic for the purposes of calculating the equivalent
@@ -67,55 +68,58 @@ type, public :: diagnostics_CS ; private
   real :: mono_N2_depth = -1.          !< The depth below which N2 is limited as monotonic for the purposes of
                                        !! calculating the equivalent barotropic wave speed. (m)
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                       !! regulate the timing of diagnostic output.
 
   ! following arrays store diagnostics calculated here and unavailable outside.
 
   ! following fields have nz+1 levels.
   real, pointer, dimension(:,:,:) :: &
-    e => NULL(), &   ! interface height (metre)
-    e_D => NULL()    ! interface height above bottom (metre)
+    e => NULL(), &   !< interface height (metre)
+    e_D => NULL()    !< interface height above bottom (metre)
 
   ! following fields have nz layers.
   real, pointer, dimension(:,:,:) :: &
-    du_dt => NULL(), &    ! net i-acceleration in m/s2
-    dv_dt => NULL(), &    ! net j-acceleration in m/s2
-    dh_dt => NULL(), &    ! thickness rate of change in (m/s) or kg/(m2*s)
+    du_dt => NULL(), & !< net i-acceleration in m/s2
+    dv_dt => NULL(), & !< net j-acceleration in m/s2
+    dh_dt => NULL(), & !< thickness rate of change in (m/s) or kg/(m2*s)
+    p_ebt => NULL()    !< Equivalent barotropic modal structure
 
-    h_Rlay => NULL(),    & ! layer thicknesses in layered potential density
-                           ! coordinates, in m (Bouss) or kg/m2 (non-Bouss)
-    uh_Rlay   => NULL(), & ! zonal and meridional transports in layered
-    vh_Rlay   => NULL(), & ! potential rho coordinates: m3/s(Bouss) kg/s(non-Bouss)
-    uhGM_Rlay => NULL(), & ! zonal and meridional Gent-McWilliams transports in layered
-    vhGM_Rlay => NULL(), & ! potential density coordinates, m3/s (Bouss) kg/s(non-Bouss)
-    p_ebt     => NULL()    ! Equivalent barotropic modal structure
+  real, pointer, dimension(:,:,:) :: h_Rlay => NULL() !< Layer thicknesses in potential density
+                                              !! coordinates, in m (Bouss) or kg/m2 (non-Bouss)
+  real, pointer, dimension(:,:,:) :: uh_Rlay => NULL() !< Zonal transports in potential density
+                                              !! coordinates in m3/s (Bouss) or kg/s (non-Bouss)
+  real, pointer, dimension(:,:,:) :: vh_Rlay => NULL() !< Meridional transports in potential density
+                                              !! coordinates in m3/s (Bouss) or kg/s (non-Bouss)
+  real, pointer, dimension(:,:,:) :: uhGM_Rlay => NULL() !< Zonal Gent-McWilliams transports in potential density
+                                              !! coordinates, in m3/s (Bouss) or kg/s (non-Bouss)
+  real, pointer, dimension(:,:,:) :: vhGM_Rlay => NULL() !< Meridional Gent-McWilliams transports in potential density
+                                              !! coordinates, in m3/s (Bouss) or kg/s (non-Bouss)
 
   ! following fields are 2-D.
   real, pointer, dimension(:,:) :: &
-    cg1 => NULL(),       & ! first baroclinic gravity wave speed, in m s-1
-    Rd1 => NULL(),       & ! first baroclinic deformation radius, in m
-    cfl_cg1 => NULL(),   & ! CFL for first baroclinic gravity wave speed, nondim
-    cfl_cg1_x => NULL(), & ! i-component of CFL for first baroclinic gravity wave speed, nondim
-    cfl_cg1_y => NULL()    ! j-component of CFL for first baroclinic gravity wave speed, nondim
+    cg1 => NULL(),       & !< First baroclinic gravity wave speed, in m s-1
+    Rd1 => NULL(),       & !< First baroclinic deformation radius, in m
+    cfl_cg1 => NULL(),   & !< CFL for first baroclinic gravity wave speed, nondim
+    cfl_cg1_x => NULL(), & !< i-component of CFL for first baroclinic gravity wave speed, nondim
+    cfl_cg1_y => NULL()    !< j-component of CFL for first baroclinic gravity wave speed, nondim
 
   ! arrays to hold diagnostics in the layer-integrated energy budget.
   ! all except KE have units of m3 s-3 (when Boussinesq).
   real, pointer, dimension(:,:,:) :: &
-    KE        => NULL(), &  ! KE per unit mass, in m2 s-2
-    dKE_dt    => NULL(), &  ! time derivative of the layer KE
-    PE_to_KE  => NULL(), &  ! potential energy to KE term
-    KE_CorAdv => NULL(), &  ! KE source from the combined Coriolis and
-                            ! advection terms.  The Coriolis source should be
-                            ! zero, but is not due to truncation errors.  There
-                            ! should be near-cancellation of the global integral
-                            ! of this spurious Coriolis source.
-    KE_adv     => NULL(),&  ! KE source from along-layer advection
-    KE_visc    => NULL(),&  ! KE source from vertical viscosity
-    KE_horvisc => NULL(),&  ! KE source from horizontal viscosity
-    KE_dia     => NULL()    ! KE source from diapycnal diffusion
+    KE        => NULL(), &  !< KE per unit mass, in m2 s-2
+    dKE_dt    => NULL(), &  !< time derivative of the layer KE
+    PE_to_KE  => NULL(), &  !< potential energy to KE term
+    KE_CorAdv => NULL(), &  !< KE source from the combined Coriolis and advection terms.
+                            !! The Coriolis source should be zero, but is not due to truncation
+                            !! errors.  There should be near-cancellation of the global integral
+                            !! of this spurious Coriolis source.
+    KE_adv     => NULL(),&  !< KE source from along-layer advection
+    KE_visc    => NULL(),&  !< KE source from vertical viscosity
+    KE_horvisc => NULL(),&  !< KE source from horizontal viscosity
+    KE_dia     => NULL()    !< KE source from diapycnal diffusion
 
-  ! diagnostic IDs
+  !>@{ Diagnostic IDs
   integer :: id_u = -1,   id_v = -1, id_h = -1
   integer :: id_e              = -1, id_e_D            = -1
   integer :: id_du_dt          = -1, id_dv_dt          = -1
@@ -144,25 +148,28 @@ type, public :: diagnostics_CS ; private
   integer :: id_pbo            = -1
   integer :: id_thkcello       = -1, id_rhoinsitu      = -1
   integer :: id_rhopot0        = -1, id_rhopot2        = -1
-  integer :: id_h_pre_sync     = -1
+  integer :: id_h_pre_sync     = -1   !!@}
+  !> The control structure for calculating wave speed.
   type(wave_speed_CS), pointer :: wave_speed_CSp => NULL()
 
-  ! pointers used in calculation of time derivatives
-  type(p3d) :: var_ptr(MAX_FIELDS_)
-  type(p3d) :: deriv(MAX_FIELDS_)
-  type(p3d) :: prev_val(MAX_FIELDS_)
-  integer   :: nlay(MAX_FIELDS_)
-  integer   :: num_time_deriv = 0
+  type(p3d) :: var_ptr(MAX_FIELDS_)  !< pointers to variables used in the calculation
+                                     !! of time derivatives
+  type(p3d) :: deriv(MAX_FIELDS_)    !< Time derivatives of various fields
+  type(p3d) :: prev_val(MAX_FIELDS_) !< Previous values of variables used in the calculation
+                                     !! of time derivatives
+  !< previous values of variables used in calculation of time derivatives
+  integer   :: nlay(MAX_FIELDS_) !< The number of layers in each diagnostics
+  integer   :: num_time_deriv = 0 !< The number of time derivative diagnostics
 
-  ! for group halo pass
-  type(group_pass_type) :: pass_KE_uv
+  type(group_pass_type) :: pass_KE_uv !< A handle used for group halo passes
 
 end type diagnostics_CS
 
 
 !> A structure with diagnostic IDs of the surface and integrated variables
 type, public :: surface_diag_IDs ; private
-  ! 2-d surface and bottom fields
+  !>@{ Diagnostic IDs for 2-d surface and bottom flux and state fields
+  !Diagnostic IDs for 2-d surface and bottom fields
   integer :: id_zos  = -1, id_zossq  = -1
   integer :: id_volo = -1, id_speed  = -1
   integer :: id_ssh  = -1, id_ssh_ga = -1
@@ -170,21 +177,21 @@ type, public :: surface_diag_IDs ; private
   integer :: id_sss  = -1, id_sss_sq = -1, id_sssabs = -1
   integer :: id_ssu  = -1, id_ssv    = -1
 
-  ! heat and salt flux fields
+  ! Diagnostic IDs for  heat and salt flux fields
   integer :: id_fraz         = -1
   integer :: id_salt_deficit = -1
   integer :: id_Heat_PmE     = -1
   integer :: id_intern_heat  = -1
+  !!@}
 end type surface_diag_IDs
 
 
 !> A structure with diagnostic IDs of mass transport related diagnostics
 type, public :: transport_diag_IDs ; private
-  ! Diagnostics for tracer horizontal transport
+  !>@{  Diagnostics for tracer horizontal transport
   integer :: id_uhtr = -1, id_umo = -1, id_umo_2d = -1
   integer :: id_vhtr = -1, id_vmo = -1, id_vmo_2d = -1
-  integer :: id_dynamics_h = -1, id_dynamics_h_tendency = -1
-
+  integer :: id_dynamics_h = -1, id_dynamics_h_tendency = -1   !!@}
 end type transport_diag_IDs
 
 
@@ -201,11 +208,11 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
                            intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2).
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
-                           intent(in)    :: uh   !< Transport through zonal faces = u*h*dy,
-                                                 !! in H m2 s-1, i.e. m3/s(Bouss) or kg/s(non-Bouss).
+                           intent(in)    :: uh   !< Transport through zonal faces = u*h*dy, in H m2 s-1.
+                                                 !! I.e. units are m3/s(Bouss) or kg/s(non-Bouss).
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                           intent(in)    :: vh   !< Transport through meridional faces = v*h*dx,
-                                                 !! in H m2 s-1, i.e. m3/s(Bouss) or kg/s(non-Bouss).
+                           intent(in)    :: vh   !< Transport through meridional faces = v*h*dx, in H m2 s-1.
+                                                 !! I.e. units are m3/s(Bouss) or kg/s(non-Bouss).
   type(thermo_var_ptrs),   intent(in)    :: tv   !< A structure pointing to various
                                                  !! thermodynamic variables.
   type(accel_diag_ptrs),   intent(in)    :: ADp  !< structure with pointers to
@@ -878,42 +885,28 @@ end subroutine calculate_vertical_integrals
 
 !> This subroutine calculates terms in the mechanical energy budget.
 subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, CS)
-  type(ocean_grid_type),                     intent(inout) :: G    !< The ocean's grid structure.
-  type(verticalGrid_type),                   intent(in)    :: GV   !< The ocean's vertical grid
-                                                                   !! structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: u    !< The zonal velocity, in m s-1.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: v    !< The meridional velocity,
-                                                                   !! in m s-1.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h    !< Layer thicknesses, in H
-                                                                   !! (usually m or kg m-2).
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: uh   !< Transport through zonal
-                                                                   !! faces=u*h*dy: m3/s (Bouss)
-                                                                   !! kg/s(non-Bouss).
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: vh   !< Transport through merid
-                                                                   !! faces=v*h*dx: m3/s (Bouss)
-                                                                   !! kg/s(non-Bouss).
-  type(accel_diag_ptrs),                     intent(in)    :: ADp  !< Structure pointing to
-                                                                   !! accelerations in momentum
-                                                                   !! equation.
-  type(cont_diag_ptrs),                      intent(in)    :: CDp  !< Structure pointing to terms
-                                                                   !! in continuity equations.
-  type(diagnostics_CS),                      intent(inout) :: CS   !< Control structure returned by
-                                                                   !! a previous call to
-                                                                   !! diagnostics_init.
+  type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: u    !< The zonal velocity, in m s-1.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                           intent(in)    :: v    !< The meridional velocity, in m s-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2).
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
+                           intent(in)    :: uh   !< Transport through zonal faces=u*h*dy, in H m2 s-1.
+                                                 !! I.e. units are m3/s (Bouss) or kg/s(non-Bouss).
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
+                           intent(in)    :: vh   !< Transport through merid faces=v*h*dx, in H m2 s-1.
+                                                 !! I.e. units are m3/s (Bouss) or kg/s(non-Bouss).
+  type(accel_diag_ptrs),   intent(in)    :: ADp  !< Structure pointing to accelerations in momentum equation.
+  type(cont_diag_ptrs),    intent(in)    :: CDp  !< Structure pointing to terms in continuity equations.
+  type(diagnostics_CS),    intent(inout) :: CS   !< Control structure returned by a previous call to
+                                                 !! diagnostics_init.
 
 ! This subroutine calculates terms in the mechanical energy budget.
 
-! Arguments:
-!  (in)      u   - zonal velocity component (m/s)
-!  (in)      v   - meridional velocity componnent (m/s)
-!  (in)      h   - layer thickness: metre(Bouss) of kg/m2(non-Bouss)
-!  (in)      uh  - transport through zonal faces=u*h*dy: m3/s (Bouss) kg/s(non-Bouss)
-!  (in)      vh  - transport through merid faces=v*h*dx: m3/s (Bouss) kg/s(non-Bouss)
-!  (in)      ADp - structure pointing to accelerations in momentum equation
-!  (in)      CDp - structure pointing to terms in continuity equations
-!  (in)      G   - ocean grid structure
-!  (in)      CS  - control structure returned by a previous call to diagnostics_init
-
+  ! Local variables
   real :: KE_u(SZIB_(G),SZJ_(G))
   real :: KE_v(SZI_(G),SZJB_(G))
   real :: KE_h(SZI_(G),SZJ_(G))
@@ -1092,16 +1085,11 @@ end subroutine calculate_energy_diagnostics
 subroutine register_time_deriv(f_ptr, deriv_ptr, CS)
   real, dimension(:,:,:), target :: f_ptr     !< Field whose derivative is taken.
   real, dimension(:,:,:), target :: deriv_ptr !< Field in which the calculated time derivatives
-                                              !! placed.
+                                              !! will be placed.
   type(diagnostics_CS),  pointer :: CS        !< Control structure returned by previous call to
                                               !! diagnostics_init.
 
-! This subroutine registers fields to calculate a diagnostic time derivative.
-! Arguments:
-!  (target)  f_ptr     - field whose derivative is taken
-!  (in)      deriv_ptr - field in which the calculated time derivatives placed
-!  (in)      num_lay   - number of layers in this field
-!  (in)      CS        - control structure returned by previous call to diagnostics_init
+  ! This subroutine registers fields to calculate a diagnostic time derivative.
 
   integer :: m
 
@@ -1127,18 +1115,12 @@ end subroutine register_time_deriv
 
 !> This subroutine calculates all registered time derivatives.
 subroutine calculate_derivs(dt, G, CS)
-  real,                  intent(in)    :: dt   !< The time interval over which differences occur,
-                                               !! in s.
+  real,                  intent(in)    :: dt   !< The time interval over which differences occur, in s.
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure.
   type(diagnostics_CS),  intent(inout) :: CS   !< Control structure returned by previous call to
                                                !! diagnostics_init.
 
 ! This subroutine calculates all registered time derivatives.
-! Arguments:
-!  (in)      dt - time interval in s over which differences occur
-!  (in)      G  - ocean grid structure.
-!  (in)      CS - control structure returned by previous call to diagnostics_init
-
   integer i, j, k, m
   real Idt
 
@@ -1160,12 +1142,12 @@ end subroutine calculate_derivs
 subroutine post_surface_dyn_diags(IDs, G, diag, sfc_state, ssh)
   type(surface_diag_IDs),   intent(in) :: IDs !< A structure with the diagnostic IDs.
   type(ocean_grid_type),    intent(in) :: G   !< ocean grid structure
-  type(diag_ctrl),          intent(in) :: diag  !< regulates diagnostic output
+  type(diag_ctrl),          intent(in) :: diag !< regulates diagnostic output
   type(surface),            intent(in) :: sfc_state !< structure describing the ocean surface state
   real, dimension(SZI_(G),SZJ_(G)), &
-                            intent(in) :: ssh !< Time mean surface height without corrections for
-                                              !! ice displacement (m)
+                            intent(in) :: ssh !< Time mean surface height without corrections for ice displacement (m)
 
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: work_2d  ! A 2-d work array
   integer :: i, j, is, ie, js, je
 
@@ -1203,11 +1185,9 @@ subroutine post_surface_thermo_diags(IDs, G, GV, diag, dt_int, sfc_state, tv, &
   type(surface),            intent(in) :: sfc_state !< structure describing the ocean surface state
   type(thermo_var_ptrs),    intent(in) :: tv  !< A structure pointing to various thermodynamic variables
   real, dimension(SZI_(G),SZJ_(G)), &
-                            intent(in) :: ssh !< Time mean surface height without corrections for
-                                              !! ice displacement (m)
-  real, dimension(SZI_(G),SZJ_(G)), &
-                            intent(in) :: ssh_ibc !< Time mean surface height with corrections for
-                                              !! ice displacement and the inverse barometer (m)
+                            intent(in) :: ssh !< Time mean surface height without corrections for ice displacement (m)
+  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: ssh_ibc !< Time mean surface height with corrections
+                                                  !! for ice displacement and the inverse barometer (m)
 
   real, dimension(SZI_(G),SZJ_(G)) :: work_2d  ! A 2-d work array
   real, dimension(SZI_(G),SZJ_(G)) :: &
@@ -1341,12 +1321,10 @@ subroutine post_transport_diagnostics(G, GV, uhtr, vhtr, h, IDs, diag_pre_dyn, d
                                       diag_to_Z_CSp, Reg)
   type(ocean_grid_type),    intent(inout) :: G   !< ocean grid structure
   type(verticalGrid_type),  intent(in)    :: GV  !< ocean vertical grid structure
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
-                            intent(in)    :: uhtr !< Accumulated zonal thickness fluxes used
-                                                  !! to advect tracers (m3 or kg)
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                            intent(in)    :: vhtr !< Accumulated meridional thickness fluxes
-                                                  !! used to advect tracers (m3 or kg)
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in) :: uhtr !< Accumulated zonal thickness fluxes
+                                                 !! used to advect tracers (m3 or kg)
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in) :: vhtr !< Accumulated meridional thickness fluxes
+                                                 !! used to advect tracers (m3 or kg)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                             intent(in)    :: h   !< The updated layer thicknesses, in H
   type(transport_diag_IDs), intent(in)    :: IDs !< A structure with the diagnostic IDs.
@@ -1858,6 +1836,7 @@ subroutine write_static_fields(G, GV, tv, diag)
   type(verticalGrid_type), intent(in)    :: GV   !< ocean vertical grid structure
   type(thermo_var_ptrs),   intent(in)    :: tv   !< A structure pointing to various thermodynamic variables
   type(diag_ctrl), target, intent(inout) :: diag !< regulates diagnostic output
+
   ! Local variables
   real    :: tmp_h(SZI_(G),SZJ_(G))
   integer :: id, i, j
@@ -2036,14 +2015,6 @@ subroutine set_dependent_diagnostics(MIS, ADp, CDp, G, CS)
                                                    !! module.
 
 ! This subroutine sets up diagnostics upon which other diagnostics depend.
-! Arguments:
-!  (in)      MIS - For "MOM Internal State" a set of pointers to the fields and
-!                  accelerations making up ocean internal physical state.
-!  (inout)   ADp - structure pointing to accelerations in momentum equation
-!  (inout)   CDp - structure pointing to terms in continuity equation
-!  (in)      G   - ocean grid structure
-!  (in)      CS -  pointer to the control structure for this module
-
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nz = G%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -70,51 +70,50 @@ public write_energy, accumulate_net_input, MOM_sum_output_init
 
 integer, parameter :: NUM_FIELDS = 17
 
+!> A list of depths and corresponding globally integrated ocean area at each
+!! depth and the ocean volume below each depth.
 type :: Depth_List
-  real :: depth       ! A depth, in m.
-  real :: area        ! The cross-sectional area of the ocean at that depth, in m2.
-  real :: vol_below   ! The ocean volume below that depth, in m3.
+  real :: depth       !< A depth, in m.
+  real :: area        !< The cross-sectional area of the ocean at that depth, in m2.
+  real :: vol_below   !< The ocean volume below that depth, in m3.
 end type Depth_List
 
+!> The control structure for the MOM_sum_output module
 type, public :: sum_output_CS ; private
-  type(Depth_List), pointer, dimension(:) :: DL => NULL() ! The sorted depth list.
-  integer :: list_size          ! =niglobal*njglobal length of sorting vector
+  type(Depth_List), pointer, dimension(:) :: DL => NULL() !< The sorted depth list.
+  integer :: list_size          !< length of sorting vector <= niglobal*njglobal
 
   integer ALLOCABLE_, dimension(NKMEM_) :: lH
-                                ! This saves the entry in DL with a volume just
-                                ! less than the volume of fluid below the
-                                ! interface.
-  logical :: do_APE_calc        !   If true, calculate the available potential
-                                ! energy of the interfaces.  Disabling this
-                                ! reduces the memory footprint of high-PE-count
-                                ! models dramatically.
-  logical :: read_depth_list    !   Read the depth list from a file if it exists
-                                ! and write it if it doesn't.
-  character(len=200) :: depth_list_file  ! The name of the depth list file.
-  real    :: D_list_min_inc     !   The minimum increment, in m, between the
-                                ! depths of the entries in the depth-list file,
-                                ! 0 by default.
-  logical :: use_temperature    !   If true, temperature and salinity are state
-                                ! variables.
-  real    :: fresh_water_input  !   The total mass of fresh water added by
-                                ! surface fluxes since the last time that
-  real    :: mass_prev          !   The total ocean mass the last time that
-                                ! write_energy was called, in kg.
-  real    :: salt_prev          !   The total amount of salt in the ocean the last
-                                ! time that write_energy was called, in PSU kg.
-  real    :: net_salt_input     !   The total salt added by surface fluxes since
-                                ! the last time that write_energy was called,
-                                ! in PSU kg.
-  real    :: heat_prev          !   The total amount of heat in the ocean the last
-                                ! time that write_energy was called, in Joules.
-  real    :: net_heat_input     !   The total heat added by surface fluxes since
-                                ! the last time that write_energy was called,
-                                ! in Joules.
-  type(EFP_type) :: &
-    fresh_water_in_EFP, &       ! These are extended fixed point versions of the
-    net_salt_in_EFP, &          ! correspondingly named variables above.
-    net_heat_in_EFP, heat_prev_EFP, salt_prev_EFP, mass_prev_EFP
-  real    :: dt                 ! The baroclinic dynamics time step, in s.
+                                !< This saves the entry in DL with a volume just
+                                !! less than the volume of fluid below the interface.
+  logical :: do_APE_calc        !<   If true, calculate the available potential energy of the
+                                !! interfaces.  Disabling this reduces the memory footprint of
+                                !! high-PE-count models dramatically.
+  logical :: read_depth_list    !<   Read the depth list from a file if it exists
+                                !! and write it if it doesn't.
+  character(len=200) :: depth_list_file  !< The name of the depth list file.
+  real    :: D_list_min_inc     !<  The minimum increment, in m, between the depths of the
+                                !! entries in the depth-list file, 0 by default.
+  logical :: use_temperature    !<   If true, temperature and salinity are state variables.
+  real    :: fresh_water_input  !<   The total mass of fresh water added by surface fluxes
+                                !! since the last time that write_energy was called, in kg.
+  real    :: mass_prev          !<   The total ocean mass the last time that
+                                !! write_energy was called, in kg.
+  real    :: salt_prev          !<   The total amount of salt in the ocean the last
+                                !! time that write_energy was called, in PSU kg.
+  real    :: net_salt_input     !<   The total salt added by surface fluxes since the last
+                                !! time that write_energy was called, in PSU kg.
+  real    :: heat_prev          !<  The total amount of heat in the ocean the last
+                                !! time that write_energy was called, in Joules.
+  real    :: net_heat_input     !<  The total heat added by surface fluxes since the last
+                                !! the last time that write_energy was called, in Joules.
+  type(EFP_type) :: fresh_water_in_EFP !< An extended fixed point version of fresh_water_input
+  type(EFP_type) :: net_salt_in_EFP !< An extended fixed point version of net_salt_input
+  type(EFP_type) :: net_heat_in_EFP !< An extended fixed point version of net_heat_input
+  type(EFP_type) :: heat_prev_EFP !< An extended fixed point version of heat_prev
+  type(EFP_type) :: salt_prev_EFP !< An extended fixed point version of salt_prev
+  type(EFP_type) :: mass_prev_EFP !< An extended fixed point version of mass_prev
+  real    :: dt                 !< The baroclinic dynamics time step, in s.
 
   type(time_type) :: energysavedays            !< The interval between writing the energies
                                                !! and other integral quantities of the run.
@@ -129,27 +128,25 @@ type, public :: sum_output_CS ; private
                                                !! of calls to write_energy and revert to the standard
                                                !! energysavedays interval
 
-  real    :: timeunit           !   The length of the units for the time
-                                ! axis, in s.
-  logical :: date_stamped_output ! If true, use dates (not times) in messages to stdout.
-  type(time_type) :: Start_time ! The start time of the simulation.
+  real    :: timeunit           !<  The length of the units for the time axis, in s.
+  logical :: date_stamped_output !< If true, use dates (not times) in messages to stdout.
+  type(time_type) :: Start_time !< The start time of the simulation.
                                 ! Start_time is set in MOM_initialization.F90
-  integer, pointer :: ntrunc => NULL() ! The number of times the velocity has been
-                                ! truncated since the last call to write_energy.
-  real    :: max_Energy         ! The maximum permitted energy per unit mass
-                                ! If there is more energy than this, the model
-                                ! should stop, in m2 s-2.
-  integer :: maxtrunc           ! The number of truncations per energy save
-                                ! interval at which the run is stopped.
-  logical :: write_stocks       ! If true, write the integrated tracer amounts
-                                ! to stdout when the energy files are written.
-  integer :: previous_calls = 0 ! The number of times write_energy has been called.
-  integer :: prev_n = 0         ! The value of n from the last call.
-  integer :: fileenergy_nc      ! NetCDF id of the energy file.
-  integer :: fileenergy_ascii   ! The unit number of the ascii version of the energy file.
+  integer, pointer :: ntrunc => NULL() !< The number of times the velocity has been
+                                !! truncated since the last call to write_energy.
+  real    :: max_Energy         !< The maximum permitted energy per unit mass.  If there is
+                                !! more energy than this, the model should stop, in m2 s-2.
+  integer :: maxtrunc           !< The number of truncations per energy save
+                                !! interval at which the run is stopped.
+  logical :: write_stocks       !< If true, write the integrated tracer amounts
+                                !! to stdout when the energy files are written.
+  integer :: previous_calls = 0 !< The number of times write_energy has been called.
+  integer :: prev_n = 0         !< The value of n from the last call.
+  integer :: fileenergy_nc      !< NetCDF id of the energy file.
+  integer :: fileenergy_ascii   !< The unit number of the ascii version of the energy file.
   type(fieldtype), dimension(NUM_FIELDS+MAX_FIELDS_) :: &
-             fields             ! fieldtype variables for the output fields.
-  character(len=200) :: energyfile  ! The name of the energy file with path.
+             fields             !< fieldtype variables for the output fields.
+  character(len=200) :: energyfile  !< The name of the energy file with path.
 end type sum_output_CS
 
 contains
@@ -167,15 +164,7 @@ subroutine MOM_sum_output_init(G, param_file, directory, ntrnc, &
   type(time_type),        intent(in)    :: Input_start_time !< The start time of the simulation.
   type(Sum_output_CS),    pointer       :: CS         !< A pointer that is set to point to the
                                                       !! control structure for this module.
-! Arguments: G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      directory - The directory where the energy file goes.
-!  (in/out)  ntrnc - The integer that stores the number of times the velocity
-!                     has been truncated since the last call to write_energy.
-!  (in)      Input_start_time - The start time of the simulation.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
+  ! Local variables
   real :: Time_unit   ! The time unit in seconds for ENERGYSAVEDAYS.
   real :: Rho_0, maxvel
 ! This include declares and sets the variable "version".
@@ -336,6 +325,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
                     optional, pointer    :: OBC !< Open boundaries control structure.
   type(time_type),  optional, intent(in) :: dt_forcing !< The forcing time step
 
+  ! Local variables
   real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! The height of interfaces, in m.
   real :: areaTm(SZI_(G),SZJ_(G)) ! A masked version of areaT, in m2.
   real :: KE(SZK_(G))  ! The total kinetic energy of a layer, in J.
@@ -961,6 +951,7 @@ subroutine accumulate_net_input(fluxes, sfc_state, dt, G, CS)
   type(Sum_output_CS),   pointer    :: CS     !< The control structure returned by a previous call
                                               !! to MOM_sum_output_init.
 
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     FW_in, &   ! The net fresh water input, integrated over a timestep in kg.
     salt_in, & ! The total salt added by surface fluxes, integrated
@@ -1112,6 +1103,7 @@ subroutine create_depth_list(G, CS)
   type(Sum_output_CS),   pointer    :: CS !< The control structure set up in MOM_sum_output_init,
                                           !! in which the ordered depth list is stored.
 
+  ! Local variables
   real, dimension(G%Domain%niglobal*G%Domain%njglobal + 1) :: &
     Dlist, &  !< The global list of bottom depths, in m.
     AreaList  !< The global list of cell areas, in m2.
@@ -1239,8 +1231,7 @@ subroutine write_depth_list(G, CS, filename, list_size)
   character(len=*),      intent(in) :: filename !< The path to the depth list file to write.
   integer,               intent(in) :: list_size !< The size of the depth list.
 
-! This subroutine writes out the depth list to the specified file.
-
+  ! Local variables
   real, allocatable :: tmp(:)
   integer :: ncid, dimid(1), Did, Aid, Vid, status, k
 
@@ -1321,8 +1312,7 @@ subroutine read_depth_list(G, CS, filename)
                                            !! previous call to MOM_sum_output_init.
   character(len=*),      intent(in) :: filename !< The path to the depth list file to read.
 
-! This subroutine reads in the depth list to the specified file
-! and allocates and sets up CS%DL and CS%list_size .
+  ! Local variables
   character(len=32) :: mdl
   character(len=240) :: var_name, var_msg
   real, allocatable :: tmp(:)

--- a/src/diagnostics/MOM_wave_structure.F90
+++ b/src/diagnostics/MOM_wave_structure.F90
@@ -43,30 +43,31 @@ implicit none ; private
 
 public wave_structure, wave_structure_init
 
+!> The control structure for the MOM_wave_structure module
 type, public :: wave_structure_CS ; !private
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
   real, allocatable, dimension(:,:,:) :: w_strct
-                                   ! Vertical structure of vertical velocity (normalized), in m s-1.
+                                   !< Vertical structure of vertical velocity (normalized), in m s-1.
   real, allocatable, dimension(:,:,:) :: u_strct
-                                   ! Vertical structure of horizontal velocity (normalized), in m s-1.
+                                   !< Vertical structure of horizontal velocity (normalized), in m s-1.
   real, allocatable, dimension(:,:,:) :: W_profile
-                                   ! Vertical profile of w_hat(z), where
-                                   ! w(x,y,z,t) = w_hat(z)*exp(i(kx+ly-freq*t)) is the full time-
-                                   ! varying vertical velocity with w_hat(z) = W0*w_strct(z), in m s-1.
+                                   !< Vertical profile of w_hat(z), where
+                                   !! w(x,y,z,t) = w_hat(z)*exp(i(kx+ly-freq*t)) is the full time-
+                                   !! varying vertical velocity with w_hat(z) = W0*w_strct(z), in m s-1.
   real, allocatable, dimension(:,:,:) :: Uavg_profile
-                                   ! Vertical profile of the magnitude of horizontal velocity,
-                                   ! (u^2+v^2)^0.5, averaged over a period, in m s-1.
+                                   !< Vertical profile of the magnitude of horizontal velocity,
+                                   !! (u^2+v^2)^0.5, averaged over a period, in m s-1.
   real, allocatable, dimension(:,:,:) :: z_depths
-                                   ! Depths of layer interfaces, in m.
+                                   !< Depths of layer interfaces, in m.
   real, allocatable, dimension(:,:,:) :: N2
-                                   ! Squared buoyancy frequency at each interface
+                                   !< Squared buoyancy frequency at each interface
   integer, allocatable, dimension(:,:):: num_intfaces
-                                   ! Number of layer interfaces (including surface and bottom)
-  real    :: int_tide_source_x     ! X Location of generation site
-                                   ! for internal tide for testing (BDM)
-  real    :: int_tide_source_y     ! Y Location of generation site
-                                   ! for internal tide for testing (BDM)
+                                   !< Number of layer interfaces (including surface and bottom)
+  real    :: int_tide_source_x     !< X Location of generation site
+                                   !! for internal tide for testing (BDM)
+  real    :: int_tide_source_y     !< Y Location of generation site
+                                   !! for internal tide for testing (BDM)
 
 end type wave_structure_CS
 
@@ -97,18 +98,6 @@ subroutine wave_structure(h, tv, G, GV, cn, ModeNum, freq, CS, En, full_halos)
                                                                 !! domain.
 
 !    This subroutine determines the internal wave velocity structure for any mode.
-! Arguments: h - Layer thickness, in m or kg m-2.
-!  (in)      tv - A structure containing the thermobaric variables.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      cn - The (non-rotational) mode internal gravity wave speed, in m s-1.
-!  (in)      ModeNum - mode number
-!  (in)      freq - intrinsic wave frequency, in s-1
-!  (in)      CS - The control structure returned by a previous call to
-!                 wave_structure_init.
-!  (in,opt)  En - Internal wave energy density, in Jm-2
-!  (in,opt)  full_halos - If true, do the calculation over the entire
-!                         computational domain.
 !
 ! This subroutine solves for the eigen vector [vertical structure, e(k)] associated with
 ! the first baroclinic mode speed [i.e., smallest eigen value (lam = 1/c^2)] of the
@@ -135,6 +124,7 @@ subroutine wave_structure(h, tv, G, GV, cn, ModeNum, freq, CS, En, full_halos)
 !     Solve (A-lam*I)e = e_guess for e
 !     Set e_guess=e/|e| and repeat, with each iteration refining the estimate of e
 
+  ! Local variables
   real, dimension(SZK_(G)+1) :: &
     dRho_dT, dRho_dS, &
     pres, T_int, S_int, &
@@ -596,7 +586,7 @@ subroutine wave_structure(h, tv, G, GV, cn, ModeNum, freq, CS, En, full_halos)
 end subroutine wave_structure
 
 !>    This subroutine solves a tri-diagonal system Ax=y using either the standard
-!! Thomas algorithim (TDMA_T) or its more stable variant that invokes the
+!! Thomas algorithm (TDMA_T) or its more stable variant that invokes the
 !! "Hallberg substitution" (TDMA_H).
 subroutine tridiag_solver(a, b, c, h, y, method, x)
   real, dimension(:), intent(in)  :: a !< lower diagonal with first entry equal to zero.
@@ -613,24 +603,7 @@ subroutine tridiag_solver(a, b, c, h, y, method, x)
   character(len=*),   intent(in)  :: method !< A string describing the algorithm to use
   real, dimension(:), intent(out) :: x !< vector of unknown values to solve for.
 
-!    This subroutine solves a tri-diagonal system Ax=y using either the standard
-! Thomas algorithim (TDMA_T) or its more stable variant that invokes the
-! "Hallberg substitution" (TDMA_H).
-!
-! Arguments:
-!  (in)      a - lower diagonal with first entry equal to zero
-!  (in)      b - middle diagonal
-!  (in)      c - upper diagonal with last entry equal to zero
-!  (in)      h - vector of values that have already been added to b; used for
-!                systems of the form (e.g. average layer thickness in vertical diffusion case):
-!                [ -alpha(k-1/2) ]                       * e(k-1) +
-!                [  alpha(k-1/2) + alpha(k+1/2) + h(k) ] * e(k)   +
-!                [ -alpha(k+1/2) ]                       * e(k+1) = y(k)
-!                where a(k)=[-alpha(k-1/2)], b(k)=[alpha(k-1/2)+alpha(k+1/2) + h(k)],
-!                and c(k)=[-alpha(k+1/2)]. Only used with TDMA_H method.
-!  (in)      y - vector of known values on right hand side
-!  (out)     x - vector of unknown values to solve for
-
+  ! Local variables
   integer :: nrow                         ! number of rows in A matrix
   real, allocatable, dimension(:,:) :: A_check ! for solution checking
   real, allocatable, dimension(:)   :: y_check ! for solution checking
@@ -738,23 +711,17 @@ subroutine tridiag_solver(a, b, c, h, y, method, x)
 
 end subroutine tridiag_solver
 
-
+!> Allocate memory associated with the wave structure module and read parameters.
 subroutine wave_structure_init(Time, G, param_file, diag, CS)
-  type(time_type),             intent(in)    :: Time !< The current model time.
-  type(ocean_grid_type),       intent(in)    :: G    !< The ocean's grid structure.
-  type(param_file_type),       intent(in)    :: param_file !< A structure to parse for run-time
-                                                     !! parameters.
-  type(diag_ctrl), target,     intent(in)    :: diag !< A structure that is used to regulate
-                                                     !! diagnostic output.
-  type(wave_structure_CS),     pointer       :: CS   !< A pointer that is set to point to the
-                                                     !! control structure for this module.
-! Arguments: Time - The current model time.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                  for this module
+  type(time_type),         intent(in) :: Time !< The current model time.
+  type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
+  type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time
+                                              !! parameters.
+  type(diag_ctrl), target, intent(in) :: diag !< A structure that is used to regulate
+                                              !! diagnostic output.
+  type(wave_structure_CS), pointer    :: CS   !< A pointer that is set to point to the
+                                              !! control structure for this module.
+
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_wave_structure"  ! This module's name.

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -116,7 +116,7 @@ integer, parameter :: TFREEZE_LINEAR = 1  !< A named integer specifying a freezi
 integer, parameter :: TFREEZE_MILLERO = 2 !< A named integer specifying a freezing point expression
 integer, parameter :: TFREEZE_TEOS10 = 3  !< A named integer specifying a freezing point expression
 character*(10), parameter :: TFREEZE_LINEAR_STRING = "LINEAR" !< A string for specifying the freezing point expression
-character*(10), parameter :: TFREEZE_MILLERO_STRING = "MILLERO_78" !< A string for specifying 
+character*(10), parameter :: TFREEZE_MILLERO_STRING = "MILLERO_78" !< A string for specifying
                                                               !! freezing point expression
 character*(10), parameter :: TFREEZE_TEOS10_STRING = "TEOS10" !< A string for specifying the freezing point expression
 character*(10), parameter :: TFREEZE_DEFAULT = TFREEZE_LINEAR_STRING !< The default freezing point expression

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -61,10 +61,13 @@ interface calculate_spec_vol
   module procedure calculate_spec_vol_scalar, calculate_spec_vol_array
 end interface calculate_spec_vol
 
+!> Calculate the derivatives of density with temperature and salinity from T, S, and P
 interface calculate_density_derivs
   module procedure calculate_density_derivs_scalar, calculate_density_derivs_array
 end interface calculate_density_derivs
 
+!> Calculates the second derivatives of density with various combinations of temperature,
+!! salinity, and pressure from T, S and P
 interface calculate_density_second_derivs
   module procedure calculate_density_second_derivs_scalar, calculate_density_second_derivs_array
 end interface calculate_density_second_derivs
@@ -92,30 +95,31 @@ type, public :: EOS_type ; private
   real :: dTFr_dS   !< The derivative of freezing point with salinity, in deg C PSU-1.
   real :: dTFr_dp   !< The derivative of freezing point with pressure, in deg C Pa-1.
 
-  logical :: test_EOS = .true.
+!  logical :: test_EOS = .true. ! If true, test the equation of state
 end type EOS_type
 
 ! The named integers that might be stored in eqn_of_state_type%form_of_EOS.
-integer, parameter, public :: EOS_LINEAR = 1
-integer, parameter, public :: EOS_UNESCO = 2
-integer, parameter, public :: EOS_WRIGHT = 3
-integer, parameter, public :: EOS_TEOS10 = 4
-integer, parameter, public :: EOS_NEMO   = 5
+integer, parameter, public :: EOS_LINEAR = 1 !< A named integer specifying an equation of state
+integer, parameter, public :: EOS_UNESCO = 2 !< A named integer specifying an equation of state
+integer, parameter, public :: EOS_WRIGHT = 3 !< A named integer specifying an equation of state
+integer, parameter, public :: EOS_TEOS10 = 4 !< A named integer specifying an equation of state
+integer, parameter, public :: EOS_NEMO   = 5 !< A named integer specifying an equation of state
 
-character*(10), parameter :: EOS_LINEAR_STRING = "LINEAR"
-character*(10), parameter :: EOS_UNESCO_STRING = "UNESCO"
-character*(10), parameter :: EOS_WRIGHT_STRING = "WRIGHT"
-character*(10), parameter :: EOS_TEOS10_STRING = "TEOS10"
-character*(10), parameter :: EOS_NEMO_STRING   = "NEMO"
-character*(10), parameter :: EOS_DEFAULT = EOS_WRIGHT_STRING
+character*(10), parameter :: EOS_LINEAR_STRING = "LINEAR" !< A string for specifying the equation of state
+character*(10), parameter :: EOS_UNESCO_STRING = "UNESCO" !< A string for specifying the equation of state
+character*(10), parameter :: EOS_WRIGHT_STRING = "WRIGHT" !< A string for specifying the equation of state
+character*(10), parameter :: EOS_TEOS10_STRING = "TEOS10" !< A string for specifying the equation of state
+character*(10), parameter :: EOS_NEMO_STRING   = "NEMO"   !< A string for specifying the equation of state
+character*(10), parameter :: EOS_DEFAULT = EOS_WRIGHT_STRING !< The default equation of state
 
-integer, parameter :: TFREEZE_LINEAR = 1
-integer, parameter :: TFREEZE_MILLERO = 2
-integer, parameter :: TFREEZE_TEOS10 = 3
-character*(10), parameter :: TFREEZE_LINEAR_STRING = "LINEAR"
-character*(10), parameter :: TFREEZE_MILLERO_STRING = "MILLERO_78"
-character*(10), parameter :: TFREEZE_TEOS10_STRING = "TEOS10"
-character*(10), parameter :: TFREEZE_DEFAULT = TFREEZE_LINEAR_STRING
+integer, parameter :: TFREEZE_LINEAR = 1  !< A named integer specifying a freezing point expression
+integer, parameter :: TFREEZE_MILLERO = 2 !< A named integer specifying a freezing point expression
+integer, parameter :: TFREEZE_TEOS10 = 3  !< A named integer specifying a freezing point expression
+character*(10), parameter :: TFREEZE_LINEAR_STRING = "LINEAR" !< A string for specifying the freezing point expression
+character*(10), parameter :: TFREEZE_MILLERO_STRING = "MILLERO_78" !< A string for specifying 
+                                                              !! freezing point expression
+character*(10), parameter :: TFREEZE_TEOS10_STRING = "TEOS10" !< A string for specifying the freezing point expression
+character*(10), parameter :: TFREEZE_DEFAULT = TFREEZE_LINEAR_STRING !< The default freezing point expression
 
 contains
 

--- a/src/equation_of_state/MOM_EOS_NEMO.F90
+++ b/src/equation_of_state/MOM_EOS_NEMO.F90
@@ -9,7 +9,7 @@ module MOM_EOS_NEMO
 !*  Roquet, F., Madec, G., McDougall, T. J., and Barker, P. M., 2015.  *
 !*  Accurate polynomial expressions for the density and specific volume*
 !*  of seawater using the TEOS-10 standard. Ocean Modelling, 90:29-43. *
-!*  These algorithms are NOT from NEMO package!!                       *
+!*  These algorithms are NOT from the standard NEMO package!!          *
 !***********************************************************************
 
 !use gsw_mod_toolbox, only : gsw_sr_from_sp, gsw_ct_from_pt
@@ -21,10 +21,15 @@ public calculate_compress_nemo, calculate_density_nemo
 public calculate_density_derivs_nemo
 public calculate_density_scalar_nemo, calculate_density_array_nemo
 
+!> Compute the in situ density of sea water (units of kg/m^3), or its anomaly with respect to
+!! a reference density, from absolute salinity (g/kg), conservative temperature (in deg C),
+!! and pressure in Pa, using the expressions derived for use with NEMO
 interface calculate_density_nemo
   module procedure calculate_density_scalar_nemo, calculate_density_array_nemo
 end interface calculate_density_nemo
 
+!> For a given thermodynamic state, return the derivatives of density with conservative temperature
+!! and absolute salinity, the expressions derived for use with NEMO
 interface calculate_density_derivs_nemo
   module procedure calculate_density_derivs_scalar_nemo, calculate_density_derivs_array_nemo
 end interface calculate_density_derivs_nemo
@@ -205,6 +210,7 @@ subroutine calculate_density_array_nemo(T, S, pressure, rho, start, npts, rho_re
   integer,            intent(in)  :: npts     !< the number of values to calculate.
   real,     optional, intent(in)  :: rho_ref  !< A reference density in kg m-3.
 
+  ! Local variables
   real :: zp, zt, zh, zs, zr0, zn, zn0, zn1, zn2, zn3, zs0
   integer :: j
 
@@ -255,6 +261,8 @@ subroutine calculate_density_array_nemo(T, S, pressure, rho, start, npts, rho_re
  enddo
 end subroutine calculate_density_array_nemo
 
+!> For a given thermodynamic state, calculate the derivatives of density with conservative
+!! temperature and absolute salinity, using the expressions derived for use with NEMO.
 subroutine calculate_density_derivs_array_nemo(T, S, pressure, drho_dT, drho_dS, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Conservative temperature in C.
   real,    intent(in),  dimension(:) :: S        !< Absolute salinity in g/kg.
@@ -265,15 +273,8 @@ subroutine calculate_density_derivs_array_nemo(T, S, pressure, drho_dT, drho_dS,
                                                  !! in kg m-3 psu-1.
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
-! * Arguments: T - conservative temperature in C.                      *
-! *  (in)      S - absolute salinity in g/kg.                          *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     drho_dT - the partial derivative of density with        *
-! *                      potential temperature, in kg m-3 K-1.         *
-! *  (out)     drho_dS - the partial derivative of density with        *
-! *                      salinity, in kg m-3 psu-1.                    *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
+
+  ! Local variables
   real :: zp,zt , zh , zs , zr0, zn , zn0, zn1, zn2, zn3
   integer :: j
 
@@ -359,6 +360,10 @@ subroutine calculate_density_derivs_scalar_nemo(T, S, pressure, drho_dt, drho_ds
   drho_ds = drds0(1)
 end subroutine calculate_density_derivs_scalar_nemo
 
+!> Compute the in situ density of sea water (rho in units of kg/m^3) and the compressibility
+!! (drho/dp = C_sound^-2, stored as drho_dp in units of s2 m-2) from absolute salinity
+!! (sal in g/kg), conservative temperature (T in deg C), and pressure in Pa, using the expressions
+!! derived for use with NEMO.
 subroutine calculate_compress_nemo(T, S, pressure, rho, drho_dp, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Conservative temperature in C.
   real,    intent(in),  dimension(:) :: S        !< Absolute salinity in g/kg.
@@ -369,16 +374,8 @@ subroutine calculate_compress_nemo(T, S, pressure, rho, drho_dp, start, npts)
                                                  !! in s2 m-2.
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
-! * Arguments: T - conservative temperature in C.                      *
-! *  (in)      S - absolute salinity in g/kg.                          *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     rho - in situ density in kg m-3.                        *
-! *  (out)     drho_dp - the partial derivative of density with        *
-! *                      pressure (also the inverse of the square of   *
-! *                      sound speed) in s2 m-2.                       *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
-! *====================================================================*
+
+  ! Local variables
   real ::  zs,zt,zp
   integer :: j
 

--- a/src/equation_of_state/MOM_EOS_TEOS10.F90
+++ b/src/equation_of_state/MOM_EOS_TEOS10.F90
@@ -21,18 +21,28 @@ public calculate_specvol_derivs_teos10
 public calculate_density_second_derivs_teos10
 public gsw_sp_from_sr, gsw_pt_from_ct
 
+!> Compute the in situ density of sea water (units of kg/m^3), or its anomaly with respect to
+!! a reference density, from absolute salinity (g/kg), conservative temperature (in deg C),
+!! and pressure in Pa, using the TEOS10 expressions.
 interface calculate_density_teos10
   module procedure calculate_density_scalar_teos10, calculate_density_array_teos10
 end interface calculate_density_teos10
 
+!> Compute the in situ specific volume of sea water (in units of m^3/kg), or an anomaly with respect
+!! to a reference specific volume, from absolute salinity (in g/kg), conservative temperature
+!! (in deg C), and pressure in Pa, using the TEOS10 expressions.
 interface calculate_spec_vol_teos10
   module procedure calculate_spec_vol_scalar_teos10, calculate_spec_vol_array_teos10
 end interface calculate_spec_vol_teos10
 
+!> For a given thermodynamic state, return the derivatives of density with conservative temperature
+!! and absolute salinity, using the TEOS10 expressions.
 interface calculate_density_derivs_teos10
   module procedure calculate_density_derivs_scalar_teos10, calculate_density_derivs_array_teos10
 end interface calculate_density_derivs_teos10
 
+!> For a given thermodynamic state, return the second derivatives of density with various combinations
+!! of conservative temperature, absolute salinity, and pressure, using the TEOS10 expressions.
 interface calculate_density_second_derivs_teos10
   module procedure calculate_density_second_derivs_scalar_teos10, calculate_density_second_derivs_array_teos10
 end interface calculate_density_second_derivs_teos10
@@ -52,6 +62,7 @@ subroutine calculate_density_scalar_teos10(T, S, pressure, rho, rho_ref)
   real,           intent(out) :: rho      !< In situ density in kg m-3.
   real, optional, intent(in)  :: rho_ref  !< A reference density in kg m-3.
 
+  ! Local variables
   real, dimension(1) :: T0, S0, pressure0
   real, dimension(1) :: rho0
 
@@ -77,6 +88,7 @@ subroutine calculate_density_array_teos10(T, S, pressure, rho, start, npts, rho_
   integer,            intent(in)  :: npts     !< the number of values to calculate.
   real,     optional, intent(in)  :: rho_ref  !< A reference density in kg m-3.
 
+  ! Local variables
   real :: zs, zt, zp
   integer :: j
 
@@ -96,17 +108,17 @@ subroutine calculate_density_array_teos10(T, S, pressure, rho, start, npts, rho_
 end subroutine calculate_density_array_teos10
 
 !> This subroutine computes the in situ specific volume of sea water (specvol in
-!! units of m^3/kg) from salinity (S in psu), potential temperature (T in deg C)
+!! units of m^3/kg) from absolute salinity (S in g/kg), conservative temperature (T in deg C)
 !! and pressure in Pa, using the TEOS10 equation of state.
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_scalar_teos10(T, S, pressure, specvol, spv_ref)
-  real,           intent(in)  :: T        !< potential temperature relative to the surface
-                                          !! in C.
-  real,           intent(in)  :: S        !< salinity in PSU.
+  real,           intent(in)  :: T        !< Conservative temperature in C.
+  real,           intent(in)  :: S        !< Absolute salinity in g/kg
   real,           intent(in)  :: pressure !< pressure in Pa.
   real,           intent(out) :: specvol  !< in situ specific volume in m3 kg-1.
   real, optional, intent(in)  :: spv_ref  !< A reference specific volume in m3 kg-1.
 
+  ! Local variables
   real, dimension(1) :: T0, S0, pressure0, spv0
 
   T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
@@ -117,19 +129,20 @@ end subroutine calculate_spec_vol_scalar_teos10
 
 
 !> This subroutine computes the in situ specific volume of sea water (specvol in
-!! units of m^3/kg) from salinity (S in psu), potential temperature (T in deg C)
+!! units of m^3/kg) from absolute salinity (S in g/kg), conservative temperature (T in deg C)
 !! and pressure in Pa, using the TEOS10 equation of state.
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_array_teos10(T, S, pressure, specvol, start, npts, spv_ref)
-  real, dimension(:), intent(in)  :: T        !< potential temperature relative to the surface
+  real, dimension(:), intent(in)  :: T        !< Conservative temperature relative to the surface
                                               !! in C.
-  real, dimension(:), intent(in)  :: S        !< salinity in PSU.
+  real, dimension(:), intent(in)  :: S        !< salinity in g/kg.
   real, dimension(:), intent(in)  :: pressure !< pressure in Pa.
   real, dimension(:), intent(out) :: specvol  !< in situ specific volume in m3 kg-1.
   integer,            intent(in)  :: start    !< the starting point in the arrays.
   integer,            intent(in)  :: npts     !< the number of values to calculate.
   real,     optional, intent(in)  :: spv_ref  !< A reference specific volume in m3 kg-1.
 
+  ! Local variables
   real :: zs, zt, zp
   integer :: j
 
@@ -149,27 +162,21 @@ subroutine calculate_spec_vol_array_teos10(T, S, pressure, specvol, start, npts,
 
 end subroutine calculate_spec_vol_array_teos10
 
-
+!> For a given thermodynamic state, calculate the derivatives of density with conservative
+!! temperature and absolute salinity, using the TEOS10 expressions.
 subroutine calculate_density_derivs_array_teos10(T, S, pressure, drho_dT, drho_dS, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Conservative temperature in C.
   real,    intent(in),  dimension(:) :: S        !< Absolute salinity in g/kg.
   real,    intent(in),  dimension(:) :: pressure !< Pressure in Pa.
-  real,    intent(out), dimension(:) :: drho_dT  !< The partial derivative of density with potential
+  real,    intent(out), dimension(:) :: drho_dT  !< The partial derivative of density with conservative
                                                  !! temperature, in kg m-3 K-1.
-  real,    intent(out), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
-                                                 !! in kg m-3 psu-1.
+  real,    intent(out), dimension(:) :: drho_dS  !< The partial derivative of density with absolute salinity,
+                                                 !! in kg m-3 (g/kg)-1.
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
-! * Arguments: T - conservative temperature in C.                      *
-! *  (in)      S - absolute salinity in g/kg.                          *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     drho_dT - the partial derivative of density with        *
-! *                      potential temperature, in kg m-3 K-1.         *
-! *  (out)     drho_dS - the partial derivative of density with        *
-! *                      salinity, in kg m-3 psu-1.                    *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
-  real :: zs,zt,zp
+
+  ! Local variables
+  real :: zs, zt, zp
   integer :: j
 
   do j=start,start+npts-1
@@ -186,16 +193,19 @@ subroutine calculate_density_derivs_array_teos10(T, S, pressure, drho_dT, drho_d
 
 end subroutine calculate_density_derivs_array_teos10
 
+!> For a given thermodynamic state, calculate the derivatives of density with conservative
+!! temperature and absolute salinity, using the TEOS10 expressions.
 subroutine calculate_density_derivs_scalar_teos10(T, S, pressure, drho_dT, drho_dS)
   real,    intent(in)  :: T        !< Conservative temperature in C
   real,    intent(in)  :: S        !< Absolute Salinity in g/kg
   real,    intent(in)  :: pressure !< Pressure in Pa.
-  real,    intent(out) :: drho_dT  !< The partial derivative of density with potential
+  real,    intent(out) :: drho_dT  !< The partial derivative of density with conservative
                                    !! temperature, in kg m-3 K-1.
-  real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
-                                   !! in kg m-3 psu-1.
+  real,    intent(out) :: drho_dS  !< The partial derivative of density with absolute salinity,
+                                   !! in kg m-3 (g/kg)-1.
+
   ! Local variables
-  real :: zs,zt,zp
+  real :: zs, zt, zp
   !Conversions
   zs = S !gsw_sr_from_sp(S)       !Convert practical salinity to absolute salinity
   zt = T !gsw_ct_from_pt(S,T)  !Convert potantial temp to conservative temp
@@ -204,25 +214,20 @@ subroutine calculate_density_derivs_scalar_teos10(T, S, pressure, drho_dT, drho_
   call gsw_rho_first_derivatives(zs, zt, zp, drho_dsa=drho_dS, drho_dct=drho_dT)
 end subroutine calculate_density_derivs_scalar_teos10
 
+!> For a given thermodynamic state, calculate the derivatives of specific volume with conservative
+!! temperature and absolute salinity, using the TEOS10 expressions.
 subroutine calculate_specvol_derivs_teos10(T, S, pressure, dSV_dT, dSV_dS, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Conservative temperature in C.
   real,    intent(in),  dimension(:) :: S        !< Absolute salinity in g/kg.
   real,    intent(in),  dimension(:) :: pressure !< Pressure in Pa.
   real,    intent(out), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
-                                                 !! potential temperature, in m3 kg-1 K-1.
+                                                 !! conservative temperature, in m3 kg-1 K-1.
   real,    intent(out), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
-                                                 !! salinity, in m3 kg-1 / (g/kg).
+                                                 !! absolute salinity, in m3 kg-1 / (g/kg).
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
-! * Arguments: T - conservative temperature in C.                      *
-! *  (in)      S - absolute salinity in g/kg.                          *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     dSV_dT - the partial derivative of specific volume with *
-! *                     potential temperature, in m3 kg-1 K-1.         *
-! *  (out)     dSV_dS - the partial derivative of specific volume with *
-! *                      salinity, in m3 kg-1 / (g/kg).                *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
+
+  ! Local variables
   real :: zs, zt, zp
   integer :: j
 
@@ -251,14 +256,9 @@ subroutine calculate_density_second_derivs_scalar_teos10(T, S, pressure, drho_dS
   real, intent(out)    :: drho_dT_dT !< Partial derivative of alpha with respect to T
   real, intent(out)    :: drho_dS_dP !< Partial derivative of beta with respect to pressure
   real, intent(out)    :: drho_dT_dP !< Partial derivative of alpha with respect to pressure
-! * Arguments: T - conservative temperature in C.                      *
-! *  (in)      S - absolute salinity in g/kg.                          *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     drho_dT - the partial derivative of density with        *
-! *                      potential temperature, in kg m-3 K-1.         *
-! *  (out)     drho_dS - the partial derivative of density with        *
-! *                      salinity, in kg m-3 psu-1.                    *
-  real :: zs,zt,zp
+
+  ! Local variables
+  real :: zs, zt, zp
 
   !Conversions
   zs = S !gsw_sr_from_sp(S)       !Convert practical salinity to absolute salinity
@@ -283,15 +283,11 @@ subroutine calculate_density_second_derivs_array_teos10(T, S, pressure, drho_dS_
   real, dimension(:), intent(out)    :: drho_dT_dP !< Partial derivative of alpha with respect to pressure
   integer, intent(in)  :: start    !< The starting point in the arrays.
   integer, intent(in)  :: npts     !< The number of values to calculate.
-! * Arguments: T - conservative temperature in C.                      *
-! *  (in)      S - absolute salinity in g/kg.                          *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     drho_dT - the partial derivative of density with        *
-! *                      potential temperature, in kg m-3 K-1.         *
-! *  (out)     drho_dS - the partial derivative of density with        *
-! *                      salinity, in kg m-3 psu-1.                    *
-  real :: zs,zt,zp
+
+  ! Local variables
+  real :: zs, zt, zp
   integer :: j
+
   do j=start,start+npts-1
     !Conversions
     zs = S(j) !gsw_sr_from_sp(S)       !Convert practical salinity to absolute salinity
@@ -308,10 +304,10 @@ subroutine calculate_density_second_derivs_array_teos10(T, S, pressure, drho_dS_
 
 end subroutine calculate_density_second_derivs_array_teos10
 
-!> This subroutine computes the in situ density of sea water (rho in *
-!! units of kg/m^3) and the compressibility (drho/dp = C_sound^-2)   *
-!! (drho_dp in units of s2 m-2) from salinity (sal in psu), potential*
-!! temperature (T in deg C), and pressure in Pa.  It uses the        *
+!> This subroutine computes the in situ density of sea water (rho in
+!! units of kg/m^3) and the compressibility (drho/dp = C_sound^-2)
+!! (drho_dp in units of s2 m-2) from absolute salinity (sal in g/kg),
+!! conservative temperature (T in deg C), and pressure in Pa.  It uses the
 !! subroutines from TEOS10 website
 subroutine calculate_compress_teos10(T, S, pressure, rho, drho_dp, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Conservative temperature in C.
@@ -323,22 +319,8 @@ subroutine calculate_compress_teos10(T, S, pressure, rho, drho_dp, start, npts)
                                                  !! in s2 m-2.
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
-! * Arguments: T - conservative temperature in C.                      *
-! *  (in)      S - absolute salinity in g/kg.                          *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     rho - in situ density in kg m-3.                        *
-! *  (out)     drho_dp - the partial derivative of density with        *
-! *                      pressure (also the inverse of the square of   *
-! *                      sound speed) in s2 m-2.                       *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
-! *====================================================================*
-! *  This subroutine computes the in situ density of sea water (rho in *
-! *  units of kg/m^3) and the compressibility (drho/dp = C_sound^-2)   *
-! *  (drho_dp in units of s2 m-2) from salinity (sal in psu), potential*
-! *  temperature (T in deg C), and pressure in Pa.  It uses the        *
-! *  subroutines from TEOS10 website                                   *
-! *====================================================================*
+
+  ! Local variables
   real :: zs,zt,zp
   integer :: j
 

--- a/src/equation_of_state/MOM_EOS_UNESCO.F90
+++ b/src/equation_of_state/MOM_EOS_UNESCO.F90
@@ -15,10 +15,16 @@ public calculate_compress_UNESCO, calculate_density_UNESCO, calculate_spec_vol_U
 public calculate_density_derivs_UNESCO
 public calculate_density_scalar_UNESCO, calculate_density_array_UNESCO
 
+!> Compute the in situ density of sea water (in units of kg/m^3), or its anomaly with respect to
+!! a reference density, from salinity (in psu), potential temperature (in deg C), and pressure in Pa,
+!! using the UNESCO (1981) equation of state.
 interface calculate_density_UNESCO
   module procedure calculate_density_scalar_UNESCO, calculate_density_array_UNESCO
 end interface calculate_density_UNESCO
 
+!> Compute the in situ specific volume of sea water (in units of m^3/kg), or an anomaly with respect
+!! to a reference specific volume, from salinity (in psu), potential temperature (in deg C), and
+!! pressure in Pa, using the UNESCO (1981) equation of state.
 interface calculate_spec_vol_UNESCO
   module procedure calculate_spec_vol_scalar_UNESCO, calculate_spec_vol_array_UNESCO
 end interface calculate_spec_vol_UNESCO
@@ -56,6 +62,7 @@ subroutine calculate_density_scalar_UNESCO(T, S, pressure, rho, rho_ref)
   real,           intent(out) :: rho      !< In situ density in kg m-3.
   real, optional, intent(in)  :: rho_ref  !< A reference density in kg m-3.
 
+  ! Local variables
   real, dimension(1) :: T0, S0, pressure0
   real, dimension(1) :: rho0
 
@@ -80,17 +87,7 @@ subroutine calculate_density_array_UNESCO(T, S, pressure, rho, start, npts, rho_
   integer,            intent(in)  :: npts     !< the number of values to calculate.
   real,     optional, intent(in)  :: rho_ref  !< A reference density in kg m-3.
 
-! *  This subroutine computes the in situ density of sea water (rho in *
-! *  units of kg/m^3) from salinity (S in psu), potential temperature  *
-! *  (T in deg C), and pressure in Pa.                                 *
-
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in PSU.                                    *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     rho - in situ density in kg m-3.                        *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
-
+  ! Local variables
   real :: t_local, t2, t3, t4, t5 ! Temperature to the 1st - 5th power.
   real :: s_local, s32, s2        ! Salinity to the 1st, 3/2, & 2nd power.
   real :: p1, p2      ! Pressure (in bars) to the 1st and 2nd power.
@@ -144,6 +141,7 @@ subroutine calculate_spec_vol_scalar_UNESCO(T, S, pressure, specvol, spv_ref)
   real,           intent(out) :: specvol  !< in situ specific volume in m3 kg-1.
   real, optional, intent(in)  :: spv_ref  !< A reference specific volume in m3 kg-1.
 
+  ! Local variables
   real, dimension(1) :: T0, S0, pressure0, spv0
 
   T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
@@ -166,6 +164,7 @@ subroutine calculate_spec_vol_array_UNESCO(T, S, pressure, specvol, start, npts,
   integer,            intent(in)  :: npts     !< the number of values to calculate.
   real,     optional, intent(in)  :: spv_ref  !< A reference specific volume in m3 kg-1.
 
+  ! Local variables
   real :: t_local, t2, t3, t4, t5; ! Temperature to the 1st - 5th power.
   real :: s_local, s32, s2;        ! Salinity to the 1st, 3/2, & 2nd power.
   real :: p1, p2;      ! Pressure (in bars) to the 1st and 2nd power.
@@ -221,18 +220,7 @@ subroutine calculate_density_derivs_UNESCO(T, S, pressure, drho_dT, drho_dS, sta
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
 
-! *   This subroutine calculates the partial derivatives of density    *
-! * with potential temperature and salinity.                           *
-! *                                                                    *
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in PSU.                                    *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     drho_dT - the partial derivative of density with        *
-! *                      potential temperature, in kg m-3 K-1.         *
-! *  (out)     drho_dS - the partial derivative of density with        *
-! *                      salinity, in kg m-3 psu-1.                    *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
+  ! Local variables
   real :: t_local, t2, t3, t4, t5; ! Temperature to the 1st - 5th power.
   real :: s12, s_local, s32, s2;   ! Salinity to the 1/2 - 2nd powers.
   real :: p1, p2;         ! Pressure (in bars) to the 1st & 2nd power.
@@ -303,20 +291,7 @@ subroutine calculate_compress_UNESCO(T, S, pressure, rho, drho_dp, start, npts)
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
 
-! *  This subroutine computes the in situ density of sea water (rho)   *
-! *  and the compressibility (drho/dp == C_sound^-2) at the given      *
-! *  salinity, potential temperature, and pressure.                    *
-! *                                                                    *
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in PSU.                                    *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     rho - in situ density in kg m-3.                        *
-! *  (out)     drho_dp - the partial derivative of density with        *
-! *                      pressure (also the inverse of the square of   *
-! *                      sound speed) in s2 m-2.                       *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
-
+  ! Local variables
   real :: t_local, t2, t3, t4, t5; ! Temperature to the 1st - 5th power.
   real :: s_local, s32, s2;        ! Salinity to the 1st, 3/2, & 2nd power.
   real :: p1, p2;      ! Pressure (in bars) to the 1st and 2nd power.

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -19,18 +19,28 @@ public calculate_density_derivs_wright, calculate_specvol_derivs_wright
 public calculate_density_second_derivs_wright
 public int_density_dz_wright, int_spec_vol_dp_wright
 
+
+!> Compute the in situ density of sea water (in units of kg/m^3), or its anomaly with respect to
+!! a reference density, from salinity (in psu), potential temperature (in deg C), and pressure in Pa,
+!! using the expressions from Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
 interface calculate_density_wright
   module procedure calculate_density_scalar_wright, calculate_density_array_wright
 end interface calculate_density_wright
 
+!> Compute the in situ specific volume of sea water (in units of m^3/kg), or an anomaly with respect
+!! to a reference specific volume, from salinity (in psu), potential temperature (in deg C), and
+!! pressure in Pa, using the expressions from Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
 interface calculate_spec_vol_wright
   module procedure calculate_spec_vol_scalar_wright, calculate_spec_vol_array_wright
 end interface calculate_spec_vol_wright
 
+!> For a given thermodynamic state, return the derivatives of density with temperature and salinity
 interface calculate_density_derivs_wright
   module procedure calculate_density_derivs_scalar_wright, calculate_density_derivs_array_wright
 end interface
 
+!> For a given thermodynamic state, return the second derivatives of density with various combinations
+!! of temperature, salinity, and pressure
 interface calculate_density_second_derivs_wright
   module procedure calculate_density_second_derivs_scalar_wright, calculate_density_second_derivs_array_wright
 end interface
@@ -99,6 +109,7 @@ subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_
   real,     optional, intent(in)  :: rho_ref  !< A reference density in kg m-3.
 
   ! Original coded by R. Hallberg, 7/00, anomaly coded in 3/18.
+  ! Local variables
   real :: al0, p0, lambda
   real :: al_TS, p_TSp, lam_TS, pa_000
   integer :: j
@@ -135,6 +146,7 @@ subroutine calculate_spec_vol_scalar_wright(T, S, pressure, specvol, spv_ref)
   real,           intent(out) :: specvol  !< in situ specific volume in m3 kg-1.
   real, optional, intent(in)  :: spv_ref  !< A reference specific volume in m3 kg-1.
 
+  ! Local variables
   real, dimension(1) :: T0, S0, pressure0, spv0
 
   T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
@@ -158,6 +170,7 @@ subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts,
   integer,            intent(in)  :: npts     !< the number of values to calculate.
   real,     optional, intent(in)  :: spv_ref  !< A reference specific volume in m3 kg-1.
 
+  ! Local variables
   real :: al0, p0, lambda
   integer :: j
 
@@ -187,15 +200,7 @@ subroutine calculate_density_derivs_array_wright(T, S, pressure, drho_dT, drho_d
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
 
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in PSU.                                    *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     drho_dT - the partial derivative of density with        *
-! *                      potential temperature, in kg m-3 K-1.         *
-! *  (out)     drho_dS - the partial derivative of density with        *
-! *                      salinity, in kg m-3 psu-1.                    *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
+  ! Local variables
   real :: al0, p0, lambda, I_denom2
   integer :: j
 
@@ -254,10 +259,11 @@ subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drh
   integer,            intent(in   ) :: start !< Starting index in T,S,P
   integer,            intent(in   ) :: npts  !< Number of points to loop over
 
+  ! Local variables
+  real :: z0, z1, z2, z3, z4, z5, z6 ,z7, z8, z9, z10, z11, z2_2, z2_3
   integer :: j
   ! Based on the above expression with common terms factored, there probably exists a more numerically stable
   ! and/or efficient expression
-  real :: z0, z1, z2, z3, z4, z5, z6 ,z7, z8, z9, z10, z11, z2_2, z2_3
 
   do j = start,start+npts-1
     z0 = T(j)*(b1 + b5*S(j) + T(j)*(b2 + b3*T(j)))
@@ -313,9 +319,10 @@ subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, dr
 
 end subroutine calculate_density_second_derivs_scalar_wright
 
+!> For a given thermodynamic state, return the partial derivatives of specific volume
+!! with temperature and salinity
 subroutine calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface
-                                                 !! in C.
+  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface in C.
   real,    intent(in),  dimension(:) :: S        !< Salinity in g/kg.
   real,    intent(in),  dimension(:) :: pressure !< Pressure in Pa.
   real,    intent(out), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
@@ -325,15 +332,7 @@ subroutine calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
 
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in g/kg.                                   *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     dSV_dT - the partial derivative of specific volume with *
-! *                     potential temperature, in m3 kg-1 K-1.         *
-! *  (out)     dSV_dS - the partial derivative of specific volume with *
-! *                      salinity, in m3 kg-1 / (g/kg).                *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
+  ! Local variables
   real :: al0, p0, lambda, I_denom
   integer :: j
 
@@ -360,8 +359,7 @@ end subroutine calculate_specvol_derivs_wright
 !! from Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
 !! Coded by R. Hallberg, 1/01
 subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface
-                                                 !! in C.
+  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface in C.
   real,    intent(in),  dimension(:) :: S        !< Salinity in PSU.
   real,    intent(in),  dimension(:) :: pressure !< Pressure in Pa.
   real,    intent(out), dimension(:) :: rho      !< In situ density in kg m-3.
@@ -371,23 +369,8 @@ subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
   integer, intent(in)                :: start    !< The starting point in the arrays.
   integer, intent(in)                :: npts     !< The number of values to calculate.
 
-! * Arguments: T - potential temperature relative to the surface in C. *
-! *  (in)      S - salinity in PSU.                                    *
-! *  (in)      pressure - pressure in Pa.                              *
-! *  (out)     rho - in situ density in kg m-3.                        *
-! *  (out)     drho_dp - the partial derivative of density with        *
-! *                      pressure (also the inverse of the square of   *
-! *                      sound speed) in s2 m-2.                       *
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
-! *====================================================================*
-! *  This subroutine computes the in situ density of sea water (rho in *
-! *  units of kg/m^3) and the compressibility (drho/dp = C_sound^-2)   *
-! *  (drho_dp in units of s2 m-2) from salinity (sal in psu), potential*
-! *  temperature (T in deg C), and pressure in Pa.  It uses the expres-*
-! *  sions from Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.     *
-! *  Coded by R. Hallberg, 1/01                                        *
-! *====================================================================*
+  ! Coded by R. Hallberg, 1/01
+  ! Local variables
   real :: al0, p0, lambda, I_denom
   integer :: j
 
@@ -448,6 +431,7 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HII, HIO, 
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
                                           !! interpolate T/S for top and bottom integrals.
 
+  ! Local variables
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed) :: al0_2d, p0_2d, lambda_2d
   real :: al0, p0, lambda
   real :: rho_anom   ! The density anomaly from rho_ref, in kg m-3.
@@ -653,13 +637,7 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
                             !! to interpolate T/S for top and bottom integrals.
 
-!   This subroutine calculates analytical and nearly-analytical integrals in
-! pressure across layers of geopotential anomalies, which are required for
-! calculating the finite-volume form pressure accelerations in a non-Boussinesq
-! model.  There are essentially no free assumptions, apart from the use of
-! Bode's rule to do the horizontal integrals, and from a truncation in the
-! series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
-
+  ! Local variables
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed) :: al0_2d, p0_2d, lambda_2d
   real :: al0, p0, lambda
   real :: p_ave

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -16,18 +16,29 @@ public calculate_density_scalar_linear, calculate_density_array_linear
 public calculate_density_second_derivs_linear
 public int_density_dz_linear, int_spec_vol_dp_linear
 
+!> Compute the density of sea water (in kg/m^3), or its anomaly from a reference density,
+!! using a simple linear equation of state from salinity (in psu), potential temperature (in deg C)
+!! and pressure in Pa.
 interface calculate_density_linear
   module procedure calculate_density_scalar_linear, calculate_density_array_linear
 end interface calculate_density_linear
 
+!> Compute the specific volume of sea water (in m^3/kg), or its anomaly from a reference value,
+!! using a simple linear equation of state from salinity (in psu), potential temperature (in deg C)
+!! and pressure in Pa.
 interface calculate_spec_vol_linear
   module procedure calculate_spec_vol_scalar_linear, calculate_spec_vol_array_linear
 end interface calculate_spec_vol_linear
 
+!> For a given thermodynamic state, return the derivatives of density with temperature and
+!! salinity using the simple linear equation of state
 interface calculate_density_derivs_linear
   module procedure calculate_density_derivs_scalar_linear, calculate_density_derivs_array_linear
 end interface calculate_density_derivs_linear
 
+!> For a given thermodynamic state, return the second derivatives of density with various
+!! combinations of temperature, salinity, and pressure.  Note that with a simple linear
+!! equation of state these second derivatives are all 0.
 interface calculate_density_second_derivs_linear
   module procedure calculate_density_second_derivs_scalar_linear, calculate_density_second_derivs_array_linear
 end interface calculate_density_second_derivs_linear
@@ -35,7 +46,7 @@ end interface calculate_density_second_derivs_linear
 contains
 
 !> This subroutine computes the density of sea water with a trivial
-!! linear equation of state (in kg/m^3) from salinity (sal in psu),
+!! linear equation of state (in kg m-3) from salinity (sal in PSU),
 !! potential temperature (T in deg C), and pressure in Pa.
 subroutine calculate_density_scalar_linear(T, S, pressure, rho, &
                                            Rho_T0_S0, dRho_dT, dRho_dS, rho_ref)

--- a/src/equation_of_state/MOM_TFreeze.F90
+++ b/src/equation_of_state/MOM_TFreeze.F90
@@ -12,21 +12,30 @@ implicit none ; private
 
 public calculate_TFreeze_linear, calculate_TFreeze_Millero, calculate_TFreeze_teos10
 
+!> Compute the freezing point potential temperature (in deg C) from salinity (in psu) and
+!! pressure (in Pa) using a simple linear expression, with coefficients passed in as arguments.
 interface calculate_TFreeze_linear
   module procedure calculate_TFreeze_linear_scalar, calculate_TFreeze_linear_array
 end interface calculate_TFreeze_linear
 
+!> Compute the freezing point potential temperature (in deg C) from salinity (in psu) and
+!! pressure (in Pa) using the expression from Millero (1978) (and in appendix A of Gill 1982),
+!! but with the of the pressure dependence changed from 7.53e-8 to 7.75e-8 to make this an
+!! expression for potential temperature (not in situ temperature), using a
+!! value that is correct at the freezing point at 35 PSU and 5e6 Pa (500 dbar).
 interface calculate_TFreeze_Millero
   module procedure calculate_TFreeze_Millero_scalar, calculate_TFreeze_Millero_array
 end interface calculate_TFreeze_Millero
 
+!> Compute the freezing point conservative temperature (in deg C) from absolute salinity (in g/kg)
+!! and pressure (in Pa) using the TEOS10 package.
 interface calculate_TFreeze_teos10
   module procedure calculate_TFreeze_teos10_scalar, calculate_TFreeze_teos10_array
 end interface calculate_TFreeze_teos10
 
 contains
 
-!>  This subroutine computes the freezing point potential temparature
+!>  This subroutine computes the freezing point potential temperature
 !!  (in deg C) from salinity (in psu), and pressure (in Pa) using a simple
 !!  linear expression, with coefficients passed in as arguments.
 subroutine calculate_TFreeze_linear_scalar(S, pres, T_Fr, TFr_S0_P0, &
@@ -40,24 +49,11 @@ subroutine calculate_TFreeze_linear_scalar(S, pres, T_Fr, TFr_S0_P0, &
   real,  intent(in)  :: dTFr_dp   !< The derivative of freezing point with pressure,
                                   !! in deg C Pa-1.
 
-!    This subroutine computes the freezing point potential temparature
-!  (in deg C) from salinity (in psu), and pressure (in Pa) using a simple
-!  linear expression, with coefficients passed in as arguments.
-!
-! Arguments: S - salinity in PSU.
-!  (in)      pres - pressure in Pa.
-!  (out)     T_Fr - Freezing point potential temperature in deg C.
-!  (in)      TFr_S0_P0 - The freezing point at S=0, p=0, in deg C.
-!  (in)      dTFr_dS - The derivatives of freezing point with salinity, in
-!                      deg C PSU-1.
-!  (in)      dTFr_dp - The derivatives of freezing point with pressure, in
-!                      deg C Pa-1.
-
   T_Fr = (TFr_S0_P0 + dTFr_dS*S) + dTFr_dp*pres
 
 end subroutine calculate_TFreeze_linear_scalar
 
-!>  This subroutine computes an array of freezing point potential temparatures
+!>  This subroutine computes an array of freezing point potential temperatures
 !!  (in deg C) from salinity (in psu), and pressure (in Pa) using a simple
 !!  linear expression, with coefficients passed in as arguments.
 subroutine calculate_TFreeze_linear_array(S, pres, T_Fr, start, npts, &
@@ -72,21 +68,6 @@ subroutine calculate_TFreeze_linear_array(S, pres, T_Fr, start, npts, &
                                                 !! in deg C PSU-1.
   real,                intent(in)  :: dTFr_dp   !< The derivative of freezing point with pressure,
                                                 !! in deg C Pa-1.
-
-!    This subroutine computes the freezing point potential temparature
-!  (in deg C) from salinity (in psu), and pressure (in Pa) using a simple
-!  linear expression, with coefficients passed in as arguments.
-!
-! Arguments: S - salinity in PSU.
-!  (in)      pres - pressure in Pa.
-!  (out)     T_Fr - Freezing point potential temperature in deg C.
-!  (in)      start - the starting point in the arrays.
-!  (in)      npts - the number of values to calculate.
-!  (in)      TFr_S0_P0 - The freezing point at S=0, p=0, in deg C.
-!  (in)      dTFr_dS - The derivative of freezing point with salinity, in
-!                      deg C PSU-1.
-!  (in)      dTFr_dp - The derivative of freezing point with pressure, in
-!                      deg C Pa-1.
   integer :: j
 
   do j=start,start+npts-1
@@ -95,7 +76,7 @@ subroutine calculate_TFreeze_linear_array(S, pres, T_Fr, start, npts, &
 
 end subroutine calculate_TFreeze_linear_array
 
-!> This subroutine computes the freezing point potential temparature
+!> This subroutine computes the freezing point potential temperature
 !! (in deg C) from salinity (in psu), and pressure (in Pa) using the expression
 !! from Millero (1978) (and in appendix A of Gill 1982), but with the of the
 !! pressure dependence changed from 7.53e-8 to 7.75e-8 to make this an
@@ -106,16 +87,7 @@ subroutine calculate_TFreeze_Millero_scalar(S, pres, T_Fr)
   real,    intent(in)  :: pres !< Pressure in Pa.
   real,    intent(out) :: T_Fr !< Freezing point potential temperature in deg C.
 
-!    This subroutine computes the freezing point potential temparature
-!  (in deg C) from salinity (in psu), and pressure (in Pa) using the expression
-!  from Millero (1978) (and in appendix A of Gill 1982), but with the of the
-!  pressure dependence changed from 7.53e-8 to 7.75e-8 to make this an
-!  expression for potential temperature (not in situ temperature), using a
-!  value that is correct at the freezing point at 35 PSU and 5e6 Pa (500 dbar).
-!
-! Arguments: S - salinity in PSU.
-!  (in)      pres - pressure in Pa.
-!  (out)     T_Fr - Freezing point potential temperature in deg C.
+  ! Local variables
   real, parameter :: cS1 = -0.0575, cS3_2 = 1.710523e-3, cS2 = -2.154996e-4
   real, parameter :: dTFr_dp = -7.75e-8
 
@@ -123,7 +95,7 @@ subroutine calculate_TFreeze_Millero_scalar(S, pres, T_Fr)
 
 end subroutine calculate_TFreeze_Millero_scalar
 
-!> This subroutine computes the freezing point potential temparature
+!> This subroutine computes the freezing point potential temperature
 !! (in deg C) from salinity (in psu), and pressure (in Pa) using the expression
 !! from Millero (1978) (and in appendix A of Gill 1982), but with the of the
 !! pressure dependence changed from 7.53e-8 to 7.75e-8 to make this an
@@ -135,18 +107,8 @@ subroutine calculate_TFreeze_Millero_array(S, pres, T_Fr, start, npts)
   real,  dimension(:), intent(out) :: T_Fr  !< Freezing point potential temperature in deg C.
   integer,             intent(in)  :: start !< The starting point in the arrays.
   integer,             intent(in)  :: npts  !< The number of values to calculate.
-!    This subroutine computes the freezing point potential temparature
-!  (in deg C) from salinity (in psu), and pressure (in Pa) using the expression
-!  from Millero (1978) (and in appendix A of Gill 1982), but with the of the
-!  pressure dependence changed from 7.53e-8 to 7.75e-8 to make this an
-!  expression for potential temperature (not in situ temperature), using a
-!  value that is correct at the freezing point at 35 PSU and 5e6 Pa (500 dbar).
-!
-! Arguments: S - salinity in PSU.
-!  (in)      pres - pressure in Pa.
-!  (out)     T_Fr - Freezing point potential temperature in deg C.
-!  (in)      start - the starting point in the arrays.
-!  (in)      npts - the number of values to calculate.
+
+  ! Local variables
   real, parameter :: cS1 = -0.0575, cS3_2 = 1.710523e-3, cS2 = -2.154996e-4
   real, parameter :: dTFr_dp = -7.75e-8
   integer :: j
@@ -158,20 +120,15 @@ subroutine calculate_TFreeze_Millero_array(S, pres, T_Fr, start, npts)
 
 end subroutine calculate_TFreeze_Millero_array
 
-!> This subroutine computes the freezing point conservative temparature
+!> This subroutine computes the freezing point conservative temperature
 !! (in deg C) from absolute salinity (in g/kg), and pressure (in Pa) using the
 !! TEOS10 package.
 subroutine calculate_TFreeze_teos10_scalar(S, pres, T_Fr)
   real,    intent(in)  :: S    !< Absolute salinity in g/kg.
   real,    intent(in)  :: pres !< Pressure in Pa.
   real,    intent(out) :: T_Fr !< Freezing point conservative temperature in deg C.
-!    This subroutine computes the freezing point conservative temparature
-!  (in deg C) from absolute salinity (in g/kg), and pressure (in Pa) using the
-!  TEOS10 package.
-!
-! Arguments: S - absolute salinity in g/kg.
-!  (in)      pres - pressure in Pa.
-!  (out)     T_Fr - Freezing point conservative temperature in deg C.
+
+  ! Local variables
   real, dimension(1) :: S0, pres0
   real, dimension(1) :: tfr0
 
@@ -183,7 +140,7 @@ subroutine calculate_TFreeze_teos10_scalar(S, pres, T_Fr)
 
 end subroutine calculate_TFreeze_teos10_scalar
 
-!> This subroutine computes the freezing point conservative temparature
+!> This subroutine computes the freezing point conservative temperature
 !! (in deg C) from absolute salinity (in g/kg), and pressure (in Pa) using the
 !! TEOS10 package.
 subroutine calculate_TFreeze_teos10_array(S, pres, T_Fr, start, npts)
@@ -192,18 +149,9 @@ subroutine calculate_TFreeze_teos10_array(S, pres, T_Fr, start, npts)
   real, dimension(:), intent(out) :: T_Fr  !< Freezing point conservative temperature in deg C.
   integer,            intent(in)  :: start !< the starting point in the arrays.
   integer,            intent(in)  :: npts  !< the number of values to calculate.
-!    This subroutine computes the freezing point conservative temparature
-!  (in deg C) from absolute salinity (in g/kg), and pressure (in Pa) using the
-!  TEOS10 package.
-!
-! Arguments: S - absolute salinity in g/kg.
-!  (in)      pres - pressure in Pa.
-!  (out)     T_Fr - Freezing point conservative temperature in deg C.
-! *  (in)      start - the starting point in the arrays.               *
-! *  (in)      npts - the number of values to calculate.               *
 
+  ! Local variables
   real, parameter :: Pa2db  = 1.e-4  ! The conversion factor from Pa to dbar.
-
   real :: zs,zp
   integer :: j
   ! Assume sea-water contains no dissolved air.
@@ -217,7 +165,6 @@ subroutine calculate_TFreeze_teos10_array(S, pres, T_Fr, start, npts)
     if (S(j) < -1.0e-10) cycle !Can we assume safely that this is a missing value?
     T_Fr(j) = gsw_ct_freezing_exact(zs,zp,saturation_fraction)
  enddo
-
 
 end subroutine calculate_TFreeze_teos10_array
 

--- a/src/framework/MOM_constants.F90
+++ b/src/framework/MOM_constants.F90
@@ -7,6 +7,7 @@ use constants_mod, only : HLV, HLF
 
 implicit none ; private
 
+!> The constant offset for converting temperatures in Kelvin to Celsius
 real, public, parameter :: CELSIUS_KELVIN_OFFSET = 273.15
 public :: HLV, HLF
 

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -45,30 +45,37 @@ public :: create_group_pass, do_group_pass, group_pass_type
 public :: start_group_pass, complete_group_pass
 public :: compute_block_extent, get_global_shape
 
+!> Do a halo update on an array
 interface pass_var
   module procedure pass_var_3d, pass_var_2d
 end interface pass_var
 
+!> Do a halo update on a pair of arrays representing the two components of a vector
 interface pass_vector
   module procedure pass_vector_3d, pass_vector_2d
 end interface pass_vector
 
+!> Initiate a non-blocking halo update on an array
 interface pass_var_start
   module procedure pass_var_start_3d, pass_var_start_2d
 end interface pass_var_start
 
+!> Complete a non-blocking halo update on an array
 interface pass_var_complete
   module procedure pass_var_complete_3d, pass_var_complete_2d
 end interface pass_var_complete
 
+!> Initiate a halo update on a pair of arrays representing the two components of a vector
 interface pass_vector_start
   module procedure pass_vector_start_3d, pass_vector_start_2d
 end interface pass_vector_start
 
+!> Complete a halo update on a pair of arrays representing the two components of a vector
 interface pass_vector_complete
   module procedure pass_vector_complete_3d, pass_vector_complete_2d
 end interface pass_vector_complete
 
+!> Set up a group of halo updates
 interface create_group_pass
   module procedure create_var_group_pass_2d
   module procedure create_var_group_pass_3d
@@ -76,11 +83,14 @@ interface create_group_pass
   module procedure create_vector_group_pass_3d
 end interface create_group_pass
 
+!> Do a set of halo updates that fill in the values at the duplicated edges
+!! of a staggered symmetric memory domain
 interface fill_symmetric_edges
   module procedure fill_vector_symmetric_edges_2d !, fill_vector_symmetric_edges_3d
 !   module procedure fill_scalar_symmetric_edges_2d, fill_scalar_symmetric_edges_3d
 end interface fill_symmetric_edges
 
+!> Copy one MOM_domain_type into another
 interface clone_MOM_domain
   module procedure clone_MD_to_MD, clone_MD_to_d2D
 end interface clone_MOM_domain
@@ -145,21 +155,7 @@ subroutine pass_var_3d(array, MOM_dom, sideflag, complete, position, halo, &
                                                     !! halo by default.
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments: array - The array which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      sideflag - An optional integer indicating which directions the
-!                       data should be sent.  It is TO_ALL or the sum of any of
-!                       TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH.  For example,
-!                       TO_EAST sends the data to the processor to the east, so
-!                       the halos on the western side are filled.  TO_ALL is
-!                       the default if sideflag is omitted.
-!  (in,opt)  complete - An optional argument indicating whether the halo updates
-!                       should be completed before progress resumes.  Omitting
-!                       complete is the same as setting complete to .true.
-!  (in,opt)   position - An optional argument indicating the position.  This is
-!                       usally CORNER, but is CENTER by default.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
+
   integer :: dirflag
   logical :: block_til_complete
 
@@ -205,21 +201,6 @@ subroutine pass_var_2d(array, MOM_dom, sideflag, complete, position, halo, &
                                                    !! by default.
   integer,      optional, intent(in)   :: clock    !< The handle for a cpu time clock that should be
                                                    !! started then stopped to time this routine.
-! Arguments: array - The array which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      sideflag - An optional integer indicating which directions the
-!                       data should be sent.  It is TO_ALL or the sum of any of
-!                       TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH.  For example,
-!                       TO_EAST sends the data to the processor to the east, so
-!                       the halos on the western side are filled.  TO_ALL is
-!                       the default if sideflag is omitted.
-!  (in,opt)  complete - An optional argument indicating whether the halo updates
-!                       should be completed before progress resumes.  Omitting
-!                       complete is the same as setting complete to .true.
-!  (in,opt)  position - An optional argument indicating the position.  This is
-!                       usally CORNER, but is CENTER by default.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
 
   integer :: dirflag
   logical :: block_til_complete
@@ -268,23 +249,7 @@ function pass_var_start_2d(array, MOM_dom, sideflag, position, complete, halo, &
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
   integer                               :: pass_var_start_2d  !<The integer index for this update.
-! Arguments: array - The array which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      sideflag - An optional integer indicating which directions the
-!                       data should be sent.  It is TO_ALL or the sum of any of
-!                       TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH.  For example,
-!                       TO_EAST sends the data to the processor to the east, so
-!                       the halos on the western side are filled.  TO_ALL is
-!                       the default if sideflag is omitted.
-!  (in)      position - An optional argument indicating the position.  This is
-!                       may be CORNER, but is CENTER by default.
-!  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be initiated immediately or wait for second
-!                       pass_..._start call.  Omitting complete is the same as
-!                       setting complete to .true.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
-!  (return value) - The integer index for this update.
+
   integer :: dirflag
 
   if (present(clock)) then ; if (clock>0) call cpu_clock_begin(clock) ; endif
@@ -329,23 +294,7 @@ function pass_var_start_3d(array, MOM_dom, sideflag, position, complete, halo, &
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
   integer                               :: pass_var_start_3d  !< The integer index for this update.
-! Arguments: array - The array which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      sideflag - An optional integer indicating which directions the
-!                       data should be sent.  It is TO_ALL or the sum of any of
-!                       TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH.  For example,
-!                       TO_EAST sends the data to the processor to the east, so
-!                       the halos on the western side are filled.  TO_ALL is
-!                       the default if sideflag is omitted.
-!  (in)      position - An optional argument indicating the position.  This is
-!                       may be CORNER, but is CENTER by default.
-!  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be initiated immediately or wait for second
-!                       pass_..._start call.  Omitting complete is the same as
-!                       setting complete to .true.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
-!  (return value) - The integer index for this update.
+
   integer :: dirflag
 
   if (present(clock)) then ; if (clock>0) call cpu_clock_begin(clock) ; endif
@@ -388,20 +337,7 @@ subroutine pass_var_complete_2d(id_update, array, MOM_dom, sideflag, position, h
                                                     !! halo by default.
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments: id_update - The integer id of this update which has been returned
-!                        from a previous call to pass_var_start.
-!  (inout)   array - The array which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      sideflag - An optional integer indicating which directions the
-!                       data should be sent.  It is TO_ALL or the sum of any of
-!                       TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH.  For example,
-!                       TO_EAST sends the data to the processor to the east, so
-!                       the halos on the western side are filled.  TO_ALL is
-!                       the default if sideflag is omitted.
-!  (in)      position - An optional argument indicating the position.  This is
-!                       may be CORNER, but is CENTER by default.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
+
   integer :: dirflag
 
   if (present(clock)) then ; if (clock>0) call cpu_clock_begin(clock) ; endif
@@ -444,20 +380,7 @@ subroutine pass_var_complete_3d(id_update, array, MOM_dom, sideflag, position, h
                                                     !! halo by default.
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments: id_update - The integer id of this update which has been returned
-!                        from a previous call to pass_var_start.
-!  (inout)   array - The array which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      sideflag - An optional integer indicating which directions the
-!                       data should be sent.  It is TO_ALL or the sum of any of
-!                       TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH.  For example,
-!                       TO_EAST sends the data to the processor to the east, so
-!                       the halos on the western side are filled.  TO_ALL is
-!                       the default if sideflag is omitted.
-!  (in)      position - An optional argument indicating the position.  This is
-!                       may be CORNER, but is CENTER by default.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
+
   integer :: dirflag
 
   if (present(clock)) then ; if (clock>0) call cpu_clock_begin(clock) ; endif
@@ -507,29 +430,8 @@ subroutine pass_vector_2d(u_cmpt, v_cmpt, MOM_dom, direction, stagger, complete,
                                                     !! halo by default.
   integer,     optional, intent(in)    :: clock     !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments: u_cmpt - The nominal zonal (u) component of the vector pair which
-!                     is having its halos points exchanged.
-!  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      direction - An optional integer indicating which directions the
-!                        data should be sent.  It is TO_ALL or the sum of any of
-!                        TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH, possibly
-!                        plus SCALAR_PAIR if these are paired non-directional
-!                        scalars discretized at the typical vector component
-!                        locations.  For example, TO_EAST sends the data to the
-!                        processor to the east, so the halos on the western
-!                        side are filled.  TO_ALL is the default if omitted.
-!  (in)      stagger - An optional flag, which may be one of A_GRID, BGRID_NE,
-!                      or CGRID_NE, indicating where the two components of the
-!                      vector are discretized.  Omitting stagger is the same as
-!                      setting it to CGRID_NE.
-!  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be completed before progress resumes.  Omitting
-!                       complete is the same as setting complete to .true.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
 
+  ! Local variables
   integer :: stagger_local
   integer :: dirflag
   logical :: block_til_complete
@@ -579,18 +481,8 @@ subroutine fill_vector_symmetric_edges_2d(u_cmpt, v_cmpt, MOM_dom, stagger, scal
   logical,     optional, intent(in)    :: scalar  !< An optional argument indicating whether.
   integer,     optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                    !! started then stopped to time this routine.
-! Arguments: u_cmpt - The nominal zonal (u) component of the vector pair which
-!                     is having its halos points exchanged.
-!  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      stagger - An optional flag, which may be one of A_GRID, BGRID_NE,
-!                      or CGRID_NE, indicating where the two components of the
-!                      vector are discretized.  Omitting stagger is the same as
-!                      setting it to CGRID_NE.
-!  (in)      scalar -  An optional argument indicating whether
 
+  ! Local variables
   integer :: stagger_local
   integer :: dirflag
   integer :: i, j, isc, iec, jsc, jec, isd, ied, jsd, jed, IscB, IecB, JscB, JecB
@@ -684,29 +576,8 @@ subroutine pass_vector_3d(u_cmpt, v_cmpt, MOM_dom, direction, stagger, complete,
                                                     !! halo by default.
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments: u_cmpt - The nominal zonal (u) component of the vector pair which
-!                     is having its halos points exchanged.
-!  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      direction - An optional integer indicating which directions the
-!                        data should be sent.  It is TO_ALL or the sum of any of
-!                        TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH, possibly
-!                        plus SCALAR_PAIR if these are paired non-directional
-!                        scalars discretized at the typical vector component
-!                        locations.  For example, TO_EAST sends the data to the
-!                        processor to the east, so the halos on the western
-!                        side are filled.  TO_ALL is the default if omitted.
-!  (in)      stagger - An optional flag, which may be one of A_GRID, BGRID_NE,
-!                      or CGRID_NE, indicating where the two components of the
-!                      vector are discretized.  Omitting stagger is the same as
-!                      setting it to CGRID_NE.
-!  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be completed before progress resumes.  Omitting
-!                       complete is the same as setting complete to .true.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
 
+  ! Local variables
   integer :: stagger_local
   integer :: dirflag
   logical :: block_til_complete
@@ -765,30 +636,8 @@ function pass_vector_start_2d(u_cmpt, v_cmpt, MOM_dom, direction, stagger, compl
                                                     !! started then stopped to time this routine.
   integer                               :: pass_vector_start_2d !< The integer index for this
                                                                 !! update.
-! Arguments: u_cmpt - The nominal zonal (u) component of the vector pair which
-!                     is having its halos points exchanged.
-!  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      direction - An optional integer indicating which directions the
-!                        data should be sent.  It is TO_ALL or the sum of any of
-!                        TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH, possibly
-!                        plus SCALAR_PAIR if these are paired non-directional
-!                        scalars discretized at the typical vector component
-!                        locations.  For example, TO_EAST sends the data to the
-!                        processor to the east, so the halos on the western
-!                        side are filled.  TO_ALL is the default if omitted.
-!  (in)      stagger - An optional flag, which may be one of A_GRID, BGRID_NE,
-!                      or CGRID_NE, indicating where the two components of the
-!                      vector are discretized.  Omitting stagger is the same as
-!                      setting it to CGRID_NE.
-!  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be initiated immediately or wait for second
-!                       pass_..._start call.  Omitting complete is the same as
-!                       setting complete to .true.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
-!  (return value) - The integer index for this update.
+
+  ! Local variables
   integer :: stagger_local
   integer :: dirflag
 
@@ -844,30 +693,7 @@ function pass_vector_start_3d(u_cmpt, v_cmpt, MOM_dom, direction, stagger, compl
                                                     !! started then stopped to time this routine.
   integer                               :: pass_vector_start_3d !< The integer index for this
                                                                 !! update.
-! Arguments: u_cmpt - The nominal zonal (u) component of the vector pair which
-!                     is having its halos points exchanged.
-!  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      direction - An optional integer indicating which directions the
-!                        data should be sent.  It is TO_ALL or the sum of any of
-!                        TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH, possibly
-!                        plus SCALAR_PAIR if these are paired non-directional
-!                        scalars discretized at the typical vector component
-!                        locations.  For example, TO_EAST sends the data to the
-!                        processor to the east, so the halos on the western
-!                        side are filled.  TO_ALL is the default if omitted.
-!  (in)      stagger - An optional flag, which may be one of A_GRID, BGRID_NE,
-!                      or CGRID_NE, indicating where the two components of the
-!                      vector are discretized.  Omitting stagger is the same as
-!                      setting it to CGRID_NE.
-!  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be initiated immediately or wait for second
-!                       pass_..._start call.  Omitting complete is the same as
-!                       setting complete to .true.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
-!  (return value) - The integer index for this update.
+  ! Local variables
   integer :: stagger_local
   integer :: dirflag
 
@@ -921,28 +747,7 @@ subroutine pass_vector_complete_2d(id_update, u_cmpt, v_cmpt, MOM_dom, direction
                                                     !! halo by default.
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments: id_update - The integer id of this update which has been returned
-!                        from a previous call to pass_var_start.
-!  (inout)   u_cmpt - The nominal zonal (u) component of the vector pair which
-!                     is having its halos points exchanged.
-!  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      direction - An optional integer indicating which directions the
-!                        data should be sent.  It is TO_ALL or the sum of any of
-!                        TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH, possibly
-!                        plus SCALAR_PAIR if these are paired non-directional
-!                        scalars discretized at the typical vector component
-!                        locations.  For example, TO_EAST sends the data to the
-!                        processor to the east, so the halos on the western
-!                        side are filled.  TO_ALL is the default if omitted.
-!  (in)      stagger - An optional flag, which may be one of A_GRID, BGRID_NE,
-!                      or CGRID_NE, indicating where the two components of the
-!                      vector are discretized.  Omitting stagger is the same as
-!                      setting it to CGRID_NE.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
-!  (return value) - The integer index for this update.
+  ! Local variables
   integer :: stagger_local
   integer :: dirflag
 
@@ -996,28 +801,7 @@ subroutine pass_vector_complete_3d(id_update, u_cmpt, v_cmpt, MOM_dom, direction
                                                     !! halo by default.
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments: id_update - The integer id of this update which has been returned
-!                        from a previous call to pass_var_start.
-!  (inout)   u_cmpt - The nominal zonal (u) component of the vector pair which
-!                     is having its halos points exchanged.
-!  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      direction - An optional integer indicating which directions the
-!                        data should be sent.  It is TO_ALL or the sum of any of
-!                        TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH, possibly
-!                        plus SCALAR_PAIR if these are paired non-directional
-!                        scalars discretized at the typical vector component
-!                        locations.  For example, TO_EAST sends the data to the
-!                        processor to the east, so the halos on the western
-!                        side are filled.  TO_ALL is the default if omitted.
-!  (in)      stagger - An optional flag, which may be one of A_GRID, BGRID_NE,
-!                      or CGRID_NE, indicating where the two components of the
-!                      vector are discretized.  Omitting stagger is the same as
-!                      setting it to CGRID_NE.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
-!  (return value) - The integer index for this update.
+  ! Local variables
   integer :: stagger_local
   integer :: dirflag
 
@@ -1064,21 +848,7 @@ subroutine create_var_group_pass_2d(group, array, MOM_dom, sideflag, position, &
                                                     !! halo by default.
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments:
-!  (inout)   group - The data type that store information for group update.
-!                    This data will be used in do_group_pass.
-!  (inout)   array - The array which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in,opt)  sideflag - An optional integer indicating which directions the
-!                       data should be sent.  It is TO_ALL or the sum of any of
-!                       TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH.  For example,
-!                       TO_EAST sends the data to the processor to the east, so
-!                       the halos on the western side are filled.  TO_ALL is
-!                       the default if sideflag is omitted.
-!  (in,opt)  position - An optional argument indicating the position.  This is
-!                       may be CORNER, but is CENTER by default.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
+  ! Local variables
   integer :: dirflag
 
   if (present(clock)) then ; if (clock>0) call cpu_clock_begin(clock) ; endif
@@ -1123,21 +893,7 @@ subroutine create_var_group_pass_3d(group, array, MOM_dom, sideflag, position, h
                                                     !! halo by default.
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments:
-!  (inout)   group - The data type that store information for group update.
-!                    This data will be used in do_group_pass.
-!  (inout)   array - The array which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in,opt)  sideflag - An optional integer indicating which directions the
-!                       data should be sent.  It is TO_ALL or the sum of any of
-!                       TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH.  For example,
-!                       TO_EAST sends the data to the processor to the east, so
-!                       the halos on the western side are filled.  TO_ALL is
-!                       the default if sideflag is omitted.
-!  (in,opt)  position - An optional argument indicating the position.  This is
-!                       may be CORNER, but is CENTER by default.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
+  ! Local variables
   integer :: dirflag
 
   if (present(clock)) then ; if (clock>0) call cpu_clock_begin(clock) ; endif
@@ -1189,28 +945,7 @@ subroutine create_vector_group_pass_2d(group, u_cmpt, v_cmpt, MOM_dom, direction
                                                     !! halo by default.
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
-! Arguments:
-!  (inout)   group - The data type that store information for group update.
-!                    This data will be used in do_group_pass.
-!  (inout)   u_cmpt - The nominal zonal (u) component of the vector pair which
-!                     is having its halos points exchanged.
-!  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      direction - An optional integer indicating which directions the
-!                        data should be sent.  It is TO_ALL or the sum of any of
-!                        TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH, possibly
-!                        plus SCALAR_PAIR if these are paired non-directional
-!                        scalars discretized at the typical vector component
-!                        locations.  For example, TO_EAST sends the data to the
-!                        processor to the east, so the halos on the western
-!                        side are filled.  TO_ALL is the default if omitted.
-!  (in)      stagger - An optional flag, which may be one of A_GRID, BGRID_NE,
-!                      or CGRID_NE, indicating where the two components of the
-!                      vector are discretized.  Omitting stagger is the same as
-!                      setting it to CGRID_NE.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
+  ! Local variables
   integer :: stagger_local
   integer :: dirflag
 
@@ -1267,29 +1002,7 @@ subroutine create_vector_group_pass_3d(group, u_cmpt, v_cmpt, MOM_dom, direction
   integer,      optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                     !! started then stopped to time this routine.
 
-! Arguments:
-!  (inout)   group - The data type that store information for group update.
-!                    This data will be used in do_group_pass.
-!  (inout)   u_cmpt - The nominal zonal (u) component of the vector pair which
-!                     is having its halos points exchanged.
-!  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-!  (in)      direction - An optional integer indicating which directions the
-!                        data should be sent.  It is TO_ALL or the sum of any of
-!                        TO_EAST, TO_WEST, TO_NORTH, and TO_SOUTH, possibly
-!                        plus SCALAR_PAIR if these are paired non-directional
-!                        scalars discretized at the typical vector component
-!                        locations.  For example, TO_EAST sends the data to the
-!                        processor to the east, so the halos on the western
-!                        side are filled.  TO_ALL is the default if omitted.
-!  (in)      stagger - An optional flag, which may be one of A_GRID, BGRID_NE,
-!                      or CGRID_NE, indicating where the two components of the
-!                      vector are discretized.  Omitting stagger is the same as
-!                      setting it to CGRID_NE.
-!  (in,opt)  halo - The size of the halo to update - the full halo by default.
-
+  ! Local variables
   integer :: stagger_local
   integer :: dirflag
 
@@ -1328,11 +1041,6 @@ subroutine do_group_pass(group, MOM_dom, clock)
                                                     !! started then stopped to time this routine.
   real :: d_type
 
-! Arguments:
-!  (inout)   group - The data type that store information for group update.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-
   if (present(clock)) then ; if (clock>0) call cpu_clock_begin(clock) ; endif
 
   call mpp_do_group_update(group, MOM_dom%mpp_domain, d_type)
@@ -1354,11 +1062,6 @@ subroutine start_group_pass(group, MOM_dom, clock)
 
   real                                 :: d_type
 
-! Arguments:
-!  (inout)   group - The data type that store information for group update.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
-
   if (present(clock)) then ; if (clock>0) call cpu_clock_begin(clock) ; endif
 
   call mpp_start_group_update(group, MOM_dom%mpp_domain, d_type)
@@ -1378,11 +1081,6 @@ subroutine complete_group_pass(group, MOM_dom, clock)
   integer,     optional, intent(in)    :: clock    !< The handle for a cpu time clock that should be
                                                    !! started then stopped to time this routine.
   real                                 :: d_type
-
-! Arguments:
-!  (inout)   group - The data type that store information for group update.
-!  (in)      MOM_dom - The MOM_domain_type containing the mpp_domain needed to
-!                      determine where data should be sent.
 
   if (present(clock)) then ; if (clock>0) call cpu_clock_begin(clock) ; endif
 
@@ -1430,26 +1128,7 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
   character(len=*),      optional, intent(in)    :: param_suffix !< A suffix to apply to
                                                                  !! layout-specific parameters.
 
-
-! Arguments: MOM_dom - A pointer to the MOM_domain_type being defined here.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in,opt)  symmetric - If present, this specifies whether this domain
-!                        is symmetric, regardless of whether the macro
-!                        SYMMETRIC_MEMORY_ is defined.
-!  (in,opt)  static_memory - If present and true, this domain type is set up for
-!                            static memory and error checking of various input
-!                            values is performed against those in the input file.
-!  (in,opt)  NIHALO, NJHALO - Default halo sizes, required with static memory.
-!  (in,opt)  NIGLOBAL, NJGLOBAL - Total domain sizes, required with static memory.
-!  (in,opt)  NIPROC, NJPROC - Processor counts, required with static memory.
-!  (in,opt)  min_halo - If present, this sets the minimum halo size for this
-!                       domain in the i- and j- directions, and returns the
-!                       actual halo size used.
-!  (in,opt)  domain_name - A name for this domain, "MOM" if missing.
-!  (in,opt)  include_name - A name for model's include file, "MOM_memory.h" if missing.
-!  (in,opt)  param_suffix - A suffix to apply to layout-specific parameters.
-
+  ! Local variables
   integer, dimension(2) :: layout = (/ 1, 1 /)
   integer, dimension(2) :: io_layout = (/ 0, 0 /)
   integer, dimension(4) :: global_indices

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -10,115 +10,153 @@ implicit none ; private
 
 public create_dyn_horgrid, destroy_dyn_horgrid, set_derived_dyn_horgrid
 
+!> Describes the horizontal ocean grid with only dynamic memory arrays
 type, public :: dyn_horgrid_type
-  type(MOM_domain_type), pointer :: Domain => NULL()
-  type(MOM_domain_type), pointer :: Domain_aux => NULL() ! A non-symmetric auxiliary domain type.
+  type(MOM_domain_type), pointer :: Domain => NULL() !< Ocean model domain
+  type(MOM_domain_type), pointer :: Domain_aux => NULL() !< A non-symmetric auxiliary domain type.
+  type(hor_index_type) :: HI !< Horizontal index ranges
 
-  ! These elements can be copied from a provided hor_index_type.
-  type(hor_index_type)  :: HI   ! Make this a pointer?
-  integer :: isc, iec, jsc, jec ! The range of the computational domain indices
-  integer :: isd, ied, jsd, jed ! and data domain indices at tracer cell centers.
-  integer :: isg, ieg, jsg, jeg ! The range of the global domain tracer cell indices.
-  integer :: IscB, IecB, JscB, JecB ! The range of the computational domain indices
-  integer :: IsdB, IedB, JsdB, JedB ! and data domain indices at tracer cell vertices.
-  integer :: IsgB, IegB, JsgB, JegB ! The range of the global domain vertex indices.
-  integer :: isd_global         ! The values of isd and jsd in the global
-  integer :: jsd_global         ! (decomposition invariant) index space.
-  integer :: idg_offset         ! The offset between the corresponding global
-  integer :: jdg_offset         ! and local array indices.
-  logical :: symmetric          ! True if symmetric memory is used.
+  integer :: isc !< The start i-index of cell centers within the computational domain
+  integer :: iec !< The end i-index of cell centers within the computational domain
+  integer :: jsc !< The start j-index of cell centers within the computational domain
+  integer :: jec !< The end j-index of cell centers within the computational domain
 
-  logical :: nonblocking_updates  ! If true, non-blocking halo updates are
-                                  ! allowed.  The default is .false. (for now).
-  integer :: first_direction ! An integer that indicates which direction is
-                             ! to be updated first in directionally split
-                             ! parts of the calculation.  This can be altered
-                             ! during the course of the run via calls to
-                             ! set_first_direction.
+  integer :: isd !< The start i-index of cell centers within the data domain
+  integer :: ied !< The end i-index of cell centers within the data domain
+  integer :: jsd !< The start j-index of cell centers within the data domain
+  integer :: jed !< The end j-index of cell centers within the data domain
 
-  real, allocatable, dimension(:,:) :: &
-    mask2dT, &   ! 0 for land points and 1 for ocean points on the h-grid. Nd.
-    geoLatT, & ! The geographic latitude at q points in degrees of latitude or m.
-    geoLonT, & ! The geographic longitude at q points in degrees of longitude or m.
-    dxT, IdxT, & ! dxT is delta x at h points, in m, and IdxT is 1/dxT in m-1.
-    dyT, IdyT, & ! dyT is delta y at h points, in m, and IdyT is 1/dyT in m-1.
-    areaT, &     ! areaT is the area of an h-cell, in m2.
-    IareaT, &    ! IareaT = 1/areaT, in m-2.
-    sin_rot, &   ! The sine and cosine of the angular rotation between the local
-    cos_rot      ! model grid's northward and the true northward directions.
+  integer :: isg !< The start i-index of cell centers within the global domain
+  integer :: ieg !< The end i-index of cell centers within the global domain
+  integer :: jsg !< The start j-index of cell centers within the global domain
+  integer :: jeg !< The end j-index of cell centers within the global domain
 
-  real, allocatable, dimension(:,:) :: &
-    mask2dCu, &  ! 0 for boundary points and 1 for ocean points on the u grid.  Nondim.
-    geoLatCu, &  ! The geographic latitude at u points in degrees of latitude or m.
-    geoLonCu, &  ! The geographic longitude at u points in degrees of longitude or m.
-    dxCu, IdxCu, & ! dxCu is delta x at u points, in m, and IdxCu is 1/dxCu in m-1.
-    dyCu, IdyCu, & ! dyCu is delta y at u points, in m, and IdyCu is 1/dyCu in m-1.
-    dy_Cu, &     ! The unblocked lengths of the u-faces of the h-cell in m.
-    IareaCu, &   ! The masked inverse areas of u-grid cells in m2.
-    areaCu       ! The areas of the u-grid cells in m2.
+  integer :: IscB !< The start i-index of cell vertices within the computational domain
+  integer :: IecB !< The end i-index of cell vertices within the computational domain
+  integer :: JscB !< The start j-index of cell vertices within the computational domain
+  integer :: JecB !< The end j-index of cell vertices within the computational domain
 
-  real, allocatable, dimension(:,:) :: &
-    mask2dCv, &  ! 0 for boundary points and 1 for ocean points on the v grid.  Nondim.
-    geoLatCv, &  ! The geographic latitude at v points in degrees of latitude or m.
-    geoLonCv, &  !  The geographic longitude at v points in degrees of longitude or m.
-    dxCv, IdxCv, & ! dxCv is delta x at v points, in m, and IdxCv is 1/dxCv in m-1.
-    dyCv, IdyCv, & ! dyCv is delta y at v points, in m, and IdyCv is 1/dyCv in m-1.
-    dx_Cv, &     ! The unblocked lengths of the v-faces of the h-cell in m.
-    IareaCv, &   ! The masked inverse areas of v-grid cells in m2.
-    areaCv       ! The areas of the v-grid cells in m2.
+  integer :: IsdB !< The start i-index of cell vertices within the data domain
+  integer :: IedB !< The end i-index of cell vertices within the data domain
+  integer :: JsdB !< The start j-index of cell vertices within the data domain
+  integer :: JedB !< The end j-index of cell vertices within the data domain
+
+  integer :: IsgB !< The start i-index of cell vertices within the global domain
+  integer :: IegB !< The end i-index of cell vertices within the global domain
+  integer :: JsgB !< The start j-index of cell vertices within the global domain
+  integer :: JegB !< The end j-index of cell vertices within the global domain
+
+  integer :: isd_global !< The value of isd in the global index space (decompoistion invariant).
+  integer :: jsd_global !< The value of isd in the global index space (decompoistion invariant).
+  integer :: idg_offset !< The offset between the corresponding global and local i-indices.
+  integer :: jdg_offset !< The offset between the corresponding global and local j-indices.
+  logical :: symmetric  !< True if symmetric memory is used.
+
+  logical :: nonblocking_updates  !< If true, non-blocking halo updates are
+                                  !! allowed.  The default is .false. (for now).
+  integer :: first_direction !< An integer that indicates which direction is to be updated first in
+                             !! directionally split parts of the calculation.  This can be altered
+                             !! during the course of the run via calls to set_first_direction.
 
   real, allocatable, dimension(:,:) :: &
-    mask2dBu, &  ! 0 for boundary points and 1 for ocean points on the q grid.  Nondim.
-    geoLatBu, &  ! The geographic latitude at q points in degrees of latitude or m.
-    geoLonBu, &  ! The geographic longitude at q points in degrees of longitude or m.
-    dxBu, IdxBu, & ! dxBu is delta x at q points, in m, and IdxBu is 1/dxBu in m-1.
-    dyBu, IdyBu, & ! dyBu is delta y at q points, in m, and IdyBu is 1/dyBu in m-1.
-    areaBu, &    ! areaBu is the area of a q-cell, in m2
-    IareaBu      ! IareaBu = 1/areaBu in m-2.
+    mask2dT, &   !< 0 for land points and 1 for ocean points on the h-grid. Nd.
+    geoLatT, &   !< The geographic latitude at q points in degrees of latitude or m.
+    geoLonT, &   !< The geographic longitude at q points in degrees of longitude or m.
+    dxT, &       !< dxT is delta x at h points, in m.
+    IdxT, &      !< 1/dxT in m-1.
+    dyT, &       !< dyT is delta y at h points, in m, and IdyT is 1/dyT in m-1.
+    IdyT, &      !< dyT is delta y at h points, in m, and IdyT is 1/dyT in m-1.
+    areaT, &     !< The area of an h-cell, in m2.
+    IareaT       !< 1/areaT, in m-2.
+  real, allocatable, dimension(:,:) :: sin_rot
+                 !< The sine of the angular rotation between the local model grid's northward
+                 !! and the true northward directions.
+  real, allocatable, dimension(:,:) :: cos_rot
+                 !< The cosine of the angular rotation between the local model grid's northward
+                 !! and the true northward directions.
 
-  real, pointer, dimension(:) :: &
-    gridLatT => NULL(), gridLatB => NULL() ! The latitude of T or B points for
-                        ! the purpose of labeling the output axes.
-                        ! On many grids these are the same as geoLatT & geoLatBu.
-  real, pointer, dimension(:) :: &
-    gridLonT => NULL(), gridLonB => NULL() ! The longitude of T or B points for
-                        ! the purpose of labeling the output axes.
-                        ! On many grids these are the same as geoLonT & geoLonBu.
+  real, allocatable, dimension(:,:) :: &
+    mask2dCu, &  !< 0 for boundary points and 1 for ocean points on the u grid.  Nondim.
+    geoLatCu, &  !< The geographic latitude at u points in degrees of latitude or m.
+    geoLonCu, &  !< The geographic longitude at u points in degrees of longitude or m.
+    dxCu, &      !< dxCu is delta x at u points, in m.
+    IdxCu, &     !< 1/dxCu in m-1.
+    dyCu, &      !< dyCu is delta y at u points, in m.
+    IdyCu, &     !< 1/dyCu in m-1.
+    dy_Cu, &     !< The unblocked lengths of the u-faces of the h-cell in m.
+    IareaCu, &   !< The masked inverse areas of u-grid cells in m2.
+    areaCu       !< The areas of the u-grid cells in m2.
+
+  real, allocatable, dimension(:,:) :: &
+    mask2dCv, &  !< 0 for boundary points and 1 for ocean points on the v grid.  Nondim.
+    geoLatCv, &  !< The geographic latitude at v points in degrees of latitude or m.
+    geoLonCv, &  !< The geographic longitude at v points in degrees of longitude or m.
+    dxCv, &      !< dxCv is delta x at v points, in m.
+    IdxCv, &     !< 1/dxCv in m-1.
+    dyCv, &      !< dyCv is delta y at v points, in m.
+    IdyCv, &     !< 1/dyCv in m-1.
+    dx_Cv, &     !< The unblocked lengths of the v-faces of the h-cell in m.
+    IareaCv, &   !< The masked inverse areas of v-grid cells in m2.
+    areaCv       !< The areas of the v-grid cells in m2.
+
+  real, allocatable, dimension(:,:) :: &
+    mask2dBu, &  !< 0 for boundary points and 1 for ocean points on the q grid.  Nondim.
+    geoLatBu, &  !< The geographic latitude at q points in degrees of latitude or m.
+    geoLonBu, &  !< The geographic longitude at q points in degrees of longitude or m.
+    dxBu, &      !< dxBu is delta x at q points, in m.
+    IdxBu, &     !< 1/dxBu in m-1.
+    dyBu, &      !< dyBu is delta y at q points, in m.
+    IdyBu, &     !< 1/dyBu in m-1.
+    areaBu, &    !< areaBu is the area of a q-cell, in m2
+    IareaBu      !< IareaBu = 1/areaBu in m-2.
+
+  real, pointer, dimension(:) :: gridLatT => NULL()
+        !< The latitude of T points for the purpose of labeling the output axes.
+        !! On many grids this is the same as geoLatT.
+  real, pointer, dimension(:) :: gridLatB => NULL()
+        !< The latitude of B points for the purpose of labeling the output axes.
+        !! On many grids this is the same as geoLatBu.
+  real, pointer, dimension(:) :: gridLonT => NULL()
+        !< The longitude of T points for the purpose of labeling the output axes.
+        !! On many grids this is the same as geoLonT.
+  real, pointer, dimension(:) :: gridLonB => NULL()
+        !< The longitude of B points for the purpose of labeling the output axes.
+        !! On many grids this is the same as geoLonBu.
   character(len=40) :: &
-    x_axis_units, &     !   The units that are used in labeling the coordinate
-    y_axis_units        ! axes.  Except on a Cartesian grid, these are usually
-                        ! some variant of "degrees".
+    x_axis_units, &     !< The units that are used in labeling the x coordinate axes.
+    y_axis_units        !< The units that are used in labeling the y coordinate axes.
+    ! Except on a Cartesian grid, these are usually  some variant of "degrees".
 
   real, allocatable, dimension(:,:) :: &
-    bathyT        ! Ocean bottom depth at tracer points, in m.
+    bathyT        !< Ocean bottom depth at tracer points, in m.
 
-  logical :: bathymetry_at_vel  ! If true, there are separate values for the
-                  ! basin depths at velocity points.  Otherwise the effects of
-                  ! of topography are entirely determined from thickness points.
+  logical :: bathymetry_at_vel  !< If true, there are separate values for the
+                  !! basin depths at velocity points.  Otherwise the effects of
+                  !! of topography are entirely determined from thickness points.
   real, allocatable, dimension(:,:) :: &
-    Dblock_u, &   ! Topographic depths at u-points at which the flow is blocked
-    Dopen_u       ! (Dblock_u) and open at width dy_Cu (Dopen_u), both in m.
+    Dblock_u, &   !< Topographic depths at u-points at which the flow is blocked, in m.
+    Dopen_u       !< Topographic depths at u-points at which the flow is open at width dy_Cu, in m.
   real, allocatable, dimension(:,:) :: &
-    Dblock_v, &   ! Topographic depths at v-points at which the flow is blocked
-    Dopen_v       ! (Dblock_v) and open at width dx_Cv (Dopen_v), both in m.
+    Dblock_v, &   !< Topographic depths at v-points at which the flow is blocked, in m.
+    Dopen_v       !< Topographic depths at v-points at which the flow is open at width dx_Cv, in m.
   real, allocatable, dimension(:,:) :: &
-    CoriolisBu    ! The Coriolis parameter at corner points, in s-1.
+    CoriolisBu    !< The Coriolis parameter at corner points, in s-1.
   real, allocatable, dimension(:,:) :: &
-    dF_dx, dF_dy  ! Derivatives of f (Coriolis parameter) at h-points, in s-1 m-1.
+    df_dx, &      !< Derivative d/dx f (Coriolis parameter) at h-points, in s-1 m-1.
+    df_dy         !< Derivative d/dy f (Coriolis parameter) at h-points, in s-1 m-1.
 
   ! These variables are global sums that are useful for 1-d diagnostics
-  real :: areaT_global  ! Global sum of h-cell area in m2
-  real :: IareaT_global ! Global sum of inverse h-cell area (1/areaT_global)
-                        ! in m2
+  real :: areaT_global  !< Global sum of h-cell area in m2
+  real :: IareaT_global !< Global sum of inverse h-cell area (1/areaT_global) in m2
 
   ! These parameters are run-time parameters that are used during some
   ! initialization routines (but not all)
-  real :: south_lat     ! The latitude (or y-coordinate) of the first v-line
-  real :: west_lon      ! The longitude (or x-coordinate) of the first u-line
-  real :: len_lat = 0.  ! The latitudinal (or y-coord) extent of physical domain
-  real :: len_lon = 0.  ! The longitudinal (or x-coord) extent of physical domain
-  real :: Rad_Earth = 6.378e6 ! The radius of the planet in meters.
-  real :: max_depth     ! The maximum depth of the ocean in meters.
+  real :: south_lat     !< The latitude (or y-coordinate) of the first v-line
+  real :: west_lon      !< The longitude (or x-coordinate) of the first u-line
+  real :: len_lat = 0.  !< The latitudinal (or y-coord) extent of physical domain
+  real :: len_lon = 0.  !< The longitudinal (or x-coord) extent of physical domain
+  real :: Rad_Earth = 6.378e6 !< The radius of the planet in meters.
+  real :: max_depth     !< The maximum depth of the ocean in meters.
 end type dyn_horgrid_type
 
 contains

--- a/src/framework/MOM_hor_index.F90
+++ b/src/framework/MOM_hor_index.F90
@@ -48,6 +48,7 @@ type, public :: hor_index_type
   logical :: symmetric  !< True if symmetric memory is used.
 end type hor_index_type
 
+!> Copy the contents of one horizontal index type into another
 interface assignment(=); module procedure HIT_assign ; end interface
 
 contains

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -40,7 +40,7 @@ implicit none ; private
 
 public :: horiz_interp_and_extrap_tracer, myStats
 
-character(len=40)  :: mdl = "MOM_horizontal_regridding" ! This module's name.
+! character(len=40)  :: mdl = "MOM_horizontal_regridding" ! This module's name.
 
 !> Fill grid edges
 interface fill_boundaries
@@ -53,8 +53,6 @@ interface horiz_interp_and_extrap_tracer
    module procedure horiz_interp_and_extrap_tracer_record
    module procedure horiz_interp_and_extrap_tracer_fms_id
 end interface
-
-real, parameter :: epsln=1.e-10
 
 contains
 

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -63,11 +63,13 @@ type, public :: vardesc
                                            !! convert from intensive to extensive
 end type vardesc
 
+!> Indicate whether a file exists, perhaps with domain decomposition
 interface file_exists
   module procedure file_exist
   module procedure MOM_file_exists
 end interface
 
+!> Read a data field from a file
 interface MOM_read_data
   module procedure MOM_read_data_4d
   module procedure MOM_read_data_3d
@@ -75,6 +77,7 @@ interface MOM_read_data
   module procedure MOM_read_data_1d
 end interface
 
+!> Read a pair of data fields representing the two components of a vector from a file
 interface MOM_read_vector
   module procedure MOM_read_vector_3d
   module procedure MOM_read_vector_2d

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -66,66 +66,73 @@ public restart_init, restart_end, restore_state, register_restart_field
 public save_restart, query_initialized, restart_init_end, vardesc
 public restart_files_exist, determine_is_new_run, is_new_run
 
+!> A type for making arrays of pointers to 4-d arrays
 type p4d
-  real, dimension(:,:,:,:), pointer :: p => NULL()
+  real, dimension(:,:,:,:), pointer :: p => NULL() !< A pointer to a 4d array
 end type p4d
 
+!> A type for making arrays of pointers to 3-d arrays
 type p3d
-  real, dimension(:,:,:), pointer :: p => NULL()
+  real, dimension(:,:,:), pointer :: p => NULL() !< A pointer to a 3d array
 end type p3d
 
+!> A type for making arrays of pointers to 2-d arrays
 type p2d
-  real, dimension(:,:), pointer :: p => NULL()
+  real, dimension(:,:), pointer :: p => NULL() !< A pointer to a 2d array
 end type p2d
 
+!> A type for making arrays of pointers to 1-d arrays
 type p1d
-  real, dimension(:), pointer :: p => NULL()
+  real, dimension(:), pointer :: p => NULL() !< A pointer to a 1d array
 end type p1d
 
+!> A type for making arrays of pointers to scalars
 type p0d
-  real, pointer :: p => NULL()
+  real, pointer :: p => NULL() !< A pointer to a scalar
 end type p0d
 
+!> A structure with information about a single restart field
 type field_restart
-  type(vardesc) :: vars         ! Descriptions of the fields that
-                                ! are to be read from or  written
-                                ! to the restart file.
-  logical :: mand_var           ! If .true. the run will abort if this
-                                ! field is not successfully read
-                                ! from the restart file.
-  logical :: initialized        ! .true. if this field has been read
-                                ! from the restart file.
-  character(len=32) :: var_name ! A name by which a variable may be queried.
+  type(vardesc) :: vars         !< Description of a field that is to be read from or written
+                                !! to the restart file.
+  logical :: mand_var           !< If .true. the run will abort if this field is not successfully
+                                !! read from the restart file.
+  logical :: initialized        !< .true. if this field has been read from the restart file.
+  character(len=32) :: var_name !< A name by which a variable may be queried.
 end type field_restart
 
+!> A restart registry and the control structure for restarts
 type, public :: MOM_restart_CS ; private
-  logical :: restart    ! restart is set to .true. if the run has been started
-                        ! from a full restart file.  Otherwise some fields must
-                        ! be initialized approximately.
-  integer :: novars = 0 ! The number of restart fields that have been registered.
-  logical :: parallel_restartfiles  ! If true, each PE writes its own restart file,
-                                    ! otherwise they are combined internally.
-  logical :: large_file_support     ! If true, NetCDF 3.6 or later is being used
-                                    ! and large-file-support is enabled.
-  logical :: new_run                ! If true, the input filenames and restart file
-                                    ! existence will result in a new run that is not
-                                    ! initializedfrom restart files.
-  logical :: new_run_set = .false.  ! If true, new_run has been determined for this restart_CS.
-  logical :: checksum_required      ! If true, require the restart checksums to match and error out otherwise.
-                                    ! Users may want to avoid this comparison if for example the restarts are
-                                    ! made from a run with a different mask_table than the current run,
-                                    ! in which case the checksums will not match and cause crash.
-  character(len=240) :: restartfile ! The name or name root for MOM restart files.
+  logical :: restart    !< restart is set to .true. if the run has been started from a full restart
+                        !! file.  Otherwise some fields must be initialized approximately.
+  integer :: novars = 0 !< The number of restart fields that have been registered.
+  logical :: parallel_restartfiles  !< If true, each PE writes its own restart file,
+                                    !! otherwise they are combined internally.
+  logical :: large_file_support     !< If true, NetCDF 3.6 or later is being used
+                                    !! and large-file-support is enabled.
+  logical :: new_run                !< If true, the input filenames and restart file existence will
+                                    !! result in a new run that is not initialized from restart files.
+  logical :: new_run_set = .false.  !< If true, new_run has been determined for this restart_CS.
+  logical :: checksum_required      !< If true, require the restart checksums to match and error out otherwise.
+                                    !! Users may want to avoid this comparison if for example the restarts are
+                                    !! made from a run with a different mask_table than the current run,
+                                    !! in which case the checksums will not match and cause crash.
+  character(len=240) :: restartfile !< The name or name root for MOM restart files.
 
+  !> An array of descriptions of the registered fields
   type(field_restart), pointer :: restart_field(:) => NULL()
+
+  !>@{ Pointers to the fields that have been registered for restarts
   type(p0d), pointer :: var_ptr0d(:) => NULL()
   type(p1d), pointer :: var_ptr1d(:) => NULL()
   type(p2d), pointer :: var_ptr2d(:) => NULL()
   type(p3d), pointer :: var_ptr3d(:) => NULL()
   type(p4d), pointer :: var_ptr4d(:) => NULL()
-  integer :: max_fields
+  !!@}
+  integer :: max_fields !< The maximum number of restart fields
 end type MOM_restart_CS
 
+!> Register fields for restarts
 interface register_restart_field
   module procedure register_restart_field_ptr4d, register_restart_field_4d
   module procedure register_restart_field_ptr3d, register_restart_field_3d
@@ -134,6 +141,7 @@ interface register_restart_field
   module procedure register_restart_field_ptr0d, register_restart_field_0d
 end interface
 
+!> Indicate whether a field has been read from a restart file
 interface query_initialized
   module procedure query_initialized_name
   module procedure query_initialized_0d, query_initialized_0d_name
@@ -443,10 +451,7 @@ function query_initialized_name(name, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine returns .true. if the field referred to by name has
 ! initialized from a restart file, and .false. otherwise.
-!
-! Arguments: name - A pointer to the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m,n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -480,10 +485,7 @@ function query_initialized_0d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr has
 ! been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m,n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -510,10 +512,7 @@ function query_initialized_1d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr has
 ! been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m,n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -541,10 +540,7 @@ function query_initialized_2d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr has
 ! been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m,n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -572,10 +568,7 @@ function query_initialized_3d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr has
 ! been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m,n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -603,10 +596,7 @@ function query_initialized_4d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr has
 ! been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m,n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -635,11 +625,7 @@ function query_initialized_0d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr or with the
 ! specified variable name has been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      name - The name of the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m,n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -675,11 +661,7 @@ function query_initialized_1d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr or with the
 ! specified variable name has been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      name - The name of the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m,n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -715,11 +697,7 @@ function query_initialized_2d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr or with the
 ! specified variable name has been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      name - The name of the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m,n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -755,11 +733,7 @@ function query_initialized_3d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr or with the
 ! specified variable name has been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      name - The name of the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m, n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -795,11 +769,7 @@ function query_initialized_4d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 !   This subroutine tests whether the field pointed to by f_ptr or with the
 ! specified variable name has been initialized from a restart file.
-!
-! Arguments: f_ptr - A pointer to the field that is being queried.
-!  (in)      name - The name of the field that is being queried.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
+
   integer :: m, n
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
@@ -837,16 +807,8 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV)
                                                   !! to the restart file names.
   character(len=*), optional, intent(in) :: filename !< A filename that overrides the name in CS%restartfile.
   type(verticalGrid_type), optional, intent(in) :: GV   !< The ocean's vertical grid structure
-! Arguments: directory - The directory where the restart file goes.
-!  (in)      time - The time of this restart file.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 restart_init.
-!  (in, opt) time_stamped - If true, the restart file names include
-!                           a unique time stamp.  The default is false.
-!  (in, opt) filename - A filename that overrides the name in CS%restartfile.
-!
-!  (in, opt) GV - The ocean's vertical grid structure.
+
+  ! Local variables
   type(vardesc) :: vars(CS%max_fields)  ! Descriptions of the fields that
                                         ! are to be read from the restart file.
   type(fieldtype) :: fields(CS%max_fields) !
@@ -1051,16 +1013,7 @@ subroutine restore_state(filename, directory, day, G, CS)
 !  generated files.  All restart variables are read from the first
 !  file in the input filename list in which they are found.
 
-! Arguments: filename - A series of space delimited strings, each of
-!                       which is either "r" or the name of a file
-!                       from which the run is to be restarted.
-!  (in)      directory - The directory where the restart or save
-!                        files should be found.
-!  (out)     day - The time of the restarted run.
-!  (in)      G - The ocean's grid structure.
-!  (in/out)  CS - The control structure returned by a previous call to
-!                 restart_init.
-
+  ! Local variables
   character(len=200) :: filepath  ! The path (dir/file) to the file being opened.
   character(len=80) :: fname     ! The name of the current file.
   character(len=8)  :: suffix     ! A suffix (like "_2") that is added to any
@@ -1430,15 +1383,7 @@ function open_restart_units(filename, directory, G, CS, units, file_paths, &
 !  generated files.  All restart variables are read from the first
 !  file in the input filename list in which they are found.
 
-! Arguments: filename - A series of space delimited strings, each of
-!                       which is either "r" or the name of a file
-!                       from which the run is to be restarted.
-!  (in)      directory - The directory where the restart or save
-!                        files should be found.
-!  (in)      G - The ocean's grid structure.
-!  (in/out)  CS - The control structure returned by a previous call to
-!                 restart_init.
-
+  ! Local variables
   character(len=200) :: filepath  ! The path (dir/file) to the file being opened.
   character(len=80) :: fname      ! The name of the current file.
   character(len=8)  :: suffix     ! A suffix (like "_2") that is added to any
@@ -1570,13 +1515,7 @@ subroutine restart_init(param_file, CS, restart_root)
                          intent(in) :: restart_root !< A filename root that overrides the value
                                           !! set by RESTARTFILE to enable the use of this module by
                                           !! other components than MOM.
-! Arguments: param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module.
-!  (in,opt)  restart_root - A filename root that overrides the value in
-!                           RESTARTFILE.  This will enable the use of this
-!                           module by other components.
+
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_restart"   ! This module's name.
@@ -1651,8 +1590,7 @@ end subroutine restart_end
 
 subroutine restart_error(CS)
   type(MOM_restart_CS),  pointer    :: CS !< A pointer to a MOM_restart_CS object
-! Arguments: CS - A pointer that is set to point to the control structure
-!                 for this module.  (Intent in.)
+
   character(len=16)  :: num  ! String for error messages
 
   if (CS%novars > CS%max_fields) then

--- a/src/framework/MOM_spatial_means.F90
+++ b/src/framework/MOM_spatial_means.F90
@@ -170,14 +170,7 @@ subroutine global_i_mean(array, i_mean, G, mask)
   real, dimension(SZI_(G),SZJ_(G)), &
                           optional, intent(in)    :: mask !< An array used for weighting the i-mean
 
-!    This subroutine determines the global mean of a field along rows of
-!  constant i, returning it in a 1-d array using the local indexing.
-
-! Arguments: array - The 2-d array whose i-mean is to be taken.
-!  (out)     i_mean - Global mean of array along its i-axis.
-!  (in)      G - The ocean's grid structure.
-!  (in)      mask - An array used for weighting the i-mean.
-
+  ! Local variables
   type(EFP_type), allocatable, dimension(:) :: asum, mask_sum
   real :: mask_sum_r
   integer :: is, ie, js, je, idg_off, jdg_off
@@ -251,14 +244,7 @@ subroutine global_j_mean(array, j_mean, G, mask)
   real, dimension(SZI_(G),SZJ_(G)), &
                           optional, intent(in)    :: mask !< An array used for weighting the j-mean
 
-!    This subroutine determines the global mean of a field along rows of
-!  constant j, returning it in a 1-d array using the local indexing.
-
-! Arguments: array - The 2-d array whose j-mean is to be taken.
-!  (out)     j_mean - Global mean of array along its j-axis.
-!  (in)      G - The ocean's grid structure.
-!  (in)      mask - An array used for weighting the j-mean.
-
+  ! Local variables
   type(EFP_type), allocatable, dimension(:) :: asum, mask_sum
   real :: mask_sum_r
   integer :: is, ie, js, je, idg_off, jdg_off

--- a/src/framework/MOM_write_cputime.F90
+++ b/src/framework/MOM_write_cputime.F90
@@ -29,22 +29,23 @@ public write_cputime, MOM_write_cputime_init, write_cputime_start_clock
 integer :: CLOCKS_PER_SEC = 1000
 integer :: MAX_TICKS      = 1000
 
+!> A control structure that regulates the writing of CPU time
 type, public :: write_cputime_CS ; private
-  real :: maxcpu                !   The maximum amount of cpu time per processor
-                                ! for which MOM should run before saving a restart
-                                ! file and quiting with a return value that
-                                ! indicates that further execution is required to
-                                ! complete the simulation, in wall-clock seconds.
-  type(time_type) :: Start_time ! The start time of the simulation.
-                                ! Start_time is set in MOM_initialization.F90
-  real :: startup_cputime       ! The CPU time used in the startup phase of the model.
-  real :: prev_cputime = 0.0    ! The last measured CPU time.
-  real :: dn_dcpu_min = -1.0    ! The minimum derivative of timestep with CPU time.
-  real :: cputime2 = 0.0        ! The accumulated cpu time.
-  integer :: previous_calls = 0 ! The number of times write_CPUtime has been called.
-  integer :: prev_n = 0         ! The value of n from the last call.
-  integer :: fileCPU_ascii      ! The unit number of the CPU time file.
-  character(len=200) :: CPUfile ! The name of the CPU time file.
+  real :: maxcpu                !<   The maximum amount of cpu time per processor
+                                !! for which MOM should run before saving a restart
+                                !! file and quiting with a return value that
+                                !! indicates that further execution is required to
+                                !! complete the simulation, in wall-clock seconds.
+  type(time_type) :: Start_time !< The start time of the simulation.
+                                !! Start_time is set in MOM_initialization.F90
+  real :: startup_cputime       !< The CPU time used in the startup phase of the model.
+  real :: prev_cputime = 0.0    !< The last measured CPU time.
+  real :: dn_dcpu_min = -1.0    !< The minimum derivative of timestep with CPU time.
+  real :: cputime2 = 0.0        !< The accumulated cpu time.
+  integer :: previous_calls = 0 !< The number of times write_CPUtime has been called.
+  integer :: prev_n = 0         !< The value of n from the last call.
+  integer :: fileCPU_ascii      !< The unit number of the CPU time file.
+  character(len=200) :: CPUfile !< The name of the CPU time file.
 end type write_cputime_CS
 
 contains
@@ -53,8 +54,6 @@ contains
 subroutine write_cputime_start_clock(CS)
   type(write_cputime_CS), pointer :: CS !< The control structure set up by a previous
                                         !! call to MOM_write_cputime_init.
-! Argument:  CS - A pointer that is set to point to the control structure
-!                 for this module
   integer :: new_cputime   ! The CPU time returned by SYSTEM_CLOCK
   if (.not.associated(CS)) allocate(CS)
 
@@ -69,12 +68,8 @@ subroutine MOM_write_cputime_init(param_file, directory, Input_start_time, CS)
   type(time_type),        intent(in) :: Input_start_time !< The start model time of the simulation.
   type(write_cputime_CS), pointer    :: CS         !< A pointer that may be set to point to the
                                                    !! control structure for this module.
-! Arguments: param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      directory - The directory where the energy file goes.
-!  (in)      Input_start_time - The start time of the simulation.
-!  (in/out)  CS - A pointer that may be set to point to the control structure
-!                 for this module.
+
+  ! Local variables
   integer :: new_cputime   ! The CPU time returned by SYSTEM_CLOCK
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -119,17 +114,8 @@ subroutine write_cputime(day, n, nmax, CS)
                                               !! that the simulation will not run out of CPU time.
   type(write_cputime_CS), pointer       :: CS !< The control structure set up by a previous
                                               !! call to MOM_write_cputime_init.
-!  This subroutine assesses how much CPU time the model has
-! taken and determines how long the model should be run before it
-! saves a restart file and stops itself.
 
-! Arguments: day - The current model time.
-!  (in)      n - The time step number of the current execution.
-!  (out)     nmax - The number of iterations after which to stop so
-!                   that the simulation will not run out of CPU time.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 MOM_write_cputime_init.
+  ! Local variables
   real    :: d_cputime     ! The change in CPU time since the last call
                            ! this subroutine.
   integer :: new_cputime   ! The CPU time returned by SYSTEM_CLOCK

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -71,7 +71,7 @@ type, public :: ice_shelf_CS ; private
                                           !! The rest is private
   real ::   flux_factor = 1.0             !< A factor that can be used to turn off ice shelf
                                           !! melting (flux_factor = 0).
-  character(len=128) :: restart_output_dir = ' '
+  character(len=128) :: restart_output_dir = ' ' !< The directory in which to write restart files
   type(ice_shelf_state), pointer :: ISS => NULL() !< A structure with elements that describe
                                           !! the ice-shelf state
   type(ice_shelf_dyn_CS), pointer :: dCS => NULL() !< The control structure for the ice-shelf dynamics.
@@ -119,11 +119,12 @@ type, public :: ice_shelf_CS ; private
                             !! it is to estimate the gravitational driving force at the
                             !! shelf front(until we think of a better way to do it-
                             !! but any difference will be negligible)
-  logical :: calve_to_mask
-  real :: min_thickness_simple_calve ! min. ice shelf thickness criteria for calving
-  real :: T0, S0 ! temp/salt at ocean surface in the restoring region
-  real :: input_flux
-  real :: input_thickness
+  logical :: calve_to_mask  !< If true, calve any ice that passes outside of a masked area
+  real :: min_thickness_simple_calve !< min. ice shelf thickness criteria for calving
+  real :: T0                !< temperature at ocean surface in the restoring region, in degC
+  real :: S0                !< Salinity at ocean surface in the restoring region, in ppt.
+  real :: input_flux        !< Ice volume flux at an upstream open boundary, in m3 s-1.
+  real :: input_thickness   !< Ice thickness at an upstream open boundary, in m.
 
   type(time_type) :: Time                !< The component's time.
   type(EOS_type), pointer :: eqn_of_state => NULL() !< Type that indicates the
@@ -143,15 +144,16 @@ type, public :: ice_shelf_CS ; private
   logical :: constant_sea_level          !< if true, apply an evaporative, heat and salt
                                          !! fluxes. It will avoid large increase in sea level.
   real    :: cutoff_depth                !< depth above which melt is set to zero (>= 0).
-  real    :: lambda1, lambda2, lambda3   !< liquidus coeffs. Needed if find_salt_root = true
-  !>@{
-  ! Diagnostic handles
+  real    :: lambda1                     !< liquidus coeff., Needed if find_salt_root = true
+  real    :: lambda2                     !< liquidus coeff., Needed if find_salt_root = true
+  real    :: lambda3                     !< liquidus coeff., Needed if find_salt_root = true
+  !>@{ Diagnostic handles
   integer :: id_melt = -1, id_exch_vel_s = -1, id_exch_vel_t = -1, &
              id_tfreeze = -1, id_tfl_shelf = -1, &
              id_thermal_driving = -1, id_haline_driving = -1, &
              id_u_ml = -1, id_v_ml = -1, id_sbdry = -1, &
              id_h_shelf = -1, id_h_mask = -1, &
-!             id_surf_elev = -1, id_bathym = -1, &
+             id_surf_elev = -1, id_bathym = -1, &
              id_area_shelf_h = -1, &
              id_ustar_shelf = -1, id_shelf_mass = -1, id_mass_flux = -1
   !>@}
@@ -162,13 +164,15 @@ type, public :: ice_shelf_CS ; private
                           !! the ice shelf mass read from a file
 
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to control diagnostic output.
-  type(user_ice_shelf_CS), pointer :: user_CS => NULL()
+  type(user_ice_shelf_CS), pointer :: user_CS => NULL() !< A pointer to the control structure for
+                                  !! user-supplied modifications to the ice shelf code.
 
   logical :: debug                !< If true, write verbose checksums for debugging purposes
                                   !! and use reproducible sums
 end type ice_shelf_CS
 
-integer :: id_clock_shelf, id_clock_pass !< Clock for group pass calls
+integer :: id_clock_shelf !< CPU Clock for the ice shelf code
+integer :: id_clock_pass !< CPU Clock for group pass calls
 
 contains
 
@@ -1298,11 +1302,9 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  "A typical density of ice.", units="kg m-3", default=917.0)
 
     call get_param(param_file, mdl, "INPUT_FLUX_ICE_SHELF", CS%input_flux, &
-                 "volume flux at upstream boundary", &
-                 units="m2 s-1", default=0.)
+                 "volume flux at upstream boundary", units="m2 s-1", default=0.)
     call get_param(param_file, mdl, "INPUT_THICK_ICE_SHELF", CS%input_thickness, &
-                 "flux thickness at upstream boundary", &
-                 units="m", default=1000.)
+                 "flux thickness at upstream boundary", units="m", default=1000.)
   else
     ! This is here because of inconsistent defaults.  I don't know why.  RWH
     call get_param(param_file, mdl, "DENSITY_ICE", CS%density_ice, &

--- a/src/ice_shelf/user_shelf_init.F90
+++ b/src/ice_shelf/user_shelf_init.F90
@@ -18,16 +18,17 @@ implicit none ; private
 
 public USER_initialize_shelf_mass, USER_update_shelf_mass
 public USER_init_ice_thickness
-logical :: first_call = .true.
 
+!> The control structure for the user_ice_shelf module
 type, public :: user_ice_shelf_CS ; private
-  real :: Rho_ocean  ! The ocean's typical density, in kg m-3.
-  real :: max_draft  ! The maximum ocean draft of the ice shelf, in m.
-  real :: min_draft  ! The minimum ocean draft of the ice shelf, in m.
-  real :: flat_shelf_width ! The range over which the shelf is min_draft thick.
-  real :: shelf_slope_scale ! The range over which the shelf slopes.
-  real :: pos_shelf_edge_0
-  real :: shelf_speed
+  real :: Rho_ocean  !< The ocean's typical density, in kg m-3.
+  real :: max_draft  !< The maximum ocean draft of the ice shelf, in m.
+  real :: min_draft  !< The minimum ocean draft of the ice shelf, in m.
+  real :: flat_shelf_width !< The range over which the shelf is min_draft thick.
+  real :: shelf_slope_scale !< The range over which the shelf slopes.
+  real :: pos_shelf_edge_0 !< The x-position of the shelf edge at time 0, in km.
+  real :: shelf_speed  !< The ice shelf speed of translation, in km day-1
+  logical :: first_call = .true. !< If true, this module has not been called before.
 end type user_ice_shelf_CS
 
 contains
@@ -75,7 +76,8 @@ subroutine USER_initialize_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, 
   if (.not.associated(CS)) allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  if (first_call) call write_user_log(param_file)
+  if (CS%first_call) call write_user_log(param_file)
+  CS%first_call = .false.
   call get_param(param_file, mdl, "RHO_0", CS%Rho_ocean, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&
                  "calculate accelerations and the mass for conservation \n"//&
@@ -213,7 +215,6 @@ subroutine write_user_log(param_file)
   character(len=40)  :: mdl = "user_shelf_init" ! This module's name.
 
   call log_version(param_file, mdl, version, tagname)
-  first_call = .false.
 
 end subroutine write_user_log
 

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -64,20 +64,24 @@ type, public :: MEKE_CS ; private
   logical :: debug      !< If true, write out checksums of data for debugging
 
   ! Optional storage
-  real, dimension(:,:), allocatable :: del2MEKE ! Laplacian of MEKE, used for bi-harmonic diffusion.
+  real, dimension(:,:), allocatable :: del2MEKE !< Laplacian of MEKE, used for bi-harmonic diffusion.
 
-  ! Diagnostic handles
-  type(diag_ctrl), pointer :: diag !< A pointer to shared diagnostics data
+  type(diag_ctrl), pointer :: diag => NULL() !< A type that regulates diagnostics output
+  !>@{ Diagnostic handles
   integer :: id_MEKE = -1, id_Ue = -1, id_Kh = -1, id_src = -1
   integer :: id_Ub = -1, id_Ut = -1
   integer :: id_GM_src = -1, id_mom_src = -1, id_decay = -1
   integer :: id_KhMEKE_u = -1, id_KhMEKE_v = -1, id_Ku = -1
   integer :: id_Le = -1, id_gamma_b = -1, id_gamma_t = -1
   integer :: id_Lrhines = -1, id_Leady = -1
+  !!@}
 
   ! Infrastructure
   integer :: id_clock_pass !< Clock for group pass calls
-  type(group_pass_type) :: pass_MEKE, pass_Kh, pass_Ku, pass_del2MEKE !< Type for group-halo pass calls
+  type(group_pass_type) :: pass_MEKE !< Type for group halo pass calls
+  type(group_pass_type) :: pass_Kh   !< Type for group halo pass calls
+  type(group_pass_type) :: pass_Ku   !< Type for group halo pass calls
+  type(group_pass_type) :: pass_del2MEKE !< Type for group halo pass calls
 end type MEKE_CS
 
 contains
@@ -89,13 +93,14 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, CS, hu, hv)
   type(ocean_grid_type),                    intent(inout) :: G    !< Ocean grid.
   type(verticalGrid_type),                  intent(in)    :: GV   !< Ocean vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thickness in H (m or kg m-2).
-  real, dimension(SZIB_(G),SZJ_(G)),         intent(in)    :: SN_u !< Eady growth rate at u-points (s-1).
-  real, dimension(SZI_(G),SZJB_(G)),         intent(in)    :: SN_v !< Eady growth rate at u-points (s-1).
+  real, dimension(SZIB_(G),SZJ_(G)),        intent(in)    :: SN_u !< Eady growth rate at u-points (s-1).
+  real, dimension(SZI_(G),SZJB_(G)),        intent(in)    :: SN_v !< Eady growth rate at u-points (s-1).
   type(vertvisc_type),                      intent(in)    :: visc !< The vertical viscosity type.
   real,                                     intent(in)    :: dt   !< Model(baroclinic) time-step (s).
   type(MEKE_CS),                            pointer       :: CS   !< MEKE control structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: hu   !< Zonal flux flux (H m2 s-1).
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: hv   !< Meridional mass flux (H m2 s-1).
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)   :: hu   !< Zonal flux flux (H m2 s-1).
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)   :: hv   !< Meridional mass flux (H m2 s-1).
+
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     mass, &         ! The total mass of the water column, in kg m-2.

--- a/src/parameterizations/lateral/MOM_MEKE_types.F90
+++ b/src/parameterizations/lateral/MOM_MEKE_types.F90
@@ -2,35 +2,26 @@ module MOM_MEKE_types
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*    This program contains the subroutine that calculates the         *
-!*  effects of horizontal viscosity, including parameterizations of    *
-!*  the value of the viscosity itself. mesosclae_EKE calculates        *
-!*  the evolution of sub-grid scale mesoscale EKE.                     *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
-
 implicit none ; private
 
+!> This type is used to exchange information related to the MEKE calculations.
 type, public :: MEKE_type
   ! Variables
   real, dimension(:,:), pointer :: &
-    MEKE => NULL(), &   ! Vertically averaged eddy kinetic energy, in m2 s-2.
-    GM_src => NULL(), & ! MEKE source due to thickness mixing (GM), in W m-2.
-    mom_src => NULL(),& ! MEKE source from lateral friction in the momentum
-                        ! equations, in W m-2.
-    Kh => NULL(), &     ! The MEKE-derived lateral mixing coefficient in m2 s-1.
-    Rd_dx_h => NULL(), &! The deformation radius compared with the grid
-                        ! spacing, copied from VarMix_CS, nondim.
-    Ku => NULL()        ! The MEKE-derived lateral viscosity coefficient in m2 s-1.
-                        ! This viscosity can be negative when representing backscatter
-                        ! from unresolved eddies (see Jansen and Held, 2014).
+    MEKE => NULL(), &   !< Vertically averaged eddy kinetic energy, in m2 s-2.
+    GM_src => NULL(), & !< MEKE source due to thickness mixing (GM), in W m-2.
+    mom_src => NULL(),& !< MEKE source from lateral friction in the momentum equations, in W m-2.
+    Kh => NULL(), &     !< The MEKE-derived lateral mixing coefficient in m2 s-1.
+    Rd_dx_h => NULL()   !< The deformation radius compared with the grid spacing, nondim.
+                        !! Rd_dx_h is copied from VarMix_CS.
+  real, dimension(:,:), pointer :: Ku => NULL() !< The MEKE-derived lateral viscosity coefficient in m2 s-1.
+                        !! This viscosity can be negative when representing backscatter
+                        !! from unresolved eddies (see Jansen and Held, 2014).
   ! Parameters
-  real :: KhTh_fac = 1.0 ! Multiplier to map Kh(MEKE) to KhTh, nondim
-  real :: KhTr_fac = 1.0 ! Multiplier to map Kh(MEKE) to KhTr, nondim.
-  real :: backscatter_Ro_pow = 0.0 ! Power in Rossby number function for backscatter.
-  real :: backscatter_Ro_c = 0.0 ! Coefficient in Rossby number function for backscatter.
+  real :: KhTh_fac = 1.0 !< Multiplier to map Kh(MEKE) to KhTh, nondim
+  real :: KhTr_fac = 1.0 !< Multiplier to map Kh(MEKE) to KhTr, nondim.
+  real :: backscatter_Ro_pow = 0.0 !< Power in Rossby number function for backscatter.
+  real :: backscatter_Ro_c = 0.0 !< Coefficient in Rossby number function for backscatter.
 end type MEKE_type
 
 end module MOM_MEKE_types

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -52,35 +52,36 @@ public tidal_forcing_sensitivity
 integer, parameter :: MAX_CONSTITUENTS = 10 ! The maximum number of tidal
                                             ! constituents that could be used.
 
+!> The control structure for the MOM_tidal_forcing mldule
 type, public :: tidal_forcing_CS ; private
-  logical :: use_sal_scalar ! If true, use the scalar approximation when
-                      ! calculating self-attraction and loading.
-  logical :: tidal_sal_from_file ! If true, Read the tidal self-attraction
-                      ! and loading from input files, specified
-                      ! by TIDAL_INPUT_FILE.
-  logical :: use_prev_tides ! If true, use the SAL from the previous
-                      ! iteration of the tides to facilitate convergence.
-  real    :: sal_scalar ! The constant of proportionality between sea surface
-                      ! height (really it should be bottom pressure) anomalies
-                      ! and bottom geopotential anomalies.
-  integer :: nc       ! The number of tidal constituents in use.
+  logical :: use_sal_scalar !< If true, use the scalar approximation when
+                      !! calculating self-attraction and loading.
+  logical :: tidal_sal_from_file !< If true, Read the tidal self-attraction
+                      !! and loading from input files, specified
+                      !! by TIDAL_INPUT_FILE.
+  logical :: use_prev_tides !< If true, use the SAL from the previous
+                      !! iteration of the tides to facilitate convergence.
+  real    :: sal_scalar !< The constant of proportionality between sea surface
+                      !! height (really it should be bottom pressure) anomalies
+                      !! and bottom geopotential anomalies.
+  integer :: nc       !< The number of tidal constituents in use.
   real, dimension(MAX_CONSTITUENTS) :: &
-    freq, &           ! The frequency of a tidal constituent, in s-1.
-    phase0, &         ! The phase of a tidal constituent at time 0, in radians.
-    amp, &            ! The amplitude of a tidal constituent at time 0, in m.
-    love_no           ! The Love number of a tidal constituent at time 0, ND.
-  integer :: struct(MAX_CONSTITUENTS)
-  character (len=16) :: const_name(MAX_CONSTITUENTS)
+    freq, &           !< The frequency of a tidal constituent, in s-1.
+    phase0, &         !< The phase of a tidal constituent at time 0, in radians.
+    amp, &            !< The amplitude of a tidal constituent at time 0, in m.
+    love_no           !< The Love number of a tidal constituent at time 0, ND.
+  integer :: struct(MAX_CONSTITUENTS) !< An encoded spatial structure for each constituent
+  character (len=16) :: const_name(MAX_CONSTITUENTS) !< The name of each constituent
 
   real, pointer, dimension(:,:,:) :: &
-    sin_struct => NULL(), &    ! The sine and cosine based structures that can
-    cos_struct => NULL(), &    ! be associated with the astronomical forcing.
-    cosphasesal => NULL(), &   ! The cosine and sine of the phase of the
-    sinphasesal => NULL(), &   ! self-attraction and loading amphidromes.
-    ampsal => NULL(), &        ! The amplitude of the SAL, in m.
-    cosphase_prev => NULL(), & ! The cosine and sine of the phase of the
-    sinphase_prev => NULL(), & ! amphidromes in the previous tidal solutions.
-    amp_prev => NULL()         ! The amplitude of the previous tidal solution, in m.
+    sin_struct => NULL(), &    !< The sine and cosine based structures that can
+    cos_struct => NULL(), &    !< be associated with the astronomical forcing.
+    cosphasesal => NULL(), &   !< The cosine and sine of the phase of the
+    sinphasesal => NULL(), &   !< self-attraction and loading amphidromes.
+    ampsal => NULL(), &        !< The amplitude of the SAL, in m.
+    cosphase_prev => NULL(), & !< The cosine and sine of the phase of the
+    sinphase_prev => NULL(), & !< amphidromes in the previous tidal solutions.
+    amp_prev => NULL()         !< The amplitude of the previous tidal solution, in m.
 end type tidal_forcing_CS
 
 integer :: id_clock_tides
@@ -95,23 +96,11 @@ contains
 subroutine tidal_forcing_init(Time, G, param_file, CS)
   type(time_type),       intent(in)    :: Time !< The current model time.
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure.
-  type(param_file_type), intent(in)    :: param_file !< A structure to parse for run-time
-                                               !! parameters.
+  type(param_file_type), intent(in)    :: param_file !< A structure to parse for run-time parameters.
   type(tidal_forcing_CS), pointer      :: CS   !< A pointer that is set to point to the control
                                                !! structure for this module.
 
-! This subroutine allocates space for the static variables used
-! by this module.  The metrics may be effectively 0, 1, or 2-D arrays,
-! while fields like the background viscosities are 2-D arrays.
-! ALLOC is a macro defined in MOM_memory.h for allocate or nothing with
-! static memory.
-!
-! Arguments: Time - The current model time.
-!  (in)      G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module.
+  ! Local variables
   real, dimension(SZI_(G), SZJ_(G)) :: &
     phase, &          ! The phase of some tidal constituent.
     lat_rad, lon_rad  ! Latitudes and longitudes of h-points in radians.
@@ -386,13 +375,10 @@ end subroutine tidal_forcing_init
 !> This subroutine finds a named variable in a list of files and reads its
 !! values into a domain-decomposed 2-d array
 subroutine find_in_files(filenames, varname, array, G)
-  character(len=*), dimension(:), &
-                         intent(in)  :: filenames !< The names of the files to search
-                                                  !! for the named variable
-  character(len=*),      intent(in)  :: varname   !< The name of the variable to read
-  type(ocean_grid_type), intent(in)  :: G         !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJ_(G)), &
-                         intent(out) :: array     !< The array to fill with the data
+  character(len=*), dimension(:),   intent(in)  :: filenames !< The names of the files to search for the named variable
+  character(len=*),                 intent(in)  :: varname   !< The name of the variable to read
+  type(ocean_grid_type),            intent(in)  :: G         !< The ocean's grid structure
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: array     !< The array to fill with the data
 
   integer :: nf
 
@@ -422,18 +408,12 @@ end subroutine find_in_files
 !! and loading.
 subroutine tidal_forcing_sensitivity(G, CS, deta_tidal_deta)
   type(ocean_grid_type),  intent(in)  :: G  !< The ocean's grid structure.
-  type(tidal_forcing_CS), pointer     :: CS !< The control structure returned by a previous call to
-                                            !! tidal_forcing_init.
+  type(tidal_forcing_CS), pointer     :: CS !< The control structure returned by a previous call to tidal_forcing_init.
   real,                   intent(out) :: deta_tidal_deta !< The partial derivative of eta_tidal with
                                             !! the local value of eta, nondim.
 !   This subroutine calculates returns the partial derivative of the local
 ! geopotential height with the input sea surface height due to self-attraction
 ! and loading.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 tidal_forcing_init.
-!  (out)     deta_tidal_deta - the partial derivative of eta_tidal with the
-!                              local value of eta, nondim.
 
   if (CS%USE_SAL_SCALAR .and. CS%USE_PREV_TIDES) then
     deta_tidal_deta = 2.0*CS%SAL_SCALAR
@@ -463,22 +443,7 @@ subroutine calc_tidal_forcing(Time, eta, eta_tidal, G, CS, deta_tidal_deta)
                                                              !! eta_tidal with the local value of
                                                              !! eta, nondim.
 
-!   This subroutine calculates the geopotential anomalies that drive the tides,
-! including self-attraction and loading.  Optionally, it also returns the
-! partial derivative of the local geopotential height with the input sea surface
-! height.  For now, eta and eta_tidal are both geopotential heights in m, but
-! probably the input for eta should really be replaced with the column mass
-! anomalies.
-!
-! Arguments: Time - The time for the caluculation.
-!  (in)      eta - The sea surface height anomaly from a time-mean geoid in m.
-!  (out)     eta_tidal - The tidal forcing geopotential anomalies, in m.
-!  (in)      G - The ocean's grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 tidal_forcing_init.
-!  (out)     deta_tidal_deta - the partial derivative of eta_tidal with the
-!                              local value of eta, nondim.
-
+  ! Local variables
   real :: eta_astro(SZI_(G),SZJ_(G))
   real :: eta_SAL(SZI_(G),SZJ_(G))
   real :: now       ! The relative time in seconds.

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -30,34 +30,31 @@ implicit none ; private
 public register_DOME_tracer, initialize_DOME_tracer
 public DOME_tracer_column_physics, DOME_tracer_surface_state, DOME_tracer_end
 
-! ntr is the number of tracers in this module.
+!> ntr is the number of tracers in this module.
 integer, parameter :: ntr = 11
 
+!> The DOME_tracer control structure
 type, public :: DOME_tracer_CS ; private
-  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
-  character(len=200) :: tracer_IC_file ! The full path to the IC file, or " "
-                                       ! to initialize internally.
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
-  real :: land_val(NTR) = -1.0 ! The value of tr used where land is masked out.
-  logical :: use_sponge    ! If true, sponges may be applied somewhere in the domain.
+  logical :: coupled_tracers = .false. !< These tracers are not offered to the coupler.
+  character(len=200) :: tracer_IC_file !< The full path to the IC file, or " " to initialize internally.
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in g m-3?
+  real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out.
+  logical :: use_sponge    !< If true, sponges may be applied somewhere in the domain.
 
-  integer, dimension(NTR) :: ind_tr ! Indices returned by aof_set_coupler_flux
-             ! if it is used and the surface tracer concentrations are to be
-             ! provided to the coupler.
+  integer, dimension(NTR) :: ind_tr !< Indices returned by aof_set_coupler_flux if it is used and the
+                                    !! surface tracer concentrations are to be provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
 
-  type(vardesc) :: tr_desc(NTR)
+  type(vardesc) :: tr_desc(NTR) !< Descriptions and metadata for the tracers
 end type DOME_tracer_CS
 
 contains
 
-!> This subroutine is used to register tracer fields and subroutines
-!! to be used with MOM.
+!> Register tracer fields and subroutines to be used with MOM.
 function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),       intent(in) :: HI   !< A horizontal index type structure.
   type(verticalGrid_type),    intent(in) :: GV   !< The ocean's vertical grid structure
@@ -136,8 +133,7 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   register_DOME_tracer = .true.
 end function register_DOME_tracer
 
-!> This subroutine initializes the NTR tracer fields in tr(:,:,:,:)
-!! and it sets up the tracer output.
+!> Initializes the NTR tracer fields in tr(:,:,:,:) and sets up the tracer output.
 subroutine initialize_DOME_tracer(restart, day, G, GV, h, diag, OBC, CS, &
                                   sponge_CSp, diag_to_Z_CSp, param_file)
   type(ocean_grid_type),                 intent(in) :: G    !< The ocean's grid structure

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -45,38 +45,33 @@ implicit none ; private
 public register_ISOMIP_tracer, initialize_ISOMIP_tracer
 public ISOMIP_tracer_column_physics, ISOMIP_tracer_surface_state, ISOMIP_tracer_end
 
-!< ntr is the number of tracers in this module.
-integer, parameter :: ntr = 1
+integer, parameter :: ntr = 1 !< ntr is the number of tracers in this module.
 
-!> tracer control structure
+!> ISOMIP tracer package control structure
 type, public :: ISOMIP_tracer_CS ; private
-  logical :: coupled_tracers = .false.  !< These tracers are not offered to the
-                                        !< coupler.
-  character(len = 200) :: tracer_IC_file !< The full path to the IC file, or " "
-                                   !< to initialize internally.
+  logical :: coupled_tracers = .false.  !< These tracers are not offered to the coupler.
+  character(len = 200) :: tracer_IC_file !< The full path to the IC file, or " " to initialize internally.
   type(time_type), pointer :: Time !< A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this
-                                           !< subroutine, in g m-3?
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the MOM tracer registry
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in g m-3?
   real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out.
-  logical :: use_sponge    ! If true, sponges may be applied somewhere in the domain.
+  logical :: use_sponge    !< If true, sponges may be applied somewhere in the domain.
 
   integer, dimension(NTR) :: ind_tr !< Indices returned by aof_set_coupler_flux
              !< if it is used and the surface tracer concentrations are to be
              !< provided to the coupler.
 
   type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the
-                             !< timing of diagnostic output.
+                                   !! timing of diagnostic output.
 
-  type(vardesc) :: tr_desc(NTR)
+  type(vardesc) :: tr_desc(NTR) !< Descriptions and metadata for the tracers in this package
 end type ISOMIP_tracer_CS
 
 contains
 
 
 !> This subroutine is used to register tracer fields
-function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, &
-                                      restart_CS)
+function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),      intent(in) :: HI    !<A horizontal index type structure.
   type(verticalGrid_type),    intent(in) :: GV   !< The ocean's vertical grid structure.
   type(param_file_type),      intent(in) :: param_file !< A structure indicating the open file
@@ -259,11 +254,10 @@ subroutine initialize_ISOMIP_tracer(restart, day, G, GV, h, diag, OBC, CS, &
 
 end subroutine initialize_ISOMIP_tracer
 
-!> This subroutine applies diapycnal diffusion and any other column
-! tracer physics or chemistry to the tracers from this file.
-! This is a simple example of a set of advected passive tracers.
+!> This subroutine applies diapycnal diffusion, including the surface boundary
+!! conditions and any other column tracer physics or chemistry to the tracers from this file.
 subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV, CS, &
-              evap_CFL_limit, minimum_forcing_depth)
+                                        evap_CFL_limit, minimum_forcing_depth)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
@@ -288,25 +282,10 @@ subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, G
   real,          optional, intent(in) :: minimum_forcing_depth !< The smallest depth over which
                                               !! fluxes can be applied, in m
 
-! Arguments: h_old -  Layer thickness before entrainment, in m or kg m-2.
-!  (in)      h_new -  Layer thickness after entrainment, in m or kg m-2.
-!  (in)      ea - an array to which the amount of fluid entrained
-!                 from the layer above during this call will be
-!                 added, in m or kg m-2.
-!  (in)      eb - an array to which the amount of fluid entrained
-!                 from the layer below during this call will be
-!                 added, in m or kg m-2.
-!  (in)      fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      dt - The amount of time covered by this call, in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 ISOMIP_register_tracer.
-!
 ! The arguments to this subroutine are redundant in that
 !     h_new[k] = h_old[k] + ea[k] - eb[k-1] + eb[k] - ea[k+1]
 
+  ! Local variables
   real :: mmax
   real :: b1(SZI_(G))          ! b1 and c1 are variables used by the
   real :: c1(SZI_(G),SZK_(G))  ! tridiagonal solver.
@@ -387,6 +366,7 @@ subroutine ISOMIP_tracer_surface_state(state, h, G, CS)
 
 end subroutine ISOMIP_tracer_surface_state
 
+!> Deallocate any memory used by the ISOMIP tracer package
 subroutine ISOMIP_tracer_end(CS)
   type(ISOMIP_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                         !! call to ISOMIP_register_tracer.

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -81,16 +81,18 @@ public OCMIP2_CFC_stock, OCMIP2_CFC_end
 ! NTR is the number of tracers in this module.
 integer, parameter :: NTR = 2
 
+!> The control structure for the  OCMPI2_CFC tracer package
 type, public :: OCMIP2_CFC_CS ; private
-  character(len=200) :: IC_file ! The file in which the CFC initial values can
-                    ! be found, or an empty string for internal initilaization.
-  logical :: Z_IC_file ! If true, the IC_file is in Z-space.  The default is false..
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
+  character(len=200) :: IC_file !< The file in which the CFC initial values can
+                                !! be found, or an empty string for internal initilaization.
+  logical :: Z_IC_file !< If true, the IC_file is in Z-space.  The default is false..
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the MOM6 tracer registry
   real, pointer, dimension(:,:,:) :: &
-    CFC11 => NULL(), &     ! The CFC11 concentration in mol m-3.
-    CFC12 => NULL()        ! The CFC12 concentration in mol m-3.
+    CFC11 => NULL(), &     !< The CFC11 concentration in mol m-3.
+    CFC12 => NULL()        !< The CFC12 concentration in mol m-3.
   ! In the following variables a suffix of _11 refers to CFC11 and _12 to CFC12.
+  !>@{ Coefficients used in the CFC11 and CFC12 solubility calculation
   real :: a1_11, a2_11, a3_11, a4_11   ! Coefficients in the calculation of the
   real :: a1_12, a2_12, a3_12, a4_12   ! CFC11 and CFC12 Schmidt numbers, in
                                        ! units of ND, degC-1, degC-2, degC-3.
@@ -100,29 +102,34 @@ type, public :: OCMIP2_CFC_CS ; private
   real :: e1_11, e2_11, e3_11          ! More coefficients in the calculation of
   real :: e1_12, e2_12, e3_12          ! the CFC11 and CFC12 solubilities, in
                                        ! units of PSU-1, PSU-1 K-1, PSU-1 K-2.
-  real :: CFC11_IC_val = 0.0    ! The initial value assigned to CFC11.
-  real :: CFC12_IC_val = 0.0    ! The initial value assigned to CFC12.
-  real :: CFC11_land_val = -1.0 ! The values of CFC11 and CFC12 used where
-  real :: CFC12_land_val = -1.0 ! land is masked out.
-  logical :: tracers_may_reinit  ! If true, tracers may go through the
-                           ! initialization code if they are not found in the
-                           ! restart files.
-  character(len=16) :: CFC11_name, CFC12_name ! Variable names.
+  !!@}
+  real :: CFC11_IC_val = 0.0    !< The initial value assigned to CFC11.
+  real :: CFC12_IC_val = 0.0    !< The initial value assigned to CFC12.
+  real :: CFC11_land_val = -1.0 !< The value of CFC11 used where land is masked out.
+  real :: CFC12_land_val = -1.0 !< The value of CFC12 used where land is masked out.
+  logical :: tracers_may_reinit !< If true, tracers may be reset via the initialization code
+                                !! if they are not found in the restart files.
+  character(len=16) :: CFC11_name !< CFC11 variable name
+  character(len=16) :: CFC12_name !< CFC12 variable name
 
-  integer :: ind_cfc_11_flux  ! Indices returned by aof_set_coupler_flux that
-  integer :: ind_cfc_12_flux  ! are used to pack and unpack surface boundary
-                              ! condition arrays.
+  integer :: ind_cfc_11_flux  !< Index returned by aof_set_coupler_flux that is used to
+                              !! pack and unpack surface boundary condition arrays.
+  integer :: ind_cfc_12_flux  !< Index returned by aof_set_coupler_flux that is used to
+                              !! pack and unpack surface boundary condition arrays.
 
   type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
                                    ! regulate the timing of diagnostic output.
   type(MOM_restart_CS), pointer :: restart_CSp => NULL()
 
   ! The following vardesc types contain a package of metadata about each tracer.
-  type(vardesc) :: CFC11_desc, CFC12_desc
+  type(vardesc) :: CFC11_desc !< A set of metadata for the CFC11 tracer
+  type(vardesc) :: CFC12_desc !< A set of metadata for the CFC12 tracer
 end type OCMIP2_CFC_CS
 
 contains
 
+!> Register the OCMIP2 CFC tracers to be used with MOM and read the parameters
+!! that are used with this tracer package
 function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),    intent(in) :: HI         !< A horizontal index type structure.
   type(verticalGrid_type), intent(in) :: GV         !< The ocean's vertical grid structure.
@@ -134,18 +141,12 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(MOM_restart_CS),    pointer    :: restart_CS !< A pointer to the restart control structure.
 ! This subroutine is used to register tracer fields and subroutines
 ! to be used with MOM.
-! Arguments: HI - A horizontal index type structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
-!  (in/out)  tr_Reg - A pointer to the tracer registry.
-!  (in)      restart_CS - A pointer to the restart control structure.
 
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! Local variables
   character(len=40)  :: mdl = "MOM_OCMIP2_CFC" ! This module's name.
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
+  ! This include declares and sets the variable "version".
+#include "version_variable.h"
   real, dimension(:,:,:), pointer :: tr_ptr => NULL()
   real :: a11_dflt(4), a12_dflt(4) ! Default values of the various coefficients
   real :: d11_dflt(4), d12_dflt(4) ! In the expressions for the solubility and
@@ -351,8 +352,7 @@ subroutine flux_init_OCMIP2_CFC(CS, verbosity)
 
 end subroutine flux_init_OCMIP2_CFC
 
-!> This subroutine initializes the NTR tracer fields in tr(:,:,:,:)
-!! and it sets up the tracer output.
+!> Initialize the OCMP2 CFC tracer fields and set up the tracer output.
 subroutine initialize_OCMIP2_CFC(restart, day, G, GV, h, diag, OBC, CS, &
                                  sponge_CSp, diag_to_Z_CSp)
   logical,                        intent(in) :: restart    !< .true. if the fields have already been
@@ -378,21 +378,6 @@ subroutine initialize_OCMIP2_CFC(restart, day, G, GV, h, diag, OBC, CS, &
 !   This subroutine initializes the NTR tracer fields in tr(:,:,:,:)
 ! and it sets up the tracer output.
 
-! Arguments: restart - .true. if the fields have already been read from
-!                     a restart file.
-!  (in)      day - Time of the start of the run.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in)      OBC - This open boundary condition type specifies whether, where,
-!                  and what open boundary conditions are used.
-!  (in/out)  CS - The control structure returned by a previous call to
-!                 register_OCMIP2_CFC.
-!  (in/out)  sponge_CSp - A pointer to the control structure for the sponges, if
-!                         they are in use.  Otherwise this may be unassociated.
-!  (in/out)  diag_to_Z_Csp - A pointer to the control structure for diagnostics
-!                            in depth space.
   logical :: from_file = .false.
 
   if (.not.associated(CS)) return
@@ -460,10 +445,9 @@ subroutine init_tracer_CFC(h, tr, name, land_val, IC_val, G, CS)
 
 end subroutine init_tracer_CFC
 
-!>  This subroutine applies diapycnal diffusion and any other column
-! tracer physics or chemistry to the tracers from this file.
-! CFCs are relatively simple, as they are passive tracers. with only a surface
-! flux as a source.
+!>  This subroutine applies diapycnal diffusion, souces and sinks and any other column
+!! tracer physics or chemistry to the OCMIP2 CFC tracers.
+!! CFCs are relatively simple, as they are passive tracers with only a surface flux as a source.
 subroutine OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS, &
               evap_CFL_limit, minimum_forcing_depth)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
@@ -494,25 +478,10 @@ subroutine OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS
 ! CFCs are relatively simple, as they are passive tracers. with only a surface
 ! flux as a source.
 
-! Arguments: h_old -  Layer thickness before entrainment, in m or kg m-2.
-!  (in)      h_new -  Layer thickness after entrainment, in m or kg m-2.
-!  (in)      ea - an array to which the amount of fluid entrained
-!                 from the layer above during this call will be
-!                 added, in m or kg m-2.
-!  (in)      eb - an array to which the amount of fluid entrained
-!                 from the layer below during this call will be
-!                 added, in m or kg m-2.
-!  (in)      fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      dt - The amount of time covered by this call, in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_OCMIP2_CFC.
-!
 ! The arguments to this subroutine are redundant in that
 !     h_new[k] = h_old[k] + ea[k] - eb[k-1] + eb[k] - ea[k+1]
 
+  ! Local variables
   real :: b1(SZI_(G))          ! b1 and c1 are variables used by the
   real :: c1(SZI_(G),SZK_(G))  ! tridiagonal solver.
   real, dimension(SZI_(G),SZJ_(G)) :: &
@@ -580,23 +549,9 @@ function OCMIP2_CFC_stock(h, stocks, G, GV, CS, names, units, stock_index)
   character(len=*), dimension(:),  intent(out)   :: units  !< The units of the stocks calculated.
   integer, optional,               intent(in)    :: stock_index !< The coded index of a specific
                                                                 !! stock being sought.
-  integer                                        :: OCMIP2_CFC_stock
-! This function calculates the mass-weighted integral of all tracer stocks,
-! returning the number of stocks it has calculated.  If the stock_index
-! is present, only the stock corresponding to that coded index is returned.
+  integer                                        :: OCMIP2_CFC_stock !< The number of stocks calculated here.
 
-! Arguments: h - Layer thickness, in m or kg m-2.
-!  (out)     stocks - the mass-weighted integrated amount of each tracer,
-!                     in kg times concentration units.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_OCMIP2_CFC.
-!  (out)     names - the names of the stocks calculated.
-!  (out)     units - the units of the stocks calculated.
-!  (in,opt)  stock_index - the coded index of a specific stock being sought.
-! Return value: the number of stocks calculated here.
-
+  ! Local variables
   real :: mass
   integer :: i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -639,6 +594,7 @@ subroutine OCMIP2_CFC_surface_state(state, h, G, CS)
   type(OCMIP2_CFC_CS),    pointer       :: CS !< The control structure returned by a previous
                                               !! call to register_OCMIP2_CFC.
 
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     CFC11_Csurf, &  ! The CFC-11 and CFC-12 surface concentrations times the
     CFC12_Csurf, &  ! Schmidt number term, both in mol m-3.
@@ -700,6 +656,7 @@ subroutine OCMIP2_CFC_surface_state(state, h, G, CS)
 
 end subroutine OCMIP2_CFC_surface_state
 
+!> Deallocate any memory associated with the OCMIP2 CFC tracer package
 subroutine OCMIP2_CFC_end(CS)
   type(OCMIP2_CFC_CS), pointer :: CS   !< The control structure returned by a
                                        !! previous call to register_OCMIP2_CFC.

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -31,61 +31,60 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public neutral_diffusion
-public neutral_diffusion_init
-public neutral_diffusion_end
+public neutral_diffusion, neutral_diffusion_init, neutral_diffusion_end
 public neutral_diffusion_calc_coeffs
 public neutral_diffusion_unit_tests
 
+!> The control structure for the MOM_neutral_diffusion module
 type, public :: neutral_diffusion_CS ; private
-  integer :: nkp1   ! Number of interfaces for a column = nk + 1
-  integer :: nsurf  ! Number of neutral surfaces
-  integer :: deg = 2 ! Degree of polynomial used for reconstructions
-  logical :: continuous_reconstruction = .true.   ! True if using continuous PPM reconstruction at interfaces
-  logical :: refine_position = .false.
-  logical :: debug = .false.
-  integer :: max_iter ! Maximum number of iterations if refine_position is defined
-  real :: tolerance   ! Convergence criterion representing difference from true neutrality
-  real :: ref_pres    ! Reference pressure, negative if using locally referenced neutral density
+  integer :: nkp1   !< Number of interfaces for a column = nk + 1
+  integer :: nsurf  !< Number of neutral surfaces
+  integer :: deg = 2 !< Degree of polynomial used for reconstructions
+  logical :: continuous_reconstruction = .true. !< True if using continuous PPM reconstruction at interfaces
+  logical :: refine_position = .false. !< If true, iterate to refine the corresponding positions
+                                       !! in neighboring columns
+  logical :: debug = .false. !< If true, write verbose debugging messages
+  integer :: max_iter !< Maximum number of iterations if refine_position is defined
+  real :: tolerance   !< Convergence criterion representing difference from true neutrality
+  real :: ref_pres    !< Reference pressure, negative if using locally referenced neutral density
 
   ! Positions of neutral surfaces in both the u, v directions
-  real,    allocatable, dimension(:,:,:) :: uPoL  ! Non-dimensional position with left layer uKoL-1, u-point
-  real,    allocatable, dimension(:,:,:) :: uPoR  ! Non-dimensional position with right layer uKoR-1, u-point
-  integer, allocatable, dimension(:,:,:) :: uKoL  ! Index of left interface corresponding to neutral surface,
-                                                  ! at a u-point
-  integer, allocatable, dimension(:,:,:) :: uKoR  ! Index of right interface corresponding to neutral surface,
-                                                  ! at a u-point
-  real,    allocatable, dimension(:,:,:) :: uHeff ! Effective thickness at u-point (H units)
-  real,    allocatable, dimension(:,:,:) :: vPoL  ! Non-dimensional position with left layer uKoL-1, v-point
-  real,    allocatable, dimension(:,:,:) :: vPoR  ! Non-dimensional position with right layer uKoR-1, v-point
-  integer, allocatable, dimension(:,:,:) :: vKoL  ! Index of left interface corresponding to neutral surface,
-                                                  ! at a v-point
-  integer, allocatable, dimension(:,:,:) :: vKoR  ! Index of right interface corresponding to neutral surface,
-                                                  ! at a v-point
-  real,    allocatable, dimension(:,:,:) :: vHeff ! Effective thickness at v-point (H units)
+  real,    allocatable, dimension(:,:,:) :: uPoL  !< Non-dimensional position with left layer uKoL-1, u-point
+  real,    allocatable, dimension(:,:,:) :: uPoR  !< Non-dimensional position with right layer uKoR-1, u-point
+  integer, allocatable, dimension(:,:,:) :: uKoL  !< Index of left interface corresponding to neutral surface,
+                                                  !! at a u-point
+  integer, allocatable, dimension(:,:,:) :: uKoR  !< Index of right interface corresponding to neutral surface,
+                                                  !! at a u-point
+  real,    allocatable, dimension(:,:,:) :: uHeff !< Effective thickness at u-point (H units)
+  real,    allocatable, dimension(:,:,:) :: vPoL  !< Non-dimensional position with left layer uKoL-1, v-point
+  real,    allocatable, dimension(:,:,:) :: vPoR  !< Non-dimensional position with right layer uKoR-1, v-point
+  integer, allocatable, dimension(:,:,:) :: vKoL  !< Index of left interface corresponding to neutral surface,
+                                                  !! at a v-point
+  integer, allocatable, dimension(:,:,:) :: vKoR  !< Index of right interface corresponding to neutral surface,
+                                                  !! at a v-point
+  real,    allocatable, dimension(:,:,:) :: vHeff !< Effective thickness at v-point (H units)
   ! Coefficients of polynomial reconstructions for temperature and salinity
   real,    allocatable, dimension(:,:,:,:) :: ppoly_coeffs_T !< Polynomial coefficients for temperature
-  real,    allocatable, dimension(:,:,:,:) :: ppoly_coeffs_S !< Polynomial coefficients for temperature
+  real,    allocatable, dimension(:,:,:,:) :: ppoly_coeffs_S !< Polynomial coefficients for salinity
   ! Variables needed for continuous reconstructions
-  real,    allocatable, dimension(:,:,:) :: dRdT ! dRho/dT (kg/m3/degC) at interfaces
-  real,    allocatable, dimension(:,:,:) :: dRdS ! dRho/dS (kg/m3/ppt) at interfaces
-  real,    allocatable, dimension(:,:,:) :: Tint ! Interface T (degC)
-  real,    allocatable, dimension(:,:,:) :: Sint ! Interface S (ppt)
-  real,    allocatable, dimension(:,:,:) :: Pint ! Interface pressure (Pa)
+  real,    allocatable, dimension(:,:,:) :: dRdT !< dRho/dT (kg/m3/degC) at interfaces
+  real,    allocatable, dimension(:,:,:) :: dRdS !< dRho/dS (kg/m3/ppt) at interfaces
+  real,    allocatable, dimension(:,:,:) :: Tint !< Interface T (degC)
+  real,    allocatable, dimension(:,:,:) :: Sint !< Interface S (ppt)
+  real,    allocatable, dimension(:,:,:) :: Pint !< Interface pressure (Pa)
   ! Variables needed for discontinuous reconstructions
-  real,    allocatable, dimension(:,:,:,:) :: T_i     ! Top edge reconstruction of temperature (degC)
-  real,    allocatable, dimension(:,:,:,:) :: S_i     ! Top edge reconstruction of salinity (ppt)
-  real,    allocatable, dimension(:,:,:,:) :: dRdT_i     ! dRho/dT (kg/m3/degC) at top edge
-  real,    allocatable, dimension(:,:,:,:) :: dRdS_i     ! dRho/dS (kg/m3/ppt) at top edge
-  integer, allocatable, dimension(:,:)     :: ns     ! Number of interfacs in a column
-  logical, allocatable, dimension(:,:,:) :: stable_cell  ! True if the cell is stably stratified wrt
-                                                         ! to the next cell
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  integer :: id_uhEff_2d = -1
-  integer :: id_vhEff_2d = -1
+  real,    allocatable, dimension(:,:,:,:) :: T_i    !< Top edge reconstruction of temperature (degC)
+  real,    allocatable, dimension(:,:,:,:) :: S_i    !< Top edge reconstruction of salinity (ppt)
+  real,    allocatable, dimension(:,:,:,:) :: dRdT_i !< dRho/dT (kg/m3/degC) at top edge
+  real,    allocatable, dimension(:,:,:,:) :: dRdS_i !< dRho/dS (kg/m3/ppt) at top edge
+  integer, allocatable, dimension(:,:)     :: ns     !< Number of interfacs in a column
+  logical, allocatable, dimension(:,:,:) :: stable_cell !< True if the cell is stably stratified wrt to the next cell
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                             !! regulate the timing of diagnostic output.
+  integer :: id_uhEff_2d = -1 !< Diagnostic IDs
+  integer :: id_vhEff_2d = -1 !< Diagnostic IDs
 
-  real    :: C_p ! heat capacity of seawater (J kg-1 K-1)
+  real    :: C_p !< heat capacity of seawater (J kg-1 K-1)
   type(EOS_type), pointer :: EOS !< Equation of state parameters
   type(remapping_CS)       :: remap_CS      !< Remapping control structure used to create sublayers
   type(ndiff_aux_CS_type), pointer :: ndiff_aux_CS !< Store parameters for iteratively finding neutral surface
@@ -93,7 +92,7 @@ end type neutral_diffusion_CS
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-character(len=40)  :: mdl = "MOM_neutral_diffusion" ! module name
+character(len=40)  :: mdl = "MOM_neutral_diffusion" !< module name
 
 contains
 

--- a/src/tracer/MOM_neutral_diffusion_aux.F90
+++ b/src/tracer/MOM_neutral_diffusion_aux.F90
@@ -20,6 +20,7 @@ public refine_nondim_position
 public check_neutral_positions
 public kahan_sum
 
+!> The control structure for this module
 type, public :: ndiff_aux_CS_type ; private
   integer :: nterm        !< Number of terms in polynomial (deg+1)
   integer :: max_iter     !< Maximum number of iterations
@@ -27,10 +28,9 @@ type, public :: ndiff_aux_CS_type ; private
   real :: xtol            !< Criterion for how much position changes (nondim)
   real :: ref_pres        !< Determines whether a constant reference pressure is used everywhere or locally referenced
                           !< density is done. ref_pres <-1 is the latter, ref_pres >= 0. otherwise
-  logical :: force_brent = .false.  !< Use Brent's method instead of Newton even when second derivatives are available
-  logical :: debug
+  logical :: force_brent = .false. !< Use Brent's method instead of Newton even when second derivatives are available
+  logical :: debug        !< If true, write verbose debugging messages and checksusm
   type(EOS_type), pointer :: EOS !< Pointer to equation of state used in the model
-
 end type ndiff_aux_CS_type
 
 contains

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -34,12 +34,14 @@ type, public :: tracer_advect_CS ; private
   logical :: debug                 !< If true, write verbose checksums for debugging purposes.
   logical :: usePPM                !< If true, use PPM instead of PLM
   logical :: useHuynh              !< If true, use the Huynh scheme for PPM interface values
-  type(group_pass_type) :: pass_uhr_vhr_t_hprev ! For group pass
+  type(group_pass_type) :: pass_uhr_vhr_t_hprev !< A structred used for group passes
 end type tracer_advect_CS
 
+!>@{ CPU time clocks
 integer :: id_clock_advect
 integer :: id_clock_pass
 integer :: id_clock_sync
+!!@}
 
 contains
 

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -67,19 +67,21 @@ public call_tracer_register, tracer_flow_control_init, call_tracer_set_forcing
 public call_tracer_column_fns, call_tracer_surface_state, call_tracer_stocks
 public call_tracer_flux_init, get_chl_from_model, tracer_flow_control_end
 
+!> The control structure for orchestrating the calling of tracer packages
 type, public :: tracer_flow_control_CS ; private
-  logical :: use_USER_tracer_example = .false.
-  logical :: use_DOME_tracer = .false.
-  logical :: use_ISOMIP_tracer = .false.
-  logical :: use_ideal_age = .false.
-  logical :: use_regional_dyes = .false.
-  logical :: use_oil = .false.
-  logical :: use_advection_test_tracer = .false.
-  logical :: use_OCMIP2_CFC = .false.
-  logical :: use_MOM_generic_tracer = .false.
-  logical :: use_pseudo_salt_tracer = .false.
-  logical :: use_boundary_impulse_tracer = .false.
-  logical :: use_dyed_obc_tracer = .false.
+  logical :: use_USER_tracer_example = .false.     !< If true, use the USER_tracer_example package
+  logical :: use_DOME_tracer = .false.             !< If true, use the DOME_tracer package
+  logical :: use_ISOMIP_tracer = .false.           !< If true, use the ISOMPE_tracer package
+  logical :: use_ideal_age = .false.               !< If true, use the ideal age tracer package
+  logical :: use_regional_dyes = .false.           !< If true, use the regional dyes tracer package
+  logical :: use_oil = .false.                     !< If true, use the oil tracer package
+  logical :: use_advection_test_tracer = .false.   !< If true, use the advection_test_tracer package
+  logical :: use_OCMIP2_CFC = .false.              !< If true, use the OCMIP2_CFC tracer package
+  logical :: use_MOM_generic_tracer = .false.      !< If true, use the MOM_generic_tracer packages
+  logical :: use_pseudo_salt_tracer = .false.      !< If true, use the psuedo_salt tracer  package
+  logical :: use_boundary_impulse_tracer = .false. !< If true, use the boundary impulse tracer package
+  logical :: use_dyed_obc_tracer = .false.         !< If true, use the dyed OBC tracer package
+  !>@{ Pointers to the control strucures for the tracer packages
   type(USER_tracer_example_CS), pointer :: USER_tracer_example_CSp => NULL()
   type(DOME_tracer_CS), pointer :: DOME_tracer_CSp => NULL()
   type(ISOMIP_tracer_CS), pointer :: ISOMIP_tracer_CSp => NULL()
@@ -94,6 +96,7 @@ type, public :: tracer_flow_control_CS ; private
   type(pseudo_salt_tracer_CS), pointer :: pseudo_salt_tracer_CSp => NULL()
   type(boundary_impulse_tracer_CS), pointer :: boundary_impulse_tracer_CSp => NULL()
   type(dyed_obc_tracer_CS), pointer :: dyed_obc_tracer_CSp => NULL()
+  !!@}
 end type tracer_flow_control_CS
 
 contains

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -32,54 +32,61 @@ implicit none ; private
 
 public tracer_hordiff, tracer_hor_diff_init, tracer_hor_diff_end
 
+!> The ocntrol structure for along-layer and epineutral tracer diffusion
 type, public :: tracer_hor_diff_CS ; private
-  real    :: dt             ! The baroclinic dynamics time step, in s.
-  real    :: KhTr           ! The along-isopycnal tracer diffusivity in m2/s.
-  real    :: KhTr_Slope_Cff ! The non-dimensional coefficient in KhTr formula
-  real    :: KhTr_min       ! Minimum along-isopycnal tracer diffusivity in m2/s.
-  real    :: KhTr_max       ! Maximum along-isopycnal tracer diffusivity in m2/s.
-  real    :: KhTr_passivity_coeff ! Passivity coefficient that scales Rd/dx (default = 0)
-                                  ! where passivity is the ratio between along-isopycnal
-                                  ! tracer mixing and thickness mixing
-  real    :: KhTr_passivity_min   ! Passivity minimum (default = 1/2)
-  real    :: ML_KhTR_scale        ! With Diffuse_ML_interior, the ratio of the
-                                  ! truly horizontal diffusivity in the mixed
-                                  ! layer to the epipycnal diffusivity.  Nondim.
-  real    :: max_diff_CFL         ! If positive, locally limit the along-isopycnal
-                                  ! tracer diffusivity to keep the diffusive CFL
-                                  ! locally at or below this value. Nondim.
-  logical :: Diffuse_ML_interior  ! If true, diffuse along isopycnals between
-                                  ! the mixed layer and the interior.
-  logical :: check_diffusive_CFL  ! If true, automatically iterate the diffusion
-                                  ! to ensure that the diffusive equivalent of
-                                  ! the CFL limit is not violated.
-  logical :: use_neutral_diffusion ! If true, use the neutral_diffusion module from within
-                                   ! tracer_hor_diff.
-  type(neutral_diffusion_CS), pointer :: neutral_diffusion_CSp => NULL() ! Control structure for neutral diffusion.
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  logical :: debug                 ! If true, write verbose checksums for debugging purposes.
-  logical :: show_call_tree        ! Display the call tree while running. Set by VERBOSITY level.
-  logical :: first_call = .true.
+  real    :: dt             !< The baroclinic dynamics time step, in s.
+  real    :: KhTr           !< The along-isopycnal tracer diffusivity in m2/s.
+  real    :: KhTr_Slope_Cff !< The non-dimensional coefficient in KhTr formula
+  real    :: KhTr_min       !< Minimum along-isopycnal tracer diffusivity in m2/s.
+  real    :: KhTr_max       !< Maximum along-isopycnal tracer diffusivity in m2/s.
+  real    :: KhTr_passivity_coeff !< Passivity coefficient that scales Rd/dx (default = 0)
+                                  !! where passivity is the ratio between along-isopycnal
+                                  !! tracer mixing and thickness mixing
+  real    :: KhTr_passivity_min   !< Passivity minimum (default = 1/2)
+  real    :: ML_KhTR_scale        !< With Diffuse_ML_interior, the ratio of the
+                                  !! truly horizontal diffusivity in the mixed
+                                  !! layer to the epipycnal diffusivity.  Nondim.
+  real    :: max_diff_CFL         !< If positive, locally limit the along-isopycnal
+                                  !! tracer diffusivity to keep the diffusive CFL
+                                  !! locally at or below this value. Nondim.
+  logical :: Diffuse_ML_interior  !< If true, diffuse along isopycnals between
+                                  !! the mixed layer and the interior.
+  logical :: check_diffusive_CFL  !< If true, automatically iterate the diffusion
+                                  !! to ensure that the diffusive equivalent of
+                                  !! the CFL limit is not violated.
+  logical :: use_neutral_diffusion !< If true, use the neutral_diffusion module from within
+                                   !! tracer_hor_diff.
+  type(neutral_diffusion_CS), pointer :: neutral_diffusion_CSp => NULL() !< Control structure for neutral diffusion.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  logical :: debug                 !< If true, write verbose checksums for debugging purposes.
+  logical :: show_call_tree        !< Display the call tree while running. Set by VERBOSITY level.
+  logical :: first_call = .true.   !< This is true until after the first call
+  !>@{ Diagnostic IDs
   integer :: id_KhTr_u  = -1
   integer :: id_KhTr_v  = -1
   integer :: id_KhTr_h  = -1
   integer :: id_CFL     = -1
   integer :: id_khdt_x  = -1
   integer :: id_khdt_y  = -1
+  !!@}
 
-  type(group_pass_type) :: pass_t !For group halo pass, used in both
-                                  !tracer_hordiff and tracer_epipycnal_ML_diff
+  type(group_pass_type) :: pass_t !< For group halo pass, used in both
+                                  !! tracer_hordiff and tracer_epipycnal_ML_diff
 end type tracer_hor_diff_CS
 
+!> A type that can be used to create arrays of pointers to 2D arrays
 type p2d
-  real, dimension(:,:), pointer :: p => NULL()
+  real, dimension(:,:), pointer :: p => NULL() !< A pointer to a 2D array of reals
 end type p2d
+!> A type that can be used to create arrays of pointers to 2D integer arrays
 type p2di
-  integer, dimension(:,:), pointer :: p => NULL()
+  integer, dimension(:,:), pointer :: p => NULL() !< A pointer to a 2D array of integers
 end type p2di
 
+!>@{ CPU time clocks
 integer :: id_clock_diffuse, id_clock_epimix, id_clock_pass, id_clock_sync
+!!@}
 
 contains
 

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -93,7 +93,7 @@ type, public :: tracer_type
   character(len=48)               :: cmor_tendprefix = ""     !< The CMOR variable prefix for tendencies of this
                                                               !! tracer, required because CMOR does not follow any
                                                               !! discernable pattern for these names.
-  integer :: ind_tr_squared = -1
+  integer :: ind_tr_squared = -1 !< The tracer registry index for the square of this tracer
 
   !### THESE CAPABILITIES HAVE NOT YET BEEN IMPLEMENTED.
   logical :: advect_tr = .true.     !< If true, this tracer should be advected
@@ -101,6 +101,7 @@ type, public :: tracer_type
   logical :: remap_tr = .true.      !< If true, this tracer should be vertically remapped
 
   integer :: diag_form = 1  !< An integer indicating which template is to be used to label diagnostics.
+  !>@{ Diagnostic IDs
   integer :: id_tr = -1
   integer :: id_adx = -1, id_ady = -1, id_dfx = -1, id_dfy = -1
   integer :: id_adx_2d = -1, id_ady_2d = -1, id_dfx_2d = -1, id_dfy_2d = -1
@@ -109,6 +110,7 @@ type, public :: tracer_type
   integer :: id_remap_conc = -1, id_remap_cont = -1, id_remap_cont_2d = -1
   integer :: id_tendency = -1, id_trxh_tendency = -1, id_trxh_tendency_2d = -1
   integer :: id_tr_vardec = -1
+  !!@}
 end type tracer_type
 
 !> Type to carry basic tracer information

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -67,35 +67,37 @@ public advection_test_tracer_column_physics, advection_test_stock
 ! ntr is the number of tracers in this module.
 integer, parameter :: NTR = 11
 
+!> The control structure for the advect_test_tracer module
 type, public :: advection_test_tracer_CS ; private
-  integer :: ntr = NTR                 ! Number of tracers in this module
-  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
-  character(len=200) :: tracer_IC_file ! The full path to the IC file, or " "
-                                       ! to initialize internally.
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
-  real :: land_val(NTR) = -1.0 ! The value of tr used where land is masked out.
-  logical :: use_sponge    ! If true, sponges may be applied somewhere in the domain.
-  logical :: tracers_may_reinit
+  integer :: ntr = NTR                 !< Number of tracers in this module
+  logical :: coupled_tracers = .false. !< These tracers are not offered to the coupler.
+  character(len=200) :: tracer_IC_file !< The full path to the IC file, or " " to initialize internally.
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the MOM tracer registry
+  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine, in g m-3?
+  real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out.
+  logical :: use_sponge    !< If true, sponges may be applied somewhere in the domain.
+  logical :: tracers_may_reinit !< If true, the tracers may be set up via the initialization code if
+                           !! they are not found in the restart files.  Otherwise it is a fatal error
+                           !! if the tracers are not found in the restart files of a restarted run.
+  real :: x_origin !< Parameters describing the test functions
+  real :: x_width  !< Parameters describing the test functions
+  real :: y_origin !< Parameters describing the test functions
+  real :: y_width  !< Parameters describing the test functions
 
-  real :: x_origin, x_width ! Parameters describing the test functions
-  real :: y_origin, y_width ! Parameters describing the test functions
+  integer, dimension(NTR) :: ind_tr !< Indices returned by aof_set_coupler_flux if it is used and
+                   !! the surface tracer concentrations are to be provided to the coupler.
 
-  integer, dimension(NTR) :: ind_tr ! Indices returned by aof_set_coupler_flux
-             ! if it is used and the surface tracer concentrations are to be
-             ! provided to the coupler.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< A pointer to the restart control structure.
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  type(MOM_restart_CS), pointer :: restart_CSp => NULL()
-
-  type(vardesc) :: tr_desc(NTR)
+  type(vardesc) :: tr_desc(NTR) !< Descriptions and metadata for the tracers
 end type advection_test_tracer_CS
 
 contains
 
+!> Register tracer fields and subroutines to be used with MOM.
 function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),        intent(in) :: HI   !< A horizontal index type structure
   type(verticalGrid_type),     intent(in) :: GV   !< The ocean's vertical grid structure
@@ -106,17 +108,8 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
                                                 !! structure for the tracer advection and
                                                 !! diffusion module
   type(MOM_restart_CS),        pointer    :: restart_CS !< A pointer to the restart control structure
-! This subroutine is used to register tracer fields and subroutines
-! to be used with MOM.
-! Arguments: HI - A horizontal index type structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
-!  (in/out)  tr_Reg - A pointer that is set to point to the control structure
-!                  for the tracer advection and diffusion module.
-!  (in)      restart_CS - A pointer to the restart control structure.
+
+  ! Local variables
   character(len=80)  :: name, longname
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -203,6 +196,7 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
   register_advection_test_tracer = .true.
 end function register_advection_test_tracer
 
+!>   Initializes the NTR tracer fields in tr(:,:,:,:) and it sets up the tracer output.
 subroutine initialize_advection_test_tracer(restart, day, G, GV, h,diag, OBC, CS, &
                                             sponge_CSp, diag_to_Z_CSp)
   logical,                            intent(in) :: restart !< .true. if the fields have already
@@ -222,24 +216,8 @@ subroutine initialize_advection_test_tracer(restart, day, G, GV, h,diag, OBC, CS
   type(sponge_CS),                    pointer    :: sponge_CSp !< Pointer to the control structure for the sponges.
   type(diag_to_Z_CS),                 pointer    :: diag_to_Z_CSp !< A pointer to the control structure
                                                                   !! for diagnostics in depth space.
-!   This subroutine initializes the NTR tracer fields in tr(:,:,:,:)
-! and it sets up the tracer output.
 
-! Arguments: restart - .true. if the fields have already been read from
-!                     a restart file.
-!  (in)      day - Time of the start of the run.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in)      OBC - This open boundary condition type specifies whether, where,
-!                  and what open boundary conditions are used.
-!  (in/out)  CS - The control structure returned by a previous call to
-!                 register_advection_test_tracer.
-!  (in/out)  sponge_CSp - A pointer to the control structure for the sponges, if
-!                         they are in use.  Otherwise this may be unassociated.
-!  (in/out)  diag_to_Z_Csp - A pointer to the control structure for diagnostics
-!                            in depth space.
+  ! Local variables
   real, allocatable :: temp(:,:,:)
   real, pointer, dimension(:,:,:) :: &
     OBC_tr1_u => NULL(), & ! These arrays should be allocated and set to
@@ -314,6 +292,8 @@ subroutine initialize_advection_test_tracer(restart, day, G, GV, h,diag, OBC, CS
 end subroutine initialize_advection_test_tracer
 
 
+!>   Applies diapycnal diffusion and any other column tracer physics or chemistry to the tracers
+!! from this package.  This is a simple example of a set of advected passive tracers.
 subroutine advection_test_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV, CS, &
               evap_CFL_limit, minimum_forcing_depth)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
@@ -343,24 +323,9 @@ subroutine advection_test_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, 
 ! tracer physics or chemistry to the tracers from this file.
 ! This is a simple example of a set of advected passive tracers.
 
-! Arguments: h_old -  Layer thickness before entrainment, in m or kg m-2.
-!  (in)      h_new -  Layer thickness after entrainment, in m or kg m-2.
-!  (in)      ea - an array to which the amount of fluid entrained
-!                 from the layer above during this call will be
-!                 added, in m or kg m-2.
-!  (in)      eb - an array to which the amount of fluid entrained
-!                 from the layer below during this call will be
-!                 added, in m or kg m-2.
-!  (in)      fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      dt - The amount of time covered by this call, in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_advection_test_tracer.
-!
 ! The arguments to this subroutine are redundant in that
 !     h_new[k] = h_old[k] + ea[k] - eb[k-1] + eb[k] - ea[k+1]
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
   real :: b1(SZI_(G))          ! b1 and c1 are variables used by the
   real :: c1(SZI_(G),SZK_(G))  ! tridiagonal solver.
@@ -419,34 +384,20 @@ subroutine advection_test_tracer_surface_state(state, h, G, CS)
 
 end subroutine advection_test_tracer_surface_state
 
+!> Calculate the mass-weighted integral of all tracer stocks, returning the number of stocks it has calculated.
+!!  If the stock_index is present, only the stock corresponding to that coded index is returned.
 function advection_test_stock(h, stocks, G, GV, CS, names, units, stock_index)
-  type(ocean_grid_type),              intent(in)    :: G    !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  type(ocean_grid_type),              intent(in)    :: G      !< The ocean's grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h   !< Layer thicknesses, in H (usually m or kg m-2)
   real, dimension(:),                 intent(out)   :: stocks !< the mass-weighted integrated amount of each
                                                               !! tracer, in kg times concentration units.
-  type(verticalGrid_type),            intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(verticalGrid_type),            intent(in)    :: GV     !< The ocean's vertical grid structure
   type(advection_test_tracer_CS),     pointer       :: CS     !< The control structure returned by a previous
                                                               !! call to register_advection_test_tracer.
   character(len=*), dimension(:),     intent(out)   :: names  !< the names of the stocks calculated.
   character(len=*), dimension(:),     intent(out)   :: units  !< the units of the stocks calculated.
-  integer, optional,                  intent(in)    :: stock_index !< the coded index of a specific stock
-                                                                   !! being sought.
-  integer                                           :: advection_test_stock
-! This function calculates the mass-weighted integral of all tracer stocks,
-! returning the number of stocks it has calculated.  If the stock_index
-! is present, only the stock corresponding to that coded index is returned.
-
-! Arguments: h - Layer thickness, in m or kg m-2.
-!  (out)     stocks - the mass-weighted integrated amount of each tracer,
-!                     in kg times concentration units.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_ideal_age_tracer.
-!  (out)     names - the names of the stocks calculated.
-!  (out)     units - the units of the stocks calculated.
-!  (in,opt)  stock_index - the coded index of a specific stock being sought.
-! Return value: the number of stocks calculated here.
+  integer, optional,                  intent(in)    :: stock_index !< the coded index of a specific stock being sought.
+  integer                                           :: advection_test_stock !< the number of stocks calculated here.
 
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -475,6 +426,7 @@ function advection_test_stock(h, stocks, G, GV, CS, names, units, stock_index)
 
 end function advection_test_stock
 
+!> Deallocate memory associated with this module
 subroutine advection_test_tracer_end(CS)
   type(advection_test_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                               !! call to register_advection_test_tracer.

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -33,33 +33,31 @@ public register_boundary_impulse_tracer, initialize_boundary_impulse_tracer
 public boundary_impulse_tracer_column_physics, boundary_impulse_tracer_surface_state
 public boundary_impulse_stock, boundary_impulse_tracer_end
 
-! NTR_MAX is the maximum number of tracers in this module.
+!> NTR_MAX is the maximum number of tracers in this module.
 integer, parameter :: NTR_MAX = 1
 
+!> The control structure for the boundary impulse tracer package
 type, public :: boundary_impulse_tracer_CS ; private
-  integer :: ntr=NTR_MAX    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false. ! These tracers are not offered to the  coupler.
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
-  logical :: tracers_may_reinit  ! If true, boundary_impulse can be initialized if
-                                 ! not found in restart file
-  integer, dimension(NTR_MAX) :: &
-    ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
-               ! surface tracer concentrations are to be provided to the coupler.
+  integer :: ntr=NTR_MAX    !< The number of tracers that are actually used.
+  logical :: coupled_tracers = .false. !< These tracers are not offered to the  coupler.
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
+  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine, in g m-3?
+  logical :: tracers_may_reinit  !< If true, boundary_impulse can be initialized if not found in restart file
+  integer, dimension(NTR_MAX) :: ind_tr  !< Indices returned by aof_set_coupler_flux if it is used and the
+                                         !! surface tracer concentrations are to be provided to the coupler.
 
-  integer :: nkml ! Number of layers in mixed layer
-  real, dimension(NTR_MAX)  :: land_val = -1.0
-  real :: kw_eff ! An effective piston velocity used to flux tracer out at the surface
-  real :: remaining_source_time ! How much longer (same units as the timestep) to
-                                ! inject the tracer at the surface
+  integer :: nkml !< Number of layers in mixed layer
+  real, dimension(NTR_MAX)  :: land_val = -1.0 !< A value to use to fill in tracers over land
+  real :: kw_eff !< An effective piston velocity used to flux tracer out at the surface
+  real :: remaining_source_time !< How much longer (same units as the timestep) to
+                                !! inject the tracer at the surface
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  type(MOM_restart_CS), pointer :: restart_CSp => NULL()
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< A pointer to the retart control structure
 
-  type(vardesc) :: tr_desc(NTR_MAX)
+  type(vardesc) :: tr_desc(NTR_MAX) !< Descriptions and metadata for the tracers
 end type boundary_impulse_tracer_CS
 
 contains
@@ -75,26 +73,16 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
                                                           !! structure for the tracer advection and
                                                           !! diffusion module
   type(MOM_restart_CS),             pointer       :: restart_CS !< A pointer to the restart control structure
-! This subroutine is used to register tracer fields and subroutines
-! to be used with MOM.
-! Arguments: HI - A horizontal index type structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
-!  (in/out)  tr_Reg - A pointer that is set to point to the control structure
-!                  for the tracer advection and diffusion module.
-!  (in)      restart_CS - A pointer to the restart control structure.
 
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! Local variables
   character(len=40)  :: mdl = "boundary_impulse_tracer" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=3)   :: name_tag ! String for creating identifying boundary_impulse
   character(len=48)  :: flux_units ! The units for tracer fluxes, usually
                             ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
+  ! This include declares and sets the variable "version".
+#include "version_variable.h"
   real, pointer :: tr_ptr(:,:,:) => NULL()
   real, pointer :: rem_time_ptr => NULL()
   logical :: register_boundary_impulse_tracer
@@ -181,24 +169,7 @@ subroutine initialize_boundary_impulse_tracer(restart, day, G, GV, h, diag, OBC,
                                                          !! for diagnostics in depth space.
   type(thermo_var_ptrs),              intent(in) :: tv   !< A structure pointing to various
                                                          !! thermodynamic variables
-!   This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
-! and it sets up the tracer output.
-
-! Arguments: restart - .true. if the fields have already been read from
-!                     a restart file.
-!  (in)      day - Time of the start of the run.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in)      OBC - This open boundary condition type specifies whether, where,
-!                  and what open boundary conditions are used.
-!  (in/out)  CS - The control structure returned by a previous call to
-!                 register_boundary_impulse_tracer.
-!  (in/out)  sponge_CSp - A pointer to the control structure for the sponges, if
-!                         they are in use.  Otherwise this may be unassociated.
-!  (in/out)  diag_to_Z_Csp - A pointer to the control structure for diagnostics
-!                            in depth space.
+  ! Local variables
   character(len=16) :: name     ! A variable's name in a NetCDF file.
   character(len=72) :: longname ! The long name of that variable.
   character(len=48) :: units    ! The dimensions of the variable.
@@ -234,7 +205,7 @@ subroutine initialize_boundary_impulse_tracer(restart, day, G, GV, h, diag, OBC,
 
 end subroutine initialize_boundary_impulse_tracer
 
-! Apply source or sink at boundary and do vertical diffusion
+!> Apply source or sink at boundary and do vertical diffusion
 subroutine boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS, &
                      tv, debug, evap_CFL_limit, minimum_forcing_depth)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
@@ -268,31 +239,10 @@ subroutine boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, 
 ! tracer physics or chemistry to the tracers from this file.
 ! This is a simple example of a set of advected passive tracers.
 
-! Arguments: h_old -  Layer thickness before entrainment, in m or kg m-2.
-!  (in)      h_new -  Layer thickness after entrainment, in m or kg m-2.
-!  (in)      ea - an array to which the amount of fluid entrained
-!                 from the layer above during this call will be
-!                 added, in m or kg m-2.
-!  (in)      eb - an array to which the amount of fluid entrained
-!                 from the layer below during this call will be
-!                 added, in m or kg m-2.
-!  (in)      fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      dt - The amount of time covered by this call, in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_boundary_impulse_tracer.
-!  (in)      tv - Thermodynamic structure with T and S
-!  (in)      evap_CFL_limit - Limits how much water can be fluxed out of the top layer
-!                             Stored previously in diabatic CS.
-!  (in)      minimum_forcing_depth - The smallest depth over which fluxes can be applied
-!                             Stored previously in diabatic CS.
-!  (in)      debug - Calculates checksums
-!
 ! The arguments to this subroutine are redundant in that
 !     h_new[k] = h_old[k] + ea[k] - eb[k-1] + eb[k] - ea[k+1]
 
+  ! Local variables
   real :: Isecs_per_year = 1.0 / (365.0*86400.0)
   real :: year, h_total, scale, htot, Ih_limit
   integer :: secs, days
@@ -352,18 +302,7 @@ function boundary_impulse_stock(h, stocks, G, GV, CS, names, units, stock_index)
 ! returning the number of stocks it has calculated.  If the stock_index
 ! is present, only the stock corresponding to that coded index is returned.
 
-! Arguments: h - Layer thickness, in m or kg m-2.
-!  (out)     stocks - the mass-weighted integrated amount of each tracer,
-!                     in kg times concentration units.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_boundary_impulse_tracer.
-!  (out)     names - the names of the stocks calculated.
-!  (out)     units - the units of the stocks calculated.
-!  (in,opt)  stock_index - the coded index of a specific stock being sought.
-! Return value: the number of stocks calculated here.
-
+  ! Local variables
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -426,7 +365,7 @@ subroutine boundary_impulse_tracer_surface_state(state, h, G, CS)
 
 end subroutine boundary_impulse_tracer_surface_state
 
-! Performs finalization of boundary impulse tracer
+!> Performs finalization of boundary impulse tracer
 subroutine boundary_impulse_tracer_end(CS)
   type(boundary_impulse_tracer_CS), pointer :: CS   !< The control structure returned by a previous
                                                     !! call to register_boundary_impulse_tracer.

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -32,30 +32,28 @@ public dye_tracer_column_physics, dye_tracer_surface_state
 public dye_stock, regional_dyes_end
 
 
+!> The control structure for the regional dyes tracer package
 type, public :: dye_tracer_CS ; private
-  integer :: ntr    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false.  ! These tracers are not offered to the
-                                        ! coupler.
-  real, allocatable, dimension(:) :: dye_source_minlon, & ! Minimum longitude of region dye will be injected.
-                                     dye_source_maxlon, & ! Maximum longitude of region dye will be injected.
-                                     dye_source_minlat, & ! Minimum latitude of region dye will be injected.
-                                     dye_source_maxlat, & ! Maximum latitude of region dye will be injected.
-                                     dye_source_mindepth, & ! Minimum depth of region dye will be injected (m).
-                                     dye_source_maxdepth  ! Maximum depth of region dye will be injected (m).
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
+  integer :: ntr    !< The number of tracers that are actually used.
+  logical :: coupled_tracers = .false.  !< These tracers are not offered to the coupler.
+  real, allocatable, dimension(:) :: dye_source_minlon !< Minimum longitude of region dye will be injected.
+  real, allocatable, dimension(:) :: dye_source_maxlon !< Maximum longitude of region dye will be injected.
+  real, allocatable, dimension(:) :: dye_source_minlat !< Minimum latitude of region dye will be injected.
+  real, allocatable, dimension(:) :: dye_source_maxlat !< Maximum latitude of region dye will be injected.
+  real, allocatable, dimension(:) :: dye_source_mindepth !< Minimum depth of region dye will be injected (m).
+  real, allocatable, dimension(:) :: dye_source_maxdepth !< Maximum depth of region dye will be injected (m).
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
+  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine, in g m-3?
 
-  integer, allocatable, dimension(:) :: &
-    ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
-               ! surface tracer concentrations are to be provided to the coupler.
+  integer, allocatable, dimension(:) :: ind_tr !< Indices returned by aof_set_coupler_flux if it is used and the
+                                               !! surface tracer concentrations are to be provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  type(MOM_restart_CS), pointer :: restart_CSp => NULL()
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< A pointer to the restart control structure
 
-  type(vardesc), allocatable :: tr_desc(:)
-  logical :: tracers_may_reinit = .false. ! hard-coding here (mjh)
+  type(vardesc), allocatable :: tr_desc(:) !< Descriptions and metadata for the tracers
+  logical :: tracers_may_reinit = .false. !< If true the tracers may be initialized if not found in a restart file
 end type dye_tracer_CS
 
 contains

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -28,31 +28,28 @@ implicit none ; private
 public register_dyed_obc_tracer, initialize_dyed_obc_tracer
 public dyed_obc_tracer_column_physics, dyed_obc_tracer_end
 
+!> The control structure for the dyed_obc tracer package
 type, public :: dyed_obc_tracer_CS ; private
-  integer :: ntr    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
-  character(len=200) :: tracer_IC_file ! The full path to the IC file, or " "
-                                       ! to initialize internally.
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
+  integer :: ntr    !< The number of tracers that are actually used.
+  logical :: coupled_tracers = .false. !< These tracers are not offered to the coupler.
+  character(len=200) :: tracer_IC_file !< The full path to the IC file, or " " to initialize internally.
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this subroutine, in g m-3?
 
-  integer, allocatable, dimension(:) :: &
-    ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
-               ! surface tracer concentrations are to be provided to the coupler.
+  integer, allocatable, dimension(:) :: ind_tr !< Indices returned by aof_set_coupler_flux if it is used and the
+                                               !! surface tracer concentrations are to be provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  type(MOM_restart_CS), pointer :: restart_CSp => NULL()
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< A pointer to the restart control structure
 
-  type(vardesc), allocatable :: tr_desc(:)
+  type(vardesc), allocatable :: tr_desc(:) !< Descriptions and metadata for the tracers
 end type dyed_obc_tracer_CS
 
 contains
 
-!> This subroutine is used to register tracer fields and subroutines
-!! to be used with MOM.
+!> Register tracer fields and subroutines to be used with MOM.
 function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),       intent(in) :: HI   !< A horizontal index type structure.
   type(verticalGrid_type),    intent(in) :: GV   !< The ocean's vertical grid structure
@@ -133,10 +130,8 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   register_dyed_obc_tracer = .true.
 end function register_dyed_obc_tracer
 
-!> This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
-!! and it sets up the tracer output.
-subroutine initialize_dyed_obc_tracer(restart, day, G, GV, h, diag, OBC, CS, &
-                                  diag_to_Z_CSp)
+!> Initializes the CS%ntr tracer fields in tr(:,:,:,:) and sets up the tracer output.
+subroutine initialize_dyed_obc_tracer(restart, day, G, GV, h, diag, OBC, CS, diag_to_Z_CSp)
   type(ocean_grid_type),                 intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type),               intent(in) :: GV   !< The ocean's vertical grid structure
   logical,                               intent(in) :: restart !< .true. if the fields have already

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -69,44 +69,42 @@ public ideal_age_stock, ideal_age_example_end
 ! NTR_MAX is the maximum number of tracers in this module.
 integer, parameter :: NTR_MAX = 3
 
+!> The control structure for the ideal_age_tracer package
 type, public :: ideal_age_tracer_CS ; private
-  integer :: ntr    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
-  integer :: nkml   ! The number of layers in the mixed layer.  The ideal
-                    ! age tracers are reset in the top nkml layers.
-  character(len=200) :: IC_file ! The file in which the age-tracer initial values
-                    ! can be found, or an empty string for internal initialization.
-  logical :: Z_IC_file ! If true, the IC_file is in Z-space.  The default is false.
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
-  real, dimension(NTR_MAX) :: &
-    IC_val = 0.0, &    ! The (uniform) initial condition value.
-    young_val = 0.0, & ! The value assigned to tr at the surface.
-    land_val = -1.0, & ! The value of tr used where land is masked out.
-    sfc_growth_rate, & ! The exponential growth rate for the surface value,
-                       ! in units of year-1.
-    tracer_start_year  ! The year in which tracers start aging, or at which the
-                       ! surface value equals young_val, in years.
-  logical :: tracers_may_reinit  ! If true, tracers may go through the
-                           ! initialization code if they are not found in the
-                           ! restart files.
-  logical :: tracer_ages(NTR_MAX)
+  integer :: ntr    !< The number of tracers that are actually used.
+  logical :: coupled_tracers = .false. !< These tracers are not offered to the coupler.
+  integer :: nkml   !< The number of layers in the mixed layer.  The ideal
+                    !1 age tracers are reset in the top nkml layers.
+  character(len=200) :: IC_file !< The file in which the age-tracer initial values
+                    !! can be found, or an empty string for internal initialization.
+  logical :: Z_IC_file !< If true, the IC_file is in Z-space.  The default is false.
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in g m-3?
+  real, dimension(NTR_MAX) :: IC_val = 0.0    !< The (uniform) initial condition value.
+  real, dimension(NTR_MAX) :: young_val = 0.0 !< The value assigned to tr at the surface.
+  real, dimension(NTR_MAX) :: land_val = -1.0 !< The value of tr used where land is masked out.
+  real, dimension(NTR_MAX) :: sfc_growth_rate !< The exponential growth rate for the surface value,
+                                              !! in units of year-1.
+  real, dimension(NTR_MAX) :: tracer_start_year !< The year in which tracers start aging, or at which the
+                                              !! surface value equals young_val, in years.
+  logical :: tracers_may_reinit  !< If true, these tracers be set up via the initialization code if
+                                 !! they are not found in the restart files.
+  logical :: tracer_ages(NTR_MAX) !< Indicates whether each tracer ages.
 
-  integer, dimension(NTR_MAX) :: &
-    ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
-               ! surface tracer concentrations are to be provided to the coupler.
+  integer, dimension(NTR_MAX) :: ind_tr !< Indices returned by aof_set_coupler_flux if it is used and the
+                                        !! surface tracer concentrations are to be provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  type(MOM_restart_CS), pointer :: restart_CSp => NULL()
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< A pointer to the restart controls structure
 
-  type(vardesc) :: tr_desc(NTR_MAX)
+  type(vardesc) :: tr_desc(NTR_MAX) !< Descriptions and metadata for the tracers
 end type ideal_age_tracer_CS
 
 contains
 
+!> Register the ideal age tracer fields to be used with MOM.
 function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),       intent(in) :: HI   !< A horizontal index type structure
   type(verticalGrid_type),    intent(in) :: GV   !< The ocean's vertical grid structure
@@ -117,16 +115,6 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                                                   !! structure for the tracer advection and
                                                   !! diffusion module
   type(MOM_restart_CS),       pointer    :: restart_CS !< A pointer to the restart control structure
-! This subroutine is used to register tracer fields and subroutines
-! to be used with MOM.
-! Arguments: HI - A horizontal index type structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
-!  (in/out)  tr_Reg - A pointer that is set to point to the control structure
-!                  for the tracer advection and diffusion module.
-!  (in)      restart_CS - A pointer to the restart control structure.
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -239,6 +227,7 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   register_ideal_age_tracer = .true.
 end function register_ideal_age_tracer
 
+!> Sets the ideal age traces to their initial values and sets up the tracer output
 subroutine initialize_ideal_age_tracer(restart, day, G, GV, h, diag, OBC, CS, &
                                        sponge_CSp, diag_to_Z_CSp)
   logical,                            intent(in) :: restart !< .true. if the fields have already
@@ -261,21 +250,7 @@ subroutine initialize_ideal_age_tracer(restart, day, G, GV, h, diag, OBC, CS, &
 !   This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
 ! and it sets up the tracer output.
 
-! Arguments: restart - .true. if the fields have already been read from
-!                     a restart file.
-!  (in)      day - Time of the start of the run.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in)      OBC - This open boundary condition type specifies whether, where,
-!                  and what open boundary conditions are used.
-!  (in/out)  CS - The control structure returned by a previous call to
-!                 register_ideal_age_tracer.
-!  (in/out)  sponge_CSp - A pointer to the control structure for the sponges, if
-!                         they are in use.  Otherwise this may be unassociated.
-!  (in/out)  diag_to_Z_Csp - A pointer to the control structure for diagnostics
-!                            in depth space.
+  ! Local variables
   character(len=24) :: name     ! A variable's name in a NetCDF file.
   character(len=72) :: longname ! The long name of that variable.
   character(len=48) :: units    ! The dimensions of the variable.
@@ -340,6 +315,7 @@ subroutine initialize_ideal_age_tracer(restart, day, G, GV, h, diag, OBC, CS, &
 
 end subroutine initialize_ideal_age_tracer
 
+!> Applies diapycnal diffusion, aging and regeneration at the surface to the ideal age tracers
 subroutine ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS, &
               evap_CFL_limit, minimum_forcing_depth)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
@@ -369,24 +345,9 @@ subroutine ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, 
 ! tracer physics or chemistry to the tracers from this file.
 ! This is a simple example of a set of advected passive tracers.
 
-! Arguments: h_old -  Layer thickness before entrainment, in m or kg m-2.
-!  (in)      h_new -  Layer thickness after entrainment, in m or kg m-2.
-!  (in)      ea - an array to which the amount of fluid entrained
-!                 from the layer above during this call will be
-!                 added, in m or kg m-2.
-!  (in)      eb - an array to which the amount of fluid entrained
-!                 from the layer below during this call will be
-!                 added, in m or kg m-2.
-!  (in)      fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      dt - The amount of time covered by this call, in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_ideal_age_tracer.
-!
 ! The arguments to this subroutine are redundant in that
 !     h_new[k] = h_old[k] + ea[k] - eb[k-1] + eb[k] - ea[k+1]
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
   real :: sfc_val  ! The surface value for the tracers.
   real :: Isecs_per_year  ! The number of seconds in a year.
@@ -444,35 +405,25 @@ subroutine ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, 
 
 end subroutine ideal_age_tracer_column_physics
 
+!> Calculates the mass-weighted integral of all tracer stocks, returning the number of stocks it
+!! has calculated.  If stock_index is present, only the stock corresponding to that coded index is found.
 function ideal_age_stock(h, stocks, G, GV, CS, names, units, stock_index)
   type(ocean_grid_type),              intent(in)    :: G    !< The ocean's grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                                       intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   real, dimension(:),                 intent(out)   :: stocks !< the mass-weighted integrated amount of each
-                                                              !! tracer, in kg times concentration units.
+                                                            !! tracer, in kg times concentration units.
   type(verticalGrid_type),            intent(in)    :: GV   !< The ocean's vertical grid structure
-  type(ideal_age_tracer_CS),          pointer       :: CS !< The control structure returned by a previous
-                                              !! call to register_ideal_age_tracer.
+  type(ideal_age_tracer_CS),          pointer       :: CS   !< The control structure returned by a previous
+                                                            !! call to register_ideal_age_tracer.
   character(len=*), dimension(:),     intent(out)   :: names  !< the names of the stocks calculated.
   character(len=*), dimension(:),     intent(out)   :: units  !< the units of the stocks calculated.
   integer, optional,                  intent(in)    :: stock_index !< the coded index of a specific stock
                                                                    !! being sought.
-  integer                                           :: ideal_age_stock
+  integer                                           :: ideal_age_stock !< The number of stocks calculated here.
 ! This function calculates the mass-weighted integral of all tracer stocks,
 ! returning the number of stocks it has calculated.  If the stock_index
 ! is present, only the stock corresponding to that coded index is returned.
-
-! Arguments: h - Layer thickness, in m or kg m-2.
-!  (out)     stocks - the mass-weighted integrated amount of each tracer,
-!                     in kg times concentration units.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_ideal_age_tracer.
-!  (out)     names - the names of the stocks calculated.
-!  (out)     units - the units of the stocks calculated.
-!  (in,opt)  stock_index - the coded index of a specific stock being sought.
-! Return value: the number of stocks calculated here.
 
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -535,6 +486,7 @@ subroutine ideal_age_tracer_surface_state(state, h, G, CS)
 
 end subroutine ideal_age_tracer_surface_state
 
+!> Deallocate any memory associated with this tracer package
 subroutine ideal_age_example_end(CS)
   type(ideal_age_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                            !! call to register_ideal_age_tracer.

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -70,48 +70,46 @@ public oil_stock, oil_tracer_end
 ! NTR_MAX is the maximum number of tracers in this module.
 integer, parameter :: NTR_MAX = 20
 
+!> The control structure for the oil tracer package
 type, public :: oil_tracer_CS ; private
-  integer :: ntr    ! The number of tracers that are actually used.
-  logical :: coupled_tracers = .false. ! These tracers are not offered to the coupler.
-  character(len=200) :: IC_file ! The file in which the age-tracer initial values
-                    ! can be found, or an empty string for internal initialization.
-  logical :: Z_IC_file ! If true, the IC_file is in Z-space.  The default is false.
-  real :: oil_source_longitude, oil_source_latitude ! Lat,lon of source location (geographic)
-  integer :: oil_source_i=-999, oil_source_j=-999 ! Local i,j of source location (computational)
-  real :: oil_source_rate     ! Rate of oil injection (kg/s)
-  real :: oil_start_year      ! The year in which tracers start aging, or at which the
-                              ! surface value equals young_val, in years.
-  real :: oil_end_year        ! The year in which tracers start aging, or at which the
-                              ! surface value equals young_val, in years.
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
-  real, dimension(NTR_MAX) :: &
-    IC_val = 0.0, &    ! The (uniform) initial condition value.
-    young_val = 0.0, & ! The value assigned to tr at the surface.
-    land_val = -1.0, & ! The value of tr used where land is masked out.
-    sfc_growth_rate    ! The exponential growth rate for the surface value,
-                       ! in units of year-1.
-  real, dimension(NTR_MAX) ::  oil_decay_days, & ! Decay time scale of oil (in days)
-                               oil_decay_rate    ! Decay rate of oil (in s^-1) calculated from oil_decay_days
-  integer, dimension(NTR_MAX) ::  oil_source_k ! Layer of source
-  logical :: oil_may_reinit  ! If true, oil may go through the
-                           ! initialization code if they are not found in the
-                           ! restart files.
-  integer, dimension(NTR_MAX) :: &
-    ind_tr     ! Indices returned by aof_set_coupler_flux if it is used and the
-               ! surface tracer concentrations are to be provided to the coupler.
+  integer :: ntr    !< The number of tracers that are actually used.
+  logical :: coupled_tracers = .false. !< These tracers are not offered to the coupler.
+  character(len=200) :: IC_file !< The file in which the age-tracer initial values
+                                !! can be found, or an empty string for internal initialization.
+  logical :: Z_IC_file !< If true, the IC_file is in Z-space.  The default is false.
+  real :: oil_source_longitude !< Latitude of source location (geographic)
+  real :: oil_source_latitude  !< Longitude of source location (geographic)
+  integer :: oil_source_i=-999 !< Local i of source location (computational)
+  integer :: oil_source_j=-999 !< Local j of source location (computational)
+  real :: oil_source_rate     !< Rate of oil injection (kg/s)
+  real :: oil_start_year      !< The year in which tracers start aging, or at which the
+                              !! surface value equals young_val, in years.
+  real :: oil_end_year        !< The year in which tracers start aging, or at which the
+                              !! surface value equals young_val, in years.
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the MOM tracer registry
+  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine, in g m-3?
+  real, dimension(NTR_MAX) :: IC_val = 0.0    !< The (uniform) initial condition value.
+  real, dimension(NTR_MAX) :: young_val = 0.0 !< The value assigned to tr at the surface.
+  real, dimension(NTR_MAX) :: land_val = -1.0 !< The value of tr used where land is masked out.
+  real, dimension(NTR_MAX) :: sfc_growth_rate !< The exponential growth rate for the surface value, in units of year-1.
+  real, dimension(NTR_MAX) :: oil_decay_days  !< Decay time scale of oil (in days)
+  real, dimension(NTR_MAX) :: oil_decay_rate  !< Decay rate of oil (in s^-1) calculated from oil_decay_days
+  integer, dimension(NTR_MAX) :: oil_source_k !< Layer of source
+  logical :: oil_may_reinit  !< If true, oil tracers may be reset by the initialization code
+                             !! if they are not found in the restart files.
+  integer, dimension(NTR_MAX) :: ind_tr !< Indices returned by aof_set_coupler_flux if it is used and the
+                                        !! surface tracer concentrations are to be provided to the coupler.
+  type(vardesc) :: tr_desc(NTR_MAX) !< Descriptions and metadata for the tracers
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  type(MOM_restart_CS), pointer :: restart_CSp => NULL()
-
-  type(vardesc) :: tr_desc(NTR_MAX)
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< A pointer to the restart control structure
 end type oil_tracer_CS
 
 contains
 
+!> Register oil tracer fields and subroutines to be used with MOM.
 function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),       intent(in) :: HI   !< A horizontal index type structure
   type(verticalGrid_type),    intent(in) :: GV   !< The ocean's vertical grid structure
@@ -122,21 +120,11 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                                                   !! structure for the tracer advection and
                                                   !! diffusion module
   type(MOM_restart_CS),       pointer   :: restart_CS !< A pointer to the restart control structure
-! This subroutine is used to register tracer fields and subroutines
-! to be used with MOM.
-! Arguments: HI - A horizontal index type structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
-!  (in/out)  tr_Reg - A pointer that is set to point to the control structure
-!                  for the tracer advection and diffusion module.
-!  (in)      restart_CS - A pointer to the restart control structure.
 
+  ! Local variables
+  character(len=40)  :: mdl = "oil_tracer" ! This module's name.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mdl = "oil_tracer" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=3)   :: name_tag ! String for creating identifying oils
@@ -247,6 +235,7 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 
 end function register_oil_tracer
 
+!> Initialize the oil tracers and set up tracer output
 subroutine initialize_oil_tracer(restart, day, G, GV, h, diag, OBC, CS, &
                                   sponge_CSp, diag_to_Z_CSp)
   logical,                            intent(in) :: restart !< .true. if the fields have already
@@ -266,24 +255,8 @@ subroutine initialize_oil_tracer(restart, day, G, GV, h, diag, OBC, CS, &
   type(sponge_CS),                    pointer    :: sponge_CSp !< Pointer to the control structure for the sponges.
   type(diag_to_Z_CS),                 pointer    :: diag_to_Z_CSp !< A pointer to the control structure
                                                                   !! for diagnostics in depth space.
-!   This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
-! and it sets up the tracer output.
 
-! Arguments: restart - .true. if the fields have already been read from
-!                     a restart file.
-!  (in)      day - Time of the start of the run.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in)      OBC - This open boundary condition type specifies whether, where,
-!                  and what open boundary conditions are used.
-!  (in/out)  CS - The control structure returned by a previous call to
-!                 register_oil_tracer.
-!  (in/out)  sponge_CSp - A pointer to the control structure for the sponges, if
-!                         they are in use.  Otherwise this may be unassociated.
-!  (in/out)  diag_to_Z_Csp - A pointer to the control structure for diagnostics
-!                            in depth space.
+  ! Local variables
   character(len=16) :: name     ! A variable's name in a NetCDF file.
   character(len=72) :: longname ! The long name of that variable.
   character(len=48) :: units    ! The dimensions of the variable.
@@ -358,6 +331,7 @@ subroutine initialize_oil_tracer(restart, day, G, GV, h, diag, OBC, CS, &
 
 end subroutine initialize_oil_tracer
 
+!> Apply sources, sinks, diapycnal mixing and rising motions to the oil tracers
 subroutine oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS, tv, &
               evap_CFL_limit, minimum_forcing_depth)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
@@ -388,25 +362,10 @@ subroutine oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS
 ! tracer physics or chemistry to the tracers from this file.
 ! This is a simple example of a set of advected passive tracers.
 
-! Arguments: h_old -  Layer thickness before entrainment, in m or kg m-2.
-!  (in)      h_new -  Layer thickness after entrainment, in m or kg m-2.
-!  (in)      ea - an array to which the amount of fluid entrained
-!                 from the layer above during this call will be
-!                 added, in m or kg m-2.
-!  (in)      eb - an array to which the amount of fluid entrained
-!                 from the layer below during this call will be
-!                 added, in m or kg m-2.
-!  (in)      fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      dt - The amount of time covered by this call, in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_oil_tracer.
-!
 ! The arguments to this subroutine are redundant in that
 !     h_new[k] = h_old[k] + ea[k] - eb[k-1] + eb[k] - ea[k+1]
 
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
   real :: Isecs_per_year = 1.0 / (365.0*86400.0)
   real :: year, h_total, ldecay
@@ -482,6 +441,8 @@ subroutine oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS
 
 end subroutine oil_tracer_column_physics
 
+!> Calculate the mass-weighted integral of the oil tracer stocks, returning the number of stocks it
+!! has calculated.  If the stock_index is present, only the stock corresponding to that coded index is returned.
 function oil_stock(h, stocks, G, GV, CS, names, units, stock_index)
   type(ocean_grid_type),              intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),            intent(in)    :: GV   !< The ocean's vertical grid structure
@@ -494,23 +455,13 @@ function oil_stock(h, stocks, G, GV, CS, names, units, stock_index)
   character(len=*), dimension(:),     intent(out)   :: units  !< the units of the stocks calculated.
   integer, optional,                  intent(in)    :: stock_index !< the coded index of a specific stock
                                                                    !! being sought.
-  integer                                           :: oil_stock
+  integer                                           :: oil_stock !< The number of stocks calculated here.
+
 ! This function calculates the mass-weighted integral of all tracer stocks,
 ! returning the number of stocks it has calculated.  If the stock_index
 ! is present, only the stock corresponding to that coded index is returned.
 
-! Arguments: h - Layer thickness, in m or kg m-2.
-!  (out)     stocks - the mass-weighted integrated amount of each tracer,
-!                     in kg times concentration units.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_oil_tracer.
-!  (out)     names - the names of the stocks calculated.
-!  (out)     units - the units of the stocks calculated.
-!  (in,opt)  stock_index - the coded index of a specific stock being sought.
-! Return value: the number of stocks calculated here.
-
+  ! Local variables
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -572,6 +523,7 @@ subroutine oil_tracer_surface_state(state, h, G, CS)
 
 end subroutine oil_tracer_surface_state
 
+!> Deallocate memory associated with this tracer package
 subroutine oil_tracer_end(CS)
   type(oil_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                      !! call to register_oil_tracer.

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -67,26 +67,28 @@ public register_pseudo_salt_tracer, initialize_pseudo_salt_tracer
 public pseudo_salt_tracer_column_physics, pseudo_salt_tracer_surface_state
 public pseudo_salt_stock, pseudo_salt_tracer_end
 
+!> The control structure for the pseudo-salt tracer
 type, public :: pseudo_salt_tracer_CS ; private
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: ps(:,:,:) => NULL()   ! The array of pseudo-salt tracer used in this
-                                         ! subroutine, in psu
-  real, pointer :: diff(:,:,:) => NULL() ! The difference between the pseudo-salt
-                                         ! tracer and the real salt, in psu.
-  logical :: pseudo_salt_may_reinit = .true. ! Hard coding since this should not matter
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the MOM tracer registry
+  real, pointer :: ps(:,:,:) => NULL()   !< The array of pseudo-salt tracer used in this
+                                         !! subroutine, in psu
+  real, pointer :: diff(:,:,:) => NULL() !< The difference between the pseudo-salt
+                                         !! tracer and the real salt, in psu.
+  logical :: pseudo_salt_may_reinit = .true. !< Hard coding since this should not matter
 
-  integer :: id_psd = -1
+  integer :: id_psd = -1   !< A diagnostic ID
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
-  type(MOM_restart_CS), pointer :: restart_CSp => NULL()
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
+                                   !! regulate the timing of diagnostic output.
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< A pointer to the restart control structure
 
-  type(vardesc) :: tr_desc
+  type(vardesc) :: tr_desc !< A description and metadata for the pseudo-salt tracer
 end type pseudo_salt_tracer_CS
 
 contains
 
+!> Register the pseudo-salt tracer with MOM6
 function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),       intent(in) :: HI   !< A horizontal index type structure
   type(verticalGrid_type),    intent(in) :: GV   !< The ocean's vertical grid structure
@@ -99,22 +101,14 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(MOM_restart_CS),       pointer    :: restart_CS !< A pointer to the restart control structure
 ! This subroutine is used to register tracer fields and subroutines
 ! to be used with MOM.
-! Arguments: HI - A horizontal index type structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in/out)  CS - A pointer that is set to point to the control structure
-!                 for this module
-!  (in/out)  tr_Reg - A pointer that is set to point to the control structure
-!                  for the tracer advection and diffusion module.
-!  (in)      restart_CS - A pointer to the restart control structure.
 
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! Local variables
   character(len=40)  :: mdl = "pseudo_salt_tracer" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=3)   :: name_tag ! String for creating identifying pseudo_salt
+! This include declares and sets the variable "version".
+#include "version_variable.h"
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_pseudo_salt_tracer
   integer :: isd, ied, jsd, jed, nz, i, j
@@ -150,6 +144,7 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 
 end function register_pseudo_salt_tracer
 
+!> Initialize the pseudo-salt tracer
 subroutine initialize_pseudo_salt_tracer(restart, day, G, GV, h, diag, OBC, CS, &
                                   sponge_CSp, diag_to_Z_CSp, tv)
   logical,                            intent(in) :: restart !< .true. if the fields have already
@@ -172,21 +167,7 @@ subroutine initialize_pseudo_salt_tracer(restart, day, G, GV, h, diag, OBC, CS, 
   type(thermo_var_ptrs),              intent(in) :: tv   !< A structure pointing to various thermodynamic variables
 !   This subroutine initializes the tracer fields in CS%ps(:,:,:).
 
-! Arguments: restart - .true. if the fields have already been read from
-!                     a restart file.
-!  (in)      day - Time of the start of the run.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      h - Layer thickness, in m or kg m-2.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (in)      OBC - This open boundary condition type specifies whether, where,
-!                  and what open boundary conditions are used.
-!  (in/out)  CS - The control structure returned by a previous call to
-!                 register_pseudo_salt_tracer.
-!  (in/out)  sponge_CSp - A pointer to the control structure for the sponges, if
-!                         they are in use.  Otherwise this may be unassociated.
-!  (in/out)  diag_to_Z_Csp - A pointer to the control structure for diagnostics
-!                            in depth space.
+  ! Local variables
   character(len=16) :: name     ! A variable's name in a NetCDF file.
   character(len=72) :: longname ! The long name of that variable.
   character(len=48) :: units    ! The dimensions of the variable.
@@ -223,6 +204,7 @@ subroutine initialize_pseudo_salt_tracer(restart, day, G, GV, h, diag, OBC, CS, 
 
 end subroutine initialize_pseudo_salt_tracer
 
+!> Apply sources, sinks and diapycnal diffusion to the tracers in this package.
 subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, CS, tv, debug, &
               evap_CFL_limit, minimum_forcing_depth)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
@@ -253,34 +235,11 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
 
 !   This subroutine applies diapycnal diffusion and any other column
 ! tracer physics or chemistry to the tracers from this file.
-! This is a simple example of a set of advected passive tracers.
 
-! Arguments: h_old -  Layer thickness before entrainment, in m or kg m-2.
-!  (in)      h_new -  Layer thickness after entrainment, in m or kg m-2.
-!  (in)      ea - an array to which the amount of fluid entrained
-!                 from the layer above during this call will be
-!                 added, in m or kg m-2.
-!  (in)      eb - an array to which the amount of fluid entrained
-!                 from the layer below during this call will be
-!                 added, in m or kg m-2.
-!  (in)      fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      dt - The amount of time covered by this call, in s.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_pseudo_salt_tracer.
-!  (in)      tv - Thermodynamic structure with T and S
-!  (in)      evap_CFL_limit - Limits how much water can be fluxed out of the top layer
-!                             Stored previously in diabatic CS.
-!  (in)      minimum_forcing_depth - The smallest depth over which fluxes can be applied
-!                             Stored previously in diabatic CS.
-!  (in)      debug - Calculates checksums
-!
 ! The arguments to this subroutine are redundant in that
 !     h_new[k] = h_old[k] + ea[k] - eb[k-1] + eb[k] - ea[k+1]
 
-  real :: Isecs_per_year = 1.0 / (365.0*86400.0)
+  ! Local variables
   real :: year, h_total, scale, htot, Ih_limit
   integer :: secs, days
   integer :: i, j, k, is, ie, js, je, nz, k_max
@@ -321,6 +280,9 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
 
 end subroutine pseudo_salt_tracer_column_physics
 
+
+!> Calculates the mass-weighted integral of all tracer stocks, returning the number of stocks it has
+!! calculated.  If the stock_index is present, only the stock corresponding to that coded index is returned.
 function pseudo_salt_stock(h, stocks, G, GV, CS, names, units, stock_index)
   type(ocean_grid_type),              intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),            intent(in)    :: GV   !< The ocean's vertical grid structure
@@ -339,18 +301,6 @@ function pseudo_salt_stock(h, stocks, G, GV, CS, names, units, stock_index)
 ! This function calculates the mass-weighted integral of all tracer stocks,
 ! returning the number of stocks it has calculated.  If the stock_index
 ! is present, only the stock corresponding to that coded index is returned.
-
-! Arguments: h - Layer thickness, in m or kg m-2.
-!  (out)     stocks - the mass-weighted integrated amount of each tracer,
-!                     in kg times concentration units.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 register_pseudo_salt_tracer.
-!  (out)     names - the names of the stocks calculated.
-!  (out)     units - the units of the stocks calculated.
-!  (in,opt)  stock_index - the coded index of a specific stock being sought.
-! Return value: the number of stocks calculated here.
 
   integer :: i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -404,6 +354,7 @@ subroutine pseudo_salt_tracer_surface_state(state, h, G, CS)
 
 end subroutine pseudo_salt_tracer_surface_state
 
+!> Deallocate memory associated with this tracer package
 subroutine pseudo_salt_tracer_end(CS)
   type(pseudo_salt_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                               !! call to register_pseudo_salt_tracer.

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -62,32 +62,28 @@ public tracer_column_physics, USER_tracer_surface_state, USER_tracer_example_end
 ! NTR is the number of tracers in this module.
 integer, parameter :: NTR = 1
 
+!> The control structure for the USER_tracer_example module
 type, public :: USER_tracer_example_CS ; private
-  logical :: coupled_tracers = .false. ! These tracers are not offered to the
-                                       ! coupler.
-  character(len=200) :: tracer_IC_file ! The full path to the IC file, or " "
-                                       ! to initialize internally.
-  type(time_type), pointer :: Time => NULL() ! A pointer to the ocean model's clock.
-  type(tracer_registry_type), pointer :: tr_Reg => NULL()
-  real, pointer :: tr(:,:,:,:) => NULL()   ! The array of tracers used in this
-                                           ! subroutine, in g m-3?
-  real :: land_val(NTR) = -1.0 ! The value of tr used where land is masked out.
-  logical :: use_sponge    ! If true, sponges may be applied somewhere in the domain.
+  logical :: coupled_tracers = .false. !< These tracers are not offered to the coupler.
+  character(len=200) :: tracer_IC_file !< The full path to the IC file, or " "
+                                       !! to initialize internally.
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
+  real, pointer :: tr(:,:,:,:) => NULL()  !< The array of tracers used in this subroutine, in g m-3?
+  real :: land_val(NTR) = -1.0 !< The value of tr that is used where land is masked out.
+  logical :: use_sponge    !< If true, sponges may be applied somewhere in the domain.
 
-  integer, dimension(NTR) :: ind_tr ! Indices returned by aof_set_coupler_flux
-             ! if it is used and the surface tracer concentrations are to be
-             ! provided to the coupler.
+  integer, dimension(NTR) :: ind_tr !< Indices returned by aof_set_coupler_flux if it is used and the
+                                    !! surface tracer concentrations are to be provided to the coupler.
 
-  type(diag_ctrl), pointer :: diag => NULL() ! A structure that is used to
-                                   ! regulate the timing of diagnostic output.
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to regulate the timing of diagnostic output.
 
-  type(vardesc) :: tr_desc(NTR)
+  type(vardesc) :: tr_desc(NTR) !< Descriptions of each of the tracers.
 end type USER_tracer_example_CS
 
 contains
 
-!> This subroutine is used to register tracer fields and subroutines
-!! to be used with MOM.
+!> This subroutine is used to register tracer fields and subroutines to be used with MOM.
 function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),    intent(in)   :: HI   !< A horizontal index type structure
   type(verticalGrid_type), intent(in)   :: GV   !< The ocean's vertical grid structure


### PR DESCRIPTION
Fixed dOyxgenization in MOM Equation of State code

  Made numerous changes and additions to the dOxyGen comments in the MOM6 code
in the equation_of_state directory to correct errors and provide more accurate
automatically generated documentation.  No answers or MOM_parameter_doc files
are changed by these modifications. This list of commits in this PR include:
- NOAA-GFDL/MOM6@3e83e5f dOyxgenization of interfaces in MOM_EOS.F90
- NOAA-GFDL/MOM6@66d8c00 dOyxgenization of interfaces in MOM_EOS_NEMO.F90
- NOAA-GFDL/MOM6@638213c dOyxgenization of interfaces in MOM_EOS_TEOS10.F90
- NOAA-GFDL/MOM6@e85be66 dOyxgenization of interfaces in MOM_EOS_UNESCO.F90
- NOAA-GFDL/MOM6@8115d20 dOyxgenization of interfaces in MOM_EOS_Wright.F90
- NOAA-GFDL/MOM6@74247b6 dOyxgenization of interfaces in MOM_EOS_linear.F90
- NOAA-GFDL/MOM6@ca6f231 dOyxgenization of interfaces in MOM_TFreeze.F90
