### PR TITLE
(*)Reduce size of GV%Rlay and improve error handling

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -375,6 +375,8 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
                   "Unsupported format in grid definition '"//trim(filename)//"'. Error message "//trim(message))
       call field_size(trim(fileName), trim(varName), nzf)
       ke = nzf(1)-1
+      if (ke < 1) call MOM_error(FATAL, trim(mdl)//" initialize_regridding via Var "//trim(varName)//&
+                                 "in FILE "//trim(filename)//" requires at least 2 target interface values.")
       if (CS%regridding_scheme == REGRIDDING_RHO) then
         allocate(rho_target(ke+1))
         call MOM_read_data(trim(fileName), trim(varName), rho_target)
@@ -392,7 +394,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
       allocate(dz(ke))
       call MOM_read_data(trim(fileName), trim(varName), dz)
     endif
-    if (main_parameters .and. ke/=GV%ke) then
+    if (main_parameters .and. (ke/=GV%ke)) then
       call MOM_error(FATAL,trim(mdl)//', initialize_regridding: '// &
                  'Mismatch in number of model levels and "'//trim(string)//'".')
     endif
@@ -2016,17 +2018,22 @@ end subroutine setCoordinateResolution
 !> Set target densities based on the old Rlay variable
 subroutine set_target_densities_from_GV( GV, US, CS )
   type(verticalGrid_type), intent(in)    :: GV !< Ocean vertical grid structure
-  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
+  type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   type(regridding_CS),     intent(inout) :: CS !< Regridding control structure
   ! Local variables
   integer :: k, nz
 
   nz = CS%nk
-  CS%target_density(1)    = (GV%Rlay(1) + 0.5*(GV%Rlay(1)-GV%Rlay(2)))
-  CS%target_density(nz+1) = (GV%Rlay(nz) + 0.5*(GV%Rlay(nz)-GV%Rlay(nz-1)))
-  do k = 2,nz
-    CS%target_density(k) = CS%target_density(k-1) + CS%coordinateResolution(k)
-  enddo
+  if (nz == 1) then ! Set a broad range of bounds.  Regridding may not be meaningful in this case.
+    CS%target_density(1)    = 0.0
+    CS%target_density(2)    = 2.0*GV%Rlay(1)
+  else
+    CS%target_density(1)    = (GV%Rlay(1) + 0.5*(GV%Rlay(1)-GV%Rlay(2)))
+    CS%target_density(nz+1) = (GV%Rlay(nz) + 0.5*(GV%Rlay(nz)-GV%Rlay(nz-1)))
+    do k=2,nz
+      CS%target_density(k)  = CS%target_density(k-1) + CS%coordinateResolution(k)
+    enddo
+  endif
   CS%target_density_set = .true.
 
 end subroutine set_target_densities_from_GV

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -174,8 +174,7 @@ subroutine verticalGridInit( param_file, GV, US )
   allocate( GV%sInterface(nk+1) )
   allocate( GV%sLayer(nk) )
   allocate( GV%g_prime(nk+1) ) ; GV%g_prime(:) = 0.0
-  ! The extent of Rlay should be changed to nk?
-  allocate( GV%Rlay(nk+1) )    ; GV%Rlay(:) = 0.0
+  allocate( GV%Rlay(nk) )      ; GV%Rlay(:) = 0.0
 
 end subroutine verticalGridInit
 

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1558,7 +1558,7 @@ subroutine initialize_temp_salt_fit(T, S, G, GV, US, param_file, eqn_of_state, P
   type(unit_scale_type),   intent(in)  :: US           !< A dimensional unit scaling type
   type(param_file_type),   intent(in)  :: param_file   !< A structure to parse for run-time
                                                        !! parameters.
-  type(EOS_type),          pointer     :: eqn_of_state !< Integer that selects the equatio of state.
+  type(EOS_type),          pointer     :: eqn_of_state !< Equation of state structure
   real,                    intent(in)  :: P_Ref        !< The coordinate-density reference pressure
                                                        !! [R L2 T-2 ~> Pa].
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -2335,7 +2335,12 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, US, PF, just_read_param
     ! Rb contains the layer interface densities
     allocate(Rb(nz+1))
     do k=2,nz ; Rb(k) = 0.5*(GV%Rlay(k-1)+GV%Rlay(k)) ; enddo
-    Rb(1) = 0.0 ;  Rb(nz+1) = 2.0*GV%Rlay(nz) - GV%Rlay(nz-1)
+    Rb(1) = 0.0
+    if (nz>1) then
+      Rb(nz+1) = 2.0*GV%Rlay(nz) - GV%Rlay(nz-1)
+    else
+      Rb(nz+1) = 2.0 * GV%Rlay(1)
+    endif
 
     nkml = 0 ; if (separate_mixed_layer) nkml = GV%nkml
 

--- a/src/user/BFB_initialization.F90
+++ b/src/user/BFB_initialization.F90
@@ -36,14 +36,13 @@ contains
 !! southern edge of the domain. The temperatures are then converted to densities of the top and bottom layers
 !! and linearly interpolated for the intermediate layers.
 subroutine BFB_set_coord(Rlay, g_prime, GV, US, param_file, eqn_of_state)
-  real, dimension(NKMEM_), intent(out) :: Rlay !< Layer potential density [R ~> kg m-3].
-  real, dimension(NKMEM_), intent(out) :: g_prime !< The reduced gravity at
-                                                  !! each interface [L2 Z-1 T-2 ~> m s-2].
-  type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure
-  type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
-  type(param_file_type),   intent(in)  :: param_file !< A structure to parse for run-time parameters
-  type(EOS_type),          pointer     :: eqn_of_state !< Integer that selects the
-                                                     !! equation of state.
+  type(verticalGrid_type),  intent(in)  :: GV      !< The ocean's vertical grid structure
+  real, dimension(GV%ke),   intent(out) :: Rlay    !< Layer potential density [R ~> kg m-3].
+  real, dimension(GV%ke+1), intent(out) :: g_prime !< The reduced gravity at each
+                                                   !! interface [L2 Z-1 T-2 ~> m s-2].
+  type(unit_scale_type),    intent(in)  :: US      !< A dimensional unit scaling type
+  type(param_file_type),    intent(in)  :: param_file !< A structure to parse for run-time parameters
+  type(EOS_type),           pointer     :: eqn_of_state !< Equation of state structure
   ! Local variables
   real                                 :: drho_dt, SST_s, T_bot, rho_top, rho_bot
   integer                              :: k, nz

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -370,7 +370,7 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, G, GV, US, param_fi
         if (fit_salin) then
           ! A first guess of the layers' salinity.
           do k=nz,1,-1
-             S0(k) = max(0.0, S0(1) + (GV%Rlay(k) - rho_guess(1)) / drho_dS1)
+            S0(k) = max(0.0, S0(1) + (GV%Rlay(k) - rho_guess(1)) / drho_dS1)
           enddo
           ! Refine the guesses for each layer.
           do itt=1,6

--- a/src/user/Neverworld_initialization.F90
+++ b/src/user/Neverworld_initialization.F90
@@ -248,8 +248,7 @@ subroutine Neverworld_initialize_thickness(h, G, GV, US, param_file, eqn_of_stat
   type(param_file_type),   intent(in) :: param_file           !< A structure indicating the open
                                                               !! file to parse for model
                                                               !! parameter values.
-  type(EOS_type),          pointer    :: eqn_of_state         !< integer that selects the
-                                                              !! equation of state.
+  type(EOS_type),          pointer    :: eqn_of_state         !< Equation of state structure
   real,                    intent(in) :: P_Ref                !< The coordinate-density
                                                               !! reference pressure [R L2 T-2 ~> Pa].
   ! Local variables

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -125,8 +125,13 @@ subroutine adjustment_initialize_thickness ( h, G, GV, US, param_file, just_read
           e0(k) = -G%max_depth * (real(k-1) / real(nz))
         enddo
       endif
-      target_values(1)    = ( GV%Rlay(1) + 0.5*(GV%Rlay(1)-GV%Rlay(2)) )
-      target_values(nz+1) = ( GV%Rlay(nz) + 0.5*(GV%Rlay(nz)-GV%Rlay(nz-1)) )
+      if (nz > 1) then
+        target_values(1)    = ( GV%Rlay(1) + 0.5*(GV%Rlay(1)-GV%Rlay(2)) )
+        target_values(nz+1) = ( GV%Rlay(nz) + 0.5*(GV%Rlay(nz)-GV%Rlay(nz-1)) )
+      else ! This might not be needed, but it avoids segmentation faults if nz=1.
+        target_values(1)    = 0.0
+        target_values(nz+1) = 2.0 * GV%Rlay(1)
+      endif
       do k = 2,nz
         target_values(k) = target_values(k-1) + ( GV%Rlay(nz) - GV%Rlay(1) ) / (nz-1)
       enddo

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -91,8 +91,7 @@ subroutine benchmark_initialize_thickness(h, G, GV, US, param_file, eqn_of_state
                            intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
-  type(EOS_type),          pointer     :: eqn_of_state !< integer that selects the
-                                                      !! equation of state.
+  type(EOS_type),          pointer     :: eqn_of_state !< Equation of state structure
   real,                    intent(in)  :: P_Ref       !< The coordinate-density
                                                       !! reference pressure [R L2 T-2 ~> Pa].
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -217,16 +216,15 @@ subroutine benchmark_init_temperature_salinity(T, S, G, GV, US, param_file, &
                eqn_of_state, P_Ref, just_read_params)
   type(ocean_grid_type),               intent(in)  :: G            !< The ocean's grid structure.
   type(verticalGrid_type),             intent(in)  :: GV           !< The ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(out) :: T      !< The potential temperature
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out) :: T       !< The potential temperature
                                                                    !! that is being initialized.
-  real, dimension(SZI_(G),SZJ_(G), SZK_(G)), intent(out) :: S      !< The salinity that is being
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(out) :: S       !< The salinity that is being
                                                                    !! initialized.
   type(unit_scale_type),                     intent(in)  :: US     !< A dimensional unit scaling type
   type(param_file_type),               intent(in)  :: param_file   !< A structure indicating the
                                                                    !! open file to parse for
                                                                    !! model parameter values.
-  type(EOS_type),                      pointer     :: eqn_of_state !< integer that selects the
-                                                                   !! equation of state.
+  type(EOS_type),                      pointer     :: eqn_of_state !< Equation of state structure
   real,                                intent(in)  :: P_Ref        !< The coordinate-density
                                                                    !! reference pressure [R L2 T-2 ~> Pa].
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -38,17 +38,15 @@ contains
 
 !> Set vertical coordinates.
 subroutine USER_set_coord(Rlay, g_prime, GV, US, param_file, eqn_of_state)
-  type(verticalGrid_type), intent(in)  :: GV         !< The ocean's vertical grid
-                                                     !! structure.
-  real, dimension(:),      intent(out) :: Rlay       !< Layer potential density [R ~> kg m-3].
-  real, dimension(:),      intent(out) :: g_prime    !< The reduced gravity at
-                                                     !! each interface [L2 Z-1 T-2 ~> m s-2].
-  type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
-  type(param_file_type),   intent(in)  :: param_file !< A structure indicating the
-                                                     !! open file to parse for model
-                                                     !! parameter values.
-  type(EOS_type),          pointer     :: eqn_of_state !< Integer that selects the
-                                                     !! equation of state.
+  type(verticalGrid_type),  intent(in)  :: GV      !< The ocean's vertical grid structure
+  real, dimension(GV%ke),   intent(out) :: Rlay    !< Layer potential density [R ~> kg m-3].
+  real, dimension(GV%ke+1), intent(out) :: g_prime !< The reduced gravity at each
+                                                   !! interface [L2 Z-1 T-2 ~> m s-2].
+  type(unit_scale_type),    intent(in)  :: US      !< A dimensional unit scaling type
+  type(param_file_type),    intent(in)  :: param_file !< A structure indicating the
+                                                   !! open file to parse for model
+                                                   !! parameter values.
+  type(EOS_type),           pointer     :: eqn_of_state !< Equation of state structure
 
   call MOM_error(FATAL, &
     "USER_initialization.F90, USER_set_coord: " // &
@@ -144,8 +142,7 @@ subroutine USER_init_temperature_salinity(T, S, G, param_file, eqn_of_state, jus
   type(param_file_type),                     intent(in)  :: param_file !< A structure indicating the
                                                             !! open file to parse for model
                                                             !! parameter values.
-  type(EOS_type),                            pointer     :: eqn_of_state !< Integer that selects the
-                                                            !! equation of state.
+  type(EOS_type),                            pointer     :: eqn_of_state !< Equation of state structure
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will only
                                                            !! read parameters without changing T & S.
 


### PR DESCRIPTION
  Reduced the size of GV%Rlay to GV%ke, befitting a layer variable, and added
code to issue error messages or appropriately handle cases with very few layers
that would have led to segmentation faults without error handling.  This
includes explicitly setting argument array sizes in various set_coord
subroutines, and correcting the descriptions of some EOS_type arguments.  All
answers in the MOM6-examples regression suite are bitwise identical, but there
may be some answer changes in cases that should not have worked previously.
This PR addresses MOM6 issue #966, which might now be closed.