### PR TITLE
Travis: Arm64 tests; git depth restored; Makefile

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -378,17 +378,17 @@ test.summary:
 	  if ls results/*/std.*.err &> /dev/null; then \
 	    echo "The following tests failed to complete:" ; \
 	    ls results/*/std.*.out \
-	      | awk '{split($$0,a,"/"); split(a[3],t,"."); print "  ",a[2],":",t[2]}' ; \
+	      | awk '{split($$0,a,"/"); split(a[3],t,"."); v=t[2]; if(length(t)>3) v=v"."t[3]; print a[2],":",v}'; \
 	  fi; \
 	  if ls results/*/ocean.stats.*.diff &> /dev/null; then \
 	    echo "The following tests report solution regressions:" ; \
 	    ls results/*/ocean.stats.*.diff \
-	      | awk '{split($$0,a,"/"); split(a[3],t,"."); print "  ",a[2],":",t[3]}' ; \
+	      | awk '{split($$0,a,"/"); split(a[3],t,"."); v=t[3]; if(length(t)>4) v=v"."t[4]; print a[2],":",v}'; \
 	  fi; \
 	  if ls results/*/chksum_diag.*.diff &> /dev/null; then \
 	    echo "The following tests report diagnostic regressions:" ; \
 	    ls results/*/chksum_diag.*.diff \
-	      | awk '{split($$0,a,"/"); split(a[3],t,"."); print "  ",a[2],":",t[2]}' ; \
+	      | awk '{split($$0,a,"/"); split(a[3],t,"."); v=t[2]; if(length(t)>3) v=v"."t[3]; print a[2],":",v}'; \
 	  fi; \
 	  false ; \
 	else \

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,16 @@
 language: c
 dist: bionic
 
-# --depth flag is breaking our merge, try disabling it
-# NOTE: We may be able to go back to depth=50 in production
-git:
-    depth: false
-
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev gfortran
+    - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev gfortran
+    - mpich libmpich-dev
     - doxygen graphviz flex bison cmake
     - python-numpy python-netcdf4
+    - bc
 
 jobs:
   include:
@@ -57,4 +54,18 @@ jobs:
         - make build.regressions
         - echo -en 'travis_fold:end:script.1\\r'
         - make -k -s test.regressions
+        - make test.summary
+
+    - arch: arm64
+      env:
+        - JOB="Configuration testing"
+        - DO_REGRESSION_TESTS=false
+        - DO_REPRO_TESTS=false
+        - MKMF_TEMPLATE=linux-ubuntu-xenial-gnu.mk
+      script:
+        - cd .testing
+        - echo 'Build executables...' && echo -en 'travis_fold:start:script.1\\r'
+        - make all
+        - echo -en 'travis_fold:end:script.1\\r'
+        - make -k -s test
         - make test.summary

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
         - test ! -s  doxy_errors
 
     - env:
-        - JOB="Configuration testing"
+        - JOB="x86 Configuration testing"
         - DO_REGRESSION_TESTS=false
         - MKMF_TEMPLATE=linux-ubuntu-xenial-gnu.mk
       script:
@@ -42,7 +42,7 @@ jobs:
     # NOTE: Code coverage upload is here to reduce load imbalance
     - if: type = pull_request
       env:
-        - JOB="Regression testing"
+        - JOB="x86 Regression testing"
         - DO_REGRESSION_TESTS=true
         - REPORT_COVERAGE=true
         - MKMF_TEMPLATE=linux-ubuntu-xenial-gnu.mk
@@ -58,7 +58,7 @@ jobs:
 
     - arch: arm64
       env:
-        - JOB="Configuration testing"
+        - JOB="ARM64 Configuration testing"
         - DO_REGRESSION_TESTS=false
         - DO_REPRO_TESTS=false
         - MKMF_TEMPLATE=linux-ubuntu-xenial-gnu.mk


### PR DESCRIPTION
There are four minor changes in this patch:

- Arm64 testing has been enabled on Travis.

  As a non-x86 architecture, this will provide more robust testing of
  the code.

- Travis MPI library switch to MPICH

  There were issues with using OpenMPI on Arm64, particularly with
  MPI_Init.  Switching to MPICH appeared to resolve those issues, and
  MPICH has a much simpler implementation, so we've switched all jobs to
  it.

- default git depth has been restored

  Our regression testing method no longer requires a complete history
  for comparison.

- Makefile fix: dimension now reported in summary

  The test.summary output now includes the dimension type in the list of
  failed tests.