### PR TITLE
Removes missing_value argument from fns in MOM_diag_remap

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1505,7 +1505,7 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
       call vertically_reintegrate_diag_field( &
               diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), &
               diag_cs%G, h_diag, staggered_in_x, staggered_in_y, &
-              diag%axes%mask3d, diag_cs%missing_value, field, remapped_field)
+              diag%axes%mask3d, field, remapped_field)
       if (id_clock_diag_remap>0) call cpu_clock_end(id_clock_diag_remap)
       if (associated(diag%axes%mask3d)) then
         ! Since 3d masks do not vary in the vertical, just use as much as is
@@ -1528,7 +1528,7 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
       allocate(remapped_field(size(field,1), size(field,2), diag%axes%nz))
       call diag_remap_do_remap(diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), &
               diag_cs%G, diag_cs%GV, h_diag, staggered_in_x, staggered_in_y, &
-              diag%axes%mask3d, diag_cs%missing_value, field, remapped_field)
+              diag%axes%mask3d, field, remapped_field)
       if (id_clock_diag_remap>0) call cpu_clock_end(id_clock_diag_remap)
       if (associated(diag%axes%mask3d)) then
         ! Since 3d masks do not vary in the vertical, just use as much as is
@@ -1552,7 +1552,7 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
       call vertically_interpolate_diag_field(diag_cs%diag_remap_cs( &
               diag%axes%vertical_coordinate_number), &
               diag_cs%G, h_diag, staggered_in_x, staggered_in_y, &
-              diag%axes%mask3d, diag_cs%missing_value, field, remapped_field)
+              diag%axes%mask3d, field, remapped_field)
       if (id_clock_diag_remap>0) call cpu_clock_end(id_clock_diag_remap)
       if (associated(diag%axes%mask3d)) then
         ! Since 3d masks do not vary in the vertical, just use as much as is
@@ -1769,7 +1769,7 @@ subroutine post_xy_average(diag_cs, diag, field)
     call horizontally_average_diag_field(diag_cs%G, diag_cs%GV, diag_cs%h, &
                                          staggered_in_x, staggered_in_y, &
                                          diag%axes%is_layer, diag%v_extensive, &
-                                         diag_cs%missing_value, field, &
+                                         field, &
                                          averaged_field, averaged_mask)
   else
     nz = size(field, 3)
@@ -1788,7 +1788,7 @@ subroutine post_xy_average(diag_cs, diag, field)
                                          diag_cs%diag_remap_cs(coord)%h, &
                                          staggered_in_x, staggered_in_y, &
                                          diag%axes%is_layer, diag%v_extensive, &
-                                         diag_cs%missing_value, field, &
+                                         field, &
                                          averaged_field, averaged_mask)
   endif
 

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -346,7 +346,7 @@ end subroutine diag_remap_update
 
 !> Remap diagnostic field to alternative vertical grid.
 subroutine diag_remap_do_remap(remap_cs, G, GV, h, staggered_in_x, staggered_in_y, &
-                               mask, missing_value, field, remapped_field)
+                               mask, field, remapped_field)
   type(diag_remap_ctrl),   intent(in) :: remap_cs !< Diagnostic coodinate control structure
   type(ocean_grid_type),   intent(in) :: G  !< Ocean grid structure
   type(verticalGrid_type), intent(in) :: GV !< ocean vertical grid structure
@@ -354,7 +354,6 @@ subroutine diag_remap_do_remap(remap_cs, G, GV, h, staggered_in_x, staggered_in_
   logical,                 intent(in) :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                 intent(in) :: staggered_in_y !< True is the y-axis location is at v or q points
   real, dimension(:,:,:),  pointer    :: mask !< A mask for the field
-  real,                    intent(in) :: missing_value !< A missing_value to assign land/vanished points
   real, dimension(:,:,:),  intent(in) :: field(:,:,:) !< The diagnostic field to be remapped
   real, dimension(:,:,:),  intent(inout) :: remapped_field !< Field remapped to new coordinate
   ! Local variables
@@ -486,14 +485,13 @@ end subroutine diag_remap_calc_hmask
 
 !> Vertically re-grid an already vertically-integrated diagnostic field to alternative vertical grid.
 subroutine vertically_reintegrate_diag_field(remap_cs, G, h, staggered_in_x, staggered_in_y, &
-                                             mask, missing_value, field, reintegrated_field)
+                                             mask, field, reintegrated_field)
   type(diag_remap_ctrl),  intent(in) :: remap_cs !< Diagnostic coodinate control structure
   type(ocean_grid_type),  intent(in) :: G !< Ocean grid structure
   real, dimension(:,:,:), intent(in) :: h   !< The current thicknesses
   logical,                intent(in) :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                intent(in) :: staggered_in_y !< True is the y-axis location is at v or q points
   real, dimension(:,:,:), pointer    :: mask !< A mask for the field
-  real,                   intent(in) :: missing_value !< A missing_value to assign land/vanished points
   real, dimension(:,:,:), intent(in) :: field !<  The diagnostic field to be remapped
   real, dimension(:,:,:), intent(inout) :: reintegrated_field !< Field argument remapped to alternative coordinate
   ! Local variables
@@ -567,14 +565,13 @@ end subroutine vertically_reintegrate_diag_field
 
 !> Vertically interpolate diagnostic field to alternative vertical grid.
 subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, staggered_in_y, &
-                                             mask, missing_value, field, interpolated_field)
+                                             mask, field, interpolated_field)
   type(diag_remap_ctrl),  intent(in) :: remap_cs !< Diagnostic coodinate control structure
   type(ocean_grid_type),  intent(in) :: G !< Ocean grid structure
   real, dimension(:,:,:), intent(in) :: h   !< The current thicknesses
   logical,                intent(in) :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                intent(in) :: staggered_in_y !< True is the y-axis location is at v or q points
   real, dimension(:,:,:), pointer    :: mask !< A mask for the field
-  real,                   intent(in) :: missing_value !< A missing_value to assign land/vanished points
   real, dimension(:,:,:), intent(in) :: field !<  The diagnostic field to be remapped
   real, dimension(:,:,:), intent(inout) :: interpolated_field !< Field argument remapped to alternative coordinate
   ! Local variables
@@ -650,7 +647,7 @@ end subroutine vertically_interpolate_diag_field
 !> Horizontally average field
 subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_in_y, &
                                            is_layer, is_extensive, &
-                                           missing_value, field, averaged_field, &
+                                           field, averaged_field, &
                                            averaged_mask)
   type(ocean_grid_type),  intent(in) :: G !< Ocean grid structure
   type(verticalGrid_type), intent(in) :: GV !< The ocean vertical grid structure
@@ -659,7 +656,6 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
   logical,                intent(in) :: staggered_in_y !< True if the y-axis location is at v or q points
   logical,                intent(in) :: is_layer !< True if the z-axis location is at h points
   logical,                intent(in) :: is_extensive !< True if the z-direction is spatially integrated (over layers)
-  real,                   intent(in) :: missing_value !< A missing_value to assign land/vanished points
   real, dimension(:,:,:), intent(in) :: field !<  The diagnostic field to be remapped
   real, dimension(:),  intent(inout) :: averaged_field !< Field argument horizontally averaged
   logical, dimension(:), intent(inout) :: averaged_mask  !< Mask for horizontally averaged field


### PR DESCRIPTION
- This is a very small step towards #769. When I looked at what it will take to deal with #769 it turns out diag_mediator needs a significant refactor that just isn't going to happen overnight.
- missing_value was an argument to several functions in MOM_diag_remap but was not used. At one point these functions incorrectly used missing_value to mask data but this is not the correct usage of missing_value nor the right way to do masking in MOM6. This was fixed 3 years ago and this commit simply removes unused arguments.