### PR TITLE
*Corrected the test whether to use fluxes%psurf

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -595,7 +595,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     dt_therm = dt ; ntstep = 1
     if (associated(fluxes%p_surf)) p_surf => fluxes%p_surf
     CS%tv%p_surf => NULL()
-    if (associated(forces%p_surf)) then  !### This should be fluxes%p_surf!
+    if (associated(fluxes%p_surf)) then
       if (CS%use_p_surf_in_EOS) CS%tv%p_surf => fluxes%p_surf
     endif
     if (CS%UseWaves) call pass_var(fluxes%ustar, G%Domain, clock=id_clock_pass)


### PR DESCRIPTION
  Changed the test to detect whether the surface pressure has been set for use
in the equation of state calculations in the thermodynamic step from evaluating
whether forces%p_surf is associated to whether fluxes%p_surf is associated.
Because these two pointers often point to the same array, this only changes
answers in the coupled_AM2_LM3_SIS2/Intersperse_ice_1deg test case, but it could
change answer in other cases, depending on how MOM6 is called.  Because this
only appears to change answers for one test case that is not widely used yet,
and does not impact configurations that are used outside of GFDL, the decision
was taken not to introduce a bug flag to preserve the old incorrect answers.