### PR TITLE
Fix dOyxGenization in miscellaneous MOM6 code

### DIFF
--- a/config_src/solo_driver/coupler_types.F90
+++ b/config_src/solo_driver/coupler_types.F90
@@ -28,9 +28,11 @@ public coupler_type_extract_data, coupler_type_set_data
 public coupler_type_copy_1d_2d
 public coupler_type_copy_1d_3d
 
+
 !
 !       3-d fields
 !
+!> A type with a 3-d array of values and metadata
 type, public :: coupler_3d_values_type
   character(len=48)       :: name = ' '  !< The diagnostic name for this array
   real, pointer, contiguous, dimension(:,:,:) :: values => NULL() !< The pointer to the
@@ -47,6 +49,7 @@ type, public :: coupler_3d_values_type
                                          !! if it can not be read from a restart file
 end type coupler_3d_values_type
 
+!> A field with one or more related 3-d variables and collective metadata
 type, public :: coupler_3d_field_type
   character(len=48)                 :: name = ' ' !< name
   integer                           :: num_fields = 0 !< num_fields
@@ -66,19 +69,24 @@ type, public :: coupler_3d_field_type
   real                              :: mol_wt = 0.0 !< mol_wt
 end type coupler_3d_field_type
 
+!> A collection of 3-D boundary conditions for exchange between components
 type, public :: coupler_3d_bc_type
   integer                                            :: num_bcs = 0  !< The number of boundary condition fields
   type(coupler_3d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary
                                                                      !! condition fields
   logical    :: set = .false.       !< If true, this type has been initialized
-  integer    :: isd, isc, iec, ied  !< The i-direction data and computational domain index ranges for this type
-  integer    :: jsd, jsc, jec, jed  !< The j-direction data and computational domain index ranges for this type
-  integer    :: ks, ke              !< The k-direction index ranges for this type
+  !>@{ The i- and j-direction data and computational domain index ranges for this type
+  integer    :: isd, isc, iec, ied  ! The i-direction data and computational domain index ranges for this type
+  integer    :: jsd, jsc, jec, jed  ! The j-direction data and computational domain index ranges for this type
+  !!@}
+  integer    :: ks                  !< The k-direction start index for this type
+  integer    :: ke                  !< The k-direction end index for this type
 end type coupler_3d_bc_type
 
 !
 !       2-d fields
 !
+!> A type with a 2-d array of values and metadata
 type, public    :: coupler_2d_values_type
   character(len=48)       :: name = ' '  !< The diagnostic name for this array
   real, pointer, contiguous, dimension(:,:) :: values => NULL() !< The pointer to the
@@ -95,6 +103,7 @@ type, public    :: coupler_2d_values_type
                                          !! if it can not be read from a restart file
 end type coupler_2d_values_type
 
+!> A field with one or more related 2-d variables and collective metadata
 type, public    :: coupler_2d_field_type
   character(len=48)                 :: name = ' ' !< name
   integer                           :: num_fields = 0 !< num_fields
@@ -114,18 +123,22 @@ type, public    :: coupler_2d_field_type
   real                              :: mol_wt = 0.0 !< mol_wt
 end type coupler_2d_field_type
 
+!> A collection of 2-D boundary conditions for exchange between components
 type, public    :: coupler_2d_bc_type
   integer                                            :: num_bcs = 0  !< The number of boundary condition fields
   type(coupler_2d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary
                                                                      !! condition fields
   logical    :: set = .false.       !< If true, this type has been initialized
-  integer    :: isd, isc, iec, ied  !< The i-direction data and computational domain index ranges for this type
-  integer    :: jsd, jsc, jec, jed  !< The j-direction data and computational domain index ranges for this type
+  !>@{ The i- and j-direction data and computational domain index ranges for this type
+  integer    :: isd, isc, iec, ied  ! The i-direction data and computational domain index ranges for this type
+  integer    :: jsd, jsc, jec, jed  ! The j-direction data and computational domain index ranges for this type
+  !!@}
 end type coupler_2d_bc_type
 
 !
 !       1-d fields
 !
+!> A type with a 1-d array of values and metadata
 type, public    :: coupler_1d_values_type
   character(len=48)           :: name = ' '  !< The diagnostic name for this array
   real, pointer, dimension(:) :: values => NULL() !< The pointer to the array of values
@@ -139,6 +152,7 @@ type, public    :: coupler_1d_values_type
                                              !! if it can not be read from a restart file
 end type coupler_1d_values_type
 
+!> A field with one or more related 1-d variables and collective metadata
 type, public    :: coupler_1d_field_type
   character(len=48)              :: name = ' ' !< name
   integer                        :: num_fields = 0 !< num_fields
@@ -156,6 +170,7 @@ type, public    :: coupler_1d_field_type
   real                           :: mol_wt = 0.0 !< mol_wt
 end type coupler_1d_field_type
 
+!> A collection of 1-D boundary conditions for exchange between components
 type, public    :: coupler_1d_bc_type
   integer                                            :: num_bcs = 0  !< The number of boundary condition fields
   type(coupler_1d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -2,550 +2,550 @@
 module MOM_oda_driver_mod
 
 ! This file is part of MOM6. see LICENSE.md for the license.
-  use fms_mod, only : open_namelist_file, close_file, check_nml_error
-  use fms_mod, only : error_mesg, FATAL
-  use mpp_mod, only : stdout, stdlog, mpp_error, npes=>mpp_npes,pe=>mpp_pe
-  use mpp_mod, only : set_current_pelist => mpp_set_current_pelist
-  use mpp_mod, only : set_root_pe => mpp_set_root_pe
-  use mpp_mod, only : mpp_sync_self, mpp_sum, get_pelist=>mpp_get_current_pelist, mpp_root_pe
-  use mpp_mod, only : set_stack_size=>mpp_set_stack_size, broadcast=>mpp_broadcast
-  use mpp_io_mod, only : io_set_stack_size=>mpp_io_set_stack_size
-  use mpp_io_mod, only : MPP_SINGLE,MPP_MULTI
-  use mpp_domains_mod, only : domain2d, mpp_global_field
-  use mpp_domains_mod, only : mpp_get_compute_domain, mpp_get_data_domain
-  use mpp_domains_mod, only : mpp_redistribute, mpp_broadcast_domain
-  use mpp_domains_mod, only : set_domains_stack_size=>mpp_domains_set_stack_size
-  use diag_manager_mod, only : register_diag_field, diag_axis_init, send_data
-  use ensemble_manager_mod, only : get_ensemble_id, get_ensemble_size
-  use ensemble_manager_mod, only : get_ensemble_pelist, get_ensemble_filter_pelist
-  use time_manager_mod, only : time_type, decrement_time, increment_time
-  use time_manager_mod, only : get_date, get_time, operator(>=),operator(/=),operator(==),operator(<)
-  use constants_mod, only : radius, epsln
-  ! ODA Modules
-  use ocean_da_types_mod, only : grid_type, ocean_profile_type, ocean_control_struct
-  use ocean_da_core_mod, only : ocean_da_core_init, get_profiles
-  !use eakf_oda_mod, only : ensemble_filter
-  use write_ocean_obs_mod, only : open_profile_file
-  use write_ocean_obs_mod, only : write_profile,close_profile_file
-  use kdtree, only : kd_root !# JEDI
-  ! MOM Modules
-  use MOM_io, only : slasher, MOM_read_data
-  use MOM_diag_mediator, only : diag_ctrl, set_axes_info
-  use MOM_error_handler, only : FATAL, WARNING, MOM_error, MOM_mesg, is_root_pe
-  use MOM_get_input, only : get_MOM_input, directories
-  use MOM_variables, only : thermo_var_ptrs
-  use MOM_grid, only : ocean_grid_type, MOM_grid_init
-  use MOM_grid_initialize, only : set_grid_metrics
-  use MOM_hor_index, only : hor_index_type, hor_index_init
-  use MOM_dyn_horgrid, only : dyn_horgrid_type, create_dyn_horgrid, destroy_dyn_horgrid
-  use MOM_transcribe_grid, only : copy_dyngrid_to_MOM_grid, copy_MOM_grid_to_dyngrid
-  use MOM_fixed_initialization, only : MOM_initialize_fixed, MOM_initialize_topography
-  use MOM_coord_initialization, only : MOM_initialize_coord
-  use MOM_verticalGrid, only : verticalGrid_type, verticalGridInit
-  use MOM_file_parser, only : read_param, get_param, param_file_type
-  use MOM_string_functions, only : lowercase
-  use MOM_ALE, only : ALE_CS, ALE_initThicknessToCoord, ALE_init, ALE_updateVerticalGridType
-  use MOM_domains, only : MOM_domains_init, MOM_domain_type, clone_MOM_domain
-  use MOM_remapping, only : remapping_CS, initialize_remapping, remapping_core_h
-  use MOM_regridding, only : regridding_CS, initialize_regridding
-  use MOM_regridding, only : regridding_main, set_regrid_params
+use fms_mod, only : open_namelist_file, close_file, check_nml_error
+use fms_mod, only : error_mesg, FATAL
+use mpp_mod, only : stdout, stdlog, mpp_error, npes=>mpp_npes,pe=>mpp_pe
+use mpp_mod, only : set_current_pelist => mpp_set_current_pelist
+use mpp_mod, only : set_root_pe => mpp_set_root_pe
+use mpp_mod, only : mpp_sync_self, mpp_sum, get_pelist=>mpp_get_current_pelist, mpp_root_pe
+use mpp_mod, only : set_stack_size=>mpp_set_stack_size, broadcast=>mpp_broadcast
+use mpp_io_mod, only : io_set_stack_size=>mpp_io_set_stack_size
+use mpp_io_mod, only : MPP_SINGLE,MPP_MULTI
+use mpp_domains_mod, only : domain2d, mpp_global_field
+use mpp_domains_mod, only : mpp_get_compute_domain, mpp_get_data_domain
+use mpp_domains_mod, only : mpp_redistribute, mpp_broadcast_domain
+use mpp_domains_mod, only : set_domains_stack_size=>mpp_domains_set_stack_size
+use diag_manager_mod, only : register_diag_field, diag_axis_init, send_data
+use ensemble_manager_mod, only : get_ensemble_id, get_ensemble_size
+use ensemble_manager_mod, only : get_ensemble_pelist, get_ensemble_filter_pelist
+use time_manager_mod, only : time_type, decrement_time, increment_time
+use time_manager_mod, only : get_date, get_time, operator(>=),operator(/=),operator(==),operator(<)
+use constants_mod, only : radius, epsln
+! ODA Modules
+use ocean_da_types_mod, only : grid_type, ocean_profile_type, ocean_control_struct
+use ocean_da_core_mod, only : ocean_da_core_init, get_profiles
+!use eakf_oda_mod, only : ensemble_filter
+use write_ocean_obs_mod, only : open_profile_file
+use write_ocean_obs_mod, only : write_profile,close_profile_file
+use kdtree, only : kd_root !# JEDI
+! MOM Modules
+use MOM_io, only : slasher, MOM_read_data
+use MOM_diag_mediator, only : diag_ctrl, set_axes_info
+use MOM_error_handler, only : FATAL, WARNING, MOM_error, MOM_mesg, is_root_pe
+use MOM_get_input, only : get_MOM_input, directories
+use MOM_variables, only : thermo_var_ptrs
+use MOM_grid, only : ocean_grid_type, MOM_grid_init
+use MOM_grid_initialize, only : set_grid_metrics
+use MOM_hor_index, only : hor_index_type, hor_index_init
+use MOM_dyn_horgrid, only : dyn_horgrid_type, create_dyn_horgrid, destroy_dyn_horgrid
+use MOM_transcribe_grid, only : copy_dyngrid_to_MOM_grid, copy_MOM_grid_to_dyngrid
+use MOM_fixed_initialization, only : MOM_initialize_fixed, MOM_initialize_topography
+use MOM_coord_initialization, only : MOM_initialize_coord
+use MOM_verticalGrid, only : verticalGrid_type, verticalGridInit
+use MOM_file_parser, only : read_param, get_param, param_file_type
+use MOM_string_functions, only : lowercase
+use MOM_ALE, only : ALE_CS, ALE_initThicknessToCoord, ALE_init, ALE_updateVerticalGridType
+use MOM_domains, only : MOM_domains_init, MOM_domain_type, clone_MOM_domain
+use MOM_remapping, only : remapping_CS, initialize_remapping, remapping_core_h
+use MOM_regridding, only : regridding_CS, initialize_regridding
+use MOM_regridding, only : regridding_main, set_regrid_params
 
-  implicit none ; private
+implicit none ; private
 
-  public :: init_oda, oda_end, set_prior_tracer, get_posterior_tracer
-  public :: set_analysis_time, oda, save_obs_diff, apply_oda_tracer_increments
+public :: init_oda, oda_end, set_prior_tracer, get_posterior_tracer
+public :: set_analysis_time, oda, save_obs_diff, apply_oda_tracer_increments
 
 #include <MOM_memory.h>
 
-  !> Control structure that contains a transpose of the ocean state across ensemble members.
-  type, public :: ODA_CS ; private
-     type(ocean_control_struct), pointer :: Ocean_prior=> NULL() !< ensemble ocean prior states in DA space
-     type(ocean_control_struct), pointer :: Ocean_posterior=> NULL() !< ensemble ocean posterior states
-                                                                     !! or increments to prior in DA space
-     integer :: nk !< number of vertical layers used for DA
-     type(ocean_grid_type), pointer :: Grid => NULL() !< MOM6 grid type and decomposition for the DA
-     type(ptr_mpp_domain), pointer, dimension(:) :: domains => NULL() !< Pointer to mpp_domain objects
-                                                                          !! for ensemble members
-     type(verticalGrid_type), pointer :: GV => NULL() !< vertical grid for DA
-     type(domain2d), pointer :: mpp_domain => NULL() !< Pointer to a mpp domain object for DA
-     type(grid_type), pointer :: oda_grid !< local tracer grid
-     real, pointer, dimension(:,:,:) :: h => NULL() !<layer thicknesses (m or kg/m2) for DA
-     type(thermo_var_ptrs), pointer :: tv => NULL() !< pointer to thermodynamic variables
-     integer :: ni          !< global i-direction grid size
-     integer :: nj          !< global j-direction grid size
-     logical :: reentrant_x !< grid is reentrant in the x direction
-     logical :: reentrant_y !< grid is reentrant in the y direction
-     logical :: tripolar_N !< grid is folded at its north edge
-     logical :: symmetric !< Values at C-grid locations are symmetric
-     integer :: assim_method !< Method: NO_ASSIM,EAKF_ASSIM or OI_ASSIM
-     integer :: ensemble_size !< Size of the ensemble
-     integer :: ensemble_id = 0 !< id of the current ensemble member
-     integer, pointer, dimension(:,:) :: ensemble_pelist !< PE list for ensemble members
-     integer, pointer, dimension(:) :: filter_pelist !< PE list for ensemble members
-     integer :: assim_frequency !< analysis interval in hours
-     ! Profiles local to the analysis domain
-     type(ocean_profile_type), pointer :: Profiles => NULL() !< pointer to linked list of all available profiles
-     type(ocean_profile_type), pointer :: CProfiles => NULL()!< pointer to linked list of current profiles
-     type(kd_root), pointer :: kdroot => NULL() !< A structure for storing nearest neighbors
-     type(ALE_CS), pointer :: ALE_CS=>NULL() !< ALE control structure for DA
-     logical :: use_ALE_algorithm !< true is using ALE remapping
-     type(regridding_CS) :: regridCS !< ALE control structure for regridding
-     type(remapping_CS) :: remapCS !< ALE control structure for remapping
-     type(time_type) :: Time !< Current Analysis time
-     type(diag_ctrl) :: diag_cs !<Diagnostics control structure
-  end type ODA_CS
+!> Control structure that contains a transpose of the ocean state across ensemble members.
+type, public :: ODA_CS ; private
+  type(ocean_control_struct), pointer :: Ocean_prior=> NULL() !< ensemble ocean prior states in DA space
+  type(ocean_control_struct), pointer :: Ocean_posterior=> NULL() !< ensemble ocean posterior states
+                                                                  !! or increments to prior in DA space
+  integer :: nk !< number of vertical layers used for DA
+  type(ocean_grid_type), pointer :: Grid => NULL() !< MOM6 grid type and decomposition for the DA
+  type(ptr_mpp_domain), pointer, dimension(:) :: domains => NULL() !< Pointer to mpp_domain objects
+                                                                       !! for ensemble members
+  type(verticalGrid_type), pointer :: GV => NULL() !< vertical grid for DA
+  type(domain2d), pointer :: mpp_domain => NULL() !< Pointer to a mpp domain object for DA
+  type(grid_type), pointer :: oda_grid !< local tracer grid
+  real, pointer, dimension(:,:,:) :: h => NULL() !<layer thicknesses (m or kg/m2) for DA
+  type(thermo_var_ptrs), pointer :: tv => NULL() !< pointer to thermodynamic variables
+  integer :: ni          !< global i-direction grid size
+  integer :: nj          !< global j-direction grid size
+  logical :: reentrant_x !< grid is reentrant in the x direction
+  logical :: reentrant_y !< grid is reentrant in the y direction
+  logical :: tripolar_N !< grid is folded at its north edge
+  logical :: symmetric !< Values at C-grid locations are symmetric
+  integer :: assim_method !< Method: NO_ASSIM,EAKF_ASSIM or OI_ASSIM
+  integer :: ensemble_size !< Size of the ensemble
+  integer :: ensemble_id = 0 !< id of the current ensemble member
+  integer, pointer, dimension(:,:) :: ensemble_pelist !< PE list for ensemble members
+  integer, pointer, dimension(:) :: filter_pelist !< PE list for ensemble members
+  integer :: assim_frequency !< analysis interval in hours
+  ! Profiles local to the analysis domain
+  type(ocean_profile_type), pointer :: Profiles => NULL() !< pointer to linked list of all available profiles
+  type(ocean_profile_type), pointer :: CProfiles => NULL()!< pointer to linked list of current profiles
+  type(kd_root), pointer :: kdroot => NULL() !< A structure for storing nearest neighbors
+  type(ALE_CS), pointer :: ALE_CS=>NULL() !< ALE control structure for DA
+  logical :: use_ALE_algorithm !< true is using ALE remapping
+  type(regridding_CS) :: regridCS !< ALE control structure for regridding
+  type(remapping_CS) :: remapCS !< ALE control structure for remapping
+  type(time_type) :: Time !< Current Analysis time
+  type(diag_ctrl) :: diag_cs !<Diagnostics control structure
+end type ODA_CS
 
-  !> A structure with a pointer to a domain2d, to allow for the creation of arrays of pointers.
-  type :: ptr_mpp_domain
-    type(domain2d), pointer :: mpp_domain => NULL() !< pointer to an mpp domain2d
-  end type ptr_mpp_domain
+!> A structure with a pointer to a domain2d, to allow for the creation of arrays of pointers.
+type :: ptr_mpp_domain
+  type(domain2d), pointer :: mpp_domain => NULL() !< pointer to an mpp domain2d
+end type ptr_mpp_domain
 
-  !>@{  DA parameters
-  integer, parameter :: NO_ASSIM = 0, OI_ASSIM=1, EAKF_ASSIM=2
-  !!@}
+!>@{  DA parameters
+integer, parameter :: NO_ASSIM = 0, OI_ASSIM=1, EAKF_ASSIM=2
+!!@}
 
 contains
 
 !> initialize First_guess (prior) and Analysis grid
 !! information for all ensemble members
-  subroutine init_oda(Time, G, GV, CS)
+subroutine init_oda(Time, G, GV, CS)
 
-    type(time_type), intent(in) :: Time !< The current model time.
-    type(ocean_grid_type), pointer :: G !< domain and grid information for ocean model
-    type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
-    type(ODA_CS), pointer, intent(inout) :: CS  !< The DA control structure
+  type(time_type), intent(in) :: Time !< The current model time.
+  type(ocean_grid_type), pointer :: G !< domain and grid information for ocean model
+  type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
+  type(ODA_CS), pointer, intent(inout) :: CS  !< The DA control structure
 
- ! Local variables
-    type(thermo_var_ptrs) :: tv_dummy
-    type(dyn_horgrid_type), pointer :: dG=> NULL()
-    type(hor_index_type), pointer :: HI=> NULL()
-    type(directories) :: dirs
+! Local variables
+  type(thermo_var_ptrs) :: tv_dummy
+  type(dyn_horgrid_type), pointer :: dG=> NULL()
+  type(hor_index_type), pointer :: HI=> NULL()
+  type(directories) :: dirs
 
-    type(grid_type), pointer :: T_grid !< global tracer grid
-    real, dimension(:,:), allocatable :: global2D, global2D_old
-    real, dimension(:), allocatable :: lon1D, lat1D, glon1D, glat1D
-    type(param_file_type) :: PF
-    integer :: n, m, k, i, j, nk
-    integer :: is,ie,js,je,isd,ied,jsd,jed
-    integer :: stdout_unit
-    character(len=32) :: assim_method
-    integer :: npes_pm, ens_info(6), ni, nj
-    character(len=128) :: mesg
-    character(len=32) :: fldnam
-    character(len=30) :: coord_mode
-    character(len=200) :: inputdir, basin_file
-    logical :: reentrant_x, reentrant_y, tripolar_N, symmetric
+  type(grid_type), pointer :: T_grid !< global tracer grid
+  real, dimension(:,:), allocatable :: global2D, global2D_old
+  real, dimension(:), allocatable :: lon1D, lat1D, glon1D, glat1D
+  type(param_file_type) :: PF
+  integer :: n, m, k, i, j, nk
+  integer :: is,ie,js,je,isd,ied,jsd,jed
+  integer :: stdout_unit
+  character(len=32) :: assim_method
+  integer :: npes_pm, ens_info(6), ni, nj
+  character(len=128) :: mesg
+  character(len=32) :: fldnam
+  character(len=30) :: coord_mode
+  character(len=200) :: inputdir, basin_file
+  logical :: reentrant_x, reentrant_y, tripolar_N, symmetric
 
-    if (associated(CS)) call mpp_error(FATAL,'Calling oda_init with associated control structure')
-    allocate(CS)
+  if (associated(CS)) call mpp_error(FATAL,'Calling oda_init with associated control structure')
+  allocate(CS)
 ! Use ens1 parameters , this could be changed at a later time
 ! if it were desirable to have alternate parameters, e.g. for the grid
 ! for the analysis
-    call get_MOM_input(PF,dirs,ensemble_num=0)
-    call get_param(PF, "MOM", "ASSIM_METHOD", assim_method,  &
-         "String which determines the data assimilation method" // &
-         "Valid methods are: \'EAKF\',\'OI\', and \'NO_ASSIM\'", default='NO_ASSIM')
-    call get_param(PF, "MOM", "ASSIM_FREQUENCY", CS%assim_frequency,  &
-         "data assimilation frequency in hours")
-    call get_param(PF, "MOM", "USE_REGRIDDING", CS%use_ALE_algorithm , &
-                  "If True, use the ALE algorithm (regridding/remapping).\n"//&
-                  "If False, use the layered isopycnal algorithm.", default=.false. )
-    call get_param(PF, "MOM", "REENTRANT_X", CS%reentrant_x, &
-         "If true, the domain is zonally reentrant.", default=.true.)
-    call get_param(PF, "MOM", "REENTRANT_Y", CS%reentrant_y, &
-         "If true, the domain is meridionally reentrant.", &
-         default=.false.)
-    call get_param(PF,"MOM", "TRIPOLAR_N", CS%tripolar_N, &
-         "Use tripolar connectivity at the northern edge of the \n"//&
-         "domain.  With TRIPOLAR_N, NIGLOBAL must be even.", &
-         default=.false.)
-    call get_param(PF,"MOM", "NIGLOBAL", CS%ni, &
-         "The total number of thickness grid points in the \n"//&
-         "x-direction in the physical domain.")
-    call get_param(PF,"MOM", "NJGLOBAL", CS%nj, &
-         "The total number of thickness grid points in the \n"//&
-         "y-direction in the physical domain.")
-    call get_param(PF, 'MOM', "INPUTDIR", inputdir)
-    inputdir = slasher(inputdir)
+  call get_MOM_input(PF,dirs,ensemble_num=0)
+  call get_param(PF, "MOM", "ASSIM_METHOD", assim_method,  &
+       "String which determines the data assimilation method" // &
+       "Valid methods are: \'EAKF\',\'OI\', and \'NO_ASSIM\'", default='NO_ASSIM')
+  call get_param(PF, "MOM", "ASSIM_FREQUENCY", CS%assim_frequency,  &
+       "data assimilation frequency in hours")
+  call get_param(PF, "MOM", "USE_REGRIDDING", CS%use_ALE_algorithm , &
+                "If True, use the ALE algorithm (regridding/remapping).\n"//&
+                "If False, use the layered isopycnal algorithm.", default=.false. )
+  call get_param(PF, "MOM", "REENTRANT_X", CS%reentrant_x, &
+       "If true, the domain is zonally reentrant.", default=.true.)
+  call get_param(PF, "MOM", "REENTRANT_Y", CS%reentrant_y, &
+       "If true, the domain is meridionally reentrant.", &
+       default=.false.)
+  call get_param(PF,"MOM", "TRIPOLAR_N", CS%tripolar_N, &
+       "Use tripolar connectivity at the northern edge of the \n"//&
+       "domain.  With TRIPOLAR_N, NIGLOBAL must be even.", &
+       default=.false.)
+  call get_param(PF,"MOM", "NIGLOBAL", CS%ni, &
+       "The total number of thickness grid points in the \n"//&
+       "x-direction in the physical domain.")
+  call get_param(PF,"MOM", "NJGLOBAL", CS%nj, &
+       "The total number of thickness grid points in the \n"//&
+       "y-direction in the physical domain.")
+  call get_param(PF, 'MOM', "INPUTDIR", inputdir)
+  inputdir = slasher(inputdir)
 
-    select case(lowercase(trim(assim_method)))
-    case('eakf')
-        CS%assim_method = EAKF_ASSIM
-    case('oi')
-       CS%assim_method = OI_ASSIM
-    case('no_assim')
-        CS%assim_method = NO_ASSIM
-    case default
-        call mpp_error(FATAL,'Invalid assimilation method provided')
-    end select
+  select case(lowercase(trim(assim_method)))
+  case('eakf')
+      CS%assim_method = EAKF_ASSIM
+  case('oi')
+     CS%assim_method = OI_ASSIM
+  case('no_assim')
+      CS%assim_method = NO_ASSIM
+  case default
+      call mpp_error(FATAL,'Invalid assimilation method provided')
+  end select
 
-    ens_info = get_ensemble_size()
-    CS%ensemble_size = ens_info(1)
-    npes_pm=ens_info(3)
-    CS%ensemble_id = get_ensemble_id()
-    !! Switch to global pelist
-    allocate(CS%ensemble_pelist(CS%ensemble_size,npes_pm))
-    allocate(CS%filter_pelist(CS%ensemble_size*npes_pm))
-    call get_ensemble_pelist(CS%ensemble_pelist,'ocean')
-    call get_ensemble_filter_pelist(CS%filter_pelist,'ocean')
+  ens_info = get_ensemble_size()
+  CS%ensemble_size = ens_info(1)
+  npes_pm=ens_info(3)
+  CS%ensemble_id = get_ensemble_id()
+  !! Switch to global pelist
+  allocate(CS%ensemble_pelist(CS%ensemble_size,npes_pm))
+  allocate(CS%filter_pelist(CS%ensemble_size*npes_pm))
+  call get_ensemble_pelist(CS%ensemble_pelist,'ocean')
+  call get_ensemble_filter_pelist(CS%filter_pelist,'ocean')
 
-    call set_current_pelist(CS%filter_pelist)
+  call set_current_pelist(CS%filter_pelist)
 
-    allocate(CS%domains(CS%ensemble_size))
-    CS%domains(CS%ensemble_id)%mpp_domain => G%Domain%mpp_domain
-    do n=1,CS%ensemble_size
-      if (.not. associated(CS%domains(n)%mpp_domain)) allocate(CS%domains(n)%mpp_domain)
-      call set_root_pe(CS%ensemble_pelist(n,1))
-      call mpp_broadcast_domain(CS%domains(n)%mpp_domain)
-    enddo
-    call set_root_pe(CS%filter_pelist(1))
-    allocate(CS%Grid)
-    ! params NIHALO_ODA, NJHALO_ODA set the DA halo size
-    call MOM_domains_init(CS%Grid%Domain,PF,param_suffix='_ODA')
-    allocate(HI)
-    call hor_index_init(CS%Grid%Domain, HI, PF, &
-         local_indexing=.false.)  ! Use global indexing for DA
-    call verticalGridInit( PF, CS%GV )
-    allocate(dG)
-    call create_dyn_horgrid(dG,HI)
-    call clone_MOM_domain(CS%Grid%Domain, dG%Domain,symmetric=.false.)
-    call set_grid_metrics(dG,PF)
-    call MOM_initialize_topography(dg%bathyT,dG%max_depth,dG,PF)
-    call MOM_initialize_coord(CS%GV, PF, .false., &
-         dirs%output_directory, tv_dummy, dG%max_depth)
-    call ALE_init(PF, CS%GV, dG%max_depth, CS%ALE_CS)
-    call MOM_grid_init(CS%Grid, PF, global_indexing=.true.)
-    call ALE_updateVerticalGridType(CS%ALE_CS,CS%GV)
-    call copy_dyngrid_to_MOM_grid(dG, CS%Grid)
-    CS%mpp_domain => CS%Grid%Domain%mpp_domain
-    CS%Grid%ke = CS%GV%ke
-    CS%nk = CS%GV%ke
-    ! initialize storage for prior and posterior
-    allocate(CS%Ocean_prior)
-    call init_ocean_ensemble(CS%Ocean_prior,CS%Grid,CS%GV,CS%ensemble_size)
-    allocate(CS%Ocean_posterior)
-    call init_ocean_ensemble(CS%Ocean_posterior,CS%Grid,CS%GV,CS%ensemble_size)
-    allocate(CS%tv)
+  allocate(CS%domains(CS%ensemble_size))
+  CS%domains(CS%ensemble_id)%mpp_domain => G%Domain%mpp_domain
+  do n=1,CS%ensemble_size
+    if (.not. associated(CS%domains(n)%mpp_domain)) allocate(CS%domains(n)%mpp_domain)
+    call set_root_pe(CS%ensemble_pelist(n,1))
+    call mpp_broadcast_domain(CS%domains(n)%mpp_domain)
+  enddo
+  call set_root_pe(CS%filter_pelist(1))
+  allocate(CS%Grid)
+  ! params NIHALO_ODA, NJHALO_ODA set the DA halo size
+  call MOM_domains_init(CS%Grid%Domain,PF,param_suffix='_ODA')
+  allocate(HI)
+  call hor_index_init(CS%Grid%Domain, HI, PF, &
+                      local_indexing=.false.)  ! Use global indexing for DA
+  call verticalGridInit( PF, CS%GV )
+  allocate(dG)
+  call create_dyn_horgrid(dG,HI)
+  call clone_MOM_domain(CS%Grid%Domain, dG%Domain,symmetric=.false.)
+  call set_grid_metrics(dG,PF)
+  call MOM_initialize_topography(dg%bathyT,dG%max_depth,dG,PF)
+  call MOM_initialize_coord(CS%GV, PF, .false., &
+           dirs%output_directory, tv_dummy, dG%max_depth)
+  call ALE_init(PF, CS%GV, dG%max_depth, CS%ALE_CS)
+  call MOM_grid_init(CS%Grid, PF, global_indexing=.true.)
+  call ALE_updateVerticalGridType(CS%ALE_CS,CS%GV)
+  call copy_dyngrid_to_MOM_grid(dG, CS%Grid)
+  CS%mpp_domain => CS%Grid%Domain%mpp_domain
+  CS%Grid%ke = CS%GV%ke
+  CS%nk = CS%GV%ke
+  ! initialize storage for prior and posterior
+  allocate(CS%Ocean_prior)
+  call init_ocean_ensemble(CS%Ocean_prior,CS%Grid,CS%GV,CS%ensemble_size)
+  allocate(CS%Ocean_posterior)
+  call init_ocean_ensemble(CS%Ocean_posterior,CS%Grid,CS%GV,CS%ensemble_size)
+  allocate(CS%tv)
 
-    call get_param(PF, 'oda_driver', "REGRIDDING_COORDINATE_MODE", coord_mode, &
-         "Coordinate mode for vertical regridding.", &
-         default="ZSTAR", fail_if_missing=.false.)
-    call initialize_regridding(CS%regridCS, CS%GV, dG%max_depth,PF,'oda_driver',coord_mode,'','')
-    call initialize_remapping(CS%remapCS,'PLM')
-    call set_regrid_params(CS%regridCS, min_thickness=0.)
-    call mpp_get_data_domain(G%Domain%mpp_domain,isd,ied,jsd,jed)
-    if (.not. associated(CS%h)) then
-        allocate(CS%h(isd:ied,jsd:jed,CS%GV%ke)); CS%h(:,:,:)=0.0
-! assign thicknesses
-        call ALE_initThicknessToCoord(CS%ALE_CS,G,CS%GV,CS%h)
-    endif
-    allocate(CS%tv%T(isd:ied,jsd:jed,CS%GV%ke)); CS%tv%T(:,:,:)=0.0
-    allocate(CS%tv%S(isd:ied,jsd:jed,CS%GV%ke)); CS%tv%S(:,:,:)=0.0
+  call get_param(PF, 'oda_driver', "REGRIDDING_COORDINATE_MODE", coord_mode, &
+       "Coordinate mode for vertical regridding.", &
+       default="ZSTAR", fail_if_missing=.false.)
+  call initialize_regridding(CS%regridCS, CS%GV, dG%max_depth,PF,'oda_driver',coord_mode,'','')
+  call initialize_remapping(CS%remapCS,'PLM')
+  call set_regrid_params(CS%regridCS, min_thickness=0.)
+  call mpp_get_data_domain(G%Domain%mpp_domain,isd,ied,jsd,jed)
+  if (.not. associated(CS%h)) then
+    allocate(CS%h(isd:ied,jsd:jed,CS%GV%ke)); CS%h(:,:,:)=0.0
+    ! assign thicknesses
+    call ALE_initThicknessToCoord(CS%ALE_CS,G,CS%GV,CS%h)
+  endif
+  allocate(CS%tv%T(isd:ied,jsd:jed,CS%GV%ke)); CS%tv%T(:,:,:)=0.0
+  allocate(CS%tv%S(isd:ied,jsd:jed,CS%GV%ke)); CS%tv%S(:,:,:)=0.0
 
-    call set_axes_info(CS%Grid,CS%GV,PF,CS%diag_cs,set_vertical=.true.)
-    do n=1,CS%ensemble_size
-      write(fldnam,'(a,i2.2)') 'temp_prior_',n
-      CS%Ocean_prior%id_t(n)=register_diag_field('ODA',trim(fldnam),CS%diag_cs%axesTL%handles,Time, &
-                                                 'ocean potential temperature','degC')
-      write(fldnam,'(a,i2.2)') 'salt_prior_',n
-      CS%Ocean_prior%id_s(n)=register_diag_field('ODA',trim(fldnam),CS%diag_cs%axesTL%handles,Time, &
-                                                 'ocean salinity','psu')
-      write(fldnam,'(a,i2.2)') 'temp_posterior_',n
-      CS%Ocean_posterior%id_t(n)=register_diag_field('ODA',trim(fldnam),CS%diag_cs%axesTL%handles,Time, &
-                                                 'ocean potential temperature','degC')
-      write(fldnam,'(a,i2.2)') 'salt_posterior_',n
-      CS%Ocean_posterior%id_s(n)=register_diag_field('ODA',trim(fldnam),CS%diag_cs%axesTL%handles,Time, &
-                                                 'ocean salinity','psu')
-    enddo
+  call set_axes_info(CS%Grid,CS%GV,PF,CS%diag_cs,set_vertical=.true.)
+  do n=1,CS%ensemble_size
+    write(fldnam,'(a,i2.2)') 'temp_prior_',n
+    CS%Ocean_prior%id_t(n)=register_diag_field('ODA',trim(fldnam),CS%diag_cs%axesTL%handles,Time, &
+                                               'ocean potential temperature','degC')
+    write(fldnam,'(a,i2.2)') 'salt_prior_',n
+    CS%Ocean_prior%id_s(n)=register_diag_field('ODA',trim(fldnam),CS%diag_cs%axesTL%handles,Time, &
+                                               'ocean salinity','psu')
+    write(fldnam,'(a,i2.2)') 'temp_posterior_',n
+    CS%Ocean_posterior%id_t(n)=register_diag_field('ODA',trim(fldnam),CS%diag_cs%axesTL%handles,Time, &
+                                               'ocean potential temperature','degC')
+    write(fldnam,'(a,i2.2)') 'salt_posterior_',n
+    CS%Ocean_posterior%id_s(n)=register_diag_field('ODA',trim(fldnam),CS%diag_cs%axesTL%handles,Time, &
+                                               'ocean salinity','psu')
+  enddo
 
-   call mpp_get_data_domain(CS%mpp_domain,isd,ied,jsd,jed)
-   allocate(CS%oda_grid)
-   CS%oda_grid%x => CS%Grid%geolonT
-   CS%oda_grid%y => CS%Grid%geolatT
+  call mpp_get_data_domain(CS%mpp_domain,isd,ied,jsd,jed)
+  allocate(CS%oda_grid)
+  CS%oda_grid%x => CS%Grid%geolonT
+  CS%oda_grid%y => CS%Grid%geolatT
 
-   call get_param(PF, 'oda_driver', "BASIN_FILE", basin_file, &
-           "A file in which to find the basin masks, in variable 'basin'.", &
-           default="basin.nc")
-   basin_file = trim(inputdir) // trim(basin_file)
-   allocate(CS%oda_grid%basin_mask(isd:ied,jsd:jed))
-   CS%oda_grid%basin_mask(:,:) = 0.0
-   call MOM_read_data(basin_file,'basin',CS%oda_grid%basin_mask,CS%Grid%domain, timelevel=1)
+  call get_param(PF, 'oda_driver', "BASIN_FILE", basin_file, &
+          "A file in which to find the basin masks, in variable 'basin'.", &
+          default="basin.nc")
+  basin_file = trim(inputdir) // trim(basin_file)
+  allocate(CS%oda_grid%basin_mask(isd:ied,jsd:jed))
+  CS%oda_grid%basin_mask(:,:) = 0.0
+  call MOM_read_data(basin_file,'basin',CS%oda_grid%basin_mask,CS%Grid%domain, timelevel=1)
 
 !    get global grid information from ocean_model
-   allocate(T_grid)
-   allocate(T_grid%x(CS%ni,CS%nj))
-   allocate(T_grid%y(CS%ni,CS%nj))
-   allocate(T_grid%basin_mask(CS%ni,CS%nj))
-   call mpp_global_field(CS%mpp_domain, CS%Grid%geolonT, T_grid%x)
-   call mpp_global_field(CS%mpp_domain, CS%Grid%geolatT, T_grid%y)
-   call mpp_global_field(CS%mpp_domain, CS%oda_grid%basin_mask, T_grid%basin_mask)
-   T_grid%ni = CS%ni
-   T_grid%nj = CS%nj
-   T_grid%nk = CS%nk
-   allocate(T_grid%mask(CS%ni,CS%nj,CS%nk))
-   allocate(T_grid%z(CS%ni,CS%nj,CS%nk))
-   allocate(global2D(CS%ni,CS%nj))
-   allocate(global2D_old(CS%ni,CS%nj))
-   T_grid%mask(:,:,:) = 0.0
-   T_grid%z(:,:,:) = 0.0
+  allocate(T_grid)
+  allocate(T_grid%x(CS%ni,CS%nj))
+  allocate(T_grid%y(CS%ni,CS%nj))
+  allocate(T_grid%basin_mask(CS%ni,CS%nj))
+  call mpp_global_field(CS%mpp_domain, CS%Grid%geolonT, T_grid%x)
+  call mpp_global_field(CS%mpp_domain, CS%Grid%geolatT, T_grid%y)
+  call mpp_global_field(CS%mpp_domain, CS%oda_grid%basin_mask, T_grid%basin_mask)
+  T_grid%ni = CS%ni
+  T_grid%nj = CS%nj
+  T_grid%nk = CS%nk
+  allocate(T_grid%mask(CS%ni,CS%nj,CS%nk))
+  allocate(T_grid%z(CS%ni,CS%nj,CS%nk))
+  allocate(global2D(CS%ni,CS%nj))
+  allocate(global2D_old(CS%ni,CS%nj))
+  T_grid%mask(:,:,:) = 0.0
+  T_grid%z(:,:,:) = 0.0
 
-   do k = 1, CS%nk
-     call mpp_global_field(G%Domain%mpp_domain, CS%h(:,:,k), global2D)
-     do i=1, CS%ni; do j=1, CS%nj
-       if ( global2D(i,j) > 1 ) then
-         T_grid%mask(i,j,k) = 1.0
-       endif
-     enddo ; enddo
-     if (k == 1) then
-       T_grid%z(:,:,k) = global2D/2
-     else
-       T_grid%z(:,:,k) = T_grid%z(:,:,k-1) + (global2D + global2D_old)/2
-     endif
-     global2D_old = global2D
-   enddo
+  do k = 1, CS%nk
+    call mpp_global_field(G%Domain%mpp_domain, CS%h(:,:,k), global2D)
+    do i=1, CS%ni; do j=1, CS%nj
+      if ( global2D(i,j) > 1 ) then
+        T_grid%mask(i,j,k) = 1.0
+      endif
+    enddo ; enddo
+    if (k == 1) then
+      T_grid%z(:,:,k) = global2D/2
+    else
+      T_grid%z(:,:,k) = T_grid%z(:,:,k-1) + (global2D + global2D_old)/2
+    endif
+    global2D_old = global2D
+  enddo
 
-   call ocean_da_core_init(CS%mpp_domain, T_grid, CS%Profiles, Time)
+  call ocean_da_core_init(CS%mpp_domain, T_grid, CS%Profiles, Time)
 
-   CS%Time=Time
-   !! switch back to ensemble member pelist
-   call set_current_pelist(CS%ensemble_pelist(CS%ensemble_id,:))
-  end subroutine init_oda
+  CS%Time=Time
+  !! switch back to ensemble member pelist
+  call set_current_pelist(CS%ensemble_pelist(CS%ensemble_id,:))
+end subroutine init_oda
 
-  !> Copy ensemble member tracers to ensemble vector.
-  subroutine set_prior_tracer(Time, G, GV, h, tv, CS)
-    type(time_type), intent(in)    :: Time !< The current model time
-    type(ocean_grid_type), pointer :: G !< domain and grid information for ocean model
-    type(verticalGrid_type),               intent(in)    :: GV   !< The ocean's vertical grid structure
-    real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-    type(thermo_var_ptrs),                 intent(in) :: tv   !< A structure pointing to various thermodynamic variables
+!> Copy ensemble member tracers to ensemble vector.
+subroutine set_prior_tracer(Time, G, GV, h, tv, CS)
+  type(time_type), intent(in)    :: Time !< The current model time
+  type(ocean_grid_type), pointer :: G !< domain and grid information for ocean model
+  type(verticalGrid_type),               intent(in)    :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  type(thermo_var_ptrs),                 intent(in) :: tv   !< A structure pointing to various thermodynamic variables
 
-    type(ODA_CS), pointer :: CS !< ocean DA control structure
-    real, dimension(:,:,:), allocatable :: T, S
-    type(ocean_grid_type), pointer :: Grid=>NULL()
-    integer :: i,j, m, n, ss
-    integer :: is, ie, js, je
-    integer :: isc, iec, jsc, jec
-    integer :: isd, ied, jsd, jed
-    integer :: id
-    logical :: used
+  type(ODA_CS), pointer :: CS !< ocean DA control structure
+  real, dimension(:,:,:), allocatable :: T, S
+  type(ocean_grid_type), pointer :: Grid=>NULL()
+  integer :: i,j, m, n, ss
+  integer :: is, ie, js, je
+  integer :: isc, iec, jsc, jec
+  integer :: isd, ied, jsd, jed
+  integer :: id
+  logical :: used
 
-    ! return if not time for analysis
-    if (Time < CS%Time) return
+  ! return if not time for analysis
+  if (Time < CS%Time) return
 
-    if (.not. associated(CS%Grid)) call MOM_ERROR(FATAL,'ODA_CS ensemble horizontal grid not associated')
-    if (.not. associated(CS%GV)) call MOM_ERROR(FATAL,'ODA_CS ensemble vertical grid not associated')
+  if (.not. associated(CS%Grid)) call MOM_ERROR(FATAL,'ODA_CS ensemble horizontal grid not associated')
+  if (.not. associated(CS%GV)) call MOM_ERROR(FATAL,'ODA_CS ensemble vertical grid not associated')
+
+  !! switch to global pelist
+  call set_current_pelist(CS%filter_pelist)
+  call MOM_mesg('Setting prior')
+
+  isc=CS%Grid%isc;iec=CS%Grid%iec;jsc=CS%Grid%jsc;jec=CS%Grid%jec
+  call mpp_get_compute_domain(CS%domains(CS%ensemble_id)%mpp_domain,is,ie,js,je)
+  call mpp_get_data_domain(CS%domains(CS%ensemble_id)%mpp_domain,isd,ied,jsd,jed)
+  allocate(T(isd:ied,jsd:jed,CS%nk))
+  allocate(S(isd:ied,jsd:jed,CS%nk))
+
+  do j=js,je; do i=is,ie
+    call remapping_core_h(CS%remapCS, GV%ke, h(i,j,:), tv%T(i,j,:), &
+         CS%nk, CS%h(i,j,:), T(i,j,:))
+    call remapping_core_h(CS%remapCS, GV%ke, h(i,j,:), tv%S(i,j,:), &
+         CS%nk, CS%h(i,j,:), S(i,j,:))
+  enddo ; enddo
+
+  do m=1,CS%ensemble_size
+    call mpp_redistribute(CS%domains(m)%mpp_domain, T,&
+         CS%mpp_domain, CS%Ocean_prior%T(:,:,:,m), complete=.true.)
+    call mpp_redistribute(CS%domains(m)%mpp_domain, S,&
+         CS%mpp_domain, CS%Ocean_prior%S(:,:,:,m), complete=.true.)
+    if (CS%Ocean_prior%id_t(m)>0) &
+      used=send_data(CS%Ocean_prior%id_t(m), CS%Ocean_prior%T(isc:iec,jsc:jec,:,m), CS%Time)
+    if (CS%Ocean_prior%id_s(m)>0) &
+      used=send_data(CS%Ocean_prior%id_s(m), CS%Ocean_prior%S(isc:iec,jsc:jec,:,m), CS%Time)
+  enddo
+  deallocate(T,S)
+
+  !! switch back to ensemble member pelist
+  call set_current_pelist(CS%ensemble_pelist(CS%ensemble_id,:))
+
+  return
+
+end subroutine set_prior_tracer
+
+!> Returns posterior adjustments or full state
+!!Note that only those PEs associated with an ensemble member receive data
+subroutine get_posterior_tracer(Time, CS, h, tv, increment)
+  type(time_type), intent(in) :: Time !< the current model time
+  type(ODA_CS), pointer :: CS !< ocean DA control structure
+  real, dimension(:,:,:), pointer :: h    !< Layer thicknesses, in H (usually m or kg m-2)
+  type(thermo_var_ptrs), pointer :: tv   !< A structure pointing to various thermodynamic variables
+  logical, optional, intent(in) :: increment !< True if returning increment only
+
+  type(ocean_control_struct), pointer :: Ocean_increment=>NULL()
+  integer :: i, j, m
+  logical :: used, get_inc
+
+  ! return if not analysis time (retain pointers for h and tv)
+  if (Time < CS%Time) return
+
+
+  !! switch to global pelist
+  call set_current_pelist(CS%filter_pelist)
+  call MOM_mesg('Getting posterior')
+
+  get_inc = .true.
+  if (present(increment)) get_inc = increment
+
+  if (get_inc) then
+    allocate(Ocean_increment)
+    call init_ocean_ensemble(Ocean_increment,CS%Grid,CS%GV,CS%ensemble_size)
+    Ocean_increment%T = CS%Ocean_posterior%T - CS%Ocean_prior%T
+    Ocean_increment%S = CS%Ocean_posterior%S - CS%Ocean_prior%S
+  endif
+  do m=1,CS%ensemble_size
+    if (get_inc) then
+      call mpp_redistribute(CS%mpp_domain, Ocean_increment%T(:,:,:,m), &
+              CS%domains(m)%mpp_domain, CS%tv%T, complete=.true.)
+      call mpp_redistribute(CS%mpp_domain, Ocean_increment%S(:,:,:,m), &
+              CS%domains(m)%mpp_domain, CS%tv%S, complete=.true.)
+    else
+      call mpp_redistribute(CS%mpp_domain, CS%Ocean_posterior%T(:,:,:,m), &
+              CS%domains(m)%mpp_domain, CS%tv%T, complete=.true.)
+      call mpp_redistribute(CS%mpp_domain, CS%Ocean_posterior%S(:,:,:,m), &
+              CS%domains(m)%mpp_domain, CS%tv%S, complete=.true.)
+    endif
+  enddo
+
+  tv => CS%tv
+  h => CS%h
+  !! switch back to ensemble member pelist
+  call set_current_pelist(CS%ensemble_pelist(CS%ensemble_id,:))
+
+end subroutine get_posterior_tracer
+
+!> Gather observations and sall ODA routines
+subroutine oda(Time, CS)
+  type(time_type), intent(in) :: Time !< the current model time
+  type(oda_CS), intent(inout) :: CS !< the ocean DA control structure
+
+  integer :: i, j
+  integer :: m
+  integer :: yr, mon, day, hr, min, sec
+
+  if ( Time >= CS%Time ) then
 
     !! switch to global pelist
     call set_current_pelist(CS%filter_pelist)
-    call MOM_mesg('Setting prior')
 
-    isc=CS%Grid%isc;iec=CS%Grid%iec;jsc=CS%Grid%jsc;jec=CS%Grid%jec
-    call mpp_get_compute_domain(CS%domains(CS%ensemble_id)%mpp_domain,is,ie,js,je)
-    call mpp_get_data_domain(CS%domains(CS%ensemble_id)%mpp_domain,isd,ied,jsd,jed)
-    allocate(T(isd:ied,jsd:jed,CS%nk))
-    allocate(S(isd:ied,jsd:jed,CS%nk))
-
-    do j=js,je; do i=is,ie
-      call remapping_core_h(CS%remapCS, GV%ke, h(i,j,:), tv%T(i,j,:), &
-           CS%nk, CS%h(i,j,:), T(i,j,:))
-      call remapping_core_h(CS%remapCS, GV%ke, h(i,j,:), tv%S(i,j,:), &
-           CS%nk, CS%h(i,j,:), S(i,j,:))
-    enddo ; enddo
-
-    do m=1,CS%ensemble_size
-      call mpp_redistribute(CS%domains(m)%mpp_domain, T,&
-           CS%mpp_domain, CS%Ocean_prior%T(:,:,:,m), complete=.true.)
-      call mpp_redistribute(CS%domains(m)%mpp_domain, S,&
-           CS%mpp_domain, CS%Ocean_prior%S(:,:,:,m), complete=.true.)
-      if (CS%Ocean_prior%id_t(m)>0) &
-        used=send_data(CS%Ocean_prior%id_t(m), CS%Ocean_prior%T(isc:iec,jsc:jec,:,m), CS%Time)
-      if (CS%Ocean_prior%id_s(m)>0) &
-        used=send_data(CS%Ocean_prior%id_s(m), CS%Ocean_prior%S(isc:iec,jsc:jec,:,m), CS%Time)
-    enddo
-    deallocate(T,S)
+    call get_profiles(Time, CS%Profiles, CS%CProfiles)
+#ifdef ENABLE_ECDA
+    call ensemble_filter(CS%Ocean_prior, CS%Ocean_posterior, CS%CProfiles, CS%kdroot, CS%mpp_domain, CS%oda_grid)
+#endif
 
     !! switch back to ensemble member pelist
     call set_current_pelist(CS%ensemble_pelist(CS%ensemble_id,:))
 
-    return
+  endif
 
-  end subroutine set_prior_tracer
+  return
+end subroutine oda
 
-  !> Returns posterior adjustments or full state
-  !!Note that only those PEs associated with an ensemble member receive data
-  subroutine get_posterior_tracer(Time, CS, h, tv, increment)
-     type(time_type), intent(in) :: Time !< the current model time
-     type(ODA_CS), pointer :: CS !< ocean DA control structure
-     real, dimension(:,:,:), pointer :: h    !< Layer thicknesses, in H (usually m or kg m-2)
-     type(thermo_var_ptrs), pointer :: tv   !< A structure pointing to various thermodynamic variables
-     logical, optional, intent(in) :: increment !< True if returning increment only
+!> Finalize DA module
+subroutine oda_end(CS)
+  type(ODA_CS), intent(inout) :: CS !< the ocean DA control structure
 
-     type(ocean_control_struct), pointer :: Ocean_increment=>NULL()
-     integer :: i, j, m
-     logical :: used, get_inc
+end subroutine oda_end
 
-     ! return if not analysis time (retain pointers for h and tv)
-     if (Time < CS%Time) return
+!> Initialize DA module
+subroutine init_ocean_ensemble(CS,Grid,GV,ens_size)
+  type(ocean_control_struct), pointer :: CS !< Pointer to ODA control structure
+  type(ocean_grid_type), pointer :: Grid !< Pointer to ocean analysis grid
+  type(verticalGrid_type), pointer :: GV !< Pointer to DA vertical grid
+  integer, intent(in) :: ens_size !< ensemble size
 
+  integer :: n,is,ie,js,je,nk
 
-     !! switch to global pelist
-     call set_current_pelist(CS%filter_pelist)
-     call MOM_mesg('Getting posterior')
+  nk=GV%ke
+  is=Grid%isd;ie=Grid%ied
+  js=Grid%jsd;je=Grid%jed
+  CS%ensemble_size=ens_size
+  allocate(CS%T(is:ie,js:je,nk,ens_size))
+  allocate(CS%S(is:ie,js:je,nk,ens_size))
+  allocate(CS%SSH(is:ie,js:je,ens_size))
+  allocate(CS%id_t(ens_size));CS%id_t(:)=-1
+  allocate(CS%id_s(ens_size));CS%id_s(:)=-1
+!  allocate(CS%U(is:ie,js:je,nk,ens_size))
+!  allocate(CS%V(is:ie,js:je,nk,ens_size))
+!  allocate(CS%id_u(ens_size));CS%id_u(:)=-1
+!  allocate(CS%id_v(ens_size));CS%id_v(:)=-1
+  allocate(CS%id_ssh(ens_size));CS%id_ssh(:)=-1
 
-     get_inc = .true.
-     if (present(increment)) get_inc = increment
+  return
+end subroutine init_ocean_ensemble
 
-     if (get_inc) then
-       allocate(Ocean_increment)
-       call init_ocean_ensemble(Ocean_increment,CS%Grid,CS%GV,CS%ensemble_size)
-       Ocean_increment%T = CS%Ocean_posterior%T - CS%Ocean_prior%T
-       Ocean_increment%S = CS%Ocean_posterior%S - CS%Ocean_prior%S
-     endif
-     do m=1,CS%ensemble_size
-       if (get_inc) then
-         call mpp_redistribute(CS%mpp_domain, Ocean_increment%T(:,:,:,m), &
-                 CS%domains(m)%mpp_domain, CS%tv%T, complete=.true.)
-         call mpp_redistribute(CS%mpp_domain, Ocean_increment%S(:,:,:,m), &
-                 CS%domains(m)%mpp_domain, CS%tv%S, complete=.true.)
-       else
-         call mpp_redistribute(CS%mpp_domain, CS%Ocean_posterior%T(:,:,:,m), &
-                 CS%domains(m)%mpp_domain, CS%tv%T, complete=.true.)
-         call mpp_redistribute(CS%mpp_domain, CS%Ocean_posterior%S(:,:,:,m), &
-                 CS%domains(m)%mpp_domain, CS%tv%S, complete=.true.)
-       endif
-     enddo
+!> Set the next analysis time
+subroutine set_analysis_time(Time,CS)
+  type(time_type), intent(in) :: Time !< the current model time
+  type(ODA_CS), pointer, intent(inout) :: CS !< the DA control structure
 
-     tv => CS%tv
-     h => CS%h
-     !! switch back to ensemble member pelist
-     call set_current_pelist(CS%ensemble_pelist(CS%ensemble_id,:))
+  character(len=160) :: mesg  ! The text of an error message
+  integer :: yr, mon, day, hr, min, sec
 
-   end subroutine get_posterior_tracer
+  if (Time >= CS%Time) then
+    CS%Time=increment_time(CS%Time,CS%assim_frequency*3600)
 
-  !> Gather observations and sall ODA routines
-  subroutine oda(Time, CS)
-     type(time_type), intent(in) :: Time !< the current model time
-     type(oda_CS), intent(inout) :: CS !< the ocean DA control structure
+    call get_date(Time, yr, mon, day, hr, min, sec)
+    write(mesg,*) 'Model Time: ', yr, mon, day, hr, min, sec
+    call MOM_mesg("set_analysis_time: "//trim(mesg))
+    call get_date(CS%time, yr, mon, day, hr, min, sec)
+    write(mesg,*) 'Assimilation Time: ', yr, mon, day, hr, min, sec
+    call MOM_mesg("set_analysis_time: "//trim(mesg))
+  endif
+  if (CS%Time < Time) then
+    call MOM_error(FATAL, " set_analysis_time: " // &
+         "assimilation interval appears to be shorter than " // &
+         "the model timestep")
+  endif
+  return
 
-     integer :: i, j
-     integer :: m
-     integer :: yr, mon, day, hr, min, sec
+end subroutine set_analysis_time
 
-     if ( Time >= CS%Time ) then
+!> Write observation differences to a file
+subroutine save_obs_diff(filename,CS)
+  character(len=*), intent(in) :: filename !< name of output file
+  type(ODA_CS), pointer, intent(in) :: CS  !< pointer to DA control structure
 
-       !! switch to global pelist
-       call set_current_pelist(CS%filter_pelist)
+  integer :: fid ! profile file handle
+  type(ocean_profile_type), pointer :: Prof=>NULL()
 
-       call get_profiles(Time, CS%Profiles, CS%CProfiles)
-#ifdef ENABLE_ECDA
-       call ensemble_filter(CS%Ocean_prior, CS%Ocean_posterior, CS%CProfiles, CS%kdroot, CS%mpp_domain, CS%oda_grid)
-#endif
+  fid = open_profile_file(trim(filename), nvar=2, thread=MPP_SINGLE, fset=MPP_SINGLE)
+  Prof=>CS%CProfiles
 
-       !! switch back to ensemble member pelist
-       call set_current_pelist(CS%ensemble_pelist(CS%ensemble_id,:))
+  !! switch to global pelist
+  !call set_current_pelist(CS%filter_pelist)
 
-     endif
+  do while (associated(Prof))
+    call write_profile(fid,Prof)
+    Prof=>Prof%cnext
+  enddo
+  call close_profile_file(fid)
 
-     return
-  end subroutine oda
+  !! switch back to ensemble member pelist
+  !call set_current_pelist(CS%ensemble_pelist(CS%ensemble_id,:))
 
-  !> Finalize DA module
-  subroutine oda_end(CS)
-    type(ODA_CS), intent(inout) :: CS !< the ocean DA control structure
-
-  end subroutine oda_end
-
-  !> Initialize DA module
-  subroutine init_ocean_ensemble(CS,Grid,GV,ens_size)
-    type(ocean_control_struct), pointer :: CS !< Pointer to ODA control structure
-    type(ocean_grid_type), pointer :: Grid !< Pointer to ocean analysis grid
-    type(verticalGrid_type), pointer :: GV !< Pointer to DA vertical grid
-    integer, intent(in) :: ens_size !< ensemble size
-
-    integer :: n,is,ie,js,je,nk
-
-    nk=GV%ke
-    is=Grid%isd;ie=Grid%ied
-    js=Grid%jsd;je=Grid%jed
-    CS%ensemble_size=ens_size
-    allocate(CS%T(is:ie,js:je,nk,ens_size))
-    allocate(CS%S(is:ie,js:je,nk,ens_size))
-    allocate(CS%SSH(is:ie,js:je,ens_size))
-    allocate(CS%id_t(ens_size));CS%id_t(:)=-1
-    allocate(CS%id_s(ens_size));CS%id_s(:)=-1
-!   allocate(CS%U(is:ie,js:je,nk,ens_size))
-!   allocate(CS%V(is:ie,js:je,nk,ens_size))
-!    allocate(CS%id_u(ens_size));CS%id_u(:)=-1
-!    allocate(CS%id_v(ens_size));CS%id_v(:)=-1
-    allocate(CS%id_ssh(ens_size));CS%id_ssh(:)=-1
-
-    return
-  end subroutine init_ocean_ensemble
-
-  !> Set the next analysis time
-  subroutine set_analysis_time(Time,CS)
-    type(time_type), intent(in) :: Time !< the current model time
-    type(ODA_CS), pointer, intent(inout) :: CS !< the DA control structure
-
-    character(len=160) :: mesg  ! The text of an error message
-    integer :: yr, mon, day, hr, min, sec
-
-    if (Time >= CS%Time) then
-      CS%Time=increment_time(CS%Time,CS%assim_frequency*3600)
-
-      call get_date(Time, yr, mon, day, hr, min, sec)
-      write(mesg,*) 'Model Time: ', yr, mon, day, hr, min, sec
-      call MOM_mesg("set_analysis_time: "//trim(mesg))
-      call get_date(CS%time, yr, mon, day, hr, min, sec)
-      write(mesg,*) 'Assimilation Time: ', yr, mon, day, hr, min, sec
-      call MOM_mesg("set_analysis_time: "//trim(mesg))
-    endif
-    if (CS%Time < Time) then
-      call MOM_error(FATAL, " set_analysis_time: " // &
-           "assimilation interval appears to be shorter than " // &
-           "the model timestep")
-    endif
-    return
-
-  end subroutine set_analysis_time
-
-  !> Write observation differences to a file
-  subroutine save_obs_diff(filename,CS)
-    character(len=*), intent(in) :: filename !< name of output file
-    type(ODA_CS), pointer, intent(in) :: CS  !< pointer to DA control structure
-
-    integer :: fid ! profile file handle
-    type(ocean_profile_type), pointer :: Prof=>NULL()
-
-    fid = open_profile_file(trim(filename), nvar=2, thread=MPP_SINGLE, fset=MPP_SINGLE)
-    Prof=>CS%CProfiles
-
-    !! switch to global pelist
-    !call set_current_pelist(CS%filter_pelist)
-
-    do while (associated(Prof))
-      call write_profile(fid,Prof)
-      Prof=>Prof%cnext
-    enddo
-    call close_profile_file(fid)
-
-    !! switch back to ensemble member pelist
-    !call set_current_pelist(CS%ensemble_pelist(CS%ensemble_id,:))
-
-    return
-  end subroutine save_obs_diff
+  return
+end subroutine save_obs_diff
 
 
-  !> Apply increments to tracers
-  subroutine apply_oda_tracer_increments(dt,G,tv,h,CS)
-    real,                     intent(in)    :: dt !< The tracer timestep (seconds)
-    type(ocean_grid_type),    intent(in)    :: G  !< ocean grid structure
-    type(thermo_var_ptrs),    intent(inout) :: tv !< A structure pointing to various thermodynamic variables
-    real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
-                              intent(in)    :: h  !< layer thickness (m or kg/m2)
-    type(ODA_CS),             intent(inout) :: CS !< the data assimilation structure
+!> Apply increments to tracers
+subroutine apply_oda_tracer_increments(dt,G,tv,h,CS)
+  real,                     intent(in)    :: dt !< The tracer timestep (seconds)
+  type(ocean_grid_type),    intent(in)    :: G  !< ocean grid structure
+  type(thermo_var_ptrs),    intent(inout) :: tv !< A structure pointing to various thermodynamic variables
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
+                            intent(in)    :: h  !< layer thickness (m or kg/m2)
+  type(ODA_CS),             intent(inout) :: CS !< the data assimilation structure
 
-  end subroutine apply_oda_tracer_increments
+end subroutine apply_oda_tracer_increments
 
 !> \namespace MOM_oda_driver_mod
 !!

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -58,7 +58,7 @@ module MOM_oda_driver_mod
 #include <MOM_memory.h>
 
   !> Control structure that contains a transpose of the ocean state across ensemble members.
-  type, public :: ODA_CS; private
+  type, public :: ODA_CS ; private
      type(ocean_control_struct), pointer :: Ocean_prior=> NULL() !< ensemble ocean prior states in DA space
      type(ocean_control_struct), pointer :: Ocean_posterior=> NULL() !< ensemble ocean posterior states
                                                                      !! or increments to prior in DA space
@@ -71,7 +71,8 @@ module MOM_oda_driver_mod
      type(grid_type), pointer :: oda_grid !< local tracer grid
      real, pointer, dimension(:,:,:) :: h => NULL() !<layer thicknesses (m or kg/m2) for DA
      type(thermo_var_ptrs), pointer :: tv => NULL() !< pointer to thermodynamic variables
-     integer :: ni, nj !< global grid size
+     integer :: ni          !< global i-direction grid size
+     integer :: nj          !< global j-direction grid size
      logical :: reentrant_x !< grid is reentrant in the x direction
      logical :: reentrant_y !< grid is reentrant in the y direction
      logical :: tripolar_N !< grid is folded at its north edge
@@ -85,7 +86,7 @@ module MOM_oda_driver_mod
      ! Profiles local to the analysis domain
      type(ocean_profile_type), pointer :: Profiles => NULL() !< pointer to linked list of all available profiles
      type(ocean_profile_type), pointer :: CProfiles => NULL()!< pointer to linked list of current profiles
-     type(kd_root), pointer :: kdroot => NULL()
+     type(kd_root), pointer :: kdroot => NULL() !< A structure for storing nearest neighbors
      type(ALE_CS), pointer :: ALE_CS=>NULL() !< ALE control structure for DA
      logical :: use_ALE_algorithm !< true is using ALE remapping
      type(regridding_CS) :: regridCS !< ALE control structure for regridding
@@ -94,15 +95,14 @@ module MOM_oda_driver_mod
      type(diag_ctrl) :: diag_cs !<Diagnostics control structure
   end type ODA_CS
 
-  !> pointer to a mpp_domain object
+  !> A structure with a pointer to a domain2d, to allow for the creation of arrays of pointers.
   type :: ptr_mpp_domain
-    type(domain2d), pointer :: mpp_domain => NULL()
+    type(domain2d), pointer :: mpp_domain => NULL() !< pointer to an mpp domain2d
   end type ptr_mpp_domain
 
-  !>@{
-  !! DA parameters
+  !>@{  DA parameters
   integer, parameter :: NO_ASSIM = 0, OI_ASSIM=1, EAKF_ASSIM=2
-  !>@}
+  !!@}
 
 contains
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -70,43 +70,52 @@ type, public :: hor_visc_CS ; private
   real    :: Kh_aniso        !< The anisotropic viscosity in m2 s-1.
   logical :: dynamic_aniso   !< If true, the anisotropic viscosity is recomputed as a function
                              !! of state. This is set depending on ANISOTROPIC_MODE.
-  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
-    Kh_bg_xx,        &!< The background Laplacian viscosity at h points, in units
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: Kh_bg_xx
+                      !< The background Laplacian viscosity at h points, in units
                       !! of m2 s-1. The actual viscosity may be the larger of this
                       !! viscosity and the Smagorinsky and Leith viscosities.
-    Kh_bg_2d,        &!< The background Laplacian viscosity at h points, in units
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: Kh_bg_2d
+                      !< The background Laplacian viscosity at h points, in units
                       !! of m2 s-1. The actual viscosity may be the larger of this
                       !! viscosity and the Smagorinsky and Leith viscosities.
-    Ah_bg_xx,        &!< The background biharmonic viscosity at h points, in units
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: Ah_bg_xx
+                      !< The background biharmonic viscosity at h points, in units
                       !! of m4 s-1. The actual viscosity may be the larger of this
                       !! viscosity and the Smagorinsky and Leith viscosities.
-    Kh_Max_xx,       &!< The maximum permitted Laplacian viscosity, m2 s-1.
-    Ah_Max_xx,       &!< The maximum permitted biharmonic viscosity, m4 s-1.
-    Biharm_Const2_xx,&!< A constant relating the biharmonic viscosity to the
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: Biharm_Const2_xx
+                      !< A constant relating the biharmonic viscosity to the
                       !! square of the velocity shear, in m4 s.  This value is
                       !! set to be the magnitude of the Coriolis terms once the
                       !! velocity differences reach a value of order 1/2 MAXVEL.
-    reduction_xx,    &!< The amount by which stresses through h points are reduced
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: reduction_xx
+                      !< The amount by which stresses through h points are reduced
                       !! due to partial barriers. Nondimensional.
-    n1n2_h,          &!< Factor n1*n2 in the anisotropic direction tensor at h-points
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
+    Kh_Max_xx,      & !< The maximum permitted Laplacian viscosity, m2 s-1.
+    Ah_Max_xx,      & !< The maximum permitted biharmonic viscosity, m4 s-1.
+    n1n2_h,         & !< Factor n1*n2 in the anisotropic direction tensor at h-points
     n1n1_m_n2n2_h     !< Factor n1**2-n2**2 in the anisotropic direction tensor at h-points
 
-  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &
-    Kh_bg_xy,        &!< The background Laplacian viscosity at q points, in units
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: Kh_bg_xy
+                      !< The background Laplacian viscosity at q points, in units
                       !! of m2 s-1. The actual viscosity may be the larger of this
                       !! viscosity and the Smagorinsky and Leith viscosities.
-    Ah_bg_xy,        &!< The background biharmonic viscosity at q points, in units
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: Ah_bg_xy
+                      !< The background biharmonic viscosity at q points, in units
                       !! of m4 s-1. The actual viscosity may be the larger of this
                       !! viscosity and the Smagorinsky and Leith viscosities.
-    Kh_Max_xy,       &!< The maximum permitted Laplacian viscosity, m2 s-1.
-    Ah_Max_xy,       &!< The maximum permitted biharmonic viscosity, m4 s-1.
-    Biharm_Const2_xy,&!< A constant relating the biharmonic viscosity to the
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: Biharm_Const2_xy
+                      !< A constant relating the biharmonic viscosity to the
                       !! square of the velocity shear, in m4 s.  This value is
                       !! set to be the magnitude of the Coriolis terms once the
                       !! velocity differences reach a value of order 1/2 MAXVEL.
-    reduction_xy,    &!! The amount by which stresses through q points are reduced
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: reduction_xy
+                      !< The amount by which stresses through q points are reduced
                       !! due to partial barriers. Nondimensional.
-    n1n2_q,          &!< Factor n1*n2 in the anisotropic direction tensor at q-points
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &
+    Kh_Max_xy,      & !< The maximum permitted Laplacian viscosity, m2 s-1.
+    Ah_Max_xy,      & !< The maximum permitted biharmonic viscosity, m4 s-1.
+    n1n2_q,         & !< Factor n1*n2 in the anisotropic direction tensor at q-points
     n1n1_m_n2n2_q     !< Factor n1**2-n2**2 in the anisotropic direction tensor at q-points
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
@@ -123,7 +132,8 @@ type, public :: hor_visc_CS ; private
     Idx2dyCu, & !< 1/(dx^2 dy) at u points, in m-3
     Idxdy2u     !< 1/(dx dy^2) at u points, in m-3
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_) :: &
-    Idx2dyCv, Idxdy2v   ! 1/(dx^2 dy) and 1/(dx dy^2) at v points, in m-3
+    Idx2dyCv, & !< 1/(dx^2 dy) at v points, in m-3
+    Idxdy2v     !< 1/(dx dy^2) at v points, in m-3
 
   ! The following variables are precalculated time-invariant combinations of
   ! parameters and metric terms.
@@ -139,7 +149,7 @@ type, public :: hor_visc_CS ; private
     Laplac3_Const_xy, & !< Laplacian  metric-dependent constants (nondim)
     Biharm5_Const_xy    !< Biharmonic metric-dependent constants (nondim)
 
-  type(diag_ctrl), pointer :: diag => NULL() ! structure to regulate diagnostics
+  type(diag_ctrl), pointer :: diag => NULL() !< structure to regulate diagnostics
 
   !>@{
   !! Diagnostic id

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -35,6 +35,7 @@ public propagate_int_tide !, register_int_tide_restarts
 public internal_tides_init, internal_tides_end
 public get_lowmode_loss
 
+!> This control structure has parameters for the MOM_internal_tides module
 type, public :: int_tide_CS ; private
   logical :: do_int_tides    !< If true, use the internal tide code.
   integer :: nFreq = 0       !< The number of internal tide frequency bands
@@ -53,7 +54,7 @@ type, public :: int_tide_CS ; private
   real, allocatable, dimension(:,:) :: refl_angle
                         !< local coastline/ridge/shelf angles read from file
                         ! (could be in G control structure)
-  real :: nullangle = -999.9 ! placeholder value in cell with no reflection
+  real :: nullangle = -999.9 !< placeholder value in cells with no reflection
   real, allocatable, dimension(:,:) :: refl_pref
                         !< partial reflection coeff for each "coast cell"
                         ! (could be in G control structure)
@@ -114,7 +115,8 @@ type, public :: int_tide_CS ; private
 
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to regulate the
                         !! timing of diagnostic output.
-  type(wave_structure_CS),  pointer :: wave_structure_CSp => NULL()
+  type(wave_structure_CS), pointer :: wave_structure_CSp => NULL()
+                        !< A pointer to the wave_structure module control structure
 
   !>@{ Diag handles
   ! Diag handles relevant to all modes, frequencies, and angles

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -46,6 +46,7 @@ public set_BBL_TKE
 public set_diffusivity_init
 public set_diffusivity_end
 
+!> This control structure contains parameters for MOM_set_diffusivity.
 type, public :: set_diffusivity_CS ; private
   logical :: debug           !< If true, write verbose checksums for debugging.
 
@@ -119,7 +120,7 @@ type, public :: set_diffusivity_CS ; private
                               !! problems (m/s).  If the value is small enough,
                               !! this parameter should not affect the solution.
   real    :: TKE_decay        !< ratio of natural Ekman depth to TKE decay scale (nondim)
-  real    :: mstar            !! ratio of friction velocity cubed to
+  real    :: mstar            !< ratio of friction velocity cubed to
                               !! TKE input to the mixed layer (nondim)
   logical :: ML_use_omega     !< If true, use absolute rotation rate instead
                               !! of the vertical component of rotation when
@@ -142,41 +143,46 @@ type, public :: set_diffusivity_CS ; private
   real    :: Max_salt_diff_salt_fingers !< max salt diffusivity for salt fingers (m2/s)
   real    :: Kv_molecular               !< molecular visc for double diff convect (m2/s)
 
-  character(len=200)                 :: inputdir
-  type(user_change_diff_CS), pointer :: user_change_diff_CSp => NULL()
-  type(diag_to_Z_CS),        pointer :: diag_to_Z_CSp        => NULL()
-  type(Kappa_shear_CS),      pointer :: kappaShear_CSp       => NULL()
-  type(CVMix_shear_cs),      pointer :: CVMix_shear_csp      => NULL()
-  type(CVMix_ddiff_cs),      pointer :: CVMix_ddiff_csp      => NULL()
-  type(bkgnd_mixing_cs),     pointer :: bkgnd_mixing_csp     => NULL()
-  type(int_tide_CS),         pointer :: int_tide_CSp         => NULL()
-  type(tidal_mixing_cs),     pointer :: tm_csp               => NULL()
+  character(len=200) :: inputdir !< The directory in which input files are found
+  type(user_change_diff_CS), pointer :: user_change_diff_CSp => NULL() !< Control structure for a child module
+  type(diag_to_Z_CS),        pointer :: diag_to_Z_CSp        => NULL() !< Control structure for a child module
+  type(Kappa_shear_CS),      pointer :: kappaShear_CSp       => NULL() !< Control structure for a child module
+  type(CVMix_shear_cs),      pointer :: CVMix_shear_csp      => NULL() !< Control structure for a child module
+  type(CVMix_ddiff_cs),      pointer :: CVMix_ddiff_csp      => NULL() !< Control structure for a child module
+  type(bkgnd_mixing_cs),     pointer :: bkgnd_mixing_csp     => NULL() !< Control structure for a child module
+  type(int_tide_CS),         pointer :: int_tide_CSp         => NULL() !< Control structure for a child module
+  type(tidal_mixing_cs),     pointer :: tm_csp               => NULL() !< Control structure for a child module
 
+  !>@{ Diagnostic IDs
   integer :: id_maxTKE     = -1, id_TKE_to_Kd   = -1, id_Kd_user    = -1
   integer :: id_Kd_layer   = -1, id_Kd_BBL      = -1, id_Kd_BBL_z   = -1
   integer :: id_Kd_user_z  = -1, id_N2          = -1, id_N2_z       = -1
   integer :: id_Kd_Work    = -1, id_KT_extra    = -1, id_KS_extra   = -1
   integer :: id_KT_extra_z = -1, id_KS_extra_z  = -1
+  !!@}
 
 end type set_diffusivity_CS
 
+!> This structure has memory for used in calculating diagnostics of diffusivity
 type diffusivity_diags
   real, pointer, dimension(:,:,:) :: &
-    N2_3d          => NULL(),& ! squared buoyancy frequency at interfaces (1/s2)
-    Kd_user        => NULL(),& ! user-added diffusivity at interfaces (m2/s)
-    Kd_BBL         => NULL(),& ! BBL diffusivity at interfaces (m2/s)
-    Kd_work        => NULL(),& ! layer integrated work by diapycnal mixing (W/m2)
-    maxTKE         => NULL(),& ! energy required to entrain to h_max (m3/s3)
-    TKE_to_Kd      => NULL(),& ! conversion rate (~1.0 / (G_Earth + dRho_lay))
-                               ! between TKE dissipated within a layer and Kd
-                               ! in that layer, in m2 s-1 / m3 s-3 = s2 m-1
-    KT_extra       => NULL(),& ! double diffusion diffusivity for temp (m2/s)
-    KS_extra       => NULL()   ! double diffusion diffusivity for saln (m2/s)
+    N2_3d     => NULL(),& !< squared buoyancy frequency at interfaces (1/s2)
+    Kd_user   => NULL(),& !< user-added diffusivity at interfaces (m2/s)
+    Kd_BBL    => NULL(),& !< BBL diffusivity at interfaces (m2/s)
+    Kd_work   => NULL(),& !< layer integrated work by diapycnal mixing (W/m2)
+    maxTKE    => NULL(),& !< energy required to entrain to h_max (m3/s3)
+    KT_extra  => NULL(),& !< double diffusion diffusivity for temp (m2/s)
+    KS_extra  => NULL()   !< double diffusion diffusivity for saln (m2/s)
+  real, pointer, dimension(:,:,:) :: TKE_to_Kd => NULL()
+                          !< conversion rate (~1.0 / (G_Earth + dRho_lay))
+                          !! between TKE dissipated within a layer and Kd
+                          !! in that layer, in m2 s-1 / m3 s-3 = s2 m-1
 
 end type diffusivity_diags
 
-! Clocks
+!>@{ CPU time clocks
 integer :: id_clock_kappaShear, id_clock_CVMix_ddiff
+!!@}
 
 contains
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -118,7 +118,7 @@ type, public :: vertvisc_CS ; private
   !>@}
 
   type(PointAccel_CS), pointer :: PointAccel_CSp => NULL() !< A pointer to the control structure
-                              !! for recording accelerations leading to velocity truncations 
+                              !! for recording accelerations leading to velocity truncations
 end type vertvisc_CS
 
 contains

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -29,6 +29,7 @@ public vertvisc, vertvisc_remnant, vertvisc_coef
 public vertvisc_limit_vel, vertvisc_init, vertvisc_end
 public updateCFLtruncationValue
 
+!> The control structure with parameters and memory for the MOM_vert_friction module
 type, public :: vertvisc_CS ; private
   real    :: Hmix            !< The mixed layer thickness in m.
   real    :: Hmix_stress     !< The mixed layer thickness over which the wind
@@ -66,13 +67,10 @@ type, public :: vertvisc_CS ; private
     a_v                !< The v-drag coefficient across an interface, in m s-1.
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: &
     h_v                !< The effective layer thickness at v-points, m or kg m-2.
-  !>@{
-  !! The surface coupling coefficient under ice shelves
-  !! in m s-1. Retained to determine stress under shelves.
-  real, pointer, dimension(:,:) :: &
-    a1_shelf_u => NULL(), &
-    a1_shelf_v => NULL()
-  !>@}
+  real, pointer, dimension(:,:) :: a1_shelf_u => NULL() !< The u-momentum coupling coefficient under
+                           !! ice shelves in m s-1. Retained to determine stress under shelves.
+  real, pointer, dimension(:,:) :: a1_shelf_v => NULL() !< The v-momentum coupling coefficient under
+                           !! ice shelves in m s-1. Retained to determine stress under shelves.
 
   logical :: split          !< If true, use the split time stepping scheme.
   logical :: bottomdraglaw  !< If true, the  bottom stress is calculated with a
@@ -99,28 +97,28 @@ type, public :: vertvisc_CS ; private
                             !! thickness for viscosity.
   logical :: debug          !< If true, write verbose checksums for debugging purposes.
   integer :: nkml           !< The number of layers in the mixed layer.
-  integer, pointer :: ntrunc  !< The number of times the velocity has been
-                              !! truncated since the last call to write_energy.
-  !>@{
-  !! The complete path to files in which a column's worth of
-  !! accelerations are written when velocity truncations occur.
-  character(len=200) :: u_trunc_file
-  character(len=200) :: v_trunc_file
-  !>@}
+  integer, pointer :: ntrunc !< The number of times the velocity has been
+                            !! truncated since the last call to write_energy.
+  character(len=200) :: u_trunc_file  !< The complete path to a file in which a column of
+                            !! u-accelerations are written if velocity truncations occur.
+  character(len=200) :: v_trunc_file !< The complete path to a file in which a column of
+                            !! v-accelerations are written if velocity truncations occur.
+  logical :: StokesMixing   !< If true, do Stokes drift mixing via the Lagrangian current
+                            !! (Eulerian plus Stokes drift).  False by default and set
+                            !! via STOKES_MIXING_COMBINED.
 
   type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the
                                    !! timing of diagnostic output.
 
-  !>@{
-  !! Diagnostic identifiers
+  !>@{ Diagnostic identifiers
   integer :: id_du_dt_visc = -1, id_dv_dt_visc = -1, id_au_vv = -1, id_av_vv = -1
   integer :: id_h_u = -1, id_h_v = -1, id_hML_u = -1 , id_hML_v = -1
   integer :: id_Ray_u = -1, id_Ray_v = -1, id_taux_bot = -1, id_tauy_bot = -1
   integer :: id_Kv_slow = -1, id_Kv_u = -1, id_Kv_v = -1
   !>@}
 
-  type(PointAccel_CS), pointer :: PointAccel_CSp => NULL()
-  logical :: StokesMixing
+  type(PointAccel_CS), pointer :: PointAccel_CSp => NULL() !< A pointer to the control structure
+                              !! for recording accelerations leading to velocity truncations 
 end type vertvisc_CS
 
 contains


### PR DESCRIPTION
  Made corrections and additions to the dOxyGen comments in various parts of
the MOM6 code to correct dOxyGen errors and provide more accurate
automatically generated documentation.  No answers or MOM_parameter_doc files
are changed by these modifications. This list of commits in this PR include:
- NOAA-GFDL/MOM6@009cc22 Fixed trailing white space in MOM_vert_friction
- NOAA-GFDL/MOM6@c61b736 dOyxgenization of types in solo/coupler_types.F90
- NOAA-GFDL/MOM6@2d55746 dOyxgenization of types in MOM_internal_tides.F90
- NOAA-GFDL/MOM6@036d706 dOyxgenization of type elements in MOM_hor_visc.F90
- NOAA-GFDL/MOM6@67d54e2 dOyxgenization of type elements in MOM_vert_friction.F90
- NOAA-GFDL/MOM6@87c4c60 dOyxgenization of types in MOM_set_diffusivity.F90
- NOAA-GFDL/MOM6@af88e4b Corrected indents in MOM_oda_driver.F90
- NOAA-GFDL/MOM6@05017cb dOyxgenization of type elements in MOM_oda_driver.F90
