### PR TITLE
+Top-level arguments control MOM6 time stepping

### DIFF
--- a/src/framework/MOM_safe_alloc.F90
+++ b/src/framework/MOM_safe_alloc.F90
@@ -10,13 +10,14 @@ public safe_alloc_ptr, safe_alloc_alloc
 
 !> Allocate a pointer to a 1-d, 2-d or 3-d array
 interface safe_alloc_ptr
-  module procedure safe_alloc_ptr_3d_2arg, safe_alloc_ptr_2d_2arg
+  module procedure safe_alloc_ptr_3d_3arg,  safe_alloc_ptr_3d_6arg, safe_alloc_ptr_2d_2arg
   module procedure safe_alloc_ptr_3d, safe_alloc_ptr_2d, safe_alloc_ptr_1d
 end interface safe_alloc_ptr
 
 !> Allocate a 2-d or 3-d allocatable array
 interface safe_alloc_alloc
   module procedure safe_alloc_allocatable_3d, safe_alloc_allocatable_2d
+  module procedure safe_alloc_allocatable_3d_6arg
 end interface safe_alloc_alloc
 
 !   This combined interface might work with a later version of Fortran, but
@@ -57,7 +58,7 @@ subroutine safe_alloc_ptr_2d_2arg(ptr, ni, nj)
 end subroutine safe_alloc_ptr_2d_2arg
 
 !> Allocate a pointer to a 3-d array based on its dimension sizes
-subroutine safe_alloc_ptr_3d_2arg(ptr, ni, nj, nk)
+subroutine safe_alloc_ptr_3d_3arg(ptr, ni, nj, nk)
   real, dimension(:,:,:), pointer :: ptr !< A pointer to allocate
   integer, intent(in) :: ni !< The size of the 1st dimension of the array
   integer, intent(in) :: nj !< The size of the 2nd dimension of the array
@@ -66,7 +67,7 @@ subroutine safe_alloc_ptr_3d_2arg(ptr, ni, nj, nk)
     allocate(ptr(ni,nj,nk))
     ptr(:,:,:) = 0.0
   endif
-end subroutine safe_alloc_ptr_3d_2arg
+end subroutine safe_alloc_ptr_3d_3arg
 
 !> Allocate a pointer to a 2-d array based on its index starting and ending values
 subroutine safe_alloc_ptr_2d(ptr, is, ie, js, je)
@@ -95,6 +96,22 @@ subroutine safe_alloc_ptr_3d(ptr, is, ie, js, je, nk)
   endif
 end subroutine safe_alloc_ptr_3d
 
+!> Allocate a pointer to a 3-d array based on its index starting and ending values
+subroutine safe_alloc_ptr_3d_6arg(ptr, is, ie, js, je, ks, ke)
+  real, dimension(:,:,:), pointer :: ptr !< A pointer to allocate
+  integer, intent(in) :: is !< The start index to allocate for the 1st dimension
+  integer, intent(in) :: ie !< The end index to allocate for the 1st dimension
+  integer, intent(in) :: js !< The start index to allocate for the 2nd dimension
+  integer, intent(in) :: je !< The end index to allocate for the 2nd dimension
+  integer, intent(in) :: ks !< The start index to allocate for the 3rd dimension
+  integer, intent(in) :: ke !< The end index to allocate for the 3rd dimension
+  if (.not.associated(ptr)) then
+    allocate(ptr(is:ie,js:je,ks:ke))
+    ptr(:,:,:) = 0.0
+  endif
+end subroutine safe_alloc_ptr_3d_6arg
+
+
 !> Allocate a 2-d allocatable array based on its index starting and ending values
 subroutine safe_alloc_allocatable_2d(ptr, is, ie, js, je)
   real, dimension(:,:), allocatable :: ptr !< An allocatable array to allocate
@@ -109,6 +126,7 @@ subroutine safe_alloc_allocatable_2d(ptr, is, ie, js, je)
 end subroutine safe_alloc_allocatable_2d
 
 !> Allocate a 3-d allocatable array based on its index starting and ending values
+!! and k-index size
 subroutine safe_alloc_allocatable_3d(ptr, is, ie, js, je, nk)
   real, dimension(:,:,:), allocatable :: ptr !< An allocatable array to allocate
   integer, intent(in) :: is !< The start index to allocate for the 1st dimension
@@ -121,5 +139,20 @@ subroutine safe_alloc_allocatable_3d(ptr, is, ie, js, je, nk)
     ptr(:,:,:) = 0.0
   endif
 end subroutine safe_alloc_allocatable_3d
+
+!> Allocate a 3-d allocatable array based on its 6 index starting and ending values
+subroutine safe_alloc_allocatable_3d_6arg(ptr, is, ie, js, je, ks, ke)
+  real, dimension(:,:,:), allocatable :: ptr !< An allocatable array to allocate
+  integer, intent(in) :: is !< The start index to allocate for the 1st dimension
+  integer, intent(in) :: ie !< The end index to allocate for the 1st dimension
+  integer, intent(in) :: js !< The start index to allocate for the 2nd dimension
+  integer, intent(in) :: je !< The end index to allocate for the 2nd dimension
+  integer, intent(in) :: ks !< The start index to allocate for the 3rd dimension
+  integer, intent(in) :: ke !< The end index to allocate for the 3rd dimension
+  if (.not.allocated(ptr)) then
+    allocate(ptr(is:ie,js:je,ks:ke))
+    ptr(:,:,:) = 0.0
+  endif
+end subroutine safe_alloc_allocatable_3d_6arg
 
 end module MOM_safe_alloc

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -422,6 +422,10 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   eaml => eatr ; ebml => ebtr
 
   ! inverse time step
+  if (dt == 0.0) call MOM_error(FATAL, "MOM_diabatic_driver: "// &
+        "diabatic was called with a zero length timestep.")
+  if (dt < 0.0) call MOM_error(FATAL, "MOM_diabatic_driver: "// &
+        "diabatic was called with a negative timestep.")
   Idt = 1.0 / dt
 
   if (.not. associated(CS)) call MOM_error(FATAL, "MOM_diabatic_driver: "// &
@@ -1301,6 +1305,10 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
   eaml => eatr ; ebml => ebtr
 
   ! inverse time step
+  if (dt == 0.0) call MOM_error(FATAL, "MOM_diabatic_driver: "// &
+        "legacy_diabatic was called with a zero length timestep.")
+  if (dt < 0.0) call MOM_error(FATAL, "MOM_diabatic_driver: "// &
+        "legacy_diabatic was called with a negative timestep.")
   Idt = 1.0 / dt
 
   if (.not. associated(CS)) call MOM_error(FATAL, "MOM_diabatic_driver: "// &
@@ -2506,7 +2514,7 @@ subroutine diagnose_diabatic_diff_tendency(tv, h, temp_old, saln_old, dt, G, GV,
   integer :: i, j, k, is, ie, js, je, nz
 
   is  = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
-  Idt = 1/dt
+  Idt = 0.0 ; if (dt > 0.0) Idt = 1. / dt
   work_3d(:,:,:) = 0.0
   work_2d(:,:)   = 0.0
 
@@ -2596,7 +2604,7 @@ subroutine diagnose_boundary_forcing_tendency(tv, h, temp_old, saln_old, h_old, 
   integer :: i, j, k, is, ie, js, je, nz
 
   is  = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
-  Idt = 1/dt
+  Idt = 0.0 ; if (dt > 0.0) Idt = 1. / dt
   work_3d(:,:,:) = 0.0
   work_2d(:,:)   = 0.0
 
@@ -2683,7 +2691,7 @@ subroutine diagnose_frazil_tendency(tv, h, temp_old, dt, G, GV, CS)
   integer :: i, j, k, is, ie, js, je, nz
 
   is  = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
-  Idt = 1/dt
+  Idt = 0.0 ; if (dt > 0.0) Idt = 1. / dt
 
   ! temperature tendency
   if (CS%id_frazil_temp_tend > 0) then


### PR DESCRIPTION
  Allow the top-level optional control arguments to specify the timestepping of
MOM6, including ignoring the DIABATIC_FIRST flag when there are separate calls
to step the dynamics and thermodynamics.  No answers or parameter_doc files are
changed in any existing test cases. The list of commits in this PR include:
 - NOAA-GFDL/MOM6@b6fa342 +Opt args to step_MOM can override DIABATIC_FIRST
 - NOAA-GFDL/MOM6@0ff4c5b Trap or deal with instances when dt=0 in diabatic
 - NOAA-GFDL/MOM6@9b7b127 +New variants of safe_alloc_ptr & safe_alloc_alloc
