### PR TITLE
*Add new update_segment_tracer_reservoirs routine

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -86,6 +86,7 @@ use MOM_obsolete_diagnostics,  only : register_obsolete_diagnostics
 use MOM_open_boundary,         only : ocean_OBC_type, OBC_registry_type
 use MOM_open_boundary,         only : register_temp_salt_segments
 use MOM_open_boundary,         only : open_boundary_register_restarts
+use MOM_open_boundary,         only : update_segment_tracer_reservoirs
 use MOM_set_visc,              only : set_viscous_BBL, set_viscous_ML, set_visc_init
 use MOM_set_visc,              only : set_visc_register_restarts, set_visc_CS
 use MOM_sponge,                only : init_sponge_diags, sponge_CS
@@ -1089,6 +1090,8 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   call tracer_hordiff(h, CS%t_dyn_rel_adv, CS%MEKE, CS%VarMix, G, GV, US, &
                       CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
   if (showCallTree) call callTree_waypoint("finished tracer advection/diffusion (step_MOM)")
+  call update_segment_tracer_reservoirs(G, GV, CS%uhtr, CS%vhtr, h, CS%OBC, &
+                     CS%t_dyn_rel_adv, CS%tracer_Reg)
   call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
 
   call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -612,7 +612,13 @@ subroutine initialize_segment_data(G, OBC, PF)
     ! needs documentation !!  Yet, unsafe for now, causes grief for
     ! MOM_parameter_docs in circle_obcs on two processes.
 !   call get_param(PF, mdl, segnam, segstr, 'xyz')
+    ! Clear out any old values
+    segstr = ''
     call get_param(PF, mdl, segnam, segstr)
+    if (segstr == '') then
+      write(mesg,'("No OBC_SEGMENT_XXX_DATA string for OBC segment ",I3)') n
+      call MOM_error(FATAL, mesg)
+    endif
 
     call parse_segment_data_str(trim(segstr), fields=fields, num_fields=num_fields)
     if (num_fields == 0) then
@@ -772,8 +778,7 @@ subroutine initialize_segment_data(G, OBC, PF)
         segment%t_values_needed .or. segment%s_values_needed .or. &
         segment%z_values_needed .or. segment%g_values_needed) then
       write(mesg,'("Values needed for OBC segment ",I3)') n
-!     call MOM_error(FATAL, mesg)
-      call MOM_error(WARNING, mesg)
+      call MOM_error(FATAL, mesg)
     endif
   enddo
 
@@ -4111,7 +4116,6 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
        if (segment%is_E_or_W) then
          do j=segment%HI%jsd,segment%HI%jed
             I = segment%HI%IsdB
-
             ishift=0 ! ishift+I corresponds to the nearest interior tracer cell index
             idir=1   ! idir switches the sign of the flow so that positive is into the reservoir
             if (segment%direction == OBC_DIRECTION_W) then


### PR DESCRIPTION
- The OBC tracer reservoirs were being updated in MOM_tracer_advect -
  twice each! Update them separately after tracer advection.
- The OBC tracer lengthscale was being cubed to get the volume. Change
  that to a lengthscale times the face area where the advection is
  happening.
- Changes answers if the tracer lengthscales were not set to zero.