### PR TITLE
+Improve documentation in MOM_parameter_doc files

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing_gfdl.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing_gfdl.F90
@@ -1272,7 +1272,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS)
 
   call write_version_number(version)
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mdl, version, "")
+  call log_version(param_file, mdl, version, "", log_to_all=.true., debugging=.true.)
 
   call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, &
                  "The directory in which all input files are found.", &

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1705,8 +1705,12 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   call find_obsolete_params(param_file)
 
+  ! Determining the internal unit scaling factors for this run.
+  call unit_scaling_init(param_file, CS%US)
+  US => CS%US
+
   ! Read relevant parameters and write them to the model log.
-  call log_version(param_file, "MOM", version, "")
+  call log_version(param_file, "MOM", version, "", log_to_all=.true., layout=.true., debugging=.true.)
   call get_param(param_file, "MOM", "VERBOSITY", verbosity,  &
                  "Integer controlling level of messaging\n" // &
                  "\t0 = Only FATAL messages\n" // &
@@ -1718,11 +1722,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   if (do_unit_tests) then
     call unit_tests(verbosity)
   endif
-
-  ! Determining the internal unit scaling factors for this run.
-  call unit_scaling_init(param_file, CS%US)
-
-  US => CS%US
 
   call get_param(param_file, "MOM", "SPLIT", CS%split, &
                  "Use the split time stepping if true.", default=.true.)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3966,7 +3966,9 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "SPLIT", CS%split, default=.true., do_not_log=.true.)
+  call log_version(param_file, mdl, version, "", log_to_all=.true., layout=CS%split, &
+                   debugging=CS%split, all_default=.not.CS%split)
   call get_param(param_file, mdl, "SPLIT", CS%split, &
                  "Use the split time stepping if true.", default=.true.)
   if (.not.CS%split) return

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -211,7 +211,8 @@ subroutine MOM_grid_init(G, param_file, US, HI, global_indexing, bathymetry_at_v
 
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mod_nm, version, &
-                   "Parameters providing information about the lateral grid.")
+                   "Parameters providing information about the lateral grid.", &
+                   log_to_all=.true., layout=.true.)
 
 
   call get_param(param_file, mod_nm, "NIBLOCK", niblock, "The number of blocks "// &

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -343,9 +343,12 @@ subroutine open_boundary_config(G, US, param_file, OBC)
   real               :: Lscale_in, Lscale_out ! parameters controlling tracer values at the boundaries [L ~> m]
   allocate(OBC)
 
+  call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", OBC%number_of_segments, &
+                 default=0, do_not_log=.true.)
   call log_version(param_file, mdl, version, &
                  "Controls where open boundaries are located, what kind of boundary condition "//&
-                 "to impose, and what data to apply, if any.")
+                 "to impose, and what data to apply, if any.", &
+                 all_default=(OBC%number_of_segments<=0))
   call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", OBC%number_of_segments, &
                  "The number of open boundary segments.", &
                  default=0)

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -92,7 +92,8 @@ subroutine verticalGridInit( param_file, GV, US )
 
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, &
-                   "Parameters providing information about the vertical grid.")
+                   "Parameters providing information about the vertical grid.", &
+                   log_to_all=.true., debugging=.true.)
   call get_param(param_file, mdl, "G_EARTH", GV%g_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80, scale=US%Z_to_m*US%m_s_to_L_T**2)

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -759,7 +759,7 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
   CS%v_av => MIS%v_av; if (.not.associated(MIS%v_av)) CS%v_av => MIS%v(:,:,:)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mdl, version, "")
+  call log_version(param_file, mdl, version, "", debugging=.true.)
   call get_param(param_file, mdl, "U_TRUNC_FILE", CS%u_trunc_file, &
                  "The absolute path to the file where the accelerations "//&
                  "leading to zonal velocity truncations are written. \n"//&
@@ -771,7 +771,7 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
                  "Leave this empty for efficiency if this diagnostic is "//&
                  "not needed.", default="", debuggingParam=.true.)
   call get_param(param_file, mdl, "MAX_TRUNC_FILE_SIZE_PER_PE", CS%max_writes, &
-                 "The maximum number of colums of truncations that any PE "//&
+                 "The maximum number of columns of truncations that any PE "//&
                  "will write out during a run.", default=50, debuggingParam=.true.)
 
   if (len_trim(dirs%output_directory) > 0) then
@@ -779,8 +779,8 @@ subroutine PointAccel_init(MIS, Time, G, param_file, diag, dirs, CS)
       CS%u_trunc_file = trim(dirs%output_directory)//trim(CS%u_trunc_file)
     if (len_trim(CS%v_trunc_file) > 0) &
       CS%v_trunc_file = trim(dirs%output_directory)//trim(CS%v_trunc_file)
-    call log_param(param_file, mdl, "output_dir/U_TRUNC_FILE", CS%u_trunc_file)
-    call log_param(param_file, mdl, "output_dir/V_TRUNC_FILE", CS%v_trunc_file)
+    call log_param(param_file, mdl, "output_dir/U_TRUNC_FILE", CS%u_trunc_file, debuggingParam=.true.)
+    call log_param(param_file, mdl, "output_dir/V_TRUNC_FILE", CS%v_trunc_file, debuggingParam=.true.)
   endif
   CS%u_file = -1 ; CS%v_file = -1 ; CS%cols_written = 0
 

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -83,7 +83,7 @@ subroutine MOM_debugging_init(param_file)
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_debugging" ! This module's name.
 
-  call log_version(param_file, mdl, version)
+  call log_version(param_file, mdl, version, debugging=.true.)
   call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1478,7 +1478,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
                  do_not_log=.true.)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mdl, version)
+  call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "DIAG_EBT_MONO_N2_COLUMN_FRACTION", CS%mono_N2_column_fraction, &
                  "The lower fraction of water column over which N2 is limited as monotonic "// &
                  "for the purposes of calculating the equivalent barotropic wave speed.", &

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -246,6 +246,7 @@ subroutine close_param_file(CS, quiet_close, component)
   character(len=*), optional, intent(in) :: component   !< If present, this component name is used
                                          !! to generate parameter documentation file names
   ! Local variables
+  logical :: all_default
   character(len=128) :: docfile_default
   character(len=40)  :: mdl   ! This module's name.
   ! This include declares and sets the variable "version".
@@ -269,8 +270,18 @@ subroutine close_param_file(CS, quiet_close, component)
   endif ; endif
 
   ! Log the parameters for the parser.
+  docfile_default = "MOM_parameter_doc"
+  if (present(component)) docfile_default = trim(component)//"_parameter_doc"
+
+  all_default = (CS%log_to_stdout .eqv. log_to_stdout_default)
+  all_default = all_default .and. (trim(CS%doc_file) == trim(docfile_default))
+  if (len_trim(CS%doc_file) > 0) then
+    all_default = all_default .and. (CS%complete_doc .eqv. complete_doc_default)
+    all_default = all_default .and. (CS%minimal_doc .eqv. minimal_doc_default)
+  endif
+
   mdl = "MOM_file_parser"
-  call log_version(CS, mdl, version, "")
+  call log_version(CS, mdl, version, "", debugging=.true., log_to_all=.true., all_default=all_default)
   call log_param(CS, mdl, "SEND_LOG_TO_STDOUT", CS%log_to_stdout, &
                  "If true, all log messages are also sent to stdout.", &
                  default=log_to_stdout_default)
@@ -282,8 +293,6 @@ subroutine close_param_file(CS, quiet_close, component)
                  "If true, kill the run if there are any unused "//&
                  "parameters.", default=unused_params_fatal_default, &
                  debuggingParam=.true.)
-  docfile_default = "MOM_parameter_doc"
-  if (present(component)) docfile_default = trim(component)//"_parameter_doc"
   call log_param(CS, mdl, "DOCUMENT_FILE", CS%doc_file, &
                  "The basename for files where run-time parameters, their "//&
                  "settings, units and defaults are documented. Blank will "//&
@@ -1240,11 +1249,17 @@ end function overrideWarningHasBeenIssued
 
 !> Log the version of a module to a log file and/or stdout, and/or to the
 !! parameter documentation file.
-subroutine log_version_cs(CS, modulename, version, desc)
+subroutine log_version_cs(CS, modulename, version, desc, log_to_all, all_default, layout, debugging)
   type(param_file_type),      intent(in) :: CS         !< File parser type
   character(len=*),           intent(in) :: modulename !< Name of calling module
   character(len=*),           intent(in) :: version    !< Version string of module
   character(len=*), optional, intent(in) :: desc       !< Module description
+  logical,          optional, intent(in) :: log_to_all !< If present and true, log this parameter to the
+                                                       !! ..._doc.all files, even if this module also has layout
+                                                       !! or debugging parameters.
+  logical,          optional, intent(in) :: all_default !< If true, all parameters take their default values.
+  logical,          optional, intent(in) :: layout     !< If present and true, this module has layout parameters.
+  logical,          optional, intent(in) :: debugging  !< If present and true, this module has debugging parameters.
   ! Local variables
   character(len=240) :: mesg
 
@@ -1254,7 +1269,7 @@ subroutine log_version_cs(CS, modulename, version, desc)
     if (CS%log_to_stdout) write(CS%stdout,'(a)') trim(mesg)
   endif
 
-  if (present(desc)) call doc_module(CS%doc, modulename, desc)
+  if (present(desc)) call doc_module(CS%doc, modulename, desc, log_to_all, all_default, layout, debugging)
 
 end subroutine log_version_cs
 

--- a/src/framework/MOM_hor_index.F90
+++ b/src/framework/MOM_hor_index.F90
@@ -81,7 +81,7 @@ subroutine hor_index_init(Domain, HI, param_file, local_indexing, index_offset)
 
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, "MOM_hor_index", version, &
-                   "Sets the horizontal array index types.")
+                   "Sets the horizontal array index types.", all_default=.true.)
 
   HI%IscB = HI%isc ; HI%JscB = HI%jsc
   HI%IsdB = HI%isd ; HI%JsdB = HI%jsd

--- a/src/framework/MOM_unit_scaling.F90
+++ b/src/framework/MOM_unit_scaling.F90
@@ -75,7 +75,7 @@ subroutine unit_scaling_init( param_file, US )
   if (present(param_file)) then
     ! Read all relevant parameters and write them to the model log.
     call log_version(param_file, mdl, version, &
-                 "Parameters for doing unit scaling of variables.")
+                 "Parameters for doing unit scaling of variables.", debugging=.true.)
     call get_param(param_file, mdl, "Z_RESCALE_POWER", Z_power, &
                  "An integer power of 2 that is used to rescale the model's "//&
                  "internal units of depths and heights.  Valid values range from -300 to 300.", &

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1007,7 +1007,8 @@ logical function MEKE_init(Time, G, US, param_file, diag, CS, MEKE, restart_CS)
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   ! Determine whether this module will be used
-  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "USE_MEKE", MEKE_init, default=.false., do_not_log=.true.)
+  call log_version(param_file, mdl, version, "", all_default=.not.MEKE_init)
   call get_param(param_file, mdl, "USE_MEKE", MEKE_init, &
                  "If true, turns on the MEKE scheme which calculates "// &
                  "a sub-grid mesoscale eddy kinetic energy budget.", &

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -812,7 +812,9 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   integer :: i, j
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "MIXEDLAYER_RESTRAT", mixedlayer_restrat_init, &
+             default=.false., do_not_log=.true.)
+  call log_version(param_file, mdl, version, "", all_default=.not.mixedlayer_restrat_init)
   call get_param(param_file, mdl, "MIXEDLAYER_RESTRAT", mixedlayer_restrat_init, &
              "If true, a density-gradient dependent re-stratifying "//&
              "flow is imposed in the mixed layer. Can be used in ALE mode "//&

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -199,8 +199,9 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
            'Control structure has already been initialized')
 
   ! Read parameters
+  call get_param(paramFile, mdl, "USE_KPP", KPP_init, default=.false., do_not_log=.true.)
   call log_version(paramFile, mdl, version, 'This is the MOM wrapper to CVMix:KPP\n' // &
-            'See http://cvmix.github.io/')
+            'See http://cvmix.github.io/', all_default=.not.KPP_init)
   call get_param(paramFile, mdl, "USE_KPP", KPP_init, &
                  "If true, turns on the [CVMix] KPP scheme of Large et al., 1994, "// &
                  "to calculate diffusivities and non-local transport in the OBL.",     &

--- a/src/parameterizations/vertical/MOM_CVMix_conv.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_conv.F90
@@ -76,8 +76,10 @@ logical function CVMix_conv_init(Time, G, GV, US, param_file, diag, CS)
   allocate(CS)
 
   ! Read parameters
+  call get_param(param_file, mdl, "USE_CVMix_CONVECTION", CVMix_conv_init, default=.false., do_not_log=.true.)
   call log_version(param_file, mdl, version, &
-    "Parameterization of enhanced mixing due to convection via CVMix")
+           "Parameterization of enhanced mixing due to convection via CVMix", &
+           all_default=.not.CVMix_conv_init)
   call get_param(param_file, mdl, "USE_CVMix_CONVECTION", CVMix_conv_init, &
                  "If true, turns on the enhanced mixing due to convection "//&
                  "via CVMix. This scheme increases diapycnal diffs./viscs. "//&

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -79,8 +79,10 @@ logical function CVMix_ddiff_init(Time, G, GV, US, param_file, diag, CS)
   allocate(CS)
 
   ! Read parameters
+  call get_param(param_file, mdl, "USE_CVMIX_DDIFF", CVMix_ddiff_init, default=.false., do_not_log=.true.)
   call log_version(param_file, mdl, version, &
-    "Parameterization of mixing due to double diffusion processes via CVMix")
+           "Parameterization of mixing due to double diffusion processes via CVMix", &
+           all_default=.not.CVMix_ddiff_init)
   call get_param(param_file, mdl, "USE_CVMIX_DDIFF", CVMix_ddiff_init, &
                  "If true, turns on double diffusive processes via CVMix. "//&
                  "Note that double diffusive processes on viscosity are ignored "//&

--- a/src/parameterizations/vertical/MOM_CVMix_shear.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_shear.F90
@@ -221,8 +221,11 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
   allocate(CS)
 
 ! Set default, read and log parameters
+  call get_param(param_file, mdl, "USE_LMD94", CS%use_LMD94, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "USE_PP81", CS%use_PP81, default=.false., do_not_log=.true.)
   call log_version(param_file, mdl, version, &
-    "Parameterization of shear-driven turbulence via CVMix (various options)")
+           "Parameterization of shear-driven turbulence via CVMix (various options)", &
+            all_default=.not.(CS%use_PP81.or.CS%use_LMD94))
   call get_param(param_file, mdl, "USE_LMD94", CS%use_LMD94, &
                  "If true, use the Large-McWilliams-Doney (JGR 1994) "//&
                  "shear mixing parameterization.", default=.false.)

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -3438,7 +3438,7 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
                  "BULKMIXEDLAYER is true.", units="nondim", default=2)
   call get_param(param_file, mdl, "MSTAR", CS%mstar, &
                  "The ratio of the friction velocity cubed to the TKE "//&
-                 "input to the mixed layer.", "units=nondim", default=1.2)
+                 "input to the mixed layer.", units="nondim", default=1.2)
   call get_param(param_file, mdl, "NSTAR", CS%nstar, &
                  "The portion of the buoyant potential energy imparted by "//&
                  "surface fluxes that is available to drive entrainment "//&

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -3223,7 +3223,8 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
   ! Set default, read and log parameters
   call log_version(param_file, mdl, version, &
-                   "The following parameters are used for diabatic processes.")
+                   "The following parameters are used for diabatic processes.", &
+                   log_to_all=.true., debugging=.true.)
   call get_param(param_file, mdl, "USE_LEGACY_DIABATIC_DRIVER", CS%use_legacy_diabatic, &
                  "If true, use a legacy version of the diabatic subroutine. "//&
                  "This is temporary and is needed to avoid change in answers.", &

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -191,7 +191,7 @@ type, public :: energetic_PBL_CS ; private
     Velocity_Scale, & !< The velocity scale used in getting Kd [Z T-1 ~> m s-1]
     Mixing_Length     !< The length scale used in getting Kd [Z ~> m]
   !>@{ Diagnostic IDs
-  integer :: id_ML_depth = -1, id_TKE_wind = -1, id_TKE_mixing = -1
+  integer :: id_ML_depth = -1, id_hML_depth = -1, id_TKE_wind = -1, id_TKE_mixing = -1
   integer :: id_TKE_MKE = -1, id_TKE_conv = -1, id_TKE_forcing = -1
   integer :: id_TKE_mech_decay = -1, id_TKE_conv_decay = -1
   integer :: id_Mixing_Length = -1, id_Velocity_Scale = -1
@@ -515,6 +515,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
 
   if (write_diags) then
     if (CS%id_ML_depth > 0) call post_data(CS%id_ML_depth, CS%ML_depth, CS%diag)
+    if (CS%id_hML_depth > 0) call post_data(CS%id_hML_depth, CS%ML_depth, CS%diag)
     if (CS%id_TKE_wind > 0) call post_data(CS%id_TKE_wind, CS%diag_TKE_wind, CS%diag)
     if (CS%id_TKE_MKE > 0)  call post_data(CS%id_TKE_MKE, CS%diag_TKE_MKE, CS%diag)
     if (CS%id_TKE_conv > 0) call post_data(CS%id_TKE_conv, CS%diag_TKE_conv, CS%diag)
@@ -2347,6 +2348,9 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
   CS%id_ML_depth = register_diag_field('ocean_model', 'ePBL_h_ML', diag%axesT1, &
       Time, 'Surface boundary layer depth', 'm', conversion=US%Z_to_m, &
       cmor_long_name='Ocean Mixed Layer Thickness Defined by Mixing Scheme')
+  ! This is an alias for the same variable as ePBL_h_ML
+  CS%id_hML_depth = register_diag_field('ocean_model', 'h_ML', diag%axesT1, &
+      Time, 'Surface mixed layer depth based on active turbulence', 'm', conversion=US%Z_to_m)
   CS%id_TKE_wind = register_diag_field('ocean_model', 'ePBL_TKE_wind', diag%axesT1, &
       Time, 'Wind-stirring source of mixed layer TKE', 'W m-2', conversion=US%RZ3_T3_to_W_m2)
   CS%id_TKE_MKE = register_diag_field('ocean_model', 'ePBL_TKE_MKE', diag%axesT1, &

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -109,10 +109,8 @@ subroutine regularize_layers(h, tv, dt, ea, eb, G, GV, US, CS)
   if (.not. associated(CS)) call MOM_error(FATAL, "MOM_regularize_layers: "//&
          "Module must be initialized before it is used.")
 
-  if (CS%regularize_surface_layers) &
-    call pass_var(h, G%Domain, clock=id_clock_pass)
-
   if (CS%regularize_surface_layers) then
+    call pass_var(h, G%Domain, clock=id_clock_pass)
     call regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
   endif
 
@@ -891,6 +889,7 @@ subroutine regularize_layers_init(Time, G, GV, param_file, diag, CS)
   character(len=40)  :: mdl = "MOM_regularize_layers"  ! This module's name.
   logical :: use_temperature
   logical :: default_2018_answers
+  logical :: just_read
   integer :: isd, ied, jsd, jed
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
@@ -904,38 +903,42 @@ subroutine regularize_layers_init(Time, G, GV, param_file, diag, CS)
   CS%Time => Time
 
 ! Set default, read and log parameters
-  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "REGULARIZE_SURFACE_LAYERS", CS%regularize_surface_layers, &
+                 default=.false., do_not_log=.true.)
+  call log_version(param_file, mdl, version, "", all_default=.not.CS%regularize_surface_layers)
   call get_param(param_file, mdl, "REGULARIZE_SURFACE_LAYERS", CS%regularize_surface_layers, &
                  "If defined, vertically restructure the near-surface "//&
                  "layers when they have too much lateral variations to "//&
                  "allow for sensible lateral barotropic transports.", &
                  default=.false.)
+  just_read = .not.CS%regularize_surface_layers
   if (CS%regularize_surface_layers) then
     call get_param(param_file, mdl, "REGULARIZE_SURFACE_DETRAIN", CS%reg_sfc_detrain, &
                  "If true, allow the buffer layers to detrain into the "//&
                  "interior as a part of the restructuring when "//&
-                 "REGULARIZE_SURFACE_LAYERS is true.", default=.true.)
-  call get_param(param_file, mdl, "REG_SFC_DENSE_MATCH_TOLERANCE", CS%density_match_tol, &
+                 "REGULARIZE_SURFACE_LAYERS is true.", default=.true., do_not_log=just_read)
+    call get_param(param_file, mdl, "REG_SFC_DENSE_MATCH_TOLERANCE", CS%density_match_tol, &
                  "A relative tolerance for how well the densities must match with the target "//&
                  "densities during detrainment when regularizing the near-surface layers.  The "//&
-                 "default of 0.6 gives 20% overlaps in density", units="nondim", default=0.6)
+                 "default of 0.6 gives 20% overlaps in density", &
+                 units="nondim", default=0.6, do_not_log=just_read)
     call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=.false.)
+                 default=.false., do_not_log=just_read)
     call get_param(param_file, mdl, "REGULARIZE_LAYERS_2018_ANSWERS", CS%answers_2018, &
-                 "If true, use the order of arithmetic and expressions that recover the "//&
-                 "answers from the end of 2018.  Otherwise, use updated and more robust "//&
-                 "forms of the same expressions.", default=default_2018_answers)
+                 "If true, use the order of arithmetic and expressions that recover the answers "//&
+                 "from the end of 2018.  Otherwise, use updated and more robust forms of the "//&
+                 "same expressions.", default=default_2018_answers, do_not_log=just_read)
   endif
 
   call get_param(param_file, mdl, "HMIX_MIN", CS%Hmix_min, &
-                 "The minimum mixed layer depth if the mixed layer depth "//&
-                 "is determined dynamically.", units="m", default=0.0, scale=GV%m_to_H)
+                 "The minimum mixed layer depth if the mixed layer depth is determined "//&
+                 "dynamically.", units="m", default=0.0, scale=GV%m_to_H, do_not_log=just_read)
   call get_param(param_file, mdl, "REG_SFC_DEFICIT_TOLERANCE", CS%h_def_tol1, &
                  "The value of the relative thickness deficit at which "//&
                  "to start modifying the layer structure when "//&
                  "REGULARIZE_SURFACE_LAYERS is true.", units="nondim", &
-                 default=0.5)
+                 default=0.5, do_not_log=just_read)
   CS%h_def_tol2 = 0.2 + 0.8*CS%h_def_tol1
   CS%h_def_tol3 = 0.3 + 0.7*CS%h_def_tol1
   CS%h_def_tol4 = 0.5 + 0.5*CS%h_def_tol1
@@ -943,12 +946,14 @@ subroutine regularize_layers_init(Time, G, GV, param_file, diag, CS)
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
 !  if (.not. CS%debug) &
 !    call get_param(param_file, mdl, "DEBUG_CONSERVATION", CS%debug, &
-!                 "If true, monitor conservation and extrema.", default=.false.)
+!                 "If true, monitor conservation and extrema.", default=.false., do_not_log=just_read)
 
   call get_param(param_file, mdl, "ALLOW_CLOCKS_IN_OMP_LOOPS", CS%allow_clocks_in_omp_loops, &
                  "If true, clocks can be called from inside loops that can "//&
                  "be threaded. To run with multiple threads, set to False.", &
-                 default=.true.)
+                 default=.true., do_not_log=just_read)
+
+  if (.not.CS%regularize_surface_layers) return
 
   CS%id_def_rat = register_diag_field('ocean_model', 'deficit_ratio', diag%axesT1, &
       Time, 'Max face thickness deficit ratio', 'nondim')

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -1982,7 +1982,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
                  "mixed layer code. This is only used if ML_RADIATION is true.", default=.true.)
     call get_param(param_file, mdl, "MSTAR", CS%mstar, &
                  "The ratio of the friction velocity cubed to the TKE "//&
-                 "input to the mixed layer.", "units=nondim", default=1.2)
+                 "input to the mixed layer.", units="nondim", default=1.2)
     call get_param(param_file, mdl, "TKE_DECAY", CS%TKE_decay, &
                  "The ratio of the natural Ekman depth to the TKE decay scale.", &
                  units="nondim", default=2.5)

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -249,8 +249,13 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, CS)
   CS%diag => diag
 
   ! Read parameters
+  call get_param(param_file, mdl, "USE_CVMix_TIDAL", CS%use_CVMix_tidal, &
+                 default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "INT_TIDE_DISSIPATION", CS%int_tide_dissipation, &
+                 default=CS%use_CVMix_tidal, do_not_log=.true.)
   call log_version(param_file, mdl, version, &
-    "Vertical Tidal Mixing Parameterization")
+                 "Vertical Tidal Mixing Parameterization", &
+                 all_default=.not.(CS%use_CVMix_tidal .or. CS%int_tide_dissipation))
   call get_param(param_file, mdl, "USE_CVMix_TIDAL", CS%use_CVMix_tidal, &
                  "If true, turns on tidal mixing via CVMix", &
                  default=.false.)

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1571,7 +1571,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
   CS%diag => diag ; CS%ntrunc => ntrunc ; ntrunc = 0
 
 ! Default, read and log parameters
-  call log_version(param_file, mdl, version, "")
+  call log_version(param_file, mdl, version, "", log_to_all=.true., debugging=.true.)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=.false.)

--- a/src/tracer/MOM_lateral_boundary_diffusion.F90
+++ b/src/tracer/MOM_lateral_boundary_diffusion.F90
@@ -80,15 +80,16 @@ logical function lateral_boundary_diffusion_init(Time, G, param_file, diag, diab
   endif
 
   ! Log this module and master switch for turning it on/off
+  call get_param(param_file, mdl, "USE_LATERAL_BOUNDARY_DIFFUSION", lateral_boundary_diffusion_init, &
+                 default=.false., do_not_log=.true.)
   call log_version(param_file, mdl, version, &
-       "This module implements lateral diffusion of tracers near boundaries")
+           "This module implements lateral diffusion of tracers near boundaries", &
+           all_default=.not.lateral_boundary_diffusion_init)
   call get_param(param_file, mdl, "USE_LATERAL_BOUNDARY_DIFFUSION", lateral_boundary_diffusion_init, &
                  "If true, enables the lateral boundary tracer's diffusion module.", &
                  default=.false.)
 
-  if (.not. lateral_boundary_diffusion_init) then
-    return
-  endif
+  if (.not. lateral_boundary_diffusion_init) return
 
   allocate(CS)
   CS%diag => diag

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -134,17 +134,17 @@ logical function neutral_diffusion_init(Time, G, US, param_file, diag, EOS, diab
     return
   endif
 
-
   ! Log this module and master switch for turning it on/off
+  call get_param(param_file, mdl, "USE_NEUTRAL_DIFFUSION", neutral_diffusion_init, &
+                 default=.false., do_not_log=.true.)
   call log_version(param_file, mdl, version, &
-       "This module implements neutral diffusion of tracers")
+           "This module implements neutral diffusion of tracers", &
+           all_default=.not.neutral_diffusion_init)
   call get_param(param_file, mdl, "USE_NEUTRAL_DIFFUSION", neutral_diffusion_init, &
                  "If true, enables the neutral diffusion module.", &
                  default=.false.)
 
-  if (.not.neutral_diffusion_init) then
-    return
-  endif
+  if (.not.neutral_diffusion_init) return
 
   allocate(CS)
   CS%diag => diag

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -382,7 +382,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
   real, dimension(SZIB_(G)) :: &
     hlst, &             ! Work variable [H L2 ~> m3 or kg].
     Ihnew, &            ! Work variable [H-1 L-2 ~> m-3 or kg-1].
-    CFL                 ! A nondimensional work variable [nondim].
+    CFL                 ! The absolute value of the advective upwind-cell CFL number [nondim].
   real :: min_h         ! The minimum thickness that can be realized during
                         ! any of the passes [H ~> m or kg m-2].
   real :: h_neglect     ! A thickness that is so small it is usually lost
@@ -757,7 +757,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
   real, dimension(SZIB_(G)) :: &
     hlst, &             ! Work variable [H L2 ~> m3 or kg].
     Ihnew, &            ! Work variable [H-1 L-2 ~> m-3 or kg-1].
-    CFL                 ! A nondimensional work variable.
+    CFL                 ! The absolute value of the advective upwind-cell CFL number [nondim].
   real :: min_h         ! The minimum thickness that can be realized during
                         ! any of the passes [H ~> m or kg m-2].
   real :: h_neglect     ! A thickness that is so small it is usually lost

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -220,8 +220,8 @@ subroutine adjustment_initialize_temperature_salinity(T, S, h, G, GV, param_file
   just_read = .false. ; if (present(just_read_params)) just_read = just_read_params
 
   ! Parameters used by main model initialization
-  call get_param(param_file, mdl,"S_REF",S_ref,'Reference salinity', units='1e-3', &
-                 fail_if_missing=.not.just_read, do_not_log=just_read)
+  call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
+                 default=35.0, units='1e-3', do_not_log=just_read)
   call get_param(param_file, mdl,"T_REF",T_ref,'Reference temperature', units='C', &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl,"S_RANGE",S_range,'Initial salinity range', units='1e-3', &


### PR DESCRIPTION
  This PR consists of a set of changes to improve the logging of modules to
the various MOM_parameter_doc files, including moving the halo size parameters
from the doc.debugging to the doc.all files, and avoiding the logging of
parameters that are specific to unused modules, although they are still being
read to avoid triggering issues if FATAL_UNUSED_PARAMS is true.  The commits
that are including in this PR include:

- NOAA-GFDL/MOM6@f5dfef8 +Do not log parameters from unused modules
- NOAA-GFDL/MOM6@85b784d +Do not log modules to parameter_doc.short files
- NOAA-GFDL/MOM6@cf80f4b +Log modules to parameter_doc.debug files
- NOAA-GFDL/MOM6@5a807f6 +Record halo sizes in MOM_parameter_doc.all files
- NOAA-GFDL/MOM6@b4d3c15 +Add 4 optional args to log_version & doc_module
