### PR TITLE
Proposal for interface/submodule framework layer

### DIFF
--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -168,11 +168,13 @@ AS_IF([test -z "$MKMF"], [
 
 
 # NOTE: MEM_LAYOUT unneeded if we shift to MOM_memory.h.in template
+# TODO: fms_layer should be configurable (and renamed)
 AC_CONFIG_COMMANDS([path_names],
   [list_paths -l \
     ${srcdir}/src \
     ${srcdir}/config_src/solo_driver \
     ${srcdir}/config_src/ext* \
+    ${srcdir}/config_src/fms_layer \
     ${MEM_LAYOUT}
 ], [MEM_LAYOUT=$MEM_LAYOUT])
 

--- a/config_src/fms_layer/MOM_error_handler_fms.F90
+++ b/config_src/fms_layer/MOM_error_handler_fms.F90
@@ -1,0 +1,30 @@
+!> FMS-based implementation of MOM_error_handler subprograms
+submodule (MOM_error_handler) MOM_error_handler_fms
+
+  ! NOTE: These are currently imported from the MOM_error_handler module.
+  !   If uncommented, this line would cause a namespace conflict.
+  !   Once all references to mpp_error and NOTE are removed from
+  !   MOM_error_module, this line should be re-enabled.
+  !
+  !use mpp_mod, only : mpp_error, NOTE
+
+  implicit none
+contains
+  !> This provides a convenient interface for writing an informative comment.
+  module subroutine MOM_mesg(message, verb, all_print)
+  !module subroutine MOM_mesg(message, verb, all_print)
+    character(len=*), intent(in)  :: message !< A message to write out
+    integer, optional, intent(in) :: verb !< A level of verbosity for this message
+    logical, optional, intent(in) :: all_print !< If present and true, any PEs are
+                                               !! able to write this message.
+    ! This provides a convenient interface for writing an informative comment.
+    integer :: verb_msg
+    logical :: write_msg
+
+    write_msg = is_root_pe()
+    if (present(all_print)) write_msg = write_msg .or. all_print
+
+    verb_msg = 2 ; if (present(verb)) verb_msg = verb
+    if (write_msg .and. (verbosity >= verb_msg)) call mpp_error(NOTE, message)
+  end subroutine MOM_mesg
+end submodule MOM_error_handler_fms

--- a/src/framework/MOM_error_handler.F90
+++ b/src/framework/MOM_error_handler.F90
@@ -37,6 +37,16 @@ integer :: verbosity = 6
 integer :: callTreeIndentLevel = 0
 !< The level of calling within the call tree
 
+interface
+  !> This provides a convenient interface for writing an informative comment.
+  module subroutine MOM_mesg(message, verb, all_print)
+    character(len=*), intent(in)  :: message !< A message to write out
+    integer, optional, intent(in) :: verb !< A level of verbosity for this message
+    logical, optional, intent(in) :: all_print !< If present and true, any PEs are
+                                               !! able to write this message.
+  end subroutine MOM_mesg
+end interface
+
 contains
 
 !> This returns .true. if the current PE is the root PE.
@@ -47,24 +57,6 @@ function is_root_pe()
   if (mpp_pe() == mpp_root_pe()) is_root_pe = .true.
   return
 end function is_root_pe
-
-!> This provides a convenient interface for writing an informative comment.
-subroutine MOM_mesg(message, verb, all_print)
-  character(len=*), intent(in)  :: message !< A message to write out
-  integer, optional, intent(in) :: verb !< A level of verbosity for this message
-  logical, optional, intent(in) :: all_print !< If present and true, any PEs are
-                                             !! able to write this message.
-  ! This provides a convenient interface for writing an informative comment.
-  integer :: verb_msg
-  logical :: write_msg
-
-  write_msg = is_root_pe()
-  if (present(all_print)) write_msg = write_msg .or. all_print
-
-  verb_msg = 2 ; if (present(verb)) verb_msg = verb
-  if (write_msg .and. (verbosity >= verb_msg)) call mpp_error(NOTE, message)
-
-end subroutine MOM_mesg
 
 !> This provides a convenient interface for writing an mpp_error message
 !! with run-time filter based on a verbosity.


### PR DESCRIPTION
This is a potential solution for implementing a more flexible layer
between MOM6 and its underlying framework.

Currently such a framework is strongly hard-coded to FMS in the
`src/framework` directory, but this can create challenges when using
MOM6 in other coupled models which do not have the same operational
requirements as GFDL.

This solution replaces FMS-based implementations of framework
subroutines with interfaces, which define the API of the framework layer
but do not explicit define it.

The implementations are provided in a separate directory, such as
`config_src/fms_layer`, which is configured at build time.  These
implementations are provided as submodules to the parent module
containing the interface.

This should not be considered a final solution, but rather a starting
point for discussion.

Advantages of separation:

- MOM6 code becomes framework-agnostic, and `src/framework` can
  predominantly contain interfaces to framework-specific
  implementations.

- This is not constrained by any particular API.  The MOM framework API
  is fixed, but is implementation is free to call any combination of
  framework functions in any way needed to achieve the same result.

- This is extendible to an arbitrary number of frameworks, and their
  behavior and testing would be completely separate from MOM6
  development.

Advantages of submodules:

- Framework interfaces are explicit.  Any implementation would need to
  follow the interface as specified in the MOM6 source code.

- A `libMOM6` could be constructed without the framework implementation,
  which could be contained in its own

- Stronger logical separation of framework modules and the other modules
  which reference them.  This may potentially reduce the build times and
  the potential for build errors due to outdated module files.