### PR TITLE
Change bounding of Kv_BBL and bbl_thick in set_viscous_BBL()

### DIFF
--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -63,7 +63,7 @@ type, public :: set_visc_CS ; private
   logical :: bottomdraglaw  !< If true, the  bottom stress is calculated with a
                             !! drag law c_drag*|u|*u. The velocity magnitude
                             !! may be an assumed value or it may be based on the
-                            !! actual velocity in the bottom most `HBBL`, depending
+                            !! actual velocity in the bottommost `HBBL`, depending
                             !! on whether linear_drag is true.
                             !! Runtime parameter `BOTTOMDRAGLAW`.
   logical :: BBL_use_EOS    !< If true, use the equation of state in determining
@@ -584,7 +584,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, symmetrize)
     endif ; endif
 
     if (use_BBL_EOS .or. .not.CS%linear_drag) then
-      ! Calculate the mean velocity magnitude over the bottom most CS%Hbbl of
+      ! Calculate the mean velocity magnitude over the bottommost CS%Hbbl of
       ! the water column for determining the quadratic bottom drag.
       ! Used in ustar(i)
       do i=is,ie ; if (do_i(i)) then
@@ -804,7 +804,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, symmetrize)
       if ((bbl_thick > 0.5*CS%Hbbl) .and. (CS%RiNo_mix)) bbl_thick = 0.5*CS%Hbbl
 
       if (CS%Channel_drag) then
-        ! The drag within the bottom most bbl_thick is applied as a part of
+        ! The drag within the bottommost bbl_thick is applied as a part of
         ! an enhanced bottom viscosity, while above this the drag is applied
         ! directly to the layers in question as a Rayleigh drag term.
         if (m==1) then

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -122,7 +122,7 @@ type, public :: vertvisc_CS ; private
   !>@{ Diagnostic identifiers
   integer :: id_du_dt_visc = -1, id_dv_dt_visc = -1, id_au_vv = -1, id_av_vv = -1
   integer :: id_h_u = -1, id_h_v = -1, id_hML_u = -1 , id_hML_v = -1
-  integer :: id_Ray_u = -1, id_Ray_v = -1, id_taux_bot = -1, id_tauy_bot = -1
+  integer :: id_taux_bot = -1, id_tauy_bot = -1
   integer :: id_Kv_slow = -1, id_Kv_u = -1, id_Kv_v = -1
   ! integer :: id_hf_du_dt_visc    = -1, id_hf_dv_dt_visc    = -1
   integer :: id_hf_du_dt_visc_2d = -1, id_hf_dv_dt_visc_2d = -1


### PR DESCRIPTION
The majority of this PR is new documentation, in the form of both code comments and equations in doxygen-generated material, with a small but optionally answer changing fix in the last commit.

- The BBL viscosity used to be simply bounded to be no less than a minimum, KV_BBL_MIN. In some limits where the BBL thickness was smaller than the bottom layer thickness, this viscosity led to too much drag on the bottom layer.
- If CORRECT_BBL_BOUNDS=True we now also adjust bbl_thick when bounding Kv_bbl so that the implied stress, viscosity and thickness are all consistent.
- By default, CORRECT_BBL_BOUNDS=False so that existing answers are unchanged.
- This introduces a new run-time parameter so changes the doc strings in MOM-examples.

First commit:
- Added lots of comments explaining method/equations
- Small refactor of code to reduce duplicated code a smidgen but really in preparation for a solution-changing fix coming later
- Also removed unused diagnostic ids in MOM_vert_friction.F90

Second commit:
- Wrote out equations being solve with reference to model parameters. Includes references.

Third commit:
- Switched to non-English spelling of bottom-most

Fourth commit:
- The actual code correction.