### PR TITLE
Travis: switch to mpich2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@
 # This is a not a c-language project but we use the same environment.
 language: c
 dist: trusty
-sudo: false
 
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - tcsh pkg-config netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran
+    - tcsh pkg-config netcdf-bin libnetcdf-dev mpich2 libmpich2-dev gfortran
 
 # For saving time...
 cache:


### PR DESCRIPTION
- After moving to the xanadu version of FMS, Travis-CI was failing to link due to not being able to find mpi_comm_create_group(). Attempts to use the xenial distribution introduced different problems.
- This is a temporary work around while we figure out how to build on newer distributions.
- Note that this does not solve the fails for existing PRs - they can only pass if updated with this commit or we temporarily rollback the MOM6-examples switch to xanadu.