### PR TITLE
Testing: tc4 installs python-netCDF4 via venv

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -93,10 +93,33 @@ TARGET_SOURCE = $(call SOURCE,build/target_codebase/src) \
 FMS_SOURCE = $(call SOURCE,$(DEPS)/fms/src)
 
 #---
+# Python preprocessing environment configuration
+
+HAS_NUMPY = $(shell python -c "import numpy" 2> /dev/null && echo "yes")
+HAS_NETCDF4 = $(shell python -c "import netCDF4" 2> /dev/null && echo "yes")
+
+USE_VENV =
+ifneq ($(HAS_NUMPY), yes)
+  USE_VENV = yes
+endif
+ifneq ($(HAS_NETCDF4), yes)
+  USE_VENV = yes
+endif
+
+# When disabled, activation is a null operation (`true`)
+VENV_PATH =
+VENV_ACTIVATE = true
+ifeq ($(USE_VENV), yes)
+  VENV_PATH = work/local-env
+  VENV_ACTIVATE = . $(VENV_PATH)/bin/activate
+endif
+
+
+#---
 # Rules
 
 .PHONY: all build.regressions
-all: $(foreach b,$(BUILDS),build/$(b)/MOM6)
+all: $(foreach b,$(BUILDS),build/$(b)/MOM6) $(VENV_PATH)
 build.regressions: $(foreach b,symmetric target,build/$(b)/MOM6)
 
 # Executable
@@ -184,6 +207,18 @@ $(LIST_PATHS) $(MKMF):
 	cd $(DEPS)/mkmf; git checkout $(MKMF_COMMIT)
 
 
+#---
+# Python preprocessing
+# NOTE: Some less mature environments (e.g. Arm64 Ubuntu) require explicit
+#   installation of numpy before netCDF4, as well as wheel and cython support.
+work/local-env:
+	python3 -m venv $@
+	. $@/bin/activate \
+	  && pip3 install wheel \
+	  && pip3 install cython \
+	  && pip3 install numpy \
+	  && pip3 install netCDF4
+
 #----
 # Testing
 
@@ -264,7 +299,6 @@ $(eval $(call CMP_RULE,regression,symmetric target))
 
 # TODO: chksum_diag parsing of restart files
 
-
 #---
 # Test run output files
 
@@ -281,7 +315,13 @@ work/%/$(1)/ocean.stats work/%/$(1)/chksum_diag: build/$(2)/MOM6
 	if [ $(3) ]; then find build/$(2) -name *.gcda -exec rm -f '{}' \; ; fi
 	mkdir -p $$(@D)
 	cp -rL $$*/* $$(@D)
-	cd $$(@D) && if [ -f Makefile ]; then $(MAKE); fi
+	if [ -f $$(@D)/Makefile ]; then \
+	  $$(VENV_ACTIVATE) \
+	    && cd $$(@D) \
+	    && $(MAKE); \
+	else \
+	  cd $$(@D); \
+	fi
 	mkdir -p $$(@D)/RESTART
 	echo -e "$(4)" > $$(@D)/MOM_override
 	cd $$(@D) \
@@ -327,7 +367,13 @@ work/%/restart/ocean.stats: build/symmetric/MOM6
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	cp -rL $*/* $(@D)
-	cd work/$*/restart && if [ -f Makefile ]; then $(MAKE); fi
+	if [ -f $(@D)/Makefile ]; then \
+	  $(VENV_ACTIVATE) \
+	    && cd work/$*/restart \
+	    && $(MAKE); \
+	else \
+	  cd work/$*/restart; \
+	fi
 	mkdir -p $(@D)/RESTART
 	# Generate the half-period input namelist
 	# TODO: Assumes that runtime set by DAYMAX, will fail if set by input.nml

--- a/.testing/tc4/.gitignore
+++ b/.testing/tc4/.gitignore
@@ -1,0 +1,4 @@
+ocean_hgrid.nc
+sponge.nc
+temp_salt_ic.nc
+topog.nc

--- a/.testing/tc4/Makefile
+++ b/.testing/tc4/Makefile
@@ -3,11 +3,14 @@ all: ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc
 local-env:
 	python3 -m venv local-env
 	. local-env/bin/activate \
-	  && pip install netCDF4
+	  && pip3 install wheel \
+	  && pip3 install cython \
+	  && pip3 install numpy \
+	  && pip3 install netCDF4
 
 ocean_hgrid.nc topog.nc: local-env
 	. local-env/bin/activate \
-	  && python build_grid.py \
+	  && python build_grid.py
 
 temp_salt_ic.nc sponge.nc: local-env
 	. local-env/bin/activate \

--- a/.testing/tc4/Makefile
+++ b/.testing/tc4/Makefile
@@ -1,5 +1,5 @@
 ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc:
-	python -m venv local-env
+	python2 -m virtualenv local-env
 	. local-env/bin/activate \
 	  && pip install netCDF4 \
 	  && python build_grid.py \

--- a/.testing/tc4/Makefile
+++ b/.testing/tc4/Makefile
@@ -1,6 +1,17 @@
-ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc:
-	python2 -m virtualenv local-env
+all: ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc
+
+local-env:
+	python3 -m venv local-env
 	. local-env/bin/activate \
-	  && pip install netCDF4 \
+	  && pip install netCDF4
+
+ocean_hgrid.nc topog.nc: local-env
+	. local-env/bin/activate \
 	  && python build_grid.py \
+
+temp_salt_ic.nc sponge.nc: local-env
+	. local-env/bin/activate \
 	  && python build_data.py
+
+clean:
+	rm -rf local-env ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc

--- a/.testing/tc4/Makefile
+++ b/.testing/tc4/Makefile
@@ -1,31 +1,8 @@
-# TODO: Identify if venv is available
-HAS_NUMPY=$(shell python -c "import numpy" 2> /dev/null && echo "yes")
-HAS_NETCDF4=$(shell python -c "import netCDF4" 2> /dev/null && echo "yes")
-
-ifneq ($(HAS_NUMPY), yes)
-ifneq ($(HAS_NETCDF4), yes)
-USE_VENV=yes
-endif
-endif
-
 OUT=ocean_hgrid.nc sponge.nc temp_salt_ic.nc topog.nc
 
-all: $(OUT)
-
 $(OUT):
-ifeq ($(USE_VENV),yes)
-	python3 -m venv local-env
-	. local-env/bin/activate \
-	  && pip3 install wheel \
-	  && pip3 install cython \
-	  && pip3 install numpy \
-	  && pip3 install netCDF4 \
-	  && python3 build_grid.py \
-	  && python3 build_data.py
-else
 	python build_grid.py
 	python build_data.py
-endif
 
 clean:
-	rm -rf local-env $(OUT)
+	rm -rf $(OUT)

--- a/.testing/tc4/Makefile
+++ b/.testing/tc4/Makefile
@@ -1,28 +1,31 @@
-# TODO: Resolve python path
 # TODO: Identify if venv is available
-PYTHON=python3
-PIP=pip3
+HAS_NUMPY=$(shell python -c "import numpy" 2> /dev/null && echo "yes")
+HAS_NETCDF4=$(shell python -c "import netCDF4" 2> /dev/null && echo "yes")
 
-HAS_NUMPY=$(shell $(PYTHON) -c "import numpy" && echo "yes")
-HAS_NETCDF4=$(shell $(PYTHON) -c "import netCDF4" && echo "yes")
+ifneq ($(HAS_NUMPY), yes)
+ifneq ($(HAS_NETCDF4), yes)
+USE_VENV=yes
+endif
+endif
 
 OUT=ocean_hgrid.nc sponge.nc temp_salt_ic.nc topog.nc
 
 all: $(OUT)
 
 $(OUT):
-ifneq ($(HAS_NUMPY), yes)
-ifneq ($(HAS_NETCDF4), yes)
-	$(PYTHON) -m venv local-env
+ifeq ($(USE_VENV),yes)
+	python3 -m venv local-env
 	. local-env/bin/activate \
-	  && $(PIP) install wheel \
-	  && $(PIP) install cython \
-	  && $(PIP) install numpy \
-	  && $(PIP) install netCDF4
+	  && pip3 install wheel \
+	  && pip3 install cython \
+	  && pip3 install numpy \
+	  && pip3 install netCDF4 \
+	  && python3 build_grid.py \
+	  && python3 build_data.py
+else
+	python build_grid.py
+	python build_data.py
 endif
-endif
-	$(PYTHON) build_grid.py
-	$(PYTHON) build_data.py
 
 clean:
 	rm -rf local-env $(OUT)

--- a/.testing/tc4/Makefile
+++ b/.testing/tc4/Makefile
@@ -2,18 +2,18 @@ all: ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc
 
 ../local-env:
 	python3 -m venv ../local-env
-	source ../local-env/bin/activate \
+	. ../local-env/bin/activate \
 	  && pip3 install wheel \
 	  && pip3 install cython \
 	  && pip3 install numpy \
 	  && pip3 install netCDF4
 
 ocean_hgrid.nc topog.nc: ../local-env
-	source ../local-env/bin/activate \
+	. ../local-env/bin/activate \
 	  && python build_grid.py
 
 temp_salt_ic.nc sponge.nc: ../local-env
-	source ../local-env/bin/activate \
+	. ../local-env/bin/activate \
 	  && python build_data.py
 
 clean:

--- a/.testing/tc4/Makefile
+++ b/.testing/tc4/Makefile
@@ -1,19 +1,19 @@
 all: ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc
 
-local-env:
-	python3 -m venv local-env
-	. local-env/bin/activate \
+../local-env:
+	python3 -m venv ../local-env
+	source ../local-env/bin/activate \
 	  && pip3 install wheel \
 	  && pip3 install cython \
 	  && pip3 install numpy \
 	  && pip3 install netCDF4
 
-ocean_hgrid.nc topog.nc: local-env
-	. local-env/bin/activate \
+ocean_hgrid.nc topog.nc: ../local-env
+	source ../local-env/bin/activate \
 	  && python build_grid.py
 
-temp_salt_ic.nc sponge.nc: local-env
-	. local-env/bin/activate \
+temp_salt_ic.nc sponge.nc: ../local-env
+	source ../local-env/bin/activate \
 	  && python build_data.py
 
 clean:

--- a/.testing/tc4/Makefile
+++ b/.testing/tc4/Makefile
@@ -1,3 +1,6 @@
 ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc:
-	python build_grid.py
-	python build_data.py
+	python -m venv local-env
+	. local-env/bin/activate \
+	  && pip install netCDF4 \
+	  && python build_grid.py \
+	  && python build_data.py

--- a/.testing/tc4/Makefile
+++ b/.testing/tc4/Makefile
@@ -1,20 +1,28 @@
-all: ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc
+# TODO: Resolve python path
+# TODO: Identify if venv is available
+PYTHON=python3
+PIP=pip3
 
-../local-env:
-	python3 -m venv ../local-env
-	. ../local-env/bin/activate \
-	  && pip3 install wheel \
-	  && pip3 install cython \
-	  && pip3 install numpy \
-	  && pip3 install netCDF4
+HAS_NUMPY=$(shell $(PYTHON) -c "import numpy" && echo "yes")
+HAS_NETCDF4=$(shell $(PYTHON) -c "import netCDF4" && echo "yes")
 
-ocean_hgrid.nc topog.nc: ../local-env
-	. ../local-env/bin/activate \
-	  && python build_grid.py
+OUT=ocean_hgrid.nc sponge.nc temp_salt_ic.nc topog.nc
 
-temp_salt_ic.nc sponge.nc: ../local-env
-	. ../local-env/bin/activate \
-	  && python build_data.py
+all: $(OUT)
+
+$(OUT):
+ifneq ($(HAS_NUMPY), yes)
+ifneq ($(HAS_NETCDF4), yes)
+	$(PYTHON) -m venv local-env
+	. local-env/bin/activate \
+	  && $(PIP) install wheel \
+	  && $(PIP) install cython \
+	  && $(PIP) install numpy \
+	  && $(PIP) install netCDF4
+endif
+endif
+	$(PYTHON) build_grid.py
+	$(PYTHON) build_data.py
 
 clean:
-	rm -rf local-env ocean_hgrid.nc topog.nc temp_salt_ic.nc sponge.nc
+	rm -rf local-env $(OUT)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
     - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev gfortran
     - mpich libmpich-dev
     - doxygen graphviz flex bison cmake
+    - python-numpy python-netcdf4
     - python3 python3-dev python3-venv python3-pip
     - bc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev gfortran
     - mpich libmpich-dev
     - doxygen graphviz flex bison cmake
-    - python-virtualenv
+    - python-dev python-virtualenv
     - bc
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
     - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev gfortran
     - mpich libmpich-dev
     - doxygen graphviz flex bison cmake
+    - python-virtualenv
     - bc
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev gfortran
     - mpich libmpich-dev
     - doxygen graphviz flex bison cmake
-    - python-dev python-virtualenv
+    - python3 python3-dev
     - bc
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev gfortran
     - mpich libmpich-dev
     - doxygen graphviz flex bison cmake
-    - python3 python3-dev
+    - python3 python3-dev python3-venv
     - bc
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev gfortran
     - mpich libmpich-dev
     - doxygen graphviz flex bison cmake
-    - python3 python3-dev python3-venv
+    - python3 python3-dev python3-venv python3-pip
     - bc
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
     - tcsh pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev gfortran
     - mpich libmpich-dev
     - doxygen graphviz flex bison cmake
-    - python-numpy python-netcdf4
     - bc
 
 jobs:


### PR DESCRIPTION
Currently, users are expected to have numpy and netcdf4 python modules
in order to generate the necessary netCDF input files.  This fails in
environments where these modules are unavailable.

This patch now installs the modules into a virtual environment which are
accessible when generating the tc4 inputs.

This solution is local to tc4 but could be extended to other tests as
needed.