### PR TITLE
Removed #ifdef debugging blocks

### DIFF
--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -627,7 +627,6 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
   real :: LangEnhK     ! Langmuir enhancement for mixing coefficient
 
 
-#ifdef __DO_SAFETY_CHECKS__
   if (CS%debug) then
     call hchksum(h, "KPP in: h",G%HI,haloshift=0, scale=GV%H_to_m)
     call hchksum(uStar, "KPP in: uStar",G%HI,haloshift=0, scale=US%Z_to_m*US%s_to_T)
@@ -635,7 +634,6 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
     call hchksum(Kt, "KPP in: Kt",G%HI,haloshift=0, scale=US%Z2_T_to_m2_s)
     call hchksum(Ks, "KPP in: Ks",G%HI,haloshift=0, scale=US%Z2_T_to_m2_s)
   endif
-#endif
 
   nonLocalTrans(:,:) = 0.0
 
@@ -862,12 +860,10 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
   enddo ! j
 
 
-#ifdef __DO_SAFETY_CHECKS__
   if (CS%debug) then
     call hchksum(Kt, "KPP out: Kt", G%HI, haloshift=0, scale=US%Z2_T_to_m2_s)
     call hchksum(Ks, "KPP out: Ks", G%HI, haloshift=0, scale=US%Z2_T_to_m2_s)
   endif
-#endif
 
   ! send diagnostics to post_data
   if (CS%id_OBLdepth > 0) call post_data(CS%id_OBLdepth, CS%OBLdepth,        CS%diag)
@@ -952,14 +948,12 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   real :: WST
 
 
-#ifdef __DO_SAFETY_CHECKS__
   if (CS%debug) then
     call hchksum(Salt, "KPP in: S",G%HI,haloshift=0)
     call hchksum(Temp, "KPP in: T",G%HI,haloshift=0)
     call hchksum(u, "KPP in: u",G%HI,haloshift=0)
     call hchksum(v, "KPP in: v",G%HI,haloshift=0)
   endif
-#endif
 
   ! some constants
   GoRho = US%L_T_to_m_s**2*US%m_to_Z * GV%g_Earth / GV%Rho0

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -19,9 +19,6 @@ use MOM_EOS, only : calculate_density_derivs
 implicit none ; private
 
 #include <MOM_memory.h>
-#ifdef use_netCDF
-#include <netcdf.inc>
-#endif
 
 public Calculate_kappa_shear, Calc_kappa_shear_vertex, kappa_shear_init
 public kappa_shear_is_used, kappa_shear_at_vertex
@@ -99,9 +96,6 @@ end type Kappa_shear_CS
 
 ! integer :: id_clock_project, id_clock_KQ, id_clock_avg, id_clock_setup
 
-#undef  DEBUG
-#undef  ADD_DIAGNOSTICS
-
 contains
 
 !> Subroutine for calculating shear-driven diffusivity and TKE in tracer columns
@@ -177,15 +171,6 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
                         ! interpolating back to the original index space [nondim].
   integer :: is, ie, js, je, i, j, k, nz, nzc
 
-  ! Diagnostics that should be deleted?
-#ifdef ADD_DIAGNOSTICS
-  real, dimension(SZK_(GV)+1) :: &  ! Additional diagnostics.
-    I_Ld2_1d, dz_Int_1d
-  real, dimension(SZI_(G),SZK_(GV)+1) :: & ! 2-D versions of diagnostics.
-    I_Ld2_2d, dz_Int_2d
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: & ! 3-D versions of diagnostics.
-    I_Ld2_3d, dz_Int_3d
-#endif
   is = G%isc ; ie = G%iec; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   use_temperature = .false. ; if (associated(tv%T)) use_temperature = .true.
@@ -195,9 +180,6 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
   dz_massless = 0.1*sqrt(k0dt)
 
   !$OMP parallel do default(private) shared(js,je,is,ie,nz,h,u_in,v_in,use_temperature,new_kappa, &
-#ifdef ADD_DIAGNOSTICS
-  !$OMP                                I_Ld2_3d,dz_Int_3d, &
-#endif
   !$OMP                                tv,G,GV,US,CS,kappa_io,dz_massless,k0dt,p_surf,dt,tke_io,kv_io)
   do j=js,je
     do k=1,nz ; do i=is,ie
@@ -295,15 +277,9 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
         do K=1,nzc+1 ; kappa(K) = kappa_2d(i,K) ; enddo
       endif
 
-#ifdef ADD_DIAGNOSTICS
-      call kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
-                              dz, u0xdz, v0xdz, T0xdz, S0xdz, kappa_avg, &
-                              tke_avg, tv, CS, GV, US, I_Ld2_1d, dz_Int_1d)
-#else
       call kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
                               dz, u0xdz, v0xdz, T0xdz, S0xdz, kappa_avg, &
                               tke_avg, tv, CS, GV, US)
-#endif
 
     ! call cpu_clock_begin(id_clock_setup)
     ! Extrapolate from the vertically reduced grid back to the original layers.
@@ -329,18 +305,10 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
           endif
         enddo
       endif
-#ifdef ADD_DIAGNOSTICS
-      do K=1,nz+1
-        I_Ld2_2d(i,K) = I_Ld2_1d(K) ; dz_Int_2d(i,K) = dz_Int_1d(K)
-      enddo
-#endif
     ! call cpu_clock_end(id_clock_setup)
     else  ! Land points, still inside the i-loop.
       do K=1,nz+1
         kappa_2d(i,K) = 0.0 ; tke_2d(i,K) = 0.0
-#ifdef ADD_DIAGNOSTICS
-        I_Ld2_2d(i,K) = 0.0  ; dz_Int_2d(i,K) = 0.0
-#endif
       enddo
     endif ; enddo ! i-loop
 
@@ -348,9 +316,6 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
       kappa_io(i,j,K) = G%mask2dT(i,j) * kappa_2d(i,K)
       tke_io(i,j,K) = G%mask2dT(i,j) * tke_2d(i,K)
       kv_io(i,j,K) = ( G%mask2dT(i,j) * kappa_2d(i,K) ) * CS%Prandtl_turb
-#ifdef ADD_DIAGNOSTICS
-      I_Ld2_3d(i,j,K) = I_Ld2_2d(i,K) ; dz_Int_3d(i,j,K) = dz_Int_2d(i,K)
-#endif
     enddo ; enddo
 
   enddo ! end of j-loop
@@ -362,10 +327,6 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
 
   if (CS%id_Kd_shear > 0) call post_data(CS%id_Kd_shear, kappa_io, CS%diag)
   if (CS%id_TKE > 0) call post_data(CS%id_TKE, tke_io, CS%diag)
-#ifdef ADD_DIAGNOSTICS
-  if (CS%id_ILd2 > 0) call post_data(CS%id_ILd2, I_Ld2_3d, CS%diag)
-  if (CS%id_dz_Int > 0) call post_data(CS%id_dz_Int, dz_Int_3d, CS%diag)
-#endif
 
 end subroutine Calculate_kappa_shear
 
@@ -451,14 +412,6 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
   integer :: IsB, IeB, JsB, JeB, i, j, k, nz, nzc, J2, J2m1
 
   ! Diagnostics that should be deleted?
-#ifdef ADD_DIAGNOSTICS
-  real, dimension(SZK_(GV)+1) :: &  ! Additional diagnostics.
-    I_Ld2_1d, dz_Int_1d
-  real, dimension(SZI_(G),SZK_(GV)+1) :: & ! 2-D versions of diagnostics.
-    I_Ld2_2d, dz_Int_2d
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: & ! 3-D versions of diagnostics.
-    I_Ld2_3d, dz_Int_3d
-#endif
   isB = G%isc-1 ; ieB = G%iecB ; jsB = G%jsc-1 ; jeB = G%jecB ; nz = GV%ke
 
   use_temperature = .false. ; if (associated(tv%T)) use_temperature = .true.
@@ -469,9 +422,6 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
   I_Prandtl = 0.0 ; if (CS%Prandtl_turb > 0.0) I_Prandtl = 1.0 / CS%Prandtl_turb
 
   !$OMP parallel do default(private) shared(jsB,jeB,isB,ieB,nz,h,u_in,v_in,use_temperature,new_kappa, &
-#ifdef ADD_DIAGNOSTICS
-  !$OMP                                I_Ld2_3d,dz_Int_3d, &
-#endif
   !$OMP                                tv,G,GV,US,CS,kappa_io,dz_massless,k0dt,p_surf,dt,tke_io,kv_io)
   do J=JsB,JeB
     J2 = mod(J,2)+1 ; J2m1 = 3-J2 ! = mod(J-1,2)+1
@@ -597,15 +547,9 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
         do K=1,nzc+1 ; kappa(K) = kappa_2d(I,K,J2) ; enddo
       endif
 
-#ifdef ADD_DIAGNOSTICS
-      call kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
-                              dz, u0xdz, v0xdz, T0xdz, S0xdz, kappa_avg, &
-                              tke_avg, tv, CS, GV, US, I_Ld2_1d, dz_Int_1d)
-#else
       call kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
                               dz, u0xdz, v0xdz, T0xdz, S0xdz, kappa_avg, &
                               tke_avg, tv, CS, GV, US)
-#endif
     ! call cpu_clock_begin(Id_clock_setup)
     ! Extrapolate from the vertically reduced grid back to the original layers.
       if (nz == nzc) then
@@ -628,27 +572,16 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
           endif
         enddo
       endif
-#ifdef ADD_DIAGNOSTICS
-      do K=1,nz+1
-        I_Ld2_2d(i,K) = I_Ld2_1d(K) ; dz_Int_2d(i,K) = dz_Int_1d(K)
-      enddo
-#endif
     ! call cpu_clock_end(Id_clock_setup)
     else  ! Land points, still inside the i-loop.
       do K=1,nz+1
         kappa_2d(I,K,J2) = 0.0 ; tke_2d(I,K) = 0.0
-#ifdef ADD_DIAGNOSTICS
-        I_Ld2_2d(I,K) = 0.0 ; dz_Int_2d(I,K) = 0.0
-#endif
       enddo
     endif ; enddo ! i-loop
 
     do K=1,nz+1 ; do I=IsB,IeB
       tke_io(I,J,K) = G%mask2dBu(I,J) * tke_2d(I,K)
       kv_io(I,J,K) = ( G%mask2dBu(I,J) * kappa_2d(I,K,J2) ) * CS%Prandtl_turb
-#ifdef ADD_DIAGNOSTICS
-      I_Ld2_3d(I,J,K) = I_Ld2_2d(I,K) ; dz_Int_3d(I,J,K) = dz_Int_2d(I,K)
-#endif
     enddo ; enddo
     if (J>=G%jsc) then ; do K=1,nz+1 ; do i=G%isc,G%iec
       ! Set the diffusivities in tracer columns from the values at vertices.
@@ -666,10 +599,6 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
 
   if (CS%id_Kd_shear > 0) call post_data(CS%id_Kd_shear, kappa_io, CS%diag)
   if (CS%id_TKE > 0) call post_data(CS%id_TKE, tke_io, CS%diag)
-#ifdef ADD_DIAGNOSTICS
-  if (CS%id_ILd2 > 0) call post_data(CS%id_ILd2, I_Ld2_3d, CS%diag)
-  if (CS%id_dz_Int > 0) call post_data(CS%id_dz_Int, dz_Int_3d, CS%diag)
-#endif
 
 end subroutine Calc_kappa_shear_vertex
 
@@ -794,23 +723,10 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
                            ! to estimate the maximum permitted time step.  I.e.,
                            ! the resolution is 1/2^dt_refinements.
   integer :: k, itt, itt_dt
-#ifdef DEBUG
-  integer :: max_debug_itt ; parameter(max_debug_itt=20)
-  real :: wt(SZK_(GV)+1), wt_tot, I_wt_tot, wt_itt
-  real, dimension(SZK_(GV)+1) :: &
-    Ri_k, tke_prev, dtke, dkappa, dtke_norm, &
-    N2_debug, & ! A version of N2 for debugging [T-2 ~> s-2]
-    ksrc_av     ! The average through the iterations of k_src [T-1 ~> s-1].
-  real, dimension(SZK_(GV)+1,0:max_debug_itt) :: &
-    tke_it1, N2_it1, Sh2_it1, ksrc_it1, kappa_it1, kprev_it1
-  real, dimension(SZK_(GV)+1,1:max_debug_itt) :: &
-    dkappa_it1, wt_it1, K_Q_it1, d_dkappa_it1, dkappa_norm
-  real, dimension(SZK_(GV),0:max_debug_itt) :: &
-    u_it1, v_it1, rho_it1, T_it1, S_it1
-  real, dimension(0:max_debug_itt) :: &
-    dk_wt_it1, dkpos_wt_it1, dkneg_wt_it1, k_mag
-  real, dimension(max_debug_itt) ::  dt_it1
-#endif
+
+  ! This calculation of N2 is for debugging only.
+  ! real, dimension(SZK_(GV)+1) :: &
+  !   N2_debug, & ! A version of N2 for debugging [T-2 ~> s-2]
 
   Ri_crit = CS%Rino_crit
   gR0 = GV%Rho0 * GV%g_Earth
@@ -916,45 +832,12 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
     do K=1,nzc+1 ; dbuoy_dT(K) = -g_R0 ; dbuoy_dS(K) = 0.0 ; enddo
   endif
 
-#ifdef DEBUG
-  N2_debug(1) = 0.0 ; N2_debug(nzc+1) = 0.0
-  do K=2,nzc
-    N2_debug(K) = max((dbuoy_dT(K) * (T0xdz(k-1)*Idz(k-1) - T0xdz(k)*Idz(k)) + &
-                       dbuoy_dS(K) * (S0xdz(k-1)*Idz(k-1) - S0xdz(k)*Idz(k))) * &
-                       I_dz_int(K), 0.0)
-  enddo
-  do k=1,nzc
-    u_it1(k,0) = u0xdz(k)*Idz(k) ; v_it1(k,0) = v0xdz(k)*Idz(k)
-    T_it1(k,0) = T0xdz(k)*Idz(k) ; S_it1(k,0) = S0xdz(k)*Idz(k)
-  enddo
-  do K=1,nzc+1
-    kprev_it1(K,0) = kappa(K) ; kappa_it1(K,0) = kappa(K)
-    tke_it1(K,0) = 0.0
-    N2_it1(K,0) = N2_debug(K) ; Sh2_it1(K,0) = S2(K) ; ksrc_it1(K,0) = K_src(K)
-  enddo
-  do k=nzc+1,GV%ke
-    u_it1(k,0) = 0.0 ; v_it1(k,0) = 0.0
-    T_it1(k,0) = 0.0 ; S_it1(k,0) = 0.0
-    kprev_it1(K+1,0) = 0.0 ; kappa_it1(K+1,0) = 0.0 ; tke_it1(K+1,0) = 0.0
-    N2_it1(K+1,0) = 0.0 ; Sh2_it1(K+1,0) = 0.0 ; ksrc_it1(K+1,0) = 0.0
-  enddo
-  do itt=1,max_debug_itt
-    dt_it1(itt) = 0.0
-    do k=1,GV%ke
-      u_it1(k,itt) = 0.0 ; v_it1(k,itt) = 0.0
-      T_it1(k,itt) = 0.0 ; S_it1(k,itt) = 0.0
-      rho_it1(k,itt) = 0.0
-    enddo
-    do K=1,GV%ke+1
-      kprev_it1(K,itt) = 0.0 ; kappa_it1(K,itt) = 0.0 ; tke_it1(K,itt) = 0.0
-      N2_it1(K,itt) = 0.0 ; Sh2_it1(K,itt) = 0.0
-      ksrc_it1(K,itt) = 0.0
-      dkappa_it1(K,itt) = 0.0 ; wt_it1(K,itt) = 0.0
-      K_Q_it1(K,itt) = 0.0 ; d_dkappa_it1(K,itt) = 0.0
-    enddo
-  enddo
-  do K=1,GV%ke+1 ; ksrc_av(K) = 0.0 ; enddo
-#endif
+  ! N2_debug(1) = 0.0 ; N2_debug(nzc+1) = 0.0
+  ! do K=2,nzc
+  !   N2_debug(K) = max((dbuoy_dT(K) * (T0xdz(k-1)*Idz(k-1) - T0xdz(k)*Idz(k)) + &
+  !                      dbuoy_dS(K) * (S0xdz(k-1)*Idz(k-1) - S0xdz(k)*Idz(k))) * &
+  !                      I_dz_int(K), 0.0)
+  ! enddo
 
   ! This call just calculates N2 and S2.
   call calculate_projected_state(kappa, u, v, T, Sal, 0.0, nzc, dz, I_dz_int, &
@@ -981,12 +864,6 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
 ! ----------------------------------------------------
 ! Calculate new values of u, v, rho, N^2 and S.
 ! ----------------------------------------------------
-#ifdef DEBUG
-    do K=1,nzc+1
-      Ri_k(K) = 1e3 ; if (S2(K) > 1e-3*N2(K)) Ri_k(K) = N2(K) / S2(K)
-      if (itt > 1) then ; tke_prev(K) = tke(K) ; else ; tke_prev(K) = 0.0 ; endif
-    enddo
-#endif
 
   ! call cpu_clock_begin(id_clock_KQ)
     call find_kappa_tke(N2, S2, kappa, Idz, dz_Int, I_L2_bdry, f2, &
@@ -1099,9 +976,6 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
         ! This would be here but does nothing.
         ! kappa_avg(K) = kappa_avg(K) + kappa_mid(K)*dt_wt
         tke_avg(K) = tke_avg(K) + dt_wt*tke(K)
-#ifdef DEBUG
-        tke_pred(K) = tke(K) ; kappa_pred(K) = 0.0 ; kappa(K) = 0.0
-#endif
       enddo
     ! call cpu_clock_end(id_clock_avg)
     else
@@ -1157,63 +1031,10 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
     ! call cpu_clock_end(id_clock_project)
     endif
 
-#ifdef DEBUG
-    if (itt <= max_debug_itt) then
-      dt_it1(itt) = dt_now
-      dk_wt_it1(itt) = 0.0 ; dkpos_wt_it1(itt) = 0.0 ;  dkneg_wt_it1(itt) = 0.0
-      k_mag(itt) = 0.0
-      wt_itt = 1.0/real(itt) ; wt_tot = 0.0
-      do K=1,nzc+1
-        ksrc_av(K) = (1.0-wt_itt)*ksrc_av(K) + wt_itt*K_src(K)
-        wt_tot = wt_tot + dz_Int(K) * ksrc_av(K)
-      enddo
-      ! Use the 1/0=0 convention.
-      I_wt_tot = 0.0 ; if (wt_tot > 0.0) I_wt_tot = 1.0/wt_tot
-
-      do K=1,nzc+1
-        wt(K) = (dz_Int(K)*ksrc_av(K)) * I_wt_tot
-        k_mag(itt) = k_mag(itt) + wt(K)*kappa_mid(K)
-        dkappa_it1(K,itt) = kappa_pred(K) - kappa_out(K)
-        dk_wt_it1(itt) = dk_wt_it1(itt) + wt(K)*dkappa_it1(K,itt)
-        if (dkappa_it1(K,itt) > 0.0) then
-          dkpos_wt_it1(itt) = dkpos_wt_it1(itt) + wt(K)*dkappa_it1(K,itt)
-        else
-          dkneg_wt_it1(itt) = dkneg_wt_it1(itt) + wt(K)*dkappa_it1(K,itt)
-        endif
-        wt_it1(K,itt) = wt(K)
-      enddo
-    endif
-    do K=1,nzc+1
-      Ri_k(K) = 1e3 ; if (N2(K) < 1e3 * S2(K)) Ri_k(K) = N2(K) / S2(K)
-      dtke(K) = tke_pred(K) - tke(K)
-      dtke_norm(K) = dtke(K) / (0.5*(tke(K) + tke_pred(K)))
-      dkappa(K) = kappa_pred(K) - kappa_out(K)
-    enddo
-    if (itt <= max_debug_itt) then
-      do k=1,nzc
-        u_it1(k,itt) = u(k) ; v_it1(k,itt) = v(k)
-        T_it1(k,itt) = T(k) ; S_it1(k,itt) = Sal(k)
-      enddo
-      do K=1,nzc+1
-        kprev_it1(K,itt) = kappa_out(K)
-        kappa_it1(K,itt) = kappa_mid(K) ; tke_it1(K,itt) = 0.5*(tke(K)+tke_pred(K))
-        N2_it1(K,itt)=N2(K) ; Sh2_it1(K,itt)=S2(K)
-        ksrc_it1(K,itt) = kappa_src(K)
-        K_Q_it1(K,itt) = kappa_out(K) / (TKE(K))
-        if (itt > 1) then
-          if (abs(dkappa_it1(K,itt-1)) > 1e-20) &
-            d_dkappa_it1(K,itt) = dkappa_it1(K,itt) / dkappa_it1(K,itt-1)
-        endif
-        dkappa_norm(K,itt) = dkappa(K) / max(0.5*(kappa_pred(K) + kappa_out(K)), US%m2_s_to_Z2_T*1e-100)
-      enddo
-    endif
-#endif
-
     if (dt_rem <= 0.0) exit
 
   enddo ! end itt loop
 
-#ifdef ADD_DIAGNOSTICS
   if (present(I_Ld2_1d)) then
     do K=1,GV%ke+1 ; I_Ld2_1d(K) = 0.0 ; enddo
     do K=2,nzc ; if (TKE(K) > 0.0) &
@@ -1224,7 +1045,6 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
     do K=1,nzc+1 ; dz_Int_1d(K) = dz_Int(K) ; enddo
     do K=nzc+2,GV%ke ; dz_Int_1d(K) = 0.0 ; enddo
   endif
-#endif
 
 end subroutine kappa_shear_column
 
@@ -1474,18 +1294,14 @@ subroutine find_kappa_tke(N2, S2, kappa_in, Idz, dz_Int, I_L2_bdry, f2, &
   integer :: ks_kappa, ke_kappa, ke_tke   ! The ranges of k-indices that are or
   integer :: ks_kappa_prev, ke_kappa_prev ! were being worked on.
   integer :: itt, k, k2
-#ifdef DEBUG
-  integer :: max_debug_itt ; parameter(max_debug_itt=20)
+
+  ! These variables are used only for debugging.
+  logical, parameter :: debug_soln = .false.
   real :: K_err_lin, Q_err_lin, TKE_src_norm
   real, dimension(nz+1) :: &
     I_Ld2_debug, & ! A separate version of I_Ld2 for debugging [Z-2 ~> m-2].
     kappa_prev, & ! The value of kappa at the start of the current iteration [Z2 T-1 ~> m2 s-1].
     TKE_prev   ! The value of TKE at the start of the current iteration [Z2 T-2 ~> m2 s-2].
-  real, dimension(nz+1,1:max_debug_itt) :: &
-    tke_it1, kappa_it1, kprev_it1, &  ! Various values from each iteration.
-    dkappa_it1, K_Q_it1, d_dkappa_it1, dkappa_norm_it1
-  integer :: it2
-#endif
 
   c_N2 = CS%C_N**2 ; c_S2 = CS%C_S**2
   q0 = CS%TKE_bg ; kappa0 = CS%kappa_0
@@ -1529,7 +1345,7 @@ subroutine find_kappa_tke(N2, S2, kappa_in, Idz, dz_Int, I_L2_bdry, f2, &
 !     TKE_decay(K) = c_n*sqrt(N2(K)) + c_s*sqrt(S2(K)) ! The expression in JHL.
     TKE_decay(K) = sqrt(c_n2*N2(K) + c_s2*S2(K))
     if ((kappa(K) > 0.0) .and. (K_Q(K) > 0.0)) then
-      TKE(K) = kappa(K) / K_Q(K)
+      TKE(K) = kappa(K) / K_Q(K) ! Perhaps take the max with TKE_min
     else
       TKE(K) = TKE_min
     endif
@@ -1564,9 +1380,7 @@ subroutine find_kappa_tke(N2, S2, kappa_in, Idz, dz_Int, I_L2_bdry, f2, &
   ! Calculate TKE
   ! ----------------------------------------------------
 
-#ifdef DEBUG
-    do K=1,nz+1 ; kappa_prev(K) = kappa(K) ; TKE_prev(K) = TKE(K) ; enddo
-#endif
+    if (debug_soln) then ; do K=1,nz+1 ; kappa_prev(K) = kappa(K) ; TKE_prev(K) = TKE(K) ; enddo ; endif
 
     if (.not.do_Newton) then
       !   Use separate steps of the TKE and kappa equations, that are
@@ -1792,25 +1606,20 @@ subroutine find_kappa_tke(N2, S2, kappa_in, Idz, dz_Int, I_L2_bdry, f2, &
         dQ(ke_kappa+1) = dQ(ke_kappa+1) / (1.0 - cQ(ke_kappa+2)*e1(ke_kappa+2))
         TKE(ke_kappa+1) = max(TKE(ke_kappa+1) + dQ(ke_kappa+1), TKE_min)
         do k=ke_kappa+2,nz+1
-#ifdef DEBUG
-          if (K < nz+1) then
+          if (debug_soln .and. (K < nz+1)) then
           ! Ignore this source?
             aQ(k) = (0.5*(kappa(K)+kappa(K+1))+kappa0) * Idz(k)
-            tke_src_norm = (dz_Int(K) * (kappa0*S2(K) - (TKE(K)-q0)*TKE_decay(K)) - &
-                           (aQ(k) * (TKE(K) - TKE(K+1)) - aQ(k-1) * (TKE(K-1) - TKE(K))) ) / &
-                           (aQ(k) + (aQ(k-1) + dz_Int(K)*TKE_decay(K)))
+        !    tke_src_norm = (dz_Int(K) * (kappa0*S2(K) - (TKE(K)-q0)*TKE_decay(K)) - &
+        !                   (aQ(k) * (TKE(K) - TKE(K+1)) - aQ(k-1) * (TKE(K-1) - TKE(K))) ) / &
+        !                   (aQ(k) + (aQ(k-1) + dz_Int(K)*TKE_decay(K)))
           endif
-#endif
           dK(K) = 0.0
         ! Ensure that TKE+dQ will not drop below 0.5*TKE.
           dQ(K) = max(e1(K)*dQ(K-1),-0.5*TKE(K))
           TKE(K) = max(TKE(K) + dQ(K), TKE_min)
           if (abs(dQ(K)) < roundoff*TKE(K)) exit
         enddo
-#ifdef DEBUG
-        do K2=K+1,ke_kappa_prev+1 ; dQ(K2) = 0.0 ; dK(K2) = 0.0 ; enddo
-        do K=K2,nz+1 ; if (dQ(K) == 0.0) exit ; dQ(K) = 0.0 ; dK(K) = 0.0 ; enddo
-#endif
+        if (debug_soln) then ; do K2=K+1,nz+1 ; dQ(K2) = 0.0 ; dK(K2) = 0.0 ; enddo ; endif
       endif
       if (.not. abort_Newton) then
         do K=ke_kappa,2,-1
@@ -1837,10 +1646,9 @@ subroutine find_kappa_tke(N2, S2, kappa_in, Idz, dz_Int, I_L2_bdry, f2, &
         dK(1) = 0.0
       endif
 
-#ifdef DEBUG
       ! Check these solutions for consistency.
       !  The unit conversions here have not been carefully tested.
-      do K=2,nz
+      if (debug_soln) then ; do K=2,nz
         ! In these equations, K_err_lin and Q_err_lin should be at round-off levels
         ! compared with the dominant terms, perhaps, dz_Int*I_Ld2*kappa and
         ! dz_Int*TKE_decay*TKE.  The exception is where, either 1) the decay term has been
@@ -1863,8 +1671,8 @@ subroutine find_kappa_tke(N2, S2, kappa_in, Idz, dz_Int, I_L2_bdry, f2, &
                     0.5*(TKE_prev(K)-TKE_prev(K+1))*Idz(k)  * (dK(K) + dK(K+1)) - &
                     0.5*(TKE_prev(K)-TKE_prev(K-1))*Idz(k-1)* (dK(K-1) + dK(K)) + &
                     dz_Int(K) * (dK(K) * (S2(K) - N2(K)) - dQ(K)*TKE_decay(K))
-      enddo
-#endif
+      enddo ; endif
+
     endif  ! End of the Newton's method solver.
 
     ! Test kappa for convergence...
@@ -1904,33 +1712,9 @@ subroutine find_kappa_tke(N2, S2, kappa_in, Idz, dz_Int, I_L2_bdry, f2, &
       do K=2,nz ; K_Q(K) = kappa(K) / max(TKE(K), TKE_min) ; enddo
     endif
 
-#ifdef DEBUG
-    if (itt <= max_debug_itt) then
-      do K=1,nz+1
-        kprev_it1(K,itt) = kappa_prev(K)
-        kappa_it1(K,itt) = kappa(K) ; tke_it1(K,itt) = tke(K)
-        dkappa_it1(K,itt) = kappa(K) - kappa_prev(K)
-        dkappa_norm_it1(K,itt) = (kappa(K) - kappa_prev(K)) / &
-            (kappa0 + 0.5*(kappa(K) + kappa_prev(K)))
-        K_Q_it1(K,itt) = kappa(K) / max(TKE(K),TKE_min)
-        d_dkappa_it1(K,itt) = 0.0
-        if (itt > 1) then ; if (abs(dkappa_it1(K,itt-1)) > 1e-20*US%m2_s_to_Z2_T) &
-            d_dkappa_it1(K,itt) = dkappa_it1(K,itt) / dkappa_it1(K,itt-1)
-        endif
-      enddo
-    endif
-#endif
-
     if (within_tolerance) exit
 
   enddo
-
-#ifdef DEBUG
-  do it2=itt+1,max_debug_itt ; do K=1,nz+1
-    kprev_it1(K,it2) = 0.0 ; kappa_it1(K,it2) = 0.0 ; tke_it1(K,it2) = 0.0
-    dkappa_it1(K,it2) = 0.0 ; K_Q_it1(K,it2) = 0.0 ; d_dkappa_it1(K,it2) = 0.0
-  enddo ; enddo
-#endif
 
   if (do_Newton) then  ! K_Q needs to be calculated.
     do K=1,ks_kappa-1 ;  K_Q(K) = 0.0 ; enddo
@@ -2127,16 +1911,10 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
 
   CS%diag => diag
 
-  CS%id_Kd_shear = register_diag_field('ocean_model','Kd_shear',diag%axesTi,Time, &
+  CS%id_Kd_shear = register_diag_field('ocean_model','Kd_shear', diag%axesTi, Time, &
       'Shear-driven Diapycnal Diffusivity', 'm2 s-1', conversion=US%Z2_T_to_m2_s)
-  CS%id_TKE = register_diag_field('ocean_model','TKE_shear',diag%axesTi,Time, &
+  CS%id_TKE = register_diag_field('ocean_model','TKE_shear', diag%axesTi, Time, &
       'Shear-driven Turbulent Kinetic Energy', 'm2 s-2', conversion=US%Z_to_m**2*US%s_to_T**2)
-#ifdef ADD_DIAGNOSTICS
-  CS%id_ILd2 = register_diag_field('ocean_model','ILd2_shear',diag%axesTi,Time, &
-      'Inverse kappa decay scale at interfaces', 'm-2', conversion=US%m_to_Z**2)
-  CS%id_dz_Int = register_diag_field('ocean_model','dz_Int_shear',diag%axesTi,Time, &
-      'Finite volume thickness of interfaces', 'm', conversion=US%Z_to_m)
-#endif
 
 end function kappa_shear_init
 

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -18,7 +18,6 @@ use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_domain
 implicit none ; private
 
 #include <MOM_memory.h>
-#undef  DEBUG_CODE
 
 public regularize_layers, regularize_layers_init
 
@@ -58,18 +57,6 @@ type, public :: regularize_layers_CS ; private
   integer :: id_def_rat = -1 !< A diagnostic ID
   logical :: allow_clocks_in_omp_loops  !< If true, clocks can be called from inside loops that
                              !! can be threaded. To run with multiple threads, set to False.
-#ifdef DEBUG_CODE
-  !>@{ Diagnostic IDs
-  integer :: id_def_rat_2 = -1, id_def_rat_3 = -1
-  integer :: id_def_rat_u = -1, id_def_rat_v = -1
-  integer :: id_e1 = -1, id_e2 = -1, id_e3 = -1
-  integer :: id_def_rat_u_1b = -1, id_def_rat_v_1b = -1
-  integer :: id_def_rat_u_2 = -1, id_def_rat_u_2b = -1
-  integer :: id_def_rat_v_2 = -1, id_def_rat_v_2b = -1
-  integer :: id_def_rat_u_3 = -1, id_def_rat_u_3b = -1
-  integer :: id_def_rat_v_3 = -1, id_def_rat_v_3b = -1
-  !>@}
-#endif
 end type regularize_layers_CS
 
 !>@{ Clock IDs
@@ -148,17 +135,6 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: &
     e           ! The interface depths [H ~> m or kg m-2], positive upward.
 
-#ifdef DEBUG_CODE
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
-    def_rat_u_1b, def_rat_u_2, def_rat_u_2b, def_rat_u_3, def_rat_u_3b
-  real, dimension(SZI_(G),SZJB_(G)) :: &
-    def_rat_v_1b, def_rat_v_2, def_rat_v_2b, def_rat_v_3, def_rat_v_3b
-  real, dimension(SZI_(G),SZJB_(G)) :: &
-    def_rat_h2, def_rat_h3
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: &
-    ef          ! The filtered interface depths [H ~> m or kg m-2], positive upward.
-#endif
-
   real, dimension(SZI_(G),SZK_(G)+1) :: &
     e_filt, e_2d  ! The interface depths [H ~> m or kg m-2], positive upward.
   real, dimension(SZI_(G),SZK_(G)) :: &
@@ -229,12 +205,6 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
 
   h_neglect = GV%H_subroundoff
   debug = (debug .or. CS%debug)
-#ifdef DEBUG_CODE
-  debug = .true.
-  if (CS%id_def_rat_2 > 0) then ! Calculate over a slightly larger domain.
-    is = G%isc-1 ; ie = G%iec+1 ; js = G%jsc-1 ; je = G%jec+1
-  endif
-#endif
 
   I_dtol = 1.0 / max(CS%h_def_tol2 - CS%h_def_tol1, 1e-40)
   I_dtol34 = 1.0 / max(CS%h_def_tol4 - CS%h_def_tol3, 1e-40)
@@ -249,11 +219,8 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
     e(i,j,K+1) = e(i,j,K) - h(i,j,k)
   enddo ; enddo ; enddo
 
-#ifdef DEBUG_CODE
-  call find_deficit_ratios(e, def_rat_u, def_rat_v, G, GV, CS, def_rat_u_1b, def_rat_v_1b, 1, h)
-#else
   call find_deficit_ratios(e, def_rat_u, def_rat_v, G, GV, CS, h=h)
-#endif
+
   ! Determine which columns are problematic
   do j=js,je ; do_j(j) = .false. ; enddo
   do j=js,je ; do i=is,ie
@@ -261,49 +228,6 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
                          def_rat_v(i,J-1), def_rat_v(i,J))
     if (def_rat_h(i,j) > CS%h_def_tol1) do_j(j) = .true.
   enddo ; enddo
-
-#ifdef DEBUG_CODE
-  if ((CS%id_def_rat_3 > 0) .or. (CS%id_e3 > 0) .or. &
-      (CS%id_def_rat_u_3 > 0) .or. (CS%id_def_rat_u_3b > 0) .or. &
-      (CS%id_def_rat_v_3 > 0) .or. (CS%id_def_rat_v_3b > 0) ) then
-    do j=js-1,je+1 ; do i=is-1,ie+1
-      ef(i,j,1) = 0.0
-    enddo ; enddo
-    do K=2,nz+1 ; do j=js,je ; do i=is,ie
-      if (G%mask2dCu(I,j) <= 0.0) then ; e_e = e(i,j,K) ; else
-        e_e = max(e(i+1,j,K) + min(e(i,j,K) - e(i+1,j,nz+1), 0.0), e(i,j,nz+1))
-      endif
-      if (G%mask2dCu(I-1,j) <= 0.0) then ; e_w = e(i,j,K) ; else
-        e_w = max(e(i-1,j,K) + min(e(i,j,K) - e(i-1,j,nz+1), 0.0), e(i,j,nz+1))
-      endif
-      if (G%mask2dCv(i,J) <= 0.0) then ; e_n = e(i,j,K) ; else
-        e_n = max(e(i,j+1,K) + min(e(i,j,K) - e(i,j+1,nz+1), 0.0), e(i,j,nz+1))
-      endif
-      if (G%mask2dCv(i,J-1) <= 0.0) then ; e_s = e(i,j,K) ; else
-        e_s = max(e(i,j-1,K) + min(e(i,j,K) - e(i,j-1,nz+1), 0.0), e(i,j,nz+1))
-      endif
-
-      wt = 1.0
-      ef(i,j,k) = (1.0 - 0.5*wt) * e(i,j,K) + &
-                  wt * 0.125 * ((e_e + e_w) + (e_n + e_s))
-    enddo ; enddo ; enddo
-    call find_deficit_ratios(ef, def_rat_u_3, def_rat_v_3, G, GV, CS, def_rat_u_3b, def_rat_v_3b)
-
-    ! Determine which columns are problematic
-    do j=js,je ; do i=is,ie
-      def_rat_h3(i,j) = max(def_rat_u_3(I-1,j), def_rat_u_3(I,j), &
-                            def_rat_v_3(i,J-1), def_rat_v_3(i,J))
-    enddo ; enddo
-
-    if (CS%id_e3 > 0) call post_data(CS%id_e3, ef, CS%diag)
-    if (CS%id_def_rat_3 > 0) call post_data(CS%id_def_rat_3, def_rat_h3, CS%diag)
-    if (CS%id_def_rat_u_3 > 0) call post_data(CS%id_def_rat_u_3, def_rat_u_3, CS%diag)
-    if (CS%id_def_rat_u_3b > 0) call post_data(CS%id_def_rat_u_3b, def_rat_u_3b, CS%diag)
-    if (CS%id_def_rat_v_3 > 0) call post_data(CS%id_def_rat_v_3, def_rat_v_3, CS%diag)
-    if (CS%id_def_rat_v_3b > 0) call post_data(CS%id_def_rat_v_3b, def_rat_v_3b, CS%diag)
-  endif
-#endif
-
 
   ! Now restructure the layers.
   !$OMP parallel do default(private) shared(is,ie,js,je,nz,do_j,def_rat_h,CS,nkmb,G,GV,US, &
@@ -682,40 +606,6 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
 
   if (CS%id_def_rat > 0) call post_data(CS%id_def_rat, def_rat_h, CS%diag)
 
-#ifdef DEBUG_CODE
-  if (CS%id_e1 > 0) call post_data(CS%id_e1, e, CS%diag)
-  if (CS%id_def_rat_u > 0) call post_data(CS%id_def_rat_u, def_rat_u, CS%diag)
-  if (CS%id_def_rat_u_1b > 0) call post_data(CS%id_def_rat_u_1b, def_rat_u_1b, CS%diag)
-  if (CS%id_def_rat_v > 0) call post_data(CS%id_def_rat_v, def_rat_v, CS%diag)
-  if (CS%id_def_rat_v_1b > 0) call post_data(CS%id_def_rat_v_1b, def_rat_v_1b, CS%diag)
-
-  if ((CS%id_def_rat_2 > 0) .or. &
-      (CS%id_def_rat_u_2 > 0) .or. (CS%id_def_rat_u_2b > 0) .or. &
-      (CS%id_def_rat_v_2 > 0) .or. (CS%id_def_rat_v_2b > 0) ) then
-    do j=js-1,je+1 ; do i=is-1,ie+1
-      e(i,j,1) = 0.0
-    enddo ; enddo
-    do K=1,nz ; do j=js-1,je+1 ; do i=is-1,ie+1
-      e(i,j,K+1) = e(i,j,K) - h(i,j,k)
-    enddo ; enddo ; enddo
-
-    call find_deficit_ratios(e, def_rat_u_2, def_rat_v_2, G, GV, CS, def_rat_u_2b, def_rat_v_2b, h=h)
-
-    ! Determine which columns are problematic
-    do j=js,je ; do i=is,ie
-      def_rat_h2(i,j) = max(def_rat_u_2(I-1,j), def_rat_u_2(I,j), &
-                            def_rat_v_2(i,J-1), def_rat_v_2(i,J))
-    enddo ; enddo
-
-    if (CS%id_def_rat_2 > 0) call post_data(CS%id_def_rat_2, def_rat_h2, CS%diag)
-    if (CS%id_e2 > 0) call post_data(CS%id_e2, e, CS%diag)
-    if (CS%id_def_rat_u_2 > 0) call post_data(CS%id_def_rat_u_2, def_rat_u_2, CS%diag)
-    if (CS%id_def_rat_u_2b > 0) call post_data(CS%id_def_rat_u_2b, def_rat_u_2b, CS%diag)
-    if (CS%id_def_rat_v_2 > 0) call post_data(CS%id_def_rat_v_2, def_rat_v_2, CS%diag)
-    if (CS%id_def_rat_v_2b > 0) call post_data(CS%id_def_rat_v_2b, def_rat_v_2b, CS%diag)
-  endif
-#endif
-
 end subroutine regularize_surface
 
 !>  This subroutine determines the amount by which the harmonic mean
@@ -957,45 +847,6 @@ subroutine regularize_layers_init(Time, G, GV, param_file, diag, CS)
 
   CS%id_def_rat = register_diag_field('ocean_model', 'deficit_ratio', diag%axesT1, &
       Time, 'Max face thickness deficit ratio', 'nondim')
-
-#ifdef DEBUG_CODE
-  CS%id_def_rat_2 = register_diag_field('ocean_model', 'deficit_rat2', diag%axesT1, &
-      Time, 'Corrected thickness deficit ratio', 'nondim')
-  CS%id_def_rat_3 = register_diag_field('ocean_model', 'deficit_rat3', diag%axesT1, &
-      Time, 'Filtered thickness deficit ratio', 'nondim')
-  CS%id_e1 = register_diag_field('ocean_model', 'er_1', diag%axesTi, &
-      Time, 'Intial interface depths before remapping', 'm')
-  CS%id_e2 = register_diag_field('ocean_model', 'er_2', diag%axesTi, &
-      Time, 'Intial interface depths after remapping', 'm')
-  CS%id_e3 = register_diag_field('ocean_model', 'er_3', diag%axesTi, &
-      Time, 'Intial interface depths filtered', 'm')
-
-  CS%id_def_rat_u = register_diag_field('ocean_model', 'defrat_u', diag%axesCu1, &
-      Time, 'U-point thickness deficit ratio', 'nondim')
-  CS%id_def_rat_u_1b = register_diag_field('ocean_model', 'defrat_u_1b', diag%axesCu1, &
-      Time, 'U-point 2-layer thickness deficit ratio', 'nondim')
-  CS%id_def_rat_u_2 = register_diag_field('ocean_model', 'defrat_u_2', diag%axesCu1, &
-      Time, 'U-point corrected thickness deficit ratio', 'nondim')
-  CS%id_def_rat_u_2b = register_diag_field('ocean_model', 'defrat_u_2b', diag%axesCu1, &
-      Time, 'U-point corrected 2-layer thickness deficit ratio', 'nondim')
-  CS%id_def_rat_u_3 = register_diag_field('ocean_model', 'defrat_u_3', diag%axesCu1, &
-      Time, 'U-point filtered thickness deficit ratio', 'nondim')
-  CS%id_def_rat_u_3b = register_diag_field('ocean_model', 'defrat_u_3b', diag%axesCu1, &
-      Time, 'U-point filtered 2-layer thickness deficit ratio', 'nondim')
-
-  CS%id_def_rat_v = register_diag_field('ocean_model', 'defrat_v', diag%axesCv1, &
-      Time, 'V-point thickness deficit ratio', 'nondim')
-  CS%id_def_rat_v_1b = register_diag_field('ocean_model', 'defrat_v_1b', diag%axesCv1, &
-      Time, 'V-point 2-layer thickness deficit ratio', 'nondim')
-  CS%id_def_rat_v_2 = register_diag_field('ocean_model', 'defrat_v_2', diag%axesCv1, &
-      Time, 'V-point corrected thickness deficit ratio', 'nondim')
-  CS%id_def_rat_v_2b = register_diag_field('ocean_model', 'defrat_v_2b', diag%axesCv1, &
-      Time, 'V-point corrected 2-layer thickness deficit ratio', 'nondim')
-  CS%id_def_rat_v_3 = register_diag_field('ocean_model', 'defrat_v_3', diag%axesCv1, &
-      Time, 'V-point filtered thickness deficit ratio', 'nondim')
-  CS%id_def_rat_v_3b = register_diag_field('ocean_model', 'defrat_v_3b', diag%axesCv1, &
-      Time, 'V-point filtered 2-layer thickness deficit ratio', 'nondim')
-#endif
 
   if (CS%allow_clocks_in_omp_loops) then
     id_clock_EOS = cpu_clock_id('(Ocean regularize_layers EOS)', grain=CLOCK_ROUTINE)


### PR DESCRIPTION
  Removed old debugging code in blocks of code surrounded by #ifdef statements
and removed unnecessary #ifdef around other blocks of debugging code.  MOM6
standards discourage the use of CPP macros except for a limited set of uses
related to memory where this is unavoidable, so this commit is bringing MOM6
closer to its stated standards.  All answers and output are identical.