### PR TITLE
+Merge dev/master into dev/gfdl

### DIFF
--- a/config_src/mct_driver/mom_ocean_model_mct.F90
+++ b/config_src/mct_driver/mom_ocean_model_mct.F90
@@ -11,56 +11,57 @@ module MOM_ocean_model_mct
 ! This code is a stop-gap wrapper of the MOM6 code to enable it to be called
 ! in the same way as MOM4.
 
-use MOM,                     only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
-use MOM,                     only : extract_surface_state, allocate_surface_state, finish_MOM_initialization
-use MOM,                     only : get_MOM_state_elements, MOM_state_is_synchronized
-use MOM,                     only : get_ocean_stocks, step_offline
-use MOM_constants,           only : CELSIUS_KELVIN_OFFSET, hlf
-use MOM_diag_mediator,       only : diag_ctrl, enable_averaging, disable_averaging
-use MOM_diag_mediator,       only : diag_mediator_close_registration, diag_mediator_end
-use MOM_domains,             only : pass_var, pass_vector, AGRID, BGRID_NE, CGRID_NE
-use MOM_domains,             only : TO_ALL, Omit_Corners
-use MOM_error_handler,       only : MOM_error, FATAL, WARNING, is_root_pe
-use MOM_error_handler,       only : callTree_enter, callTree_leave
-use MOM_file_parser,         only : get_param, log_version, close_param_file, param_file_type
-use MOM_forcing_type,        only : allocate_forcing_type
-use MOM_forcing_type,        only : forcing, mech_forcing
-use MOM_forcing_type,        only : forcing_accumulate, copy_common_forcing_fields
-use MOM_forcing_type,        only : copy_back_forcing_fields, set_net_mass_forcing
-use MOM_forcing_type,        only : set_derived_forcing_fields
-use MOM_forcing_type,        only : forcing_diagnostics, mech_forcing_diags
-use MOM_get_input,           only : Get_MOM_Input, directories
-use MOM_grid,                only : ocean_grid_type
-use MOM_io,                  only : close_file, file_exists, read_data, write_version_number
-use MOM_marine_ice,          only : iceberg_forces, iceberg_fluxes, marine_ice_init, marine_ice_CS
-use MOM_restart,             only : MOM_restart_CS, save_restart
-use MOM_string_functions,    only : uppercase
-use MOM_surface_forcing_mct, only : surface_forcing_init, convert_IOB_to_fluxes
-use MOM_surface_forcing_mct, only : convert_IOB_to_forces, ice_ocn_bnd_type_chksum
-use MOM_surface_forcing_mct, only : ice_ocean_boundary_type, surface_forcing_CS
-use MOM_surface_forcing_mct, only : forcing_save_restart
-use MOM_time_manager,        only : time_type, get_time, set_time, operator(>)
-use MOM_time_manager,        only : operator(+), operator(-), operator(*), operator(/)
-use MOM_time_manager,        only : operator(/=), operator(<=), operator(>=)
-use MOM_time_manager,        only : operator(<), real_to_time_type, time_type_to_real
-use MOM_tracer_flow_control, only : call_tracer_register, tracer_flow_control_init
-use MOM_tracer_flow_control, only : call_tracer_flux_init
-use MOM_unit_scaling,        only : unit_scale_type
-use MOM_variables,           only : surface
-use MOM_verticalGrid,        only : verticalGrid_type
-use MOM_ice_shelf,           only : initialize_ice_shelf, shelf_calc_flux, ice_shelf_CS
-use MOM_ice_shelf,           only : add_shelf_forces, ice_shelf_end, ice_shelf_save_restart
-use coupler_types_mod,       only : coupler_1d_bc_type, coupler_2d_bc_type
-use coupler_types_mod,       only : coupler_type_spawn, coupler_type_write_chksums
-use coupler_types_mod,       only : coupler_type_initialized, coupler_type_copy_data
-use coupler_types_mod,       only : coupler_type_set_diags, coupler_type_send_data
-use mpp_domains_mod,         only : domain2d, mpp_get_layout, mpp_get_global_domain
-use mpp_domains_mod,         only : mpp_define_domains, mpp_get_compute_domain, mpp_get_data_domain
-use fms_mod,                 only : stdout
-use mpp_mod,                 only : mpp_chksum
-use MOM_EOS,                 only : gsw_sp_from_sr, gsw_pt_from_ct
-use MOM_wave_interface,      only: wave_parameters_CS, MOM_wave_interface_init
-use MOM_wave_interface,      only: MOM_wave_interface_init_lite, Update_Surface_Waves
+use MOM,                      only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
+use MOM,                      only : extract_surface_state, allocate_surface_state, finish_MOM_initialization
+use MOM,                      only : get_MOM_state_elements, MOM_state_is_synchronized
+use MOM,                      only : get_ocean_stocks, step_offline
+use MOM_constants,            only : CELSIUS_KELVIN_OFFSET, hlf
+use MOM_diag_mediator,        only : diag_ctrl, enable_averaging, disable_averaging
+use MOM_diag_mediator,        only : diag_mediator_close_registration, diag_mediator_end
+use MOM_domains,              only : pass_var, pass_vector, AGRID, BGRID_NE, CGRID_NE
+use MOM_domains,              only : TO_ALL, Omit_Corners
+use MOM_error_handler,        only : MOM_error, FATAL, WARNING, is_root_pe
+use MOM_error_handler,        only : callTree_enter, callTree_leave
+use MOM_file_parser,          only : get_param, log_version, close_param_file, param_file_type
+use MOM_forcing_type,         only : allocate_forcing_type
+use MOM_forcing_type,         only : forcing, mech_forcing
+use MOM_forcing_type,         only : forcing_accumulate, copy_common_forcing_fields
+use MOM_forcing_type,         only : copy_back_forcing_fields, set_net_mass_forcing
+use MOM_forcing_type,         only : set_derived_forcing_fields
+use MOM_forcing_type,         only : forcing_diagnostics, mech_forcing_diags
+use MOM_get_input,            only : Get_MOM_Input, directories
+use MOM_grid,                 only : ocean_grid_type
+use MOM_io,                   only : close_file, file_exists, read_data, write_version_number
+use MOM_marine_ice,           only : iceberg_forces, iceberg_fluxes, marine_ice_init, marine_ice_CS
+use MOM_restart,              only : MOM_restart_CS, save_restart
+use MOM_string_functions,     only : uppercase
+use MOM_surface_forcing_mct,  only : surface_forcing_init, convert_IOB_to_fluxes
+use MOM_surface_forcing_mct,  only : convert_IOB_to_forces, ice_ocn_bnd_type_chksum
+use MOM_surface_forcing_mct,  only : ice_ocean_boundary_type, surface_forcing_CS
+use MOM_surface_forcing_mct,  only : forcing_save_restart
+use MOM_time_manager,         only : time_type, get_time, set_time, operator(>)
+use MOM_time_manager,         only : operator(+), operator(-), operator(*), operator(/)
+use MOM_time_manager,         only : operator(/=), operator(<=), operator(>=)
+use MOM_time_manager,         only : operator(<), real_to_time_type, time_type_to_real
+use MOM_tracer_flow_control,  only : call_tracer_register, tracer_flow_control_init
+use MOM_tracer_flow_control,  only : call_tracer_flux_init
+use MOM_unit_scaling,         only : unit_scale_type
+use MOM_variables,            only : surface
+use MOM_verticalGrid,         only : verticalGrid_type
+use MOM_ice_shelf,            only : initialize_ice_shelf, shelf_calc_flux, ice_shelf_CS
+use MOM_ice_shelf,            only : add_shelf_forces, ice_shelf_end, ice_shelf_save_restart
+use coupler_types_mod,        only : coupler_1d_bc_type, coupler_2d_bc_type
+use coupler_types_mod,        only : coupler_type_spawn, coupler_type_write_chksums
+use coupler_types_mod,        only : coupler_type_initialized, coupler_type_copy_data
+use coupler_types_mod,        only : coupler_type_set_diags, coupler_type_send_data
+use mpp_domains_mod,          only : domain2d, mpp_get_layout, mpp_get_global_domain
+use mpp_domains_mod,          only : mpp_define_domains, mpp_get_compute_domain, mpp_get_data_domain
+use fms_mod,                  only : stdout
+use mpp_mod,                  only : mpp_chksum
+use MOM_EOS,                  only : gsw_sp_from_sr, gsw_pt_from_ct
+use MOM_wave_interface,       only : wave_parameters_CS, MOM_wave_interface_init
+use MOM_wave_interface,       only : MOM_wave_interface_init_lite, Update_Surface_Waves
+use time_interp_external_mod, only : time_interp_external_init
 
 ! MCT specfic routines
 use MOM_domains,             only : MOM_infra_end
@@ -264,6 +265,8 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
 
   OS%is_ocean_pe = Ocean_sfc%is_ocean_pe
   if (.not.OS%is_ocean_pe) return
+
+  call time_interp_external_init
 
   OS%Time = Time_in
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &

--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -119,7 +119,9 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
   integer                 :: year, month, day, hour, minute, seconds, seconds_n, seconds_d, rc
   character(len=240)      :: runid                !< Run ID
   character(len=32)       :: runtype              !< Run type
-  character(len=240)      :: restartfile          !< Path/Name of restart file
+  character(len=512)      :: restartfile          !< Path/Name of restart file
+  character(len=2048)     :: restartfiles         !< Path/Name of restart files.
+                                                  !! (same as restartfile if a single restart file is to be read in)
   integer                 :: nu                   !< i/o unit to read pointer file
   character(len=240)      :: restart_pointer_file !< File name for restart pointer file
   character(len=240)      :: restartpath          !< Path of the restart file
@@ -164,6 +166,7 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
   !logical :: lsend_precip_fact      !< If T,send precip_fact to cpl for use in fw balance
                                     !! (partially-coupled option)
   character(len=128) :: err_msg     !< Error message
+  integer :: iostat
 
   ! set the cdata pointers:
   call seq_cdata_setptrs(cdata_o, id=MOM_MCT_ID, mpicom=mpicom_ocn, &
@@ -296,15 +299,27 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
     nu = shr_file_getUnit()
     restart_pointer_file = trim(glb%pointer_filename)
     if (is_root_pe()) write(glb%stdout,*) 'Reading ocn pointer file: ',restart_pointer_file
+    restartfile = ""; restartfiles = "";
     open(nu, file=restart_pointer_file, form='formatted', status='unknown')
-    read(nu,'(a)') restartfile
+    do
+      read(nu,'(a)', iostat=iostat) restartfile
+      if (len(trim(restartfiles))>1 .and. iostat<0) then
+        exit ! done reading restart files list.
+      else if (iostat/=0) then
+        call MOM_error(FATAL, 'Error reading rpointer.ocn')
+      endif
+      ! check if the length of restartfiles variable is sufficient:
+      if (len(restartfiles)-len(trim(restartfiles)) < len(trim(restartfile))) then
+        call MOM_error(FATAL, "Restart file name(s) too long.")
+      endif
+      restartfiles = trim(restartfiles) // " " // trim(restartfile)
+    enddo
     close(nu)
-    !restartfile = trim(restartpath) // trim(restartfile)
     if (is_root_pe()) then
-      write(glb%stdout,*) 'Reading restart file: ',trim(restartfile)
+      write(glb%stdout,*) 'Reading restart file(s): ',trim(restartfiles)
     end if
     call shr_file_freeUnit(nu)
-    call ocean_model_init(glb%ocn_public, glb%ocn_state, time0, time_start, input_restart_file=trim(restartfile))
+    call ocean_model_init(glb%ocn_public, glb%ocn_state, time0, time_start, input_restart_file=trim(restartfiles))
   endif
   if (is_root_pe()) then
     write(glb%stdout,'(/12x,a/)') '======== COMPLETED MOM INITIALIZATION ========'
@@ -434,6 +449,9 @@ subroutine ocn_run_mct( EClock, cdata_o, x2o_o, o2x_o)
   integer                   :: ocn_cpl_dt   !< one ocn coupling interval in seconds. (to be received from cesm)
   real (kind=8)             :: mom_cpl_dt   !< one ocn coupling interval in seconds. (internal)
   integer                   :: ncouple_per_day !< number of ocean coupled call in one day (non-dim)
+  integer                   :: num_rest_files !< number of restart files written
+  integer                   :: i
+  character(len=8)          :: suffix
 
   ! reset shr logging to ocn log file:
   if (is_root_pe()) then
@@ -534,7 +552,8 @@ subroutine ocn_run_mct( EClock, cdata_o, x2o_o, o2x_o)
     write(restartname,'(A,".mom6.r.",I4.4,"-",I2.2,"-",I2.2,"-",I5.5)') trim(runid), year, month, day, seconds
 
     call save_restart(glb%ocn_state%dirs%restart_output_dir, glb%ocn_state%Time, glb%grid, &
-                      glb%ocn_state%restart_CSp, .false., filename=restartname, GV=glb%ocn_state%GV)
+                      glb%ocn_state%restart_CSp, .false., filename=restartname, GV=glb%ocn_state%GV, &
+                      num_rest_files=num_rest_files)
 
     ! write name of restart file in the rpointer file
     nu = shr_file_getUnit()
@@ -542,6 +561,19 @@ subroutine ocn_run_mct( EClock, cdata_o, x2o_o, o2x_o)
       restart_pointer_file = trim(glb%pointer_filename)
       open(nu, file=restart_pointer_file, form='formatted', status='unknown')
       write(nu,'(a)') trim(restartname) //'.nc'
+
+      if (num_rest_files > 1) then
+        ! append i.th restart file name to rpointer
+        do i=1, num_rest_files-1
+          if (i < 10) then
+            write(suffix,'("_",I1)') i
+          else
+            write(suffix,'("_",I2)') i
+          endif
+          write(nu,'(a)') trim(restartname) // trim(suffix) // '.nc'
+        enddo
+      endif
+
       close(nu)
       write(glb%stdout,*) 'ocn restart pointer file written: ',trim(restartname)
     endif

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -15,7 +15,6 @@ use mpp_io_mod,               only: mpp_open, MPP_RDONLY, MPP_ASCII, MPP_OVERWR,
 use mpp_mod,                  only: stdlog, stdout, mpp_root_pe, mpp_clock_id
 use mpp_mod,                  only: mpp_clock_begin, mpp_clock_end, MPP_CLOCK_SYNC
 use mpp_mod,                  only: MPP_CLOCK_DETAILED, CLOCK_COMPONENT, MAXPES
-use time_interp_external_mod, only: time_interp_external_init
 use time_manager_mod,         only: set_calendar_type, time_type, increment_date
 use time_manager_mod,         only: set_time, set_date, get_time, get_date, month_name
 use time_manager_mod,         only: GREGORIAN, JULIAN, NOLEAP, THIRTY_DAY_MONTHS, NO_CALENDAR
@@ -70,6 +69,11 @@ use ESMF,  only: ESMF_COORDSYS_SPH_DEG, ESMF_GridCreate, ESMF_INDEX_DELOCAL
 use ESMF,  only: ESMF_MESHLOC_ELEMENT, ESMF_RC_VAL_OUTOFRANGE, ESMF_StateGet
 use ESMF,  only: ESMF_TimePrint, ESMF_AlarmSet, ESMF_FieldGet, ESMF_Array
 use ESMF,  only: ESMF_ArrayCreate
+use ESMF,  only: ESMF_RC_FILE_OPEN, ESMF_RC_FILE_READ, ESMF_RC_FILE_WRITE
+use ESMF,  only: ESMF_VMBroadcast
+use ESMF,  only: ESMF_AlarmCreate, ESMF_ClockGetAlarmList, ESMF_AlarmList_Flag
+use ESMF,  only: ESMF_AlarmGet, ESMF_AlarmIsCreated, ESMF_ALARMLIST_ALL, ESMF_AlarmIsEnabled
+use ESMF,  only: ESMF_STATEITEM_NOTFOUND, ESMF_FieldWrite
 use ESMF,  only: operator(==), operator(/=), operator(+), operator(-)
 
 ! TODO ESMF_GridCompGetInternalState does not have an explicit Fortran interface.
@@ -81,16 +85,17 @@ use NUOPC,       only: NUOPC_CompFilterPhaseMap, NUOPC_CompAttributeGet, NUOPC_C
 use NUOPC,       only: NUOPC_Advertise, NUOPC_SetAttribute, NUOPC_IsUpdated, NUOPC_Write
 use NUOPC,       only: NUOPC_IsConnected, NUOPC_Realize, NUOPC_CompAttributeSet
 use NUOPC_Model, only: NUOPC_ModelGet
-use NUOPC_Model, &
-  model_routine_SS           => SetServices, &
-  model_label_Advance        => label_Advance, &
-  model_label_DataInitialize => label_DataInitialize, &
-  model_label_SetRunClock    => label_SetRunClock, &
-  model_label_Finalize       => label_Finalize
+use NUOPC_Model, only: model_routine_SS           => SetServices
+use NUOPC_Model, only: model_label_Advance        => label_Advance
+use NUOPC_Model, only: model_label_DataInitialize => label_DataInitialize
+use NUOPC_Model, only: model_label_SetRunClock    => label_SetRunClock
+use NUOPC_Model, only: model_label_Finalize       => label_Finalize
+use NUOPC_Model, only: SetVM
 
 implicit none; private
 
 public SetServices
+public SetVM
 
 !> Internal state type with pointers to three types defined by MOM.
 type ocean_internalstate_type
@@ -409,13 +414,6 @@ subroutine InitializeP0(gcomp, importState, exportState, clock, rc)
           return
   endif
 
-  call NUOPC_CompAttributeAdd(gcomp, &
-       attrList=(/'RestartFileToRead', 'RestartFileToWrite'/), rc=rc)
-  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-       line=__LINE__, &
-       file=__FILE__)) &
-       return
-
 end subroutine
 
 !> Called by NUOPC to advertise import and export fields.  "Advertise"
@@ -462,7 +460,12 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   logical                                :: isPresent, isPresentDiro, isPresentLogfile, isSet
   logical                                :: existflag
   integer                                :: userRc
+  integer                                :: localPet
+  integer                                :: iostat
+  integer                                :: readunit
   character(len=512)                     :: restartfile          ! Path/Name of restart file
+  character(len=2048)                    :: restartfiles         ! Path/Name of restart files
+                                                                 ! (same as restartfile if single restart file)
   character(len=*), parameter            :: subname='(MOM_cap:InitializeAdvertise)'
   character(len=32)                      :: calendar
 !--------------------------------
@@ -652,57 +655,58 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
          return
   endif
 
-  restartfile = ""
+  restartfile = ""; restartfiles = ""
   if (runtype == "initial") then
-     ! startup (new run) - 'n' is needed below if we don't specify input_filename in input.nml
-     restartfile = "n"
+
+     restartfiles = "n"
+
   else if (runtype == "continue") then ! hybrid or branch or continuos runs
 
-     ! optionally call into system-specific implementation to get restart file name
-     call ESMF_MethodExecute(gcomp, label="GetRestartFileToRead", &
-          existflag=existflag, userRc=userRc, rc=rc)
-     if (ESMF_LogFoundError(rcToCheck=rc, msg="Error executing user method to get restart filename", &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
-     if (ESMF_LogFoundError(rcToCheck=userRc, msg="Error in method to get restart filename", &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
-     if (existflag) then
-        call ESMF_LogWrite('MOM_cap: called user GetRestartFileToRead', ESMF_LOGMSG_INFO, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-     endif
+     if (cesm_coupled) then
+        call ESMF_LogWrite('MOM_cap: restart requested, using rpointer.ocn', ESMF_LOGMSG_WARNING)
+        call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+        call ESMF_VMGet(vm, localPet=localPet, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
 
-     call NUOPC_CompAttributeGet(gcomp, name='RestartFileToRead', &
-          value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
-     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-     if (isPresent .and. isSet) then
-        restartfile = trim(cvalue)
-        call ESMF_LogWrite('MOM_cap: RestartFileToRead = '//trim(restartfile), ESMF_LOGMSG_INFO, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-     else
-        call ESMF_LogWrite('MOM_cap: restart requested, no RestartFileToRead attribute provided-will use input.nml',&
-             ESMF_LOGMSG_WARNING, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-     endif
+        if (localPet == 0) then
+           ! this hard coded for rpointer.ocn right now
+            open(newunit=readunit, file='rpointer.ocn', form='formatted', status='old', iostat=iostat)
+            if (iostat /= 0) then
+                call ESMF_LogSetError(ESMF_RC_FILE_OPEN, msg=subname//' ERROR opening rpointer.ocn', &
+                     line=__LINE__, file=u_FILE_u, rcToReturn=rc)
+                return
+            endif
+            do
+              read(readunit,'(a)', iostat=iostat) restartfile
+              if (iostat /= 0) then
+                if (len(trim(restartfiles))>1 .and. iostat<0) then
+                  exit ! done reading restart files list.
+                else
+                   call ESMF_LogSetError(ESMF_RC_FILE_READ, msg=subname//' ERROR reading rpointer.ocn', &
+                     line=__LINE__, file=u_FILE_u, rcToReturn=rc)
+                   return
+                endif
+              endif
+              ! check if the length of restartfiles variable is sufficient:
+              if (len(restartfiles)-len(trim(restartfiles)) < len(trim(restartfile))) then
+                call MOM_error(FATAL, "Restart file name(s) too long.")
+              endif
+              restartfiles = trim(restartfiles) // " " // trim(restartfile)
+            enddo
+            close(readunit)
+         endif
+         ! broadcast attribute set on master task to all tasks
+         call ESMF_VMBroadcast(vm, restartfiles, count=len(restartfiles), rootPet=0, rc=rc)
+         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+      else
+         call ESMF_LogWrite('MOM_cap: restart requested, use input.nml', ESMF_LOGMSG_WARNING)
+       endif
 
   endif
 
   ocean_public%is_ocean_pe = .true.
-  call ocean_model_init(ocean_public, ocean_state, time0, time_start, input_restart_file=trim(restartfile))
+  call ocean_model_init(ocean_public, ocean_state, time0, time_start, input_restart_file=trim(restartfiles))
 
   call ocean_model_init_sfc(ocean_state, ocean_public)
 
@@ -1475,12 +1479,17 @@ subroutine DataInitialize(gcomp, rc)
   ! local variables
   type(ESMF_Clock)                       :: clock
   type(ESMF_State)                       :: importState, exportState
+  type(ESMF_Time)                        :: currTime
+  type(ESMF_TimeInterval)                :: timeStep
+  type(ESMF_StateItem_Flag)              :: itemType
   type (ocean_public_type),      pointer :: ocean_public       => NULL()
   type (ocean_state_type),       pointer :: ocean_state        => NULL()
   type(ice_ocean_boundary_type), pointer :: Ice_ocean_boundary => NULL()
   type(ocean_internalstate_wrapper)      :: ocean_internalstate
   type(ocean_grid_type), pointer         :: ocean_grid
   character(240)                         :: msgString
+  character(240)                         :: fldname
+  character(240)                         :: timestr
   integer                                :: fieldCount, n
   type(ESMF_Field)                       :: field
   character(len=64),allocatable          :: fieldNameList(:)
@@ -1493,6 +1502,11 @@ subroutine DataInitialize(gcomp, rc)
     line=__LINE__, &
     file=__FILE__)) &
     return  ! bail out
+
+  call ESMF_ClockGet(clock, currTime=currTime, timeStep=timeStep, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+  call ESMF_TimeGet(currTime,          timestring=timestr, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
   call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -1542,7 +1556,6 @@ subroutine DataInitialize(gcomp, rc)
   ! check whether all Fields in the exportState are "Updated"
   if (NUOPC_IsUpdated(exportState)) then
     call NUOPC_CompAttributeSet(gcomp, name="InitializeDataComplete", value="true", rc=rc)
-
     call ESMF_LogWrite("MOM6 - Initialize-Data-Dependency SATISFIED!!!", ESMF_LOGMSG_INFO, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, &
@@ -1551,12 +1564,20 @@ subroutine DataInitialize(gcomp, rc)
   endif
 
   if(write_diagnostics) then
-    call NUOPC_Write(exportState, fileNamePrefix='field_init_ocn_export_', &
-      overwrite=overwrite_timeslice,timeslice=import_slice, relaxedFlag=.true., rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+     do n = 1,fldsFrOcn_num
+      fldname = fldsFrOcn(n)%shortname
+      call ESMF_StateGet(exportState, itemName=trim(fldname), itemType=itemType, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+      if (itemType /= ESMF_STATEITEM_NOTFOUND) then
+        call ESMF_StateGet(exportState, itemName=trim(fldname), field=field, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+        call ESMF_FieldWrite(field, fileName='field_init_ocn_export_'//trim(timestr)//'.nc', &
+          timeslice=1, overwrite=overwrite_timeslice, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      endif
+     enddo
   endif
 
 end subroutine DataInitialize
@@ -1574,13 +1595,15 @@ subroutine ModelAdvance(gcomp, rc)
   logical                                :: existflag, isPresent, isSet
   logical                                :: do_advance = .true.
   type(ESMF_Clock)                       :: clock!< ESMF Clock class definition
-  type(ESMF_Alarm)                       :: alarm
+  type(ESMF_Alarm)                       :: restart_alarm, stop_alarm
   type(ESMF_State)                       :: importState, exportState
   type(ESMF_Time)                        :: currTime
   type(ESMF_TimeInterval)                :: timeStep
   type(ESMF_Time)                        :: startTime
   type(ESMF_TimeInterval)                :: time_elapsed
   integer(ESMF_KIND_I8)                  :: n_interval, time_elapsed_sec
+  type(ESMF_Field)                       :: lfield
+  type(ESMF_StateItem_Flag)              :: itemType
   character(len=64)                      :: timestamp
   type (ocean_public_type),      pointer :: ocean_public       => NULL()
   type (ocean_state_type),       pointer :: ocean_state        => NULL()
@@ -1596,7 +1619,17 @@ subroutine ModelAdvance(gcomp, rc)
   integer                                :: seconds, day, year, month, hour, minute
   character(ESMF_MAXSTR)                 :: restartname, cvalue
   character(240)                         :: msgString
+  character(ESMF_MAXSTR)                 :: casename
+  integer                                :: iostat
+  integer                                :: writeunit
+  integer                                :: localPet
+  type(ESMF_VM)                          :: vm
+  integer                                :: n, i
+  character(240)                         :: import_timestr, export_timestr
+  character(len=128)                     :: fldname
   character(len=*),parameter             :: subname='(MOM_cap:ModelAdvance)'
+  character(len=8)                       :: suffix
+  integer                                :: num_rest_files
 
   rc = ESMF_SUCCESS
   if(profile_memory) call ESMF_VMLogMemInfo("Entering MOM Model_ADVANCE: ")
@@ -1643,6 +1676,9 @@ subroutine ModelAdvance(gcomp, rc)
     line=__LINE__, &
     file=__FILE__)) &
     return  ! bail out
+
+  call ESMF_TimeGet(currTime,          timestring=import_timestr, rc=rc)
+  call ESMF_TimeGet(currTime+timestep, timestring=export_timestr, rc=rc)
 
   Time_step_coupled = esmf2fms_time(timeStep)
   Time = esmf2fms_time(currTime)
@@ -1705,13 +1741,20 @@ subroutine ModelAdvance(gcomp, rc)
      !---------------
 
      if (write_diagnostics) then
-        call NUOPC_Write(importState, fileNamePrefix='field_ocn_import_', &
-             overwrite=overwrite_timeslice,timeslice=import_slice, relaxedFlag=.true., rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-             line=__LINE__, &
-             file=__FILE__)) &
-             return  ! bail out
-        import_slice = import_slice + 1
+     do n = 1,fldsToOcn_num
+      fldname = fldsToOcn(n)%shortname
+      call ESMF_StateGet(importState, itemName=trim(fldname), itemType=itemType, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+      if (itemType /= ESMF_STATEITEM_NOTFOUND) then
+        call ESMF_StateGet(importState, itemName=trim(fldname), field=lfield, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+        call ESMF_FieldWrite(lfield, fileName='field_ocn_import_'//trim(import_timestr)//'.nc', &
+          timeslice=1, overwrite=overwrite_timeslice, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      endif
+     enddo
      endif
 
      !---------------
@@ -1751,109 +1794,107 @@ subroutine ModelAdvance(gcomp, rc)
   endif
 
   !---------------
-  ! If restart alarm is ringing - write restart file
+  ! Get the stop alarm
   !---------------
 
-  call ESMF_ClockGetAlarm(clock, alarmname='alarm_restart', alarm=alarm, rc=rc)
+   call ESMF_ClockGetAlarm(clock, alarmname='stop_alarm', alarm=stop_alarm, rc=rc)
+   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  !---------------
+  ! If restart alarm exists and is ringing - write restart file
+  !---------------
+
+  call ESMF_ClockGetAlarm(clock, alarmname='restart_alarm', alarm=restart_alarm, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, &
       file=__FILE__)) &
       return  ! bail out
 
-  if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
-     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+  if (ESMF_AlarmIsRinging(restart_alarm, rc=rc)) then
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
 
-     call ESMF_AlarmRingerOff(alarm, rc=rc )
-     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+  ! turn off the alarm
+  call ESMF_AlarmRingerOff(restart_alarm, rc=rc )
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
 
-     ! call into system specific method to get desired restart filename
-     restartname = ""
-     call ESMF_MethodExecute(gcomp, label="GetRestartFileToWrite", &
-          existflag=existflag, userRc=userRc, rc=rc)
-     if (ESMF_LogFoundError(rcToCheck=rc, msg="Error executing user method to get restart filename", &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+  ! determine restart filename
+  call ESMF_ClockGetNextTime(clock, MyTime, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+  call ESMF_TimeGet (MyTime, yy=year, mm=month, dd=day, h=hour, m=minute, s=seconds, rc=rc )
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    if (cesm_coupled) then
+        call NUOPC_CompAttributeGet(gcomp, name='case_name', value=casename, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+        call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+        call ESMF_VMGet(vm, localPet=localPet, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
 
-     if (ESMF_LogFoundError(rcToCheck=userRc, msg="Error in method to get restart filename", &
-          line=__LINE__, &
-          file=__FILE__)) &
-          return  ! bail out
-     if (existflag) then
-        call ESMF_LogWrite("MOM_cap: called user GetRestartFileToWrite method", ESMF_LOGMSG_INFO, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-        call NUOPC_CompAttributeGet(gcomp, name='RestartFileToWrite', &
-             isPresent=isPresent, isSet=isSet, value=cvalue, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-        if (isPresent .and. isSet) then
-           restartname = trim(cvalue)
-           call ESMF_LogWrite("MOM_cap: User RestartFileToWrite: "//trim(restartname), ESMF_LOGMSG_INFO, rc=rc)
-           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
+        write(restartname,'(A,".mom6.r.",I4.4,"-",I2.2,"-",I2.2,"-",I5.5)') &
+             trim(casename), year, month, day, seconds
+
+        call ESMF_LogWrite("MOM_cap: Writing restart :  "//trim(restartname), ESMF_LOGMSG_INFO, rc=rc)
+
+        ! write restart file(s)
+        call ocean_model_restart(ocean_state, restartname=restartname, num_rest_files=num_rest_files)
+
+        if (localPet == 0) then
+           ! Write name of restart file in the rpointer file - this is currently hard-coded for the ocean
+           open(newunit=writeunit, file='rpointer.ocn', form='formatted', status='unknown', iostat=iostat)
+           if (iostat /= 0) then
+              call ESMF_LogSetError(ESMF_RC_FILE_OPEN, &
+                   msg=subname//' ERROR opening rpointer.ocn', line=__LINE__, file=u_FILE_u, rcToReturn=rc)
+              return
+           endif
+           write(writeunit,'(a)') trim(restartname)//'.nc'
+
+           if (num_rest_files > 1) then
+              ! append i.th restart file name to rpointer
+              do i=1, num_rest_files-1
+                if (i < 10) then
+                  write(suffix,'("_",I1)') i
+                else
+                  write(suffix,'("_",I2)') i
+                endif
+                write(writeunit,'(a)') trim(restartname) // trim(suffix) // '.nc'
+              enddo
+           endif
+
+           close(writeunit)
         endif
-     endif
+    else
+      ! write the final restart without a timestamp
+      if (ESMF_AlarmIsRinging(stop_alarm, rc=rc)) then
+        write(restartname,'(A)')"MOM.res"
+      else
+        write(restartname,'(A,I4.4,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2)') &
+             "MOM.res.", year, month, day, hour, minute, seconds
+      endif
 
-     if (len_trim(restartname) == 0) then
-        ! none provided, so use a default restart filename
-        call ESMF_ClockGetNextTime(clock, MyTime, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-        call ESMF_TimeGet (MyTime, yy=year, mm=month, dd=day, &
-             h=hour, m=minute, s=seconds, rc=rc )
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-        write(restartname,'(A,".mom6.r.",I4.4,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2)') &
-              "ocn", year, month, day, hour, minute, seconds
-        call ESMF_LogWrite("MOM_cap: Using default restart filename:  "//trim(restartname), ESMF_LOGMSG_INFO, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-     endif
+      call ESMF_LogWrite("MOM_cap: Writing restart :  "//trim(restartname), ESMF_LOGMSG_INFO, rc=rc)
 
-     ! TODO: address if this requirement is being met for the DA group
-     ! Optionally write restart files when currTime-startTime is integer multiples of restart_interval
-     ! if (restart_interval > 0 ) then
-     !   time_elapsed = currTime - startTime
-     !   call ESMF_TimeIntervalGet(time_elapsed, s_i8=time_elapsed_sec, rc=rc)
-     !   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-     !     line=__LINE__, &
-     !     file=__FILE__)) &
-     !     return  ! bail out
-     !   n_interval = time_elapsed_sec / restart_interval
-     !   if ((n_interval .gt. 0) .and. (n_interval*restart_interval == time_elapsed_sec)) then
-     !       time_restart_current = esmf2fms_time(currTime)
-     !       timestamp = date_to_string(time_restart_current)
-     !       call ESMF_LogWrite("MOM: Writing restart at "//trim(timestamp), ESMF_LOGMSG_INFO, rc=rc)
-     !       write(*,*) 'calling ocean_model_restart'
-     !       call ocean_model_restart(ocean_state, timestamp)
-     !   endif
-     ! endif
+      ! write restart file(s)
+      call ocean_model_restart(ocean_state, restartname=restartname)
+    end if
 
-     ! write restart file(s)
-     call ocean_model_restart(ocean_state, restartname=restartname)
-
-     if (is_root_pe()) then
-       write(logunit,*) subname//' writing restart file ',trim(restartname)
-     endif
+    if (is_root_pe()) then
+      write(logunit,*) subname//' writing restart file ',trim(restartname)
+    endif
   endif
 
   !---------------
@@ -1861,13 +1902,20 @@ subroutine ModelAdvance(gcomp, rc)
   !---------------
 
   if (write_diagnostics) then
-     call NUOPC_Write(exportState, fileNamePrefix='field_ocn_export_', &
-          overwrite=overwrite_timeslice,timeslice=export_slice, relaxedFlag=.true., rc=rc)
-     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
-     export_slice = export_slice + 1
+     do n = 1,fldsFrOcn_num
+      fldname = fldsFrOcn(n)%shortname
+      call ESMF_StateGet(exportState, itemName=trim(fldname), itemType=itemType, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+      if (itemType /= ESMF_STATEITEM_NOTFOUND) then
+        call ESMF_StateGet(exportState, itemName=trim(fldname), field=lfield, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+        call ESMF_FieldWrite(lfield, fileName='field_ocn_export_'//trim(export_timestr)//'.nc', &
+          timeslice=1, overwrite=overwrite_timeslice, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      endif
+     enddo
   endif
 
   if(profile_memory) call ESMF_VMLogMemInfo("Leaving MOM Model_ADVANCE: ")
@@ -1882,17 +1930,19 @@ subroutine ModelSetRunClock(gcomp, rc)
   ! local variables
   type(ESMF_Clock)         :: mclock, dclock
   type(ESMF_Time)          :: mcurrtime, dcurrtime
-  type(ESMF_Time)          :: mstoptime
+  type(ESMF_Time)          :: mstoptime, dstoptime
   type(ESMF_TimeInterval)  :: mtimestep, dtimestep
   character(len=128)       :: mtimestring, dtimestring
   character(len=256)       :: cvalue
   character(len=256)       :: restart_option ! Restart option units
   integer                  :: restart_n      ! Number until restart interval
   integer                  :: restart_ymd    ! Restart date (YYYYMMDD)
-  type(ESMF_ALARM)         :: restart_alarm
+  type(ESMF_Alarm)         :: restart_alarm
+  type(ESMF_Alarm)         :: stop_alarm
   logical                  :: isPresent, isSet
   logical                  :: first_time = .true.
   character(len=*),parameter :: subname='MOM_cap:(ModelSetRunClock) '
+  character(len=256)       :: timestr
   !--------------------------------
 
   rc = ESMF_SUCCESS
@@ -1904,7 +1954,8 @@ subroutine ModelSetRunClock(gcomp, rc)
     file=__FILE__)) &
     return  ! bail out
 
-  call ESMF_ClockGet(dclock, currTime=dcurrtime, timeStep=dtimestep, rc=rc)
+  call ESMF_ClockGet(dclock, currTime=dcurrtime, timeStep=dtimestep, &
+                     stopTime=dstoptime, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, &
     file=__FILE__)) &
@@ -1960,33 +2011,66 @@ subroutine ModelSetRunClock(gcomp, rc)
      restart_n = 0
      restart_ymd = 0
 
-     call NUOPC_CompAttributeGet(gcomp, name="restart_option", isPresent=isPresent, &
-          isSet=isSet, value=restart_option, rc=rc)
-     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-          line=__LINE__, &
-          file=__FILE__)) &
-          return  ! bail out
-     if (isPresent .and. isSet) then
-        call NUOPC_CompAttributeGet(gcomp,  name="restart_n", value=cvalue, &
-             isPresent=isPresent, isSet=isSet, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-             line=__LINE__, &
-             file=__FILE__)) &
-             return  ! bail out
+     if (cesm_coupled) then
+
+        call NUOPC_CompAttributeGet(gcomp, name="restart_option", value=restart_option, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+
+        ! If restart_option is set then must also have set either restart_n or restart_ymd
+        call NUOPC_CompAttributeGet(gcomp, name="restart_n", value=cvalue, &
+                isPresent=isPresent, isSet=isSet, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
         if (isPresent .and. isSet) then
            read(cvalue,*) restart_n
         endif
         call NUOPC_CompAttributeGet(gcomp, name="restart_ymd", value=cvalue, &
              isPresent=isPresent, isSet=isSet, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-             line=__LINE__, &
-             file=__FILE__)) &
-             return  ! bail out
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
         if (isPresent .and. isSet) then
            read(cvalue,*) restart_ymd
         endif
+        if (restart_n == 0 .and. restart_ymd == 0) then
+           call ESMF_LogSetError(ESMF_RC_VAL_WRONG, &
+                msg=subname//": ERROR both restart_n and restart_ymd are zero for restart_option set ",  &
+                line=__LINE__, file=__FILE__, rcToReturn=rc)
+           return
+        endif
+        call ESMF_LogWrite(subname//" Set restart option = "//restart_option, ESMF_LOGMSG_INFO)
+
      else
-        restart_option = "none"
+        call NUOPC_CompAttributeGet(gcomp, name="restart_n", value=cvalue, &
+             isPresent=isPresent, isSet=isSet, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, file=__FILE__)) return
+
+        ! If restart_option is set then must also have set either restart_n or restart_ymd
+        if (isPresent .and. isSet) then
+          call ESMF_LogWrite(subname//" Restart_n = "//trim(cvalue), ESMF_LOGMSG_INFO, rc=rc)
+          read(cvalue,*) restart_n
+          if(restart_n /= 0)then
+            call NUOPC_CompAttributeGet(gcomp, name="restart_option", value=cvalue, &
+                 isPresent=isPresent, isSet=isSet, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+                line=__LINE__, file=__FILE__)) return
+            if (isPresent .and. isSet) then
+              read(cvalue,*) restart_option
+              call ESMF_LogWrite(subname//" Restart_option = "//restart_option, &
+                   ESMF_LOGMSG_INFO, rc=rc)
+            endif
+
+            call NUOPC_CompAttributeGet(gcomp, name="restart_ymd", value=cvalue, &
+                 isPresent=isPresent, isSet=isSet, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+                line=__LINE__, file=__FILE__)) return
+            if (isPresent .and. isSet) then
+               read(cvalue,*) restart_ymd
+               call ESMF_LogWrite(subname//" Restart_ymd = "//trim(cvalue), ESMF_LOGMSG_INFO, rc=rc)
+            endif
+          else
+            restart_option = 'none'
+            call ESMF_LogWrite(subname//" Set restart option = "//restart_option, ESMF_LOGMSG_INFO, rc=rc)
+          endif
+        endif
      endif
 
      call AlarmInit(mclock, &
@@ -1995,7 +2079,7 @@ subroutine ModelSetRunClock(gcomp, rc)
           opt_n   = restart_n,             &
           opt_ymd = restart_ymd,           &
           RefTime = mcurrTime,             &
-          alarmname = 'alarm_restart', rc=rc)
+          alarmname = 'restart_alarm', rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, &
           file=__FILE__)) &
@@ -2006,14 +2090,18 @@ subroutine ModelSetRunClock(gcomp, rc)
           line=__LINE__, &
           file=__FILE__)) &
           return  ! bail out
-     first_time = .false.
+     call ESMF_LogWrite(subname//" Restart alarm is Created and Set", ESMF_LOGMSG_INFO, rc=rc)
 
-     call ESMF_LogWrite(subname//" Set restart option = "//restart_option, &
-          ESMF_LOGMSG_INFO, rc=rc)
+     ! create a 1-shot alarm at the driver stop time
+     stop_alarm = ESMF_AlarmCreate(mclock, ringtime=dstopTime, name = "stop_alarm", rc=rc)
+     call ESMF_LogWrite(subname//" Create Stop alarm", ESMF_LOGMSG_INFO, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-          line=__LINE__, &
-          file=__FILE__)) &
-          return  ! bail out
+         line=__LINE__, file=__FILE__)) return
+
+     call ESMF_TimeGet(dstoptime, timestring=timestr, rc=rc)
+     call ESMF_LogWrite("Stop Alarm will ring at : "//trim(timestr), ESMF_LOGMSG_INFO, rc=rc)
+
+     first_time = .false.
 
   endif
 
@@ -2054,7 +2142,12 @@ subroutine ocean_model_finalize(gcomp, rc)
   type(TIME_TYPE)                        :: Time
   type(ESMF_Clock)                       :: clock
   type(ESMF_Time)                        :: currTime
+  type(ESMF_Alarm), allocatable          :: alarmList(:)
+  integer                                :: alarmCount
   character(len=64)                      :: timestamp
+  character(len=64)                      :: alarm_name
+  logical                                :: write_restart
+  integer                                :: i
   character(len=*),parameter  :: subname='(MOM_cap:ocean_model_finalize)'
 
   write(*,*) 'MOM: --- finalize called ---'
@@ -2082,11 +2175,25 @@ subroutine ocean_model_finalize(gcomp, rc)
     return  ! bail out
   Time = esmf2fms_time(currTime)
 
-  if (cesm_coupled) then
-     call ocean_model_end(ocean_public, ocean_State, Time, write_restart=.false.)
-  else
-     call ocean_model_end(ocean_public, ocean_State, Time, write_restart=.true.)
-  endif
+  ! Check if the clock has a restart alarm - and if it does do not write a restart
+  call ESMF_ClockGet(clock, alarmCount=alarmCount, rc = rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, file=__FILE__)) return
+
+  allocate(alarmList(1:alarmCount))
+  call ESMF_ClockGetAlarmList(clock, alarmlistflag=ESMF_ALARMLIST_ALL, alarmList=alarmList, rc = rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, file=__FILE__)) return
+
+  write_restart = .true.
+  do i = 1,alarmCount
+   call ESMF_AlarmGet(alarmlist(i), name=alarm_name, rc = rc)
+   if(trim(alarm_name) == 'restart_alarm' .and. ESMF_AlarmIsEnabled(alarmlist(i), rc=rc))write_restart = .false.
+  enddo
+  deallocate(alarmList)
+
+  if(write_restart)call ESMF_LogWrite("No Restart Alarm, writing restart at Finalize ", ESMF_LOGMSG_INFO, rc=rc)
+  call ocean_model_end(ocean_public, ocean_State, Time, write_restart=write_restart)
   call field_manager_end()
 
   call fms_io_exit()

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -1760,48 +1760,49 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     endif
 
     if (integral_BT_cont) then
-      !GOMP parallel do default(shared)
+      !$OMP parallel do default(shared)
       do j=jsv-1,jev+1 ; do I=isv-2,iev+1
         ubt_int_prev(I,j) = ubt_int(I,j) ; uhbt_int_prev(I,j) = uhbt_int(I,j)
       enddo ; enddo
-      !GOMP parallel do default(shared)
+      !$OMP parallel do default(shared)
       do J=jsv-2,jev+1 ; do i=isv-1,iev+1
         vbt_int_prev(i,J) = vbt_int(i,J) ; vhbt_int_prev(i,J) = vhbt_int(i,J)
       enddo ; enddo
     endif
 
-    !GOMP parallel default(shared)
+    !$OMP parallel default(shared) private(vel_prev, ioff, joff)
     if (CS%dynamic_psurf .or. .not.project_velocity) then
       if (integral_BT_cont) then
-        !GOMP do
+        !$OMP do
         do j=jsv-1,jev+1 ; do I=isv-2,iev+1
           uhbt_int(I,j) = find_uhbt(ubt_int(I,j) + dtbt*ubt(I,j), BTCL_u(I,j)) + n*dtbt*uhbt0(I,j)
         enddo ; enddo
-        !GOMP do
+        !$OMP end do nowait
+        !$OMP do
         do J=jsv-2,jev+1 ; do i=isv-1,iev+1
           vhbt_int(i,J) = find_vhbt(vbt_int(i,J) + dtbt*vbt(i,J), BTCL_v(i,J)) + n*dtbt*vhbt0(i,J)
         enddo ; enddo
-        !GOMP do
+        !$OMP do
         do j=jsv-1,jev+1 ; do i=isv-1,iev+1
           eta_pred(i,j) = (eta_IC(i,j) + n*eta_src(i,j)) + CS%IareaT(i,j) * &
                      ((uhbt_int(I-1,j) - uhbt_int(I,j)) + (vhbt_int(i,J-1) - vhbt_int(i,J)))
         enddo ; enddo
       elseif (use_BT_cont) then
-        !GOMP do
+        !$OMP do
         do j=jsv-1,jev+1 ; do I=isv-2,iev+1
           uhbt(I,j) = find_uhbt(ubt(I,j), BTCL_u(I,j)) + uhbt0(I,j)
         enddo ; enddo
-        !GOMP do
+        !$OMP do
         do J=jsv-2,jev+1 ; do i=isv-1,iev+1
           vhbt(i,J) = find_vhbt(vbt(i,J), BTCL_v(i,J)) + vhbt0(i,J)
         enddo ; enddo
-        !GOMP do
+        !$OMP do
         do j=jsv-1,jev+1 ; do i=isv-1,iev+1
           eta_pred(i,j) = (eta(i,j) + eta_src(i,j)) + (dtbt * CS%IareaT(i,j)) * &
                      ((uhbt(I-1,j) - uhbt(I,j)) + (vhbt(i,J-1) - vhbt(i,J)))
         enddo ; enddo
       else
-        !GOMP do
+        !$OMP do
         do j=jsv-1,jev+1 ; do i=isv-1,iev+1
           eta_pred(i,j) = (eta(i,j) + eta_src(i,j)) + (dtbt * CS%IareaT(i,j)) * &
               (((Datu(I-1,j)*ubt(I-1,j) + uhbt0(I-1,j)) - &
@@ -1812,7 +1813,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       endif
 
       if (CS%dynamic_psurf) then
-        !GOMP do
+        !$OMP do
         do j=jsv-1,jev+1 ; do i=isv-1,iev+1
           p_surf_dyn(i,j) = dyn_coef_eta(i,j) * (eta_pred(i,j) - eta(i,j))
         enddo ; enddo
@@ -1823,31 +1824,31 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     !  eta_PF_BT => eta_pred ; if (project_velocity) eta_PF_BT => eta
 
     if (find_etaav) then
-      !GOMP do
+      !$OMP do
       do j=js,je ; do i=is,ie
         eta_sum(i,j) = eta_sum(i,j) + wt_accel2(n) * eta_PF_BT(i,j)
       enddo ; enddo
+      !$OMP end do nowait
     endif
 
     if (interp_eta_PF) then
       wt_end = n*Instep  ! This could be (n-0.5)*Instep.
-      !GOMP do
+      !$OMP do
       do j=jsv-1,jev+1 ; do i=isv-1,iev+1
         eta_PF(i,j) = eta_PF_1(i,j) + wt_end*d_eta_PF(i,j)
       enddo ; enddo
     endif
 
     if (apply_OBC_flather .or. apply_OBC_open) then
-      !GOMP do
+      !$OMP do
       do j=jsv,jev ; do I=isv-2,iev+1
         ubt_old(I,j) = ubt(I,j)
       enddo ; enddo
-      !GOMP do
+      !$OMP do
       do J=jsv-2,jev+1 ; do i=isv,iev
         vbt_old(i,J) = vbt(i,J)
       enddo ; enddo
     endif
-    !GOMP end parallel
 
     if (apply_OBCs) then
       if (MOD(n+G%first_direction,2)==1) then
@@ -1857,7 +1858,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       endif
 
       if (CS%BT_OBC%apply_u_OBCs) then  ! save the old value of ubt and uhbt
-        !GOMP parallel do default(shared)
+        !$OMP do
         do j=jsv-joff,jev+joff ; do I=isv-1,iev
           ubt_prev(I,j) = ubt(I,j) ; uhbt_prev(I,j) = uhbt(I,j)
           ubt_sum_prev(I,j) = ubt_sum(I,j) ; uhbt_sum_prev(I,j) = uhbt_sum(I,j) ; ubt_wtd_prev(I,j) = ubt_wtd(I,j)
@@ -1865,7 +1866,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       endif
 
       if (CS%BT_OBC%apply_v_OBCs) then  ! save the old value of vbt and vhbt
-        !GOMP parallel do default(shared)
+        !$OMP do
         do J=jsv-1,jev ; do i=isv-ioff,iev+ioff
           vbt_prev(i,J) = vbt(i,J) ; vhbt_prev(i,J) = vhbt(i,J)
           vbt_sum_prev(i,J) = vbt_sum(i,J) ; vhbt_sum_prev(i,J) = vhbt_sum(i,J) ; vbt_wtd_prev(i,J) = vbt_wtd(i,J)
@@ -1873,10 +1874,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       endif
     endif
 
-    !GOMP parallel default(shared) private(vel_prev)
     if (MOD(n+G%first_direction,2)==1) then
       ! On odd-steps, update v first.
-      !GOMP do
+      !$OMP do schedule(static)
       do J=jsv-1,jev ; do i=isv-1,iev+1
         Cor_v(i,J) = -1.0*((amer(I-1,j) * ubt(I-1,j) + cmer(I,j+1) * ubt(I,j+1)) + &
                (bmer(I,j) * ubt(I,j) + dmer(I-1,j+1) * ubt(I-1,j+1))) - Cor_ref_v(i,J)
@@ -1884,20 +1884,23 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                      (eta_PF_BT(i,j+1)-eta_PF(i,j+1))*gtot_S(i,j+1)) * &
                    dgeo_de * CS%IdyCv(i,J)
       enddo ; enddo
+      !$OMP end do nowait
       if (CS%dynamic_psurf) then
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv-1,iev+1
           PFv(i,J) = PFv(i,J) + (p_surf_dyn(i,j) - p_surf_dyn(i,j+1)) * CS%IdyCv(i,J)
         enddo ; enddo
+        !$OMP end do nowait
       endif
 
       if (CS%BT_OBC%apply_v_OBCs) then  ! zero out PF across boundary
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv-1,iev+1 ; if (OBC%segnum_v(i,J) /= OBC_NONE) then
           PFv(i,J) = 0.0
         endif ; enddo ; enddo
+        !$OMP end do nowait
       endif
-      !GOMP do
+      !$OMP do schedule(static)
       do J=jsv-1,jev ; do i=isv-1,iev+1
         vel_prev = vbt(i,J)
         vbt(i,J) = bt_rem_v(i,J) * (vbt(i,J) + &
@@ -1913,7 +1916,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       enddo ; enddo
 
       if (integral_BT_cont) then
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv-1,iev+1
           vbt_int(i,J) = vbt_int(i,J) + dtbt * vbt_trans(i,J)
           vhbt_int(i,J) = find_vhbt(vbt_int(i,J), BTCL_v(i,J)) + n*dtbt*vhbt0(i,J)
@@ -1921,24 +1924,26 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
           vhbt(i,J) = (vhbt_int(i,J) - vhbt_int_prev(i,J)) * Idtbt
         enddo ; enddo
       elseif (use_BT_cont) then
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv-1,iev+1
           vhbt(i,J) = find_vhbt(vbt_trans(i,J), BTCL_v(i,J)) + vhbt0(i,J)
         enddo ; enddo
+        !$OMP end do nowait
       else
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv-1,iev+1
           vhbt(i,J) = Datv(i,J)*vbt_trans(i,J) + vhbt0(i,J)
         enddo ; enddo
+        !$OMP end do nowait
       endif
       if (CS%BT_OBC%apply_v_OBCs) then  ! copy back the value for v-points on the boundary.
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv-1,iev+1 ; if (OBC%segnum_v(i,J) /= OBC_NONE) then
           vbt(i,J) = vbt_prev(i,J) ; vhbt(i,J) = vhbt_prev(i,J)
         endif ; enddo ; enddo
       endif
       ! Now update the zonal velocity.
-      !GOMP do
+      !$OMP do schedule(static)
       do j=jsv,jev ; do I=isv-1,iev
         Cor_u(I,j) = ((azon(I,j) * vbt(i+1,J) + czon(I,j) * vbt(i,J-1)) + &
                       (bzon(I,j) * vbt(i,J) + dzon(I,j) * vbt(i+1,J-1))) - &
@@ -1947,21 +1952,24 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                      (eta_PF_BT(i+1,j)-eta_PF(i+1,j))*gtot_W(i+1,j)) * &
                     dgeo_de * CS%IdxCu(I,j)
       enddo ; enddo
+      !$OMP end do nowait
 
       if (CS%dynamic_psurf) then
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv,jev ; do I=isv-1,iev
           PFu(I,j) = PFu(I,j) + (p_surf_dyn(i,j) - p_surf_dyn(i+1,j)) * CS%IdxCu(I,j)
         enddo ; enddo
+        !$OMP end do nowait
       endif
 
       if (CS%BT_OBC%apply_u_OBCs) then  ! zero out pressure force across boundary
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv,jev ; do I=isv-1,iev ; if (OBC%segnum_u(I,j) /= OBC_NONE) then
           PFu(I,j) = 0.0
         endif ; enddo ; enddo
+        !$OMP end do nowait
       endif
-      !GOMP do
+      !$OMP do schedule(static)
       do j=jsv,jev ; do I=isv-1,iev
         vel_prev = ubt(I,j)
         ubt(I,j) = bt_rem_u(I,j) * (ubt(I,j) + &
@@ -1976,9 +1984,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
           u_accel_bt(I,j) = u_accel_bt(I,j) + wt_accel(n) * (Cor_u(I,j) + PFu(I,j))
         endif
       enddo ; enddo
+      !$OMP end do nowait
 
       if (integral_BT_cont) then
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv,jev ; do I=isv-1,iev
           ubt_int(I,j) = ubt_int(I,j) + dtbt * ubt_trans(I,j)
           uhbt_int(I,j) = find_uhbt(ubt_int(I,j), BTCL_u(I,j)) + n*dtbt*uhbt0(I,j)
@@ -1986,25 +1995,25 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
           uhbt(I,j) = (uhbt_int(I,j) - uhbt_int_prev(I,j)) * Idtbt
         enddo ; enddo
       elseif (use_BT_cont) then
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv,jev ; do I=isv-1,iev
           uhbt(I,j) = find_uhbt(ubt_trans(I,j), BTCL_u(I,j)) + uhbt0(I,j)
         enddo ; enddo
       else
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv,jev ; do I=isv-1,iev
           uhbt(I,j) = Datu(I,j)*ubt_trans(I,j) + uhbt0(I,j)
         enddo ; enddo
       endif
       if (CS%BT_OBC%apply_u_OBCs) then  ! copy back the value for u-points on the boundary.
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv,jev ; do I=isv-1,iev ; if (OBC%segnum_u(I,j) /= OBC_NONE) then
           ubt(I,j) = ubt_prev(I,j) ; uhbt(I,j) = uhbt_prev(I,j)
         endif ; enddo ; enddo
       endif
     else
       ! On even steps, update u first.
-      !GOMP do
+      !$OMP do schedule(static)
       do j=jsv-1,jev+1 ; do I=isv-1,iev
         Cor_u(I,j) = ((azon(I,j) * vbt(i+1,J) + czon(I,j) * vbt(i,J-1)) + &
                       (bzon(I,j) * vbt(i,J) +  dzon(I,j) * vbt(i+1,J-1))) - &
@@ -2013,22 +2022,24 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                      (eta_PF_BT(i+1,j)-eta_PF(i+1,j))*gtot_W(i+1,j)) * &
                      dgeo_de * CS%IdxCu(I,j)
       enddo ; enddo
+      !$OMP end do nowait
 
       if (CS%dynamic_psurf) then
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv-1,jev+1 ; do I=isv-1,iev
           PFu(I,j) = PFu(I,j) + (p_surf_dyn(i,j) - p_surf_dyn(i+1,j)) * CS%IdxCu(I,j)
         enddo ; enddo
+        !$OMP end do nowait
       endif
 
       if (CS%BT_OBC%apply_u_OBCs) then  ! zero out pressure force across boundary
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv,jev ; do I=isv-1,iev ; if (OBC%segnum_u(I,j) /= OBC_NONE) then
           PFu(I,j) = 0.0
         endif ; enddo ; enddo
       endif
 
-      !GOMP do
+      !$OMP do schedule(static)
       do j=jsv-1,jev+1 ; do I=isv-1,iev
         vel_prev = ubt(I,j)
         ubt(I,j) = bt_rem_u(I,j) * (ubt(I,j) + &
@@ -2045,7 +2056,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       enddo ; enddo
 
       if (integral_BT_cont) then
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv-1,jev+1 ; do I=isv-1,iev
           ubt_int(I,j) = ubt_int(I,j) + dtbt * ubt_trans(I,j)
           uhbt_int(I,j) = find_uhbt(ubt_int(I,j), BTCL_u(I,j)) + n*dtbt*uhbt0(I,j)
@@ -2053,18 +2064,20 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
           uhbt(I,j) = (uhbt_int(I,j) - uhbt_int_prev(I,j)) * Idtbt
         enddo ; enddo
       elseif (use_BT_cont) then
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv-1,jev+1 ; do I=isv-1,iev
           uhbt(I,j) = find_uhbt(ubt_trans(I,j), BTCL_u(I,j)) + uhbt0(I,j)
         enddo ; enddo
+        !$OMP end do nowait
       else
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv-1,jev+1 ; do I=isv-1,iev
           uhbt(I,j) = Datu(I,j)*ubt_trans(I,j) + uhbt0(I,j)
         enddo ; enddo
+        !$OMP end do nowait
       endif
       if (CS%BT_OBC%apply_u_OBCs) then  ! copy back the value for u-points on the boundary.
-        !GOMP do
+        !$OMP do schedule(static)
         do j=jsv-1,jev+1 ; do I=isv-1,iev ; if (OBC%segnum_u(I,j) /= OBC_NONE) then
           ubt(I,j) = ubt_prev(I,j) ; uhbt(I,j) = uhbt_prev(I,j)
         endif ; enddo ; enddo
@@ -2072,7 +2085,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
       ! Now update the meridional velocity.
       if (CS%use_old_coriolis_bracket_bug) then
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv,iev
           Cor_v(i,J) = -1.0*((amer(I-1,j) * ubt(I-1,j) + bmer(I,j) * ubt(I,j)) + &
                   (cmer(I,j+1) * ubt(I,j+1) + dmer(I-1,j+1) * ubt(I-1,j+1))) - Cor_ref_v(i,J)
@@ -2080,8 +2093,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                        (eta_PF_BT(i,j+1)-eta_PF(i,j+1))*gtot_S(i,j+1)) * &
                       dgeo_de * CS%IdyCv(i,J)
         enddo ; enddo
+        !$OMP end do nowait
       else
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv,iev
           Cor_v(i,J) = -1.0*((amer(I-1,j) * ubt(I-1,j) + cmer(I,j+1) * ubt(I,j+1)) + &
                   (bmer(I,j) * ubt(I,j) + dmer(I-1,j+1) * ubt(I-1,j+1))) - Cor_ref_v(i,J)
@@ -2089,23 +2103,25 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                        (eta_PF_BT(i,j+1)-eta_PF(i,j+1))*gtot_S(i,j+1)) * &
                       dgeo_de * CS%IdyCv(i,J)
         enddo ; enddo
+        !$OMP end do nowait
       endif
 
       if (CS%dynamic_psurf) then
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv,iev
           PFv(i,J) = PFv(i,J) + (p_surf_dyn(i,j) - p_surf_dyn(i,j+1)) * CS%IdyCv(i,J)
         enddo ; enddo
+        !$OMP end do nowait
       endif
 
       if (CS%BT_OBC%apply_v_OBCs) then  ! zero out PF across boundary
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv-1,iev+1 ; if (OBC%segnum_v(i,J) /= OBC_NONE) then
           PFv(i,J) = 0.0
         endif ; enddo ; enddo
       endif
 
-      !GOMP do
+      !$OMP do schedule(static)
       do J=jsv-1,jev ; do i=isv,iev
         vel_prev = vbt(i,J)
         vbt(i,J) = bt_rem_v(i,J) * (vbt(i,J) + &
@@ -2120,8 +2136,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
           v_accel_bt(i,J) = v_accel_bt(i,J) + wt_accel(n) * (Cor_v(i,J) + PFv(i,J))
         endif
       enddo ; enddo
+      !$OMP end do nowait
       if (integral_BT_cont) then
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv,iev
           vbt_int(i,J) = vbt_int(i,J) + dtbt * vbt_trans(i,J)
           vhbt_int(i,J) = find_vhbt(vbt_int(i,J), BTCL_v(i,J)) + n*dtbt*vhbt0(i,J)
@@ -2129,25 +2146,25 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
           vhbt(i,J) = (vhbt_int(i,J) - vhbt_int_prev(i,J)) * Idtbt
         enddo ; enddo
       elseif (use_BT_cont) then
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv,iev
           vhbt(i,J) = find_vhbt(vbt_trans(i,J), BTCL_v(i,J)) + vhbt0(i,J)
         enddo ; enddo
       else
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv,iev
           vhbt(i,J) = Datv(i,J)*vbt_trans(i,J) + vhbt0(i,J)
         enddo ; enddo
       endif
       if (CS%BT_OBC%apply_v_OBCs) then  ! copy back the value for v-points on the boundary.
-        !GOMP do
+        !$OMP do schedule(static)
         do J=jsv-1,jev ; do i=isv,iev ; if (OBC%segnum_v(i,J) /= OBC_NONE) then
           vbt(i,J) = vbt_prev(i,J); vhbt(i,J) = vhbt_prev(i,J)
         endif ; enddo ; enddo
       endif
     endif
-    !GOMP end parallel
 
+    ! This might need to be moved outside of the OMP do loop directives.
     if (CS%debug_bt) then
       write(mesg,'("BT vel update ",I4)') n
       call uvchksum(trim(mesg)//" PF[uv]", PFu, PFv, CS%debug_BT_HI, haloshift=iev-ie, &
@@ -2168,75 +2185,86 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                       scale=US%L_to_m**2*GV%H_to_m)
     endif
 
-
-    !GOMP parallel default(shared)
     if (find_PF) then
-      !GOMP do
+      !$OMP do
       do j=js,je ; do I=is-1,ie
         PFu_bt_sum(I,j)  = PFu_bt_sum(I,j) + wt_accel2(n) * PFu(I,j)
       enddo ; enddo
-      !GOMP do
+      !$OMP end do nowait
+      !$OMP do
       do J=js-1,je ; do i=is,ie
         PFv_bt_sum(i,J)  = PFv_bt_sum(i,J) + wt_accel2(n) * PFv(i,J)
       enddo ; enddo
+      !$OMP end do nowait
     endif
     if (find_Cor) then
-      !GOMP do
+      !$OMP do
       do j=js,je ; do I=is-1,ie
         Coru_bt_sum(I,j) = Coru_bt_sum(I,j) + wt_accel2(n) * Cor_u(I,j)
       enddo ; enddo
-      !GOMP do
+      !$OMP end do nowait
+      !$OMP do
       do J=js-1,je ; do i=is,ie
         Corv_bt_sum(i,J) = Corv_bt_sum(i,J) + wt_accel2(n) * Cor_v(i,J)
       enddo ; enddo
+      !$OMP end do nowait
     endif
 
-    !GOMP do
+    !$OMP do
     do j=js,je ; do I=is-1,ie
       ubt_sum(I,j) = ubt_sum(I,j) + wt_trans(n) * ubt_trans(I,j)
       uhbt_sum(I,j) = uhbt_sum(I,j) + wt_trans(n) * uhbt(I,j)
       ubt_wtd(I,j) = ubt_wtd(I,j) + wt_vel(n) * ubt(I,j)
     enddo ; enddo
-    !GOMP do
+    !$OMP end do nowait
+    !$OMP do
     do J=js-1,je ; do i=is,ie
       vbt_sum(i,J) = vbt_sum(i,J) + wt_trans(n) * vbt_trans(i,J)
       vhbt_sum(i,J) = vhbt_sum(i,J) + wt_trans(n) * vhbt(i,J)
       vbt_wtd(i,J) = vbt_wtd(i,J) + wt_vel(n) * vbt(i,J)
     enddo ; enddo
-    !GOMP end parallel
+    !$OMP end do nowait
 
     if (apply_OBCs) then
 
+      !$OMP single
       call apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, &
              ubt_trans, vbt_trans, eta, ubt_old, vbt_old, CS%BT_OBC, &
              G, MS, US, iev-ie, dtbt, bebt, use_BT_cont, integral_BT_cont, &
              n*dtbt, Datu, Datv, BTCL_u, BTCL_v, uhbt0, vhbt0, &
              ubt_int_prev, vbt_int_prev, uhbt_int_prev, vhbt_int_prev)
+      !$OMP end single
 
-      if (CS%BT_OBC%apply_u_OBCs) then ; do j=js,je ; do I=is-1,ie
-        if (OBC%segnum_u(I,j) /= OBC_NONE) then
-          ! Update the summed and integrated quantities from the saved previous values.
-          ubt_sum(I,j) = ubt_sum_prev(I,j) + wt_trans(n) * ubt_trans(I,j)
-          uhbt_sum(I,j) = uhbt_sum_prev(I,j) + wt_trans(n) * uhbt(I,j)
-          ubt_wtd(I,j) = ubt_wtd_prev(I,j) + wt_vel(n) * ubt(I,j)
-          if (integral_BT_cont) then
-            uhbt_int(I,j) = uhbt_int_prev(I,j) + dtbt * uhbt(I,j)
-            ubt_int(I,j) = ubt_int_prev(I,j) + dtbt * ubt_trans(I,j)
+      if (CS%BT_OBC%apply_u_OBCs) then
+        !$OMP do
+        do j=js,je ; do I=is-1,ie
+          if (OBC%segnum_u(I,j) /= OBC_NONE) then
+            ! Update the summed and integrated quantities from the saved previous values.
+            ubt_sum(I,j) = ubt_sum_prev(I,j) + wt_trans(n) * ubt_trans(I,j)
+            uhbt_sum(I,j) = uhbt_sum_prev(I,j) + wt_trans(n) * uhbt(I,j)
+            ubt_wtd(I,j) = ubt_wtd_prev(I,j) + wt_vel(n) * ubt(I,j)
+            if (integral_BT_cont) then
+              uhbt_int(I,j) = uhbt_int_prev(I,j) + dtbt * uhbt(I,j)
+              ubt_int(I,j) = ubt_int_prev(I,j) + dtbt * ubt_trans(I,j)
+            endif
           endif
-        endif
-      enddo ; enddo ; endif
-      if (CS%BT_OBC%apply_v_OBCs) then ; do J=js-1,je ; do i=is,ie
-        if (OBC%segnum_v(i,J) /= OBC_NONE) then
-          ! Update the summed and integrated quantities from the saved previous values.
-          vbt_sum(i,J) = vbt_sum_prev(i,J) + wt_trans(n) * vbt_trans(i,J)
-          vhbt_sum(i,J) = vhbt_sum_prev(i,J) + wt_trans(n) * vhbt(i,J)
-          vbt_wtd(i,J) = vbt_wtd_prev(i,J) + wt_vel(n) * vbt(i,J)
-          if (integral_BT_cont) then
-            vbt_int(i,J) = vbt_int_prev(i,J) + dtbt * vbt_trans(i,J)
-            vhbt_int(i,J) = vhbt_int_prev(i,J) + dtbt * vhbt(i,J)
+        enddo ; enddo
+      endif
+      if (CS%BT_OBC%apply_v_OBCs) then
+        !$OMP do
+        do J=js-1,je ; do i=is,ie
+          if (OBC%segnum_v(i,J) /= OBC_NONE) then
+            ! Update the summed and integrated quantities from the saved previous values.
+            vbt_sum(i,J) = vbt_sum_prev(i,J) + wt_trans(n) * vbt_trans(i,J)
+            vhbt_sum(i,J) = vhbt_sum_prev(i,J) + wt_trans(n) * vhbt(i,J)
+            vbt_wtd(i,J) = vbt_wtd_prev(i,J) + wt_vel(n) * vbt(i,J)
+            if (integral_BT_cont) then
+              vbt_int(i,J) = vbt_int_prev(i,J) + dtbt * vbt_trans(i,J)
+              vhbt_int(i,J) = vhbt_int_prev(i,J) + dtbt * vhbt(i,J)
+            endif
           endif
-        endif
-      enddo ; enddo ; endif
+        enddo ; enddo
+      endif
     endif
 
     if (CS%debug_bt) then
@@ -2247,22 +2275,22 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                       haloshift=iev-ie, scale=US%L_to_m**2*GV%H_to_m)
     endif
 
-
     if (integral_BT_cont) then
-      !$OMP parallel do default(shared)
+      !$OMP do
       do j=jsv,jev ; do i=isv,iev
         eta(i,j) = (eta_IC(i,j) + n*eta_src(i,j)) + CS%IareaT(i,j) * &
                    ((uhbt_int(I-1,j) - uhbt_int(I,j)) + (vhbt_int(i,J-1) - vhbt_int(i,J)))
         eta_wtd(i,j) = eta_wtd(i,j) + eta(i,j) * wt_eta(n)
       enddo ; enddo
     else
-      !$OMP parallel do default(shared)
+      !$OMP do
       do j=jsv,jev ; do i=isv,iev
         eta(i,j) = (eta(i,j) + eta_src(i,j)) + (dtbt * CS%IareaT(i,j)) * &
                    ((uhbt(I-1,j) - uhbt(I,j)) + (vhbt(i,J-1) - vhbt(i,J)))
         eta_wtd(i,j) = eta_wtd(i,j) + eta(i,j) * wt_eta(n)
       enddo ; enddo
     endif
+    !$OMP end parallel
 
     if (do_hifreq_output) then
       time_step_end = time_bt_start + real_to_time(n*US%T_to_s*dtbt)

--- a/src/framework/MOM_get_input.F90
+++ b/src/framework/MOM_get_input.F90
@@ -21,7 +21,8 @@ type, public :: directories
   character(len=240) :: &
     restart_input_dir = ' ',& !< The directory to read restart and input files.
     restart_output_dir = ' ',&!< The directory into which to write restart files.
-    output_directory = ' ', & !< The directory to use to write the model output.
+    output_directory = ' '    !< The directory to use to write the model output.
+  character(len=2048) :: &
     input_filename  = ' '     !< A string that indicates the input files or how
                               !! the run segment should be started.
 end type directories
@@ -46,7 +47,8 @@ subroutine get_MOM_input(param_file, dirs, check_params, default_input_filename,
     parameter_filename(npf), & ! List of files containing parameters.
     output_directory,        & ! Directory to use to write the model output.
     restart_input_dir,       & ! Directory for reading restart and input files.
-    restart_output_dir,      & ! Directory into which to write restart files.
+    restart_output_dir         ! Directory into which to write restart files.
+  character(len=2048) :: &
     input_filename             ! A string that indicates the input files or how
                                ! the run segment should be started.
   character(len=240) :: output_dir

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -849,7 +849,7 @@ function query_initialized_4d_name(f_ptr, name, CS) result(query_initialized)
 end function query_initialized_4d_name
 
 !> save_restart saves all registered variables to restart files.
-subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV)
+subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_rest_files)
   character(len=*),        intent(in)    :: directory !< The directory where the restart files
                                                   !! are to be written
   type(time_type),         intent(in)    :: time  !< The current model time
@@ -860,6 +860,7 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV)
                                                   !! to the restart file names.
   character(len=*), optional, intent(in) :: filename !< A filename that overrides the name in CS%restartfile.
   type(verticalGrid_type), optional, intent(in) :: GV   !< The ocean's vertical grid structure
+  integer, optional, intent(out) :: num_rest_files      !< number of restart files written
 
   ! Local variables
   type(vardesc) :: vars(CS%max_fields)  ! Descriptions of the fields that
@@ -1056,6 +1057,9 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV)
     num_files = num_files+1
 
   enddo
+
+  if (present(num_rest_files)) num_rest_files = num_files
+
 end subroutine save_restart
 
 !> restore_state reads the model state from previously generated files.  All

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -47,6 +47,8 @@ type, public :: hor_visc_CS ; private
                              !! limited to guarantee stability.
   logical :: better_bound_Ah !< If true, use a more careful bounding of the
                              !! biharmonic viscosity to guarantee stability.
+  real    :: Re_Ah           !! If nonzero, the biharmonic coefficient is scaled
+                             !< so that the biharmonic Reynolds number is equal to this.
   real    :: bound_coef      !< The nondimensional coefficient of the ratio of
                              !! the viscosity bounds to the theoretical maximum
                              !! for stability without considering other terms [nondim].
@@ -104,11 +106,6 @@ type, public :: hor_visc_CS ; private
                       !< The background biharmonic viscosity at h points [L4 T-1 ~> m4 s-1].
                       !! The actual viscosity may be the larger of this
                       !! viscosity and the Smagorinsky and Leith viscosities.
-!  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: Biharm5_const2_xx
-                      !< A constant relating the biharmonic viscosity to the
-                      !! square of the velocity shear [L4 T ~> m4 s].  This value is
-                      !! set to be the magnitude of the Coriolis terms once the
-                      !! velocity differences reach a value of order 1/2 MAXVEL.
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: reduction_xx
                       !< The amount by which stresses through h points are reduced
                       !! due to partial barriers [nondim].
@@ -116,8 +113,9 @@ type, public :: hor_visc_CS ; private
     Kh_Max_xx,      & !< The maximum permitted Laplacian viscosity [L2 T-1 ~> m2 s-1].
     Ah_Max_xx,      & !< The maximum permitted biharmonic viscosity [L4 T-1 ~> m4 s-1].
     n1n2_h,         & !< Factor n1*n2 in the anisotropic direction tensor at h-points
-    n1n1_m_n2n2_h     !< Factor n1**2-n2**2 in the anisotropic direction tensor at h-points
-
+    n1n1_m_n2n2_h,  & !< Factor n1**2-n2**2 in the anisotropic direction tensor at h-points
+    grid_sp_h2,     & !< Harmonic mean of the squares of the grid [L2 ~> m2]
+    grid_sp_h3        !< Harmonic mean of the squares of the grid^(3/2) [L3 ~> m3]
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: Kh_bg_xy
                       !< The background Laplacian viscosity at q points [L2 T-1 ~> m2 s-1].
                       !! The actual viscosity may be the larger of this
@@ -126,11 +124,6 @@ type, public :: hor_visc_CS ; private
                       !< The background biharmonic viscosity at q points [L4 T-1 ~> m4 s-1].
                       !! The actual viscosity may be the larger of this
                       !! viscosity and the Smagorinsky and Leith viscosities.
-!  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: Biharm5_const2_xy
-                      !< A constant relating the biharmonic viscosity to the
-                      !! square of the velocity shear [L4 T ~> m4 s].  This value is
-                      !! set to be the magnitude of the Coriolis terms once the
-                      !! velocity differences reach a value of order 1/2 MAXVEL.
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: reduction_xy
                       !< The amount by which stresses through q points are reduced
                       !! due to partial barriers [nondim].
@@ -161,17 +154,19 @@ type, public :: hor_visc_CS ; private
   ! parameters and metric terms.
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
     Laplac2_const_xx, & !< Laplacian  metric-dependent constants [L2 ~> m2]
-    Biharm5_const_xx, & !< Biharmonic metric-dependent constants [L5 ~> m5]
+    Biharm6_const_xx, & !< Biharmonic metric-dependent constants [L6 ~> m6]
     Laplac3_const_xx, & !< Laplacian  metric-dependent constants [L3 ~> m3]
     Biharm_const_xx,  & !< Biharmonic metric-dependent constants [L4 ~> m4]
-    Biharm_const2_xx    !< Biharmonic metric-dependent constants [T L4 ~> s m4]
+    Biharm_const2_xx, & !< Biharmonic metric-dependent constants [T L4 ~> s m4]
+    Re_Ah_const_xx      !< Biharmonic metric-dependent constants [L3 ~> m3]
 
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &
     Laplac2_const_xy, & !< Laplacian  metric-dependent constants [L2 ~> m2]
-    Biharm5_const_xy, & !< Biharmonic metric-dependent constants [L5 ~> m5]
+    Biharm6_const_xy, & !< Biharmonic metric-dependent constants [L6 ~> m6]
     Laplac3_const_xy, & !< Laplacian  metric-dependent constants [L3 ~> m3]
     Biharm_const_xy,  & !< Biharmonic metric-dependent constants [L4 ~> m4]
-    Biharm_const2_xy    !< Biharmonic metric-dependent constants [T L4 ~> s m4]
+    Biharm_const2_xy, & !< Biharmonic metric-dependent constants [T L4 ~> s m4]
+    Re_Ah_const_xy      !< Biharmonic metric-dependent constants [L3 ~> m3]
 
   type(diag_ctrl), pointer :: diag => NULL() !< structure to regulate diagnostics
 
@@ -182,6 +177,7 @@ type, public :: hor_visc_CS ; private
 
   !>@{
   !! Diagnostic id
+  integer :: id_grid_Re_Ah = -1, id_grid_Re_Kh   = -1
   integer :: id_diffu     = -1, id_diffv         = -1
   ! integer :: id_hf_diffu  = -1, id_hf_diffv      = -1
   integer :: id_hf_diffu_2d = -1, id_hf_diffv_2d = -1
@@ -189,6 +185,7 @@ type, public :: hor_visc_CS ; private
   integer :: id_Kh_h      = -1, id_Kh_q          = -1
   integer :: id_GME_coeff_h = -1, id_GME_coeff_q = -1
   integer :: id_vort_xy_q = -1, id_div_xx_h      = -1
+  integer :: id_sh_xy_q = -1,    id_sh_xx_h      = -1
   integer :: id_FrictWork = -1, id_FrictWorkIntz = -1
   integer :: id_FrictWork_GME = -1
   !>@}
@@ -266,6 +263,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     ! Leith_Ah_h, & ! Leith bi-harmonic viscosity at h-points [L4 T-1 ~> m4 s-1]
     grad_vort_mag_h, & ! Magnitude of vorticity gradient at h-points [L-1 T-1 ~> m-1 s-1]
     grad_vort_mag_h_2d, & ! Magnitude of 2d vorticity gradient at h-points [L-1 T-1 ~> m-1 s-1]
+    Del2vort_h, & ! Laplacian of vorticity at h-points [L-2 T-1 ~> m-2 s-1]
     grad_div_mag_h, &     ! Magnitude of divergence gradient at h-points [L-1 T-1 ~> m-1 s-1]
     dudx, dvdy, &    ! components in the horizontal tension [T-1 ~> s-1]
     grad_vel_mag_h, & ! Magnitude of the velocity gradient tensor squared at h-points [T-2 ~> s-2]
@@ -290,6 +288,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     Leith_Ah_q, & ! Leith bi-harmonic viscosity at q-points [L4 T-1 ~> m4 s-1]
     grad_vort_mag_q, & ! Magnitude of vorticity gradient at q-points [L-1 T-1 ~> m-1 s-1]
     grad_vort_mag_q_2d, & ! Magnitude of 2d vorticity gradient at q-points [L-1 T-1 ~> m-1 s-1]
+    Del2vort_q, & ! Laplacian of vorticity at q-points [L-2 T-1 ~> m-2 s-1]
     grad_div_mag_q, &  ! Magnitude of divergence gradient at q-points [L-1 T-1 ~> m-1 s-1]
     grad_vel_mag_q, &  ! Magnitude of the velocity gradient tensor squared at q-points [T-2 ~> s-2]
     hq, &  ! harmonic mean of the harmonic means of the u- & v point thicknesses [H ~> m or kg m-2]
@@ -301,6 +300,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     Ah_q, &      ! biharmonic viscosity at corner points [L4 T-1 ~> m4 s-1]
     Kh_q, &      ! Laplacian viscosity at corner points [L2 T-1 ~> m2 s-1]
     vort_xy_q, & ! vertical vorticity at corner points [T-1 ~> s-1]
+    sh_xy_q,   & ! horizontal shearing strain at corner points [T-1 ~> s-1]
     GME_coeff_q, &  !< GME coeff. at q-points [L2 T-1 ~> m2 s-1]
     max_diss_rate_q ! maximum possible energy dissipated by lateral friction [L2 T-3 ~> m2 s-3]
 
@@ -313,9 +313,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     Kh_h, &          ! Laplacian viscosity at thickness points [L2 T-1 ~> m2 s-1]
     max_diss_rate_h, & ! maximum possible energy dissipated by lateral friction [L2 T-3 ~> m2 s-3]
     FrictWork, &     ! work done by MKE dissipation mechanisms [R L2 T-3 ~> W m-2]
-    FrictWork_GME, &  ! work done by GME [R L2 T-3 ~> W m-2]
-    div_xx_h         ! horizontal divergence [T-1 ~> s-1]
+    FrictWork_GME, & ! work done by GME [R L2 T-3 ~> W m-2]
+    div_xx_h,      & ! horizontal divergence [T-1 ~> s-1]
+    sh_xx_h          ! horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: &
+    grid_Re_Kh, &    !< Grid Reynolds number for Laplacian horizontal viscosity at h points [nondim]
+    grid_Re_Ah, &    !< Grid Reynolds number for Biharmonic horizontal viscosity at h points [nondim]
     GME_coeff_h      !< GME coeff. at h-points [L2 T-1 ~> m2 s-1]
   real :: Ah         ! biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: Kh         ! Laplacian  viscosity [L2 T-1 ~> m2 s-1]
@@ -348,10 +351,18 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   real :: FWfrac    ! Fraction of maximum theoretical energy transfer to use when scaling GME coefficient [nondim]
   real :: DY_dxBu   ! Ratio of meridional over zonal grid spacing at vertices [nondim]
   real :: DX_dyBu   ! Ratio of zonal over meridiononal grid spacing at vertices [nondim]
+  real :: DY_dxCv   ! Ratio of meridional over zonal grid spacing at faces [nondim]
+  real :: DX_dyCu   ! Ratio of zonal over meridional grid spacing at faces [nondim]
   real :: Sh_F_pow  ! The ratio of shear over the absolute value of f raised to some power and rescaled [nondim]
   real :: backscat_subround ! The ratio of f over Shear_mag that is so small that the backscatter
                     ! calculation gives the same value as if f were 0 [nondim].
   real :: H0_GME    ! Depth used to scale down GME coefficient in shallow areas [Z ~> m]
+  real :: KE        ! Local kinetic energy [L2 T-2 ~> m2 s-2]
+  real, parameter :: KH_min = 1.E-30 ! This is the minimun horizontal Laplacian viscosity used to estimate the
+                    ! grid Raynolds number [L2 T-1 ~> m2 s-1]
+  real, parameter :: AH_min = 1.E-30 ! This is the minimun horizontal Biharmonic viscosity used to estimate the
+                    ! grid Raynolds number [L4 T-1 ~> m4 s-1]
+
   logical :: rescale_Kh, legacy_bound
   logical :: find_FrictWork
   logical :: apply_OBC = .false.
@@ -359,7 +370,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   logical :: use_MEKE_Au
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: i, j, k, n
-  real :: inv_PI3, inv_PI2, inv_PI5
+  real :: inv_PI3, inv_PI2, inv_PI6
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = G%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
@@ -367,7 +378,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   h_neglect3 = h_neglect**3
   inv_PI3 = 1.0/((4.0*atan(1.0))**3)
   inv_PI2 = 1.0/((4.0*atan(1.0))**2)
-  inv_PI5 = inv_PI3 * inv_PI2
+  inv_PI6 = inv_PI3 * inv_PI3
 
   Ah_h(:,:,:) = 0.0
   Kh_h(:,:,:) = 0.0
@@ -478,11 +489,11 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   !$OMP   apply_OBC, rescale_Kh, legacy_bound, find_FrictWork, &
   !$OMP   use_MEKE_Ku, use_MEKE_Au, boundary_mask_h, boundary_mask_q, &
   !$OMP   backscat_subround, GME_coeff_limiter, &
-  !$OMP   h_neglect, h_neglect3, FWfrac, inv_PI3, inv_PI5, H0_GME, &
+  !$OMP   h_neglect, h_neglect3, FWfrac, inv_PI3, inv_PI6, H0_GME, &
   !$OMP   diffu, diffv, max_diss_rate_h, max_diss_rate_q, &
   !$OMP   Kh_h, Kh_q, Ah_h, Ah_q, FrictWork, FrictWork_GME, &
-  !$OMP   div_xx_h, vort_xy_q, GME_coeff_h, GME_coeff_q, &
-  !$OMP   TD, KH_u_GME, KH_v_GME &
+  !$OMP   div_xx_h, sh_xx_h, vort_xy_q, sh_xy_q, GME_coeff_h, GME_coeff_q, &
+  !$OMP   TD, KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah &
   !$OMP ) &
   !$OMP private( &
   !$OMP   i, j, k, n, &
@@ -496,7 +507,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   !$OMP   grad_vel_mag_bt_h, grad_vel_mag_bt_q, grad_d2vel_mag_h, &
   !$OMP   meke_res_fn, Shear_mag, vert_vort_mag, hrat_min, visc_bound_rem, &
   !$OMP   Kh, Ah, AhSm, AhLth, local_strain, Sh_F_pow, &
-  !$OMP   dDel2vdx, dDel2udy, &
+  !$OMP   dDel2vdx, dDel2udy, DY_dxCv, DX_dyCu, Del2vort_q, Del2vort_h, KE, &
   !$OMP   h2uq, h2vq, hu, hv, hq, FatH, RoScl, GME_coeff &
   !$OMP )
   do k=1,nz
@@ -515,7 +526,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     enddo ; enddo
 
     ! Components for the shearing strain
-    do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+    do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
       dvdx(I,J) = CS%DY_dxBu(I,J)*(v(i+1,J,k)*G%IdyCv(i+1,J) - v(i,J,k)*G%IdyCv(i,J))
       dudy(I,J) = CS%DX_dyBu(I,J)*(u(I,j+1,k)*G%IdxCu(I,j+1) - u(I,j,k)*G%IdxCu(I,j))
     enddo ; enddo
@@ -636,7 +647,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-1) .and. (J <= je+1)) then
           do I = max(Isq-1,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
-            h_u(I,j) = h_u(i,j+1)
+            h_u(I,j) = h_u(I,j+1)
           enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
@@ -692,35 +703,48 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       endif; endif
     endif
 
+    ! Vorticity
+    if (CS%no_slip) then
+      do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
+        vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
+      enddo ; enddo
+    else
+      do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
+        vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
+      enddo ; enddo
+    endif
+
+    ! Divergence
+    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+      div_xx(i,j) = dudx(i,j) + dvdy(i,j)
+    enddo ; enddo
+
     if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
 
-      ! Vorticity
-      if (CS%no_slip) then
-        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-          vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
-        enddo ; enddo
-      else
-        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-          vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
-        enddo ; enddo
-      endif
-
       ! Vorticity gradient
-      do J=js-2,Jeq+1 ; do i=is-1,Ieq+1
+      do J=Jsq-1,Jeq+1 ; do i=Isq-1,Ieq+2
         DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
         vort_xy_dx(i,J) = DY_dxBu * (vort_xy(I,J) * G%IdyCu(I,j) - vort_xy(I-1,J) * G%IdyCu(I-1,j))
       enddo ; enddo
 
-      do j=js-1,Jeq+1 ; do I=is-2,Ieq+1
+      do j=Jsq-1,Jeq+2 ; do I=Isq-1,Ieq+1
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
         vort_xy_dy(I,j) = DX_dyBu * (vort_xy(I,J) * G%IdxCv(i,J) - vort_xy(I,J-1) * G%IdxCv(i,J-1))
       enddo ; enddo
 
+      ! Laplacian of vorticity
+      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+        DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+
+        Del2vort_q(I,J) = DY_dxBu * (vort_xy_dx(i+1,J) * G%IdyCv(i+1,J) - vort_xy_dx(i,J) * G%IdyCv(i,J)) + &
+                        DX_dyBu * (vort_xy_dy(I,j+1) * G%IdyCu(I,j+1) - vort_xy_dy(I,j) * G%IdyCu(I,j))
+      enddo ; enddo
+      do J=Jsq,Jeq+1 ; do I=Isq,Ieq+1
+        Del2vort_h(i,j) = 0.25*(Del2vort_q(I,J) + Del2vort_q(I-1,J) + Del2vort_q(I,J-1) + Del2vort_q(I-1,J-1))
+      enddo ; enddo
+
       if (CS%modified_Leith) then
-        ! Divergence
-        do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-          div_xx(i,j) = dudx(i,j) + dvdy(i,j)
-        enddo ; enddo
 
         ! Divergence gradient
         do j=Jsq-1,Jeq+2 ; do I=Isq-1,Ieq+1
@@ -850,7 +874,14 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         endif
 
         if ((CS%id_Kh_h>0) .or. find_FrictWork .or. CS%debug) Kh_h(i,j,k) = Kh
+
+        if (CS%id_grid_Re_Kh>0) then
+          KE = 0.125*((u(I,j,k)+u(I-1,j,k))**2 + (v(i,J,k)+v(i,J-1,k))**2)
+          grid_Re_Kh(i,j,k) = (sqrt(KE) * sqrt(CS%grid_sp_h2(i,j)))/MAX(Kh,KH_min)
+        endif
+
         if (CS%id_div_xx_h>0) div_xx_h(i,j,k) = div_xx(i,j)
+        if (CS%id_sh_xx_h>0) sh_xx_h(i,j,k) = sh_xx(i,j)
 
         str_xx(i,j) = -Kh * sh_xx(i,j)
       else   ! not Laplacian
@@ -877,7 +908,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
               AhSm = CS%Biharm_const_xx(i,j) * Shear_mag
             endif
           endif
-          if (CS%Leith_Ah) AhLth = CS%Biharm5_const_xx(i,j) * vert_vort_mag * inv_PI5
+          if (CS%Leith_Ah) AhLth = CS%Biharm6_const_xx(i,j) * abs(Del2vort_h(i,j)) * inv_PI6
           Ah = MAX(MAX(CS%Ah_bg_xx(i,j), AhSm), AhLth)
           if (CS%bound_Ah .and. .not.CS%better_bound_Ah) &
             Ah = MIN(Ah, CS%Ah_Max_xx(i,j))
@@ -887,11 +918,21 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
         if (use_MEKE_Au) Ah = Ah + MEKE%Au(i,j) ! *Add* the MEKE contribution
 
+        if (CS%Re_Ah > 0.0) then
+          KE = 0.125*((u(I,j,k)+u(I-1,j,k))**2 + (v(i,J,k)+v(i,J-1,k))**2)
+          Ah = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
+        endif
+
         if (CS%better_bound_Ah) then
           Ah = MIN(Ah, visc_bound_rem*hrat_min*CS%Ah_Max_xx(i,j))
         endif
 
         if ((CS%id_Ah_h>0) .or. find_FrictWork .or. CS%debug) Ah_h(i,j,k) = Ah
+
+        if (CS%id_grid_Re_Ah>0) then
+           KE = 0.125*((u(I,j,k)+u(I-1,j,k))**2 + (v(i,J,k)+v(i,J-1,k))**2)
+           grid_Re_Ah(i,j,k) = (sqrt(KE) * CS%grid_sp_h3(i,j))/MAX(Ah,AH_min)
+        endif
 
         str_xx(i,j) = str_xx(i,j) + Ah * &
           (CS%DY_dxT(i,j) * (G%IdyCu(I,j)*Del2u(I,j) - G%IdyCu(I-1,j)*Del2u(I-1,j)) - &
@@ -1021,6 +1062,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
         if (CS%id_Kh_q>0 .or. CS%debug) Kh_q(I,J,k) = Kh
         if (CS%id_vort_xy_q>0) vort_xy_q(I,J,k) = vort_xy(I,J)
+        if (CS%id_sh_xy_q>0) sh_xy_q(I,J,k) = sh_xy(I,J)
 
         str_xy(I,J) = -Kh * sh_xy(I,J)
       else   ! not Laplacian
@@ -1047,7 +1089,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
               AhSm = CS%Biharm_const_xy(I,J) * Shear_mag
             endif
           endif
-          if (CS%Leith_Ah) AhLth = CS%Biharm5_const_xy(I,J) * vert_vort_mag * inv_PI5
+          if (CS%Leith_Ah) AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J)) * inv_PI6
           Ah = MAX(MAX(CS%Ah_bg_xy(I,J), AhSm), AhLth)
           if (CS%bound_Ah .and. .not.CS%better_bound_Ah) &
             Ah = MIN(Ah, CS%Ah_Max_xy(I,J))
@@ -1056,8 +1098,13 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         endif ! Smagorinsky_Ah or Leith_Ah
 
         if (use_MEKE_Au) then ! *Add* the MEKE contribution
-          Ah = Ah + 0.25*( (MEKE%Au(I,J) + MEKE%Au(I+1,J+1)) +  &
-                           (MEKE%Au(I+1,J) + MEKE%Au(I,J+1)) )
+          Ah = Ah + 0.25*( (MEKE%Au(i,j) + MEKE%Au(i+1,j+1)) +  &
+                           (MEKE%Au(i+1,j) + MEKE%Au(i,j+1)) )
+        endif
+
+        if (CS%Re_Ah > 0.0) then
+          KE = 0.125*((u(I,j,k)+u(I,j+1,k))**2 + (v(i,J,k)+v(i+1,J,k))**2)
+          Ah = sqrt(KE) * CS%Re_Ah_const_xy(i,j)
         endif
 
         if (CS%better_bound_Ah) then
@@ -1158,7 +1205,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
                                      CS%dy2h(i+1,j)*str_xx(i+1,j)) + &
                        G%IdxCu(I,j)*(CS%dx2q(I,J-1)*str_xy(I,J-1) - &
                                      CS%dx2q(I,J) *str_xy(I,J))) * &
-                     G%IareaCu(I,j)) / (h_u(i,j) + h_neglect)
+                     G%IareaCu(I,j)) / (h_u(I,j) + h_neglect)
 
     enddo ; enddo
     if (apply_OBC) then
@@ -1293,10 +1340,14 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   if (CS%id_FrictWork>0) call post_data(CS%id_FrictWork, FrictWork, CS%diag)
   if (CS%id_FrictWork_GME>0) call post_data(CS%id_FrictWork_GME, FrictWork_GME, CS%diag)
   if (CS%id_Ah_h>0)      call post_data(CS%id_Ah_h, Ah_h, CS%diag)
+  if (CS%id_grid_Re_Ah>0) call post_data(CS%id_grid_Re_Ah, grid_Re_Ah, CS%diag)
   if (CS%id_div_xx_h>0)  call post_data(CS%id_div_xx_h, div_xx_h, CS%diag)
   if (CS%id_vort_xy_q>0) call post_data(CS%id_vort_xy_q, vort_xy_q, CS%diag)
+  if (CS%id_sh_xx_h>0)  call post_data(CS%id_sh_xx_h, sh_xx_h, CS%diag)
+  if (CS%id_sh_xy_q>0) call post_data(CS%id_sh_xy_q, sh_xy_q, CS%diag)
   if (CS%id_Ah_q>0)      call post_data(CS%id_Ah_q, Ah_q, CS%diag)
   if (CS%id_Kh_h>0)      call post_data(CS%id_Kh_h, Kh_h, CS%diag)
+  if (CS%id_grid_Re_Kh>0) call post_data(CS%id_grid_Re_Kh, grid_Re_Kh, CS%diag)
   if (CS%id_Kh_q>0)      call post_data(CS%id_Kh_q, Kh_q, CS%diag)
   if (CS%id_GME_coeff_h > 0)  call post_data(CS%id_GME_coeff_h, GME_coeff_h, CS%diag)
   if (CS%id_GME_coeff_q > 0)  call post_data(CS%id_GME_coeff_q, GME_coeff_q, CS%diag)
@@ -1412,7 +1463,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
   logical :: split         ! If true, use the split time stepping scheme.
                            ! If false and USE_GME = True, issue a FATAL error.
   logical :: default_2018_answers
-
   character(len=64) :: inputdir, filename
   real    :: deg2rad       ! Converts degrees to radians
   real    :: slat_fn       ! sin(lat)**Kh_pwr_of_sine
@@ -1421,28 +1471,22 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   integer :: i, j
-
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_hor_visc"  ! module name
-
   is   = G%isc  ; ie   = G%iec  ; js   = G%jsc  ; je   = G%jec ; nz = G%ke
   Isq  = G%IscB ; Ieq  = G%IecB ; Jsq  = G%JscB ; Jeq  = G%JecB
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
-
   if (associated(CS)) then
     call MOM_error(WARNING, "hor_visc_init called with an associated "// &
                             "control structure.")
     return
   endif
   allocate(CS)
-
   CS%diag => diag
-
   ! Read parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
-
   !   It is not clear whether these initialization lines are needed for the
   ! cases where the corresponding parameters are not read.
   CS%bound_Kh = .false. ; CS%better_bound_Kh = .false. ; CS%Smagorinsky_Kh = .false. ; CS%Leith_Kh = .false.
@@ -1452,13 +1496,10 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
   CS%Modified_Leith = .false.
   CS%anisotropic = .false.
   CS%dynamic_aniso = .false.
-
   Kh = 0.0 ; Ah = 0.0
-
   !   If GET_ALL_PARAMS is true, all parameters are read in all cases to enable
   ! parameter spelling checks.
   call get_param(param_file, mdl, "GET_ALL_PARAMS", get_all, default=.false.)
-
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=.false.)
@@ -1466,9 +1507,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
-
   call get_param(param_file, mdl, "LAPLACIAN", CS%Laplacian, &
                  "If true, use a Laplacian horizontal viscosity.", &
                  default=.false.)
@@ -1494,7 +1533,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                  "The power used to raise SIN(LAT) when using a latitudinally "//&
                  "dependent background viscosity.", &
                  units = "nondim",  default=4.0)
-
     call get_param(param_file, mdl, "SMAGORINSKY_KH", CS%Smagorinsky_Kh, &
                  "If true, use a Smagorinsky nonlinear eddy viscosity.", &
                  default=.false.)
@@ -1503,11 +1541,9 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                  "The nondimensional Laplacian Smagorinsky constant, "//&
                  "often 0.15.", units="nondim", default=0.0, &
                   fail_if_missing = CS%Smagorinsky_Kh)
-
     call get_param(param_file, mdl, "LEITH_KH", CS%Leith_Kh, &
                  "If true, use a Leith nonlinear eddy viscosity.", &
                  default=.false.)
-
     call get_param(param_file, mdl, "MODIFIED_LEITH", CS%Modified_Leith, &
                  "If true, add a term to Leith viscosity which is "//&
                  "proportional to the gradient of divergence.", &
@@ -1515,7 +1551,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
     call get_param(param_file, mdl, "RES_SCALE_MEKE_VISC", CS%res_scale_MEKE, &
                  "If true, the viscosity contribution from MEKE is scaled by "//&
                  "the resolution function.", default=.false.)
-
     if (CS%Leith_Kh .or. get_all) then
       call get_param(param_file, mdl, "LEITH_LAP_CONST", Leith_Lap_const, &
                  "The nondimensional Laplacian Leith constant, "//&
@@ -1574,7 +1609,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                  "to the spherical coordinates.", units = "nondim", fail_if_missing=.true.)
     end select
   endif
-
   call get_param(param_file, mdl, "BIHARMONIC", CS%biharmonic, &
                  "If true, use a biharmonic horizontal viscosity. "//&
                  "BIHARMONIC may be used with LAPLACIAN.", &
@@ -1601,7 +1635,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
     call get_param(param_file, mdl, "LEITH_AH", CS%Leith_Ah, &
                  "If true, use a biharmonic Leith nonlinear eddy "//&
                  "viscosity.", default=.false.)
-
     call get_param(param_file, mdl, "BOUND_AH", CS%bound_Ah, &
                  "If true, the biharmonic coefficient is locally limited "//&
                  "to be stable.", default=.true.)
@@ -1609,13 +1642,16 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                  "If true, the biharmonic coefficient is locally limited "//&
                  "to be stable with a better bounding than just BOUND_AH.", &
                  default=CS%bound_Ah)
+    call get_param(param_file, mdl, "RE_AH", CS%Re_Ah, &
+                 "If nonzero, the biharmonic coefficient is scaled "//&
+                 "so that the biharmonic Reynolds number is equal to this.", &
+                 units="nondim", default=0.0)
 
     if (CS%Smagorinsky_Ah .or. get_all) then
       call get_param(param_file, mdl, "SMAG_BI_CONST",Smag_bi_const, &
                  "The nondimensional biharmonic Smagorinsky constant, "//&
                  "typically 0.015 - 0.06.", units="nondim", default=0.0, &
                  fail_if_missing = CS%Smagorinsky_Ah)
-
       call get_param(param_file, mdl, "BOUND_CORIOLIS", bound_Cor_def, default=.false.)
       call get_param(param_file, mdl, "BOUND_CORIOLIS_BIHARM", CS%bound_Coriolis, &
                  "If true use a viscosity that increases with the square "//&
@@ -1634,27 +1670,22 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                  units="m s-1", default=maxvel, scale=US%m_s_to_L_T)
       endif
     endif
-
     if (CS%Leith_Ah .or. get_all) &
       call get_param(param_file, mdl, "LEITH_BI_CONST", Leith_bi_const, &
                  "The nondimensional biharmonic Leith constant, "//&
                  "typical values are thus far undetermined.", units="nondim", default=0.0, &
                  fail_if_missing = CS%Leith_Ah)
-
   endif
-
   call get_param(param_file, mdl, "USE_LAND_MASK_FOR_HVISC", CS%use_land_mask, &
                  "If true, use Use the land mask for the computation of thicknesses "//&
                  "at velocity locations. This eliminates the dependence on arbitrary "//&
                  "values over land or outside of the domain.", default=.true.)
-
   if (CS%better_bound_Ah .or. CS%better_bound_Kh .or. get_all) &
     call get_param(param_file, mdl, "HORVISC_BOUND_COEF", CS%bound_coef, &
                  "The nondimensional coefficient of the ratio of the "//&
                  "viscosity bounds to the theoretical maximum for "//&
                  "stability without considering other terms.", units="nondim", &
                  default=0.8)
-
   call get_param(param_file, mdl, "NOSLIP", CS%no_slip, &
                  "If true, no slip boundary conditions are used; otherwise "//&
                  "free slip boundary conditions are assumed. The "//&
@@ -1662,7 +1693,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                  "cleaner than the no slip BCs. The use of free slip BCs "//&
                  "is strongly encouraged, and no slip BCs are not used with "//&
                  "the biharmonic viscosity.", default=.false.)
-
   call get_param(param_file, mdl, "USE_KH_BG_2D", CS%use_Kh_bg_2d, &
                  "If true, read a file containing 2-d background harmonic "//&
                  "viscosities. The final viscosity is the maximum of the other "//&
@@ -1671,38 +1701,30 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
   call get_param(param_file, mdl, "USE_GME", CS%use_GME, &
                  "If true, use the GM+E backscatter scheme in association \n"//&
                  "with the Gent and McWilliams parameterization.", default=.false.)
-
   if (CS%use_GME) then
     call get_param(param_file, mdl, "SPLIT", split, &
                  "Use the split time stepping if true.", default=.true., &
                   do_not_log=.true.)
     if (.not. split) call MOM_error(FATAL,"ERROR: Currently, USE_GME = True "// &
                                            "cannot be used with SPLIT=False.")
-
     call get_param(param_file, mdl, "GME_H0", CS%GME_h0, &
                  "The strength of GME tapers quadratically to zero when the bathymetric "//&
                  "depth is shallower than GME_H0.", units="m", scale=US%m_to_Z, &
                  default=1000.0)
-
     call get_param(param_file, mdl, "GME_EFFICIENCY", CS%GME_efficiency, &
                  "The nondimensional prefactor multiplying the GME coefficient.", &
                  units="nondim", default=1.0)
-
     call get_param(param_file, mdl, "GME_LIMITER", CS%GME_limiter, &
                  "The absolute maximum value the GME coefficient is allowed to take.", &
                  units="m2 s-1", scale=US%m_to_L**2*US%T_to_s, default=1.0e7)
-
   endif
-
   if (CS%bound_Kh .or. CS%bound_Ah .or. CS%better_bound_Kh .or. CS%better_bound_Ah) &
     call get_param(param_file, mdl, "DT", dt, &
                  "The (baroclinic) dynamics time step.", units="s", scale=US%s_to_T, &
                  fail_if_missing=.true.)
-
   if (CS%no_slip .and. CS%biharmonic) &
     call MOM_error(FATAL,"ERROR: NOSLIP and BIHARMONIC cannot be defined "// &
                          "at the same time in MOM.")
-
   if (.not.(CS%Laplacian .or. CS%biharmonic)) then
     ! Only issue inviscid warning if not in single column mode (usually 2x2 domain)
     if ( max(G%domain%niglobal, G%domain%njglobal)>2 ) call MOM_error(WARNING, &
@@ -1710,9 +1732,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
       "LAPLACIAN or BIHARMONIC viscosity.")
     return ! We are not using either Laplacian or Bi-harmonic lateral viscosity
   endif
-
   deg2rad = atan(1.0) / 45.
-
   ALLOC_(CS%dx2h(isd:ied,jsd:jed))        ; CS%dx2h(:,:)    = 0.0
   ALLOC_(CS%dy2h(isd:ied,jsd:jed))        ; CS%dy2h(:,:)    = 0.0
   ALLOC_(CS%dx2q(IsdB:IedB,JsdB:JedB))    ; CS%dx2q(:,:)    = 0.0
@@ -1721,8 +1741,8 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
   ALLOC_(CS%dy_dxT(isd:ied,jsd:jed))      ; CS%dy_dxT(:,:)  = 0.0
   ALLOC_(CS%dx_dyBu(IsdB:IedB,JsdB:JedB)) ; CS%dx_dyBu(:,:) = 0.0
   ALLOC_(CS%dy_dxBu(IsdB:IedB,JsdB:JedB)) ; CS%dy_dxBu(:,:) = 0.0
-
   if (CS%Laplacian) then
+    ALLOC_(CS%grid_sp_h2(isd:ied,jsd:jed))   ; CS%grid_sp_h2(:,:) = 0.0
     ALLOC_(CS%Kh_bg_xx(isd:ied,jsd:jed))     ; CS%Kh_bg_xx(:,:) = 0.0
     ALLOC_(CS%Kh_bg_xy(IsdB:IedB,JsdB:JedB)) ; CS%Kh_bg_xy(:,:) = 0.0
     if (CS%bound_Kh .or. CS%better_bound_Kh) then
@@ -1740,7 +1760,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
   endif
   ALLOC_(CS%reduction_xx(isd:ied,jsd:jed))     ; CS%reduction_xx(:,:) = 0.0
   ALLOC_(CS%reduction_xy(IsdB:IedB,JsdB:JedB)) ; CS%reduction_xy(:,:) = 0.0
-
   if (CS%anisotropic) then
     ALLOC_(CS%n1n2_h(isd:ied,jsd:jed)) ; CS%n1n2_h(:,:) = 0.0
     ALLOC_(CS%n1n1_m_n2n2_h(isd:ied,jsd:jed)) ; CS%n1n1_m_n2n2_h(:,:) = 0.0
@@ -1758,7 +1777,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
              "Runtime parameter ANISOTROPIC_MODE is out of range.")
     end select
   endif
-
   if (CS%use_Kh_bg_2d) then
     ALLOC_(CS%Kh_bg_2d(isd:ied,jsd:jed))     ; CS%Kh_bg_2d(:,:) = 0.0
     call get_param(param_file, mdl, "KH_BG_2D_FILENAME", filename, &
@@ -1770,15 +1788,14 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                        G%domain, timelevel=1, scale=US%m_to_L**2*US%T_to_s)
     call pass_var(CS%Kh_bg_2d, G%domain)
   endif
-
   if (CS%biharmonic) then
     ALLOC_(CS%Idx2dyCu(IsdB:IedB,jsd:jed)) ; CS%Idx2dyCu(:,:) = 0.0
     ALLOC_(CS%Idx2dyCv(isd:ied,JsdB:JedB)) ; CS%Idx2dyCv(:,:) = 0.0
     ALLOC_(CS%Idxdy2u(IsdB:IedB,jsd:jed))  ; CS%Idxdy2u(:,:)  = 0.0
     ALLOC_(CS%Idxdy2v(isd:ied,JsdB:JedB))  ; CS%Idxdy2v(:,:)  = 0.0
-
     ALLOC_(CS%Ah_bg_xx(isd:ied,jsd:jed))     ; CS%Ah_bg_xx(:,:) = 0.0
     ALLOC_(CS%Ah_bg_xy(IsdB:IedB,JsdB:JedB)) ; CS%Ah_bg_xy(:,:) = 0.0
+    ALLOC_(CS%grid_sp_h3(isd:ied,jsd:jed))   ; CS%grid_sp_h3(:,:) = 0.0
     if (CS%bound_Ah .or. CS%better_bound_Ah) then
       ALLOC_(CS%Ah_Max_xx(isd:ied,jsd:jed))     ; CS%Ah_Max_xx(:,:) = 0.0
       ALLOC_(CS%Ah_Max_xy(IsdB:IedB,JsdB:JedB)) ; CS%Ah_Max_xy(:,:) = 0.0
@@ -1792,11 +1809,14 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
       endif
     endif
     if (CS%Leith_Ah) then
-        ALLOC_(CS%biharm5_const_xx(isd:ied,jsd:jed)) ; CS%biharm5_const_xx(:,:) = 0.0
-        ALLOC_(CS%biharm5_const_xy(IsdB:IedB,JsdB:JedB)) ; CS%biharm5_const_xy(:,:) = 0.0
+        ALLOC_(CS%biharm6_const_xx(isd:ied,jsd:jed)) ; CS%biharm6_const_xx(:,:) = 0.0
+        ALLOC_(CS%biharm6_const_xy(IsdB:IedB,JsdB:JedB)) ; CS%biharm6_const_xy(:,:) = 0.0
+    endif
+    if (CS%Re_Ah > 0.0) then
+      ALLOC_(CS%Re_Ah_const_xx(isd:ied,jsd:jed)); CS%Re_Ah_const_xx(:,:) = 0.0
+      ALLOC_(CS%Re_Ah_const_xy(IsdB:IedB,JsdB:JedB)); CS%Re_Ah_const_xy(:,:) = 0.0
     endif
   endif
-
   do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
     CS%dx2q(I,J) = G%dxBu(I,J)*G%dxBu(I,J) ; CS%dy2q(I,J) = G%dyBu(I,J)*G%dyBu(I,J)
     CS%DX_dyBu(I,J) = G%dxBu(I,J)*G%IdyBu(I,J) ; CS%DY_dxBu(I,J) = G%dyBu(I,J)*G%IdxBu(I,J)
@@ -1805,7 +1825,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
     CS%dx2h(i,j) = G%dxT(i,j)*G%dxT(i,j) ; CS%dy2h(i,j) = G%dyT(i,j)*G%dyT(i,j)
     CS%DX_dyT(i,j) = G%dxT(i,j)*G%IdyT(i,j) ; CS%DY_dxT(i,j) = G%dyT(i,j)*G%IdxT(i,j)
   enddo ; enddo
-
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     CS%reduction_xx(i,j) = 1.0
     if ((G%dy_Cu(I,j) > 0.0) .and. (G%dy_Cu(I,j) < G%dyCu(I,j)) .and. &
@@ -1821,7 +1840,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
         (G%dx_Cv(i,J-1) < G%dxCv(i,J-1) * CS%reduction_xx(i,j))) &
       CS%reduction_xx(i,j) = G%dx_Cv(i,J-1) / (G%dxCv(i,J-1))
   enddo ; enddo
-
   do J=js-1,Jeq ; do I=is-1,Ieq
     CS%reduction_xy(I,J) = 1.0
     if ((G%dy_Cu(I,j) > 0.0) .and. (G%dy_Cu(I,j) < G%dyCu(I,j)) .and. &
@@ -1837,38 +1855,33 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
         (G%dx_Cv(i+1,J) < G%dxCv(i+1,J) * CS%reduction_xy(I,J))) &
       CS%reduction_xy(I,J) = G%dx_Cv(i+1,J) / (G%dxCv(i+1,J))
   enddo ; enddo
-
   if (CS%Laplacian) then
    ! The 0.3 below was 0.4 in MOM1.10.  The change in hq requires
    ! this to be less than 1/3, rather than 1/2 as before.
     if (CS%bound_Kh .or. CS%bound_Ah) Kh_Limit = 0.3 / (dt*4.0)
-
     ! Calculate and store the background viscosity at h-points
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       ! Static factors in the Smagorinsky and Leith schemes
       grid_sp_h2 = (2.0*CS%dx2h(i,j)*CS%dy2h(i,j)) / (CS%dx2h(i,j) + CS%dy2h(i,j))
+      CS%grid_sp_h2(i,j) = grid_sp_h2
       grid_sp_h3 = grid_sp_h2*sqrt(grid_sp_h2)
       if (CS%Smagorinsky_Kh) CS%Laplac2_const_xx(i,j) = Smag_Lap_const * grid_sp_h2
       if (CS%Leith_Kh)       CS%Laplac3_const_xx(i,j) = Leith_Lap_const * grid_sp_h3
       ! Maximum of constant background and MICOM viscosity
       CS%Kh_bg_xx(i,j) = MAX(Kh, Kh_vel_scale * sqrt(grid_sp_h2))
-
       ! Use the larger of the above and values read from a file
       if (CS%use_Kh_bg_2d) CS%Kh_bg_xx(i,j) = MAX(CS%Kh_bg_2d(i,j), CS%Kh_bg_xx(i,j))
-
       ! Use the larger of the above and a function of sin(latitude)
       if (Kh_sin_lat>0.) then
         slat_fn = abs( sin( deg2rad * G%geoLatT(i,j) ) ) ** Kh_pwr_of_sine
         CS%Kh_bg_xx(i,j) = MAX(Kh_sin_lat * slat_fn, CS%Kh_bg_xx(i,j))
       endif
-
       if (CS%bound_Kh .and. .not.CS%better_bound_Kh) then
         ! Limit the background viscosity to be numerically stable
         CS%Kh_Max_xx(i,j) = Kh_Limit * grid_sp_h2
         CS%Kh_bg_xx(i,j) = MIN(CS%Kh_bg_xx(i,j), CS%Kh_Max_xx(i,j))
       endif
     enddo ; enddo
-
     ! Calculate and store the background viscosity at q-points
     do J=js-1,Jeq ; do I=is-1,Ieq
       ! Static factors in the Smagorinsky and Leith schemes
@@ -1878,7 +1891,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
       if (CS%Leith_Kh)       CS%Laplac3_const_xy(I,J) = Leith_Lap_const * grid_sp_q3
       ! Maximum of constant background and MICOM viscosity
       CS%Kh_bg_xy(I,J) = MAX(Kh, Kh_vel_scale * sqrt(grid_sp_q2))
-
       ! Use the larger of the above and values read from a file
       if (CS%use_Kh_bg_2d) then
         CS%Kh_bg_xy(I,J) = MAX(CS%Kh_bg_xy(I,J), &
@@ -1891,7 +1903,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
         slat_fn = abs( sin( deg2rad * G%geoLatBu(I,J) ) ) ** Kh_pwr_of_sine
         CS%Kh_bg_xy(I,J) = MAX(Kh_sin_lat * slat_fn, CS%Kh_bg_xy(I,J))
       endif
-
       if (CS%bound_Kh .and. .not.CS%better_bound_Kh) then
         ! Limit the background viscosity to be numerically stable
         CS%Kh_Max_xy(I,J) = Kh_Limit * grid_sp_q2
@@ -1899,9 +1910,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
       endif
     enddo ; enddo
   endif
-
   if (CS%biharmonic) then
-
     do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
       CS%Idx2dyCu(I,j) = (G%IdxCu(I,j)*G%IdxCu(I,j)) * G%IdyCu(I,j)
       CS%Idxdy2u(I,j) = G%IdxCu(I,j) * (G%IdyCu(I,j)*G%IdyCu(I,j))
@@ -1910,7 +1919,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
       CS%Idx2dyCv(i,J) = (G%IdxCv(i,J)*G%IdxCv(i,J)) * G%IdyCv(i,J)
       CS%Idxdy2v(i,J) = G%IdxCv(i,J) * (G%IdyCv(i,J)*G%IdyCv(i,J))
     enddo ; enddo
-
     CS%Ah_bg_xy(:,:) = 0.0
    ! The 0.3 below was 0.4 in MOM1.10.  The change in hq requires
    ! this to be less than 1/3, rather than 1/2 as before.
@@ -1920,7 +1928,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       grid_sp_h2 = (2.0*CS%dx2h(i,j)*CS%dy2h(i,j)) / (CS%dx2h(i,j)+CS%dy2h(i,j))
       grid_sp_h3 = grid_sp_h2*sqrt(grid_sp_h2)
-
+      CS%grid_sp_h3(i,j) = grid_sp_h3
       if (CS%Smagorinsky_Ah) then
         CS%Biharm_const_xx(i,j) = Smag_bi_const * (grid_sp_h2 * grid_sp_h2)
         if (CS%bound_Coriolis) then
@@ -1931,9 +1939,10 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
         endif
       endif
       if (CS%Leith_Ah) then
-         CS%biharm5_const_xx(i,j) = Leith_bi_const * (grid_sp_h3 * grid_sp_h2)
+         CS%biharm6_const_xx(i,j) = Leith_bi_const * (grid_sp_h3 * grid_sp_h3)
       endif
       CS%Ah_bg_xx(i,j) = MAX(Ah, Ah_vel_scale * grid_sp_h2 * sqrt(grid_sp_h2))
+      if (CS%Re_Ah > 0.0) CS%Re_Ah_const_xx(i,j) = grid_sp_h3 / CS%Re_Ah
       if (Ah_time_scale > 0.) CS%Ah_bg_xx(i,j) = &
             MAX(CS%Ah_bg_xx(i,j), (grid_sp_h2 * grid_sp_h2) / Ah_time_scale)
       if (CS%bound_Ah .and. .not.CS%better_bound_Ah) then
@@ -1944,7 +1953,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
     do J=js-1,Jeq ; do I=is-1,Ieq
       grid_sp_q2 = (2.0*CS%dx2q(I,J)*CS%dy2q(I,J)) / (CS%dx2q(I,J)+CS%dy2q(I,J))
       grid_sp_q3 = grid_sp_q2*sqrt(grid_sp_q2)
-
       if (CS%Smagorinsky_Ah) then
         CS%Biharm_const_xy(I,J) = Smag_bi_const * (grid_sp_q2 * grid_sp_q2)
         if (CS%bound_Coriolis) then
@@ -1953,10 +1961,10 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
         endif
       endif
       if (CS%Leith_Ah) then
-         CS%biharm5_const_xy(i,j) = Leith_bi_const * (grid_sp_q3 * grid_sp_q2)
+         CS%biharm6_const_xy(I,J) = Leith_bi_const * (grid_sp_q3 * grid_sp_q3)
       endif
-
       CS%Ah_bg_xy(I,J) = MAX(Ah, Ah_vel_scale * grid_sp_q2 * sqrt(grid_sp_q2))
+      if (CS%Re_Ah > 0.0) CS%Re_Ah_const_xy(i,j) = grid_sp_q3 / CS%Re_Ah
       if (Ah_time_scale > 0.) CS%Ah_bg_xy(i,j) = &
            MAX(CS%Ah_bg_xy(i,j), (grid_sp_q2 * grid_sp_q2) / Ah_time_scale)
       if (CS%bound_Ah .and. .not.CS%better_bound_Ah) then
@@ -1965,7 +1973,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
       endif
     enddo ; enddo
   endif
-
   ! The Laplacian bounds should avoid overshoots when CS%bound_coef < 1.
   if (CS%Laplacian .and. CS%better_bound_Kh) then
     Idt = 1.0 / dt
@@ -1994,7 +2001,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
       call Bchksum(CS%Kh_Max_xy, "Kh_Max_xy", G%HI, haloshift=0, scale=US%L_to_m**2*US%s_to_T)
     endif
   endif
-
   ! The biharmonic bounds should avoid overshoots when CS%bound_coef < 0.5, but
   ! empirically work for CS%bound_coef <~ 1.0
   if (CS%biharmonic .and. CS%better_bound_Ah) then
@@ -2004,7 +2010,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                                    CS%dy2h(i,j) * CS%DY_dxT(i,j) * (G%IdyCu(I,j) + G%IdyCu(I-1,j)) ) + &
                  CS%Idx2dyCu(I,j)*(CS%dx2q(I,J) * CS%DX_dyBu(I,J) * (G%IdxCu(I,j+1) + G%IdxCu(I,j)) + &
                                    CS%dx2q(I,J-1)*CS%DX_dyBu(I,J-1)*(G%IdxCu(I,j) + G%IdxCu(I,j-1)) ) )
-
       u0v(I,j) = (CS%Idxdy2u(I,j)*(CS%dy2h(i+1,j)*CS%DX_dyT(i+1,j)*(G%IdxCv(i+1,J) + G%IdxCv(i+1,J-1)) + &
                                    CS%dy2h(i,j) * CS%DX_dyT(i,j) * (G%IdxCv(i,J) + G%IdxCv(i,J-1)) )   + &
                  CS%Idx2dyCu(I,j)*(CS%dx2q(I,J) * CS%DY_dxBu(I,J) * (G%IdyCv(i+1,J) + G%IdyCv(i,J))   + &
@@ -2015,13 +2020,11 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
                                    CS%dy2q(I-1,J)*CS%DX_dyBu(I-1,J)*(G%IdxCu(I-1,j+1) + G%IdxCu(I-1,j)) ) + &
                  CS%Idx2dyCv(i,J)*(CS%dx2h(i,j+1)*CS%DY_dxT(i,j+1)*(G%IdyCu(I,j+1) + G%IdyCu(I-1,j+1))   + &
                                    CS%dx2h(i,j) * CS%DY_dxT(i,j) * (G%IdyCu(I,j) + G%IdyCu(I-1,j)) ) )
-
       v0v(i,J) = (CS%Idxdy2v(i,J)*(CS%dy2q(I,J) * CS%DY_dxBu(I,J) * (G%IdyCv(i+1,J) + G%IdyCv(i,J))   + &
                                    CS%dy2q(I-1,J)*CS%DY_dxBu(I-1,J)*(G%IdyCv(i,J) + G%IdyCv(i-1,J)) ) + &
                  CS%Idx2dyCv(i,J)*(CS%dx2h(i,j+1)*CS%DX_dyT(i,j+1)*(G%IdxCv(i,J+1) + G%IdxCv(i,J))   + &
                                    CS%dx2h(i,j) * CS%DX_dyT(i,j) * (G%IdxCv(i,J) + G%IdxCv(i,J-1)) ) )
     enddo ; enddo
-
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       denom = max( &
          (CS%dy2h(i,j) * &
@@ -2036,7 +2039,6 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
       if (denom > 0.0) &
         CS%Ah_Max_xx(I,J) = CS%bound_coef * 0.5 * Idt / denom
     enddo ; enddo
-
     do J=js-1,Jeq ; do I=is-1,Ieq
       denom = max( &
          (CS%dx2q(I,J) * &
@@ -2056,12 +2058,9 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
       call Bchksum(CS%Ah_Max_xy, "Ah_Max_xy", G%HI, haloshift=0, scale=US%L_to_m**4*US%s_to_T)
     endif
   endif
-
   ! Register fields for output from this module.
-
   CS%id_diffu = register_diag_field('ocean_model', 'diffu', diag%axesCuL, Time, &
       'Zonal Acceleration from Horizontal Viscosity', 'm s-2', conversion=US%L_T2_to_m_s2)
-
   CS%id_diffv = register_diag_field('ocean_model', 'diffv', diag%axesCvL, Time, &
       'Meridional Acceleration from Horizontal Viscosity', 'm s-2', conversion=US%L_T2_to_m_s2)
 
@@ -2101,59 +2100,51 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS, MEKE, ADp)
         cmor_field_name='difmxybo',                                             &
         cmor_long_name='Ocean lateral biharmonic viscosity',                     &
         cmor_standard_name='ocean_momentum_xy_biharmonic_diffusivity')
-
     CS%id_Ah_q = register_diag_field('ocean_model', 'Ahq', diag%axesBL, Time, &
         'Biharmonic Horizontal Viscosity at q Points', 'm4 s-1', conversion=US%L_to_m**4*US%s_to_T)
+    CS%id_grid_Re_Ah = register_diag_field('ocean_model', 'grid_Re_Ah', diag%axesTL, Time, &
+        'Grid Reynolds number for the Biharmonic horizontal viscosity at h points', 'nondim')
   endif
-
   if (CS%Laplacian) then
     CS%id_Kh_h = register_diag_field('ocean_model', 'Khh', diag%axesTL, Time,   &
         'Laplacian Horizontal Viscosity at h Points', 'm2 s-1', conversion=US%L_to_m**2*US%s_to_T, &
         cmor_field_name='difmxylo',                                             &
         cmor_long_name='Ocean lateral Laplacian viscosity',                     &
         cmor_standard_name='ocean_momentum_xy_laplacian_diffusivity')
-
     CS%id_Kh_q = register_diag_field('ocean_model', 'Khq', diag%axesBL, Time, &
         'Laplacian Horizontal Viscosity at q Points', 'm2 s-1', conversion=US%L_to_m**2*US%s_to_T)
-
-    if (CS%Leith_Kh) then
-      CS%id_vort_xy_q = register_diag_field('ocean_model', 'vort_xy_q', diag%axesBL, Time, &
-        'Vertical vorticity at q Points', 's-1', conversion=US%s_to_T)
-
-      CS%id_div_xx_h = register_diag_field('ocean_model', 'div_xx_h', diag%axesTL, Time, &
-        'Horizontal divergence at h Points', 's-1', conversion=US%s_to_T)
-    endif
-
+    CS%id_grid_Re_Kh = register_diag_field('ocean_model', 'grid_Re_Kh', diag%axesTL, Time, &
+        'Grid Reynolds number for the Laplacian horizontal viscosity at h points', 'nondim')
+    CS%id_vort_xy_q = register_diag_field('ocean_model', 'vort_xy_q', diag%axesBL, Time, &
+      'Vertical vorticity at q Points', 's-1', conversion=US%s_to_T)
+    CS%id_div_xx_h = register_diag_field('ocean_model', 'div_xx_h', diag%axesTL, Time, &
+      'Horizontal divergence at h Points', 's-1', conversion=US%s_to_T)
+    CS%id_sh_xy_q = register_diag_field('ocean_model', 'sh_xy_q', diag%axesBL, Time, &
+      'Shearing strain at q Points', 's-1', conversion=US%s_to_T)
+    CS%id_sh_xx_h = register_diag_field('ocean_model', 'sh_xx_h', diag%axesTL, Time, &
+      'Horizontal tension at h Points', 's-1', conversion=US%s_to_T)
   endif
-
   if (CS%use_GME) then
       CS%id_GME_coeff_h = register_diag_field('ocean_model', 'GME_coeff_h', diag%axesTL, Time, &
         'GME coefficient at h Points', 'm2 s-1', conversion=US%L_to_m**2*US%s_to_T)
-
       CS%id_GME_coeff_q = register_diag_field('ocean_model', 'GME_coeff_q', diag%axesBL, Time, &
         'GME coefficient at q Points', 'm2 s-1', conversion=US%L_to_m**2*US%s_to_T)
-
       CS%id_FrictWork_GME = register_diag_field('ocean_model','FrictWork_GME',diag%axesTL,Time,&
       'Integral work done by lateral friction terms in GME (excluding diffusion of energy)', &
       'W m-2', conversion=US%RZ3_T3_to_W_m2*US%L_to_Z**2)
   endif
-
   CS%id_FrictWork = register_diag_field('ocean_model','FrictWork',diag%axesTL,Time,&
       'Integral work done by lateral friction terms', &
       'W m-2', conversion=US%RZ3_T3_to_W_m2*US%L_to_Z**2)
-
   CS%id_FrictWorkIntz = register_diag_field('ocean_model','FrictWorkIntz',diag%axesT1,Time,      &
       'Depth integrated work done by lateral friction', &
       'W m-2', conversion=US%RZ3_T3_to_W_m2*US%L_to_Z**2, &
       cmor_field_name='dispkexyfo',                                                              &
       cmor_long_name='Depth integrated ocean kinetic energy dissipation due to lateral friction',&
       cmor_standard_name='ocean_kinetic_energy_dissipation_per_unit_area_due_to_xy_friction')
-
   if (CS%Laplacian .or. get_all) then
   endif
-
 end subroutine hor_visc_init
-
 !> Calculates factors in the anisotropic orientation tensor to be align with the grid.
 !! With n1=1 and n2=0, this recovers the approach of Large et al, 2001.
 subroutine align_aniso_tensor_to_grid(CS, n1, n2)
@@ -2162,18 +2153,14 @@ subroutine align_aniso_tensor_to_grid(CS, n1, n2)
   real,              intent(in) :: n2 !< j-component of direction vector [nondim]
   ! Local variables
   real :: recip_n2_norm
-
   ! For normalizing n=(n1,n2) in case arguments are not a unit vector
   recip_n2_norm = n1**2 + n2**2
   if (recip_n2_norm > 0.) recip_n2_norm = 1./recip_n2_norm
-
   CS%n1n2_h(:,:) = 2. * ( n1 * n2 ) * recip_n2_norm
   CS%n1n2_q(:,:) = 2. * ( n1 * n2 ) * recip_n2_norm
   CS%n1n1_m_n2n2_h(:,:) = ( n1 * n1 - n2 * n2 ) * recip_n2_norm
   CS%n1n1_m_n2n2_q(:,:) = ( n1 * n1 - n2 * n2 ) * recip_n2_norm
-
 end subroutine align_aniso_tensor_to_grid
-
 !> Apply a 1-1-4-1-1 Laplacian filter one time on GME diffusive flux to reduce any
 !! horizontal two-grid-point noise
 subroutine smooth_GME(CS,G,GME_flux_h,GME_flux_q)
@@ -2184,15 +2171,12 @@ subroutine smooth_GME(CS,G,GME_flux_h,GME_flux_q)
                                                               !! at h points
   real, dimension(SZIB_(G),SZJB_(G)), optional, intent(inout) :: GME_flux_q!< GME diffusive flux
                                                               !! at q points
-
   ! local variables
   real, dimension(SZI_(G),SZJ_(G)) :: GME_flux_h_original
   real, dimension(SZIB_(G),SZJB_(G)) :: GME_flux_q_original
   real :: wc, ww, we, wn, ws ! averaging weights for smoothing
   integer :: i, j, k, s
-
   do s=1,1
-
     ! Update halos
     if (present(GME_flux_h)) then
       call pass_var(GME_flux_h, G%Domain)
@@ -2202,14 +2186,12 @@ subroutine smooth_GME(CS,G,GME_flux_h,GME_flux_q)
         do i = G%isc, G%iec
           ! skip land points
           if (G%mask2dT(i,j)==0.) cycle
-
           ! compute weights
           ww = 0.125 * G%mask2dT(i-1,j)
           we = 0.125 * G%mask2dT(i+1,j)
           ws = 0.125 * G%mask2dT(i,j-1)
           wn = 0.125 * G%mask2dT(i,j+1)
           wc = 1.0 - (ww+we+wn+ws)
-
           GME_flux_h(i,j) =  wc * GME_flux_h_original(i,j)   &
                            + ww * GME_flux_h_original(i-1,j) &
                            + we * GME_flux_h_original(i+1,j) &
@@ -2217,7 +2199,6 @@ subroutine smooth_GME(CS,G,GME_flux_h,GME_flux_q)
                            + wn * GME_flux_h_original(i,j+1)
       enddo; enddo
     endif
-
     ! Update halos
     if (present(GME_flux_q)) then
       call pass_var(GME_flux_q, G%Domain, position=CORNER, complete=.true.)
@@ -2227,14 +2208,12 @@ subroutine smooth_GME(CS,G,GME_flux_h,GME_flux_q)
         do I = G%IscB, G%IecB
           ! skip land points
           if (G%mask2dBu(I,J)==0.) cycle
-
           ! compute weights
           ww = 0.125 * G%mask2dBu(I-1,J)
           we = 0.125 * G%mask2dBu(I+1,J)
           ws = 0.125 * G%mask2dBu(I,J-1)
           wn = 0.125 * G%mask2dBu(I,J+1)
           wc = 1.0 - (ww+we+wn+ws)
-
           GME_flux_q(I,J) =  wc * GME_flux_q_original(I,J)   &
                            + ww * GME_flux_q_original(I-1,J) &
                            + we * GME_flux_q_original(I+1,J) &
@@ -2242,24 +2221,20 @@ subroutine smooth_GME(CS,G,GME_flux_h,GME_flux_q)
                            + wn * GME_flux_q_original(I,J+1)
       enddo; enddo
     endif
-
   enddo ! s-loop
-
 end subroutine smooth_GME
-
 !> Deallocates any variables allocated in hor_visc_init.
 subroutine hor_visc_end(CS)
   type(hor_visc_CS), pointer :: CS !< The control structure returned by a
                                    !! previous call to hor_visc_init.
-
   if (CS%Laplacian .or. CS%biharmonic) then
     DEALLOC_(CS%dx2h) ; DEALLOC_(CS%dx2q) ; DEALLOC_(CS%dy2h) ; DEALLOC_(CS%dy2q)
     DEALLOC_(CS%dx_dyT) ; DEALLOC_(CS%dy_dxT) ; DEALLOC_(CS%dx_dyBu) ; DEALLOC_(CS%dy_dxBu)
     DEALLOC_(CS%reduction_xx) ; DEALLOC_(CS%reduction_xy)
   endif
-
   if (CS%Laplacian) then
     DEALLOC_(CS%Kh_bg_xx) ; DEALLOC_(CS%Kh_bg_xy)
+    DEALLOC_(CS%grid_sp_h2)
     if (CS%bound_Kh) then
       DEALLOC_(CS%Kh_Max_xx) ; DEALLOC_(CS%Kh_Max_xy)
     endif
@@ -2270,8 +2245,8 @@ subroutine hor_visc_end(CS)
       DEALLOC_(CS%Laplac3_const_xx) ; DEALLOC_(CS%Laplac3_const_xy)
     endif
   endif
-
   if (CS%biharmonic) then
+    DEALLOC_(CS%grid_sp_h3)
     DEALLOC_(CS%Idx2dyCu) ; DEALLOC_(CS%Idx2dyCv)
     DEALLOC_(CS%Idxdy2u) ; DEALLOC_(CS%Idxdy2v)
     DEALLOC_(CS%Ah_bg_xx) ; DEALLOC_(CS%Ah_bg_xy)
@@ -2279,13 +2254,13 @@ subroutine hor_visc_end(CS)
       DEALLOC_(CS%Ah_Max_xx) ; DEALLOC_(CS%Ah_Max_xy)
     endif
     if (CS%Smagorinsky_Ah) then
-      DEALLOC_(CS%Biharm5_const_xx) ; DEALLOC_(CS%Biharm5_const_xy)
-      ! if (CS%bound_Coriolis) then
-      !   DEALLOC_(CS%Biharm5_const2_xx) ; DEALLOC_(CS%Biharm5_const2_xy)
-      ! endif
+      DEALLOC_(CS%Biharm6_const_xx) ; DEALLOC_(CS%Biharm6_const_xy)
     endif
     if (CS%Leith_Ah) then
       DEALLOC_(CS%Biharm_const_xx) ; DEALLOC_(CS%Biharm_const_xy)
+    endif
+    if (CS%Re_Ah > 0.0) then
+      DEALLOC_(CS%Re_Ah_const_xx) ; DEALLOC_(CS%Re_Ah_const_xy)
     endif
   endif
   if (CS%anisotropic) then
@@ -2295,10 +2270,7 @@ subroutine hor_visc_end(CS)
     DEALLOC_(CS%n1n1_m_n2n2_q)
   endif
   deallocate(CS)
-
 end subroutine hor_visc_end
-
-
 !> \namespace mom_hor_visc
 !!
 !! This module contains the subroutine horizontal_viscosity() that calculates the
@@ -2599,5 +2571,4 @@ end subroutine hor_visc_end
 !! Smith, R.D., and McWilliams, J.C., 2003: Anisotropic horizontal viscosity for
 !! ocean models. Ocean Modelling, 5(2), 129-156.
 !! https://doi.org/10.1016/S1463-5003(02)00016-1
-
 end module MOM_hor_visc

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -17,6 +17,8 @@ use MOM_variables,      only : thermo_var_ptrs
 use MOM_verticalGrid,   only : verticalGrid_type
 use MOM_wave_interface, only : wave_parameters_CS, Get_Langmuir_Number
 use MOM_domains,        only : pass_var
+use MOM_cpu_clock,      only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
+use MOM_cpu_clock,      only : CLOCK_MODULE, CLOCK_ROUTINE
 
 use CVMix_kpp, only : CVMix_init_kpp, CVMix_put_kpp, CVMix_get_kpp_real
 use CVMix_kpp, only : CVMix_coeffs_kpp
@@ -169,6 +171,10 @@ type, public :: KPP_CS ; private
 
 end type KPP_CS
 
+!>@{ CPU time clocks
+integer :: id_clock_KPP_calc, id_clock_KPP_compute_BLD, id_clock_KPP_smoothing
+!!@}
+
 #define __DO_SAFETY_CHECKS__
 
 contains
@@ -227,11 +233,17 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
                  'The number of times the 1-1-4-1-1 Laplacian filter is applied on '//  &
                  'OBL depth.',   &
                  default=0)
+  if (CS%n_smooth > G%domain%nihalo) then
+    call MOM_error(FATAL,'KPP smoothing number (N_SMOOTH) cannot be greater than NIHALO.')
+  elseif (CS%n_smooth > G%domain%njhalo) then
+    call MOM_error(FATAL,'KPP smoothing number (N_SMOOTH) cannot be greater than NJHALO.')
+  endif
   if (CS%n_smooth > 0) then
     call get_param(paramFile, mdl, 'DEEPEN_ONLY_VIA_SMOOTHING', CS%deepen_only,  &
                    'If true, apply OBLdepth smoothing at a cell only if the OBLdepth '// &
                    'gets deeper via smoothing.',   &
                    default=.false.)
+    id_clock_KPP_smoothing = cpu_clock_id('(Ocean KPP BLD smoothing)', grain=CLOCK_ROUTINE)
   endif
   call get_param(paramFile, mdl, 'RI_CRIT', CS%Ri_crit,                            &
                  'Critical bulk Richardson number used to define depth of the '// &
@@ -580,6 +592,8 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive, Waves)
   if (CS%id_EnhK > 0)    allocate( CS%EnhK( SZI_(G), SZJ_(G), SZK_(G)+1 ) )
   if (CS%id_EnhK > 0)    CS%EnhK(:,:,:) = 0.
 
+  id_clock_KPP_calc = cpu_clock_id('Ocean KPP calculate)', grain=CLOCK_MODULE)
+  id_clock_KPP_compute_BLD = cpu_clock_id('(Ocean KPP comp BLD)', grain=CLOCK_ROUTINE)
 
 end function KPP_init
 
@@ -639,6 +653,7 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
 
   if (CS%id_Kd_in > 0) call post_data(CS%id_Kd_in, Kt, CS%diag)
 
+  call cpu_clock_begin(id_clock_KPP_calc)
   buoy_scale = US%L_to_m**2*US%s_to_T**3
 
   !$OMP parallel do default(none) firstprivate(nonLocalTrans)                               &
@@ -859,6 +874,7 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
     enddo ! i
   enddo ! j
 
+  call cpu_clock_end(id_clock_KPP_calc)
 
   if (CS%debug) then
     call hchksum(Kt, "KPP out: Kt", G%HI, haloshift=0, scale=US%Z2_T_to_m2_s)
@@ -955,21 +971,23 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
     call hchksum(v, "KPP in: v",G%HI,haloshift=0)
   endif
 
+  call cpu_clock_begin(id_clock_KPP_compute_BLD)
+
   ! some constants
   GoRho = US%L_T_to_m_s**2*US%m_to_Z * GV%g_Earth / GV%Rho0
   buoy_scale = US%L_to_m**2*US%s_to_T**3
 
   ! loop over horizontal points on processor
-  !GOMP parallel do default(none) private(surfFricVel, iFaceHeight, hcorr, dh, cellHeight,  &
-  !GOMP                           surfBuoyFlux, U_H, V_H, u, v, Coriolis, pRef, SLdepth_0d, &
-  !GOMP                           ksfc, surfHtemp, surfHsalt, surfHu, surfHv, surfHuS,      &
-  !GOMP                           surfHvS, hTot, delH, surftemp, surfsalt, surfu, surfv,    &
-  !GOMP                           surfUs, surfVs, Uk, Vk, deltaU2, km1, kk, pres_1D,        &
-  !GOMP                           Temp_1D, salt_1D, surfBuoyFlux2, MLD_GUESS, LA, rho_1D,   &
-  !GOMP                           deltarho, N2_1d, ws_1d, LangEnhVT2, enhvt2, wst,          &
-  !GOMP                           BulkRi_1d, zBottomMinusOffset) &
-  !GOMP                           shared(G, GV, CS, US, uStar, h, buoy_scale, buoyFlux,     &
-  !GOMP                           Temp, Salt, waves, tv, GoRho)
+  !$OMP parallel do default(none) private(surfFricVel, iFaceHeight, hcorr, dh, cellHeight,  &
+  !$OMP                           surfBuoyFlux, U_H, V_H, Coriolis, pRef, SLdepth_0d,       &
+  !$OMP                           ksfc, surfHtemp, surfHsalt, surfHu, surfHv, surfHuS,      &
+  !$OMP                           surfHvS, hTot, delH, surftemp, surfsalt, surfu, surfv,    &
+  !$OMP                           surfUs, surfVs, Uk, Vk, deltaU2, km1, kk, pres_1D,        &
+  !$OMP                           Temp_1D, salt_1D, surfBuoyFlux2, MLD_GUESS, LA, rho_1D,   &
+  !$OMP                           deltarho, N2_1d, ws_1d, LangEnhVT2, enhvt2, wst,          &
+  !$OMP                           BulkRi_1d, zBottomMinusOffset) &
+  !$OMP                           shared(G, GV, CS, US, uStar, h, buoy_scale, buoyFlux,     &
+  !$OMP                           Temp, Salt, waves, tv, GoRho, u, v)
   do j = G%jsc, G%jec
     do i = G%isc, G%iec
 
@@ -1240,6 +1258,8 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
     enddo
   enddo
 
+  call cpu_clock_end(id_clock_KPP_compute_BLD)
+
   ! send diagnostics to post_data
   if (CS%id_BulkRi   > 0) call post_data(CS%id_BulkRi,   CS%BulkRi,          CS%diag)
   if (CS%id_N        > 0) call post_data(CS%id_N,        CS%N,               CS%diag)
@@ -1269,7 +1289,7 @@ subroutine KPP_smooth_BLD(CS,G,GV,h)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  intent(in) :: h    !< Layer/level thicknesses [H ~> m or kg m-2]
 
   ! local
-  real, dimension(SZI_(G),SZJ_(G)) :: OBLdepth_original ! Original OBL depths computed by CVMix
+  real, dimension(SZI_(G),SZJ_(G)) :: OBLdepth_prev     ! OBLdepth before s.th smoothing iteration
   real, dimension( G%ke )          :: cellHeight        ! Cell center heights referenced to surface [m]
                                                         ! (negative in the ocean)
   real, dimension( G%ke+1 )        :: iFaceHeight       ! Interface heights referenced to surface [m]
@@ -1279,15 +1299,20 @@ subroutine KPP_smooth_BLD(CS,G,GV,h)
   real :: hcorr              ! A cumulative correction arising from inflation of vanished layers [m]
   integer :: i, j, k, s
 
+  call cpu_clock_begin(id_clock_KPP_smoothing)
+
+  ! Update halos
+  call pass_var(CS%OBLdepth, G%Domain, halo=CS%n_smooth)
+
+  if (CS%id_OBLdepth_original > 0) CS%OBLdepth_original = CS%OBLdepth
+
   do s=1,CS%n_smooth
 
-    ! Update halos
-    call pass_var(CS%OBLdepth, G%Domain)
-
-    OBLdepth_original = CS%OBLdepth
-    if (CS%id_OBLdepth_original > 0) CS%OBLdepth_original = OBLdepth_original
+    OBLdepth_prev = CS%OBLdepth
 
     ! apply smoothing on OBL depth
+    !$OMP parallel do default(none) shared(G, GV, CS, h, OBLdepth_prev) &
+    !$OMP                           private(wc, ww, we, wn, ws, dh, hcorr, cellHeight, iFaceHeight)
     do j = G%jsc, G%jec
       do i = G%isc, G%iec
 
@@ -1314,14 +1339,14 @@ subroutine KPP_smooth_BLD(CS,G,GV,h)
         wn = 0.125 * G%mask2dT(i,j+1)
         wc = 1.0 - (ww+we+wn+ws)
 
-        CS%OBLdepth(i,j) =  wc * OBLdepth_original(i,j)   &
-                          + ww * OBLdepth_original(i-1,j) &
-                          + we * OBLdepth_original(i+1,j) &
-                          + ws * OBLdepth_original(i,j-1) &
-                          + wn * OBLdepth_original(i,j+1)
+        CS%OBLdepth(i,j) =  wc * OBLdepth_prev(i,j)   &
+                          + ww * OBLdepth_prev(i-1,j) &
+                          + we * OBLdepth_prev(i+1,j) &
+                          + ws * OBLdepth_prev(i,j-1) &
+                          + wn * OBLdepth_prev(i,j+1)
 
         ! Apply OBLdepth smoothing at a cell only if the OBLdepth gets deeper via smoothing.
-        if (CS%deepen_only) CS%OBLdepth(i,j) = max(CS%OBLdepth(i,j),CS%OBLdepth_original(i,j))
+        if (CS%deepen_only) CS%OBLdepth(i,j) = max(CS%OBLdepth(i,j), OBLdepth_prev(i,j))
 
         ! prevent OBL depths deeper than the bathymetric depth
         CS%OBLdepth(i,j) = min( CS%OBLdepth(i,j), -iFaceHeight(G%ke+1) ) ! no deeper than bottom
@@ -1331,30 +1356,7 @@ subroutine KPP_smooth_BLD(CS,G,GV,h)
 
   enddo ! s-loop
 
-  ! Update kOBL for smoothed OBL depths
-  do j = G%jsc, G%jec
-    do i = G%isc, G%iec
-
-      ! skip land points
-      if (G%mask2dT(i,j)==0.) cycle
-
-      iFaceHeight(1) = 0.0 ! BBL is all relative to the surface
-      hcorr = 0.
-      do k=1,G%ke
-
-        ! cell center and cell bottom in meters (negative values in the ocean)
-        dh = h(i,j,k) * GV%H_to_m ! Nominal thickness to use for increment
-        dh = dh + hcorr ! Take away the accumulated error (could temporarily make dh<0)
-        hcorr = min( dh - CS%min_thickness, 0. ) ! If inflating then hcorr<0
-        dh = max( dh, CS%min_thickness ) ! Limit increment dh>=min_thickness
-        cellHeight(k)    = iFaceHeight(k) - 0.5 * dh
-        iFaceHeight(k+1) = iFaceHeight(k) - dh
-      enddo
-
-      CS%kOBL(i,j) = CVMix_kpp_compute_kOBL_depth( iFaceHeight, cellHeight, CS%OBLdepth(i,j) )
-
-    enddo
-  enddo
+  call cpu_clock_end(id_clock_KPP_smoothing)
 
 end subroutine KPP_smooth_BLD
 
@@ -1375,6 +1377,7 @@ subroutine KPP_get_BLD(CS, BLD, G, US, m_to_BLD_units)
 
   scale = US%m_to_Z ; if (present(m_to_BLD_units)) scale = m_to_BLD_units
 
+  !$OMP parallel do default(none) shared(BLD, CS, G, scale)
   do j = G%jsc, G%jec ; do i = G%isc, G%iec
     BLD(i,j) = scale * CS%OBLdepth(i,j)
   enddo ; enddo
@@ -1413,6 +1416,7 @@ subroutine KPP_NonLocalTransport_temp(CS, G, GV, h, nonLocalTrans, surfFlux, &
 
   !  Update tracer due to non-local redistribution of surface flux
   if (CS%applyNonLocalTrans) then
+    !$OMP parallel do default(none) shared(dt, scalar, dtracer, G)
     do k = 1, G%ke
       do j = G%jsc, G%jec
         do i = G%isc, G%iec
@@ -1427,6 +1431,7 @@ subroutine KPP_NonLocalTransport_temp(CS, G, GV, h, nonLocalTrans, surfFlux, &
   if (CS%id_NLT_dTdt        > 0) call post_data(CS%id_NLT_dTdt, dtracer,  CS%diag)
   if (CS%id_NLT_temp_budget > 0) then
     dtracer(:,:,:) = 0.0
+    !$OMP parallel do default(none) shared(dtracer, nonLocalTrans, surfFlux, C_p, G, GV)
     do k = 1, G%ke
       do j = G%jsc, G%jec
         do i = G%isc, G%iec
@@ -1472,6 +1477,7 @@ subroutine KPP_NonLocalTransport_saln(CS, G, GV, h, nonLocalTrans, surfFlux, dt,
 
   !  Update tracer due to non-local redistribution of surface flux
   if (CS%applyNonLocalTrans) then
+    !$OMP parallel do default(none) shared(G, dt, scalar, dtracer)
     do k = 1, G%ke
       do j = G%jsc, G%jec
         do i = G%isc, G%iec
@@ -1486,6 +1492,7 @@ subroutine KPP_NonLocalTransport_saln(CS, G, GV, h, nonLocalTrans, surfFlux, dt,
   if (CS%id_NLT_dSdt        > 0) call post_data(CS%id_NLT_dSdt, dtracer,  CS%diag)
   if (CS%id_NLT_saln_budget > 0) then
     dtracer(:,:,:) = 0.0
+    !$OMP parallel do default(none) shared(G, GV, dtracer, nonLocalTrans, surfFlux)
     do k = 1, G%ke
       do j = G%jsc, G%jec
         do i = G%isc, G%iec

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -692,7 +692,7 @@ subroutine calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US, C
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                                     intent(inout) :: Kd_lay !< The diapycnal diffusvity in layers [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
-                          optional, intent(inout) :: Kd_int !< The diapycnal diffusvity at interfaces,
+                         optional,  intent(inout) :: Kd_int !< The diapycnal diffusvity at interfaces,
                                                             !! [Z2 T-1 ~> m2 s-1].
   real,                             intent(in)    :: Kd_max !< The maximum increment for diapycnal
                                                             !! diffusivity due to TKE-based processes,
@@ -703,7 +703,7 @@ subroutine calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US, C
 
   if (CS%Int_tide_dissipation .or. CS%Lee_wave_dissipation .or. CS%Lowmode_itidal_dissipation) then
     if (CS%use_CVMix_tidal) then
-      call calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
+      call calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv)
     else
       call add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, &
                                     G, GV, US, CS, N2_lay, Kd_lay, Kd_int, Kd_max)
@@ -714,7 +714,7 @@ end subroutine calculate_tidal_mixing
 
 !> Calls the CVMix routines to compute tidal dissipation and to add the effect of internal-tide-driven
 !! mixing to the interface diffusivities.
-subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
+subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv)
   integer,                 intent(in)    :: j     !< The j-index to work on
   type(ocean_grid_type),   intent(in)    :: G     !< Grid structure.
   type(verticalGrid_type), intent(in)    :: GV    !< ocean vertical grid structure
@@ -726,6 +726,9 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
                            intent(in)    :: h     !< Layer thicknesses [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(inout) :: Kd_lay!< The diapycnal diffusivities in the layers [Z2 T-1 ~> m2 s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
+                optional,  intent(inout) :: Kd_int !< The diapycnal diffusvity at interfaces,
+                                                            !! [Z2 T-1 ~> m2 s-1].
   real, dimension(:,:,:),  pointer       :: Kv    !< The "slow" vertical viscosity at each interface
                                                   !! (not layer!) [Z2 T-1 ~> m2 s-1].
   ! Local variables
@@ -785,8 +788,8 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
 
 
       ! XXX: Temporary de-scaling of N2_int(i,:) into a temporary variable
-      do k=1,G%ke+1
-        N2_int_i(k) = US%s_to_T**2 * N2_int(i,k)
+      do K=1,G%ke+1
+        N2_int_i(K) = US%s_to_T**2 * N2_int(i,K)
       enddo
 
       call CVMix_coeffs_tidal( Mdiff_out               = Kv_tidal,            &
@@ -804,11 +807,15 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
       do k=1,G%ke
         Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
       enddo
-
+      if (present(Kd_int)) then
+        do K=1,G%ke+1
+          Kd_int(i,j,K) = Kd_int(i,j,K) +  (US%m2_s_to_Z2_T * Kd_tidal(K))
+        enddo
+      endif
       ! Update viscosity with the proper unit conversion.
       if (associated(Kv)) then
-        do k=1,G%ke+1
-          Kv(i,j,k) = Kv(i,j,k) + US%m2_s_to_Z2_T * Kv_tidal(k)  ! Rescale from m2 s-1 to Z2 T-1.
+        do K=1,G%ke+1
+          Kv(i,j,K) = Kv(i,j,K) + US%m2_s_to_Z2_T * Kv_tidal(K)  ! Rescale from m2 s-1 to Z2 T-1.
         enddo
       endif
 
@@ -900,11 +907,16 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kv)
       do k=1,G%ke
         Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
       enddo
+      if (present(Kd_int)) then
+        do K=1,G%ke+1
+          Kd_int(i,j,K) = Kd_int(i,j,K) +  (US%m2_s_to_Z2_T * Kd_tidal(K))
+        enddo
+      endif
 
       ! Update viscosity
       if (associated(Kv)) then
-        do k=1,G%ke+1
-          Kv(i,j,k) = Kv(i,j,k) + US%m2_s_to_Z2_T * Kv_tidal(k)   ! Rescale from m2 s-1 to Z2 T-1.
+        do K=1,G%ke+1
+          Kv(i,j,K) = Kv(i,j,K) + US%m2_s_to_Z2_T * Kv_tidal(K)   ! Rescale from m2 s-1 to Z2 T-1.
         enddo
       endif
 

--- a/src/tracer/MOM_lateral_boundary_diffusion.F90
+++ b/src/tracer/MOM_lateral_boundary_diffusion.F90
@@ -23,8 +23,7 @@ use MOM_verticalGrid,          only : verticalGrid_type
 use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
 use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
 use MOM_diabatic_driver,       only : diabatic_CS, extract_diabatic_member
-
-use iso_fortran_env, only : stdout=>output_unit, stderr=>error_unit
+use iso_fortran_env,           only : stdout=>output_unit, stderr=>error_unit
 
 implicit none ; private
 
@@ -38,15 +37,18 @@ integer, public, parameter :: BOTTOM  = 1  !< Set a value that corresponds to th
 
 !> Sets parameters for lateral boundary mixing module.
 type, public :: lateral_boundary_diffusion_CS ; private
-  integer :: method                                               !< Determine which of the three methods calculate
-                                                                  !! and apply near boundary layer fluxes
-                                                                  !! 1. Bulk-layer approach
-                                                                  !! 2. Along layer
-  integer :: deg                                                  !< Degree of polynomial reconstruction
-  integer :: surface_boundary_scheme                              !< Which boundary layer scheme to use
-                                                                  !! 1. ePBL; 2. KPP
-  logical :: limiter                                              !< Controls wether a flux limiter is applied.
-                                                                  !! Only valid when method = 1.
+  integer :: method                          !< Determine which of the three methods calculate
+                                             !! and apply near boundary layer fluxes
+                                             !! 1. Along layer
+                                             !! 2. Bulk-layer approach (not recommended)
+  integer :: deg                             !< Degree of polynomial reconstruction
+  integer :: surface_boundary_scheme         !< Which boundary layer scheme to use
+                                             !! 1. ePBL; 2. KPP
+  logical :: limiter                         !< Controls wether a flux limiter is applied.
+                                             !! Only valid when method = 2.
+  logical :: linear                          !< If True, apply a linear transition at the base/top of the boundary.
+                                             !! The flux will be fully applied at k=k_min and zero at k=k_max.
+
   type(remapping_CS)              :: remap_CS                     !< Control structure to hold remapping configuration
   type(KPP_CS),           pointer :: KPP_CSp => NULL()            !< KPP control structure needed to get BLD
   type(energetic_PBL_CS), pointer :: energetic_PBL_CSp => NULL()  !< ePBL control structure needed to get BLD
@@ -104,13 +106,16 @@ logical function lateral_boundary_diffusion_init(Time, G, param_file, diag, diab
   ! Read all relevant parameters and write them to the model log.
   call get_param(param_file, mdl, "LATERAL_BOUNDARY_METHOD", CS%method, &
                  "Determine how to apply boundary lateral diffusion of tracers: \n"//&
-                 "1. Bulk layer approach  \n"//&
-                 "2. Along layer approach", default=1)
-  if (CS%method == 1) then
+                 "1. Along layer approach \n"//&
+                 "2. Bulk layer approach (this option is not recommended)", default=1)
+  if (CS%method == 2) then
     call get_param(param_file, mdl, "APPLY_LIMITER", CS%limiter, &
                    "If True, apply a flux limiter in the LBD. This is only available \n"//&
-                   "when LATERAL_BOUNDARY_METHOD=1.", default=.false.)
+                   "when LATERAL_BOUNDARY_METHOD=2.", default=.false.)
   endif
+  call get_param(param_file, mdl, "LBD_LINEAR_TRANSITION", CS%linear, &
+                 "If True, apply a linear transition at the base/top of the boundary. \n"//&
+                 "The flux will be fully applied at k=k_min and zero at k=k_max.", default=.false.)
   call get_param(param_file, mdl, "LBD_BOUNDARY_EXTRAP", boundary_extrap, &
                  "Use boundary extrapolation in LBD code", &
                  default=.false.)
@@ -180,21 +185,46 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
       call build_reconstructions_1d( CS%remap_CS, G%ke, h(i,j,:), tracer%t(i,j,:), ppoly0_coefs(i,j,:,:), &
                                      ppoly0_E(i,j,:,:), ppoly_S, remap_method, GV%H_subroundoff, GV%H_subroundoff)
     enddo ; enddo
+
     ! Diffusive fluxes in the i-direction
     uFlx(:,:,:) = 0.
     vFlx(:,:,:) = 0.
     uFlx_bulk(:,:) = 0.
     vFlx_bulk(:,:) = 0.
 
-    ! Method #1
-    if ( CS%method == 1 ) then
+    ! Method #1 (layer by layer)
+    if (CS%method == 1) then
+      do j=G%jsc,G%jec
+        do i=G%isc-1,G%iec
+          if (G%mask2dCu(I,j)>0.) then
+            call fluxes_layer_method(SURFACE, GV%ke, CS%deg, h(I,j,:), h(I+1,j,:), hbl(I,j), hbl(I+1,j),  &
+              G%areaT(I,j), G%areaT(I+1,j), tracer%t(I,j,:), tracer%t(I+1,j,:), ppoly0_coefs(I,j,:,:),    &
+              ppoly0_coefs(I+1,j,:,:), ppoly0_E(I,j,:,:), ppoly0_E(I+1,j,:,:), remap_method, Coef_x(I,j), &
+              uFlx(I,j,:), CS%linear)
+          endif
+        enddo
+      enddo
+      do J=G%jsc-1,G%jec
+        do i=G%isc,G%iec
+          if (G%mask2dCv(i,J)>0.) then
+            call fluxes_layer_method(SURFACE, GV%ke, CS%deg, h(i,J,:), h(i,J+1,:), hbl(i,J), hbl(i,J+1),  &
+              G%areaT(i,J), G%areaT(i,J+1), tracer%t(i,J,:), tracer%t(i,J+1,:), ppoly0_coefs(i,J,:,:),    &
+              ppoly0_coefs(i,J+1,:,:), ppoly0_E(i,J,:,:), ppoly0_E(i,J+1,:,:), remap_method, Coef_y(i,J), &
+              vFlx(i,J,:), CS%linear)
+          endif
+        enddo
+      enddo
+
+    ! Method #2 (bulk approach)
+    elseif (CS%method == 2) then
       do j=G%jsc,G%jec
         do i=G%isc-1,G%iec
           if (G%mask2dCu(I,j)>0.) then
             call fluxes_bulk_method(SURFACE, GV%ke, CS%deg, h(I,j,:), h(I+1,j,:), hbl(I,j), hbl(I+1,j), &
               G%areaT(I,j), G%areaT(I+1,j), tracer%t(I,j,:), tracer%t(I+1,j,:),                         &
               ppoly0_coefs(I,j,:,:), ppoly0_coefs(I+1,j,:,:), ppoly0_E(I,j,:,:),                        &
-              ppoly0_E(I+1,j,:,:), remap_method, Coef_x(I,j), uFlx_bulk(I,j), uFlx(I,j,:), CS%limiter)
+              ppoly0_E(I+1,j,:,:), remap_method, Coef_x(I,j), uFlx_bulk(I,j), uFlx(I,j,:), CS%limiter,  &
+              CS%linear)
           endif
         enddo
       enddo
@@ -204,34 +234,14 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
             call fluxes_bulk_method(SURFACE, GV%ke, CS%deg, h(i,J,:), h(i,J+1,:), hbl(i,J), hbl(i,J+1), &
               G%areaT(i,J), G%areaT(i,J+1), tracer%t(i,J,:), tracer%t(i,J+1,:),                         &
               ppoly0_coefs(i,J,:,:), ppoly0_coefs(i,J+1,:,:), ppoly0_E(i,J,:,:),                        &
-              ppoly0_E(i,J+1,:,:), remap_method, Coef_y(i,J), vFlx_bulk(i,J), vFlx(i,J,:), CS%limiter)
+              ppoly0_E(i,J+1,:,:), remap_method, Coef_y(i,J), vFlx_bulk(i,J), vFlx(i,J,:), CS%limiter,  &
+              CS%linear)
           endif
         enddo
       enddo
       ! Post tracer bulk diags
       if (tracer%id_lbd_bulk_dfx>0) call post_data(tracer%id_lbd_bulk_dfx, uFlx_bulk*Idt, CS%diag)
       if (tracer%id_lbd_bulk_dfy>0) call post_data(tracer%id_lbd_bulk_dfy, vFlx_bulk*Idt, CS%diag)
-
-    ! Method #2
-    elseif (CS%method == 2) then
-      do j=G%jsc,G%jec
-        do i=G%isc-1,G%iec
-          if (G%mask2dCu(I,j)>0.) then
-            call fluxes_layer_method(SURFACE, GV%ke, CS%deg, h(I,j,:), h(I+1,j,:), hbl(I,j), hbl(I+1,j), &
-              G%areaT(I,j), G%areaT(I+1,j), tracer%t(I,j,:), tracer%t(I+1,j,:), ppoly0_coefs(I,j,:,:), &
-              ppoly0_coefs(I+1,j,:,:), ppoly0_E(I,j,:,:), ppoly0_E(I+1,j,:,:), remap_method, Coef_x(I,j), uFlx(I,j,:))
-          endif
-        enddo
-      enddo
-      do J=G%jsc-1,G%jec
-        do i=G%isc,G%iec
-          if (G%mask2dCv(i,J)>0.) then
-            call fluxes_layer_method(SURFACE, GV%ke, CS%deg, h(i,J,:), h(i,J+1,:), hbl(i,J), hbl(i,J+1), &
-              G%areaT(i,J), G%areaT(i,J+1), tracer%t(i,J,:), tracer%t(i,J+1,:), ppoly0_coefs(i,J,:,:), &
-              ppoly0_coefs(i,J+1,:,:), ppoly0_E(i,J,:,:), ppoly0_E(i,J+1,:,:), remap_method, Coef_y(i,J), vFlx(i,J,:))
-          endif
-        enddo
-      enddo
     endif
 
     ! Update the tracer fluxes
@@ -299,26 +309,26 @@ end subroutine lateral_boundary_diffusion
 !< Calculate bulk layer value of a scalar quantity as the thickness weighted average
 real function bulk_average(boundary, nk, deg, h, hBLT, phi, ppoly0_E, ppoly0_coefs, method, k_top, zeta_top, k_bot, &
                            zeta_bot)
-  integer             :: boundary          !< SURFACE or BOTTOM                                         [nondim]
-  integer             :: nk                !< Number of layers                                          [nondim]
-  integer             :: deg               !< Degree of polynomial                                      [nondim]
-  real, dimension(nk) :: h                 !< Layer thicknesses                               [H ~> m or kg m-2]
-  real                :: hBLT              !< Depth of the boundary layer                     [H ~> m or kg m-2]
+  integer             :: boundary          !< SURFACE or BOTTOM                                     [nondim]
+  integer             :: nk                !< Number of layers                                      [nondim]
+  integer             :: deg               !< Degree of polynomial                                  [nondim]
+  real, dimension(nk) :: h                 !< Layer thicknesses                                     [H ~> m or kg m-2]
+  real                :: hBLT              !< Depth of the boundary layer                           [H ~> m or kg m-2]
   real, dimension(nk) :: phi               !< Scalar quantity
-  real, dimension(nk,2)     :: ppoly0_E     !< Edge value of polynomial
-  real, dimension(nk,deg+1) :: ppoly0_coefs !< Coefficients of polynomial
-  integer                   :: method       !< Remapping scheme to use
+  real, dimension(nk,2)     :: ppoly0_E    !< Edge value of polynomial
+  real, dimension(nk,deg+1) :: ppoly0_coefs!< Coefficients of polynomial
+  integer                   :: method      !< Remapping scheme to use
 
   integer             :: k_top             !< Index of the first layer within the boundary
   real                :: zeta_top          !< Fraction of the layer encompassed by the bottom boundary layer
                                            !! (0 if none, 1. if all). For the surface, this is always 0. because
-                                           !! integration starts at the surface                         [nondim]
+                                           !! integration starts at the surface                     [nondim]
   integer             :: k_bot             !< Index of the last layer within the boundary
   real                :: zeta_bot          !< Fraction of the layer encompassed by the surface boundary layer
                                            !! (0 if none, 1. if all). For the bottom boundary layer, this is always 1.
-                                           !! because integration starts at the bottom                  [nondim]
+                                           !! because integration starts at the bottom              [nondim]
   ! Local variables
-  real    :: htot !< Running sum of the thicknesses (top to bottom) [H ~> m or kg m-2]
+  real    :: htot !< Running sum of the thicknesses (top to bottom)
   integer :: k    !< k indice
 
 
@@ -427,45 +437,50 @@ end subroutine boundary_k_range
 
 
 !> Calculate the lateral boundary diffusive fluxes using the layer by layer method.
-!! See \ref section_method2
+!! See \ref section_method1
 subroutine fluxes_layer_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L, area_R, phi_L, phi_R, &
-                              ppoly0_coefs_L, ppoly0_coefs_R, ppoly0_E_L, ppoly0_E_R, method, khtr_u, F_layer)
+                              ppoly0_coefs_L, ppoly0_coefs_R, ppoly0_E_L, ppoly0_E_R, method, khtr_u, &
+                              F_layer, linear_decay)
 
   integer,                   intent(in   )       :: boundary !< Which boundary layer SURFACE or BOTTOM  [nondim]
   integer,                   intent(in   )       :: nk       !< Number of layers                        [nondim]
   integer,                   intent(in   )       :: deg      !< order of the polynomial reconstruction  [nondim]
-  real, dimension(nk),       intent(in   )       :: h_L      !< Layer thickness (left)        [H ~> m or kg m-2]
-  real, dimension(nk),       intent(in   )       :: h_R      !< Layer thickness (right)       [H ~> m or kg m-2]
+  real, dimension(nk),       intent(in   )       :: h_L      !< Layer thickness (left)              [H ~> m or kg m-2]
+  real, dimension(nk),       intent(in   )       :: h_R      !< Layer thickness (right)             [H ~> m or kg m-2]
   real,                      intent(in   )       :: hbl_L    !< Thickness of the boundary boundary
-                                                                       !! layer (left)        [H ~> m or kg m-2]
+                                                                       !! layer (left)              [H ~> m or kg m-2]
   real,                      intent(in   )       :: hbl_R    !< Thickness of the boundary boundary
-                                                             !! layer (right)                 [H ~> m or kg m-2]
-  real,                      intent(in   )       :: area_L   !< Area of the horizontal grid (left)    [L2 ~> m2]
-  real,                      intent(in   )       :: area_R   !< Area of the horizontal grid (right)   [L2 ~> m2]
-  real, dimension(nk),       intent(in   )       :: phi_L    !< Tracer values (left)                    [conc]
-  real, dimension(nk),       intent(in   )       :: phi_R    !< Tracer values (right)                   [conc]
-  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_L !< Tracer reconstruction (left)      [conc]
-  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_R !< Tracer reconstruction (right)     [conc]
-  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_L !< Polynomial edge values (left)         [ nondim ]
-  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_R !< Polynomial edge values (right)        [ nondim ]
-  integer,                   intent(in   )       :: method   !< Method of polynomial integration        [ nondim ]
+                                                             !! layer (right)                       [H ~> m or kg m-2]
+  real,                      intent(in   )       :: area_L   !< Area of the horizontal grid (left)  [L2 ~> m2]
+  real,                      intent(in   )       :: area_R   !< Area of the horizontal grid (right) [L2 ~> m2]
+  real, dimension(nk),       intent(in   )       :: phi_L    !< Tracer values (left)                [conc]
+  real, dimension(nk),       intent(in   )       :: phi_R    !< Tracer values (right)               [conc]
+  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_L !< Tracer reconstruction (left)  [conc]
+  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_R !< Tracer reconstruction (right) [conc]
+  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_L !< Polynomial edge values (left)     [nondim]
+  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_R !< Polynomial edge values (right)    [nondim]
+  integer,                   intent(in   )       :: method   !< Method of polynomial integration    [nondim]
   real,                      intent(in   )       :: khtr_u   !< Horizontal diffusivities times delta t
                                                              !! at a velocity point [L2 ~> m2]
   real, dimension(nk),       intent(  out)       :: F_layer  !< Layerwise diffusive flux at U- or V-point
                                                              !! [H L2 conc ~> m3 conc]
-
+  logical, optional,         intent(in   )       :: linear_decay !< If True, apply a linear transition at the base of
+                                                             !! the boundary layer
   ! Local variables
-  real, dimension(nk) :: h_means              !< Calculate the layer-wise harmonic means      [H ~> m or kg m-2]
-  real                :: khtr_avg             !< Thickness-weighted diffusivity at the u-point        [m^2 s^-1]
+  real, dimension(nk) :: h_means              !< Calculate the layer-wise harmonic means           [H ~> m or kg m-2]
+  real                :: khtr_avg             !< Thickness-weighted diffusivity at the u-point     [m^2 s^-1]
                                               !! This is just to remind developers that khtr_avg should be
                                               !! computed once khtr is 3D.
   real                :: heff                 !< Harmonic mean of layer thicknesses           [H ~> m or kg m-2]
   real                :: inv_heff             !< Inverse of the harmonic mean of layer thicknesses
                                               !!  [H-1 ~> m-1 or m2 kg-1]
   real                :: phi_L_avg, phi_R_avg !< Bulk, thickness-weighted tracer averages (left and right column)
-                                              !!                                                    [conc m^-3 ]
+                                              !!                                                   [conc m^-3 ]
   real    :: htot                      !< Total column thickness [H ~> m or kg m-2]
-  integer :: k, k_bot_min, k_top_max   !< k-indices, min and max for top and bottom, respectively
+  real    :: heff_tot                  !< Total effective column thickness in the transition layer [m]
+  integer :: k, k_bot_min, k_top_max   !< k-indices, min and max for bottom and top, respectively
+  integer :: k_bot_max, k_top_min      !< k-indices, max and min for bottom and top, respectively
+  integer :: k_bot_diff, k_top_diff    !< different between left and right k-indices for bottom and top, respectively
   integer :: k_top_L, k_bot_L          !< k-indices left
   integer :: k_top_R, k_bot_R          !< k-indices right
   real    :: zeta_top_L, zeta_top_R    !< distance from the top of a layer to the boundary
@@ -473,11 +488,19 @@ subroutine fluxes_layer_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L
   real    :: zeta_bot_L, zeta_bot_R    !< distance from the bottom of a layer to the boundary
                                        !!layer depth                                      [nondim]
   real    :: h_work_L, h_work_R  !< dummy variables
-  real    :: hbl_min             !< minimum BLD (left and right)                                   [m]
+  real    :: hbl_min             !< minimum BLD (left and right)                          [m]
+  real    :: wgt                 !< weight to be used in the linear transition to the interior [nondim]
+  real    :: a                   !< coefficient to be used in the linear transition to the interior [nondim]
+  logical :: linear              !< True if apply a linear transition
 
   F_layer(:) = 0.0
   if (hbl_L == 0. .or. hbl_R == 0.) then
     return
+  endif
+
+  linear = .false.
+  if (PRESENT(linear_decay)) then
+    linear = linear_decay
   endif
 
   ! Calculate vertical indices containing the boundary layer
@@ -486,6 +509,9 @@ subroutine fluxes_layer_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L
 
   if (boundary == SURFACE) then
     k_bot_min = MIN(k_bot_L, k_bot_R)
+    k_bot_max = MAX(k_bot_L, k_bot_R)
+    k_bot_diff = (k_bot_max - k_bot_min)
+
     ! make sure left and right k indices span same range
     if (k_bot_min .ne. k_bot_L) then
       k_bot_L = k_bot_min
@@ -504,15 +530,37 @@ subroutine fluxes_layer_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L
     heff = harmonic_mean(h_work_L, h_work_R)
     ! tracer flux where the minimum BLD intersets layer
     ! GMM, khtr_avg should be computed once khtr is 3D
-    F_layer(k_bot_min) = -(heff * khtr_u) * (phi_R_avg - phi_L_avg)
+    if ((linear) .and. (k_bot_diff .gt. 1)) then
+      ! apply linear decay at the base of hbl
+      do k = k_bot_min,1,-1
+        heff = harmonic_mean(h_L(k), h_R(k))
+        F_layer(k) = -(heff * khtr_u) * (phi_R(k) - phi_L(k))
+      enddo
+      ! heff_total
+      heff_tot = 0.0
+      do k = k_bot_min+1,k_bot_max, 1
+        heff_tot = heff_tot + harmonic_mean(h_L(k), h_R(k))
+      enddo
 
-    do k = k_bot_min-1,1,-1
-      heff = harmonic_mean(h_L(k), h_R(k))
-      F_layer(k) = -(heff * khtr_u) * (phi_R(k) - phi_L(k))
-    enddo
+      a = -1.0/heff_tot
+      heff_tot = 0.0
+      do k = k_bot_min+1,k_bot_max, 1
+        heff = harmonic_mean(h_L(k), h_R(k))
+        wgt = (a*(heff_tot + (heff * 0.5))) + 1.0
+        F_layer(k) = -(heff * khtr_u) * (phi_R(k) - phi_L(k)) * wgt
+        heff_tot = heff_tot + heff
+      enddo
+    else
+      F_layer(k_bot_min) = -(heff * khtr_u) * (phi_R_avg - phi_L_avg)
+      do k = k_bot_min-1,1,-1
+        heff = harmonic_mean(h_L(k), h_R(k))
+        F_layer(k) = -(heff * khtr_u) * (phi_R(k) - phi_L(k))
+      enddo
+    endif
   endif
 
   if (boundary == BOTTOM) then
+    ! TODO: GMM add option to apply linear decay
     k_top_max = MAX(k_top_L, k_top_R)
     ! make sure left and right k indices span same range
     if (k_top_max .ne. k_top_L) then
@@ -543,28 +591,29 @@ subroutine fluxes_layer_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L
 end subroutine fluxes_layer_method
 
 !> Apply the lateral boundary diffusive fluxes calculated from a 'bulk model'
-!! See \ref section_method1
+!! See \ref section_method2
 subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L, area_R, phi_L, phi_R, ppoly0_coefs_L, &
-                                   ppoly0_coefs_R, ppoly0_E_L, ppoly0_E_R, method, khtr_u, F_bulk, F_layer, F_limit)
+                              ppoly0_coefs_R, ppoly0_E_L, ppoly0_E_R, method, khtr_u, F_bulk, F_layer, F_limit, &
+                              linear_decay)
 
   integer,                   intent(in   )       :: boundary !< Which boundary layer SURFACE or BOTTOM  [nondim]
   integer,                   intent(in   )       :: nk       !< Number of layers                        [nondim]
   integer,                   intent(in   )       :: deg      !< order of the polynomial reconstruction  [nondim]
-  real, dimension(nk),       intent(in   )       :: h_L      !< Layer thickness (left)          [H ~> m or kg m-2]
-  real, dimension(nk),       intent(in   )       :: h_R      !< Layer thickness (right)         [H ~> m or kg m-2]
+  real, dimension(nk),       intent(in   )       :: h_L      !< Layer thickness (left)              [H ~> m or kg m-2]
+  real, dimension(nk),       intent(in   )       :: h_R      !< Layer thickness (right)             [H ~> m or kg m-2]
   real,                      intent(in   )       :: hbl_L    !< Thickness of the boundary boundary
-                                                                       !! layer (left)          [H ~> m or kg m-2]
+                                                                       !! layer (left)              [H ~> m or kg m-2]
   real,                      intent(in   )       :: hbl_R    !< Thickness of the boundary boundary
-                                                             !! layer (left)                    [H ~> m or kg m-2]
-  real,                      intent(in   )       :: area_L   !< Area of the horizontal grid (left)      [L2 ~> m2]
-  real,                      intent(in   )       :: area_R   !< Area of the horizontal grid (right)     [L2 ~> m2]
-  real, dimension(nk),       intent(in   )       :: phi_L    !< Tracer values (left)                    [conc]
-  real, dimension(nk),       intent(in   )       :: phi_R    !< Tracer values (right)                   [conc]
-  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_L !< Tracer reconstruction (left)      [conc]
-  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_R !< Tracer reconstruction (right)     [conc]
-  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_L !< Polynomial edge values (left)         [nondim]
-  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_R !< Polynomial edge values (right)        [nondim]
-  integer,                   intent(in   )       :: method   !< Method of polynomial integration        [nondim]
+                                                             !! layer (left)                        [H ~> m or kg m-2]
+  real,                      intent(in   )       :: area_L   !< Area of the horizontal grid (left)  [L2 ~> m2]
+  real,                      intent(in   )       :: area_R   !< Area of the horizontal grid (right) [L2 ~> m2]
+  real, dimension(nk),       intent(in   )       :: phi_L    !< Tracer values (left)                [conc]
+  real, dimension(nk),       intent(in   )       :: phi_R    !< Tracer values (right)               [conc]
+  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_L !< Tracer reconstruction (left)  [conc]
+  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_R !< Tracer reconstruction (right) [conc]
+  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_L !< Polynomial edge values (left)     [nondim]
+  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_R !< Polynomial edge values (right)    [nondim]
+  integer,                   intent(in   )       :: method   !< Method of polynomial integration    [nondim]
   real,                      intent(in   )       :: khtr_u   !< Horizontal diffusivities times delta t
                                                              !! at a velocity point [L2 ~> m2]
   real,                      intent(  out)       :: F_bulk   !< The bulk mixed layer lateral flux
@@ -572,6 +621,8 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
   real, dimension(nk),       intent(  out)       :: F_layer  !< Layerwise diffusive flux at U- or V-point
                                                              !! [H L2 conc ~> m3 conc]
   logical, optional,         intent(in   )       :: F_limit  !< If True, apply a limiter
+  logical, optional,         intent(in   )       :: linear_decay !< If True, apply a linear transition at the base of
+                                                             !! the boundary layer
 
   ! Local variables
   real, dimension(nk) :: h_means              !< Calculate the layer-wise harmonic means           [H ~> m or kg m-2]
@@ -579,12 +630,14 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
                                               !! This is just to remind developers that khtr_avg should be
                                               !! computed once khtr is 3D.
   real                :: heff                 !< Harmonic mean of layer thicknesses                [H ~> m or kg m-2]
+  real                :: heff_tot             !< Total effective column thickness in the transition layer [m]
   real                :: inv_heff             !< Inverse of the harmonic mean of layer thicknesses
                                               !! [H-1 ~> m-1 or m2 kg-1]
   real                :: phi_L_avg, phi_R_avg !< Bulk, thickness-weighted tracer averages (left and right column)
                                               !!                                                   [conc m^-3 ]
-  real    :: htot                             !< Total column thickness [H ~> m or kg m-2]
+  real    :: htot                             ! Total column thickness [H ~> m or kg m-2]
   integer :: k, k_min, k_max                  !< k-indices, min and max for top and bottom, respectively
+  integer :: k_diff                           !< difference between k_max and k_min
   integer :: k_top_L, k_bot_L                 !< k-indices left
   integer :: k_top_R, k_bot_R                 !< k-indices right
   real    :: zeta_top_L, zeta_top_R           !< distance from the top of a layer to the
@@ -595,18 +648,27 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
   real    :: F_max                            !< The maximum amount of flux that can leave a
                                               !! cell  [m^3 conc]
   logical :: limiter                          !< True if flux limiter should be applied
+  logical :: linear                           !< True if apply a linear transition
   real    :: hfrac                            !< Layer fraction wrt sum of all layers [nondim]
   real    :: dphi                             !< tracer gradient                      [conc m^-3]
+  real    :: wgt                              !< weight to be used in the linear transition to the
+                                              !! interior [nondim]
+  real    :: a                                !< coefficient to be used in the linear transition to the
+                                              !! interior [nondim]
 
+  F_bulk = 0.
+  F_layer(:) = 0.
   if (hbl_L == 0. .or. hbl_R == 0.) then
-    F_bulk = 0.
-    F_layer(:) = 0.
     return
   endif
 
   limiter = .false.
   if (PRESENT(F_limit)) then
     limiter = F_limit
+  endif
+  linear = .false.
+  if (PRESENT(linear_decay)) then
+    linear = linear_decay
   endif
 
   ! Calculate vertical indices containing the boundary layer
@@ -618,7 +680,6 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
                             zeta_top_L, k_bot_L, zeta_bot_L)
   phi_R_avg  = bulk_average(boundary, nk, deg, h_R, hbl_R, phi_R, ppoly0_E_R, ppoly0_coefs_R, method, k_top_R, &
                             zeta_top_R, k_bot_R, zeta_bot_R)
-
   ! Calculate the 'bulk' diffusive flux from the bulk averaged quantities
   ! GMM, khtr_avg should be computed once khtr is 3D
   heff = harmonic_mean(hbl_L, hbl_R)
@@ -626,31 +687,53 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
   ! Calculate the layerwise sum of the vertical effective thickness. This is different than the heff calculated
   ! above, but is used as a way to decompose the fluxes onto the individual layers
   h_means(:) = 0.
-
   if (boundary == SURFACE) then
     k_min = MIN(k_bot_L, k_bot_R)
+    k_max = MAX(k_bot_L, k_bot_R)
+    k_diff = (k_max - k_min)
+    if ((linear) .and. (k_diff .gt. 1)) then
+      do k=1,k_min
+        h_means(k) = harmonic_mean(h_L(k),h_R(k))
+      enddo
+      ! heff_total
+      heff_tot = 0.0
+      do k = k_min+1,k_max, 1
+        heff_tot = heff_tot + harmonic_mean(h_L(k), h_R(k))
+      enddo
 
-    ! left hand side
-    if (k_bot_L == k_min) then
-      h_work_L = h_L(k_min) * zeta_bot_L
+      a = -1.0/heff_tot
+      heff_tot = 0.0
+      ! fluxes will decay linearly at base of hbl
+      do k = k_min+1,k_max, 1
+        heff = harmonic_mean(h_L(k), h_R(k))
+        wgt = (a*(heff_tot + (heff * 0.5))) + 1.0
+        h_means(k) = harmonic_mean(h_L(k), h_R(k)) * wgt
+        heff_tot = heff_tot + heff
+      enddo
     else
-      h_work_L = h_L(k_min)
+      ! left hand side
+      if (k_bot_L == k_min) then
+        h_work_L = h_L(k_min) * zeta_bot_L
+      else
+        h_work_L = h_L(k_min)
+      endif
+
+      ! right hand side
+      if (k_bot_R == k_min) then
+        h_work_R = h_R(k_min) * zeta_bot_R
+      else
+        h_work_R = h_R(k_min)
+      endif
+
+      h_means(k_min) = harmonic_mean(h_work_L,h_work_R)
+
+      do k=1,k_min-1
+        h_means(k) = harmonic_mean(h_L(k),h_R(k))
+      enddo
     endif
-
-    ! right hand side
-    if (k_bot_R == k_min) then
-      h_work_R = h_R(k_min) * zeta_bot_R
-    else
-      h_work_R = h_R(k_min)
-    endif
-
-    h_means(k_min) = harmonic_mean(h_work_L,h_work_R)
-
-    do k=1,k_min-1
-      h_means(k) = harmonic_mean(h_L(k),h_R(k))
-    enddo
 
   elseif (boundary == BOTTOM) then
+    !TODO, GMM linear decay is not implemented here
     k_max = MAX(k_top_L, k_top_R)
     ! left hand side
     if (k_top_L == k_max) then
@@ -673,14 +756,14 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
     enddo
   endif
 
-  if ( SUM(h_means) == 0. ) then
+  if ( SUM(h_means) == 0. .or. F_bulk == 0.) then
     return
- ! Decompose the bulk flux onto the individual layers
+  ! Decompose the bulk flux onto the individual layers
   else
     ! Initialize remaining thickness
     inv_heff = 1./SUM(h_means)
     do k=1,nk
-      if (h_means(k) > 0.) then
+      if ((h_means(k) > 0.) .and. (phi_L(k) /= phi_R(k))) then
         hfrac = h_means(k)*inv_heff
         F_layer(k) = F_bulk * hfrac
 
@@ -1036,10 +1119,6 @@ logical function test_layer_fluxes(verbose, nk, test_name, F_calc, F_ans)
       test_layer_fluxes = .true.
       write(stdunit,*) "MOM_lateral_boundary_diffusion, UNIT TEST FAILED: ", test_name
       write(stdunit,10) k, F_calc(k), F_ans(k)
-      ! ### Once these unit tests are passing, and failures are caught properly,
-      ! we will post failure notifications to both stdout and stderr.
-      !write(stderr,*) "MOM_lateral_boundary_diffusion, UNIT TEST FAILED: ", test_name
-      !write(stderr,10) k, F_calc(k), F_ans(k)
     elseif (verbose) then
       write(stdunit,10) k, F_calc(k), F_ans(k)
     endif
@@ -1097,12 +1176,37 @@ end function test_boundary_k_range
 !!
 !! Boundary lateral diffusion can be applied using one of the three methods:
 !!
-!! * [Method #1: Bulk layer](@ref section_method1) (default);
-!! * [Method #2: Along layer](@ref section_method2);
+!! * [Method #1: Along layer](@ref section_method2) (default);
+!! * [Method #2: Bulk layer](@ref section_method1);
 !!
 !! A brief summary of these methods is provided below.
 !!
-!! \subsection section_method1 Bulk layer approach (Method #1)
+!! \subsection section_method1 Along layer approach (Method #1)
+!!
+!! This is the recommended and more straight forward method where diffusion is
+!! applied layer by layer using only information from neighboring cells.
+!!
+!! Step #1: compute vertical indices containing boundary layer (boundary_k_range).
+!! For the TOP boundary layer, these are:
+!!
+!! k_top, k_bot, zeta_top, zeta_bot
+!!
+!! Step #2: calculate the diffusive flux at each layer:
+!!
+!! \f[ F_{k} = -KHTR \times h_{eff}(k) \times (\phi_R(k) - \phi_L(k)),  \f]
+!! where h_eff is the [harmonic mean](@ref section_harmonic_mean) of the layer thickness
+!! in the left and right columns. This method does not require a limiter since KHTR
+!! is already limted based on a diffusive CFL condition prior to the call of this
+!! module.
+!!
+!! Step #3: option to linearly decay the flux from k_bot_min to k_bot_max:
+!!
+!! If LBD_LINEAR_TRANSITION = True and k_bot_diff > 1, the diffusive flux will decay
+!! linearly between the top interface of the layer containing the minimum boundary
+!! layer depth (k_bot_min) and the lower interface of the layer containing the
+!! maximum layer depth (k_bot_max).
+!!
+!! \subsection section_method2 Bulk layer approach (Method #2)
 !!
 !! Apply the lateral boundary diffusive fluxes calculated from a 'bulk model'.This
 !! is a lower order representation (Kraus-Turner like approach) which assumes that
@@ -1132,7 +1236,14 @@ end function test_boundary_k_range
 !! h_u is the [harmonic mean](@ref section_harmonic_mean) of thicknesses at each layer.
 !! Special care (layer reconstruction) must be taken at k_min = min(k_botL, k_bot_R).
 !!
-!! Step #4: limit the tracer flux so that 1) only down-gradient fluxes are applied,
+!! Step #4: option to linearly decay the flux from k_bot_min to k_bot_max:
+!!
+!! If LBD_LINEAR_TRANSITION = True and k_bot_diff > 1, the diffusive flux will decay
+!! linearly between the top interface of the layer containing the minimum boundary
+!! layer depth (k_bot_min) and the lower interface of the layer containing the
+!! maximum layer depth (k_bot_max).
+!!
+!! Step #5: limit the tracer flux so that 1) only down-gradient fluxes are applied,
 !! and 2) the flux cannot be larger than F_max, which is defined using the tracer
 !! gradient:
 !!
@@ -1142,25 +1253,6 @@ end function test_boundary_k_range
 !!           0           .2
 !!         0 1 0       .2.2.2
 !!           0           .2
-!!
-!! \subsection section_method2 Along layer approach (Method #2)
-!!
-!! This is a more straight forward method where diffusion is applied layer by layer using
-!! only information from neighboring cells.
-!!
-!! Step #1: compute vertical indices containing boundary layer (boundary_k_range).
-!! For the TOP boundary layer, these are:
-!!
-!! k_top, k_bot, zeta_top, zeta_bot
-!!
-!! Step #2: calculate the diffusive flux at each layer:
-!!
-!! \f[ F_{k} = -KHTR \times h_{eff}(k) \times (\phi_R(k) - \phi_L(k)),  \f]
-!! where h_eff is the [harmonic mean](@ref section_harmonic_mean) of the layer thickness
-!! in the left and right columns. Special care (layer reconstruction) must be taken at
-!! k_min = min(k_botL, k_bot_R). This method does not require a limiter since KHTR
-!! is already limted based on a diffusive CFL condition prior to the call of this
-!! module.
 !!
 !! \subsection section_harmonic_mean Harmonic Mean
 !!

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -312,7 +312,7 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, CS, p_surf)
   pa_to_H = 1. / (GV%H_to_RZ * GV%g_Earth)
 
   k_top(:,:) = 1     ; k_bot(:,:) = 1
-  zeta_top(:,:) = 0. ; zeta_bot(:,:) = 1.
+  zeta_top(:,:) = 0. ; zeta_bot(:,:) = 0.
 
   ! Check if hbl needs to be extracted
   if (CS%interior_only) then
@@ -461,7 +461,7 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, CS, p_surf)
                 CS%Pint(i,j,:), CS%Tint(i,j,:), CS%Sint(i,j,:), CS%dRdT(i,j,:), CS%dRdS(i,j,:),            &
                 CS%Pint(i+1,j,:), CS%Tint(i+1,j,:), CS%Sint(i+1,j,:), CS%dRdT(i+1,j,:), CS%dRdS(i+1,j,:),  &
                 CS%uPoL(I,j,:), CS%uPoR(I,j,:), CS%uKoL(I,j,:), CS%uKoR(I,j,:), CS%uhEff(I,j,:),           &
-                k_bot(I,j), k_bot(I+1,j), 1.-zeta_bot(I,j), 1.-zeta_bot(I+1,j))
+                k_bot(I,j), k_bot(I+1,j), zeta_bot(I,j), zeta_bot(I+1,j))
       else
         call find_neutral_surface_positions_discontinuous(CS, G%ke, &
             CS%P_i(i,j,:,:), h(i,j,:), CS%T_i(i,j,:,:), CS%S_i(i,j,:,:), CS%ppoly_coeffs_T(i,j,:,:),           &
@@ -482,7 +482,7 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, CS, p_surf)
                 CS%Pint(i,j,:), CS%Tint(i,j,:), CS%Sint(i,j,:), CS%dRdT(i,j,:), CS%dRdS(i,j,:),           &
                 CS%Pint(i,j+1,:), CS%Tint(i,j+1,:), CS%Sint(i,j+1,:), CS%dRdT(i,j+1,:), CS%dRdS(i,j+1,:), &
                 CS%vPoL(i,J,:), CS%vPoR(i,J,:), CS%vKoL(i,J,:), CS%vKoR(i,J,:), CS%vhEff(i,J,:), &
-                k_bot(i,J), k_bot(i,J+1), 1.-zeta_bot(i,J), 1.-zeta_bot(i,J+1))
+                k_bot(i,J), k_bot(i,J+1), zeta_bot(i,J), zeta_bot(i,J+1))
       else
         call find_neutral_surface_positions_discontinuous(CS, G%ke, &
             CS%P_i(i,j,:,:), h(i,j,:), CS%T_i(i,j,:,:), CS%S_i(i,j,:,:), CS%ppoly_coeffs_T(i,j,:,:),           &


### PR DESCRIPTION
  This PR merges the latest changes from dev/master into dev/gfdl.  The changes
introduced with this PR come primarily from contributions from the NCAR/MOM6
fork, but with some changes to reconcile conflicts with other developments.
There are new runtime parameters and diagnostics with this PR, so some of the
MOM_parameteter_doc files and available_diags files will need to be updated.
All answers in the MOM6-examples test cases are bitwise identical, and an
interactive version of the travis testing passes, apart from noting the newly
added diagnostics.  The list of commits in this PR include:

- NCAR/MOM6@97793be50 Merge branch 'dev/master' into merge_ncar_gfdl
- NCAR/MOM6@eb57e51f5 Merge pull request #1176 sfrom gustavo-marques/dev-master-candidate-ncar-2020-08-11
- NCAR/MOM6@2946903bc Fix one more letter case to follow MOM6 convention
- NCAR/MOM6@e3bc47a8d Fix letter case to follow MOM6 convention
- NCAR/MOM6@17936f3fd Add modifications suggested by Bob Hallberg
- NCAR/MOM6@ab9386c66 In do-loops, use uppercase K index for variables discretized on interfaces
- NCAR/MOM6@287281cf6 Remove unnecessary present(num_rest_files) condition
- NCAR/MOM6@6331da102 Remove (:,:) after 2-d variable declariation
- NCAR/MOM6@608f4bfb8 Merge branch 'dev/master' into dev-master-candidate-ncar-2020-08-11
- NCAR/MOM6@aa8ce213f Merge pull request #156 from NCAR/fix_multi_restart
- NCAR/MOM6@648bb1ce8 make mct cap be able to read multiple restart files from rpointer
- NCAR/MOM6@829aadea9 make mct cap be able to write multiple restart files to rpointer
- NCAR/MOM6@bba3e91b5 increase nuopc cap restart filename length
- NCAR/MOM6@0a5515b3d increase restart filename lengths
- NCAR/MOM6@4c91ae3ac add filename length check
- NCAR/MOM6@7a2256c50 correct restart file suffix index
- NCAR/MOM6@4c6090010 read/write multiple restart filenames from/to rpointer files
- NCAR/MOM6@ff27ad560 add num_rest_files to ocean_model_restart
- NCAR/MOM6@2fe90f2fe retrieve num_rest_files from save_restart
- NCAR/MOM6@330d7c45a Merge pull request #155 from gustavo-marques/LBD_improvements_jun2020
- NCAR/MOM6@388b100c8 Fix default zeta_bot values
- NCAR/MOM6@3698c4055 Merge pull request #154 from gustavo-marques/restart_nuopc
- NCAR/MOM6@0c98fa994 Merge pull request #153 from gustavo-marques/add_calls_time_interp_external_init
- NCAR/MOM6@bb222c875 Merge pull request #152 from gustavo-marques/add_diagnostics
- NCAR/MOM6@ca86bad51 Remove trailing space
- NCAR/MOM6@8fdcd9048 Improve documentation and changed default method
- NCAR/MOM6@7f478aa3e Add option to apply linear decay at the base of hbl
- NCAR/MOM6@aed316cd7 Merge branch 'dev/ncar' into restart_nuopc
- NCAR/MOM6@abb10ed4c Add calls to time_interp_external_init
- NCAR/MOM6@473c3f47b Remove unused module
- NCAR/MOM6@a69aea961 Add new diagnostics
- NCAR/MOM6@4041cc90b Fix bug when applying ND only in the interior
- NCAR/MOM6@fd68ffa0b Merge pull request #151 from gustavo-marques/merge-dev-master-candidate-2020-05-15
- NCAR/MOM6@97547426a Fix OMP directives broken by merge
- NCAR/MOM6@532e65ad5 undo OMP changes in MOM_EOS
- NCAR/MOM6@b34478800 undo indent change from conflict resolve
- NCAR/MOM6@2f44ca7ce correct conflict resolve in KPP
- NCAR/MOM6@81805cc99 Merge branch 'dev/ncar' into merge-dev-master-candidate-2020-05-15
- NCAR/MOM6@85f4dc09b Merge pull request #150 from NCAR/omp_performance
- NCAR/MOM6@4755458e3 Merge branch 'dev-master-candidate-2020-05-15-patch1' into merge-dev-master-candidate-2020-05-15
- NCAR/MOM6@fab21a749 Fixes an integer-kind mismatch in MOM_random, seed_from_time()
- NCAR/MOM6@6d5a5f90b Merge branch 'dev-master-candidate-2020-05-15' into merge-dev-master-candidate-2020-05-15
- NCAR/MOM6@02f5a8cf3 Merge pull request #149 from gustavo-marques/fix_tidal_mixing
- NCAR/MOM6@c42d104c5 Merge pull request #148 from gustavo-marques/leith_improvements
- NCAR/MOM6@809593cb4 Merge branch 'dev/ncar' into leith_improvements
- NCAR/MOM6@4e54ad531 Merge pull request #147 from gustavo-marques/biharmonic_grid_Re
- NCAR/MOM6@c06515f19 Add tidal diffusivities (Kd_tidal) into Kd_int
- NCAR/MOM6@933b09abe Remove OMP directive that came with cherry-picking
- NCAR/MOM6@7d228f73a Add missing OMP directives
- NCAR/MOM6@b412fde96 Fix Leith_Ah
- NCAR/MOM6@c53525eae Clean QG_Leith
- NCAR/MOM6@48310e3d6 eliminate omp parallel open/close in to int_density_dz_generic_plm
- NCAR/MOM6@98f5a8d97 add omp directives to int_density_dz_generic_plm
- NCAR/MOM6@1165a61ba further refactor smoothing subroutine
- NCAR/MOM6@e47e8b712 uncomment KPP clocks
- NCAR/MOM6@e5fcc694d remove OMP enclosing get_BLD call
- NCAR/MOM6@1e7fa519b add KPP timing clocks and omp directives
- NCAR/MOM6@cd00022b5 Fix OMP calls
- NCAR/MOM6@e3cbcbbd0 Fix openmp directives
- NCAR/MOM6@e955c6d9a Fix openmp directives
- NCAR/MOM6@3fb86e3ed Avoid division by zero
- NCAR/MOM6@b609dead2 Fix indices in KE calculation
- NCAR/MOM6@49ab54ab5 move pass_var in KPP smoothing outside the do-loop
- NCAR/MOM6@65f36d768 Add diags for Lapl. and Bihar grid Reynolds #s
- NCAR/MOM6@6cf28bf15 Add option to scale AH via a biharmonic Reynolds #
- NCAR/MOM6@3dd70fe71 remove unnecessary kOBL computation
- NCAR/MOM6@2aa10917d optimize barotropic timestepping openmp
- NCAR/MOM6@01f7c452e uncomment omp in barotropic solver
- NCAR/MOM6@0a2bb505f uncomment omp directive for KPP_compute_BLD
- NCAR/MOM6@e089a159f bug fix for cesm when restart_option is none
- NCAR/MOM6@1a6411f0c added changes to unify cap with EMC changes
- NCAR/MOM6@2fe522454 updates to clean up differences between nems and cmeps for restarts
