### PR TITLE
+Cleanup MOM_set_diffusivity and MOM_geothermal

### DIFF
--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -143,22 +143,22 @@ subroutine compute_ddiff_coeffs(h, tv, G, GV, US, j, Kd_T, Kd_S, CS, R_rho)
 
   type(ocean_grid_type),                      intent(in)    :: G    !< Grid structure.
   type(verticalGrid_type),                    intent(in)    :: GV   !< Vertical grid structure.
-  type(unit_scale_type),                      intent(in)    :: US   !< A dimensional unit scaling type
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: h    !< Layer thickness [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h    !< Layer thickness [H ~> m or kg m-2].
   type(thermo_var_ptrs),                      intent(in)    :: tv   !< Thermodynamics structure.
+  type(unit_scale_type),                      intent(in)    :: US   !< A dimensional unit scaling type
+  integer,                                    intent(in)    :: j    !< Meridional grid index to work on.
   ! Kd_T and Kd_S are intent inout because only one j-row is set here, but they are essentially outputs.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: Kd_T !< Interface double diffusion diapycnal
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: Kd_T !< Interface double diffusion diapycnal
                                                                     !! diffusivity for temp [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: Kd_S !< Interface double diffusion diapycnal
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: Kd_S !< Interface double diffusion diapycnal
                                                                     !! diffusivity for salt [Z2 T-1 ~> m2 s-1].
   type(CVMix_ddiff_cs),                       pointer       :: CS   !< The control structure returned
                                                                     !! by a previous call to CVMix_ddiff_init.
-  integer,                                    intent(in)    :: j    !< Meridional grid index to work on.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
                                     optional, intent(inout) :: R_rho !< The density ratios at interfaces [nondim].
 
   ! Local variables
-  real, dimension(SZK_(G)) :: &
+  real, dimension(SZK_(GV)) :: &
     cellHeight, &  !< Height of cell centers [m]
     dRho_dT,    &  !< partial derivatives of density wrt temp [R degC-1 ~> kg m-3 degC-1]
     dRho_dS,    &  !< partial derivatives of density wrt saln [R ppt-1 ~> kg m-3 ppt-1]
@@ -169,11 +169,11 @@ subroutine compute_ddiff_coeffs(h, tv, G, GV, US, j, Kd_T, Kd_S, CS, R_rho)
     beta_dS,    &  !< beta*dS across interfaces [kg m-3]
     dT,         &  !< temp. difference between adjacent layers [degC]
     dS             !< salt difference between adjacent layers [ppt]
-  real, dimension(SZK_(G)+1) :: &
+  real, dimension(SZK_(GV)+1) :: &
     Kd1_T,      &  !< Diapycanal diffusivity of temperature [m2 s-1].
     Kd1_S          !< Diapycanal diffusivity of salinity [m2 s-1].
 
-  real, dimension(SZK_(G)+1) :: iFaceHeight !< Height of interfaces [m]
+  real, dimension(SZK_(GV)+1) :: iFaceHeight !< Height of interfaces [m]
   integer :: kOBL                        !< level of OBL extent
   real :: dh, hcorr
   integer :: i, k

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -23,7 +23,7 @@ implicit none ; private
 public CVMix_ddiff_init, CVMix_ddiff_end, CVMix_ddiff_is_used, compute_ddiff_coeffs
 
 !> Control structure including parameters for CVMix double diffusion.
-type, public :: CVMix_ddiff_cs
+type, public :: CVMix_ddiff_cs ; private
 
   ! Parameters
   real    :: strat_param_max !< maximum value for the stratification parameter [nondim]
@@ -39,17 +39,6 @@ type, public :: CVMix_ddiff_cs
   character(len=4) :: diff_conv_type !< type of diffusive convection to use. Options are Marmorino &
                                 !! Caldwell 1976 ("MC76"; default) and Kelley 1988, 1990 ("K90")
   logical :: debug              !< If true, turn on debugging
-
-  ! Daignostic handles and pointers
-  type(diag_ctrl), pointer :: diag => NULL() !< Pointer to diagnostics control structure
-  !>@{ Diagnostics handles
-  integer :: id_KT_extra = -1, id_KS_extra = -1, id_R_rho = -1
-  !>@}
-
-  ! Diagnostics arrays
-!  real, allocatable, dimension(:,:,:) :: KT_extra  !< Double diffusion diffusivity for temp [Z2 s-1 ~> m2 s-1]
-!  real, allocatable, dimension(:,:,:) :: KS_extra  !< Double diffusion diffusivity for salt [Z2 s-1 ~> m2 s-1]
-  real, allocatable, dimension(:,:,:) :: R_rho     !< Double-diffusion density ratio [nondim]
 
 end type CVMix_ddiff_cs
 
@@ -136,23 +125,6 @@ logical function CVMix_ddiff_init(Time, G, GV, US, param_file, diag, CS)
 
   call closeParameterBlock(param_file)
 
-  ! Register diagnostics
-  CS%diag => diag
-
-  CS%id_KT_extra = register_diag_field('ocean_model','KT_extra',diag%axesTi,Time, &
-         'Double-diffusive diffusivity for temperature', 'm2 s-1', conversion=US%Z2_T_to_m2_s)
-
-  CS%id_KS_extra = register_diag_field('ocean_model','KS_extra',diag%axesTi,Time, &
-         'Double-diffusive diffusivity for salinity', 'm2 s-1', conversion=US%Z2_T_to_m2_s)
-
-  CS%id_R_rho = register_diag_field('ocean_model','R_rho',diag%axesTi,Time, &
-         'Double-diffusion density ratio', 'nondim')
-
-  if (CS%id_R_rho > 0) then
-     allocate(CS%R_rho( SZI_(G), SZJ_(G), SZK_(G)+1))
-     CS%R_rho(:,:,:) = 0.0
-  endif
-
   call cvmix_init_ddiff(strat_param_max=CS%strat_param_max,          &
                         kappa_ddiff_s=CS%kappa_ddiff_s,           &
                         ddiff_exp1=CS%ddiff_exp1,                 &
@@ -167,20 +139,24 @@ end function CVMix_ddiff_init
 
 !> Subroutine for computing vertical diffusion coefficients for the
 !! double diffusion mixing parameterization.
-subroutine compute_ddiff_coeffs(h, tv, G, GV, US, j, Kd_T, Kd_S, CS)
+subroutine compute_ddiff_coeffs(h, tv, G, GV, US, j, Kd_T, Kd_S, CS, R_rho)
 
-  type(ocean_grid_type),                      intent(in)  :: G    !< Grid structure.
-  type(verticalGrid_type),                    intent(in)  :: GV   !< Vertical grid structure.
-  type(unit_scale_type),                      intent(in)  :: US   !< A dimensional unit scaling type
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)  :: h    !< Layer thickness [H ~> m or kg m-2].
-  type(thermo_var_ptrs),                      intent(in)  :: tv   !< Thermodynamics structure.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(out) :: Kd_T !< Interface double diffusion diapycnal
-                                                                  !! diffusivity for temp [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(out) :: Kd_S !< Interface double diffusion diapycnal
-                                                                  !! diffusivity for salt [Z2 T-1 ~> m2 s-1].
-  type(CVMix_ddiff_cs),                       pointer     :: CS   !< The control structure returned
-                                                                  !! by a previous call to CVMix_ddiff_init.
-  integer,                                    intent(in)  :: j    !< Meridional grid indice.
+  type(ocean_grid_type),                      intent(in)    :: G    !< Grid structure.
+  type(verticalGrid_type),                    intent(in)    :: GV   !< Vertical grid structure.
+  type(unit_scale_type),                      intent(in)    :: US   !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)),   intent(in)    :: h    !< Layer thickness [H ~> m or kg m-2].
+  type(thermo_var_ptrs),                      intent(in)    :: tv   !< Thermodynamics structure.
+  ! Kd_T and Kd_S are intent inout because only one j-row is set here, but they are essentially outputs.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: Kd_T !< Interface double diffusion diapycnal
+                                                                    !! diffusivity for temp [Z2 T-1 ~> m2 s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: Kd_S !< Interface double diffusion diapycnal
+                                                                    !! diffusivity for salt [Z2 T-1 ~> m2 s-1].
+  type(CVMix_ddiff_cs),                       pointer       :: CS   !< The control structure returned
+                                                                    !! by a previous call to CVMix_ddiff_init.
+  integer,                                    intent(in)    :: j    !< Meridional grid index to work on.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
+                                    optional, intent(inout) :: R_rho !< The density ratios at interfaces [nondim].
+
   ! Local variables
   real, dimension(SZK_(G)) :: &
     cellHeight, &  !< Height of cell centers [m]
@@ -246,11 +222,12 @@ subroutine compute_ddiff_coeffs(h, tv, G, GV, US, j, Kd_T, Kd_S, CS)
       beta_dS(k)  = US%R_to_kg_m3*drho_dS(k) * dS(k)
     enddo
 
-    if (CS%id_R_rho > 0.0)  then
+    if (present(R_rho))  then
       do k=1,G%ke
-        CS%R_rho(i,j,k) = alpha_dT(k)/beta_dS(k)
-        ! avoid NaN's
-        if(CS%R_rho(i,j,k) /= CS%R_rho(i,j,k)) CS%R_rho(i,j,k) = 0.0
+        ! Set R_rho using Adcroft's rule of reciprocals.
+        R_rho(i,j,k) = 0.0 ; if (abs(beta_dS(k)) > 0.0) R_rho(i,j,k) = alpha_dT(k) / beta_dS(k)
+        ! avoid NaN's again for safety, perhaps unnecessarily.
+        if (R_rho(i,j,k) /= R_rho(i,j,k)) R_rho(i,j,k) = 0.0
       enddo
     endif
 

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -298,29 +298,29 @@ end subroutine bkgnd_mixing_init
 !> Calculates the vertical background diffusivities/viscosities
 subroutine calculate_bkgnd_mixing(h, tv, N2_lay, Kd_lay, Kd_int, Kv_bkgnd, j, G, GV, US, CS)
 
-  type(ocean_grid_type),                    intent(in)    :: G   !< Grid structure.
-  type(verticalGrid_type),                  intent(in)    :: GV  !< Vertical grid structure.
-  type(unit_scale_type),                    intent(in)    :: US  !< A dimensional unit scaling type
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
-  type(thermo_var_ptrs),                    intent(in)    :: tv  !< Thermodynamics structure.
-  real, dimension(SZI_(G),SZK_(G)),         intent(in)    :: N2_lay !< squared buoyancy frequency associated
-                                                                 !! with layers [T-2 ~> s-2]
-  real, dimension(SZI_(G),SZK_(G)),         intent(out)   :: Kd_lay !< The background diapycnal diffusivity
-                                                                 !! of each layer [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZK_(G)+1),       intent(out)   :: Kd_int !< The background diapycnal diffusivity
-                                                                 !! of each interface [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZK_(G)+1),       intent(out)   :: Kv_bkgnd !< The background vertical viscosity at
-                                                                 !! each interface [Z2 T-1 ~> m2 s-1]
-  integer,                                  intent(in)    :: j   !< MKeridional grid index
-  type(bkgnd_mixing_cs),                    pointer       :: CS  !< The control structure returned by
-                                                                 !! a previous call to bkgnd_mixing_init.
+  type(ocean_grid_type),                     intent(in)    :: G   !< Grid structure.
+  type(verticalGrid_type),                   intent(in)    :: GV  !< Vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
+  type(thermo_var_ptrs),                     intent(in)    :: tv  !< Thermodynamics structure.
+  real, dimension(SZI_(G),SZK_(GV)),         intent(in)    :: N2_lay !< squared buoyancy frequency associated
+                                                                  !! with layers [T-2 ~> s-2]
+  real, dimension(SZI_(G),SZK_(GV)),         intent(out)   :: Kd_lay !< The background diapycnal diffusivity
+                                                                  !! of each layer [Z2 T-1 ~> m2 s-1].
+  real, dimension(SZI_(G),SZK_(GV)+1),       intent(out)   :: Kd_int !< The background diapycnal diffusivity
+                                                                  !! of each interface [Z2 T-1 ~> m2 s-1].
+  real, dimension(SZI_(G),SZK_(GV)+1),       intent(out)   :: Kv_bkgnd !< The background vertical viscosity at
+                                                                  !! each interface [Z2 T-1 ~> m2 s-1]
+  integer,                                   intent(in)    :: j   !< Meridional grid index
+  type(unit_scale_type),                     intent(in)    :: US  !< A dimensional unit scaling type
+  type(bkgnd_mixing_cs),                     pointer       :: CS  !< The control structure returned by
+                                                                  !! a previous call to bkgnd_mixing_init.
 
   ! local variables
-  real, dimension(SZK_(G)+1) :: depth_int  !< Distance from surface of the interfaces [m]
-  real, dimension(SZK_(G)+1) :: Kd_col     !< Diffusivities at the interfaces [m2 s-1]
-  real, dimension(SZK_(G)+1) :: Kv_col     !< Viscosities at the interfaces [m2 s-1]
-  real, dimension(SZI_(G))   :: Kd_sfc     !< Surface value of the diffusivity [Z2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G))   :: depth      !< Distance from surface of an interface [Z ~> m]
+  real, dimension(SZK_(GV)+1) :: depth_int  !< Distance from surface of the interfaces [m]
+  real, dimension(SZK_(GV)+1) :: Kd_col     !< Diffusivities at the interfaces [m2 s-1]
+  real, dimension(SZK_(GV)+1) :: Kv_col     !< Viscosities at the interfaces [m2 s-1]
+  real, dimension(SZI_(G))    :: Kd_sfc     !< Surface value of the diffusivity [Z2 T-1 ~> m2 s-1]
+  real, dimension(SZI_(G))    :: depth      !< Distance from surface of an interface [Z ~> m]
   real :: depth_c    !< depth of the center of a layer [Z ~> m]
   real :: I_Hmix     !< inverse of fixed mixed layer thickness [Z-1 ~> m-1]
   real :: I_2Omega   !< 1/(2 Omega) [T ~> s]

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -39,7 +39,8 @@ use MOM_error_handler,       only : callTree_enter, callTree_leave, callTree_way
 use MOM_file_parser,         only : get_param, log_version, param_file_type, read_param
 use MOM_forcing_type,        only : forcing, MOM_forcing_chksum
 use MOM_forcing_type,        only : calculateBuoyancyFlux2d, forcing_SinglePointPrint
-use MOM_geothermal,          only : geothermal, geothermal_init, geothermal_end, geothermal_CS
+use MOM_geothermal,          only : geothermal_entraining, geothermal_in_place
+use MOM_geothermal,          only : geothermal_init, geothermal_end, geothermal_CS
 use MOM_grid,                only : ocean_grid_type
 use MOM_int_tide_input,      only : set_int_tide_input, int_tide_input_init
 use MOM_int_tide_input,      only : int_tide_input_end, int_tide_input_CS, int_tide_input_type
@@ -563,7 +564,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
 
   if (CS%use_geothermal) then
     call cpu_clock_begin(id_clock_geothermal)
-    call geothermal(h, tv, dt, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
+    call geothermal_in_place(h, tv, dt, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
     call cpu_clock_end(id_clock_geothermal)
     if (showCallTree) call callTree_waypoint("geothermal (diabatic)")
     if (CS%debugConservation) call MOM_state_stats('geothermal', u, v, h, tv%T, tv%S, G, GV, US)
@@ -1283,7 +1284,7 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
 
   if (CS%use_geothermal) then
     call cpu_clock_begin(id_clock_geothermal)
-    call geothermal(h, tv, dt, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
+    call geothermal_in_place(h, tv, dt, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
     call cpu_clock_end(id_clock_geothermal)
     if (showCallTree) call callTree_waypoint("geothermal (diabatic)")
     if (CS%debugConservation) call MOM_state_stats('geothermal', u, v, h, tv%T, tv%S, G, GV, US)
@@ -1990,7 +1991,7 @@ subroutine layered_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_e
 
   if (CS%use_geothermal) then
     call cpu_clock_begin(id_clock_geothermal)
-    call geothermal(h, tv, dt, eaml, ebml, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
+    call geothermal_entraining(h, tv, dt, eaml, ebml, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
     call cpu_clock_end(id_clock_geothermal)
     if (showCallTree) call callTree_waypoint("geothermal (diabatic)")
     if (CS%debugConservation) call MOM_state_stats('geothermal', u, v, h, tv%T, tv%S, G, GV, US)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -570,7 +570,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
     enddo ; enddo ; enddo
 
     call cpu_clock_begin(id_clock_geothermal)
-    call geothermal(h, tv, dt, eatr, ebtr, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
+    call geothermal(h, tv, dt, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
     call cpu_clock_end(id_clock_geothermal)
     if (showCallTree) call callTree_waypoint("geothermal (diabatic)")
     if (CS%debugConservation) call MOM_state_stats('geothermal', u, v, h, tv%T, tv%S, G, GV, US)
@@ -1301,7 +1301,7 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
     enddo ; enddo ; enddo
 
     call cpu_clock_begin(id_clock_geothermal)
-    call geothermal(h, tv, dt, eatr, ebtr, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
+    call geothermal(h, tv, dt, G, GV, US, CS%geothermal_CSp, halo=CS%halo_TS_diff)
     call cpu_clock_end(id_clock_geothermal)
     if (showCallTree) call callTree_waypoint("geothermal (diabatic)")
     if (CS%debugConservation) call MOM_state_stats('geothermal', u, v, h, tv%T, tv%S, G, GV, US)

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -42,6 +42,13 @@ type, public :: geothermal_CS ; private
 
 end type geothermal_CS
 
+!> Apply geothermal heating to the bottommost part of the water column, either by directly
+!! heating water in place, or by also including the movement of water between isopycal layers,
+!! depending on which arguments that are supplied.
+interface geothermal
+  module procedure geothermal_in_place, isopycnal_geothermal
+end interface geothermal
+
 contains
 
 !> Applies geothermal heating, including the movement of water
@@ -50,7 +57,7 @@ contains
 !! the partial derivative of the coordinate density with temperature is positive
 !! or very small, the layers are simply heated in place.  Any heat that can not
 !! be applied to the ocean is returned (WHERE)?
-subroutine geothermal(h, tv, dt, ea, eb, G, GV, US, CS, halo)
+subroutine isopycnal_geothermal(h, tv, dt, ea, eb, G, GV, US, CS, halo)
   type(ocean_grid_type),                    intent(inout) :: G  !< The ocean's grid structure.
   type(verticalGrid_type),                  intent(in)    :: GV !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(inout) :: h  !< Layer thicknesses [H ~> m or kg m-2]
@@ -120,7 +127,7 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, US, CS, halo)
   logical :: do_i(SZI_(G))
   logical :: compute_h_old, compute_T_old
   integer :: i, j, k, is, ie, js, je, nz, k2, i2
-  integer :: isj, iej, num_start, num_left, nkmb, k_tgt
+  integer :: isj, iej, num_left, nkmb, k_tgt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
   if (present(halo)) then
@@ -157,11 +164,11 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, US, CS, halo)
   if (compute_h_old) h_old(:,:,:) = 0.0
   if (compute_T_old) T_old(:,:,:) = 0.0
 
-!$OMP parallel do default(none) shared(is,ie,js,je,G,GV,US,CS,dt,Irho_cp,nkmb,tv,    &
+!$OMP parallel do default(none) shared(is,ie,js,je,G,GV,US,CS,dt,Irho_cp,nkmb,tv, &
 !$OMP                                  p_Ref,h,Angstrom,nz,H_neglect,eb,          &
 !$OMP                                  compute_h_old,compute_T_old,h_old,T_old,   &
 !$OMP                                  work_3d,Idt)                               &
-!$OMP                          private(num_start,heat_rem,do_i,h_geo_rem,num_left,&
+!$OMP                          private(heat_rem,do_i,h_geo_rem,num_left, &
 !$OMP                                  isj,iej,Rcv_BL,h_heated,heat_avail,k_tgt,  &
 !$OMP                                  Rcv_tgt,Rcv,dRcv_dT,T2,S2,dRcv_dT_,        &
 !$OMP                                  dRcv_dS_,heat_in_place,heat_trans,         &
@@ -183,15 +190,14 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, US, CS, halo)
     ! 6. If there is not enough mass in the ocean, pass some of the heat up
     !    from the ocean via the frazil field?
 
-    num_start = 0
+    num_left = 0
     do i=is,ie
       heat_rem(i) = G%mask2dT(i,j) * (CS%geo_heat(i,j) * (dt*Irho_cp))
       do_i(i) = .true. ; if (heat_rem(i) <= 0.0) do_i(i) = .false.
-      if (do_i(i)) num_start = num_start + 1
+      if (do_i(i)) num_left = num_left + 1
       h_geo_rem(i) = CS%Geothermal_thick
     enddo
-    if (num_start == 0) cycle
-    num_left = num_start
+    if (num_left == 0) cycle
 
     ! Find the first and last columns that need to be worked on.
     isj = ie+1 ; do i=is,ie ; if (do_i(i)) then ; isj = i ; exit ; endif ; enddo
@@ -322,16 +328,12 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, US, CS, halo)
           if (heat_rem(i) <= 0.0) then
             do_i(i) = .false. ; num_left = num_left-1
             ! For efficiency, uncomment these?
-            ! if ((i==isj) .and. (num_left > 0)) then
-            !   do i2=isj+1,iej ; if (do_i(i2)) then
-            !     isj = i2 ; exit ! Set the new starting value.
-            !   endif ; enddo
-            ! endif
-            ! if ((i==iej) .and. (num_left > 0)) then
-            !   do i2=iej-1,isj,-1 ; if (do_i(i2)) then
-            !     iej = i2 ; exit ! Set the new ending value.
-            !   endif ; enddo
-            ! endif
+            ! if ((i==isj) .and. (num_left > 0)) then ; do i2=isj+1,iej ; if (do_i(i2)) then
+            !   isj = i2 ; exit ! Set the new starting value.
+            ! endif ; enddo ; endif
+            ! if ((i==iej) .and. (num_left > 0)) then ; do i2=iej-1,isj,-1 ; if (do_i(i2)) then
+            !   iej = i2 ; exit ! Set the new ending value.
+            ! endif ; enddo ; endif
           endif
         endif
 
@@ -372,7 +374,174 @@ subroutine geothermal(h, tv, dt, ea, eb, G, GV, US, CS, halo)
 !           (G%mask2dT(i,j) * (CS%geo_heat(i,j) * (dt*Irho_cp)))
 !  enddo ; enddo
 
-end subroutine geothermal
+end subroutine isopycnal_geothermal
+
+!> Applies geothermal heating to the bottommost layers that occur within GEOTHERMAL_THICKNESS of
+!! the bottom, by simply heating the water in place.  Any heat that can not be applied to the ocean
+!! is returned (WHERE)?
+subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, halo)
+  type(ocean_grid_type),                    intent(inout) :: G  !< The ocean's grid structure.
+  type(verticalGrid_type),                  intent(in)    :: GV !< The ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), intent(in)    :: h  !< Layer thicknesses [H ~> m or kg m-2]
+  type(thermo_var_ptrs),                    intent(inout) :: tv !< A structure containing pointers
+                                                                !! to any available thermodynamic
+                                                                !! fields. Absent fields have NULL
+                                                                !! ptrs.
+  real,                                     intent(in)    :: dt !< Time increment [T ~> s].
+  type(unit_scale_type),                    intent(in)    :: US !< A dimensional unit scaling type
+  type(geothermal_CS),                      pointer       :: CS !< The control structure returned by
+                                                                !! a previous call to
+                                                                !! geothermal_init.
+  integer,                        optional, intent(in)    :: halo !< Halo width over which to work
+
+  ! Local variables
+  real, dimension(SZI_(G)) :: &
+    heat_rem,  & ! remaining heat [H degC ~> m degC or kg degC m-2]
+    h_geo_rem    ! remaining thickness to apply geothermal heating [H ~> m or kg m-2]
+
+
+  real :: Angstrom, H_neglect  ! small thicknesses [H ~> m or kg m-2]
+  real :: h_heated      ! thickness that is being heated [H ~> m or kg m-2]
+  real :: heat_avail    ! heating available for the present layer [degC H ~> degC m or degC kg m-2]
+  real :: dTemp         ! temperature increase in a layer [degC]
+  real :: Irho_cp       ! inverse of heat capacity per unit layer volume
+                        ! [degC H Q-1 R-1 Z-1 ~> degC m3 J-1 or degC kg J-1]
+
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: T_old   ! Temperature of each layer
+                                                      ! before any heat is added,
+                                                      ! for diagnostics [degC]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: work_3d ! Scratch variable used to
+                                                      ! calculate change in heat
+                                                      ! due to geothermal
+  real :: Idt           ! inverse of the timestep [T-1 ~> s-1]
+
+  logical :: do_i(SZI_(G))
+  logical :: compute_T_old
+  integer :: i, j, k, is, ie, js, je, nz, i2, isj, iej, num_left
+
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = G%ke
+  if (present(halo)) then
+    is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
+  endif
+
+  if (.not. associated(CS)) call MOM_error(FATAL, "MOM_geothermal: "//&
+         "Module must be initialized before it is used.")
+  if (.not.CS%apply_geothermal) return
+
+  Irho_cp   = 1.0 / (GV%H_to_RZ * tv%C_p)
+  Angstrom  = GV%Angstrom_H
+  H_neglect = GV%H_subroundoff
+  Idt       = 1.0 / dt
+
+  if (.not.associated(tv%T)) call MOM_error(FATAL, "MOM geothermal: "//&
+      "Geothermal heating can only be applied if T & S are state variables.")
+
+!  do i=is,ie ; do j=js,je
+!    resid(i,j) = tv%internal_heat(i,j)
+!  enddo ; enddo
+
+  ! Conditionals for tracking diagnostic depdendencies
+  compute_T_old = (CS%id_internal_heat_heat_tendency > 0) .or. (CS%id_internal_heat_temp_tendency > 0)
+
+  if (CS%id_internal_heat_heat_tendency > 0) work_3d(:,:,:) = 0.0
+  if (compute_T_old) T_old(:,:,:) = 0.0
+
+  !$OMP parallel do default(none) shared(is,ie,js,je,G,GV,US,CS,dt,Irho_cp,tv,h,Angstrom,&
+  !$OMP                                  nz,H_neglect,compute_T_old,T_old,work_3d,Idt) &
+  !$OMP                          private(heat_rem,do_i,h_geo_rem,num_left,&
+  !$OMP                                  isj,iej,h_heated,heat_avail,dTemp)
+  do j=js,je
+    ! Only work on columns that are being heated, and heat the near-bottom water.
+
+    ! If there is not enough mass in the ocean, pass some of the heat up
+    ! from the ocean via the frazil field?
+
+    num_left = 0
+    do i=is,ie
+      heat_rem(i) = G%mask2dT(i,j) * (CS%geo_heat(i,j) * (dt*Irho_cp))
+      do_i(i) = (heat_rem(i) > 0.0)
+      if (do_i(i)) num_left = num_left + 1
+      h_geo_rem(i) = CS%Geothermal_thick
+    enddo
+    if (num_left == 0) cycle
+
+    ! Find the first and last columns that need to be worked on.
+    isj = ie+1 ; do i=is,ie ; if (do_i(i)) then ; isj = i ; exit ; endif ; enddo
+    iej = is-1 ; do i=ie,is,-1 ; if (do_i(i)) then ; iej = i ; exit ; endif ; enddo
+
+    do k=nz,1,-1
+      do i=isj,iej ; if (do_i(i)) then
+
+        ! Save temperature and thickness before any changes are made (for diagnostic)
+        if (compute_T_old) then
+          T_old(i,j,k) = tv%T(i,j,k)
+        endif
+
+        if (h(i,j,k) > Angstrom) then
+          ! Simply heat the layer; convective adjustment occurs later if necessary.
+          if ((h(i,j,k)-Angstrom) >= h_geo_rem(i)) then
+            h_heated = h_geo_rem(i)
+            heat_avail = heat_rem(i)
+            h_geo_rem(i) = 0.0
+            heat_rem(i) = 0.0
+          else
+            h_heated = (h(i,j,k)-Angstrom)
+            heat_avail = heat_rem(i) * (h_heated / (h_geo_rem(i) + H_neglect))
+            h_geo_rem(i) = h_geo_rem(i) - h_heated
+            heat_rem(i) = heat_rem(i) - heat_avail
+          endif
+
+          if (heat_avail > 0.0) then
+            dTemp = heat_avail / (h(i,j,k) + H_neglect)
+            tv%T(i,j,k) = tv%T(i,j,k) + dTemp
+          endif
+
+          if (heat_rem(i) <= 0.0) then
+            do_i(i) = .false. ; num_left = num_left-1
+            ! For efficiency, uncomment these?
+            ! if ((i==isj) .and. (num_left > 0)) then ; do i2=isj+1,iej ; if (do_i(i2)) then
+            !   isj = i2 ; exit ! Set the new starting value.
+            ! endif ; enddo ; endif
+            ! if ((i==iej) .and. (num_left > 0)) then ; do i2=iej-1,isj,-1 ; if (do_i(i2)) then
+            !   iej = i2 ; exit ! Set the new ending value.
+            ! endif ; enddo ; endif
+          endif
+        endif
+
+        !### In this case, calculate dTemp_dT first, then heating for efficiency, but diagnostics
+        !    will be changed at roundoff.
+        ! Calculate heat tendency due to addition and transfer of internal heat
+        if (CS%id_internal_heat_heat_tendency > 0) then
+          work_3d(i,j,k) = ((GV%H_to_RZ*tv%C_p) * Idt) * (h(i,j,k) * tv%T(i,j,k) - h(i,j,k) * T_old(i,j,k))
+        endif
+
+      endif ; enddo
+      if (num_left <= 0) exit
+    enddo ! k-loop
+
+    if (associated(tv%internal_heat)) then ; do i=is,ie
+      tv%internal_heat(i,j) = tv%internal_heat(i,j) + GV%H_to_RZ * &
+           (G%mask2dT(i,j) * (CS%geo_heat(i,j) * (dt*Irho_cp)) - heat_rem(i))
+    enddo ; endif
+  enddo ! j-loop
+
+  ! Post diagnostic of 3D tendencies (heat, temperature, and thickness) due to internal heat
+  if (CS%id_internal_heat_heat_tendency > 0) then
+    call post_data(CS%id_internal_heat_heat_tendency, work_3d, CS%diag, alt_h=h)
+  endif
+  if (CS%id_internal_heat_temp_tendency > 0) then
+    do j=js,je; do i=is,ie; do k=nz,1,-1
+      work_3d(i,j,k) = Idt * (tv%T(i,j,k) - T_old(i,j,k))
+    enddo; enddo; enddo
+    call post_data(CS%id_internal_heat_temp_tendency, work_3d, CS%diag, alt_h=h)
+  endif
+
+!  do i=is,ie ; do j=js,je
+!    resid(i,j) = tv%internal_heat(i,j) - resid(i,j) - GV%H_to_RZ * &
+!           (G%mask2dT(i,j) * (CS%geo_heat(i,j) * (dt*Irho_cp)))
+!  enddo ; enddo
+
+end subroutine geothermal_in_place
 
 !> Initialize parameters and allocate memory associated with the geothermal heating module.
 subroutine geothermal_init(Time, G, GV, US, param_file, diag, CS)
@@ -470,6 +639,7 @@ subroutine geothermal_init(Time, G, GV, US, param_file, diag, CS)
         'internal_heat_temp_tendency', diag%axesTL, Time,              &
         'Temperature tendency (in 3D) due to internal (geothermal) sources', &
         'degC s-1', conversion=US%s_to_T, v_extensive=.true.)
+!### Do not do this if heating will be in place.
   CS%id_internal_heat_h_tendency=register_diag_field('ocean_model',    &
         'internal_heat_h_tendency', diag%axesTL, Time,                &
         'Thickness tendency (in 3D) due to internal (geothermal) sources', &

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -32,6 +32,7 @@ public tidal_mixing_init
 public setup_tidal_diagnostics
 public calculate_tidal_mixing
 public post_tidal_diagnostics
+public tidal_mixing_h_amp
 public tidal_mixing_end
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
@@ -68,8 +69,7 @@ type, public :: tidal_mixing_diags ; private
 end type
 
 !> Control structure with parameters for the tidal mixing module.
-type, public :: tidal_mixing_cs
-  ! TODO: private
+type, public :: tidal_mixing_cs ; private
   logical :: debug = .true.   !< If true, do more extensive debugging checks.  This is hard-coded.
 
   ! Parameters
@@ -1557,6 +1557,24 @@ subroutine post_tidal_diagnostics(G, GV, h ,CS)
   if (associated(dd%tidal_qe_md)) deallocate(dd%tidal_qe_md)
 
 end subroutine post_tidal_diagnostics
+
+!> This subroutine returns a zonal slice of the topographic roughness amplitudes
+subroutine tidal_mixing_h_amp(h_amp, G, j, CS)
+  type(ocean_grid_type),    intent(in)  :: G     !< The ocean's grid structure
+  real, dimension(SZI_(G)), intent(out) :: h_amp !< The topographic roughness amplitude [Z ~> m]
+  integer,                  intent(in)  :: j     !< j-index of the row to work on
+  type(tidal_mixing_cs),    pointer     :: CS    !< The control structure for this module
+
+  integer :: i
+
+  h_amp(:) = 0.0
+  if ( CS%Int_tide_dissipation .and. .not. CS%use_CVMix_tidal ) then
+    do i=G%isc,G%iec
+      h_amp(i) = sqrt(CS%h2(i,j))
+    enddo
+  endif
+
+end subroutine tidal_mixing_h_amp
 
 ! TODO: move this subroutine to MOM_internal_tide_input module (?)
 !> This subroutine read tidal energy inputs from a file.

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -689,7 +689,7 @@ subroutine calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US, C
   real, dimension(SZI_(G),SZK_(G)), intent(in)    :: max_TKE !< The energy required to for a layer to entrain
                                                             !! to its maximum realizable thickness [Z3 T-3 ~> m3 s-3]
   type(tidal_mixing_cs),            pointer       :: CS     !< The control structure for this module
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+  real, dimension(SZI_(G),SZK_(G)), &
                           optional, intent(inout) :: Kd_lay !< The diapycnal diffusivity in layers [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
                           optional, intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces,
@@ -724,7 +724,7 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv
                                                   !! frequency at the interfaces [T-2 ~> s-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(in)    :: h     !< Layer thicknesses [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+  real, dimension(SZI_(G),SZK_(G)), &
                  optional, intent(inout) :: Kd_lay!< The diapycnal diffusivity in the layers [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
                  optional, intent(inout) :: Kd_int!< The diapycnal diffusivity at interfaces [Z2 T-1 ~> m2 s-1].
@@ -805,7 +805,7 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv
       ! Update diffusivity
       if (present(Kd_lay)) then
         do k=1,G%ke
-          Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
+          Kd_lay(i,k) = Kd_lay(i,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
         enddo
       endif
       if (present(Kd_int)) then
@@ -907,7 +907,7 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv
       ! Update diffusivity
       if (present(Kd_lay)) then
         do k=1,G%ke
-          Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
+          Kd_lay(i,k) = Kd_lay(i,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
         enddo
       endif
       if (present(Kd_int)) then
@@ -977,7 +977,7 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
   real, dimension(SZI_(G),SZK_(G)), intent(in)    :: max_TKE !< The energy required to for a layer to entrain
                                                             !! to its maximum realizable thickness [Z3 T-3 ~> m3 s-3]
   type(tidal_mixing_cs),            pointer       :: CS     !< The control structure for this module
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+  real, dimension(SZI_(G),SZK_(G)), &
                           optional, intent(inout) :: Kd_lay !< The diapycnal diffusivity in layers [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
                           optional, intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces
@@ -1262,7 +1262,7 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
 
       if (Kd_max >= 0.0) Kd_add = min(Kd_add, Kd_max)
       if (present(Kd_lay)) then
-        Kd_lay(i,j,k) = Kd_lay(i,j,k) + Kd_add
+        Kd_lay(i,k) = Kd_lay(i,k) + Kd_add
       endif
 
       if (present(Kd_int)) then
@@ -1359,7 +1359,7 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
 
       if (Kd_max >= 0.0) Kd_add = min(Kd_add, Kd_max)
       if (present(Kd_lay)) then
-        Kd_lay(i,j,k) = Kd_lay(i,j,k) + Kd_add
+        Kd_lay(i,k) = Kd_lay(i,k) + Kd_add
       endif
 
       if (present(Kd_int)) then

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -691,7 +691,7 @@ subroutine calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US, C
   type(tidal_mixing_cs),            pointer       :: CS     !< The control structure for this module
   real, dimension(SZI_(G),SZK_(G)), &
                           optional, intent(inout) :: Kd_lay !< The diapycnal diffusivity in layers [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
+  real, dimension(SZI_(G),SZK_(G)+1), &
                           optional, intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces,
                                                             !! [Z2 T-1 ~> m2 s-1].
   real,                             intent(in)    :: Kd_max !< The maximum increment for diapycnal
@@ -726,7 +726,7 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv
                            intent(in)    :: h     !< Layer thicknesses [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZK_(G)), &
                  optional, intent(inout) :: Kd_lay!< The diapycnal diffusivity in the layers [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
+  real, dimension(SZI_(G),SZK_(G)+1), &
                  optional, intent(inout) :: Kd_int!< The diapycnal diffusivity at interfaces [Z2 T-1 ~> m2 s-1].
   real, dimension(:,:,:),  pointer       :: Kv    !< The "slow" vertical viscosity at each interface
                                                   !! (not layer!) [Z2 T-1 ~> m2 s-1].
@@ -810,7 +810,7 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv
       endif
       if (present(Kd_int)) then
         do K=1,G%ke+1
-          Kd_int(i,j,K) = Kd_int(i,j,K) +  (US%m2_s_to_Z2_T * Kd_tidal(K))
+          Kd_int(i,K) = Kd_int(i,K) +  (US%m2_s_to_Z2_T * Kd_tidal(K))
         enddo
       endif
       ! Update viscosity with the proper unit conversion.
@@ -912,7 +912,7 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv
       endif
       if (present(Kd_int)) then
         do K=1,G%ke+1
-          Kd_int(i,j,K) = Kd_int(i,j,K) +  (US%m2_s_to_Z2_T * Kd_tidal(K))
+          Kd_int(i,K) = Kd_int(i,K) +  (US%m2_s_to_Z2_T * Kd_tidal(K))
         enddo
       endif
 
@@ -979,7 +979,7 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
   type(tidal_mixing_cs),            pointer       :: CS     !< The control structure for this module
   real, dimension(SZI_(G),SZK_(G)), &
                           optional, intent(inout) :: Kd_lay !< The diapycnal diffusivity in layers [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
+  real, dimension(SZI_(G),SZK_(G)+1), &
                           optional, intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces
                                                             !! [Z2 T-1 ~> m2 s-1].
   real,                             intent(in)    :: Kd_max !< The maximum increment for diapycnal
@@ -1266,8 +1266,8 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
       endif
 
       if (present(Kd_int)) then
-        Kd_int(i,j,K)   = Kd_int(i,j,K)   + 0.5 * Kd_add
-        Kd_int(i,j,K+1) = Kd_int(i,j,K+1) + 0.5 * Kd_add
+        Kd_int(i,K)   = Kd_int(i,K)   + 0.5 * Kd_add
+        Kd_int(i,K+1) = Kd_int(i,K+1) + 0.5 * Kd_add
       endif
 
       ! diagnostics
@@ -1363,8 +1363,8 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
       endif
 
       if (present(Kd_int)) then
-        Kd_int(i,j,K)   = Kd_int(i,j,K)   + 0.5 * Kd_add
-        Kd_int(i,j,K+1) = Kd_int(i,j,K+1) + 0.5 * Kd_add
+        Kd_int(i,K)   = Kd_int(i,K)   + 0.5 * Kd_add
+        Kd_int(i,K+1) = Kd_int(i,K+1) + 0.5 * Kd_add
       endif
 
       ! diagnostics

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -690,9 +690,9 @@ subroutine calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US, C
                                                             !! to its maximum realizable thickness [Z3 T-3 ~> m3 s-3]
   type(tidal_mixing_cs),            pointer       :: CS     !< The control structure for this module
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                                    intent(inout) :: Kd_lay !< The diapycnal diffusvity in layers [Z2 T-1 ~> m2 s-1].
+                          optional, intent(inout) :: Kd_lay !< The diapycnal diffusivity in layers [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
-                         optional,  intent(inout) :: Kd_int !< The diapycnal diffusvity at interfaces,
+                          optional, intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces,
                                                             !! [Z2 T-1 ~> m2 s-1].
   real,                             intent(in)    :: Kd_max !< The maximum increment for diapycnal
                                                             !! diffusivity due to TKE-based processes,
@@ -725,10 +725,9 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(in)    :: h     !< Layer thicknesses [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                           intent(inout) :: Kd_lay!< The diapycnal diffusivities in the layers [Z2 T-1 ~> m2 s-1].
+                 optional, intent(inout) :: Kd_lay!< The diapycnal diffusivity in the layers [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
-                optional,  intent(inout) :: Kd_int !< The diapycnal diffusvity at interfaces,
-                                                            !! [Z2 T-1 ~> m2 s-1].
+                 optional, intent(inout) :: Kd_int!< The diapycnal diffusivity at interfaces [Z2 T-1 ~> m2 s-1].
   real, dimension(:,:,:),  pointer       :: Kv    !< The "slow" vertical viscosity at each interface
                                                   !! (not layer!) [Z2 T-1 ~> m2 s-1].
   ! Local variables
@@ -804,9 +803,11 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv
                                CVMix_tidal_params_user = CS%CVMix_tidal_params)
 
       ! Update diffusivity
-      do k=1,G%ke
-        Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
-      enddo
+      if (present(Kd_lay)) then
+        do k=1,G%ke
+          Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
+        enddo
+      endif
       if (present(Kd_int)) then
         do K=1,G%ke+1
           Kd_int(i,j,K) = Kd_int(i,j,K) +  (US%m2_s_to_Z2_T * Kd_tidal(K))
@@ -904,9 +905,11 @@ subroutine calculate_CVMix_tidal(h, j, G, GV, US, CS, N2_int, Kd_lay, Kd_int, Kv
                                           CVmix_tidal_params_user = CS%CVMix_tidal_params)
 
       ! Update diffusivity
-      do k=1,G%ke
-        Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
-      enddo
+      if (present(Kd_lay)) then
+        do k=1,G%ke
+          Kd_lay(i,j,k) = Kd_lay(i,j,k) + 0.5 * US%m2_s_to_Z2_T * (Kd_tidal(k) + Kd_tidal(k+1))
+        enddo
+      endif
       if (present(Kd_int)) then
         do K=1,G%ke+1
           Kd_int(i,j,K) = Kd_int(i,j,K) +  (US%m2_s_to_Z2_T * Kd_tidal(K))
@@ -975,9 +978,9 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
                                                             !! to its maximum realizable thickness [Z3 T-3 ~> m3 s-3]
   type(tidal_mixing_cs),            pointer       :: CS     !< The control structure for this module
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                                    intent(inout) :: Kd_lay !< The diapycnal diffusvity in layers [Z2 T-1 ~> m2 s-1].
+                          optional, intent(inout) :: Kd_lay !< The diapycnal diffusivity in layers [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1), &
-                          optional, intent(inout) :: Kd_int !< The diapycnal diffusvity at interfaces
+                          optional, intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces
                                                             !! [Z2 T-1 ~> m2 s-1].
   real,                             intent(in)    :: Kd_max !< The maximum increment for diapycnal
                                                             !! diffusivity due to TKE-based processes
@@ -1258,7 +1261,9 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
       Kd_add  = TKE_to_Kd(i,k) * (TKE_itide_lay + TKE_Niku_lay + TKE_lowmode_lay)
 
       if (Kd_max >= 0.0) Kd_add = min(Kd_add, Kd_max)
-      Kd_lay(i,j,k) = Kd_lay(i,j,k) + Kd_add
+      if (present(Kd_lay)) then
+        Kd_lay(i,j,k) = Kd_lay(i,j,k) + Kd_add
+      endif
 
       if (present(Kd_int)) then
         Kd_int(i,j,K)   = Kd_int(i,j,K)   + 0.5 * Kd_add
@@ -1353,7 +1358,9 @@ subroutine add_int_tide_diffusivity(h, N2_bot, j, TKE_to_Kd, max_TKE, G, GV, US,
       Kd_add  = TKE_to_Kd(i,k) * (TKE_itide_lay + TKE_Niku_lay + TKE_lowmode_lay)
 
       if (Kd_max >= 0.0) Kd_add = min(Kd_add, Kd_max)
-      Kd_lay(i,j,k) = Kd_lay(i,j,k) + Kd_add
+      if (present(Kd_lay)) then
+        Kd_lay(i,j,k) = Kd_lay(i,j,k) + Kd_add
+      endif
 
       if (present(Kd_int)) then
         Kd_int(i,j,K)   = Kd_int(i,j,K)   + 0.5 * Kd_add

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -120,9 +120,9 @@ contains
 
     register_MOM_generic_tracer = .false.
     if (associated(CS)) then
-       call MOM_error(WARNING, "register_MOM_generic_tracer called with an "// &
+      call MOM_error(WARNING, "register_MOM_generic_tracer called with an "// &
             "associated control structure.")
-       return
+      return
     endif
     allocate(CS)
 
@@ -130,7 +130,7 @@ contains
     !Register all the generic tracers used and create the list of them.
     !This can be called by ALL PE's. No array fields allocated.
     if (.not. g_registered) then
-       call generic_tracer_register
+       call generic_tracer_register()
        g_registered = .true.
     endif
 
@@ -270,10 +270,10 @@ contains
 
     do
       if (INDEX(CS%IC_file, '_NULL_') /= 0) then
-         call MOM_error(WARNING,"The name of the IC_file "//trim(CS%IC_file)//&
+        call MOM_error(WARNING, "The name of the IC_file "//trim(CS%IC_file)//&
                               " indicates no MOM initialization was asked for the generic tracers."//&
                               "Bypassing the MOM initialization of ALL generic tracers!")
-         exit
+        exit
       endif
       call g_tracer_get_alias(g_tracer,g_tracer_name)
       call g_tracer_get_pointer(g_tracer,g_tracer_name,'field',tr_field)
@@ -296,20 +296,20 @@ contains
 
          !Check/apply the bounds for each g_tracer
          do k=1,nk ; do j=jsc,jec ; do i=isc,iec
-            if (tr_ptr(i,j,k) /= CS%tracer_land_val) then
-              if (tr_ptr(i,j,k) < g_tracer%src_var_valid_min) tr_ptr(i,j,k) = g_tracer%src_var_valid_min
-              !Jasmin does not want to apply the maximum for now
-              !if (tr_ptr(i,j,k) > g_tracer%src_var_valid_max) tr_ptr(i,j,k) = g_tracer%src_var_valid_max
-            endif
+           if (tr_ptr(i,j,k) /= CS%tracer_land_val) then
+             if (tr_ptr(i,j,k) < g_tracer%src_var_valid_min) tr_ptr(i,j,k) = g_tracer%src_var_valid_min
+             !Jasmin does not want to apply the maximum for now
+             !if (tr_ptr(i,j,k) > g_tracer%src_var_valid_max) tr_ptr(i,j,k) = g_tracer%src_var_valid_max
+           endif
          enddo ; enddo ; enddo
 
          !jgj: Reset CASED to 0 below K=1
          if ( (trim(g_tracer_name) == 'cased') .or. (trim(g_tracer_name) == 'ca13csed') ) then
-            do k=2,nk ; do j=jsc,jec ; do i=isc,iec
-               if (tr_ptr(i,j,k) /= CS%tracer_land_val) then
-                 tr_ptr(i,j,k) = 0.0
-               endif
-            enddo ; enddo ; enddo
+           do k=2,nk ; do j=jsc,jec ; do i=isc,iec
+             if (tr_ptr(i,j,k) /= CS%tracer_land_val) then
+               tr_ptr(i,j,k) = 0.0
+             endif
+           enddo ; enddo ; enddo
          endif
        elseif(.not. g_tracer%requires_restart) then
          !Do nothing for this tracer, it is initialized by the tracer package
@@ -362,10 +362,10 @@ contains
     grid_tmask(:,:,:) = 0.0
     grid_kmt(:,:) = 0
     do j = G%jsd, G%jed ; do i = G%isd, G%ied
-       if (G%mask2dT(i,j) > 0) then
-          grid_tmask(i,j,:) = 1.0
-          grid_kmt(i,j) = G%ke ! Tell the code that a layer thicker than 1m is the bottom layer.
-       endif
+      if (G%mask2dT(i,j) > 0) then
+        grid_tmask(i,j,:) = 1.0
+        grid_kmt(i,j) = G%ke ! Tell the code that a layer thicker than 1m is the bottom layer.
+      endif
     enddo ; enddo
     call g_tracer_set_common(G%isc,G%iec,G%jsc,G%jec,G%isd,G%ied,G%jsd,G%jed,&
                              GV%ke,1,CS%diag%axesTL%handles,grid_tmask,grid_kmt,day)
@@ -769,25 +769,25 @@ contains
     type(g_tracer_type), pointer :: g_tracer_list,g_tracer,g_tracer_next
 
     if (.not. g_registered) then
-       call generic_tracer_register
-       g_registered = .true.
+      call generic_tracer_register()
+      g_registered = .true.
     endif
 
     call generic_tracer_get_list(g_tracer_list)
     if (.NOT. associated(g_tracer_list)) then
-       call MOM_error(WARNING, trim(sub_name)// ": No generic tracer in the list.")
-       return
+      call MOM_error(WARNING, trim(sub_name)// ": No generic tracer in the list.")
+      return
     endif
 
     g_tracer=>g_tracer_list
     do
 
-       call g_tracer_flux_init(g_tracer) !, verbosity=verbosity) !### Add this after ocean shared is updated.
+      call g_tracer_flux_init(g_tracer) !, verbosity=verbosity) !### Add this after ocean shared is updated.
 
-       !traverse the linked list till hit NULL
-       call g_tracer_get_next(g_tracer, g_tracer_next)
-       if (.NOT. associated(g_tracer_next)) exit
-       g_tracer=>g_tracer_next
+      ! traverse the linked list till hit NULL
+      call g_tracer_get_next(g_tracer, g_tracer_next)
+      if (.NOT. associated(g_tracer_next)) exit
+      g_tracer=>g_tracer_next
 
     enddo
 
@@ -798,7 +798,7 @@ contains
                                               !! thermodynamic and tracer forcing fields.
     real,          intent(in)    :: weight    !< A weight for accumulating this flux
 
-   call generic_tracer_coupler_accumulate(flux_tmp%tr_fluxes, weight)
+    call generic_tracer_coupler_accumulate(flux_tmp%tr_fluxes, weight)
 
   end subroutine MOM_generic_tracer_fluxes_accumulate
 
@@ -821,10 +821,10 @@ contains
   subroutine end_MOM_generic_tracer(CS)
     type(MOM_generic_tracer_CS), pointer :: CS   !< Pointer to the control structure for this module.
 
-    call generic_tracer_end
+    call generic_tracer_end()
 
     if (associated(CS)) then
-       deallocate(CS)
+      deallocate(CS)
     endif
   end subroutine end_MOM_generic_tracer
 


### PR DESCRIPTION
  Refactored MOM_set_diffusivity.F90, MOM_geothermal.F90, MOM_diabatic_driver.F90
and related modules to improve the code structure, and to avoid unnecessarily setting
or using 3-d arrays that are not used themselves.  This includes the elimination
of at least 3 3-d arrays and a dramatic simplification of the geothermal heating
routine in ALE mode.  The registration calls for some modules and diagnostics
were changed, so there are changes in the order of the entries in many
MOM_parameter_doc files.  Also added the new runtime parameter PRANDTL_EPBL, and
corrected two diagnostics of the thickness and temperature changes due to
geothermal heating that were just wrong before. All tested solutions are bitwise
identical, but the corrections to diagnostics cause some automated regression
tests fail.  The commits in this PR include:


- NOAA/GFDL/MOM6@94a833839 Fixed the diagnostic internal_heat_temp_tendency
- NOAA/GFDL/MOM6@cd3ebe41f Merge branch 'dev/gfdl' into set_diffusivity_cleanup
- NOAA/GFDL/MOM6@5df01372d +Added the runtime parameter PRANDTL_EPBL
- NOAA/GFDL/MOM6@fc806af64 Reordering of code in calculate_bkgnd_mixing
- NOAA/GFDL/MOM6@2968e4dfe Refactored diagnostics in geothermal_in_place
- NOAA/GFDL/MOM6@c4e145519 Eliminated unused variables in diabatic_ALE
- NOAA/GFDL/MOM6@c61232f06 +Overloaded the interface to geothermal
- NOAA/GFDL/MOM6@986bfbd24 Reuse auxiliary salinity array in set_diffusivity
- NOAA/GFDL/MOM6@ca3a5a988 +Initialize tidal_mixing from set_diffusivity_init
- NOAA/GFDL/MOM6@03c7433a9 Removed Kd_lay from diabatic_ALE routines
- NOAA/GFDL/MOM6@741b9c703 +Work with 2-d slice of Kd_int in set_diffusivity
- NOAA/GFDL/MOM6@f05782194 +Made Kd_lay argument to set_diffusivity optional
- NOAA/GFDL/MOM6@8d1539e8a +Made elements of tidal_mixing_CS private
- NOAA/GFDL/MOM6@c007a1395 +Move diagnostics out of MOM_CVMix_ddiff
- NOAA/GFDL/MOM6@8ef820ea1 +Remove 3-d diagnostic arrays in MOM_bkgnd_mixing
- NOAA/GFDL/MOM6@db4d3f0f8 White space cleanup in MOM_generic_tracer
- NOAA/GFDL/MOM6@902f7a9f2 +Made Kd_lay arg to calculate_tidal_mixing optional
- NOAA/GFDL/MOM6@449d568fe +Eliminated sfc_bkgnd_mixing
