### PR TITLE
More useful message when detecting bad surface state

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2701,7 +2701,7 @@ subroutine extract_surface_state(CS, sfc_state)
   real :: T_freeze           !< freezing temperature [degC]
   real :: delT(SZI_(CS%G))   !< T-T_freeze [degC]
   logical :: use_temperature !< If true, temp and saln used as state variables.
-  integer :: i, j, k, is, ie, js, je, nz, numberOfErrors
+  integer :: i, j, k, is, ie, js, je, nz, numberOfErrors, ig, jg
   integer :: isd, ied, jsd, jed
   integer :: iscB, iecB, jscB, jecB, isdB, iedB, jsdB, jedB
   logical :: localError
@@ -2980,18 +2980,22 @@ subroutine extract_surface_state(CS, sfc_state)
         if (localError) then
           numberOfErrors=numberOfErrors+1
           if (numberOfErrors<9) then ! Only report details for the first few errors
+            ig = i + G%HI%idg_offset ! Global i-index
+            jg = j + G%HI%jdg_offset ! Global j-index
             if (use_temperature) then
-              write(msg(1:240),'(2(a,i4,x),2(a,f8.3,x),8(a,es11.4,x))') &
-                'Extreme surface sfc_state detected: i=',i,'j=',j, &
-                'x=',G%geoLonT(i,j), 'y=',G%geoLatT(i,j), &
+              write(msg(1:240),'(2(a,i4,x),4(a,f8.3,x),8(a,es11.4,x))') &
+                'Extreme surface sfc_state detected: i=',ig,'j=',jg, &
+                'lon=',G%geoLonT(i,j), 'lat=',G%geoLatT(i,j), &
+                'x=',G%gridLonT(ig), 'y=',G%gridLatT(jg), &
                 'D=',bathy_m,  'SSH=',sfc_state%sea_lev(i,j), &
                 'SST=',sfc_state%SST(i,j), 'SSS=',sfc_state%SSS(i,j), &
                 'U-=',sfc_state%u(I-1,j), 'U+=',sfc_state%u(I,j), &
                 'V-=',sfc_state%v(i,J-1), 'V+=',sfc_state%v(i,J)
             else
-              write(msg(1:240),'(2(a,i4,x),2(a,f8.3,x),6(a,es11.4))') &
-                'Extreme surface sfc_state detected: i=',i,'j=',j, &
-                'x=',G%geoLonT(i,j), 'y=',G%geoLatT(i,j), &
+              write(msg(1:240),'(2(a,i4,x),4(a,f8.3,x),6(a,es11.4))') &
+                'Extreme surface sfc_state detected: i=',ig,'j=',jg, &
+                'lon=',G%geoLonT(i,j), 'lat=',G%geoLatT(i,j), &
+                'x=',G%gridLonT(i), 'y=',G%gridLatT(j), &
                 'D=',bathy_m,  'SSH=',sfc_state%sea_lev(i,j), &
                 'U-=',sfc_state%u(I-1,j), 'U+=',sfc_state%u(I,j), &
                 'V-=',sfc_state%v(i,J-1), 'V+=',sfc_state%v(i,J)


### PR DESCRIPTION
When the surface state went out of user-specified bounds we reported an error such as:
```
WARNING from PE   130: Extreme surface sfc_state detected: i=  18 j=  18 x= -60.625 y= -72.075 D= 1.9385E+01 SSH=-1.1945E+00 SST=-2.5183E+00 SSS= 3.2605E+01 U-= 0.0000E+00 U+=-8.9452E-03 V-= 0.0000E+00 V+= 0.0000E+00
```
The i,j here are the on-core local i,j and the x,y are the geographic location (so you can find the location on a map). Neither of these are particularly useful when looking at actual model output unless you are adept on projections.

This commit changes the message to:
```
WARNING from PE   130: Extreme surface sfc_state detected: i= 958 j=  89 lon= -60.625 lat= -72.075 x= -60.042 y= -72.075 D= 1.9385E+01 SSH=-1.1945E+00 SST=-2.5183E+00 SSS= 3.2605E+01 U-= 0.0000E+00 U+=-8.9452E-0
3 V-= 0.0000E+00 V+= 0.0000E+00
```
which allows you to look at model output using either indices or coordinates and still find the location on a map.

- Changes the reported i,j-location to global index
- Adds the diagnostic grid-lon,lat to report