### PR TITLE
Sponge damping rate units

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -540,7 +540,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
                  " \t USER - call a user modified routine.", default="file")
     select case (trim(config))
       case ("DOME"); call DOME_initialize_sponges(G, GV, US, tv, PF, sponge_CSp)
-      case ("DOME2D"); call DOME2d_initialize_sponges(G, GV, tv, PF, useALE, &
+      case ("DOME2D"); call DOME2d_initialize_sponges(G, GV, US, tv, PF, useALE, &
                                                       sponge_CSp, ALE_sponge_CSp)
       case ("ISOMIP"); call ISOMIP_initialize_sponges(G, GV, US, tv, PF, useALE, &
                                                       sponge_CSp, ALE_sponge_CSp)
@@ -552,7 +552,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
       case ("DUMBBELL"); call dumbbell_initialize_sponges(G, GV, US, tv, PF, useALE, &
                                                           sponge_CSp, ALE_sponge_CSp)
       case ("phillips"); call Phillips_initialize_sponges(G, GV, US, tv, PF, sponge_CSp, h)
-      case ("dense"); call dense_water_initialize_sponges(G, GV, tv, PF, useALE, &
+      case ("dense"); call dense_water_initialize_sponges(G, GV, US, tv, PF, useALE, &
                                                           sponge_CSp, ALE_sponge_CSp)
       case ("file"); call initialize_sponges_file(G, GV, US, use_temperature, tv, PF, &
                                                   sponge_CSp, ALE_sponge_CSp, Time)
@@ -1713,7 +1713,7 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, param_file, C
   real, dimension (SZI_(G),SZJ_(G)) :: &
     tmp_2d ! A temporary array for tracers.
 
-  real :: Idamp(SZI_(G),SZJ_(G))    ! The inverse damping rate [s-1].
+  real :: Idamp(SZI_(G),SZJ_(G))    ! The inverse damping rate [T-1 ~> s-1].
   real :: pres(SZI_(G))     ! An array of the reference pressure [Pa].
 
   integer :: i, j, k, is, ie, js, je, nz
@@ -1775,7 +1775,7 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, param_file, C
   if (new_sponges .and. .not. use_ALE) &
     call MOM_error(FATAL, " initialize_sponges: Newer sponges are currently unavailable in layered mode ")
 
-  call MOM_read_data(filename, "Idamp", Idamp(:,:), G%Domain)
+  call MOM_read_data(filename, "Idamp", Idamp(:,:), G%Domain, scale=US%T_to_s)
 
   ! Now register all of the fields which are damped in the sponge.
   ! By default, momentum is advected vertically within the sponge, but

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -587,8 +587,8 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   real :: drdjA, drdjB  ! gradients in the layers above (A) and below(B) the
                         ! interface times the grid spacing [R ~> kg m-3].
   real :: drdkL, drdkR  ! Vertical density differences across an interface [R ~> kg m-3].
-  real :: drdi_u(SZIB_(G), SZK_(G)+1) ! Copy of drdi at u-points [R ~> kg m-3].
-  real :: drdj_v(SZI_(G), SZK_(G)+1)  ! Copy of drdj at v-points [R ~> kg m-3].
+  real :: drdi_u(SZIB_(G), SZK_(G)) ! Copy of drdi at u-points [R ~> kg m-3].
+  real :: drdj_v(SZI_(G), SZK_(G))  ! Copy of drdj at v-points [R ~> kg m-3].
   real :: drdkDe_u(SZIB_(G),SZK_(G)+1) ! Lateral difference of product of drdk and e at u-points
                                        ! [Z R ~> kg m-2].
   real :: drdkDe_v(SZI_(G),SZK_(G)+1)  ! Lateral difference of product of drdk and e at v-points
@@ -764,7 +764,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
           drdkDe_u(I,K) = drdkR * e(i+1,j,K) - drdkL * e(i,j,K)
         endif
 
-        if (find_work) drdi_u(I,K) = drdiB
+        if (find_work) drdi_u(I,k) = drdiB
 
         if (k > nk_linear) then
           if (use_EOS) then
@@ -955,7 +955,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
           Work_u(I,j) = Work_u(I,j) + G_scale * &
             ( uhtot(I,j) * drdkDe_u(I,K) - &
-              (uhD(I,j,K) * drdi_u(I,K)) * 0.25 * &
+              (uhD(I,j,k) * drdi_u(I,k)) * 0.25 * &
               ((e(i,j,K) + e(i,j,K+1)) + (e(i+1,j,K) + e(i+1,j,K+1))) )
         endif
 
@@ -1014,7 +1014,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
           drdkDe_v(i,K) =  drdkR * e(i,j+1,K) - drdkL * e(i,j,K)
         endif
 
-        if (find_work) drdj_v(i,K) = drdjB
+        if (find_work) drdj_v(i,k) = drdjB
 
         if (k > nk_linear) then
           if (use_EOS) then
@@ -1204,7 +1204,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
           Work_v(i,J) = Work_v(i,J) + G_scale * &
             ( vhtot(i,J) * drdkDe_v(i,K) - &
-             (vhD(i,J,K) * drdj_v(i,K)) * 0.25 * &
+             (vhD(i,J,k) * drdj_v(i,k)) * 0.25 * &
              ((e(i,j,K) + e(i,j,K+1)) + (e(i,j+1,K) + e(i,j+1,K+1))) )
         endif
 

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -141,7 +141,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
 
   type(ocean_grid_type),            intent(in) :: G !< The ocean's grid structure.
   integer,                          intent(in) :: nz_data !< The total number of sponge input layers.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: Iresttime !< The inverse of the restoring time [s-1].
+  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: Iresttime !< The inverse of the restoring time [T-1 ~> s-1].
   type(param_file_type),            intent(in) :: param_file !< A structure indicating the open file
                                                              !! to parse for model parameter values.
   type(ALE_sponge_CS),              pointer    :: CS !< A pointer that is set to point to the control
@@ -156,8 +156,8 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
   logical :: use_sponge
   real, allocatable, dimension(:,:,:) :: data_hu !< thickness at u points [H ~> m or kg m-2]
   real, allocatable, dimension(:,:,:) :: data_hv !< thickness at v points [H ~> m or kg m-2]
-  real, allocatable, dimension(:,:) :: Iresttime_u !< inverse of the restoring time at u points [s-1]
-  real, allocatable, dimension(:,:) :: Iresttime_v !< inverse of the restoring time at v points [s-1]
+  real, allocatable, dimension(:,:) :: Iresttime_u !< inverse of the restoring time at u points [T-1 ~> s-1]
+  real, allocatable, dimension(:,:) :: Iresttime_v !< inverse of the restoring time at v points [T-1 ~> s-1]
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
   integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
   character(len=10)  :: remapScheme
@@ -216,7 +216,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
     do j=G%jsc,G%jec ; do i=G%isc,G%iec
       if ((Iresttime(i,j)>0.0) .and. (G%mask2dT(i,j)>0)) then
         CS%col_i(col) = i ; CS%col_j(col) = j
-        CS%Iresttime_col(col) = G%US%T_to_s*Iresttime(i,j)
+        CS%Iresttime_col(col) = Iresttime(i,j)
         col = col +1
       endif
     enddo ; enddo
@@ -264,7 +264,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
        do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
          if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) then
            CS%col_i_u(col) = i ; CS%col_j_u(col) = j
-           CS%Iresttime_col_u(col) = G%US%T_to_s*Iresttime_u(i,j)
+           CS%Iresttime_col_u(col) = Iresttime_u(i,j)
            col = col +1
          endif
        enddo ; enddo
@@ -301,7 +301,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
       do J=CS%jscB,CS%jecB ; do i=CS%isc,CS%iec
         if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) then
           CS%col_i_v(col) = i ; CS%col_j_v(col) = j
-          CS%Iresttime_col_v(col) = G%US%T_to_s*Iresttime_v(i,j)
+          CS%Iresttime_col_v(col) = Iresttime_v(i,j)
           col = col +1
         endif
       enddo ; enddo
@@ -375,7 +375,7 @@ end subroutine get_ALE_sponge_thicknesses
 subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
 
   type(ocean_grid_type),            intent(in) :: G !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: Iresttime !< The inverse of the restoring time [s-1].
+  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: Iresttime !< The inverse of the restoring time [T-1 ~> s-1].
   type(param_file_type),            intent(in) :: param_file !< A structure indicating the open file to parse
                                                              !! for model parameter values.
   type(ALE_sponge_CS),              pointer    :: CS !< A pointer that is set to point to the control
@@ -385,8 +385,8 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_sponge"  ! This module's name.
   logical :: use_sponge
-    real, allocatable, dimension(:,:) :: Iresttime_u !< inverse of the restoring time at u points [s-1]
-  real, allocatable, dimension(:,:) :: Iresttime_v !< inverse of the restoring time at v points [s-1]
+    real, allocatable, dimension(:,:) :: Iresttime_u !< inverse of the restoring time at u points [T-1 ~> s-1]
+  real, allocatable, dimension(:,:) :: Iresttime_v !< inverse of the restoring time at v points [T-1 ~> s-1]
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
   logical :: spongeDataOngrid = .false.
   integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
@@ -443,7 +443,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
     do j=G%jsc,G%jec ; do i=G%isc,G%iec
       if ((Iresttime(i,j)>0.0) .and. (G%mask2dT(i,j)>0)) then
         CS%col_i(col) = i ; CS%col_j(col) = j
-        CS%Iresttime_col(col) = G%US%T_to_s*Iresttime(i,j)
+        CS%Iresttime_col(col) = Iresttime(i,j)
         col = col +1
       endif
     enddo ; enddo
@@ -474,7 +474,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
       do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
         if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) then
           CS%col_i_u(col) = i ; CS%col_j_u(col) = j
-          CS%Iresttime_col_u(col) = G%US%T_to_s*Iresttime_u(i,j)
+          CS%Iresttime_col_u(col) = Iresttime_u(i,j)
           col = col +1
         endif
       enddo ; enddo
@@ -500,7 +500,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
       do J=CS%jscB,CS%jecB ; do i=CS%isc,CS%iec
         if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) then
           CS%col_i_v(col) = i ; CS%col_j_v(col) = j
-          CS%Iresttime_col_v(col) = G%US%T_to_s*Iresttime_v(i,j)
+          CS%Iresttime_col_v(col) = Iresttime_v(i,j)
           col = col +1
         endif
       enddo ; enddo

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -28,7 +28,7 @@ type, public :: geothermal_CS ; private
                              !! of moving upward between layers [R degC-1 ~> kg m-3 degC-1].
   real, pointer :: geo_heat(:,:) => NULL() !< The geothermal heat flux [J m-2 T-1 ~> W m-2].
   real    :: geothermal_thick !< The thickness over which geothermal heating is
-                             !! applied [m] (not [H]).
+                             !! applied [H ~> m or kg m-2].
   logical :: apply_geothermal !< If true, geothermal heating will be applied
                              !! otherwise GEOTHERMAL_SCALE has been set to 0 and
                              !! there is no heat to apply.
@@ -46,7 +46,7 @@ contains
 
 !> Applies geothermal heating, including the movement of water
 !! between isopycnal layers to match the target densities.  The heating is
-!! applied to the bottommost layers that occur within ### of the bottom. If
+!! applied to the bottommost layers that occur within GEOTHERMAL_THICKNESS of the bottom. If
 !! the partial derivative of the coordinate density with temperature is positive
 !! or very small, the layers are simply heated in place.  Any heat that can not
 !! be applied to the ocean is returned (WHERE)?
@@ -188,7 +188,7 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, US, CS, halo)
       heat_rem(i) = G%mask2dT(i,j) * (CS%geo_heat(i,j) * (dt*Irho_cp))
       do_i(i) = .true. ; if (heat_rem(i) <= 0.0) do_i(i) = .false.
       if (do_i(i)) num_start = num_start + 1
-      h_geo_rem(i) = CS%Geothermal_thick * GV%m_to_H
+      h_geo_rem(i) = CS%Geothermal_thick
     enddo
     if (num_start == 0) cycle
     num_left = num_start
@@ -422,7 +422,7 @@ subroutine geothermal_init(Time, G, GV, US, param_file, diag, CS)
                  "read, or blank to use a constant heating rate.", default=" ")
   call get_param(param_file, mdl, "GEOTHERMAL_THICKNESS", CS%geothermal_thick, &
                  "The thickness over which to apply geothermal heating.", &
-                 units="m", default=0.1)
+                 units="m", default=0.1, scale=GV%m_to_H)
   call get_param(param_file, mdl, "GEOTHERMAL_DRHO_DT_INPLACE", CS%dRcv_dT_inplace, &
                  "The value of drho_dT above which geothermal heating "//&
                  "simply heats water in place instead of moving it between "//&

--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -89,7 +89,7 @@ subroutine initialize_sponge(Iresttime, int_height, G, param_file, CS, GV, &
                              Iresttime_i_mean, int_height_i_mean)
   type(ocean_grid_type),   intent(in) :: G          !< The ocean's grid structure
   real, dimension(SZI_(G),SZJ_(G)), &
-                           intent(in) :: Iresttime  !< The inverse of the restoring time [s-1].
+                           intent(in) :: Iresttime  !< The inverse of the restoring time [T-1 ~> s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
                            intent(in) :: int_height !< The interface heights to damp back toward [Z ~> m].
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
@@ -98,7 +98,7 @@ subroutine initialize_sponge(Iresttime, int_height, G, param_file, CS, GV, &
   type(verticalGrid_type), intent(in) :: GV         !< The ocean's vertical grid structure
   real, dimension(SZJ_(G)), &
                  optional, intent(in) :: Iresttime_i_mean !< The inverse of the restoring time for
-                                                          !! the zonal mean properties [s-1].
+                                                          !! the zonal mean properties [T-1 ~> s-1].
   real, dimension(SZJ_(G),SZK_(G)+1), &
                  optional, intent(in) :: int_height_i_mean !< The interface heights toward which to
                                                            !! damp the zonal mean heights [Z ~> m].
@@ -155,7 +155,7 @@ subroutine initialize_sponge(Iresttime, int_height, G, param_file, CS, GV, &
     do j=G%jsc,G%jec ; do i=G%isc,G%iec
       if ((Iresttime(i,j)>0.0) .and. (G%mask2dT(i,j)>0)) then
         CS%col_i(col) = i ; CS%col_j(col) = j
-        CS%Iresttime_col(col) = G%US%T_to_s*Iresttime(i,j)
+        CS%Iresttime_col(col) = Iresttime(i,j)
         col = col +1
       endif
     enddo ; enddo
@@ -172,7 +172,7 @@ subroutine initialize_sponge(Iresttime, int_height, G, param_file, CS, GV, &
     allocate(CS%Ref_eta_im(G%jsd:G%jed,G%ke+1)) ; CS%Ref_eta_im(:,:) = 0.0
 
     do j=G%jsc,G%jec
-      CS%Iresttime_im(j) = G%US%T_to_s*Iresttime_i_mean(j)
+      CS%Iresttime_im(j) = Iresttime_i_mean(j)
     enddo
     do K=1,CS%nz+1 ; do j=G%jsc,G%jec
       CS%Ref_eta_im(j,K) = int_height_i_mean(j,K)

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -1294,10 +1294,17 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
     do k=nz-1,2,-1 ; do i=is,ie
       if (max_TKE(i,k) <= 0.0) cycle
       z_from_bot(i) = z_from_bot(i) + GV%H_to_Z*h(i,j,k)
-      if (N2_meanz(i) > 1.0e-14*US%T_to_s**2 ) then
-        z_from_bot_WKB(i) = z_from_bot_WKB(i) &
-            + GV%H_to_Z * h(i,j,k) * N2_lay(i,k) / N2_meanz(i)
-      else ; z_from_bot_WKB(i) = 0 ; endif
+      if (CS%answers_2018) then
+        if (N2_meanz(i) > 1.0e-14*US%T_to_s**2 ) then
+          z_from_bot_WKB(i) = z_from_bot_WKB(i) &
+              + GV%H_to_Z * h(i,j,k) * N2_lay(i,k) / N2_meanz(i)
+        else ; z_from_bot_WKB(i) = 0 ; endif
+      else
+        if (GV%H_to_Z*h(i,j,k) * N2_lay(i,k) < (1.0e14 * htot_WKB(i)) * N2_meanz(i)) then
+          z_from_bot_WKB(i) = z_from_bot_WKB(i) + &
+             GV%H_to_Z*h(i,j,k) * N2_lay(i,k) / N2_meanz(i)
+        endif
+      endif
 
       ! Fraction of bottom flux predicted to reach top of this layer
       TKE_frac_top(i)     = ( Inv_int(i) * z0_polzin_scaled(i) ) / &

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -353,9 +353,10 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
 end subroutine DOME2d_initialize_temperature_salinity
 
 !> Set up sponges in 2d DOME configuration
-subroutine DOME2d_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
-  type(ocean_grid_type),   intent(in) :: G !< Ocean grid structure
+subroutine DOME2d_initialize_sponges(G, GV, US, tv, param_file, use_ALE, CSp, ACSp)
+  type(ocean_grid_type),   intent(in) :: G  !< Ocean grid structure
   type(verticalGrid_type), intent(in) :: GV !< Vertical grid structure
+  type(unit_scale_type),   intent(in) :: US !< A dimensional unit scaling type
   type(thermo_var_ptrs),   intent(in) :: tv !< Thermodynamics structure
   type(param_file_type),   intent(in) :: param_file !< Parameter file structure
   logical,                 intent(in) :: use_ALE !< If true, indicates model is in ALE mode
@@ -367,7 +368,7 @@ subroutine DOME2d_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
   real :: RHO(SZI_(G),SZJ_(G),SZK_(G)) ! A temporary array for RHO [kg m-3]
   real :: h(SZI_(G),SZJ_(G),SZK_(G))   ! A temporary array for thickness [H ~> m or kg m-2].
   real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! A temporary array for thickness [Z ~> m]
-  real :: Idamp(SZI_(G),SZJ_(G))       ! The inverse damping rate [s-1].
+  real :: Idamp(SZI_(G),SZJ_(G))       ! The inverse damping rate [T-1 ~> s-1].
   real :: S_ref, T_ref                 ! Reference salinity and temerature within surface layer
   real :: S_range, T_range             ! Range of salinities and temperatures over the vertical
   real :: e0(SZK_(G)+1)             ! The resting interface heights [Z ~> m],
@@ -376,7 +377,7 @@ subroutine DOME2d_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
                                     ! positive upward [Z ~> m].
   real :: d_eta(SZK_(G))            ! The layer thickness in a column [Z ~> m].
   real :: dome2d_width_bay, dome2d_width_bottom, dome2d_depth_bay
-  real :: dome2d_west_sponge_time_scale, dome2d_east_sponge_time_scale
+  real :: dome2d_west_sponge_time_scale, dome2d_east_sponge_time_scale ! Sponge timescales [T ~> s]
   real :: dome2d_west_sponge_width, dome2d_east_sponge_width
   real :: dummy1, x, z
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
@@ -387,11 +388,11 @@ subroutine DOME2d_initialize_sponges(G, GV, tv, param_file, use_ALE, CSp, ACSp)
   call get_param(param_file, mdl, "DOME2D_WEST_SPONGE_TIME_SCALE", dome2d_west_sponge_time_scale, &
                  'The time-scale on the west edge of the domain for restoring T/S '//&
                  'in the sponge. If zero, the western sponge is disabled', &
-                 units='s', default=0.)
+                 units='s', default=0., scale=US%s_to_T)
   call get_param(param_file, mdl, "DOME2D_EAST_SPONGE_TIME_SCALE", dome2d_east_sponge_time_scale, &
                  'The time-scale on the east edge of the domain for restoring T/S '//&
                  'in the sponge. If zero, the eastern sponge is disabled', &
-                 units='s', default=0.)
+                 units='s', default=0., scale=US%s_to_T)
   call get_param(param_file, mdl, "DOME2D_WEST_SPONGE_WIDTH", dome2d_west_sponge_width, &
                  'The fraction of the domain in which the western sponge for restoring T/S '//&
                  'is active.', &

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -166,8 +166,8 @@ subroutine Phillips_initialize_velocity(u, v, G, GV, US, param_file, just_read_p
   do k=nz-1,1 ; do j=js,je ; do I=is-1,ie
     y_2 = G%geoLatCu(I,j) - G%south_lat - 0.5*G%len_lat
 ! This uses d/d y_2 atan(y_2 / jet_width)
-!    u(I,j,k) = u(I,j,k+1) + (1e-3 * jet_height / &
-!           (US%m_to_L*jet_width * (1.0 + (y_2 / jet_width)**2))) * &
+!    u(I,j,k) = u(I,j,k+1) + ( jet_height / &
+!           (1.0e3*US%m_to_L*jet_width * (1.0 + (y_2 / jet_width)**2))) * &
 !           (2.0 * GV%g_prime(K+1) / (G%CoriolisBu(I,J) + G%CoriolisBu(I,J-1)))
 ! This uses d/d y_2 tanh(y_2 / jet_width)
     u(I,j,k) = u(I,j,k+1) + (1e-3 * (jet_height / (US%m_to_L*jet_width)) * &
@@ -219,10 +219,10 @@ subroutine Phillips_initialize_sponges(G, GV, US, tv, param_file, CSp, h)
   real :: eta0(SZK_(G)+1)   ! The 1-d nominal positions of the interfaces.
   real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! A temporary array for eta [Z ~> m].
   real :: temp(SZI_(G),SZJ_(G),SZK_(G))  ! A temporary array for other variables.
-  real :: Idamp(SZI_(G),SZJ_(G))    ! The inverse damping rate [s-1].
+  real :: Idamp(SZI_(G),SZJ_(G))    ! The inverse damping rate [T-1 ~> s-1].
   real :: eta_im(SZJ_(G),SZK_(G)+1) ! A temporary array for zonal-mean eta [Z ~> m].
-  real :: Idamp_im(SZJ_(G))         ! The inverse zonal-mean damping rate [s-1].
-  real :: damp_rate    ! The inverse zonal-mean damping rate [s-1].
+  real :: Idamp_im(SZJ_(G))         ! The inverse zonal-mean damping rate [T-1 ~> s-1].
+  real :: damp_rate    ! The inverse zonal-mean damping rate [T-1 ~> s-1].
   real :: jet_width    ! The width of the zonal mean jet, in km.
   real :: jet_height   ! The interface height scale associated with the zonal-mean jet [Z ~> m].
   real :: y_2          ! The y-position relative to the channel center, in km.
@@ -246,7 +246,7 @@ subroutine Phillips_initialize_sponges(G, GV, US, tv, param_file, CSp, h)
                  units="nondim", default = 0.5)
   call get_param(param_file, mdl, "SPONGE_RATE", damp_rate, &
                  "The rate at which the zonal-mean sponges damp.", units="s-1", &
-                 default = 1.0/(10.0*86400.0))
+                 default = 1.0/(10.0*86400.0), scale=US%T_to_s)
 
   call get_param(param_file, mdl, "JET_WIDTH", jet_width, &
                  "The width of the zonal-mean jet.", units="km", &

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -75,8 +75,8 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, PF, use_ALE, CSp, ACSp)
   real :: RHO(SZI_(G),SZJ_(G),SZK_(G))  ! A temporary array for RHO
   real :: tmp(SZI_(G),SZJ_(G))        ! A temporary array for tracers.
   real :: h(SZI_(G),SZJ_(G),SZK_(G))  ! A temporary array for thickness at h points
-  real :: Idamp(SZI_(G),SZJ_(G))    ! The inverse damping rate at h points [s-1].
-  real :: TNUDG                     ! Nudging time scale, days
+  real :: Idamp(SZI_(G),SZJ_(G))    ! The inverse damping rate at h points [T-1 ~> s-1].
+  real :: TNUDG                     ! Nudging time scale [T ~> s]
   real :: pres(SZI_(G))             ! An array of the reference pressure, in Pa
   real :: e0(SZK_(G)+1)               ! The resting interface heights, in m, usually !
                                     ! negative because it is positive upward.      !
@@ -84,7 +84,7 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, PF, use_ALE, CSp, ACSp)
                                     ! positive upward, in m.
   logical :: sponge_uv              ! Nudge velocities (u and v) towards zero
   real :: min_depth, dummy1, z, delta_h
-  real :: damp, rho_dummy, min_thickness, rho_tmp, xi0
+  real :: rho_dummy, min_thickness, rho_tmp, xi0
   real :: lenlat, lenlon, lensponge
   character(len=40) :: filename, state_file
   character(len=40) :: temp_var, salt_var, eta_var, inputdir, h_var
@@ -98,7 +98,8 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, PF, use_ALE, CSp, ACSp)
 
   call get_param(PF,mod,"MIN_THICKNESS",min_thickness,'Minimum layer thickness',units='m',default=1.e-3)
 
-  call get_param(PF, mod, "RGC_TNUDG", TNUDG, 'Nudging time scale for sponge layers (days)',  default=0.0)
+  call get_param(PF, mod, "RGC_TNUDG", TNUDG, 'Nudging time scale for sponge layers (days)', &
+                 default=0.0, scale=86400.0*US%s_to_T)
 
   call get_param(PF, mod, "LENLAT", lenlat, &
                   "The latitudinal or y-direction length of the domain", &
@@ -126,31 +127,20 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, PF, use_ALE, CSp, ACSp)
   if (associated(ACSp)) call MOM_error(FATAL, &
           "RGC_initialize_sponges called with an associated ALE-sponge control structure.")
 
-  !  Here the inverse damping time, in s-1, is set. Set Idamp to 0     !
-  !  wherever there is no sponge, and the subroutines that are called  !
-  !  will automatically set up the sponges only where Idamp is positive!
+  !  Here the inverse damping time [T-1 ~> s-1], is set. Set Idamp to 0
+  !  wherever there is no sponge, and the subroutines that are called
+  !  will automatically set up the sponges only where Idamp is positive
   !  and mask2dT is 1.
 
   do i=is,ie ; do j=js,je
-    if (G%geoLonT(i,j) <= lensponge) then
-      dummy1 = -(G%geoLonT(i,j))/lensponge + 1.0
-      !damp = 1.0/TNUDG * max(0.0,dummy1)
-      damp = 0.0
-      !write(*,*)'1st, G%geoLonT(i,j), damp',G%geoLonT(i,j), damp
-
+    if ((G%bathyT(i,j) <= min_depth) .or. (G%geoLonT(i,j) <= lensponge)) then
+      Idamp(i,j) = 0.0
     elseif (G%geoLonT(i,j) >= (lenlon - lensponge) .AND. G%geoLonT(i,j) <= lenlon) then
-
-! 1 / day
-      dummy1=(G%geoLonT(i,j)-(lenlon - lensponge))/(lensponge)
-      damp = (1.0/TNUDG) * max(0.0,dummy1)
-
-    else ; damp=0.0
+      dummy1 = (G%geoLonT(i,j)-(lenlon - lensponge))/(lensponge)
+      Idamp(i,j) = (1.0/TNUDG) * max(0.0,dummy1)
+    else
+      Idamp(i,j) = 0.0
     endif
-
-! convert to 1 / seconds
-    if (G%bathyT(i,j) > min_depth) then
-        Idamp(i,j) = damp/86400.0
-    else ; Idamp(i,j) = 0.0 ; endif
   enddo ; enddo
 
 

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -269,15 +269,16 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, param_file, use_ALE, CSp, 
   type(sponge_CS),         pointer    :: CSp !< Layered sponge control structure pointer
   type(ALE_sponge_CS),     pointer    :: ACSp !< ALE sponge control structure pointer
 
-  real :: sponge_time_scale
+  real :: sponge_time_scale  ! The damping time scale [T ~> s]
 
-  real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale
+  real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h, T, S ! sponge thicknesses, temp and salt
   real, dimension(SZK_(GV)+1) :: e0, eta1D ! interface positions for ALE sponge
 
   integer :: i, j, k, nz
   real :: x, zi, zmid, dist, min_thickness, dblen
   real :: mld, S_ref, S_range, S_dense, T_ref, sill_height
+
   call get_param(param_file, mdl,"DUMBBELL_LEN",dblen, &
                 'Lateral Length scale for dumbbell ',&
                  units='k', default=600., do_not_log=.true.)
@@ -290,7 +291,7 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, param_file, use_ALE, CSp, 
 
   call get_param(param_file, mdl, "DUMBBELL_SPONGE_TIME_SCALE", sponge_time_scale, &
        "The time scale in the reservoir for restoring. If zero, the sponge is disabled.", &
-       units="s", default=0.)
+       units="s", default=0., scale=US%s_to_T)
   call get_param(param_file, mdl, "DUMBBELL_SREF", S_ref, do_not_log=.true.)
   call get_param(param_file, mdl, "DUMBBELL_S_RANGE", S_range, do_not_log=.true.)
   call get_param(param_file, mdl,"MIN_THICKNESS", min_thickness, &


### PR DESCRIPTION
  This PR rescales a few remaining variables for dimensional consistency
testing, corrects some diagnostic calculations, and adds optionally enabled
improved expressions for specifying the mixing rate in very weakly stratified
water columns.  No answers in the MOM6-examples test suite or MOM_parameter_doc
files are changed.  The commits in this PR include:

- NOAA-GFDL/MOM6@ff15540 Merge branch 'dev/gfdl' into sponge_rate_units
- NOAA-GFDL/MOM6@d197c30 Changed small-N code in add_int_tide_diffusivity
- NOAA-GFDL/MOM6@01fd87e Earlier rescaling of GEOTHERMAL_THICKNESS
- NOAA-GFDL/MOM6@4cd721f Fixed thickness_diffuse diagnostic array extents
- NOAA-GFDL/MOM6@722c1f5 +(*)Specify sponge damping rates in [T-1]
