### PR TITLE
MOM6: +(*)Fix problems in the ice_shelf code

### DIFF
--- a/src/framework/MOM_spatial_means.F90
+++ b/src/framework/MOM_spatial_means.F90
@@ -56,7 +56,7 @@ function global_area_integral(var, G, scale, area)
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: area !< The alternate area to use, including
                                                           !! any required masking [L2 ~> m2].
   real :: global_area_integral !< The returned area integral, usually in the units of var times [m2].
-  
+
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming
   real :: scalefac  ! An overall scaling factor for the areas and variable.

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -350,12 +350,8 @@ subroutine shelf_calc_flux(state, fluxes, Time, time_step, CS, forces)
       ! but it won't make a difference otherwise.
       fluxes%ustar_shelf(i,j)= 0.0
 
-      ! DNG - to allow this everywhere Hml>0.0 allows for melting under grounded cells
-      !       propose instead to allow where Hml > [some threshold]
-      !### I do not know what the Hml flag adds; consider removing it.
       if ((iDens*state%ocean_mass(i,j) > CS%col_thick_melt_threshold) .and. &
-          (ISS%area_shelf_h(i,j) > 0.0) .and. &
-          (CS%isthermo) .and. (state%Hml(i,j) > 0.0) ) then
+          (ISS%area_shelf_h(i,j) > 0.0) .and. CS%isthermo ) then
 
         if (CS%threeeq) then
           !   Iteratively determine a self-consistent set of fluxes, with the ocean
@@ -602,8 +598,7 @@ subroutine shelf_calc_flux(state, fluxes, Time, time_step, CS, forces)
 
   do j=js,je ; do i=is,ie
     if ((iDens*state%ocean_mass(i,j) > CS%col_thick_melt_threshold) .and. &
-        (ISS%area_shelf_h(i,j) > 0.0) .and. &
-        (CS%isthermo) .and. (state%Hml(i,j) > 0.0) ) then
+        (ISS%area_shelf_h(i,j) > 0.0) .and. CS%isthermo) then
 
       ! Set melt to zero above a cutoff pressure (CS%Rho0*CS%cutoff_depth*CS%g_Earth).
       ! This is needed for the ISOMIP test case.

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -931,7 +931,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   real, dimension(max(nsw,1),SZI_(G),SZK_(G)) :: &
     opacityBand      ! The opacity (inverse of the exponential absorption length) of each frequency
                      ! band of shortwave radation in each layer [H-1 ~> m-1 or m2 kg-1]
-  real, dimension(maxGroundings) :: hGrounding
+  real, dimension(maxGroundings) :: hGrounding ! Thickness added by each grounding event [H ~> m or kg m-2]
   real    :: Temp_in, Salin_in
   real    :: g_Hconv2 ! A conversion factor for use in the TKE calculation
                       ! in units of [Z3 R2 T-2 H-2 ~> kg2 m-5 s-2 or m s-2].
@@ -1380,7 +1380,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
     do i = 1, min(numberOfGroundings, maxGroundings)
       call forcing_SinglePointPrint(fluxes,G,iGround(i),jGround(i),'applyBoundaryFluxesInOut (grounding)')
       write(mesg(1:45),'(3es15.3)') G%geoLonT( iGround(i), jGround(i) ), &
-                             G%geoLatT( iGround(i), jGround(i)) , hGrounding(i)
+                             G%geoLatT( iGround(i), jGround(i)), hGrounding(i)*GV%H_to_m
       call MOM_error(WARNING, "MOM_diabatic_driver.F90, applyBoundaryFluxesInOut(): "//&
                               "Mass created. x,y,dh= "//trim(mesg), all_print=.true.)
     enddo

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -173,13 +173,13 @@ subroutine ISOMIP_initialize_thickness ( h, G, GV, US, param_file, tv, just_read
 
   case ( REGRIDDING_LAYER, REGRIDDING_RHO ) ! Initial thicknesses for isopycnal coordinates
     call get_param(param_file, mdl, "ISOMIP_T_SUR", t_sur, &
-                   'Temperature at the surface (interface)', units="degC", default=-1.9, do_not_log=just_read)
+                   "Temperature at the surface (interface)", units="degC", default=-1.9, do_not_log=just_read)
     call get_param(param_file, mdl, "ISOMIP_S_SUR", s_sur, &
-                   'Salinity at the surface (interface)', units="ppt",  default=33.8, do_not_log=just_read)
+                   "Salinity at the surface (interface)", units="ppt",  default=33.8, do_not_log=just_read)
     call get_param(param_file, mdl, "ISOMIP_T_BOT", t_bot, &
-                   'Temperature at the bottom (interface)', units="degC", default=-1.9, do_not_log=just_read)
+                   "Temperature at the bottom (interface)", units="degC", default=-1.9, do_not_log=just_read)
     call get_param(param_file, mdl, "ISOMIP_S_BOT", s_bot,&
-                   'Salinity at the bottom (interface)', units="ppt", default=34.55, do_not_log=just_read)
+                   "Salinity at the bottom (interface)", units="ppt", default=34.55, do_not_log=just_read)
 
     if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -293,13 +293,13 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, US, param_fi
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
   call get_param(param_file, mdl, "ISOMIP_T_SUR",t_sur, &
-                 'Temperature at the surface (interface)', default=-1.9, do_not_log=just_read)
+                 "Temperature at the surface (interface)", units="degC", default=-1.9, do_not_log=just_read)
   call get_param(param_file, mdl, "ISOMIP_S_SUR", s_sur, &
-                 'Salinity at the surface (interface)',  default=33.8, do_not_log=just_read)
+                 "Salinity at the surface (interface)", units="ppt", default=33.8, do_not_log=just_read)
   call get_param(param_file, mdl, "ISOMIP_T_BOT", t_bot, &
-                 'Temperature at the bottom (interface)', default=-1.9, do_not_log=just_read)
+                 "Temperature at the bottom (interface)", units="degC", default=-1.9, do_not_log=just_read)
   call get_param(param_file, mdl, "ISOMIP_S_BOT", s_bot, &
-                 'Salinity at the bottom (interface)', default=34.55, do_not_log=just_read)
+                 "Salinity at the bottom (interface)", units="ppt", default=34.55, do_not_log=just_read)
 
   call calculate_density(t_sur,s_sur,0.0,rho_sur,eqn_of_state, scale=US%kg_m3_to_R)
   ! write(mesg,*) 'Density in the surface layer:', rho_sur
@@ -481,16 +481,16 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, PF, use_ALE, CSp, ACSp)
                  do_not_log=.true.)
 
   call get_param(PF, mdl, "ISOMIP_S_SUR_SPONGE", s_sur, &
-                 'Surface salinity in sponge layer.', default=s_ref) ! units="ppt")
+                 "Surface salinity in sponge layer.", units="ppt", default=s_ref) ! units="ppt")
 
   call get_param(PF, mdl, "ISOMIP_S_BOT_SPONGE", s_bot, &
-                 'Bottom salinity in sponge layer.', default=s_ref) ! units="ppt")
+                 "Bottom salinity in sponge layer.", units="ppt", default=s_ref) ! units="ppt")
 
   call get_param(PF, mdl, "ISOMIP_T_SUR_SPONGE", t_sur, &
-                 'Surface temperature in sponge layer.', default=t_ref) ! units="degC")
+                 "Surface temperature in sponge layer.", units="degC", default=t_ref) ! units="degC")
 
   call get_param(PF, mdl, "ISOMIP_T_BOT_SPONGE", t_bot, &
-                 'Bottom temperature in sponge layer.', default=t_ref) ! units="degC")
+                 "Bottom temperature in sponge layer.", units="degC", default=t_ref) ! units="degC")
 
   T(:,:,:) = 0.0 ; S(:,:,:) = 0.0 ; Idamp(:,:) = 0.0 !; RHO(:,:,:) = 0.0
 

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -172,14 +172,14 @@ subroutine ISOMIP_initialize_thickness ( h, G, GV, US, param_file, tv, just_read
   select case ( coordinateMode(verticalCoordinate) )
 
   case ( REGRIDDING_LAYER, REGRIDDING_RHO ) ! Initial thicknesses for isopycnal coordinates
-    call get_param(param_file, mdl, "ISOMIP_T_SUR",t_sur, &
-                   'Temperature at the surface (interface)', default=-1.9, do_not_log=just_read)
+    call get_param(param_file, mdl, "ISOMIP_T_SUR", t_sur, &
+                   'Temperature at the surface (interface)', units="degC", default=-1.9, do_not_log=just_read)
     call get_param(param_file, mdl, "ISOMIP_S_SUR", s_sur, &
-                   'Salinity at the surface (interface)',  default=33.8, do_not_log=just_read)
+                   'Salinity at the surface (interface)', units="ppt",  default=33.8, do_not_log=just_read)
     call get_param(param_file, mdl, "ISOMIP_T_BOT", t_bot, &
-                   'Temperature at the bottom (interface)', default=-1.9, do_not_log=just_read)
+                   'Temperature at the bottom (interface)', units="degC", default=-1.9, do_not_log=just_read)
     call get_param(param_file, mdl, "ISOMIP_S_BOT", s_bot,&
-                   'Salinity at the bottom (interface)', default=34.55, do_not_log=just_read)
+                   'Salinity at the bottom (interface)', units="ppt", default=34.55, do_not_log=just_read)
 
     if (just_read) return ! All run-time parameters have been read, so return.
 


### PR DESCRIPTION
  This PR includes a set of commits that correct a number obvious bugs and other 
problems with the MOM6 ice_shelf code.  The solutions are now using reproducing 
sums, so they should reproduce across PE count.  Some horizontal indexing bugs 
were corrected, but without more extensive testing it is not clear that these 
solutions will satisfy rotational symmetry.  Answers and parameter_doc files 
will change for any cases that use a thermodynamically active ice shelf, but 
there are no changes to the MOM6-examples test suite.  The commits in this PR 
include:

- NOAA-GFDL/MOM6@4693962 Merge branch 'dev/gfdl' into fix_iceshelf_problems
- NOAA-GFDL/MOM6@bcc3f5e Merge branch 'dev/gfdl' into fix_iceshelf_problems
- NOAA-GFDL/MOM6@7cdffb1 (*)Use state%taux_shelf to set state%ustar_shelf
- NOAA-GFDL/MOM6@684681b +Ice shelf code cleanup
- NOAA-GFDL/MOM6@04d5a83 (*)Use a blend of ice-shelf and open water fluxes
- NOAA-GFDL/MOM6@fcb1e92 +Add optional arg to ice_shelf_min_thickness_calve
- NOAA-GFDL/MOM6@e87c664 (*)Removed rescaling from mean_melt_flux to vprec
- NOAA-GFDL/MOM6@e88732c (*)Do not use Hml>0 as an ice shelf melt filter
- NOAA-GFDL/MOM6@1a8c75a (*+)Set ice shelf latent heat consistently
- NOAA-GFDL/MOM6@880da80 (*+)Corrected a bug in setting ustar_shelf
- NOAA-GFDL/MOM6@3c3f721 (*+)Corrected bugs in 3-eqn ice shelf skin salinity
- NOAA-GFDL/MOM6@7121619 (*)Use global_area_integral in add_shelf_flux
- NOAA-GFDL/MOM6@63fd8e1 +Added optional arg area to global_area_integral
- NOAA-GFDL/MOM6@7fb8f55 Flipped the sign convention for wT_flux

