### PR TITLE
+Refactor code handling double diffusive diffusivities

### DIFF
--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -241,15 +241,6 @@ type, public :: vertvisc_type
   real, pointer, dimension(:,:,:) :: &
     Ray_u => NULL(), & !< The Rayleigh drag velocity to be applied to each layer at u-points [Z T-1 ~> m s-1].
     Ray_v => NULL()    !< The Rayleigh drag velocity to be applied to each layer at v-points [Z T-1 ~> m s-1].
-  real, pointer, dimension(:,:,:) :: Kd_extra_T => NULL()
-                !< The extra diffusivity of temperature due to double diffusion relative to the
-                !! diffusivity of density [Z2 T-1 ~> m2 s-1].
-  real, pointer, dimension(:,:,:) :: Kd_extra_S => NULL()
-                !< The extra diffusivity of salinity due to double diffusion relative to the
-                !! diffusivity of density [Z2 T-1 ~> m2 s-1].
-  ! One of Kd_extra_T and Kd_extra_S is always 0. Kd_extra_S is positive for salt fingering;
-  ! Kd_extra_T is positive for double diffusive convection.  They are only allocated if
-  ! DOUBLE_DIFFUSION is true.
   real, pointer, dimension(:,:,:) :: Kd_shear => NULL()
                 !< The shear-driven turbulent diapycnal diffusivity at the interfaces between layers
                 !! in tracer columns [Z2 T-1 ~> m2 s-1].

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -237,16 +237,13 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
                  units="nondim", default=1.0)
 
   if (CS%Bryan_Lewis_diffusivity .or. CS%horiz_varying_background) then
-
     prandtl_bkgnd_comp = CS%prandtl_bkgnd
-    if (CS%Kd /= 0.0) prandtl_bkgnd_comp = Kv/CS%Kd
+    if (CS%Kd /= 0.0) prandtl_bkgnd_comp = Kv / CS%Kd
 
     if ( abs(CS%prandtl_bkgnd - prandtl_bkgnd_comp)>1.e-14) then
-      call MOM_error(FATAL,"set_diffusivity_init: The provided KD, KV,"//&
-                           "and PRANDTL_BKGND values are incompatible. The following "//&
-                           "must hold: KD*PRANDTL_BKGND==KV")
+      call MOM_error(FATAL, "bkgnd_mixing_init: The provided KD, KV and PRANDTL_BKGND values "//&
+                            "are incompatible. The following must hold: KD*PRANDTL_BKGND==KV")
     endif
-
   endif
 
   call get_param(param_file, mdl, "HENYEY_IGW_BACKGROUND", CS%Henyey_IGW_background, &
@@ -264,7 +261,7 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
 
   if (CS%Kd>0.0 .and. (trim(CS%bkgnd_scheme_str)=="BRYAN_LEWIS_DIFFUSIVITY" .or.&
                           trim(CS%bkgnd_scheme_str)=="HORIZ_VARYING_BACKGROUND" )) then
-    call MOM_error(WARNING, "set_diffusivity_init: a nonzero constant background "//&
+    call MOM_error(WARNING, "bkgnd_mixing_init: a nonzero constant background "//&
          "diffusivity (KD) is specified along with "//trim(CS%bkgnd_scheme_str))
   endif
 
@@ -540,7 +537,7 @@ subroutine check_bkgnd_scheme(CS, str)
   if (trim(CS%bkgnd_scheme_str)=="none") then
     CS%bkgnd_scheme_str = str
   else
-    call MOM_error(FATAL, "set_diffusivity_init: Cannot activate both "//trim(str)//" and "//&
+    call MOM_error(FATAL, "bkgnd_mixing_init: Cannot activate both "//trim(str)//" and "//&
                    trim(CS%bkgnd_scheme_str)//".")
   endif
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -600,8 +600,13 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
   ! Also changes: visc%Kd_shear, visc%Kv_shear and visc%Kv_slow
   if (CS%debug) &
     call MOM_state_chksum("before set_diffusivity", u, v, h, G, GV, US, haloshift=CS%halo_TS_diff)
-  call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, &
-                       visc, dt, G, GV, US, CS%set_diff_CSp, Kd_int=Kd_int)
+  if (CS%double_diffuse) then
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, CS%set_diff_CSp, &
+                         Kd_int=Kd_int, Kd_extra_T=visc%Kd_extra_T, Kd_extra_S=visc%Kd_extra_S)
+  else
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, &
+                         CS%set_diff_CSp, Kd_int=Kd_int)
+  endif
   call cpu_clock_end(id_clock_set_diffusivity)
   if (showCallTree) call callTree_waypoint("done with set_diffusivity (diabatic)")
 
@@ -1308,8 +1313,13 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
   ! Also changes: visc%Kd_shear, visc%Kv_shear and visc%Kv_slow
   if (CS%debug) &
     call MOM_state_chksum("before set_diffusivity", u, v, h, G, GV, US, haloshift=CS%halo_TS_diff)
-  call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, &
-                       CS%set_diff_CSp, Kd_int=Kd_int)
+  if (CS%double_diffuse) then
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, CS%set_diff_CSp, &
+                         Kd_int=Kd_int, Kd_extra_T=visc%Kd_extra_T, Kd_extra_S=visc%Kd_extra_S)
+  else
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, &
+                         CS%set_diff_CSp, Kd_int=Kd_int)
+  endif
   call cpu_clock_end(id_clock_set_diffusivity)
   if (showCallTree) call callTree_waypoint("done with set_diffusivity (diabatic)")
 
@@ -2055,8 +2065,13 @@ subroutine layered_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_e
   endif
   if (CS%debug) &
     call MOM_state_chksum("before set_diffusivity", u, v, h, G, GV, US, haloshift=CS%halo_TS_diff)
-  call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, &
-                       visc, dt, G, GV, US, CS%set_diff_CSp, Kd_lay, Kd_int)
+  if (CS%double_diffuse) then
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, CS%set_diff_CSp, &
+                         Kd_lay=Kd_lay, Kd_int=Kd_int, Kd_extra_T=visc%Kd_extra_T, Kd_extra_S=visc%Kd_extra_S)
+  else
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, &
+                         CS%set_diff_CSp, Kd_lay=Kd_lay, Kd_int=Kd_int)
+  endif
   call cpu_clock_end(id_clock_set_diffusivity)
   if (showCallTree) call callTree_waypoint("done with set_diffusivity (diabatic)")
 

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -437,16 +437,16 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
         if (KS_extra(i,K) > KT_extra(i,K)) then ! salt fingering
           Kd_lay_2d(i,k-1) = Kd_lay_2d(i,k-1) + 0.5 * KT_extra(i,K)
           Kd_lay_2d(i,k)   = Kd_lay_2d(i,k)   + 0.5 * KT_extra(i,K)
-          visc%Kd_extra_S(i,j,k) = (KS_extra(i,K) - KT_extra(i,K))
-          visc%Kd_extra_T(i,j,k) = 0.0
+          visc%Kd_extra_S(i,j,K) = (KS_extra(i,K) - KT_extra(i,K))
+          visc%Kd_extra_T(i,j,K) = 0.0
         elseif (KT_extra(i,K) > 0.0) then ! double-diffusive convection
           Kd_lay_2d(i,k-1) = Kd_lay_2d(i,k-1) + 0.5 * KS_extra(i,K)
           Kd_lay_2d(i,k)   = Kd_lay_2d(i,k)   + 0.5 * KS_extra(i,K)
-          visc%Kd_extra_T(i,j,k) = (KT_extra(i,K) - KS_extra(i,K))
-          visc%Kd_extra_S(i,j,k) = 0.0
+          visc%Kd_extra_T(i,j,K) = (KT_extra(i,K) - KS_extra(i,K))
+          visc%Kd_extra_S(i,j,K) = 0.0
         else ! There is no double diffusion at this interface.
-          visc%Kd_extra_T(i,j,k) = 0.0
-          visc%Kd_extra_S(i,j,k) = 0.0
+          visc%Kd_extra_T(i,j,K) = 0.0
+          visc%Kd_extra_S(i,j,K) = 0.0
         endif
       enddo ; enddo
       if (associated(dd%KT_extra)) then ; do K=1,nz+1 ; do i=is,ie

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -2271,8 +2271,8 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
          'User-specified Extra Diffusivity', 'm2 s-1', conversion=US%Z2_T_to_m2_s)
 
   call get_param(param_file, mdl, "DOUBLE_DIFFUSION", CS%double_diffusion, &
-                 "If true, increase diffusivites for temperature or salt "//&
-                 "based on double-diffusive parameterization from MOM4/KPP.", &
+                 "If true, increase diffusivites for temperature or salinity based on the "//&
+                 "double-diffusive parameterization described in Large et al. (1994).", &
                  default=.false.)
 
   if (CS%double_diffusion) then

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1999,7 +1999,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
   logical :: default_2018_answers
   logical :: use_kappa_shear, adiabatic, use_omega, MLE_use_PBL_MLD
-  logical :: use_CVMix_ddiff, differential_diffusion, use_KPP
+  logical :: use_KPP
   logical :: use_regridding
   character(len=200) :: filename, tideamp_file
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to OBC segment type
@@ -2024,8 +2024,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
 
   ! Set default, read and log parameters
   call log_version(param_file, mdl, version, "")
-  CS%RiNo_mix = .false. ; use_CVMix_ddiff = .false.
-  differential_diffusion = .false.
+  CS%RiNo_mix = .false.
   call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
   CS%inputdir = slasher(CS%inputdir)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
@@ -2060,11 +2059,6 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
 
   if (.not.adiabatic) then
     CS%RiNo_mix = kappa_shear_is_used(param_file)
-    call get_param(param_file, mdl, "DOUBLE_DIFFUSION", differential_diffusion, &
-                 "If true, increase diffusivites for temperature or salt "//&
-                 "based on double-diffusive parameterization from MOM4/KPP.", &
-                 default=.false.)
-    use_CVMix_ddiff = CVMix_ddiff_is_used(param_file)
   endif
 
   call get_param(param_file, mdl, "PRANDTL_TURB", visc%Prandtl_turb, &
@@ -2263,10 +2257,6 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
        Time, 'Rayleigh drag velocity at v points', 'm s-1', conversion=US%Z_to_m*US%s_to_T)
   endif
 
-  if (use_CVMix_ddiff .or. differential_diffusion) then
-    allocate(visc%Kd_extra_T(isd:ied,jsd:jed,nz+1)) ; visc%Kd_extra_T(:,:,:) = 0.0
-    allocate(visc%Kd_extra_S(isd:ied,jsd:jed,nz+1)) ; visc%Kd_extra_S(:,:,:) = 0.0
-  endif
 
   if (CS%dynamic_viscous_ML) then
     allocate(visc%nkml_visc_u(IsdB:IedB,jsd:jed)) ; visc%nkml_visc_u(:,:) = 0.0


### PR DESCRIPTION
  Revised the code to pass around the extra diffusivities for temperature and
salinity as arguments to subroutines, rather than passing them around as
elements of the vertvisc_type, where they are not a good match with other
elements.  This PR also identifies in comments some apparent bugs in which
arrays appear in calls for passive tracer mixing when MOM6 is run in ALE mode.
All answers are bitwise identical, but there are changes to the
MOM_parameter_doc files.  The commits in this PR include:

- NOAA/GFDL/MOM6@2f4ef927b +Remove visc%Kd_extra_T and visc%Kd_extra_S
- NOAA/GFDL/MOM6@34a978151 +Add Kd_extra_T opt arg to set_diffusivity
- NOAA/GFDL/MOM6@193348248 Combine loops setting double diffusion Kd_heat
- NOAA/GFDL/MOM6@c71670e29 Corrected bkgnd_mixing error messages
- NOAA/GFDL/MOM6@5cc8861ae +Revised interface to differential_diffuse_T_S
