### PR TITLE
Document user code parameters

### DIFF
--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -135,7 +135,7 @@ subroutine wave_speed(h, tv, G, GV, US, cg1, CS, full_halos, use_ebt_mode, &
   rescale = 1024.0**4 ; I_rescale = 1.0/rescale
 
   min_h_frac = tol1 / real(nz)
-!$OMP parallel do default(none) shared(is,ie,js,je,nz,h,G,GV,min_h_frac,use_EOS,T,S,tv,&
+!$OMP parallel do default(none) shared(is,ie,js,je,nz,h,G,GV,US,min_h_frac,use_EOS,T,S,tv,&
 !$OMP                                  calc_modal_structure,l_use_ebt_mode,modal_structure, &
 !$OMP                                  l_mono_N2_column_fraction,l_mono_N2_depth,CS,   &
 !$OMP                                  Z_to_Pa,cg1,g_Rho0,rescale,I_rescale,L2_to_Z2)  &

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -38,8 +38,8 @@ subroutine benchmark_initialize_topography(D, G, param_file, max_depth)
   real :: D0                   ! A constant to make the maximum     !
                                ! basin depth MAXIMUM_DEPTH.         !
   real :: x, y
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "benchmark_initialize_topography" ! This subroutine's name.
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -107,12 +107,21 @@ subroutine benchmark_initialize_thickness(h, G, GV, US, param_file, eqn_of_state
                      ! interface temperature for a given z and its derivative.
   real :: pi, z
   logical :: just_read
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "benchmark_initialize_thickness" ! This subroutine's name.
   integer :: i, j, k, k1, is, ie, js, je, nz, itt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
+  if (.not.just_read) call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "BENCHMARK_ML_DEPTH_IC", ML_depth, &
+                 "Initial mixed layer depth in the benchmark test case.", &
+                 units='m', default=50.0, scale=US%m_to_Z, do_not_log=just_read)
+  call get_param(param_file, mdl, "BENCHMARK_THERMOCLINE_SCALE", thermocline_scale, &
+                 "Initial thermocline depth scale in the benchmark test case.", &
+                 default=500.0, units="m", scale=US%m_to_Z, do_not_log=just_read)
 
   if (just_read) return ! This subroutine has no run-time parameters.
 
@@ -120,8 +129,6 @@ subroutine benchmark_initialize_thickness(h, G, GV, US, param_file, eqn_of_state
 
   k1 = GV%nk_rho_varies + 1
 
-  ML_depth = 50.0 * US%m_to_Z
-  thermocline_scale = 500.0 * US%m_to_Z
   a_exp = 0.9
 
 ! This block calculates T0(k) for the purpose of diagnosing where the

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -37,10 +37,11 @@ subroutine circle_obcs_initialize_thickness(h, G, GV, param_file, just_read_para
                            ! negative because it is positive upward.
   real :: eta1D(SZK_(GV)+1)! Interface height relative to the sea surface
                            ! positive upward, in in depth units (Z).
+  real :: IC_amp           ! The amplitude of the initial height displacement, in H.
   real :: diskrad, rad, xCenter, xRadius, lonC, latC, xOffset
   logical :: just_read
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "circle_obcs_initialization"   ! This module's name.
   integer :: i, j, k, is, ie, js, je, nz
 
@@ -61,6 +62,10 @@ subroutine circle_obcs_initialize_thickness(h, G, GV, param_file, just_read_para
                  "The x-offset of the initially elevated disk in the \n"//&
                  "circle_obcs test case.", units=G%x_axis_units, &
                  default = 0.0, do_not_log=just_read)
+  call get_param(param_file, mdl, "DISK_IC_AMPLITUDE", IC_amp, &
+                 "Initial amplitude of interface height displacements \n"//&
+                 "in the circle_obcs test case.", &
+                 units='m', default=5.0, scale=GV%m_to_H, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -93,12 +98,11 @@ subroutine circle_obcs_initialize_thickness(h, G, GV, param_file, just_read_para
     rad = rad*(2.*asin(1.)) ! Map 0-1 to 0-pi
     if (nz==1) then
       ! The model is barotropic
-      h(i,j,k) = h(i,j,k) + GV%m_to_H * 1.0*0.5*(1.+cos(rad)) ! cosine bell
+      h(i,j,k) = h(i,j,k) + IC_amp * 0.5*(1.+cos(rad)) ! cosine bell
     else
       ! The model is baroclinic
       do k = 1, nz
-        h(i,j,k) = h(i,j,k) - GV%m_to_H * 0.5*(1.+cos(rad)) & ! cosine bell
-            * 5.0 * real( 2*k-nz )
+        h(i,j,k) = h(i,j,k) - 0.5*(1.+cos(rad)) * IC_amp * real( 2*k-nz )
       enddo
     endif
   enddo ; enddo

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -6,7 +6,7 @@ module sloshing_initialization
 use MOM_domains, only : sum_across_PEs
 use MOM_dyn_horgrid, only : dyn_horgrid_type
 use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
-use MOM_file_parser, only : get_param, param_file_type
+use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
@@ -24,8 +24,6 @@ implicit none ; private
 public sloshing_initialize_topography
 public sloshing_initialize_thickness
 public sloshing_initialize_temperature_salinity
-
-character(len=40)  :: mdl = "sloshing_initialization" !< This module's name.
 
 contains
 
@@ -73,14 +71,27 @@ subroutine sloshing_initialize_thickness ( h, G, GV, US, param_file, just_read_p
   real    :: weight_z           ! A (misused?) depth-space weighting, in inconsistent units.
   real    :: x1, y1, x2, y2     ! Dimensonless parameters.
   real    :: x, t               ! Dimensionless depth coordinates?
+  logical :: use_IC_bug         ! If true, set the initial conditions retaining an old bug.
   logical :: just_read          ! If true, just read parameters but set nothing.
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
+  character(len=40)  :: mdl = "sloshing_initialization" !< This module's name.
 
   integer :: i, j, k, is, ie, js, je, nx, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
-  if (just_read) return ! This subroutine has no run-time parameters.
+  if (.not.just_read) call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "SLOSHING_IC_AMPLITUDE", a0, &
+                 "Initial amplitude of sloshing internal interface height \n"//&
+                 "displacements it the sloshing test case.", &
+                 units='m', default=75.0, scale=US%m_to_Z, do_not_log=just_read)
+  call get_param(param_file, mdl, "SLOSHING_IC_BUG", use_IC_bug, &
+                 "If true, use code with a bug to set the sloshing initial conditions.", &
+                 default=.true., do_not_log=just_read)
+
+  if (just_read) return ! All run-time parameters have been read, so return.
 
   ! Define thicknesses
   do j=G%jsc,G%jec ; do i=G%isc,G%iec
@@ -116,14 +127,17 @@ subroutine sloshing_initialize_thickness ( h, G, GV, US, param_file, just_read_p
     enddo
 
     ! 2. Define displacement
-    a0 = 75.0 * US%m_to_Z ! 75m Displacement amplitude in depth units.
+    ! a0 is set via get_param; by default a0 is a 75m Displacement amplitude in depth units.
     do k = 1,nz+1
 
       weight_z = - 4.0 * ( z_unif(k) + 0.5 )**2 + 1.0
 
       x = G%geoLonT(i,j) / G%len_lon
-      !### Perhaps the '+ weight_z' here should be '* weight_z' - RWH
-      displ(k) = a0 * cos(acos(-1.0)*x) + weight_z * US%m_to_Z
+      if (use_IC_bug) then
+        displ(k) = a0 * cos(acos(-1.0)*x) + weight_z * US%m_to_Z
+      else
+        displ(k) = a0 * cos(acos(-1.0)*x) * weight_z
+      endif
 
       if ( k == 1 ) then
         displ(k) = 0.0

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -92,7 +92,7 @@ subroutine USER_initialize_thickness(h, G, GV, param_file, just_read_params)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
-  h(:,:,1) = 0.0 * GV%m_to_H
+  h(:,:,1) = 0.0 ! h should be set in units of H.
 
   if (first_call) call write_user_log(param_file)
 


### PR DESCRIPTION
  Added new runtime parameters and get_param calls that specify some of the
details of the user test cases.  All answers are bitwise identical, but there
are updates to all of the MOM_parameter_doc files.  The list of commits in this
PR include:
- NOAA-GFDL/MOM6@0ace776 Added a comment in USER_initialize_thickness
- NOAA-GFDL/MOM6@9259ba1 +Added run-time parameters for sloshing test case
- NOAA-GFDL/MOM6@0874ac4 +Added the INTERFACE_IC_QUANTA runtime parameter
- NOAA-GFDL/MOM6@6ccb6b6 +Added a run-time parameter for circle_obcs
- NOAA-GFDL/MOM6@fa1a762 +Added run-time parameters for benchmark test case
