### PR TITLE
Replaced intent(out) with intent(inout) in EOS

### DIFF
--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -136,14 +136,14 @@ contains
 !> Calls the appropriate subroutine to calculate density of sea water for scalar inputs.
 !! If rho_ref is present, the anomaly with respect to rho_ref is returned.
 subroutine calculate_density_scalar(T, S, pressure, rho, EOS, rho_ref, scale)
-  real,           intent(in)  :: T !< Potential temperature referenced to the surface [degC]
-  real,           intent(in)  :: S !< Salinity [ppt]
+  real,           intent(in)  :: T        !< Potential temperature referenced to the surface [degC]
+  real,           intent(in)  :: S        !< Salinity [ppt]
   real,           intent(in)  :: pressure !< Pressure [Pa]
-  real,           intent(out) :: rho !< Density (in-situ if pressure is local) [kg m-3] or [R ~> kg m-3]
-  type(EOS_type), pointer     :: EOS !< Equation of state structure
+  real,           intent(out) :: rho      !< Density (in-situ if pressure is local) [kg m-3] or [R ~> kg m-3]
+  type(EOS_type), pointer     :: EOS      !< Equation of state structure
   real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
-  real, optional, intent(in)  :: scale !< A multiplicative factor by which to scale density
-                                       !! from kg m-3 to the desired units [R m3 kg-1]
+  real, optional, intent(in)  :: scale    !< A multiplicative factor by which to scale density
+                                          !! from kg m-3 to the desired units [R m3 kg-1]
 
   if (.not.associated(EOS)) call MOM_error(FATAL, &
     "calculate_density_scalar called with an unassociated EOS_type EOS.")
@@ -174,16 +174,16 @@ end subroutine calculate_density_scalar
 !> Calls the appropriate subroutine to calculate the density of sea water for 1-D array inputs.
 !! If rho_ref is present, the anomaly with respect to rho_ref is returned.
 subroutine calculate_density_array(T, S, pressure, rho, start, npts, EOS, rho_ref, scale)
-  real, dimension(:), intent(in)  :: T !< Potential temperature referenced to the surface [degC]
-  real, dimension(:), intent(in)  :: S !< Salinity [ppt]
-  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
-  real, dimension(:), intent(out) :: rho !< Density (in-situ if pressure is local) [kg m-3] or [R ~> kg m-3]
-  integer,            intent(in)  :: start !< Start index for computation
-  integer,            intent(in)  :: npts !< Number of point to compute
-  type(EOS_type),     pointer     :: EOS !< Equation of state structure
-  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
-  real,     optional, intent(in)  :: scale !< A multiplicative factor by which to scale density
-                                           !! from kg m-3 to the desired units [R m3 kg-1]
+  real, dimension(:), intent(in)    :: T        !< Potential temperature referenced to the surface [degC]
+  real, dimension(:), intent(in)    :: S        !< Salinity [ppt]
+  real, dimension(:), intent(in)    :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(inout) :: rho      !< Density (in-situ if pressure is local) [kg m-3] or [R ~> kg m-3]
+  integer,            intent(in)    :: start    !< Start index for computation
+  integer,            intent(in)    :: npts     !< Number of point to compute
+  type(EOS_type),     pointer       :: EOS      !< Equation of state structure
+  real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3].
+  real,     optional, intent(in)    :: scale    !< A multiplicative factor by which to scale density
+                                                !! from kg m-3 to the desired units [R m3 kg-1]
   integer :: j
 
   if (.not.associated(EOS)) call MOM_error(FATAL, &
@@ -215,14 +215,14 @@ end subroutine calculate_density_array
 !> Calls the appropriate subroutine to calculate specific volume of sea water
 !! for scalar inputs.
 subroutine calculate_spec_vol_scalar(T, S, pressure, specvol, EOS, spv_ref, scale)
-  real,           intent(in)  :: T !< Potential temperature referenced to the surface [degC]
-  real,           intent(in)  :: S !< Salinity [ppt]
+  real,           intent(in)  :: T        !< Potential temperature referenced to the surface [degC]
+  real,           intent(in)  :: S        !< Salinity [ppt]
   real,           intent(in)  :: pressure !< Pressure [Pa]
   real,           intent(out) :: specvol  !< In situ? specific volume [m3 kg-1] or [R-1 ~> m3 kg-1]
   type(EOS_type), pointer     :: EOS      !< Equation of state structure
   real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
-  real, optional, intent(in)  :: scale    !< A multiplicative factor by which to scale specific volume
-                                          !! from m3 kg-1 to the desired units [kg m-3 R-1]
+  real, optional, intent(in)  :: scale    !< A multiplicative factor by which to scale specific
+                                          !! volume from m3 kg-1 to the desired units [kg m-3 R-1]
 
   real :: rho
 
@@ -261,17 +261,16 @@ end subroutine calculate_spec_vol_scalar
 !> Calls the appropriate subroutine to calculate the specific volume of sea water
 !! for 1-D array inputs.
 subroutine calculate_spec_vol_array(T, S, pressure, specvol, start, npts, EOS, spv_ref, scale)
-  real, dimension(:), intent(in)  :: T        !< potential temperature relative to the surface
-                                              !! [degC].
-  real, dimension(:), intent(in)  :: S        !< salinity [ppt].
-  real, dimension(:), intent(in)  :: pressure !< pressure [Pa].
-  real, dimension(:), intent(out) :: specvol  !< in situ specific volume [kg m-3] or [R-1 ~> m3 kg-1].
-  integer,            intent(in)  :: start    !< the starting point in the arrays.
-  integer,            intent(in)  :: npts     !< the number of values to calculate.
-  type(EOS_type),     pointer     :: EOS      !< Equation of state structure
-  real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
-  real,     optional, intent(in)  :: scale    !< A multiplicative factor by which to scale specific volume
-                                              !! from m3 kg-1 to the desired units [kg m-3 R-1]
+  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the surface [degC].
+  real, dimension(:), intent(in)    :: S        !< salinity [ppt].
+  real, dimension(:), intent(in)    :: pressure !< pressure [Pa].
+  real, dimension(:), intent(inout) :: specvol  !< in situ specific volume [kg m-3] or [R-1 ~> m3 kg-1].
+  integer,            intent(in)    :: start    !< the starting point in the arrays.
+  integer,            intent(in)    :: npts     !< the number of values to calculate.
+  type(EOS_type),     pointer       :: EOS      !< Equation of state structure
+  real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1].
+  real,     optional, intent(in)    :: scale    !< A multiplicative factor by which to scale specific volume
+                                                !! from m3 kg-1 to the desired units [kg m-3 R-1]
 
   real, dimension(size(specvol)) :: rho
   integer :: j
@@ -336,13 +335,13 @@ end subroutine calculate_TFreeze_scalar
 
 !> Calls the appropriate subroutine to calculate the freezing point for a 1-D array.
 subroutine calculate_TFreeze_array(S, pressure, T_fr, start, npts, EOS)
-  real, dimension(:), intent(in)  :: S !< Salinity [ppt]
-  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
-  real, dimension(:), intent(out) :: T_fr !< Freezing point potential temperature referenced
-                                          !! to the surface [degC]
-  integer,            intent(in)  :: start !< Starting index within the array
-  integer,            intent(in)  :: npts !< The number of values to calculate
-  type(EOS_type),     pointer     :: EOS !< Equation of state structure
+  real, dimension(:), intent(in)    :: S        !< Salinity [ppt]
+  real, dimension(:), intent(in)    :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(inout) :: T_fr     !< Freezing point potential temperature referenced
+                                                !! to the surface [degC]
+  integer,            intent(in)    :: start    !< Starting index within the array
+  integer,            intent(in)    :: npts     !< The number of values to calculate
+  type(EOS_type),     pointer       :: EOS      !< Equation of state structure
 
   if (.not.associated(EOS)) call MOM_error(FATAL, &
     "calculate_TFreeze_scalar called with an unassociated EOS_type EOS.")
@@ -364,18 +363,18 @@ end subroutine calculate_TFreeze_array
 
 !> Calls the appropriate subroutine to calculate density derivatives for 1-D array inputs.
 subroutine calculate_density_derivs_array(T, S, pressure, drho_dT, drho_dS, start, npts, EOS, scale)
-  real, dimension(:), intent(in)  :: T !< Potential temperature referenced to the surface [degC]
-  real, dimension(:), intent(in)  :: S !< Salinity [ppt]
-  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
-  real, dimension(:), intent(out) :: drho_dT !< The partial derivative of density with potential
-                                             !! temperature [kg m-3 degC-1] or [R degC-1 ~> kg m-3 degC-1].
-  real, dimension(:), intent(out) :: drho_dS !< The partial derivative of density with salinity,
-                                             !! in [kg m-3 ppt-1] or [R degC-1 ~> kg m-3 ppt-1].
-  integer,            intent(in)  :: start !< Starting index within the array
-  integer,            intent(in)  :: npts !< The number of values to calculate
-  type(EOS_type),     pointer     :: EOS !< Equation of state structure
-  real,     optional, intent(in)  :: scale !< A multiplicative factor by which to scale density
-                                           !! from kg m-3 to the desired units [R m3 kg-1]
+  real, dimension(:), intent(in)    :: T        !< Potential temperature referenced to the surface [degC]
+  real, dimension(:), intent(in)    :: S        !< Salinity [ppt]
+  real, dimension(:), intent(in)    :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(inout) :: drho_dT  !< The partial derivative of density with potential
+                                                !! temperature [kg m-3 degC-1] or [R degC-1 ~> kg m-3 degC-1].
+  real, dimension(:), intent(inout) :: drho_dS  !< The partial derivative of density with salinity,
+                                                !! in [kg m-3 ppt-1] or [R degC-1 ~> kg m-3 ppt-1].
+  integer,            intent(in)    :: start    !< Starting index within the array
+  integer,            intent(in)    :: npts     !< The number of values to calculate
+  type(EOS_type),     pointer       :: EOS      !< Equation of state structure
+  real,     optional, intent(in)    :: scale    !< A multiplicative factor by which to scale density
+                                                !! from kg m-3 to the desired units [R m3 kg-1]
   integer :: j
 
   if (.not.associated(EOS)) call MOM_error(FATAL, &
@@ -448,16 +447,16 @@ subroutine calculate_density_second_derivs_array(T, S, pressure, drho_dS_dS, drh
   real, dimension(:), intent(in)  :: T !< Potential temperature referenced to the surface [degC]
   real, dimension(:), intent(in)  :: S !< Salinity [ppt]
   real, dimension(:), intent(in)  :: pressure   !< Pressure [Pa]
-  real, dimension(:), intent(out) :: drho_dS_dS !< Partial derivative of beta with respect to S
-                                                !!  [kg m-3 ppt-2] or [R ppt-2 ~> kg m-3 ppt-2]
-  real, dimension(:), intent(out) :: drho_dS_dT !< Partial derivative of beta with respect to T
-                                                !! [kg m-3 ppt-1 degC-1] or [R ppt-1 degC-1 ~> kg m-3 ppt-1 degC-1]
-  real, dimension(:), intent(out) :: drho_dT_dT !< Partial derivative of alpha with respect to T
-                                                !! [kg m-3 degC-2] or [R degC-2 ~> kg m-3 degC-2]
-  real, dimension(:), intent(out) :: drho_dS_dP !< Partial derivative of beta with respect to pressure
-                                                !! [kg m-3 ppt-1 Pa-1] or [R ppt-1 Pa-1 ~> kg m-3 ppt-1 Pa-1]
-  real, dimension(:), intent(out) :: drho_dT_dP !< Partial derivative of alpha with respect to pressure
-                                                !! [kg m-3 degC-1 Pa-1] or [R degC-1 Pa-1 ~> kg m-3 degC-1 Pa-1]
+  real, dimension(:), intent(inout) :: drho_dS_dS !< Partial derivative of beta with respect to S
+                                                  !!  [kg m-3 ppt-2] or [R ppt-2 ~> kg m-3 ppt-2]
+  real, dimension(:), intent(inout) :: drho_dS_dT !< Partial derivative of beta with respect to T
+                                                  !! [kg m-3 ppt-1 degC-1] or [R ppt-1 degC-1 ~> kg m-3 ppt-1 degC-1]
+  real, dimension(:), intent(inout) :: drho_dT_dT !< Partial derivative of alpha with respect to T
+                                                  !! [kg m-3 degC-2] or [R degC-2 ~> kg m-3 degC-2]
+  real, dimension(:), intent(inout) :: drho_dS_dP !< Partial derivative of beta with respect to pressure
+                                                  !! [kg m-3 ppt-1 Pa-1] or [R ppt-1 Pa-1 ~> kg m-3 ppt-1 Pa-1]
+  real, dimension(:), intent(inout) :: drho_dT_dP !< Partial derivative of alpha with respect to pressure
+                                                  !! [kg m-3 degC-1 Pa-1] or [R degC-1 Pa-1 ~> kg m-3 degC-1 Pa-1]
   integer,            intent(in)  :: start !< Starting index within the array
   integer,            intent(in)  :: npts !< The number of values to calculate
   type(EOS_type),     pointer     :: EOS !< Equation of state structure
@@ -546,10 +545,10 @@ subroutine calculate_specific_vol_derivs(T, S, pressure, dSV_dT, dSV_dS, start, 
   real, dimension(:), intent(in)  :: T !< Potential temperature referenced to the surface [degC]
   real, dimension(:), intent(in)  :: S !< Salinity [ppt]
   real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
-  real, dimension(:), intent(out) :: dSV_dT !< The partial derivative of specific volume with potential
-                                            !! temperature [m3 kg-1 degC-1] or [R-1 degC-1 ~> m3 kg-1 degC-1]
-  real, dimension(:), intent(out) :: dSV_dS !< The partial derivative of specific volume with salinity
-                                            !! [m3 kg-1 ppt-1] or [R-1 ppt-1 ~> m3 kg-1 ppt-1].
+  real, dimension(:), intent(inout) :: dSV_dT !< The partial derivative of specific volume with potential
+                                              !! temperature [m3 kg-1 degC-1] or [R-1 degC-1 ~> m3 kg-1 degC-1]
+  real, dimension(:), intent(inout) :: dSV_dS !< The partial derivative of specific volume with salinity
+                                              !! [m3 kg-1 ppt-1] or [R-1 ppt-1 ~> m3 kg-1 ppt-1].
   integer,            intent(in)  :: start  !< Starting index within the array
   integer,            intent(in)  :: npts   !< The number of values to calculate
   type(EOS_type),     pointer     :: EOS    !< Equation of state structure
@@ -603,9 +602,9 @@ subroutine calculate_compress_array(T, S, pressure, rho, drho_dp, start, npts, E
   real, dimension(:), intent(in)  :: T        !< Potential temperature referenced to the surface [degC]
   real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
   real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
-  real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3].
-  real, dimension(:), intent(out) :: drho_dp   !< The partial derivative of density with pressure
-                                     !! (also the inverse of the square of sound speed) [s2 m-2].
+  real, dimension(:), intent(inout) :: rho      !< In situ density [kg m-3].
+  real, dimension(:), intent(inout) :: drho_dp  !< The partial derivative of density with pressure
+                                                !! (also the inverse of the square of sound speed) [s2 m-2].
   integer,            intent(in)  :: start    !< Starting index within the array
   integer,            intent(in)  :: npts     !< The number of values to calculate
   type(EOS_type),     pointer     :: EOS      !< Equation of state structure
@@ -677,18 +676,18 @@ subroutine int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
                             !! alpha_ref, but this reduces the effects of roundoff.
   type(EOS_type),       pointer     :: EOS !< Equation of state structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-                        intent(out) :: dza !< The change in the geopotential anomaly across
+                        intent(inout) :: dza !< The change in the geopotential anomaly across
                             !! the layer [m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-              optional, intent(out) :: intp_dza !< The integral in pressure through the layer of the
+              optional, intent(inout) :: intp_dza !< The integral in pressure through the layer of the
                             !! geopotential anomaly relative to the anomaly at the bottom of the
                             !! layer [Pa m2 s-2].
   real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), &
-              optional, intent(out) :: intx_dza !< The integral in x of the difference between the
+              optional, intent(inout) :: intx_dza !< The integral in x of the difference between the
                             !! geopotential anomaly at the top and bottom of the layer divided by
                             !! the x grid spacing [m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), &
-              optional, intent(out) :: inty_dza !< The integral in y of the difference between the
+              optional, intent(inout) :: inty_dza !< The integral in y of the difference between the
                             !! geopotential anomaly at the top and bottom of the layer divided by
                             !! the y grid spacing [m2 s-2].
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate dza.
@@ -747,17 +746,17 @@ subroutine int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HII, HIO, EOS, &
   real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration [m2 Z-1 s-2 ~> m s-2].
   type(EOS_type),       pointer     :: EOS !< Equation of state structure
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-                        intent(out) :: dpa !< The change in the pressure anomaly across the layer [Pa].
+                        intent(inout) :: dpa !< The change in the pressure anomaly across the layer [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intz_dpa !< The integral through the thickness of the layer of
+              optional, intent(inout) :: intz_dpa !< The integral through the thickness of the layer of
                                            !! the pressure anomaly relative to the anomaly at the
                                            !! top of the layer [Pa Z ~> Pa m].
   real, dimension(HIO%IsdB:HIO%IedB,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intx_dpa !< The integral in x of the difference between the
+              optional, intent(inout) :: intx_dpa !< The integral in x of the difference between the
                                            !! pressure anomaly at the top and bottom of the layer
                                            !! divided by the x grid spacing [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%JsdB:HIO%JedB), &
-              optional, intent(out) :: inty_dpa !< The integral in y of the difference between the
+              optional, intent(inout) :: inty_dpa !< The integral in y of the difference between the
                                            !! pressure anomaly at the top and bottom of the layer
                                            !! divided by the y grid spacing [Pa].
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
@@ -1000,18 +999,18 @@ subroutine int_density_dz_generic(T, S, z_t, z_b, rho_ref, rho_0, G_e, HII, HIO,
   real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration [m2 Z-1 s-2 ~> m s-2].
   type(EOS_type),       pointer     :: EOS !< Equation of state structure
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-                        intent(out) :: dpa !< The change in the pressure anomaly
+                        intent(inout) :: dpa !< The change in the pressure anomaly
                                           !! across the layer [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intz_dpa !< The integral through the thickness of the
+              optional, intent(inout) :: intz_dpa !< The integral through the thickness of the
                                           !! layer of the pressure anomaly relative to the
                                           !! anomaly at the top of the layer [Pa Z ~> Pa m].
   real, dimension(HIO%IsdB:HIO%IedB,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intx_dpa !< The integral in x of the difference between
+              optional, intent(inout) :: intx_dpa !< The integral in x of the difference between
                                           !! the pressure anomaly at the top and bottom of the
                                           !! layer divided by the x grid spacing [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%JsdB:HIO%JedB), &
-              optional, intent(out) :: inty_dpa !< The integral in y of the difference between
+              optional, intent(inout) :: inty_dpa !< The integral in y of the difference between
                                           !! the pressure anomaly at the top and bottom of the
                                           !! layer divided by the y grid spacing [Pa].
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
@@ -1193,17 +1192,17 @@ subroutine int_density_dz_generic_plm (T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, &
                         intent(in)  :: bathyT !< The depth of the bathymetry [Z ~> m].
   type(EOS_type),       pointer     :: EOS !< Equation of state structure
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-                        intent(out) :: dpa !< The change in the pressure anomaly across the layer [Pa].
+                        intent(inout) :: dpa !< The change in the pressure anomaly across the layer [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intz_dpa !< The integral through the thickness of the layer of
+              optional, intent(inout) :: intz_dpa !< The integral through the thickness of the layer of
                                            !! the pressure anomaly relative to the anomaly at the
                                            !! top of the layer [Pa Z].
   real, dimension(HIO%IsdB:HIO%IedB,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intx_dpa !< The integral in x of the difference between the
+              optional, intent(inout) :: intx_dpa !< The integral in x of the difference between the
                                            !! pressure anomaly at the top and bottom of the layer
                                            !! divided by the x grid spacing [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%JsdB:HIO%JedB), &
-              optional, intent(out) :: inty_dpa !< The integral in y of the difference between the
+              optional, intent(inout) :: inty_dpa !< The integral in y of the difference between the
                                            !! pressure anomaly at the top and bottom of the layer
                                            !! divided by the y grid spacing [Pa].
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
@@ -1608,17 +1607,17 @@ subroutine int_density_dz_generic_ppm (T, T_t, T_b, S, S_t, S_b, &
   real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration [m s-2]
   type(EOS_type),       pointer     :: EOS !< Equation of state structure
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-                        intent(out) :: dpa !< The change in the pressure anomaly across the layer [Pa].
+                        intent(inout) :: dpa !< The change in the pressure anomaly across the layer [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intz_dpa !< The integral through the thickness of the layer of
+              optional, intent(inout) :: intz_dpa !< The integral through the thickness of the layer of
                                            !! the pressure anomaly relative to the anomaly at the
                                            !! top of the layer [Pa Z ~> Pa m].
   real, dimension(HIO%IsdB:HIO%IedB,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intx_dpa !< The integral in x of the difference between the
+              optional, intent(inout) :: intx_dpa !< The integral in x of the difference between the
                                            !! pressure anomaly at the top and bottom of the layer
                                            !! divided by the x grid spacing [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%JsdB:HIO%JedB), &
-              optional, intent(out) :: inty_dpa !< The integral in y of the difference between the
+              optional, intent(inout) :: inty_dpa !< The integral in y of the difference between the
                                            !! pressure anomaly at the top and bottom of the layer
                                            !! divided by the y grid spacing [Pa].
 
@@ -1916,10 +1915,10 @@ end subroutine compute_integral_quadratic
 subroutine evaluate_shape_bilinear( xi, eta, phi, dphidxi, dphideta )
   real,               intent(in)  :: xi  !< The x position to evaluate
   real,               intent(in)  :: eta !< The z position to evaluate
-  real, dimension(4), intent(out) :: phi !< The weights of the four corners at this point
-  real, dimension(4), intent(out) :: dphidxi  !< The x-gradient of the weights of the four
+  real, dimension(4), intent(inout) :: phi !< The weights of the four corners at this point
+  real, dimension(4), intent(inout) :: dphidxi  !< The x-gradient of the weights of the four
                                          !! corners at this point
-  real, dimension(4), intent(out) :: dphideta !< The z-gradient of the weights of the four
+  real, dimension(4), intent(inout) :: dphideta !< The z-gradient of the weights of the four
                                          !! corners at this point
 
   ! The shape functions within the parent element are defined as shown here:
@@ -1957,11 +1956,11 @@ subroutine evaluate_shape_quadratic ( xi, eta, phi, dphidxi, dphideta )
   ! Arguments
   real,               intent(in)  :: xi  !< The x position to evaluate
   real,               intent(in)  :: eta !< The z position to evaluate
-  real, dimension(9), intent(out) :: phi !< The weights of the 9 bilinear quadrature points
+  real, dimension(9), intent(inout) :: phi !< The weights of the 9 bilinear quadrature points
                                          !! at this point
-  real, dimension(9), intent(out) :: dphidxi  !< The x-gradient of the weights of the 9 bilinear
+  real, dimension(9), intent(inout) :: dphidxi  !< The x-gradient of the weights of the 9 bilinear
                                          !! quadrature points corners at this point
-  real, dimension(9), intent(out) :: dphideta !< The z-gradient of the weights of the 9 bilinear
+  real, dimension(9), intent(inout) :: dphideta !< The z-gradient of the weights of the 9 bilinear
                                          !! quadrature points corners at this point
 
   ! The quadratic shape functions within the parent element are defined as shown here:
@@ -2037,18 +2036,18 @@ subroutine int_spec_vol_dp_generic(T, S, p_t, p_b, alpha_ref, HI, EOS, &
                             !! alters the effects of roundoff, and answers do change.
   type(EOS_type),       pointer     :: EOS !< Equation of state structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-                        intent(out) :: dza !< The change in the geopotential anomaly
+                        intent(inout) :: dza !< The change in the geopotential anomaly
                             !! across the layer [m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-              optional, intent(out) :: intp_dza !< The integral in pressure through the
+              optional, intent(inout) :: intp_dza !< The integral in pressure through the
                             !! layer of the geopotential anomaly relative to the anomaly
                             !! at the bottom of the layer [Pa m2 s-2].
   real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), &
-              optional, intent(out) :: intx_dza  !< The integral in x of the difference
+              optional, intent(inout) :: intx_dza  !< The integral in x of the difference
                             !! between the geopotential anomaly at the top and bottom of
                             !! the layer divided by the x grid spacing [m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), &
-              optional, intent(out) :: inty_dza  !< The integral in y of the difference
+              optional, intent(inout) :: inty_dza  !< The integral in y of the difference
                             !! between the geopotential anomaly at the top and bottom of
                             !! the layer divided by the y grid spacing [m2 s-2].
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate dza.
@@ -2235,18 +2234,18 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
                         intent(in)  :: bathyP !< The pressure at the bathymetry [Pa]
   type(EOS_type),       pointer     :: EOS !< Equation of state structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-                        intent(out) :: dza !< The change in the geopotential anomaly
+                        intent(inout) :: dza !< The change in the geopotential anomaly
                             !! across the layer [m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-              optional, intent(out) :: intp_dza !< The integral in pressure through the
+              optional, intent(inout) :: intp_dza !< The integral in pressure through the
                             !! layer of the geopotential anomaly relative to the anomaly
                             !! at the bottom of the layer [Pa m2 s-2].
   real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), &
-              optional, intent(out) :: intx_dza  !< The integral in x of the difference
+              optional, intent(inout) :: intx_dza  !< The integral in x of the difference
                             !! between the geopotential anomaly at the top and bottom of
                             !! the layer divided by the x grid spacing [m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), &
-              optional, intent(out) :: inty_dza  !< The integral in y of the difference
+              optional, intent(inout) :: inty_dza  !< The integral in y of the difference
                             !! between the geopotential anomaly at the top and bottom of
                             !! the layer divided by the y grid spacing [m2 s-2].
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -108,13 +108,13 @@ end subroutine calculate_density_scalar_wright
 !! (T [degC]), and pressure [Pa].  It uses the expression from
 !! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
 subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_ref)
-  real, dimension(:), intent(in)  :: T        !< potential temperature relative to the surface [degC].
-  real, dimension(:), intent(in)  :: S        !< salinity [PSU].
-  real, dimension(:), intent(in)  :: pressure !< pressure [Pa].
-  real, dimension(:), intent(out) :: rho      !< in situ density [kg m-3].
-  integer,            intent(in)  :: start    !< the starting point in the arrays.
-  integer,            intent(in)  :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
+  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the surface [degC].
+  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
+  real, dimension(:), intent(in)    :: pressure !< pressure [Pa].
+  real, dimension(:), intent(inout) :: rho      !< in situ density [kg m-3].
+  integer,            intent(in)    :: start    !< the starting point in the arrays.
+  integer,            intent(in)    :: npts     !< the number of values to calculate.
+  real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3].
 
   ! Original coded by R. Hallberg, 7/00, anomaly coded in 3/18.
   ! Local variables
@@ -169,14 +169,14 @@ end subroutine calculate_spec_vol_scalar_wright
 !! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts, spv_ref)
-  real, dimension(:), intent(in)  :: T        !< potential temperature relative to the
+  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the
                                               !! surface [degC].
-  real, dimension(:), intent(in)  :: S        !< salinity [PSU].
-  real, dimension(:), intent(in)  :: pressure !< pressure [Pa].
-  real, dimension(:), intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
-  integer,            intent(in)  :: start    !< the starting point in the arrays.
-  integer,            intent(in)  :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
+  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
+  real, dimension(:), intent(in)    :: pressure !< pressure [Pa].
+  real, dimension(:), intent(inout) :: specvol  !< in situ specific volume [m3 kg-1].
+  integer,            intent(in)    :: start    !< the starting point in the arrays.
+  integer,            intent(in)    :: npts     !< the number of values to calculate.
+  real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1].
 
   ! Local variables
   real :: al0, p0, lambda
@@ -197,16 +197,16 @@ end subroutine calculate_spec_vol_array_wright
 
 !> For a given thermodynamic state, return the thermal/haline expansion coefficients
 subroutine calculate_density_derivs_array_wright(T, S, pressure, drho_dT, drho_dS, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the
-                                                 !! surface [degC].
-  real,    intent(in),  dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),  dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(out), dimension(:) :: drho_dT  !< The partial derivative of density with potential
-                                                 !! temperature [kg m-3 degC-1].
-  real,    intent(out), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
-                                                 !! in [kg m-3 PSU-1].
-  integer, intent(in)                :: start    !< The starting point in the arrays.
-  integer, intent(in)                :: npts     !< The number of values to calculate.
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the
+                                                   !! surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
+  real,    intent(inout), dimension(:) :: drho_dT  !< The partial derivative of density with potential
+                                                   !! temperature [kg m-3 degC-1].
+  real,    intent(inout), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
+                                                   !! in [kg m-3 PSU-1].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
 
   ! Local variables
   real :: al0, p0, lambda, I_denom2
@@ -259,15 +259,15 @@ subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drh
   real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
   real, dimension(:), intent(in   ) :: S !< Salinity [PSU]
   real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
-  real, dimension(:), intent(  out) :: drho_ds_ds !< Partial derivative of beta with respect
+  real, dimension(:), intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
                                                   !! to S [kg m-3 PSU-2]
-  real, dimension(:), intent(  out) :: drho_ds_dt !< Partial derivative of beta with respcct
+  real, dimension(:), intent(inout) :: drho_ds_dt !< Partial derivative of beta with respcct
                                                   !! to T [kg m-3 PSU-1 degC-1]
-  real, dimension(:), intent(  out) :: drho_dt_dt !< Partial derivative of alpha with respect
+  real, dimension(:), intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
                                                   !! to T [kg m-3 degC-2]
-  real, dimension(:), intent(  out) :: drho_ds_dp !< Partial derivative of beta with respect
+  real, dimension(:), intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
                                                   !! to pressure [kg m-3 PSU-1 Pa-1]
-  real, dimension(:), intent(  out) :: drho_dt_dp !< Partial derivative of alpha with respect
+  real, dimension(:), intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
                                                   !! to pressure [kg m-3 degC-1 Pa-1]
   integer,            intent(in   ) :: start !< Starting index in T,S,P
   integer,            intent(in   ) :: npts  !< Number of points to loop over
@@ -340,15 +340,15 @@ end subroutine calculate_density_second_derivs_scalar_wright
 !> For a given thermodynamic state, return the partial derivatives of specific volume
 !! with temperature and salinity
 subroutine calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in),  dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),  dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(out), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
-                                                 !! potential temperature [m3 kg-1 degC-1].
-  real,    intent(out), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
-                                                 !! salinity [m3 kg-1 / Pa].
-  integer, intent(in)                :: start    !< The starting point in the arrays.
-  integer, intent(in)                :: npts     !< The number of values to calculate.
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
+  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
+                                                   !! potential temperature [m3 kg-1 degC-1].
+  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
+                                                   !! salinity [m3 kg-1 / Pa].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
 
   ! Local variables
   real :: al0, p0, lambda, I_denom
@@ -377,15 +377,15 @@ end subroutine calculate_specvol_derivs_wright
 !! from Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
 !! Coded by R. Hallberg, 1/01
 subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in),  dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),  dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(out), dimension(:) :: rho      !< In situ density [kg m-3].
-  real,    intent(out), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
-                                                 !! (also the inverse of the square of sound speed)
-                                                 !! [s2 m-2].
-  integer, intent(in)                :: start    !< The starting point in the arrays.
-  integer, intent(in)                :: npts     !< The number of values to calculate.
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
+  real,    intent(inout), dimension(:) :: rho      !< In situ density [kg m-3].
+  real,    intent(inout), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
+                                                   !! (also the inverse of the square of sound speed)
+                                                   !! [s2 m-2].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
 
   ! Coded by R. Hallberg, 1/01
   ! Local variables
@@ -428,18 +428,18 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HII, HIO, 
                                                 !! equation of state.
   real,                 intent(in)  :: G_e      !< The Earth's gravitational acceleration [m2 Z-1 s-2 ~> m s-2].
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-                        intent(out) :: dpa      !< The change in the pressure anomaly across the
+                        intent(inout) :: dpa    !< The change in the pressure anomaly across the
                                                 !! layer [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intz_dpa !< The integral through the thickness of the layer
+              optional, intent(inout) :: intz_dpa !< The integral through the thickness of the layer
                                                 !! of the pressure anomaly relative to the anomaly
                                                 !! at the top of the layer [Pa Z ~> Pa m].
   real, dimension(HIO%IsdB:HIO%IedB,HIO%jsd:HIO%jed), &
-              optional, intent(out) :: intx_dpa !< The integral in x of the difference between the
+              optional, intent(inout) :: intx_dpa !< The integral in x of the difference between the
                                                 !! pressure anomaly at the top and bottom of the
                                                 !! layer divided by the x grid spacing [Pa].
   real, dimension(HIO%isd:HIO%ied,HIO%JsdB:HIO%JedB), &
-              optional, intent(out) :: inty_dpa !< The integral in y of the difference between the
+              optional, intent(inout) :: inty_dpa !< The integral in y of the difference between the
                                                 !! pressure anomaly at the top and bottom of the
                                                 !! layer divided by the y grid spacing [Pa].
   real, dimension(HII%isd:HII%ied,HII%jsd:HII%jed), &
@@ -629,18 +629,18 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
            !! mathematically identical with different values of spv_ref, but this reduces the
            !! effects of roundoff.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-                        intent(out) :: dza       !< The change in the geopotential anomaly across
+                        intent(inout) :: dza     !< The change in the geopotential anomaly across
                                                  !! the layer [m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-              optional, intent(out) :: intp_dza  !< The integral in pressure through the layer of
+              optional, intent(inout) :: intp_dza !< The integral in pressure through the layer of
                                                  !! the geopotential anomaly relative to the anomaly
                                                  !! at the bottom of the layer [Pa m2 s-2].
   real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), &
-              optional, intent(out) :: intx_dza  !< The integral in x of the difference between the
+              optional, intent(inout) :: intx_dza !< The integral in x of the difference between the
                                                  !! geopotential anomaly at the top and bottom of
                                                  !! the layer divided by the x grid spacing [m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), &
-              optional, intent(out) :: inty_dza  !< The integral in y of the difference between the
+              optional, intent(inout) :: inty_dza !< The integral in y of the difference between the
                                                  !! geopotential anomaly at the top and bottom of
                                                  !! the layer divided by the y grid spacing [m2 s-2].
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate


### PR DESCRIPTION
- For arrays using `intent(inout)` instead of `intent(out)` avoids potential copies.
- Adding the extra 2 characters meant I had to realign all the comments to pass the Hallberg filter.