### PR TITLE
Rescaled units of ustar fields and ice_shelf code

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -414,7 +414,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, US, CS, sfc
       fluxes%frunoff(i,j) = IOB%calving(i-i0,j-j0) * G%mask2dT(i,j)
 
     if (associated(IOB%ustar_berg)) &
-      fluxes%ustar_berg(i,j) = IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)
+      fluxes%ustar_berg(i,j) = US%m_to_Z * IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)
 
     if (associated(IOB%area_berg)) &
       fluxes%area_berg(i,j) = IOB%area_berg(i-i0,j-j0) * G%mask2dT(i,j)

--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -28,6 +28,7 @@ use MOM_restart,          only : register_restart_field, restart_init, MOM_resta
 use MOM_restart,          only : restart_init_end, save_restart, restore_state
 use MOM_string_functions, only : uppercase
 use MOM_spatial_means,    only : adjust_area_mean_to_zero
+use MOM_unit_scaling,     only : unit_scale_type
 use MOM_variables,        only : surface
 use user_revise_forcing,  only : user_alter_forcing, user_revise_forcing_init
 use user_revise_forcing,  only : user_revise_forcing_CS
@@ -194,7 +195,7 @@ contains
 !> This subroutine translates the Ice_ocean_boundary_type into a MOM
 !! thermodynamic forcing type, including changes of units, sign conventions,
 !! and putting the fields into arrays with MOM-standard halos.
-subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, sfc_state)
+subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, US, CS, sfc_state)
   type(ice_ocean_boundary_type), &
                    target, intent(in)    :: IOB    !< An ice-ocean boundary type with fluxes to drive
                                                    !! the ocean in a coupled model
@@ -205,6 +206,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, sfc_sta
   type(time_type),         intent(in)    :: Time   !< The time of the fluxes, used for interpolating the
                                                    !! salinity to the right time, when it is being restored.
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure
+  type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   type(surface_forcing_CS),pointer       :: CS     !< A pointer to the control structure returned by a
                                                    !! previous call to surface_forcing_init.
   type(surface),           intent(in)    :: sfc_state !< A structure containing fields that describe the
@@ -531,12 +533,12 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, sfc_sta
 
   ! Set the wind stresses and ustar.
   if (associated(fluxes%ustar) .and. associated(fluxes%ustar_gustless)) then
-    call extract_IOB_stresses(IOB, index_bounds, Time, G, CS, ustar=fluxes%ustar, &
+    call extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, ustar=fluxes%ustar, &
                               gustless_ustar=fluxes%ustar_gustless)
   elseif (associated(fluxes%ustar)) then
-    call extract_IOB_stresses(IOB, index_bounds, Time, G, CS, ustar=fluxes%ustar)
+    call extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, ustar=fluxes%ustar)
   elseif (associated(fluxes%ustar_gustless)) then
-    call extract_IOB_stresses(IOB, index_bounds, Time, G, CS, gustless_ustar=fluxes%ustar_gustless)
+    call extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, gustless_ustar=fluxes%ustar_gustless)
   endif
 
   if (coupler_type_initialized(fluxes%tr_fluxes) .and. &
@@ -558,7 +560,7 @@ end subroutine convert_IOB_to_fluxes
 !> This subroutine translates the Ice_ocean_boundary_type into a MOM
 !! mechanical forcing type, including changes of units, sign conventions,
 !! and putting the fields into arrays with MOM-standard halos.
-subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS, dt_forcing, reset_avg)
+subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS, dt_forcing, reset_avg)
   type(ice_ocean_boundary_type), &
                    target, intent(in)    :: IOB    !< An ice-ocean boundary type with fluxes to drive
                                                    !! the ocean in a coupled model
@@ -567,6 +569,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS, dt_forc
   type(time_type),         intent(in)    :: Time   !< The time of the fluxes, used for interpolating the
                                                    !! salinity to the right time, when it is being restored.
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure
+  type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   type(surface_forcing_CS),pointer       :: CS     !< A pointer to the control structure returned by a
                                                    !! previous call to surface_forcing_init.
   real,          optional, intent(in)    :: dt_forcing !< A time interval over which to apply the
@@ -678,10 +681,10 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS, dt_forc
 
   ! Set the wind stresses and ustar.
   if (wt1 <= 0.0) then
-    call extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux=forces%taux, tauy=forces%tauy, &
+    call extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, taux=forces%taux, tauy=forces%tauy, &
                               ustar=forces%ustar, tau_halo=1)
   else
-    call extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux=forces%taux, tauy=forces%tauy, &
+    call extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, taux=forces%taux, tauy=forces%tauy, &
                               ustar=ustar_tmp, tau_halo=1)
     do j=js,je ; do i=is,ie
       forces%ustar(i,j) = wt1*forces%ustar(i,j) + wt2*ustar_tmp(i,j)
@@ -782,7 +785,7 @@ end subroutine convert_IOB_to_forces
 !> This subroutine extracts the wind stresses and related fields like ustar from an
 !! Ice_ocean_boundary_type into optional argument arrays, including changes of units, sign
 !! conventions, and putting the fields into arrays with MOM-standard sized halos.
-subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, ustar, &
+subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, taux, tauy, ustar, &
                                 gustless_ustar, tau_halo)
   type(ice_ocean_boundary_type), &
                    target, intent(in)    :: IOB  !< An ice-ocean boundary type with fluxes to drive
@@ -791,6 +794,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
   type(time_type),         intent(in)    :: Time !< The time of the fluxes, used for interpolating the
                                                  !! salinity to the right time, when it is being restored.
   type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure
+  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
   type(surface_forcing_CS),pointer       :: CS   !< A pointer to the control structure returned by a
                                                  !! previous call to surface_forcing_init.
   real, dimension(SZIB_(G),SZJ_(G)), &
@@ -798,7 +802,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
   real, dimension(SZI_(G),SZJB_(G)), &
                  optional, intent(inout) :: tauy !< The meridional wind stresses on a C-grid, in Pa.
   real, dimension(SZI_(G),SZJ_(G)), &
-                 optional, intent(inout) :: ustar !< The surface friction velocity, in m s-1.
+                 optional, intent(inout) :: ustar !< The surface friction velocity, in Z s-1.
   real, dimension(SZI_(G),SZJ_(G)), &
                  optional, intent(out)   :: gustless_ustar !< The surface friction velocity without
                                                  !! any contributions from gustiness, in m s-1.
@@ -939,7 +943,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
                 (G%mask2dBu(I,J-1) + G%mask2dBu(I-1,J))) > 0)) ) &
             gustiness = CS%gust(i,j)
         endif
-        ustar(i,j) = sqrt(gustiness*Irho0 + Irho0*IOB%stress_mag(i-i0,j-j0))
+        ustar(i,j) = US%m_to_Z * sqrt(gustiness*Irho0 + Irho0*IOB%stress_mag(i-i0,j-j0))
       enddo ; enddo ; endif
       if (do_gustless) then ; do j=js,je ; do i=is,ie
         gustless_ustar(i,j) = sqrt(IOB%stress_mag(i-i0,j-j0) / CS%Rho0)
@@ -958,7 +962,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
             ((G%mask2dBu(I,J) + G%mask2dBu(I-1,J-1)) + (G%mask2dBu(I,J-1) + G%mask2dBu(I-1,J))) )
           if (CS%read_gust_2d) gustiness = CS%gust(i,j)
         endif
-        if (do_ustar) ustar(i,j) = sqrt(gustiness*Irho0 + Irho0 * tau_mag)
+        if (do_ustar) ustar(i,j) = US%m_to_Z * sqrt(gustiness*Irho0 + Irho0 * tau_mag)
         if (do_gustless) gustless_ustar(i,j) = sqrt(tau_mag / CS%Rho0)
 !### Change to:
 !        if (do_gustless) gustless_ustar(i,j) = sqrt(Irho0 * tau_mag)
@@ -968,7 +972,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
         tau_mag = G%mask2dT(i,j) * sqrt(taux_in_A(i,j)**2 + tauy_in_A(i,j)**2)
         gustiness = CS%gust_const
         if (CS%read_gust_2d .and. (G%mask2dT(i,j) > 0)) gustiness = CS%gust(i,j)
-        if (do_ustar) ustar(i,j) = sqrt(gustiness*Irho0 + Irho0 * tau_mag)
+        if (do_ustar) ustar(i,j) = US%m_to_Z * sqrt(gustiness*Irho0 + Irho0 * tau_mag)
         if (do_gustless) gustless_ustar(i,j) = sqrt(tau_mag / CS%Rho0)
 !### Change to:
 !        if (do_gustless) gustless_ustar(i,j) = sqrt(Irho0 * tau_mag)
@@ -987,7 +991,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, CS, taux, tauy, usta
         gustiness = CS%gust_const
         if (CS%read_gust_2d) gustiness = CS%gust(i,j)
 
-        if (do_ustar) ustar(i,j) = sqrt(gustiness*Irho0 + Irho0 * tau_mag)
+        if (do_ustar) ustar(i,j) = US%m_to_Z * sqrt(gustiness*Irho0 + Irho0 * tau_mag)
         if (do_gustless) gustless_ustar(i,j) = sqrt(tau_mag / CS%Rho0)
 !### Change to:
 !        if (do_gustless) gustless_ustar(i,j) = sqrt(Irho0 * tau_mag)
@@ -1122,9 +1126,10 @@ subroutine forcing_save_restart(CS, G, Time, directory, time_stamped, &
 end subroutine forcing_save_restart
 
 !> Initialize the surface forcing, including setting parameters and allocating permanent memory.
-subroutine surface_forcing_init(Time, G, param_file, diag, CS)
+subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
   type(time_type),          intent(in)    :: Time !< The current model time
   type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
+  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),    intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(diag_ctrl), target,  intent(inout) :: diag !< A structure that is used to regulate
                                                   !! diagnostic output
@@ -1407,7 +1412,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS)
   call get_param(param_file, mdl, "ALLOW_ICEBERG_FLUX_DIAGNOSTICS", iceberg_flux_diags, &
                  "If true, makes available diagnostics of fluxes from icebergs\n"//&
                  "as seen by MOM6.", default=.false.)
-  call register_forcing_type_diags(Time, diag, CS%use_temperature, CS%handles, &
+  call register_forcing_type_diags(Time, diag, US, CS%use_temperature, CS%handles, &
                                    use_berg_fluxes=iceberg_flux_diags)
 
   call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -43,7 +43,7 @@ use MOM_time_manager, only : operator(<=), operator(>=), operator(<)
 use MOM_time_manager, only : real_to_time, time_type_to_real
 use MOM_tracer_flow_control, only : call_tracer_register, tracer_flow_control_init
 use MOM_tracer_flow_control, only : call_tracer_flux_init
-use MOM_unit_scaling,    only : unit_scale_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_ice_shelf, only : initialize_ice_shelf, shelf_calc_flux, ice_shelf_CS
@@ -355,7 +355,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
   call allocate_surface_state(OS%sfc_state, OS%grid, use_temperature, do_integrals=.true., &
                               gas_fields_ocn=gas_fields_ocn, use_meltpot=use_melt_pot)
 
-  call surface_forcing_init(Time_in, OS%grid, param_file, OS%diag, &
+  call surface_forcing_init(Time_in, OS%grid, OS%US, param_file, OS%diag, &
                             OS%forcing_CSp)
 
   if (OS%use_ice_shelf)  then
@@ -498,7 +498,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
                               index_bnds(3), index_bnds(4))
 
   if (do_dyn) then
-    call convert_IOB_to_forces(Ice_ocean_boundary, OS%forces, index_bnds, OS%Time_dyn, OS%grid, &
+    call convert_IOB_to_forces(Ice_ocean_boundary, OS%forces, index_bnds, OS%Time_dyn, OS%grid, OS%US, &
                                OS%forcing_CSp, dt_forcing=dt_coupling, reset_avg=OS%fluxes%fluxes_used)
     if (OS%use_ice_shelf) &
       call add_shelf_forces(OS%grid, OS%Ice_shelf_CSp, OS%forces)
@@ -510,7 +510,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
   if (do_thermo) then
     if (OS%fluxes%fluxes_used) then
       call convert_IOB_to_fluxes(Ice_ocean_boundary, OS%fluxes, index_bnds, OS%Time, &
-                                 OS%grid, OS%forcing_CSp, OS%sfc_state)
+                                 OS%grid, OS%US, OS%forcing_CSp, OS%sfc_state)
 
       ! Add ice shelf fluxes
       if (OS%use_ice_shelf) &
@@ -532,7 +532,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
       ! into a temporary type and then accumulate them in about 20 lines.
       OS%flux_tmp%C_p = OS%fluxes%C_p
       call convert_IOB_to_fluxes(Ice_ocean_boundary, OS%flux_tmp, index_bnds, OS%Time, &
-                                 OS%grid, OS%forcing_CSp, OS%sfc_state)
+                                 OS%grid, OS%US, OS%forcing_CSp, OS%sfc_state)
 
       if (OS%use_ice_shelf) &
         call shelf_calc_flux(OS%sfc_state, OS%flux_tmp, OS%Time, dt_coupling, OS%Ice_shelf_CSp)

--- a/config_src/ice_solo_driver/user_surface_forcing.F90
+++ b/config_src/ice_solo_driver/user_surface_forcing.F90
@@ -55,6 +55,7 @@ use MOM_io, only : file_exists, read_data
 use MOM_time_manager, only : time_type, operator(+), operator(/), get_time
 use MOM_tracer_flow_control, only : call_tracer_set_forcing
 use MOM_tracer_flow_control, only : tracer_flow_control_CS
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface
 
 implicit none ; private
@@ -88,12 +89,13 @@ contains
 !> This subroutine sets the surface wind stresses, forces%taux and forces%tauy.
 !! These are the stresses in the direction of the model grid (i.e. the same
 !! direction as the u- and v- velocities.)  They are both in Pa.
-subroutine USER_wind_forcing(sfc_state, forces, day, G, CS)
+subroutine USER_wind_forcing(sfc_state, forces, day, G, US, CS)
   type(surface),                 intent(inout) :: sfc_state !< A structure containing fields that
                                                     !! describe the surface state of the ocean.
   type(mech_forcing),            intent(inout) :: forces !< A structure with the driving mechanical forces
   type(time_type),               intent(in)    :: day  !< The time of the fluxes
   type(ocean_grid_type),         intent(inout) :: G    !< The ocean's grid structure
+  type(unit_scale_type),         intent(in)    :: US   !< A dimensional unit scaling type
   type(user_surface_forcing_CS), pointer       :: CS   !< A pointer to the control structure returned
                                                        !! by a previous call to user_surface_forcing_init
 
@@ -101,7 +103,7 @@ subroutine USER_wind_forcing(sfc_state, forces, day, G, CS)
 ! These are the stresses in the direction of the model grid (i.e. the same
 ! direction as the u- and v- velocities.)  They are both in Pa.
 !   In addition, this subroutine can be used to set the surface friction
-! velocity, forces%ustar, in m s-1. This is needed with a bulk mixed layer.
+! velocity, forces%ustar, in Z s-1. This is needed with a bulk mixed layer.
 !
 ! Arguments: state - A structure containing fields that describe the
 !                    surface state of the ocean.
@@ -144,7 +146,7 @@ subroutine USER_wind_forcing(sfc_state, forces, day, G, CS)
   !  is always positive.
   if (associated(forces%ustar)) then ; do j=js,je ; do i=is,ie
     !  This expression can be changed if desired, but need not be.
-    forces%ustar(i,j) = G%mask2dT(i,j) * sqrt(CS%gust_const/CS%Rho0 + &
+    forces%ustar(i,j) = US%m_to_Z * G%mask2dT(i,j) * sqrt(CS%gust_const/CS%Rho0 + &
        sqrt(0.5*(forces%taux(I-1,j)**2 + forces%taux(I,j)**2) + &
             0.5*(forces%tauy(i,J-1)**2 + forces%tauy(i,J)**2))/CS%Rho0)
   enddo ; enddo ; endif

--- a/config_src/mct_driver/MOM_ocean_model.F90
+++ b/config_src/mct_driver/MOM_ocean_model.F90
@@ -53,6 +53,7 @@ use MOM_time_manager,        only : operator(/=), operator(<=), operator(>=)
 use MOM_time_manager,        only : operator(<), real_to_time_type, time_type_to_real
 use MOM_tracer_flow_control, only : call_tracer_register, tracer_flow_control_init
 use MOM_tracer_flow_control, only : call_tracer_flux_init
+use MOM_unit_scaling,        only : unit_scale_type
 use MOM_variables,           only : surface
 use MOM_verticalGrid,        only : verticalGrid_type
 use MOM_ice_shelf,           only : initialize_ice_shelf, shelf_calc_flux, ice_shelf_CS
@@ -198,6 +199,8 @@ type, public :: ocean_state_type
                               !! containing metrics and related information.
   type(verticalGrid_type), pointer :: GV => NULL() !< A pointer to a vertical grid
                               !! structure containing metrics and related information.
+  type(unit_scale_type), pointer :: US => NULL() !< A pointer to a structure containing
+                              !! dimensional unit scaling factors.
   type(MOM_control_struct), pointer :: MOM_CSp => NULL()
   type(surface_forcing_CS), pointer :: forcing_CSp => NULL()
   type(MOM_restart_CS), pointer :: &
@@ -276,7 +279,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                       OS%restart_CSp, Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       input_restart_file=input_restart_file, diag_ptr=OS%diag, &
                       count_calls=.true.)
-  call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, C_p=OS%fluxes%C_p, &
+  call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%fluxes%C_p, &
                               use_temp=use_temperature)
   OS%C_p = OS%fluxes%C_p
 
@@ -361,7 +364,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   call allocate_surface_state(OS%sfc_state, OS%grid, use_temperature, do_integrals=.true., &
                               gas_fields_ocn=gas_fields_ocn, use_meltpot=use_melt_pot)
 
-  call surface_forcing_init(Time_in, OS%grid, param_file, OS%diag, &
+  call surface_forcing_init(Time_in, OS%grid, OS%US, param_file, OS%diag, &
                             OS%forcing_CSp, OS%restore_salinity, OS%restore_temp)
 
   if (OS%use_ice_shelf)  then
@@ -473,7 +476,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   weight = 1.0
 
   call convert_IOB_to_forces(Ice_ocean_boundary, OS%forces, index_bnds, OS%Time, &
-                             OS%grid, OS%forcing_CSp)
+                             OS%grid, OS%US, OS%forcing_CSp)
 
   if (OS%fluxes%fluxes_used) then
 
@@ -481,7 +484,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
     call enable_averaging(time_step, OS%Time + Ocean_coupling_time_step, OS%diag)
 
     ! Import fluxes from coupler to ocean. Also, perform do SST and SSS restoring, if needed.
-    call convert_IOB_to_fluxes(Ice_ocean_boundary, OS%fluxes, OS%Time, OS%grid, OS%forcing_CSp, &
+    call convert_IOB_to_fluxes(Ice_ocean_boundary, OS%fluxes, OS%Time, OS%grid, OS%US, OS%forcing_CSp, &
                                OS%sfc_state, OS%restore_salinity, OS%restore_temp)
 
     ! Fields that exist in both the forcing and mech_forcing types must be copied.
@@ -513,7 +516,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
     OS%flux_tmp%C_p = OS%fluxes%C_p
 
     ! Import fluxes from coupler to ocean. Also, perform do SST and SSS restoring, if needed.
-    call convert_IOB_to_fluxes(Ice_ocean_boundary, OS%fluxes, OS%Time, OS%grid, OS%forcing_CSp, &
+    call convert_IOB_to_fluxes(Ice_ocean_boundary, OS%fluxes, OS%Time, OS%grid, OS%US, OS%forcing_CSp, &
                                OS%sfc_state, OS%restore_salinity, OS%restore_temp)
 
     if (OS%use_ice_shelf) then

--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -28,6 +28,7 @@ use MOM_restart,          only : register_restart_field, restart_init, MOM_resta
 use MOM_restart,          only : restart_init_end, save_restart, restore_state
 use MOM_string_functions, only : uppercase
 use MOM_spatial_means,    only : adjust_area_mean_to_zero
+use MOM_unit_scaling,     only : unit_scale_type
 use MOM_variables,        only : surface
 use user_revise_forcing,  only : user_alter_forcing, user_revise_forcing_init
 use user_revise_forcing,  only : user_revise_forcing_CS
@@ -202,7 +203,7 @@ contains
 !! See \ref section_ocn_import for a summary of the surface fluxes that are
 !! passed from MCT to MOM6, including fluxes that need to be included in
 !! the future.
-subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, CS, &
+subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, US, CS, &
                                  sfc_state, restore_salt, restore_temp)
 
   type(ice_ocean_boundary_type), &
@@ -216,6 +217,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, CS, &
   type(time_type),         intent(in)    :: Time   !< The time of the fluxes, used for interpolating the
                                                    !! salinity to the right time, when it is being restored.
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure
+  type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   type(surface_forcing_CS),pointer       :: CS     !< A pointer to the control structure returned by a
                                                    !! previous call to surface_forcing_init.
   type(surface),           intent(in)    :: sfc_state !< A structure containing fields that describe the
@@ -516,7 +518,7 @@ end subroutine convert_IOB_to_fluxes
 !> This subroutine translates the Ice_ocean_boundary_type into a MOM
 !! mechanical forcing type, including changes of units, sign conventions,
 !! and putting the fields into arrays with MOM-standard halos.
-subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS)
+subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
   type(ice_ocean_boundary_type), &
                    target, intent(in)    :: IOB    !< An ice-ocean boundary type with fluxes to drive
                                                    !! the ocean in a coupled model
@@ -525,6 +527,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS)
   type(time_type),         intent(in)    :: Time   !< The time of the fluxes, used for interpolating the
                                                    !! salinity to the right time, when it is being restored.
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure
+  type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   type(surface_forcing_CS),pointer       :: CS     !< A pointer to the control structure returned by a
                                                    !! previous call to surface_forcing_init.
 
@@ -668,7 +671,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS)
              ((G%mask2dBu(I,J) + G%mask2dBu(I-1,J-1)) + (G%mask2dBu(I,J-1) + G%mask2dBu(I-1,J))) )
         if (CS%read_gust_2d) gustiness = CS%gust(i,j)
       endif
-      forces%ustar(i,j) = sqrt(gustiness*Irho0 + Irho0*tau_mag)
+      forces%ustar(i,j) = US%m_to_Z * sqrt(gustiness*Irho0 + Irho0*tau_mag)
     enddo; enddo
 
   elseif (wind_stagger == AGRID) then
@@ -693,7 +696,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS)
     do j=js,je ; do i=is,ie
       gustiness = CS%gust_const
       if (CS%read_gust_2d .and. (G%mask2dT(i,j) > 0)) gustiness = CS%gust(i,j)
-      forces%ustar(i,j) = sqrt(gustiness*Irho0 + Irho0 * G%mask2dT(i,j) * &
+      forces%ustar(i,j) = US%m_to_Z * sqrt(gustiness*Irho0 + Irho0 * G%mask2dT(i,j) * &
                                sqrt(taux_at_h(i,j)**2 + tauy_at_h(i,j)**2))
     enddo; enddo
 
@@ -714,9 +717,9 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS)
                  G%mask2dCv(i,J)*forces%tauy(i,J)**2) / (G%mask2dCv(i,J-1) + G%mask2dCv(i,J))
 
       if (CS%read_gust_2d) then
-        forces%ustar(i,j) = sqrt(CS%gust(i,j)*Irho0 + Irho0*sqrt(taux2 + tauy2))
+        forces%ustar(i,j) = US%m_to_Z * sqrt(CS%gust(i,j)*Irho0 + Irho0*sqrt(taux2 + tauy2))
       else
-        forces%ustar(i,j) = sqrt(CS%gust_const*Irho0 + Irho0*sqrt(taux2 + tauy2))
+        forces%ustar(i,j) = US%m_to_Z * sqrt(CS%gust_const*Irho0 + Irho0*sqrt(taux2 + tauy2))
       endif
     enddo; enddo
 
@@ -964,9 +967,10 @@ end subroutine forcing_save_restart
 !=======================================================================
 
 !> Initializes surface forcing: get relevant parameters and allocate arrays.
-subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, restore_temp)
+subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt, restore_temp)
   type(time_type),          intent(in)    :: Time !< The current model time
   type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
+  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),    intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(diag_ctrl), target,  intent(inout) :: diag !< A structure that is used to regulate diagnostic output
   type(surface_forcing_CS), pointer       :: CS !< A pointer that is set to point to the
@@ -1231,7 +1235,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
   call get_param(param_file, mdl, "ALLOW_ICEBERG_FLUX_DIAGNOSTICS", iceberg_flux_diags, &
                  "If true, makes available diagnostics of fluxes from icebergs\n"//&
                  "as seen by MOM6.", default=.false.)
-  call register_forcing_type_diags(Time, diag, CS%use_temperature, CS%handles, &
+  call register_forcing_type_diags(Time, diag, US, CS%use_temperature, CS%handles, &
                                    use_berg_fluxes=iceberg_flux_diags)
 
   call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &

--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -422,7 +422,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, US, CS, &
     !  .or. (associated(IOB%mass_berg) .and. (.not. associated(fluxes%mass_berg)))) &
     !  call allocate_forcing_type(G, fluxes, iceberg=.true.)
     !if (associated(IOB%ustar_berg)) &
-    !  fluxes%ustar_berg(i,j) = IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)
+    !  fluxes%ustar_berg(i,j) = US%m_to_Z * IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)
     !if (associated(IOB%area_berg)) &
     !  fluxes%area_berg(i,j) = IOB%area_berg(i-i0,j-j0) * G%mask2dT(i,j)
     !if (associated(IOB%mass_berg)) &

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -322,7 +322,7 @@ program MOM_main
 
   call extract_surface_state(MOM_CSp, sfc_state)
 
-  call surface_forcing_init(Time, grid, param_file, diag, &
+  call surface_forcing_init(Time, grid, US, param_file, diag, &
                             surface_forcing_CSp, tracer_flow_CSp)
   call callTree_waypoint("done surface_forcing_init")
 
@@ -478,12 +478,12 @@ program MOM_main
 
     ! Set the forcing for the next steps.
     if (.not. offline_tracer_mode) then
-        call set_forcing(sfc_state, forces, fluxes, Time, Time_step_ocean, grid, &
+        call set_forcing(sfc_state, forces, fluxes, Time, Time_step_ocean, grid, US, &
                      surface_forcing_CSp)
     endif
     if (debug) then
-      call MOM_mech_forcing_chksum("After set forcing", forces, grid, haloshift=0)
-      call MOM_forcing_chksum("After set forcing", fluxes, grid, haloshift=0)
+      call MOM_mech_forcing_chksum("After set forcing", forces, grid, US, haloshift=0)
+      call MOM_forcing_chksum("After set forcing", fluxes, grid, US, haloshift=0)
     endif
 
     if (use_ice_shelf) then

--- a/config_src/solo_driver/Neverland_surface_forcing.F90
+++ b/config_src/solo_driver/Neverland_surface_forcing.F90
@@ -13,6 +13,7 @@ use MOM_forcing_type, only : allocate_forcing_type, allocate_mech_forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : file_exists, read_data, slasher
 use MOM_time_manager, only : time_type, operator(+), operator(/)
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface
 
 implicit none ; private
@@ -46,12 +47,13 @@ contains
 
 !> Sets the surface wind stresses, forces%taux and forces%tauy for the
 !! Neverland forcing configuration.
-subroutine Neverland_wind_forcing(sfc_state, forces, day, G, CS)
+subroutine Neverland_wind_forcing(sfc_state, forces, day, G, US, CS)
   type(surface),                 intent(inout) :: sfc_state !< A structure containing fields that
                                                          !! describe the surface state of the ocean.
   type(mech_forcing),            intent(inout) :: forces !< A structure with the driving mechanical forces
   type(time_type),               intent(in)    :: day    !< Time used for determining the fluxes.
   type(ocean_grid_type),         intent(inout) :: G      !< Grid structure.
+  type(unit_scale_type),         intent(in)    :: US     !< A dimensional unit scaling type
   type(Neverland_surface_forcing_CS), pointer  :: CS     !< Control structure for this module.
 
   ! Local variables
@@ -102,7 +104,7 @@ subroutine Neverland_wind_forcing(sfc_state, forces, day, G, CS)
   !  is always positive.
 ! if (associated(forces%ustar)) then ; do j=js,je ; do i=is,ie
 !   !  This expression can be changed if desired, but need not be.
-!   forces%ustar(i,j) = G%mask2dT(i,j) * sqrt(CS%gust_const/CS%Rho0 + &
+!   forces%ustar(i,j) = US%m_to_Z * G%mask2dT(i,j) * sqrt(CS%gust_const/CS%Rho0 + &
 !      sqrt(0.5*(forces%taux(I-1,j)**2 + forces%taux(I,j)**2) + &
 !           0.5*(forces%tauy(i,J-1)**2 + forces%tauy(i,J)**2))/CS%Rho0)
 ! enddo ; enddo ; endif

--- a/config_src/solo_driver/user_surface_forcing.F90
+++ b/config_src/solo_driver/user_surface_forcing.F90
@@ -15,6 +15,7 @@ use MOM_io, only : file_exists, read_data
 use MOM_time_manager, only : time_type, operator(+), operator(/)
 use MOM_tracer_flow_control, only : call_tracer_set_forcing
 use MOM_tracer_flow_control, only : tracer_flow_control_CS
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface
 
 implicit none ; private
@@ -47,12 +48,13 @@ contains
 !> This subroutine sets the surface wind stresses, forces%taux and forces%tauy.
 !! These are the stresses in the direction of the model grid (i.e. the same
 !! direction as the u- and v- velocities.)  They are both in Pa.
-subroutine USER_wind_forcing(sfc_state, forces, day, G, CS)
+subroutine USER_wind_forcing(sfc_state, forces, day, G, US, CS)
   type(surface),                 intent(inout) :: sfc_state !< A structure containing fields that
                                                        !! describe the surface state of the ocean.
   type(mech_forcing),            intent(inout) :: forces !< A structure with the driving mechanical forces
   type(time_type),               intent(in)    :: day  !< The time of the fluxes
   type(ocean_grid_type),         intent(inout) :: G    !< The ocean's grid structure
+  type(unit_scale_type),         intent(in)    :: US   !< A dimensional unit scaling type
   type(user_surface_forcing_CS), pointer       :: CS   !< A pointer to the control structure returned
                                                        !! by a previous call to user_surface_forcing_init
 
@@ -86,7 +88,7 @@ subroutine USER_wind_forcing(sfc_state, forces, day, G, CS)
   !  is always positive.
   if (associated(forces%ustar)) then ; do j=js,je ; do i=is,ie
     !  This expression can be changed if desired, but need not be.
-    forces%ustar(i,j) = G%mask2dT(i,j) * sqrt(CS%gust_const/CS%Rho0 + &
+    forces%ustar(i,j) = US%m_to_Z * G%mask2dT(i,j) * sqrt(CS%gust_const/CS%Rho0 + &
        sqrt(0.5*(forces%taux(I-1,j)**2 + forces%taux(I,j)**2) + &
             0.5*(forces%tauy(i,J-1)**2 + forces%tauy(i,J)**2))/CS%Rho0)
   enddo ; enddo ; endif

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -605,7 +605,7 @@ subroutine step_MOM(forces, fluxes, sfc_state, Time_start, time_interval, CS, &
     if (cycle_start) &
       call MOM_state_chksum("Before steps ", u, v, h, CS%uh, CS%vh, G, GV)
     if (cycle_start) call check_redundant("Before steps ", u, v, G)
-    if (do_dyn) call MOM_mech_forcing_chksum("Before steps", forces, G, haloshift=0)
+    if (do_dyn) call MOM_mech_forcing_chksum("Before steps", forces, G, US, haloshift=0)
     if (do_dyn) call check_redundant("Before steps ", forces%taux, forces%tauy, G)
   endif
   call cpu_clock_end(id_clock_other)
@@ -1185,7 +1185,7 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     ! call MOM_state_chksum("Pre-diabatic ",u, v, h, CS%uhtr, CS%vhtr, G, GV)
       call MOM_thermo_chksum("Pre-diabatic ", tv, G,haloshift=0)
       call check_redundant("Pre-diabatic ", u, v, G)
-      call MOM_forcing_chksum("Pre-diabatic", fluxes, G, haloshift=0)
+      call MOM_forcing_chksum("Pre-diabatic", fluxes, G, US, haloshift=0)
     endif
 
     call cpu_clock_begin(id_clock_diabatic)

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -129,12 +129,12 @@ type, public :: forcing
 
   ! iceberg related inputs
   real, pointer, dimension(:,:) :: &
-    ustar_berg => NULL(), &   !< iceberg contribution to top ustar (m/s)
+    ustar_berg => NULL(), &   !< iceberg contribution to top ustar (Z/s)
     area_berg  => NULL(), &   !< area of ocean surface covered by icebergs (m2/m2)
     mass_berg  => NULL()      !< mass of icebergs (kg/m2)
 
   ! land ice-shelf related inputs
-  real, pointer, dimension(:,:) :: ustar_shelf => NULL()  !< Friction velocity under ice-shelves (in m/s)
+  real, pointer, dimension(:,:) :: ustar_shelf => NULL()  !< Friction velocity under ice-shelves (in Z/s)
                                  !! as computed by the ocean at the previous time step.
   real, pointer, dimension(:,:) :: frac_shelf_h => NULL() !< Fractional ice shelf coverage of h-cells, nondimensional
                                  !! cells, nondimensional from 0 to 1. This is only
@@ -1167,7 +1167,7 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
   if (present(use_berg_fluxes)) then
     if (use_berg_fluxes) then
       handles%id_ustar_berg = register_diag_field('ocean_model', 'ustar_berg', diag%axesT1, Time, &
-          'Friction velocity below iceberg ', 'm s-1')
+          'Friction velocity below iceberg ', 'm s-1', conversion=US%Z_to_m)
 
       handles%id_area_berg = register_diag_field('ocean_model', 'area_berg', diag%axesT1, Time, &
           'Area of grid cell covered by iceberg ', 'm2 m-2')
@@ -1176,7 +1176,7 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
           'Mass of icebergs ', 'kg m-2')
 
       handles%id_ustar_ice_cover = register_diag_field('ocean_model', 'ustar_ice_cover', diag%axesT1, Time, &
-          'Friction velocity below iceberg and ice shelf together', 'm s-1')
+          'Friction velocity below iceberg and ice shelf together', 'm s-1', conversion=US%Z_to_m)
 
       handles%id_frac_ice_cover = register_diag_field('ocean_model', 'frac_ice_cover', diag%axesT1, Time, &
           'Area of grid cell below iceberg and ice shelf together ', 'm2 m-2')

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -645,7 +645,7 @@ subroutine shelf_calc_flux(state, fluxes, Time, time_step, CS, forces)
     endif
   endif
 
-  if (CS%DEBUG) call MOM_forcing_chksum("Before add shelf flux", fluxes, G, haloshift=0)
+  if (CS%DEBUG) call MOM_forcing_chksum("Before add shelf flux", fluxes, G, US, haloshift=0)
 
   call add_shelf_flux(G, CS, state, fluxes)
 
@@ -687,7 +687,7 @@ subroutine shelf_calc_flux(state, fluxes, Time, time_step, CS, forces)
 
   call cpu_clock_end(id_clock_shelf)
 
-  if (CS%DEBUG) call MOM_forcing_chksum("End of shelf calc flux", fluxes, G, haloshift=0)
+  if (CS%DEBUG) call MOM_forcing_chksum("End of shelf calc flux", fluxes, G, US, haloshift=0)
 
 end subroutine shelf_calc_flux
 
@@ -1053,7 +1053,7 @@ subroutine add_shelf_flux(G, CS, state, fluxes)
     if (CS%DEBUG) then
       write(mesg,*) 'Mean melt flux (kg/(m^2 s)), dt = ', mean_melt_flux, CS%time_step
       call MOM_mesg(mesg)
-      call MOM_forcing_chksum("After constant sea level", fluxes, G, haloshift=0)
+      call MOM_forcing_chksum("After constant sea level", fluxes, G, CS%US, haloshift=0)
     endif
 
   endif !constant_sea_level

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -18,6 +18,7 @@ use MOM_io, only : file_exists, slasher, MOM_read_data
 use MOM_restart, only : register_restart_field, query_initialized
 use MOM_restart, only : MOM_restart_CS
 use MOM_time_manager, only : time_type, set_time
+use MOM_unit_scaling, only : unit_scale_type, unit_scaling_init
 !MJH use MOM_ice_shelf_initialize, only : initialize_ice_shelf_boundary
 use MOM_ice_shelf_state, only : ice_shelf_state
 use MOM_coms, only : reproducing_sum, sum_across_PEs, max_across_PEs, min_across_PEs
@@ -51,9 +52,9 @@ type, public :: ice_shelf_dyn_CS ; private
   real, pointer, dimension(:,:) :: u_face_mask_bdry => NULL() !< A duplicate copy of u_face_mask?
   real, pointer, dimension(:,:) :: v_face_mask_bdry => NULL() !< A duplicate copy of v_face_mask?
   real, pointer, dimension(:,:) :: u_flux_bdry_val => NULL() !< The ice volume flux into the cell through open boundary
-                                       !! u-faces (where u_face_mask=4), in m3 s-1???
+                                       !! u-faces (where u_face_mask=4), in Z m2 s-1???
   real, pointer, dimension(:,:) :: v_flux_bdry_val => NULL() !< The ice volume flux into the cell through open boundary
-                                       !! v-faces (where v_face_mask=4), in m3 s-1???
+                                       !! v-faces (where v_face_mask=4), in Z m2 s-1???
    ! needed where u_face_mask is equal to 4, similary for v_face_mask
   real, pointer, dimension(:,:) :: umask => NULL()      !< u-mask on the actual degrees of freedom (B grid)
                                        !! 1=normal node, 3=inhomogeneous boundary node,
@@ -67,7 +68,7 @@ type, public :: ice_shelf_dyn_CS ; private
                                                      !! in degC  on corner-points (B grid)
   real, pointer, dimension(:,:) :: tmask => NULL()   !< A mask on tracer points that is 1 where there is ice.
   real, pointer, dimension(:,:) :: ice_visc => NULL()   !< Glen's law ice viscosity, perhaps in m.
-  real, pointer, dimension(:,:) :: thickness_bdry_val => NULL() !< The ice thickness at an inflowing boundary, in m.
+  real, pointer, dimension(:,:) :: thickness_bdry_val => NULL() !< The ice thickness at an inflowing boundary, in Z.
   real, pointer, dimension(:,:) :: u_bdry_val => NULL() !< The zonal ice velocity at inflowing boundaries in m/s???
   real, pointer, dimension(:,:) :: v_bdry_val => NULL() !< The meridional ice velocity at inflowing boundaries in m/s???
   real, pointer, dimension(:,:) :: h_bdry_val => NULL() !< The ice thickness at inflowing boundaries, in m.
@@ -78,7 +79,7 @@ type, public :: ice_shelf_dyn_CS ; private
 
   real, pointer, dimension(:,:) :: OD_rt => NULL()         !< A running total for calculating OD_av.
   real, pointer, dimension(:,:) :: float_frac_rt => NULL() !< A running total for calculating float_frac.
-  real, pointer, dimension(:,:) :: OD_av => NULL()         !< The time average open ocean depth, in m.
+  real, pointer, dimension(:,:) :: OD_av => NULL()         !< The time average open ocean depth, in Z.
   real, pointer, dimension(:,:) :: float_frac => NULL()   !< Fraction of the time a cell is "exposed", i.e. the column
                                !! thickness is below a threshold.
                        !### [if float_frac = 1 ==> grounded; obviously counterintuitive; might fix]
@@ -123,7 +124,7 @@ type, public :: ice_shelf_dyn_CS ; private
   real :: thresh_float_col_depth !< The water column depth over which the shelf if considered to be floating
   logical :: moving_shelf_front  !< Specify whether to advance shelf front (and calve).
   logical :: calve_to_mask       !< If true, calve off the ice shelf when it passes the edge of a mask.
-  real :: min_thickness_simple_calve !< min. ice shelf thickness criteria for calving, in m
+  real :: min_thickness_simple_calve !< min. ice shelf thickness criteria for calving, in Z
 
   real :: cg_tolerance !< The tolerance in the CG solver, relative to initial residual, that
                        !! deterimnes when to stop the conguage gradient iterations.
@@ -253,7 +254,7 @@ subroutine register_ice_shelf_dyn_restarts(G, param_file, CS, restart_CS)
 end subroutine register_ice_shelf_dyn_restarts
 
 !> Initializes shelf model data, parameters and diagnostics
-subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, diag, new_sim, solo_ice_sheet_in)
+subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_sim, solo_ice_sheet_in)
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(ocean_grid_type),   pointer       :: ocn_grid   !< The calling ocean model's horizontal grid structure
   type(time_type),         intent(inout) :: Time !< The clock that that will indicate the model time
@@ -261,14 +262,18 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, diag, new_sim,
                                                  !! the ice-shelf state
   type(ice_shelf_dyn_CS),  pointer       :: CS   !< A pointer to the ice shelf dynamics control structure
   type(ocean_grid_type),   intent(inout) :: G    !< The grid type describing the ice shelf grid.
+  type(unit_scale_type),   intent(in)    :: US   !< Pointer to a structure containing unit conversion factors
   type(diag_ctrl), target, intent(in)    :: diag !< A structure that is used to regulate the diagnostic output.
   logical,                 intent(in)    :: new_sim !< If true this is a new simulation, otherwise
                                                  !! has been started from a restart file.
   logical,       optional, intent(in)    :: solo_ice_sheet_in !< If present, this indicates whether
                                                  !! a solo ice-sheet driver.
 
+  ! Local variables
+  real    :: Z_rescale  ! A rescaling factor for heights from the representation in
+                        ! a reastart fole to the internal representation in this run.
   !This include declares and sets the variable "version".
-#include "version_variable.h"
+# include "version_variable.h"
   character(len=200) :: config
   character(len=200) :: IC_file,filename,inputdir
   character(len=40)  :: var_name
@@ -364,7 +369,7 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, diag, new_sim,
     call get_param(param_file, mdl, "THRESH_FLOAT_COL_DEPTH", CS%thresh_float_col_depth, &
                 "min ocean thickness to consider ice *floating*; \n"// &
                 "will only be important with use of tides", &
-                units="m", default=1.e-3)
+                units="m", default=1.e-3, scale=US%m_to_Z)
     call get_param(param_file, mdl, "NONLIN_SOLVE_ERR_MODE", CS%nonlin_solve_err_mode, &
                 "Choose whether nonlin error in vel solve is based on nonlinear \n"// &
                 "residual (1) or relative change since last iteration (2)", default=1)
@@ -382,7 +387,7 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, diag, new_sim,
   call get_param(param_file, mdl, "MIN_THICKNESS_SIMPLE_CALVE", &
                  CS%min_thickness_simple_calve, &
                  "Min thickness rule for the VERY simple calving law",&
-                 units="m", default=0.0)
+                 units="m", default=0.0, scale=US%m_to_Z)
 
   ! Allocate memory in the ice shelf dynamics control structure that was not
   ! previously allocated for registration for restarts.
@@ -420,6 +425,13 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, diag, new_sim,
 
   ! Take additional initialization steps, for example of dependent variables.
   if (active_shelf_dynamics .and. .not.new_sim) then
+    if ((US%m_to_Z_restart /= 0.0) .and. (US%m_to_Z_restart /= US%m_to_Z)) then
+      Z_rescale = US%m_to_Z / US%m_to_Z_restart
+      do j=G%jsc,G%jec ; do i=G%isc,G%iec
+        CS%OD_av(i,j) = Z_rescale * CS%OD_av(i,j)
+      enddo ; enddo
+    endif
+
     ! this is unfortunately necessary; if grid is not symmetric the boundary values
     !  of u and v are otherwise not set till the end of the first linear solve, and so
     !  viscosity is not calculated correctly.
@@ -475,8 +487,8 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, diag, new_sim,
 
     if (new_sim) then
       call MOM_mesg("MOM_ice_shelf.F90, initialize_ice_shelf: initialize ice velocity.")
-      call update_OD_ffrac_uncoupled(CS, G, ISS%h_shelf)
-      call ice_shelf_solve_outer(CS, ISS, G, CS%u_shelf, CS%v_shelf, iters, Time)
+      call update_OD_ffrac_uncoupled(CS, G, ISS%h_shelf(:,:))
+      call ice_shelf_solve_outer(CS, ISS, G, US, CS%u_shelf, CS%v_shelf, iters, Time)
 
       if (CS%id_u_shelf > 0) call post_data(CS%id_u_shelf,CS%u_shelf,CS%diag)
       if (CS%id_v_shelf > 0) call post_data(CS%id_v_shelf,CS%v_shelf,CS%diag)
@@ -496,9 +508,9 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, diag, new_sim,
     CS%id_float_frac = register_diag_field('ocean_model','ice_float_frac',CS%diag%axesT1, Time, &
        'fraction of cell that is floating (sort of)', 'none')
     CS%id_col_thick = register_diag_field('ocean_model','col_thick',CS%diag%axesT1, Time, &
-       'ocean column thickness passed to ice model', 'm')
+       'ocean column thickness passed to ice model', 'm', conversion=US%Z_to_m)
     CS%id_OD_av = register_diag_field('ocean_model','OD_av',CS%diag%axesT1, Time, &
-       'intermediate ocean column thickness passed to ice model', 'm')
+       'intermediate ocean column thickness passed to ice model', 'm', conversion=US%Z_to_m)
     !CS%id_h_after_uflux = register_diag_field('ocean_model','h_after_uflux',CS%diag%axesh1, Time, &
     !   'thickness after u flux ', 'none')
     !CS%id_h_after_vflux = register_diag_field('ocean_model','h_after_vflux',CS%diag%axesh1, Time, &
@@ -516,25 +528,25 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, diag, new_sim,
 end subroutine initialize_ice_shelf_dyn
 
 
-subroutine initialize_diagnostic_fields(CS, ISS, G, Time)
+subroutine initialize_diagnostic_fields(CS, ISS, G, US, Time)
   type(ice_shelf_dyn_CS), intent(inout) :: CS  !< A pointer to the ice shelf control structure
   type(ice_shelf_state),  intent(in)    :: ISS !< A structure with elements that describe
                                                !! the ice-shelf state
   type(ocean_grid_type),  intent(inout) :: G   !< The grid structure used by the ice shelf.
+  type(unit_scale_type),  intent(in)    :: US  !< Pointer to a structure containing unit conversion factors
   type(time_type),        intent(in)    :: Time !< The current model time
 
   integer         :: i, j, iters, isd, ied, jsd, jed
-  real            :: rhoi, rhow, OD
+  real            :: rhoi_rhow, OD
   type(time_type) :: dummy_time
 
-  rhoi = CS%density_ice
-  rhow = CS%density_ocean_avg
+  rhoi_rhow = CS%density_ice / CS%density_ocean_avg
   dummy_time = set_time(0,0)
   isd=G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   do j=jsd,jed
     do i=isd,ied
-      OD = G%Zd_to_m*G%bathyT(i,j) - rhoi/rhow * ISS%h_shelf(i,j)
+      OD = G%bathyT(i,j) - rhoi_rhow * ISS%h_shelf(i,j)
       if (OD >= 0) then
     ! ice thickness does not take up whole ocean column -> floating
         CS%OD_av(i,j) = OD
@@ -546,7 +558,7 @@ subroutine initialize_diagnostic_fields(CS, ISS, G, Time)
     enddo
   enddo
 
-  call ice_shelf_solve_outer(CS, ISS, G, CS%u_shelf, CS%v_shelf, iters, dummy_time)
+  call ice_shelf_solve_outer(CS, ISS, G, US, CS%u_shelf, CS%v_shelf, iters, dummy_time)
 
 end subroutine initialize_diagnostic_fields
 
@@ -583,11 +595,12 @@ end function ice_time_step_CFL
 
 !> This subroutine updates the ice shelf velocities, mass, stresses and properties due to the
 !! ice shelf dynamics.
-subroutine update_ice_shelf(CS, ISS, G, time_step, Time, ocean_mass, coupled_grounding, must_update_vel)
+subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, ocean_mass, coupled_grounding, must_update_vel)
   type(ice_shelf_dyn_CS), intent(inout) :: CS !< The ice shelf dynamics control structure
   type(ice_shelf_state),  intent(inout) :: ISS !< A structure with elements that describe
                                               !! the ice-shelf state
   type(ocean_grid_type),  intent(inout) :: G  !< The grid structure used by the ice shelf.
+  type(unit_scale_type),  intent(in)    :: US !< Pointer to a structure containing unit conversion factors
   real,                   intent(in)    :: time_step !< time step in sec
   type(time_type),        intent(in)    :: Time !< The current model time
   real, dimension(SZDI_(G),SZDJ_(G)), &
@@ -611,16 +624,16 @@ subroutine update_ice_shelf(CS, ISS, G, time_step, Time, ocean_mass, coupled_gro
   if (CS%elapsed_velocity_time >= CS%velocity_update_time_step) update_ice_vel = .true.
 
   if (coupled_GL) then
-    call update_OD_ffrac(CS, G, ocean_mass, update_ice_vel)
+    call update_OD_ffrac(CS, G, US, ocean_mass, update_ice_vel)
   elseif (update_ice_vel) then
-    call update_OD_ffrac_uncoupled(CS, G, ISS%h_shelf)
+    call update_OD_ffrac_uncoupled(CS, G, ISS%h_shelf(:,:))
   endif
 
   if (update_ice_vel) then
-    call ice_shelf_solve_outer(CS, ISS, G, CS%u_shelf, CS%v_shelf, iters, Time)
+    call ice_shelf_solve_outer(CS, ISS, G, US, CS%u_shelf, CS%v_shelf, iters, Time)
   endif
 
-  call ice_shelf_temp(CS, ISS, G, time_step, ISS%water_flux, Time)
+  call ice_shelf_temp(CS, ISS, G, US, time_step, ISS%water_flux, Time)
 
   if (update_ice_vel) then
     call enable_averaging(CS%elapsed_velocity_time, Time, CS%diag)
@@ -629,7 +642,7 @@ subroutine update_ice_shelf(CS, ISS, G, time_step, Time, ocean_mass, coupled_gro
     if (CS%id_v_shelf > 0) call post_data(CS%id_v_shelf,CS%v_shelf,CS%diag)
     if (CS%id_t_shelf > 0) call post_data(CS%id_t_shelf,CS%t_shelf,CS%diag)
     if (CS%id_float_frac > 0) call post_data(CS%id_float_frac,CS%float_frac,CS%diag)
-    if (CS%id_OD_av >0) call post_data(CS%id_OD_av,CS%OD_av,CS%diag)
+    if (CS%id_OD_av >0) call post_data(CS%id_OD_av, CS%OD_av,CS%diag)
 
     if (CS%id_u_mask > 0) call post_data(CS%id_u_mask,CS%umask,CS%diag)
     if (CS%id_v_mask > 0) call post_data(CS%id_v_mask,CS%vmask,CS%diag)
@@ -691,10 +704,10 @@ subroutine ice_shelf_advect(CS, ISS, G, time_step, Time)
   !   o--- (3) ---o
   !
 
-  real, dimension(SZDI_(G),SZDJ_(G))   :: h_after_uflux, h_after_vflux
+  real, dimension(SZDI_(G),SZDJ_(G))   :: h_after_uflux, h_after_vflux ! Ice thicknesses in Z.
   real, dimension(SZDI_(G),SZDJ_(G),4) :: flux_enter
   integer                           :: isd, ied, jsd, jed, i, j, isc, iec, jsc, jec
-  real                              :: rho, spy, thick_bd
+  real                              :: rho, spy
 
   rho = CS%density_ice
   spy = 365 * 86400 ! seconds per year; is there a global constant for this?  No - it is dependent upon a calendar.
@@ -707,14 +720,9 @@ subroutine ice_shelf_advect(CS, ISS, G, time_step, Time)
   h_after_vflux(:,:) = 0.0
   ! call MOM_mesg("MOM_ice_shelf.F90: ice_shelf_advect called")
 
-  do j=jsd,jed
-    do i=isd,ied
-      thick_bd = CS%thickness_bdry_val(i,j)
-      if (thick_bd /= 0.0) then
-          ISS%h_shelf(i,j) = CS%thickness_bdry_val(i,j)
-      endif
-    enddo
-  enddo
+  do j=jsd,jed ; do i=isd,ied ; if (CS%thickness_bdry_val(i,j) /= 0.0) then
+    ISS%h_shelf(i,j) = CS%thickness_bdry_val(i,j)
+  endif ; enddo ; enddo
 
   call ice_shelf_advect_thickness_x(CS, G, time_step/spy, ISS%hmask, ISS%h_shelf, h_after_uflux, flux_enter)
 
@@ -757,11 +765,12 @@ subroutine ice_shelf_advect(CS, ISS, G, time_step, Time)
 
 end subroutine ice_shelf_advect
 
-subroutine ice_shelf_solve_outer(CS, ISS, G, u, v, iters, time)
+subroutine ice_shelf_solve_outer(CS, ISS, G, US, u, v, iters, time)
   type(ice_shelf_dyn_CS), intent(inout) :: CS !< The ice shelf dynamics control structure
   type(ice_shelf_state),  intent(in)    :: ISS !< A structure with elements that describe
                                                !! the ice-shelf state
   type(ocean_grid_type),  intent(inout) :: G  !< The grid structure used by the ice shelf.
+  type(unit_scale_type),  intent(in)    :: US !< Pointer to a structure containing unit conversion factors
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                           intent(inout) :: u  !< The zonal ice shelf velocity at vertices, in m/year
   real, dimension(SZDIB_(G),SZDJB_(G)), &
@@ -771,13 +780,14 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, u, v, iters, time)
 
   real, dimension(SZDIB_(G),SZDJB_(G)) :: TAUDX, TAUDY, u_prev_iterate, v_prev_iterate, &
                         u_bdry_cont, v_bdry_cont, Au, Av, err_u, err_v, &
-                        u_last, v_last, H_node
+                        u_last, v_last
+  real, dimension(SZDIB_(G),SZDJB_(G)) :: H_node ! Ice shelf thickness at corners, in Z.
   real, dimension(SZDI_(G),SZDJ_(G)) :: float_cond ! An array indicating where the ice
                                                 ! shelf is floating: 0 if floating, 1 if not.
   character(len=160) :: mesg  ! The text of an error message
   integer :: conv_flag, i, j, k,l, iter
   integer :: isdq, iedq, jsdq, jedq, isd, ied, jsd, jed, isumstart, jsumstart, nodefloat, nsub
-  real                     :: err_max, err_tempu, err_tempv, err_init, area, max_vel, tempu, tempv, rhoi, rhow
+  real                     :: err_max, err_tempu, err_tempv, err_init, area, max_vel, tempu, tempv, rhoi_rhow
   real, pointer, dimension(:,:,:,:) :: Phi => NULL()
   real, pointer, dimension(:,:,:,:,:,:) :: Phisub => NULL()
   real, dimension(8,4)       :: Phi_temp
@@ -790,8 +800,7 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, u, v, iters, time)
 
   isdq = G%isdB ; iedq = G%iedB ; jsdq = G%jsdB ; jedq = G%jedB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
-  rhoi = CS%density_ice
-  rhow = CS%density_ocean_avg
+  rhoi_rhow = CS%density_ice / CS%density_ocean_avg
 
   TAUDX(:,:) = 0.0 ; TAUDY(:,:) = 0.0
   u_bdry_cont(:,:) = 0.0 ; v_bdry_cont(:,:) = 0.0
@@ -809,7 +818,7 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, u, v, iters, time)
   ! Include the edge if tile is at the southern bdry;  Should add a test to avoid this if reentrant.
   if (G%jsc+G%jdg_offset==G%jsg) jsumstart = G%jscB
 
-  call calc_shelf_driving_stress(CS, ISS, G, TAUDX, TAUDY, CS%OD_av)
+  call calc_shelf_driving_stress(CS, ISS, G, US, TAUDX, TAUDY, CS%OD_av)
 
   ! this is to determine which cells contain the grounding line,
   !  the criterion being that the cell is ice-covered, with some nodes
@@ -829,7 +838,7 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, u, v, iters, time)
         do k=0,1
           do l=0,1
             if ((ISS%hmask(i,j) == 1) .and. &
-              (rhoi/rhow * H_node(i-1+k,j-1+l) - G%Zd_to_m*G%bathyT(i,j) <= 0)) then
+              (rhoi_rhow * H_node(i-1+k,j-1+l) - G%bathyT(i,j) <= 0)) then
               nodefloat = nodefloat + 1
             endif
           enddo
@@ -870,7 +879,7 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, u, v, iters, time)
     Phi(i,j,:,:) = Phi_temp
   enddo ; enddo
 
-  call calc_shelf_visc(CS, ISS, G, u, v)
+  call calc_shelf_visc(CS, ISS, G, US, u, v)
 
   call pass_var(CS%ice_visc, G%domain)
   call pass_var(CS%taub_beta_eff, G%domain)
@@ -883,13 +892,13 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, u, v, iters, time)
 
   call apply_boundary_values(CS, ISS, G, time, Phisub, H_node, CS%ice_visc, &
                                       CS%taub_beta_eff, float_cond, &
-                                      rhoi/rhow, u_bdry_cont, v_bdry_cont)
+                                      rhoi_rhow, u_bdry_cont, v_bdry_cont)
 
   Au(:,:) = 0.0 ; Av(:,:) = 0.0
 
   call CG_action(Au, Av, u, v, Phi, Phisub, CS%umask, CS%vmask, ISS%hmask, H_node, &
-            CS%ice_visc, float_cond, G%Zd_to_m*G%bathyT(:,:), CS%taub_beta_eff, G%areaT, &
-            G, G%isc-1, G%iec+1, G%jsc-1, G%jec+1, rhoi/rhow)
+            CS%ice_visc, float_cond, G%bathyT(:,:), CS%taub_beta_eff, G%areaT, &
+            G, G%isc-1, G%iec+1, G%jsc-1, G%jec+1, rhoi_rhow)
 
   err_init = 0 ; err_tempu = 0; err_tempv = 0
   do j=jsumstart,G%jecB
@@ -928,7 +937,7 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, u, v, iters, time)
     write(mesg,*) "ice_shelf_solve_outer: linear solve done in ",iters," iterations"
     call MOM_mesg(mesg, 5)
 
-    call calc_shelf_visc(CS, ISS, G, u, v)
+    call calc_shelf_visc(CS, ISS, G, US, u, v)
     call pass_var(CS%ice_visc, G%domain)
     call pass_var(CS%taub_beta_eff, G%domain)
 
@@ -942,13 +951,13 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, u, v, iters, time)
 
     call apply_boundary_values(CS, ISS, G, time, Phisub, H_node, CS%ice_visc, &
                                         CS%taub_beta_eff, float_cond, &
-                                        rhoi/rhow, u_bdry_cont, v_bdry_cont)
+                                        rhoi_rhow, u_bdry_cont, v_bdry_cont)
 
     Au(:,:) = 0 ; Av(:,:) = 0
 
     call CG_action(Au, Av, u, v, Phi, Phisub, CS%umask, CS%vmask, ISS%hmask, H_node, &
-            CS%ice_visc, float_cond, G%Zd_to_m*G%bathyT(:,:), CS%taub_beta_eff, G%areaT, &
-            G, G%isc-1, G%iec+1, G%jsc-1, G%jec+1, rhoi/rhow)
+            CS%ice_visc, float_cond, G%bathyT(:,:), CS%taub_beta_eff, G%areaT, &
+            G, G%isc-1, G%iec+1, G%jsc-1, G%jec+1, rhoi_rhow)
 
     err_max = 0
 
@@ -1034,7 +1043,7 @@ subroutine ice_shelf_solve_inner(CS, ISS, G, u, v, taudx, taudy, H_node, float_c
                           intent(in)    :: taudy  !< The y-direction driving stress, in ???
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                           intent(in)    :: H_node !< The ice shelf thickness at nodal (corner)
-                                             !! points, in m.
+                                             !! points, in Z.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(in)    :: float_cond !< An array indicating where the ice
                                                 !! shelf is floating: 0 if floating, 1 if not.
@@ -1111,7 +1120,7 @@ subroutine ice_shelf_solve_inner(CS, ISS, G, u, v, taudx, taudy, H_node, float_c
   call pass_vector(DIAGu, DIAGv, G%domain, TO_ALL, BGRID_NE)
 
   call CG_action(Au, Av, u, v, Phi, Phisub, CS%umask, CS%vmask, hmask, &
-          H_node, CS%ice_visc, float_cond, G%Zd_to_m*G%bathyT(:,:), CS%taub_beta_eff, &
+          H_node, CS%ice_visc, float_cond, G%bathyT(:,:), CS%taub_beta_eff, &
           G%areaT, G, isc-1, iec+1, jsc-1, jec+1, CS%density_ice/CS%density_ocean_avg)
 
   call pass_vector(Au, Av, G%domain, TO_ALL, BGRID_NE)
@@ -1182,7 +1191,7 @@ subroutine ice_shelf_solve_inner(CS, ISS, G, u, v, taudx, taudy, H_node, float_c
     Au(:,:) = 0 ; Av(:,:) = 0
 
     call CG_action(Au, Av, Du, Dv, Phi, Phisub, CS%umask, CS%vmask, hmask, &
-          H_node, CS%ice_visc, float_cond, G%Zd_to_m*G%bathyT(:,:), CS%taub_beta_eff, &
+          H_node, CS%ice_visc, float_cond, G%bathyT(:,:), CS%taub_beta_eff, &
           G%areaT, G, is, ie, js, je, CS%density_ice/CS%density_ocean_avg)
 
     ! Au, Av valid region moves in by 1
@@ -1412,13 +1421,13 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
                           intent(inout) :: hmask !< A mask indicating which tracer points are
                                              !! partly or fully covered by an ice-shelf
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                          intent(in)    :: h0 !< The initial ice shelf thicknesses in m.
+                          intent(in)    :: h0 !< The initial ice shelf thicknesses in Z.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(inout) :: h_after_uflux !< The ice shelf thicknesses after
-                                              !! the zonal mass fluxes, in m.
+                                              !! the zonal mass fluxes, in Z.
   real, dimension(SZDI_(G),SZDJ_(G),4), &
                           intent(inout) :: flux_enter !< The ice volume flux into the cell
-                                              !! through the 4 cell boundaries, in m3
+                                              !! through the 4 cell boundaries, in Z m2
 
   ! use will be made of ISS%hmask here - its value at the boundary will be zero, just like uncovered cells
 
@@ -1441,7 +1450,7 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed, gjed, gied
   integer :: i_off, j_off
   logical :: at_east_bdry, at_west_bdry, one_off_west_bdry, one_off_east_bdry
-  real, dimension(-2:2) :: stencil
+  real, dimension(-2:2) :: stencil ! Thicknesses in Z.
   real :: u_face, &  ! positive if out
       flux_diff_cell, phi, dxh, dyh, dxdyh
   character (len=1)        :: debug_str
@@ -1454,7 +1463,7 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
     if (((j+j_off) <= G%domain%njglobal+G%domain%njhalo) .AND. &
         ((j+j_off) >= G%domain%njhalo+1)) then ! based on mehmet's code - only if btw north & south boundaries
 
-      stencil(:) = -1
+      stencil(:) = -1.
 !     if (i+i_off == G%domain%nihalo+G%domain%nihalo)
       do i=is,ie
 
@@ -1512,7 +1521,7 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
                                     ! (o.w. flux would most likely be out of cell)
                                     !  but h(i-2) is not
 
-                  flux_diff_cell = flux_diff_cell + ABS(u_face) * dyh * time_step / dxdyh * stencil(-1)
+                  flux_diff_cell = flux_diff_cell + ABS(u_face) * (dyh * time_step / dxdyh) * stencil(-1)
 
                 endif
 
@@ -1523,7 +1532,7 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
                              (stencil(0) - phi * (stencil(0)-stencil(-1))/2)
 
                 else
-                  flux_diff_cell = flux_diff_cell - ABS(u_face) * dyh * time_step / dxdyh * stencil(0)
+                  flux_diff_cell = flux_diff_cell - ABS(u_face) * (dyh * time_step / dxdyh) * stencil(0)
 
                   if ((hmask(i-1,j) == 0) .OR. (hmask(i-1,j) == 2)) then
                     flux_enter(i-1,j,2) = ABS(u_face) * dyh * time_step * stencil(0)
@@ -1561,7 +1570,7 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
                                             ! (o.w. flux would most likely be out of cell)
                                             !  but h(i+2) is not
 
-                  flux_diff_cell = flux_diff_cell + ABS(u_face) * dyh * time_step / dxdyh * stencil(1)
+                  flux_diff_cell = flux_diff_cell + ABS(u_face) * (dyh * time_step / dxdyh) * stencil(1)
 
                 endif
 
@@ -1577,7 +1586,7 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
                                             ! (o.w. flux would most likely be out of cell)
                                             !  but h(i+2) is not
 
-                  flux_diff_cell = flux_diff_cell - ABS(u_face) * dyh * time_step / dxdyh * stencil(0)
+                  flux_diff_cell = flux_diff_cell - ABS(u_face) * (dyh * time_step / dxdyh) * stencil(0)
 
                   if ((hmask(i+1,j) == 0) .OR. (hmask(i+1,j) == 2)) then
                     flux_enter(i+1,j,1) = ABS(u_face) * dyh * time_step  * stencil(0)
@@ -1643,13 +1652,13 @@ subroutine ice_shelf_advect_thickness_y(CS, G, time_step, hmask, h_after_uflux, 
                                              !! partly or fully covered by an ice-shelf
   real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(in)    :: h_after_uflux !< The ice shelf thicknesses after
-                                              !! the zonal mass fluxes, in m.
+                                              !! the zonal mass fluxes, in Z.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(inout) :: h_after_vflux !< The ice shelf thicknesses after
-                                              !! the meridional mass fluxes, in m.
+                                              !! the meridional mass fluxes, in Z.
   real, dimension(SZDI_(G),SZDJ_(G),4), &
                           intent(inout) :: flux_enter !< The ice volume flux into the cell
-                                              !! through the 4 cell boundaries, in m3
+                                              !! through the 4 cell boundaries, in Z m2
 
   ! use will be made of ISS%hmask here - its value at the boundary will be zero, just like uncovered cells
 
@@ -1672,7 +1681,7 @@ subroutine ice_shelf_advect_thickness_y(CS, G, time_step, hmask, h_after_uflux, 
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed, gjed, gied
   integer :: i_off, j_off
   logical :: at_north_bdry, at_south_bdry, one_off_west_bdry, one_off_east_bdry
-  real, dimension(-2:2) :: stencil
+  real, dimension(-2:2) :: stencil  ! Thicknesses in Z
   real :: v_face, &  ! positive if out
       flux_diff_cell, phi, dxh, dyh, dxdyh
   character(len=1)        :: debug_str
@@ -1738,7 +1747,7 @@ subroutine ice_shelf_advect_thickness_y(CS, G, time_step, hmask, h_after_uflux, 
                 else     ! h(j-1) is valid
                          ! (o.w. flux would most likely be out of cell)
                          !  but h(j-2) is not
-                  flux_diff_cell = flux_diff_cell + ABS(v_face) * dxh * time_step / dxdyh * stencil(-1)
+                  flux_diff_cell = flux_diff_cell + ABS(v_face) * (dxh * time_step / dxdyh) * stencil(-1)
                 endif
 
               elseif (v_face < 0) then !flux is out of cell - we need info from h(j-1), h(j+1) if available
@@ -1748,7 +1757,7 @@ subroutine ice_shelf_advect_thickness_y(CS, G, time_step, hmask, h_after_uflux, 
                   flux_diff_cell = flux_diff_cell - ABS(v_face) * dxh * time_step / dxdyh * &
                       (stencil(0) - phi * (stencil(0)-stencil(-1))/2)
                 else
-                  flux_diff_cell = flux_diff_cell - ABS(v_face) * dxh * time_step / dxdyh * stencil(0)
+                  flux_diff_cell = flux_diff_cell - ABS(v_face) * (dxh * time_step / dxdyh) * stencil(0)
 
                   if ((hmask(i,j-1) == 0) .OR. (hmask(i,j-1) == 2)) then
                     flux_enter(i,j-1,4) = ABS(v_face) * dyh * time_step * stencil(0)
@@ -1850,7 +1859,7 @@ subroutine shelf_advance_front(CS, ISS, G, flux_enter)
   type(ocean_grid_type),  intent(in)    :: G  !< The grid structure used by the ice shelf.
   real, dimension(SZDI_(G),SZDJ_(G),4), &
                           intent(inout) :: flux_enter !< The ice volume flux into the cell
-                                              !! through the 4 cell boundaries, in m3
+                                              !! through the 4 cell boundaries, in Z m2
 
   ! in this subroutine we go through the computational cells only and, if they are empty or partial cells,
   ! we find the reference thickness and update the shelf mass and partial area fraction and the hmask if necessary
@@ -2025,13 +2034,13 @@ end subroutine shelf_advance_front
 subroutine ice_shelf_min_thickness_calve(G, h_shelf, area_shelf_h, hmask, thickness_calve)
   type(ocean_grid_type), intent(in)    :: G  !< The grid structure used by the ice shelf.
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(inout) :: h_shelf !< The ice shelf thickness, in m.
+                         intent(inout) :: h_shelf !< The ice shelf thickness, in Z.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(inout) :: area_shelf_h !< The area per cell covered by the ice shelf, in m2.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(inout) :: hmask !< A mask indicating which tracer points are
                                              !! partly or fully covered by an ice-shelf
-  real,                  intent(in)    :: thickness_calve !< The thickness at which to trigger calving, in m.
+  real,                  intent(in)    :: thickness_calve !< The thickness at which to trigger calving, in Z.
 
   integer                        :: i,j
 
@@ -2039,7 +2048,7 @@ subroutine ice_shelf_min_thickness_calve(G, h_shelf, area_shelf_h, hmask, thickn
     do i=G%isd,G%ied
 !      if ((h_shelf(i,j) < CS%thickness_calve) .and. (hmask(i,j) == 1) .and. &
 !           (CS%float_frac(i,j) == 0.0)) then
-       if ((h_shelf(i,j) < thickness_calve) .and. (area_shelf_h(i,j) > 0.)) then
+      if ((h_shelf(i,j) < thickness_calve) .and. (area_shelf_h(i,j) > 0.)) then
         h_shelf(i,j) = 0.0
         area_shelf_h(i,j) = 0.0
         hmask(i,j) = 0.0
@@ -2052,7 +2061,7 @@ end subroutine ice_shelf_min_thickness_calve
 subroutine calve_to_mask(G, h_shelf, area_shelf_h, hmask, calve_mask)
   type(ocean_grid_type), intent(in) :: G  !< The grid structure used by the ice shelf.
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(inout) :: h_shelf !< The ice shelf thickness, in m.
+                         intent(inout) :: h_shelf !< The ice shelf thickness, in Z.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(inout) :: area_shelf_h !< The area per cell covered by the ice shelf, in m2.
   real, dimension(SZDI_(G),SZDJ_(G)), &
@@ -2074,13 +2083,14 @@ subroutine calve_to_mask(G, h_shelf, area_shelf_h, hmask, calve_mask)
 
 end subroutine calve_to_mask
 
-subroutine calc_shelf_driving_stress(CS, ISS, G, TAUD_X, TAUD_Y, OD)
+subroutine calc_shelf_driving_stress(CS, ISS, G, US, TAUD_X, TAUD_Y, OD)
   type(ice_shelf_dyn_CS), intent(in)   :: CS !< A pointer to the ice shelf control structure
   type(ice_shelf_state), intent(in)    :: ISS !< A structure with elements that describe
-                                           !! the ice-shelf state
+                                             !! the ice-shelf state
   type(ocean_grid_type), intent(inout) :: G  !< The grid structure used by the ice shelf.
+  type(unit_scale_type), intent(in)    :: US !< Pointer to a structure containing unit conversion factors
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(in)    :: OD  !< ocean floor depth at tracer points, in m
+                         intent(in)    :: OD  !< ocean floor depth at tracer points, in Z
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                          intent(inout) :: TAUD_X  !< X-direction driving stress at q-points
   real, dimension(SZDIB_(G),SZDJB_(G)), &
@@ -2097,8 +2107,8 @@ subroutine calc_shelf_driving_stress(CS, ISS, G, TAUD_X, TAUD_Y, OD)
 !     "average" ocean depth -- and is needed to find surface elevation
 !    (it is assumed that base_ice = bed + OD)
 
-  real, dimension(SIZE(OD,1),SIZE(OD,2))  :: S, &     ! surface elevation
-                            BASE     ! basal elevation of shelf/stream
+  real, dimension(SIZE(OD,1),SIZE(OD,2))  :: S, &     ! surface elevation, in Z
+                            BASE     ! basal elevation of shelf/stream, in Z
 
 
   real      :: rho, rhow, sx, sy, neumann_val, dxh, dyh, dxdyh, grav
@@ -2118,12 +2128,12 @@ subroutine calc_shelf_driving_stress(CS, ISS, G, TAUD_X, TAUD_Y, OD)
 
   rho = CS%density_ice
   rhow = CS%density_ocean_avg
-  grav = CS%g_Earth
+  grav = US%Z_to_m**2 * CS%g_Earth
 
   ! prelim - go through and calculate S
 
   ! or is this faster?
-  BASE(:,:) = -G%Zd_to_m*G%bathyT(:,:) + OD(:,:)
+  BASE(:,:) = -G%bathyT(:,:) + OD(:,:)
   S(:,:) = BASE(:,:) + ISS%h_shelf(:,:)
 
   do j=jsc-1,jec+1
@@ -2148,23 +2158,23 @@ subroutine calc_shelf_driving_stress(CS, ISS, G, TAUD_X, TAUD_Y, OD)
           if (ISS%hmask(i-1,j) == 1) then
             sx = (S(i,j)-S(i-1,j))/dxh
           else
-            sx=0
+            sx = 0
           endif
         else ! interior
           if (ISS%hmask(i+1,j) == 1) then
             cnt = cnt+1
-                sx = S(i+1,j)
+            sx = S(i+1,j)
           else
             sx = S(i,j)
-              endif
-              if (ISS%hmask(i-1,j) == 1) then
+          endif
+          if (ISS%hmask(i-1,j) == 1) then
             cnt = cnt+1
-                sx = sx - S(i-1,j)
+            sx = sx - S(i-1,j)
           else
             sx = sx - S(i,j)
-              endif
+          endif
           if (cnt == 0) then
-            sx=0
+            sx = 0
           else
             sx = sx / (cnt * dxh)
           endif
@@ -2199,7 +2209,7 @@ subroutine calc_shelf_driving_stress(CS, ISS, G, TAUD_X, TAUD_Y, OD)
             sy = sy - S(i,j)
           endif
           if (cnt == 0) then
-            sy=0
+            sy = 0
           else
             sy = sy / (cnt * dyh)
           endif
@@ -2222,9 +2232,9 @@ subroutine calc_shelf_driving_stress(CS, ISS, G, TAUD_X, TAUD_Y, OD)
         taud_y(I,J) = taud_y(I,J) - .25 * rho * grav * ISS%h_shelf(i,j) * sy * dxdyh
 
         if (CS%float_frac(i,j) == 1) then
-          neumann_val = .5 * grav * (rho * ISS%h_shelf(i,j) ** 2 - rhow * (G%Zd_to_m*G%bathyT(i,j)) ** 2)
+          neumann_val = .5 * grav * (rho * ISS%h_shelf(i,j)**2 - rhow * G%bathyT(i,j)**2)
         else
-          neumann_val = .5 * grav * (1-rho/rhow) * rho * ISS%h_shelf(i,j) ** 2
+          neumann_val = .5 * grav * (1-rho/rhow) * rho * ISS%h_shelf(i,j)**2
         endif
 
 
@@ -2273,8 +2283,8 @@ subroutine init_boundary_values(CS, G, time, hmask, input_flux, input_thick, new
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(in)    :: hmask !< A mask indicating which tracer points are
                                              !! partly or fully covered by an ice-shelf
-  real,                  intent(in)    :: input_flux !< The integrated inward ice thickness flux in m3 s-1.
-  real,                  intent(in)    :: input_thick !< The ice thickness at boundaries, in m.
+  real,                  intent(in)    :: input_flux !< The integrated inward ice thickness flux in Z m2 s-1.
+  real,                  intent(in)    :: input_thick !< The ice thickness at boundaries, in Z.
   logical,     optional, intent(in)    :: new_sim !< If present and false, this run is being restarted
 
 ! this will be a per-setup function. the boundary values of thickness and velocity
@@ -2362,7 +2372,7 @@ subroutine CG_action(uret, vret, u, v, Phi, Phisub, umask, vmask, hmask, H_node,
                                              !! meridional flow at the corner point
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                          intent(in)    :: H_node !< The ice shelf thickness at nodal (corner)
-                                             !! points, in m.
+                                             !! points, in Z.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(in)    :: hmask !< A mask indicating which tracer points are
                                              !! partly or fully covered by an ice-shelf
@@ -2374,7 +2384,7 @@ subroutine CG_action(uret, vret, u, v, Phi, Phisub, umask, vmask, hmask, H_node,
                          intent(in)    :: float_cond !< An array indicating where the ice
                                                 !! shelf is floating: 0 if floating, 1 if not.
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(in)    :: bathyT !< The depth of ocean bathymetry at tracer points, in m.
+                         intent(in)    :: bathyT !< The depth of ocean bathymetry at tracer points, in Z.
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                          intent(in)    :: beta  !< A field related to the nonlinear part of the
                                                 !! "linearized" basal stress.  The exact form and
@@ -2530,8 +2540,8 @@ subroutine CG_action(uret, vret, u, v, Phi, Phisub, umask, vmask, hmask, H_node,
       if (float_cond(i,j) == 1) then
         Usubcontr = 0.0 ; Vsubcontr = 0.0 ; basel = bathyT(i,j)
         Ucell(:,:) = u(i-1:i,j-1:j) ; Vcell(:,:) = v(i-1:i,j-1:j) ; Hcell(:,:) = H_node(i-1:i,j-1:j)
-        call CG_action_subgrid_basal &
-            (Phisub, Hcell, Ucell, Vcell, area, basel, dens_ratio, Usubcontr, Vsubcontr)
+        call CG_action_subgrid_basal(Phisub, Hcell, Ucell, Vcell, area, basel, &
+                                     dens_ratio, Usubcontr, Vsubcontr)
         do iphi=1,2 ; do jphi=1,2
           if (umask(i-2+iphi,j-2+jphi) == 1) then
             uret(i-2+iphi,j-2+jphi) = uret(i-2+iphi,j-2+jphi) + Usubcontr (iphi,jphi) * beta(i,j)
@@ -2551,11 +2561,11 @@ subroutine CG_action_subgrid_basal(Phisub, H, U, V, DXDYH, bathyT, dens_ratio, U
   real, dimension(:,:,:,:,:,:), &
                         intent(in)    :: Phisub !< Quadrature structure weights at subgridscale
                                             !! locations for finite element calculations
-  real, dimension(2,2), intent(in)    :: H  !< The ice shelf thickness at nodal (corner) points, in m.
+  real, dimension(2,2), intent(in)    :: H  !< The ice shelf thickness at nodal (corner) points, in Z.
   real, dimension(2,2), intent(in)    :: U  !< The zonal ice shelf velocity at vertices, in m/year
   real, dimension(2,2), intent(in)    :: V  !< The meridional ice shelf velocity at vertices, in m/year
   real,                 intent(in)    :: DXDYH  !< The tracer cell area, in m2
-  real,                 intent(in)    :: bathyT !< The depth of ocean bathymetry at tracer points, in m.
+  real,                 intent(in)    :: bathyT !< The depth of ocean bathymetry at tracer points, in Z.
   real,                 intent(in)    :: dens_ratio !< The density of ice divided by the density
                                                     !! of seawater, nondimensional
   real, dimension(2,2), intent(inout) :: Ucontr !< A field related to the subgridscale contributions to
@@ -2615,7 +2625,7 @@ subroutine matrix_diagonal(CS, G, float_cond, H_node, nu, beta, hmask, dens_rati
                                                 !! shelf is floating: 0 if floating, 1 if not.
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                           intent(in)    :: H_node !< The ice shelf thickness at nodal
-                                                 !! (corner) points, in m.
+                                                 !! (corner) points, in Z.
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                           intent(in)    :: nu   !< A field related to the ice viscosity from Glen's
                                                 !! flow law. The exact form and units depend on the
@@ -2738,10 +2748,9 @@ subroutine matrix_diagonal(CS, G, float_cond, H_node, nu, beta, hmask, dens_rati
       enddo ; enddo
     enddo ; enddo
     if (float_cond(i,j) == 1) then
-      Usubcontr = 0.0 ; Vsubcontr = 0.0 ; basel = G%Zd_to_m*G%bathyT(i,j)
+      Usubcontr = 0.0 ; Vsubcontr = 0.0 ; basel = G%bathyT(i,j)
       Hcell(:,:) = H_node(i-1:i,j-1:j)
-      call CG_diagonal_subgrid_basal &
-          (Phisub, Hcell, dxdyh, basel, dens_ratio, Usubcontr, Vsubcontr)
+      call CG_diagonal_subgrid_basal(Phisub, Hcell, dxdyh, basel, dens_ratio, Usubcontr, Vsubcontr)
       do iphi=1,2 ; do jphi=1,2
         if (CS%umask(i-2+iphi,j-2+jphi) == 1) then
           u_diagonal(i-2+iphi,j-2+jphi) = u_diagonal(i-2+iphi,j-2+jphi) + Usubcontr(iphi,jphi) * beta(i,j)
@@ -2758,9 +2767,9 @@ subroutine CG_diagonal_subgrid_basal (Phisub, H_node, DXDYH, bathyT, dens_ratio,
                         intent(in) :: Phisub !< Quadrature structure weights at subgridscale
                                              !! locations for finite element calculations
   real, dimension(2,2), intent(in) :: H_node !< The ice shelf thickness at nodal (corner)
-                                             !! points, in m
+                                             !! points, in Z
   real,              intent(in)    :: DXDYH  !< The tracer cell area, in m2
-  real,              intent(in)    :: bathyT !< The depth of ocean bathymetry at tracer points, in m
+  real,              intent(in)    :: bathyT !< The depth of ocean bathymetry at tracer points, in Z
   real,              intent(in)    :: dens_ratio !< The density of ice divided by the density
                                                  !! of seawater, nondimensional
   real, dimension(2,2), intent(inout) :: Ucontr !< A field related to the subgridscale contributions to
@@ -2804,7 +2813,7 @@ subroutine apply_boundary_values(CS, ISS, G, time, Phisub, H_node, nu, beta, flo
                                             !! locations for finite element calculations
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                           intent(in)    :: H_node !< The ice shelf thickness at nodal
-                                                 !! (corner) points, in m.
+                                                 !! (corner) points, in Z.
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                           intent(in)    :: nu   !< A field related to the ice viscosity from Glen's
                                                 !! flow law. The exact form and units depend on the
@@ -2953,11 +2962,11 @@ subroutine apply_boundary_values(CS, ISS, G, time, Phisub, H_node, nu, beta, flo
       enddo ; enddo
 
       if (float_cond(i,j) == 1) then
-        Usubcontr = 0.0 ; Vsubcontr = 0.0 ; basel = G%Zd_to_m*G%bathyT(i,j)
+        Usubcontr = 0.0 ; Vsubcontr = 0.0 ; basel = G%bathyT(i,j)
         Ucell(:,:) = CS%u_bdry_val(i-1:i,j-1:j) ; Vcell(:,:) = CS%v_bdry_val(i-1:i,j-1:j)
         Hcell(:,:) = H_node(i-1:i,j-1:j)
-        call CG_action_subgrid_basal &
-            (Phisub, Hcell, Ucell, Vcell, dxdyh, basel, dens_ratio, Usubcontr, Vsubcontr)
+        call CG_action_subgrid_basal(Phisub, Hcell, Ucell, Vcell, dxdyh, basel, &
+                                     dens_ratio, Usubcontr, Vsubcontr)
         do iphi=1,2 ; do jphi = 1,2
           if (CS%umask(i-2+iphi,j-2+jphi) == 1) then
             u_bdry_contr(i-2+iphi,j-2+jphi) = u_bdry_contr(i-2+iphi,j-2+jphi) + &
@@ -2976,11 +2985,12 @@ end subroutine apply_boundary_values
 
 !> Update depth integrated viscosity, based on horizontal strain rates, and also update the
 !! nonlinear part of the basal traction.
-subroutine calc_shelf_visc(CS, ISS, G, u, v)
+subroutine calc_shelf_visc(CS, ISS, G, US, u, v)
   type(ice_shelf_dyn_CS),    intent(inout) :: CS !< A pointer to the ice shelf control structure
   type(ice_shelf_state), intent(in)    :: ISS !< A structure with elements that describe
                                               !! the ice-shelf state
   type(ocean_grid_type), intent(in)    :: G  !< The grid structure used by the ice shelf.
+  type(unit_scale_type), intent(in)    :: US !< Pointer to a structure containing unit conversion factors
   real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB), &
                          intent(inout) :: u !< The zonal ice shelf velocity, in m/year.
   real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB), &
@@ -3023,7 +3033,7 @@ subroutine calc_shelf_visc(CS, ISS, G, u, v)
 
         CS%ice_visc(i,j) = .5 * A**(-1/n) * &
              (ux**2+vy**2+ux*vy+0.25*(uy+vx)**2+eps_min**2) ** ((1-n)/(2*n)) * &
-             ISS%h_shelf(i,j)
+             US%Z_to_m*ISS%h_shelf(i,j)
 
         umid = (u(i,j) + u(i,j-1) + u(i-1,j) + u(i-1,j-1))/4
         vmid = (v(i,j) + v(i,j-1) + v(i-1,j) + v(i-1,j-1))/4
@@ -3035,9 +3045,10 @@ subroutine calc_shelf_visc(CS, ISS, G, u, v)
 
 end subroutine calc_shelf_visc
 
-subroutine update_OD_ffrac(CS, G, ocean_mass, find_avg)
+subroutine update_OD_ffrac(CS, G, US, ocean_mass, find_avg)
   type(ice_shelf_dyn_CS), intent(inout) :: CS !< A pointer to the ice shelf control structure
   type(ocean_grid_type),  intent(inout) :: G  !< The grid structure used by the ice shelf.
+  type(unit_scale_type),  intent(in)    :: US !< Pointer to a structure containing unit conversion factors
   real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(in)    :: ocean_mass !< The mass per unit area of the ocean in kg m-2.
   logical,                intent(in)    :: find_avg !< If true, find the average of OD and ffrac, and
@@ -3047,12 +3058,12 @@ subroutine update_OD_ffrac(CS, G, ocean_mass, find_avg)
   real    :: I_rho_ocean
   real    :: I_counter
 
-  I_rho_ocean = 1.0/CS%density_ocean_avg
+  I_rho_ocean = 1.0 / (US%Z_to_m*CS%density_ocean_avg)
 
   isc = G%isc ; jsc = G%jsc ; iec = G%iec ; jec = G%jec
 
   do j=jsc,jec ; do i=isc,iec
-    CS%OD_rt(i,j) = CS%OD_rt(i,j) +  ocean_mass(i,j)*I_rho_ocean
+    CS%OD_rt(i,j) = CS%OD_rt(i,j) + ocean_mass(i,j)*I_rho_ocean
     if (ocean_mass(i,j)*I_rho_ocean > CS%thresh_float_col_depth) then
       CS%float_frac_rt(i,j) = CS%float_frac_rt(i,j) + 1.0
     endif
@@ -3076,20 +3087,19 @@ end subroutine update_OD_ffrac
 
 subroutine update_OD_ffrac_uncoupled(CS, G, h_shelf)
   type(ice_shelf_dyn_CS), intent(inout) :: CS !< A pointer to the ice shelf control structure
-  type(ocean_grid_type), intent(in) :: G  !< The grid structure used by the ice shelf.
+  type(ocean_grid_type),  intent(in)    :: G  !< The grid structure used by the ice shelf.
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(in) :: h_shelf !< the thickness of the ice shelf in m
+                          intent(in)    :: h_shelf !< the thickness of the ice shelf in Z
 
-  integer             :: i, j, iters, isd, ied, jsd, jed
-  real                 :: rhoi, rhow, OD
+  integer :: i, j, iters, isd, ied, jsd, jed
+  real    :: rhoi_rhow, OD
 
-  rhoi = CS%density_ice
-  rhow = CS%density_ocean_avg
+  rhoi_rhow = CS%density_ice / CS%density_ocean_avg
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   do j=jsd,jed
     do i=isd,ied
-      OD = G%Zd_to_m*G%bathyT(i,j) - rhoi/rhow * h_shelf(i,j)
+      OD = G%bathyT(i,j) - rhoi_rhow * h_shelf(i,j)
       if (OD >= 0) then
     ! ice thickness does not take up whole ocean column -> floating
         CS%OD_av(i,j) = OD
@@ -3398,13 +3408,13 @@ end subroutine update_velocity_masks
 subroutine interpolate_H_to_B(G, h_shelf, hmask, H_node)
   type(ocean_grid_type), intent(inout) :: G  !< The grid structure used by the ice shelf.
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(in)    :: h_shelf !< The ice shelf thickness at tracer points, in m.
+                         intent(in)    :: h_shelf !< The ice shelf thickness at tracer points, in Z.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(in)    :: hmask !< A mask indicating which tracer points are
                                              !! partly or fully covered by an ice-shelf
   real, dimension(SZDIB_(G),SZDJB_(G)), &
                          intent(inout) :: H_node !< The ice shelf thickness at nodal (corner)
-                                             !! points, in m.
+                                             !! points, in Z.
 
   integer :: i, j, isc, iec, jsc, jec, num_h, k, l
   real    :: summ
@@ -3460,11 +3470,12 @@ end subroutine ice_shelf_dyn_end
 
 
 !> This subroutine updates the vertically averaged ice shelf temperature.
-subroutine ice_shelf_temp(CS, ISS, G, time_step, melt_rate, Time)
+subroutine ice_shelf_temp(CS, ISS, G, US, time_step, melt_rate, Time)
   type(ice_shelf_dyn_CS), intent(inout) :: CS !< A pointer to the ice shelf control structure
   type(ice_shelf_state), intent(in) :: ISS !< A structure with elements that describe
                                            !! the ice-shelf state
   type(ocean_grid_type), intent(inout) :: G  !< The grid structure used by the ice shelf.
+  type(unit_scale_type), intent(in)    :: US !< Pointer to a structure containing unit conversion factors
   real,                  intent(in) :: time_step !< The time step for this update, in s.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(in) :: melt_rate !< basal melt rate in kg/m^2/s
@@ -3481,7 +3492,7 @@ subroutine ice_shelf_temp(CS, ISS, G, time_step, melt_rate, Time)
 ! t_after_vflux - similar
 !
 !    This subroutine takes the velocity (on the Bgrid) and timesteps
-!      (HT)_t = - div (uHT) + (adot Tsurd -bdot Tbot) once and then calculates T=HT/H
+!      (HT)_t = - div (uHT) + (adot Tsurf -bdot Tbot) once and then calculates T=HT/H
 !
 !    The flux overflows are included here. That is because they will be used to advect 3D scalars
 !    into partial cells
@@ -3516,7 +3527,7 @@ subroutine ice_shelf_temp(CS, ISS, G, time_step, melt_rate, Time)
   rho = CS%density_ice
   spy = 365 * 86400 ! seconds per year; is there a global constant for this?  No - it is dependent upon a calendar.
 
-  adot = 0.1/spy ! for now adot and Tsurf are defined here adot=surf acc 0.1m/yr, Tsurf=-20oC, vary them later
+  adot = 0.1*US%m_to_Z/spy ! for now adot and Tsurf are defined here adot=surf acc 0.1m/yr, Tsurf=-20oC, vary them later
   Tsurf = -20.0
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -3531,14 +3542,14 @@ subroutine ice_shelf_temp(CS, ISS, G, time_step, melt_rate, Time)
       t_bd = CS%t_bdry_val(i,j)
 !      if (ISS%hmask(i,j) > 1) then
       if ((ISS%hmask(i,j) == 3) .or. (ISS%hmask(i,j) == -2)) then
-          CS%t_shelf(i,j) = CS%t_bdry_val(i,j)
+        CS%t_shelf(i,j) = CS%t_bdry_val(i,j)
       endif
     enddo
   enddo
 
   do j=jsd,jed
     do i=isd,ied
-        TH(i,j) = CS%t_shelf(i,j)*ISS%h_shelf(i,j)
+      TH(i,j) = CS%t_shelf(i,j)*ISS%h_shelf(i,j)
     enddo
   enddo
 
@@ -3557,7 +3568,7 @@ subroutine ice_shelf_temp(CS, ISS, G, time_step, melt_rate, Time)
     do i=isd,ied
 !      if (ISS%hmask(i,j) == 1) then
       if (ISS%h_shelf(i,j) > 0.0) then
-        CS%t_shelf(i,j) = th_after_vflux(i,j)/ISS%h_shelf(i,j)
+        CS%t_shelf(i,j) = th_after_vflux(i,j)/(ISS%h_shelf(i,j))
       else
         CS%t_shelf(i,j) = -10.0
       endif
@@ -3579,8 +3590,8 @@ subroutine ice_shelf_temp(CS, ISS, G, time_step, melt_rate, Time)
     do i=isc,iec
       if ((ISS%hmask(i,j) == 1) .or. (ISS%hmask(i,j) == 2)) then
         if (ISS%h_shelf(i,j) > 0.0) then
-!          CS%t_shelf(i,j) = CS%t_shelf(i,j) + time_step*(adot*Tsurf -melt_rate(i,j)*ISS%tfreeze(i,j))/ISS%h_shelf(i,j)
-          CS%t_shelf(i,j) = CS%t_shelf(i,j) + time_step*(adot*Tsurf -3/spy*ISS%tfreeze(i,j))/ISS%h_shelf(i,j)
+!          CS%t_shelf(i,j) = CS%t_shelf(i,j) + time_step*(adot*Tsurf - US%m_to_Z*melt_rate(i,j)*ISS%tfreeze(i,j))/(ISS%h_shelf(i,j))
+          CS%t_shelf(i,j) = CS%t_shelf(i,j) + time_step*(adot*Tsurf - (3.0*US%m_to_Z/spy)*ISS%tfreeze(i,j)) / ISS%h_shelf(i,j)
         else
           ! the ice is about to melt away
           ! in this case set thickness, area, and mask to zero
@@ -3612,13 +3623,13 @@ subroutine ice_shelf_advect_temp_x(CS, G, time_step, hmask, h0, h_after_uflux, f
                           intent(in)    :: hmask !< A mask indicating which tracer points are
                                              !! partly or fully covered by an ice-shelf
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                          intent(in)    :: h0 !< The initial ice shelf thicknesses in m.
+                          intent(in)    :: h0 !< The initial ice shelf thicknesses in Z.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(inout) :: h_after_uflux !< The ice shelf thicknesses after
                                               !! the zonal mass fluxes, in m.
   real, dimension(SZDI_(G),SZDJ_(G),4), &
                           intent(inout) :: flux_enter !< The integrated temperature flux into
-                                              !! the cell through the 4 cell boundaries, in degC m3
+                                              !! the cell through the 4 cell boundaries, in degC Z m2
 
   ! use will be made of ISS%hmask here - its value at the boundary will be zero, just like uncovered cells
 
@@ -3690,9 +3701,6 @@ subroutine ice_shelf_advect_temp_x(CS, G, time_step, hmask, h0, h_after_uflux, f
 
               flux_diff_cell = flux_diff_cell + dyh * time_step * CS%u_flux_bdry_val(i-1,j) * &
                                CS%t_bdry_val(i-1,j) / dxdyh
-! assume no flux bc for temp
-!               flux_diff_cell = flux_diff_cell + dyh * time_step * CS%u_shelf(i,j)*CS%t_bdry_val(i-1,j) / dxdyh
-
             else
 
               ! get u-velocity at center of left face
@@ -3743,9 +3751,6 @@ subroutine ice_shelf_advect_temp_x(CS, G, time_step, hmask, h0, h_after_uflux, f
 
               flux_diff_cell = flux_diff_cell + dyh * time_step * CS%u_flux_bdry_val(i+1,j) *&
                                CS%t_bdry_val(i+1,j)/ dxdyh
-! assume no flux bc for temp
-!               flux_diff_cell = flux_diff_cell + dyh * time_step *  CS%u_shelf(i,j)*CS%t_bdry_val(i+1,j)/ dxdyh
-
             else
 
               u_face = 0.5 * (CS%u_shelf(i,j-1) + CS%u_shelf(i,j))
@@ -3806,8 +3811,6 @@ subroutine ice_shelf_advect_temp_x(CS, G, time_step, hmask, h0, h_after_uflux, f
                                   CS%thickness_bdry_val(i+1,j)
             elseif (CS%u_face_mask(i-1,j) == 4.) then
               flux_enter(i,j,1) = G%dyT(i,j) * time_step * CS%u_flux_bdry_val(i-1,j)*CS%t_bdry_val(i-1,j)
-!              flux_enter(i,j,1) = G%dyh(i,j) * time_step *  CS%u_shelf(i,j)*CS%t_bdry_val(i-1,j)
-! assume no flux bc for temp
             endif
 
             if (at_east_bdry .AND. (hmask(i+1,j) == 3)) then
@@ -3816,8 +3819,6 @@ subroutine ice_shelf_advect_temp_x(CS, G, time_step, hmask, h0, h_after_uflux, f
                                   CS%thickness_bdry_val(i+1,j)
             elseif (CS%u_face_mask(i+1,j) == 4.) then
               flux_enter(i,j,2) = G%dyT(i,j) * time_step * CS%u_flux_bdry_val(i+1,j) * CS%t_bdry_val(i+1,j)
-! assume no flux bc for temp
-!              flux_enter(i,j,2) = G%dyh(i,j) * time_step *  CS%u_shelf(i,j)*CS%t_bdry_val(i+1,j)
             endif
 
 !            if ((i == is) .AND. (hmask(i,j) == 0) .AND. (hmask(i-1,j) == 1)) then
@@ -3854,13 +3855,13 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
                                              !! partly or fully covered by an ice-shelf
   real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(in)    :: h_after_uflux !< The ice shelf thicknesses after
-                                              !! the zonal mass fluxes, in m.
+                                              !! the zonal mass fluxes, in Z.
   real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(inout) :: h_after_vflux !< The ice shelf thicknesses after
-                                              !! the meridional mass fluxes, in m.
+                                              !! the meridional mass fluxes, in Z.
   real, dimension(SZDI_(G),SZDJ_(G),4), &
                           intent(inout) :: flux_enter !< The integrated temperature flux into
-                                              !! the cell through the 4 cell boundaries, in degC m3
+                                              !! the cell through the 4 cell boundaries, in degC Z m2
 
   ! use will be made of ISS%hmask here - its value at the boundary will be zero, just like uncovered cells
 
@@ -3926,9 +3927,6 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
 
               flux_diff_cell = flux_diff_cell + dxh * time_step * CS%v_flux_bdry_val(i,j-1) * &
                                  CS%t_bdry_val(i,j-1)/ dxdyh
-! assume no flux bc for temp
-!              flux_diff_cell = flux_diff_cell + dxh * time_step *  CS%v_shelf(i,j)*CS%t_bdry_val(i,j-1) / dxdyh
-
             else
 
               ! get u-velocity at center of left face
@@ -3979,9 +3977,6 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
 
               flux_diff_cell = flux_diff_cell + dxh * time_step * CS%v_flux_bdry_val(i,j+1) *&
                                CS%t_bdry_val(i,j+1)/ dxdyh
-! assume no flux bc for temp
-!              flux_diff_cell = flux_diff_cell + dxh * time_step *  CS%v_shelf(i,j)*CS%t_bdry_val(i,j+1) / dxdyh
-
             else
 
             ! get u-velocity at center of right face
@@ -4031,9 +4026,6 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
                                    CS%thickness_bdry_val(i,j-1)
             elseif (CS%v_face_mask(i,j-1) == 4.) then
               flux_enter(i,j,3) = G%dxT(i,j) * time_step * CS%v_flux_bdry_val(i,j-1)*CS%t_bdry_val(i,j-1)
-! assume no flux bc for temp
-!              flux_enter(i,j,3) = G%dxh(i,j) * time_step *  CS%v_shelf(i,j)*CS%t_bdry_val(i,j-1)
-
             endif
 
             if (at_north_bdry .AND. (hmask(i,j+1) == 3)) then
@@ -4042,8 +4034,6 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
                                    CS%thickness_bdry_val(i,j+1)
             elseif (CS%v_face_mask(i,j+1) == 4.) then
               flux_enter(i,j,4) = G%dxT(i,j) * time_step * CS%v_flux_bdry_val(i,j+1)*CS%t_bdry_val(i,j+1)
-! assume no flux bc for temp
-!              flux_enter(i,j,4) = G%dxh(i,j) * time_step * CS%v_shelf(i,j)*CS%t_bdry_val(i,j+1)
             endif
 
 !            if ((j == js) .AND. (hmask(i,j) == 0) .AND. (hmask(i,j-1) == 1)) then

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -3590,8 +3590,10 @@ subroutine ice_shelf_temp(CS, ISS, G, US, time_step, melt_rate, Time)
     do i=isc,iec
       if ((ISS%hmask(i,j) == 1) .or. (ISS%hmask(i,j) == 2)) then
         if (ISS%h_shelf(i,j) > 0.0) then
-!          CS%t_shelf(i,j) = CS%t_shelf(i,j) + time_step*(adot*Tsurf - US%m_to_Z*melt_rate(i,j)*ISS%tfreeze(i,j))/(ISS%h_shelf(i,j))
-          CS%t_shelf(i,j) = CS%t_shelf(i,j) + time_step*(adot*Tsurf - (3.0*US%m_to_Z/spy)*ISS%tfreeze(i,j)) / ISS%h_shelf(i,j)
+!         CS%t_shelf(i,j) = CS%t_shelf(i,j) + &
+!             time_step*(adot*Tsurf - US%m_to_Z*melt_rate(i,j)*ISS%tfreeze(i,j))/(ISS%h_shelf(i,j))
+          CS%t_shelf(i,j) = CS%t_shelf(i,j) + &
+              time_step*(adot*Tsurf - (3.0*US%m_to_Z/spy)*ISS%tfreeze(i,j)) / ISS%h_shelf(i,j)
         else
           ! the ice is about to melt away
           ! in this case set thickness, area, and mask to zero

--- a/src/ice_shelf/MOM_marine_ice.F90
+++ b/src/ice_shelf/MOM_marine_ice.F90
@@ -136,8 +136,8 @@ subroutine iceberg_fluxes(G, fluxes, use_ice_shelf, sfc_state, &
     fluxes%ustar_shelf(:,:) = 0.
   endif
   do j=jsd,jed ; do i=isd,ied ; if (G%areaT(i,j) > 0.0) then
-    fluxes%frac_shelf_h(i,j) = fluxes%frac_shelf_h(i,j) +  fluxes%area_berg(i,j)
-    fluxes%ustar_shelf(i,j)  = fluxes%ustar_shelf(i,j)  +  fluxes%ustar_berg(i,j)
+    fluxes%frac_shelf_h(i,j) = fluxes%frac_shelf_h(i,j) + fluxes%area_berg(i,j)
+    fluxes%ustar_shelf(i,j)  = fluxes%ustar_shelf(i,j)  + fluxes%ustar_berg(i,j)
   endif ; enddo ; enddo
 
   !Zero'ing out other fluxes under the tabular icebergs

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -339,7 +339,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
 
   if (CS%debug) then
     call hchksum(h,'mixed_layer_restrat: h',G%HI,haloshift=1,scale=GV%H_to_m)
-    call hchksum(forces%ustar,'mixed_layer_restrat: u*',G%HI,haloshift=1)
+    call hchksum(forces%ustar,'mixed_layer_restrat: u*',G%HI,haloshift=1,scale=US%Z_to_m)
     call hchksum(MLD_fast,'mixed_layer_restrat: MLD',G%HI,haloshift=1,scale=GV%H_to_m)
     call hchksum(Rml_av_fast,'mixed_layer_restrat: rml',G%HI,haloshift=1, scale=US%m_to_Z)
   endif
@@ -351,7 +351,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
 !   U - Component
 !$OMP do
   do j=js,je ; do I=is-1,ie
-    u_star = US%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
+    u_star = 0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
     absf = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
     ! If needed, res_scaling_fac = min( ds, L_d ) / l_f
     if (res_upscale) res_scaling_fac = &
@@ -427,7 +427,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
 !  V- component
 !$OMP do
   do J=js-1,je ; do i=is,ie
-    u_star = US%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
+    u_star = 0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
     absf = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
     ! If needed, res_scaling_fac = min( ds, L_d ) / l_f
     if (res_upscale) res_scaling_fac = &
@@ -650,7 +650,7 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
     do I=is-1,ie
       h_vel = 0.5*(htot(i,j) + htot(i+1,j)) * GV%H_to_Z
 
-      u_star = US%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
+      u_star = 0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
       absf = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
       ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
       ! momentum mixing rate: pi^2*visc/h_ml^2
@@ -698,7 +698,7 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
   do J=js-1,je ; do i=is,ie
     h_vel = 0.5*(htot(i,j) + htot(i,j+1)) * GV%H_to_Z
 
-    u_star = US%m_to_Z*0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
+    u_star = 0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
     absf = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
     ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -488,7 +488,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
   CS%id_Vt2 = register_diag_field('ocean_model', 'KPP_Vt2', diag%axesTL, Time, &
       'Unresolved shear turbulence used by [CVMix] KPP', 'm2/s2')
   CS%id_uStar = register_diag_field('ocean_model', 'KPP_uStar', diag%axesT1, Time, &
-      'Friction velocity, u*, as used by [CVMix] KPP', 'm/s')
+      'Friction velocity, u*, as used by [CVMix] KPP', 'm/s', conversion=US%Z_to_m)
   CS%id_buoyFlux = register_diag_field('ocean_model', 'KPP_buoyFlux', diag%axesTi, Time, &
       'Surface (and penetrating) buoyancy flux, as used by [CVMix] KPP', 'm2/s3')
   CS%id_QminusSW = register_diag_field('ocean_model', 'KPP_QminusSW', diag%axesT1, Time, &
@@ -587,7 +587,7 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
   type(unit_scale_type),                      intent(in)    :: US    !< A dimensional unit scaling type
   type(wave_parameters_CS),         optional, pointer       :: Waves !< Wave CS
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: h     !< Layer/level thicknesses (units of H)
-  real, dimension(SZI_(G),SZJ_(G)),           intent(in)    :: uStar !< Surface friction velocity (m/s)
+  real, dimension(SZI_(G),SZJ_(G)),           intent(in)    :: uStar !< Surface friction velocity (Z/s)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(in)    :: buoyFlux !< Surface buoyancy flux (m2/s3)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: Kt   !< (in)  Vertical diffusivity of heat w/o KPP (Z2/s)
                                                                     !< (out) Vertical diffusivity including KPP (Z2/s)
@@ -618,7 +618,7 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
 #ifdef __DO_SAFETY_CHECKS__
   if (CS%debug) then
     call hchksum(h, "KPP in: h",G%HI,haloshift=0, scale=GV%H_to_m)
-    call hchksum(uStar, "KPP in: uStar",G%HI,haloshift=0)
+    call hchksum(uStar, "KPP in: uStar",G%HI,haloshift=0, scale=US%Z_to_m)
     call hchksum(buoyFlux, "KPP in: buoyFlux",G%HI,haloshift=0)
     call hchksum(Kt, "KPP in: Kt",G%HI,haloshift=0, scale=US%Z_to_m**2)
     call hchksum(Ks, "KPP in: Ks",G%HI,haloshift=0, scale=US%Z_to_m**2)
@@ -638,7 +638,7 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
       if (G%mask2dT(i,j)==0.) cycle
 
       ! things independent of position within the column
-      surfFricVel = uStar(i,j)
+      surfFricVel = US%Z_to_m * uStar(i,j)
 
       iFaceHeight(1) = 0.0 ! BBL is all relative to the surface
       hcorr = 0.
@@ -882,7 +882,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, EOS, uStar, buoyF
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)),  intent(in)    :: u     !< Velocity i-component (m/s)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)),  intent(in)    :: v     !< Velocity j-component (m/s)
   type(EOS_type),                             pointer       :: EOS   !< Equation of state
-  real, dimension(SZI_(G),SZJ_(G)),           intent(in)    :: uStar !< Surface friction velocity (m/s)
+  real, dimension(SZI_(G),SZJ_(G)),           intent(in)    :: uStar !< Surface friction velocity (Z/s)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(in)    :: buoyFlux !< Surface buoyancy flux (m2/s3)
   type(wave_parameters_CS),         optional, pointer       :: Waves !< Wave CS
 
@@ -958,7 +958,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, EOS, uStar, buoyF
       ! things independent of position within the column
       Coriolis = 0.25*( (G%CoriolisBu(i,j)   + G%CoriolisBu(i-1,j-1)) &
                        +(G%CoriolisBu(i-1,j) + G%CoriolisBu(i,j-1)) )
-      surfFricVel = uStar(i,j)
+      surfFricVel = US%Z_to_m * uStar(i,j)
 
       ! Bullk Richardson number computed for each cell in a column,
       ! assuming OBLdepth = grid cell depth. After Rib(k) is

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -668,7 +668,7 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, US, C
             associated(fluxes%frac_shelf_h)) then
           if (fluxes%frac_shelf_h(i,j) > 0.0) &
             kU_Star = (1.0 - fluxes%frac_shelf_h(i,j)) * kU_star + &
-                      fluxes%frac_shelf_h(i,j) * (0.41*US%m_to_Z*fluxes%ustar_shelf(i,j))
+                      fluxes%frac_shelf_h(i,j) * (0.41*fluxes%ustar_shelf(i,j))
         endif
         absf_x_H = 0.25 * US%m_to_Z * h(i,0) * &  !### I think this should be H_to_Z -RWH
             ((abs(G%CoriolisBu(I,J)) + abs(G%CoriolisBu(I-1,J-1))) + &
@@ -1372,7 +1372,7 @@ subroutine find_starting_TKE(htot, h_CA, fluxes, Conv_En, cTKE, dKE_FC, dKE_CA, 
     if (associated(fluxes%ustar_shelf) .and. associated(fluxes%frac_shelf_h)) then
       if (fluxes%frac_shelf_h(i,j) > 0.0) &
         U_Star = (1.0 - fluxes%frac_shelf_h(i,j)) * U_star + &
-                  fluxes%frac_shelf_h(i,j) * US%m_to_Z * fluxes%ustar_shelf(i,j)
+                  fluxes%frac_shelf_h(i,j) * fluxes%ustar_shelf(i,j)
     endif
 
     if (U_Star < CS%ustar_min) U_Star = CS%ustar_min

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -663,7 +663,7 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, US, C
       ! as the third piece will then optimally describe mixed layer
       ! restratification.  For nkml>=4 the whole strategy should be revisited.
       do i=is,ie
-        kU_Star = 0.41*US%m_to_Z*fluxes%ustar(i,j) ! Maybe could be replaced with u*+w*?
+        kU_Star = 0.41*fluxes%ustar(i,j) ! Maybe could be replaced with u*+w*?
         if (associated(fluxes%ustar_shelf) .and. &
             associated(fluxes%frac_shelf_h)) then
           if (fluxes%frac_shelf_h(i,j) > 0.0) &
@@ -1368,7 +1368,7 @@ subroutine find_starting_TKE(htot, h_CA, fluxes, Conv_En, cTKE, dKE_FC, dKE_CA, 
 
   if (CS%omega_frac >= 1.0) absf = 2.0*CS%omega
   do i=is,ie
-    U_Star = US%m_to_Z * fluxes%ustar(i,j)
+    U_Star = fluxes%ustar(i,j)
     if (associated(fluxes%ustar_shelf) .and. associated(fluxes%frac_shelf_h)) then
       if (fluxes%frac_shelf_h(i,j) > 0.0) &
         U_Star = (1.0 - fluxes%frac_shelf_h(i,j)) * U_star + &

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -425,7 +425,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
 
   if (CS%debug) then
     call MOM_state_chksum("Start of diabatic ", u, v, h, G, GV, haloshift=0)
-    call MOM_forcing_chksum("Start of diabatic", fluxes, G, haloshift=0)
+    call MOM_forcing_chksum("Start of diabatic", fluxes, G, US, haloshift=0)
   endif
   if (CS%debugConservation) call MOM_state_stats('Start of diabatic', u, v, h, tv%T, tv%S, G)
 
@@ -587,7 +587,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
 
   if (CS%debug) then
     call MOM_state_chksum("after set_diffusivity ", u, v, h, G, GV, haloshift=0)
-    call MOM_forcing_chksum("after set_diffusivity ", fluxes, G, haloshift=0)
+    call MOM_forcing_chksum("after set_diffusivity ", fluxes, G, US, haloshift=0)
     call MOM_thermovar_chksum("after set_diffusivity ", tv, G)
     call hchksum(Kd_heat, "after set_diffusivity Kd_heat", G%HI, haloshift=0, scale=US%Z_to_m**2)
     call hchksum(Kd_salt, "after set_diffusivity Kd_salt", G%HI, haloshift=0, scale=US%Z_to_m**2)
@@ -610,7 +610,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     ! The KPP scheme calculates boundary layer diffusivities and non-local transport.
 
     call KPP_compute_BLD(CS%KPP_CSp, G, GV, US, h, tv%T, tv%S, u, v, tv%eqn_of_state, &
-      fluxes%ustar, CS%KPP_buoy_flux, Waves=Waves)
+                         fluxes%ustar, CS%KPP_buoy_flux, Waves=Waves)
 
     call KPP_calculate(CS%KPP_CSp, G, GV, US, h, fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, &
       Kd_salt, visc%Kv_shear, CS%KPP_NLTheat, CS%KPP_NLTscalar, Waves=Waves)
@@ -628,7 +628,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     if (showCallTree) call callTree_waypoint("done with KPP_calculate (diabatic)")
     if (CS%debug) then
       call MOM_state_chksum("after KPP", u, v, h, G, GV, haloshift=0)
-      call MOM_forcing_chksum("after KPP", fluxes, G, haloshift=0)
+      call MOM_forcing_chksum("after KPP", fluxes, G, US, haloshift=0)
       call MOM_thermovar_chksum("after KPP", tv, G)
       call hchksum(Kd_heat, "after KPP Kd_heat", G%HI, haloshift=0, scale=US%Z_to_m**2)
       call hchksum(Kd_salt, "after KPP Kd_salt", G%HI, haloshift=0, scale=US%Z_to_m**2)
@@ -655,7 +655,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
 
     if (CS%debug) then
       call MOM_state_chksum("after KPP_applyNLT ", u, v, h, G, GV, haloshift=0)
-      call MOM_forcing_chksum("after KPP_applyNLT ", fluxes, G, haloshift=0)
+      call MOM_forcing_chksum("after KPP_applyNLT ", fluxes, G, US, haloshift=0)
       call MOM_thermovar_chksum("after KPP_applyNLT ", tv, G)
     endif
   endif ! endif for KPP
@@ -789,7 +789,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   call diag_update_remap_grids(CS%diag)
   call cpu_clock_end(id_clock_remap)
   if (CS%debug) then
-    call MOM_forcing_chksum("after applyBoundaryFluxes ", fluxes, G, haloshift=0)
+    call MOM_forcing_chksum("after applyBoundaryFluxes ", fluxes, G, US, haloshift=0)
     call MOM_thermovar_chksum("after applyBoundaryFluxes ", tv, G)
     call MOM_state_chksum("after applyBoundaryFluxes ", u, v, h, G, GV, haloshift=0)
   endif
@@ -1305,7 +1305,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
   if (CS%debug) then
     call MOM_state_chksum("Start of diabatic ", u, v, h, G, GV, haloshift=0)
-    call MOM_forcing_chksum("Start of diabatic", fluxes, G, haloshift=0)
+    call MOM_forcing_chksum("Start of diabatic", fluxes, G, US, haloshift=0)
   endif
   if (CS%debugConservation) call MOM_state_stats('Start of diabatic', u, v, h, tv%T, tv%S, G)
 
@@ -1373,7 +1373,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
   if (CS%bulkmixedlayer) then
     if (CS%debug) then
-      call MOM_forcing_chksum("Before mixedlayer", fluxes, G, haloshift=0)
+      call MOM_forcing_chksum("Before mixedlayer", fluxes, G, US, haloshift=0)
     endif
 
     if (CS%ML_mix_first > 0.0) then
@@ -1413,7 +1413,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       call cpu_clock_end(id_clock_mixedlayer)
       if (CS%debug) then
         call MOM_state_chksum("After mixedlayer ", u, v, h, G, GV, haloshift=0)
-        call MOM_forcing_chksum("After mixedlayer", fluxes, G, haloshift=0)
+        call MOM_forcing_chksum("After mixedlayer", fluxes, G, US, haloshift=0)
       endif
       if (showCallTree) call callTree_waypoint("done with 1st bulkmixedlayer (diabatic)")
       if (CS%debugConservation) call MOM_state_stats('1st bulkmixedlayer', u, v, h, tv%T, tv%S, G)
@@ -1497,7 +1497,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
   if (CS%debug) then
     call MOM_state_chksum("after set_diffusivity ", u, v, h, G, GV, haloshift=0)
-    call MOM_forcing_chksum("after set_diffusivity ", fluxes, G, haloshift=0)
+    call MOM_forcing_chksum("after set_diffusivity ", fluxes, G, US, haloshift=0)
     call MOM_thermovar_chksum("after set_diffusivity ", tv, G)
     call hchksum(Kd_lay, "after set_diffusivity Kd_lay", G%HI, haloshift=0, scale=US%Z_to_m**2)
     call hchksum(Kd_Int, "after set_diffusivity Kd_Int", G%HI, haloshift=0, scale=US%Z_to_m**2)
@@ -1569,7 +1569,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
     if (showCallTree) call callTree_waypoint("done with KPP_calculate (diabatic)")
     if (CS%debug) then
       call MOM_state_chksum("after KPP", u, v, h, G, GV, haloshift=0)
-      call MOM_forcing_chksum("after KPP", fluxes, G, haloshift=0)
+      call MOM_forcing_chksum("after KPP", fluxes, G, US, haloshift=0)
       call MOM_thermovar_chksum("after KPP", tv, G)
       call hchksum(Kd_lay, "after KPP Kd_lay", G%HI, haloshift=0, scale=US%Z_to_m**2)
       call hchksum(Kd_Int, "after KPP Kd_Int", G%HI, haloshift=0, scale=US%Z_to_m**2)
@@ -1610,7 +1610,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
     if (CS%debug) then
       call MOM_state_chksum("after KPP_applyNLT ", u, v, h, G, GV, haloshift=0)
-      call MOM_forcing_chksum("after KPP_applyNLT ", fluxes, G, haloshift=0)
+      call MOM_forcing_chksum("after KPP_applyNLT ", fluxes, G, US, haloshift=0)
       call MOM_thermovar_chksum("after KPP_applyNLT ", tv, G)
     endif
 
@@ -1673,7 +1673,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
   endif ! endif for (CS%useALEalgorithm)
 
   if (CS%debug) then
-    call MOM_forcing_chksum("after calc_entrain ", fluxes, G, haloshift=0)
+    call MOM_forcing_chksum("after calc_entrain ", fluxes, G, US, haloshift=0)
     call MOM_thermovar_chksum("after calc_entrain ", tv, G)
     call MOM_state_chksum("after calc_entrain ", u, v, h, G, GV, haloshift=0)
     call hchksum(ea, "after calc_entrain ea", G%HI, haloshift=0, scale=GV%H_to_m)
@@ -1771,7 +1771,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
     call cpu_clock_end(id_clock_remap)
     if (CS%debug) then
-      call MOM_forcing_chksum("after applyBoundaryFluxes ", fluxes, G, haloshift=0)
+      call MOM_forcing_chksum("after applyBoundaryFluxes ", fluxes, G, US, haloshift=0)
       call MOM_thermovar_chksum("after applyBoundaryFluxes ", tv, G)
       call MOM_state_chksum("after applyBoundaryFluxes ", u, v, h, G, GV, haloshift=0)
     endif
@@ -1816,7 +1816,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
   if (CS%debug) then
     call MOM_state_chksum("after negative check ", u, v, h, G, GV, haloshift=0)
-    call MOM_forcing_chksum("after negative check ", fluxes, G, haloshift=0)
+    call MOM_forcing_chksum("after negative check ", fluxes, G, US, haloshift=0)
     call MOM_thermovar_chksum("after negative check ", tv, G)
   endif
   if (showCallTree) call callTree_waypoint("done with h=ea-eb (diabatic)")

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -608,7 +608,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
       if (associated(fluxes%ustar_shelf) .and. associated(fluxes%frac_shelf_h)) then
         if (fluxes%frac_shelf_h(i,j) > 0.0) &
           U_star = (1.0 - fluxes%frac_shelf_h(i,j)) * U_star + &
-                    fluxes%frac_shelf_h(i,j) * US%m_to_Z*fluxes%ustar_shelf(i,j)
+                    fluxes%frac_shelf_h(i,j) * fluxes%ustar_shelf(i,j)
       endif
       if (U_Star < CS%ustar_min) U_Star = CS%ustar_min
 

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -603,7 +603,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
     ! interface.
     do i=is,ie ; if (G%mask2dT(i,j) > 0.5) then
 
-      U_star = US%m_to_Z*fluxes%ustar(i,j)
+      U_star = fluxes%ustar(i,j)
       U_Star_Mean = fluxes%ustar_gustless(i,j)
       if (associated(fluxes%ustar_shelf) .and. associated(fluxes%frac_shelf_h)) then
         if (fluxes%frac_shelf_h(i,j) > 0.0) &

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1206,7 +1206,7 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS, symmetri
             if (CS%omega_frac > 0.0) &
               absf = sqrt(CS%omega_frac*4.0*CS%omega**2 + (1.0-CS%omega_frac)*absf**2)
           endif
-          U_star = max(CS%ustar_min, 0.5 * (forces%ustar(i,j) + forces%ustar(i+1,j))*US%m_to_Z)
+          U_star = max(CS%ustar_min, 0.5 * (forces%ustar(i,j) + forces%ustar(i+1,j)))
           Idecay_len_TKE(I) = ((absf / U_star) * CS%TKE_decay) * GV%H_to_Z
         endif
       enddo
@@ -1442,7 +1442,7 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS, symmetri
              absf = sqrt(CS%omega_frac*4.0*CS%omega**2 + (1.0-CS%omega_frac)*absf**2)
          endif
 
-         U_star = max(CS%ustar_min, 0.5 * (forces%ustar(i,j) + forces%ustar(i,j+1))*US%m_to_Z)
+         U_star = max(CS%ustar_min, 0.5 * (forces%ustar(i,j) + forces%ustar(i,j+1)))
          Idecay_len_TKE(i) = ((absf / U_star) * CS%TKE_decay) * GV%H_to_Z
 
         endif

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1296,11 +1296,11 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
     do i=is,ie ; if (do_i(i)) then
       if (GV%nkml>0) nk_visc(i) = real(GV%nkml+1)
       if (work_on_u) then
-        u_star(I) = 0.5*US%m_to_Z*(forces%ustar(i,j) + forces%ustar(i+1,j))
+        u_star(I) = 0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
         absf(I) = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
         if (CS%dynamic_viscous_ML) nk_visc(I) = visc%nkml_visc_u(I,j) + 1
       else
-        u_star(i) = 0.5*US%m_to_Z*(forces%ustar(i,j) + forces%ustar(i,j+1))
+        u_star(i) = 0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
         absf(i) = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
         if (CS%dynamic_viscous_ML) nk_visc(i) = visc%nkml_visc_v(i,J) + 1
       endif
@@ -1311,16 +1311,16 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
     if (do_OBCS) then ; if (work_on_u) then
       do I=is,ie ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= OBC_NONE)) then
         if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) &
-          u_star(I) = US%m_to_Z*forces%ustar(i,j)
+          u_star(I) = forces%ustar(i,j)
         if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) &
-          u_star(I) = US%m_to_Z*forces%ustar(i+1,j)
+          u_star(I) = forces%ustar(i+1,j)
       endif ; enddo
     else
       do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= OBC_NONE)) then
         if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) &
-          u_star(i) = US%m_to_Z*forces%ustar(i,j)
+          u_star(i) = forces%ustar(i,j)
         if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) &
-          u_star(i) = US%m_to_Z*forces%ustar(i,j+1)
+          u_star(i) = forces%ustar(i,j+1)
       endif ; enddo
     endif ; endif
 

--- a/src/user/SCM_CVMix_tests.F90
+++ b/src/user/SCM_CVMix_tests.F90
@@ -12,6 +12,7 @@ use MOM_verticalgrid,  only : verticalGrid_type
 use MOM_safe_alloc,    only : safe_alloc_ptr
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_time_manager,  only : time_type, operator(+), operator(/), time_type_to_real
+use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs, surface
 implicit none ; private
 
@@ -184,11 +185,12 @@ subroutine SCM_CVMix_tests_surface_forcing_init(Time, G, param_file, CS)
 
 end subroutine SCM_CVMix_tests_surface_forcing_init
 
-subroutine SCM_CVMix_tests_wind_forcing(state, forces, day, G, CS)
-  type(surface),                    intent(in)    :: state  !< Surface state structure
-  type(mech_forcing),               intent(inout) :: forces !< A structure with the driving mechanical forces
-  type(time_type),                  intent(in)    :: day    !< Time in days
-  type(ocean_grid_type),            intent(inout) :: G      !< Grid structure
+subroutine SCM_CVMix_tests_wind_forcing(state, forces, day, G, US, CS)
+  type(surface),            intent(in)    :: state  !< Surface state structure
+  type(mech_forcing),       intent(inout) :: forces !< A structure with the driving mechanical forces
+  type(time_type),          intent(in)    :: day    !< Time in days
+  type(ocean_grid_type),    intent(inout) :: G      !< Grid structure
+  type(unit_scale_type),    intent(in)    :: US     !< A dimensional unit scaling type
   type(SCM_CVMix_tests_CS), pointer       :: CS     !< Container for SCM parameters
   ! Local variables
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq
@@ -211,7 +213,7 @@ subroutine SCM_CVMix_tests_wind_forcing(state, forces, day, G, CS)
 
   mag_tau = sqrt(CS%tau_x*CS%tau_x + CS%tau_y*CS%tau_y)
   if (associated(forces%ustar)) then ; do j=js,je ; do i=is,ie
-    forces%ustar(i,j) = sqrt(  mag_tau / CS%Rho0 )
+    forces%ustar(i,j) = US%m_to_Z * sqrt(  mag_tau / CS%Rho0 )
   enddo ; enddo ; endif
 
 end subroutine SCM_CVMix_tests_wind_forcing

--- a/src/user/baroclinic_zone_initialization.F90
+++ b/src/user/baroclinic_zone_initialization.F90
@@ -94,7 +94,8 @@ subroutine baroclinic_zone_init_temperature_salinity(T, S, h, G, GV, US, param_f
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
-  call bcz_params(G, GV, US, param_file, S_ref, dSdz, delta_S, dSdx, T_ref, dTdz, delta_T, dTdx, L_zone, just_read_params)
+  call bcz_params(G, GV, US, param_file, S_ref, dSdz, delta_S, dSdx, T_ref, dTdz, &
+                  delta_T, dTdx, L_zone, just_read_params)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 


### PR DESCRIPTION
  Recast the depth units in the ice_shelf code from m to Z and changed the units
of several shared ustar fields from m/s to Z/s for greater dimensional
consistency testing.  No answers or parameter_doc files are changed. The list of
commits in this PR include:
- NOAA-GFDL/MOM6@fba65d2 Merge branch 'dev/gfdl' into rescale_ustar
- NOAA-GFDL/MOM6@3e67206 +Changed units of fluxes%ustar_shelf to Z/s
- NOAA-GFDL/MOM6@a4fcbd3 Split excessively long lines
- NOAA-GFDL/MOM6@c8eeaab +Changed units of ustar from m/s to Z/s
- NOAA-GFDL/MOM6@718e1d9 +Recast ice_shelf code to work in units of Z