### PR TITLE
+Removed hard newlines in get_param calls

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -1177,12 +1177,12 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
                  default=".")
   CS%inputdir = slasher(CS%inputdir)
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
@@ -1190,64 +1190,64 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
   call get_param(param_file, mdl, "LATENT_HEAT_VAPORIZATION", CS%latent_heat_vapor, &
                  "The latent heat of fusion.", units="J/kg", default=hlv)
   call get_param(param_file, mdl, "MAX_P_SURF", CS%max_p_surf, &
-                 "The maximum surface pressure that can be exerted by the \n"//&
-                 "atmosphere and floating sea-ice or ice shelves. This is \n"//&
-                 "needed because the FMS coupling structure does not \n"//&
-                 "limit the water that can be frozen out of the ocean and \n"//&
-                 "the ice-ocean heat fluxes are treated explicitly.  No \n"//&
+                 "The maximum surface pressure that can be exerted by the "//&
+                 "atmosphere and floating sea-ice or ice shelves. This is "//&
+                 "needed because the FMS coupling structure does not "//&
+                 "limit the water that can be frozen out of the ocean and "//&
+                 "the ice-ocean heat fluxes are treated explicitly.  No "//&
                  "limit is applied if a negative value is used.", units="Pa", &
                  default=-1.0)
   call get_param(param_file, mdl, "RESTORE_SALINITY", CS%restore_salt, &
-                 "If true, the coupled driver will add a globally-balanced \n"//&
-                 "fresh-water flux that drives sea-surface salinity \n"//&
+                 "If true, the coupled driver will add a globally-balanced "//&
+                 "fresh-water flux that drives sea-surface salinity "//&
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RESTORE_TEMPERATURE", CS%restore_temp, &
-                 "If true, the coupled driver will add a  \n"//&
-                 "heat flux that drives sea-surface temperature \n"//&
+                 "If true, the coupled driver will add a  "//&
+                 "heat flux that drives sea-surface temperature "//&
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_TO_ZERO", &
                  CS%adjust_net_srestore_to_zero, &
-                 "If true, adjusts the salinity restoring seen to zero\n"//&
+                 "If true, adjusts the salinity restoring seen to zero "//&
                  "whether restoring is via a salt flux or virtual precip.",&
                  default=CS%restore_salt)
   call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_BY_SCALING", &
                  CS%adjust_net_srestore_by_scaling, &
-                 "If true, adjustments to salt restoring to achieve zero net are\n"//&
+                 "If true, adjustments to salt restoring to achieve zero net are "//&
                  "made by scaling values without moving the zero contour.",&
                  default=.false.)
   call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_TO_ZERO", &
                  CS%adjust_net_fresh_water_to_zero, &
-                 "If true, adjusts the net fresh-water forcing seen \n"//&
+                 "If true, adjusts the net fresh-water forcing seen "//&
                  "by the ocean (including restoring) to zero.", default=.false.)
   if (CS%adjust_net_fresh_water_to_zero) &
     call get_param(param_file, mdl, "USE_NET_FW_ADJUSTMENT_SIGN_BUG", &
                  CS%use_net_FW_adjustment_sign_bug, &
-                   "If true, use the wrong sign for the adjustment to\n"//&
+                   "If true, use the wrong sign for the adjustment to "//&
                    "the net fresh-water.", default=.true.)
   call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_BY_SCALING", &
                  CS%adjust_net_fresh_water_by_scaling, &
-                 "If true, adjustments to net fresh water to achieve zero net are\n"//&
+                 "If true, adjustments to net fresh water to achieve zero net are "//&
                  "made by scaling values without moving the zero contour.",&
                  default=.false.)
   call get_param(param_file, mdl, "ICE_SALT_CONCENTRATION", &
                  CS%ice_salt_concentration, &
-                 "The assumed sea-ice salinity needed to reverse engineer the \n"//&
+                 "The assumed sea-ice salinity needed to reverse engineer the "//&
                  "melt flux (or ice-ocean fresh-water flux).", &
                  units="kg/kg", default=0.005)
   call get_param(param_file, mdl, "USE_LIMITED_PATM_SSH", CS%use_limited_P_SSH, &
-                 "If true, return the sea surface height with the \n"//&
-                 "correction for the atmospheric (and sea-ice) pressure \n"//&
-                 "limited by max_p_surf instead of the full atmospheric \n"//&
+                 "If true, return the sea surface height with the "//&
+                 "correction for the atmospheric (and sea-ice) pressure "//&
+                 "limited by max_p_surf instead of the full atmospheric "//&
                  "pressure.", default=.true.)
   call get_param(param_file, mdl, "APPROX_NET_MASS_SRC", CS%approx_net_mass_src, &
-                 "If true, use the net mass sources from the ice-ocean \n"//&
-                 "boundary type without any further adjustments to drive \n"//&
-                 "the ocean dynamics.  The actual net mass source may differ \n"//&
+                 "If true, use the net mass sources from the ice-ocean "//&
+                 "boundary type without any further adjustments to drive "//&
+                 "the ocean dynamics.  The actual net mass source may differ "//&
                  "due to internal corrections.", default=.false.)
 
   call get_param(param_file, mdl, "WIND_STAGGER", stagger, &
-                 "A case-insensitive character string to indicate the \n"//&
-                 "staggering of the input wind stress field.  Valid \n"//&
+                 "A case-insensitive character string to indicate the "//&
+                 "staggering of the input wind stress field.  Valid "//&
                  "values are 'A', 'B', or 'C'.", default="C")
   if (uppercase(stagger(1:1)) == 'A') then ; CS%wind_stagger = AGRID
   elseif (uppercase(stagger(1:1)) == 'B') then ; CS%wind_stagger = BGRID_NE
@@ -1255,14 +1255,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
   else ; call MOM_error(FATAL,"surface_forcing_init: WIND_STAGGER = "// &
                         trim(stagger)//" is invalid.") ; endif
   call get_param(param_file, mdl, "WIND_STRESS_MULTIPLIER", CS%wind_stress_multiplier, &
-                 "A factor multiplying the wind-stress given to the ocean by the\n"//&
-                 "coupler. This is used for testing and should be =1.0 for any\n"//&
+                 "A factor multiplying the wind-stress given to the ocean by the "//&
+                 "coupler. This is used for testing and should be =1.0 for any "//&
                  "production runs.", default=1.0)
 
   if (CS%restore_salt) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, "SALT_RESTORE_FILE", CS%salt_restore_file, &
@@ -1276,19 +1276,19 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
     CS%Flux_const = CS%Flux_const / 86400.0
 
     call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
-                 "If true, the restoring of salinity is applied as a salt \n"//&
+                 "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)
     call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
                  "The maximum salinity difference used in restoring terms.", &
                  units="PSU or g kg-1", default=999.0)
     call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", &
                  CS%mask_srestore_under_ice, &
-                 "If true, disables SSS restoring under sea-ice based on a frazil\n"//&
+                 "If true, disables SSS restoring under sea-ice based on a frazil "//&
                  "criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.",      &
                  default=.false.)
     call get_param(param_file, mdl, "MASK_SRESTORE_MARGINAL_SEAS", &
                  CS%mask_srestore_marginal_seas, &
-                 "If true, disable SSS restoring in marginal seas. Only used when\n"//&
+                 "If true, disable SSS restoring in marginal seas. Only used when "//&
                  "RESTORE_SALINITY is True.", default=.false.)
     call get_param(param_file, mdl, "BASIN_FILE", basin_file, &
                  "A file in which to find the basin masks, in variable 'basin'.", &
@@ -1303,14 +1303,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
       enddo ; enddo
     endif
     call get_param(param_file, mdl, "MASK_SRESTORE", CS%mask_srestore, &
-                 "If true, read a file (salt_restore_mask) containing \n"//&
+                 "If true, read a file (salt_restore_mask) containing "//&
                  "a mask for SSS restoring.", default=.false.)
   endif
 
   if (CS%restore_temp) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, "SST_RESTORE_FILE", CS%temp_restore_file, &
@@ -1327,7 +1327,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
                  "The maximum sst difference used in restoring terms.", &
                  units="degC ", default=999.0)
     call get_param(param_file, mdl, "MASK_TRESTORE", CS%mask_trestore, &
-                 "If true, read a file (temp_restore_mask) containing \n"//&
+                 "If true, read a file (temp_restore_mask) containing "//&
                  "a mask for SST restoring.", default=.false.)
 
   endif
@@ -1340,11 +1340,11 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
                  "The drag coefficient that applies to the tides.", &
                  units="nondim", default=1.0e-4)
   call get_param(param_file, mdl, "READ_TIDEAMP", CS%read_TIDEAMP, &
-                 "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
+                 "If true, read a file (given by TIDEAMP_FILE) containing "//&
                  "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
   if (CS%read_TIDEAMP) then
     call get_param(param_file, mdl, "TIDEAMP_FILE", TideAmp_file, &
-                 "The path to the file containing the spatially varying \n"//&
+                 "The path to the file containing the spatially varying "//&
                  "tidal amplitudes with INT_TIDE_DISSIPATION.", &
                  default="tideamp.nc")
     CS%utide=0.0
@@ -1379,14 +1379,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
 ! constant.
 
   call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
-                 "If true, use a 2-dimensional gustiness supplied from \n"//&
+                 "If true, use a 2-dimensional gustiness supplied from "//&
                  "an input file", default=.false.)
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                "The background gustiness in the winds.", units="Pa", &
                default=0.02)
   if (CS%read_gust_2d) then
     call get_param(param_file, mdl, "GUST_2D_FILE", gust_file, &
-                 "The file in which the wind gustiness is found in \n"//&
+                 "The file in which the wind gustiness is found in "//&
                  "variable gustiness.")
 
     call safe_alloc_ptr(CS%gust,isd,ied,jsd,jed)
@@ -1396,31 +1396,31 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
 
 ! See whether sufficiently thick sea ice should be treated as rigid.
   call get_param(param_file, mdl, "USE_RIGID_SEA_ICE", CS%rigid_sea_ice, &
-                 "If true, sea-ice is rigid enough to exert a \n"//&
+                 "If true, sea-ice is rigid enough to exert a "//&
                  "nonhydrostatic pressure that resist vertical motion.", &
                  default=.false.)
   if (CS%rigid_sea_ice) then
     call get_param(param_file, mdl, "SEA_ICE_MEAN_DENSITY", CS%density_sea_ice, &
-                 "A typical density of sea ice, used with the kinematic \n"//&
+                 "A typical density of sea ice, used with the kinematic "//&
                  "viscosity, when USE_RIGID_SEA_ICE is true.", units="kg m-3", &
                  default=900.0)
     call get_param(param_file, mdl, "SEA_ICE_VISCOSITY", CS%Kv_sea_ice, &
-                 "The kinematic viscosity of sufficiently thick sea ice \n"//&
+                 "The kinematic viscosity of sufficiently thick sea ice "//&
                  "for use in calculating the rigidity of sea ice.", &
                  units="m2 s-1", default=1.0e9)
     call get_param(param_file, mdl, "SEA_ICE_RIGID_MASS", CS%rigid_sea_ice_mass, &
-                 "The mass of sea-ice per unit area at which the sea-ice \n"//&
+                 "The mass of sea-ice per unit area at which the sea-ice "//&
                  "starts to exhibit rigidity", units="kg m-2", default=1000.0)
   endif
 
   call get_param(param_file, mdl, "ALLOW_ICEBERG_FLUX_DIAGNOSTICS", iceberg_flux_diags, &
-                 "If true, makes available diagnostics of fluxes from icebergs\n"//&
+                 "If true, makes available diagnostics of fluxes from icebergs "//&
                  "as seen by MOM6.", default=.false.)
   call register_forcing_type_diags(Time, diag, US, CS%use_temperature, CS%handles, &
                                    use_berg_fluxes=iceberg_flux_diags)
 
   call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
-                 "If true, allows flux adjustments to specified via the \n"//&
+                 "If true, allows flux adjustments to specified via the "//&
                  "data_table using the component name 'OCN'.", default=.false.)
 
   call data_override_init(Ocean_domain_in=G%Domain%mpp_domain)

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -278,41 +278,41 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, mdl, "SINGLE_STEPPING_CALL", OS%single_step_call, &
-                 "If true, advance the state of MOM with a single step \n"//&
-                 "including both dynamics and thermodynamics.  If false, \n"//&
+                 "If true, advance the state of MOM with a single step "//&
+                 "including both dynamics and thermodynamics.  If false, "//&
                  "the two phases are advanced with separate calls.", default=.true.)
   call get_param(param_file, mdl, "DT", OS%dt, &
-                 "The (baroclinic) dynamics time step.  The time-step that \n"//&
-                 "is actually used will be an integer fraction of the \n"//&
+                 "The (baroclinic) dynamics time step.  The time-step that "//&
+                 "is actually used will be an integer fraction of the "//&
                  "forcing time-step.", units="s", fail_if_missing=.true.)
   call get_param(param_file, mdl, "DT_THERM", OS%dt_therm, &
-                 "The thermodynamic and tracer advection time step. \n"//&
-                 "Ideally DT_THERM should be an integer multiple of DT \n"//&
-                 "and less than the forcing or coupling time-step, unless \n"//&
-                 "THERMO_SPANS_COUPLING is true, in which case DT_THERM \n"//&
-                 "can be an integer multiple of the coupling timestep.  By \n"//&
+                 "The thermodynamic and tracer advection time step. "//&
+                 "Ideally DT_THERM should be an integer multiple of DT "//&
+                 "and less than the forcing or coupling time-step, unless "//&
+                 "THERMO_SPANS_COUPLING is true, in which case DT_THERM "//&
+                 "can be an integer multiple of the coupling timestep.  By "//&
                  "default DT_THERM is set to DT.", units="s", default=OS%dt)
   call get_param(param_file, "MOM", "THERMO_SPANS_COUPLING", OS%thermo_spans_coupling, &
-                 "If true, the MOM will take thermodynamic and tracer \n"//&
-                 "timesteps that can be longer than the coupling timestep. \n"//&
-                 "The actual thermodynamic timestep that is used in this \n"//&
-                 "case is the largest integer multiple of the coupling \n"//&
+                 "If true, the MOM will take thermodynamic and tracer "//&
+                 "timesteps that can be longer than the coupling timestep. "//&
+                 "The actual thermodynamic timestep that is used in this "//&
+                 "case is the largest integer multiple of the coupling "//&
                  "timestep that is less than or equal to DT_THERM.", default=.false.)
   call get_param(param_file, mdl, "DIABATIC_FIRST", OS%diabatic_first, &
-                 "If true, apply diabatic and thermodynamic processes, \n"//&
-                 "including buoyancy forcing and mass gain or loss, \n"//&
+                 "If true, apply diabatic and thermodynamic processes, "//&
+                 "including buoyancy forcing and mass gain or loss, "//&
                  "before stepping the dynamics forward.", default=.false.)
 
   call get_param(param_file, mdl, "RESTART_CONTROL", OS%Restart_control, &
-                 "An integer whose bits encode which restart files are \n"//&
-                 "written. Add 2 (bit 1) for a time-stamped file, and odd \n"//&
-                 "(bit 0) for a non-time-stamped file.  A restart file \n"//&
-                 "will be saved at the end of the run segment for any \n"//&
+                 "An integer whose bits encode which restart files are "//&
+                 "written. Add 2 (bit 1) for a time-stamped file, and odd "//&
+                 "(bit 0) for a non-time-stamped file.  A restart file "//&
+                 "will be saved at the end of the run segment for any "//&
                  "non-negative value.", default=1)
   call get_param(param_file, mdl, "OCEAN_SURFACE_STAGGER", stagger, &
-                 "A case-insensitive character string to indicate the \n"//&
-                 "staggering of the surface velocity field that is \n"//&
-                 "returned to the coupler.  Valid values include \n"//&
+                 "A case-insensitive character string to indicate the "//&
+                 "staggering of the surface velocity field that is "//&
+                 "returned to the coupler.  Valid values include "//&
                  "'A', 'B', or 'C'.", default="C")
   if (uppercase(stagger(1:1)) == 'A') then ; Ocean_sfc%stagger = AGRID
   elseif (uppercase(stagger(1:1)) == 'B') then ; Ocean_sfc%stagger = BGRID_NE
@@ -321,9 +321,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
                         trim(stagger)//" is invalid.") ; endif
 
   call get_param(param_file, mdl, "RHO_0", Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "G_EARTH", G_Earth, &
@@ -341,9 +341,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
   !   Consider using a run-time flag to determine whether to do the diagnostic
   ! vertical integrals, since the related 3-d sums are not negligible in cost.
   call get_param(param_file, mdl, "HFREEZE", HFrz, &
-                 "If HFREEZE > 0, melt potential will be computed. The actual depth \n"//&
-                 "over which melt potential is computed will be min(HFREEZE, OBLD), \n"//&
-                 "where OBLD is the boundary layer depth. If HFREEZE <= 0 (default), \n"//&
+                 "If HFREEZE > 0, melt potential will be computed. The actual depth "//&
+                 "over which melt potential is computed will be min(HFREEZE, OBLD), "//&
+                 "where OBLD is the boundary layer depth. If HFREEZE <= 0 (default), "//&
                  "melt potential will not be computed.", units="m", default=-1.0, do_not_log=.true.)
 
   if (HFrz .gt. 0.0) then

--- a/config_src/ice_solo_driver/MOM_surface_forcing.F90
+++ b/config_src/ice_solo_driver/MOM_surface_forcing.F90
@@ -976,7 +976,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
   call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, &
                  "The directory in which all input files are found.", &
@@ -984,33 +984,33 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
   CS%inputdir = slasher(CS%inputdir)
 
   call get_param(param_file, mdl, "ADIABATIC", CS%adiabatic, &
-                 "There are no diapycnal mass fluxes if ADIABATIC is \n"//&
-                 "true. This assumes that KD = KDML = 0.0 and that \n"//&
-                 "there is no buoyancy forcing, but makes the model \n"//&
+                 "There are no diapycnal mass fluxes if ADIABATIC is "//&
+                 "true. This assumes that KD = KDML = 0.0 and that "//&
+                 "there is no buoyancy forcing, but makes the model "//&
                  "faster by eliminating subroutine calls.", default=.false.)
   call get_param(param_file, mdl, "VARIABLE_WINDS", CS%variable_winds, &
                  "If true, the winds vary in time after the initialization.", &
                  default=.true.)
   call get_param(param_file, mdl, "VARIABLE_BUOYFORCE", CS%variable_buoyforce, &
-                 "If true, the buoyancy forcing varies in time after the \n"//&
+                 "If true, the buoyancy forcing varies in time after the "//&
                  "initialization of the model.", default=.true.)
 
   call get_param(param_file, mdl, "BUOY_CONFIG", CS%buoy_config, &
-                 "The character string that indicates how buoyancy forcing \n"//&
-                 "is specified. Valid options include (file), (zero), \n"//&
+                 "The character string that indicates how buoyancy forcing "//&
+                 "is specified. Valid options include (file), (zero), "//&
                  "(linear), (USER), and (NONE).", fail_if_missing=.true.)
   if (trim(CS%buoy_config) == "file") then
     call get_param(param_file, mdl, "LONGWAVEDOWN_FILE", CS%longwavedown_file, &
-                 "The file with the downward longwave heat flux, in \n"//&
+                 "The file with the downward longwave heat flux, in "//&
                  "variable lwdn_sfc.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "LONGWAVEUP_FILE", CS%longwaveup_file, &
-                 "The file with the upward longwave heat flux, in \n"//&
+                 "The file with the upward longwave heat flux, in "//&
                  "variable lwup_sfc.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "EVAPORATION_FILE", CS%evaporation_file, &
-                 "The file with the evaporative moisture flux, in \n"//&
+                 "The file with the evaporative moisture flux, in "//&
                  "variable evap.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "SENSIBLEHEAT_FILE", CS%sensibleheat_file, &
-                 "The file with the sensible heat flux, in \n"//&
+                 "The file with the sensible heat flux, in "//&
                  "variable shflx.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "SHORTWAVEUP_FILE", CS%shortwaveup_file, &
                  "The file with the upward shortwave heat flux.", &
@@ -1019,28 +1019,28 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
                  "The file with the downward shortwave heat flux.", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, "SNOW_FILE", CS%snow_file, &
-                 "The file with the downward frozen precip flux, in \n"//&
+                 "The file with the downward frozen precip flux, in "//&
                  "variable snow.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "PRECIP_FILE", CS%precip_file, &
-                 "The file with the downward total precip flux, in \n"//&
+                 "The file with the downward total precip flux, in "//&
                  "variable precip.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "FRESHDISCHARGE_FILE", CS%freshdischarge_file, &
-                 "The file with the fresh and frozen runoff/calving fluxes, \n"//&
+                 "The file with the fresh and frozen runoff/calving fluxes, "//&
                  "invariables disch_w and disch_s.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "SSTRESTORE_FILE", CS%SSTrestore_file, &
-                 "The file with the SST toward which to restore in \n"//&
+                 "The file with the SST toward which to restore in "//&
                  "variable TEMP.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "SALINITYRESTORE_FILE", CS%salinityrestore_file, &
-                 "The file with the surface salinity toward which to \n"//&
+                 "The file with the surface salinity toward which to "//&
                  "restore in variable SALT.", fail_if_missing=.true.)
   endif
   call get_param(param_file, mdl, "WIND_CONFIG", CS%wind_config, &
-                 "The character string that indicates how wind forcing \n"//&
-                 "is specified. Valid options include (file), (2gyre), \n"//&
+                 "The character string that indicates how wind forcing "//&
+                 "is specified. Valid options include (file), (2gyre), "//&
                  "(1gyre), (gyres), (zero), and (USER).", fail_if_missing=.true.)
   if (trim(CS%wind_config) == "file") then
     call get_param(param_file, mdl, "WIND_FILE", CS%wind_file, &
-                 "The file in which the wind stresses are found in \n"//&
+                 "The file in which the wind stresses are found in "//&
                  "variables STRESS_X and STRESS_Y.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "WINDSTRESS_X_VAR",CS%stress_x_var, &
                  "The name of the x-wind stress variable in WIND_FILE.", &
@@ -1049,7 +1049,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
                  "The name of the y-wind stress variable in WIND_FILE.", &
                  default="STRESS_Y")
     call get_param(param_file, mdl, "WINDSTRESS_STAGGER",CS%wind_stagger, &
-                 "A character indicating how the wind stress components \n"//&
+                 "A character indicating how the wind stress components "//&
                  "are staggered in WIND_FILE.  This may be A or C for now.", &
                  default="A")
     call get_param(param_file, mdl, "WINDSTRESS_SCALE", CS%wind_scale, &
@@ -1058,66 +1058,66 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
   endif
   if (trim(CS%wind_config) == "gyres") then
     call get_param(param_file, mdl, "TAUX_CONST", CS%gyres_taux_const, &
-                 "With the gyres wind_config, the constant offset in the \n"//&
-                 "zonal wind stress profile: \n"//&
+                 "With the gyres wind_config, the constant offset in the "//&
+                 "zonal wind stress profile: "//&
                  "  A in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
     call get_param(param_file, mdl, "TAUX_SIN_AMP",CS%gyres_taux_sin_amp, &
-                 "With the gyres wind_config, the sine amplitude in the \n"//&
-                 "zonal wind stress profile: \n"//&
+                 "With the gyres wind_config, the sine amplitude in the "//&
+                 "zonal wind stress profile: "//&
                  "  B in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
     call get_param(param_file, mdl, "TAUX_COS_AMP",CS%gyres_taux_cos_amp, &
-                 "With the gyres wind_config, the cosine amplitude in \n"//&
-                 "the zonal wind stress profile: \n"//&
+                 "With the gyres wind_config, the cosine amplitude in "//&
+                 "the zonal wind stress profile: "//&
                  "  C in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
     call get_param(param_file, mdl, "TAUX_N_PIS",CS%gyres_taux_n_pis, &
-                 "With the gyres wind_config, the number of gyres in \n"//&
-                 "the zonal wind stress profile: \n"//&
+                 "With the gyres wind_config, the number of gyres in "//&
+                 "the zonal wind stress profile: "//&
                  "  n in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="nondim", default=0.0)
   endif
   call get_param(param_file, mdl, "SOUTHLAT", CS%south_lat, &
-                 "The southern latitude of the domain or the equivalent \n"//&
+                 "The southern latitude of the domain or the equivalent "//&
                  "starting value for the y-axis.", units=axis_units, default=0.)
   call get_param(param_file, mdl, "LENLAT", CS%len_lat, &
                  "The latitudinal or y-direction length of the domain.", &
                  units=axis_units, fail_if_missing=.true.)
    call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
-                 "If true, the buoyancy fluxes drive the model back \n"//&
-                 "toward some specified surface state with a rate \n"//&
+                 "If true, the buoyancy fluxes drive the model back "//&
+                 "toward some specified surface state with a rate "//&
                  "given by FLUXCONST.", default= .false.)
   if (CS%restorebuoy) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     ! Convert CS%Flux_const from m day-1 to m s-1.
     CS%Flux_const = CS%Flux_const / 86400.0
     if (trim(CS%buoy_config) == "linear") then
       call get_param(param_file, mdl, "SST_NORTH", CS%T_north, &
-                 "With buoy_config linear, the sea surface temperature \n"//&
-                 "at the northern end of the domain toward which to \n"//&
+                 "With buoy_config linear, the sea surface temperature "//&
+                 "at the northern end of the domain toward which to "//&
                  "to restore.", units="deg C", default=0.0)
       call get_param(param_file, mdl, "SST_SOUTH", CS%T_south, &
-                 "With buoy_config linear, the sea surface temperature \n"//&
-                 "at the southern end of the domain toward which to \n"//&
+                 "With buoy_config linear, the sea surface temperature "//&
+                 "at the southern end of the domain toward which to "//&
                  "to restore.", units="deg C", default=0.0)
       call get_param(param_file, mdl, "SSS_NORTH", CS%S_north, &
-                 "With buoy_config linear, the sea surface salinity \n"//&
-                 "at the northern end of the domain toward which to \n"//&
+                 "With buoy_config linear, the sea surface salinity "//&
+                 "at the northern end of the domain toward which to "//&
                  "to restore.", units="PSU", default=35.0)
       call get_param(param_file, mdl, "SSS_SOUTH", CS%S_south, &
-                 "With buoy_config linear, the sea surface salinity \n"//&
-                 "at the southern end of the domain toward which to \n"//&
+                 "With buoy_config linear, the sea surface salinity "//&
+                 "at the southern end of the domain toward which to "//&
                  "to restore.", units="PSU", default=35.0)
     endif
   endif
@@ -1129,11 +1129,11 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
                  "The background gustiness in the winds.", units="Pa", &
                  default=0.02)
   call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
-                 "If true, use a 2-dimensional gustiness supplied from \n"//&
+                 "If true, use a 2-dimensional gustiness supplied from "//&
                  "an input file", default=.false.)
   if (CS%read_gust_2d) then
     call get_param(param_file, mdl, "GUST_2D_FILE", gust_file, &
-                 "The file in which the wind gustiness is found in \n"//&
+                 "The file in which the wind gustiness is found in "//&
                  "variable gustiness.", fail_if_missing=.true.)
     call safe_alloc_ptr(CS%gust,G%isd,G%ied,G%jsd,G%jed) ; CS%gust(:,:) = 0.0
     filename = trim(CS%inputdir) // trim(gust_file)

--- a/config_src/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/ice_solo_driver/ice_shelf_driver.F90
@@ -209,14 +209,14 @@ program SHELF_main
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, mdl, "ICE_SHELF", use_ice_shelf, &
-                 "If true, call the code to apply an ice shelf model over \n"//&
+                 "If true, call the code to apply an ice shelf model over "//&
                  "some of the domain.", default=.false.)
 
   if (.not.use_ice_shelf) call MOM_error(FATAL, &
         "shelf_driver: ICE_SHELF must be defined.")
 
   call get_param(param_file, mdl, "ICE_VELOCITY_TIMESTEP", time_step, &
-                 "The time step for changing forcing, coupling with other \n"//&
+                 "The time step for changing forcing, coupling with other "//&
                  "components, or potentially writing certain diagnostics.", &
                  units="s", fail_if_missing=.true.)
 
@@ -250,16 +250,16 @@ program SHELF_main
     Time_end = increment_date(Time, years, months, days, hours, minutes, seconds)
     call MOM_mesg('Segment run length determied from ice_solo_nml.', 2)
     call get_param(param_file, mdl, "DAYMAX", daymax, &
-                 "The final time of the whole simulation, in units of \n"//&
-                 "TIMEUNIT seconds.  This also sets the potential end \n"//&
-                 "time of the present run segment if the end time is \n"//&
+                 "The final time of the whole simulation, in units of "//&
+                 "TIMEUNIT seconds.  This also sets the potential end "//&
+                 "time of the present run segment if the end time is "//&
                  "not set (as it was here) via ocean_solo_nml in input.nml.", &
                  timeunit=Time_unit, default=Time_end)
   else
     call get_param(param_file, mdl, "DAYMAX", daymax, &
-                 "The final time of the whole simulation, in units of \n"//&
-                 "TIMEUNIT seconds.  This also sets the potential end \n"//&
-                 "time of the present run segment if the end time is \n"//&
+                 "The final time of the whole simulation, in units of "//&
+                 "TIMEUNIT seconds.  This also sets the potential end "//&
+                 "time of the present run segment if the end time is "//&
                  "not set via ocean_solo_nml in input.nml.", &
                  timeunit=Time_unit, fail_if_missing=.true.)
     Time_end = daymax
@@ -271,14 +271,14 @@ program SHELF_main
     "MOM_driver: The run has been started at or after the end time of the run.")
 
   call get_param(param_file, mdl, "RESTART_CONTROL", Restart_control, &
-                 "An integer whose bits encode which restart files are \n"//&
-                 "written. Add 2 (bit 1) for a time-stamped file, and odd \n"//&
-                 "(bit 0) for a non-time-stamped file. A non-time-stamped \n"//&
-                 "restart file is saved at the end of the run segment \n"//&
+                 "An integer whose bits encode which restart files are "//&
+                 "written. Add 2 (bit 1) for a time-stamped file, and odd "//&
+                 "(bit 0) for a non-time-stamped file. A non-time-stamped "//&
+                 "restart file is saved at the end of the run segment "//&
                  "for any non-negative value.", default=1)
   call get_param(param_file, mdl, "RESTINT", restint, &
-                 "The interval between saves of the restart file in units \n"//&
-                 "of TIMEUNIT.  Use 0 (the default) to not save \n"//&
+                 "The interval between saves of the restart file in units "//&
+                 "of TIMEUNIT.  Use 0 (the default) to not save "//&
                  "incremental restart files at all.", default=set_time(0), &
                  timeunit=Time_unit)
   call log_param(param_file, mdl, "ELAPSED TIME AS MASTER", elapsed_time_master)

--- a/config_src/ice_solo_driver/user_surface_forcing.F90
+++ b/config_src/ice_solo_driver/user_surface_forcing.F90
@@ -306,16 +306,16 @@ subroutine USER_surface_forcing_init(Time, G, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
 
   call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
@@ -323,13 +323,13 @@ subroutine USER_surface_forcing_init(Time, G, param_file, diag, CS)
                  default=0.02)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
-                 "If true, the buoyancy fluxes drive the model back \n"//&
-                 "toward some specified surface state with a rate \n"//&
+                 "If true, the buoyancy fluxes drive the model back "//&
+                 "toward some specified surface state with a rate "//&
                  "given by FLUXCONST.", default= .false.)
   if (CS%restorebuoy) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     ! Convert CS%Flux_const from m day-1 to m s-1.

--- a/config_src/mct_driver/MOM_ocean_model.F90
+++ b/config_src/mct_driver/MOM_ocean_model.F90
@@ -286,15 +286,15 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "RESTART_CONTROL", OS%Restart_control, &
-                 "An integer whose bits encode which restart files are \n"//&
-                 "written. Add 2 (bit 1) for a time-stamped file, and odd \n"//&
-                 "(bit 0) for a non-time-stamped file.  A restart file \n"//&
-                 "will be saved at the end of the run segment for any \n"//&
+                 "An integer whose bits encode which restart files are "//&
+                 "written. Add 2 (bit 1) for a time-stamped file, and odd "//&
+                 "(bit 0) for a non-time-stamped file.  A restart file "//&
+                 "will be saved at the end of the run segment for any "//&
                  "non-negative value.", default=1)
   call get_param(param_file, mdl, "OCEAN_SURFACE_STAGGER", stagger, &
-                 "A case-insensitive character string to indicate the \n"//&
-                 "staggering of the surface velocity field that is \n"//&
-                 "returned to the coupler.  Valid values include \n"//&
+                 "A case-insensitive character string to indicate the "//&
+                 "staggering of the surface velocity field that is "//&
+                 "returned to the coupler.  Valid values include "//&
                  "'A', 'B', or 'C'.", default="C")
   if (uppercase(stagger(1:1)) == 'A') then
     Ocean_sfc%stagger = AGRID
@@ -308,17 +308,17 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   end if
 
   call get_param(param_file, mdl, "RESTORE_SALINITY",OS%restore_salinity, &
-                 "If true, the coupled driver will add a globally-balanced \n"//&
-                 "fresh-water flux that drives sea-surface salinity \n"//&
+                 "If true, the coupled driver will add a globally-balanced "//&
+                 "fresh-water flux that drives sea-surface salinity "//&
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RESTORE_TEMPERATURE",OS%restore_temp, &
-                 "If true, the coupled driver will add a  \n"//&
-                 "heat flux that drives sea-surface temperature \n"//&
+                 "If true, the coupled driver will add a "//&
+                 "heat flux that drives sea-surface temperature "//&
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RHO_0", Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "G_EARTH", G_Earth, &
@@ -339,8 +339,8 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
     call get_param(param_file, mdl, "LATENT_HEAT_FUSION", OS%latent_heat_fusion, &
                  "The latent heat of fusion.", units="J/kg", default=hlf)
     call get_param(param_file, mdl, "BERG_AREA_THRESHOLD", OS%berg_area_threshold, &
-                 "Fraction of grid cell which iceberg must occupy, so that fluxes \n"//&
-                 "below berg are set to zero. Not applied for negative \n"//&
+                 "Fraction of grid cell which iceberg must occupy, so that fluxes "//&
+                 "below berg are set to zero. Not applied for negative "//&
                  " values.", units="non-dim", default=-1.0)
   endif
 
@@ -350,9 +350,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   ! vertical integrals, since the related 3-d sums are not negligible in cost.
 
   call get_param(param_file, mdl, "HFREEZE", HFrz, &
-                 "If HFREEZE > 0, melt potential will be computed. The actual depth \n"//&
-                 "over which melt potential is computed will be min(HFREEZE, OBLD), \n"//&
-                 "where OBLD is the boundary layer depth. If HFREEZE <= 0 (default), \n"//&
+                 "If HFREEZE > 0, melt potential will be computed. The actual depth "//&
+                 "over which melt potential is computed will be min(HFREEZE, OBLD), "//&
+                 "where OBLD is the boundary layer depth. If HFREEZE <= 0 (default), "//&
                  "melt potential will not be computed.", units="m", default=-1.0, do_not_log=.true.)
 
   if (HFrz .gt. 0.0) then

--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -1033,12 +1033,12 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                  default=".")
   CS%inputdir = slasher(CS%inputdir)
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
@@ -1046,46 +1046,46 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   call get_param(param_file, mdl, "LATENT_HEAT_VAPORIZATION", CS%latent_heat_vapor, &
                  "The latent heat of fusion.", units="J/kg", default=hlv)
   call get_param(param_file, mdl, "MAX_P_SURF", CS%max_p_surf, &
-                 "The maximum surface pressure that can be exerted by the \n"//&
-                 "atmosphere and floating sea-ice or ice shelves. This is \n"//&
-                 "needed because the FMS coupling structure does not \n"//&
-                 "limit the water that can be frozen out of the ocean and \n"//&
-                 "the ice-ocean heat fluxes are treated explicitly.  No \n"//&
+                 "The maximum surface pressure that can be exerted by the "//&
+                 "atmosphere and floating sea-ice or ice shelves. This is "//&
+                 "needed because the FMS coupling structure does not "//&
+                 "limit the water that can be frozen out of the ocean and "//&
+                 "the ice-ocean heat fluxes are treated explicitly.  No "//&
                  "limit is applied if a negative value is used.", units="Pa", &
                  default=-1.0)
   call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_TO_ZERO", &
                  CS%adjust_net_srestore_to_zero, &
-                 "If true, adjusts the salinity restoring seen to zero\n"//&
+                 "If true, adjusts the salinity restoring seen to zero "//&
                  "whether restoring is via a salt flux or virtual precip.",&
                  default=restore_salt)
   call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_BY_SCALING", &
                  CS%adjust_net_srestore_by_scaling, &
-                 "If true, adjustments to salt restoring to achieve zero net are\n"//&
+                 "If true, adjustments to salt restoring to achieve zero net are "//&
                  "made by scaling values without moving the zero contour.",&
                  default=.false.)
   call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_TO_ZERO", &
                  CS%adjust_net_fresh_water_to_zero, &
-                 "If true, adjusts the net fresh-water forcing seen \n"//&
+                 "If true, adjusts the net fresh-water forcing seen "//&
                  "by the ocean (including restoring) to zero.", default=.false.)
   if (CS%adjust_net_fresh_water_to_zero) &
     call get_param(param_file, mdl, "USE_NET_FW_ADJUSTMENT_SIGN_BUG", &
                  CS%use_net_FW_adjustment_sign_bug, &
-                   "If true, use the wrong sign for the adjustment to\n"//&
+                   "If true, use the wrong sign for the adjustment to "//&
                    "the net fresh-water.", default=.false.)
   call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_BY_SCALING", &
                  CS%adjust_net_fresh_water_by_scaling, &
-                 "If true, adjustments to net fresh water to achieve zero net are\n"//&
+                 "If true, adjustments to net fresh water to achieve zero net are "//&
                  "made by scaling values without moving the zero contour.",&
                  default=.false.)
   call get_param(param_file, mdl, "ICE_SALT_CONCENTRATION", &
                  CS%ice_salt_concentration, &
-                 "The assumed sea-ice salinity needed to reverse engineer the \n"//&
+                 "The assumed sea-ice salinity needed to reverse engineer the "//&
                  "melt flux (or ice-ocean fresh-water flux).", &
                  units="kg/kg", default=0.005)
   call get_param(param_file, mdl, "USE_LIMITED_PATM_SSH", CS%use_limited_P_SSH, &
-                 "If true, return the sea surface height with the \n"//&
-                 "correction for the atmospheric (and sea-ice) pressure \n"//&
-                 "limited by max_p_surf instead of the full atmospheric \n"//&
+                 "If true, return the sea surface height with the "//&
+                 "correction for the atmospheric (and sea-ice) pressure "//&
+                 "limited by max_p_surf instead of the full atmospheric "//&
                  "pressure.", default=.true.)
 
 ! smg: should get_param call should be removed when have A=B code reconciled.
@@ -1094,8 +1094,8 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                  default=CS%use_temperature,do_not_log=.true.)
 
   call get_param(param_file, mdl, "WIND_STAGGER", stagger, &
-                 "A case-insensitive character string to indicate the \n"//&
-                 "staggering of the input wind stress field.  Valid \n"//&
+                 "A case-insensitive character string to indicate the "//&
+                 "staggering of the input wind stress field.  Valid "//&
                  "values are 'A', 'B', or 'C'.", default="C")
   if (uppercase(stagger(1:1)) == 'A') then ; CS%wind_stagger = AGRID
   elseif (uppercase(stagger(1:1)) == 'B') then ; CS%wind_stagger = BGRID_NE
@@ -1103,14 +1103,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   else ; call MOM_error(FATAL,"surface_forcing_init: WIND_STAGGER = "// &
                         trim(stagger)//" is invalid.") ; endif
   call get_param(param_file, mdl, "WIND_STRESS_MULTIPLIER", CS%wind_stress_multiplier, &
-                 "A factor multiplying the wind-stress given to the ocean by the\n"//&
-                 "coupler. This is used for testing and should be =1.0 for any\n"//&
+                 "A factor multiplying the wind-stress given to the ocean by the "//&
+                 "coupler. This is used for testing and should be =1.0 for any "//&
                  "production runs.", default=1.0)
 
   if (restore_salt) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, "SALT_RESTORE_FILE", CS%salt_restore_file, &
@@ -1124,19 +1124,19 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     CS%Flux_const = CS%Flux_const / 86400.0
 
     call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
-                 "If true, the restoring of salinity is applied as a salt \n"//&
+                 "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)
     call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
                  "The maximum salinity difference used in restoring terms.", &
                  units="PSU or g kg-1", default=999.0)
     call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", &
                  CS%mask_srestore_under_ice, &
-                 "If true, disables SSS restoring under sea-ice based on a frazil\n"//&
+                 "If true, disables SSS restoring under sea-ice based on a frazil "//&
                  "criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.",      &
                  default=.false.)
     call get_param(param_file, mdl, "MASK_SRESTORE_MARGINAL_SEAS", &
                  CS%mask_srestore_marginal_seas, &
-                 "If true, disable SSS restoring in marginal seas. Only used when\n"//&
+                 "If true, disable SSS restoring in marginal seas. Only used when "//&
                  "RESTORE_SALINITY is True.", default=.false.)
     call get_param(param_file, mdl, "BASIN_FILE", basin_file, &
                  "A file in which to find the basin masks, in variable 'basin'.", &
@@ -1154,8 +1154,8 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 
   if (restore_temp) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, "SST_RESTORE_FILE", CS%temp_restore_file, &
@@ -1182,11 +1182,11 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                  "The drag coefficient that applies to the tides.", &
                  units="nondim", default=1.0e-4)
   call get_param(param_file, mdl, "READ_TIDEAMP", CS%read_TIDEAMP, &
-                 "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
+                 "If true, read a file (given by TIDEAMP_FILE) containing "//&
                  "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
   if (CS%read_TIDEAMP) then
     call get_param(param_file, mdl, "TIDEAMP_FILE", TideAmp_file, &
-                 "The path to the file containing the spatially varying \n"//&
+                 "The path to the file containing the spatially varying "//&
                  "tidal amplitudes with INT_TIDE_DISSIPATION.", &
                  default="tideamp.nc")
     CS%utide=0.0
@@ -1221,14 +1221,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 ! constant.
 
   call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
-                 "If true, use a 2-dimensional gustiness supplied from \n"//&
+                 "If true, use a 2-dimensional gustiness supplied from "//&
                  "an input file", default=.false.)
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                "The background gustiness in the winds.", units="Pa", &
                default=0.02)
   if (CS%read_gust_2d) then
     call get_param(param_file, mdl, "GUST_2D_FILE", gust_file, &
-                 "The file in which the wind gustiness is found in \n"//&
+                 "The file in which the wind gustiness is found in "//&
                  "variable gustiness.")
 
     call safe_alloc_ptr(CS%gust,isd,ied,jsd,jed)
@@ -1239,31 +1239,31 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 
 ! See whether sufficiently thick sea ice should be treated as rigid.
   call get_param(param_file, mdl, "USE_RIGID_SEA_ICE", CS%rigid_sea_ice, &
-                 "If true, sea-ice is rigid enough to exert a \n"//&
+                 "If true, sea-ice is rigid enough to exert a "//&
                  "nonhydrostatic pressure that resist vertical motion.", &
                  default=.false.)
   if (CS%rigid_sea_ice) then
     call get_param(param_file, mdl, "SEA_ICE_MEAN_DENSITY", CS%density_sea_ice, &
-                 "A typical density of sea ice, used with the kinematic \n"//&
+                 "A typical density of sea ice, used with the kinematic "//&
                  "viscosity, when USE_RIGID_SEA_ICE is true.", units="kg m-3", &
                  default=900.0)
     call get_param(param_file, mdl, "SEA_ICE_VISCOSITY", CS%Kv_sea_ice, &
-                 "The kinematic viscosity of sufficiently thick sea ice \n"//&
+                 "The kinematic viscosity of sufficiently thick sea ice "//&
                  "for use in calculating the rigidity of sea ice.", &
                  units="m2 s-1", default=1.0e9)
     call get_param(param_file, mdl, "SEA_ICE_RIGID_MASS", CS%rigid_sea_ice_mass, &
-                 "The mass of sea-ice per unit area at which the sea-ice \n"//&
+                 "The mass of sea-ice per unit area at which the sea-ice "//&
                  "starts to exhibit rigidity", units="kg m-2", default=1000.0)
   endif
 
   call get_param(param_file, mdl, "ALLOW_ICEBERG_FLUX_DIAGNOSTICS", iceberg_flux_diags, &
-                 "If true, makes available diagnostics of fluxes from icebergs\n"//&
+                 "If true, makes available diagnostics of fluxes from icebergs "//&
                  "as seen by MOM6.", default=.false.)
   call register_forcing_type_diags(Time, diag, US, CS%use_temperature, CS%handles, &
                                    use_berg_fluxes=iceberg_flux_diags)
 
   call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
-                 "If true, allows flux adjustments to specified via the \n"//&
+                 "If true, allows flux adjustments to specified via the "//&
                  "data_table using the component name 'OCN'.", default=.false.)
   if (CS%allow_flux_adjustments) then
     call data_override_init(Ocean_domain_in=G%Domain%mpp_domain)

--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -259,19 +259,19 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
 
   if (glb%sw_decomp) then
     call get_param(param_file, mdl, "SW_c1", glb%c1, &
-                  "Coeff. used to convert net shortwave rad. into \n"//&
+                  "Coeff. used to convert net shortwave rad. into "//&
                   "visible, direct shortwave.", units="nondim", default=0.285)
 
     call get_param(param_file, mdl, "SW_c2", glb%c2, &
-                  "Coeff. used to convert net shortwave rad. into \n"//&
+                  "Coeff. used to convert net shortwave rad. into "//&
                   "visible, diffuse shortwave.", units="nondim", default=0.285)
 
     call get_param(param_file, mdl, "SW_c3", glb%c3, &
-                  "Coeff. used to convert net shortwave rad. into \n"//&
+                  "Coeff. used to convert net shortwave rad. into "//&
                   "near-IR, direct shortwave.", units="nondim", default=0.215)
 
     call get_param(param_file, mdl, "SW_c4", glb%c4, &
-                  "Coeff. used to convert net shortwave rad. into \n"//&
+                  "Coeff. used to convert net shortwave rad. into "//&
                   "near-IR, diffuse shortwave.", units="nondim", default=0.215)
   else
     glb%c1 = 0.0; glb%c2 = 0.0; glb%c3 = 0.0; glb%c4 = 0.0

--- a/config_src/nuopc_driver/MOM_ocean_model.F90
+++ b/config_src/nuopc_driver/MOM_ocean_model.F90
@@ -286,41 +286,41 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, mdl, "SINGLE_STEPPING_CALL", OS%single_step_call, &
-                 "If true, advance the state of MOM with a single step \n"//&
-                 "including both dynamics and thermodynamics.  If false, \n"//&
+                 "If true, advance the state of MOM with a single step "//&
+                 "including both dynamics and thermodynamics.  If false, "//&
                  "the two phases are advanced with separate calls.", default=.true.)
   call get_param(param_file, mdl, "DT", OS%dt, &
-                 "The (baroclinic) dynamics time step.  The time-step that \n"//&
-                 "is actually used will be an integer fraction of the \n"//&
+                 "The (baroclinic) dynamics time step.  The time-step that "//&
+                 "is actually used will be an integer fraction of the "//&
                  "forcing time-step.", units="s", fail_if_missing=.true.)
   call get_param(param_file, mdl, "DT_THERM", OS%dt_therm, &
-                 "The thermodynamic and tracer advection time step. \n"//&
-                 "Ideally DT_THERM should be an integer multiple of DT \n"//&
-                 "and less than the forcing or coupling time-step, unless \n"//&
-                 "THERMO_SPANS_COUPLING is true, in which case DT_THERM \n"//&
-                 "can be an integer multiple of the coupling timestep.  By \n"//&
+                 "The thermodynamic and tracer advection time step. "//&
+                 "Ideally DT_THERM should be an integer multiple of DT "//&
+                 "and less than the forcing or coupling time-step, unless "//&
+                 "THERMO_SPANS_COUPLING is true, in which case DT_THERM "//&
+                 "can be an integer multiple of the coupling timestep.  By "//&
                  "default DT_THERM is set to DT.", units="s", default=OS%dt)
   call get_param(param_file, "MOM", "THERMO_SPANS_COUPLING", OS%thermo_spans_coupling, &
-                 "If true, the MOM will take thermodynamic and tracer \n"//&
-                 "timesteps that can be longer than the coupling timestep. \n"//&
-                 "The actual thermodynamic timestep that is used in this \n"//&
-                 "case is the largest integer multiple of the coupling \n"//&
+                 "If true, the MOM will take thermodynamic and tracer "//&
+                 "timesteps that can be longer than the coupling timestep. "//&
+                 "The actual thermodynamic timestep that is used in this "//&
+                 "case is the largest integer multiple of the coupling "//&
                  "timestep that is less than or equal to DT_THERM.", default=.false.)
   call get_param(param_file, mdl, "DIABATIC_FIRST", OS%diabatic_first, &
-                 "If true, apply diabatic and thermodynamic processes, \n"//&
-                 "including buoyancy forcing and mass gain or loss, \n"//&
+                 "If true, apply diabatic and thermodynamic processes, "//&
+                 "including buoyancy forcing and mass gain or loss, "//&
                  "before stepping the dynamics forward.", default=.false.)
 
   call get_param(param_file, mdl, "RESTART_CONTROL", OS%Restart_control, &
-                 "An integer whose bits encode which restart files are \n"//&
-                 "written. Add 2 (bit 1) for a time-stamped file, and odd \n"//&
-                 "(bit 0) for a non-time-stamped file.  A restart file \n"//&
-                 "will be saved at the end of the run segment for any \n"//&
+                 "An integer whose bits encode which restart files are "//&
+                 "written. Add 2 (bit 1) for a time-stamped file, and odd "//&
+                 "(bit 0) for a non-time-stamped file.  A restart file "//&
+                 "will be saved at the end of the run segment for any "//&
                  "non-negative value.", default=1)
   call get_param(param_file, mdl, "OCEAN_SURFACE_STAGGER", stagger, &
-                 "A case-insensitive character string to indicate the \n"//&
-                 "staggering of the surface velocity field that is \n"//&
-                 "returned to the coupler.  Valid values include \n"//&
+                 "A case-insensitive character string to indicate the "//&
+                 "staggering of the surface velocity field that is "//&
+                 "returned to the coupler.  Valid values include "//&
                  "'A', 'B', or 'C'.", default="C")
   if (uppercase(stagger(1:1)) == 'A') then ; Ocean_sfc%stagger = AGRID
   elseif (uppercase(stagger(1:1)) == 'B') then ; Ocean_sfc%stagger = BGRID_NE
@@ -329,17 +329,17 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                         trim(stagger)//" is invalid.") ; endif
 
   call get_param(param_file, mdl, "RESTORE_SALINITY",OS%restore_salinity, &
-                 "If true, the coupled driver will add a globally-balanced \n"//&
-                 "fresh-water flux that drives sea-surface salinity \n"//&
+                 "If true, the coupled driver will add a globally-balanced "//&
+                 "fresh-water flux that drives sea-surface salinity "//&
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RESTORE_TEMPERATURE",OS%restore_temp, &
-                 "If true, the coupled driver will add a  \n"//&
-                 "heat flux that drives sea-surface temperature \n"//&
+                 "If true, the coupled driver will add a "//&
+                 "heat flux that drives sea-surface temperature "//&
                  "toward specified values.", default=.false.)
   call get_param(param_file, mdl, "RHO_0", Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "G_EARTH", G_Earth, &
@@ -355,9 +355,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   OS%press_to_z = 1.0/(Rho0*G_Earth)
 
     call get_param(param_file, mdl, "HFREEZE", HFrz, &
-                 "If HFREEZE > 0, melt potential will be computed. The actual depth \n"//&
-                 "over which melt potential is computed will be min(HFREEZE, OBLD), \n"//&
-                 "where OBLD is the boundary layer depth. If HFREEZE <= 0 (default), \n"//&
+                 "If HFREEZE > 0, melt potential will be computed. The actual depth "//&
+                 "over which melt potential is computed will be min(HFREEZE, OBLD), "//&
+                 "where OBLD is the boundary layer depth. If HFREEZE <= 0 (default), "//&
                  "melt potential will not be computed.", units="m", default=-1.0, do_not_log=.true.)
 
   if (HFrz .gt. 0.0) then

--- a/config_src/nuopc_driver/MOM_surface_forcing.F90
+++ b/config_src/nuopc_driver/MOM_surface_forcing.F90
@@ -1049,12 +1049,12 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                  default=".")
   CS%inputdir = slasher(CS%inputdir)
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
@@ -1062,51 +1062,51 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   call get_param(param_file, mdl, "LATENT_HEAT_VAPORIZATION", CS%latent_heat_vapor, &
                  "The latent heat of fusion.", units="J/kg", default=hlv)
   call get_param(param_file, mdl, "MAX_P_SURF", CS%max_p_surf, &
-                 "The maximum surface pressure that can be exerted by the \n"//&
-                 "atmosphere and floating sea-ice or ice shelves. This is \n"//&
-                 "needed because the FMS coupling structure does not \n"//&
-                 "limit the water that can be frozen out of the ocean and \n"//&
-                 "the ice-ocean heat fluxes are treated explicitly.  No \n"//&
+                 "The maximum surface pressure that can be exerted by the "//&
+                 "atmosphere and floating sea-ice or ice shelves. This is "//&
+                 "needed because the FMS coupling structure does not "//&
+                 "limit the water that can be frozen out of the ocean and "//&
+                 "the ice-ocean heat fluxes are treated explicitly.  No "//&
                  "limit is applied if a negative value is used.", units="Pa", &
                  default=-1.0)
   call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_TO_ZERO", &
                  CS%adjust_net_srestore_to_zero, &
-                 "If true, adjusts the salinity restoring seen to zero\n"//&
+                 "If true, adjusts the salinity restoring seen to zero "//&
                  "whether restoring is via a salt flux or virtual precip.",&
                  default=restore_salt)
   call get_param(param_file, mdl, "ADJUST_NET_SRESTORE_BY_SCALING", &
                  CS%adjust_net_srestore_by_scaling, &
-                 "If true, adjustments to salt restoring to achieve zero net are\n"//&
+                 "If true, adjustments to salt restoring to achieve zero net are "//&
                  "made by scaling values without moving the zero contour.",&
                  default=.false.)
   call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_TO_ZERO", &
                  CS%adjust_net_fresh_water_to_zero, &
-                 "If true, adjusts the net fresh-water forcing seen \n"//&
+                 "If true, adjusts the net fresh-water forcing seen "//&
                  "by the ocean (including restoring) to zero.", default=.false.)
   if (CS%adjust_net_fresh_water_to_zero) &
     call get_param(param_file, mdl, "USE_NET_FW_ADJUSTMENT_SIGN_BUG", &
                  CS%use_net_FW_adjustment_sign_bug, &
-                   "If true, use the wrong sign for the adjustment to\n"//&
+                   "If true, use the wrong sign for the adjustment to "//&
                    "the net fresh-water.", default=.true.)
   call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_BY_SCALING", &
                  CS%adjust_net_fresh_water_by_scaling, &
-                 "If true, adjustments to net fresh water to achieve zero net are\n"//&
+                 "If true, adjustments to net fresh water to achieve zero net are "//&
                  "made by scaling values without moving the zero contour.",&
                  default=.false.)
   call get_param(param_file, mdl, "ICE_SALT_CONCENTRATION", &
                  CS%ice_salt_concentration, &
-                 "The assumed sea-ice salinity needed to reverse engineer the \n"//&
+                 "The assumed sea-ice salinity needed to reverse engineer the "//&
                  "melt flux (or ice-ocean fresh-water flux).", &
                  units="kg/kg", default=0.005)
   call get_param(param_file, mdl, "USE_LIMITED_PATM_SSH", CS%use_limited_P_SSH, &
-                 "If true, return the sea surface height with the \n"//&
-                 "correction for the atmospheric (and sea-ice) pressure \n"//&
-                 "limited by max_p_surf instead of the full atmospheric \n"//&
+                 "If true, return the sea surface height with the "//&
+                 "correction for the atmospheric (and sea-ice) pressure "//&
+                 "limited by max_p_surf instead of the full atmospheric "//&
                  "pressure.", default=.true.)
 
   call get_param(param_file, mdl, "WIND_STAGGER", stagger, &
-                 "A case-insensitive character string to indicate the \n"//&
-                 "staggering of the input wind stress field.  Valid \n"//&
+                 "A case-insensitive character string to indicate the "//&
+                 "staggering of the input wind stress field.  Valid "//&
                  "values are 'A', 'B', or 'C'.", default="C")
   if (uppercase(stagger(1:1)) == 'A') then ; CS%wind_stagger = AGRID
   elseif (uppercase(stagger(1:1)) == 'B') then ; CS%wind_stagger = BGRID_NE
@@ -1114,14 +1114,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   else ; call MOM_error(FATAL,"surface_forcing_init: WIND_STAGGER = "// &
                         trim(stagger)//" is invalid.") ; endif
   call get_param(param_file, mdl, "WIND_STRESS_MULTIPLIER", CS%wind_stress_multiplier, &
-                 "A factor multiplying the wind-stress given to the ocean by the\n"//&
-                 "coupler. This is used for testing and should be =1.0 for any\n"//&
+                 "A factor multiplying the wind-stress given to the ocean by the "//&
+                 "coupler. This is used for testing and should be =1.0 for any "//&
                  "production runs.", default=1.0)
 
   if (restore_salt) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, "SALT_RESTORE_FILE", CS%salt_restore_file, &
@@ -1135,19 +1135,19 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     CS%Flux_const = CS%Flux_const / 86400.0
 
     call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
-                 "If true, the restoring of salinity is applied as a salt \n"//&
+                 "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)
     call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
                  "The maximum salinity difference used in restoring terms.", &
                  units="PSU or g kg-1", default=999.0)
     call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", &
                  CS%mask_srestore_under_ice, &
-                 "If true, disables SSS restoring under sea-ice based on a frazil\n"//&
+                 "If true, disables SSS restoring under sea-ice based on a frazil "//&
                  "criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.",      &
                  default=.false.)
     call get_param(param_file, mdl, "MASK_SRESTORE_MARGINAL_SEAS", &
                  CS%mask_srestore_marginal_seas, &
-                 "If true, disable SSS restoring in marginal seas. Only used when\n"//&
+                 "If true, disable SSS restoring in marginal seas. Only used when "//&
                  "RESTORE_SALINITY is True.", default=.false.)
     call get_param(param_file, mdl, "BASIN_FILE", basin_file, &
                  "A file in which to find the basin masks, in variable 'basin'.", &
@@ -1162,14 +1162,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
       enddo ; enddo
     endif
     call get_param(param_file, mdl, "MASK_SRESTORE", CS%mask_srestore, &
-                 "If true, read a file (salt_restore_mask) containing \n"//&
+                 "If true, read a file (salt_restore_mask) containing "//&
                  "a mask for SSS restoring.", default=.false.)
   endif
 
   if (restore_temp) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, "SST_RESTORE_FILE", CS%temp_restore_file, &
@@ -1186,7 +1186,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                  "The maximum sst difference used in restoring terms.", &
                  units="degC ", default=999.0)
     call get_param(param_file, mdl, "MASK_TRESTORE", CS%mask_trestore, &
-                 "If true, read a file (temp_restore_mask) containing \n"//&
+                 "If true, read a file (temp_restore_mask) containing "//&
                  "a mask for SST restoring.", default=.false.)
 
   endif
@@ -1199,11 +1199,11 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                  "The drag coefficient that applies to the tides.", &
                  units="nondim", default=1.0e-4)
   call get_param(param_file, mdl, "READ_TIDEAMP", CS%read_TIDEAMP, &
-                 "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
+                 "If true, read a file (given by TIDEAMP_FILE) containing "//&
                  "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
   if (CS%read_TIDEAMP) then
     call get_param(param_file, mdl, "TIDEAMP_FILE", TideAmp_file, &
-                 "The path to the file containing the spatially varying \n"//&
+                 "The path to the file containing the spatially varying "//&
                  "tidal amplitudes with INT_TIDE_DISSIPATION.", &
                  default="tideamp.nc")
     CS%utide=0.0
@@ -1238,14 +1238,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 ! constant.
 
   call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
-                 "If true, use a 2-dimensional gustiness supplied from \n"//&
+                 "If true, use a 2-dimensional gustiness supplied from "//&
                  "an input file", default=.false.)
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                "The background gustiness in the winds.", units="Pa", &
                default=0.02)
   if (CS%read_gust_2d) then
     call get_param(param_file, mdl, "GUST_2D_FILE", gust_file, &
-                 "The file in which the wind gustiness is found in \n"//&
+                 "The file in which the wind gustiness is found in "//&
                  "variable gustiness.")
 
     call safe_alloc_ptr(CS%gust,isd,ied,jsd,jed)
@@ -1255,31 +1255,31 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 
 ! See whether sufficiently thick sea ice should be treated as rigid.
   call get_param(param_file, mdl, "USE_RIGID_SEA_ICE", CS%rigid_sea_ice, &
-                 "If true, sea-ice is rigid enough to exert a \n"//&
+                 "If true, sea-ice is rigid enough to exert a "//&
                  "nonhydrostatic pressure that resist vertical motion.", &
                  default=.false.)
   if (CS%rigid_sea_ice) then
     call get_param(param_file, mdl, "SEA_ICE_MEAN_DENSITY", CS%density_sea_ice, &
-                 "A typical density of sea ice, used with the kinematic \n"//&
+                 "A typical density of sea ice, used with the kinematic "//&
                  "viscosity, when USE_RIGID_SEA_ICE is true.", units="kg m-3", &
                  default=900.0)
     call get_param(param_file, mdl, "SEA_ICE_VISCOSITY", CS%Kv_sea_ice, &
-                 "The kinematic viscosity of sufficiently thick sea ice \n"//&
+                 "The kinematic viscosity of sufficiently thick sea ice "//&
                  "for use in calculating the rigidity of sea ice.", &
                  units="m2 s-1", default=1.0e9)
     call get_param(param_file, mdl, "SEA_ICE_RIGID_MASS", CS%rigid_sea_ice_mass, &
-                 "The mass of sea-ice per unit area at which the sea-ice \n"//&
+                 "The mass of sea-ice per unit area at which the sea-ice "//&
                  "starts to exhibit rigidity", units="kg m-2", default=1000.0)
   endif
 
   call get_param(param_file, mdl, "ALLOW_ICEBERG_FLUX_DIAGNOSTICS", iceberg_flux_diags, &
-                 "If true, makes available diagnostics of fluxes from icebergs\n"//&
+                 "If true, makes available diagnostics of fluxes from icebergs "//&
                  "as seen by MOM6.", default=.false.)
   call register_forcing_type_diags(Time, diag, US, CS%use_temperature, CS%handles, &
                                    use_berg_fluxes=iceberg_flux_diags)
 
   call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
-                 "If true, allows flux adjustments to specified via the \n"//&
+                 "If true, allows flux adjustments to specified via the "//&
                  "data_table using the component name 'OCN'.", default=.false.)
   if (CS%allow_flux_adjustments) then
     call data_override_init(Ocean_domain_in=G%Domain%mpp_domain)

--- a/config_src/solo_driver/MESO_surface_forcing.F90
+++ b/config_src/solo_driver/MESO_surface_forcing.F90
@@ -228,16 +228,16 @@ subroutine MESO_surface_forcing_init(Time, G, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
 
   call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
@@ -245,33 +245,33 @@ subroutine MESO_surface_forcing_init(Time, G, param_file, diag, CS)
                  default=0.02)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
-                 "If true, the buoyancy fluxes drive the model back \n"//&
-                 "toward some specified surface state with a rate \n"//&
+                 "If true, the buoyancy fluxes drive the model back "//&
+                 "toward some specified surface state with a rate "//&
                  "given by FLUXCONST.", default= .false.)
 
   if (CS%restorebuoy) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     ! Convert CS%Flux_const from m day-1 to m s-1.
     CS%Flux_const = CS%Flux_const / 86400.0
 
     call get_param(param_file, mdl, "SSTRESTORE_FILE", CS%SSTrestore_file, &
-                 "The file with the SST toward which to restore in \n"//&
+                 "The file with the SST toward which to restore in "//&
                  "variable TEMP.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "SALINITYRESTORE_FILE", CS%salinityrestore_file, &
-                 "The file with the surface salinity toward which to \n"//&
+                 "The file with the surface salinity toward which to "//&
                  "restore in variable SALT.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "SENSIBLEHEAT_FILE", CS%heating_file, &
-                 "The file with the non-shortwave heat flux in \n"//&
+                 "The file with the non-shortwave heat flux in "//&
                  "variable Heat.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "PRECIP_FILE", CS%PmE_file, &
-                 "The file with the net precipiation minus evaporation \n"//&
+                 "The file with the net precipiation minus evaporation "//&
                  "in variable PmE.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "SHORTWAVE_FILE", CS%Solar_file, &
-                 "The file with the shortwave heat flux in \n"//&
+                 "The file with the shortwave heat flux in "//&
                  "variable NET_SOL.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
     CS%inputdir = slasher(CS%inputdir)

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -350,8 +350,8 @@ program MOM_main
   call log_version(param_file, mod_name, version, "")
   call get_param(param_file, mod_name, "DT", dt, fail_if_missing=.true.)
   call get_param(param_file, mod_name, "DT_FORCING", dt_forcing, &
-                 "The time step for changing forcing, coupling with other \n"//&
-                 "components, or potentially writing certain diagnostics. \n"//&
+                 "The time step for changing forcing, coupling with other "//&
+                 "components, or potentially writing certain diagnostics. "//&
                  "The default value is given by DT.", units="s", default=dt)
   if (offline_tracer_mode) then
     call get_param(param_file, mod_name, "DT_OFFLINE", dt_forcing, &
@@ -375,35 +375,35 @@ program MOM_main
     call get_param(param_file, mod_name, "DAYMAX", daymax, timeunit=Time_unit, &
                    default=Time_end, do_not_log=.true.)
     call log_param(param_file, mod_name, "DAYMAX", daymax, &
-                 "The final time of the whole simulation, in units of \n"//&
-                 "TIMEUNIT seconds.  This also sets the potential end \n"//&
-                 "time of the present run segment if the end time is \n"//&
+                 "The final time of the whole simulation, in units of "//&
+                 "TIMEUNIT seconds.  This also sets the potential end "//&
+                 "time of the present run segment if the end time is "//&
                  "not set via ocean_solo_nml in input.nml.", &
                  timeunit=Time_unit)
   else
     call get_param(param_file, mod_name, "DAYMAX", daymax, &
-                 "The final time of the whole simulation, in units of \n"//&
-                 "TIMEUNIT seconds.  This also sets the potential end \n"//&
-                 "time of the present run segment if the end time is \n"//&
+                 "The final time of the whole simulation, in units of "//&
+                 "TIMEUNIT seconds.  This also sets the potential end "//&
+                 "time of the present run segment if the end time is "//&
                  "not set via ocean_solo_nml in input.nml.", &
                  timeunit=Time_unit, fail_if_missing=.true.)
     Time_end = daymax
   endif
 
   call get_param(param_file, mod_name, "SINGLE_STEPPING_CALL", single_step_call, &
-                 "If true, advance the state of MOM with a single step \n"//&
-                 "including both dynamics and thermodynamics.  If false \n"//&
+                 "If true, advance the state of MOM with a single step "//&
+                 "including both dynamics and thermodynamics.  If false "//&
                  "the two phases are advanced with separate calls.", default=.true.)
   call get_param(param_file, mod_name, "DT_THERM", dt_therm, &
-                 "The thermodynamic and tracer advection time step. \n"//&
-                 "Ideally DT_THERM should be an integer multiple of DT \n"//&
-                 "and less than the forcing or coupling time-step, unless \n"//&
-                 "THERMO_SPANS_COUPLING is true, in which case DT_THERM \n"//&
-                 "can be an integer multiple of the coupling timestep.  By \n"//&
+                 "The thermodynamic and tracer advection time step. "//&
+                 "Ideally DT_THERM should be an integer multiple of DT "//&
+                 "and less than the forcing or coupling time-step, unless "//&
+                 "THERMO_SPANS_COUPLING is true, in which case DT_THERM "//&
+                 "can be an integer multiple of the coupling timestep.  By "//&
                  "default DT_THERM is set to DT.", units="s", default=dt)
   call get_param(param_file, mod_name, "DIABATIC_FIRST", diabatic_first, &
-                 "If true, apply diabatic and thermodynamic processes, \n"//&
-                 "including buoyancy forcing and mass gain or loss, \n"//&
+                 "If true, apply diabatic and thermodynamic processes, "//&
+                 "including buoyancy forcing and mass gain or loss, "//&
                  "before stepping the dynamics forward.", default=.false.)
 
 
@@ -411,19 +411,19 @@ program MOM_main
     "MOM_driver: The run has been started at or after the end time of the run.")
 
   call get_param(param_file, mod_name, "RESTART_CONTROL", Restart_control, &
-                 "An integer whose bits encode which restart files are \n"//&
-                 "written. Add 2 (bit 1) for a time-stamped file, and odd \n"//&
-                 "(bit 0) for a non-time-stamped file. A non-time-stamped \n"//&
-                 "restart file is saved at the end of the run segment \n"//&
+                 "An integer whose bits encode which restart files are "//&
+                 "written. Add 2 (bit 1) for a time-stamped file, and odd "//&
+                 "(bit 0) for a non-time-stamped file. A non-time-stamped "//&
+                 "restart file is saved at the end of the run segment "//&
                  "for any non-negative value.", default=1)
   call get_param(param_file, mod_name, "RESTINT", restint, &
-                 "The interval between saves of the restart file in units \n"//&
-                 "of TIMEUNIT.  Use 0 (the default) to not save \n"//&
+                 "The interval between saves of the restart file in units "//&
+                 "of TIMEUNIT.  Use 0 (the default) to not save "//&
                  "incremental restart files at all.", default=real_to_time(0.0), &
                  timeunit=Time_unit)
   call get_param(param_file, mod_name, "WRITE_CPU_STEPS", cpu_steps, &
-                 "The number of coupled timesteps between writing the cpu \n"//&
-                 "time. If this is not positive, do not check cpu time, and \n"//&
+                 "The number of coupled timesteps between writing the cpu "//&
+                 "time. If this is not positive, do not check cpu time, and "//&
                  "the segment run-length can not be set via an elapsed CPU time.", &
                  default=1000)
   call get_param(param_file, "MOM", "DEBUG", debug, &

--- a/config_src/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/solo_driver/MOM_surface_forcing.F90
@@ -1392,7 +1392,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, '')
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
   call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, &
                  "The directory in which all input files are found.", &
@@ -1400,39 +1400,39 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
   CS%inputdir = slasher(CS%inputdir)
 
   call get_param(param_file, mdl, "ADIABATIC", CS%adiabatic, &
-                 "There are no diapycnal mass fluxes if ADIABATIC is \n"//&
-                 "true. This assumes that KD = KDML = 0.0 and that \n"//&
-                 "there is no buoyancy forcing, but makes the model \n"//&
+                 "There are no diapycnal mass fluxes if ADIABATIC is "//&
+                 "true. This assumes that KD = KDML = 0.0 and that "//&
+                 "there is no buoyancy forcing, but makes the model "//&
                  "faster by eliminating subroutine calls.", default=.false.)
   call get_param(param_file, mdl, "VARIABLE_WINDS", CS%variable_winds, &
                  "If true, the winds vary in time after the initialization.", &
                  default=.true.)
   call get_param(param_file, mdl, "VARIABLE_BUOYFORCE", CS%variable_buoyforce, &
-                 "If true, the buoyancy forcing varies in time after the \n"//&
+                 "If true, the buoyancy forcing varies in time after the "//&
                  "initialization of the model.", default=.true.)
 
   call get_param(param_file, mdl, "BUOY_CONFIG", CS%buoy_config, &
-                 "The character string that indicates how buoyancy forcing \n"//&
-                 "is specified. Valid options include (file), (zero), \n"//&
+                 "The character string that indicates how buoyancy forcing "//&
+                 "is specified. Valid options include (file), (zero), "//&
                  "(linear), (USER), (BFB) and (NONE).", fail_if_missing=.true.)
   if (trim(CS%buoy_config) == "file") then
     call get_param(param_file, mdl, "ARCHAIC_OMIP_FORCING_FILE", CS%archaic_OMIP_file, &
-                 "If true, use the forcing variable decomposition from \n"//&
-                 "the old German OMIP prescription that predated CORE. If \n"//&
-                 "false, use the variable groupings available from MOM \n"//&
+                 "If true, use the forcing variable decomposition from "//&
+                 "the old German OMIP prescription that predated CORE. If "//&
+                 "false, use the variable groupings available from MOM "//&
                  "output diagnostics of forcing variables.", default=.true.)
     if (CS%archaic_OMIP_file) then
       call get_param(param_file, mdl, "LONGWAVEDOWN_FILE", CS%longwave_file, &
-                 "The file with the downward longwave heat flux, in \n"//&
+                 "The file with the downward longwave heat flux, in "//&
                  "variable lwdn_sfc.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "LONGWAVEUP_FILE", CS%longwaveup_file, &
-                 "The file with the upward longwave heat flux, in \n"//&
+                 "The file with the upward longwave heat flux, in "//&
                  "variable lwup_sfc.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "EVAPORATION_FILE", CS%evaporation_file, &
-                 "The file with the evaporative moisture flux, in \n"//&
+                 "The file with the evaporative moisture flux, in "//&
                  "variable evap.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "SENSIBLEHEAT_FILE", CS%sensibleheat_file, &
-                 "The file with the sensible heat flux, in \n"//&
+                 "The file with the sensible heat flux, in "//&
                  "variable shflx.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "SHORTWAVEUP_FILE", CS%shortwaveup_file, &
                  "The file with the upward shortwave heat flux.", &
@@ -1441,13 +1441,13 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
                  "The file with the downward shortwave heat flux.", &
                  fail_if_missing=.true.)
       call get_param(param_file, mdl, "SNOW_FILE", CS%snow_file, &
-                 "The file with the downward frozen precip flux, in \n"//&
+                 "The file with the downward frozen precip flux, in "//&
                  "variable snow.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "PRECIP_FILE", CS%rain_file, &
-                 "The file with the downward total precip flux, in \n"//&
+                 "The file with the downward total precip flux, in "//&
                  "variable precip.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "FRESHDISCHARGE_FILE", CS%runoff_file, &
-                 "The file with the fresh and frozen runoff/calving fluxes, \n"//&
+                 "The file with the fresh and frozen runoff/calving fluxes, "//&
                  "invariables disch_w and disch_s.", fail_if_missing=.true.)
 
       ! These variable names are hard-coded, per the archaic OMIP conventions.
@@ -1458,52 +1458,52 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
 
     else
       call get_param(param_file, mdl, "LONGWAVE_FILE", CS%longwave_file, &
-                 "The file with the longwave heat flux, in the variable \n"//&
+                 "The file with the longwave heat flux, in the variable "//&
                  "given by LONGWAVE_FORCING_VAR.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "LONGWAVE_FORCING_VAR", CS%LW_var, &
                  "The variable with the longwave forcing field.", default="LW")
 
       call get_param(param_file, mdl, "SHORTWAVE_FILE", CS%shortwave_file, &
-                 "The file with the shortwave heat flux, in the variable \n"//&
+                 "The file with the shortwave heat flux, in the variable "//&
                  "given by SHORTWAVE_FORCING_VAR.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "SHORTWAVE_FORCING_VAR", CS%SW_var, &
                  "The variable with the shortwave forcing field.", default="SW")
 
       call get_param(param_file, mdl, "EVAPORATION_FILE", CS%evaporation_file, &
-                 "The file with the evaporative moisture flux, in the \n"//&
+                 "The file with the evaporative moisture flux, in the "//&
                  "variable given by EVAP_FORCING_VAR.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "EVAP_FORCING_VAR", CS%evap_var, &
                  "The variable with the evaporative moisture flux.", &
                  default="evap")
 
       call get_param(param_file, mdl, "LATENTHEAT_FILE", CS%latentheat_file, &
-                 "The file with the latent heat flux, in the variable \n"//&
+                 "The file with the latent heat flux, in the variable "//&
                  "given by LATENT_FORCING_VAR.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "LATENT_FORCING_VAR", CS%latent_var, &
                  "The variable with the latent heat flux.", default="latent")
 
       call get_param(param_file, mdl, "SENSIBLEHEAT_FILE", CS%sensibleheat_file, &
-                 "The file with the sensible heat flux, in the variable \n"//&
+                 "The file with the sensible heat flux, in the variable "//&
                  "given by SENSIBLE_FORCING_VAR.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "SENSIBLE_FORCING_VAR", CS%sens_var, &
                  "The variable with the sensible heat flux.", default="sensible")
 
       call get_param(param_file, mdl, "RAIN_FILE", CS%rain_file, &
-                 "The file with the liquid precipitation flux, in the \n"//&
+                 "The file with the liquid precipitation flux, in the "//&
                  "variable given by RAIN_FORCING_VAR.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "RAIN_FORCING_VAR", CS%rain_var, &
                  "The variable with the liquid precipitation flux.", &
                  default="liq_precip")
       call get_param(param_file, mdl, "SNOW_FILE", CS%snow_file, &
-                 "The file with the frozen precipitation flux, in the \n"//&
+                 "The file with the frozen precipitation flux, in the "//&
                  "variable given by SNOW_FORCING_VAR.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "SNOW_FORCING_VAR", CS%snow_var, &
                  "The variable with the frozen precipitation flux.", &
                  default="froz_precip")
 
       call get_param(param_file, mdl, "RUNOFF_FILE", CS%runoff_file, &
-                 "The file with the fresh and frozen runoff/calving \n"//&
-                 "fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR \n"//&
+                 "The file with the fresh and frozen runoff/calving "//&
+                 "fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR "//&
                  "and FROZ_RUNOFF_FORCING_VAR.", fail_if_missing=.true.)
       call get_param(param_file, mdl, "LIQ_RUNOFF_FORCING_VAR", CS%lrunoff_var, &
                  "The variable with the liquid runoff flux.", &
@@ -1514,10 +1514,10 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
     endif
 
     call get_param(param_file, mdl, "SSTRESTORE_FILE", CS%SSTrestore_file, &
-                 "The file with the SST toward which to restore in the \n"//&
+                 "The file with the SST toward which to restore in the "//&
                  "variable given by SST_RESTORE_VAR.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "SALINITYRESTORE_FILE", CS%salinityrestore_file, &
-                 "The file with the surface salinity toward which to \n"//&
+                 "The file with the surface salinity toward which to "//&
                  "restore in the variable given by SSS_RESTORE_VAR.", &
                  fail_if_missing=.true.)
 
@@ -1549,17 +1549,17 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
     CS%salinityrestore_file = trim(CS%inputdir)//trim(CS%salinityrestore_file)
   elseif (trim(CS%buoy_config) == "const") then
     call get_param(param_file, mdl, "SENSIBLE_HEAT_FLUX", CS%constantHeatForcing, &
-                 "A constant heat forcing (positive into ocean) applied \n"//&
+                 "A constant heat forcing (positive into ocean) applied "//&
                  "through the sensible heat flux field. ", &
                  units='W/m2', fail_if_missing=.true.)
   endif
   call get_param(param_file, mdl, "WIND_CONFIG", CS%wind_config, &
-                 "The character string that indicates how wind forcing \n"//&
-                 "is specified. Valid options include (file), (2gyre), \n"//&
+                 "The character string that indicates how wind forcing "//&
+                 "is specified. Valid options include (file), (2gyre), "//&
                  "(1gyre), (gyres), (zero), and (USER).", fail_if_missing=.true.)
   if (trim(CS%wind_config) == "file") then
     call get_param(param_file, mdl, "WIND_FILE", CS%wind_file, &
-                 "The file in which the wind stresses are found in \n"//&
+                 "The file in which the wind stresses are found in "//&
                  "variables STRESS_X and STRESS_Y.", fail_if_missing=.true.)
     call get_param(param_file, mdl, "WINDSTRESS_X_VAR",CS%stress_x_var, &
                  "The name of the x-wind stress variable in WIND_FILE.", &
@@ -1568,37 +1568,37 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
                  "The name of the y-wind stress variable in WIND_FILE.", &
                  default="STRESS_Y")
     call get_param(param_file, mdl, "WINDSTRESS_STAGGER",CS%wind_stagger, &
-                 "A character indicating how the wind stress components \n"//&
+                 "A character indicating how the wind stress components "//&
                  "are staggered in WIND_FILE.  This may be A or C for now.", &
                  default="A")
     call get_param(param_file, mdl, "WINDSTRESS_SCALE", CS%wind_scale, &
                  "A value by which the wind stresses in WIND_FILE are rescaled.", &
                  default=1.0, units="nondim")
     call get_param(param_file, mdl, "USTAR_FORCING_VAR", CS%ustar_var, &
-                 "The name of the friction velocity variable in WIND_FILE \n"//&
-                 "or blank to get ustar from the wind stresses plus the \n"//&
+                 "The name of the friction velocity variable in WIND_FILE "//&
+                 "or blank to get ustar from the wind stresses plus the "//&
                  "gustiness.", default=" ", units="nondim")
     CS%wind_file = trim(CS%inputdir) // trim(CS%wind_file)
   endif
   if (trim(CS%wind_config) == "gyres") then
     call get_param(param_file, mdl, "TAUX_CONST", CS%gyres_taux_const, &
-                 "With the gyres wind_config, the constant offset in the \n"//&
-                 "zonal wind stress profile: \n"//&
+                 "With the gyres wind_config, the constant offset in the "//&
+                 "zonal wind stress profile: "//&
                  "  A in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
     call get_param(param_file, mdl, "TAUX_SIN_AMP",CS%gyres_taux_sin_amp, &
-                 "With the gyres wind_config, the sine amplitude in the \n"//&
-                 "zonal wind stress profile: \n"//&
+                 "With the gyres wind_config, the sine amplitude in the "//&
+                 "zonal wind stress profile: "//&
                  "  B in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
     call get_param(param_file, mdl, "TAUX_COS_AMP",CS%gyres_taux_cos_amp, &
-                 "With the gyres wind_config, the cosine amplitude in \n"//&
-                 "the zonal wind stress profile: \n"//&
+                 "With the gyres wind_config, the cosine amplitude in "//&
+                 "the zonal wind stress profile: "//&
                  "  C in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="Pa", default=0.0)
     call get_param(param_file, mdl, "TAUX_N_PIS",CS%gyres_taux_n_pis, &
-                 "With the gyres wind_config, the number of gyres in \n"//&
-                 "the zonal wind stress profile: \n"//&
+                 "With the gyres wind_config, the number of gyres in "//&
+                 "the zonal wind stress profile: "//&
                  "  n in taux = A + B*sin(n*pi*y/L) + C*cos(n*pi*y/L).", &
                  units="nondim", default=0.0)
   endif
@@ -1610,14 +1610,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
     CS%len_lat = G%len_lat
   endif
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
-                 "If true, the buoyancy fluxes drive the model back \n"//&
-                 "toward some specified surface state with a rate \n"//&
+                 "If true, the buoyancy fluxes drive the model back "//&
+                 "toward some specified surface state with a rate "//&
                  "given by FLUXCONST.", default= .false.)
   call get_param(param_file, mdl, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
                  "The latent heat of fusion.", units="J/kg", default=hlf)
@@ -1625,20 +1625,20 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
                  "The latent heat of fusion.", units="J/kg", default=hlv)
   if (CS%restorebuoy) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
 
     if (CS%use_temperature) then
       call get_param(param_file, mdl, "FLUXCONST_T", CS%Flux_const_T, &
-           "The constant that relates the restoring surface temperature\n"//&
-           "flux to the relative surface anomaly (akin to a piston \n"//&
+           "The constant that relates the restoring surface temperature "//&
+           "flux to the relative surface anomaly (akin to a piston "//&
            "velocity).  Note the non-MKS units.", units="m day-1", &
            default=CS%Flux_const)
       call get_param(param_file, mdl, "FLUXCONST_S", CS%Flux_const_S, &
-           "The constant that relates the restoring surface salinity\n"//&
-           "flux to the relative surface anomaly (akin to a piston \n"//&
+           "The constant that relates the restoring surface salinity "//&
+           "flux to the relative surface anomaly (akin to a piston "//&
            "velocity).  Note the non-MKS units.", units="m day-1", &
            default=CS%Flux_const)
     endif
@@ -1650,20 +1650,20 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
 
     if (trim(CS%buoy_config) == "linear") then
       call get_param(param_file, mdl, "SST_NORTH", CS%T_north, &
-                 "With buoy_config linear, the sea surface temperature \n"//&
-                 "at the northern end of the domain toward which to \n"//&
+                 "With buoy_config linear, the sea surface temperature "//&
+                 "at the northern end of the domain toward which to "//&
                  "to restore.", units="deg C", default=0.0)
       call get_param(param_file, mdl, "SST_SOUTH", CS%T_south, &
-                 "With buoy_config linear, the sea surface temperature \n"//&
-                 "at the southern end of the domain toward which to \n"//&
+                 "With buoy_config linear, the sea surface temperature "//&
+                 "at the southern end of the domain toward which to "//&
                  "to restore.", units="deg C", default=0.0)
       call get_param(param_file, mdl, "SSS_NORTH", CS%S_north, &
-                 "With buoy_config linear, the sea surface salinity \n"//&
-                 "at the northern end of the domain toward which to \n"//&
+                 "With buoy_config linear, the sea surface salinity "//&
+                 "at the northern end of the domain toward which to "//&
                  "to restore.", units="PSU", default=35.0)
       call get_param(param_file, mdl, "SSS_SOUTH", CS%S_south, &
-                 "With buoy_config linear, the sea surface salinity \n"//&
-                 "at the southern end of the domain toward which to \n"//&
+                 "With buoy_config linear, the sea surface salinity "//&
+                 "at the southern end of the domain toward which to "//&
                  "to restore.", units="PSU", default=35.0)
     endif
   endif
@@ -1675,11 +1675,11 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
                  "The background gustiness in the winds.", units="Pa", &
                  default=0.02)
   call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
-                 "If true, use a 2-dimensional gustiness supplied from \n"//&
+                 "If true, use a 2-dimensional gustiness supplied from "//&
                  "an input file", default=.false.)
   if (CS%read_gust_2d) then
     call get_param(param_file, mdl, "GUST_2D_FILE", gust_file, &
-                 "The file in which the wind gustiness is found in \n"//&
+                 "The file in which the wind gustiness is found in "//&
                  "variable gustiness.", fail_if_missing=.true.)
     call safe_alloc_ptr(CS%gust,G%isd,G%ied,G%jsd,G%jed)
     filename = trim(CS%inputdir) // trim(gust_file)
@@ -1704,10 +1704,10 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
     call idealized_hurricane_wind_init(Time, G, param_file, CS%idealized_hurricane_CSp)
   elseif (trim(CS%wind_config) == "const") then
     call get_param(param_file, mdl, "CONST_WIND_TAUX", CS%tau_x0, &
-                 "With wind_config const, this is the constant zonal\n"//&
+                 "With wind_config const, this is the constant zonal "//&
                  "wind-stress", units="Pa", fail_if_missing=.true.)
     call get_param(param_file, mdl, "CONST_WIND_TAUY", CS%tau_y0, &
-                 "With wind_config const, this is the constant meridional\n"//&
+                 "With wind_config const, this is the constant meridional "//&
                  "wind-stress", units="Pa", fail_if_missing=.true.)
   elseif (trim(CS%wind_config) == "SCM_CVmix_tests" .or. &
           trim(CS%buoy_config) == "SCM_CVmix_tests") then

--- a/config_src/solo_driver/Neverland_surface_forcing.F90
+++ b/config_src/solo_driver/Neverland_surface_forcing.F90
@@ -233,16 +233,16 @@ subroutine Neverland_surface_forcing_init(Time, G, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
 
   call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
 ! call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
@@ -250,14 +250,14 @@ subroutine Neverland_surface_forcing_init(Time, G, param_file, diag, CS)
 !                default=0.02)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
-                 "If true, the buoyancy fluxes drive the model back \n"//&
-                 "toward some specified surface state with a rate \n"//&
+                 "If true, the buoyancy fluxes drive the model back "//&
+                 "toward some specified surface state with a rate "//&
                  "given by FLUXCONST.", default= .false.)
 
   if (CS%restorebuoy) then
     call get_param(param_file, mdl, "FLUXCONST", CS%flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     ! Convert CS%flux_const from m day-1 to m s-1.

--- a/config_src/solo_driver/user_surface_forcing.F90
+++ b/config_src/solo_driver/user_surface_forcing.F90
@@ -256,16 +256,16 @@ subroutine USER_surface_forcing_init(Time, G, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
 
   call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
@@ -273,13 +273,13 @@ subroutine USER_surface_forcing_init(Time, G, param_file, diag, CS)
                  default=0.02)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
-                 "If true, the buoyancy fluxes drive the model back \n"//&
-                 "toward some specified surface state with a rate \n"//&
+                 "If true, the buoyancy fluxes drive the model back "//&
+                 "toward some specified surface state with a rate "//&
                  "given by FLUXCONST.", default= .false.)
   if (CS%restorebuoy) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     ! Convert CS%Flux_const from m day-1 to m s-1.

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -161,8 +161,8 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
 
   call get_param(param_file, mdl, "REMAP_UV_USING_OLD_ALG", &
                  CS%remap_uv_using_old_alg, &
-                 "If true, uses the old remapping-via-a-delta-z method for\n"//&
-                 "remapping u and v. If false, uses the new method that remaps\n"//&
+                 "If true, uses the old remapping-via-a-delta-z method for "//&
+                 "remapping u and v. If false, uses the new method that remaps "//&
                  "between grids described by an old and new thickness.", &
                  default=.true.)
 
@@ -171,24 +171,24 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
 
   ! Initialize and configure remapping
   call get_param(param_file, mdl, "REMAPPING_SCHEME", string, &
-                 "This sets the reconstruction scheme used\n"//&
-                 "for vertical remapping for all variables.\n"//&
-                 "It can be one of the following schemes:\n"//&
+                 "This sets the reconstruction scheme used "//&
+                 "for vertical remapping for all variables. "//&
+                 "It can be one of the following schemes: "//&
                  trim(remappingSchemesDoc), default=remappingDefaultScheme)
   call get_param(param_file, mdl, "FATAL_CHECK_RECONSTRUCTIONS", check_reconstruction, &
-                 "If true, cell-by-cell reconstructions are checked for\n"//&
-                 "consistency and if non-monotonicity or an inconsistency is\n"//&
+                 "If true, cell-by-cell reconstructions are checked for "//&
+                 "consistency and if non-monotonicity or an inconsistency is "//&
                  "detected then a FATAL error is issued.", default=.false.)
   call get_param(param_file, mdl, "FATAL_CHECK_REMAPPING", check_remapping, &
-                 "If true, the results of remapping are checked for\n"//&
-                 "conservation and new extrema and if an inconsistency is\n"//&
+                 "If true, the results of remapping are checked for "//&
+                 "conservation and new extrema and if an inconsistency is "//&
                  "detected then a FATAL error is issued.", default=.false.)
   call get_param(param_file, mdl, "REMAP_BOUND_INTERMEDIATE_VALUES", force_bounds_in_subcell, &
-                 "If true, the values on the intermediate grid used for remapping\n"//&
-                 "are forced to be bounded, which might not be the case due to\n"//&
+                 "If true, the values on the intermediate grid used for remapping "//&
+                 "are forced to be bounded, which might not be the case due to "//&
                  "round off.", default=.false.)
   call get_param(param_file, mdl, "REMAP_BOUNDARY_EXTRAP", remap_boundary_extrap, &
-                 "If true, values at the interfaces of boundary cells are \n"//&
+                 "If true, values at the interfaces of boundary cells are "//&
                  "extrapolated instead of piecewise constant", default=.false.)
   call initialize_remapping( CS%remapCS, string, &
                              boundary_extrapolation=remap_boundary_extrap, &
@@ -197,32 +197,32 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
                              force_bounds_in_subcell=force_bounds_in_subcell)
 
   call get_param(param_file, mdl, "REMAP_AFTER_INITIALIZATION", CS%remap_after_initialization, &
-                 "If true, applies regridding and remapping immediately after\n"//&
-                 "initialization so that the state is ALE consistent. This is a\n"//&
-                 "legacy step and should not be needed if the initialization is\n"//&
+                 "If true, applies regridding and remapping immediately after "//&
+                 "initialization so that the state is ALE consistent. This is a "//&
+                 "legacy step and should not be needed if the initialization is "//&
                  "consistent with the coordinate mode.", default=.true.)
 
   call get_param(param_file, mdl, "REGRID_TIME_SCALE", CS%regrid_time_scale, &
-                 "The time-scale used in blending between the current (old) grid\n"//&
-                 "and the target (new) grid. A short time-scale favors the target\n"//&
-                 "grid (0. or anything less than DT_THERM) has no memory of the old\n"//&
+                 "The time-scale used in blending between the current (old) grid "//&
+                 "and the target (new) grid. A short time-scale favors the target "//&
+                 "grid (0. or anything less than DT_THERM) has no memory of the old "//&
                  "grid. A very long time-scale makes the model more Lagrangian.", &
                  units="s", default=0.)
   call get_param(param_file, mdl, "REGRID_FILTER_SHALLOW_DEPTH", filter_shallow_depth, &
-                 "The depth above which no time-filtering is applied. Above this depth\n"//&
+                 "The depth above which no time-filtering is applied. Above this depth "//&
                  "final grid exactly matches the target (new) grid.", &
                  units="m", default=0., scale=GV%m_to_H)
   call get_param(param_file, mdl, "REGRID_FILTER_DEEP_DEPTH", filter_deep_depth, &
-                 "The depth below which full time-filtering is applied with time-scale\n"//&
-                 "REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and\n"//&
+                 "The depth below which full time-filtering is applied with time-scale "//&
+                 "REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and "//&
                  "REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.", &
                  units="m", default=0., scale=GV%m_to_H)
   call set_regrid_params(CS%regridCS, depth_of_time_filter_shallow=filter_shallow_depth, &
                                       depth_of_time_filter_deep=filter_deep_depth)
   call get_param(param_file, mdl, "REGRID_USE_OLD_DIRECTION", local_logical, &
-                 "If true, the regridding ntegrates upwards from the bottom for\n"//&
-                 "interface positions, much as the main model does. If false\n"//&
-                 "regridding integrates downward, consistant with the remapping\n"//&
+                 "If true, the regridding ntegrates upwards from the bottom for "//&
+                 "interface positions, much as the main model does. If false "//&
+                 "regridding integrates downward, consistant with the remapping "//&
                  "code.", default=.true., do_not_log=.true.)
   call set_regrid_params(CS%regridCS, integrate_downward_for_e=.not.local_logical)
 
@@ -1121,8 +1121,8 @@ subroutine ALE_initRegridding(GV, US, max_depth, param_file, mdl, regridCS)
   character(len=30) :: coord_mode
 
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", coord_mode, &
-                 "Coordinate mode for vertical regridding.\n"//&
-                 "Choose among the following possibilities:\n"//&
+                 "Coordinate mode for vertical regridding. "//&
+                 "Choose among the following possibilities: "//&
                  trim(regriddingCoordinateModeDoc), &
                  default=DEFAULT_COORDINATE_MODE, fail_if_missing=.true.)
 

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -244,21 +244,21 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
       string2 = 'PPM_H4' ! Default for diagnostics
     endif
     call get_param(param_file, mdl, "INTERPOLATION_SCHEME", string, &
-                 "This sets the interpolation scheme to use to\n"//&
-                 "determine the new grid. These parameters are\n"//&
-                 "only relevant when REGRIDDING_COORDINATE_MODE is\n"//&
-                 "set to a function of state. Otherwise, it is not\n"//&
-                 "used. It can be one of the following schemes:\n"//&
+                 "This sets the interpolation scheme to use to "//&
+                 "determine the new grid. These parameters are "//&
+                 "only relevant when REGRIDDING_COORDINATE_MODE is "//&
+                 "set to a function of state. Otherwise, it is not "//&
+                 "used. It can be one of the following schemes: "//&
                  trim(regriddingInterpSchemeDoc), default=trim(string2))
     call set_regrid_params(CS, interp_scheme=string)
   endif
 
   if (main_parameters .and. coord_is_state_dependent) then
     call get_param(param_file, mdl, "BOUNDARY_EXTRAPOLATION", tmpLogical, &
-                 "When defined, a proper high-order reconstruction\n"//&
-                 "scheme is used within boundary cells rather\n"//&
-                 "than PCM. E.g., if PPM is used for remapping, a\n"//&
-                 "PPM reconstruction will also be used within\n"//&
+                 "When defined, a proper high-order reconstruction "//&
+                 "scheme is used within boundary cells rather "//&
+                 "than PCM. E.g., if PPM is used for remapping, a "//&
+                 "PPM reconstruction will also be used within "//&
                  "boundary cells.", default=regriddingDefaultBoundaryExtrapolation)
     call set_regrid_params(CS, boundary_extrapolation=tmpLogical)
   else
@@ -277,7 +277,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
     if (maximum_depth>3000.) string2='WOA09' ! For convenience
   endif
   call get_param(param_file, mdl, param_name, string, &
-                 "Determines how to specify the coordinate\n"//&
+                 "Determines how to specify the coordinate "//&
                  "resolution. Valid options are:\n"//&
                  " PARAM       - use the vector-parameter "//trim(coord_res_param)//"\n"//&
                  " UNIFORM[:N] - uniformly distributed\n"//&
@@ -501,15 +501,15 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
 
   if (main_parameters .and. coord_is_state_dependent) then
     call get_param(param_file, mdl, "REGRID_COMPRESSIBILITY_FRACTION", tmpReal, &
-                 "When interpolating potential density profiles we can add\n"//&
-                 "some artificial compressibility solely to make homogeneous\n"//&
+                 "When interpolating potential density profiles we can add "//&
+                 "some artificial compressibility solely to make homogeneous "//&
                  "regions appear stratified.", default=0.)
     call set_regrid_params(CS, compress_fraction=tmpReal)
   endif
 
   if (main_parameters) then
     call get_param(param_file, mdl, "MIN_THICKNESS", tmpReal, &
-                 "When regridding, this is the minimum layer\n"//&
+                 "When regridding, this is the minimum layer "//&
                  "thickness allowed.", units="m", scale=GV%m_to_H, &
                  default=regriddingDefaultMinThickness )
     call set_regrid_params(CS, min_thickness=tmpReal)
@@ -520,23 +520,23 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
   if (coordinateMode(coord_mode) == REGRIDDING_SLIGHT) then
     ! Set SLight-specific regridding parameters.
     call get_param(param_file, mdl, "SLIGHT_DZ_SURFACE", dz_fixed_sfc, &
-                 "The nominal thickness of fixed thickness near-surface\n"//&
+                 "The nominal thickness of fixed thickness near-surface "//&
                  "layers with the SLight coordinate.", units="m", default=1.0, scale=GV%m_to_H)
     call get_param(param_file, mdl, "SLIGHT_NZ_SURFACE_FIXED", nz_fixed_sfc, &
-                 "The number of fixed-depth surface layers with the SLight\n"//&
+                 "The number of fixed-depth surface layers with the SLight "//&
                  "coordinate.", units="nondimensional", default=2)
     call get_param(param_file, mdl, "SLIGHT_SURFACE_AVG_DEPTH", Rho_avg_depth, &
-                 "The thickness of the surface region over which to average\n"//&
-                 "when calculating the density to use to define the interior\n"//&
+                 "The thickness of the surface region over which to average "//&
+                 "when calculating the density to use to define the interior "//&
                  "with the SLight coordinate.", units="m", default=1.0, scale=GV%m_to_H)
     call get_param(param_file, mdl, "SLIGHT_NLAY_TO_INTERIOR", nlay_sfc_int, &
-                 "The number of layers to offset the surface density when\n"//&
+                 "The number of layers to offset the surface density when "//&
                  "defining where the interior ocean starts with SLight.", &
                  units="nondimensional", default=2.0)
     call get_param(param_file, mdl, "SLIGHT_FIX_HALOCLINES", fix_haloclines, &
-                 "If true, identify regions above the reference pressure\n"//&
-                 "where the reference pressure systematically underestimates\n"//&
-                 "the stratification and use this in the definition of the\n"//&
+                 "If true, identify regions above the reference pressure "//&
+                 "where the reference pressure systematically underestimates "//&
+                 "the stratification and use this in the definition of the "//&
                  "interior with the SLight coordinate.", default=.false.)
 
     call set_regrid_params(CS, dz_min_surface=dz_fixed_sfc, &
@@ -545,14 +545,14 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
     if (fix_haloclines) then
       ! Set additional parameters related to SLIGHT_FIX_HALOCLINES.
       call get_param(param_file, mdl, "HALOCLINE_FILTER_LENGTH", filt_len, &
-                 "A length scale over which to smooth the temperature and\n"//&
+                 "A length scale over which to smooth the temperature and "//&
                  "salinity before identifying erroneously unstable haloclines.", &
                  units="m", default=2.0)
       call get_param(param_file, mdl, "HALOCLINE_STRAT_TOL", strat_tol, &
-                 "A tolerance for the ratio of the stratification of the\n"//&
-                 "apparent coordinate stratification to the actual value\n"//&
-                 "that is used to identify erroneously unstable haloclines.\n"//&
-                 "This ratio is 1 when they are equal, and sensible values \n"//&
+                 "A tolerance for the ratio of the stratification of the "//&
+                 "apparent coordinate stratification to the actual value "//&
+                 "that is used to identify erroneously unstable haloclines. "//&
+                 "This ratio is 1 when they are equal, and sensible values "//&
                  "are between 0 and 0.5.", units="nondimensional", default=0.2)
       call set_regrid_params(CS, halocline_filt_len=filt_len, &
                              halocline_strat_tol=strat_tol)
@@ -575,7 +575,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
          "Scaling on optimization tendency.", &
          units="nondim", default=1.0)
     call get_param(param_file, mdl, "ADAPT_DO_MIN_DEPTH", tmpLogical, &
-         "If true, make a HyCOM-like mixed layer by preventing interfaces\n"//&
+         "If true, make a HyCOM-like mixed layer by preventing interfaces "//&
          "from being shallower than the depths specified by the regridding coordinate.", &
          default=.false.)
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1662,86 +1662,86 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   endif
 
   call get_param(param_file, "MOM", "CALC_RHO_FOR_SEA_LEVEL", CS%calc_rho_for_sea_lev, &
-                 "If true, the in-situ density is used to calculate the\n"//&
-                 "effective sea level that is returned to the coupler. If false,\n"//&
+                 "If true, the in-situ density is used to calculate the "//&
+                 "effective sea level that is returned to the coupler. If false, "//&
                  "the Boussinesq parameter RHO_0 is used.", default=.false.)
   call get_param(param_file, "MOM", "ENABLE_THERMODYNAMICS", use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
   call get_param(param_file, "MOM", "USE_EOS", use_EOS, &
-                 "If true,  density is calculated from temperature and \n"//&
-                 "salinity with an equation of state.  If USE_EOS is \n"//&
+                 "If true,  density is calculated from temperature and "//&
+                 "salinity with an equation of state.  If USE_EOS is "//&
                  "true, ENABLE_THERMODYNAMICS must be true as well.", &
                  default=use_temperature)
   call get_param(param_file, "MOM", "DIABATIC_FIRST", CS%diabatic_first, &
-                 "If true, apply diabatic and thermodynamic processes, \n"//&
-                 "including buoyancy forcing and mass gain or loss, \n"//&
+                 "If true, apply diabatic and thermodynamic processes, "//&
+                 "including buoyancy forcing and mass gain or loss, "//&
                  "before stepping the dynamics forward.", default=.false.)
   call get_param(param_file, "MOM", "USE_CONTEMP_ABSSAL", use_conT_absS, &
-                 "If true, the prognostics T&S are the conservative temperature \n"//&
-                 "and absolute salinity. Care should be taken to convert them \n"//&
-                 "to potential temperature and practical salinity before \n"//&
-                 "exchanging them with the coupler and/or reporting T&S diagnostics.\n", &
+                 "If true, the prognostics T&S are the conservative temperature "//&
+                 "and absolute salinity. Care should be taken to convert them "//&
+                 "to potential temperature and practical salinity before "//&
+                 "exchanging them with the coupler and/or reporting T&S diagnostics.", &
                  default=.false.)
   CS%tv%T_is_conT = use_conT_absS ; CS%tv%S_is_absS = use_conT_absS
   call get_param(param_file, "MOM", "ADIABATIC", CS%adiabatic, &
-                 "There are no diapycnal mass fluxes if ADIABATIC is \n"//&
-                 "true. This assumes that KD = KDML = 0.0 and that \n"//&
-                 "there is no buoyancy forcing, but makes the model \n"//&
+                 "There are no diapycnal mass fluxes if ADIABATIC is "//&
+                 "true. This assumes that KD = KDML = 0.0 and that "//&
+                 "there is no buoyancy forcing, but makes the model "//&
                  "faster by eliminating subroutine calls.", default=.false.)
   call get_param(param_file, "MOM", "USE_LEGACY_DIABATIC_DRIVER", CS%use_legacy_diabatic_driver, &
-                 "If true, use a legacy version of the diabatic subroutine. \n"//&
+                 "If true, use a legacy version of the diabatic subroutine. "//&
                  "This is temporary and is needed to avoid change in answers.", &
                  default=.true.)
   call get_param(param_file, "MOM", "DO_DYNAMICS", CS%do_dynamics, &
-                 "If False, skips the dynamics calls that update u & v, as well as \n"//&
-                 "the gravity wave adjustment to h. This is a fragile feature and \n"//&
+                 "If False, skips the dynamics calls that update u & v, as well as "//&
+                 "the gravity wave adjustment to h. This is a fragile feature and "//&
                  "thus undocumented.", default=.true., do_not_log=.true. )
   call get_param(param_file, "MOM", "ADVECT_TS", advect_TS, &
-                 "If True, advect temperature and salinity horizontally \n"//&
-                 "If False, T/S are registered for advection.\n"//&
-                 "This is intended only to be used in offline tracer mode \n"//&
+                 "If True, advect temperature and salinity horizontally "//&
+                 "If False, T/S are registered for advection. "//&
+                 "This is intended only to be used in offline tracer mode "//&
                  "and is by default false in that case.", &
                  do_not_log = .true., default=.true. )
   if (present(offline_tracer_mode)) then ! Only read this parameter in enabled modes
     call get_param(param_file, "MOM", "OFFLINE_TRACER_MODE", CS%offline_tracer_mode, &
-                 "If true, barotropic and baroclinic dynamics, thermodynamics\n"//&
-                 "are all bypassed with all the fields necessary to integrate\n"//&
-                 "the tracer advection and diffusion equation are read in from\n"//&
-                 "files stored from a previous integration of the prognostic model.\n"//&
+                 "If true, barotropic and baroclinic dynamics, thermodynamics "//&
+                 "are all bypassed with all the fields necessary to integrate "//&
+                 "the tracer advection and diffusion equation are read in from "//&
+                 "files stored from a previous integration of the prognostic model. "//&
                  "NOTE: This option only used in the ocean_solo_driver.", default=.false.)
     if (CS%offline_tracer_mode) then
       call get_param(param_file, "MOM", "ADVECT_TS", advect_TS, &
-                   "If True, advect temperature and salinity horizontally\n"//&
-                   "If False, T/S are registered for advection.\n"//&
+                   "If True, advect temperature and salinity horizontally "//&
+                   "If False, T/S are registered for advection. "//&
                    "This is intended only to be used in offline tracer mode."//&
                    "and is by default false in that case", &
                    default=.false. )
     endif
   endif
   call get_param(param_file, "MOM", "USE_REGRIDDING", CS%use_ALE_algorithm, &
-                 "If True, use the ALE algorithm (regridding/remapping).\n"//&
+                 "If True, use the ALE algorithm (regridding/remapping). "//&
                  "If False, use the layered isopycnal algorithm.", default=.false. )
   call get_param(param_file, "MOM", "BULKMIXEDLAYER", bulkmixedlayer, &
-                 "If true, use a Kraus-Turner-like bulk mixed layer \n"//&
-                 "with transitional buffer layers.  Layers 1 through  \n"//&
-                 "NKML+NKBL have variable densities. There must be at \n"//&
-                 "least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. \n"//&
-                 "BULKMIXEDLAYER can not be used with USE_REGRIDDING. \n"//&
+                 "If true, use a Kraus-Turner-like bulk mixed layer "//&
+                 "with transitional buffer layers.  Layers 1 through "//&
+                 "NKML+NKBL have variable densities. There must be at "//&
+                 "least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. "//&
+                 "BULKMIXEDLAYER can not be used with USE_REGRIDDING. "//&
                  "The default is influenced by ENABLE_THERMODYNAMICS.", &
                  default=use_temperature .and. .not.CS%use_ALE_algorithm)
   call get_param(param_file, "MOM", "THICKNESSDIFFUSE", CS%thickness_diffuse, &
-                 "If true, interface heights are diffused with a \n"//&
+                 "If true, interface heights are diffused with a "//&
                  "coefficient of KHTH.", default=.false.)
   call get_param(param_file, "MOM",  "THICKNESSDIFFUSE_FIRST", &
                                       CS%thickness_diffuse_first, &
-                 "If true, do thickness diffusion before dynamics.\n"//&
+                 "If true, do thickness diffusion before dynamics. "//&
                  "This is only used if THICKNESSDIFFUSE is true.", &
                  default=.false.)
   if (.not.CS%thickness_diffuse) CS%thickness_diffuse_first = .false.
   call get_param(param_file, "MOM", "BATHYMETRY_AT_VEL", bathy_at_vel, &
-                 "If true, there are separate values for the basin depths \n"//&
-                 "at velocity points.  Otherwise the effects of topography \n"//&
+                 "If true, there are separate values for the basin depths "//&
+                 "at velocity points.  Otherwise the effects of topography "//&
                  "are entirely determined from thickness points.", &
                  default=.false.)
   call get_param(param_file, "MOM", "USE_WAVES", CS%UseWaves, default=.false., &
@@ -1751,56 +1751,56 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
   call get_param(param_file, "MOM", "DEBUG_TRUNCATIONS", debug_truncations, &
-                 "If true, calculate all diagnostics that are useful for \n"//&
+                 "If true, calculate all diagnostics that are useful for "//&
                  "debugging truncations.", default=.false., debuggingParam=.true.)
 
   call get_param(param_file, "MOM", "DT", CS%dt, &
-                 "The (baroclinic) dynamics time step.  The time-step that \n"//&
-                 "is actually used will be an integer fraction of the \n"//&
-                 "forcing time-step (DT_FORCING in ocean-only mode or the \n"//&
+                 "The (baroclinic) dynamics time step.  The time-step that "//&
+                 "is actually used will be an integer fraction of the "//&
+                 "forcing time-step (DT_FORCING in ocean-only mode or the "//&
                  "coupling timestep in coupled mode.)", units="s", &
                  fail_if_missing=.true.)
   call get_param(param_file, "MOM", "DT_THERM", CS%dt_therm, &
-                 "The thermodynamic and tracer advection time step. \n"//&
-                 "Ideally DT_THERM should be an integer multiple of DT \n"//&
-                 "and less than the forcing or coupling time-step, unless \n"//&
-                 "THERMO_SPANS_COUPLING is true, in which case DT_THERM \n"//&
-                 "can be an integer multiple of the coupling timestep.  By \n"//&
+                 "The thermodynamic and tracer advection time step. "//&
+                 "Ideally DT_THERM should be an integer multiple of DT "//&
+                 "and less than the forcing or coupling time-step, unless "//&
+                 "THERMO_SPANS_COUPLING is true, in which case DT_THERM "//&
+                 "can be an integer multiple of the coupling timestep.  By "//&
                  "default DT_THERM is set to DT.", units="s", default=CS%dt)
   call get_param(param_file, "MOM", "THERMO_SPANS_COUPLING", CS%thermo_spans_coupling, &
-                 "If true, the MOM will take thermodynamic and tracer \n"//&
-                 "timesteps that can be longer than the coupling timestep. \n"//&
-                 "The actual thermodynamic timestep that is used in this \n"//&
-                 "case is the largest integer multiple of the coupling \n"//&
+                 "If true, the MOM will take thermodynamic and tracer "//&
+                 "timesteps that can be longer than the coupling timestep. "//&
+                 "The actual thermodynamic timestep that is used in this "//&
+                 "case is the largest integer multiple of the coupling "//&
                  "timestep that is less than or equal to DT_THERM.", default=.false.)
 
   if (bulkmixedlayer) then
     CS%Hmix = -1.0 ; CS%Hmix_UV = -1.0
   else
     call get_param(param_file, "MOM", "HMIX_SFC_PROP", CS%Hmix, &
-                 "If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth \n"//&
-                 "over which to average to find surface properties like \n"//&
+                 "If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth "//&
+                 "over which to average to find surface properties like "//&
                  "SST and SSS or density (but not surface velocities).", &
                  units="m", default=1.0, scale=US%m_to_Z)
     call get_param(param_file, "MOM", "HMIX_UV_SFC_PROP", CS%Hmix_UV, &
-                 "If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth\n"//&
-                 "over which to average to find surface flow properties,\n"//&
+                 "If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth "//&
+                 "over which to average to find surface flow properties, "//&
                  "SSU, SSV. A non-positive value indicates no averaging.", &
                  units="m", default=0.0, scale=US%m_to_Z)
   endif
   call get_param(param_file, "MOM", "HFREEZE", CS%HFrz, &
-                 "If HFREEZE > 0, melt potential will be computed. The actual depth \n"//&
-                 "over which melt potential is computed will be min(HFREEZE, OBLD), \n"//&
-                 "where OBLD is the boundary layer depth. If HFREEZE <= 0 (default), \n"//&
+                 "If HFREEZE > 0, melt potential will be computed. The actual depth "//&
+                 "over which melt potential is computed will be min(HFREEZE, OBLD), "//&
+                 "where OBLD is the boundary layer depth. If HFREEZE <= 0 (default), "//&
                  "melt potential will not be computed.", units="m", default=-1.0)
   call get_param(param_file, "MOM", "MIN_Z_DIAG_INTERVAL", Z_diag_int, &
-                 "The minimum amount of time in seconds between \n"//&
-                 "calculations of depth-space diagnostics. Making this \n"//&
-                 "larger than DT_THERM reduces the  performance penalty \n"//&
+                 "The minimum amount of time in seconds between "//&
+                 "calculations of depth-space diagnostics. Making this "//&
+                 "larger than DT_THERM reduces the  performance penalty "//&
                  "of regridding to depth online.", units="s", default=0.0)
   call get_param(param_file, "MOM", "INTERPOLATE_P_SURF", CS%interp_p_surf, &
-                 "If true, linearly interpolate the surface pressure \n"//&
-                 "over the coupling time step, using the specified value \n"//&
+                 "If true, linearly interpolate the surface pressure "//&
+                 "over the coupling time step, using the specified value "//&
                  "at the end of the step.", default=.false.)
 
   if (CS%split) then
@@ -1808,10 +1808,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     default_val = CS%dt_therm ; if (dtbt > 0.0) default_val = -1.0
     CS%dtbt_reset_period = -1.0
     call get_param(param_file, "MOM", "DTBT_RESET_PERIOD", CS%dtbt_reset_period, &
-                 "The period between recalculations of DTBT (if DTBT <= 0). \n"//&
-                 "If DTBT_RESET_PERIOD is negative, DTBT is set based \n"//&
-                 "only on information available at initialization.  If 0, \n"//&
-                 "DTBT will be set every dynamics time step. The default \n"//&
+                 "The period between recalculations of DTBT (if DTBT <= 0). "//&
+                 "If DTBT_RESET_PERIOD is negative, DTBT is set based "//&
+                 "only on information available at initialization.  If 0, "//&
+                 "DTBT will be set every dynamics time step. The default "//&
                  "is set by DT_THERM.  This is only used if SPLIT is true.", &
                  units="s", default=default_val, do_not_read=(dtbt > 0.0))
   endif
@@ -1820,46 +1820,46 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   use_frazil = .false. ; bound_salinity = .false. ; CS%tv%P_Ref = 2.0e7
   if (use_temperature) then
     call get_param(param_file, "MOM", "FRAZIL", use_frazil, &
-                 "If true, water freezes if it gets too cold, and the \n"//&
-                 "the accumulated heat deficit is returned in the \n"//&
-                 "surface state.  FRAZIL is only used if \n"//&
+                 "If true, water freezes if it gets too cold, and the "//&
+                 "the accumulated heat deficit is returned in the "//&
+                 "surface state.  FRAZIL is only used if "//&
                  "ENABLE_THERMODYNAMICS is true.", default=.false.)
     call get_param(param_file, "MOM", "DO_GEOTHERMAL", use_geothermal, &
                  "If true, apply geothermal heating.", default=.false.)
     call get_param(param_file, "MOM", "BOUND_SALINITY", bound_salinity, &
-                 "If true, limit salinity to being positive. (The sea-ice \n"//&
-                 "model may ask for more salt than is available and \n"//&
+                 "If true, limit salinity to being positive. (The sea-ice "//&
+                 "model may ask for more salt than is available and "//&
                  "drive the salinity negative otherwise.)", default=.false.)
     call get_param(param_file, "MOM", "MIN_SALINITY", CS%tv%min_salinity, &
-                 "The minimum value of salinity when BOUND_SALINITY=True. \n"//&
-                 "The default is 0.01 for backward compatibility but ideally \n"//&
+                 "The minimum value of salinity when BOUND_SALINITY=True. "//&
+                 "The default is 0.01 for backward compatibility but ideally "//&
                  "should be 0.", units="PPT", default=0.01, do_not_log=.not.bound_salinity)
     call get_param(param_file, "MOM", "C_P", CS%tv%C_p, &
-                 "The heat capacity of sea water, approximated as a \n"//&
-                 "constant. This is only used if ENABLE_THERMODYNAMICS is \n"//&
-                 "true. The default value is from the TEOS-10 definition \n"//&
+                 "The heat capacity of sea water, approximated as a "//&
+                 "constant. This is only used if ENABLE_THERMODYNAMICS is "//&
+                 "true. The default value is from the TEOS-10 definition "//&
                  "of conservative temperature.", units="J kg-1 K-1", &
                  default=3991.86795711963)
   endif
   if (use_EOS) call get_param(param_file, "MOM", "P_REF", CS%tv%P_Ref, &
-                 "The pressure that is used for calculating the coordinate \n"//&
-                 "density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.) \n"//&
-                 "This is only used if USE_EOS and ENABLE_THERMODYNAMICS \n"//&
+                 "The pressure that is used for calculating the coordinate "//&
+                 "density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.) "//&
+                 "This is only used if USE_EOS and ENABLE_THERMODYNAMICS "//&
                  "are true.", units="Pa", default=2.0e7)
 
   if (bulkmixedlayer) then
     call get_param(param_file, "MOM", "NKML", nkml, &
-                 "The number of sublayers within the mixed layer if \n"//&
+                 "The number of sublayers within the mixed layer if "//&
                  "BULKMIXEDLAYER is true.", units="nondim", default=2)
     call get_param(param_file, "MOM", "NKBL", nkbl, &
-                 "The number of layers that are used as variable density \n"//&
+                 "The number of layers that are used as variable density "//&
                  "buffer layers if BULKMIXEDLAYER is true.", units="nondim", &
                  default=2)
   endif
 
   call get_param(param_file, "MOM", "GLOBAL_INDEXING", global_indexing, &
-                 "If true, use a global lateral indexing convention, so \n"//&
-                 "that corresponding points on different processors have \n"//&
+                 "If true, use a global lateral indexing convention, so "//&
+                 "that corresponding points on different processors have "//&
                  "the same index. This does not work with static memory.", &
                  default=.false., layoutParam=.true.)
 #ifdef STATIC_MEMORY_
@@ -1867,9 +1867,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
        "GLOBAL_INDEXING can not be true with STATIC_MEMORY.")
 #endif
   call get_param(param_file, "MOM", "FIRST_DIRECTION", first_direction, &
-                 "An integer that indicates which direction goes first \n"//&
-                 "in parts of the code that use directionally split \n"//&
-                 "updates, with even numbers (or 0) used for x- first \n"//&
+                 "An integer that indicates which direction goes first "//&
+                 "in parts of the code that use directionally split "//&
+                 "updates, with even numbers (or 0) used for x- first "//&
                  "and odd numbers used for y-first.", default=0)
 
   call get_param(param_file, "MOM", "CHECK_BAD_SURFACE_VALS", CS%check_bad_sfc_vals, &
@@ -1877,37 +1877,37 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  default=.false.)
   if (CS%check_bad_sfc_vals) then
     call get_param(param_file, "MOM", "BAD_VAL_SSH_MAX", CS%bad_val_ssh_max, &
-                 "The value of SSH above which a bad value message is \n"//&
+                 "The value of SSH above which a bad value message is "//&
                  "triggered, if CHECK_BAD_SURFACE_VALS is true.", units="m", &
                  default=20.0)
     call get_param(param_file, "MOM", "BAD_VAL_SSS_MAX", CS%bad_val_sss_max, &
-                 "The value of SSS above which a bad value message is \n"//&
+                 "The value of SSS above which a bad value message is "//&
                  "triggered, if CHECK_BAD_SURFACE_VALS is true.", units="PPT", &
                  default=45.0)
     call get_param(param_file, "MOM", "BAD_VAL_SST_MAX", CS%bad_val_sst_max, &
-                 "The value of SST above which a bad value message is \n"//&
+                 "The value of SST above which a bad value message is "//&
                  "triggered, if CHECK_BAD_SURFACE_VALS is true.", &
                  units="deg C", default=45.0)
     call get_param(param_file, "MOM", "BAD_VAL_SST_MIN", CS%bad_val_sst_min, &
-                 "The value of SST below which a bad value message is \n"//&
+                 "The value of SST below which a bad value message is "//&
                  "triggered, if CHECK_BAD_SURFACE_VALS is true.", &
                  units="deg C", default=-2.1)
     call get_param(param_file, "MOM", "BAD_VAL_COLUMN_THICKNESS", CS%bad_val_col_thick, &
-                 "The value of column thickness below which a bad value message is \n"//&
+                 "The value of column thickness below which a bad value message is "//&
                  "triggered, if CHECK_BAD_SURFACE_VALS is true.", units="m", &
                  default=0.0)
   endif
 
   call get_param(param_file, "MOM", "SAVE_INITIAL_CONDS", save_IC, &
-                 "If true, write the initial conditions to a file given \n"//&
+                 "If true, write the initial conditions to a file given "//&
                  "by IC_OUTPUT_FILE.", default=.false.)
   call get_param(param_file, "MOM", "IC_OUTPUT_FILE", CS%IC_file, &
                  "The file into which to write the initial conditions.", &
                  default="MOM_IC")
   call get_param(param_file, "MOM", "WRITE_GEOM", write_geom, &
-                 "If =0, never write the geometry and vertical grid files.\n"//&
-                 "If =1, write the geometry and vertical grid files only for\n"//&
-                 "a new simulation. If =2, always write the geometry and\n"//&
+                 "If =0, never write the geometry and vertical grid files. "//&
+                 "If =1, write the geometry and vertical grid files only for "//&
+                 "a new simulation. If =2, always write the geometry and "//&
                  "vertical grid files. Other values are invalid.", default=1)
   if (write_geom<0 .or. write_geom>2) call MOM_error(FATAL,"MOM: "//&
          "WRITE_GEOM must be equal to 0, 1 or 2.")
@@ -1947,9 +1947,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   CS%ensemble_ocean=.false.
   call get_param(param_file, "MOM", "ENSEMBLE_OCEAN", CS%ensemble_ocean, &
-                 "If False, The model is being run in serial mode as a single realization.\n"//&
-                 "If True, The current model realization is part of a larger ensemble \n"//&
-                 "and at the end of step MOM, we will perform a gather of the ensemble\n"//&
+                 "If False, The model is being run in serial mode as a single realization. "//&
+                 "If True, The current model realization is part of a larger ensemble "//&
+                 "and at the end of step MOM, we will perform a gather of the ensemble "//&
                  "members for statistical evaluation and/or data assimilation.", default=.false.)
 
   call callTree_waypoint("MOM parameters read (initialize_MOM)")

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -951,23 +951,23 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "NOSLIP", CS%no_slip, &
-                 "If true, no slip boundary conditions are used; otherwise \n"//&
-                 "free slip boundary conditions are assumed. The \n"//&
-                 "implementation of the free slip BCs on a C-grid is much \n"//&
-                 "cleaner than the no slip BCs. The use of free slip BCs \n"//&
-                 "is strongly encouraged, and no slip BCs are not used with \n"//&
+                 "If true, no slip boundary conditions are used; otherwise "//&
+                 "free slip boundary conditions are assumed. The "//&
+                 "implementation of the free slip BCs on a C-grid is much "//&
+                 "cleaner than the no slip BCs. The use of free slip BCs "//&
+                 "is strongly encouraged, and no slip BCs are not used with "//&
                  "the biharmonic viscosity.", default=.false.)
 
   call get_param(param_file, mdl, "CORIOLIS_EN_DIS", CS%Coriolis_En_Dis, &
-                 "If true, two estimates of the thickness fluxes are used \n"//&
-                 "to estimate the Coriolis term, and the one that \n"//&
+                 "If true, two estimates of the thickness fluxes are used "//&
+                 "to estimate the Coriolis term, and the one that "//&
                  "dissipates energy relative to the other one is used.", &
                  default=.false.)
 
   ! Set %Coriolis_Scheme
   ! (Select the baseline discretization for the Coriolis term)
   call get_param(param_file, mdl, "CORIOLIS_SCHEME", tmpstr, &
-                 "CORIOLIS_SCHEME selects the discretization for the \n"//&
+                 "CORIOLIS_SCHEME selects the discretization for the "//&
                  "Coriolis terms. Valid values are: \n"//&
                  "\t SADOURNY75_ENERGY - Sadourny, 1975; energy cons. \n"//&
                  "\t ARAKAWA_HSU90     - Arakawa & Hsu, 1990 \n"//&
@@ -998,16 +998,16 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
   end select
   if (CS%Coriolis_Scheme == AL_BLEND) then
     call get_param(param_file, mdl, "CORIOLIS_BLEND_WT_LIN", CS%wt_lin_blend, &
-                 "A weighting value for the ratio of inverse thicknesses, \n"//&
-                 "beyond which the blending between Sadourny Energy and \n"//&
-                 "Arakawa & Hsu goes linearly to 0 when CORIOLIS_SCHEME \n"//&
+                 "A weighting value for the ratio of inverse thicknesses, "//&
+                 "beyond which the blending between Sadourny Energy and "//&
+                 "Arakawa & Hsu goes linearly to 0 when CORIOLIS_SCHEME "//&
                  "is ARAWAKA_LAMB_BLEND. This must be between 1 and 1e-16.", &
                  units="nondim", default=0.125)
     call get_param(param_file, mdl, "CORIOLIS_BLEND_F_EFF_MAX", CS%F_eff_max_blend, &
-                 "The factor by which the maximum effective Coriolis \n"//&
-                 "acceleration from any point can be increased when \n"//&
-                 "blending different discretizations with the \n"//&
-                 "ARAKAWA_LAMB_BLEND Coriolis scheme.  This must be \n"//&
+                 "The factor by which the maximum effective Coriolis "//&
+                 "acceleration from any point can be increased when "//&
+                 "blending different discretizations with the "//&
+                 "ARAKAWA_LAMB_BLEND Coriolis scheme.  This must be "//&
                  "greater than 2.0 (the max value for Sadourny energy).", &
                  units="nondim", default=4.0)
     CS%wt_lin_blend = min(1.0, max(CS%wt_lin_blend,1e-16))
@@ -1015,16 +1015,16 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
            "CORIOLIS_BLEND_F_EFF_MAX should be at least 2.")
   endif
 
-  mesg = "If true, the Coriolis terms at u-points are bounded by \n"//&
-         "the four estimates of (f+rv)v from the four neighboring \n"//&
+  mesg = "If true, the Coriolis terms at u-points are bounded by "//&
+         "the four estimates of (f+rv)v from the four neighboring "//&
          "v-points, and similarly at v-points."
   if (CS%Coriolis_En_Dis .and. (CS%Coriolis_Scheme == SADOURNY75_ENERGY)) then
-    mesg = trim(mesg)//"  This option is \n"//&
-                 "always effectively false with CORIOLIS_EN_DIS defined and \n"//&
+    mesg = trim(mesg)//"  This option is "//&
+                 "always effectively false with CORIOLIS_EN_DIS defined and "//&
                  "CORIOLIS_SCHEME set to "//trim(SADOURNY75_ENERGY_STRING)//"."
   else
-    mesg = trim(mesg)//"  This option would \n"//&
-                 "have no effect on the SADOURNY Coriolis scheme if it \n"//&
+    mesg = trim(mesg)//"  This option would "//&
+                 "have no effect on the SADOURNY Coriolis scheme if it "//&
                  "were possible to use centered difference thickness fluxes."
   endif
   call get_param(param_file, mdl, "BOUND_CORIOLIS", CS%bound_Coriolis, mesg, &
@@ -1034,7 +1034,7 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
 
   ! Set KE_Scheme (selects discretization of KE)
   call get_param(param_file, mdl, "KE_SCHEME", tmpstr, &
-                 "KE_SCHEME selects the discretization for acceleration \n"//&
+                 "KE_SCHEME selects the discretization for acceleration "//&
                  "due to the kinetic energy gradient. Valid values are: \n"//&
                  "\t KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV", &
                  default=KE_ARAKAWA_STRING)
@@ -1051,7 +1051,7 @@ subroutine CoriolisAdv_init(Time, G, param_file, diag, AD, CS)
 
   ! Set PV_Adv_Scheme (selects discretization of PV advection)
   call get_param(param_file, mdl, "PV_ADV_SCHEME", tmpstr, &
-                 "PV_ADV_SCHEME selects the discretization for PV \n"//&
+                 "PV_ADV_SCHEME selects the discretization for PV "//&
                  "advection. Valid values are: \n"//&
                  "\t PV_ADV_CENTERED - centered (aka Sadourny, 75) \n"//&
                  "\t PV_ADV_UPWIND1  - upwind, first order", &

--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -117,13 +117,13 @@ subroutine PressureForce_init(Time, G, GV, US, param_file, diag, CS, tides_CSp)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ANALYTIC_FV_PGF", CS%Analytic_FV_PGF, &
-                 "If true the pressure gradient forces are calculated \n"//&
-                 "with a finite volume form that analytically integrates \n"//&
-                 "the equations of state in pressure to avoid any \n"//&
-                 "possibility of numerical thermobaric instability, as \n"//&
+                 "If true the pressure gradient forces are calculated "//&
+                 "with a finite volume form that analytically integrates "//&
+                 "the equations of state in pressure to avoid any "//&
+                 "possibility of numerical thermobaric instability, as "//&
                  "described in Adcroft et al., O. Mod. (2008).", default=.true.)
   call get_param(param_file, mdl, "BLOCKED_ANALYTIC_FV_PGF", CS%blocked_AFV, &
-                 "If true, used the blocked version of the ANALYTIC_FV_PGF \n"//&
+                 "If true, used the blocked version of the ANALYTIC_FV_PGF "//&
                  "code.  The value of this parameter should not change answers.", &
                  default=.false., do_not_log=.true., debuggingParam=.true.)
 

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -842,9 +842,9 @@ subroutine PressureForce_Mont_init(Time, G, GV, US, param_file, diag, CS, tides_
   mdl = "MOM_PressureForce_Mont"
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "TIDES", CS%tides, &

--- a/src/core/MOM_PressureForce_analytic_FV.F90
+++ b/src/core/MOM_PressureForce_analytic_FV.F90
@@ -810,36 +810,36 @@ subroutine PressureForce_AFV_init(Time, G, GV, US, param_file, diag, CS, tides_C
   mdl = "MOM_PressureForce_AFV"
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "TIDES", CS%tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
   call get_param(param_file, "MOM", "USE_REGRIDDING", use_ALE, &
-                 "If True, use the ALE algorithm (regridding/remapping).\n"//&
+                 "If True, use the ALE algorithm (regridding/remapping). "//&
                  "If False, use the layered isopycnal algorithm.", default=.false. )
   call get_param(param_file, mdl, "MASS_WEIGHT_IN_PRESSURE_GRADIENT", CS%useMassWghtInterp, &
-                 "If true, use mass weighting when interpolating T/S for\n"//&
-                 "integrals near the bathymetry in AFV pressure gradient\n"//&
+                 "If true, use mass weighting when interpolating T/S for "//&
+                 "integrals near the bathymetry in AFV pressure gradient "//&
                  "calculations.", default=.false.)
   call get_param(param_file, mdl, "RECONSTRUCT_FOR_PRESSURE", CS%reconstruct, &
-                 "If True, use vertical reconstruction of T & S within\n"//&
-                 "the integrals of the FV pressure gradient calculation.\n"//&
-                 "If False, use the constant-by-layer algorithm.\n"//&
+                 "If True, use vertical reconstruction of T & S within "//&
+                 "the integrals of the FV pressure gradient calculation. "//&
+                 "If False, use the constant-by-layer algorithm. "//&
                  "The default is set by USE_REGRIDDING.", &
                  default=use_ALE )
   call get_param(param_file, mdl, "PRESSURE_RECONSTRUCTION_SCHEME", CS%Recon_Scheme, &
-                 "Order of vertical reconstruction of T/S to use in the \n"//&
+                 "Order of vertical reconstruction of T/S to use in the "//&
                  "integrals within the FV pressure gradient calculation.\n"//&
                  " 0: PCM or no reconstruction.\n"//&
                  " 1: PLM reconstruction.\n"//&
                  " 2: PPM reconstruction.", default=1)
   call get_param(param_file, mdl, "BOUNDARY_EXTRAPOLATION_PRESSURE", CS%boundary_extrap, &
-                 "If true, the reconstruction of T & S for pressure in \n"//&
-                 "boundary cells is extrapolated, rather than using PCM \n"//&
-                 "in these cells. If true, the same order polynomial is \n"//&
+                 "If true, the reconstruction of T & S for pressure in "//&
+                 "boundary cells is extrapolated, rather than using PCM "//&
+                 "in these cells. If true, the same order polynomial is "//&
                  "used as is used for the interior cells.", default=.true.)
 
   if (CS%tides) then

--- a/src/core/MOM_PressureForce_blocked_AFV.F90
+++ b/src/core/MOM_PressureForce_blocked_AFV.F90
@@ -802,36 +802,36 @@ subroutine PressureForce_blk_AFV_init(Time, G, GV, US, param_file, diag, CS, tid
   mdl = "MOM_PressureForce_blk_AFV"
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "TIDES", CS%tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
   call get_param(param_file, "MOM", "USE_REGRIDDING", use_ALE, &
-                 "If True, use the ALE algorithm (regridding/remapping).\n"//&
+                 "If True, use the ALE algorithm (regridding/remapping). "//&
                  "If False, use the layered isopycnal algorithm.", default=.false. )
   call get_param(param_file, mdl, "MASS_WEIGHT_IN_PRESSURE_GRADIENT", CS%useMassWghtInterp, &
-                 "If true, use mass weighting when interpolating T/S for\n"//&
-                 "integrals near the bathymetry in AFV pressure gradient\n"//&
+                 "If true, use mass weighting when interpolating T/S for "//&
+                 "integrals near the bathymetry in AFV pressure gradient "//&
                  "calculations.", default=.false.)
   call get_param(param_file, mdl, "RECONSTRUCT_FOR_PRESSURE", CS%reconstruct, &
-                 "If True, use vertical reconstruction of T & S within\n"//&
-                 "the integrals of the FV pressure gradient calculation.\n"//&
-                 "If False, use the constant-by-layer algorithm.\n"//&
+                 "If True, use vertical reconstruction of T & S within "//&
+                 "the integrals of the FV pressure gradient calculation. "//&
+                 "If False, use the constant-by-layer algorithm. "//&
                  "The default is set by USE_REGRIDDING.", &
                  default=use_ALE )
   call get_param(param_file, mdl, "PRESSURE_RECONSTRUCTION_SCHEME", CS%Recon_Scheme, &
-                 "Order of vertical reconstruction of T/S to use in the \n"//&
+                 "Order of vertical reconstruction of T/S to use in the "//&
                  "integrals within the FV pressure gradient calculation.\n"//&
                  " 0: PCM or no reconstruction.\n"//&
                  " 1: PLM reconstruction.\n"//&
                  " 2: PPM reconstruction.", default=1)
   call get_param(param_file, mdl, "BOUNDARY_EXTRAPOLATION_PRESSURE", CS%boundary_extrap, &
-                 "If true, the reconstruction of T & S for pressure in \n"//&
-                 "boundary cells is extrapolated, rather than using PCM \n"//&
-                 "in these cells. If true, the same order polynomial is \n"//&
+                 "If true, the reconstruction of T & S for pressure in "//&
+                 "boundary cells is extrapolated, rather than using PCM "//&
+                 "in these cells. If true, the same order polynomial is "//&
                  "used as is used for the interior cells.", default=.true.)
 
   if (CS%tides) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3779,32 +3779,32 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
   if (.not.CS%split) return
 
   call get_param(param_file, mdl, "BOUND_BT_CORRECTION", CS%bound_BT_corr, &
-                 "If true, the corrective pseudo mass-fluxes into the \n"//&
-                 "barotropic solver are limited to values that require \n"//&
+                 "If true, the corrective pseudo mass-fluxes into the "//&
+                 "barotropic solver are limited to values that require "//&
                  "less than maxCFL_BT_cont to be accommodated.",default=.false.)
   call get_param(param_file, mdl, "BT_CONT_CORR_BOUNDS", CS%BT_cont_bounds, &
-                 "If true, and BOUND_BT_CORRECTION is true, use the \n"//&
-                 "BT_cont_type variables to set limits determined by \n"//&
-                 "MAXCFL_BT_CONT on the CFL number of the velocities \n"//&
+                 "If true, and BOUND_BT_CORRECTION is true, use the "//&
+                 "BT_cont_type variables to set limits determined by "//&
+                 "MAXCFL_BT_CONT on the CFL number of the velocities "//&
                  "that are likely to be driven by the corrective mass fluxes.", &
                  default=.true.) !, do_not_log=.not.CS%bound_BT_corr)
   call get_param(param_file, mdl, "ADJUST_BT_CONT", CS%adjust_BT_cont, &
-                 "If true, adjust the curve fit to the BT_cont type \n"//&
-                 "that is used by the barotropic solver to match the \n"//&
+                 "If true, adjust the curve fit to the BT_cont type "//&
+                 "that is used by the barotropic solver to match the "//&
                  "transport about which the flow is being linearized.", default=.false.)
   call get_param(param_file, mdl, "GRADUAL_BT_ICS", CS%gradual_BT_ICs, &
-                 "If true, adjust the initial conditions for the \n"//&
-                 "barotropic solver to the values from the layered \n"//&
-                 "solution over a whole timestep instead of instantly. \n"//&
-                 "This is a decent approximation to the inclusion of \n"//&
+                 "If true, adjust the initial conditions for the "//&
+                 "barotropic solver to the values from the layered "//&
+                 "solution over a whole timestep instead of instantly. "//&
+                 "This is a decent approximation to the inclusion of "//&
                  "sum(u dh_dt) while also correcting for truncation errors.", &
                  default=.false.)
   call get_param(param_file, mdl, "BT_USE_VISC_REM_U_UH0", CS%visc_rem_u_uh0, &
-                 "If true, use the viscous remnants when estimating the \n"//&
-                 "barotropic velocities that were used to calculate uh0 \n"//&
+                 "If true, use the viscous remnants when estimating the "//&
+                 "barotropic velocities that were used to calculate uh0 "//&
                  "and vh0.  False is probably the better choice.", default=.false.)
   call get_param(param_file, mdl, "BT_USE_WIDE_HALOS", CS%use_wide_halos, &
-                 "If true, use wide halos and march in during the \n"//&
+                 "If true, use wide halos and march in during the "//&
                  "barotropic time stepping for efficiency.", default=.true., &
                  layoutParam=.true.)
   call get_param(param_file, mdl, "BTHALO", bt_halo_sz, &
@@ -3812,7 +3812,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                  layoutParam=.true.)
 #ifdef STATIC_MEMORY_
   if ((bt_halo_sz > 0) .and. (bt_halo_sz /= BTHALO_)) call MOM_error(FATAL, &
-      "barotropic_init: Run-time values of BTHALO must agree with the \n"//&
+      "barotropic_init: Run-time values of BTHALO must agree with the "//&
       "macro BTHALO_ with STATIC_MEMORY_.")
   wd_halos(1) = WHALOI_+NIHALO_ ; wd_halos(2) = WHALOJ_+NJHALO_
 #else
@@ -3826,65 +3826,65 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                  layoutParam=.true.)
 
   call get_param(param_file, mdl, "USE_BT_CONT_TYPE", use_BT_cont_type, &
-               "If true, use a structure with elements that describe \n"//&
-               "effective face areas from the summed continuity solver \n"//&
-               "as a function the barotropic flow in coupling between \n"//&
-               "the barotropic and baroclinic flow.  This is only used \n"//&
+               "If true, use a structure with elements that describe "//&
+               "effective face areas from the summed continuity solver "//&
+               "as a function the barotropic flow in coupling between "//&
+               "the barotropic and baroclinic flow.  This is only used "//&
                "if SPLIT is true. \n", default=.true.)
   call get_param(param_file, mdl, "NONLINEAR_BT_CONTINUITY", &
                                 CS%Nonlinear_continuity, &
-                 "If true, use nonlinear transports in the barotropic \n"//&
-                 "continuity equation.  This does not apply if \n"//&
+                 "If true, use nonlinear transports in the barotropic "//&
+                 "continuity equation.  This does not apply if "//&
                  "USE_BT_CONT_TYPE is true.", default=.false.)
   CS%Nonlin_cont_update_period = 1
   if (CS%Nonlinear_continuity) &
     call get_param(param_file, mdl, "NONLIN_BT_CONT_UPDATE_PERIOD", &
                                   CS%Nonlin_cont_update_period, &
-                 "If NONLINEAR_BT_CONTINUITY is true, this is the number \n"//&
-                 "of barotropic time steps between updates to the face \n"//&
+                 "If NONLINEAR_BT_CONTINUITY is true, this is the number "//&
+                 "of barotropic time steps between updates to the face "//&
                  "areas, or 0 to update only before the barotropic stepping.",&
                  units="nondim", default=1)
   call get_param(param_file, mdl, "BT_PROJECT_VELOCITY", CS%BT_project_velocity,&
-                 "If true, step the barotropic velocity first and project \n"//&
-                 "out the velocity tendency by 1+BEBT when calculating the \n"//&
-                 "transport.  The default (false) is to use a predictor \n"//&
-                 "continuity step to find the pressure field, and then \n"//&
-                 "to do a corrector continuity step using a weighted \n"//&
-                 "average of the old and new velocities, with weights \n"//&
+                 "If true, step the barotropic velocity first and project "//&
+                 "out the velocity tendency by 1+BEBT when calculating the "//&
+                 "transport.  The default (false) is to use a predictor "//&
+                 "continuity step to find the pressure field, and then "//&
+                 "to do a corrector continuity step using a weighted "//&
+                 "average of the old and new velocities, with weights "//&
                  "of (1-BEBT) and BEBT.", default=.false.)
 
   call get_param(param_file, mdl, "DYNAMIC_SURFACE_PRESSURE", CS%dynamic_psurf, &
-                 "If true, add a dynamic pressure due to a viscous ice \n"//&
+                 "If true, add a dynamic pressure due to a viscous ice "//&
                  "shelf, for instance.", default=.false.)
   if (CS%dynamic_psurf) then
     call get_param(param_file, mdl, "ICE_LENGTH_DYN_PSURF", CS%ice_strength_length, &
-                 "The length scale at which the Rayleigh damping rate due \n"//&
-                 "to the ice strength should be the same as if a Laplacian \n"//&
+                 "The length scale at which the Rayleigh damping rate due "//&
+                 "to the ice strength should be the same as if a Laplacian "//&
                  "were applied, if DYNAMIC_SURFACE_PRESSURE is true.", &
                  units="m", default=1.0e4)
     call get_param(param_file, mdl, "DEPTH_MIN_DYN_PSURF", CS%Dmin_dyn_psurf, &
-                  "The minimum depth to use in limiting the size of the \n"//&
-                  "dynamic surface pressure for stability, if \n"//&
+                  "The minimum depth to use in limiting the size of the "//&
+                  "dynamic surface pressure for stability, if "//&
                   "DYNAMIC_SURFACE_PRESSURE is true..", units="m", &
                   default=1.0e-6)
     call get_param(param_file, mdl, "CONST_DYN_PSURF", CS%const_dyn_psurf, &
-                 "The constant that scales the dynamic surface pressure, \n"//&
-                 "if DYNAMIC_SURFACE_PRESSURE is true.  Stable values \n"//&
+                 "The constant that scales the dynamic surface pressure, "//&
+                 "if DYNAMIC_SURFACE_PRESSURE is true.  Stable values "//&
                  "are < ~1.0.", units="nondim", default=0.9)
   endif
 
   call get_param(param_file, mdl, "TIDES", CS%tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
   call get_param(param_file, mdl, "SADOURNY", CS%Sadourny, &
-                 "If true, the Coriolis terms are discretized with the \n"//&
-                 "Sadourny (1975) energy conserving scheme, otherwise \n"//&
-                 "the Arakawa & Hsu scheme is used.  If the internal \n"//&
-                 "deformation radius is not resolved, the Sadourny scheme \n"//&
+                 "If true, the Coriolis terms are discretized with the "//&
+                 "Sadourny (1975) energy conserving scheme, otherwise "//&
+                 "the Arakawa & Hsu scheme is used.  If the internal "//&
+                 "deformation radius is not resolved, the Sadourny scheme "//&
                  "should probably be used.", default=.true.)
 
   call get_param(param_file, mdl, "BT_THICK_SCHEME", hvel_str, &
-                 "A string describing the scheme that is used to set the \n"//&
-                 "open face areas used for barotropic transport and the \n"//&
+                 "A string describing the scheme that is used to set the "//&
+                 "open face areas used for barotropic transport and the "//&
                  "relative weights of the accelerations. Valid values are:\n"//&
                  "\t ARITHMETIC - arithmetic mean layer thicknesses \n"//&
                  "\t HARMONIC - harmonic mean layer thicknesses \n"//&
@@ -3910,63 +3910,63 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                            "can only be used if USE_BT_CONT_TYPE is defined.")
 
   call get_param(param_file, mdl, "BT_STRONG_DRAG", CS%strong_drag, &
-                 "If true, use a stronger estimate of the retarding \n"//&
-                 "effects of strong bottom drag, by making it implicit \n"//&
-                 "with the barotropic time-step instead of implicit with \n"//&
-                 "the baroclinic time-step and dividing by the number of \n"//&
+                 "If true, use a stronger estimate of the retarding "//&
+                 "effects of strong bottom drag, by making it implicit "//&
+                 "with the barotropic time-step instead of implicit with "//&
+                 "the baroclinic time-step and dividing by the number of "//&
                  "barotropic steps.", default=.false.)
   call get_param(param_file, mdl, "BT_LINEAR_WAVE_DRAG", CS%linear_wave_drag, &
-                 "If true, apply a linear drag to the barotropic velocities, \n"//&
-                 "using rates set by lin_drag_u & _v divided by the depth of \n"//&
+                 "If true, apply a linear drag to the barotropic velocities, "//&
+                 "using rates set by lin_drag_u & _v divided by the depth of "//&
                  "the ocean.  This was introduced to facilitate tide modeling.", &
                  default=.false.)
   call get_param(param_file, mdl, "BT_WAVE_DRAG_FILE", wave_drag_file, &
-                 "The name of the file with the barotropic linear wave drag \n"//&
+                 "The name of the file with the barotropic linear wave drag "//&
                  "piston velocities.", default="", do_not_log=.not.CS%linear_wave_drag)
   call get_param(param_file, mdl, "BT_WAVE_DRAG_VAR", wave_drag_var, &
-                 "The name of the variable in BT_WAVE_DRAG_FILE with the \n"//&
+                 "The name of the variable in BT_WAVE_DRAG_FILE with the "//&
                  "barotropic linear wave drag piston velocities at h points.", &
                  default="rH", do_not_log=.not.CS%linear_wave_drag)
   call get_param(param_file, mdl, "BT_WAVE_DRAG_SCALE", wave_drag_scale, &
-                 "A scaling factor for the barotropic linear wave drag \n"//&
+                 "A scaling factor for the barotropic linear wave drag "//&
                  "piston velocities.", default=1.0, units="nondim", &
                  do_not_log=.not.CS%linear_wave_drag)
 
   call get_param(param_file, mdl, "CLIP_BT_VELOCITY", CS%clip_velocity, &
-                 "If true, limit any velocity components that exceed \n"//&
-                 "CFL_TRUNCATE.  This should only be used as a desperate \n"//&
+                 "If true, limit any velocity components that exceed "//&
+                 "CFL_TRUNCATE.  This should only be used as a desperate "//&
                  "debugging measure.", default=.false.)
   call get_param(param_file, mdl, "CFL_TRUNCATE", CS%CFL_trunc, &
-                 "The value of the CFL number that will cause velocity \n"//&
+                 "The value of the CFL number that will cause velocity "//&
                  "components to be truncated; instability can occur past 0.5.", &
                  units="nondim", default=0.5, do_not_log=.not.CS%clip_velocity)
   call get_param(param_file, mdl, "MAXVEL", CS%maxvel, &
-                 "The maximum velocity allowed before the velocity \n"//&
+                 "The maximum velocity allowed before the velocity "//&
                  "components are truncated.", units="m s-1", default=3.0e8, &
                  do_not_log=.not.CS%clip_velocity)
   call get_param(param_file, mdl, "MAXCFL_BT_CONT", CS%maxCFL_BT_cont, &
-                 "The maximum permitted CFL number associated with the \n"//&
-                 "barotropic accelerations from the summed velocities \n"//&
+                 "The maximum permitted CFL number associated with the "//&
+                 "barotropic accelerations from the summed velocities "//&
                  "times the time-derivatives of thicknesses.", units="nondim", &
                  default=0.25)
   call get_param(param_file, mdl, "VEL_UNDERFLOW", CS%vel_underflow, &
-                 "A negligibly small velocity magnitude below which velocity \n"//&
-                 "components are set to 0.  A reasonable value might be \n"//&
-                 "1e-30 m/s, which is less than an Angstrom divided by \n"//&
+                 "A negligibly small velocity magnitude below which velocity "//&
+                 "components are set to 0.  A reasonable value might be "//&
+                 "1e-30 m/s, which is less than an Angstrom divided by "//&
                  "the age of the universe.", units="m s-1", default=0.0)
 
   call get_param(param_file, mdl, "DT_BT_FILTER", CS%dt_bt_filter, &
-                 "A time-scale over which the barotropic mode solutions \n"//&
-                 "are filtered, in seconds if positive, or as a fraction \n"//&
-                 "of DT if negative. When used this can never be taken to \n"//&
+                 "A time-scale over which the barotropic mode solutions "//&
+                 "are filtered, in seconds if positive, or as a fraction "//&
+                 "of DT if negative. When used this can never be taken to "//&
                  "be longer than 2*dt.  Set this to 0 to apply no filtering.", &
                  units="sec or nondim", default=-0.25)
   call get_param(param_file, mdl, "G_BT_EXTRA", CS%G_extra, &
                  "A nondimensional factor by which gtot is enhanced.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "SSH_EXTRA", SSH_extra, &
-                 "An estimate of how much higher SSH might get, for use \n"//&
-                 "in calculating the safe external wave speed. The \n"//&
+                 "An estimate of how much higher SSH might get, for use "//&
+                 "in calculating the safe external wave speed. The "//&
                  "default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.", &
                  units="m", default=min(10.0,0.05*G%max_depth*US%Z_to_m), scale=US%m_to_Z)
 
@@ -3974,33 +3974,33 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_BT", CS%debug_bt, &
-                 "If true, write out verbose debugging data within the \n"//&
-                 "barotropic time-stepping loop. The data volume can be \n"//&
+                 "If true, write out verbose debugging data within the "//&
+                 "barotropic time-stepping loop. The data volume can be "//&
                  "quite large if this is true.", default=CS%debug, &
                  debuggingParam=.true.)
 
   CS%linearized_BT_PV = .true.
   call get_param(param_file, mdl, "BEBT", CS%bebt, &
-                 "BEBT determines whether the barotropic time stepping \n"//&
-                 "uses the forward-backward time-stepping scheme or a \n"//&
-                 "backward Euler scheme. BEBT is valid in the range from \n"//&
-                 "0 (for a forward-backward treatment of nonrotating \n"//&
-                 "gravity waves) to 1 (for a backward Euler treatment). \n"//&
+                 "BEBT determines whether the barotropic time stepping "//&
+                 "uses the forward-backward time-stepping scheme or a "//&
+                 "backward Euler scheme. BEBT is valid in the range from "//&
+                 "0 (for a forward-backward treatment of nonrotating "//&
+                 "gravity waves) to 1 (for a backward Euler treatment). "//&
                  "In practice, BEBT must be greater than about 0.05.", &
                  units="nondim", default=0.1)
   call get_param(param_file, mdl, "DTBT", dtbt_input, &
-                 "The barotropic time step, in s. DTBT is only used with \n"//&
-                 "the split explicit time stepping. To set the time step \n"//&
-                 "automatically based the maximum stable value use 0, or \n"//&
-                 "a negative value gives the fraction of the stable value. \n"//&
-                 "Setting DTBT to 0 is the same as setting it to -0.98. \n"//&
-                 "The value of DTBT that will actually be used is an \n"//&
+                 "The barotropic time step, in s. DTBT is only used with "//&
+                 "the split explicit time stepping. To set the time step "//&
+                 "automatically based the maximum stable value use 0, or "//&
+                 "a negative value gives the fraction of the stable value. "//&
+                 "Setting DTBT to 0 is the same as setting it to -0.98. "//&
+                 "The value of DTBT that will actually be used is an "//&
                  "integer fraction of DT, rounding down.", units="s or nondim",&
                  default = -0.98)
   call get_param(param_file, mdl, "BT_USE_OLD_CORIOLIS_BRACKET_BUG", &
                  CS%use_old_coriolis_bracket_bug , &
-                 "If True, use an order of operations that is not bitwise\n"//&
-                 "rotationally symmetric in the meridional Coriolis term of\n"//&
+                 "If True, use an order of operations that is not bitwise "//&
+                 "rotationally symmetric in the meridional Coriolis term of "//&
                  "the barotropic solver.", default=.false.)
 
   ! Initialize a version of the MOM domain that is specific to the barotropic solver.

--- a/src/core/MOM_continuity.F90
+++ b/src/core/MOM_continuity.F90
@@ -148,7 +148,7 @@ subroutine continuity_init(Time, G, GV, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "CONTINUITY_SCHEME", tmpstr, &
-                 "CONTINUITY_SCHEME selects the discretization for the \n"//&
+                 "CONTINUITY_SCHEME selects the discretization for the "//&
                  "continuity solver. The only valid value currently is: \n"//&
                  "\t PPM - use a positive-definite (or monotonic) \n"//&
                  "\t       piecewise parabolic reconstruction solver.", &

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2258,66 +2258,66 @@ subroutine continuity_PPM_init(Time, G, GV, param_file, diag, CS)
 ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "MONOTONIC_CONTINUITY", CS%monotonic, &
-                 "If true, CONTINUITY_PPM uses the Colella and Woodward \n"//&
-                 "monotonic limiter.  The default (false) is to use a \n"//&
+                 "If true, CONTINUITY_PPM uses the Colella and Woodward "//&
+                 "monotonic limiter.  The default (false) is to use a "//&
                  "simple positive definite limiter.", default=.false.)
   call get_param(param_file, mdl, "SIMPLE_2ND_PPM_CONTINUITY", CS%simple_2nd, &
-                 "If true, CONTINUITY_PPM uses a simple 2nd order \n"//&
-                 "(arithmetic mean) interpolation of the edge values. \n"//&
-                 "This may give better PV conservation properties. While \n"//&
-                 "it formally reduces the accuracy of the continuity \n"//&
-                 "solver itself in the strongly advective limit, it does \n"//&
-                 "not reduce the overall order of accuracy of the dynamic \n"//&
+                 "If true, CONTINUITY_PPM uses a simple 2nd order "//&
+                 "(arithmetic mean) interpolation of the edge values. "//&
+                 "This may give better PV conservation properties. While "//&
+                 "it formally reduces the accuracy of the continuity "//&
+                 "solver itself in the strongly advective limit, it does "//&
+                 "not reduce the overall order of accuracy of the dynamic "//&
                  "core.", default=.false.)
   call get_param(param_file, mdl, "UPWIND_1ST_CONTINUITY", CS%upwind_1st, &
-                 "If true, CONTINUITY_PPM becomes a 1st-order upwind \n"//&
-                 "continuity solver.  This scheme is highly diffusive \n"//&
-                 "but may be useful for debugging or in single-column \n"//&
+                 "If true, CONTINUITY_PPM becomes a 1st-order upwind "//&
+                 "continuity solver.  This scheme is highly diffusive "//&
+                 "but may be useful for debugging or in single-column "//&
                  "mode where its minimal stencil is useful.", default=.false.)
   call get_param(param_file, mdl, "ETA_TOLERANCE", CS%tol_eta, &
-                 "The tolerance for the differences between the \n"//&
-                 "barotropic and baroclinic estimates of the sea surface \n"//&
-                 "height due to the fluxes through each face.  The total \n"//&
-                 "tolerance for SSH is 4 times this value.  The default \n"//&
-                 "is 0.5*NK*ANGSTROM, and this should not be set less x\n"//&
+                 "The tolerance for the differences between the "//&
+                 "barotropic and baroclinic estimates of the sea surface "//&
+                 "height due to the fluxes through each face.  The total "//&
+                 "tolerance for SSH is 4 times this value.  The default "//&
+                 "is 0.5*NK*ANGSTROM, and this should not be set less "//&
                  "than about 10^-15*MAXIMUM_DEPTH.", units="m", scale=GV%m_to_H, &
                  default=0.5*G%ke*GV%Angstrom_m, unscaled=tol_eta_m)
 
   call get_param(param_file, mdl, "ETA_TOLERANCE_AUX", CS%tol_eta_aux, &
-                 "The tolerance for free-surface height discrepancies \n"//&
-                 "between the barotropic solution and the sum of the \n"//&
-                 "layer thicknesses when calculating the auxiliary \n"//&
-                 "corrected velocities. By default, this is the same as \n"//&
+                 "The tolerance for free-surface height discrepancies "//&
+                 "between the barotropic solution and the sum of the "//&
+                 "layer thicknesses when calculating the auxiliary "//&
+                 "corrected velocities. By default, this is the same as "//&
                  "ETA_TOLERANCE, but can be made larger for efficiency.", &
                  units="m", default=tol_eta_m, scale=GV%m_to_H)
   call get_param(param_file, mdl, "VELOCITY_TOLERANCE", CS%tol_vel, &
-                 "The tolerance for barotropic velocity discrepancies \n"//&
-                 "between the barotropic solution and  the sum of the \n"//&
+                 "The tolerance for barotropic velocity discrepancies "//&
+                 "between the barotropic solution and  the sum of the "//&
                  "layer thicknesses.", units="m s-1", default=3.0e8) ! The speed of light is the default.
 
   call get_param(param_file, mdl, "CONT_PPM_AGGRESS_ADJUST", CS%aggress_adjust,&
-                 "If true, allow the adjusted velocities to have a \n"//&
+                 "If true, allow the adjusted velocities to have a "//&
                  "relative CFL change up to 0.5.", default=.false.)
   CS%vol_CFL = CS%aggress_adjust
   call get_param(param_file, mdl, "CONT_PPM_VOLUME_BASED_CFL", CS%vol_CFL, &
-                 "If true, use the ratio of the open face lengths to the \n"//&
-                 "tracer cell areas when estimating CFL numbers.  The \n"//&
+                 "If true, use the ratio of the open face lengths to the "//&
+                 "tracer cell areas when estimating CFL numbers.  The "//&
                  "default is set by CONT_PPM_AGGRESS_ADJUST.", &
                  default=CS%aggress_adjust, do_not_read=CS%aggress_adjust)
   call get_param(param_file, mdl, "CONTINUITY_CFL_LIMIT", CS%CFL_limit_adjust, &
                  "The maximum CFL of the adjusted velocities.", units="nondim", &
                  default=0.5)
   call get_param(param_file, mdl, "CONT_PPM_BETTER_ITER", CS%better_iter, &
-                 "If true, stop corrective iterations using a velocity \n"//&
-                 "based criterion and only stop if the iteration is \n"//&
+                 "If true, stop corrective iterations using a velocity "//&
+                 "based criterion and only stop if the iteration is "//&
                  "better than all predecessors.", default=.true.)
   call get_param(param_file, mdl, "CONT_PPM_USE_VISC_REM_MAX", &
                                  CS%use_visc_rem_max, &
-                 "If true, use more appropriate limiting bounds for \n"//&
+                 "If true, use more appropriate limiting bounds for "//&
                  "corrections in strongly viscous columns.", default=.true.)
   call get_param(param_file, mdl, "CONT_PPM_MARGINAL_FACE_AREAS", CS%marginal_faces, &
-                 "If true, use the marginal face areas from the continuity \n"//&
-                 "solver for use as the weights in the barotropic solver. \n"//&
+                 "If true, use the marginal face areas from the continuity "//&
+                 "solver for use as the weights in the barotropic solver. "//&
                  "Otherwise use the transport averaged areas.", default=.true.)
 
   CS%diag => diag

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1023,28 +1023,28 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
   call get_param(param_file, mdl, "TIDES", use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
   call get_param(param_file, mdl, "BE", CS%be, &
-                 "If SPLIT is true, BE determines the relative weighting \n"//&
-                 "of a  2nd-order Runga-Kutta baroclinic time stepping \n"//&
-                 "scheme (0.5) and a backward Euler scheme (1) that is \n"//&
-                 "used for the Coriolis and inertial terms.  BE may be \n"//&
-                 "from 0.5 to 1, but instability may occur near 0.5. \n"//&
-                 "BE is also applicable if SPLIT is false and USE_RK2 \n"//&
+                 "If SPLIT is true, BE determines the relative weighting "//&
+                 "of a  2nd-order Runga-Kutta baroclinic time stepping "//&
+                 "scheme (0.5) and a backward Euler scheme (1) that is "//&
+                 "used for the Coriolis and inertial terms.  BE may be "//&
+                 "from 0.5 to 1, but instability may occur near 0.5. "//&
+                 "BE is also applicable if SPLIT is false and USE_RK2 "//&
                  "is true.", units="nondim", default=0.6)
   call get_param(param_file, mdl, "BEGW", CS%begw, &
-                 "If SPLIT is true, BEGW is a number from 0 to 1 that \n"//&
-                 "controls the extent to which the treatment of gravity \n"//&
-                 "waves is forward-backward (0) or simulated backward \n"//&
-                 "Euler (1).  0 is almost always used.\n"//&
-                 "If SPLIT is false and USE_RK2 is true, BEGW can be \n"//&
+                 "If SPLIT is true, BEGW is a number from 0 to 1 that "//&
+                 "controls the extent to which the treatment of gravity "//&
+                 "waves is forward-backward (0) or simulated backward "//&
+                 "Euler (1).  0 is almost always used. "//&
+                 "If SPLIT is false and USE_RK2 is true, BEGW can be "//&
                  "between 0 and 0.5 to damp gravity waves.", &
                  units="nondim", default=0.0)
 
   call get_param(param_file, mdl, "SPLIT_BOTTOM_STRESS", CS%split_bottom_stress, &
-                 "If true, provide the bottom stress calculated by the \n"//&
+                 "If true, provide the bottom stress calculated by the "//&
                  "vertical viscosity to the barotropic solver.", default=.false.)
   call get_param(param_file, mdl, "BT_USE_LAYER_FLUXES", CS%BT_use_layer_fluxes, &
-                 "If true, use the summed layered fluxes plus an \n"//&
-                 "adjustment due to the change in the barotropic velocity \n"//&
+                 "If true, use the summed layered fluxes plus an "//&
+                 "adjustment due to the change in the barotropic velocity "//&
                  "in the barotropic continuity equation.", default=.true.)
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -575,19 +575,19 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, US, param_file, diag
   CS%diag => diag
 
   call get_param(param_file, mdl, "BE", CS%be, &
-                 "If SPLIT is true, BE determines the relative weighting \n"//&
-                 "of a  2nd-order Runga-Kutta baroclinic time stepping \n"//&
-                 "scheme (0.5) and a backward Euler scheme (1) that is \n"//&
-                 "used for the Coriolis and inertial terms.  BE may be \n"//&
-                 "from 0.5 to 1, but instability may occur near 0.5. \n"//&
-                 "BE is also applicable if SPLIT is false and USE_RK2 \n"//&
+                 "If SPLIT is true, BE determines the relative weighting "//&
+                 "of a  2nd-order Runga-Kutta baroclinic time stepping "//&
+                 "scheme (0.5) and a backward Euler scheme (1) that is "//&
+                 "used for the Coriolis and inertial terms.  BE may be "//&
+                 "from 0.5 to 1, but instability may occur near 0.5. "//&
+                 "BE is also applicable if SPLIT is false and USE_RK2 "//&
                  "is true.", units="nondim", default=0.6)
   call get_param(param_file, mdl, "BEGW", CS%begw, &
-                 "If SPLIT is true, BEGW is a number from 0 to 1 that \n"//&
-                 "controls the extent to which the treatment of gravity \n"//&
-                 "waves is forward-backward (0) or simulated backward \n"//&
-                 "Euler (1).  0 is almost always used.\n"//&
-                 "If SPLIT is false and USE_RK2 is true, BEGW can be \n"//&
+                 "If SPLIT is true, BEGW is a number from 0 to 1 that "//&
+                 "controls the extent to which the treatment of gravity "//&
+                 "waves is forward-backward (0) or simulated backward "//&
+                 "Euler (1).  0 is almost always used. "//&
+                 "If SPLIT is false and USE_RK2 is true, BEGW can be "//&
                  "between 0 and 0.5 to damp gravity waves.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "DEBUG", CS%debug, &

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -306,7 +306,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
   allocate(OBC)
 
   call log_version(param_file, mdl, version, &
-                 "Controls where open boundaries are located, what kind of boundary condition \n"//&
+                 "Controls where open boundaries are located, what kind of boundary condition "//&
                  "to impose, and what data to apply, if any.")
   call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", OBC%number_of_segments, &
                  "The number of open boundary segments.", &
@@ -315,7 +315,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
   call get_param(param_file, mdl, "OBC_USER_CONFIG", config1, &
-                 "A string that sets how the open boundary conditions are \n"//&
+                 "A string that sets how the open boundary conditions are "//&
                  " configured: \n", default="none", do_not_log=.true.)
   call get_param(param_file, mdl, "NK", OBC%ke, &
                  "The number of model layers", default=0, do_not_log=.true.)
@@ -327,16 +327,16 @@ subroutine open_boundary_config(G, US, param_file, OBC)
          "If true, sets relative vorticity to zero on open boundaries.", &
          default=.false.)
     call get_param(param_file, mdl, "OBC_FREESLIP_VORTICITY", OBC%freeslip_vorticity, &
-         "If true, sets the normal gradient of tangential velocity to\n"// &
-         "zero in the relative vorticity on open boundaries. This cannot\n"// &
+         "If true, sets the normal gradient of tangential velocity to "//&
+         "zero in the relative vorticity on open boundaries. This cannot "//&
          "be true if another OBC_XXX_VORTICITY option is True.", default=.true.)
     call get_param(param_file, mdl, "OBC_COMPUTED_VORTICITY", OBC%computed_vorticity, &
-         "If true, uses the external values of tangential velocity\n"// &
-         "in the relative vorticity on open boundaries. This cannot\n"// &
+         "If true, uses the external values of tangential velocity "//&
+         "in the relative vorticity on open boundaries. This cannot "//&
          "be true if another OBC_XXX_VORTICITY option is True.", default=.false.)
     call get_param(param_file, mdl, "OBC_SPECIFIED_VORTICITY", OBC%specified_vorticity, &
-         "If true, uses the external values of tangential velocity\n"// &
-         "in the relative vorticity on open boundaries. This cannot\n"// &
+         "If true, uses the external values of tangential velocity "//&
+         "in the relative vorticity on open boundaries. This cannot "//&
          "be true if another OBC_XXX_VORTICITY option is True.", default=.false.)
     if ((OBC%zero_vorticity .and. OBC%freeslip_vorticity) .or.  &
         (OBC%zero_vorticity .and. OBC%computed_vorticity) .or.  &
@@ -351,16 +351,16 @@ subroutine open_boundary_config(G, US, param_file, OBC)
          "If true, sets the strain used in the stress tensor to zero on open boundaries.", &
          default=.false.)
     call get_param(param_file, mdl, "OBC_FREESLIP_STRAIN", OBC%freeslip_strain, &
-         "If true, sets the normal gradient of tangential velocity to\n"// &
-         "zero in the strain use in the stress tensor on open boundaries. This cannot\n"// &
+         "If true, sets the normal gradient of tangential velocity to "//&
+         "zero in the strain use in the stress tensor on open boundaries. This cannot "//&
          "be true if another OBC_XXX_STRAIN option is True.", default=.true.)
     call get_param(param_file, mdl, "OBC_COMPUTED_STRAIN", OBC%computed_strain, &
-         "If true, sets the normal gradient of tangential velocity to\n"// &
-         "zero in the strain use in the stress tensor on open boundaries. This cannot\n"// &
+         "If true, sets the normal gradient of tangential velocity to "//&
+         "zero in the strain use in the stress tensor on open boundaries. This cannot "//&
          "be true if another OBC_XXX_STRAIN option is True.", default=.false.)
     call get_param(param_file, mdl, "OBC_SPECIFIED_STRAIN", OBC%specified_strain, &
-         "If true, sets the normal gradient of tangential velocity to\n"// &
-         "zero in the strain use in the stress tensor on open boundaries. This cannot\n"// &
+         "If true, sets the normal gradient of tangential velocity to "//&
+         "zero in the strain use in the stress tensor on open boundaries. This cannot "//&
          "be true if another OBC_XXX_STRAIN option is True.", default=.false.)
     if ((OBC%zero_strain .and. OBC%freeslip_strain) .or.  &
         (OBC%zero_strain .and. OBC%computed_strain) .or.  &
@@ -368,11 +368,11 @@ subroutine open_boundary_config(G, US, param_file, OBC)
         (OBC%freeslip_strain .and. OBC%computed_strain) .or.  &
         (OBC%freeslip_strain .and. OBC%specified_strain) .or.  &
         (OBC%computed_strain .and. OBC%specified_strain))  &
-         call MOM_error(FATAL, "MOM_open_boundary.F90, open_boundary_config:\n"//&
-         "Only one of OBC_ZERO_STRAIN, OBC_FREESLIP_STRAIN, OBC_COMPUTED_STRAIN\n"//&
+         call MOM_error(FATAL, "MOM_open_boundary.F90, open_boundary_config: \n"//&
+         "Only one of OBC_ZERO_STRAIN, OBC_FREESLIP_STRAIN, OBC_COMPUTED_STRAIN \n"//&
          "and OBC_IMPORTED_STRAIN can be True at once.")
     call get_param(param_file, mdl, "OBC_ZERO_BIHARMONIC", OBC%zero_biharmonic, &
-         "If true, zeros the Laplacian of flow on open boundaries in the biharmonic\n"//&
+         "If true, zeros the Laplacian of flow on open boundaries in the biharmonic "//&
          "viscosity term.", default=.false.)
     call get_param(param_file, mdl, "MASK_OUTSIDE_OBCS", mask_outside, &
          "If true, set the areas outside open boundaries to be land.", &
@@ -382,16 +382,16 @@ subroutine open_boundary_config(G, US, param_file, OBC)
     call get_param(param_file, mdl, "DEBUG_OBC", debug_OBC, default=.false.)
     if (debug_OBC .or. debug) &
       call log_param(param_file, mdl, "DEBUG_OBC", debug_OBC, &
-                 "If true, do additional calls to help debug the performance \n"//&
+                 "If true, do additional calls to help debug the performance "//&
                  "of the open boundary condition code.", default=.false., &
                  debuggingParam=.true.)
 
     call get_param(param_file, mdl, "OBC_SILLY_THICK", OBC%silly_h, &
-                 "A silly value of thicknesses used outside of open boundary \n"//&
+                 "A silly value of thicknesses used outside of open boundary "//&
                  "conditions for debugging.", units="m", default=0.0, &
                  do_not_log=.not.debug_OBC, debuggingParam=.true.)
     call get_param(param_file, mdl, "OBC_SILLY_VEL", OBC%silly_u, &
-                 "A silly value of velocities used outside of open boundary \n"//&
+                 "A silly value of velocities used outside of open boundary "//&
                  "conditions for debugging.", units="m/s", default=0.0, &
                  do_not_log=.not.debug_OBC, debuggingParam=.true.)
     reentrant_x = .false.
@@ -449,15 +449,15 @@ subroutine open_boundary_config(G, US, param_file, OBC)
 
     if (open_boundary_query(OBC, apply_open_OBC=.true.)) then
       call get_param(param_file, mdl, "OBC_RADIATION_MAX", OBC%rx_max, &
-                   "The maximum magnitude of the baroclinic radiation \n"//&
-                   "velocity (or speed of characteristics).  This is only \n"//&
+                   "The maximum magnitude of the baroclinic radiation "//&
+                   "velocity (or speed of characteristics).  This is only "//&
                    "used if one of the open boundary segments is using Orlanski.", &
                    units="m s-1", default=10.0)
       call get_param(param_file, mdl, "OBC_RAD_VEL_WT", OBC%gamma_uv, &
-                   "The relative weighting for the baroclinic radiation \n"//&
-                   "velocities (or speed of characteristics) at the new \n"//&
-                   "time level (1) or the running mean (0) for velocities. \n"//&
-                   "Valid values range from 0 to 1. This is only used if \n"//&
+                   "The relative weighting for the baroclinic radiation "//&
+                   "velocities (or speed of characteristics) at the new "//&
+                   "time level (1) or the running mean (0) for velocities. "//&
+                   "Valid values range from 0 to 1. This is only used if "//&
                    "one of the open boundary segments is using Orlanski.", &
                    units="nondim",  default=0.3)
     endif
@@ -466,13 +466,13 @@ subroutine open_boundary_config(G, US, param_file, OBC)
     Lscale_out = 0.
     if (open_boundary_query(OBC, apply_open_OBC=.true.)) then
       call get_param(param_file, mdl, "OBC_TRACER_RESERVOIR_LENGTH_SCALE_OUT ", Lscale_out, &
-                 "An effective length scale for restoring the tracer concentration \n"//&
-                 "at the boundaries to externally imposed values when the flow \n"//&
+                 "An effective length scale for restoring the tracer concentration "//&
+                 "at the boundaries to externally imposed values when the flow "//&
                  "is exiting the domain.", units="m", default=0.0)
 
       call get_param(param_file, mdl, "OBC_TRACER_RESERVOIR_LENGTH_SCALE_IN ", Lscale_in, &
-                 "An effective length scale for restoring the tracer concentration \n"//&
-                 "at the boundaries to values from the interior when the flow \n"//&
+                 "An effective length scale for restoring the tracer concentration "//&
+                 "at the boundaries to values from the interior when the flow "//&
                  "is entering the domain.", units="m", default=0.0)
     endif
 
@@ -547,21 +547,21 @@ subroutine initialize_segment_data(G, OBC, PF)
   inputdir = slasher(inputdir)
 
   call get_param(PF, mdl, "REMAPPING_SCHEME", remappingScheme, &
-          "This sets the reconstruction scheme used\n"//&
-          "for vertical remapping for all variables.\n"//&
-          "It can be one of the following schemes:\n"//&
+          "This sets the reconstruction scheme used "//&
+          "for vertical remapping for all variables. "//&
+          "It can be one of the following schemes: \n"//&
           trim(remappingSchemesDoc), default=remappingDefaultScheme,do_not_log=.true.)
   call get_param(PF, mdl, "FATAL_CHECK_RECONSTRUCTIONS", check_reconstruction, &
-          "If true, cell-by-cell reconstructions are checked for\n"//&
-          "consistency and if non-monotonicity or an inconsistency is\n"//&
+          "If true, cell-by-cell reconstructions are checked for "//&
+          "consistency and if non-monotonicity or an inconsistency is "//&
           "detected then a FATAL error is issued.", default=.false.,do_not_log=.true.)
   call get_param(PF, mdl, "FATAL_CHECK_REMAPPING", check_remapping, &
-          "If true, the results of remapping are checked for\n"//&
-          "conservation and new extrema and if an inconsistency is\n"//&
+          "If true, the results of remapping are checked for "//&
+          "conservation and new extrema and if an inconsistency is "//&
           "detected then a FATAL error is issued.", default=.false.,do_not_log=.true.)
   call get_param(PF, mdl, "REMAP_BOUND_INTERMEDIATE_VALUES", force_bounds_in_subcell, &
-          "If true, the values on the intermediate grid used for remapping\n"//&
-          "are forced to be bounded, which might not be the case due to\n"//&
+          "If true, the values on the intermediate grid used for remapping "//&
+          "are forced to be bounded, which might not be the case due to "//&
           "round off.", default=.false.,do_not_log=.true.)
     call get_param(PF, mdl, "BRUSHCUTTER_MODE", OBC%brushcutter_mode, &
          "If true, read external OBC data on the supergrid.", &
@@ -863,8 +863,8 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg, PF, reentrant_y)
       write(segment_param_str(1:43),"('OBC_SEGMENT_',i3.3,'_VELOCITY_NUDGING_TIMESCALES')") l_seg
       allocate(tnudge(2))
       call get_param(PF, mdl, segment_param_str(1:43), tnudge, &
-           "Timescales in days for nudging along a segment,\n"//&
-           "for inflow, then outflow. Setting both to zero should\n"//&
+           "Timescales in days for nudging along a segment, "//&
+           "for inflow, then outflow. Setting both to zero should "//&
            "behave like SIMPLE obcs for the baroclinic velocities.", &
                 fail_if_missing=.true.,default=0.,units="days")
       OBC%segment(l_seg)%Velocity_nudging_timescale_in = tnudge(1)*86400.
@@ -892,7 +892,7 @@ subroutine setup_u_point_obc(OBC, G, segment_str, l_seg, PF, reentrant_y)
   call allocate_OBC_segment_data(OBC, OBC%segment(l_seg))
 
   if (OBC%segment(l_seg)%oblique .and.  OBC%segment(l_seg)%radiation) &
-         call MOM_error(FATAL, "MOM_open_boundary.F90, setup_u_point_obc:\n"//&
+         call MOM_error(FATAL, "MOM_open_boundary.F90, setup_u_point_obc: \n"//&
          "Orlanski and Oblique OBC options cannot be used together on one segment.")
 
 end subroutine setup_u_point_obc
@@ -987,8 +987,8 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg, PF, reentrant_x)
       write(segment_param_str(1:43),"('OBC_SEGMENT_',i3.3,'_VELOCITY_NUDGING_TIMESCALES')") l_seg
       allocate(tnudge(2))
       call get_param(PF, mdl, segment_param_str(1:43), tnudge, &
-           "Timescales in days for nudging along a segment,\n"//&
-           "for inflow, then outflow. Setting both to zero should\n"//&
+           "Timescales in days for nudging along a segment, "//&
+           "for inflow, then outflow. Setting both to zero should "//&
            "behave like SIMPLE obcs for the baroclinic velocities.", &
                 fail_if_missing=.true.,default=0.,units="days")
       OBC%segment(l_seg)%Velocity_nudging_timescale_in = tnudge(1)*86400.
@@ -1016,7 +1016,7 @@ subroutine setup_v_point_obc(OBC, G, segment_str, l_seg, PF, reentrant_x)
   call allocate_OBC_segment_data(OBC, OBC%segment(l_seg))
 
   if (OBC%segment(l_seg)%oblique .and.  OBC%segment(l_seg)%radiation) &
-         call MOM_error(FATAL, "MOM_open_boundary.F90, setup_v_point_obc:\n"//&
+         call MOM_error(FATAL, "MOM_open_boundary.F90, setup_v_point_obc: \n"//&
          "Orlanski and Oblique OBC options cannot be used together on one segment.")
 
 end subroutine setup_v_point_obc

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -92,9 +92,9 @@ subroutine verticalGridInit( param_file, GV, US )
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
   call get_param(param_file, mdl, "RHO_0", GV%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "BOUSSINESQ", GV%Boussinesq, &
@@ -103,7 +103,7 @@ subroutine verticalGridInit( param_file, GV, US )
                  "The minimum layer thickness, usually one-Angstrom.", &
                  units="m", default=1.0e-10)
   call get_param(param_file, mdl, "H_RESCALE_POWER", H_power, &
-                 "An integer power of 2 that is used to rescale the model's \n"//&
+                 "An integer power of 2 that is used to rescale the model's "//&
                  "intenal units of thickness.  Valid values range from -300 to 300.", &
                  units="nondim", default=0, debuggingParam=.true.)
   if (abs(H_power) > 300) call MOM_error(FATAL, "verticalGridInit: "//&
@@ -112,13 +112,13 @@ subroutine verticalGridInit( param_file, GV, US )
   if (H_power /= 0) H_rescale_factor = 2.0**H_power
   if (.not.GV%Boussinesq) then
     call get_param(param_file, mdl, "H_TO_KG_M2", GV%H_to_kg_m2,&
-                 "A constant that translates thicknesses from the model's \n"//&
+                 "A constant that translates thicknesses from the model's "//&
                  "internal units of thickness to kg m-2.", units="kg m-2 H-1", &
                  default=1.0)
     GV%H_to_kg_m2 = GV%H_to_kg_m2 * H_rescale_factor
   else
     call get_param(param_file, mdl, "H_TO_M", GV%H_to_m, &
-                 "A constant that translates the model's internal \n"//&
+                 "A constant that translates the model's internal "//&
                  "units of thickness into m.", units="m H-1", default=1.0)
     GV%H_to_m = GV%H_to_m * H_rescale_factor
   endif

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -758,17 +758,17 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "U_TRUNC_FILE", CS%u_trunc_file, &
-                 "The absolute path to the file where the accelerations \n"//&
+                 "The absolute path to the file where the accelerations "//&
                  "leading to zonal velocity truncations are written. \n"//&
-                 "Leave this empty for efficiency if this diagnostic is \n"//&
+                 "Leave this empty for efficiency if this diagnostic is "//&
                  "not needed.", default="", debuggingParam=.true.)
   call get_param(param_file, mdl, "V_TRUNC_FILE", CS%v_trunc_file, &
-                 "The absolute path to the file where the accelerations \n"//&
+                 "The absolute path to the file where the accelerations "//&
                  "leading to meridional velocity truncations are written. \n"//&
-                 "Leave this empty for efficiency if this diagnostic is \n"//&
+                 "Leave this empty for efficiency if this diagnostic is "//&
                  "not needed.", default="", debuggingParam=.true.)
   call get_param(param_file, mdl, "MAX_TRUNC_FILE_SIZE_PER_PE", CS%max_writes, &
-                 "The maximum number of colums of truncations that any PE \n"//&
+                 "The maximum number of colums of truncations that any PE "//&
                  "will write out during a run.", default=50, debuggingParam=.true.)
 
   if (len_trim(dirs%output_directory) > 0) then

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -88,11 +88,11 @@ subroutine MOM_debugging_init(param_file)
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_CHKSUMS", debug_chksums, &
-                 "If true, checksums are performed on arrays in the \n"//&
+                 "If true, checksums are performed on arrays in the "//&
                  "various vec_chksum routines.", default=debug, &
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_REDUNDANT", debug_redundant, &
-                 "If true, debug redundant data points during calls to \n"//&
+                 "If true, debug redundant data points during calls to "//&
                  "the various vec_chksum routines.", default=debug, &
                  debuggingParam=.true.)
 

--- a/src/diagnostics/MOM_diag_to_Z.F90
+++ b/src/diagnostics/MOM_diag_to_Z.F90
@@ -997,8 +997,8 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, US, param_file, diag, CS)
   call log_version(param_file, mdl, version, "")
   ! Read in z-space info from a NetCDF file.
   call get_param(param_file, mdl, "Z_OUTPUT_GRID_FILE", zgrid_file, &
-                 "The file that specifies the vertical grid for \n"//&
-                 "depth-space diagnostics, or blank to disable \n"//&
+                 "The file that specifies the vertical grid for "//&
+                 "depth-space diagnostics, or blank to disable "//&
                  "depth-space output.", default="")
 
   if (len_trim(zgrid_file) > 0) then
@@ -1011,7 +1011,7 @@ subroutine MOM_diag_to_Z_init(Time, G, GV, US, param_file, diag, CS)
     call log_param(param_file, mdl, "!INPUTDIR/Z_OUTPUT_GRID_FILE", &
                    trim(in_dir)//trim(zgrid_file))
     call log_param(param_file, mdl, "!NK_ZSPACE (from file)", CS%nk_zspace, &
-                 "The number of depth-space levels.  This is determined \n"//&
+                 "The number of depth-space levels.  This is determined "//&
                  "from the size of the variable zw in the output grid file.", &
                  units="nondim")
   else

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1450,11 +1450,11 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "DIAG_EBT_MONO_N2_COLUMN_FRACTION", CS%mono_N2_column_fraction, &
-                 "The lower fraction of water column over which N2 is limited as monotonic\n"// &
+                 "The lower fraction of water column over which N2 is limited as monotonic "// &
                  "for the purposes of calculating the equivalent barotropic wave speed.", &
                  units='nondim', default=0.)
   call get_param(param_file, mdl, "DIAG_EBT_MONO_N2_DEPTH", CS%mono_N2_depth, &
-                 "The depth below which N2 is limited as monotonic for the\n"// &
+                 "The depth below which N2 is limited as monotonic for the "// &
                  "purposes of calculating the equivalent barotropic wave speed.", &
                  units='m', default=-1.)
 

--- a/src/diagnostics/MOM_obsolete_diagnostics.F90
+++ b/src/diagnostics/MOM_obsolete_diagnostics.F90
@@ -31,8 +31,8 @@ subroutine register_obsolete_diagnostics(param_file, diag)
 
   call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "OBSOLETE_DIAGNOSTIC_IS_FATAL", causeFatal,              &
-                 "If an obsolete diagnostic variable appears in the diag_table\n"//        &
-                 "then cause a FATAL error rather than issue a WARNING.", default=.true.)
+                 "If an obsolete diagnostic variable appears in the diag_table, "//        &
+                 "cause a FATAL error rather than issue a WARNING.", default=.true.)
 
   foundEntry = .false.
   ! Each obsolete entry, with replacement name is available.

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -169,41 +169,41 @@ subroutine MOM_sum_output_init(G, US, param_file, directory, ntrnc, &
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "CALCULATE_APE", CS%do_APE_calc, &
-                 "If true, calculate the available potential energy of \n"//&
-                 "the interfaces.  Setting this to false reduces the \n"//&
+                 "If true, calculate the available potential energy of "//&
+                 "the interfaces.  Setting this to false reduces the "//&
                  "memory footprint of high-PE-count models dramatically.", &
                  default=.true.)
   call get_param(param_file, mdl, "WRITE_STOCKS", CS%write_stocks, &
-                 "If true, write the integrated tracer amounts to stdout \n"//&
+                 "If true, write the integrated tracer amounts to stdout "//&
                  "when the energy files are written.", default=.true.)
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
   call get_param(param_file, mdl, "DT", CS%dt, &
                  "The (baroclinic) dynamics time step.", units="s", &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "MAXTRUNC", CS%maxtrunc, &
-                 "The run will be stopped, and the day set to a very \n"//&
-                 "large value if the velocity is truncated more than \n"//&
-                 "MAXTRUNC times between energy saves.  Set MAXTRUNC to 0 \n"//&
+                 "The run will be stopped, and the day set to a very "//&
+                 "large value if the velocity is truncated more than "//&
+                 "MAXTRUNC times between energy saves.  Set MAXTRUNC to 0 "//&
                  "to stop if there is any truncation of velocities.", &
                  units="truncations save_interval-1", default=0)
 
   call get_param(param_file, mdl, "MAX_ENERGY", CS%max_Energy, &
-                 "The maximum permitted average energy per unit mass; the \n"//&
-                 "model will be stopped if there is more energy than \n"//&
+                 "The maximum permitted average energy per unit mass; the "//&
+                 "model will be stopped if there is more energy than "//&
                  "this.  If zero or negative, this is set to 10*MAXVEL^2.", &
                  units="m2 s-2", default=0.0)
   if (CS%max_Energy <= 0.0) then
     call get_param(param_file, mdl, "MAXVEL", maxvel, &
-                 "The maximum velocity allowed before the velocity \n"//&
+                 "The maximum velocity allowed before the velocity "//&
                  "components are truncated.", units="m s-1", default=3.0e8)
     CS%max_Energy = 10.0 * maxvel**2
     call log_param(param_file, mdl, "MAX_ENERGY as used", CS%max_Energy)
   endif
 
   call get_param(param_file, mdl, "ENERGYFILE", energyfile, &
-                 "The file to use to write the energies and globally \n"//&
+                 "The file to use to write the energies and globally "//&
                  "summed diagnostics.", default="ocean.stats")
 
   !query fms_io if there is a filename_appendix (for ensemble runs)
@@ -230,10 +230,10 @@ subroutine MOM_sum_output_init(G, US, param_file, directory, ntrnc, &
 
   if (CS%do_APE_calc) then
     call get_param(param_file, mdl, "READ_DEPTH_LIST", CS%read_depth_list, &
-                   "Read the depth list from a file if it exists or \n"//&
+                   "Read the depth list from a file if it exists or "//&
                    "create that file otherwise.", default=.false.)
     call get_param(param_file, mdl, "DEPTH_LIST_MIN_INC", CS%D_list_min_inc, &
-                   "The minimum increment between the depths of the \n"//&
+                   "The minimum increment between the depths of the "//&
                    "entries in the depth-list file.", &
                    units="m", default=1.0E-10, scale=US%m_to_Z)
     if (CS%read_depth_list) then
@@ -244,12 +244,12 @@ subroutine MOM_sum_output_init(G, US, param_file, directory, ntrnc, &
 
       call get_param(param_file, mdl, "REQUIRE_DEPTH_LIST_CHECKSUMS", &
                      CS%require_depth_list_chksum, &
-                 "Require that matching checksums be in Depth_list.nc\n" // &
+                 "Require that matching checksums be in Depth_list.nc "//&
                  "when reading the file.", default=.true.)
       if (.not. CS%require_depth_list_chksum) &
         call get_param(param_file, mdl, "UPDATE_DEPTH_LIST_CHECKSUMS", &
                      CS%update_depth_list_chksum, &
-                 "Automatically update the Depth_list.nc file if the\n" // &
+                 "Automatically update the Depth_list.nc file if the "//&
                  "checksums are missing or do not match current values.", &
                  default=.false.)
     endif
@@ -264,12 +264,12 @@ subroutine MOM_sum_output_init(G, US, param_file, directory, ntrnc, &
                  "The time unit for ENERGYSAVEDAYS.", &
                  units="s", default=86400.0)
   call get_param(param_file, mdl, "ENERGYSAVEDAYS",CS%energysavedays, &
-                 "The interval in units of TIMEUNIT between saves of the \n"//&
+                 "The interval in units of TIMEUNIT between saves of the "//&
                  "energies of the run and other globally summed diagnostics.",&
                  default=set_time(0,days=1), timeunit=Time_unit)
   call get_param(param_file, mdl, "ENERGYSAVEDAYS_GEOMETRIC",CS%energysavedays_geometric, &
-                 "The starting interval in units of TIMEUNIT for the first call \n"//&
-                 "to save the energies of the run and other globally summed diagnostics. \n"//&
+                 "The starting interval in units of TIMEUNIT for the first call "//&
+                 "to save the energies of the run and other globally summed diagnostics. "//&
                  "The interval increases by a factor of 2. after each call to write_energy.",&
                  default=set_time(seconds=0), timeunit=Time_unit)
 

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -719,9 +719,9 @@ subroutine EOS_init(param_file, EOS)
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, mdl, "EQN_OF_STATE", tmpstr, &
-                 "EQN_OF_STATE determines which ocean equation of state \n"//&
-                 "should be used.  Currently, the valid choices are \n"//&
-                 '"LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10". \n'//&
+                 "EQN_OF_STATE determines which ocean equation of state "//&
+                 "should be used.  Currently, the valid choices are "//&
+                 '"LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10". '//&
                  "This is only used if USE_EOS is true.", default=EOS_DEFAULT)
   select case (uppercase(tmpstr))
     case (EOS_LINEAR_STRING)
@@ -744,26 +744,26 @@ subroutine EOS_init(param_file, EOS)
   if (EOS%form_of_EOS == EOS_LINEAR) then
     EOS%Compressible = .false.
     call get_param(param_file, mdl, "RHO_T0_S0", EOS%Rho_T0_S0, &
-                 "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", \n"//&
+                 "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", "//&
                  "this is the density at T=0, S=0.", units="kg m-3", &
                  default=1000.0)
     call get_param(param_file, mdl, "DRHO_DT", EOS%dRho_dT, &
-                 "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", \n"//&
-                 "this is the partial derivative of density with \n"//&
+                 "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", "//&
+                 "this is the partial derivative of density with "//&
                  "temperature.", units="kg m-3 K-1", default=-0.2)
     call get_param(param_file, mdl, "DRHO_DS", EOS%dRho_dS, &
-                 "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", \n"//&
-                 "this is the partial derivative of density with \n"//&
+                 "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", "//&
+                 "this is the partial derivative of density with "//&
                  "salinity.", units="kg m-3 PSU-1", default=0.8)
   endif
 
   call get_param(param_file, mdl, "EOS_QUADRATURE", EOS%EOS_quadrature, &
-                 "If true, always use the generic (quadrature) code \n"//&
+                 "If true, always use the generic (quadrature) code "//&
                  "code for the integrals of density.", default=.false.)
 
   call get_param(param_file, mdl, "TFREEZE_FORM", tmpstr, &
-                 "TFREEZE_FORM determines which expression should be \n"//&
-                 "used for the freezing point.  Currently, the valid \n"//&
+                 "TFREEZE_FORM determines which expression should be "//&
+                 "used for the freezing point.  Currently, the valid "//&
                  'choices are "LINEAR", "MILLERO_78", "TEOS10"', &
                  default=TFREEZE_DEFAULT)
   select case (uppercase(tmpstr))
@@ -780,17 +780,17 @@ subroutine EOS_init(param_file, EOS)
 
   if (EOS%form_of_TFreeze == TFREEZE_LINEAR) then
     call get_param(param_file, mdl, "TFREEZE_S0_P0",EOS%TFr_S0_P0, &
-                 "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", \n"//&
-                 "this is the freezing potential temperature at \n"//&
+                 "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", "//&
+                 "this is the freezing potential temperature at "//&
                  "S=0, P=0.", units="deg C", default=0.0)
     call get_param(param_file, mdl, "DTFREEZE_DS",EOS%dTFr_dS, &
-                 "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", \n"//&
-                 "this is the derivative of the freezing potential \n"//&
+                 "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", "//&
+                 "this is the derivative of the freezing potential "//&
                  "temperature with salinity.", &
                  units="deg C PSU-1", default=-0.054)
     call get_param(param_file, mdl, "DTFREEZE_DP",EOS%dTFr_dP, &
-                 "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", \n"//&
-                 "this is the derivative of the freezing potential \n"//&
+                 "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", "//&
+                 "this is the derivative of the freezing potential "//&
                  "temperature with pressure.", &
                  units="deg C Pa-1", default=0.0)
   endif

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -2914,21 +2914,21 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, mdl, 'NUM_DIAG_COORDS', diag_cs%num_diag_coords, &
-                 'The number of diagnostic vertical coordinates to use.\n'//&
+                 'The number of diagnostic vertical coordinates to use. '//&
                  'For each coordinate, an entry in DIAG_COORDS must be provided.', &
                  default=1)
   if (diag_cs%num_diag_coords>0) then
     allocate(diag_coords(diag_cs%num_diag_coords))
     if (diag_cs%num_diag_coords==1) then ! The default is to provide just one instance of Z*
       call get_param(param_file, mdl, 'DIAG_COORDS', diag_coords, &
-                 'A list of string tuples associating diag_table modules to\n'//&
-                 'a coordinate definition used for diagnostics. Each string\n'//&
+                 'A list of string tuples associating diag_table modules to '//&
+                 'a coordinate definition used for diagnostics. Each string '//&
                  'is of the form "MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME".', &
                  default='z Z ZSTAR')
     else ! If using more than 1 diagnostic coordinate, all must be explicitly defined
       call get_param(param_file, mdl, 'DIAG_COORDS', diag_coords, &
-                 'A list of string tuples associating diag_table modules to\n'//&
-                 'a coordinate definition used for diagnostics. Each string\n'//&
+                 'A list of string tuples associating diag_table modules to '//&
+                 'a coordinate definition used for diagnostics. Each string '//&
                  'is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".', &
                  fail_if_missing=.true.)
     endif
@@ -2944,7 +2944,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
                  'Set the default missing value to use for diagnostics.', &
                  default=1.e20)
   call get_param(param_file, mdl, 'DIAG_AS_CHKSUM', diag_cs%diag_as_chksum, &
-                 'Instead of writing diagnostics to the diag manager, write\n'//&
+                 'Instead of writing diagnostics to the diag manager, write '//&
                  'a text file containing the checksum (bitcount) of the array.',  &
                  default=.false.)
 
@@ -2982,7 +2982,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
     write(this_pe,'(i6.6)') PE_here()
     doc_file_dflt = "available_diags."//this_pe
     call get_param(param_file, mdl, "AVAILABLE_DIAGS_FILE", doc_file, &
-                 "A file into which to write a list of all available \n"//&
+                 "A file into which to write a list of all available "//&
                  "ocean diagnostics that can be included in a diag_table.", &
                  default=doc_file_dflt, do_not_log=(diag_CS%available_diag_doc_unit/=-1))
     if (len_trim(doc_file) > 0) then
@@ -3020,7 +3020,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
     write(this_pe,'(i6.6)') PE_here()
     doc_file_dflt = "chksum_diag."//this_pe
     call get_param(param_file, mdl, "CHKSUM_DIAG_FILE", doc_file, &
-                 "A file into which to write all checksums of the \n"//&
+                 "A file into which to write all checksums of the "//&
                  "diagnostics listed in the diag_table.", &
                  default=doc_file_dflt, do_not_log=(diag_CS%chksum_diag_doc_unit/=-1))
     if (len_trim(doc_file) > 0) then

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -1267,7 +1267,7 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
                  "If true, the domain is meridionally reentrant.", &
                  default=.false.)
   call get_param(param_file, mdl, "TRIPOLAR_N", tripolar_N, &
-                 "Use tripolar connectivity at the northern edge of the \n"//&
+                 "Use tripolar connectivity at the northern edge of the "//&
                  "domain.  With TRIPOLAR_N, NIGLOBAL must be even.", &
                  default=.false.)
 
@@ -1307,19 +1307,19 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
 !$ endif
 #endif
   call log_param(param_file, mdl, "!SYMMETRIC_MEMORY_", MOM_dom%symmetric, &
-                 "If defined, the velocity point data domain includes \n"//&
-                 "every face of the thickness points. In other words, \n"//&
-                 "some arrays are larger than others, depending on where \n"//&
-                 "they are on the staggered grid.  Also, the starting \n"//&
-                 "index of the velocity-point arrays is usually 0, not 1. \n"//&
+                 "If defined, the velocity point data domain includes "//&
+                 "every face of the thickness points. In other words, "//&
+                 "some arrays are larger than others, depending on where "//&
+                 "they are on the staggered grid.  Also, the starting "//&
+                 "index of the velocity-point arrays is usually 0, not 1. "//&
                  "This can only be set at compile time.",&
                  layoutParam=.true.)
   call get_param(param_file, mdl, "NONBLOCKING_UPDATES", MOM_dom%nonblocking_updates, &
                  "If true, non-blocking halo updates may be used.", &
                  default=.false., layoutParam=.true.)
   call get_param(param_file, mdl, "THIN_HALO_UPDATES", MOM_dom%thin_halo_updates, &
-                 "If true, optional arguments may be used to specify the \n"//&
-                 "The width of the halos that are updated with each call.", &
+                 "If true, optional arguments may be used to specify the "//&
+                 "the width of the halos that are updated with each call.", &
                  default=.true., layoutParam=.true.)
 
   nihalo_dflt = 4 ; njhalo_dflt = 4
@@ -1327,24 +1327,24 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
   if (present(NJHALO)) njhalo_dflt = NJHALO
 
   call log_param(param_file, mdl, "!STATIC_MEMORY_", is_static, &
-                 "If STATIC_MEMORY_ is defined, the principle variables \n"//&
-                 "will have sizes that are statically determined at \n"//&
-                 "compile time.  Otherwise the sizes are not determined \n"//&
-                 "until run time. The STATIC option is substantially \n"//&
-                 "faster, but does not allow the PE count to be changed \n"//&
+                 "If STATIC_MEMORY_ is defined, the principle variables "//&
+                 "will have sizes that are statically determined at "//&
+                 "compile time.  Otherwise the sizes are not determined "//&
+                 "until run time. The STATIC option is substantially "//&
+                 "faster, but does not allow the PE count to be changed "//&
                  "at run time.  This can only be set at compile time.",&
                  layoutParam=.true.)
 
   call get_param(param_file, mdl, trim(nihalo_nm), MOM_dom%nihalo, &
-                 "The number of halo points on each side in the \n"//&
-                 "x-direction.  With STATIC_MEMORY_ this is set as NIHALO_ \n"//&
-                 "in "//trim(inc_nm)//" at compile time; without STATIC_MEMORY_ \n"//&
+                 "The number of halo points on each side in the "//&
+                 "x-direction.  With STATIC_MEMORY_ this is set as NIHALO_ "//&
+                 "in "//trim(inc_nm)//" at compile time; without STATIC_MEMORY_ "//&
                  "the default is NIHALO_ in "//trim(inc_nm)//" (if defined) or 2.", &
                  default=4, static_value=nihalo_dflt, layoutParam=.true.)
   call get_param(param_file, mdl, trim(njhalo_nm), MOM_dom%njhalo, &
-                 "The number of halo points on each side in the \n"//&
-                 "y-direction.  With STATIC_MEMORY_ this is set as NJHALO_ \n"//&
-                 "in "//trim(inc_nm)//" at compile time; without STATIC_MEMORY_ \n"//&
+                 "The number of halo points on each side in the "//&
+                 "y-direction.  With STATIC_MEMORY_ this is set as NJHALO_ "//&
+                 "in "//trim(inc_nm)//" at compile time; without STATIC_MEMORY_ "//&
                  "the default is NJHALO_ in "//trim(inc_nm)//" (if defined) or 2.", &
                  default=4, static_value=njhalo_dflt, layoutParam=.true.)
   if (present(min_halo)) then
@@ -1357,13 +1357,13 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
   endif
   if (is_static) then
     call get_param(param_file, mdl, "NIGLOBAL", MOM_dom%niglobal, &
-                 "The total number of thickness grid points in the \n"//&
-                 "x-direction in the physical domain. With STATIC_MEMORY_ \n"//&
+                 "The total number of thickness grid points in the "//&
+                 "x-direction in the physical domain. With STATIC_MEMORY_ "//&
                  "this is set in "//trim(inc_nm)//" at compile time.", &
                  static_value=NIGLOBAL)
     call get_param(param_file, mdl, "NJGLOBAL", MOM_dom%njglobal, &
-                 "The total number of thickness grid points in the \n"//&
-                 "y-direction in the physical domain. With STATIC_MEMORY_ \n"//&
+                 "The total number of thickness grid points in the "//&
+                 "y-direction in the physical domain. With STATIC_MEMORY_ "//&
                  "this is set in "//trim(inc_nm)//" at compile time.", &
                  static_value=NJGLOBAL)
     if (MOM_dom%niglobal /= NIGLOBAL) call MOM_error(FATAL,"MOM_domains_init: " // &
@@ -1379,13 +1379,13 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
     endif
   else
     call get_param(param_file, mdl, "NIGLOBAL", MOM_dom%niglobal, &
-                 "The total number of thickness grid points in the \n"//&
-                 "x-direction in the physical domain. With STATIC_MEMORY_ \n"//&
+                 "The total number of thickness grid points in the "//&
+                 "x-direction in the physical domain. With STATIC_MEMORY_ "//&
                  "this is set in "//trim(inc_nm)//" at compile time.", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, "NJGLOBAL", MOM_dom%njglobal, &
-                 "The total number of thickness grid points in the \n"//&
-                 "y-direction in the physical domain. With STATIC_MEMORY_ \n"//&
+                 "The total number of thickness grid points in the "//&
+                 "y-direction in the physical domain. With STATIC_MEMORY_ "//&
                  "this is set in "//trim(inc_nm)//" at compile time.", &
                  fail_if_missing=.true.)
   endif
@@ -1397,15 +1397,15 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
   inputdir = slasher(inputdir)
 
   call get_param(param_file, mdl, trim(masktable_nm), mask_table, &
-                 "A text file to specify n_mask, layout and mask_list. \n"//&
-                 "This feature masks out processors that contain only land points. \n"//&
-                 "The first line of mask_table is the number of regions to be masked out.\n"//&
-                 "The second line is the layout of the model and must be \n"//&
-                 "consistent with the actual model layout.\n"//&
-                 "The following (n_mask) lines give the logical positions \n"//&
-                 "of the processors that are masked out. The mask_table \n"//&
-                 "can be created by tools like check_mask. The \n"//&
-                 "following example of mask_table masks out 2 processors, \n"//&
+                 "A text file to specify n_mask, layout and mask_list. "//&
+                 "This feature masks out processors that contain only land points. "//&
+                 "The first line of mask_table is the number of regions to be masked out. "//&
+                 "The second line is the layout of the model and must be "//&
+                 "consistent with the actual model layout. "//&
+                 "The following (n_mask) lines give the logical positions "//&
+                 "of the processors that are masked out. The mask_table "//&
+                 "can be created by tools like check_mask. The "//&
+                 "following example of mask_table masks out 2 processors, "//&
                  "(1,2) and (3,6), out of the 24 in a 4x6 layout: \n"//&
                  " 2\n 4,6\n 1,2\n 3,6\n", default="MOM_mask_table", &
                  layoutParam=.true.)
@@ -1416,7 +1416,7 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
     layout(1) = NIPROC ; layout(2) = NJPROC
   else
     call get_param(param_file, mdl, trim(layout_nm), layout, &
-                 "The processor layout to be used, or 0, 0 to automatically \n"//&
+                 "The processor layout to be used, or 0, 0 to automatically "//&
                  "set the layout based on the number of processors.", default=0, &
                  do_not_log=.true.)
     call get_param(param_file, mdl, trim(niproc_nm), nip_parsed, &
@@ -1455,11 +1455,11 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
     endif
   endif
   call log_param(param_file, mdl, trim(niproc_nm), layout(1), &
-                 "The number of processors in the x-direction. With \n"//&
+                 "The number of processors in the x-direction. With "//&
                  "STATIC_MEMORY_ this is set in "//trim(inc_nm)//" at compile time.",&
                  layoutParam=.true.)
   call log_param(param_file, mdl, trim(njproc_nm), layout(2), &
-                 "The number of processors in the y-direction. With \n"//&
+                 "The number of processors in the y-direction. With "//&
                  "STATIC_MEMORY_ this is set in "//trim(inc_nm)//" at compile time.",&
                  layoutParam=.true.)
   call log_param(param_file, mdl, trim(layout_nm), layout, &
@@ -1484,7 +1484,7 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
   ! number of PEs in each direction.
   io_layout(:) = (/ 1, 1 /)
   call get_param(param_file, mdl, trim(io_layout_nm), io_layout, &
-                 "The processor layout to be used, or 0,0 to automatically \n"//&
+                 "The processor layout to be used, or 0,0 to automatically "//&
                  "set the io_layout to be the same as the layout.", default=1, &
                  layoutParam=.true.)
 

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -275,26 +275,26 @@ subroutine close_param_file(CS, quiet_close, component)
                  "If true, all log messages are also sent to stdout.", &
                  default=log_to_stdout_default)
   call log_param(CS, mdl, "REPORT_UNUSED_PARAMS", CS%report_unused, &
-                 "If true, report any parameter lines that are not used \n"//&
+                 "If true, report any parameter lines that are not used "//&
                  "in the run.", default=report_unused_default, &
                  debuggingParam=.true.)
   call log_param(CS, mdl, "FATAL_UNUSED_PARAMS", CS%unused_params_fatal, &
-                 "If true, kill the run if there are any unused \n"//&
+                 "If true, kill the run if there are any unused "//&
                  "parameters.", default=unused_params_fatal_default, &
                  debuggingParam=.true.)
   docfile_default = "MOM_parameter_doc"
   if (present(component)) docfile_default = trim(component)//"_parameter_doc"
   call log_param(CS, mdl, "DOCUMENT_FILE", CS%doc_file, &
-                 "The basename for files where run-time parameters, their\n"//&
-                 "settings, units and defaults are documented. Blank will\n"//&
+                 "The basename for files where run-time parameters, their "//&
+                 "settings, units and defaults are documented. Blank will "//&
                  "disable all parameter documentation.", default=docfile_default)
   if (len_trim(CS%doc_file) > 0) then
     call log_param(CS, mdl, "COMPLETE_DOCUMENTATION",  CS%complete_doc, &
-                  "If true, all run-time parameters are\n"//&
+                  "If true, all run-time parameters are "//&
                   "documented in "//trim(CS%doc_file)//&
                   ".all .", default=complete_doc_default)
     call log_param(CS, mdl, "MINIMAL_DOCUMENTATION", CS%minimal_doc, &
-                  "If true, non-default run-time parameters are\n"//&
+                  "If true, non-default run-time parameters are "//&
                   "documented in "//trim(CS%doc_file)//&
                   ".short .", default=minimal_doc_default)
   endif

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1439,7 +1439,7 @@ subroutine restart_init(param_file, CS, restart_root)
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "PARALLEL_RESTARTFILES", &
                                 CS%parallel_restartfiles, &
-                 "If true, each processor writes its own restart file, \n"//&
+                 "If true, each processor writes its own restart file, "//&
                  "otherwise a single restart file is generated", &
                  default=.false.)
 
@@ -1451,16 +1451,16 @@ subroutine restart_init(param_file, CS, restart_root)
                  "The name-root of the restart file.", default="MOM.res")
   endif
   call get_param(param_file, mdl, "LARGE_FILE_SUPPORT", CS%large_file_support, &
-                 "If true, use the file-size limits with NetCDF large \n"//&
+                 "If true, use the file-size limits with NetCDF large "//&
                  "file support (4Gb), otherwise the limit is 2Gb.", &
                  default=.true.)
   call get_param(param_file, mdl, "MAX_FIELDS", CS%max_fields, &
                  "The maximum number of restart fields that can be used.", &
                  default=100)
   call get_param(param_file, mdl, "RESTART_CHECKSUMS_REQUIRED", CS%checksum_required, &
-                 "If true, require the restart checksums to match and error out otherwise. \n"//&
-                 "Users may want to avoid this comparison if for example the restarts are  \n"//&
-                 "made from a run with a different mask_table than the current run,  \n"//&
+                 "If true, require the restart checksums to match and error out otherwise. "//&
+                 "Users may want to avoid this comparison if for example the restarts are "//&
+                 "made from a run with a different mask_table than the current run, "//&
                  "in which case the checksums will not match and cause crash.",&
                  default=.true.)
 

--- a/src/framework/MOM_unit_scaling.F90
+++ b/src/framework/MOM_unit_scaling.F90
@@ -58,15 +58,15 @@ subroutine unit_scaling_init( param_file, US )
   call log_version(param_file, mdl, version, &
                    "Parameters for doing unit scaling of variables.")
   call get_param(param_file, mdl, "Z_RESCALE_POWER", Z_power, &
-                 "An integer power of 2 that is used to rescale the model's \n"//&
+                 "An integer power of 2 that is used to rescale the model's "//&
                  "intenal units of depths and heights.  Valid values range from -300 to 300.", &
                  units="nondim", default=0, debuggingParam=.true.)
   call get_param(param_file, mdl, "L_RESCALE_POWER", L_power, &
-                 "An integer power of 2 that is used to rescale the model's \n"//&
+                 "An integer power of 2 that is used to rescale the model's "//&
                  "intenal units of lateral distances.  Valid values range from -300 to 300.", &
                  units="nondim", default=0, debuggingParam=.true.)
   call get_param(param_file, mdl, "T_RESCALE_POWER", T_power, &
-                 "An integer power of 2 that is used to rescale the model's \n"//&
+                 "An integer power of 2 that is used to rescale the model's "//&
                  "intenal units of time.  Valid values range from -300 to 300.", &
                  units="nondim", default=0, debuggingParam=.true.)
   if (abs(Z_power) > 300) call MOM_error(FATAL, "unit_scaling_init: "//&

--- a/src/framework/MOM_write_cputime.F90
+++ b/src/framework/MOM_write_cputime.F90
@@ -73,13 +73,13 @@ subroutine MOM_write_cputime_init(param_file, directory, Input_start_time, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "MAXCPU", CS%maxcpu, &
-                 "The maximum amount of cpu time per processor for which \n"//&
-                 "MOM should run before saving a restart file and \n"//&
-                 "quitting with a return value that indicates that a \n"//&
-                 "further run is required to complete the simulation. \n"//&
-                 "If automatic restarts are not desired, use a negative \n"//&
-                 "value for MAXCPU.  MAXCPU has units of wall-clock \n"//&
-                 "seconds, so the actual CPU time used is larger by a \n"//&
+                 "The maximum amount of cpu time per processor for which "//&
+                 "MOM should run before saving a restart file and "//&
+                 "quitting with a return value that indicates that a "//&
+                 "further run is required to complete the simulation. "//&
+                 "If automatic restarts are not desired, use a negative "//&
+                 "value for MAXCPU.  MAXCPU has units of wall-clock "//&
+                 "seconds, so the actual CPU time used is larger by a "//&
                  "factor of the number of processors used.", &
                  units="wall-clock seconds", default=-1.0)
   call get_param(param_file, mdl, "CPU_TIME_FILE", CS%CPUfile, &

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1170,15 +1170,15 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  default=.false.)
   if (shelf_mass_is_dynamic) then
     call get_param(param_file, mdl, "OVERRIDE_SHELF_MOVEMENT", CS%override_shelf_movement, &
-                 "If true, user provided code specifies the ice-shelf \n"//&
+                 "If true, user provided code specifies the ice-shelf "//&
                  "movement instead of the dynamic ice model.", default=.false.)
     CS%active_shelf_dynamics = .not.CS%override_shelf_movement
     call get_param(param_file, mdl, "GROUNDING_LINE_INTERPOLATE", CS%GL_regularize, &
-                 "If true, regularize the floatation condition at the \n"//&
+                 "If true, regularize the floatation condition at the "//&
                  "grounding line as in Goldberg Holland Schoof 2009.", default=.false.)
     call get_param(param_file, mdl, "GROUNDING_LINE_COUPLE", CS%GL_couple, &
-                 "If true, let the floatation condition be determined by \n"//&
-                 "ocean column thickness. This means that update_OD_ffrac \n"//&
+                 "If true, let the floatation condition be determined by "//&
+                 "ocean column thickness. This means that update_OD_ffrac "//&
                  "will be called.  GL_REGULARIZE and GL_COUPLE are exclusive.", &
                  default=.false., do_not_log=CS%GL_regularize)
     if (CS%GL_regularize) CS%GL_couple = .false.
@@ -1188,24 +1188,24 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  "If true, use a thermodynamically interactive ice shelf.", &
                  default=.false.)
   call get_param(param_file, mdl, "SHELF_THREE_EQN", CS%threeeq, &
-                 "If true, use the three equation expression of \n"//&
-                 "consistency to calculate the fluxes at the ice-ocean \n"//&
+                 "If true, use the three equation expression of "//&
+                 "consistency to calculate the fluxes at the ice-ocean "//&
                  "interface.", default=.true.)
   call get_param(param_file, mdl, "SHELF_INSULATOR", CS%insulator, &
-                 "If true, the ice shelf is a perfect insulatior \n"//&
+                 "If true, the ice shelf is a perfect insulatior "//&
                  "(no conduction).", default=.false.)
   call get_param(param_file, mdl, "MELTING_CUTOFF_DEPTH", CS%cutoff_depth, &
-                 "Depth above which the melt is set to zero (it must be >= 0) \n"//&
+                 "Depth above which the melt is set to zero (it must be >= 0) "//&
                  "Default value won't affect the solution.", default=0.0)
   if (CS%cutoff_depth < 0.) &
     call MOM_error(WARNING,"Initialize_ice_shelf: MELTING_CUTOFF_DEPTH must be >= 0.")
 
   call get_param(param_file, mdl, "CONST_SEA_LEVEL", CS%constant_sea_level, &
-                 "If true, apply evaporative, heat and salt fluxes in \n"//&
-                  "the sponge region. This will avoid a large increase \n"//&
-                 "in sea level. This option is needed for some of the \n"//&
-                 "ISOMIP+ experiments (Ocean3 and Ocean4). \n"//&
-                 "IMPORTANT: it is not currently possible to do \n"//&
+                 "If true, apply evaporative, heat and salt fluxes in "//&
+                  "the sponge region. This will avoid a large increase "//&
+                 "in sea level. This option is needed for some of the "//&
+                 "ISOMIP+ experiments (Ocean3 and Ocean4). "//&
+                 "IMPORTANT: it is not currently possible to do "//&
                  "prefect restarts using this flag.", default=.false.)
 
   call get_param(param_file, mdl, "ISOMIP_S_SUR_SPONGE", &
@@ -1217,8 +1217,8 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                 default=-1.9, do_not_log=.true.)
 
   call get_param(param_file, mdl, "SHELF_3EQ_GAMMA", CS%const_gamma, &
-                 "If true, user specifies a constant nondimensional heat-transfer coefficient \n"//&
-                 "(GAMMA_T_3EQ), from which the salt-transfer coefficient is then computed \n"//&
+                 "If true, user specifies a constant nondimensional heat-transfer coefficient "//&
+                 "(GAMMA_T_3EQ), from which the salt-transfer coefficient is then computed "//&
                  " as GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.", default=.false.)
   if (CS%const_gamma) call get_param(param_file, mdl, "SHELF_3EQ_GAMMA_T", CS%Gamma_T_3EQ, &
                  "Nondimensional heat-transfer coefficient.",default=2.2E-2, &
@@ -1230,19 +1230,19 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
 
   if (CS%threeeq) &
     call get_param(param_file, mdl, "SHELF_S_ROOT", CS%find_salt_root, &
-                 "If SHELF_S_ROOT = True, salinity at the ice/ocean interface (Sbdry) \n "//&
-                 "is computed from a quadratic equation. Otherwise, the previous \n"//&
+                 "If SHELF_S_ROOT = True, salinity at the ice/ocean interface (Sbdry) "//&
+                 "is computed from a quadratic equation. Otherwise, the previous "//&
                  "interactive method to estimate Sbdry is used.", default=.false.)
   if (CS%find_salt_root) then ! read liquidus coeffs.
      call get_param(param_file, mdl, "TFREEZE_S0_P0",CS%lambda1, &
-                 "this is the freezing potential temperature at \n"//&
+                 "this is the freezing potential temperature at "//&
                  "S=0, P=0.", units="degC", default=0.0, do_not_log=.true.)
     call get_param(param_file, mdl, "DTFREEZE_DS",CS%lambda1, &
-                 "this is the derivative of the freezing potential \n"//&
+                 "this is the derivative of the freezing potential "//&
                  "temperature with salinity.", &
                  units="degC psu-1", default=-0.054, do_not_log=.true.)
     call get_param(param_file, mdl, "DTFREEZE_DP",CS%lambda3, &
-                 "this is the derivative of the freezing potential \n"//&
+                 "this is the derivative of the freezing potential "//&
                  "temperature with pressure.", &
                  units="degC Pa-1", default=0.0, do_not_log=.true.)
 
@@ -1250,7 +1250,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
 
   if (.not.CS%threeeq) &
     call get_param(param_file, mdl, "SHELF_2EQ_GAMMA_T", CS%gamma_t, &
-                 "If SHELF_THREE_EQN is false, this the fixed turbulent \n"//&
+                 "If SHELF_THREE_EQN is false, this the fixed turbulent "//&
                  "exchange velocity at the ice-ocean interface.", &
                  units="m s-1", fail_if_missing=.true.)
 
@@ -1261,9 +1261,9 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  "The heat capacity of sea water.", units="J kg-1 K-1", &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0) !### MAKE THIS A SEPARATE PARAMETER.
   call get_param(param_file, mdl, "C_P_ICE", CS%Cp_ice, &
@@ -1271,13 +1271,13 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  default=2.10e3)
 
   call get_param(param_file, mdl, "ICE_SHELF_FLUX_FACTOR", CS%flux_factor, &
-                 "Non-dimensional factor applied to shelf thermodynamic \n"//&
+                 "Non-dimensional factor applied to shelf thermodynamic "//&
                  "fluxes.", units="none", default=1.0)
 
   call get_param(param_file, mdl, "KV_ICE", CS%kv_ice, &
                  "The viscosity of the ice.", units="m2 s-1", default=1.0e10)
   call get_param(param_file, mdl, "KV_MOLECULAR", CS%kv_molec, &
-                 "The molecular kinimatic viscosity of sea water at the \n"//&
+                 "The molecular kinimatic viscosity of sea water at the "//&
                  "freezing temperature.", units="m2 s-1", default=1.95e-6)
   call get_param(param_file, mdl, "ICE_SHELF_SALINITY", CS%Salin_ice, &
                  "The salinity of the ice inside the ice shelf.", units="psu", &
@@ -1286,17 +1286,17 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  "The temperature at the center of the ice shelf.", &
                  units = "degC", default=-15.0)
   call get_param(param_file, mdl, "KD_SALT_MOLECULAR", CS%kd_molec_salt, &
-                 "The molecular diffusivity of salt in sea water at the \n"//&
+                 "The molecular diffusivity of salt in sea water at the "//&
                  "freezing point.", units="m2 s-1", default=8.02e-10)
   call get_param(param_file, mdl, "KD_TEMP_MOLECULAR", CS%kd_molec_temp, &
-                 "The molecular diffusivity of heat in sea water at the \n"//&
+                 "The molecular diffusivity of heat in sea water at the "//&
                  "freezing point.", units="m2 s-1", default=1.41e-7)
   call get_param(param_file, mdl, "RHO_0", CS%density_ocean_avg, &
                  "avg ocean density used in floatation cond", &
                  units="kg m-3", default=1035.)
   call get_param(param_file, mdl, "DT_FORCING", CS%time_step, &
-                 "The time step for changing forcing, coupling with other \n"//&
-                 "components, or potentially writing certain diagnostics. \n"//&
+                 "The time step for changing forcing, coupling with other "//&
+                 "components, or potentially writing certain diagnostics. "//&
                  "The default value is given by DT.", units="s", default=0.0)
 
   call get_param(param_file, mdl, "COL_THICK_MELT_THRESHOLD", CS%col_thick_melt_threshold, &
@@ -1304,14 +1304,14 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  default=0.0)
 
   call get_param(param_file, mdl, "READ_TIDEAMP", read_TIDEAMP, &
-                 "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
+                 "If true, read a file (given by TIDEAMP_FILE) containing "//&
                  "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
 
   call safe_alloc_ptr(CS%utide,isd,ied,jsd,jed)   ; CS%utide(:,:) = 0.0
 
   if (read_TIDEAMP) then
     call get_param(param_file, mdl, "TIDEAMP_FILE", TideAmp_file, &
-                 "The path to the file containing the spatially varying \n"//&
+                 "The path to the file containing the spatially varying "//&
                  "tidal amplitudes.", &
                  default="tideamp.nc")
     call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
@@ -1353,15 +1353,15 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  "The minimum value of ustar under ice sheves.", &
                  units="m s-1", default=0.0, scale=US%m_to_Z)
   call get_param(param_file, mdl, "CDRAG_SHELF", cdrag, &
-       "CDRAG is the drag coefficient relating the magnitude of \n"//&
+       "CDRAG is the drag coefficient relating the magnitude of "//&
        "the velocity field to the surface stress.", units="nondim", &
        default=0.003)
   CS%cdrag = cdrag
   if (CS%ustar_bg <= 0.0) then
     call get_param(param_file, mdl, "DRAG_BG_VEL_SHELF", drag_bg_vel, &
-                 "DRAG_BG_VEL is either the assumed bottom velocity (with \n"//&
-                 "LINEAR_DRAG) or an unresolved  velocity that is \n"//&
-                 "combined with the resolved velocity to estimate the \n"//&
+                 "DRAG_BG_VEL is either the assumed bottom velocity (with "//&
+                 "LINEAR_DRAG) or an unresolved  velocity that is "//&
+                 "combined with the resolved velocity to estimate the "//&
                  "velocity magnitude.", units="m s-1", default=0.0, scale=US%m_to_Z)
     if (CS%cdrag*drag_bg_vel > 0.0) CS%ustar_bg = sqrt(CS%cdrag)*drag_bg_vel
   endif
@@ -1536,7 +1536,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces, fl
                  "If true, save the ice shelf initial conditions.", &
                  default=.false.)
   if (save_IC) call get_param(param_file, mdl, "SHELF_IC_OUTPUT_FILE", IC_file,&
-                 "The name-root of the output file for the ice shelf \n"//&
+                 "The name-root of the output file for the ice shelf "//&
                  "initial conditions.", default="MOM_Shelf_IC")
 
   if (save_IC .and. .not.((dirs%input_filename(1:1) == 'r') .and. &
@@ -1606,7 +1606,7 @@ subroutine initialize_shelf_mass(G, param_file, CS, ISS, new_sim)
   new_sim_2 = .true. ; if (present(new_sim)) new_sim_2 = new_sim
 
   call get_param(param_file, mdl, "ICE_SHELF_CONFIG", config, &
-                 "A string that specifies how the ice shelf is \n"//&
+                 "A string that specifies how the ice shelf is "//&
                  "initialized. Valid options include:\n"//&
                  " \tfile\t Read from a file.\n"//&
                  " \tzero\t Set shelf mass to 0 everywhere.\n"//&
@@ -1622,8 +1622,8 @@ subroutine initialize_shelf_mass(G, param_file, CS, ISS, new_sim)
       inputdir = slasher(inputdir)
 
       call get_param(param_file, mdl, "SHELF_FILE", shelf_file, &
-              "If DYNAMIC_SHELF_MASS = True, OVERRIDE_SHELF_MOVEMENT = True \n"//&
-              "and ICE_SHELF_MASS_FROM_FILE = True, this is the file from \n"//&
+              "If DYNAMIC_SHELF_MASS = True, OVERRIDE_SHELF_MOVEMENT = True "//&
+              "and ICE_SHELF_MASS_FROM_FILE = True, this is the file from "//&
               "which to read the shelf mass and area.", &
                default="shelf_mass.nc")
       call get_param(param_file, mdl, "SHELF_MASS_VAR", shelf_mass_var, &

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -225,7 +225,7 @@ subroutine register_ice_shelf_dyn_restarts(G, param_file, CS, restart_CS)
                  default=.false., do_not_log=.true.)
   if (shelf_mass_is_dynamic) then
     call get_param(param_file, mdl, "OVERRIDE_SHELF_MOVEMENT", override_shelf_movement, &
-                 "If true, user provided code specifies the ice-shelf \n"//&
+                 "If true, user provided code specifies the ice-shelf "//&
                  "movement instead of the dynamic ice model.", default=.false., do_not_log=.true.)
     active_shelf_dynamics = .not.override_shelf_movement
   endif
@@ -312,29 +312,29 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
   override_shelf_movement = .false. ; active_shelf_dynamics = .false.
   if (shelf_mass_is_dynamic) then
     call get_param(param_file, mdl, "OVERRIDE_SHELF_MOVEMENT", override_shelf_movement, &
-                 "If true, user provided code specifies the ice-shelf \n"//&
+                 "If true, user provided code specifies the ice-shelf "//&
                  "movement instead of the dynamic ice model.", default=.false., do_not_log=.true.)
     active_shelf_dynamics = .not.override_shelf_movement
 
     call get_param(param_file, mdl, "GROUNDING_LINE_INTERPOLATE", CS%GL_regularize, &
-                 "If true, regularize the floatation condition at the \n"//&
+                 "If true, regularize the floatation condition at the "//&
                  "grounding line as in Goldberg Holland Schoof 2009.", default=.false.)
     call get_param(param_file, mdl, "GROUNDING_LINE_INTERP_SUBGRID_N", CS%n_sub_regularize, &
-                 "The number of sub-partitions of each cell over which to \n"//&
-                 "integrate for the interpolated grounding line. Each cell \n"//&
-                 "is divided into NxN equally-sized rectangles, over which the \n"//&
+                 "The number of sub-partitions of each cell over which to "//&
+                 "integrate for the interpolated grounding line. Each cell "//&
+                 "is divided into NxN equally-sized rectangles, over which the "//&
                  "basal contribution is integrated by iterative quadrature.", &
                  default=0)
     call get_param(param_file, mdl, "GROUNDING_LINE_COUPLE", CS%GL_couple, &
-                 "If true, let the floatation condition be determined by \n"//&
-                 "ocean column thickness. This means that update_OD_ffrac \n"//&
+                 "If true, let the floatation condition be determined by "//&
+                 "ocean column thickness. This means that update_OD_ffrac "//&
                  "will be called.  GL_REGULARIZE and GL_COUPLE are exclusive.", &
                  default=.false., do_not_log=CS%GL_regularize)
     if (CS%GL_regularize) CS%GL_couple = .false.
     if (CS%GL_regularize .and. (CS%n_sub_regularize == 0)) call MOM_error (FATAL, &
       "GROUNDING_LINE_INTERP_SUBGRID_N must be a positive integer if GL regularization is used")
     call get_param(param_file, mdl, "ICE_SHELF_CFL_FACTOR", CS%CFL_factor, &
-                 "A factor used to limit timestep as CFL_FACTOR * min (\Delta x / u). \n"// &
+                 "A factor used to limit timestep as CFL_FACTOR * min (\Delta x / u). "//&
                  "This is only used with an ice-only model.", default=0.25)
   endif
   call get_param(param_file, mdl, "RHO_0", CS%density_ocean_avg, &
@@ -372,14 +372,14 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
     call get_param(param_file, mdl, "CONJUGATE_GRADIENT_MAXIT", CS%cg_max_iterations, &
                 "max iteratiions in CG solver", default=2000)
     call get_param(param_file, mdl, "THRESH_FLOAT_COL_DEPTH", CS%thresh_float_col_depth, &
-                "min ocean thickness to consider ice *floating*; \n"// &
+                "min ocean thickness to consider ice *floating*; "//&
                 "will only be important with use of tides", &
                 units="m", default=1.e-3, scale=US%m_to_Z)
     call get_param(param_file, mdl, "NONLIN_SOLVE_ERR_MODE", CS%nonlin_solve_err_mode, &
-                "Choose whether nonlin error in vel solve is based on nonlinear \n"// &
+                "Choose whether nonlin error in vel solve is based on nonlinear "//&
                 "residual (1) or relative change since last iteration (2)", default=1)
     call get_param(param_file, mdl, "SHELF_DYN_REPRODUCING_SUMS", CS%use_reproducing_sums, &
-                "If true, use the reproducing extended-fixed-point sums in \n"//&
+                "If true, use the reproducing extended-fixed-point sums in "//&
                 "the ice shelf dynamics solvers.", default=.true.)
 
     call get_param(param_file, mdl, "SHELF_MOVING_FRONT", CS%moving_shelf_front, &

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -42,7 +42,7 @@ subroutine initialize_ice_thickness(h_shelf, area_shelf_h, hmask, G, US, PF)
   character(len=200) :: config
 
   call get_param(PF, mdl, "ICE_PROFILE_CONFIG", config, &
-                 "This specifies how the initial ice profile is specified. \n"//&
+                 "This specifies how the initial ice profile is specified. "//&
                  "Valid values are: CHANNEL, FILE, and USER.", &
                  fail_if_missing=.true.)
 
@@ -180,9 +180,9 @@ subroutine initialize_ice_thickness_channel(h_shelf, area_shelf_h, hmask, G, US,
   call get_param(PF, mdl, "SHELF_EDGE_POS_0", edge_pos, &
                  units="axis_units", default=0.0)
 !  call get_param(param_file, mdl, "RHO_0", Rho_ocean, &
-!                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-!                 "calculate accelerations and the mass for conservation \n"//&
-!                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+!                 "The mean ocean density used with BOUSSINESQ true to "//&
+!                 "calculate accelerations and the mass for conservation "//&
+!                 "properties, or with BOUSSINSEQ false to convert some "//&
 !                 "parameters from vertical units of m to kg m-2.", &
 !                 units="kg m-3", default=1035.0, scale=US%Z_to_m)
 
@@ -272,11 +272,11 @@ end subroutine initialize_ice_thickness_channel
 !   logical flux_bdry
 
 !   call get_param(PF, mdl, "ICE_BOUNDARY_CONFIG", config, &
-!                  "This specifies how the ice domain boundary is specified. \n"//&
+!                  "This specifies how the ice domain boundary is specified. "//&
 !                  "valid values include CHANNEL, FILE and USER.", &
 !                  fail_if_missing=.true.)
 !   call get_param(PF, mdl, "ICE_BOUNDARY_FLUX_CONDITION", flux_bdry, &
-!                  "This specifies whether mass input is a dirichlet or \n"//&
+!                  "This specifies whether mass input is a dirichlet or "//&
 !                  "flux condition", default=.true.)
 
 !   select case ( trim(config) )

--- a/src/ice_shelf/MOM_marine_ice.F90
+++ b/src/ice_shelf/MOM_marine_ice.F90
@@ -185,8 +185,7 @@ subroutine marine_ice_init(Time, G, param_file, diag, CS)
   character(len=40)  :: mdl = "MOM_marine_ice"  ! This module's name.
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "marine_ice_init called with an "// &
-                            "associated control structure.")
+    call MOM_error(WARNING, "marine_ice_init called with an associated control structure.")
     return
   else ; allocate(CS) ; endif
 
@@ -200,8 +199,8 @@ subroutine marine_ice_init(Time, G, param_file, diag, CS)
   call get_param(param_file, mdl, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
                  "The latent heat of fusion.", units="J/kg", default=hlf)
   call get_param(param_file, mdl, "BERG_AREA_THRESHOLD", CS%berg_area_threshold, &
-                 "Fraction of grid cell which iceberg must occupy, so that fluxes \n"//&
-                 "below berg are set to zero. Not applied for negative \n"//&
+                 "Fraction of grid cell which iceberg must occupy, so that fluxes "//&
+                 "below berg are set to zero. Not applied for negative "//&
                  "values.", units="non-dim", default=-1.0)
 
 end subroutine marine_ice_init

--- a/src/ice_shelf/user_shelf_init.F90
+++ b/src/ice_shelf/user_shelf_init.F90
@@ -77,9 +77,9 @@ subroutine USER_initialize_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, 
   if (CS%first_call) call write_user_log(param_file)
   CS%first_call = .false.
   call get_param(param_file, mdl, "RHO_0", CS%Rho_ocean, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0, scale=US%Z_to_m)
   call get_param(param_file, mdl, "SHELF_MAX_DRAFT", CS%max_draft, &

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -275,7 +275,7 @@ subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, US, param_file, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)
   call get_param(param_file, mdl, "COORD_FILE", coord_file, &
-                 "The file from which the coordinate temperatures and \n"//&
+                 "The file from which the coordinate temperatures and "//&
                  "salinities are read.", fail_if_missing=.true.)
 
   call get_param(param_file,  mdl, "INPUTDIR", inputdir, default=".")
@@ -330,25 +330,25 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, US, param_file, &
   call get_param(param_file, mdl, "T_REF", T_Ref, &
                  "The default initial temperatures.", units="degC", default=10.0)
   call get_param(param_file, mdl, "TS_RANGE_T_LIGHT", T_Light, &
-                 "The initial temperature of the lightest layer when \n"//&
+                 "The initial temperature of the lightest layer when "//&
                  "COORD_CONFIG is set to ts_range.", units="degC", default=T_Ref)
   call get_param(param_file, mdl, "TS_RANGE_T_DENSE", T_Dense, &
-                 "The initial temperature of the densest layer when \n"//&
+                 "The initial temperature of the densest layer when "//&
                  "COORD_CONFIG is set to ts_range.", units="degC", default=T_Ref)
 
   call get_param(param_file, mdl, "S_REF", S_Ref, &
                  "The default initial salinities.", units="PSU", default=35.0)
   call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_Light, &
-                 "The initial lightest salinities when COORD_CONFIG \n"//&
+                 "The initial lightest salinities when COORD_CONFIG "//&
                  "is set to ts_range.", default = S_Ref, units="PSU")
   call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_Dense, &
-                 "The initial densest salinities when COORD_CONFIG \n"//&
+                 "The initial densest salinities when COORD_CONFIG "//&
                  "is set to ts_range.", default = S_Ref, units="PSU")
 
   call get_param(param_file, mdl, "TS_RANGE_RESOLN_RATIO", res_rat, &
-                 "The ratio of density space resolution in the densest \n"//&
-                 "part of the range to that in the lightest part of the \n"//&
-                 "range when COORD_CONFIG is set to ts_range. Values \n"//&
+                 "The ratio of density space resolution in the densest "//&
+                 "part of the range to that in the lightest part of the "//&
+                 "range when COORD_CONFIG is set to ts_range. Values "//&
                  "greater than 1 increase the resolution of the denser water.",&
                  default=1.0, units="nondim")
 
@@ -408,7 +408,7 @@ subroutine set_coord_from_file(Rlay, g_prime, GV, US, param_file)
                  "The file from which the coordinate densities are read.", &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "COORD_VAR", coord_var, &
-                 "The variable in COORD_FILE that is to be used for the \n"//&
+                 "The variable in COORD_FILE that is to be used for the "//&
                  "coordinate densities.", default="Layer")
   filename = trim(inputdir)//trim(coord_file)
   call log_param(param_file, mdl, "INPUTDIR/COORD_FILE", filename)
@@ -449,11 +449,11 @@ subroutine set_coord_linear(Rlay, g_prime, GV, US, param_file)
   call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")
 
   call get_param(param_file, mdl, "LIGHTEST_DENSITY", Rlay_Ref, &
-                 "The reference potential density used for the surface \n"// &
-                 "interface.", units="kg m-3", default=GV%Rho0)
+                 "The reference potential density used for the surface interface.", &
+                 units="kg m-3", default=GV%Rho0)
   call get_param(param_file, mdl, "DENSITY_RANGE", Rlay_range, &
-                 "The range of reference potential densities across \n"// &
-                 "all interfaces.", units="kg m-3", default=2.0)
+                 "The range of reference potential densities across all interfaces.", &
+                 units="kg m-3", default=2.0)
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=(GV%g_Earth*US%m_to_Z), scale=US%Z_to_m)

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -134,7 +134,7 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF, write_geom, output_dir)
   !   This call sets the topography at velocity points.
   if (G%bathymetry_at_vel) then
     call get_param(PF, mdl, "VELOCITY_DEPTH_CONFIG", config, &
-                   "A string that determines how the topography is set at \n"//&
+                   "A string that determines how the topography is set at "//&
                    "velocity points. This may be 'min' or 'max'.", &
                    default="max")
     select case ( trim(config) )

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -72,7 +72,7 @@ subroutine set_grid_metrics(G, param_file, US)
   call callTree_enter("set_grid_metrics(), MOM_grid_initialize.F90")
   call log_version(param_file, "MOM_grid_init", version, "")
   call get_param(param_file, "MOM_grid_init", "GRID_CONFIG", config, &
-                 "A character string that determines the method for \n"//&
+                 "A character string that determines the method for "//&
                  "defining the horizontal grid.  Current options are: \n"//&
                  " \t mosaic - read the grid from a mosaic (supergrid) \n"//&
                  " \t          file set by GRID_FILE.\n"//&
@@ -202,7 +202,7 @@ subroutine set_grid_metrics_from_mosaic(G, param_file)
                  "Name of the file from which to read horizontal grid data.", &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "USE_TRIPOLAR_GEOLONB_BUG", lon_bug, &
-                 "If true, use older code that incorrectly sets the longitude \n"//&
+                 "If true, use older code that incorrectly sets the longitude "//&
                  "in some points along the tripolar fold to be off by 360 degrees.", &
                  default=.true.)
   call get_param(param_file,  mdl, "INPUTDIR", inputdir, default=".")
@@ -443,14 +443,14 @@ subroutine set_grid_metrics_cartesian(G, param_file)
                  " \t degrees - degrees of latitude and longitude \n"//&
                  " \t m - meters \n \t k - kilometers", default="degrees")
   call get_param(param_file, mdl, "SOUTHLAT", G%south_lat, &
-                 "The southern latitude of the domain or the equivalent \n"//&
+                 "The southern latitude of the domain or the equivalent "//&
                  "starting value for the y-axis.", units=units_temp, &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "LENLAT", G%len_lat, &
                  "The latitudinal or y-direction length of the domain.", &
                  units=units_temp, fail_if_missing=.true.)
   call get_param(param_file, mdl, "WESTLON", G%west_lon, &
-                 "The western longitude of the domain or the equivalent \n"//&
+                 "The western longitude of the domain or the equivalent "//&
                  "starting value for the x-axis.", units=units_temp, &
                  default=0.0)
   call get_param(param_file, mdl, "LENLON", G%len_lon, &
@@ -746,24 +746,24 @@ subroutine set_grid_metrics_mercator(G, param_file)
   G%west_lon = GP%west_lon ; G%len_lon = GP%len_lon
   G%Rad_Earth = GP%Rad_Earth
   call get_param(param_file, mdl, "ISOTROPIC", GP%isotropic, &
-                 "If true, an isotropic grid on a sphere (also known as \n"//&
-                 "a Mercator grid) is used. With an isotropic grid, the \n"//&
-                 "meridional extent of the domain (LENLAT), the zonal \n"//&
-                 "extent (LENLON), and the number of grid points in each \n"//&
-                 "direction are _not_ independent. In MOM the meridional \n"//&
-                 "extent is determined to fit the zonal extent and the \n"//&
+                 "If true, an isotropic grid on a sphere (also known as "//&
+                 "a Mercator grid) is used. With an isotropic grid, the "//&
+                 "meridional extent of the domain (LENLAT), the zonal "//&
+                 "extent (LENLON), and the number of grid points in each "//&
+                 "direction are _not_ independent. In MOM the meridional "//&
+                 "extent is determined to fit the zonal extent and the "//&
                  "number of grid points, while grid is perfectly isotropic.", &
                  default=.false.)
   call get_param(param_file, mdl, "EQUATOR_REFERENCE", GP%equator_reference, &
-                 "If true, the grid is defined to have the equator at the \n"//&
+                 "If true, the grid is defined to have the equator at the "//&
                  "nearest q- or h- grid point to (-LOWLAT*NJGLOBAL/LENLAT).", &
                  default=.true.)
   call get_param(param_file, mdl, "LAT_ENHANCE_FACTOR", GP%Lat_enhance_factor, &
-                 "The amount by which the meridional resolution is \n"//&
+                 "The amount by which the meridional resolution is "//&
                  "enhanced within LAT_EQ_ENHANCE of the equator.", &
                  units="nondim", default=1.0)
   call get_param(param_file, mdl, "LAT_EQ_ENHANCE", GP%Lat_eq_enhance, &
-                 "The latitude range to the north and south of the equator \n"//&
+                 "The latitude range to the north and south of the equator "//&
                  "over which the resolution is enhanced.", units="degrees", &
                  default=0.0)
 
@@ -1236,13 +1236,13 @@ subroutine initialize_masks(G, PF, US)
   call callTree_enter("initialize_masks(), MOM_grid_initialize.F90")
   m_to_Z_scale = 1.0 ; if (present(US)) m_to_Z_scale = US%m_to_Z
   call get_param(PF, mdl, "MINIMUM_DEPTH", min_depth, &
-                 "If MASKING_DEPTH is unspecified, then anything shallower than\n"//&
-                 "MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.\n"//&
-                 "If MASKING_DEPTH is specified, then all depths shallower than\n"//&
+                 "If MASKING_DEPTH is unspecified, then anything shallower than "//&
+                 "MINIMUM_DEPTH is assumed to be land and all fluxes are masked out. "//&
+                 "If MASKING_DEPTH is specified, then all depths shallower than "//&
                  "MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.", &
                  units="m", default=0.0, scale=m_to_Z_scale)
   call get_param(PF, mdl, "MASKING_DEPTH", mask_depth, &
-                 "The depth below which to mask points as land points, for which all\n"//&
+                 "The depth below which to mask points as land points, for which all "//&
                  "fluxes are zeroed out. MASKING_DEPTH is ignored if negative.", &
                  units="m", default=-9999.0, scale=m_to_Z_scale)
 

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -72,7 +72,7 @@ subroutine MOM_initialize_rotation(f, G, PF, US)
                  "This specifies how the Coriolis parameter is specified: \n"//&
                  " \t 2omegasinlat - Use twice the planetary rotation rate \n"//&
                  " \t\t times the sine of latitude.\n"//&
-                 " \t betaplane - Use a beta-plane or f-plane. \n"//&
+                 " \t betaplane - Use a beta-plane or f-plane.\n"//&
                  " \t USER - call a user modified routine.", &
                  default="2omegasinlat")
   select case (trim(config))
@@ -349,7 +349,7 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
 !   call get_param(param_file, mdl, "RAD_EARTH", Rad_Earth, &
 !                  "The radius of the Earth.", units="m", default=6.378e6)
     call get_param(param_file, mdl, "TOPOG_SLOPE_SCALE", expdecay, &
-                   "The exponential decay scale used in defining some of \n"//&
+                   "The exponential decay scale used in defining some of "//&
                    "the named topographies.", units="m", default=400000.0)
   endif
 
@@ -426,9 +426,9 @@ subroutine limit_topography(D, G, param_file, max_depth, US)
   m_to_Z = 1.0 ; if (present(US)) m_to_Z = US%m_to_Z
 
   call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
-                 "If MASKING_DEPTH is unspecified, then anything shallower than\n"//&
-                 "MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.\n"//&
-                 "If MASKING_DEPTH is specified, then all depths shallower than\n"//&
+                 "If MASKING_DEPTH is unspecified, then anything shallower than "//&
+                 "MINIMUM_DEPTH is assumed to be land and all fluxes are masked out. "//&
+                 "If MASKING_DEPTH is specified, then all depths shallower than "//&
                  "MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.", &
                  units="m", default=0.0, scale=m_to_Z)
   call get_param(param_file, mdl, "MASKING_DEPTH", mask_depth, &
@@ -511,10 +511,10 @@ subroutine set_rotation_beta_plane(f, G, param_file, US)
   T_to_s = 1.0 ; if (present(US)) T_to_s = US%T_to_s
 
   call get_param(param_file, mdl, "F_0", f_0, &
-                 "The reference value of the Coriolis parameter with the \n"//&
+                 "The reference value of the Coriolis parameter with the "//&
                  "betaplane option.", units="s-1", default=0.0, scale=T_to_s)
   call get_param(param_file, mdl, "BETA", beta, &
-                 "The northward gradient of the Coriolis parameter with \n"//&
+                 "The northward gradient of the Coriolis parameter with "//&
                  "the betaplane option.", units="m-1 s-1", default=0.0, scale=T_to_s)
   call get_param(param_file, mdl, "AXIS_UNITS", axis_units, default="degrees")
 
@@ -554,8 +554,8 @@ subroutine initialize_grid_rotation_angle(G, PF)
   integer :: i, j, m, n
 
   call get_param(PF, mdl, "GRID_ROTATION_ANGLE_BUGS", use_bugs, &
-                 "If true, use an older algorithm to calculate the sine and \n"//&
-                 "cosines needed rotate between grid-oriented directions and \n"//&
+                 "If true, use an older algorithm to calculate the sine and "//&
+                 "cosines needed rotate between grid-oriented directions and "//&
                  "true north and east.  Differences arise at the tripolar fold.", &
                  default=.True.)
 
@@ -842,7 +842,7 @@ subroutine reset_face_lengths_list(G, param_file, US)
   filename = trim(inputdir)//trim(chan_file)
   call log_param(param_file, mdl, "INPUTDIR/CHANNEL_LIST_FILE", filename)
   call get_param(param_file, mdl, "CHANNEL_LIST_360_LON_CHECK", check_360, &
-                 "If true, the channel configuration list works for any \n"//&
+                 "If true, the channel configuration list works for any "//&
                  "longitudes in the range of -360 to 360.", default=.true.)
 
   if (is_root_pe()) then
@@ -1241,7 +1241,7 @@ subroutine write_ocean_geometry_file(G, param_file, directory, geom_file, US)
   out_q(:,:) = 0.0
 
   call get_param(param_file, mdl, "PARALLEL_RESTARTFILES", multiple_files, &
-                 "If true, each processor writes its own restart file, \n"//&
+                 "If true, each processor writes its own restart file, "//&
                  "otherwise a single restart file is generated", &
                  default=.false.)
   file_threading = SINGLE_FILE

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -229,9 +229,9 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   ! is just to make sure that all valid parameters are read to enable the
   ! detection of unused parameters.
   call get_param(PF, mdl, "INIT_LAYERS_FROM_Z_FILE", from_Z_file, &
-             "If true, initialize the layer thicknesses, temperatures, \n"//&
-             "and salinities from a Z-space file on a latitude- \n"//&
-             "longitude grid.", default=.false., do_not_log=just_read)
+             "If true, initialize the layer thicknesses, temperatures, "//&
+             "and salinities from a Z-space file on a latitude-longitude "//&
+             "grid.", default=.false., do_not_log=just_read)
 
   if (from_Z_file) then
     ! Initialize thickness and T/S from z-coordinate data in a file.
@@ -243,7 +243,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   else
     ! Initialize thickness, h.
     call get_param(PF, mdl, "THICKNESS_CONFIG", config, &
-             "A string that determines how the initial layer \n"//&
+             "A string that determines how the initial layer "//&
              "thicknesses are specified for a new run: \n"//&
              " \t file - read interface heights from the file specified \n"//&
              " \t thickness_file - read thicknesses from the file specified \n"//&
@@ -325,7 +325,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
     ! Initialize temperature and salinity (T and S).
     if ( use_temperature ) then
       call get_param(PF, mdl, "TS_CONFIG", config, &
-             "A string that determines how the initial tempertures \n"//&
+             "A string that determines how the initial tempertures "//&
              "and salinities are specified for a new run: \n"//&
              " \t file - read velocities from the file specified \n"//&
              " \t\t by (TS_FILE). \n"//&
@@ -392,7 +392,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
 
   ! Initialize velocity components, u and v
   call get_param(PF, mdl, "VELOCITY_CONFIG", config, &
-       "A string that determines how the initial velocities \n"//&
+       "A string that determines how the initial velocities "//&
        "are specified for a new run: \n"//&
        " \t file - read velocities from the file specified \n"//&
        " \t\t by (VELOCITY_FILE). \n"//&
@@ -431,9 +431,9 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   ! Optionally convert the thicknesses from m to kg m-2.  This is particularly
   ! useful in a non-Boussinesq model.
   call get_param(PF, mdl, "CONVERT_THICKNESS_UNITS", convert, &
-               "If true,  convert the thickness initial conditions from \n"//&
-               "units of m to kg m-2 or vice versa, depending on whether \n"//&
-               "BOUSSINESQ is defined. This does not apply if a restart \n"//&
+               "If true,  convert the thickness initial conditions from "//&
+               "units of m to kg m-2 or vice versa, depending on whether "//&
+               "BOUSSINESQ is defined. This does not apply if a restart "//&
                "file is read.", default=.not.GV%Boussinesq, do_not_log=just_read)
 
   if (new_sim .and. convert .and. .not.GV%Boussinesq) &
@@ -442,12 +442,12 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
 
   ! Remove the mass that would be displaced by an ice shelf or inverse barometer.
   call get_param(PF, mdl, "DEPRESS_INITIAL_SURFACE", depress_sfc, &
-               "If true,  depress the initial surface to avoid huge \n"//&
+               "If true,  depress the initial surface to avoid huge "//&
                "tsunamis when a large surface pressure is applied.", &
                default=.false., do_not_log=just_read)
   call get_param(PF, mdl, "TRIM_IC_FOR_P_SURF", trim_ic_for_p_surf, &
-               "If true, cuts way the top of the column for initial conditions\n"//&
-               "at the depth where the hydrostatic pressure matches the imposed\n"//&
+               "If true, cuts way the top of the column for initial conditions "//&
+               "at the depth where the hydrostatic pressure matches the imposed "//&
                "surface pressure which is read from file.", default=.false., &
                do_not_log=just_read)
   if (depress_sfc .and. trim_ic_for_p_surf) call MOM_error(FATAL, "MOM_initialize_state: "//&
@@ -461,13 +461,13 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   ! iterations here so the initial grid is consistent with the coordinate
   if (useALE) then
     call get_param(PF, mdl, "REGRID_ACCELERATE_INIT", regrid_accelerate, &
-         "If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding\n"//&
-         "algorithm to push the initial grid to be consistent with the initial\n"//&
+         "If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding "//&
+         "algorithm to push the initial grid to be consistent with the initial "//&
          "condition. Useful only for state-based and iterative coordinates.", &
          default=.false., do_not_log=just_read)
     if (regrid_accelerate) then
       call get_param(PF, mdl, "REGRID_ACCELERATE_ITERATIONS", regrid_iterations, &
-           "The number of regridding iterations to perform to generate\n"//&
+           "The number of regridding iterations to perform to generate "//&
            "an initial grid that is consistent with the initial conditions.", &
            default=1, do_not_log=just_read)
 
@@ -513,8 +513,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   endif
 
   call get_param(PF, mdl, "SPONGE", use_sponge, &
-                 "If true, sponges may be applied anywhere in the domain. \n"//&
-                 "The exact location and properties of those sponges are \n"//&
+                 "If true, sponges may be applied anywhere in the domain. "//&
+                 "The exact location and properties of those sponges are "//&
                  "specified via SPONGE_CONFIG.", default=.false.)
   if ( use_sponge ) then
     call get_param(PF, mdl, "SPONGE_CONFIG", config, &
@@ -554,8 +554,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   ! This controls user code for setting open boundary data
   if (associated(OBC)) then
     call get_param(PF, mdl, "OBC_USER_CONFIG", config, &
-                 "A string that sets how the user code is invoked to set open\n"//&
-                 " boundary data: \n"//&
+                 "A string that sets how the user code is invoked to set open boundary data: \n"//&
                  "   DOME - specified inflow on northern boundary\n"//&
                  "   dyed_channel - supercritical with dye on the inflow boundary\n"//&
                  "   dyed_obcs - circle_obcs with dyes on the open boundaries\n"//&
@@ -655,8 +654,8 @@ subroutine initialize_thickness_from_file(h, G, GV, US, param_file, file_has_thi
     call MOM_read_data(filename, "h", h(:,:,:), G%Domain, scale=GV%m_to_H)
   else
     call get_param(param_file, mdl, "ADJUST_THICKNESS", correct_thickness, &
-                 "If true, all mass below the bottom removed if the \n"//&
-                 "topography is shallower than the thickness input file \n"//&
+                 "If true, all mass below the bottom removed if the "//&
+                 "topography is shallower than the thickness input file "//&
                  "would indicate.", default=.false., do_not_log=just_read)
     if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -854,10 +853,10 @@ subroutine initialize_thickness_list(h, G, GV, US, param_file, just_read_params)
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
   call get_param(param_file, mdl, "INTERFACE_IC_FILE", eta_file, &
-                 "The file from which horizontal mean initial conditions \n"//&
+                 "The file from which horizontal mean initial conditions "//&
                  "for interface depths can be read.", fail_if_missing=.true.)
   call get_param(param_file, mdl, "INTERFACE_IC_VAR", eta_var, &
-                 "The variable name for horizontal mean initial conditions \n"//&
+                 "The variable name for horizontal mean initial conditions "//&
                  "for interface depths relative to mean sea level.", &
                  default="eta")
 
@@ -1029,7 +1028,7 @@ subroutine depress_surface(h, G, GV, US, param_file, tv, just_read_params)
     call log_param(param_file,  mdl, "INPUTDIR/SURFACE_HEIGHT_IC_FILE", filename)
 
   call get_param(param_file, mdl, "SURFACE_HEIGHT_IC_SCALE", scale_factor, &
-                 "A scaling factor to convert SURFACE_HEIGHT_IC_VAR into \n"//&
+                 "A scaling factor to convert SURFACE_HEIGHT_IC_VAR into "//&
                  "units of m", units="variable", default=1.0, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
@@ -1108,7 +1107,7 @@ subroutine trim_for_ice(PF, G, GV, US, ALE_CSp, tv, h, just_read_params)
   if (.not.just_read) call log_param(PF,  mdl, "!INPUTDIR/SURFACE_HEIGHT_IC_FILE", filename)
 
   call get_param(PF, mdl, "SURFACE_PRESSURE_SCALE", scale_factor, &
-                 "A scaling factor to convert SURFACE_PRESSURE_VAR from\n"//&
+                 "A scaling factor to convert SURFACE_PRESSURE_VAR from "//&
                  "file SURFACE_PRESSURE_FILE into a surface pressure.", &
                  units="file dependent", default=1., do_not_log=just_read)
   call get_param(PF, mdl, "MIN_THICKNESS", min_thickness, 'Minimum layer thickness', &
@@ -1371,7 +1370,7 @@ subroutine initialize_velocity_circular(u, v, G, param_file, just_read_params)
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
   call get_param(param_file, mdl, "CIRCULAR_MAX_U", circular_max_u, &
-                 "The amplitude of zonal flow from which to scale the\n"// &
+                 "The amplitude of zonal flow from which to scale the "// &
                  "circular stream function [m s-1].", &
                  units="m s-1", default=0., do_not_log=just_read)
 
@@ -1487,7 +1486,7 @@ subroutine initialize_temp_salt_from_profile(T, S, G, param_file, just_read_para
   if (.not.just_read) call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
   call get_param(param_file, mdl, "TS_FILE", ts_file, &
-                 "The file with the reference profiles for temperature \n"//&
+                 "The file with the reference profiles for temperature "//&
                  "and salinity.", fail_if_missing=.not.just_read, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
@@ -1551,7 +1550,7 @@ subroutine initialize_temp_salt_fit(T, S, G, GV, param_file, eqn_of_state, P_Ref
                  "A reference salinity used in initialization.", units="PSU", &
                  default=35.0, do_not_log=just_read)
   call get_param(param_file, mdl, "FIT_SALINITY", fit_salin, &
-                 "If true, accept the prescribed temperature and fit the \n"//&
+                 "If true, accept the prescribed temperature and fit the "//&
                  "salinity; otherwise take salinity and fit temperature.", &
                  default=.false., do_not_log=just_read)
 
@@ -1724,27 +1723,27 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, param_file, C
                  "The name of the file with the state to damp toward.", &
                  default=damping_file)
   call get_param(param_file, mdl, "SPONGE_PTEMP_VAR", potemp_var, &
-                 "The name of the potential temperature variable in \n"//&
+                 "The name of the potential temperature variable in "//&
                  "SPONGE_STATE_FILE.", default="PTEMP")
   call get_param(param_file, mdl, "SPONGE_SALT_VAR", salin_var, &
-                 "The name of the salinity variable in \n"//&
+                 "The name of the salinity variable in "//&
                  "SPONGE_STATE_FILE.", default="SALT")
   call get_param(param_file, mdl, "SPONGE_ETA_VAR", eta_var, &
-                 "The name of the interface height variable in \n"//&
+                 "The name of the interface height variable in "//&
                  "SPONGE_STATE_FILE.", default="ETA")
   call get_param(param_file, mdl, "SPONGE_IDAMP_VAR", Idamp_var, &
-                 "The name of the inverse damping rate variable in \n"//&
+                 "The name of the inverse damping rate variable in "//&
                  "SPONGE_DAMPING_FILE.", default="IDAMP")
   call get_param(param_file, mdl, "USE_REGRIDDING", use_ALE, do_not_log = .true.)
 
   call get_param(param_file, mdl, "NEW_SPONGES", new_sponges, &
-                 "Set True if using the newer sponging code which \n"//&
+                 "Set True if using the newer sponging code which "//&
                  "performs on-the-fly regridding in lat-lon-time.",&
                  "of sponge restoring data.", default=.false.)
 
 !  if (use_ALE) then
 !    call get_param(param_file, mdl, "SPONGE_RESTORE_ETA", restore_eta, &
-!                 "If true, then restore the interface positions towards \n"//&
+!                 "If true, then restore the interface positions towards "//&
 !                 "target values (in ALE mode)", default = .false.)
 !  endif
 
@@ -2024,45 +2023,45 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_param
   call get_param(PF, mdl, "NKBL",nkbl,default=0)
 
   call get_param(PF, mdl, "TEMP_SALT_Z_INIT_FILE",filename, &
-                 "The name of the z-space input file used to initialize \n"//&
-                 "temperatures (T) and salinities (S). If T and S are not \n" //&
-                 "in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE \n" //&
+                 "The name of the z-space input file used to initialize "//&
+                 "temperatures (T) and salinities (S). If T and S are not "//&
+                 "in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE "//&
                  "must be set.",default="temp_salt_z.nc",do_not_log=just_read)
   call get_param(PF, mdl, "TEMP_Z_INIT_FILE",tfilename, &
-                 "The name of the z-space input file used to initialize \n"//&
+                 "The name of the z-space input file used to initialize "//&
                  "temperatures, only.", default=trim(filename),do_not_log=just_read)
   call get_param(PF, mdl, "SALT_Z_INIT_FILE",sfilename, &
-                 "The name of the z-space input file used to initialize \n"//&
+                 "The name of the z-space input file used to initialize "//&
                  "temperatures, only.", default=trim(filename),do_not_log=just_read)
   filename = trim(inputdir)//trim(filename)
   tfilename = trim(inputdir)//trim(tfilename)
   sfilename = trim(inputdir)//trim(sfilename)
   call get_param(PF, mdl, "Z_INIT_FILE_PTEMP_VAR", potemp_var, &
-                 "The name of the potential temperature variable in \n"//&
+                 "The name of the potential temperature variable in "//&
                  "TEMP_Z_INIT_FILE.", default="ptemp",do_not_log=just_read)
   call get_param(PF, mdl, "Z_INIT_FILE_SALT_VAR", salin_var, &
-                 "The name of the salinity variable in \n"//&
+                 "The name of the salinity variable in "//&
                  "SALT_Z_INIT_FILE.", default="salt",do_not_log=just_read)
   call get_param(PF, mdl, "Z_INIT_HOMOGENIZE", homogenize, &
-                 "If True, then horizontally homogenize the interpolated \n"//&
+                 "If True, then horizontally homogenize the interpolated "//&
                  "initial conditions.", default=.false., do_not_log=just_read)
   call get_param(PF, mdl, "Z_INIT_ALE_REMAPPING", useALEremapping, &
-                 "If True, then remap straight to model coordinate from file.",&
+                 "If True, then remap straight to model coordinate from file.", &
                  default=.false., do_not_log=just_read)
   call get_param(PF, mdl, "Z_INIT_REMAPPING_SCHEME", remappingScheme, &
-                 "The remapping scheme to use if using Z_INIT_ALE_REMAPPING\n"//&
+                 "The remapping scheme to use if using Z_INIT_ALE_REMAPPING "//&
                  "is True.", default="PPM_IH4", do_not_log=just_read)
   call get_param(PF, mdl, "Z_INIT_REMAP_GENERAL", remap_general, &
-                 "If false, only initializes to z* coordinates.\n"//&
+                 "If false, only initializes to z* coordinates. "//&
                  "If true, allows initialization directly to general coordinates.",&
                  default=.false., do_not_log=just_read)
   call get_param(PF, mdl, "Z_INIT_REMAP_FULL_COLUMN", remap_full_column, &
-                 "If false, only reconstructs profiles for valid data points.\n"//&
-                 "If true, inserts vanished layers below the valid data.",&
+                 "If false, only reconstructs profiles for valid data points. "//&
+                 "If true, inserts vanished layers below the valid data.", &
                  default=remap_general, do_not_log=just_read)
   call get_param(PF, mdl, "Z_INIT_REMAP_OLD_ALG", remap_old_alg, &
-                 "If false, uses the preferred remapping algorithm for initialization.\n"//&
-                 "If true, use an older, less robust algorithm for remapping.",&
+                 "If false, uses the preferred remapping algorithm for initialization. "//&
+                 "If true, use an older, less robust algorithm for remapping.", &
                  default=.true., do_not_log=just_read)
   call get_param(PF, mdl, "ICE_SHELF", use_ice_shelf, default=.false.)
   if (use_ice_shelf) then
@@ -2077,14 +2076,14 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_param
   endif
   if (.not.useALEremapping) then
     call get_param(PF, mdl, "ADJUST_THICKNESS", correct_thickness, &
-                 "If true, all mass below the bottom removed if the \n"//&
-                 "topography is shallower than the thickness input file \n"//&
+                 "If true, all mass below the bottom removed if the "//&
+                 "topography is shallower than the thickness input file "//&
                  "would indicate.", default=.false., do_not_log=just_read)
 
     call get_param(PF, mdl, "FIT_TO_TARGET_DENSITY_IC", adjust_temperature, &
-                 "If true, all the interior layers are adjusted to \n"//&
-                 "their target densities using mostly temperature \n"//&
-                 "This approach can be problematic, particularly in the \n"//&
+                 "If true, all the interior layers are adjusted to "//&
+                 "their target densities using mostly temperature "//&
+                 "This approach can be problematic, particularly in the "//&
                  "high latitudes.", default=.true., do_not_log=just_read)
   endif
   if (just_read) then

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -103,14 +103,14 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
 
   call get_param(PF, mdl, "Z_INIT_HOMOGENIZE", homog, &
-                 "If True, then horizontally homogenize the interpolated \n"//&
+                 "If True, then horizontally homogenize the interpolated "//&
                  "initial conditions.", default=.false.)
   call get_param(PF, mdl, "Z_INIT_ALE_REMAPPING", useALE, &
                  "If True, then remap straight to model coordinate from file.",&
                  default=.true.)
   call get_param(PF, mdl, "Z_INIT_REMAPPING_SCHEME", remapScheme, &
-                 "The remapping scheme to use if using Z_INIT_ALE_REMAPPING\n"//&
-                 "is True.", default="PLM")
+                 "The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.", &
+                 default="PLM")
 
   ! These are model grid properties, but being applied to the data grid for now.
   ! need to revisit this (mjh)

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -150,7 +150,7 @@ subroutine init_oda(Time, G, GV, CS)
   call unit_scaling_init(PF, CS%US)
 
   call get_param(PF, "MOM", "ASSIM_METHOD", assim_method,  &
-       "String which determines the data assimilation method" // &
+       "String which determines the data assimilation method "//&
        "Valid methods are: \'EAKF\',\'OI\', and \'NO_ASSIM\'", default='NO_ASSIM')
   call get_param(PF, "MOM", "ASSIM_FREQUENCY", CS%assim_frequency,  &
        "data assimilation frequency in hours")
@@ -163,14 +163,14 @@ subroutine init_oda(Time, G, GV, CS)
        "If true, the domain is meridionally reentrant.", &
        default=.false.)
   call get_param(PF,"MOM", "TRIPOLAR_N", CS%tripolar_N, &
-       "Use tripolar connectivity at the northern edge of the \n"//&
+       "Use tripolar connectivity at the northern edge of the "//&
        "domain.  With TRIPOLAR_N, NIGLOBAL must be even.", &
        default=.false.)
   call get_param(PF,"MOM", "NIGLOBAL", CS%ni, &
-       "The total number of thickness grid points in the \n"//&
+       "The total number of thickness grid points in the "//&
        "x-direction in the physical domain.")
   call get_param(PF,"MOM", "NJGLOBAL", CS%nj, &
-       "The total number of thickness grid points in the \n"//&
+       "The total number of thickness grid points in the "//&
        "y-direction in the physical domain.")
   call get_param(PF, 'MOM', "INPUTDIR", inputdir)
   inputdir = slasher(inputdir)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -874,7 +874,7 @@ logical function MEKE_init(Time, G, param_file, diag, CS, MEKE, restart_CS)
   ! Determine whether this module will be used
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "USE_MEKE", MEKE_init, &
-                 "If true, turns on the MEKE scheme which calculates\n"// &
+                 "If true, turns on the MEKE scheme which calculates "// &
                  "a sub-grid mesoscale eddy kinetic energy budget.", &
                  default=.false.)
   if (.not. MEKE_init) return
@@ -898,56 +898,56 @@ logical function MEKE_init(Time, G, param_file, diag, CS, MEKE, restart_CS)
                  "The local depth-independent MEKE dissipation rate.", &
                  units="s-1", default=0.0)
   call get_param(param_file, mdl, "MEKE_CD_SCALE", CS%MEKE_Cd_scale, &
-                 "The ratio of the bottom eddy velocity to the column mean\n"//&
-                 "eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1\n"//&
+                 "The ratio of the bottom eddy velocity to the column mean "//&
+                 "eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1 "//&
                  "to account for the surface intensification of MEKE.", &
                  units="nondim", default=0.)
   call get_param(param_file, mdl, "MEKE_CB", CS%MEKE_Cb, &
-                 "A coefficient in the expression for the ratio of bottom projected\n"//&
+                 "A coefficient in the expression for the ratio of bottom projected "//&
                  "eddy energy and mean column energy (see Jansen et al. 2015).",&
                  units="nondim", default=25.)
   call get_param(param_file, mdl, "MEKE_MIN_GAMMA2", CS%MEKE_min_gamma, &
                  "The minimum allowed value of gamma_b^2.",&
                  units="nondim", default=0.0001)
   call get_param(param_file, mdl, "MEKE_CT", CS%MEKE_Ct, &
-                 "A coefficient in the expression for the ratio of barotropic\n"//&
+                 "A coefficient in the expression for the ratio of barotropic "//&
                  "eddy energy and mean column energy (see Jansen et al. 2015).",&
                  units="nondim", default=50.)
   call get_param(param_file, mdl, "MEKE_GMCOEFF", CS%MEKE_GMcoeff, &
-                 "The efficiency of the conversion of potential energy \n"//&
-                 "into MEKE by the thickness mixing parameterization. \n"//&
-                 "If MEKE_GMCOEFF is negative, this conversion is not \n"//&
+                 "The efficiency of the conversion of potential energy "//&
+                 "into MEKE by the thickness mixing parameterization. "//&
+                 "If MEKE_GMCOEFF is negative, this conversion is not "//&
                  "used or calculated.", units="nondim", default=-1.0)
   call get_param(param_file, mdl, "MEKE_FRCOEFF", CS%MEKE_FrCoeff, &
-                 "The efficiency of the conversion of mean energy into \n"//&
-                 "MEKE.  If MEKE_FRCOEFF is negative, this conversion \n"//&
+                 "The efficiency of the conversion of mean energy into "//&
+                 "MEKE.  If MEKE_FRCOEFF is negative, this conversion "//&
                  "is not used or calculated.", units="nondim", default=-1.0)
   call get_param(param_file, mdl, "MEKE_BGSRC", CS%MEKE_BGsrc, &
                  "A background energy source for MEKE.", units="W kg-1", &
                  default=0.0)
   call get_param(param_file, mdl, "MEKE_KH", CS%MEKE_Kh, &
-                 "A background lateral diffusivity of MEKE.\n"//&
+                 "A background lateral diffusivity of MEKE. "//&
                  "Use a negative value to not apply lateral diffusion to MEKE.", &
                  units="m2 s-1", default=-1.0)
   call get_param(param_file, mdl, "MEKE_K4", CS%MEKE_K4, &
-                 "A lateral bi-harmonic diffusivity of MEKE.\n"//&
+                 "A lateral bi-harmonic diffusivity of MEKE. "//&
                  "Use a negative value to not apply bi-harmonic diffusion to MEKE.", &
                  units="m4 s-1", default=-1.0)
   call get_param(param_file, mdl, "MEKE_DTSCALE", CS%MEKE_dtScale, &
                  "A scaling factor to accelerate the time evolution of MEKE.", &
                  units="nondim", default=1.0)
   call get_param(param_file, mdl, "MEKE_KHCOEFF", CS%MEKE_KhCoeff, &
-                 "A scaling factor in the expression for eddy diffusivity\n"//&
-                 "which is otherwise proportional to the MEKE velocity-\n"//&
-                 "scale times an eddy mixing-length. This factor\n"//&
-                 "must be >0 for MEKE to contribute to the thickness/\n"//&
+                 "A scaling factor in the expression for eddy diffusivity "//&
+                 "which is otherwise proportional to the MEKE velocity- "//&
+                 "scale times an eddy mixing-length. This factor "//&
+                 "must be >0 for MEKE to contribute to the thickness/ "//&
                  "and tracer diffusivity in the rest of the model.", &
                  units="nondim", default=1.0)
   call get_param(param_file, mdl, "MEKE_USCALE", CS%MEKE_Uscale, &
-                 "The background velocity that is combined with MEKE to \n"//&
+                 "The background velocity that is combined with MEKE to "//&
                  "calculate the bottom drag.", units="m s-1", default=0.0)
   call get_param(param_file, mdl, "MEKE_VISC_DRAG", CS%visc_drag, &
-                 "If true, use the vertvisc_type to calculate the bottom \n"//&
+                 "If true, use the vertvisc_type to calculate the bottom "//&
                  "drag acting on MEKE.", default=.true.)
   call get_param(param_file, mdl, "MEKE_KHTH_FAC", MEKE%KhTh_fac, &
                  "A factor that maps MEKE%Kh to KhTh.", units="nondim", &
@@ -959,71 +959,71 @@ logical function MEKE_init(Time, G, param_file, diag, CS, MEKE, restart_CS)
                  "A factor that maps MEKE%Kh to Kh for MEKE itself.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_OLD_LSCALE", CS%use_old_lscale, &
-                 "If true, use the old formula for length scale which is\n"//&
+                 "If true, use the old formula for length scale which is "//&
                  "a function of grid spacing and deformation radius.",  &
                  default=.false.)
   call get_param(param_file, mdl, "MEKE_MIN_LSCALE", CS%use_min_lscale, &
-                 "If true, use a strict minimum of provided length scales\n"//&
+                 "If true, use a strict minimum of provided length scales "//&
                  "rather than harmonic mean.",  &
                  default=.false.)
   call get_param(param_file, mdl, "MEKE_RD_MAX_SCALE", CS%Rd_as_max_scale, &
-                 "If true, the length scale used by MEKE is the minimum of\n"//&
-                 "the deformation radius or grid-spacing. Only used if\n"//&
+                 "If true, the length scale used by MEKE is the minimum of "//&
+                 "the deformation radius or grid-spacing. Only used if "//&
                  "MEKE_OLD_LSCALE=True", units="nondim", default=.false.)
   call get_param(param_file, mdl, "MEKE_VISCOSITY_COEFF", CS%viscosity_coeff, &
-                 "If non-zero, is the scaling coefficient in the expression for\n"//&
-                 "viscosity used to parameterize lateral momentum mixing by\n"//&
-                 "unresolved eddies represented by MEKE. Can be negative to\n"//&
+                 "If non-zero, is the scaling coefficient in the expression for "//&
+                 "viscosity used to parameterize lateral momentum mixing by "//&
+                 "unresolved eddies represented by MEKE. Can be negative to "//&
                  "represent backscatter from the unresolved eddies.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_FIXED_MIXING_LENGTH", CS%Lfixed, &
-                 "If positive, is a fixed length contribution to the expression\n"//&
+                 "If positive, is a fixed length contribution to the expression "//&
                  "for mixing length used in MEKE-derived diffusivity.", &
                  units="m", default=0.0)
   call get_param(param_file, mdl, "MEKE_ALPHA_DEFORM", CS%aDeform, &
-                 "If positive, is a coefficient weighting the deformation scale\n"//&
+                 "If positive, is a coefficient weighting the deformation scale "//&
                  "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_ALPHA_RHINES", CS%aRhines, &
-                 "If positive, is a coefficient weighting the Rhines scale\n"//&
+                 "If positive, is a coefficient weighting the Rhines scale "//&
                  "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.05)
   call get_param(param_file, mdl, "MEKE_ALPHA_EADY", CS%aEady, &
-                 "If positive, is a coefficient weighting the Eady length scale\n"//&
+                 "If positive, is a coefficient weighting the Eady length scale "//&
                  "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.05)
   call get_param(param_file, mdl, "MEKE_ALPHA_FRICT", CS%aFrict, &
-                 "If positive, is a coefficient weighting the frictional arrest scale\n"//&
+                 "If positive, is a coefficient weighting the frictional arrest scale "//&
                  "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_ALPHA_GRID", CS%aGrid, &
-                 "If positive, is a coefficient weighting the grid-spacing as a scale\n"//&
+                 "If positive, is a coefficient weighting the grid-spacing as a scale "//&
                  "in the expression for mixing length used in MEKE-derived diffusivity.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_COLD_START", coldStart, &
-                 "If true, initialize EKE to zero. Otherwise a local equilibrium solution\n"//&
+                 "If true, initialize EKE to zero. Otherwise a local equilibrium solution "//&
                  "is used as an initial condition for EKE.", default=.false.)
   call get_param(param_file, mdl, "MEKE_BACKSCAT_RO_C", MEKE%backscatter_Ro_c, &
-                 "The coefficient in the Rossby number function for scaling the biharmonic\n"//&
+                 "The coefficient in the Rossby number function for scaling the biharmonic "//&
                  "frictional energy source. Setting to non-zero enables the Rossby number function.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_BACKSCAT_RO_POW", MEKE%backscatter_Ro_pow, &
-                 "The power in the Rossby number function for scaling the biharmonic\n"//&
+                 "The power in the Rossby number function for scaling the biharmonic "//&
                  "frictional energy source.", units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_ADVECTION_FACTOR", CS%MEKE_advection_factor, &
-                 "A scale factor in front of advection of eddy energy. Zero turns advection off.\n"//&
-                 "Using unity would be normal but other values could accommodate a mismatch\n"//&
+                 "A scale factor in front of advection of eddy energy. Zero turns advection off. "//&
+                 "Using unity would be normal but other values could accommodate a mismatch "//&
                  "between the advecting barotropic flow and the vertical structure of MEKE.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_TOPOGRAPHIC_BETA", CS%MEKE_topographic_beta, &
-                 "A scale factor to determine how much topographic beta is weighed in\n" //&
-                 "computing beta in the expression of Rhines scale. Use 1 if full\n"//&
+                 "A scale factor to determine how much topographic beta is weighed in " //&
+                 "computing beta in the expression of Rhines scale. Use 1 if full "//&
                  "topographic beta effect is considered; use 0 if it's completely ignored.", &
                  units="nondim", default=0.0)
 
   ! Nonlocal module parameters
   call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
-                 "CDRAG is the drag coefficient relating the magnitude of \n"//&
+                 "CDRAG is the drag coefficient relating the magnitude of "//&
                  "the velocity field to the bottom stress.", units="nondim", &
                  default=0.003)
   call get_param(param_file, mdl, "LAPLACIAN", laplacian, default=.false., do_not_log=.true.)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1069,18 +1069,18 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
                  "The minimum value allowed for Laplacian horizontal viscosity, KH.", &
                  units = "m2 s-1",  default=0.0)
     call get_param(param_file, mdl, "KH_VEL_SCALE", Kh_vel_scale, &
-                 "The velocity scale which is multiplied by the grid \n"//&
-                 "spacing to calculate the Laplacian viscosity. \n"//&
-                 "The final viscosity is the largest of this scaled \n"//&
+                 "The velocity scale which is multiplied by the grid "//&
+                 "spacing to calculate the Laplacian viscosity. "//&
+                 "The final viscosity is the largest of this scaled "//&
                  "viscosity, the Smagorinsky and Leith viscosities, and KH.", &
                  units="m s-1", default=0.0)
     call get_param(param_file, mdl, "KH_SIN_LAT", Kh_sin_lat, &
-                 "The amplitude of a latitudinally-dependent background\n"//&
+                 "The amplitude of a latitudinally-dependent background "//&
                  "viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).", &
                  units = "m2 s-1",  default=0.0)
     if (Kh_sin_lat>0. .or. get_all) &
       call get_param(param_file, mdl, "KH_PWR_OF_SINE", Kh_pwr_of_sine, &
-                 "The power used to raise SIN(LAT) when using a latitudinally-\n"//&
+                 "The power used to raise SIN(LAT) when using a latitudinally "//&
                  "dependent background viscosity.", &
                  units = "nondim",  default=4.0)
 
@@ -1089,7 +1089,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
                  default=.false.)
     if (CS%Smagorinsky_Kh .or. get_all) &
       call get_param(param_file, mdl, "SMAG_LAP_CONST", Smag_Lap_const, &
-                 "The nondimensional Laplacian Smagorinsky constant, \n"//&
+                 "The nondimensional Laplacian Smagorinsky constant, "//&
                  "often 0.15.", units="nondim", default=0.0, &
                   fail_if_missing = CS%Smagorinsky_Kh)
 
@@ -1098,7 +1098,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
                  default=.false.)
 
     call get_param(param_file, mdl, "MODIFIED_LEITH", CS%Modified_Leith, &
-                 "If true, add a term to Leith viscosity which is \n"//&
+                 "If true, add a term to Leith viscosity which is "//&
                  "proportional to the gradient of divergence.", &
                  default=.false.)
     call get_param(param_file, mdl, "RES_SCALE_MEKE_VISC", CS%res_scale_MEKE, &
@@ -1107,19 +1107,19 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
 
     if (CS%Leith_Kh .or. get_all) &
       call get_param(param_file, mdl, "LEITH_LAP_CONST", Leith_Lap_const, &
-                 "The nondimensional Laplacian Leith constant, \n"//&
+                 "The nondimensional Laplacian Leith constant, "//&
                  "often ??", units="nondim", default=0.0, &
                   fail_if_missing = CS%Leith_Kh)
 
     call get_param(param_file, mdl, "BOUND_KH", CS%bound_Kh, &
-                 "If true, the Laplacian coefficient is locally limited \n"//&
+                 "If true, the Laplacian coefficient is locally limited "//&
                  "to be stable.", default=.true.)
     call get_param(param_file, mdl, "BETTER_BOUND_KH", CS%better_bound_Kh, &
-                 "If true, the Laplacian coefficient is locally limited \n"//&
+                 "If true, the Laplacian coefficient is locally limited "//&
                  "to be stable with a better bounding than just BOUND_KH.", &
                  default=CS%bound_Kh)
     call get_param(param_file, mdl, "ANISOTROPIC_VISCOSITY", CS%anisotropic, &
-                 "If true, allow anistropic viscosity in the Laplacian\n"//&
+                 "If true, allow anistropic viscosity in the Laplacian "//&
                  "horizontal viscosity.", default=.false.)
   endif
   if (CS%anisotropic .or. get_all) then
@@ -1135,19 +1135,19 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
     select case (aniso_mode)
       case (0)
         call get_param(param_file, mdl, "ANISO_GRID_DIR", aniso_grid_dir, &
-                 "The vector pointing in the direction of anistropy for\n"//&
-                 "horizont viscosity. n1,n2 are the i,j components relative\n"//&
+                 "The vector pointing in the direction of anistropy for "//&
+                 "horizont viscosity. n1,n2 are the i,j components relative "//&
                  "to the grid.", units = "nondim", fail_if_missing=.true.)
       case (1)
         call get_param(param_file, mdl, "ANISO_GRID_DIR", aniso_grid_dir, &
-                 "The vector pointing in the direction of anistropy for\n"//&
-                 "horizont viscosity. n1,n2 are the i,j components relative\n"//&
+                 "The vector pointing in the direction of anistropy for "//&
+                 "horizont viscosity. n1,n2 are the i,j components relative "//&
                  "to the spherical coordinates.", units = "nondim", fail_if_missing=.true.)
     end select
   endif
 
   call get_param(param_file, mdl, "BIHARMONIC", CS%biharmonic, &
-                 "If true, use a biharmonic horizontal viscosity. \n"//&
+                 "If true, use a biharmonic horizontal viscosity. "//&
                  "BIHARMONIC may be used with LAPLACIAN.", &
                  default=.true.)
   if (CS%biharmonic .or. get_all) then
@@ -1155,52 +1155,52 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
                  "The background biharmonic horizontal viscosity.", &
                  units = "m4 s-1", default=0.0)
     call get_param(param_file, mdl, "AH_VEL_SCALE", Ah_vel_scale, &
-                 "The velocity scale which is multiplied by the cube of \n"//&
-                 "the grid spacing to calculate the biharmonic viscosity. \n"//&
-                 "The final viscosity is the largest of this scaled \n"//&
+                 "The velocity scale which is multiplied by the cube of "//&
+                 "the grid spacing to calculate the biharmonic viscosity. "//&
+                 "The final viscosity is the largest of this scaled "//&
                  "viscosity, the Smagorinsky and Leith viscosities, and AH.", &
                  units="m s-1", default=0.0)
     call get_param(param_file, mdl, "AH_TIME_SCALE", Ah_time_scale, &
-                 "A time scale whose inverse is multiplied by the fourth \n"//&
-                 "power of the grid spacing to calculate biharmonic viscosity. \n"//&
-                 "The final viscosity is the largest of all viscosity  \n"//&
+                 "A time scale whose inverse is multiplied by the fourth "//&
+                 "power of the grid spacing to calculate biharmonic viscosity. "//&
+                 "The final viscosity is the largest of all viscosity "//&
                  "formulations in use. 0.0 means that it's not used.", &
                  units="s", default=0.0)
     call get_param(param_file, mdl, "SMAGORINSKY_AH", CS%Smagorinsky_Ah, &
-                 "If true, use a biharmonic Smagorinsky nonlinear eddy \n"//&
+                 "If true, use a biharmonic Smagorinsky nonlinear eddy "//&
                  "viscosity.", default=.false.)
     call get_param(param_file, mdl, "LEITH_AH", CS%Leith_Ah, &
-                 "If true, use a biharmonic Leith nonlinear eddy \n"//&
+                 "If true, use a biharmonic Leith nonlinear eddy "//&
                  "viscosity.", default=.false.)
 
     call get_param(param_file, mdl, "BOUND_AH", CS%bound_Ah, &
-                 "If true, the biharmonic coefficient is locally limited \n"//&
+                 "If true, the biharmonic coefficient is locally limited "//&
                  "to be stable.", default=.true.)
     call get_param(param_file, mdl, "BETTER_BOUND_AH", CS%better_bound_Ah, &
-                 "If true, the biharmonic coefficient is locally limited \n"//&
+                 "If true, the biharmonic coefficient is locally limited "//&
                  "to be stable with a better bounding than just BOUND_AH.", &
                  default=CS%bound_Ah)
 
     if (CS%Smagorinsky_Ah .or. get_all) then
       call get_param(param_file, mdl, "SMAG_BI_CONST",Smag_bi_const, &
-                 "The nondimensional biharmonic Smagorinsky constant, \n"//&
+                 "The nondimensional biharmonic Smagorinsky constant, "//&
                  "typically 0.015 - 0.06.", units="nondim", default=0.0, &
                  fail_if_missing = CS%Smagorinsky_Ah)
 
       call get_param(param_file, mdl, "BOUND_CORIOLIS", bound_Cor_def, default=.false.)
       call get_param(param_file, mdl, "BOUND_CORIOLIS_BIHARM", CS%bound_Coriolis, &
-                 "If true use a viscosity that increases with the square \n"//&
-                 "of the velocity shears, so that the resulting viscous \n"//&
-                 "drag is of comparable magnitude to the Coriolis terms \n"//&
-                 "when the velocity differences between adjacent grid \n"//&
-                 "points is 0.5*BOUND_CORIOLIS_VEL.  The default is the \n"//&
+                 "If true use a viscosity that increases with the square "//&
+                 "of the velocity shears, so that the resulting viscous "//&
+                 "drag is of comparable magnitude to the Coriolis terms "//&
+                 "when the velocity differences between adjacent grid "//&
+                 "points is 0.5*BOUND_CORIOLIS_VEL.  The default is the "//&
                  "value of BOUND_CORIOLIS (or false).", default=bound_Cor_def)
       if (CS%bound_Coriolis .or. get_all) then
         call get_param(param_file, mdl, "MAXVEL", maxvel, default=3.0e8)
         bound_Cor_vel = maxvel
         call get_param(param_file, mdl, "BOUND_CORIOLIS_VEL", bound_Cor_vel, &
-                 "The velocity scale at which BOUND_CORIOLIS_BIHARM causes \n"//&
-                 "the biharmonic drag to have comparable magnitude to the \n"//&
+                 "The velocity scale at which BOUND_CORIOLIS_BIHARM causes "//&
+                 "the biharmonic drag to have comparable magnitude to the "//&
                  "Coriolis acceleration.  The default is set by MAXVEL.", &
                  units="m s-1", default=maxvel)
       endif
@@ -1208,7 +1208,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
 
     if (CS%Leith_Ah .or. get_all) then
       call get_param(param_file, mdl, "LEITH_BI_CONST",Leith_bi_const, &
-                 "The nondimensional biharmonic Leith constant, \n"//&
+                 "The nondimensional biharmonic Leith constant, "//&
                  "typical values are thus far undetermined", units="nondim", default=0.0, &
                  fail_if_missing = CS%Leith_Ah)
     endif
@@ -1216,30 +1216,30 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
   endif
 
   call get_param(param_file, mdl, "USE_LAND_MASK_FOR_HVISC", CS%use_land_mask, &
-                 "If true, use Use the land mask for the computation of thicknesses \n"//&
-                 "at velocity locations. This eliminates the dependence on arbitrary \n"//&
-                 "values over land or outside of the domain. Default is False in order to \n"//&
-                 "maintain answers with legacy experiments but should be changed to True \n"//&
+                 "If true, use Use the land mask for the computation of thicknesses "//&
+                 "at velocity locations. This eliminates the dependence on arbitrary "//&
+                 "values over land or outside of the domain. Default is False in order to "//&
+                 "maintain answers with legacy experiments but should be changed to True "//&
                  "for new experiments.", default=.false.)
 
   if (CS%better_bound_Ah .or. CS%better_bound_Kh .or. get_all) &
     call get_param(param_file, mdl, "HORVISC_BOUND_COEF", CS%bound_coef, &
-                 "The nondimensional coefficient of the ratio of the \n"//&
-                 "viscosity bounds to the theoretical maximum for \n"//&
+                 "The nondimensional coefficient of the ratio of the "//&
+                 "viscosity bounds to the theoretical maximum for "//&
                  "stability without considering other terms.", units="nondim", &
                  default=0.8)
 
   call get_param(param_file, mdl, "NOSLIP", CS%no_slip, &
-                 "If true, no slip boundary conditions are used; otherwise \n"//&
-                 "free slip boundary conditions are assumed. The \n"//&
-                 "implementation of the free slip BCs on a C-grid is much \n"//&
-                 "cleaner than the no slip BCs. The use of free slip BCs \n"//&
-                 "is strongly encouraged, and no slip BCs are not used with \n"//&
+                 "If true, no slip boundary conditions are used; otherwise "//&
+                 "free slip boundary conditions are assumed. The "//&
+                 "implementation of the free slip BCs on a C-grid is much "//&
+                 "cleaner than the no slip BCs. The use of free slip BCs "//&
+                 "is strongly encouraged, and no slip BCs are not used with "//&
                  "the biharmonic viscosity.", default=.false.)
 
   call get_param(param_file, mdl, "USE_KH_BG_2D", CS%use_Kh_bg_2d, &
-                 "If true, read a file containing 2-d background harmonic \n"//&
-                 "viscosities. The final viscosity is the maximum of the other \n"//&
+                 "If true, read a file containing 2-d background harmonic "//&
+                 "viscosities. The final viscosity is the maximum of the other "//&
                  "terms and this background value.", default=.false.)
 
 

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -2191,13 +2191,13 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, mdl, "INTERNAL_TIDE_FREQS", num_freq, &
-                 "The number of distinct internal tide frequency bands \n"//&
+                 "The number of distinct internal tide frequency bands "//&
                  "that will be calculated.", default=1)
   call get_param(param_file, mdl, "INTERNAL_TIDE_MODES", num_mode, &
-                 "The number of distinct internal tide modes \n"//&
+                 "The number of distinct internal tide modes "//&
                  "that will be calculated.", default=1)
   call get_param(param_file, mdl, "INTERNAL_TIDE_ANGLES", num_angle, &
-                 "The number of angular resolution bands for the internal \n"//&
+                 "The number of angular resolution bands for the internal "//&
                  "tide calculations.", default=24)
 
   if (use_int_tides) then
@@ -2227,34 +2227,34 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   CS%diag => diag
 
   call get_param(param_file, mdl, "INTERNAL_TIDE_DECAY_RATE", CS%decay_rate, &
-                 "The rate at which internal tide energy is lost to the \n"//&
+                 "The rate at which internal tide energy is lost to the "//&
                  "interior ocean internal wave field.", units="s-1", default=0.0)
   call get_param(param_file, mdl, "INTERNAL_TIDE_VOLUME_BASED_CFL", CS%vol_CFL, &
-                 "If true, use the ratio of the open face lengths to the \n"//&
-                 "tracer cell areas when estimating CFL numbers in the \n"//&
+                 "If true, use the ratio of the open face lengths to the "//&
+                 "tracer cell areas when estimating CFL numbers in the "//&
                  "internal tide code.", default=.false.)
   call get_param(param_file, mdl, "INTERNAL_TIDE_CORNER_ADVECT", CS%corner_adv, &
-                 "If true, internal tide ray-tracing advection uses a \n"//&
-                 " corner-advection scheme rather than PPM.\n", default=.false.)
+                 "If true, internal tide ray-tracing advection uses a "//&
+                 "corner-advection scheme rather than PPM.", default=.false.)
   call get_param(param_file, mdl, "INTERNAL_TIDE_SIMPLE_2ND_PPM", CS%simple_2nd, &
-                 "If true, CONTINUITY_PPM uses a simple 2nd order \n"//&
-                 "(arithmetic mean) interpolation of the edge values. \n"//&
-                 "This may give better PV conservation properties. While \n"//&
-                 "it formally reduces the accuracy of the continuity \n"//&
-                 "solver itself in the strongly advective limit, it does \n"//&
-                 "not reduce the overall order of accuracy of the dynamic \n"//&
+                 "If true, CONTINUITY_PPM uses a simple 2nd order "//&
+                 "(arithmetic mean) interpolation of the edge values. "//&
+                 "This may give better PV conservation properties. While "//&
+                 "it formally reduces the accuracy of the continuity "//&
+                 "solver itself in the strongly advective limit, it does "//&
+                 "not reduce the overall order of accuracy of the dynamic "//&
                  "core.", default=.false.)
   call get_param(param_file, mdl, "INTERNAL_TIDE_UPWIND_1ST", CS%upwind_1st, &
-                 "If true, the internal tide ray-tracing advection uses \n"//&
-                 "1st-order upwind advection.  This scheme is highly \n"//&
-                 "continuity solver.  This scheme is highly \n"//&
+                 "If true, the internal tide ray-tracing advection uses "//&
+                 "1st-order upwind advection.  This scheme is highly "//&
+                 "continuity solver.  This scheme is highly "//&
                  "diffusive but may be useful for debugging.", default=.false.)
   call get_param(param_file, mdl, "INTERNAL_TIDE_BACKGROUND_DRAG", &
-                 CS%apply_background_drag, "If true, the internal tide \n"//&
+                 CS%apply_background_drag, "If true, the internal tide "//&
                  "ray-tracing advection uses a background drag term as a sink.",&
                  default=.false.)
   call get_param(param_file, mdl, "INTERNAL_TIDE_QUAD_DRAG", CS%apply_bottom_drag, &
-                 "If true, the internal tide ray-tracing advection uses \n"//&
+                 "If true, the internal tide ray-tracing advection uses "//&
                  "a quadratic bottom drag term as a sink.", default=.false.)
   call get_param(param_file, mdl, "INTERNAL_TIDE_WAVE_DRAG", CS%apply_wave_drag, &
                  "If true, apply scattering due to small-scale roughness as a sink.", &
@@ -2263,22 +2263,22 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                  "If true, apply wave breaking as a sink.", &
                  default=.false.)
   call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
-                 "CDRAG is the drag coefficient relating the magnitude of \n"//&
+                 "CDRAG is the drag coefficient relating the magnitude of "//&
                  "the velocity field to the bottom stress.", units="nondim", &
                  default=0.003)
   call get_param(param_file, mdl, "INTERNAL_TIDE_ENERGIZED_ANGLE", CS%energized_angle, &
-                 "If positive, only one angular band of the internal tides \n"//&
+                 "If positive, only one angular band of the internal tides "//&
                  "gets all of the energy.  (This is for debugging.)", default=-1)
   call get_param(param_file, mdl, "USE_PPM_ANGULAR", CS%use_PPMang, &
-                 "If true, use PPM for advection of energy in angular  \n"//&
-                 "space.", default=.false.)
+                 "If true, use PPM for advection of energy in angular space.", &
+                 default=.false.)
   call get_param(param_file, mdl, "GAMMA_ITIDES", CS%q_itides, &
-                 "The fraction of the internal tidal energy that is \n"//&
-                 "dissipated locally with INT_TIDE_DISSIPATION.  \n"//&
+                 "The fraction of the internal tidal energy that is "//&
+                 "dissipated locally with INT_TIDE_DISSIPATION. "//&
                  "THIS NAME COULD BE BETTER.", &
                  units="nondim", default=0.3333)
   call get_param(param_file, mdl, "KAPPA_ITIDES", kappa_itides, &
-               "A topographic wavenumber used with INT_TIDE_DISSIPATION. \n"//&
+               "A topographic wavenumber used with INT_TIDE_DISSIPATION. "//&
                "The default is 2pi/10 km, as in St.Laurent et al. 2002.", &
                units="m-1", default=8.e-4*atan(1.0))
   call get_param(param_file, mdl, "KAPPA_H2_FACTOR", kappa_h2_factor, &
@@ -2304,7 +2304,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
 
   ! Compute the fixed part of the bottom drag loss from baroclinic modes
   call get_param(param_file, mdl, "H2_FILE", h2_file, &
-          "The path to the file containing the sub-grid-scale \n"//&
+          "The path to the file containing the sub-grid-scale "//&
           "topographic roughness amplitude with INT_TIDE_DISSIPATION.", &
           fail_if_missing=.true.)
   filename = trim(CS%inputdir) // trim(h2_file)
@@ -2323,7 +2323,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
 
   ! Read in prescribed coast/ridge/shelf angles from file
   call get_param(param_file, mdl, "REFL_ANGLE_FILE", refl_angle_file, &
-               "The path to the file containing the local angle of \n"//&
+               "The path to the file containing the local angle of "//&
                "the coastline/ridge/shelf with respect to the equator.", &
                fail_if_missing=.false.)
   filename = trim(CS%inputdir) // trim(refl_angle_file)
@@ -2437,7 +2437,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                  Time, 'Interior and bottom drag internal tide decay timescale', 's-1')
   !Register 2-D energy input into internal tides
   CS%id_TKE_itidal_input = register_diag_field('ocean_model', 'TKE_itidal_input', diag%axesT1, &
-                 Time, 'Conversion from barotropic to baroclinic tide, \n'//&
+                 Time, 'Conversion from barotropic to baroclinic tide, '//&
                  'a fraction of which goes into rays', 'W m-2')
   ! Register 2-D energy losses (summed over angles, freq, modes)
   CS%id_tot_leak_loss = register_diag_field('ocean_model', 'ITide_tot_leak_loss', diag%axesT1, &

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -752,42 +752,42 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "USE_VARIABLE_MIXING", CS%use_variable_mixing,&
-                 "If true, the variable mixing code will be called.  This \n"//&
-                 "allows diagnostics to be created even if the scheme is \n"//&
-                 "not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0, \n"//&
-                 "this is set to true regardless of what is in the \n"//&
+                 "If true, the variable mixing code will be called.  This "//&
+                 "allows diagnostics to be created even if the scheme is "//&
+                 "not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0, "//&
+                 "this is set to true regardless of what is in the "//&
                  "parameter file.", default=.false.)
   call get_param(param_file, mdl, "RESOLN_SCALED_KH", CS%Resoln_scaled_Kh, &
-                 "If true, the Laplacian lateral viscosity is scaled away \n"//&
-                 "when the first baroclinic deformation radius is well \n"//&
+                 "If true, the Laplacian lateral viscosity is scaled away "//&
+                 "when the first baroclinic deformation radius is well "//&
                  "resolved.", default=.false.)
   call get_param(param_file, mdl, "RESOLN_SCALED_KHTH", CS%Resoln_scaled_KhTh, &
-                 "If true, the interface depth diffusivity is scaled away \n"//&
-                 "when the first baroclinic deformation radius is well \n"//&
+                 "If true, the interface depth diffusivity is scaled away "//&
+                 "when the first baroclinic deformation radius is well "//&
                  "resolved.", default=.false.)
   call get_param(param_file, mdl, "RESOLN_SCALED_KHTR", CS%Resoln_scaled_KhTr, &
-                 "If true, the epipycnal tracer diffusivity is scaled \n"//&
-                 "away when the first baroclinic deformation radius is \n"//&
+                 "If true, the epipycnal tracer diffusivity is scaled "//&
+                 "away when the first baroclinic deformation radius is "//&
                  "well resolved.", default=.false.)
   call get_param(param_file, mdl, "RESOLN_USE_EBT", CS%Resoln_use_ebt, &
-                 "If true, uses the equivalent barotropic wave speed instead\n"//&
+                 "If true, uses the equivalent barotropic wave speed instead "//&
                  "of first baroclinic wave for calculating the resolution fn.",&
                  default=.false.)
   call get_param(param_file, mdl, "KHTH_USE_EBT_STRUCT", CS%khth_use_ebt_struct, &
-                 "If true, uses the equivalent barotropic structure\n"//&
+                 "If true, uses the equivalent barotropic structure "//&
                  "as the vertical structure of thickness diffusivity.",&
                  default=.false.)
   call get_param(param_file, mdl, "KHTH_SLOPE_CFF", KhTh_Slope_Cff, &
-                 "The nondimensional coefficient in the Visbeck formula \n"//&
+                 "The nondimensional coefficient in the Visbeck formula "//&
                  "for the interface depth diffusivity", units="nondim", &
                  default=0.0)
   call get_param(param_file, mdl, "KHTR_SLOPE_CFF", KhTr_Slope_Cff, &
-                 "The nondimensional coefficient in the Visbeck formula \n"//&
+                 "The nondimensional coefficient in the Visbeck formula "//&
                  "for the epipycnal tracer diffusivity", units="nondim", &
                  default=0.0)
   call get_param(param_file, mdl, "USE_STORED_SLOPES", CS%use_stored_slopes,&
-                 "If true, the isopycnal slopes are calculated once and\n"//&
-                 "stored for re-use. This uses more memory but avoids calling\n"//&
+                 "If true, the isopycnal slopes are calculated once and "//&
+                 "stored for re-use. This uses more memory but avoids calling "//&
                  "the equation of state more times than should be necessary.", &
                  default=.false.)
   call get_param(param_file, mdl, "KHTH_USE_FGNV_STREAMFUNCTION", use_FGNV_streamfn, &
@@ -809,7 +809,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   if (CS%Resoln_use_ebt .or. CS%khth_use_ebt_struct) then
     in_use = .true.
     call get_param(param_file, mdl, "RESOLN_N2_FILTER_DEPTH", N2_filter_depth, &
-                 "The depth below which N2 is monotonized to avoid stratification\n"//&
+                 "The depth below which N2 is monotonized to avoid stratification "//&
                  "artifacts from altering the equivalent barotropic mode structure.",&
                  units='m', default=2000.)
     allocate(CS%ebt_struct(isd:ied,jsd:jed,G%ke)) ; CS%ebt_struct(:,:,:) = 0.0
@@ -818,8 +818,8 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   if (KhTr_Slope_Cff>0. .or. KhTh_Slope_Cff>0.) then
     CS%calculate_Eady_growth_rate = .true.
     call get_param(param_file, mdl, "VISBECK_MAX_SLOPE", CS%Visbeck_S_max, &
-          "If non-zero, is an upper bound on slopes used in the\n"//       &
-          "Visbeck formula for diffusivity. This does not affect the\n"//  &
+          "If non-zero, is an upper bound on slopes used in the "//&
+          "Visbeck formula for diffusivity. This does not affect the "//&
           "isopycnal slope calculation used within thickness diffusion.",  &
           units="nondim", default=0.0)
   endif
@@ -829,7 +829,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     allocate(CS%slope_x(IsdB:IedB,jsd:jed,G%ke+1)) ; CS%slope_x(:,:,:) = 0.0
     allocate(CS%slope_y(isd:ied,JsdB:JedB,G%ke+1)) ; CS%slope_y(:,:,:) = 0.0
     call get_param(param_file, mdl, "KD_SMOOTH", CS%kappa_smooth, &
-                 "A diapycnal diffusivity that is used to interpolate \n"//&
+                 "A diapycnal diffusivity that is used to interpolate "//&
                  "more sensible values of T & S into thin layers.", &
                  default=1.0e-6, scale=US%m_to_Z**2) !### Add units argument.
   endif
@@ -843,7 +843,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     CS%id_SN_v = register_diag_field('ocean_model', 'SN_v', diag%axesCv1, Time, &
        'Inverse eddy time-scale, S*N, at v-points', 's-1')
     call get_param(param_file, mdl, "VARMIX_KTOP", CS%VarMix_Ktop, &
-                 "The layer number at which to start vertical integration \n"//&
+                 "The layer number at which to start vertical integration "//&
                  "of S*N for purposes of finding the Eady growth rate.", &
                  units="nondim", default=2)
   endif
@@ -902,39 +902,39 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
        'Resolution function for scaling diffusivities', 'nondim')
 
     call get_param(param_file, mdl, "KH_RES_SCALE_COEF", CS%Res_coef_khth, &
-                 "A coefficient that determines how KhTh is scaled away if \n"//&
-                 "RESOLN_SCALED_... is true, as \n"//&
+                 "A coefficient that determines how KhTh is scaled away if "//&
+                 "RESOLN_SCALED_... is true, as "//&
                  "F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).", &
                  units="nondim", default=1.0)
     call get_param(param_file, mdl, "KH_RES_FN_POWER", CS%Res_fn_power_khth, &
-                 "The power of dx/Ld in the Kh resolution function.  Any \n"//&
-                 "positive integer may be used, although even integers \n"//&
-                 "are more efficient to calculate.  Setting this greater \n"//&
+                 "The power of dx/Ld in the Kh resolution function.  Any "//&
+                 "positive integer may be used, although even integers "//&
+                 "are more efficient to calculate.  Setting this greater "//&
                  "than 100 results in a step-function being used.", &
                  units="nondim", default=2)
     call get_param(param_file, mdl, "VISC_RES_SCALE_COEF", CS%Res_coef_visc, &
-                 "A coefficient that determines how Kh is scaled away if \n"//&
-                 "RESOLN_SCALED_... is true, as \n"//&
-                 "F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).\n"//&
+                 "A coefficient that determines how Kh is scaled away if "//&
+                 "RESOLN_SCALED_... is true, as "//&
+                 "F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). "//&
                  "This function affects lateral viscosity, Kh, and not KhTh.", &
                  units="nondim", default=CS%Res_coef_khth)
     call get_param(param_file, mdl, "VISC_RES_FN_POWER", CS%Res_fn_power_visc, &
-                 "The power of dx/Ld in the Kh resolution function.  Any \n"//&
-                 "positive integer may be used, although even integers \n"//&
-                 "are more efficient to calculate.  Setting this greater \n"//&
-                 "than 100 results in a step-function being used.\n"//&
+                 "The power of dx/Ld in the Kh resolution function.  Any "//&
+                 "positive integer may be used, although even integers "//&
+                 "are more efficient to calculate.  Setting this greater "//&
+                 "than 100 results in a step-function being used. "//&
                  "This function affects lateral viscosity, Kh, and not KhTh.", &
                  units="nondim", default=CS%Res_fn_power_khth)
     call get_param(param_file, mdl, "INTERPOLATE_RES_FN", CS%interpolate_Res_fn, &
-                 "If true, interpolate the resolution function to the \n"//&
-                 "velocity points from the thickness points; otherwise \n"//&
-                 "interpolate the wave speed and calculate the resolution \n"//&
+                 "If true, interpolate the resolution function to the "//&
+                 "velocity points from the thickness points; otherwise "//&
+                 "interpolate the wave speed and calculate the resolution "//&
                  "function independently at each point.", default=.true.)
     call get_param(param_file, mdl, "USE_VISBECK_SLOPE_BUG", CS%use_Visbeck_slope_bug, &
-                 "If true, then retain a legacy bug in the calculation of weights \n"//&
-                 "applied to isoneutral slopes. There was an erroneous k-indexing \n"//&
-                 "for layer thicknesses. In addition, masking at coastlines was not \n"//&
-                 "used which introduced potential restart issues.  This flag will be \n"//&
+                 "If true, then retain a legacy bug in the calculation of weights "//&
+                 "applied to isoneutral slopes. There was an erroneous k-indexing "//&
+                 "for layer thicknesses. In addition, masking at coastlines was not "//&
+                 "used which introduced potential restart issues.  This flag will be "//&
                  "deprecated in a future release.", default=.false.)
     if (CS%interpolate_Res_fn) then
       if (CS%Res_coef_visc /= CS%Res_coef_khth) call MOM_error(FATAL, &
@@ -946,11 +946,11 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     endif
     !### Change the default of GILL_EQUATORIAL_LD to True.
     call get_param(param_file, mdl, "GILL_EQUATORIAL_LD", Gill_equatorial_Ld, &
-                 "If true, uses Gill's definition of the baroclinic\n"//&
-                 "equatorial deformation radius, otherwise, if false, use\n"//&
-                 "Pedlosky's definition. These definitions differ by a factor \n"//&
-                 "of 2 in front of the beta term in the denominator. Gill's \n"//&
-                 "is the more appropriate definition.\n", default=.false.)
+                 "If true, uses Gill's definition of the baroclinic "//&
+                 "equatorial deformation radius, otherwise, if false, use "//&
+                 "Pedlosky's definition. These definitions differ by a factor "//&
+                 "of 2 in front of the beta term in the denominator. Gill's "//&
+                 "is the more appropriate definition.", default=.false.)
     if (Gill_equatorial_Ld) then
       oneOrTwo = 2.0
     else

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -797,9 +797,9 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "MIXEDLAYER_RESTRAT", mixedlayer_restrat_init, &
-             "If true, a density-gradient dependent re-stratifying \n"//&
-             "flow is imposed in the mixed layer. Can be used in ALE mode\n"//&
-             "without restriction but in layer mode can only be used if\n"//&
+             "If true, a density-gradient dependent re-stratifying "//&
+             "flow is imposed in the mixed layer. Can be used in ALE mode "//&
+             "without restriction but in layer mode can only be used if "//&
              "BULKMIXEDLAYER is true.", default=.false.)
   if (.not. mixedlayer_restrat_init) return
 
@@ -817,53 +817,53 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "FOX_KEMPER_ML_RESTRAT_COEF", CS%ml_restrat_coef, &
-             "A nondimensional coefficient that is proportional to \n"//&
-             "the ratio of the deformation radius to the dominant \n"//&
-             "lengthscale of the submesoscale mixed layer \n"//&
-             "instabilities, times the minimum of the ratio of the \n"//&
-             "mesoscale eddy kinetic energy to the large-scale \n"//&
-             "geostrophic kinetic energy or 1 plus the square of the \n"//&
-             "grid spacing over the deformation radius, as detailed \n"//&
+             "A nondimensional coefficient that is proportional to "//&
+             "the ratio of the deformation radius to the dominant "//&
+             "lengthscale of the submesoscale mixed layer "//&
+             "instabilities, times the minimum of the ratio of the "//&
+             "mesoscale eddy kinetic energy to the large-scale "//&
+             "geostrophic kinetic energy or 1 plus the square of the "//&
+             "grid spacing over the deformation radius, as detailed "//&
              "by Fox-Kemper et al. (2010)", units="nondim", default=0.0)
   ! We use GV%nkml to distinguish between the old and new implementation of MLE.
   ! The old implementation only works for the layer model with nkml>0.
   if (GV%nkml==0) then
     call get_param(param_file, mdl, "FOX_KEMPER_ML_RESTRAT_COEF2", CS%ml_restrat_coef2, &
-             "As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application\n"//&
+             "As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application "//&
              "of the MLE restratification parameterization.", units="nondim", default=0.0)
     call get_param(param_file, mdl, "MLE_FRONT_LENGTH", CS%front_length, &
-             "If non-zero, is the frontal-length scale used to calculate the\n"//&
-             "upscaling of buoyancy gradients that is otherwise represented\n"//&
-             "by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is\n"//&
+             "If non-zero, is the frontal-length scale used to calculate the "//&
+             "upscaling of buoyancy gradients that is otherwise represented "//&
+             "by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is "//&
              "non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.",&
              units="m", default=0.0)
     call get_param(param_file, mdl, "MLE_USE_PBL_MLD", CS%MLE_use_PBL_MLD, &
-             "If true, the MLE parameterization will use the mixed-layer\n"//&
-             "depth provided by the active PBL parameterization. If false,\n"//&
-             "MLE will estimate a MLD based on a density difference with the\n"//&
+             "If true, the MLE parameterization will use the mixed-layer "//&
+             "depth provided by the active PBL parameterization. If false, "//&
+             "MLE will estimate a MLD based on a density difference with the "//&
              "surface using the parameter MLE_DENSITY_DIFF.", default=.false.)
     call get_param(param_file, mdl, "MLE_MLD_DECAY_TIME", CS%MLE_MLD_decay_time, &
-             "The time-scale for a running-mean filter applied to the mixed-layer\n"//&
-             "depth used in the MLE restratification parameterization. When\n"//&
-             "the MLD deepens below the current running-mean the running-mean\n"//&
+             "The time-scale for a running-mean filter applied to the mixed-layer "//&
+             "depth used in the MLE restratification parameterization. When "//&
+             "the MLD deepens below the current running-mean the running-mean "//&
              "is instantaneously set to the current MLD.", units="s", default=0.)
     call get_param(param_file, mdl, "MLE_MLD_DECAY_TIME2", CS%MLE_MLD_decay_time2, &
-             "The time-scale for a running-mean filter applied to the filtered\n"//&
-             "mixed-layer depth used in a second MLE restratification parameterization.\n"//&
-             "When the MLD deepens below the current running-mean the running-mean\n"//&
+             "The time-scale for a running-mean filter applied to the filtered "//&
+             "mixed-layer depth used in a second MLE restratification parameterization. "//&
+             "When the MLD deepens below the current running-mean the running-mean "//&
              "is instantaneously set to the current MLD.", units="s", default=0.)
     if (.not. CS%MLE_use_PBL_MLD) then
       call get_param(param_file, mdl, "MLE_DENSITY_DIFF", CS%MLE_density_diff, &
-             "Density difference used to detect the mixed-layer\n"//&
-             "depth used for the mixed-layer eddy parameterization\n"//&
+             "Density difference used to detect the mixed-layer "//&
+             "depth used for the mixed-layer eddy parameterization "//&
              "by Fox-Kemper et al. (2010)", units="kg/m3", default=0.03)
     endif
     call get_param(param_file, mdl, "MLE_TAIL_DH", CS%MLE_tail_dh, &
-             "Fraction by which to extend the mixed-layer restratification\n"//&
-             "depth used for a smoother stream function at the base of\n"//&
+             "Fraction by which to extend the mixed-layer restratification "//&
+             "depth used for a smoother stream function at the base of "//&
              "the mixed-layer.", units="nondim", default=0.0)
     call get_param(param_file, mdl, "MLE_MLD_STRETCH", CS%MLE_MLD_stretch, &
-             "A scaling coefficient for stretching/shrinking the MLD\n"//&
+             "A scaling coefficient for stretching/shrinking the MLD "//&
              "used in the MLE scheme. This simply multiplies MLD wherever used.",&
              units="nondim", default=1.0)
     call get_param(param_file, mdl, "MLE_USE_MLD_AVE_BUG", CS%MLE_use_MLD_ave_bug, &

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1718,13 +1718,13 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "THICKNESSDIFFUSE", CS%thickness_diffuse, &
-                 "If true, interface heights are diffused with a \n"//&
+                 "If true, interface heights are diffused with a "//&
                  "coefficient of KHTH.", default=.false.)
   call get_param(param_file, mdl, "KHTH", CS%Khth, &
                  "The background horizontal thickness diffusivity.", &
                  units = "m2 s-1", default=0.0)
   call get_param(param_file, mdl, "KHTH_SLOPE_CFF", CS%KHTH_Slope_Cff, &
-                 "The nondimensional coefficient in the Visbeck formula \n"//&
+                 "The nondimensional coefficient in the Visbeck formula "//&
                  "for the interface depth diffusivity", units="nondim", &
                  default=0.0)
   call get_param(param_file, mdl, "KHTH_MIN", CS%KHTH_Min, &
@@ -1734,45 +1734,45 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
                  "The maximum horizontal thickness diffusivity.", &
                  units = "m2 s-1", default=0.0)
   call get_param(param_file, mdl, "KHTH_MAX_CFL", CS%max_Khth_CFL, &
-                 "The maximum value of the local diffusive CFL ratio that \n"//&
-                 "is permitted for the thickness diffusivity. 1.0 is the \n"//&
-                 "marginally unstable value in a pure layered model, but \n"//&
-                 "much smaller numbers (e.g. 0.1) seem to work better for \n"//&
+                 "The maximum value of the local diffusive CFL ratio that "//&
+                 "is permitted for the thickness diffusivity. 1.0 is the "//&
+                 "marginally unstable value in a pure layered model, but "//&
+                 "much smaller numbers (e.g. 0.1) seem to work better for "//&
                  "ALE-based models.", units = "nondimensional", default=0.8)
   if (CS%max_Khth_CFL < 0.0) CS%max_Khth_CFL = 0.0
   call get_param(param_file, mdl, "DETANGLE_INTERFACES", CS%detangle_interfaces, &
-                 "If defined add 3-d structured enhanced interface height \n"//&
+                 "If defined add 3-d structured enhanced interface height "//&
                  "diffusivities to horizontally smooth jagged layers.", &
                  default=.false.)
   CS%detangle_time = 0.0
   if (CS%detangle_interfaces) &
     call get_param(param_file, mdl, "DETANGLE_TIMESCALE", CS%detangle_time, &
-                 "A timescale over which maximally jagged grid-scale \n"//&
-                 "thickness variations are suppressed.  This must be \n"//&
+                 "A timescale over which maximally jagged grid-scale "//&
+                 "thickness variations are suppressed.  This must be "//&
                  "longer than DT, or 0 to use DT.", units = "s", default=0.0)
   call get_param(param_file, mdl, "KHTH_SLOPE_MAX", CS%slope_max, &
-                 "A slope beyond which the calculated isopycnal slope is \n"//&
+                 "A slope beyond which the calculated isopycnal slope is "//&
                  "not reliable and is scaled away.", units="nondim", default=0.01)
   call get_param(param_file, mdl, "KD_SMOOTH", CS%kappa_smooth, &
-                 "A diapycnal diffusivity that is used to interpolate \n"//&
+                 "A diapycnal diffusivity that is used to interpolate "//&
                  "more sensible values of T & S into thin layers.", &
                  default=1.0e-6, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "KHTH_USE_FGNV_STREAMFUNCTION", CS%use_FGNV_streamfn, &
-                 "If true, use the streamfunction formulation of\n"//    &
-                 "Ferrari et al., 2010, which effectively emphasizes\n"//&
+                 "If true, use the streamfunction formulation of "//&
+                 "Ferrari et al., 2010, which effectively emphasizes "//&
                  "graver vertical modes by smoothing in the vertical.",  &
                  default=.false.)
   call get_param(param_file, mdl, "FGNV_FILTER_SCALE", CS%FGNV_scale, &
-                 "A coefficient scaling the vertical smoothing term in the\n"//&
+                 "A coefficient scaling the vertical smoothing term in the "//&
                  "Ferrari et al., 2010, streamfunction formulation.", &
                  default=1., do_not_log=.not.CS%use_FGNV_streamfn)
   call get_param(param_file, mdl, "FGNV_C_MIN", CS%FGNV_c_min, &
-                 "A minium wave speed used in the Ferrari et al., 2010,\n"//&
+                 "A minium wave speed used in the Ferrari et al., 2010, "//&
                  "streamfunction formulation.", &
                  default=0., units="m s-1", do_not_log=.not.CS%use_FGNV_streamfn)
   call get_param(param_file, mdl, "FGNV_STRAT_FLOOR", strat_floor, &
-                 "A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,\n"//&
-                 "streamfunction formulation, expressed as a fraction of planetary\n"//&
+                 "A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010, "//&
+                 "streamfunction formulation, expressed as a fraction of planetary "//&
                  "rotation, OMEGA. This should be tiny but non-zero to avoid degeneracy.", &
                  default=1.e-15, units="nondim", do_not_log=.not.CS%use_FGNV_streamfn)
   call get_param(param_file, mdl, "OMEGA",omega, &

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -123,43 +123,43 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
   enddo ; enddo
 
   call get_param(param_file, mdl, "TIDE_M2", use_M2, &
-                 "If true, apply tidal momentum forcing at the M2 \n"//&
+                 "If true, apply tidal momentum forcing at the M2 "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
   call get_param(param_file, mdl, "TIDE_S2", use_S2, &
-                 "If true, apply tidal momentum forcing at the S2 \n"//&
+                 "If true, apply tidal momentum forcing at the S2 "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
   call get_param(param_file, mdl, "TIDE_N2", use_N2, &
-                 "If true, apply tidal momentum forcing at the N2 \n"//&
+                 "If true, apply tidal momentum forcing at the N2 "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
   call get_param(param_file, mdl, "TIDE_K2", use_K2, &
-                 "If true, apply tidal momentum forcing at the K2 \n"//&
+                 "If true, apply tidal momentum forcing at the K2 "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
   call get_param(param_file, mdl, "TIDE_K1", use_K1, &
-                 "If true, apply tidal momentum forcing at the K1 \n"//&
+                 "If true, apply tidal momentum forcing at the K1 "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
   call get_param(param_file, mdl, "TIDE_O1", use_O1, &
-                 "If true, apply tidal momentum forcing at the O1 \n"//&
+                 "If true, apply tidal momentum forcing at the O1 "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
   call get_param(param_file, mdl, "TIDE_P1", use_P1, &
-                 "If true, apply tidal momentum forcing at the P1 \n"//&
+                 "If true, apply tidal momentum forcing at the P1 "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
   call get_param(param_file, mdl, "TIDE_Q1", use_Q1, &
-                 "If true, apply tidal momentum forcing at the Q1 \n"//&
+                 "If true, apply tidal momentum forcing at the Q1 "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
   call get_param(param_file, mdl, "TIDE_MF", use_MF, &
-                 "If true, apply tidal momentum forcing at the MF \n"//&
+                 "If true, apply tidal momentum forcing at the MF "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
   call get_param(param_file, mdl, "TIDE_MM", use_MM, &
-                 "If true, apply tidal momentum forcing at the MM \n"//&
+                 "If true, apply tidal momentum forcing at the MM "//&
                  "frequency. This is only used if TIDES is true.", &
                  default=.false.)
 
@@ -179,23 +179,23 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
   endif
 
   call get_param(param_file, mdl, "TIDAL_SAL_FROM_FILE", CS%tidal_sal_from_file, &
-                 "If true, read the tidal self-attraction and loading \n"//&
-                 "from input files, specified by TIDAL_INPUT_FILE. \n"//&
+                 "If true, read the tidal self-attraction and loading "//&
+                 "from input files, specified by TIDAL_INPUT_FILE. "//&
                  "This is only used if TIDES is true.", default=.false.)
   call get_param(param_file, mdl, "USE_PREVIOUS_TIDES", CS%use_prev_tides, &
-                 "If true, use the SAL from the previous iteration of the \n"//&
-                 "tides to facilitate convergent iteration. \n"//&
+                 "If true, use the SAL from the previous iteration of the "//&
+                 "tides to facilitate convergent iteration. "//&
                  "This is only used if TIDES is true.", default=.false.)
   call get_param(param_file, mdl, "TIDE_USE_SAL_SCALAR", CS%use_sal_scalar, &
-                 "If true and TIDES is true, use the scalar approximation \n"//&
+                 "If true and TIDES is true, use the scalar approximation "//&
                  "when calculating self-attraction and loading.", &
                  default=.not.CS%tidal_sal_from_file)
   ! If it is being used, sal_scalar MUST be specified in param_file.
   if (CS%use_sal_scalar .or. CS%use_prev_tides) &
     call get_param(param_file, mdl, "TIDE_SAL_SCALAR_VALUE", CS%sal_scalar, &
-                 "The constant of proportionality between sea surface \n"//&
-                 "height (really it should be bottom pressure) anomalies \n"//&
-                 "and bottom geopotential anomalies. This is only used if \n"//&
+                 "The constant of proportionality between sea surface "//&
+                 "height (really it should be bottom pressure) anomalies "//&
+                 "and bottom geopotential anomalies. This is only used if "//&
                  "TIDES and TIDE_USE_SAL_SCALAR are true.", units="m m-1", &
                  fail_if_missing=.true.)
 
@@ -290,15 +290,15 @@ subroutine tidal_forcing_init(Time, G, param_file, CS)
   ! values that are actually used.
   do c=1,nc
     call get_param(param_file, mdl, "TIDE_"//trim(CS%const_name(c))//"_FREQ", CS%freq(c), &
-                   "Frequency of the "//trim(CS%const_name(c))//" tidal constituent. \n"//&
+                   "Frequency of the "//trim(CS%const_name(c))//" tidal constituent. "//&
                    "This is only used if TIDES and TIDE_"//trim(CS%const_name(c))// &
                    " are true.", units="s-1", default=freq_def(c))
     call get_param(param_file, mdl, "TIDE_"//trim(CS%const_name(c))//"_AMP", CS%amp(c), &
-                   "Amplitude of the "//trim(CS%const_name(c))//" tidal constituent. \n"//&
+                   "Amplitude of the "//trim(CS%const_name(c))//" tidal constituent. "//&
                    "This is only used if TIDES and TIDE_"//trim(CS%const_name(c))// &
                    " are true.", units="m", default=amp_def(c))
     call get_param(param_file, mdl, "TIDE_"//trim(CS%const_name(c))//"_PHASE_T0", CS%phase0(c), &
-                   "Phase of the "//trim(CS%const_name(c))//" tidal constituent at time 0. \n"//&
+                   "Phase of the "//trim(CS%const_name(c))//" tidal constituent at time 0. "//&
                    "This is only used if TIDES and TIDE_"//trim(CS%const_name(c))// &
                    " are true.", units="radians", default=phase0_def(c))
   enddo

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -170,8 +170,8 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
 ! Set default, read and log parameters
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "SPONGE", use_sponge, &
-                 "If true, sponges may be applied anywhere in the domain. \n"//&
-                 "The exact location and properties of those sponges are \n"//&
+                 "If true, sponges may be applied anywhere in the domain. "//&
+                 "The exact location and properties of those sponges are "//&
                  "specified from MOM_initialization.F90.", default=.false.)
 
   if (.not.use_sponge) return
@@ -183,14 +183,14 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
                  default=.false.)
 
   call get_param(param_file, mdl, "REMAPPING_SCHEME", remapScheme, &
-                 "This sets the reconstruction scheme used \n"//&
+                 "This sets the reconstruction scheme used "//&
                  " for vertical remapping for all variables.", &
                  default="PLM", do_not_log=.true.)
 
   call get_param(param_file, mdl, "BOUNDARY_EXTRAPOLATION", bndExtrapolation, &
-                 "When defined, a proper high-order reconstruction \n"//&
-                 "scheme is used within boundary cells rather \n"// &
-                 "than PCM. E.g., if PPM is used for remapping, a \n" //&
+                 "When defined, a proper high-order reconstruction "//&
+                 "scheme is used within boundary cells rather "//&
+                 "than PCM. E.g., if PPM is used for remapping, a "//&
                  "PPM reconstruction will also be used within boundary cells.", &
                  default=.false., do_not_log=.true.)
 
@@ -401,8 +401,8 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
 ! Set default, read and log parameters
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "SPONGE", use_sponge, &
-                 "If true, sponges may be applied anywhere in the domain. \n"//&
-                 "The exact location and properties of those sponges are \n"//&
+                 "If true, sponges may be applied anywhere in the domain. "//&
+                 "The exact location and properties of those sponges are "//&
                  "specified from MOM_initialization.F90.", default=.false.)
 
   if (.not.use_sponge) return
@@ -414,14 +414,14 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
                  default=.false.)
 
   call get_param(param_file, mdl, "REMAPPING_SCHEME", remapScheme, &
-                 "This sets the reconstruction scheme used \n"//&
+                 "This sets the reconstruction scheme used "//&
                  " for vertical remapping for all variables.", &
                  default="PLM", do_not_log=.true.)
 
   call get_param(param_file, mdl, "BOUNDARY_EXTRAPOLATION", bndExtrapolation, &
-                 "When defined, a proper high-order reconstruction \n"//&
-                 "scheme is used within boundary cells rather \n"// &
-                 "than PCM. E.g., if PPM is used for remapping, a \n" //&
+                 "When defined, a proper high-order reconstruction "//&
+                 "scheme is used within boundary cells rather "//&
+                 "than PCM. E.g., if PPM is used for remapping, a "//&
                  "PPM reconstruction will also be used within boundary cells.", &
                  default=.false., do_not_log=.true.)
 

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -201,7 +201,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
   call log_version(paramFile, mdl, version, 'This is the MOM wrapper to CVMix:KPP\n' // &
             'See http://cvmix.github.io/')
   call get_param(paramFile, mdl, "USE_KPP", KPP_init, &
-                 "If true, turns on the [CVMix] KPP scheme of Large et al., 1994,\n"// &
+                 "If true, turns on the [CVMix] KPP scheme of Large et al., 1994, "// &
                  "to calculate diffusivities and non-local transport in the OBL.",     &
                  default=.false.)
   ! Forego remainder of initialization if not using this scheme
@@ -216,22 +216,22 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
   if (present(passive)) passive=CS%passiveMode ! This is passed back to the caller so
                                                ! the caller knows to not use KPP output
   call get_param(paramFile, mdl, 'APPLY_NONLOCAL_TRANSPORT', CS%applyNonLocalTrans,  &
-                 'If True, applies the non-local transport to heat and scalars.\n'//  &
-                 'If False, calculates the non-local transport and tendencies but\n'//&
+                 'If True, applies the non-local transport to heat and scalars. '//  &
+                 'If False, calculates the non-local transport and tendencies but '//&
                  'purely for diagnostic purposes.',                                   &
                  default=.not. CS%passiveMode)
   call get_param(paramFile, mdl, 'N_SMOOTH', CS%n_smooth,  &
-                 'The number of times the 1-1-4-1-1 Laplacian filter is applied on\n'//  &
+                 'The number of times the 1-1-4-1-1 Laplacian filter is applied on '//  &
                  'OBL depth.',   &
                  default=0)
   if (CS%n_smooth > 0) then
     call get_param(paramFile, mdl, 'DEEPEN_ONLY_VIA_SMOOTHING', CS%deepen_only,  &
-                   'If true, apply OBLdepth smoothing at a cell only if the OBLdepth.\n'// &
+                   'If true, apply OBLdepth smoothing at a cell only if the OBLdepth '// &
                    'gets deeper via smoothing.',   &
                    default=.false.)
   endif
   call get_param(paramFile, mdl, 'RI_CRIT', CS%Ri_crit,                            &
-                 'Critical bulk Richardson number used to define depth of the\n'// &
+                 'Critical bulk Richardson number used to define depth of the '// &
                  'surface Ocean Boundary Layer (OBL).',                            &
                  units='nondim', default=0.3)
   call get_param(paramFile, mdl, 'VON_KARMAN', CS%vonKarman, &
@@ -252,7 +252,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
                  'If True, limit OBL depth to be no deeper than Ekman depth.', &
                  default=.False.)
   call get_param(paramFile, mdl, 'COMPUTE_MONIN_OBUKHOV', CS%computeMoninObukhov, &
-                 'If True, limit the OBL depth to be no deeper than\n'//          &
+                 'If True, limit the OBL depth to be no deeper than '//          &
                  'Monin-Obukhov depth.',                                          &
                  default=.False.)
   call get_param(paramFile, mdl, 'CS', CS%cs,                        &
@@ -262,47 +262,47 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
                  'Parameter for computing non-local term.', &
                  units='nondim', default=6.32739901508)
   call get_param(paramFile, mdl, 'DEEP_OBL_OFFSET', CS%deepOBLoffset,                             &
-                 'If non-zero, the distance above the bottom to which the OBL is clipped\n'//     &
+                 'If non-zero, the distance above the bottom to which the OBL is clipped '//     &
                  'if it would otherwise reach the bottom. The smaller of this and 0.1D is used.', &
                  units='m',default=0.)
   call get_param(paramFile, mdl, 'FIXED_OBLDEPTH', CS%fixedOBLdepth,       &
-                 'If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE\n'//  &
-                 'rather than using the OBL depth from CVMix.\n'//         &
+                 'If True, fix the OBL depth to FIXED_OBLDEPTH_VALUE '//  &
+                 'rather than using the OBL depth from CVMix. '//         &
                  'This option is just for testing purposes.',              &
                  default=.False.)
   call get_param(paramFile, mdl, 'FIXED_OBLDEPTH_VALUE', CS%fixedOBLdepth_value,  &
-                 'Value for the fixed OBL depth when fixedOBLdepth==True. \n'//   &
-                 'This parameter is for just for testing purposes. \n'//          &
+                 'Value for the fixed OBL depth when fixedOBLdepth==True. '//   &
+                 'This parameter is for just for testing purposes. '//          &
                  'It will over-ride the OBLdepth computed from CVMix.',           &
                  units='m',default=30.0)
   call get_param(paramFile, mdl, 'SURF_LAYER_EXTENT', CS%surf_layer_ext,   &
                  'Fraction of OBL depth considered in the surface layer.', &
                  units='nondim',default=0.10)
   call get_param(paramFile, mdl, 'MINIMUM_OBL_DEPTH', CS%minOBLdepth,                            &
-                 'If non-zero, a minimum depth to use for KPP OBL depth. Independent of\n'//     &
+                 'If non-zero, a minimum depth to use for KPP OBL depth. Independent of '//     &
                  'this parameter, the OBL depth is always at least as deep as the first layer.', &
                  units='m',default=0.)
   call get_param(paramFile, mdl, 'MINIMUM_VT2', CS%minVtsqr,                                   &
-                 'Min of the unresolved velocity Vt2 used in Rib CVMix calculation.     \n'//  &
+                 'Min of the unresolved velocity Vt2 used in Rib CVMix calculation.\n'//  &
                  'Scaling: MINIMUM_VT2 = const1*d*N*ws, with d=1m, N=1e-5/s, ws=1e-6 m/s.',    &
                  units='m2/s2',default=1e-10)
 
 ! smg: for removal below
   call get_param(paramFile, mdl, 'CORRECT_SURFACE_LAYER_AVERAGE', CS%correctSurfLayerAvg,   &
-                 'If true, applies a correction step to the averaging of surface layer\n'// &
+                 'If true, applies a correction step to the averaging of surface layer '// &
                  'properties. This option is obsolete.', default=.False.)
   if (CS%correctSurfLayerAvg) &
     call MOM_error(FATAL,'Correct surface layer average disabled in code.  To recover \n'// &
                        ' feature will require code intervention.')
   call get_param(paramFile, mdl, 'FIRST_GUESS_SURFACE_LAYER_DEPTH', CS%surfLayerDepth,              &
-                 'The first guess at the depth of the surface layer used for averaging\n'//         &
-                 'the surface layer properties. If =0, the top model level properties\n'//          &
-                 'will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a\n'// &
+                 'The first guess at the depth of the surface layer used for averaging '//         &
+                 'the surface layer properties. If =0, the top model level properties '//          &
+                 'will be used for the surface layer. If CORRECT_SURFACE_LAYER_AVERAGE=True, a '// &
                  'subsequent correction is applied. This parameter is obsolete', units='m', default=0.)
 ! smg: for removal above
 
   call get_param(paramFile, mdl, 'NLT_SHAPE', string, &
-                 'MOM6 method to set nonlocal transport profile.\n'//                          &
+                 'MOM6 method to set nonlocal transport profile. '//                          &
                  'Over-rides the result from CVMix.  Allowed values are: \n'//                 &
                  '\t CVMix     - Uses the profiles from CVMix specified by MATCH_TECHNIQUE\n'//&
                  '\t LINEAR    - A linear profile, 1-sigma\n'//                                &
@@ -320,7 +320,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
                    "Unrecognized NLT_SHAPE option"//trim(string))
   end select
   call get_param(paramFile, mdl, 'MATCH_TECHNIQUE', CS%MatchTechnique,                                    &
-                 'CVMix method to set profile function for diffusivity and NLT,\n'//                      &
+                 'CVMix method to set profile function for diffusivity and NLT, '//                      &
                  'as well as matching across OBL base. Allowed values are: \n'//                          &
                  '\t SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT\n'//              &
                  '\t MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching\n'//&
@@ -353,7 +353,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
                  'If false, KPP is the only diffusivity wherever KPP is non-zero.',  &
                  default=.True.)
   call get_param(paramFile, mdl, 'KPP_SHORTWAVE_METHOD',string,                      &
-                 'Determines contribution of shortwave radiation to KPP surface \n'// &
+                 'Determines contribution of shortwave radiation to KPP surface '// &
                  'buoyancy flux.  Options include:\n'//                             &
                  '  ALL_SW: use total shortwave radiation\n'//                      &
                  '  MXL_SW: use shortwave radiation absorbed by mixing layer\n'//  &
@@ -367,7 +367,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
                    "Unrecognized KPP_SHORTWAVE_METHOD option"//trim(string))
   end select
   call get_param(paramFile, mdl, 'CVMix_ZERO_H_WORK_AROUND', CS%min_thickness,                           &
-                 'A minimum thickness used to avoid division by small numbers in the vicinity\n'//       &
+                 'A minimum thickness used to avoid division by small numbers in the vicinity '//       &
                  'of vanished layers. This is independent of MIN_THICKNESS used in other parts of MOM.', &
                  units='m', default=0.)
 
@@ -381,7 +381,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
        'mixing coefficient.', units="", Default=.false.)
   if (CS%LT_K_Enhancement) then
     call get_param(paramFile, mdl, 'KPP_LT_K_SHAPE', string,                 &
-                 'Vertical dependence of LT enhancement of mixing. \n'//     &
+                 'Vertical dependence of LT enhancement of mixing. '//     &
                  'Valid options are: \n'//                                   &
                  '\t CONSTANT = Constant value for full OBL\n'//             &
                  '\t SCALED   = Varies based on normalized shape function.', &
@@ -393,7 +393,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
                     "Unrecognized KPP_LT_K_SHAPE option: "//trim(string))
     end select
     call get_param(paramFile, mdl, "KPP_LT_K_METHOD", string ,                   &
-                   'Method to enhance mixing coefficient in KPP. \n'//           &
+                   'Method to enhance mixing coefficient in KPP. '//           &
                    'Valid options are: \n'//                                     &
                    '\t CONSTANT = Constant value (KPP_K_ENH_FAC) \n'//           &
                    '\t VR12     = Function of Langmuir number based on VR12\n'// &
@@ -418,7 +418,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
        'in Bulk Richardson Number.', units="", Default=.false.)
   if (CS%LT_Vt2_Enhancement) then
     call get_param(paramFile, mdl, "KPP_LT_VT2_METHOD",string ,                  &
-                   'Method to enhance Vt2 in KPP. \n'//                          &
+                   'Method to enhance Vt2 in KPP. '//                          &
                    'Valid options are: \n'//                                     &
                    '\t CONSTANT = Constant value (KPP_VT2_ENH_FAC) \n'//         &
                    '\t VR12     = Function of Langmuir number based on VR12\n'// &

--- a/src/parameterizations/vertical/MOM_CVMix_conv.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_conv.F90
@@ -79,9 +79,9 @@ logical function CVMix_conv_init(Time, G, GV, US, param_file, diag, CS)
   call log_version(param_file, mdl, version, &
     "Parameterization of enhanced mixing due to convection via CVMix")
   call get_param(param_file, mdl, "USE_CVMix_CONVECTION", CVMix_conv_init, &
-                 "If true, turns on the enhanced mixing due to convection  \n"// &
-                 "via CVMix. This scheme increases diapycnal diffs./viscs. \n"// &
-                 " at statically unstable interfaces. Relevant parameters are \n"// &
+                 "If true, turns on the enhanced mixing due to convection "//&
+                 "via CVMix. This scheme increases diapycnal diffs./viscs. "//&
+                 "at statically unstable interfaces. Relevant parameters are "//&
                  "contained in the CVMix_CONVECTION% parameter block.", &
                  default=.false.)
 
@@ -105,17 +105,17 @@ logical function CVMix_conv_init(Time, G, GV, US, param_file, diag, CS)
   call openParameterBlock(param_file,'CVMix_CONVECTION')
 
   call get_param(param_file, mdl, "PRANDTL_CONV", prandtl_conv, &
-                 "The turbulent Prandtl number applied to convective \n"//&
+                 "The turbulent Prandtl number applied to convective "//&
                  "instabilities (i.e., used to convert KD_CONV into KV_CONV)", &
                  units="nondim", default=1.0)
 
   call get_param(param_file, mdl, 'KD_CONV', CS%kd_conv_const, &
-                 "Diffusivity used in convective regime. Corresponding viscosity \n" // &
+                 "Diffusivity used in convective regime. Corresponding viscosity "//&
                  "(KV_CONV) will be set to KD_CONV * PRANDTL_TURB.", &
                  units='m2/s', default=1.00)
 
   call get_param(param_file, mdl, 'BV_SQR_CONV', CS%bv_sqr_conv, &
-                 "Threshold for squared buoyancy frequency needed to trigger \n" // &
+                 "Threshold for squared buoyancy frequency needed to trigger "//&
                  "Brunt-Vaisala parameterization.", &
                  units='1/s^2', default=0.0)
 

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -82,9 +82,9 @@ logical function CVMix_ddiff_init(Time, G, GV, US, param_file, diag, CS)
   call log_version(param_file, mdl, version, &
     "Parameterization of mixing due to double diffusion processes via CVMix")
   call get_param(param_file, mdl, "USE_CVMIX_DDIFF", CVMix_ddiff_init, &
-                 "If true, turns on double diffusive processes via CVMix.  \n"// &
-                 "Note that double diffusive processes on viscosity are ignored \n"// &
-                 "in CVMix, see http://cvmix.github.io/ for justification.",&
+                 "If true, turns on double diffusive processes via CVMix. "//&
+                 "Note that double diffusive processes on viscosity are ignored "//&
+                 "in CVMix, see http://cvmix.github.io/ for justification.", &
                  default=.false.)
 
   if (.not. CVMix_ddiff_init) return
@@ -100,7 +100,7 @@ logical function CVMix_ddiff_init(Time, G, GV, US, param_file, diag, CS)
                  units="nondim", default=2.55)
 
   call get_param(param_file, mdl, "KAPPA_DDIFF_S", CS%kappa_ddiff_s, &
-                 "Leading coefficient in formula for salt-fingering regime \n"// &
+                 "Leading coefficient in formula for salt-fingering regime "//&
                  "for salinity diffusion.", units="m2 s-1", default=1.0e-4)
 
   call get_param(param_file, mdl, "DDIFF_EXP1", CS%ddiff_exp1, &

--- a/src/parameterizations/vertical/MOM_CVMix_shear.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_shear.F90
@@ -213,14 +213,14 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
   call log_version(param_file, mdl, version, &
     "Parameterization of shear-driven turbulence via CVMix (various options)")
   call get_param(param_file, mdl, "USE_LMD94", CS%use_LMD94, &
-                 "If true, use the Large-McWilliams-Doney (JGR 1994) \n"//&
+                 "If true, use the Large-McWilliams-Doney (JGR 1994) "//&
                  "shear mixing parameterization.", default=.false.)
   if (CS%use_LMD94) then
      NumberTrue=NumberTrue + 1
      CS%Mix_Scheme='KPP'
   endif
   call get_param(param_file, mdl, "USE_PP81", CS%use_PP81, &
-                 "If true, use the Pacanowski and Philander (JPO 1981) \n"//&
+                 "If true, use the Pacanowski and Philander (JPO 1981) "//&
                  "shear mixing parameterization.", default=.false.)
   if (CS%use_PP81) then
      NumberTrue = NumberTrue + 1
@@ -243,16 +243,16 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
                  "Leading coefficient in KPP shear mixing.", &
                  units="nondim", default=5.e-3)
   call get_param(param_file, mdl, "RI_ZERO", CS%Ri_Zero, &
-                 "Critical Richardson for KPP shear mixing,"// &
-                 " NOTE this the internal mixing and this is"// &
-                 " not for setting the boundary layer depth." &
+                 "Critical Richardson for KPP shear mixing, "// &
+                 "NOTE this the internal mixing and this is "// &
+                 "not for setting the boundary layer depth." &
                  ,units="nondim", default=0.8)
   call get_param(param_file, mdl, "KPP_EXP", CS%KPP_exp, &
-                 "Exponent of unitless factor of diffusivities,"// &
-                 " for KPP internal shear mixing scheme." &
+                 "Exponent of unitless factor of diffusivities, "// &
+                 "for KPP internal shear mixing scheme." &
                  ,units="nondim", default=3.0)
   call get_param(param_file, mdl, "SMOOTH_RI", CS%smooth_ri, &
-                 "If true, vertically smooth the Richardson"// &
+                 "If true, vertically smooth the Richardson "// &
                  "number by applying a 1-2-1 filter once.", &
                  default = .false.)
   call cvmix_init_shear(mix_scheme=CS%Mix_Scheme, &

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -144,12 +144,12 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
     "Adding static vertical background mixing coefficients")
 
   call get_param(param_file, mdl, "KD", CS%Kd, &
-                 "The background diapycnal diffusivity of density in the \n"//&
-                 "interior. Zero or the molecular value, ~1e-7 m2 s-1, \n"//&
+                 "The background diapycnal diffusivity of density in the "//&
+                 "interior. Zero or the molecular value, ~1e-7 m2 s-1, "//&
                  "may be used.", units="m2 s-1", scale=US%m_to_Z**2, fail_if_missing=.true.)
 
   call get_param(param_file, mdl, "KV", Kv, &
-                 "The background kinematic viscosity in the interior. \n"//&
+                 "The background kinematic viscosity in the interior. "//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
                  units="m2 s-1", fail_if_missing=.true.)
 
@@ -172,13 +172,13 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
                     ! cannot be a NaN.
   else
     call get_param(param_file, mdl, "KDML", CS%Kdml, &
-                 "If BULKMIXEDLAYER is false, KDML is the elevated \n"//&
-                 "diapycnal diffusivity in the topmost HMIX of fluid. \n"//&
+                 "If BULKMIXEDLAYER is false, KDML is the elevated "//&
+                 "diapycnal diffusivity in the topmost HMIX of fluid. "//&
                  "KDML is only used if BULKMIXEDLAYER is false.", &
                  units="m2 s-1", default=CS%Kd*US%Z_to_m**2, scale=US%m_to_Z**2)
     call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
-                 "The prescribed depth over which the near-surface \n"//&
-                 "viscosity and diffusivity are elevated when the bulk \n"//&
+                 "The prescribed depth over which the near-surface "//&
+                 "viscosity and diffusivity are elevated when the bulk "//&
                  "mixed layer is not used.", units="m", scale=US%m_to_Z, fail_if_missing=.true.)
   endif
 
@@ -186,10 +186,9 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
 
 !  call openParameterBlock(param_file,'MOM_BACKGROUND_MIXING')
 
-  call get_param(param_file, mdl, "BRYAN_LEWIS_DIFFUSIVITY", &
-                                CS%Bryan_Lewis_diffusivity, &
-                 "If true, use a Bryan & Lewis (JGR 1979) like tanh \n"//&
-                 "profile of background diapycnal diffusivity with depth. \n"//&
+  call get_param(param_file, mdl, "BRYAN_LEWIS_DIFFUSIVITY", CS%Bryan_Lewis_diffusivity, &
+                 "If true, use a Bryan & Lewis (JGR 1979) like tanh "//&
+                 "profile of background diapycnal diffusivity with depth. "//&
                  "This is done via CVMix.", default=.false.)
 
   if (CS%Bryan_Lewis_diffusivity) then
@@ -219,7 +218,7 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
 
   call get_param(param_file, mdl, "HORIZ_VARYING_BACKGROUND", &
                                 CS%horiz_varying_background, &
-                 "If true, apply vertically uniform, latitude-dependent background\n"//&
+                 "If true, apply vertically uniform, latitude-dependent background "//&
                  "diffusivity, as described in Danabasoglu et al., 2012", &
                  default=.false.)
 
@@ -248,7 +247,7 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
   endif
 
   call get_param(param_file, mdl, "PRANDTL_BKGND", CS%prandtl_bkgnd, &
-                 "Turbulent Prandtl number used to convert vertical \n"//&
+                 "Turbulent Prandtl number used to convert vertical "//&
                  "background diffusivities into viscosities.", &
                  units="nondim", default=1.0)
 
@@ -265,18 +264,16 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
 
   endif
 
-  call get_param(param_file, mdl, "HENYEY_IGW_BACKGROUND", &
-                                CS%Henyey_IGW_background, &
-                 "If true, use a latitude-dependent scaling for the near \n"//&
-                 "surface background diffusivity, as described in \n"//&
+  call get_param(param_file, mdl, "HENYEY_IGW_BACKGROUND", CS%Henyey_IGW_background, &
+                 "If true, use a latitude-dependent scaling for the near "//&
+                 "surface background diffusivity, as described in "//&
                  "Harrison & Hallberg, JPO 2008.", default=.false.)
   if (CS%Henyey_IGW_background) call check_bkgnd_scheme(CS, "HENYEY_IGW_BACKGROUND")
 
 
-  call get_param(param_file, mdl, "HENYEY_IGW_BACKGROUND_NEW", &
-                                CS%Henyey_IGW_background_new, &
-                 "If true, use a better latitude-dependent scaling for the\n"//&
-                 "background diffusivity, as described in \n"//&
+  call get_param(param_file, mdl, "HENYEY_IGW_BACKGROUND_NEW", CS%Henyey_IGW_background_new, &
+                 "If true, use a better latitude-dependent scaling for the "//&
+                 "background diffusivity, as described in "//&
                  "Harrison & Hallberg, JPO 2008.", default=.false.)
   if (CS%Henyey_IGW_background_new) call check_bkgnd_scheme(CS, "HENYEY_IGW_BACKGROUND_NEW")
 
@@ -288,22 +285,21 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
 
   if (CS%Henyey_IGW_background) &
     call get_param(param_file, mdl, "HENYEY_N0_2OMEGA", CS%N0_2Omega, &
-                  "The ratio of the typical Buoyancy frequency to twice \n"//&
-                  "the Earth's rotation period, used with the Henyey \n"//&
+                  "The ratio of the typical Buoyancy frequency to twice "//&
+                  "the Earth's rotation period, used with the Henyey "//&
                   "scaling from the mixing.", units="nondim", default=20.0)
 
   call get_param(param_file, mdl, "KD_TANH_LAT_FN", &
                   CS%Kd_tanh_lat_fn, &
-                 "If true, use a tanh dependence of Kd_sfc on latitude, \n"//&
-                 "like CM2.1/CM2M.  There is no physical justification \n"//&
-                 "for this form, and it can not be used with \n"//&
+                 "If true, use a tanh dependence of Kd_sfc on latitude, "//&
+                 "like CM2.1/CM2M.  There is no physical justification "//&
+                 "for this form, and it can not be used with "//&
                  "HENYEY_IGW_BACKGROUND.", default=.false.)
 
   if (CS%Kd_tanh_lat_fn) &
-  call get_param(param_file, mdl, "KD_TANH_LAT_SCALE", &
-                 CS%Kd_tanh_lat_scale, &
-                 "A nondimensional scaling for the range ofdiffusivities \n"//&
-                 "with KD_TANH_LAT_FN. Valid values are in the range of \n"//&
+    call get_param(param_file, mdl, "KD_TANH_LAT_SCALE", CS%Kd_tanh_lat_scale, &
+                 "A nondimensional scaling for the range ofdiffusivities "//&
+                 "with KD_TANH_LAT_FN. Valid values are in the range of "//&
                  "-2 to 2; 0.4 reproduces CM2M.", units="nondim", default=0.0)
 
   if (CS%Henyey_IGW_background .and. CS%Kd_tanh_lat_fn) call MOM_error(FATAL, &

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -3429,81 +3429,81 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
 
   CS%nkml = GV%nkml
   call log_param(param_file, mdl, "NKML", CS%nkml, &
-                 "The number of sublayers within the mixed layer if \n"//&
+                 "The number of sublayers within the mixed layer if "//&
                  "BULKMIXEDLAYER is true.", units="nondim", default=2)
   CS%nkbl = GV%nk_rho_varies - GV%nkml
   call log_param(param_file, mdl, "NKBL", CS%nkbl, &
-                 "The number of variable density buffer layers if \n"//&
+                 "The number of variable density buffer layers if "//&
                  "BULKMIXEDLAYER is true.", units="nondim", default=2)
   call get_param(param_file, mdl, "MSTAR", CS%mstar, &
-                 "The ratio of the friction velocity cubed to the TKE \n"//&
+                 "The ratio of the friction velocity cubed to the TKE "//&
                  "input to the mixed layer.", "units=nondim", default=1.2)
   call get_param(param_file, mdl, "NSTAR", CS%nstar, &
-                 "The portion of the buoyant potential energy imparted by \n"//&
-                 "surface fluxes that is available to drive entrainment \n"//&
+                 "The portion of the buoyant potential energy imparted by "//&
+                 "surface fluxes that is available to drive entrainment "//&
                  "at the base of mixed layer when that energy is positive.", &
                  units="nondim", default=0.15)
   call get_param(param_file, mdl, "BULK_RI_ML", CS%bulk_Ri_ML, &
-                 "The efficiency with which mean kinetic energy released \n"//&
-                 "by mechanically forced entrainment of the mixed layer \n"//&
+                 "The efficiency with which mean kinetic energy released "//&
+                 "by mechanically forced entrainment of the mixed layer "//&
                  "is converted to turbulent kinetic energy.", units="nondim",&
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "ABSORB_ALL_SW", CS%absorb_all_sw, &
-                 "If true,  all shortwave radiation is absorbed by the \n"//&
+                 "If true,  all shortwave radiation is absorbed by the "//&
                  "ocean, instead of passing through to the bottom mud.", &
                  default=.false.)
   call get_param(param_file, mdl, "TKE_DECAY", CS%TKE_decay, &
-                 "TKE_DECAY relates the vertical rate of decay of the \n"//&
-                 "TKE available for mechanical entrainment to the natural \n"//&
+                 "TKE_DECAY relates the vertical rate of decay of the "//&
+                 "TKE available for mechanical entrainment to the natural "//&
                  "Ekman depth.", units="nondim", default=2.5)
   call get_param(param_file, mdl, "NSTAR2", CS%nstar2, &
-                 "The portion of any potential energy released by \n"//&
-                 "convective adjustment that is available to drive \n"//&
-                 "entrainment at the base of mixed layer. By default \n"//&
+                 "The portion of any potential energy released by "//&
+                 "convective adjustment that is available to drive "//&
+                 "entrainment at the base of mixed layer. By default "//&
                  "NSTAR2=NSTAR.", units="nondim", default=CS%nstar)
   call get_param(param_file, mdl, "BULK_RI_CONVECTIVE", CS%bulk_Ri_convective, &
-                 "The efficiency with which convectively released mean \n"//&
-                 "kinetic energy is converted to turbulent kinetic \n"//&
+                 "The efficiency with which convectively released mean "//&
+                 "kinetic energy is converted to turbulent kinetic "//&
                  "energy.  By default BULK_RI_CONVECTIVE=BULK_RI_ML.", &
                  units="nondim", default=CS%bulk_Ri_ML)
   call get_param(param_file, mdl, "HMIX_MIN", CS%Hmix_min, &
-                 "The minimum mixed layer depth if the mixed layer depth \n"//&
+                 "The minimum mixed layer depth if the mixed layer depth "//&
                  "is determined dynamically.", units="m", default=0.0, scale=GV%m_to_H, &
                  unscaled=Hmix_min_m)
 
   call get_param(param_file, mdl, "LIMIT_BUFFER_DETRAIN", CS%limit_det, &
-                 "If true, limit the detrainment from the buffer layers \n"//&
+                 "If true, limit the detrainment from the buffer layers "//&
                  "to not be too different from the neighbors.", default=.false.)
   call get_param(param_file, mdl, "ALLOWED_DETRAIN_TEMP_CHG", CS%Allowed_T_chg, &
-                 "The amount by which temperature is allowed to exceed \n"//&
+                 "The amount by which temperature is allowed to exceed "//&
                  "previous values during detrainment.", units="K", default=0.5)
   call get_param(param_file, mdl, "ALLOWED_DETRAIN_SALT_CHG", CS%Allowed_S_chg, &
-                 "The amount by which salinity is allowed to exceed \n"//&
+                 "The amount by which salinity is allowed to exceed "//&
                  "previous values during detrainment.", units="PSU", default=0.1)
   call get_param(param_file, mdl, "ML_DT_DS_WEIGHT", CS%dT_dS_wt, &
-                 "When forced to extrapolate T & S to match the layer \n"//&
-                 "densities, this factor (in deg C / PSU) is combined \n"//&
-                 "with the derivatives of density with T & S to determine \n"//&
-                 "what direction is orthogonal to density contours. It \n"//&
-                 "should be a typical value of (dR/dS) / (dR/dT) in \n"//&
+                 "When forced to extrapolate T & S to match the layer "//&
+                 "densities, this factor (in deg C / PSU) is combined "//&
+                 "with the derivatives of density with T & S to determine "//&
+                 "what direction is orthogonal to density contours. It "//&
+                 "should be a typical value of (dR/dS) / (dR/dT) in "//&
                  "oceanic profiles.", units="degC PSU-1", default=6.0)
   call get_param(param_file, mdl, "BUFFER_LAYER_EXTRAP_LIMIT", CS%BL_extrap_lim, &
-                 "A limit on the density range over which extrapolation \n"//&
-                 "can occur when detraining from the buffer layers, \n"//&
-                 "relative to the density range within the mixed and \n"//&
-                 "buffer layers, when the detrainment is going into the \n"//&
-                 "lightest interior layer, nondimensional, or a negative \n"//&
+                 "A limit on the density range over which extrapolation "//&
+                 "can occur when detraining from the buffer layers, "//&
+                 "relative to the density range within the mixed and "//&
+                 "buffer layers, when the detrainment is going into the "//&
+                 "lightest interior layer, nondimensional, or a negative "//&
                  "value not to apply this limit.", units="nondim", default = -1.0)
   call get_param(param_file, mdl, "DEPTH_LIMIT_FLUXES", CS%H_limit_fluxes, &
-                 "The surface fluxes are scaled away when the total ocean \n"//&
+                 "The surface fluxes are scaled away when the total ocean "//&
                  "depth is less than DEPTH_LIMIT_FLUXES.", &
                  units="m", default=0.1*Hmix_min_m, scale=GV%m_to_H)
   call get_param(param_file, mdl, "OMEGA",CS%omega, &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5)
   call get_param(param_file, mdl, "ML_USE_OMEGA", use_omega, &
-                 "If true, use the absolute rotation rate instead of the \n"//&
-                 "vertical component of rotation when setting the decay \n"//&
+                 "If true, use the absolute rotation rate instead of the "//&
+                 "vertical component of rotation when setting the decay "//&
                  "scale for turbulence.", default=.false., do_not_log=.true.)
   omega_frac_dflt = 0.0
   if (use_omega) then
@@ -3511,58 +3511,58 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
     omega_frac_dflt = 1.0
   endif
   call get_param(param_file, mdl, "ML_OMEGA_FRAC", CS%omega_frac, &
-                 "When setting the decay scale for turbulence, use this \n"//&
-                 "fraction of the absolute rotation rate blended with the \n"//&
+                 "When setting the decay scale for turbulence, use this "//&
+                 "fraction of the absolute rotation rate blended with the "//&
                  "local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).", &
                  units="nondim", default=omega_frac_dflt)
   call get_param(param_file, mdl, "ML_RESORT", CS%ML_resort, &
-                 "If true, resort the topmost layers by potential density \n"//&
+                 "If true, resort the topmost layers by potential density "//&
                  "before the mixed layer calculations.", default=.false.)
   if (CS%ML_resort) &
     call get_param(param_file, mdl, "ML_PRESORT_NK_CONV_ADJ", CS%ML_presort_nz_conv_adj, &
-                 "Convectively mix the first ML_PRESORT_NK_CONV_ADJ \n"//&
+                 "Convectively mix the first ML_PRESORT_NK_CONV_ADJ "//&
                  "layers before sorting when ML_RESORT is true.", &
                  units="nondim", default=0, fail_if_missing=.true.) ! Fail added by AJA.
   ! This gives a minimum decay scale that is typically much less than Angstrom.
   ustar_min_dflt = 2e-4*CS%omega*(GV%Angstrom_m + GV%H_to_m*GV%H_subroundoff)
   call get_param(param_file, mdl, "BML_USTAR_MIN", CS%ustar_min, &
-                 "The minimum value of ustar that should be used by the \n"//&
-                 "bulk mixed layer model in setting vertical TKE decay \n"//&
+                 "The minimum value of ustar that should be used by the "//&
+                 "bulk mixed layer model in setting vertical TKE decay "//&
                  "scales. This must be greater than 0.", units="m s-1", &
                  default=ustar_min_dflt, scale=US%m_to_Z)
   if (CS%ustar_min<=0.0) call MOM_error(FATAL, "BML_USTAR_MIN must be positive.")
 
   call get_param(param_file, mdl, "RESOLVE_EKMAN", CS%Resolve_Ekman, &
-                 "If true, the NKML>1 layers in the mixed layer are \n"//&
-                 "chosen to optimally represent the impact of the Ekman \n"//&
-                 "transport on the mixed layer TKE budget.  Otherwise, \n"//&
-                 "the sublayers are distributed uniformly through the \n"//&
+                 "If true, the NKML>1 layers in the mixed layer are "//&
+                 "chosen to optimally represent the impact of the Ekman "//&
+                 "transport on the mixed layer TKE budget.  Otherwise, "//&
+                 "the sublayers are distributed uniformly through the "//&
                  "mixed layer.", default=.false.)
   call get_param(param_file, mdl, "CORRECT_ABSORPTION_DEPTH", CS%correct_absorption, &
-                 "If true, the average depth at which penetrating shortwave \n"//&
-                 "radiation is absorbed is adjusted to match the average \n"//&
-                 "heating depth of an exponential profile by moving some \n"//&
+                 "If true, the average depth at which penetrating shortwave "//&
+                 "radiation is absorbed is adjusted to match the average "//&
+                 "heating depth of an exponential profile by moving some "//&
                  "of the heating upward in the water column.", default=.false.)
   call get_param(param_file, mdl, "DO_RIVERMIX", CS%do_rivermix, &
-                 "If true, apply additional mixing wherever there is \n"//&
-                 "runoff, so that it is mixed down to RIVERMIX_DEPTH, \n"//&
+                 "If true, apply additional mixing wherever there is "//&
+                 "runoff, so that it is mixed down to RIVERMIX_DEPTH, "//&
                  "if the ocean is that deep.", default=.false.)
   if (CS%do_rivermix) &
     call get_param(param_file, mdl, "RIVERMIX_DEPTH", CS%rivermix_depth, &
-                 "The depth to which rivers are mixed if DO_RIVERMIX is \n"//&
+                 "The depth to which rivers are mixed if DO_RIVERMIX is "//&
                  "defined.", units="m", default=0.0, scale=US%m_to_Z)
   call get_param(param_file, mdl, "USE_RIVER_HEAT_CONTENT", CS%use_river_heat_content, &
-                 "If true, use the fluxes%runoff_Hflx field to set the \n"//&
+                 "If true, use the fluxes%runoff_Hflx field to set the "//&
                  "heat carried by runoff, instead of using SST*CP*liq_runoff.", &
                  default=.false.)
   call get_param(param_file, mdl, "USE_CALVING_HEAT_CONTENT", CS%use_calving_heat_content, &
-                 "If true, use the fluxes%calving_Hflx field to set the \n"//&
+                 "If true, use the fluxes%calving_Hflx field to set the "//&
                  "heat carried by runoff, instead of using SST*CP*froz_runoff.", &
                  default=.false.)
 
   call get_param(param_file, mdl, "ALLOW_CLOCKS_IN_OMP_LOOPS", &
                  CS%allow_clocks_in_omp_loops, &
-                 "If true, clocks can be called from inside loops that can \n"//&
+                 "If true, clocks can be called from inside loops that can "//&
                  "be threaded. To run with multiple threads, set to False.", &
                  default=.true.)
 
@@ -3602,17 +3602,17 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
  !CS%lim_det_dH_sfc = 0.5 ; CS%lim_det_dH_bathy = 0.2 ! Technically these should not get used if limit_det is false?
   if (CS%limit_det .or. (CS%id_Hsfc_min > 0)) then
     call get_param(param_file, mdl, "LIMIT_BUFFER_DET_DH_SFC", CS%lim_det_dH_sfc, &
-                 "The fractional limit in the change between grid points \n"//&
+                 "The fractional limit in the change between grid points "//&
                  "of the surface region (mixed & buffer layer) thickness.", &
                  units="nondim", default=0.5)
     call get_param(param_file, mdl, "LIMIT_BUFFER_DET_DH_BATHY", CS%lim_det_dH_bathy, &
-                 "The fraction of the total depth by which the thickness \n"//&
-                 "of the surface region (mixed & buffer layer) is allowed \n"//&
+                 "The fraction of the total depth by which the thickness "//&
+                 "of the surface region (mixed & buffer layer) is allowed "//&
                  "to change between grid points.", units="nondim", default=0.2)
   endif
 
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", use_temperature, &
-                 "If true, temperature and salinity are used as state \n"//&
+                 "If true, temperature and salinity are used as state "//&
                  "variables.", default=.true.)
   CS%nsw = 0
   if (use_temperature) then

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -1337,31 +1337,31 @@ subroutine diabatic_aux_init(Time, G, GV, US, param_file, diag, CS, useALEalgori
                    "The following parameters are used for auxiliary diabatic processes.")
 
   call get_param(param_file, mdl, "RECLAIM_FRAZIL", CS%reclaim_frazil, &
-                 "If true, try to use any frazil heat deficit to cool any\n"//&
-                 "overlying layers down to the freezing point, thereby \n"//&
-                 "avoiding the creation of thin ice when the SST is above \n"//&
+                 "If true, try to use any frazil heat deficit to cool any "//&
+                 "overlying layers down to the freezing point, thereby "//&
+                 "avoiding the creation of thin ice when the SST is above "//&
                  "the freezing point.", default=.true.)
   call get_param(param_file, mdl, "PRESSURE_DEPENDENT_FRAZIL", &
                                 CS%pressure_dependent_frazil, &
-                 "If true, use a pressure dependent freezing temperature \n"//&
-                 "when making frazil. The default is false, which will be \n"//&
+                 "If true, use a pressure dependent freezing temperature "//&
+                 "when making frazil. The default is false, which will be "//&
                  "faster but is inappropriate with ice-shelf cavities.", &
                  default=.false.)
 
   if (use_ePBL) then
     call get_param(param_file, mdl, "IGNORE_FLUXES_OVER_LAND", CS%ignore_fluxes_over_land,&
-         "If true, the model does not check if fluxes are being applied\n"//&
-         "over land points. This is needed when the ocean is coupled \n"//&
-         "with ice shelves and sea ice, since the sea ice mask needs to \n"//&
-         "be different than the ocean mask to avoid sea ice formation \n"//&
+         "If true, the model does not check if fluxes are being applied "//&
+         "over land points. This is needed when the ocean is coupled "//&
+         "with ice shelves and sea ice, since the sea ice mask needs to "//&
+         "be different than the ocean mask to avoid sea ice formation "//&
          "under ice shelves. This flag only works when use_ePBL = True.", default=.false.)
     call get_param(param_file, mdl, "DO_RIVERMIX", CS%do_rivermix, &
-                 "If true, apply additional mixing wherever there is \n"//&
-                 "runoff, so that it is mixed down to RIVERMIX_DEPTH \n"//&
+                 "If true, apply additional mixing wherever there is "//&
+                 "runoff, so that it is mixed down to RIVERMIX_DEPTH "//&
                  "if the ocean is that deep.", default=.false.)
     if (CS%do_rivermix) &
       call get_param(param_file, mdl, "RIVERMIX_DEPTH", CS%rivermix_depth, &
-                 "The depth to which rivers are mixed if DO_RIVERMIX is \n"//&
+                 "The depth to which rivers are mixed if DO_RIVERMIX is "//&
                  "defined.", units="m", default=0.0, scale=US%m_to_Z)
   else
     CS%do_rivermix = .false. ; CS%rivermix_depth = 0.0 ; CS%ignore_fluxes_over_land = .false.
@@ -1369,11 +1369,11 @@ subroutine diabatic_aux_init(Time, G, GV, US, param_file, diag, CS, useALEalgori
 
   if (GV%nkml == 0) then
     call get_param(param_file, mdl, "USE_RIVER_HEAT_CONTENT", CS%use_river_heat_content, &
-                   "If true, use the fluxes%runoff_Hflx field to set the \n"//&
+                   "If true, use the fluxes%runoff_Hflx field to set the "//&
                    "heat carried by runoff, instead of using SST*CP*liq_runoff.", &
                    default=.false.)
     call get_param(param_file, mdl, "USE_CALVING_HEAT_CONTENT", CS%use_calving_heat_content, &
-                   "If true, use the fluxes%calving_Hflx field to set the \n"//&
+                   "If true, use the fluxes%calving_Hflx field to set the "//&
                    "heat carried by runoff, instead of using SST*CP*froz_runoff.", &
                    default=.false.)
   else

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -2825,27 +2825,27 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   call log_version(param_file, mdl, version, &
                    "The following parameters are used for diabatic processes.")
   call get_param(param_file, mdl, "SPONGE", CS%use_sponge, &
-                 "If true, sponges may be applied anywhere in the domain. \n"//&
-                 "The exact location and properties of those sponges are \n"//&
-                 "specified via calls to initialize_sponge and possibly \n"//&
+                 "If true, sponges may be applied anywhere in the domain. "//&
+                 "The exact location and properties of those sponges are "//&
+                 "specified via calls to initialize_sponge and possibly "//&
                  "set_up_sponge_field.", default=.false.)
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", use_temperature, &
-                 "If true, temperature and salinity are used as state \n"//&
+                 "If true, temperature and salinity are used as state "//&
                  "variables.", default=.true.)
   call get_param(param_file, mdl, "ENERGETICS_SFC_PBL", CS%use_energetic_PBL, &
-                 "If true, use an implied energetics planetary boundary \n"//&
-                 "layer scheme to determine the diffusivity and viscosity \n"//&
+                 "If true, use an implied energetics planetary boundary "//&
+                 "layer scheme to determine the diffusivity and viscosity "//&
                  "in the surface boundary layer.", default=.false.)
   call get_param(param_file, mdl, "EPBL_IS_ADDITIVE", CS%ePBL_is_additive, &
-                 "If true, the diffusivity from ePBL is added to all\n"//&
-                 "other diffusivities. Otherwise, the larger of kappa-\n"//&
-                 "shear and ePBL diffusivities are used.", default=.true.)
+                 "If true, the diffusivity from ePBL is added to all "//&
+                 "other diffusivities. Otherwise, the larger of kappa-shear "//&
+                 "and ePBL diffusivities are used.", default=.true.)
   call get_param(param_file, mdl, "DOUBLE_DIFFUSION", differentialDiffusion, &
                  "If true, apply parameterization of double-diffusion.", &
                  default=.false. )
   call get_param(param_file, mdl, "USE_KPP", CS%use_KPP, &
-                 "If true, turns on the [CVMix] KPP scheme of Large et al., 1994,\n"// &
-                 "to calculate diffusivities and non-local transport in the OBL.",     &
+                 "If true, turns on the [CVMix] KPP scheme of Large et al., 1994, "//&
+                 "to calculate diffusivities and non-local transport in the OBL.", &
                  default=.false., do_not_log=.true.)
   CS%use_CVMix_ddiff = CVMix_ddiff_is_used(param_file)
 
@@ -2860,7 +2860,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
   if (CS%bulkmixedlayer) then
     call get_param(param_file, mdl, "ML_MIX_FIRST", CS%ML_mix_first, &
-                 "The fraction of the mixed layer mixing that is applied \n"//&
+                 "The fraction of the mixed layer mixing that is applied "//&
                  "before interior diapycnal mixing.  0 by default.", &
                  units="nondim", default=0.0)
     call get_param(param_file, mdl, "NKBL", CS%nkbl, default=2, do_not_log=.true.)
@@ -2874,13 +2874,13 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
     CS%use_geothermal = .false.
   endif
   call get_param(param_file, mdl, "INTERNAL_TIDES", CS%use_int_tides, &
-                 "If true, use the code that advances a separate set of \n"//&
+                 "If true, use the code that advances a separate set of "//&
                  "equations for the internal tide energy density.", default=.false.)
   CS%nMode = 1
   if (CS%use_int_tides) then
     ! SET NUMBER OF MODES TO CONSIDER
     call get_param(param_file, mdl, "INTERNAL_TIDE_MODES", CS%nMode, &
-                 "The number of distinct internal tide modes \n"//&
+                 "The number of distinct internal tide modes "//&
                  "that will be calculated.", default=1, do_not_log=.true.)
 
     ! The following parameters are used in testing the internal tide code.
@@ -2909,17 +2909,17 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
   call get_param(param_file, mdl, "MASSLESS_MATCH_TARGETS", &
                                 CS%massless_match_targets, &
-                 "If true, the temperature and salinity of massless layers \n"//&
-                 "are kept consistent with their target densities. \n"//&
-                 "Otherwise the properties of massless layers evolve \n"//&
+                 "If true, the temperature and salinity of massless layers "//&
+                 "are kept consistent with their target densities. "//&
+                 "Otherwise the properties of massless layers evolve "//&
                  "diffusively to match massive neighboring layers.", &
                  default=.true.)
 
   call get_param(param_file, mdl, "AGGREGATE_FW_FORCING", CS%aggregate_FW_forcing, &
-                 "If true, the net incoming and outgoing fresh water fluxes are combined \n"//&
-                 "and applied as either incoming or outgoing depending on the sign of the net. \n"//&
-                 "If false, the net incoming fresh water flux is added to the model and \n"//&
-                 "thereafter the net outgoing is removed from the topmost non-vanished \n"//&
+                 "If true, the net incoming and outgoing fresh water fluxes are combined "//&
+                 "and applied as either incoming or outgoing depending on the sign of the net. "//&
+                 "If false, the net incoming fresh water flux is added to the model and "//&
+                 "thereafter the net outgoing is removed from the topmost non-vanished "//&
                  "layers of the updated state.", default=.true.)
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
@@ -2932,36 +2932,36 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   call get_param(param_file, mdl, "DEBUG_ENERGY_REQ", CS%debug_energy_req, &
                  "If true, debug the energy requirements.", default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "MIX_BOUNDARY_TRACERS", CS%mix_boundary_tracers, &
-                 "If true, mix the passive tracers in massless layers at \n"//&
-                 "the bottom into the interior as though a diffusivity of \n"//&
+                 "If true, mix the passive tracers in massless layers at "//&
+                 "the bottom into the interior as though a diffusivity of "//&
                  "KD_MIN_TR were operating.", default=.true.)
 
   if (CS%mix_boundary_tracers) then
     call get_param(param_file, mdl, "KD", Kd, fail_if_missing=.true.)
     call get_param(param_file, mdl, "KD_MIN_TR", CS%Kd_min_tr, &
-                 "A minimal diffusivity that should always be applied to \n"//&
-                 "tracers, especially in massless layers near the bottom. \n"//&
+                 "A minimal diffusivity that should always be applied to "//&
+                 "tracers, especially in massless layers near the bottom. "//&
                  "The default is 0.1*KD.", units="m2 s-1", default=0.1*Kd, scale=US%m_to_Z**2)
     call get_param(param_file, mdl, "KD_BBL_TR", CS%Kd_BBL_tr, &
-                 "A bottom boundary layer tracer diffusivity that will \n"//&
-                 "allow for explicitly specified bottom fluxes. The \n"//&
-                 "entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt) \n"//&
+                 "A bottom boundary layer tracer diffusivity that will "//&
+                 "allow for explicitly specified bottom fluxes. The "//&
+                 "entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt) "//&
                  "over the same distance.", units="m2 s-1", default=0., scale=US%m_to_Z**2)
   endif
 
   call get_param(param_file, mdl, "TRACER_TRIDIAG", CS%tracer_tridiag, &
-                 "If true, use the passive tracer tridiagonal solver for T and S\n", &
+                 "If true, use the passive tracer tridiagonal solver for T and S", &
                  default=.false.)
 
   call get_param(param_file, mdl, "MINIMUM_FORCING_DEPTH", CS%minimum_forcing_depth, &
-                 "The smallest depth over which forcing can be applied. This\n"//&
-                 "only takes effect when near-surface layers become thin\n"//&
-                 "relative to this scale, in which case the forcing tendencies\n"//&
+                 "The smallest depth over which forcing can be applied. This "//&
+                 "only takes effect when near-surface layers become thin "//&
+                 "relative to this scale, in which case the forcing tendencies "//&
                  "scaled down by distributing the forcing over this depth scale.", &
                  units="m", default=0.001)
   call get_param(param_file, mdl, "EVAP_CFL_LIMIT", CS%evap_CFL_limit, &
-                 "The largest fraction of a layer than can be lost to forcing\n"//&
-                 "(e.g. evaporation, sea-ice formation) in one time-step. The unused\n"//&
+                 "The largest fraction of a layer than can be lost to forcing "//&
+                 "(e.g. evaporation, sea-ice formation) in one time-step. The unused "//&
                  "mass loss is passed down through the column.", &
                  units="nondim", default=0.8)
 
@@ -3032,12 +3032,12 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   CS%id_MLD_user = register_diag_field('ocean_model','MLD_user',diag%axesT1,Time, &
       'Mixed layer depth (used defined)', 'm', conversion=US%Z_to_m)
   call get_param(param_file, mdl, "DIAG_MLD_DENSITY_DIFF", CS%MLDdensityDifference, &
-                 "The density difference used to determine a diagnostic mixed\n"//&
-                 "layer depth, MLD_user, following the definition of Levitus 1982. \n"//&
-                 "The MLD is the depth at which the density is larger than the\n"//&
+                 "The density difference used to determine a diagnostic mixed "//&
+                 "layer depth, MLD_user, following the definition of Levitus 1982. "//&
+                 "The MLD is the depth at which the density is larger than the "//&
                  "surface density by the specified amount.", units='kg/m3', default=0.1)
   call get_param(param_file, mdl, "DIAG_DEPTH_SUBML_N2", CS%dz_subML_N2, &
-                 "The distance over which to calculate a diagnostic of the \n"//&
+                 "The distance over which to calculate a diagnostic of the "//&
                  "stratification at the base of the mixed layer.", &
                  units='m', default=50.0, scale=US%m_to_Z)
 
@@ -3123,7 +3123,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   endif
 
   call get_param(param_file, mdl, "SALT_REJECT_BELOW_ML", CS%salt_reject_below_ML, &
-                 "If true, place salt from brine rejection below the mixed layer,\n"// &
+                 "If true, place salt from brine rejection below the mixed layer, "// &
                  "into the first non-vanished layer for which the column remains stable", &
                  default=.false.)
 

--- a/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
+++ b/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
@@ -1291,14 +1291,14 @@ subroutine diapyc_energy_req_init(Time, G, GV, US, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ENERGY_REQ_KH_SCALING", CS%test_Kh_scaling, &
-                 "A scaling factor for the diapycnal diffusivity used in \n"//&
+                 "A scaling factor for the diapycnal diffusivity used in "//&
                  "testing the energy requirements.", default=1.0, units="nondim")
   call get_param(param_file, mdl, "ENERGY_REQ_COL_HT_SCALING", CS%ColHt_scaling, &
-                 "A scaling factor for the column height change correction \n"//&
+                 "A scaling factor for the column height change correction "//&
                  "used in testing the energy requirements.", default=1.0, units="nondim")
   call get_param(param_file, mdl, "ENERGY_REQ_USE_TEST_PROFILE", &
                  CS%use_test_Kh_profile, &
-                 "If true, use the internal test diffusivity profile in \n"//&
+                 "If true, use the internal test diffusivity profile in "//&
                  "place of any that might be passed in as an argument.", default=.false.)
 
   CS%id_ERt = register_diag_field('ocean_model', 'EnReqTest_ERt', diag%axesZi, Time, &

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -2048,68 +2048,68 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
                  "    2 for MSTAR w/ L_E/L_O in stabilizing limit.",&
                  "units=nondim",default=0)
   call get_param(param_file, mdl, "MSTAR", CS%mstar, &
-                 "The ratio of the friction velocity cubed to the TKE \n"//&
+                 "The ratio of the friction velocity cubed to the TKE "//&
                  "input to the mixed layer.", "units=nondim", default=1.2)
   call get_param(param_file, mdl, "MIX_LEN_EXPONENT", CS%MixLenExponent, &
-                 "The exponent applied to the ratio of the distance to the MLD \n"//&
+                 "The exponent applied to the ratio of the distance to the MLD "//&
                  "and the MLD depth which determines the shape of the mixing length.",&
                  "units=nondim", default=2.0)
   call get_param(param_file, mdl, "MSTAR_CAP", CS%mstar_cap, &
-                 "Maximum value of mstar allowed in model if non-negative\n"//&
+                 "Maximum value of mstar allowed in model if non-negative "//&
                  "(used if MSTAR_MODE>0).",&
                  "units=nondim", default=-1.0)
   call get_param(param_file, mdl, "MSTAR_CONV_ADJ", CS%cnv_mst_fac, &
-                 "Factor used for reducing mstar during convection \n"//&
-                 " due to reduction of stable density gradient.",&
+                 "Factor used for reducing mstar during convection "//&
+                 "due to reduction of stable density gradient.",&
                  "units=nondim", default=0.0)
   call get_param(param_file, mdl, "MSTAR_SLOPE", CS%mstar_slope, &
-                 "The slope of the linear relationship between mstar \n"//&
+                 "The slope of the linear relationship between mstar "//&
                  "and the length scale ratio (used if MSTAR_MODE=1).",&
                  "units=nondim", default=0.85)
   call get_param(param_file, mdl, "MSTAR_XINT", CS%mstar_xint, &
-                 "The value of the length scale ratio where the mstar \n"//&
+                 "The value of the length scale ratio where the mstar "//&
                  "is linear above (used if MSTAR_MODE=1).",&
                  "units=nondim", default=-0.3)
   call get_param(param_file, mdl, "MSTAR_AT_XINT", CS%mstar_at_xint, &
-                 "The value of mstar at MSTAR_XINT \n"//&
+                 "The value of mstar at MSTAR_XINT "//&
                  "(used if MSTAR_MODE=1).",&
                  "units=nondim", default=0.095)
   call get_param(param_file, mdl, "MSTAR_FLATCAP", CS%MSTAR_FLATCAP, &
-                 "Set false to use asymptotic cap, defaults to true.\n"//&
+                 "Set false to use asymptotic cap, defaults to true. "//&
                  "(used only if MSTAR_MODE=1)"&
                  ,"units=nondim",default=.true.)
   call get_param(param_file, mdl, "MSTAR2_COEF1", CS%MSTAR_COEF, &
-                 "Coefficient in computing mstar when rotation and \n"//&
-                 " stabilizing effects are both important (used if MSTAR_MODE=2)"&
+                 "Coefficient in computing mstar when rotation and "//&
+                 "stabilizing effects are both important (used if MSTAR_MODE=2)"&
                   ,"units=nondim",default=0.3)
   call get_param(param_file, mdl, "MSTAR2_COEF2", CS%C_EK, &
-                 "Coefficient in computing mstar when only rotation limits \n"//&
-                 " the total mixing. (used only if MSTAR_MODE=2)"&
+                 "Coefficient in computing mstar when only rotation limits "//&
+                 "the total mixing. (used only if MSTAR_MODE=2)"&
                   ,"units=nondim",default=0.085)
   call get_param(param_file, mdl, "NSTAR", CS%nstar, &
-                 "The portion of the buoyant potential energy imparted by \n"//&
-                 "surface fluxes that is available to drive entrainment \n"//&
+                 "The portion of the buoyant potential energy imparted by "//&
+                 "surface fluxes that is available to drive entrainment "//&
                  "at the base of mixed layer when that energy is positive.", &
                  units="nondim", default=0.2)
   call get_param(param_file, mdl, "MKE_TO_TKE_EFFIC", CS%MKE_to_TKE_effic, &
-                 "The efficiency with which mean kinetic energy released \n"//&
-                 "by mechanically forced entrainment of the mixed layer \n"//&
+                 "The efficiency with which mean kinetic energy released "//&
+                 "by mechanically forced entrainment of the mixed layer "//&
                  "is converted to turbulent kinetic energy.", units="nondim", &
                  default=0.0)
   call get_param(param_file, mdl, "TKE_DECAY", CS%TKE_decay, &
-                 "TKE_DECAY relates the vertical rate of decay of the \n"//&
-                 "TKE available for mechanical entrainment to the natural \n"//&
+                 "TKE_DECAY relates the vertical rate of decay of the "//&
+                 "TKE available for mechanical entrainment to the natural "//&
                  "Ekman depth.", units="nondim", default=2.5)
 !  call get_param(param_file, mdl, "HMIX_MIN", CS%Hmix_min, &
-!                 "The minimum mixed layer depth if the mixed layer depth \n"//&
+!                 "The minimum mixed layer depth if the mixed layer depth "//&
 !                 "is determined dynamically.", units="m", default=0.0)
 
   call get_param(param_file, mdl, "OMEGA",CS%omega,              &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5)
   call get_param(param_file, mdl, "ML_USE_OMEGA", use_omega,                  &
-                 "If true, use the absolute rotation rate instead of the \n"//&
-                 "vertical component of rotation when setting the decay \n"// &
+                 "If true, use the absolute rotation rate instead of the "//&
+                 "vertical component of rotation when setting the decay "// &
                  "scale for turbulence.", default=.false., do_not_log=.true.)
   omega_frac_dflt = 0.0
   if (use_omega) then
@@ -2117,51 +2117,51 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
     omega_frac_dflt = 1.0
   endif
   call get_param(param_file, mdl, "ML_OMEGA_FRAC", CS%omega_frac,              &
-                 "When setting the decay scale for turbulence, use this \n"//  &
-                 "fraction of the absolute rotation rate blended with the \n"//&
+                 "When setting the decay scale for turbulence, use this "//  &
+                 "fraction of the absolute rotation rate blended with the "//&
                  "local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).",      &
                  units="nondim", default=omega_frac_dflt)
   call get_param(param_file, mdl, "WSTAR_USTAR_COEF", CS%wstar_ustar_coef,     &
-                 "A ratio relating the efficiency with which convectively \n"//&
-                 "released energy is converted to a turbulent velocity, \n"//  &
-                 "relative to mechanically forced TKE. Making this larger \n"//&
+                 "A ratio relating the efficiency with which convectively "//&
+                 "released energy is converted to a turbulent velocity, "//  &
+                 "relative to mechanically forced TKE. Making this larger "//&
                  "increases the BL diffusivity", units="nondim", default=1.0)
   call get_param(param_file, mdl, "VSTAR_SCALE_FACTOR", CS%vstar_scale_fac, &
-                 "An overall nondimensional scaling factor for v*. \n"//    &
+                 "An overall nondimensional scaling factor for v*. "//    &
                  "Making this larger decreases the PBL diffusivity.",       &
                  units="nondim", default=1.0, scale=US%m_to_Z)
   call get_param(param_file, mdl, "EKMAN_SCALE_COEF", CS%Ekman_scale_coef,           &
-                 "A nondimensional scaling factor controlling the inhibition \n"//   &
-                 "of the diffusive length scale by rotation. Making this larger \n"//&
+                 "A nondimensional scaling factor controlling the inhibition "//   &
+                 "of the diffusive length scale by rotation. Making this larger "//&
                  "decreases the PBL diffusivity.", units="nondim", default=1.0)
   call get_param(param_file, mdl, "USE_MLD_ITERATION", CS%USE_MLD_ITERATION,    &
-                 "A logical that specifies whether or not to use the \n"//      &
-                 "distance to the bottom of the actively turbulent boundary \n"//&
+                 "A logical that specifies whether or not to use the "//      &
+                 "distance to the bottom of the actively turbulent boundary "//&
                  "layer to help set the EPBL length scale.", default=.false.)
   call get_param(param_file, mdl, "ORIG_MLD_ITERATION", CS%ORIG_MLD_ITERATION,  &
-                 "A logical that specifies whether or not to use the \n"//      &
-                 "old method for determining MLD depth in iteration, which \n"//&
+                 "A logical that specifies whether or not to use the "//      &
+                 "old method for determining MLD depth in iteration, which "//&
                  "is limited to resolution.", default=.true.)
   call get_param(param_file, mdl, "MLD_ITERATION_GUESS", CS%MLD_ITERATION_GUESS,       &
-                 "A logical that specifies whether or not to use the \n"//             &
-                 "previous timestep MLD as a first guess in the MLD iteration.\n"//    &
+                 "A logical that specifies whether or not to use the "//             &
+                 "previous timestep MLD as a first guess in the MLD iteration. "//    &
                  "The default is false to facilitate reproducibility.", default=.false.)
   call get_param(param_file, mdl, "EPBL_MLD_TOLERANCE", CS%MLD_tol,         &
-                 "The tolerance for the iteratively determined mixed \n"//  &
+                 "The tolerance for the iteratively determined mixed "//  &
                  "layer depth.  This is only used with USE_MLD_ITERATION.", &
                  units="meter", default=1.0, scale=US%m_to_Z)
   call get_param(param_file, mdl, "EPBL_MIN_MIX_LEN", CS%min_mix_len,    &
-                 "The minimum mixing length scale that will be used \n"//&
+                 "The minimum mixing length scale that will be used "//&
                  "by ePBL.  The default (0) does not set a minimum.",    &
                  units="meter", default=0.0, scale=US%m_to_Z)
   call get_param(param_file, mdl, "EPBL_ORIGINAL_PE_CALC", CS%orig_PE_calc,         &
-                 "If true, the ePBL code uses the original form of the \n"//        &
-                 "potential energy change code.  Otherwise, the newer \n"//         &
-                 "version that can work with successive increments to the \n"//     &
+                 "If true, the ePBL code uses the original form of the "//        &
+                 "potential energy change code.  Otherwise, the newer "//         &
+                 "version that can work with successive increments to the "//     &
                  "diffusivity in upward or downward passes is used.", default=.true.)
   call get_param(param_file, mdl, "EPBL_TRANSITION_SCALE", CS%transLay_scale, &
-                 "A scale for the mixing length in the transition layer \n"// &
-                 "at the edge of the boundary layer as a fraction of the \n"//&
+                 "A scale for the mixing length in the transition layer "// &
+                 "at the edge of the boundary layer as a fraction of the "//&
                  "boundary layer thickness.  The default is 0.1.", &
                  units="nondim", default=0.1)
   if ( CS%USE_MLD_ITERATION .and. abs(CS%transLay_scale-0.5) >= 0.5) then
@@ -2169,19 +2169,18 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
                  "EPBL_TRANSITION should be greater than 0 and less than 1.")
   endif
   call get_param(param_file, mdl, "N2_DISSIPATION_POS", CS%N2_Dissipation_Scale_Pos, &
-                 "A scale for the dissipation of TKE due to stratification \n"//     &
-                 "in the boundary layer, applied when local stratification \n"//     &
+                 "A scale for the dissipation of TKE due to stratification "//     &
+                 "in the boundary layer, applied when local stratification "//     &
                  "is positive.  The default is 0, but should probably be ~0.4.",     &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "N2_DISSIPATION_NEG", CS%N2_Dissipation_Scale_Neg,&
-                 "A scale for the dissipation of TKE due to stratification \n"//    &
-                 "in the boundary layer, applied when local stratification \n"//    &
+                 "A scale for the dissipation of TKE due to stratification "//    &
+                 "in the boundary layer, applied when local stratification "//    &
                  "is negative.  The default is 0, but should probably be ~1.",      &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "USE_LA_LI2016", USE_LA_Windsea,      &
-       "A logical to use the Li et al. 2016 (submitted) formula to \n"//&
-       " determine the Langmuir number.",                               &
-       units="nondim", default=.false.)
+       "A logical to use the Li et al. 2016 (submitted) formula to "//&
+       "determine the Langmuir number.", units="nondim", default=.false.)
   ! Note this can be activated in other ways, but this preserves the old method.
   if (use_la_windsea) then
     CS%USE_LT = .true.
@@ -2206,30 +2205,30 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
          "Exponent for Langmuir enhancement if LT_ENHANCE > 1",          &
          units="nondim", default=-1.33)
     call get_param(param_file, mdl, "LT_MOD_LAC1", CS%LaC_MLDoEK,    &
-         "Coefficient for modification of Langmuir number due to\n"//&
-         " MLD approaching Ekman depth if LT_ENHANCE=2.",            &
+         "Coefficient for modification of Langmuir number due to "//&
+         "MLD approaching Ekman depth if LT_ENHANCE=2.",            &
          units="nondim", default=-0.87)
     call get_param(param_file, mdl, "LT_MOD_LAC2", CS%LaC_MLDoOB_stab, &
-         "Coefficient for modification of Langmuir number due to\n"//  &
-         " MLD approaching stable Obukhov depth if LT_ENHANCE=2.",     &
+         "Coefficient for modification of Langmuir number due to "//  &
+         "MLD approaching stable Obukhov depth if LT_ENHANCE=2.",     &
          units="nondim", default=0.0)
     call get_param(param_file, mdl, "LT_MOD_LAC3", CS%LaC_MLDoOB_un, &
-         "Coefficient for modification of Langmuir number due to\n"//&
-         " MLD approaching unstable Obukhov depth if LT_ENHANCE=2.", &
+         "Coefficient for modification of Langmuir number due to "//&
+         "MLD approaching unstable Obukhov depth if LT_ENHANCE=2.", &
          units="nondim", default=0.0)
     call get_param(param_file, mdl, "LT_MOD_LAC4", CS%Lac_EKoOB_stab, &
-         "Coefficient for modification of Langmuir number due to\n"// &
-         " ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.",  &
+         "Coefficient for modification of Langmuir number due to "// &
+         "ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.",  &
          units="nondim", default=0.95)
     call get_param(param_file, mdl, "LT_MOD_LAC5", CS%Lac_EKoOB_un,   &
-         "Coefficient for modification of Langmuir number due to\n"// &
-         " ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.",&
+         "Coefficient for modification of Langmuir number due to "// &
+         "ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.",&
          units="nondim", default=0.95)
   endif
   ! This gives a minimum decay scale that is typically much less than Angstrom.
   CS%ustar_min = 2e-4*CS%omega*(GV%Angstrom_Z + GV%H_to_Z*GV%H_subroundoff)
   call log_param(param_file, mdl, "EPBL_USTAR_MIN", CS%ustar_min*US%Z_to_m, &
-                 "The (tiny) minimum friction velocity used within the \n"//&
+                 "The (tiny) minimum friction velocity used within the "//&
                  "ePBL code, derived from OMEGA and ANGSTROM.", units="m s-1")
 
   CS%id_ML_depth = register_diag_field('ocean_model', 'ePBL_h_ML', diag%axesT1, &
@@ -2278,7 +2277,7 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
       Time, 'MSTAR applied for LT effect.', 'nondim')
 
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", use_temperature, &
-                 "If true, temperature and salinity are used as state \n"//&
+                 "If true, temperature and salinity are used as state "//&
                  "variables.", default=.true.)
 
   if (max(CS%id_TKE_wind, CS%id_TKE_MKE, CS%id_TKE_conv, &

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -2114,12 +2114,12 @@ subroutine entrain_diffusive_init(Time, G, GV, US, param_file, diag, CS)
 ! Set default, read and log parameters
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "CORRECT_DENSITY", CS%correct_density, &
-                 "If true, and USE_EOS is true, the layer densities are \n"//&
-                 "restored toward their target values by the diapycnal \n"//&
+                 "If true, and USE_EOS is true, the layer densities are "//&
+                 "restored toward their target values by the diapycnal "//&
                  "mixing, as described in Hallberg (MWR, 2000).", &
                  default=.true.)
   call get_param(param_file, mdl, "MAX_ENT_IT", CS%max_ent_it, &
-                 "The maximum number of iterations that may be used to \n"//&
+                 "The maximum number of iterations that may be used to "//&
                  "calculate the interior diapycnal entrainment.", default=5)
 ! In this module, KD is only used to set the default for TOLERANCE_ENT. [m2 s-1]
   call get_param(param_file, mdl, "KD", Kd, fail_if_missing=.true.)

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -341,8 +341,8 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
   ! write parameters to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "GEOTHERMAL_SCALE", scale, &
-                 "The constant geothermal heat flux, a rescaling \n"//&
-                 "factor for the heat flux read from GEOTHERMAL_FILE, or \n"//&
+                 "The constant geothermal heat flux, a rescaling "//&
+                 "factor for the heat flux read from GEOTHERMAL_FILE, or "//&
                  "0 to disable the geothermal heating.", &
                  units="W m-2 or various", default=0.0)
   CS%apply_geothermal = .not.(scale == 0.0)
@@ -351,14 +351,14 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
   call safe_alloc_ptr(CS%geo_heat, isd, ied, jsd, jed) ; CS%geo_heat(:,:) = 0.0
 
   call get_param(param_file, mdl, "GEOTHERMAL_FILE", geo_file, &
-                 "The file from which the geothermal heating is to be \n"//&
+                 "The file from which the geothermal heating is to be "//&
                  "read, or blank to use a constant heating rate.", default=" ")
   call get_param(param_file, mdl, "GEOTHERMAL_THICKNESS", CS%geothermal_thick, &
                  "The thickness over which to apply geothermal heating.", &
                  units="m", default=0.1)
   call get_param(param_file, mdl, "GEOTHERMAL_DRHO_DT_INPLACE", CS%dRcv_dT_inplace, &
-                 "The value of drho_dT above which geothermal heating \n"//&
-                 "simply heats water in place instead of moving it between \n"//&
+                 "The value of drho_dT above which geothermal heating "//&
+                 "simply heats water in place instead of moving it between "//&
                  "isopycnal layers.  This must be negative.", &
                  units="kg m-3 K-1",  default=-0.01)
   if (CS%dRcv_dT_inplace >= 0.0) call MOM_error(FATAL, "geothermal_init: "//&
@@ -370,7 +370,7 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
     filename = trim(inputdir)//trim(geo_file)
     call log_param(param_file, mdl, "INPUTDIR/GEOTHERMAL_FILE", filename)
     call get_param(param_file, mdl, "GEOTHERMAL_VARNAME", geotherm_var, &
-                 "The name of the geothermal heating variable in \n"//&
+                 "The name of the geothermal heating variable in "//&
                  "GEOTHERMAL_FILE.", default="geo_heat")
     call MOM_read_data(filename, trim(geotherm_var), CS%geo_heat, G%Domain)
     do j=jsd,jed ; do i=isd,ied

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -294,7 +294,7 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
 
   call get_param(param_file, mdl, "MIN_ZBOT_ITIDES", min_zbot_itides, &
-               "Turn off internal tidal dissipation when the total \n"//&
+               "Turn off internal tidal dissipation when the total "//&
                "ocean depth is less than this value.", units="m", default=0.0, scale=US%m_to_Z)
 
   call get_param(param_file, mdl, "UTIDE", utide, &
@@ -308,7 +308,7 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
   allocate(CS%TKE_itidal_coef(isd:ied,jsd:jed)) ; CS%TKE_itidal_coef(:,:) = 0.0
 
   call get_param(param_file, mdl, "KAPPA_ITIDES", kappa_itides, &
-               "A topographic wavenumber used with INT_TIDE_DISSIPATION. \n"//&
+               "A topographic wavenumber used with INT_TIDE_DISSIPATION. "//&
                "The default is 2pi/10 km, as in St.Laurent et al. 2002.", &
                units="m-1", default=8.e-4*atan(1.0))
 
@@ -316,16 +316,16 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
                "A scaling factor for the roughness amplitude with n"//&
                "INT_TIDE_DISSIPATION.",  units="nondim", default=1.0)
   call get_param(param_file, mdl, "TKE_ITIDE_MAX", CS%TKE_itide_max, &
-               "The maximum internal tide energy source available to mix \n"//&
+               "The maximum internal tide energy source available to mix "//&
                "above the bottom boundary layer with INT_TIDE_DISSIPATION.", &
                units="W m-2",  default=1.0e3)
 
   call get_param(param_file, mdl, "READ_TIDEAMP", read_tideamp, &
-               "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
+               "If true, read a file (given by TIDEAMP_FILE) containing "//&
                "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
   if (read_tideamp) then
     call get_param(param_file, mdl, "TIDEAMP_FILE", tideamp_file, &
-               "The path to the file containing the spatially varying \n"//&
+               "The path to the file containing the spatially varying "//&
                "tidal amplitudes with INT_TIDE_DISSIPATION.", default="tideamp.nc")
     filename = trim(CS%inputdir) // trim(tideamp_file)
     call log_param(param_file, mdl, "INPUTDIR/TIDEAMP_FILE", filename)
@@ -333,7 +333,7 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
   endif
 
   call get_param(param_file, mdl, "H2_FILE", h2_file, &
-               "The path to the file containing the sub-grid-scale \n"//&
+               "The path to the file containing the sub-grid-scale "//&
                "topographic roughness amplitude with INT_TIDE_DISSIPATION.", &
                fail_if_missing=.true.)
   filename = trim(CS%inputdir) // trim(h2_file)

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -2021,86 +2021,86 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
   call log_version(param_file, mdl, version, &
     "Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008")
   call get_param(param_file, mdl, "USE_JACKSON_PARAM", kappa_shear_init, &
-                 "If true, use the Jackson-Hallberg-Legg (JPO 2008) \n"//&
+                 "If true, use the Jackson-Hallberg-Legg (JPO 2008) "//&
                  "shear mixing parameterization.", default=.false.)
   call get_param(param_file, mdl, "VERTEX_SHEAR", CS%KS_at_vertex, &
-                 "If true, do the calculations of the shear-driven mixing \n"//&
+                 "If true, do the calculations of the shear-driven mixing "//&
                  "at the cell vertices (i.e., the vorticity points).", &
                  default=.false.)
   call get_param(param_file, mdl, "RINO_CRIT", CS%RiNo_crit, &
                  "The critical Richardson number for shear mixing.", &
                  units="nondim", default=0.25)
   call get_param(param_file, mdl, "SHEARMIX_RATE", CS%Shearmix_rate, &
-                 "A nondimensional rate scale for shear-driven entrainment.\n"//&
+                 "A nondimensional rate scale for shear-driven entrainment. "//&
                  "Jackson et al find values in the range of 0.085-0.089.", &
                  units="nondim", default=0.089)
   call get_param(param_file, mdl, "MAX_RINO_IT", CS%max_RiNo_it, &
-                 "The maximum number of iterations that may be used to \n"//&
+                 "The maximum number of iterations that may be used to "//&
                  "estimate the Richardson number driven mixing.", &
                  units="nondim", default=50)
   call get_param(param_file, mdl, "KD", KD_normal, default=1.0e-7, do_not_log=.true.)
   call get_param(param_file, mdl, "KD_KAPPA_SHEAR_0", CS%kappa_0, &
-                 "The background diffusivity that is used to smooth the \n"//&
-                 "density and shear profiles before solving for the \n"//&
+                 "The background diffusivity that is used to smooth the "//&
+                 "density and shear profiles before solving for the "//&
                  "diffusivities. Defaults to value of KD.", &
                  units="m2 s-1", default=KD_normal, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "FRI_CURVATURE", CS%FRi_curvature, &
-                 "The nondimensional curvature of the function of the \n"//&
-                 "Richardson number in the kappa source term in the \n"//&
+                 "The nondimensional curvature of the function of the "//&
+                 "Richardson number in the kappa source term in the "//&
                  "Jackson et al. scheme.", units="nondim", default=-0.97)
   call get_param(param_file, mdl, "TKE_N_DECAY_CONST", CS%C_N, &
-                 "The coefficient for the decay of TKE due to \n"//&
-                 "stratification (i.e. proportional to N*tke). \n"//&
+                 "The coefficient for the decay of TKE due to "//&
+                 "stratification (i.e. proportional to N*tke). "//&
                  "The values found by Jackson et al. are 0.24-0.28.", &
                  units="nondim", default=0.24)
 !  call get_param(param_file, mdl, "LAYER_KAPPA_STAGGER", CS%layer_stagger, &
 !                 default=.false.)
   call get_param(param_file, mdl, "TKE_SHEAR_DECAY_CONST", CS%C_S, &
-                 "The coefficient for the decay of TKE due to shear (i.e. \n"//&
-                 "proportional to |S|*tke). The values found by Jackson \n"//&
+                 "The coefficient for the decay of TKE due to shear (i.e. "//&
+                 "proportional to |S|*tke). The values found by Jackson "//&
                  "et al. are 0.14-0.12.", units="nondim", default=0.14)
   call get_param(param_file, mdl, "KAPPA_BUOY_SCALE_COEF", CS%lambda, &
-                 "The coefficient for the buoyancy length scale in the \n"//&
-                 "kappa equation.  The values found by Jackson et al. are \n"//&
+                 "The coefficient for the buoyancy length scale in the "//&
+                 "kappa equation.  The values found by Jackson et al. are "//&
                  "in the range of 0.81-0.86.", units="nondim", default=0.82)
   call get_param(param_file, mdl, "KAPPA_N_OVER_S_SCALE_COEF2", CS%lambda2_N_S, &
-                 "The square of the ratio of the coefficients of the \n"//&
-                 "buoyancy and shear scales in the diffusivity equation, \n"//&
-                 "Set this to 0 (the default) to eliminate the shear scale. \n"//&
+                 "The square of the ratio of the coefficients of the "//&
+                 "buoyancy and shear scales in the diffusivity equation, "//&
+                 "Set this to 0 (the default) to eliminate the shear scale. "//&
                  "This is only used if USE_JACKSON_PARAM is true.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "KAPPA_SHEAR_TOL_ERR", CS%kappa_tol_err, &
-                 "The fractional error in kappa that is tolerated. \n"//&
-                 "Iteration stops when changes between subsequent \n"//&
-                 "iterations are smaller than this everywhere in a \n"//&
-                 "column.  The peak diffusivities usually converge most \n"//&
+                 "The fractional error in kappa that is tolerated. "//&
+                 "Iteration stops when changes between subsequent "//&
+                 "iterations are smaller than this everywhere in a "//&
+                 "column.  The peak diffusivities usually converge most "//&
                  "rapidly, and have much smaller errors than this.", &
                  units="nondim", default=0.1)
   call get_param(param_file, mdl, "TKE_BACKGROUND", CS%TKE_bg, &
-                 "A background level of TKE used in the first iteration \n"//&
+                 "A background level of TKE used in the first iteration "//&
                  "of the kappa equation.  TKE_BACKGROUND could be 0.", &
                  units="m2 s-2", default=0.0)
   call get_param(param_file, mdl, "KAPPA_SHEAR_ELIM_MASSLESS", CS%eliminate_massless, &
-                 "If true, massless layers are merged with neighboring \n"//&
-                 "massive layers in this calculation.  The default is \n"//&
-                 "true and I can think of no good reason why it should \n"//&
+                 "If true, massless layers are merged with neighboring "//&
+                 "massive layers in this calculation.  The default is "//&
+                 "true and I can think of no good reason why it should "//&
                  "be false. This is only used if USE_JACKSON_PARAM is true.", &
                  default=.true.)
   call get_param(param_file, mdl, "MAX_KAPPA_SHEAR_IT", CS%max_KS_it, &
-                 "The maximum number of iterations that may be used to \n"//&
+                 "The maximum number of iterations that may be used to "//&
                  "estimate the time-averaged diffusivity.", units="nondim", &
                  default=13)
   call get_param(param_file, mdl, "PRANDTL_TURB", CS%Prandtl_turb, &
-                 "The turbulent Prandtl number applied to shear \n"//&
+                 "The turbulent Prandtl number applied to shear "//&
                  "instability.", units="nondim", default=1.0, do_not_log=.true.)
   call get_param(param_file, mdl, "VEL_UNDERFLOW", CS%vel_underflow, &
-                 "A negligibly small velocity magnitude below which velocity \n"//&
-                 "components are set to 0.  A reasonable value might be \n"//&
-                 "1e-30 m/s, which is less than an Angstrom divided by \n"//&
+                 "A negligibly small velocity magnitude below which velocity "//&
+                 "components are set to 0.  A reasonable value might be "//&
+                 "1e-30 m/s, which is less than an Angstrom divided by "//&
                  "the age of the universe.", units="m s-1", default=0.0)
   call get_param(param_file, mdl, "DEBUG_KAPPA_SHEAR", CS%debug, &
                  "If true, write debugging data for the kappa-shear code. \n"//&
-                 "Caution: this option is _very_ verbose and should only \n"//&
+                 "Caution: this option is _very_ verbose and should only "//&
                  "be used in single-column mode!", &
                  default=.false., debuggingParam=.true.)
 
@@ -2112,7 +2112,7 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
   CS%nkml = 1
   if (GV%nkml>0) then
     call get_param(param_file, mdl, "KAPPA_SHEAR_MERGE_ML",merge_mixedlayer, &
-                 "If true, combine the mixed layers together before \n"//&
+                 "If true, combine the mixed layers together before "//&
                  "solving the kappa-shear equations.", default=.true.)
     if (merge_mixedlayer) CS%nkml = GV%nkml
   endif
@@ -2160,7 +2160,7 @@ logical function kappa_shear_at_vertex(param_file)
   kappa_shear_at_vertex = .false.
   if (do_Kappa_Shear) &
     call get_param(param_file, mdl, "VERTEX_SHEAR", kappa_shear_at_vertex, &
-                 "If true, do the calculations of the shear-driven mixing \n"//&
+                 "If true, do the calculations of the shear-driven mixing "//&
                  "at the cell vertices (i.e., the vorticity points).", &
                  default=.false., do_not_log=.true.)
 

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -477,15 +477,15 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
 
 ! parameters for CHL_A routines
   call get_param(param_file, mdl, "VAR_PEN_SW", CS%var_pen_sw, &
-                 "If true, use one of the CHL_A schemes specified by \n"//&
-                 "OPACITY_SCHEME to determine the e-folding depth of \n"//&
+                 "If true, use one of the CHL_A schemes specified by "//&
+                 "OPACITY_SCHEME to determine the e-folding depth of "//&
                  "incoming short wave radiation.", default=.false.)
 
   CS%opacity_scheme = NO_SCHEME ; scheme_string = ''
   if (CS%var_pen_sw) then
     call get_param(param_file, mdl, "OPACITY_SCHEME", tmpstr, &
-                 "This character string specifies how chlorophyll \n"//&
-                 "concentrations are translated into opacities. Currently \n"//&
+                 "This character string specifies how chlorophyll "//&
+                 "concentrations are translated into opacities. Currently "//&
                  "valid options include:\n"//&
                  " \t\t  MANIZZA_05 - Use Manizza et al., GRL, 2005. \n"//&
                  " \t\t  MOREL_88 - Use Morel, JGR, 1988.", &
@@ -516,8 +516,8 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
 
       call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
       call get_param(param_file, mdl, "CHL_FILE", chl_file, &
-                 "CHL_FILE is the file containing chl_a concentrations in \n"//&
-                 "the variable CHL_A. It is used when VAR_PEN_SW and \n"//&
+                 "CHL_FILE is the file containing chl_a concentrations in "//&
+                 "the variable CHL_A. It is used when VAR_PEN_SW and "//&
                  "CHL_FROM_FILE are true.", fail_if_missing=.true.)
       filename = trim(slasher(inputdir))//trim(chl_file)
       call log_param(param_file, mdl, "INPUTDIR/CHL_FILE", filename)
@@ -527,12 +527,12 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
     endif
 
     call get_param(param_file, mdl, "BLUE_FRAC_SW", CS%blue_frac, &
-                 "The fraction of the penetrating shortwave radiation \n"//&
+                 "The fraction of the penetrating shortwave radiation "//&
                  "that is in the blue band.", default=0.5, units="nondim")
   else
     call get_param(param_file, mdl, "EXP_OPACITY_SCHEME", tmpstr, &
-                 "This character string specifies which exponential \n"//&
-                 "opacity scheme to utilize. Currently \n"//&
+                 "This character string specifies which exponential "//&
+                 "opacity scheme to utilize. Currently "//&
                  "valid options include:\n"//&
                  " \t\t  SINGLE_EXP - Single Exponent decay. \n"//&
                  " \t\t  DOUBLE_EXP - Double Exponent decay.", &
@@ -548,17 +548,17 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
       call MOM_mesg('opacity_init: opacity scheme set to "'//trim(tmpstr)//'".', 5)
     endif
     call get_param(param_file, mdl, "PEN_SW_SCALE", CS%pen_sw_scale, &
-                 "The vertical absorption e-folding depth of the \n"//&
+                 "The vertical absorption e-folding depth of the "//&
                  "penetrating shortwave radiation.", units="m", default=0.0)
     !BGR/ Added for opacity_scheme==double_exp read in 2nd exp-decay and fraction
     if (CS%Opacity_scheme == DOUBLE_EXP ) then
       call get_param(param_file, mdl, "PEN_SW_SCALE_2ND", CS%pen_sw_scale_2nd, &
-                 "The (2nd) vertical absorption e-folding depth of the \n"//&
-                 "penetrating shortwave radiation \n"//&
+                 "The (2nd) vertical absorption e-folding depth of the "//&
+                 "penetrating shortwave radiation "//&
                  "(use if SW_EXP_MODE==double.)",&
                  units="m", default=0.0)
       call get_param(param_file, mdl, "SW_1ST_EXP_RATIO", CS%sw_1st_exp_ratio, &
-                 "The fraction of 1st vertical absorption e-folding depth \n"//&
+                 "The fraction of 1st vertical absorption e-folding depth "//&
                  "penetrating shortwave radiation if SW_EXP_MODE==double.",&
                   units="m", default=0.0)
     elseif (CS%OPACITY_SCHEME == Single_Exp) then
@@ -567,7 +567,7 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
       CS%sw_1st_exp_ratio = 1.0
     endif
     call get_param(param_file, mdl, "PEN_SW_FRAC", CS%pen_sw_frac, &
-                 "The fraction of the shortwave radiation that penetrates \n"//&
+                 "The fraction of the shortwave radiation that penetrates "//&
                  "below the surface.", units="nondim", default=0.0)
 
   endif
@@ -606,7 +606,7 @@ subroutine opacity_init(Time, G, param_file, diag, tracer_flow, CS, optics)
   endif
 
   call get_param(param_file, mdl, "OPACITY_LAND_VALUE", CS%opacity_land_value, &
-                 "The value to use for opacity over land. The default is \n"//&
+                 "The value to use for opacity over land. The default is "//&
                  "10 m-1 - a value for muddy water.", units="m-1", default=10.0)
 
   if (.not.associated(optics%opacity_band)) &

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -899,23 +899,23 @@ subroutine regularize_layers_init(Time, G, GV, param_file, diag, CS)
 ! Set default, read and log parameters
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "REGULARIZE_SURFACE_LAYERS", CS%regularize_surface_layers, &
-                 "If defined, vertically restructure the near-surface \n"//&
-                 "layers when they have too much lateral variations to \n"//&
+                 "If defined, vertically restructure the near-surface "//&
+                 "layers when they have too much lateral variations to "//&
                  "allow for sensible lateral barotropic transports.", &
                  default=.false.)
   if (CS%regularize_surface_layers) then
     call get_param(param_file, mdl, "REGULARIZE_SURFACE_DETRAIN", CS%reg_sfc_detrain, &
-                 "If true, allow the buffer layers to detrain into the \n"//&
-                 "interior as a part of the restructuring when \n"//&
+                 "If true, allow the buffer layers to detrain into the "//&
+                 "interior as a part of the restructuring when "//&
                  "REGULARIZE_SURFACE_LAYERS is true.", default=.true.)
   endif
 
   call get_param(param_file, mdl, "HMIX_MIN", CS%Hmix_min, &
-                 "The minimum mixed layer depth if the mixed layer depth \n"//&
+                 "The minimum mixed layer depth if the mixed layer depth "//&
                  "is determined dynamically.", units="m", default=0.0, scale=GV%m_to_H)
   call get_param(param_file, mdl, "REG_SFC_DEFICIT_TOLERANCE", CS%h_def_tol1, &
-                 "The value of the relative thickness deficit at which \n"//&
-                 "to start modifying the layer structure when \n"//&
+                 "The value of the relative thickness deficit at which "//&
+                 "to start modifying the layer structure when "//&
                  "REGULARIZE_SURFACE_LAYERS is true.", units="nondim", &
                  default=0.5)
   CS%h_def_tol2 = 0.2 + 0.8*CS%h_def_tol1
@@ -927,9 +927,8 @@ subroutine regularize_layers_init(Time, G, GV, param_file, diag, CS)
 !    call get_param(param_file, mdl, "DEBUG_CONSERVATION", CS%debug, &
 !                 "If true, monitor conservation and extrema.", default=.false.)
 
-  call get_param(param_file, mdl, "ALLOW_CLOCKS_IN_OMP_LOOPS", &
-                 CS%allow_clocks_in_omp_loops, &
-                 "If true, clocks can be called from inside loops that can \n"//&
+  call get_param(param_file, mdl, "ALLOW_CLOCKS_IN_OMP_LOOPS", CS%allow_clocks_in_omp_loops, &
+                 "If true, clocks can be called from inside loops that can "//&
                  "be threaded. To run with multiple threads, set to False.", &
                  default=.true.)
 

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -1958,54 +1958,54 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
   call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
   CS%inputdir = slasher(CS%inputdir)
   call get_param(param_file, mdl, "FLUX_RI_MAX", CS%FluxRi_max, &
-                 "The flux Richardson number where the stratification is \n"//&
-                 "large enough that N2 > omega2.  The full expression for \n"//&
-                 "the Flux Richardson number is usually \n"//&
+                 "The flux Richardson number where the stratification is "//&
+                 "large enough that N2 > omega2.  The full expression for "//&
+                 "the Flux Richardson number is usually "//&
                  "FLUX_RI_MAX*N2/(N2+OMEGA2).", default=0.2)
   call get_param(param_file, mdl, "OMEGA", CS%omega, &
                  "The rotation rate of the earth.", units="s-1", &
                  default=7.2921e-5, scale=US%T_to_s)
 
   call get_param(param_file, mdl, "ML_RADIATION", CS%ML_radiation, &
-                 "If true, allow a fraction of TKE available from wind \n"//&
-                 "work to penetrate below the base of the mixed layer \n"//&
-                 "with a vertical decay scale determined by the minimum \n"//&
-                 "of: (1) The depth of the mixed layer, (2) an Ekman \n"//&
+                 "If true, allow a fraction of TKE available from wind "//&
+                 "work to penetrate below the base of the mixed layer "//&
+                 "with a vertical decay scale determined by the minimum "//&
+                 "of: (1) The depth of the mixed layer, (2) an Ekman "//&
                  "length scale.", default=.false.)
   if (CS%ML_radiation) then
     ! This give a minimum decay scale that is typically much less than Angstrom.
     CS%ustar_min = 2e-4 * CS%omega * (GV%Angstrom_Z + GV%H_subroundoff*GV%H_to_Z)
 
     call get_param(param_file, mdl, "ML_RAD_EFOLD_COEFF", CS%ML_rad_efold_coeff, &
-                 "A coefficient that is used to scale the penetration \n"//&
-                 "depth for turbulence below the base of the mixed layer. \n"//&
+                 "A coefficient that is used to scale the penetration "//&
+                 "depth for turbulence below the base of the mixed layer. "//&
                  "This is only used if ML_RADIATION is true.", units="nondim", &
                  default=0.2)
     call get_param(param_file, mdl, "ML_RAD_KD_MAX", CS%ML_rad_kd_max, &
-                 "The maximum diapycnal diffusivity due to turbulence \n"//&
-                 "radiated from the base of the mixed layer. \n"//&
+                 "The maximum diapycnal diffusivity due to turbulence "//&
+                 "radiated from the base of the mixed layer. "//&
                  "This is only used if ML_RADIATION is true.", &
                  units="m2 s-1", default=1.0e-3, &
                  scale=US%m2_s_to_Z2_T)
     call get_param(param_file, mdl, "ML_RAD_COEFF", CS%ML_rad_coeff, &
-                 "The coefficient which scales MSTAR*USTAR^3 to obtain \n"//&
-                 "the energy available for mixing below the base of the \n"//&
+                 "The coefficient which scales MSTAR*USTAR^3 to obtain "//&
+                 "the energy available for mixing below the base of the "//&
                  "mixed layer. This is only used if ML_RADIATION is true.", &
                  units="nondim", default=0.2)
     call get_param(param_file, mdl, "ML_RAD_APPLY_TKE_DECAY", CS%ML_rad_TKE_decay, &
-                 "If true, apply the same exponential decay to ML_rad as \n"//&
-                 "is applied to the other surface sources of TKE in the \n"//&
+                 "If true, apply the same exponential decay to ML_rad as "//&
+                 "is applied to the other surface sources of TKE in the "//&
                  "mixed layer code. This is only used if ML_RADIATION is true.", &
                  default=.true.)
     call get_param(param_file, mdl, "MSTAR", CS%mstar, &
-                 "The ratio of the friction velocity cubed to the TKE \n"//&
+                 "The ratio of the friction velocity cubed to the TKE "//&
                  "input to the mixed layer.", "units=nondim", default=1.2)
     call get_param(param_file, mdl, "TKE_DECAY", CS%TKE_decay, &
                  "The ratio of the natural Ekman depth to the TKE decay scale.", &
                  units="nondim", default=2.5)
     call get_param(param_file, mdl, "ML_USE_OMEGA", ML_use_omega, &
-                 "If true, use the absolute rotation rate instead of the \n"//&
-                 "vertical component of rotation when setting the decay \n"//&
+                 "If true, use the absolute rotation rate instead of the "//&
+                 "vertical component of rotation when setting the decay "//&
                  "scale for turbulence.", default=.false., do_not_log=.true.)
     omega_frac_dflt = 0.0
     if (ML_use_omega) then
@@ -2013,48 +2013,48 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
       omega_frac_dflt = 1.0
     endif
     call get_param(param_file, mdl, "ML_OMEGA_FRAC", CS%ML_omega_frac, &
-                   "When setting the decay scale for turbulence, use this \n"//&
-                   "fraction of the absolute rotation rate blended with the \n"//&
+                   "When setting the decay scale for turbulence, use this "//&
+                   "fraction of the absolute rotation rate blended with the "//&
                    "local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).", &
                    units="nondim", default=omega_frac_dflt)
   endif
 
   call get_param(param_file, mdl, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
-                 "If true, the bottom stress is calculated with a drag \n"//&
-                 "law of the form c_drag*|u|*u. The velocity magnitude \n"//&
-                 "may be an assumed value or it may be based on the \n"//&
-                 "actual velocity in the bottommost HBBL, depending on \n"//&
+                 "If true, the bottom stress is calculated with a drag "//&
+                 "law of the form c_drag*|u|*u. The velocity magnitude "//&
+                 "may be an assumed value or it may be based on the "//&
+                 "actual velocity in the bottommost HBBL, depending on "//&
                  "LINEAR_DRAG.", default=.true.)
   if  (CS%bottomdraglaw) then
     call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
-                 "The drag coefficient relating the magnitude of the \n"//&
-                 "velocity field to the bottom stress. CDRAG is only used \n"//&
+                 "The drag coefficient relating the magnitude of the "//&
+                 "velocity field to the bottom stress. CDRAG is only used "//&
                  "if BOTTOMDRAGLAW is true.", units="nondim", default=0.003)
     call get_param(param_file, mdl, "BBL_EFFIC", CS%BBL_effic, &
-                 "The efficiency with which the energy extracted by \n"//&
-                 "bottom drag drives BBL diffusion.  This is only \n"//&
+                 "The efficiency with which the energy extracted by "//&
+                 "bottom drag drives BBL diffusion.  This is only "//&
                  "used if BOTTOMDRAGLAW is true.", units="nondim", default=0.20)
     call get_param(param_file, mdl, "BBL_MIXING_MAX_DECAY", decay_length, &
-                 "The maximum decay scale for the BBL diffusion, or 0 \n"//&
-                 "to allow the mixing to penetrate as far as \n"//&
-                 "stratification and rotation permit.  The default is 0. \n"//&
+                 "The maximum decay scale for the BBL diffusion, or 0 "//&
+                 "to allow the mixing to penetrate as far as "//&
+                 "stratification and rotation permit.  The default is 0. "//&
                  "This is only used if BOTTOMDRAGLAW is true.", &
                  units="m", default=0.0, scale=US%m_to_Z)
 
     CS%IMax_decay = 1.0 / (200.0*US%m_to_Z)  !### This is inconsistent with the description above.
     if (decay_length > 0.0) CS%IMax_decay = 1.0/decay_length
     call get_param(param_file, mdl, "BBL_MIXING_AS_MAX", CS%BBL_mixing_as_max, &
-                 "If true, take the maximum of the diffusivity from the \n"//&
-                 "BBL mixing and the other diffusivities. Otherwise, \n"//&
+                 "If true, take the maximum of the diffusivity from the "//&
+                 "BBL mixing and the other diffusivities. Otherwise, "//&
                  "diffusivity from the BBL_mixing is simply added.", &
                  default=.true.)
     call get_param(param_file, mdl, "USE_LOTW_BBL_DIFFUSIVITY", CS%use_LOTW_BBL_diffusivity, &
-                 "If true, uses a simple, imprecise but non-coordinate dependent, model\n"//&
-                 "of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses\n"//&
+                 "If true, uses a simple, imprecise but non-coordinate dependent, model "//&
+                 "of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses "//&
                  "the original BBL scheme.", default=.false.)
     if (CS%use_LOTW_BBL_diffusivity) then
       call get_param(param_file, mdl, "LOTW_BBL_USE_OMEGA", CS%LOTW_BBL_use_omega, &
-                 "If true, use the maximum of Omega and N for the TKE to diffusion\n"//&
+                 "If true, use the maximum of Omega and N for the TKE to diffusion "//&
                  "calculation. Otherwise, N is N.", default=.true.)
     endif
   else
@@ -2064,9 +2064,9 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
                  'Bottom Boundary Layer Diffusivity', 'm2 s-1', &
                  conversion=US%Z2_T_to_m2_s)
   call get_param(param_file, mdl, "SIMPLE_TKE_TO_KD", CS%simple_TKE_to_Kd, &
-                 "If true, uses a simple estimate of Kd/TKE that will\n"//&
-                 "work for arbitrary vertical coordinates. If false,\n"//&
-                 "calculates Kd/TKE and bounds based on exact energetics\n"//&
+                 "If true, uses a simple estimate of Kd/TKE that will "//&
+                 "work for arbitrary vertical coordinates. If false, "//&
+                 "calculates Kd/TKE and bounds based on exact energetics "//&
                  "for an isopycnal layer-formulation.", &
                  default=.false.)
 
@@ -2074,14 +2074,14 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
   call bkgnd_mixing_init(Time, G, GV, US, param_file, CS%diag, CS%bkgnd_mixing_csp)
 
   call get_param(param_file, mdl, "KV", CS%Kv, &
-                 "The background kinematic viscosity in the interior. \n"//&
+                 "The background kinematic viscosity in the interior. "//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
                  units="m2 s-1", scale=US%m2_s_to_Z2_T, &
                  fail_if_missing=.true.)
 
   call get_param(param_file, mdl, "KD", CS%Kd, &
-                 "The background diapycnal diffusivity of density in the \n"//&
-                 "interior. Zero or the molecular value, ~1e-7 m2 s-1, \n"//&
+                 "The background diapycnal diffusivity of density in the "//&
+                 "interior. Zero or the molecular value, ~1e-7 m2 s-1, "//&
                  "may be used.", units="m2 s-1", scale=US%m2_s_to_Z2_T, &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "KD_MIN", CS%Kd_min, &
@@ -2089,14 +2089,14 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
                  units="m2 s-1", default=0.01*CS%Kd*US%Z2_T_to_m2_s, &
                  scale=US%m2_s_to_Z2_T)
   call get_param(param_file, mdl, "KD_MAX", CS%Kd_max, &
-                 "The maximum permitted increment for the diapycnal \n"//&
-                 "diffusivity from TKE-based parameterizations, or a \n"//&
+                 "The maximum permitted increment for the diapycnal "//&
+                 "diffusivity from TKE-based parameterizations, or a "//&
                  "negative value for no limit.", units="m2 s-1", default=-1.0, &
                  scale=US%m2_s_to_Z2_T)
   if (CS%simple_TKE_to_Kd .and. CS%Kd_max<=0.) call MOM_error(FATAL, &
          "set_diffusivity_init: To use SIMPLE_TKE_TO_KD, KD_MAX must be set to >0.")
   call get_param(param_file, mdl, "KD_ADD", CS%Kd_add, &
-                 "A uniform diapycnal diffusivity that is added \n"//&
+                 "A uniform diapycnal diffusivity that is added "//&
                  "everywhere without any filtering or scaling.", &
                  units="m2 s-1", default=0.0, scale=US%m2_s_to_Z2_T)
   if (CS%use_LOTW_BBL_diffusivity .and. CS%Kd_max<=0.) call MOM_error(FATAL, &
@@ -2114,14 +2114,14 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
   else
     ! ### This parameter is unused and is staged for deletion
     call get_param(param_file, mdl, "KDML", CS%Kdml, &
-                 "If BULKMIXEDLAYER is false, KDML is the elevated \n"//&
-                 "diapycnal diffusivity in the topmost HMIX of fluid. \n"//&
+                 "If BULKMIXEDLAYER is false, KDML is the elevated "//&
+                 "diapycnal diffusivity in the topmost HMIX of fluid. "//&
                  "KDML is only used if BULKMIXEDLAYER is false.", &
                  units="m2 s-1", default=CS%Kd*US%Z2_T_to_m2_s, &
                  scale=US%m2_s_to_Z2_T)
     call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
-                 "The prescribed depth over which the near-surface \n"//&
-                 "viscosity and diffusivity are elevated when the bulk \n"//&
+                 "The prescribed depth over which the near-surface "//&
+                 "viscosity and diffusivity are elevated when the bulk "//&
                  "mixed layer is not used.", units="m", fail_if_missing=.true.)
   endif
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
@@ -2133,18 +2133,18 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
                  default=.false.)
 
   call get_param(param_file, mdl, "DISSIPATION_MIN", CS%dissip_min, &
-                 "The minimum dissipation by which to determine a lower \n"//&
+                 "The minimum dissipation by which to determine a lower "//&
                  "bound of Kd (a floor).", units="W m-3", default=0.0, &
                  scale=US%m2_s_to_Z2_T*(US%T_to_s**2))
   call get_param(param_file, mdl, "DISSIPATION_N0", CS%dissip_N0, &
-                 "The intercept when N=0 of the N-dependent expression \n"//&
-                 "used to set a minimum dissipation by which to determine \n"//&
+                 "The intercept when N=0 of the N-dependent expression "//&
+                 "used to set a minimum dissipation by which to determine "//&
                  "a lower bound of Kd (a floor): A in eps_min = A + B*N.", &
                  units="W m-3", default=0.0, &
                  scale=US%m2_s_to_Z2_T*(US%T_to_s**2))
   call get_param(param_file, mdl, "DISSIPATION_N1", CS%dissip_N1, &
-                 "The coefficient multiplying N, following Gargett, used to \n"//&
-                 "set a minimum dissipation by which to determine a lower \n"//&
+                 "The coefficient multiplying N, following Gargett, used to "//&
+                 "set a minimum dissipation by which to determine a lower "//&
                  "bound of Kd (a floor): B in eps_min = A + B*N", &
                  units="J m-3", default=0.0, scale=US%m2_s_to_Z2_T*US%T_to_s)
   call get_param(param_file, mdl, "DISSIPATION_KD_MIN", CS%dissip_Kd_min, &
@@ -2192,7 +2192,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
   endif
 
   call get_param(param_file, mdl, "DOUBLE_DIFFUSION", CS%double_diffusion, &
-                 "If true, increase diffusivites for temperature or salt \n"//&
+                 "If true, increase diffusivites for temperature or salt "//&
                  "based on double-diffusive parameterization from MOM4/KPP.", &
                  default=.false.)
 
@@ -2204,7 +2204,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, diag_to_Z
                  "Maximum salt diffusivity for salt fingering regime.", &
                  default=1.e-4, units="m2 s-1", scale=US%m2_s_to_Z2_T)
     call get_param(param_file, mdl, "KV_MOLECULAR", CS%Kv_molecular, &
-                 "Molecular viscosity for calculation of fluxes under \n"//&
+                 "Molecular viscosity for calculation of fluxes under "//&
                  "double-diffusive convection.", default=1.5e-6, units="m2 s-1", &
                  scale=US%m2_s_to_Z2_T)
     ! The default molecular viscosity follows the CCSM4.0 and MOM4p1 defaults.

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1700,12 +1700,12 @@ subroutine set_visc_register_restarts(HI, GV, param_file, visc, restart_CS)
     use_CVMix_shear = CVMix_shear_is_used(param_file)
     use_CVMix_conv  = CVMix_conv_is_used(param_file)
     call get_param(param_file, mdl, "USE_KPP", useKPP, &
-                 "If true, turns on the [CVMix] KPP scheme of Large et al., 1984,\n"// &
+                 "If true, turns on the [CVMix] KPP scheme of Large et al., 1994, "//&
                  "to calculate diffusivities and non-local transport in the OBL.", &
                  default=.false., do_not_log=.true.)
     call get_param(param_file, mdl, "ENERGETICS_SFC_PBL", useEPBL, &
-                 "If true, use an implied energetics planetary boundary \n"//&
-                 "layer scheme to determine the diffusivity and viscosity \n"//&
+                 "If true, use an implied energetics planetary boundary "//&
+                 "layer scheme to determine the diffusivity and viscosity "//&
                  "in the surface boundary layer.", default=.false., do_not_log=.true.)
   endif
 
@@ -1812,65 +1812,65 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   CS%RiNo_mix = .false. ; use_CVMix_ddiff = .false.
   differential_diffusion = .false.
   call get_param(param_file, mdl, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
-                 "If true, the bottom stress is calculated with a drag \n"//&
-                 "law of the form c_drag*|u|*u. The velocity magnitude \n"//&
-                 "may be an assumed value or it may be based on the \n"//&
-                 "actual velocity in the bottommost HBBL, depending on \n"//&
+                 "If true, the bottom stress is calculated with a drag "//&
+                 "law of the form c_drag*|u|*u. The velocity magnitude "//&
+                 "may be an assumed value or it may be based on the "//&
+                 "actual velocity in the bottommost HBBL, depending on "//&
                  "LINEAR_DRAG.", default=.true.)
   call get_param(param_file, mdl, "CHANNEL_DRAG", CS%Channel_drag, &
-                 "If true, the bottom drag is exerted directly on each \n"//&
-                 "layer proportional to the fraction of the bottom it \n"//&
+                 "If true, the bottom drag is exerted directly on each "//&
+                 "layer proportional to the fraction of the bottom it "//&
                  "overlies.", default=.false.)
   call get_param(param_file, mdl, "LINEAR_DRAG", CS%linear_drag, &
-                 "If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag \n"//&
+                 "If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag "//&
                  "law is cdrag*DRAG_BG_VEL*u.", default=.false.)
   call get_param(param_file, mdl, "ADIABATIC", adiabatic, default=.false., &
                  do_not_log=.true.)
   if (adiabatic) then
     call log_param(param_file, mdl, "ADIABATIC",adiabatic, &
-                 "There are no diapycnal mass fluxes if ADIABATIC is \n"//&
-                 "true. This assumes that KD = KDML = 0.0 and that \n"//&
-                 "there is no buoyancy forcing, but makes the model \n"//&
+                 "There are no diapycnal mass fluxes if ADIABATIC is "//&
+                 "true. This assumes that KD = KDML = 0.0 and that "//&
+                 "there is no buoyancy forcing, but makes the model "//&
                  "faster by eliminating subroutine calls.", default=.false.)
   endif
 
   if (.not.adiabatic) then
     CS%RiNo_mix = kappa_shear_is_used(param_file)
     call get_param(param_file, mdl, "DOUBLE_DIFFUSION", differential_diffusion, &
-                 "If true, increase diffusivites for temperature or salt \n"//&
+                 "If true, increase diffusivites for temperature or salt "//&
                  "based on double-diffusive parameterization from MOM4/KPP.", &
                  default=.false.)
     use_CVMix_ddiff = CVMix_ddiff_is_used(param_file)
   endif
 
   call get_param(param_file, mdl, "PRANDTL_TURB", visc%Prandtl_turb, &
-                 "The turbulent Prandtl number applied to shear \n"//&
+                 "The turbulent Prandtl number applied to shear "//&
                  "instability.", units="nondim", default=1.0)
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
 
   call get_param(param_file, mdl, "DYNAMIC_VISCOUS_ML", CS%dynamic_viscous_ML, &
-                 "If true, use a bulk Richardson number criterion to \n"//&
+                 "If true, use a bulk Richardson number criterion to "//&
                  "determine the mixed layer thickness for viscosity.", &
                  default=.false.)
   if (CS%dynamic_viscous_ML) then
     call get_param(param_file, mdl, "BULK_RI_ML", bulk_Ri_ML_dflt, default=0.0)
     call get_param(param_file, mdl, "BULK_RI_ML_VISC", CS%bulk_Ri_ML, &
-                 "The efficiency with which mean kinetic energy released \n"//&
-                 "by mechanically forced entrainment of the mixed layer \n"//&
-                 "is converted to turbulent kinetic energy.  By default, \n"//&
+                 "The efficiency with which mean kinetic energy released "//&
+                 "by mechanically forced entrainment of the mixed layer "//&
+                 "is converted to turbulent kinetic energy.  By default, "//&
                  "BULK_RI_ML_VISC = BULK_RI_ML or 0.", units="nondim", &
                  default=bulk_Ri_ML_dflt)
     call get_param(param_file, mdl, "TKE_DECAY", TKE_decay_dflt, default=0.0)
     call get_param(param_file, mdl, "TKE_DECAY_VISC", CS%TKE_decay, &
-                 "TKE_DECAY_VISC relates the vertical rate of decay of \n"//&
-                 "the TKE available for mechanical entrainment to the \n"//&
-                 "natural Ekman depth for use in calculating the dynamic \n"//&
-                 "mixed layer viscosity.  By default, \n"//&
+                 "TKE_DECAY_VISC relates the vertical rate of decay of "//&
+                 "the TKE available for mechanical entrainment to the "//&
+                 "natural Ekman depth for use in calculating the dynamic "//&
+                 "mixed layer viscosity.  By default, "//&
                  "TKE_DECAY_VISC = TKE_DECAY or 0.", units="nondim", &
                  default=TKE_decay_dflt)
     call get_param(param_file, mdl, "ML_USE_OMEGA", use_omega, &
-                 "If true, use the absolute rotation rate instead of the \n"//&
-                 "vertical component of rotation when setting the decay \n"//&
+                 "If true, use the absolute rotation rate instead of the "//&
+                 "vertical component of rotation when setting the decay "//&
                    "scale for turbulence.", default=.false., do_not_log=.true.)
     omega_frac_dflt = 0.0
     if (use_omega) then
@@ -1878,8 +1878,8 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
       omega_frac_dflt = 1.0
     endif
     call get_param(param_file, mdl, "ML_OMEGA_FRAC", CS%omega_frac, &
-                   "When setting the decay scale for turbulence, use this \n"//&
-                   "fraction of the absolute rotation rate blended with the \n"//&
+                   "When setting the decay scale for turbulence, use this "//&
+                   "fraction of the absolute rotation rate blended with the "//&
                    "local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).", &
                    units="nondim", default=omega_frac_dflt)
     call get_param(param_file, mdl, "OMEGA", CS%omega, &
@@ -1894,62 +1894,62 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   endif
 
   call get_param(param_file, mdl, "HBBL", CS%Hbbl, &
-                 "The thickness of a bottom boundary layer with a \n"//&
-                 "viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or \n"//&
-                 "the thickness over which near-bottom velocities are \n"//&
-                 "averaged for the drag law if BOTTOMDRAGLAW is defined \n"//&
+                 "The thickness of a bottom boundary layer with a "//&
+                 "viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or "//&
+                 "the thickness over which near-bottom velocities are "//&
+                 "averaged for the drag law if BOTTOMDRAGLAW is defined "//&
                  "but LINEAR_DRAG is not.", units="m", fail_if_missing=.true.) ! Rescaled later
   if (CS%bottomdraglaw) then
     call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
-                 "CDRAG is the drag coefficient relating the magnitude of \n"//&
-                 "the velocity field to the bottom stress. CDRAG is only \n"//&
+                 "CDRAG is the drag coefficient relating the magnitude of "//&
+                 "the velocity field to the bottom stress. CDRAG is only "//&
                  "used if BOTTOMDRAGLAW is defined.", units="nondim", &
                  default=0.003)
     call get_param(param_file, mdl, "DRAG_BG_VEL", CS%drag_bg_vel, &
-                 "DRAG_BG_VEL is either the assumed bottom velocity (with \n"//&
-                 "LINEAR_DRAG) or an unresolved  velocity that is \n"//&
-                 "combined with the resolved velocity to estimate the \n"//&
-                 "velocity magnitude.  DRAG_BG_VEL is only used when \n"//&
+                 "DRAG_BG_VEL is either the assumed bottom velocity (with "//&
+                 "LINEAR_DRAG) or an unresolved  velocity that is "//&
+                 "combined with the resolved velocity to estimate the "//&
+                 "velocity magnitude.  DRAG_BG_VEL is only used when "//&
                  "BOTTOMDRAGLAW is defined.", units="m s-1", default=0.0)
     call get_param(param_file, mdl, "BBL_USE_EOS", CS%BBL_use_EOS, &
-                 "If true, use the equation of state in determining the \n"//&
-                 "properties of the bottom boundary layer.  Otherwise use \n"//&
+                 "If true, use the equation of state in determining the "//&
+                 "properties of the bottom boundary layer.  Otherwise use "//&
                  "the layer target potential densities.", default=.false.)
   endif
   call get_param(param_file, mdl, "BBL_THICK_MIN", CS%BBL_thick_min, &
-                 "The minimum bottom boundary layer thickness that can be \n"//&
-                 "used with BOTTOMDRAGLAW. This might be \n"//&
-                 "Kv / (cdrag * drag_bg_vel) to give Kv as the minimum \n"//&
+                 "The minimum bottom boundary layer thickness that can be "//&
+                 "used with BOTTOMDRAGLAW. This might be "//&
+                 "Kv/(cdrag*drag_bg_vel) to give Kv as the minimum "//&
                  "near-bottom viscosity.", units="m", default=0.0)  ! Rescaled later
   call get_param(param_file, mdl, "HTBL_SHELF_MIN", CS%Htbl_shelf_min, &
-                 "The minimum top boundary layer thickness that can be \n"//&
-                 "used with BOTTOMDRAGLAW. This might be \n"//&
-                 "Kv / (cdrag * drag_bg_vel) to give Kv as the minimum \n"//&
+                 "The minimum top boundary layer thickness that can be "//&
+                 "used with BOTTOMDRAGLAW. This might be "//&
+                 "Kv/(cdrag*drag_bg_vel) to give Kv as the minimum "//&
                  "near-top viscosity.", units="m", default=CS%BBL_thick_min, scale=GV%m_to_H)
   call get_param(param_file, mdl, "HTBL_SHELF", CS%Htbl_shelf, &
-                 "The thickness over which near-surface velocities are \n"//&
-                 "averaged for the drag law under an ice shelf.  By \n"//&
+                 "The thickness over which near-surface velocities are "//&
+                 "averaged for the drag law under an ice shelf.  By "//&
                  "default this is the same as HBBL", units="m", default=CS%Hbbl, scale=GV%m_to_H)
   ! These unit conversions are out outside the get_param calls because the are also defaults.
   CS%Hbbl = CS%Hbbl * GV%m_to_H                   ! Rescale
   CS%BBL_thick_min = CS%BBL_thick_min * GV%m_to_H ! Rescale
 
   call get_param(param_file, mdl, "KV", Kv_background, &
-                 "The background kinematic viscosity in the interior. \n"//&
+                 "The background kinematic viscosity in the interior. "//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
                  units="m2 s-1", fail_if_missing=.true.)
 
   call get_param(param_file, mdl, "ADD_KV_SLOW", visc%add_Kv_slow, &
-                 "If true, the background vertical viscosity in the interior \n"//&
-                 "(i.e., tidal + background + shear + convection) is added \n"// &
-                 "when computing the coupling coefficient. The purpose of this \n"// &
-                 "flag is to be able to recover previous answers and it will likely \n"// &
+                 "If true, the background vertical viscosity in the interior "//&
+                 "(i.e., tidal + background + shear + convection) is added "//&
+                 "when computing the coupling coefficient. The purpose of this "//&
+                 "flag is to be able to recover previous answers and it will likely "//&
                  "be removed in the future since this option should always be true.", &
                   default=.false.)
 
   call get_param(param_file, mdl, "USE_KPP", use_KPP, &
-                 "If true, turns on the [CVMix] KPP scheme of Large et al., 1994,\n"// &
-                 "to calculate diffusivities and non-local transport in the OBL.",     &
+                 "If true, turns on the [CVMix] KPP scheme of Large et al., 1994, "//&
+                 "to calculate diffusivities and non-local transport in the OBL.", &
                  do_not_log=.true., default=.false.)
 
   if (use_KPP .and. visc%add_Kv_slow) call MOM_error(FATAL,"set_visc_init: "//&
@@ -1971,10 +1971,10 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
     if (smag_const1 >= 0.0) cSmag_chan_dflt = smag_const1
 
     call get_param(param_file, mdl, "SMAG_CONST_CHANNEL", CS%c_Smag, &
-                 "The nondimensional Laplacian Smagorinsky constant used \n"//&
-                 "in calculating the channel drag if it is enabled.  The \n"//&
-                 "default is to use the same value as SMAG_LAP_CONST if \n"//&
-                 "it is defined, or 0.15 if it is not. The value used is \n"//&
+                 "The nondimensional Laplacian Smagorinsky constant used "//&
+                 "in calculating the channel drag if it is enabled.  The "//&
+                 "default is to use the same value as SMAG_LAP_CONST if "//&
+                 "it is defined, or 0.15 if it is not. The value used is "//&
                  "also 0.15 if the specified value is negative.", &
                  units="nondim", default=cSmag_chan_dflt)
     if (CS%c_Smag < 0.0) CS%c_Smag = 0.15

--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -118,8 +118,8 @@ subroutine initialize_sponge(Iresttime, int_height, G, param_file, CS, GV, &
 ! Set default, read and log parameters
   call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "SPONGE", use_sponge, &
-                 "If true, sponges may be applied anywhere in the domain. \n"//&
-                 "The exact location and properties of those sponges are \n"//&
+                 "If true, sponges may be applied anywhere in the domain. "//&
+                 "The exact location and properties of those sponges are "//&
                  "specified from MOM_initialization.F90.", default=.false.)
 
   if (.not.use_sponge) return

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -261,8 +261,8 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
   call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".",do_not_log=.true.)
   CS%inputdir = slasher(CS%inputdir)
   call get_param(param_file, mdl, "INT_TIDE_DISSIPATION", CS%int_tide_dissipation, &
-                 "If true, use an internal tidal dissipation scheme to \n"//&
-                 "drive diapycnal mixing, along the lines of St. Laurent \n"//&
+                 "If true, use an internal tidal dissipation scheme to "//&
+                 "drive diapycnal mixing, along the lines of St. Laurent "//&
                  "et al. (2002) and Simmons et al. (2004).", default=CS%use_CVMix_tidal)
 
   ! return if tidal mixing is inactive
@@ -274,7 +274,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
     ! Read in CVMix tidal scheme if CVMix tidal mixing is on
     if (CS%use_CVMix_tidal) then
       call get_param(param_file, mdl, "CVMIX_TIDAL_SCHEME", CVMix_tidal_scheme_str, &
-                 "CVMIX_TIDAL_SCHEME selects the CVMix tidal mixing\n"//&
+                 "CVMIX_TIDAL_SCHEME selects the CVMix tidal mixing "//&
                  "scheme with INT_TIDE_DISSIPATION. Valid values are:\n"//&
                  "\t SIMMONS - Use the Simmons et al (2004) tidal \n"//&
                  "\t                mixing scheme.\n"//&
@@ -295,7 +295,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
     ! Read in vertical profile of tidal energy dissipation
     if ( CS%CVMix_tidal_scheme.eq.SCHMITTNER .or. .not. CS%use_CVMix_tidal) then
       call get_param(param_file, mdl, "INT_TIDE_PROFILE", int_tide_profile_str, &
-                   "INT_TIDE_PROFILE selects the vertical profile of energy \n"//&
+                   "INT_TIDE_PROFILE selects the vertical profile of energy "//&
                    "dissipation with INT_TIDE_DISSIPATION. Valid values are:\n"//&
                    "\t STLAURENT_02 - Use the St. Laurent et al exponential \n"//&
                    "\t                decay profile.\n"//&
@@ -319,9 +319,9 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
   endif
 
   call get_param(param_file, mdl, "LEE_WAVE_DISSIPATION", CS%Lee_wave_dissipation, &
-                 "If true, use an lee wave driven dissipation scheme to \n"//&
-                 "drive diapycnal mixing, along the lines of Nikurashin \n"//&
-                 "(2010) and using the St. Laurent et al. (2002) \n"//&
+                 "If true, use an lee wave driven dissipation scheme to "//&
+                 "drive diapycnal mixing, along the lines of Nikurashin "//&
+                 "(2010) and using the St. Laurent et al. (2002) "//&
                  "and Simmons et al. (2004) vertical profile", default=.false.)
   if (CS%lee_wave_dissipation) then
     if (CS%use_CVMix_tidal) then
@@ -329,7 +329,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
             "be used when CVMix tidal mixing scheme is active.")
     endif
     call get_param(param_file, mdl, "LEE_WAVE_PROFILE", tmpstr, &
-                 "LEE_WAVE_PROFILE selects the vertical profile of energy \n"//&
+                 "LEE_WAVE_PROFILE selects the vertical profile of energy "//&
                  "dissipation with LEE_WAVE_DISSIPATION. Valid values are:\n"//&
                  "\t STLAURENT_02 - Use the St. Laurent et al exponential \n"//&
                  "\t                decay profile.\n"//&
@@ -347,10 +347,10 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
   endif
 
   call get_param(param_file, mdl, "INT_TIDE_LOWMODE_DISSIPATION", CS%Lowmode_itidal_dissipation, &
-                 "If true, consider mixing due to breaking low modes that \n"//&
-                 "have been remotely generated; as with itidal drag on the \n"//&
-                 "barotropic tide, use an internal tidal dissipation scheme to \n"//&
-                 "drive diapycnal mixing, along the lines of St. Laurent \n"//&
+                 "If true, consider mixing due to breaking low modes that "//&
+                 "have been remotely generated; as with itidal drag on the "//&
+                 "barotropic tide, use an internal tidal dissipation scheme to "//&
+                 "drive diapycnal mixing, along the lines of St. Laurent "//&
                  "et al. (2002) and Simmons et al. (2004).", default=.false.)
 
   if ((CS%Int_tide_dissipation .and. (CS%int_tide_profile == POLZIN_09)) .or. &
@@ -360,29 +360,29 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
             "be used when CVMix tidal mixing scheme is active.")
     endif
     call get_param(param_file, mdl, "NU_POLZIN", CS%Nu_Polzin, &
-                 "When the Polzin decay profile is used, this is a \n"//&
-                 "non-dimensional constant in the expression for the \n"//&
+                 "When the Polzin decay profile is used, this is a "//&
+                 "non-dimensional constant in the expression for the "//&
                  "vertical scale of decay for the tidal energy dissipation.", &
                  units="nondim", default=0.0697)
     call get_param(param_file, mdl, "NBOTREF_POLZIN", CS%Nbotref_Polzin, &
-                 "When the Polzin decay profile is used, this is the \n"//&
-                 "reference value of the buoyancy frequency at the ocean \n"//&
-                 "bottom in the Polzin formulation for the vertical \n"//&
+                 "When the Polzin decay profile is used, this is the "//&
+                 "reference value of the buoyancy frequency at the ocean "//&
+                 "bottom in the Polzin formulation for the vertical "//&
                  "scale of decay for the tidal energy dissipation.", &
                  units="s-1", default=9.61e-4)
     call get_param(param_file, mdl, "POLZIN_DECAY_SCALE_FACTOR", &
                  CS%Polzin_decay_scale_factor, &
-                 "When the Polzin decay profile is used, this is a \n"//&
-                 "scale factor for the vertical scale of decay of the tidal \n"//&
+                 "When the Polzin decay profile is used, this is a "//&
+                 "scale factor for the vertical scale of decay of the tidal "//&
                  "energy dissipation.", default=1.0, units="nondim")
     call get_param(param_file, mdl, "POLZIN_SCALE_MAX_FACTOR", &
                  CS%Polzin_decay_scale_max_factor, &
-                 "When the Polzin decay profile is used, this is a factor \n"//&
-                 "to limit the vertical scale of decay of the tidal \n"//&
-                 "energy dissipation to POLZIN_DECAY_SCALE_MAX_FACTOR \n"//&
+                 "When the Polzin decay profile is used, this is a factor "//&
+                 "to limit the vertical scale of decay of the tidal "//&
+                 "energy dissipation to POLZIN_DECAY_SCALE_MAX_FACTOR "//&
                  "times the depth of the ocean.", units="nondim", default=1.0)
     call get_param(param_file, mdl, "POLZIN_MIN_DECAY_SCALE", CS%Polzin_min_decay_scale, &
-                 "When the Polzin decay profile is used, this is the \n"//&
+                 "When the Polzin decay profile is used, this is the "//&
                  "minimum vertical decay scale for the vertical profile\n"//&
                  "of internal tide dissipation with the Polzin (2009) formulation", &
                  units="m", default=0.0, scale=US%m_to_Z)
@@ -390,20 +390,20 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
 
   if (CS%Int_tide_dissipation .or. CS%Lee_wave_dissipation) then
     call get_param(param_file, mdl, "INT_TIDE_DECAY_SCALE", CS%Int_tide_decay_scale, &
-                 "The decay scale away from the bottom for tidal TKE with \n"//&
+                 "The decay scale away from the bottom for tidal TKE with "//&
                  "the new coding when INT_TIDE_DISSIPATION is used.", &
                  !units="m", default=0.0)
                  units="m", default=500.0, scale=US%m_to_Z)  ! TODO: confirm this new default
     call get_param(param_file, mdl, "MU_ITIDES", CS%Mu_itides, &
-                 "A dimensionless turbulent mixing efficiency used with \n"//&
+                 "A dimensionless turbulent mixing efficiency used with "//&
                  "INT_TIDE_DISSIPATION, often 0.2.", units="nondim", default=0.2)
     call get_param(param_file, mdl, "GAMMA_ITIDES", CS%Gamma_itides, &
-                 "The fraction of the internal tidal energy that is \n"//&
-                 "dissipated locally with INT_TIDE_DISSIPATION.  \n"//&
+                 "The fraction of the internal tidal energy that is "//&
+                 "dissipated locally with INT_TIDE_DISSIPATION. "//&
                  "THIS NAME COULD BE BETTER.", &
                  units="nondim", default=0.3333)
     call get_param(param_file, mdl, "MIN_ZBOT_ITIDES", CS%min_zbot_itides, &
-                 "Turn off internal tidal dissipation when the total \n"//&
+                 "Turn off internal tidal dissipation when the total "//&
                  "ocean depth is less than this value.", units="m", default=0.0, scale=US%m_to_Z)
   endif
 
@@ -416,7 +416,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
     call safe_alloc_ptr(CS%mask_itidal,isd,ied,jsd,jed) ; CS%mask_itidal(:,:) = 1.0
 
     call get_param(param_file, mdl, "KAPPA_ITIDES", CS%kappa_itides, &
-                 "A topographic wavenumber used with INT_TIDE_DISSIPATION. \n"//&
+                 "A topographic wavenumber used with INT_TIDE_DISSIPATION. "//&
                  "The default is 2pi/10 km, as in St.Laurent et al. 2002.", &
                  units="m-1", default=8.e-4*atan(1.0), scale=US%Z_to_m)
 
@@ -426,15 +426,15 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
     call safe_alloc_ptr(CS%tideamp,is,ie,js,je) ; CS%tideamp(:,:) = CS%utide
 
     call get_param(param_file, mdl, "KAPPA_H2_FACTOR", CS%kappa_h2_factor, &
-                 "A scaling factor for the roughness amplitude with \n"//&
+                 "A scaling factor for the roughness amplitude with "//&
                  "INT_TIDE_DISSIPATION.",  units="nondim", default=1.0)
     call get_param(param_file, mdl, "TKE_ITIDE_MAX", CS%TKE_itide_max, &
-                 "The maximum internal tide energy source available to mix \n"//&
+                 "The maximum internal tide energy source available to mix "//&
                  "above the bottom boundary layer with INT_TIDE_DISSIPATION.", &
                  units="W m-2",  default=1.0e3, scale=US%m_to_Z**3*US%T_to_s**3)
 
     call get_param(param_file, mdl, "READ_TIDEAMP", read_tideamp, &
-                 "If true, read a file (given by TIDEAMP_FILE) containing \n"//&
+                 "If true, read a file (given by TIDEAMP_FILE) containing "//&
                  "the tidal amplitude with INT_TIDE_DISSIPATION.", default=.false.)
     if (read_tideamp) then
       if (CS%use_CVMix_tidal) then
@@ -442,7 +442,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
               "not compatible with CVMix tidal mixing. ")
       endif
       call get_param(param_file, mdl, "TIDEAMP_FILE", tideamp_file, &
-                 "The path to the file containing the spatially varying \n"//&
+                 "The path to the file containing the spatially varying "//&
                  "tidal amplitudes with INT_TIDE_DISSIPATION.", default="tideamp.nc")
       filename = trim(CS%inputdir) // trim(tideamp_file)
       call log_param(param_file, mdl, "INPUTDIR/TIDEAMP_FILE", filename)
@@ -450,7 +450,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
     endif
 
     call get_param(param_file, mdl, "H2_FILE", h2_file, &
-                 "The path to the file containing the sub-grid-scale \n"//&
+                 "The path to the file containing the sub-grid-scale "//&
                  "topographic roughness amplitude with INT_TIDE_DISSIPATION.", &
                  fail_if_missing=(.not.CS%use_CVMix_tidal))
     filename = trim(CS%inputdir) // trim(h2_file)
@@ -477,11 +477,11 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
   if (CS%Lee_wave_dissipation) then
 
     call get_param(param_file, mdl, "NIKURASHIN_TKE_INPUT_FILE",Niku_TKE_input_file, &
-                 "The path to the file containing the TKE input from lee \n"//&
+                 "The path to the file containing the TKE input from lee "//&
                  "wave driven mixing. Used with LEE_WAVE_DISSIPATION.", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, "NIKURASHIN_SCALE",Niku_scale, &
-                 "A non-dimensional factor by which to scale the lee-wave \n"//&
+                 "A non-dimensional factor by which to scale the lee-wave "//&
                  "driven TKE input. Used with LEE_WAVE_DISSIPATION.", &
                  units="nondim", default=1.0)
 
@@ -494,11 +494,11 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
     CS%TKE_Niku(:,:) = Niku_scale * CS%TKE_Niku(:,:)
 
     call get_param(param_file, mdl, "GAMMA_NIKURASHIN",CS%Gamma_lee, &
-                 "The fraction of the lee wave energy that is dissipated \n"//&
+                 "The fraction of the lee wave energy that is dissipated "//&
                  "locally with LEE_WAVE_DISSIPATION.", units="nondim", &
                  default=0.3333)
     call get_param(param_file, mdl, "DECAY_SCALE_FACTOR_LEE",CS%Decay_scale_factor_lee, &
-                 "Scaling for the vertical decay scaleof the local \n"//&
+                 "Scaling for the vertical decay scaleof the local "//&
                  "dissipation of lee waves dissipation.", units="nondim", &
                  default=1.0)
   else
@@ -514,17 +514,17 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, diag_to_Z_
                    "largest acceptable value for tidal diffusivity", &
                    units="m^2/s", default=50e-4) ! the default is 50e-4 in CVMix, 100e-4 in POP.
     call get_param(param_file, mdl, "TIDAL_DISS_LIM_TC", CS%tidal_diss_lim_tc, &
-                   "Min allowable depth for dissipation for tidal-energy-constituent data. \n"//&
+                   "Min allowable depth for dissipation for tidal-energy-constituent data. "//&
                    "No dissipation contribution is applied above TIDAL_DISS_LIM_TC.", &
                    units="m", default=0.0, scale=US%m_to_Z)
     call get_param(param_file, mdl, "TIDAL_ENERGY_FILE",tidal_energy_file, &
-                 "The path to the file containing tidal energy \n"//&
+                 "The path to the file containing tidal energy "//&
                  "dissipation. Used with CVMix tidal mixing schemes.", &
                  fail_if_missing=.true.)
     call get_param(param_file, mdl, 'MIN_THICKNESS', CS%min_thickness, default=0.001, &
                    do_not_log=.True.)
     call get_param(param_file, mdl, "PRANDTL_TIDAL", prandtl_tidal, &
-                   "Prandtl number used by CVMix tidal mixing schemes \n"//&
+                   "Prandtl number used by CVMix tidal mixing schemes "//&
                    "to convert vertical diffusivities into viscosities.", &
                     units="nondim", default=1.0, &
                    do_not_log=.true.)

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1603,110 +1603,110 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
 ! Default, read and log parameters
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
-                 "If true, the bottom stress is calculated with a drag \n"//&
-                 "law of the form c_drag*|u|*u. The velocity magnitude \n"//&
-                 "may be an assumed value or it may be based on the \n"//&
-                 "actual velocity in the bottommost HBBL, depending on \n"//&
+                 "If true, the bottom stress is calculated with a drag "//&
+                 "law of the form c_drag*|u|*u. The velocity magnitude "//&
+                 "may be an assumed value or it may be based on the "//&
+                 "actual velocity in the bottommost HBBL, depending on "//&
                  "LINEAR_DRAG.", default=.true.)
   call get_param(param_file, mdl, "CHANNEL_DRAG", CS%Channel_drag, &
-                 "If true, the bottom drag is exerted directly on each \n"//&
-                 "layer proportional to the fraction of the bottom it \n"//&
+                 "If true, the bottom drag is exerted directly on each "//&
+                 "layer proportional to the fraction of the bottom it "//&
                  "overlies.", default=.false.)
   call get_param(param_file, mdl, "DIRECT_STRESS", CS%direct_stress, &
-                 "If true, the wind stress is distributed over the \n"//&
-                 "topmost HMIX_STRESS of fluid (like in HYCOM), and KVML \n"//&
+                 "If true, the wind stress is distributed over the "//&
+                 "topmost HMIX_STRESS of fluid (like in HYCOM), and KVML "//&
                  "may be set to a very small value.", default=.false.)
   call get_param(param_file, mdl, "DYNAMIC_VISCOUS_ML", CS%dynamic_viscous_ML, &
-                 "If true, use a bulk Richardson number criterion to \n"//&
+                 "If true, use a bulk Richardson number criterion to "//&
                  "determine the mixed layer thickness for viscosity.", &
                  default=.false.)
   call get_param(param_file, mdl, "U_TRUNC_FILE", CS%u_trunc_file, &
-                 "The absolute path to a file into which the accelerations \n"//&
-                 "leading to zonal velocity truncations are written.  \n"//&
-                 "Undefine this for efficiency if this diagnostic is not \n"//&
+                 "The absolute path to a file into which the accelerations "//&
+                 "leading to zonal velocity truncations are written. "//&
+                 "Undefine this for efficiency if this diagnostic is not "//&
                  "needed.", default=" ", debuggingParam=.true.)
   call get_param(param_file, mdl, "V_TRUNC_FILE", CS%v_trunc_file, &
-                 "The absolute path to a file into which the accelerations \n"//&
-                 "leading to meridional velocity truncations are written. \n"//&
-                 "Undefine this for efficiency if this diagnostic is not \n"//&
+                 "The absolute path to a file into which the accelerations "//&
+                 "leading to meridional velocity truncations are written. "//&
+                 "Undefine this for efficiency if this diagnostic is not "//&
                  "needed.", default=" ", debuggingParam=.true.)
   call get_param(param_file, mdl, "HARMONIC_VISC", CS%harmonic_visc, &
-                 "If true, use the harmonic mean thicknesses for \n"//&
+                 "If true, use the harmonic mean thicknesses for "//&
                  "calculating the vertical viscosity.", default=.false.)
   call get_param(param_file, mdl, "HARMONIC_BL_SCALE", CS%harm_BL_val, &
-                 "A scale to determine when water is in the boundary \n"//&
-                 "layers based solely on harmonic mean thicknesses for \n"//&
-                 "the purpose of determining the extent to which the \n"//&
+                 "A scale to determine when water is in the boundary "//&
+                 "layers based solely on harmonic mean thicknesses for "//&
+                 "the purpose of determining the extent to which the "//&
                  "thicknesses used in the viscosities are upwinded.", &
                  default=0.0, units="nondim")
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
 
   if (GV%nkml < 1) &
     call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
-                 "The prescribed depth over which the near-surface \n"//&
-                 "viscosity and diffusivity are elevated when the bulk \n"//&
+                 "The prescribed depth over which the near-surface "//&
+                 "viscosity and diffusivity are elevated when the bulk "//&
                  "mixed layer is not used.", units="m", scale=GV%m_to_H, &
                  unscaled=Hmix_m, fail_if_missing=.true.)
   if (CS%direct_stress) then
     if (GV%nkml < 1) then
       call get_param(param_file, mdl, "HMIX_STRESS", CS%Hmix_stress, &
-                 "The depth over which the wind stress is applied if \n"//&
+                 "The depth over which the wind stress is applied if "//&
                  "DIRECT_STRESS is true.", units="m", default=Hmix_m, scale=GV%m_to_H)
     else
       call get_param(param_file, mdl, "HMIX_STRESS", CS%Hmix_stress, &
-                 "The depth over which the wind stress is applied if \n"//&
+                 "The depth over which the wind stress is applied if "//&
                  "DIRECT_STRESS is true.", units="m", fail_if_missing=.true., scale=GV%m_to_H)
     endif
     if (CS%Hmix_stress <= 0.0) call MOM_error(FATAL, "vertvisc_init: " // &
        "HMIX_STRESS must be set to a positive value if DIRECT_STRESS is true.")
   endif
   call get_param(param_file, mdl, "KV", CS%Kv, &
-                 "The background kinematic viscosity in the interior. \n"//&
+                 "The background kinematic viscosity in the interior. "//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
                  units="m2 s-1", fail_if_missing=.true., scale=US%m_to_Z**2, unscaled=Kv_dflt)
 
   if (GV%nkml < 1) call get_param(param_file, mdl, "KVML", CS%Kvml, &
-                 "The kinematic viscosity in the mixed layer.  A typical \n"//&
-                 "value is ~1e-2 m2 s-1. KVML is not used if \n"//&
+                 "The kinematic viscosity in the mixed layer.  A typical "//&
+                 "value is ~1e-2 m2 s-1. KVML is not used if "//&
                  "BULKMIXEDLAYER is true.  The default is set by KV.", &
                  units="m2 s-1", default=Kv_dflt, scale=US%m_to_Z**2)
   if (.not.CS%bottomdraglaw) call get_param(param_file, mdl, "KVBBL", CS%Kvbbl, &
-                 "The kinematic viscosity in the benthic boundary layer. \n"//&
-                 "A typical value is ~1e-2 m2 s-1. KVBBL is not used if \n"//&
+                 "The kinematic viscosity in the benthic boundary layer. "//&
+                 "A typical value is ~1e-2 m2 s-1. KVBBL is not used if "//&
                  "BOTTOMDRAGLAW is true.  The default is set by KV.", &
                  units="m2 s-1", default=Kv_dflt, scale=US%m_to_Z**2)
   call get_param(param_file, mdl, "HBBL", CS%Hbbl, &
-                 "The thickness of a bottom boundary layer with a \n"//&
-                 "viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or \n"//&
-                 "the thickness over which near-bottom velocities are \n"//&
-                 "averaged for the drag law if BOTTOMDRAGLAW is defined \n"//&
+                 "The thickness of a bottom boundary layer with a "//&
+                 "viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or "//&
+                 "the thickness over which near-bottom velocities are "//&
+                 "averaged for the drag law if BOTTOMDRAGLAW is defined "//&
                  "but LINEAR_DRAG is not.", units="m", fail_if_missing=.true., scale=GV%m_to_H)
   call get_param(param_file, mdl, "MAXVEL", CS%maxvel, &
-                 "The maximum velocity allowed before the velocity \n"//&
+                 "The maximum velocity allowed before the velocity "//&
                  "components are truncated.", units="m s-1", default=3.0e8)
   call get_param(param_file, mdl, "CFL_BASED_TRUNCATIONS", CS%CFL_based_trunc, &
-                 "If true, base truncations on the CFL number, and not an \n"//&
+                 "If true, base truncations on the CFL number, and not an "//&
                  "absolute speed.", default=.true.)
   call get_param(param_file, mdl, "CFL_TRUNCATE", CS%CFL_trunc, &
-                 "The value of the CFL number that will cause velocity \n"//&
+                 "The value of the CFL number that will cause velocity "//&
                  "components to be truncated; instability can occur past 0.5.", &
                  units="nondim", default=0.5)
   call get_param(param_file, mdl, "CFL_REPORT", CS%CFL_report, &
-                 "The value of the CFL number that causes accelerations \n"//&
+                 "The value of the CFL number that causes accelerations "//&
                  "to be reported; the default is CFL_TRUNCATE.", &
                  units="nondim", default=CS%CFL_trunc)
   call get_param(param_file, mdl, "CFL_TRUNCATE_RAMP_TIME", CS%truncRampTime, &
-                 "The time over which the CFL truncation value is ramped\n"//&
+                 "The time over which the CFL truncation value is ramped "//&
                  "up at the beginning of the run.", &
                  units="s", default=0.)
   CS%CFL_truncE = CS%CFL_trunc
   call get_param(param_file, mdl, "CFL_TRUNCATE_START", CS%CFL_truncS, &
-                 "The start value of the truncation CFL number used when\n"//&
+                 "The start value of the truncation CFL number used when "//&
                  "ramping up CFL_TRUNC.", &
                  units="nondim", default=0.)
   call get_param(param_file, mdl, "STOKES_MIXING_COMBINED", CS%StokesMixing, &
-                 "Flag to use Stokes drift Mixing via the Lagrangian \n"//&
-                 " current (Eulerian plus Stokes drift). \n"//&
+                 "Flag to use Stokes drift Mixing via the Lagrangian "//&
+                 " current (Eulerian plus Stokes drift). "//&
                  " Still needs work and testing, so not recommended for use.",&
                  Default=.false.)
   !BGR 04/04/2018{
@@ -1719,14 +1719,14 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
   !   MOM_error to use, but do so at your own risk and with these points in mind.
   !}
   if (CS%StokesMixing) then
-    call MOM_error(FATAL, "Stokes mixing requires user interfention in the code.\n"//&
-                          "  Model now exiting.  See MOM_vert_friction.F90 for  \n"//&
+    call MOM_error(FATAL, "Stokes mixing requires user intervention in the code.\n"//&
+                          "  Model now exiting.  See MOM_vert_friction.F90 for \n"//&
                           "  details (search 'BGR 04/04/2018' to locate comment).")
   endif
   call get_param(param_file, mdl, "VEL_UNDERFLOW", CS%vel_underflow, &
-                 "A negligibly small velocity magnitude below which velocity \n"//&
-                 "components are set to 0.  A reasonable value might be \n"//&
-                 "1e-30 m/s, which is less than an Angstrom divided by \n"//&
+                 "A negligibly small velocity magnitude below which velocity "//&
+                 "components are set to 0.  A reasonable value might be "//&
+                 "1e-30 m/s, which is less than an Angstrom divided by "//&
                  "the age of the universe.", units="m s-1", default=0.0)
 
   ALLOC_(CS%a_u(IsdB:IedB,jsd:jed,nz+1)) ; CS%a_u(:,:,:) = 0.0

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -93,8 +93,8 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "DOME_TRACER_IC_FILE", CS%tracer_IC_file, &
-                 "The name of a file from which to read the initial \n"//&
-                 "conditions for the DOME tracers, or blank to initialize \n"//&
+                 "The name of a file from which to read the initial "//&
+                 "conditions for the DOME tracers, or blank to initialize "//&
                  "them internally.", default=" ")
   if (len_trim(CS%tracer_IC_file) >= 1) then
     call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
@@ -104,8 +104,8 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                    CS%tracer_IC_file)
   endif
   call get_param(param_file, mdl, "SPONGE", CS%use_sponge, &
-                 "If true, sponges may be applied anywhere in the domain. \n"//&
-                 "The exact location and properties of those sponges are \n"//&
+                 "If true, sponges may be applied anywhere in the domain. "//&
+                 "The exact location and properties of those sponges are "//&
                  "specified from MOM_initialization.F90.", default=.false.)
 
   allocate(CS%tr(isd:ied,jsd:jed,nz,NTR)) ; CS%tr(:,:,:,:) = 0.0

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -97,8 +97,8 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ISOMIP_TRACER_IC_FILE", CS%tracer_IC_file, &
-                 "The name of a file from which to read the initial \n"//&
-                 "conditions for the ISOMIP tracers, or blank to initialize \n"//&
+                 "The name of a file from which to read the initial "//&
+                 "conditions for the ISOMIP tracers, or blank to initialize "//&
                  "them internally.", default=" ")
   if (len_trim(CS%tracer_IC_file) >= 1) then
     call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
@@ -108,8 +108,8 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                    CS%tracer_IC_file)
   endif
   call get_param(param_file, mdl, "SPONGE", CS%use_sponge, &
-                 "If true, sponges may be applied anywhere in the domain. \n"//&
-                 "The exact location and properties of those sponges are \n"//&
+                 "If true, sponges may be applied anywhere in the domain. "//&
+                 "The exact location and properties of those sponges are "//&
                  "specified from MOM_initialization.F90.", default=.false.)
 
   allocate(CS%tr(isd:ied,jsd:jed,nz,NTR)) ; CS%tr(:,:,:,:) = 0.0

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -140,7 +140,7 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "CFC_IC_FILE", CS%IC_file, &
-                 "The file in which the CFC initial values can be \n"//&
+                 "The file in which the CFC initial values can be "//&
                  "found, or an empty string for internal initialization.", &
                  default=" ")
   if ((len_trim(CS%IC_file) > 0) .and. (scan(CS%IC_file,'/') == 0)) then
@@ -153,9 +153,9 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
                  "If true, CFC_IC_FILE is in depth space, not layer space", &
                  default=.false.)
   call get_param(param_file, mdl, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
-                 "If true, tracers may go through the initialization code \n"//&
-                 "if they are not found in the restart files.  Otherwise \n"//&
-                 "it is a fatal error if tracers are not found in the \n"//&
+                 "If true, tracers may go through the initialization code "//&
+                 "if they are not found in the restart files.  Otherwise "//&
+                 "it is a fatal error if tracers are not found in the "//&
                  "restart files of a restarted run.", default=.false.)
 
   !   The following vardesc types contain a package of metadata about each tracer,

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -134,7 +134,7 @@ contains
   ! Read all relevant parameters and write them to the model log.
     call log_version(param_file, sub_name, version, "")
     call get_param(param_file, sub_name, "GENERIC_TRACER_IC_FILE", CS%IC_file, &
-                 "The file in which the generic trcer initial values can \n"//&
+                 "The file in which the generic trcer initial values can "//&
                  "be found, or an empty string for internal initialization.", &
                  default=" ")
     if ((len_trim(CS%IC_file) > 0) .and. (scan(CS%IC_file,'/') == 0)) then
@@ -144,12 +144,12 @@ contains
       call log_param(param_file, sub_name, "INPUTDIR/GENERIC_TRACER_IC_FILE", CS%IC_file)
     endif
     call get_param(param_file, sub_name, "GENERIC_TRACER_IC_FILE_IS_Z", CS%Z_IC_file, &
-                 "If true, GENERIC_TRACER_IC_FILE is in depth space, not \n"//&
+                 "If true, GENERIC_TRACER_IC_FILE is in depth space, not "//&
                  "layer space.",default=.false.)
     call get_param(param_file, sub_name, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
-                 "If true, tracers may go through the initialization code \n"//&
-                 "if they are not found in the restart files.  Otherwise \n"//&
-                 "it is a fatal error if tracers are not found in the \n"//&
+                 "If true, tracers may go through the initialization code "//&
+                 "if they are not found in the restart files.  Otherwise "//&
+                 "it is a fatal error if tracers are not found in the "//&
                  "restart files of a restarted run.", default=.false.)
 
     CS%restart_CSp => restart_CS

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -137,54 +137,54 @@ logical function neutral_diffusion_init(Time, G, param_file, diag, EOS, CS)
 
   ! Read all relevant parameters and write them to the model log.
   call get_param(param_file, mdl, "NDIFF_CONTINUOUS", CS%continuous_reconstruction, &
-                 "If true, uses a continuous reconstruction of T and S when  \n"//  &
-                 "finding neutral surfaces along which diffusion will happen.\n"//  &
-                 "If false, a PPM discontinuous reconstruction of T and S    \n"//  &
-                 "is done which results in a higher order routine but exacts \n"//  &
+                 "If true, uses a continuous reconstruction of T and S when "//&
+                 "finding neutral surfaces along which diffusion will happen. "//&
+                 "If false, a PPM discontinuous reconstruction of T and S "//&
+                 "is done which results in a higher order routine but exacts "//&
                  "a higher computational cost.", default=.true.)
   call get_param(param_file, mdl, "NDIFF_REF_PRES", CS%ref_pres,                    &
-                 "The reference pressure (Pa) used for the derivatives of    \n"//  &
-                 "the equation of state. If negative (default), local        \n"//  &
+                 "The reference pressure (Pa) used for the derivatives of "//&
+                 "the equation of state. If negative (default), local "//&
                  "pressure is used.", &
                  default = -1.)
   ! Initialize and configure remapping
   if (CS%continuous_reconstruction .eqv. .false.) then
     call get_param(param_file, mdl, "NDIFF_BOUNDARY_EXTRAP", boundary_extrap, &
-                   "Uses a rootfinding approach to find the position of a\n"//   &
-                   "neutral surface within a layer taking into account the\n"//  &
-                   "nonlinearity of the equation of state and the\n"//           &
+                   "Uses a rootfinding approach to find the position of a "//&
+                   "neutral surface within a layer taking into account the "//&
+                   "nonlinearity of the equation of state and the "//&
                    "polynomial reconstructions of T/S.",                         &
                    default=.false.)
     call get_param(param_file, mdl, "NDIFF_REMAPPING_SCHEME", string, &
-                   "This sets the reconstruction scheme used\n"//&
-                   "for vertical remapping for all variables.\n"//&
-                   "It can be one of the following schemes:\n"//&
+                   "This sets the reconstruction scheme used "//&
+                   "for vertical remapping for all variables. "//&
+                   "It can be one of the following schemes: "//&
                    trim(remappingSchemesDoc), default=remappingDefaultScheme)
     call initialize_remapping( CS%remap_CS, string, boundary_extrapolation = boundary_extrap )
     call extract_member_remapping_CS(CS%remap_CS, degree=CS%deg)
     call get_param(param_file, mdl, "NDIFF_REFINE_POSITION", CS%refine_position, &
-                   "Uses a rootfinding approach to find the position of a\n"//   &
-                   "neutral surface within a layer taking into account the\n"//  &
-                   "nonlinearity of the equation of state and the\n"//           &
+                   "Uses a rootfinding approach to find the position of a "//&
+                   "neutral surface within a layer taking into account the "//&
+                   "nonlinearity of the equation of state and the "//&
                    "polynomial reconstructions of T/S.",                         &
                    default=.false.)
     if (CS%refine_position) then
       call get_param(param_file, mdl, "NDIFF_DRHO_TOL", drho_tol,            &
-                     "Sets the convergence criterion for finding the neutral\n"// &
+                     "Sets the convergence criterion for finding the neutral "//&
                      "position within a layer in kg m-3.",                        &
                      default=1.e-10)
       call get_param(param_file, mdl, "NDIFF_X_TOL", xtol,            &
-                     "Sets the convergence criterion for a change in nondim\n"// &
+                     "Sets the convergence criterion for a change in nondim "//&
                      "position within a layer.",                        &
                      default=0.)
       call get_param(param_file, mdl, "NDIFF_MAX_ITER", max_iter,              &
-                    "The maximum number of iterations to be done before \n"//     &
+                    "The maximum number of iterations to be done before "//&
                      "exiting the iterative loop to find the neutral surface",    &
                      default=10)
       call set_ndiff_aux_params(CS%ndiff_aux_CS, max_iter = max_iter, drho_tol = drho_tol, xtol = xtol)
     endif
     call get_param(param_file, mdl, "NDIFF_DEBUG", CS%debug,             &
-                   "Turns on verbose output for discontinuous neutral \n"//      &
+                   "Turns on verbose output for discontinuous neutral "//&
                    "diffusion routines.", &
                    default = .false.)
     call set_ndiff_aux_params(CS%ndiff_aux_CS, deg=CS%deg, ref_pres = CS%ref_pres, EOS = EOS, debug = CS%debug)

--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -1313,27 +1313,27 @@ subroutine offline_transport_init(param_file, CS, diabatic_CSp, G, GV)
   call get_param(param_file, mdl, "DT_OFFLINE", CS%dt_offline, &
     "Length of time between reading in of input fields",      fail_if_missing = .true.)
   call get_param(param_file, mdl, "DT_OFFLINE_VERTICAL", CS%dt_offline_vertical, &
-    "Length of the offline timestep for tracer column sources/sinks\n" //&
-    "This should be set to the length of the coupling timestep for \n" //&
+    "Length of the offline timestep for tracer column sources/sinks " //&
+    "This should be set to the length of the coupling timestep for " //&
     "tracers which need shortwave fluxes",                    fail_if_missing = .true.)
   call get_param(param_file, mdl, "START_INDEX", CS%start_index, &
     "Which time index to start from", default=1)
   call get_param(param_file, mdl, "FIELDS_ARE_OFFSET", CS%fields_are_offset, &
-    "True if the time-averaged fields and snapshot fields\n"//&
+    "True if the time-averaged fields and snapshot fields "//&
     "are offset by one time level", default=.false.)
   call get_param(param_file, mdl, "REDISTRIBUTE_METHOD", redistribute_method, &
-    "Redistributes any remaining horizontal fluxes throughout\n"    //&
-    "the rest of water column. Options are 'barotropic' which\n"    //&
-    "evenly distributes flux throughout the entire water column,\n" //&
-    "'upwards' which adds the maximum of the remaining flux in\n"   //&
-    "each layer above, both which first applies upwards and then\n" //&
+    "Redistributes any remaining horizontal fluxes throughout "    //&
+    "the rest of water column. Options are 'barotropic' which "    //&
+    "evenly distributes flux throughout the entire water column, " //&
+    "'upwards' which adds the maximum of the remaining flux in "   //&
+    "each layer above, both which first applies upwards and then " //&
     "barotropic, and 'none' which does no redistribution", &
     default='barotropic')
   call get_param(param_file, mdl, "NUM_OFF_ITER", CS%num_off_iter, &
     "Number of iterations to subdivide the offline tracer advection and diffusion", &
     default = 60)
   call get_param(param_file, mdl, "OFF_ALE_MOD", CS%off_ale_mod, &
-    "Sets how many horizontal advection steps are taken before an ALE\n" //&
+    "Sets how many horizontal advection steps are taken before an ALE " //&
     "remapping step is done. 1 would be x->y->ALE, 2 would be"           //&
     "x->y->x->y->ALE", default = 1)
   call get_param(param_file, mdl, "PRINT_ADV_OFFLINE", CS%print_adv_offline, &
@@ -1350,21 +1350,21 @@ subroutine offline_transport_init(param_file, CS, diabatic_CSp, G, GV)
     "Name of the variable containing the depth of active mixing",&
     default='ePBL_h_ML')
   call get_param(param_file, mdl, "OFFLINE_ADD_DIURNAL_SW", CS%diurnal_sw, &
-    "Adds a synthetic diurnal cycle in the same way that the ice\n" // &
-    "model would have when time-averaged fields of shortwave\n"    // &
+    "Adds a synthetic diurnal cycle in the same way that the ice " // &
+    "model would have when time-averaged fields of shortwave "    // &
     "radiation are read in", default=.false.)
   call get_param(param_file, mdl, "KD_MAX", CS%Kd_max, &
-    "The maximum permitted increment for the diapycnal \n"//&
-    "diffusivity from TKE-based parameterizations, or a \n"//&
+    "The maximum permitted increment for the diapycnal "//&
+    "diffusivity from TKE-based parameterizations, or a "//&
     "negative value for no limit.", units="m2 s-1", default=-1.0)
   call get_param(param_file, mdl, "MIN_RESIDUAL_TRANSPORT", CS%min_residual, &
-    "How much remaining transport before the main offline advection\n"// &
-    "is exited. The default value corresponds to about 1 meter of\n"  // &
+    "How much remaining transport before the main offline advection "// &
+    "is exited. The default value corresponds to about 1 meter of "  // &
     "difference in a grid cell", default = 1.e9)
   call get_param(param_file, mdl, "READ_ALL_TS_UVH", CS%read_all_ts_uvh,  &
-    "Reads all time levels of a subset of the fields necessary to run \n"    //      &
-    "the model offline. This can require a large amount of memory\n"//      &
-    "and will make initialization very slow. However, for offline\n"//      &
+    "Reads all time levels of a subset of the fields necessary to run "    //      &
+    "the model offline. This can require a large amount of memory "//      &
+    "and will make initialization very slow. However, for offline "//      &
     "runs spanning more than a year this can reduce total I/O overhead",    &
     default = .false.)
 

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -202,9 +202,8 @@ subroutine call_tracer_register(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   call get_param(param_file, mdl, "USE_OCMIP2_CFC", CS%use_OCMIP2_CFC, &
                  "If true, use the MOM_OCMIP2_CFC tracer package.", &
                  default=.false.)
-  call get_param(param_file, mdl, "USE_generic_tracer", &
-                                CS%use_MOM_generic_tracer, &
-                 "If true and _USE_GENERIC_TRACER is defined as a \n"//&
+  call get_param(param_file, mdl, "USE_generic_tracer", CS%use_MOM_generic_tracer, &
+                 "If true and _USE_GENERIC_TRACER is defined as a "//&
                  "preprocessor macro, use the MOM_generic_tracer packages.", &
                  default=.false.)
   call get_param(param_file, mdl, "USE_PSEUDO_SALT_TRACER", CS%use_pseudo_salt_tracer, &

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -1403,8 +1403,8 @@ subroutine tracer_hor_diff_init(Time, G, param_file, diag, EOS, CS)
                  "The background along-isopycnal tracer diffusivity.", &
                  units="m2 s-1", default=0.0)
   call get_param(param_file, mdl, "KHTR_SLOPE_CFF", CS%KhTr_Slope_Cff, &
-                 "The scaling coefficient for along-isopycnal tracer \n"//&
-                 "diffusivity using a shear-based (Visbeck-like) \n"//&
+                 "The scaling coefficient for along-isopycnal tracer "//&
+                 "diffusivity using a shear-based (Visbeck-like) "//&
                  "parameterization.  A non-zero value enables this param.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "KHTR_MIN", CS%KhTr_Min, &
@@ -1414,34 +1414,34 @@ subroutine tracer_hor_diff_init(Time, G, param_file, diag, EOS, CS)
                  "The maximum along-isopycnal tracer diffusivity.", &
                  units="m2 s-1", default=0.0)
   call get_param(param_file, mdl, "KHTR_PASSIVITY_COEFF", CS%KhTr_passivity_coeff, &
-                 "The coefficient that scales deformation radius over \n"//&
-                 "grid-spacing in passivity, where passivity is the ratio \n"//&
-                 "between along isopycnal mixing of tracers to thickness mixing. \n"//&
+                 "The coefficient that scales deformation radius over "//&
+                 "grid-spacing in passivity, where passivity is the ratio "//&
+                 "between along isopycnal mixing of tracers to thickness mixing. "//&
                  "A non-zero value enables this parameterization.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "KHTR_PASSIVITY_MIN", CS%KhTr_passivity_min, &
-                 "The minimum passivity which is the ratio between \n"//&
-                 "along isopycnal mixing of tracers to thickness mixing. \n", &
+                 "The minimum passivity which is the ratio between "//&
+                 "along isopycnal mixing of tracers to thickness mixing.", &
                  units="nondim", default=0.5)
   call get_param(param_file, mdl, "DIFFUSE_ML_TO_INTERIOR", CS%Diffuse_ML_interior, &
-                 "If true, enable epipycnal mixing between the surface \n"//&
+                 "If true, enable epipycnal mixing between the surface "//&
                  "boundary layer and the interior.", default=.false.)
   call get_param(param_file, mdl, "CHECK_DIFFUSIVE_CFL", CS%check_diffusive_CFL, &
-                 "If true, use enough iterations the diffusion to ensure \n"//&
-                 "that the diffusive equivalent of the CFL limit is not \n"//&
-                 "violated.  If false, always use the greater of 1 or \n"//&
+                 "If true, use enough iterations the diffusion to ensure "//&
+                 "that the diffusive equivalent of the CFL limit is not "//&
+                 "violated.  If false, always use the greater of 1 or "//&
                  "MAX_TR_DIFFUSION_CFL iteration.", default=.false.)
   call get_param(param_file, mdl, "MAX_TR_DIFFUSION_CFL", CS%max_diff_CFL, &
-                 "If positive, locally limit the along-isopycnal tracer \n"//&
-                 "diffusivity to keep the diffusive CFL locally at or \n"//&
-                 "below this value.  The number of diffusive iterations \n"//&
+                 "If positive, locally limit the along-isopycnal tracer "//&
+                 "diffusivity to keep the diffusive CFL locally at or "//&
+                 "below this value.  The number of diffusive iterations "//&
                  "is often this value or the next greater integer.", &
                  units="nondim", default=-1.0)
   CS%ML_KhTR_scale = 1.0
   if (CS%Diffuse_ML_interior) then
     call get_param(param_file, mdl, "ML_KHTR_SCALE", CS%ML_KhTR_scale, &
-                 "With Diffuse_ML_interior, the ratio of the truly \n"//&
-                 "horizontal diffusivity in the mixed layer to the \n"//&
+                 "With Diffuse_ML_interior, the ratio of the truly "//&
+                 "horizontal diffusivity in the mixed layer to the "//&
                  "epipycnal diffusivity.  The valid range is 0 to 1.", &
                  units="nondim", default=1.0)
   endif

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -99,16 +99,16 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, mdl, "ADVECTION_TEST_X_ORIGIN", CS%x_origin, &
-        "The x-coorindate of the center of the test-functions.\n", default=0.)
+        "The x-coorindate of the center of the test-functions.", default=0.)
   call get_param(param_file, mdl, "ADVECTION_TEST_Y_ORIGIN", CS%y_origin, &
-        "The y-coorindate of the center of the test-functions.\n", default=0.)
+        "The y-coorindate of the center of the test-functions.", default=0.)
   call get_param(param_file, mdl, "ADVECTION_TEST_X_WIDTH", CS%x_width, &
-        "The x-width of the test-functions.\n", default=0.)
+        "The x-width of the test-functions.", default=0.)
   call get_param(param_file, mdl, "ADVECTION_TEST_Y_WIDTH", CS%y_width, &
-        "The y-width of the test-functions.\n", default=0.)
+        "The y-width of the test-functions.", default=0.)
   call get_param(param_file, mdl, "ADVECTION_TEST_TRACER_IC_FILE", CS%tracer_IC_file, &
-                 "The name of a file from which to read the initial \n"//&
-                 "conditions for the tracers, or blank to initialize \n"//&
+                 "The name of a file from which to read the initial "//&
+                 "conditions for the tracers, or blank to initialize "//&
                  "them internally.", default=" ")
 
   if (len_trim(CS%tracer_IC_file) >= 1) then
@@ -118,14 +118,14 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
                    CS%tracer_IC_file)
   endif
   call get_param(param_file, mdl, "SPONGE", CS%use_sponge, &
-                 "If true, sponges may be applied anywhere in the domain. \n"//&
-                 "The exact location and properties of those sponges are \n"//&
+                 "If true, sponges may be applied anywhere in the domain. "//&
+                 "The exact location and properties of those sponges are "//&
                  "specified from MOM_initialization.F90.", default=.false.)
 
   call get_param(param_file, mdl, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
-                 "If true, tracers may go through the initialization code \n"//&
-                 "if they are not found in the restart files.  Otherwise \n"//&
-                 "it is a fatal error if the tracers are not found in the \n"//&
+                 "If true, tracers may go through the initialization code "//&
+                 "if they are not found in the restart files.  Otherwise "//&
+                 "it is a fatal error if the tracers are not found in the "//&
                  "restart files of a restarted run.", default=.false.)
 
 

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -99,14 +99,14 @@ function register_boundary_impulse_tracer(HI, GV, param_file, CS, tr_Reg, restar
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "IMPULSE_SOURCE_TIME", CS%remaining_source_time, &
-                 "Length of time for the boundary tracer to be injected\n"//&
-                 "into the mixed layer. After this time has elapsed, the\n"//&
+                 "Length of time for the boundary tracer to be injected "//&
+                 "into the mixed layer. After this time has elapsed, the "//&
                  "surface becomes a sink for the boundary impulse tracer.", &
                  default=31536000.0)
   call get_param(param_file, mdl, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
-                 "If true, tracers may go through the initialization code \n"//&
-                 "if they are not found in the restart files.  Otherwise \n"//&
-                 "it is a fatal error if the tracers are not found in the \n"//&
+                 "If true, tracers may go through the initialization code "//&
+                 "if they are not found in the restart files.  Otherwise "//&
+                 "it is a fatal error if the tracers are not found in the "//&
                  "restart files of a restarted run.", default=.false.)
   CS%ntr = NTR_MAX
   allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr)) ; CS%tr(:,:,:,:) = 0.0

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -99,7 +99,7 @@ function register_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "NUM_DYE_TRACERS", CS%ntr, &
-                 "The number of dye tracers in this run. Each tracer \n"//&
+                 "The number of dye tracers in this run. Each tracer "//&
                  "should have a separate region.", default=0)
   allocate(CS%dye_source_minlon(CS%ntr), &
            CS%dye_source_maxlon(CS%ntr), &

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -83,14 +83,14 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "NUM_DYE_TRACERS", CS%ntr, &
-                 "The number of dye tracers in this run. Each tracer \n"//&
+                 "The number of dye tracers in this run. Each tracer "//&
                  "should have a separate boundary segment.", default=0)
   allocate(CS%ind_tr(CS%ntr))
   allocate(CS%tr_desc(CS%ntr))
 
   call get_param(param_file, mdl, "dyed_obc_TRACER_IC_FILE", CS%tracer_IC_file, &
-                 "The name of a file from which to read the initial \n"//&
-                 "conditions for the dyed_obc tracers, or blank to initialize \n"//&
+                 "The name of a file from which to read the initial "//&
+                 "conditions for the dyed_obc tracers, or blank to initialize "//&
                  "them internally.", default=" ")
   if (len_trim(CS%tracer_IC_file) >= 1) then
     call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -102,23 +102,23 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "DO_IDEAL_AGE", do_ideal_age, &
-                 "If true, use an ideal age tracer that is set to 0 age \n"//&
+                 "If true, use an ideal age tracer that is set to 0 age "//&
                  "in the mixed layer and ages at unit rate in the interior.", &
                  default=.true.)
   call get_param(param_file, mdl, "DO_IDEAL_VINTAGE", do_vintage, &
-                 "If true, use an ideal vintage tracer that is set to an \n"//&
-                 "exponentially increasing value in the mixed layer and \n"//&
+                 "If true, use an ideal vintage tracer that is set to an "//&
+                 "exponentially increasing value in the mixed layer and "//&
                  "is conserved thereafter.", default=.false.)
   call get_param(param_file, mdl, "DO_IDEAL_AGE_DATED", do_ideal_age_dated, &
-                 "If true, use an ideal age tracer that is everywhere 0 \n"//&
-                 "before IDEAL_AGE_DATED_START_YEAR, but the behaves like \n"//&
-                 "the standard ideal age tracer - i.e. is set to 0 age in \n"//&
+                 "If true, use an ideal age tracer that is everywhere 0 "//&
+                 "before IDEAL_AGE_DATED_START_YEAR, but the behaves like "//&
+                 "the standard ideal age tracer - i.e. is set to 0 age in "//&
                  "the mixed layer and ages at unit rate in the interior.", &
                  default=.false.)
 
 
   call get_param(param_file, mdl, "AGE_IC_FILE", CS%IC_file, &
-                 "The file in which the age-tracer initial values can be \n"//&
+                 "The file in which the age-tracer initial values can be "//&
                  "found, or an empty string for internal initialization.", &
                  default=" ")
   if ((len_trim(CS%IC_file) > 0) .and. (scan(CS%IC_file,'/') == 0)) then
@@ -131,9 +131,9 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                  "If true, AGE_IC_FILE is in depth space, not layer space", &
                  default=.false.)
   call get_param(param_file, mdl, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
-                 "If true, tracers may go through the initialization code \n"//&
-                 "if they are not found in the restart files.  Otherwise \n"//&
-                 "it is a fatal error if the tracers are not found in the \n"//&
+                 "If true, tracers may go through the initialization code "//&
+                 "if they are not found in the restart files.  Otherwise "//&
+                 "it is a fatal error if the tracers are not found in the "//&
                  "restart files of a restarted run.", default=.false.)
 
   CS%ntr = 0

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -110,7 +110,7 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "OIL_IC_FILE", CS%IC_file, &
-                 "The file in which the oil tracer initial values can be \n"//&
+                 "The file in which the oil tracer initial values can be "//&
                  "found, or an empty string for internal initialization.", &
                  default=" ")
   if ((len_trim(CS%IC_file) > 0) .and. (scan(CS%IC_file,'/') == 0)) then
@@ -124,9 +124,9 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                  default=.false.)
 
   call get_param(param_file, mdl, "OIL_MAY_REINIT", CS%oil_may_reinit, &
-                 "If true, oil tracers may go through the initialization \n"//&
-                 "code if they are not found in the restart files. \n"//&
-                 "Otherwise it is a fatal error if the oil tracers are not \n"//&
+                 "If true, oil tracers may go through the initialization "//&
+                 "code if they are not found in the restart files. "//&
+                 "Otherwise it is a fatal error if the oil tracers are not "//&
                  "found in the restart files of a restarted run.", &
                  default=.false.)
   call get_param(param_file, mdl, "OIL_SOURCE_LONGITUDE", CS%oil_source_longitude, &
@@ -136,14 +136,14 @@ function register_oil_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                  "The geographic latitude of the oil source.", units="degrees N", &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "OIL_SOURCE_LAYER", CS%oil_source_k, &
-                 "The layer into which the oil is introduced, or a \n"//&
-                 "negative number for a vertically uniform source, \n"//&
+                 "The layer into which the oil is introduced, or a "//&
+                 "negative number for a vertically uniform source, "//&
                  "or 0 not to use this tracer.", units="Layer", default=0)
   call get_param(param_file, mdl, "OIL_SOURCE_RATE", CS%oil_source_rate, &
                  "The rate of oil injection.", units="kg s-1", default=1.0)
   call get_param(param_file, mdl, "OIL_DECAY_DAYS", CS%oil_decay_days, &
-                 "The decay timescale in days (if positive), or no decay \n"//&
-                 "if 0, or use the temperature dependent decay rate of \n"//&
+                 "The decay timescale in days (if positive), or no decay "//&
+                 "if 0, or use the temperature dependent decay rate of "//&
                  "Adcroft et al. (GRL, 2010) if negative.", units="days", &
                  default=0.0)
   call get_param(param_file, mdl, "OIL_DATED_START_YEAR", CS%oil_start_year, &

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -87,8 +87,8 @@ function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "TRACER_EXAMPLE_IC_FILE", CS%tracer_IC_file, &
-                 "The name of a file from which to read the initial \n"//&
-                 "conditions for the DOME tracers, or blank to initialize \n"//&
+                 "The name of a file from which to read the initial "//&
+                 "conditions for the DOME tracers, or blank to initialize "//&
                  "them internally.", default=" ")
   if (len_trim(CS%tracer_IC_file) >= 1) then
     call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
@@ -97,8 +97,8 @@ function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS
                    CS%tracer_IC_file)
   endif
   call get_param(param_file, mdl, "SPONGE", CS%use_sponge, &
-                 "If true, sponges may be applied anywhere in the domain. \n"//&
-                 "The exact location and properties of those sponges are \n"//&
+                 "If true, sponges may be applied anywhere in the domain. "//&
+                 "The exact location and properties of those sponges are "//&
                  "specified from MOM_initialization.F90.", default=.false.)
 
   allocate(CS%tr(isd:ied,jsd:jed,nz,NTR)) ; CS%tr(:,:,:,:) = 0.0

--- a/src/user/BFB_surface_forcing.F90
+++ b/src/user/BFB_surface_forcing.F90
@@ -192,16 +192,16 @@ subroutine BFB_surface_forcing_init(Time, G, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
 
   call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "LFR_SLAT", CS%lfrslat, &
@@ -224,13 +224,13 @@ subroutine BFB_surface_forcing_init(Time, G, param_file, diag, CS)
                  default=0.02)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
-                 "If true, the buoyancy fluxes drive the model back \n"//&
-                 "toward some specified surface state with a rate \n"//&
+                 "If true, the buoyancy fluxes drive the model back "//&
+                 "toward some specified surface state with a rate "//&
                  "given by FLUXCONST.", default= .false.)
   if (CS%restorebuoy) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     ! Convert CS%Flux_const from m day-1 to m s-1.

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -385,19 +385,19 @@ subroutine DOME2d_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   call get_param(param_file, mdl, "DOME2D_WEST_SPONGE_TIME_SCALE", dome2d_west_sponge_time_scale, &
-                 'The time-scale on the west edge of the domain for restoring T/S\n' //&
+                 'The time-scale on the west edge of the domain for restoring T/S '//&
                  'in the sponge. If zero, the western sponge is disabled', &
                  units='s', default=0.)
   call get_param(param_file, mdl, "DOME2D_EAST_SPONGE_TIME_SCALE", dome2d_east_sponge_time_scale, &
-                 'The time-scale on the east edge of the domain for restoring T/S\n' //&
+                 'The time-scale on the east edge of the domain for restoring T/S '//&
                  'in the sponge. If zero, the eastern sponge is disabled', &
                  units='s', default=0.)
   call get_param(param_file, mdl, "DOME2D_WEST_SPONGE_WIDTH", dome2d_west_sponge_width, &
-                 'The fraction of the domain in which the western sponge for restoring T/S\n' //&
+                 'The fraction of the domain in which the western sponge for restoring T/S '//&
                  'is active.', &
                  units='nondim', default=0.1)
   call get_param(param_file, mdl, "DOME2D_EAST_SPONGE_WIDTH", dome2d_east_sponge_width, &
-                 'The fraction of the domain in which the eastern sponge for restoring T/S\n' //&
+                 'The fraction of the domain in which the eastern sponge for restoring T/S '//&
                  'is active.', &
                  units='nondim', default=0.1)
 

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -321,7 +321,7 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
 
     case ( REGRIDDING_LAYER )
       call get_param(param_file, mdl, "FIT_SALINITY", fit_salin, &
-                  "If true, accept the prescribed temperature and fit the \n"//&
+                  "If true, accept the prescribed temperature and fit the "//&
                   "salinity; otherwise take salinity and fit temperature.", &
                   default=.false., do_not_log=just_read)
       call get_param(param_file, mdl, "DRHO_DS", drho_dS1, &
@@ -628,16 +628,16 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, PF, use_ALE, CSp, ACSp)
     ! sponge, FIT_SALINITY=False. The oposite is true for temp. One can
     ! combined the *correct* temp and salt values in one file instead.
     call get_param(PF, mdl, "ISOMIP_SPONGE_FILE", state_file, &
-              "The name of the file with temps., salts. and interfaces to \n"// &
+              "The name of the file with temps., salts. and interfaces to "//&
               "damp toward.", fail_if_missing=.true.)
     call get_param(PF, mdl, "SPONGE_PTEMP_VAR", temp_var, &
-              "The name of the potential temperature variable in \n"//&
+              "The name of the potential temperature variable in "//&
               "SPONGE_STATE_FILE.", default="Temp")
     call get_param(PF, mdl, "SPONGE_SALT_VAR", salt_var, &
-              "The name of the salinity variable in \n"//&
+              "The name of the salinity variable in "//&
               "SPONGE_STATE_FILE.", default="Salt")
     call get_param(PF, mdl, "SPONGE_ETA_VAR", eta_var, &
-              "The name of the interface height variable in \n"//&
+              "The name of the interface height variable in "//&
               "SPONGE_STATE_FILE.", default="eta")
 
     !read temp and eta

--- a/src/user/Idealized_Hurricane.F90
+++ b/src/user/Idealized_Hurricane.F90
@@ -121,25 +121,25 @@ subroutine idealized_hurricane_wind_init(Time, G, param_file, CS)
 
   ! Parameters for computing a wind profile
   call get_param(param_file, mdl, "IDL_HURR_RHO_AIR", CS%rho_a, &
-                 "Air density used to compute the idealized hurricane"// &
+                 "Air density used to compute the idealized hurricane "//&
                  "wind profile.", units='kg/m3', default=1.2)
   call get_param(param_file, mdl, "IDL_HURR_AMBIENT_PRESSURE", &
-                 CS%pressure_ambient, "Ambient pressure used in the "// &
+                 CS%pressure_ambient, "Ambient pressure used in the "//&
                  "idealized hurricane wind profile.", units='Pa', &
                  default=101200.)
   call get_param(param_file, mdl, "IDL_HURR_CENTRAL_PRESSURE", &
-                 CS%pressure_central, "Central pressure used in the "// &
+                 CS%pressure_central, "Central pressure used in the "//&
                  "idealized hurricane wind profile.", units='Pa', &
                  default=96800.)
   call get_param(param_file, mdl, "IDL_HURR_RAD_MAX_WIND", &
-                 CS%rad_max_wind, "Radius of maximum winds used in the"// &
+                 CS%rad_max_wind, "Radius of maximum winds used in the "//&
                  "idealized hurricane wind profile.", units='m', &
                  default=50.e3)
   call get_param(param_file, mdl, "IDL_HURR_MAX_WIND", CS%max_windspeed, &
                  "Maximum wind speed used in the idealized hurricane"// &
                  "wind profile.", units='m/s', default=65.)
   call get_param(param_file, mdl, "IDL_HURR_TRAN_SPEED", CS%hurr_translation_spd, &
-                 "Translation speed of hurricane used in the idealized"// &
+                 "Translation speed of hurricane used in the idealized "//&
                  "hurricane wind profile.", units='m/s', default=5.0)
   call get_param(param_file, mdl, "IDL_HURR_TRAN_DIR", CS%hurr_translation_dir, &
                  "Translation direction (towards) of hurricane used in the "//&
@@ -153,7 +153,7 @@ subroutine idealized_hurricane_wind_init(Time, G, param_file, CS)
                  "Idealized Hurricane initial Y position", &
                  units='m', default=0.)
   call get_param(param_file, mdl, "IDL_HURR_TAU_CURR_REL", CS%relative_tau, &
-                 "Current relative stress switch"//                         &
+                 "Current relative stress switch "//&
                  "used in the idealized hurricane wind profile.", &
                  units='', default=.false.)
 
@@ -163,20 +163,20 @@ subroutine idealized_hurricane_wind_init(Time, G, param_file, CS)
                  "invoking a modification (bug) in the wind profile meant to "//&
                  "reproduce a previous implementation.", units='', default=.false.)
   call get_param(param_file, mdl, "IDL_HURR_SCM", CS%SCM_MODE, &
-                 "Single Column mode switch"//                         &
+                 "Single Column mode switch "//&
                  "used in the SCM idealized hurricane wind profile.", &
                  units='', default=.false.)
   call get_param(param_file, mdl, "IDL_HURR_SCM_LOCY", CS%DY_from_center, &
-                 "Y distance of station used in the SCM idealized hurricane "// &
+                 "Y distance of station used in the SCM idealized hurricane "//&
                  "wind profile.", units='m', default=50.e3)
 
   ! The following parameters are model run-time parameters which are used
   ! and logged elsewhere and so should not be logged here. The default
   ! value should be consistent with the rest of the model.
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0, do_not_log=.true.)
   call get_param(param_file, mdl, "GUST_CONST", CS%gustiness, &

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -75,11 +75,11 @@ function register_Kelvin_OBC(param_file, CS, OBC_Reg)
   call get_param(param_file, mdl, "TOPO_CONFIG", config, do_not_log=.true.)
   if (trim(config) == "Kelvin") then
     call get_param(param_file, mdl, "ROTATED_COAST_OFFSET_1", CS%coast_offset1, &
-                   "The distance along the southern and northern boundaries \n"//&
+                   "The distance along the southern and northern boundaries "//&
                    "at which the coasts angle in.", &
                    units="km", default=100.0)
     call get_param(param_file, mdl, "ROTATED_COAST_OFFSET_2", CS%coast_offset2, &
-                   "The distance from the southern and northern boundaries \n"//&
+                   "The distance from the southern and northern boundaries "//&
                    "at which the coasts angle in.", &
                    units="km", default=10.0)
     call get_param(param_file, mdl, "ROTATED_COAST_ANGLE", CS%coast_angle, &

--- a/src/user/MOM_controlled_forcing.F90
+++ b/src/user/MOM_controlled_forcing.F90
@@ -509,11 +509,11 @@ subroutine controlled_forcing_init(Time, G, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call log_param(param_file, mdl, "CTRL_FORCE_INTEGRATED", do_integrated, &
-                 "If true, use a PI controller to determine the surface \n"//&
+                 "If true, use a PI controller to determine the surface "//&
                  "forcing that is consistent with the observed mean properties.", &
                  default=.false.)
   call log_param(param_file, mdl, "CTRL_FORCE_NUM_CYCLE", num_cycle, &
-                 "The number of cycles per year in the controlled forcing, \n"//&
+                 "The number of cycles per year in the controlled forcing, "//&
                  "or 0 for no cyclic forcing.", default=0)
 
   if (.not.associated(CS)) return
@@ -521,33 +521,33 @@ subroutine controlled_forcing_init(Time, G, param_file, diag, CS)
   CS%diag => diag
 
   call get_param(param_file, mdl, "CTRL_FORCE_HEAT_INT_RATE", CS%heat_int_rate, &
-                 "The integrated rate at which heat flux anomalies are \n"//&
+                 "The integrated rate at which heat flux anomalies are "//&
                  "accumulated.", units="s-1", default=0.0)
   call get_param(param_file, mdl, "CTRL_FORCE_PREC_INT_RATE", CS%prec_int_rate, &
-                 "The integrated rate at which precipitation anomalies \n"//&
+                 "The integrated rate at which precipitation anomalies "//&
                  "are accumulated.", units="s-1", default=0.0)
   call get_param(param_file, mdl, "CTRL_FORCE_HEAT_CYC_RATE", CS%heat_cyc_rate, &
-                 "The integrated rate at which cyclical heat flux \n"//&
+                 "The integrated rate at which cyclical heat flux "//&
                  "anomalies are accumulated.", units="s-1", default=0.0)
   call get_param(param_file, mdl, "CTRL_FORCE_PREC_CYC_RATE", CS%prec_cyc_rate, &
-                 "The integrated rate at which cyclical precipitation \n"//&
+                 "The integrated rate at which cyclical precipitation "//&
                  "anomalies are accumulated.", units="s-1", default=0.0)
   call get_param(param_file, mdl, "CTRL_FORCE_SMOOTH_LENGTH", smooth_len, &
-                 "The length scales over which controlled forcing \n"//&
+                 "The length scales over which controlled forcing "//&
                  "anomalies are smoothed.", units="m", default=0.0)
   call get_param(param_file, mdl, "CTRL_FORCE_LAMDA_HEAT", CS%lam_heat, &
-                 "A constant of proportionality between SST anomalies \n"//&
+                 "A constant of proportionality between SST anomalies "//&
                  "and controlling heat fluxes", "W m-2 K-1", default=0.0)
   call get_param(param_file, mdl, "CTRL_FORCE_LAMDA_PREC", CS%lam_prec, &
-                 "A constant of proportionality between SSS anomalies \n"//&
+                 "A constant of proportionality between SSS anomalies "//&
                  "(normalised by mean SSS) and controlling precipitation.", &
                  "kg m-2", default=0.0)
   call get_param(param_file, mdl, "CTRL_FORCE_LAMDA_CYC_HEAT", CS%lam_cyc_heat, &
-                 "A constant of proportionality between SST anomalies \n"//&
+                 "A constant of proportionality between SST anomalies "//&
                  "and cyclical controlling heat fluxes", "W m-2 K-1", default=0.0)
   call get_param(param_file, mdl, "CTRL_FORCE_LAMDA_CYC_PREC", CS%lam_cyc_prec, &
-                 "A constant of proportionality between SSS anomalies \n"//&
-                 "(normalised by mean SSS) and cyclical controlling \n"//&
+                 "A constant of proportionality between SSS anomalies "//&
+                 "(normalised by mean SSS) and cyclical controlling "//&
                  "precipitation.", "kg m-2", default=0.0)
 
   CS%Len2 = smooth_len**2

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -302,9 +302,9 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
     case (INPUT_STRING)! A method to input the Stokes band (globally uniform)
       DataSource = Input
       call get_param(param_file,mdl,"SURFBAND_NB",NumBands,                 &
-         "Prescribe number of wavenumber bands for Stokes drift. \n"//      &
-         " Make sure this is consistnet w/ WAVENUMBERS, STOKES_X, and \n"// &
-         " STOKES_Y, there are no safety checks in the code.",              &
+         "Prescribe number of wavenumber bands for Stokes drift. "//      &
+         "Make sure this is consistnet w/ WAVENUMBERS, STOKES_X, and "// &
+         "STOKES_Y, there are no safety checks in the code.",              &
          units='', default=1)
       allocate( CS%WaveNum_Cen(1:NumBands) )
       CS%WaveNum_Cen(:) = 0.0
@@ -351,16 +351,16 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
 
   ! Langmuir number Options
   call get_param(param_file, mdl, "LA_DEPTH_RATIO", LA_FracHBL,              &
-         "The depth (normalized by BLD) to average Stokes drift over in \n"//&
-         " Langmuir number calculation, where La = sqrt(ust/Stokes).",       &
+         "The depth (normalized by BLD) to average Stokes drift over in "//&
+         "Langmuir number calculation, where La = sqrt(ust/Stokes).",       &
          units="nondim",default=0.04)
   call get_param(param_file, mdl, "LA_MISALIGNMENT", LA_Misalignment,    &
          "Flag (logical) if using misalignment bt shear and waves in LA",&
          default=.false.)
   call get_param(param_file, mdl, "MIN_LANGMUIR", CS%La_min,    &
-         "A minimum value for all Langmuir numbers that is not physical, \n"//&
-         " but is likely only encountered when the wind is very small and \n"//&
-         " therefore its effects should be mostly benign.",units="nondim",&
+         "A minimum value for all Langmuir numbers that is not physical, "//&
+         "but is likely only encountered when the wind is very small and "//&
+         "therefore its effects should be mostly benign.",units="nondim",&
          default=0.05)
 
   ! Allocate and initialize
@@ -407,8 +407,8 @@ subroutine MOM_wave_interface_init_lite(param_file)
 
   ! Langmuir number Options
   call get_param(param_file, mdl, "LA_DEPTH_RATIO", LA_FracHBL,              &
-       "The depth (normalized by BLD) to average Stokes drift over in \n"//&
-       " Langmuir number calculation, where La = sqrt(ust/Stokes).",       &
+       "The depth (normalized by BLD) to average Stokes drift over in "//&
+       "Langmuir number calculation, where La = sqrt(ust/Stokes).",       &
        units="nondim",default=0.04)
 
   if (WaveMethod==NULL_WaveMethod) then

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -73,7 +73,7 @@ subroutine Phillips_initialize_thickness(h, G, GV, US, param_file, just_read_par
                  "The width of the zonal-mean jet.", units="km", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "JET_HEIGHT", jet_height, &
-                 "The interface height scale associated with the \n"//&
+                 "The interface height scale associated with the "//&
                  "zonal-mean jet.", units="m", scale=US%m_to_Z, &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
 
@@ -147,7 +147,7 @@ subroutine Phillips_initialize_velocity(u, v, G, GV, US, param_file, just_read_p
                  "The width of the zonal-mean jet.", units="km", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "JET_HEIGHT", jet_height, &
-                 "The interface height scale associated with the \n"//&
+                 "The interface height scale associated with the "//&
                  "zonal-mean jet.", units="m", scale=US%m_to_Z, &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
 
@@ -248,7 +248,7 @@ subroutine Phillips_initialize_sponges(G, GV, US, tv, param_file, CSp, h)
                  "The width of the zonal-mean jet.", units="km", &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "JET_HEIGHT", jet_height, &
-                 "The interface height scale associated with the \n"//&
+                 "The interface height scale associated with the "//&
                  "zonal-mean jet.", units="m", scale=US%m_to_Z, &
                  fail_if_missing=.true.)
 

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -60,15 +60,15 @@ subroutine circle_obcs_initialize_thickness(h, G, GV, param_file, just_read_para
   if (.not.just_read) call log_version(param_file, mdl, version, "")
   ! Parameters read by cartesian grid initialization
   call get_param(param_file, mdl, "DISK_RADIUS", diskrad, &
-                 "The radius of the initially elevated disk in the \n"//&
+                 "The radius of the initially elevated disk in the "//&
                  "circle_obcs test case.", units=G%x_axis_units, &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "DISK_X_OFFSET", xOffset, &
-                 "The x-offset of the initially elevated disk in the \n"//&
+                 "The x-offset of the initially elevated disk in the "//&
                  "circle_obcs test case.", units=G%x_axis_units, &
                  default = 0.0, do_not_log=just_read)
   call get_param(param_file, mdl, "DISK_IC_AMPLITUDE", IC_amp, &
-                 "Initial amplitude of interface height displacements \n"//&
+                 "Initial amplitude of interface height displacements "//&
                  "in the circle_obcs test case.", &
                  units='m', default=5.0, scale=GV%m_to_H, do_not_log=just_read)
 

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -132,7 +132,7 @@ subroutine dumbbell_initialize_thickness ( h, G, GV, US, param_file, just_read_p
     call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, default = S_Ref, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, default = S_Ref, do_not_log=.true.)
     call get_param(param_file, mdl, "INTERFACE_IC_QUANTA", eta_IC_quanta, &
-                   "The granularity of initial interface height values \n"//&
+                   "The granularity of initial interface height values "//&
                    "per meter, to avoid sensivity to order-of-arithmetic changes.", &
                    default=2048.0, units="m-1", scale=US%Z_to_m, do_not_log=just_read)
     if (just_read) return ! All run-time parameters have been read, so return.
@@ -220,7 +220,7 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, param_file
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_DENSITY_PROFILE", density_profile, &
-                 'Initial profile shape. Valid values are "linear", "parabolic"\n'// &
+                 'Initial profile shape. Valid values are "linear", "parabolic" '// &
                  'and "exponential".', default='linear', do_not_log=just_read)
   call get_param(param_file, mdl,"DUMBBELL_SREF", S_surf, &
                  'DUMBBELL REFERENCE SALINITY', units='1e-3', default=34., do_not_log=just_read)

--- a/src/user/dumbbell_surface_forcing.F90
+++ b/src/user/dumbbell_surface_forcing.F90
@@ -203,16 +203,16 @@ subroutine dumbbell_surface_forcing_init(Time, G, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "ENABLE_THERMODYNAMICS", CS%use_temperature, &
-                 "If true, Temperature and salinity are used as state \n"//&
+                 "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
 
   call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
   call get_param(param_file, mdl, "RHO_0", CS%Rho0, &
-                 "The mean ocean density used with BOUSSINESQ true to \n"//&
-                 "calculate accelerations and the mass for conservation \n"//&
-                 "properties, or with BOUSSINSEQ false to convert some \n"//&
+                 "The mean ocean density used with BOUSSINESQ true to "//&
+                 "calculate accelerations and the mass for conservation "//&
+                 "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0)
   call get_param(param_file, mdl, "DUMBBELL_SLP_AMP", CS%slp_amplitude, &
@@ -231,13 +231,13 @@ subroutine dumbbell_surface_forcing_init(Time, G, param_file, diag, CS)
                  default=2., do_not_log=.true.)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
-                 "If true, the buoyancy fluxes drive the model back \n"//&
-                 "toward some specified surface state with a rate \n"//&
+                 "If true, the buoyancy fluxes drive the model back "//&
+                 "toward some specified surface state with a rate "//&
                  "given by FLUXCONST.", default= .false.)
   if (CS%restorebuoy) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
-                 "The constant that relates the restoring surface fluxes \n"//&
-                 "to the relative surface anomalies (akin to a piston \n"//&
+                 "The constant that relates the restoring surface fluxes "//&
+                 "to the relative surface anomalies (akin to a piston "//&
                  "velocity).  Note the non-MKS units.", units="m day-1", &
                  fail_if_missing=.true.)
     ! Convert CS%Flux_const from m day-1 to m s-1.

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -101,7 +101,7 @@ subroutine dyed_channel_set_OBC_tracer_data(OBC, G, GV, param_file, tr_Reg)
         'dyed_channel_set_OBC_data() was called but OBC type was not initialized!')
 
   call get_param(param_file, mdl, "NUM_DYE_TRACERS", ntr, &
-                 "The number of dye tracers in this run. Each tracer \n"//&
+                 "The number of dye tracers in this run. Each tracer "//&
                  "should have a separate boundary segment.", default=0,   &
                  do_not_log=.true.)
 

--- a/src/user/dyed_obcs_initialization.F90
+++ b/src/user/dyed_obcs_initialization.F90
@@ -52,7 +52,7 @@ subroutine dyed_obcs_set_OBC_data(OBC, G, GV, param_file, tr_Reg)
   if (.not.associated(OBC)) return
 
   call get_param(param_file, mdl, "NUM_DYE_TRACERS", ntr, &
-                 "The number of dye tracers in this run. Each tracer \n"//&
+                 "The number of dye tracers in this run. Each tracer "//&
                  "should have a separate boundary segment.", default=0,   &
                  do_not_log=.true.)
 

--- a/src/user/lock_exchange_initialization.F90
+++ b/src/user/lock_exchange_initialization.F90
@@ -56,12 +56,12 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, US, param_file, just_rea
 
   if (.not.just_read) call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "FRONT_DISPLACEMENT", front_displacement, &
-                 "The vertical displacement of interfaces across the front. \n"//&
+                 "The vertical displacement of interfaces across the front. "//&
                  "A value larger in magnitude that MAX_DEPTH is truncated,", &
                  units="m", fail_if_missing=.not.just_read, do_not_log=just_read, scale=US%m_to_Z)
   call get_param(param_file, mdl, "THERMOCLINE_THICKNESS", thermocline_thickness, &
-                 "The thickness of the thermocline in the lock exchange \n"//&
-                 "experiment.  A value of zero creates a two layer system \n"//&
+                 "The thickness of the thermocline in the lock exchange "//&
+                 "experiment.  A value of zero creates a two layer system "//&
                  "with vanished layers in between the two inflated layers.", &
                  default=0., units="m", do_not_log=just_read, scale=US%m_to_Z)
 

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -53,11 +53,11 @@ subroutine seamount_initialize_topography( D, G, param_file, max_depth )
                  "Non-dimensional height of seamount.", &
                  units="non-dim", default=0.5)
   call get_param(param_file, mdl,"SEAMOUNT_X_LENGTH_SCALE",Lx, &
-                 "Length scale of seamount in x-direction.\n"//&
+                 "Length scale of seamount in x-direction. "//&
                  "Set to zero make topography uniform in the x-direction.", &
                  units="Same as x,y", default=20.)
   call get_param(param_file, mdl,"SEAMOUNT_Y_LENGTH_SCALE",Ly, &
-                 "Length scale of seamount in y-direction.\n"//&
+                 "Length scale of seamount in y-direction. "//&
                  "Set to zero make topography uniform in the y-direction.", &
                  units="Same as x,y", default=0.)
 
@@ -132,7 +132,7 @@ subroutine seamount_initialize_thickness ( h, G, GV, US, param_file, just_read_p
     call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, default = S_Ref, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, default = S_Ref, do_not_log=.true.)
     call get_param(param_file, mdl, "INTERFACE_IC_QUANTA", eta_IC_quanta, &
-                   "The granularity of initial interface height values \n"//&
+                   "The granularity of initial interface height values "//&
                    "per meter, to avoid sensivity to order-of-arithmetic changes.", &
                    default=2048.0, units="m-1", scale=US%Z_to_m, do_not_log=just_read)
     if (just_read) return ! All run-time parameters have been read, so return.
@@ -217,7 +217,7 @@ subroutine seamount_initialize_temperature_salinity ( T, S, h, G, GV, param_file
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_DENSITY_PROFILE", density_profile, &
-                 'Initial profile shape. Valid values are "linear", "parabolic"\n'// &
+                 'Initial profile shape. Valid values are "linear", "parabolic" '//&
                  'and "exponential".', default='linear', do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_SSS", S_surf, &
                  'Initial surface salinity', units='1e-3', default=34., do_not_log=just_read)

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -69,7 +69,7 @@ function register_shelfwave_OBC(param_file, CS, OBC_Reg)
                  "Length scale of shelfwave in x-direction.",&
                  units="Same as x,y", default=100.)
   call get_param(param_file, mdl,"SHELFWAVE_Y_LENGTH_SCALE",CS%Ly, &
-                 "Length scale of exponential dropoff of topography\n"//&
+                 "Length scale of exponential dropoff of topography "//&
                  "in the y-direction.", &
                  units="Same as x,y", default=50.)
   call get_param(param_file, mdl,"SHELFWAVE_Y_MODE",CS%jj, &

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -84,7 +84,7 @@ subroutine sloshing_initialize_thickness ( h, G, GV, US, param_file, just_read_p
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
   if (.not.just_read) call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "SLOSHING_IC_AMPLITUDE", a0, &
-                 "Initial amplitude of sloshing internal interface height \n"//&
+                 "Initial amplitude of sloshing internal interface height "//&
                  "displacements it the sloshing test case.", &
                  units='m', default=75.0, scale=US%m_to_Z, do_not_log=just_read)
   call get_param(param_file, mdl, "SLOSHING_IC_BUG", use_IC_bug, &

--- a/src/user/user_change_diffusivity.F90
+++ b/src/user/user_change_diffusivity.F90
@@ -221,26 +221,26 @@ subroutine user_change_diff_init(Time, G, GV, US, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "USER_KD_ADD", CS%Kd_add, &
-                 "A user-specified additional diffusivity over a range of \n"//&
+                 "A user-specified additional diffusivity over a range of "//&
                  "latitude and density.", default=0.0, units="m2 s-1", &
                  scale=US%m2_s_to_Z2_T)
   if (CS%Kd_add /= 0.0) then
     call get_param(param_file, mdl, "USER_KD_ADD_LAT_RANGE", CS%lat_range(:), &
-                 "Four successive values that define a range of latitudes \n"//&
-                 "over which the user-specified extra diffusivity is \n"//&
-                 "applied.  The four values specify the latitudes at \n"//&
-                 "which the extra diffusivity starts to increase from 0, \n"//&
-                 "hits its full value, starts to decrease again, and is \n"//&
+                 "Four successive values that define a range of latitudes "//&
+                 "over which the user-specified extra diffusivity is "//&
+                 "applied.  The four values specify the latitudes at "//&
+                 "which the extra diffusivity starts to increase from 0, "//&
+                 "hits its full value, starts to decrease again, and is "//&
                  "back to 0.", units="degree", default=-1.0e9)
     call get_param(param_file, mdl, "USER_KD_ADD_RHO_RANGE", CS%rho_range(:), &
-                 "Four successive values that define a range of potential \n"//&
-                 "densities over which the user-given extra diffusivity \n"//&
-                 "is applied.  The four values specify the density at \n"//&
-                 "which the extra diffusivity starts to increase from 0, \n"//&
-                 "hits its full value, starts to decrease again, and is \n"//&
+                 "Four successive values that define a range of potential "//&
+                 "densities over which the user-given extra diffusivity "//&
+                 "is applied.  The four values specify the density at "//&
+                 "which the extra diffusivity starts to increase from 0, "//&
+                 "hits its full value, starts to decrease again, and is "//&
                  "back to 0.", units="kg m-3", default=-1.0e9)
     call get_param(param_file, mdl, "USER_KD_ADD_USE_ABS_LAT", CS%use_abs_lat, &
-                 "If true, use the absolute value of latitude when \n"//&
+                 "If true, use the absolute value of latitude when "//&
                  "checking whether a point fits into range of latitudes.", &
                  default=.false.)
   endif


### PR DESCRIPTION
  Removed hard newlines from numerous get_param and log_param descriptions
throughout the MOM6 codebase, relying instead on the new automatic newline
capability in writeMessageAndDesc.  In the case of formatted lists of options,
the hard newlines were retained. This cleans up the code and gives more standard
messages and smaller parameter_doc files, but it changes the comments in every
MOM_parameter_doc and SIS_parameter_doc file. All answers are bitwise identical.