### PR TITLE
User/bgr/jhl threshold option

### DIFF
--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -87,6 +87,10 @@ type, public :: Kappa_shear_CS ; private
                              !! time average TKE when there is mass in all layers.  Otherwise always
                              !! report the time-averaged TKE, as is currently done when there
                              !! are some massless layers.
+  logical :: restrictive_tolerance_check !< If false, uses the less restrictive tolerance check to
+                             !! determine if a timestep is acceptable for the KS_it outer iteration
+                             !! loop, as the code was originally written.  True uses the more
+                             !! restrictive check.
 !  logical :: layer_stagger = .false. ! If true, do the calculations centered at
                              !  layers, rather than the interfaces.
   logical :: debug = .false. !< If true, write verbose debugging messages.
@@ -928,9 +932,16 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
           if (N2(K) < Ri_crit * S2(K)) then ! Equivalent to Ri < Ri_crit.
             K_src(K) = (2.0 * CS%Shearmix_rate * sqrt(S2(K))) * &
                        ((Ri_crit*S2(K) - N2(K)) / (Ri_crit*S2(K) + CS%FRi_curvature*N2(K)))
-            if ((K_src(K) > max(tol_max(K), kappa_src(K) + Idtt*tol_chg(K))) .or. &
-                (K_src(K) < min(tol_min(K), kappa_src(K) - Idtt*tol_chg(K)))) then
-              valid_dt = .false. ; exit
+            if (CS%restrictive_tolerance_check) then
+              if ((K_src(K) > min(tol_max(K), kappa_src(K) + Idtt*tol_chg(K))) .or. &
+                  (K_src(K) < max(tol_min(K), kappa_src(K) - Idtt*tol_chg(K)))) then
+                valid_dt = .false. ; exit
+              endif
+            else
+              if ((K_src(K) > max(tol_max(K), kappa_src(K) + Idtt*tol_chg(K))) .or. &
+                  (K_src(K) < min(tol_min(K), kappa_src(K) - Idtt*tol_chg(K)))) then
+                valid_dt = .false. ; exit
+              endif
             endif
           else
             if (0.0 < min(tol_min(K), kappa_src(K) - Idtt*tol_chg(K))) then
@@ -1915,6 +1926,10 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
                  "TKE when there is mass in all layers.  Otherwise always report the time "//&
                  "averaged TKE, as is currently done when there are some massless layers.", &
                  default=.false., do_not_log=just_read)
+  call get_param(param_file, mdl, "USE_RESTRICTIVE_TOLERANCE_CHECK", CS%restrictive_tolerance_check, &
+                 "If true, uses the more restrictive tolerance check to determine if a timestep "//&
+                 "is acceptable for the KS_it outer iteration loop.  False uses the original less "//&
+                 "restrictive check.", default=.false., do_not_log=just_read)
 !    id_clock_KQ = cpu_clock_id('Ocean KS kappa_shear', grain=CLOCK_ROUTINE)
 !    id_clock_avg = cpu_clock_id('Ocean KS avg', grain=CLOCK_ROUTINE)
 !    id_clock_project = cpu_clock_id('Ocean KS project', grain=CLOCK_ROUTINE)

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -903,7 +903,7 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, &
     ! Determine how long to use this value of kappa (dt_now).
 
   ! call cpu_clock_begin(id_clock_project)
-    if ((ke_kappa < ks_kappa) .or. (itt==CS%max_RiNo_it)) then
+    if ((ke_kappa < ks_kappa) .or. (itt==CS%max_KS_it)) then
       dt_now = dt_rem
     else
       ! Limit dt_now so that |k_src(k)-kappa_src(k)| < tol * local_src(k)


### PR DESCRIPTION
Add an option to use the more restrictive tolerance check in place of the less restrictive tolerance check in MOM_kappa_shear and fix an iteration max criteria check.

- The new option (USE_RESTRICTIVE_TOLERANCE_CHECK) defaults to False to maintain the original JHL tolerance check.  Setting it True uses the more restrictive option, which appears to improve the scheme stability.
- Fix for itt number criteria check that should have been max_KS_it but was max_RiNo_it

The first will not change answers by default.  The second could potentially change answers, but only if the iteration count ever hits the cap max_KS_it.  It does not hit the cap default of 13 with USE_RESTRICTIVE_TOLERANCE_CHECK=False in the global_ALE test cases, and therefore it does not change answers in any of these cases.