### PR TITLE
Diag scaling p2

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -250,7 +250,8 @@ subroutine ALE_register_diags(Time, G, GV, US, diag, CS)
   CS%id_v_preale = register_diag_field('ocean_model', 'v_preale', diag%axesCvL, Time, &
       'Meridional velocity before remapping', 'm s-1', conversion=US%L_T_to_m_s)
   CS%id_h_preale = register_diag_field('ocean_model', 'h_preale', diag%axesTL, Time, &
-      'Layer Thickness before remapping', get_thickness_units(GV), v_extensive=.true.)
+      'Layer Thickness before remapping', get_thickness_units(GV), &
+      conversion=GV%H_to_MKS, v_extensive=.true.)
   CS%id_T_preale = register_diag_field('ocean_model', 'T_preale', diag%axesTL, Time, &
       'Temperature before remapping', 'degC')
   CS%id_S_preale = register_diag_field('ocean_model', 'S_preale', diag%axesTL, Time, &
@@ -260,8 +261,9 @@ subroutine ALE_register_diags(Time, G, GV, US, diag, CS)
 
   CS%id_dzRegrid = register_diag_field('ocean_model','dzRegrid',diag%axesTi,Time, &
       'Change in interface height due to ALE regridding', 'm')
-  cs%id_vert_remap_h = register_diag_field('ocean_model','vert_remap_h',diag%axestl,time, &
-      'layer thicknesses after ALE regridding and remapping', 'm', v_extensive = .true.)
+  cs%id_vert_remap_h = register_diag_field('ocean_model', 'vert_remap_h', &
+      diag%axestl, time, 'layer thicknesses after ALE regridding and remapping', 'm', &
+      conversion=GV%H_to_m, v_extensive=.true.)
   cs%id_vert_remap_h_tendency = register_diag_field('ocean_model','vert_remap_h_tendency',diag%axestl,time, &
       'Layer thicknesses tendency due to ALE regridding and remapping', 'm', v_extensive = .true.)
 

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -260,12 +260,14 @@ subroutine ALE_register_diags(Time, G, GV, US, diag, CS)
       'Interface Heights before remapping', 'm', conversion=US%Z_to_m)
 
   CS%id_dzRegrid = register_diag_field('ocean_model','dzRegrid',diag%axesTi,Time, &
-      'Change in interface height due to ALE regridding', 'm')
+      'Change in interface height due to ALE regridding', 'm', &
+      conversion=GV%H_to_m)
   cs%id_vert_remap_h = register_diag_field('ocean_model', 'vert_remap_h', &
       diag%axestl, time, 'layer thicknesses after ALE regridding and remapping', 'm', &
       conversion=GV%H_to_m, v_extensive=.true.)
   cs%id_vert_remap_h_tendency = register_diag_field('ocean_model','vert_remap_h_tendency',diag%axestl,time, &
-      'Layer thicknesses tendency due to ALE regridding and remapping', 'm', v_extensive = .true.)
+      'Layer thicknesses tendency due to ALE regridding and remapping', 'm', &
+      conversion=GV%H_to_m, v_extensive = .true.)
 
 end subroutine ALE_register_diags
 

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1323,7 +1323,7 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
 
   handles%id_massout_flux = register_diag_field('ocean_model', 'massout_flux', diag%axesT1, Time, &
         'Net mass flux of freshwater out of the ocean (used in the boundary flux calculation)', &
-         'kg m-2')
+         'kg m-2', conversion=diag%GV%H_to_kg_m2)
 
   handles%id_massin_flux  = register_diag_field('ocean_model', 'massin_flux', diag%axesT1, Time, &
         'Net mass flux of freshwater into the ocean (used in boundary flux calculation)', 'kg m-2')

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -61,6 +61,8 @@ type, public :: verticalGrid_type
   real :: H_to_Pa       !< A constant that translates the units of thickness to pressure [Pa].
   real :: H_to_Z        !< A constant that translates thickness units to the units of depth.
   real :: Z_to_H        !< A constant that translates depth units to thickness units.
+  real :: H_to_MKS      !< A constant that translates thickness units to its
+                        !! MKS unit (m or kg m-2) based on GV%Boussinesq
 
   real :: m_to_H_restart = 0.0 !< A copy of the m_to_H that is used in restart files.
 end type verticalGrid_type
@@ -143,11 +145,13 @@ subroutine verticalGridInit( param_file, GV, US )
     GV%kg_m2_to_H = 1.0 / GV%H_to_kg_m2
     GV%m_to_H = 1.0 / GV%H_to_m
     GV%Angstrom_H = GV%m_to_H * GV%Angstrom_m
+    GV%H_to_MKS = GV%H_to_m
   else
     GV%kg_m2_to_H = 1.0 / GV%H_to_kg_m2
     GV%m_to_H = GV%Rho0 * GV%kg_m2_to_H
     GV%H_to_m = GV%H_to_kg_m2 / GV%Rho0
     GV%Angstrom_H = GV%Angstrom_m*1000.0*GV%kg_m2_to_H
+    GV%H_to_MKS = GV%H_to_kg_m2
   endif
   GV%H_subroundoff = 1e-20 * max(GV%Angstrom_H,GV%m_to_H*1e-17)
   GV%H_to_Pa = GV%mks_g_Earth * GV%H_to_kg_m2

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1845,7 +1845,7 @@ subroutine register_transport_diags(Time, G, GV, US, IDs, diag)
       'm s-1', v_extensive=.true., conversion=GV%H_to_m)
   IDs%id_dynamics_h_tendency = register_diag_field('ocean_model','dynamics_h_tendency',  &
       diag%axesTl, Time, 'Change in layer thicknesses due to horizontal dynamics', &
-      'm s-1', v_extensive=.true.)
+      'm s-1', v_extensive=.true., conversion=GV%H_to_m)
 
 end subroutine register_transport_diags
 

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1765,7 +1765,7 @@ subroutine post_xy_average(diag_cs, diag, field)
   staggered_in_y = diag%axes%is_v_point .or. diag%axes%is_q_point
 
   if (diag%axes%is_native) then
-    call horizontally_average_diag_field(diag_cs%G, diag_cs%h, &
+    call horizontally_average_diag_field(diag_cs%G, diag_cs%GV, diag_cs%h, &
                                          staggered_in_x, staggered_in_y, &
                                          diag%axes%is_layer, diag%v_extensive, &
                                          diag_cs%missing_value, field, &
@@ -1783,7 +1783,8 @@ subroutine post_xy_average(diag_cs, diag, field)
     call assert(IMPLIES(.not. diag%axes%is_layer, nz == remap_nz+1), &
               'post_xy_average: interface field dimension mismatch.')
 
-    call horizontally_average_diag_field(diag_cs%G, diag_cs%diag_remap_cs(coord)%h, &
+    call horizontally_average_diag_field(diag_cs%G, diag_cs%GV, &
+                                         diag_cs%diag_remap_cs(coord)%h, &
                                          staggered_in_x, staggered_in_y, &
                                          diag%axes%is_layer, diag%v_extensive, &
                                          diag_cs%missing_value, field, &

--- a/src/framework/MOM_spatial_means.F90
+++ b/src/framework/MOM_spatial_means.F90
@@ -36,9 +36,9 @@ function global_area_mean(var,G)
 
   tmpForSumming(:,:) = 0.
   do j=js,je ; do i=is,ie
-    tmpForSumming(i,j) = var(i,j) * (G%areaT(i,j) * G%mask2dT(i,j))
+    tmpForSumming(i,j) = var(i,j) * (G%US%L_to_m**2 * G%areaT(i,j) * G%mask2dT(i,j))
   enddo ; enddo
-  global_area_mean = reproducing_sum( tmpForSumming ) * G%IareaT_global
+  global_area_mean = reproducing_sum(tmpForSumming) * (G%US%m_to_L**2 * G%IareaT_global)
 
 end function global_area_mean
 
@@ -54,9 +54,9 @@ function global_area_integral(var,G)
 
   tmpForSumming(:,:) = 0.
   do j=js,je ; do i=is, ie
-    tmpForSumming(i,j) = ( var(i,j) * (G%US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j)) )
+    tmpForSumming(i,j) = var(i,j) * (G%US%L_to_m**2 * G%areaT(i,j) * G%mask2dT(i,j))
   enddo ; enddo
-  global_area_integral = reproducing_sum( tmpForSumming )
+  global_area_integral = reproducing_sum(tmpForSumming)
 
 end function global_area_integral
 

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -884,30 +884,30 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
 
   CS%diag => diag
 
-  if (GV%Boussinesq) then ; flux_to_kg_per_s = GV%H_to_kg_m2 * US%L_to_m**2 * US%s_to_T
-  else ; flux_to_kg_per_s = GV%H_to_m * US%L_to_m**2 * US%s_to_T ; endif
+  flux_to_kg_per_s = GV%H_to_kg_m2 * US%L_to_m**2 * US%s_to_T
 
   CS%id_uhml = register_diag_field('ocean_model', 'uhml', diag%axesCuL, Time, &
-      'Zonal Thickness Flux to Restratify Mixed Layer', 'kg s-1', conversion=flux_to_kg_per_s, &
-      y_cell_method='sum', v_extensive=.true.)
+      'Zonal Thickness Flux to Restratify Mixed Layer', 'kg s-1', &
+      conversion=flux_to_kg_per_s, y_cell_method='sum', v_extensive=.true.)
   CS%id_vhml = register_diag_field('ocean_model', 'vhml', diag%axesCvL, Time, &
-      'Meridional Thickness Flux to Restratify Mixed Layer', 'kg s-1', conversion=flux_to_kg_per_s, &
-      x_cell_method='sum', v_extensive=.true.)
+      'Meridional Thickness Flux to Restratify Mixed Layer', 'kg s-1', &
+      conversion=flux_to_kg_per_s, x_cell_method='sum', v_extensive=.true.)
   CS%id_urestrat_time = register_diag_field('ocean_model', 'MLu_restrat_time', diag%axesCu1, Time, &
       'Mixed Layer Zonal Restratification Timescale', 's', conversion=US%T_to_s)
   CS%id_vrestrat_time = register_diag_field('ocean_model', 'MLv_restrat_time', diag%axesCv1, Time, &
       'Mixed Layer Meridional Restratification Timescale', 's', conversion=US%T_to_s)
   CS%id_MLD = register_diag_field('ocean_model', 'MLD_restrat', diag%axesT1, Time, &
-      'Mixed Layer Depth as used in the mixed-layer restratification parameterization', 'm')
+      'Mixed Layer Depth as used in the mixed-layer restratification parameterization', 'm', &
+      conversion=GV%H_to_m)
   CS%id_Rml = register_diag_field('ocean_model', 'ML_buoy_restrat', diag%axesT1, Time, &
       'Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization', &
-      'm s2', conversion=US%m_to_Z*US%L_to_m**2*US%s_to_T**2)
+      'm s2', conversion=US%m_to_Z*(US%L_to_m**2)*(US%s_to_T**2))
   CS%id_uDml = register_diag_field('ocean_model', 'udml_restrat', diag%axesCu1, Time, &
       'Transport stream function amplitude for zonal restratification of mixed layer', &
-      'm3 s-1', conversion=GV%H_to_m*US%L_to_m**2*US%s_to_T)
+      'm3 s-1', conversion=GV%H_to_m*(US%L_to_m**2)*US%s_to_T)
   CS%id_vDml = register_diag_field('ocean_model', 'vdml_restrat', diag%axesCv1, Time, &
       'Transport stream function amplitude for meridional restratification of mixed layer', &
-      'm3 s-1', conversion=GV%H_to_m*US%L_to_m**2*US%s_to_T)
+      'm3 s-1', conversion=GV%H_to_m*(US%L_to_m**2)*US%s_to_T)
   CS%id_uml = register_diag_field('ocean_model', 'uml_restrat', diag%axesCu1, Time, &
       'Surface zonal velocity component of mixed layer restratification', &
       'm s-1', conversion=US%L_T_to_m_s)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -66,7 +66,7 @@ use MOM_tracer_diabatic,     only : tracer_vertdiff
 use MOM_unit_scaling,        only : unit_scale_type
 use MOM_variables,           only : thermo_var_ptrs, vertvisc_type, accel_diag_ptrs
 use MOM_variables,           only : cont_diag_ptrs, MOM_thermovar_chksum, p3d
-use MOM_verticalGrid,        only : verticalGrid_type
+use MOM_verticalGrid,        only : verticalGrid_type, get_thickness_units
 use MOM_wave_speed,          only : wave_speeds
 use MOM_wave_interface,      only : wave_parameters_CS
 
@@ -508,10 +508,10 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
     Kd_heat,  & ! diapycnal diffusivity of heat [Z2 T-1 ~> m2 s-1]
     Kd_salt,  & ! diapycnal diffusivity of salt and passive tracers [Z2 T-1 ~> m2 s-1]
     Kd_ePBL,  & ! test array of diapycnal diffusivities at interfaces [Z2 T-1 ~> m2 s-1]
-    Tdif_flx, & ! diffusive diapycnal heat flux across interfaces [degC m s-1]
-    Tadv_flx, & ! advective diapycnal heat flux across interfaces [degC m s-1]
-    Sdif_flx, & ! diffusive diapycnal salt flux across interfaces [ppt m s-1]
-    Sadv_flx    ! advective diapycnal salt flux across interfaces [ppt m s-1]
+    Tdif_flx, & ! diffusive diapycnal heat flux across interfaces [degC H s-1 ~> degC m s-1 or degC kg m-2 s-1]
+    Tadv_flx, & ! advective diapycnal heat flux across interfaces [degC H s-1 ~> degC m s-1 or degC kg m-2 s-1]
+    Sdif_flx, & ! diffusive diapycnal salt flux across interfaces [ppt H s-1 ~> ppt m s-1 or ppt kg m-2 s-1]
+    Sadv_flx    ! advective diapycnal salt flux across interfaces [ppt H s-1 ~> ppt m s-1 or ppt kg m-2 s-1]
 
   logical :: in_boundary(SZI_(G)) ! True if there are no massive layers below,
                                   ! where massive is defined as sufficiently thick that
@@ -1291,10 +1291,10 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
     Kd_heat,  & ! diapycnal diffusivity of heat [Z2 T-1 ~> m2 s-1]
     Kd_salt,  & ! diapycnal diffusivity of salt and passive tracers [Z2 T-1 ~> m2 s-1]
     Kd_ePBL,  & ! test array of diapycnal diffusivities at interfaces [Z2 T-1 ~> m2 s-1]
-    Tdif_flx, & ! diffusive diapycnal heat flux across interfaces [degC m s-1]
-    Tadv_flx, & ! advective diapycnal heat flux across interfaces [degC m s-1]
-    Sdif_flx, & ! diffusive diapycnal salt flux across interfaces [ppt m s-1]
-    Sadv_flx    ! advective diapycnal salt flux across interfaces [ppt m s-1]
+    Tdif_flx, & ! diffusive diapycnal heat flux across interfaces [degC H s-1 ~> degC m s-1 or degC kg m-2 s-1]
+    Tadv_flx, & ! advective diapycnal heat flux across interfaces [degC H s-1 ~> degC m s-1 or degC kg m-2 s-1]
+    Sdif_flx, & ! diffusive diapycnal salt flux across interfaces [ppt H s-1 ~> ppt m s-1 or ppt kg m-2 s-1]
+    Sadv_flx    ! advective diapycnal salt flux across interfaces [ppt H s-1 ~> ppt m s-1 or ppt kg m-2 s-1]
 
   logical :: in_boundary(SZI_(G)) ! True if there are no massive layers below,
                                   ! where massive is defined as sufficiently thick that
@@ -2705,7 +2705,7 @@ subroutine layered_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_e
     !$OMP parallel do default(shared)
     do j=js,je
       do K=2,nz ; do i=is,ie
-        CDp%diapyc_vel(i,j,K) = Idt * (GV%H_to_m * (ea(i,j,k) - eb(i,j,k-1)))
+        CDp%diapyc_vel(i,j,K) = Idt * (ea(i,j,k) - eb(i,j,k-1))
       enddo ; enddo
       do i=is,ie
         CDp%diapyc_vel(i,j,1) = 0.0
@@ -3203,7 +3203,6 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   real    :: Kd
   integer :: num_mode
   logical :: use_temperature, differentialDiffusion
-  real    :: H_to_MKS   !< Conversion factor from H to equivalent MKS unit
 
 ! This "include" declares and sets the variable "version".
 #include "version_variable.h"
@@ -3362,22 +3361,20 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
 
   ! Register all available diagnostics for this module.
-  if (GV%Boussinesq) then
-    thickness_units = "m"
-    H_to_MKS = GV%H_to_m
-  else
-    thickness_units = "kg m-2"
-    H_to_MKS = GV%H_to_kg_m2
-  endif
+  thickness_units = get_thickness_units(GV)
 
   CS%id_ea_t = register_diag_field('ocean_model','ea_t',diag%axesTL,Time, &
-      'Layer (heat) entrainment from above per timestep','m')
+      'Layer (heat) entrainment from above per timestep','m', &
+      conversion=GV%H_to_m)
   CS%id_eb_t = register_diag_field('ocean_model','eb_t',diag%axesTL,Time, &
-      'Layer (heat) entrainment from below per timestep', 'm')
+      'Layer (heat) entrainment from below per timestep', 'm', &
+      conversion=GV%H_to_m)
   CS%id_ea_s = register_diag_field('ocean_model','ea_s',diag%axesTL,Time, &
-      'Layer (salt) entrainment from above per timestep','m')
+      'Layer (salt) entrainment from above per timestep','m', &
+      conversion=GV%H_to_m)
   CS%id_eb_s = register_diag_field('ocean_model','eb_s',diag%axesTL,Time, &
-      'Layer (salt) entrainment from below per timestep', 'm')
+      'Layer (salt) entrainment from below per timestep', 'm', &
+      conversion=GV%H_to_m)
   ! used by layer diabatic
   CS%id_ea = register_diag_field('ocean_model','ea',diag%axesTL,Time, &
       'Layer entrainment from above per timestep','m', &
@@ -3410,16 +3407,16 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   if (use_temperature) then
     CS%id_Tdif = register_diag_field('ocean_model',"Tflx_dia_diff",diag%axesTi, &
         Time, "Diffusive diapycnal temperature flux across interfaces", &
-        "degC m s-1")
+        "degC m s-1", conversion=GV%H_to_m)
     CS%id_Tadv = register_diag_field('ocean_model',"Tflx_dia_adv",diag%axesTi, &
         Time, "Advective diapycnal temperature flux across interfaces", &
-        "degC m s-1")
+        "degC m s-1", conversion=GV%H_to_m)
     CS%id_Sdif = register_diag_field('ocean_model',"Sflx_dia_diff",diag%axesTi, &
         Time, "Diffusive diapycnal salnity flux across interfaces", &
-        "psu m s-1")
+        "psu m s-1", conversion=GV%H_to_m)
     CS%id_Sadv = register_diag_field('ocean_model',"Sflx_dia_adv",diag%axesTi, &
         Time, "Advective diapycnal salnity flux across interfaces", &
-        "psu m s-1")
+        "psu m s-1", conversion=GV%H_to_m)
     CS%id_MLD_003 = register_diag_field('ocean_model', 'MLD_003', diag%axesT1, Time, &
         'Mixed layer depth (delta rho = 0.03)', 'm', conversion=US%Z_to_m, &
         cmor_field_name='mlotst', cmor_long_name='Ocean Mixed Layer Thickness Defined by Sigma T', &
@@ -3454,8 +3451,8 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   CS%id_v_predia = register_diag_field('ocean_model', 'v_predia', diag%axesCvL, Time, &
       'Meridional velocity before diabatic forcing', 'm s-1', conversion=US%L_T_to_m_s)
   CS%id_h_predia = register_diag_field('ocean_model', 'h_predia', diag%axesTL, Time, &
-      'Layer Thickness before diabatic forcing', thickness_units, v_extensive=.true., &
-      conversion=H_to_MKS)
+      'Layer Thickness before diabatic forcing', trim(thickness_units), &
+      conversion=GV%H_to_MKS, v_extensive=.true.)
   CS%id_e_predia = register_diag_field('ocean_model', 'e_predia', diag%axesTi, Time, &
       'Interface Heights before diabatic forcing', 'm')
   if (use_temperature) then
@@ -3519,7 +3516,8 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   ! available only for ALE algorithm.
   ! diagnostics for tendencies of temp and heat due to frazil
   CS%id_diabatic_diff_h = register_diag_field('ocean_model', 'diabatic_diff_h', diag%axesTL, Time, &
-      long_name = 'Cell thickness used during diabatic diffusion', units='m', v_extensive=.true.)
+      long_name = 'Cell thickness used during diabatic diffusion', units='m', &
+      conversion=GV%H_to_m, v_extensive=.true.)
   if (CS%useALEalgorithm) then
     CS%id_diabatic_diff_temp_tend = register_diag_field('ocean_model', &
         'diabatic_diff_temp_tendency', diag%axesTL, Time,              &
@@ -3591,7 +3589,8 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
     ! available only for ALE algorithm.
   ! diagnostics for tendencies of temp and heat due to frazil
     CS%id_boundary_forcing_h = register_diag_field('ocean_model', 'boundary_forcing_h', diag%axesTL, Time, &
-      long_name = 'Cell thickness after applying boundary forcing', units='m', v_extensive=.true.)
+      long_name = 'Cell thickness after applying boundary forcing', units='m', &
+      conversion=GV%H_to_m, v_extensive=.true.)
     CS%id_boundary_forcing_h_tendency = register_diag_field('ocean_model',   &
         'boundary_forcing_h_tendency', diag%axesTL, Time,                &
         'Cell thickness tendency due to boundary forcing', 'm s-1',                  &
@@ -3650,7 +3649,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   ! diagnostics for tendencies of temp and heat due to frazil
   CS%id_frazil_h = register_diag_field('ocean_model', 'frazil_h', diag%axesTL, Time, &
       long_name = 'Cell Thickness', standard_name='cell_thickness', units='m', &
-      v_extensive=.true., conversion=GV%H_to_m)
+      conversion=GV%H_to_m, v_extensive=.true.)
 
   ! diagnostic for tendency of temp due to frazil
   CS%id_frazil_temp_tend = register_diag_field('ocean_model',&
@@ -3693,7 +3692,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
   ! initialize the geothermal heating module
   if (CS%use_geothermal) &
-    call geothermal_init(Time, G, param_file, diag, CS%geothermal_CSp)
+    call geothermal_init(Time, G, GV, param_file, diag, CS%geothermal_CSp)
 
   ! initialize module for internal tide induced mixing
   if (CS%use_int_tides) then

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -3383,7 +3383,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
       'Layer entrainment from below per timestep', 'm', &
       conversion=GV%H_to_m)
   CS%id_wd = register_diag_field('ocean_model','wd',diag%axesTi,Time, &
-    'Diapycnal velocity', 'm s-1')
+    'Diapycnal velocity', 'm s-1', conversion=GV%H_to_m)
   if (CS%id_wd > 0) call safe_alloc_ptr(CDp%diapyc_vel,isd,ied,jsd,jed,nz+1)
 
   CS%id_dudt_dia = register_diag_field('ocean_model','dudt_dia',diag%axesCuL,Time, &

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -123,8 +123,8 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     ! Register the tracer for horizontal advection, diffusion, and restarts.
     call register_tracer(tr_ptr, tr_Reg, param_file, HI, GV, &
                          name=name, longname=longname, units="kg kg-1", &
-                         registry_diags=.true., flux_units=flux_units, &
-                         restart_CS=restart_CS)
+                         registry_diags=.true., restart_CS=restart_CS, &
+                         flux_units=trim(flux_units), flux_scale=GV%H_to_MKS)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -392,18 +392,20 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE)
     if (Tr%diag_form == 1) then
       Tr%id_adx = register_diag_field("ocean_model", trim(shortnm)//"_adx", &
           diag%axesCuL, Time, trim(flux_longname)//" advective zonal flux" , &
-          trim(flux_units), v_extensive = .true., y_cell_method = 'sum')
+          trim(flux_units), v_extensive = .true., y_cell_method = 'sum', &
+          conversion=Tr%flux_scale)
       Tr%id_ady = register_diag_field("ocean_model", trim(shortnm)//"_ady", &
           diag%axesCvL, Time, trim(flux_longname)//" advective meridional flux" , &
-          trim(flux_units), v_extensive = .true., x_cell_method = 'sum')
+          trim(flux_units), v_extensive = .true., x_cell_method = 'sum', &
+          conversion=Tr%flux_scale)
       Tr%id_dfx = register_diag_field("ocean_model", trim(shortnm)//"_dfx", &
           diag%axesCuL, Time, trim(flux_longname)//" diffusive zonal flux" , &
-          trim(flux_units), v_extensive = .true., conversion=US%L_to_m**2, &
-          y_cell_method = 'sum')
+          trim(flux_units), v_extensive = .true., y_cell_method = 'sum', &
+          conversion=(US%L_to_m**2)*Tr%flux_scale)
       Tr%id_dfy = register_diag_field("ocean_model", trim(shortnm)//"_dfy", &
           diag%axesCvL, Time, trim(flux_longname)//" diffusive zonal flux" , &
-          trim(flux_units), v_extensive = .true., conversion=US%L_to_m**2, &
-          x_cell_method = 'sum')
+          trim(flux_units), v_extensive = .true., x_cell_method = 'sum', &
+          conversion=(US%L_to_m**2)*Tr%flux_scale)
     else
       Tr%id_adx = register_diag_field("ocean_model", trim(shortnm)//"_adx", &
           diag%axesCuL, Time, "Advective (by residual mean) Zonal Flux of "//trim(flux_longname), &
@@ -508,9 +510,11 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE)
     var_lname = "Net time tendency for "//lowercase(flux_longname)
     if (len_trim(Tr%cmor_tendprefix) == 0) then
       Tr%id_trxh_tendency = register_diag_field('ocean_model', trim(shortnm)//'h_tendency', &
-          diag%axesTL, Time, var_lname, conv_units, v_extensive=.true.)
+          diag%axesTL, Time, var_lname, conv_units, v_extensive=.true., &
+          conversion=Tr%conv_scale)
       Tr%id_trxh_tendency_2d = register_diag_field('ocean_model', trim(shortnm)//'h_tendency_2d', &
-          diag%axesT1, Time, "Vertical sum of "//trim(lowercase(var_lname)), conv_units)
+          diag%axesT1, Time, "Vertical sum of "//trim(lowercase(var_lname)), conv_units, &
+          conversion=Tr%conv_scale)
     else
       cmor_var_lname = "Tendency of "//trim(cmor_longname)//" Expressed as "//&
                         trim(flux_longname)//" Content"

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -176,7 +176,8 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     ! Register the tracer for horizontal advection, diffusion, and restarts.
     call register_tracer(tr_ptr, tr_Reg, param_file, HI, GV, tr_desc=CS%tr_desc(m), &
                          registry_diags=.true., restart_CS=restart_CS, &
-                         mandatory=.not.CS%tracers_may_reinit)
+                         mandatory=.not.CS%tracers_may_reinit, &
+                         flux_scale=GV%H_to_m)
 
     !   Set coupled_tracers to be true (hard-coded above) to provide the surface
     ! values to the coupler (if any).  This is meta-code and its arguments will


### PR DESCRIPTION
This PR fixes all of the diagnostic scaling issues in the current test cases (TC0-3).

Most consist of supplying the dimension conversions in register_diag_field, along with a few genuine fixes.

The main part worth mentioning is the fixes associated with tracer diagnostics.  While all are now working, they were fixed used the `flux_scale` and `conv_scale` arguments in various places.  In just about every case, it was following precedent in adjacent code.  But it still seems that this isn't the ideal use of these arguments, which were defined for more specific purposes.  For now, I think it's fine, but we may want to revisit this in the future.

The PR does not fix the "negative zero" issues in one of the barotropic transport diagnostics, so we cannot yet enable the diagnostic checksum support in the test suite.