### PR TITLE
(*)Add a halo update to fix VERTEX_SHEAR solutions

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1250,10 +1250,13 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     call apply_oda_tracer_increments(US%T_to_s*dtdia,G,tv,h,CS%odaCS)
   endif
 
-  if (associated(fluxes%p_surf)) then
+  if (associated(fluxes%p_surf) .or. associated(fluxes%p_surf_full)) then
     call extract_diabatic_member(CS%diabatic_CSp, diabatic_halo=halo_sz)
     if (halo_sz > 0) then
-      call pass_var(fluxes%p_surf, G%Domain, clock=id_clock_pass, halo=halo_sz)
+      if (associated(fluxes%p_surf_full)) &
+        call pass_var(fluxes%p_surf_full, G%Domain, &
+                      clock=id_clock_pass, halo=halo_sz, complete=.not.associated(fluxes%p_surf))
+      call pass_var(fluxes%p_surf, G%Domain, clock=id_clock_pass, halo=halo_sz, complete=.true.)
     endif
   endif
 


### PR DESCRIPTION
  Added halo update for fluxes%p_surf_full when VERTEX_SHEAR=true.  This field
is not used directly with the vertex shear code, but its halo regions are used
in the frazil code when the diabatic solver is using slightly wider halos to
work with the VERTEX_SHEAR option for shear mixing.  Without this change, some
cases using VERTEX_SHEAR=True were not reproducing across PE layout, whereas now
they do.  There is no flag to recover the old answers because the old answers
were ill-defined.  All answers in the MOM6-examples test suite are bitwise
identical but there will be answer changes in some ice-ocean or coupled cases
with VERTEX_SHEAR=True; these cases should now reproduce across PE layouts.

  This PR should help address MOM6 Issue #850.