### PR TITLE
(*) MOM_mixed_layer_restrat [uv]Dml_diag index fix

### DIFF
--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -524,14 +524,14 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
     if (CS%id_vDml          > 0) call post_data(CS%id_vDml, vDml_diag, CS%diag)
 
     if (CS%id_uml > 0) then
-      do J=js,je ; do i=is,ie
+      do J=js,je ; do i=is-1,ie
         h_vel = 0.5*((htot_fast(i,j) + htot_fast(i+1,j)) + h_neglect)
         uDml_diag(I,j) = uDml_diag(I,j) / (0.01*h_vel) * G%IdyCu(I,j) * (PSI(0.)-PSI(-.01))
       enddo ; enddo
       call post_data(CS%id_uml, uDml_diag, CS%diag)
     endif
     if (CS%id_vml > 0) then
-      do J=js,je ; do i=is,ie
+      do J=js-1,je ; do i=is,ie
         h_vel = 0.5*((htot_fast(i,j) + htot_fast(i,j+1)) + h_neglect)
         vDml_diag(i,J) = vDml_diag(i,J) / (0.01*h_vel) * G%IdxCv(i,J) * (PSI(0.)-PSI(-.01))
       enddo ; enddo
@@ -650,54 +650,50 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
 
 !   U - Component
 !$OMP do
-  do j=js,je
-    do i=is,ie ; utimescale_diag(i,j) = 0.0 ; enddo
-    do i=is,ie ; vtimescale_diag(i,j) = 0.0 ; enddo
-    do I=is-1,ie
-      h_vel = 0.5*(htot(i,j) + htot(i+1,j)) * GV%H_to_Z
+  do j=js,je; do I=is-1,ie
+    h_vel = 0.5*(htot(i,j) + htot(i+1,j)) * GV%H_to_Z
 
-      u_star = 0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
-      absf = 0.5*US%s_to_T*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
-      ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
-      ! momentum mixing rate: pi^2*visc/h_ml^2
-      ! 0.41 is the von Karmen constant, 9.8696 = pi^2.
-      mom_mixrate = (0.41*9.8696)*u_star**2 / &
-                    (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
-      timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
+    u_star = 0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
+    absf = 0.5*US%s_to_T*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
+    ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
+    ! momentum mixing rate: pi^2*visc/h_ml^2
+    ! 0.41 is the von Karmen constant, 9.8696 = pi^2.
+    mom_mixrate = (0.41*9.8696)*u_star**2 / &
+                  (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
+    timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
 
-      timescale = timescale * CS%ml_restrat_coef
-!        timescale = timescale*(2?)*(L_def/L_MLI)*min(EKE/MKE,1.0 + G%dyCv(i,j)**2/L_def**2))
+    timescale = timescale * CS%ml_restrat_coef
+!      timescale = timescale*(2?)*(L_def/L_MLI)*min(EKE/MKE,1.0 + G%dyCv(i,j)**2/L_def**2))
 
-      utimescale_diag(I,j) = timescale
+    uDml(I) = timescale * G%mask2dCu(I,j)*G%dyCu(I,j)* &
+        G%IdxCu(I,j)*(Rml_av(i+1,j)-Rml_av(i,j)) * (h_vel**2 * GV%Z_to_H)
 
-      uDml(I) = timescale * G%mask2dCu(I,j)*G%dyCu(I,j)* &
-          G%IdxCu(I,j)*(Rml_av(i+1,j)-Rml_av(i,j)) * (h_vel**2 * GV%Z_to_H)
+    if (uDml(I) == 0) then
+      do k=1,nkml ; uhml(I,j,k) = 0.0 ; enddo
+    else
+      I2htot = 1.0 / (htot(i,j) + htot(i+1,j) + h_neglect)
+      z_topx2 = 0.0
+      ! a(k) relates the sublayer transport to uDml with a linear profile.
+      ! The sum of a(k) through the mixed layers must be 0.
+      do k=1,nkml
+        hx2 = (h(i,j,k) + h(i+1,j,k) + h_neglect)
+        a(k) = (hx2 * I2htot) * (2.0 - 4.0*(z_topx2+0.5*hx2)*I2htot)
+        z_topx2 = z_topx2 + hx2
+        if (a(k)*uDml(I) > 0.0) then
+          if (a(k)*uDml(I) > h_avail(i,j,k)) uDml(I) = h_avail(i,j,k) / a(k)
+        else
+          if (-a(k)*uDml(I) > h_avail(i+1,j,k)) uDml(I) = -h_avail(i+1,j,k)/a(k)
+        endif
+      enddo
+      do k=1,nkml
+        uhml(I,j,k) = a(k)*uDml(I)
+        uhtr(I,j,k) = uhtr(I,j,k) + uhml(I,j,k)*dt
+      enddo
+    endif
 
-      if (uDml(i) == 0) then
-        do k=1,nkml ; uhml(I,j,k) = 0.0 ; enddo
-      else
-        I2htot = 1.0 / (htot(i,j) + htot(i+1,j) + h_neglect)
-        z_topx2 = 0.0
-        ! a(k) relates the sublayer transport to uDml with a linear profile.
-        ! The sum of a(k) through the mixed layers must be 0.
-        do k=1,nkml
-          hx2 = (h(i,j,k) + h(i+1,j,k) + h_neglect)
-          a(k) = (hx2 * I2htot) * (2.0 - 4.0*(z_topx2+0.5*hx2)*I2htot)
-          z_topx2 = z_topx2 + hx2
-          if (a(k)*uDml(I) > 0.0) then
-            if (a(k)*uDml(I) > h_avail(i,j,k)) uDml(I) = h_avail(i,j,k) / a(k)
-          else
-            if (-a(k)*uDml(I) > h_avail(i+1,j,k)) uDml(I) = -h_avail(i+1,j,k)/a(k)
-          endif
-        enddo
-        do k=1,nkml
-          uhml(I,j,k) = a(k)*uDml(I)
-          uhtr(I,j,k) = uhtr(I,j,k) + uhml(I,j,k)*dt
-        enddo
-      endif
-    enddo
-    uDml_diag(is:ie,j) = uDml(is:ie)
-  enddo
+    uDml_diag(I,j) = uDml(I)
+    utimescale_diag(I,j) = timescale
+  enddo; enddo
 
 !  V- component
 !$OMP do
@@ -715,8 +711,6 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
 
     timescale = timescale * CS%ml_restrat_coef
 !        timescale = timescale*(2?)*(L_def/L_MLI)*min(EKE/MKE,1.0 + G%dyCv(i,j)**2/L_def**2))
-
-    vtimescale_diag(i,J) = timescale
 
     vDml(i) = timescale * G%mask2dCv(i,J)*G%dxCv(i,J)* &
         G%IdyCv(i,J)*(Rml_av(i,j+1)-Rml_av(i,j)) * (h_vel**2 * GV%Z_to_H)
@@ -742,9 +736,10 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
         vhtr(i,J,k) = vhtr(i,J,k) + vhml(i,J,k)*dt
       enddo
     endif
-    enddo
-    vDml_diag(is:ie,j) = vDml(is:ie)
-  enddo
+
+    vtimescale_diag(i,J) = timescale
+    vDml_diag(i,J) = vDml(i)
+  enddo; enddo
 
 !$OMP do
   do j=js,je ; do k=1,nkml ; do i=is,ie


### PR DESCRIPTION
This patch resolves a few issues related to the `uDml_diag` and `vDml_diag`
diagnostics in the `MOM_mixed_layer_restrat` module.  In both cases, the
index loops were not including the starting values (`is-1` for `uDml` and
`js-1` for `vDml`).

In `mixedlayer_restrat_BML`, `uDml_diag(is-1,:)` was never assigned a
value, since only the `uDml(is:ie,:)` values were copied to `uDml_diag`.
This produced volatile answers along these records.

There were no known issues with `vDml`, since `is:ie` spans the vector, but
we have nonetheless moved the vector copy inside of the loop.

We have introduced the following changes:

* `[uv]Dml_diag` is now evaluated in the loop, rather than relying on a
  vector copy, since there are no dependencies within the loop.

* `[uv]timescale_diag` are no longer initialised within the outer loop,
  since their values are explicitly set.

* The `I` and `J` loops are now fully nested (with whitespace changes)

In `mixedlayer_restrat_general`, we now include the edge cases
`uDml(is-1,:)` and `vDml(:,js-1)` in surface velocity estimates.

In both functions, some half-index notation (`ij`->`IJ`) was corrected
within the loops.

The following diagnostics may change value:

* `udml_restrat`
* `vdml_restrat`
* `uml_restrat`
* `vml_restrat`