### PR TITLE
Add a codecov upload job to establish coverage changes

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -243,6 +243,12 @@ test.nans: $(foreach c,$(CONFIGS),$(c).nan $(c).nan.diag)
 test.dims: $(foreach c,$(CONFIGS),$(foreach d,$(DIMS),$(c).dim.$(d) $(c).dim.$(d).diag))
 test.regressions: $(foreach c,$(CONFIGS),$(c).regression $(c).regression.diag)
 
+.PHONY: run.symmetric run.asymmetric run.nans run.openmp
+run.symmetric: $(foreach c,$(CONFIGS),work/$(c)/symmetric/ocean.stats)
+run.asymmetric: $(foreach c,$(filter-out tc3,$(CONFIGS)),$(CONFIGS),work/$(c)/asymmetric/ocean.stats)
+run.nans: $(foreach c,$(CONFIGS),work/$(c)/nan/ocean.stats)
+run.openmp: $(foreach c,$(CONFIGS),work/$(c)/openmp/ocean.stats)
+
 # Color highlights for test results
 RED=\033[0;31m
 GREEN=\033[0;32m

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ jobs:
         - make test.summary
 
     # NOTE: Code coverage upload is here to reduce load imbalance
+    # We do coverage with the regressions if part of a pull request
+    # otherwise as a separate job.
     - if: type = pull_request
       env:
         - JOB="x86 Regression testing"
@@ -56,6 +58,19 @@ jobs:
         - echo -en 'travis_fold:end:script.1\\r'
         - make -k -s test.regressions
         - make test.summary
+
+    - if: NOT type = pull_request
+      env:
+        - JOB="Coverage upload"
+        - REPORT_COVERAGE=true
+        - DO_REGRESSION_TESTS=false
+        - MKMF_TEMPLATE=linux-ubuntu-xenial-gnu.mk
+      script:
+        - cd .testing
+        - echo 'Build executables...' && echo -en 'travis_fold:start:script.1\\r'
+        - make build/symmetric/MOM6
+        - echo -en 'travis_fold:end:script.1\\r'
+        - make -k -s run.symmetric
 
     - arch: arm64
       env:


### PR DESCRIPTION
The code coverage diffs were failing or returning nonsense I suspect because the coverage of the base commit needs to have been uploaded.
- We could upload coverage for the target commit from the the PR itself (i.e. run coverage twice) but then we'd have to send more information about which upload is for which commit. Instead ...
- ...it seems to me that adding a 5 minute job to run coverage for non-PR pushes should solve the issue since it will establish the coverage for any commit that might be the base of a diff. _This is speculative until we actually try it._