### PR TITLE
 Conditional registration of FrictWorkMax with MEKE

### DIFF
--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1418,6 +1418,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
                            ! valid parameters.
   logical :: split         ! If true, use the split time stepping scheme.
                            ! If false and USE_GME = True, issue a FATAL error.
+  logical :: use_MEKE      ! True if MEKE has been enabled
   character(len=64) :: inputdir, filename
   real    :: deg2rad       ! Converts degrees to radians
   real    :: slat_fn       ! sin(lat)**Kh_pwr_of_sine
@@ -1690,6 +1691,9 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
       "LAPLACIAN or BIHARMONIC viscosity.")
     return ! We are not using either Laplacian or Bi-harmonic lateral viscosity
   endif
+
+  call get_param(param_file, mdl, "USE_MEKE", use_MEKE, default=.false., &
+                 do_not_log=.true.)
 
   deg2rad = atan(1.0) / 45.
 
@@ -2081,8 +2085,10 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
   CS%id_FrictWork_diss = register_diag_field('ocean_model','FrictWork_diss',diag%axesTL,Time,&
       'Integral work done by lateral friction terms (excluding diffusion of energy)', 'W m-2')
 
-  CS%id_FrictWorkMax = register_diag_field('ocean_model','FrictWorkMax',diag%axesTL,Time,&
-      'Maximum possible integral work done by lateral friction terms', 'W m-2')
+  if (use_MEKE) then
+    CS%id_FrictWorkMax = register_diag_field('ocean_model','FrictWorkMax',diag%axesTL,Time,&
+        'Maximum possible integral work done by lateral friction terms', 'W m-2')
+  endif
 
   CS%id_FrictWorkIntz = register_diag_field('ocean_model','FrictWorkIntz',diag%axesT1,Time,      &
       'Depth integrated work done by lateral friction', 'W m-2',                          &


### PR DESCRIPTION
The `FrictWorkMax` diagnostic requires that MEKE be enabled and that `MEKE%MEKE` field be allocated and defined.  It is currently possible to register this diagnostic, even when MEKE is disabled.

This patch prevents the registration of `FrictWorkMax` when MEKE is turned off.