### PR TITLE
+(*)Remapping code corrections and improvements

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -63,9 +63,9 @@ implicit none ; private
 
 !> ALE control structure
 type, public :: ALE_CS ; private
-  logical :: remap_uv_using_old_alg              !< If true, uses the old "remapping via a delta z"
-                                                 !! method. If False, uses the new method that
-                                                 !! remaps between grids described by h.
+  logical :: remap_uv_using_old_alg !< If true, uses the old "remapping via a delta z"
+                                    !! method. If False, uses the new method that
+                                    !! remaps between grids described by h.
 
   real :: regrid_time_scale !< The time-scale used in blending between the current (old) grid
                             !! and the target (new) grid [T ~> s]
@@ -73,9 +73,13 @@ type, public :: ALE_CS ; private
   type(regridding_CS) :: regridCS !< Regridding parameters and work arrays
   type(remapping_CS)  :: remapCS  !< Remapping parameters and work arrays
 
-  integer :: nk              !< Used only for queries, not directly by this module
+  integer :: nk             !< Used only for queries, not directly by this module
 
-  logical :: remap_after_initialization !<   Indicates whether to regrid/remap after initializing the state.
+  logical :: remap_after_initialization !< Indicates whether to regrid/remap after initializing the state.
+
+  logical :: answers_2018   !< If true, use the order of arithmetic and expressions for remapping
+                            !! that recover the answers from the end of 2018.  Otherwise, use more
+                            !! robust and accurate forms of mathematically equivalent expressions.
 
   logical :: show_call_tree !< For debugging
 
@@ -145,6 +149,7 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
   character(len=40)               :: mdl = "MOM_ALE" ! This module's name.
   character(len=80)               :: string ! Temporary strings
   real                            :: filter_shallow_depth, filter_deep_depth
+  logical       :: default_2018_answers
   logical                         :: check_reconstruction
   logical                         :: check_remapping
   logical                         :: force_bounds_in_subcell
@@ -192,11 +197,19 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
   call get_param(param_file, mdl, "REMAP_BOUNDARY_EXTRAP", remap_boundary_extrap, &
                  "If true, values at the interfaces of boundary cells are "//&
                  "extrapolated instead of piecewise constant", default=.false.)
+  call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", CS%answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
   call initialize_remapping( CS%remapCS, string, &
                              boundary_extrapolation=remap_boundary_extrap, &
                              check_reconstruction=check_reconstruction, &
                              check_remapping=check_remapping, &
-                             force_bounds_in_subcell=force_bounds_in_subcell)
+                             force_bounds_in_subcell=force_bounds_in_subcell, &
+                             answers_2018=CS%answers_2018)
 
   call get_param(param_file, mdl, "REMAP_AFTER_INITIALIZATION", CS%remap_after_initialization, &
                  "If true, applies regridding and remapping immediately after "//&
@@ -220,7 +233,7 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
                  "REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.", &
                  units="m", default=0., scale=GV%m_to_H)
   call set_regrid_params(CS%regridCS, depth_of_time_filter_shallow=filter_shallow_depth, &
-                                      depth_of_time_filter_deep=filter_deep_depth)
+                         depth_of_time_filter_deep=filter_deep_depth)
   call get_param(param_file, mdl, "REGRID_USE_OLD_DIRECTION", local_logical, &
                  "If true, the regridding ntegrates upwards from the bottom for "//&
                  "interface positions, much as the main model does. If false "//&
@@ -1089,13 +1102,13 @@ subroutine pressure_gradient_ppm( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_ext
 
   ! Local variables
   integer :: i, j, k
-  real    :: hTmp(GV%ke)
-  real    :: tmp(GV%ke)
+  real    :: hTmp(GV%ke) ! A 1-d copy of h [H ~> m or kg m-2]
+  real    :: tmp(GV%ke)  ! A 1-d copy of a column of temperature [degC] or salinity [ppt]
   real, dimension(CS%nk,2) :: &
-      ppol_E            !Edge value of polynomial
+      ppol_E            ! Edge value of polynomial in [degC] or [ppt]
   real, dimension(CS%nk,3) :: &
-      ppol_coefs !Coefficients of polynomial
-  real :: h_neglect, h_neglect_edge
+      ppol_coefs        ! Coefficients of polynomial, all in [degC] or [ppt]
+  real :: h_neglect, h_neglect_edge ! Tiny thicknesses [H ~> m or kg m-2]
 
   !### Try replacing both of these with GV%H_subroundoff
   if (GV%Boussinesq) then
@@ -1116,7 +1129,8 @@ subroutine pressure_gradient_ppm( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_ext
     ppol_E(:,:) = 0.0
     ppol_coefs(:,:) = 0.0
     !### Try to replace the following value of h_neglect with GV%H_subroundoff.
-    call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=h_neglect_edge )
+    call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=h_neglect_edge, &
+                                  answers_2018=CS%answers_2018 )
     call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )
     if (bdry_extrap) &
       call PPM_boundary_extrapolation( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )
@@ -1131,7 +1145,8 @@ subroutine pressure_gradient_ppm( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_ext
     ppol_coefs(:,:) = 0.0
     tmp(:) = tv%T(i,j,:)
     !### Try to replace the following value of h_neglect with GV%H_subroundoff.
-    call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=1.0e-10*GV%m_to_H )
+    call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=1.0e-10*GV%m_to_H, &
+                                  answers_2018=CS%answers_2018 )
     call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )
     if (bdry_extrap) &
       call PPM_boundary_extrapolation(GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )

--- a/src/ALE/regrid_edge_values.F90
+++ b/src/ALE/regrid_edge_values.F90
@@ -46,23 +46,20 @@ contains
 !! Therefore, boundary cells are treated as if they were local extrama.
 subroutine bound_edge_values( N, h, u, edge_val, h_neglect )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
-  real, dimension(:),   intent(in)    :: u !< cell average properties (size N)
-  real, dimension(:,:), intent(inout) :: edge_val !< Potentially modified edge values,
-                                           !! with the same units as u.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width
-                                           !! in the same units as h.
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
+  real, dimension(:),   intent(in)    :: u !< cell average properties (size N) in arbitrary units [A]
+  real, dimension(:,:), intent(inout) :: edge_val !< Potentially modified edge values [A]
+  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   ! Local variables
   integer       :: k            ! loop index
   integer       :: k0, k1, k2
-  real          :: h_l, h_c, h_r
-  real          :: u_l, u_c, u_r
-  real          :: u0_l, u0_r
+  real          :: h_l, h_c, h_r ! Layer thicknesses [H]
+  real          :: u_l, u_c, u_r ! Cell average properties [A]
+  real          :: u0_l, u0_r    ! Edge values of properties [A]
   real          :: sigma_l, sigma_c, sigma_r    ! left, center and right
-                                                ! van Leer slopes
-  real          :: slope                ! retained PLM slope
-
-  real      :: hNeglect ! A negligible thicness in the same units as h.
+                                                ! van Leer slopes [A H-1]
+  real          :: slope         ! retained PLM slope [A H-1]
+  real          :: hNeglect      ! A negligible thickness [H].
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
@@ -175,15 +172,15 @@ end subroutine average_discontinuous_edge_values
 !! If so and if they are not monotonic, replace each edge value by their average.
 subroutine check_discontinuous_edge_values( N, u, edge_val )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: u !< cell averages (size N)
-  real, dimension(:,:), intent(inout) :: edge_val !< Cell edge values with the same units as u.
+  real, dimension(:),   intent(in)    :: u !< cell averages (size N) in arbitrary units [A]
+  real, dimension(:,:), intent(inout) :: edge_val !< Cell edge values [A].
   ! Local variables
   integer       :: k            ! loop index
-  real          :: u0_minus     ! left value at given edge
-  real          :: u0_plus      ! right value at given edge
-  real          :: um_minus     ! left cell average
-  real          :: um_plus      ! right cell average
-  real          :: u0_avg       ! avg value at given edge
+  real          :: u0_minus     ! left value at given edge [A]
+  real          :: u0_plus      ! right value at given edge [A]
+  real          :: um_minus     ! left cell average [A]
+  real          :: um_plus      ! right cell average [A]
+  real          :: u0_avg       ! avg value at given edge [A]
 
   ! Loop on interior cells
   do k = 1,N-1
@@ -227,16 +224,15 @@ end subroutine check_discontinuous_edge_values
 !! Boundary edge values are set to be equal to the boundary cell averages.
 subroutine edge_values_explicit_h2( N, h, u, edge_val, h_neglect )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
-  real, dimension(:),   intent(in)    :: u !< cell average properties (size N)
-  real, dimension(:,:), intent(inout) :: edge_val !< Returned edge values, with the
-                                           !! same units as u; the second index size is 2.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
+  real, dimension(:),   intent(in)    :: u !< cell average properties (size N) in arbitrary units [A]
+  real, dimension(:,:), intent(inout) :: edge_val !< Returned edge values [A]; the second index size is 2.
+  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   ! Local variables
   integer   :: k        ! loop index
-  real      :: h0, h1   ! cell widths
-  real      :: u0, u1   ! cell averages
-  real      :: hNeglect ! A negligible thicness in the same units as h.
+  real      :: h0, h1   ! cell widths [H]
+  real      :: u0, u1   ! cell averages [A]
+  real      :: hNeglect ! A negligible thickness [H]
 
   hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
@@ -289,24 +285,29 @@ end subroutine edge_values_explicit_h2
 !! available interpolant.
 !!
 !! For this fourth-order scheme, at least four cells must exist.
-subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect )
+subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
-  real, dimension(:),   intent(in)    :: u !< cell average properties (size N)
-  real, dimension(:,:), intent(inout) :: edge_val !< Returned edge values, with the
-                                           !! same units as u; the second index size is 2.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
+  real, dimension(:),   intent(in)    :: u !< cell average properties (size N) in arbitrary units [A]
+  real, dimension(:,:), intent(inout) :: edge_val !< Returned edge values [A]; the second index size is 2.
+  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+
   ! Local variables
   integer               :: i, j
-  real                  :: u0, u1, u2, u3
-  real                  :: h0, h1, h2, h3
-  real                  :: f1, f2, f3       ! auxiliary variables
+  real                  :: u0, u1, u2, u3   ! temporary properties [A]
+  real                  :: h0, h1, h2, h3   ! temporary thicknesses [H]
+  real                  :: f1, f2, f3       ! auxiliary variables with various units
   real                  :: e                ! edge value
-  real, dimension(5)    :: x                ! used to compute edge
+  real, dimension(5)    :: x          ! Coordinate system with 0 at edges [H]
+  real, parameter       :: C1_12 = 1.0 / 12.0
+  real                  :: dx, xavg   ! Differences and averages of successive values of x [same units as h]
   real, dimension(4,4)  :: A                ! values near the boundaries
   real, dimension(4)    :: B, C
-  real      :: hNeglect ! A negligible thicness in the same units as h.
+  real      :: hNeglect ! A negligible thickness in the same units as h.
+  logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
 
+  use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
   hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
   ! Loop on interior cells
@@ -372,12 +373,18 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect )
   enddo
 
   do i = 1,4
+    dx = max(f1, h(i) )
+    if (use_2018_answers) then
+      do j = 1,4 ; A(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / real(j) ; enddo
+    else  ! Use expressions with less sensitivity to roundoff
+      xavg = 0.5 * (x(i+1) + x(i))
+      A(i,1) = dx
+      A(i,2) = dx * xavg
+      A(i,3) = dx * (xavg**2 + C1_12*dx**2)
+      A(i,4) = dx * xavg * (xavg**2 + 0.25*dx**2)
+    endif
 
-    do j = 1,4
-      A(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / real(j)
-    enddo
-
-    B(i) = u(i) * max(f1, h(i) )
+    B(i) = u(i) * dx
 
   enddo
 
@@ -410,12 +417,18 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect )
   enddo
 
   do i = 1,4
+    dx = max(f1, h(N-4+i) )
+    if (use_2018_answers) then
+      do j = 1,4 ; A(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / real(j) ; enddo
+    else  ! Use expressions with less sensitivity to roundoff
+      xavg = 0.5 * (x(i+1) + x(i))
+      A(i,1) = dx
+      A(i,2) = dx * xavg
+      A(i,3) = dx * (xavg**2 + C1_12*dx**2)
+      A(i,4) = dx * xavg * (xavg**2 + 0.25*dx**2)
+    endif
 
-    do j = 1,4
-      A(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / real(j)
-    enddo
-
-    B(i) = u(N-4+i) * max(f1,  h(N-4+i) )
+    B(i) = u(N-4+i) * dx
 
   enddo
 
@@ -475,21 +488,24 @@ end subroutine edge_values_explicit_h4
 !!
 !! There are N+1 unknowns and we are able to write N-1 equations. The
 !! boundary conditions close the system.
-subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect )
+subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
-  real, dimension(:),   intent(in)    :: u !< cell average properties (size N)
-  real, dimension(:,:), intent(inout) :: edge_val !< Returned edge values, with the
-                                           !! same units as u; the second index size is 2.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
+  real, dimension(:),   intent(in)    :: u !< cell average properties (size N) in arbitrary units [A]
+  real, dimension(:,:), intent(inout) :: edge_val !< Returned edge values [A]; the second index size is 2.
+  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+
   ! Local variables
   integer               :: i, j                 ! loop indexes
-  real                  :: h0, h1               ! cell widths
+  real                  :: h0, h1               ! cell widths [H]
   real                  :: h0_2, h1_2, h0h1
   real                  :: d2, d4
   real                  :: alpha, beta          ! stencil coefficients
   real                  :: a, b
-  real, dimension(5)    :: x                    ! system used to enforce
+  real, dimension(5)    :: x                    ! Coordinate system with 0 at edges [H]
+  real, parameter       :: C1_12 = 1.0 / 12.0
+  real                  :: dx, xavg             ! Differences and averages of successive values of x [H]
   real, dimension(4,4)  :: Asys                 ! boundary conditions
   real, dimension(4)    :: Bsys, Csys
   real, dimension(N+1)  :: tri_l, &             ! trid. system (lower diagonal)
@@ -497,8 +513,10 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect )
                            tri_u, &             ! trid. system (upper diagonal)
                            tri_b, &             ! trid. system (unknowns vector)
                            tri_x                ! trid. system (rhs)
-  real      :: hNeglect ! A negligible thicness in the same units as h.
+  real      :: hNeglect          ! A negligible thickness [H]
+  logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
 
+  use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
   hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
   ! Loop on cells (except last one)
@@ -543,12 +561,18 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect )
   enddo
 
   do i = 1,4
+    dx = max(h0, h(i) )
+    if (use_2018_answers) then
+      do j = 1,4 ; Asys(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / j ; enddo
+    else  ! Use expressions with less sensitivity to roundoff
+      xavg = 0.5 * (x(i+1) + x(i))
+      Asys(i,1) = dx
+      Asys(i,2) = dx * xavg
+      Asys(i,3) = dx * (xavg**2 + C1_12*dx**2)
+      Asys(i,4) = dx * xavg * (xavg**2 + 0.25*dx**2)
+    endif
 
-    do j = 1,4
-      Asys(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / j
-    enddo
-
-    Bsys(i) = u(i) * max( h0, h(i) )
+    Bsys(i) = u(i) * dx
 
   enddo
 
@@ -566,12 +590,17 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect )
   enddo
 
   do i = 1,4
-
-    do j = 1,4
-      Asys(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / j
-    enddo
-
-    Bsys(i) = u(N-4+i) * max( h0, h(N-4+i) )
+    dx = max(h0, h(N-4+i) )
+    if (use_2018_answers) then
+      do j = 1,4 ; Asys(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / j ; enddo
+    else  ! Use expressions with less sensitivity to roundoff
+      xavg = 0.5 * (x(i+1) + x(i))
+      Asys(i,1) = dx
+      Asys(i,2) = dx * xavg
+      Asys(i,3) = dx * (xavg**2 + C1_12*dx**2)
+      Asys(i,4) = dx * xavg * (xavg**2 + 0.25*dx**2)
+    endif
+    Bsys(i) = u(N-4+i) * dx
 
   enddo
 
@@ -628,16 +657,17 @@ end subroutine edge_values_implicit_h4
 !!          become computationally expensive if regridding is carried out
 !!          often. Figuring out closed-form expressions for these coefficients
 !!          on nonuniform meshes turned out to be intractable.
-subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect )
+subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answers_2018 )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
-  real, dimension(:),   intent(in)    :: u !< cell average properties (size N)
-  real, dimension(:,:), intent(inout) :: edge_val !< Returned edge values, with the
-                                           !! same units as u; the second index size is 2.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
+  real, dimension(:),   intent(in)    :: u !< cell average properties (size N) in arbitrary units [A]
+  real, dimension(:,:), intent(inout) :: edge_val !!< Returned edge values [A]; the second index size is 2.
+  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+
   ! Local variables
   integer               :: i, j, k              ! loop indexes
-  real                  :: h0, h1, h2, h3       ! cell widths
+  real                  :: h0, h1, h2, h3       ! cell widths [H]
   real                  :: g, g_2, g_3          ! the following are
   real                  :: g_4, g_5, g_6        ! auxiliary variables
   real                  :: d2, d3, d4, d5, d6   ! to set up the systems
@@ -654,7 +684,10 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect )
   real                  :: h0ph1_5, h2ph3_5     ! ...
   real                  :: alpha, beta          ! stencil coefficients
   real                  :: a, b, c, d           ! "
-  real, dimension(7)    :: x                    ! system used to enforce
+  real, dimension(7)    :: x          ! Coordinate system with 0 at edges [same units as h]
+  real, parameter       :: C1_12 = 1.0 / 12.0
+  real, parameter       :: C5_6 = 5.0 / 6.0
+  real                  :: dx, xavg   ! Differences and averages of successive values of x [same units as h]
   real, dimension(6,6)  :: Asys                 ! boundary conditions
   real, dimension(6)    :: Bsys, Csys           ! ...
   real, dimension(N+1)  :: tri_l, &             ! trid. system (lower diagonal)
@@ -662,8 +695,10 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect )
                            tri_u, &             ! trid. system (upper diagonal)
                            tri_b, &             ! trid. system (unknowns vector)
                            tri_x                ! trid. system (rhs)
-  real      :: hNeglect ! A negligible thicness in the same units as h.
+  real      :: hNeglect          ! A negligible thickness [H].
+  logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
 
+  use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
   hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
   ! Loop on cells (except last one)
@@ -913,12 +948,19 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect )
   enddo
 
   do i = 1,6
-
-    do j = 1,6
-      Asys(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / j
-    enddo
-
-    Bsys(i) = u(i) * max( g, h(i) )
+    dx = max( g, h(i) )
+    if (use_2018_answers) then
+      do j = 1,6 ; Asys(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / j ; enddo
+    else  ! Use expressions with less sensitivity to roundoff
+      xavg = 0.5 * (x(i+1) + x(i))
+      Asys(i,1) = dx
+      Asys(i,2) = dx * xavg
+      Asys(i,3) = dx * (xavg**2 + C1_12*dx**2)
+      Asys(i,4) = dx * xavg * (xavg**2 + 0.25*dx**2)
+      Asys(i,5) = dx * (xavg**4 + 0.5*xavg**2*dx**2 + 0.0125*dx**4)
+      Asys(i,6) = dx * xavg * (xavg**4 + C5_6*xavg**2*dx**2 + 0.0625*dx**4)
+    endif
+    Bsys(i) = u(i) * dx
 
   enddo
 
@@ -1058,12 +1100,19 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect )
   enddo
 
   do i = 1,6
-
-    do j = 1,6
-      Asys(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / j
-    enddo
-
-    Bsys(i) = u(N-6+i) * max( g, h(N-6+i) )
+    dx = max( g, h(N-6+i) )
+    if (use_2018_answers) then
+      do j = 1,6 ; Asys(i,j) = ( (x(i+1)**j) - (x(i)**j) ) / j ; enddo
+    else  ! Use expressions with less sensitivity to roundoff
+      xavg = 0.5 * (x(i+1) + x(i))
+      Asys(i,1) = dx
+      Asys(i,2) = dx * xavg
+      Asys(i,3) = dx * (xavg**2 + C1_12*dx**2)
+      Asys(i,4) = dx * xavg * (xavg**2 + 0.25*dx**2)
+      Asys(i,5) = dx * (xavg**4 + 0.5*xavg**2*dx**2 + 0.0125*dx**4)
+      Asys(i,6) = dx * xavg * (xavg**4 + C5_6*xavg**2*dx**2 + 0.0625*dx**4)
+    endif
+    Bsys(i) = u(N-6+i) * dx
 
   enddo
 

--- a/src/ALE/regrid_edge_values.F90
+++ b/src/ALE/regrid_edge_values.F90
@@ -661,7 +661,7 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answers_2018 )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell average properties (size N) in arbitrary units [A]
-  real, dimension(:,:), intent(inout) :: edge_val !!< Returned edge values [A]; the second index size is 2.
+  real, dimension(:,:), intent(inout) :: edge_val  !< Returned edge values [A]; the second index size is 2.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
 

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -30,6 +30,9 @@ type, public :: interp_CS_type ; private
   !> Indicate whether high-order boundary extrapolation should be used within
   !! boundary cells
   logical :: boundary_extrapolation
+
+   !> If true use older, less acccurate expressions.
+  logical :: answers_2018 = .true.
 end type interp_CS_type
 
 public regridding_set_ppolys, interpolate_grid
@@ -112,7 +115,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_P1M_H4 )
       degree = DEGREE_1
       if ( n0 >= 4 ) then
-        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge )
+        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
       else
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
       endif
@@ -124,7 +127,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_P1M_IH4 )
       degree = DEGREE_1
       if ( n0 >= 4 ) then
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge )
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
       else
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
       endif
@@ -143,7 +146,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_PPM_H4 )
       if ( n0 >= 4 ) then
         degree = DEGREE_2
-        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge )
+        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
         call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
         if (extrapolate) then
           call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, &
@@ -161,7 +164,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_PPM_IH4 )
       if ( n0 >= 4 ) then
         degree = DEGREE_2
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge )
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
         call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
         if (extrapolate) then
           call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, &
@@ -179,8 +182,8 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_P3M_IH4IH3 )
       if ( n0 >= 4 ) then
         degree = DEGREE_3
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect )
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
+        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
         call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                 ppoly0_coefs, h_neglect )
         if (extrapolate) then
@@ -199,8 +202,8 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_P3M_IH6IH5 )
       if ( n0 >= 6 ) then
         degree = DEGREE_3
-        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect )
+        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
+        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
         call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                 ppoly0_coefs, h_neglect )
         if (extrapolate) then
@@ -219,8 +222,8 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_PQM_IH4IH3 )
       if ( n0 >= 4 ) then
         degree = DEGREE_4
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect )
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
+        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
         call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                  ppoly0_coefs, h_neglect )
         if (extrapolate) then
@@ -239,8 +242,8 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_PQM_IH6IH5 )
       if ( n0 >= 6 ) then
         degree = DEGREE_4
-        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect )
+        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
+        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
         call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                  ppoly0_coefs, h_neglect )
         if (extrapolate) then
@@ -264,7 +267,7 @@ end subroutine regridding_set_ppolys
 !! 'ppoly0' (possibly discontinuous), the coordinates of the new grid 'grid1'
 !! are determined by finding the corresponding target interface densities.
 subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
-                             target_values, degree, n1, h1, x1 )
+                             target_values, degree, n1, h1, x1, answers_2018 )
   integer,            intent(in)    :: n0            !< Number of points on source grid
   real, dimension(:), intent(in)    :: h0            !< Thicknesses of source grid cells
   real, dimension(:), intent(in)    :: x0            !< Source interface positions
@@ -275,7 +278,10 @@ subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
   integer,            intent(in)    :: n1            !< Number of points on target grid
   real, dimension(:), intent(inout) :: h1            !< Thicknesses of target grid cells
   real, dimension(:), intent(inout) :: x1            !< Target interface positions
+  logical,  optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+
   ! Local variables
+  logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
   integer        :: k ! loop index
   real           :: t ! current interface target density
 
@@ -287,7 +293,8 @@ subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
   ! Find coordinates for interior target values
   do k = 2,n1
     t = target_values(k)
-    x1(k) = get_polynomial_coordinate ( n0, h0, x0, ppoly0_E, ppoly0_coefs, t, degree )
+    x1(k) = get_polynomial_coordinate ( n0, h0, x0, ppoly0_E, ppoly0_coefs, t, degree, &
+                                        answers_2018=answers_2018 )
     h1(k-1) = x1(k) - x1(k-1)
   enddo
   h1(n1) = x1(n1+1) - x1(n1)
@@ -320,7 +327,7 @@ subroutine build_and_interpolate_grid(CS, densities, n0, h0, x0, target_values, 
   call regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, ppoly0_C, &
        degree, h_neglect, h_neglect_edge)
   call interpolate_grid(n0, h0, x0, ppoly0_E, ppoly0_C, target_values, degree, &
-       n1, h1, x1)
+       n1, h1, x1, answers_2018=CS%answers_2018)
 end subroutine build_and_interpolate_grid
 
 !> Given a target value, find corresponding coordinate for given polynomial
@@ -340,7 +347,7 @@ end subroutine build_and_interpolate_grid
 !! It is assumed that the number of cells defining 'grid' and 'ppoly' are the
 !! same.
 function get_polynomial_coordinate( N, h, x_g, ppoly_E, ppoly_coefs, &
-                                    target_value, degree ) result ( x_tgt )
+                                    target_value, degree, answers_2018 ) result ( x_tgt )
   ! Arguments
   integer,              intent(in) :: N            !< Number of grid cells
   real, dimension(:),   intent(in) :: h            !< Grid cell thicknesses
@@ -349,6 +356,7 @@ function get_polynomial_coordinate( N, h, x_g, ppoly_E, ppoly_coefs, &
   real, dimension(:,:), intent(in) :: ppoly_coefs  !< Coefficients of interpolating polynomials
   real,                 intent(in) :: target_value !< Target value to find position for
   integer,              intent(in) :: degree       !< Degree of the interpolating polynomials
+  logical,    optional, intent(in) :: answers_2018 !< If true use older, less acccurate expressions.
   real :: x_tgt !< The position of x_g at which target_value is found.
   ! Local variables
   integer                     :: i, k        ! loop indices
@@ -363,9 +371,11 @@ function get_polynomial_coordinate( N, h, x_g, ppoly_E, ppoly_coefs, &
   real                        :: eps         ! offset used to get away from
                                              ! boundaries
   real                        :: grad        ! gradient during N-R iterations
+  logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
 
   eps = NR_OFFSET
   k_found = -1
+  use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
 
   ! If the target value is outside the range of all values, we
   ! force the target coordinate to be equal to the lowest or
@@ -441,10 +451,14 @@ function get_polynomial_coordinate( N, h, x_g, ppoly_E, ppoly_coefs, &
       exit
     endif
 
-    numerator = a(1) + a(2)*xi0 + a(3)*xi0*xi0 + a(4)*xi0*xi0*xi0 + &
-                a(5)*xi0*xi0*xi0*xi0 - target_value
-
-    denominator = a(2) + 2*a(3)*xi0 + 3*a(4)*xi0*xi0 + 4*a(5)*xi0*xi0*xi0
+    if (use_2018_answers) then
+      numerator = a(1) + a(2)*xi0 + a(3)*xi0*xi0 + a(4)*xi0*xi0*xi0 + &
+                  a(5)*xi0*xi0*xi0*xi0 - target_value
+      denominator = a(2) + 2*a(3)*xi0 + 3*a(4)*xi0*xi0 + 4*a(5)*xi0*xi0*xi0
+    else  ! These expressions are mathematicaly equivalent but more accurate.
+      numerator = (a(1) - target_value) + xi0*(a(2) + xi0*(a(3) + xi0*(a(4) + a(5)*xi0)))
+      denominator = a(2) + xi0*(2.*a(3) + xi0*(3.*a(4) + 4.*a(5)*xi0))
+    endif
 
     delta = -numerator / denominator
 
@@ -463,7 +477,11 @@ function get_polynomial_coordinate( N, h, x_g, ppoly_E, ppoly_coefs, &
 
     if ( xi0 > 1.0 ) then
       xi0 = 1.0
-      grad = a(2) + 2*a(3) + 3*a(4) + 4*a(5)
+      if (use_2018_answers) then
+        grad = a(2) + 2*a(3) + 3*a(4) + 4*a(5)
+      else  ! These expressions are mathematicaly equivalent but more accurate.
+        grad = a(2) + (2.*a(3) + (3.*a(4) + 4.*a(5)))
+      endif
       if ( grad == 0.0 ) xi0 = xi0 - eps
     endif
 


### PR DESCRIPTION
MOM6: +(*)Improved consistency and accuracy in remapping code

  This pair of commits corrects dimensionally inconsistent expressions and adds
in new options to use remapping expressions that are less prone to a loss of
accuracy due to roundoff.  Exercising these options will change answers,
although by default and without rescaling the answers are bitwise identical. 
There are changes in the entries in the MOM_parameter_doc files.  The commits in
this PR include:

- NOAA-GFDL/MOM6@e9ee86a +Added REMAPPING_2018 runtime option
- NOAA-GFDL/MOM6@4edc165 (*)Fixed dimensional inconsistency in P3M_functions
