### PR TITLE
(*)Corrected halo size in EOS call if VERTEX_SHEAR=T

### DIFF
--- a/src/parameterizations/vertical/MOM_full_convection.F90
+++ b/src/parameterizations/vertical/MOM_full_convection.F90
@@ -408,7 +408,7 @@ subroutine smoothed_dRdT_dRdS(h, tv, Kddt, dR_dT, dR_dS, G, GV, US, j, p_surf, h
   else
     do i=is,ie ; pres(i) = 0.0 ; enddo
   endif
-  EOSdom(:) = EOS_domain(G%HI)
+  EOSdom(:) = EOS_domain(G%HI, halo)
   call calculate_density_derivs(T_f(:,1), S_f(:,1), pres, dR_dT(:,1), dR_dS(:,1), tv%eqn_of_state, EOSdom)
   do i=is,ie ; pres(i) = pres(i) + h(i,j,1)*(GV%H_to_RZ*GV%g_Earth) ; enddo
   do K=2,nz


### PR DESCRIPTION
  Corrected halo size in density derivative calculations in smoothed_dRdT_dRdS
This fixes an i-parallelization problem that was recently introduced (as a part
of MOM6 PR #1089) when VERTEX_SHEAR is True, and closes MOM6 issue #1146.  All
answers in the existing MOM6-examples test suite are bitwise identical, but this
does change (correct) answers when VERTEX_SHEAR is true. 