### PR TITLE
.testing Makefile typo fix

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -293,9 +293,9 @@ $(eval $(call CMP_RULE,regression,symmetric target))
 	  || !( \
 	    mkdir -p results/$*; \
 	    (diff $$^ | tee results/$*/chksum_diag.restart.diff | head) ; \
-	    echo -e "${FAIL}: Diagnostics $*.restart.diag have changed." \
+	    echo -e "${FAIL}: Solutions $*.restart have changed." \
 	  )
-	@echo -e "${PASS}: Diagnostics $*.restart.diag agree."
+	@echo -e "${PASS}: Solutions $*.restart agree."
 
 # TODO: chksum_diag parsing of restart files
 


### PR DESCRIPTION
The restart tests were incorrectly reported as restart.diag tests in the
output log.  This patch fixes these typos.

Restart test diagnostics are currently not checked, and this patch is a
good reminder that we need to get these in ASAP.

This change does not affect source code, so should not require a
regression test.