### PR TITLE
Adding apt-get update to avoid libpoppler73 issue

### DIFF
--- a/.github/workflows/documentation-and-style.yml
+++ b/.github/workflows/documentation-and-style.yml
@@ -18,11 +18,11 @@ jobs:
       continue-on-error: true
 
     - name: Install packages used when generating documentation
-      run: >
-        sudo apt-get install
-        python3-sphinx python3-lxml perl
-        texlive-binaries texlive-base bibtool tex-common texlive-bibtex-extra
-        graphviz
+      run: |
+        sudo apt-get update
+        sudo apt-get install python3-sphinx python3-lxml perl
+        sudo apt-get install texlive-binaries texlive-base bibtool tex-common texlive-bibtex-extra
+        sudo apt-get install graphviz
 
     - name: Build doxygen HTML
       run: |


### PR DESCRIPTION
- Apparently security issues with libpoppler73 have caused the texlive package install to fail. This is fixed by updating the package list before installing any packages. Without texlive-bibtex-extra the `\cite` commands in the doxumentation was causing warnings from doxygen which we consider an error.