### PR TITLE
Enables CI using GitHub actions

### DIFF
--- a/.github/actions/testing-setup/action.yml
+++ b/.github/actions/testing-setup/action.yml
@@ -1,0 +1,67 @@
+name: 'Build-.testing-prerequisites'
+description: 'Build pre-requisites for .testing including FMS and a symmetric MOM6 executable'
+runs:
+  using: 'composite'
+  steps:
+    - name: Git info
+      shell: bash
+      run: |
+        echo "::group::Git commit info"
+        echo "git log:"
+        git log | head -60
+        echo "::endgroup::"
+
+    - name: Env
+      shell: bash
+      run: |
+        echo "::group::Environment"
+        env
+        echo "::endgroup::"
+
+    - name: Install needed packages for compiling
+      shell: bash
+      run: |
+        echo "::group::Install linux packages"
+        sudo apt-get install netcdf-bin libnetcdf-dev libnetcdff-dev mpich libmpich-dev
+        echo "::endgroup::"
+
+    - name: Compile FMS library
+      shell: bash
+      run: |
+        echo "::group::Compile FMS library"
+        cd .testing
+        make deps/lib/libFMS.a -s -j
+        echo "::endgroup::"
+
+    - name: Store compiler flags used in Makefile
+      shell: bash
+      run: |
+        echo "::group::config.mk"
+        cd .testing
+        echo "FCFLAGS_DEBUG=-g -O0 -Wextra -Wno-compare-reals -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=bounds" >> config.mk
+        echo "FCFLAGS_REPRO=-g -O2 -fbacktrace" >> config.mk
+        echo "FCFLAGS_INIT=-finit-real=snan -finit-integer=2147483647 -finit-derived" >> config.mk
+        echo "FCFLAGS_COVERAGE=--coverage" >> config.mk
+        cat config.mk
+        echo "::endgroup::"
+
+    - name: Compile MOM6 in symmetric memory mode
+      shell: bash
+      run: |
+        echo "::group::Compile MOM6 in symmetric memory mode"
+        cd .testing
+        make build/symmetric/MOM6 -j
+        echo "::endgroup::"
+
+    - name: Install local python venv for generating input data
+      shell: bash
+      run: |
+        echo "::group::Create local python env for input data generation"
+        cd .testing
+        make work/local-env
+        echo "::endgroup::"
+
+    - name: Set flags
+      shell: bash
+      run: |
+        echo "TIMEFORMAT=... completed in %lR  (user: %lU, sys: %lS)" >> $GITHUB_ENV

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,24 @@
+name: Code coverage
+
+on: [push, pull_request]
+
+jobs:
+  build-test-nans:
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .testing
+
+    env:
+      REPORT_COVERAGE: true
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: ./.github/actions/testing-setup
+
+    - name: Run and post coverage
+      run: make run.symmetric -k -s

--- a/.github/workflows/documentation-and-style.yml
+++ b/.github/workflows/documentation-and-style.yml
@@ -1,0 +1,37 @@
+name: Doxygen and style
+
+on: [push, pull_request]
+
+jobs:
+  doxygen:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Check white space (non-blocking)
+      run: |
+        ./.testing/trailer.py -e TEOS10 -l 120 src config_src | tee style_errors
+      continue-on-error: true
+
+    - name: Install packages used when generating documentation
+      run: >
+        sudo apt-get install
+        python3-sphinx python3-lxml perl
+        texlive-binaries texlive-base bibtool tex-common texlive-bibtex-extra
+
+    - name: Build doxygen HTML
+      run: |
+        cd docs
+        perl -e 'print "perl version $^V" . "\n"'
+        mkdir _build && make nortd DOXYGEN_RELEASE=Release_1_8_13 UPDATEHTMLEQS=Y
+        cat _build/doxygen_warn_nortd_log.txt
+
+    - name: Report doxygen or style errors
+      run: |
+        grep "warning:" docs/_build/doxygen_warn_nortd_log.txt | grep -v "as part of a" | tee doxy_errors
+        cat style_errors doxy_errors > all_errors
+        test ! -s  all_errors

--- a/.github/workflows/expression.yml
+++ b/.github/workflows/expression.yml
@@ -1,0 +1,27 @@
+name: Expression verification
+
+on: [push, pull_request]
+
+jobs:
+  test-repro-and-dims:
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .testing
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: ./.github/actions/testing-setup
+
+    - name: Compile MOM6 using repro optimization
+      run: make build/repro/MOM6 -j
+
+    - name: Create validation data
+      run: make run.symmetric -k -s
+
+    - name: Run tests
+      run: make test.repros test.dims -k -s

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -1,0 +1,27 @@
+name: OpenMP and Restart verification
+
+on: [push, pull_request]
+
+jobs:
+  test-openmp-nan-restarts:
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .testing
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: ./.github/actions/testing-setup
+
+    - name: Compile with openMP
+      run: make build/openmp/MOM6 -j
+
+    - name: Create validation data
+      run: make run.symmetric -k -s
+
+    - name: Run tests
+      run: make test.openmps test.nans test.restarts -k -s

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,27 @@
+name: Regression
+
+on: [pull_request]
+
+jobs:
+  build-test-regression:
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .testing
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: ./.github/actions/testing-setup
+
+    - name: Compile reference model
+      run: make build.regressions MOM_TARGET_SLUG=$GITHUB_REPOSITORY MOM_TARGET_LOCAL_BRANCH=$GITHUB_BASE_REF DO_REGRESSION_TESTS=true -j
+
+    - name: Create validation data
+      run: make run.symmetric -k -s
+
+    - name: Regression test 
+      run: make test.regressions DO_REGRESSION_TESTS=true -k -s

--- a/.github/workflows/stencil.yml
+++ b/.github/workflows/stencil.yml
@@ -1,0 +1,27 @@
+name: Stencil related verification
+
+on: [push, pull_request]
+
+jobs:
+  test-symmetric-layout-rotation:
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .testing
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: ./.github/actions/testing-setup
+
+    - name: Compile MOM6 in asymmetric memory mode
+      run: make build/asymmetric/MOM6 -j
+
+    - name: Create validation data
+      run: make run.symmetric -k -s
+
+    - name: Run tests
+      run: make test.grids test.layouts test.rotations -k -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ jobs:
       env:
         - JOB="x86 Regression testing"
         - DO_REGRESSION_TESTS=true
-        - REPORT_COVERAGE=true
         - MOM_TARGET_SLUG=${TRAVIS_REPO_SLUG}
         - MOM_TARGET_LOCAL_BRANCH=${TRAVIS_BRANCH}
       script:
@@ -69,18 +68,6 @@ jobs:
         - echo -en 'travis_fold:end:script.1\\r'
         - time make -k -s test.regressions
         - make test.summary
-
-    - if: NOT type = pull_request
-      env:
-        - JOB="Coverage upload"
-        - REPORT_COVERAGE=true
-        - DO_REGRESSION_TESTS=false
-      script:
-        - cd .testing
-        - echo 'Build executables...' && echo -en 'travis_fold:start:script.1\\r'
-        - make build/symmetric/MOM6
-        - echo -en 'travis_fold:end:script.1\\r'
-        - make -k -s run.symmetric
 
     - arch: arm64
       env:


### PR DESCRIPTION
- Duplicates on "GitHub actions" the tests currently conducted on Travis-CI
- I've grouped the tests into three workflows such that each workflow
  takes a reasonable, and comparable, time to complete (< 7m30s)
  - "stencil" (symmetric/asymmetric, decomposition, rotation)
  - "expression" (repro and dimensionality)
  - "other" (OpenMP, nan initialization and restart)
- Two other workflows execute on all pushes
  - "doxygen and style" checks for doxygen errors and code style
  - "coverage" which posts code coverage to codecov and is slow enough that
    it had to be a separate workflow
- One workflow is exclusive to pull requests
  - "regression" which checks for regressions against the head of the target
    branch
- I disabled posting code coverage from Travis-CI so that we aren't
  posting the same data twice. Otherwise the tests on Travis-CI are still
  live so we have a period of overlap for safety. I have not yet tried
  the ARM64 platform on GitHub so Travis-CI is useful for providing that.