### PR TITLE
Fixes doxygen configuration and missing module one-liners

### DIFF
--- a/config_src/coupled_driver/coupler_util.F90
+++ b/config_src/coupled_driver/coupler_util.F90
@@ -1,9 +1,9 @@
+!> Provides a couple of interfaces to allow more transparent and
+!! robust extraction of the various fields in the coupler types.
 module coupler_util
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!   This code provides a couple of interfaces to allow more transparent and
-! robust extraction of the various fields in the coupler types.
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use coupler_types_mod, only : coupler_2d_bc_type, ind_flux, ind_alpha
 use coupler_types_mod, only : ind_csurf
@@ -15,24 +15,20 @@ public :: ind_flux, ind_alpha, ind_csurf
 
 contains
 
+!> Extract an array of values in a coupler bc type
 subroutine extract_coupler_values(BC_struc, BC_index, BC_element, array_out, &
                                   is, ie, js, je, conversion)
-  type(coupler_2d_bc_type), intent(in)  :: BC_struc
-  integer,                  intent(in)  :: BC_index, BC_element
-  real, dimension(:,:),     intent(out) :: array_out
-  integer,        optional, intent(in)  :: is, ie, js, je
-  real,           optional, intent(in)  :: conversion
-! Arguments: BC_struc - The type from which the data is being extracted.
-!  (in)      BC_index - The boundary condition number being extracted.
-!  (in)      BC_element - The element of the boundary condition being extracted.
-!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
-!  (out)     array_out - The array being filled with the input values.
-!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
-!            These must match the size of the corresponding value array or an
-!            error message is issued.
-!  (in, opt) conversion - A number that every element is multiplied by, to
-!                         permit sign convention or unit conversion.
-
+  type(coupler_2d_bc_type), intent(in)  :: BC_struc !< The type from which the data is being extracted.
+  integer,                  intent(in)  :: BC_index !< The boundary condition number being extracted.
+  integer,                  intent(in)  :: BC_element !< The element of the boundary condition being extracted.
+  real, dimension(:,:),     intent(out) :: array_out !< The array being filled with the input values.
+  integer,        optional, intent(in)  :: is !< Start i-index
+  integer,        optional, intent(in)  :: ie !< End i-index
+  integer,        optional, intent(in)  :: js !< Start j-index
+  integer,        optional, intent(in)  :: je !< End j-index
+  real,           optional, intent(in)  :: conversion !< A number that every element is multiplied by, to
+                                           !! permit sign convention or unit conversion.
+  ! Local variables
   real, pointer, dimension(:,:) :: Array_in
   real :: conv
   integer :: i, j, is0, ie0, js0, je0, i_offset, j_offset
@@ -78,24 +74,21 @@ subroutine extract_coupler_values(BC_struc, BC_index, BC_element, array_out, &
 
 end subroutine extract_coupler_values
 
+!> Set an array of values in a coupler bc type
 subroutine set_coupler_values(array_in, BC_struc, BC_index, BC_element, &
                               is, ie, js, je, conversion)
-  real, dimension(:,:),     intent(in)    :: array_in
-  type(coupler_2d_bc_type), intent(inout) :: BC_struc
-  integer,                  intent(in)    :: BC_index, BC_element
-  integer,        optional, intent(in)    :: is, ie, js, je
-  real,           optional, intent(in)    :: conversion
-! Arguments: array_in - The array containing the values to load into the BC.
-!  (out)     BC_struc - The type into which the data is being loaded.
-!  (in)      BC_index - The boundary condition number being extracted.
-!  (in)      BC_element - The element of the boundary condition being extracted.
-!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
-!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
-!            These must match the size of the corresponding value array or an
-!            error message is issued.
-!  (in, opt) conversion - A number that every element is multiplied by, to
-!                         permit sign convention or unit conversion.
-
+  real, dimension(:,:),     intent(in)    :: array_in !< The array containing the values to load into the BC.
+  type(coupler_2d_bc_type), intent(inout) :: BC_struc !< The type from which the data is being extracted.
+  integer,                  intent(in)    :: BC_index !< The boundary condition number being extracted.
+  integer,                  intent(in)    :: BC_element !< The element of the boundary condition being extracted.
+                                             !! This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
+  integer,        optional, intent(in)    :: is !< Start i-index
+  integer,        optional, intent(in)    :: ie !< End i-index
+  integer,        optional, intent(in)    :: js !< Start j-index
+  integer,        optional, intent(in)    :: je !< End j-index
+  real,           optional, intent(in)    :: conversion !< A number that every element is multiplied by, to
+                                             !! permit sign convention or unit conversion.
+  ! Local variables
   real, pointer, dimension(:,:) :: Array_out
   real :: conv
   integer :: i, j, is0, ie0, js0, je0, i_offset, j_offset

--- a/config_src/solo_driver/MESO_surface_forcing.F90
+++ b/config_src/solo_driver/MESO_surface_forcing.F90
@@ -1,48 +1,8 @@
+!> Sets forcing for the MESO configuration
 module MESO_surface_forcing
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*  Rewritten by Robert Hallberg, June 2009                            *
-!*                                                                     *
-!*    This file contains the subroutines that a user should modify to  *
-!*  to set the surface wind stresses and fluxes of buoyancy or         *
-!*  temperature and fresh water.  They are called when the run-time    *
-!*  parameters WIND_CONFIG or BUOY_CONFIG are set to "USER".  The      *
-!*  standard version has simple examples, along with run-time error    *
-!*  messages that will cause the model to abort if this code has not   *
-!*  been modified.  This code is intended for use with relatively      *
-!*  simple specifications of the forcing.  For more complicated forms, *
-!*  it is probably a good idea to read the forcing from input files    *
-!*  using "file" for WIND_CONFIG and BUOY_CONFIG.                      *
-!*                                                                     *
-!*    MESO_wind_forcing should set the surface wind stresses (taux and *
-!*  tauy) perhaps along with the surface friction velocity (ustar).    *
-!*                                                                     *
-!*    MESO_buoyancy forcing is used to set the surface buoyancy        *
-!*  forcing, which may include a number of fresh water flux fields     *
-!*  (evap, liq_precip, froz_precip, liq_runoff, froz_runoff, and       *
-!*  vprec) and the surface heat fluxes (sw, lw, latent and sens)       *
-!*  if temperature and salinity are state variables, or it may simply  *
-!*  be the buoyancy flux if it is not.  This routine also has coded a  *
-!*  restoring to surface values of temperature and salinity.           *
-!*                                                                     *
-!*  Macros written all in capital letters are defined in MOM_memory.h. *
-!*                                                                     *
-!*     A small fragment of the grid is shown below:                    *
-!*                                                                     *
-!*    j+1  x ^ x ^ x   At x:  q                                        *
-!*    j+1  > o > o >   At ^:  v, tauy                                  *
-!*    j    x ^ x ^ x   At >:  u, taux                                  *
-!*    j    > o > o >   At o:  h, fluxes.                               *
-!*    j-1  x ^ x ^ x                                                   *
-!*        i-1  i  i+1  At x & ^:                                       *
-!*           i  i+1    At > & o:                                       *
-!*                                                                     *
-!*  The boundaries always run through q grid points (x).               *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 use MOM_diag_mediator, only : post_data, query_averaging_enabled
 use MOM_diag_mediator, only : register_diag_field, diag_ctrl, safe_alloc_ptr
 use MOM_domains, only : pass_var, pass_vector, AGRID
@@ -407,5 +367,31 @@ subroutine MESO_surface_forcing_init(Time, G, param_file, diag, CS)
    endif
 
 end subroutine MESO_surface_forcing_init
+
+!> \namespace meso_surface_forcing
+!!
+!! Rewritten by Robert Hallberg, June 2009
+!!
+!!   This file contains the subroutines that a user should modify to
+!! to set the surface wind stresses and fluxes of buoyancy or
+!! temperature and fresh water.  They are called when the run-time
+!! parameters WIND_CONFIG or BUOY_CONFIG are set to "USER".  The
+!! standard version has simple examples, along with run-time error
+!! messages that will cause the model to abort if this code has not
+!! been modified.  This code is intended for use with relatively
+!! simple specifications of the forcing.  For more complicated forms,
+!! it is probably a good idea to read the forcing from input files
+!! using "file" for WIND_CONFIG and BUOY_CONFIG.
+!!
+!!   MESO_wind_forcing should set the surface wind stresses (taux and
+!! tauy) perhaps along with the surface friction velocity (ustar).
+!!
+!!   MESO_buoyancy forcing is used to set the surface buoyancy
+!! forcing, which may include a number of fresh water flux fields
+!! (evap, liq_precip, froz_precip, liq_runoff, froz_runoff, and
+!! vprec) and the surface heat fluxes (sw, lw, latent and sens)
+!! if temperature and salinity are state variables, or it may simply
+!! be the buoyancy flux if it is not.  This routine also has coded a
+!! restoring to surface values of temperature and salinity.
 
 end module MESO_surface_forcing

--- a/config_src/solo_driver/coupler_types.F90
+++ b/config_src/solo_driver/coupler_types.F90
@@ -1,11 +1,12 @@
+!> This module contains the coupler-type declarations and methods for use in
+!! ocean-only configurations of MOM6.
+!!
+!! It is intended that the version of coupler_types_mod that is avialable from
+!! FMS will conform to this version with the FMS city release after warsaw.
+
 module coupler_types_mod
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!   This module contains the coupler-type declarations and methods for use in
-! ocean-only configurations of MOM6.  It is intended that the version of
-! coupler_types_mod that is avialable from FMS will conform to this version with
-! the FMS city release after warsaw.
 
 use fms_io_mod,        only: restart_file_type, register_restart_field
 use fms_io_mod,        only: query_initialized, restore_state

--- a/config_src/solo_driver/coupler_util.F90
+++ b/config_src/solo_driver/coupler_util.F90
@@ -1,9 +1,9 @@
+!> Provides a couple of interfaces to allow more transparent and
+!! robust extraction of the various fields in the coupler types.
 module coupler_util
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!   This code provides a couple of interfaces to allow more transparent and
-! robust extraction of the various fields in the coupler types.
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use coupler_types_mod, only : coupler_2d_bc_type, ind_flux, ind_alpha
 use coupler_types_mod, only : ind_csurf
@@ -15,24 +15,19 @@ public :: ind_flux, ind_alpha, ind_csurf
 
 contains
 
+!> Extract an array of values in a coupler bc type
 subroutine extract_coupler_values(BC_struc, BC_index, BC_element, array_out, &
                                   is, ie, js, je, conversion)
-  type(coupler_2d_bc_type), intent(in)  :: BC_struc
-  integer,                  intent(in)  :: BC_index, BC_element
-  real, dimension(:,:),     intent(out) :: array_out
-  integer,        optional, intent(in)  :: is, ie, js, je
-  real,           optional, intent(in)  :: conversion
-! Arguments: BC_struc - The type from which the data is being extracted.
-!  (in)      BC_index - The boundary condition number being extracted.
-!  (in)      BC_element - The element of the boundary condition being extracted.
-!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
-!  (out)     array_out - The array being filled with the input values.
-!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
-!            These must match the size of the corresponding value array or an
-!            error message is issued.
-!  (in, opt) conversion - A number that every element is multiplied by, to
-!                         permit sign convention or unit conversion.
-
+  type(coupler_2d_bc_type), intent(in)  :: BC_struc !< The type from which the data is being extracted.
+  integer,                  intent(in)  :: BC_index !< The boundary condition number being extracted.
+  integer,                  intent(in)  :: BC_element !< The element of the boundary condition being extracted.
+  real, dimension(:,:),     intent(out) :: array_out !< The array being filled with the input values.
+  integer,        optional, intent(in)  :: is !< Start i-index
+  integer,        optional, intent(in)  :: ie !< End i-index
+  integer,        optional, intent(in)  :: js !< Start j-index
+  integer,        optional, intent(in)  :: je !< End j-index
+  real,           optional, intent(in)  :: conversion !< A number that every element is multiplied by, to
+  ! Local variables
   real, pointer, dimension(:,:) :: Array_in
   real :: conv
   integer :: i, j, is0, ie0, js0, je0, i_offset, j_offset
@@ -78,24 +73,20 @@ subroutine extract_coupler_values(BC_struc, BC_index, BC_element, array_out, &
 
 end subroutine extract_coupler_values
 
+!> Set an array of values in a coupler bc type
 subroutine set_coupler_values(array_in, BC_struc, BC_index, BC_element, &
                               is, ie, js, je, conversion)
-  real, dimension(:,:),     intent(in)    :: array_in
-  type(coupler_2d_bc_type), intent(inout) :: BC_struc
-  integer,                  intent(in)    :: BC_index, BC_element
-  integer,        optional, intent(in)    :: is, ie, js, je
-  real,           optional, intent(in)    :: conversion
-! Arguments: array_in - The array containing the values to load into the BC.
-!  (out)     BC_struc - The type into which the data is being loaded.
-!  (in)      BC_index - The boundary condition number being extracted.
-!  (in)      BC_element - The element of the boundary condition being extracted.
-!            This could be ind_csurf, ind_alpha, ind_flux or ind_deposition.
-!  (in, opt) is, ie, js, je - The i- and j- limits of array_out to be filled.
-!            These must match the size of the corresponding value array or an
-!            error message is issued.
-!  (in, opt) conversion - A number that every element is multiplied by, to
-!                         permit sign convention or unit conversion.
-
+  real, dimension(:,:),     intent(in)    :: array_in !< The array containing the values to load into the BC.
+  type(coupler_2d_bc_type), intent(inout) :: BC_struc !< The type from which the data is being extracted.
+  integer,                  intent(in)    :: BC_index !< The boundary condition number being extracted.
+  integer,                  intent(in)    :: BC_element !< The element of the boundary condition being extracted.
+  integer,        optional, intent(in)    :: is !< Start i-index
+  integer,        optional, intent(in)    :: ie !< End i-index
+  integer,        optional, intent(in)    :: js !< Start j-index
+  integer,        optional, intent(in)    :: je !< End j-index
+  real,           optional, intent(in)    :: conversion !< A number that every element is multiplied by, to
+                                             !! permit sign convention or unit conversion.
+  ! Local variables
   real, pointer, dimension(:,:) :: Array_out
   real :: conv
   integer :: i, j, is0, ie0, js0, je0, i_offset, j_offset

--- a/docs/Doxyfile_nortd
+++ b/docs/Doxyfile_nortd
@@ -793,8 +793,7 @@ WARN_LOGFILE           = doxygen.log
 INPUT                  = ../src \
                          front_page.md \
                          ../config_src/solo_driver \
-                         ../config_src/dynamic_symmetric \
-                         ../config_src/coupled_driver/coupler_util.F90 \
+                         ../config_src/dynamic_symmetric
                          ../config_src/coupled_driver/ocean_model_MOM.F90
 
 # This tag can be used to specify the character encoding of the source files

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -1,30 +1,13 @@
+!> Debug accelerations at a given point
+!!
+!!    The two subroutines in this file write out all of the terms
+!! in the u- or v-momentum balance at a given point.  Usually
+!! these subroutines are called after the velocities exceed some
+!! threshold, in order to determine which term is culpable.
+!! often this is done for debugging purposes.
 module MOM_PointAccel
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!***********************************************************************
-!*                                                                     *
-!*     The two subroutines in this file write out all of the terms     *
-!*  in the u- or v-momentum balance at a given point.  Usually         *
-!*  these subroutines are called after the velocities exceed some      *
-!*  threshold, in order to determine which term is culpable.           *
-!*  often this is done for debugging purposes.                         *
-!*                                                                     *
-!*  Macros written all in capital letters are defined in MOM_memory.h  *
-!*                                                                     *
-!*     A small fragment of the grid is shown below:                    *
-!*                                                                     *
-!*    j+1  x ^ x ^ x   At x:  q, CoriolisBu                            *
-!*    j+1  > o > o >   At ^:  v, PFv, CAv, vh, diffv, vbt, vhtr        *
-!*    j    x ^ x ^ x   At >:  u, PFu, CAu, uh, diffu, ubt, uhtr        *
-!*    j    > o > o >   At o:  h, bathyT, tr, T, S                      *
-!*    j-1  x ^ x ^ x                                                   *
-!*        i-1  i  i+1  At x & ^:                                       *
-!*           i  i+1    At > & o:                                       *
-!*                                                                     *
-!*  The boundaries always run through q grid points (x).               *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_diag_mediator, only : diag_ctrl
 use MOM_domains, only : pe_here
@@ -106,11 +89,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                      optional, intent(in) :: hv  !< The layer thicknesses at velocity grid points,
                                                  !! from vertvisc, in m.
-
-! This subroutine writes to an output file all of the accelerations
-! that have been applied to a column of zonal velocities over the
-! previous timestep.  This subroutine is called from vertvisc.
-
+  ! Local variables
   real    :: f_eff, CFL
   real    :: Angstrom
   real    :: truncvel, du
@@ -438,11 +417,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                      optional, intent(in) :: hv  !< The layer thicknesses at velocity grid points,
                                                  !! from vertvisc, in m.
-
-! This subroutine writes to an output file all of the accelerations
-! that have been applied to a column of meridional velocities over
-! the previous timestep.  This subroutine is called from vertvisc.
-
+  ! Local variables
   real    :: f_eff, CFL
   real    :: Angstrom
   real    :: truncvel, dv
@@ -758,7 +733,6 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
                                                       !! directory paths.
   type(PointAccel_CS),          pointer       :: CS   !< A pointer that is set to point to the
                                                       !! control structure for this module.
-
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_PointAccel" ! This module's name.
@@ -801,4 +775,5 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
   CS%u_file = -1 ; CS%v_file = -1 ; CS%cols_written = 0
 
 end subroutine PointAccel_init
+
 end module MOM_PointAccel

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -1,13 +1,12 @@
+!> Provides checksumming functions for debugging
+!!
+!! This module contains subroutines that perform various error checking and
+!! debugging functions for MOM6.  This routine is similar to it counterpart in
+!! the SIS2 code, except for the use of the ocean_grid_type and by keeping them
+!! separate we retain the ability to set up MOM6 and SIS2 debugging separately.
 module MOM_debugging
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
-!   This module contains subroutines that perform various error checking and   !
-! debugging functions for MOM6.  This routine is similar to it counterpart in  !
-! the SIS2 code, except for the use of the ocean_grid_type and by keeping them !
-! separate we retain the ability to set up MOM6 and SIS2 debugging separately. !
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
 use MOM_checksums, only : hchksum, Bchksum, qchksum, uvchksum
 use MOM_checksums, only : is_NaN, chksum, MOM_checksums_init
@@ -66,15 +65,15 @@ interface vec_chksum_A
   module procedure chksum_vec_A3d, chksum_vec_A2d
 end interface vec_chksum_A
 
-integer :: max_redundant_prints = 100
-integer :: redundant_prints(3) = 0
-logical :: debug = .false.
-logical :: debug_chksums = .true.
-logical :: debug_redundant = .true.
+! Note: these parameters are module data but ONLY used when debugging and
+!       so can violate the thread-safe requirement of no module/global data.
+integer :: max_redundant_prints = 100 !< Maximum number of times to write redundant messages
+integer :: redundant_prints(3) = 0 !< Counters for controlling redundant printing
+logical :: debug = .false. !< Write out verbose debugging data
+logical :: debug_chksums = .true. !< Perform checksums on arrays
+logical :: debug_redundant = .true. !< Check redundant 
 
 contains
-
-! =====================================================================
 
 !> MOM_debugging_init initializes the MOM_debugging module, and sets
 !! the parameterts that control which checks are active for MOM6.
@@ -116,7 +115,7 @@ subroutine check_redundant_vC3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer,                   optional, intent(in)    :: je     !< The ending j-index to check
   integer,                   optional, intent(in)    :: direction !< the direction flag to be
                                                                !! passed to pass_vector
-
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -152,9 +151,9 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   real :: u_resym(G%IsdB:G%IedB,G%jsd:G%jed)
   real :: v_resym(G%isd:G%ied,G%JsdB:G%JedB)
   character(len=128) :: mesg2
-
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -241,14 +240,13 @@ subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
   integer,                optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                optional, intent(in)    :: js    !< The starting j-index to check
   integer,                optional, intent(in)    :: je    !< The ending j-index to check
-
   ! Local variables
   real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)
   real :: a_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
   character(len=128) :: mesg2
-
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -306,7 +304,6 @@ subroutine check_redundant_vB3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer,                   optional, intent(in)    :: je     !< The ending j-index to check
   integer,                   optional, intent(in)    :: direction !< the direction flag to be
                                                                !! passed to pass_vector
-
   ! Local variables
   character(len=24) :: mesg_k
   integer :: k
@@ -337,16 +334,15 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer,                optional, intent(in)    :: je     !< The ending j-index to check
   integer,                optional, intent(in)    :: direction !< the direction flag to be
                                                             !! passed to pass_vector
-
   ! Local variables
   real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
   real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
   real :: u_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
   real :: v_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
   character(len=128) :: mesg2
-
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -409,7 +405,6 @@ subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je)
   integer,                    optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                    optional, intent(in)    :: js    !< The starting j-index to check
   integer,                    optional, intent(in)    :: je    !< The ending j-index to check
-
   ! Local variables
   character(len=24) :: mesg_k
   integer :: k
@@ -435,7 +430,6 @@ subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
   integer,                optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                optional, intent(in)    :: js    !< The starting j-index to check
   integer,                optional, intent(in)    :: je    !< The ending j-index to check
-
   ! Local variables
   real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)
   character(len=128) :: mesg2
@@ -516,13 +510,7 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer,               optional, intent(in)    :: je     !< The ending j-index to check
   integer,               optional, intent(in)    :: direction !< the direction flag to be
                                                            !! passed to pass_vector
-! Arguments: u_comp - The u-component of the vector being checked.
-!  (in)      v_comp - The v-component of the vector being checked.
-!  (in)      mesg - A message indicating what is being checked.
-!  (in)      G - The ocean's grid structure.
-!  (in/opt)  is, ie, js, je - the i- and j- range of indices to check.
-!  (in/opt)  direction - the direction flag to be passed to pass_vector.
-
+  ! Local variables
   real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
   real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
   character(len=128) :: mesg2
@@ -571,8 +559,6 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
 
 end subroutine  check_redundant_vT2d
 
-! =====================================================================
-
 !> Do a checksum and redundant point check on a 3d C-grid vector.
 subroutine chksum_vec_C3d(mesg, u_comp, v_comp, G, halos, scalars)
   character(len=*),                  intent(in)    :: mesg   !< An identifying message
@@ -582,7 +568,7 @@ subroutine chksum_vec_C3d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,                 optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                 optional, intent(in)    :: scalars !< If true this is a pair of
                                                              !! scalars that are being checked.
-
+  ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
@@ -608,7 +594,7 @@ subroutine chksum_vec_C2d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,               optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,               optional, intent(in)    :: scalars !< If true this is a pair of
                                                            !! scalars that are being checked.
-
+  ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
@@ -634,7 +620,7 @@ subroutine chksum_vec_B3d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,                  optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                  optional, intent(in)    :: scalars !< If true this is a pair of
                                                               !! scalars that are being checked.
-
+  ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
@@ -663,7 +649,7 @@ subroutine chksum_vec_B2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric)
                                                             !! scalars that are being checked.
   logical,                optional, intent(in)    :: symmetric !< If true, do the checksums on the
                                                             !! full symmetric computational domain.
-
+  ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
@@ -690,7 +676,7 @@ subroutine chksum_vec_A3d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,                optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                optional, intent(in)    :: scalars !< If true this is a pair of
                                                             !! scalars that are being checked.
-
+  ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
@@ -708,7 +694,6 @@ subroutine chksum_vec_A3d(mesg, u_comp, v_comp, G, halos, scalars)
 
 end subroutine chksum_vec_A3d
 
-
 !> Do a checksum and redundant point check on a 2d C-grid vector.
 subroutine chksum_vec_A2d(mesg, u_comp, v_comp, G, halos, scalars)
   character(len=*),               intent(in)    :: mesg   !< An identifying message
@@ -718,7 +703,7 @@ subroutine chksum_vec_A2d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,              optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,              optional, intent(in)    :: scalars !< If true this is a pair of
                                                           !! scalars that are being checked.
-
+  ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
@@ -736,9 +721,6 @@ subroutine chksum_vec_A2d(mesg, u_comp, v_comp, G, halos, scalars)
 
 end subroutine chksum_vec_A2d
 
-
-! =====================================================================
-
 !> This function returns the sum over computational domain of all
 !! processors of hThick*stuff, where stuff is a 3-d array at tracer points.
 function totalStuff(HI, hThick, areaT, stuff)
@@ -747,7 +729,6 @@ function totalStuff(HI, hThick, areaT, stuff)
   real, dimension(HI%isd:,HI%jsd:),   intent(in) :: areaT  !< The array of cell areas in m2
   real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: stuff  !< The array of stuff to be summed
   real                                         :: totalStuff !< the globally integrated amoutn of stuff
-
   ! Local variables
   integer :: i, j, k, nz
 
@@ -760,12 +741,8 @@ function totalStuff(HI, hThick, areaT, stuff)
 
 end function totalStuff
 
-! =====================================================================
-
 !> This subroutine display the total thickness, temperature and salinity
 !! as well as the change since the last call.
-!! NOTE: This subroutine uses "save" data which is not thread safe and is purely
-!! for extreme debugging without a proper debugger.
 subroutine totalTandS(HI, hThick, areaT, temperature, salinity, mesg)
   type(hor_index_type),               intent(in) :: HI     !< A horizontal index type
   real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: hThick !< The array of thicknesses to use as weights
@@ -773,11 +750,10 @@ subroutine totalTandS(HI, hThick, areaT, temperature, salinity, mesg)
   real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: temperature !< The temperature field to sum
   real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: salinity    !< The salinity field to sum
   character(len=*),                   intent(in) :: mesg        !< An identifying message
-
   ! NOTE: This subroutine uses "save" data which is not thread safe and is purely for
   ! extreme debugging without a proper debugger.
   real, save :: totalH = 0., totalT = 0., totalS = 0.
-
+  ! Local variables
   logical, save :: firstCall = .true.
   real :: thisH, thisT, thisS, delH, delT, delS
   integer :: i, j, k, nz
@@ -850,8 +826,6 @@ logical function check_column_integrals(nk_1, field_1, nk_2, field_2, missing_va
   real, dimension(nk_2), intent(in) :: field_2        !< Second field to be summed
   real, optional,        intent(in) :: missing_value  !< If column contains missing values,
                                                       !! mask them from the sum
-
-
   ! Local variables
   real    :: u1_sum, error1, u2_sum, error2, misval
   integer :: k

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -71,7 +71,7 @@ integer :: max_redundant_prints = 100 !< Maximum number of times to write redund
 integer :: redundant_prints(3) = 0 !< Counters for controlling redundant printing
 logical :: debug = .false. !< Write out verbose debugging data
 logical :: debug_chksums = .true. !< Perform checksums on arrays
-logical :: debug_redundant = .true. !< Check redundant 
+logical :: debug_redundant = .true. !< Check redundant values on PE boundaries
 
 contains
 

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1,28 +1,9 @@
+!> Calculates any requested diagnostic quantities
+!! that are not calculated in the various subroutines.
+!! Diagnostic quantities are requested by allocating them memory.
 module MOM_diagnostics
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*  By Robert Hallberg, February 2001                                  *
-!*                                                                     *
-!*    This subroutine calculates any requested diagnostic quantities   *
-!*  that are not calculated in the various subroutines.  Diagnostic    *
-!*  quantities are requested by allocating them memory.                *
-!*                                                                     *
-!*     A small fragment of the grid is shown below:                    *
-!*                                                                     *
-!*    j+1  x ^ x ^ x   At x:  q, CoriolisBu                            *
-!*    j+1  > o > o >   At ^:  v                                        *
-!*    j    x ^ x ^ x   At >:  u                                        *
-!*    j    > o > o >   At o:  h, bathyT                                *
-!*    j-1  x ^ x ^ x                                                   *
-!*        i-1  i  i+1  At x & ^:                                       *
-!*           i  i+1    At > & o:                                       *
-!*                                                                     *
-!*  The boundaries always run through q grid points (x).               *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_coms,              only : reproducing_sum
 use MOM_diag_mediator,     only : post_data, post_data_1d_k, get_diag_time_end

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -1,41 +1,7 @@
+!> Reports integrated quantities for monitoring the model state
 module MOM_sum_output
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*  By Robert Hallberg, April 1994 - June 2002                         *
-!*                                                                     *
-!*    This file contains the subroutine (write_energy) that writes     *
-!*  horizontally integrated quantities, such as energies and layer     *
-!*  volumes, and other summary information to an output file.  Some    *
-!*  of these quantities (APE or resting interface height) are defined  *
-!*  relative to the global histogram of topography.  The subroutine    *
-!*  that compiles that histogram (depth_list_setup) is also included   *
-!*  in this file.                                                      *
-!*                                                                     *
-!*    In addition, if the number of velocity truncations since the     *
-!*  previous call to write_energy exceeds maxtrunc or the total energy *
-!*  exceeds a very large threshold, a fatal termination is triggered.  *
-!*                                                                     *
-!*    This file also contains a few miscelaneous initialization        *
-!*  calls to FMS-related modules.                                      *
-!*                                                                     *
-!*  Macros written all in capital letters are defined in MOM_memory.h. *
-!*                                                                     *
-!*     A small fragment of the grid is shown below:                    *
-!*                                                                     *
-!*    j+1  x ^ x ^ x   At x:  q                                        *
-!*    j+1  > o > o >   At ^:  v                                        *
-!*    j    x ^ x ^ x   At >:  u                                        *
-!*    j    > o > o >   At o:  h, bathyT                                *
-!*    j-1  x ^ x ^ x                                                   *
-!*        i-1  i  i+1  At x & ^:                                       *
-!*           i  i+1    At > & o:                                       *
-!*                                                                     *
-!*  The boundaries always run through q grid points (x).               *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_coms, only : sum_across_PEs, PE_here, root_PE, num_PEs, max_across_PEs
 use MOM_coms, only : reproducing_sum, EFP_to_real, real_to_EFP
@@ -66,9 +32,7 @@ implicit none ; private
 
 public write_energy, accumulate_net_input, MOM_sum_output_init
 
-!-----------------------------------------------------------------------
-
-integer, parameter :: NUM_FIELDS = 17
+integer, parameter :: NUM_FIELDS = 17 !< Number of diagnostic fields
 
 !> A list of depths and corresponding globally integrated ocean area at each
 !! depth and the ocean volume below each depth.
@@ -323,7 +287,6 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
   type(ocean_OBC_type),         &
                     optional, pointer    :: OBC !< Open boundaries control structure.
   type(time_type),  optional, intent(in) :: dt_forcing !< The forcing time step
-
   ! Local variables
   real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! The height of interfaces, in m.
   real :: areaTm(SZI_(G),SZJ_(G)) ! A masked version of areaT, in m2.
@@ -949,7 +912,6 @@ subroutine accumulate_net_input(fluxes, sfc_state, dt, G, CS)
   type(ocean_grid_type), intent(in) :: G      !< The ocean's grid structure.
   type(Sum_output_CS),   pointer    :: CS     !< The control structure returned by a previous call
                                               !! to MOM_sum_output_init.
-
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     FW_in, &   ! The net fresh water input, integrated over a timestep in kg.
@@ -1068,11 +1030,7 @@ subroutine depth_list_setup(G, CS)
   type(ocean_grid_type), intent(in) :: G    !< The ocean's grid structure
   type(Sum_output_CS),   pointer    :: CS  !< The control structure returned by a
                                            !! previous call to MOM_sum_output_init.
-!  This subroutine sets up an ordered list of depths, along with the
-! cross sectional areas at each depth and the volume of fluid deeper
-! than each depth.  This might be read from a previously created file
-! or it might be created anew.  (For now only new creation occurs.
-
+  ! Local variables
   integer :: k
 
   if (CS%read_depth_list) then
@@ -1101,7 +1059,6 @@ subroutine create_depth_list(G, CS)
   type(ocean_grid_type), intent(in) :: G  !< The ocean's grid structure.
   type(Sum_output_CS),   pointer    :: CS !< The control structure set up in MOM_sum_output_init,
                                           !! in which the ordered depth list is stored.
-
   ! Local variables
   real, dimension(G%Domain%niglobal*G%Domain%njglobal + 1) :: &
     Dlist, &  !< The global list of bottom depths, in m.
@@ -1229,7 +1186,6 @@ subroutine write_depth_list(G, CS, filename, list_size)
                                            !! previous call to MOM_sum_output_init.
   character(len=*),      intent(in) :: filename !< The path to the depth list file to write.
   integer,               intent(in) :: list_size !< The size of the depth list.
-
   ! Local variables
   real, allocatable :: tmp(:)
   integer :: ncid, dimid(1), Did, Aid, Vid, status, k
@@ -1310,7 +1266,6 @@ subroutine read_depth_list(G, CS, filename)
   type(Sum_output_CS),   pointer    :: CS  !< The control structure returned by a
                                            !! previous call to MOM_sum_output_init.
   character(len=*),      intent(in) :: filename !< The path to the depth list file to read.
-
   ! Local variables
   character(len=32) :: mdl
   character(len=240) :: var_name, var_msg
@@ -1392,5 +1347,21 @@ subroutine read_depth_list(G, CS, filename)
   deallocate(tmp)
 
 end subroutine read_depth_list
+
+!> \namespace mom_sum_output
+!!
+!! By Robert Hallberg, April 1994 - June 2002
+!!
+!!   This file contains the subroutine (write_energy) that writes
+!! horizontally integrated quantities, such as energies and layer
+!! volumes, and other summary information to an output file.  Some
+!! of these quantities (APE or resting interface height) are defined
+!! relative to the global histogram of topography.  The subroutine
+!! that compiles that histogram (depth_list_setup) is also included
+!! in this file.
+!!
+!!   In addition, if the number of velocity truncations since the
+!! previous call to write_energy exceeds maxtrunc or the total energy
+!! exceeds a very large threshold, a fatal termination is triggered.
 
 end module MOM_sum_output

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -1,3 +1,4 @@
+!> Initialize ice shelf variables
 module MOM_ice_shelf_initialize
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -12,14 +13,13 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-
 !MJHpublic initialize_ice_shelf_boundary, initialize_ice_thickness
 public initialize_ice_thickness
 
 contains
 
-subroutine initialize_ice_thickness (h_shelf, area_shelf_h, hmask, G, PF)
-
+!> Initialize ice shelf thickness
+subroutine initialize_ice_thickness(h_shelf, area_shelf_h, hmask, G, PF)
   type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(inout) :: h_shelf !< The ice shelf thickness, in m.
@@ -48,9 +48,8 @@ subroutine initialize_ice_thickness (h_shelf, area_shelf_h, hmask, G, PF)
 
 end subroutine initialize_ice_thickness
 
-
-subroutine initialize_ice_thickness_from_file (h_shelf, area_shelf_h, hmask, G, PF)
-
+!> Initialize ice shelf thickness from file
+subroutine initialize_ice_thickness_from_file(h_shelf, area_shelf_h, hmask, G, PF)
   type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(inout) :: h_shelf !< The ice shelf thickness, in m.
@@ -135,9 +134,8 @@ subroutine initialize_ice_thickness_from_file (h_shelf, area_shelf_h, hmask, G, 
 
 end subroutine initialize_ice_thickness_from_file
 
-
-subroutine initialize_ice_thickness_channel (h_shelf, area_shelf_h, hmask, G, PF)
-
+!> Initialize ice shelf thickness for a channel configuration
+subroutine initialize_ice_thickness_channel(h_shelf, area_shelf_h, hmask, G, PF)
   type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(inout) :: h_shelf !< The ice shelf thickness, in m.


### PR DESCRIPTION
- Changes doxygen configuration to avoid conflict between duplicate files in coupled_driver/ and solo_driver/
- Adds doxumentation for modules missing one-line headers that are ignored by the newer versions of doxygen.
  - These files detected with doxygen version 1.8.4