### PR TITLE
OBC meridional flux flag fix

### DIFF
--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -1448,7 +1448,7 @@ subroutine merid_face_thickness(v, h, h_L, h_R, h_v, dt, G, US, LB, vol_CFL, &
 
   local_open_BC = .false.
   if (present(OBC)) then ; if (associated(OBC)) then
-    local_open_BC = OBC%open_u_BCs_exist_globally
+    local_open_BC = OBC%open_v_BCs_exist_globally
   endif ; endif
   if (local_open_BC) then
     do n = 1, OBC%number_of_segments


### PR DESCRIPTION
Inside `merid_face_thickness` of the PPM meridional mass flux calculation, the OBC contribution was incorrectly checking for the u BC flag, `OBC%open_u_BCs_exist_globally`, rather than the v-point equivalent.

This may not have previously been a serious issue, due to the prior error which was incorrectly setting similar flags across all segments rather than individual segments.

In any case, this error caused other errors in the current state of the model.  This patch corrects the flag name and resolves those errors.