### PR TITLE
Add missing diag_id check before  post_data

### DIFF
--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -2355,7 +2355,7 @@ subroutine forcing_diagnostics(fluxes, sfc_state, dt, G, diag, handles)
       ! endif
         if (associated(fluxes%heat_added))         res(i,j) = res(i,j) + fluxes%heat_added(i,j)
       enddo ; enddo
-      call post_data(handles%id_net_heat_surface, res, diag)
+      if (handles%id_net_heat_surface > 0) call post_data(handles%id_net_heat_surface, res, diag)
 
       if (handles%id_total_net_heat_surface > 0) then
         total_transport = global_area_integral(res,G)


### PR DESCRIPTION
The diag_id check is missing causing segmentation fault crash in some models that don't have that diagnostics registered.