### PR TITLE
Move FMS tag to 2019.01.03

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -20,7 +20,7 @@ MKMF := $(abspath $(DEPS)/mkmf/bin/mkmf)
 
 # FMS framework
 FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
-FMS_COMMIT ?= 2019.01.02
+FMS_COMMIT ?= 2019.01.03
 FMS := $(DEPS)/fms
 
 #---


### PR DESCRIPTION
FMS tag 2019.01.03 fixes problems for EMC allowing the newer FV3 to work with MOM6 which is not yet compatible with FMS2020.
This updates the version of FMS used in .testing/ .