### PR TITLE
Re-factor of Travis-CI usage

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -1,0 +1,77 @@
+# Makefile steps to run on Travis-CI
+# e.g. make MEMORY_SHAPE=dynamic_symmetric REPRO=1 OPENMP=1
+
+# Versions to use
+FMS_COMMIT ?= xanadu
+MKMF_COMMIT ?= master
+
+# Where to clone from
+FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
+MKMF_URL ?= https://github.com/NOAA-GFDL/mkmf.git
+CONFIGS_URL ?= https://github.com/NOAA-GFDL/MOM6-examples.git
+REGRESSIONS_URL ?= https://github.com/adcroft/Gaea-stats-MOM6-examples
+
+# Experiments to run
+ifeq ($(MEMORY_SHAPE),"dynamic_symmetric")
+EXPERIMENTS ?= unit_tests double_gyre flow_downslope/z CVmix_SCM_tests/cooling_only/EPBL circle_obcs
+else
+EXPERIMENTS ?= unit_tests double_gyre flow_downslope/z CVmix_SCM_tests/cooling_only/EPBL
+endif
+
+FMS_PACKAGES ?= platform,include,memutils,constants,mpp,fms,time_manager,diag_manager,data_override,coupler/ensemble_manager.F90,axis_utils,horiz_interp,time_interp,astronomy,mosaic,random_numbers
+TEMPLATE ?= .testing/linux-ubuntu-xenial-gnu.mk
+MPIRUN ?= mpirun
+
+# MEMORY_SHAPE must be defined for this Makefile to work
+MEMORY_SHAPE ?= dynamic_symmetric
+
+# Everything above is above is "configurable" with environment variables
+SHELL = bash
+
+# Path where executable will be built
+BUILD_PATH = build
+###/$(MEMORY_SHAPE)-$(EXEC_MODE)
+# Root of configurations (MOM6-examples)
+EXPERIMENTS_ROOT = experiments
+# Regression results
+REGRESSIONS_ROOT = answers
+
+.PRECIOUS: %/ocean.stats
+
+run: $(foreach e,$(EXPERIMENTS),$(EXPERIMENTS_ROOT)/ocean_only/$(e)/ocean.stats)
+
+test: $(foreach e,$(EXPERIMENTS),$(REGRESSIONS_ROOT)/regressions/ocean_only/$(e)/ocean.stats.gnu)
+
+compile: $(BUILD_PATH)/MOM6
+
+$(BUILD_PATH)/MOM6: FMS mkmf
+	mkdir -p $(@D)
+	cd $(@D); \
+	../mkmf/bin/list_paths -l ../FMS/{$(FMS_PACKAGES)} ../config_src/{$(MEMORY_SHAPE),solo_driver} ../src \
+	&& ../mkmf/bin/mkmf -t ../$(TEMPLATE) -c '-Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO -DMAXFIELDMETHODS_=500' -p $(@F) path_names \
+	&& make -j NETCDF=3 $(@F)
+
+$(EXPERIMENTS_ROOT)/%/ocean.stats: $(EXPERIMENTS_ROOT)
+	mkdir -p $(@D)/RESTART
+	cd $(@D) ; $(MPIRUN) -n 1 $(PWD)/$(BUILD_PATH)/MOM6
+
+$(REGRESSIONS_ROOT)/regressions/%/ocean.stats.gnu: $(EXPERIMENTS_ROOT)/%/ocean.stats $(REGRESSIONS_ROOT)
+	cp $< $@
+	cd $(@D) ; git status --porcelain $(@F)
+
+# Targets to clone repositories needed to build
+FMS:
+	git clone -q $(FMS_URL)
+	cd $@ ; git checkout -q $(FMS_COMMIT)
+
+mkmf:
+	git clone -q $(MKMF_URL)
+	cd $@ ; git checkout -q $(MKMF_COMMIT)
+
+$(EXPERIMENTS_ROOT):
+	mkdir -p $(@D)
+	cd $(@D) ; git clone --depth 1 $(CONFIGS_URL) experiments
+
+$(REGRESSIONS_ROOT):
+	mkdir -p $(@D)
+	cd $(@D) ; git clone --depth 1 $(REGRESSIONS_URL) answers

--- a/.testing/README.md
+++ b/.testing/README.md
@@ -1,0 +1,3 @@
+# .testing
+
+This directory contains scripts used when evaluating commits on Travis-CI

--- a/.testing/configure
+++ b/.testing/configure
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Configured!" $MAKEARGS
+touch build/test_${MAKEARGS//\ /_}

--- a/.testing/linux-ubuntu-xenial-gnu.mk
+++ b/.testing/linux-ubuntu-xenial-gnu.mk
@@ -1,0 +1,273 @@
+# Template for the GNU Compiler Collection on Xenial version of Ubuntu Linux systems (used by Travis-CI)
+#
+# Typical use with mkmf
+# mkmf -t linux-ubuntu-xenial-gnu.mk -c"-Duse_libMPI -Duse_netCDF" path_names /usr/local/include
+
+############
+# Commands Macors
+FC = mpif90
+CC = mpicc
+LD = mpif90 $(MAIN_PROGRAM)
+
+#######################
+# Build target macros
+#
+# Macros that modify compiler flags used in the build.  Target
+# macrose are usually set on the call to make:
+#
+#    make REPRO=on NETCDF=3
+#
+# Most target macros are activated when their value is non-blank.
+# Some have a single value that is checked.  Others will use the
+# value of the macro in the compile command.
+
+DEBUG =              # If non-blank, perform a debug build (Cannot be
+                     # mixed with REPRO or TEST)
+
+REPRO =              # If non-blank, erform a build that guarentees
+                     # reprodicuibilty from run to run.  Cannot be used
+                     # with DEBUG or TEST
+
+TEST  =              # If non-blank, use the compiler options defined in
+                     # the FFLAGS_TEST and CFLAGS_TEST macros.  Cannot be
+                     # use with REPRO or DEBUG
+
+VERBOSE =            # If non-blank, add additional verbosity compiler
+                     # options
+
+OPENMP =             # If non-blank, compile with openmp enabled
+
+NO_OVERRIDE_LIMITS = # If non-blank, do not use the -qoverride-limits
+                     # compiler option.  Default behavior is to compile
+                     # with -qoverride-limits.
+
+NETCDF =             # If value is '3' and CPPDEFS contains
+                     # '-Duse_netCDF', then the additional cpp macro
+                     # '-Duse_LARGEFILE' is added to the CPPDEFS macro.
+
+INCLUDES =           # A list of -I Include directories to be added to the
+                     # the compile command.
+
+SSE =                # The SSE options to be used to compile.  If blank,
+                     # than use the default SSE settings for the host.
+                     # Current default is to use SSE2.
+
+COVERAGE =           # Add the code coverage compile options.
+
+# Need to use at least GNU Make version 3.81
+need := 3.81
+ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
+ifneq ($(need),$(ok))
+$(error Need at least make version $(need).  Load module gmake/3.81)
+endif
+
+# REPRO, DEBUG and TEST need to be mutually exclusive of each other.
+# Make sure the user hasn't supplied two at the same time
+ifdef REPRO
+ifneq ($(DEBUG),)
+$(error Options REPRO and DEBUG cannot be used together)
+else ifneq ($(TEST),)
+$(error Options REPRO and TEST cannot be used together)
+endif
+else ifdef DEBUG
+ifneq ($(TEST),)
+$(error Options DEBUG and TEST cannot be used together)
+endif
+endif
+
+MAKEFLAGS += --jobs=$(shell grep '^processor' /proc/cpuinfo | wc -l)
+
+# Macro for Fortran preprocessor
+FPPFLAGS := $(INCLUDES)
+# Fortran Compiler flags for the NetCDF library
+FPPFLAGS += $(shell nf-config --fflags)
+
+# Base set of Fortran compiler flags
+FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check
+
+# Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
+FFLAGS_OPT = -O3
+FFLAGS_REPRO = -O2 -fbounds-check
+FFLAGS_DEBUG = -O0 -g -W -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow
+
+# Flags to add additional build options
+FFLAGS_OPENMP = -fopenmp
+FFLAGS_VERBOSE =
+FFLAGS_COVERAGE =
+
+# Macro for C preprocessor
+CPPFLAGS = $(INCLUDES)
+# C Compiler flags for the NetCDF library
+CPPFLAGS += $(shell nf-config --cflags)
+
+# Base set of C compiler flags
+CFLAGS := -D__IFC
+
+# Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
+CFLAGS_OPT = -O2
+CFLAGS_REPRO = -O2
+CFLAGS_DEBUG = -O0 -g
+
+# Flags to add additional build options
+CFLAGS_OPENMP = -fopenmp
+CFLAGS_VERBOSE =
+CFLAGS_COVERAGE =
+
+# Optional Testing compile flags.  Mutually exclusive from DEBUG, REPRO, and OPT
+# *_TEST will match the production if no new option(s) is(are) to be tested.
+FFLAGS_TEST = $(FFLAGS_OPT)
+CFLAGS_TEST = $(CFLAGS_OPT)
+
+# Linking flags
+LDFLAGS :=
+LDFLAGS_OPENMP := -fopenmp
+LDFLAGS_VERBOSE :=
+LDFLAGS_COVERAGE :=
+
+# Start with a blank LIBS
+LIBS =
+# NetCDF library flags
+LIBS += $(shell nf-config --flibs)
+
+# Get compile flags based on target macros.
+ifdef REPRO
+CFLAGS += $(CFLAGS_REPRO)
+FFLAGS += $(FFLAGS_REPRO)
+else ifdef DEBUG
+CFLAGS += $(CFLAGS_DEBUG)
+FFLAGS += $(FFLAGS_DEBUG)
+else ifdef TEST
+CFLAGS += $(CFLAGS_TEST)
+FFLAGS += $(FFLAGS_TEST)
+else
+CFLAGS += $(CFLAGS_OPT)
+FFLAGS += $(FFLAGS_OPT)
+endif
+
+ifdef OPENMP
+CFLAGS += $(CFLAGS_OPENMP)
+FFLAGS += $(FFLAGS_OPENMP)
+LDFLAGS += $(LDFLAGS_OPENMP)
+endif
+
+ifdef SSE
+CFLAGS += $(SSE)
+FFLAGS += $(SSE)
+endif
+
+ifdef NO_OVERRIDE_LIMITS
+FFLAGS += $(FFLAGS_OVERRIDE_LIMITS)
+endif
+
+ifdef VERBOSE
+CFLAGS += $(CFLAGS_VERBOSE)
+FFLAGS += $(FFLAGS_VERBOSE)
+LDFLAGS += $(LDFLAGS_VERBOSE)
+endif
+
+ifeq ($(NETCDF),3)
+  # add the use_LARGEFILE cppdef
+  ifneq ($(findstring -Duse_netCDF,$(CPPDEFS)),)
+    CPPDEFS += -Duse_LARGEFILE
+  endif
+endif
+
+ifdef COVERAGE
+ifdef BUILDROOT
+PROF_DIR=-prof-dir=$(BUILDROOT)
+endif
+CFLAGS += $(CFLAGS_COVERAGE) $(PROF_DIR)
+FFLAGS += $(FFLAGS_COVERAGE) $(PROF_DIR)
+LDFLAGS += $(LDFLAGS_COVERAGE) $(PROF_DIR)
+endif
+
+LDFLAGS += $(LIBS)
+
+#---------------------------------------------------------------------------
+# you should never need to change any lines below.
+
+# see the MIPSPro F90 manual for more details on some of the file extensions
+# discussed here.
+# this makefile template recognizes fortran sourcefiles with extensions
+# .f, .f90, .F, .F90. Given a sourcefile <file>.<ext>, where <ext> is one of
+# the above, this provides a number of default actions:
+
+# make <file>.opt	create an optimization report
+# make <file>.o		create an object file
+# make <file>.s		create an assembly listing
+# make <file>.x		create an executable file, assuming standalone
+#			source
+# make <file>.i		create a preprocessed file (for .F)
+# make <file>.i90	create a preprocessed file (for .F90)
+
+# The macro TMPFILES is provided to slate files like the above for removal.
+
+RM = rm -f
+TMPFILES = .*.m *.B *.L *.i *.i90 *.l *.s *.mod *.opt
+
+.SUFFIXES: .F .F90 .H .L .T .f .f90 .h .i .i90 .l .o .s .opt .x
+
+.f.L:
+	$(FC) $(FFLAGS) -c -listing $*.f
+.f.opt:
+	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f
+.f.l:
+	$(FC) $(FFLAGS) -c $(LIST) $*.f
+.f.T:
+	$(FC) $(FFLAGS) -c -cif $*.f
+.f.o:
+	$(FC) $(FFLAGS) -c $*.f
+.f.s:
+	$(FC) $(FFLAGS) -S $*.f
+.f.x:
+	$(FC) $(FFLAGS) -o $*.x $*.f *.o $(LDFLAGS)
+.f90.L:
+	$(FC) $(FFLAGS) -c -listing $*.f90
+.f90.opt:
+	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f90
+.f90.l:
+	$(FC) $(FFLAGS) -c $(LIST) $*.f90
+.f90.T:
+	$(FC) $(FFLAGS) -c -cif $*.f90
+.f90.o:
+	$(FC) $(FFLAGS) -c $*.f90
+.f90.s:
+	$(FC) $(FFLAGS) -c -S $*.f90
+.f90.x:
+	$(FC) $(FFLAGS) -o $*.x $*.f90 *.o $(LDFLAGS)
+.F.L:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F
+.F.opt:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F
+.F.l:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F
+.F.T:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F
+.F.f:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F > $*.f
+.F.i:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F
+.F.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F
+.F.s:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F
+.F.x:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F *.o $(LDFLAGS)
+.F90.L:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F90
+.F90.opt:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F90
+.F90.l:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F90
+.F90.T:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F90
+.F90.f90:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F90 > $*.f90
+.F90.i90:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F90
+.F90.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F90
+.F90.s:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F90
+.F90.x:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F90 *.o $(LDFLAGS)

--- a/.testing/trailer.py
+++ b/.testing/trailer.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import re
+import sys
+
+def parseCommandLine():
+  """
+  Parse the command line positional and optional arguments.
+  This is the highest level procedure invoked from the very end of the script.
+  """
+
+  # Arguments
+  parser = argparse.ArgumentParser(description='''trailer.py checks Fortran files for trailing white space.''',
+      epilog='Written by A.Adcroft, 2017.')
+  parser.add_argument('files_or_dirs', type=str, nargs='+',
+      metavar='FILE|DIR',
+      help='''Fortran files or director in which to search for Fortran files (with .f, .f90, .F90 suffixes).''')
+  parser.add_argument('-e','--exclude_dir', type=str, action='append',
+      metavar='DIR',
+      help='''Exclude directories from search that end in DIR.''')
+  parser.add_argument('-l','--line_length', type=int, default=512,
+      help='''Maximum allowed length of a line.''')
+  parser.add_argument('-d','--debug', action='store_true',
+      help='turn on debugging information.')
+  args = parser.parse_args()
+
+  global debug
+  debug = args.debug
+
+  main(args)
+
+def main(args):
+  '''
+  Does the actual work
+  '''
+  if (debug): print(args)
+
+  # Process files_or_dirs argument into list of files
+  all_files = []
+  for a in args.files_or_dirs:
+    if os.path.isfile(a): all_files.append(a)
+    elif os.path.isdir(a):
+      for d,s,files in os.walk(a):
+        ignore = False
+        if args.exclude_dir is not None:
+          for e in args.exclude_dir:
+            if e+'/' in d+'/': ignore = True
+        if not ignore:
+          for f in files:
+            _,ext = os.path.splitext(f)
+            if ext in ('.f','.F','.f90','.F90'): all_files.append( os.path.join(d,f) )
+    else: raise Exception('Argument '+a+' is not a file or directory! Stopping.')
+  if (debug): print('Found: ',all_files)
+
+  # For each file, check for trailing white space
+  fail = False
+  for filename in all_files:
+    this = scan_file(filename, line_length=args.line_length)
+    fail = fail or this
+  if fail: sys.exit(1)
+
+def scan_file(filename, line_length=120):
+  '''Scans file for trailing white space'''
+  def msg(filename,lineno,mesg,line=None):
+    if line is None: print('%s, line %i: %s'%(filename,lineno,mesg))
+    else: print('%s, line %i: %s "%s"'%(filename,lineno,mesg,line))
+  white_space_detected = False
+  tabs_space_detected = False
+  long_line_detected = False
+  with open(filename) as file:
+    trailing_space = re.compile(r'.* +$')
+    tabs = re.compile(r'.*\t.*')
+    lineno = 0
+    for line in file.readlines():
+      lineno += 1
+      line = line.replace('\n','')
+      if trailing_space.match(line) is not None:
+        if debug: print(filename,lineno,line,trailing_space.match(line))
+        if len(line.strip())>0: msg(filename,lineno,'Trailing space detected',line)
+        else: msg(filename,lineno,'Blank line contains spaces')
+        white_space_detected = True
+      if tabs.match(line) is not None:
+        if len(line.strip())>0: msg(filename,lineno,'Tab detected',line)
+        else: msg(filename,lineno,'Blank line contains tabs')
+        tabs_space_detected = True
+      if len(line)>line_length:
+        if len(line.strip())>0: msg(filename,lineno,'Line length exceeded',line)
+        else: msg(filename,lineno,'Blank line exceeds line length limit')
+        long_line_detected = True
+  return white_space_detected or tabs_space_detected or long_line_detected
+
+# Invoke parseCommandLine(), the top-level procedure
+if __name__ == '__main__': parseCommandLine()

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,46 +3,109 @@
 
 # This is a not a c-language project but we use the same environment.
 language: c
-dist: trusty
+dist: xenial
 
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - tcsh pkg-config netcdf-bin libnetcdf-dev mpich2 libmpich2-dev gfortran
+    - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev gfortran
+    - doxygen graphviz flex bison cmake
 
-# For saving time...
+# Stages occur sequentially. Within each stage jobs run concurrently.
+stages:
+  - check and compile
+  - tests
+  - cleanup
+
 cache:
   directories:
-    - MOM6-examples
-#   - build # Uncomment this line to save time building. Less robust when FMS changes version!
+    - build
 
-# Install tools and clone the configurations repository
-before_install:
- - git clone https://github.com/adcroft/house_cleaning.git
- # This line clones MOM6-examples when there is no cache
- - test -f MOM6-examples/README.md || (rm -rf MOM6-examples && git clone https://github.com/NOAA-GFDL/MOM6-examples.git)
-
+# Compilation and testing is controlled by the "configure" and "Makefile" in
+# .testing/ but they operate from the root directory. We copy them into place
+# so that they can remain hidden from users.
 install:
- # This restores all files in MOM6-examples and updates
- - (cd MOM6-examples/ && git checkout . && git pull)
- # Update submodules mkmf and FMS
- - (cd MOM6-examples/src/ && git submodule init mkmf FMS && git submodule update mkmf FMS)
+  - echo "Install step"
+  - cp .testing/{configure,Makefile} .
 
-# Build FMS
 before_script:
- - bash MOM6-examples/tools/tests/Travis-MOM6/build_fms.sh
- - bash MOM6-examples/tools/tests/Travis-MOM6/before_script.sh
+  - ls -l
+  - ls build
 
-# Tests to run
-script:
- - ./house_cleaning/trailer.py -e TEOS10 src config_src
- - bash MOM6-examples/tools/tests/Travis-MOM6/build_ocean_only.sh
- - bash MOM6-examples/tools/tests/Travis-MOM6/build_symmetric_ocean_only.sh
- - bash MOM6-examples/tools/tests/Travis-MOM6/run_tests.sh
-
+# This avoids caching files we do not need between stages
 before_cache:
-- rm -rf build/ocn build/symocn
-- (cd MOM6-examples; rm -rf ocean_only; git checkout .)
-- find MOM6-examples -type l -exec rm {} \;
+  - rm -f build/*.o build/*.mod
+
+jobs:
+  include:
+
+    # Checks and compilation ###################################################
+#   - stage: check and compile
+#     script:
+#     - echo "Blank environment - this is where we would compile if we wanted to reuse executables in multiple tests"
+#     #- touch build/comp_nothing
+    - stage: check and compile
+      env: JOB="Code style compliance"
+      script:
+      - ./.testing/trailer.py -e TEOS10 src config_src
+    - stage: check and compile
+      env: JOB="Doxygen"
+      script:
+      - cd docs && doxygen Doxyfile_nortd
+      - grep -v "config_src/solo_driver/coupler_types.F90" doxygen.log | tee doxy_errors
+      - test ! -s  doxy_errors
+    - &compile-code
+      stage: check and compile
+      env: MAKEARGS="MEMORY_SHAPE=dynamic_symmetric REPRO=1"
+      script:
+      - make $MAKEARGS compile
+      - touch build/comp_${MAKEARGS//\ /_}
+    - <<: *compile-code
+      env: MAKEARGS="MEMORY_SHAPE=dynamic REPRO=1"
+    - <<: *compile-code
+      env: MAKEARGS="MEMORY_SHAPE=dynamic_symmetric DEBUG=1"
+    - <<: *compile-code
+      env: MAKEARGS="MEMORY_SHAPE=dynamic DEBUG=1"
+#   - <<: *compile-code
+#     env: MAKEARGS="MEMORY_SHAPE=dynamic_symmetric OPENMP=1"
+
+    # Run tests ################################################################
+    # The default "test" job is automatically invoked for each of the matrix environments
+    # The "test" jobs executes "./configure && make && make test"
+#   - stage: tests
+#     script:
+#     - echo "Placeholder for generic text using blank environment"
+    - &compile
+      stage: tests
+      env: MAKEARGS="MEMORY_SHAPE=dynamic_symmetric REPRO=1"
+      script:
+      - ./configure && make -j && make test
+    - <<: *compile
+      env: MAKEARGS="MEMORY_SHAPE=dynamic REPRO=1"
+    - <<: *compile
+      env: MAKEARGS="MEMORY_SHAPE=dynamic_symmetric DEBUG=1"
+    - <<: *compile
+      env: MAKEARGS="MEMORY_SHAPE=dynamic DEBUG=1"
+#   - <<: *compile
+#     env: MAKEARGS="MEMORY_SHAPE=dynamic_symmetric OPENMP=1"
+
+    # Clean up #################################################################
+    # We only want the cache directory to exist between stages so we manually
+    # clean out the cache, i.e. build/
+    - &clean-build
+      stage: cleanup
+      script:
+      - rm -rf build/*
+      - ls -l
+#   - <<: *clean-build
+      env: MAKEARGS="MEMORY_SHAPE=dynamic_symmetric REPRO=1"
+    - <<: *clean-build
+      env: MAKEARGS="MEMORY_SHAPE=dynamic REPRO=1"
+    - <<: *clean-build
+      env: MAKEARGS="MEMORY_SHAPE=dynamic_symmetric DEBUG=1"
+    - <<: *clean-build
+      env: MAKEARGS="MEMORY_SHAPE=dynamic DEBUG=1"
+#   - <<: *clean-build
+#     env: MAKEARGS="MEMORY_SHAPE=dynamic_symmetric OPENMP=1"


### PR DESCRIPTION
- Uses stages to parallelize testing process
- Adds a doxygen job that tests for doxygen errors
- Reduces dependency on other repositories
  - No longer uses scripts from MOM6-examples/tools/tests/Travis-MOM6/
  - Still uses configurations from MOM6-examples/ocean_only/
- Adds test building/using a debug executable
- Adds a .testing/ directory
- Uses the latest xenial image on Travis (with openmpi)
- Example of new report is at https://travis-ci.org/adcroft/MOM6/builds/520870218

Todo:
- Add code coverage (needs more experiments)
- Break dependence on MOM6-examples (long term project)
- Add other portable tests (e.g. parameter scaling, rotation, etc)