### PR TITLE
Use stress magnitude and split coupling

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -544,6 +544,16 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
 
   endif
 
+  ! Set the wind stresses and ustar.
+  if (associated(fluxes%ustar) .and. associated(fluxes%ustar_gustless)) then
+    call extract_IOB_stresses(IOB, index_bounds, Time, G, CS, ustar=fluxes%ustar, &
+                              gustless_ustar=fluxes%ustar_gustless)
+  elseif (associated(fluxes%ustar)) then
+    call extract_IOB_stresses(IOB, index_bounds, Time, G, CS, ustar=fluxes%ustar)
+  elseif (associated(fluxes%ustar_gustless)) then
+    call extract_IOB_stresses(IOB, index_bounds, Time, G, CS, gustless_ustar=fluxes%ustar_gustless)
+  endif
+
   if (coupler_type_initialized(fluxes%tr_fluxes) .and. &
       coupler_type_initialized(IOB%fluxes)) &
     call coupler_type_copy_data(IOB%fluxes, fluxes%tr_fluxes)
@@ -862,7 +872,9 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
         ustar(i,j) = sqrt(gustiness*Irho0 + Irho0*IOB%stress_mag(i-i0,j-j0))
       enddo ; enddo ; endif
       if (do_gustless) then ; do j=js,je ; do i=is,ie
-        gustless_ustar(i,j) = sqrt(Irho0*IOB%stress_mag(i-i0,j-j0))
+        gustless_ustar(i,j) = sqrt(IOB%stress_mag(i-i0,j-j0) / CS%Rho0)
+!### Change to:
+!        gustless_ustar(i,j) = sqrt(Irho0 * IOB%stress_mag(i-i0,j-j0))
       enddo ; enddo ; endif
     elseif (wind_stagger == BGRID_NE) then
       do j=js,je ; do i=is,ie
@@ -877,7 +889,9 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
           if (CS%read_gust_2d) gustiness = CS%gust(i,j)
         endif
         if (do_ustar) ustar(i,j) = sqrt(gustiness*Irho0 + Irho0 * tau_mag)
-        if (do_gustless) gustless_ustar(i,j) = sqrt(Irho0*tau_mag)
+        if (do_gustless) gustless_ustar(i,j) = sqrt(tau_mag / CS%Rho0)
+!### Change to:
+!        if (do_gustless) gustless_ustar(i,j) = sqrt(Irho0 * tau_mag)
       enddo ; enddo
     elseif (wind_stagger == AGRID) then
       do j=js,je ; do i=is,ie
@@ -885,7 +899,9 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
         gustiness = CS%gust_const
         if (CS%read_gust_2d .and. (G%mask2dT(i,j) > 0)) gustiness = CS%gust(i,j)
         if (do_ustar) ustar(i,j) = sqrt(gustiness*Irho0 + Irho0 * tau_mag)
-        if (do_gustless) gustless_ustar(i,j) = sqrt(Irho0*tau_mag)
+        if (do_gustless) gustless_ustar(i,j) = sqrt(tau_mag / CS%Rho0)
+!### Change to:
+!        if (do_gustless) gustless_ustar(i,j) = sqrt(Irho0 * tau_mag)
       enddo ; enddo
     else  ! C-grid wind stresses.
       do j=js,je ; do i=is,ie
@@ -902,7 +918,9 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
         if (CS%read_gust_2d) gustiness = CS%gust(i,j)
 
         if (do_ustar) ustar(i,j) = sqrt(gustiness*Irho0 + Irho0 * tau_mag)
-        if (do_gustless) gustless_ustar(i,j) = sqrt(Irho0*tau_mag)
+        if (do_gustless) gustless_ustar(i,j) = sqrt(tau_mag / CS%Rho0)
+!### Change to:
+!        if (do_gustless) gustless_ustar(i,j) = sqrt(Irho0 * tau_mag)
       enddo ; enddo
     endif ! endif for wind friction velocity fields
   endif

--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -50,107 +50,106 @@ public surface_forcing_init
 public ice_ocn_bnd_type_chksum
 public forcing_save_restart
 
-
-! surface_forcing_CS is a structure containing pointers to the forcing fields
-! which may be used to drive MOM.  All fluxes are positive downward.
+!> surface_forcing_CS is a structure containing pointers to the forcing fields
+!! which may be used to drive MOM.  All fluxes are positive downward.
 type, public :: surface_forcing_CS ; private
-  integer :: wind_stagger       ! AGRID, BGRID_NE, or CGRID_NE (integer values
-                                ! from MOM_domains) to indicate the staggering of
-                                ! the winds that are being provided in calls to
-                                ! update_ocean_model.
-  logical :: use_temperature    ! If true, temp and saln used as state variables
+  integer :: wind_stagger       !< AGRID, BGRID_NE, or CGRID_NE (integer values
+                                !! from MOM_domains) to indicate the staggering of
+                                !! the winds that are being provided in calls to
+                                !! update_ocean_model.
+  logical :: use_temperature    !< If true, temp and saln used as state variables
   real :: wind_stress_multiplier !< A multiplier applied to incoming wind stress (nondim).
 
-  real :: Rho0                  ! Boussinesq reference density (kg/m^3)
-  real :: area_surf = -1.0      ! total ocean surface area (m^2)
-  real :: latent_heat_fusion    ! latent heat of fusion (J/kg)
-  real :: latent_heat_vapor     ! latent heat of vaporization (J/kg)
+  real :: Rho0                  !< Boussinesq reference density (kg/m^3)
+  real :: area_surf = -1.0      !< Total ocean surface area (m^2)
+  real :: latent_heat_fusion    !< Latent heat of fusion (J/kg)
+  real :: latent_heat_vapor     !< Latent heat of vaporization (J/kg)
 
-  real :: max_p_surf            ! maximum surface pressure that can be
-                                ! exerted by the atmosphere and floating sea-ice,
-                                ! in Pa.  This is needed because the FMS coupling
-                                ! structure does not limit the water that can be
-                                ! frozen out of the ocean and the ice-ocean heat
-                                ! fluxes are treated explicitly.
-  logical :: use_limited_P_SSH  ! If true, return the sea surface height with
-                                ! the correction for the atmospheric (and sea-ice)
-                                ! pressure limited by max_p_surf instead of the
-                                ! full atmospheric pressure.  The default is true.
+  real :: max_p_surf            !< The maximum surface pressure that can be
+                                !! exerted by the atmosphere and floating sea-ice,
+                                !! in Pa.  This is needed because the FMS coupling
+                                !! structure does not limit the water that can be
+                                !! frozen out of the ocean and the ice-ocean heat
+                                !! fluxes are treated explicitly.
+  logical :: use_limited_P_SSH  !< If true, return the sea surface height with
+                                !! the correction for the atmospheric (and sea-ice)
+                                !! pressure limited by max_p_surf instead of the
+                                !! full atmospheric pressure.  The default is true.
+  logical :: approx_net_mass_src !< If true, use the net mass sources from the ice-ocean boundary
+                                !! type without any further adjustments to drive the ocean dynamics.
+                                !! The actual net mass source may differ due to corrections.
 
-  real :: gust_const            ! constant unresolved background gustiness for ustar (Pa)
-  logical :: read_gust_2d       ! If true, use a 2-dimensional gustiness supplied
-                                ! from an input file.
+  real :: gust_const            !< Constant unresolved background gustiness for ustar (Pa)
+  logical :: read_gust_2d       !< If true, use a 2-dimensional gustiness supplied from an input file.
   real, pointer, dimension(:,:) :: &
-    TKE_tidal => NULL(), &      ! turbulent kinetic energy introduced to the
-                                ! bottom boundary layer by drag on the tidal flows,
-                                ! in W m-2.
-    gust => NULL(), &           ! spatially varying unresolved background
-                                ! gustiness that contributes to ustar (Pa).
-                                ! gust is used when read_gust_2d is true.
-    ustar_tidal => NULL()       ! tidal contribution to the bottom friction velocity (m/s)
-  real :: cd_tides              ! drag coefficient that applies to the tides (nondimensional)
-  real :: utide                 ! constant tidal velocity to use if read_tideamp
-                                ! is false, in m s-1.
-  logical :: read_tideamp       ! If true, spatially varying tidal amplitude read from a file.
+    TKE_tidal => NULL()         !< Turbulent kinetic energy introduced to the bottom boundary layer
+                                !! by drag on the tidal flows, in W m-2.
+  real, pointer, dimension(:,:) :: &
+    gust => NULL()              !< A spatially varying unresolved background gustiness that
+                                !! contributes to ustar (Pa).  gust is used when read_gust_2d is true.
+  real, pointer, dimension(:,:) :: &
+    ustar_tidal => NULL()       !< Tidal contribution to the bottom friction velocity (m/s)
+  real :: cd_tides              !< Drag coefficient that applies to the tides (nondimensional)
+  real :: utide                 !< Constant tidal velocity to use if read_tideamp is false, in m s-1.
+  logical :: read_tideamp       !< If true, spatially varying tidal amplitude read from a file.
 
-  logical :: rigid_sea_ice      ! If true, sea-ice exerts a rigidity that acts
-                                ! to damp surface deflections (especially surface
-                                ! gravity waves).  The default is false.
-  real    :: Kv_sea_ice         ! viscosity in sea-ice that resists sheared vertical motions (m^2/s)
-  real    :: density_sea_ice    ! typical density of sea-ice (kg/m^3). The value is
-                                ! only used to convert the ice pressure into
-                                ! appropriate units for use with Kv_sea_ice.
-  real    :: rigid_sea_ice_mass ! A mass per unit area of sea-ice beyond which
-                                ! sea-ice viscosity becomes effective, in kg m-2,
-                                ! typically of order 1000 kg m-2.
-  logical :: allow_flux_adjustments ! If true, use data_override to obtain flux adjustments
+  logical :: rigid_sea_ice      !< If true, sea-ice exerts a rigidity that acts to damp surface
+                                !! deflections (especially surface gravity waves).  The default is false.
+  real    :: Kv_sea_ice         !< Viscosity in sea-ice that resists sheared vertical motions (m^2/s)
+  real    :: density_sea_ice    !< Typical density of sea-ice (kg/m^3). The value is only used to convert
+                                !! the ice pressure into appropriate units for use with Kv_sea_ice.
+  real    :: rigid_sea_ice_mass !< A mass per unit area of sea-ice beyond which sea-ice viscosity
+                                !! becomes effective, in kg m-2, typically of order 1000 kg m-2.
+  logical :: allow_flux_adjustments !< If true, use data_override to obtain flux adjustments
 
-  real    :: Flux_const                     ! piston velocity for surface restoring (m/s)
-  logical :: salt_restore_as_sflux          ! If true, SSS restore as salt flux instead of water flux
-  logical :: adjust_net_srestore_to_zero    ! adjust srestore to zero (for both salt_flux or vprec)
-  logical :: adjust_net_srestore_by_scaling ! adjust srestore w/o moving zero contour
-  logical :: adjust_net_fresh_water_to_zero ! adjust net surface fresh-water (w/ restoring) to zero
-  logical :: use_net_FW_adjustment_sign_bug ! use the wrong sign when adjusting net FW
-  logical :: adjust_net_fresh_water_by_scaling ! adjust net surface fresh-water w/o moving zero contour
-  logical :: mask_srestore_under_ice        ! If true, use an ice mask defined by frazil
-                                            ! criteria for salinity restoring.
-  real    :: ice_salt_concentration         ! salt concentration for sea ice (kg/kg)
-  logical :: mask_srestore_marginal_seas    ! if true, then mask SSS restoring in marginal seas
-  real    :: max_delta_srestore             ! maximum delta salinity used for restoring
-  real    :: max_delta_trestore             ! maximum delta sst used for restoring
-  real, pointer, dimension(:,:) :: basin_mask => NULL() ! mask for SSS restoring by basin
+  logical :: restore_salt       !< If true, the coupled MOM driver adds a term to restore surface
+                                !! salinity to a specified value.
+  logical :: restore_temp       !< If true, the coupled MOM driver adds a term to restore sea
+                                !! surface temperature to a specified value.
+  real    :: Flux_const                     !< Piston velocity for surface restoring (m/s)
+  logical :: salt_restore_as_sflux          !< If true, SSS restore as salt flux instead of water flux
+  logical :: adjust_net_srestore_to_zero    !< Adjust srestore to zero (for both salt_flux or vprec)
+  logical :: adjust_net_srestore_by_scaling !< Adjust srestore w/o moving zero contour
+  logical :: adjust_net_fresh_water_to_zero !< Adjust net surface fresh-water (with restoring) to zero
+  logical :: use_net_FW_adjustment_sign_bug !< Use the wrong sign when adjusting net FW
+  logical :: adjust_net_fresh_water_by_scaling !< Adjust net surface fresh-water w/o moving zero contour
+  logical :: mask_srestore_under_ice        !< If true, use an ice mask defined by frazil criteria
+                                            !! for salinity restoring.
+  real    :: ice_salt_concentration         !< Salt concentration for sea ice (kg/kg)
+  logical :: mask_srestore_marginal_seas    !< If true, then mask SSS restoring in marginal seas
+  real    :: max_delta_srestore             !< Maximum delta salinity used for restoring
+  real    :: max_delta_trestore             !< Maximum delta sst used for restoring
+  real, pointer, dimension(:,:) :: basin_mask => NULL() !< Mask for surface salinity restoring by basin
 
-  type(diag_ctrl), pointer :: diag                  ! structure to regulate diagnostic output timing
-  character(len=200)       :: inputdir              ! directory where NetCDF input files are
-  character(len=200)       :: salt_restore_file     ! filename for salt restoring data
-  character(len=30)        :: salt_restore_var_name ! name of surface salinity in salt_restore_file
-  logical                  :: mask_srestore         ! if true, apply a 2-dimensional mask to the surface
-                                                    ! salinity restoring fluxes. The masking file should be
-                                                    ! in inputdir/salt_restore_mask.nc and the field should
-                                                    ! be named 'mask'
-  real, pointer, dimension(:,:) :: srestore_mask => NULL() ! mask for SSS restoring
-  character(len=200)       :: temp_restore_file     ! filename for sst restoring data
-  character(len=30)        :: temp_restore_var_name ! name of surface temperature in temp_restore_file
-  logical                  :: mask_trestore         ! if true, apply a 2-dimensional mask to the surface
-                                                    ! temperature restoring fluxes. The masking file should be
-                                                    ! in inputdir/temp_restore_mask.nc and the field should
-                                                    ! be named 'mask'
-  real, pointer, dimension(:,:) :: trestore_mask => NULL() ! mask for SST restoring
-  integer :: id_srestore = -1     ! id number for time_interp_external.
-  integer :: id_trestore = -1     ! id number for time_interp_external.
+  type(diag_ctrl), pointer :: diag => NULL()  !< Structure to regulate diagnostic output timing
+  character(len=200) :: inputdir              !< Directory where NetCDF input files are
+  character(len=200) :: salt_restore_file     !< Filename for salt restoring data
+  character(len=30)  :: salt_restore_var_name !< Name of surface salinity in salt_restore_file
+  logical            :: mask_srestore         !< If true, apply a 2-dimensional mask to the surface
+                                              !! salinity restoring fluxes. The masking file should be
+                                              !! in inputdir/salt_restore_mask.nc and the field should
+                                              !! be named 'mask'
+  real, pointer, dimension(:,:) :: srestore_mask => NULL() !< mask for SSS restoring
+  character(len=200) :: temp_restore_file     !< Filename for sst restoring data
+  character(len=30)  :: temp_restore_var_name !< Name of surface temperature in temp_restore_file
+  logical            :: mask_trestore         !< If true, apply a 2-dimensional mask to the surface
+                                              !! temperature restoring fluxes. The masking file should be
+                                              !! in inputdir/temp_restore_mask.nc and the field should
+                                              !! be named 'mask'
+  real, pointer, dimension(:,:) :: trestore_mask => NULL() !< Mask for SST restoring
+  integer :: id_srestore = -1  !< An id number for time_interp_external.
+  integer :: id_trestore = -1  !< An id number for time_interp_external.
 
-  ! Diagnostics handles
-  type(forcing_diags), public :: handles
+  type(forcing_diags), public :: handles !< Diagnostics handles
 
 !###  type(ctrl_forcing_CS), pointer :: ctrl_forcing_CSp => NULL()
-  type(MOM_restart_CS), pointer :: restart_CSp => NULL()
-  type(user_revise_forcing_CS), pointer :: urf_CS => NULL()
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< A pointer to the restart control structure
+  type(user_revise_forcing_CS), pointer :: urf_CS => NULL() !< A control structure for user forcing revisions
 end type surface_forcing_CS
 
 
-! ice_ocean_boundary_type is a structure corresponding to forcing, but with
-! the elements, units, and conventions that exactly conform to the use for
-! MOM-based coupled models.
+!> ice_ocean_boundary_type is a structure corresponding to forcing, but with the elements, units,
+!! and conventions that exactly conform to the use for MOM6-based coupled models.
 type, public :: ice_ocean_boundary_type
   real, pointer, dimension(:,:) :: u_flux          =>NULL() !< i-direction wind stress (Pa)
   real, pointer, dimension(:,:) :: v_flux          =>NULL() !< j-direction wind stress (Pa)
@@ -179,25 +178,23 @@ type, public :: ice_ocean_boundary_type
                                                             !! ice-shelves, expressed as a coefficient
                                                             !! for divergence damping, as determined
                                                             !! outside of the ocean model in (m3/s)
-  integer :: xtype                                   !< The type of the exchange - REGRID, REDIST or DIRECT
-  type(coupler_2d_bc_type)      :: fluxes            !< A structure that may contain an array of
-                                                     !! named fields used for passive tracer fluxes.
-  integer :: wind_stagger = -999                     !< A flag indicating the spatial discretization of
-                                                     !! wind stresses.  This flag may be set by the
-                                                     !! flux-exchange code, based on what the sea-ice
-                                                     !! model is providing.  Otherwise, the value from
-                                                     !! the surface_forcing_CS is used.
+  integer :: xtype                    !< The type of the exchange - REGRID, REDIST or DIRECT
+  type(coupler_2d_bc_type) :: fluxes  !< A structure that may contain an array of named fields
+                                      !! used for passive tracer fluxes.
+  integer :: wind_stagger = -999      !< A flag indicating the spatial discretization of wind stresses.
+                                      !! This flag may be set by the flux-exchange code, based on what
+                                      !! the sea-ice model is providing.  Otherwise, the value from
+                                      !! the surface_forcing_CS is used.
 end type ice_ocean_boundary_type
 
-integer :: id_clock_forcing
+integer :: id_clock_forcing !< A CPU time clock
 
 contains
 
 !> This subroutine translates the Ice_ocean_boundary_type into a MOM
 !! thermodynamic forcing type, including changes of units, sign conventions,
 !! and putting the fields into arrays with MOM-standard halos.
-subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
-                                 sfc_state, restore_salt, restore_temp)
+subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, sfc_state)
   type(ice_ocean_boundary_type), &
                    target, intent(in)    :: IOB    !< An ice-ocean boundary type with fluxes to drive
                                                    !! the ocean in a coupled model
@@ -212,9 +209,6 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
                                                    !! previous call to surface_forcing_init.
   type(surface),           intent(in)    :: sfc_state !< A structure containing fields that describe the
                                                    !! surface state of the ocean.
-  logical,       optional, intent(in)    :: restore_salt !< If true, salinity is restored to a target value.
-  logical,       optional, intent(in)    :: restore_temp !< If true, temperature is restored to a target value.
-
 
   real, dimension(SZI_(G),SZJ_(G)) :: &
     data_restore,  & ! The surface value toward which to restore (g/kg or degC)
@@ -234,10 +228,6 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, isr, ier, jsr, jer
   integer :: isc_bnd, iec_bnd, jsc_bnd, jec_bnd
 
-  logical :: restore_salinity ! local copy of the argument restore_salt, if it
-                              ! is present, or false (no restoring) otherwise.
-  logical :: restore_sst      ! local copy of the argument restore_temp, if it
-                              ! is present, or false (no restoring) otherwise.
   real :: delta_sss           ! temporary storage for sss diff from restoring value
   real :: delta_sst           ! temporary storage for sst diff from restoring value
 
@@ -263,11 +253,6 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
   fluxes%saltFluxGlobalScl = 0.0
   fluxes%netFWGlobalAdj = 0.0
   fluxes%netFWGlobalScl = 0.0
-
-  restore_salinity = .false.
-  if (present(restore_salt)) restore_salinity = restore_salt
-  restore_sst = .false.
-  if (present(restore_temp)) restore_sst = restore_temp
 
   ! allocation and initialization if this is the first time that this
   ! flux type has been used.
@@ -305,7 +290,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
       fluxes%ustar_tidal(i,j) = CS%ustar_tidal(i,j)
     enddo ; enddo
 
-    if (restore_temp) call safe_alloc_ptr(fluxes%heat_added,isd,ied,jsd,jed)
+    if (CS%restore_temp) call safe_alloc_ptr(fluxes%heat_added,isd,ied,jsd,jed)
 
     fluxes%dt_buoy_accum = 0.0
   endif   ! endif for allocation and initialization
@@ -343,7 +328,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
   enddo ; enddo
 
   ! Salinity restoring logic
-  if (restore_salinity) then
+  if (CS%restore_salt) then
     call time_interp_external(CS%id_srestore,Time,data_restore)
     ! open_ocn_mask indicates where to restore salinity (1 means restore, 0 does not)
     open_ocn_mask(:,:) = 1.0
@@ -396,7 +381,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
   endif
 
   ! SST restoring logic
-  if (restore_sst) then
+  if (CS%restore_temp) then
     call time_interp_external(CS%id_trestore,Time,data_restore)
     do j=js,je ; do i=is,ie
       delta_sst = data_restore(i,j)- sfc_state%SST(i,j)
@@ -593,7 +578,8 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS, dt_forc
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     rigidity_at_h, &  ! Ice rigidity at tracer points (m3 s-1)
-    ustar_tmp         ! A temporary array of ustars.
+    net_mass_src, &   ! A temporary of net mass sources, in kg m-2 s-1.
+    ustar_tmp         ! A temporary array of ustar values, in m s-1.
 
   real :: I_GEarth      ! 1.0 / G%G_Earth  (s^2/m)
   real :: Kv_rho_ice    ! (CS%kv_sea_ice / CS%density_sea_ice) ( m^5/(s*kg) )
@@ -700,6 +686,36 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS, dt_forc
     do j=js,je ; do i=is,ie
       forces%ustar(i,j) = wt1*forces%ustar(i,j) + wt2*ustar_tmp(i,j)
     enddo ; enddo
+  endif
+
+  ! Find the net mass source in the input forcing without other adjustments.
+  if (CS%approx_net_mass_src .and. associated(forces%net_mass_src)) then
+    net_mass_src(:,:) = 0.0
+    i0 = is - isc_bnd ; j0 = js - jsc_bnd
+    do j=js,je ; do i=is,ie ; if (G%mask2dT(i,j) > 0.0) then
+      if (associated(IOB%lprec)) &
+        net_mass_src(i,j) = net_mass_src(i,j) + IOB%lprec(i-i0,j-j0)
+      if (associated(IOB%fprec)) &
+        net_mass_src(i,j) = net_mass_src(i,j) + IOB%fprec(i-i0,j-j0)
+      if (associated(IOB%runoff)) &
+        net_mass_src(i,j) = net_mass_src(i,j) + IOB%runoff(i-i0,j-j0)
+      if (associated(IOB%calving)) &
+        net_mass_src(i,j) = net_mass_src(i,j) + IOB%calving(i-i0,j-j0)
+      if (associated(IOB%q_flux)) &
+        net_mass_src(i,j) = net_mass_src(i,j) - IOB%q_flux(i-i0,j-j0)
+    endif ; enddo ; enddo
+    if (wt1 <= 0.0) then
+      do j=js,je ; do i=is,ie
+        forces%net_mass_src(i,j) = wt2*net_mass_src(i,j)
+      enddo ; enddo
+    else
+      do j=js,je ; do i=is,ie
+        forces%net_mass_src(i,j) = wt1*forces%net_mass_src(i,j) + wt2*net_mass_src(i,j)
+      enddo ; enddo
+    endif
+    forces%net_mass_src_set = .true.
+  else
+    forces%net_mass_src_set = .false.
   endif
 
   ! Obtain optional ice-berg related fluxes from the IOB type:
@@ -1084,7 +1100,7 @@ subroutine forcing_save_restart(CS, G, Time, directory, time_stamped, &
 end subroutine forcing_save_restart
 
 !> Initialize the surface forcing, including setting parameters and allocating permanent memory.
-subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, restore_temp)
+subroutine surface_forcing_init(Time, G, param_file, diag, CS)
   type(time_type),          intent(in)    :: Time !< The current model time
   type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
   type(param_file_type),    intent(in)    :: param_file !< A structure to parse for run-time parameters
@@ -1092,10 +1108,6 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
                                                   !! diagnostic output
   type(surface_forcing_CS), pointer       :: CS   !< A pointer that is set to point to the control
                                                   !! structure for this module
-  logical, optional,        intent(in)    :: restore_salt !< If present and true surface salinity
-                                                  !! restoring will be applied in this model.
-  logical, optional,        intent(in)    :: restore_temp !< If present and true surface temperature
-                                                  !! restoring will be applied in this model.
 
   ! Local variables
   real :: utide  ! The RMS tidal velocity, in m s-1.
@@ -1154,11 +1166,19 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
                  "the ice-ocean heat fluxes are treated explicitly.  No \n"//&
                  "limit is applied if a negative value is used.", units="Pa", &
                  default=-1.0)
+  call get_param(param_file, mdl, "RESTORE_SALINITY", CS%restore_salt, &
+                 "If true, the coupled driver will add a globally-balanced \n"//&
+                 "fresh-water flux that drives sea-surface salinity \n"//&
+                 "toward specified values.", default=.false.)
+  call get_param(param_file, mdl, "RESTORE_TEMPERATURE", CS%restore_temp, &
+                 "If true, the coupled driver will add a  \n"//&
+                 "heat flux that drives sea-surface temperauture \n"//&
+                 "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_TO_ZERO", &
                  CS%adjust_net_srestore_to_zero, &
                  "If true, adjusts the salinity restoring seen to zero\n"//&
                  "whether restoring is via a salt flux or virtual precip.",&
-                 default=restore_salt)
+                 default=CS%restore_salt)
   call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_BY_SCALING", &
                  CS%adjust_net_srestore_by_scaling, &
                  "If true, adjustments to salt restoring to achieve zero net are\n"//&
@@ -1188,6 +1208,11 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
                  "correction for the atmospheric (and sea-ice) pressure \n"//&
                  "limited by max_p_surf instead of the full atmospheric \n"//&
                  "pressure.", default=.true.)
+  call get_param(param_file, mdl, "APPROX_NET_MASS_SRC", CS%approx_net_mass_src, &
+                 "If true, use the net mass sources from the ice-ocean \n"//&
+                 "boundary type without any further adjustments to drive \n"//&
+                 "the ocean dynamics.  The actual net mass source may differ \n"//&
+                 "due to internal corrections.", default=.false.)
 
   call get_param(param_file, mdl, "WIND_STAGGER", stagger, &
                  "A case-insensitive character string to indicate the \n"//&
@@ -1203,7 +1228,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
                  "coupler. This is used for testing and should be =1.0 for any\n"//&
                  "production runs.", default=1.0)
 
-  if (restore_salt) then
+  if (CS%restore_salt) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
@@ -1251,7 +1276,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
                  "a mask for SSS restoring.", default=.false.)
   endif
 
-  if (restore_temp) then
+  if (CS%restore_temp) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes \n"//&
                  "to the relative surface anomalies (akin to a piston \n"//&
@@ -1370,7 +1395,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
     call data_override_init(Ocean_domain_in=G%Domain%mpp_domain)
   endif
 
-  if (present(restore_salt)) then ; if (restore_salt) then
+  if (CS%restore_salt) then
     salt_file = trim(CS%inputdir) // trim(CS%salt_restore_file)
     CS%id_srestore = init_external_field(salt_file, CS%salt_restore_var_name, domain=G%Domain%mpp_domain)
     call safe_alloc_ptr(CS%srestore_mask,isd,ied,jsd,jed); CS%srestore_mask(:,:) = 1.0
@@ -1378,9 +1403,9 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
       flnam = trim(CS%inputdir) // 'salt_restore_mask.nc'
       call MOM_read_data(flnam,'mask', CS%srestore_mask, G%domain, timelevel=1)
     endif
-  endif ; endif
+  endif
 
-  if (present(restore_temp)) then ; if (restore_temp) then
+  if (CS%restore_temp) then
     temp_file = trim(CS%inputdir) // trim(CS%temp_restore_file)
     CS%id_trestore = init_external_field(temp_file, CS%temp_restore_var_name, domain=G%Domain%mpp_domain)
     call safe_alloc_ptr(CS%trestore_mask,isd,ied,jsd,jed); CS%trestore_mask(:,:) = 1.0
@@ -1388,7 +1413,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
       flnam = trim(CS%inputdir) // 'temp_restore_mask.nc'
       call MOM_read_data(flnam, 'mask', CS%trestore_mask, G%domain, timelevel=1)
     endif
-  endif ; endif
+  endif
 
   ! Set up any restart fields associated with the forcing.
   call restart_init(param_file, CS%restart_CSp, "MOM_forcing.res")

--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -1790,8 +1790,7 @@ subroutine update_ocean_model(OS, Ocean_sfc, time_start_update, &
   OS%nstep = OS%nstep + 1
 
   call enable_averaging(time_step, OS%Time, OS%diag)
-  call mech_forcing_diags(OS%forces, OS%fluxes, time_step, OS%grid, &
-                          OS%diag, OS%forcing_CSp%handles)
+  call mech_forcing_diags(OS%forces, time_step, OS%grid, OS%diag, OS%forcing_CSp%handles)
   call disable_averaging(OS%diag)
 
   if (OS%fluxes%fluxes_used) then

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -48,7 +48,8 @@ program MOM_main
   use MOM_string_functions,only : uppercase
   use MOM_surface_forcing, only : set_forcing, forcing_save_restart
   use MOM_surface_forcing, only : surface_forcing_init, surface_forcing_CS
-  use MOM_time_manager,    only : time_type, set_date, set_time, get_date, time_type_to_real
+  use MOM_time_manager,    only : time_type, set_date, set_time, get_date
+  use MOM_time_manager,    only : real_to_time_type, time_type_to_real
   use MOM_time_manager,    only : operator(+), operator(-), operator(*), operator(/)
   use MOM_time_manager,    only : operator(>), operator(<), operator(>=)
   use MOM_time_manager,    only : increment_date, set_calendar_type, month_name
@@ -356,7 +357,7 @@ program MOM_main
   endif
   ntstep = MAX(1,ceiling(dt_forcing/dt - 0.001))
 
-  Time_step_ocean = set_time(int(floor(dt_forcing+0.5)))
+  Time_step_ocean = real_to_time_type(dt_forcing)
   elapsed_time_master = (abs(dt_forcing - time_type_to_real(Time_step_ocean)) > 1.0e-12*dt_forcing)
   if (elapsed_time_master) &
     call MOM_mesg("Using real elapsed time for the master clock.", 2)
@@ -532,7 +533,7 @@ program MOM_main
             dtdia = dt_dyn*(n - n_last_thermo)
             ! Back up Time2 to the start of the thermodynamic segment.
             if (n > n_last_thermo+1) &
-              Time2 = Time2 - set_time(int(floor((dtdia - dt_dyn) + 0.5)))
+              Time2 = Time2 - real_to_time_type(dtdia - dt_dyn)
             call step_MOM(forces, fluxes, sfc_state, Time2, dtdia, MOM_CSp, &
                           do_dynamics=.false., do_thermodynamics=.true., &
                           start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_forcing)
@@ -541,7 +542,7 @@ program MOM_main
         endif
 
         t_elapsed_seg = t_elapsed_seg + dt_dyn
-        Time2 = Time1 + set_time(int(floor(t_elapsed_seg + 0.5)))
+        Time2 = Time1 + real_to_time_type(t_elapsed_seg)
       enddo
     endif
 
@@ -559,7 +560,7 @@ program MOM_main
       elapsed_time = elapsed_time - floor(elapsed_time)
     endif
     if (elapsed_time_master) then
-      Master_Time = segment_start_time + set_time(int(floor(elapsed_time+0.5)))
+      Master_Time = segment_start_time + real_to_time_type(elapsed_time)
     else
       Master_Time = Master_Time + Time_step_ocean
     endif

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -388,7 +388,7 @@ program MOM_main
   endif
 
   call get_param(param_file, mod_name, "SINGLE_STEPPING_CALL", single_step_call, &
-                 "If true, advance the state of MOMtime_chg with a single step \n"//&
+                 "If true, advance the state of MOM with a single step \n"//&
                  "including both dynamics and thermodynamics.  If false \n"//&
                  "the two phases are advanced with separate calls.", default=.true.)
   call get_param(param_file, mod_name, "DT_THERM", dt_therm, &

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -138,7 +138,7 @@ program MOM_main
   real :: dt_dyn, dtdia, t_elapsed_seg
   integer :: n, n_max, nts, n_last_thermo
   logical :: diabatic_first, single_step_call
-  type(time_type) :: Time2
+  type(time_type) :: Time2, time_chg
 
   integer :: Restart_control    ! An integer that is bit-tested to determine whether
                                 ! incremental restart files are saved and whether they
@@ -388,7 +388,7 @@ program MOM_main
   endif
 
   call get_param(param_file, mod_name, "SINGLE_STEPPING_CALL", single_step_call, &
-                 "If true, advance the state of MOM with a single step \n"//&
+                 "If true, advance the state of MOMtime_chg with a single step \n"//&
                  "including both dynamics and thermodynamics.  If false \n"//&
                  "the two phases are advanced with separate calls.", default=.true.)
   call get_param(param_file, mod_name, "DT_THERM", dt_therm, &
@@ -550,14 +550,14 @@ program MOM_main
 !   This is here to enable fractional-second time steps.
     elapsed_time = elapsed_time + dt_forcing
     if (elapsed_time > 2e9) then
-      ! This is here to ensure that the conversion from a real to an integer
-      ! can be accurately represented in long runs (longer than ~63 years).
-      ! It will also ensure that elapsed time does not lose resolution of order
-      ! the timetype's resolution, provided that the timestep and tick are
-      ! larger than 10-5 seconds.  If a clock with a finer resolution is used,
-      ! a smaller value would be required.
-      segment_start_time = segment_start_time + set_time(int(floor(elapsed_time)))
-      elapsed_time = elapsed_time - floor(elapsed_time)
+      ! This is here to ensure that the conversion from a real to an integer can be accurately
+      ! represented in long runs (longer than ~63 years). It will also ensure that elapsed time
+      ! does not lose resolution of order the timetype's resolution, provided that the timestep and
+      ! tick are larger than 10-5 seconds.  If a clock with a finer resolution is used, a smaller
+      ! value would be required.
+      time_chg = real_to_time_type(elapsed_time)
+      segment_start_time = segment_start_time + time_chg
+      elapsed_time = elapsed_time - time_type_to_real(time_chg)
     endif
     if (elapsed_time_master) then
       Master_Time = segment_start_time + real_to_time_type(elapsed_time)

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -571,8 +571,7 @@ program MOM_main
     endif ; endif
 
     call enable_averaging(dt_forcing, Time, diag)
-    call mech_forcing_diags(forces, fluxes, dt_forcing, grid, diag, &
-                            surface_forcing_CSp%handles)
+    call mech_forcing_diags(forces, dt_forcing, grid, diag, surface_forcing_CSp%handles)
     call disable_averaging(diag)
 
     if (.not. offline_tracer_mode) then

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2135,8 +2135,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   ! Set a few remaining fields that are specific to the ocean grid type.
   call set_first_direction(G, first_direction)
   ! Allocate the auxiliary non-symmetric domain for debugging or I/O purposes.
-  if (CS%debug .or. G%symmetric) &
+  if (CS%debug .or. G%symmetric) then
     call clone_MOM_domain(G%Domain, G%Domain_aux, symmetric=.false.)
+  else ; G%Domain_aux => G%Domain ; endif
   ! Copy common variables from the vertical grid to the horizontal grid.
   ! Consider removing this later?
   G%ke = GV%ke ; G%g_Earth = GV%g_Earth
@@ -2165,8 +2166,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     call MOM_grid_end(G) ; deallocate(G)
 
     G => CS%G
-    if (CS%debug .or. CS%G%symmetric) &
+    if (CS%debug .or. CS%G%symmetric) then
       call clone_MOM_domain(CS%G%Domain, CS%G%Domain_aux, symmetric=.false.)
+    else ; CS%G%Domain_aux => CS%G%Domain ;endif
     G%ke = GV%ke ; G%g_Earth = GV%g_Earth
   endif
 

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -212,6 +212,7 @@ type, public :: mech_forcing
     rigidity_ice_v => NULL()    !< Depth-integrated lateral viscosity of ice shelves or sea ice at v-points (m3/s)
   real :: dt_force_accum = -1.0 !< The amount of time over which the mechanical forcing fluxes
                                 !! have been averaged, in s.
+  logical :: net_mass_src_set = .false. !< If true, an estimate of net_mass_src has been provided.
   logical :: accumulate_p_surf = .false. !< If true, the surface pressure due to the atmosphere
                                 !! and various types of ice needs to be accumulated, and the
                                 !! surface pressure explicitly reset to zero at the driver level

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -42,8 +42,6 @@ public set_net_mass_forcing, get_net_mass_forcing
 !! MESO_surface_forcing.F90, which is a special case of solo_driver/MOM_surface_forcing.F90.
 type, public :: forcing
 
-  ! Pointers in this module should be initialized to NULL.
-
   ! surface stress components and turbulent velocity scale
   real, pointer, dimension(:,:) :: &
     ustar         => NULL(), & !< surface friction velocity scale (m/s)
@@ -154,11 +152,10 @@ type, public :: forcing
 
   logical :: fluxes_used = .true. !< If true, all of the heat, salt, and mass
                                   !! fluxes have been applied to the ocean.
-  real :: dt_buoy_accum  = -1.0   !< The amount of time over which the buoyancy fluxes
+  real :: dt_buoy_accum = -1.0    !< The amount of time over which the buoyancy fluxes
                                   !! should be applied, in s.  If negative, this forcing
                                   !! type variable has not yet been inialized.
 
-  ! heat capacity
   real :: C_p                !< heat capacity of seawater ( J/(K kg) ).
                              !! C_p is is the same value as in thermovar_ptrs_type.
 
@@ -169,7 +166,7 @@ type, public :: forcing
      !! This is not a convenient convention, but imposed on MOM6 by the coupler.
 
   ! For internal error tracking
-  integer :: num_msg = 0 !< Number of messages issues about excessive SW penetration
+  integer :: num_msg = 0 !< Number of messages issued about excessive SW penetration
   integer :: max_msg = 2 !< Maximum number of messages to issue about excessive SW penetration
 
 end type forcing
@@ -213,6 +210,8 @@ type, public :: mech_forcing
   real, pointer, dimension(:,:) :: &
     rigidity_ice_u => NULL(), & !< Depth-integrated lateral viscosity of ice shelves or sea ice at u-points (m3/s)
     rigidity_ice_v => NULL()    !< Depth-integrated lateral viscosity of ice shelves or sea ice at v-points (m3/s)
+  real :: dt_force_accum = -1.0 !< The amount of time over which the mechanical forcing fluxes
+                                !! have been averaged, in s.
   logical :: accumulate_p_surf = .false. !< If true, the surface pressure due to the atmosphere
                                 !! and various types of ice needs to be accumulated, and the
                                 !! surface pressure explicitly reset to zero at the driver level


### PR DESCRIPTION
  Extensive revisions to the top level FMS coupled interfaces to the of MOM6 code to allow
for time stepping the ocean dynamics and thermodynamics separately, and to accept stress
magnitudes as calculated by the ice and atmosphere, rather than being derived from stress.
This PR includes the following commits:
 - NOAA-GFDL/MOM6@835c357 Merge branch 'dev/gfdl' into use_stress_mag
 - NOAA-GFDL/MOM6@c4529f3 +Added optional arguments to update_ocean_model
 - NOAA-GFDL/MOM6@6c46811 +Removed forcing type arg from mech_forcing_diags
 - NOAA-GFDL/MOM6@a30575d +Added APPROX_NET_MASS_SRC & moved RESTORE_SALINITY
 - NOAA-GFDL/MOM6@974662e Corrected description of SINGLE_STEPPING_CALL
 - NOAA-GFDL/MOM6@d9e9457 Use real_to_time_type in 63+year segment clock cor
 - NOAA-GFDL/MOM6@c54a25a (*)Allow for fractional second coupling timesteps
 - NOAA-GFDL/MOM6@5f253d4 Consolidate dynamic & thermodynamic forcing setup
 - NOAA-GFDL/MOM6@13f9303 +Added optional arguments to convert_IOB_to_forces
 - NOAA-GFDL/MOM6@c02b134 (+)Restored the interface to forcing_accumulate
 - NOAA-GFDL/MOM6@f20c3f1 +Changed interface to forcing_accumulate
 - NOAA-GFDL/MOM6@b15f514 Set ustar in fluxes via extract_IOB_stresses
 - NOAA-GFDL/MOM6@0d18946 Code cleanup in MOM_surface_forcing.F90
 - NOAA-GFDL/MOM6@7507e2d Set stresses via extract_IOB_stresses
 - NOAA-GFDL/MOM6@4b859d4 Always set G%Domain_aux
 - NOAA-GFDL/MOM6@e1762f5 +Added extract_IOB_stresses
 - NOAA-GFDL/MOM6@c95d513 +Use stress_mag to set ustar