### PR TITLE
Fix stupid bug in soliton case.

### DIFF
--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -53,7 +53,7 @@ subroutine soliton_initialize_thickness(h, G, GV)
       y = G%geoLatT(i,j)-y0
       val3 = exp(-val1*x)
       val4 = val2*((2.0*val3/(1.0+(val3*val3)))**2)
-      h(i,j,k) = GV%m_to_H * (0.25*val4 * (6.0*y*y+3.0) * exp(-0.5*y*y))
+      h(i,j,k) = GV%m_to_H * (0.25*val4 * (6.0*y*y+3.0) * exp(-0.5*y*y)) + G%bathyT(i,j)
     enddo
   enddo ; enddo
 

--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -53,7 +53,7 @@ subroutine soliton_initialize_thickness(h, G, GV)
       y = G%geoLatT(i,j)-y0
       val3 = exp(-val1*x)
       val4 = val2*((2.0*val3/(1.0+(val3*val3)))**2)
-      h(i,j,k) = GV%m_to_H * (0.25*val4 * (6.0*y*y+3.0) * exp(-0.5*y*y)) + G%bathyT(i,j)
+      h(i,j,k) = GV%m_to_H * (0.25*val4 * (6.0*y*y+3.0) * exp(-0.5*y*y) + G%bathyT(i,j))
     enddo
   enddo ; enddo
 


### PR DESCRIPTION
Needs PR #833 to work at all. I can watch the soliton move in the debugger but get no output:

> FATAL from PE     0: diag_manager_mod::send_data_3d: module/output_field ocean_model/u is skipped one time level in output data
@Hallberg-NOAA 