### PR TITLE
Test pathc to FMS 2019.01.02 from Rusty

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,8 @@ setup:
     - git clone https://github.com/adcroft/MRS.git MRS
     # Update MOM6-examples and submodules
     - (cd MOM6-examples && git checkout . && git checkout dev/gfdl && git pull && git submodule init && git submodule update)
+    # Test Rusty's version of FMS
+    - (cd MOM6-examples/src/FMS && git checkout 2019.01 && git checkout -b zhi_nest_merge_nofms2io && git pull https://github.com/bensonr/FMS.git zhi_nest_merge_nofms2io )
     - (cd MOM6-examples/src/MOM6 && git submodule update)
     - test -d MOM6-examples/src/LM3 || make -f MRS/Makefile.clone clone_gfdl -s
     - make -f MRS/Makefile.clone MOM6-examples/.datasets -s

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -174,7 +174,7 @@ $(FMS)/build/path_names: $(LIST_PATHS) $(FMS)/src $(FMS_SOURCE)
 $(FMS)/src:
 	git clone $(FMS_URL) $@
 	cd $@; git checkout $(FMS_COMMIT)
-
+	cd $@; git checkout 2019.01; git checkout -b zhi_nest_merge_nofms2io; git pull https://github.com/bensonr/FMS.git zhi_nest_merge_nofms2io
 
 #---
 # Build Toolchain


### PR DESCRIPTION
This is not a real PR - we're just using Travis-CI to force regressions tests for compatibility with a patch to FMS