### PR TITLE
Travis bionic test

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -9,17 +9,18 @@ DO_REPRO_TESTS ?= true
 
 #---
 # Dependencies
+DEPS = deps
 
 # mkmf, list_paths (GFDL build toolchain)
 MKMF_URL ?= https://github.com/NOAA-GFDL/mkmf.git
 MKMF_COMMIT ?= master
-LIST_PATHS := $(abspath build/mkmf/bin/list_paths)
-MKMF := $(abspath build/mkmf/bin/mkmf)
+LIST_PATHS := $(abspath $(DEPS)/mkmf/bin/list_paths)
+MKMF := $(abspath $(DEPS)/mkmf/bin/mkmf)
 
 # FMS framework
 FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
 FMS_COMMIT ?= f2e2c86f6c0eb6d389a20509a8a60fa22924e16b
-FMS := build/fms
+FMS := $(DEPS)/fms
 
 #---
 # Build configuration
@@ -85,7 +86,7 @@ SOURCE = \
 MOM_SOURCE = $(call SOURCE,../src) $(wildcard ../config_src/solo_driver/*.F90)
 TARGET_SOURCE = $(call SOURCE,build/target_codebase/src) \
   $(wildcard build/target_codebase/config_src/solo_driver/*.F90)
-FMS_SOURCE = $(call SOURCE,build/fms/src)
+FMS_SOURCE = $(call SOURCE,$(DEPS)/fms/src)
 
 #---
 # Rules
@@ -117,9 +118,9 @@ build/%/Makefile: build/%/path_names
 	cp $(MKMF_TEMPLATE) $(@D)
 	cd $(@D) && $(MKMF) \
 		-t $(notdir $(MKMF_TEMPLATE)) \
-		-o '-I ../fms/build' \
+		-o '-I ../../$(DEPS)/fms/build' \
 		-p MOM6 \
-		-l '../fms/lib/libfms.a' \
+		-l '../../$(DEPS)/fms/lib/libfms.a' \
 		-c $(MKMF_CPP) \
 		path_names
 
@@ -173,8 +174,8 @@ $(FMS)/src:
 # Build Toolchain
 
 $(LIST_PATHS) $(MKMF):
-	git clone $(MKMF_URL) build/mkmf
-	cd build/mkmf; git checkout $(MKMF_COMMIT)
+	git clone $(MKMF_URL) $(DEPS)/mkmf
+	cd $(DEPS)/mkmf; git checkout $(MKMF_COMMIT)
 
 
 #----

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -102,11 +102,11 @@ BUILD_TARGETS = MOM6 Makefile path_names
 # Conditionally build symmetric with coverage support
 COVFLAG=$(if $(REPORT_COVERAGE),COVERAGE=1,)
 
-build/target/MOM6: MOMFLAGS=NETCDF=3 DEBUG=1
-build/symmetric/MOM6: MOMFLAGS=NETCDF=3 DEBUG=1 $(COVFLAG)
-build/asymmetric/MOM6: MOMFLAGS=NETCDF=3 DEBUG=1
+build/target/MOM6: MOMFLAGS=NETCDF=3 DEBUG=1 INIT=1
+build/symmetric/MOM6: MOMFLAGS=NETCDF=3 DEBUG=1 INIT=1 $(COVFLAG)
+build/asymmetric/MOM6: MOMFLAGS=NETCDF=3 DEBUG=1 INIT=1
 build/repro/MOM6: MOMFLAGS=NETCDF=3 REPRO=1
-build/openmp/MOM6: MOMFLAGS=NETCDF=3 DEBUG=1 OPENMP=1
+build/openmp/MOM6: MOMFLAGS=NETCDF=3 DEBUG=1 OPENMP=1 INIT=1
 
 build/asymmetric/path_names: GRID_SRC=config_src/dynamic
 build/%/path_names: GRID_SRC=config_src/dynamic_symmetric

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -19,7 +19,7 @@ MKMF := $(abspath $(DEPS)/mkmf/bin/mkmf)
 
 # FMS framework
 FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
-FMS_COMMIT ?= f2e2c86f6c0eb6d389a20509a8a60fa22924e16b
+FMS_COMMIT ?= 2019.01.01
 FMS := $(DEPS)/fms
 
 #---

--- a/.testing/linux-ubuntu-xenial-gnu.mk
+++ b/.testing/linux-ubuntu-xenial-gnu.mk
@@ -24,7 +24,7 @@ LD = mpif90 $(MAIN_PROGRAM)
 DEBUG =              # If non-blank, perform a debug build (Cannot be
                      # mixed with REPRO or TEST)
 
-REPRO =              # If non-blank, erform a build that guarentees
+REPRO =              # If non-blank, perform a build that guarentees
                      # reprodicuibilty from run to run.  Cannot be used
                      # with DEBUG or TEST
 
@@ -53,6 +53,8 @@ SSE =                # The SSE options to be used to compile.  If blank,
                      # Current default is to use SSE2.
 
 COVERAGE =           # Add the code coverage compile options.
+
+INIT =               # Enable aggressive initialization
 
 # Need to use at least GNU Make version 3.81
 need := 3.81
@@ -89,6 +91,10 @@ FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-l
 FFLAGS_OPT = -O3
 FFLAGS_REPRO = -O2 -fbounds-check
 FFLAGS_DEBUG = -O0 -g -W -Wno-compare-reals -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow
+# Enable aggressive initialization
+ifdef INIT
+FFLAGS_DEBUG += -finit-real=snan -finit-integer=2147483647 -finit-derived
+endif
 
 # Flags to add additional build options
 FFLAGS_OPENMP = -fopenmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 # This is a not a c-language project but we use the same environment.
 language: c
-dist: xenial
+dist: bionic
 
 # --depth flag is breaking our merge, try disabling it
 # NOTE: We may be able to go back to depth=50 in production


### PR DESCRIPTION
This PR includes four major changes:
* The FMS and mkmf builds are moved into a local `deps` directory due to a clash of Makefile pattern rules.
* Update of FMS to the 2019.01.01 release, which includes a few fixes enabling the changes below.
* Travis environment is upgraded to bionic, in order to get a newer GCC compiler
* Aggressive initialization flags have been turned on, which set all stack reals to SNaN, and integers (and, since we use GCC, logicals) to 2^31 - 1.  Upgrades to FMS and GCC were required to support these flags.

This will enforce stricter initialization rules in the source code, and may expose issues on other branches on a later `dev/master` merge.
