### PR TITLE
fix mech_forcing_diags args

### DIFF
--- a/config_src/mct_driver/MOM_ocean_model.F90
+++ b/config_src/mct_driver/MOM_ocean_model.F90
@@ -559,8 +559,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   OS%nstep = OS%nstep + 1
 
   call enable_averaging(time_step, OS%Time, OS%diag)
-  call mech_forcing_diags(OS%forces, OS%fluxes, time_step, OS%grid, &
-                          OS%diag, OS%forcing_CSp%handles)
+  call mech_forcing_diags(OS%forces, time_step, OS%grid, OS%diag, OS%forcing_CSp%handles)
   call disable_averaging(OS%diag)
 
   if (OS%fluxes%fluxes_used) then


### PR DESCRIPTION
A single change in MCT cap that corrects the arguments of mech_forcing_diags.
