### PR TITLE
Label output for TCs

### DIFF
--- a/.testing/.gitignore
+++ b/.testing/.gitignore
@@ -13,3 +13,4 @@ GOLD_IC.nc
 debug.out
 chksum_diag.*
 config.mk
+std.out*

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -218,13 +218,20 @@ else
 MPIRUN_CMD=$(MPIRUN) $(if $(1),-x $(1),)
 endif
 
+# Rule to build <tc>/ocean.stats.<tag>
+# $(1) - <tag>
+# $(2) - <executable-label>
+# $(3) - report to codecov
+# $(4) - Parameter line for MOM_override
+# $(5) - Environment for MPIRUN
+# $(6) - Number of PEs
 define STAT_RULE
 $$(BASE)/.testing/%/ocean.stats.$(1): $$(BUILD)/$(2)/MOM6
 	if [ $(3) ]; then find $$(BUILD) -name *.gcda -exec rm -f '{}' \; ; fi
 	mkdir -p $$(@D)/RESTART
 	echo $(4) > $$(@D)/MOM_override
-	cd $$(@D) && $$(call MPIRUN_CMD,$(5)) -n $(6) $$< 2> debug.out \
-		|| ! cat debug.out
+	cd $$(@D) && $$(call MPIRUN_CMD,$(5)) -n $(6) $$< 2> debug.out > std.out \
+		|| ! sed 's/^/$$*.$(1): /' std.out debug.out && sed 's/^/$$*.$(1): /' std.out
 	cp $$(@D)/ocean.stats $$@
 	> $$(@D)/MOM_override
 	if [ $(3) ]; then cd $$(BASE) && bash <(curl -s https://codecov.io/bash) -n $$@; fi
@@ -264,13 +271,15 @@ $(BASE)/.testing/%/ocean.stats.restart: $(BUILD)/symmetric/MOM6
 		&& printf "\n&ocean_solo_nml\n    seconds = $${halfperiod}\n/\n" >> input.nml \
 		&& echo $${daymax} $${timeunit}
 	# Run the first half-period
-	cd $(@D) && $(MPIRUN) -n 1 $< 2> debug.out
+	cd $(@D) && $(MPIRUN) -n 1 $< 2> debug.out > std.out \
+		|| ! sed 's/^/$*.restart1: /' std.out debug.out && sed 's/^/$*.restart1: /' std.out
 	# Setup the next inputs
 	rm -rf $(@D)/INPUT && mv $(@D)/RESTART $(@D)/INPUT
 	mkdir $(@D)/RESTART
 	cd $(@D) && sed -i -e "s/input_filename *= *'n'/input_filename = 'r'/g" input.nml
 	# Run the second half-period
-	cd $(@D) && $(MPIRUN) -n 1 $< 2> debug.out
+	cd $(@D) && $(MPIRUN) -n 1 $< 2> debug.out > std.out \
+		|| ! sed 's/^/$*.restart2: /' std.out debug.out && sed 's/^/$*.restart2: /' std.out
 	# Archive the results and cleanup
 	cp $(@D)/ocean.stats $@
 	rm -rf $(@D)/INPUT

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -202,16 +202,8 @@ $(foreach d,t l h z,$(eval $(call CMP_RULE,dim.$(d),symmetric dim.$(d))))
 #---
 # Test run output files
 
-#(1): Configuration name
-#(2): Executable type
-#(3): Enable coverage flag
-#(4): MOM_override configuration
-#(5): Environment variables
-#(6): Number of MPI ranks
-
-# Simple function for generalised Slurm (srun) and OpenMPI (mpirun) support
-# (1): Environment variables
-
+# Simple function for generalized Slurm (srun) and OpenMPI (mpirun) support
+# $(1): Environment variables
 ifeq ($(MPIRUN), srun)
 MPIRUN_CMD=$(1) $(MPIRUN)
 else
@@ -219,12 +211,12 @@ MPIRUN_CMD=$(MPIRUN) $(if $(1),-x $(1),)
 endif
 
 # Rule to build <tc>/ocean.stats.<tag>
-# $(1) - <tag>
-# $(2) - <executable-label>
-# $(3) - report to codecov
-# $(4) - Parameter line for MOM_override
-# $(5) - Environment for MPIRUN
-# $(6) - Number of PEs
+# $(1): Test configuration name <tag>
+# $(2): Executable type
+# $(3): Enable coverage flag
+# $(4): MOM_override configuration
+# $(5): Environment variables
+# $(6): Number of MPI ranks
 define STAT_RULE
 $$(BASE)/.testing/%/ocean.stats.$(1): $$(BUILD)/$(2)/MOM6
 	if [ $(3) ]; then find $$(BUILD) -name *.gcda -exec rm -f '{}' \; ; fi
@@ -254,7 +246,7 @@ $(eval $(call STAT_RULE,dim.l,symmetric,,L_RESCALE_POWER=11,,1))
 $(eval $(call STAT_RULE,dim.h,symmetric,,H_RESCALE_POWER=11,,1))
 $(eval $(call STAT_RULE,dim.z,symmetric,,Z_RESCALE_POWER=11,,1))
 
-# Restart tests require signicant preprocessing, and are handled separately.
+# Restart tests require significant preprocessing, and are handled separately.
 $(BASE)/.testing/%/ocean.stats.restart: $(BUILD)/symmetric/MOM6
 	# Cleanup
 	mkdir -p $(@D)/RESTART

--- a/.testing/tc3/MOM_input
+++ b/.testing/tc3/MOM_input
@@ -35,11 +35,11 @@ NJHALO = 4                      ! default = 2
                                 ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
                                 ! in MOM_memory.h at compile time; without STATIC_MEMORY_
                                 ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
-NIGLOBAL = 13                   !
+NIGLOBAL = 10                   !
                                 ! The total number of thickness grid points in the
                                 ! x-direction in the physical domain. With STATIC_MEMORY_
                                 ! this is set in MOM_memory.h at compile time.
-NJGLOBAL = 13                   !
+NJGLOBAL = 8                    !
                                 ! The total number of thickness grid points in the
                                 ! y-direction in the physical domain. With STATIC_MEMORY_
                                 ! this is set in MOM_memory.h at compile time.


### PR DESCRIPTION
- Resizes tc3 to 10x8 to be same size as other TCs
- Labels stdout from each TC and test, e.g.
```
tc2.dim.t: MOM Date      1/01/02 00:00:00     24: En 2.773492E-04, MaxCFL  0.00014, Mass 1.396373904329E+20, Salt  35.00000000000, Temp  13.34855257895
tc2.dim.t:     Total Energy: 436132E673084A4D  3.8728319662969448E+16
tc2.dim.t:     Total Mass:   1.3963739043293897E+20, Change:  -2.3821105957031250E+02 Error: -2.37768E+02 (-1.7E-18)
tc2.dim.t:     Total Salt:   4.8873086651528632E+18, Change:  -2.7443200000000002E+02 Error: -2.74432E+02 (-5.6E-17)
tc2.dim.t:     Total Heat:   7.3160314141103079E+24, Change:   7.6890406992664855E+19 Error:  1.31315E+08 ( 1.8E-17)
```
See https://travis-ci.org/adcroft/MOM6/jobs/587225628 for complete example