### PR TITLE
Most of the remaining MOM6 code dimensionally rescaled into Z

### DIFF
--- a/src/ALE/coord_adapt.F90
+++ b/src/ALE/coord_adapt.F90
@@ -22,22 +22,22 @@ type, public :: adapt_CS ; private
   real, allocatable, dimension(:) :: coordinateResolution
 
   !> Ratio of optimisation and diffusion timescales
-  real :: adaptTimeRatio = 1e-1
+  real :: adaptTimeRatio
 
   !> Nondimensional coefficient determining how much optimisation to apply
-  real :: adaptAlpha     = 1.0
+  real :: adaptAlpha
 
-  !> Near-surface zooming depth
-  real :: adaptZoom      = 200.0
+  !> Near-surface zooming depth in H
+  real :: adaptZoom
 
   !> Near-surface zooming coefficient
-  real :: adaptZoomCoeff = 0.0
+  real :: adaptZoomCoeff
 
   !> Stratification-dependent diffusion coefficient
-  real :: adaptBuoyCoeff = 0.0
+  real :: adaptBuoyCoeff
 
-  !> Reference density difference for stratification-dependent diffusion
-  real :: adaptDrho0     = 0.5
+  !> Reference density difference for stratification-dependent diffusion in kg m-3
+  real :: adaptDrho0
 
   !> If true, form a HYCOM1-like mixed layet by preventing interfaces
   !! from becoming shallower than the depths set by coordinateResolution
@@ -49,17 +49,31 @@ public init_coord_adapt, set_adapt_params, build_adapt_column, end_coord_adapt
 contains
 
 !> Initialise an adapt_CS with parameters
-subroutine init_coord_adapt(CS, nk, coordinateResolution)
+subroutine init_coord_adapt(CS, nk, coordinateResolution, m_to_H)
   type(adapt_CS),     pointer    :: CS !< Unassociated pointer to hold the control structure
   integer,            intent(in) :: nk !< Number of layers in the grid
   real, dimension(:), intent(in) :: coordinateResolution !< Nominal near-surface resolution (H)
+  real,     optional, intent(in) :: m_to_H !< A conversion factor from m to the units of thicknesses
+
+  real :: m_to_H_rescale  ! A unit conversion factor.
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_adapt: CS already associated")
   allocate(CS)
   allocate(CS%coordinateResolution(nk))
 
+  m_to_H_rescale = 1.0 ; if (present(m_to_H)) m_to_H_rescale = m_to_H
+
   CS%nk = nk
   CS%coordinateResolution(:) = coordinateResolution(:)
+
+  ! Set real parameter default values
+  CS%adaptTimeRatio = 1e-1 ! Nondim.
+  CS%adaptAlpha     = 1.0  ! Nondim.
+  CS%adaptZoom = 200.0 * m_to_H_rescale
+  CS%adaptZoomCoeff = 0.0  ! Nondim.
+  CS%adaptBuoyCoeff = 0.0  ! Nondim.
+  CS%adaptDrho0     = 0.5  ! kg m-3
+
 end subroutine init_coord_adapt
 
 !> Clean up the coordinate control structure
@@ -79,7 +93,7 @@ subroutine set_adapt_params(CS, adaptTimeRatio, adaptAlpha, adaptZoom, adaptZoom
   real,    optional, intent(in) :: adaptTimeRatio !< Ratio of optimisation and diffusion timescales
   real,    optional, intent(in) :: adaptAlpha     !< Nondimensional coefficient determining
                                                   !! how much optimisation to apply
-  real,    optional, intent(in) :: adaptZoom      !< Near-surface zooming depth, in m
+  real,    optional, intent(in) :: adaptZoom      !< Near-surface zooming depth, in H
   real,    optional, intent(in) :: adaptZoomCoeff !< Near-surface zooming coefficient
   real,    optional, intent(in) :: adaptBuoyCoeff !< Stratification-dependent diffusion coefficient
   real,    optional, intent(in) :: adaptDrho0  !< Reference density difference for
@@ -226,7 +240,7 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
 
     ! set vertical grid diffusivity
     kGrid(k) = (CS%adaptTimeRatio * nz**2 * depth) * &
-         (CS%adaptZoomCoeff / (CS%adaptZoom * GV%m_to_H + 0.5*(zNext(K) + zNext(K+1))) + &
+         (CS%adaptZoomCoeff / (CS%adaptZoom + 0.5*(zNext(K) + zNext(K+1))) + &
          (CS%adaptBuoyCoeff * drdz / CS%adaptDrho0) + &
          max(1.0 - CS%adaptZoomCoeff - CS%adaptBuoyCoeff, 0.0) / depth)
   enddo

--- a/src/ALE/coord_adapt.F90
+++ b/src/ALE/coord_adapt.F90
@@ -18,7 +18,7 @@ type, public :: adapt_CS ; private
   !> Number of layers/levels
   integer :: nk
 
-  !> Nominal near-surface resolution
+  !> Nominal near-surface resolution in H
   real, allocatable, dimension(:) :: coordinateResolution
 
   !> Ratio of optimisation and diffusion timescales
@@ -52,7 +52,7 @@ contains
 subroutine init_coord_adapt(CS, nk, coordinateResolution)
   type(adapt_CS),     pointer    :: CS !< Unassociated pointer to hold the control structure
   integer,            intent(in) :: nk !< Number of layers in the grid
-  real, dimension(:), intent(in) :: coordinateResolution !< Nominal near-surface resolution (m)
+  real, dimension(:), intent(in) :: coordinateResolution !< Nominal near-surface resolution (H)
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_adapt: CS already associated")
   allocate(CS)
@@ -126,7 +126,7 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
   zNext(nz+1) = zInt(i,j,nz+1)
 
   ! local depth for scaling diffusivity
-  depth = G%bathyT(i,j) * G%Zd_to_m*GV%m_to_H
+  depth = G%bathyT(i,j) * GV%Z_to_H
 
   ! initialize del2sigma to zero
   del2sigma(:) = 0.

--- a/src/ALE/coord_sigma.F90
+++ b/src/ALE/coord_sigma.F90
@@ -16,7 +16,7 @@ type, public :: sigma_CS ; private
   !> Minimum thickness allowed for layers
   real :: min_thickness
 
-  !> Target coordinate resolution
+  !> Target coordinate resolution, nondimensional
   real, allocatable, dimension(:) :: coordinateResolution
 end type sigma_CS
 
@@ -51,7 +51,7 @@ end subroutine end_coord_sigma
 !> This subroutine can be used to set the parameters for the coord_sigma module
 subroutine set_sigma_params(CS, min_thickness)
   type(sigma_CS), pointer    :: CS !< Coordinate control structure
-  real, optional, intent(in) :: min_thickness !< Minimum allowed thickness, in m
+  real, optional, intent(in) :: min_thickness !< Minimum allowed thickness, in H
 
   if (.not. associated(CS)) call MOM_error(FATAL, "set_sigma_params: CS not associated")
 
@@ -62,9 +62,9 @@ end subroutine set_sigma_params
 !> Build a sigma coordinate column
 subroutine build_sigma_column(CS, depth, totalThickness, zInterface)
   type(sigma_CS),           intent(in)    :: CS !< Coordinate control structure
-  real,                     intent(in)    :: depth !< Depth of ocean bottom (positive in m)
-  real,                     intent(in)    :: totalThickness !< Column thickness (positive in m)
-  real, dimension(CS%nk+1), intent(inout) :: zInterface !< Absolute positions of interfaces in m
+  real,                     intent(in)    :: depth !< Depth of ocean bottom (positive in H, often m)
+  real,                     intent(in)    :: totalThickness !< Column thickness (positive in H)
+  real, dimension(CS%nk+1), intent(inout) :: zInterface !< Absolute positions of interfaces in H
 
   ! Local variables
   integer :: k

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -17,7 +17,7 @@ type, public :: slight_CS ; private
   !> Number of layers/levels
   integer :: nk
 
-  !> Minimum thickness allowed when building the new grid through regridding (m)
+  !> Minimum thickness allowed when building the new grid through regridding (H)
   real :: min_thickness
 
   !> Reference pressure for potential density calculations (Pa)
@@ -25,39 +25,39 @@ type, public :: slight_CS ; private
 
   !> Fraction (between 0 and 1) of compressibility to add to potential density
   !! profiles when interpolating for target grid positions. (nondim)
-  real :: compressibility_fraction = 0.
+  real :: compressibility_fraction
 
   ! The following 4 parameters were introduced for use with the SLight coordinate:
-  !> Depth over which to average to determine the mixed layer potential density (m)
-  real :: Rho_ML_avg_depth = 1.0
+  !> Depth over which to average to determine the mixed layer potential density (H)
+  real :: Rho_ML_avg_depth
 
   !> Number of layers to offset the mixed layer density to find resolved stratification (nondim)
-  real :: nlay_ml_offset = 2.0
+  real :: nlay_ml_offset
 
   !> The number of fixed-thickness layers at the top of the model
   integer :: nz_fixed_surface = 2
 
-  !> The fixed resolution in the topmost SLight_nkml_min layers (m)
-  real :: dz_ml_min = 1.0
+  !> The fixed resolution in the topmost SLight_nkml_min layers (H)
+  real :: dz_ml_min
 
   !> If true, detect regions with much weaker stratification in the coordinate
   !! than based on in-situ density, and use a stretched coordinate there.
   logical :: fix_haloclines = .false.
 
   !> A length scale over which to filter T & S when looking for spuriously
-  !! unstable water mass profiles, in m.
-  real :: halocline_filter_length = 2.0
+  !! unstable water mass profiles, in H.
+  real :: halocline_filter_length
 
   !> A value of the stratification ratio that defines a problematic halocline region (nondim).
-  real :: halocline_strat_tol = 0.25
+  real :: halocline_strat_tol
 
   !> Nominal density of interfaces, in kg m-3.
   real, allocatable, dimension(:) :: target_density
 
-  !> Maximum depths of interfaces, in m.
+  !> Maximum depths of interfaces, in H.
   real, allocatable, dimension(:) :: max_interface_depths
 
-  !> Maximum thicknesses of layers, in m.
+  !> Maximum thicknesses of layers, in H.
   real, allocatable, dimension(:) :: max_layer_thickness
 
   !> Interpolation control structure
@@ -69,21 +69,35 @@ public init_coord_slight, set_slight_params, build_slight_column, end_coord_slig
 contains
 
 !> Initialise a slight_CS with pointers to parameters
-subroutine init_coord_slight(CS, nk, ref_pressure, target_density, interp_CS)
+subroutine init_coord_slight(CS, nk, ref_pressure, target_density, interp_CS, m_to_H)
   type(slight_CS),      pointer    :: CS !< Unassociated pointer to hold the control structure
   integer,              intent(in) :: nk !< Number of layers in the grid
   real,                 intent(in) :: ref_pressure !< Nominal density of interfaces in Pa
   real, dimension(:),   intent(in) :: target_density !< Nominal density of interfaces in kg m-3
   type(interp_CS_type), intent(in) :: interp_CS !< Controls for interpolation
+  real,       optional, intent(in) :: m_to_H !< A conversion factor from m to the units of thicknesses
+
+  real :: m_to_H_rescale  ! A unit conversion factor.
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_slight: CS already associated!")
   allocate(CS)
   allocate(CS%target_density(nk+1))
 
+  m_to_H_rescale = 1.0 ; if (present(m_to_H)) m_to_H_rescale = m_to_H
+
   CS%nk                = nk
   CS%ref_pressure      = ref_pressure
   CS%target_density(:) = target_density(:)
   CS%interp_CS         = interp_CS
+
+  ! Set real parameter default values
+  CS%compressibility_fraction = 0. ! Nondim.
+  CS%Rho_ML_avg_depth = 1.0 * m_to_H_rescale
+  CS%nlay_ml_offset = 2.0          ! Nondim.
+  CS%dz_ml_min = 1.0 * m_to_H_rescale
+  CS%halocline_filter_length = 2.0 * m_to_H_rescale
+  CS%halocline_strat_tol = 0.25    ! Nondim.
+
 end subroutine init_coord_slight
 
 !> This subroutine deallocates memory in the control structure for the coord_slight module
@@ -103,26 +117,26 @@ subroutine set_slight_params(CS, max_interface_depths, max_layer_thickness, &
                halocline_filter_length, halocline_strat_tol, interp_CS)
   type(slight_CS),   pointer    :: CS !< Coordinate control structure
   real, dimension(:), &
-           optional, intent(in) :: max_interface_depths !< Maximum depths of interfaces in m
+           optional, intent(in) :: max_interface_depths !< Maximum depths of interfaces in H
   real, dimension(:), &
-           optional, intent(in) :: max_layer_thickness  !< Maximum thicknesses of layers in m
+           optional, intent(in) :: max_layer_thickness  !< Maximum thicknesses of layers in H
   real,    optional, intent(in) :: min_thickness    !< Minimum thickness allowed when building the
-                                      !! new grid through regridding, in m
+                                      !! new grid through regridding, in H
   real,    optional, intent(in) :: compressibility_fraction !< Fraction (between 0 and 1) of
                                       !! compressibility to add to potential density profiles when
                                       !! interpolating for target grid positions. (nondim)
   real,    optional, intent(in) :: dz_ml_min        !< The fixed resolution in the topmost
-                                      !! SLight_nkml_min layers (m)
+                                      !! SLight_nkml_min layers (H)
   integer, optional, intent(in) :: nz_fixed_surface !< The number of fixed-thickness layers at the
                                       !! top of the model
   real,    optional, intent(in) :: Rho_ML_avg_depth !< Depth over which to average to determine
-                                      !! the mixed layer potential density (m)
+                                      !! the mixed layer potential density (H)
   real,    optional, intent(in) :: nlay_ML_offset   !< Number of layers to offset the mixed layer
                                       !! density to find resolved stratification (nondim)
   logical, optional, intent(in) :: fix_haloclines   !< If true, detect regions with much weaker than
                                       !! based on in-situ density, and use a stretched coordinate there.
   real,    optional, intent(in) :: halocline_filter_length !< A length scale over which to filter T & S
-                                      !! when looking for spuriously unstable water mass profiles, in m.
+                                      !! when looking for spuriously unstable water mass profiles, in H.
   real,    optional, intent(in) :: halocline_strat_tol !< A value of the stratification ratio that
                                       !! defines a problematic halocline region (nondim).
   type(interp_CS_type), &
@@ -163,28 +177,25 @@ subroutine set_slight_params(CS, max_interface_depths, max_layer_thickness, &
 end subroutine set_slight_params
 
 !> Build a SLight coordinate column
-subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff, &
+subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, H_subroundoff, &
                                nz, depth, h_col, T_col, S_col, p_col, z_col, z_col_new, &
                                h_neglect, h_neglect_edge)
-  type(slight_CS),       intent(in)    :: CS !< Coordinate control structure
+  type(slight_CS),       intent(in)    :: CS    !< Coordinate control structure
   type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
   real,                  intent(in)    :: H_to_Pa !< GV%H_to_Pa
-  real,                  intent(in)    :: m_to_H  !< GV%m_to_H
   real,                  intent(in)    :: H_subroundoff !< GV%H_subroundoff
-  integer,               intent(in)    :: nz !< Number of levels
-  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in m)
+  integer,               intent(in)    :: nz    !< Number of levels
+  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in H)
   real, dimension(nz),   intent(in)    :: T_col !< T for column
   real, dimension(nz),   intent(in)    :: S_col !< S for column
-  real, dimension(nz),   intent(in)    :: h_col !< Layer thicknesses, in m
+  real, dimension(nz),   intent(in)    :: h_col !< Layer thicknesses, in H units (m or kg m-2)
   real, dimension(nz),   intent(in)    :: p_col !< Layer quantities
-  real, dimension(nz+1), intent(in)    :: z_col !< Interface positions relative to the surface in H units (m or kg m-2)
-  real, dimension(nz+1), intent(inout) :: z_col_new !< Absolute positions of interfaces
-  real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the
-                                             !! purpose of cell reconstructions
-                                             !! in the same units as h_col.
-  real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width
-                                             !! for the purpose of edge value calculations
-                                             !! in the same units as h_col.
+  real, dimension(nz+1), intent(in)    :: z_col !< Interface positions relative to the surface in H
+  real, dimension(nz+1), intent(inout) :: z_col_new !< Absolute positions of interfaces in H
+  real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the purpose of
+                                                !! cell reconstructions in H.
+  real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width for the purpose
+                                                !! of edge value calculations in H.
   ! Local variables
   real, dimension(nz) :: rho_col ! Layer quantities
   real, dimension(nz) :: T_f, S_f  ! Filtered ayer quantities
@@ -282,7 +293,7 @@ subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff,
     ! Determine which interfaces are in the s-space region and the depth extent
     ! of this region.
     z_wt = 0.0 ; rho_x_z = 0.0
-    H_ml_av = m_to_H*CS%Rho_ml_avg_depth
+    H_ml_av = CS%Rho_ml_avg_depth
     do k=1,nz
       if (z_wt + h_col(k) >= H_ml_av) then
         rho_x_z = rho_x_z + rho_col(k) * (H_ml_av - z_wt)
@@ -323,7 +334,7 @@ subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff,
   !       ! z_int_unst and k_interior.
 
       if (CS%halocline_filter_length > 0.0) then
-        Lfilt = CS%halocline_filter_length*m_to_H
+        Lfilt = CS%halocline_filter_length
 
         ! Filter the temperature and salnity with a fixed lengthscale.
         h_tr = h_col(1) + H_subroundoff

--- a/src/ALE/coord_zlike.F90
+++ b/src/ALE/coord_zlike.F90
@@ -17,7 +17,7 @@ type, public :: zlike_CS ; private
   !! be used in all subsequent calls to build_zstar_column with this structure.
   real :: min_thickness
 
-  !> Target coordinate resolution, usually in m
+  !> Target coordinate resolution, usually in Z (often m)
   real, allocatable, dimension(:) :: coordinateResolution
 end type zlike_CS
 
@@ -29,7 +29,7 @@ contains
 subroutine init_coord_zlike(CS, nk, coordinateResolution)
   type(zlike_CS),     pointer    :: CS !< Unassociated pointer to hold the control structure
   integer,            intent(in) :: nk !< Number of levels in the grid
-  real, dimension(:), intent(in) :: coordinateResolution !< Target coordinate resolution, in m
+  real, dimension(:), intent(in) :: coordinateResolution !< Target coordinate resolution, in Z (often m)
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_zlike: CS already associated!")
   allocate(CS)
@@ -52,7 +52,7 @@ end subroutine end_coord_zlike
 !> Set parameters in the zlike structure
 subroutine set_zlike_params(CS, min_thickness)
   type(zlike_CS), pointer    :: CS !< Coordinate control structure
-  real, optional, intent(in) :: min_thickness !< Minimum allowed thickness, in m
+  real, optional, intent(in) :: min_thickness !< Minimum allowed thickness, in H
 
   if (.not. associated(CS)) call MOM_error(FATAL, "set_zlike_params: CS not associated")
 
@@ -63,7 +63,7 @@ end subroutine set_zlike_params
 subroutine build_zstar_column(CS, depth, total_thickness, zInterface, &
                               z_rigid_top, eta_orig, zScale)
   type(zlike_CS),           intent(in)    :: CS !< Coordinate control structure
-  real,                     intent(in)    :: depth !< Depth of ocean bottom (positive in m or H)
+  real,                     intent(in)    :: depth !< Depth of ocean bottom (positive in the output units)
   real,                     intent(in)    :: total_thickness !< Column thickness (positive in the same units as depth)
   real, dimension(CS%nk+1), intent(inout) :: zInterface !< Absolute positions of interfaces
   real, optional,           intent(in)    :: z_rigid_top !< The height of a rigid top (negative in the
@@ -71,7 +71,7 @@ subroutine build_zstar_column(CS, depth, total_thickness, zInterface, &
   real, optional,           intent(in)    :: eta_orig !< The actual original height of the top in the
                                                       !! same units as depth
   real, optional,           intent(in)    :: zScale !< Scaling factor from the target coordinate resolution
-                                                    !! in m to desired units for zInterface, perhaps m_to_H
+                                                    !! in Z to desired units for zInterface, perhaps Z_to_H
   ! Local variables
   real :: eta, stretching, dh, min_thickness, z0_top, z_star, z_scale
   integer :: k

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1972,7 +1972,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   ! Allocate initialize time-invariant MOM variables.
   call MOM_initialize_fixed(dG, CS%OBC, param_file, write_geom_files, dirs%output_directory)
   call callTree_waypoint("returned from MOM_initialize_fixed() (initialize_MOM)")
-  ! This could replace a later call to rescale_grid_bathymetry.
+
   if (dG%Zd_to_m /= GV%Z_to_m) call rescale_dyn_horgrid_bathymetry(dG, GV%Z_to_m)
 
   if (associated(CS%OBC)) call call_OBC_register(param_file, CS%update_OBC_CSp, CS%OBC)
@@ -2133,11 +2133,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   ! Initialize dynamically evolving fields, perhaps from restart files.
   call cpu_clock_begin(id_clock_MOM_init)
   call MOM_initialize_coord(GV, param_file, write_geom_files, &
-                            dirs%output_directory, CS%tv, dG%max_depth*dG%Zd_to_m)
+                            dirs%output_directory, CS%tv, dG%max_depth)
   call callTree_waypoint("returned from MOM_initialize_coord() (initialize_MOM)")
 
   if (CS%use_ALE_algorithm) then
-    call ALE_init(param_file, GV, dG%max_depth*dG%Zd_to_m, CS%ALE_CSp)
+    call ALE_init(param_file, GV, dG%max_depth, CS%ALE_CSp)
     call callTree_waypoint("returned from ALE_init() (initialize_MOM)")
   endif
 
@@ -2148,9 +2148,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   call MOM_grid_init(G, param_file, HI, bathymetry_at_vel=bathy_at_vel)
   call copy_dyngrid_to_MOM_grid(dG, G)
   call destroy_dyn_horgrid(dG)
-
-  ! This could replace an earlier call to rescale_dyn_horgrid_bathymetry just after MOM_initialize_fixed.
-  !  if (G%Zd_to_m /= GV%Z_to_m) call rescale_grid_bathymetry(G, GV%Z_to_m)
 
   ! Set a few remaining fields that are specific to the ocean grid type.
   call set_first_direction(G, first_direction)

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -73,7 +73,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                                intent(in) :: um  !< The new zonal velocity, in m s-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
-                               intent(in) :: hin !< The layer thickness, in m.
+                               intent(in) :: hin !< The layer thickness, in H.
   type(accel_diag_ptrs),       intent(in) :: ADp !< A structure pointing to the various
                                                  !! accelerations in the momentum equations.
   type(cont_diag_ptrs),        intent(in) :: CDp !<  A structure with pointers to various terms
@@ -88,7 +88,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
                      optional, intent(in) :: a   !< The layer coupling coefficients from vertvisc, Z s-1.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                      optional, intent(in) :: hv  !< The layer thicknesses at velocity grid points,
-                                                 !! from vertvisc, in m.
+                                                 !! from vertvisc, in H.
   ! Local variables
   real    :: f_eff, CFL
   real    :: Angstrom
@@ -231,27 +231,27 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
     endif
 
     write(file,'(/,"h--:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i,j-1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j-1,k)); enddo
     write(file,'(/,"h+-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i+1,j-1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j-1,k)); enddo
     write(file,'(/,"h-0:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i,j,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j,k)); enddo
     write(file,'(/,"h+0:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i+1,j,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j,k)); enddo
     write(file,'(/,"h-+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i,j+1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j+1,k)); enddo
     write(file,'(/,"h++:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i+1,j+1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j+1,k)); enddo
 
 
-    e(nz+1) = -G%Zd_to_m*G%bathyT(i,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + hin(i,j,k) ; enddo
+    e(nz+1) = -GV%Z_to_m*G%bathyT(i,j)
+    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j,k) ; enddo
     write(file,'(/,"e-:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
 
-    e(nz+1) = -G%Zd_to_m*G%bathyT(i+1,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + hin(i+1,j,k) ; enddo
+    e(nz+1) = -GV%Z_to_m*G%bathyT(i+1,j)
+    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i+1,j,k) ; enddo
     write(file,'(/,"e+:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K) ; enddo
@@ -281,53 +281,53 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 
     write(file,'(/,"vh--:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%vh(i,J-1,k)*G%IdxCv(i,J-1)); enddo
+                                    (GV%H_to_m*CDp%vh(i,J-1,k)*G%IdxCv(i,J-1)); enddo
     write(file,'(/," vhC--:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                        (0.5*CS%v_av(i,j-1,k)*(hin(i,j-1,k) + hin(i,j,k))); enddo
+                        (0.5*CS%v_av(i,j-1,k)*GV%H_to_m*(hin(i,j-1,k) + hin(i,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp--:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%v_prev(i,j-1,k)*(hin(i,j-1,k) + hin(i,j,k))); enddo
+                          (0.5*CS%v_prev(i,j-1,k)*GV%H_to_m*(hin(i,j-1,k) + hin(i,j,k))); enddo
     endif
 
     write(file,'(/,"vh-+:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%vh(i,J,k)*G%IdxCv(i,J)); enddo
+                                    (GV%H_to_m*CDp%vh(i,J,k)*G%IdxCv(i,J)); enddo
     write(file,'(/," vhC-+:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                        (0.5*CS%v_av(i,J,k)*(hin(i,j,k) + hin(i,j+1,k))); enddo
+                        (0.5*CS%v_av(i,J,k)*GV%H_to_m*(hin(i,j,k) + hin(i,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp-+:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%v_prev(i,J,k)*(hin(i,j,k) + hin(i,j+1,k))); enddo
+                          (0.5*CS%v_prev(i,J,k)*GV%H_to_m*(hin(i,j,k) + hin(i,j+1,k))); enddo
     endif
 
     write(file,'(/,"vh+-:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                      (CDp%vh(i+1,J-1,k)*G%IdxCv(i+1,J-1)); enddo
+                                      (GV%H_to_m*CDp%vh(i+1,J-1,k)*G%IdxCv(i+1,J-1)); enddo
     write(file,'(/," vhC+-:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                    (0.5*CS%v_av(i+1,J-1,k)*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
+                    (0.5*CS%v_av(i+1,J-1,k)*GV%H_to_m*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp+-:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                      (0.5*CS%v_prev(i+1,J-1,k)*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
+                      (0.5*CS%v_prev(i+1,J-1,k)*GV%H_to_m*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
     endif
 
     write(file,'(/,"vh++:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (CDp%vh(i+1,J,k)*G%IdxCv(i+1,J)); enddo
+                          (GV%H_to_m*CDp%vh(i+1,J,k)*G%IdxCv(i+1,J)); enddo
     write(file,'(/," vhC++:",$)')
          do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                     (0.5*CS%v_av(i+1,J,k)*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
+                     (0.5*CS%v_av(i+1,J,k)*GV%H_to_m*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp++:",$)')
            do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                       (0.5*CS%v_av(i+1,J,k)*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
+                       (0.5*CS%v_av(i+1,J,k)*GV%H_to_m*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
     endif
 
-    write(file,'(/,"D:     ",2(ES10.3))') G%Zd_to_m*G%bathyT(i,j),G%Zd_to_m*G%bathyT(i+1,j)
+    write(file,'(/,"D:     ",2(ES10.3))') GV%Z_to_m*G%bathyT(i,j),GV%Z_to_m*G%bathyT(i+1,j)
 
   !  From here on, the normalized accelerations are written.
     if (prev_avail) then
@@ -401,7 +401,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                                intent(in) :: vm  !< The new meridional velocity, in m s-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
-                               intent(in) :: hin !< The layer thickness, in m.
+                               intent(in) :: hin !< The layer thickness, in H.
   type(accel_diag_ptrs),       intent(in) :: ADp !< A structure pointing to the various
                                                  !! accelerations in the momentum equations.
   type(cont_diag_ptrs),        intent(in) :: CDp !< A structure with pointers to various terms in
@@ -416,7 +416,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
                      optional, intent(in) :: a   !< The layer coupling coefficients from vertvisc, Z s-1.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                      optional, intent(in) :: hv  !< The layer thicknesses at velocity grid points,
-                                                 !! from vertvisc, in m.
+                                                 !! from vertvisc, in H.
   ! Local variables
   real    :: f_eff, CFL
   real    :: Angstrom
@@ -563,26 +563,26 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
     endif
 
     write(file,'("h--:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i-1,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i-1,j,k); enddo
     write(file,'(/,"h0-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i,j,k); enddo
     write(file,'(/,"h+-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i+1,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i+1,j,k); enddo
     write(file,'(/,"h-+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i-1,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i-1,j+1,k); enddo
     write(file,'(/,"h0+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i,j+1,k); enddo
     write(file,'(/,"h++:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i+1,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i+1,j+1,k); enddo
 
-    e(nz+1) = -G%Zd_to_m*G%bathyT(i,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + hin(i,j,k); enddo
+    e(nz+1) = -GV%Z_to_m*G%bathyT(i,j)
+    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j,k); enddo
     write(file,'(/,"e-:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
 
-    e(nz+1) = -G%Zd_to_m*G%bathyT(i,j+1)
-    do k=nz,1,-1 ; e(K) = e(K+1) + hin(i,j+1,k) ; enddo
+    e(nz+1) = -GV%Z_to_m*G%bathyT(i,j+1)
+    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j+1,k) ; enddo
     write(file,'(/,"e+:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
@@ -612,14 +612,14 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 
     write(file,'(/,"uh--:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%uh(I-1,j,k)*G%IdyCu(I-1,j)); enddo
+                                    (GV%H_to_m*CDp%uh(I-1,j,k)*G%IdyCu(I-1,j)); enddo
     write(file,'(/," uhC--: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I-1,j,k) * 0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
+            (CS%u_av(I-1,j,k) * GV%H_to_m*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp--:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%u_prev(I-1,j,k)*(hin(i-1,j,k) + hin(i,j,k))); enddo
+            (CS%u_prev(I-1,j,k) * GV%H_to_m*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
     endif
 
     write(file,'(/,"uh-+:  ",$)')
@@ -627,38 +627,38 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
                                     (CDp%uh(I-1,j+1,k)*G%IdyCu(I-1,j+1)); enddo
     write(file,'(/," uhC-+: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I-1,j+1,k) * 0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
+            (CS%u_av(I-1,j+1,k) * GV%H_to_m*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp-+:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                    (0.5*CS%u_prev(I-1,j+1,k)*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
+            (CS%u_prev(I-1,j+1,k) * GV%H_to_m*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
     endif
 
     write(file,'(/,"uh+-:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%uh(I,j,k)*G%IdyCu(I,j)); enddo
+                                    (GV%H_to_m*CDp%uh(I,j,k)*G%IdyCu(I,j)); enddo
     write(file,'(/," uhC+-: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I,j,k) * 0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
+            (CS%u_av(I,j,k) * GV%H_to_m*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp+-:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                            (0.5*CS%u_prev(I,j,k)*(hin(i,j,k) + hin(i+1,j,k))); enddo
+            (CS%u_prev(I,j,k) * GV%H_to_m*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
     endif
 
     write(file,'(/,"uh++:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%uh(I,j+1,k)*G%IdyCu(I,j+1)); enddo
+                                    (GV%H_to_m*CDp%uh(I,j+1,k)*G%IdyCu(I,j+1)); enddo
     write(file,'(/," uhC++: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I,j+1,k) * 0.5*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
+            (CS%u_av(I,j+1,k) * 0.5*GV%H_to_m*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp++:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                      (0.5*CS%u_prev(I,j+1,k)*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
+            (CS%u_prev(I,j+1,k) * GV%H_to_m*0.5*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
     endif
 
-    write(file,'(/,"D:     ",2(ES10.3))') G%Zd_to_m*G%bathyT(i,j),G%Zd_to_m*G%bathyT(i,j+1)
+    write(file,'(/,"D:     ",2(ES10.3))') GV%Z_to_m*G%bathyT(i,j),GV%Z_to_m*G%bathyT(i,j+1)
 
   !  From here on, the normalized accelerations are written.
     if (prev_avail) then

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -95,6 +95,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real    :: truncvel, du
   real    :: Inorm(SZK_(G))
   real    :: e(SZK_(G)+1)
+  real    :: h_scale, uh_scale
   integer :: yr, mo, day, hr, minute, sec, yearday
   integer :: k, ks, ke
   integer :: nz
@@ -103,6 +104,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   integer :: file
 
   Angstrom = GV%Angstrom_H + GV%H_subroundoff
+  h_scale = GV%H_to_m ; uh_scale = GV%H_to_m
 
 !  if (.not.associated(CS)) return
   nz = G%ke
@@ -231,27 +233,27 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
     endif
 
     write(file,'(/,"h--:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j-1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i,j-1,k)); enddo
     write(file,'(/,"h+-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j-1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i+1,j-1,k)); enddo
     write(file,'(/,"h-0:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i,j,k)); enddo
     write(file,'(/,"h+0:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i+1,j,k)); enddo
     write(file,'(/,"h-+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j+1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i,j+1,k)); enddo
     write(file,'(/,"h++:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j+1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i+1,j+1,k)); enddo
 
 
     e(nz+1) = -GV%Z_to_m*G%bathyT(i,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j,k) ; enddo
+    do k=nz,1,-1 ; e(K) = e(K+1) + h_scale*hin(i,j,k) ; enddo
     write(file,'(/,"e-:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
 
     e(nz+1) = -GV%Z_to_m*G%bathyT(i+1,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i+1,j,k) ; enddo
+    do k=nz,1,-1 ; e(K) = e(K+1) + h_scale*hin(i+1,j,k) ; enddo
     write(file,'(/,"e+:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K) ; enddo
@@ -281,50 +283,50 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 
     write(file,'(/,"vh--:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%vh(i,J-1,k)*G%IdxCv(i,J-1)); enddo
+                                    (uh_scale*CDp%vh(i,J-1,k)*G%IdxCv(i,J-1)); enddo
     write(file,'(/," vhC--:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                        (0.5*CS%v_av(i,j-1,k)*GV%H_to_m*(hin(i,j-1,k) + hin(i,j,k))); enddo
+                        (0.5*CS%v_av(i,j-1,k)*h_scale*(hin(i,j-1,k) + hin(i,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp--:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%v_prev(i,j-1,k)*GV%H_to_m*(hin(i,j-1,k) + hin(i,j,k))); enddo
+                          (0.5*CS%v_prev(i,j-1,k)*h_scale*(hin(i,j-1,k) + hin(i,j,k))); enddo
     endif
 
     write(file,'(/,"vh-+:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%vh(i,J,k)*G%IdxCv(i,J)); enddo
+                                    (uh_scale*CDp%vh(i,J,k)*G%IdxCv(i,J)); enddo
     write(file,'(/," vhC-+:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                        (0.5*CS%v_av(i,J,k)*GV%H_to_m*(hin(i,j,k) + hin(i,j+1,k))); enddo
+                        (0.5*CS%v_av(i,J,k)*h_scale*(hin(i,j,k) + hin(i,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp-+:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%v_prev(i,J,k)*GV%H_to_m*(hin(i,j,k) + hin(i,j+1,k))); enddo
+                          (0.5*CS%v_prev(i,J,k)*h_scale*(hin(i,j,k) + hin(i,j+1,k))); enddo
     endif
 
     write(file,'(/,"vh+-:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                      (GV%H_to_m*CDp%vh(i+1,J-1,k)*G%IdxCv(i+1,J-1)); enddo
+                                      (uh_scale*CDp%vh(i+1,J-1,k)*G%IdxCv(i+1,J-1)); enddo
     write(file,'(/," vhC+-:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                    (0.5*CS%v_av(i+1,J-1,k)*GV%H_to_m*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
+                    (0.5*CS%v_av(i+1,J-1,k)*h_scale*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp+-:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                      (0.5*CS%v_prev(i+1,J-1,k)*GV%H_to_m*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
+                      (0.5*CS%v_prev(i+1,J-1,k)*h_scale*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
     endif
 
     write(file,'(/,"vh++:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (GV%H_to_m*CDp%vh(i+1,J,k)*G%IdxCv(i+1,J)); enddo
+                          (uh_scale*CDp%vh(i+1,J,k)*G%IdxCv(i+1,J)); enddo
     write(file,'(/," vhC++:",$)')
          do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                     (0.5*CS%v_av(i+1,J,k)*GV%H_to_m*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
+                     (0.5*CS%v_av(i+1,J,k)*h_scale*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp++:",$)')
            do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                       (0.5*CS%v_av(i+1,J,k)*GV%H_to_m*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
+                       (0.5*CS%v_av(i+1,J,k)*h_scale*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
     endif
 
     write(file,'(/,"D:     ",2(ES10.3))') GV%Z_to_m*G%bathyT(i,j),GV%Z_to_m*G%bathyT(i+1,j)
@@ -423,6 +425,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real    :: truncvel, dv
   real    :: Inorm(SZK_(G))
   real    :: e(SZK_(G)+1)
+  real    :: h_scale, uh_scale
   integer :: yr, mo, day, hr, minute, sec, yearday
   integer :: k, ks, ke
   integer :: nz
@@ -431,6 +434,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   integer :: file
 
   Angstrom = GV%Angstrom_H + GV%H_subroundoff
+  h_scale = GV%H_to_m ; uh_scale = GV%H_to_m
 
 !  if (.not.associated(CS)) return
   nz = G%ke
@@ -563,26 +567,26 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
     endif
 
     write(file,'("h--:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i-1,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i-1,j,k); enddo
     write(file,'(/,"h0-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i,j,k); enddo
     write(file,'(/,"h+-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i+1,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i+1,j,k); enddo
     write(file,'(/,"h-+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i-1,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i-1,j+1,k); enddo
     write(file,'(/,"h0+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i,j+1,k); enddo
     write(file,'(/,"h++:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i+1,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i+1,j+1,k); enddo
 
     e(nz+1) = -GV%Z_to_m*G%bathyT(i,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j,k); enddo
+    do k=nz,1,-1 ; e(K) = e(K+1) + h_scale*hin(i,j,k); enddo
     write(file,'(/,"e-:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
 
     e(nz+1) = -GV%Z_to_m*G%bathyT(i,j+1)
-    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j+1,k) ; enddo
+    do k=nz,1,-1 ; e(K) = e(K+1) + h_scale*hin(i,j+1,k) ; enddo
     write(file,'(/,"e+:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
@@ -612,50 +616,50 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 
     write(file,'(/,"uh--:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%uh(I-1,j,k)*G%IdyCu(I-1,j)); enddo
+                                    (uh_scale*CDp%uh(I-1,j,k)*G%IdyCu(I-1,j)); enddo
     write(file,'(/," uhC--: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I-1,j,k) * GV%H_to_m*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
+            (CS%u_av(I-1,j,k) * h_scale*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp--:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_prev(I-1,j,k) * GV%H_to_m*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
+            (CS%u_prev(I-1,j,k) * h_scale*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
     endif
 
     write(file,'(/,"uh-+:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%uh(I-1,j+1,k)*G%IdyCu(I-1,j+1)); enddo
+                                    (uh_scale*CDp%uh(I-1,j+1,k)*G%IdyCu(I-1,j+1)); enddo
     write(file,'(/," uhC-+: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I-1,j+1,k) * GV%H_to_m*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
+            (CS%u_av(I-1,j+1,k) * h_scale*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp-+:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_prev(I-1,j+1,k) * GV%H_to_m*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
+            (CS%u_prev(I-1,j+1,k) * h_scale*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
     endif
 
     write(file,'(/,"uh+-:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%uh(I,j,k)*G%IdyCu(I,j)); enddo
+                                    (uh_scale*CDp%uh(I,j,k)*G%IdyCu(I,j)); enddo
     write(file,'(/," uhC+-: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I,j,k) * GV%H_to_m*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
+            (CS%u_av(I,j,k) * h_scale*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp+-:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_prev(I,j,k) * GV%H_to_m*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
+            (CS%u_prev(I,j,k) * h_scale*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
     endif
 
     write(file,'(/,"uh++:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%uh(I,j+1,k)*G%IdyCu(I,j+1)); enddo
+                                    (uh_scale*CDp%uh(I,j+1,k)*G%IdyCu(I,j+1)); enddo
     write(file,'(/," uhC++: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I,j+1,k) * 0.5*GV%H_to_m*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
+            (CS%u_av(I,j+1,k) * 0.5*h_scale*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp++:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_prev(I,j+1,k) * GV%H_to_m*0.5*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
+            (CS%u_prev(I,j+1,k) * h_scale*0.5*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
     endif
 
     write(file,'(/,"D:     ",2(ES10.3))') GV%Z_to_m*G%bathyT(i,j),GV%Z_to_m*G%bathyT(i,j+1)

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -66,7 +66,7 @@ type, public :: diag_to_Z_CS ; private
   integer :: num_tr_used = 0 !< Th enumber of tracers in use.
   integer :: nk_zspace = -1 !< The number of levels in the z-space output
 
-  real, pointer :: Z_int(:) => NULL()  !< interface depths of the z-space file (meter)
+  real, pointer :: Z_int(:) => NULL()  !< interface depths of the z-space file, in Z
 
   !>@{ Axis groups for z-space diagnostic output
   type(axes_grp) :: axesBz,  axesTz,  axesCuz,  axesCvz
@@ -85,13 +85,14 @@ integer, parameter :: NO_ZSPACE = -1 !< Flag to enable z-space?
 contains
 
 !> Return the global horizontal mean in z-space
-function global_z_mean(var,G,CS,tracer)
-  type(ocean_grid_type), intent(in)  :: G    !< The ocean's grid structure
-  type(diag_to_Z_CS),    pointer     :: CS   !< Control structure returned by
-                                             !! previous call to diag_to_Z_init.
+function global_z_mean(var, G, GV, CS, tracer)
+  type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
+  type(diag_to_Z_CS),      pointer     :: CS   !< Control structure returned by
+                                               !! previous call to diag_to_Z_init.
   real, dimension(SZI_(G), SZJ_(G), CS%nk_zspace), &
-                         intent(in)  :: var    !< An array with the variable to average
-  integer,               intent(in)  :: tracer !< The tracer index being worked on
+                           intent(in)  :: var  !< An array with the variable to average
+  integer,                 intent(in)  :: tracer !< The tracer index being worked on
   ! Local variables
   real, dimension(SZI_(G), SZJ_(G), CS%nk_zspace)  :: tmpForSumming, weight
   real, dimension(CS%nk_zspace)                    :: global_z_mean, scalarij, weightij
@@ -107,13 +108,13 @@ function global_z_mean(var,G,CS,tracer)
   do k=1,nz ; do j=js,je ; do i=is,ie
     valid_point = 1.0
     ! Weight factor for partial bottom cells
-    depth_weight = min( max( (-G%Zd_to_m*G%bathyT(i,j)), CS%Z_int(k+1) ) - CS%Z_int(k), 0.)
+    depth_weight = min( max(-G%bathyT(i,j), CS%Z_int(k+1)) - CS%Z_int(k), 0.)
 
     ! Flag the point as invalid if it contains missing data, or is below the bathymetry
     if (var(i,j,k) == CS%missing_tr(tracer)) valid_point = 0.
     if (depth_weight == 0.) valid_point = 0.
 
-    weight(i,j,k) = depth_weight * ( (valid_point * (G%areaT(i,j) * G%mask2dT(i,j))) )
+    weight(i,j,k) = GV%Z_to_m * depth_weight * ( (valid_point * (G%areaT(i,j) * G%mask2dT(i,j))) )
 
     ! If the point is flagged, set the variable itself to zero to avoid NaNs
     if (valid_point == 0.) then
@@ -123,8 +124,8 @@ function global_z_mean(var,G,CS,tracer)
     endif
   enddo ; enddo ; enddo
 
-  global_temp_scalar   = reproducing_sum(tmpForSumming,sums=scalarij)
-  global_weight_scalar = reproducing_sum(weight,sums=weightij)
+  global_temp_scalar   = reproducing_sum(tmpForSumming, sums=scalarij)
+  global_weight_scalar = reproducing_sum(weight, sums=weightij)
 
   do k=1, nz
     if (scalarij(k) == 0) then
@@ -154,8 +155,8 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
                                                  !! to diag_to_Z_init.
   ! Local variables
   ! Note the deliberately reversed axes in h_f, u_f, v_f, and tr_f.
-  real :: ssh(SZI_(G),SZJ_(G))   ! copy of ssh_in (meter or kg/m2)
-  real :: e(SZK_(G)+2)           ! z-star interface heights (meter or kg/m2)
+  real :: ssh(SZI_(G),SZJ_(G))   ! copy of ssh_in whose halos can be updated (meter or kg/m2)
+  real :: e(SZK_(G)+2)           ! z-star interface heights in Z
   real :: h_f(SZK_(G)+1,SZI_(G)) ! thicknesses of massive layers (meter or kg/m2)
   real :: u_f(SZK_(G)+1,SZIB_(G))! zonal velocity component in any massive layer
   real :: v_f(SZK_(G)+1,SZI_(G)) ! meridional velocity component in any massive layer
@@ -163,8 +164,8 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
   real :: tr_f(SZK_(G),max(CS%num_tr_used,1),SZI_(G)) ! tracer concentration in massive layers
   integer :: nk_valid(SZIB_(G))  ! number of massive layers in a column
 
-  real :: D_pt(SZIB_(G))        ! bottom depth (meter or kg/m2)
-  real :: shelf_depth(SZIB_(G)) ! ice shelf depth (meter or kg/m2)
+  real :: D_pt(SZIB_(G))        ! bottom depth in Z
+  real :: shelf_depth(SZIB_(G)) ! ice shelf depth in Z
   real :: htot           ! summed layer thicknesses (meter or kg/m2)
   real :: dilate         ! proportion by which to dilate every layer
   real :: wt(SZK_(G)+1)  ! fractional weight for each layer in the
@@ -191,15 +192,19 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
   IsgB = G%IsgB ; IegB = G%IegB ; JsgB = G%JsgB ; JegB = G%JegB
   nkml = max(GV%nkml, 1)
   Angstrom = GV%Angstrom_H
-  ssh(:,:) = ssh_in
   linear_velocity_profiles = .true.
-  ! Update the halos
-  call pass_var(ssh, G%Domain)
+
 
   if (.not.associated(CS)) call MOM_error(FATAL, &
          "diagnostic_fields_zstar: Module must be initialized before it is used.")
 
   ice_shelf = associated(frac_shelf_h)
+
+  ! Update the halos
+  if (ice_shelf) then
+    do J=Jsq,Jeq+1 ; do i=Isq,Ieq+1 ; ssh(i,j) = GV%m_to_Z*ssh_in(i,j) ; enddo ; enddo
+    call pass_var(ssh, G%Domain)
+  endif
 
   ! If no fields are needed, return
   if ((CS%id_u_z <= 0) .and. (CS%id_v_z <= 0) .and. (CS%num_tr_used < 1)) return
@@ -217,7 +222,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
       ! Remove all massless layers.
       do I=Isq,Ieq
         nk_valid(I) = 0
-        D_pt(I) = 0.5*G%Zd_to_m*(G%bathyT(i+1,j)+G%bathyT(i,j))
+        D_pt(I) = 0.5*(G%bathyT(i+1,j)+G%bathyT(i,j))
         if (ice_shelf) then
           if (frac_shelf_h(i,j)+frac_shelf_h(i+1,j) > 0.) then ! under shelf
             shelf_depth(I) = abs(0.5*(ssh(i+1,j)+ssh(i,j)))
@@ -236,9 +241,9 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         nk_valid(I) = nk_valid(I) + 1 ; k2 = nk_valid(I)
         h_f(k2,I) = Angstrom ; u_f(k2,I) = 0.0
         ! GM: D_pt is always slightly larger (by 1E-6 or so) than shelf_depth, so
-        ! I consider that the ice shelf is grounded when
-        ! shelf_depth(I) + 1.0E-3 > D_pt(i)
-        if (ice_shelf .and. shelf_depth(I) + 1.0E-3 > D_pt(i)) nk_valid(I)=0
+        ! I consider that the ice shelf is grounded for diagnostic purposes when
+        ! shelf_depth(I) + 1.0E-3*GV%m_to_Z > D_pt(i)
+        if (ice_shelf .and. (shelf_depth(I) + 1.0E-3*GV%m_to_Z > D_pt(i))) nk_valid(I)=0
       endif ; enddo
 
 
@@ -246,8 +251,8 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
       ! Calculate the z* interface heights for tracers.
         htot = 0.0 ; do k=1,nk_valid(i) ; htot = htot + h_f(k,i) ; enddo
         dilate = 0.0
-        if (htot*GV%H_to_m > 2.0*Angstrom) then
-           dilate = MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot
+        if (htot > 2.0*Angstrom) then
+          dilate = MAX((D_pt(i) - shelf_depth(i)), GV%Angstrom_Z)/htot
         endif
         e(nk_valid(i)+1) = -D_pt(i)
         do k=nk_valid(i),1,-1 ; e(K) = e(K+1) + h_f(k,i)*dilate ; enddo
@@ -314,7 +319,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
       shelf_depth(:) = 0.0 ! initially all is open ocean
       ! Remove all massless layers.
       do i=is,ie
-        nk_valid(i) = 0 ; D_pt(i) = 0.5*G%Zd_to_m*(G%bathyT(i,j)+G%bathyT(i,j+1))
+        nk_valid(i) = 0 ; D_pt(i) = 0.5*(G%bathyT(i,j)+G%bathyT(i,j+1))
         if (ice_shelf) then
           if (frac_shelf_h(i,j)+frac_shelf_h(i,j+1) > 0.) then ! under shelf
             shelf_depth(i) = abs(0.5*(ssh(i,j)+ssh(i,j+1)))
@@ -332,7 +337,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         ! no-slip BBC in the output, if anything but piecewise constant is used.
         nk_valid(i) = nk_valid(i) + 1 ; k2 = nk_valid(i)
         h_f(k2,i) = Angstrom ; v_f(k2,i) = 0.0
-        if (ice_shelf .and. shelf_depth(i) + 1.0E-3 > D_pt(i)) nk_valid(I)=0
+        if (ice_shelf .and. shelf_depth(i) + 1.0E-3*GV%m_to_Z > D_pt(i)) nk_valid(I)=0
       endif ; enddo
 
       do i=is,ie ; if (nk_valid(i) > 0) then
@@ -340,7 +345,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         htot = 0.0 ; do k=1,nk_valid(i) ; htot = htot + h_f(k,i) ; enddo
         dilate = 0.0
         if (htot > 2.0*Angstrom) then
-           dilate = MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot
+          dilate = MAX((D_pt(i) - shelf_depth(i)), GV%Angstrom_Z)/htot
         endif
         e(nk_valid(i)+1) = -D_pt(i)
         do k=nk_valid(i),1,-1 ; e(K) = e(K+1) + h_f(k,i)*dilate ; enddo
@@ -406,7 +411,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
       shelf_depth(:) = 0.0 ! initially all is open ocean
       ! Remove all massless layers.
       do i=is,ie
-        nk_valid(i) = 0 ; D_pt(i) = G%Zd_to_m*G%bathyT(i,j)
+        nk_valid(i) = 0 ; D_pt(i) = G%bathyT(i,j)
         if (ice_shelf) then
           if (frac_shelf_h(i,j) > 0.) then ! under shelf
             shelf_depth(i) = abs(ssh(i,j))
@@ -417,7 +422,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         if ((G%mask2dT(i,j) > 0.5) .and. (h(i,j,k) > 2.0*Angstrom)) then
           nk_valid(i) = nk_valid(i) + 1 ; k2 = nk_valid(i)
           h_f(k2,i) = h(i,j,k)
-          if (ice_shelf .and. shelf_depth(I) + 1.0E-3 > D_pt(i)) nk_valid(I)=0
+          if (ice_shelf .and. shelf_depth(I) + 1.0E-3*GV%m_to_Z > D_pt(i)) nk_valid(I)=0
           do m=1,CS%num_tr_used ; tr_f(k2,m,i) = CS%tr_model(m)%p(i,j,k) ; enddo
         endif
       enddo ; enddo
@@ -427,7 +432,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         htot = 0.0 ;  do k=1,nk_valid(i) ; htot = htot + h_f(k,i) ; enddo
         dilate = 0.0
         if (htot > 2.0*Angstrom) then
-           dilate = MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot
+          dilate = MAX((D_pt(i) - shelf_depth(i)), GV%Angstrom_Z)/htot
         endif
         e(nk_valid(i)+1) = -D_pt(i)
         do k=nk_valid(i),1,-1 ; e(K) = e(K+1) + h_f(k,i)*dilate ; enddo
@@ -478,7 +483,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
     do m=1,CS%num_tr_used
       if (CS%id_tr(m) > 0) call post_data(CS%id_tr(m), CS%tr_z(m)%p, CS%diag)
       if (CS%id_tr_xyave(m) > 0) then
-        layer_ave = global_z_mean(CS%tr_z(m)%p,G,CS,m)
+        layer_ave = global_z_mean(CS%tr_z(m)%p, G, GV, CS, m)
         call post_data(CS%id_tr_xyave(m), layer_ave, CS%diag)
       endif
     enddo
@@ -505,9 +510,9 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
                                                                    !! diag_to_Z_init.
   ! Local variables
   real, dimension(SZI_(G), SZJ_(G)) :: &
-    htot, &        ! total layer thickness (meter or kg/m2)
-    dilate         ! nondimensional factor by which to dilate layers to
-                   ! convert them into z* space.  (-G%D < z* < 0)
+    htot, &        ! total layer thickness, in H
+    dilate         ! Factor by which to dilate layers to convert them
+                   ! into z* space, in Z H-1.  (-G%D < z* < 0)
 
   real, dimension(SZI_(G), max(CS%nk_zspace,1)) :: &
     uh_Z           ! uh_int interpolated into depth space (m3 or kg)
@@ -515,22 +520,22 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
     vh_Z           ! vh_int interpolated into depth space (m3 or kg)
 
   real :: h_rem    ! dilated thickness of a layer that has yet to be mapped
-                   ! into depth space (meter or kg/m2)
+                   ! into depth space (in Z)
   real :: uh_rem   ! integrated zonal transport of a layer that has yet to be
                    ! mapped into depth space (m3 or kg)
   real :: vh_rem   ! integrated meridional transport of a layer that has yet
                    ! to be mapped into depth space (m3 or kg)
   real :: h_here   ! thickness of a layer that is within the range of the
-                   ! current depth level (meter or kg/m2)
+                   ! current depth level (in Z)
   real :: h_above  ! thickness of a layer that is above the current depth
-                   ! level (meter or kg.m2)
+                   ! level (in Z)
   real :: uh_here  ! zonal transport of a layer that is attributed to the
                    ! current depth level (m3 or kg)
   real :: vh_here  ! meridional transport of a layer that is attributed to
                    ! the current depth level (m3 or kg)
   real :: Idt      ! inverse of the time step (sec)
 
-  real :: Z_int_above(SZIB_(G)) ! height of the interface atop a layer (meter or kg/m2)
+  real :: z_int_above(SZIB_(G)) ! height of the interface atop a layer (meter or kg/m2)
 
   integer :: kz(SZIB_(G)) ! index of depth level that is being contributed to
 
@@ -556,13 +561,13 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
     htot(i,j) = htot(i,j) + h(i,j,k)
   enddo ; enddo ; enddo
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-    dilate(i,j) = G%Zd_to_m*G%bathyT(i,j) / htot(i,j)
+    dilate(i,j) = G%bathyT(i,j) / htot(i,j)
   enddo ; enddo
 
   ! zonal transport
   if (CS%id_uh_Z > 0) then ; do j=js,je
     do I=Isq,Ieq
-      kz(I) = nk_z ; z_int_above(I) = -0.5*G%Zd_to_m*(G%bathyT(i,j)+G%bathyT(i+1,j))
+      kz(I) = nk_z ; z_int_above(I) = -0.5*(G%bathyT(i,j)+G%bathyT(i+1,j))
     enddo
     do k=nk_z,1,-1 ; do I=Isq,Ieq
       uh_Z(I,k) = 0.0
@@ -597,7 +602,7 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
   ! meridional transport
   if (CS%id_vh_Z > 0) then ; do J=Jsq,Jeq
     do i=is,ie
-      kz(i) = nk_z ; z_int_above(i) = -0.5*G%Zd_to_m*(G%bathyT(i,j)+G%bathyT(i,j+1))
+      kz(i) = nk_z ; z_int_above(i) = -0.5*(G%bathyT(i,j)+G%bathyT(i,j+1))
     enddo
     do k=nk_z,1,-1 ; do i=is,ie
       vh_Z(i,k) = 0.0
@@ -650,9 +655,9 @@ end subroutine calculate_Z_transport
 !! of each layer. It also calculates the normalized relative depths of the range
 !! of each layer that overlaps that depth range.
 subroutine find_overlap(e, Z_top, Z_bot, k_max, k_start, k_top, k_bot, wt, z1, z2)
-  real, dimension(:), intent(in)    :: e      !< Column interface heights (meter or kg/m2).
-  real,               intent(in)    :: Z_top  !< Top of range being mapped to (meter or kg/m2).
-  real,               intent(in)    :: Z_bot  !< Bottom of range being mapped to (meter or kg/m2).
+  real, dimension(:), intent(in)    :: e      !< Column interface heights, in arbitrary units.
+  real,               intent(in)    :: Z_top  !< Top of range being mapped to, in the units of e.
+  real,               intent(in)    :: Z_bot  !< Bottom of range being mapped to, in the units of e.
   integer,            intent(in)    :: k_max  !< Number of valid layers.
   integer,            intent(in)    :: k_start !< Layer at which to start searching.
   integer,            intent(inout) :: k_top  !< Indices of top layers that overlap with the depth
@@ -713,11 +718,11 @@ end subroutine find_overlap
 !! a piecewise limited scheme.
 subroutine find_limited_slope(val, e, slope, k)
   real, dimension(:), intent(in)  :: val !< A column of values that are being interpolated.
-  real, dimension(:), intent(in)  :: e   !< Column interface heights (meter or kg/m2).
+  real, dimension(:), intent(in)  :: e   !< Column interface heights in arbitrary units
   real,               intent(out) :: slope !< Normalized slope in the intracell distribution of val.
   integer,            intent(in)  :: k   !< Layer whose slope is being determined.
   ! Local variables
-  real :: d1, d2
+  real :: d1, d2  ! Thicknesses in the units of e.
 
   d1 = 0.5*(e(K-1)-e(K+1)) ; d2 = 0.5*(e(K)-e(K+2))
   if (((val(k)-val(k-1)) * (val(k)-val(k+1)) >= 0.0) .or. (d1*d2 <= 0.0)) then
@@ -773,8 +778,8 @@ subroutine calc_Zint_diags(h, in_ptrs, ids, num_diags, G, GV, CS)
     do k=1,nk ; do i=is,ie ; htot(i) = htot(i) + h(i,j,k) ; enddo ; enddo
     do i=is,ie
       dilate(i) = 0.0
-      if (htot(i)*GV%H_to_m > 0.5) dilate(i) = (G%Zd_to_m*G%bathyT(i,j) - 0.0) / htot(i)
-      e(i,nk+1) = -G%Zd_to_m*G%bathyT(i,j)
+      if (htot(i) > 0.5*GV%m_to_H) dilate(i) = (G%bathyT(i,j) - 0.0) / htot(i)
+      e(i,nk+1) = -G%bathyT(i,j)
     enddo
     do k=nk,1,-1 ; do i=is,ie
       e(i,k) = e(i,k+1) + h(i,j,k) * dilate(i)
@@ -964,8 +969,8 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
   character(len=200) :: in_dir, zgrid_file    ! strings for directory/file
   character(len=48)  :: flux_units, string
   integer :: z_axis, zint_axis
-  integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nk, id_test
-  isd  = G%isd   ; ied = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nk = G%ke
+  integer :: k, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nk, id_test
+  isd  = G%isd  ; ied = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nk = G%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
   if (associated(CS)) then
@@ -994,6 +999,7 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
     in_dir = slasher(in_dir)
     call get_Z_depths(trim(in_dir)//trim(zgrid_file), "zw", CS%Z_int, "zt", &
                       z_axis, zint_axis, CS%nk_zspace)
+    do K=1,CS%nk_zspace+1 ; CS%Z_int(K) = GV%m_to_Z*CS%Z_int(K) ; enddo
     call log_param(param_file, mdl, "!INPUTDIR/Z_OUTPUT_GRID_FILE", &
                    trim(in_dir)//trim(zgrid_file))
     call log_param(param_file, mdl, "!NK_ZSPACE (from file)", CS%nk_zspace, &
@@ -1051,7 +1057,7 @@ subroutine get_Z_depths(depth_file, int_depth_name, int_depth, cell_depth_name, 
   character(len=*),   intent(in)  :: depth_file  !< The file to read for the depths
   character(len=*),   intent(in)  :: int_depth_name !< The interface depth variable name
   real, dimension(:), pointer     :: int_depth   !< A pointer that will be allocated and
-                                                 !! returned with the interface depths
+                                                 !! returned with the interface depths in m
   character(len=*),   intent(in)  :: cell_depth_name !< The cell-center depth variable name
   integer,            intent(out) :: z_axis_index !< The cell-center z-axis diagnostic index handle
   integer,            intent(out) :: edge_index  !< The interface z-axis diagnostic index handle

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -56,7 +56,7 @@ type, public :: sum_output_CS ; private
   logical :: read_depth_list    !<   Read the depth list from a file if it exists
                                 !! and write it if it doesn't.
   character(len=200) :: depth_list_file  !< The name of the depth list file.
-  real    :: D_list_min_inc     !<  The minimum increment, in m, between the depths of the
+  real    :: D_list_min_inc     !<  The minimum increment, in Z, between the depths of the
                                 !! entries in the depth-list file, 0 by default.
   logical :: use_temperature    !<   If true, temperature and salinity are state variables.
   real    :: fresh_water_input  !<   The total mass of fresh water added by surface fluxes
@@ -211,8 +211,8 @@ subroutine MOM_sum_output_init(G, param_file, directory, ntrnc, &
                    "create that file otherwise.", default=.false.)
     call get_param(param_file, mdl, "DEPTH_LIST_MIN_INC", CS%D_list_min_inc, &
                    "The minimum increment between the depths of the \n"//&
-                   "entries in the depth-list file.", units="m", &
-                   default=1.0E-10)
+                   "entries in the depth-list file.", &
+                   units="m", default=1.0E-10, scale=1.0/G%Zd_to_m)
     if (CS%read_depth_list) then
       call get_param(param_file, mdl, "DEPTH_LIST_FILE", CS%depth_list_file, &
                    "The name of the depth list file.", default="Depth_list.nc")
@@ -288,21 +288,21 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
                     optional, pointer    :: OBC !< Open boundaries control structure.
   type(time_type),  optional, intent(in) :: dt_forcing !< The forcing time step
   ! Local variables
-  real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! The height of interfaces, in m.
+  real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! The height of interfaces, in Z.
   real :: areaTm(SZI_(G),SZJ_(G)) ! A masked version of areaT, in m2.
   real :: KE(SZK_(G))  ! The total kinetic energy of a layer, in J.
   real :: PE(SZK_(G)+1)! The available potential energy of an interface, in J.
   real :: KE_tot       ! The total kinetic energy, in J.
   real :: PE_tot       ! The total available potential energy, in J.
-  real :: H_0APE(SZK_(G)+1) ! The uniform depth which overlies the same
-                       ! volume as is below an interface, in m.
-                       ! H is usually positive.
+  real :: Z_0APE(SZK_(G)+1) ! The uniform depth which overlies the same
+                       ! volume as is below an interface, in Z.
+  real :: H_0APE(SZK_(G)+1) ! A version of Z_0APE, converted to m, usually positive.
   real :: toten        ! The total kinetic & potential energies of
                        ! all layers, in Joules (i.e. kg m2 s-2).
   real :: En_mass      ! The total kinetic and potential energies divided by
                        ! the total mass of the ocean, in m2 s-2.
-  real :: vol_lay(SZK_(G))  ! The volume of fluid in a layer, in m3.
-  real :: volbelow     ! The volume of all layers beneath an interface in m3.
+  real :: vol_lay(SZK_(G))  ! The volume of fluid in a layer, in Z m2.
+  real :: volbelow     ! The volume of all layers beneath an interface in Z m2.
   real :: mass_lay(SZK_(G)) ! The mass of fluid in a layer, in kg.
   real :: mass_tot     ! The total mass of the ocean in kg.
   real :: vol_tot      ! The total ocean volume in m3.
@@ -332,12 +332,11 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
   real :: temp_anom    ! The change in total heat that cannot be accounted for
                        ! by the surface fluxes, divided by the total heat
                        ! capacity of the ocean, in C.
-  real :: hint         ! The deviation of an interface from H, in m.
+  real :: hint         ! The deviation of an interface from H, in Z.
   real :: hbot         ! 0 if the basin is deeper than H, or the
                        ! height of the basin depth over H otherwise,
-                       ! in m. This makes PE only include real fluid.
-  real :: hbelow       ! The depth of fluid in all layers beneath
-                       ! an interface, in m.
+                       ! in Z. This makes PE only include real fluid.
+  real :: hbelow       ! The depth of fluid in all layers beneath an interface, in Z.
   type(EFP_type) :: &
     mass_EFP, &        ! Extended fixed point sums of total mass, etc.
     salt_EFP, heat_EFP, salt_chg_EFP, heat_chg_EFP, mass_chg_EFP, &
@@ -345,37 +344,35 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
   real :: CFL_trans    ! A transport-based definition of the CFL number, nondim.
   real :: CFL_lin      ! A simpler definition of the CFL number, nondim.
   real :: max_CFL(2)   ! The maxima of the CFL numbers, nondim.
-  real :: Irho0
+  real :: Irho0        ! The inverse of the reference density, in m3 kg-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: &
-    tmp1
+    tmp1               ! A temporary array
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: &
-    PE_pt
+    PE_pt              ! The potential energy at each point, in J.
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    Temp_int, Salt_int
-  real :: H_to_m, H_to_kg_m2  ! Local copies of unit conversion factors.
+    Temp_int, Salt_int ! Layer and cell integrated heat and salt, in J and g Salt.
+  real :: H_to_kg_m2   ! Local copy of a unit conversion factor.
   integer :: num_nc_fields  ! The number of fields that will actually go into
                             ! the NetCDF file.
   integer :: i, j, k, is, ie, js, je, ns, nz, m, Isq, Ieq, Jsq, Jeq
-  integer :: l, lbelow, labove   ! indices of deep_area_vol, used to find
-                                 ! H.  lbelow & labove are lower & upper
-                                 ! limits for l in the search for lH.
+  integer :: l, lbelow, labove   ! indices of deep_area_vol, used to find Z_0APE.
+                                 ! lbelow & labove are lower & upper limits for l
+                                 ! in the search for the entry in lH to use.
   integer :: start_of_day, num_days
   real    :: reday, var
   character(len=240) :: energypath_nc
   character(len=200) :: mesg
   character(len=32)  :: mesg_intro, time_units, day_str, n_str, date_str
   logical :: date_stamped
-  type(time_type) :: dt_force
+  type(time_type) :: dt_force ! A time_type version of the forcing timestep.
   real :: Tr_stocks(MAX_FIELDS_)
-  real :: Tr_min(MAX_FIELDS_),Tr_max(MAX_FIELDS_)
+  real :: Tr_min(MAX_FIELDS_), Tr_max(MAX_FIELDS_)
   real :: Tr_min_x(MAX_FIELDS_), Tr_min_y(MAX_FIELDS_), Tr_min_z(MAX_FIELDS_)
   real :: Tr_max_x(MAX_FIELDS_), Tr_max_y(MAX_FIELDS_), Tr_max_z(MAX_FIELDS_)
   logical :: Tr_minmax_got(MAX_FIELDS_) = .false.
   character(len=40), dimension(MAX_FIELDS_) :: &
     Tr_names, Tr_units
   integer :: nTr_stocks
-  real, allocatable :: toten_PE(:)
-  integer :: pe_num
   integer :: iyear, imonth, iday, ihour, iminute, isecond, itick ! For call to get_date()
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
@@ -445,7 +442,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
-  H_to_m = GV%H_to_m ; H_to_kg_m2 = GV%H_to_kg_m2
+  H_to_kg_m2 = GV%H_to_kg_m2
 
   if (.not.associated(CS)) call MOM_error(FATAL, &
          "write_energy: Module must be initialized before it is used.")
@@ -489,7 +486,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
     endif
 
     mass_tot = reproducing_sum(tmp1, sums=mass_lay, EFP_sum=mass_EFP)
-    do k=1,nz ; vol_lay(k) = (H_to_m/H_to_kg_m2)*mass_lay(k) ; enddo
+    do k=1,nz ; vol_lay(k) = (GV%H_to_Z/H_to_kg_m2)*mass_lay(k) ; enddo
   else
     tmp1(:,:,:) = 0.0
     if (CS%do_APE_calc) then
@@ -498,17 +495,17 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
       enddo ; enddo ; enddo
       mass_tot = reproducing_sum(tmp1, sums=mass_lay, EFP_sum=mass_EFP)
 
-      call find_eta(h, tv, G, GV, eta, eta_to_m=1.0)
+      call find_eta(h, tv, G, GV, eta)
       do k=1,nz ; do j=js,je ; do i=is,ie
         tmp1(i,j,k) = (eta(i,j,K)-eta(i,j,K+1)) * areaTm(i,j)
       enddo ; enddo ; enddo
-      vol_tot = H_to_m*reproducing_sum(tmp1, sums=vol_lay)
+      vol_tot = GV%Z_to_m*reproducing_sum(tmp1, sums=vol_lay)
     else
       do k=1,nz ; do j=js,je ; do i=is,ie
         tmp1(i,j,k) = H_to_kg_m2 * h(i,j,k) * areaTm(i,j)
       enddo ; enddo ; enddo
       mass_tot = reproducing_sum(tmp1, sums=mass_lay, EFP_sum=mass_EFP)
-      do k=1,nz ; vol_lay(k) = mass_lay(k) / GV%Rho0 ; enddo
+      do k=1,nz ; vol_lay(k) = GV%m_to_Z * (mass_lay(k) / GV%Rho0) ; enddo
     endif
   endif ! Boussinesq
 
@@ -615,11 +612,43 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
         CS%lH(k) = l
       endif
       lbelow = l
-      H_0APE(K) = CS%DL(l)%depth - (volbelow - CS%DL(l)%vol_below) / CS%DL(l)%area
+      Z_0APE(K) = CS%DL(l)%depth - (volbelow - CS%DL(l)%vol_below) / CS%DL(l)%area
     enddo
-    H_0APE(nz+1) = CS%DL(2)%depth
+    Z_0APE(nz+1) = CS%DL(2)%depth
+
+    !   Calculate the Available Potential Energy integrated over each
+    ! interface.  With a nonlinear equation of state or with a bulk
+    ! mixed layer this calculation is only approximate.  With an ALE model
+    ! this does not make sense.
+    PE_pt(:,:,:) = 0.0
+    if (GV%Boussinesq) then
+      do j=js,je ; do i=is,ie
+        hbelow = 0.0
+        do k=nz,1,-1
+          hbelow = hbelow + h(i,j,k) * GV%H_to_Z
+          hint = Z_0APE(K) + (hbelow - G%bathyT(i,j))
+          hbot = Z_0APE(K) - G%bathyT(i,j)
+          hbot = (hbot + ABS(hbot)) * 0.5
+          PE_pt(i,j,K) = 0.5 * areaTm(i,j) * GV%Z_to_m*(GV%Rho0*GV%g_prime(K)) * &
+                  (hint * hint - hbot * hbot)
+        enddo
+      enddo ; enddo
+    else
+      do j=js,je ; do i=is,ie
+        do k=nz,1,-1
+          hint = Z_0APE(K) + eta(i,j,K)  ! eta and H_0 have opposite signs.
+          hbot = max(Z_0APE(K) - G%bathyT(i,j), 0.0)
+          PE_pt(i,j,K) = 0.5 * (areaTm(i,j) * GV%Z_to_m*(GV%Rho0*GV%g_prime(K))) * &
+                  (hint * hint - hbot * hbot)
+        enddo
+      enddo ; enddo
+    endif
+
+    PE_tot = reproducing_sum(PE_pt, sums=PE)
+    do k=1,nz+1 ; H_0APE(K) = GV%Z_to_m*Z_0APE(K) ; enddo
   else
-    do k=1,nz+1 ; H_0APE(K) = 0.0 ; enddo
+    PE_tot = 0.0
+    do k=1,nz+1 ; PE(K) = 0.0 ; H_0APE(K) = 0.0 ; enddo
   endif
 
 ! Calculate the Kinetic Energy integrated over each layer.
@@ -628,42 +657,8 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
     tmp1(i,j,k) = (0.25 * H_to_kg_m2 * (areaTm(i,j) * h(i,j,k))) * &
             (u(I-1,j,k)**2 + u(I,j,k)**2 + v(i,J-1,k)**2 + v(i,J,k)**2)
   enddo ; enddo ; enddo
-
-!   Calculate the Available Potential Energy integrated over each
-! interface.  With a nonlinear equation of state or with a bulk
-! mixed layer this calculation is only approximate.
-  do k=1,nz+1 ; PE(K) = 0.0 ; enddo
-  if (CS%do_APE_calc) then
-    PE_pt(:,:,:) = 0.0
-    if (GV%Boussinesq) then
-      do j=js,je ; do i=is,ie
-        hbelow = 0.0
-        do k=nz,1,-1
-          hbelow = hbelow + h(i,j,k) * H_to_m
-          hint = H_0APE(K) + (hbelow - G%Zd_to_m*G%bathyT(i,j))
-          hbot = H_0APE(K) - G%Zd_to_m*G%bathyT(i,j)
-          hbot = (hbot + ABS(hbot)) * 0.5
-          PE_pt(i,j,K) = 0.5 * areaTm(i,j) * (GV%Rho0*GV%m_to_Z*GV%g_prime(K)) * &
-                  (hint * hint - hbot * hbot)
-        enddo
-      enddo ; enddo
-    else
-      do j=js,je ; do i=is,ie
-        hbelow = 0.0
-        do k=nz,1,-1
-          hint = H_0APE(K) + eta(i,j,K)  ! eta and H_0 have opposite signs.
-          hbot = max(H_0APE(K) - G%Zd_to_m*G%bathyT(i,j), 0.0)
-          PE_pt(i,j,K) = 0.5 * (areaTm(i,j) * (GV%Rho0*GV%m_to_Z*GV%g_prime(K))) * &
-                  (hint * hint - hbot * hbot)
-        enddo
-      enddo ; enddo
-    endif
-  endif
-
   KE_tot = reproducing_sum(tmp1, sums=KE)
-  PE_tot = 0.0
-  if (CS%do_APE_calc) &
-    PE_tot = reproducing_sum(PE_pt, sums=PE)
+
   toten = KE_tot + PE_tot
 
   Salt = 0.0 ; Heat = 0.0
@@ -1061,15 +1056,15 @@ subroutine create_depth_list(G, CS)
                                           !! in which the ordered depth list is stored.
   ! Local variables
   real, dimension(G%Domain%niglobal*G%Domain%njglobal + 1) :: &
-    Dlist, &  !< The global list of bottom depths, in m.
+    Dlist, &  !< The global list of bottom depths, in Z.
     AreaList  !< The global list of cell areas, in m2.
   integer, dimension(G%Domain%niglobal*G%Domain%njglobal+1) :: &
     indx2     !< The position of an element in the original unsorted list.
-  real    :: Dnow  !< The depth now being considered for sorting, in m.
-  real    :: Dprev !< The most recent depth that was considered, in m.
-  real    :: vol   !< The running sum of open volume below a deptn, in m3.
+  real    :: Dnow  !< The depth now being considered for sorting, in Z.
+  real    :: Dprev !< The most recent depth that was considered, in Z.
+  real    :: vol   !< The running sum of open volume below a deptn, in Z m2.
   real    :: area  !< The open area at the current depth, in m2.
-  real    :: D_list_prev !< The most recent depth added to the list, in m.
+  real    :: D_list_prev !< The most recent depth added to the list, in Z.
   logical :: add_to_list !< This depth should be included as an entry on the list.
 
   integer :: ir, indxt
@@ -1088,7 +1083,7 @@ subroutine create_depth_list(G, CS)
     i_global = i + G%idg_offset - (G%isg-1)
 
     list_pos = (j_global-1)*G%Domain%niglobal + i_global
-    Dlist(list_pos) = G%Zd_to_m*G%bathyT(i,j)
+    Dlist(list_pos) = G%bathyT(i,j)
     Arealist(list_pos) = G%mask2dT(i,j)*G%areaT(i,j)
   enddo ; enddo
 
@@ -1238,7 +1233,7 @@ subroutine write_depth_list(G, CS, filename, list_size)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
       filename//trim(NF90_STRERROR(status)))
 
-  do k=1,list_size ; tmp(k) = CS%DL(k)%depth ; enddo
+  do k=1,list_size ; tmp(k) = G%Zd_to_m*CS%DL(k)%depth ; enddo
   status = NF90_PUT_VAR(ncid, Did, tmp)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
       filename//" depth "//trim(NF90_STRERROR(status)))
@@ -1248,7 +1243,7 @@ subroutine write_depth_list(G, CS, filename, list_size)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
       filename//" area "//trim(NF90_STRERROR(status)))
 
-  do k=1,list_size ; tmp(k) = CS%DL(k)%vol_below ; enddo
+  do k=1,list_size ; tmp(k) = G%Zd_to_m*CS%DL(k)%vol_below ; enddo
   status = NF90_PUT_VAR(ncid, Vid, tmp)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
       filename//" vol_below "//trim(NF90_STRERROR(status)))
@@ -1270,10 +1265,12 @@ subroutine read_depth_list(G, CS, filename)
   character(len=32) :: mdl
   character(len=240) :: var_name, var_msg
   real, allocatable :: tmp(:)
+  real    :: m_to_Z
   integer :: ncid, status, varid, list_size, k
   integer :: ndim, len, var_dim_ids(NF90_MAX_VAR_DIMS)
 
   mdl = "MOM_sum_output read_depth_list:"
+  m_to_Z = 1.0/G%Zd_to_m
 
   status = NF90_OPEN(filename, NF90_NOWRITE, ncid)
   if (status /= NF90_NOERR) then
@@ -1312,7 +1309,7 @@ subroutine read_depth_list(G, CS, filename)
         " Difficulties reading variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
 
-  do k=1,list_size ; CS%DL(k)%depth = tmp(k) ; enddo
+  do k=1,list_size ; CS%DL(k)%depth = m_to_Z*tmp(k) ; enddo
 
   var_name = "area"
   var_msg = trim(var_name)//" in "//trim(filename)//" - "
@@ -1338,7 +1335,7 @@ subroutine read_depth_list(G, CS, filename)
         " Difficulties reading variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
 
-  do k=1,list_size ; CS%DL(k)%vol_below = tmp(k) ; enddo
+  do k=1,list_size ; CS%DL(k)%vol_below = m_to_Z*tmp(k) ; enddo
 
   status = NF90_CLOSE(ncid)
   if (status /= NF90_NOERR) call MOM_error(WARNING, mdl// &

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1917,7 +1917,7 @@ function register_static_field(module_name, field_name, axes, &
      long_name, units, missing_value, range, mask_variant, standard_name, &
      do_not_log, interp_method, tile_count, &
      cmor_field_name, cmor_long_name, cmor_units, cmor_standard_name, area, &
-     x_cell_method, y_cell_method, area_cell_method)
+     x_cell_method, y_cell_method, area_cell_method, conversion)
   integer :: register_static_field !< An integer handle for a diagnostic array.
   character(len=*), intent(in) :: module_name !< Name of this module, usually "ocean_model"
                                               !! or "ice_shelf_model"
@@ -1943,6 +1943,7 @@ function register_static_field(module_name, field_name, axes, &
   character(len=*), optional, intent(in) :: x_cell_method !< Specifies the cell method for the x-direction.
   character(len=*), optional, intent(in) :: y_cell_method !< Specifies the cell method for the y-direction.
   character(len=*), optional, intent(in) :: area_cell_method !< Specifies the cell method for area
+  real,             optional, intent(in) :: conversion !< A value to multiply data by before writing to file
 
   ! Local variables
   real :: MOM_missing_value
@@ -1971,6 +1972,7 @@ function register_static_field(module_name, field_name, axes, &
     call assert(associated(diag), 'register_static_field: diag allocation failed')
     diag%fms_diag_id = fms_id
     diag%debug_str = trim(module_name)//"-"//trim(field_name)
+    if (present(conversion)) diag%conversion_factor = conversion
     if (present(x_cell_method)) then
       call get_diag_axis_name(axes%handles(1), axis_name)
       call diag_field_add_attribute(fms_id, 'cell_methods', trim(axis_name)//':'//trim(x_cell_method))
@@ -2013,6 +2015,7 @@ function register_static_field(module_name, field_name, axes, &
       call alloc_diag_with_id(dm_id, diag_cs, cmor_diag)
       cmor_diag%fms_diag_id = fms_id
       cmor_diag%debug_str = trim(module_name)//"-"//trim(cmor_field_name)
+      if (present(conversion)) cmor_diag%conversion_factor = conversion
       if (present(x_cell_method)) then
         call get_diag_axis_name(axes%handles(1), axis_name)
         call diag_field_add_attribute(fms_id, 'cell_methods', trim(axis_name)//':'//trim(x_cell_method))

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -270,7 +270,7 @@ subroutine diag_remap_update(remap_cs, G, GV, h, T, S, eqn_of_state)
     if (remap_cs%vertical_coord == coordinateMode('ZSTAR')) then
       call build_zstar_column(get_zlike_CS(remap_cs%regrid_cs), &
                               GV%Z_to_H*G%bathyT(i,j), sum(h(i,j,:)), &
-                              zInterfaces, zScale=GV%m_to_H)
+                              zInterfaces, zScale=GV%Z_to_H)
     elseif (remap_cs%vertical_coord == coordinateMode('SIGMA')) then
       call build_sigma_column(get_sigma_CS(remap_cs%regrid_cs), &
                               GV%Z_to_H*G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -50,8 +50,8 @@ end interface
 
 !> Extrapolate and interpolate data
 interface horiz_interp_and_extrap_tracer
-   module procedure horiz_interp_and_extrap_tracer_record
-   module procedure horiz_interp_and_extrap_tracer_fms_id
+  module procedure horiz_interp_and_extrap_tracer_record
+  module procedure horiz_interp_and_extrap_tracer_fms_id
 end interface
 
 contains
@@ -73,21 +73,19 @@ subroutine myStats(array, missing, is, ie, js, je, k, mesg)
   character(len=120) :: lMesg
   minA = 9.E24 ; maxA = -9.E24 ; found = .false.
 
-  do j = js, je
-     do i = is, ie
-        if (array(i,j) /= array(i,j)) stop 'Nan!'
-        if (abs(array(i,j)-missing)>1.e-6*abs(missing)) then
-           if (found) then
-              minA = min(minA, array(i,j))
-              maxA = max(maxA, array(i,j))
-           else
-              found = .true.
-              minA = array(i,j)
-              maxA = array(i,j)
-           endif
-        endif
-     enddo
-  enddo
+  do j=js,je ; do i=is,ie
+    if (array(i,j) /= array(i,j)) stop 'Nan!'
+    if (abs(array(i,j)-missing) > 1.e-6*abs(missing)) then
+      if (found) then
+        minA = min(minA, array(i,j))
+        maxA = max(maxA, array(i,j))
+      else
+        found = .true.
+        minA = array(i,j)
+        maxA = array(i,j)
+      endif
+    endif
+  enddo ; enddo
   call min_across_PEs(minA)
   call max_across_PEs(maxA)
   if (is_root_pe()) then
@@ -95,6 +93,7 @@ subroutine myStats(array, missing, is, ie, js, je, k, mesg)
           'init_from_Z: min=',minA,' max=',maxA,' Level=',k,trim(mesg)
      call MOM_mesg(lMesg,2)
   endif
+
 end subroutine myStats
 
 
@@ -102,7 +101,7 @@ end subroutine myStats
 !! valid data (good=1). If no information is available,
 !! Then use a previous guess (prev). Optionally (smooth)
 !! blend the filled points to achieve a more desirable result.
-subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug,debug)
+subroutine fill_miss_2d(aout, good, fill, prev, G, smooth, num_pass, relc, crit, keep_bug, debug)
   use MOM_coms, only : sum_across_PEs
 
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure.
@@ -127,7 +126,7 @@ subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug
 
 
   real, dimension(SZI_(G),SZJ_(G)) :: b,r
-  real, dimension(SZI_(G),SZJ_(G)) :: fill_pts,good_,good_new
+  real, dimension(SZI_(G),SZJ_(G)) :: fill_pts, good_, good_new
 
   character(len=256) :: mesg  ! The text of an error message
   integer :: i,j,k
@@ -163,116 +162,111 @@ subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug
   do_smooth=.false.
   if (PRESENT(smooth)) do_smooth=smooth
 
-  fill_pts(:,:)=fill(:,:)
+  fill_pts(:,:) = fill(:,:)
 
   nfill = sum(fill(is:ie,js:je))
   call sum_across_PEs(nfill)
 
   nfill_prev = nfill
-  good_(:,:)=good(:,:)
-  r(:,:)=0.0
+  good_(:,:) = good(:,:)
+  r(:,:) = 0.0
 
   do while (nfill > 0.0)
 
-     call pass_var(good_,G%Domain)
-     call pass_var(aout,G%Domain)
+    call pass_var(good_,G%Domain)
+    call pass_var(aout,G%Domain)
 
-     b(:,:)=aout(:,:)
-     good_new(:,:)=good_(:,:)
+    b(:,:)=aout(:,:)
+    good_new(:,:)=good_(:,:)
 
-     do j=js,je
-        i_loop: do i=is,ie
+    do j=js,je ; do i=is,ie
 
-           if (good_(i,j) == 1.0 .or. fill(i,j) == 0.) cycle i_loop
+      if (good_(i,j) == 1.0 .or. fill(i,j) == 0.) cycle
 
-           ge=good_(i+1,j);gw=good_(i-1,j)
-           gn=good_(i,j+1);gs=good_(i,j-1)
-           east=0.0;west=0.0;north=0.0;south=0.0
-           if (ge == 1.0) east=aout(i+1,j)*ge
-           if (gw == 1.0) west=aout(i-1,j)*gw
-           if (gn == 1.0) north=aout(i,j+1)*gn
-           if (gs == 1.0) south=aout(i,j-1)*gs
+      ge=good_(i+1,j) ; gw=good_(i-1,j)
+      gn=good_(i,j+1) ; gs=good_(i,j-1)
+      east=0.0 ; west=0.0 ; north=0.0 ; south=0.0
+      if (ge == 1.0) east = aout(i+1,j)*ge
+      if (gw == 1.0) west = aout(i-1,j)*gw
+      if (gn == 1.0) north = aout(i,j+1)*gn
+      if (gs == 1.0) south = aout(i,j-1)*gs
 
-           ngood = ge+gw+gn+gs
-           if (ngood > 0.) then
-              b(i,j)=(east+west+north+south)/ngood
-              fill_pts(i,j)=0.0
-              good_new(i,j)=1.0
-           endif
-        enddo i_loop
-     enddo
+      ngood = ge+gw+gn+gs
+      if (ngood > 0.) then
+        b(i,j)=(east+west+north+south)/ngood
+        !### Replace this with
+        ! b(i,j) = ((east+west) + (north+south))/ngood
+        fill_pts(i,j) = 0.0
+        good_new(i,j) = 1.0
+      endif
+    enddo ; enddo
 
-     aout(is:ie,js:je)=b(is:ie,js:je)
-     good_(is:ie,js:je)=good_new(is:ie,js:je)
-     nfill_prev = nfill
-     nfill = sum(fill_pts(is:ie,js:je))
-     call sum_across_PEs(nfill)
+    aout(is:ie,js:je) = b(is:ie,js:je)
+    good_(is:ie,js:je) = good_new(is:ie,js:je)
+    nfill_prev = nfill
+    nfill = sum(fill_pts(is:ie,js:je))
+    call sum_across_PEs(nfill)
 
-     if (nfill == nfill_prev .and. PRESENT(prev)) then
-        do j=js,je
-           do i=is,ie
-              if (fill_pts(i,j) == 1.0) then
-                 aout(i,j)=prev(i,j)
-                 fill_pts(i,j)=0.0
-              endif
-           enddo
-        enddo
-     elseif (nfill == nfill_prev) then
-        call MOM_error(WARNING, &
-             'Unable to fill missing points using either data at the same vertical level from a connected basin'//&
-             'or using a point from a previous vertical level.  Make sure that the original data has some valid'//&
-             'data in all basins.', .true.)
-        write(mesg,*) 'nfill=',nfill
-        call MOM_error(WARNING, mesg, .true.)
-     endif
+    if (nfill == nfill_prev .and. PRESENT(prev)) then
+      do j=js,je ; do i=is,ie ; if (fill_pts(i,j) == 1.0) then
+        aout(i,j) = prev(i,j)
+        fill_pts(i,j) = 0.0
+      endif ; enddo ; enddo
+    elseif (nfill == nfill_prev) then
+      call MOM_error(WARNING, &
+           'Unable to fill missing points using either data at the same vertical level from a connected basin'//&
+           'or using a point from a previous vertical level.  Make sure that the original data has some valid'//&
+           'data in all basins.', .true.)
+      write(mesg,*) 'nfill=',nfill
+      call MOM_error(WARNING, mesg, .true.)
+    endif
 
-     nfill = sum(fill_pts(is:ie,js:je))
-     call sum_across_PEs(nfill)
+    nfill = sum(fill_pts(is:ie,js:je))
+    call sum_across_PEs(nfill)
 
   enddo
 
-  if (do_smooth) then
-     do k=1,npass
-        call pass_var(aout,G%Domain)
-        do j=js,je
-           do i=is,ie
-              if (fill(i,j) == 1) then
-                 east=max(good(i+1,j),fill(i+1,j)) ; west=max(good(i-1,j),fill(i-1,j))
-                 north=max(good(i,j+1),fill(i,j+1)) ; south=max(good(i,j-1),fill(i,j-1))
-                 !### Appropriate parentheses should be added here, but they will change answers.
-                 r(i,j) = relax_coeff*(south*aout(i,j-1)+north*aout(i,j+1) + &
-                                       west*aout(i-1,j)+east*aout(i+1,j) - &
-                                      (south+north+west+east)*aout(i,j))
-              else
-                 r(i,j) = 0.
-              endif
-           enddo
-        enddo
-        aout(is:ie,js:je)=r(is:ie,js:je)+aout(is:ie,js:je)
-        ares = maxval(abs(r))
-        call max_across_PEs(ares)
-        if (ares <= acrit) exit
-     enddo
-  endif
+  if (do_smooth) then ; do k=1,npass
+    call pass_var(aout,G%Domain)
+    do j=js,je ; do i=is,ie
+      if (fill(i,j) == 1) then
+        east = max(good(i+1,j),fill(i+1,j)) ; west = max(good(i-1,j),fill(i-1,j))
+        north = max(good(i,j+1),fill(i,j+1)) ; south = max(good(i,j-1),fill(i,j-1))
+        r(i,j) = relax_coeff*(south*aout(i,j-1)+north*aout(i,j+1) + &
+                              west*aout(i-1,j)+east*aout(i+1,j) - &
+                             (south+north+west+east)*aout(i,j))
+        !### Appropriate parentheses should be added here, but they will change answers.
+        ! r(i,j) = relax_coeff*( ((south*aout(i,j-1) + north*aout(i,j+1)) + &
+        !                         (west*aout(i-1,j)+east*aout(i+1,j))) - &
+        !                        ((south+north)+(west+east))*aout(i,j) )
+      else
+        r(i,j) = 0.
+      endif
+    enddo ; enddo
+    ares = 0.0
+    do j=js,je ; do i=is,ie
+      aout(i,j) = r(i,j) + aout(i,j)
+      ares = max(ares, abs(r(i,j)))
+    enddo ; enddo
+    call max_across_PEs(ares)
+    if (ares <= acrit) exit
+  enddo ; endif
 
-  do j=js,je
-     do i=is,ie
-        if (good_(i,j) == 0.0 .and. fill_pts(i,j) == 1.0) then
-           write(mesg,*) 'In fill_miss, fill, good,i,j= ',fill_pts(i,j),good_(i,j),i,j
-           call MOM_error(WARNING, mesg, .true.)
-           call MOM_error(FATAL,"MOM_initialize: "// &
-                "fill is true and good is false after fill_miss, how did this happen? ")
-        endif
-     enddo
-  enddo
-
-  return
+  do j=js,je ; do i=is,ie
+    if (good_(i,j) == 0.0 .and. fill_pts(i,j) == 1.0) then
+      write(mesg,*) 'In fill_miss, fill, good,i,j= ',fill_pts(i,j),good_(i,j),i,j
+      call MOM_error(WARNING, mesg, .true.)
+      call MOM_error(FATAL,"MOM_initialize: "// &
+           "fill is true and good is false after fill_miss, how did this happen? ")
+    endif
+ enddo ; enddo
 
 end subroutine fill_miss_2d
 
 !> Extrapolate and interpolate from a file record
-subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, recnum, G, tr_z, mask_z, z_in, &
-                                                z_edges_in, missing_value, reentrant_x, tripolar_n, homogenize )
+subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, recnum, G, tr_z, &
+                                                 mask_z, z_in, z_edges_in, missing_value, reentrant_x, &
+                                                 tripolar_n, homogenize, m_to_Z)
 
   character(len=*),      intent(in)    :: filename   !< Path to file containing tracer to be
                                                      !! interpolated.
@@ -281,9 +275,9 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   integer,               intent(in)    :: recnum     !< Record number of tracer to be read.
   type(ocean_grid_type), intent(inout) :: G          !< Grid object
   real, allocatable, dimension(:,:,:)  :: tr_z       !< pointer to allocatable tracer array on local
-                                                     !! model grid and native vertical levels.
+                                                     !! model grid and input-file vertical levels.
   real, allocatable, dimension(:,:,:)  :: mask_z     !< pointer to allocatable tracer mask array on
-                                                     !! local model grid and native vertical levels.
+                                                     !! local model grid and input-file vertical levels.
   real, allocatable,     dimension(:)  :: z_in       !< Cell grid values for input data.
   real, allocatable,     dimension(:)  :: z_edges_in !< Cell grid edge values for input data.
   real,                  intent(out)   :: missing_value !< The missing value in the returned array.
@@ -291,8 +285,11 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   logical,               intent(in)    :: tripolar_n !< If true, this is a northern tripolar grid
   logical,     optional, intent(in)    :: homogenize !< If present and true, horizontally homogenize data
                                                      !! to produce perfectly "flat" initial conditions
+  real,        optional, intent(in)    :: m_to_Z     !< A conversion factor from meters to the units
+                                                     !! of depth.  If missing, G%bathyT must be in m.
 
-  real, dimension(:,:),  allocatable   :: tr_in,tr_inp ! A 2-d array for holding input data on
+  ! Local variables
+  real, dimension(:,:),  allocatable   :: tr_in, tr_inp ! A 2-d array for holding input data on
                                                      ! native horizontal grid and extended grid
                                                      ! with poles.
   real, dimension(:,:),  allocatable   :: mask_in    ! A 2-d mask for extended input grid.
@@ -405,6 +402,8 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 
   call cpu_clock_end(id_clock_read)
 
+  if (present(m_to_Z)) then ; do k=1,kd ; z_in(k) = m_to_Z * z_in(k) ; enddo ; endif
+
 ! extrapolate the input data to the north pole using the northerm-most latitude
 
   max_lat = maxval(lat_in)
@@ -425,8 +424,8 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 ! construct level cell boundaries as the mid-point between adjacent centers
 
   z_edges_in(1) = 0.0
-  do k=2,kd
-   z_edges_in(k)=0.5*(z_in(k-1)+z_in(k))
+  do K=2,kd
+   z_edges_in(K)=0.5*(z_in(k-1)+z_in(k))
   enddo
   z_edges_in(kd+1)=2.0*z_in(kd) - z_in(kd-1)
 
@@ -446,7 +445,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   allocate(mask_in(id,jdp)) ; mask_in(:,:)=0.0
   allocate(last_row(id))    ; last_row(:)=0.0
 
-  max_depth = G%Zd_to_m*maxval(G%bathyT)
+  max_depth = maxval(G%bathyT)
   call mpp_max(max_depth)
 
   if (z_edges_in(kd+1)<max_depth) z_edges_in(kd+1)=max_depth
@@ -463,7 +462,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     write(laynum,'(I8)') k ; laynum = adjustl(laynum)
 
     if (is_root_pe()) then
-      start = 1; start(3) = k; count = 1; count(1) = id; count(2) = jd
+      start = 1 ; start(3) = k ; count(:) = 1 ; count(1) = id ; count(2) = jd
       rcode = NF90_GET_VAR(ncid,varid, tr_in, start, count)
       if (rcode /= 0) call MOM_error(FATAL,"hinterp_and_extract_from_Fie: "//&
            "error reading level "//trim(laynum)//" of variable "//&
@@ -491,7 +490,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     endif
 
     call mpp_sync()
-    call mpp_broadcast(tr_inp,id*jdp,root_PE())
+    call mpp_broadcast(tr_inp, id*jdp, root_PE())
     call mpp_sync_self()
 
     mask_in=0.0
@@ -499,10 +498,10 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     do j=1,jdp
       do i=1,id
          if (abs(tr_inp(i,j)-missing_value) > abs(roundoff*missing_value)) then
-           mask_in(i,j)=1.0
-            tr_inp(i,j) = tr_inp(i,j) * conversion
+           mask_in(i,j) = 1.0
+           tr_inp(i,j) = tr_inp(i,j) * conversion
          else
-           tr_inp(i,j)=missing_value
+           tr_inp(i,j) = missing_value
          endif
       enddo
     enddo
@@ -543,7 +542,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
           nPoints = nPoints + 1
           varAvg = varAvg + tr_out(i,j)
         endif
-        if (G%mask2dT(i,j) == 1.0 .and. z_edges_in(k) <= G%Zd_to_m*G%bathyT(i,j) .and. mask_out(i,j) < 1.0) &
+        if (G%mask2dT(i,j) == 1.0 .and. z_edges_in(k) <= G%bathyT(i,j) .and. mask_out(i,j) < 1.0) &
           fill(i,j)=1.0
       enddo
     enddo
@@ -569,18 +568,18 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 ! tr_out contains input z-space data on the model grid with missing values
 ! now fill in missing values using "ICE-nine" algorithm.
 
-    tr_outf(:,:)=tr_out(:,:)
-    if (k==1) tr_prev(:,:)=tr_outf(:,:)
-    good2(:,:)=good(:,:)
-    fill2(:,:)=fill(:,:)
+    tr_outf(:,:) = tr_out(:,:)
+    if (k==1) tr_prev(:,:) = tr_outf(:,:)
+    good2(:,:) = good(:,:)
+    fill2(:,:) = fill(:,:)
 
-    call fill_miss_2d(tr_outf,good2,fill2,tr_prev,G,smooth=.true.)
-    call myStats(tr_outf,missing_value,is,ie,js,je,k,'field from fill_miss_2d()')
+    call fill_miss_2d(tr_outf, good2, fill2, tr_prev, G, smooth=.true.)
+    call myStats(tr_outf, missing_value, is, ie, js, je, k, 'field from fill_miss_2d()')
 
-    tr_z(:,:,k) = tr_outf(:,:)*G%mask2dT(:,:)
-    mask_z(:,:,k) = good2(:,:)+fill2(:,:)
+    tr_z(:,:,k) = tr_outf(:,:) * G%mask2dT(:,:)
+    mask_z(:,:,k) = good2(:,:) + fill2(:,:)
 
-    tr_prev(:,:)=tr_z(:,:,k)
+    tr_prev(:,:) = tr_z(:,:,k)
 
     if (debug) then
       call hchksum(tr_prev,'field after fill ',G%HI)
@@ -591,8 +590,9 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 end subroutine horiz_interp_and_extrap_tracer_record
 
 !> Extrapolate and interpolate using a FMS time interpolation handle
-subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, tr_z, mask_z, z_in, &
-                                                z_edges_in, missing_value, reentrant_x, tripolar_n, homogenize )
+subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, tr_z, mask_z, &
+                                                 z_in, z_edges_in, missing_value, reentrant_x, &
+                                                 tripolar_n, homogenize, m_to_Z)
 
   integer,               intent(in)    :: fms_id     !< A unique id used by the FMS time interpolator
   type(time_type),       intent(in)    :: Time       !< A FMS time type
@@ -603,13 +603,16 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   real, allocatable, dimension(:,:,:)  :: mask_z     !< pointer to allocatable tracer mask array on
                                                      !! local model grid and native vertical levels.
   real, allocatable,     dimension(:)  :: z_in       !< Cell grid values for input data.
-  real, allocatable,     dimension(:)  :: z_edges_in !< Cell grid edge values for input data.
+  real, allocatable,     dimension(:)  :: z_edges_in !< Cell grid edge values for input data. (Intent out)
   real,                  intent(out)   :: missing_value !< The missing value in the returned array.
   logical,               intent(in)    :: reentrant_x !< If true, this grid is reentrant in the x-direction
   logical,               intent(in)    :: tripolar_n !< If true, this is a northern tripolar grid
   logical,     optional, intent(in)    :: homogenize !< If present and true, horizontally homogenize data
                                                      !! to produce perfectly "flat" initial conditions
+  real,        optional, intent(in)    :: m_to_Z     !< A conversion factor from meters to the units
+                                                     !! of depth.  If missing, G%bathyT must be in m.
 
+  ! Local variables
   real, dimension(:,:),  allocatable   :: tr_in,tr_inp !< A 2-d array for holding input data on
                                                      !! native horizontal grid and extended grid
                                                      !! with poles.
@@ -678,9 +681,11 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   call mpp_get_axis_data(axes_data(2), lat_in)
   call mpp_get_axis_data(axes_data(3), z_in)
 
+  if (present(m_to_Z)) then ; do k=1,kd ; z_in(k) = m_to_Z * z_in(k) ; enddo ; endif
+
   call cpu_clock_end(id_clock_read)
 
-  missing_value=get_external_field_missing(fms_id)
+  missing_value = get_external_field_missing(fms_id)
 
 
 ! extrapolate the input data to the north pole using the northerm-most latitude
@@ -688,14 +693,14 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   max_lat = maxval(lat_in)
   add_np=.false.
   if (max_lat < 90.0) then
-    add_np=.true.
-    jdp=jd+1
+    add_np = .true.
+    jdp = jd+1
     allocate(lat_inp(jdp))
-    lat_inp(1:jd)=lat_in(:)
-    lat_inp(jd+1)=90.0
+    lat_inp(1:jd) = lat_in(:)
+    lat_inp(jd+1) = 90.0
     deallocate(lat_in)
     allocate(lat_in(1:jdp))
-    lat_in(:)=lat_inp(:)
+    lat_in(:) = lat_inp(:)
   else
     jdp=jd
   endif
@@ -704,16 +709,16 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
 
   z_edges_in(1) = 0.0
   do k=2,kd
-   z_edges_in(k)=0.5*(z_in(k-1)+z_in(k))
+   z_edges_in(k) = 0.5*(z_in(k-1)+z_in(k))
   enddo
-  z_edges_in(kd+1)=2.0*z_in(kd) - z_in(kd-1)
+  z_edges_in(kd+1) = 2.0*z_in(kd) - z_in(kd-1)
 
   call horiz_interp_init()
 
   lon_in = lon_in*PI_180
   lat_in = lat_in*PI_180
-  allocate(x_in(id,jdp),y_in(id,jdp))
-  call meshgrid(lon_in,lat_in, x_in, y_in)
+  allocate(x_in(id,jdp), y_in(id,jdp))
+  call meshgrid(lon_in, lat_in, x_in, y_in)
 
   lon_out(:,:) = G%geoLonT(:,:)*PI_180
   lat_out(:,:) = G%geoLatT(:,:)*PI_180
@@ -724,13 +729,13 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   allocate(mask_in(id,jdp)) ; mask_in(:,:)=0.0
   allocate(last_row(id))    ; last_row(:)=0.0
 
-  max_depth = G%Zd_to_m*maxval(G%bathyT)
+  max_depth = maxval(G%bathyT)
   call mpp_max(max_depth)
 
   if (z_edges_in(kd+1)<max_depth) z_edges_in(kd+1)=max_depth
 
   if (is_root_pe()) &
-  call time_interp_external(fms_id, Time, data_in,verbose=.true.)
+  call time_interp_external(fms_id, Time, data_in, verbose=.true.)
 
 ! loop through each data level and interpolate to model grid.
 ! after interpolating, fill in points which will be needed
@@ -766,100 +771,91 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
     endif
 
     call mpp_sync()
-    call mpp_broadcast(tr_inp,id*jdp,root_PE())
+    call mpp_broadcast(tr_inp, id*jdp, root_PE())
     call mpp_sync_self()
 
     mask_in=0.0
 
-    do j=1,jdp
-      do i=1,id
-         if (abs(tr_inp(i,j)-missing_value) > abs(roundoff*missing_value)) then
-           mask_in(i,j)=1.0
-           tr_inp(i,j) = tr_inp(i,j) * conversion
-         else
-           tr_inp(i,j)=missing_value
-         endif
-      enddo
-    enddo
+    do j=1,jdp ; do i=1,id
+      if (abs(tr_inp(i,j)-missing_value) > abs(roundoff*missing_value)) then
+        mask_in(i,j)=1.0
+        tr_inp(i,j) = tr_inp(i,j) * conversion
+      else
+        tr_inp(i,j) = missing_value
+      endif
+    enddo ; enddo
 
-
-! call fms routine horiz_interp to interpolate input level data to model horizontal grid
-
-
+    ! call fms routine horiz_interp to interpolate input level data to model horizontal grid
     if (k == 1) then
-      call horiz_interp_new(Interp,x_in,y_in,lon_out(is:ie,js:je),lat_out(is:ie,js:je), &
-               interp_method='bilinear',src_modulo=reentrant_x)
+      call horiz_interp_new(Interp, x_in, y_in, lon_out(is:ie,js:je), lat_out(is:ie,js:je), &
+               interp_method='bilinear', src_modulo=reentrant_x)
     endif
 
-!    if (debug) then
-       call myStats(tr_in,missing_value, 1,id,1,jd,k,'Tracer from file')
-!    endif
+    if (debug) then
+      call myStats(tr_in, missing_value, 1, id, 1, jd, k, 'Tracer from file')
+    endif
 
     tr_out(:,:) = 0.0
 
-    call horiz_interp(Interp,tr_inp,tr_out(is:ie,js:je), missing_value=missing_value, new_missing_handle=.true.)
+    call horiz_interp(Interp, tr_inp, tr_out(is:ie,js:je), missing_value=missing_value, &
+                      new_missing_handle=.true.)
 
-    mask_out=1.0
-    do j=js,je
-      do i=is,ie
-        if (abs(tr_out(i,j)-missing_value) < abs(roundoff*missing_value)) mask_out(i,j)=0.
-      enddo
-    enddo
+    mask_out(:,:) = 1.0
+    do j=js,je ; do i=is,ie
+      if (abs(tr_out(i,j)-missing_value) < abs(roundoff*missing_value)) mask_out(i,j) = 0.
+    enddo ; enddo
 
-    fill = 0.0; good = 0.0
+    fill(:,:) = 0.0 ; good(:,:) = 0.0
 
     nPoints = 0 ; varAvg = 0.
-    do j=js,je
-      do i=is,ie
-        if (mask_out(i,j) < 1.0) then
-          tr_out(i,j)=missing_value
-        else
-          good(i,j)=1.0
-          nPoints = nPoints + 1
-          varAvg = varAvg + tr_out(i,j)
-        endif
-        if (G%mask2dT(i,j) == 1.0 .and. z_edges_in(k) <= G%Zd_to_m*G%bathyT(i,j) .and. mask_out(i,j) < 1.0) &
-          fill(i,j)=1.0
-      enddo
-    enddo
-    call pass_var(fill,G%Domain)
-    call pass_var(good,G%Domain)
+    do j=js,je ; do i=is,ie
+      if (mask_out(i,j) < 1.0) then
+        tr_out(i,j) = missing_value
+      else
+        good(i,j) = 1.0
+        nPoints = nPoints + 1
+        varAvg = varAvg + tr_out(i,j)
+      endif
+      if ((G%mask2dT(i,j) == 1.0) .and. (z_edges_in(k) <= G%bathyT(i,j)) .and. &
+          (mask_out(i,j) < 1.0)) &
+        fill(i,j)=1.0
+    enddo ;  enddo
+    call pass_var(fill, G%Domain)
+    call pass_var(good, G%Domain)
 
     if (debug) then
-      call myStats(tr_out,missing_value, is,ie,js,je,k,'variable from horiz_interp()')
+      call myStats(tr_out, missing_value, is, ie, js, je, k, 'variable from horiz_interp()')
     endif
 
     ! Horizontally homogenize data to produce perfectly "flat" initial conditions
-    if (PRESENT(homogenize)) then
-       if (homogenize) then
-          call sum_across_PEs(nPoints)
-          call sum_across_PEs(varAvg)
-          if (nPoints>0) then
-             varAvg = varAvg/real(nPoints)
-          endif
-          tr_out(:,:) = varAvg
-       endif
-    endif
+    if (PRESENT(homogenize)) then ; if (homogenize) then
+      call sum_across_PEs(nPoints)
+      call sum_across_PEs(varAvg)
+      if (nPoints>0) then
+         varAvg = varAvg/real(nPoints)
+      endif
+      tr_out(:,:) = varAvg
+    endif ; endif
 
-! tr_out contains input z-space data on the model grid with missing values
-! now fill in missing values using "ICE-nine" algorithm.
+  ! tr_out contains input z-space data on the model grid with missing values
+  ! now fill in missing values using "ICE-nine" algorithm.
 
-    tr_outf(:,:)=tr_out(:,:)
-    if (k==1) tr_prev(:,:)=tr_outf(:,:)
-    good2(:,:)=good(:,:)
-    fill2(:,:)=fill(:,:)
+    tr_outf(:,:) = tr_out(:,:)
+    if (k==1) tr_prev(:,:) = tr_outf(:,:)
+    good2(:,:) = good(:,:)
+    fill2(:,:) = fill(:,:)
 
-    call fill_miss_2d(tr_outf,good2,fill2,tr_prev,G,smooth=.true.)
+    call fill_miss_2d(tr_outf, good2, fill2, tr_prev, G, smooth=.true.)
 
 !    if (debug) then
-!      call hchksum(tr_outf,'field from fill_miss_2d ',G%HI)
+!      call hchksum(tr_outf, 'field from fill_miss_2d ', G%HI)
 !    endif
 
-!    call myStats(tr_outf,missing_value,is,ie,js,je,k,'field from fill_miss_2d()')
+!    call myStats(tr_outf, missing_value, is, ie, js, je, k, 'field from fill_miss_2d()')
 
     tr_z(:,:,k) = tr_outf(:,:)*G%mask2dT(:,:)
-    mask_z(:,:,k) = good2(:,:)+fill2(:,:)
-    tr_prev(:,:)=tr_z(:,:,k)
+    mask_z(:,:,k) = good2(:,:) + fill2(:,:)
+    tr_prev(:,:) = tr_z(:,:,k)
 
     if (debug) then
       call hchksum(tr_prev,'field after fill ',G%HI)
@@ -872,80 +868,75 @@ end subroutine horiz_interp_and_extrap_tracer_fms_id
 
 
 !> Create a 2d-mesh of grid coordinates from 1-d arrays.
-subroutine meshgrid(x,y,x_T,y_T)
-real, dimension(:),                   intent(in)    :: x  !< input 1-dimensional vector
-real, dimension(:),                   intent(in)    :: y  !< input 1-dimensional vector
-real, dimension(size(x,1),size(y,1)), intent(inout) :: x_T !< output 2-dimensional array
-real, dimension(size(x,1),size(y,1)), intent(inout) :: y_T !< output 2-dimensional array
+subroutine meshgrid(x, y, x_T, y_T)
+  real, dimension(:),                   intent(in)    :: x  !< input 1-dimensional vector
+  real, dimension(:),                   intent(in)    :: y  !< input 1-dimensional vector
+  real, dimension(size(x,1),size(y,1)), intent(inout) :: x_T !< output 2-dimensional array
+  real, dimension(size(x,1),size(y,1)), intent(inout) :: y_T !< output 2-dimensional array
 
-integer :: ni,nj,i,j
+  integer :: ni,nj,i,j
 
-ni=size(x,1);nj=size(y,1)
+  ni=size(x,1) ; nj=size(y,1)
 
-do j=1,nj
-  x_T(:,j)=x(:)
-enddo
+  do j=1,nj ; do i=1,ni
+    x_T(i,j) = x(i)
+  enddo ; enddo
 
-do i=1,ni
-  y_T(i,:)=y(:)
-enddo
-
-return
+  do j=1,nj ; do i=1,ni
+    y_T(i,j) = y(j)
+  enddo ; enddo
 
 end subroutine meshgrid
 
+! None of the subsequent code appears to be used at all.
 
 !> Fill grid edges for integer data
 function fill_boundaries_int(m,cyclic_x,tripolar_n) result(mp)
-integer, dimension(:,:), intent(in)             :: m !< input array (ND)
-logical,                 intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
-logical,                 intent(in)             :: tripolar_n !< True if domain has an Arctic fold
-integer, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
+  integer, dimension(:,:), intent(in)             :: m !< input array (ND)
+  logical,                 intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
+  logical,                 intent(in)             :: tripolar_n !< True if domain has an Arctic fold
+  integer, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
 
-real,    dimension(size(m,1),size(m,2))         :: m_real
-real,    dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp_real
+  real,    dimension(size(m,1),size(m,2))         :: m_real
+  real,    dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp_real
 
-m_real = real(m)
+  m_real = real(m)
 
-mp_real = fill_boundaries_real(m_real,cyclic_x,tripolar_n)
+  mp_real = fill_boundaries_real(m_real,cyclic_x,tripolar_n)
 
-mp = int(mp_real)
-
-return
+  mp = int(mp_real)
 
 end function fill_boundaries_int
 
 !> Fill grid edges for real data
 function fill_boundaries_real(m,cyclic_x,tripolar_n) result(mp)
-real, dimension(:,:), intent(in)             :: m !< input array (ND)
-logical,              intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
-logical,              intent(in)             :: tripolar_n !< True if domain has an Arctic fold
-real, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
+  real, dimension(:,:), intent(in)             :: m !< input array (ND)
+  logical,              intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
+  logical,              intent(in)             :: tripolar_n !< True if domain has an Arctic fold
+  real, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
 
-integer :: ni,nj,i,j
+  integer :: ni,nj,i,j
 
-ni=size(m,1); nj=size(m,2)
+  ni=size(m,1); nj=size(m,2)
 
-mp(1:ni,1:nj)=m(:,:)
+  mp(1:ni,1:nj)=m(:,:)
 
-if (cyclic_x) then
-  mp(0,1:nj)=m(ni,1:nj)
-  mp(ni+1,1:nj)=m(1,1:nj)
-else
-  mp(0,1:nj)=m(1,1:nj)
-  mp(ni+1,1:nj)=m(ni,1:nj)
-endif
+  if (cyclic_x) then
+    mp(0,1:nj)=m(ni,1:nj)
+    mp(ni+1,1:nj)=m(1,1:nj)
+  else
+    mp(0,1:nj)=m(1,1:nj)
+    mp(ni+1,1:nj)=m(ni,1:nj)
+  endif
 
-mp(1:ni,0)=m(1:ni,1)
-if (tripolar_n) then
-  do i=1,ni
-    mp(i,nj+1)=m(ni-i+1,nj)
-  enddo
-else
-  mp(1:ni,nj+1)=m(1:ni,nj)
-endif
-
-return
+  mp(1:ni,0)=m(1:ni,1)
+  if (tripolar_n) then
+    do i=1,ni
+      mp(i,nj+1)=m(ni-i+1,nj)
+    enddo
+  else
+    mp(1:ni,nj+1)=m(1:ni,nj)
+  endif
 
 end function fill_boundaries_real
 
@@ -956,68 +947,62 @@ end function fill_boundaries_real
 !! in each region is an approximation to del2(zi)=0 subject to
 !! boundary conditions along the valid points curve bounding this region.
 subroutine smooth_heights(zi,fill,bad,sor,niter,cyclic_x, tripolar_n)
+  real,    dimension(:,:),                   intent(inout) :: zi !< input and output array (ND)
+  integer, dimension(size(zi,1),size(zi,2)), intent(in) :: fill !< same shape as zi, 1=fill
+  integer, dimension(size(zi,1),size(zi,2)), intent(in) :: bad  !< same shape as zi, 1=bad data
+  real,                                      intent(in)  :: sor !< relaxation coefficient (ND)
+  integer,                                   intent(in) :: niter !< maximum number of iterations
+  logical,                                   intent(in) :: cyclic_x !< true if domain is zonally reentrant
+  logical,                                   intent(in) :: tripolar_n !< true if domain has an Arctic fold
 
-real,    dimension(:,:),                   intent(inout) :: zi !< input and output array (ND)
-integer, dimension(size(zi,1),size(zi,2)), intent(in) :: fill !< same shape as zi, 1=fill
-integer, dimension(size(zi,1),size(zi,2)), intent(in) :: bad  !< same shape as zi, 1=bad data
-real,                                      intent(in)  :: sor !< relaxation coefficient (ND)
-integer,                                   intent(in) :: niter !< maximum number of iterations
-logical,                                   intent(in) :: cyclic_x !< true if domain is zonally reentrant
-logical,                                   intent(in) :: tripolar_n !< true if domain has an Arctic fold
+  ! Local variables
+  real, dimension(size(zi,1),size(zi,2)) :: res, m
+  integer, dimension(size(zi,1),size(zi,2),4) :: B
+  real, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: mp
+  integer, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: nm
+  integer :: i,j,k,n
+  integer :: ni,nj
+  real :: Isum, bsum
 
-integer :: i,j,k,n
-integer :: ni,nj
-
-real, dimension(size(zi,1),size(zi,2)) :: res, m
-integer, dimension(size(zi,1),size(zi,2),4) :: B
-real, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: mp
-integer, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: nm
-
-real :: Isum, bsum
-
-ni=size(zi,1); nj=size(zi,2)
+  ni=size(zi,1) ; nj=size(zi,2)
 
 
-mp=fill_boundaries(zi,cyclic_x,tripolar_n)
+  mp(:,:) = fill_boundaries(zi,cyclic_x,tripolar_n)
 
-B(:,:,:)=0.0
-nm=fill_boundaries(bad,cyclic_x,tripolar_n)
+  B(:,:,:) = 0.0
+  nm(:,:) = fill_boundaries(bad,cyclic_x,tripolar_n)
 
-do j=1,nj
-  do i=1,ni
-    if (fill(i,j) == 1) then
-      B(i,j,1)=1-nm(i+1,j);B(i,j,2)=1-nm(i-1,j)
-      B(i,j,3)=1-nm(i,j+1);B(i,j,4)=1-nm(i,j-1)
-    endif
-  enddo
-enddo
-
-do n=1,niter
   do j=1,nj
     do i=1,ni
       if (fill(i,j) == 1) then
-        bsum = real(B(i,j,1)+B(i,j,2)+B(i,j,3)+B(i,j,4))
-        Isum = 1.0/bsum
-        res(i,j)=Isum*(B(i,j,1)*mp(i+1,j)+B(i,j,2)*mp(i-1,j)+&
-             B(i,j,3)*mp(i,j+1)+B(i,j,4)*mp(i,j-1)) - mp(i,j)
+        B(i,j,1)=1-nm(i+1,j);B(i,j,2)=1-nm(i-1,j)
+        B(i,j,3)=1-nm(i,j+1);B(i,j,4)=1-nm(i,j-1)
       endif
     enddo
   enddo
-  res(:,:)=res(:,:)*sor
 
-  do j=1,nj
-    do i=1,ni
-      mp(i,j)=mp(i,j)+res(i,j)
+  do n=1,niter
+    do j=1,nj
+      do i=1,ni
+        if (fill(i,j) == 1) then
+          bsum = real(B(i,j,1)+B(i,j,2)+B(i,j,3)+B(i,j,4))
+          Isum = 1.0/bsum
+          res(i,j)=Isum*(B(i,j,1)*mp(i+1,j)+B(i,j,2)*mp(i-1,j)+&
+               B(i,j,3)*mp(i,j+1)+B(i,j,4)*mp(i,j-1)) - mp(i,j)
+        endif
+      enddo
     enddo
+    res(:,:)=res(:,:)*sor
+
+    do j=1,nj
+      do i=1,ni
+        mp(i,j)=mp(i,j)+res(i,j)
+      enddo
+    enddo
+
+    zi(:,:)=mp(1:ni,1:nj)
+    mp = fill_boundaries(zi,cyclic_x,tripolar_n)
   enddo
-
-  zi(:,:)=mp(1:ni,1:nj)
-  mp = fill_boundaries(zi,cyclic_x,tripolar_n)
-enddo
-
-
-
-return
 
 end subroutine smooth_heights
 

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -37,7 +37,7 @@ subroutine MOM_initialize_coord(GV, PF, write_geom, output_dir, tv, max_depth)
   logical,                 intent(in)    :: write_geom !< If true, write grid geometry files.
   character(len=*),        intent(in)    :: output_dir !< The directory into which to write files.
   type(thermo_var_ptrs),   intent(inout) :: tv         !< The thermodynamic variable structure.
-  real,                    intent(in)    :: max_depth  !< The ocean's maximum depth, in m.
+  real,                    intent(in)    :: max_depth  !< The ocean's maximum depth, in Z.
   ! Local
   character(len=200) :: config
   logical :: debug

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1824,8 +1824,8 @@ subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp, 
     call MOM_read_data(filename, salin_var, tmp(:,:,:), G%Domain)
     call set_up_sponge_field(tmp, tv%S, G, nz, CSp)
   elseif (use_temperature) then
-    call set_up_ALE_sponge_field(filename, potemp_var, Time, G, tv%T, ALE_CSp)
-    call set_up_ALE_sponge_field(filename, salin_var, Time, G, tv%S, ALE_CSp)
+    call set_up_ALE_sponge_field(filename, potemp_var, Time, G, GV, tv%T, ALE_CSp)
+    call set_up_ALE_sponge_field(filename, salin_var, Time, G, GV, tv%S, ALE_CSp)
   endif
 
 end subroutine initialize_sponges_file
@@ -2089,16 +2089,17 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
   ! value at the northernmost/southernmost latitude.
 
   call horiz_interp_and_extrap_tracer(tfilename, potemp_var, 1.0, 1, &
-       G, temp_z, mask_z, z_in, z_edges_in, missing_value_temp, reentrant_x, tripolar_n, homogenize)
+       G, temp_z, mask_z, z_in, z_edges_in, missing_value_temp, reentrant_x, &
+       tripolar_n, homogenize, m_to_Z=GV%m_to_Z)
 
   call horiz_interp_and_extrap_tracer(sfilename, salin_var, 1.0, 1, &
-       G, salt_z, mask_z, z_in, z_edges_in, missing_value_salt, reentrant_x, tripolar_n, homogenize)
+       G, salt_z, mask_z, z_in, z_edges_in, missing_value_salt, reentrant_x, &
+       tripolar_n, homogenize, m_to_Z=GV%m_to_Z)
 
   kd = size(z_in,1)
 
-  ! Convert the units and sign convention of z_in and Z_edges_in.
-  do k=1,kd ; z_in(k) = GV%m_to_Z*z_in(k) ; enddo
-  do k=1,size(Z_edges_in,1) ; Z_edges_in(k) = -GV%m_to_Z*Z_edges_in(k) ; enddo
+  ! Convert the sign convention of Z_edges_in.
+  do k=1,size(Z_edges_in,1) ; Z_edges_in(k) = -Z_edges_in(k) ; enddo
 
   allocate(rho_z(isd:ied,jsd:jed,kd))
   allocate(area_shelf_h(isd:ied,jsd:jed))

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2184,12 +2184,12 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 
     ! Build the target grid (and set the model thickness to it)
     ! This call can be more general but is hard-coded for z* coordinates...  ????
-    call ALE_initRegridding( GV, GV%Z_to_m*G%max_depth, PF, mdl, regridCS ) ! sets regridCS
+    call ALE_initRegridding( GV, G%max_depth, PF, mdl, regridCS ) ! sets regridCS
 
     if (.not. remap_general) then
       ! This is the old way of initializing to z* coordinates only
       allocate( hTarget(nz) )
-      hTarget = GV%m_to_Z * getCoordinateResolution( regridCS )
+      hTarget = getCoordinateResolution( regridCS )
       do j = js, je ; do i = is, ie
         h(i,j,:) = 0.
         if (G%mask2dT(i,j)>0.) then

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -120,10 +120,10 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
   if (PRESENT(src_var_unit_conversion)) convert = src_var_unit_conversion
 
   call horiz_interp_and_extrap_tracer(src_file, src_var_nam, convert, recnum, &
-       G, tr_z, mask_z, z_in, z_edges_in, missing_value, reentrant_x, tripolar_n, homog)
+       G, tr_z, mask_z, z_in, z_edges_in, missing_value, reentrant_x, tripolar_n, &
+       homog, m_to_Z=GV%m_to_Z)
 
   kd = size(z_edges_in,1)-1
-  do k=1,kd+1 ; z_edges_in(k) = GV%m_to_Z*z_edges_in(k) ; enddo
   call pass_var(tr_z,G%Domain)
   call pass_var(mask_z,G%Domain)
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1015,7 +1015,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     call cpu_clock_begin(id_clock_sponge)
     if (associated(CS%ALE_sponge_CSp)) then
       ! ALE sponge
-      call apply_ALE_sponge(h, dt, G, CS%ALE_sponge_CSp, CS%Time)
+      call apply_ALE_sponge(h, dt, G, GV, CS%ALE_sponge_CSp, CS%Time)
     endif
 
     call cpu_clock_end(id_clock_sponge)
@@ -2174,7 +2174,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     call cpu_clock_begin(id_clock_sponge)
     if (associated(CS%ALE_sponge_CSp)) then
       ! ALE sponge
-      call apply_ALE_sponge(h, dt, G, CS%ALE_sponge_CSp, CS%Time)
+      call apply_ALE_sponge(h, dt, G, GV, CS%ALE_sponge_CSp, CS%Time)
     else
       ! Layer mode sponge
       if (CS%bulkmixedlayer .and. associated(tv%eqn_of_state)) then

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1307,7 +1307,6 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
   if (CS%debug_energy_req) &
     call diapyc_energy_req_test(h, dt, tv, G, GV, CS%diapyc_en_rec_CSp)
 
-
   call cpu_clock_begin(id_clock_set_diffusivity)
   call set_BBL_TKE(u, v, h, fluxes, visc, G, GV, CS%set_diff_CSp)
   call cpu_clock_end(id_clock_set_diffusivity)
@@ -3327,7 +3326,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
   call regularize_layers_init(Time, G, GV, param_file, diag, CS%regularize_layers_CSp)
 
   if (CS%debug_energy_req) &
-    call diapyc_energy_req_init(Time, G, param_file, diag, CS%diapyc_en_rec_CSp)
+    call diapyc_energy_req_init(Time, G, GV, param_file, diag, CS%diapyc_en_rec_CSp)
 
   ! obtain information about the number of bands for penetrative shortwave
   if (use_temperature) then

--- a/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
+++ b/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
@@ -44,8 +44,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
   type(ocean_grid_type),          intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type),        intent(in)    :: GV   !< The ocean's vertical grid structure.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,GV%ke), &
-                                  intent(in)    :: h_3d !< Layer thickness before entrainment,
-                                                        !! in m or kg m-2.
+                                  intent(in)    :: h_3d !< Layer thickness before entrainment, in H.
   type(thermo_var_ptrs),          intent(inout) :: tv   !< A structure containing pointers to any
                                                         !! available thermodynamic fields.
                                                         !! Absent fields have NULL ptrs.
@@ -60,7 +59,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
     T0, S0, &   ! T0 & S0 are columns of initial temperatures and salinities, in degC and g/kg.
     h_col       ! h_col is a column of thicknesses h at tracer points, in H (m or kg m-2).
   real, dimension(GV%ke+1) :: &
-    Kd, &       ! A column of diapycnal diffusivities at interfaces, in m2 s-1.
+    Kd, &       ! A column of diapycnal diffusivities at interfaces, in Z2 s-1.
     h_top, h_bot ! Distances from the top or bottom, in H.
   real :: ustar, absf, htot
   real :: energy_Kd ! The energy used by diapycnal mixing in W m-2.
@@ -75,7 +74,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
 !$OMP do
   do j=js,je ; do i=is,ie ; if (G%mask2dT(i,j) > 0.5) then
     if (present(Kd_int) .and. .not.CS%use_test_Kh_profile) then
-      do k=1,nz+1 ; Kd(K) = CS%test_Kh_scaling*GV%Z_to_m**2*Kd_int(i,j,K) ; enddo
+      do k=1,nz+1 ; Kd(K) = CS%test_Kh_scaling*Kd_int(i,j,K) ; enddo
     else
       htot = 0.0 ; h_top(1) = 0.0
       do k=1,nz
@@ -95,7 +94,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
       Kd(1) = 0.0 ; Kd(nz+1) = 0.0
       do K=2,nz
         tmp1 = h_top(K) * h_bot(K) * GV%H_to_Z
-        Kd(K) = CS%test_Kh_scaling * GV%Z_to_m**2 * &
+        Kd(K) = CS%test_Kh_scaling *  &
                 ustar * 0.41 * (tmp1*ustar) / (absf*tmp1 + htot*ustar)
       enddo
     endif
@@ -121,9 +120,8 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
   real, dimension(GV%ke),   intent(in)    :: T_in !< The layer temperatures, in degC.
   real, dimension(GV%ke),   intent(in)    :: S_in !< The layer salinities, in g kg-1.
   real, dimension(GV%ke+1), intent(in)    :: Kd   !< The interfaces diapycnal diffusivities,
-                                                  !! in m2 s-1.
-  real,                     intent(in)    :: dt   !< The amount of time covered by this call,
-                                                  !! in s.
+                                                  !! in Z2 s-1.
+  real,                     intent(in)    :: dt   !< The amount of time covered by this call, in s.
   real,                     intent(out)   :: energy_Kd !< The column-integrated rate of energy
                                                   !! consumption by diapycnal diffusion, in W m-2.
   type(thermo_var_ptrs),    intent(inout) :: tv   !< A structure containing pointers to any
@@ -147,8 +145,8 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     dSV_dS, &   ! Partial derivative of specific volume with salinity, in m3 kg-1 / (g kg-1).
     T0, S0, &   ! Initial temperatures and salinities.
     Te, Se, &   ! Running incomplete estimates of the new temperatures and salinities.
-    Te_a, Se_a, &   ! Running incomplete estimates of the new temperatures and salinities.
-    Te_b, Se_b, &   ! Running incomplete estimates of the new temperatures and salinities.
+    Te_a, Se_a, & ! Running incomplete estimates of the new temperatures and salinities.
+    Te_b, Se_b, & ! Running incomplete estimates of the new temperatures and salinities.
     Tf, Sf, &   ! New final values of the temperatures and salinities.
     dTe, dSe, & ! Running (1-way) estimates of temperature and salinity change.
     dTe_a, dSe_a, & ! Running (1-way) estimates of temperature and salinity change.
@@ -156,21 +154,21 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     Th_a, &     !  An effective temperature times a thickness in the layer above,
                 !  including implicit mixing effects with other yet higher layers, in K H.
     Sh_a, &     !  An effective salinity times a thickness in the layer above,
-                !  including implicit mixing effects with other yet higher layers, in K H.
+                !  including implicit mixing effects with other yet higher layers, in ppt H.
     Th_b, &     !  An effective temperature times a thickness in the layer below,
                 !  including implicit mixing effects with other yet lower layers, in K H.
     Sh_b, &     !  An effective salinity times a thickness in the layer below,
-                !  including implicit mixing effects with other yet lower layers, in K H.
+                !  including implicit mixing effects with other yet lower layers, in ppt H.
     dT_to_dPE, & ! Partial derivative of column potential energy with the temperature
     dS_to_dPE, & ! and salinity changes within a layer, in J m-2 K-1 and J m-2 / (g kg-1).
     dT_to_dColHt, & ! Partial derivatives of the total column height with the temperature
-    dS_to_dColHt, & ! and salinity changes within a layer, in m K-1 and m ppt-1.
+    dS_to_dColHt, & ! and salinity changes within a layer, in Z K-1 and Z ppt-1.
     dT_to_dColHt_a, & ! Partial derivatives of the total column height with the temperature
     dS_to_dColHt_a, & ! and salinity changes within a layer, including the implicit effects
-                    ! of mixing with layers higher in the water colun, in m K-1 and m ppt-1.
+                    ! of mixing with layers higher in the water colun, in Z K-1 and Z ppt-1.
     dT_to_dColHt_b, & ! Partial derivatives of the total column height with the temperature
     dS_to_dColHt_b, & ! and salinity changes within a layer, including the implicit effects
-                    ! of mixing with layers lower in the water colun, in m K-1 and m ppt-1.
+                    ! of mixing with layers lower in the water colun, in Z K-1 and Z ppt-1.
     dT_to_dPE_a, &  ! Partial derivatives of column potential energy with the temperature
     dS_to_dPE_a, &  ! and salinity changes within a layer, including the implicit effects
                     ! of mixing with layers higher in the water column, in
@@ -191,14 +189,18 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
                 ! ensure positive definiteness, in m or kg m-2.
   real, dimension(GV%ke+1) :: &
     pres, &     ! Interface pressures in Pa.
-    z_Int, &    ! Interface heights relative to the surface, in m.
+    pres_Z, &   ! Interface pressures with a rescaling factor to convert interface height
+                ! movements into changes in column potential energy, in J m-2 Z-1.
+    z_Int, &    ! Interface heights relative to the surface, in H.
     N2, &       ! An estimate of the buoyancy frequency in s-2.
-    Kddt_h_a, & !
-    Kddt_h_b, & !
     Kddt_h, &   ! The diapycnal diffusivity times a timestep divided by the
-                ! average thicknesses around a layer, in m or kg m-2.
+                ! average thicknesses around a layer, in H (m or kg m-2).
+    Kddt_h_a, & ! The value of Kddt_h for layers above the central point in the
+                ! tridiagonal solver, in H.
+    Kddt_h_b, & ! The value of Kddt_h for layers below the central point in the
+                ! tridiagonal solver, in H.
     Kd_so_far   ! The value of Kddt_h that has been applied already in
-                ! calculating the energy changes, in m or kg m-2.
+                ! calculating the energy changes, in H (m or kg m-2).
   real, dimension(GV%ke+1,4) :: &
     PE_chg_k, &     ! The integrated potential energy change within a timestep due
                     ! to the diffusivity at interface K for 4 different orders of
@@ -206,14 +208,18 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     ColHt_cor_k     ! The correction to the potential energy change due to
                     ! changes in the net column height, in J m-2.
   real :: &
-    b1              ! b1 is used by the tridiagonal solver, in m-1 or m2 kg-1.
+    b1              ! b1 is used by the tridiagonal solver, in H-1.
   real :: &
-    I_b1            ! The inverse of b1, in m or kg m-2.
-  real :: Kd0, dKd
+    I_b1            ! The inverse of b1, in H.
+  real :: Kd0       ! The value of Kddt_h that has already been applied, in H.
+  real :: dKd       ! The change in the value of Kddt_h, in H.
   real :: h_neglect ! A thickness that is so small it is usually lost
-                    ! in roundoff and can be neglected, in m.
-  real :: dTe_term, dSe_term
-  real :: Kddt_h_guess
+                    ! in roundoff and can be neglected, in H.
+  real :: dTe_term  ! A diffusivity-independent term related to the temperature
+                    ! change in the layer below the interface, in K H.
+  real :: dSe_term  ! A diffusivity-independent term related to the salinity
+                    ! change in the layer below the interface, in ppt H.
+  real :: Kddt_h_guess ! A guess of the final value of Kddt_h, in H.
   real :: dMass     ! The mass per unit area within a layer, in kg m-2.
   real :: dPres     ! The hydrostatic pressure change across a layer, in Pa.
   real :: dMKE_max  ! The maximum amount of mean kinetic energy that could be
@@ -221,12 +227,13 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
                     ! the layer below an interface were homogenized with all of
                     ! the water above the interface, in J m-2 = kg s-2.
   real :: rho_here  ! The in-situ density, in kg m-3.
-  real :: PE_change, ColHt_cor
-  real :: htot
-  real :: dT_k, dT_km1, dS_k, dS_km1  ! Temporary arrays
-  real :: b1Kd                        ! Temporary arrays
-  real :: Kd_rat, Kdr_denom, I_Kdr_denom  ! Temporary arrays
-  real :: dTe_t2, dSe_t2, dT_km1_t2, dS_km1_t2, dT_k_t2, dS_k_t2
+  real :: PE_change ! The change in column potential energy from applying Kddt_h at the
+                    ! present interface, in J m-2.
+  real :: ColHt_cor ! The correction to PE_chg that is made due to a net
+                    ! change in the column height, in J m-2.
+  real :: htot      ! A running sum of thicknesses, in H.
+  real :: dTe_t2, dT_km1_t2, dT_k_t2  ! Temporary arrays describing temperature changes.
+  real :: dSe_t2, dS_km1_t2, dS_k_t2  ! Temporary arrays describing salinity changes.
   logical :: do_print
 
   ! The following are a bunch of diagnostic arrays for debugging purposes.
@@ -243,15 +250,12 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
   real :: PE_chg(6)
   real, dimension(6) :: dT_k_itt, dS_k_itt, dT_km1_itt, dS_km1_itt
 
-  real :: I_G_Earth
-  real :: dKd_rat_dKd, ddT_k_dKd, ddS_k_dKd, ddT_km1_dKd, ddS_km1_dKd
   integer :: k, nz, itt, max_itt, k_cent
   logical :: surface_BL, bottom_BL, central, halves, debug
   logical :: old_PE_calc
   nz = G%ke
   h_neglect = GV%H_subroundoff
 
-  I_G_Earth = 1.0 / (GV%g_Earth*GV%m_to_Z)
   debug = .true.
 
   surface_BL = .true. ; bottom_BL = .true. ; halves = .true.
@@ -264,14 +268,15 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
   dPEb_dKd(:) = 0.0 ; dPEb_dKd_est(:) = 0.0 ; dPEb_dKd_err(:) = 0.0
   dPEb_dKd_err_norm(:) = 0.0 ; dPEb_dKd_trunc(:) = 0.0
 
-  htot = 0.0 ; pres(1) = 0.0 ; Z_int(1) = 0.0
+  htot = 0.0 ; pres(1) = 0.0 ; pres_Z(1) = 0.0 ; Z_int(1) = 0.0
   do k=1,nz
     T0(k) = T_in(k) ; S0(k) = S_in(k)
     h_tr(k) = h_in(k)
     htot = htot + h_tr(k)
     pres(K+1) = pres(K) + GV%H_to_Pa * h_tr(k)
+    pres_Z(K+1) = GV%Z_to_m * pres(K+1)
     p_lay(k) = 0.5*(pres(K) + pres(K+1))
-    Z_int(K+1) = Z_int(K) - GV%H_to_m * h_tr(k)
+    Z_int(K+1) = Z_int(K) - h_tr(k)
   enddo
   do k=1,nz
     h_tr(k) = max(h_tr(k), 1e-15*htot)
@@ -281,7 +286,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
 
   Kddt_h(1) = 0.0 ; Kddt_h(nz+1) = 0.0
   do K=2,nz
-    Kddt_h(K) = min((GV%m_to_H**2*dt)*Kd(k) / (0.5*(h_tr(k-1) + h_tr(k))),1e3*htot)
+    Kddt_h(K) = min((GV%Z_to_H**2*dt)*Kd(k) / (0.5*(h_tr(k-1) + h_tr(k))), 1e3*htot)
   enddo
 
   ! Solve the tridiagonal equations for new temperatures.
@@ -290,11 +295,11 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
 
   do k=1,nz
     dMass = GV%H_to_kg_m2 * h_tr(k)
-    dPres = (GV%g_Earth*GV%m_to_Z) * dMass
+    dPres = GV%H_to_Pa * h_tr(k)
     dT_to_dPE(k) = (dMass * (pres(K) + 0.5*dPres)) * dSV_dT(k)
     dS_to_dPE(k) = (dMass * (pres(K) + 0.5*dPres)) * dSV_dS(k)
-    dT_to_dColHt(k) = dMass * dSV_dT(k) * CS%ColHt_scaling
-    dS_to_dColHt(k) = dMass * dSV_dS(k) * CS%ColHt_scaling
+    dT_to_dColHt(k) = dMass * GV%m_to_Z * dSV_dT(k) * CS%ColHt_scaling
+    dS_to_dColHt(k) = dMass * GV%m_to_Z * dSV_dS(k) * CS%ColHt_scaling
   enddo
 
 !  PE_chg_k(1) = 0.0 ; PE_chg_k(nz+1) = 0.0
@@ -352,14 +357,14 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
         call find_PE_chg_orig(Kddt_h_guess, h_tr(k), hp_a(k-1), &
                          dTe_term, dSe_term, dT_km1_t2, dS_km1_t2, &
                          dT_to_dPE(k), dS_to_dPE(k), dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), &
-                         pres(K), dT_to_dColHt(k), dS_to_dColHt(k), &
+                         pres_Z(K), dT_to_dColHt(k), dS_to_dColHt(k), &
                          dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                          PE_chg_k(k,1), dPEa_dKd(k))
       else
         call find_PE_chg(0.0, Kddt_h_guess, hp_a(k-1), hp_b(k), &
                          Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                          dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                         pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                         pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                          dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                          PE_chg=PE_chg_k(K,1), dPEc_dKd=dPEa_dKd(K), &
                          ColHt_cor=ColHt_cor_k(K,1))
@@ -373,14 +378,14 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
             call find_PE_chg_orig(Kddt_h_guess, h_tr(k), hp_a(k-1), &
                              dTe_term, dSe_term, dT_km1_t2, dS_km1_t2, &
                              dT_to_dPE(k), dS_to_dPE(k), dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), &
-                             pres(K), dT_to_dColHt(k), dS_to_dColHt(k), &
+                             pres_Z(K), dT_to_dColHt(k), dS_to_dColHt(k), &
                              dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                              PE_chg=PE_chg(itt))
           else
             call find_PE_chg(0.0, Kddt_h_guess, hp_a(k-1), hp_b(k), &
                              Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                              dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                             pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                             pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                              dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                              PE_chg=PE_chg(itt))
           endif
@@ -497,14 +502,14 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
         call find_PE_chg_orig(Kddt_h_guess, h_tr(k-1), hp_b(k), &
                          dTe_term, dSe_term, dT_k_t2, dS_k_t2, &
                          dT_to_dPE(k-1), dS_to_dPE(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                         pres(K), dT_to_dColHt(k-1), dS_to_dColHt(k-1), &
+                         pres_Z(K), dT_to_dColHt(k-1), dS_to_dColHt(k-1), &
                          dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                          PE_chg=PE_chg_k(K,2), dPEc_dKd=dPEb_dKd(K))
       else
         call find_PE_chg(0.0, Kddt_h_guess, hp_a(k-1), hp_b(k), &
                          Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                          dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                         pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                         pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                          dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                          PE_chg=PE_chg_k(K,2), dPEc_dKd=dPEb_dKd(K), &
                          ColHt_cor=ColHt_cor_k(K,2))
@@ -519,14 +524,14 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
             call find_PE_chg_orig(Kddt_h_guess, h_tr(k-1), hp_b(k), &
                            dTe_term, dSe_term, dT_k_t2, dS_k_t2, &
                            dT_to_dPE(k-1), dS_to_dPE(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                           pres(K), dT_to_dColHt(k-1), dS_to_dColHt(k-1), &
+                           pres_Z(K), dT_to_dColHt(k-1), dS_to_dColHt(k-1), &
                            dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                            PE_chg=PE_chg(itt))
           else
             call find_PE_chg(0.0, Kddt_h_guess, hp_a(k-1), hp_b(k), &
                              Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                              dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                             pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                             pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                              dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                              PE_chg=PE_chg(itt))
           endif
@@ -618,15 +623,13 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
       endif
       Th_b(k) = h_tr(k) * T0(k) ; Sh_b(k) = h_tr(k) * S0(k)
 
-      Kddt_h_a(K) = 0.0
-      if (K < K_cent) Kddt_h_a(K) = Kddt_h(K)
-
+      Kddt_h_a(K) = 0.0 ; if (K < K_cent) Kddt_h_a(K) = Kddt_h(K)
       dKd = Kddt_h_a(K)
 
       call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                        Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                        dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                       pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                       pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                        dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                        PE_chg=PE_change, ColHt_cor=ColHt_cor)
       PE_chg_k(K,3) = PE_change
@@ -673,7 +676,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
       call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                        Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                        dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                       pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                       pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                        dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                        PE_chg=PE_change, ColHt_cor=ColHt_cor)
       PE_chg_k(K,3) = PE_chg_k(K,3) + PE_change
@@ -720,7 +723,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                      Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                      dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                     pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                     pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                      dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                      PE_chg=PE_change, ColHt_cor=ColHt_cor)
     PE_chg_k(K,3) = PE_chg_k(K,3) + PE_change
@@ -805,7 +808,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
       call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                        Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                        dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                       pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                       pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                        dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                        PE_chg=PE_change, ColHt_cor=ColHt_cor)
 
@@ -853,7 +856,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
       call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                        Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                        dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                       pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                       pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                        dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                        PE_chg=PE_change, ColHt_cor=ColHt_cor)
 
@@ -914,9 +917,9 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     if (CS%id_ERb>0) call post_data(CS%id_ERb, PE_chg_k(:,2), CS%diag)
     if (CS%id_ERc>0) call post_data(CS%id_ERc, PE_chg_k(:,3), CS%diag)
     if (CS%id_ERh>0) call post_data(CS%id_ERh, PE_chg_k(:,4), CS%diag)
-    if (CS%id_Kddt>0) call post_data(CS%id_Kddt, GV%H_to_m*Kddt_h, CS%diag)
-    if (CS%id_Kd>0)   call post_data(CS%id_Kd, Kd, CS%diag)
-    if (CS%id_h>0)    call post_data(CS%id_h, GV%H_to_m*h_tr, CS%diag)
+    if (CS%id_Kddt>0) call post_data(CS%id_Kddt, Kddt_h, CS%diag)
+    if (CS%id_Kd>0)   call post_data(CS%id_Kd,   Kd, CS%diag)
+    if (CS%id_h>0)    call post_data(CS%id_h,    h_tr, CS%diag)
     if (CS%id_zInt>0) call post_data(CS%id_zInt, Z_int, CS%diag)
     if (CS%id_CHCt>0) call post_data(CS%id_CHCt, ColHt_cor_k(:,1), CS%diag)
     if (CS%id_CHCb>0) call post_data(CS%id_CHCb, ColHt_cor_k(:,2), CS%diag)
@@ -956,7 +959,7 @@ end subroutine diapyc_energy_req_calc
 !! for several changes in an interfaces's diapycnal diffusivity times a timestep.
 subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
                        dT_to_dPE_a, dS_to_dPE_a, dT_to_dPE_b, dS_to_dPE_b, &
-                       pres, dT_to_dColHt_a, dS_to_dColHt_a, dT_to_dColHt_b, dS_to_dColHt_b, &
+                       pres_Z, dT_to_dColHt_a, dS_to_dColHt_a, dT_to_dColHt_b, dS_to_dColHt_b, &
                        PE_chg, dPEc_dKd, dPE_max, dPEc_dKd_0, ColHt_cor)
   real, intent(in)  :: Kddt_h0  !< The previously used diffusivity at an interface times
                                 !! the time step and  divided by the average of the
@@ -1000,25 +1003,25 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
                                 !! a layer's salinity change to the change in column
                                 !! potential energy, including all implicit diffusive changes
                                 !! in the salinities of all the layers below, in J m-2 ppt-1.
-  real, intent(in)  :: pres     !< The hydrostatic interface pressure, which is used to relate
+  real, intent(in)  :: pres_Z   !< The hydrostatic interface pressure, which is used to relate
                                 !! the changes in column thickness to the energy that is radiated
-                                !! as gravity waves and unavailable to drive mixing, in Pa.
+                                !! as gravity waves and unavailable to drive mixing, in J m-2 Z-1.
   real, intent(in)  :: dT_to_dColHt_a !< A factor (mass_lay*dSColHtc_vol/dT) relating
                                 !! a layer's temperature change to the change in column
                                 !! height, including all implicit diffusive changes
-                                !! in the temperatures of all the layers above, in m K-1.
+                                !! in the temperatures of all the layers above, in Z K-1.
   real, intent(in)  :: dS_to_dColHt_a !< A factor (mass_lay*dSColHtc_vol/dS) relating
                                 !! a layer's salinity change to the change in column
                                 !! height, including all implicit diffusive changes
-                                !! in the salinities of all the layers above, in m ppt-1.
+                                !! in the salinities of all the layers above, in Z ppt-1.
   real, intent(in)  :: dT_to_dColHt_b !< A factor (mass_lay*dSColHtc_vol/dT) relating
                                 !! a layer's temperature change to the change in column
                                 !! height, including all implicit diffusive changes
-                                !! in the temperatures of all the layers below, in m K-1.
+                                !! in the temperatures of all the layers below, in Z K-1.
   real, intent(in)  :: dS_to_dColHt_b !< A factor (mass_lay*dSColHtc_vol/dS) relating
                                 !! a layer's salinity change to the change in column
                                 !! height, including all implicit diffusive changes
-                                !! in the salinities of all the layers below, in m ppt-1.
+                                !! in the salinities of all the layers below, in Z ppt-1.
 
   real, optional, intent(out) :: PE_chg   !< The change in column potential energy from applying
                                           !! Kddt_h at the present interface, in J m-2.
@@ -1066,11 +1069,11 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
     y1 = dKddt_h / (bdt1 * (bdt1 + dKddt_h * hps))
     PE_chg = PEc_core * y1
     ColHt_chg = ColHt_core * y1
-    if (ColHt_chg < 0.0) PE_chg = PE_chg - pres * ColHt_chg
-    if (present(ColHt_cor)) ColHt_cor = -pres * min(ColHt_chg, 0.0)
+    if (ColHt_chg < 0.0) PE_chg = PE_chg - pres_Z * ColHt_chg
+    if (present(ColHt_cor)) ColHt_cor = -pres_Z * min(ColHt_chg, 0.0)
   elseif (present(ColHt_cor)) then
     y1 = dKddt_h / (bdt1 * (bdt1 + dKddt_h * hps))
-    ColHt_cor = -pres * min(ColHt_core * y1, 0.0)
+    ColHt_cor = -pres_Z * min(ColHt_core * y1, 0.0)
   endif
 
   if (present(dPEc_dKd)) then
@@ -1078,7 +1081,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
     y1 = 1.0 / (bdt1 + dKddt_h * hps)**2
     dPEc_dKd = PEc_core * y1
     ColHt_chg = ColHt_core * y1
-    if (ColHt_chg < 0.0) dPEc_dKd = dPEc_dKd - pres * ColHt_chg
+    if (ColHt_chg < 0.0) dPEc_dKd = dPEc_dKd - pres_Z * ColHt_chg
   endif
 
   if (present(dPE_max)) then
@@ -1086,7 +1089,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
     y1 = 1.0 / (bdt1 * hps)
     dPE_max = PEc_core * y1
     ColHt_chg = ColHt_core * y1
-    if (ColHt_chg < 0.0) dPE_max = dPE_max - pres * ColHt_chg
+    if (ColHt_chg < 0.0) dPE_max = dPE_max - pres_Z * ColHt_chg
   endif
 
   if (present(dPEc_dKd_0)) then
@@ -1094,7 +1097,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
     y1 = 1.0 / bdt1**2
     dPEc_dKd_0 = PEc_core * y1
     ColHt_chg = ColHt_core * y1
-    if (ColHt_chg < 0.0) dPEc_dKd_0 = dPEc_dKd_0 - pres * ColHt_chg
+    if (ColHt_chg < 0.0) dPEc_dKd_0 = dPEc_dKd_0 - pres_Z * ColHt_chg
   endif
 
 end subroutine find_PE_chg
@@ -1105,7 +1108,7 @@ end subroutine find_PE_chg
 !! using the original form used in the first version of ePBL.
 subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
                             dT_km1_t2, dS_km1_t2, dT_to_dPE_k, dS_to_dPE_k, &
-                            dT_to_dPEa, dS_to_dPEa, pres, dT_to_dColHt_k, &
+                            dT_to_dPEa, dS_to_dPEa, pres_Z, dT_to_dColHt_k, &
                             dS_to_dColHt_k, dT_to_dColHta, dS_to_dColHta, &
                             PE_chg, dPEc_dKd, dPE_max, dPEc_dKd_0)
   real, intent(in)  :: Kddt_h   !< The diffusivity at an interface times the time step and
@@ -1124,9 +1127,9 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
                                  !! temperature change in the layer above the interface, in K.
   real, intent(in)  :: dS_km1_t2 !< A diffusivity-independent term related to the
                                  !! salinity change in the layer above the interface, in ppt.
-  real, intent(in)  :: pres      !< The hydrostatic interface pressure, which is used to relate
+  real, intent(in)  :: pres_Z    !< The hydrostatic interface pressure, which is used to relate
                                  !! the changes in column thickness to the energy that is radiated
-                                 !! as gravity waves and unavailable to drive mixing, in Pa.
+                                 !! as gravity waves and unavailable to drive mixing, in J m-2 Z-1.
   real, intent(in)  :: dT_to_dPE_k !< A factor (pres_lay*mass_lay*dSpec_vol/dT) relating
                                  !! a layer's temperature change to the change in column
                                  !! potential energy, including all implicit diffusive changes
@@ -1146,19 +1149,19 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
   real, intent(in)  :: dT_to_dColHt_k !< A factor (mass_lay*dSColHtc_vol/dT) relating
                                  !! a layer's temperature change to the change in column
                                  !! height, including all implicit diffusive changes
-                                 !! in the temperatures of all the layers below, in m K-1.
+                                 !! in the temperatures of all the layers below, in Z K-1.
   real, intent(in)  :: dS_to_dColHt_k !< A factor (mass_lay*dSColHtc_vol/dS) relating
                                  !! a layer's salinity change to the change in column
                                  !! height, including all implicit diffusive changes
-                                 !! in the salinities of all the layers below, in m ppt-1.
+                                 !! in the salinities of all the layers below, in Z ppt-1.
   real, intent(in)  :: dT_to_dColHta !< A factor (mass_lay*dSColHtc_vol/dT) relating
                                  !! a layer's temperature change to the change in column
                                  !! height, including all implicit diffusive changes
-                                 !! in the temperatures of all the layers above, in m K-1.
+                                 !! in the temperatures of all the layers above, in Z K-1.
   real, intent(in)  :: dS_to_dColHta !< A factor (mass_lay*dSColHtc_vol/dS) relating
                                  !! a layer's salinity change to the change in column
                                  !! height, including all implicit diffusive changes
-                                 !! in the salinities of all the layers above, in m ppt-1.
+                                 !! in the salinities of all the layers above, in Z ppt-1.
 
   real, optional, intent(out) :: PE_chg   !< The change in column potential energy from applying
                                           !! Kddt_h at the present interface, in J m-2.
@@ -1213,7 +1216,7 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
              (dS_to_dPE_k * dS_k + dS_to_dPEa * dS_km1)
     ColHt_chg = (dT_to_dColHt_k * dT_k + dT_to_dColHta * dT_km1) + &
                 (dS_to_dColHt_k * dS_k + dS_to_dColHta * dS_km1)
-    if (ColHt_chg < 0.0) PE_chg = PE_chg - pres * ColHt_chg
+    if (ColHt_chg < 0.0) PE_chg = PE_chg - pres_Z * ColHt_chg
   endif
 
   if (present(dPEc_dKd)) then
@@ -1230,7 +1233,7 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
                (dS_to_dPE_k * ddS_k_dKd + dS_to_dPEa * ddS_km1_dKd)
     dColHt_dKd = (dT_to_dColHt_k * ddT_k_dKd + dT_to_dColHta * ddT_km1_dKd) + &
                  (dS_to_dColHt_k * ddS_k_dKd + dS_to_dColHta * ddS_km1_dKd)
-    if (dColHt_dKd < 0.0) dPEc_dKd = dPEc_dKd - pres * dColHt_dKd
+    if (dColHt_dKd < 0.0) dPEc_dKd = dPEc_dKd - pres_Z * dColHt_dKd
   endif
 
   if (present(dPE_max)) then
@@ -1241,7 +1244,7 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
     dColHt_max = (dT_to_dColHta * dT_km1_t2 + dS_to_dColHta * dS_km1_t2) + &
               ((dT_to_dColHt_k + dT_to_dColHta) * dTe_term + &
                (dS_to_dColHt_k + dS_to_dColHta) * dSe_term) / (b_den_1 + h_k)
-    if (dColHt_max < 0.0) dPE_max = dPE_max - pres*dColHt_max
+    if (dColHt_max < 0.0) dPE_max = dPE_max - pres_Z*dColHt_max
   endif
 
   if (present(dPEc_dKd_0)) then
@@ -1250,15 +1253,16 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
                  (dT_to_dPE_k * dTe_term + dS_to_dPE_k * dSe_term) / (h_k*b_den_1)
     dColHt_dKd = (dT_to_dColHta * dT_km1_t2 + dS_to_dColHta * dS_km1_t2) / (b_den_1) + &
                  (dT_to_dColHt_k * dTe_term + dS_to_dColHt_k * dSe_term) / (h_k*b_den_1)
-    if (dColHt_dKd < 0.0) dPEc_dKd_0 = dPEc_dKd_0 - pres*dColHt_dKd
+    if (dColHt_dKd < 0.0) dPEc_dKd_0 = dPEc_dKd_0 - pres_Z*dColHt_dKd
   endif
 
 end subroutine find_PE_chg_orig
 
 !> Initialize parameters and allocate memory associated with the diapycnal energy requirement module.
-subroutine diapyc_energy_req_init(Time, G, param_file, diag, CS)
+subroutine diapyc_energy_req_init(Time, G, GV, param_file, diag, CS)
   type(time_type),            intent(in)    :: Time        !< model time
   type(ocean_grid_type),      intent(in)    :: G           !< model grid structure
+  type(verticalGrid_type),    intent(in)    :: GV          !< ocean vertical grid structure
   type(param_file_type),      intent(in)    :: param_file  !< file to parse for parameter values
   type(diag_ctrl),    target, intent(inout) :: diag        !< structure to regulate diagnostic output
   type(diapyc_energy_req_CS), pointer       :: CS          !< module control structure
@@ -1297,13 +1301,13 @@ subroutine diapyc_energy_req_init(Time, G, param_file, diag, CS)
   CS%id_ERh = register_diag_field('ocean_model', 'EnReqTest_ERh', diag%axesZi, Time, &
                  "Diffusivity Energy Requirements, halves", "J m-2")
   CS%id_Kddt = register_diag_field('ocean_model', 'EnReqTest_Kddt', diag%axesZi, Time, &
-                 "Implicit diffusive coupling coefficient", "m")
+                 "Implicit diffusive coupling coefficient", "m", conversion=GV%H_to_m)
   CS%id_Kd = register_diag_field('ocean_model', 'EnReqTest_Kd', diag%axesZi, Time, &
-                 "Diffusivity in test", "m2 s-1")
+                 "Diffusivity in test", "m2 s-1", conversion=GV%Z_to_m**2)
   CS%id_h   = register_diag_field('ocean_model', 'EnReqTest_h_lay', diag%axesZL, Time, &
-                 "Test column layer thicknesses", "m")
+                 "Test column layer thicknesses", "m", conversion=GV%H_to_m)
   CS%id_zInt   = register_diag_field('ocean_model', 'EnReqTest_z_int', diag%axesZi, Time, &
-                 "Test column layer interface heights", "m")
+                 "Test column layer interface heights", "m", conversion=GV%H_to_m)
   CS%id_CHCt = register_diag_field('ocean_model', 'EnReqTest_CHCt', diag%axesZi, Time, &
                  "Column Height Correction to Energy Requirements, top-down", "J m-2")
   CS%id_CHCb = register_diag_field('ocean_model', 'EnReqTest_CHCb', diag%axesZi, Time, &

--- a/src/user/Idealized_Hurricane.F90
+++ b/src/user/Idealized_Hurricane.F90
@@ -268,8 +268,8 @@ subroutine idealized_hurricane_wind_forcing(state, forces, day, G, CS)
         YY = YC + CS%dy_from_center
         XX = XC
       else
-        LAT = G%geoLatCu(I,j)*1000. !KM_to_m
-        LON = G%geoLonCu(I,j)*1000. !KM_to_m
+        LAT = G%geoLatCu(I,j)*1000. ! Convert Lat from km to m.
+        LON = G%geoLonCu(I,j)*1000. ! Convert Lon from km to m.
         YY = LAT - YC
         XX = LON - XC
       endif
@@ -291,13 +291,12 @@ subroutine idealized_hurricane_wind_forcing(state, forces, day, G, CS)
         YY = YC + CS%dy_from_center
         XX = XC
       else
-        LAT = G%geoLatCv(i,J)*1000. !KM_to_m
-        LON = G%geoLonCv(i,J)*1000. !KM_to_m
+        LAT = G%geoLatCv(i,J)*1000. ! Convert Lat from km to m.
+        LON = G%geoLonCv(i,J)*1000. ! Convert Lon from km to m.
         YY = LAT - YC
         XX = LON - XC
       endif
-      call idealized_hurricane_wind_profile(&
-           CS,f,YY,XX,Uocn,Vocn,TX,TY)
+      call idealized_hurricane_wind_profile(CS, f, YY, XX, Uocn, Vocn, TX, TY)
       forces%tauy(i,J) = G%mask2dCv(i,J) * TY
     enddo
   enddo
@@ -316,7 +315,7 @@ subroutine idealized_hurricane_wind_forcing(state, forces, day, G, CS)
 end subroutine idealized_hurricane_wind_forcing
 
 !> Calculate the wind speed at a location as a function of time.
-subroutine idealized_hurricane_wind_profile(CS,absf,YY,XX,UOCN,VOCN,Tx,Ty)
+subroutine idealized_hurricane_wind_profile(CS, absf, YY, XX, UOCN, VOCN, Tx, Ty)
   ! Author: Brandon Reichl
   ! Date: Nov-20-2014
   !       Aug-14-2018 Generalized for non-SCM configuration
@@ -436,8 +435,8 @@ subroutine idealized_hurricane_wind_profile(CS,absf,YY,XX,UOCN,VOCN,Tx,Ty)
   endif
 
   ! Compute stress vector
-  TX = CS%rho_A * Cd * sqrt(du**2+dV**2) * dU
-  TY = CS%rho_A * Cd * sqrt(du**2+dV**2) * dV
+  TX = CS%rho_A * Cd * sqrt(du**2 + dV**2) * dU
+  TY = CS%rho_A * Cd * sqrt(du**2 + dV**2) * dV
 
   return
 end subroutine idealized_hurricane_wind_profile


### PR DESCRIPTION
  Added rescaling of vertical heights in most of the remaining modules from
units of m into Z for expanded dimensional consistency testing.  All answers are
bitwise identical and no parameter_doc files are changed by these
modifications.  The list of commits in this PR include:
- NOAA-GFDL/MOM6@284591f Calculate height-related diagnostics in Z
- NOAA-GFDL/MOM6@0948407 Set coord_adapt and coord_slight parameters in H
- NOAA-GFDL/MOM6@989b12c Corrected comments in build_zlike_column
- NOAA-GFDL/MOM6@ac5ff38 +Pass max_depth to initialize_regridding in Z
- NOAA-GFDL/MOM6@7853e83 Corrected comments in build_sigma_column
- NOAA-GFDL/MOM6@618c475 Combined scaling factors in build_adapt_column
- NOAA-GFDL/MOM6@7037258 Clarified comments in Idealized_Hurricane
- NOAA-GFDL/MOM6@9015a89 +Recast MOM_diag_to_Z to work in units of Z
- NOAA-GFDL/MOM6@b3e712b +Recast MOM_ALE_sponge to work in units of Z
- NOAA-GFDL/MOM6@4863472 +Added m_to_Z arg to horiz_interp_and_extrap_tracer
- NOAA-GFDL/MOM6@3034a4c Find energetic_PBL column height changes in Z
- NOAA-GFDL/MOM6@abcf214 +Find diapyc_energy_req column height changes in Z
- NOAA-GFDL/MOM6@ea8ed3e Use local variables to rescale in MOM_Point_Accel
- NOAA-GFDL/MOM6@b008d92 Recast MOM_sum_output to work in units of Z
- NOAA-GFDL/MOM6@970f440 Simplify MOM_diagnostics code
- NOAA-GFDL/MOM6@fce22cb +Rescale depth inside of MEKE_lengthScales_0d
- NOAA-GFDL/MOM6@d3244d6 +Add conversion argument to register_static_field
- NOAA-GFDL/MOM6@368848f Rescale values reported by PointAccel
