### PR TITLE
Add missing register*/ safe_alloc* for diapycnal velocity (wd)

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1665,8 +1665,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "there is no buoyancy forcing, but makes the model \n"//&
                  "faster by eliminating subroutine calls.", default=.false.)
   call get_param(param_file, "MOM", "USE_LEGACY_DIABATIC_DRIVER", CS%use_legacy_diabatic_driver, &
-                 "If true, use the a legacy version of the diabatic subroutine. \n"//&
-                 "This is temporary and is needed avoid change in answers.", &
+                 "If true, use a legacy version of the diabatic subroutine. \n"//&
+                 "This is temporary and is needed to avoid change in answers.", &
                  default=.true.)
   call get_param(param_file, "MOM", "DO_DYNAMICS", CS%do_dynamics, &
                  "If False, skips the dynamics calls that update u & v, as well as \n"//&

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -2948,12 +2948,6 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
   if (GV%Boussinesq) then ; thickness_units = "m"
   else ; thickness_units = "kg m-2" ; endif
 
-  ! used by layer diabatic
-  CS%id_ea = register_diag_field('ocean_model','ea',diag%axesTL,Time, &
-      'Layer entrainment from above per timestep','m')
-  CS%id_eb = register_diag_field('ocean_model','eb',diag%axesTL,Time, &
-      'Layer entrainment from below per timestep', 'm')
-
   CS%id_ea_t = register_diag_field('ocean_model','ea_t',diag%axesTL,Time, &
       'Layer (heat) entrainment from above per timestep','m')
   CS%id_eb_t = register_diag_field('ocean_model','eb_t',diag%axesTL,Time, &
@@ -2962,10 +2956,20 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
       'Layer (salt) entrainment from above per timestep','m')
   CS%id_eb_s = register_diag_field('ocean_model','eb_s',diag%axesTL,Time, &
       'Layer (salt) entrainment from below per timestep', 'm')
+  ! used by layer diabatic
+  CS%id_ea = register_diag_field('ocean_model','ea',diag%axesTL,Time, &
+      'Layer entrainment from above per timestep','m')
+  CS%id_eb = register_diag_field('ocean_model','eb',diag%axesTL,Time, &
+      'Layer entrainment from below per timestep', 'm')
+  CS%id_wd = register_diag_field('ocean_model','wd',diag%axesTi,Time, &
+    'Diapycnal velocity', 'm s-1')
+  if (CS%id_wd > 0) call safe_alloc_ptr(CDp%diapyc_vel,isd,ied,jsd,jed,nz+1)
+
   CS%id_dudt_dia = register_diag_field('ocean_model','dudt_dia',diag%axesCuL,Time, &
       'Zonal Acceleration from Diapycnal Mixing', 'm s-2')
   CS%id_dvdt_dia = register_diag_field('ocean_model','dvdt_dia',diag%axesCvL,Time, &
       'Meridional Acceleration from Diapycnal Mixing', 'm s-2')
+
   if (CS%use_int_tides) then
     CS%id_cg1 = register_diag_field('ocean_model','cn1', diag%axesT1, &
                  Time, 'First baroclinic mode (eigen) speed', 'm s-1')


### PR DESCRIPTION
The option to diagnose diapycnal velocity in non-ALE (layer) mode has been removed during the recent refactor of subroutine diabatic. This PR re-introduces the missing code.  

This PR closes issue https://github.com/NOAA-GFDL/MOM6-examples/issues/250