### PR TITLE
MOM6: +(*)Refactor MOM_ice_shelf code

### DIFF
--- a/config_src/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/ice_solo_driver/ice_shelf_driver.F90
@@ -50,7 +50,7 @@ program SHELF_main
   use MOM_write_cputime, only : write_cputime_start_clock, write_cputime_CS
 
   use MOM_ice_shelf, only : initialize_ice_shelf, ice_shelf_end, ice_shelf_CS
-  use MOM_ice_shelf, only : ice_shelf_save_restart, solo_time_step
+  use MOM_ice_shelf, only : ice_shelf_save_restart, solo_step_ice_shelf
 ! , add_shelf_flux_forcing, add_shelf_flux_IOB
   implicit none
 
@@ -330,7 +330,7 @@ program SHELF_main
 
     ! This call steps the model over a time time_step.
     Time1 = Master_Time ; Time = Master_Time
-    call solo_time_step (ice_shelf_CSp, time_step, m, Time)
+    call solo_step_ice_shelf(ice_shelf_CSp, Time_step_shelf, m, Time)
 
 !    Time = Time + Time_step_ocean
 !  This is here to enable fractional-second time steps.

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -149,7 +149,7 @@ type, public :: forcing
                                  !! associated if ice shelves are enabled, and are
                                  !! exactly 0 away from shelves or on land.
   real, pointer, dimension(:,:) :: iceshelf_melt => NULL() !< Ice shelf melt rate (positive)
-                                 !! or freezing (negative) [Z year-1 ~> m year-1]
+                                 !! or freezing (negative) [R Z T-1 ~> kg m-2 s-1]
 
   ! Scalars set by surface forcing modules
   real :: vPrecGlobalAdj = 0.     !< adjustment to restoring vprec to zero out global net [kg m-2 s-1]

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -149,7 +149,7 @@ type, public :: forcing
                                  !! associated if ice shelves are enabled, and are
                                  !! exactly 0 away from shelves or on land.
   real, pointer, dimension(:,:) :: iceshelf_melt => NULL() !< Ice shelf melt rate (positive)
-                                 !! or freezing (negative) [m year-1]
+                                 !! or freezing (negative) [Z year-1 ~> m year-1]
 
   ! Scalars set by surface forcing modules
   real :: vPrecGlobalAdj = 0.     !< adjustment to restoring vprec to zero out global net [kg m-2 s-1]

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -665,7 +665,8 @@ subroutine shelf_calc_flux(state, fluxes, Time, time_step, CS, forces)
 
     ! advect the ice shelf, and advance the front. Calving will be in here somewhere as well..
     ! when we decide on how to do it
-    call update_ice_shelf(CS%dCS, ISS, G, US, time_step, Time, state%ocean_mass, coupled_GL)
+    call update_ice_shelf(CS%dCS, ISS, G, US, time_step, Time, &
+                          US%kg_m3_to_R*US%m_to_Z*state%ocean_mass(:,:), coupled_GL)
 
   endif
 

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -1310,7 +1310,7 @@ subroutine ice_shelf_advect_thickness_x(CS, G, LB, time_step, hmask, h0, h_after
                           intent(inout) :: h_after_uflux !< The ice shelf thicknesses after
                                               !! the zonal mass fluxes [Z ~> m].
   real, dimension(SZDIB_(G),SZDJ_(G)), &
-                          intent(inout) :: uh_ice ! The accumulated zonal ice volume flux [Z L2 ~> m3]
+                          intent(inout) :: uh_ice !< The accumulated zonal ice volume flux [Z L2 ~> m3]
 
   ! use will be made of ISS%hmask here - its value at the boundary will be zero, just like uncovered cells
   ! if there is an input bdry condition, the thickness there will be set in initialization
@@ -1393,7 +1393,7 @@ subroutine ice_shelf_advect_thickness_y(CS, G, LB, time_step, hmask, h0, h_after
                           intent(inout) :: h_after_vflux !< The ice shelf thicknesses after
                                               !! the meridional mass fluxes [Z ~> m].
   real, dimension(SZDI_(G),SZDJB_(G)), &
-                          intent(inout) :: vh_ice ! The accumulated meridional ice volume flux [Z L2 ~> m3]
+                          intent(inout) :: vh_ice !< The accumulated meridional ice volume flux [Z L2 ~> m3]
 
   ! use will be made of ISS%hmask here - its value at the boundary will be zero, just like uncovered cells
   ! if there is an input bdry condition, the thickness there will be set in initialization
@@ -1467,9 +1467,9 @@ subroutine shelf_advance_front(CS, ISS, G, hmask, uh_ice, vh_ice)
                           intent(inout) :: hmask !< A mask indicating which tracer points are
                                               !! partly or fully covered by an ice-shelf
   real, dimension(SZDIB_(G),SZDJ_(G)), &
-                          intent(inout) :: uh_ice ! The accumulated zonal ice volume flux [Z L2 ~> m3]
+                          intent(inout) :: uh_ice !< The accumulated zonal ice volume flux [Z L2 ~> m3]
   real, dimension(SZDI_(G),SZDJB_(G)), &
-                          intent(inout) :: vh_ice ! The accumulated meridional ice volume flux [Z L2 ~> m3]
+                          intent(inout) :: vh_ice !< The accumulated meridional ice volume flux [Z L2 ~> m3]
 
   ! in this subroutine we go through the computational cells only and, if they are empty or partial cells,
   ! we find the reference thickness and update the shelf mass and partial area fraction and the hmask if necessary

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -709,10 +709,10 @@ subroutine ice_shelf_advect(CS, ISS, G, time_step, Time)
   ! ###Perhaps flux_enter should be changed into u-face and v-face
   ! ###fluxes, which can then be used in halo updates, etc.
   !
-  !   from left neighbor:   flux_enter(:,:,1)
-  !   from right neighbor:  flux_enter(:,:,2)
-  !   from bottom neighbor: flux_enter(:,:,3)
-  !   from top neighbor:    flux_enter(:,:,4)
+  !   from eastern neighbor:  flux_enter(:,:,1)
+  !   from western neighbor:  flux_enter(:,:,2)
+  !   from southern neighbor: flux_enter(:,:,3)
+  !   from northern neighbor: flux_enter(:,:,4)
   !
   !  THESE ARE NOT CONSISTENT ==> FIND OUT WHAT YOU IMPLEMENTED
 
@@ -1329,10 +1329,10 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
 
   ! flux_enter(isd:ied,jsd:jed,1:4): if cell is not ice-covered, gives flux of ice into cell from kth boundary
   !
-  !   from left neighbor:   flux_enter(:,:,1)
-  !   from right neighbor:  flux_enter(:,:,2)
-  !   from bottom neighbor: flux_enter(:,:,3)
-  !   from top neighbor:    flux_enter(:,:,4)
+  !   from eastern neighbor:  flux_enter(:,:,1)
+  !   from western neighbor:  flux_enter(:,:,2)
+  !   from southern neighbor: flux_enter(:,:,3)
+  !   from northern neighbor: flux_enter(:,:,4)
   !
   !        o--- (4) ---o
   !        |           |
@@ -1433,11 +1433,11 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
 
             ! NEXT DO RIGHT FACE
 
-            ! get u-velocity at center of right face
+            ! get u-velocity at center of east face
 
-            if (CS%u_face_mask(I+1,j) == 4.) then
+            if (CS%u_face_mask(I,j) == 4.) then
 
-              flux_diff = flux_diff + G%dyCu(I,j) * time_step * CS%u_flux_bdry_val(I+1,j) / G%areaT(i,j)
+              flux_diff = flux_diff + G%dyCu(I,j) * time_step * CS%u_flux_bdry_val(I,j) / G%areaT(i,j)
 
             else
 
@@ -1502,8 +1502,8 @@ subroutine ice_shelf_advect_thickness_x(CS, G, time_step, hmask, h0, h_after_ufl
             if (at_east_bdry .AND. (hmask(i+1,j) == 3)) then
               u_face = 0.5 * (CS%u_shelf(I,J-1) + CS%u_shelf(I,J))
               flux_enter(i,j,2) = ABS(u_face) * G%dyCu(I,j) * time_step * CS%thickness_bdry_val(i+1,j)
-            elseif (CS%u_face_mask(I+1,j) == 4.) then
-              flux_enter(i,j,2) = G%dyCu(I,j) * time_step * CS%u_flux_bdry_val(I+1,j)
+            elseif (CS%u_face_mask(I,j) == 4.) then
+              flux_enter(i,j,2) = G%dyCu(I,j) * time_step * CS%u_flux_bdry_val(I,j)
             endif
 
             if ((i == is) .AND. (hmask(i,j) == 0) .AND. (hmask(i-1,j) == 1)) then
@@ -1556,10 +1556,10 @@ subroutine ice_shelf_advect_thickness_y(CS, G, time_step, hmask, h_after_uflux, 
 
   ! flux_enter(isd:ied,jsd:jed,1:4): if cell is not ice-covered, gives flux of ice into cell from kth boundary
   !
-  !   from left neighbor:   flux_enter(:,:,1)
-  !   from right neighbor:  flux_enter(:,:,2)
-  !   from bottom neighbor: flux_enter(:,:,3)
-  !   from top neighbor:    flux_enter(:,:,4)
+  !   from eastern neighbor:  flux_enter(:,:,1)
+  !   from western neighbor:  flux_enter(:,:,2)
+  !   from southern neighbor: flux_enter(:,:,3)
+  !   from northern neighbor: flux_enter(:,:,4)
   !
   !        o--- (4) ---o
   !        |           |
@@ -1661,9 +1661,9 @@ subroutine ice_shelf_advect_thickness_y(CS, G, time_step, hmask, h_after_uflux, 
 
             ! NEXT DO north FACE
 
-            if (CS%v_face_mask(i,J+1) == 4.) then
+            if (CS%v_face_mask(i,J) == 4.) then
 
-              flux_diff = flux_diff + G%dxCv(i,J) * time_step * CS%v_flux_bdry_val(i,J+1) / G%areaT(i,j)
+              flux_diff = flux_diff + G%dxCv(i,J) * time_step * CS%v_flux_bdry_val(i,J) / G%areaT(i,j)
 
             else
 
@@ -1718,8 +1718,8 @@ subroutine ice_shelf_advect_thickness_y(CS, G, time_step, hmask, h_after_uflux, 
             if (at_north_bdry .AND. (hmask(i,j+1) == 3)) then
               v_face = 0.5 * (CS%u_shelf(I-1,J) + CS%u_shelf(I,J))
               flux_enter(i,j,4) = ABS(v_face) * G%dxCv(i,J) * time_step * CS%thickness_bdry_val(i,j+1)
-            elseif (CS%v_face_mask(i,J+1) == 4.) then
-              flux_enter(i,j,4) = G%dxCv(i,J) * time_step * CS%v_flux_bdry_val(i,J+1)
+            elseif (CS%v_face_mask(i,J) == 4.) then
+              flux_enter(i,j,4) = G%dxCv(i,J) * time_step * CS%v_flux_bdry_val(i,J)
             endif
 
             if ((j == js) .AND. (hmask(i,j) == 0) .AND. (hmask(i,j-1) == 1)) then
@@ -1766,10 +1766,10 @@ subroutine shelf_advance_front(CS, ISS, G, flux_enter)
 
   ! flux_enter(isd:ied,jsd:jed,1:4): if cell is not ice-covered, gives flux of ice into cell from kth boundary
   !
-  !   from left neighbor:   flux_enter(:,:,1)
-  !   from right neighbor:  flux_enter(:,:,2)
-  !   from bottom neighbor: flux_enter(:,:,3)
-  !   from top neighbor:    flux_enter(:,:,4)
+  !   from eastern neighbor:  flux_enter(:,:,1)
+  !   from western neighbor:  flux_enter(:,:,2)
+  !   from southern neighbor: flux_enter(:,:,3)
+  !   from northern neighbor: flux_enter(:,:,4)
   !
   !        o--- (4) ---o
   !        |           |
@@ -2042,7 +2042,7 @@ subroutine calc_shelf_driving_stress(CS, ISS, G, US, taudx, taudy, OD)
           else
             sx = 0
           endif
-        elseif ((i+i_off) == giec) then ! at right computational bdry
+        elseif ((i+i_off) == giec) then ! at east computational bdry
           if (ISS%hmask(i-1,j) == 1) then
             sx = (S(i,j)-S(i-1,j))/dxh
           else
@@ -2140,7 +2140,7 @@ subroutine calc_shelf_driving_stress(CS, ISS, G, US, taudx, taudy, OD)
         endif
 
         if ((CS%u_face_mask(I,j) == 2) .OR. (ISS%hmask(i+1,j) == 0) .OR. (ISS%hmask(i+1,j) == 2) ) then
-          ! right face of the cell is at a stress boundary
+          ! east face of the cell is at a stress boundary
           taudx(I,J-1) = taudx(I,J-1) + .5 * dyh * neumann_val
           taudx(I,J) = taudx(I,J) + .5 * dyh * neumann_val
         endif
@@ -3145,9 +3145,8 @@ subroutine update_velocity_masks(CS, G, hmask, umask, vmask, u_face_mask, v_face
         !endif
 
         if (i < G%ied) then
-          if ((hmask(i+1,j) == 0) &
-              .OR. (hmask(i+1,j) == 2)) then
-            !right boundary or adjacent to unfilled cell
+          if ((hmask(i+1,j) == 0) .OR. (hmask(i+1,j) == 2)) then
+            ! east boundary or adjacent to unfilled cell
             u_face_mask(I,j) = 2.
           endif
         endif
@@ -3278,10 +3277,10 @@ subroutine ice_shelf_temp(CS, ISS, G, US, time_step, melt_rate, Time)
   ! ###Perhaps flux_enter should be changed into u-face and v-face
   ! ###fluxes, which can then be used in halo updates, etc.
   !
-  !   from left neighbor:   flux_enter(:,:,1)
-  !   from right neighbor:  flux_enter(:,:,2)
-  !   from bottom neighbor: flux_enter(:,:,3)
-  !   from top neighbor:    flux_enter(:,:,4)
+  !   from eastern neighbor:  flux_enter(:,:,1)
+  !   from western neighbor:  flux_enter(:,:,2)
+  !   from southern neighbor: flux_enter(:,:,3)
+  !   from northern neighbor: flux_enter(:,:,4)
   !
   !  THESE ARE NOT CONSISTENT ==> FIND OUT WHAT YOU IMPLEMENTED
 
@@ -3411,10 +3410,10 @@ subroutine ice_shelf_advect_temp_x(CS, G, time_step, hmask, h0, h_after_uflux, f
 
   ! flux_enter(isd:ied,jsd:jed,1:4): if cell is not ice-covered, gives flux of ice into cell from kth boundary
   !
-  !   from left neighbor:   flux_enter(:,:,1)
-  !   from right neighbor:  flux_enter(:,:,2)
-  !   from bottom neighbor: flux_enter(:,:,3)
-  !   from top neighbor:    flux_enter(:,:,4)
+  !   from eastern neighbor:  flux_enter(:,:,1)
+  !   from western neighbor:  flux_enter(:,:,2)
+  !   from southern neighbor: flux_enter(:,:,3)
+  !   from northern neighbor: flux_enter(:,:,4)
   !
   !        o--- (4) ---o
   !        |           |
@@ -3517,11 +3516,11 @@ subroutine ice_shelf_advect_temp_x(CS, G, time_step, hmask, h0, h_after_uflux, f
 
             ! NEXT DO RIGHT FACE
 
-            ! get u-velocity at center of right face
+            ! get u-velocity at center of eastern face
 
-            if (CS%u_face_mask(I+1,j) == 4.) then
+            if (CS%u_face_mask(I,j) == 4.) then
 
-              flux_diff = flux_diff + G%dyCu(I,j) * time_step * CS%u_flux_bdry_val(I+1,j) *&
+              flux_diff = flux_diff + G%dyCu(I,j) * time_step * CS%u_flux_bdry_val(I,j) *&
                                CS%t_bdry_val(i+1,j) / G%areaT(i,j)
             else
 
@@ -3589,18 +3588,18 @@ subroutine ice_shelf_advect_temp_x(CS, G, time_step, hmask, h0, h_after_uflux, f
               u_face = 0.5 * (CS%u_shelf(I,J-1) + CS%u_shelf(I,J))
               flux_enter(i,j,2) = ABS(u_face) * G%dyCu(I,j) * time_step * CS%t_bdry_val(i+1,j)* &
                                   CS%thickness_bdry_val(i+1,j)
-            elseif (CS%u_face_mask(I+1,j) == 4.) then
-              flux_enter(i,j,2) = G%dyCu(I,j) * time_step * CS%u_flux_bdry_val(I+1,j) * CS%t_bdry_val(i+1,j)
+            elseif (CS%u_face_mask(I,j) == 4.) then
+              flux_enter(i,j,2) = G%dyCu(I,j) * time_step * CS%u_flux_bdry_val(I,j) * CS%t_bdry_val(i+1,j)
             endif
 
 !            if ((i == is) .AND. (hmask(i,j) == 0) .AND. (hmask(i-1,j) == 1)) then
               ! this is solely for the purposes of keeping the mask consistent while advancing
-              ! the front without having to call pass_var - if cell is empty and cell to left
+              ! the front without having to call pass_var - if cell is empty and cell to west
               ! is ice-covered then this cell will become partly covered
 !              hmask(i,j) = 2
 !            elseif ((i == ie) .AND. (hmask(i,j) == 0) .AND. (hmask(i+1,j) == 1)) then
               ! this is solely for the purposes of keeping the mask consistent while advancing
-              ! the front without having to call pass_var - if cell is empty and cell to left
+              ! the front without having to call pass_var - if cell is empty and cell to west
               ! is ice-covered then this cell will become partly covered
 !              hmask(i,j) = 2
 
@@ -3641,10 +3640,10 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
 
   ! flux_enter(isd:ied,jsd:jed,1:4): if cell is not ice-covered, gives flux of ice into cell from kth boundary
   !
-  !   from left neighbor:   flux_enter(:,:,1)
-  !   from right neighbor:  flux_enter(:,:,2)
-  !   from bottom neighbor: flux_enter(:,:,3)
-  !   from top neighbor:    flux_enter(:,:,4)
+  !   from eastern neighbor:  flux_enter(:,:,1)
+  !   from western neighbor:  flux_enter(:,:,2)
+  !   from southern neighbor: flux_enter(:,:,3)
+  !   from northern neighbor: flux_enter(:,:,4)
   !
   !        o--- (4) ---o
   !        |           |
@@ -3700,7 +3699,7 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
                                  CS%t_bdry_val(i,j-1)/ G%areaT(i,j)
             else
 
-              ! get u-velocity at center of left face
+              ! get u-velocity at center of west face
               v_face = 0.5 * (CS%v_shelf(I-1,J-1) + CS%v_shelf(I,J-1))
 
               if (v_face > 0) then !flux is into cell - we need info from h(j-2), h(j-1) if available
@@ -3744,13 +3743,13 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
 
             ! NEXT DO north FACE
 
-            if (CS%v_face_mask(i,J+1) == 4.) then
+            if (CS%v_face_mask(i,J) == 4.) then
 
-              flux_diff = flux_diff + G%dxCv(i,J) * time_step * CS%v_flux_bdry_val(i,J+1) *&
+              flux_diff = flux_diff + G%dxCv(i,J) * time_step * CS%v_flux_bdry_val(i,J) *&
                                CS%t_bdry_val(i,j+1)/ G%areaT(i,j)
             else
 
-            ! get u-velocity at center of right face
+            ! get u-velocity at center of east face
               v_face = 0.5 * (CS%v_shelf(I-1,J) + CS%v_shelf(I,J))
 
               if (v_face < 0) then !flux is into cell - we need info from h(j+2), h(j+1) if available
@@ -3803,18 +3802,18 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
               v_face = 0.5 * (CS%v_shelf(I-1,J) + CS%v_shelf(I,J))
               flux_enter(i,j,4) = ABS(v_face) * G%dxCv(i,J) * time_step * CS%t_bdry_val(i,j+1)* &
                                    CS%thickness_bdry_val(i,j+1)
-            elseif (CS%v_face_mask(i,J+1) == 4.) then
-              flux_enter(i,j,4) = G%dxCv(i,J) * time_step * CS%v_flux_bdry_val(i,J+1)*CS%t_bdry_val(i,j+1)
+            elseif (CS%v_face_mask(i,J) == 4.) then
+              flux_enter(i,j,4) = G%dxCv(i,J) * time_step * CS%v_flux_bdry_val(i,J)*CS%t_bdry_val(i,j+1)
             endif
 
 !            if ((j == js) .AND. (hmask(i,j) == 0) .AND. (hmask(i,j-1) == 1)) then
                ! this is solely for the purposes of keeping the mask consistent while advancing
-               ! the front without having to call pass_var - if cell is empty and cell to left
+               ! the front without having to call pass_var - if cell is empty and cell to west
                ! is ice-covered then this cell will become partly covered
  !             hmask(i,j) = 2
  !           elseif ((j == je) .AND. (hmask(i,j) == 0) .AND. (hmask(i,j+1) == 1)) then
                 ! this is solely for the purposes of keeping the mask consistent while advancing the
-                ! front without having to call pass_var - if cell is empty and cell to left is
+                ! front without having to call pass_var - if cell is empty and cell to west is
                 ! ice-covered then this cell will become partly covered
 !              hmask(i,j) = 2
 !            endif

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -1969,7 +1969,7 @@ subroutine shelf_advance_front(CS, ISS, G, flux_enter)
                 ISS%area_shelf_h(i,j) = dxdyh
               elseif ((partial_vol / dxdyh) < h_reference) then
                 ISS%hmask(i,j) = 2
-        !         ISS%mass_shelf(i,j) = G%US%L_to_m**2*partial_vol * rho
+        !         ISS%mass_shelf(i,j) = G%US%L_to_Z*G%US%L_to_m*partial_vol * G%US%kg_m3_to_R*rho
                 ISS%area_shelf_h(i,j) = partial_vol / h_reference
                 ISS%h_shelf(i,j) = h_reference
               else

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -247,20 +247,20 @@ end subroutine initialize_ice_thickness_channel
 !                          intent(inout) :: u_face_mask_bdry !< A boundary-type mask at C-grid u faces
 !   real, dimension(SZIB_(G),SZJ_(G)), &
 !                          intent(inout) :: u_flux_bdry_val  !< The boundary thickness flux through
-!                                                      !! C-grid u faces [L Z s-1 ~> m2 s-1].
+!                                                      !! C-grid u faces [L Z T-1 ~> m2 s-1].
 !   real, dimension(SZI_(G),SZJB_(G)), &
 !                          intent(inout) :: v_face_mask_bdry !< A boundary-type mask at C-grid v faces
 !   real, dimension(SZI_(G),SZJB_(G)), &
 !                          intent(inout) :: v_flux_bdry_val  !< The boundary thickness flux through
-!                                                      !! C-grid v faces [L Z s-1 ~> m2 s-1].
+!                                                      !! C-grid v faces [L Z T-1 ~> m2 s-1].
 !   real, dimension(SZIB_(G),SZJB_(G)), &
 !                          intent(inout) :: u_bdry_val !< The zonal ice shelf velocity at open
-!                                                      !! boundary vertices [m yr-1].
+!                                                      !! boundary vertices [L T-1 ~> m s-1].
 !   real, dimension(SZIB_(G),SZJB_(G)), &
 !                          intent(inout) :: v_bdry_val !< The meridional ice shelf velocity at open
-!                                                      !! boundary vertices [m yr-1].
+!                                                      !! boundary vertices [L T-1 ~> m s-1].
 !   real, dimension(SZDI_(G),SZDJ_(G)), &
-!                          intent(inout) :: h_bdry_val !< The ice shelf thickness at open boundaries
+!                          intent(inout) :: h_bdry_val !< The ice shelf thickness at open boundaries [Z ~> m]
 !   real, dimension(SZDI_(G),SZDJ_(G)), &
 !                          intent(inout) :: hmask !< A mask indicating which tracer points are
 !                                              !! partly or fully covered by an ice-shelf
@@ -304,20 +304,20 @@ end subroutine initialize_ice_thickness_channel
 !                          intent(inout) :: u_face_mask_bdry !< A boundary-type mask at C-grid u faces
 !   real, dimension(SZIB_(G),SZJ_(G)), &
 !                          intent(inout) :: u_flux_bdry_val  !< The boundary thickness flux through
-!                                                      !! C-grid u faces [L Z s-1 ~> m2 s-1].
+!                                                      !! C-grid u faces [L Z T-1 ~> m2 s-1].
 !   real, dimension(SZI_(G),SZJB_(G)), &
 !                          intent(inout) :: v_face_mask_bdry !< A boundary-type mask at C-grid v faces
 !   real, dimension(SZI_(G),SZJB_(G)), &
 !                          intent(inout) :: v_flux_bdry_val  !< The boundary thickness flux through
-!                                                      !! C-grid v faces [L Z s-1 ~> m2 s-1].
+!                                                      !! C-grid v faces [L Z T-1 ~> m2 s-1].
 !   real, dimension(SZIB_(G),SZJB_(G)), &
 !                          intent(inout) :: u_bdry_val !< The zonal ice shelf velocity at open
-                                                       !! boundary vertices [m yr-1].
+                                                       !! boundary vertices [L T-1 ~> m s-1].
 !   real, dimension(SZIB_(G),SZJB_(G)), &
 !                          intent(inout) :: v_bdry_val !< The meridional ice shelf velocity at open
-                                                       !! boundary vertices [m yr-1].
+                                                       !! boundary vertices [L T-1 ~> m s-1].
 !   real, dimension(SZDI_(G),SZDJ_(G)), &
-!                          intent(inout) :: h_bdry_val !< The ice shelf thickness at open boundaries
+!                          intent(inout) :: h_bdry_val !< The ice shelf thickness at open boundaries [Z ~> m]
 !   real, dimension(SZDI_(G),SZDJ_(G)), &
 !                          intent(inout) :: hmask !< A mask indicating which tracer points are
 !                                              !! partly or fully covered by an ice-shelf
@@ -327,18 +327,18 @@ end subroutine initialize_ice_thickness_channel
 
 !   character(len=40)  :: mdl = "initialize_ice_shelf_boundary_channel" ! This subroutine's name.
 !   integer :: i, j, isd, jsd, is, js, iegq, jegq, giec, gjec, gisc, gjsc, isc, jsc, iec, jec, ied, jed
-!   real    :: input_thick
-!   real    :: input_flux  ! The input ice flux per unit length [L Z t-1 ~> m2 s-1]
+!   real    :: input_thick ! The input ice shelf thickness [Z ~> m]
+!   real    :: input_flux  ! The input ice flux per unit length [L Z T-1 ~> m2 s-1]
 !   real    :: lenlat, len_stress
 
 !   call get_param(PF, mdl, "LENLAT", lenlat, fail_if_missing=.true.)
 
 !   call get_param(PF, mdl, "INPUT_FLUX_ICE_SHELF", input_flux, &
 !                  "volume flux at upstream boundary", &
-!                  units="m2 s-1", default=0., scale=US%m_to_L*US%m_to_Z)
+!                  units="m2 s-1", default=0., scale=US%m_s_to_L_T*US%m_to_Z)
 !   call get_param(PF, mdl, "INPUT_THICK_ICE_SHELF", input_thick, &
 !                  "flux thickness at upstream boundary", &
-!                  units="m", default=1000.)
+!                  units="m", default=1000., scale=US%m_to_Z)
 !   call get_param(PF, mdl, "LEN_SIDE_STRESS", len_stress, &
 !                  "maximum position of no-flow condition in along-flow direction", &
 !                  units="km", default=0.)

--- a/src/ice_shelf/MOM_ice_shelf_state.F90
+++ b/src/ice_shelf/MOM_ice_shelf_state.F90
@@ -23,9 +23,9 @@ public ice_shelf_state_end, ice_shelf_state_init
 !> Structure that describes the ice shelf state
 type, public :: ice_shelf_state
   real, pointer, dimension(:,:) :: &
-    mass_shelf => NULL(), &    !< The mass per unit area of the ice shelf or sheet [kg m-2].
+    mass_shelf => NULL(), &    !< The mass per unit area of the ice shelf or sheet [R Z ~> kg m-2].
     area_shelf_h => NULL(), &  !< The area per cell covered by the ice shelf [L2 ~> m2].
-    h_shelf => NULL(), &       !< the thickness of the shelf [m], redundant with mass but may
+    h_shelf => NULL(), &       !< the thickness of the shelf [Z ~> m], redundant with mass but may
                                !! make the code more readable
     hmask => NULL(),&          !< Mask used to indicate ice-covered or partiall-covered cells
                                !! 1: fully covered, solve for velocity here (for now all

--- a/src/ice_shelf/MOM_ice_shelf_state.F90
+++ b/src/ice_shelf/MOM_ice_shelf_state.F90
@@ -42,7 +42,7 @@ type, public :: ice_shelf_state
     salt_flux => NULL(), &     !< The downward salt flux at the ocean-ice
                                !! interface [kg m-2 s-1].
     water_flux => NULL(), &    !< The net downward liquid water flux at the
-                               !! ocean-ice interface [kg m-2 s-1].
+                               !! ocean-ice interface [R Z T-1 ~> kg m-2 s-1].
     tflux_shelf => NULL(), &   !< The UPWARD diffusive heat flux in the ice
                                !! shelf at the ice-ocean interface [W m-2].
 

--- a/src/ice_shelf/MOM_ice_shelf_state.F90
+++ b/src/ice_shelf/MOM_ice_shelf_state.F90
@@ -37,14 +37,14 @@ type, public :: ice_shelf_state
                                !! NOTE: hmask will change over time and NEEDS TO BE MAINTAINED
                                !!   otherwise the wrong nodes will be included in velocity calcs.
 
-    tflux_ocn => NULL(), &     !< The UPWARD sensible ocean heat flux at the
-                               !! ocean-ice interface [m-2].
+    tflux_ocn => NULL(), &     !< The downward sensible ocean heat flux at the
+                               !! ocean-ice interface [Q R Z T-1 ~> W m-2].
     salt_flux => NULL(), &     !< The downward salt flux at the ocean-ice
-                               !! interface [kg m-2 s-1].
+                               !! interface [kgSalt kgWater-1 R Z T-1 ~> kgSalt m-2 s-1].
     water_flux => NULL(), &    !< The net downward liquid water flux at the
                                !! ocean-ice interface [R Z T-1 ~> kg m-2 s-1].
-    tflux_shelf => NULL(), &   !< The UPWARD diffusive heat flux in the ice
-                               !! shelf at the ice-ocean interface [W m-2].
+    tflux_shelf => NULL(), &   !< The downward diffusive heat flux in the ice
+                               !! shelf at the ice-ocean interface [Q R Z T-1 ~> W m-2].
 
     tfreeze => NULL()          !< The freezing point potential temperature
                                !! an the ice-ocean interface [degC].

--- a/src/ice_shelf/MOM_ice_shelf_state.F90
+++ b/src/ice_shelf/MOM_ice_shelf_state.F90
@@ -24,7 +24,7 @@ public ice_shelf_state_end, ice_shelf_state_init
 type, public :: ice_shelf_state
   real, pointer, dimension(:,:) :: &
     mass_shelf => NULL(), &    !< The mass per unit area of the ice shelf or sheet [kg m-2].
-    area_shelf_h => NULL(), &  !< The area per cell covered by the ice shelf [m2].
+    area_shelf_h => NULL(), &  !< The area per cell covered by the ice shelf [L2 ~> m2].
     h_shelf => NULL(), &       !< the thickness of the shelf [m], redundant with mass but may
                                !! make the code more readable
     hmask => NULL(),&          !< Mask used to indicate ice-covered or partiall-covered cells

--- a/src/ice_shelf/MOM_marine_ice.F90
+++ b/src/ice_shelf/MOM_marine_ice.F90
@@ -30,7 +30,7 @@ type, public :: marine_ice_CS ; private
   real :: berg_area_threshold !< Fraction of grid cell which iceberg must occupy
                               !! so that fluxes below are set to zero. (0.5 is a
                               !! good value to use.) Not applied for negative values.
-  real :: latent_heat_fusion  !< Latent heat of fusion [J kg-1]
+  real :: latent_heat_fusion  !< Latent heat of fusion [Q ~> J kg-1]
   real :: density_iceberg     !< A typical density of icebergs [kg m-3] (for ice rigidity)
 
   type(time_type), pointer :: Time !< A pointer to the ocean model's clock.
@@ -42,8 +42,7 @@ contains
 !> add_berg_flux_to_shelf adds rigidity and ice-area coverage due to icebergs
 !! to the forces type fields, and adds ice-areal coverage and modifies various
 !! thermodynamic fluxes due to the presence of icebergs.
-subroutine iceberg_forces(G, forces, use_ice_shelf, sfc_state, &
-                                  time_step, CS)
+subroutine iceberg_forces(G, forces, use_ice_shelf, sfc_state, time_step, CS)
   type(ocean_grid_type), intent(inout) :: G       !< The ocean's grid structure
   type(mech_forcing),    intent(inout) :: forces  !< A structure with the driving mechanical forces
   type(surface),         intent(inout) :: sfc_state !< A structure containing fields that
@@ -81,18 +80,16 @@ subroutine iceberg_forces(G, forces, use_ice_shelf, sfc_state, &
   do j=js,je ; do I=is-1,ie
     if ((G%areaT(i,j) + G%areaT(i+1,j) > 0.0)) & ! .and. (G%dxdy_u(I,j) > 0.0)) &
       forces%frac_shelf_u(I,j) = forces%frac_shelf_u(I,j) + &
-          (((forces%area_berg(i,j)*G%US%L_to_m**2*G%areaT(i,j)) + &
-            (forces%area_berg(i+1,j)*G%US%L_to_m**2*G%areaT(i+1,j))) / &
-           (G%US%L_to_m**2*G%areaT(i,j) + G%US%L_to_m**2*G%areaT(i+1,j)) )
+           (forces%area_berg(i,j)*G%areaT(i,j) + forces%area_berg(i+1,j)*G%areaT(i+1,j)) / &
+           (G%areaT(i,j) + G%areaT(i+1,j))
     forces%rigidity_ice_u(I,j) = forces%rigidity_ice_u(I,j) + kv_rho_ice * &
                          min(forces%mass_berg(i,j), forces%mass_berg(i+1,j))
   enddo ; enddo
   do J=js-1,je ; do i=is,ie
     if ((G%areaT(i,j) + G%areaT(i,j+1) > 0.0)) & ! .and. (G%dxdy_v(i,J) > 0.0)) &
       forces%frac_shelf_v(i,J) = forces%frac_shelf_v(i,J) + &
-          (((forces%area_berg(i,j)*G%US%L_to_m**2*G%areaT(i,j)) + &
-            (forces%area_berg(i,j+1)*G%US%L_to_m**2*G%areaT(i,j+1))) / &
-           (G%US%L_to_m**2*G%areaT(i,j) + G%US%L_to_m**2*G%areaT(i,j+1)) )
+           (forces%area_berg(i,j)*G%areaT(i,j) + forces%area_berg(i,j+1)*G%areaT(i,j+1)) / &
+           (G%areaT(i,j) + G%areaT(i,j+1))
     forces%rigidity_ice_v(i,J) = forces%rigidity_ice_v(i,J) + kv_rho_ice * &
                          min(forces%mass_berg(i,j), forces%mass_berg(i,j+1))
   enddo ; enddo
@@ -101,8 +98,7 @@ end subroutine iceberg_forces
 
 !> iceberg_fluxes adds ice-area-coverage and modifies various
 !! thermodynamic fluxes due to the presence of icebergs.
-subroutine iceberg_fluxes(G, US, fluxes, use_ice_shelf, sfc_state, &
-                          time_step, CS)
+subroutine iceberg_fluxes(G, US, fluxes, use_ice_shelf, sfc_state, time_step, CS)
   type(ocean_grid_type), intent(inout) :: G       !< The ocean's grid structure
   type(unit_scale_type), intent(in)    :: US      !< A dimensional unit scaling type
   type(forcing),         intent(inout) :: fluxes  !< A structure with pointers to themodynamic,
@@ -114,7 +110,8 @@ subroutine iceberg_fluxes(G, US, fluxes, use_ice_shelf, sfc_state, &
   type(marine_ice_CS),   pointer       :: CS !< Pointer to the control structure for MOM_marine_ice
 
   real :: fraz      ! refreezing rate [R Z T-1 ~> kg m-2 s-1]
-  real :: I_dt_LHF  ! The inverse of the timestep times the latent heat of fusion [kg J-1 T-1 ~> kg J-1 s-1].
+  real :: I_dt_LHF  ! The inverse of the timestep times the latent heat of fusion times unit conversion
+                    ! factors because sfc_state is in MKS units [R Z m2 J-1 T-1 ~> kg J-1 s-1].
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; jsd = G%jsd ; ied = G%ied ; jed = G%jed
@@ -142,7 +139,7 @@ subroutine iceberg_fluxes(G, US, fluxes, use_ice_shelf, sfc_state, &
 
   !Zero'ing out other fluxes under the tabular icebergs
   if (CS%berg_area_threshold >= 0.) then
-    I_dt_LHF = 1.0 / (US%s_to_T*time_step * CS%latent_heat_fusion)
+    I_dt_LHF = US%W_m2_to_QRZ_T / (time_step * CS%latent_heat_fusion)
     do j=jsd,jed ; do i=isd,ied
       if (fluxes%frac_shelf_h(i,j) > CS%berg_area_threshold) then
         ! Only applying for ice shelf covering most of cell.
@@ -157,7 +154,7 @@ subroutine iceberg_fluxes(G, US, fluxes, use_ice_shelf, sfc_state, &
         ! control structure for diagnostic purposes.
 
         if (allocated(sfc_state%frazil)) then
-          fraz = US%kg_m3_to_R*US%m_to_Z*sfc_state%frazil(i,j) * I_dt_LHF
+          fraz = sfc_state%frazil(i,j) * I_dt_LHF
           if (associated(fluxes%evap))  fluxes%evap(i,j)  = fluxes%evap(i,j)  - fraz
         ! if (associated(fluxes%lprec)) fluxes%lprec(i,j) = fluxes%lprec(i,j) - fraz
           sfc_state%frazil(i,j) = 0.0
@@ -193,11 +190,11 @@ subroutine marine_ice_init(Time, G, param_file, diag, CS)
   call log_version(mdl, version)
 
   call get_param(param_file, mdl, "KV_ICEBERG",  CS%kv_iceberg, &
-                 "The viscosity of the icebergs",  units="m2 s-1",default=1.0e10)
+                 "The viscosity of the icebergs",  units="m2 s-1", default=1.0e10)
   call get_param(param_file, mdl, "DENSITY_ICEBERGS",  CS%density_iceberg, &
                  "A typical density of icebergs.", units="kg m-3", default=917.0)
   call get_param(param_file, mdl, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
-                 "The latent heat of fusion.", units="J/kg", default=hlf)
+                 "The latent heat of fusion.", units="J/kg", default=hlf, scale=G%US%J_kg_to_Q)
   call get_param(param_file, mdl, "BERG_AREA_THRESHOLD", CS%berg_area_threshold, &
                  "Fraction of grid cell which iceberg must occupy, so that fluxes "//&
                  "below berg are set to zero. Not applied for negative "//&

--- a/src/ice_shelf/user_shelf_init.F90
+++ b/src/ice_shelf/user_shelf_init.F90
@@ -27,7 +27,7 @@ public USER_init_ice_thickness
 
 !> The control structure for the user_ice_shelf module
 type, public :: user_ice_shelf_CS ; private
-  real :: Rho_ocean  !< The ocean's typical density [kg m-2 Z-1].
+  real :: Rho_ocean  !< The ocean's typical density [R ~> kg m-3].
   real :: max_draft  !< The maximum ocean draft of the ice shelf [Z ~> m].
   real :: min_draft  !< The minimum ocean draft of the ice shelf [Z ~> m].
   real :: flat_shelf_width !< The range over which the shelf is min_draft thick [km].
@@ -45,7 +45,7 @@ subroutine USER_initialize_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, 
   type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
   real, dimension(SZDI_(G),SZDJ_(G)), &
                            intent(out) :: mass_shelf !< The ice shelf mass per unit area averaged
-                                                  !! over the full ocean cell [kg m-2].
+                                                  !! over the full ocean cell [R Z ~> kg m-2].
   real, dimension(SZDI_(G),SZDJ_(G)), &
                            intent(out) :: h_shelf !< The ice shelf thickness [Z ~> m].
   real, dimension(SZDI_(G),SZDJ_(G)), &
@@ -60,7 +60,6 @@ subroutine USER_initialize_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, 
                                                    !! being started from a restart file.
 
 ! This subroutine sets up the initial mass and area covered by the ice shelf.
-  real :: Rho_ocean  ! The ocean's typical density [kg m-3].
   real :: max_draft  ! The maximum ocean draft of the ice shelf [Z ~> m].
   real :: min_draft  ! The minimum ocean draft of the ice shelf [Z ~> m].
   real :: flat_shelf_width ! The range over which the shelf is min_draft thick.
@@ -81,7 +80,7 @@ subroutine USER_initialize_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, 
                  "calculate accelerations and the mass for conservation "//&
                  "properties, or with BOUSSINSEQ false to convert some "//&
                  "parameters from vertical units of m to kg m-2.", &
-                 units="kg m-3", default=1035.0, scale=US%Z_to_m)
+                 units="kg m-3", default=1035.0, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "SHELF_MAX_DRAFT", CS%max_draft, &
                  units="m", default=1.0, scale=US%m_to_Z)
   call get_param(param_file, mdl, "SHELF_MIN_DRAFT", CS%min_draft, &
@@ -126,7 +125,7 @@ subroutine USER_update_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, G, C
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   real, dimension(SZDI_(G),SZDJ_(G)), &
                            intent(inout) :: mass_shelf !< The ice shelf mass per unit area averaged
-                                                  !! over the full ocean cell [kg m-2].
+                                                  !! over the full ocean cell [R Z ~> kg m-2].
   real, dimension(SZDI_(G),SZDJ_(G)), &
                            intent(inout) :: area_shelf_h !< The area per cell covered by the ice shelf [L2 ~> m2].
   real, dimension(SZDI_(G),SZDJ_(G)), &

--- a/src/ice_shelf/user_shelf_init.F90
+++ b/src/ice_shelf/user_shelf_init.F90
@@ -49,7 +49,7 @@ subroutine USER_initialize_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, 
   real, dimension(SZDI_(G),SZDJ_(G)), &
                            intent(out) :: h_shelf !< The ice shelf thickness [Z ~> m].
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                           intent(out) :: area_shelf_h !< The area per cell covered by the ice shelf [m2].
+                           intent(out) :: area_shelf_h !< The area per cell covered by the ice shelf [L2 ~> m2].
   real, dimension(SZDI_(G),SZDJ_(G)), &
                            intent(out) :: hmask !< A mask indicating which tracer points are
                                                 !! partly or fully covered by an ice-shelf
@@ -105,7 +105,7 @@ subroutine USER_init_ice_thickness(h_shelf, area_shelf_h, hmask, G, US, param_fi
   real, dimension(SZDI_(G),SZDJ_(G)), &
                            intent(out) :: h_shelf !< The ice shelf thickness [m].
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                           intent(out) :: area_shelf_h !< The area per cell covered by the ice shelf [m2].
+                           intent(out) :: area_shelf_h !< The area per cell covered by the ice shelf [L2 ~> m2].
   real, dimension(SZDI_(G),SZDJ_(G)), &
                            intent(out) :: hmask !< A mask indicating which tracer points are
                                                 !! partly or fully covered by an ice-shelf
@@ -128,7 +128,7 @@ subroutine USER_update_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, G, C
                            intent(inout) :: mass_shelf !< The ice shelf mass per unit area averaged
                                                   !! over the full ocean cell [kg m-2].
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                           intent(inout) :: area_shelf_h !< The area per cell covered by the ice shelf [m2].
+                           intent(inout) :: area_shelf_h !< The area per cell covered by the ice shelf [L2 ~> m2].
   real, dimension(SZDI_(G),SZDJ_(G)), &
                            intent(inout) :: h_shelf !< The ice shelf thickness [Z ~> m].
   real, dimension(SZDI_(G),SZDJ_(G)), &
@@ -168,11 +168,11 @@ subroutine USER_update_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, G, C
         h_shelf (i,j) = 0.0
       else
         if (G%geoLonCu(i,j) > edge_pos) then
-          area_shelf_h(i,j) = G%US%L_to_m**2*G%areaT(i,j) * (edge_pos - G%geoLonCu(i-1,j)) / &
+          area_shelf_h(i,j) = G%areaT(i,j) * (edge_pos - G%geoLonCu(i-1,j)) / &
                               (G%geoLonCu(i,j) - G%geoLonCu(i-1,j))
           hmask (i,j) = 2.0
         else
-          area_shelf_h(i,j) = G%US%L_to_m**2*G%areaT(i,j)
+          area_shelf_h(i,j) = G%areaT(i,j)
           hmask (i,j) = 1.0
         endif
 

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -279,8 +279,8 @@ subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, G
   real :: b1(SZI_(G))          ! b1 and c1 are variables used by the
   real :: c1(SZI_(G),SZK_(G))  ! tridiagonal solver.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
-  real :: melt(SZI_(G),SZJ_(G)) ! melt water (positive for melting, negative for freezing) [Z year-1 ~> m year-1]
-  real :: mmax                ! The global maximum melting rate [Z year-1 ~> m year-1]
+  real :: melt(SZI_(G),SZJ_(G)) ! melt water (positive for melting, negative for freezing) [R Z T-1 ~> kg m-2 s-1]
+  real :: mmax                ! The global maximum melting rate [R Z T-1 ~> kg m-2 s-1]
   character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -276,12 +276,11 @@ subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, G
 !     h_new(k) = h_old(k) + ea(k) - eb(k-1) + eb(k) - ea(k+1)
 
   ! Local variables
-  real :: mmax
   real :: b1(SZI_(G))          ! b1 and c1 are variables used by the
   real :: c1(SZI_(G),SZK_(G))  ! tridiagonal solver.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
-  real :: melt(SZI_(G),SZJ_(G))  ! melt water (positive for melting
-                                 ! negative for freezing)
+  real :: melt(SZI_(G),SZJ_(G)) ! melt water (positive for melting, negative for freezing) [Z year-1 ~> m year-1]
+  real :: mmax                ! The global maximum melting rate [Z year-1 ~> m year-1]
   character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke


### PR DESCRIPTION
  This PR includes a set of commits that extensively revise the MOM6 ice_shelf
code to apply dimensional scaling and bring it into alignment with MOM6 code
conventions, but without any changes to answers or output files, including
those associated with the ISOMIP test case, which is not being run routinely.
The MOM_ice_shelf_dynamics.F90 code in particular has been drastically revised,
but as that code never worked (to the best of my knowledge), it should not be a
problem if the answers are changed by the correction of obvious bugs.  Some bugs
were identified in the MOM_ice_shelf.F90 code that will be corrected in a future
PR.  There are some changes to the interfaces to the ice_shelf code that cause
modest changes outside of the src/ice_shelf_directory.  There are no changes to
solutions, diagnostics, or output files.  The commits in this PR include:

- NOAA-GFDL/MOM6@5fb71b1 +Revised routines in ice_shelf_advect
- NOAA-GFDL/MOM6@6fd0edf (*)Fixed spatial index errors in ice_shelf_advect
- NOAA-GFDL/MOM6@e45326b (*)+Fix grid length use in MOM_ice_shelf_dynamics.F90
- NOAA-GFDL/MOM6@185b42e +Renamed solo_time_step to solo_step_ice_shelf
- NOAA-GFDL/MOM6@d77c803 +Rescaled velocities in MOM_ice_shelf_dynamics.F90
- NOAA-GFDL/MOM6@f3177f4 +Rescaled lengths in MOM_ice_shelf_dynamics.F90
- NOAA-GFDL/MOM6@81974e1 +Changed units of forcing%ice_shelf_melt
- NOAA-GFDL/MOM6@27bffdb +Rescaled ISS%shelf_mass to [R Z]
- NOAA-GFDL/MOM6@e1fcb3b Changed the sign of ISS%tflux_ocn and rescaled it
- NOAA-GFDL/MOM6@16a48e5 Rescaled internal MOM_ice_shelf variables units
- NOAA-GFDL/MOM6@1160c6b +Rescaled forcing%ice_shelf_melt and ice_shelf variables
- NOAA-GFDL/MOM6@c46d97c +Rescaled ISS%area_shelf_h to [L2]
