### PR TITLE
Travis: config.mk user config; enable coverage

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -219,13 +219,13 @@ endif
 
 define STAT_RULE
 $$(BASE)/.testing/%/ocean.stats.$(1): $$(BUILD)/$(2)/MOM6
-	if [ $(3) ]; then find build -name *.gcda -exec rm -f '{}' \; ; fi
+	if [ $(3) ]; then find $$(BUILD) -name *.gcda -exec rm -f '{}' \; ; fi
 	mkdir -p $$(@D)/RESTART
 	echo $(4) > $$(@D)/MOM_override
 	cd $$(@D) && $$(call MPIRUN_CMD,$(5)) -n $(6) $$< 2> debug.out
 	cp $$(@D)/ocean.stats $$@
 	> $$(@D)/MOM_override
-	if [ $(3) ]; then bash <(curl -s https://codecov.io/bash) -n $$@; fi
+	if [ $(3) ]; then cd $$(BASE) && bash <(curl -s https://codecov.io/bash) -n $$@; fi
 
 $$(BASE)/.testing/%/chksum_diag.$(1): $$(BASE)/.testing/%/ocean.stats.$(1)
 	cp $$(@D)/chksum_diag $$@

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -1,6 +1,8 @@
 SHELL = bash
 MPIRUN ?= mpirun
 
+-include config.mk
+
 #---
 # Dependencies
 BASE = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/..

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ jobs:
             REPORT_COVERAGE=true
         - echo -en 'travis_fold:end:script.1\\r'
         - echo 'Running tests...' && echo -en 'travis_fold:start:script.2\\r'
-        - make \
+        - make test \
             DO_REGRESSION_TESTS=${TRAVIS_IS_PR} \
-            REPORT_COVERAGE=true \
-            test
+            REPORT_COVERAGE=true
         - echo -en 'travis_fold:end:script.2\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,8 @@ jobs:
             REPORT_COVERAGE=true
         - echo -en 'travis_fold:end:script.1\\r'
         - echo 'Running tests...' && echo -en 'travis_fold:start:script.2\\r'
-        - make DO_REGRESSION_TESTS=${TRAVIS_IS_PR} test
+        - make \
+            DO_REGRESSION_TESTS=${TRAVIS_IS_PR} \
+            REPORT_COVERAGE=true \
+            test
         - echo -en 'travis_fold:end:script.2\\r'


### PR DESCRIPTION
This PR enables coverage cleanup and CodeCov upload for test runs.

It also introduces an optional configuration file, config.mk which can
be used for user-configured settings, such as templates or mpirun
commands.