### PR TITLE
* Fixed sign error in thickness diffuse work

### DIFF
--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1235,7 +1235,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
           drdiB = drho_dT_u(I) * (T(i+1,j,1)-T(i,j,1)) + &
                   drho_dS_u(I) * (S(i+1,j,1)-S(i,j,1))
         endif
-        Work_u(I,j) = Work_u(I,j) + G_scale * &
+        Work_u(I,j) = Work_u(I,j) - G_scale * &
             ( (uhD(I,j,1) * drdiB) * 0.25 * &
               ((e(i,j,1) + e(i,j,2)) + (e(i+1,j,1) + e(i+1,j,2))) )
 


### PR DESCRIPTION
This patch fixes a bug in the sign of the tendency of the work by
thickness diffusion in the top layer along the u-points.

This resolves a variance in model runs after a 90-degree rotation, and
results are now consistent with the work_v calculation.

This patch will change answers for any runs using work-based thickness
diffusion.