### PR TITLE
*+Add halo updates needed with VERTEX_SHEAR=True

### DIFF
--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -80,7 +80,7 @@ type, public :: Kappa_shear_CS ; private
                              !! greater than 1.  The lower limit for the permitted fractional
                              !! decrease is (1 - 0.5/kappa_src_max_chg).  These limits could
                              !! perhaps be made dynamic with an improved iterative solver.
-  logical :: psurf_bug       !! If true, do a simple average of the cell surface pressures to get a
+  logical :: psurf_bug       !< If true, do a simple average of the cell surface pressures to get a
                              !! surface pressure at the corner if VERTEX_SHEAR=True.  Otherwise mask
                              !! out any land points in the average.
   logical :: all_layer_TKE_bug !< If true, report back the latest estimate of TKE instead of the


### PR DESCRIPTION
  Made a set of changes to add halo updates that are needed to reproduce answers
across PE layouts or for reentrant cases with USE_JACKSON_PARAM=True and
VERTEX_SHEAR=True.  The changes include:

  1. Add halo updates for T & S after advection if needed.
  2. Add new optional argument to extract_diabatic_member to return the valid
     temperature, salinity, p_surf and thickness halos that are required upon
     entry to calls to diabatic.
  3. Added the new runtime parameter KAPPA_SHEAR_VERTEX_PSURF_BUG, which when
     set to False causes the surface pressures used in equation of state
     calculations in the kappa-shear code to avoid averaging any values from
     land points.
  4. Stopped logging the debugging parameter DEBUG_KAPPA_SHEAR in a prelude
     to obsoleting it, as the debugging output this triggers is not so invasive
     as it once was (it is now a few checksums, and not extensive reporting on
     each column), and there is no reason why DEBUG should not trigger it,
     as is now the case.
  4. Added chksum calls with appropriate halo sizes to check the MOM state
     before calls to set_diffusivity.
  5. Added a haloshift=0 argument to a call to MOM_surface_chksum to avoid
     spuriously flagging halo regions that were not supposed to reproduce.

The answers in most test cases in MOM6-examples are bitwise identical, and there
are no changes to output files, but this does change answers in cases with
VERTEX_SHEAR=True, including ice_ocean_SIS2/SIS2_bergs_cgrid, which was not
previously reproducing across PE layouts.