### PR TITLE
Ac263 support

### DIFF
--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -8,6 +8,8 @@
 # - We would probably run this inside of a script to avoid the explicit
 #   dependency on git.
 
+AC_PREREQ([2.63])
+
 AC_INIT(
   [MOM6],
   [ ],
@@ -102,11 +104,22 @@ AS_IF(
 
 
 # OpenMP configuration
+
+# NOTE: AC_OPENMP fails on `Fortran` for Autoconf <2.69 due to a m4 bug.
+#   For older versions, we test against CC and use the result for FC.
+m4_version_prereq([2.69], [], [AC_LANG_PUSH([C])])
 AC_OPENMP
+m4_version_prereq([2.69], [], [
+  AC_LANG_POP([C])
+  OPENMP_FCFLAGS="$OPENMP_CFLAGS"
+])
+
+# NOTE: Only apply OpenMP flags if explicitly enabled.
 AS_IF(
-  [test "$enable_openmp" = yes],
-  [FCFLAGS="$FCFLAGS $OPENMP_FCFLAGS"
-  LDFLAGS="$LDFLAGS $OPENMP_FCFLAGS"])
+  [test "$enable_openmp" = yes], [
+  FCFLAGS="$FCFLAGS $OPENMP_FCFLAGS"
+  LDFLAGS="$LDFLAGS $OPENMP_FCFLAGS"
+])
 
 
 # FMS support

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -107,9 +107,9 @@ AS_IF(
 
 # NOTE: AC_OPENMP fails on `Fortran` for Autoconf <2.69 due to a m4 bug.
 #   For older versions, we test against CC and use the result for FC.
-m4_version_prereq([2.69], [], [AC_LANG_PUSH([C])])
-AC_OPENMP
-m4_version_prereq([2.69], [], [
+m4_version_prereq([2.69], [AC_OPENMP], [
+  AC_LANG_PUSH([C])
+  AC_OPENMP
   AC_LANG_POP([C])
   OPENMP_FCFLAGS="$OPENMP_CFLAGS"
 ])

--- a/ac/deps/configure.fms.ac
+++ b/ac/deps/configure.fms.ac
@@ -1,4 +1,6 @@
 # Autoconf configuration
+AC_PREREQ([2.63])
+
 AC_INIT(
     [FMS],
     [ ],
@@ -15,11 +17,11 @@ CC=$MPICC
 
 # FMS configuration
 
-# Linux and OSX have a gettid system call, but it is not implemented in older
+# Linux and macOS have a gettid system call, but it is not implemented in older
 # glibc implementations.  When unavailable, a native syscall is used.
 #
 # On Linux, this is defined in unistd.h as __NR_gettid, and FMS is hard-coded
-# to use this value.  In OS X, this is defined in sys/syscall.h as SYS_gettid,
+# to use this value.  In macOS, this is defined in sys/syscall.h as SYS_gettid,
 # so we override this macro if __NR_gettid is unavailable.
 AC_CHECK_FUNCS([gettid], [], [
   AC_MSG_CHECKING([if __NR_gettid must be redefined])
@@ -98,15 +100,31 @@ AS_IF(
 
 
 # OpenMP configuration
+
+# NOTE: AC_OPENMP fails in  Autoconf <2.69 when LANG is Fortran or Fortran 77.
+#   For older versions, we test against CC and use the result for FC.
+m4_version_prereq([2.69], [], [AC_LANG_PUSH([C])])
 AC_OPENMP
+m4_version_prereq([2.69], [], [
+  AC_LANG_POP([C])
+  OPENMP_FCFLAGS="$OPENMP_CFLAGS"
+])
+
+# NOTE: Only apply OpenMP flags if explicitly enabled.
 AS_IF(
-  [test "$enable_openmp" = yes],
-  [FCFLAGS="$FCFLAGS $OPENMP_FCFLAGS"
-  LDFLAGS="$LDFLAGS $OPENMP_FCFLAGS"])
+  [test "$enable_openmp" = yes], [
+  FCFLAGS="$FCFLAGS $OPENMP_FCFLAGS"
+  LDFLAGS="$LDFLAGS $OPENMP_FCFLAGS"
+])
 
 
-# Unlimited line length
-AC_FC_LINE_LENGTH([unlimited])
+# Unlimited line length (2.67)
+# AC_FC_LINE_LENGTH was added in 2.67.
+m4_version_prereq([2.67],
+  [AC_FC_LINE_LENGTH([unlimited])],
+  [AX_FC_LINE_LENGTH([unlimited])]
+)
+
 
 # Allow invaliz BOZ assignment
 AX_FC_ALLOW_INVALID_BOZ
@@ -141,12 +159,14 @@ AS_IF([test -z "$MKMF"], [
 # MKMF commands
 AC_CONFIG_COMMANDS([path_names],
   [${LIST_PATHS} -l ${srcdir}],
-  [LIST_PATHS=${LIST_PATHS}])
+  [LIST_PATHS=${LIST_PATHS}]
+)
 
 
 AC_CONFIG_COMMANDS([mkmf],
   [${MKMF} -p libFMS.a -m Makefile.mkmf path_names],
-  [MKMF=${MKMF}])
+  [MKMF=${MKMF}]
+)
 
 
 # Prepare output

--- a/ac/deps/configure.fms.ac
+++ b/ac/deps/configure.fms.ac
@@ -103,9 +103,9 @@ AS_IF(
 
 # NOTE: AC_OPENMP fails in  Autoconf <2.69 when LANG is Fortran or Fortran 77.
 #   For older versions, we test against CC and use the result for FC.
-m4_version_prereq([2.69], [], [AC_LANG_PUSH([C])])
-AC_OPENMP
-m4_version_prereq([2.69], [], [
+m4_version_prereq([2.69], [AC_OPENMP], [
+  AC_LANG_PUSH([C])
+  AC_OPENMP
   AC_LANG_POP([C])
   OPENMP_FCFLAGS="$OPENMP_CFLAGS"
 ])

--- a/ac/deps/m4/ax_fc_cray_pointer.m4
+++ b/ac/deps/m4/ax_fc_cray_pointer.m4
@@ -19,8 +19,8 @@ dnl
 AC_DEFUN([AX_FC_CRAY_POINTER], [
   AC_LANG_ASSERT([Fortran])
   AC_MSG_CHECKING([for $FC option to support Cray pointers])
-  AC_CACHE_VAL([ac_cv_prog_fc_cray_ptr], [
-    ac_cv_prog_fc_cray_ptr='unknown'
+  AC_CACHE_VAL([ac_cv_fc_cray_ptr], [
+    ac_cv_fc_cray_ptr='unknown'
     ac_save_FCFLAGS=$FCFLAGS
     for ac_option in none -fcray-pointer -Mcray=pointer; do
       test "$ac_option" != none && FCFLAGS="$ac_save_FCFLAGS $ac_option"
@@ -29,21 +29,21 @@ AC_DEFUN([AX_FC_CRAY_POINTER], [
       integer aptr(2)
       pointer (iptr, aptr)
         ])],
-        [ac_cv_prog_fc_cray_ptr=$ac_option],
+        [ac_cv_fc_cray_ptr=$ac_option],
       )
       FCFLAGS=$ac_save_FCFLAGS
-      AS_IF([test "$ac_cv_prog_fc_cray_ptr" != unknown], [break])
+      AS_IF([test "$ac_cv_fc_cray_ptr" != unknown], [break])
     done
   ])
-  AS_CASE([ac_cv_prog_fc_cray_ptr],
+  AS_CASE([ac_cv_fc_cray_ptr],
     [none], [AC_MSG_RESULT([none_needed])],
     [unknown], [AC_MSG_RESULT([unsupported])],
-    [AC_MSG_RESULT([$ac_cv_prog_fc_cray_ptr])]
+    [AC_MSG_RESULT([$ac_cv_fc_cray_ptr])]
   )
-  AS_IF([test "$ac_cv_prog_fc_cray_ptr" != unknown], [
+  AS_IF([test "$ac_cv_fc_cray_ptr" != unknown], [
     m4_default([$1], [
-      AS_IF([test "$ac_cv_prog_fc_cray_ptr" != none],
-        [FCFLAGS="$FCFLAGS $ac_cv_prog_fc_cray_ptr"]
+      AS_IF([test "$ac_cv_fc_cray_ptr" != none],
+        [FCFLAGS="$FCFLAGS $ac_cv_fc_cray_ptr"]
       )
     ])],
     [m4_default([$2], [AC_MSG_ERROR(["$FC does not support Cray pointers"])])]

--- a/ac/deps/m4/ax_fc_line_length.m4
+++ b/ac/deps/m4/ax_fc_line_length.m4
@@ -1,0 +1,101 @@
+# AX_FC_LINE_LENGTH([LENGTH], [ACTION-IF-SUCCESS],
+#		    [ACTION-IF-FAILURE = FAILURE])
+# ------------------------------------------------
+# This is a backport of the AC_FC_LINE_LENGTH macro in Autoconf 2.67 and newer.
+# Comments below are from the Autoconf 2.69 implementation.
+#
+# Look for a compiler flag to make the Fortran (FC) compiler accept long lines
+# in the current (free- or fixed-format) source code, and adds it to FCFLAGS.
+# The optional LENGTH may be 80, 132 (default), or `unlimited' for longer
+# lines.  Note that line lengths above 250 columns are not portable, and some
+# compilers (hello ifort) do not accept more than 132 columns at least for
+# fixed format.  Call ACTION-IF-SUCCESS (defaults to nothing) if successful
+# (i.e. can compile code using new extension) and ACTION-IF-FAILURE (defaults
+# to failing with an error message) if not.  (Defined via DEFUN_ONCE to
+# prevent flag from being added to FCFLAGS multiple times.)
+# You should call AC_FC_FREEFORM or AC_FC_FIXEDFORM to set the desired format
+# prior to using this macro.
+#
+# The known flags are:
+# -f{free,fixed}-line-length-N with N 72, 80, 132, or 0 or none for none.
+# -ffree-line-length-none: GNU gfortran
+# -ffree-line-length-huge: g95 (also -ffixed-line-length-N as above)
+#       -qfixed=132 80 72: IBM compiler (xlf)
+#                -Mextend: Cray
+#            -132 -80 -72: Intel compiler (ifort)
+#                          Needs to come before -extend_source because ifort
+#                          accepts that as well with an optional parameter and
+#                          doesn't fail but only warns about unknown arguments.
+#          -extend_source: SGI compiler
+#  -W, -WNN (132, 80, 72): Absoft Fortran
+#     +es, +extend_source: HP Fortran (254 in either form, default is 72 fixed,
+#			   132 free)
+#            -w, (-)-wide: Lahey/Fujitsu Fortran (255 cols in fixed form)
+#                      -e: Sun Fortran compiler (132 characters)
+#                    -132: NAGWare
+#         -72, -f, -Wf,-f: f2c (a weak form of "free-form" and long lines).
+#                  /XLine: Open Watcom
+
+AC_DEFUN_ONCE([AX_FC_LINE_LENGTH], [
+  AC_LANG_ASSERT([Fortran])
+  m4_case(m4_default([$1], [132]),
+    [unlimited], [
+      ac_fc_line_len_string=unlimited
+      ac_fc_line_len=0
+      ac_fc_line_length_test='
+      subroutine longer_than_132(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,'\
+'arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,arg17,arg18,arg19)'
+    ],
+    [132], [
+      ac_fc_line_len=132
+      ac_fc_line_length_test='
+      subroutine longer_than_80(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,'\
+'arg10)'
+    ],
+    [80], [
+      ac_fc_line_len=80
+      ac_fc_line_length_test='
+      subroutine longer_than_72(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)'
+    ],
+    [m4_warning([Invalid length argument `$1'])]
+  )
+  : ${ac_fc_line_len_string=$ac_fc_line_len}
+  AC_MSG_CHECKING([for Fortran flag needed to accept $ac_fc_line_len_string column source lines])
+  AC_CACHE_VAL([ac_cv_fc_line_length], [
+    ac_cv_fc_line_length=unknown
+    ac_save_FCFLAGS=$FCFLAGS
+    for ac_flag in none \
+      -ffree-line-length-none \
+      -ffixed-line-length-none \
+      -ffree-line-length-huge \
+      -ffree-line-length-$ac_fc_line_len \
+      -ffixed-line-length-$ac_fc_line_len \
+      -qfixed=$ac_fc_line_len \
+      -Mextend \
+      -$ac_fc_line_len \
+      -extend_source \
+      -W$ac_fc_line_len \
+      -W +extend_source +es -wide --wide -w -e -f -Wf,-f -xline
+    do
+      test "$ac_flag" != none && FCFLAGS="$ac_save_FCFLAGS $ac_flag"
+      AC_COMPILE_IFELSE([$ac_fc_line_length_test
+      end subroutine
+        ], [ac_cv_fc_line_length=$ac_flag]
+      )
+      FCFLAGS=$ac_save_FCFLAGS
+      dnl TODO: Remove conftest.{err,$ac_objext,$ac_ext} ??
+      AS_IF([test "$ac_cv_fc_line_length" != unknown], [break])
+    done
+  ])
+  AC_MSG_RESULT([$ac_cv_fc_line_length])
+  AS_IF([test "$ac_cv_fc_line_length" != unknown], [
+    m4_default([$2], [
+      AS_IF([test "$ac_cv_fc_line_length" != none], [
+        FCFLAGS="$FCFLAGS $ac_cv_fc_line_length"
+      ])
+    ])], [
+    m4_default([$3], [
+      AC_MSG_ERROR([Fortran does not accept long source lines], 77)
+    ])
+  ])
+])


### PR DESCRIPTION
Additional changes were made to support older Autoconf versions (at
least as far back as 2.63).

* AC_FC_LINE_LENGTH, added in 2.67, was backported
* AC_OPENMP, bugged for Fortran until 2.69, tests against the C flag

Version restrictions are now explicit (2.63).

This may work with 2.62, when the m4_version_change macro was
introduced, but I have not yet tested it.

The Cray pointer macro's cache variable was also renamed.
