### PR TITLE
dev/master candidate 2019-04-26

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,8 +32,9 @@ setup:
     - git clone --recursive http://gitlab.gfdl.noaa.gov/ogrp/Gaea-stats-MOM6-examples.git tests && cd tests
     # Install / update testing scripts
     - git clone https://github.com/adcroft/MRS.git MRS
+    - (cd MRS ; git checkout 9badc63acefbf038)
     # Update MOM6-examples and submodules
-    - (cd MOM6-examples && git checkout . && git checkout dev/gfdl && git pull && git submodule init && git submodule update)
+    - (cd MOM6-examples && git checkout . && git checkout dev/gfdl && git pull && git checkout cf73a9ad63f8ccf7 && git submodule init && git submodule update)
     - (cd MOM6-examples/src/MOM6 && git submodule update)
     - test -d MOM6-examples/src/LM3 || make -f MRS/Makefile.clone clone_gfdl -s
     - make -f MRS/Makefile.clone MOM6-examples/.datasets -s
@@ -73,7 +74,7 @@ gnu:ice-ocean-nolibs:
     - time tar zxf $CACHE_DIR/tests_$CI_PIPELINE_ID.tgz && cd tests
     - make -f MRS/Makefile.build build/gnu/env && cd build/gnu
     # mkdir -p build/gnu/repro/symmetric_dynamic/ocean_only && cd build/gnu/repro/symmetric_dynamic/ocean_only
-    - ../../MOM6-examples/src/mkmf/bin/list_paths -l ../../../config_src/{coupled_driver,dynamic} ../../../src ../../MOM6-examples/src/{FMS,coupler,SIS2,icebergs,ice_ocean_extras,land_null,atmos_null}
+    - ../../MOM6-examples/src/mkmf/bin/list_paths -l ../../../config_src/{coupled_driver,dynamic} ../../../src ../../MOM6-examples/src/{FMS,coupler,SIS2,icebergs,ice_param,land_null,atmos_null}
     - ../../MOM6-examples/src/mkmf/bin/mkmf -t ../../MOM6-examples/src/mkmf/templates/ncrc-gnu.mk -p MOM6 -c"-Duse_libMPI -Duse_netCDF -D_USE_LEGACY_LAND_ -Duse_AM3_physics" path_names
     - time (source ./env ; make NETCDF=3 REPRO=1 MOM6 -s -j)
 


### PR DESCRIPTION
This is a PR onto dev/master of MOM6 and MOM6-examples but has no source code changes for MOM6. The PR pertains to the use of xanadu versions of FMS and the GFDL coupler and primarily affects your super-repositories.

- All that changes for MOM6 are the versions of testings scripts used on Travis-CI and gitlab. This is because some source code has moved between repositories and those paths are reflected in the testing scripts.
- The latest versions of MOM6 and SIS2 can work with either the warsaw or xanadu versions of FMS, but there will be additional simplifications to MOM6 in coming weeks that depend on the FMS code being updated to xanadu.
- xanadu adds new APIs between/for ice and ocean components. The old APIs still exist but building the xanadu version of the GFDL coupler or FMS requires newer versions of other components.
  - If you are not using https://github.com/NOAA-GFDL/coupler then you should be able to roll forward to xanadu FMS and latest versions of SIS2 and MOM6 without further ado.
  - If you are using either the GFDL coupler or SIS2 in addition to MOM6 then you will need to figure out how to use the xanadu versions of FMS and GFDL coupler.
- MOM6-examples/src/ice_ocean_extras has been removed:
  - A new submodule/repository https://github.com/NOAA-GFDL/ice_param now exists for the albedo code.
  - New directories within FMS provide diag_integral and monin_obukhov code.
- The specific commits for submodules in MOM6-examples/src/ become:
  - 3cde6bb9fc3f860eacfbf52d095ec2d81e29b272 src/FMS (xanadu)
  - 14578f09a25c8e6101faba18342630af267cdba9 src/coupler (xanadu)
  - d9bf8341a280ec0927a50c0036e81283050ec967 src/SIS2 (current HEAD of dev/master and dev/gfdl)
  - b114a809187317909e19fdca7ff843f2a603f011 src/icebergs (current HEAD of dev/master and dev/gfdl)
  - aeac506b910c06ce949fea408c2968c0a928a62e src/atmos_null (xanadu_esm4_20190304)
  - 49b089ea8d5b963ede276660cb63c6c3ec2516ab src/land_null (xanadu_esm4_20190304)
  - bf6e4fca190d809e8fb6e7b9be9fb68e47cfdc06 src/ice_param (xanadu)
- The submodules in MOM6-examples/src/ (above) define everything needed for ocean_only and ice_ocean_SIS2 experiments.

The following pertains to legacy and fully-coupled experiments that can only be built within the GFDL firewall. Namely the experiments in ice_ocean_SIS/, land_ice_ocean_LM3_SIS2/, coupled_AM2_LM3_SIS/, or coupled_AM2_LM3_SIS2/. These require the following repositories:
  - 8628c352367dd889833df1480a582bc5652ff0da sis1 (xanadu)
  - b59c0450b5d1219a7d10c029354d16917884b26e atmos_param_am3 (warsaw_201803)
  - 3be6ed406de2db29766746a69115fd6a47048692 atmos_drivers (warsaw_201803)
  - 75be30e6977582f011d0460e75cc7c59d56a3afc atmos_fv_dynamics (warsaw_201803)
  - 357aed1a76a7d7fec8cdcf80b62e9820974a7e45 atmos_shared_am3 (warsaw_201803)
  - 25c6bc861631176f6e363c5a7bee4e8d30b73815 land_lad2 (verona_201701)
  - 80ce1b59e29b0b775fce46e90e723bc07993795e land_param (xanadu)