### PR TITLE
Adds .testing jobs to the gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,6 +122,30 @@ run:
     - test -f restart_results_gnu.tar.gz
     - time tar zvcf $CACHE_DIR/results-$CI_PIPELINE_ID.tgz *.tar.gz
 
+gnu.testing:
+  stage: run
+  tags:
+    - ncrc4
+  script:
+    - cd .testing
+    - module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu darshan ; module load PrgEnv-gnu ; module unload netcdf gcc ; module load gcc/7.3.0 cray-hdf5 cray-netcdf
+    - make work/local-env
+    - make -s -j
+    - (echo '#!/bin/bash';echo '. ./work/local-env/bin/activate';echo 'make MPIRUN="srun -mblock --exclusive" test -s -j') > job.sh
+    - sbatch --clusters=c3,c4 --nodes=5 --time=0:05:00 --account=gfdl_o --qos=debug --job-name=MOM6.gnu.testing --output=log.$CI_PIPELINE_ID --wait job.sh || cat log.$CI_PIPELINE_ID && make test
+
+intel.testing:
+  stage: run
+  tags:
+    - ncrc4
+  script:
+    - cd .testing
+    - module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu darshan; module load PrgEnv-intel; module unload netcdf intel; module load intel/18.0.6.288 cray-hdf5 cray-netcdf
+    - make work/local-env
+    - make -s -j
+    - (echo '#!/bin/bash';echo '. ./work/local-env/bin/activate';echo 'make MPIRUN="srun -mblock --exclusive" test -s -j') > job.sh
+    - sbatch --clusters=c3,c4 --nodes=5 --time=0:05:00 --account=gfdl_o --qos=debug --job-name=MOM6.gnu.testing --output=log.$CI_PIPELINE_ID --wait job.sh || cat log.$CI_PIPELINE_ID && make test
+
 # Tests
 gnu:non-symmetric:
   stage: tests


### PR DESCRIPTION
- This adds the .testing tests, that until now have only run on Travis-CI,
  to the gitlab pipeline.
- Travis-CI only uses the gnu compiler (7.5.0). Adding these tests to gaea
  uses both gcc/7.3.0 and intel/18.0.6.288 which are the versions used to
  define the regression results for the MOM6-examples suite.
- The gnu test (compile and run) completes in under 5 minutes and the intel
  test in 10 minutes. I've added these in parallel to the "run" stage which
  takes >20 minutes so in all this has no impact of total turn around time.
- We can consider adding other available compilers and versions since these
  are relatively quick and cheap.

![image](https://user-images.githubusercontent.com/5859571/98029579-b6fddb00-1ddd-11eb-9e17-bc53bc299a86.png)

Example of full test is at https://gitlab.gfdl.noaa.gov/ogrp/MOM6/-/pipelines/11484
