### PR TITLE
Report negative zero min/max as positive

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -181,7 +181,7 @@ define CMP_RULE
 
 .PRECIOUS: $(foreach b,$(2),results/%/chksum_diag.$(b))
 %.$(1).diag: $(foreach b,$(2),results/%/chksum_diag.$(b))
-	cmp $$^ || true
+	cmp $$^
 endef
 
 $(eval $(call CMP_RULE,regression,symmetric target))
@@ -255,7 +255,7 @@ results/%/ocean.stats.restart: ../build/symmetric/MOM6
 	rm -rf work/$*/restart
 	mkdir -p work/$*/restart
 	cp -rL $*/* work/$*/restart
-	mkdir work/$*/restart/RESTART
+	mkdir -p work/$*/restart/RESTART
 	# Generate the half-period input namelist
 	# TODO: Assumes runtime set by DAYMAX, will fail if set by input.nml
 	cd work/$*/restart \

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -1822,8 +1822,11 @@ subroutine chk_sum_msg3(fmsg, aMean, aMin, aMax, mesg, iounit)
   real,             intent(in) :: aMax !< The maximum value of the array
   integer,          intent(in) :: iounit !< Checksum logger IO unit
 
+  ! NOTE: We add zero to aMin and aMax to remove any negative zeros.
+  ! This is due to inconsistencies of signed zero in local vs MPI calculations.
+
   if (is_root_pe()) write(iounit, '(A,3(A,ES25.16,1X),A)') &
-    fmsg, " mean=", aMean, "min=", aMin, "max=", aMax, trim(mesg)
+    fmsg, " mean=", aMean, "min=", (0. + aMin), "max=", (0. + aMax), trim(mesg)
 end subroutine chk_sum_msg3
 
 !> MOM_checksums_init initializes the MOM_checksums module. As it happens, the


### PR DESCRIPTION
This patch addresses the inconsistency of signed zero in the minimum and
maximum values used in checksum report.

The behavior of the Fortran intrinsic min() and our MPI library's
implementation of MPI_Reduce with MPI_MIN can give different results for
different values of signed zero, e.g. min(0,-0) vs min(-0,0).
Additionally, the MPI_Reduce result appears to not consistenty follow
these rules in more complex MPI calculations.

This can give different results depending on model layout.

Due to these issues, we add the result to positive zero to ensure that
any negative zero results are reported as positive.

This PR also enables diagnostic checksum testing, which now passes for all tests.