### PR TITLE
Fixes an integer-kind mismatch in MOM_random, seed_from_time()

### DIFF
--- a/src/framework/MOM_random.F90
+++ b/src/framework/MOM_random.F90
@@ -143,8 +143,9 @@ integer function seed_from_time(Time)
   call get_date(Time,yr,mo,dy,hr,mn,sc)
   s1 = sc + 61*(mn + 61*hr) + 379 ! Range 379 .. 89620
   ! Fun fact: 2147483647 is the eighth Mersenne prime.
-  ! This is not the reason for using 2147483647+1 here.
-  s2 = mod(dy + 32*(mo + 13*yr), 2147483648) ! Range 0 .. 2147483647
+  ! This is not the reason for using 2147483647 here. It is the
+  ! largest integer of kind=4.
+  s2 = modulo(dy + 32*(mo + 13*yr), 2147483647_4) ! Range 0 .. 2147483646
   seed_from_time = ieor(s1*4111, s2)
 
 end function seed_from_time


### PR DESCRIPTION
- gcc/8.3.0 issued `Error: Integer too big for its kind` reported in
  feedback on PR #1111. The intent was to assume kind=4 in these
  calculations but apparently our compilers were promoting
  `mod(dy + 32*(mo + 13*yr), 2147483648)` to kind=8. There were two
  mistakes in the expression:
  - the use of `2147483648` in the `mod` is not representable with kind=4;
  - the `mod` produces negative values and should have been a `modulo`.
- This commit reduces the range of the results by one number on the
  positive side and removes all the negatives.

@gustavo-marques Could you test this patch for me? It passes everything at our end but so did the original PR.