### PR TITLE
Autoconf: netCDF flag fixes

### DIFF
--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -82,12 +82,20 @@ AX_FC_CHECK_MODULE([mpi],
 
 
 # netCDF configuration
-AC_PATH_PROG([NC_CONFIG], [nc-config])
-AS_IF([test -n "$NC_CONFIG"],
-  [CPPFLAGS="$CPPFLAGS -I$($NC_CONFIG --includedir)"
-  FCFLAGS="$FCFLAGS -I$($NC_CONFIG --includedir)"
-  LDFLAGS="$LDFLAGS -L$($NC_CONFIG --libdir)"],
-  [AC_MSG_ERROR([Could not find nc-config.])])
+
+# NOTE: `nf-config --flibs` combines library paths (-L) and libraries (-l),
+#   even though these ought to be separated in the invocation of `ld`.
+#
+# We use `sed` to strip the -l and pass the -L to LDFLAGS, and rely on autoconf
+#   to configure the -l flags.
+AC_PROG_SED
+
+AC_PATH_PROG([NF_CONFIG], [nf-config])
+AS_IF([test -n "$NF_CONFIG"],
+  [CPPFLAGS="$CPPFLAGS $($NF_CONFIG --fflags)"
+  FCFLAGS="$FCFLAGS $($NF_CONFIG --fflags)"
+  LDFLAGS="$LDFLAGS $($NF_CONFIG --flibs | $SED -e 's/-l[[^ 	]]*//g')"],
+  [AC_MSG_ERROR([Could not find nf-config.])])
 
 AX_FC_CHECK_MODULE([netcdf],
   [], [AC_MSG_ERROR([Could not find netcdf module.])])

--- a/ac/deps/configure.fms.ac
+++ b/ac/deps/configure.fms.ac
@@ -73,12 +73,20 @@ AC_DEFINE([use_libMPI])
 
 
 # netCDF configuration
-AC_PATH_PROG([NC_CONFIG], [nc-config])
-AS_IF([test -n "$NC_CONFIG"],
-  [CPPFLAGS="$CPPFLAGS -I$($NC_CONFIG --includedir)"
-  FCFLAGS="$FCFLAGS -I$($NC_CONFIG --includedir)"
-  LDFLAGS="$LDFLAGS -L$($NC_CONFIG --libdir)"],
-  [AC_MSG_ERROR([Could not find nc-config.])])
+
+# NOTE: `nf-config --flibs` combines library paths (-L) and libraries (-l),
+#   even though these ought to be separated in the invocation of `ld`.
+#
+# We use `sed` to strip the -l and pass the -L to LDFLAGS, and rely on autoconf
+#   to configure the -l flags.
+AC_PROG_SED
+
+AC_PATH_PROG([NF_CONFIG], [nf-config])
+AS_IF([test -n "$NF_CONFIG"],
+  [CPPFLAGS="$CPPFLAGS $($NF_CONFIG --fflags)"
+  FCFLAGS="$FCFLAGS $($NF_CONFIG --fflags)"
+  LDFLAGS="$LDFLAGS $($NF_CONFIG --flibs | $SED -e 's/-l[[^ 	]]*//g')"],
+  [AC_MSG_ERROR([Could not find nf-config.])])
 
 AX_FC_CHECK_MODULE([netcdf],
   [], [AC_MSG_ERROR([Could not find netcdf module.])])


### PR DESCRIPTION
Autoconf netCDF flag configuration was broken due to using nc-config for
Fortran flags, and assuming that C and Fortran files (modules,
libraries, etc) were installed in the same directory.

This patch replaces the lower level --includedir and --libdir flags with
the higher level --fflags and --flibs flags, which provide more
processed Fortran output.

One significant issue here is that --flibs combines the directory (-L)
and library (-l) flags into a single output, even though these should be
split when passed to `ld`, with autoconf passing the former to LDFLAGS
and the latter to LIBS.

We resolve this by stripping the -l flags (via sed) and pass the
remaining flags (almost always -L) to LDFLAGS.  We rely on autoconf
macros to assign the -l flags to LIBS.

This should resolve issues where nc-fortran and nf-fortran are installed
in separate directories.  This was detected in a spack-based
environment, where this would be commonplace.