### PR TITLE
Travis: Output stderr on fail

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -222,7 +222,8 @@ $$(BASE)/.testing/%/ocean.stats.$(1): $$(BUILD)/$(2)/MOM6
 	if [ $(3) ]; then find $$(BUILD) -name *.gcda -exec rm -f '{}' \; ; fi
 	mkdir -p $$(@D)/RESTART
 	echo $(4) > $$(@D)/MOM_override
-	cd $$(@D) && $$(call MPIRUN_CMD,$(5)) -n $(6) $$< 2> debug.out
+	cd $$(@D) && $$(call MPIRUN_CMD,$(5)) -n $(6) $$< 2> debug.out \
+		|| ! cat debug.out
 	cp $$(@D)/ocean.stats $$@
 	> $$(@D)/MOM_override
 	if [ $(3) ]; then cd $$(BASE) && bash <(curl -s https://codecov.io/bash) -n $$@; fi


### PR DESCRIPTION
Stderr for a test is currently saved to the debug.out file, for future
potential parsing.  We now print this output to stdout if a test case
fails in order to help troubleshooting any failed Travis jobs.