### PR TITLE
Low CodeCov coverage threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ coverage:
     status:
         project:
             default:
-                target: 30%
+                threshold: 100%
         patch:
             default:
-                target: 50%
+                threshold: 100%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+    status:
+        project:
+            default:
+                target: 30%
+        patch:
+            default:
+                target: 50%


### PR DESCRIPTION
Testing a lower coverage threshold for CodeCov testing, since the
current settings are distracting during this early stage of testing.