### PR TITLE
(*)Correct the use of memory macros for arguments

### DIFF
--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -189,7 +189,7 @@ subroutine initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_C
   type(time_type), target,            intent(in) :: day  !< Time of the start of the run.
   type(ocean_grid_type),              intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type),            intent(in) :: GV   !< The ocean's vertical grid structure
-  real, dimension(NIMEM_,NJMEM_,NKMEM_), intent(in) :: h !< Layer thicknesses [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h !< Layer thicknesses [H ~> m or kg m-2]
   type(diag_ctrl), target,            intent(in) :: diag !< Structure used to regulate diagnostic output.
   type(ocean_OBC_type),               pointer    :: OBC  !< This open boundary condition type specifies
                                                          !! whether, where, and what open boundary
@@ -326,11 +326,11 @@ end subroutine dye_tracer_column_physics
 !! returning the number of stocks it has calculated.  If the stock_index
 !! is present, only the stock corresponding to that coded index is returned.
 function dye_stock(h, stocks, G, GV, CS, names, units, stock_index)
-  real, dimension(NIMEM_,NJMEM_,NKMEM_), intent(in) :: h    !< Layer thicknesses [H ~> m or kg m-2]
-  real, dimension(:),                 intent(out)   :: stocks !< the mass-weighted integrated amount of
-                                                            !! each tracer, in kg times concentration units [kg conc].
   type(ocean_grid_type),              intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),            intent(in)    :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h  !< Layer thicknesses [H ~> m or kg m-2]
+  real, dimension(:),                 intent(out)   :: stocks !< the mass-weighted integrated amount of
+                                                            !! each tracer, in kg times concentration units [kg conc].
   type(dye_tracer_CS),                pointer       :: CS   !< The control structure returned by a
                                                             !! previous call to register_dye_tracer.
   character(len=*), dimension(:),     intent(out)   :: names !< the names of the stocks calculated.

--- a/src/user/BFB_initialization.F90
+++ b/src/user/BFB_initialization.F90
@@ -86,13 +86,13 @@ subroutine BFB_initialize_sponges_southonly(G, GV, US, use_temperature, tv, para
   type(thermo_var_ptrs),   intent(in) :: tv   !< A structure pointing to various thermodynamic variables
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
   type(sponge_CS),         pointer    :: CSp  !< A pointer to the sponge control structure
-  real, dimension(NIMEM_, NJMEM_, NKMEM_), &
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(in) :: h    !< Layer thicknesses [H ~> m or kg m-2]
 
   ! Local variables
-  real :: eta(SZI_(G),SZJ_(G),SZK_(G)+1) ! A temporary array for eta, in depth units [Z ~> m].
+  real :: eta(SZI_(G),SZJ_(G),SZK_(GV)+1) ! A temporary array for eta, in depth units [Z ~> m].
   real :: Idamp(SZI_(G),SZJ_(G))    ! The inverse damping rate [T-1 ~> s-1].
-  real :: H0(SZK_(G))               ! Resting layer thicknesses in depth units [Z ~> m].
+  real :: H0(SZK_(GV))              ! Resting layer thicknesses in depth units [Z ~> m].
   real :: min_depth                 ! The minimum ocean depth in depth units [Z ~> m].
   real :: slat, wlon, lenlat, lenlon, nlat
   real :: max_damping               ! The maximum damping rate [T-1 ~> s-1]

--- a/src/user/SCM_CVMix_tests.F90
+++ b/src/user/SCM_CVMix_tests.F90
@@ -53,15 +53,15 @@ contains
 
 !> Initializes temperature and salinity for the SCM CVMix test example
 subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, US, param_file, just_read_params)
-  real, dimension(NIMEM_,NJMEM_, NKMEM_), intent(out) :: T  !< Potential temperature [degC]
-  real, dimension(NIMEM_,NJMEM_, NKMEM_), intent(out) :: S  !< Salinity [psu]
-  real, dimension(NIMEM_,NJMEM_, NKMEM_), intent(in)  :: h  !< Layer thickness [H ~> m or kg m-2]
-  type(ocean_grid_type),                  intent(in)  :: G  !< Grid structure
-  type(verticalGrid_type),                intent(in)  :: GV !< Vertical grid structure
-  type(unit_scale_type),                  intent(in)  :: US !< A dimensional unit scaling type
-  type(param_file_type),                  intent(in)  :: param_file !< Input parameter structure
-  logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
-                                                      !! only read parameters without changing h.
+  type(ocean_grid_type),                     intent(in)  :: G  !< Grid structure
+  type(verticalGrid_type),                   intent(in)  :: GV !< Vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T  !< Potential temperature [degC]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S  !< Salinity [psu]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h  !< Layer thickness [H ~> m or kg m-2]
+  type(unit_scale_type),                     intent(in)  :: US !< A dimensional unit scaling type
+  type(param_file_type),                     intent(in)  :: param_file !< Input parameter structure
+  logical,                         optional, intent(in)  :: just_read_params !< If present and true, this call
+                                                               !! will only read parameters without changing h.
   ! Local variables
   real :: UpperLayerTempMLD !< Upper layer Temp MLD thickness [Z ~> m].
   real :: UpperLayerSaltMLD !< Upper layer Salt MLD thickness [Z ~> m].


### PR DESCRIPTION
  Corrected a number of memory macros that would cause MOM6 to give the wrong
answers and probably lead to segmentation faults if global indexing were
enabled.  Macros like NIMEM_ are intended to be used to support static or
dynamic memory in the declaration of ALLOCABLE_ arrays, but instead were being
used to define the sizes of arguments in some routines, which would cause these
arrays to start at 1, not G%isd, inside these routines.  All answers in the
MOM6-examples test suite are bitwise identical.