### PR TITLE
(*) Bugfix: reproducing_sum, bin equals prec

### DIFF
--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -535,7 +535,7 @@ subroutine carry_overflow(int_sum, prec_error)
   ! This subroutine handles carrying of the overflow.
   integer :: i, num_carry
 
-  do i=ni,2,-1 ; if (abs(int_sum(i)) > prec) then
+  do i=ni,2,-1 ; if (abs(int_sum(i)) >= prec) then
     num_carry = int(int_sum(i) * I_prec)
     int_sum(i) = int_sum(i) - num_carry*prec
     int_sum(i-1) = int_sum(i-1) + num_carry
@@ -559,7 +559,7 @@ subroutine regularize_ints(int_sum)
   logical :: positive
   integer :: i, num_carry
 
-  do i=ni,2,-1 ; if (abs(int_sum(i)) > prec) then
+  do i=ni,2,-1 ; if (abs(int_sum(i)) >= prec) then
     num_carry = int(int_sum(i) * I_prec)
     int_sum(i) = int_sum(i) - num_carry*prec
     int_sum(i-1) = int_sum(i-1) + num_carry


### PR DESCRIPTION
In `reproducing_sum`, if a bin inside `int_sum` is exactly equal to `prec`
(currently 2**46 to some integer power) then this value will not be
transferred up to the next bin, due to the `>` check rather than a `>=`
check.  See code block below:
```
  562   do i=ni,2,-1 ; if (abs(int_sum(i)) > prec) then
  563     num_carry = int(int_sum(i) * I_prec)
  564     int_sum(i) = int_sum(i) - num_carry*prec
  565     int_sum(i-1) = int_sum(i-1) + num_carry
  566   endif ; enddo
```
This can cause inconsistency in reproducibility across CPUs,
particularly on 1 rank, since the construction of `int_sum` will not
produce filled bins of size `prec`.

We fix this by replacing the `>` check with a `>=`, so that both overfilled
and exactly full values in a bin are also transferred up to the next
bin.  We specifically fix this in `regularize_ints`, but also in
`carry_overflow` for the sake of consistency.

This was observed in the mean calculations of a few sparse diagnostics
at isolated timesteps for certain CPU layouts, and caused variation in
the least significant bit (LSB).  When the patch was applied, results
were consistent with the 1-rank result.

It seems like a phenomenal coincidence that a bin value managed to
exactly equal `prec`, which may indicate a further systematic error
somewhere, but that can be treated as a separate issue.

While this change has the potential to modify answers, since we are
modifying the results of `reproducing_sum`, no changes were observed in
the regression tests.