### PR TITLE
Updating the default setting for BBL_USE_EOS to match USE_REGRIDDING

### DIFF
--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1846,6 +1846,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   logical :: default_2018_answers
   logical :: use_kappa_shear, adiabatic, use_omega, MLE_use_PBL_MLD
   logical :: use_CVMix_ddiff, differential_diffusion, use_KPP
+  logical :: use_regridding
   character(len=200) :: filename, tideamp_file
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to OBC segment type
   ! This include declares and sets the variable "version".
@@ -1991,10 +1992,13 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                    "velocity magnitude.  DRAG_BG_VEL is only used when "//&
                    "BOTTOMDRAGLAW is defined.", units="m s-1", default=0.0, scale=US%m_s_to_L_T)
     endif
+    call get_param(param_file, mdl, "USE_REGRIDDING", use_regridding, &
+         do_not_log = .true.)
     call get_param(param_file, mdl, "BBL_USE_EOS", CS%BBL_use_EOS, &
                  "If true, use the equation of state in determining the "//&
                  "properties of the bottom boundary layer.  Otherwise use "//&
-                 "the layer target potential densities.", default=.false.)
+                 "the layer target potential densities.  The default of "//&
+                 "this is determined by USE_REGRIDDING.", default=use_regridding)
   endif
   call get_param(param_file, mdl, "BBL_THICK_MIN", CS%BBL_thick_min, &
                  "The minimum bottom boundary layer thickness that can be "//&

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1999,6 +1999,9 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                  "properties of the bottom boundary layer.  Otherwise use "//&
                  "the layer target potential densities.  The default of "//&
                  "this is determined by USE_REGRIDDING.", default=use_regridding)
+    if (use_regridding .and. (.not. CS%BBL_use_EOS)) &
+      call MOM_error(FATAL,"When using MOM6 in ALE mode it is required to "//&
+           "set BBL_USE_EOS to True")
   endif
   call get_param(param_file, mdl, "BBL_THICK_MIN", CS%BBL_thick_min, &
                  "The minimum bottom boundary layer thickness that can be "//&

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1993,7 +1993,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                    "BOTTOMDRAGLAW is defined.", units="m s-1", default=0.0, scale=US%m_s_to_L_T)
     endif
     call get_param(param_file, mdl, "USE_REGRIDDING", use_regridding, &
-         do_not_log = .true.)
+         do_not_log = .true., default = .false. )
     call get_param(param_file, mdl, "BBL_USE_EOS", CS%BBL_use_EOS, &
                  "If true, use the equation of state in determining the "//&
                  "properties of the bottom boundary layer.  Otherwise use "//&


### PR DESCRIPTION
I tested 1 ALE and 1 layer config for reproducing answers, but I did not sweep the repository for any cases that use the now prevented combination of USE_REGRIDDING = True and BBL_USE_EOS = False.  @Hallberg-NOAA suggests that there are no such cases, which we should confirm soon.

I decided to add "FATAL" error for using these in combination because (1) WARNINGS usually get buried in output text, and (2) I don't see a good reason to allow the model to proceed in this situation.  But we can revisit this.