### PR TITLE
Fixes doxygen warnings mostly from config_src/external

### DIFF
--- a/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
@@ -33,7 +33,17 @@ contains
 
   !> Initialize generic tracers
   subroutine generic_tracer_init(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time)
-    integer, intent(in) :: isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes(3) !< Domain boundaries and axes
+    integer,                       intent(in) :: isc !< Computation start index in i direction
+    integer,                       intent(in) :: iec !< Computation end index in i direction
+    integer,                       intent(in) :: jsc !< Computation start index in j direction
+    integer,                       intent(in) :: jec !< Computation end index in j direction
+    integer,                       intent(in) :: isd !< Data start index in i direction
+    integer,                       intent(in) :: ied !< Data end index in i direction
+    integer,                       intent(in) :: jsd !< Data start index in j direction
+    integer,                       intent(in) :: jed !< Data end index in j direction
+    integer,                       intent(in) :: nk  !< Number of levels in k direction
+    integer,                       intent(in) :: ntau !< Unknown
+    integer,                       intent(in) :: axes(3) !< Domain axes?
     type(time_type),               intent(in) :: init_time !< Time
     real, dimension(:,:,:),target, intent(in) :: grid_tmask !< Mask
     integer, dimension(:,:)      , intent(in) :: grid_kmt !< Number of wet cells in column
@@ -61,7 +71,7 @@ contains
        frunoff,grid_ht, current_wave_stress, sosga)
     real, dimension(ilb:,jlb:,:),   intent(in) :: Temp !< Potential temperature [deg C]
     real, dimension(ilb:,jlb:,:),   intent(in) :: Salt !< Salinity [psu]
-    real, dimension(ilb:,jlb:,:),   intent(in) :: rho_dzt
+    real, dimension(ilb:,jlb:,:),   intent(in) :: rho_dzt !< Unknown
     real, dimension(ilb:,jlb:,:),   intent(in) :: dzt !< Ocean layer thickness [m]
     real, dimension(ilb:,jlb:),     intent(in) :: hblt_depth !< Boundary layer depth
     integer,                        intent(in) :: ilb !< Lower bounds of x extent of input arrays on data domain
@@ -71,14 +81,14 @@ contains
     real, dimension(ilb:,jlb:),     intent(in) :: grid_dat !< Unknown
     type(time_type),                intent(in) :: model_time !< Time
     integer,                        intent(in) :: nbands !< Unknown
-    real, dimension(:),             intent(in) :: max_wavelength_band
+    real, dimension(:),             intent(in) :: max_wavelength_band !< Unknown
     real, dimension(:,ilb:,jlb:),   intent(in) :: sw_pen_band !< Shortwave penetration
     real, dimension(:,ilb:,jlb:,:), intent(in) :: opacity_band !< Unknown
     real, dimension(ilb:,jlb:),optional,  intent(in) :: internal_heat !< Unknown
     real, dimension(ilb:,jlb:),optional,  intent(in) :: frunoff !< Unknown
     real, dimension(ilb:,jlb:),optional,  intent(in) :: grid_ht !< Unknown
     real, dimension(ilb:,jlb:),optional , intent(in) :: current_wave_stress !< Unknown
-    real,                      optional , intent(in) :: sosga ! global avg. sea surface salinity
+    real,                      optional , intent(in) :: sosga !< Global average sea surface salinity
   end subroutine generic_tracer_source
 
   !> Update the tracers from bottom fluxes

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -21,8 +21,10 @@ implicit none ; private
     !> Tracer concentration in river runoff
     real, allocatable, dimension(:,:) :: trunoff
     logical :: requires_restart = .true. !< Unknown
-    !> Tracer source: filename, type, var name, units, record, gridfile
-    character(len=fm_string_len) :: src_file, src_var_name, src_var_unit, src_var_gridspec
+    character(len=fm_string_len) :: src_file !< Tracer source filename
+    character(len=fm_string_len) :: src_var_name !< Tracer source variable name
+    character(len=fm_string_len) :: src_var_unit !< Tracer source variable units
+    character(len=fm_string_len) :: src_var_gridspec !< Tracer source grid file name
     integer :: src_var_record !< Unknown
     logical :: requires_src_info = .false. !< Unknown
     real    :: src_var_unit_conversion = 1.0 !< This factor depends on the tracer. Ask Jasmin
@@ -38,7 +40,8 @@ implicit none ; private
   type g_tracer_common
 !   type(g_diag_ctrl) :: diag_CS !< Unknown
     !> Domain extents
-    integer :: isd,jsd
+    integer :: isd !< Start index of the data domain in the i-direction
+    integer :: jsd !< Start index of the data domain in the j-direction
   end type g_tracer_common
 
   !> Unknown dangerous module data!
@@ -102,7 +105,17 @@ contains
   end subroutine g_tracer_set_csdiag
 
   subroutine g_tracer_set_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time)
-    integer,                     intent(in) :: isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes(3) !< Unknown
+    integer,                     intent(in) :: isc !< Computation start index in i direction
+    integer,                     intent(in) :: iec !< Computation end index in i direction
+    integer,                     intent(in) :: jsc !< Computation start index in j direction
+    integer,                     intent(in) :: jec !< Computation end index in j direction
+    integer,                     intent(in) :: isd !< Data start index in i direction
+    integer,                     intent(in) :: ied !< Data end index in i direction
+    integer,                     intent(in) :: jsd !< Data start index in j direction
+    integer,                     intent(in) :: jed !< Data end index in j direction
+    integer,                     intent(in) :: nk  !< Number of levels in k direction
+    integer,                     intent(in) :: ntau !< Unknown
+    integer,                     intent(in) :: axes(3) !< Domain axes?
     real, dimension(isd:,jsd:,:),intent(in) :: grid_tmask !< Unknown
     integer,dimension(isd:,jsd:),intent(in) :: grid_kmt !< Unknown
     type(time_type),             intent(in) :: init_time !< Unknown
@@ -110,10 +123,19 @@ contains
 
   subroutine g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,&
        axes,grid_tmask,grid_mask_coast,grid_kmt,init_time,diag_CS)
-    integer,               intent(out) :: isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau !< Unknown
-    integer,optional,      intent(out) :: axes(3) !< Unknown
+    integer,                        intent(out) :: isc !< Computation start index in i direction
+    integer,                        intent(out) :: iec !< Computation end index in i direction
+    integer,                        intent(out) :: jsc !< Computation start index in j direction
+    integer,                        intent(out) :: jec !< Computation end index in j direction
+    integer,                        intent(out) :: isd !< Data start index in i direction
+    integer,                        intent(out) :: ied !< Data end index in i direction
+    integer,                        intent(out) :: jsd !< Data start index in j direction
+    integer,                        intent(out) :: jed !< Data end index in j direction
+    integer,                        intent(out) :: nk  !< Number of levels in k direction
+    integer,                        intent(out) :: ntau !< Unknown
+    integer, optional,              intent(out) :: axes(3) !< Unknown
     type(time_type), optional,      intent(out) :: init_time !< Unknown
-    real, optional, dimension(:,:,:),pointer    :: grid_tmask !< Unknown
+    real, optional, dimension(:,:,:),   pointer :: grid_tmask !< Unknown
     integer, optional, dimension(:,:),  pointer :: grid_mask_coast !< Unknown
     integer, optional, dimension(:,:),  pointer :: grid_kmt !< Unknown
     type(g_diag_ctrl), optional,        pointer :: diag_CS !< Unknown
@@ -123,32 +145,33 @@ contains
   subroutine g_tracer_get_4D(g_tracer_list,name,member,array_ptr)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
-    real, dimension(:,:,:,:), pointer    :: array_ptr
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    real, dimension(:,:,:,:), pointer    :: array_ptr !< Unknown
   end subroutine g_tracer_get_4D
 
   !> Unknown
   subroutine g_tracer_get_3D(g_tracer_list,name,member,array_ptr)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
-    real, dimension(:,:,:), pointer    :: array_ptr !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    real, dimension(:,:,:),   pointer    :: array_ptr !< Unknown
   end subroutine g_tracer_get_3D
 
   !> Unknown
   subroutine g_tracer_get_2D(g_tracer_list,name,member,array_ptr)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
-    real, dimension(:,:), pointer    :: array_ptr !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    real, dimension(:,:),     pointer    :: array_ptr !< Unknown
   end subroutine g_tracer_get_2D
 
   !> Unknown
   subroutine g_tracer_get_4D_val(g_tracer_list,name,member,array,isd,jsd)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
-    integer,                  intent(in) :: isd,jsd !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    integer,                  intent(in) :: isd !< Unknown
+    integer,                  intent(in) :: jsd !< Unknown
     real, dimension(isd:,jsd:,:,:), intent(out):: array !< Unknown
   end subroutine g_tracer_get_4D_val
 
@@ -156,8 +179,9 @@ contains
   subroutine g_tracer_get_3D_val(g_tracer_list,name,member,array,isd,jsd,ntau,positive)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
-    integer,                  intent(in) :: isd,jsd !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    integer,                  intent(in) :: isd !< Unknown
+    integer,                  intent(in) :: jsd !< Unknown
     integer, optional,        intent(in) :: ntau !< Unknown
     logical, optional,        intent(in) :: positive !< Unknown
     real, dimension(isd:,jsd:,:), intent(out):: array !< Unknown
@@ -169,8 +193,9 @@ contains
   subroutine g_tracer_get_2D_val(g_tracer_list,name,member,array,isd,jsd)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
-    integer,                  intent(in) :: isd,jsd !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    integer,                  intent(in) :: isd !< Unknown
+    integer,                  intent(in) :: jsd !< Unknown
     real, dimension(isd:,jsd:), intent(out):: array !< Unknown
   end subroutine g_tracer_get_2D_val
 
@@ -178,15 +203,15 @@ contains
   subroutine g_tracer_get_real(g_tracer_list,name,member,value)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
-    real,                     intent(out):: value
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    real,                     intent(out):: value !< Unknown
   end subroutine g_tracer_get_real
 
   !> Unknown
   subroutine g_tracer_get_string(g_tracer_list,name,member,string)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
     character(len=fm_string_len), intent(out) :: string !< Unknown
   end subroutine g_tracer_get_string
 
@@ -194,8 +219,9 @@ contains
   subroutine g_tracer_set_2D(g_tracer_list,name,member,array,isd,jsd,weight)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),      pointer    :: g_tracer_list, g_tracer !< Unknown
-    integer,                   intent(in) :: isd,jsd !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    integer,                   intent(in) :: isd !< Unknown
+    integer,                   intent(in) :: jsd !< Unknown
     real, dimension(isd:,jsd:),intent(in) :: array !< Unknown
     real, optional            ,intent(in) :: weight !< Unknown
   end subroutine g_tracer_set_2D
@@ -204,8 +230,9 @@ contains
   subroutine g_tracer_set_3D(g_tracer_list,name,member,array,isd,jsd,ntau)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
-    integer,                  intent(in) :: isd,jsd !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    integer,                  intent(in) :: isd !< Unknown
+    integer,                  intent(in) :: jsd !< Unknown
     integer, optional,        intent(in) :: ntau !< Unknown
     real, dimension(isd:,jsd:,:), intent(in)       :: array !< Unknown
   end subroutine g_tracer_set_3D
@@ -214,16 +241,17 @@ contains
   subroutine g_tracer_set_4D(g_tracer_list,name,member,array,isd,jsd)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
-    integer,                  intent(in) :: isd,jsd !< Unknown
-    real, dimension(isd:,jsd:,:,:), intent(in)       :: array !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
+    integer,                  intent(in) :: isd !< Unknown
+    integer,                  intent(in) :: jsd !< Unknown
+    real, dimension(isd:,jsd:,:,:), intent(in) :: array !< Unknown
   end subroutine g_tracer_set_4D
 
   !> Unknown
   subroutine g_tracer_set_real(g_tracer_list,name,member,value)
     character(len=*),         intent(in) :: name !< Unknown
     character(len=*),         intent(in) :: member !< Unknown
-    type(g_tracer_type),    pointer    :: g_tracer_list, g_tracer !< Unknown
+    type(g_tracer_type),      pointer    :: g_tracer_list !< Unknown
     real,                     intent(in) :: value !< Unknown
   end subroutine g_tracer_set_real
 
@@ -265,7 +293,7 @@ contains
   !! Since the surface flux from the atmosphere (%stf) has the units of mol/m^2/sec the resulting
   !!  tracer concentration has units of mol/Kg
   subroutine g_tracer_vertdiff_G(g_tracer, h_old, ea, eb, dt, kg_m2_to_H, m_to_H, tau, mom)
-    type(g_tracer_type),    pointer  :: g_tracer
+    type(g_tracer_type),    pointer  :: g_tracer !< Unknown
     !> Layer thickness before entrainment, in m or kg m-2.
     real, dimension(g_tracer_com%isd:,g_tracer_com%jsd:,:), intent(in) :: h_old
     !> The amount of fluid entrained from the layer above, in H.
@@ -278,7 +306,7 @@ contains
     real,     intent(in) :: m_to_H !< A conversion factor that translates m into the units
                                    !! of h_old (H).
     integer,  intent(in) :: tau !< Unknown
-    logical,  intent(in), optional :: mom
+    logical,  intent(in), optional :: mom !< Unknown
   end subroutine g_tracer_vertdiff_G
 
 end module g_tracer_utils

--- a/config_src/external/ODA_hooks/ocean_da_types.F90
+++ b/config_src/external/ODA_hooks/ocean_da_types.F90
@@ -7,7 +7,6 @@ module ocean_da_types_mod
 
   private
 
-
   !> Example type for ocean ensemble DA state
   type, public :: OCEAN_CONTROL_STRUCT
      integer :: ensemble_size
@@ -54,7 +53,8 @@ module ocean_da_types_mod
      real, dimension(:,:,:), pointer :: analysis => NULL() !< ensemble member analysis
      type(forward_operator_type), pointer :: obs_def => NULL() !< observation forward operator
      type(time_type) :: time !< profile time type
-     real :: i_index, j_index !< model longitude and latitude indices respectively
+     real :: i_index !< model longitude indices respectively
+     real :: j_index !< model latitude indices respectively
      real, dimension(:,:), pointer :: k_index !< model depth indices
      type(time_type) :: tdiff !< difference between model time and observation time
      character(len=128) :: filename

--- a/config_src/external/ODA_hooks/write_ocean_obs.F90
+++ b/config_src/external/ODA_hooks/write_ocean_obs.F90
@@ -20,8 +20,8 @@ integer function open_profile_file(name, nvar, grid_lon, grid_lat,thread,fset)
   integer, intent(in), optional :: nvar !< Number of variables
   real, dimension(:), optional, intent(in) :: grid_lon !< Longitude [degreeE]
   real, dimension(:), optional, intent(in) :: grid_lat !< Latitude [degreeN]
-  integer, intent(in), optional :: thread !< Thread
-  integer, intent(in), optional :: fset !< File set
+  integer, optional, intent(in) :: thread !< Thread number
+  integer, optional, intent(in) :: fset !< File set
 
   open_profile_file=-1
 end function open_profile_file
@@ -29,7 +29,7 @@ end function open_profile_file
 !> Write a profile
 subroutine write_profile(unit,profile)
   integer, intent(in) :: unit !< File unit
-  type(ocean_profile_type), intent(in) :: profile !< Profile
+  type(ocean_profile_type), intent(in) :: profile !< Profile to write
 
   return
 end subroutine write_profile

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -173,7 +173,7 @@ end type KPP_CS
 
 !>@{ CPU time clocks
 integer :: id_clock_KPP_calc, id_clock_KPP_compute_BLD, id_clock_KPP_smoothing
-!!@}
+!>@}
 
 #define __DO_SAFETY_CHECKS__
 


### PR DESCRIPTION
- #1225 is showing lots of errors due to using a newer version of doxygen
- These doxygen mistakes exist in the current dev/gfdl branch and apparently are missed by the older versions we are using on mom6.readthedocs.io and locally.

Todo:
[ ] - Have the OBGC routines properly documented so we can replace the "Unknown" documentation in the generic_tracer stubs.