### PR TITLE
CodeCov: Set number of reports to 8

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,6 @@ coverage:
         patch:
             default:
                 threshold: 100%
+comment:
+    # This must be set to the number of test cases (TCs)
+    after_n_builds: 8


### PR DESCRIPTION
This setting will prevent CodeCov from updating the repository until all
8 test suites are completed.

The number is fixed to 8 in the file, so we now need to keep these in
sync until this can be sorted out some other way.