### PR TITLE
Fix data_override issue introduced by present(gas_fields_ocn)

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -1413,9 +1413,8 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS)
   call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
                  "If true, allows flux adjustments to specified via the \n"//&
                  "data_table using the component name 'OCN'.", default=.false.)
-  if (CS%allow_flux_adjustments) then
-    call data_override_init(Ocean_domain_in=G%Domain%mpp_domain)
-  endif
+
+  call data_override_init(Ocean_domain_in=G%Domain%mpp_domain)
 
   if (CS%restore_salt) then
     salt_file = trim(CS%inputdir) // trim(CS%salt_restore_file)


### PR DESCRIPTION
- commit [515d9283](https://github.com/NOAA-GFDL/MOM6/commit/515d9283aa02ada218751cb5df2911d0751406a3#diff-f16d17035f85963c903ca25a093d678fR374) has introduced a new path that OMIP initialization takes before the data_override_init() is being called  in [ocean_model_MOM.F90](https://github.com/NOAA-GFDL/MOM6/blob/dev/gfdl/config_src/coupled_driver/ocean_model_MOM.F90#L368).
  This leads to OMIP experiments  (as well as many ocean-ice-biogeochemistry models) to crash because they  call data_override before data_override_init is called :
```
Image              PC                Routine            Line        Source
fms_MOM6_SIS2_com  000000000177DD86  mpp_mod_mp_mpp_er          69  mpp_util_mpi.inc
fms_MOM6_SIS2_com  0000000001657BCC  data_override_mod         581  data_override.F90
fms_MOM6_SIS2_com  000000000165127F  data_override_mod         762  data_override.F90
fms_MOM6_SIS2_com  000000000165733F  data_override_mod         636  data_override.F90
fms_MOM6_SIS2_com  0000000000F673EF  generic_abiotic_m        1043  generic_abiotic.F90
fms_MOM6_SIS2_com  0000000000DF4A2F  generic_tracer_mp         718  generic_tracer.F90
fms_MOM6_SIS2_com  0000000000C6E1A7  mom_generic_trace         872  MOM_generic_tracer.F90
fms_MOM6_SIS2_com  0000000000DF6488  mom_tracer_flow_c         835  MOM_tracer_flow_control.F90
fms_MOM6_SIS2_com  000000000078EAE7  mom_mp_extract_su        2889  MOM.F90
fms_MOM6_SIS2_com  0000000000772E28  ocean_model_mod_m         372  ocean_model_MOM.F90
fms_MOM6_SIS2_com  000000000041385A  coupler_main_IP_c        1837  coupler_main.F90
fms_MOM6_SIS2_com  000000000040A7BB  MAIN__                    611  coupler_main.F90
```

- To fix this issue we leverage an existing data_override_init call which is being done at
  the right place, but only if some parameters are set.