### PR TITLE
Doxygenize down sampling APIs

### DIFF
--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -1825,10 +1825,20 @@ subroutine get_domain_extent_dsamp2(Domain, isc_d2, iec_d2, jsc_d2, jec_d2,&
                                             isd_d2, ied_d2, jsd_d2, jed_d2,&
                                             isg_d2, ieg_d2, jsg_d2, jeg_d2)
   type(MOM_domain_type), &
-           intent(in)  :: Domain         !< The MOM domain from which to extract information
-  integer, intent(out) :: isc_d2, iec_d2, jsc_d2, jec_d2
-  integer, intent(out) :: isd_d2, ied_d2, jsd_d2, jed_d2
-  integer, intent(out) :: isg_d2, ieg_d2, jsg_d2, jeg_d2
+           intent(in)  :: Domain !< The MOM domain from which to extract information
+  integer, intent(out) :: isc_d2 !< The start i-index of the computational domain
+  integer, intent(out) :: iec_d2 !< The end i-index of the computational domain
+  integer, intent(out) :: jsc_d2 !< The start j-index of the computational domain
+  integer, intent(out) :: jec_d2 !< The end j-index of the computational domain
+  integer, intent(out) :: isd_d2 !< The start i-index of the data domain
+  integer, intent(out) :: ied_d2 !< The end i-index of the data domain
+  integer, intent(out) :: jsd_d2 !< The start j-index of the data domain
+  integer, intent(out) :: jed_d2 !< The end j-index of the data domain
+  integer, intent(out) :: isg_d2 !< The start i-index of the global domain
+  integer, intent(out) :: ieg_d2 !< The end i-index of the global domain
+  integer, intent(out) :: jsg_d2 !< The start j-index of the global domain
+  integer, intent(out) :: jeg_d2 !< The end j-index of the global domain
+
   call mpp_get_compute_domain(Domain%mpp_domain_d2, isc_d2, iec_d2, jsc_d2, jec_d2)
   call mpp_get_data_domain(Domain%mpp_domain_d2, isd_d2, ied_d2, jsd_d2, jed_d2)
   call mpp_get_global_domain (Domain%mpp_domain_d2, isg_d2, ieg_d2, jsg_d2, jeg_d2)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1264,7 +1264,7 @@ end subroutine MEKE_end
 !!
 !! \f$L_c\f$ is a constant and \f$\delta[L_c]\f$ is the impulse function so that the term
 !! \f$\frac{\delta[L_c]}{L_c}\f$ evaluates to \f$\frac{1}{L_c}\f$ when \f$L_c\f$ is non-zero
-!! but is dropped if \f$L_c=0\fi$.
+!! but is dropped if \f$L_c=0\f$.
 !!
 !! \f$\beta^*\f$ is the effective \f$\beta\f$ that combines both the planetary vorticity
 !! gradient (i.e. \f$\beta=\nabla f\f$) and the topographic \f$\beta\f$ effect,

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -48,7 +48,7 @@ type, public :: bkgnd_mixing_cs  ! TODO: private
                                     !! Bryan-Lewis profile [m]
   real    :: bckgrnd_vdc1           !< Background diffusivity (Ledwell) when
                                     !! horiz_varying_background=.true.
-  real    :: bckgrnd_vdc_eq         !! Equatorial diffusivity (Gregg) when
+  real    :: bckgrnd_vdc_eq         !< Equatorial diffusivity (Gregg) when
                                     !! horiz_varying_background=.true.
   real    :: bckgrnd_vdc_psim       !< Max. PSI induced diffusivity (MacKinnon) when
                                     !! horiz_varying_background=.true.

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -111,11 +111,11 @@ type, public :: wave_parameters_CS ; private
   type(diag_ctrl), pointer, public :: diag !< A structure that is used to regulate the
                                            !! timing of diagnostic output.
 
-  ! An arbitrary lower-bound on the Langmuir number.  Run-time parameter.
-  ! Langmuir number is sqrt(u_star/u_stokes). When both are small
-  ! but u_star is orders of magnitude smaller the Langmuir number could
-  ! have unintended consequences.  Since both are small it can be safely capped
-  ! to avoid such consequences.
+  !> An arbitrary lower-bound on the Langmuir number.  Run-time parameter.
+  !! Langmuir number is sqrt(u_star/u_stokes). When both are small
+  !! but u_star is orders of magnitude smaller the Langmuir number could
+  !! have unintended consequences.  Since both are small it can be safely capped
+  !! to avoid such consequences.
   real :: La_min = 0.05
 
   !>@{ Diagnostic handles


### PR DESCRIPTION
- Adds documentation of APIs for routines recently added to diag_mediator.
- Also corrects doxygen syntax in MOM_MEKE.F90, MOM_wave_interface.F90, and MOM_bkgnd_mixing.F90, that were leading to warnings in doxygen.log