### PR TITLE
FMS2020.01 "runtime required" but optional argument to diag_axis_init

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing.F90
@@ -1413,9 +1413,7 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS)
   call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
                  "If true, allows flux adjustments to specified via the \n"//&
                  "data_table using the component name 'OCN'.", default=.false.)
-  if (CS%allow_flux_adjustments) then
-    call data_override_init(Ocean_domain_in=G%Domain%mpp_domain)
-  endif
+  call data_override_init(Ocean_domain_in=G%Domain%mpp_domain)
 
   if (CS%restore_salt) then
     salt_file = trim(CS%inputdir) // trim(CS%salt_restore_file)

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -30,7 +30,7 @@ use MOM_diag_remap,       only : horizontally_average_diag_field
 use diag_axis_mod, only : get_diag_axis_name
 use diag_data_mod, only : null_axis_id
 use diag_manager_mod, only : diag_manager_init, diag_manager_end
-use diag_manager_mod, only : send_data, diag_axis_init, diag_field_add_attribute
+use diag_manager_mod, only : send_data, diag_axis_init, EAST, NORTH, diag_field_add_attribute
 ! The following module is needed for PGI since the following line does not compile with PGI 6.5.0
 ! was: use diag_manager_mod, only : register_diag_field_fms=>register_diag_field
 use MOM_diag_manager_wrapper, only : register_diag_field_fms
@@ -257,14 +257,14 @@ subroutine set_axes_info(G, GV, param_file, diag_cs, set_vertical)
 
   if (G%symmetric) then
     id_xq = diag_axis_init('xq', G%gridLonB(G%isgB:G%iegB), G%x_axis_units, 'x', &
-              'q point nominal longitude', Domain2=G%Domain%mpp_domain)
+              'q point nominal longitude', Domain2=G%Domain%mpp_domain, domain_position=EAST)
     id_yq = diag_axis_init('yq', G%gridLatB(G%jsgB:G%jegB), G%y_axis_units, 'y', &
-              'q point nominal latitude', Domain2=G%Domain%mpp_domain)
+              'q point nominal latitude', Domain2=G%Domain%mpp_domain, domain_position=NORTH)
   else
     id_xq = diag_axis_init('xq', G%gridLonB(G%isg:G%ieg), G%x_axis_units, 'x', &
-              'q point nominal longitude', Domain2=G%Domain%mpp_domain)
+              'q point nominal longitude', Domain2=G%Domain%mpp_domain, domain_position=EAST)
     id_yq = diag_axis_init('yq', G%gridLatB(G%jsg:G%jeg), G%y_axis_units, 'y', &
-              'q point nominal latitude', Domain2=G%Domain%mpp_domain)
+              'q point nominal latitude', Domain2=G%Domain%mpp_domain, domain_position=NORTH)
   endif
   id_xh = diag_axis_init('xh', G%gridLonT(G%isg:G%ieg), G%x_axis_units, 'x', &
               'h point nominal longitude', Domain2=G%Domain%mpp_domain)

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -62,8 +62,9 @@ type field_restart
   character(len=32) :: var_name !< A name by which a variable may be queried.
 end type field_restart
 
+!> A structure to store information about restart fields that are no longer used
 type obsolete_restart
-   character(len=32) :: field_name    !< Name of restart field that is no longer in use
+   character(len=32) :: field_name       !< Name of restart field that is no longer in use
    character(len=32) :: replacement_name !< Name of replacement restart field, if applicable
 end type obsolete_restart
 
@@ -124,9 +125,9 @@ end interface
 contains
 !!> Register a restart field as obsolete
 subroutine register_restart_field_as_obsolete(field_name, replacement_name, CS)
-  character(len=32), intent(in) :: field_name    !< Name of restart field that is no longer in use
-  character(len=32), intent(in) :: replacement_name !< Name of replacement restart field, if applicable
-  type(MOM_restart_CS), pointer :: CS        !< A pointer to a MOM_restart_CS object (intent in/out)
+  character(*), intent(in) :: field_name       !< Name of restart field that is no longer in use
+  character(*), intent(in) :: replacement_name !< Name of replacement restart field, if applicable
+  type(MOM_restart_CS), pointer :: CS          !< A pointer to a MOM_restart_CS object (intent in/out)
 
   CS%num_obsolete_vars = CS%num_obsolete_vars+1
   CS%restart_obsolete(CS%num_obsolete_vars)%field_name = field_name
@@ -1083,13 +1084,14 @@ subroutine restore_state(filename, directory, day, G, CS)
     call get_file_fields(unit(n),fields(1:nvar))
 
     do m=1, nvar
-      call get_file_atts(fields(i),name=varname)
+      call get_file_atts(fields(m),name=varname)
       do i=1,CS%num_obsolete_vars
-        if (lowercase(trim(varname)) == lowercase(trim(CS%restart_obsolete(i)%field_name))) then
+        if (adjustl(lowercase(trim(varname))) == adjustl(lowercase(trim(CS%restart_obsolete(i)%field_name)))) then
             call MOM_error(FATAL, "MOM_restart restore_state: Attempting to use obsolete restart field "//&
-                           trim(varname))
+                           trim(varname)//" - the new corresponding restart field is "//&
+                           trim(CS%restart_obsolete(i)%replacement_name))
         endif
-      enddo 
+      enddo
     enddo
 
     missing_fields = 0

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -25,6 +25,7 @@ implicit none ; private
 public restart_init, restart_end, restore_state, register_restart_field
 public save_restart, query_initialized, restart_init_end, vardesc
 public restart_files_exist, determine_is_new_run, is_new_run
+public register_restart_field_as_obsolete
 
 !> A type for making arrays of pointers to 4-d arrays
 type p4d
@@ -61,11 +62,17 @@ type field_restart
   character(len=32) :: var_name !< A name by which a variable may be queried.
 end type field_restart
 
+type obsolete_restart
+   character(len=32) :: field_name    !< Name of restart field that is no longer in use
+   character(len=32) :: replacement_name !< Name of replacement restart field, if applicable
+end type obsolete_restart
+
 !> A restart registry and the control structure for restarts
 type, public :: MOM_restart_CS ; private
   logical :: restart    !< restart is set to .true. if the run has been started from a full restart
                         !! file.  Otherwise some fields must be initialized approximately.
   integer :: novars = 0 !< The number of restart fields that have been registered.
+  integer :: num_obsolete_vars = 0  !< The number of obsolete restart fields that have been registered.
   logical :: parallel_restartfiles  !< If true, each PE writes its own restart file,
                                     !! otherwise they are combined internally.
   logical :: large_file_support     !< If true, NetCDF 3.6 or later is being used
@@ -81,6 +88,9 @@ type, public :: MOM_restart_CS ; private
 
   !> An array of descriptions of the registered fields
   type(field_restart), pointer :: restart_field(:) => NULL()
+
+  !> An array of obsolete restart fields
+  type(obsolete_restart), pointer :: restart_obsolete(:) => NULL()
 
   !>@{ Pointers to the fields that have been registered for restarts
   type(p0d), pointer :: var_ptr0d(:) => NULL()
@@ -112,6 +122,16 @@ interface query_initialized
 end interface
 
 contains
+!!> Register a restart field as obsolete
+subroutine register_restart_field_as_obsolete(field_name, replacement_name, CS)
+  character(len=32), intent(in) :: field_name    !< Name of restart field that is no longer in use
+  character(len=32), intent(in) :: replacement_name !< Name of replacement restart field, if applicable
+  type(MOM_restart_CS), pointer :: CS        !< A pointer to a MOM_restart_CS object (intent in/out)
+
+  CS%num_obsolete_vars = CS%num_obsolete_vars+1
+  CS%restart_obsolete(CS%num_obsolete_vars)%field_name = field_name
+  CS%restart_obsolete(CS%num_obsolete_vars)%replacement_name = replacement_name
+end subroutine register_restart_field_as_obsolete
 
 !> Register a 3-d field for restarts, providing the metadata in a structure
 subroutine register_restart_field_ptr3d(f_ptr, var_desc, mandatory, CS)
@@ -1062,6 +1082,16 @@ subroutine restore_state(filename, directory, day, G, CS)
     allocate(fields(nvar))
     call get_file_fields(unit(n),fields(1:nvar))
 
+    do m=1, nvar
+      call get_file_atts(fields(i),name=varname)
+      do i=1,CS%num_obsolete_vars
+        if (lowercase(trim(varname)) == lowercase(trim(CS%restart_obsolete(i)%field_name))) then
+            call MOM_error(FATAL, "MOM_restart restore_state: Attempting to use obsolete restart field "//&
+                           trim(varname))
+        endif
+      enddo 
+    enddo
+
     missing_fields = 0
 
     do m=1,CS%novars
@@ -1433,6 +1463,7 @@ subroutine restart_init(param_file, CS, restart_root)
                  default=.true.)
 
   allocate(CS%restart_field(CS%max_fields))
+  allocate(CS%restart_obsolete(CS%max_fields))
   allocate(CS%var_ptr0d(CS%max_fields))
   allocate(CS%var_ptr1d(CS%max_fields))
   allocate(CS%var_ptr2d(CS%max_fields))
@@ -1456,6 +1487,7 @@ subroutine restart_end(CS)
   type(MOM_restart_CS),  pointer    :: CS !< A pointer to a MOM_restart_CS object
 
   if (associated(CS%restart_field)) deallocate(CS%restart_field)
+  if (associated(CS%restart_obsolete)) deallocate(CS%restart_obsolete)
   if (associated(CS%var_ptr0d)) deallocate(CS%var_ptr0d)
   if (associated(CS%var_ptr1d)) deallocate(CS%var_ptr1d)
   if (associated(CS%var_ptr2d)) deallocate(CS%var_ptr2d)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -18,7 +18,8 @@ use MOM_kappa_shear, only : kappa_shear_is_used, kappa_shear_at_vertex
 use MOM_cvmix_shear, only : cvmix_shear_is_used
 use MOM_cvmix_conv,  only : cvmix_conv_is_used
 use MOM_CVMix_ddiff, only : CVMix_ddiff_is_used
-use MOM_restart, only : register_restart_field, MOM_restart_CS
+use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
+use MOM_restart, only : register_restart_field_as_obsolete
 use MOM_safe_alloc, only : safe_alloc_ptr, safe_alloc_alloc
 use MOM_variables, only : thermo_var_ptrs
 use MOM_variables, only : vertvisc_type
@@ -1746,6 +1747,9 @@ subroutine set_visc_register_restarts(HI, GV, param_file, visc, restart_CS)
                  "layer scheme to determine the diffusivity and viscosity \n"//&
                  "in the surface boundary layer.", default=.false., do_not_log=.true.)
   endif
+
+  call register_restart_field_as_obsolete('Kd_turb','Kd_shear', restart_CS)
+  call register_restart_field_as_obsolete('Kv_turb','Kv_shear', restart_CS)
 
   if (use_kappa_shear .or. useKPP .or. useEPBL .or. use_CVMix_shear .or. use_CVMix_conv) then
     call safe_alloc_ptr(visc%Kd_shear, isd, ied, jsd, jed, nz+1)


### PR DESCRIPTION
diag_axis_init has a new optional argument to specify the corner location of the diagnostics on the grid. 
Although these are optional args the model would crash if it sends such corner diagnostics without passing the appropriate optional argument to diag_axis_init.