### PR TITLE
Use unit scaling type

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -43,6 +43,7 @@ use MOM_time_manager, only : operator(<=), operator(>=), operator(<)
 use MOM_time_manager, only : real_to_time, time_type_to_real
 use MOM_tracer_flow_control, only : call_tracer_register, tracer_flow_control_init
 use MOM_tracer_flow_control, only : call_tracer_flux_init
+use MOM_unit_scaling,    only : unit_scale_type
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_ice_shelf, only : initialize_ice_shelf, shelf_calc_flux, ice_shelf_CS
@@ -190,6 +191,9 @@ type, public :: ocean_state_type ; private
   type(verticalGrid_type), pointer :: &
     GV => NULL()              !< A pointer to a structure containing information
                               !! about the vertical grid.
+  type(unit_scale_type), pointer :: &
+    US => NULL()              !< A pointer to a structure containing dimensional
+                              !! unit scaling factors.
   type(MOM_control_struct), pointer :: &
     MOM_CSp => NULL()         !< A pointer to the MOM control structure
   type(ice_shelf_CS), pointer :: &
@@ -266,7 +270,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &
                       OS%restart_CSp, Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       diag_ptr=OS%diag, count_calls=.true.)
-  call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, C_p=OS%C_p, &
+  call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%C_p, &
                               use_temp=use_temperature)
   OS%fluxes%C_p = OS%C_p
 
@@ -367,7 +371,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
   call get_param(param_file, mdl, "USE_WAVES", OS%Use_Waves, &
        "If true, enables surface wave modules.", default=.false.)
   if (OS%use_waves) then
-    call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, param_file, OS%Waves, OS%diag)
+    call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
   else
     call MOM_wave_interface_init_lite(param_file)
   endif
@@ -552,7 +556,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
     ! For now, the waves are only updated on the thermodynamics steps, because that is where
     ! the wave intensities are actually used to drive mixing.  At some point, the wave updates
     ! might also need to become a part of the ocean dynamics, according to B. Reichl.
-    call Update_Surface_Waves(OS%grid, OS%GV, OS%time, ocean_coupling_time_step, OS%waves)
+    call Update_Surface_Waves(OS%grid, OS%GV, OS%US, OS%time, ocean_coupling_time_step, OS%waves)
   endif
 
   if ((OS%nstep==0) .and. (OS%nstep_thermo==0)) then ! This is the first call to update_ocean_model.

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -228,9 +228,10 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
 end subroutine ALE_init
 
 !> Initialize diagnostics for the ALE module.
-subroutine ALE_register_diags(Time, G, GV, diag, CS)
+subroutine ALE_register_diags(Time, G, GV, US, diag, CS)
   type(time_type),target,     intent(in)  :: Time  !< Time structure
   type(ocean_grid_type),      intent(in)  :: G     !< Grid structure
+  type(unit_scale_type),      intent(in)  :: US    !< A dimensional unit scaling type
   type(verticalGrid_type),    intent(in)  :: GV    !< Ocean vertical grid structure
   type(diag_ctrl), target,    intent(in)  :: diag  !< Diagnostics control structure
   type(ALE_CS), pointer                   :: CS    !< Module control structure
@@ -250,7 +251,7 @@ subroutine ALE_register_diags(Time, G, GV, diag, CS)
   CS%id_S_preale = register_diag_field('ocean_model', 'S_preale', diag%axesTL, Time, &
       'Salinity before remapping', 'PSU')
   CS%id_e_preale = register_diag_field('ocean_model', 'e_preale', diag%axesTi, Time, &
-      'Interface Heights before remapping', 'm', conversion=GV%Z_to_m)
+      'Interface Heights before remapping', 'm', conversion=US%Z_to_m)
 
   CS%id_dzRegrid = register_diag_field('ocean_model','dzRegrid',diag%axesTi,Time, &
       'Change in interface height due to ALE regridding', 'm')

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -42,6 +42,7 @@ use MOM_remapping,        only : remappingSchemesDoc, remappingDefaultScheme
 use MOM_remapping,        only : remapping_CS, dzFromH1H2
 use MOM_string_functions, only : uppercase, extractWord, extract_integer
 use MOM_tracer_registry,  only : tracer_registry_type, tracer_type, MOM_tracer_chkinv
+use MOM_unit_scaling,     only : unit_scale_type
 use MOM_variables,        only : ocean_grid_type, thermo_var_ptrs
 use MOM_verticalGrid,     only : get_thickness_units, verticalGrid_type
 
@@ -125,9 +126,10 @@ contains
 !! before the main time integration loop to initialize the regridding stuff.
 !! We read the MOM_input file to register the values of different
 !! regridding/remapping parameters.
-subroutine ALE_init( param_file, GV, max_depth, CS)
+subroutine ALE_init( param_file, GV, US, max_depth, CS)
   type(param_file_type),   intent(in) :: param_file !< Parameter file
   type(verticalGrid_type), intent(in) :: GV         !< Ocean vertical grid structure
+  type(unit_scale_type),   intent(in) :: US         !< A dimensional unit scaling type
   real,                    intent(in) :: max_depth  !< The maximum depth of the ocean, in Z.
   type(ALE_CS),            pointer    :: CS         !< Module control structure
 
@@ -160,7 +162,7 @@ subroutine ALE_init( param_file, GV, max_depth, CS)
                  default=.true.)
 
   ! Initialize and configure regridding
-  call ALE_initRegridding( GV, max_depth, param_file, mdl, CS%regridCS)
+  call ALE_initRegridding(GV, US, max_depth, param_file, mdl, CS%regridCS)
 
   ! Initialize and configure remapping
   call get_param(param_file, mdl, "REMAPPING_SCHEME", string, &
@@ -293,9 +295,10 @@ end subroutine ALE_end
 !! the old grid and the new grid. The creation of the new grid can be based
 !! on z coordinates, target interface densities, sigma coordinates or any
 !! arbitrary coordinate system.
-subroutine ALE_main( G, GV, h, u, v, tv, Reg, CS, dt, frac_shelf_h)
+subroutine ALE_main( G, GV, US, h, u, v, tv, Reg, CS, dt, frac_shelf_h)
   type(ocean_grid_type),                      intent(in)    :: G   !< Ocean grid informations
   type(verticalGrid_type),                    intent(in)    :: GV  !< Ocean vertical grid structure
+  type(unit_scale_type),                      intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(inout) :: h   !< Current 3D grid obtained after the
                                                                    !! last time step in H (often m or Pa)
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(inout) :: u   !< Zonal velocity field (m/s)
@@ -328,7 +331,7 @@ subroutine ALE_main( G, GV, h, u, v, tv, Reg, CS, dt, frac_shelf_h)
   if (CS%id_T_preale > 0) call post_data(CS%id_T_preale, tv%T, CS%diag)
   if (CS%id_S_preale > 0) call post_data(CS%id_S_preale, tv%S, CS%diag)
   if (CS%id_e_preale > 0) then
-    call find_eta(h, tv, G, GV, eta_preale)
+    call find_eta(h, tv, G, GV, US, eta_preale)
     call post_data(CS%id_e_preale, eta_preale, CS%diag)
   endif
 
@@ -1095,8 +1098,9 @@ end subroutine pressure_gradient_ppm
 
 
 !> Initializes regridding for the main ALE algorithm
-subroutine ALE_initRegridding(GV, max_depth, param_file, mdl, regridCS)
+subroutine ALE_initRegridding(GV, US, max_depth, param_file, mdl, regridCS)
   type(verticalGrid_type), intent(in)  :: GV         !< Ocean vertical grid structure
+  type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   real,                    intent(in)  :: max_depth  !< The maximum depth of the ocean, in Z.
   type(param_file_type),   intent(in)  :: param_file !< parameter file
   character(len=*),        intent(in)  :: mdl        !< Name of calling module
@@ -1110,7 +1114,7 @@ subroutine ALE_initRegridding(GV, max_depth, param_file, mdl, regridCS)
                  trim(regriddingCoordinateModeDoc), &
                  default=DEFAULT_COORDINATE_MODE, fail_if_missing=.true.)
 
-  call initialize_regridding(regridCS, GV, max_depth, param_file, mdl, coord_mode, '', '')
+  call initialize_regridding(regridCS, GV, US, max_depth, param_file, mdl, coord_mode, '', '')
 
 end subroutine ALE_initRegridding
 

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -216,7 +216,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
   CS%nk = 0
   CS%regridding_scheme = coordinateMode(coord_mode)
   coord_is_state_dependent = state_dependent(coord_mode)
-  maximum_depth = GV%Z_to_m*max_depth
+  maximum_depth = US%Z_to_m*max_depth
 
   if (main_parameters) then
     ! Read coordinate units parameter (main model = REGRIDDING_COORDINATE_UNITS)
@@ -473,7 +473,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
       CS%coord_scale = GV%H_to_m
     else
       call setCoordinateResolution(dz, CS, scale=US%m_to_Z)
-      CS%coord_scale = GV%Z_to_m
+      CS%coord_scale = US%Z_to_m
     endif
   endif
 

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -7,10 +7,11 @@ use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser,   only : param_file_type, get_param, log_param
 use MOM_io,            only : file_exists, field_exists, field_size, MOM_read_data
 use MOM_io,            only : slasher
+use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : ocean_grid_type, thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type
 use MOM_EOS,           only : EOS_type, calculate_density
-use MOM_string_functions,only : uppercase, extractWord, extract_integer, extract_real
+use MOM_string_functions, only : uppercase, extractWord, extract_integer, extract_real
 
 use MOM_remapping, only : remapping_CS
 use regrid_consts, only : state_dependent, coordinateUnits
@@ -167,9 +168,10 @@ real, parameter, public :: regriddingDefaultMinThickness = 1.e-3
 contains
 
 !> Initialization and configures a regridding control structure based on customizable run-time parameters
-subroutine initialize_regridding(CS, GV, max_depth, param_file, mdl, coord_mode, param_prefix, param_suffix)
-  type(regridding_CS),        intent(inout) :: CS !< Regridding control structure
-  type(verticalGrid_type),    intent(in)    :: GV         !< Ocean vertical grid structure
+subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_mode, param_prefix, param_suffix)
+  type(regridding_CS),        intent(inout) :: CS  !< Regridding control structure
+  type(verticalGrid_type),    intent(in)    :: GV  !< Ocean vertical grid structure
+  type(unit_scale_type),      intent(in)    :: US  !< A dimensional unit scaling type
   real,                       intent(in)    :: max_depth  !< The maximum depth of the ocean, in Z.
   type(param_file_type),      intent(in)    :: param_file !< Parameter file
   character(len=*),           intent(in)    :: mdl        !< Name of calling module.
@@ -470,7 +472,7 @@ subroutine initialize_regridding(CS, GV, max_depth, param_file, mdl, coord_mode,
       call setCoordinateResolution(dz, CS, scale=GV%m_to_H)
       CS%coord_scale = GV%H_to_m
     else
-      call setCoordinateResolution(dz, CS, scale=GV%m_to_Z)
+      call setCoordinateResolution(dz, CS, scale=US%m_to_Z)
       CS%coord_scale = GV%Z_to_m
     endif
   endif

--- a/src/ALE/coord_adapt.F90
+++ b/src/ALE/coord_adapt.F90
@@ -22,22 +22,22 @@ type, public :: adapt_CS ; private
   real, allocatable, dimension(:) :: coordinateResolution
 
   !> Ratio of optimisation and diffusion timescales
-  real :: adaptTimeRatio = 1e-1
+  real :: adaptTimeRatio
 
   !> Nondimensional coefficient determining how much optimisation to apply
-  real :: adaptAlpha     = 1.0
+  real :: adaptAlpha
 
-  !> Near-surface zooming depth
-  real :: adaptZoom      = 200.0
+  !> Near-surface zooming depth in H
+  real :: adaptZoom
 
   !> Near-surface zooming coefficient
-  real :: adaptZoomCoeff = 0.0
+  real :: adaptZoomCoeff
 
   !> Stratification-dependent diffusion coefficient
-  real :: adaptBuoyCoeff = 0.0
+  real :: adaptBuoyCoeff
 
-  !> Reference density difference for stratification-dependent diffusion
-  real :: adaptDrho0     = 0.5
+  !> Reference density difference for stratification-dependent diffusion in kg m-3
+  real :: adaptDrho0
 
   !> If true, form a HYCOM1-like mixed layet by preventing interfaces
   !! from becoming shallower than the depths set by coordinateResolution
@@ -49,17 +49,31 @@ public init_coord_adapt, set_adapt_params, build_adapt_column, end_coord_adapt
 contains
 
 !> Initialise an adapt_CS with parameters
-subroutine init_coord_adapt(CS, nk, coordinateResolution)
+subroutine init_coord_adapt(CS, nk, coordinateResolution, m_to_H)
   type(adapt_CS),     pointer    :: CS !< Unassociated pointer to hold the control structure
   integer,            intent(in) :: nk !< Number of layers in the grid
   real, dimension(:), intent(in) :: coordinateResolution !< Nominal near-surface resolution (H)
+  real,     optional, intent(in) :: m_to_H !< A conversion factor from m to the units of thicknesses
+
+  real :: m_to_H_rescale  ! A unit conversion factor.
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_adapt: CS already associated")
   allocate(CS)
   allocate(CS%coordinateResolution(nk))
 
+  m_to_H_rescale = 1.0 ; if (present(m_to_H)) m_to_H_rescale = m_to_H
+
   CS%nk = nk
   CS%coordinateResolution(:) = coordinateResolution(:)
+
+  ! Set real parameter default values
+  CS%adaptTimeRatio = 1e-1 ! Nondim.
+  CS%adaptAlpha     = 1.0  ! Nondim.
+  CS%adaptZoom = 200.0 * m_to_H_rescale
+  CS%adaptZoomCoeff = 0.0  ! Nondim.
+  CS%adaptBuoyCoeff = 0.0  ! Nondim.
+  CS%adaptDrho0     = 0.5  ! kg m-3
+
 end subroutine init_coord_adapt
 
 !> Clean up the coordinate control structure
@@ -79,7 +93,7 @@ subroutine set_adapt_params(CS, adaptTimeRatio, adaptAlpha, adaptZoom, adaptZoom
   real,    optional, intent(in) :: adaptTimeRatio !< Ratio of optimisation and diffusion timescales
   real,    optional, intent(in) :: adaptAlpha     !< Nondimensional coefficient determining
                                                   !! how much optimisation to apply
-  real,    optional, intent(in) :: adaptZoom      !< Near-surface zooming depth, in m
+  real,    optional, intent(in) :: adaptZoom      !< Near-surface zooming depth, in H
   real,    optional, intent(in) :: adaptZoomCoeff !< Near-surface zooming coefficient
   real,    optional, intent(in) :: adaptBuoyCoeff !< Stratification-dependent diffusion coefficient
   real,    optional, intent(in) :: adaptDrho0  !< Reference density difference for
@@ -226,7 +240,7 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
 
     ! set vertical grid diffusivity
     kGrid(k) = (CS%adaptTimeRatio * nz**2 * depth) * &
-         (CS%adaptZoomCoeff / (CS%adaptZoom * GV%m_to_H + 0.5*(zNext(K) + zNext(K+1))) + &
+         (CS%adaptZoomCoeff / (CS%adaptZoom + 0.5*(zNext(K) + zNext(K+1))) + &
          (CS%adaptBuoyCoeff * drdz / CS%adaptDrho0) + &
          max(1.0 - CS%adaptZoomCoeff - CS%adaptBuoyCoeff, 0.0) / depth)
   enddo

--- a/src/ALE/coord_adapt.F90
+++ b/src/ALE/coord_adapt.F90
@@ -18,7 +18,7 @@ type, public :: adapt_CS ; private
   !> Number of layers/levels
   integer :: nk
 
-  !> Nominal near-surface resolution
+  !> Nominal near-surface resolution in H
   real, allocatable, dimension(:) :: coordinateResolution
 
   !> Ratio of optimisation and diffusion timescales
@@ -52,7 +52,7 @@ contains
 subroutine init_coord_adapt(CS, nk, coordinateResolution)
   type(adapt_CS),     pointer    :: CS !< Unassociated pointer to hold the control structure
   integer,            intent(in) :: nk !< Number of layers in the grid
-  real, dimension(:), intent(in) :: coordinateResolution !< Nominal near-surface resolution (m)
+  real, dimension(:), intent(in) :: coordinateResolution !< Nominal near-surface resolution (H)
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_adapt: CS already associated")
   allocate(CS)
@@ -126,7 +126,7 @@ subroutine build_adapt_column(CS, G, GV, tv, i, j, zInt, tInt, sInt, h, zNext)
   zNext(nz+1) = zInt(i,j,nz+1)
 
   ! local depth for scaling diffusivity
-  depth = G%bathyT(i,j) * G%Zd_to_m*GV%m_to_H
+  depth = G%bathyT(i,j) * GV%Z_to_H
 
   ! initialize del2sigma to zero
   del2sigma(:) = 0.

--- a/src/ALE/coord_sigma.F90
+++ b/src/ALE/coord_sigma.F90
@@ -16,7 +16,7 @@ type, public :: sigma_CS ; private
   !> Minimum thickness allowed for layers
   real :: min_thickness
 
-  !> Target coordinate resolution
+  !> Target coordinate resolution, nondimensional
   real, allocatable, dimension(:) :: coordinateResolution
 end type sigma_CS
 
@@ -51,7 +51,7 @@ end subroutine end_coord_sigma
 !> This subroutine can be used to set the parameters for the coord_sigma module
 subroutine set_sigma_params(CS, min_thickness)
   type(sigma_CS), pointer    :: CS !< Coordinate control structure
-  real, optional, intent(in) :: min_thickness !< Minimum allowed thickness, in m
+  real, optional, intent(in) :: min_thickness !< Minimum allowed thickness, in H
 
   if (.not. associated(CS)) call MOM_error(FATAL, "set_sigma_params: CS not associated")
 
@@ -62,9 +62,9 @@ end subroutine set_sigma_params
 !> Build a sigma coordinate column
 subroutine build_sigma_column(CS, depth, totalThickness, zInterface)
   type(sigma_CS),           intent(in)    :: CS !< Coordinate control structure
-  real,                     intent(in)    :: depth !< Depth of ocean bottom (positive in m)
-  real,                     intent(in)    :: totalThickness !< Column thickness (positive in m)
-  real, dimension(CS%nk+1), intent(inout) :: zInterface !< Absolute positions of interfaces in m
+  real,                     intent(in)    :: depth !< Depth of ocean bottom (positive in H, often m)
+  real,                     intent(in)    :: totalThickness !< Column thickness (positive in H)
+  real, dimension(CS%nk+1), intent(inout) :: zInterface !< Absolute positions of interfaces in H
 
   ! Local variables
   integer :: k

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -17,7 +17,7 @@ type, public :: slight_CS ; private
   !> Number of layers/levels
   integer :: nk
 
-  !> Minimum thickness allowed when building the new grid through regridding (m)
+  !> Minimum thickness allowed when building the new grid through regridding (H)
   real :: min_thickness
 
   !> Reference pressure for potential density calculations (Pa)
@@ -25,39 +25,39 @@ type, public :: slight_CS ; private
 
   !> Fraction (between 0 and 1) of compressibility to add to potential density
   !! profiles when interpolating for target grid positions. (nondim)
-  real :: compressibility_fraction = 0.
+  real :: compressibility_fraction
 
   ! The following 4 parameters were introduced for use with the SLight coordinate:
-  !> Depth over which to average to determine the mixed layer potential density (m)
-  real :: Rho_ML_avg_depth = 1.0
+  !> Depth over which to average to determine the mixed layer potential density (H)
+  real :: Rho_ML_avg_depth
 
   !> Number of layers to offset the mixed layer density to find resolved stratification (nondim)
-  real :: nlay_ml_offset = 2.0
+  real :: nlay_ml_offset
 
   !> The number of fixed-thickness layers at the top of the model
   integer :: nz_fixed_surface = 2
 
-  !> The fixed resolution in the topmost SLight_nkml_min layers (m)
-  real :: dz_ml_min = 1.0
+  !> The fixed resolution in the topmost SLight_nkml_min layers (H)
+  real :: dz_ml_min
 
   !> If true, detect regions with much weaker stratification in the coordinate
   !! than based on in-situ density, and use a stretched coordinate there.
   logical :: fix_haloclines = .false.
 
   !> A length scale over which to filter T & S when looking for spuriously
-  !! unstable water mass profiles, in m.
-  real :: halocline_filter_length = 2.0
+  !! unstable water mass profiles, in H.
+  real :: halocline_filter_length
 
   !> A value of the stratification ratio that defines a problematic halocline region (nondim).
-  real :: halocline_strat_tol = 0.25
+  real :: halocline_strat_tol
 
   !> Nominal density of interfaces, in kg m-3.
   real, allocatable, dimension(:) :: target_density
 
-  !> Maximum depths of interfaces, in m.
+  !> Maximum depths of interfaces, in H.
   real, allocatable, dimension(:) :: max_interface_depths
 
-  !> Maximum thicknesses of layers, in m.
+  !> Maximum thicknesses of layers, in H.
   real, allocatable, dimension(:) :: max_layer_thickness
 
   !> Interpolation control structure
@@ -69,21 +69,35 @@ public init_coord_slight, set_slight_params, build_slight_column, end_coord_slig
 contains
 
 !> Initialise a slight_CS with pointers to parameters
-subroutine init_coord_slight(CS, nk, ref_pressure, target_density, interp_CS)
+subroutine init_coord_slight(CS, nk, ref_pressure, target_density, interp_CS, m_to_H)
   type(slight_CS),      pointer    :: CS !< Unassociated pointer to hold the control structure
   integer,              intent(in) :: nk !< Number of layers in the grid
   real,                 intent(in) :: ref_pressure !< Nominal density of interfaces in Pa
   real, dimension(:),   intent(in) :: target_density !< Nominal density of interfaces in kg m-3
   type(interp_CS_type), intent(in) :: interp_CS !< Controls for interpolation
+  real,       optional, intent(in) :: m_to_H !< A conversion factor from m to the units of thicknesses
+
+  real :: m_to_H_rescale  ! A unit conversion factor.
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_slight: CS already associated!")
   allocate(CS)
   allocate(CS%target_density(nk+1))
 
+  m_to_H_rescale = 1.0 ; if (present(m_to_H)) m_to_H_rescale = m_to_H
+
   CS%nk                = nk
   CS%ref_pressure      = ref_pressure
   CS%target_density(:) = target_density(:)
   CS%interp_CS         = interp_CS
+
+  ! Set real parameter default values
+  CS%compressibility_fraction = 0. ! Nondim.
+  CS%Rho_ML_avg_depth = 1.0 * m_to_H_rescale
+  CS%nlay_ml_offset = 2.0          ! Nondim.
+  CS%dz_ml_min = 1.0 * m_to_H_rescale
+  CS%halocline_filter_length = 2.0 * m_to_H_rescale
+  CS%halocline_strat_tol = 0.25    ! Nondim.
+
 end subroutine init_coord_slight
 
 !> This subroutine deallocates memory in the control structure for the coord_slight module
@@ -103,26 +117,26 @@ subroutine set_slight_params(CS, max_interface_depths, max_layer_thickness, &
                halocline_filter_length, halocline_strat_tol, interp_CS)
   type(slight_CS),   pointer    :: CS !< Coordinate control structure
   real, dimension(:), &
-           optional, intent(in) :: max_interface_depths !< Maximum depths of interfaces in m
+           optional, intent(in) :: max_interface_depths !< Maximum depths of interfaces in H
   real, dimension(:), &
-           optional, intent(in) :: max_layer_thickness  !< Maximum thicknesses of layers in m
+           optional, intent(in) :: max_layer_thickness  !< Maximum thicknesses of layers in H
   real,    optional, intent(in) :: min_thickness    !< Minimum thickness allowed when building the
-                                      !! new grid through regridding, in m
+                                      !! new grid through regridding, in H
   real,    optional, intent(in) :: compressibility_fraction !< Fraction (between 0 and 1) of
                                       !! compressibility to add to potential density profiles when
                                       !! interpolating for target grid positions. (nondim)
   real,    optional, intent(in) :: dz_ml_min        !< The fixed resolution in the topmost
-                                      !! SLight_nkml_min layers (m)
+                                      !! SLight_nkml_min layers (H)
   integer, optional, intent(in) :: nz_fixed_surface !< The number of fixed-thickness layers at the
                                       !! top of the model
   real,    optional, intent(in) :: Rho_ML_avg_depth !< Depth over which to average to determine
-                                      !! the mixed layer potential density (m)
+                                      !! the mixed layer potential density (H)
   real,    optional, intent(in) :: nlay_ML_offset   !< Number of layers to offset the mixed layer
                                       !! density to find resolved stratification (nondim)
   logical, optional, intent(in) :: fix_haloclines   !< If true, detect regions with much weaker than
                                       !! based on in-situ density, and use a stretched coordinate there.
   real,    optional, intent(in) :: halocline_filter_length !< A length scale over which to filter T & S
-                                      !! when looking for spuriously unstable water mass profiles, in m.
+                                      !! when looking for spuriously unstable water mass profiles, in H.
   real,    optional, intent(in) :: halocline_strat_tol !< A value of the stratification ratio that
                                       !! defines a problematic halocline region (nondim).
   type(interp_CS_type), &
@@ -163,28 +177,25 @@ subroutine set_slight_params(CS, max_interface_depths, max_layer_thickness, &
 end subroutine set_slight_params
 
 !> Build a SLight coordinate column
-subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff, &
+subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, H_subroundoff, &
                                nz, depth, h_col, T_col, S_col, p_col, z_col, z_col_new, &
                                h_neglect, h_neglect_edge)
-  type(slight_CS),       intent(in)    :: CS !< Coordinate control structure
+  type(slight_CS),       intent(in)    :: CS    !< Coordinate control structure
   type(EOS_type),        pointer       :: eqn_of_state !< Equation of state structure
   real,                  intent(in)    :: H_to_Pa !< GV%H_to_Pa
-  real,                  intent(in)    :: m_to_H  !< GV%m_to_H
   real,                  intent(in)    :: H_subroundoff !< GV%H_subroundoff
-  integer,               intent(in)    :: nz !< Number of levels
-  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in m)
+  integer,               intent(in)    :: nz    !< Number of levels
+  real,                  intent(in)    :: depth !< Depth of ocean bottom (positive in H)
   real, dimension(nz),   intent(in)    :: T_col !< T for column
   real, dimension(nz),   intent(in)    :: S_col !< S for column
-  real, dimension(nz),   intent(in)    :: h_col !< Layer thicknesses, in m
+  real, dimension(nz),   intent(in)    :: h_col !< Layer thicknesses, in H units (m or kg m-2)
   real, dimension(nz),   intent(in)    :: p_col !< Layer quantities
-  real, dimension(nz+1), intent(in)    :: z_col !< Interface positions relative to the surface in H units (m or kg m-2)
-  real, dimension(nz+1), intent(inout) :: z_col_new !< Absolute positions of interfaces
-  real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the
-                                             !! purpose of cell reconstructions
-                                             !! in the same units as h_col.
-  real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width
-                                             !! for the purpose of edge value calculations
-                                             !! in the same units as h_col.
+  real, dimension(nz+1), intent(in)    :: z_col !< Interface positions relative to the surface in H
+  real, dimension(nz+1), intent(inout) :: z_col_new !< Absolute positions of interfaces in H
+  real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the purpose of
+                                                !! cell reconstructions in H.
+  real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width for the purpose
+                                                !! of edge value calculations in H.
   ! Local variables
   real, dimension(nz) :: rho_col ! Layer quantities
   real, dimension(nz) :: T_f, S_f  ! Filtered ayer quantities
@@ -282,7 +293,7 @@ subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff,
     ! Determine which interfaces are in the s-space region and the depth extent
     ! of this region.
     z_wt = 0.0 ; rho_x_z = 0.0
-    H_ml_av = m_to_H*CS%Rho_ml_avg_depth
+    H_ml_av = CS%Rho_ml_avg_depth
     do k=1,nz
       if (z_wt + h_col(k) >= H_ml_av) then
         rho_x_z = rho_x_z + rho_col(k) * (H_ml_av - z_wt)
@@ -323,7 +334,7 @@ subroutine build_slight_column(CS, eqn_of_state, H_to_Pa, m_to_H, H_subroundoff,
   !       ! z_int_unst and k_interior.
 
       if (CS%halocline_filter_length > 0.0) then
-        Lfilt = CS%halocline_filter_length*m_to_H
+        Lfilt = CS%halocline_filter_length
 
         ! Filter the temperature and salnity with a fixed lengthscale.
         h_tr = h_col(1) + H_subroundoff

--- a/src/ALE/coord_zlike.F90
+++ b/src/ALE/coord_zlike.F90
@@ -17,7 +17,7 @@ type, public :: zlike_CS ; private
   !! be used in all subsequent calls to build_zstar_column with this structure.
   real :: min_thickness
 
-  !> Target coordinate resolution, usually in m
+  !> Target coordinate resolution, usually in Z (often m)
   real, allocatable, dimension(:) :: coordinateResolution
 end type zlike_CS
 
@@ -29,7 +29,7 @@ contains
 subroutine init_coord_zlike(CS, nk, coordinateResolution)
   type(zlike_CS),     pointer    :: CS !< Unassociated pointer to hold the control structure
   integer,            intent(in) :: nk !< Number of levels in the grid
-  real, dimension(:), intent(in) :: coordinateResolution !< Target coordinate resolution, in m
+  real, dimension(:), intent(in) :: coordinateResolution !< Target coordinate resolution, in Z (often m)
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_zlike: CS already associated!")
   allocate(CS)
@@ -52,7 +52,7 @@ end subroutine end_coord_zlike
 !> Set parameters in the zlike structure
 subroutine set_zlike_params(CS, min_thickness)
   type(zlike_CS), pointer    :: CS !< Coordinate control structure
-  real, optional, intent(in) :: min_thickness !< Minimum allowed thickness, in m
+  real, optional, intent(in) :: min_thickness !< Minimum allowed thickness, in H
 
   if (.not. associated(CS)) call MOM_error(FATAL, "set_zlike_params: CS not associated")
 
@@ -63,7 +63,7 @@ end subroutine set_zlike_params
 subroutine build_zstar_column(CS, depth, total_thickness, zInterface, &
                               z_rigid_top, eta_orig, zScale)
   type(zlike_CS),           intent(in)    :: CS !< Coordinate control structure
-  real,                     intent(in)    :: depth !< Depth of ocean bottom (positive in m or H)
+  real,                     intent(in)    :: depth !< Depth of ocean bottom (positive in the output units)
   real,                     intent(in)    :: total_thickness !< Column thickness (positive in the same units as depth)
   real, dimension(CS%nk+1), intent(inout) :: zInterface !< Absolute positions of interfaces
   real, optional,           intent(in)    :: z_rigid_top !< The height of a rigid top (negative in the
@@ -71,7 +71,7 @@ subroutine build_zstar_column(CS, depth, total_thickness, zInterface, &
   real, optional,           intent(in)    :: eta_orig !< The actual original height of the top in the
                                                       !! same units as depth
   real, optional,           intent(in)    :: zScale !< Scaling factor from the target coordinate resolution
-                                                    !! in m to desired units for zInterface, perhaps m_to_H
+                                                    !! in Z to desired units for zInterface, perhaps Z_to_H
   ! Local variables
   real :: eta, stretching, dh, min_thickness, z0_top, z_star, z_scale
   integer :: k

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1972,7 +1972,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   ! Allocate initialize time-invariant MOM variables.
   call MOM_initialize_fixed(dG, CS%OBC, param_file, write_geom_files, dirs%output_directory)
   call callTree_waypoint("returned from MOM_initialize_fixed() (initialize_MOM)")
-  ! This could replace a later call to rescale_grid_bathymetry.
+
   if (dG%Zd_to_m /= GV%Z_to_m) call rescale_dyn_horgrid_bathymetry(dG, GV%Z_to_m)
 
   if (associated(CS%OBC)) call call_OBC_register(param_file, CS%update_OBC_CSp, CS%OBC)
@@ -2133,11 +2133,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   ! Initialize dynamically evolving fields, perhaps from restart files.
   call cpu_clock_begin(id_clock_MOM_init)
   call MOM_initialize_coord(GV, param_file, write_geom_files, &
-                            dirs%output_directory, CS%tv, dG%max_depth*dG%Zd_to_m)
+                            dirs%output_directory, CS%tv, dG%max_depth)
   call callTree_waypoint("returned from MOM_initialize_coord() (initialize_MOM)")
 
   if (CS%use_ALE_algorithm) then
-    call ALE_init(param_file, GV, dG%max_depth*dG%Zd_to_m, CS%ALE_CSp)
+    call ALE_init(param_file, GV, dG%max_depth, CS%ALE_CSp)
     call callTree_waypoint("returned from ALE_init() (initialize_MOM)")
   endif
 
@@ -2148,9 +2148,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   call MOM_grid_init(G, param_file, HI, bathymetry_at_vel=bathy_at_vel)
   call copy_dyngrid_to_MOM_grid(dG, G)
   call destroy_dyn_horgrid(dG)
-
-  ! This could replace an earlier call to rescale_dyn_horgrid_bathymetry just after MOM_initialize_fixed.
-  !  if (G%Zd_to_m /= GV%Z_to_m) call rescale_grid_bathymetry(G, GV%Z_to_m)
 
   ! Set a few remaining fields that are specific to the ocean grid type.
   call set_first_direction(G, first_direction)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1770,12 +1770,12 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth \n"//&
                  "over which to average to find surface properties like \n"//&
                  "SST and SSS or density (but not surface velocities).", &
-                 units="m", default=1.0) !, scale=US%m_to_Z)
+                 units="m", default=1.0, scale=US%m_to_Z)
     call get_param(param_file, "MOM", "HMIX_UV_SFC_PROP", CS%Hmix_UV, &
                  "If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth\n"//&
                  "over which to average to find surface flow properties,\n"//&
                  "SSU, SSV. A non-positive value indicates no averaging.", &
-                 units="m", default=0.) !, scale=US%m_to_Z)
+                 units="m", default=0.0, scale=US%m_to_Z)
   endif
   call get_param(param_file, "MOM", "HFREEZE", CS%HFrz, &
                  "If HFREEZE > 0, melt potential will be computed. The actual depth \n"//&
@@ -1968,18 +1968,12 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   call verticalGridInit( param_file, CS%GV, US )
   GV => CS%GV
 !  dG%g_Earth = (GV%g_Earth*US%m_to_Z)
-  !### These should be merged with the get_param calls, but must follow verticalGridInit.
-  if (.not.bulkmixedlayer) then
-    CS%Hmix = CS%Hmix * US%m_to_Z
-    CS%Hmix_UV = CS%Hmix_UV * US%m_to_Z
-  endif
 
   ! Allocate the auxiliary non-symmetric domain for debugging or I/O purposes.
   if (CS%debug .or. dG%symmetric) &
     call clone_MOM_domain(dG%Domain, dG%Domain_aux, symmetric=.false.)
 
   call callTree_waypoint("grids initialized (initialize_MOM)")
-
 
   call MOM_timing_init(CS)
 

--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -17,6 +17,7 @@ use MOM_PressureForce_Mont, only : PressureForce_Mont_Bouss, PressureForce_Mont_
 use MOM_PressureForce_Mont, only : PressureForce_Mont_init, PressureForce_Mont_end
 use MOM_PressureForce_Mont, only : PressureForce_Mont_CS
 use MOM_tidal_forcing, only : tidal_forcing_CS
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_ALE, only: ALE_CS
@@ -43,9 +44,10 @@ end type PressureForce_CS
 contains
 
 !> A thin layer between the model and the Boussinesq and non-Boussinesq pressure force routines.
-subroutine PressureForce(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
+subroutine PressureForce(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm, pbce, eta)
   type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(in)  :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   type(thermo_var_ptrs),   intent(in)  :: tv   !< A structure pointing to various thermodynamic variables
@@ -67,26 +69,26 @@ subroutine PressureForce(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
 
   if (CS%Analytic_FV_PGF .and. CS%blocked_AFV) then
     if (GV%Boussinesq) then
-      call PressureForce_blk_AFV_Bouss(h, tv, PFu, PFv, G, GV, &
+      call PressureForce_blk_AFV_Bouss(h, tv, PFu, PFv, G, GV, US, &
                CS%PressureForce_blk_AFV_CSp, ALE_CSp, p_atm, pbce, eta)
     else
-      call PressureForce_blk_AFV_nonBouss(h, tv, PFu, PFv, G, GV, &
+      call PressureForce_blk_AFV_nonBouss(h, tv, PFu, PFv, G, GV, US, &
                CS%PressureForce_blk_AFV_CSp, p_atm, pbce, eta)
     endif
   elseif (CS%Analytic_FV_PGF) then
     if (GV%Boussinesq) then
-      call PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS%PressureForce_AFV_CSp, &
+      call PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, US, CS%PressureForce_AFV_CSp, &
                                    ALE_CSp, p_atm, pbce, eta)
     else
-      call PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS%PressureForce_AFV_CSp, &
+      call PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, US, CS%PressureForce_AFV_CSp, &
                                       ALE_CSp, p_atm, pbce, eta)
     endif
   else
     if (GV%Boussinesq) then
-      call PressureForce_Mont_Bouss(h, tv, PFu, PFv, G, GV, CS%PressureForce_Mont_CSp, &
+      call PressureForce_Mont_Bouss(h, tv, PFu, PFv, G, GV, US, CS%PressureForce_Mont_CSp, &
                                     p_atm, pbce, eta)
     else
-      call PressureForce_Mont_nonBouss(h, tv, PFu, PFv, G, GV, CS%PressureForce_Mont_CSp, &
+      call PressureForce_Mont_nonBouss(h, tv, PFu, PFv, G, GV, US, CS%PressureForce_Mont_CSp, &
                                        p_atm, pbce, eta)
     endif
   endif

--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -96,10 +96,11 @@ subroutine PressureForce(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm, pbce, e
 end subroutine Pressureforce
 
 !> Initialize the pressure force control structure
-subroutine PressureForce_init(Time, G, GV, param_file, diag, CS, tides_CSp)
+subroutine PressureForce_init(Time, G, GV, US, param_file, diag, CS, tides_CSp)
   type(time_type), target, intent(in)    :: Time !< Current model time
   type(ocean_grid_type),   intent(in)    :: G    !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< Vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< Parameter file handles
   type(diag_ctrl), target, intent(inout) :: diag !< Diagnostics control structure
   type(PressureForce_CS),  pointer       :: CS   !< Pressure force control structure
@@ -127,13 +128,13 @@ subroutine PressureForce_init(Time, G, GV, param_file, diag, CS, tides_CSp)
                  default=.false., do_not_log=.true., debuggingParam=.true.)
 
   if (CS%Analytic_FV_PGF .and. CS%blocked_AFV) then
-    call PressureForce_blk_AFV_init(Time, G, GV, param_file, diag, &
+    call PressureForce_blk_AFV_init(Time, G, GV, US, param_file, diag, &
              CS%PressureForce_blk_AFV_CSp, tides_CSp)
   elseif (CS%Analytic_FV_PGF) then
-    call PressureForce_AFV_init(Time, G, GV, param_file, diag, &
+    call PressureForce_AFV_init(Time, G, GV, US, param_file, diag, &
              CS%PressureForce_AFV_CSp, tides_CSp)
   else
-    call PressureForce_Mont_init(Time, G, GV, param_file, diag, &
+    call PressureForce_Mont_init(Time, G, GV, US, param_file, diag, &
              CS%PressureForce_Mont_CSp, tides_CSp)
   endif
 

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -810,10 +810,11 @@ subroutine Set_pbce_nonBouss(p, tv, G, GV, GFS_scale, pbce, alpha_star)
 end subroutine Set_pbce_nonBouss
 
 !> Initialize the Montgomery-potential form of PGF control structure
-subroutine PressureForce_Mont_init(Time, G, GV, param_file, diag, CS, tides_CSp)
+subroutine PressureForce_Mont_init(Time, G, GV, US, param_file, diag, CS, tides_CSp)
   type(time_type), target, intent(in)    :: Time !< Current model time
   type(ocean_grid_type),   intent(in)    :: G  !< ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV !< Vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< Parameter file handles
   type(diag_ctrl), target, intent(inout) :: diag !< Diagnostics control structure
   type(PressureForce_Mont_CS),  pointer  :: CS !< Montgomery PGF control structure
@@ -865,7 +866,7 @@ subroutine PressureForce_Mont_init(Time, G, GV, param_file, diag, CS, tides_CSp)
 
   if (CS%tides) then
     CS%id_e_tidal = register_diag_field('ocean_model', 'e_tidal', diag%axesT1, &
-        Time, 'Tidal Forcing Astronomical and SAL Height Anomaly', 'meter', conversion=GV%Z_to_m)
+        Time, 'Tidal Forcing Astronomical and SAL Height Anomaly', 'meter', conversion=US%Z_to_m)
   endif
 
   CS%GFS_scale = 1.0

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -9,6 +9,7 @@ use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
 use MOM_tidal_forcing, only : calc_tidal_forcing, tidal_forcing_CS
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs
@@ -55,9 +56,10 @@ contains
 !! ie to ie, je to je range before this subroutine is called:
 !! h[ie+1] and h[je+1] and and (if tv%form_of_EOS is set) T[ie+1], S[ie+1],
 !! T[je+1], and S[je+1].
-subroutine PressureForce_Mont_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, eta)
+subroutine PressureForce_Mont_nonBouss(h, tv, PFu, PFv, G, GV, US, CS, p_atm, pbce, eta)
   type(ocean_grid_type),                     intent(in)  :: G   !< Ocean grid structure.
   type(verticalGrid_type),                   intent(in)  :: GV  !< Vertical grid structure.
+  type(unit_scale_type),                     intent(in)  :: US !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)  :: h   !< Layer thickness, in kg/m2.
   type(thermo_var_ptrs),                     intent(in)  :: tv  !< Thermodynamic variables.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(out) :: PFu !< Zonal acceleration due to pressure gradients
@@ -193,11 +195,11 @@ subroutine PressureForce_Mont_nonBouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, 
     else
       !$OMP parallel do default(shared)
       do j=Jsq,Jeq+1 ; do k=1,nz ; do i=Isq,Ieq+1
-        SSH(i,j) = SSH(i,j) + (GV%m_to_Z*GV%H_to_kg_m2)*h(i,j,k)*alpha_Lay(k)
+        SSH(i,j) = SSH(i,j) + (US%m_to_Z*GV%H_to_kg_m2)*h(i,j,k)*alpha_Lay(k)
       enddo ; enddo ; enddo
     endif
 
-    call calc_tidal_forcing(CS%Time, SSH, e_tidal, G, CS%tides_CSp, m_to_Z=GV%m_to_Z)
+    call calc_tidal_forcing(CS%Time, SSH, e_tidal, G, CS%tides_CSp, m_to_Z=US%m_to_Z)
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       geopot_bot(i,j) = -GV%g_Earth*(e_tidal(i,j) + G%bathyT(i,j))
@@ -353,9 +355,10 @@ end subroutine PressureForce_Mont_nonBouss
 !! ie to ie, je to je range before this subroutine is called:
 !!  h[ie+1] and h[je+1] and (if tv%form_of_EOS is set) T[ie+1], S[ie+1],
 !!  T[je+1], and S[je+1].
-subroutine PressureForce_Mont_Bouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, eta)
+subroutine PressureForce_Mont_Bouss(h, tv, PFu, PFv, G, GV, US, CS, p_atm, pbce, eta)
   type(ocean_grid_type),                     intent(in)  :: G   !< Ocean grid structure.
   type(verticalGrid_type),                   intent(in)  :: GV  !< Vertical grid structure.
+  type(unit_scale_type),                     intent(in)  :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)  :: h   !< Layer thickness, in m.
   type(thermo_var_ptrs),                     intent(in)  :: tv  !< Thermodynamic variables.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(out) :: PFu !< Zonal acceleration due to pressure gradients
@@ -443,7 +446,7 @@ subroutine PressureForce_Mont_Bouss(h, tv, PFu, PFv, G, GV, CS, p_atm, pbce, eta
         e(i,j,1) = e(i,j,1) + h(i,j,k)*GV%H_to_Z
       enddo ; enddo
     enddo
-    call calc_tidal_forcing(CS%Time, e(:,:,1), e_tidal, G, CS%tides_CSp, m_to_Z=GV%m_to_Z)
+    call calc_tidal_forcing(CS%Time, e(:,:,1), e_tidal, G, CS%tides_CSp, m_to_Z=US%m_to_Z)
   endif
 
 !    Here layer interface heights, e, are calculated.

--- a/src/core/MOM_PressureForce_analytic_FV.F90
+++ b/src/core/MOM_PressureForce_analytic_FV.F90
@@ -10,6 +10,7 @@ use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
 use MOM_PressureForce_Mont, only : set_pbce_Bouss, set_pbce_nonBouss
 use MOM_tidal_forcing, only : calc_tidal_forcing, tidal_forcing_CS
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs
@@ -57,9 +58,10 @@ contains
 
 !> Thin interface between the model and the Boussinesq and non-Boussinesq
 !! pressure force routines.
-subroutine PressureForce_AFV(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
+subroutine PressureForce_AFV(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm, pbce, eta)
   type(ocean_grid_type),                     intent(in)    :: G   !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV  !< Vertical grid structure
+  type(unit_scale_type),                     intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h   !< Layer thickness (m or kg/m2)
   type(thermo_var_ptrs),                     intent(inout) :: tv  !< Thermodynamic variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(out)   :: PFu !< Zonal acceleration (m/s2)
@@ -76,9 +78,9 @@ subroutine PressureForce_AFV(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, e
                                                            !! contributions or compressibility compensation.
 
   if (GV%Boussinesq) then
-    call PressureForce_AFV_bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
+    call PressureForce_AFV_bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm, pbce, eta)
   else
-    call PressureForce_AFV_nonbouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
+    call PressureForce_AFV_nonbouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm, pbce, eta)
   endif
 
 end subroutine PressureForce_AFV
@@ -93,9 +95,10 @@ end subroutine PressureForce_AFV
 !! ie to ie, je to je range before this subroutine is called:
 !!  h[ie+1] and h[je+1] and (if tv%eqn_of_state is set) T[ie+1], S[ie+1],
 !!  T[je+1], and S[je+1].
-subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
+subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm, pbce, eta)
   type(ocean_grid_type),                     intent(in)  :: G   !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)  :: GV  !< Vertical grid structure
+  type(unit_scale_type),                     intent(in)  :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)  :: h   !< Layer thickness (kg/m2)
   type(thermo_var_ptrs),                     intent(in)  :: tv  !< Thermodynamic variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(out) :: PFu !< Zonal acceleration (m/s2)
@@ -316,7 +319,7 @@ subroutine PressureForce_AFV_nonBouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       SSH(i,j) = (za(i,j) - alpha_ref*p(i,j,1)) * I_gEarth
     enddo ; enddo
-    call calc_tidal_forcing(CS%Time, SSH, e_tidal, G, CS%tides_CSp, m_to_Z=GV%m_to_Z)
+    call calc_tidal_forcing(CS%Time, SSH, e_tidal, G, CS%tides_CSp, m_to_Z=US%m_to_Z)
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       za(i,j) = za(i,j) - g_Earth_z * e_tidal(i,j)
@@ -434,9 +437,10 @@ end subroutine PressureForce_AFV_nonBouss
 !! ie to ie, je to je range before this subroutine is called:
 !!  h[ie+1] and h[je+1] and (if tv%eqn_of_state is set) T[ie+1], S[ie+1],
 !!  T[je+1], and S[je+1].
-subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, pbce, eta)
+subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm, pbce, eta)
   type(ocean_grid_type),                     intent(in)  :: G   !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)  :: GV  !< Vertical grid structure
+  type(unit_scale_type),                     intent(in)  :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)  :: h   !< Layer thickness (kg/m2)
   type(thermo_var_ptrs),                     intent(in)  :: tv  !< Thermodynamic variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(out) :: PFu !< Zonal acceleration (m/s2)
@@ -541,7 +545,7 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, CS, ALE_CSp, p_atm, p
         e(i,j,1) = e(i,j,1) + h(i,j,k)*GV%H_to_Z
       enddo ; enddo
     enddo
-    call calc_tidal_forcing(CS%Time, e(:,:,1), e_tidal, G, CS%tides_CSp, m_to_Z=GV%m_to_Z)
+    call calc_tidal_forcing(CS%Time, e(:,:,1), e_tidal, G, CS%tides_CSp, m_to_Z=US%m_to_Z)
   endif
 
 !    Here layer interface heights, e, are calculated.

--- a/src/core/MOM_PressureForce_analytic_FV.F90
+++ b/src/core/MOM_PressureForce_analytic_FV.F90
@@ -777,10 +777,11 @@ subroutine PressureForce_AFV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_at
 end subroutine PressureForce_AFV_Bouss
 
 !> Initializes the finite volume pressure gradient control structure
-subroutine PressureForce_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
+subroutine PressureForce_AFV_init(Time, G, GV, US, param_file, diag, CS, tides_CSp)
   type(time_type), target,    intent(in)    :: Time !< Current model time
   type(ocean_grid_type),      intent(in)    :: G  !< Ocean grid structure
   type(verticalGrid_type),    intent(in)    :: GV !< Vertical grid structure
+  type(unit_scale_type),      intent(in)    :: US !< A dimensional unit scaling type
   type(param_file_type),      intent(in)    :: param_file !< Parameter file handles
   type(diag_ctrl), target,    intent(inout) :: diag !< Diagnostics control structure
   type(PressureForce_AFV_CS), pointer       :: CS !< Finite volume PGF control structure
@@ -838,7 +839,7 @@ subroutine PressureForce_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
 
   if (CS%tides) then
     CS%id_e_tidal = register_diag_field('ocean_model', 'e_tidal', diag%axesT1, &
-        Time, 'Tidal Forcing Astronomical and SAL Height Anomaly', 'meter', conversion=GV%Z_to_m)
+        Time, 'Tidal Forcing Astronomical and SAL Height Anomaly', 'meter', conversion=US%Z_to_m)
   endif
 
   CS%GFS_scale = 1.0

--- a/src/core/MOM_PressureForce_blocked_AFV.F90
+++ b/src/core/MOM_PressureForce_blocked_AFV.F90
@@ -771,10 +771,11 @@ subroutine PressureForce_blk_AFV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, 
 end subroutine PressureForce_blk_AFV_Bouss
 
 !> Initializes the finite volume pressure gradient control structure
-subroutine PressureForce_blk_AFV_init(Time, G, GV, param_file, diag, CS, tides_CSp)
+subroutine PressureForce_blk_AFV_init(Time, G, GV, US, param_file, diag, CS, tides_CSp)
   type(time_type), target,    intent(in)    :: Time !< Current model time
   type(ocean_grid_type),      intent(in)    :: G  !< Ocean grid structure
   type(verticalGrid_type),    intent(in)    :: GV !< Vertical grid structure
+  type(unit_scale_type),      intent(in)    :: US !< A dimensional unit scaling type
   type(param_file_type),      intent(in)    :: param_file !< Parameter file handles
   type(diag_ctrl), target,    intent(inout) :: diag !< Diagnostics control structure
   type(PressureForce_blk_AFV_CS), pointer       :: CS !< Finite volume PGF control structure
@@ -832,7 +833,7 @@ subroutine PressureForce_blk_AFV_init(Time, G, GV, param_file, diag, CS, tides_C
 
   if (CS%tides) then
     CS%id_e_tidal = register_diag_field('ocean_model', 'e_tidal', diag%axesT1, &
-        Time, 'Tidal Forcing Astronomical and SAL Height Anomaly', 'meter', conversion=GV%Z_to_m)
+        Time, 'Tidal Forcing Astronomical and SAL Height Anomaly', 'meter', conversion=US%Z_to_m)
   endif
 
   CS%GFS_scale = 1.0

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1251,7 +1251,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 !$OMP                               Rayleigh_u, Rayleigh_v,                         &
 !$OMP                               use_BT_Cont,BTCL_u,uhbt0,BTCL_v,vhbt0,eta,Idt)  &
 !$OMP                       private(u_max_cor,v_max_cor,eta_cor_max,Htot)
-!$OMP do
+  !$OMP do
   do j=js-1,je+1 ; do I=is-1,ie ; av_rem_u(I,j) = 0.0 ; enddo ; enddo
   !$OMP do
   do J=js-1,je ; do i=is-1,ie+1 ; av_rem_v(i,J) = 0.0 ; enddo ; enddo
@@ -1311,23 +1311,23 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   ! Zero out the arrays for various time-averaged quantities.
   if (find_etaav) then
-!$OMP do
+    !$OMP do
     do j=jsvf-1,jevf+1 ; do i=isvf-1,ievf+1
       eta_sum(i,j) = 0.0 ; eta_wtd(i,j) = 0.0
     enddo ; enddo
   else
-!$OMP do
+    !$OMP do
     do j=jsvf-1,jevf+1 ; do i=isvf-1,ievf+1
       eta_wtd(i,j) = 0.0
     enddo ; enddo
    endif
-!$OMP do
+  !$OMP do
   do j=jsvf-1,jevf+1 ; do I=isvf-1,ievf
     ubt_sum(I,j) = 0.0 ; uhbt_sum(I,j) = 0.0
     PFu_bt_sum(I,j) = 0.0 ; Coru_bt_sum(I,j) = 0.0
     ubt_wtd(I,j) = 0.0 ; ubt_trans(I,j) = 0.0
   enddo ; enddo
-!$OMP do
+  !$OMP do
   do J=jsvf-1,jevf ; do i=isvf-1,ievf+1
     vbt_sum(i,J) = 0.0 ; vhbt_sum(i,J) = 0.0
     PFv_bt_sum(i,J) = 0.0 ; Corv_bt_sum(i,J) = 0.0
@@ -1335,7 +1335,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   enddo ; enddo
 
   ! Set the mass source, after first initializing the halos to 0.
-!$OMP do
+  !$OMP do
   do j=jsvf-1,jevf+1; do i=isvf-1,ievf+1 ; eta_src(i,j) = 0.0 ; enddo ; enddo
   if (CS%bound_BT_corr) then ; if (use_BT_Cont .and. CS%BT_cont_bounds) then
     do j=js,je ; do i=is,ie ; if (G%mask2dT(i,j) > 0.0) then
@@ -1364,7 +1364,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     if (abs(CS%eta_cor(i,j)) > dt*CS%eta_cor_bound(i,j)) &
       CS%eta_cor(i,j) = sign(dt*CS%eta_cor_bound(i,j),CS%eta_cor(i,j))
   enddo ; enddo ; endif ; endif
-!$OMP do
+  !$OMP do
   do j=js,je ; do i=is,ie
     eta_src(i,j) = G%mask2dT(i,j) * (Instep * CS%eta_cor(i,j))
   enddo ; enddo

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3956,7 +3956,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                  "An estimate of how much higher SSH might get, for use \n"//&
                  "in calculating the safe external wave speed. The \n"//&
                  "default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.", &
-                 units="m", default=min(10.0,0.05*G%max_depth*GV%Z_to_m))
+                 units="m", default=min(10.0,0.05*G%max_depth*US%Z_to_m))
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &

--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -13,6 +13,7 @@ use MOM_dyn_horgrid,           only : dyn_horgrid_type
 use MOM_open_boundary,         only : ocean_obc_type, update_OBC_segment_data
 use MOM_open_boundary,         only : OBC_registry_type, file_OBC_CS
 use MOM_open_boundary,         only : register_file_OBC, file_OBC_end
+use MOM_unit_scaling,          only : unit_scale_type
 use MOM_verticalGrid,          only : verticalGrid_type
 use MOM_tracer_registry,       only : tracer_registry_type
 use MOM_variables,             only : thermo_var_ptrs
@@ -109,9 +110,10 @@ subroutine call_OBC_register(param_file, CS, OBC)
 end subroutine call_OBC_register
 
 !> Calls appropriate routine to update the open boundary conditions.
-subroutine update_OBC_data(OBC, G, GV, tv, h, CS, Time)
+subroutine update_OBC_data(OBC, G, GV, US, tv, h, CS, Time)
   type(ocean_grid_type),                    intent(in)    :: G    !< Ocean grid structure
   type(verticalGrid_type),                  intent(in)    :: GV   !< Ocean vertical grid structure
+  type(unit_scale_type),                    intent(in)    :: US   !< A dimensional unit scaling type
   type(thermo_var_ptrs),                    intent(in)    :: tv   !< Thermodynamics structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h    !< layer thicknesses, in H
   type(ocean_OBC_type),                     pointer       :: OBC  !< Open boundary structure
@@ -138,7 +140,7 @@ subroutine update_OBC_data(OBC, G, GV, tv, h, CS, Time)
   if (CS%use_tidal_bay) &
       call tidal_bay_set_OBC_data(OBC, CS%tidal_bay_OBC_CSp, G, h, Time)
   if (CS%use_Kelvin)  &
-      call Kelvin_set_OBC_data(OBC, CS%Kelvin_OBC_CSp, G, GV, h, Time)
+      call Kelvin_set_OBC_data(OBC, CS%Kelvin_OBC_CSp, G, GV, US, h, Time)
   if (CS%use_shelfwave) &
       call shelfwave_set_OBC_data(OBC, CS%shelfwave_OBC_CSp, G, h, Time)
   if (CS%use_dyed_channel) &

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -579,7 +579,7 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   call vertvisc_coef(up, vp, h, forces, visc, dt_pred, G, GV, US, CS%vertvisc_CSp, &
                      CS%OBC)
   call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%ADp, CS%CDp, G, &
-                GV, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
+                GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
   if (showCallTree) call callTree_wayPoint("done with vertvisc (step_MOM_dyn_split_RK2)")
   if (G%nonblocking_updates) then
     call cpu_clock_end(id_clock_vertvisc)
@@ -774,7 +774,7 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   ! u_av <- u_av + dt d/dz visc d/dz u_av
   call cpu_clock_begin(id_clock_vertvisc)
   call vertvisc_coef(u, v, h, forces, visc, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC)
-  call vertvisc(u, v, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, &
+  call vertvisc(u, v, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
                 CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot,waves=waves)
   if (G%nonblocking_updates) then
     call cpu_clock_end(id_clock_vertvisc)
@@ -1093,7 +1093,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
   call continuity_init(Time, G, GV, param_file, diag, CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, param_file, diag, CS%ADp, CS%CoriolisAdv_CSp)
   if (use_tides) call tidal_forcing_init(Time, G, param_file, CS%tides_CSp)
-  call PressureForce_init(Time, G, GV, param_file, diag, CS%PressureForce_CSp, &
+  call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, &
                           CS%tides_CSp)
   call hor_visc_init(Time, G, param_file, diag, CS%hor_visc_CSp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -348,7 +348,7 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
   call vertvisc_coef(up, vp, h_av, forces, visc, dt*0.5, G, GV, US, &
                      CS%vertvisc_CSp, CS%OBC)
   call vertvisc(up, vp, h_av, forces, visc, dt*0.5, CS%OBC, CS%ADp, CS%CDp, &
-                G, GV, CS%vertvisc_CSp, Waves=Waves)
+                G, GV, US, CS%vertvisc_CSp, Waves=Waves)
   call cpu_clock_end(id_clock_vertvisc)
   call pass_vector(up, vp, G%Domain, clock=id_clock_pass)
 
@@ -412,7 +412,7 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
   call vertvisc_coef(upp, vpp, hp, forces, visc, dt*0.5, G, GV, US, &
                      CS%vertvisc_CSp, CS%OBC)
   call vertvisc(upp, vpp, hp, forces, visc, dt*0.5, CS%OBC, CS%ADp, CS%CDp, &
-                G, GV, CS%vertvisc_CSp, Waves=Waves)
+                G, GV, US, CS%vertvisc_CSp, Waves=Waves)
   call cpu_clock_end(id_clock_vertvisc)
   call pass_vector(upp, vpp, G%Domain, clock=id_clock_pass)
 
@@ -482,7 +482,7 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
   call cpu_clock_begin(id_clock_vertvisc)
   call vertvisc_coef(u, v, h_av, forces, visc, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC)
   call vertvisc(u, v, h_av, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, &
-                G, GV, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, Waves=Waves)
+                G, GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, Waves=Waves)
   call cpu_clock_end(id_clock_vertvisc)
   call pass_vector(u, v, G%Domain, clock=id_clock_pass)
 
@@ -653,7 +653,7 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, US, param_file, diag, CS
   call continuity_init(Time, G, GV, param_file, diag, CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, param_file, diag, CS%ADp, CS%CoriolisAdv_CSp)
   if (use_tides) call tidal_forcing_init(Time, G, param_file, CS%tides_CSp)
-  call PressureForce_init(Time, G, GV, param_file, diag, CS%PressureForce_CSp, &
+  call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, &
                           CS%tides_CSp)
   call hor_visc_init(Time, G, param_file, diag, CS%hor_visc_CSp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -344,7 +344,7 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   call vertvisc_coef(up, vp, h_av, forces, visc, dt_pred, G, GV, US, &
                      CS%vertvisc_CSp, CS%OBC)
   call vertvisc(up, vp, h_av, forces, visc, dt_pred, CS%OBC, CS%ADp, CS%CDp, &
-                G, GV, CS%vertvisc_CSp)
+                G, GV, US, CS%vertvisc_CSp)
   call cpu_clock_end(id_clock_vertvisc)
   call pass_vector(up, vp, G%Domain, clock=id_clock_pass)
 
@@ -397,11 +397,11 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   call vertvisc_coef(up, vp, h_av, forces, visc, dt, G, GV, US, &
                      CS%vertvisc_CSp, CS%OBC)
   call vertvisc(up, vp, h_av, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, &
-                G, GV, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot)
+                G, GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot)
   call vertvisc_coef(u_in, v_in, h_av, forces, visc, dt, G, GV, US, &
                      CS%vertvisc_CSp, CS%OBC)
   call vertvisc(u_in, v_in, h_av, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp,&
-                G, GV, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot)
+                G, GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot)
   call cpu_clock_end(id_clock_vertvisc)
   call pass_vector(up, vp, G%Domain, clock=id_clock_pass)
   call pass_vector(u_in, v_in, G%Domain, clock=id_clock_pass)
@@ -614,7 +614,7 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, US, param_file, diag
   call continuity_init(Time, G, GV, param_file, diag, CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, param_file, diag, CS%ADp, CS%CoriolisAdv_CSp)
   if (use_tides) call tidal_forcing_init(Time, G, param_file, CS%tides_CSp)
-  call PressureForce_init(Time, G, GV, param_file, diag, CS%PressureForce_CSp, &
+  call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, &
                           CS%tides_CSp)
   call hor_visc_init(Time, G, param_file, diag, CS%hor_visc_CSp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -931,15 +931,13 @@ subroutine calculateBuoyancyFlux2d(G, GV, US, fluxes, optics, h, Temp, Salt, tv,
 
   netT(G%isc:G%iec) = 0. ; netS(G%isc:G%iec) = 0.
 
-!$OMP parallel do default(none) shared(G,GV,fluxes,optics,h,Temp,Salt,tv,buoyancyFlux,&
-!$OMP                                  netHeatMinusSW,netSalt,skip_diags)             &
-!$OMP                     firstprivate(netT,netS)
-  do j = G%jsc, G%jec
+  !$OMP parallel do default(shared) firstprivate(netT,netS)
+  do j=G%jsc,G%jec
     call calculateBuoyancyFlux1d(G, GV, US, fluxes, optics, h, Temp, Salt, tv, j, buoyancyFlux(:,j,:), &
                                  netT, netS, skip_diags=skip_diags)
     if (present(netHeatMinusSW)) netHeatMinusSW(G%isc:G%iec,j) = netT(G%isc:G%iec)
     if (present(netSalt)) netSalt(G%isc:G%iec,j) = netS(G%isc:G%iec)
-  enddo ! j
+  enddo
 
 end subroutine calculateBuoyancyFlux2d
 

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -13,6 +13,7 @@ use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
 use MOM_shortwave_abs, only : sumSWoverBands, optics_type
 use MOM_spatial_means, only : global_area_integral, global_area_mean
+use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : surface, thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type
 
@@ -817,10 +818,11 @@ end subroutine extractFluxes2d
 !! These are actual fluxes, with units of stuff per time. Setting dt=1 in the call to
 !! extractFluxes routine allows us to get "stuf per time" rather than the time integrated
 !! fluxes needed in other routines that call extractFluxes.
-subroutine calculateBuoyancyFlux1d(G, GV, fluxes, optics, h, Temp, Salt, tv, j, &
+subroutine calculateBuoyancyFlux1d(G, GV, US, fluxes, optics, h, Temp, Salt, tv, j, &
                                    buoyancyFlux, netHeatMinusSW, netSalt, skip_diags)
   type(ocean_grid_type),                    intent(in)    :: G              !< ocean grid
   type(verticalGrid_type),                  intent(in)    :: GV             !< ocean vertical grid structure
+  type(unit_scale_type),                    intent(in)    :: US             !< A dimensional unit scaling type
   type(forcing),                            intent(inout) :: fluxes         !< surface fluxes
   type(optics_type),                        pointer       :: optics         !< penetrating SW optics
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h              !< layer thickness (H)
@@ -858,7 +860,7 @@ subroutine calculateBuoyancyFlux1d(G, GV, fluxes, optics, h, Temp, Salt, tv, j, 
 
   depthBeforeScalingFluxes = max( GV%Angstrom_H, 1.e-30*GV%m_to_H )
   pressure(:) = 0. ! Ignore atmospheric pressure
-  GoRho       = (GV%g_Earth*GV%m_to_Z) / GV%Rho0
+  GoRho       = (GV%g_Earth*US%m_to_Z) / GV%Rho0
   start       = 1 + G%isc - G%isd
   npts        = 1 + G%iec - G%isc
 
@@ -906,16 +908,17 @@ end subroutine calculateBuoyancyFlux1d
 
 !> Calculates surface buoyancy flux by adding up the heat, FW and salt fluxes,
 !! for 2d arrays.  This is a wrapper for calculateBuoyancyFlux1d.
-subroutine calculateBuoyancyFlux2d(G, GV, fluxes, optics, h, Temp, Salt, tv, &
+subroutine calculateBuoyancyFlux2d(G, GV, US, fluxes, optics, h, Temp, Salt, tv, &
                                    buoyancyFlux, netHeatMinusSW, netSalt, skip_diags)
-  type(ocean_grid_type),                      intent(in)    :: G              !< ocean grid
-  type(verticalGrid_type),                    intent(in)    :: GV             !< ocean vertical grid structure
-  type(forcing),                              intent(inout) :: fluxes         !< surface fluxes
-  type(optics_type),                          pointer       :: optics         !< SW ocean optics
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: h              !< layer thickness (H)
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: Temp           !< temperature (deg C)
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: Salt           !< salinity (ppt)
-  type(thermo_var_ptrs),                      intent(inout) :: tv             !< thermodynamics type
+  type(ocean_grid_type),                      intent(in)    :: G      !< ocean grid
+  type(verticalGrid_type),                    intent(in)    :: GV     !< ocean vertical grid structure
+  type(unit_scale_type),                      intent(in)    :: US     !< A dimensional unit scaling type
+  type(forcing),                              intent(inout) :: fluxes !< surface fluxes
+  type(optics_type),                          pointer       :: optics !< SW ocean optics
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: h      !< layer thickness (H)
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: Temp   !< temperature (deg C)
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: Salt   !< salinity (ppt)
+  type(thermo_var_ptrs),                      intent(inout) :: tv     !< thermodynamics type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: buoyancyFlux   !< buoy flux (m^2/s^3)
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(inout) :: netHeatMinusSW !< surf temp flux (K H)
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(inout) :: netSalt        !< surf salt flux (ppt H)
@@ -932,7 +935,7 @@ subroutine calculateBuoyancyFlux2d(G, GV, fluxes, optics, h, Temp, Salt, tv, &
 !$OMP                                  netHeatMinusSW,netSalt,skip_diags)             &
 !$OMP                     firstprivate(netT,netS)
   do j = G%jsc, G%jec
-    call calculateBuoyancyFlux1d(G, GV, fluxes, optics, h, Temp, Salt, tv, j, buoyancyFlux(:,j,:), &
+    call calculateBuoyancyFlux1d(G, GV, US, fluxes, optics, h, Temp, Salt, tv, j, buoyancyFlux(:,j,:), &
                                  netT, netS, skip_diags=skip_diags)
     if (present(netHeatMinusSW)) netHeatMinusSW(G%isc:G%iec,j) = netT(G%isc:G%iec)
     if (present(netSalt)) netSalt(G%isc:G%iec,j) = netS(G%isc:G%iec)

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -46,7 +46,7 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, eta_to_m)
   integer,                          optional, intent(in)  :: halo_size !< width of halo points on
                                                                  !! which to calculate eta.
   real,                             optional, intent(in)  :: eta_to_m  !< The conversion factor from
-             !! the units of eta to m; by default this is GV%Z_to_m.
+             !! the units of eta to m; by default this is US%Z_to_m.
 
   ! Local variables
   real :: p(SZI_(G),SZJ_(G),SZK_(G)+1)
@@ -66,7 +66,7 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, eta_to_m)
   if ((isv<G%isd) .or. (iev>G%ied) .or. (jsv<G%jsd) .or. (jev>G%jed)) &
     call MOM_error(FATAL,"find_eta called with an overly large halo_size.")
 
-  Z_to_eta = 1.0 ; if (present(eta_to_m)) Z_to_eta = GV%Z_to_m / eta_to_m
+  Z_to_eta = 1.0 ; if (present(eta_to_m)) Z_to_eta = US%Z_to_m / eta_to_m
   H_to_eta = GV%H_to_Z * Z_to_eta
   H_to_rho_eta =  GV%H_to_kg_m2 * (US%m_to_Z * Z_to_eta)
   I_gEarth = Z_to_eta / GV%g_Earth
@@ -161,7 +161,7 @@ subroutine find_eta_2d(h, tv, G, GV, US, eta, eta_bt, halo_size, eta_to_m)
   integer,                          optional, intent(in)  :: halo_size !< width of halo points on
                                                                  !! which to calculate eta.
   real,                             optional, intent(in)  :: eta_to_m  !< The conversion factor from
-             !! the units of eta to m; by default this is GV%Z_to_m.
+             !! the units of eta to m; by default this is US%Z_to_m.
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: &
     p     ! The pressure in Pa.
@@ -176,7 +176,7 @@ subroutine find_eta_2d(h, tv, G, GV, US, eta, eta_bt, halo_size, eta_to_m)
   is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
   nz = G%ke
 
-  Z_to_eta = 1.0 ; if (present(eta_to_m)) Z_to_eta = GV%Z_to_m / eta_to_m
+  Z_to_eta = 1.0 ; if (present(eta_to_m)) Z_to_eta = US%Z_to_m / eta_to_m
   H_to_eta = GV%H_to_Z * Z_to_eta
   H_to_rho_eta =  GV%H_to_kg_m2 * (US%m_to_Z * Z_to_eta)
   I_gEarth = Z_to_eta / GV%g_Earth

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -6,6 +6,7 @@ module MOM_interface_heights
 use MOM_error_handler, only : MOM_error, FATAL
 use MOM_file_parser, only : log_version
 use MOM_grid, only : ocean_grid_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : int_specific_vol_dp
@@ -27,23 +28,23 @@ contains
 !! form for consistency with the calculation of the pressure gradient forces.
 !! Additionally, these height may be dilated for consistency with the
 !! corresponding time-average quantity from the barotropic calculation.
-subroutine find_eta_3d(h, tv, G, GV, eta, eta_bt, halo_size, eta_to_m)
-  type(ocean_grid_type),                      intent(in)  :: G         !< The ocean's grid structure.
-  type(verticalGrid_type),                    intent(in)  :: GV        !< The ocean's vertical
-                                                                       !! grid structure.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)  :: h         !< Layer thicknesses, in H
-                                                                       !! (usually m or kg m-2).
-  type(thermo_var_ptrs),                      intent(in)  :: tv        !< A structure pointing to
-                                                                       !! various thermodynamic
-                                                                       !! variables.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(out) :: eta       !< layer interface heights
-                                                                       !! (Z or 1/eta_to_m m).
-  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)  :: eta_bt    !< optional barotropic
+subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, eta_to_m)
+  type(ocean_grid_type),                      intent(in)  :: G   !< The ocean's grid structure.
+  type(verticalGrid_type),                    intent(in)  :: GV  !< The ocean's vertical grid structure.
+  type(unit_scale_type),                      intent(in)  :: US  !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)  :: h   !< Layer thicknesses, in H
+                                                                 !! (usually m or kg m-2).
+  type(thermo_var_ptrs),                      intent(in)  :: tv  !< A structure pointing to
+                                                                 !! various thermodynamic
+                                                                 !! variables.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(out) :: eta !< layer interface heights
+                                                                 !! (Z or 1/eta_to_m m).
+  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)  :: eta_bt !< optional barotropic
              !! variable that gives the "correct" free surface height (Boussinesq) or total water
              !! column mass per unit area (non-Boussinesq).  This is used to dilate the layer.
              !! thicknesses when calculating interfaceheights, in H (m or kg m-2).
   integer,                          optional, intent(in)  :: halo_size !< width of halo points on
-                                                                       !! which to calculate eta.
+                                                                 !! which to calculate eta.
   real,                             optional, intent(in)  :: eta_to_m  !< The conversion factor from
              !! the units of eta to m; by default this is GV%Z_to_m.
 
@@ -67,7 +68,7 @@ subroutine find_eta_3d(h, tv, G, GV, eta, eta_bt, halo_size, eta_to_m)
 
   Z_to_eta = 1.0 ; if (present(eta_to_m)) Z_to_eta = GV%Z_to_m / eta_to_m
   H_to_eta = GV%H_to_Z * Z_to_eta
-  H_to_rho_eta =  GV%H_to_kg_m2 * (GV%m_to_Z * Z_to_eta)
+  H_to_rho_eta =  GV%H_to_kg_m2 * (US%m_to_Z * Z_to_eta)
   I_gEarth = Z_to_eta / GV%g_Earth
 
 !$OMP parallel default(shared) private(dilate,htot)
@@ -142,23 +143,23 @@ end subroutine find_eta_3d
 !! with the calculation of the pressure gradient forces.  Additionally, the sea
 !! surface height may be adjusted for consistency with the corresponding
 !! time-average quantity from the barotropic calculation.
-subroutine find_eta_2d(h, tv, G, GV, eta, eta_bt, halo_size, eta_to_m)
-  type(ocean_grid_type),                      intent(in)  :: G        !< The ocean's grid structure.
-  type(verticalGrid_type),                    intent(in)  :: GV       !< The ocean's vertical grid
-                                                                      !! structure.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)  :: h        !< Layer thicknesses, in H
-                                                                      !! (usually m or kg m-2).
-  type(thermo_var_ptrs),                      intent(in)  :: tv       !< A structure pointing to
-                                                                      !! various thermodynamic
-                                                                      !! variables.
-  real, dimension(SZI_(G),SZJ_(G)),           intent(out) :: eta      !< free surface height
-                                                                      !! relative to mean sea
-                                                                      !! level (z=0) (m).
-  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)  :: eta_bt   !< optional barotropic
+subroutine find_eta_2d(h, tv, G, GV, US, eta, eta_bt, halo_size, eta_to_m)
+  type(ocean_grid_type),                      intent(in)  :: G   !< The ocean's grid structure.
+  type(verticalGrid_type),                    intent(in)  :: GV  !< The ocean's vertical grid structure.
+  type(unit_scale_type),                      intent(in)  :: US  !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)  :: h   !< Layer thicknesses, in H
+                                                                 !! (usually m or kg m-2).
+  type(thermo_var_ptrs),                      intent(in)  :: tv  !< A structure pointing to
+                                                                 !! various thermodynamic
+                                                                 !! variables.
+  real, dimension(SZI_(G),SZJ_(G)),           intent(out) :: eta !< free surface height
+                                                                 !! relative to mean sea
+                                                                 !! level (z=0) (m).
+  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)  :: eta_bt !< optional barotropic
                    !! variable that gives the "correct" free surface height (Boussinesq) or total
                    !! water column mass per unit area (non-Boussinesq), in H (m or kg m-2).
   integer,                          optional, intent(in)  :: halo_size !< width of halo points on
-                                                                       !! which to calculate eta.
+                                                                 !! which to calculate eta.
   real,                             optional, intent(in)  :: eta_to_m  !< The conversion factor from
              !! the units of eta to m; by default this is GV%Z_to_m.
   ! Local variables
@@ -177,7 +178,7 @@ subroutine find_eta_2d(h, tv, G, GV, eta, eta_bt, halo_size, eta_to_m)
 
   Z_to_eta = 1.0 ; if (present(eta_to_m)) Z_to_eta = GV%Z_to_m / eta_to_m
   H_to_eta = GV%H_to_Z * Z_to_eta
-  H_to_rho_eta =  GV%H_to_kg_m2 * (GV%m_to_Z * Z_to_eta)
+  H_to_rho_eta =  GV%H_to_kg_m2 * (US%m_to_Z * Z_to_eta)
   I_gEarth = Z_to_eta / GV%g_Earth
 
 !$OMP parallel default(shared) private(htot)

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -4,6 +4,7 @@ module MOM_isopycnal_slopes
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_grid, only : ocean_grid_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : int_specific_vol_dp, calculate_density_derivs
@@ -17,10 +18,11 @@ public calc_isoneutral_slopes
 contains
 
 !> Calculate isopycnal slopes, and optionally return N2 used in calculation.
-subroutine calc_isoneutral_slopes(G, GV, h, e, tv, dt_kappa_smooth, &
+subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, &
                                   slope_x, slope_y, N2_u, N2_v, halo) !, eta_to_m)
   type(ocean_grid_type),                       intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),                     intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),                       intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),    intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1),  intent(in)    :: e    !< Interface heights (in Z or units
                                                                      !! given by 1/eta_to_m)
@@ -114,7 +116,7 @@ subroutine calc_isoneutral_slopes(G, GV, h, e, tv, dt_kappa_smooth, &
 
   present_N2_u = PRESENT(N2_u)
   present_N2_v = PRESENT(N2_v)
-  G_Rho0 = (GV%g_Earth*L_to_Z*GV%m_to_Z) / GV%Rho0
+  G_Rho0 = (GV%g_Earth*L_to_Z*US%m_to_Z) / GV%Rho0
   if (present_N2_u) then
     do j=js,je ; do I=is-1,ie
       N2_u(I,j,1) = 0.

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -41,7 +41,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, &
   integer,                           optional, intent(in)    :: halo !< Halo width over which to compute
 
   ! real,                              optional, intent(in)    :: eta_to_m !< The conversion factor from the units
-  !  (This argument has been tested but for now serves no purpose.)  !! of eta to m; GV%Z_to_m by default.
+  !  (This argument has been tested but for now serves no purpose.)  !! of eta to m; US%Z_to_m by default.
   ! Local variables
   real, dimension(SZI_(G), SZJ_(G), SZK_(G)) :: &
     T, &          ! The temperature (or density) in C, with the values in
@@ -105,7 +105,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, &
   nz = G%ke ; IsdB = G%IsdB
 
   h_neglect = GV%H_subroundoff ; h_neglect2 = h_neglect**2
-  Z_to_L = GV%Z_to_m ; H_to_Z = GV%H_to_Z
+  Z_to_L = US%Z_to_m ; H_to_Z = GV%H_to_Z
   ! if (present(eta_to_m)) then
   !   Z_to_L = eta_to_m ; H_to_Z = GV%H_to_m / eta_to_m
   ! endif

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -73,7 +73,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                                intent(in) :: um  !< The new zonal velocity, in m s-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
-                               intent(in) :: hin !< The layer thickness, in m.
+                               intent(in) :: hin !< The layer thickness, in H.
   type(accel_diag_ptrs),       intent(in) :: ADp !< A structure pointing to the various
                                                  !! accelerations in the momentum equations.
   type(cont_diag_ptrs),        intent(in) :: CDp !<  A structure with pointers to various terms
@@ -88,7 +88,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
                      optional, intent(in) :: a   !< The layer coupling coefficients from vertvisc, Z s-1.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                      optional, intent(in) :: hv  !< The layer thicknesses at velocity grid points,
-                                                 !! from vertvisc, in m.
+                                                 !! from vertvisc, in H.
   ! Local variables
   real    :: f_eff, CFL
   real    :: Angstrom
@@ -231,27 +231,27 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
     endif
 
     write(file,'(/,"h--:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i,j-1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j-1,k)); enddo
     write(file,'(/,"h+-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i+1,j-1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j-1,k)); enddo
     write(file,'(/,"h-0:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i,j,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j,k)); enddo
     write(file,'(/,"h+0:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i+1,j,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j,k)); enddo
     write(file,'(/,"h-+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i,j+1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j+1,k)); enddo
     write(file,'(/,"h++:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (hin(i+1,j+1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j+1,k)); enddo
 
 
-    e(nz+1) = -G%Zd_to_m*G%bathyT(i,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + hin(i,j,k) ; enddo
+    e(nz+1) = -GV%Z_to_m*G%bathyT(i,j)
+    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j,k) ; enddo
     write(file,'(/,"e-:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
 
-    e(nz+1) = -G%Zd_to_m*G%bathyT(i+1,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + hin(i+1,j,k) ; enddo
+    e(nz+1) = -GV%Z_to_m*G%bathyT(i+1,j)
+    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i+1,j,k) ; enddo
     write(file,'(/,"e+:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K) ; enddo
@@ -281,53 +281,53 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 
     write(file,'(/,"vh--:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%vh(i,J-1,k)*G%IdxCv(i,J-1)); enddo
+                                    (GV%H_to_m*CDp%vh(i,J-1,k)*G%IdxCv(i,J-1)); enddo
     write(file,'(/," vhC--:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                        (0.5*CS%v_av(i,j-1,k)*(hin(i,j-1,k) + hin(i,j,k))); enddo
+                        (0.5*CS%v_av(i,j-1,k)*GV%H_to_m*(hin(i,j-1,k) + hin(i,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp--:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%v_prev(i,j-1,k)*(hin(i,j-1,k) + hin(i,j,k))); enddo
+                          (0.5*CS%v_prev(i,j-1,k)*GV%H_to_m*(hin(i,j-1,k) + hin(i,j,k))); enddo
     endif
 
     write(file,'(/,"vh-+:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%vh(i,J,k)*G%IdxCv(i,J)); enddo
+                                    (GV%H_to_m*CDp%vh(i,J,k)*G%IdxCv(i,J)); enddo
     write(file,'(/," vhC-+:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                        (0.5*CS%v_av(i,J,k)*(hin(i,j,k) + hin(i,j+1,k))); enddo
+                        (0.5*CS%v_av(i,J,k)*GV%H_to_m*(hin(i,j,k) + hin(i,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp-+:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%v_prev(i,J,k)*(hin(i,j,k) + hin(i,j+1,k))); enddo
+                          (0.5*CS%v_prev(i,J,k)*GV%H_to_m*(hin(i,j,k) + hin(i,j+1,k))); enddo
     endif
 
     write(file,'(/,"vh+-:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                      (CDp%vh(i+1,J-1,k)*G%IdxCv(i+1,J-1)); enddo
+                                      (GV%H_to_m*CDp%vh(i+1,J-1,k)*G%IdxCv(i+1,J-1)); enddo
     write(file,'(/," vhC+-:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                    (0.5*CS%v_av(i+1,J-1,k)*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
+                    (0.5*CS%v_av(i+1,J-1,k)*GV%H_to_m*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp+-:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                      (0.5*CS%v_prev(i+1,J-1,k)*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
+                      (0.5*CS%v_prev(i+1,J-1,k)*GV%H_to_m*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
     endif
 
     write(file,'(/,"vh++:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (CDp%vh(i+1,J,k)*G%IdxCv(i+1,J)); enddo
+                          (GV%H_to_m*CDp%vh(i+1,J,k)*G%IdxCv(i+1,J)); enddo
     write(file,'(/," vhC++:",$)')
          do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                     (0.5*CS%v_av(i+1,J,k)*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
+                     (0.5*CS%v_av(i+1,J,k)*GV%H_to_m*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp++:",$)')
            do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                       (0.5*CS%v_av(i+1,J,k)*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
+                       (0.5*CS%v_av(i+1,J,k)*GV%H_to_m*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
     endif
 
-    write(file,'(/,"D:     ",2(ES10.3))') G%Zd_to_m*G%bathyT(i,j),G%Zd_to_m*G%bathyT(i+1,j)
+    write(file,'(/,"D:     ",2(ES10.3))') GV%Z_to_m*G%bathyT(i,j),GV%Z_to_m*G%bathyT(i+1,j)
 
   !  From here on, the normalized accelerations are written.
     if (prev_avail) then
@@ -401,7 +401,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                                intent(in) :: vm  !< The new meridional velocity, in m s-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
-                               intent(in) :: hin !< The layer thickness, in m.
+                               intent(in) :: hin !< The layer thickness, in H.
   type(accel_diag_ptrs),       intent(in) :: ADp !< A structure pointing to the various
                                                  !! accelerations in the momentum equations.
   type(cont_diag_ptrs),        intent(in) :: CDp !< A structure with pointers to various terms in
@@ -416,7 +416,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
                      optional, intent(in) :: a   !< The layer coupling coefficients from vertvisc, Z s-1.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                      optional, intent(in) :: hv  !< The layer thicknesses at velocity grid points,
-                                                 !! from vertvisc, in m.
+                                                 !! from vertvisc, in H.
   ! Local variables
   real    :: f_eff, CFL
   real    :: Angstrom
@@ -563,26 +563,26 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
     endif
 
     write(file,'("h--:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i-1,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i-1,j,k); enddo
     write(file,'(/,"h0-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i,j,k); enddo
     write(file,'(/,"h+-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i+1,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i+1,j,k); enddo
     write(file,'(/,"h-+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i-1,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i-1,j+1,k); enddo
     write(file,'(/,"h0+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i,j+1,k); enddo
     write(file,'(/,"h++:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') hin(i+1,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i+1,j+1,k); enddo
 
-    e(nz+1) = -G%Zd_to_m*G%bathyT(i,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + hin(i,j,k); enddo
+    e(nz+1) = -GV%Z_to_m*G%bathyT(i,j)
+    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j,k); enddo
     write(file,'(/,"e-:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
 
-    e(nz+1) = -G%Zd_to_m*G%bathyT(i,j+1)
-    do k=nz,1,-1 ; e(K) = e(K+1) + hin(i,j+1,k) ; enddo
+    e(nz+1) = -GV%Z_to_m*G%bathyT(i,j+1)
+    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j+1,k) ; enddo
     write(file,'(/,"e+:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
@@ -612,14 +612,14 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 
     write(file,'(/,"uh--:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%uh(I-1,j,k)*G%IdyCu(I-1,j)); enddo
+                                    (GV%H_to_m*CDp%uh(I-1,j,k)*G%IdyCu(I-1,j)); enddo
     write(file,'(/," uhC--: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I-1,j,k) * 0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
+            (CS%u_av(I-1,j,k) * GV%H_to_m*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp--:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%u_prev(I-1,j,k)*(hin(i-1,j,k) + hin(i,j,k))); enddo
+            (CS%u_prev(I-1,j,k) * GV%H_to_m*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
     endif
 
     write(file,'(/,"uh-+:  ",$)')
@@ -627,38 +627,38 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
                                     (CDp%uh(I-1,j+1,k)*G%IdyCu(I-1,j+1)); enddo
     write(file,'(/," uhC-+: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I-1,j+1,k) * 0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
+            (CS%u_av(I-1,j+1,k) * GV%H_to_m*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp-+:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                    (0.5*CS%u_prev(I-1,j+1,k)*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
+            (CS%u_prev(I-1,j+1,k) * GV%H_to_m*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
     endif
 
     write(file,'(/,"uh+-:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%uh(I,j,k)*G%IdyCu(I,j)); enddo
+                                    (GV%H_to_m*CDp%uh(I,j,k)*G%IdyCu(I,j)); enddo
     write(file,'(/," uhC+-: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I,j,k) * 0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
+            (CS%u_av(I,j,k) * GV%H_to_m*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp+-:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                            (0.5*CS%u_prev(I,j,k)*(hin(i,j,k) + hin(i+1,j,k))); enddo
+            (CS%u_prev(I,j,k) * GV%H_to_m*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
     endif
 
     write(file,'(/,"uh++:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%uh(I,j+1,k)*G%IdyCu(I,j+1)); enddo
+                                    (GV%H_to_m*CDp%uh(I,j+1,k)*G%IdyCu(I,j+1)); enddo
     write(file,'(/," uhC++: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I,j+1,k) * 0.5*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
+            (CS%u_av(I,j+1,k) * 0.5*GV%H_to_m*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp++:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                      (0.5*CS%u_prev(I,j+1,k)*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
+            (CS%u_prev(I,j+1,k) * GV%H_to_m*0.5*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
     endif
 
-    write(file,'(/,"D:     ",2(ES10.3))') G%Zd_to_m*G%bathyT(i,j),G%Zd_to_m*G%bathyT(i,j+1)
+    write(file,'(/,"D:     ",2(ES10.3))') GV%Z_to_m*G%bathyT(i,j),GV%Z_to_m*G%bathyT(i,j+1)
 
   !  From here on, the normalized accelerations are written.
     if (prev_avail) then

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -95,6 +95,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real    :: truncvel, du
   real    :: Inorm(SZK_(G))
   real    :: e(SZK_(G)+1)
+  real    :: h_scale, uh_scale
   integer :: yr, mo, day, hr, minute, sec, yearday
   integer :: k, ks, ke
   integer :: nz
@@ -103,6 +104,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   integer :: file
 
   Angstrom = GV%Angstrom_H + GV%H_subroundoff
+  h_scale = GV%H_to_m ; uh_scale = GV%H_to_m
 
 !  if (.not.associated(CS)) return
   nz = G%ke
@@ -231,27 +233,27 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
     endif
 
     write(file,'(/,"h--:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j-1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i,j-1,k)); enddo
     write(file,'(/,"h+-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j-1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i+1,j-1,k)); enddo
     write(file,'(/,"h-0:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i,j,k)); enddo
     write(file,'(/,"h+0:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i+1,j,k)); enddo
     write(file,'(/,"h-+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i,j+1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i,j+1,k)); enddo
     write(file,'(/,"h++:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (GV%H_to_m*hin(i+1,j+1,k)); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') (h_scale*hin(i+1,j+1,k)); enddo
 
 
     e(nz+1) = -GV%Z_to_m*G%bathyT(i,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j,k) ; enddo
+    do k=nz,1,-1 ; e(K) = e(K+1) + h_scale*hin(i,j,k) ; enddo
     write(file,'(/,"e-:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
 
     e(nz+1) = -GV%Z_to_m*G%bathyT(i+1,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i+1,j,k) ; enddo
+    do k=nz,1,-1 ; e(K) = e(K+1) + h_scale*hin(i+1,j,k) ; enddo
     write(file,'(/,"e+:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K) ; enddo
@@ -281,50 +283,50 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 
     write(file,'(/,"vh--:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%vh(i,J-1,k)*G%IdxCv(i,J-1)); enddo
+                                    (uh_scale*CDp%vh(i,J-1,k)*G%IdxCv(i,J-1)); enddo
     write(file,'(/," vhC--:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                        (0.5*CS%v_av(i,j-1,k)*GV%H_to_m*(hin(i,j-1,k) + hin(i,j,k))); enddo
+                        (0.5*CS%v_av(i,j-1,k)*h_scale*(hin(i,j-1,k) + hin(i,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp--:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%v_prev(i,j-1,k)*GV%H_to_m*(hin(i,j-1,k) + hin(i,j,k))); enddo
+                          (0.5*CS%v_prev(i,j-1,k)*h_scale*(hin(i,j-1,k) + hin(i,j,k))); enddo
     endif
 
     write(file,'(/,"vh-+:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%vh(i,J,k)*G%IdxCv(i,J)); enddo
+                                    (uh_scale*CDp%vh(i,J,k)*G%IdxCv(i,J)); enddo
     write(file,'(/," vhC-+:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                        (0.5*CS%v_av(i,J,k)*GV%H_to_m*(hin(i,j,k) + hin(i,j+1,k))); enddo
+                        (0.5*CS%v_av(i,J,k)*h_scale*(hin(i,j,k) + hin(i,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp-+:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (0.5*CS%v_prev(i,J,k)*GV%H_to_m*(hin(i,j,k) + hin(i,j+1,k))); enddo
+                          (0.5*CS%v_prev(i,J,k)*h_scale*(hin(i,j,k) + hin(i,j+1,k))); enddo
     endif
 
     write(file,'(/,"vh+-:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                      (GV%H_to_m*CDp%vh(i+1,J-1,k)*G%IdxCv(i+1,J-1)); enddo
+                                      (uh_scale*CDp%vh(i+1,J-1,k)*G%IdxCv(i+1,J-1)); enddo
     write(file,'(/," vhC+-:",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                    (0.5*CS%v_av(i+1,J-1,k)*GV%H_to_m*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
+                    (0.5*CS%v_av(i+1,J-1,k)*h_scale*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp+-:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                      (0.5*CS%v_prev(i+1,J-1,k)*GV%H_to_m*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
+                      (0.5*CS%v_prev(i+1,J-1,k)*h_scale*(hin(i+1,j-1,k) + hin(i+1,j,k))); enddo
     endif
 
     write(file,'(/,"vh++:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                          (GV%H_to_m*CDp%vh(i+1,J,k)*G%IdxCv(i+1,J)); enddo
+                          (uh_scale*CDp%vh(i+1,J,k)*G%IdxCv(i+1,J)); enddo
     write(file,'(/," vhC++:",$)')
          do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                     (0.5*CS%v_av(i+1,J,k)*GV%H_to_m*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
+                     (0.5*CS%v_av(i+1,J,k)*h_scale*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," vhCp++:",$)')
            do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                       (0.5*CS%v_av(i+1,J,k)*GV%H_to_m*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
+                       (0.5*CS%v_av(i+1,J,k)*h_scale*(hin(i+1,j,k) + hin(i+1,j+1,k))); enddo
     endif
 
     write(file,'(/,"D:     ",2(ES10.3))') GV%Z_to_m*G%bathyT(i,j),GV%Z_to_m*G%bathyT(i+1,j)
@@ -423,6 +425,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   real    :: truncvel, dv
   real    :: Inorm(SZK_(G))
   real    :: e(SZK_(G)+1)
+  real    :: h_scale, uh_scale
   integer :: yr, mo, day, hr, minute, sec, yearday
   integer :: k, ks, ke
   integer :: nz
@@ -431,6 +434,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
   integer :: file
 
   Angstrom = GV%Angstrom_H + GV%H_subroundoff
+  h_scale = GV%H_to_m ; uh_scale = GV%H_to_m
 
 !  if (.not.associated(CS)) return
   nz = G%ke
@@ -563,26 +567,26 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
     endif
 
     write(file,'("h--:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i-1,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i-1,j,k); enddo
     write(file,'(/,"h0-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i,j,k); enddo
     write(file,'(/,"h+-:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i+1,j,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i+1,j,k); enddo
     write(file,'(/,"h-+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i-1,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i-1,j+1,k); enddo
     write(file,'(/,"h0+:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i,j+1,k); enddo
     write(file,'(/,"h++:   ",$)')
-    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') GV%H_to_m*hin(i+1,j+1,k); enddo
+    do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') h_scale*hin(i+1,j+1,k); enddo
 
     e(nz+1) = -GV%Z_to_m*G%bathyT(i,j)
-    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j,k); enddo
+    do k=nz,1,-1 ; e(K) = e(K+1) + h_scale*hin(i,j,k); enddo
     write(file,'(/,"e-:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
 
     e(nz+1) = -GV%Z_to_m*G%bathyT(i,j+1)
-    do k=nz,1,-1 ; e(K) = e(K+1) + GV%H_to_m*hin(i,j+1,k) ; enddo
+    do k=nz,1,-1 ; e(K) = e(K+1) + h_scale*hin(i,j+1,k) ; enddo
     write(file,'(/,"e+:    ",$)')
     write(file,'(ES10.3," ",$)') e(ks)
     do K=ks+1,ke+1 ; if (do_k(k-1)) write(file,'(ES10.3," ",$)') e(K); enddo
@@ -612,50 +616,50 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, CS, vel_rpt, str, a
 
     write(file,'(/,"uh--:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%uh(I-1,j,k)*G%IdyCu(I-1,j)); enddo
+                                    (uh_scale*CDp%uh(I-1,j,k)*G%IdyCu(I-1,j)); enddo
     write(file,'(/," uhC--: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I-1,j,k) * GV%H_to_m*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
+            (CS%u_av(I-1,j,k) * h_scale*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp--:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_prev(I-1,j,k) * GV%H_to_m*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
+            (CS%u_prev(I-1,j,k) * h_scale*0.5*(hin(i-1,j,k) + hin(i,j,k))); enddo
     endif
 
     write(file,'(/,"uh-+:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (CDp%uh(I-1,j+1,k)*G%IdyCu(I-1,j+1)); enddo
+                                    (uh_scale*CDp%uh(I-1,j+1,k)*G%IdyCu(I-1,j+1)); enddo
     write(file,'(/," uhC-+: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I-1,j+1,k) * GV%H_to_m*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
+            (CS%u_av(I-1,j+1,k) * h_scale*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp-+:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_prev(I-1,j+1,k) * GV%H_to_m*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
+            (CS%u_prev(I-1,j+1,k) * h_scale*0.5*(hin(i-1,j+1,k) + hin(i,j+1,k))); enddo
     endif
 
     write(file,'(/,"uh+-:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%uh(I,j,k)*G%IdyCu(I,j)); enddo
+                                    (uh_scale*CDp%uh(I,j,k)*G%IdyCu(I,j)); enddo
     write(file,'(/," uhC+-: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I,j,k) * GV%H_to_m*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
+            (CS%u_av(I,j,k) * h_scale*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp+-:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_prev(I,j,k) * GV%H_to_m*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
+            (CS%u_prev(I,j,k) * h_scale*0.5*(hin(i,j,k) + hin(i+1,j,k))); enddo
     endif
 
     write(file,'(/,"uh++:  ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-                                    (GV%H_to_m*CDp%uh(I,j+1,k)*G%IdyCu(I,j+1)); enddo
+                                    (uh_scale*CDp%uh(I,j+1,k)*G%IdyCu(I,j+1)); enddo
     write(file,'(/," uhC++: ",$)')
     do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_av(I,j+1,k) * 0.5*GV%H_to_m*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
+            (CS%u_av(I,j+1,k) * 0.5*h_scale*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
     if (prev_avail) then
       write(file,'(/," uhCp++:",$)')
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ",$)') &
-            (CS%u_prev(I,j+1,k) * GV%H_to_m*0.5*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
+            (CS%u_prev(I,j+1,k) * h_scale*0.5*(hin(i,j+1,k) + hin(i+1,j+1,k))); enddo
     endif
 
     write(file,'(/,"D:     ",2(ES10.3))') GV%Z_to_m*G%bathyT(i,j),GV%Z_to_m*G%bathyT(i,j+1)

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -6,17 +6,18 @@ module MOM_diag_to_Z
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_domains,       only : pass_var
 use MOM_coms,          only : reproducing_sum
 use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl, time_type, diag_axis_init
 use MOM_diag_mediator, only : axes_grp, define_axes_group
 use MOM_diag_mediator, only : ocean_register_diag
+use MOM_domains,       only : pass_var
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
 use MOM_io,            only : slasher, vardesc, query_vardesc, modify_vardesc
 use MOM_spatial_means, only : global_layer_mean
+use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : p3d, p2d
 use MOM_verticalGrid,  only : verticalGrid_type
 
@@ -138,9 +139,10 @@ function global_z_mean(var, G, GV, CS, tracer)
 end function global_z_mean
 
 !> This subroutine maps tracers and velocities into depth space for diagnostics.
-subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
+subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, US, CS)
   type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                            intent(in)    :: u    !< The zonal velocity, in m s-1.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -202,7 +204,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
 
   ! Update the halos
   if (ice_shelf) then
-    do J=Jsq,Jeq+1 ; do i=Isq,Ieq+1 ; ssh(i,j) = GV%m_to_Z*ssh_in(i,j) ; enddo ; enddo
+    do J=Jsq,Jeq+1 ; do i=Isq,Ieq+1 ; ssh(i,j) = US%m_to_Z*ssh_in(i,j) ; enddo ; enddo
     call pass_var(ssh, G%Domain)
   endif
 
@@ -242,8 +244,8 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         h_f(k2,I) = Angstrom ; u_f(k2,I) = 0.0
         ! GM: D_pt is always slightly larger (by 1E-6 or so) than shelf_depth, so
         ! I consider that the ice shelf is grounded for diagnostic purposes when
-        ! shelf_depth(I) + 1.0E-3*GV%m_to_Z > D_pt(i)
-        if (ice_shelf .and. (shelf_depth(I) + 1.0E-3*GV%m_to_Z > D_pt(i))) nk_valid(I)=0
+        ! shelf_depth(I) + 1.0E-3*US%m_to_Z > D_pt(i)
+        if (ice_shelf .and. (shelf_depth(I) + 1.0E-3*US%m_to_Z > D_pt(i))) nk_valid(I)=0
       endif ; enddo
 
 
@@ -337,7 +339,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         ! no-slip BBC in the output, if anything but piecewise constant is used.
         nk_valid(i) = nk_valid(i) + 1 ; k2 = nk_valid(i)
         h_f(k2,i) = Angstrom ; v_f(k2,i) = 0.0
-        if (ice_shelf .and. shelf_depth(i) + 1.0E-3*GV%m_to_Z > D_pt(i)) nk_valid(I)=0
+        if (ice_shelf .and. shelf_depth(i) + 1.0E-3*US%m_to_Z > D_pt(i)) nk_valid(I)=0
       endif ; enddo
 
       do i=is,ie ; if (nk_valid(i) > 0) then
@@ -422,7 +424,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         if ((G%mask2dT(i,j) > 0.5) .and. (h(i,j,k) > 2.0*Angstrom)) then
           nk_valid(i) = nk_valid(i) + 1 ; k2 = nk_valid(i)
           h_f(k2,i) = h(i,j,k)
-          if (ice_shelf .and. shelf_depth(I) + 1.0E-3*GV%m_to_Z > D_pt(i)) nk_valid(I)=0
+          if (ice_shelf .and. shelf_depth(I) + 1.0E-3*US%m_to_Z > D_pt(i)) nk_valid(I)=0
           do m=1,CS%num_tr_used ; tr_f(k2,m,i) = CS%tr_model(m)%p(i,j,k) ; enddo
         endif
       enddo ; enddo
@@ -953,10 +955,11 @@ subroutine register_Z_tracer_low(tr_ptr, name, long_name, units, standard_name, 
 end subroutine register_Z_tracer_low
 
 !> This subroutine sets parameters that control Z-space diagnostic output.
-subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
+subroutine MOM_diag_to_Z_init(Time, G, GV, US, param_file, diag, CS)
   type(time_type),         intent(in)    :: Time !< Current model time.
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters.
   type(diag_ctrl), target, intent(inout) :: diag !< Struct to regulate diagnostic output.
   type(diag_to_Z_CS),      pointer       :: CS   !< Pointer to point to control structure for
@@ -999,7 +1002,7 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
     in_dir = slasher(in_dir)
     call get_Z_depths(trim(in_dir)//trim(zgrid_file), "zw", CS%Z_int, "zt", &
                       z_axis, zint_axis, CS%nk_zspace)
-    do K=1,CS%nk_zspace+1 ; CS%Z_int(K) = GV%m_to_Z*CS%Z_int(K) ; enddo
+    do K=1,CS%nk_zspace+1 ; CS%Z_int(K) = US%m_to_Z*CS%Z_int(K) ; enddo
     call log_param(param_file, mdl, "!INPUTDIR/Z_OUTPUT_GRID_FILE", &
                    trim(in_dir)//trim(zgrid_file))
     call log_param(param_file, mdl, "!NK_ZSPACE (from file)", CS%nk_zspace, &

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -66,7 +66,7 @@ type, public :: diag_to_Z_CS ; private
   integer :: num_tr_used = 0 !< Th enumber of tracers in use.
   integer :: nk_zspace = -1 !< The number of levels in the z-space output
 
-  real, pointer :: Z_int(:) => NULL()  !< interface depths of the z-space file (meter)
+  real, pointer :: Z_int(:) => NULL()  !< interface depths of the z-space file, in Z
 
   !>@{ Axis groups for z-space diagnostic output
   type(axes_grp) :: axesBz,  axesTz,  axesCuz,  axesCvz
@@ -85,13 +85,14 @@ integer, parameter :: NO_ZSPACE = -1 !< Flag to enable z-space?
 contains
 
 !> Return the global horizontal mean in z-space
-function global_z_mean(var,G,CS,tracer)
-  type(ocean_grid_type), intent(in)  :: G    !< The ocean's grid structure
-  type(diag_to_Z_CS),    pointer     :: CS   !< Control structure returned by
-                                             !! previous call to diag_to_Z_init.
+function global_z_mean(var, G, GV, CS, tracer)
+  type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
+  type(diag_to_Z_CS),      pointer     :: CS   !< Control structure returned by
+                                               !! previous call to diag_to_Z_init.
   real, dimension(SZI_(G), SZJ_(G), CS%nk_zspace), &
-                         intent(in)  :: var    !< An array with the variable to average
-  integer,               intent(in)  :: tracer !< The tracer index being worked on
+                           intent(in)  :: var  !< An array with the variable to average
+  integer,                 intent(in)  :: tracer !< The tracer index being worked on
   ! Local variables
   real, dimension(SZI_(G), SZJ_(G), CS%nk_zspace)  :: tmpForSumming, weight
   real, dimension(CS%nk_zspace)                    :: global_z_mean, scalarij, weightij
@@ -107,13 +108,13 @@ function global_z_mean(var,G,CS,tracer)
   do k=1,nz ; do j=js,je ; do i=is,ie
     valid_point = 1.0
     ! Weight factor for partial bottom cells
-    depth_weight = min( max( (-G%Zd_to_m*G%bathyT(i,j)), CS%Z_int(k+1) ) - CS%Z_int(k), 0.)
+    depth_weight = min( max(-G%bathyT(i,j), CS%Z_int(k+1)) - CS%Z_int(k), 0.)
 
     ! Flag the point as invalid if it contains missing data, or is below the bathymetry
     if (var(i,j,k) == CS%missing_tr(tracer)) valid_point = 0.
     if (depth_weight == 0.) valid_point = 0.
 
-    weight(i,j,k) = depth_weight * ( (valid_point * (G%areaT(i,j) * G%mask2dT(i,j))) )
+    weight(i,j,k) = GV%Z_to_m * depth_weight * ( (valid_point * (G%areaT(i,j) * G%mask2dT(i,j))) )
 
     ! If the point is flagged, set the variable itself to zero to avoid NaNs
     if (valid_point == 0.) then
@@ -123,8 +124,8 @@ function global_z_mean(var,G,CS,tracer)
     endif
   enddo ; enddo ; enddo
 
-  global_temp_scalar   = reproducing_sum(tmpForSumming,sums=scalarij)
-  global_weight_scalar = reproducing_sum(weight,sums=weightij)
+  global_temp_scalar   = reproducing_sum(tmpForSumming, sums=scalarij)
+  global_weight_scalar = reproducing_sum(weight, sums=weightij)
 
   do k=1, nz
     if (scalarij(k) == 0) then
@@ -154,8 +155,8 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
                                                  !! to diag_to_Z_init.
   ! Local variables
   ! Note the deliberately reversed axes in h_f, u_f, v_f, and tr_f.
-  real :: ssh(SZI_(G),SZJ_(G))   ! copy of ssh_in (meter or kg/m2)
-  real :: e(SZK_(G)+2)           ! z-star interface heights (meter or kg/m2)
+  real :: ssh(SZI_(G),SZJ_(G))   ! copy of ssh_in whose halos can be updated (meter or kg/m2)
+  real :: e(SZK_(G)+2)           ! z-star interface heights in Z
   real :: h_f(SZK_(G)+1,SZI_(G)) ! thicknesses of massive layers (meter or kg/m2)
   real :: u_f(SZK_(G)+1,SZIB_(G))! zonal velocity component in any massive layer
   real :: v_f(SZK_(G)+1,SZI_(G)) ! meridional velocity component in any massive layer
@@ -163,8 +164,8 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
   real :: tr_f(SZK_(G),max(CS%num_tr_used,1),SZI_(G)) ! tracer concentration in massive layers
   integer :: nk_valid(SZIB_(G))  ! number of massive layers in a column
 
-  real :: D_pt(SZIB_(G))        ! bottom depth (meter or kg/m2)
-  real :: shelf_depth(SZIB_(G)) ! ice shelf depth (meter or kg/m2)
+  real :: D_pt(SZIB_(G))        ! bottom depth in Z
+  real :: shelf_depth(SZIB_(G)) ! ice shelf depth in Z
   real :: htot           ! summed layer thicknesses (meter or kg/m2)
   real :: dilate         ! proportion by which to dilate every layer
   real :: wt(SZK_(G)+1)  ! fractional weight for each layer in the
@@ -191,15 +192,19 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
   IsgB = G%IsgB ; IegB = G%IegB ; JsgB = G%JsgB ; JegB = G%JegB
   nkml = max(GV%nkml, 1)
   Angstrom = GV%Angstrom_H
-  ssh(:,:) = ssh_in
   linear_velocity_profiles = .true.
-  ! Update the halos
-  call pass_var(ssh, G%Domain)
+
 
   if (.not.associated(CS)) call MOM_error(FATAL, &
          "diagnostic_fields_zstar: Module must be initialized before it is used.")
 
   ice_shelf = associated(frac_shelf_h)
+
+  ! Update the halos
+  if (ice_shelf) then
+    do J=Jsq,Jeq+1 ; do i=Isq,Ieq+1 ; ssh(i,j) = GV%m_to_Z*ssh_in(i,j) ; enddo ; enddo
+    call pass_var(ssh, G%Domain)
+  endif
 
   ! If no fields are needed, return
   if ((CS%id_u_z <= 0) .and. (CS%id_v_z <= 0) .and. (CS%num_tr_used < 1)) return
@@ -217,7 +222,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
       ! Remove all massless layers.
       do I=Isq,Ieq
         nk_valid(I) = 0
-        D_pt(I) = 0.5*G%Zd_to_m*(G%bathyT(i+1,j)+G%bathyT(i,j))
+        D_pt(I) = 0.5*(G%bathyT(i+1,j)+G%bathyT(i,j))
         if (ice_shelf) then
           if (frac_shelf_h(i,j)+frac_shelf_h(i+1,j) > 0.) then ! under shelf
             shelf_depth(I) = abs(0.5*(ssh(i+1,j)+ssh(i,j)))
@@ -236,9 +241,9 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         nk_valid(I) = nk_valid(I) + 1 ; k2 = nk_valid(I)
         h_f(k2,I) = Angstrom ; u_f(k2,I) = 0.0
         ! GM: D_pt is always slightly larger (by 1E-6 or so) than shelf_depth, so
-        ! I consider that the ice shelf is grounded when
-        ! shelf_depth(I) + 1.0E-3 > D_pt(i)
-        if (ice_shelf .and. shelf_depth(I) + 1.0E-3 > D_pt(i)) nk_valid(I)=0
+        ! I consider that the ice shelf is grounded for diagnostic purposes when
+        ! shelf_depth(I) + 1.0E-3*GV%m_to_Z > D_pt(i)
+        if (ice_shelf .and. (shelf_depth(I) + 1.0E-3*GV%m_to_Z > D_pt(i))) nk_valid(I)=0
       endif ; enddo
 
 
@@ -246,8 +251,8 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
       ! Calculate the z* interface heights for tracers.
         htot = 0.0 ; do k=1,nk_valid(i) ; htot = htot + h_f(k,i) ; enddo
         dilate = 0.0
-        if (htot*GV%H_to_m > 2.0*Angstrom) then
-           dilate = MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot
+        if (htot > 2.0*Angstrom) then
+          dilate = MAX((D_pt(i) - shelf_depth(i)), GV%Angstrom_Z)/htot
         endif
         e(nk_valid(i)+1) = -D_pt(i)
         do k=nk_valid(i),1,-1 ; e(K) = e(K+1) + h_f(k,i)*dilate ; enddo
@@ -314,7 +319,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
       shelf_depth(:) = 0.0 ! initially all is open ocean
       ! Remove all massless layers.
       do i=is,ie
-        nk_valid(i) = 0 ; D_pt(i) = 0.5*G%Zd_to_m*(G%bathyT(i,j)+G%bathyT(i,j+1))
+        nk_valid(i) = 0 ; D_pt(i) = 0.5*(G%bathyT(i,j)+G%bathyT(i,j+1))
         if (ice_shelf) then
           if (frac_shelf_h(i,j)+frac_shelf_h(i,j+1) > 0.) then ! under shelf
             shelf_depth(i) = abs(0.5*(ssh(i,j)+ssh(i,j+1)))
@@ -332,7 +337,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         ! no-slip BBC in the output, if anything but piecewise constant is used.
         nk_valid(i) = nk_valid(i) + 1 ; k2 = nk_valid(i)
         h_f(k2,i) = Angstrom ; v_f(k2,i) = 0.0
-        if (ice_shelf .and. shelf_depth(i) + 1.0E-3 > D_pt(i)) nk_valid(I)=0
+        if (ice_shelf .and. shelf_depth(i) + 1.0E-3*GV%m_to_Z > D_pt(i)) nk_valid(I)=0
       endif ; enddo
 
       do i=is,ie ; if (nk_valid(i) > 0) then
@@ -340,7 +345,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         htot = 0.0 ; do k=1,nk_valid(i) ; htot = htot + h_f(k,i) ; enddo
         dilate = 0.0
         if (htot > 2.0*Angstrom) then
-           dilate = MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot
+          dilate = MAX((D_pt(i) - shelf_depth(i)), GV%Angstrom_Z)/htot
         endif
         e(nk_valid(i)+1) = -D_pt(i)
         do k=nk_valid(i),1,-1 ; e(K) = e(K+1) + h_f(k,i)*dilate ; enddo
@@ -406,7 +411,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
       shelf_depth(:) = 0.0 ! initially all is open ocean
       ! Remove all massless layers.
       do i=is,ie
-        nk_valid(i) = 0 ; D_pt(i) = G%Zd_to_m*G%bathyT(i,j)
+        nk_valid(i) = 0 ; D_pt(i) = G%bathyT(i,j)
         if (ice_shelf) then
           if (frac_shelf_h(i,j) > 0.) then ! under shelf
             shelf_depth(i) = abs(ssh(i,j))
@@ -417,7 +422,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         if ((G%mask2dT(i,j) > 0.5) .and. (h(i,j,k) > 2.0*Angstrom)) then
           nk_valid(i) = nk_valid(i) + 1 ; k2 = nk_valid(i)
           h_f(k2,i) = h(i,j,k)
-          if (ice_shelf .and. shelf_depth(I) + 1.0E-3 > D_pt(i)) nk_valid(I)=0
+          if (ice_shelf .and. shelf_depth(I) + 1.0E-3*GV%m_to_Z > D_pt(i)) nk_valid(I)=0
           do m=1,CS%num_tr_used ; tr_f(k2,m,i) = CS%tr_model(m)%p(i,j,k) ; enddo
         endif
       enddo ; enddo
@@ -427,7 +432,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
         htot = 0.0 ;  do k=1,nk_valid(i) ; htot = htot + h_f(k,i) ; enddo
         dilate = 0.0
         if (htot > 2.0*Angstrom) then
-           dilate = MAX((D_pt(i) - shelf_depth(i)),Angstrom)/htot
+          dilate = MAX((D_pt(i) - shelf_depth(i)), GV%Angstrom_Z)/htot
         endif
         e(nk_valid(i)+1) = -D_pt(i)
         do k=nk_valid(i),1,-1 ; e(K) = e(K+1) + h_f(k,i)*dilate ; enddo
@@ -478,7 +483,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, CS)
     do m=1,CS%num_tr_used
       if (CS%id_tr(m) > 0) call post_data(CS%id_tr(m), CS%tr_z(m)%p, CS%diag)
       if (CS%id_tr_xyave(m) > 0) then
-        layer_ave = global_z_mean(CS%tr_z(m)%p,G,CS,m)
+        layer_ave = global_z_mean(CS%tr_z(m)%p, G, GV, CS, m)
         call post_data(CS%id_tr_xyave(m), layer_ave, CS%diag)
       endif
     enddo
@@ -505,9 +510,9 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
                                                                    !! diag_to_Z_init.
   ! Local variables
   real, dimension(SZI_(G), SZJ_(G)) :: &
-    htot, &        ! total layer thickness (meter or kg/m2)
-    dilate         ! nondimensional factor by which to dilate layers to
-                   ! convert them into z* space.  (-G%D < z* < 0)
+    htot, &        ! total layer thickness, in H
+    dilate         ! Factor by which to dilate layers to convert them
+                   ! into z* space, in Z H-1.  (-G%D < z* < 0)
 
   real, dimension(SZI_(G), max(CS%nk_zspace,1)) :: &
     uh_Z           ! uh_int interpolated into depth space (m3 or kg)
@@ -515,22 +520,22 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
     vh_Z           ! vh_int interpolated into depth space (m3 or kg)
 
   real :: h_rem    ! dilated thickness of a layer that has yet to be mapped
-                   ! into depth space (meter or kg/m2)
+                   ! into depth space (in Z)
   real :: uh_rem   ! integrated zonal transport of a layer that has yet to be
                    ! mapped into depth space (m3 or kg)
   real :: vh_rem   ! integrated meridional transport of a layer that has yet
                    ! to be mapped into depth space (m3 or kg)
   real :: h_here   ! thickness of a layer that is within the range of the
-                   ! current depth level (meter or kg/m2)
+                   ! current depth level (in Z)
   real :: h_above  ! thickness of a layer that is above the current depth
-                   ! level (meter or kg.m2)
+                   ! level (in Z)
   real :: uh_here  ! zonal transport of a layer that is attributed to the
                    ! current depth level (m3 or kg)
   real :: vh_here  ! meridional transport of a layer that is attributed to
                    ! the current depth level (m3 or kg)
   real :: Idt      ! inverse of the time step (sec)
 
-  real :: Z_int_above(SZIB_(G)) ! height of the interface atop a layer (meter or kg/m2)
+  real :: z_int_above(SZIB_(G)) ! height of the interface atop a layer (meter or kg/m2)
 
   integer :: kz(SZIB_(G)) ! index of depth level that is being contributed to
 
@@ -556,13 +561,13 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
     htot(i,j) = htot(i,j) + h(i,j,k)
   enddo ; enddo ; enddo
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-    dilate(i,j) = G%Zd_to_m*G%bathyT(i,j) / htot(i,j)
+    dilate(i,j) = G%bathyT(i,j) / htot(i,j)
   enddo ; enddo
 
   ! zonal transport
   if (CS%id_uh_Z > 0) then ; do j=js,je
     do I=Isq,Ieq
-      kz(I) = nk_z ; z_int_above(I) = -0.5*G%Zd_to_m*(G%bathyT(i,j)+G%bathyT(i+1,j))
+      kz(I) = nk_z ; z_int_above(I) = -0.5*(G%bathyT(i,j)+G%bathyT(i+1,j))
     enddo
     do k=nk_z,1,-1 ; do I=Isq,Ieq
       uh_Z(I,k) = 0.0
@@ -597,7 +602,7 @@ subroutine calculate_Z_transport(uh_int, vh_int, h, dt, G, GV, CS)
   ! meridional transport
   if (CS%id_vh_Z > 0) then ; do J=Jsq,Jeq
     do i=is,ie
-      kz(i) = nk_z ; z_int_above(i) = -0.5*G%Zd_to_m*(G%bathyT(i,j)+G%bathyT(i,j+1))
+      kz(i) = nk_z ; z_int_above(i) = -0.5*(G%bathyT(i,j)+G%bathyT(i,j+1))
     enddo
     do k=nk_z,1,-1 ; do i=is,ie
       vh_Z(i,k) = 0.0
@@ -650,9 +655,9 @@ end subroutine calculate_Z_transport
 !! of each layer. It also calculates the normalized relative depths of the range
 !! of each layer that overlaps that depth range.
 subroutine find_overlap(e, Z_top, Z_bot, k_max, k_start, k_top, k_bot, wt, z1, z2)
-  real, dimension(:), intent(in)    :: e      !< Column interface heights (meter or kg/m2).
-  real,               intent(in)    :: Z_top  !< Top of range being mapped to (meter or kg/m2).
-  real,               intent(in)    :: Z_bot  !< Bottom of range being mapped to (meter or kg/m2).
+  real, dimension(:), intent(in)    :: e      !< Column interface heights, in arbitrary units.
+  real,               intent(in)    :: Z_top  !< Top of range being mapped to, in the units of e.
+  real,               intent(in)    :: Z_bot  !< Bottom of range being mapped to, in the units of e.
   integer,            intent(in)    :: k_max  !< Number of valid layers.
   integer,            intent(in)    :: k_start !< Layer at which to start searching.
   integer,            intent(inout) :: k_top  !< Indices of top layers that overlap with the depth
@@ -713,11 +718,11 @@ end subroutine find_overlap
 !! a piecewise limited scheme.
 subroutine find_limited_slope(val, e, slope, k)
   real, dimension(:), intent(in)  :: val !< A column of values that are being interpolated.
-  real, dimension(:), intent(in)  :: e   !< Column interface heights (meter or kg/m2).
+  real, dimension(:), intent(in)  :: e   !< Column interface heights in arbitrary units
   real,               intent(out) :: slope !< Normalized slope in the intracell distribution of val.
   integer,            intent(in)  :: k   !< Layer whose slope is being determined.
   ! Local variables
-  real :: d1, d2
+  real :: d1, d2  ! Thicknesses in the units of e.
 
   d1 = 0.5*(e(K-1)-e(K+1)) ; d2 = 0.5*(e(K)-e(K+2))
   if (((val(k)-val(k-1)) * (val(k)-val(k+1)) >= 0.0) .or. (d1*d2 <= 0.0)) then
@@ -773,8 +778,8 @@ subroutine calc_Zint_diags(h, in_ptrs, ids, num_diags, G, GV, CS)
     do k=1,nk ; do i=is,ie ; htot(i) = htot(i) + h(i,j,k) ; enddo ; enddo
     do i=is,ie
       dilate(i) = 0.0
-      if (htot(i)*GV%H_to_m > 0.5) dilate(i) = (G%Zd_to_m*G%bathyT(i,j) - 0.0) / htot(i)
-      e(i,nk+1) = -G%Zd_to_m*G%bathyT(i,j)
+      if (htot(i) > 0.5*GV%m_to_H) dilate(i) = (G%bathyT(i,j) - 0.0) / htot(i)
+      e(i,nk+1) = -G%bathyT(i,j)
     enddo
     do k=nk,1,-1 ; do i=is,ie
       e(i,k) = e(i,k+1) + h(i,j,k) * dilate(i)
@@ -964,8 +969,8 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
   character(len=200) :: in_dir, zgrid_file    ! strings for directory/file
   character(len=48)  :: flux_units, string
   integer :: z_axis, zint_axis
-  integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nk, id_test
-  isd  = G%isd   ; ied = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nk = G%ke
+  integer :: k, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nk, id_test
+  isd  = G%isd  ; ied = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nk = G%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
   if (associated(CS)) then
@@ -994,6 +999,7 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, param_file, diag, CS)
     in_dir = slasher(in_dir)
     call get_Z_depths(trim(in_dir)//trim(zgrid_file), "zw", CS%Z_int, "zt", &
                       z_axis, zint_axis, CS%nk_zspace)
+    do K=1,CS%nk_zspace+1 ; CS%Z_int(K) = GV%m_to_Z*CS%Z_int(K) ; enddo
     call log_param(param_file, mdl, "!INPUTDIR/Z_OUTPUT_GRID_FILE", &
                    trim(in_dir)//trim(zgrid_file))
     call log_param(param_file, mdl, "!NK_ZSPACE (from file)", CS%nk_zspace, &
@@ -1051,7 +1057,7 @@ subroutine get_Z_depths(depth_file, int_depth_name, int_depth, cell_depth_name, 
   character(len=*),   intent(in)  :: depth_file  !< The file to read for the depths
   character(len=*),   intent(in)  :: int_depth_name !< The interface depth variable name
   real, dimension(:), pointer     :: int_depth   !< A pointer that will be allocated and
-                                                 !! returned with the interface depths
+                                                 !! returned with the interface depths in m
   character(len=*),   intent(in)  :: cell_depth_name !< The cell-center depth variable name
   integer,            intent(out) :: z_axis_index !< The cell-center z-axis diagnostic index handle
   integer,            intent(out) :: edge_index  !< The interface z-axis diagnostic index handle

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -86,9 +86,10 @@ integer, parameter :: NO_ZSPACE = -1 !< Flag to enable z-space?
 contains
 
 !> Return the global horizontal mean in z-space
-function global_z_mean(var, G, GV, CS, tracer)
+function global_z_mean(var, G, GV, US, CS, tracer)
   type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
   type(diag_to_Z_CS),      pointer     :: CS   !< Control structure returned by
                                                !! previous call to diag_to_Z_init.
   real, dimension(SZI_(G), SZJ_(G), CS%nk_zspace), &
@@ -115,7 +116,7 @@ function global_z_mean(var, G, GV, CS, tracer)
     if (var(i,j,k) == CS%missing_tr(tracer)) valid_point = 0.
     if (depth_weight == 0.) valid_point = 0.
 
-    weight(i,j,k) = GV%Z_to_m * depth_weight * ( (valid_point * (G%areaT(i,j) * G%mask2dT(i,j))) )
+    weight(i,j,k) = US%Z_to_m * depth_weight * ( (valid_point * (G%areaT(i,j) * G%mask2dT(i,j))) )
 
     ! If the point is flagged, set the variable itself to zero to avoid NaNs
     if (valid_point == 0.) then
@@ -485,7 +486,7 @@ subroutine calculate_Z_diag_fields(u, v, h, ssh_in, frac_shelf_h, G, GV, US, CS)
     do m=1,CS%num_tr_used
       if (CS%id_tr(m) > 0) call post_data(CS%id_tr(m), CS%tr_z(m)%p, CS%diag)
       if (CS%id_tr_xyave(m) > 0) then
-        layer_ave = global_z_mean(CS%tr_z(m)%p, G, GV, CS, m)
+        layer_ave = global_z_mean(CS%tr_z(m)%p, G, GV, US, CS, m)
         call post_data(CS%id_tr_xyave(m), layer_ave, CS%diag)
       endif
     enddo

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -56,7 +56,7 @@ type, public :: sum_output_CS ; private
   logical :: read_depth_list    !<   Read the depth list from a file if it exists
                                 !! and write it if it doesn't.
   character(len=200) :: depth_list_file  !< The name of the depth list file.
-  real    :: D_list_min_inc     !<  The minimum increment, in m, between the depths of the
+  real    :: D_list_min_inc     !<  The minimum increment, in Z, between the depths of the
                                 !! entries in the depth-list file, 0 by default.
   logical :: use_temperature    !<   If true, temperature and salinity are state variables.
   real    :: fresh_water_input  !<   The total mass of fresh water added by surface fluxes
@@ -211,8 +211,8 @@ subroutine MOM_sum_output_init(G, param_file, directory, ntrnc, &
                    "create that file otherwise.", default=.false.)
     call get_param(param_file, mdl, "DEPTH_LIST_MIN_INC", CS%D_list_min_inc, &
                    "The minimum increment between the depths of the \n"//&
-                   "entries in the depth-list file.", units="m", &
-                   default=1.0E-10)
+                   "entries in the depth-list file.", &
+                   units="m", default=1.0E-10, scale=1.0/G%Zd_to_m)
     if (CS%read_depth_list) then
       call get_param(param_file, mdl, "DEPTH_LIST_FILE", CS%depth_list_file, &
                    "The name of the depth list file.", default="Depth_list.nc")
@@ -288,21 +288,21 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
                     optional, pointer    :: OBC !< Open boundaries control structure.
   type(time_type),  optional, intent(in) :: dt_forcing !< The forcing time step
   ! Local variables
-  real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! The height of interfaces, in m.
+  real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! The height of interfaces, in Z.
   real :: areaTm(SZI_(G),SZJ_(G)) ! A masked version of areaT, in m2.
   real :: KE(SZK_(G))  ! The total kinetic energy of a layer, in J.
   real :: PE(SZK_(G)+1)! The available potential energy of an interface, in J.
   real :: KE_tot       ! The total kinetic energy, in J.
   real :: PE_tot       ! The total available potential energy, in J.
-  real :: H_0APE(SZK_(G)+1) ! The uniform depth which overlies the same
-                       ! volume as is below an interface, in m.
-                       ! H is usually positive.
+  real :: Z_0APE(SZK_(G)+1) ! The uniform depth which overlies the same
+                       ! volume as is below an interface, in Z.
+  real :: H_0APE(SZK_(G)+1) ! A version of Z_0APE, converted to m, usually positive.
   real :: toten        ! The total kinetic & potential energies of
                        ! all layers, in Joules (i.e. kg m2 s-2).
   real :: En_mass      ! The total kinetic and potential energies divided by
                        ! the total mass of the ocean, in m2 s-2.
-  real :: vol_lay(SZK_(G))  ! The volume of fluid in a layer, in m3.
-  real :: volbelow     ! The volume of all layers beneath an interface in m3.
+  real :: vol_lay(SZK_(G))  ! The volume of fluid in a layer, in Z m2.
+  real :: volbelow     ! The volume of all layers beneath an interface in Z m2.
   real :: mass_lay(SZK_(G)) ! The mass of fluid in a layer, in kg.
   real :: mass_tot     ! The total mass of the ocean in kg.
   real :: vol_tot      ! The total ocean volume in m3.
@@ -332,12 +332,11 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
   real :: temp_anom    ! The change in total heat that cannot be accounted for
                        ! by the surface fluxes, divided by the total heat
                        ! capacity of the ocean, in C.
-  real :: hint         ! The deviation of an interface from H, in m.
+  real :: hint         ! The deviation of an interface from H, in Z.
   real :: hbot         ! 0 if the basin is deeper than H, or the
                        ! height of the basin depth over H otherwise,
-                       ! in m. This makes PE only include real fluid.
-  real :: hbelow       ! The depth of fluid in all layers beneath
-                       ! an interface, in m.
+                       ! in Z. This makes PE only include real fluid.
+  real :: hbelow       ! The depth of fluid in all layers beneath an interface, in Z.
   type(EFP_type) :: &
     mass_EFP, &        ! Extended fixed point sums of total mass, etc.
     salt_EFP, heat_EFP, salt_chg_EFP, heat_chg_EFP, mass_chg_EFP, &
@@ -345,37 +344,35 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
   real :: CFL_trans    ! A transport-based definition of the CFL number, nondim.
   real :: CFL_lin      ! A simpler definition of the CFL number, nondim.
   real :: max_CFL(2)   ! The maxima of the CFL numbers, nondim.
-  real :: Irho0
+  real :: Irho0        ! The inverse of the reference density, in m3 kg-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: &
-    tmp1
+    tmp1               ! A temporary array
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: &
-    PE_pt
+    PE_pt              ! The potential energy at each point, in J.
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    Temp_int, Salt_int
-  real :: H_to_m, H_to_kg_m2  ! Local copies of unit conversion factors.
+    Temp_int, Salt_int ! Layer and cell integrated heat and salt, in J and g Salt.
+  real :: H_to_kg_m2   ! Local copy of a unit conversion factor.
   integer :: num_nc_fields  ! The number of fields that will actually go into
                             ! the NetCDF file.
   integer :: i, j, k, is, ie, js, je, ns, nz, m, Isq, Ieq, Jsq, Jeq
-  integer :: l, lbelow, labove   ! indices of deep_area_vol, used to find
-                                 ! H.  lbelow & labove are lower & upper
-                                 ! limits for l in the search for lH.
+  integer :: l, lbelow, labove   ! indices of deep_area_vol, used to find Z_0APE.
+                                 ! lbelow & labove are lower & upper limits for l
+                                 ! in the search for the entry in lH to use.
   integer :: start_of_day, num_days
   real    :: reday, var
   character(len=240) :: energypath_nc
   character(len=200) :: mesg
   character(len=32)  :: mesg_intro, time_units, day_str, n_str, date_str
   logical :: date_stamped
-  type(time_type) :: dt_force
+  type(time_type) :: dt_force ! A time_type version of the forcing timestep.
   real :: Tr_stocks(MAX_FIELDS_)
-  real :: Tr_min(MAX_FIELDS_),Tr_max(MAX_FIELDS_)
+  real :: Tr_min(MAX_FIELDS_), Tr_max(MAX_FIELDS_)
   real :: Tr_min_x(MAX_FIELDS_), Tr_min_y(MAX_FIELDS_), Tr_min_z(MAX_FIELDS_)
   real :: Tr_max_x(MAX_FIELDS_), Tr_max_y(MAX_FIELDS_), Tr_max_z(MAX_FIELDS_)
   logical :: Tr_minmax_got(MAX_FIELDS_) = .false.
   character(len=40), dimension(MAX_FIELDS_) :: &
     Tr_names, Tr_units
   integer :: nTr_stocks
-  real, allocatable :: toten_PE(:)
-  integer :: pe_num
   integer :: iyear, imonth, iday, ihour, iminute, isecond, itick ! For call to get_date()
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
@@ -445,7 +442,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
-  H_to_m = GV%H_to_m ; H_to_kg_m2 = GV%H_to_kg_m2
+  H_to_kg_m2 = GV%H_to_kg_m2
 
   if (.not.associated(CS)) call MOM_error(FATAL, &
          "write_energy: Module must be initialized before it is used.")
@@ -489,7 +486,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
     endif
 
     mass_tot = reproducing_sum(tmp1, sums=mass_lay, EFP_sum=mass_EFP)
-    do k=1,nz ; vol_lay(k) = (H_to_m/H_to_kg_m2)*mass_lay(k) ; enddo
+    do k=1,nz ; vol_lay(k) = (GV%H_to_Z/H_to_kg_m2)*mass_lay(k) ; enddo
   else
     tmp1(:,:,:) = 0.0
     if (CS%do_APE_calc) then
@@ -498,17 +495,17 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
       enddo ; enddo ; enddo
       mass_tot = reproducing_sum(tmp1, sums=mass_lay, EFP_sum=mass_EFP)
 
-      call find_eta(h, tv, G, GV, eta, eta_to_m=1.0)
+      call find_eta(h, tv, G, GV, eta)
       do k=1,nz ; do j=js,je ; do i=is,ie
         tmp1(i,j,k) = (eta(i,j,K)-eta(i,j,K+1)) * areaTm(i,j)
       enddo ; enddo ; enddo
-      vol_tot = H_to_m*reproducing_sum(tmp1, sums=vol_lay)
+      vol_tot = GV%Z_to_m*reproducing_sum(tmp1, sums=vol_lay)
     else
       do k=1,nz ; do j=js,je ; do i=is,ie
         tmp1(i,j,k) = H_to_kg_m2 * h(i,j,k) * areaTm(i,j)
       enddo ; enddo ; enddo
       mass_tot = reproducing_sum(tmp1, sums=mass_lay, EFP_sum=mass_EFP)
-      do k=1,nz ; vol_lay(k) = mass_lay(k) / GV%Rho0 ; enddo
+      do k=1,nz ; vol_lay(k) = GV%m_to_Z * (mass_lay(k) / GV%Rho0) ; enddo
     endif
   endif ! Boussinesq
 
@@ -615,11 +612,43 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
         CS%lH(k) = l
       endif
       lbelow = l
-      H_0APE(K) = CS%DL(l)%depth - (volbelow - CS%DL(l)%vol_below) / CS%DL(l)%area
+      Z_0APE(K) = CS%DL(l)%depth - (volbelow - CS%DL(l)%vol_below) / CS%DL(l)%area
     enddo
-    H_0APE(nz+1) = CS%DL(2)%depth
+    Z_0APE(nz+1) = CS%DL(2)%depth
+
+    !   Calculate the Available Potential Energy integrated over each
+    ! interface.  With a nonlinear equation of state or with a bulk
+    ! mixed layer this calculation is only approximate.  With an ALE model
+    ! this does not make sense.
+    PE_pt(:,:,:) = 0.0
+    if (GV%Boussinesq) then
+      do j=js,je ; do i=is,ie
+        hbelow = 0.0
+        do k=nz,1,-1
+          hbelow = hbelow + h(i,j,k) * GV%H_to_Z
+          hint = Z_0APE(K) + (hbelow - G%bathyT(i,j))
+          hbot = Z_0APE(K) - G%bathyT(i,j)
+          hbot = (hbot + ABS(hbot)) * 0.5
+          PE_pt(i,j,K) = 0.5 * areaTm(i,j) * GV%Z_to_m*(GV%Rho0*GV%g_prime(K)) * &
+                  (hint * hint - hbot * hbot)
+        enddo
+      enddo ; enddo
+    else
+      do j=js,je ; do i=is,ie
+        do k=nz,1,-1
+          hint = Z_0APE(K) + eta(i,j,K)  ! eta and H_0 have opposite signs.
+          hbot = max(Z_0APE(K) - G%bathyT(i,j), 0.0)
+          PE_pt(i,j,K) = 0.5 * (areaTm(i,j) * GV%Z_to_m*(GV%Rho0*GV%g_prime(K))) * &
+                  (hint * hint - hbot * hbot)
+        enddo
+      enddo ; enddo
+    endif
+
+    PE_tot = reproducing_sum(PE_pt, sums=PE)
+    do k=1,nz+1 ; H_0APE(K) = GV%Z_to_m*Z_0APE(K) ; enddo
   else
-    do k=1,nz+1 ; H_0APE(K) = 0.0 ; enddo
+    PE_tot = 0.0
+    do k=1,nz+1 ; PE(K) = 0.0 ; H_0APE(K) = 0.0 ; enddo
   endif
 
 ! Calculate the Kinetic Energy integrated over each layer.
@@ -628,42 +657,8 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
     tmp1(i,j,k) = (0.25 * H_to_kg_m2 * (areaTm(i,j) * h(i,j,k))) * &
             (u(I-1,j,k)**2 + u(I,j,k)**2 + v(i,J-1,k)**2 + v(i,J,k)**2)
   enddo ; enddo ; enddo
-
-!   Calculate the Available Potential Energy integrated over each
-! interface.  With a nonlinear equation of state or with a bulk
-! mixed layer this calculation is only approximate.
-  do k=1,nz+1 ; PE(K) = 0.0 ; enddo
-  if (CS%do_APE_calc) then
-    PE_pt(:,:,:) = 0.0
-    if (GV%Boussinesq) then
-      do j=js,je ; do i=is,ie
-        hbelow = 0.0
-        do k=nz,1,-1
-          hbelow = hbelow + h(i,j,k) * H_to_m
-          hint = H_0APE(K) + (hbelow - G%Zd_to_m*G%bathyT(i,j))
-          hbot = H_0APE(K) - G%Zd_to_m*G%bathyT(i,j)
-          hbot = (hbot + ABS(hbot)) * 0.5
-          PE_pt(i,j,K) = 0.5 * areaTm(i,j) * (GV%Rho0*GV%m_to_Z*GV%g_prime(K)) * &
-                  (hint * hint - hbot * hbot)
-        enddo
-      enddo ; enddo
-    else
-      do j=js,je ; do i=is,ie
-        hbelow = 0.0
-        do k=nz,1,-1
-          hint = H_0APE(K) + eta(i,j,K)  ! eta and H_0 have opposite signs.
-          hbot = max(H_0APE(K) - G%Zd_to_m*G%bathyT(i,j), 0.0)
-          PE_pt(i,j,K) = 0.5 * (areaTm(i,j) * (GV%Rho0*GV%m_to_Z*GV%g_prime(K))) * &
-                  (hint * hint - hbot * hbot)
-        enddo
-      enddo ; enddo
-    endif
-  endif
-
   KE_tot = reproducing_sum(tmp1, sums=KE)
-  PE_tot = 0.0
-  if (CS%do_APE_calc) &
-    PE_tot = reproducing_sum(PE_pt, sums=PE)
+
   toten = KE_tot + PE_tot
 
   Salt = 0.0 ; Heat = 0.0
@@ -1061,15 +1056,15 @@ subroutine create_depth_list(G, CS)
                                           !! in which the ordered depth list is stored.
   ! Local variables
   real, dimension(G%Domain%niglobal*G%Domain%njglobal + 1) :: &
-    Dlist, &  !< The global list of bottom depths, in m.
+    Dlist, &  !< The global list of bottom depths, in Z.
     AreaList  !< The global list of cell areas, in m2.
   integer, dimension(G%Domain%niglobal*G%Domain%njglobal+1) :: &
     indx2     !< The position of an element in the original unsorted list.
-  real    :: Dnow  !< The depth now being considered for sorting, in m.
-  real    :: Dprev !< The most recent depth that was considered, in m.
-  real    :: vol   !< The running sum of open volume below a deptn, in m3.
+  real    :: Dnow  !< The depth now being considered for sorting, in Z.
+  real    :: Dprev !< The most recent depth that was considered, in Z.
+  real    :: vol   !< The running sum of open volume below a deptn, in Z m2.
   real    :: area  !< The open area at the current depth, in m2.
-  real    :: D_list_prev !< The most recent depth added to the list, in m.
+  real    :: D_list_prev !< The most recent depth added to the list, in Z.
   logical :: add_to_list !< This depth should be included as an entry on the list.
 
   integer :: ir, indxt
@@ -1088,7 +1083,7 @@ subroutine create_depth_list(G, CS)
     i_global = i + G%idg_offset - (G%isg-1)
 
     list_pos = (j_global-1)*G%Domain%niglobal + i_global
-    Dlist(list_pos) = G%Zd_to_m*G%bathyT(i,j)
+    Dlist(list_pos) = G%bathyT(i,j)
     Arealist(list_pos) = G%mask2dT(i,j)*G%areaT(i,j)
   enddo ; enddo
 
@@ -1238,7 +1233,7 @@ subroutine write_depth_list(G, CS, filename, list_size)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
       filename//trim(NF90_STRERROR(status)))
 
-  do k=1,list_size ; tmp(k) = CS%DL(k)%depth ; enddo
+  do k=1,list_size ; tmp(k) = G%Zd_to_m*CS%DL(k)%depth ; enddo
   status = NF90_PUT_VAR(ncid, Did, tmp)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
       filename//" depth "//trim(NF90_STRERROR(status)))
@@ -1248,7 +1243,7 @@ subroutine write_depth_list(G, CS, filename, list_size)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
       filename//" area "//trim(NF90_STRERROR(status)))
 
-  do k=1,list_size ; tmp(k) = CS%DL(k)%vol_below ; enddo
+  do k=1,list_size ; tmp(k) = G%Zd_to_m*CS%DL(k)%vol_below ; enddo
   status = NF90_PUT_VAR(ncid, Vid, tmp)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
       filename//" vol_below "//trim(NF90_STRERROR(status)))
@@ -1270,10 +1265,12 @@ subroutine read_depth_list(G, CS, filename)
   character(len=32) :: mdl
   character(len=240) :: var_name, var_msg
   real, allocatable :: tmp(:)
+  real    :: m_to_Z
   integer :: ncid, status, varid, list_size, k
   integer :: ndim, len, var_dim_ids(NF90_MAX_VAR_DIMS)
 
   mdl = "MOM_sum_output read_depth_list:"
+  m_to_Z = 1.0/G%Zd_to_m
 
   status = NF90_OPEN(filename, NF90_NOWRITE, ncid)
   if (status /= NF90_NOERR) then
@@ -1312,7 +1309,7 @@ subroutine read_depth_list(G, CS, filename)
         " Difficulties reading variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
 
-  do k=1,list_size ; CS%DL(k)%depth = tmp(k) ; enddo
+  do k=1,list_size ; CS%DL(k)%depth = m_to_Z*tmp(k) ; enddo
 
   var_name = "area"
   var_msg = trim(var_name)//" in "//trim(filename)//" - "
@@ -1338,7 +1335,7 @@ subroutine read_depth_list(G, CS, filename)
         " Difficulties reading variable "//trim(var_msg)//&
         trim(NF90_STRERROR(status)))
 
-  do k=1,list_size ; CS%DL(k)%vol_below = tmp(k) ; enddo
+  do k=1,list_size ; CS%DL(k)%vol_below = m_to_Z*tmp(k) ; enddo
 
   status = NF90_CLOSE(ncid)
   if (status /= NF90_NOERR) call MOM_error(WARNING, mdl// &

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -501,7 +501,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, OBC, dt_
       do k=1,nz ; do j=js,je ; do i=is,ie
         tmp1(i,j,k) = (eta(i,j,K)-eta(i,j,K+1)) * areaTm(i,j)
       enddo ; enddo ; enddo
-      vol_tot = GV%Z_to_m*reproducing_sum(tmp1, sums=vol_lay)
+      vol_tot = US%Z_to_m*reproducing_sum(tmp1, sums=vol_lay)
     else
       do k=1,nz ; do j=js,je ; do i=is,ie
         tmp1(i,j,k) = H_to_kg_m2 * h(i,j,k) * areaTm(i,j)
@@ -631,7 +631,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, OBC, dt_
           hint = Z_0APE(K) + (hbelow - G%bathyT(i,j))
           hbot = Z_0APE(K) - G%bathyT(i,j)
           hbot = (hbot + ABS(hbot)) * 0.5
-          PE_pt(i,j,K) = 0.5 * areaTm(i,j) * GV%Z_to_m*(GV%Rho0*GV%g_prime(K)) * &
+          PE_pt(i,j,K) = 0.5 * areaTm(i,j) * US%Z_to_m*(GV%Rho0*GV%g_prime(K)) * &
                   (hint * hint - hbot * hbot)
         enddo
       enddo ; enddo
@@ -640,14 +640,14 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, OBC, dt_
         do k=nz,1,-1
           hint = Z_0APE(K) + eta(i,j,K)  ! eta and H_0 have opposite signs.
           hbot = max(Z_0APE(K) - G%bathyT(i,j), 0.0)
-          PE_pt(i,j,K) = 0.5 * (areaTm(i,j) * GV%Z_to_m*(GV%Rho0*GV%g_prime(K))) * &
+          PE_pt(i,j,K) = 0.5 * (areaTm(i,j) * US%Z_to_m*(GV%Rho0*GV%g_prime(K))) * &
                   (hint * hint - hbot * hbot)
         enddo
       enddo ; enddo
     endif
 
     PE_tot = reproducing_sum(PE_pt, sums=PE)
-    do k=1,nz+1 ; H_0APE(K) = GV%Z_to_m*Z_0APE(K) ; enddo
+    do k=1,nz+1 ; H_0APE(K) = US%Z_to_m*Z_0APE(K) ; enddo
   else
     PE_tot = 0.0
     do k=1,nz+1 ; PE(K) = 0.0 ; H_0APE(K) = 0.0 ; enddo

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -21,6 +21,7 @@ use MOM_time_manager, only : operator(+), operator(-), operator(*), operator(/)
 use MOM_time_manager, only : operator(/=), operator(<=), operator(>=), operator(<)
 use MOM_time_manager, only : get_calendar_type, time_type_to_real, NO_CALENDAR
 use MOM_tracer_flow_control, only : tracer_flow_control_CS, call_tracer_stocks
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface, thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 
@@ -266,9 +267,10 @@ end subroutine MOM_sum_output_end
 
 !>  This subroutine calculates and writes the total model energy, the energy and
 !! mass of each layer, and other globally integrated  physical quantities.
-subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forcing)
+subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, OBC, dt_forcing)
   type(ocean_grid_type),   intent(in)    :: G   !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV  !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                            intent(in)    :: u   !< The zonal velocity, in m s-1.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -495,7 +497,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
       enddo ; enddo ; enddo
       mass_tot = reproducing_sum(tmp1, sums=mass_lay, EFP_sum=mass_EFP)
 
-      call find_eta(h, tv, G, GV, eta)
+      call find_eta(h, tv, G, GV, US, eta)
       do k=1,nz ; do j=js,je ; do i=is,ie
         tmp1(i,j,k) = (eta(i,j,K)-eta(i,j,K+1)) * areaTm(i,j)
       enddo ; enddo ; enddo
@@ -505,7 +507,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, CS, tracer_CSp, OBC, dt_forc
         tmp1(i,j,k) = H_to_kg_m2 * h(i,j,k) * areaTm(i,j)
       enddo ; enddo ; enddo
       mass_tot = reproducing_sum(tmp1, sums=mass_lay, EFP_sum=mass_EFP)
-      do k=1,nz ; vol_lay(k) = GV%m_to_Z * (mass_lay(k) / GV%Rho0) ; enddo
+      do k=1,nz ; vol_lay(k) = US%m_to_Z * (mass_lay(k) / GV%Rho0) ; enddo
     endif
   endif ! Boussinesq
 

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -325,11 +325,11 @@ subroutine wave_speed(h, tv, G, GV, US, cg1, CS, full_halos, use_ebt_mode, &
                     L2_to_Z2*gp > N2min*hw) then
                   ! Filters out regions where N2 increases with depth but only in a lower fraction of water column
                   gp = N2min/hw  !### THIS IS DIMENSIONALLY INCONSISTENT! -RWH
-                  !### This should be gp = GV%Z_to_m**2* (N2min*hw)
+                  !### This should be gp = US%Z_to_m**2* (N2min*hw)
                 elseif (l_mono_N2_depth>=0. .and. sum_hc>l_mono_N2_depth .and. L2_to_Z2*gp>N2min*hw) then
                   ! Filters out regions where N2 increases with depth but only below a certain depth
                   gp = N2min/hw  !### THIS IS DIMENSIONALLY INCONSISTENT! -RWH
-                  !### This should be gp = GV%Z_to_m**2* (N2min*hw)
+                  !### This should be gp = US%Z_to_m**2* (N2min*hw)
                 else
                   N2min = L2_to_Z2 * gp/hw
                 endif

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -609,18 +609,8 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos)
   H_to_m = GV%H_to_m
 
   min_h_frac = tol1 / real(nz)
-!$OMP parallel do default(none) shared(is,ie,js,je,nz,h,G,GV,min_h_frac,use_EOS,T,S,   &
-!$OMP                                  H_to_pres,H_to_m,tv,cn,g_Rho0,nmodes)           &
-!$OMP                          private(htot,hmin,kf,H_here,HxT_here,HxS_here,HxR_here, &
-!$OMP                                  Hf,Tf,Sf,Rf,pres,T_int,S_int,drho_dT,           &
-!$OMP                                  drho_dS,drxh_sum,kc,Hc,Tc,Sc,I_Hnew,gprime,     &
-!$OMP                                  Rc,speed2_tot,Igl,Igu,dlam,                     &
-!$OMP                                  det,ddet,ig,jg,z_int,N2,row,nrows,lam_1,        &
-!$OMP                                  lamMin,speed2_min,lamMax,lamInc,numint,det_l,   &
-!$OMP                                  ddet_l,xr,xl,det_r,xbl,xbr,ddet_r,xl_sub,       &
-!$OMP                                  ig_need_sub,jg_need_sub,sub_rootfound,nsub,     &
-!$OMP                                  det_sub,ddet_sub,lam_n,                         &
-!$OMP                                  a_diag,b_diag,c_diag,nrootsfound)
+  !$OMP parallel do default(private) shared(is,ie,js,je,nz,h,G,GV,US,min_h_frac,use_EOS,T,S, &
+  !$OMP                                     H_to_pres,H_to_m,tv,cn,g_Rho0,nmodes)
   do j=js,je
     !   First merge very thin layers with the one above (or below if they are
     ! at the top).  This also transposes the row order so that columns can

--- a/src/diagnostics/MOM_wave_structure.F90
+++ b/src/diagnostics/MOM_wave_structure.F90
@@ -444,7 +444,7 @@ subroutine wave_structure(h, tv, G, GV, US, cn, ModeNum, freq, CS, En, full_halo
                        !(including surface and bottom)
             w2avg = 0.0
             do k=1,nzm-1
-              dz(k) = GV%Z_to_m*Hc(k)
+              dz(k) = US%Z_to_m*Hc(k)
               w2avg = w2avg + 0.5*(w_strct(K)**2+w_strct(K+1)**2)*dz(k)
             enddo
             !### Some mathematical cancellations could occur in the next two lines.
@@ -503,7 +503,7 @@ subroutine wave_structure(h, tv, G, GV, US, cn, ModeNum, freq, CS, En, full_halo
             CS%u_strct(i,j,1:nzm)     = u_strct(:)
             CS%W_profile(i,j,1:nzm)   = W_profile(:)
             CS%Uavg_profile(i,j,1:nzm)= Uavg_profile(:)
-            CS%z_depths(i,j,1:nzm)    = GV%Z_to_m*z_int(:)
+            CS%z_depths(i,j,1:nzm)    = US%Z_to_m*z_int(:)
             CS%N2(i,j,1:nzm)          = N2(:)
             CS%num_intfaces(i,j)      = nzm
           else

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -15,6 +15,7 @@ use MOM_io,               only : slasher, vardesc, query_vardesc, mom_read_data
 use MOM_safe_alloc,       only : safe_alloc_ptr, safe_alloc_alloc
 use MOM_string_functions, only : lowercase
 use MOM_time_manager,     only : time_type
+use MOM_unit_scaling,       only : unit_scale_type
 use MOM_verticalGrid,     only : verticalGrid_type
 use MOM_EOS,              only : EOS_type
 use MOM_diag_remap,       only : diag_remap_ctrl
@@ -240,12 +241,13 @@ integer :: id_clock_diag_mediator, id_clock_diag_remap, id_clock_diag_grid_updat
 contains
 
 !> Sets up diagnostics axes
-subroutine set_axes_info(G, GV, param_file, diag_cs, set_vertical)
-  type(ocean_grid_type), intent(inout) :: G !< Ocean grid structure
-  type(verticalGrid_type), intent(in)  :: GV !< ocean vertical grid structure
-  type(param_file_type), intent(in)    :: param_file !< Parameter file structure
-  type(diag_ctrl),       intent(inout) :: diag_cs !< Diagnostics control structure
-  logical, optional,     intent(in)    :: set_vertical !< If true or missing, set up
+subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
+  type(ocean_grid_type),   intent(inout) :: G  !< Ocean grid structure
+  type(verticalGrid_type), intent(in)    :: GV !< ocean vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
+  type(param_file_type),   intent(in)    :: param_file !< Parameter file structure
+  type(diag_ctrl),         intent(inout) :: diag_cs !< Diagnostics control structure
+  logical,       optional, intent(in)    :: set_vertical !< If true or missing, set up
                                                        !! vertical axes
   ! Local variables
   integer :: id_xq, id_yq, id_zl, id_zi, id_xh, id_yh
@@ -347,7 +349,7 @@ subroutine set_axes_info(G, GV, param_file, diag_cs, set_vertical)
 
   do i=1, diag_cs%num_diag_coords
     ! For each possible diagnostic coordinate
-    call diag_remap_configure_axes(diag_cs%diag_remap_cs(i), GV, param_file)
+    call diag_remap_configure_axes(diag_cs%diag_remap_cs(i), GV, US, param_file)
 
     ! This vertical coordinate has been configured so can be used.
     if (diag_remap_axes_configured(diag_cs%diag_remap_cs(i))) then

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1917,7 +1917,7 @@ function register_static_field(module_name, field_name, axes, &
      long_name, units, missing_value, range, mask_variant, standard_name, &
      do_not_log, interp_method, tile_count, &
      cmor_field_name, cmor_long_name, cmor_units, cmor_standard_name, area, &
-     x_cell_method, y_cell_method, area_cell_method)
+     x_cell_method, y_cell_method, area_cell_method, conversion)
   integer :: register_static_field !< An integer handle for a diagnostic array.
   character(len=*), intent(in) :: module_name !< Name of this module, usually "ocean_model"
                                               !! or "ice_shelf_model"
@@ -1943,6 +1943,7 @@ function register_static_field(module_name, field_name, axes, &
   character(len=*), optional, intent(in) :: x_cell_method !< Specifies the cell method for the x-direction.
   character(len=*), optional, intent(in) :: y_cell_method !< Specifies the cell method for the y-direction.
   character(len=*), optional, intent(in) :: area_cell_method !< Specifies the cell method for area
+  real,             optional, intent(in) :: conversion !< A value to multiply data by before writing to file
 
   ! Local variables
   real :: MOM_missing_value
@@ -1971,6 +1972,7 @@ function register_static_field(module_name, field_name, axes, &
     call assert(associated(diag), 'register_static_field: diag allocation failed')
     diag%fms_diag_id = fms_id
     diag%debug_str = trim(module_name)//"-"//trim(field_name)
+    if (present(conversion)) diag%conversion_factor = conversion
     if (present(x_cell_method)) then
       call get_diag_axis_name(axes%handles(1), axis_name)
       call diag_field_add_attribute(fms_id, 'cell_methods', trim(axis_name)//':'//trim(x_cell_method))
@@ -2013,6 +2015,7 @@ function register_static_field(module_name, field_name, axes, &
       call alloc_diag_with_id(dm_id, diag_cs, cmor_diag)
       cmor_diag%fms_diag_id = fms_id
       cmor_diag%debug_str = trim(module_name)//"-"//trim(cmor_field_name)
+      if (present(conversion)) cmor_diag%conversion_factor = conversion
       if (present(x_cell_method)) then
         call get_diag_axis_name(axes%handles(1), axis_name)
         call diag_field_add_attribute(fms_id, 'cell_methods', trim(axis_name)//':'//trim(x_cell_method))

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -26,6 +26,7 @@ use MOM_io,               only : slasher, mom_read_data
 use MOM_io,               only : file_exists, field_size
 use MOM_string_functions, only : lowercase, extractWord
 use MOM_grid,             only : ocean_grid_type
+use MOM_unit_scaling,     only : unit_scale_type
 use MOM_verticalGrid,     only : verticalGrid_type
 use MOM_EOS,              only : EOS_type
 use MOM_remapping,        only : remapping_CS, initialize_remapping
@@ -136,10 +137,11 @@ end subroutine diag_remap_set_active
 
 !> Configure the vertical axes for a diagnostic remapping control structure.
 !! Reads a configuration parameters to determine coordinate generation.
-subroutine diag_remap_configure_axes(remap_cs, GV, param_file)
+subroutine diag_remap_configure_axes(remap_cs, GV, US, param_file)
   type(diag_remap_ctrl),   intent(inout) :: remap_cs !< Diag remap control structure
-  type(verticalGrid_type),    intent(in) :: GV !< ocean vertical grid structure
-  type(param_file_type),      intent(in) :: param_file !< Parameter file structure
+  type(verticalGrid_type), intent(in)    :: GV !< ocean vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
+  type(param_file_type),   intent(in)    :: param_file !< Parameter file structure
   ! Local variables
   integer :: nzi(4), nzl(4), k
   character(len=200) :: inputdir, string, filename, int_varname, layer_varname
@@ -152,7 +154,7 @@ subroutine diag_remap_configure_axes(remap_cs, GV, param_file)
 
   real, allocatable, dimension(:) :: interfaces, layers
 
-  call initialize_regridding(remap_cs%regrid_cs, GV, GV%max_depth, param_file, mod, &
+  call initialize_regridding(remap_cs%regrid_cs, GV, US, GV%max_depth, param_file, mod, &
            trim(remap_cs%vertical_coord_name), "DIAG_COORD", trim(remap_cs%diag_coord_name))
   call set_regrid_params(remap_cs%regrid_cs, min_thickness=0., integrate_downward_for_e=.false.)
 

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -270,7 +270,7 @@ subroutine diag_remap_update(remap_cs, G, GV, h, T, S, eqn_of_state)
     if (remap_cs%vertical_coord == coordinateMode('ZSTAR')) then
       call build_zstar_column(get_zlike_CS(remap_cs%regrid_cs), &
                               GV%Z_to_H*G%bathyT(i,j), sum(h(i,j,:)), &
-                              zInterfaces, zScale=GV%m_to_H)
+                              zInterfaces, zScale=GV%Z_to_H)
     elseif (remap_cs%vertical_coord == coordinateMode('SIGMA')) then
       call build_sigma_column(get_sigma_CS(remap_cs%regrid_cs), &
                               GV%Z_to_H*G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -50,8 +50,8 @@ end interface
 
 !> Extrapolate and interpolate data
 interface horiz_interp_and_extrap_tracer
-   module procedure horiz_interp_and_extrap_tracer_record
-   module procedure horiz_interp_and_extrap_tracer_fms_id
+  module procedure horiz_interp_and_extrap_tracer_record
+  module procedure horiz_interp_and_extrap_tracer_fms_id
 end interface
 
 contains
@@ -73,21 +73,19 @@ subroutine myStats(array, missing, is, ie, js, je, k, mesg)
   character(len=120) :: lMesg
   minA = 9.E24 ; maxA = -9.E24 ; found = .false.
 
-  do j = js, je
-     do i = is, ie
-        if (array(i,j) /= array(i,j)) stop 'Nan!'
-        if (abs(array(i,j)-missing)>1.e-6*abs(missing)) then
-           if (found) then
-              minA = min(minA, array(i,j))
-              maxA = max(maxA, array(i,j))
-           else
-              found = .true.
-              minA = array(i,j)
-              maxA = array(i,j)
-           endif
-        endif
-     enddo
-  enddo
+  do j=js,je ; do i=is,ie
+    if (array(i,j) /= array(i,j)) stop 'Nan!'
+    if (abs(array(i,j)-missing) > 1.e-6*abs(missing)) then
+      if (found) then
+        minA = min(minA, array(i,j))
+        maxA = max(maxA, array(i,j))
+      else
+        found = .true.
+        minA = array(i,j)
+        maxA = array(i,j)
+      endif
+    endif
+  enddo ; enddo
   call min_across_PEs(minA)
   call max_across_PEs(maxA)
   if (is_root_pe()) then
@@ -95,6 +93,7 @@ subroutine myStats(array, missing, is, ie, js, je, k, mesg)
           'init_from_Z: min=',minA,' max=',maxA,' Level=',k,trim(mesg)
      call MOM_mesg(lMesg,2)
   endif
+
 end subroutine myStats
 
 
@@ -102,7 +101,7 @@ end subroutine myStats
 !! valid data (good=1). If no information is available,
 !! Then use a previous guess (prev). Optionally (smooth)
 !! blend the filled points to achieve a more desirable result.
-subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug,debug)
+subroutine fill_miss_2d(aout, good, fill, prev, G, smooth, num_pass, relc, crit, keep_bug, debug)
   use MOM_coms, only : sum_across_PEs
 
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure.
@@ -127,7 +126,7 @@ subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug
 
 
   real, dimension(SZI_(G),SZJ_(G)) :: b,r
-  real, dimension(SZI_(G),SZJ_(G)) :: fill_pts,good_,good_new
+  real, dimension(SZI_(G),SZJ_(G)) :: fill_pts, good_, good_new
 
   character(len=256) :: mesg  ! The text of an error message
   integer :: i,j,k
@@ -163,116 +162,111 @@ subroutine fill_miss_2d(aout,good,fill,prev,G,smooth,num_pass,relc,crit,keep_bug
   do_smooth=.false.
   if (PRESENT(smooth)) do_smooth=smooth
 
-  fill_pts(:,:)=fill(:,:)
+  fill_pts(:,:) = fill(:,:)
 
   nfill = sum(fill(is:ie,js:je))
   call sum_across_PEs(nfill)
 
   nfill_prev = nfill
-  good_(:,:)=good(:,:)
-  r(:,:)=0.0
+  good_(:,:) = good(:,:)
+  r(:,:) = 0.0
 
   do while (nfill > 0.0)
 
-     call pass_var(good_,G%Domain)
-     call pass_var(aout,G%Domain)
+    call pass_var(good_,G%Domain)
+    call pass_var(aout,G%Domain)
 
-     b(:,:)=aout(:,:)
-     good_new(:,:)=good_(:,:)
+    b(:,:)=aout(:,:)
+    good_new(:,:)=good_(:,:)
 
-     do j=js,je
-        i_loop: do i=is,ie
+    do j=js,je ; do i=is,ie
 
-           if (good_(i,j) == 1.0 .or. fill(i,j) == 0.) cycle i_loop
+      if (good_(i,j) == 1.0 .or. fill(i,j) == 0.) cycle
 
-           ge=good_(i+1,j);gw=good_(i-1,j)
-           gn=good_(i,j+1);gs=good_(i,j-1)
-           east=0.0;west=0.0;north=0.0;south=0.0
-           if (ge == 1.0) east=aout(i+1,j)*ge
-           if (gw == 1.0) west=aout(i-1,j)*gw
-           if (gn == 1.0) north=aout(i,j+1)*gn
-           if (gs == 1.0) south=aout(i,j-1)*gs
+      ge=good_(i+1,j) ; gw=good_(i-1,j)
+      gn=good_(i,j+1) ; gs=good_(i,j-1)
+      east=0.0 ; west=0.0 ; north=0.0 ; south=0.0
+      if (ge == 1.0) east = aout(i+1,j)*ge
+      if (gw == 1.0) west = aout(i-1,j)*gw
+      if (gn == 1.0) north = aout(i,j+1)*gn
+      if (gs == 1.0) south = aout(i,j-1)*gs
 
-           ngood = ge+gw+gn+gs
-           if (ngood > 0.) then
-              b(i,j)=(east+west+north+south)/ngood
-              fill_pts(i,j)=0.0
-              good_new(i,j)=1.0
-           endif
-        enddo i_loop
-     enddo
+      ngood = ge+gw+gn+gs
+      if (ngood > 0.) then
+        b(i,j)=(east+west+north+south)/ngood
+        !### Replace this with
+        ! b(i,j) = ((east+west) + (north+south))/ngood
+        fill_pts(i,j) = 0.0
+        good_new(i,j) = 1.0
+      endif
+    enddo ; enddo
 
-     aout(is:ie,js:je)=b(is:ie,js:je)
-     good_(is:ie,js:je)=good_new(is:ie,js:je)
-     nfill_prev = nfill
-     nfill = sum(fill_pts(is:ie,js:je))
-     call sum_across_PEs(nfill)
+    aout(is:ie,js:je) = b(is:ie,js:je)
+    good_(is:ie,js:je) = good_new(is:ie,js:je)
+    nfill_prev = nfill
+    nfill = sum(fill_pts(is:ie,js:je))
+    call sum_across_PEs(nfill)
 
-     if (nfill == nfill_prev .and. PRESENT(prev)) then
-        do j=js,je
-           do i=is,ie
-              if (fill_pts(i,j) == 1.0) then
-                 aout(i,j)=prev(i,j)
-                 fill_pts(i,j)=0.0
-              endif
-           enddo
-        enddo
-     elseif (nfill == nfill_prev) then
-        call MOM_error(WARNING, &
-             'Unable to fill missing points using either data at the same vertical level from a connected basin'//&
-             'or using a point from a previous vertical level.  Make sure that the original data has some valid'//&
-             'data in all basins.', .true.)
-        write(mesg,*) 'nfill=',nfill
-        call MOM_error(WARNING, mesg, .true.)
-     endif
+    if (nfill == nfill_prev .and. PRESENT(prev)) then
+      do j=js,je ; do i=is,ie ; if (fill_pts(i,j) == 1.0) then
+        aout(i,j) = prev(i,j)
+        fill_pts(i,j) = 0.0
+      endif ; enddo ; enddo
+    elseif (nfill == nfill_prev) then
+      call MOM_error(WARNING, &
+           'Unable to fill missing points using either data at the same vertical level from a connected basin'//&
+           'or using a point from a previous vertical level.  Make sure that the original data has some valid'//&
+           'data in all basins.', .true.)
+      write(mesg,*) 'nfill=',nfill
+      call MOM_error(WARNING, mesg, .true.)
+    endif
 
-     nfill = sum(fill_pts(is:ie,js:je))
-     call sum_across_PEs(nfill)
+    nfill = sum(fill_pts(is:ie,js:je))
+    call sum_across_PEs(nfill)
 
   enddo
 
-  if (do_smooth) then
-     do k=1,npass
-        call pass_var(aout,G%Domain)
-        do j=js,je
-           do i=is,ie
-              if (fill(i,j) == 1) then
-                 east=max(good(i+1,j),fill(i+1,j)) ; west=max(good(i-1,j),fill(i-1,j))
-                 north=max(good(i,j+1),fill(i,j+1)) ; south=max(good(i,j-1),fill(i,j-1))
-                 !### Appropriate parentheses should be added here, but they will change answers.
-                 r(i,j) = relax_coeff*(south*aout(i,j-1)+north*aout(i,j+1) + &
-                                       west*aout(i-1,j)+east*aout(i+1,j) - &
-                                      (south+north+west+east)*aout(i,j))
-              else
-                 r(i,j) = 0.
-              endif
-           enddo
-        enddo
-        aout(is:ie,js:je)=r(is:ie,js:je)+aout(is:ie,js:je)
-        ares = maxval(abs(r))
-        call max_across_PEs(ares)
-        if (ares <= acrit) exit
-     enddo
-  endif
+  if (do_smooth) then ; do k=1,npass
+    call pass_var(aout,G%Domain)
+    do j=js,je ; do i=is,ie
+      if (fill(i,j) == 1) then
+        east = max(good(i+1,j),fill(i+1,j)) ; west = max(good(i-1,j),fill(i-1,j))
+        north = max(good(i,j+1),fill(i,j+1)) ; south = max(good(i,j-1),fill(i,j-1))
+        r(i,j) = relax_coeff*(south*aout(i,j-1)+north*aout(i,j+1) + &
+                              west*aout(i-1,j)+east*aout(i+1,j) - &
+                             (south+north+west+east)*aout(i,j))
+        !### Appropriate parentheses should be added here, but they will change answers.
+        ! r(i,j) = relax_coeff*( ((south*aout(i,j-1) + north*aout(i,j+1)) + &
+        !                         (west*aout(i-1,j)+east*aout(i+1,j))) - &
+        !                        ((south+north)+(west+east))*aout(i,j) )
+      else
+        r(i,j) = 0.
+      endif
+    enddo ; enddo
+    ares = 0.0
+    do j=js,je ; do i=is,ie
+      aout(i,j) = r(i,j) + aout(i,j)
+      ares = max(ares, abs(r(i,j)))
+    enddo ; enddo
+    call max_across_PEs(ares)
+    if (ares <= acrit) exit
+  enddo ; endif
 
-  do j=js,je
-     do i=is,ie
-        if (good_(i,j) == 0.0 .and. fill_pts(i,j) == 1.0) then
-           write(mesg,*) 'In fill_miss, fill, good,i,j= ',fill_pts(i,j),good_(i,j),i,j
-           call MOM_error(WARNING, mesg, .true.)
-           call MOM_error(FATAL,"MOM_initialize: "// &
-                "fill is true and good is false after fill_miss, how did this happen? ")
-        endif
-     enddo
-  enddo
-
-  return
+  do j=js,je ; do i=is,ie
+    if (good_(i,j) == 0.0 .and. fill_pts(i,j) == 1.0) then
+      write(mesg,*) 'In fill_miss, fill, good,i,j= ',fill_pts(i,j),good_(i,j),i,j
+      call MOM_error(WARNING, mesg, .true.)
+      call MOM_error(FATAL,"MOM_initialize: "// &
+           "fill is true and good is false after fill_miss, how did this happen? ")
+    endif
+ enddo ; enddo
 
 end subroutine fill_miss_2d
 
 !> Extrapolate and interpolate from a file record
-subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, recnum, G, tr_z, mask_z, z_in, &
-                                                z_edges_in, missing_value, reentrant_x, tripolar_n, homogenize )
+subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, recnum, G, tr_z, &
+                                                 mask_z, z_in, z_edges_in, missing_value, reentrant_x, &
+                                                 tripolar_n, homogenize, m_to_Z)
 
   character(len=*),      intent(in)    :: filename   !< Path to file containing tracer to be
                                                      !! interpolated.
@@ -281,9 +275,9 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   integer,               intent(in)    :: recnum     !< Record number of tracer to be read.
   type(ocean_grid_type), intent(inout) :: G          !< Grid object
   real, allocatable, dimension(:,:,:)  :: tr_z       !< pointer to allocatable tracer array on local
-                                                     !! model grid and native vertical levels.
+                                                     !! model grid and input-file vertical levels.
   real, allocatable, dimension(:,:,:)  :: mask_z     !< pointer to allocatable tracer mask array on
-                                                     !! local model grid and native vertical levels.
+                                                     !! local model grid and input-file vertical levels.
   real, allocatable,     dimension(:)  :: z_in       !< Cell grid values for input data.
   real, allocatable,     dimension(:)  :: z_edges_in !< Cell grid edge values for input data.
   real,                  intent(out)   :: missing_value !< The missing value in the returned array.
@@ -291,8 +285,11 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   logical,               intent(in)    :: tripolar_n !< If true, this is a northern tripolar grid
   logical,     optional, intent(in)    :: homogenize !< If present and true, horizontally homogenize data
                                                      !! to produce perfectly "flat" initial conditions
+  real,        optional, intent(in)    :: m_to_Z     !< A conversion factor from meters to the units
+                                                     !! of depth.  If missing, G%bathyT must be in m.
 
-  real, dimension(:,:),  allocatable   :: tr_in,tr_inp ! A 2-d array for holding input data on
+  ! Local variables
+  real, dimension(:,:),  allocatable   :: tr_in, tr_inp ! A 2-d array for holding input data on
                                                      ! native horizontal grid and extended grid
                                                      ! with poles.
   real, dimension(:,:),  allocatable   :: mask_in    ! A 2-d mask for extended input grid.
@@ -405,6 +402,8 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 
   call cpu_clock_end(id_clock_read)
 
+  if (present(m_to_Z)) then ; do k=1,kd ; z_in(k) = m_to_Z * z_in(k) ; enddo ; endif
+
 ! extrapolate the input data to the north pole using the northerm-most latitude
 
   max_lat = maxval(lat_in)
@@ -425,8 +424,8 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 ! construct level cell boundaries as the mid-point between adjacent centers
 
   z_edges_in(1) = 0.0
-  do k=2,kd
-   z_edges_in(k)=0.5*(z_in(k-1)+z_in(k))
+  do K=2,kd
+   z_edges_in(K)=0.5*(z_in(k-1)+z_in(k))
   enddo
   z_edges_in(kd+1)=2.0*z_in(kd) - z_in(kd-1)
 
@@ -446,7 +445,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   allocate(mask_in(id,jdp)) ; mask_in(:,:)=0.0
   allocate(last_row(id))    ; last_row(:)=0.0
 
-  max_depth = G%Zd_to_m*maxval(G%bathyT)
+  max_depth = maxval(G%bathyT)
   call mpp_max(max_depth)
 
   if (z_edges_in(kd+1)<max_depth) z_edges_in(kd+1)=max_depth
@@ -463,7 +462,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     write(laynum,'(I8)') k ; laynum = adjustl(laynum)
 
     if (is_root_pe()) then
-      start = 1; start(3) = k; count = 1; count(1) = id; count(2) = jd
+      start = 1 ; start(3) = k ; count(:) = 1 ; count(1) = id ; count(2) = jd
       rcode = NF90_GET_VAR(ncid,varid, tr_in, start, count)
       if (rcode /= 0) call MOM_error(FATAL,"hinterp_and_extract_from_Fie: "//&
            "error reading level "//trim(laynum)//" of variable "//&
@@ -491,7 +490,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     endif
 
     call mpp_sync()
-    call mpp_broadcast(tr_inp,id*jdp,root_PE())
+    call mpp_broadcast(tr_inp, id*jdp, root_PE())
     call mpp_sync_self()
 
     mask_in=0.0
@@ -499,10 +498,10 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     do j=1,jdp
       do i=1,id
          if (abs(tr_inp(i,j)-missing_value) > abs(roundoff*missing_value)) then
-           mask_in(i,j)=1.0
-            tr_inp(i,j) = tr_inp(i,j) * conversion
+           mask_in(i,j) = 1.0
+           tr_inp(i,j) = tr_inp(i,j) * conversion
          else
-           tr_inp(i,j)=missing_value
+           tr_inp(i,j) = missing_value
          endif
       enddo
     enddo
@@ -543,7 +542,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
           nPoints = nPoints + 1
           varAvg = varAvg + tr_out(i,j)
         endif
-        if (G%mask2dT(i,j) == 1.0 .and. z_edges_in(k) <= G%Zd_to_m*G%bathyT(i,j) .and. mask_out(i,j) < 1.0) &
+        if (G%mask2dT(i,j) == 1.0 .and. z_edges_in(k) <= G%bathyT(i,j) .and. mask_out(i,j) < 1.0) &
           fill(i,j)=1.0
       enddo
     enddo
@@ -569,18 +568,18 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 ! tr_out contains input z-space data on the model grid with missing values
 ! now fill in missing values using "ICE-nine" algorithm.
 
-    tr_outf(:,:)=tr_out(:,:)
-    if (k==1) tr_prev(:,:)=tr_outf(:,:)
-    good2(:,:)=good(:,:)
-    fill2(:,:)=fill(:,:)
+    tr_outf(:,:) = tr_out(:,:)
+    if (k==1) tr_prev(:,:) = tr_outf(:,:)
+    good2(:,:) = good(:,:)
+    fill2(:,:) = fill(:,:)
 
-    call fill_miss_2d(tr_outf,good2,fill2,tr_prev,G,smooth=.true.)
-    call myStats(tr_outf,missing_value,is,ie,js,je,k,'field from fill_miss_2d()')
+    call fill_miss_2d(tr_outf, good2, fill2, tr_prev, G, smooth=.true.)
+    call myStats(tr_outf, missing_value, is, ie, js, je, k, 'field from fill_miss_2d()')
 
-    tr_z(:,:,k) = tr_outf(:,:)*G%mask2dT(:,:)
-    mask_z(:,:,k) = good2(:,:)+fill2(:,:)
+    tr_z(:,:,k) = tr_outf(:,:) * G%mask2dT(:,:)
+    mask_z(:,:,k) = good2(:,:) + fill2(:,:)
 
-    tr_prev(:,:)=tr_z(:,:,k)
+    tr_prev(:,:) = tr_z(:,:,k)
 
     if (debug) then
       call hchksum(tr_prev,'field after fill ',G%HI)
@@ -591,8 +590,9 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 end subroutine horiz_interp_and_extrap_tracer_record
 
 !> Extrapolate and interpolate using a FMS time interpolation handle
-subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, tr_z, mask_z, z_in, &
-                                                z_edges_in, missing_value, reentrant_x, tripolar_n, homogenize )
+subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, tr_z, mask_z, &
+                                                 z_in, z_edges_in, missing_value, reentrant_x, &
+                                                 tripolar_n, homogenize, m_to_Z)
 
   integer,               intent(in)    :: fms_id     !< A unique id used by the FMS time interpolator
   type(time_type),       intent(in)    :: Time       !< A FMS time type
@@ -603,13 +603,16 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   real, allocatable, dimension(:,:,:)  :: mask_z     !< pointer to allocatable tracer mask array on
                                                      !! local model grid and native vertical levels.
   real, allocatable,     dimension(:)  :: z_in       !< Cell grid values for input data.
-  real, allocatable,     dimension(:)  :: z_edges_in !< Cell grid edge values for input data.
+  real, allocatable,     dimension(:)  :: z_edges_in !< Cell grid edge values for input data. (Intent out)
   real,                  intent(out)   :: missing_value !< The missing value in the returned array.
   logical,               intent(in)    :: reentrant_x !< If true, this grid is reentrant in the x-direction
   logical,               intent(in)    :: tripolar_n !< If true, this is a northern tripolar grid
   logical,     optional, intent(in)    :: homogenize !< If present and true, horizontally homogenize data
                                                      !! to produce perfectly "flat" initial conditions
+  real,        optional, intent(in)    :: m_to_Z     !< A conversion factor from meters to the units
+                                                     !! of depth.  If missing, G%bathyT must be in m.
 
+  ! Local variables
   real, dimension(:,:),  allocatable   :: tr_in,tr_inp !< A 2-d array for holding input data on
                                                      !! native horizontal grid and extended grid
                                                      !! with poles.
@@ -678,9 +681,11 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   call mpp_get_axis_data(axes_data(2), lat_in)
   call mpp_get_axis_data(axes_data(3), z_in)
 
+  if (present(m_to_Z)) then ; do k=1,kd ; z_in(k) = m_to_Z * z_in(k) ; enddo ; endif
+
   call cpu_clock_end(id_clock_read)
 
-  missing_value=get_external_field_missing(fms_id)
+  missing_value = get_external_field_missing(fms_id)
 
 
 ! extrapolate the input data to the north pole using the northerm-most latitude
@@ -688,14 +693,14 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   max_lat = maxval(lat_in)
   add_np=.false.
   if (max_lat < 90.0) then
-    add_np=.true.
-    jdp=jd+1
+    add_np = .true.
+    jdp = jd+1
     allocate(lat_inp(jdp))
-    lat_inp(1:jd)=lat_in(:)
-    lat_inp(jd+1)=90.0
+    lat_inp(1:jd) = lat_in(:)
+    lat_inp(jd+1) = 90.0
     deallocate(lat_in)
     allocate(lat_in(1:jdp))
-    lat_in(:)=lat_inp(:)
+    lat_in(:) = lat_inp(:)
   else
     jdp=jd
   endif
@@ -704,16 +709,16 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
 
   z_edges_in(1) = 0.0
   do k=2,kd
-   z_edges_in(k)=0.5*(z_in(k-1)+z_in(k))
+   z_edges_in(k) = 0.5*(z_in(k-1)+z_in(k))
   enddo
-  z_edges_in(kd+1)=2.0*z_in(kd) - z_in(kd-1)
+  z_edges_in(kd+1) = 2.0*z_in(kd) - z_in(kd-1)
 
   call horiz_interp_init()
 
   lon_in = lon_in*PI_180
   lat_in = lat_in*PI_180
-  allocate(x_in(id,jdp),y_in(id,jdp))
-  call meshgrid(lon_in,lat_in, x_in, y_in)
+  allocate(x_in(id,jdp), y_in(id,jdp))
+  call meshgrid(lon_in, lat_in, x_in, y_in)
 
   lon_out(:,:) = G%geoLonT(:,:)*PI_180
   lat_out(:,:) = G%geoLatT(:,:)*PI_180
@@ -724,13 +729,13 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   allocate(mask_in(id,jdp)) ; mask_in(:,:)=0.0
   allocate(last_row(id))    ; last_row(:)=0.0
 
-  max_depth = G%Zd_to_m*maxval(G%bathyT)
+  max_depth = maxval(G%bathyT)
   call mpp_max(max_depth)
 
   if (z_edges_in(kd+1)<max_depth) z_edges_in(kd+1)=max_depth
 
   if (is_root_pe()) &
-  call time_interp_external(fms_id, Time, data_in,verbose=.true.)
+  call time_interp_external(fms_id, Time, data_in, verbose=.true.)
 
 ! loop through each data level and interpolate to model grid.
 ! after interpolating, fill in points which will be needed
@@ -766,100 +771,91 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
     endif
 
     call mpp_sync()
-    call mpp_broadcast(tr_inp,id*jdp,root_PE())
+    call mpp_broadcast(tr_inp, id*jdp, root_PE())
     call mpp_sync_self()
 
     mask_in=0.0
 
-    do j=1,jdp
-      do i=1,id
-         if (abs(tr_inp(i,j)-missing_value) > abs(roundoff*missing_value)) then
-           mask_in(i,j)=1.0
-           tr_inp(i,j) = tr_inp(i,j) * conversion
-         else
-           tr_inp(i,j)=missing_value
-         endif
-      enddo
-    enddo
+    do j=1,jdp ; do i=1,id
+      if (abs(tr_inp(i,j)-missing_value) > abs(roundoff*missing_value)) then
+        mask_in(i,j)=1.0
+        tr_inp(i,j) = tr_inp(i,j) * conversion
+      else
+        tr_inp(i,j) = missing_value
+      endif
+    enddo ; enddo
 
-
-! call fms routine horiz_interp to interpolate input level data to model horizontal grid
-
-
+    ! call fms routine horiz_interp to interpolate input level data to model horizontal grid
     if (k == 1) then
-      call horiz_interp_new(Interp,x_in,y_in,lon_out(is:ie,js:je),lat_out(is:ie,js:je), &
-               interp_method='bilinear',src_modulo=reentrant_x)
+      call horiz_interp_new(Interp, x_in, y_in, lon_out(is:ie,js:je), lat_out(is:ie,js:je), &
+               interp_method='bilinear', src_modulo=reentrant_x)
     endif
 
-!    if (debug) then
-       call myStats(tr_in,missing_value, 1,id,1,jd,k,'Tracer from file')
-!    endif
+    if (debug) then
+      call myStats(tr_in, missing_value, 1, id, 1, jd, k, 'Tracer from file')
+    endif
 
     tr_out(:,:) = 0.0
 
-    call horiz_interp(Interp,tr_inp,tr_out(is:ie,js:je), missing_value=missing_value, new_missing_handle=.true.)
+    call horiz_interp(Interp, tr_inp, tr_out(is:ie,js:je), missing_value=missing_value, &
+                      new_missing_handle=.true.)
 
-    mask_out=1.0
-    do j=js,je
-      do i=is,ie
-        if (abs(tr_out(i,j)-missing_value) < abs(roundoff*missing_value)) mask_out(i,j)=0.
-      enddo
-    enddo
+    mask_out(:,:) = 1.0
+    do j=js,je ; do i=is,ie
+      if (abs(tr_out(i,j)-missing_value) < abs(roundoff*missing_value)) mask_out(i,j) = 0.
+    enddo ; enddo
 
-    fill = 0.0; good = 0.0
+    fill(:,:) = 0.0 ; good(:,:) = 0.0
 
     nPoints = 0 ; varAvg = 0.
-    do j=js,je
-      do i=is,ie
-        if (mask_out(i,j) < 1.0) then
-          tr_out(i,j)=missing_value
-        else
-          good(i,j)=1.0
-          nPoints = nPoints + 1
-          varAvg = varAvg + tr_out(i,j)
-        endif
-        if (G%mask2dT(i,j) == 1.0 .and. z_edges_in(k) <= G%Zd_to_m*G%bathyT(i,j) .and. mask_out(i,j) < 1.0) &
-          fill(i,j)=1.0
-      enddo
-    enddo
-    call pass_var(fill,G%Domain)
-    call pass_var(good,G%Domain)
+    do j=js,je ; do i=is,ie
+      if (mask_out(i,j) < 1.0) then
+        tr_out(i,j) = missing_value
+      else
+        good(i,j) = 1.0
+        nPoints = nPoints + 1
+        varAvg = varAvg + tr_out(i,j)
+      endif
+      if ((G%mask2dT(i,j) == 1.0) .and. (z_edges_in(k) <= G%bathyT(i,j)) .and. &
+          (mask_out(i,j) < 1.0)) &
+        fill(i,j)=1.0
+    enddo ;  enddo
+    call pass_var(fill, G%Domain)
+    call pass_var(good, G%Domain)
 
     if (debug) then
-      call myStats(tr_out,missing_value, is,ie,js,je,k,'variable from horiz_interp()')
+      call myStats(tr_out, missing_value, is, ie, js, je, k, 'variable from horiz_interp()')
     endif
 
     ! Horizontally homogenize data to produce perfectly "flat" initial conditions
-    if (PRESENT(homogenize)) then
-       if (homogenize) then
-          call sum_across_PEs(nPoints)
-          call sum_across_PEs(varAvg)
-          if (nPoints>0) then
-             varAvg = varAvg/real(nPoints)
-          endif
-          tr_out(:,:) = varAvg
-       endif
-    endif
+    if (PRESENT(homogenize)) then ; if (homogenize) then
+      call sum_across_PEs(nPoints)
+      call sum_across_PEs(varAvg)
+      if (nPoints>0) then
+         varAvg = varAvg/real(nPoints)
+      endif
+      tr_out(:,:) = varAvg
+    endif ; endif
 
-! tr_out contains input z-space data on the model grid with missing values
-! now fill in missing values using "ICE-nine" algorithm.
+  ! tr_out contains input z-space data on the model grid with missing values
+  ! now fill in missing values using "ICE-nine" algorithm.
 
-    tr_outf(:,:)=tr_out(:,:)
-    if (k==1) tr_prev(:,:)=tr_outf(:,:)
-    good2(:,:)=good(:,:)
-    fill2(:,:)=fill(:,:)
+    tr_outf(:,:) = tr_out(:,:)
+    if (k==1) tr_prev(:,:) = tr_outf(:,:)
+    good2(:,:) = good(:,:)
+    fill2(:,:) = fill(:,:)
 
-    call fill_miss_2d(tr_outf,good2,fill2,tr_prev,G,smooth=.true.)
+    call fill_miss_2d(tr_outf, good2, fill2, tr_prev, G, smooth=.true.)
 
 !    if (debug) then
-!      call hchksum(tr_outf,'field from fill_miss_2d ',G%HI)
+!      call hchksum(tr_outf, 'field from fill_miss_2d ', G%HI)
 !    endif
 
-!    call myStats(tr_outf,missing_value,is,ie,js,je,k,'field from fill_miss_2d()')
+!    call myStats(tr_outf, missing_value, is, ie, js, je, k, 'field from fill_miss_2d()')
 
     tr_z(:,:,k) = tr_outf(:,:)*G%mask2dT(:,:)
-    mask_z(:,:,k) = good2(:,:)+fill2(:,:)
-    tr_prev(:,:)=tr_z(:,:,k)
+    mask_z(:,:,k) = good2(:,:) + fill2(:,:)
+    tr_prev(:,:) = tr_z(:,:,k)
 
     if (debug) then
       call hchksum(tr_prev,'field after fill ',G%HI)
@@ -872,80 +868,75 @@ end subroutine horiz_interp_and_extrap_tracer_fms_id
 
 
 !> Create a 2d-mesh of grid coordinates from 1-d arrays.
-subroutine meshgrid(x,y,x_T,y_T)
-real, dimension(:),                   intent(in)    :: x  !< input 1-dimensional vector
-real, dimension(:),                   intent(in)    :: y  !< input 1-dimensional vector
-real, dimension(size(x,1),size(y,1)), intent(inout) :: x_T !< output 2-dimensional array
-real, dimension(size(x,1),size(y,1)), intent(inout) :: y_T !< output 2-dimensional array
+subroutine meshgrid(x, y, x_T, y_T)
+  real, dimension(:),                   intent(in)    :: x  !< input 1-dimensional vector
+  real, dimension(:),                   intent(in)    :: y  !< input 1-dimensional vector
+  real, dimension(size(x,1),size(y,1)), intent(inout) :: x_T !< output 2-dimensional array
+  real, dimension(size(x,1),size(y,1)), intent(inout) :: y_T !< output 2-dimensional array
 
-integer :: ni,nj,i,j
+  integer :: ni,nj,i,j
 
-ni=size(x,1);nj=size(y,1)
+  ni=size(x,1) ; nj=size(y,1)
 
-do j=1,nj
-  x_T(:,j)=x(:)
-enddo
+  do j=1,nj ; do i=1,ni
+    x_T(i,j) = x(i)
+  enddo ; enddo
 
-do i=1,ni
-  y_T(i,:)=y(:)
-enddo
-
-return
+  do j=1,nj ; do i=1,ni
+    y_T(i,j) = y(j)
+  enddo ; enddo
 
 end subroutine meshgrid
 
+! None of the subsequent code appears to be used at all.
 
 !> Fill grid edges for integer data
 function fill_boundaries_int(m,cyclic_x,tripolar_n) result(mp)
-integer, dimension(:,:), intent(in)             :: m !< input array (ND)
-logical,                 intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
-logical,                 intent(in)             :: tripolar_n !< True if domain has an Arctic fold
-integer, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
+  integer, dimension(:,:), intent(in)             :: m !< input array (ND)
+  logical,                 intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
+  logical,                 intent(in)             :: tripolar_n !< True if domain has an Arctic fold
+  integer, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
 
-real,    dimension(size(m,1),size(m,2))         :: m_real
-real,    dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp_real
+  real,    dimension(size(m,1),size(m,2))         :: m_real
+  real,    dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp_real
 
-m_real = real(m)
+  m_real = real(m)
 
-mp_real = fill_boundaries_real(m_real,cyclic_x,tripolar_n)
+  mp_real = fill_boundaries_real(m_real,cyclic_x,tripolar_n)
 
-mp = int(mp_real)
-
-return
+  mp = int(mp_real)
 
 end function fill_boundaries_int
 
 !> Fill grid edges for real data
 function fill_boundaries_real(m,cyclic_x,tripolar_n) result(mp)
-real, dimension(:,:), intent(in)             :: m !< input array (ND)
-logical,              intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
-logical,              intent(in)             :: tripolar_n !< True if domain has an Arctic fold
-real, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
+  real, dimension(:,:), intent(in)             :: m !< input array (ND)
+  logical,              intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
+  logical,              intent(in)             :: tripolar_n !< True if domain has an Arctic fold
+  real, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
 
-integer :: ni,nj,i,j
+  integer :: ni,nj,i,j
 
-ni=size(m,1); nj=size(m,2)
+  ni=size(m,1); nj=size(m,2)
 
-mp(1:ni,1:nj)=m(:,:)
+  mp(1:ni,1:nj)=m(:,:)
 
-if (cyclic_x) then
-  mp(0,1:nj)=m(ni,1:nj)
-  mp(ni+1,1:nj)=m(1,1:nj)
-else
-  mp(0,1:nj)=m(1,1:nj)
-  mp(ni+1,1:nj)=m(ni,1:nj)
-endif
+  if (cyclic_x) then
+    mp(0,1:nj)=m(ni,1:nj)
+    mp(ni+1,1:nj)=m(1,1:nj)
+  else
+    mp(0,1:nj)=m(1,1:nj)
+    mp(ni+1,1:nj)=m(ni,1:nj)
+  endif
 
-mp(1:ni,0)=m(1:ni,1)
-if (tripolar_n) then
-  do i=1,ni
-    mp(i,nj+1)=m(ni-i+1,nj)
-  enddo
-else
-  mp(1:ni,nj+1)=m(1:ni,nj)
-endif
-
-return
+  mp(1:ni,0)=m(1:ni,1)
+  if (tripolar_n) then
+    do i=1,ni
+      mp(i,nj+1)=m(ni-i+1,nj)
+    enddo
+  else
+    mp(1:ni,nj+1)=m(1:ni,nj)
+  endif
 
 end function fill_boundaries_real
 
@@ -956,68 +947,62 @@ end function fill_boundaries_real
 !! in each region is an approximation to del2(zi)=0 subject to
 !! boundary conditions along the valid points curve bounding this region.
 subroutine smooth_heights(zi,fill,bad,sor,niter,cyclic_x, tripolar_n)
+  real,    dimension(:,:),                   intent(inout) :: zi !< input and output array (ND)
+  integer, dimension(size(zi,1),size(zi,2)), intent(in) :: fill !< same shape as zi, 1=fill
+  integer, dimension(size(zi,1),size(zi,2)), intent(in) :: bad  !< same shape as zi, 1=bad data
+  real,                                      intent(in)  :: sor !< relaxation coefficient (ND)
+  integer,                                   intent(in) :: niter !< maximum number of iterations
+  logical,                                   intent(in) :: cyclic_x !< true if domain is zonally reentrant
+  logical,                                   intent(in) :: tripolar_n !< true if domain has an Arctic fold
 
-real,    dimension(:,:),                   intent(inout) :: zi !< input and output array (ND)
-integer, dimension(size(zi,1),size(zi,2)), intent(in) :: fill !< same shape as zi, 1=fill
-integer, dimension(size(zi,1),size(zi,2)), intent(in) :: bad  !< same shape as zi, 1=bad data
-real,                                      intent(in)  :: sor !< relaxation coefficient (ND)
-integer,                                   intent(in) :: niter !< maximum number of iterations
-logical,                                   intent(in) :: cyclic_x !< true if domain is zonally reentrant
-logical,                                   intent(in) :: tripolar_n !< true if domain has an Arctic fold
+  ! Local variables
+  real, dimension(size(zi,1),size(zi,2)) :: res, m
+  integer, dimension(size(zi,1),size(zi,2),4) :: B
+  real, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: mp
+  integer, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: nm
+  integer :: i,j,k,n
+  integer :: ni,nj
+  real :: Isum, bsum
 
-integer :: i,j,k,n
-integer :: ni,nj
-
-real, dimension(size(zi,1),size(zi,2)) :: res, m
-integer, dimension(size(zi,1),size(zi,2),4) :: B
-real, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: mp
-integer, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: nm
-
-real :: Isum, bsum
-
-ni=size(zi,1); nj=size(zi,2)
+  ni=size(zi,1) ; nj=size(zi,2)
 
 
-mp=fill_boundaries(zi,cyclic_x,tripolar_n)
+  mp(:,:) = fill_boundaries(zi,cyclic_x,tripolar_n)
 
-B(:,:,:)=0.0
-nm=fill_boundaries(bad,cyclic_x,tripolar_n)
+  B(:,:,:) = 0.0
+  nm(:,:) = fill_boundaries(bad,cyclic_x,tripolar_n)
 
-do j=1,nj
-  do i=1,ni
-    if (fill(i,j) == 1) then
-      B(i,j,1)=1-nm(i+1,j);B(i,j,2)=1-nm(i-1,j)
-      B(i,j,3)=1-nm(i,j+1);B(i,j,4)=1-nm(i,j-1)
-    endif
-  enddo
-enddo
-
-do n=1,niter
   do j=1,nj
     do i=1,ni
       if (fill(i,j) == 1) then
-        bsum = real(B(i,j,1)+B(i,j,2)+B(i,j,3)+B(i,j,4))
-        Isum = 1.0/bsum
-        res(i,j)=Isum*(B(i,j,1)*mp(i+1,j)+B(i,j,2)*mp(i-1,j)+&
-             B(i,j,3)*mp(i,j+1)+B(i,j,4)*mp(i,j-1)) - mp(i,j)
+        B(i,j,1)=1-nm(i+1,j);B(i,j,2)=1-nm(i-1,j)
+        B(i,j,3)=1-nm(i,j+1);B(i,j,4)=1-nm(i,j-1)
       endif
     enddo
   enddo
-  res(:,:)=res(:,:)*sor
 
-  do j=1,nj
-    do i=1,ni
-      mp(i,j)=mp(i,j)+res(i,j)
+  do n=1,niter
+    do j=1,nj
+      do i=1,ni
+        if (fill(i,j) == 1) then
+          bsum = real(B(i,j,1)+B(i,j,2)+B(i,j,3)+B(i,j,4))
+          Isum = 1.0/bsum
+          res(i,j)=Isum*(B(i,j,1)*mp(i+1,j)+B(i,j,2)*mp(i-1,j)+&
+               B(i,j,3)*mp(i,j+1)+B(i,j,4)*mp(i,j-1)) - mp(i,j)
+        endif
+      enddo
     enddo
+    res(:,:)=res(:,:)*sor
+
+    do j=1,nj
+      do i=1,ni
+        mp(i,j)=mp(i,j)+res(i,j)
+      enddo
+    enddo
+
+    zi(:,:)=mp(1:ni,1:nj)
+    mp = fill_boundaries(zi,cyclic_x,tripolar_n)
   enddo
-
-  zi(:,:)=mp(1:ni,1:nj)
-  mp = fill_boundaries(zi,cyclic_x,tripolar_n)
-enddo
-
-
-
-return
 
 end subroutine smooth_heights
 

--- a/src/framework/MOM_unit_scaling.F90
+++ b/src/framework/MOM_unit_scaling.F90
@@ -1,0 +1,125 @@
+!> Provides a transparent unit rescaling type to facilitate dimensional consistency testing
+module MOM_unit_scaling
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL
+use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
+
+implicit none ; private
+
+public unit_scaling_init, unit_scaling_end, fix_restart_unit_scaling
+
+!> Describes various unit conversion factors
+type, public :: unit_scale_type
+  real :: m_to_Z !< A constant that translates distances in meters to the units of depth.
+  real :: Z_to_m !< A constant that translates distances in the units of depth to meters.
+  real :: m_to_L !< A constant that translates lengths in meters to the units of horizontal lengths.
+  real :: L_to_m !< A constant that translates lengths in the units of horizontal lengths to meters.
+  real :: s_to_T !< A constant that time intervals in seconds to the units of time.
+  real :: T_to_s !< A constant that the units of time to seconds.
+
+  ! These are useful combinations of the fundamental scale conversion factors above.
+  real :: Z_to_L !< Convert vertical distances to lateral lengths
+  real :: L_to_Z !< Convert vertical distances to lateral lengths
+  real :: L_T_to_m_s !< Convert lateral velocities from L T-1 to m s-1.
+  real :: m_s_to_L_T !< Convert lateral velocities from m s-1 to L T-1.
+  real :: L_T2_to_m_s2 !< Convert lateral accelerations from L T-2 to m s-2.
+  real :: Z2_T_to_m2_s !< Convert vertical diffusivities from Z2 T-1 to m2 s-1.
+  real :: m2_s_to_Z2_T !< Convert vertical diffusivities from m2 s-1 to Z2 T-1.
+
+  ! These are used for changing scaling across restarts.
+  real :: m_to_Z_restart = 0.0 !< A copy of the m_to_Z that is used in restart files.
+  real :: m_to_L_restart = 0.0 !< A copy of the m_to_L that is used in restart files.
+  real :: s_to_T_restart = 0.0 !< A copy of the s_to_T that is used in restart files.
+end type unit_scale_type
+
+contains
+
+!> Allocates and initializes the ocean model unit scaling type
+subroutine unit_scaling_init( param_file, US )
+  type(param_file_type), intent(in) :: param_file !< Parameter file handle/type
+  type(unit_scale_type), pointer    :: US         !< A dimensional unit scaling type
+
+  ! This routine initializes a unit_scale_type structure (US).
+
+  ! Local variables
+  integer :: Z_power, L_power, T_power
+  real    :: Z_rescale_factor, L_rescale_factor, T_rescale_factor
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
+  character(len=16) :: mdl = "MOM_unit_scaling"
+
+  if (associated(US)) call MOM_error(FATAL, &
+     'unit_scaling_init: called with an associated US pointer.')
+  allocate(US)
+
+  ! Read all relevant parameters and write them to the model log.
+  call log_version(param_file, mdl, version, &
+                   "Parameters for doing unit scaling of variables.")
+  call get_param(param_file, mdl, "Z_RESCALE_POWER", Z_power, &
+                 "An integer power of 2 that is used to rescale the model's \n"//&
+                 "intenal units of depths and heights.  Valid values range from -300 to 300.", &
+                 units="nondim", default=0, debuggingParam=.true.)
+  call get_param(param_file, mdl, "L_RESCALE_POWER", L_power, &
+                 "An integer power of 2 that is used to rescale the model's \n"//&
+                 "intenal units of lateral distances.  Valid values range from -300 to 300.", &
+                 units="nondim", default=0, debuggingParam=.true.)
+  call get_param(param_file, mdl, "T_RESCALE_POWER", T_power, &
+                 "An integer power of 2 that is used to rescale the model's \n"//&
+                 "intenal units of time.  Valid values range from -300 to 300.", &
+                 units="nondim", default=0, debuggingParam=.true.)
+  if (abs(Z_power) > 300) call MOM_error(FATAL, "unit_scaling_init: "//&
+                 "Z_RESCALE_POWER is outside of the valid range of -300 to 300.")
+  if (abs(L_power) > 300) call MOM_error(FATAL, "unit_scaling_init: "//&
+                 "L_RESCALE_POWER is outside of the valid range of -300 to 300.")
+  if (abs(T_power) > 300) call MOM_error(FATAL, "unit_scaling_init: "//&
+                 "T_RESCALE_POWER is outside of the valid range of -300 to 300.")
+
+  Z_rescale_factor = 1.0
+  if (Z_power /= 0) Z_rescale_factor = 2.0**Z_power
+  US%Z_to_m = 1.0 * Z_rescale_factor
+  US%m_to_Z = 1.0 / Z_rescale_factor
+
+  L_rescale_factor = 1.0
+  if (L_power /= 0) L_rescale_factor = 2.0**L_power
+  US%L_to_m = 1.0 * L_rescale_factor
+  US%m_to_L = 1.0 / L_rescale_factor
+
+  T_rescale_factor = 1.0
+  if (T_power /= 0) T_rescale_factor = 2.0**T_power
+  US%T_to_s = 1.0 * T_rescale_factor
+  US%s_to_T = 1.0 / T_rescale_factor
+
+  ! These are useful combinations of the fundamental scale conversion factors set above.
+  US%Z_to_L = US%Z_to_m * US%m_to_L
+  US%L_to_Z = US%L_to_m * US%m_to_Z
+  US%L_T_to_m_s = US%L_to_m * US%s_to_T
+  US%m_s_to_L_T = US%m_to_L * US%T_to_s
+  US%L_T2_to_m_s2 = US%L_to_m * US%s_to_T**2
+  ! It does not look like US%m_s2_to_L_T2 would be used, so it does not exist.
+  US%Z2_T_to_m2_s = US%Z_to_m**2 * US%s_to_T
+  US%m2_s_to_Z2_T = US%m_to_Z**2 * US%T_to_s
+
+end subroutine unit_scaling_init
+
+!> Set the unit scaling factors for output to restart files to the unit scaling
+!! factors for this run.
+subroutine fix_restart_unit_scaling(US)
+  type(unit_scale_type), intent(inout) :: US !< A dimensional unit scaling type
+
+  US%m_to_Z_restart = US%m_to_Z
+  US%m_to_L_restart = US%m_to_L
+  US%s_to_T_restart = US%s_to_T
+
+end subroutine fix_restart_unit_scaling
+
+!> Deallocates a unit scaling structure.
+subroutine unit_scaling_end( US )
+  type(unit_scale_type), pointer :: US !< A dimensional unit scaling type
+
+  deallocate( US )
+
+end subroutine unit_scaling_end
+
+end module MOM_unit_scaling

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -13,6 +13,7 @@ use MOM_io, only : close_file, create_file, fieldtype, file_exists
 use MOM_io, only : open_file, MOM_read_data, read_axis_data, SINGLE_FILE, MULTIPLE
 use MOM_io, only : slasher, vardesc, write_field, var_desc
 use MOM_string_functions, only : uppercase
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type, setVerticalGridAxes
 use user_initialization, only : user_set_coord
@@ -30,8 +31,9 @@ contains
 
 !> MOM_initialize_coord sets up time-invariant quantities related to MOM6's
 !!   vertical coordinate.
-subroutine MOM_initialize_coord(GV, PF, write_geom, output_dir, tv, max_depth)
+subroutine MOM_initialize_coord(GV, US, PF, write_geom, output_dir, tv, max_depth)
   type(verticalGrid_type), intent(inout) :: GV         !< Ocean vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: PF         !< A structure indicating the open file
                                                        !! to parse for model parameter values.
   logical,                 intent(in)    :: write_geom !< If true, write grid geometry files.
@@ -76,30 +78,30 @@ subroutine MOM_initialize_coord(GV, PF, write_geom, output_dir, tv, max_depth)
                  fail_if_missing=.true.)
   select case ( trim(config) )
     case ("gprime")
-      call set_coord_from_gprime(GV%Rlay, GV%g_prime, GV, PF)
+      call set_coord_from_gprime(GV%Rlay, GV%g_prime, GV, US, PF)
     case ("layer_ref")
-      call set_coord_from_layer_density(GV%Rlay, GV%g_prime, GV, PF)
+      call set_coord_from_layer_density(GV%Rlay, GV%g_prime, GV, US, PF)
     case ("linear")
-      call set_coord_linear(GV%Rlay, GV%g_prime, GV, PF)
+      call set_coord_linear(GV%Rlay, GV%g_prime, GV, US, PF)
     case ("ts_ref")
-      call set_coord_from_ts_ref(GV%Rlay, GV%g_prime, GV, PF, eos, tv%P_Ref)
+      call set_coord_from_ts_ref(GV%Rlay, GV%g_prime, GV, US, PF, eos, tv%P_Ref)
     case ("ts_profile")
-      call set_coord_from_TS_profile(GV%Rlay, GV%g_prime, GV, PF, eos, tv%P_Ref)
+      call set_coord_from_TS_profile(GV%Rlay, GV%g_prime, GV, US, PF, eos, tv%P_Ref)
     case ("ts_range")
-      call set_coord_from_TS_range(GV%Rlay, GV%g_prime, GV, PF, eos, tv%P_Ref)
+      call set_coord_from_TS_range(GV%Rlay, GV%g_prime, GV, US, PF, eos, tv%P_Ref)
     case ("file")
-      call set_coord_from_file(GV%Rlay, GV%g_prime, GV, PF)
+      call set_coord_from_file(GV%Rlay, GV%g_prime, GV, US, PF)
     case ("USER")
       call user_set_coord(GV%Rlay, GV%g_prime, GV, PF, eos)
     case ("BFB")
       call BFB_set_coord(GV%Rlay, GV%g_prime, GV, PF, eos)
     case ("none", "ALE")
-      call set_coord_to_none(GV%Rlay, GV%g_prime, GV, PF)
+      call set_coord_to_none(GV%Rlay, GV%g_prime, GV, US, PF)
     case default ; call MOM_error(FATAL,"MOM_initialize_coord: "// &
       "Unrecognized coordinate setup"//trim(config))
   end select
   if (debug) call chksum(GV%Rlay, "MOM_initialize_coord: Rlay ", 1, nz)
-  if (debug) call chksum(GV%m_to_Z*GV%g_prime(:), "MOM_initialize_coord: g_prime ", 1, nz)
+  if (debug) call chksum(US%m_to_Z*GV%g_prime(:), "MOM_initialize_coord: g_prime ", 1, nz)
   call setVerticalGridAxes( GV%Rlay, GV )
 
 ! Copy the maximum depth across from the input argument
@@ -115,12 +117,13 @@ end subroutine MOM_initialize_coord
 !  The set_coord routines deal with initializing aspects of the vertical grid.
 
 !> Sets the layer densities (Rlay) and the interface reduced gravities (g).
-subroutine set_coord_from_gprime(Rlay, g_prime, GV, param_file)
+subroutine set_coord_from_gprime(Rlay, g_prime, GV, US, param_file)
   real, dimension(:),      intent(out) :: Rlay       !< The layers' target coordinate values
                                                      !! (potential density).
   real, dimension(:),      intent(out) :: g_prime    !< The reduced gravity across the interfaces
                                                      !! in m2 Z-1 s-2.
   type(verticalGrid_type), intent(in)  :: GV         !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
   ! Local variables
   real :: g_int   ! Reduced gravities across the internal interfaces, in m s-2.
@@ -133,7 +136,7 @@ subroutine set_coord_from_gprime(Rlay, g_prime, GV, param_file)
 
   call get_param(param_file, mdl, "GFS" , g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*GV%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
   call get_param(param_file, mdl, "GINT", g_int, &
                  "The reduced gravity across internal interfaces.", &
                  units="m s-2", fail_if_missing=.true., scale=GV%Z_to_m)
@@ -148,12 +151,13 @@ subroutine set_coord_from_gprime(Rlay, g_prime, GV, param_file)
 end subroutine set_coord_from_gprime
 
 !> Sets the layer densities (Rlay) and the interface reduced gravities (g).
-subroutine set_coord_from_layer_density(Rlay, g_prime, GV, param_file)
+subroutine set_coord_from_layer_density(Rlay, g_prime, GV, US, param_file)
   real, dimension(:),      intent(out) :: Rlay       !< The layers' target coordinate values
                                                      !! (potential density).
   real, dimension(:),      intent(out) :: g_prime    !< The reduced gravity across the interfaces
                                                      !! in m2 Z-1 s-2.
   type(verticalGrid_type), intent(in)  :: GV         !< The ocean's vertical grid structure
+  type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
   ! Local variables
   real :: g_fs    ! Reduced gravity across the free surface, in m s-2.
@@ -167,7 +171,7 @@ subroutine set_coord_from_layer_density(Rlay, g_prime, GV, param_file)
 
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*GV%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
   call get_param(param_file, mdl, "LIGHTEST_DENSITY", Rlay_Ref, &
                  "The reference potential density used for layer 1.", &
                  units="kg m-3", default=GV%Rho0)
@@ -189,13 +193,14 @@ subroutine set_coord_from_layer_density(Rlay, g_prime, GV, param_file)
 end subroutine set_coord_from_layer_density
 
 !> Sets the layer densities (Rlay) and the interface reduced gravities (g) from a profile of g'.
-subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, param_file, eqn_of_state, &
+subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, US, param_file, eqn_of_state, &
                                  P_Ref)
   real, dimension(:),      intent(out) :: Rlay         !< The layers' target coordinate values
                                                        !! (potential density).
   real, dimension(:),      intent(out) :: g_prime      !< The reduced gravity across the interfaces
                                                        !! in m2 Z-1 s-2.
   type(verticalGrid_type), intent(in)  :: GV           !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US           !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file   !< A structure to parse for run-time
                                                        !! parameters
   type(EOS_type),          pointer     :: eqn_of_state !< integer selecting the equation of state.
@@ -219,7 +224,7 @@ subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, param_file, eqn_of_state, &
                  "The initial salinities.", units="PSU", default=35.0)
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*GV%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
   call get_param(param_file, mdl, "GINT", g_int, &
                  "The reduced gravity across internal interfaces.", &
                  units="m s-2", fail_if_missing=.true., scale=GV%Z_to_m)
@@ -240,13 +245,14 @@ subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, param_file, eqn_of_state, &
 end subroutine set_coord_from_TS_ref
 
 !> Sets the layer densities (Rlay) and the interface reduced gravities (g) from a T-S profile.
-subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, param_file, &
+subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, US, param_file, &
                                      eqn_of_state, P_Ref)
   real, dimension(:),      intent(out) :: Rlay         !< The layers' target coordinate values
                                                        !! (potential density).
   real, dimension(:),      intent(out) :: g_prime      !< The reduced gravity across the interfaces
                                                        !! in m2 Z-1 s-2.
   type(verticalGrid_type), intent(in)  :: GV           !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US           !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file   !< A structure to parse for run-time
                                                        !! parameters
   type(EOS_type),          pointer     :: eqn_of_state !< integer that selects equation of state.
@@ -264,7 +270,7 @@ subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, param_file, &
 
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*GV%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
   call get_param(param_file, mdl, "COORD_FILE", coord_file, &
                  "The file from which the coordinate temperatures and \n"//&
                  "salinities are read.", fail_if_missing=.true.)
@@ -288,13 +294,14 @@ subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, param_file, &
 end subroutine set_coord_from_TS_profile
 
 !> Sets the layer densities (Rlay) and the interface reduced gravities (g) from a linear T-S profile.
-subroutine set_coord_from_TS_range(Rlay, g_prime, GV, param_file, &
+subroutine set_coord_from_TS_range(Rlay, g_prime, GV, US, param_file, &
                                      eqn_of_state, P_Ref)
   real, dimension(:),      intent(out) :: Rlay         !< The layers' target coordinate values
                                                        !! (potential density).
   real, dimension(:),      intent(out) :: g_prime      !< The reduced gravity across the interfaces
                                                        !! in m2 Z-1 s-2.
   type(verticalGrid_type), intent(in)  :: GV           !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US           !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file   !< A structure to parse for run-time
                                                        !! parameters
   type(EOS_type),          pointer     :: eqn_of_state !< integer that selects equation of state
@@ -343,7 +350,7 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, param_file, &
 
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*GV%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
 
   k_light = GV%nk_rho_varies + 1
 
@@ -370,12 +377,13 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, param_file, &
 end subroutine set_coord_from_TS_range
 
 ! Sets the layer densities (Rlay) and the interface reduced gravities (g) from data in file.
-subroutine set_coord_from_file(Rlay, g_prime, GV, param_file)
+subroutine set_coord_from_file(Rlay, g_prime, GV, US, param_file)
   real, dimension(:),      intent(out) :: Rlay       !< The layers' target coordinate values
                                                      !! (potential density).
   real, dimension(:),      intent(out) :: g_prime    !< The reduced gravity across the interfaces
                                                      !! in m2 Z-1 s-2.
   type(verticalGrid_type), intent(in)  :: GV         !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
   ! Local variables
   real :: g_fs    ! Reduced gravity across the free surface, in m s-2.
@@ -389,7 +397,7 @@ subroutine set_coord_from_file(Rlay, g_prime, GV, param_file)
 
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*GV%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
   call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
   call get_param(param_file, mdl, "COORD_FILE", coord_file, &
@@ -420,12 +428,13 @@ end subroutine set_coord_from_file
 !! reference surface layer density and spanning a range of densities
 !! to the bottom defined by the parameter RLAY_RANGE
 !! (defaulting to 2.0 if not defined)
-subroutine set_coord_linear(Rlay, g_prime, GV, param_file)
+subroutine set_coord_linear(Rlay, g_prime, GV, US, param_file)
   real, dimension(:),      intent(out) :: Rlay       !< The layers' target coordinate values
                                                      !! (potential density).
   real, dimension(:),      intent(out) :: g_prime    !< The reduced gravity across the interfaces
                                                      !! in m2 Z-1 s-2.
   type(verticalGrid_type), intent(in)  :: GV         !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
   ! Local variables
   character(len=40)  :: mdl = "set_coord_linear" ! This subroutine
@@ -443,7 +452,7 @@ subroutine set_coord_linear(Rlay, g_prime, GV, param_file)
                  "all interfaces.", units="kg m-3", default=2.0)
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*GV%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
 
   ! This following sets the target layer densities such that a the
   ! surface interface has density Rlay_ref and the bottom
@@ -463,12 +472,13 @@ end subroutine set_coord_linear
 !> Sets Rlay to Rho0 and g_prime to zero except for the free surface.
 !! This is for use only in ALE mode where Rlay should not be used and g_prime(1) alone
 !! might be used.
-subroutine set_coord_to_none(Rlay, g_prime, GV, param_file)
+subroutine set_coord_to_none(Rlay, g_prime, GV, US, param_file)
   real, dimension(:),      intent(out) :: Rlay       !< The layers' target coordinate values
                                                      !! (potential density).
   real, dimension(:),      intent(out) :: g_prime    !< The reduced gravity across the interfaces,
                                                      !! in m s-2.
   type(verticalGrid_type), intent(in)  :: GV         !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
   ! Local variables
   real :: g_fs    ! Reduced gravity across the free surface, in m s-2.
@@ -480,7 +490,7 @@ subroutine set_coord_to_none(Rlay, g_prime, GV, param_file)
 
   call get_param(param_file, mdl, "GFS" , g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*GV%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
 
   g_prime(1) = g_fs
   do k=2,nz ; g_prime(k) = 0. ; enddo
@@ -511,7 +521,7 @@ subroutine write_vertgrid_file(GV, param_file, directory)
   call create_file(unit, trim(filepath), vars, 2, fields, SINGLE_FILE, GV=GV)
 
   call write_field(unit, fields(1), GV%Rlay)
-  call write_field(unit, fields(2), GV%g_prime)
+  call write_field(unit, fields(2), GV%g_prime)  !### RESCALE THIS?
 
   call close_file(unit)
 

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -136,10 +136,10 @@ subroutine set_coord_from_gprime(Rlay, g_prime, GV, US, param_file)
 
   call get_param(param_file, mdl, "GFS" , g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)
   call get_param(param_file, mdl, "GINT", g_int, &
                  "The reduced gravity across internal interfaces.", &
-                 units="m s-2", fail_if_missing=.true., scale=GV%Z_to_m)
+                 units="m s-2", fail_if_missing=.true., scale=US%Z_to_m)
 
   g_prime(1) = g_fs
   do k=2,nz ; g_prime(k) = g_int ; enddo
@@ -171,7 +171,7 @@ subroutine set_coord_from_layer_density(Rlay, g_prime, GV, US, param_file)
 
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)
   call get_param(param_file, mdl, "LIGHTEST_DENSITY", Rlay_Ref, &
                  "The reference potential density used for layer 1.", &
                  units="kg m-3", default=GV%Rho0)
@@ -224,10 +224,10 @@ subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, US, param_file, eqn_of_state
                  "The initial salinities.", units="PSU", default=35.0)
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)
   call get_param(param_file, mdl, "GINT", g_int, &
                  "The reduced gravity across internal interfaces.", &
-                 units="m s-2", fail_if_missing=.true., scale=GV%Z_to_m)
+                 units="m s-2", fail_if_missing=.true., scale=US%Z_to_m)
                                       !
 !    These statements set the interface reduced gravities.           !
   g_prime(1) = g_fs
@@ -270,7 +270,7 @@ subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, US, param_file, &
 
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)
   call get_param(param_file, mdl, "COORD_FILE", coord_file, &
                  "The file from which the coordinate temperatures and \n"//&
                  "salinities are read.", fail_if_missing=.true.)
@@ -350,7 +350,7 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, US, param_file, &
 
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)
 
   k_light = GV%nk_rho_varies + 1
 
@@ -397,7 +397,7 @@ subroutine set_coord_from_file(Rlay, g_prime, GV, US, param_file)
 
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)
   call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
   call get_param(param_file, mdl, "COORD_FILE", coord_file, &
@@ -452,7 +452,7 @@ subroutine set_coord_linear(Rlay, g_prime, GV, US, param_file)
                  "all interfaces.", units="kg m-3", default=2.0)
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)
 
   ! This following sets the target layer densities such that a the
   ! surface interface has density Rlay_ref and the bottom
@@ -490,7 +490,7 @@ subroutine set_coord_to_none(Rlay, g_prime, GV, US, param_file)
 
   call get_param(param_file, mdl, "GFS" , g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
-                 default=(GV%g_Earth*US%m_to_Z), scale=GV%Z_to_m)
+                 default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)
 
   g_prime(1) = g_fs
   do k=2,nz ; g_prime(k) = 0. ; enddo

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -37,7 +37,7 @@ subroutine MOM_initialize_coord(GV, PF, write_geom, output_dir, tv, max_depth)
   logical,                 intent(in)    :: write_geom !< If true, write grid geometry files.
   character(len=*),        intent(in)    :: output_dir !< The directory into which to write files.
   type(thermo_var_ptrs),   intent(inout) :: tv         !< The thermodynamic variable structure.
-  real,                    intent(in)    :: max_depth  !< The ocean's maximum depth, in m.
+  real,                    intent(in)    :: max_depth  !< The ocean's maximum depth, in Z.
   ! Local
   character(len=200) :: config
   logical :: debug

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -36,6 +36,7 @@ use MOM_ALE_sponge, only : ALE_sponge_CS
 use MOM_string_functions, only : uppercase, lowercase
 use MOM_time_manager, only : time_type
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : setVerticalGridAxes, verticalGrid_type
 use MOM_ALE, only : pressure_gradient_plm
@@ -111,11 +112,12 @@ contains
 
 !> Initialize temporally evolving fields, either as initial
 !! conditions or by reading them from a restart (or saves) file.
-subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
+subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
                                 restart_CS, ALE_CSp, tracer_Reg, sponge_CSp, &
                                 ALE_sponge_CSp, OBC, Time_in)
   type(ocean_grid_type),      intent(inout) :: G    !< The ocean's grid structure.
   type(verticalGrid_type),    intent(in)    :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),      intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                               intent(out)   :: u    !< The zonal velocity that is being initialized,
                                                     !! in m s-1
@@ -233,7 +235,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
     if (.NOT.use_temperature) call MOM_error(FATAL,"MOM_initialize_state : "//&
        "use_temperature must be true if INIT_LAYERS_FROM_Z_FILE is true")
 
-    call MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params=just_read)
+    call MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_params=just_read)
 
   else
     ! Initialize thickness, h.
@@ -267,9 +269,9 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
              fail_if_missing=new_sim, do_not_log=just_read)
     select case (trim(config))
        case ("file")
-         call initialize_thickness_from_file(h, G, GV, PF, .false., just_read_params=just_read)
+         call initialize_thickness_from_file(h, G, GV, US, PF, .false., just_read_params=just_read)
        case ("thickness_file")
-         call initialize_thickness_from_file(h, G, GV, PF, .true., just_read_params=just_read)
+         call initialize_thickness_from_file(h, G, GV, US, PF, .true., just_read_params=just_read)
        case ("coord")
          if (new_sim .and. useALE) then
            call ALE_initThicknessToCoord( ALE_CSp, G, GV, h )
@@ -279,35 +281,35 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
          endif
        case ("uniform"); call initialize_thickness_uniform(h, G, GV, PF, &
                                   just_read_params=just_read)
-       case ("list"); call initialize_thickness_list(h, G, GV, PF, &
+       case ("list"); call initialize_thickness_list(h, G, GV, US, PF, &
                                   just_read_params=just_read)
        case ("DOME"); call DOME_initialize_thickness(h, G, GV, PF, &
                                just_read_params=just_read)
-       case ("ISOMIP"); call ISOMIP_initialize_thickness(h, G, GV, PF, tv, &
+       case ("ISOMIP"); call ISOMIP_initialize_thickness(h, G, GV, US, PF, tv, &
                                  just_read_params=just_read)
-       case ("benchmark"); call benchmark_initialize_thickness(h, G, GV, PF, &
+       case ("benchmark"); call benchmark_initialize_thickness(h, G, GV, US, PF, &
                                     tv%eqn_of_state, tv%P_Ref, just_read_params=just_read)
-       case ("Neverland"); call Neverland_initialize_thickness(h, G, GV, PF, &
+       case ("Neverland"); call Neverland_initialize_thickness(h, G, GV, US, PF, &
                                  tv%eqn_of_state, tv%P_Ref)
        case ("search"); call initialize_thickness_search
        case ("circle_obcs"); call circle_obcs_initialize_thickness(h, G, GV, PF, &
                                       just_read_params=just_read)
-       case ("lock_exchange"); call lock_exchange_initialize_thickness(h, G, GV, &
+       case ("lock_exchange"); call lock_exchange_initialize_thickness(h, G, GV, US, &
                                         PF, just_read_params=just_read)
-       case ("external_gwave"); call external_gwave_initialize_thickness(h, G, GV, &
+       case ("external_gwave"); call external_gwave_initialize_thickness(h, G, GV, US, &
                                          PF, just_read_params=just_read)
-       case ("DOME2D"); call DOME2d_initialize_thickness(h, G, GV, PF, &
+       case ("DOME2D"); call DOME2d_initialize_thickness(h, G, GV, US, PF, &
                                  just_read_params=just_read)
-       case ("adjustment2d"); call adjustment_initialize_thickness(h, G, GV, &
+       case ("adjustment2d"); call adjustment_initialize_thickness(h, G, GV, US, &
                                        PF, just_read_params=just_read)
-       case ("sloshing"); call sloshing_initialize_thickness(h, G, GV, PF, &
+       case ("sloshing"); call sloshing_initialize_thickness(h, G, GV, US, PF, &
                                    just_read_params=just_read)
-       case ("seamount"); call seamount_initialize_thickness(h, G, GV, PF, &
+       case ("seamount"); call seamount_initialize_thickness(h, G, GV, US, PF, &
                                    just_read_params=just_read)
-       case ("dumbbell"); call dumbbell_initialize_thickness(h, G, GV, PF, &
+       case ("dumbbell"); call dumbbell_initialize_thickness(h, G, GV, US, PF, &
                                    just_read_params=just_read)
-       case ("soliton"); call soliton_initialize_thickness(h, G, GV)
-       case ("phillips"); call Phillips_initialize_thickness(h, G, GV, PF, &
+       case ("soliton"); call soliton_initialize_thickness(h, G, GV, US)
+       case ("phillips"); call Phillips_initialize_thickness(h, G, GV, US, PF, &
                                    just_read_params=just_read)
        case ("rossby_front"); call Rossby_front_initialize_thickness(h, G, GV, &
                                        PF, just_read_params=just_read)
@@ -368,8 +370,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                                     tv%S, h, G, GV, PF, eos, just_read_params=just_read)
         case ("rossby_front"); call Rossby_front_initialize_temperature_salinity ( tv%T, &
                                         tv%S, h, G, GV, PF, eos, just_read_params=just_read)
-        case ("SCM_CVMix_tests"); call SCM_CVMix_tests_TS_init (tv%T, &
-                                           tv%S, h, G, GV, PF, just_read_params=just_read)
+        case ("SCM_CVMix_tests"); call SCM_CVMix_tests_TS_init(tv%T, tv%S, h, &
+                                           G, GV, US, PF, just_read_params=just_read)
         case ("dense"); call dense_water_initialize_TS(G, GV, PF, eos, tv%T, tv%S, &
                                  h, just_read_params=just_read)
         case ("USER"); call user_init_temperature_salinity(tv%T, tv%S, G, PF, eos, &
@@ -407,7 +409,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                                 just_read_params=just_read)
      case ("circular"); call initialize_velocity_circular(u, v, G, PF, &
                                  just_read_params=just_read)
-     case ("phillips"); call Phillips_initialize_velocity(u, v, G, GV, PF, &
+     case ("phillips"); call Phillips_initialize_velocity(u, v, G, GV, US, PF, &
                                  just_read_params=just_read)
      case ("rossby_front"); call Rossby_front_initialize_velocity(u, v, h, &
                                      G, GV, PF, just_read_params=just_read)
@@ -433,7 +435,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
 
   if (new_sim .and. convert .and. .not.GV%Boussinesq) &
     ! Convert thicknesses from geomtric distances to mass-per-unit-area.
-    call convert_thickness(h, G, GV, tv)
+    call convert_thickness(h, G, GV, US, tv)
 
   ! Remove the mass that would be displaced by an ice shelf or inverse barometer.
   call get_param(PF, mdl, "DEPRESS_INITIAL_SURFACE", depress_sfc, &
@@ -449,8 +451,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
            "DEPRESS_INITIAL_SURFACE and TRIM_IC_FOR_P_SURF are exclusive and cannot both be True")
   if (new_sim .and. debug .and. (depress_sfc .or. trim_ic_for_p_surf)) &
     call hchksum(h, "Pre-depress: h ", G%HI, haloshift=1, scale=GV%H_to_m)
-  if (depress_sfc) call depress_surface(h, G, GV, PF, tv, just_read_params=just_read)
-  if (trim_ic_for_p_surf) call trim_for_ice(PF, G, GV, ALE_CSp, tv, h, just_read_params=just_read)
+  if (depress_sfc) call depress_surface(h, G, GV, US, PF, tv, just_read_params=just_read)
+  if (trim_ic_for_p_surf) call trim_for_ice(PF, G, GV, US, ALE_CSp, tv, h, just_read_params=just_read)
 
   ! Perhaps we want to run the regridding coordinate generator for multiple
   ! iterations here so the initial grid is consistent with the coordinate
@@ -523,20 +525,20 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                  " \t\t for buoyancy-forced basin case.\n"//&
                  " \t USER - call a user modified routine.", default="file")
     select case (trim(config))
-      case ("DOME"); call DOME_initialize_sponges(G, GV, tv, PF, sponge_CSp)
+      case ("DOME"); call DOME_initialize_sponges(G, GV, US, tv, PF, sponge_CSp)
       case ("DOME2D"); call DOME2d_initialize_sponges(G, GV, tv, PF, useALE, &
                                                       sponge_CSp, ALE_sponge_CSp)
-      case ("ISOMIP"); call ISOMIP_initialize_sponges(G, GV, tv, PF, useALE, &
+      case ("ISOMIP"); call ISOMIP_initialize_sponges(G, GV, US, tv, PF, useALE, &
                                                       sponge_CSp, ALE_sponge_CSp)
       case ("USER"); call user_initialize_sponges(G, GV, use_temperature, tv, PF, sponge_CSp, h)
-      case ("BFB"); call BFB_initialize_sponges_southonly(G, GV, use_temperature, tv, PF, &
+      case ("BFB"); call BFB_initialize_sponges_southonly(G, GV, US, use_temperature, tv, PF, &
                                                           sponge_CSp, h)
-      case ("DUMBBELL"); call dumbbell_initialize_sponges(G, GV, tv, PF, useALE, &
+      case ("DUMBBELL"); call dumbbell_initialize_sponges(G, GV, US, tv, PF, useALE, &
                                                           sponge_CSp, ALE_sponge_CSp)
-      case ("phillips"); call Phillips_initialize_sponges(G, GV, tv, PF, sponge_CSp, h)
+      case ("phillips"); call Phillips_initialize_sponges(G, GV, US, tv, PF, sponge_CSp, h)
       case ("dense"); call dense_water_initialize_sponges(G, GV, tv, PF, useALE, &
                                                           sponge_CSp, ALE_sponge_CSp)
-      case ("file"); call initialize_sponges_file(G, GV, use_temperature, tv, PF, &
+      case ("file"); call initialize_sponges_file(G, GV, US, use_temperature, tv, PF, &
                                                   sponge_CSp, ALE_sponge_CSp, Time)
       case default ; call MOM_error(FATAL,  "MOM_initialize_state: "//&
              "Unrecognized sponge configuration "//trim(config))
@@ -560,7 +562,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
                  "   tidal_bay - Flather with tidal forcing on eastern boundary\n"//&
                  "   USER - user specified", default="none")
     if (trim(config) == "DOME") then
-      call DOME_set_OBC_data(OBC, tv, G, GV, PF, tracer_Reg)
+      call DOME_set_OBC_data(OBC, tv, G, GV, US, PF, tracer_Reg)
     elseif (trim(config) == "dyed_channel") then
       call dyed_channel_set_OBC_tracer_data(OBC, G, GV, PF, tracer_Reg)
       OBC%update_OBC = .true.
@@ -601,18 +603,20 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, PF, dirs, &
 end subroutine MOM_initialize_state
 
 !> Reads the layer thicknesses or interface heights from a file.
-subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickness, just_read_params)
+subroutine initialize_thickness_from_file(h, G, GV, US, param_file, file_has_thickness, &
+                                          just_read_params)
   type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized, in m.
+                           intent(out) :: h    !< The thickness that is being initialized, in m.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
-                                                      !! to parse for model parameter values.
+                                               !! to parse for model parameter values.
   logical,                 intent(in)  :: file_has_thickness !< If true, this file contains layer
-                                                      !! thicknesses; otherwise it contains
-                                                      !! interface heights.
+                                               !! thicknesses; otherwise it contains
+                                               !! interface heights.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
-                                                      !! only read parameters without changing h.
+                                               !! only read parameters without changing h.
 
   ! Local variables
   real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1)  ! Interface heights, in depth units.
@@ -653,10 +657,10 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
                  "would indicate.", default=.false., do_not_log=just_read)
     if (just_read) return ! All run-time parameters have been read, so return.
 
-    call MOM_read_data(filename, "eta", eta(:,:,:), G%Domain, scale=GV%m_to_Z)
+    call MOM_read_data(filename, "eta", eta(:,:,:), G%Domain, scale=US%m_to_Z)
 
     if (correct_thickness) then
-      call adjustEtaToFitBathymetry(G, GV, eta, h)
+      call adjustEtaToFitBathymetry(G, GV, US, eta, h)
     else
       do k=nz,1,-1 ; do j=js,je ; do i=is,ie
         if (eta(i,j,K) < (eta(i,j,K+1) + GV%Angstrom_Z)) then
@@ -668,7 +672,7 @@ subroutine initialize_thickness_from_file(h, G, GV, param_file, file_has_thickne
       enddo ; enddo ; enddo
 
       do j=js,je ; do i=is,ie
-        if (abs(eta(i,j,nz+1) + G%bathyT(i,j)) > 1.0*GV%m_to_Z) &
+        if (abs(eta(i,j,nz+1) + G%bathyT(i,j)) > 1.0*US%m_to_Z) &
           inconsistent = inconsistent + 1
       enddo ; enddo
       call sum_across_PEs(inconsistent)
@@ -692,9 +696,10 @@ end subroutine initialize_thickness_from_file
 !! is dilated (expanded) to fill the void.
 !!   @remark{There is a (hard-wired) "tolerance" parameter such that the
 !! criteria for adjustment must equal or exceed 10cm.}
-subroutine adjustEtaToFitBathymetry(G, GV, eta, h)
+subroutine adjustEtaToFitBathymetry(G, GV, US, eta, h)
   type(ocean_grid_type),                      intent(in)    :: G   !< The ocean's grid structure
   type(verticalGrid_type),                    intent(in)    :: GV  !< The ocean's vertical grid structure
+  type(unit_scale_type),                      intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: eta !< Interface heights, in Z
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(inout) :: h   !< Layer thicknesses, in H
   ! Local variables
@@ -704,7 +709,7 @@ subroutine adjustEtaToFitBathymetry(G, GV, eta, h)
   character(len=100) :: mesg
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
-  hTolerance = 0.1*GV%m_to_Z
+  hTolerance = 0.1*US%m_to_Z
 
   contractions = 0
   do j=js,je ; do i=is,ie
@@ -820,9 +825,10 @@ subroutine initialize_thickness_uniform(h, G, GV, param_file, just_read_params)
 end subroutine initialize_thickness_uniform
 
 !> Initialize thickness from a 1D list
-subroutine initialize_thickness_list(h, G, GV, param_file, just_read_params)
+subroutine initialize_thickness_list(h, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -861,7 +867,7 @@ subroutine initialize_thickness_list(h, G, GV, param_file, just_read_params)
   call log_param(param_file, mdl, "INPUTDIR/INTERFACE_IC_FILE", filename)
 
   e0(:) = 0.0
-  call MOM_read_data(filename, eta_var, e0(:), scale=GV%m_to_Z)
+  call MOM_read_data(filename, eta_var, e0(:), scale=US%m_to_Z)
 
   if ((abs(e0(1)) - 0.0) > 0.001) then
     ! This list probably starts with the interior interface, so shift it up.
@@ -900,9 +906,10 @@ subroutine initialize_thickness_search
 end subroutine initialize_thickness_search
 
 !> Converts thickness from geometric to pressure units
-subroutine convert_thickness(h, G, GV, tv)
+subroutine convert_thickness(h, G, GV, US, tv)
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(inout) :: h    !< Input geometric layer thicknesses (in H units),
                                                  !! being converted to layer pressure
@@ -926,7 +933,7 @@ subroutine convert_thickness(h, G, GV, tv)
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   max_itt = 10
   Boussinesq = GV%Boussinesq
-  I_gEarth = 1.0 / (GV%g_Earth*GV%m_to_Z)
+  I_gEarth = 1.0 / (GV%g_Earth*US%m_to_Z)
   Hm_rho_to_Pa = GV%g_Earth * GV%H_to_Z ! = GV%H_to_Pa / GV%Rho0
 
   if (Boussinesq) then
@@ -978,9 +985,10 @@ subroutine convert_thickness(h, G, GV, tv)
 end subroutine convert_thickness
 
 !> Depress the sea-surface based on an initial condition file
-subroutine depress_surface(h, G, GV, param_file, tv, just_read_params)
+subroutine depress_surface(h, G, GV, US, param_file, tv, just_read_params)
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(inout) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
@@ -1027,7 +1035,7 @@ subroutine depress_surface(h, G, GV, param_file, tv, just_read_params)
   call MOM_read_data(filename, eta_srf_var, eta_sfc, G%Domain, scale=scale_factor)
 
   ! Convert thicknesses to interface heights.
-  call find_eta(h, tv, G, GV, eta, eta_to_m=1.0)
+  call find_eta(h, tv, G, GV, US, eta, eta_to_m=1.0)
 
   do j=js,je ; do i=is,ie ; if (G%mask2dT(i,j) > 0.0) then
 !    if (eta_sfc(i,j) < eta(i,j,nz+1)) then
@@ -1061,10 +1069,11 @@ end subroutine depress_surface
 
 !> Adjust the layer thicknesses by cutting away the top of each model column at the depth
 !! where the hydrostatic pressure matches an imposed surface pressure read from file.
-subroutine trim_for_ice(PF, G, GV, ALE_CSp, tv, h, just_read_params)
+subroutine trim_for_ice(PF, G, GV, US, ALE_CSp, tv, h, just_read_params)
   type(param_file_type),   intent(in)    :: PF !< Parameter file structure
   type(ocean_grid_type),   intent(in)    :: G !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV !< Vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
   type(ALE_CS),            pointer       :: ALE_CSp !< ALE control structure
   type(thermo_var_ptrs),   intent(inout) :: tv !< Thermodynamics structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
@@ -1101,7 +1110,7 @@ subroutine trim_for_ice(PF, G, GV, ALE_CSp, tv, h, just_read_params)
                  "file SURFACE_PRESSURE_FILE into a surface pressure.", &
                  units="file dependent", default=1., do_not_log=just_read)
   call get_param(PF, mdl, "MIN_THICKNESS", min_thickness, 'Minimum layer thickness', &
-                 units='m', default=1.e-3, do_not_log=just_read, scale=GV%m_to_Z)
+                 units='m', default=1.e-3, do_not_log=just_read, scale=US%m_to_Z)
   call get_param(PF, mdl, "TRIMMING_USES_REMAPPING", use_remapping, &
                  'When trimming the column, also remap T and S.', &
                  default=.false., do_not_log=just_read)
@@ -1130,7 +1139,7 @@ subroutine trim_for_ice(PF, G, GV, ALE_CSp, tv, h, just_read_params)
     call cut_off_column_top(GV%ke, tv, GV, GV%g_Earth, G%bathyT(i,j), &
                min_thickness, tv%T(i,j,:), T_t(i,j,:), T_b(i,j,:), &
                tv%S(i,j,:), S_t(i,j,:), S_b(i,j,:), p_surf(i,j), h(i,j,:), remap_CS, &
-               z_tol=1.0e-5*GV%m_to_Z)
+               z_tol=1.0e-5*US%m_to_Z)
   enddo ; enddo
 
 end subroutine trim_for_ice
@@ -1651,9 +1660,10 @@ end subroutine initialize_temp_salt_linear
 !! number of tracers should be restored within each sponge. The
 !! interface height is always subject to damping, and must always be
 !! the first registered field.
-subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp, ALE_CSp, Time)
+subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, param_file, CSp, ALE_CSp, Time)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in) :: US  !< A dimensional unit scaling type
   logical,                 intent(in) :: use_temperature !< If true, T & S are state variables.
   type(thermo_var_ptrs),   intent(in) :: tv   !< A structure pointing to various thermodynamic
                                               !! variables.
@@ -1750,7 +1760,7 @@ subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp, 
 
   if (.not. use_ALE) then
     allocate(eta(isd:ied,jsd:jed,nz+1))
-    call MOM_read_data(filename, eta_var, eta(:,:,:), G%Domain, scale=GV%m_to_Z)
+    call MOM_read_data(filename, eta_var, eta(:,:,:), G%Domain, scale=US%m_to_Z)
 
     do j=js,je ; do i=is,ie
       eta(i,j,nz+1) = -G%bathyT(i,j)
@@ -1775,7 +1785,7 @@ subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp, 
     allocate(eta(isd:ied,jsd:jed,nz_data+1))
     allocate(h(isd:ied,jsd:jed,nz_data))
 
-    call MOM_read_data(filename, eta_var, eta(:,:,:), G%Domain, scale=GV%m_to_Z)
+    call MOM_read_data(filename, eta_var, eta(:,:,:), G%Domain, scale=US%m_to_Z)
 
     do j=js,je ; do i=is,ie
       eta(i,j,nz+1) = -G%bathyT(i,j)
@@ -1884,13 +1894,14 @@ end subroutine set_velocity_depth_min
 !> This subroutine determines the isopycnal or other coordinate interfaces and
 !! layer potential temperatures and salinities directly from a z-space file on
 !! a latitude-longitude grid.
-subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
+subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_params)
   type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(out)   :: h    !< Layer thicknesses being initialized, in H
   type(thermo_var_ptrs),   intent(inout) :: tv   !< A structure pointing to various thermodynamic
                                                  !! variables including temperature and salinity
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: PF   !< A structure indicating the open file
                                                  !! to parse for model parameter values.
   logical,       optional, intent(in)    :: just_read_params !< If present and true, this call will
@@ -1996,7 +2007,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 
   reentrant_x = .false. ; call get_param(PF, mdl, "REENTRANT_X", reentrant_x,default=.true.)
   tripolar_n = .false. ;  call get_param(PF, mdl, "TRIPOLAR_N", tripolar_n, default=.false.)
-  call get_param(PF, mdl, "MINIMUM_DEPTH", min_depth, default=0.0, scale=GV%m_to_Z)
+  call get_param(PF, mdl, "MINIMUM_DEPTH", min_depth, default=0.0, scale=US%m_to_Z)
 
   call get_param(PF, mdl, "NKML",nkml,default=0)
   call get_param(PF, mdl, "NKBL",nkbl,default=0)
@@ -2071,7 +2082,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
   endif
 
   !### Change this to GV%Angstrom_Z
-  eps_z = 1.0e-10*GV%m_to_Z
+  eps_z = 1.0e-10*US%m_to_Z
 
   ! Read input grid coordinates for temperature and salinity field
   ! in z-coordinate dataset. The file is REQUIRED to contain the
@@ -2090,11 +2101,11 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 
   call horiz_interp_and_extrap_tracer(tfilename, potemp_var, 1.0, 1, &
        G, temp_z, mask_z, z_in, z_edges_in, missing_value_temp, reentrant_x, &
-       tripolar_n, homogenize, m_to_Z=GV%m_to_Z)
+       tripolar_n, homogenize, m_to_Z=US%m_to_Z)
 
   call horiz_interp_and_extrap_tracer(sfilename, salin_var, 1.0, 1, &
        G, salt_z, mask_z, z_in, z_edges_in, missing_value_salt, reentrant_x, &
-       tripolar_n, homogenize, m_to_Z=GV%m_to_Z)
+       tripolar_n, homogenize, m_to_Z=US%m_to_Z)
 
   kd = size(z_in,1)
 
@@ -2184,7 +2195,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 
     ! Build the target grid (and set the model thickness to it)
     ! This call can be more general but is hard-coded for z* coordinates...  ????
-    call ALE_initRegridding( GV, G%max_depth, PF, mdl, regridCS ) ! sets regridCS
+    call ALE_initRegridding( GV, US, G%max_depth, PF, mdl, regridCS ) ! sets regridCS
 
     if (.not. remap_general) then
       ! This is the old way of initializing to z* coordinates only
@@ -2250,7 +2261,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
                                         nlevs(is:ie,js:je), nkml, nkbl, min_depth, eps_z=eps_z)
 
     if (correct_thickness) then
-      call adjustEtaToFitBathymetry(G, GV, zi, h)
+      call adjustEtaToFitBathymetry(G, GV, US, zi, h)
     else
       do k=nz,1,-1 ; do j=js,je ; do i=is,ie
         if (zi(i,j,K) < (zi(i,j,K+1) + GV%Angstrom_Z)) then
@@ -2262,7 +2273,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
       enddo ; enddo ; enddo
       inconsistent=0
       do j=js,je ; do i=is,ie
-        if (abs(zi(i,j,nz+1) + G%bathyT(i,j)) > 1.0*GV%m_to_Z) &
+        if (abs(zi(i,j,nz+1) + G%bathyT(i,j)) > 1.0*US%m_to_Z) &
           inconsistent = inconsistent + 1
       enddo ; enddo
       call sum_across_PEs(inconsistent)
@@ -2335,9 +2346,10 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 end subroutine MOM_temp_salt_initialize_from_Z
 
 !> Run simple unit tests
-subroutine MOM_state_init_tests(G, GV, tv)
+subroutine MOM_state_init_tests(G, GV, US, tv)
   type(ocean_grid_type),     intent(inout) :: G    !< The ocean's grid structure.
   type(verticalGrid_type),   intent(in)    :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),     intent(in)    :: US   !< A dimensional unit scaling type
   type(thermo_var_ptrs),     intent(in)    :: tv   !< Thermodynamics structure.
   ! Local variables
   integer, parameter :: nk=5
@@ -2363,15 +2375,15 @@ subroutine MOM_state_init_tests(G, GV, tv)
     S_t(k) = 35.-(0./500.)*e(k)
     S(k)   = 35.+(0./500.)*z(k)
     S_b(k) = 35.-(0./500.)*e(k+1)
-    call calculate_density(0.5*(T_t(k)+T_b(k)), 0.5*(S_t(k)+S_b(k)), -GV%Rho0*(GV%g_Earth*GV%m_to_Z)*z(k), &
+    call calculate_density(0.5*(T_t(k)+T_b(k)), 0.5*(S_t(k)+S_b(k)), -GV%Rho0*(GV%g_Earth*US%m_to_Z)*z(k), &
                            rho(k), tv%eqn_of_state)
-    P_tot = P_tot + (GV%g_Earth*GV%m_to_Z) * rho(k) * h(k)
+    P_tot = P_tot + (GV%g_Earth*US%m_to_Z) * rho(k) * h(k)
   enddo
 
   P_t = 0.
   do k = 1, nk
     call find_depth_of_pressure_in_cell(T_t(k), T_b(k), S_t(k), S_b(k), e(K), e(K+1), &
-                                        P_t, 0.5*P_tot, GV%Rho0, (GV%g_Earth*GV%m_to_Z), tv%eqn_of_state, P_b, z_out)
+                                        P_t, 0.5*P_tot, GV%Rho0, (GV%g_Earth*US%m_to_Z), tv%eqn_of_state, P_b, z_out)
     write(0,*) k,P_t,P_b,0.5*P_tot,e(K),e(K+1),z_out
     P_t = P_b
   enddo
@@ -2381,7 +2393,7 @@ subroutine MOM_state_init_tests(G, GV, tv)
   write(0,*) ' ==================================================================== '
   write(0,*) ''
   write(0,*) h
-  call cut_off_column_top(nk, tv, GV, (GV%g_Earth*GV%m_to_Z), -e(nk+1), GV%Angstrom_H, &
+  call cut_off_column_top(nk, tv, GV, (GV%g_Earth*US%m_to_Z), -e(nk+1), GV%Angstrom_H, &
                T, T_t, T_b, S, S_t, S_b, 0.5*P_tot, h, remap_CS)
   write(0,*) h
 

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1824,8 +1824,8 @@ subroutine initialize_sponges_file(G, GV, use_temperature, tv, param_file, CSp, 
     call MOM_read_data(filename, salin_var, tmp(:,:,:), G%Domain)
     call set_up_sponge_field(tmp, tv%S, G, nz, CSp)
   elseif (use_temperature) then
-    call set_up_ALE_sponge_field(filename, potemp_var, Time, G, tv%T, ALE_CSp)
-    call set_up_ALE_sponge_field(filename, salin_var, Time, G, tv%S, ALE_CSp)
+    call set_up_ALE_sponge_field(filename, potemp_var, Time, G, GV, tv%T, ALE_CSp)
+    call set_up_ALE_sponge_field(filename, salin_var, Time, G, GV, tv%S, ALE_CSp)
   endif
 
 end subroutine initialize_sponges_file
@@ -2089,16 +2089,17 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
   ! value at the northernmost/southernmost latitude.
 
   call horiz_interp_and_extrap_tracer(tfilename, potemp_var, 1.0, 1, &
-       G, temp_z, mask_z, z_in, z_edges_in, missing_value_temp, reentrant_x, tripolar_n, homogenize)
+       G, temp_z, mask_z, z_in, z_edges_in, missing_value_temp, reentrant_x, &
+       tripolar_n, homogenize, m_to_Z=GV%m_to_Z)
 
   call horiz_interp_and_extrap_tracer(sfilename, salin_var, 1.0, 1, &
-       G, salt_z, mask_z, z_in, z_edges_in, missing_value_salt, reentrant_x, tripolar_n, homogenize)
+       G, salt_z, mask_z, z_in, z_edges_in, missing_value_salt, reentrant_x, &
+       tripolar_n, homogenize, m_to_Z=GV%m_to_Z)
 
   kd = size(z_in,1)
 
-  ! Convert the units and sign convention of z_in and Z_edges_in.
-  do k=1,kd ; z_in(k) = GV%m_to_Z*z_in(k) ; enddo
-  do k=1,size(Z_edges_in,1) ; Z_edges_in(k) = -GV%m_to_Z*Z_edges_in(k) ; enddo
+  ! Convert the sign convention of Z_edges_in.
+  do k=1,size(Z_edges_in,1) ; Z_edges_in(k) = -Z_edges_in(k) ; enddo
 
   allocate(rho_z(isd:ied,jsd:jed,kd))
   allocate(area_shelf_h(isd:ied,jsd:jed))

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2184,12 +2184,12 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, just_read_params)
 
     ! Build the target grid (and set the model thickness to it)
     ! This call can be more general but is hard-coded for z* coordinates...  ????
-    call ALE_initRegridding( GV, GV%Z_to_m*G%max_depth, PF, mdl, regridCS ) ! sets regridCS
+    call ALE_initRegridding( GV, G%max_depth, PF, mdl, regridCS ) ! sets regridCS
 
     if (.not. remap_general) then
       ! This is the old way of initializing to z* coordinates only
       allocate( hTarget(nz) )
-      hTarget = GV%m_to_Z * getCoordinateResolution( regridCS )
+      hTarget = getCoordinateResolution( regridCS )
       do j = js, je ; do i = is, ie
         h(i,j,:) = 0.
         if (G%mask2dT(i,j)>0.) then

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -361,7 +361,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
         case ("adjustment2d"); call adjustment_initialize_temperature_salinity ( tv%T, &
                                         tv%S, h, G, GV, PF, eos, just_read_params=just_read)
         case ("baroclinic_zone"); call baroclinic_zone_init_temperature_salinity( tv%T, &
-                                           tv%S, h, G, GV, PF, just_read_params=just_read)
+                                           tv%S, h, G, GV, US, PF, just_read_params=just_read)
         case ("sloshing"); call sloshing_initialize_temperature_salinity(tv%T, &
                                     tv%S, h, G, GV, PF, eos, just_read_params=just_read)
         case ("seamount"); call seamount_initialize_temperature_salinity(tv%T, &

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -120,10 +120,10 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
   if (PRESENT(src_var_unit_conversion)) convert = src_var_unit_conversion
 
   call horiz_interp_and_extrap_tracer(src_file, src_var_nam, convert, recnum, &
-       G, tr_z, mask_z, z_in, z_edges_in, missing_value, reentrant_x, tripolar_n, homog)
+       G, tr_z, mask_z, z_in, z_edges_in, missing_value, reentrant_x, tripolar_n, &
+       homog, m_to_Z=GV%m_to_Z)
 
   kd = size(z_edges_in,1)-1
-  do k=1,kd+1 ; z_edges_in(k) = GV%m_to_Z*z_edges_in(k) ; enddo
   call pass_var(tr_z,G%Domain)
   call pass_var(mask_z,G%Domain)
 

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -15,17 +15,17 @@ use MOM_file_parser, only : get_param, read_param, log_param, param_file_type
 use MOM_file_parser, only : log_version
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type, isPointInCell
-use MOM_string_functions, only : uppercase
-use MOM_variables, only : thermo_var_ptrs
-use MOM_verticalGrid, only : setVerticalGridAxes
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
-use MOM_EOS, only : int_specific_vol_dp
-use MOM_ALE, only : ALE_remap_scalar
+use MOM_horizontal_regridding, only : myStats, horiz_interp_and_extrap_tracer
 use MOM_regridding, only : regridding_CS
 use MOM_remapping, only : remapping_CS, initialize_remapping
 use MOM_remapping, only : remapping_core_h
-use MOM_verticalGrid,     only : verticalGrid_type
-use MOM_horizontal_regridding, only : myStats, horiz_interp_and_extrap_tracer
+use MOM_string_functions, only : uppercase
+use MOM_unit_scaling, only : unit_scale_type
+use MOM_variables, only : thermo_var_ptrs
+use MOM_verticalGrid, only : verticalGrid_type, setVerticalGridAxes
+use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
+use MOM_EOS, only : int_specific_vol_dp
+use MOM_ALE, only : ALE_remap_scalar
 
 implicit none ; private
 
@@ -38,11 +38,12 @@ character(len=40)  :: mdl = "MOM_tracer_initialization_from_Z" !< This module's 
 contains
 
 !> Initializes a tracer from a z-space data file.
-subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam, &
+subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_nam, &
                           src_var_unit_conversion, src_var_record, homogenize, &
                           useALEremapping, remappingScheme, src_var_gridspec )
   type(ocean_grid_type),      intent(inout) :: G   !< Ocean grid structure.
   type(verticalGrid_type),    intent(in)    :: GV  !< Ocean vertical grid structure.
+  type(unit_scale_type),      intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                               intent(in)    :: h   !< Layer thickness, in H (often m or kg m-2).
   real, dimension(:,:,:),     pointer       :: tr  !< Pointer to array to be initialized
@@ -121,7 +122,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, PF, src_file, src_var_nam,
 
   call horiz_interp_and_extrap_tracer(src_file, src_var_nam, convert, recnum, &
        G, tr_z, mask_z, z_in, z_edges_in, missing_value, reentrant_x, tripolar_n, &
-       homog, m_to_Z=GV%m_to_Z)
+       homog, m_to_Z=US%m_to_Z)
 
   kd = size(z_edges_in,1)-1
   call pass_var(tr_z,G%Domain)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -198,14 +198,8 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       enddo
     endif
 
-!$OMP parallel default(none) shared(MEKE,CS,is,ie,js,je,nz,src,mass,G,GV,h,I_mass, &
-!$OMP                               sdt,drag_vel_u,visc,drag_vel_v,drag_rate_visc, &
-!$OMP                               drag_rate,Rho0,MEKE_decay,sdt_damp,cdrag2, &
-!$OMP                               bottomFac2) &
-!$OMP                       private(ldamping)
-
     if (CS%MEKE_Cd_scale == 0.0 .and. .not. CS%visc_drag) then
-!$OMP do
+      !$OMP parallel do default(shared) private(ldamping)
       do j=js,je ; do i=is,ie
         drag_rate(i,j) = 0.
       enddo ; enddo
@@ -213,20 +207,20 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
 
     ! Calculate drag_rate_visc(i,j) which accounts for the model bottom mean flow
     if (CS%visc_drag) then
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do I=is-1,ie
         drag_vel_u(I,j) = 0.0
         if ((G%mask2dCu(I,j) > 0.0) .and. (visc%bbl_thick_u(I,j) > 0.0)) &
           drag_vel_u(I,j) = US%Z_to_m*visc%kv_bbl_u(I,j) / visc%bbl_thick_u(I,j)
       enddo ; enddo
-!$OMP do
+      !$OMP parallel do default(shared)
       do J=js-1,je ; do i=is,ie
         drag_vel_v(i,J) = 0.0
         if ((G%mask2dCv(i,J) > 0.0) .and. (visc%bbl_thick_v(i,J) > 0.0)) &
           drag_vel_v(i,J) = US%Z_to_m*visc%kv_bbl_v(i,J) / visc%bbl_thick_v(i,J)
       enddo ; enddo
 
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do i=is,ie
         drag_rate_visc(i,j) = (0.25*G%IareaT(i,j) * &
                 ((G%areaCu(I-1,j)*drag_vel_u(I-1,j) + &
@@ -235,13 +229,13 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
                   G%areaCv(i,J)*drag_vel_v(i,J)) ) )
       enddo ; enddo
     else
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do i=is,ie
         drag_rate_visc(i,j) = 0.
       enddo ; enddo
     endif
 
-!$OMP do
+    !$OMP parallel do default(shared)
     do j=js-1,je+1
       do i=is-1,ie+1 ; mass(i,j) = 0.0 ; enddo
       do k=1,nz ; do i=is-1,ie+1
@@ -252,7 +246,6 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
         if (mass(i,j) > 0.0) I_mass(i,j) = 1.0 / mass(i,j)
       enddo
     enddo
-!$OMP end parallel
 
     if (CS%initialize) then
       call MEKE_equilibrium(CS, MEKE, G, GV, US, SN_u, SN_v, drag_rate_visc, I_mass)
@@ -270,41 +263,35 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       call hchksum(LmixScale, 'MEKE LmixScale',G%HI)
     endif
 
-!$OMP parallel default(none) shared(MEKE,CS,is,ie,js,je,nz,src,mass,G,h,I_mass, &
-!$OMP                               sdt,drag_vel_u,visc,drag_vel_v,drag_rate_visc, &
-!$OMP                               drag_rate,Rho0,MEKE_decay,sdt_damp,cdrag2, &
-!$OMP                               bottomFac2,barotrFac2,use_drag_rate) &
-!$OMP                       private(ldamping)
-
     ! Aggregate sources of MEKE (background, frictional and GM)
-!$OMP do
+    !$OMP parallel do default(shared)
     do j=js,je ; do i=is,ie
       src(i,j) = CS%MEKE_BGsrc
     enddo ; enddo
 
     if (associated(MEKE%mom_src)) then
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do i=is,ie
         src(i,j) = src(i,j) - CS%MEKE_FrCoeff*I_mass(i,j)*MEKE%mom_src(i,j)
       enddo ; enddo
     endif
 
     if (associated(MEKE%GM_src)) then
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do i=is,ie
         src(i,j) = src(i,j) - CS%MEKE_GMcoeff*I_mass(i,j)*MEKE%GM_src(i,j)
       enddo ; enddo
     endif
 
     ! Increase EKE by a full time-steps worth of source
-!$OMP do
+    !$OMP parallel do default(shared)
     do j=js,je ; do i=is,ie
       MEKE%MEKE(i,j) = (MEKE%MEKE(i,j) + sdt*src(i,j) )*G%mask2dT(i,j)
     enddo ; enddo
 
     if (use_drag_rate) then
       ! Calculate a viscous drag rate (includes BBL contributions from mean flow and eddies)
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do i=is,ie
         drag_rate(i,j) = (Rho0 * I_mass(i,j)) * sqrt( drag_rate_visc(i,j)**2 &
              + cdrag2 * ( max(0.0, 2.0*bottomFac2(i,j)*MEKE%MEKE(i,j)) + CS%MEKE_Uscale**2 ) )
@@ -312,7 +299,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
     endif
 
     ! First stage of Strang splitting
-!$OMP do
+    !$OMP parallel do default(shared) private(ldamping)
     do j=js,je ; do i=is,ie
       ldamping = CS%MEKE_damping + drag_rate(i,j) * bottomFac2(i,j)
       if (MEKE%MEKE(i,j)<0.) ldamping = 0.
@@ -321,7 +308,6 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       MEKE%MEKE(i,j) =  MEKE%MEKE(i,j) / (1.0 + sdt_damp*ldamping)
       MEKE_decay(i,j) = ldamping*G%mask2dT(i,j)
     enddo ; enddo
-!$OMP end parallel
 
     if (CS%MEKE_KH >= 0.0 .or. CS%KhMEKE_FAC > 0.0 .or. CS%MEKE_K4 >= 0.0) then
       ! Update halos for lateral or bi-harmonic diffusion
@@ -332,8 +318,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
 
     if (CS%MEKE_K4 >= 0.0) then
       ! Calculate Laplacian of MEKE
-!$OMP parallel default(none) shared(is,ie,js,je,MEKE_uflux,G,MEKE,MEKE_vflux,CS)
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do I=is-1,ie
         MEKE_uflux(I,j) = ((G%dy_Cu(I,j)*G%IdxCu(I,j)) * G%mask2dCu(I,j)) * &
             (MEKE%MEKE(i+1,j) - MEKE%MEKE(i,j))
@@ -341,7 +326,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       !     ((2.0*mass(i,j)*mass(i+1,j)) / ((mass(i,j)+mass(i+1,j)) + mass_neglect)) ) * &
       !     (MEKE%MEKE(i+1,j) - MEKE%MEKE(i,j))
       enddo ; enddo
-!$OMP do
+      !$OMP parallel do default(shared)
       do J=js-1,je ; do i=is,ie
         MEKE_vflux(i,J) = ((G%dx_Cv(i,J)*G%IdyCv(i,J)) * G%mask2dCv(i,J)) * &
             (MEKE%MEKE(i,j+1) - MEKE%MEKE(i,j))
@@ -349,23 +334,19 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       !     ((2.0*mass(i,j)*mass(i,j+1)) / ((mass(i,j)+mass(i,j+1)) + mass_neglect)) ) * &
       !     (MEKE%MEKE(i,j+1) - MEKE%MEKE(i,j))
       enddo ; enddo
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do i=is,ie
         CS%del2MEKE(i,j) = G%IareaT(i,j) * &
             ((MEKE_uflux(I,j) - MEKE_uflux(I-1,j)) + (MEKE_vflux(i,J) - MEKE_vflux(i,J-1)))
       ! CS%del2MEKE(i,j) = (G%IareaT(i,j)*I_mass(i,j)) * &
       !     ((MEKE_uflux(I,j) - MEKE_uflux(I-1,j)) + (MEKE_vflux(i,J) - MEKE_vflux(i,J-1)))
       enddo ; enddo
-!$OMP end parallel
       call cpu_clock_begin(CS%id_clock_pass)
       call do_group_pass(CS%pass_del2MEKE, G%Domain)
       call cpu_clock_end(CS%id_clock_pass)
 
       ! Bi-harmonic diffusion of MEKE
-!$OMP parallel default(none) shared(is,ie,js,je,MEKE_uflux,G,CS,sdt,mass, &
-!$OMP                               mass_neglect,MEKE_vflux,I_mass)       &
-!$OMP                       private(K4_here,Inv_Kh_max)
-!$OMP do
+      !$OMP parallel do default(shared) private(K4_here,Inv_Kh_max)
       do j=js,je ; do I=is-1,ie
         K4_here = CS%MEKE_K4
         ! Limit Kh to avoid CFL violations.
@@ -377,7 +358,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
             ((2.0*mass(i,j)*mass(i+1,j)) / ((mass(i,j)+mass(i+1,j)) + mass_neglect)) ) * &
             (CS%del2MEKE(i+1,j) - CS%del2MEKE(i,j))
       enddo ; enddo
-!$OMP do
+      !$OMP parallel do default(shared) private(K4_here,Inv_Kh_max)
       do J=js-1,je ; do i=is,ie
         K4_here = CS%MEKE_K4
         Inv_Kh_max = 64.0*sdt * (((G%dx_Cv(i,J)*G%IdyCv(i,J)) * &
@@ -388,26 +369,19 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
             ((2.0*mass(i,j)*mass(i,j+1)) / ((mass(i,j)+mass(i,j+1)) + mass_neglect)) ) * &
             (CS%del2MEKE(i,j+1) - CS%del2MEKE(i,j))
       enddo ; enddo
-!$OMP do
+      !$OMP parallel do default(shared)
       ! Store tendency of bi-harmonic in del2MEKE
       do j=js,je ; do i=is,ie
         CS%del2MEKE(i,j) = (sdt*(G%IareaT(i,j)*I_mass(i,j))) * &
             ((MEKE_uflux(I-1,j) - MEKE_uflux(I,j)) + &
              (MEKE_vflux(i,J-1) - MEKE_vflux(i,J)))
       enddo ; enddo
-!$OMP end parallel
     endif !
 
-!$OMP parallel default(none) shared(is,ie,js,je,MEKE,CS,sdt,G,Kh_u,MEKE_uflux, &
-!$OMP                               mass,mass_neglect,Kh_v,MEKE_vflux,I_mass, &
-!$OMP                               sdt_damp,drag_rate,Rho0,drag_rate_visc,   &
-!$OMP                               cdrag2,bottomFac2,MEKE_decay,barotrFac2,  &
-!$OMP                               use_drag_rate,dt,baroHu,baroHv,GV) &
-!$OMP                       private(Kh_here,Inv_Kh_max,ldamping,advFac)
     if (CS%MEKE_KH >= 0.0 .or. CS%KhMEKE_FAC > 0.0 .or. CS%MEKE_advection_factor >0.0) then
       ! Lateral diffusion of MEKE
       Kh_here = max(0.,CS%MEKE_Kh)
-!$OMP do
+      !$OMP parallel do default(shared) firstprivate(Kh_here) private(Inv_Kh_max)
       do j=js,je ; do I=is-1,ie
         ! Limit Kh to avoid CFL violations.
         if (associated(MEKE%Kh)) &
@@ -421,7 +395,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
             ((2.0*mass(i,j)*mass(i+1,j)) / ((mass(i,j)+mass(i+1,j)) + mass_neglect)) ) * &
             (MEKE%MEKE(i,j) - MEKE%MEKE(i+1,j))
       enddo ; enddo
-!$OMP do
+      !$OMP parallel do default(shared) firstprivate(Kh_here) private(Inv_Kh_max)
       do J=js-1,je ; do i=is,ie
         if (associated(MEKE%Kh)) &
           Kh_here = max(0.,CS%MEKE_Kh) + CS%KhMEKE_Fac*0.5*(MEKE%Kh(i,j)+MEKE%Kh(i,j+1))
@@ -436,7 +410,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       enddo ; enddo
       if (CS%MEKE_advection_factor>0.) then
         advFac = GV%H_to_m * CS%MEKE_advection_factor / dt
-!$OMP do
+        !$OMP parallel do default(shared)
         do j=js,je ; do I=is-1,ie
           if (baroHu(I,j)>0.) then
             MEKE_uflux(I,j) = MEKE_uflux(I,j) + baroHu(I,j)*MEKE%MEKE(i,j)*advFac
@@ -444,7 +418,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
             MEKE_uflux(I,j) = MEKE_uflux(I,j) + baroHu(I,j)*MEKE%MEKE(i+1,j)*advFac
           endif
         enddo ; enddo
-!$OMP do
+        !$OMP parallel do default(shared)
         do J=js-1,je ; do i=is,ie
           if (baroHv(i,J)>0.) then
             MEKE_vflux(i,J) = MEKE_vflux(i,J) + baroHv(i,J)*MEKE%MEKE(i,j)*advFac
@@ -453,7 +427,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
           endif
         enddo ; enddo
       endif
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do i=is,ie
         MEKE%MEKE(i,j) = MEKE%MEKE(i,j) + (sdt*(G%IareaT(i,j)*I_mass(i,j))) * &
             ((MEKE_uflux(I-1,j) - MEKE_uflux(I,j)) + &
@@ -463,7 +437,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
 
     ! Add on bi-harmonic tendency
     if (CS%MEKE_K4 >= 0.0) then
-!$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do i=is,ie
         MEKE%MEKE(i,j) = MEKE%MEKE(i,j) + CS%del2MEKE(i,j)
       enddo ; enddo
@@ -474,13 +448,13 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       if (sdt>sdt_damp) then
         ! Recalculate the drag rate, since MEKE has changed.
         if (use_drag_rate) then
-!$OMP do
+          !$OMP parallel do default(shared)
           do j=js,je ; do i=is,ie
             drag_rate(i,j) = (Rho0 * I_mass(i,j)) * sqrt( drag_rate_visc(i,j)**2 &
                  + cdrag2 * ( max(0.0, 2.0*bottomFac2(i,j)*MEKE%MEKE(i,j)) + CS%MEKE_Uscale**2 ) )
           enddo ; enddo
         endif
-!$OMP do
+        !$OMP parallel do default(shared) private(ldamping)
         do j=js,je ; do i=is,ie
           ldamping = CS%MEKE_damping + drag_rate(i,j) * bottomFac2(i,j)
           if (MEKE%MEKE(i,j)<0.) ldamping = 0.
@@ -491,7 +465,6 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
         enddo ; enddo
       endif
     endif ! MEKE_KH>=0
-!$OMP end parallel
 
     call cpu_clock_begin(CS%id_clock_pass)
     call do_group_pass(CS%pass_MEKE, G%Domain)
@@ -501,20 +474,20 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
     if (CS%MEKE_KhCoeff>0.) then
       if (CS%use_old_lscale) then
         if (CS%Rd_as_max_scale) then
-!$OMP parallel do default(none) shared(is,ie,js,je,MEKE,CS,G,barotrFac2)
+          !$OMP parallel do default(shared)
           do j=js,je ; do i=is,ie
             MEKE%Kh(i,j) = (CS%MEKE_KhCoeff &
                          * sqrt(2.*max(0.,barotrFac2(i,j)*MEKE%MEKE(i,j))*G%areaT(i,j))) &
                          * min(MEKE%Rd_dx_h(i,j), 1.0)
           enddo ; enddo
         else
-!$OMP parallel do default(none) shared(is,ie,js,je,MEKE,CS,G,barotrFac2)
+          !$OMP parallel do default(shared)
           do j=js,je ; do i=is,ie
             MEKE%Kh(i,j) = CS%MEKE_KhCoeff*sqrt(2.*max(0.,barotrFac2(i,j)*MEKE%MEKE(i,j))*G%areaT(i,j))
           enddo ; enddo
         endif
       else
-!$OMP parallel do default(none) shared(is,ie,js,je,MEKE,LmixScale,CS,G,barotrFac2)
+        !$OMP parallel do default(shared)
         do j=js,je ; do i=is,ie
           MEKE%Kh(i,j) = (CS%MEKE_KhCoeff*sqrt(2.*max(0.,barotrFac2(i,j)*MEKE%MEKE(i,j)))*LmixScale(i,j))
         enddo ; enddo
@@ -534,7 +507,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       call cpu_clock_end(CS%id_clock_pass)
     endif
 
-! Offer fields for averaging.
+    ! Offer fields for averaging.
     if (CS%id_MEKE>0) call post_data(CS%id_MEKE, MEKE%MEKE, CS%diag)
     if (CS%id_Ue>0) call post_data(CS%id_Ue, sqrt(max(0.,2.0*MEKE%MEKE)), CS%diag)
     if (CS%id_Ub>0) call post_data(CS%id_Ub, sqrt(max(0.,2.0*MEKE%MEKE*bottomFac2)), CS%diag)

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -351,7 +351,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
   if (CS%apply_bottom_drag) then
     do j=jsd,jed ; do i=isd,ied
       ! Note the 1 m dimensional scale here.  Should this be a parameter?
-      I_D_here = 1.0 / (GV%Z_to_m*max(G%bathyT(i,j), 1.0*US%m_to_Z))
+      I_D_here = 1.0 / (US%Z_to_m*max(G%bathyT(i,j), 1.0*US%m_to_Z))
       drag_scale(i,j) = CS%cdrag * sqrt(max(0.0, vel_btTide(i,j)**2 + &
                         tot_En(i,j) * I_rho0 * I_D_here)) * I_D_here
     enddo ; enddo

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -614,7 +614,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e, calculate_slop
   one_meter = 1.0 * GV%m_to_H
   h_neglect = GV%H_subroundoff
   H_cutoff = real(2*nz) * (GV%Angstrom_H + h_neglect)
-  Z_to_L = GV%Z_to_m
+  Z_to_L = US%Z_to_m
 
   ! To set the length scale based on the deformation radius, use wave_speed to
   ! calculate the first-mode gravity wave speed and then blend the equatorial

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -288,10 +288,10 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
   endif
 
   p0(:) = 0.0
-!$OMP parallel default(none) shared(is,ie,js,je,G,GV,htot_fast,Rml_av_fast,tv,p0,h,h_avail,&
+!$OMP parallel default(none) shared(is,ie,js,je,G,GV,US,htot_fast,Rml_av_fast,tv,p0,h,h_avail,&
 !$OMP                               h_neglect,g_Rho0,I4dt,CS,uhml,uhtr,dt,vhml,vhtr,   &
 !$OMP                               utimescale_diag,vtimescale_diag,forces,dz_neglect, &
-!$OMP                               htot_slow,MLD_slow,Rml_av_slow,VarMix,I_l_f,        &
+!$OMP                               htot_slow,MLD_slow,Rml_av_slow,VarMix,I_l_f,       &
 !$OMP                               res_upscale,                                       &
 !$OMP                               nz,MLD_fast,uDml_diag,vDml_diag,proper_averaging)  &
 !$OMP                       private(rho_ml,h_vel,u_star,absf,mom_mixrate,timescale,    &
@@ -612,7 +612,7 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
   ! Fix this later for nkml >= 3.
 
   p0(:) = 0.0
-!$OMP parallel default(none) shared(is,ie,js,je,G,GV,htot,Rml_av,tv,p0,h,h_avail,      &
+!$OMP parallel default(none) shared(is,ie,js,je,G,GV,US,htot,Rml_av,tv,p0,h,h_avail,   &
 !$OMP                               h_neglect,g_Rho0,I4dt,CS,uhml,uhtr,dt,vhml,vhtr,   &
 !$OMP                               utimescale_diag,vtimescale_diag,forces,dz_neglect, &
 !$OMP                               uDml_diag,vDml_diag,nkml)                          &

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -16,6 +16,7 @@ use MOM_hor_index,     only : hor_index_type
 use MOM_io,            only : vardesc, var_desc
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_restart,       only : register_restart_field, query_initialized, MOM_restart_CS
+use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type
 use MOM_EOS,           only : calculate_density
@@ -84,9 +85,10 @@ contains
 !> Driver for the mixed-layer restratification parameterization.
 !! The code branches between two different implementations depending
 !! on whether the bulk-mixed layer or a general coordinate are in use.
-subroutine mixedlayer_restrat(h, uhtr, vhtr, tv, forces, dt, MLD, VarMix, G, GV, CS)
+subroutine mixedlayer_restrat(h, uhtr, vhtr, tv, forces, dt, MLD, VarMix, G, GV, US, CS)
   type(ocean_grid_type),                     intent(inout) :: G      !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV     !< Ocean vertical grid structure
+  type(unit_scale_type),                     intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h      !< Layer thickness (H units = m or kg/m2)
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uhtr   !< Accumulated zonal mass flux (m3 or kg)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: vhtr   !< Accumulated meridional mass flux (m3 or kg)
@@ -102,18 +104,19 @@ subroutine mixedlayer_restrat(h, uhtr, vhtr, tv, forces, dt, MLD, VarMix, G, GV,
          "Module must be initialized before it is used.")
 
   if (GV%nkml>0) then
-    call mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, CS)
+    call mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
   else
-    call mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD, VarMix, G, GV, CS)
+    call mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD, VarMix, G, GV, US, CS)
   endif
 
 end subroutine mixedlayer_restrat
 
 !> Calculates a restratifying flow in the mixed layer.
-subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix, G, GV, CS)
+subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix, G, GV, US, CS)
   ! Arguments
   type(ocean_grid_type),                     intent(inout) :: G      !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV     !< Ocean vertical grid structure
+  type(unit_scale_type),                     intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h      !< Layer thickness (H units = m or kg/m2)
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uhtr   !< Accumulated zonal mass flux (m3 or kg)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: vhtr   !< Accumulated meridional mass flux (m3 or kg)
@@ -338,7 +341,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
     call hchksum(h,'mixed_layer_restrat: h',G%HI,haloshift=1,scale=GV%H_to_m)
     call hchksum(forces%ustar,'mixed_layer_restrat: u*',G%HI,haloshift=1)
     call hchksum(MLD_fast,'mixed_layer_restrat: MLD',G%HI,haloshift=1,scale=GV%H_to_m)
-    call hchksum(Rml_av_fast,'mixed_layer_restrat: rml',G%HI,haloshift=1, scale=GV%m_to_Z)
+    call hchksum(Rml_av_fast,'mixed_layer_restrat: rml',G%HI,haloshift=1, scale=US%m_to_Z)
   endif
 
 ! TO DO:
@@ -348,7 +351,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
 !   U - Component
 !$OMP do
   do j=js,je ; do I=is-1,ie
-    u_star = GV%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
+    u_star = US%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
     absf = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
     ! If needed, res_scaling_fac = min( ds, L_d ) / l_f
     if (res_upscale) res_scaling_fac = &
@@ -424,7 +427,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
 !  V- component
 !$OMP do
   do J=js-1,je ; do i=is,ie
-    u_star = GV%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
+    u_star = US%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
     absf = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
     ! If needed, res_scaling_fac = min( ds, L_d ) / l_f
     if (res_upscale) res_scaling_fac = &
@@ -539,9 +542,10 @@ end subroutine mixedlayer_restrat_general
 
 
 !> Calculates a restratifying flow assuming a 2-layer bulk mixed layer.
-subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, CS)
+subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
   type(ocean_grid_type),                     intent(in)    :: G      !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV     !< Ocean vertical grid structure
+  type(unit_scale_type),                     intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h      !< Layer thickness (H units = m or kg/m2)
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: uhtr   !< Accumulated zonal mass flux (m3 or kg)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: vhtr   !< Accumulated meridional mass flux (m3 or kg)
@@ -646,7 +650,7 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, CS)
     do I=is-1,ie
       h_vel = 0.5*(htot(i,j) + htot(i+1,j)) * GV%H_to_Z
 
-      u_star = GV%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
+      u_star = US%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
       absf = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
       ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
       ! momentum mixing rate: pi^2*visc/h_ml^2
@@ -694,7 +698,7 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, CS)
   do J=js-1,je ; do i=is,ie
     h_vel = 0.5*(htot(i,j) + htot(i,j+1)) * GV%H_to_Z
 
-    u_star = GV%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
+    u_star = US%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
     absf = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
     ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2
@@ -771,10 +775,11 @@ end subroutine mixedlayer_restrat_BML
 
 
 !> Initialize the mixed layer restratification module
-logical function mixedlayer_restrat_init(Time, G, GV, param_file, diag, CS, restart_CS)
+logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, restart_CS)
   type(time_type),             intent(in)    :: Time       !< Current model time
   type(ocean_grid_type),       intent(inout) :: G          !< Ocean grid structure
   type(verticalGrid_type),     intent(in)    :: GV         !< Ocean vertical grid structure
+  type(unit_scale_type),       intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),       intent(in)    :: param_file !< Parameter file to parse
   type(diag_ctrl), target,     intent(inout) :: diag       !< Regulate diagnostics
   type(mixedlayer_restrat_CS), pointer       :: CS         !< Module control structure
@@ -884,7 +889,7 @@ logical function mixedlayer_restrat_init(Time, G, GV, param_file, diag, CS, rest
       'Mixed Layer Depth as used in the mixed-layer restratification parameterization', 'm')
   CS%id_Rml = register_diag_field('ocean_model', 'ML_buoy_restrat', diag%axesT1, Time, &
       'Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization', &
-      'm s2', conversion=GV%m_to_Z)
+      'm s2', conversion=US%m_to_Z)
   CS%id_uDml = register_diag_field('ocean_model', 'udml_restrat', diag%axesCu1, Time, &
       'Transport stream function amplitude for zonal restratification of mixed layer', 'm3 s-1')
   CS%id_vDml = register_diag_field('ocean_model', 'vdml_restrat', diag%axesCv1, Time, &

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -580,7 +580,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   enddo ; enddo
 !$OMP end parallel
 
-!$OMP parallel do default(none) shared(nz,is,ie,js,je,find_work,use_EOS,G,GV,pres,T,S, &
+!$OMP parallel do default(none) shared(nz,is,ie,js,je,find_work,use_EOS,G,GV,US,pres,T,S, &
 !$OMP                                  nk_linear,IsdB,tv,h,h_neglect,e,dz_neglect,  &
 !$OMP                                  I_slope_max2,h_neglect2,present_int_slope_u, &
 !$OMP                                  int_slope_u,KH_u,uhtot,h_frac,h_avail_rsum,  &
@@ -829,7 +829,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   enddo ! end of j-loop
 
     ! Calculate the meridional fluxes and gradients.
-!$OMP parallel do default(none) shared(nz,is,ie,js,je,find_work,use_EOS,G,GV,pres,T,S, &
+!$OMP parallel do default(none) shared(nz,is,ie,js,je,find_work,use_EOS,G,GV,US,pres,T,S, &
 !$OMP                                  nk_linear,IsdB,tv,h,h_neglect,e,dz_neglect,  &
 !$OMP                                  I_slope_max2,h_neglect2,present_int_slope_v, &
 !$OMP                                  int_slope_v,KH_v,vhtot,h_frac,h_avail_rsum,  &

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -22,6 +22,7 @@ use MOM_horizontal_regridding, only : horiz_interp_and_extrap_tracer
 use MOM_spatial_means, only : global_i_mean
 use MOM_time_manager, only : time_type, init_external_field, get_external_field_size, time_interp_external_init
 use MOM_remapping, only : remapping_cs, remapping_core_h, initialize_remapping
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_verticalGrid, only : verticalGrid_type
 ! GMM - Planned extension:  Support for time varying sponge targets.
 
@@ -652,7 +653,7 @@ subroutine set_up_ALE_sponge_field_varying(filename, fieldname, Time, G, GV, f_p
   ! modulo attribute of the zonal axis (mjh).
 
  ! call horiz_interp_and_extrap_tracer(CS%Ref_val(CS%fldno)%id,Time, 1.0,G,sp_val,mask_z,z_in,z_edges_in, &
- !                                     missing_value, .true., .false., .false., m_to_Z=GV%m_to_Z)
+ !                                     missing_value, .true., .false., .false., m_to_Z=US%m_to_Z)
 
 ! Do not think halo updates are needed (mjh)
 !  call pass_var(sp_val,G%Domain)
@@ -834,9 +835,10 @@ end subroutine set_up_ALE_sponge_vel_field_varying
 
 !> This subroutine applies damping to the layers thicknesses, temp, salt and a variety of tracers
 !! for every column where there is damping.
-subroutine apply_ALE_sponge(h, dt, G, GV, CS, Time)
+subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
   type(ocean_grid_type),     intent(inout) :: G  !< The ocean's grid structure (in).
   type(verticalGrid_type),   intent(in)    :: GV !< ocean vertical grid structure
+  type(unit_scale_type),     intent(in)    :: US !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                              intent(inout) :: h  !< Layer thickness, in H (in)
   real,                      intent(in)    :: dt !< The amount of time covered by this call, in s (in).
@@ -883,7 +885,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, CS, Time)
       mask_z(:,:,:)=0.0
 
       call horiz_interp_and_extrap_tracer(CS%Ref_val(CS%fldno)%id,Time, 1.0,G,sp_val,mask_z,z_in,z_edges_in, &
-                                          missing_value,.true., .false.,.false., m_to_Z=GV%m_to_Z)
+                                          missing_value,.true., .false.,.false., m_to_Z=US%m_to_Z)
 
 !      call pass_var(sp_val,G%Domain)
 !      call pass_var(mask_z,G%Domain)
@@ -953,7 +955,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, CS, Time)
       allocate(mask_z(G%isdB:G%iedB,G%jsd:G%jed,1:nz_data))
 ! Interpolate from the external horizontal grid and in time
       call horiz_interp_and_extrap_tracer(CS%Ref_val_u%id,Time, 1.0,G,sp_val,mask_z,z_in,z_edges_in, &
-                                     missing_value, .true., .false., .false., m_to_Z=GV%m_to_Z)
+                                     missing_value, .true., .false., .false., m_to_Z=US%m_to_Z)
 
 !      call pass_var(sp_val,G%Domain)
 !      call pass_var(mask_z,G%Domain)
@@ -972,7 +974,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, CS, Time)
       allocate(mask_z(G%isd:G%ied,G%jsdB:G%jedB,1:nz_data))
 ! Interpolate from the external horizontal grid and in time
       call horiz_interp_and_extrap_tracer(CS%Ref_val_v%id,Time, 1.0,G,sp_val,mask_z,z_in,z_edges_in, &
-                                     missing_value, .true., .false., .false., m_to_Z=GV%m_to_Z)
+                                     missing_value, .true., .false., .false., m_to_Z=US%m_to_Z)
 
 !      call pass_var(sp_val,G%Domain)
 !      call pass_var(mask_z,G%Domain)

--- a/src/parameterizations/vertical/MOM_CVMix_conv.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_conv.F90
@@ -52,14 +52,15 @@ character(len=40)  :: mdl = "MOM_CVMix_conv"     !< This module's name.
 contains
 
 !> Initialized the CVMix convection mixing routine.
-logical function CVMix_conv_init(Time, G, GV, param_file, diag, CS)
+logical function CVMix_conv_init(Time, G, GV, US, param_file, diag, CS)
 
   type(time_type),         intent(in)    :: Time       !< The current time.
   type(ocean_grid_type),   intent(in)    :: G          !< Grid structure.
   type(verticalGrid_type), intent(in)    :: GV         !< Vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< Run-time parameter file handle
   type(diag_ctrl), target, intent(inout) :: diag       !< Diagnostics control structure.
-  type(CVMix_conv_cs),    pointer        :: CS         !< This module's control structure.
+  type(CVMix_conv_cs),     pointer       :: CS         !< This module's control structure.
   ! Local variables
   real    :: prandtl_conv !< Turbulent Prandtl number used in convective instabilities.
   logical :: useEPBL      !< If True, use the ePBL boundary layer scheme.
@@ -133,9 +134,9 @@ logical function CVMix_conv_init(Time, G, GV, param_file, diag, CS)
   CS%id_N2 = register_diag_field('ocean_model', 'N2_conv', diag%axesTi, Time, &
       'Square of Brunt-Vaisala frequency used by MOM_CVMix_conv module', '1/s2')
   CS%id_kd_conv = register_diag_field('ocean_model', 'kd_conv', diag%axesTi, Time, &
-      'Additional diffusivity added by MOM_CVMix_conv module', 'm2/s', conversion=GV%Z_to_m**2)
+      'Additional diffusivity added by MOM_CVMix_conv module', 'm2/s', conversion=US%Z_to_m**2)
   CS%id_kv_conv = register_diag_field('ocean_model', 'kv_conv', diag%axesTi, Time, &
-      'Additional viscosity added by MOM_CVMix_conv module', 'm2/s', conversion=GV%Z_to_m**2)
+      'Additional viscosity added by MOM_CVMix_conv module', 'm2/s', conversion=US%Z_to_m**2)
 
   call CVMix_init_conv(convect_diff=CS%kd_conv_const, &
                        convect_visc=CS%kv_conv_const, &

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -58,14 +58,15 @@ character(len=40)  :: mdl = "MOM_CVMix_ddiff"     !< This module's name.
 contains
 
 !> Initialized the CVMix double diffusion module.
-logical function CVMix_ddiff_init(Time, G, GV, param_file, diag, CS)
+logical function CVMix_ddiff_init(Time, G, GV, US, param_file, diag, CS)
 
   type(time_type),         intent(in)    :: Time       !< The current time.
   type(ocean_grid_type),   intent(in)    :: G          !< Grid structure.
   type(verticalGrid_type), intent(in)    :: GV         !< Vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< Run-time parameter file handle
   type(diag_ctrl), target, intent(inout) :: diag       !< Diagnostics control structure.
-  type(CVMix_ddiff_cs),    pointer        :: CS        !< This module's control structure.
+  type(CVMix_ddiff_cs),    pointer       :: CS         !< This module's control structure.
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -137,10 +138,10 @@ logical function CVMix_ddiff_init(Time, G, GV, param_file, diag, CS)
   CS%diag => diag
 
   CS%id_KT_extra = register_diag_field('ocean_model','KT_extra',diag%axesTi,Time, &
-         'Double-diffusive diffusivity for temperature', 'm2 s-1', conversion=GV%Z_to_m**2)
+         'Double-diffusive diffusivity for temperature', 'm2 s-1', conversion=US%Z_to_m**2)
 
   CS%id_KS_extra = register_diag_field('ocean_model','KS_extra',diag%axesTi,Time, &
-         'Double-diffusive diffusivity for salinity', 'm2 s-1', conversion=GV%Z_to_m**2)
+         'Double-diffusive diffusivity for salinity', 'm2 s-1', conversion=US%Z_to_m**2)
 
   CS%id_R_rho = register_diag_field('ocean_model','R_rho',diag%axesTi,Time, &
          'Double-diffusion density ratio', 'nondim')

--- a/src/parameterizations/vertical/MOM_CVMix_shear.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_shear.F90
@@ -151,8 +151,8 @@ subroutine calculate_CVMix_shear(u_H, v_H, h, tv, kd, kv, G, GV, US, CS )
       endif
 
       do K=1,G%ke+1
-        Kvisc(K) = GV%Z_to_m**2 * kv(i,j,K)
-        Kdiff(K) = GV%Z_to_m**2 * kd(i,j,K)
+        Kvisc(K) = US%Z_to_m**2 * kv(i,j,K)
+        Kdiff(K) = US%Z_to_m**2 * kd(i,j,K)
       enddo
 
       ! Call to CVMix wrapper for computing interior mixing coefficients.
@@ -183,10 +183,11 @@ end subroutine calculate_CVMix_shear
 !! \note *This is where we test to make sure multiple internal shear
 !!       mixing routines (including JHL) are not enabled at the same time.
 !! (returns) CVMix_shear_init - True if module is to be used, False otherwise
-logical function CVMix_shear_init(Time, G, GV, param_file, diag, CS)
+logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
   type(time_type),         intent(in)    :: Time !< The current time.
-  type(ocean_grid_type),   intent(in)    :: G !< Grid structure.
+  type(ocean_grid_type),   intent(in)    :: G  !< Grid structure.
   type(verticalGrid_type), intent(in)    :: GV !< Vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< Run-time parameter file handle
   type(diag_ctrl), target, intent(inout) :: diag !< Diagnostics control structure.
   type(CVMix_shear_cs),    pointer       :: CS !< This module's control structure.
@@ -283,9 +284,9 @@ logical function CVMix_shear_init(Time, G, GV, param_file, diag, CS)
   endif
 
   CS%id_kd = register_diag_field('ocean_model', 'kd_shear_CVMix', diag%axesTi, Time, &
-      'Vertical diffusivity added by MOM_CVMix_shear module', 'm2/s', conversion=GV%Z_to_m**2)
+      'Vertical diffusivity added by MOM_CVMix_shear module', 'm2/s', conversion=US%Z_to_m**2)
   CS%id_kv = register_diag_field('ocean_model', 'kv_shear_CVMix', diag%axesTi, Time, &
-      'Vertical viscosity added by MOM_CVMix_shear module', 'm2/s', conversion=GV%Z_to_m**2)
+      'Vertical viscosity added by MOM_CVMix_shear module', 'm2/s', conversion=US%Z_to_m**2)
 
 end function CVMix_shear_init
 

--- a/src/parameterizations/vertical/MOM_CVMix_shear.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_shear.F90
@@ -10,6 +10,7 @@ use MOM_diag_mediator, only : diag_ctrl, time_type
 use MOM_error_handler, only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, EOS_type
@@ -50,9 +51,10 @@ character(len=40)  :: mdl = "MOM_CVMix_shear"  !< This module's name.
 contains
 
 !> Subroutine for calculating (internal) vertical diffusivities/viscosities
-subroutine calculate_CVMix_shear(u_H, v_H, h, tv, kd, kv, G, GV, CS )
+subroutine calculate_CVMix_shear(u_H, v_H, h, tv, kd, kv, G, GV, US, CS )
   type(ocean_grid_type),                      intent(in)  :: G   !< Grid structure.
   type(verticalGrid_type),                    intent(in)  :: GV  !< Vertical grid structure.
+  type(unit_scale_type),                      intent(in)  :: US     !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)  :: u_H !< Initial zonal velocity on T points, in m s-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)  :: v_H !< Initial meridional velocity on T points, in m s-1.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)  :: h   !< Layer thickness, in m or kg m-2.
@@ -74,7 +76,7 @@ subroutine calculate_CVMix_shear(u_H, v_H, h, tv, kd, kv, G, GV, CS )
   real, parameter         :: epsln = 1.e-10 !< Threshold to identify vanished layers
 
   ! some constants
-  GoRho = (GV%g_Earth*GV%m_to_Z) / GV%Rho0
+  GoRho = (GV%g_Earth*US%m_to_Z) / GV%Rho0
 
   do j = G%jsc, G%jec
     do i = G%isc, G%iec
@@ -160,8 +162,8 @@ subroutine calculate_CVMix_shear(u_H, v_H, h, tv, kd, kv, G, GV, CS )
                                    nlev=G%ke,    &
                                    max_nlev=G%ke)
       do K=1,G%ke+1
-        kv(i,j,K) = GV%m_to_Z**2 * Kvisc(K)
-        kd(i,j,K) = GV%m_to_Z**2 * Kdiff(K)
+        kv(i,j,K) = US%m_to_Z**2 * Kvisc(K)
+        kd(i,j,K) = US%m_to_Z**2 * Kdiff(K)
       enddo
     enddo
   enddo

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -150,7 +150,7 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
 
   call get_param(param_file, mdl, "KD_MIN", CS%Kd_min, &
                  "The minimum diapycnal diffusivity.", &
-                 units="m2 s-1", default=0.01*CS%Kd*GV%Z_to_m**2, scale=US%m_to_Z**2)
+                 units="m2 s-1", default=0.01*CS%Kd*US%Z_to_m**2, scale=US%m_to_Z**2)
 
   ! The following is needed to set one of the choices of vertical background mixing
 
@@ -170,7 +170,7 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
                  "If BULKMIXEDLAYER is false, KDML is the elevated \n"//&
                  "diapycnal diffusivity in the topmost HMIX of fluid. \n"//&
                  "KDML is only used if BULKMIXEDLAYER is false.", &
-                 units="m2 s-1", default=CS%Kd*GV%Z_to_m**2, scale=US%m_to_Z**2)
+                 units="m2 s-1", default=CS%Kd*US%Z_to_m**2, scale=US%m_to_Z**2)
     call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
                  "The prescribed depth over which the near-surface \n"//&
                  "viscosity and diffusivity are elevated when the bulk \n"//&
@@ -314,17 +314,17 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
   ! Register diagnostics
   CS%diag => diag
   CS%id_kd_bkgnd = register_diag_field('ocean_model', 'Kd_bkgnd', diag%axesTi, Time, &
-      'Background diffusivity added by MOM_bkgnd_mixing module', 'm2/s', conversion=GV%Z_to_m**2)
+      'Background diffusivity added by MOM_bkgnd_mixing module', 'm2/s', conversion=US%Z_to_m**2)
   CS%id_kv_bkgnd = register_diag_field('ocean_model', 'Kv_bkgnd', diag%axesTi, Time, &
-      'Background viscosity added by MOM_bkgnd_mixing module', 'm2/s', conversion=GV%Z_to_m**2)
+      'Background viscosity added by MOM_bkgnd_mixing module', 'm2/s', conversion=US%Z_to_m**2)
 
 end subroutine bkgnd_mixing_init
 
 !> Get surface vertical background diffusivities/viscosities.
-subroutine sfc_bkgnd_mixing(G, GV, CS)
+subroutine sfc_bkgnd_mixing(G, US, CS)
 
   type(ocean_grid_type),          intent(in)    :: G  !< Grid structure.
-  type(verticalGrid_type),        intent(in)    :: GV  !< Vertical grid structure.
+  type(unit_scale_type),          intent(in)    :: US !< A dimensional unit scaling type
   type(bkgnd_mixing_cs), pointer, intent(inout) :: CS !< The control structure returned by
                                                       !! a previous call to bkgnd_mixing_init.
   ! local variables
@@ -369,7 +369,7 @@ subroutine sfc_bkgnd_mixing(G, GV, CS)
     enddo ; enddo
   endif
 
-  if (CS%debug) call hchksum(CS%Kd_sfc,"After sfc_bkgnd_mixing: Kd_sfc",G%HI,haloshift=0, scale=GV%Z_to_m**2)
+  if (CS%debug) call hchksum(CS%Kd_sfc,"After sfc_bkgnd_mixing: Kd_sfc",G%HI,haloshift=0, scale=US%Z_to_m**2)
 
 end subroutine sfc_bkgnd_mixing
 

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -5,20 +5,20 @@ module MOM_bkgnd_mixing
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use MOM_debugging,       only : hchksum
 use MOM_diag_mediator,   only : diag_ctrl, time_type, register_diag_field
 use MOM_diag_mediator,   only : post_data
 use MOM_EOS,             only : calculate_density, calculate_density_derivs
-use MOM_variables,       only : thermo_var_ptrs
-use MOM_forcing_type,    only : forcing
 use MOM_error_handler,   only : MOM_error, FATAL, WARNING, NOTE
-use MOM_file_parser,     only : openParameterBlock, closeParameterBlock
-use MOM_debugging,       only : hchksum
-use MOM_grid,            only : ocean_grid_type
-use MOM_verticalGrid,    only : verticalGrid_type
 use MOM_file_parser,     only : get_param, log_version, param_file_type
-use CVMix_background,    only : CVMix_init_bkgnd, CVMix_coeffs_bkgnd
-use MOM_variables,       only : vertvisc_type
+use MOM_file_parser,     only : openParameterBlock, closeParameterBlock
+use MOM_forcing_type,    only : forcing
+use MOM_grid,            only : ocean_grid_type
+use MOM_unit_scaling,    only : unit_scale_type
+use MOM_verticalGrid,    only : verticalGrid_type
+use MOM_variables,       only : thermo_var_ptrs,  vertvisc_type
 use MOM_intrinsic_functions, only : invcosh
+use CVMix_background,    only : CVMix_init_bkgnd, CVMix_coeffs_bkgnd
 
 implicit none ; private
 
@@ -109,14 +109,15 @@ character(len=40)  :: mdl = "MOM_bkgnd_mixing" !< This module's name.
 contains
 
 !> Initialize the background mixing routine.
-subroutine bkgnd_mixing_init(Time, G, GV, param_file, diag, CS)
+subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
 
   type(time_type),         intent(in)    :: Time       !< The current time.
   type(ocean_grid_type),   intent(in)    :: G          !< Grid structure.
   type(verticalGrid_type), intent(in)    :: GV         !< Vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< Run-time parameter file handle
   type(diag_ctrl), target, intent(inout) :: diag       !< Diagnostics control structure.
-  type(bkgnd_mixing_cs),    pointer      :: CS        !< This module's control structure.
+  type(bkgnd_mixing_cs),    pointer      :: CS         !< This module's control structure.
 
   ! Local variables
   real :: Kv                    ! The interior vertical viscosity (m2/s) - read to set prandtl
@@ -140,7 +141,7 @@ subroutine bkgnd_mixing_init(Time, G, GV, param_file, diag, CS)
   call get_param(param_file, mdl, "KD", CS%Kd, &
                  "The background diapycnal diffusivity of density in the \n"//&
                  "interior. Zero or the molecular value, ~1e-7 m2 s-1, \n"//&
-                 "may be used.", units="m2 s-1", scale=GV%m_to_Z**2, fail_if_missing=.true.)
+                 "may be used.", units="m2 s-1", scale=US%m_to_Z**2, fail_if_missing=.true.)
 
   call get_param(param_file, mdl, "KV", Kv, &
                  "The background kinematic viscosity in the interior. \n"//&
@@ -149,7 +150,7 @@ subroutine bkgnd_mixing_init(Time, G, GV, param_file, diag, CS)
 
   call get_param(param_file, mdl, "KD_MIN", CS%Kd_min, &
                  "The minimum diapycnal diffusivity.", &
-                 units="m2 s-1", default=0.01*CS%Kd*GV%Z_to_m**2, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=0.01*CS%Kd*GV%Z_to_m**2, scale=US%m_to_Z**2)
 
   ! The following is needed to set one of the choices of vertical background mixing
 
@@ -169,11 +170,11 @@ subroutine bkgnd_mixing_init(Time, G, GV, param_file, diag, CS)
                  "If BULKMIXEDLAYER is false, KDML is the elevated \n"//&
                  "diapycnal diffusivity in the topmost HMIX of fluid. \n"//&
                  "KDML is only used if BULKMIXEDLAYER is false.", &
-                 units="m2 s-1", default=CS%Kd*GV%Z_to_m**2, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=CS%Kd*GV%Z_to_m**2, scale=US%m_to_Z**2)
     call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
                  "The prescribed depth over which the near-surface \n"//&
                  "viscosity and diffusivity are elevated when the bulk \n"//&
-                 "mixed layer is not used.", units="m", scale=GV%m_to_Z, fail_if_missing=.true.)
+                 "mixed layer is not used.", units="m", scale=US%m_to_Z, fail_if_missing=.true.)
   endif
 
   call get_param(param_file, mdl, 'DEBUG', CS%debug, default=.False., do_not_log=.True.)
@@ -223,22 +224,22 @@ subroutine bkgnd_mixing_init(Time, G, GV, param_file, diag, CS)
     call get_param(param_file, mdl, "BCKGRND_VDC1", &
                    CS%bckgrnd_vdc1, &
                    "Background diffusivity (Ledwell) when HORIZ_VARYING_BACKGROUND=True", &
-                   units="m2 s-1",default = 0.16e-04, scale=GV%m_to_Z**2)
+                   units="m2 s-1",default = 0.16e-04, scale=US%m_to_Z**2)
 
     call get_param(param_file, mdl, "BCKGRND_VDC_EQ", &
                    CS%bckgrnd_vdc_eq, &
                    "Equatorial diffusivity (Gregg) when HORIZ_VARYING_BACKGROUND=True", &
-                   units="m2 s-1",default = 0.01e-04, scale=GV%m_to_Z**2)
+                   units="m2 s-1",default = 0.01e-04, scale=US%m_to_Z**2)
 
     call get_param(param_file, mdl, "BCKGRND_VDC_PSIM", &
                    CS%bckgrnd_vdc_psim, &
                    "Max. PSI induced diffusivity (MacKinnon) when HORIZ_VARYING_BACKGROUND=True", &
-                   units="m2 s-1",default = 0.13e-4, scale=GV%m_to_Z**2)
+                   units="m2 s-1",default = 0.13e-4, scale=US%m_to_Z**2)
 
     call get_param(param_file, mdl, "BCKGRND_VDC_BAN", &
                    CS%bckgrnd_vdc_ban, &
                    "Banda Sea diffusivity (Gordon) when HORIZ_VARYING_BACKGROUND=True", &
-                   units="m2 s-1",default = 1.0e-4, scale=GV%m_to_Z**2)
+                   units="m2 s-1",default = 1.0e-4, scale=US%m_to_Z**2)
   endif
 
   call get_param(param_file, mdl, "PRANDTL_BKGND", CS%prandtl_bkgnd, &
@@ -374,10 +375,11 @@ end subroutine sfc_bkgnd_mixing
 
 
 !> Calculates the vertical background diffusivities/viscosities
-subroutine calculate_bkgnd_mixing(h, tv, N2_lay, kd_lay, Kv, j, G, GV, CS)
+subroutine calculate_bkgnd_mixing(h, tv, N2_lay, kd_lay, Kv, j, G, GV, US, CS)
 
   type(ocean_grid_type),                    intent(in)    :: G   !< Grid structure.
   type(verticalGrid_type),                  intent(in)    :: GV  !< Vertical grid structure.
+  type(unit_scale_type),                    intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h   !< Layer thickness, in m or kg m-2.
   type(thermo_var_ptrs),                    intent(in)    :: tv  !< Thermodynamics structure.
   real, dimension(SZI_(G),SZK_(G)),         intent(in)    :: N2_lay !< squared buoyancy frequency associated
@@ -435,11 +437,11 @@ subroutine calculate_bkgnd_mixing(h, tv, N2_lay, kd_lay, Kv, j, G, GV, CS)
 
       ! Update Kd and Kv.
       do K=1,nz+1
-        CS%Kv_bkgnd(i,j,K) = GV%m_to_Z**2*Kv_col(K)
-        CS%Kd_bkgnd(i,j,K) = GV%m_to_Z**2*Kd_col(K)
+        CS%Kv_bkgnd(i,j,K) = US%m_to_Z**2*Kv_col(K)
+        CS%Kd_bkgnd(i,j,K) = US%m_to_Z**2*Kd_col(K)
       enddo
       do k=1,nz
-        Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5*GV%m_to_Z**2*(Kd_col(K) + Kd_col(K+1))
+        Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5*US%m_to_Z**2*(Kd_col(K) + Kd_col(K+1))
       enddo
     enddo ! i loop
 

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -1454,7 +1454,7 @@ subroutine find_starting_TKE(htot, h_CA, fluxes, Conv_En, cTKE, dKE_FC, dKE_CA, 
     dKE_conv = dKE_CA(i,1) * MKE_rate_CA + dKE_FC(i) * MKE_rate_FC
 ! At this point, it is assumed that cTKE is positive and stored in TKE_CA!
 ! Note: Removed factor of 2 in u*^3 terms.
-    TKE(i) = (dt*CS%mstar)*((GV%Z_to_m**2*(U_Star*U_Star*U_Star))*exp_kh) + &
+    TKE(i) = (dt*CS%mstar)*((US%Z_to_m**2*(U_Star*U_Star*U_Star))*exp_kh) + &
              (exp_kh * dKE_conv + nstar_FC*Conv_En(i) + nstar_CA * TKE_CA)
 
     if (CS%do_rivermix) then ! Add additional TKE at river mouths
@@ -1462,7 +1462,7 @@ subroutine find_starting_TKE(htot, h_CA, fluxes, Conv_En, cTKE, dKE_FC, dKE_CA, 
     endif
 
     if (CS%TKE_diagnostics) then
-      wind_TKE_src = CS%mstar*(GV%Z_to_m**2*U_Star*U_Star*U_Star) * diag_wt
+      wind_TKE_src = CS%mstar*(US%Z_to_m**2*U_Star*U_Star*U_Star) * diag_wt
       CS%diag_TKE_wind(i,j) = CS%diag_TKE_wind(i,j) + &
           ( wind_TKE_src + TKE_river(i) * diag_wt )
       CS%diag_TKE_RiBulk(i,j) = CS%diag_TKE_RiBulk(i,j) + dKE_conv*Idt_diag
@@ -3668,36 +3668,36 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
   CS%id_ML_depth = register_diag_field('ocean_model', 'h_ML', diag%axesT1, &
       Time, 'Surface mixed layer depth', 'm')
   CS%id_TKE_wind = register_diag_field('ocean_model', 'TKE_wind', diag%axesT1, &
-      Time, 'Wind-stirring source of mixed layer TKE', 'm3 s-3', conversion=GV%Z_to_m)
+      Time, 'Wind-stirring source of mixed layer TKE', 'm3 s-3', conversion=US%Z_to_m)
   CS%id_TKE_RiBulk = register_diag_field('ocean_model', 'TKE_RiBulk', diag%axesT1, &
-      Time, 'Mean kinetic energy source of mixed layer TKE', 'm3 s-3', conversion=GV%Z_to_m)
+      Time, 'Mean kinetic energy source of mixed layer TKE', 'm3 s-3', conversion=US%Z_to_m)
   CS%id_TKE_conv = register_diag_field('ocean_model', 'TKE_conv', diag%axesT1, &
-      Time, 'Convective source of mixed layer TKE', 'm3 s-3', conversion=GV%Z_to_m)
+      Time, 'Convective source of mixed layer TKE', 'm3 s-3', conversion=US%Z_to_m)
   CS%id_TKE_pen_SW = register_diag_field('ocean_model', 'TKE_pen_SW', diag%axesT1, &
       Time, 'TKE consumed by mixing penetrative shortwave radation through the mixed layer', &
-      'm3 s-3', conversion=GV%Z_to_m)
+      'm3 s-3', conversion=US%Z_to_m)
   CS%id_TKE_mixing = register_diag_field('ocean_model', 'TKE_mixing', diag%axesT1, &
-      Time, 'TKE consumed by mixing that deepens the mixed layer', 'm3 s-3', conversion=GV%Z_to_m)
+      Time, 'TKE consumed by mixing that deepens the mixed layer', 'm3 s-3', conversion=US%Z_to_m)
   CS%id_TKE_mech_decay = register_diag_field('ocean_model', 'TKE_mech_decay', diag%axesT1, &
-      Time, 'Mechanical energy decay sink of mixed layer TKE', 'm3 s-3', conversion=GV%Z_to_m)
+      Time, 'Mechanical energy decay sink of mixed layer TKE', 'm3 s-3', conversion=US%Z_to_m)
   CS%id_TKE_conv_decay = register_diag_field('ocean_model', 'TKE_conv_decay', diag%axesT1, &
-      Time, 'Convective energy decay sink of mixed layer TKE', 'm3 s-3', conversion=GV%Z_to_m)
+      Time, 'Convective energy decay sink of mixed layer TKE', 'm3 s-3', conversion=US%Z_to_m)
   CS%id_TKE_conv_s2 = register_diag_field('ocean_model', 'TKE_conv_s2', diag%axesT1, &
-      Time, 'Spurious source of mixed layer TKE from sigma2', 'm3 s-3', conversion=GV%Z_to_m)
+      Time, 'Spurious source of mixed layer TKE from sigma2', 'm3 s-3', conversion=US%Z_to_m)
   CS%id_PE_detrain = register_diag_field('ocean_model', 'PE_detrain', diag%axesT1, &
       Time, 'Spurious source of potential energy from mixed layer detrainment', &
-      'W m-2', conversion=GV%Z_to_m)
+      'W m-2', conversion=US%Z_to_m)
   CS%id_PE_detrain2 = register_diag_field('ocean_model', 'PE_detrain2', diag%axesT1, &
       Time, 'Spurious source of potential energy from mixed layer only detrainment', &
-      'W m-2', conversion=GV%Z_to_m)
+      'W m-2', conversion=US%Z_to_m)
   CS%id_h_mismatch = register_diag_field('ocean_model', 'h_miss_ML', diag%axesT1, &
-      Time, 'Summed absolute mismatch in entrainment terms', 'm', conversion=GV%Z_to_m)
+      Time, 'Summed absolute mismatch in entrainment terms', 'm', conversion=US%Z_to_m)
   CS%id_Hsfc_used = register_diag_field('ocean_model', 'Hs_used', diag%axesT1, &
-      Time, 'Surface region thickness that is used', 'm', conversion=GV%Z_to_m)
+      Time, 'Surface region thickness that is used', 'm', conversion=US%Z_to_m)
   CS%id_Hsfc_max = register_diag_field('ocean_model', 'Hs_max', diag%axesT1, &
-      Time, 'Maximum surface region thickness', 'm', conversion=GV%Z_to_m)
+      Time, 'Maximum surface region thickness', 'm', conversion=US%Z_to_m)
   CS%id_Hsfc_min = register_diag_field('ocean_model', 'Hs_min', diag%axesT1, &
-      Time, 'Minimum surface region thickness', 'm', conversion=GV%Z_to_m)
+      Time, 'Minimum surface region thickness', 'm', conversion=US%Z_to_m)
  !CS%lim_det_dH_sfc = 0.5 ; CS%lim_det_dH_bathy = 0.2 ! Technically these should not get used if limit_det is false?
   if (CS%limit_det .or. (CS%id_Hsfc_min > 0)) then
     call get_param(param_file, mdl, "LIMIT_BUFFER_DET_DH_SFC", CS%lim_det_dH_sfc, &

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -12,6 +12,7 @@ use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,  only : extractFluxes1d, forcing
 use MOM_grid,          only : ocean_grid_type
 use MOM_shortwave_abs, only : absorbRemainingSW, optics_type
+use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs
@@ -168,10 +169,11 @@ contains
 !!    For a traditional Kraus-Turner mixed layer, the values are:
 !!      pen_SW_frac = 0.0, pen_SW_scale = 0.0 m, mstar = 1.25,
 !!      nstar = 0.4, TKE_decay = 0.0, conv_decay = 0.0
-subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
+subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, US, CS, &
                           optics, Hml, aggregate_FW_forcing, dt_diag, last_call)
   type(ocean_grid_type),      intent(inout) :: G      !< The ocean's grid structure.
   type(verticalGrid_type),    intent(in)    :: GV     !< The ocean's vertical grid structure.
+  type(unit_scale_type),      intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                               intent(inout) :: h_3d   !< Layer thickness, in m or kg m-2.
                                                       !! (Intent in/out) The units of h are
@@ -217,65 +219,7 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
                                                       !! diagnostics will be written. The default is
                                                       !! .true.
 
-!    This subroutine partially steps the bulk mixed layer model.
-!  The following processes are executed, in the order listed.
-!    1. Undergo convective adjustment into mixed layer.
-!    2. Apply surface heating and cooling.
-!    3. Starting from the top, entrain whatever fluid the TKE budget
-!       permits.  Penetrating shortwave radiation is also applied at
-!       this point.
-!    4. If there is any unentrained fluid that was formerly in the
-!       mixed layer, detrain this fluid into the buffer layer.  This
-!       is equivalent to the mixed layer detraining to the Monin-
-!       Obukhov depth.
-!    5. Divide the fluid in the mixed layer evenly into CS%nkml pieces.
-!    6. Split the buffer layer if appropriate.
-! Layers 1 to nkml are the mixed layer, nkml+1 to nkml+nkbl are the
-! buffer layers. The results of this subroutine are mathematically
-! identical if there are multiple pieces of the mixed layer with
-! the same density or if there is just a single layer. There is no
-! stability limit on the time step.
-!
-!   The key parameters for the mixed layer are found in the control structure.
-! These include mstar, nstar, nstar2, pen_SW_frac, pen_SW_scale, and TKE_decay.
-!   For the Oberhuber (1993) mixed layer, the values of these are:
-!      pen_SW_frac = 0.42, pen_SW_scale = 15.0 m, mstar = 1.25,
-!      nstar = 1, TKE_decay = 2.5, conv_decay = 0.5
-!  TKE_decay is 1/kappa in eq. 28 of Oberhuber (1993), while conv_decay is 1/mu.
-!  Conv_decay has been eliminated in favor of the well-calibrated form for the
-!  efficiency of penetrating convection from Wang (2003).
-!    For a traditional Kraus-Turner mixed layer, the values are:
-!      pen_SW_frac = 0.0, pen_SW_scale = 0.0 m, mstar = 1.25,
-!      nstar = 0.4, TKE_decay = 0.0, conv_decay = 0.0
-
-! Arguments: h_3d - Layer thickness, in m or kg m-2. (Intent in/out)
-!                   The units of h are referred to as H below.
-!  (in)      u_3d - Zonal velocities interpolated to h points, m s-1.
-!  (in)      v_3d - Zonal velocities interpolated to h points, m s-1.
-!  (in/out)  tv - A structure containing pointers to any available
-!                 thermodynamic fields. Absent fields have NULL ptrs.
-!  (in)      fluxes - A structure containing pointers to any possible
-!                     forcing fields.  Unused fields have NULL ptrs.
-!  (in)      dt - Time increment, in s.
-!  (in/out)  ea - The amount of fluid moved downward into a layer; this should
-!                 be increased due to mixed layer detrainment, in the same units
-!                 as h - usually m or kg m-2 (i.e., H).
-!  (in/out)  eb - The amount of fluid moved upward into a layer; this should
-!                 be increased due to mixed layer entrainment, in the same units
-!                 as h - usually m or kg m-2 (i.e., H).
-!  (in)      G - The ocean's grid structure.
-!  (in)      GV - The ocean's vertical grid structure.
-!  (in)      CS - The control structure returned by a previous call to
-!                 mixedlayer_init.
-!  (in)      optics - The structure containing the inverse of the vertical
-!                     absorption decay scale for penetrating shortwave
-!                     radiation, in m-1.
-!  (in,opt)  dt_diag - The diagnostic time step, which may be less than dt
-!                      if there are two callse to mixedlayer, in s.
-!  (in,opt)  last_call - if true, this is the last call to mixedlayer in the
-!                        current time step, so diagnostics will be written.
-!                        The default is .true.
-
+  ! Local variiables
   real, dimension(SZI_(G),SZK_(GV)) :: &
     eaml, &     !   The amount of fluid moved downward into a layer due to mixed
                 ! mixed layer detrainment, in m. (I.e. entrainment from above.)
@@ -560,7 +504,7 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
       ! rivermix_depth =  The prescribed depth over which to mix river inflow
       ! drho_ds = The gradient of density wrt salt at the ambient surface salinity.
       ! Sriver = 0 (i.e. rivers are assumed to be pure freshwater)
-      RmixConst = 0.5*CS%rivermix_depth * (GV%g_Earth*GV%m_to_Z) * Irho0**2
+      RmixConst = 0.5*CS%rivermix_depth * (GV%g_Earth*US%m_to_Z) * Irho0**2
       do i=is,ie
         TKE_river(i) = max(0.0, RmixConst*dR0_dS(i)* &
             (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j)) * S(i,1))
@@ -606,13 +550,13 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
 
     call find_starting_TKE(htot, h_CA, fluxes, Conv_En, cTKE, dKE_FC, dKE_CA, &
                            TKE, TKE_river, Idecay_len_TKE, cMKE, dt, Idt_diag, &
-                           j, ksort, G, GV, CS)
+                           j, ksort, G, GV, US, CS)
 
     ! Here the mechanically driven entrainment occurs.
     call mechanical_entrainment(h(:,1:), d_eb, htot, Ttot, Stot, uhtot, vhtot, &
                                 R0_tot, Rcv_tot, u, v, T(:,1:), S(:,1:), R0(:,1:), Rcv(:,1:), eps, dR0_dT, dRcv_dT, &
                                 cMKE, Idt_diag, nsw, Pen_SW_bnd, opacity_band, TKE, &
-                                Idecay_len_TKE, j, ksort, G, GV, CS)
+                                Idecay_len_TKE, j, ksort, G, GV, US, CS)
 
     call absorbRemainingSW(G, GV, h(:,1:), opacity_band, nsw, j, dt, CS%H_limit_fluxes, &
                            CS%correct_absorption, CS%absorb_all_SW, &
@@ -719,14 +663,14 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, CS, &
       ! as the third piece will then optimally describe mixed layer
       ! restratification.  For nkml>=4 the whole strategy should be revisited.
       do i=is,ie
-        kU_Star = 0.41*GV%m_to_Z*fluxes%ustar(i,j) ! Maybe could be replaced with u*+w*?
+        kU_Star = 0.41*US%m_to_Z*fluxes%ustar(i,j) ! Maybe could be replaced with u*+w*?
         if (associated(fluxes%ustar_shelf) .and. &
             associated(fluxes%frac_shelf_h)) then
           if (fluxes%frac_shelf_h(i,j) > 0.0) &
             kU_Star = (1.0 - fluxes%frac_shelf_h(i,j)) * kU_star + &
-                      fluxes%frac_shelf_h(i,j) * (0.41*GV%m_to_Z*fluxes%ustar_shelf(i,j))
+                      fluxes%frac_shelf_h(i,j) * (0.41*US%m_to_Z*fluxes%ustar_shelf(i,j))
         endif
-        absf_x_H = 0.25 * GV%m_to_Z * h(i,0) * &  !### I think this should be H_to_Z -RWH
+        absf_x_H = 0.25 * US%m_to_Z * h(i,0) * &  !### I think this should be H_to_Z -RWH
             ((abs(G%CoriolisBu(I,J)) + abs(G%CoriolisBu(I-1,J-1))) + &
              (abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I-1,J))))
         ! If the mixed layer vertical viscosity specification is changed in
@@ -1353,9 +1297,10 @@ end subroutine mixedlayer_convection
 !! convection to drive mechanical entrainment.
 subroutine find_starting_TKE(htot, h_CA, fluxes, Conv_En, cTKE, dKE_FC, dKE_CA, &
                              TKE, TKE_river, Idecay_len_TKE, cMKE, dt, Idt_diag, &
-                             j, ksort, G, GV, CS)
+                             j, ksort, G, GV, US, CS)
   type(ocean_grid_type),      intent(in)    :: G       !< The ocean's grid structure.
   type(verticalGrid_type),    intent(in)    :: GV      !< The ocean's vertical grid structure.
+  type(unit_scale_type),      intent(in)    :: US      !< A dimensional unit scaling type
   real, dimension(SZI_(G)),   intent(in)    :: htot    !< The accumlated mixed layer thickness, in H
                                                        !! (often m or kg m-2).
   real, dimension(SZI_(G)),   intent(in)    :: h_CA    !< The mixed layer depth after convective
@@ -1423,11 +1368,11 @@ subroutine find_starting_TKE(htot, h_CA, fluxes, Conv_En, cTKE, dKE_FC, dKE_CA, 
 
   if (CS%omega_frac >= 1.0) absf = 2.0*CS%omega
   do i=is,ie
-    U_Star = GV%m_to_Z * fluxes%ustar(i,j)
+    U_Star = US%m_to_Z * fluxes%ustar(i,j)
     if (associated(fluxes%ustar_shelf) .and. associated(fluxes%frac_shelf_h)) then
       if (fluxes%frac_shelf_h(i,j) > 0.0) &
         U_Star = (1.0 - fluxes%frac_shelf_h(i,j)) * U_star + &
-                  fluxes%frac_shelf_h(i,j) * GV%m_to_Z * fluxes%ustar_shelf(i,j)
+                  fluxes%frac_shelf_h(i,j) * US%m_to_Z * fluxes%ustar_shelf(i,j)
     endif
 
     if (U_Star < CS%ustar_min) U_Star = CS%ustar_min
@@ -1465,7 +1410,7 @@ subroutine find_starting_TKE(htot, h_CA, fluxes, Conv_En, cTKE, dKE_FC, dKE_CA, 
     if (Conv_En(i) < 0.0) Conv_En(i) = 0.0
     if (cTKE(i,1) > 0.0) then ; TKE_CA = cTKE(i,1) ; else ; TKE_CA = 0.0 ; endif
     if ((htot(i) >= h_CA(i)) .or. (TKE_CA == 0.0)) then
-      totEn_Z = GV%m_to_Z**2 * (Conv_En(i) + TKE_CA)
+      totEn_Z = US%m_to_Z**2 * (Conv_En(i) + TKE_CA)
 
       if (totEn_Z > 0.0) then
         nstar_FC = CS%nstar * totEn_Z / (totEn_Z + 0.2 * &
@@ -1477,14 +1422,14 @@ subroutine find_starting_TKE(htot, h_CA, fluxes, Conv_En, cTKE, dKE_FC, dKE_CA, 
     else
       ! This reconstructs the Buoyancy flux within the topmost htot of water.
       if (Conv_En(i) > 0.0) then
-        totEn_Z = GV%m_to_Z**2 * (Conv_En(i) + TKE_CA * (htot(i) / h_CA(i)) )
+        totEn_Z = US%m_to_Z**2 * (Conv_En(i) + TKE_CA * (htot(i) / h_CA(i)) )
         nstar_FC = CS%nstar * totEn_Z / (totEn_Z + 0.2 * &
                         sqrt(0.5 * dt * (absf*(htot(i)*GV%H_to_Z))**3 * totEn_Z))
       else
         nstar_FC = CS%nstar
       endif
 
-      totEn_Z = GV%m_to_Z**2 * (Conv_En(i) + TKE_CA)
+      totEn_Z = US%m_to_Z**2 * (Conv_En(i) + TKE_CA)
       if (TKE_CA > 0.0) then
         nstar_CA = CS%nstar * totEn_Z / (totEn_Z + 0.2 * &
                         sqrt(0.5 * dt * (absf*(h_CA(i)*GV%H_to_Z))**3 * totEn_Z))
@@ -1539,9 +1484,10 @@ subroutine mechanical_entrainment(h, d_eb, htot, Ttot, Stot, uhtot, vhtot, &
                                   R0_tot, Rcv_tot, u, v, T, S, R0, Rcv, eps, &
                                   dR0_dT, dRcv_dT, cMKE, Idt_diag, nsw, &
                                   Pen_SW_bnd, opacity_band, TKE, &
-                                  Idecay_len_TKE, j, ksort, G, GV, CS)
+                                  Idecay_len_TKE, j, ksort, G, GV, US, CS)
   type(ocean_grid_type),    intent(in)    :: G     !< The ocean's grid structure.
   type(verticalGrid_type),  intent(in)    :: GV    !< The ocean's vertical grid structure.
+  type(unit_scale_type),    intent(in)    :: US    !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZK_(GV)), &
                             intent(inout) :: h     !< Layer thickness, in m or kg m-2.
                                                    !! The units of h are referred to as H below.
@@ -1737,7 +1683,7 @@ subroutine mechanical_entrainment(h, d_eb, htot, Ttot, Stot, uhtot, vhtot, &
           endif
 
           TKE(i) = TKE_full_ent
-          if (TKE(i) <= 0.0) TKE(i) = 1.0e-150*GV%m_to_Z
+          if (TKE(i) <= 0.0) TKE(i) = 1.0e-150*US%m_to_Z
         else
 ! The layer is only partially entrained.  The amount that will be
 ! entrained is determined iteratively.  No further layers will be
@@ -3539,10 +3485,11 @@ subroutine mixedlayer_detrain_1(h, T, S, R0, Rcv, RcvTgt, dt, dt_diag, d_ea, d_e
 end subroutine mixedlayer_detrain_1
 
 !> This subroutine initializes the MOM bulk mixed layer module.
-subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
+subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
   type(time_type), target, intent(in)    :: Time !< The model's clock with the current time.
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time
                                                  !! parameters.
   type(diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic
@@ -3681,7 +3628,7 @@ subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
                  "The minimum value of ustar that should be used by the \n"//&
                  "bulk mixed layer model in setting vertical TKE decay \n"//&
                  "scales. This must be greater than 0.", units="m s-1", &
-                 default=ustar_min_dflt, scale=GV%m_to_Z)
+                 default=ustar_min_dflt, scale=US%m_to_Z)
   if (CS%ustar_min<=0.0) call MOM_error(FATAL, "BML_USTAR_MIN must be positive.")
 
   call get_param(param_file, mdl, "RESOLVE_EKMAN", CS%Resolve_Ekman, &
@@ -3702,7 +3649,7 @@ subroutine bulkmixedlayer_init(Time, G, GV, param_file, diag, CS)
   if (CS%do_rivermix) &
     call get_param(param_file, mdl, "RIVERMIX_DEPTH", CS%rivermix_depth, &
                  "The depth to which rivers are mixed if DO_RIVERMIX is \n"//&
-                 "defined.", units="m", default=0.0, scale=GV%m_to_Z)
+                 "defined.", units="m", default=0.0, scale=US%m_to_Z)
   call get_param(param_file, mdl, "USE_RIVER_HEAT_CONTENT", CS%use_river_heat_content, &
                  "If true, use the fluxes%runoff_Hflx field to set the \n"//&
                  "heat carried by runoff, instead of using SST*CP*liq_runoff.", &

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -915,8 +915,8 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, h, tv, &
                  dSV_dT(:,j,k), dSV_dS(:,j,k), is, ie-is+1, tv%eqn_of_state)
         do i=is,ie ; dSV_dT_2d(i,k) = dSV_dT(i,j,k) ; enddo
 !        do i=is,ie
-!          dT_to_dPE(i,k) = I_G_Earth * GV%Z_to_m * d_pres(i) * p_lay(i) * dSV_dT(i,j,k)
-!          dS_to_dPE(i,k) = I_G_Earth * GV%Z_to_m * d_pres(i) * p_lay(i) * dSV_dS(i,j,k)
+!          dT_to_dPE(i,k) = I_G_Earth * US%Z_to_m * d_pres(i) * p_lay(i) * dSV_dT(i,j,k)
+!          dS_to_dPE(i,k) = I_G_Earth * US%Z_to_m * d_pres(i) * p_lay(i) * dSV_dS(i,j,k)
 !        enddo
       enddo
       pen_TKE_2d(:,:) = 0.0

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -870,26 +870,23 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, h, tv, &
   if (CS%id_createdH>0) CS%createdH(:,:) = 0.
   numberOfGroundings = 0
 
-!$OMP parallel do default(none) shared(is,ie,js,je,nz,h,tv,nsw,G,GV,optics,fluxes,dt,    &
-!$OMP                                  H_limit_fluxes,                                   &
-!$OMP                                  numberOfGroundings,iGround,jGround,nonPenSW,      &
-!$OMP                                  hGrounding,CS,Idt,aggregate_FW_forcing,           &
-!$OMP                                  minimum_forcing_depth,evap_CFL_limit,             &
-!$OMP                                  calculate_buoyancy,netPen,SkinBuoyFlux,GoRho,     &
-!$OMP                                  calculate_energetics,dSV_dT,dSV_dS,cTKE,g_Hconv2) &
-!$OMP                          private(opacityBand,h2d,T2d,netMassInOut,netMassOut,      &
-!$OMP                                  netHeat,netSalt,Pen_SW_bnd,fractionOfForcing,     &
-!$OMP                                  IforcingDepthScale,                               &
-!$OMP                                  dThickness,dTemp,dSalt,hOld,Ithickness,           &
-!$OMP                                  netMassIn,pres,d_pres,p_lay,dSV_dT_2d,            &
-!$OMP                                  netmassinout_rate,netheat_rate,netsalt_rate,      &
-!$OMP                                  drhodt,drhods,pen_sw_bnd_rate,SurfPressure,       &
-!$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst)        &
-!$OMP                     firstprivate(start,npts)
-
-
-  ! Work in vertical slices for efficiency
+  !$OMP parallel do default(none) shared(is,ie,js,je,nz,h,tv,nsw,G,GV,US,optics,fluxes,dt, &
+  !$OMP                                  H_limit_fluxes,numberOfGroundings,iGround,jGround,&
+  !$OMP                                  nonPenSW,hGrounding,CS,Idt,aggregate_FW_forcing,  &
+  !$OMP                                  minimum_forcing_depth,evap_CFL_limit,             &
+  !$OMP                                  calculate_buoyancy,netPen,SkinBuoyFlux,GoRho,     &
+  !$OMP                                  calculate_energetics,dSV_dT,dSV_dS,cTKE,g_Hconv2) &
+  !$OMP                          private(opacityBand,h2d,T2d,netMassInOut,netMassOut,      &
+  !$OMP                                  netHeat,netSalt,Pen_SW_bnd,fractionOfForcing,     &
+  !$OMP                                  IforcingDepthScale,                               &
+  !$OMP                                  dThickness,dTemp,dSalt,hOld,Ithickness,           &
+  !$OMP                                  netMassIn,pres,d_pres,p_lay,dSV_dT_2d,            &
+  !$OMP                                  netmassinout_rate,netheat_rate,netsalt_rate,      &
+  !$OMP                                  drhodt,drhods,pen_sw_bnd_rate,SurfPressure,       &
+  !$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst)        &
+  !$OMP                     firstprivate(start,npts)
   do j=js,je
+  ! Work in vertical slices for efficiency
 
     ! Copy state into 2D-slice arrays
     do k=1,nz ; do i=is,ie

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -64,6 +64,7 @@ use MOM_ALE_sponge,          only : apply_ALE_sponge, ALE_sponge_CS
 use MOM_time_manager,        only : time_type, real_to_time, operator(-), operator(<=)
 use MOM_tracer_flow_control, only : call_tracer_column_fns, tracer_flow_control_CS
 use MOM_tracer_diabatic,     only : tracer_vertdiff
+use MOM_unit_scaling,        only : unit_scale_type
 use MOM_variables,           only : thermo_var_ptrs, vertvisc_type, accel_diag_ptrs
 use MOM_variables,           only : cont_diag_ptrs, MOM_thermovar_chksum, p3d
 use MOM_verticalGrid,        only : verticalGrid_type
@@ -260,9 +261,10 @@ contains
 !>  This subroutine imposes the diapycnal mass fluxes and the
 !!  accompanying diapycnal advection of momentum and tracers.
 subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
-                    G, GV, CS, WAVES)
+                    G, GV, US, CS, WAVES)
   type(ocean_grid_type),                     intent(inout) :: G         !< ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV        !< ocean vertical grid structure
+  type(unit_scale_type),                     intent(in)    :: US        !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: u         !< zonal velocity (m/s)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: v         !< meridional velocity (m/s)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h         !< thickness (m for Bouss / kg/m2 for non-Bouss)
@@ -407,7 +409,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   if (CS%id_T_predia > 0) call post_data(CS%id_T_predia, tv%T, CS%diag)
   if (CS%id_S_predia > 0) call post_data(CS%id_S_predia, tv%S, CS%diag)
   if (CS%id_e_predia > 0) then
-    call find_eta(h, tv, G, GV, eta, eta_to_m=1.0)
+    call find_eta(h, tv, G, GV, US, eta, eta_to_m=1.0)
     call post_data(CS%id_e_predia, eta, CS%diag)
   endif
 
@@ -428,7 +430,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   if (CS%debugConservation) call MOM_state_stats('Start of diabatic', u, v, h, tv%T, tv%S, G)
 
   if (CS%debug_energy_req) &
-    call diapyc_energy_req_test(h, dt, tv, G, GV, CS%diapyc_en_rec_CSp)
+    call diapyc_energy_req_test(h, dt, tv, G, GV, US, CS%diapyc_en_rec_CSp)
 
 
   call cpu_clock_begin(id_clock_set_diffusivity)
@@ -512,7 +514,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     ! tide module (BDM).
 
     ! PROVIDE ENERGY DISTRIBUTION (calculate time-varying energy source)
-    call set_int_tide_input(u, v, h, tv, fluxes, CS%int_tide_input, dt, G, GV, &
+    call set_int_tide_input(u, v, h, tv, fluxes, CS%int_tide_input, dt, G, GV, US, &
                             CS%int_tide_input_CSp)
     ! CALCULATE MODAL VELOCITIES
     cn(:,:,:) = 0.0
@@ -520,7 +522,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
        ! SET TO CONSTANT VALUE TO TEST PROPAGATE CODE
        do m=1,CS%nMode ; cn(:,:,m) = CS%cg_test ; enddo
     else
-       call wave_speeds(h, tv, G, GV, CS%nMode, cn, full_halos=.true.)
+       call wave_speeds(h, tv, G, GV, US, CS%nMode, cn, full_halos=.true.)
        ! uncomment the lines below for a hard-coded cn that changes linearly with latitude
        !do j=G%jsd,G%jed ; do i=G%isd,G%ied
        !  cn(i,j,:) = ((7.-1.)/14000000.)*G%geoLatBu(i,j) + (1.-((7.-1.)/14000000.)*-7000000.)
@@ -543,11 +545,13 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
       endif
       ! CALL ROUTINE USING PRESCRIBED KE FOR TESTING
       call propagate_int_tide(h, tv, cn, TKE_itidal_input_test, &
-                            CS%int_tide_input%tideamp, CS%int_tide_input%Nb, dt, G, GV, CS%int_tide_CSp)
+                              CS%int_tide_input%tideamp, CS%int_tide_input%Nb, dt, G, GV, US, &
+                              CS%int_tide_CSp)
     else
       ! CALL ROUTINE USING CALCULATED KE INPUT
       call propagate_int_tide(h, tv, cn, CS%int_tide_input%TKE_itidal_input, &
-                              CS%int_tide_input%tideamp, CS%int_tide_input%Nb, dt, G, GV, CS%int_tide_CSp)
+                              CS%int_tide_input%tideamp, CS%int_tide_input%Nb, dt, G, GV, US, &
+                              CS%int_tide_CSp)
     endif
     if (showCallTree) call callTree_waypoint("done with propagate_int_tide (diabatic)")
   endif ! end CS%use_int_tides
@@ -555,8 +559,8 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   call cpu_clock_begin(id_clock_set_diffusivity)
   ! Sets: Kd_lay, Kd_int, visc%Kd_extra_T, visc%Kd_extra_S
   ! Also changes: visc%Kd_shear, visc%Kv_slow and visc%TKE_turb (not clear that TKE_turb is used as input ????
-  call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, CS%set_diff_CSp, &
-                       Kd_lay, Kd_int)
+  call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, &
+                       CS%set_diff_CSp, Kd_lay, Kd_int)
   call cpu_clock_end(id_clock_set_diffusivity)
   if (showCallTree) call callTree_waypoint("done with set_diffusivity (diabatic)")
 
@@ -601,14 +605,14 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     ! Sets: CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux
     ! NOTE: CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux are returned as rates (i.e. stuff per second)
     ! unlike other instances where the fluxes are integrated in time over a time-step.
-    call calculateBuoyancyFlux2d(G, GV, fluxes, CS%optics, h, tv%T, tv%S, tv, &
+    call calculateBuoyancyFlux2d(G, GV, US, fluxes, CS%optics, h, tv%T, tv%S, tv, &
                                  CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux)
     ! The KPP scheme calculates boundary layer diffusivities and non-local transport.
 
-    call KPP_compute_BLD(CS%KPP_CSp, G, GV, h, tv%T, tv%S, u, v, tv%eqn_of_state, &
+    call KPP_compute_BLD(CS%KPP_CSp, G, GV, US, h, tv%T, tv%S, u, v, tv%eqn_of_state, &
       fluxes%ustar, CS%KPP_buoy_flux, Waves=Waves)
 
-    call KPP_calculate(CS%KPP_CSp, G, GV, h, fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, &
+    call KPP_calculate(CS%KPP_CSp, G, GV, US, h, fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, &
       Kd_salt, visc%Kv_shear, CS%KPP_NLTheat, CS%KPP_NLTscalar, Waves=Waves)
 
     if (associated(Hml)) then
@@ -682,7 +686,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
 
   ! Calculate vertical mixing due to convection (computed via CVMix)
   if (CS%use_CVMix_conv) then
-    call calculate_CVMix_conv(h, tv, G, GV, CS%CVMix_conv_csp, Hml)
+    call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_csp, Hml)
     ! Increment vertical diffusion and viscosity due to convection
     !$OMP parallel do default(shared)
     do k=1,nz+1 ; do j=js,je ; do i=is,ie
@@ -715,7 +719,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   if (CS%use_energetic_PBL) then
 
     skinbuoyflux(:,:) = 0.0
-    call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, dt, fluxes, CS%optics, &
+    call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
             h, tv, CS%aggregate_FW_forcing, CS%evap_CFL_limit,                         &
             CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux)
 
@@ -730,7 +734,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     endif
 
     call find_uv_at_h(u, v, h, u_h, v_h, G, GV)
-    call energetic_PBL(h, u_h, v_h, tv, fluxes, dt, Kd_ePBL, G, GV, &
+    call energetic_PBL(h, u_h, v_h, tv, fluxes, dt, Kd_ePBL, G, GV, US, &
          CS%energetic_PBL_CSp, dSV_dT, dSV_dS, cTKE, SkinBuoyFlux, waves=waves)
 
     if (associated(Hml)) then
@@ -768,7 +772,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     endif
 
   else
-    call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, dt, fluxes, CS%optics, &
+    call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
                                   h, tv, CS%aggregate_FW_forcing, &
                                   CS%evap_CFL_limit, CS%minimum_forcing_depth)
 
@@ -1015,7 +1019,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     call cpu_clock_begin(id_clock_sponge)
     if (associated(CS%ALE_sponge_CSp)) then
       ! ALE sponge
-      call apply_ALE_sponge(h, dt, G, GV, CS%ALE_sponge_CSp, CS%Time)
+      call apply_ALE_sponge(h, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
     endif
 
     call cpu_clock_end(id_clock_sponge)
@@ -1087,14 +1091,14 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   if (CS%id_dvdt_dia > 0) call post_data(CS%id_dvdt_dia, ADp%dv_dt_dia,  CS%diag)
 
   if (CS%id_MLD_003 > 0 .or. CS%id_subMLN2 > 0 .or. CS%id_mlotstsq > 0) then
-    call diagnoseMLDbyDensityDifference(CS%id_MLD_003, h, tv, 0.03, G, GV, CS%diag, &
+    call diagnoseMLDbyDensityDifference(CS%id_MLD_003, h, tv, 0.03, G, GV, US, CS%diag, &
                                         id_N2subML=CS%id_subMLN2, id_MLDsq=CS%id_mlotstsq)
   endif
   if (CS%id_MLD_0125 > 0) then
-    call diagnoseMLDbyDensityDifference(CS%id_MLD_0125, h, tv, 0.125, G, GV, CS%diag)
+    call diagnoseMLDbyDensityDifference(CS%id_MLD_0125, h, tv, 0.125, G, GV, US, CS%diag)
   endif
   if (CS%id_MLD_user > 0) then
-    call diagnoseMLDbyDensityDifference(CS%id_MLD_user, h, tv, CS%MLDdensityDifference, G, GV, CS%diag)
+    call diagnoseMLDbyDensityDifference(CS%id_MLD_user, h, tv, CS%MLDdensityDifference, G, GV, US, CS%diag)
   endif
 
   if (CS%id_Tdif > 0) call post_data(CS%id_Tdif, Tdif_flx, CS%diag)
@@ -1143,9 +1147,10 @@ end subroutine diabatic
 !> Imposes the diapycnal mass fluxes and the accompanying diapycnal advection of momentum and tracers
 !! using the original MOM6 algorithms.
 subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
-                    G, GV, CS, WAVES)
+                           G, GV, US, CS, WAVES)
   type(ocean_grid_type),                     intent(inout) :: G         !< ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV        !< ocean vertical grid structure
+  type(unit_scale_type),                     intent(in)    :: US        !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(inout) :: u         !< zonal velocity (m/s)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout) :: v         !< meridional velocity (m/s)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(inout) :: h         !< thickness (m for Bouss / kg/m2 for non-Bouss)
@@ -1285,7 +1290,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
   if (CS%id_T_predia > 0) call post_data(CS%id_T_predia, tv%T, CS%diag)
   if (CS%id_S_predia > 0) call post_data(CS%id_S_predia, tv%S, CS%diag)
   if (CS%id_e_predia > 0) then
-    call find_eta(h, tv, G, GV, eta, eta_to_m=1.0)
+    call find_eta(h, tv, G, GV, US, eta, eta_to_m=1.0)
     call post_data(CS%id_e_predia, eta, CS%diag)
   endif
 
@@ -1305,7 +1310,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
   if (CS%debugConservation) call MOM_state_stats('Start of diabatic', u, v, h, tv%T, tv%S, G)
 
   if (CS%debug_energy_req) &
-    call diapyc_energy_req_test(h, dt, tv, G, GV, CS%diapyc_en_rec_CSp)
+    call diapyc_energy_req_test(h, dt, tv, G, GV, US, CS%diapyc_en_rec_CSp)
 
   call cpu_clock_begin(id_clock_set_diffusivity)
   call set_BBL_TKE(u, v, h, fluxes, visc, G, GV, CS%set_diff_CSp)
@@ -1385,7 +1390,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       if (CS%ML_mix_first < 1.0) then
         ! Changes: h, tv%T, tv%S, eaml and ebml  (G is also inout???)
         call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt*CS%ML_mix_first, &
-                            eaml,ebml, G, GV, CS%bulkmixedlayer_CSp, CS%optics, &
+                            eaml,ebml, G, GV, US, CS%bulkmixedlayer_CSp, CS%optics, &
                             Hml, CS%aggregate_FW_forcing, dt, last_call=.false.)
         if (CS%salt_reject_below_ML) &
           call insert_brine(h, tv, G, GV, fluxes, nkmb, CS%diabatic_aux_CSp, &
@@ -1393,8 +1398,8 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       else
         ! Changes: h, tv%T, tv%S, eaml and ebml  (G is also inout???)
         call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt, eaml, ebml, &
-                        G, GV, CS%bulkmixedlayer_CSp, CS%optics, &
-                        Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
+                            G, GV, US, CS%bulkmixedlayer_CSp, CS%optics, &
+                            Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
       endif
 
       !  Keep salinity from falling below a small but positive threshold.
@@ -1436,7 +1441,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     ! tide module (BDM).
 
     ! PROVIDE ENERGY DISTRIBUTION (calculate time-varying energy source)
-    call set_int_tide_input(u, v, h, tv, fluxes, CS%int_tide_input, dt, G, GV, &
+    call set_int_tide_input(u, v, h, tv, fluxes, CS%int_tide_input, dt, G, GV, US, &
                             CS%int_tide_input_CSp)
     ! CALCULATE MODAL VELOCITIES
     cn(:,:,:) = 0.0
@@ -1444,7 +1449,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
        ! SET TO CONSTANT VALUE TO TEST PROPAGATE CODE
        do m=1,CS%nMode ; cn(:,:,m) = CS%cg_test ; enddo
     else
-       call wave_speeds(h, tv, G, GV, CS%nMode, cn, full_halos=.true.)
+       call wave_speeds(h, tv, G, GV, US, CS%nMode, cn, full_halos=.true.)
        ! uncomment the lines below for a hard-coded cn that changes linearly with latitude
        !do j=G%jsd,G%jed ; do i=G%isd,G%ied
        !  cn(i,j,:) = ((7.-1.)/14000000.)*G%geoLatBu(i,j) + (1.-((7.-1.)/14000000.)*-7000000.)
@@ -1466,12 +1471,12 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
         enddo ; enddo
       endif
       ! CALL ROUTINE USING PRESCRIBED KE FOR TESTING
-      call propagate_int_tide(h, tv, cn, TKE_itidal_input_test, &
-                            CS%int_tide_input%tideamp, CS%int_tide_input%Nb, dt, G, GV, CS%int_tide_CSp)
+      call propagate_int_tide(h, tv, cn, TKE_itidal_input_test, CS%int_tide_input%tideamp, &
+                              CS%int_tide_input%Nb, dt, G, GV, US, CS%int_tide_CSp)
     else
       ! CALL ROUTINE USING CALCULATED KE INPUT
-      call propagate_int_tide(h, tv, cn, CS%int_tide_input%TKE_itidal_input, &
-                              CS%int_tide_input%tideamp, CS%int_tide_input%Nb, dt, G, GV, CS%int_tide_CSp)
+      call propagate_int_tide(h, tv, cn, CS%int_tide_input%TKE_itidal_input, CS%int_tide_input%tideamp, &
+                              CS%int_tide_input%Nb, dt, G, GV, US, CS%int_tide_CSp)
     endif
     if (showCallTree) call callTree_waypoint("done with propagate_int_tide (diabatic)")
   endif
@@ -1485,8 +1490,8 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     if (associated(tv%T)) call pass_var(tv%S, G%Domain, halo=CS%halo_TS_diff, complete=.false.)
     call pass_var(h, G%domain, halo=CS%halo_TS_diff, complete=.true.)
   endif
-  call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, CS%set_diff_CSp, &
-                       Kd_lay, Kd_int)
+  call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, &
+                       CS%set_diff_CSp, Kd_lay, Kd_int)
   call cpu_clock_end(id_clock_set_diffusivity)
   if (showCallTree) call callTree_waypoint("done with set_diffusivity (diabatic)")
 
@@ -1506,7 +1511,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     ! Sets: CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux
     ! NOTE: CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux are returned as rates (i.e. stuff per second)
     ! unlike other instances where the fluxes are integrated in time over a time-step.
-    call calculateBuoyancyFlux2d(G, GV, fluxes, CS%optics, h, tv%T, tv%S, tv, &
+    call calculateBuoyancyFlux2d(G, GV, US, fluxes, CS%optics, h, tv%T, tv%S, tv, &
                                  CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux)
     ! The KPP scheme calculates boundary layer diffusivities and non-local transport.
 
@@ -1528,11 +1533,11 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       enddo ; enddo ; enddo
     endif
 
-    call KPP_compute_BLD(CS%KPP_CSp, G, GV, h, tv%T, tv%S, u, v, tv%eqn_of_state, &
-      fluxes%ustar, CS%KPP_buoy_flux, Waves=Waves)
+    call KPP_compute_BLD(CS%KPP_CSp, G, GV, US, h, tv%T, tv%S, u, v, tv%eqn_of_state, &
+                         fluxes%ustar, CS%KPP_buoy_flux, Waves=Waves)
 
-    call KPP_calculate(CS%KPP_CSp, G, GV, h, fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, &
-      Kd_salt, visc%Kv_shear, CS%KPP_NLTheat, CS%KPP_NLTscalar, Waves=Waves)
+    call KPP_calculate(CS%KPP_CSp, G, GV, US, h, fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, &
+                       Kd_salt, visc%Kv_shear, CS%KPP_NLTheat, CS%KPP_NLTscalar, Waves=Waves)
 
     if (associated(Hml)) then
       call KPP_get_BLD(CS%KPP_CSp, Hml(:,:), G)
@@ -1574,7 +1579,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
   ! Add vertical diff./visc. due to convection (computed via CVMix)
   if (CS%use_CVMix_conv) then
-    call calculate_CVMix_conv(h, tv, G, GV, CS%CVMix_conv_csp, Hml)
+    call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_csp, Hml)
 
     !!!!!!!! GMM, the following needs to be checked !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !### The vertical extent here is more limited that Kv_slow or Kd_int; it might be k=1,nz+1.
@@ -1660,7 +1665,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     call cpu_clock_begin(id_clock_entrain)
     ! Calculate appropriately limited diapycnal mass fluxes to account
     ! for diapycnal diffusion and advection.  Sets: ea, eb. Changes: kb
-    call Entrainment_diffusive(u, v, h, tv, fluxes, dt, G, GV, CS%entrain_diffusive_CSp, &
+    call Entrainment_diffusive(u, v, h, tv, fluxes, dt, G, GV, US, CS%entrain_diffusive_CSp, &
                                ea, eb, kb, Kd_Lay=Kd_lay, Kd_int=Kd_int)
     call cpu_clock_end(id_clock_entrain)
     if (showCallTree) call callTree_waypoint("done with Entrainment_diffusive (diabatic)")
@@ -1696,7 +1701,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     if (CS%use_energetic_PBL) then
 
       skinbuoyflux(:,:) = 0.0
-      call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, dt, fluxes, CS%optics, &
+      call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
               h, tv, CS%aggregate_FW_forcing, CS%evap_CFL_limit,                         &
               CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux)
 
@@ -1709,7 +1714,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       endif
 
       call find_uv_at_h(u, v, h, u_h, v_h, G, GV)
-      call energetic_PBL(h, u_h, v_h, tv, fluxes, dt, Kd_ePBL, G, GV, &
+      call energetic_PBL(h, u_h, v_h, tv, fluxes, dt, Kd_ePBL, G, GV, US, &
            CS%energetic_PBL_CSp, dSV_dT, dSV_dS, cTKE, SkinBuoyFlux, waves=waves)
 
       ! If visc%MLD exists, copy the ePBL's MLD into it
@@ -1748,7 +1753,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       endif
 
     else
-      call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, dt, fluxes, CS%optics, &
+      call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
                                     h, tv, CS%aggregate_FW_forcing, &
                                     CS%evap_CFL_limit, CS%minimum_forcing_depth)
 
@@ -1940,8 +1945,8 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       call cpu_clock_begin(id_clock_mixedlayer)
       ! Changes: h, tv%T, tv%S, ea and eb  (G is also inout???)
       call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt_mix, ea, eb, &
-                      G, GV, CS%bulkmixedlayer_CSp, CS%optics, &
-                      Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
+                          G, GV, US, CS%bulkmixedlayer_CSp, CS%optics, &
+                          Hml, CS%aggregate_FW_forcing, dt, last_call=.true.)
 
       if (CS%salt_reject_below_ML) &
         call insert_brine(h, tv, G, GV, fluxes, nkmb, CS%diabatic_aux_CSp, dt_mix, &
@@ -2174,7 +2179,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     call cpu_clock_begin(id_clock_sponge)
     if (associated(CS%ALE_sponge_CSp)) then
       ! ALE sponge
-      call apply_ALE_sponge(h, dt, G, GV, CS%ALE_sponge_CSp, CS%Time)
+      call apply_ALE_sponge(h, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
     else
       ! Layer mode sponge
       if (CS%bulkmixedlayer .and. associated(tv%eqn_of_state)) then
@@ -2380,14 +2385,14 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
   if (CS%id_wd       > 0) call post_data(CS%id_wd,       CDp%diapyc_vel, CS%diag)
 
   if (CS%id_MLD_003 > 0 .or. CS%id_subMLN2 > 0 .or. CS%id_mlotstsq > 0) then
-    call diagnoseMLDbyDensityDifference(CS%id_MLD_003, h, tv, 0.03, G, GV, CS%diag, &
+    call diagnoseMLDbyDensityDifference(CS%id_MLD_003, h, tv, 0.03, G, GV, US, CS%diag, &
                                         id_N2subML=CS%id_subMLN2, id_MLDsq=CS%id_mlotstsq)
   endif
   if (CS%id_MLD_0125 > 0) then
-    call diagnoseMLDbyDensityDifference(CS%id_MLD_0125, h, tv, 0.125, G, GV, CS%diag)
+    call diagnoseMLDbyDensityDifference(CS%id_MLD_0125, h, tv, 0.125, G, GV, US, CS%diag)
   endif
   if (CS%id_MLD_user > 0) then
-    call diagnoseMLDbyDensityDifference(CS%id_MLD_user, h, tv, CS%MLDdensityDifference, G, GV, CS%diag)
+    call diagnoseMLDbyDensityDifference(CS%id_MLD_user, h, tv, CS%MLDdensityDifference, G, GV, US, CS%diag)
   endif
 
   if (CS%id_Tdif > 0) call post_data(CS%id_Tdif, Tdif_flx, CS%diag)
@@ -2744,12 +2749,13 @@ end subroutine adiabatic_driver_init
 
 
 !> This routine initializes the diabatic driver module.
-subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, &
+subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, diag, &
                                 ADp, CDp, CS, tracer_flow_CSp, sponge_CSp, &
                                 ALE_sponge_CSp, diag_to_Z_CSp)
   type(time_type), target                :: Time             !< model time
   type(ocean_grid_type),   intent(inout) :: G                !< model grid structure
   type(verticalGrid_type), intent(in)    :: GV               !< model vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US               !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file       !< file to parse for parameter values
   logical,                 intent(in)    :: useALEalgorithm  !< logical for whether to use ALE remapping
   type(diag_ctrl), target, intent(inout) :: diag             !< structure to regulate diagnostic output
@@ -2918,12 +2924,12 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
     call get_param(param_file, mdl, "KD_MIN_TR", CS%Kd_min_tr, &
                  "A minimal diffusivity that should always be applied to \n"//&
                  "tracers, especially in massless layers near the bottom. \n"//&
-                 "The default is 0.1*KD.", units="m2 s-1", default=0.1*Kd, scale=GV%m_to_Z**2)
+                 "The default is 0.1*KD.", units="m2 s-1", default=0.1*Kd, scale=US%m_to_Z**2)
     call get_param(param_file, mdl, "KD_BBL_TR", CS%Kd_BBL_tr, &
                  "A bottom boundary layer tracer diffusivity that will \n"//&
                  "allow for explicitly specified bottom fluxes. The \n"//&
                  "entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt) \n"//&
-                 "over the same distance.", units="m2 s-1", default=0., scale=GV%m_to_Z**2)
+                 "over the same distance.", units="m2 s-1", default=0., scale=US%m_to_Z**2)
   endif
 
   call get_param(param_file, mdl, "TRACER_TRIDIAG", CS%tracer_tridiag, &
@@ -3272,7 +3278,8 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
   endif
 
   ! CS%use_tidal_mixing is set to True if an internal tidal dissipation scheme is to be used.
-  CS%use_tidal_mixing = tidal_mixing_init(Time, G, GV, param_file, diag, diag_to_Z_CSp, CS%tidal_mixing_CSp)
+  CS%use_tidal_mixing = tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_CSp, &
+                                          CS%tidal_mixing_CSp)
 
   ! CS%use_CVMix_conv is set to True if CVMix convection will be used, otherwise
   ! False.
@@ -3286,13 +3293,13 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
 
   ! initialize module for internal tide induced mixing
   if (CS%use_int_tides) then
-    call int_tide_input_init(Time, G, GV, param_file, diag, CS%int_tide_input_CSp, &
+    call int_tide_input_init(Time, G, GV, US, param_file, diag, CS%int_tide_input_CSp, &
                              CS%int_tide_input)
     call internal_tides_init(Time, G, GV, param_file, diag, CS%int_tide_CSp)
   endif
 
   ! initialize module for setting diffusivities
-  call set_diffusivity_init(Time, G, GV, param_file, diag, CS%set_diff_CSp, diag_to_Z_CSp, &
+  call set_diffusivity_init(Time, G, GV, US, param_file, diag, CS%set_diff_CSp, diag_to_Z_CSp, &
                             CS%int_tide_CSp, CS%tidal_mixing_CSp, CS%halo_TS_diff)
 
 
@@ -3314,14 +3321,14 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
     id_clock_differential_diff = cpu_clock_id('(Ocean differential diffusion)', grain=CLOCK_ROUTINE)
 
   ! initialize the auxiliary diabatic driver module
-  call diabatic_aux_init(Time, G, GV, param_file, diag, CS%diabatic_aux_CSp, &
+  call diabatic_aux_init(Time, G, GV, US, param_file, diag, CS%diabatic_aux_CSp, &
                          CS%useALEalgorithm, CS%use_energetic_PBL)
 
   ! initialize the boundary layer modules
   if (CS%bulkmixedlayer) &
-    call bulkmixedlayer_init(Time, G, GV, param_file, diag, CS%bulkmixedlayer_CSp)
+    call bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS%bulkmixedlayer_CSp)
   if (CS%use_energetic_PBL) &
-    call energetic_PBL_init(Time, G, GV, param_file, diag, CS%energetic_PBL_CSp)
+    call energetic_PBL_init(Time, G, GV, US, param_file, diag, CS%energetic_PBL_CSp)
 
   call regularize_layers_init(Time, G, GV, param_file, diag, CS%regularize_layers_CSp)
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1015,7 +1015,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     call cpu_clock_begin(id_clock_sponge)
     if (associated(CS%ALE_sponge_CSp)) then
       ! ALE sponge
-      call apply_ALE_sponge(h, dt, G, CS%ALE_sponge_CSp, CS%Time)
+      call apply_ALE_sponge(h, dt, G, GV, CS%ALE_sponge_CSp, CS%Time)
     endif
 
     call cpu_clock_end(id_clock_sponge)
@@ -2174,7 +2174,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     call cpu_clock_begin(id_clock_sponge)
     if (associated(CS%ALE_sponge_CSp)) then
       ! ALE sponge
-      call apply_ALE_sponge(h, dt, G, CS%ALE_sponge_CSp, CS%Time)
+      call apply_ALE_sponge(h, dt, G, GV, CS%ALE_sponge_CSp, CS%Time)
     else
       ! Layer mode sponge
       if (CS%bulkmixedlayer .and. associated(tv%eqn_of_state)) then

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -434,7 +434,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
 
 
   call cpu_clock_begin(id_clock_set_diffusivity)
-  call set_BBL_TKE(u, v, h, fluxes, visc, G, GV, CS%set_diff_CSp)
+  call set_BBL_TKE(u, v, h, fluxes, visc, G, GV, US, CS%set_diff_CSp)
   call cpu_clock_end(id_clock_set_diffusivity)
 
   ! Frazil formation keeps the temperature above the freezing point.
@@ -589,8 +589,8 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     call MOM_state_chksum("after set_diffusivity ", u, v, h, G, GV, haloshift=0)
     call MOM_forcing_chksum("after set_diffusivity ", fluxes, G, haloshift=0)
     call MOM_thermovar_chksum("after set_diffusivity ", tv, G)
-    call hchksum(Kd_heat, "after set_diffusivity Kd_heat", G%HI, haloshift=0, scale=GV%Z_to_m**2)
-    call hchksum(Kd_salt, "after set_diffusivity Kd_salt", G%HI, haloshift=0, scale=GV%Z_to_m**2)
+    call hchksum(Kd_heat, "after set_diffusivity Kd_heat", G%HI, haloshift=0, scale=US%Z_to_m**2)
+    call hchksum(Kd_salt, "after set_diffusivity Kd_salt", G%HI, haloshift=0, scale=US%Z_to_m**2)
   endif
 
   if (CS%useKPP) then
@@ -630,8 +630,8 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
       call MOM_state_chksum("after KPP", u, v, h, G, GV, haloshift=0)
       call MOM_forcing_chksum("after KPP", fluxes, G, haloshift=0)
       call MOM_thermovar_chksum("after KPP", tv, G)
-      call hchksum(Kd_heat, "after KPP Kd_heat", G%HI, haloshift=0, scale=GV%Z_to_m**2)
-      call hchksum(Kd_salt, "after KPP Kd_salt", G%HI, haloshift=0, scale=GV%Z_to_m**2)
+      call hchksum(Kd_heat, "after KPP Kd_heat", G%HI, haloshift=0, scale=US%Z_to_m**2)
+      call hchksum(Kd_salt, "after KPP Kd_salt", G%HI, haloshift=0, scale=US%Z_to_m**2)
     endif
 
   endif  ! endif for KPP
@@ -738,12 +738,12 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
          CS%energetic_PBL_CSp, dSV_dT, dSV_dS, cTKE, SkinBuoyFlux, waves=waves)
 
     if (associated(Hml)) then
-      call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, Hml(:,:), G, GV)
+      call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, Hml(:,:), G, US)
       call pass_var(Hml, G%domain, halo=1)
       ! If visc%MLD exists, copy ePBL's MLD into it
       if (associated(visc%MLD)) visc%MLD(:,:) = Hml(:,:)
     elseif (associated(visc%MLD)) then
-      call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, visc%MLD, G, GV)
+      call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, visc%MLD, G, US)
       call pass_var(visc%MLD, G%domain, halo=1)
     endif
 
@@ -768,7 +768,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
       call hchksum(eb_t, "after ePBL eb_t",G%HI,haloshift=0, scale=GV%H_to_m)
       call hchksum(ea_s, "after ePBL ea_s",G%HI,haloshift=0, scale=GV%H_to_m)
       call hchksum(eb_s, "after ePBL eb_s",G%HI,haloshift=0, scale=GV%H_to_m)
-      call hchksum(Kd_ePBL, "after ePBL Kd_ePBL", G%HI, haloshift=0, scale=GV%Z_to_m**2)
+      call hchksum(Kd_ePBL, "after ePBL Kd_ePBL", G%HI, haloshift=0, scale=US%Z_to_m**2)
     endif
 
   else
@@ -1313,7 +1313,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     call diapyc_energy_req_test(h, dt, tv, G, GV, US, CS%diapyc_en_rec_CSp)
 
   call cpu_clock_begin(id_clock_set_diffusivity)
-  call set_BBL_TKE(u, v, h, fluxes, visc, G, GV, CS%set_diff_CSp)
+  call set_BBL_TKE(u, v, h, fluxes, visc, G, GV, US, CS%set_diff_CSp)
   call cpu_clock_end(id_clock_set_diffusivity)
 
   ! Frazil formation keeps the temperature above the freezing point.
@@ -1499,8 +1499,8 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     call MOM_state_chksum("after set_diffusivity ", u, v, h, G, GV, haloshift=0)
     call MOM_forcing_chksum("after set_diffusivity ", fluxes, G, haloshift=0)
     call MOM_thermovar_chksum("after set_diffusivity ", tv, G)
-    call hchksum(Kd_lay, "after set_diffusivity Kd_lay", G%HI, haloshift=0, scale=GV%Z_to_m**2)
-    call hchksum(Kd_Int, "after set_diffusivity Kd_Int", G%HI, haloshift=0, scale=GV%Z_to_m**2)
+    call hchksum(Kd_lay, "after set_diffusivity Kd_lay", G%HI, haloshift=0, scale=US%Z_to_m**2)
+    call hchksum(Kd_Int, "after set_diffusivity Kd_Int", G%HI, haloshift=0, scale=US%Z_to_m**2)
   endif
 
 
@@ -1571,8 +1571,8 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       call MOM_state_chksum("after KPP", u, v, h, G, GV, haloshift=0)
       call MOM_forcing_chksum("after KPP", fluxes, G, haloshift=0)
       call MOM_thermovar_chksum("after KPP", tv, G)
-      call hchksum(Kd_lay, "after KPP Kd_lay", G%HI, haloshift=0, scale=GV%Z_to_m**2)
-      call hchksum(Kd_Int, "after KPP Kd_Int", G%HI, haloshift=0, scale=GV%Z_to_m**2)
+      call hchksum(Kd_lay, "after KPP Kd_lay", G%HI, haloshift=0, scale=US%Z_to_m**2)
+      call hchksum(Kd_Int, "after KPP Kd_Int", G%HI, haloshift=0, scale=US%Z_to_m**2)
     endif
 
   endif  ! endif for KPP
@@ -1719,7 +1719,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
       ! If visc%MLD exists, copy the ePBL's MLD into it
       if (associated(visc%MLD)) then
-        call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, visc%MLD, G, GV)
+        call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, visc%MLD, G, US)
         call pass_var(visc%MLD, G%domain, halo=1)
         Hml(:,:) = visc%MLD(:,:)
       endif
@@ -1749,7 +1749,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       if (CS%debug) then
         call hchksum(ea, "after ePBL ea",G%HI,haloshift=0, scale=GV%H_to_m)
         call hchksum(eb, "after ePBL eb",G%HI,haloshift=0, scale=GV%H_to_m)
-        call hchksum(Kd_ePBL, "after ePBL Kd_ePBL", G%HI, haloshift=0, scale=GV%Z_to_m**2)
+        call hchksum(Kd_ePBL, "after ePBL Kd_ePBL", G%HI, haloshift=0, scale=US%Z_to_m**2)
       endif
 
     else
@@ -3001,19 +3001,19 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
       Time, "Advective diapycnal salnity flux across interfaces", &
       "psu m s-1")
   CS%id_MLD_003 = register_diag_field('ocean_model', 'MLD_003', diag%axesT1, Time, &
-      'Mixed layer depth (delta rho = 0.03)', 'm', conversion=GV%Z_to_m, &
+      'Mixed layer depth (delta rho = 0.03)', 'm', conversion=US%Z_to_m, &
       cmor_field_name='mlotst', cmor_long_name='Ocean Mixed Layer Thickness Defined by Sigma T', &
       cmor_standard_name='ocean_mixed_layer_thickness_defined_by_sigma_t')
   CS%id_mlotstsq = register_diag_field('ocean_model','mlotstsq',diag%axesT1, Time, &
       long_name='Square of Ocean Mixed Layer Thickness Defined by Sigma T', &
       standard_name='square_of_ocean_mixed_layer_thickness_defined_by_sigma_t', &
-      units='m2', conversion=GV%Z_to_m**2)
+      units='m2', conversion=US%Z_to_m**2)
   CS%id_MLD_0125 = register_diag_field('ocean_model','MLD_0125',diag%axesT1,Time, &
-      'Mixed layer depth (delta rho = 0.125)', 'm', conversion=GV%Z_to_m)
+      'Mixed layer depth (delta rho = 0.125)', 'm', conversion=US%Z_to_m)
   CS%id_subMLN2  = register_diag_field('ocean_model','subML_N2',diag%axesT1,Time, &
       'Squared buoyancy frequency below mixed layer', 's-2')
   CS%id_MLD_user = register_diag_field('ocean_model','MLD_user',diag%axesT1,Time, &
-      'Mixed layer depth (used defined)', 'm', conversion=GV%Z_to_m)
+      'Mixed layer depth (used defined)', 'm', conversion=US%Z_to_m)
   call get_param(param_file, mdl, "DIAG_MLD_DENSITY_DIFF", CS%MLDdensityDifference, &
                  "The density difference used to determine a diagnostic mixed\n"//&
                  "layer depth, MLD_user, following the definition of Levitus 1982. \n"//&
@@ -3065,26 +3065,26 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
   !call set_diffusivity_init(Time, G, param_file, diag, CS%set_diff_CSp, diag_to_Z_CSp, CS%int_tide_CSp)
   CS%id_Kd_interface = register_diag_field('ocean_model', 'Kd_interface', diag%axesTi, Time, &
-      'Total diapycnal diffusivity at interfaces', 'm2 s-1', conversion=GV%Z_to_m**2)
+      'Total diapycnal diffusivity at interfaces', 'm2 s-1', conversion=US%Z_to_m**2)
   if (CS%use_energetic_PBL) then
       CS%id_Kd_ePBL = register_diag_field('ocean_model', 'Kd_ePBL', diag%axesTi, Time, &
-          'ePBL diapycnal diffusivity at interfaces', 'm2 s-1', conversion=GV%Z_to_m**2)
+          'ePBL diapycnal diffusivity at interfaces', 'm2 s-1', conversion=US%Z_to_m**2)
   endif
 
   CS%id_Kd_heat = register_diag_field('ocean_model', 'Kd_heat', diag%axesTi, Time, &
-      'Total diapycnal diffusivity for heat at interfaces', 'm2 s-1', conversion=GV%Z_to_m**2, &
+      'Total diapycnal diffusivity for heat at interfaces', 'm2 s-1', conversion=US%Z_to_m**2, &
        cmor_field_name='difvho',                                                   &
        cmor_standard_name='ocean_vertical_heat_diffusivity',                       &
        cmor_long_name='Ocean vertical heat diffusivity')
   CS%id_Kd_salt = register_diag_field('ocean_model', 'Kd_salt', diag%axesTi, Time, &
-      'Total diapycnal diffusivity for salt at interfaces', 'm2 s-1',  conversion=GV%Z_to_m**2, &
+      'Total diapycnal diffusivity for salt at interfaces', 'm2 s-1',  conversion=US%Z_to_m**2, &
        cmor_field_name='difvso',                                                   &
        cmor_standard_name='ocean_vertical_salt_diffusivity',                       &
        cmor_long_name='Ocean vertical salt diffusivity')
 
   ! CS%useKPP is set to True if KPP-scheme is to be used, False otherwise.
   ! KPP_init() allocated CS%KPP_Csp and also sets CS%KPPisPassive
-  CS%useKPP = KPP_init(param_file, G, GV, diag, Time, CS%KPP_CSp, passive=CS%KPPisPassive)
+  CS%useKPP = KPP_init(param_file, G, GV, US, diag, Time, CS%KPP_CSp, passive=CS%KPPisPassive)
   if (CS%useKPP) then
     allocate( CS%KPP_NLTheat(isd:ied,jsd:jed,nz+1) )   ; CS%KPP_NLTheat(:,:,:)   = 0.
     allocate( CS%KPP_NLTscalar(isd:ied,jsd:jed,nz+1) ) ; CS%KPP_NLTscalar(:,:,:) = 0.
@@ -3283,9 +3283,9 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
   ! CS%use_CVMix_conv is set to True if CVMix convection will be used, otherwise
   ! False.
-  CS%use_CVMix_conv = CVMix_conv_init(Time, G, GV, param_file, diag, CS%CVMix_conv_csp)
+  CS%use_CVMix_conv = CVMix_conv_init(Time, G, GV, US, param_file, diag, CS%CVMix_conv_csp)
 
-  call entrain_diffusive_init(Time, G, GV, param_file, diag, CS%entrain_diffusive_CSp)
+  call entrain_diffusive_init(Time, G, GV, US, param_file, diag, CS%entrain_diffusive_CSp)
 
   ! initialize the geothermal heating module
   if (CS%use_geothermal) &
@@ -3333,7 +3333,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   call regularize_layers_init(Time, G, GV, param_file, diag, CS%regularize_layers_CSp)
 
   if (CS%debug_energy_req) &
-    call diapyc_energy_req_init(Time, G, GV, param_file, diag, CS%diapyc_en_rec_CSp)
+    call diapyc_energy_req_init(Time, G, GV, US, param_file, diag, CS%diapyc_en_rec_CSp)
 
   ! obtain information about the number of bands for penetrative shortwave
   if (use_temperature) then

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1307,7 +1307,6 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
   if (CS%debug_energy_req) &
     call diapyc_energy_req_test(h, dt, tv, G, GV, CS%diapyc_en_rec_CSp)
 
-
   call cpu_clock_begin(id_clock_set_diffusivity)
   call set_BBL_TKE(u, v, h, fluxes, visc, G, GV, CS%set_diff_CSp)
   call cpu_clock_end(id_clock_set_diffusivity)
@@ -3327,7 +3326,7 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
   call regularize_layers_init(Time, G, GV, param_file, diag, CS%regularize_layers_CSp)
 
   if (CS%debug_energy_req) &
-    call diapyc_energy_req_init(Time, G, param_file, diag, CS%diapyc_en_rec_CSp)
+    call diapyc_energy_req_init(Time, G, GV, param_file, diag, CS%diapyc_en_rec_CSp)
 
   ! obtain information about the number of bands for penetrative shortwave
   if (use_temperature) then

--- a/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
+++ b/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
@@ -277,7 +277,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     h_tr(k) = h_in(k)
     htot = htot + h_tr(k)
     pres(K+1) = pres(K) + GV%H_to_Pa * h_tr(k)
-    pres_Z(K+1) = GV%Z_to_m * pres(K+1)
+    pres_Z(K+1) = US%Z_to_m * pres(K+1)
     p_lay(k) = 0.5*(pres(K) + pres(K+1))
     Z_int(K+1) = Z_int(K) - h_tr(k)
   enddo
@@ -1262,10 +1262,11 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
 end subroutine find_PE_chg_orig
 
 !> Initialize parameters and allocate memory associated with the diapycnal energy requirement module.
-subroutine diapyc_energy_req_init(Time, G, GV, param_file, diag, CS)
+subroutine diapyc_energy_req_init(Time, G, GV, US, param_file, diag, CS)
   type(time_type),            intent(in)    :: Time        !< model time
   type(ocean_grid_type),      intent(in)    :: G           !< model grid structure
   type(verticalGrid_type),    intent(in)    :: GV          !< ocean vertical grid structure
+  type(unit_scale_type),      intent(in)    :: US          !< A dimensional unit scaling type
   type(param_file_type),      intent(in)    :: param_file  !< file to parse for parameter values
   type(diag_ctrl),    target, intent(inout) :: diag        !< structure to regulate diagnostic output
   type(diapyc_energy_req_CS), pointer       :: CS          !< module control structure
@@ -1306,10 +1307,10 @@ subroutine diapyc_energy_req_init(Time, G, GV, param_file, diag, CS)
   CS%id_Kddt = register_diag_field('ocean_model', 'EnReqTest_Kddt', diag%axesZi, Time, &
                  "Implicit diffusive coupling coefficient", "m", conversion=GV%H_to_m)
   CS%id_Kd = register_diag_field('ocean_model', 'EnReqTest_Kd', diag%axesZi, Time, &
-                 "Diffusivity in test", "m2 s-1", conversion=GV%Z_to_m**2)
+                 "Diffusivity in test", "m2 s-1", conversion=US%Z_to_m**2)
   CS%id_h   = register_diag_field('ocean_model', 'EnReqTest_h_lay', diag%axesZL, Time, &
                  "Test column layer thicknesses", "m", conversion=GV%H_to_m)
-  CS%id_zInt   = register_diag_field('ocean_model', 'EnReqTest_z_int', diag%axesZi, Time, &
+  CS%id_zInt = register_diag_field('ocean_model', 'EnReqTest_z_int', diag%axesZi, Time, &
                  "Test column layer interface heights", "m", conversion=GV%H_to_m)
   CS%id_CHCt = register_diag_field('ocean_model', 'EnReqTest_CHCt', diag%axesZi, Time, &
                  "Column Height Correction to Energy Requirements, top-down", "J m-2")

--- a/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
+++ b/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
@@ -44,8 +44,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
   type(ocean_grid_type),          intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type),        intent(in)    :: GV   !< The ocean's vertical grid structure.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,GV%ke), &
-                                  intent(in)    :: h_3d !< Layer thickness before entrainment,
-                                                        !! in m or kg m-2.
+                                  intent(in)    :: h_3d !< Layer thickness before entrainment, in H.
   type(thermo_var_ptrs),          intent(inout) :: tv   !< A structure containing pointers to any
                                                         !! available thermodynamic fields.
                                                         !! Absent fields have NULL ptrs.
@@ -60,7 +59,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
     T0, S0, &   ! T0 & S0 are columns of initial temperatures and salinities, in degC and g/kg.
     h_col       ! h_col is a column of thicknesses h at tracer points, in H (m or kg m-2).
   real, dimension(GV%ke+1) :: &
-    Kd, &       ! A column of diapycnal diffusivities at interfaces, in m2 s-1.
+    Kd, &       ! A column of diapycnal diffusivities at interfaces, in Z2 s-1.
     h_top, h_bot ! Distances from the top or bottom, in H.
   real :: ustar, absf, htot
   real :: energy_Kd ! The energy used by diapycnal mixing in W m-2.
@@ -75,7 +74,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
 !$OMP do
   do j=js,je ; do i=is,ie ; if (G%mask2dT(i,j) > 0.5) then
     if (present(Kd_int) .and. .not.CS%use_test_Kh_profile) then
-      do k=1,nz+1 ; Kd(K) = CS%test_Kh_scaling*GV%Z_to_m**2*Kd_int(i,j,K) ; enddo
+      do k=1,nz+1 ; Kd(K) = CS%test_Kh_scaling*Kd_int(i,j,K) ; enddo
     else
       htot = 0.0 ; h_top(1) = 0.0
       do k=1,nz
@@ -95,7 +94,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, CS, Kd_int)
       Kd(1) = 0.0 ; Kd(nz+1) = 0.0
       do K=2,nz
         tmp1 = h_top(K) * h_bot(K) * GV%H_to_Z
-        Kd(K) = CS%test_Kh_scaling * GV%Z_to_m**2 * &
+        Kd(K) = CS%test_Kh_scaling *  &
                 ustar * 0.41 * (tmp1*ustar) / (absf*tmp1 + htot*ustar)
       enddo
     endif
@@ -121,9 +120,8 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
   real, dimension(GV%ke),   intent(in)    :: T_in !< The layer temperatures, in degC.
   real, dimension(GV%ke),   intent(in)    :: S_in !< The layer salinities, in g kg-1.
   real, dimension(GV%ke+1), intent(in)    :: Kd   !< The interfaces diapycnal diffusivities,
-                                                  !! in m2 s-1.
-  real,                     intent(in)    :: dt   !< The amount of time covered by this call,
-                                                  !! in s.
+                                                  !! in Z2 s-1.
+  real,                     intent(in)    :: dt   !< The amount of time covered by this call, in s.
   real,                     intent(out)   :: energy_Kd !< The column-integrated rate of energy
                                                   !! consumption by diapycnal diffusion, in W m-2.
   type(thermo_var_ptrs),    intent(inout) :: tv   !< A structure containing pointers to any
@@ -147,8 +145,8 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     dSV_dS, &   ! Partial derivative of specific volume with salinity, in m3 kg-1 / (g kg-1).
     T0, S0, &   ! Initial temperatures and salinities.
     Te, Se, &   ! Running incomplete estimates of the new temperatures and salinities.
-    Te_a, Se_a, &   ! Running incomplete estimates of the new temperatures and salinities.
-    Te_b, Se_b, &   ! Running incomplete estimates of the new temperatures and salinities.
+    Te_a, Se_a, & ! Running incomplete estimates of the new temperatures and salinities.
+    Te_b, Se_b, & ! Running incomplete estimates of the new temperatures and salinities.
     Tf, Sf, &   ! New final values of the temperatures and salinities.
     dTe, dSe, & ! Running (1-way) estimates of temperature and salinity change.
     dTe_a, dSe_a, & ! Running (1-way) estimates of temperature and salinity change.
@@ -156,21 +154,21 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     Th_a, &     !  An effective temperature times a thickness in the layer above,
                 !  including implicit mixing effects with other yet higher layers, in K H.
     Sh_a, &     !  An effective salinity times a thickness in the layer above,
-                !  including implicit mixing effects with other yet higher layers, in K H.
+                !  including implicit mixing effects with other yet higher layers, in ppt H.
     Th_b, &     !  An effective temperature times a thickness in the layer below,
                 !  including implicit mixing effects with other yet lower layers, in K H.
     Sh_b, &     !  An effective salinity times a thickness in the layer below,
-                !  including implicit mixing effects with other yet lower layers, in K H.
+                !  including implicit mixing effects with other yet lower layers, in ppt H.
     dT_to_dPE, & ! Partial derivative of column potential energy with the temperature
     dS_to_dPE, & ! and salinity changes within a layer, in J m-2 K-1 and J m-2 / (g kg-1).
     dT_to_dColHt, & ! Partial derivatives of the total column height with the temperature
-    dS_to_dColHt, & ! and salinity changes within a layer, in m K-1 and m ppt-1.
+    dS_to_dColHt, & ! and salinity changes within a layer, in Z K-1 and Z ppt-1.
     dT_to_dColHt_a, & ! Partial derivatives of the total column height with the temperature
     dS_to_dColHt_a, & ! and salinity changes within a layer, including the implicit effects
-                    ! of mixing with layers higher in the water colun, in m K-1 and m ppt-1.
+                    ! of mixing with layers higher in the water colun, in Z K-1 and Z ppt-1.
     dT_to_dColHt_b, & ! Partial derivatives of the total column height with the temperature
     dS_to_dColHt_b, & ! and salinity changes within a layer, including the implicit effects
-                    ! of mixing with layers lower in the water colun, in m K-1 and m ppt-1.
+                    ! of mixing with layers lower in the water colun, in Z K-1 and Z ppt-1.
     dT_to_dPE_a, &  ! Partial derivatives of column potential energy with the temperature
     dS_to_dPE_a, &  ! and salinity changes within a layer, including the implicit effects
                     ! of mixing with layers higher in the water column, in
@@ -191,14 +189,18 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
                 ! ensure positive definiteness, in m or kg m-2.
   real, dimension(GV%ke+1) :: &
     pres, &     ! Interface pressures in Pa.
-    z_Int, &    ! Interface heights relative to the surface, in m.
+    pres_Z, &   ! Interface pressures with a rescaling factor to convert interface height
+                ! movements into changes in column potential energy, in J m-2 Z-1.
+    z_Int, &    ! Interface heights relative to the surface, in H.
     N2, &       ! An estimate of the buoyancy frequency in s-2.
-    Kddt_h_a, & !
-    Kddt_h_b, & !
     Kddt_h, &   ! The diapycnal diffusivity times a timestep divided by the
-                ! average thicknesses around a layer, in m or kg m-2.
+                ! average thicknesses around a layer, in H (m or kg m-2).
+    Kddt_h_a, & ! The value of Kddt_h for layers above the central point in the
+                ! tridiagonal solver, in H.
+    Kddt_h_b, & ! The value of Kddt_h for layers below the central point in the
+                ! tridiagonal solver, in H.
     Kd_so_far   ! The value of Kddt_h that has been applied already in
-                ! calculating the energy changes, in m or kg m-2.
+                ! calculating the energy changes, in H (m or kg m-2).
   real, dimension(GV%ke+1,4) :: &
     PE_chg_k, &     ! The integrated potential energy change within a timestep due
                     ! to the diffusivity at interface K for 4 different orders of
@@ -206,14 +208,18 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     ColHt_cor_k     ! The correction to the potential energy change due to
                     ! changes in the net column height, in J m-2.
   real :: &
-    b1              ! b1 is used by the tridiagonal solver, in m-1 or m2 kg-1.
+    b1              ! b1 is used by the tridiagonal solver, in H-1.
   real :: &
-    I_b1            ! The inverse of b1, in m or kg m-2.
-  real :: Kd0, dKd
+    I_b1            ! The inverse of b1, in H.
+  real :: Kd0       ! The value of Kddt_h that has already been applied, in H.
+  real :: dKd       ! The change in the value of Kddt_h, in H.
   real :: h_neglect ! A thickness that is so small it is usually lost
-                    ! in roundoff and can be neglected, in m.
-  real :: dTe_term, dSe_term
-  real :: Kddt_h_guess
+                    ! in roundoff and can be neglected, in H.
+  real :: dTe_term  ! A diffusivity-independent term related to the temperature
+                    ! change in the layer below the interface, in K H.
+  real :: dSe_term  ! A diffusivity-independent term related to the salinity
+                    ! change in the layer below the interface, in ppt H.
+  real :: Kddt_h_guess ! A guess of the final value of Kddt_h, in H.
   real :: dMass     ! The mass per unit area within a layer, in kg m-2.
   real :: dPres     ! The hydrostatic pressure change across a layer, in Pa.
   real :: dMKE_max  ! The maximum amount of mean kinetic energy that could be
@@ -221,12 +227,13 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
                     ! the layer below an interface were homogenized with all of
                     ! the water above the interface, in J m-2 = kg s-2.
   real :: rho_here  ! The in-situ density, in kg m-3.
-  real :: PE_change, ColHt_cor
-  real :: htot
-  real :: dT_k, dT_km1, dS_k, dS_km1  ! Temporary arrays
-  real :: b1Kd                        ! Temporary arrays
-  real :: Kd_rat, Kdr_denom, I_Kdr_denom  ! Temporary arrays
-  real :: dTe_t2, dSe_t2, dT_km1_t2, dS_km1_t2, dT_k_t2, dS_k_t2
+  real :: PE_change ! The change in column potential energy from applying Kddt_h at the
+                    ! present interface, in J m-2.
+  real :: ColHt_cor ! The correction to PE_chg that is made due to a net
+                    ! change in the column height, in J m-2.
+  real :: htot      ! A running sum of thicknesses, in H.
+  real :: dTe_t2, dT_km1_t2, dT_k_t2  ! Temporary arrays describing temperature changes.
+  real :: dSe_t2, dS_km1_t2, dS_k_t2  ! Temporary arrays describing salinity changes.
   logical :: do_print
 
   ! The following are a bunch of diagnostic arrays for debugging purposes.
@@ -243,15 +250,12 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
   real :: PE_chg(6)
   real, dimension(6) :: dT_k_itt, dS_k_itt, dT_km1_itt, dS_km1_itt
 
-  real :: I_G_Earth
-  real :: dKd_rat_dKd, ddT_k_dKd, ddS_k_dKd, ddT_km1_dKd, ddS_km1_dKd
   integer :: k, nz, itt, max_itt, k_cent
   logical :: surface_BL, bottom_BL, central, halves, debug
   logical :: old_PE_calc
   nz = G%ke
   h_neglect = GV%H_subroundoff
 
-  I_G_Earth = 1.0 / (GV%g_Earth*GV%m_to_Z)
   debug = .true.
 
   surface_BL = .true. ; bottom_BL = .true. ; halves = .true.
@@ -264,14 +268,15 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
   dPEb_dKd(:) = 0.0 ; dPEb_dKd_est(:) = 0.0 ; dPEb_dKd_err(:) = 0.0
   dPEb_dKd_err_norm(:) = 0.0 ; dPEb_dKd_trunc(:) = 0.0
 
-  htot = 0.0 ; pres(1) = 0.0 ; Z_int(1) = 0.0
+  htot = 0.0 ; pres(1) = 0.0 ; pres_Z(1) = 0.0 ; Z_int(1) = 0.0
   do k=1,nz
     T0(k) = T_in(k) ; S0(k) = S_in(k)
     h_tr(k) = h_in(k)
     htot = htot + h_tr(k)
     pres(K+1) = pres(K) + GV%H_to_Pa * h_tr(k)
+    pres_Z(K+1) = GV%Z_to_m * pres(K+1)
     p_lay(k) = 0.5*(pres(K) + pres(K+1))
-    Z_int(K+1) = Z_int(K) - GV%H_to_m * h_tr(k)
+    Z_int(K+1) = Z_int(K) - h_tr(k)
   enddo
   do k=1,nz
     h_tr(k) = max(h_tr(k), 1e-15*htot)
@@ -281,7 +286,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
 
   Kddt_h(1) = 0.0 ; Kddt_h(nz+1) = 0.0
   do K=2,nz
-    Kddt_h(K) = min((GV%m_to_H**2*dt)*Kd(k) / (0.5*(h_tr(k-1) + h_tr(k))),1e3*htot)
+    Kddt_h(K) = min((GV%Z_to_H**2*dt)*Kd(k) / (0.5*(h_tr(k-1) + h_tr(k))), 1e3*htot)
   enddo
 
   ! Solve the tridiagonal equations for new temperatures.
@@ -290,11 +295,11 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
 
   do k=1,nz
     dMass = GV%H_to_kg_m2 * h_tr(k)
-    dPres = (GV%g_Earth*GV%m_to_Z) * dMass
+    dPres = GV%H_to_Pa * h_tr(k)
     dT_to_dPE(k) = (dMass * (pres(K) + 0.5*dPres)) * dSV_dT(k)
     dS_to_dPE(k) = (dMass * (pres(K) + 0.5*dPres)) * dSV_dS(k)
-    dT_to_dColHt(k) = dMass * dSV_dT(k) * CS%ColHt_scaling
-    dS_to_dColHt(k) = dMass * dSV_dS(k) * CS%ColHt_scaling
+    dT_to_dColHt(k) = dMass * GV%m_to_Z * dSV_dT(k) * CS%ColHt_scaling
+    dS_to_dColHt(k) = dMass * GV%m_to_Z * dSV_dS(k) * CS%ColHt_scaling
   enddo
 
 !  PE_chg_k(1) = 0.0 ; PE_chg_k(nz+1) = 0.0
@@ -352,14 +357,14 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
         call find_PE_chg_orig(Kddt_h_guess, h_tr(k), hp_a(k-1), &
                          dTe_term, dSe_term, dT_km1_t2, dS_km1_t2, &
                          dT_to_dPE(k), dS_to_dPE(k), dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), &
-                         pres(K), dT_to_dColHt(k), dS_to_dColHt(k), &
+                         pres_Z(K), dT_to_dColHt(k), dS_to_dColHt(k), &
                          dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                          PE_chg_k(k,1), dPEa_dKd(k))
       else
         call find_PE_chg(0.0, Kddt_h_guess, hp_a(k-1), hp_b(k), &
                          Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                          dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                         pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                         pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                          dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                          PE_chg=PE_chg_k(K,1), dPEc_dKd=dPEa_dKd(K), &
                          ColHt_cor=ColHt_cor_k(K,1))
@@ -373,14 +378,14 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
             call find_PE_chg_orig(Kddt_h_guess, h_tr(k), hp_a(k-1), &
                              dTe_term, dSe_term, dT_km1_t2, dS_km1_t2, &
                              dT_to_dPE(k), dS_to_dPE(k), dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), &
-                             pres(K), dT_to_dColHt(k), dS_to_dColHt(k), &
+                             pres_Z(K), dT_to_dColHt(k), dS_to_dColHt(k), &
                              dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                              PE_chg=PE_chg(itt))
           else
             call find_PE_chg(0.0, Kddt_h_guess, hp_a(k-1), hp_b(k), &
                              Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                              dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                             pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                             pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                              dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                              PE_chg=PE_chg(itt))
           endif
@@ -497,14 +502,14 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
         call find_PE_chg_orig(Kddt_h_guess, h_tr(k-1), hp_b(k), &
                          dTe_term, dSe_term, dT_k_t2, dS_k_t2, &
                          dT_to_dPE(k-1), dS_to_dPE(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                         pres(K), dT_to_dColHt(k-1), dS_to_dColHt(k-1), &
+                         pres_Z(K), dT_to_dColHt(k-1), dS_to_dColHt(k-1), &
                          dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                          PE_chg=PE_chg_k(K,2), dPEc_dKd=dPEb_dKd(K))
       else
         call find_PE_chg(0.0, Kddt_h_guess, hp_a(k-1), hp_b(k), &
                          Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                          dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                         pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                         pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                          dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                          PE_chg=PE_chg_k(K,2), dPEc_dKd=dPEb_dKd(K), &
                          ColHt_cor=ColHt_cor_k(K,2))
@@ -519,14 +524,14 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
             call find_PE_chg_orig(Kddt_h_guess, h_tr(k-1), hp_b(k), &
                            dTe_term, dSe_term, dT_k_t2, dS_k_t2, &
                            dT_to_dPE(k-1), dS_to_dPE(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                           pres(K), dT_to_dColHt(k-1), dS_to_dColHt(k-1), &
+                           pres_Z(K), dT_to_dColHt(k-1), dS_to_dColHt(k-1), &
                            dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                            PE_chg=PE_chg(itt))
           else
             call find_PE_chg(0.0, Kddt_h_guess, hp_a(k-1), hp_b(k), &
                              Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                              dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                             pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                             pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                              dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                              PE_chg=PE_chg(itt))
           endif
@@ -618,15 +623,13 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
       endif
       Th_b(k) = h_tr(k) * T0(k) ; Sh_b(k) = h_tr(k) * S0(k)
 
-      Kddt_h_a(K) = 0.0
-      if (K < K_cent) Kddt_h_a(K) = Kddt_h(K)
-
+      Kddt_h_a(K) = 0.0 ; if (K < K_cent) Kddt_h_a(K) = Kddt_h(K)
       dKd = Kddt_h_a(K)
 
       call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                        Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                        dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                       pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                       pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                        dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                        PE_chg=PE_change, ColHt_cor=ColHt_cor)
       PE_chg_k(K,3) = PE_change
@@ -673,7 +676,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
       call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                        Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                        dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                       pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                       pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                        dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                        PE_chg=PE_change, ColHt_cor=ColHt_cor)
       PE_chg_k(K,3) = PE_chg_k(K,3) + PE_change
@@ -720,7 +723,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                      Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                      dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                     pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                     pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                      dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                      PE_chg=PE_change, ColHt_cor=ColHt_cor)
     PE_chg_k(K,3) = PE_chg_k(K,3) + PE_change
@@ -805,7 +808,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
       call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                        Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                        dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                       pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                       pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                        dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                        PE_chg=PE_change, ColHt_cor=ColHt_cor)
 
@@ -853,7 +856,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
       call find_PE_chg(Kd0, dKd, hp_a(k-1), hp_b(k), &
                        Th_a(k-1), Sh_a(k-1), Th_b(k), Sh_b(k), &
                        dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE_b(k), dS_to_dPE_b(k), &
-                       pres(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
+                       pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                        dT_to_dColHt_b(k), dS_to_dColHt_b(k), &
                        PE_chg=PE_change, ColHt_cor=ColHt_cor)
 
@@ -914,9 +917,9 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     if (CS%id_ERb>0) call post_data(CS%id_ERb, PE_chg_k(:,2), CS%diag)
     if (CS%id_ERc>0) call post_data(CS%id_ERc, PE_chg_k(:,3), CS%diag)
     if (CS%id_ERh>0) call post_data(CS%id_ERh, PE_chg_k(:,4), CS%diag)
-    if (CS%id_Kddt>0) call post_data(CS%id_Kddt, GV%H_to_m*Kddt_h, CS%diag)
-    if (CS%id_Kd>0)   call post_data(CS%id_Kd, Kd, CS%diag)
-    if (CS%id_h>0)    call post_data(CS%id_h, GV%H_to_m*h_tr, CS%diag)
+    if (CS%id_Kddt>0) call post_data(CS%id_Kddt, Kddt_h, CS%diag)
+    if (CS%id_Kd>0)   call post_data(CS%id_Kd,   Kd, CS%diag)
+    if (CS%id_h>0)    call post_data(CS%id_h,    h_tr, CS%diag)
     if (CS%id_zInt>0) call post_data(CS%id_zInt, Z_int, CS%diag)
     if (CS%id_CHCt>0) call post_data(CS%id_CHCt, ColHt_cor_k(:,1), CS%diag)
     if (CS%id_CHCb>0) call post_data(CS%id_CHCb, ColHt_cor_k(:,2), CS%diag)
@@ -956,7 +959,7 @@ end subroutine diapyc_energy_req_calc
 !! for several changes in an interfaces's diapycnal diffusivity times a timestep.
 subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
                        dT_to_dPE_a, dS_to_dPE_a, dT_to_dPE_b, dS_to_dPE_b, &
-                       pres, dT_to_dColHt_a, dS_to_dColHt_a, dT_to_dColHt_b, dS_to_dColHt_b, &
+                       pres_Z, dT_to_dColHt_a, dS_to_dColHt_a, dT_to_dColHt_b, dS_to_dColHt_b, &
                        PE_chg, dPEc_dKd, dPE_max, dPEc_dKd_0, ColHt_cor)
   real, intent(in)  :: Kddt_h0  !< The previously used diffusivity at an interface times
                                 !! the time step and  divided by the average of the
@@ -1000,25 +1003,25 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
                                 !! a layer's salinity change to the change in column
                                 !! potential energy, including all implicit diffusive changes
                                 !! in the salinities of all the layers below, in J m-2 ppt-1.
-  real, intent(in)  :: pres     !< The hydrostatic interface pressure, which is used to relate
+  real, intent(in)  :: pres_Z   !< The hydrostatic interface pressure, which is used to relate
                                 !! the changes in column thickness to the energy that is radiated
-                                !! as gravity waves and unavailable to drive mixing, in Pa.
+                                !! as gravity waves and unavailable to drive mixing, in J m-2 Z-1.
   real, intent(in)  :: dT_to_dColHt_a !< A factor (mass_lay*dSColHtc_vol/dT) relating
                                 !! a layer's temperature change to the change in column
                                 !! height, including all implicit diffusive changes
-                                !! in the temperatures of all the layers above, in m K-1.
+                                !! in the temperatures of all the layers above, in Z K-1.
   real, intent(in)  :: dS_to_dColHt_a !< A factor (mass_lay*dSColHtc_vol/dS) relating
                                 !! a layer's salinity change to the change in column
                                 !! height, including all implicit diffusive changes
-                                !! in the salinities of all the layers above, in m ppt-1.
+                                !! in the salinities of all the layers above, in Z ppt-1.
   real, intent(in)  :: dT_to_dColHt_b !< A factor (mass_lay*dSColHtc_vol/dT) relating
                                 !! a layer's temperature change to the change in column
                                 !! height, including all implicit diffusive changes
-                                !! in the temperatures of all the layers below, in m K-1.
+                                !! in the temperatures of all the layers below, in Z K-1.
   real, intent(in)  :: dS_to_dColHt_b !< A factor (mass_lay*dSColHtc_vol/dS) relating
                                 !! a layer's salinity change to the change in column
                                 !! height, including all implicit diffusive changes
-                                !! in the salinities of all the layers below, in m ppt-1.
+                                !! in the salinities of all the layers below, in Z ppt-1.
 
   real, optional, intent(out) :: PE_chg   !< The change in column potential energy from applying
                                           !! Kddt_h at the present interface, in J m-2.
@@ -1066,11 +1069,11 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
     y1 = dKddt_h / (bdt1 * (bdt1 + dKddt_h * hps))
     PE_chg = PEc_core * y1
     ColHt_chg = ColHt_core * y1
-    if (ColHt_chg < 0.0) PE_chg = PE_chg - pres * ColHt_chg
-    if (present(ColHt_cor)) ColHt_cor = -pres * min(ColHt_chg, 0.0)
+    if (ColHt_chg < 0.0) PE_chg = PE_chg - pres_Z * ColHt_chg
+    if (present(ColHt_cor)) ColHt_cor = -pres_Z * min(ColHt_chg, 0.0)
   elseif (present(ColHt_cor)) then
     y1 = dKddt_h / (bdt1 * (bdt1 + dKddt_h * hps))
-    ColHt_cor = -pres * min(ColHt_core * y1, 0.0)
+    ColHt_cor = -pres_Z * min(ColHt_core * y1, 0.0)
   endif
 
   if (present(dPEc_dKd)) then
@@ -1078,7 +1081,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
     y1 = 1.0 / (bdt1 + dKddt_h * hps)**2
     dPEc_dKd = PEc_core * y1
     ColHt_chg = ColHt_core * y1
-    if (ColHt_chg < 0.0) dPEc_dKd = dPEc_dKd - pres * ColHt_chg
+    if (ColHt_chg < 0.0) dPEc_dKd = dPEc_dKd - pres_Z * ColHt_chg
   endif
 
   if (present(dPE_max)) then
@@ -1086,7 +1089,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
     y1 = 1.0 / (bdt1 * hps)
     dPE_max = PEc_core * y1
     ColHt_chg = ColHt_core * y1
-    if (ColHt_chg < 0.0) dPE_max = dPE_max - pres * ColHt_chg
+    if (ColHt_chg < 0.0) dPE_max = dPE_max - pres_Z * ColHt_chg
   endif
 
   if (present(dPEc_dKd_0)) then
@@ -1094,7 +1097,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
     y1 = 1.0 / bdt1**2
     dPEc_dKd_0 = PEc_core * y1
     ColHt_chg = ColHt_core * y1
-    if (ColHt_chg < 0.0) dPEc_dKd_0 = dPEc_dKd_0 - pres * ColHt_chg
+    if (ColHt_chg < 0.0) dPEc_dKd_0 = dPEc_dKd_0 - pres_Z * ColHt_chg
   endif
 
 end subroutine find_PE_chg
@@ -1105,7 +1108,7 @@ end subroutine find_PE_chg
 !! using the original form used in the first version of ePBL.
 subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
                             dT_km1_t2, dS_km1_t2, dT_to_dPE_k, dS_to_dPE_k, &
-                            dT_to_dPEa, dS_to_dPEa, pres, dT_to_dColHt_k, &
+                            dT_to_dPEa, dS_to_dPEa, pres_Z, dT_to_dColHt_k, &
                             dS_to_dColHt_k, dT_to_dColHta, dS_to_dColHta, &
                             PE_chg, dPEc_dKd, dPE_max, dPEc_dKd_0)
   real, intent(in)  :: Kddt_h   !< The diffusivity at an interface times the time step and
@@ -1124,9 +1127,9 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
                                  !! temperature change in the layer above the interface, in K.
   real, intent(in)  :: dS_km1_t2 !< A diffusivity-independent term related to the
                                  !! salinity change in the layer above the interface, in ppt.
-  real, intent(in)  :: pres      !< The hydrostatic interface pressure, which is used to relate
+  real, intent(in)  :: pres_Z    !< The hydrostatic interface pressure, which is used to relate
                                  !! the changes in column thickness to the energy that is radiated
-                                 !! as gravity waves and unavailable to drive mixing, in Pa.
+                                 !! as gravity waves and unavailable to drive mixing, in J m-2 Z-1.
   real, intent(in)  :: dT_to_dPE_k !< A factor (pres_lay*mass_lay*dSpec_vol/dT) relating
                                  !! a layer's temperature change to the change in column
                                  !! potential energy, including all implicit diffusive changes
@@ -1146,19 +1149,19 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
   real, intent(in)  :: dT_to_dColHt_k !< A factor (mass_lay*dSColHtc_vol/dT) relating
                                  !! a layer's temperature change to the change in column
                                  !! height, including all implicit diffusive changes
-                                 !! in the temperatures of all the layers below, in m K-1.
+                                 !! in the temperatures of all the layers below, in Z K-1.
   real, intent(in)  :: dS_to_dColHt_k !< A factor (mass_lay*dSColHtc_vol/dS) relating
                                  !! a layer's salinity change to the change in column
                                  !! height, including all implicit diffusive changes
-                                 !! in the salinities of all the layers below, in m ppt-1.
+                                 !! in the salinities of all the layers below, in Z ppt-1.
   real, intent(in)  :: dT_to_dColHta !< A factor (mass_lay*dSColHtc_vol/dT) relating
                                  !! a layer's temperature change to the change in column
                                  !! height, including all implicit diffusive changes
-                                 !! in the temperatures of all the layers above, in m K-1.
+                                 !! in the temperatures of all the layers above, in Z K-1.
   real, intent(in)  :: dS_to_dColHta !< A factor (mass_lay*dSColHtc_vol/dS) relating
                                  !! a layer's salinity change to the change in column
                                  !! height, including all implicit diffusive changes
-                                 !! in the salinities of all the layers above, in m ppt-1.
+                                 !! in the salinities of all the layers above, in Z ppt-1.
 
   real, optional, intent(out) :: PE_chg   !< The change in column potential energy from applying
                                           !! Kddt_h at the present interface, in J m-2.
@@ -1213,7 +1216,7 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
              (dS_to_dPE_k * dS_k + dS_to_dPEa * dS_km1)
     ColHt_chg = (dT_to_dColHt_k * dT_k + dT_to_dColHta * dT_km1) + &
                 (dS_to_dColHt_k * dS_k + dS_to_dColHta * dS_km1)
-    if (ColHt_chg < 0.0) PE_chg = PE_chg - pres * ColHt_chg
+    if (ColHt_chg < 0.0) PE_chg = PE_chg - pres_Z * ColHt_chg
   endif
 
   if (present(dPEc_dKd)) then
@@ -1230,7 +1233,7 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
                (dS_to_dPE_k * ddS_k_dKd + dS_to_dPEa * ddS_km1_dKd)
     dColHt_dKd = (dT_to_dColHt_k * ddT_k_dKd + dT_to_dColHta * ddT_km1_dKd) + &
                  (dS_to_dColHt_k * ddS_k_dKd + dS_to_dColHta * ddS_km1_dKd)
-    if (dColHt_dKd < 0.0) dPEc_dKd = dPEc_dKd - pres * dColHt_dKd
+    if (dColHt_dKd < 0.0) dPEc_dKd = dPEc_dKd - pres_Z * dColHt_dKd
   endif
 
   if (present(dPE_max)) then
@@ -1241,7 +1244,7 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
     dColHt_max = (dT_to_dColHta * dT_km1_t2 + dS_to_dColHta * dS_km1_t2) + &
               ((dT_to_dColHt_k + dT_to_dColHta) * dTe_term + &
                (dS_to_dColHt_k + dS_to_dColHta) * dSe_term) / (b_den_1 + h_k)
-    if (dColHt_max < 0.0) dPE_max = dPE_max - pres*dColHt_max
+    if (dColHt_max < 0.0) dPE_max = dPE_max - pres_Z*dColHt_max
   endif
 
   if (present(dPEc_dKd_0)) then
@@ -1250,15 +1253,16 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
                  (dT_to_dPE_k * dTe_term + dS_to_dPE_k * dSe_term) / (h_k*b_den_1)
     dColHt_dKd = (dT_to_dColHta * dT_km1_t2 + dS_to_dColHta * dS_km1_t2) / (b_den_1) + &
                  (dT_to_dColHt_k * dTe_term + dS_to_dColHt_k * dSe_term) / (h_k*b_den_1)
-    if (dColHt_dKd < 0.0) dPEc_dKd_0 = dPEc_dKd_0 - pres*dColHt_dKd
+    if (dColHt_dKd < 0.0) dPEc_dKd_0 = dPEc_dKd_0 - pres_Z*dColHt_dKd
   endif
 
 end subroutine find_PE_chg_orig
 
 !> Initialize parameters and allocate memory associated with the diapycnal energy requirement module.
-subroutine diapyc_energy_req_init(Time, G, param_file, diag, CS)
+subroutine diapyc_energy_req_init(Time, G, GV, param_file, diag, CS)
   type(time_type),            intent(in)    :: Time        !< model time
   type(ocean_grid_type),      intent(in)    :: G           !< model grid structure
+  type(verticalGrid_type),    intent(in)    :: GV          !< ocean vertical grid structure
   type(param_file_type),      intent(in)    :: param_file  !< file to parse for parameter values
   type(diag_ctrl),    target, intent(inout) :: diag        !< structure to regulate diagnostic output
   type(diapyc_energy_req_CS), pointer       :: CS          !< module control structure
@@ -1297,13 +1301,13 @@ subroutine diapyc_energy_req_init(Time, G, param_file, diag, CS)
   CS%id_ERh = register_diag_field('ocean_model', 'EnReqTest_ERh', diag%axesZi, Time, &
                  "Diffusivity Energy Requirements, halves", "J m-2")
   CS%id_Kddt = register_diag_field('ocean_model', 'EnReqTest_Kddt', diag%axesZi, Time, &
-                 "Implicit diffusive coupling coefficient", "m")
+                 "Implicit diffusive coupling coefficient", "m", conversion=GV%H_to_m)
   CS%id_Kd = register_diag_field('ocean_model', 'EnReqTest_Kd', diag%axesZi, Time, &
-                 "Diffusivity in test", "m2 s-1")
+                 "Diffusivity in test", "m2 s-1", conversion=GV%Z_to_m**2)
   CS%id_h   = register_diag_field('ocean_model', 'EnReqTest_h_lay', diag%axesZL, Time, &
-                 "Test column layer thicknesses", "m")
+                 "Test column layer thicknesses", "m", conversion=GV%H_to_m)
   CS%id_zInt   = register_diag_field('ocean_model', 'EnReqTest_z_int', diag%axesZi, Time, &
-                 "Test column layer interface heights", "m")
+                 "Test column layer interface heights", "m", conversion=GV%H_to_m)
   CS%id_CHCt = register_diag_field('ocean_model', 'EnReqTest_CHCt', diag%axesZi, Time, &
                  "Column Height Correction to Energy Requirements, top-down", "J m-2")
   CS%id_CHCb = register_diag_field('ocean_model', 'EnReqTest_CHCb', diag%axesZi, Time, &

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -550,7 +550,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
 
 
 !!OMP parallel do default(none) shared(js,je,nz,is,ie,h_3d,u_3d,v_3d,tv,dt,      &
-!!OMP                                  CS,G,GV,fluxes,IdtdR0,                    &
+!!OMP                                  CS,G,GV,US,fluxes,IdtdR0,                 &
 !!OMP                                  TKE_forced,debug,H_neglect,dSV_dT,        &
 !!OMP                                  dSV_dS,I_dtrho,C1_3,h_tt_min,vonKar,      &
 !!OMP                                  max_itt,Kd_int)                           &

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -248,22 +248,22 @@ subroutine entrainment_diffusive(u, v, h, tv, fluxes, dt, G, GV, US, CS, ea, eb,
     pres(:) = 0.0
   endif
 
-!$OMP parallel do default(none) shared(is,ie,js,je,nz,Kd_Lay,G,GV,dt,Kd_int,CS,h,tv, &
-!$OMP                                  kmb,Angstrom,fluxes,K2,h_neglect,tolerance, &
-!$OMP                                  ea,eb,correct_density,Kd_eff,diff_work,     &
-!$OMP                                  g_2dt, kb_out)                              &
-!$OMP                     firstprivate(kb,ds_dsp1,dsp1_ds,pres,kb_min)             &
-!$OMP                          private(dtKd,dtKd_int,do_i,Ent_bl,dtKd_kb,h_bl,     &
-!$OMP                                  I2p2dsp1_ds,grats,htot,max_eakb,I_dSkbp1,   &
-!$OMP                                  zeros,maxF_kb,maxF,ea_kbp1,eakb,Sref,       &
-!$OMP                                  maxF_correct,do_any,                        &
-!$OMP                                  err_min_eakb0,err_max_eakb0,eakb_maxF,      &
-!$OMP                                  min_eakb,err_eakb0,F,minF,hm,fk,F_kb_maxent,&
-!$OMP                                  F_kb,is1,ie1,kb_min_act,dFdfm_kb,b1,dFdfm,  &
-!$OMP                                  Fprev,fm,fr,c1,reiterate,eb_kmb,did_i,      &
-!$OMP                                  h_avail,h_guess,dS_kb,Rcv,F_cor,dS_kb_eff,  &
-!$OMP                                  Rho_cor,ea_cor,h1,Idt,Kd_here,pressure,     &
-!$OMP                                  T_eos,S_eos,dRho_dT,dRho_dS,dRho,dS_anom_lim)
+  !$OMP parallel do default(none) shared(is,ie,js,je,nz,Kd_Lay,G,GV,US,dt,CS,h,tv,   &
+  !$OMP                                  kmb,Angstrom,fluxes,K2,h_neglect,tolerance, &
+  !$OMP                                  ea,eb,correct_density,Kd_int,Kd_eff,        &
+  !$OMP                                  diff_work,g_2dt, kb_out)                    &
+  !$OMP                     firstprivate(kb,ds_dsp1,dsp1_ds,pres,kb_min)             &
+  !$OMP                          private(dtKd,dtKd_int,do_i,Ent_bl,dtKd_kb,h_bl,     &
+  !$OMP                                  I2p2dsp1_ds,grats,htot,max_eakb,I_dSkbp1,   &
+  !$OMP                                  zeros,maxF_kb,maxF,ea_kbp1,eakb,Sref,       &
+  !$OMP                                  maxF_correct,do_any,                        &
+  !$OMP                                  err_min_eakb0,err_max_eakb0,eakb_maxF,      &
+  !$OMP                                  min_eakb,err_eakb0,F,minF,hm,fk,F_kb_maxent,&
+  !$OMP                                  F_kb,is1,ie1,kb_min_act,dFdfm_kb,b1,dFdfm,  &
+  !$OMP                                  Fprev,fm,fr,c1,reiterate,eb_kmb,did_i,      &
+  !$OMP                                  h_avail,h_guess,dS_kb,Rcv,F_cor,dS_kb_eff,  &
+  !$OMP                                  Rho_cor,ea_cor,h1,Idt,Kd_here,pressure,     &
+  !$OMP                                  T_eos,S_eos,dRho_dT,dRho_dS,dRho,dS_anom_lim)
   do j=js,je
     do i=is,ie ; kb(i) = 1 ; enddo
 

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -9,6 +9,7 @@ use MOM_error_handler, only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs
@@ -41,10 +42,11 @@ contains
 !! the buoyancy flux in a layer and inversely proportional to the density
 !! differences between layers.  The scheme that is used here is described in
 !! detail in Hallberg, Mon. Wea. Rev. 2000.
-subroutine entrainment_diffusive(u, v, h, tv, fluxes, dt, G, GV, CS, ea, eb, &
+subroutine entrainment_diffusive(u, v, h, tv, fluxes, dt, G, GV, US, CS, ea, eb, &
                                  kb_out, Kd_Lay, Kd_int)
   type(ocean_grid_type),      intent(in)  :: G  !< The ocean's grid structure.
   type(verticalGrid_type),    intent(in)  :: GV !< The ocean's vertical grid structure.
+  type(unit_scale_type),      intent(in)  :: US !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)),  &
                               intent(in)  :: u  !< The zonal velocity, in m s-1.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)),  &
@@ -381,7 +383,7 @@ subroutine entrainment_diffusive(u, v, h, tv, fluxes, dt, G, GV, CS, ea, eb, &
         htot(i) = h(i,j,1) - Angstrom
       enddo
       if (associated(fluxes%buoy)) then ; do i=is,ie
-        maxF(i,1) = (dt*fluxes%buoy(i,j)) / (GV%g_prime(2)*GV%m_to_Z)
+        maxF(i,1) = (dt*fluxes%buoy(i,j)) / (GV%g_prime(2)*US%m_to_Z)
       enddo ; endif
     endif
 

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -2135,10 +2135,11 @@ end subroutine find_maxF_kb
 
 !> This subroutine initializes the parameters and memory associated with the
 !! entrain_diffusive module.
-subroutine entrain_diffusive_init(Time, G, GV, param_file, diag, CS)
+subroutine entrain_diffusive_init(Time, G, GV, US, param_file, diag, CS)
   type(time_type),         intent(in)    :: Time !< The current model time.
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time
                                                  !! parameters.
   type(diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic
@@ -2191,9 +2192,9 @@ subroutine entrain_diffusive_init(Time, G, GV, param_file, diag, CS)
                  units="m", default=MAX(100.0*GV%Angstrom_m,1.0e-4*sqrt(dt*Kd)), scale=GV%m_to_H)
 
   CS%id_Kd = register_diag_field('ocean_model', 'Kd_effective', diag%axesTL, Time, &
-      'Diapycnal diffusivity as applied', 'm2 s-1', conversion=GV%Z_to_m**2)
+      'Diapycnal diffusivity as applied', 'm2 s-1', conversion=US%Z_to_m**2)
   CS%id_diff_work = register_diag_field('ocean_model', 'diff_work', diag%axesTi, Time, &
-      'Work actually done by diapycnal diffusion across each interface', 'W m-2', conversion=GV%Z_to_m)
+      'Work actually done by diapycnal diffusion across each interface', 'W m-2', conversion=US%Z_to_m)
 
 end subroutine entrain_diffusive_init
 

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -15,6 +15,7 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : slasher, vardesc, MOM_read_data
 use MOM_thickness_diffuse, only : vert_fill_TS
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs, vertvisc_type, p3d
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs
@@ -54,9 +55,10 @@ end type int_tide_input_type
 contains
 
 !> Sets the model-state dependent internal tide energy sources.
-subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, CS)
+subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, US, CS)
   type(ocean_grid_type),                     intent(in)    :: G  !< The ocean's grid structure
   type(verticalGrid_type),                   intent(in)    :: GV !< The ocean's vertical grid structure
+  type(unit_scale_type),                     intent(in)    :: US !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)    :: u  !< The zonal velocity, in m s-1
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)    :: v  !< The meridional velocity, in m s-1
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in)    :: h  !< Layer thicknesses, in H (usually m or kg m-2)
@@ -88,7 +90,7 @@ subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, CS)
   if (.not.associated(CS)) call MOM_error(FATAL,"set_diffusivity: "//&
          "Module must be initialized before it is used.")
 
-  kappa_fill = 1.e-3*GV%m_to_Z**2 !### Dimensional constant in m2 s-1.
+  kappa_fill = 1.e-3*US%m_to_Z**2 !### Dimensional constant in m2 s-1.
   dt_fill    = 7200.              !### Dimensionalconstant in s.
 
   use_EOS = associated(tv%eqn_of_state)
@@ -98,7 +100,7 @@ subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, CS)
     call vert_fill_TS(h, tv%T, tv%S, kappa_fill, dt_fill, T_f, S_f, G, GV)
   endif
 
-  call find_N2_bottom(h, tv, T_f, S_f, itide%h2, fluxes, G, GV, N2_bot)
+  call find_N2_bottom(h, tv, T_f, S_f, itide%h2, fluxes, G, GV, US, N2_bot)
 
 !$OMP parallel do default(none) shared(is,ie,js,je,G,itide,N2_bot,CS)
   do j=js,je ; do i=is,ie
@@ -118,9 +120,10 @@ subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, CS)
 end subroutine set_int_tide_input
 
 !> Estimates the near-bottom buoyancy frequency (N^2).
-subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, N2_bot)
+subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, US, N2_bot)
   type(ocean_grid_type),                    intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type),                  intent(in)  :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),                    intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)  :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   type(thermo_var_ptrs),                    intent(in)  :: tv   !< A structure containing pointers to the
                                                                 !! thermodynamic fields
@@ -153,7 +156,7 @@ subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, N2_bot)
   logical :: do_i(SZI_(G)), do_any
   integer :: i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
-  G_Rho0 = (GV%g_Earth*GV%m_to_Z**2) / GV%Rho0
+  G_Rho0 = (GV%g_Earth*US%m_to_Z**2) / GV%Rho0
 
   ! Find the (limited) density jump across each interface.
   do i=is,ie
@@ -232,10 +235,11 @@ subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, N2_bot)
 end subroutine find_N2_bottom
 
 !> Initializes the data related to the internal tide input module
-subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
+subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
   type(time_type),           intent(in)    :: Time !< The current model time
   type(ocean_grid_type),     intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),   intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),     intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),     intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(diag_ctrl),   target, intent(inout) :: diag !< structure used to regulate diagnostic output.
   type(int_tide_input_CS),   pointer       :: CS   !< This module's control structure, which is initialized here.
@@ -286,7 +290,7 @@ subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
 
   call get_param(param_file, mdl, "MIN_ZBOT_ITIDES", min_zbot_itides, &
                "Turn off internal tidal dissipation when the total \n"//&
-               "ocean depth is less than this value.", units="m", default=0.0, scale=GV%m_to_Z)
+               "ocean depth is less than this value.", units="m", default=0.0, scale=US%m_to_Z)
 
   call get_param(param_file, mdl, "UTIDE", utide, &
                "The constant tidal amplitude used with INT_TIDE_DISSIPATION.", &
@@ -329,7 +333,7 @@ subroutine int_tide_input_init(Time, G, GV, param_file, diag, CS, itide)
                fail_if_missing=.true.)
   filename = trim(CS%inputdir) // trim(h2_file)
   call log_param(param_file, mdl, "INPUTDIR/H2_FILE", filename)
-  call MOM_read_data(filename, 'h2', itide%h2, G%domain, timelevel=1, scale=GV%m_to_Z**2)
+  call MOM_read_data(filename, 'h2', itide%h2, G%domain, timelevel=1, scale=US%m_to_Z**2)
 
   do j=js,je ; do i=is,ie
     mask_itidal = 1.0

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -347,7 +347,7 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
 
     ! Compute the fixed part of internal tidal forcing; units are [J m-2] here.
     CS%TKE_itidal_coef(i,j) = 0.5*kappa_h2_factor*GV%Rho0*&
-         kappa_itides * GV%Z_to_m**2*itide%h2(i,j) * itide%tideamp(i,j)**2
+         kappa_itides * US%Z_to_m**2*itide%h2(i,j) * itide%tideamp(i,j)**2
   enddo ; enddo
 
 

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -204,7 +204,7 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
 #ifdef ADD_DIAGNOSTICS
   !$OMP                                I_Ld2_3d,dz_Int_3d, &
 #endif
-  !$OMP                                tv,G,GV,CS,kappa_io,dz_massless,k0dt,p_surf,dt,tke_io,kv_io)
+  !$OMP                                tv,G,GV,US,CS,kappa_io,dz_massless,k0dt,p_surf,dt,tke_io,kv_io)
   do j=js,je
     do k=1,nz ; do i=is,ie
       h_2d(i,k) = h(i,j,k)*GV%H_to_Z
@@ -501,7 +501,7 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
 #ifdef ADD_DIAGNOSTICS
   !$OMP                                I_Ld2_3d,dz_Int_3d, &
 #endif
-  !$OMP                                tv,G,GV,CS,kappa_io,dz_massless,k0dt,p_surf,dt,tke_io,kv_io)
+  !$OMP                                tv,G,GV,US,CS,kappa_io,dz_massless,k0dt,p_surf,dt,tke_io,kv_io)
   do J=JsB,JeB
     J2 = mod(J,2)+1 ; J2m1 = 3-J2 ! = mod(J-1,2)+1
 

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -11,6 +11,7 @@ use MOM_debugging, only : hchksum, Bchksum
 use MOM_error_handler, only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs
@@ -87,9 +88,10 @@ contains
 
 !> Subroutine for calculating shear-driven diffusivity and TKE in tracer columns
 subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
-                                 kv_io, dt, G, GV, CS, initialize_all)
+                                 kv_io, dt, G, GV, US, CS, initialize_all)
   type(ocean_grid_type),   intent(in)    :: G      !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV     !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   &
                            intent(in)    :: u_in   !< Initial zonal velocity, in m s-1. (Intent in)
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   &
@@ -293,14 +295,14 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
     ! Set the initial guess for kappa, here defined at interfaces.
     ! ----------------------------------------------------
       if (new_kappa) then
-        do K=1,nzc+1 ; kappa(K) = GV%m_to_Z**2*1.0 ; enddo
+        do K=1,nzc+1 ; kappa(K) = US%m_to_Z**2*1.0 ; enddo
       else
         do K=1,nzc+1 ; kappa(K) = kappa_2d(i,K) ; enddo
       endif
 
       call kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
                               dz, u0xdz, v0xdz, T0xdz, S0xdz, kappa_avg, &
-                              tke_avg, tv, CS, GV)
+                              tke_avg, tv, CS, GV, US)
 
     ! call cpu_clock_begin(id_clock_setup)
     ! Extrapolate from the vertically reduced grid back to the original layers.
@@ -375,9 +377,10 @@ end subroutine Calculate_kappa_shear
 
 !> Subroutine for calculating shear-driven diffusivity and TKE in corner columns
 subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_io, tke_io, &
-                                   kv_io, dt, G, GV, CS, initialize_all)
+                                   kv_io, dt, G, GV, US, CS, initialize_all)
   type(ocean_grid_type),   intent(in)    :: G      !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV     !< The ocean's vertical grid structure.
+  type(unit_scale_type),    intent(in)   :: US     !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)),   &
                            intent(in)    :: u_in   !< Initial zonal velocity, in m s-1. (Intent in)
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)),   &
@@ -619,14 +622,14 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
     ! Set the initial guess for kappa, here defined at interfaces.
     ! ----------------------------------------------------
       if (new_kappa) then
-        do K=1,nzc+1 ; kappa(K) = GV%m_to_Z**2*1.0 ; enddo
+        do K=1,nzc+1 ; kappa(K) = US%m_to_Z**2*1.0 ; enddo
       else
         do K=1,nzc+1 ; kappa(K) = kappa_2d(I,K,J2) ; enddo
       endif
 
       call kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
                               dz, u0xdz, v0xdz, T0xdz, S0xdz, kappa_avg, &
-                              tke_avg, tv, CS, GV)
+                              tke_avg, tv, CS, GV, US)
 
     ! call cpu_clock_begin(Id_clock_setup)
     ! Extrapolate from the vertically reduced grid back to the original layers.
@@ -707,8 +710,9 @@ end subroutine Calc_kappa_shear_vertex
 !> This subroutine calculates shear-driven diffusivity and TKE in a single column
 subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
                               dz, u0xdz, v0xdz, T0xdz, S0xdz, kappa_avg, &
-                              tke_avg, tv, CS, GV)
+                              tke_avg, tv, CS, GV, US)
   type(verticalGrid_type), intent(in)    :: GV !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   real, dimension(SZK_(GV)+1), &
                      intent(inout) :: kappa !< The time-weighted average of kappa, in Z2 s-1.
   real, dimension(SZK_(GV)+1), &
@@ -817,7 +821,7 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
   integer :: k, itt, itt_dt
 
   Ri_crit = CS%Rino_crit
-  gR0 = GV%Rho0*(GV%g_Earth*GV%m_to_Z) ; g_R0 = (GV%g_Earth*GV%m_to_Z**2)/GV%Rho0
+  gR0 = GV%Rho0*(GV%g_Earth*US%m_to_Z) ; g_R0 = (GV%g_Earth*US%m_to_Z**2)/GV%Rho0
   k0dt = dt*CS%kappa_0
   ! These are hard-coded for now.  Perhaps these could be made dynamic later?
   ! tol_dksrc = 0.5*tol_ksrc_chg ; tol_dksrc_low = 1.0 - 1.0/tol_ksrc_chg ?
@@ -963,7 +967,7 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
 
   ! This call just calculates N2 and S2.
   call calculate_projected_state(kappa, u, v, T, Sal, 0.0, nzc, dz, I_dz_int, &
-                                 dbuoy_dT, dbuoy_dS, u, v, T, Sal, GV, &
+                                 dbuoy_dT, dbuoy_dS, u, v, T, Sal, GV, US, &
                                  N2=N2, S2=S2, vel_underflow=CS%vel_underflow)
 ! ----------------------------------------------------
 ! Iterate
@@ -1034,7 +1038,7 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
         ! enough.
         call calculate_projected_state(kappa_out, u, v, T, Sal, 0.5*dt_test, nzc, dz, I_dz_int, &
                                        dbuoy_dT, dbuoy_dS, u_test, v_test, T_test, S_test, &
-                                       GV, N2, S2, ks_int=ks_kappa, ke_int=ke_kappa, &
+                                       GV, US, N2, S2, ks_int=ks_kappa, ke_int=ke_kappa, &
                                        vel_underflow=CS%vel_underflow)
         valid_dt = .true.
         Idtt = 1.0 / dt_test
@@ -1061,7 +1065,7 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
         do itt_dt=1,dt_refinements
           call calculate_projected_state(kappa_out, u, v, T, Sal, 0.5*(dt_test+dt_inc), &
                    nzc, dz, I_dz_int, dbuoy_dT, dbuoy_dS, u_test, v_test, T_test, S_test, &
-                   GV, N2, S2, ks_int=ks_kappa, ke_int=ke_kappa, vel_underflow=CS%vel_underflow)
+                   GV, US, N2, S2, ks_int=ks_kappa, ke_int=ke_kappa, vel_underflow=CS%vel_underflow)
           valid_dt = .true.
           Idtt = 1.0 / (dt_test+dt_inc)
           do K=max(ks_kappa-1,2),min(ke_kappa+1,nzc)
@@ -1114,7 +1118,7 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
     ! call cpu_clock_begin(id_clock_project)
       call calculate_projected_state(kappa_out, u, v, T, Sal, dt_now, nzc, dz, I_dz_int, &
                                      dbuoy_dT, dbuoy_dS, u_test, v_test, T_test, S_test, &
-                                     GV, N2=N2, S2=S2, ks_int=ks_kappa, ke_int=ke_kappa, &
+                                     GV, US, N2=N2, S2=S2, ks_int=ks_kappa, ke_int=ke_kappa, &
                                      vel_underflow=CS%vel_underflow)
     ! call cpu_clock_end(id_clock_project)
 
@@ -1134,7 +1138,7 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
     ! call cpu_clock_begin(id_clock_project)
       call calculate_projected_state(kappa_mid, u, v, T, Sal, dt_now, nzc, dz, I_dz_int, &
                                      dbuoy_dT, dbuoy_dS, u_test, v_test, T_test, S_test, &
-                                     GV, N2=N2, S2=S2, ks_int=ks_kappa, ke_int=ke_kappa, &
+                                     GV, US, N2=N2, S2=S2, ks_int=ks_kappa, ke_int=ke_kappa, &
                                      vel_underflow=CS%vel_underflow)
     ! call cpu_clock_end(id_clock_project)
 
@@ -1159,7 +1163,7 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
     ! call cpu_clock_begin(id_clock_project)
       call calculate_projected_state(kappa_mid, u, v, T, Sal, dt_now, nzc, &
                                      dz, I_dz_int, dbuoy_dT, dbuoy_dS, u, v, T, Sal, &
-                                     GV, N2, S2, vel_underflow=CS%vel_underflow)
+                                     GV, US, N2, S2, vel_underflow=CS%vel_underflow)
     ! call cpu_clock_end(id_clock_project)
     endif
 
@@ -1210,7 +1214,7 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
           if (abs(dkappa_it1(K,itt-1)) > 1e-20) &
             d_dkappa_it1(K,itt) = dkappa_it1(K,itt) / dkappa_it1(K,itt-1)
         endif
-        dkappa_norm(K,itt) = dkap(K) / max(0.5*(kappa_pred(K) + kappa_out(K)), GV%m_to_Z**2*1e-100)
+        dkappa_norm(K,itt) = dkap(K) / max(0.5*(kappa_pred(K) + kappa_out(K)), US%m_to_Z**2*1e-100)
       enddo
     endif
 #endif
@@ -1226,7 +1230,7 @@ end subroutine kappa_shear_column
 !! may also calculate the projected buoyancy frequency and shear.
 subroutine calculate_projected_state(kappa, u0, v0, T0, S0, dt, nz, &
                                      dz, I_dz_int, dbuoy_dT, dbuoy_dS, &
-                                     u, v, T, Sal, GV, N2, S2, ks_int, ke_int, vel_underflow)
+                                     u, v, T, Sal, GV, US, N2, S2, ks_int, ke_int, vel_underflow)
   integer,               intent(in)    :: nz  !< The number of layers (after eliminating massless
                                               !! layers?).
   real, dimension(nz+1), intent(in)    :: kappa !< The diapycnal diffusivity at interfaces,
@@ -1248,6 +1252,7 @@ subroutine calculate_projected_state(kappa, u0, v0, T0, S0, dt, nz, &
   real, dimension(nz),   intent(inout) :: T   !< The temperature after dt, in C.
   real, dimension(nz),   intent(inout) :: Sal !< The salinity after dt, in PSU.
   type(verticalGrid_type), intent(in)  :: GV  !< The ocean's vertical grid structure.
+  type(unit_scale_type), intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(nz+1), optional, &
                          intent(inout) :: N2  !< The buoyancy frequency squared at interfaces,
                                               !! in s-2.
@@ -1334,7 +1339,7 @@ subroutine calculate_projected_state(kappa, u0, v0, T0, S0, dt, nz, &
   endif
 
   if (present(S2)) then
-    L2_to_Z2 = GV%m_to_Z**2
+    L2_to_Z2 = US%m_to_Z**2
     S2(1) = 0.0 ; S2(nz+1) = 0.0
     if (ks > 1) &
       S2(ks) = ((u(ks)-u0(ks-1))**2 + (v(ks)-v0(ks-1))**2) * (L2_to_Z2*I_dz_int(ks)**2)
@@ -1978,10 +1983,11 @@ subroutine find_kappa_tke(N2, S2, kappa_in, Idz, dz_Int, I_L2_bdry, f2, &
 end subroutine find_kappa_tke
 
 !> This subroutineinitializesthe parameters that regulate shear-driven mixing
-function kappa_shear_init(Time, G, GV, param_file, diag, CS)
+function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
   type(time_type),         intent(in)    :: Time !< The current model time.
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time
                                                  !! parameters.
   type(diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic
@@ -2040,7 +2046,7 @@ function kappa_shear_init(Time, G, GV, param_file, diag, CS)
                  "The background diffusivity that is used to smooth the \n"//&
                  "density and shear profiles before solving for the \n"//&
                  "diffusivities. Defaults to value of KD.", &
-                 units="m2 s-1", default=KD_normal, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=KD_normal, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "FRI_CURVATURE", CS%FRi_curvature, &
                  "The nondimensional curvature of the function of the \n"//&
                  "Richardson number in the kappa source term in the \n"//&
@@ -2125,7 +2131,7 @@ function kappa_shear_init(Time, G, GV, param_file, diag, CS)
       'Shear-driven Turbulent Kinetic Energy', 'm2 s-2')
 #ifdef ADD_DIAGNOSTICS
   CS%id_ILd2 = register_diag_field('ocean_model','ILd2_shear',diag%axesTi,Time, &
-      'Inverse kappa decay scale at interfaces', 'm-2', conversion=GV%m_to_Z**2)
+      'Inverse kappa decay scale at interfaces', 'm-2', conversion=US%m_to_Z**2)
   CS%id_dz_Int = register_diag_field('ocean_model','dz_Int_shear',diag%axesTi,Time, &
       'Finite volume thickness of interfaces', 'm', conversion=GV%Z_to_m)
 #endif

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -1708,7 +1708,7 @@ subroutine set_BBL_TKE(u, v, h, fluxes, visc, G, GV, US, CS)
 
   cdrag_sqrt = sqrt(CS%cdrag)
 
-!$OMP parallel default(none) shared(cdrag_sqrt,is,ie,js,je,nz,visc,CS,G,GV,vstar,h,v, &
+!$OMP parallel default(none) shared(cdrag_sqrt,is,ie,js,je,nz,visc,CS,G,GV,US,vstar,h,v, &
 !$OMP                               v2_bbl,u) &
 !$OMP                       private(do_i,vhtot,htot,domore,hvel,uhtot,ustar,u2_bbl)
 !$OMP do

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -32,6 +32,7 @@ use MOM_bkgnd_mixing,        only : calculate_bkgnd_mixing, bkgnd_mixing_init, b
 use MOM_bkgnd_mixing,        only : bkgnd_mixing_end, sfc_bkgnd_mixing
 use MOM_string_functions,    only : uppercase
 use MOM_thickness_diffuse,   only : vert_fill_TS
+use MOM_unit_scaling,        only : unit_scale_type
 use MOM_variables,           only : thermo_var_ptrs, vertvisc_type, p3d
 use MOM_verticalGrid,        only : verticalGrid_type
 use user_change_diffusivity, only : user_change_diff, user_change_diff_init
@@ -196,9 +197,10 @@ contains
 !! visc%Kv_slow. Vertical viscosity due to shear-driven mixing is passed via
 !! visc%Kv_shear
 subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
-                           G, GV, CS, Kd_lay, Kd_int)
+                           G, GV, US, CS, Kd_lay, Kd_int)
   type(ocean_grid_type),     intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type),   intent(in)    :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),     intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                              intent(in)    :: u    !< The zonal velocity, in m s-1.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -276,7 +278,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
          "Module must be initialized before it is used.")
 
   I_Rho0     = 1.0/GV%Rho0
-  kappa_fill = 1.e-3*GV%m_to_Z**2 !### Dimensional constant in m2 s-1.
+  kappa_fill = 1.e-3*US%m_to_Z**2 !### Dimensional constant in m2 s-1.
   dt_fill    = 7200.              !### Dimensionalconstant in s.
   Omega2     = CS%Omega*CS%Omega
 
@@ -349,7 +351,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
                            GV%Z_to_H**2*kappa_fill*dt_fill, halo=1)
 
       call calc_kappa_shear_vertex(u, v, h, T_adj, S_adj, tv, fluxes%p_surf, visc%Kd_shear, &
-                                   visc%TKE_turb, visc%Kv_shear_Bu, dt, G, GV, CS%kappaShear_CSp)
+                                   visc%TKE_turb, visc%Kv_shear_Bu, dt, G, GV, US, CS%kappaShear_CSp)
       if (associated(visc%Kv_shear)) visc%Kv_shear(:,:,:) = 0.0 ! needed for other parameterizations
       if (CS%debug) then
         call hchksum(visc%Kd_shear, "after calc_KS_vert visc%Kd_shear", G%HI, scale=GV%Z_to_m**2)
@@ -360,7 +362,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
       ! Changes: visc%Kd_shear, visc%TKE_turb (not clear that TKE_turb is used as input ????)
       ! Sets visc%Kv_shear
       call calculate_kappa_shear(u_h, v_h, h, tv, fluxes%p_surf, visc%Kd_shear, visc%TKE_turb, &
-                                 visc%Kv_shear, dt, G, GV, CS%kappaShear_CSp)
+                                 visc%Kv_shear, dt, G, GV, US, CS%kappaShear_CSp)
       if (CS%debug) then
         call hchksum(visc%Kd_shear, "after calc_KS visc%Kd_shear", G%HI, scale=GV%Z_to_m**2)
         call hchksum(visc%Kv_shear, "after calc_KS visc%Kv_shear", G%HI, scale=GV%Z_to_m**2)
@@ -371,7 +373,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
     if (showCallTree) call callTree_waypoint("done with calculate_kappa_shear (set_diffusivity)")
   elseif (CS%use_CVMix_shear) then
     !NOTE{BGR}: this needs to be cleaned up.  It works in 1D case, but has not been tested outside.
-    call calculate_CVMix_shear(u_h, v_h, h, tv, visc%Kd_shear, visc%Kv_shear, G, GV, CS%CVMix_shear_CSp)
+    call calculate_CVMix_shear(u_h, v_h, h, tv, visc%Kd_shear, visc%Kv_shear, G, GV, US, CS%CVMix_shear_CSp)
     if (CS%debug) then
       call hchksum(visc%Kd_shear, "after CVMix_shear visc%Kd_shear", G%HI, scale=GV%Z_to_m**2)
       call hchksum(visc%Kv_shear, "after CVMix_shear visc%Kv_shear", G%HI, scale=GV%Z_to_m**2)
@@ -392,18 +394,18 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   do j=js,je
 
     ! Set up variables related to the stratification.
-    call find_N2(h, tv, T_f, S_f, fluxes, j, G, GV, CS, dRho_int, N2_lay, N2_int, N2_bot)
+    call find_N2(h, tv, T_f, S_f, fluxes, j, G, GV, US, CS, dRho_int, N2_lay, N2_int, N2_bot)
 
     if (associated(dd%N2_3d)) then
       do K=1,nz+1 ; do i=is,ie ; dd%N2_3d(i,j,K) = N2_int(i,K) ; enddo ; enddo
     endif
 
     ! Add background mixing
-    call calculate_bkgnd_mixing(h, tv, N2_lay, Kd_lay, visc%Kv_slow, j, G, GV, CS%bkgnd_mixing_csp)
+    call calculate_bkgnd_mixing(h, tv, N2_lay, Kd_lay, visc%Kv_slow, j, G, GV, US, CS%bkgnd_mixing_csp)
 
     ! Double-diffusion (old method)
     if (CS%double_diffusion) then
-      call double_diffusion(tv, h, T_f, S_f, j, G, GV, CS, KT_extra, KS_extra)
+      call double_diffusion(tv, h, T_f, S_f, j, G, GV, US, CS, KT_extra, KS_extra)
       do K=2,nz ; do i=is,ie
         if (KS_extra(i,K) > KT_extra(i,K)) then ! salt fingering
           Kd_lay(i,j,k-1) = Kd_lay(i,j,k-1) + 0.5*KT_extra(i,K)
@@ -433,7 +435,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
     ! GMM, we need to pass HBL to compute_ddiff_coeffs, but it is not yet available.
     if (CS%use_CVMix_ddiff) then
       call cpu_clock_begin(id_clock_CVMix_ddiff)
-      call compute_ddiff_coeffs(h, tv, G, GV, j, visc%Kd_extra_T, visc%Kd_extra_S, CS%CVMix_ddiff_csp)
+      call compute_ddiff_coeffs(h, tv, G, GV, US, j, visc%Kd_extra_T, visc%Kd_extra_S, CS%CVMix_ddiff_csp)
       call cpu_clock_end(id_clock_CVMix_ddiff)
     endif
 
@@ -462,7 +464,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
       endif
     endif
 
-    call find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, CS, TKE_to_Kd, &
+    call find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, US, CS, TKE_to_Kd, &
                         maxTKE, kb)
     if (associated(dd%maxTKE)) then ; do k=1,nz ; do i=is,ie
       dd%maxTKE(i,j,k) = maxTKE(i,k)
@@ -473,21 +475,21 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
 
     ! Add the ML_Rad diffusivity.
     if (CS%ML_radiation) &
-      call add_MLrad_diffusivity(h, fluxes, j, G, GV, CS, Kd_lay, TKE_to_Kd, Kd_int)
+      call add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, Kd_lay, TKE_to_Kd, Kd_int)
 
     ! Add the Nikurashin and / or tidal bottom-driven mixing
-    call calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, maxTKE, G, GV, CS%tm_csp, &
+    call calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, maxTKE, G, GV, US, CS%tm_csp, &
                                 N2_lay, N2_int, Kd_lay, Kd_int, CS%Kd_max, visc%Kv_slow)
 
     ! This adds the diffusion sustained by the energy extracted from the flow
     ! by the bottom drag.
     if (CS%bottomdraglaw .and. (CS%BBL_effic>0.0)) then
       if (CS%use_LOTW_BBL_diffusivity) then
-        call add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, G, GV, CS,  &
+        call add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, G, GV, US, CS,  &
                                       Kd_lay, Kd_int, dd%Kd_BBL)
       else
         call add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, &
-                                  maxTKE, kb, G, GV, CS, Kd_lay, Kd_int, dd%Kd_BBL)
+                                  maxTKE, kb, G, GV, US, CS, Kd_lay, Kd_int, dd%Kd_BBL)
       endif
     endif
 
@@ -657,10 +659,11 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
 end subroutine set_diffusivity
 
 !> Convert turbulent kinetic energy to diffusivity
-subroutine find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, CS, &
+subroutine find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, US, CS, &
                           TKE_to_Kd, maxTKE, kb)
   type(ocean_grid_type),            intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),          intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),            intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                                     intent(in)    :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   type(thermo_var_ptrs),            intent(in)    :: tv   !< Structure containing pointers to any available
@@ -720,7 +723,7 @@ subroutine find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, CS, &
 
   I_dt      = 1.0/dt
   Omega2    = CS%Omega**2
-  G_Rho0    = (GV%g_Earth*GV%m_to_Z**2) / GV%Rho0
+  G_Rho0    = (GV%g_Earth*US%m_to_Z**2) / GV%Rho0
   H_neglect = GV%H_subroundoff
   I_Rho0    = 1.0/GV%Rho0
 
@@ -828,7 +831,7 @@ subroutine find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, CS, &
   enddo
   do k=2,kmb ; do i=is,ie
     maxTKE(i,k) = 0.0
-    TKE_to_Kd(i,k) = GV%m_to_Z**3 / ((N2_lay(i,k) + Omega2) * &
+    TKE_to_Kd(i,k) = US%m_to_Z**3 / ((N2_lay(i,k) + Omega2) * &
                             (GV%H_to_Z*(h(i,j,k) + H_neglect)))
   enddo ; enddo
   do k=kmb+1,kb_min-1 ; do i=is,ie
@@ -845,14 +848,14 @@ subroutine find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, CS, &
       ! ### This should be 1 / G_Earth * (delta rho_InSitu)
       !  kappa_max = I_dt * dRho_int(i,K+1) * maxEnt(i,k) * &
       !             (GV%H_to_m*h(i,j,k) + dh_max) / dRho_lay
-      !  maxTKE(i,k) = (GV%g_Earth*GV%m_to_Z) * dRho_lay * kappa_max
+      !  maxTKE(i,k) = (GV%g_Earth*US%m_to_Z) * dRho_lay * kappa_max
       ! dRho_int should already be non-negative, so the max is redundant?
       dh_max = maxEnt(i,k) * (1.0 + dsp1_ds(i,k))
       dRho_lay = 0.5 * max(dRho_int(i,K) + dRho_int(i,K+1), 0.0)
       maxTKE(i,k) = I_dt*GV%Z_to_m * ((GV%g_Earth * I_Rho0) * &
           (0.5*max(dRho_int(i,K+1) + dsp1_ds(i,k)*dRho_int(i,K), 0.0))) * &
                    ((GV%H_to_Z*h(i,j,k) + dh_max) * maxEnt(i,k))
-      TKE_to_Kd(i,k) = GV%m_to_Z**3 / (G_Rho0 * dRho_lay + &
+      TKE_to_Kd(i,k) = US%m_to_Z**3 / (G_Rho0 * dRho_lay + &
                               CS%Omega**2 * GV%H_to_Z*(h(i,j,k) + H_neglect))
     endif
   enddo ; enddo
@@ -860,10 +863,11 @@ subroutine find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, CS, &
 end subroutine find_TKE_to_Kd
 
 !> Calculate Brunt-Vaisala frequency, N^2.
-subroutine find_N2(h, tv, T_f, S_f, fluxes, j, G, GV, CS, dRho_int, &
+subroutine find_N2(h, tv, T_f, S_f, fluxes, j, G, GV, US, CS, dRho_int, &
                    N2_lay, N2_int, N2_bot)
   type(ocean_grid_type),    intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type),  intent(in)  :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),    intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                             intent(in)  :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   type(thermo_var_ptrs),    intent(in)  :: tv   !< Structure containing pointers to any available
@@ -910,7 +914,7 @@ subroutine find_N2(h, tv, T_f, S_f, fluxes, j, G, GV, CS, dRho_int, &
   integer :: i, k, is, ie, nz
 
   is = G%isc ; ie = G%iec ; nz = G%ke
-  G_Rho0    = (GV%g_Earth*GV%m_to_Z**2) / GV%Rho0
+  G_Rho0    = (GV%g_Earth*US%m_to_Z**2) / GV%Rho0
   H_neglect = GV%H_subroundoff
 
   ! Find the (limited) density jump across each interface.
@@ -1035,9 +1039,10 @@ end subroutine find_N2
 !! be made run-time variables rather than hard-coded constants.
 !!
 !! \todo Find reference for NCAR tech note above.
-subroutine double_diffusion(tv, h, T_f, S_f, j, G, GV, CS, Kd_T_dd, Kd_S_dd)
+subroutine double_diffusion(tv, h, T_f, S_f, j, G, GV, US, CS, Kd_T_dd, Kd_S_dd)
   type(ocean_grid_type),    intent(in)  :: G   !< The ocean's grid structure.
   type(verticalGrid_type),  intent(in)  :: GV  !< The ocean's vertical grid structure.
+  type(unit_scale_type),    intent(in)  :: US  !< A dimensional unit scaling type
   type(thermo_var_ptrs),    intent(in)  :: tv  !< Structure containing pointers to any available
                                                !! thermodynamic fields; absent fields have NULL ptrs.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
@@ -1080,8 +1085,8 @@ subroutine double_diffusion(tv, h, T_f, S_f, j, G, GV, CS, Kd_T_dd, Kd_S_dd)
   is = G%isc ; ie = G%iec ; nz = G%ke
 
   if (associated(tv%eqn_of_state)) then
-    dsfmax = GV%m_to_Z**2 * 1.e-4 ! max salt fingering diffusivity rescaled to (Z2/sec)
-    Kv_molecular = GV%m_to_Z**2 * 1.5e-6 ! molecular viscosity rescaled to (Z2/sec)
+    dsfmax = US%m_to_Z**2 * 1.e-4 ! max salt fingering diffusivity rescaled to (Z2/sec)
+    Kv_molecular = US%m_to_Z**2 * 1.5e-6 ! molecular viscosity rescaled to (Z2/sec)
 
     do i=is,ie
       pres(i) = 0.0 ; Kd_T_dd(i,1) = 0.0 ; Kd_S_dd(i,1) = 0.0
@@ -1124,9 +1129,10 @@ end subroutine double_diffusion
 
 !> This routine adds diffusion sustained by flow energy extracted by bottom drag.
 subroutine add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, &
-                                maxTKE, kb, G, GV, CS, Kd_lay, Kd_int, Kd_BBL)
+                                maxTKE, kb, G, GV, US, CS, Kd_lay, Kd_int, Kd_BBL)
   type(ocean_grid_type),            intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),          intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),            intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                                     intent(in)    :: u    !< The zonal velocity, in m s-1
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -1199,7 +1205,7 @@ subroutine add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, &
   if (associated(visc%Ray_u) .and. associated(visc%Ray_v)) Rayleigh_drag = .true.
 
   I_Rho0 = 1.0/GV%Rho0
-  R0_g = GV%Rho0 / (GV%m_to_Z**2*GV%g_Earth)
+  R0_g = GV%Rho0 / (US%m_to_Z**2*GV%g_Earth)
 
   do K=2,nz ; Rint(K) = 0.5*(GV%Rlay(k-1)+GV%Rlay(k)) ; enddo
 
@@ -1211,7 +1217,7 @@ subroutine add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, &
   do i=is,ie
     ustar_h = visc%ustar_BBL(i,j)
     if (associated(fluxes%ustar_tidal)) &
-      ustar_h = ustar_h + GV%m_to_Z*fluxes%ustar_tidal(i,j)
+      ustar_h = ustar_h + US%m_to_Z*fluxes%ustar_tidal(i,j)
     absf = 0.25*((abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
                  (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))))
     if ((ustar_h > 0.0) .and. (absf > 0.5*CS%IMax_decay*ustar_h))  then
@@ -1358,9 +1364,10 @@ end subroutine add_drag_diffusivity
 !! wall turbulent viscosity, up to a BBL height where the energy used for mixing has
 !! consumed the mechanical TKE input.
 subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, &
-                                    G, GV, CS, Kd_lay, Kd_int, Kd_BBL)
+                                    G, GV, US, CS, Kd_lay, Kd_int, Kd_BBL)
   type(ocean_grid_type),    intent(in)    :: G  !< Grid structure
   type(verticalGrid_type),  intent(in)    :: GV !< Vertical grid structure
+  type(unit_scale_type),    intent(in)    :: US !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                             intent(in)    :: u  !< u component of flow (m s-1)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -1433,7 +1440,7 @@ subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, &
     ustar2 = ustar**2
     ! In add_drag_diffusivity(), fluxes%ustar_tidal is added in. This might be double counting
     ! since ustar_BBL should already include all contributions to u*? -AJA
-    if (associated(fluxes%ustar_tidal)) ustar = ustar + GV%m_to_Z*fluxes%ustar_tidal(i,j)
+    if (associated(fluxes%ustar_tidal)) ustar = ustar + US%m_to_Z*fluxes%ustar_tidal(i,j)
 
     ! The maximum decay scale should be something of order 200 m. We use the smaller of u*/f and
     ! (IMax_decay)^-1 as the decay scale. If ustar = 0, this is land so this value doesn't matter.
@@ -1518,9 +1525,10 @@ subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, &
 end subroutine add_LOTW_BBL_diffusivity
 
 !> This routine adds effects of mixed layer radiation to the layer diffusivities.
-subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, CS, Kd_lay, TKE_to_Kd, Kd_int)
+subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, Kd_lay, TKE_to_Kd, Kd_int)
   type(ocean_grid_type),            intent(in)    :: G      !< The ocean's grid structure
   type(verticalGrid_type),          intent(in)    :: GV     !< The ocean's vertical grid structure
+  type(unit_scale_type),            intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                                     intent(in)    :: h      !< Layer thicknesses, in H (usually m or kg m-2)
   type(forcing),                    intent(in)    :: fluxes !< Surface fluxes structure
@@ -1580,7 +1588,7 @@ subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, CS, Kd_lay, TKE_to_Kd, Kd_
     ustar_sq = max(fluxes%ustar(i,j), CS%ustar_min)**2
 
     TKE_ml_flux(i) = (CS%mstar*CS%ML_rad_coeff)*(ustar_sq*fluxes%ustar(i,j))
-    I_decay_len2_TKE = CS%TKE_decay**2 * (f_sq / (GV%m_to_Z**2*ustar_sq))
+    I_decay_len2_TKE = CS%TKE_decay**2 * (f_sq / (US%m_to_Z**2*ustar_sq))
 
     if (CS%ML_rad_TKE_decay) &
       TKE_ml_flux(i) = TKE_ml_flux(i) * exp(-h_ml(i) * sqrt(I_decay_len2_TKE))
@@ -1621,10 +1629,10 @@ subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, CS, Kd_lay, TKE_to_Kd, Kd_
       dzL = GV%H_to_Z*h(i,j,k) ;  z1 = dzL*I_decay(i)
       if (z1 > 1e-5) then
         Kd_mlr = (TKE_ml_flux(i) * TKE_to_Kd(i,k)) * &
-                 GV%m_to_Z * ((1.0 - exp(-z1)) / dzL)
+                 US%m_to_Z * ((1.0 - exp(-z1)) / dzL)
       else
         Kd_mlr = (TKE_ml_flux(i) * TKE_to_Kd(i,k)) * &
-                 GV%m_to_Z * (I_decay(i) * (1.0 - z1 * (0.5 - C1_6*z1)))
+                 US%m_to_Z * (I_decay(i) * (1.0 - z1 * (0.5 - C1_6*z1)))
       endif
       Kd_mlr = min(Kd_mlr, CS%ML_rad_kd_max)
       Kd_lay(i,j,k) = Kd_lay(i,j,k) + Kd_mlr
@@ -1899,11 +1907,12 @@ subroutine set_density_ratios(h, tv, kb, G, GV, CS, j, ds_dsp1, rho_0)
 
 end subroutine set_density_ratios
 
-subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp, int_tide_CSp, &
+subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z_CSp, int_tide_CSp, &
                                 tm_CSp, halo_TS)
   type(time_type),          intent(in)    :: Time !< The current model time
   type(ocean_grid_type),    intent(inout) :: G    !< The ocean's grid structure.
   type(verticalGrid_type),  intent(in)    :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),    intent(in)    :: param_file !< A structure to parse for run-time
                                                   !! parameters.
   type(diag_ctrl), target,  intent(inout) :: diag !< A structure used to regulate diagnostic output.
@@ -1985,7 +1994,7 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
                  "The maximum diapycnal diffusivity due to turbulence \n"//&
                  "radiated from the base of the mixed layer. \n"//&
                  "This is only used if ML_RADIATION is true.", &
-                 units="m2 s-1", default=1.0e-3, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=1.0e-3, scale=US%m_to_Z**2)
     call get_param(param_file, mdl, "ML_RAD_COEFF", CS%ML_rad_coeff, &
                  "The coefficient which scales MSTAR*USTAR^3 to obtain \n"//&
                  "the energy available for mixing below the base of the \n"//&
@@ -2038,9 +2047,9 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
                  "to allow the mixing to penetrate as far as \n"//&
                  "stratification and rotation permit.  The default is 0. \n"//&
                  "This is only used if BOTTOMDRAGLAW is true.", &
-                 units="m", default=0.0, scale=GV%m_to_Z)
+                 units="m", default=0.0, scale=US%m_to_Z)
 
-    CS%IMax_decay = 1.0 / (200.0*GV%m_to_Z)  !### This is inconsistent with the description above.
+    CS%IMax_decay = 1.0 / (200.0*US%m_to_Z)  !### This is inconsistent with the description above.
     if (decay_length > 0.0) CS%IMax_decay = 1.0/decay_length
     call get_param(param_file, mdl, "BBL_MIXING_AS_MAX", CS%BBL_mixing_as_max, &
                  "If true, take the maximum of the diffusivity from the \n"//&
@@ -2069,30 +2078,30 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
                  default=.false.)
 
   ! set params releted to the background mixing
-  call bkgnd_mixing_init(Time, G, GV, param_file, CS%diag, CS%bkgnd_mixing_csp)
+  call bkgnd_mixing_init(Time, G, GV, US, param_file, CS%diag, CS%bkgnd_mixing_csp)
 
   call get_param(param_file, mdl, "KV", CS%Kv, &
                  "The background kinematic viscosity in the interior. \n"//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
-                 units="m2 s-1", scale=GV%m_to_Z**2, fail_if_missing=.true.)
+                 units="m2 s-1", scale=US%m_to_Z**2, fail_if_missing=.true.)
 
   call get_param(param_file, mdl, "KD", CS%Kd, &
                  "The background diapycnal diffusivity of density in the \n"//&
                  "interior. Zero or the molecular value, ~1e-7 m2 s-1, \n"//&
-                 "may be used.", units="m2 s-1", scale=GV%m_to_Z**2, fail_if_missing=.true.)
+                 "may be used.", units="m2 s-1", scale=US%m_to_Z**2, fail_if_missing=.true.)
   call get_param(param_file, mdl, "KD_MIN", CS%Kd_min, &
                  "The minimum diapycnal diffusivity.", &
-                 units="m2 s-1", default=0.01*CS%Kd*GV%Z_to_m**2, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=0.01*CS%Kd*GV%Z_to_m**2, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "KD_MAX", CS%Kd_max, &
                  "The maximum permitted increment for the diapycnal \n"//&
                  "diffusivity from TKE-based parameterizations, or a \n"//&
-                 "negative value for no limit.", units="m2 s-1", default=-1.0, scale=GV%m_to_Z**2)
+                 "negative value for no limit.", units="m2 s-1", default=-1.0, scale=US%m_to_Z**2)
   if (CS%simple_TKE_to_Kd .and. CS%Kd_max<=0.) call MOM_error(FATAL, &
          "set_diffusivity_init: To use SIMPLE_TKE_TO_KD, KD_MAX must be set to >0.")
   call get_param(param_file, mdl, "KD_ADD", CS%Kd_add, &
                  "A uniform diapycnal diffusivity that is added \n"//&
                  "everywhere without any filtering or scaling.", &
-                 units="m2 s-1", default=0.0, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=0.0, scale=US%m_to_Z**2)
   if (CS%use_LOTW_BBL_diffusivity .and. CS%Kd_max<=0.) call MOM_error(FATAL, &
                  "set_diffusivity_init: KD_MAX must be set (positive) when "// &
                  "USE_LOTW_BBL_DIFFUSIVITY=True.")
@@ -2110,7 +2119,7 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
                  "If BULKMIXEDLAYER is false, KDML is the elevated \n"//&
                  "diapycnal diffusivity in the topmost HMIX of fluid. \n"//&
                  "KDML is only used if BULKMIXEDLAYER is false.", &
-                 units="m2 s-1", default=CS%Kd*GV%Z_to_m**2, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=CS%Kd*GV%Z_to_m**2, scale=US%m_to_Z**2)
     call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
                  "The prescribed depth over which the near-surface \n"//&
                  "viscosity and diffusivity are elevated when the bulk \n"//&
@@ -2126,20 +2135,20 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
 
   call get_param(param_file, mdl, "DISSIPATION_MIN", CS%dissip_min, &
                  "The minimum dissipation by which to determine a lower \n"//&
-                 "bound of Kd (a floor).", units="W m-3", default=0.0, scale=GV%m_to_Z**2)
+                 "bound of Kd (a floor).", units="W m-3", default=0.0, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "DISSIPATION_N0", CS%dissip_N0, &
                  "The intercept when N=0 of the N-dependent expression \n"//&
                  "used to set a minimum dissipation by which to determine \n"//&
                  "a lower bound of Kd (a floor): A in eps_min = A + B*N.", &
-                 units="W m-3", default=0.0, scale=GV%m_to_Z**2)
+                 units="W m-3", default=0.0, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "DISSIPATION_N1", CS%dissip_N1, &
                  "The coefficient multiplying N, following Gargett, used to \n"//&
                  "set a minimum dissipation by which to determine a lower \n"//&
                  "bound of Kd (a floor): B in eps_min = A + B*N", &
-                 units="J m-3", default=0.0, scale=GV%m_to_Z**2)
+                 units="J m-3", default=0.0, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "DISSIPATION_KD_MIN", CS%dissip_Kd_min, &
                  "The minimum vertical diffusivity applied as a floor.", &
-                 units="m2 s-1", default=0.0, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=0.0, scale=US%m_to_Z**2)
 
   CS%limit_dissipation = (CS%dissip_min>0.) .or. (CS%dissip_N1>0.) .or. &
                          (CS%dissip_N0>0.) .or. (CS%dissip_Kd_min>0.)
@@ -2217,14 +2226,14 @@ subroutine set_diffusivity_init(Time, G, GV, param_file, diag, CS, diag_to_Z_CSp
   endif ! old double-diffusion
 
   if (CS%user_change_diff) then
-    call user_change_diff_init(Time, G, GV, param_file, diag, CS%user_change_diff_CSp)
+    call user_change_diff_init(Time, G, GV, US, param_file, diag, CS%user_change_diff_CSp)
   endif
 
   if (CS%tm_csp%Int_tide_dissipation .and. CS%bkgnd_mixing_csp%Bryan_Lewis_diffusivity) &
     call MOM_error(FATAL,"MOM_Set_Diffusivity: "// &
          "Bryan-Lewis and internal tidal dissipation are both enabled. Choose one.")
 
-  CS%useKappaShear = kappa_shear_init(Time, G, GV, param_file, CS%diag, CS%kappaShear_CSp)
+  CS%useKappaShear = kappa_shear_init(Time, G, GV, US, param_file, CS%diag, CS%kappaShear_CSp)
   if (CS%useKappaShear) CS%Vertex_Shear = kappa_shear_at_vertex(param_file)
 
   if (CS%useKappaShear) &

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -354,8 +354,8 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
                                    visc%TKE_turb, visc%Kv_shear_Bu, dt, G, GV, US, CS%kappaShear_CSp)
       if (associated(visc%Kv_shear)) visc%Kv_shear(:,:,:) = 0.0 ! needed for other parameterizations
       if (CS%debug) then
-        call hchksum(visc%Kd_shear, "after calc_KS_vert visc%Kd_shear", G%HI, scale=GV%Z_to_m**2)
-        call Bchksum(visc%Kv_shear_Bu, "after calc_KS_vert visc%Kv_shear_Bu", G%HI, scale=GV%Z_to_m**2)
+        call hchksum(visc%Kd_shear, "after calc_KS_vert visc%Kd_shear", G%HI, scale=US%Z_to_m**2)
+        call Bchksum(visc%Kv_shear_Bu, "after calc_KS_vert visc%Kv_shear_Bu", G%HI, scale=US%Z_to_m**2)
         call Bchksum(visc%TKE_turb, "after calc_KS_vert visc%TKE_turb", G%HI)
       endif
     else
@@ -364,8 +364,8 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
       call calculate_kappa_shear(u_h, v_h, h, tv, fluxes%p_surf, visc%Kd_shear, visc%TKE_turb, &
                                  visc%Kv_shear, dt, G, GV, US, CS%kappaShear_CSp)
       if (CS%debug) then
-        call hchksum(visc%Kd_shear, "after calc_KS visc%Kd_shear", G%HI, scale=GV%Z_to_m**2)
-        call hchksum(visc%Kv_shear, "after calc_KS visc%Kv_shear", G%HI, scale=GV%Z_to_m**2)
+        call hchksum(visc%Kd_shear, "after calc_KS visc%Kd_shear", G%HI, scale=US%Z_to_m**2)
+        call hchksum(visc%Kv_shear, "after calc_KS visc%Kv_shear", G%HI, scale=US%Z_to_m**2)
         call hchksum(visc%TKE_turb, "after calc_KS visc%TKE_turb", G%HI)
       endif
     endif
@@ -375,8 +375,8 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
     !NOTE{BGR}: this needs to be cleaned up.  It works in 1D case, but has not been tested outside.
     call calculate_CVMix_shear(u_h, v_h, h, tv, visc%Kd_shear, visc%Kv_shear, G, GV, US, CS%CVMix_shear_CSp)
     if (CS%debug) then
-      call hchksum(visc%Kd_shear, "after CVMix_shear visc%Kd_shear", G%HI, scale=GV%Z_to_m**2)
-      call hchksum(visc%Kv_shear, "after CVMix_shear visc%Kv_shear", G%HI, scale=GV%Z_to_m**2)
+      call hchksum(visc%Kd_shear, "after CVMix_shear visc%Kd_shear", G%HI, scale=US%Z_to_m**2)
+      call hchksum(visc%Kv_shear, "after CVMix_shear visc%Kv_shear", G%HI, scale=US%Z_to_m**2)
     endif
   elseif (associated(visc%Kv_shear)) then
     visc%Kv_shear(:,:,:) = 0.0 ! needed if calculate_kappa_shear is not enabled
@@ -387,7 +387,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   ! another explicit parameterization of Kd.
 
   ! set surface diffusivities (CS%bkgnd_mixing_csp%Kd_sfc)
-  call sfc_bkgnd_mixing(G, GV, CS%bkgnd_mixing_csp)
+  call sfc_bkgnd_mixing(G, US, CS%bkgnd_mixing_csp)
 
   !$OMP parallel do default(shared) private(dRho_int, N2_lay, N2_int, N2_bot, KT_extra, &
   !$OMP                                     KS_extra, TKE_to_Kd,maxTKE, dissip, kb)
@@ -523,34 +523,34 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
 
     if (associated(dd%Kd_work)) then
       do k=1,nz ; do i=is,ie
-        dd%Kd_Work(i,j,k) = GV%Rho0 * GV%Z_to_m**3*Kd_lay(i,j,k) * N2_lay(i,k) * &
+        dd%Kd_Work(i,j,k) = GV%Rho0 * US%Z_to_m**3*Kd_lay(i,j,k) * N2_lay(i,k) * &
                             GV%H_to_Z*h(i,j,k)  ! Watt m-2 s or kg s-3
       enddo ; enddo
     endif
   enddo ! j-loop
 
   if (CS%debug) then
-    call hchksum(Kd_lay ,"Kd_lay", G%HI, haloshift=0, scale=GV%Z_to_m**2)
+    call hchksum(Kd_lay ,"Kd_lay", G%HI, haloshift=0, scale=US%Z_to_m**2)
 
-    if (CS%useKappaShear) call hchksum(visc%Kd_shear, "Turbulent Kd", G%HI, haloshift=0, scale=GV%Z_to_m**2)
+    if (CS%useKappaShear) call hchksum(visc%Kd_shear, "Turbulent Kd", G%HI, haloshift=0, scale=US%Z_to_m**2)
 
     if (CS%use_CVMix_ddiff) then
-      call hchksum(visc%Kd_extra_T, "MOM_set_diffusivity: Kd_extra_T", G%HI, haloshift=0, scale=GV%Z_to_m**2)
-      call hchksum(visc%Kd_extra_S, "MOM_set_diffusivity: Kd_extra_S", G%HI, haloshift=0, scale=GV%Z_to_m**2)
+      call hchksum(visc%Kd_extra_T, "MOM_set_diffusivity: Kd_extra_T", G%HI, haloshift=0, scale=US%Z_to_m**2)
+      call hchksum(visc%Kd_extra_S, "MOM_set_diffusivity: Kd_extra_S", G%HI, haloshift=0, scale=US%Z_to_m**2)
     endif
 
     if (associated(visc%kv_bbl_u) .and. associated(visc%kv_bbl_v)) then
       call uvchksum("BBL Kv_bbl_[uv]", visc%kv_bbl_u, visc%kv_bbl_v, &
-                    G%HI, 0, symmetric=.true., scale=GV%Z_to_m**2)
+                    G%HI, 0, symmetric=.true., scale=US%Z_to_m**2)
     endif
 
     if (associated(visc%bbl_thick_u) .and. associated(visc%bbl_thick_v)) then
       call uvchksum("BBL bbl_thick_[uv]", visc%bbl_thick_u, &
-                    visc%bbl_thick_v, G%HI, 0, symmetric=.true., scale=GV%Z_to_m)
+                    visc%bbl_thick_v, G%HI, 0, symmetric=.true., scale=US%Z_to_m)
     endif
 
     if (associated(visc%Ray_u) .and. associated(visc%Ray_v)) then
-      call uvchksum("Ray_[uv]", visc%Ray_u, visc%Ray_v, G%HI, 0, symmetric=.true., scale=GV%Z_to_m)
+      call uvchksum("Ray_[uv]", visc%Ray_u, visc%Ray_v, G%HI, 0, symmetric=.true., scale=US%Z_to_m)
     endif
 
   endif
@@ -730,7 +730,7 @@ subroutine find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, US, CS, &
   ! Simple but coordinate-independent estimate of Kd/TKE
   if (CS%simple_TKE_to_Kd) then
     do k=1,nz ; do i=is,ie
-      hN2pO2 = GV%Z_to_m**3 * ( GV%H_to_Z * h(i,j,k) ) * ( N2_lay(i,k) + Omega2 ) ! Units of m3 Z-2 s-2.
+      hN2pO2 = US%Z_to_m**3 * ( GV%H_to_Z * h(i,j,k) ) * ( N2_lay(i,k) + Omega2 ) ! Units of m3 Z-2 s-2.
       if (hN2pO2>0.) then
         TKE_to_Kd(i,k) = 1.0 / hN2pO2 ! Units of Z2 s2 m-3.
       else; TKE_to_Kd(i,k) = 0.; endif
@@ -852,7 +852,7 @@ subroutine find_TKE_to_Kd(h, tv, dRho_int, N2_lay, j, dt, G, GV, US, CS, &
       ! dRho_int should already be non-negative, so the max is redundant?
       dh_max = maxEnt(i,k) * (1.0 + dsp1_ds(i,k))
       dRho_lay = 0.5 * max(dRho_int(i,K) + dRho_int(i,K+1), 0.0)
-      maxTKE(i,k) = I_dt*GV%Z_to_m * ((GV%g_Earth * I_Rho0) * &
+      maxTKE(i,k) = I_dt*US%Z_to_m * ((GV%g_Earth * I_Rho0) * &
           (0.5*max(dRho_int(i,K+1) + dsp1_ds(i,k)*dRho_int(i,K), 0.0))) * &
                    ((GV%H_to_Z*h(i,j,k) + dh_max) * maxEnt(i,k))
       TKE_to_Kd(i,k) = US%m_to_Z**3 / (G_Rho0 * dRho_lay + &
@@ -1289,7 +1289,7 @@ subroutine add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, &
       else ; TKE_to_layer = 0.0 ; endif
 
       ! TKE_Ray has been initialized to 0 above.
-      if (Rayleigh_drag) TKE_Ray = 0.5*CS%BBL_effic * GV%Z_to_m * G%IareaT(i,j) * &
+      if (Rayleigh_drag) TKE_Ray = 0.5*CS%BBL_effic * US%Z_to_m * G%IareaT(i,j) * &
             ((G%areaCu(I-1,j) * visc%Ray_u(I-1,j,k) * u(I-1,j,k)**2 + &
               G%areaCu(I,j)   * visc%Ray_u(I,j,k)   * u(I,j,k)**2) + &
              (G%areaCv(i,J-1) * visc%Ray_v(i,J-1,k) * v(i,J-1,k)**2 + &
@@ -1471,7 +1471,7 @@ subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, &
 
       ! Add in additional energy input from bottom-drag against slopes (sides)
       if (Rayleigh_drag) TKE_remaining = TKE_remaining + &
-            0.5*CS%BBL_effic * GV%Z_to_m * G%IareaT(i,j) * &
+            0.5*CS%BBL_effic * US%Z_to_m * G%IareaT(i,j) * &
             ((G%areaCu(I-1,j) * visc%Ray_u(I-1,j,k) * u(I-1,j,k)**2 + &
               G%areaCu(I,j)   * visc%Ray_u(I,j,k)   * u(I,j,k)**2) + &
              (G%areaCv(i,J-1) * visc%Ray_v(i,J-1,k) * v(i,J-1,k)**2 + &
@@ -1495,7 +1495,7 @@ subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, &
 
       ! TKE associated with Kd_wall, in m3 s-2.
       ! This calculation if for the volume spanning the interface.
-      TKE_Kd_wall = GV%Z_to_m**3*Kd_wall * 0.5 * (dh + dhm1) * max(N2_int(i,k), N2_min)
+      TKE_Kd_wall = US%Z_to_m**3*Kd_wall * 0.5 * (dh + dhm1) * max(N2_int(i,k), N2_min)
 
       ! Now bound Kd such that the associated TKE is no greater than available TKE for mixing.
       if (TKE_Kd_wall > 0.) then
@@ -1642,7 +1642,7 @@ subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, Kd_lay, TKE_to_Kd,
       endif
 
       TKE_ml_flux(i) = TKE_ml_flux(i) * exp(-z1)
-      if (TKE_ml_flux(i) * I_decay(i) < 0.1*CS%Kd_min*GV%Z_to_m**3*Omega2) then
+      if (TKE_ml_flux(i) * I_decay(i) < 0.1*CS%Kd_min*US%Z_to_m**3*Omega2) then
         do_i(i) = .false.
       else ; do_any = .true. ; endif
     endif ; enddo
@@ -1653,9 +1653,10 @@ end subroutine add_MLrad_diffusivity
 
 !> This subroutine calculates several properties related to bottom
 !! boundary layer turbulence.
-subroutine set_BBL_TKE(u, v, h, fluxes, visc, G, GV, CS)
+subroutine set_BBL_TKE(u, v, h, fluxes, visc, G, GV, US, CS)
   type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),  intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                             intent(in)    :: u    !< The zonal velocity, in m s-1
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -1778,7 +1779,7 @@ subroutine set_BBL_TKE(u, v, h, fluxes, visc, G, GV, CS)
                   G%areaCu(I,j)*(ustar(I)*ustar(I))) + &
                  (G%areaCv(i,J-1)*(vstar(i,J-1)*vstar(i,J-1)) + &
                   G%areaCv(i,J)*(vstar(i,J)*vstar(i,J))) ) )
-      visc%TKE_BBL(i,j) = GV%Z_to_m * &
+      visc%TKE_BBL(i,j) = US%Z_to_m * &
                  (((G%areaCu(I-1,j)*(ustar(I-1)*u2_bbl(I-1)) + &
                     G%areaCu(I,j) * (ustar(I)*u2_bbl(I))) + &
                    (G%areaCv(i,J-1)*(vstar(i,J-1)*v2_bbl(i,J-1)) + &
@@ -2069,7 +2070,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
     CS%use_LOTW_BBL_diffusivity = .false. ! This parameterization depends on a u* from viscous BBL
   endif
   CS%id_Kd_BBL = register_diag_field('ocean_model', 'Kd_BBL', diag%axesTi, Time, &
-       'Bottom Boundary Layer Diffusivity', 'm2 s-1', conversion=GV%Z_to_m**2)
+       'Bottom Boundary Layer Diffusivity', 'm2 s-1', conversion=US%Z_to_m**2)
   call get_param(param_file, mdl, "SIMPLE_TKE_TO_KD", CS%simple_TKE_to_Kd, &
                  "If true, uses a simple estimate of Kd/TKE that will\n"//&
                  "work for arbitrary vertical coordinates. If false,\n"//&
@@ -2091,7 +2092,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
                  "may be used.", units="m2 s-1", scale=US%m_to_Z**2, fail_if_missing=.true.)
   call get_param(param_file, mdl, "KD_MIN", CS%Kd_min, &
                  "The minimum diapycnal diffusivity.", &
-                 units="m2 s-1", default=0.01*CS%Kd*GV%Z_to_m**2, scale=US%m_to_Z**2)
+                 units="m2 s-1", default=0.01*CS%Kd*US%Z_to_m**2, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "KD_MAX", CS%Kd_max, &
                  "The maximum permitted increment for the diapycnal \n"//&
                  "diffusivity from TKE-based parameterizations, or a \n"//&
@@ -2119,7 +2120,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
                  "If BULKMIXEDLAYER is false, KDML is the elevated \n"//&
                  "diapycnal diffusivity in the topmost HMIX of fluid. \n"//&
                  "KDML is only used if BULKMIXEDLAYER is false.", &
-                 units="m2 s-1", default=CS%Kd*GV%Z_to_m**2, scale=US%m_to_Z**2)
+                 units="m2 s-1", default=CS%Kd*US%Z_to_m**2, scale=US%m_to_Z**2)
     call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
                  "The prescribed depth over which the near-surface \n"//&
                  "viscosity and diffusivity are elevated when the bulk \n"//&
@@ -2157,7 +2158,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
     CS%dissip_N2 = CS%dissip_Kd_min * GV%Rho0 / CS%FluxRi_max
 
   CS%id_Kd_layer = register_diag_field('ocean_model', 'Kd_layer', diag%axesTL, Time, &
-      'Diapycnal diffusivity of layers (as set)', 'm2 s-1', conversion=GV%Z_to_m**2)
+      'Diapycnal diffusivity of layers (as set)', 'm2 s-1', conversion=US%Z_to_m**2)
 
 
   if (CS%tm_csp%Int_tide_dissipation .or. CS%tm_csp%Lee_wave_dissipation .or. &
@@ -2168,7 +2169,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
     CS%id_maxTKE = register_diag_field('ocean_model', 'maxTKE', diag%axesTL, Time, &
            'Maximum layer TKE', 'm3 s-3')
     CS%id_TKE_to_Kd = register_diag_field('ocean_model', 'TKE_to_Kd', diag%axesTL, Time, &
-           'Convert TKE to Kd', 's2 m', conversion=GV%Z_to_m**2)
+           'Convert TKE to Kd', 's2 m', conversion=US%Z_to_m**2)
     CS%id_N2 = register_diag_field('ocean_model', 'N2', diag%axesTi, Time, &
          'Buoyancy frequency squared', 's-2', cmor_field_name='obvfsq', &
           cmor_long_name='Square of seawater buoyancy frequency', &
@@ -2176,14 +2177,14 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
 
     if (CS%user_change_diff) &
       CS%id_Kd_user = register_diag_field('ocean_model', 'Kd_user', diag%axesTi, Time, &
-           'User-specified Extra Diffusivity', 'm2 s-1', conversion=GV%Z_to_m**2)
+           'User-specified Extra Diffusivity', 'm2 s-1', conversion=US%Z_to_m**2)
 
     if (associated(diag_to_Z_CSp)) then
       vd = var_desc("N2", "s-2", &
                     "Buoyancy frequency, interpolated to z", z_grid='z')
       CS%id_N2_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time)
       if (CS%user_change_diff) &
-        CS%id_Kd_user_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=GV%Z_to_m**2)
+        CS%id_Kd_user_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=US%Z_to_m**2)
     endif
   endif
 
@@ -2205,23 +2206,23 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
     ! The default molecular viscosity follows the CCSM4.0 and MOM4p1 defaults.
 
     CS%id_KT_extra = register_diag_field('ocean_model', 'KT_extra', diag%axesTi, Time, &
-         'Double-diffusive diffusivity for temperature', 'm2 s-1', conversion=GV%Z_to_m**2)
+         'Double-diffusive diffusivity for temperature', 'm2 s-1', conversion=US%Z_to_m**2)
 
     CS%id_KS_extra = register_diag_field('ocean_model', 'KS_extra', diag%axesTi, Time, &
-         'Double-diffusive diffusivity for salinity', 'm2 s-1', conversion=GV%Z_to_m**2)
+         'Double-diffusive diffusivity for salinity', 'm2 s-1', conversion=US%Z_to_m**2)
 
     if (associated(diag_to_Z_CSp)) then
       vd = var_desc("KT_extra", "m2 s-1", &
                     "Double-Diffusive Temperature Diffusivity, interpolated to z", &
                     z_grid='z')
-      CS%id_KT_extra_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=GV%Z_to_m**2)
+      CS%id_KT_extra_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=US%Z_to_m**2)
       vd = var_desc("KS_extra", "m2 s-1", &
                     "Double-Diffusive Salinity Diffusivity, interpolated to z", &
                     z_grid='z')
-      CS%id_KS_extra_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=GV%Z_to_m**2)
+      CS%id_KS_extra_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=US%Z_to_m**2)
       vd = var_desc("Kd_BBL", "m2 s-1", &
                     "Bottom Boundary Layer Diffusivity", z_grid='z')
-      CS%id_Kd_BBL_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=GV%Z_to_m**2)
+      CS%id_Kd_BBL_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=US%Z_to_m**2)
     endif
   endif ! old double-diffusion
 
@@ -2240,10 +2241,10 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
     id_clock_kappaShear = cpu_clock_id('(Ocean kappa_shear)', grain=CLOCK_MODULE)
 
   ! CVMix shear-driven mixing
-  CS%use_CVMix_shear = CVMix_shear_init(Time, G, GV, param_file, CS%diag, CS%CVMix_shear_csp)
+  CS%use_CVMix_shear = CVMix_shear_init(Time, G, GV, US, param_file, CS%diag, CS%CVMix_shear_csp)
 
   ! CVMix double diffusion mixing
-  CS%use_CVMix_ddiff = CVMix_ddiff_init(Time, G, GV, param_file, CS%diag, CS%CVMix_ddiff_csp)
+  CS%use_CVMix_ddiff = CVMix_ddiff_init(Time, G, GV, US, param_file, CS%diag, CS%CVMix_ddiff_csp)
   if (CS%use_CVMix_ddiff) &
     id_clock_CVMix_ddiff = cpu_clock_id('(Double diffusion via CVMix)', grain=CLOCK_MODULE)
 

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -263,7 +263,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, symmetrize)
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   nkmb = GV%nk_rho_varies ; nkml = GV%nkml
   h_neglect = GV%H_subroundoff
-  Rho0x400_G = 400.0*(GV%Rho0/GV%g_Earth) * GV%Z_to_m**2 * GV%Z_to_H
+  Rho0x400_G = 400.0*(GV%Rho0/GV%g_Earth) * US%Z_to_m**2 * GV%Z_to_H
   Vol_quit = 0.9*GV%Angstrom_H + h_neglect
   C2pi_3 = 8.0*atan(1.0)/3.0
 
@@ -892,12 +892,12 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, symmetrize)
 
   if (CS%debug) then
     if (associated(visc%Ray_u) .and. associated(visc%Ray_v)) &
-        call uvchksum("Ray [uv]", visc%Ray_u, visc%Ray_v, G%HI, haloshift=0, scale=GV%Z_to_m)
+        call uvchksum("Ray [uv]", visc%Ray_u, visc%Ray_v, G%HI, haloshift=0, scale=US%Z_to_m)
     if (associated(visc%kv_bbl_u) .and. associated(visc%kv_bbl_v)) &
-        call uvchksum("kv_bbl_[uv]", visc%kv_bbl_u, visc%kv_bbl_v, G%HI, haloshift=0, scale=GV%Z_to_m**2)
+        call uvchksum("kv_bbl_[uv]", visc%kv_bbl_u, visc%kv_bbl_v, G%HI, haloshift=0, scale=US%Z_to_m**2)
     if (associated(visc%bbl_thick_u) .and. associated(visc%bbl_thick_v)) &
         call uvchksum("bbl_thick_[uv]", visc%bbl_thick_u, &
-                      visc%bbl_thick_v, G%HI, haloshift=0, scale=GV%Z_to_m)
+                      visc%bbl_thick_v, G%HI, haloshift=0, scale=US%Z_to_m)
   endif
 
 end subroutine set_viscous_BBL
@@ -1126,7 +1126,7 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS, symmetri
     Jsq = js-1 ; Isq = is-1
   endif ; endif
 
-  Rho0x400_G = 400.0*(GV%Rho0/GV%g_Earth) * GV%Z_to_m**2 * GV%Z_to_H
+  Rho0x400_G = 400.0*(GV%Rho0/GV%g_Earth) * US%Z_to_m**2 * GV%Z_to_H
   U_bg_sq = CS%drag_bg_vel * CS%drag_bg_vel
   cdrag_sqrt = sqrt(CS%cdrag)
   cdrag_sqrt_Z = US%m_to_Z * sqrt(CS%cdrag)
@@ -1994,21 +1994,21 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
     allocate(visc%TKE_bbl(isd:ied,jsd:jed)) ; visc%TKE_bbl = 0.0
 
     CS%id_bbl_thick_u = register_diag_field('ocean_model', 'bbl_thick_u', &
-       diag%axesCu1, Time, 'BBL thickness at u points', 'm', conversion=GV%Z_to_m)
+       diag%axesCu1, Time, 'BBL thickness at u points', 'm', conversion=US%Z_to_m)
     CS%id_kv_bbl_u = register_diag_field('ocean_model', 'kv_bbl_u', diag%axesCu1, &
-       Time, 'BBL viscosity at u points', 'm2 s-1', conversion=GV%Z_to_m**2)
+       Time, 'BBL viscosity at u points', 'm2 s-1', conversion=US%Z_to_m**2)
     CS%id_bbl_thick_v = register_diag_field('ocean_model', 'bbl_thick_v', &
-       diag%axesCv1, Time, 'BBL thickness at v points', 'm', conversion=GV%Z_to_m)
+       diag%axesCv1, Time, 'BBL thickness at v points', 'm', conversion=US%Z_to_m)
     CS%id_kv_bbl_v = register_diag_field('ocean_model', 'kv_bbl_v', diag%axesCv1, &
-       Time, 'BBL viscosity at v points', 'm2 s-1', conversion=GV%Z_to_m**2)
+       Time, 'BBL viscosity at v points', 'm2 s-1', conversion=US%Z_to_m**2)
   endif
   if (CS%Channel_drag) then
     allocate(visc%Ray_u(IsdB:IedB,jsd:jed,nz)) ; visc%Ray_u = 0.0
     allocate(visc%Ray_v(isd:ied,JsdB:JedB,nz)) ; visc%Ray_v = 0.0
     CS%id_Ray_u = register_diag_field('ocean_model', 'Rayleigh_u', diag%axesCuL, &
-       Time, 'Rayleigh drag velocity at u points', 'm s-1', conversion=GV%Z_to_m)
+       Time, 'Rayleigh drag velocity at u points', 'm s-1', conversion=US%Z_to_m)
     CS%id_Ray_v = register_diag_field('ocean_model', 'Rayleigh_v', diag%axesCvL, &
-       Time, 'Rayleigh drag velocity at v points', 'm s-1', conversion=GV%Z_to_m)
+       Time, 'Rayleigh drag velocity at v points', 'm s-1', conversion=US%Z_to_m)
   endif
 
   if (use_CVMix_ddiff .or. differential_diffusion) then

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -356,7 +356,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, symmetrize)
 
   if (.not.use_BBL_EOS) Rml_vel(:,:) = 0.0
 
-  !$OMP parallel do default(private) shared(u,v,h,tv,visc,G,GV,CS,Rml,is,ie,js,je,nz,nkmb,    &
+  !$OMP parallel do default(private) shared(u,v,h,tv,visc,G,GV,US,CS,Rml,is,ie,js,je,nz,nkmb, &
   !$OMP                                     nkml,Isq,Ieq,Jsq,Jeq,h_neglect,Rho0x400_G,C2pi_3, &
   !$OMP                                     U_bg_sq,cdrag_sqrt_Z,cdrag_sqrt,K2,use_BBL_EOS,   &
   !$OMP                                     OBC,maxitt,Vol_quit,D_u,D_v,mask_u,mask_v)
@@ -1183,7 +1183,7 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS, symmetri
     endif
   enddo ; endif
 
-  !$OMP parallel do default(private) shared(u,v,h,tv,forces,visc,dt,G,GV,CS,use_EOS,dt_Rho0, &
+  !$OMP parallel do default(private) shared(u,v,h,tv,forces,visc,dt,G,GV,US,CS,use_EOS,dt_Rho0, &
   !$OMP                                     h_neglect,h_tiny,g_H_Rho0,js,je,OBC,Isq,Ieq,nz,  &
   !$OMP                                     U_bg_sq,mask_v,cdrag_sqrt,cdrag_sqrt_Z,Rho0x400_G,nkml)
   do j=js,je  ! u-point loop
@@ -1418,7 +1418,7 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS, symmetri
 
   enddo ! j-loop at u-points
 
-  !$OMP parallel do default(private) shared(u,v,h,tv,forces,visc,dt,G,GV,CS,use_EOS,dt_Rho0, &
+  !$OMP parallel do default(private) shared(u,v,h,tv,forces,visc,dt,G,GV,US,CS,use_EOS,dt_Rho0, &
   !$OMP                                     h_neglect,h_tiny,g_H_Rho0,is,ie,OBC,Jsq,Jeq,nz, &
   !$OMP                                     U_bg_sq,cdrag_sqrt,cdrag_sqrt_Z,Rho0x400_G,nkml,mask_u)
   do J=Jsq,Jeq  ! v-point loop

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -7,17 +7,18 @@ use MOM_diag_mediator,      only : diag_ctrl, time_type, register_diag_field
 use MOM_diag_mediator,      only : safe_alloc_ptr, post_data
 use MOM_diag_to_Z,          only : diag_to_Z_CS, register_Zint_diag
 use MOM_diag_to_Z,          only : calc_Zint_diags
-use MOM_EOS,                only : calculate_density
-use MOM_variables,          only : thermo_var_ptrs, p3d
-use MOM_error_handler,      only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_debugging,          only : hchksum
-use MOM_grid,               only : ocean_grid_type
-use MOM_verticalGrid,       only : verticalGrid_type
-use MOM_remapping,          only : remapping_CS, initialize_remapping, remapping_core_h
+use MOM_EOS,                only : calculate_density
+use MOM_error_handler,      only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_file_parser,        only : openParameterBlock, closeParameterBlock
 use MOM_file_parser,        only : get_param, log_param, log_version, param_file_type
-use MOM_string_functions,   only : uppercase, lowercase
+use MOM_grid,               only : ocean_grid_type
 use MOM_io,                 only : slasher, MOM_read_data, vardesc, var_desc, field_size
+use MOM_remapping,          only : remapping_CS, initialize_remapping, remapping_core_h
+use MOM_string_functions,   only : uppercase, lowercase
+use MOM_unit_scaling,       only : unit_scale_type
+use MOM_variables,          only : thermo_var_ptrs, p3d
+use MOM_verticalGrid,       only : verticalGrid_type
 use CVMix_tidal,            only : CVMix_init_tidal, CVMix_compute_Simmons_invariant
 use CVMix_tidal,            only : CVMix_coeffs_tidal, CVMix_tidal_params_type
 use CVMix_tidal,            only : CVMix_compute_Schmittner_invariant, CVMix_compute_SchmittnerCoeff
@@ -204,10 +205,11 @@ integer,        parameter :: SCHMITTNER   = 2
 contains
 
 !> Initializes internal tidal dissipation scheme for diapycnal mixing
-logical function tidal_mixing_init(Time, G, GV, param_file, diag, diag_to_Z_CSp, CS)
+logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_CSp, CS)
   type(time_type),          intent(in)    :: Time       !< The current time.
   type(ocean_grid_type),    intent(in)    :: G          !< Grid structure.
   type(verticalGrid_type),  intent(in)    :: GV         !< Vertical grid structure.
+  type(unit_scale_type),    intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),    intent(in)    :: param_file !< Run-time parameter file handle
   type(diag_ctrl), target,  intent(inout) :: diag       !< Diagnostics control structure.
   type(diag_to_Z_CS),       pointer       :: diag_to_Z_CSp !< pointer to the Z-diagnostics control
@@ -378,7 +380,7 @@ logical function tidal_mixing_init(Time, G, GV, param_file, diag, diag_to_Z_CSp,
                  "When the Polzin decay profile is used, this is the \n"//&
                  "minimum vertical decay scale for the vertical profile\n"//&
                  "of internal tide dissipation with the Polzin (2009) formulation", &
-                 units="m", default=0.0, scale=GV%m_to_Z)
+                 units="m", default=0.0, scale=US%m_to_Z)
   endif
 
   if (CS%Int_tide_dissipation .or. CS%Lee_wave_dissipation) then
@@ -386,7 +388,7 @@ logical function tidal_mixing_init(Time, G, GV, param_file, diag, diag_to_Z_CSp,
                  "The decay scale away from the bottom for tidal TKE with \n"//&
                  "the new coding when INT_TIDE_DISSIPATION is used.", &
                  !units="m", default=0.0)
-                 units="m", default=500.0, scale=GV%m_to_Z)  ! TODO: confirm this new default
+                 units="m", default=500.0, scale=US%m_to_Z)  ! TODO: confirm this new default
     call get_param(param_file, mdl, "MU_ITIDES", CS%Mu_itides, &
                  "A dimensionless turbulent mixing efficiency used with \n"//&
                  "INT_TIDE_DISSIPATION, often 0.2.", units="nondim", default=0.2)
@@ -397,7 +399,7 @@ logical function tidal_mixing_init(Time, G, GV, param_file, diag, diag_to_Z_CSp,
                  units="nondim", default=0.3333)
     call get_param(param_file, mdl, "MIN_ZBOT_ITIDES", CS%min_zbot_itides, &
                  "Turn off internal tidal dissipation when the total \n"//&
-                 "ocean depth is less than this value.", units="m", default=0.0, scale=GV%m_to_Z)
+                 "ocean depth is less than this value.", units="m", default=0.0, scale=US%m_to_Z)
   endif
 
   if ( (CS%Int_tide_dissipation .or. CS%Lee_wave_dissipation) .and. &
@@ -448,7 +450,7 @@ logical function tidal_mixing_init(Time, G, GV, param_file, diag, diag_to_Z_CSp,
                  fail_if_missing=(.not.CS%use_CVMix_tidal))
     filename = trim(CS%inputdir) // trim(h2_file)
     call log_param(param_file, mdl, "INPUTDIR/H2_FILE", filename)
-    call MOM_read_data(filename, 'h2', CS%h2, G%domain, timelevel=1, scale=GV%m_to_Z**2)
+    call MOM_read_data(filename, 'h2', CS%h2, G%domain, timelevel=1, scale=US%m_to_Z**2)
 
     do j=js,je ; do i=is,ie
       if (G%bathyT(i,j) < CS%min_zbot_itides) CS%mask_itidal(i,j) = 0.0
@@ -645,10 +647,11 @@ end function tidal_mixing_init
 !> Depending on whether or not CVMix is active, calls the associated subroutine to compute internal
 !! tidal dissipation and to add the effect of internal-tide-driven mixing to the layer or interface
 !! diffusivities.
-subroutine calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS, &
+subroutine calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US, CS, &
                                   N2_lay, N2_int, Kd_lay, Kd_int, Kd_max, Kv)
   type(ocean_grid_type),            intent(in)    :: G      !< The ocean's grid structure
   type(verticalGrid_type),          intent(in)    :: GV     !< The ocean's vertical grid structure
+  type(unit_scale_type),            intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                                     intent(in)    :: h      !< Layer thicknesses, in H (usually m or kg m-2)
   real, dimension(SZI_(G)),         intent(in)    :: N2_bot !< The near-bottom squared buoyancy
@@ -678,9 +681,9 @@ subroutine calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS, &
 
   if (CS%Int_tide_dissipation .or. CS%Lee_wave_dissipation .or. CS%Lowmode_itidal_dissipation) then
     if (CS%use_CVMix_tidal) then
-      call calculate_CVMix_tidal(h, j, G, GV, CS, N2_int, Kd_lay, Kv)
+      call calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
     else
-      call add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS, &
+      call add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US, CS, &
                                     N2_lay, Kd_lay, Kd_int, Kd_max)
     endif
   endif
@@ -689,14 +692,14 @@ end subroutine calculate_tidal_mixing
 
 !> Calls the CVMix routines to compute tidal dissipation and to add the effect of internal-tide-driven
 !! mixing to the interface diffusivities.
-subroutine calculate_CVMix_tidal(h, j, G, GV, CS, N2_int, Kd_lay, Kv)
+subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
   integer,                 intent(in)    :: j     !< The j-index to work on
   type(ocean_grid_type),   intent(in)    :: G     !< Grid structure.
   type(verticalGrid_type), intent(in)    :: GV    !< ocean vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US    !< A dimensional unit scaling type
   type(tidal_mixing_cs),   pointer       :: CS    !< This module's control structure.
-  real, dimension(SZI_(G),SZK_(G)+1), &
-                           intent(in)    :: N2_int !< The squared buoyancy frequency at the
-                                                                   !! interfaces, in s-2.
+  real, dimension(SZI_(G),SZK_(G)+1), intent(in) :: N2_int !< The squared buoyancy
+                                                  !! frequency at the interfaces, in s-2.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(in)    :: h     !< Layer thicknesses, in H (usually m or kg m-2).
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
@@ -772,13 +775,13 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, CS, N2_int, Kd_lay, Kv)
 
       ! Update diffusivity
       do k=1,G%ke
-        Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5*GV%m_to_Z**2*(Kd_tidal(k) + Kd_tidal(k+1)) ! Rescale from m2 s-1 to Z2 s-1.
+        Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5*US%m_to_Z**2*(Kd_tidal(k) + Kd_tidal(k+1)) ! Rescale from m2 s-1 to Z2 s-1.
       enddo
 
       ! Update viscosity with the proper unit conversion.
       if (associated(Kv)) then
         do k=1,G%ke+1
-          Kv(i,j,k) = Kv(i,j,k) + GV%m_to_Z**2 * Kv_tidal(k)   ! Rescale from m2 s-1 to Z2 s-1.
+          Kv(i,j,k) = Kv(i,j,k) + US%m_to_Z**2 * Kv_tidal(k)   ! Rescale from m2 s-1 to Z2 s-1.
         enddo
       endif
 
@@ -870,13 +873,13 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, CS, N2_int, Kd_lay, Kv)
 
       ! Update diffusivity
       do k=1,G%ke
-        Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5*GV%m_to_Z**2*(Kd_tidal(k) + Kd_tidal(k+1)) ! Rescale from m2 s-1 to Z2 s-1.
+        Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5*US%m_to_Z**2*(Kd_tidal(k) + Kd_tidal(k+1)) ! Rescale from m2 s-1 to Z2 s-1.
       enddo
 
       ! Update viscosity
       if (associated(Kv)) then
         do k=1,G%ke+1
-          Kv(i,j,k) = Kv(i,j,k) + GV%m_to_Z**2 * Kv_tidal(k)   ! Rescale from m2 s-1 to Z2 s-1.
+          Kv(i,j,k) = Kv(i,j,k) + US%m_to_Z**2 * Kv_tidal(k)   ! Rescale from m2 s-1 to Z2 s-1.
         enddo
       endif
 
@@ -914,10 +917,11 @@ end subroutine calculate_CVMix_tidal
 !! low modes (rays) of the internal tide ("lowmode"), and (3) local dissipation of internal lee waves.
 !! Will eventually need to add diffusivity due to other wave-breaking processes (e.g. Bottom friction,
 !! Froude-number-depending breaking, PSI, etc.).
-subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS, &
+subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US, CS, &
                                     N2_lay, Kd_lay, Kd_int, Kd_max)
   type(ocean_grid_type),            intent(in)    :: G      !< The ocean's grid structure
   type(verticalGrid_type),          intent(in)    :: GV     !< The ocean's vertical grid structure
+  type(unit_scale_type),            intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                                     intent(in)    :: h      !< Layer thicknesses, in H (usually m or kg m-2)
   real, dimension(SZI_(G)),         intent(in)    :: N2_bot !< The near-bottom squared buoyancy frequency
@@ -1058,7 +1062,7 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS,
       !### In the code below 1.0e-14 is a dimensional constant in s-3
       if ((CS%tideamp(i,j) > 0.0) .and. &
           (CS%kappa_itides**2 * CS%h2(i,j) * CS%Nb(i,j)**3 > 1.0e-14) ) then
-        z0_polzin(i) = GV%m_to_Z * CS%Polzin_decay_scale_factor * CS%Nu_Polzin * &
+        z0_polzin(i) = US%m_to_Z * CS%Polzin_decay_scale_factor * CS%Nu_Polzin * &
                        CS%Nbotref_Polzin**2 * CS%tideamp(i,j) / &
                      ( CS%kappa_itides**2 * CS%h2(i,j) * CS%Nb(i,j)**3 )
         if (z0_polzin(i) < CS%Polzin_min_decay_scale) &
@@ -1084,21 +1088,21 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, CS,
       if ( CS%Int_tide_dissipation .and. (CS%int_tide_profile == POLZIN_09) ) then
         ! For the Polzin formulation, this if loop prevents the vertical
         ! flux of energy dissipation from having NaN values
-        if (htot_WKB(i) > 1.0e-14*GV%m_to_Z) then  !### Avoid using this dimensional constant.
+        if (htot_WKB(i) > 1.0e-14*US%m_to_Z) then  !### Avoid using this dimensional constant.
           Inv_int(i) = ( z0_polzin_scaled(i) / htot_WKB(i) ) + 1.0
         endif
       endif
       if ( CS%lee_wave_dissipation .and. (CS%lee_wave_profile == POLZIN_09) ) then
         ! For the Polzin formulation, this if loop prevents the vertical
         ! flux of energy dissipation from having NaN values
-        if (htot_WKB(i) > 1.0e-14*GV%m_to_Z) then !### Avoid using this dimensional constant.
+        if (htot_WKB(i) > 1.0e-14*US%m_to_Z) then !### Avoid using this dimensional constant.
           Inv_int_lee(i) = ( z0_polzin_scaled(i)*CS%Decay_scale_factor_lee / htot_WKB(i) ) + 1.0
         endif
       endif
       if ( CS%Lowmode_itidal_dissipation .and. (CS%int_tide_profile == POLZIN_09) ) then
         ! For the Polzin formulation, this if loop prevents the vertical
         ! flux of energy dissipation from having NaN values
-        if (htot_WKB(i) > 1.0e-14*GV%m_to_Z) then !### Avoid using this dimensional constant.
+        if (htot_WKB(i) > 1.0e-14*US%m_to_Z) then !### Avoid using this dimensional constant.
           Inv_int_low(i) = ( z0_polzin_scaled(i) / htot_WKB(i) ) + 1.0
         endif
       endif

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -413,7 +413,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
     call get_param(param_file, mdl, "KAPPA_ITIDES", CS%kappa_itides, &
                  "A topographic wavenumber used with INT_TIDE_DISSIPATION. \n"//&
                  "The default is 2pi/10 km, as in St.Laurent et al. 2002.", &
-                 units="m-1", default=8.e-4*atan(1.0), scale=GV%Z_to_m)
+                 units="m-1", default=8.e-4*atan(1.0), scale=US%Z_to_m)
 
     call get_param(param_file, mdl, "UTIDE", CS%utide, &
                  "The constant tidal amplitude used with INT_TIDE_DISSIPATION.", &
@@ -463,7 +463,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
 
       utide = CS%tideamp(i,j)
       ! Compute the fixed part of internal tidal forcing; units are [kg s-2] here.
-      CS%TKE_itidal(i,j) = 0.5*GV%Z_to_m * CS%kappa_h2_factor*GV%Rho0*&
+      CS%TKE_itidal(i,j) = 0.5*US%Z_to_m * CS%kappa_h2_factor*GV%Rho0*&
            CS%kappa_itides * CS%h2(i,j) * utide*utide
     enddo ; enddo
 
@@ -544,10 +544,10 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
     call CVMix_init_tidal(CVmix_tidal_params_user = CS%CVMix_tidal_params,    &
                           mix_scheme              = CVMix_tidal_scheme_str,   &
                           efficiency              = CS%Mu_itides,             &
-                          vertical_decay_scale    = CS%int_tide_decay_scale*GV%Z_to_m,  &
+                          vertical_decay_scale    = CS%int_tide_decay_scale*US%Z_to_m,  &
                           max_coefficient         = CS%tidal_max_coef,        &
                           local_mixing_frac       = CS%Gamma_itides,          &
-                          depth_cutoff            = CS%min_zbot_itides*GV%Z_to_m)
+                          depth_cutoff            = CS%min_zbot_itides*US%Z_to_m)
 
     call read_tidal_energy(G, tidal_energy_type, tidal_energy_file, CS)
 
@@ -561,7 +561,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
       CS%Lowmode_itidal_dissipation) then
 
     CS%id_Kd_itidal = register_diag_field('ocean_model','Kd_itides',diag%axesTi,Time, &
-         'Internal Tide Driven Diffusivity', 'm2 s-1', conversion=GV%Z_to_m**2)
+         'Internal Tide Driven Diffusivity', 'm2 s-1', conversion=US%Z_to_m**2)
 
     if (CS%use_CVMix_tidal) then
       CS%id_N2_int = register_diag_field('ocean_model','N2_int',diag%axesTi,Time, &
@@ -583,7 +583,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
            'Bottom Buoyancy Frequency', 's-1')
 
       CS%id_Kd_lowmode = register_diag_field('ocean_model','Kd_lowmode',diag%axesTi,Time, &
-           'Internal Tide Driven Diffusivity (from propagating low modes)', 'm2 s-1', conversion=GV%Z_to_m**2)
+           'Internal Tide Driven Diffusivity (from propagating low modes)', 'm2 s-1', conversion=US%Z_to_m**2)
 
       CS%id_Fl_itidal = register_diag_field('ocean_model','Fl_itides',diag%axesTi,Time, &
           'Vertical flux of tidal turbulent dissipation', 'm3 s-3')
@@ -592,12 +592,12 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
            'Vertical flux of tidal turbulent dissipation (from propagating low modes)', 'm3 s-3')
 
       CS%id_Polzin_decay_scale = register_diag_field('ocean_model','Polzin_decay_scale',diag%axesT1,Time, &
-           'Vertical decay scale for the tidal turbulent dissipation with Polzin scheme', 'm', conversion=GV%Z_to_m)
+           'Vertical decay scale for the tidal turbulent dissipation with Polzin scheme', 'm', conversion=US%Z_to_m)
 
       CS%id_Polzin_decay_scale_scaled = register_diag_field('ocean_model', &
            'Polzin_decay_scale_scaled', diag%axesT1, Time, &
            'Vertical decay scale for the tidal turbulent dissipation with Polzin scheme, '// &
-           'scaled by N2_bot/N2_meanz', 'm', conversion=GV%Z_to_m)
+           'scaled by N2_bot/N2_meanz', 'm', conversion=US%Z_to_m)
 
       CS%id_N2_bot = register_diag_field('ocean_model','N2_b',diag%axesT1,Time, &
            'Bottom Buoyancy frequency squared', 's-2')
@@ -618,24 +618,24 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
         CS%id_TKE_leewave = register_diag_field('ocean_model','TKE_leewave',diag%axesT1,Time, &
             'Lee wave Driven Turbulent Kinetic Energy', 'W m-2')
         CS%id_Kd_Niku = register_diag_field('ocean_model','Kd_Nikurashin',diag%axesTi,Time, &
-             'Lee Wave Driven Diffusivity', 'm2 s-1', conversion=GV%Z_to_m**2)
+             'Lee Wave Driven Diffusivity', 'm2 s-1', conversion=US%Z_to_m**2)
       endif
     endif ! S%use_CVMix_tidal
 
     if (associated(CS%diag_to_Z_CSp)) then
       vd = var_desc("Kd_itides","m2 s-1", &
                     "Internal Tide Driven Diffusivity, interpolated to z", z_grid='z')
-      CS%id_Kd_itidal_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=GV%Z_to_m**2)
+      CS%id_Kd_itidal_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=US%Z_to_m**2)
       if (CS%Lee_wave_dissipation) then
          vd = var_desc("Kd_Nikurashin", "m2 s-1", &
                        "Lee Wave Driven Diffusivity, interpolated to z", z_grid='z')
-         CS%id_Kd_Niku_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=GV%Z_to_m**2)
+         CS%id_Kd_Niku_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=US%Z_to_m**2)
       endif
       if (CS%Lowmode_itidal_dissipation) then
         vd = var_desc("Kd_lowmode","m2 s-1", &
                   "Internal Tide Driven Diffusivity (from low modes), interpolated to z",&
                   z_grid='z')
-        CS%id_Kd_lowmode_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=GV%Z_to_m**2)
+        CS%id_Kd_lowmode_z = register_Zint_diag(vd, CS%diag_to_Z_CSp, Time, conversion=US%Z_to_m**2)
       endif
     endif
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -16,6 +16,7 @@ use MOM_open_boundary, only : OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_PointAccel, only : write_u_accel, write_v_accel, PointAccel_init
 use MOM_PointAccel, only : PointAccel_CS
 use MOM_time_manager, only : time_type, time_type_to_real, operator(-)
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs, vertvisc_type
 use MOM_variables, only : cont_diag_ptrs, accel_diag_ptrs
 use MOM_variables, only : ocean_internal_state
@@ -563,9 +564,10 @@ end subroutine vertvisc_remnant
 !> Calculate the coupling coefficients (CS%a_u and CS%a_v)
 !! and effective layer thicknesses (CS%h_u and CS%h_v) for later use in the
 !! applying the implicit vertical viscosity via vertvisc().
-subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, CS, OBC)
+subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, US, CS, OBC)
   type(ocean_grid_type),   intent(in)    :: G      !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV     !< Ocean vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
                            intent(in)    :: u      !< Zonal velocity in m s-1
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
@@ -755,7 +757,7 @@ subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, CS, OBC)
     endif
 
     call find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i, h_ml, &
-                            dt, j, G, GV, CS, visc, forces, work_on_u=.true., OBC=OBC)
+                            dt, j, G, GV, US, CS, visc, forces, work_on_u=.true., OBC=OBC)
     if (allocated(hML_u)) then
       do i=isq,ieq ; if (do_i(i)) then ; hML_u(I,j) = h_ml(I) ; endif ; enddo
     endif
@@ -770,7 +772,7 @@ subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, CS, OBC)
       if (do_any_shelf) then
         if (CS%harmonic_visc) then
           call find_coupling_coef(a_shelf, hvel, do_i_shelf, h_harm, bbl_thick, &
-                                  kv_bbl, z_i, h_ml, dt, j, G, GV, CS, &
+                                  kv_bbl, z_i, h_ml, dt, j, G, GV, US, CS, &
                                   visc, forces, work_on_u=.true., OBC=OBC, shelf=.true.)
         else  ! Find upwind-biased thickness near the surface.
           ! Perhaps this needs to be done more carefully, via find_eta.
@@ -798,7 +800,7 @@ subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, CS, OBC)
             endif ; enddo
           enddo
           call find_coupling_coef(a_shelf, hvel_shelf, do_i_shelf, h_harm, &
-                                  bbl_thick, kv_bbl, z_i, h_ml, dt, j, G, GV, CS, &
+                                  bbl_thick, kv_bbl, z_i, h_ml, dt, j, G, GV, US, CS, &
                                   visc, forces, work_on_u=.true., OBC=OBC, shelf=.true.)
         endif
         do I=Isq,Ieq ; if (do_i_shelf(I)) CS%a1_shelf_u(I,j) = a_shelf(I,1) ; enddo
@@ -924,7 +926,7 @@ subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, CS, OBC)
     endif
 
     call find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i, h_ml, &
-                            dt, j, G, GV, CS, visc, forces, work_on_u=.false., OBC=OBC)
+                            dt, j, G, GV, US, CS, visc, forces, work_on_u=.false., OBC=OBC)
     if ( allocated(hML_v)) then
        do i=is,ie ; if (do_i(i)) then ; hML_v(i,J) = h_ml(i) ; endif ; enddo
     endif
@@ -938,7 +940,7 @@ subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, CS, OBC)
       if (do_any_shelf) then
         if (CS%harmonic_visc) then
           call find_coupling_coef(a_shelf, hvel, do_i_shelf, h_harm, bbl_thick, &
-                                  kv_bbl, z_i, h_ml, dt, j, G, GV, CS, visc, &
+                                  kv_bbl, z_i, h_ml, dt, j, G, GV, US, CS, visc, &
                                   forces, work_on_u=.false., OBC=OBC, shelf=.true.)
         else  ! Find upwind-biased thickness near the surface.
           ! Perhaps this needs to be done more carefully, via find_eta.
@@ -966,7 +968,7 @@ subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, CS, OBC)
             endif ; enddo
           enddo
           call find_coupling_coef(a_shelf, hvel_shelf, do_i_shelf, h_harm, &
-                                  bbl_thick, kv_bbl, z_i, h_ml, dt, j, G, GV, CS, &
+                                  bbl_thick, kv_bbl, z_i, h_ml, dt, j, G, GV, US, CS, &
                                   visc, forces, work_on_u=.false., OBC=OBC, shelf=.true.)
         endif
         do i=is,ie ; if (do_i_shelf(i)) CS%a1_shelf_v(i,J) = a_shelf(i,1) ; enddo
@@ -1034,9 +1036,10 @@ end subroutine vertvisc_coef
 !! interfaces. If BOTTOMDRAGLAW is defined, the minimum of Hbbl and half the
 !! adjacent layer thicknesses are used to calculate a[k] near the bottom.
 subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i, h_ml, &
-                              dt, j, G, GV, CS, visc, forces, work_on_u, OBC, shelf)
+                              dt, j, G, GV, US, CS, visc, forces, work_on_u, OBC, shelf)
   type(ocean_grid_type),     intent(in)  :: G  !< Ocean grid structure
   type(verticalGrid_type),   intent(in)  :: GV !< Ocean vertical grid structure
+  type(unit_scale_type),     intent(in)  :: US !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZK_(GV)+1), &
                              intent(out) :: a_cpl !< Coupling coefficient across interfaces, in Z s-1
   real, dimension(SZIB_(G),SZK_(GV)), &
@@ -1292,11 +1295,11 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
     do i=is,ie ; if (do_i(i)) then
       if (GV%nkml>0) nk_visc(i) = real(GV%nkml+1)
       if (work_on_u) then
-        u_star(I) = 0.5*GV%m_to_Z*(forces%ustar(i,j) + forces%ustar(i+1,j))
+        u_star(I) = 0.5*US%m_to_Z*(forces%ustar(i,j) + forces%ustar(i+1,j))
         absf(I) = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
         if (CS%dynamic_viscous_ML) nk_visc(I) = visc%nkml_visc_u(I,j) + 1
       else
-        u_star(i) = 0.5*GV%m_to_Z*(forces%ustar(i,j) + forces%ustar(i,j+1))
+        u_star(i) = 0.5*US%m_to_Z*(forces%ustar(i,j) + forces%ustar(i,j+1))
         absf(i) = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
         if (CS%dynamic_viscous_ML) nk_visc(i) = visc%nkml_visc_v(i,J) + 1
       endif
@@ -1307,16 +1310,16 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
     if (do_OBCS) then ; if (work_on_u) then
       do I=is,ie ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= OBC_NONE)) then
         if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) &
-          u_star(I) = GV%m_to_Z*forces%ustar(i,j)
+          u_star(I) = US%m_to_Z*forces%ustar(i,j)
         if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) &
-          u_star(I) = GV%m_to_Z*forces%ustar(i+1,j)
+          u_star(I) = US%m_to_Z*forces%ustar(i+1,j)
       endif ; enddo
     else
       do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= OBC_NONE)) then
         if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) &
-          u_star(i) = GV%m_to_Z*forces%ustar(i,j)
+          u_star(i) = US%m_to_Z*forces%ustar(i,j)
         if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) &
-          u_star(i) = GV%m_to_Z*forces%ustar(i,j+1)
+          u_star(i) = US%m_to_Z*forces%ustar(i,j+1)
       endif ; enddo
     endif ; endif
 
@@ -1557,7 +1560,7 @@ subroutine vertvisc_limit_vel(u, v, h, ADp, CDp, forces, visc, dt, G, GV, CS)
 end subroutine vertvisc_limit_vel
 
 !> Initialize the vertical friction module
-subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
+subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
                          ntrunc, CS)
   type(ocean_internal_state), &
                    target, intent(in)    :: MIS    !< The "MOM Internal State", a set of pointers
@@ -1566,6 +1569,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
   type(time_type), target, intent(in)    :: Time   !< Current model time
   type(ocean_grid_type),   intent(in)    :: G      !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV     !< Ocean vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< File to parse for parameters
   type(diag_ctrl), target, intent(inout) :: diag   !< Diagnostic control structure
   type(accel_diag_ptrs),   intent(inout) :: ADp    !< Acceleration diagnostic pointers
@@ -1662,18 +1666,18 @@ subroutine vertvisc_init(MIS, Time, G, GV, param_file, diag, ADp, dirs, &
   call get_param(param_file, mdl, "KV", CS%Kv, &
                  "The background kinematic viscosity in the interior. \n"//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
-                 units="m2 s-1", fail_if_missing=.true., scale=GV%m_to_Z**2, unscaled=Kv_dflt)
+                 units="m2 s-1", fail_if_missing=.true., scale=US%m_to_Z**2, unscaled=Kv_dflt)
 
   if (GV%nkml < 1) call get_param(param_file, mdl, "KVML", CS%Kvml, &
                  "The kinematic viscosity in the mixed layer.  A typical \n"//&
                  "value is ~1e-2 m2 s-1. KVML is not used if \n"//&
                  "BULKMIXEDLAYER is true.  The default is set by KV.", &
-                 units="m2 s-1", default=Kv_dflt, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=Kv_dflt, scale=US%m_to_Z**2)
   if (.not.CS%bottomdraglaw) call get_param(param_file, mdl, "KVBBL", CS%Kvbbl, &
                  "The kinematic viscosity in the benthic boundary layer. \n"//&
                  "A typical value is ~1e-2 m2 s-1. KVBBL is not used if \n"//&
                  "BOTTOMDRAGLAW is true.  The default is set by KV.", &
-                 units="m2 s-1", default=Kv_dflt, scale=GV%m_to_Z**2)
+                 units="m2 s-1", default=Kv_dflt, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "HBBL", CS%Hbbl, &
                  "The thickness of a bottom boundary layer with a \n"//&
                  "viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or \n"//&

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -18,6 +18,7 @@ use MOM_sponge,          only : set_up_sponge_field, sponge_CS
 use MOM_time_manager,    only : time_type
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables,       only : surface
 use MOM_verticalGrid,    only : verticalGrid_type
 
@@ -134,10 +135,11 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 end function register_DOME_tracer
 
 !> Initializes the NTR tracer fields in tr(:,:,:,:) and sets up the tracer output.
-subroutine initialize_DOME_tracer(restart, day, G, GV, h, diag, OBC, CS, &
+subroutine initialize_DOME_tracer(restart, day, G, GV, US, h, diag, OBC, CS, &
                                   sponge_CSp, diag_to_Z_CSp, param_file)
   type(ocean_grid_type),                 intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type),               intent(in) :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),                 intent(in) :: US !< A dimensional unit scaling type
   logical,                               intent(in) :: restart !< .true. if the fields have already
                                                                !! been read from a restart file.
   type(time_type), target,               intent(in) :: day     !< Time of the start of the run.
@@ -218,8 +220,8 @@ subroutine initialize_DOME_tracer(restart, day, G, GV, h, diag, OBC, CS, &
           do k=nz,1,-1
             e(K) = e(K+1) + h(i,j,k)*GV%H_to_Z
             do m=7,NTR
-              e_top = (-600.0*real(m-1) + 3000.0) * GV%m_to_Z
-              e_bot = (-600.0*real(m-1) + 2700.0) * GV%m_to_Z
+              e_top = (-600.0*real(m-1) + 3000.0) * US%m_to_Z
+              e_bot = (-600.0*real(m-1) + 2700.0) * US%m_to_Z
               if (e_top < e(K)) then
                 if (e_top < e(K+1)) then ; d_tr = 0.0
                 elseif (e_bot < e(K+1)) then

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -18,6 +18,7 @@ use MOM_time_manager,       only : time_type
 use MOM_tracer_registry,    only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic,    only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init,      only : tracer_Z_init
+use MOM_unit_scaling,       only : unit_scale_type
 use MOM_variables,          only : surface
 use MOM_verticalGrid,       only : verticalGrid_type
 
@@ -61,9 +62,10 @@ contains
 
 !> This subroutine is used to register tracer fields and subroutines
 !! to be used with MOM.
-function register_dye_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
+function register_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   type(hor_index_type),       intent(in) :: HI   !< A horizontal index type structure.
   type(verticalGrid_type),    intent(in) :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),      intent(in) :: US   !< A dimensional unit scaling type
   type(param_file_type),      intent(in) :: param_file !< A structure to parse for run-time parameters
   type(dye_tracer_CS),        pointer    :: CS   !< A pointer that is set to point to the control
                                                  !! structure for this module
@@ -135,15 +137,15 @@ function register_dye_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   CS%dye_source_mindepth(:) = -1.e30
   call get_param(param_file, mdl, "DYE_SOURCE_MINDEPTH", CS%dye_source_mindepth, &
                  "This is the minumum depth at which we inject dyes.", &
-                 units="m", scale=GV%m_to_Z, fail_if_missing=.true.)
-  if (minval(CS%dye_source_mindepth(:)) < -1.e29*GV%m_to_Z) &
+                 units="m", scale=US%m_to_Z, fail_if_missing=.true.)
+  if (minval(CS%dye_source_mindepth(:)) < -1.e29*US%m_to_Z) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MINDEPTH")
 
   CS%dye_source_maxdepth(:) = -1.e30
   call get_param(param_file, mdl, "DYE_SOURCE_MAXDEPTH", CS%dye_source_maxdepth, &
                  "This is the maximum depth at which we inject dyes.", &
-                 units="m", scale=GV%m_to_Z, fail_if_missing=.true.)
-  if (minval(CS%dye_source_maxdepth(:)) < -1.e29*GV%m_to_Z) &
+                 units="m", scale=US%m_to_Z, fail_if_missing=.true.)
+  if (minval(CS%dye_source_maxdepth(:)) < -1.e29*US%m_to_Z) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MAXDEPTH ")
 
   allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr)) ; CS%tr(:,:,:,:) = 0.0

--- a/src/user/BFB_initialization.F90
+++ b/src/user/BFB_initialization.F90
@@ -9,6 +9,7 @@ use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use MOM_verticalGrid, only : verticalGrid_type
@@ -70,9 +71,10 @@ end subroutine BFB_set_coord
 
 !> This subroutine sets up the sponges for the southern bouundary of the domain. Maximum damping occurs
 !! within 2 degrees lat of the boundary. The damping linearly decreases northward over the next 2 degrees.
-subroutine BFB_initialize_sponges_southonly(G, GV, use_temperature, tv, param_file, CSp, h)
+subroutine BFB_initialize_sponges_southonly(G, GV, US, use_temperature, tv, param_file, CSp, h)
   type(ocean_grid_type),   intent(in) :: G  !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in) :: US !< A dimensional unit scaling type
   logical,                 intent(in) :: use_temperature !< If true, temperature and salinity are used as
                                             !! state variables.
   type(thermo_var_ptrs),   intent(in) :: tv   !< A structure pointing to various thermodynamic variables
@@ -102,7 +104,7 @@ subroutine BFB_initialize_sponges_southonly(G, GV, use_temperature, tv, param_fi
 
 !   Set up sponges for DOME configuration
   call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
-                 "The minimum depth of the ocean.", units="m", default=0.0, scale=GV%m_to_Z)
+                 "The minimum depth of the ocean.", units="m", default=0.0, scale=US%m_to_Z)
 
   call get_param(param_file, mdl, "SOUTHLAT", slat, &
                  "The southern latitude of the domain.", units="degrees")

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -10,6 +10,7 @@ use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_sponge, only : sponge_CS, set_up_sponge_field, initialize_sponge
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -84,9 +85,10 @@ subroutine DOME2d_initialize_topography ( D, G, param_file, max_depth )
 end subroutine DOME2d_initialize_topography
 
 !> Initialize thicknesses according to coordinate mode
-subroutine DOME2d_initialize_thickness ( h, G, GV, param_file, just_read_params )
+subroutine DOME2d_initialize_thickness ( h, G, GV, US, param_file, just_read_params )
   type(ocean_grid_type),   intent(in)  :: G  !< Ocean grid structure
   type(verticalGrid_type), intent(in)  :: GV !< Vertical grid structure
+  type(unit_scale_type),   intent(in)  :: US !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -115,7 +117,7 @@ subroutine DOME2d_initialize_thickness ( h, G, GV, param_file, just_read_params 
     call MOM_mesg("MOM_initialization.F90, DOME2d_initialize_thickness: setting thickness")
 
   call get_param(param_file, mdl,"MIN_THICKNESS",min_thickness, &
-                 default=1.e-3, units="m", do_not_log=.true., scale=GV%m_to_Z)
+                 default=1.e-3, units="m", do_not_log=.true., scale=US%m_to_Z)
   call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=.true.)
   call get_param(param_file, mdl, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &

--- a/src/user/Idealized_Hurricane.F90
+++ b/src/user/Idealized_Hurricane.F90
@@ -268,8 +268,8 @@ subroutine idealized_hurricane_wind_forcing(state, forces, day, G, CS)
         YY = YC + CS%dy_from_center
         XX = XC
       else
-        LAT = G%geoLatCu(I,j)*1000. !KM_to_m
-        LON = G%geoLonCu(I,j)*1000. !KM_to_m
+        LAT = G%geoLatCu(I,j)*1000. ! Convert Lat from km to m.
+        LON = G%geoLonCu(I,j)*1000. ! Convert Lon from km to m.
         YY = LAT - YC
         XX = LON - XC
       endif
@@ -291,13 +291,12 @@ subroutine idealized_hurricane_wind_forcing(state, forces, day, G, CS)
         YY = YC + CS%dy_from_center
         XX = XC
       else
-        LAT = G%geoLatCv(i,J)*1000. !KM_to_m
-        LON = G%geoLonCv(i,J)*1000. !KM_to_m
+        LAT = G%geoLatCv(i,J)*1000. ! Convert Lat from km to m.
+        LON = G%geoLonCv(i,J)*1000. ! Convert Lon from km to m.
         YY = LAT - YC
         XX = LON - XC
       endif
-      call idealized_hurricane_wind_profile(&
-           CS,f,YY,XX,Uocn,Vocn,TX,TY)
+      call idealized_hurricane_wind_profile(CS, f, YY, XX, Uocn, Vocn, TX, TY)
       forces%tauy(i,J) = G%mask2dCv(i,J) * TY
     enddo
   enddo
@@ -316,7 +315,7 @@ subroutine idealized_hurricane_wind_forcing(state, forces, day, G, CS)
 end subroutine idealized_hurricane_wind_forcing
 
 !> Calculate the wind speed at a location as a function of time.
-subroutine idealized_hurricane_wind_profile(CS,absf,YY,XX,UOCN,VOCN,Tx,Ty)
+subroutine idealized_hurricane_wind_profile(CS, absf, YY, XX, UOCN, VOCN, Tx, Ty)
   ! Author: Brandon Reichl
   ! Date: Nov-20-2014
   !       Aug-14-2018 Generalized for non-SCM configuration
@@ -436,8 +435,8 @@ subroutine idealized_hurricane_wind_profile(CS,absf,YY,XX,UOCN,VOCN,Tx,Ty)
   endif
 
   ! Compute stress vector
-  TX = CS%rho_A * Cd * sqrt(du**2+dV**2) * dU
-  TY = CS%rho_A * Cd * sqrt(du**2+dV**2) * dV
+  TX = CS%rho_A * Cd * sqrt(du**2 + dV**2) * dU
+  TY = CS%rho_A * Cd * sqrt(du**2 + dV**2) * dV
 
   return
 end subroutine idealized_hurricane_wind_profile

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -16,6 +16,7 @@ use MOM_open_boundary,  only : OBC_segment_type, register_OBC
 use MOM_open_boundary,  only : OBC_DIRECTION_N, OBC_DIRECTION_E
 use MOM_open_boundary,  only : OBC_DIRECTION_S, OBC_DIRECTION_W
 use MOM_open_boundary,  only : OBC_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type
 use MOM_time_manager,   only : time_type, time_type_to_real
 
@@ -155,13 +156,14 @@ subroutine Kelvin_initialize_topography(D, G, param_file, max_depth)
 end subroutine Kelvin_initialize_topography
 
 !> This subroutine sets the properties of flow at open boundary conditions.
-subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, h, Time)
+subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   type(ocean_OBC_type),    pointer    :: OBC  !< This open boundary condition type specifies
                                               !! whether, where, and what open boundary
                                               !! conditions are used.
   type(Kelvin_OBC_CS),     pointer    :: CS   !< Kelvin wave control structure.
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in) :: US    !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h !< layer thickness, in H.
   type(time_type),         intent(in) :: Time !< model time.
 
@@ -192,9 +194,9 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, h, Time)
 
   if (CS%mode == 0) then
     omega = 2.0 * PI / (12.42 * 3600.0)      ! M2 Tide period
-    val1 = GV%m_to_Z * sin(omega * time_sec)
+    val1 = US%m_to_Z * sin(omega * time_sec)
   else
-    N0 = sqrt((CS%rho_range / CS%rho_0) * GV%g_Earth * (GV%m_to_Z * CS%H0))
+    N0 = sqrt((CS%rho_range / CS%rho_0) * GV%g_Earth * (US%m_to_Z * CS%H0))
     ! Two wavelengths in domain
     plx = 4.0 * PI / G%len_lon
     pmz = PI * CS%mode / CS%H0

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -796,7 +796,7 @@ subroutine Surface_Bands_by_data_override(day_center, G, GV, US, CS)
              " in file "// trim(SurfBandFileName)//" in MOM_wave_interface")
       endif
       NUMBANDS = ID
-      do B = 1,NumBands ; CS%WaveNum_Cen(b) = GV%Z_to_m*CS%WaveNum_Cen(b) ; enddo
+      do B = 1,NumBands ; CS%WaveNum_Cen(b) = US%Z_to_m*CS%WaveNum_Cen(b) ; enddo
     elseif (PartitionMode==1) then
       rcode_fr = NF90_GET_VAR(ncid, dim_id(1), CS%Freq_Cen, start, counter)
       if (rcode_fr /= 0) then
@@ -1032,7 +1032,7 @@ subroutine get_StokesSL_LiFoxKemper(ustar, hbl, GV, US, UStokes_SL, LA)
     ! is also included
     kstar = kphil * 2.56
     ! surface layer
-    z0 = abs(GV%Z_to_m*hbl)
+    z0 = abs(US%Z_to_m*hbl)
     z0i = 1.0 / z0
     ! term 1 to 4
     r1 = ( 0.151 / kphil * z0i -0.84 ) * &

--- a/src/user/Neverland_initialization.F90
+++ b/src/user/Neverland_initialization.F90
@@ -10,6 +10,7 @@ use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -102,9 +103,10 @@ end function spike
 !! by finding the depths of interfaces in a specified latitude-dependent
 !! temperature profile with an exponentially decaying thermocline on top of a
 !! linear stratification.
-subroutine Neverland_initialize_thickness(h, G, GV, param_file, eqn_of_state, P_ref)
+subroutine Neverland_initialize_thickness(h, G, GV, US, param_file, eqn_of_state, P_ref)
   type(ocean_grid_type),   intent(in) :: G                    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in) :: GV                   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in) :: US                   !< A dimensional unit scaling type
   real, intent(out), dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h !< The thickness that is being
                                                               !! initialized, in H.
   type(param_file_type),   intent(in) :: param_file           !< A structure indicating the open
@@ -126,7 +128,7 @@ subroutine Neverland_initialize_thickness(h, G, GV, param_file, eqn_of_state, P_
 
   call MOM_mesg("  Neverland_initialization.F90, Neverland_initialize_thickness: setting thickness", 5)
   call get_param(param_file, mdl, "INIT_THICKNESS_PROFILE", h_profile, &
-                 "Profile of initial layer thicknesses.", units="m", scale=GV%m_to_Z, &
+                 "Profile of initial layer thicknesses.", units="m", scale=US%m_to_Z, &
                  fail_if_missing=.true.)
 
   ! e0 is the notional position of interfaces

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -10,6 +10,7 @@ use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -29,15 +30,16 @@ public Phillips_initialize_topography
 contains
 
 !> Initialize the thickness field for the Phillips model test case.
-subroutine Phillips_initialize_thickness(h, G, GV, param_file, just_read_params)
-  type(ocean_grid_type),   intent(in) :: G          !< The ocean's grid structure.
-  type(verticalGrid_type), intent(in) :: GV         !< The ocean's vertical grid structure.
+subroutine Phillips_initialize_thickness(h, G, GV, US, param_file, just_read_params)
+  type(ocean_grid_type),   intent(in)  :: G          !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)  :: GV         !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h         !< The thickness that is being initialized, in H.
-  type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
-                                                      !! to parse for model parameter values.
+                           intent(out) :: h          !< The thickness that is being initialized, in H.
+  type(param_file_type),   intent(in)  :: param_file !< A structure indicating the open file
+                                                     !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
-                                                      !! only read parameters without changing h.
+                                                     !! only read parameters without changing h.
 
   real :: eta0(SZK_(G)+1)   ! The 1-d nominal positions of the interfaces, in depth units (Z).
   real :: eta_im(SZJ_(G),SZK_(G)+1) ! A temporary array for zonal-mean eta, in depth units (Z).
@@ -65,7 +67,7 @@ subroutine Phillips_initialize_thickness(h, G, GV, param_file, just_read_params)
                  fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "JET_HEIGHT", jet_height, &
                  "The interface height scale associated with the \n"//&
-                 "zonal-mean jet.", units="m", scale=GV%m_to_Z, &
+                 "zonal-mean jet.", units="m", scale=US%m_to_Z, &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
@@ -109,17 +111,18 @@ subroutine Phillips_initialize_thickness(h, G, GV, param_file, just_read_params)
 end subroutine Phillips_initialize_thickness
 
 !> Initialize the velocity fields for the Phillips model test case
-subroutine Phillips_initialize_velocity(u, v, G, GV, param_file, just_read_params)
+subroutine Phillips_initialize_velocity(u, v, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G  !< Grid structure
   type(verticalGrid_type), intent(in)  :: GV !< Vertical grid structure
+  type(unit_scale_type),   intent(in)  :: US !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                            intent(out) :: u  !< i-component of velocity [m/s]
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                            intent(out) :: v  !< j-component of velocity [m/s]
   type(param_file_type),   intent(in)  :: param_file !< A structure indicating the open file to
-                                                        !! parse for modelparameter values.
+                                                     !! parse for modelparameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
-                                                      !! only read parameters without changing h.
+                                                     !! only read parameters without changing h.
 
   real :: damp_rate, jet_width, jet_height, x_2, y_2
   real :: velocity_amplitude, pi
@@ -139,7 +142,7 @@ subroutine Phillips_initialize_velocity(u, v, G, GV, param_file, just_read_param
                  fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "JET_HEIGHT", jet_height, &
                  "The interface height scale associated with the \n"//&
-                 "zonal-mean jet.", units="m", scale=GV%m_to_Z, &
+                 "zonal-mean jet.", units="m", scale=US%m_to_Z, &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
@@ -185,9 +188,10 @@ end subroutine Phillips_initialize_velocity
 !> Sets up the the inverse restoration time (Idamp), and the values towards which the interface
 !! heights and an arbitrary number of tracers should be restored within each sponge for the Phillips
 !! model test case
-subroutine Phillips_initialize_sponges(G, GV, tv, param_file, CSp, h)
+subroutine Phillips_initialize_sponges(G, GV, US, tv, param_file, CSp, h)
   type(ocean_grid_type), intent(in) :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in) :: GV !< Vertical grid structure
+  type(unit_scale_type), intent(in) :: US   !< A dimensional unit scaling type
   type(thermo_var_ptrs), intent(in) :: tv   !< A structure containing pointers
                                             !! to any available thermodynamic
                                             !! fields, potential temperature and
@@ -239,7 +243,7 @@ subroutine Phillips_initialize_sponges(G, GV, tv, param_file, CSp, h)
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "JET_HEIGHT", jet_height, &
                  "The interface height scale associated with the \n"//&
-                 "zonal-mean jet.", units="m", scale=GV%m_to_Z, &
+                 "zonal-mean jet.", units="m", scale=US%m_to_Z, &
                  fail_if_missing=.true.)
 
   half_depth = G%max_depth*half_strat

--- a/src/user/SCM_CVMix_tests.F90
+++ b/src/user/SCM_CVMix_tests.F90
@@ -93,10 +93,10 @@ subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, US, param_file, just_read_par
                  'Layer 2 surface temperature', units='C', default=20.0, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_DTDZ", LowerLayerdTdZ,     &
                  'Initial temperature stratification in layer 2', &
-                 units='C/m', default=0.0, scale=GV%Z_to_m, do_not_log=just_read)
+                 units='C/m', default=0.0, scale=US%Z_to_m, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_DSDZ", LowerLayerdSdZ,  &
                  'Initial salinity stratification in layer 2', &
-                 units='PPT/m', default=0.0, scale=GV%Z_to_m, do_not_log=just_read)
+                 units='PPT/m', default=0.0, scale=US%Z_to_m, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_MINTEMP",LowerLayerMinTemp, &
                  'Layer 2 minimum temperature', units='C', default=4.0, do_not_log=just_read)
 

--- a/src/user/SCM_CVMix_tests.F90
+++ b/src/user/SCM_CVMix_tests.F90
@@ -10,6 +10,7 @@ use MOM_forcing_type,  only : forcing, mech_forcing
 use MOM_grid,          only : ocean_grid_type
 use MOM_verticalgrid,  only : verticalGrid_type
 use MOM_safe_alloc,    only : safe_alloc_ptr
+use MOM_unit_scaling,  only : unit_scale_type
 use MOM_time_manager,  only : time_type, operator(+), operator(/), time_type_to_real
 use MOM_variables,     only : thermo_var_ptrs, surface
 implicit none ; private
@@ -45,12 +46,13 @@ character(len=40)  :: mdl = "SCM_CVMix_tests" !< This module's name.
 contains
 
 !> Initializes temperature and salinity for the SCM CVMix test example
-subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, param_file, just_read_params)
-  real, dimension(NIMEM_,NJMEM_, NKMEM_), intent(out) :: T !< Potential temperature (degC)
-  real, dimension(NIMEM_,NJMEM_, NKMEM_), intent(out) :: S !< Salinity (psu)
-  real, dimension(NIMEM_,NJMEM_, NKMEM_), intent(in)  :: h !< Layer thickness in H (often m or Pa)
-  type(ocean_grid_type),                  intent(in)  :: G !< Grid structure
-  type(verticalGrid_type),                intent(in)  :: GV!< Vertical grid structure
+subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, US, param_file, just_read_params)
+  real, dimension(NIMEM_,NJMEM_, NKMEM_), intent(out) :: T  !< Potential temperature (degC)
+  real, dimension(NIMEM_,NJMEM_, NKMEM_), intent(out) :: S  !< Salinity (psu)
+  real, dimension(NIMEM_,NJMEM_, NKMEM_), intent(in)  :: h  !< Layer thickness in H (often m or Pa)
+  type(ocean_grid_type),                  intent(in)  :: G  !< Grid structure
+  type(verticalGrid_type),                intent(in)  :: GV !< Vertical grid structure
+  type(unit_scale_type),                  intent(in)  :: US !< A dimensional unit scaling type
   type(param_file_type),                  intent(in)  :: param_file !< Input parameter structure
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing h.
@@ -77,10 +79,10 @@ subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, param_file, just_read_params)
   if (.not.just_read) call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "SCM_TEMP_MLD", UpperLayerTempMLD, &
                  'Initial temp mixed layer depth', &
-                 units='m', default=0.0, scale=GV%m_to_Z, do_not_log=just_read)
+                 units='m', default=0.0, scale=US%m_to_Z, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_SALT_MLD", UpperLayerSaltMLD, &
                  'Initial salt mixed layer depth', &
-                 units='m', default=0.0, scale=GV%m_to_Z, do_not_log=just_read)
+                 units='m', default=0.0, scale=US%m_to_Z, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L1_SALT", UpperLayerSalt, &
                  'Layer 2 surface salinity', units='1e-3', default=35.0, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L1_TEMP", UpperLayerTemp, &

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -7,6 +7,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -26,9 +27,10 @@ public adjustment_initialize_temperature_salinity
 contains
 
 !> Initializes the layer thicknesses in the adjustment test case
-subroutine adjustment_initialize_thickness ( h, G, GV, param_file, just_read_params)
+subroutine adjustment_initialize_thickness ( h, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -61,7 +63,7 @@ subroutine adjustment_initialize_thickness ( h, G, GV, param_file, just_read_par
   if (.not.just_read) call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl,"S_REF",S_ref,fail_if_missing=.true.,do_not_log=.true.)
   call get_param(param_file, mdl,"MIN_THICKNESS",min_thickness,'Minimum layer thickness', &
-         units='m', default=1.0e-3, do_not_log=just_read, scale=GV%m_to_Z)
+         units='m', default=1.0e-3, do_not_log=just_read, scale=US%m_to_Z)
 
   ! Parameters specific to this experiment configuration
   call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE",verticalCoordinate, &

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -10,6 +10,7 @@ use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -71,10 +72,11 @@ end subroutine benchmark_initialize_topography
 !! by finding the depths of interfaces in a specified latitude-dependent
 !! temperature profile with an exponentially decaying thermocline on top of a
 !! linear stratification.
-subroutine benchmark_initialize_thickness(h, G, GV, param_file, eqn_of_state, &
+subroutine benchmark_initialize_thickness(h, G, GV, US, param_file, eqn_of_state, &
                                           P_ref, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -118,8 +120,8 @@ subroutine benchmark_initialize_thickness(h, G, GV, param_file, eqn_of_state, &
 
   k1 = GV%nk_rho_varies + 1
 
-  ML_depth = 50.0 * GV%m_to_Z
-  thermocline_scale = 500.0 * GV%m_to_Z
+  ML_depth = 50.0 * US%m_to_Z
+  thermocline_scale = 500.0 * US%m_to_Z
   a_exp = 0.9
 
 ! This block calculates T0(k) for the purpose of diagnosing where the

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -137,7 +137,7 @@ subroutine dumbbell_initialize_thickness ( h, G, GV, US, param_file, just_read_p
       e0(K) = - G%max_depth * ( ( S_light  - S_surf ) + ( S_dense - S_light ) * &
                 ( (real(K)-1.5) / real(nz-1) ) ) / S_range
       ! Force round numbers ... the above expression has irrational factors ...
-      e0(K) = nint(2048.*GV%Z_to_m*e0(K)) / (2048.*GV%Z_to_m)
+      e0(K) = nint(2048.*US%Z_to_m*e0(K)) / (2048.*US%Z_to_m)
       e0(K) = min(real(1-K)*GV%Angstrom_Z, e0(K)) ! Bound by surface
       e0(K) = max(-G%max_depth, e0(K)) ! Bound by bottom
     enddo

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -11,6 +11,7 @@ use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -70,9 +71,10 @@ subroutine dumbbell_initialize_topography ( D, G, param_file, max_depth )
 end subroutine dumbbell_initialize_topography
 
 !> Initializes the layer thicknesses to be uniform in the dumbbell test case
-subroutine dumbbell_initialize_thickness ( h, G, GV, param_file, just_read_params)
+subroutine dumbbell_initialize_thickness ( h, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized, in m.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -100,7 +102,7 @@ subroutine dumbbell_initialize_thickness ( h, G, GV, param_file, just_read_param
 
   call get_param(param_file, mdl,"MIN_THICKNESS", min_thickness, &
                 'Minimum thickness for layer',&
-                 units='m', default=1.0e-3, do_not_log=just_read, scale=GV%m_to_Z)
+                 units='m', default=1.0e-3, do_not_log=just_read, scale=US%m_to_Z)
   call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
 
@@ -246,9 +248,10 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, param_file
 end subroutine dumbbell_initialize_temperature_salinity
 
 !> Initialize the restoring sponges for the dumbbell test case
-subroutine dumbbell_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
+subroutine dumbbell_initialize_sponges(G, GV, US, tv, param_file, use_ALE, CSp, ACSp)
   type(ocean_grid_type),   intent(in) :: G !< Horizontal grid control structure
   type(verticalGrid_type), intent(in) :: GV !< Vertical grid control structure
+  type(unit_scale_type),   intent(in) :: US !< A dimensional unit scaling type
   type(thermo_var_ptrs),   intent(in) :: tv !< Thermodynamic variables
   type(param_file_type),   intent(in) :: param_file !< Parameter file structure
   logical,                 intent(in) :: use_ALE !< ALE flag
@@ -281,7 +284,7 @@ subroutine dumbbell_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp
   call get_param(param_file, mdl, "DUMBBELL_S_RANGE", S_range, do_not_log=.true.)
   call get_param(param_file, mdl,"MIN_THICKNESS", min_thickness, &
                 'Minimum thickness for layer',&
-                 units='m', default=1.0e-3, do_not_log=.true., scale=GV%m_to_Z)
+                 units='m', default=1.0e-3, do_not_log=.true., scale=US%m_to_Z)
 
   ! no active sponges
   if (sponge_time_scale <= 0.) return

--- a/src/user/external_gwave_initialization.F90
+++ b/src/user/external_gwave_initialization.F90
@@ -8,6 +8,7 @@ use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 implicit none ; private
@@ -19,9 +20,10 @@ public external_gwave_initialize_thickness
 contains
 
 !> This subroutine initializes layer thicknesses for the external_gwave experiment.
-subroutine external_gwave_initialize_thickness(h, G, GV, param_file, just_read_params)
+subroutine external_gwave_initialize_thickness(h, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -50,7 +52,7 @@ subroutine external_gwave_initialize_thickness(h, G, GV, param_file, just_read_p
   if (.not.just_read) call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "SSH_ANOMALY_HEIGHT", ssh_anomaly_height, &
                  "The vertical displacement of the SSH anomaly. ", units="m", &
-                 fail_if_missing=.not.just_read, do_not_log=just_read, scale=GV%m_to_Z)
+                 fail_if_missing=.not.just_read, do_not_log=just_read, scale=US%m_to_Z)
   call get_param(param_file, mdl, "SSH_ANOMALY_WIDTH", ssh_anomaly_width, &
                  "The lateral width of the SSH anomaly. ", units="coordinate", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)

--- a/src/user/lock_exchange_initialization.F90
+++ b/src/user/lock_exchange_initialization.F90
@@ -9,6 +9,7 @@ use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 
@@ -22,9 +23,10 @@ contains
 
 !> This subroutine initializes layer thicknesses for the lock_exchange experiment.
 ! -----------------------------------------------------------------------------
-subroutine lock_exchange_initialize_thickness(h, G, GV, param_file, just_read_params)
+subroutine lock_exchange_initialize_thickness(h, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -57,12 +59,12 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, param_file, just_read_pa
   call get_param(param_file, mdl, "FRONT_DISPLACEMENT", front_displacement, &
                  "The vertical displacement of interfaces across the front. \n"//&
                  "A value larger in magnitude that MAX_DEPTH is truncated,", &
-                 units="m", fail_if_missing=.not.just_read, do_not_log=just_read, scale=GV%m_to_Z)
+                 units="m", fail_if_missing=.not.just_read, do_not_log=just_read, scale=US%m_to_Z)
   call get_param(param_file, mdl, "THERMOCLINE_THICKNESS", thermocline_thickness, &
                  "The thickness of the thermocline in the lock exchange \n"//&
                  "experiment.  A value of zero creates a two layer system \n"//&
                  "with vanished layers in between the two inflated layers.", &
-                 default=0., units="m", do_not_log=just_read, scale=GV%m_to_Z)
+                 default=0., units="m", do_not_log=just_read, scale=US%m_to_Z)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -11,6 +11,7 @@ use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -73,9 +74,10 @@ end subroutine seamount_initialize_topography
 
 !> Initialization of thicknesses.
 !! This subroutine initializes the layer thicknesses to be uniform.
-subroutine seamount_initialize_thickness ( h, G, GV, param_file, just_read_params)
+subroutine seamount_initialize_thickness ( h, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized, in H.
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -101,7 +103,7 @@ subroutine seamount_initialize_thickness ( h, G, GV, param_file, just_read_param
 
   call get_param(param_file, mdl,"MIN_THICKNESS",min_thickness, &
                 'Minimum thickness for layer',&
-                 units='m', default=1.0e-3, do_not_log=just_read, scale=GV%m_to_Z)
+                 units='m', default=1.0e-3, do_not_log=just_read, scale=US%m_to_Z)
   call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE",verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
 

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -138,7 +138,7 @@ subroutine seamount_initialize_thickness ( h, G, GV, US, param_file, just_read_p
       e0(K) = - G%max_depth * ( ( S_light  - S_surf ) + ( S_dense - S_light ) * &
                               ( (real(K)-1.5) / real(nz-1) ) ) / S_range
       ! Force round numbers ... the above expression has irrational factors ...
-      e0(K) = nint(2048.*GV%Z_to_m*e0(K))/(2048.*GV%Z_to_m)
+      e0(K) = nint(2048.*US%Z_to_m*e0(K))/(2048.*US%Z_to_m)
       e0(K) = min(real(1-K)*GV%Angstrom_Z, e0(K)) ! Bound by surface
       e0(K) = max(-G%max_depth, e0(K)) ! Bound by bottom
     enddo

--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -7,6 +7,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -27,9 +28,10 @@ public soliton_initialize_velocity
 contains
 
 !> Initialization of thicknesses in Equatorial Rossby soliton test
-subroutine soliton_initialize_thickness(h, G, GV)
+subroutine soliton_initialize_thickness(h, G, GV, US)
   type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h    !< The thickness that is being initialized, in H.
 
@@ -45,7 +47,7 @@ subroutine soliton_initialize_thickness(h, G, GV)
   x0 = 2.0*G%len_lon/3.0
   y0 = 0.0
   val1 = 0.395
-  val2 = GV%m_to_Z * 0.771*(val1*val1)
+  val2 = US%m_to_Z * 0.771*(val1*val1)
 
   do j = G%jsc,G%jec ; do i = G%isc,G%iec
     do k = 1, nz

--- a/src/user/user_change_diffusivity.F90
+++ b/src/user/user_change_diffusivity.F90
@@ -7,6 +7,7 @@ use MOM_diag_mediator, only : diag_ctrl, time_type
 use MOM_error_handler, only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs, vertvisc_type, p3d
 use MOM_verticalGrid,  only : verticalGrid_type
 use MOM_EOS,           only : calculate_density
@@ -181,10 +182,11 @@ function val_weights(val, range) result(ans)
 end function val_weights
 
 !> Set up the module control structure.
-subroutine user_change_diff_init(Time, G, GV, param_file, diag, CS)
+subroutine user_change_diff_init(Time, G, GV, US, param_file, diag, CS)
   type(time_type),           intent(in)    :: Time       !< The current model time.
   type(ocean_grid_type),     intent(in)    :: G          !< The ocean's grid structure.
   type(verticalGrid_type),   intent(in)    :: GV         !< The ocean's vertical grid structure
+  type(unit_scale_type),     intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),     intent(in)    :: param_file !< A structure indicating the
                                                          !! open file to parse for
                                                          !! model parameter values.
@@ -215,7 +217,7 @@ subroutine user_change_diff_init(Time, G, GV, param_file, diag, CS)
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "USER_KD_ADD", CS%Kd_add, &
                  "A user-specified additional diffusivity over a range of \n"//&
-                 "latitude and density.", default=0.0, units="m2 s-1", scale=GV%m_to_Z**2)
+                 "latitude and density.", default=0.0, units="m2 s-1", scale=US%m_to_Z**2)
   if (CS%Kd_add /= 0.0) then
     call get_param(param_file, mdl, "USER_KD_ADD_LAT_RANGE", CS%lat_range(:), &
                  "Four successive values that define a range of latitudes \n"//&


### PR DESCRIPTION
  Added a new unit_scale_type and related module to handle dimensional unit
rescaling, and use it throughout the MOM6 code for rescaling Z_to_m and m_to_Z.
This involves numerous additional arguments and widespread changes.  There are
two new runtime debugging parameters and a third moved from the MOM_verticalGrid
module.  All answers are bitwise identical, but there are updates to all of the
MOM_parameter_doc files.  The list of new commits in this PR include:
- NOAA-GFDL/MOM6@e1136e0 Rescale HMIX_SFC_PROP via get_param
- NOAA-GFDL/MOM6@fa04b52 Corrected openMP directives
- NOAA-GFDL/MOM6@04069b7 +Pass unit_scale_type argument to step_MOM_thermo
- NOAA-GFDL/MOM6@f8384ef +Replace GV%Z_to_m with US%Z_to_m
- NOAA-GFDL/MOM6@533d495 +Replace GV%m_to_Z with US%m_to_Z
- NOAA-GFDL/MOM6@9b542c3 +Add MOM_unit_scaling module

This PR builds upon https://github.com/NOAA-GFDL/MOM6/pull/874 and should not be accepted until after that PR.