### PR TITLE
module DoxyGenization in the MOM6/src/core directory

### DIFF
--- a/src/core/MOM_checksum_packages.F90
+++ b/src/core/MOM_checksum_packages.F90
@@ -1,8 +1,9 @@
+!> Provides routines that do checksums of groups of MOM variables
 module MOM_checksum_packages
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!   This module provdes a several routines that do check-sums of groups
+!   This module provides several routines that do check-sums of groups
 ! of variables in the various dynamic solver routines.
 
 use MOM_debugging, only : hchksum, uvchksum
@@ -110,10 +111,7 @@ subroutine MOM_thermo_chksum(mesg, tv, G, haloshift)
                                                !! thermodynamic variables.
   type(ocean_grid_type),    intent(in) :: G    !< The ocean's grid structure.
   integer,        optional, intent(in) :: haloshift !< The width of halos to check (default 0).
-! Arguments: mesg - A message that appears on the chksum lines.
-!  (in)      tv - A structure containing pointers to any thermodynamic
-!                 fields that are in use.
-!  (in)      G - The ocean's grid structure.
+
   integer :: is, ie, js, je, nz, hs
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   hs=1; if (present(haloshift)) hs=haloshift

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -1,3 +1,4 @@
+!> Time steps the ocean dynamics with an unsplit quasi 3rd order scheme
 module MOM_dynamics_unsplit
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -176,17 +177,16 @@ contains
 
 ! =============================================================================
 
+!> Step the MOM6 dynamics using an unsplit mixed 2nd order (for continuity) and
+!! 3rd order (for the inviscid momentum equations) order scheme
 subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
                   p_surf_begin, p_surf_end, uh, vh, uhtr, vhtr, eta_av, G, GV, CS, &
                   VarMix, MEKE, Waves)
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV     !< The ocean's vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
-                           intent(inout) :: u      !< The zonal velocity, in m s-1.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                           intent(inout) :: v      !< The meridional velocity, in m s-1.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
-                           intent(inout) :: h      !< Layer thicknesses, in H.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: u !< The zonal velocity, in m s-1.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: v !< The meridional velocity, in m s-1.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h !< Layer thicknesses, in H.
                                                    !! (usually m or kg m-2).
   type(thermo_var_ptrs),   intent(in)    :: tv     !< A structure pointing to various
                                                    !! thermodynamic variables.
@@ -196,24 +196,19 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
                                                          !! of the time step.
   real,                    intent(in)    :: dt     !< The dynamics time step, in s.
   type(mech_forcing),      intent(in)    :: forces !< A structure with the driving mechanical forces
-  real, dimension(:,:),    pointer       :: p_surf_begin !< A pointer (perhaps NULL) to the
-                                 !! surface pressure at the beginning of this dynamic step, in Pa.
-  real, dimension(:,:),    pointer       :: p_surf_end   !< A pointer (perhaps NULL) to the
-                                 !! surface pressure at the end of this dynamic step, in Pa.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
-                           intent(inout) :: uh     !< The zonal volume or mass transport,
+  real, dimension(:,:),    pointer       :: p_surf_begin !< A pointer (perhaps NULL) to the surface
+                                                   !! pressure at the start of this dynamic step, in Pa.
+  real, dimension(:,:),    pointer       :: p_surf_end   !< A pointer (perhaps NULL) to the surface
+                                                   !! pressure at the end of this dynamic step, in Pa.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uh !< The zonal volume or mass transport,
                                                    !! in m3 s-1 or kg s-1.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                           intent(inout) :: vh     !< The meridional volume or mass
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: vh !< The meridional volume or mass
                                                    !! transport, in m3 s-1 or kg s-1.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
-                           intent(inout) :: uhtr   !< he accumulated zonal volume or mass
-                                 !! transport since the last tracer advection, in m3 or kg.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                           intent(inout) :: vhtr   !< The accumulated meridional volume or
-                                 !! mass transport since the last tracer advection, in m3 or kg.
-  real, dimension(SZI_(G),SZJ_(G)), &
-                           intent(out)   :: eta_av !< The time-mean free surface height or
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uhtr !< The accumulated zonal volume or mass
+                                                   !! transport since the last tracer advection, in m3 or kg.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: vhtr !< The accumulated meridional volume or mass
+                                                   !! transport since the last tracer advection, in m3 or kg.
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: eta_av !< The time-mean free surface height or
                                                    !! column mass, in m or kg m-2.
   type(MOM_dyn_unsplit_CS), pointer      :: CS     !< The control structure set up by
                                                    !! initialize_dyn_unsplit.
@@ -221,41 +216,10 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
                                  !! that specify the spatially variable viscosities.
   type(MEKE_type),         pointer       :: MEKE   !< A pointer to a structure containing
                                  !! fields related to the Mesoscale Eddy Kinetic Energy.
-  type(wave_parameters_CS), &
-                 optional, pointer     :: Waves  !< A pointer to a structure containing
+  type(wave_parameters_CS), optional, pointer :: Waves !< A pointer to a structure containing
                                  !! fields related to the surface wave conditions
 
-! Arguments: u - The input and output zonal velocity, in m s-1.
-!  (inout)   v - The input and output meridional velocity, in m s-1.
-!  (inout)   h - The input and output layer thicknesses, in m or kg m-2,
-!                depending on whether the Boussinesq approximation is made.
-!  (in)      tv - a structure pointing to various thermodynamic variables.
-!  (inout)   visc - A structure containing vertical viscosities, bottom drag
-!                   viscosities, and related fields.
-!  (in)      Time_local - The model time at the end of the time step.
-!  (in)      dt - The time step in s.
-!  (in)      fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      p_surf_begin - A pointer (perhaps NULL) to the surface pressure
-!                     at the beginning of this dynamic step, in Pa.
-!  (in)      p_surf_end - A pointer (perhaps NULL) to the surface pressure
-!                     at the end of this dynamic step, in Pa.
-!  (inout)   uh - The zonal volume or mass transport, in m3 s-1 or kg s-1.
-!  (inout)   vh - The meridional volume or mass transport, in m3 s-1 or kg s-1.
-!  (inout)   uhtr - The accumulated zonal volume or mass transport since the last
-!                   tracer advection, in m3 or kg.
-!  (inout)   vhtr - The accumulated meridional volume or mass transport since the last
-!                   tracer advection, in m3 or kg.
-!  (out)     eta_av - The time-mean free surface height or column mass, in m or
-!                     kg m-2.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure set up by initialize_dyn_unsplit.
-!  (in)      VarMix - A pointer to a structure with fields that specify the
-!                     spatially variable viscosities.
-!  (inout)   MEKE - A pointer to a structure containing fields related to
-!                   the Mesoscale Eddy Kinetic Energy.
-
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_av, hp
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)) :: up, upp
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)) :: vp, vpp
@@ -548,6 +512,11 @@ end subroutine step_MOM_dyn_unsplit
 
 ! =============================================================================
 
+!> Allocate the control structure for this module, allocates memory in it, and registers
+!! any auxiliary restart variables that are specific to the unsplit time stepping scheme.
+!!
+!! All variables registered here should have the ability to be recreated if they are not present
+!! in a restart file.
 subroutine register_restarts_dyn_unsplit(HI, GV, param_file, CS, restart_CS)
   type(hor_index_type),      intent(in) :: HI         !< A horizontal index type structure.
   type(verticalGrid_type),   intent(in) :: GV         !< The ocean's vertical grid structure.
@@ -557,24 +526,14 @@ subroutine register_restarts_dyn_unsplit(HI, GV, param_file, CS, restart_CS)
                                                       !! initialize_dyn_unsplit.
   type(MOM_restart_CS),      pointer    :: restart_CS !< A pointer to the restart control structure.
 
-!   This subroutine sets up any auxiliary restart variables that are specific
-! to the unsplit time stepping scheme.  All variables registered here should
-! have the ability to be recreated if they are not present in a restart file.
-
-! Arguments: HI - A horizontal index type structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (inout)   CS - The control structure set up by initialize_dyn_unsplit.
-!  (inout)   restart_CS - A pointer to the restart control structure.
-
+  ! Local arguments
   character(len=40)  :: mdl = "MOM_dynamics_unsplit" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
   IsdB = HI%IsdB ; IedB = HI%IedB ; JsdB = HI%JsdB ; JedB = HI%JedB
 
-! This is where a control structure that is specific to this module would be allocated.
+  ! This is where a control structure that is specific to this module is allocated.
   if (associated(CS)) then
     call MOM_error(WARNING, "register_restarts_dyn_unsplit called with an associated "// &
                              "control structure.")
@@ -648,39 +607,10 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, param_file, diag, CS, &
                                                         !! records the number of times the velocity
                                                         !! is truncated (this should be 0).
 
-! Arguments: u - The zonal velocity, in m s-1.
-!  (inout)   v - The meridional velocity, in m s-1.
-!  (inout)   h - The layer thicknesses, in m or kg m-2, depending on whether
-!                the Boussinesq approximation is made.
-!  (in)      Time - The current model time.
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      diag - A structure that is used to regulate diagnostic output.
-!  (inout)   CS - The control structure set up by initialize_dyn_unsplit.
-!  (in)      restart_CS - A pointer to the restart control structure.
-!  (inout)   Accel_diag - A set of pointers to the various accelerations in
-!                  the momentum equations, which can be used for later derived
-!                  diagnostics, like energy budgets.
-!  (inout)   Cont_diag - A structure with pointers to various terms in the
-!                   continuity equations.
-!  (inout)   MIS - The "MOM6 Internal State" structure, used to pass around
-!                  pointers to various arrays for diagnostic purposes.
-!  (in)      OBC - If open boundary conditions are used, this points to the
-!                  ocean_OBC_type that was set up in MOM_initialization.
-!  (in)      update_OBC_CSp - If open boundary condition updates are used,
-!                  this points to the appropriate control structure.
-!  (in)      ALE_CS - This points to the ALE control structure.
-!  (in)      setVisc_CSp - This points to the set_visc control structure.
-!  (inout)   visc - A structure containing vertical viscosities, bottom drag
-!                   viscosities, and related fields.
-!  (in)      dirs - A structure containing several relevant directory paths.
-!  (in)      ntrunc - A target for the variable that records the number of times
-!                     the velocity is truncated (this should be 0).
-
   !   This subroutine initializes all of the variables that are used by this
   ! dynamic core, including diagnostics and the cpu clocks.
+
+  ! Local variables
   character(len=40) :: mdl = "MOM_dynamics_unsplit" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   real :: H_convert

--- a/src/core/MOM_transcribe_grid.F90
+++ b/src/core/MOM_transcribe_grid.F90
@@ -1,3 +1,5 @@
+!> Module with routines for copying information from a shared dynamic horizontal
+!! grid to an ocean-specific horizontal grid and the reverse.
 module MOM_transcribe_grid
 
 ! This file is part of MOM6. See LICENSE.md for the license.

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -1,3 +1,4 @@
+!> Provides transparent structures with groups of MOM6 variables and supporting routines
 module MOM_variables
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -116,29 +117,29 @@ end type thermo_var_ptrs
 !! they refer to in MOM.F90.
 type, public :: ocean_internal_state
   real, pointer, dimension(:,:,:) :: &
-    T => NULL(), & !< Pointer to the temperature state variable
-    S => NULL(), & !< Pointer to the salinity state variable
-    u => NULL(), & !< Pointer to the zonal velocity
-    v => NULL(), & !< Pointer to the meridional velocity
-    h => NULL()    !< Pointer to the layer thicknesses
+    T => NULL(), & !< Pointer to the temperature state variable, in deg C
+    S => NULL(), & !< Pointer to the salinity state variable, in PSU or g/kg
+    u => NULL(), & !< Pointer to the zonal velocity, in m s-1
+    v => NULL(), & !< Pointer to the meridional velocity, in m s-1
+    h => NULL()    !< Pointer to the layer thicknesses, in H (often m or kg m-2)
   real, pointer, dimension(:,:,:) :: &
-    uh => NULL(), & !<  Pointer to zonal transports
-    vh => NULL()    !<  Pointer to meridional transports
+    uh => NULL(), & !<  Pointer to zonal transports, in H m2 s-1
+    vh => NULL()    !<  Pointer to meridional transports, in H m2 s-1
   real, pointer, dimension(:,:,:) :: &
-    CAu => NULL(), & !< Pointer to the zonal Coriolis and Advective acceleration
-    CAv => NULL(), & !< Pointer to the meridional Coriolis and Advective acceleration
-    PFu => NULL(), & !< Pointer to the zonal Pressure force acceleration
-    PFv => NULL(), & !< Pointer to the meridional Pressure force acceleration
-    diffu => NULL(), & !< Pointer to the zonal acceleration due to lateral viscosity
-    diffv => NULL(), & !< Pointer to the meridional acceleration due to lateral viscosity
-    pbce => NULL(), &  !< Pointer to the baroclinic pressure force dependency on free surface movement
-    u_accel_bt => NULL(), & !< Pointer to the zonal barotropic-solver acceleration
-    v_accel_bt => NULL()  !< Pointer to the meridional barotropic-solver acceleration
+    CAu => NULL(), & !< Pointer to the zonal Coriolis and Advective acceleration, in m s-2
+    CAv => NULL(), & !< Pointer to the meridional Coriolis and Advective acceleration, in m s-2
+    PFu => NULL(), & !< Pointer to the zonal Pressure force acceleration, in m s-2
+    PFv => NULL(), & !< Pointer to the meridional Pressure force acceleration, in m s-2
+    diffu => NULL(), & !< Pointer to the zonal acceleration due to lateral viscosity, in m s-2
+    diffv => NULL(), & !< Pointer to the meridional acceleration due to lateral viscosity, in m s-2
+    pbce => NULL(), &  !< Pointer to the baroclinic pressure force dependency on free surface movement, in s-2
+    u_accel_bt => NULL(), & !< Pointer to the zonal barotropic-solver acceleration, in m s-2
+    v_accel_bt => NULL()  !< Pointer to the meridional barotropic-solver acceleration, in m s-2
   real, pointer, dimension(:,:,:) :: &
-    u_av => NULL(), &  !< Pointer to zonal velocity averaged over the timestep
-    v_av => NULL(), &  !< Pointer to meridional velocity averaged over the timestep
-    u_prev => NULL(), & !< Pointer to zonal velocity at the end of the last timestep
-    v_prev => NULL()   !< Pointer to meridional velocity at the end of the last timestep
+    u_av => NULL(), &  !< Pointer to zonal velocity averaged over the timestep, in m s-1
+    v_av => NULL(), &  !< Pointer to meridional velocity averaged over the timestep, in m s-1
+    u_prev => NULL(), & !< Pointer to zonal velocity at the end of the last timestep, in m s-1
+    v_prev => NULL()   !< Pointer to meridional velocity at the end of the last timestep, in m s-1
 end type ocean_internal_state
 
 !> Pointers to arrays with accelerations, which can later be used for derived diagnostics, like energy balances.
@@ -234,8 +235,7 @@ type, public :: vertvisc_type
   real, pointer, dimension(:,:,:) :: Kd_shear => NULL()
                 !< The shear-driven turbulent diapycnal diffusivity at the interfaces between layers
                 !! in tracer columns, in m2 s-1.
-  real, pointer, dimension(:,:,:) :: &
-    Kv_shear => NULL()
+  real, pointer, dimension(:,:,:) :: Kv_shear => NULL()
                 !< The shear-driven turbulent vertical viscosity at the interfaces between layers
                 !! in tracer columns, in m2 s-1.
   real, pointer, dimension(:,:,:) :: Kv_shear_Bu => NULL()
@@ -290,13 +290,13 @@ contains
 !! the ocean model. Unused fields are unallocated.
 subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
                                   gas_fields_ocn)
-  type(ocean_grid_type), intent(in)    :: G                !< ocean grid structure
-  type(surface),         intent(inout) :: sfc_state        !< ocean surface state type to be allocated.
-  logical,     optional, intent(in)    :: use_temperature  !< If true, allocate the space for thermodynamic variables.
-  logical,     optional, intent(in)    :: do_integrals     !< If true, allocate the space for vertically
-                                                           !! integrated fields.
+  type(ocean_grid_type), intent(in)    :: G               !< ocean grid structure
+  type(surface),         intent(inout) :: sfc_state       !< ocean surface state type to be allocated.
+  logical,     optional, intent(in)    :: use_temperature !< If true, allocate the space for thermodynamic variables.
+  logical,     optional, intent(in)    :: do_integrals    !< If true, allocate the space for vertically
+                                                          !! integrated fields.
   type(coupler_1d_bc_type), &
-               optional, intent(in)    :: gas_fields_ocn   !< If present, this type describes the ocean
+               optional, intent(in)    :: gas_fields_ocn  !< If present, this type describes the ocean
                                               !! ocean and surface-ice fields that will participate
                                               !! in the calculation of additional gas or other
                                               !! tracer fluxes, and can be used to spawn related
@@ -327,8 +327,7 @@ subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
   allocate(sfc_state%v(isd:ied,JsdB:JedB)) ; sfc_state%v(:,:) = 0.0
 
   if (alloc_integ) then
-    ! Allocate structures for the vertically integrated ocean_mass, ocean_heat,
-    ! and ocean_salt.
+    ! Allocate structures for the vertically integrated ocean_mass, ocean_heat, and ocean_salt.
     allocate(sfc_state%ocean_mass(isd:ied,jsd:jed)) ; sfc_state%ocean_mass(:,:) = 0.0
     if (use_temp) then
       allocate(sfc_state%ocean_heat(isd:ied,jsd:jed)) ; sfc_state%ocean_heat(:,:) = 0.0
@@ -347,7 +346,7 @@ end subroutine allocate_surface_state
 
 !> Deallocates the elements of a surface state type.
 subroutine deallocate_surface_state(sfc_state)
-  type(surface),         intent(inout) :: sfc_state        !< ocean surface state type to be deallocated.
+  type(surface), intent(inout) :: sfc_state !< ocean surface state type to be deallocated here.
 
   if (.not.sfc_state%arrays_allocated) return
 

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -1,3 +1,4 @@
+!> Provides a transparent vertical ocean grid type and supporting routines
 module MOM_verticalGrid
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -56,14 +57,16 @@ contains
 
 !> Allocates and initializes the ocean model vertical grid structure.
 subroutine verticalGridInit( param_file, GV )
-! This routine initializes the verticalGrid_type structure (GV).
-! All memory is allocated but not necessarily set to meaningful values until later.
   type(param_file_type),   intent(in) :: param_file !< Parameter file handle/type
   type(verticalGrid_type), pointer    :: GV         !< The container for vertical grid data
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This routine initializes the verticalGrid_type structure (GV).
+  ! All memory is allocated but not necessarily set to meaningful values until later.
+
+  ! Local variables
   integer :: nk, H_power
   real    :: rescale_factor
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=16) :: mdl = 'MOM_verticalGrid'
 
   if (associated(GV)) call MOM_error(FATAL, &
@@ -150,14 +153,11 @@ end subroutine verticalGridInit
 
 !> Returns the model's thickness units, usually m or kg/m^2.
 function get_thickness_units(GV)
-  character(len=48)                 :: get_thickness_units
+  character(len=48)                   :: get_thickness_units !< The vertical thickness units
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
-!   This subroutine returns the appropriate units for thicknesses,
-! depending on whether the model is Boussinesq or not and the scaling for
-! the vertical thickness.
-
-! Arguments: G - The ocean's grid structure.
-!  (ret)     get_thickness_units - The model's vertical thickness units.
+  !   This subroutine returns the appropriate units for thicknesses,
+  ! depending on whether the model is Boussinesq or not and the scaling for
+  ! the vertical thickness.
 
   if (GV%Boussinesq) then
     get_thickness_units = "m"
@@ -168,14 +168,11 @@ end function get_thickness_units
 
 !> Returns the model's thickness flux units, usually m^3/s or kg/s.
 function get_flux_units(GV)
-  character(len=48)                 :: get_flux_units
+  character(len=48)                   :: get_flux_units !< The thickness flux units
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
-!   This subroutine returns the appropriate units for thickness fluxes,
-! depending on whether the model is Boussinesq or not and the scaling for
-! the vertical thickness.
-
-! Arguments: G - The ocean's grid structure.
-!  (ret)     get_flux_units - The model's thickness flux units.
+  !   This subroutine returns the appropriate units for thickness fluxes,
+  ! depending on whether the model is Boussinesq or not and the scaling for
+  ! the vertical thickness.
 
   if (GV%Boussinesq) then
     get_flux_units = "m3 s-1"
@@ -201,20 +198,9 @@ function get_tr_flux_units(GV, tr_units, tr_vol_conc_units, tr_mass_conc_units)
                                                               !! the units are mol kg-1,
                                                               !! tr_vol_conc_units would be mol.
 
-!   This subroutine returns the appropriate units for thicknesses and fluxes,
-! depending on whether the model is Boussinesq or not and the scaling for
-! the vertical thickness.
-
-! Arguments: G - The ocean's grid structure.
-!      One of the following three arguments must be present.
-!  (in,opt)  tr_units - Units for a tracer, for example Celsius or PSU.
-!  (in,opt)  tr_vol_conc_units - The concentration units per unit volume, for
-!                                example if the units are umol m-3,
-!                                tr_vol_conc_units would be umol.
-!  (in,opt)  tr_mass_conc_units - The concentration units per unit mass of sea
-!                                water, for example if the units are mol kg-1,
-!                                tr_vol_conc_units would be mol.
-!  (ret)     get_tr_flux_units - The model's flux units for a tracer.
+  !   This subroutine returns the appropriate units for thicknesses and fluxes,
+  ! depending on whether the model is Boussinesq or not and the scaling for
+  ! the vertical thickness.
   integer :: cnt
 
   cnt = 0
@@ -253,7 +239,6 @@ end function get_tr_flux_units
 
 !> This sets the coordinate data for the "layer mode" of the isopycnal model.
 subroutine setVerticalGridAxes( Rlay, GV )
-  ! Arguments
   type(verticalGrid_type), intent(inout) :: GV   !< The container for vertical grid data
   real, dimension(GV%ke),  intent(in)    :: Rlay !< The layer target density
   ! Local variables
@@ -276,8 +261,7 @@ end subroutine setVerticalGridAxes
 
 !> Deallocates the model's vertical grid structure.
 subroutine verticalGridEnd( GV )
-! Arguments: G - The ocean's grid structure.
-  type(verticalGrid_type), pointer :: GV   !< The ocean's vertical grid structure
+  type(verticalGrid_type), pointer :: GV !< The ocean's vertical grid structure
 
   deallocate( GV%g_prime, GV%Rlay )
   deallocate( GV%sInterface , GV%sLayer )


### PR DESCRIPTION
Added module DoxyGenization in the MOM6/src/core directory

  Added comments with module-level dOxyGen comments to those files in the
MOM6/src/core directory where this was missing.  No answers or MOM_parameter_doc
files are changed by these modifications.  The list of commits in this PR
include:
- NOAA-GFDL/MOM6@de13a2c Module dOxyGenization for MOM_transribe_grid
- NOAA-GFDL/MOM6@0431fd7 Module dOxyGenization for MOM_dynamics_unsplit
- NOAA-GFDL/MOM6@f3b818b Module dOxyGenization for MOM_checksum_packages
- NOAA-GFDL/MOM6@c621b54 Module dOxyGenization for MOM
- NOAA-GFDL/MOM6@0da8297 Module dOxyGenization for MOM_variables & vertGrid
