### PR TITLE
Corrected MOM5 webpage link to github.io site

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
         <h3> <a name="welcome-to-github-pages-for-mom6" class="anchor" href="#welcome-to-github-pages-for-mom6"><span class="octicon octicon-link"></span></a>Welcome to GitHub Pages for MOM6.</h3>
 
-        <p>MOM6 is currently under active development. If you are looking for the most mature ocean model from GFDL, then you might be looking for MOM5, which is supported at <a href="http://mom-ocean.org/web">http://mom-ocean.org/web</a>, and which you can find at <a href="http://www.gfdl.noaa.gov/ocean-model">http://www.gfdl.noaa.gov/ocean-model</a>.</p>
+        <p>MOM6 is currently under active development. If you are looking for the most mature ocean model from GFDL, then you might be looking for MOM5, which is supported at <a href="https://mom-ocean.github.io">https://mom-ocean.github.io</a>, and which you can find at <a href="http://www.gfdl.noaa.gov/ocean-model">http://www.gfdl.noaa.gov/ocean-model</a>.</p>
 
         <p>MOM6 documentation can be found in several key locations:</p>
         <ul>


### PR DESCRIPTION
Is this the right branch to submit changes to http://noaa-gfdl.github.io/MOM6/ ?

The MOM5 website is now hosted on GitHub pages at 

https://mom-ocean.github.io

Steve G is now maintaining that so it should hopefully remain there and be kept updated.
