### PR TITLE
Additions from GMAO (2): Add hooks to get melt_potential and OBLD

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -898,7 +898,7 @@ subroutine convert_state_to_ocean_type(sfc_state, Ocean_sfc, G, US, patm, press_
       Ocean_sfc%melt_potential(i,j) = US%Q_to_J_kg*US%RZ_to_kg_m2 * sfc_state%melt_potential(i+i0,j+j0)
     enddo ; enddo
   endif
-  
+
   if (allocated(sfc_state%Hml)) then
     do j=jsc_bnd,jec_bnd ; do i=isc_bnd,iec_bnd
       Ocean_sfc%OBLD(i,j) = US%Z_to_m * sfc_state%Hml(i+i0,j+j0)

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -806,8 +806,8 @@ subroutine initialize_ocean_public_type(input_domain, Ocean_sfc, diag, maskmap, 
   Ocean_sfc%v_surf(:,:)  = 0.0  ! time averaged v-current (m/sec)  passed to atmosphere/ice models
   Ocean_sfc%sea_lev(:,:) = 0.0  ! time averaged thickness of top model grid cell (m) plus patm/rho0/grav
   Ocean_sfc%frazil(:,:)  = 0.0  ! time accumulated frazil (J/m^2) passed to ice model
-  Ocean_sfc%melt_potential  = 0.0  ! time accumulated melt potential (J/m^2) passed to ice model
-  Ocean_sfc%OBLD    = 0.0  ! ocean boundary layer depth (m)
+  Ocean_sfc%melt_potential(:,:)  = 0.0  ! time accumulated melt potential (J/m^2) passed to ice model
+  Ocean_sfc%OBLD(:,:)    = 0.0  ! ocean boundary layer depth (m)
   Ocean_sfc%area(:,:)    = 0.0
   Ocean_sfc%axes    = diag%axesT1%handles !diag axes to be used by coupler tracer flux diagnostics
 

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -121,8 +121,8 @@ type, public ::  ocean_public_type
                         !! i.e. dzt(1) + eta_t + patm/rho0/grav [m]
     frazil =>NULL(), &  !< Accumulated heating [J m-2] from frazil
                         !! formation in the ocean.
-    melt_potential => NULL(), & !< Instantaneous heat used to melt sea ice (in J/m^2)
-    OBLD => NULL(),   & !< Ocean boundary layer depth, in m.
+    melt_potential => NULL(), & !< Instantaneous heat used to melt sea ice [J m-2].
+    OBLD => NULL(),   & !< Ocean boundary layer depth [m].
     area => NULL()      !< cell area of the ocean surface [m2].
   type(coupler_2d_bc_type) :: fields    !< A structure that may contain named
                                         !! arrays of tracer-related surface fields.
@@ -807,7 +807,7 @@ subroutine initialize_ocean_public_type(input_domain, Ocean_sfc, diag, maskmap, 
   Ocean_sfc%sea_lev(:,:) = 0.0  ! time averaged thickness of top model grid cell (m) plus patm/rho0/grav
   Ocean_sfc%frazil(:,:)  = 0.0  ! time accumulated frazil (J/m^2) passed to ice model
   Ocean_sfc%melt_potential  = 0.0  ! time accumulated melt potential (J/m^2) passed to ice model
-  Ocean_sfc%OBLD    = 0.0  ! ocean boundary layer depth, in m
+  Ocean_sfc%OBLD    = 0.0  ! ocean boundary layer depth (m)
   Ocean_sfc%area(:,:)    = 0.0
   Ocean_sfc%axes    = diag%axesT1%handles !diag axes to be used by coupler tracer flux diagnostics
 


### PR DESCRIPTION
This PR includes addition of:
- melt potential
- ocean boundary layer depth (OBLD)

to variables that can obtained by `ocean_model_data2D_get`