### PR TITLE
MOM6: +(*)Refactored ALE remapping code

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -522,8 +522,8 @@ subroutine ALE_offline_inputs(CS, G, GV, h, tv, Reg, uhtr, vhtr, Kd, debug, OBC)
     endif
   enddo ; enddo
 
-  call ALE_remap_scalar(CS%remapCS, G, GV, nk, h, tv%T, h_new, tv%T)
-  call ALE_remap_scalar(CS%remapCS, G, GV, nk, h, tv%S, h_new, tv%S)
+  call ALE_remap_scalar(CS%remapCS, G, GV, nk, h, tv%T, h_new, tv%T, answers_2018=CS%answers_2018)
+  call ALE_remap_scalar(CS%remapCS, G, GV, nk, h, tv%S, h_new, tv%S, answers_2018=CS%answers_2018)
 
   if (debug) call MOM_tracer_chkinv("After ALE_offline_inputs", G, h_new, Reg%Tr, Reg%ntr)
 
@@ -787,8 +787,9 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
                           "and u/v are to be remapped")
   endif
 
-  !### Try replacing both of these with GV%H_subroundoff
-  if (GV%Boussinesq) then
+  if (.not.CS_ALE%answers_2018) then
+    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
+  elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
   else
     h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
@@ -939,7 +940,7 @@ end subroutine remap_all_state_vars
 !> Remaps a single scalar between grids described by thicknesses h_src and h_dst.
 !! h_dst must be dimensioned as a model array with GV%ke layers while h_src can
 !! have an arbitrary number of layers specified by nk_src.
-subroutine ALE_remap_scalar(CS, G, GV, nk_src, h_src, s_src, h_dst, s_dst, all_cells, old_remap )
+subroutine ALE_remap_scalar(CS, G, GV, nk_src, h_src, s_src, h_dst, s_dst, all_cells, old_remap, answers_2018 )
   type(remapping_CS),                      intent(in)    :: CS        !< Remapping control structure
   type(ocean_grid_type),                   intent(in)    :: G         !< Ocean grid structure
   type(verticalGrid_type),                 intent(in)    :: GV        !< Ocean vertical grid structure
@@ -955,20 +956,26 @@ subroutine ALE_remap_scalar(CS, G, GV, nk_src, h_src, s_src, h_dst, s_dst, all_c
                                                                       !! layers otherwise (default).
   logical, optional,                       intent(in)    :: old_remap !< If true, use the old "remapping_core_w"
                                                                       !! method, otherwise use "remapping_core_h".
+  logical,                       optional, intent(in)    :: answers_2018 !< If true, use the order of arithmetic
+                                                                      !! and expressions that recover the answers for
+                                                                      !! remapping from the end of 2018. Otherwise,
+                                                                      !! use more robust forms of the same expressions.
   ! Local variables
   integer :: i, j, k, n_points
   real :: dx(GV%ke+1)
   real :: h_neglect, h_neglect_edge
-  logical :: ignore_vanished_layers, use_remapping_core_w
+  logical :: ignore_vanished_layers, use_remapping_core_w, use_2018_remap
 
   ignore_vanished_layers = .false.
   if (present(all_cells)) ignore_vanished_layers = .not. all_cells
   use_remapping_core_w = .false.
   if (present(old_remap)) use_remapping_core_w = old_remap
   n_points = nk_src
+  use_2018_remap = .true. ; if (present(answers_2018)) use_2018_remap = answers_2018
 
-  !### Try replacing both of these with GV%H_subroundoff
-  if (GV%Boussinesq) then
+  if (.not.use_2018_remap) then
+    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
+  elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
   else
     h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
@@ -1031,8 +1038,9 @@ subroutine pressure_gradient_plm( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_ext
   real, dimension(CS%nk,2) :: ppol_coefs !Coefficients of polynomial
   real :: h_neglect
 
-  !### Replace this with GV%H_subroundoff
-  if (GV%Boussinesq) then
+  if (.not.CS%answers_2018) then
+    h_neglect = GV%H_subroundoff
+  elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30
   else
     h_neglect = GV%kg_m2_to_H*1.0e-30
@@ -1107,8 +1115,9 @@ subroutine pressure_gradient_ppm( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_ext
       ppol_coefs        ! Coefficients of polynomial, all in [degC] or [ppt]
   real :: h_neglect, h_neglect_edge ! Tiny thicknesses [H ~> m or kg m-2]
 
-  !### Try replacing both of these with GV%H_subroundoff
-  if (GV%Boussinesq) then
+  if (.not.CS%answers_2018) then
+    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
+  elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
   else
     h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
@@ -1125,7 +1134,6 @@ subroutine pressure_gradient_ppm( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_ext
     ! Reconstruct salinity profile
     ppol_E(:,:) = 0.0
     ppol_coefs(:,:) = 0.0
-    !### Try to replace the following value of h_neglect with GV%H_subroundoff.
     call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=h_neglect_edge, &
                                   answers_2018=CS%answers_2018 )
     call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect, &
@@ -1142,9 +1150,13 @@ subroutine pressure_gradient_ppm( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_ext
     ppol_E(:,:) = 0.0
     ppol_coefs(:,:) = 0.0
     tmp(:) = tv%T(i,j,:)
-    !### Try to replace the following value of h_neglect with GV%H_subroundoff.
-    call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=1.0e-10*GV%m_to_H, &
+    if (CS%answers_2018) then
+      call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=1.0e-10*GV%m_to_H, &
                                   answers_2018=CS%answers_2018 )
+    else
+      call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=GV%H_subroundoff, &
+                                  answers_2018=CS%answers_2018 )
+    endif
     call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect, &
                                   answers_2018=CS%answers_2018 )
     if (bdry_extrap) &

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -53,9 +53,6 @@ use regrid_consts,        only : coordinateUnits, coordinateMode, state_dependen
 use regrid_edge_values,   only : edge_values_implicit_h4
 use PLM_functions,        only : PLM_reconstruction, PLM_boundary_extrapolation
 use PPM_functions,        only : PPM_reconstruction, PPM_boundary_extrapolation
-use P1M_functions,        only : P1M_interpolation,  P1M_boundary_extrapolation
-use P3M_functions,        only : P3M_interpolation,  P3M_boundary_extrapolation
-
 
 implicit none ; private
 #include <MOM_memory.h>
@@ -1131,7 +1128,8 @@ subroutine pressure_gradient_ppm( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_ext
     !### Try to replace the following value of h_neglect with GV%H_subroundoff.
     call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=h_neglect_edge, &
                                   answers_2018=CS%answers_2018 )
-    call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )
+    call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect, &
+                                  answers_2018=CS%answers_2018 )
     if (bdry_extrap) &
       call PPM_boundary_extrapolation( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )
 
@@ -1147,7 +1145,8 @@ subroutine pressure_gradient_ppm( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_ext
     !### Try to replace the following value of h_neglect with GV%H_subroundoff.
     call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=1.0e-10*GV%m_to_H, &
                                   answers_2018=CS%answers_2018 )
-    call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )
+    call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect, &
+                                  answers_2018=CS%answers_2018 )
     if (bdry_extrap) &
       call PPM_boundary_extrapolation(GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )
 

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -184,7 +184,7 @@ function isPosSumErrSignificant(n1, sum1, n2, sum2)
 end function isPosSumErrSignificant
 
 !> Remaps column of values u0 on grid h0 to grid h1 assuming the top edge is aligned.
-subroutine remapping_core_h(CS,  n0, h0, u0, n1, h1, u1, h_neglect, h_neglect_edge)
+subroutine remapping_core_h(CS, n0, h0, u0, n1, h1, u1, h_neglect, h_neglect_edge)
   type(remapping_CS),  intent(in)  :: CS !< Remapping control structure
   integer,             intent(in)  :: n0 !< Number of cells on source grid
   real, dimension(n0), intent(in)  :: h0 !< Cell widths on source grid
@@ -1630,9 +1630,9 @@ logical function remapping_unit_tests(verbose)
   logical :: thisTest, v
 
   v = verbose
-  h_neglect = hNeglect_dflt
-  h_neglect_edge = 1.0e-10
   answers_2018 = .false. ! .true.
+  h_neglect = hNeglect_dflt
+  h_neglect_edge = hNeglect_dflt ; if (answers_2018) h_neglect_edge = 1.0e-10
 
   write(*,*) '==== MOM_remapping: remapping_unit_tests ================='
   remapping_unit_tests = .false. ! Normally return false

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -399,14 +399,14 @@ subroutine build_reconstructions_1d( CS, n0, h0, u0, ppoly_r_coefs, &
       iMethod = INTEGRATION_PLM
     case ( REMAPPING_PPM_H4 )
       call edge_values_explicit_h4( n0, h0, u0, ppoly_r_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect )
+      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answers_2018=CS%answers_2018 )
       if ( CS%boundary_extrapolation ) then
         call PPM_boundary_extrapolation( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect )
       endif
       iMethod = INTEGRATION_PPM
     case ( REMAPPING_PPM_IH4 )
       call edge_values_implicit_h4( n0, h0, u0, ppoly_r_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect )
+      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answers_2018=CS%answers_2018 )
       if ( CS%boundary_extrapolation ) then
         call PPM_boundary_extrapolation( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect )
       endif
@@ -414,7 +414,8 @@ subroutine build_reconstructions_1d( CS, n0, h0, u0, ppoly_r_coefs, &
     case ( REMAPPING_PQM_IH4IH3 )
       call edge_values_implicit_h4( n0, h0, u0, ppoly_r_E, h_neglect_edge, answers_2018=CS%answers_2018 )
       call edge_slopes_implicit_h3( n0, h0, u0, ppoly_r_S, h_neglect, answers_2018=CS%answers_2018 )
-      call PQM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_S, ppoly_r_coefs, h_neglect )
+      call PQM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_S, ppoly_r_coefs, h_neglect, &
+                               answers_2018=CS%answers_2018 )
       if ( CS%boundary_extrapolation ) then
         call PQM_boundary_extrapolation_v1( n0, h0, u0, ppoly_r_E, ppoly_r_S, &
                                             ppoly_r_coefs, h_neglect )
@@ -423,7 +424,8 @@ subroutine build_reconstructions_1d( CS, n0, h0, u0, ppoly_r_coefs, &
     case ( REMAPPING_PQM_IH6IH5 )
       call edge_values_implicit_h6( n0, h0, u0, ppoly_r_E, h_neglect_edge, answers_2018=CS%answers_2018 )
       call edge_slopes_implicit_h5( n0, h0, u0, ppoly_r_S, h_neglect, answers_2018=CS%answers_2018 )
-      call PQM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_S, ppoly_r_coefs, h_neglect )
+      call PQM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_S, ppoly_r_coefs, h_neglect, &
+                               answers_2018=CS%answers_2018 )
       if ( CS%boundary_extrapolation ) then
         call PQM_boundary_extrapolation_v1( n0, h0, u0, ppoly_r_E, ppoly_r_S, &
                                             ppoly_r_coefs, h_neglect )
@@ -1630,7 +1632,7 @@ logical function remapping_unit_tests(verbose)
   v = verbose
   h_neglect = hNeglect_dflt
   h_neglect_edge = 1.0e-10
-  answers_2018 = .true.
+  answers_2018 = .false. ! .true.
 
   write(*,*) '==== MOM_remapping: remapping_unit_tests ================='
   remapping_unit_tests = .false. ! Normally return false
@@ -1677,7 +1679,7 @@ logical function remapping_unit_tests(verbose)
   ppoly0_coefs(:,:) = 0.0
 
   call edge_values_explicit_h4( n0, h0, u0, ppoly0_E, h_neglect=1e-10, answers_2018=answers_2018 )
-  call PPM_reconstruction( n0, h0, u0, ppoly0_E, ppoly0_coefs, h_neglect )
+  call PPM_reconstruction( n0, h0, u0, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=answers_2018 )
   call PPM_boundary_extrapolation( n0, h0, u0, ppoly0_E, ppoly0_coefs, h_neglect )
   u1(:) = 0.
   call remapByProjection( n0, h0, u0, ppoly0_E, ppoly0_coefs, &
@@ -1814,7 +1816,7 @@ logical function remapping_unit_tests(verbose)
   ppoly0_E(:,1) = (/0.,2.,4.,6.,8./)
   ppoly0_E(:,2) = (/2.,4.,6.,8.,10./)
   call PPM_reconstruction(5, (/1.,1.,1.,1.,1./), (/1.,3.,5.,7.,9./), ppoly0_E(1:5,:), &
-                              ppoly0_coefs(1:5,:), h_neglect )
+                              ppoly0_coefs(1:5,:), h_neglect, answers_2018=answers_2018 )
   remapping_unit_tests = remapping_unit_tests .or. &
     test_answer(v, 5, ppoly0_coefs(:,1), (/1.,2.,4.,6.,9./), 'Line PPM: P0')
   remapping_unit_tests = remapping_unit_tests .or. &
@@ -1830,7 +1832,7 @@ logical function remapping_unit_tests(verbose)
   ppoly0_E(:,1) = (/0.,0.,3.,12.,27./)
   ppoly0_E(:,2) = (/0.,3.,12.,27.,48./)
   call PPM_reconstruction(5, (/1.,1.,1.,1.,1./), (/0.,1.,7.,19.,37./), ppoly0_E(1:5,:), &
-                          ppoly0_coefs(1:5,:), h_neglect )
+                          ppoly0_coefs(1:5,:), h_neglect, answers_2018=answers_2018 )
   remapping_unit_tests = remapping_unit_tests .or. &
     test_answer(v, 5, ppoly0_E(:,1), (/0.,0.,3.,12.,37./), 'Parabola PPM: left edges')
   remapping_unit_tests = remapping_unit_tests .or. &
@@ -1845,7 +1847,7 @@ logical function remapping_unit_tests(verbose)
   ppoly0_E(:,1) = (/0.,0.,6.,10.,15./)
   ppoly0_E(:,2) = (/0.,6.,12.,17.,15./)
   call PPM_reconstruction(5, (/1.,1.,1.,1.,1./), (/0.,5.,7.,16.,15./), ppoly0_E(1:5,:), &
-                          ppoly0_coefs(1:5,:), h_neglect )
+                          ppoly0_coefs(1:5,:), h_neglect, answers_2018=answers_2018 )
   remapping_unit_tests = remapping_unit_tests .or. &
     test_answer(v, 5, ppoly0_E(:,1), (/0.,3.,6.,16.,15./), 'Limits PPM: left edges')
   remapping_unit_tests = remapping_unit_tests .or. &

--- a/src/ALE/P1M_functions.F90
+++ b/src/ALE/P1M_functions.F90
@@ -24,23 +24,22 @@ contains
 !!
 !! It is assumed that the size of the array 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed here.
-subroutine P1M_interpolation( N, h, u, ppoly_E, ppoly_coef, h_neglect )
+subroutine P1M_interpolation( N, h, u, ppoly_E, ppoly_coef, h_neglect, answers_2018 )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
-  real, dimension(:),   intent(in)    :: u !< cell average properties (size N)
-  real, dimension(:,:), intent(inout) :: ppoly_E !< Potentially modified edge values,
-                                           !! with the same units as u.
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
+  real, dimension(:),   intent(in)    :: u !< cell average properties (size N) [A]
+  real, dimension(:,:), intent(inout) :: ppoly_E !< Potentially modified edge values [A]
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Potentially modified
-                                           !! piecewise polynomial coefficients, mainly
-                                           !! with the same units as u.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width
-                                           !! in the same units as h.
+                                           !! piecewise polynomial coefficients, mainly [A]
+  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+
   ! Local variables
   integer   :: k            ! loop index
   real      :: u0_l, u0_r   ! edge values (left and right)
 
   ! Bound edge values (routine found in 'edge_values.F90')
-  call bound_edge_values( N, h, u, ppoly_E, h_neglect )
+  call bound_edge_values( N, h, u, ppoly_E, h_neglect, answers_2018 )
 
   ! Systematically average discontinuous edge values (routine found in
   ! 'edge_values.F90')
@@ -69,12 +68,11 @@ end subroutine P1M_interpolation
 subroutine P1M_boundary_extrapolation( N, h, u, ppoly_E, ppoly_coef )
   ! Arguments
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
-  real, dimension(:),   intent(in)    :: u !< cell averages (size N)
-  real, dimension(:,:), intent(inout) :: ppoly_E !< edge values of piecewise polynomials,
-                                           !! with the same units as u.
-  real, dimension(:,:), intent(inout) :: ppoly_coef !< coefficients of piecewise polynomials, mainly
-                                           !! with the same units as u.
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
+  real, dimension(:),   intent(in)    :: u !< cell averages (size N) [A]
+  real, dimension(:,:), intent(inout) :: ppoly_E !< edge values of piecewise polynomials [A]
+  real, dimension(:,:), intent(inout) :: ppoly_coef !< coefficients of piecewise polynomials, mainly [A]
+
   ! Local variables
   real          :: u0, u1               ! cell averages
   real          :: h0, h1               ! corresponding cell widths

--- a/src/ALE/P3M_functions.F90
+++ b/src/ALE/P3M_functions.F90
@@ -25,7 +25,7 @@ contains
 !!
 !! It is assumed that the size of the array 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed here.
-subroutine P3M_interpolation( N, h, u, ppoly_E, ppoly_S, ppoly_coef, h_neglect )
+subroutine P3M_interpolation( N, h, u, ppoly_E, ppoly_S, ppoly_coef, h_neglect, answers_2018 )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell averages (size N) in arbitrary units [A]
@@ -34,13 +34,14 @@ subroutine P3M_interpolation( N, h, u, ppoly_E, ppoly_S, ppoly_coef, h_neglect )
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Coefficients of polynomial [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for the
                                           !! purpose of cell reconstructions [H]
+  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
 
   ! Call the limiter for p3m, which takes care of everything from
   ! computing the coefficients of the cubic to monotonizing it.
   ! This routine could be called directly instead of having to call
   ! 'P3M_interpolation' first but we do that to provide an homogeneous
   ! interface.
-  call P3M_limiter( N, h, u, ppoly_E, ppoly_S, ppoly_coef, h_neglect )
+  call P3M_limiter( N, h, u, ppoly_E, ppoly_S, ppoly_coef, h_neglect, answers_2018 )
 
 end subroutine P3M_interpolation
 
@@ -57,7 +58,7 @@ end subroutine P3M_interpolation
 !!    c. If not, monotonize cubic curve and rebuild it
 !!
 !! Step 3 of the monotonization process leaves all edge values unchanged.
-subroutine P3M_limiter( N, h, u, ppoly_E, ppoly_S, ppoly_coef, h_neglect )
+subroutine P3M_limiter( N, h, u, ppoly_E, ppoly_S, ppoly_coef, h_neglect, answers_2018 )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell averages (size N) in arbitrary units [A]
@@ -66,6 +67,8 @@ subroutine P3M_limiter( N, h, u, ppoly_E, ppoly_S, ppoly_coef, h_neglect )
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Coefficients of polynomial [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for
                                            !! the purpose of cell reconstructions [H]
+  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+
   ! Local variables
   integer :: k            ! loop index
   logical :: monotonic    ! boolean indicating whether the cubic is monotonic
@@ -83,7 +86,7 @@ subroutine P3M_limiter( N, h, u, ppoly_E, ppoly_S, ppoly_coef, h_neglect )
   eps = 1e-10
 
   ! 1. Bound edge values (boundary cells are assumed to be local extrema)
-  call bound_edge_values( N, h, u, ppoly_E, hNeglect )
+  call bound_edge_values( N, h, u, ppoly_E, hNeglect, answers_2018 )
 
   ! 2. Systematically average discontinuous edge values
   call average_discontinuous_edge_values( N, ppoly_E )

--- a/src/ALE/P3M_functions.F90
+++ b/src/ALE/P3M_functions.F90
@@ -212,8 +212,7 @@ subroutine P3M_boundary_extrapolation( N, h, u, ppoly_E, ppoly_S, ppoly_coef, &
   real    :: hNeglect, hNeglect_edge ! Negligibly small thickness [H]
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
-  hNeglect_edge = hNeglect_edge_dflt
-  if (present(h_neglect_edge)) hNeglect_edge = h_neglect_edge
+  hNeglect_edge = hNeglect_edge_dflt ; if (present(h_neglect_edge)) hNeglect_edge = h_neglect_edge
 
   ! ----- Left boundary -----
   i0 = 1

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -77,20 +77,20 @@ contains
 !! continuous linear scheme (P1M h2).
 subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
      ppoly0_coefs, degree, h_neglect, h_neglect_edge)
-  type(interp_CS_type),intent(in)    :: CS !< Interpolation control structure
-  real, dimension(:),  intent(in)    :: densities !< Actual cell densities
-  integer,             intent(in)    :: n0 !< Number of cells on source grid
-  real, dimension(:),  intent(in)    :: h0 !< cell widths on source grid
-  real, dimension(:,:),intent(inout) :: ppoly0_E  !< Edge value of polynomial
-  real, dimension(:,:),intent(inout) :: ppoly0_S  !< Edge slope of polynomial
-  real, dimension(:,:),intent(inout) :: ppoly0_coefs !< Coefficients of polynomial
-  integer,             intent(inout) :: degree    !< The degree of the polynomials
-  real,      optional, intent(in)    :: h_neglect !< A negligibly small width for the
-                                           !! purpose of cell reconstructions
-                                           !! in the same units as h0.
-  real,      optional, intent(in)    :: h_neglect_edge !< A negligibly small width
-                                           !! for the purpose of edge value calculations
-                                           !! in the same units as h0.
+  type(interp_CS_type),  intent(in)    :: CS !< Interpolation control structure
+  integer,               intent(in)    :: n0 !< Number of cells on source grid
+  real, dimension(n0),   intent(in)    :: densities !< Actual cell densities
+  real, dimension(n0),   intent(in)    :: h0 !< cell widths on source grid
+  real, dimension(n0,2), intent(inout) :: ppoly0_E  !< Edge value of polynomial
+  real, dimension(n0,2), intent(inout) :: ppoly0_S  !< Edge slope of polynomial
+  real, dimension(n0,DEGREE_MAX+1), intent(inout) :: ppoly0_coefs !< Coefficients of polynomial
+  integer,               intent(inout) :: degree    !< The degree of the polynomials
+  real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the
+                                             !! purpose of cell reconstructions
+                                             !! in the same units as h0.
+  real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width
+                                             !! for the purpose of edge value calculations
+                                             !! in the same units as h0.
   ! Local variables
   logical :: extrapolate
 
@@ -106,8 +106,8 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
 
     case ( INTERPOLATION_P1M_H2 )
       degree = DEGREE_1
-      call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
-      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+      call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
       if (extrapolate) then
         call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
       endif
@@ -117,9 +117,9 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       if ( n0 >= 4 ) then
         call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
       else
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
       endif
-      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
       if (extrapolate) then
         call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
       endif
@@ -129,9 +129,9 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       if ( n0 >= 4 ) then
         call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
       else
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
       endif
-      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
       if (extrapolate) then
         call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
       endif
@@ -147,15 +147,15 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       if ( n0 >= 4 ) then
         degree = DEGREE_2
         call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, &
                                            ppoly0_coefs, h_neglect )
         endif
       else
         degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -165,15 +165,15 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       if ( n0 >= 4 ) then
         degree = DEGREE_2
         call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, &
                                            ppoly0_coefs, h_neglect )
         endif
       else
         degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -185,15 +185,15 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
         call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
         call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
         call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
-                                ppoly0_coefs, h_neglect )
+                                ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call P3M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                            ppoly0_coefs, h_neglect, h_neglect_edge )
         endif
       else
         degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -205,15 +205,15 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
         call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
         call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
         call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
-                                ppoly0_coefs, h_neglect )
+                                ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call P3M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
                    ppoly0_coefs, h_neglect, h_neglect_edge )
         endif
       else
         degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -225,15 +225,15 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
         call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
         call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
         call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, &
-                                 ppoly0_coefs, h_neglect )
+                                 ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call PQM_boundary_extrapolation_v1( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                  ppoly0_coefs, h_neglect )
         endif
       else
         degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -245,20 +245,21 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
         call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
         call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
         call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, &
-                                 ppoly0_coefs, h_neglect )
+                                 ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call PQM_boundary_extrapolation_v1( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                  ppoly0_coefs, h_neglect )
         endif
       else
         degree = DEGREE_1
-        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E, h_neglect_edge )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
       endif
   end select
+
 end subroutine regridding_set_ppolys
 
 !> Given target values (e.g., density), build new grid based on polynomial
@@ -268,17 +269,18 @@ end subroutine regridding_set_ppolys
 !! are determined by finding the corresponding target interface densities.
 subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
                              target_values, degree, n1, h1, x1, answers_2018 )
-  integer,            intent(in)    :: n0            !< Number of points on source grid
-  real, dimension(:), intent(in)    :: h0            !< Thicknesses of source grid cells
-  real, dimension(:), intent(in)    :: x0            !< Source interface positions
-  real, dimension(:,:), intent(in)  :: ppoly0_E      !< Edge values of interpolating polynomials
-  real, dimension(:,:), intent(in)  :: ppoly0_coefs  !< Coefficients of interpolating polynomials
-  real, dimension(:), intent(in)    :: target_values !< Target values of interfaces
-  integer,            intent(in)    :: degree        !< Degree of interpolating polynomials
-  integer,            intent(in)    :: n1            !< Number of points on target grid
-  real, dimension(:), intent(inout) :: h1            !< Thicknesses of target grid cells
-  real, dimension(:), intent(inout) :: x1            !< Target interface positions
-  logical,  optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,               intent(in)     :: n0            !< Number of points on source grid
+  integer,               intent(in)     :: n1            !< Number of points on target grid
+  real, dimension(n0),   intent(in)     :: h0            !< Thicknesses of source grid cells
+  real, dimension(n0+1), intent(in)     :: x0            !< Source interface positions
+  real, dimension(n0,2), intent(in)     :: ppoly0_E      !< Edge values of interpolating polynomials
+  real, dimension(n0,DEGREE_MAX+1), &
+                          intent(in)    :: ppoly0_coefs  !< Coefficients of interpolating polynomials
+  real, dimension(n1+1),  intent(in)    :: target_values !< Target values of interfaces
+  integer,                intent(in)    :: degree        !< Degree of interpolating polynomials
+  real, dimension(n1),    intent(inout) :: h1            !< Thicknesses of target grid cells
+  real, dimension(n1+1),  intent(inout) :: x1            !< Target interface positions
+  logical,      optional, intent(in)    :: answers_2018  !< If true use older, less acccurate expressions.
 
   ! Local variables
   logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
@@ -304,19 +306,19 @@ end subroutine interpolate_grid
 !> Build a grid by interpolating for target values
 subroutine build_and_interpolate_grid(CS, densities, n0, h0, x0, target_values, &
                                       n1, h1, x1, h_neglect, h_neglect_edge)
-  type(interp_CS_type), intent(in)  :: CS  !< A control structure for regrid_interp
-  real, dimension(:), intent(in)    :: densities !< Input cell densities [kg m-3]
-  real, dimension(:), intent(in)    :: target_values !< Target values of interfaces
-  integer,            intent(in)    :: n0  !< The number of points on the input grid
-  real, dimension(:), intent(in)    :: h0  !< Initial cell widths
-  real, dimension(:), intent(in)    :: x0  !< Source interface positions
-  integer,            intent(in)    :: n1  !< The number of points on the output grid
-  real, dimension(:), intent(inout) :: h1  !< Output cell widths
-  real, dimension(:), intent(inout) :: x1  !< Target interface positions
-  real,     optional, intent(in)    :: h_neglect !< A negligibly small width for the
+  type(interp_CS_type),  intent(in)    :: CS  !< A control structure for regrid_interp
+  integer,               intent(in)    :: n0  !< The number of points on the input grid
+  integer,               intent(in)    :: n1  !< The number of points on the output grid
+  real, dimension(n0),   intent(in)    :: densities !< Input cell densities [kg m-3]
+  real, dimension(n1+1), intent(in)    :: target_values !< Target values of interfaces
+  real, dimension(n0),   intent(in)    :: h0  !< Initial cell widths
+  real, dimension(n0+1), intent(in)    :: x0  !< Source interface positions
+  real, dimension(n1),   intent(inout) :: h1  !< Output cell widths
+  real, dimension(n1+1), intent(inout) :: x1  !< Target interface positions
+  real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the
                                            !! purpose of cell reconstructions
                                            !! in the same units as h0.
-  real,     optional, intent(in)    :: h_neglect_edge !< A negligibly small width
+  real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width
                                            !! for the purpose of edge value calculations
                                            !! in the same units as h0.
 
@@ -350,10 +352,10 @@ function get_polynomial_coordinate( N, h, x_g, ppoly_E, ppoly_coefs, &
                                     target_value, degree, answers_2018 ) result ( x_tgt )
   ! Arguments
   integer,              intent(in) :: N            !< Number of grid cells
-  real, dimension(:),   intent(in) :: h            !< Grid cell thicknesses
-  real, dimension(:),   intent(in) :: x_g          !< Grid interface locations
-  real, dimension(:,:), intent(in) :: ppoly_E      !< Edge values of interpolating polynomials
-  real, dimension(:,:), intent(in) :: ppoly_coefs  !< Coefficients of interpolating polynomials
+  real, dimension(N),   intent(in) :: h            !< Grid cell thicknesses
+  real, dimension(N+1), intent(in) :: x_g          !< Grid interface locations
+  real, dimension(N,2), intent(in) :: ppoly_E      !< Edge values of interpolating polynomials
+  real, dimension(N,DEGREE_MAX+1), intent(in) :: ppoly_coefs  !< Coefficients of interpolating polynomials
   real,                 intent(in) :: target_value !< Target value to find position for
   integer,              intent(in) :: degree       !< Degree of the interpolating polynomials
   logical,    optional, intent(in) :: answers_2018 !< If true use older, less acccurate expressions.

--- a/src/ALE/regrid_solvers.F90
+++ b/src/ALE/regrid_solvers.F90
@@ -7,52 +7,50 @@ use MOM_error_handler, only : MOM_error, FATAL
 
 implicit none ; private
 
-public :: solve_linear_system, solve_tridiagonal_system
+public :: solve_linear_system, solve_tridiagonal_system, solve_diag_dominant_tridiag
 
 contains
 
-!> Solve the linear system AX = B by Gaussian elimination
+!> Solve the linear system AX = R by Gaussian elimination
 !!
 !! This routine uses Gauss's algorithm to transform the system's original
 !! matrix into an upper triangular matrix. Back substitution yields the answer.
-!! The matrix A must be square and its size must be that of the vectors B and X.
-subroutine solve_linear_system( A, B, X, system_size )
-  real, dimension(:,:), intent(inout) :: A  !< The matrix being inverted
-  real, dimension(:),   intent(inout) :: B  !< system right-hand side
-  real, dimension(:),   intent(inout) :: X  !< solution vector
-  integer, intent(in)                 :: system_size !< The size of the system
+!! The matrix A must be square and its size must be that of the vectors R and X.
+subroutine solve_linear_system( A, R, X, N, answers_2018 )
+  integer,              intent(in)    :: N  !< The size of the system
+  real, dimension(N,N), intent(inout) :: A  !< The matrix being inverted [nondim]
+  real, dimension(N),   intent(inout) :: R  !< system right-hand side [A]
+  real, dimension(N),   intent(inout) :: X  !< solution vector [A]
+  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   ! Local variables
-  integer               :: i, j, k
   real, parameter       :: eps = 0.0        ! Minimum pivot magnitude allowed
-  real                  :: factor
-  real                  :: pivot
-  real                  :: swap_a, swap_b
-  logical               :: found_pivot      ! boolean indicating whether
-                                            ! a pivot has been found
-  ! Loop on rows
-  do i = 1,system_size-1
+  real    :: factor       ! The factor that eliminates the leading nonzero element in a  row.
+  real    :: pivot, I_pivot ! The pivot value and its reciprocal [nondim]
+  real    :: swap_a, swap_b
+  logical :: found_pivot  ! If true, a pivot has been found
+  logical :: old_answers  ! If true, use expressions that give the original (2008 through 2018) MOM6 answers
+  integer :: i, j, k
 
+  old_answers = .true. ; if (present(answers_2018)) old_answers = answers_2018
+
+  ! Loop on rows to transform the problem into multiplication by an upper-right matrix.
+  do i = 1,N-1
+
+
+    ! Start to look for a pivot in the current row, i.  If the pivot in row i is not valid,
+    ! keep looking for a valid pivot by searching the entries of column i in rows below row i.
+    ! Once a valid pivot is found (say in row k), rows i and k are swaped.
     found_pivot = .false.
-
-    ! Start to look for a pivot in row i. If the pivot
-    ! in row i -- which is the current row -- is not valid,
-    ! we keep looking for a valid pivot by searching the
-    ! entries of column i in rows below row i. Once a valid
-    ! pivot is found (say in row k), rows i and k are swaped.
     k = i
-    do while ( ( .NOT. found_pivot ) .AND. ( k <= system_size ) )
-
-        if ( abs( A(k,i) ) > eps ) then  ! a valid pivot is found
-          found_pivot = .true.
-        else                                ! Go to the next row to see
-                                            ! if there is a valid pivot there
-          k = k + 1
-        endif
-
+    do while ( ( .NOT. found_pivot ) .AND. ( k <= N ) )
+      if ( abs( A(k,i) ) > eps ) then  ! A valid pivot has been found
+        found_pivot = .true.
+      else                             ! Seek a valid pivot in the next row
+        k = k + 1
+      endif
     enddo ! end loop to find pivot
 
-    ! If no pivot could be found, the system is singular and we need
-    ! to end the execution
+    ! If no pivot could be found, the system is singular.
     if ( .NOT. found_pivot ) then
       write(0,*) ' A=',A
       call MOM_error( FATAL, 'The linear system is singular !' )
@@ -61,86 +59,152 @@ subroutine solve_linear_system( A, B, X, system_size )
     ! If the pivot is in a row that is different than row i, that is if
     ! k is different than i, we need to swap those two rows
     if ( k /= i ) then
-      do j = 1,system_size
-        swap_a = A(i,j)
-        A(i,j) = A(k,j)
-        A(k,j) = swap_a
+      do j = 1,N
+        swap_a = A(i,j) ; A(i,j) = A(k,j) ; A(k,j) = swap_a
       enddo
-      swap_b = B(i)
-      B(i) = B(k)
-      B(k) = swap_b
+      swap_b = R(i) ; R(i) = R(k) ; R(k) = swap_b
     endif
 
-    ! Transform pivot to 1 by dividing the entire row
-    ! (right-hand side included) by the pivot
-    pivot = A(i,i)
-    do j = i,system_size
-      A(i,j) = A(i,j) / pivot
-    enddo
-    B(i) = B(i) / pivot
+    ! Transform pivot to 1 by dividing the entire row (right-hand side included) by the pivot
+    if (old_answers) then
+      pivot = A(i,i)
+      do j = i,N ; A(i,j) = A(i,j) / pivot ; enddo
+      R(i) = R(i) / pivot
+    else
+      I_pivot = 1.0 / A(i,i)
+      A(i,i) = 1.0
+      do j = i+1,N ; A(i,j) = A(i,j) * I_pivot ; enddo
+      R(i) = R(i) * I_pivot
+    endif
 
     ! #INV: At this point, A(i,i) is a suitable pivot and it is equal to 1
 
-    ! Put zeros in column for all rows below that containing
-    ! pivot (which is row i)
-    do k = (i+1),system_size    ! k is the row index
+    ! Put zeros in column for all rows below that contain the pivot (which is row i)
+    do k = i+1,N    ! k is the row index
       factor = A(k,i)
-      do j = (i+1),system_size      ! j is the column index
+      ! A(k,i) = 0.0  ! These elements are not used again, so this line can be skipped for speed.
+      do j = i+1,N  ! j is the column index
         A(k,j) = A(k,j) - factor * A(i,j)
       enddo
-      B(k) = B(k) - factor * B(i)
+      R(k) = R(k) - factor * R(i)
     enddo
 
   enddo ! end loop on i
 
-
-  ! Solve system by back substituting
-  X(system_size) = B(system_size) / A(system_size,system_size)
-  do i = system_size-1,1,-1 ! loop on rows, starting from second to last row
-    X(i) = B(i)
-    do j = (i+1),system_size
+  ! Solve system by back substituting in what is now an upper-right matrix.
+  X(N) = R(N) / A(N,N)  ! The last row is now trivially solved.
+  do i = N-1,1,-1 ! loop on rows, starting from second to last row
+    X(i) = R(i)
+    do j = i+1,N
       X(i) = X(i) - A(i,j) * X(j)
     enddo
-    X(i) = X(i) / A(i,i)
+    if (old_answers) X(i) = X(i) / A(i,i)
   enddo
 
 end subroutine solve_linear_system
 
-!> Solve the tridiagonal system AX = B
+!> Solve the tridiagonal system AX = R
 !!
-!! This routine uses Thomas's algorithm to solve the tridiagonal system AX = B.
+!! This routine uses Thomas's algorithm to solve the tridiagonal system AX = R.
 !! (A is made up of lower, middle and upper diagonals)
-subroutine solve_tridiagonal_system( Al, Ad, Au, B, X, system_size )
-  real, dimension(:), intent(inout) :: Ad  !< Maxtix center diagonal
-  real, dimension(:), intent(inout) :: Al  !< Matrix lower diagonal
-  real, dimension(:), intent(inout) :: Au  !< Matrix upper diagonal
-  real, dimension(:), intent(inout) :: B   !< system right-hand side
-  real, dimension(:), intent(inout) :: X   !< solution vector
-  integer, intent(in)               :: system_size !< The size of the system
+subroutine solve_tridiagonal_system( Al, Ad, Au, R, X, N, answers_2018 )
+  integer,            intent(in)  :: N   !< The size of the system
+  real, dimension(N), intent(in)  :: Ad  !< Matrix center diagonal
+  real, dimension(N), intent(in)  :: Al  !< Matrix lower diagonal
+  real, dimension(N), intent(in)  :: Au  !< Matrix upper diagonal
+  real, dimension(N), intent(in)  :: R   !< system right-hand side
+  real, dimension(N), intent(out) :: X   !< solution vector
+  logical,  optional, intent(in)  :: answers_2018 !< If true use older, less acccurate expressions.
   ! Local variables
-  integer                               :: k        ! Loop index
-  integer                               :: N        ! system size
+  real, dimension(N) :: pivot, Al_piv
+  real, dimension(N) :: c1       ! Au / pivot for the backward sweep
+  real    :: I_pivot  ! The inverse of the most recent pivot
+  integer :: k        ! Loop index
+  logical :: old_answers  ! If true, use expressions that give the original (2008 through 2018) MOM6 answers
 
-  N = system_size
+  old_answers = .true. ; if (present(answers_2018)) old_answers = answers_2018
 
-  ! Factorization
-  do k = 1,N-1
-    Al(k+1) = Al(k+1) / Ad(k)
-    Ad(k+1) = Ad(k+1) - Al(k+1) * Au(k)
-  enddo
+  if (old_answers) then
+    ! This version gives the same answers as the original (2008 through 2018) MOM6 code
+    ! Factorization and forward sweep
+    pivot(1) = Ad(1)
+    X(1) = R(1)
+    do k = 2,N
+      Al_piv(k) = Al(k) / pivot(k-1)
+      pivot(k) = Ad(k) - Al_piv(k) * Au(k-1)
+      X(k) = R(k) - Al_piv(k) * X(k-1)
+    enddo
 
-  ! Forward sweep
-  do k = 2,N
-    B(k) = B(k) - Al(k) * B(k-1)
-  enddo
+    ! Backward sweep
+    X(N) = R(N) / pivot(N)  ! This should be X(N) / pivot(N), but is OK if Al(N) = 0.
+    do k = N-1,1,-1
+      X(k) = ( X(k) - Au(k)*X(k+1) ) / pivot(k)
+    enddo
+  else
+    ! This is a more typical implementation of a tridiagonal solver than the one above.
+    ! It is mathematically equivalent but differs at roundoff, which can cascade up to larger values.
 
-  ! Backward sweep
-  X(N) = B(N) / Ad(N)
-  do k = N-1,1,-1
-    X(k) = ( B(k) - Au(k)*X(k+1) ) / Ad(k)
-  enddo
+    ! Factorization and forward sweep
+    I_pivot = 1.0 / Ad(1)
+    X(1) = R(1) * I_pivot
+    do k = 2,N
+      c1(K-1) = Au(k-1) * I_pivot
+      I_pivot = 1.0 / (Ad(k) - Al(k) * c1(K-1))
+      X(k) = (R(k) - Al(k) * X(k-1)) * I_pivot
+    enddo
+    ! Backward sweep
+    do k = N-1,1,-1
+      X(k) = X(k) - c1(K) * X(k+1)
+    enddo
+
+  endif
 
 end subroutine solve_tridiagonal_system
+
+
+!> Solve the tridiagonal system AX = R
+!!
+!! This routine uses a variant of Thomas's algorithm to solve the tridiagonal system AX = R, in
+!! a form that is guaranteed to avoid dividing by a zero pivot.  The matrix A is made up of
+!! lower (Al) and upper diagonals (Au) and a central diagonal Ad = Ac+Al+Au, where
+!! Al, Au, and Ac are all positive (or negative) definite.  However when Ac is smaller than
+!! roundoff compared with (Al+Au), the answers are prone to inaccuracy.
+subroutine solve_diag_dominant_tridiag( Al, Ac, Au, R, X, N )
+  integer,            intent(in)  :: N   !< The size of the system
+  real, dimension(N), intent(in)  :: Ac  !< Matrix center diagonal offset from Al + Au
+  real, dimension(N), intent(in)  :: Al  !< Matrix lower diagonal
+  real, dimension(N), intent(in)  :: Au  !< Matrix upper diagonal
+  real, dimension(N), intent(in)  :: R   !< system right-hand side
+  real, dimension(N), intent(out) :: X   !< solution vector
+  ! Local variables
+  real, dimension(N) :: c1       ! Au / pivot for the backward sweep
+  real               :: d1       ! The next value of 1.0 - c1
+  real               :: I_pivot  ! The inverse of the most recent pivot
+  real               :: denom_t1 ! The first term in the denominator of the inverse of the pivot.
+  integer            :: k        ! Loop index
+
+  ! Factorization and forward sweep, in a form that will never give a division by a
+  ! zero pivot for positive definite Ac, Al, and Au.
+  I_pivot = 1.0 / (Ac(1) + Au(1))
+  d1 = Ac(1) * I_pivot
+  c1(1) = Au(1) * I_pivot
+  X(1) = R(1) * I_pivot
+  do k=2,N-1
+    denom_t1 = Ac(k) + d1 * Al(k)
+    I_pivot = 1.0 / (denom_t1 + Au(k))
+    d1 = denom_t1 * I_pivot
+    c1(k) = Au(k) * I_pivot
+    X(k) = (R(k) - Al(k) * X(k-1)) * I_pivot
+  enddo
+  I_pivot = 1.0 / (Ac(N) + d1 * Al(N))
+  X(N) = (R(N) - Al(N) * X(N-1)) * I_pivot
+  ! Backward sweep
+  do k=N-1,1,-1
+    X(k) = X(k) - c1(k) * X(k+1)
+  enddo
+
+end subroutine solve_diag_dominant_tridiag
+
 
 !> \namespace regrid_solvers
 !!
@@ -148,6 +212,6 @@ end subroutine solve_tridiagonal_system
 !! L. White
 !!
 !! This module contains solvers of linear systems.
-!! These routines could (should ?) be replaced later by more efficient ones.
+!! These routines have now been updated for greater efficiency, especially in special cases.
 
 end module regrid_solvers

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -555,6 +555,7 @@ subroutine initialize_segment_data(G, OBC, PF)
   character(len=32)  :: remappingScheme
   character(len=256) :: mesg    ! Message for error messages.
   logical :: check_reconstruction, check_remapping, force_bounds_in_subcell
+  logical :: answers_2018, default_2018_answers
   integer, dimension(4) :: siz,siz2
   integer :: is, ie, js, je
   integer :: isd, ied, jsd, jed
@@ -591,14 +592,21 @@ subroutine initialize_segment_data(G, OBC, PF)
           "If true, the values on the intermediate grid used for remapping "//&
           "are forced to be bounded, which might not be the case due to "//&
           "round off.", default=.false.,do_not_log=.true.)
-    call get_param(PF, mdl, "BRUSHCUTTER_MODE", OBC%brushcutter_mode, &
+  call get_param(PF, mdl, "BRUSHCUTTER_MODE", OBC%brushcutter_mode, &
          "If true, read external OBC data on the supergrid.", &
          default=.false.)
+  call get_param(PF, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+  call get_param(PF, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
 
   allocate(OBC%remap_CS)
   call initialize_remapping(OBC%remap_CS, remappingScheme, boundary_extrapolation = .false., &
-       check_reconstruction=check_reconstruction, &
-       check_remapping=check_remapping, force_bounds_in_subcell=force_bounds_in_subcell)
+               check_reconstruction=check_reconstruction, check_remapping=check_remapping, &
+               force_bounds_in_subcell=force_bounds_in_subcell, answers_2018=answers_2018)
 
   if (OBC%user_BCs_set_globally) return
 

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1446,6 +1446,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   character(len=40)  :: mdl = "MOM_diagnostics" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   logical :: use_temperature, adiabatic
+  logical :: default_2018_answers, remap_answers_2018
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz, nkml, nkbl
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j
 
@@ -1476,6 +1477,13 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
                  "The depth below which N2 is limited as monotonic for the "// &
                  "purposes of calculating the equivalent barotropic wave speed.", &
                  units='m', scale=US%m_to_Z, default=-1.)
+  call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", remap_answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
 
   if (GV%Boussinesq) then
     thickness_units = "m" ; flux_units = "m3 s-1" ; convert_H = GV%H_to_m
@@ -1686,7 +1694,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   if ((CS%id_cg1>0) .or. (CS%id_Rd1>0) .or. (CS%id_cfl_cg1>0) .or. &
       (CS%id_cfl_cg1_x>0) .or. (CS%id_cfl_cg1_y>0) .or. &
       (CS%id_cg_ebt>0) .or. (CS%id_Rd_ebt>0) .or. (CS%id_p_ebt>0)) then
-    call wave_speed_init(CS%wave_speed_CSp)
+    call wave_speed_init(CS%wave_speed_CSp, remap_answers_2018=remap_answers_2018)
     call safe_alloc_ptr(CS%cg1,isd,ied,jsd,jed)
     if (CS%id_Rd1>0)       call safe_alloc_ptr(CS%Rd1,isd,ied,jsd,jed)
     if (CS%id_Rd_ebt>0)    call safe_alloc_ptr(CS%Rd1,isd,ied,jsd,jed)

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -40,7 +40,7 @@ type, public :: wave_speed_CS ; private
                                        !! can be overridden by optional arguments.
   type(remapping_CS) :: remapping_CS   !< Used for vertical remapping when calculating equivalent barotropic
                                        !! mode structure.
-  logical :: remap_answers_2018 = .true.  !> If true, use the order of arithmetic and expressions that
+  logical :: remap_answers_2018 = .true.  !< If true, use the order of arithmetic and expressions that
                                        !! recover the remapping answers from 2018.  If false, use more
                                        !! robust forms of the same remapping expressions.
   type(diag_ctrl), pointer :: diag     !< Diagnostics control structure

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -2986,6 +2986,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
   ! Local variables
   integer :: ios, i, new_unit
   logical :: opened, new_file
+  logical :: answers_2018, default_2018_answers
   character(len=8)   :: this_pe
   character(len=240) :: doc_file, doc_file_dflt, doc_path
   character(len=240), allocatable :: diag_coords(:)
@@ -3012,6 +3013,13 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
                  'The number of diagnostic vertical coordinates to use. '//&
                  'For each coordinate, an entry in DIAG_COORDS must be provided.', &
                  default=1)
+  call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
   if (diag_cs%num_diag_coords>0) then
     allocate(diag_coords(diag_cs%num_diag_coords))
     if (diag_cs%num_diag_coords==1) then ! The default is to provide just one instance of Z*
@@ -3030,7 +3038,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
     allocate(diag_cs%diag_remap_cs(diag_cs%num_diag_coords))
     ! Initialize each diagnostic vertical coordinate
     do i=1, diag_cs%num_diag_coords
-      call diag_remap_init(diag_cs%diag_remap_cs(i), diag_coords(i))
+      call diag_remap_init(diag_cs%diag_remap_cs(i), diag_coords(i), answers_2018=answers_2018)
     enddo
     deallocate(diag_coords)
   endif

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -292,8 +292,9 @@ subroutine diag_remap_update(remap_cs, G, GV, US, h, T, S, eqn_of_state)
     return
   endif
 
-  !### Try replacing both of these with GV%H_subroundoff
-  if (GV%Boussinesq) then
+  if (.not.remap_cs%answers_2018) then
+    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
+  elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
   else
     h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
@@ -369,11 +370,9 @@ subroutine diag_remap_do_remap(remap_cs, G, GV, h, staggered_in_x, staggered_in_
   call assert(size(field, 3) == size(h, 3), &
               'diag_remap_do_remap: Remap field and thickness z-axes do not match.')
 
-  !### Try replacing both of these with GV%H_subroundoff
-  ! if (remap_cs%answers_2018) then
-  !   h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
-  ! elseif (GV%Boussinesq) then
-  if (GV%Boussinesq) then
+  if (.not.remap_cs%answers_2018) then
+    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
+  elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
   else
     h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2011,6 +2011,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_param
   type(remapping_CS) :: remapCS ! Remapping parameters and work arrays
 
   logical :: homogenize, useALEremapping, remap_full_column, remap_general, remap_old_alg
+  logical :: answers_2018, default_2018_answers
   logical :: use_ice_shelf
   character(len=10) :: remappingScheme
   real :: tempAvg, saltAvg
@@ -2088,6 +2089,15 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_param
                  "If false, uses the preferred remapping algorithm for initialization. "//&
                  "If true, use an older, less robust algorithm for remapping.", &
                  default=.true., do_not_log=just_read)
+  if (useALEremapping) then
+    call get_param(PF, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+    call get_param(PF, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
+  endif
   call get_param(PF, mdl, "ICE_SHELF", use_ice_shelf, default=.false.)
   if (use_ice_shelf) then
     call get_param(PF, mdl, "ICE_THICKNESS_FILE", ice_shelf_file, &
@@ -2256,8 +2266,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_param
       deallocate( hTarget )
     endif
 
-    ! Now remap from source grid to target grid
-    call initialize_remapping( remapCS, remappingScheme, boundary_extrapolation=.false. ) ! Reconstruction parameters
+    ! Now remap from source grid to target grid, first setting reconstruction parameters
+    call initialize_remapping( remapCS, remappingScheme, boundary_extrapolation=.false., answers_2018=answers_2018 )
     if (remap_general) then
       call set_regrid_params( regridCS, min_thickness=0. )
       tv_loc = tv

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -90,6 +90,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   real :: missing_value
   integer :: nPoints
   integer :: id_clock_routine, id_clock_ALE
+  logical :: answers_2018, default_2018_answers
   logical :: reentrant_x, tripolar_n
 
   id_clock_routine = cpu_clock_id('(Initialize tracer from Z)', grain=CLOCK_ROUTINE)
@@ -111,6 +112,15 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   call get_param(PF, mdl, "Z_INIT_REMAPPING_SCHEME", remapScheme, &
                  "The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.", &
                  default="PLM")
+  if (useALE) then
+    call get_param(PF, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+    call get_param(PF, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
+  endif
 
   ! These are model grid properties, but being applied to the data grid for now.
   ! need to revisit this (mjh)
@@ -140,7 +150,8 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
     ! First we reserve a work space for reconstructions of the source data
     allocate( h1(kd) )
     allocate( hSrc(isd:ied,jsd:jed,kd) )
-    call initialize_remapping( remapCS, remapScheme, boundary_extrapolation=.false. ) ! Data for reconstructions
+    ! Set parameters for reconstructions
+    call initialize_remapping( remapCS, remapScheme, boundary_extrapolation=.false., answers_2018=answers_2018 )
     ! Next we initialize the regridding package so that it knows about the target grid
 
     do j = js, je ; do i = is, ie

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -176,7 +176,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
       hSrc(i,j,:) = GV%Z_to_H * h1(:)
     enddo ; enddo
 
-    call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false. )
+    call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false., answers_2018=answers_2018 )
 
     deallocate( hSrc )
     deallocate( h1 )

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -877,6 +877,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   real :: absurdly_small_freq  ! A miniscule frequency that is used to avoid division by 0 [T-1 ~> s-1].  The
              ! default value is roughly (pi / (the age of the universe)).
   logical :: Gill_equatorial_Ld, use_FGNV_streamfn, use_MEKE, in_use
+  logical :: default_2018_answers, remap_answers_2018
   real :: MLE_front_length
   real :: Leith_Lap_const      ! The non-dimensional coefficient in the Leith viscosity
   real :: grid_sp_u2, grid_sp_v2 ! Intermediate quantities for Leith metrics [L2 ~> m2]
@@ -1178,7 +1179,15 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   if (CS%calculate_cg1) then
     in_use = .true.
     allocate(CS%cg1(isd:ied,jsd:jed)) ; CS%cg1(:,:) = 0.0
-    call wave_speed_init(CS%wave_speed_CSp, use_ebt_mode=CS%Resoln_use_ebt, mono_N2_depth=N2_filter_depth)
+    call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+    call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", remap_answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
+    call wave_speed_init(CS%wave_speed_CSp, use_ebt_mode=CS%Resoln_use_ebt, &
+                         mono_N2_depth=N2_filter_depth, remap_answers_2018=remap_answers_2018)
   endif
 
   ! Leith parameters

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -159,6 +159,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
   real, allocatable, dimension(:,:) :: Iresttime_u !< inverse of the restoring time at u points [s-1]
   real, allocatable, dimension(:,:) :: Iresttime_v !< inverse of the restoring time at v points [s-1]
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
+  logical :: answers_2018, default_2018_answers
   integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
   character(len=10)  :: remapScheme
   if (associated(CS)) then
@@ -193,6 +194,13 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
                  "than PCM. E.g., if PPM is used for remapping, a "//&
                  "PPM reconstruction will also be used within boundary cells.", &
                  default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
 
   CS%time_varying_sponges = .false.
   CS%nz = G%ke
@@ -232,7 +240,8 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
   call sum_across_PEs(total_sponge_cols)
 
 ! Call the constructor for remapping control structure
-  call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation)
+  call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
+                            answers_2018=answers_2018)
 
   call log_param(param_file, mdl, "!Total sponge columns at h points", total_sponge_cols, &
                  "The total number of columns where sponges are applied at h points.")
@@ -388,6 +397,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
     real, allocatable, dimension(:,:) :: Iresttime_u !< inverse of the restoring time at u points [s-1]
   real, allocatable, dimension(:,:) :: Iresttime_v !< inverse of the restoring time at v points [s-1]
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
+  logical :: answers_2018, default_2018_answers
   logical :: spongeDataOngrid = .false.
   integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
   character(len=10)  :: remapScheme
@@ -418,6 +428,13 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
                  "than PCM. E.g., if PPM is used for remapping, a "//&
                  "PPM reconstruction will also be used within boundary cells.", &
                  default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
   call get_param(param_file, mdl, "SPONGE_DATA_ONGRID", CS%spongeDataOngrid, &
                  "When defined, the incoming sponge data are "//&
                  "assumed to be on the model grid " , &
@@ -452,7 +469,8 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
   call sum_across_PEs(total_sponge_cols)
 
 ! Call the constructor for remapping control structure
-  call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation)
+  call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
+                            answers_2018=answers_2018)
   call log_param(param_file, mdl, "!Total sponge columns at h points", total_sponge_cols, &
                  "The total number of columns where sponges are applied at h points.")
   if (CS%sponge_uv) then

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -127,6 +127,9 @@ type, public :: ALE_sponge_CS ; private
                                    !! timing of diagnostic output.
 
   type(remapping_cs) :: remap_cs   !< Remapping parameters and work arrays
+  logical :: remap_answers_2018    !< If true, use the order of arithmetic and expressions that
+                                   !! recover the answers for remapping from the end of 2018.
+                                   !! Otherwise, use more robust forms of the same expressions.
 
   logical :: time_varying_sponges  !< True if using newer sponge code
   logical :: spongeDataOngrid !< True if the sponge data are on the model horizontal grid
@@ -159,7 +162,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
   real, allocatable, dimension(:,:) :: Iresttime_u !< inverse of the restoring time at u points [s-1]
   real, allocatable, dimension(:,:) :: Iresttime_v !< inverse of the restoring time at v points [s-1]
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
-  logical :: answers_2018, default_2018_answers
+  logical :: default_2018_answers
   integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
   character(len=10)  :: remapScheme
   if (associated(CS)) then
@@ -197,7 +200,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=.true.)
-  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", CS%remap_answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
@@ -241,7 +244,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, param_file, CS, data_h, nz_
 
 ! Call the constructor for remapping control structure
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
-                            answers_2018=answers_2018)
+                            answers_2018=CS%remap_answers_2018)
 
   call log_param(param_file, mdl, "!Total sponge columns at h points", total_sponge_cols, &
                  "The total number of columns where sponges are applied at h points.")
@@ -397,7 +400,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
     real, allocatable, dimension(:,:) :: Iresttime_u !< inverse of the restoring time at u points [s-1]
   real, allocatable, dimension(:,:) :: Iresttime_v !< inverse of the restoring time at v points [s-1]
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
-  logical :: answers_2018, default_2018_answers
+  logical :: default_2018_answers
   logical :: spongeDataOngrid = .false.
   integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
   character(len=10)  :: remapScheme
@@ -431,7 +434,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=.true.)
-  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", CS%remap_answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
@@ -470,7 +473,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, param_file, CS)
 
 ! Call the constructor for remapping control structure
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
-                            answers_2018=answers_2018)
+                            answers_2018=CS%remap_answers_2018)
   call log_param(param_file, mdl, "!Total sponge columns at h points", total_sponge_cols, &
                  "The total number of columns where sponges are applied at h points.")
   if (CS%sponge_uv) then
@@ -804,7 +807,9 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   if (.not.associated(CS)) return
 
-  if (GV%Boussinesq) then
+  if (.not.CS%remap_answers_2018) then
+    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
+  elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
   else
     h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -308,7 +308,7 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
   ! Now restructure the layers.
   !$OMP parallel do default(private) shared(is,ie,js,je,nz,do_j,def_rat_h,CS,nkmb,G,GV,US, &
   !$OMP                                     e,I_dtol,h,tv,debug,h_neglect,p_ref_cv,ea, &
-  !$OMP                                     eb,id_clock_EOS,nkml)                      &
+  !$OMP                                     eb,id_clock_EOS,nkml)
   do j=js,je ; if (do_j(j)) then
 
 !  call cpu_clock_begin(id_clock_EOS)

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -31,22 +31,28 @@ type, public :: regularize_layers_CS ; private
   logical :: reg_sfc_detrain !< If true, allow the buffer layers to detrain into the
                              !! interior as a part of the restructuring when
                              !! regularize_surface_layers is true
+  real    :: density_match_tol !< A relative tolerance for how well the densities must match
+                             !! with the target densities during detrainment when regularizing
+                             !! the near-surface layers [nondim]
   real    :: h_def_tol1      !< The value of the relative thickness deficit at
                              !! which to start modifying the structure, 0.5 by
-                             !! default (or a thickness ratio of 5.83).
+                             !! default (or a thickness ratio of 5.83) [nondim].
   real    :: h_def_tol2      !< The value of the relative thickness deficit at
                              !! which to the structure modification is in full
-                             !! force, now 20% of the way from h_def_tol1 to 1.
+                             !! force, now 20% of the way from h_def_tol1 to 1 [nondim].
   real    :: h_def_tol3      !< The value of the relative thickness deficit at which to start
                              !! detrainment from the buffer layers to the interior, now 30% of
-                             !! the way from h_def_tol1 to 1.
+                             !! the way from h_def_tol1 to 1 [nondim].
   real    :: h_def_tol4      !< The value of the relative thickness deficit at which to do
                              !! detrainment from the buffer layers to the interior at full
-                             !! force, now 50% of the way from h_def_tol1 to 1.
+                             !! force, now 50% of the way from h_def_tol1 to 1 [nondim].
   real    :: Hmix_min        !< The minimum mixed layer thickness [H ~> m or kg m-2].
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
                              !! regulate the timing of diagnostic output.
+  logical :: answers_2018    !< If true, use the order of arithmetic and expressions that recover the
+                             !! answers from the end of 2018.  Otherwise, use updated and more robust
+                             !! forms of the same expressions.
   logical :: debug           !< If true, do more thorough checks for debugging purposes.
 
   integer :: id_def_rat = -1 !< A diagnostic ID
@@ -209,7 +215,7 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
   logical :: debug = .false.
   logical :: fatal_error
   character(len=256) :: mesg    ! Message for error messages.
-  integer :: i, j, k, is, ie, js, je, nz, nkmb, nkml, k1, k2, k3, ks, nz_filt
+  integer :: i, j, k, is, ie, js, je, nz, nkmb, nkml, k1, k2, k3, ks, nz_filt, kmax_d_ea
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
 
@@ -300,20 +306,9 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
 
 
   ! Now restructure the layers.
-!$OMP parallel do default(none) shared(is,ie,js,je,nz,do_j,def_rat_h,CS,nkmb,G,GV,US, &
-!$OMP                                  e,I_dtol,h,tv,debug,h_neglect,p_ref_cv,ea, &
-!$OMP                                  eb,id_clock_EOS,nkml)                      &
-!$OMP                          private(d_ea,d_eb,max_def_rat,do_i,nz_filt,e_e,e_w,&
-!$OMP                                  e_n,e_s,wt,e_filt,e_2d,h_2d,T_2d,S_2d,     &
-!$OMP                                  h_2d_init,T_2d_init,S_2d_init,ent_any,     &
-!$OMP                                  more_ent_i,ent_i,h_add_tgt,h_add_tot,      &
-!$OMP                                  cols_left,h_add,h_prev,ks,det_any,det_i,   &
-!$OMP                                  Rcv_tol,Rcv,k1,k2,h_det_tot,Rcv_min_det,   &
-!$OMP                                  Rcv_max_det,h_deficit,h_tot3,Th_tot3,      &
-!$OMP                                  Sh_tot3,scale,int_top,int_flux,int_Rflux,  &
-!$OMP                                  int_Tflux,int_Sflux,int_bot,h_prev_1d,     &
-!$OMP                                  h_tot1,Th_tot1,Sh_tot1,h_tot2,Th_tot2,     &
-!$OMP                                  Sh_tot2,h_predicted,fatal_error,mesg )
+  !$OMP parallel do default(private) shared(is,ie,js,je,nz,do_j,def_rat_h,CS,nkmb,G,GV,US, &
+  !$OMP                                     e,I_dtol,h,tv,debug,h_neglect,p_ref_cv,ea, &
+  !$OMP                                     eb,id_clock_EOS,nkml)                      &
   do j=js,je ; if (do_j(j)) then
 
 !  call cpu_clock_begin(id_clock_EOS)
@@ -322,6 +317,7 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
 !  call cpu_clock_end(id_clock_EOS)
 
     do k=1,nz ; do i=is,ie ; d_ea(i,k) = 0.0 ; d_eb(i,k) = 0.0 ; enddo ; enddo
+    kmax_d_ea = 0
 
     max_def_rat = 0.0
     do i=is,ie
@@ -389,13 +385,18 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
             if (e_2d(i,nkmb+1)-e_filt(i,nkmb+1) > h_2d(i,k) - GV%Angstrom_H) then
               h_add = h_2d(i,k) - GV%Angstrom_H
               h_2d(i,k) = GV%Angstrom_H
+              e_2d(i,nkmb+1) = e_2d(i,nkmb+1) - h_add
             else
-              h_add = e_2d(i,nkmb+1)-e_filt(i,nkmb+1)
+              h_add = e_2d(i,nkmb+1) - e_filt(i,nkmb+1)
               h_2d(i,k) = h_2d(i,k) - h_add
+              if (CS%answers_2018) then
+                e_2d(i,nkmb+1) = e_2d(i,nkmb+1) - h_add
+              else
+                e_2d(i,nkmb+1) = e_filt(i,nkmb+1)
+              endif
             endif
             d_eb(i,k-1) = d_eb(i,k-1) + h_add
             h_add_tot(i) = h_add_tot(i) + h_add
-            e_2d(i,nkmb+1) = e_2d(i,nkmb+1) - h_add
             h_prev = h_2d(i,nkmb)
             h_2d(i,nkmb) = h_2d(i,nkmb) + h_add
 
@@ -436,7 +437,8 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
         if (do_i(i) .and. (e_2d(i,nkmb+1) < e_filt(i,nkmb+1)) .and. &
             (def_rat_h(i,j) > CS%h_def_tol3)) then
           det_i(i) = .true. ; det_any = .true.
-          Rcv_tol(i) = min((def_rat_h(i,j) - CS%h_def_tol3), 1.0)
+          ! The CS%density_match_tol default value of 0.6 gives 20% overlap in acceptable densities.
+          Rcv_tol(i) = CS%density_match_tol * min((def_rat_h(i,j) - CS%h_def_tol3), 1.0)
         endif
       enddo
     endif
@@ -454,12 +456,11 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
         do ! This loop is terminated by exits.
           if (k1 <= 1) exit
           if (k2 <= nkmb) exit
-          ! ### The 0.6 here should be adjustable?  It gives 20% overlap for now.
-          Rcv_min_det = (GV%Rlay(k2) + 0.6*Rcv_tol(i)*(GV%Rlay(k2-1)-GV%Rlay(k2)))
+          Rcv_min_det = (GV%Rlay(k2) + Rcv_tol(i)*(GV%Rlay(k2-1)-GV%Rlay(k2)))
           if (k2 < nz) then
-            Rcv_max_det = (GV%Rlay(k2) + 0.6*Rcv_tol(i)*(GV%Rlay(k2+1)-GV%Rlay(k2)))
+            Rcv_max_det = (GV%Rlay(k2) + Rcv_tol(i)*(GV%Rlay(k2+1)-GV%Rlay(k2)))
           else
-            Rcv_max_det = (GV%Rlay(nz) + 0.6*Rcv_tol(i)*(GV%Rlay(nz)-GV%Rlay(nz-1)))
+            Rcv_max_det = (GV%Rlay(nz) + Rcv_tol(i)*(GV%Rlay(nz)-GV%Rlay(nz-1)))
           endif
           if (Rcv(i,k1) > Rcv_max_det) &
             exit ! All shallower interior layers are too light for detrainment.
@@ -476,7 +477,8 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
                 h_2d(i,k2) = h_2d(i,k2) + h_add
                 e_2d(i,k2) = e_2d(i,k2+1) + h_2d(i,k2)
                 d_ea(i,k2) = d_ea(i,k2) + h_add
-                ! ### THIS IS UPWIND.  IT SHOULD BE HIGHER ORDER...
+                kmax_d_ea = max(kmax_d_ea, k2)
+                ! This is upwind.  It should perhaps be higher order...
                 T_2d(i,k2) = (h_prev*T_2d(i,k2) + h_add*T_2d(i,k1)) / h_2d(i,k2)
                 S_2d(i,k2) = (h_prev*S_2d(i,k2) + h_add*S_2d(i,k1)) / h_2d(i,k2)
                 h_det_tot = h_det_tot + h_add
@@ -499,6 +501,7 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
               h_2d(i,k2) = h_2d(i,k2) + h_add
               e_2d(i,k2) = e_2d(i,k2+1) + h_2d(i,k2)
               d_ea(i,k2) = d_ea(i,k2) + h_add
+              kmax_d_ea = max(kmax_d_ea, k2)
               T_2d(i,k2) = (h_prev*T_2d(i,k2) + h_add*T_2d(i,k1)) / h_2d(i,k2)
               S_2d(i,k2) = (h_prev*S_2d(i,k2) + h_add*S_2d(i,k1)) / h_2d(i,k2)
               h_det_tot = h_det_tot + h_add
@@ -519,8 +522,7 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
 
         enddo ! exit terminated loop.
       endif ; enddo
-      ! ### This could be faster if the deepest k with nonzero d_ea were kept.
-      do k=nz-1,nkmb+1,-1 ; do i=is,ie ; if (det_i(i)) then
+      do k=kmax_d_ea-1,nkmb+1,-1 ; do i=is,ie ; if (det_i(i)) then
         d_ea(i,k) = d_ea(i,k) + d_ea(i,k+1)
       endif ; enddo ; enddo
     endif  ! Detrainment to the interior.
@@ -550,7 +552,8 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
         e_filt(i,2) = e_2d(i,nkml)
       endif
 
-      ! Map the water back into the layers.
+      ! Map the water back into the layers.  There are not mixed or buffer layers that are exceedingly
+      ! small compared to the others, so the code here is less prone to roundoff than elsewhere in MOM6.
       k1 = 1 ; k2 = 1
       int_top = 0.0
       do k=1,nkmb+1
@@ -887,6 +890,7 @@ subroutine regularize_layers_init(Time, G, GV, param_file, diag, CS)
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_regularize_layers"  ! This module's name.
   logical :: use_temperature
+  logical :: default_2018_answers
   integer :: isd, ied, jsd, jed
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
@@ -911,6 +915,17 @@ subroutine regularize_layers_init(Time, G, GV, param_file, diag, CS)
                  "If true, allow the buffer layers to detrain into the "//&
                  "interior as a part of the restructuring when "//&
                  "REGULARIZE_SURFACE_LAYERS is true.", default=.true.)
+  call get_param(param_file, mdl, "REG_SFC_DENSE_MATCH_TOLERANCE", CS%density_match_tol, &
+                 "A relative tolerance for how well the densities must match with the target "//&
+                 "densities during detrainment when regularizing the near-surface layers.  The "//&
+                 "default of 0.6 gives 20% overlaps in density", units="nondim", default=0.6)
+    call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+    call get_param(param_file, mdl, "REGULARIZE_LAYERS_2018_ANSWERS", CS%answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
   endif
 
   call get_param(param_file, mdl, "HMIX_MIN", CS%Hmix_min, &

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -142,6 +142,9 @@ type, public :: tidal_mixing_cs
   real                            :: tidal_diss_lim_tc  !< CVMix-specific dissipation limit depth for
                                                         !! tidal-energy-constituent data [Z ~> m].
   type(remapping_CS)              :: remap_CS           !< The control structure for remapping
+  logical :: remap_answers_2018 = .true.  !> If true, use the order of arithmetic and expressions that
+                                       !! recover the remapping answers from 2018.  If false, use more
+                                       !! robust forms of the same remapping expressions.
 
   ! Data containers
   real, pointer, dimension(:,:) :: TKE_Niku    => NULL() !< Lee wave driven Turbulent Kinetic Energy input
@@ -267,6 +270,10 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, CS)
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=.true.)
   call get_param(param_file, mdl, "TIDAL_MIXING_2018_ANSWERS", CS%answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", CS%remap_answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
@@ -1652,7 +1659,8 @@ subroutine read_tidal_constituents(G, US, tidal_energy_file, CS)
 
   ! initialize input remapping:
   call initialize_remapping(CS%remap_cs, remapping_scheme="PLM", &
-                            boundary_extrapolation=.false., check_remapping=CS%debug)
+                            boundary_extrapolation=.false., check_remapping=CS%debug, &
+                            answers_2018=CS%remap_answers_2018)
 
   deallocate(tc_m2)
   deallocate(tc_s2)

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -735,7 +735,6 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
   real :: dh, hcorr, Simmons_coeff
   real, parameter :: rho_fw = 1000.0 ! fresh water density [kg/m^3]
                                      ! TODO: when coupled, get this from CESM (SHR_CONST_RHOFW)
-  real :: h_neglect, h_neglect_edge
   type(tidal_mixing_diags), pointer :: dd => NULL()
 
   is  = G%isc ; ie  = G%iec
@@ -824,12 +823,6 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
     ! and CVMix_compute_SchmittnerCoeff low subroutines
 
     allocate(exp_hab_zetar(G%ke+1,G%ke+1))
-    if (GV%Boussinesq) then
-      h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
-    else
-      h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
-    endif
-
 
     do i=is,ie
 

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -142,7 +142,7 @@ type, public :: tidal_mixing_cs
   real                            :: tidal_diss_lim_tc  !< CVMix-specific dissipation limit depth for
                                                         !! tidal-energy-constituent data [Z ~> m].
   type(remapping_CS)              :: remap_CS           !< The control structure for remapping
-  logical :: remap_answers_2018 = .true.  !> If true, use the order of arithmetic and expressions that
+  logical :: remap_answers_2018 = .true.  !< If true, use the order of arithmetic and expressions that
                                        !! recover the remapping answers from 2018.  If false, use more
                                        !! robust forms of the same remapping expressions.
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -821,13 +821,13 @@ subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, US, CS, OBC)
       do k=1,nz ; do I=Isq,Ieq ; if (do_i_shelf(I)) then
         ! Should we instead take the inverse of the average of the inverses?
         CS%h_u(I,j,k) = forces%frac_shelf_u(I,j)  * hvel_shelf(I,k) + &
-                   (1.0-forces%frac_shelf_u(I,j)) * hvel(I,k)
+                   (1.0-forces%frac_shelf_u(I,j)) * hvel(I,k) + h_neglect
       elseif (do_i(I)) then
-        CS%h_u(I,j,k) = hvel(I,k)
+        CS%h_u(I,j,k) = hvel(I,k) + h_neglect
       endif ; enddo ; enddo
     else
       do K=1,nz+1 ; do I=Isq,Ieq ; if (do_i(I)) CS%a_u(I,j,K) = a_cpl(I,K) ; enddo ; enddo
-      do k=1,nz ; do I=Isq,Ieq ; if (do_i(I)) CS%h_u(I,j,k) = hvel(I,k) ; enddo ; enddo
+      do k=1,nz ; do I=Isq,Ieq ; if (do_i(I)) CS%h_u(I,j,k) = hvel(I,k) + h_neglect ; enddo ; enddo
     endif
 
     ! Diagnose total Kv at u-points
@@ -989,13 +989,13 @@ subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, US, CS, OBC)
       do k=1,nz ; do i=is,ie ; if (do_i_shelf(i)) then
         ! Should we instead take the inverse of the average of the inverses?
         CS%h_v(i,J,k) = forces%frac_shelf_v(i,J)  * hvel_shelf(i,k) + &
-                   (1.0-forces%frac_shelf_v(i,J)) * hvel(i,k)
+                   (1.0-forces%frac_shelf_v(i,J)) * hvel(i,k) + h_neglect
       elseif (do_i(i)) then
-        CS%h_v(i,J,k) = hvel(i,k)
+        CS%h_v(i,J,k) = hvel(i,k) + h_neglect
       endif ; enddo ; enddo
     else
       do K=1,nz+1 ; do i=is,ie ; if (do_i(i)) CS%a_v(i,J,K) = a_cpl(i,K) ; enddo ; enddo
-      do k=1,nz ; do i=is,ie ; if (do_i(i)) CS%h_v(i,J,k) = hvel(i,k) ; enddo ; enddo
+      do k=1,nz ; do i=is,ie ; if (do_i(i)) CS%h_v(i,J,k) = hvel(i,k) + h_neglect ; enddo ; enddo
     endif
 
     ! Diagnose total Kv at v-points

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -108,6 +108,7 @@ logical function neutral_diffusion_init(Time, G, param_file, diag, EOS, CS)
   ! Local variables
   character(len=256) :: mesg    ! Message for error messages.
   character(len=80)  :: string  ! Temporary strings
+  logical :: answers_2018, default_2018_answers
   logical :: boundary_extrap
 
   if (associated(CS)) then
@@ -144,7 +145,7 @@ logical function neutral_diffusion_init(Time, G, param_file, diag, EOS, CS)
                  "pressure is used.", &
                  default = -1.)
   ! Initialize and configure remapping
-  if (CS%continuous_reconstruction .eqv. .false.) then
+  if ( .not.CS%continuous_reconstruction ) then
     call get_param(param_file, mdl, "NDIFF_BOUNDARY_EXTRAP", boundary_extrap, &
                    "Extrapolate at the top and bottommost cells, otherwise   \n"//  &
                    "assume boundaries are piecewise constant",                      &
@@ -154,7 +155,15 @@ logical function neutral_diffusion_init(Time, G, param_file, diag, EOS, CS)
                    "for vertical remapping for all variables. "//&
                    "It can be one of the following schemes: "//&
                    trim(remappingSchemesDoc), default=remappingDefaultScheme)
-    call initialize_remapping( CS%remap_CS, string, boundary_extrapolation = boundary_extrap )
+    call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
+                 "This sets the default value for the various _2018_ANSWERS parameters.", &
+                 default=.true.)
+    call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
+                 "If true, use the order of arithmetic and expressions that recover the "//&
+                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
+                 "forms of the same expressions.", default=default_2018_answers)
+    call initialize_remapping( CS%remap_CS, string, boundary_extrapolation=boundary_extrap, &
+                               answers_2018=answers_2018 )
     call extract_member_remapping_CS(CS%remap_CS, degree=CS%deg)
     call get_param(param_file, mdl, "NEUTRAL_POS_METHOD", CS%neutral_pos_method,   &
                    "Method used to find the neutral position                 \n"// &


### PR DESCRIPTION
  This PR includes code that greatly improves the stability of the regridding
code, especially when layers are very thin and makes similar changes to accommodate
tiny layers to several other modules.  A separate large value of hNeglect_edge is no
longer needed when these changes are activated.  By default, all answers are
bitwise identical in the MOM6-examples test suite, but there are new entries in
the MOM_parameter_doc files.  The commits in this PR include:

- NOAA-GFDL/MOM6@fb73225 Merge branch 'dev/gfdl' into remapping_refactor
- NOAA-GFDL/MOM6@4265603 +Added REGULARIZE_LAYERS_2018_ANSWERS
- NOAA-GFDL/MOM6@e0554d4 (*)Safer edge value estimates for very thin layers
- NOAA-GFDL/MOM6@bc2191d Add h_neglect to h_u for vertical viscosity
- NOAA-GFDL/MOM6@60d9e7f +(*)Set h_neglect_edge to GV%H_subroundoff
- NOAA-GFDL/MOM6@730de2b +Set REMAPPING_2018_ANSWERS in 6 modules
- NOAA-GFDL/MOM6@c58fb9b (*)Modified MOM_remapping to use new regridding
- NOAA-GFDL/MOM6@f96534f +(*)Reformulated regridding code