### PR TITLE
MOM6: +Minor improvements in framework code

### DIFF
--- a/src/framework/MOM_cpu_clock.F90
+++ b/src/framework/MOM_cpu_clock.F90
@@ -3,8 +3,9 @@ module MOM_cpu_clock
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use fms_mod, only : clock_flag_default
 use mpp_mod, only : cpu_clock_begin => mpp_clock_begin
-use mpp_mod, only : cpu_clock_end => mpp_clock_end, cpu_clock_id => mpp_clock_id
+use mpp_mod, only : cpu_clock_end => mpp_clock_end, mpp_clock_id
 use mpp_mod, only : CLOCK_COMPONENT, CLOCK_SUBCOMPONENT, CLOCK_MODULE_DRIVER
 use mpp_mod, only : CLOCK_MODULE, CLOCK_ROUTINE, CLOCK_LOOP, CLOCK_INFRA
 use mpp_mod, only : CLOCK_SYNC => MPP_CLOCK_SYNC
@@ -14,5 +15,28 @@ implicit none ; private
 public :: cpu_clock_id, cpu_clock_begin, cpu_clock_end
 public :: CLOCK_COMPONENT, CLOCK_SUBCOMPONENT, CLOCK_MODULE_DRIVER, CLOCK_MODULE
 public :: CLOCK_ROUTINE, CLOCK_LOOP, CLOCK_INFRA, CLOCK_SYNC
+
+contains
+
+!> cpu_clock_id returns the integer handle for a named CPU clock.
+function cpu_clock_id( name, synchro_flag, grain )
+  character(len=*),  intent(in) :: name  !< The unique name of the CPU clock
+  integer, intent(in), optional :: synchro_flag !< An integer flag that controls whether the PEs
+                                       !! are synchronized before the cpu clocks start counting.
+                                       !! Synchronization occurs before the start of a clock if this
+                                       !! is odd, while additional (expensive) statistics can set
+                                       !! for other values. If absent, the default is taken from the
+                                       !! settings for FMS.
+  integer, intent(in), optional :: grain !< The timing granularity for this clock, usually set to
+                                       !! the values of CLOCK_COMPONENT, CLOCK_ROUTINE, CLOCK_LOOP, etc.
+  integer                       :: cpu_clock_id !< The integer CPU clock handle.
+
+  if (present(synchro_flag)) then
+    cpu_clock_id = mpp_clock_id(name, flags=synchro_flag, grain=grain)
+  else
+    cpu_clock_id = mpp_clock_id(name, flags=clock_flag_default, grain=grain)
+  endif
+
+end function cpu_clock_id
 
 end module MOM_cpu_clock

--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -500,6 +500,7 @@ subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, &
 
     substr_start = start_ind
     do ! Adjust the available line length for anomalies in the size of tabs
+      if (len_trim(desc) <= start_ind+len_cor) exit  ! This line will not span another line.
       tab_ind = index(desc(substr_start:start_ind+len_cor), "\t") ! Count \t as 2 spaces.
       if (tab_ind == 0) exit
       substr_start = substr_start + tab_ind
@@ -510,11 +511,11 @@ subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, &
     end_ind = 0
     if ((nl_ind > 0) .and. (len_trim(desc(start_ind:start_ind+nl_ind-2)) > len_cor)) then
       ! This line is too long despite the new-line character.  Look for an earlier space to break.
-      end_ind = scan(desc(start_ind:start_ind+(len_cor)), " ", back=.true.) - 1
+      end_ind = scan(desc(start_ind:start_ind+len_cor), " ", back=.true.) - 1
       if (end_ind > 0) nl_ind = 0
     elseif ((nl_ind == 0) .and. (len_trim(desc(start_ind:)) > len_cor)) then
       ! This line is too long and does not have a new-line character.  Look for a space to break.
-      end_ind = scan(desc(start_ind:start_ind+(len_cor)), " ", back=.true.) - 1
+      end_ind = scan(desc(start_ind:start_ind+len_cor), " ", back=.true.) - 1
     endif
 
     reset_msg_pad = .false.

--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -468,6 +468,8 @@ subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, &
   integer :: start_ind = 1             ! The starting index in the description for the next line.
   integer :: nl_ind, tab_ind, end_ind  ! The indices of new-lines, tabs, and the end of a line.
   integer :: len_text, len_tab, len_nl ! The lengths of the text string, tabs and new-lines.
+  integer :: len_cor                   ! The permitted length corrected for tab sizes in a line.
+  integer :: substr_start              ! The starting index of a substring to search for tabs.
   integer :: indnt, msg_pad            ! Space counts used to format a message.
   logical :: msg_done, reset_msg_pad   ! Logicals used to format messages.
   logical :: all, short, layout, debug ! Flags indicating which files to write into.
@@ -494,16 +496,25 @@ subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, &
   do
     if (len_trim(desc(start_ind:)) < 1) exit
 
-    nl_ind = index(desc(start_ind:), "\n")
+    len_cor = len_text - msg_pad
 
+    substr_start = start_ind
+    do ! Adjust the available line length for anomalies in the size of tabs
+      tab_ind = index(desc(substr_start:start_ind+len_cor), "\t") ! Count \t as 2 spaces.
+      if (tab_ind == 0) exit
+      substr_start = substr_start + tab_ind
+      len_cor = len_cor + (len_tab - 2)
+    enddo
+
+    nl_ind = index(desc(start_ind:), "\n")
     end_ind = 0
-    if ((nl_ind > 0) .and. (len_trim(desc(start_ind:start_ind+nl_ind-2)) > len_text-msg_pad)) then
+    if ((nl_ind > 0) .and. (len_trim(desc(start_ind:start_ind+nl_ind-2)) > len_cor)) then
       ! This line is too long despite the new-line character.  Look for an earlier space to break.
-      end_ind = scan(desc(start_ind:start_ind+(len_text-msg_pad)), " ", back=.true.) - 1
+      end_ind = scan(desc(start_ind:start_ind+(len_cor)), " ", back=.true.) - 1
       if (end_ind > 0) nl_ind = 0
-    elseif ((nl_ind == 0) .and. (len_trim(desc(start_ind:)) > len_text-msg_pad)) then
+    elseif ((nl_ind == 0) .and. (len_trim(desc(start_ind:)) > len_cor)) then
       ! This line is too long and does not have a new-line character.  Look for a space to break.
-      end_ind = scan(desc(start_ind:start_ind+(len_text-msg_pad)), " ", back=.true.) - 1
+      end_ind = scan(desc(start_ind:start_ind+(len_cor)), " ", back=.true.) - 1
     endif
 
     reset_msg_pad = .false.

--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -469,6 +469,7 @@ subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, &
   integer :: nl_ind, tab_ind, end_ind  ! The indices of new-lines, tabs, and the end of a line.
   integer :: len_text, len_tab, len_nl ! The lengths of the text string, tabs and new-lines.
   integer :: len_cor                   ! The permitted length corrected for tab sizes in a line.
+  integer :: len_desc                  ! The non-whitespace length of the description.
   integer :: substr_start              ! The starting index of a substring to search for tabs.
   integer :: indnt, msg_pad            ! Space counts used to format a message.
   logical :: msg_done, reset_msg_pad   ! Logicals used to format messages.
@@ -499,9 +500,10 @@ subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, &
     len_cor = len_text - msg_pad
 
     substr_start = start_ind
-    do ! Adjust the available line length for anomalies in the size of tabs
-      if (len_trim(desc) <= start_ind+len_cor) exit  ! This line will not span another line.
-      tab_ind = index(desc(substr_start:start_ind+len_cor), "\t") ! Count \t as 2 spaces.
+    len_desc = len_trim(desc)
+    do ! Adjust the available line length for anomalies in the size of tabs, counting \t as 2 spaces.
+      if (substr_start >= start_ind+len_cor) exit
+      tab_ind = index(desc(substr_start:min(len_desc,start_ind+len_cor)), "\t")
       if (tab_ind == 0) exit
       substr_start = substr_start + tab_ind
       len_cor = len_cor + (len_tab - 2)

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -445,7 +445,7 @@ subroutine calculate_bkgnd_mixing(h, tv, N2_lay, Kd_lay, Kv, j, G, GV, US, CS)
 
   elseif ((.not. CS%Bryan_Lewis_diffusivity) .and. (.not.CS%bulkmixedlayer) .and. &
           (.not. CS%horiz_varying_background) .and. (CS%Kd /= CS%Kdml)) then
-    I_Hmix = 1.0 / CS%Hmix
+    I_Hmix = 1.0 / (CS%Hmix + GV%H_subroundoff*GV%H_to_Z)
     do i=is,ie ; depth(i) = 0.0 ; enddo
     do k=1,nz ; do i=is,ie
       depth_c = depth(i) + 0.5*GV%H_to_Z*h(i,j,k)


### PR DESCRIPTION
  This PR includes some improvement in the MOM6 parameter documentation code so 
that output is the same for different compilers, and code to improve the ability
to specify the synchronization behavior of the cpu clocks.  There are no changes 
to output files, and all answers are bitwise identical.  The commits in this PR
include:

- NOAA-GFDL/MOM6@3303fb9 Included H_subroundoff in a denominator
- NOAA-GFDL/MOM6@e0af94c +Added code to handle tab lengths in documentation
- NOAA-GFDL/MOM6@0ee031d Added explicit form of cpu_clock_id
