### PR TITLE
+Added stress_mag to ice_ocean_boundary_type

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -166,6 +166,7 @@ type, public :: ice_ocean_boundary_type
   real, pointer, dimension(:,:) :: fprec           =>NULL() !< mass flux of frozen precip (kg/m2/s)
   real, pointer, dimension(:,:) :: runoff          =>NULL() !< mass flux of liquid runoff (kg/m2/s)
   real, pointer, dimension(:,:) :: calving         =>NULL() !< mass flux of frozen runoff (kg/m2/s)
+  real, pointer, dimension(:,:) :: stress_mag      =>NULL() !< The time-mean magnitude of the stress on the ocean (Pa)
   real, pointer, dimension(:,:) :: ustar_berg      =>NULL() !< frictional velocity beneath icebergs (m/s)
   real, pointer, dimension(:,:) :: area_berg       =>NULL() !< area covered by icebergs(m2/m2)
   real, pointer, dimension(:,:) :: mass_berg       =>NULL() !< mass of icebergs(kg/m2)


### PR DESCRIPTION
  Added a new element, stress_mag, with the time-mean of the magnitude of the
wind stresses at tracer points, to the ice_ocean_boundary_type.  It is not yet
being used, so all answers are bitwise identical.