### PR TITLE
added diagnostic for internal heat in 3D

### DIFF
--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -455,7 +455,7 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
         'internal_heat_h_tendency', diag%axesTL, Time,                &
         'Thickness tendency (in 3D) due to internal (geothermal) sources', &
         'm OR kg m-2', v_extensive = .true.)
- 
+
 end subroutine geothermal_init
 
 !> Clean up and deallocate memory associated with the geothermal heating module.

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -339,16 +339,16 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, CS, halo)
 
   ! Post diagnostic of 3D tendencies (heat, temperature, and thickness) due to internal heat
   if (CS%id_internal_heat_heat_tendency > 0) then
-    call post_data(CS%id_internal_heat_heat_tendemcy, work_3d, CS%diag, alt_h = h_old)
+    call post_data(CS%id_internal_heat_heat_tendency, work_3d, CS%diag, alt_h = h_old)
   endif
   if (CS%id_internal_heat_temp_tendency > 0) then
-    do j=js,je; do i=is,ie; do k=ks,ke
+    do j=js,je; do i=is,ie; do k=nz,1,-1
       work_3d(i,j,k) = Idt * (tv%T(i,j,k) - T_old(i,j,k))
     enddo; enddo; enddo
-    call post_data(CS%id_T_internal_heat_temp_tendency, work_3d, CS%diag, alt_h = h_old)
+    call post_data(CS%id_internal_heat_temp_tendency, work_3d, CS%diag, alt_h = h_old)
   endif
   if (CS%id_internal_heat_h_tendency > 0) then
-    do j=js,je; do i=is,ie; do k=ks,ke
+    do j=js,je; do i=is,ie; do k=nz,1,-1
       work_3d(i,j,k) = Idt * (h(i,j,k) - h_old(i,j,k))
     enddo; enddo; enddo
     call post_data(CS%id_internal_heat_h_tendency, work_3d, CS%diag, alt_h = h_old)
@@ -455,7 +455,7 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
         'internal_heat_h_tendency', diag%axesTL, Time,                &
         'Thickness tendency (in 3D) due to internal (geothermal) sources', &
         'm OR kg m-2', v_extensive = .true.)
-  
+ 
 end subroutine geothermal_init
 
 !> Clean up and deallocate memory associated with the geothermal heating module.

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -193,11 +193,12 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, CS, halo)
 
         ! Save temperature and thickness before any changes are made (for diagnostic)
         if (CS%id_internal_heat_h_tendency > 0 &
-             .or. CS%id_internal_heat_heat_tendency &
-             .or. CS%id_internal_heat_temp_tendency ) then
+             .or. CS%id_internal_heat_heat_tendency > 0 &
+             .or. CS%id_internal_heat_temp_tendency > 0 ) then
           h_old(i,j,k) = h(i,j,k)
         endif
-        if (CS%id_internal_heat_heat_tendency > 0 .or. CS%id_internal_heat_temp_tendency) then
+        if (CS%id_internal_heat_heat_tendency > 0 &
+             .or. CS%id_internal_heat_temp_tendency > 0) then
           T_old(i,j,k) = tv%T(i,j,k)
         endif
 

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -35,6 +35,8 @@ type, public :: geothermal_CS ; private
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
                                              !! regulate the timing of diagnostic output.
+  integer :: id_internal_heat_tend_3d = -1 ! ID for 3D diagnostic of internal heat
+
 end type geothermal_CS
 
 contains
@@ -100,6 +102,11 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, CS, halo)
   real :: Irho_cp       ! inverse of heat capacity per unit layer volume
                         ! [degC H m2 J-1 ~> degC m3 J-1 or degC kg J-1]
 
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: temp_old  ! Temperature of each layer before any heat is added, for diagnostics [degC]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_old     ! Thickness of each layer before any heat is added, for diagnostics [m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: work_3d   ! Scratch variable used to calculate change in heat due to geothermal
+  real :: Idt           ! inverse of the timestep [s-1]
+
   logical :: do_i(SZI_(G))
   integer :: i, j, k, is, ie, js, je, nz, k2, i2
   integer :: isj, iej, num_start, num_left, nkmb, k_tgt
@@ -119,6 +126,7 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, CS, halo)
   Angstrom  = GV%Angstrom_H
   H_neglect = GV%H_subroundoff
   p_ref(:)  = tv%P_Ref
+  Idt       = 1/dt
 
   if (.not.associated(tv%T)) call MOM_error(FATAL, "MOM geothermal: "//&
       "Geothermal heating can only be applied if T & S are state variables.")
@@ -135,6 +143,10 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, CS, halo)
 !$OMP                                  dRcv_dS_,heat_in_place,heat_trans,         &
 !$OMP                                  wt_in_place,dTemp,dRcv,h_transfer,heating, &
 !$OMP                                  I_h)
+
+! Save temperature and thickness before any changes are made (for diagnostic)
+temp_old = tv%T
+h_old = h
 
   do j=js,je
     ! 1. Only work on columns that are being heated.
@@ -304,6 +316,14 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, CS, halo)
     enddo ; endif
   enddo ! j-loop
 
+! Calculate heat tendency due to addition and transfer of internal heat
+if (CS%id_internal_heat_tend_3d > 0) then
+  do k=1,nz ; do j=js,je ; do i=is,ie
+    work_3d(i,j,k) = GV%H_to_kg_m2 * tv%C_p * Idt * (h(i,j,k) * tv%T(i,j,k) - h_old(i,j,k) * temp_old(i,j,k))
+  enddo ; enddo ; enddo
+  call post_data(CS%id_internal_heat_tend_3d, work_3d, CS%diag, alt_h = h_old)
+endif
+
 !  do i=is,ie ; do j=js,je
 !    resid(i,j) = tv%internal_heat(i,j) - resid(i,j) - GV%H_to_kg_m2 * &
 !           (G%mask2dT(i,j) * (CS%geo_heat(i,j) * (dt*Irho_cp)))
@@ -392,6 +412,12 @@ subroutine geothermal_init(Time, G, param_file, diag, CS)
         x_cell_method='mean', y_cell_method='mean', area_cell_method='mean')
   if (id > 0) call post_data(id, CS%geo_heat, diag, .true.)
 
+  ! Diagnostic for tendency due to internal heat (in 3d)
+  CS%id_internal_heat_tend_3d = register_diag_field('ocean_model',&
+        'internal_heat_tend_3d', diag%axesTL, Time,             &
+        'Internal heat tendency in 3D, reveals layer(s) that heat is added to','W m-2',&
+        v_extensive = .true.)
+  
 end subroutine geothermal_init
 
 !> Clean up and deallocate memory associated with the geothermal heating module.

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -35,7 +35,7 @@ type, public :: geothermal_CS ; private
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
                                              !! regulate the timing of diagnostic output.
-  integer :: id_internal_heat_tend_3d = -1   !< test ID for 3D diagnostic of internal heat
+  integer :: id_internal_heat_tend_3d = -1   !< ID for 3D diagnostic of internal heat
 
 end type geothermal_CS
 

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -35,7 +35,7 @@ type, public :: geothermal_CS ; private
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
                                              !! regulate the timing of diagnostic output.
-  integer :: id_internal_heat_tend_3d = -1   !< ID for 3D diagnostic of internal heat
+  integer :: id_internal_heat_tend_3d = -1   !< test ID for 3D diagnostic of internal heat
 
 end type geothermal_CS
 


### PR DESCRIPTION
Previous diagnostic for heat tendency due to geothermal heating was only a 2D field, with no information on the model layer into which the heat is added, preventing closure of cell-wise heat budget. Created a new diagnostic in MOM_geothermal.F90, called `internal_heat_tend_3d` that keeps track of the change in the 3d heat field heat before and after geothermal heating is applied.