### PR TITLE
Diagnostic fixes on sym/nonsym grids, remapped, and averaged fields

### DIFF
--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1128,8 +1128,17 @@ subroutine calculate_derivs(dt, G, CS)
   if (dt > 0.0) then ; Idt = 1.0/dt
   else ; return ; endif
 
+  ! Because the field is unknown, its grid index bounds are also unknown.
+  ! Additionally, two of the fields (dudt, dvdt) require calculation of spatial
+  ! derivatives when computing d(KE)/dt.  This raises issues in non-symmetric
+  ! mode, where the symmetric boundaries (west, south) may not be updated.
+
+  ! For this reason, we explicitly loop from isc-1:iec and jsc-1:jec, in order
+  ! to force boundary value updates, even though it may not be strictly valid
+  ! for all fields.  Note this assumes a halo, and that it has been updated.
+
   do m=1,CS%num_time_deriv
-    do k=1,CS%nlay(m) ; do j=G%jsc,G%jec ; do i=G%isc,G%iec
+    do k=1,CS%nlay(m) ; do j=G%jsc-1,G%jec ; do i=G%isc-1,G%iec
       CS%deriv(m)%p(i,j,k) = (CS%var_ptr(m)%p(i,j,k) - CS%prev_val(m)%p(i,j,k)) * Idt
       CS%prev_val(m)%p(i,j,k) = CS%var_ptr(m)%p(i,j,k)
     enddo ; enddo ; enddo

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -750,7 +750,7 @@ subroutine set_masks_for_axes(G, diag_cs)
       call assert(axes%nz == nk, 'set_masks_for_axes: vertical size mismatch at h-interfaces')
       call assert(.not. associated(axes%mask3d), 'set_masks_for_axes: already associated')
       allocate( axes%mask3d(G%isd:G%ied,G%jsd:G%jed,nk+1) ) ; axes%mask3d(:,:,:) = 0.
-      do J=G%jsc-1,G%jec ; do i=G%isc,G%iec
+      do J=G%jsc-1,G%jec+1 ; do i=G%isc-1,G%iec+1
         if (h_axes%mask3d(i,j,1) > 0.) axes%mask3d(i,J,1) = 1.
         do K = 2, nk
           if (h_axes%mask3d(i,j,k-1) + h_axes%mask3d(i,j,k) > 0.) axes%mask3d(i,J,k) = 1.

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -379,10 +379,10 @@ subroutine diag_remap_do_remap(remap_cs, G, GV, h, staggered_in_x, staggered_in_
     ! U-points
     do j=G%jsc, G%jec
       do I=G%iscB, G%iecB
-        i1 = i - G%isdB + 1
-        i_lo = i1 - shift; i_hi = i_lo + 1
+        I1 = I - G%isdB + 1
+        i_lo = I1 - shift; i_hi = i_lo + 1
         if (associated(mask)) then
-          if (mask(i,j,1) == 0.) cycle
+          if (mask(I,j,1) == 0.) cycle
         endif
         h_src(:) = 0.5 * (h(i_lo,j,:) + h(i_hi,j,:))
         h_dest(:) = 0.5 * (remap_cs%h(i_lo,j,:) + remap_cs%h(i_hi,j,:))
@@ -395,11 +395,11 @@ subroutine diag_remap_do_remap(remap_cs, G, GV, h, staggered_in_x, staggered_in_
   elseif (staggered_in_y .and. .not. staggered_in_x) then
     ! V-points
     do J=G%jscB, G%jecB
-      j1 = j - G%jsdB + 1
-      j_lo = j1 - shift; j_hi = j_lo + 1
+      J1 = J - G%jsdB + 1
+      j_lo = J1 - shift; j_hi = j_lo + 1
       do i=G%isc, G%iec
         if (associated(mask)) then
-          if (mask(i,j,1) == 0.) cycle
+          if (mask(i,J,1) == 0.) cycle
         endif
         h_src(:) = 0.5 * (h(i,j_lo,:) + h(i,j_hi,:))
         h_dest(:) = 0.5 * (remap_cs%h(i,j_lo,:) + remap_cs%h(i,j_hi,:))
@@ -509,10 +509,10 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, staggered_in_x, sta
     ! U-points
     do j=G%jsc, G%jec
       do I=G%iscB, G%iecB
-        i1 = i - G%isdB + 1
-        i_lo = i1 - shift; i_hi = i_lo + 1
+        I1 = I - G%isdB + 1
+        i_lo = I1 - shift; i_hi = i_lo + 1
         if (associated(mask)) then
-          if (mask(i,j,1) == 0.) cycle
+          if (mask(I,j,1) == 0.) cycle
         endif
         h_src(:) = 0.5 * (h(i_lo,j,:) + h(i_hi,j,:))
         h_dest(:) = 0.5 * (remap_cs%h(i_lo,j,:) + remap_cs%h(i_hi,j,:))
@@ -523,11 +523,11 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, staggered_in_x, sta
   elseif (staggered_in_y .and. .not. staggered_in_x) then
     ! V-points
     do J=G%jscB, G%jecB
-      j1 = j - G%jsdB + 1
-      j_lo = j1 - shift; j_hi = j_lo + 1
+      J1 = J - G%jsdB + 1
+      j_lo = J1 - shift; j_hi = j_lo + 1
       do i=G%isc, G%iec
         if (associated(mask)) then
-          if (mask(i,j,1) == 0.) cycle
+          if (mask(i,J,1) == 0.) cycle
         endif
         h_src(:) = 0.5 * (h(i,j_lo,:) + h(i,j_hi,:))
         h_dest(:) = 0.5 * (remap_cs%h(i,j_lo,:) + remap_cs%h(i,j_hi,:))
@@ -591,10 +591,10 @@ subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, sta
     ! U-points
     do j=G%jsc, G%jec
       do I=G%iscB, G%iecB
-        i1 = i - G%isdB + 1
-        i_lo = i1 - shift; i_hi = i_lo + 1
+        I1 = I - G%isdB + 1
+        i_lo = I1 - shift; i_hi = i_lo + 1
         if (associated(mask)) then
-          if (mask(i,j,1) == 0.) cycle
+          if (mask(I,j,1) == 0.) cycle
         endif
         h_src(:) = 0.5 * (h(i_lo,j,:) + h(i_hi,j,:))
         h_dest(:) = 0.5 * (remap_cs%h(i_lo,j,:) + remap_cs%h(i_hi,j,:))
@@ -605,11 +605,11 @@ subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, sta
   elseif (staggered_in_y .and. .not. staggered_in_x) then
     ! V-points
     do J=G%jscB, G%jecB
-      j1 = j - G%jsdB + 1
-      j_lo = j1 - shift; j_hi = j_lo + 1
+      J1 = J - G%jsdB + 1
+      j_lo = J1 - shift; j_hi = j_lo + 1
       do i=G%isc, G%iec
         if (associated(mask)) then
-          if (mask(i,j,1) == 0.) cycle
+          if (mask(i,J,1) == 0.) cycle
         endif
         h_src(:) = 0.5 * (h(i,j_lo,:) + h(i,j_hi,:))
         h_dest(:) = 0.5 * (remap_cs%h(i,j_lo,:) + remap_cs%h(i,j_hi,:))

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -7,7 +7,7 @@ use MOM_debugging,     only : hchksum
 use MOM_diag_mediator, only : post_data, query_averaging_enabled, diag_ctrl
 use MOM_diag_mediator, only : register_diag_field, safe_alloc_ptr, time_type
 use MOM_diag_mediator, only : diag_update_remap_grids
-use MOM_domains,       only : pass_var
+use MOM_domains,       only : pass_var, To_West, To_South, Omit_Corners
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_forcing_type,  only : mech_forcing
@@ -750,6 +750,9 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
 
   ! Whenever thickness changes let the diag manager know, target grids
   ! for vertical remapping may need to be regenerated.
+  if (CS%id_uhml > 0 .or. CS%id_vhml > 0) &
+    ! Remapped uhml and vhml require east/north halo updates of h
+    call pass_var(h, G%domain, To_West+To_South+Omit_Corners, halo=1)
   call diag_update_remap_grids(CS%diag)
 
   ! Offer diagnostic fields for averaging.


### PR DESCRIPTION
This PR has several changes related to fixing several diagnostics, mostly issues with boundary values due to symmetric vs. non-symmetric grids, as well as a number of fixes to the supplemental vertically remapped and horizontally averaged diagnostics.

Details of the changes are in the individual commit logs.  Many of the diagnostic values will have changed, but should now be consistent for symmetric and nonsymmetric grids, and across layouts.  Model dynamics should be unaffected.