### PR TITLE
Use f2e2c86f6c0eb commit for FMS in .testing

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -2,7 +2,7 @@
 # e.g. make MEMORY_SHAPE=dynamic_symmetric REPRO=1 OPENMP=1
 
 # Versions to use
-FMS_COMMIT ?= xanadu
+FMS_COMMIT ?= f2e2c86f6c0eb6d389a20509a8a60fa22924e16b
 MKMF_COMMIT ?= master
 
 # Where to clone from


### PR DESCRIPTION
- Prior to rolling forward the FMS submodule in MOM6-examples, this
  rolls evaluates that version in the Travis-CI pipeline.
- f2e2c86f6c0eb includes changes necessary to build MOM6 on MacOS.
- Partial step towards NOAA-GFDL/MOM6-examples#279