### PR TITLE
Always set VARIABLE_BUOYFORCE = True with RESTOREBUOY = True

### DIFF
--- a/config_src/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/solo_driver/MOM_surface_forcing.F90
@@ -304,7 +304,7 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
   ! calls to various buoyancy forcing options
   if (CS%restorebuoy .and. .not.CS%variable_buoyforce) then
     call MOM_error(FATAL, "With RESTOREBUOY = True, VARIABLE_BUOYFORCE = True should be used. "//&
-                          "Otherwise, this can lead to diverging soultions when a simulation "//&
+                          "Otherwise, this can lead to diverging solutions when a simulation "//&
                           "is continued using a restart file.")
   endif
 

--- a/config_src/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/solo_driver/MOM_surface_forcing.F90
@@ -303,9 +303,9 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
 
   ! calls to various buoyancy forcing options
   if (CS%restorebuoy .and. .not.CS%variable_buoyforce) then
-    call MOM_error(WARNING, "With RESTOREBUOY = True, VARIABLE_BUOYFORCE = True should be used. "//&
-                            "Changed to VARIABLE_BUOYFORCE = True")
-    CS%variable_buoyforce = .true.
+    call MOM_error(FATAL, "With RESTOREBUOY = True, VARIABLE_BUOYFORCE = True should be used. "//&
+                          "Otherwise, this can lead to diverging soultions when a simulation "//&
+                          "is continued using a restart file.")
   endif
 
   if ((CS%variable_buoyforce .or. CS%first_call_set_forcing) .and. &

--- a/config_src/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/solo_driver/MOM_surface_forcing.F90
@@ -302,6 +302,12 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
   endif
 
   ! calls to various buoyancy forcing options
+  if (CS%restorebuoy .and. .not.CS%variable_buoyforce) then
+    call MOM_error(WARNING, "With RESTOREBUOY = True, VARIABLE_BUOYFORCE = True should be used. "//&
+                            "Changed to VARIABLE_BUOYFORCE = True")
+    CS%variable_buoyforce = .true.
+  endif
+
   if ((CS%variable_buoyforce .or. CS%first_call_set_forcing) .and. &
       (.not.CS%adiabatic)) then
     if (trim(CS%buoy_config) == "file") then


### PR DESCRIPTION
Here is a minor addition in the `MOM_surface_forcing.F90` module. For `RESTOREBUOY = True`, modified code always sets `VARIABLE_BUOYFORCE` to be True (default option in MOM6), even if the user specifies the opposite in `MOM_input` file. A warning message is also printed.

Setting `VARIABLE_BUOYFORCE = False` with `RESTOREBUOY = True` leads to diverging solutions, e.g. in #1157. 

@Hallberg-NOAA Could you please have a quick look?