### PR TITLE
Use flush function instead of subroutine/extension

### DIFF
--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -257,7 +257,7 @@ program MOM_main
 !$  call omp_set_num_threads(ocean_nthreads)
 !$OMP PARALLEL
 !$  write(6,*) "ocean_solo OMPthreading ", fms_affinity_get(), omp_get_thread_num(), omp_get_num_threads()
-!$  call flush(6)
+!$  flush(6)
 !$OMP END PARALLEL
 
   ! Read ocean_solo restart, which can override settings from the namelist.

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -390,7 +390,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt_in_T, G, GV, US, CS, vel_rp
 
     write(file,'(2/)')
 
-    call flush(file)
+    flush(file)
   endif
 
 end subroutine write_u_accel
@@ -722,7 +722,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt_in_T, G, GV, US, CS, vel_rp
 
     write(file,'(2/)')
 
-    call flush(file)
+    flush(file)
   endif
 
 end subroutine write_v_accel

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -1309,7 +1309,7 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
 !$   call fms_affinity_set('OCEAN', ocean_omp_hyper_thread, ocean_nthreads)
 !$   call omp_set_num_threads(ocean_nthreads)
 !$   write(6,*) "MOM_domains_mod OMPthreading ", fms_affinity_get(), omp_get_thread_num(), omp_get_num_threads()
-!$   call flush(6)
+!$   flush(6)
 !$ endif
 #endif
   call log_param(param_file, mdl, "!SYMMETRIC_MEMORY_", MOM_dom%symmetric, &

--- a/src/framework/MOM_write_cputime.F90
+++ b/src/framework/MOM_write_cputime.F90
@@ -110,7 +110,7 @@ subroutine MOM_write_cputime_end(CS)
 
   ! Flush and close the output files.
   if (is_root_pe() .and. CS%fileCPU_ascii > 0) then
-    call flush(CS%fileCPU_ascii)
+    flush(CS%fileCPU_ascii)
     call close_file(CS%fileCPU_ascii)
   endif
 
@@ -200,7 +200,7 @@ subroutine write_cputime(day, n, CS, nmax, call_end)
            reday, n, (CS%cputime2 / real(CLOCKS_PER_SEC)), &
            d_cputime / real(CLOCKS_PER_SEC)
 
-    call flush(CS%fileCPU_ascii)
+    flush(CS%fileCPU_ascii)
   endif
   CS%previous_calls = CS%previous_calls + 1
 


### PR DESCRIPTION
This fixes #1263. It converts the `call FLUSH()` in MOM6 to be `flush()`