### PR TITLE
Codecov: Set base as parent (target) branch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,9 +3,11 @@ coverage:
         project:
             default:
                 threshold: 100%
+                base: parent
         patch:
             default:
                 threshold: 100%
+                base: parent
 comment:
     # This must be set to the number of test cases (TCs)
     after_n_builds: 8


### PR DESCRIPTION
Codecov appears to have two schemes for setting a target reference for
coverage measurements: `pr` and `parent`.

The first seems to measure coverage relative to the point where the PR
was branched to branch against the current state of the PR.

The second measures coverage relative to the  current state of branch to
be merged against the merged PR conent

PR submissions default to the first, but we want to measure coverage
relative to the second.  This patch always uses the `parent` method.