### PR TITLE
Rescale topography during initialization

### DIFF
--- a/config_src/ice_solo_driver/MOM_surface_forcing.F90
+++ b/config_src/ice_solo_driver/MOM_surface_forcing.F90
@@ -167,15 +167,17 @@ integer :: id_clock_forcing
 
 contains
 
-subroutine set_forcing(sfc_state, forcing, fluxes, day_start, day_interval, G, CS)
+subroutine set_forcing(sfc_state, forcing, fluxes, day_start, day_interval, G, US, CS)
   type(surface),         intent(inout) :: sfc_state !< A structure containing fields that
                                                     !! describe the surface state of the ocean.
   type(mech_forcing),    intent(inout) :: forces !< A structure with the driving mechanical forces
-  type(forcing),         intent(inout) :: fluxes
-  type(time_type),       intent(in)    :: day_start
-  type(time_type),       intent(in)    :: day_interval
+  type(forcing),         intent(inout) :: fluxes !< A structure containing thermodynamic forcing fields
+  type(time_type),       intent(in)    :: day_start !< The start time of the fluxes
+  type(time_type),       intent(in)    :: day_interval !< Length of time over which these fluxes applied
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure
-  type(surface_forcing_CS), pointer    :: CS
+  type(unit_scale_type), intent(in)    :: US   !< A dimensional unit scaling type
+  type(surface_forcing_CS), pointer    :: CS   !< pointer to control struct returned by
+                                               !! a previous surface_forcing_init call
 
 ! This subroutine calls other subroutines in this file to get surface forcing fields.
 ! It also allocates and initializes the fields in the flux type.
@@ -282,7 +284,7 @@ subroutine set_forcing(sfc_state, forcing, fluxes, day_start, day_interval, G, C
   ! Fields that exist in both the forcing and mech_forcing types must be copied.
   if (CS%variable_winds .or. CS%first_call_set_forcing) then
     call copy_common_forcing_fields(forces, fluxes, G)
-    call set_derived_forcing_fields(forces, fluxes, G, CS%Rho0)
+    call set_derived_forcing_fields(forces, fluxes, G, US, CS%Rho0)
   endif
 
   if ((CS%variable_buoyforce .or. CS%first_call_set_forcing) .and. &

--- a/config_src/mct_driver/MOM_ocean_model.F90
+++ b/config_src/mct_driver/MOM_ocean_model.F90
@@ -542,7 +542,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
 #endif
   endif
 
-  call set_derived_forcing_fields(OS%forces, OS%fluxes, OS%grid, OS%GV%Rho0)
+  call set_derived_forcing_fields(OS%forces, OS%fluxes, OS%grid, OS%US, OS%GV%Rho0)
   call set_net_mass_forcing(OS%fluxes, OS%forces, OS%grid)
 
   if (OS%nstep==0) then

--- a/config_src/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/solo_driver/MOM_surface_forcing.F90
@@ -340,7 +340,7 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
   ! Fields that exist in both the forcing and mech_forcing types must be copied.
   if (CS%variable_winds .or. CS%first_call_set_forcing) then
     call copy_common_forcing_fields(forces, fluxes, G)
-    call set_derived_forcing_fields(forces, fluxes, G, CS%Rho0)
+    call set_derived_forcing_fields(forces, fluxes, G, US, CS%Rho0)
   endif
 
   if ((CS%variable_buoyforce .or. CS%first_call_set_forcing) .and. &

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2256,7 +2256,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   diag => CS%diag
   ! Initialize the diag mediator.
-  call diag_mediator_init(G, GV, GV%ke, param_file, diag, doc_file_dir=dirs%output_directory)
+  call diag_mediator_init(G, GV, US, GV%ke, param_file, diag, doc_file_dir=dirs%output_directory)
   if (present(diag_ptr)) diag_ptr => CS%diag
 
   ! Initialize the diagnostics masks for native arrays.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2452,7 +2452,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   CS%nstep_tot = 0
   if (present(count_calls)) CS%count_calls = count_calls
-  call MOM_sum_output_init(G, param_file, dirs%output_directory, &
+  call MOM_sum_output_init(G, US, param_file, dirs%output_directory, &
                            CS%ntrunc, Time_init, CS%sum_output_CSp)
 
   ! Flag whether to save initial conditions in finish_MOM_initialization() or not.

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -132,7 +132,6 @@ type, public :: ocean_grid_type
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
     bathyT        !< Ocean bottom depth at tracer points, in depth units.
-  real :: Zd_to_m  = 1.0 !< The conversion factor between the units of bathyT and m.
 
   logical :: bathymetry_at_vel  !< If true, there are separate values for the
                   !! basin depths at velocity points.  Otherwise the effects of
@@ -165,7 +164,7 @@ type, public :: ocean_grid_type
   real :: len_lat = 0.  !< The latitudinal (or y-coord) extent of physical domain
   real :: len_lon = 0.  !< The longitudinal (or x-coord) extent of physical domain
   real :: Rad_Earth = 6.378e6 !< The radius of the planet in meters.
-  real :: max_depth     !< The maximum depth of the ocean in depth units (scaled by Zd_to_m).
+  real :: max_depth     !< The maximum depth of the ocean in depth units (Z).
 end type ocean_grid_type
 
 contains
@@ -359,13 +358,13 @@ subroutine rescale_grid_bathymetry(G, m_in_new_units)
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
-  if (m_in_new_units == G%Zd_to_m) return
+  if (m_in_new_units == 1.0) return
   if (m_in_new_units < 0.0) &
     call MOM_error(FATAL, "rescale_grid_bathymetry: Negative depth units are not permitted.")
   if (m_in_new_units == 0.0) &
     call MOM_error(FATAL, "rescale_grid_bathymetry: Zero depth units are not permitted.")
 
-  rescale = G%Zd_to_m / m_in_new_units
+  rescale = 1.0 / m_in_new_units
   do j=jsd,jed ; do i=isd,ied
     G%bathyT(i,j) = rescale*G%bathyT(i,j)
   enddo ; enddo
@@ -376,7 +375,6 @@ subroutine rescale_grid_bathymetry(G, m_in_new_units)
     G%Dblock_v(i,J) = rescale*G%Dblock_v(i,J) ; G%Dopen_v(i,J) = rescale*G%Dopen_v(i,J)
   enddo ; enddo ; endif
   G%max_depth = rescale*G%max_depth
-  G%Zd_to_m = m_in_new_units
 
 end subroutine rescale_grid_bathymetry
 

--- a/src/core/MOM_transcribe_grid.F90
+++ b/src/core/MOM_transcribe_grid.F90
@@ -44,7 +44,6 @@ subroutine copy_dyngrid_to_MOM_grid(dG, oG)
   if ((isd > oG%isc) .or. (ied < oG%ied) .or. (jsd > oG%jsc) .or. (jed > oG%jed)) &
     call MOM_error(FATAL, "copy_dyngrid_to_MOM_grid called with incompatible grids.")
 
-  oG%Zd_to_m = dG%Zd_to_m
   do i=isd,ied ; do j=jsd,jed
     oG%geoLonT(i,j) = dG%geoLonT(i+ido,j+jdo)
     oG%geoLatT(i,j) = dG%geoLatT(i+ido,j+jdo)
@@ -188,7 +187,6 @@ subroutine copy_MOM_grid_to_dyngrid(oG, dG)
   if ((isd > dG%isc) .or. (ied < dG%ied) .or. (jsd > dG%jsc) .or. (jed > dG%jed)) &
     call MOM_error(FATAL, "copy_dyngrid_to_MOM_grid called with incompatible grids.")
 
-  dG%Zd_to_m = oG%Zd_to_m
   do i=isd,ied ; do j=jsd,jed
     dG%geoLonT(i,j) = oG%geoLonT(i+ido,j+jdo)
     dG%geoLatT(i,j) = oG%geoLatT(i+ido,j+jdo)

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -15,7 +15,7 @@ use MOM_io,               only : slasher, vardesc, query_vardesc, mom_read_data
 use MOM_safe_alloc,       only : safe_alloc_ptr, safe_alloc_alloc
 use MOM_string_functions, only : lowercase
 use MOM_time_manager,     only : time_type
-use MOM_unit_scaling,       only : unit_scale_type
+use MOM_unit_scaling,     only : unit_scale_type
 use MOM_verticalGrid,     only : verticalGrid_type
 use MOM_EOS,              only : EOS_type
 use MOM_diag_remap,       only : diag_remap_ctrl
@@ -223,6 +223,7 @@ type, public :: diag_ctrl
   type(EOS_type),  pointer :: eqn_of_state => null() !< The equation of state type
   type(ocean_grid_type), pointer :: G => null()  !< The ocean grid type
   type(verticalGrid_type), pointer :: GV => null()  !< The model's vertical ocean grid
+  type(unit_scale_type), pointer :: US => null() !< A dimensional unit scaling type
 
   !> The volume cell measure (special diagnostic) manager id
   integer :: volume_cell_measure_dm_id = -1
@@ -2177,9 +2178,10 @@ end subroutine diag_mediator_infrastructure_init
 
 !> diag_mediator_init initializes the MOM diag_mediator and opens the available
 !! diagnostics file, if appropriate.
-subroutine diag_mediator_init(G, GV, nz, param_file, diag_cs, doc_file_dir)
+subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
   type(ocean_grid_type), target, intent(inout) :: G  !< The ocean grid type.
   type(verticalGrid_type), target, intent(in)  :: GV !< The ocean vertical grid structure
+  type(unit_scale_type),   target, intent(in)  :: US !< A dimensional unit scaling type
   integer,                    intent(in)    :: nz    !< The number of layers in the model's native grid.
   type(param_file_type),      intent(in)    :: param_file !< Parameter file structure
   type(diag_ctrl),            intent(inout) :: diag_cs !< A pointer to a type with many variables
@@ -2251,6 +2253,7 @@ subroutine diag_mediator_init(G, GV, nz, param_file, diag_cs, doc_file_dir)
   ! Keep pointers grid, h, T, S needed diagnostic remapping
   diag_cs%G => G
   diag_cs%GV => GV
+  diag_cs%US => US
   diag_cs%h => null()
   diag_cs%T => null()
   diag_cs%S => null()
@@ -2404,7 +2407,7 @@ subroutine diag_update_remap_grids(diag_cs, alt_h, alt_T, alt_S)
 
   do i=1, diag_cs%num_diag_coords
     call diag_remap_update(diag_cs%diag_remap_cs(i), &
-                           diag_cs%G, diag_cs%GV, h_diag, T_diag, S_diag, &
+                           diag_cs%G, diag_cs%GV, diag_cs%US, h_diag, T_diag, S_diag, &
                            diag_cs%eqn_of_state)
   enddo
 

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -225,10 +225,11 @@ end function
 !! height or layer thicknesses changes. In the case of density-based
 !! coordinates then technically we should also regenerate the
 !! target grid whenever T/S change.
-subroutine diag_remap_update(remap_cs, G, GV, h, T, S, eqn_of_state)
+subroutine diag_remap_update(remap_cs, G, GV, US, h, T, S, eqn_of_state)
   type(diag_remap_ctrl), intent(inout) :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),    pointer    :: G  !< The ocean's grid type
   type(verticalGrid_type),  intent(in) :: GV !< ocean vertical grid structure
+  type(unit_scale_type),    intent(in) :: US !< A dimensional unit scaling type
   real, dimension(:, :, :), intent(in) :: h  !< New thickness
   real, dimension(:, :, :), intent(in) :: T  !< New T
   real, dimension(:, :, :), intent(in) :: S  !< New S
@@ -278,15 +279,15 @@ subroutine diag_remap_update(remap_cs, G, GV, h, T, S, eqn_of_state)
                               GV%Z_to_H*G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
     elseif (remap_cs%vertical_coord == coordinateMode('RHO')) then
       call build_rho_column(get_rho_CS(remap_cs%regrid_cs), G%ke, &
-                            G%Zd_to_m*G%bathyT(i,j), h(i,j,:), T(i,j,:), S(i,j,:), &
+                            US%Z_to_m*G%bathyT(i,j), h(i,j,:), T(i,j,:), S(i,j,:), &
                             eqn_of_state, zInterfaces, h_neglect, h_neglect_edge)
     elseif (remap_cs%vertical_coord == coordinateMode('SLIGHT')) then
 !     call build_slight_column(remap_cs%regrid_cs,remap_cs%remap_cs, nz, &
-!                           G%Zd_to_m*G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
+!                           US%Z_to_m*G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
       call MOM_error(FATAL,"diag_remap_update: SLIGHT coordinate not coded for diagnostics yet!")
     elseif (remap_cs%vertical_coord == coordinateMode('HYCOM1')) then
 !     call build_hycom1_column(remap_cs%regrid_cs, nz, &
-!                           G%Zd_to_m*G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
+!                           US%Z_to_m*G%bathyT(i,j), sum(h(i,j,:)), zInterfaces)
       call MOM_error(FATAL,"diag_remap_update: HYCOM1 coordinate not coded for diagnostics yet!")
     endif
     remap_cs%h(i,j,:) = zInterfaces(1:nz) - zInterfaces(2:nz+1)

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -132,17 +132,16 @@ type, public :: dyn_horgrid_type
 
   real, allocatable, dimension(:,:) :: &
     bathyT        !< Ocean bottom depth at tracer points, in depth units.
-  real :: Zd_to_m  = 1.0 !< The conversion factor between the units of bathyT and m.
 
   logical :: bathymetry_at_vel  !< If true, there are separate values for the
                   !! basin depths at velocity points.  Otherwise the effects of
                   !! of topography are entirely determined from thickness points.
   real, allocatable, dimension(:,:) :: &
-    Dblock_u, &   !< Topographic depths at u-points at which the flow is blocked, in depth units.
-    Dopen_u       !< Topographic depths at u-points at which the flow is open at width dy_Cu, in depth units.
+    Dblock_u, &   !< Topographic depths at u-points at which the flow is blocked, in Z.
+    Dopen_u       !< Topographic depths at u-points at which the flow is open at width dy_Cu, in Z.
   real, allocatable, dimension(:,:) :: &
-    Dblock_v, &   !< Topographic depths at v-points at which the flow is blocked, in depth units.
-    Dopen_v       !< Topographic depths at v-points at which the flow is open at width dx_Cv, in depth units.
+    Dblock_v, &   !< Topographic depths at v-points at which the flow is blocked, in Z.
+    Dopen_v       !< Topographic depths at v-points at which the flow is open at width dx_Cv, in Z.
   real, allocatable, dimension(:,:) :: &
     CoriolisBu    !< The Coriolis parameter at corner points, in s-1.
   real, allocatable, dimension(:,:) :: &
@@ -160,7 +159,7 @@ type, public :: dyn_horgrid_type
   real :: len_lat = 0.  !< The latitudinal (or y-coord) extent of physical domain
   real :: len_lon = 0.  !< The longitudinal (or x-coord) extent of physical domain
   real :: Rad_Earth = 6.378e6 !< The radius of the planet in meters.
-  real :: max_depth     !< The maximum depth of the ocean in depth units (scaled by Zd_to_m).
+  real :: max_depth     !< The maximum depth of the ocean in Z.
 end type dyn_horgrid_type
 
 contains
@@ -287,13 +286,13 @@ subroutine rescale_dyn_horgrid_bathymetry(G, m_in_new_units)
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
-  if (m_in_new_units == G%Zd_to_m) return
+  if (m_in_new_units == 1.0) return
   if (m_in_new_units < 0.0) &
     call MOM_error(FATAL, "rescale_grid_bathymetry: Negative depth units are not permitted.")
   if (m_in_new_units == 0.0) &
     call MOM_error(FATAL, "rescale_grid_bathymetry: Zero depth units are not permitted.")
 
-  rescale = G%Zd_to_m / m_in_new_units
+  rescale = 1.0 / m_in_new_units
   do j=jsd,jed ; do i=isd,ied
     G%bathyT(i,j) = rescale*G%bathyT(i,j)
   enddo ; enddo
@@ -304,7 +303,6 @@ subroutine rescale_dyn_horgrid_bathymetry(G, m_in_new_units)
     G%Dblock_v(i,J) = rescale*G%Dblock_v(i,J) ; G%Dopen_v(i,J) = rescale*G%Dopen_v(i,J)
   enddo ; enddo ; endif
   G%max_depth = rescale*G%max_depth
-  G%Zd_to_m = m_in_new_units
 
 end subroutine rescale_dyn_horgrid_bathymetry
 

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1385,7 +1385,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
 
   ! Set up the bottom depth, G%D either analytically or from file
   call MOM_initialize_topography(dG%bathyT, G%max_depth, dG, param_file)
-  if (dG%Zd_to_m /= US%Z_to_m) call rescale_dyn_horgrid_bathymetry(dG, US%Z_to_m)
+  call rescale_dyn_horgrid_bathymetry(dG, US%Z_to_m)
 
   ! Set up the Coriolis parameter, G%f, usually analytically.
   call MOM_initialize_rotation(dG%CoriolisBu, dG, param_file)

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -6,7 +6,7 @@ module MOM_fixed_initialization
 
 use MOM_debugging, only : hchksum, qchksum, uvchksum
 use MOM_domains, only : pass_var
-use MOM_dyn_horgrid, only : dyn_horgrid_type
+use MOM_dyn_horgrid, only : dyn_horgrid_type, rescale_dyn_horgrid_bathymetry
 use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser, only : get_param, read_param, log_param, param_file_type
@@ -25,6 +25,7 @@ use MOM_shared_initialization, only : set_rotation_planetary, set_rotation_beta_
 use MOM_shared_initialization, only : reset_face_lengths_named, reset_face_lengths_file, reset_face_lengths_list
 use MOM_shared_initialization, only : read_face_length_list, set_velocity_depth_max, set_velocity_depth_min
 use MOM_shared_initialization, only : compute_global_grid_integrals, write_ocean_geometry_file
+use MOM_unit_scaling, only : unit_scale_type
 
 use user_initialization, only : user_initialize_topography
 use DOME_initialization, only : DOME_initialize_topography
@@ -51,8 +52,9 @@ contains
 ! -----------------------------------------------------------------------------
 !> MOM_initialize_fixed sets up time-invariant quantities related to MOM6's
 !!   horizontal grid, bathymetry, and the Coriolis parameter.
-subroutine MOM_initialize_fixed(G, OBC, PF, write_geom, output_dir)
+subroutine MOM_initialize_fixed(G, US, OBC, PF, write_geom, output_dir)
   type(dyn_horgrid_type),  intent(inout) :: G    !< The ocean's grid structure.
+  type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   type(ocean_OBC_type),    pointer       :: OBC  !< Open boundary structure.
   type(param_file_type),   intent(in)    :: PF   !< A structure indicating the open file
                                                  !! to parse for model parameter values.
@@ -75,19 +77,20 @@ subroutine MOM_initialize_fixed(G, OBC, PF, write_geom, output_dir)
          "The directory in which input files are found.", default=".")
   inputdir = slasher(inputdir)
 
-! Set up the parameters of the physical domain (i.e. the grid), G
+  ! Set up the parameters of the physical domain (i.e. the grid), G
   call set_grid_metrics(G, PF)
 
-! Set up the bottom depth, G%bathyT either analytically or from file
-! This also sets G%max_depth based on the input parameter MAXIMUM_DEPTH,
-! or, if absent, is diagnosed as G%max_depth = max( G%D(:,:) )
+  ! Set up the bottom depth, G%bathyT either analytically or from file
+  ! This also sets G%max_depth based on the input parameter MAXIMUM_DEPTH,
+  ! or, if absent, is diagnosed as G%max_depth = max( G%D(:,:) )
   call MOM_initialize_topography(G%bathyT, G%max_depth, G, PF)
+  if (G%Zd_to_m /= US%Z_to_m) call rescale_dyn_horgrid_bathymetry(G, US%Z_to_m)
 
   ! To initialize masks, the bathymetry in halo regions must be filled in
   call pass_var(G%bathyT, G%Domain)
 
-! Determine the position of any open boundaries
-  call open_boundary_config(G, PF, OBC)
+  ! Determine the position of any open boundaries
+  call open_boundary_config(G, US, PF, OBC)
 
   ! Make bathymetry consistent with open boundaries
   call open_boundary_impose_normal_slope(OBC, G, G%bathyT)
@@ -99,14 +102,14 @@ subroutine MOM_initialize_fixed(G, OBC, PF, write_geom, output_dir)
   call open_boundary_impose_land_mask(OBC, G, G%areaCu, G%areaCv)
 
   if (debug) then
-    call hchksum(G%bathyT, 'MOM_initialize_fixed: depth ', G%HI, haloshift=1)
+    call hchksum(G%bathyT, 'MOM_initialize_fixed: depth ', G%HI, haloshift=1, scale=US%Z_to_m)
     call hchksum(G%mask2dT, 'MOM_initialize_fixed: mask2dT ', G%HI)
     call uvchksum('MOM_initialize_fixed: mask2dC[uv]', G%mask2dCu, &
                   G%mask2dCv, G%HI)
     call qchksum(G%mask2dBu, 'MOM_initialize_fixed: mask2dBu ', G%HI)
   endif
 
-! Modulate geometric scales according to geography.
+  ! Modulate geometric scales according to geography.
   call get_param(PF, mdl, "CHANNEL_CONFIG", config, &
                  "A parameter that determines which set of channels are \n"//&
                  "restricted to specific  widths.  Options are:\n"//&
@@ -128,7 +131,7 @@ subroutine MOM_initialize_fixed(G, OBC, PF, write_geom, output_dir)
       "Unrecognized channel configuration "//trim(config))
   end select
 
-!   This call sets the topography at velocity points.
+  !   This call sets the topography at velocity points.
   if (G%bathymetry_at_vel) then
     call get_param(PF, mdl, "VELOCITY_DEPTH_CONFIG", config, &
                    "A string that determines how the topography is set at \n"//&

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -84,7 +84,7 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF, write_geom, output_dir)
   ! This also sets G%max_depth based on the input parameter MAXIMUM_DEPTH,
   ! or, if absent, is diagnosed as G%max_depth = max( G%D(:,:) )
   call MOM_initialize_topography(G%bathyT, G%max_depth, G, PF)
-  if (G%Zd_to_m /= US%Z_to_m) call rescale_dyn_horgrid_bathymetry(G, US%Z_to_m)
+  call rescale_dyn_horgrid_bathymetry(G, US%Z_to_m)
 
   ! To initialize masks, the bathymetry in halo regions must be filled in
   call pass_var(G%bathyT, G%Domain)
@@ -96,7 +96,7 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF, write_geom, output_dir)
   call open_boundary_impose_normal_slope(OBC, G, G%bathyT)
 
   ! This call sets masks that prohibit flow over any point interpreted as land
-  call initialize_masks(G, PF)
+  call initialize_masks(G, PF, US)
 
   ! Make OBC mask consistent with land mask
   call open_boundary_impose_land_mask(OBC, G, G%areaCu, G%areaCv)
@@ -162,7 +162,7 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF, write_geom, output_dir)
   call compute_global_grid_integrals(G)
 
 ! Write out all of the grid data used by this run.
-  if (write_geom) call write_ocean_geometry_file(G, PF, output_dir)
+  if (write_geom) call write_ocean_geometry_file(G, PF, output_dir, US=US)
 
   call callTree_leave('MOM_initialize_fixed()')
 

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -16,6 +16,7 @@ use MOM_error_handler, only : callTree_enter, callTree_leave
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_io, only : MOM_read_data, read_data, slasher, file_exists
 use MOM_io, only : CORNER, NORTH_FACE, EAST_FACE
+use MOM_unit_scaling, only : unit_scale_type
 
 use mpp_domains_mod, only : mpp_get_domain_extents, mpp_deallocate_domain
 
@@ -1214,26 +1215,30 @@ end function Adcroft_reciprocal
 !! are 0.0 at any points adjacent to a land point.  mask2dBu is 0.0 at
 !! any land or boundary point.  For points in the interior, mask2dCu,
 !! mask2dCv, and mask2dBu are all 1.0.
-subroutine initialize_masks(G, PF)
-  type(dyn_horgrid_type), intent(inout) :: G   !< The dynamic horizontal grid type
-  type(param_file_type), intent(in)     :: PF  !< Parameter file structure
+subroutine initialize_masks(G, PF, US)
+  type(dyn_horgrid_type),       intent(inout) :: G  !< The dynamic horizontal grid type
+  type(param_file_type),        intent(in)    :: PF !< Parameter file structure
+  type(unit_scale_type), optional, intent(in) :: US !< A dimensional unit scaling type
   ! Local variables
-  real :: Dmin ! The depth for masking in the same units as G%bathyT (Z).
-  real :: min_depth, mask_depth ! Depths in the same units as G%bathyT (Z).
+  real :: m_to_Z_scale ! A unit conversion factor from m to Z.
+  real :: Dmin       ! The depth for masking in the same units as G%bathyT (Z).
+  real :: min_depth  ! The minimum ocean depth in the same units as G%bathyT (Z).
+  real :: mask_depth ! The depth shallower than which to mask a point as land, in Z.
   character(len=40)  :: mdl = "MOM_grid_init initialize_masks"
   integer :: i, j
 
   call callTree_enter("initialize_masks(), MOM_grid_initialize.F90")
+  m_to_Z_scale = 1.0 ; if (present(US)) m_to_Z_scale = US%m_to_Z
   call get_param(PF, mdl, "MINIMUM_DEPTH", min_depth, &
                  "If MASKING_DEPTH is unspecified, then anything shallower than\n"//&
                  "MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.\n"//&
                  "If MASKING_DEPTH is specified, then all depths shallower than\n"//&
                  "MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.", &
-                 units="m", default=0.0, scale=1.0/G%Zd_to_m)
+                 units="m", default=0.0, scale=m_to_Z_scale)
   call get_param(PF, mdl, "MASKING_DEPTH", mask_depth, &
                  "The depth below which to mask points as land points, for which all\n"//&
                  "fluxes are zeroed out. MASKING_DEPTH is ignored if negative.", &
-                 units="m", default=-9999.0, scale=1.0/G%Zd_to_m)
+                 units="m", default=-9999.0, scale=m_to_Z_scale)
 
   Dmin = min_depth
   if (mask_depth>=0.) Dmin = mask_depth

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -54,9 +54,10 @@ contains
 !> set_grid_metrics is used to set the primary values in the model's horizontal
 !! grid.  The bathymetry, land-sea mask and any restricted channel widths are
 !! not known yet, so these are set later.
-subroutine set_grid_metrics(G, param_file)
-  type(dyn_horgrid_type), intent(inout) :: G          !< The dynamic horizontal grid type
-  type(param_file_type), intent(in)    :: param_file  !< Parameter file structure
+subroutine set_grid_metrics(G, param_file, US)
+  type(dyn_horgrid_type),          intent(inout) :: G  !< The dynamic horizontal grid type
+  type(param_file_type),           intent(in)    :: param_file !< Parameter file structure
+  type(unit_scale_type), optional, intent(in)    :: US !< A dimensional unit scaling type
   ! Local variables
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -1216,9 +1217,9 @@ end function Adcroft_reciprocal
 !! any land or boundary point.  For points in the interior, mask2dCu,
 !! mask2dCv, and mask2dBu are all 1.0.
 subroutine initialize_masks(G, PF, US)
-  type(dyn_horgrid_type),       intent(inout) :: G  !< The dynamic horizontal grid type
-  type(param_file_type),        intent(in)    :: PF !< Parameter file structure
-  type(unit_scale_type), optional, intent(in) :: US !< A dimensional unit scaling type
+  type(dyn_horgrid_type),          intent(inout) :: G  !< The dynamic horizontal grid type
+  type(param_file_type),           intent(in)    :: PF !< Parameter file structure
+  type(unit_scale_type), optional, intent(in)    :: US !< A dimensional unit scaling type
   ! Local variables
   real :: m_to_Z_scale ! A unit conversion factor from m to Z.
   real :: Dmin       ! The depth for masking in the same units as G%bathyT (Z).

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -49,10 +49,11 @@ end subroutine MOM_shared_init_init
 ! -----------------------------------------------------------------------------
 
 !> MOM_initialize_rotation makes the appropriate call to set up the Coriolis parameter.
-subroutine MOM_initialize_rotation(f, G, PF)
+subroutine MOM_initialize_rotation(f, G, PF, US)
   type(dyn_horgrid_type),                       intent(in)  :: G  !< The dynamic horizontal grid type
   real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB), intent(out) :: f  !< The Coriolis parameter in s-1
   type(param_file_type),                        intent(in)  :: PF !< Parameter file structure
+  type(unit_scale_type),              optional, intent(in)  :: US !< A dimensional unit scaling type
 
 !   This subroutine makes the appropriate call to set up the Coriolis parameter.
 ! This is a separate subroutine so that it can be made public and shared with
@@ -81,12 +82,13 @@ subroutine MOM_initialize_rotation(f, G, PF)
 end subroutine MOM_initialize_rotation
 
 !> Calculates the components of grad f (Coriolis parameter)
-subroutine MOM_calculate_grad_Coriolis(dF_dx, dF_dy, G)
+subroutine MOM_calculate_grad_Coriolis(dF_dx, dF_dy, G, US)
   type(dyn_horgrid_type),             intent(inout) :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
                                       intent(out)   :: dF_dx !< x-component of grad f
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
                                       intent(out)   :: dF_dy !< y-component of grad f
+  type(unit_scale_type),    optional, intent(in)    :: US !< A dimensional unit scaling type
   ! Local variables
   integer :: i,j
   real :: f1, f2
@@ -109,36 +111,38 @@ subroutine MOM_calculate_grad_Coriolis(dF_dx, dF_dy, G)
   call pass_vector(dF_dx, dF_dy, G%Domain, stagger=AGRID)
 end subroutine MOM_calculate_grad_Coriolis
 
-!> Return the global maximum ocean bottom depth in m.
-function diagnoseMaximumDepth(D,G)
+!> Return the global maximum ocean bottom depth in the same units as the input depth.
+function diagnoseMaximumDepth(D, G)
   type(dyn_horgrid_type),  intent(in) :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                           intent(in) :: D !< Ocean bottom depth in m
-  real :: diagnoseMaximumDepth             !< The global maximum ocean bottom depth in m
+                           intent(in) :: D !< Ocean bottom depth in m or Z
+  real :: diagnoseMaximumDepth             !< The global maximum ocean bottom depth in m or Z
   ! Local variables
   integer :: i,j
-  diagnoseMaximumDepth=D(G%isc,G%jsc)
-  do j=G%jsc, G%jec
-    do i=G%isc, G%iec
-      diagnoseMaximumDepth=max(diagnoseMaximumDepth,D(i,j))
-    enddo
-  enddo
+  diagnoseMaximumDepth = D(G%isc,G%jsc)
+  do j=G%jsc, G%jec ; do i=G%isc, G%iec
+    diagnoseMaximumDepth = max(diagnoseMaximumDepth,D(i,j))
+  enddo ; enddo
   call max_across_PEs(diagnoseMaximumDepth)
 end function diagnoseMaximumDepth
 
 
 !> Read gridded depths from file
-subroutine initialize_topography_from_file(D, G, param_file)
+subroutine initialize_topography_from_file(D, G, param_file, US)
   type(dyn_horgrid_type),           intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                    intent(out) :: D !< Ocean bottom depth in m
+                                    intent(out) :: D !< Ocean bottom depth in m or Z if US is present
   type(param_file_type),            intent(in)  :: param_file !< Parameter file structure
+  type(unit_scale_type),  optional, intent(in)  :: US !< A dimensional unit scaling type
   ! Local variables
+  real :: m_to_Z  ! A dimensional rescaling factor.
   character(len=200) :: filename, topo_file, inputdir ! Strings for file/path
   character(len=200) :: topo_varname                  ! Variable name in file
   character(len=40)  :: mdl = "initialize_topography_from_file" ! This subroutine's name.
 
   call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
+
+  m_to_Z = 1.0 ; if (present(US)) m_to_Z = US%m_to_Z
 
   call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
@@ -155,28 +159,29 @@ subroutine initialize_topography_from_file(D, G, param_file)
   if (.not.file_exists(filename, G%Domain)) call MOM_error(FATAL, &
        " initialize_topography_from_file: Unable to open "//trim(filename))
 
-  D(:,:) = -9.E30 ! Initializing to a very large negative depth (tall mountains)
-                  ! everywhere before reading from a file should do nothing.
-                  ! However, in the instance of masked-out PEs, halo regions
-                  ! are not updated when a processor does not exist. We need to
-                  ! ensure the depth in masked-out PEs appears to be that of land
-                  ! so this line does that in the halo regions. For non-masked PEs
-                  ! the halo region is filled properly with a later pass_var().
-  call MOM_read_data(filename, trim(topo_varname), D, G%Domain)
+  D(:,:) = -9.e30*m_to_Z ! Initializing to a very large negative depth (tall mountains) everywhere
+                         ! before reading from a file should do nothing. However, in the instance of
+                         ! masked-out PEs, halo regions are not updated when a processor does not
+                         ! exist. We need to ensure the depth in masked-out PEs appears to be that
+                         ! of land so this line does that in the halo regions. For non-masked PEs
+                         ! the halo region is filled properly with a later pass_var().
+  call MOM_read_data(filename, trim(topo_varname), D, G%Domain, scale=m_to_Z)
 
-  call apply_topography_edits_from_file(D, G, param_file)
+  call apply_topography_edits_from_file(D, G, param_file, US)
 
   call callTree_leave(trim(mdl)//'()')
 end subroutine initialize_topography_from_file
 
 !> Applies a list of topography overrides read from a netcdf file
-subroutine apply_topography_edits_from_file(D, G, param_file)
+subroutine apply_topography_edits_from_file(D, G, param_file, US)
   type(dyn_horgrid_type),           intent(in)    :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                    intent(inout) :: D !< Ocean bottom depth in m
+                                    intent(inout) :: D !< Ocean bottom depth in m or Z if US is present
   type(param_file_type),            intent(in)    :: param_file !< Parameter file structure
+  type(unit_scale_type),  optional, intent(in)    :: US !< A dimensional unit scaling type
 
   ! Local variables
+  real :: m_to_Z  ! A dimensional rescaling factor.
   character(len=200) :: topo_edits_file, inputdir ! Strings for file/path
   character(len=40)  :: mdl = "apply_topography_edits_from_file" ! This subroutine's name.
   integer :: n_edits, n, ashape(5), i, j, ncid, id, ncstatus, iid, jid, zid
@@ -184,6 +189,8 @@ subroutine apply_topography_edits_from_file(D, G, param_file)
   real, dimension(:), allocatable :: new_depth
 
   call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
+
+  m_to_Z = 1.0 ; if (present(US)) m_to_Z = US%m_to_Z
 
   call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
@@ -267,8 +274,8 @@ subroutine apply_topography_edits_from_file(D, G, param_file)
     if (i>=G%isc .and. i<=G%iec .and. j>=G%jsc .and. j<=G%jec) then
       if (new_depth(n)/=0.) then
         write(*,'(a,3i5,f8.2,a,f8.2,2i4)') &
-          'Ocean topography edit: ',n,ig(n),jg(n),D(i,j),'->',abs(new_depth(n)),i,j
-        D(i,j) = abs(new_depth(n)) ! Allows for height-file edits (i.e. converts negatives)
+          'Ocean topography edit: ',n,ig(n),jg(n),D(i,j)/m_to_Z,'->',abs(new_depth(n)),i,j
+        D(i,j) = abs(m_to_Z*new_depth(n)) ! Allows for height-file edits (i.e. converts negatives)
       else
         call MOM_error(FATAL, ' apply_topography_edits_from_file: '//&
           "A zero depth edit would change the land mask and is not allowed in"//trim(topo_edits_file))
@@ -282,30 +289,25 @@ subroutine apply_topography_edits_from_file(D, G, param_file)
 end subroutine apply_topography_edits_from_file
 
 !> initialize the bathymetry based on one of several named idealized configurations
-subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth)
+subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth, US)
   type(dyn_horgrid_type),           intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                    intent(out) :: D !< Ocean bottom depth in m
+                                    intent(out) :: D !< Ocean bottom depth in m or Z if US is present
   type(param_file_type),            intent(in)  :: param_file !< Parameter file structure
   character(len=*),                 intent(in)  :: topog_config !< The name of an idealized
                                                               !! topographic configuration
-  real,                             intent(in)  :: max_depth  !< Maximum depth of model in m
+  real,                             intent(in)  :: max_depth  !< Maximum depth of model in the units of D
+  type(unit_scale_type),  optional, intent(in)  :: US !< A dimensional unit scaling type
 
-! Arguments: D          - the bottom depth in m. Intent out.
-!  (in)      G          - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      topog_config - The name of an idealized topographic configuration.
-!  (in)      max_depth  - The maximum depth in m.
+  ! This subroutine places the bottom depth in m into D(:,:), shaped according to the named config.
 
-! This subroutine places the bottom depth in m into D(:,:), shaped in a spoon
-  real :: min_depth            ! The minimum depth in m.
+  ! Local variables
+  real :: m_to_Z               ! A dimensional rescaling factor.
+  real :: min_depth            ! The minimum depth in Z.
   real :: PI                   ! 3.1415926... calculated as 4*atan(1)
-  real :: D0                   ! A constant to make the maximum     !
-                               ! basin depth MAXIMUM_DEPTH.         !
-  real :: expdecay             ! A decay scale of associated with   !
-                               ! the sloping boundaries, in m.      !
-  real :: Dedge                ! The depth in m at the basin edge.  !
+  real :: D0                   ! A constant to make the maximum  basin depth MAXIMUM_DEPTH.
+  real :: expdecay             ! A decay scale of associated with the sloping boundaries, in m.
+  real :: Dedge                ! The depth in Z at the basin edge
 ! real :: south_lat, west_lon, len_lon, len_lat, Rad_earth
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
   character(len=40)  :: mdl = "initialize_topography_named" ! This subroutine's name.
@@ -316,15 +318,17 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
   call MOM_mesg("  MOM_shared_initialization.F90, initialize_topography_named: "//&
                  "TOPO_CONFIG = "//trim(topog_config), 5)
 
+  m_to_Z = 1.0 ; if (present(US)) m_to_Z = US%m_to_Z
+
   call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
-                 "The minimum depth of the ocean.", units="m", default=0.0)
+                 "The minimum depth of the ocean.", units="m", default=0.0, scale=m_to_Z)
   if (max_depth<=0.) call MOM_error(FATAL,"initialize_topography_named: "// &
       "MAXIMUM_DEPTH has a non-sensical value! Was it set?")
 
   if (trim(topog_config) /= "flat") then
     call get_param(param_file, mdl, "EDGE_DEPTH", Dedge, &
                    "The depth at the edge of one of the named topographies.", &
-                   units="m", default=100.0)
+                   units="m", default=100.0, scale=m_to_Z)
 !   call get_param(param_file, mdl, "SOUTHLAT", south_lat, &
 !                  "The southern latitude of the domain.", units="degrees", &
 !                  fail_if_missing=.true.)
@@ -398,37 +402,36 @@ end subroutine initialize_topography_named
 
 ! -----------------------------------------------------------------------------
 !> limit_topography ensures that  min_depth < D(x,y) < max_depth
-subroutine limit_topography(D, G, param_file, max_depth)
+subroutine limit_topography(D, G, param_file, max_depth, US)
   type(dyn_horgrid_type), intent(in)    :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                          intent(inout) :: D !< Ocean bottom depth in m
+                          intent(inout) :: D !< Ocean bottom depth in m or Z if US is present
   type(param_file_type),  intent(in)    :: param_file !< Parameter file structure
-  real,                   intent(in)    :: max_depth  !< Maximum depth of model in m
-! Arguments: D          - the bottom depth in m. Intent in/out.
-!  (in)      G          - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      max_depth  - The maximum depth in m.
+  real,                   intent(in)    :: max_depth  !< Maximum depth of model in the units of D
+  type(unit_scale_type), optional, intent(in) :: US   !< A dimensional unit scaling type
 
-! This subroutine ensures that    min_depth < D(x,y) < max_depth
+  ! Local variables
+  real :: m_to_Z  ! A dimensional rescaling factor.
   integer :: i, j
   character(len=40)  :: mdl = "limit_topography" ! This subroutine's name.
   real :: min_depth, mask_depth
 
   call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
+  m_to_Z = 1.0 ; if (present(US)) m_to_Z = US%m_to_Z
+
   call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "If MASKING_DEPTH is unspecified, then anything shallower than\n"//&
                  "MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.\n"//&
                  "If MASKING_DEPTH is specified, then all depths shallower than\n"//&
                  "MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.", &
-                 units="m", default=0.0)
+                 units="m", default=0.0, scale=m_to_Z)
   call get_param(param_file, mdl, "MASKING_DEPTH", mask_depth, &
-                 "The depth below which to mask the ocean as land.", units="m", &
-                 default=-9999.0, do_not_log=.true.)
+                 "The depth below which to mask the ocean as land.", &
+                 units="m", default=-9999.0, scale=m_to_Z, do_not_log=.true.)
 
 ! Make sure that min_depth < D(x,y) < max_depth
-  if (mask_depth<-9990.) then
+  if (mask_depth < -9990.*m_to_Z) then
     do j=G%jsd,G%jed ; do i=G%isd,G%ied
       D(i,j) = min( max( D(i,j), 0.5*min_depth ), max_depth )
     enddo ; enddo
@@ -448,11 +451,12 @@ end subroutine limit_topography
 
 ! -----------------------------------------------------------------------------
 !> This subroutine sets up the Coriolis parameter for a sphere
-subroutine set_rotation_planetary(f, G, param_file)
+subroutine set_rotation_planetary(f, G, param_file, US)
   type(dyn_horgrid_type), intent(in)  :: G  !< The dynamic horizontal grid
   real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB), &
                           intent(out) :: f  !< Coriolis parameter (vertical component) in s^-1
   type(param_file_type),  intent(in)  :: param_file !< A structure to parse for run-time parameters
+  type(unit_scale_type), optional, intent(in) :: US !< A dimensional unit scaling type
 
 ! This subroutine sets up the Coriolis parameter for a sphere
   character(len=30) :: mdl = "set_rotation_planetary" ! This subroutine's name.
@@ -476,11 +480,12 @@ end subroutine set_rotation_planetary
 
 ! -----------------------------------------------------------------------------
 !> This subroutine sets up the Coriolis parameter for a beta-plane or f-plane
-subroutine set_rotation_beta_plane(f, G, param_file)
+subroutine set_rotation_beta_plane(f, G, param_file, US)
   type(dyn_horgrid_type), intent(in)  :: G  !< The dynamic horizontal grid
   real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB), &
                           intent(out) :: f  !< Coriolis parameter (vertical component) in s^-1
   type(param_file_type),  intent(in)  :: param_file !< A structure to parse for run-time parameters
+  type(unit_scale_type), optional, intent(in) :: US !< A dimensional unit scaling type
 
 ! This subroutine sets up the Coriolis parameter for a beta-plane
   integer :: I, J
@@ -594,18 +599,14 @@ end function modulo_around_point
 ! -----------------------------------------------------------------------------
 !>   This subroutine sets the open face lengths at selected points to restrict
 !! passages to their observed widths based on a named set of sizes.
-subroutine reset_face_lengths_named(G, param_file, name)
+subroutine reset_face_lengths_named(G, param_file, name, US)
   type(dyn_horgrid_type), intent(inout) :: G  !< The dynamic horizontal grid
   type(param_file_type),  intent(in)    :: param_file !< A structure to parse for run-time parameters
   character(len=*),       intent(in)    :: name !< The name for the set of face lengths. Only "global_1deg"
                                                 !! is currently implemented.
-!   This subroutine sets the open face lengths at selected points to restrict
-! passages to their observed widths.
+  type(unit_scale_type), optional, intent(in) :: US !< A dimensional unit scaling type
 
-! Arguments: G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
-!  (in)      name - The name for the set of face lengths.
+  ! Local variables
   character(len=256) :: mesg    ! Message for error messages.
   real    :: dx_2 = -1.0, dy_2 = -1.0
   real    :: pi_180
@@ -722,15 +723,12 @@ end subroutine reset_face_lengths_named
 ! -----------------------------------------------------------------------------
 !> This subroutine sets the open face lengths at selected points to restrict
 !! passages to their observed widths from a arrays read from a file.
-subroutine reset_face_lengths_file(G, param_file)
+subroutine reset_face_lengths_file(G, param_file, US)
   type(dyn_horgrid_type), intent(inout) :: G  !< The dynamic horizontal grid
-  type(param_file_type), intent(in)     :: param_file !< A structure to parse for run-time parameters
-!   This subroutine sets the open face lengths at selected points to restrict
-! passages to their observed widths.
+  type(param_file_type),  intent(in)    :: param_file !< A structure to parse for run-time parameters
+  type(unit_scale_type), optional, intent(in) :: US !< A dimensional unit scaling type
 
-! Arguments: G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
+  ! Local variables
   character(len=40)  :: mdl = "reset_face_lengths_file" ! This subroutine's name.
   character(len=256) :: mesg    ! Message for error messages.
   character(len=200) :: filename, chan_file, inputdir ! Strings for file/path
@@ -791,15 +789,12 @@ end subroutine reset_face_lengths_file
 ! -----------------------------------------------------------------------------
 !> This subroutine sets the open face lengths at selected points to restrict
 !! passages to their observed widths from a list read from a file.
-subroutine reset_face_lengths_list(G, param_file)
+subroutine reset_face_lengths_list(G, param_file, US)
   type(dyn_horgrid_type), intent(inout) :: G  !< The dynamic horizontal grid
   type(param_file_type),  intent(in)    :: param_file !< A structure to parse for run-time parameters
-!   This subroutine sets the open face lengths at selected points to restrict
-! passages to their observed widths.
+  type(unit_scale_type), optional, intent(in)  :: US !< A dimensional unit scaling type
 
-! Arguments: G - The ocean's grid structure.
-!  (in)      param_file - A structure indicating the open file to parse for
-!                         model parameter values.
+  ! Local variables
   character(len=120), pointer, dimension(:) :: lines => NULL()
   character(len=120) :: line
   character(len=200) :: filename, chan_file, inputdir, mesg ! Strings for file/path
@@ -1121,8 +1116,8 @@ end subroutine set_velocity_depth_min
 !! later use in reporting diagnostics
 subroutine compute_global_grid_integrals(G)
   type(dyn_horgrid_type), intent(inout) :: G  !< The dynamic horizontal grid
-  ! Subroutine to pre-compute global integrals of grid quantities for
-  ! later use in reporting diagnostics
+
+  ! Local variables
   real, dimension(G%isc:G%iec, G%jsc:G%jec) :: tmpForSumming
   integer :: i,j
 
@@ -1282,10 +1277,14 @@ subroutine write_ocean_geometry_file(G, param_file, directory, geom_file, US)
   call write_field(unit, fields(19), G%Domain%mpp_domain, G%mask2dT)
 
   if (G%bathymetry_at_vel) then
-    call write_field(unit, fields(20), G%Domain%mpp_domain, G%Dblock_u)
-    call write_field(unit, fields(21), G%Domain%mpp_domain, G%Dopen_u)
-    call write_field(unit, fields(22), G%Domain%mpp_domain, G%Dblock_v)
-    call write_field(unit, fields(23), G%Domain%mpp_domain, G%Dopen_v)
+    do j=js,je ; do I=Isq,Ieq ; out_u(I,j) = Z_to_m_scale*G%Dblock_u(I,j) ; enddo ; enddo
+    call write_field(unit, fields(20), G%Domain%mpp_domain, out_u)
+    do j=js,je ; do I=Isq,Ieq ; out_u(I,j) = Z_to_m_scale*G%Dopen_u(I,j) ; enddo ; enddo
+    call write_field(unit, fields(21), G%Domain%mpp_domain, out_u)
+    do J=Jsq,Jeq ; do i=is,ie ; out_v(i,J) = Z_to_m_scale*G%Dblock_v(i,J) ; enddo ; enddo
+    call write_field(unit, fields(22), G%Domain%mpp_domain, out_v)
+    do J=Jsq,Jeq ; do i=is,ie ; out_v(i,J) = Z_to_m_scale*G%Dopen_v(i,J) ; enddo ; enddo
+    call write_field(unit, fields(23), G%Domain%mpp_domain, out_v)
   endif
 
   call close_file(unit)

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -741,13 +741,14 @@ end subroutine set_up_ALE_sponge_vel_field_fixed
 !> This subroutine stores the reference profile at uand v points for the variable
 !! whose address is given by u_ptr and v_ptr.
 subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename_v, fieldname_v, &
-                                               Time, G, CS, u_ptr, v_ptr)
+                                               Time, G, US, CS, u_ptr, v_ptr)
   character(len=*), intent(in)    :: filename_u  !< File name for u field
   character(len=*), intent(in)    :: fieldname_u !< Name of u variable in file
   character(len=*), intent(in)    :: filename_v  !< File name for v field
   character(len=*), intent(in)    :: fieldname_v !< Name of v variable in file
   type(time_type),  intent(in)    :: Time        !< Model time
   type(ocean_grid_type), intent(inout) :: G      !< Ocean grid (in)
+  type(unit_scale_type), intent(in)    :: US     !< A dimensional unit scaling type
   type(ALE_sponge_CS), pointer    :: CS          !< Sponge structure (in/out).
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), target, intent(in) :: u_ptr !< u pointer to the field to be damped (in).
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), target, intent(in) :: v_ptr !< v pointer to the field to be damped (in).
@@ -798,7 +799,7 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename
   ! modulo attribute of the zonal axis (mjh).
 
   call horiz_interp_and_extrap_tracer(CS%Ref_val_u%id,Time, 1.0,G,u_val,mask_u,z_in,z_edges_in,&
-                                     missing_value,.true.,.false.,.false., m_to_Z=1.0/G%Zd_to_m)
+                                     missing_value,.true.,.false.,.false., m_to_Z=US%m_to_Z)
 
 !!! TODO: add a velocity interface! (mjh)
 
@@ -808,7 +809,7 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename
   ! modulo attribute of the zonal axis (mjh).
 
   call horiz_interp_and_extrap_tracer(CS%Ref_val_v%id,Time, 1.0,G,v_val,mask_v,z_in,z_edges_in, &
-                                     missing_value,.true.,.false.,.false., m_to_Z=1.0/G%Zd_to_m)
+                                     missing_value,.true.,.false.,.false., m_to_Z=US%m_to_Z)
 
   ! stores the reference profile
   allocate(CS%Ref_val_u%p(fld_sz(3),CS%num_col_u))

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1072,7 +1072,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, EOS, uStar, buoyF
         endif
         !For now get Langmuir number based on prev. MLD (otherwise must compute 3d LA)
         MLD_GUESS = max( 1.*US%m_to_Z, abs(US%m_to_Z*CS%OBLdepthprev(i,j) ) )
-        call get_Langmuir_Number( LA, G, GV, US, MLD_guess, surfFricVel, I, J, &
+        call get_Langmuir_Number( LA, G, GV, US, MLD_guess, uStar(i,j), i, j, &
              H=H(i,j,:), U_H=U_H, V_H=V_H, WAVES=WAVES)
         WAVES%La_SL(i,j)=LA
       endif

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -3295,7 +3295,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   if (CS%use_int_tides) then
     call int_tide_input_init(Time, G, GV, US, param_file, diag, CS%int_tide_input_CSp, &
                              CS%int_tide_input)
-    call internal_tides_init(Time, G, GV, param_file, diag, CS%int_tide_CSp)
+    call internal_tides_init(Time, G, GV, US, param_file, diag, CS%int_tide_CSp)
   endif
 
   ! initialize module for setting diffusivities

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -352,7 +352,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
   real :: I_dtrho   ! 1.0 / (dt * Rho0) in m3 kg-1 s-1.  This is
                     ! used convert TKE back into ustar^3.
   real :: U_star    ! The surface friction velocity, in Z s-1.
-  real :: U_Star_Mean ! The surface friction without gustiness in m s-1.
+  real :: U_Star_Mean ! The surface friction without gustiness in Z s-1.
   real :: vstar     ! An in-situ turbulent velocity, in m s-1.
   real :: Enhance_M ! An enhancement factor for vstar, based here on Langmuir impact.
   real :: LA        ! The Langmuir number (non-dim)

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -40,6 +40,7 @@ module MOM_generic_tracer
   use MOM_tracer_registry, only : register_tracer, tracer_registry_type
   use MOM_tracer_Z_init, only : tracer_Z_init
   use MOM_tracer_initialization_from_Z, only : MOM_initialize_tracer_from_Z
+  use MOM_unit_scaling, only : unit_scale_type
   use MOM_variables, only : surface, thermo_var_ptrs
   use MOM_open_boundary, only : ocean_OBC_type
   use MOM_verticalGrid, only : verticalGrid_type
@@ -222,13 +223,14 @@ contains
   !!
   !!   This subroutine initializes the NTR tracer fields in tr(:,:,:,:)
   !! and it sets up the tracer output.
-  subroutine initialize_MOM_generic_tracer(restart, day, G, GV, h, param_file, diag, OBC, CS, &
+  subroutine initialize_MOM_generic_tracer(restart, day, G, GV, US, h, param_file, diag, OBC, CS, &
                                           sponge_CSp, ALE_sponge_CSp,diag_to_Z_CSp)
     logical,                               intent(in) :: restart !< .true. if the fields have already been
                                                                  !! read from a restart file.
     type(time_type), target,               intent(in) :: day     !< Time of the start of the run.
     type(ocean_grid_type),                 intent(inout) :: G    !< The ocean's grid structure
     type(verticalGrid_type),               intent(in)    :: GV   !< The ocean's vertical grid structure
+    type(unit_scale_type),                 intent(in)    :: US   !< A dimensional unit scaling type
     real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
     type(param_file_type),                 intent(in) :: param_file !< A structure to parse for run-time parameters
     type(diag_ctrl),               target, intent(in) :: diag    !< Regulates diagnostic output.
@@ -319,9 +321,9 @@ contains
           if (.not.file_exists(CS%IC_file)) call MOM_error(FATAL, &
                   "initialize_MOM_Generic_tracer: Unable to open "//CS%IC_file)
           if (CS%Z_IC_file) then
-            OK = tracer_Z_init(tr_ptr, h, CS%IC_file, g_tracer_name, G)
+            OK = tracer_Z_init(tr_ptr, h, CS%IC_file, g_tracer_name, G, US)
             if (.not.OK) then
-              OK = tracer_Z_init(tr_ptr, h, CS%IC_file, trim(g_tracer_name), G)
+              OK = tracer_Z_init(tr_ptr, h, CS%IC_file, trim(g_tracer_name), G, US)
               if (.not.OK) call MOM_error(FATAL,"initialize_MOM_Generic_tracer: "//&
                       "Unable to read "//trim(g_tracer_name)//" from "//&
                       trim(CS%IC_file)//".")

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -8,6 +8,7 @@ use MOM_error_handler, only : MOM_error, FATAL, WARNING, MOM_mesg, is_root_pe
 ! use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : MOM_read_data
+use MOM_unit_scaling, only : unit_scale_type
 
 use netcdf
 
@@ -21,9 +22,10 @@ contains
 
 !>   This function initializes a tracer by reading a Z-space file, returning
 !! .true. if this appears to have been successful, and false otherwise.
-function tracer_Z_init(tr, h, filename, tr_name, G, missing_val, land_val)
+function tracer_Z_init(tr, h, filename, tr_name, G, US, missing_val, land_val)
   logical :: tracer_Z_init !< A return code indicating if the initialization has been successful
   type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
+  type(unit_scale_type), intent(in)    :: US !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                          intent(out)   :: tr   !< The tracer to initialize
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
@@ -82,7 +84,7 @@ function tracer_Z_init(tr, h, filename, tr_name, G, missing_val, land_val)
   ! Find out the number of input levels and read the depth of the edges,
   ! also modifying their sign convention to be monotonically decreasing.
   call read_Z_edges(filename, tr_name, z_edges, nz_in, has_edges, use_missing, &
-                    missing, scale=1.0/G%Zd_to_m)
+                    missing, scale=US%m_to_Z)
   if (nz_in < 1) then
     tracer_Z_init = .false.
     return

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -317,23 +317,23 @@ subroutine tracer_flow_control_init(restart, day, G, GV, US, h, param_file, diag
     call initialize_ISOMIP_tracer(restart, day, G, GV, h, diag, OBC, CS%ISOMIP_tracer_CSp, &
                                 ALE_sponge_CSp, diag_to_Z_CSp)
   if (CS%use_ideal_age) &
-    call initialize_ideal_age_tracer(restart, day, G, GV, h, diag, OBC, CS%ideal_age_tracer_CSp, &
+    call initialize_ideal_age_tracer(restart, day, G, GV, US, h, diag, OBC, CS%ideal_age_tracer_CSp, &
                                      sponge_CSp, diag_to_Z_CSp)
   if (CS%use_regional_dyes) &
     call initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS%dye_tracer_CSp, &
                                      sponge_CSp, diag_to_Z_CSp)
   if (CS%use_oil) &
-    call initialize_oil_tracer(restart, day, G, GV, h, diag, OBC, CS%oil_tracer_CSp, &
+    call initialize_oil_tracer(restart, day, G, GV, US, h, diag, OBC, CS%oil_tracer_CSp, &
                                      sponge_CSp, diag_to_Z_CSp)
   if (CS%use_advection_test_tracer) &
     call initialize_advection_test_tracer(restart, day, G, GV, h, diag, OBC, CS%advection_test_tracer_CSp, &
                                 sponge_CSp, diag_to_Z_CSp)
   if (CS%use_OCMIP2_CFC) &
-    call initialize_OCMIP2_CFC(restart, day, G, GV, h, diag, OBC, CS%OCMIP2_CFC_CSp, &
+    call initialize_OCMIP2_CFC(restart, day, G, GV, US, h, diag, OBC, CS%OCMIP2_CFC_CSp, &
                                 sponge_CSp, diag_to_Z_CSp)
 #ifdef _USE_GENERIC_TRACER
   if (CS%use_MOM_generic_tracer) &
-    call initialize_MOM_generic_tracer(restart, day, G, GV, h, param_file, diag, OBC, &
+    call initialize_MOM_generic_tracer(restart, day, G, GV, US, h, param_file, diag, OBC, &
         CS%MOM_generic_tracer_CSp, sponge_CSp, ALE_sponge_CSp, diag_to_Z_CSp)
 #endif
   if (CS%use_pseudo_salt_tracer) &

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -18,6 +18,7 @@ use MOM_time_manager, only : time_type, time_type_to_real
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
@@ -193,13 +194,14 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 end function register_ideal_age_tracer
 
 !> Sets the ideal age traces to their initial values and sets up the tracer output
-subroutine initialize_ideal_age_tracer(restart, day, G, GV, h, diag, OBC, CS, &
+subroutine initialize_ideal_age_tracer(restart, day, G, GV, US, h, diag, OBC, CS, &
                                        sponge_CSp, diag_to_Z_CSp)
   logical,                            intent(in) :: restart !< .true. if the fields have already
                                                          !! been read from a restart file.
   type(time_type),            target, intent(in) :: day  !< Time of the start of the run.
   type(ocean_grid_type),              intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type),            intent(in) :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),              intent(in) :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                                       intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   type(diag_ctrl),            target, intent(in) :: diag !< A structure that is used to regulate
@@ -250,10 +252,10 @@ subroutine initialize_ideal_age_tracer(restart, day, G, GV, h, diag, OBC, CS, &
 
         if (CS%Z_IC_file) then
           OK = tracer_Z_init(CS%tr(:,:,:,m), h, CS%IC_file, name,&
-                             G, -1e34, 0.0) ! CS%land_val(m))
+                             G, US, -1e34, 0.0) ! CS%land_val(m))
           if (.not.OK) then
             OK = tracer_Z_init(CS%tr(:,:,:,m), h, CS%IC_file, &
-                     trim(name), G, -1e34, 0.0) ! CS%land_val(m))
+                     trim(name), G, US, -1e34, 0.0) ! CS%land_val(m))
             if (.not.OK) call MOM_error(FATAL,"initialize_ideal_age_tracer: "//&
                     "Unable to read "//trim(name)//" from "//&
                     trim(CS%IC_file)//".")

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -18,8 +18,8 @@ use MOM_time_manager, only : time_type, time_type_to_real
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
-use MOM_variables, only : surface
-use MOM_variables, only : thermo_var_ptrs
+use MOM_unit_scaling, only : unit_scale_type
+use MOM_variables, only : surface, thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 
 use coupler_types_mod, only : coupler_type_set_data, ind_csurf
@@ -201,13 +201,14 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 end function register_oil_tracer
 
 !> Initialize the oil tracers and set up tracer output
-subroutine initialize_oil_tracer(restart, day, G, GV, h, diag, OBC, CS, &
+subroutine initialize_oil_tracer(restart, day, G, GV, US, h, diag, OBC, CS, &
                                   sponge_CSp, diag_to_Z_CSp)
   logical,                            intent(in) :: restart !< .true. if the fields have already
                                                          !! been read from a restart file.
   type(time_type),            target, intent(in) :: day  !< Time of the start of the run.
   type(ocean_grid_type),              intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type),            intent(in) :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),              intent(in) :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                                       intent(in) :: h    !< Layer thicknesses, in H (usually m or kg m-2)
   type(diag_ctrl),            target, intent(in) :: diag !< A structure that is used to regulate
@@ -266,10 +267,10 @@ subroutine initialize_oil_tracer(restart, day, G, GV, h, diag, OBC, CS, &
 
         if (CS%Z_IC_file) then
           OK = tracer_Z_init(CS%tr(:,:,:,m), h, CS%IC_file, name, &
-                             G, -1e34, 0.0) ! CS%land_val(m))
+                             G, US, -1e34, 0.0) ! CS%land_val(m))
           if (.not.OK) then
             OK = tracer_Z_init(CS%tr(:,:,:,m), h, CS%IC_file, &
-                     trim(name), G, -1e34, 0.0) ! CS%land_val(m))
+                     trim(name), G, US, -1e34, 0.0) ! CS%land_val(m))
             if (.not.OK) call MOM_error(FATAL,"initialize_oil_tracer: "//&
                     "Unable to read "//trim(name)//" from "//&
                     trim(CS%IC_file)//".")

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -33,19 +33,19 @@ character(len=40) :: mdl = "DOME2D_initialization" !< This module's name.
 contains
 
 !> Initialize topography with a shelf and slope in a 2D domain
-subroutine DOME2d_initialize_topography ( D, G, param_file, max_depth )
-  ! Arguments
-  type(dyn_horgrid_type), intent(in)  :: G !< The dynamic horizontal grid type
+subroutine DOME2d_initialize_topography( D, G, param_file, max_depth )
+  type(dyn_horgrid_type),  intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                          intent(out) :: D !< Ocean bottom depth in m
-  type(param_file_type),  intent(in)  :: param_file !< Parameter file structure
-  real,                   intent(in)  :: max_depth  !< Maximum depth of model in m
+                           intent(out) :: D !< Ocean bottom depth in the units of depth_max
+  type(param_file_type),   intent(in)  :: param_file !< Parameter file structure
+  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
+
   ! Local variables
   integer :: i, j
   real    :: x, bay_depth, l1, l2
   real    :: dome2d_width_bay, dome2d_width_bottom, dome2d_depth_bay
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
 
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "DOME2D_SHELF_WIDTH", dome2d_width_bay, &

--- a/src/user/Neverland_initialization.F90
+++ b/src/user/Neverland_initialization.F90
@@ -26,18 +26,19 @@ contains
 
 !> This subroutine sets up the Neverland test case topography.
 subroutine Neverland_initialize_topography(D, G, param_file, max_depth)
-  type(dyn_horgrid_type),             intent(in)  :: G !< The dynamic horizontal grid type
+  type(dyn_horgrid_type),  intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                      intent(out) :: D !< Ocean bottom depth in m
-  type(param_file_type),              intent(in)  :: param_file !< Parameter file structure
-  real,                               intent(in)  :: max_depth  !< Maximum depth of model in m
+                           intent(out) :: D !< Ocean bottom depth in the units of depth_max
+  type(param_file_type),   intent(in)  :: param_file !< Parameter file structure
+  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
+
   ! Local variables
   real :: PI                   ! 3.1415926... calculated as 4*atan(1)
   real :: D0                   ! A constant to make the maximum     !
                                ! basin depth MAXIMUM_DEPTH.         !
   real :: x, y
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "Neverland_initialize_topography" ! This subroutine's name.
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
   real :: nl_roughness_amp, nl_top_amp
@@ -55,10 +56,9 @@ subroutine Neverland_initialize_topography(D, G, param_file, max_depth)
   PI = 4.0*atan(1.0)
 
 !  Calculate the depth of the bottom.
-  do i=is,ie
-  do j=js,je
-    x=(G%geoLonT(i,j)-G%west_lon)/G%len_lon
-    y=(G%geoLatT(i,j)-G%south_lat)/G%len_lat
+  do j=js,je ; do i=is,ie
+    x = (G%geoLonT(i,j)-G%west_lon) / G%len_lon
+    y =( G%geoLatT(i,j)-G%south_lat) / G%len_lat
 !  This sets topography that has a reentrant channel to the south.
     D(i,j) = 1.0 - 1.1 * spike(y-1,0.12) - 1.1 * spike(y,0.12) - & !< The great northern wall and Antarctica
               nl_top_amp*( &
@@ -73,8 +73,7 @@ subroutine Neverland_initialize_topography(D, G, param_file, max_depth)
               -  nl_roughness_amp * cos(20*PI*x) * cos(20*PI*y)              !< roughness
     if (D(i,j) < 0.0) D(i,j) = 0.0
     D(i,j) = D(i,j) * max_depth
-  enddo
-  enddo
+  enddo ; enddo
 
 end subroutine Neverland_initialize_topography
 ! -----------------------------------------------------------------------------

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -11,6 +11,7 @@ use MOM_error_handler, only : MOM_error, FATAL
 use MOM_file_parser,   only : get_param, param_file_type
 use MOM_grid,          only : ocean_grid_type
 use MOM_sponge,        only : sponge_CS
+use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type
 
@@ -32,10 +33,12 @@ contains
 
 !> Initialize the topography field for the dense water experiment
 subroutine dense_water_initialize_topography(D, G, param_file, max_depth)
-  type(dyn_horgrid_type),           intent(in)  :: G !< Grid control structure
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: D !< Output topography field
-  type(param_file_type),            intent(in)  :: param_file !< Parameter file structure
-  real,                             intent(in)  :: max_depth !< Maximum depth of the model
+  type(dyn_horgrid_type),  intent(in)  :: G !< The dynamic horizontal grid type
+  real, dimension(G%isd:G%ied,G%jsd:G%jed), &
+                           intent(out) :: D !< Ocean bottom depth in the units of depth_max
+  type(param_file_type),   intent(in)  :: param_file !< Parameter file structure
+  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
+
   ! Local variables
   real, dimension(5) :: domain_params ! nondimensional widths of all domain sections
   real :: sill_frac, shelf_frac
@@ -63,8 +66,8 @@ subroutine dense_water_initialize_topography(D, G, param_file, max_depth)
     domain_params(i) = domain_params(i-1) + domain_params(i)
   enddo
 
-  do i = G%isc,G%iec
-    do j = G%jsc,G%jec
+  do j = G%jsc,G%jec
+    do i = G%isc,G%iec
       ! compute normalised zonal coordinate
       x = (G%geoLonT(i,j) - G%west_lon) / G%len_lon
 
@@ -88,6 +91,7 @@ subroutine dense_water_initialize_topography(D, G, param_file, max_depth)
       endif
     enddo
   enddo
+
 end subroutine dense_water_initialize_topography
 
 !> Initialize the temperature and salinity for the dense water experiment

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -34,13 +34,13 @@ public dumbbell_initialize_sponges
 contains
 
 !> Initialization of topography.
-subroutine dumbbell_initialize_topography ( D, G, param_file, max_depth )
-  ! Arguments
-  type(dyn_horgrid_type),             intent(in)  :: G !< The dynamic horizontal grid type
+subroutine dumbbell_initialize_topography( D, G, param_file, max_depth )
+  type(dyn_horgrid_type),  intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                      intent(out) :: D !< Ocean bottom depth in m
-  type(param_file_type),              intent(in)  :: param_file !< Parameter file structure
-  real,                               intent(in)  :: max_depth  !< Maximum depth of model in m
+                           intent(out) :: D !< Ocean bottom depth in the units of depth_max
+  type(param_file_type),   intent(in)  :: param_file !< Parameter file structure
+  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
+
   ! Local variables
   integer   :: i, j
   real      :: x, y, delta, dblen, dbfrac
@@ -56,17 +56,15 @@ subroutine dumbbell_initialize_topography ( D, G, param_file, max_depth )
     dblen=dblen*1.e3
   endif
 
-  do i=G%isc,G%iec
-    do j=G%jsc,G%jec
-      ! Compute normalized zonal coordinates (x,y=0 at center of domain)
-      x = ( G%geoLonT(i,j) ) / dblen
-      y = ( G%geoLatT(i,j)  ) / G%len_lat
-      D(i,j) = G%max_depth
-      if ((x>=-0.25 .and. x<=0.25) .and. (y <= -0.5*dbfrac .or. y >= 0.5*dbfrac)) then
-        D(i,j) = 0.0
-      endif
-    enddo
-  enddo
+  do j=G%jsc,G%jec ; do i=G%isc,G%iec
+    ! Compute normalized zonal coordinates (x,y=0 at center of domain)
+    x = ( G%geoLonT(i,j) ) / dblen
+    y = ( G%geoLatT(i,j)  ) / G%len_lat
+    D(i,j) = G%max_depth
+    if ((x>=-0.25 .and. x<=0.25) .and. (y <= -0.5*dbfrac .or. y >= 0.5*dbfrac)) then
+      D(i,j) = 0.0
+    endif
+  enddo ; enddo
 
 end subroutine dumbbell_initialize_topography
 

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -33,13 +33,12 @@ public seamount_initialize_temperature_salinity
 contains
 
 !> Initialization of topography.
-subroutine seamount_initialize_topography ( D, G, param_file, max_depth )
-  ! Arguments
-  type(dyn_horgrid_type),             intent(in)  :: G !< The dynamic horizontal grid type
+subroutine seamount_initialize_topography( D, G, param_file, max_depth )
+  type(dyn_horgrid_type),  intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                      intent(out) :: D !< Ocean bottom depth in m
-  type(param_file_type),              intent(in)  :: param_file !< Parameter file structure
-  real,                               intent(in)  :: max_depth  !< Maximum depth of model in m
+                           intent(out) :: D !< Ocean bottom depth in the units of depth_max
+  type(param_file_type),   intent(in)  :: param_file !< Parameter file structure
+  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
 
   ! Local variables
   integer   :: i, j
@@ -61,14 +60,13 @@ subroutine seamount_initialize_topography ( D, G, param_file, max_depth )
   Ly = Ly / G%len_lat
   rLx = 0. ; if (Lx>0.) rLx = 1. / Lx
   rLy = 0. ; if (Ly>0.) rLy = 1. / Ly
-  do i=G%isc,G%iec
-    do j=G%jsc,G%jec
-      ! Compute normalized zonal coordinates (x,y=0 at center of domain)
-      x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon - 0.5
-      y = ( G%geoLatT(i,j) - G%south_lat ) / G%len_lat - 0.5
-      D(i,j) = G%max_depth * ( 1.0 - delta * exp(-(rLx*x)**2 -(rLy*y)**2) )
-    enddo
-  enddo
+
+  do j=G%jsc,G%jec ; do i=G%isc,G%iec
+    ! Compute normalized zonal coordinates (x,y=0 at center of domain)
+    x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon - 0.5
+    y = ( G%geoLatT(i,j) - G%south_lat ) / G%len_lat - 0.5
+    D(i,j) = G%max_depth * ( 1.0 - delta * exp(-(rLx*x)**2 -(rLy*y)**2) )
+  enddo ; enddo
 
 end subroutine seamount_initialize_topography
 

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -12,6 +12,7 @@ use MOM_open_boundary,  only : ocean_OBC_type, OBC_NONE, OBC_DIRECTION_W
 use MOM_open_boundary,  only : OBC_segment_type, register_OBC
 use MOM_open_boundary,  only : OBC_registry_type
 use MOM_time_manager,   only : time_type, time_type_to_real
+use MOM_unit_scaling,   only : unit_scale_type
 
 implicit none ; private
 
@@ -93,31 +94,33 @@ subroutine shelfwave_OBC_end(CS)
 end subroutine shelfwave_OBC_end
 
 !> Initialization of topography.
-subroutine shelfwave_initialize_topography ( D, G, param_file, max_depth )
-  ! Arguments
-  type(dyn_horgrid_type),             intent(in)  :: G !< The dynamic horizontal grid type
+subroutine shelfwave_initialize_topography( D, G, param_file, max_depth, US )
+  type(dyn_horgrid_type),          intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                      intent(out) :: D !< Ocean bottom depth in m
-  type(param_file_type),              intent(in)  :: param_file !< Parameter file structure
-  real,                               intent(in)  :: max_depth  !< Maximum depth of model in m
+                                   intent(out) :: D !< Ocean bottom depth in m or Z if US is present
+  type(param_file_type),           intent(in)  :: param_file !< Parameter file structure
+  real,                            intent(in)  :: max_depth !< Maximum model depth in the units of D
+  type(unit_scale_type), optional, intent(in)  :: US !< A dimensional unit scaling type
 
   ! Local variables
+  real :: m_to_Z  ! A dimensional rescaling factor.
   integer   :: i, j
   real      :: y, rLy, Ly, H0
 
+  m_to_Z = 1.0 ; if (present(US)) m_to_Z = US%m_to_Z
+
   call get_param(param_file, mdl,"SHELFWAVE_Y_LENGTH_SCALE",Ly, &
                  default=50., do_not_log=.true.)
-  call get_param(param_file, mdl,"MINIMUM_DEPTH",H0, &
-                 default=10., do_not_log=.true.)
+  call get_param(param_file, mdl,"MINIMUM_DEPTH", H0, &
+                 default=10., units="m", scale=m_to_Z, do_not_log=.true.)
 
   rLy = 0. ; if (Ly>0.) rLy = 1. / Ly
-  do i=G%isc,G%iec
-    do j=G%jsc,G%jec
-      ! Compute normalized zonal coordinates (x,y=0 at center of domain)
-      y = ( G%geoLatT(i,j) - G%south_lat )
-      D(i,j) = H0 * exp(2 * rLy * y)
-    enddo
-  enddo
+
+  do j=G%jsc,G%jec ; do i=G%isc,G%iec
+    ! Compute normalized zonal coordinates (x,y=0 at center of domain)
+    y = ( G%geoLatT(i,j) - G%south_lat )
+    D(i,j) = H0 * exp(2 * rLy * y)
+  enddo ; enddo
 
 end subroutine shelfwave_initialize_topography
 

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -28,12 +28,12 @@ public sloshing_initialize_temperature_salinity
 contains
 
 !> Initialization of topography.
-subroutine sloshing_initialize_topography ( D, G, param_file, max_depth )
-  type(dyn_horgrid_type),             intent(in)  :: G !< The dynamic horizontal grid type
+subroutine sloshing_initialize_topography( D, G, param_file, max_depth )
+  type(dyn_horgrid_type),  intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                      intent(out) :: D !< Ocean bottom depth in m
-  type(param_file_type),              intent(in)  :: param_file !< Parameter file structure
-  real,                               intent(in)  :: max_depth  !< Maximum depth of model in m
+                           intent(out) :: D !< Ocean bottom depth in the units of depth_max
+  type(param_file_type),   intent(in)  :: param_file !< Parameter file structure
+  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
 
   ! Local variables
   integer   :: i, j

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -13,6 +13,7 @@ use MOM_open_boundary, only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N
 use MOM_open_boundary, only : OBC_DIRECTION_S
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
+use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
@@ -54,12 +55,13 @@ subroutine USER_set_coord(Rlay, g_prime, GV, param_file, eqn_of_state)
 end subroutine USER_set_coord
 
 !> Initialize topography.
-subroutine USER_initialize_topography(D, G, param_file, max_depth)
-  type(dyn_horgrid_type),             intent(in)  :: G !< The dynamic horizontal grid type
+subroutine USER_initialize_topography(D, G, param_file, max_depth, US)
+  type(dyn_horgrid_type),          intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                      intent(out) :: D !< Ocean bottom depth in m
-  type(param_file_type),              intent(in)  :: param_file !< Parameter file structure
-  real,                               intent(in)  :: max_depth  !< Maximum depth of model in m
+                                   intent(out) :: D !< Ocean bottom depth in m or Z if US is present
+  type(param_file_type),           intent(in)  :: param_file !< Parameter file structure
+  real,                            intent(in)  :: max_depth !< Maximum model depth in the units of D
+  type(unit_scale_type), optional, intent(in)  :: US !< A dimensional unit scaling type
 
   call MOM_error(FATAL, &
     "USER_initialization.F90, USER_initialize_topography: " // &


### PR DESCRIPTION
  Altered the various initialize_topography routines so that they can optionally
rescale the units of the bottom depth during initialization, and then use this
new capability in MOM6.  (SIS2 and the ice shelf code use the same routines for
initializing topography but still do any rescaling outside of the routines to
initialize_topography. No answers or parameter_doc files are changed. The list of
commits in this PR include:
 - NOAA-GFDL/MOM6@604a716 Rescale topography during initialization
 - NOAA-GFDL/MOM6@bc808be +Rescale topography in MOM_shared_initialization
 - NOAA-GFDL/MOM6@74014e7 Better comments in initialize_topography routines
 - NOAA-GFDL/MOM6@c9517fe +Rescale depth in USER_initialize_topography
 - NOAA-GFDL/MOM6@8560c62 +Rescale depth in shelfwave_initialize_topography
 - NOAA-GFDL/MOM6@c40b482 +Rescale depth in benchmark_initialize_topography
 - NOAA-GFDL/MOM6@e543439 +Rescale depth in Phillips_initialize_topography
 - NOAA-GFDL/MOM6@f272edc +Rescale depth in Kelvin_initialize_topography
 - NOAA-GFDL/MOM6@771e44f +Rescale depth in ISOMIP_initialize_topography
 - NOAA-GFDL/MOM6@a1653f6 +Rescale depth in DOME_initialize_topography