### PR TITLE
MOM6: +Miscellaneous code cleanup

### DIFF
--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -32,8 +32,6 @@ type, public :: PressureForce_Mont_CS ; private
   logical :: tides          !< If true, apply tidal momentum forcing.
   real    :: Rho0           !< The density used in the Boussinesq
                             !! approximation [kg m-3].
-  real    :: Rho_atm        !< The assumed atmospheric density [kg m-3].
-                            !! By default, Rho_atm is 0.
   real    :: GFS_scale      !< Ratio between gravity applied to top interface and the
                             !! gravitational acceleration of the planet [nondim].
                             !! Usually this ratio is 1.

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -204,7 +204,7 @@ type, public :: vertvisc_type
   real, pointer, dimension(:,:) :: TKE_BBL => NULL()
                              !< A term related to the bottom boundary layer source of turbulent kinetic
                              !! energy, currently in [Z3 T-3 ~> m3 s-3], but may at some time be changed
-                             !! to [kg Z3 m-3 T-3 ~> W m-2].
+                             !! to [R Z3 T-3 ~> W m-2].
   real, pointer, dimension(:,:) :: &
     taux_shelf => NULL(), &  !< The zonal stresses on the ocean under shelves [R Z L T-2 ~> Pa].
     tauy_shelf => NULL()     !< The meridional stresses on the ocean under shelves [R Z L T-2 ~> Pa].

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -29,7 +29,7 @@ type, public :: verticalGrid_type
   real :: mks_g_Earth !< The gravitational acceleration in unscaled MKS units [m s-2].
   real :: g_Earth   !< The gravitational acceleration [L2 Z-1 T-2 ~> m s-2].
   real :: Rho0      !< The density used in the Boussinesq approximation or nominal
-                    !! density used to convert depths into mass units [kg m-3].
+                    !! density used to convert depths into mass units [R ~> kg m-3].
 
   ! Vertical coordinate descriptions for diagnostics and I/O
   character(len=40) :: zAxisUnits !< The units that vertical coordinates are written in

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -386,7 +386,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, OBC, dt_
     PE_pt              ! The potential energy at each point [J].
   real, dimension(SZI_(G),SZJ_(G)) :: &
     Temp_int, Salt_int ! Layer and cell integrated heat and salt [J] and [g Salt].
-  real :: HL2_to_kg    ! A conversion factor form a thickness-volume to mass [kg H-1 L-2 ~> kg m-3 or 1]
+  real :: HL2_to_kg    ! A conversion factor from a thickness-volume to mass [kg H-1 L-2 ~> kg m-3 or 1]
   real :: KE_scale_factor   ! The combination of unit rescaling factors in the kinetic energy
                             ! calculation [kg T2 H-1 L-2 s-2 ~> kg m-3 or nondim]
   real :: PE_scale_factor   ! The combination of unit rescaling factors in the potential energy

--- a/src/ice_shelf/MOM_marine_ice.F90
+++ b/src/ice_shelf/MOM_marine_ice.F90
@@ -96,8 +96,6 @@ subroutine iceberg_forces(G, forces, use_ice_shelf, sfc_state, &
     forces%rigidity_ice_v(i,J) = forces%rigidity_ice_v(i,J) + kv_rho_ice * &
                          min(forces%mass_berg(i,j), forces%mass_berg(i,j+1))
   enddo ; enddo
-  !### This halo update may be unnecessary. Test it.  -RWH
-  call pass_vector(forces%frac_shelf_u, forces%frac_shelf_v, G%domain, TO_ALL, CGRID_NE)
 
 end subroutine iceberg_forces
 

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -131,8 +131,8 @@ subroutine set_coord_from_gprime(Rlay, g_prime, GV, US, param_file)
   type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
   ! Local variables
-  real :: g_int   ! Reduced gravities across the internal interfaces [m s-2].
-  real :: g_fs    ! Reduced gravity across the free surface [m s-2].
+  real :: g_int   ! Reduced gravities across the internal interfaces [L2 Z-1 T-2 ~> m s-2].
+  real :: g_fs    ! Reduced gravity across the free surface [L2 Z-1 T-2 ~> m s-2].
   character(len=40)  :: mdl = "set_coord_from_gprime" ! This subroutine's name.
   integer :: k, nz
   nz = GV%ke
@@ -165,9 +165,9 @@ subroutine set_coord_from_layer_density(Rlay, g_prime, GV, US, param_file)
   type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
   ! Local variables
-  real :: g_fs    ! Reduced gravity across the free surface [m s-2].
-  real :: Rlay_Ref! The surface layer's target density [kg m-3].
-  real :: RLay_range ! The range of densities [kg m-3].
+  real :: g_fs    ! Reduced gravity across the free surface [L2 Z-1 T-2 ~> m s-2].
+  real :: Rlay_Ref! The surface layer's target density [R ~> kg m-3].
+  real :: RLay_range ! The range of densities [R ~> kg m-3].
   character(len=40)  :: mdl = "set_coord_from_layer_density" ! This subroutine's name.
   integer :: k, nz
   nz = GV%ke
@@ -213,8 +213,8 @@ subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, US, param_file, eqn_of_state
   ! Local variables
   real :: T_ref   ! Reference temperature
   real :: S_ref   ! Reference salinity
-  real :: g_int   ! Reduced gravities across the internal interfaces [m s-2].
-  real :: g_fs    ! Reduced gravity across the free surface [m s-2].
+  real :: g_int   ! Reduced gravities across the internal interfaces [L2 Z-1 T-2 ~> m s-2].
+  real :: g_fs    ! Reduced gravity across the free surface [L2 Z-1 T-2 ~> m s-2].
   character(len=40)  :: mdl = "set_coord_from_TS_ref" ! This subroutine's name.
   integer :: k, nz
   nz = GV%ke
@@ -263,7 +263,7 @@ subroutine set_coord_from_TS_profile(Rlay, g_prime, GV, US, param_file, &
   real,                    intent(in)  :: P_Ref        !< The coordinate-density reference pressure [Pa].
   ! Local variables
   real, dimension(GV%ke) :: T0, S0,  Pref
-  real :: g_fs    ! Reduced gravity across the free surface [m s-2].
+  real :: g_fs    ! Reduced gravity across the free surface [L2 Z-1 T-2 ~> m s-2].
   integer :: k, nz
   character(len=40)  :: mdl = "set_coord_from_TS_profile" ! This subroutine's name.
   character(len=200) :: filename, coord_file, inputdir ! Strings for file/path
@@ -318,7 +318,7 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, US, param_file, &
                   ! of the range to that in the lighter part of the range.
                   ! Setting this greater than 1 increases the resolution for
                   ! the denser water.
-  real :: g_fs    ! Reduced gravity across the free surface [m s-2].
+  real :: g_fs    ! Reduced gravity across the free surface [L2 Z-1 T-2 ~> m s-2].
   real :: a1, frac_dense, k_frac
   integer :: k, nz, k_light
   character(len=40)  :: mdl = "set_coord_from_TS_range" ! This subroutine's name.
@@ -390,7 +390,7 @@ subroutine set_coord_from_file(Rlay, g_prime, GV, US, param_file)
   type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
   ! Local variables
-  real :: g_fs    ! Reduced gravity across the free surface [m s-2].
+  real :: g_fs    ! Reduced gravity across the free surface [L2 Z-1 T-2 ~> m s-2].
   integer :: k, nz
   character(len=40)  :: mdl = "set_coord_from_file" ! This subroutine's name.
   character(len=40)  :: coord_var
@@ -486,7 +486,7 @@ subroutine set_coord_to_none(Rlay, g_prime, GV, US, param_file)
   type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
   ! Local variables
-  real :: g_fs    ! Reduced gravity across the free surface [m s-2].
+  real :: g_fs    ! Reduced gravity across the free surface [L2 Z-1 T-2 ~> m s-2].
   character(len=40)  :: mdl = "set_coord_to_none" ! This subroutine's name.
   integer :: k, nz
   nz = GV%ke

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2009,7 +2009,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_param
   logical :: debug = .false.  ! manually set this to true for verbose output
 
   ! data arrays
-  real, dimension(:), allocatable :: z_edges_in, z_in
+  real, dimension(:), allocatable :: z_edges_in, z_in ! Interface heights [Z ~> m]
   real, dimension(:), allocatable :: Rb  ! Interface densities [R ~> kg m-3]
   real, dimension(:,:,:), allocatable, target :: temp_z, salt_z, mask_z
   real, dimension(:,:,:), allocatable :: rho_z ! Densities in Z-space [R ~> kg m-3]
@@ -2326,9 +2326,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_param
     do k=2,nz ; Rb(k) = 0.5*(GV%Rlay(k-1)+GV%Rlay(k)) ; enddo
     Rb(1) = 0.0 ;  Rb(nz+1) = 2.0*GV%Rlay(nz) - GV%Rlay(nz-1)
 
-    zi(is:ie,js:je,:) = find_interfaces(rho_z(is:ie,js:je,:), z_in, Rb, G%bathyT(is:ie,js:je), &
-                                        nlevs(is:ie,js:je), nkml, nkbl, min_depth, eps_z=eps_z, &
-                                        eps_rho=eps_rho)
+    call find_interfaces(rho_z, z_in, kd, Rb, G%bathyT, zi, G, US, &
+                         nlevs, nkml, nkbl, min_depth, eps_z=eps_z, eps_rho=eps_rho)
 
     if (correct_thickness) then
       call adjustEtaToFitBathymetry(G, GV, US, zi, h)
@@ -2399,7 +2398,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_param
 
   if (adjust_temperature .and. .not. useALEremapping) then
     call determine_temperature(tv%T(is:ie,js:je,:), tv%S(is:ie,js:je,:), &
-            US%R_to_kg_m3*GV%Rlay(1:nz), tv%p_ref, niter, missing_value, h(is:ie,js:je,:), ks, eos)
+            GV%Rlay(1:nz), tv%p_ref, niter, missing_value, h(is:ie,js:je,:), ks, US, eos)
 
   endif
 

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -349,7 +349,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
     endif
     call cpu_clock_begin(id_clock_kappaShear)
     if (CS%Vertex_shear) then
-      call full_convection(G, GV, h, tv, T_adj, S_adj, fluxes%p_surf, &
+      call full_convection(G, GV, US, h, tv, T_adj, S_adj, fluxes%p_surf, &
                            (GV%Z_to_H**2)*kappa_dt_fill, halo=1)
 
       call calc_kappa_shear_vertex(u, v, h, T_adj, S_adj, tv, fluxes%p_surf, visc%Kd_shear, &
@@ -567,7 +567,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   endif
 
   if (CS%user_change_diff) then
-    call user_change_diff(h, tv, G, GV, CS%user_change_diff_CSp, Kd_lay, Kd_int, &
+    call user_change_diff(h, tv, G, GV, US, CS%user_change_diff_CSp, Kd_lay, Kd_int, &
                           T_f, S_f, dd%Kd_user)
   endif
 

--- a/src/user/BFB_surface_forcing.F90
+++ b/src/user/BFB_surface_forcing.F90
@@ -98,7 +98,7 @@ subroutine BFB_buoyancy_forcing(state, fluxes, day, dt, G, US, CS)
     ! Set whichever fluxes are to be used here.  Any fluxes that
     ! are always zero do not need to be changed here.
     do j=js,je ; do i=is,ie
-      ! Fluxes of fresh water through the surface are in units of [kg m-2 s-1]
+      ! Fluxes of fresh water through the surface are in units of [R Z T-1 ~> kg m-2 s-1]
       ! and are positive downward - i.e. evaporation should be negative.
       fluxes%evap(i,j) = -0.0 * G%mask2dT(i,j)
       fluxes%lprec(i,j) = 0.0 * G%mask2dT(i,j)
@@ -151,7 +151,7 @@ subroutine BFB_buoyancy_forcing(state, fluxes, day, dt, G, US, CS)
       Temp_restore = 0.0
       do j=js,je ; do i=is,ie
        !   Set density_restore to an expression for the surface potential
-       ! density [kg m-3] that is being restored toward.
+       ! density [R ~> kg m-3] that is being restored toward.
         if (G%geoLatT(i,j) < CS%lfrslat) then
             Temp_restore = CS%SST_s
         elseif (G%geoLatT(i,j) > CS%lfrnlat) then

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -365,7 +365,6 @@ subroutine DOME2d_initialize_sponges(G, GV, US, tv, param_file, use_ALE, CSp, AC
   ! Local variables
   real :: T(SZI_(G),SZJ_(G),SZK_(G))   ! A temporary array for temp [degC]
   real :: S(SZI_(G),SZJ_(G),SZK_(G))   ! A temporary array for salt [ppt]
-  real :: RHO(SZI_(G),SZJ_(G),SZK_(G)) ! A temporary array for RHO [kg m-3]
   real :: h(SZI_(G),SZJ_(G),SZK_(G))   ! A temporary array for thickness [H ~> m or kg m-2].
   real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! A temporary array for thickness [Z ~> m]
   real :: Idamp(SZI_(G),SZJ_(G))       ! The inverse damping rate [T-1 ~> s-1].

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -351,13 +351,11 @@ end subroutine Phillips_initialize_topography
 !!  The one argument passed to initialize, Time, is set to the
 !!  current time of the simulation.  The fields which are initialized
 !!  here are:
-!!    u - Zonal velocity [m s-1].
-!!    v - Meridional velocity [m s-1].
-!!    h - Layer thickness in m.  (Must be positive.)
-!!    D - Basin depth in m.  (Must be positive.)
-!!    f - The Coriolis parameter [s-1].
-!!    g - The reduced gravity at each interface [m s-2]
-!!    Rlay - Layer potential density (coordinate variable) [kg m-3].
+!!    u - Zonal velocity [L T-1 ~> m s-1].
+!!    v - Meridional velocity [L T-1 ~> m s-1].
+!!    h - Layer thickness [H ~> m or kg m-2] (must be positive)
+!!    D - Basin depth [Z ~> m] (positive downward)
+!!    f - The Coriolis parameter [T-1 ~> s-1].
 !!  If ENABLE_THERMODYNAMICS is defined:
 !!    T - Temperature [degC].
 !!    S - Salinity [ppt].

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -232,7 +232,7 @@ subroutine benchmark_init_temperature_salinity(T, S, G, GV, US, param_file, &
                                                       !! only read parameters without changing h.
   ! Local variables
   real :: T0(SZK_(G)), S0(SZK_(G))
-  real :: pres(SZK_(G))      ! Reference pressure [kg m-3].
+  real :: pres(SZK_(G))      ! Reference pressure [Pa].
   real :: drho_dT(SZK_(G))   ! Derivative of density with temperature [R degC-1 ~> kg m-3 degC-1].
   real :: drho_dS(SZK_(G))   ! Derivative of density with salinity [R ppt-1 ~> kg m-3 ppt-1].
   real :: rho_guess(SZK_(G)) ! Potential density at T0 & S0 [R ~> kg m-3].

--- a/src/user/dumbbell_surface_forcing.F90
+++ b/src/user/dumbbell_surface_forcing.F90
@@ -63,9 +63,6 @@ subroutine dumbbell_buoyancy_forcing(state, fluxes, day, dt, G, US, CS)
   ! Local variables
   real :: Temp_restore   ! The temperature that is being restored toward [degC].
   real :: Salin_restore  ! The salinity that is being restored toward [ppt].
-  real :: density_restore  ! The potential density that is being restored
-                         ! toward [kg m-3].
-  real :: rhoXcp ! The mean density times the heat capacity [J m-3 degC-1].
   integer :: i, j, is, ie, js, je
   integer :: isd, ied, jsd, jed
 
@@ -97,7 +94,7 @@ subroutine dumbbell_buoyancy_forcing(state, fluxes, day, dt, G, US, CS)
     ! Set whichever fluxes are to be used here.  Any fluxes that
     ! are always zero do not need to be changed here.
     do j=js,je ; do i=is,ie
-      ! Fluxes of fresh water through the surface are in units of [kg m-2 s-1]
+      ! Fluxes of fresh water through the surface are in units of [R Z T-1 ~> kg m-2 s-1]
       ! and are positive downward - i.e. evaporation should be negative.
       fluxes%evap(i,j) = -0.0 * G%mask2dT(i,j)
       fluxes%lprec(i,j) = 0.0 * G%mask2dT(i,j)
@@ -121,8 +118,6 @@ subroutine dumbbell_buoyancy_forcing(state, fluxes, day, dt, G, US, CS)
 
   if (CS%use_temperature .and. CS%restorebuoy) then
     do j=js,je ; do i=is,ie
-      !   Set density_restore to an expression for the surface potential
-      ! density [kg m-3] that is being restored toward.
       if (CS%forcing_mask(i,j)>0.) then
         fluxes%vprec(i,j) = - (G%mask2dT(i,j) * (CS%Rho0*CS%Flux_const)) * &
                 ((CS%S_restore(i,j) - state%SSS(i,j)) /  (0.5 * (CS%S_restore(i,j) + state%SSS(i,j))))

--- a/src/user/user_change_diffusivity.F90
+++ b/src/user/user_change_diffusivity.F90
@@ -31,7 +31,7 @@ type, public :: user_change_diff_CS ; private
                         !! a diffusivity scaled by Kd_add is added [degLat].
   real :: rho_range(4)  !< 4 values that define the coordinate potential
                         !! density range over which a diffusivity scaled by
-                        !! Kd_add is added [kg m-3].
+                        !! Kd_add is added [R ~> kg m-3].
   logical :: use_abs_lat  !< If true, use the absolute value of latitude when
                           !! setting lat_range.
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
@@ -44,13 +44,14 @@ contains
 !! main code to alter the diffusivities as needed.  The specific example
 !! implemented here augments the diffusivity for a specified range of latitude
 !! and coordinate potential density.
-subroutine user_change_diff(h, tv, G, GV, CS, Kd_lay, Kd_int, T_f, S_f, Kd_int_add)
+subroutine user_change_diff(h, tv, G, GV, US, CS, Kd_lay, Kd_int, T_f, S_f, Kd_int_add)
   type(ocean_grid_type),                    intent(in)    :: G   !< The ocean's grid structure.
   type(verticalGrid_type),                  intent(in)    :: GV  !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
   type(thermo_var_ptrs),                    intent(in)    :: tv  !< A structure containing pointers
                                                                  !! to any available thermodynamic
                                                                  !! fields. Absent fields have NULL ptrs.
+  type(unit_scale_type),                    intent(in)    :: US  !< A dimensional unit scaling type
   type(user_change_diff_CS),                pointer       :: CS  !< This module's control structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   optional, intent(inout) :: Kd_lay !< The diapycnal diffusivity of
                                                                   !! each layer [Z2 T-1 ~> m2 s-1].
@@ -64,7 +65,7 @@ subroutine user_change_diff(h, tv, G, GV, CS, Kd_lay, Kd_int, T_f, S_f, Kd_int_a
                                                                   !! diffusivity that is being added at
                                                                   !! each interface [Z2 T-1 ~> m2 s-1].
   ! Local variables
-  real :: Rcv(SZI_(G),SZK_(G)) ! The coordinate density in layers [kg m-3].
+  real :: Rcv(SZI_(G),SZK_(G)) ! The coordinate density in layers [R ~> kg m-3].
   real :: p_ref(SZI_(G))       ! An array of tv%P_Ref pressures.
   real :: rho_fn      ! The density dependence of the input function, 0-1 [nondim].
   real :: lat_fn      ! The latitude dependence of the input function, 0-1 [nondim].
@@ -106,13 +107,13 @@ subroutine user_change_diff(h, tv, G, GV, CS, Kd_lay, Kd_int, T_f, S_f, Kd_int_a
   do j=js,je
     if (present(T_f) .and. present(S_f)) then
       do k=1,nz
-        call calculate_density(T_f(:,j,k),S_f(:,j,k),p_ref,Rcv(:,k),&
-                               is,ie-is+1,tv%eqn_of_state)
+        call calculate_density(T_f(:,j,k), S_f(:,j,k), p_ref, Rcv(:,k),&
+                               is, ie-is+1, tv%eqn_of_state, scale=US%kg_m3_to_R)
       enddo
     else
       do k=1,nz
-        call calculate_density(tv%T(:,j,k),tv%S(:,j,k),p_ref,Rcv(:,k),&
-                               is,ie-is+1,tv%eqn_of_state)
+        call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p_ref, Rcv(:,k),&
+                               is, ie-is+1, tv%eqn_of_state, scale=US%kg_m3_to_R)
       enddo
     endif
 
@@ -135,7 +136,6 @@ subroutine user_change_diff(h, tv, G, GV, CS, Kd_lay, Kd_int, T_f, S_f, Kd_int_a
         else
           lat_fn = val_weights(G%geoLatT(i,j), CS%lat_range)
         endif
-        !   rho_int = 0.5*(Rcv(i,k-1) + Rcv(i,k))
         rho_fn = val_weights( 0.5*(Rcv(i,k-1) + Rcv(i,k)), CS%rho_range)
         if (rho_fn * lat_fn > 0.0) then
           Kd_int(i,j,K) = Kd_int(i,j,K) + CS%Kd_add * rho_fn * lat_fn
@@ -163,9 +163,9 @@ end function range_OK
 !! hit 0 and 1.  The values in range must be in ascending order, as can be
 !! checked by calling range_OK.
 function val_weights(val, range) result(ans)
-  real,               intent(in) :: val    !< Value for which we need an answer.
-  real, dimension(4), intent(in) :: range  !< Range over which the answer is non-zero.
-  real                           :: ans    !< Return value.
+  real,               intent(in) :: val    !< Value for which we need an answer [arbitrary units].
+  real, dimension(4), intent(in) :: range  !< Range over which the answer is non-zero [arbitrary units].
+  real                           :: ans    !< Return value [nondim].
   ! Local variables
   real :: x   ! A nondimensional number between 0 and 1.
 
@@ -238,7 +238,7 @@ subroutine user_change_diff_init(Time, G, GV, US, param_file, diag, CS)
                  "is applied.  The four values specify the density at "//&
                  "which the extra diffusivity starts to increase from 0, "//&
                  "hits its full value, starts to decrease again, and is "//&
-                 "back to 0.", units="kg m-3", default=-1.0e9)
+                 "back to 0.", units="kg m-3", default=-1.0e9, scale=US%kg_m3_to_R)
     call get_param(param_file, mdl, "USER_KD_ADD_USE_ABS_LAT", CS%use_abs_lat, &
                  "If true, use the absolute value of latitude when "//&
                  "checking whether a point fits into range of latitudes.", &

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -242,10 +242,10 @@ end subroutine write_user_log
 !!
 !!  This subroutine initializes the fields for the simulations.
 !!  The one argument passed to initialize, Time, is set to the
-!!  current time of the simulation.  The fields which are initialized
+!!  current time of the simulation.  The fields which might be initialized
 !!  here are:
-!!  - u - Zonal velocity [m s-1].
-!!  - v - Meridional velocity [m s-1].
+!!  - u - Zonal velocity [Z T-1 ~> m s-1].
+!!  - v - Meridional velocity [Z T-1 ~> m s-1].
 !!  - h - Layer thickness [H ~> m or kg m-2].  (Must be positive.)
 !!  - G%bathyT - Basin depth [Z ~> m].  (Must be positive.)
 !!  - G%CoriolisBu - The Coriolis parameter [T-1 ~> s-1].
@@ -255,7 +255,7 @@ end subroutine write_user_log
 !!  - T - Temperature [degC].
 !!  - S - Salinity [psu].
 !!  If BULKMIXEDLAYER is defined:
-!!  - Rml - Mixed layer and buffer layer potential densities [kg m-3].
+!!  - Rml - Mixed layer and buffer layer potential densities [R ~> kg m-3].
 !!  If SPONGE is defined:
 !!  - A series of subroutine calls are made to set up the damping
 !!    rates and reference profiles for all variables that are damped


### PR DESCRIPTION
  This PR includes a number of minor changes to clean up the MOM6 code, 
including corrections to comments, removing an unnecessary halo update
rescaling of internal diagnostic calculations, and refactoring of the 
find_interfaces code to avoid lots of unnecessary copies and to match the code
style used elsewhere in the MOM6 code.  There are no changes to solutions,   
diagnostics, or output files.  The commits in this PR include:

- NOAA-GFDL/MOM6@7a7488f Removed an unneeded halo update
- NOAA-GFDL/MOM6@5b76e07 +Converted find_interfaces from a function to a subroutine
- NOAA-GFDL/MOM6@43ba3bc +Rescaled density derivatives in full_convection
- NOAA-GFDL/MOM6@2c2cf56 Rescaled diagnostic calculations
- NOAA-GFDL/MOM6@6760d1e Corrected documented units in comments
