### PR TITLE
(*)Correct the values returned by wave_speeds

### DIFF
--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -686,6 +686,7 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
                                      !! below which 0 is returned [L T-1 ~> m s-1].
   real,    optional, intent(in) :: wave_speed_tol !< The fractional tolerance for finding the
                                      !! wave speeds [nondim]
+
   ! Local variables
   real, dimension(SZK_(G)+1) :: &
     dRho_dT, &    ! Partial derivative of density with temperature [R degC-1 ~> kg m-3 degC-1]
@@ -696,23 +697,22 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
     H_top, &      ! The distance of each filtered interface from the ocean surface [Z ~> m]
     H_bot, &      ! The distance of each filtered interface from the bottom [Z ~> m]
     gprime        ! The reduced gravity across each interface [L2 Z-1 T-2 ~> m s-2].
-  real, dimension(SZK_(G)) :: &
-    Igl, Igu      ! The inverse of the reduced gravity across an interface times
-                  ! the thickness of the layer below (Igl) or above (Igu) it, in [T2 L-2 ~> s2 m-2].
-  real, dimension(SZK_(G)-1) :: &
-    a_diag, b_diag, c_diag
-                  ! diagonals of tridiagonal matrix; one value for each
-                  ! interface (excluding surface and bottom) [T2 L-2 ~> s2 m-2]
   real, dimension(SZK_(G),SZI_(G)) :: &
     Hf, &         ! Layer thicknesses after very thin layers are combined [Z ~> m]
     Tf, &         ! Layer temperatures after very thin layers are combined [degC]
     Sf, &         ! Layer salinities after very thin layers are combined [ppt]
     Rf            ! Layer densities after very thin layers are combined [R ~> kg m-3]
   real, dimension(SZK_(G)) :: &
+    Igl, Igu, &   ! The inverse of the reduced gravity across an interface times
+                  ! the thickness of the layer below (Igl) or above (Igu) it, in [T2 L-2 ~> s2 m-2].
     Hc, &         ! A column of layer thicknesses after convective istabilities are removed [Z ~> m]
     Tc, &         ! A column of layer temperatures after convective istabilities are removed [degC]
     Sc, &         ! A column of layer salinites after convective istabilities are removed [ppt]
     Rc            ! A column of layer densities after convective istabilities are removed [R ~> kg m-3]
+  real, dimension(SZK_(G)-1) :: &
+    a_diag, b_diag, c_diag
+                  ! diagonals of tridiagonal matrix; one value for each
+                  ! interface (excluding surface and bottom) [T2 L-2 ~> s2 m-2]
   real :: I_Htot  ! The inverse of the total filtered thicknesses [Z ~> m]
   real :: c1_thresh  ! if c1 is below this value, don't bother calculating
                      ! cn values for higher modes [L T-1 ~> m s-1]
@@ -722,7 +722,7 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
   real :: det, ddet       ! determinant & its derivative of eigen system
   real :: lam_1           ! approximate mode-1 eigenvalue [T2 L-2 ~> s2 m-2]
   real :: lam_n           ! approximate mode-n eigenvalue [T2 L-2 ~> s2 m-2]
-  real :: dlam            ! increment in lam for Newton's method [T2 L-2 ~> s2 m-2]
+  real :: dlam            ! The change in estimates of the eigenvalue [T2 L-2 ~> s m-1]
   real :: lamMin          ! minimum lam value for root searching range [T2 L-2 ~> s2 m-2]
   real :: lamMax          ! maximum lam value for root searching range [T2 L-2 ~> s2 m-2]
   real :: lamInc          ! width of moving window for root searching [T2 L-2 ~> s2 m-2]
@@ -735,7 +735,6 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
           xbl,xbr         ! lam guesses bracketing a zero-crossing (root) [T2 L-2 ~> s2 m-2]
   integer :: numint       ! number of widows (intervals) in root searching range
   integer :: nrootsfound  ! number of extra roots found (not including 1st root)
-  real :: min_h_frac
   real :: Z_to_pres ! A conversion factor from thicknesses to pressure [R L2 T-2 Z-1 ~> Pa m-1]
   real, dimension(SZI_(G)) :: &
     htot, hmin, &  ! Thicknesses [Z ~> m]
@@ -747,13 +746,14 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
   real :: speed2_min ! minimum mode speed (squared) to consider in root searching [L2 T-2 ~> m2 s-2]
   real :: cg1_min2 ! A floor in the squared first mode speed below which 0 is returned [L2 T-2 ~> m2 s-2]
   real, parameter :: reduct_factor = 0.5
-                     ! factor used in setting speed2_min [nondim]
+                     ! A factor used in setting speed2_min [nondim]
   real :: I_Hnew   ! The inverse of a new layer thickness [Z-1 ~> m-1]
   real :: drxh_sum ! The sum of density differences across interfaces times thicknesses [R Z ~> kg m-2]
   real, pointer, dimension(:,:,:) :: T => NULL(), S => NULL()
   real :: g_Rho0   ! G_Earth/Rho0 [L2 T-2 Z-1 R-1 ~> m4 s-2 kg-1].
   real :: tol_Hfrac  ! Layers that together are smaller than this fraction of
                      ! the total water column can be merged for efficiency.
+  real :: min_h_frac ! tol_Hfrac divided by the total number of layers [nondim].
   real :: tol_solve  ! The fractional tolerance with which to solve for the wave speeds [nondim].
   real :: tol_merge  ! The fractional change in estimated wave speed that is allowed
                      ! when deciding to merge layers in the calculation [nondim]
@@ -762,8 +762,6 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
   logical :: use_EOS    ! If true, density is calculated from T & S using the equation of state.
   logical :: better_est ! If true, use an improved estimate of the first mode internal wave speed.
   logical :: merge      ! If true, merge the current layer with the one above.
-  real, dimension(SZK_(G)+1) :: z_int
-  ! real, dimension(SZK_(G)+1) :: N2  ! The local squared buoyancy frequency [T-2 ~> s-2]
   integer :: nsub       ! number of subintervals used for root finding
   integer, parameter :: sub_it_max = 4
                         ! maximum number of times to subdivide interval
@@ -786,9 +784,9 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
 
   S => tv%S ; T => tv%T
   g_Rho0 = GV%g_Earth / GV%Rho0
-  use_EOS = associated(tv%eqn_of_state)
   ! Simplifying the following could change answers at roundoff.
   Z_to_pres = GV%Z_to_H * (GV%H_to_RZ * GV%g_Earth)
+  use_EOS = associated(tv%eqn_of_state)
   c1_thresh = 0.01*US%m_s_to_L_T
   c2_scale = US%m_s_to_L_T**2 / 4096.0**2 ! Other powers of 2 give identical results.
 
@@ -799,10 +797,14 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
     if (present(wave_speed_tol)) tol_solve = wave_speed_tol
     tol_Hfrac  = 0.1*tol_solve ; tol_merge = tol_solve / real(nz)
   else
-    tol_Hfrac  = 0.0001 ; tol_solve = 0.001 ; tol_merge = 0.001
+    tol_solve = 0.001 ; tol_Hfrac  = 0.0001 ; tol_merge = 0.001
   endif
   cg1_min2 = 0.0 ; if (present(CS)) cg1_min2 = CS%min_speed2
   if (present(min_speed)) cg1_min2 = min_speed**2
+
+  ! Zero out all wave speeds.  Values over land or for columns that are too weakly stratified
+  ! are not changed from this zero value.
+  cn(:,:,:) = 0.0
 
   min_h_frac = tol_Hfrac / real(nz)
   !$OMP parallel do default(private) shared(is,ie,js,je,nz,h,G,GV,US,min_h_frac,use_EOS,T,S, &
@@ -922,9 +924,7 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
 
         !   Find gprime across each internal interface, taking care of convective
         ! instabilities by merging layers.
-        if (g_Rho0 * drxh_sum <= cg1_min2) then
-          cn(i,j,:) = 0.0
-        else
+        if (g_Rho0 * drxh_sum > cg1_min2) then
           ! Merge layers to eliminate convective instabilities or exceedingly
           ! small reduced gravities.  Merging layers reduces the estimated wave speed by
           ! (rho(2)-rho(1))*h(1)*h(2) / H_tot.
@@ -995,7 +995,7 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
                 ! far back we go.
                 do k2=kc,2,-1
                   if (better_est) then
-                    merge = ((Rc(k2)-Rc(k2-1)) * ((Hc(kc) * Hc(k2-1))*I_Htot) < tol_merge*drxh_sum)
+                    merge = ((Rc(k2)-Rc(k2-1)) * ((Hc(k2) * Hc(k2-1))*I_Htot) < tol_merge*drxh_sum)
                   else
                     merge = ((Rc(k2)-Rc(k2-1)) * (Hc(k2)+Hc(k2-1)) < tol_merge*drxh_sum)
                   endif
@@ -1019,12 +1019,11 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
           endif  ! use_EOS
 
           !-----------------NOW FIND WAVE SPEEDS---------------------------------------
-          ig = i + G%idg_offset ; jg = j + G%jdg_offset
+          ! ig = i + G%idg_offset ; jg = j + G%jdg_offset
           !   Sum the contributions from all of the interfaces to give an over-estimate
-          ! of the first-mode wave speed.
+          ! of the first-mode wave speed.  Also populate Igl and Igu which are the
+          ! non-leading diagonals of the tridiagonal matrix.
           if (kc >= 2) then
-            ! Set depth at surface
-            z_int(1) = 0.0
             ! initialize speed2_tot
             speed2_tot = 0.0
             if (better_est) then
@@ -1038,41 +1037,25 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
             ! [excludes surface (K=1) and bottom (K=kc+1)]
             do K=2,kc
               Igl(K) = 1.0/(gprime(K)*Hc(k)) ; Igu(K) = 1.0/(gprime(K)*Hc(k-1))
-              z_int(K) = z_int(K-1) + Hc(k-1)
-              ! N2(K) = US%L_to_Z**2*gprime(K)/(0.5*(Hc(k)+Hc(k-1)))
               if (better_est) then
                 speed2_tot = speed2_tot + gprime(K)*((H_top(K) * H_bot(K)) * I_Htot)
               else
                 speed2_tot = speed2_tot + gprime(K)*(Hc(k-1)+Hc(k))
               endif
             enddo
-            ! Set stratification for surface and bottom (setting equal to nearest interface for now)
-            ! N2(1) = N2(2) ; N2(kc+1) = N2(kc)
-            ! Calculate depth at bottom
-            z_int(kc+1) = z_int(kc)+Hc(kc)
-            ! check that thicknesses sum to total depth
-            if (abs(z_int(kc+1)-htot(i)) > 1.e-12*htot(i)) then
-              call MOM_error(FATAL, "wave_structure: mismatch in total depths")
-            endif
 
-            ! Define the diagonals of the tridiagonal matrix
-            ! First, populate interior rows
-            do K=3,kc-1
-              row = K-1 ! indexing for TD matrix rows
-              a_diag(row) = -Igu(K)
-              b_diag(row) = Igu(K)+Igl(K)
-              c_diag(row) = -Igl(K)
+            ! Define the diagonals of the tridiagonal matrix for use by tridiag_det
+            a_diag(1) = 0.0
+            b_diag(1) = Igu(2)+Igl(2)
+            c_diag(1) = -Igl(2)
+            do k=2,kc-2
+              a_diag(k) = -Igu(k+1)
+              b_diag(k) = Igu(k+1)+Igl(k+1)
+              c_diag(k) = -Igl(k+1)
             enddo
-            ! Populate top row of tridiagonal matrix
-            K=2 ; row = K-1
-            a_diag(row) = 0.0
-            b_diag(row) = Igu(K)+Igl(K)
-            c_diag(row) = -Igl(K)
-            ! Populate bottom row of tridiagonal matrix
-            K=kc ; row = K-1
-            a_diag(row) = -Igu(K)
-            b_diag(row) = Igu(K)+Igl(K)
-            c_diag(row) = 0.0
+            a_diag(kc-1) = -Igu(kc)
+            b_diag(kc-1) = Igu(kc)+Igl(kc)
+            c_diag(kc-1) = 0.0
             ! Total number of rows in the matrix = number of interior interfaces
             nrows = kc-1
 
@@ -1082,25 +1065,25 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
             ! Find the first eigen value
             do itt=1,max_itt
               ! calculate the determinant of (A-lam_1*I)
-              call tridiag_det(a_diag(1:nrows),b_diag(1:nrows),c_diag(1:nrows), &
-                                      nrows,lam_1,det,ddet, row_scale=c2_scale)
-              ! Use Newton's method iteration to find a new estimate of lam_1
+              call tridiag_det(a_diag(1:nrows), b_diag(1:nrows), c_diag(1:nrows), &
+                                      nrows, lam_1, det, ddet, row_scale=c2_scale)
+
+              ! If possible, use Newton's method iteration to find a new estimate of lam_1
               !det = det_it(itt) ; ddet = ddet_it(itt)
               if ((ddet >= 0.0) .or. (-det > -0.5*lam_1*ddet)) then
                 ! lam_1 was not an under-estimate, as intended, so Newton's method
-                ! may not be reliable; lam_1 must be reduced, but not by more
-                ! than half.
+                ! may not be reliable; lam_1 must be reduced, but not by more than half.
                 lam_1 = 0.5 * lam_1
+                dlam = -lam_1
               else  ! Newton's method is OK.
                 dlam = - det / ddet
                 lam_1 = lam_1 + dlam
-                if (abs(dlam) < tol_solve*lam_1) then
-                  ! calculate 1st mode speed
-                  if (lam_1 > 0.0) cn(i,j,1) = 1.0 / sqrt(lam_1)
-                  exit
-                endif
               endif
+
+              if (abs(dlam) < tol_solve*lam_1) exit
             enddo
+
+            if (lam_1 > 0.0) cn(i,j,1) = 1.0 / sqrt(lam_1)
 
             ! Find other eigen values if c1 is of significant magnitude, > cn_thresh
             nrootsfound = 0    ! number of extra roots found (not including 1st root)
@@ -1177,7 +1160,7 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
                 elseif (iint == numint) then
                   ! oops, lamMax not large enough - could add code to increase (BDM)
                   ! set unfound modes to zero for now (BDM)
-                  cn(i,j,nrootsfound+2:nmodes) = 0.0
+                  !   cn(i,j,nrootsfound+2:nmodes) = 0.0
                 else
                   ! else shift interval and keep looking until nmodes or numint is reached
                   det_l = det_r
@@ -1195,22 +1178,14 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos, better_spee
                   ! Use Newton's method to find a new estimate of lam_n
                   dlam = - det / ddet
                   lam_n = lam_n + dlam
-                  if (abs(dlam) < tol_solve*lam_1) then
-                    ! calculate nth mode speed
-                    if (lam_n > 0.0) cn(i,j,m+1) = 1.0 / sqrt(lam_n)
-                    exit
-                  endif ! within tol
+                  if (abs(dlam) < tol_solve*lam_1)  exit
                 enddo ! itt-loop
+                ! calculate nth mode speed
+                if (lam_n > 0.0) cn(i,j,m+1) = 1.0 / sqrt(lam_n)
               enddo ! n-loop
-            else
-              cn(i,j,2:nmodes) = 0.0 ! else too small to worry about
             endif ! if nmodes>1 .and. kc>nmodes .and. c1>c1_thresh
-          else
-            cn(i,j,:) = 0.0
           endif ! if more than 2 layers
         endif ! if drxh_sum < 0
-      else
-        cn(i,j,:) = 0.0 ! This is a land point.
       endif ! if not land
     enddo ! i-loop
   enddo ! j-loop
@@ -1221,47 +1196,50 @@ end subroutine wave_speeds
 !! with lam, where lam is constant across rows.  Only the ratio of det to its derivative and their
 !! signs are typically used, so internal rescaling by consistent factors are used to avoid
 !! over- or underflow.
-subroutine tridiag_det(a, b, c, nrows, lam, det_out, ddet_out, row_scale)
-  real, dimension(:), intent(in) :: a !< Lower diagonal of matrix (first entry = 0)
-  real, dimension(:), intent(in) :: b !< Leading diagonal of matrix (excluding lam)
-  real, dimension(:), intent(in) :: c !< Upper diagonal of matrix (last entry = 0)
+subroutine tridiag_det(a, b, c, nrows, lam, det, ddet, row_scale)
+  real, dimension(:), intent(in) :: a     !< Lower diagonal of matrix (first entry unused)
+  real, dimension(:), intent(in) :: b     !< Leading diagonal of matrix (excluding lam)
+  real, dimension(:), intent(in) :: c     !< Upper diagonal of matrix (last entry unused)
   integer,            intent(in) :: nrows !< Size of matrix
-  real,               intent(in) :: lam !< Value subtracted from b
-  real,               intent(out):: det_out !< Determinant
-  real,               intent(out):: ddet_out !< Derivative of determinant w.r.t. lam
+  real,               intent(in) :: lam   !< Value subtracted from b
+  real,               intent(out):: det   !< Determinant
+  real,               intent(out):: ddet  !< Derivative of determinant with lam
   real,     optional, intent(in) :: row_scale !< A scaling factor of the rows of the
                                       !! matrix to limit the growth of the determinant
   ! Local variables
-  real, dimension(nrows) :: det ! value of recursion function
-  real, dimension(nrows) :: ddet ! value of recursion function for derivative
+  real :: detKm1, detKm2   ! Cumulative value of the determinant for the previous two layers.
+  real :: ddetKm1, ddetKm2 ! Derivative of the cumulative determinant with lam for the previous two layers.
   real, parameter :: rescale = 1024.0**4 ! max value of determinant allowed before rescaling
-  real :: rscl
+  real :: rscl      ! A rescaling factor that is applied succesively to each row.
   real :: I_rescale ! inverse of rescale
-  integer :: n      ! row (layer interface) index
+  integer :: k      ! row (layer interface) index
 
   if (size(b) /= nrows) call MOM_error(WARNING, "Diagonal b must be same length as nrows.")
   if (size(a) /= nrows) call MOM_error(WARNING, "Diagonal a must be same length as nrows.")
   if (size(c) /= nrows) call MOM_error(WARNING, "Diagonal c must be same length as nrows.")
 
-  I_rescale = 1.0/rescale
+  I_rescale = 1.0 / rescale
   rscl = 1.0 ; if (present(row_scale)) rscl = row_scale
 
-  det(1) = 1.0      ; ddet(1) = 0.0
-  if (nrows > 1) then ; det(2) = b(2)-lam ; ddet(2) = -1.0 ; endif
-  do n=3,nrows
-    det(n)  = rscl*(b(n)-lam)*det(n-1)  - rscl*(a(n)*c(n-1))*det(n-2)
-    ddet(n) = rscl*(b(n)-lam)*ddet(n-1) - rscl*(a(n)*c(n-1))*ddet(n-2) - det(n-1)
-    ! Rescale det & ddet if det is getting too large or too small to avoid overflow or underflow.
-    if (abs(det(n)) > rescale) then
-      det(n)  = I_rescale*det(n)  ; det(n-1)  = I_rescale*det(n-1)
-      ddet(n) = I_rescale*ddet(n) ; ddet(n-1) = I_rescale*ddet(n-1)
-    elseif (abs(det(n)) < I_rescale) then
-      det(n)  = rescale*det(n)  ; det(n-1)  = rescale*det(n-1)
-      ddet(n) = rescale*ddet(n) ; ddet(n-1) = rescale*ddet(n-1)
+  detKm1 = 1.0 ; ddetKm1 = 0.0
+  det = (b(1) - lam) ; ddet = -1.0
+  do k=2,nrows
+    ! Shift variables and rescale rows to avoid over- or underflow.
+    detKm2 = row_scale*detKm1 ; ddetKm2 = row_scale*ddetKm1
+    detKm1 = row_scale*det    ; ddetKm1 = row_scale*ddet
+
+    det = (b(k)-lam)*detKm1 - (a(k)*c(k-1))*detKm2
+    ddet = (b(k)-lam)*ddetKm1 - (a(k)*c(k-1))*ddetKm2 - detKm1
+
+    ! Rescale det & ddet if det is getting too large or too small.
+    if (abs(det) > rescale) then
+      det = I_rescale*det ; detKm1 = I_rescale*detKm1
+      ddet = I_rescale*ddet ; ddetKm1 = I_rescale*ddetKm1
+    elseif (abs(det) < I_rescale) then
+      det = rescale*det ; detKm1 = rescale*detKm1
+      ddet = rescale*ddet ; ddetKm1 = rescale*ddetKm1
     endif
   enddo
-  det_out = det(nrows)
-  ddet_out = ddet(nrows) / rscl
 
 end subroutine tridiag_det
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -352,7 +352,6 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   endif ! associated(tv%T) .AND. associated(tv%frazil)
   if (CS%debugConservation) call MOM_state_stats('1st make_frazil', u, v, h, tv%T, tv%S, G, GV, US)
 
-
   if (CS%use_int_tides) then
     ! This block provides an interface for the unresolved low-mode internal tide module (BDM).
     call set_int_tide_input(u, v, h, tv, fluxes, CS%int_tide_input, dt, G, GV, US, &
@@ -3379,13 +3378,13 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
   if (CS%use_int_tides) then
     CS%id_cg1 = register_diag_field('ocean_model', 'cn1', diag%axesT1, &
-                 Time, 'First baroclinic mode (eigen) speed', 'm s-1')
+                 Time, 'First baroclinic mode (eigen) speed', 'm s-1', conversion=US%L_T_to_m_s)
     allocate(CS%id_cn(CS%nMode)) ; CS%id_cn(:) = -1
     do m=1,CS%nMode
       write(var_name, '("cn_mode",i1)') m
       write(var_descript, '("Baroclinic (eigen) speed of mode ",i1)') m
       CS%id_cn(m) = register_diag_field('ocean_model',var_name, diag%axesT1, &
-                   Time, var_descript, 'm s-1')
+                   Time, var_descript, 'm s-1', conversion=US%L_T_to_m_s)
       call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
     enddo
   endif


### PR DESCRIPTION
  Revised wave_speeds to agree with the calculation of the first mode wave speed
in wave_speed, and to also avoid returning speeds that report back uninitialized
values that do not reproduce across processor layouts and are not dimensionally
consistent.  With these revisions, the diagnosed speeds of the modes reproduce
other solutions, reproduce across layouts, are of sensible magnitude and are
demonstrably dimensionally consistent.  Also use the same underlying routines as
a part of wave_speed and wave_speeds to make the commonalities between the
routines more obvious.  The answers returned by wave_speed are unchanged, but
the answers returned by wave_speeds do change, and this could change the overall
model solutions in cases where these wave speeds are actively used in
parameterizations, and some diagnostics of internal wave speeds have changed
deliberately. The commits in this PR include:

- NOAA-GFDL/MOM6@74614b588 Use similar routines in wave_speed and wave_speeds
- NOAA-GFDL/MOM6@13d74a4f6 (*)Revised the routine wave_speeds