### PR TITLE
(*) Bugfix: [uv]hml z-diags in general restrat

### DIFF
--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -514,6 +514,13 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt_in_T, MLD_in
   enddo ; enddo ; enddo
 !$OMP end parallel
 
+  ! Whenever thickness changes let the diag manager know, target grids
+  ! for vertical remapping may need to be regenerated.
+  if (CS%id_uhml > 0 .or. CS%id_vhml > 0) &
+    ! Remapped uhml and vhml require east/north halo updates of h
+    call pass_var(h, G%domain, To_West+To_South+Omit_Corners, halo=1)
+  call diag_update_remap_grids(CS%diag)
+
   ! Offer diagnostic fields for averaging.
   if (query_averaging_enabled(CS%diag)) then
     if (CS%id_urestrat_time > 0) call post_data(CS%id_urestrat_time, utimescale_diag, CS%diag)


### PR DESCRIPTION
The z-interpolated uhml and vhml diagnostics gave inconsistent answers
across layouts when using the general mixed layer restratification
scheme, because the value of h had changed but its halos had not been
updated.

This had been previously fixed in the BML restratification but not the
general stratification method.

This patch updates the value of h by conditionally updating the halos if
this diagnostic is required.