### PR TITLE
*Fix frazil restarts (corrects bug from PR#1102)

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2665,7 +2665,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   call register_obsolete_diagnostics(param_file, CS%diag)
 
   if (use_frazil) then
-    if (.not.query_initialized(CS%tv%frazil,"frazil",restart_CSp)) then
+    if (query_initialized(CS%tv%frazil, "frazil", restart_CSp)) then
       ! Test whether the dimensional rescaling has changed for heat content.
       if ((US%kg_m3_to_R_restart*US%m_to_Z_restart*US%J_kg_to_Q_restart /= 0.0) .and. &
           ((US%J_kg_to_Q*US%kg_m3_to_R*US%m_to_Z) /= &


### PR DESCRIPTION
  Corrected a bug which causes frazil to be zeroed out during restarts.  This
will change answers in long coupled or ice-ocean runs, but not in the short
MOM6-examples test suite.  This bug was introduced to MOM6 on April 30, 2020
with PR#1102. The answers and documentation files in MOM6-examples are
unchanged.  This PR was tested for restarts, but it used the Baltic test case
and happened to use a day where the frazil was zero everywhere in this limited
test case.  Other test cases should be expected to change answers with every
restart, leading to a small net long-term heat gain in the coupled system.