### PR TITLE
+Corrected doc_param_time

### DIFF
--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -1556,8 +1556,7 @@ subroutine log_param_time(CS, modulename, varname, value, desc, units, &
         call doc_param(CS%doc, varname, desc, myunits, real_time)
       endif
     else
-      myunits='not defined'; if (present(units)) write(myunits(1:240),'(A)') trim(units)
-      call doc_param(CS%doc, varname, desc, myunits, value, default)
+      call doc_param(CS%doc, varname, desc, value, default, units=units)
     endif
   endif
 


### PR DESCRIPTION
  Rewrote the subroutine doc_param_time to work like the other doc_param
routines, including making the units argument optional, removing the argument
layout_param, and adding the new internally visible routine time_string.
Because time variables are currently logged as real values using the timeunit
argument to log_param_time, these changes do not have a widespread impact.  All
answers are bitwise identical, but there are some limited interface changes.