### PR TITLE
MOM_sum_output: Reproducibility fix to energy

### DIFF
--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -703,8 +703,9 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, OBC, dt_
   tmp1(:,:,:) = 0.0
   do k=1,nz ; do j=js,je ; do i=is,ie
     tmp1(i,j,k) = (0.25 * KE_scale_factor * (areaTm(i,j) * h(i,j,k))) * &
-            (u(I-1,j,k)**2 + u(I,j,k)**2 + v(i,J-1,k)**2 + v(i,J,k)**2)
+            ((u(I-1,j,k)**2 + u(I,j,k)**2) + (v(i,J-1,k)**2 + v(i,J,k)**2))
   enddo ; enddo ; enddo
+
   KE_tot = reproducing_sum(tmp1, isr, ier, jsr, jer, sums=KE)
 
   toten = KE_tot + PE_tot


### PR DESCRIPTION
The total kinetic energy per unit mass, used heavily for model
reproducibility tests, was being computed in a non-reproducibile form:
```
   KE_mass = 0.5 * (u(i-1)**2 + u(i)**2 + v(j-1)**2 + v**2)
```
which uses an ambiguous order of summation.

This was causing reproducibility errors in rotational tests where u and
v become swapped.

This patch resolves the problem by explicitly summing the `u**2` and `v**2`
interpolations before adding together.

There is an extremely high change that this will change answers
somewhere and cause regressions.