### PR TITLE
Allows vector-of-reals debugging parameters

### DIFF
--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -1370,7 +1370,7 @@ end subroutine log_param_real
 
 !> Log the name and values of an array of real model parameter in documentation files.
 subroutine log_param_real_array(CS, modulename, varname, value, desc, &
-                                units, default)
+                                units, default, debuggingParam)
   type(param_file_type),      intent(in) :: CS      !< The control structure for the file_parser module,
                                          !! it is also a structure to parse for run-time parameters
   character(len=*),           intent(in) :: modulename !< The name of the calling module
@@ -1380,6 +1380,8 @@ subroutine log_param_real_array(CS, modulename, varname, value, desc, &
                                              !! present, this parameter is not written to a doc file
   character(len=*), optional, intent(in) :: units   !< The units of this parameter
   real,             optional, intent(in) :: default !< The default value of the parameter
+  logical,          optional, intent(in) :: debuggingParam !< If present and true, this parameter is
+                                         !! logged in the debugging parameter file
 
   character(len=1320) :: mesg
   character(len=240) :: myunits
@@ -1396,7 +1398,8 @@ subroutine log_param_real_array(CS, modulename, varname, value, desc, &
 
   myunits="not defined"; if (present(units)) write(myunits(1:240),'(A)') trim(units)
   if (present(desc)) &
-    call doc_param(CS%doc, varname, desc, myunits, value, default)
+    call doc_param(CS%doc, varname, desc, myunits, value, default, &
+                   debuggingParam=debuggingParam)
 
 end subroutine log_param_real_array
 
@@ -1739,7 +1742,8 @@ end subroutine get_param_real
 !> This subroutine reads the values of an array of real model parameters from a parameter file
 !! and logs them in documentation files.
 subroutine get_param_real_array(CS, modulename, varname, value, desc, units, &
-               default, fail_if_missing, do_not_read, do_not_log, static_value, scale, unscaled)
+               default, fail_if_missing, do_not_read, do_not_log, debuggingParam, &
+               static_value, scale, unscaled)
   type(param_file_type),      intent(in)    :: CS      !< The control structure for the file_parser module,
                                          !! it is also a structure to parse for run-time parameters
   character(len=*),           intent(in)    :: modulename !< The name of the calling module
@@ -1759,6 +1763,8 @@ subroutine get_param_real_array(CS, modulename, varname, value, desc, units, &
                                          !! value for this parameter, although it might be logged.
   logical,          optional, intent(in)    :: do_not_log !< If present and true, do not log this
                                          !! parameter to the documentation files
+  logical,          optional, intent(in)    :: debuggingParam !< If present and true, this parameter is
+                                         !! logged in the debugging parameter file
   real,             optional, intent(in)    :: scale   !< A scaling factor that the parameter is
                                          !! multiplied by before it is returned.
   real, dimension(:), optional, intent(out) :: unscaled !< The value of the parameter that would be
@@ -1777,7 +1783,7 @@ subroutine get_param_real_array(CS, modulename, varname, value, desc, units, &
 
   if (do_log) then
     call log_param_real_array(CS, modulename, varname, value, desc, &
-                              units, default)
+                              units, default, debuggingParam)
   endif
 
   if (present(unscaled)) unscaled(:) = value(:)


### PR DESCRIPTION
When defining a parameter with `get_param()` we can indicate that the parameter is for debugging purposes with the optional argument `debuggingParam=.true.`. This had been implemented for scalar reals
but not for a vector of reals.