### PR TITLE
MOM6: +(*)Added MIN_SALINITY and fixed subML_N2

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -1203,7 +1203,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RESTORE_TEMPERATURE", CS%restore_temp, &
                  "If true, the coupled driver will add a  \n"//&
-                 "heat flux that drives sea-surface temperauture \n"//&
+                 "heat flux that drives sea-surface temperature \n"//&
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_TO_ZERO", &
                  CS%adjust_net_srestore_to_zero, &

--- a/config_src/mct_driver/MOM_ocean_model.F90
+++ b/config_src/mct_driver/MOM_ocean_model.F90
@@ -313,7 +313,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RESTORE_TEMPERATURE",OS%restore_temp, &
                  "If true, the coupled driver will add a  \n"//&
-                 "heat flux that drives sea-surface temperauture \n"//&
+                 "heat flux that drives sea-surface temperature \n"//&
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RHO_0", Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&

--- a/config_src/nuopc_driver/MOM_ocean_model.F90
+++ b/config_src/nuopc_driver/MOM_ocean_model.F90
@@ -334,7 +334,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RESTORE_TEMPERATURE",OS%restore_temp, &
                  "If true, the coupled driver will add a  \n"//&
-                 "heat flux that drives sea-surface temperauture \n"//&
+                 "heat flux that drives sea-surface temperature \n"//&
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RHO_0", Rho0, &
                  "The mean ocean density used with BOUSSINESQ true to \n"//&

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -177,7 +177,7 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
                  trim(remappingSchemesDoc), default=remappingDefaultScheme)
   call get_param(param_file, mdl, "FATAL_CHECK_RECONSTRUCTIONS", check_reconstruction, &
                  "If true, cell-by-cell reconstructions are checked for\n"//&
-                 "consistency and if non-monotonicty or an inconsistency is\n"//&
+                 "consistency and if non-monotonicity or an inconsistency is\n"//&
                  "detected then a FATAL error is issued.", default=.false.)
   call get_param(param_file, mdl, "FATAL_CHECK_REMAPPING", check_remapping, &
                  "If true, the results of remapping are checked for\n"//&
@@ -215,7 +215,7 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
   call get_param(param_file, mdl, "REGRID_FILTER_DEEP_DEPTH", filter_deep_depth, &
                  "The depth below which full time-filtering is applied with time-scale\n"//&
                  "REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and\n"//&
-                 "REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.", &
+                 "REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.", &
                  units="m", default=0., scale=GV%m_to_H)
   call set_regrid_params(CS%regridCS, depth_of_time_filter_shallow=filter_shallow_depth, &
                                       depth_of_time_filter_deep=filter_deep_depth)

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -140,8 +140,8 @@ public get_zlike_CS, get_sigma_CS, get_rho_CS
 !> Documentation for coordinate options
 character(len=*), parameter, public :: regriddingCoordinateModeDoc = &
                  " LAYER - Isopycnal or stacked shallow water layers\n"//&
-                 " ZSTAR, Z* - stetched geopotential z*\n"//&
-                 " SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf\n"//&
+                 " ZSTAR, Z* - stretched geopotential z*\n"//&
+                 " SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf\n"//&
                  " SIGMA - terrain following coordinates\n"//&
                  " RHO   - continuous isopycnal\n"//&
                  " HYCOM1 - HyCOM-like hybrid coordinate\n"//&
@@ -230,8 +230,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
   if (main_parameters) then
     ! Read coordinate units parameter (main model = REGRIDDING_COORDINATE_UNITS)
     call get_param(param_file, mdl, "REGRIDDING_COORDINATE_UNITS", coord_units, &
-                 "Units of the regridding coordinuate.",& !### Spelling error "coordinuate"
-                 default=coordinateUnits(coord_mode))
+                 "Units of the regridding coordinate.", default=coordinateUnits(coord_mode))
   else
     coord_units=coordinateUnits(coord_mode)
   endif
@@ -420,7 +419,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
       call log_param(param_file, mdl, "!"//coord_res_param, dz, &
                trim(message), units=coordinateUnits(coord_mode))
       call log_param(param_file, mdl, "!TARGET_DENSITIES", rho_target, &
-               'HYBRID target densities for itnerfaces', units=coordinateUnits(coord_mode))
+               'HYBRID target densities for interfaces', units=coordinateUnits(coord_mode))
     endif
   elseif (index(trim(string),'WOA09')==1) then
     if (len_trim(string)==5) then
@@ -503,7 +502,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
   if (main_parameters .and. coord_is_state_dependent) then
     call get_param(param_file, mdl, "REGRID_COMPRESSIBILITY_FRACTION", tmpReal, &
                  "When interpolating potential density profiles we can add\n"//&
-                 "some artificial compressibility solely to make homogenous\n"//&
+                 "some artificial compressibility solely to make homogeneous\n"//&
                  "regions appear stratified.", default=0.)
     call set_regrid_params(CS, compress_fraction=tmpReal)
   endif

--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -286,7 +286,7 @@ subroutine build_rho_column_iteratively(CS, remapCS, nz, depth, h, T, S, eqn_of_
     zInterface(1) = 0.
     do k = 1,nz
       zInterface(k+1) = zInterface(k) - h1(k)
-      ! Adjust interface position to accomodate inflating layers
+      ! Adjust interface position to accommodate inflating layers
       ! without disturbing the interface above
     enddo
   else
@@ -294,7 +294,7 @@ subroutine build_rho_column_iteratively(CS, remapCS, nz, depth, h, T, S, eqn_of_
     zInterface(nz+1) = -depth
     do k = nz,1,-1
       zInterface(k) = zInterface(k+1) + h1(k)
-      ! Adjust interface position to accomodate inflating layers
+      ! Adjust interface position to accommodate inflating layers
       ! without disturbing the interface above
     enddo
   endif

--- a/src/ALE/coord_sigma.F90
+++ b/src/ALE/coord_sigma.F90
@@ -72,7 +72,7 @@ subroutine build_sigma_column(CS, depth, totalThickness, zInterface)
   zInterface(CS%nk+1) = -depth
   do k = CS%nk,1,-1
     zInterface(k) = zInterface(k+1) + (totalThickness * CS%coordinateResolution(k))
-    ! Adjust interface position to accomodate inflating layers
+    ! Adjust interface position to accommodate inflating layers
     ! without disturbing the interface above
     if (zInterface(k) < (zInterface(k+1) + CS%min_thickness)) then
       zInterface(k) = zInterface(k+1) + CS%min_thickness

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1516,7 +1516,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                           count_calls, tracer_flow_CSp)
   type(time_type), target,   intent(inout) :: Time        !< model time, set in this routine
   type(time_type),           intent(in)    :: Time_init   !< The start time for the coupled model's calendar
-  type(param_file_type),     intent(out)   :: param_file  !< structure indicating paramater file to parse
+  type(param_file_type),     intent(out)   :: param_file  !< structure indicating parameter file to parse
   type(directories),         intent(out)   :: dirs        !< structure with directory paths
   type(MOM_control_struct),  pointer       :: CS          !< pointer set in this routine to MOM control structure
   type(MOM_restart_CS),      pointer       :: restart_CSp !< pointer set in this routine to the
@@ -1830,6 +1830,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "If true, limit salinity to being positive. (The sea-ice \n"//&
                  "model may ask for more salt than is available and \n"//&
                  "drive the salinity negative otherwise.)", default=.false.)
+    call get_param(param_file, "MOM", "MIN_SALINITY", CS%tv%min_salinity, &
+                 "The minimum value of salinity when BOUND_SALINITY=True. \n"//&
+                 "The default is 0.01 for backward compatibility but ideally \n"//&
+                 "should be 0.", units="PPT", default=0.01, do_not_log=.not.bound_salinity)
     call get_param(param_file, "MOM", "C_P", CS%tv%C_p, &
                  "The heat capacity of sea water, approximated as a \n"//&
                  "constant. This is only used if ENABLE_THERMODYNAMICS is \n"//&
@@ -3410,7 +3414,7 @@ end subroutine MOM_end
 !!  * src/tracer:
 !!    These files handle the lateral transport and diffusion of
 !!    tracers, or are the code to implement various passive tracer
-!!    packages.  Additional tracer packages are readily accomodated.
+!!    packages.  Additional tracer packages are readily accommodated.
 !!
 !!  * src/user:
 !!    These are either stub routines that a user could use to change

--- a/src/core/MOM_PressureForce_analytic_FV.F90
+++ b/src/core/MOM_PressureForce_analytic_FV.F90
@@ -831,8 +831,8 @@ subroutine PressureForce_AFV_init(Time, G, GV, US, param_file, diag, CS, tides_C
                  "The default is set by USE_REGRIDDING.", &
                  default=use_ALE )
   call get_param(param_file, mdl, "PRESSURE_RECONSTRUCTION_SCHEME", CS%Recon_Scheme, &
-                 "Order of vertical reconstruction of T/S to use in the\n"//&
-                 "integrals within the FV pressure gradient calculation."//&
+                 "Order of vertical reconstruction of T/S to use in the \n"//&
+                 "integrals within the FV pressure gradient calculation.\n"//&
                  " 0: PCM or no reconstruction.\n"//&
                  " 1: PLM reconstruction.\n"//&
                  " 2: PPM reconstruction.", default=1)

--- a/src/core/MOM_PressureForce_blocked_AFV.F90
+++ b/src/core/MOM_PressureForce_blocked_AFV.F90
@@ -823,8 +823,8 @@ subroutine PressureForce_blk_AFV_init(Time, G, GV, US, param_file, diag, CS, tid
                  "The default is set by USE_REGRIDDING.", &
                  default=use_ALE )
   call get_param(param_file, mdl, "PRESSURE_RECONSTRUCTION_SCHEME", CS%Recon_Scheme, &
-                 "Order of vertical reconstruction of T/S to use in the\n"//&
-                 "integrals within the FV pressure gradient calculation."//&
+                 "Order of vertical reconstruction of T/S to use in the \n"//&
+                 "integrals within the FV pressure gradient calculation.\n"//&
                  " 0: PCM or no reconstruction.\n"//&
                  " 1: PLM reconstruction.\n"//&
                  " 2: PPM reconstruction.", default=1)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -199,7 +199,7 @@ type, public :: barotropic_CS ; private
                              !! update at the start of a call to btstep.  The
                              !! default is 1.
   logical :: BT_project_velocity !< If true, step the barotropic velocity first
-                             !! and project out the velocity tendancy by 1+BEBT
+                             !! and project out the velocity tendency by 1+BEBT
                              !! when calculating the transport.  The default
                              !! (false) is to use a predictor continuity step to
                              !! find the pressure field, and then do a corrector
@@ -3785,7 +3785,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
   call get_param(param_file, mdl, "BT_CONT_CORR_BOUNDS", CS%BT_cont_bounds, &
                  "If true, and BOUND_BT_CORRECTION is true, use the \n"//&
                  "BT_cont_type variables to set limits determined by \n"//&
-                 "MAXCFL_BT_CONT on the CFL number of the velocites \n"//&
+                 "MAXCFL_BT_CONT on the CFL number of the velocities \n"//&
                  "that are likely to be driven by the corrective mass fluxes.", &
                  default=.true.) !, do_not_log=.not.CS%bound_BT_corr)
   call get_param(param_file, mdl, "ADJUST_BT_CONT", CS%adjust_BT_cont, &
@@ -3846,7 +3846,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                  units="nondim", default=1)
   call get_param(param_file, mdl, "BT_PROJECT_VELOCITY", CS%BT_project_velocity,&
                  "If true, step the barotropic velocity first and project \n"//&
-                 "out the velocity tendancy by 1+BEBT when calculating the \n"//&
+                 "out the velocity tendency by 1+BEBT when calculating the \n"//&
                  "transport.  The default (false) is to use a predictor \n"//&
                  "continuity step to find the pressure field, and then \n"//&
                  "to do a corrector continuity step using a weighted \n"//&
@@ -3917,7 +3917,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                  "barotropic steps.", default=.false.)
   call get_param(param_file, mdl, "BT_LINEAR_WAVE_DRAG", CS%linear_wave_drag, &
                  "If true, apply a linear drag to the barotropic velocities, \n"//&
-                 "using rates set by lin_drag_u & _vdivided by the depth of \n"//&
+                 "using rates set by lin_drag_u & _v divided by the depth of \n"//&
                  "the ocean.  This was introduced to facilitate tide modeling.", &
                  default=.false.)
   call get_param(param_file, mdl, "BT_WAVE_DRAG_FILE", wave_drag_file, &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2264,7 +2264,7 @@ subroutine continuity_PPM_init(Time, G, GV, param_file, diag, CS)
   call get_param(param_file, mdl, "SIMPLE_2ND_PPM_CONTINUITY", CS%simple_2nd, &
                  "If true, CONTINUITY_PPM uses a simple 2nd order \n"//&
                  "(arithmetic mean) interpolation of the edge values. \n"//&
-                 "This may give better PV conservation propterties. While \n"//&
+                 "This may give better PV conservation properties. While \n"//&
                  "it formally reduces the accuracy of the continuity \n"//&
                  "solver itself in the strongly advective limit, it does \n"//&
                  "not reduce the overall order of accuracy of the dynamic \n"//&

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -305,8 +305,9 @@ subroutine open_boundary_config(G, US, param_file, OBC)
   real               :: Lscale_in, Lscale_out ! parameters controlling tracer values at the boundaries
   allocate(OBC)
 
-  call log_version(param_file, mdl, version, "Controls where open boundaries are located, what "//&
-                 "kind of boundary condition to impose, and what data to apply, if any.")
+  call log_version(param_file, mdl, version, &
+                 "Controls where open boundaries are located, what kind of boundary condition \n"//&
+                 "to impose, and what data to apply, if any.")
   call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", OBC%number_of_segments, &
                  "The number of open boundary segments.", &
                  default=0)

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -80,7 +80,7 @@ end type surface
 !> Pointers to an assortment of thermodynamic fields that may be available, including
 !! potential temperature, salinity, heat capacity, and the equation of state control structure.
 type, public :: thermo_var_ptrs
-!   If allocated, the following variables have nz layers.
+  ! If allocated, the following variables have nz layers.
   real, pointer :: T(:,:,:) => NULL() !< Potential temperature [degC].
   real, pointer :: S(:,:,:) => NULL() !< Salnity [PSU] or [gSalt/kg], generically [ppt].
   type(EOS_type), pointer :: eqn_of_state => NULL() !< Type that indicates the
@@ -95,14 +95,16 @@ type, public :: thermo_var_ptrs
                          !! actually the conservative temperature [degC].
   logical :: S_is_absS = .false. !< If true, the salinity variable tv%S is
                          !! actually the absolute salinity in units of [gSalt/kg].
-!  These arrays are accumulated fluxes for communication with other components.
+  real :: min_salinity = 0.01 !< The minimum value of salinity when BOUND_SALINITY=True [ppt].
+                         !! The default is 0.01 for backward compatibility but should be 0.
+  ! These arrays are accumulated fluxes for communication with other components.
   real, dimension(:,:), pointer :: frazil => NULL()
                          !< The energy needed to heat the ocean column to the
                          !! freezing point since calculate_surface_state was2
                          !! last called [J m-2].
   real, dimension(:,:), pointer :: salt_deficit => NULL()
                          !<   The salt needed to maintain the ocean column
-                         !! at a minumum salinity of 0.01 PSU since the last time
+                         !! at a minimum salinity of MIN_SALINITY since the last time
                          !! that calculate_surface_state was called, [gSalt m-2].
   real, dimension(:,:), pointer :: TempxPmE => NULL()
                          !<   The net inflow of water into the ocean times the

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -50,7 +50,7 @@ type, public :: verticalGrid_type
     g_prime, &          !< The reduced gravity at each interface [m2 Z-1 s-2 ~> m s-2].
     Rlay                !< The target coordinate value (potential density) in each layer [kg m-3].
   integer :: nkml = 0   !< The number of layers at the top that should be treated
-                        !! as parts of a homogenous region.
+                        !! as parts of a homogeneous region.
   integer :: nk_rho_varies = 0 !< The number of layers at the top where the
                         !! density does not track any target density.
   real :: H_to_kg_m2    !< A constant that translates thicknesses from the units of thickness to kg m-2.
@@ -100,7 +100,7 @@ subroutine verticalGridInit( param_file, GV, US )
   call get_param(param_file, mdl, "BOUSSINESQ", GV%Boussinesq, &
                  "If true, make the Boussinesq approximation.", default=.true.)
   call get_param(param_file, mdl, "ANGSTROM", GV%Angstrom_m, &
-                 "The minumum layer thickness, usually one-Angstrom.", &
+                 "The minimum layer thickness, usually one-Angstrom.", &
                  units="m", default=1.0e-10)
   call get_param(param_file, mdl, "H_RESCALE_POWER", H_power, &
                  "An integer power of 2 that is used to rescale the model's \n"//&

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1142,7 +1142,7 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
   real :: dz(HIO%iscB:HIO%iecB+1)   ! Layer thicknesses at tracer points [Z ~> m].
   real :: dz_x(5,HIO%iscB:HIO%iecB) ! Layer thicknesses along an x-line of subrid locations [Z ~> m].
   real :: dz_y(5,HIO%isc:HIO%iec)   ! Layer thicknesses along a y-line of subrid locations [Z ~> m].
-  real :: weight_t, weight_b        ! Nondimensional wieghts of the top and bottom.
+  real :: weight_t, weight_b        ! Nondimensional weights of the top and bottom.
   real :: massWeightToggle          ! A nondimensional toggle factor (0 or 1).
   real :: Ttl, Tbl, Ttr, Tbr        ! Temperatures at the velocity cell corners [degC].
   real :: Stl, Sbl, Str, Sbr        ! Salinities at the velocity cell corners [ppt].

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -2944,8 +2944,8 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
                  'Set the default missing value to use for diagnostics.', &
                  default=1.e20)
   call get_param(param_file, mdl, 'DIAG_AS_CHKSUM', diag_cs%diag_as_chksum, &
-                 'Instead of writing diagnostics to the diag manager, write\n' //&
-                 'a textfile containing the checksum (bitcount) of the array.',  &
+                 'Instead of writing diagnostics to the diag manager, write\n'//&
+                 'a text file containing the checksum (bitcount) of the array.',  &
                  default=.false.)
 
   ! Keep pointers grid, h, T, S needed diagnostic remapping

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -229,8 +229,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   ! is just to make sure that all valid parameters are read to enable the
   ! detection of unused parameters.
   call get_param(PF, mdl, "INIT_LAYERS_FROM_Z_FILE", from_Z_file, &
-             "If true, intialize the layer thicknesses, temperatures, \n"//&
-             "and salnities from a Z-space file on a latitude- \n"//&
+             "If true, initialize the layer thicknesses, temperatures, \n"//&
+             "and salinities from a Z-space file on a latitude- \n"//&
              "longitude grid.", default=.false., do_not_log=just_read)
 
   if (from_Z_file) then
@@ -447,7 +447,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
                default=.false., do_not_log=just_read)
   call get_param(PF, mdl, "TRIM_IC_FOR_P_SURF", trim_ic_for_p_surf, &
                "If true, cuts way the top of the column for initial conditions\n"//&
-               "at the depth where the hydrostatic presure matches the imposed\n"//&
+               "at the depth where the hydrostatic pressure matches the imposed\n"//&
                "surface pressure which is read from file.", default=.false., &
                do_not_log=just_read)
   if (depress_sfc .and. trim_ic_for_p_surf) call MOM_error(FATAL, "MOM_initialize_state: "//&

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -865,7 +865,7 @@ logical function MEKE_init(Time, G, param_file, diag, CS, MEKE, restart_CS)
 
   ! Read all relevant parameters and write them to the model log.
   call get_param(param_file, mdl, "MEKE_DAMPING", CS%MEKE_damping, &
-                 "The local depth-indepented MEKE dissipation rate.", &
+                 "The local depth-independent MEKE dissipation rate.", &
                  units="s-1", default=0.0)
   call get_param(param_file, mdl, "MEKE_CD_SCALE", CS%MEKE_Cd_scale, &
                  "The ratio of the bottom eddy velocity to the column mean\n"//&
@@ -944,41 +944,41 @@ logical function MEKE_init(Time, G, param_file, diag, CS, MEKE, restart_CS)
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_FIXED_MIXING_LENGTH", CS%Lfixed, &
                  "If positive, is a fixed length contribution to the expression\n"//&
-                 "for mixing length used in MEKE-derived diffusiviity.", &
+                 "for mixing length used in MEKE-derived diffusivity.", &
                  units="m", default=0.0)
   call get_param(param_file, mdl, "MEKE_ALPHA_DEFORM", CS%aDeform, &
                  "If positive, is a coefficient weighting the deformation scale\n"//&
-                 "in the expression for mixing length used in MEKE-derived diffusiviity.", &
+                 "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_ALPHA_RHINES", CS%aRhines, &
                  "If positive, is a coefficient weighting the Rhines scale\n"//&
-                 "in the expression for mixing length used in MEKE-derived diffusiviity.", &
+                 "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.05)
   call get_param(param_file, mdl, "MEKE_ALPHA_EADY", CS%aEady, &
                  "If positive, is a coefficient weighting the Eady length scale\n"//&
-                 "in the expression for mixing length used in MEKE-derived diffusiviity.", &
+                 "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.05)
   call get_param(param_file, mdl, "MEKE_ALPHA_FRICT", CS%aFrict, &
                  "If positive, is a coefficient weighting the frictional arrest scale\n"//&
-                 "in the expression for mixing length used in MEKE-derived diffusiviity.", &
+                 "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_ALPHA_GRID", CS%aGrid, &
                  "If positive, is a coefficient weighting the grid-spacing as a scale\n"//&
-                 "in the expression for mixing length used in MEKE-derived diffusiviity.", &
+                 "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_COLD_START", coldStart, &
                  "If true, initialize EKE to zero. Otherwise a local equilibrium solution\n"//&
                  "is used as an initial condition for EKE.", default=.false.)
   call get_param(param_file, mdl, "MEKE_BACKSCAT_RO_C", MEKE%backscatter_Ro_c, &
-                 "The coefficient in the Rossby number function for scaling the buharmonic\n"//&
+                 "The coefficient in the Rossby number function for scaling the biharmonic\n"//&
                  "frictional energy source. Setting to non-zero enables the Rossby number function.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_BACKSCAT_RO_POW", MEKE%backscatter_Ro_pow, &
-                 "The power in the Rossby number function for scaling the biharmomnic\n"//&
+                 "The power in the Rossby number function for scaling the biharmonic\n"//&
                  "frictional energy source.", units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_ADVECTION_FACTOR", CS%MEKE_advection_factor, &
                  "A scale factor in front of advection of eddy energy. Zero turns advection off.\n"//&
-                 "Using unity would be normal but other values could accomodate a mismatch\n"//&
+                 "Using unity would be normal but other values could accommodate a mismatch\n"//&
                  "between the advecting barotropic flow and the vertical structure of MEKE.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_TOPOGRAPHIC_BETA", CS%MEKE_topographic_beta, &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1217,19 +1217,19 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
                  "the biharmonic viscosity.", default=.false.)
 
   call get_param(param_file, mdl, "USE_KH_BG_2D", CS%use_Kh_bg_2d, &
-                 "If true, read a file containing 2-d background harmonic  \n"//&
-                 "viscosities. The final viscosity is the maximum of the other "//&
+                 "If true, read a file containing 2-d background harmonic \n"//&
+                 "viscosities. The final viscosity is the maximum of the other \n"//&
                  "terms and this background value.", default=.false.)
 
 
   if (CS%bound_Kh .or. CS%bound_Ah .or. CS%better_bound_Kh .or. CS%better_bound_Ah) &
     call get_param(param_file, mdl, "DT", dt, &
-                 "The (baroclinic) dynamics time step.", units = "s", &
+                 "The (baroclinic) dynamics time step.", units="s", &
                  fail_if_missing=.true.)
 
   if (CS%no_slip .and. CS%biharmonic) &
     call MOM_error(FATAL,"ERROR: NOSLIP and BIHARMONIC cannot be defined "// &
-                          "at the same time in MOM.")
+                         "at the same time in MOM.")
 
   if (.not.(CS%Laplacian .or. CS%biharmonic)) then
     ! Only issue inviscid warning if not in single column mode (usually 2x2 domain)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -417,7 +417,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         endif
       endif
       if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-        ! There are extra wide halos here to accomodate the cross-corner-point
+        ! There are extra wide halos here to accommodate the cross-corner-point
         ! OBC projections, but they might not be necessary if the accelerations
         ! are always zeroed out at OBC points, in which case the i-loop below
         ! becomes do i=is-1,ie+1. -RWH
@@ -1063,12 +1063,12 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
                  "viscosity, the Smagorinsky and Leith viscosities, and KH.", &
                  units="m s-1", default=0.0)
     call get_param(param_file, mdl, "KH_SIN_LAT", Kh_sin_lat, &
-                 "The amplitude of a latidutinally-dependent background\n"//&
+                 "The amplitude of a latitudinally-dependent background\n"//&
                  "viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).", &
                  units = "m2 s-1",  default=0.0)
     if (Kh_sin_lat>0. .or. get_all) &
       call get_param(param_file, mdl, "KH_PWR_OF_SINE", Kh_pwr_of_sine, &
-                 "The power used to raise SIN(LAT) when using a latidutinally-\n"//&
+                 "The power used to raise SIN(LAT) when using a latitudinally-\n"//&
                  "dependent background viscosity.", &
                  units = "nondim",  default=4.0)
 

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -1808,7 +1808,7 @@ subroutine teleport(En, NAngle, CS, G, LB)
 
 end subroutine teleport
 
-!> Rotates points in the halos where required to accomodate
+!> Rotates points in the halos where required to accommodate
 !! changes in grid orientation, such as at the tripolar fold.
 subroutine correct_halo_rotation(En, test, G, NAngle)
   type(ocean_grid_type),      intent(in)    :: G    !< The ocean's grid structure
@@ -2239,7 +2239,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   call get_param(param_file, mdl, "INTERNAL_TIDE_SIMPLE_2ND_PPM", CS%simple_2nd, &
                  "If true, CONTINUITY_PPM uses a simple 2nd order \n"//&
                  "(arithmetic mean) interpolation of the edge values. \n"//&
-                 "This may give better PV conservation propterties. While \n"//&
+                 "This may give better PV conservation properties. While \n"//&
                  "it formally reduces the accuracy of the continuity \n"//&
                  "solver itself in the strongly advective limit, it does \n"//&
                  "not reduce the overall order of accuracy of the dynamic \n"//&

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -108,10 +108,6 @@ type, public :: int_tide_CS ; private
                         !< The internal wave energy density as a function of (i,j,angle); temporary for restart
   real, allocatable, dimension(:) :: frequency  !< The frequency of each band [s-1].
 
-  !### Delete later
-  real    :: int_tide_source_x !< X Location of generation site for internal tide testing
-  real    :: int_tide_source_y !< Y Location of generation site for internal tide testing
-
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to regulate the
                         !! timing of diagnostic output.
   type(wave_structure_CS), pointer :: wave_structure_CSp => NULL()
@@ -215,10 +211,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
     frac_per_sector = 1.0 / real(CS%nAngle * CS%nMode * CS%nFreq)
     do m=1,CS%nMode ; do fr=1,CS%nFreq ; do a=1,CS%nAngle ; do j=js,je ; do i=is,ie
       f2 = 0.25*US%s_to_T**2*((G%CoriolisBu(I,J)**2 + G%CoriolisBu(I-1,J-1)**2) + &
-                              (G%CoriolisBu(I,J-1)**2 + G%CoriolisBu(I-1,J)**2))
-      !### For rotational symmetry this should be
-      ! f2 = 0.25*US%s_to_T**2*((G%CoriolisBu(I,J)**2 + G%CoriolisBu(I-1,J-1)**2) + &
-      !                         (G%CoriolisBu(I-1,J)**2 + G%CoriolisBu(I,J-1)**2))
+                              (G%CoriolisBu(I-1,J)**2 + G%CoriolisBu(I,J-1)**2))
       if (CS%frequency(fr)**2 > f2) &
         CS%En(i,j,a,fr,m) = CS%En(i,j,a,fr,m) + &
                             dt*frac_per_sector*(1-CS%q_itides)*TKE_itidal_input(i,j)
@@ -228,10 +221,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
     a = CS%energized_angle
     do m=1,CS%nMode ; do fr=1,CS%nFreq ; do j=js,je ; do i=is,ie
       f2 = 0.25*US%s_to_T**2*((G%CoriolisBu(I,J)**2 + G%CoriolisBu(I-1,J-1)**2) + &
-                              (G%CoriolisBu(I,J-1)**2 + G%CoriolisBu(I-1,J)**2))
-      !### For rotational symmetry this should be
-      ! f2 = 0.25*US%s_to_T**2*((G%CoriolisBu(I,J)**2 + G%CoriolisBu(I-1,J-1)**2) + &
-      !                         (G%CoriolisBu(I-1,J)**2 + G%CoriolisBu(I,J-1)**2))
+                              (G%CoriolisBu(I-1,J)**2 + G%CoriolisBu(I,J-1)**2))
       if (CS%frequency(fr)**2 > f2) &
         CS%En(i,j,a,fr,m) = CS%En(i,j,a,fr,m) + &
                             dt*frac_per_sector**(1-CS%q_itides)*TKE_itidal_input(i,j)
@@ -427,11 +417,8 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
       do j=jsd,jed ; do i=isd,ied
         id_g = i + G%idg_offset ; jd_g = j + G%jdg_offset ! for debugging
         ! Calculate horizontal phase velocity magnitudes
-        f2 = 0.25*US%s_to_T**2*(G%CoriolisBu(I,J)**2 + G%CoriolisBu(I-1,J)**2 + &
-                                G%CoriolisBu(I,J-1)**2 + G%CoriolisBu(I-1,J-1)**2 )
-        !### For rotational symmetry this should be
-        ! f2 = 0.25*US%s_to_T**2*((G%CoriolisBu(I,J)**2 + G%CoriolisBu(I-1,J-1)**2) + &
-        !                         (G%CoriolisBu(I-1,J)**2 + G%CoriolisBu(I,J-1)**2))
+        f2 = 0.25*US%s_to_T**2*((G%CoriolisBu(I,J)**2 + G%CoriolisBu(I-1,J-1)**2) + &
+                                (G%CoriolisBu(I-1,J)**2 + G%CoriolisBu(I,J-1)**2))
         Kmag2 = (freq2 - f2) / (cn(i,j,m)**2 + cn_subRO**2)
         c_phase = 0.0
         if (Kmag2 > 0.0) then
@@ -2423,12 +2410,6 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   !G%dx_Cv(:,:) = 0.0
   !call MOM_read_data(filename, 'dx_Cv', G%dx_Cv, G%domain, timelevel=1)
   !call pass_var(G%dx_Cv,G%domain)
-
-  ! For debugging - delete later
-  call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_X", CS%int_tide_source_x, &
-                "X Location of generation site for internal tide", default=1.)
-  call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_Y", CS%int_tide_source_y, &
-                "Y Location of generation site for internal tide", default=1.)
 
   ! Register maps of reflection parameters
   CS%id_refl_ang = register_diag_field('ocean_model', 'refl_angle', diag%axesT1, &

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -933,11 +933,12 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
            "MOM_lateral_mixing_coeffs.F90, VarMix_init:"//&
            "When INTERPOLATE_RES_FN=True, VISC_RES_FN_POWER must equal KH_RES_FN_POWER.")
     endif
+    !### Change the default of GILL_EQUATORIAL_LD to True.
     call get_param(param_file, mdl, "GILL_EQUATORIAL_LD", Gill_equatorial_Ld, &
                  "If true, uses Gill's definition of the baroclinic\n"//&
                  "equatorial deformation radius, otherwise, if false, use\n"//&
-                 "Pedlosky's definition. These definitions differ by a factor\n"//&
-                 "of 2 infront of the beta term in the denominator. Gill's"//&
+                 "Pedlosky's definition. These definitions differ by a factor \n"//&
+                 "of 2 in front of the beta term in the denominator. Gill's \n"//&
                  "is the more appropriate definition.\n", default=.false.)
     if (Gill_equatorial_Ld) then
       oneOrTwo = 2.0

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1742,7 +1742,7 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
   if (CS%max_Khth_CFL < 0.0) CS%max_Khth_CFL = 0.0
   call get_param(param_file, mdl, "DETANGLE_INTERFACES", CS%detangle_interfaces, &
                  "If defined add 3-d structured enhanced interface height \n"//&
-                 "diffusivities to horizonally smooth jagged layers.", &
+                 "diffusivities to horizontally smooth jagged layers.", &
                  default=.false.)
   CS%detangle_time = 0.0
   if (CS%detangle_interfaces) &

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -201,7 +201,7 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
 
   if (nc > MAX_CONSTITUENTS) then
     write(mesg,'("Increase MAX_CONSTITUENTS in MOM_tidal_forcing.F90 to at least",I3, &
-                &"to accomodate all the registered tidal constituents.")') nc
+                &"to accommodate all the registered tidal constituents.")') nc
     call MOM_error(FATAL, "MOM_tidal_forcing"//mesg)
   endif
 

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -328,19 +328,19 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
                  '\t ParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT',         &
                  default='SimpleShapes')
   if (CS%MatchTechnique == 'ParabolicNonLocal') then
-     ! This forces Cs2 (Cs in non-local computation) to equal 1 for parabolic non-local option.
-     !  May be used during CVMix initialization.
-     Cs_is_one=.true.
+    ! This forces Cs2 (Cs in non-local computation) to equal 1 for parabolic non-local option.
+    !  May be used during CVMix initialization.
+    Cs_is_one=.true.
   endif
   if (CS%MatchTechnique == 'ParabolicNonLocal' .or. CS%MatchTechnique == 'SimpleShapes') then
-     ! if gradient won't be matched, lnoDGat1=.true.
-     lnoDGat1=.true.
+    ! if gradient won't be matched, lnoDGat1=.true.
+    lnoDGat1=.true.
   endif
 
   ! safety check to avoid negative diff/visc
   if (CS%MatchTechnique == 'MatchBoth' .and. (CS%interpType2 == 'cubic' .or. &
-     CS%interpType2 == 'quadratic')) then
-     call MOM_error(FATAL,"If MATCH_TECHNIQUE=MatchBoth, INTERP_TYPE2 must be set to \n"//&
+      CS%interpType2 == 'quadratic')) then
+    call MOM_error(FATAL,"If MATCH_TECHNIQUE=MatchBoth, INTERP_TYPE2 must be set to \n"//&
                "linear or LMD94 (recommended) to avoid negative viscosity and diffusivity.\n"//&
                "Please select one of these valid options." )
   endif
@@ -349,15 +349,15 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
                  'If True, zeroes the KPP diffusivity and viscosity; for testing purpose.',&
                  default=.False.)
   call get_param(paramFile, mdl, 'KPP_IS_ADDITIVE', CS%KPPisAdditive,                &
-                 'If true, adds KPP diffusivity to diffusivity from other schemes.'//&
+                 'If true, adds KPP diffusivity to diffusivity from other schemes.\n'//&
                  'If false, KPP is the only diffusivity wherever KPP is non-zero.',  &
                  default=.True.)
   call get_param(paramFile, mdl, 'KPP_SHORTWAVE_METHOD',string,                      &
-                 'Determines contribution of shortwave radiation to KPP surface '// &
+                 'Determines contribution of shortwave radiation to KPP surface \n'// &
                  'buoyancy flux.  Options include:\n'//                             &
                  '  ALL_SW: use total shortwave radiation\n'//                      &
-                 '  MXL_SW:  use shortwave radiation absorbed by mixing layer\n'//  &
-                 '  LV1_SW:  use shortwave radiation absorbed by top model layer',  &
+                 '  MXL_SW: use shortwave radiation absorbed by mixing layer\n'//  &
+                 '  LV1_SW: use shortwave radiation absorbed by top model layer',  &
                  default='MXL_SW')
   select case ( trim(string) )
     case ("ALL_SW") ; CS%SW_METHOD = SW_METHOD_ALL_SW

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -3544,7 +3544,7 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
                  "heating depth of an exponential profile by moving some \n"//&
                  "of the heating upward in the water column.", default=.false.)
   call get_param(param_file, mdl, "DO_RIVERMIX", CS%do_rivermix, &
-                 "If true, apply additional mixing whereever there is \n"//&
+                 "If true, apply additional mixing wherever there is \n"//&
                  "runoff, so that it is mixed down to RIVERMIX_DEPTH, \n"//&
                  "if the ocean is that deep.", default=.false.)
   if (CS%do_rivermix) &

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -338,8 +338,7 @@ subroutine adjust_salt(h, tv, G, GV, CS, halo)
 
   salt_add_col(:,:) = 0.0
 
-!$OMP parallel do default(none) shared(is,ie,js,je,nz,G,GV,tv,h,salt_add_col, S_min) &
-!$OMP                          private(mc)
+  !$OMP parallel do default(none) private(mc)
   do j=js,je
     do k=nz,1,-1 ; do i=is,ie
       if ((G%mask2dT(i,j) > 0.0) .and. &
@@ -643,7 +642,8 @@ end subroutine find_uv_at_h
 
 !> Diagnose a mixed layer depth (MLD) determined by a given density difference with the surface.
 !> This routine is appropriate in MOM_diabatic_driver due to its position within the time stepping.
-subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, US, diagPtr, id_N2subML, id_MLDsq)
+subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, US, diagPtr, &
+                                          id_N2subML, id_MLDsq, dz_subML)
   type(ocean_grid_type),   intent(in) :: G           !< Grid type
   type(verticalGrid_type), intent(in) :: GV          !< ocean vertical grid structure
   type(unit_scale_type),   intent(in) :: US          !< A dimensional unit scaling type
@@ -656,19 +656,25 @@ subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, US,
   type(diag_ctrl),         pointer    :: diagPtr     !< Diagnostics structure
   integer,       optional, intent(in) :: id_N2subML  !< Optional handle (ID) of subML stratification
   integer,       optional, intent(in) :: id_MLDsq    !< Optional handle (ID) of squared MLD
+  real,          optional, intent(in) :: dz_subML    !< The distance over which to calculate N2subML
+                                                     !! or 50 m if missing [Z ~> m]
 
   ! Local variables
   real, dimension(SZI_(G)) :: deltaRhoAtKm1, deltaRhoAtK ! Density differences [kg m-3].
-  real, dimension(SZI_(G)) :: pRef_MLD, pRef_N2     ! Reference pressures [Pa].
-  real, dimension(SZI_(G)) :: dK, dKm1, d1          ! Depths [Z ~> m].
-  real, dimension(SZI_(G)) :: rhoSurf, rhoAtK, rho1 ! Densities used for N2 [kg m-3].
+  real, dimension(SZI_(G)) :: pRef_MLD, pRef_N2 ! Reference pressures [Pa].
+  real, dimension(SZI_(G)) :: H_subML, dH_N2    ! Summed thicknesses used in N2 calculation [H ~> m].
+  real, dimension(SZI_(G)) :: T_subML, T_deeper ! Temperatures used in the N2 calculation [degC].
+  real, dimension(SZI_(G)) :: S_subML, S_deeper ! Salinities used in the N2 calculation [ppt].
+  real, dimension(SZI_(G)) :: rho_subML, rho_deeper ! Densities used in the N2 calculation [kg m-3].
+  real, dimension(SZI_(G)) :: dK, dKm1          ! Depths [Z ~> m].
+  real, dimension(SZI_(G)) :: rhoSurf          ! Density used in finding the mixedlayer depth [kg m-3].
   real, dimension(SZI_(G), SZJ_(G)) :: MLD     ! Diagnosed mixed layer depth [Z ~> m].
   real, dimension(SZI_(G), SZJ_(G)) :: subMLN2 ! Diagnosed stratification below ML [s-2].
   real, dimension(SZI_(G), SZJ_(G)) :: MLD2    ! Diagnosed MLD^2 [Z2 ~> m2].
-  real :: Rho_x_gE         ! The product of density, gravitational acceleartion and a unit
-                           ! conversion factor [kg m-1 Z-1 s-2 ~> kg m-2 s-2].
+  logical, dimension(SZI_(G)) :: N2_region_set ! If true, all necessary values for calculating N2
+                                               ! have been stored already.
   real :: gE_Rho0          ! The gravitational acceleration divided by a mean density [m4 s-2 kg-1].
-  real :: dz_subML         ! Depth below ML over which to diagnose stratification [Z ~> m].
+  real :: dH_subML         ! Depth below ML over which to diagnose stratification [H ~> m].
   integer :: i, j, is, ie, js, je, k, nz, id_N2, id_SQ
   real :: aFac, ddRho
 
@@ -676,12 +682,12 @@ subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, US,
 
   id_SQ = -1 ; if (PRESENT(id_N2subML)) id_SQ = id_MLDsq
 
-  Rho_x_gE = GV%g_Earth * GV%Rho0
   gE_rho0 = US%m_to_Z**2 * GV%g_Earth / GV%Rho0
-  dz_subML = 50.*US%m_to_Z
+  dH_subML = 50.*GV%m_to_H  ; if (present(dz_subML)) dH_subML = GV%Z_to_H*dz_subML
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
-  pRef_MLD(:) = 0. ; pRef_N2(:) = 0.
+
+  pRef_MLD(:) = 0.0
   do j=js,je
     do i=is,ie ; dK(i) = 0.5 * h(i,j,1) * GV%H_to_Z ; enddo ! Depth of center of surface layer
     call calculate_density(tv%T(:,j,1), tv%S(:,j,1), pRef_MLD, rhoSurf, is, ie-is+1, tv%eqn_of_state)
@@ -689,11 +695,10 @@ subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, US,
       deltaRhoAtK(i) = 0.
       MLD(i,j) = 0.
       if (id_N2>0) then
-        subMLN2(i,j) = 0.
-        rho1(i) = 0.
-        d1(i) = 0.
-        pRef_N2(i) = Rho_x_gE * h(i,j,1) * GV%H_to_Z ! Boussinesq approximation!!!! ?????
-        !### This should be: pRef_N2(i) = GV%H_to_Pa * h(i,j,1) ! This might change answers at roundoff.
+        subMLN2(i,j) = 0.0
+        H_subML(i) = h(i,j,1) ; dH_N2(i) = 0.0
+        T_subML(i) = 0.0  ; S_subML(i) = 0.0 ; T_deeper(i) = 0.0 ; S_deeper(i) = 0.0
+        N2_region_set(i) = (G%mask2dT(i,j)<0.5) ! Only need to work on ocean points.
       endif
     enddo
     do k=2,nz
@@ -702,27 +707,23 @@ subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, US,
         dK(i) = dK(i) + 0.5 * ( h(i,j,k) + h(i,j,k-1) ) * GV%H_to_Z ! Depth of center of layer K
       enddo
 
-      ! Stratification, N2, immediately below the mixed layer, averaged over at least 50 m.
+      ! Prepare to calculate stratification, N2, immediately below the mixed layer by finding
+      ! the cells that extend over at least dz_subML.
       if (id_N2>0) then
-        do i=is,ie
-          pRef_N2(i) = pRef_N2(i) + Rho_x_gE * h(i,j,k) * GV%H_to_Z ! Boussinesq approximation!!!! ?????
-          !### This should be: pRef_N2(i) = pRev_N2(i) + GV%H_to_Pa * h(i,j,k)
-          !### This might change answers at roundoff.
-        enddo
-        call calculate_density(tv%T(:,j,k), tv%S(:,j,k), pRef_N2, rhoAtK, is, ie-is+1, tv%eqn_of_state)
-        do i=is,ie
-          if (MLD(i,j)>0. .and. subMLN2(i,j)==0.) then ! This block is below the mixed layer
-            if (d1(i)==0.) then ! Record the density, depth and pressure, immediately below the ML
-              rho1(i) = rhoAtK(i)
-              d1(i) = dK(i)
-              !### It looks to me like there is bad logic here. - RWH
-              ! Use pressure at the bottom of the upper layer used in calculating d/dz rho
-              pRef_N2(i) = pRef_N2(i) + Rho_x_gE * h(i,j,k) * GV%H_to_Z ! Boussinesq approximation!!!! ?????
-              !### This line should be: pRef_N2(i) = pRev_N2(i) + GV%H_to_Pa * h(i,j,k)
-              !### This might change answers at roundoff.
-            endif
-            if (d1(i)>0. .and. dK(i)-d1(i)>=dz_subML) then
-              subMLN2(i,j) = gE_rho0 * (rho1(i)-rhoAtK(i)) / (d1(i) - dK(i))
+         do i=is,ie
+          if (MLD(i,j)==0.0) then  ! Still in the mixed layer.
+            H_subML(i) = H_subML(i) + h(i,j,k)
+          elseif (.not.N2_region_set(i)) then ! This block is below the mixed layer, but N2 has not been found yet.
+            if (dH_N2(i)==0.0) then ! Record the temperature, salinity, pressure, immediately below the ML
+              T_subML(i) = tv%T(i,j,k) ; S_subML(i) = tv%S(i,j,k)
+              H_subML(i) = H_subML(i) + 0.5 * h(i,j,k) ! Start midway through this layer.
+              dH_N2(i) = 0.5 * h(i,j,k)
+            elseif (dH_N2(i) + h(i,j,k) < dH_subML) then
+              dH_N2(i) = dH_N2(i) + h(i,j,k)
+            else  ! This layer includes the base of the region where N2 is calculated.
+              T_deeper(i) = tv%T(i,j,k) ; S_deeper(i) = tv%S(i,j,k)
+              dH_N2(i) = dH_N2(i) + 0.5 * h(i,j,k)
+              N2_region_set(i) = .true.
             endif
           endif
         enddo ! i-loop
@@ -744,11 +745,21 @@ subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, US,
     enddo ! k-loop
     do i=is,ie
       if ((MLD(i,j)==0.) .and. (deltaRhoAtK(i)<densityDiff)) MLD(i,j) = dK(i) ! Assume mixing to the bottom
-   !  if (id_N2>0 .and. subMLN2(i,j)==0. .and. d1(i)>0. .and. dK(i)-d1(i)>0.) then
-   !    ! Use what ever stratification we can, measured over what ever distance is available
-   !    subMLN2(i,j) = gE_rho0 * (rho1(i)-rhoAtK(i)) / (d1(i) - dK(i))
-   !  endif
     enddo
+
+    if (id_N2>0) then  ! Now actually calculate stratification, N2, below the mixed layer.
+      do i=is,ie ; pRef_N2(i) = GV%H_to_Pa * (H_subML(i) + 0.5*dH_N2(i)) ; enddo
+      ! if ((.not.N2_region_set(i)) .and. (dH_N2(i) > 0.5*dH_subML)) then
+      !    ! Use whatever stratification we can, measured over whatever distance is available?
+      !    T_deeper(i) = tv%T(i,j,nz) ; S_deeper(i) = tv%S(i,j,nz)
+      !    N2_region_set(i) = .true.
+      ! endif
+      call calculate_density(T_subML, S_subML, pRef_N2, rho_subML, is, ie-is+1, tv%eqn_of_state)
+      call calculate_density(T_deeper, S_deeper, pRef_N2, rho_deeper, is, ie-is+1, tv%eqn_of_state)
+      do i=is,ie ; if ((G%mask2dT(i,j)>0.5) .and. N2_region_set(i)) then
+        subMLN2(i,j) =  gE_rho0 * (rho_deeper(i) - rho_subML(i)) / (GV%H_to_z * dH_N2(i))
+      endif ; enddo
+    endif
   enddo ! j-loop
 
   if (id_MLD > 0) call post_data(id_MLD, MLD, diagPtr)
@@ -1101,13 +1112,12 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, h, tv, &
           ! Diagnostics of heat content associated with mass fluxes
           if (associated(fluxes%heat_content_massin))                             &
             fluxes%heat_content_massin(i,j) = fluxes%heat_content_massin(i,j) +   &
-                         tv%T(i,j,k) * max(0.,dThickness) * GV%H_to_kg_m2 * fluxes%C_p * Idt
+                         T2d(i,k) * max(0.,dThickness) * GV%H_to_kg_m2 * fluxes%C_p * Idt
           if (associated(fluxes%heat_content_massout))                            &
             fluxes%heat_content_massout(i,j) = fluxes%heat_content_massout(i,j) + &
-                         tv%T(i,j,k) * min(0.,dThickness) * GV%H_to_kg_m2 * fluxes%C_p * Idt
+                         T2d(i,k) * min(0.,dThickness) * GV%H_to_kg_m2 * fluxes%C_p * Idt
           if (associated(tv%TempxPmE)) tv%TempxPmE(i,j) = tv%TempxPmE(i,j) + &
-                         tv%T(i,j,k) * dThickness * GV%H_to_kg_m2
-!### NOTE: tv%T should be T2d in the expressions above.
+                         T2d(i,k) * dThickness * GV%H_to_kg_m2
 
           ! Update state by the appropriate increment.
           hOld     = h2d(i,k)               ! Keep original thickness in hand

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -2911,12 +2911,11 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
                  default=.true.)
 
   call get_param(param_file, mdl, "AGGREGATE_FW_FORCING", CS%aggregate_FW_forcing, &
-                 "If true, the net incoming and outgoing fresh water fluxes are combined\n"//&
-                 "and applied as either incoming or outgoing depending on the sign of the net.\n"//&
-                 "If false, the net incoming fresh water flux is added to the model and\n"//&
-                 "thereafter the net outgoing is removed from the updated state."//&
-                 "into the first non-vanished layer for which the column remains stable", &
-                 default=.true.)
+                 "If true, the net incoming and outgoing fresh water fluxes are combined \n"//&
+                 "and applied as either incoming or outgoing depending on the sign of the net. \n"//&
+                 "If false, the net incoming fresh water flux is added to the model and \n"//&
+                 "thereafter the net outgoing is removed from the topmost non-vanished \n"//&
+                 "layers of the updated state.", default=.true.)
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -174,6 +174,8 @@ type, public:: diabatic_CS; private
   logical :: debug_energy_req        !< If true, test the mixing energy requirement code.
   type(diag_ctrl), pointer :: diag   !< structure used to regulate timing of diagnostic output
   real :: MLDdensityDifference       !< Density difference used to determine MLD_user
+  real :: dz_subML_N2                !< The distance over which to calculate a diagnostic of the
+                                     !! average stratification at the base of the mixed layer [Z ~> m].
   integer :: nsw                     !< SW_NBANDS
 
   !>@{ Diagnostic IDs
@@ -1100,7 +1102,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
 
   if (CS%id_MLD_003 > 0 .or. CS%id_subMLN2 > 0 .or. CS%id_mlotstsq > 0) then
     call diagnoseMLDbyDensityDifference(CS%id_MLD_003, h, tv, 0.03, G, GV, US, CS%diag, &
-                                        id_N2subML=CS%id_subMLN2, id_MLDsq=CS%id_mlotstsq)
+                                        id_N2subML=CS%id_subMLN2, id_MLDsq=CS%id_mlotstsq, dz_subML=CS%dz_subML_N2)
   endif
   if (CS%id_MLD_0125 > 0) then
     call diagnoseMLDbyDensityDifference(CS%id_MLD_0125, h, tv, 0.125, G, GV, US, CS%diag)
@@ -2397,7 +2399,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
   if (CS%id_MLD_003 > 0 .or. CS%id_subMLN2 > 0 .or. CS%id_mlotstsq > 0) then
     call diagnoseMLDbyDensityDifference(CS%id_MLD_003, h, tv, 0.03, G, GV, US, CS%diag, &
-                                        id_N2subML=CS%id_subMLN2, id_MLDsq=CS%id_mlotstsq)
+                                        id_N2subML=CS%id_subMLN2, id_MLDsq=CS%id_mlotstsq, dz_subML=CS%dz_subML_N2)
   endif
   if (CS%id_MLD_0125 > 0) then
     call diagnoseMLDbyDensityDifference(CS%id_MLD_0125, h, tv, 0.125, G, GV, US, CS%diag)
@@ -3030,6 +3032,10 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
                  "layer depth, MLD_user, following the definition of Levitus 1982. \n"//&
                  "The MLD is the depth at which the density is larger than the\n"//&
                  "surface density by the specified amount.", units='kg/m3', default=0.1)
+  call get_param(param_file, mdl, "DIAG_DEPTH_SUBML_N2", CS%dz_subML_N2, &
+                 "The distance over which to calculate a diagnostic of the \n"//&
+                 "stratification at the base of the mixed layer.", &
+                 units='m', default=50.0, scale=US%m_to_Z)
 
   ! diagnostics making use of the z-gridding code
   if (associated(diag_to_Z_CSp)) then

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -2136,7 +2136,7 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
                  "decreases the PBL diffusivity.", units="nondim", default=1.0)
   call get_param(param_file, mdl, "USE_MLD_ITERATION", CS%USE_MLD_ITERATION,    &
                  "A logical that specifies whether or not to use the \n"//      &
-                 "distance to the bottom of the actively turblent boundary \n"//&
+                 "distance to the bottom of the actively turbulent boundary \n"//&
                  "layer to help set the EPBL length scale.", default=.false.)
   call get_param(param_file, mdl, "ORIG_MLD_ITERATION", CS%ORIG_MLD_ITERATION,  &
                  "A logical that specifies whether or not to use the \n"//      &

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -316,7 +316,7 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
                "A scaling factor for the roughness amplitude with n"//&
                "INT_TIDE_DISSIPATION.",  units="nondim", default=1.0)
   call get_param(param_file, mdl, "TKE_ITIDE_MAX", CS%TKE_itide_max, &
-               "The maximum internal tide energy source availble to mix \n"//&
+               "The maximum internal tide energy source available to mix \n"//&
                "above the bottom boundary layer with INT_TIDE_DISSIPATION.", &
                units="W m-2",  default=1.0e3)
 

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -103,7 +103,7 @@ type, public :: set_diffusivity_CS ; private
                           !! decay scale determined by the minimum of
                           !! (1) The depth of the mixed layer, or
                           !! (2) An Ekman length scale.
-                          !! Energy availble to drive mixing below the mixed layer is
+                          !! Energy available to drive mixing below the mixed layer is
                           !! given by E = ML_RAD_COEFF*MSTAR*USTAR**3.  Optionally, if
                           !! ML_rad_TKE_decay is true, this is further reduced by a factor
                           !! of exp(-h_ML*Idecay_len_TkE), where Idecay_len_TKE is
@@ -2045,7 +2045,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
     call get_param(param_file, mdl, "BBL_MIXING_AS_MAX", CS%BBL_mixing_as_max, &
                  "If true, take the maximum of the diffusivity from the \n"//&
                  "BBL mixing and the other diffusivities. Otherwise, \n"//&
-                 "diffusiviy from the BBL_mixing is simply added.", &
+                 "diffusivity from the BBL_mixing is simply added.", &
                  default=.true.)
     call get_param(param_file, mdl, "USE_LOTW_BBL_DIFFUSIVITY", CS%use_LOTW_BBL_diffusivity, &
                  "If true, uses a simple, imprecise but non-coordinate dependent, model\n"//&
@@ -2064,7 +2064,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
   call get_param(param_file, mdl, "SIMPLE_TKE_TO_KD", CS%simple_TKE_to_Kd, &
                  "If true, uses a simple estimate of Kd/TKE that will\n"//&
                  "work for arbitrary vertical coordinates. If false,\n"//&
-                 "calculates Kd/TKE and bounds based on exact energetics/n"//&
+                 "calculates Kd/TKE and bounds based on exact energetics\n"//&
                  "for an isopycnal layer-formulation.", &
                  default=.false.)
 
@@ -2179,8 +2179,8 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
   endif
 
   call get_param(param_file, mdl, "DOUBLE_DIFFUSION", CS%double_diffusion, &
-                 "If true, increase diffusivitives for temperature or salt \n"//&
-                 "based on double-diffusive paramaterization from MOM4/KPP.", &
+                 "If true, increase diffusivites for temperature or salt \n"//&
+                 "based on double-diffusive parameterization from MOM4/KPP.", &
                  default=.false.)
 
   if (CS%double_diffusion) then

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1837,8 +1837,8 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   if (.not.adiabatic) then
     CS%RiNo_mix = kappa_shear_is_used(param_file)
     call get_param(param_file, mdl, "DOUBLE_DIFFUSION", differential_diffusion, &
-                 "If true, increase diffusivitives for temperature or salt \n"//&
-                 "based on double-diffusive paramaterization from MOM4/KPP.", &
+                 "If true, increase diffusivites for temperature or salt \n"//&
+                 "based on double-diffusive parameterization from MOM4/KPP.", &
                  default=.false.)
     use_CVMix_ddiff = CVMix_ddiff_is_used(param_file)
   endif
@@ -1941,7 +1941,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
 
   call get_param(param_file, mdl, "ADD_KV_SLOW", visc%add_Kv_slow, &
                  "If true, the background vertical viscosity in the interior \n"//&
-                 "(i.e., tidal + background + shear + convenction) is addded \n"// &
+                 "(i.e., tidal + background + shear + convection) is added \n"// &
                  "when computing the coupling coefficient. The purpose of this \n"// &
                  "flag is to be able to recover previous answers and it will likely \n"// &
                  "be removed in the future since this option should always be true.", &

--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -188,7 +188,7 @@ end subroutine initialize_sponge
 
 !> This subroutine sets up diagnostics for the sponges.  It is separate
 !! from initialize_sponge because it requires fields that are not readily
-!! availble where initialize_sponge is called.
+!! available where initialize_sponge is called.
 subroutine init_sponge_diags(Time, G, diag, CS)
   type(time_type),       target, intent(in)    :: Time !< The current model time
   type(ocean_grid_type),         intent(in)    :: G    !< The ocean's grid structure

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -298,7 +298,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
                    "dissipation with INT_TIDE_DISSIPATION. Valid values are:\n"//&
                    "\t STLAURENT_02 - Use the St. Laurent et al exponential \n"//&
                    "\t                decay profile.\n"//&
-                   "\t POLZIN_09 - Use the Polzin WKB-streched algebraic \n"//&
+                   "\t POLZIN_09 - Use the Polzin WKB-stretched algebraic \n"//&
                    "\t                decay profile.", &
                    default=STLAURENT_PROFILE_STRING)
       int_tide_profile_str = uppercase(int_tide_profile_str)
@@ -332,7 +332,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
                  "dissipation with LEE_WAVE_DISSIPATION. Valid values are:\n"//&
                  "\t STLAURENT_02 - Use the St. Laurent et al exponential \n"//&
                  "\t                decay profile.\n"//&
-                 "\t POLZIN_09 - Use the Polzin WKB-streched algebraic \n"//&
+                 "\t POLZIN_09 - Use the Polzin WKB-stretched algebraic \n"//&
                  "\t                decay profile.", &
                  default=STLAURENT_PROFILE_STRING)
     tmpstr = uppercase(tmpstr)
@@ -365,7 +365,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
                  units="nondim", default=0.0697)
     call get_param(param_file, mdl, "NBOTREF_POLZIN", CS%Nbotref_Polzin, &
                  "When the Polzin decay profile is used, this is the \n"//&
-                 "Rreference value of the buoyancy frequency at the ocean \n"//&
+                 "reference value of the buoyancy frequency at the ocean \n"//&
                  "bottom in the Polzin formulation for the vertical \n"//&
                  "scale of decay for the tidal energy dissipation.", &
                  units="s-1", default=9.61e-4)
@@ -425,10 +425,10 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
     call safe_alloc_ptr(CS%tideamp,is,ie,js,je) ; CS%tideamp(:,:) = CS%utide
 
     call get_param(param_file, mdl, "KAPPA_H2_FACTOR", CS%kappa_h2_factor, &
-                 "A scaling factor for the roughness amplitude with n"//&
+                 "A scaling factor for the roughness amplitude with \n"//&
                  "INT_TIDE_DISSIPATION.",  units="nondim", default=1.0)
     call get_param(param_file, mdl, "TKE_ITIDE_MAX", CS%TKE_itide_max, &
-                 "The maximum internal tide energy source availble to mix \n"//&
+                 "The maximum internal tide energy source available to mix \n"//&
                  "above the bottom boundary layer with INT_TIDE_DISSIPATION.", &
                  units="W m-2",  default=1.0e3)
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1696,7 +1696,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
                  "to be reported; the default is CFL_TRUNCATE.", &
                  units="nondim", default=CS%CFL_trunc)
   call get_param(param_file, mdl, "CFL_TRUNCATE_RAMP_TIME", CS%truncRampTime, &
-                 "The time over which the CFL trunction value is ramped\n"//&
+                 "The time over which the CFL truncation value is ramped\n"//&
                  "up at the beginning of the run.", &
                  units="s", default=0.)
   CS%CFL_truncE = CS%CFL_trunc

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -1415,13 +1415,13 @@ subroutine tracer_hor_diff_init(Time, G, param_file, diag, EOS, CS)
                  units="m2 s-1", default=0.0)
   call get_param(param_file, mdl, "KHTR_PASSIVITY_COEFF", CS%KhTr_passivity_coeff, &
                  "The coefficient that scales deformation radius over \n"//&
-                 "grid-spacing in passivity, where passiviity is the ratio \n"//&
-                 "between along isopycnal mxiing of tracers to thickness mixing. \n"//&
+                 "grid-spacing in passivity, where passivity is the ratio \n"//&
+                 "between along isopycnal mixing of tracers to thickness mixing. \n"//&
                  "A non-zero value enables this parameterization.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "KHTR_PASSIVITY_MIN", CS%KhTr_passivity_min, &
                  "The minimum passivity which is the ratio between \n"//&
-                 "along isopycnal mxiing of tracers to thickness mixing. \n", &
+                 "along isopycnal mixing of tracers to thickness mixing. \n", &
                  units="nondim", default=0.5)
   call get_param(param_file, mdl, "DIFFUSE_ML_TO_INTERIOR", CS%Diffuse_ML_interior, &
                  "If true, enable epipycnal mixing between the surface \n"//&

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -140,7 +140,7 @@ function register_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
 
   CS%dye_source_mindepth(:) = -1.e30
   call get_param(param_file, mdl, "DYE_SOURCE_MINDEPTH", CS%dye_source_mindepth, &
-                 "This is the minumum depth at which we inject dyes.", &
+                 "This is the minimum depth at which we inject dyes.", &
                  units="m", scale=US%m_to_Z, fail_if_missing=.true.)
   if (minval(CS%dye_source_mindepth(:)) < -1.e29*US%m_to_Z) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MINDEPTH")

--- a/src/user/Idealized_Hurricane.F90
+++ b/src/user/Idealized_Hurricane.F90
@@ -34,7 +34,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public idealized_hurricane_wind_init !Public interface to intialize the idealized
+public idealized_hurricane_wind_init !Public interface to initialize the idealized
                                      ! hurricane wind profile.
 public idealized_hurricane_wind_forcing !Public interface to update the idealized
                                         ! hurricane wind profile.

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -352,7 +352,7 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
   ! Langmuir number Options
   call get_param(param_file, mdl, "LA_DEPTH_RATIO", LA_FracHBL,              &
          "The depth (normalized by BLD) to average Stokes drift over in \n"//&
-         " Lanmguir number calculation, where La = sqrt(ust/Stokes).",       &
+         " Langmuir number calculation, where La = sqrt(ust/Stokes).",       &
          units="nondim",default=0.04)
   call get_param(param_file, mdl, "LA_MISALIGNMENT", LA_Misalignment,    &
          "Flag (logical) if using misalignment bt shear and waves in LA",&
@@ -408,7 +408,7 @@ subroutine MOM_wave_interface_init_lite(param_file)
   ! Langmuir number Options
   call get_param(param_file, mdl, "LA_DEPTH_RATIO", LA_FracHBL,              &
        "The depth (normalized by BLD) to average Stokes drift over in \n"//&
-       " Lanmguir number calculation, where La = sqrt(ust/Stokes).",       &
+       " Langmuir number calculation, where La = sqrt(ust/Stokes).",       &
        units="nondim",default=0.04)
 
   if (WaveMethod==NULL_WaveMethod) then

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -67,8 +67,7 @@ subroutine Phillips_initialize_thickness(h, G, GV, US, param_file, just_read_par
 
   if (.not.just_read) call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "HALF_STRAT_DEPTH", half_strat, &
-!### UNCOMMENT TO FIX THIS "The fractional depth where the stratification is centered.", &
-                 "The maximum depth of the ocean.", &
+                 "The fractional depth where the stratification is centered.", &
                  units="nondim", default = 0.5, do_not_log=just_read)
   call get_param(param_file, mdl, "JET_WIDTH", jet_width, &
                  "The width of the zonal-mean jet.", units="km", &


### PR DESCRIPTION
  Added a new run-time parameter to set the minimum salinity, corrected the
calculation of the diagnostic subML_N2 and corrected spelling error in
descriptions that are logged to the MOM_parameter_doc files.  By default, all
answers are bitwise identical, but there are numerous minor changes to the
MOM_parameter_doc files, which are being updated in MOM6-examples.  MOM6 commits
in this PR include:

 - NOAA-GFDL/MOM6@d927495 +Corrected spelling errors in documentation
 - NOAA-GFDL/MOM6@550308c +Corrected documentation of HALF_STRAT_DEPTH
 - NOAA-GFDL/MOM6@62c113e +Added MIN_SALINITY as a new runtime parameter.
 - NOAA-GFDL/MOM6@dc35d3a +(*)Revised the diagnostic subML_N2
 - NOAA-GFDL/MOM6@2015e63 (*)Revised propagate_int_tide code for symmetry