### PR TITLE
Revert drivers

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -48,7 +48,6 @@ use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_ice_shelf, only : initialize_ice_shelf, shelf_calc_flux, ice_shelf_CS
 use MOM_ice_shelf, only : add_shelf_forces, ice_shelf_end, ice_shelf_save_restart
-use MOM_IS_diag_mediator, only : diag_IS_ctrl => diag_ctrl, diag_mediator_IS_end=>diag_mediator_end
 use coupler_types_mod, only : coupler_1d_bc_type, coupler_2d_bc_type
 use coupler_types_mod, only : coupler_type_spawn, coupler_type_write_chksums
 use coupler_types_mod, only : coupler_type_initialized, coupler_type_copy_data
@@ -217,9 +216,6 @@ type, public :: ocean_state_type ; private
                               !! that will be used for MOM restart files.
   type(diag_ctrl), pointer :: &
     diag => NULL()            !< A pointer to the diagnostic regulatory structure
-  type(diag_IS_ctrl), pointer :: &
-    diag_IS => NULL()         !< A pointer to the diagnostic regulatory structure
-                              !! for the ice shelf module.
 end type ocean_state_type
 
 contains
@@ -728,8 +724,6 @@ subroutine ocean_model_end(Ocean_sfc, Ocean_state, Time)
 
   call ocean_model_save_restart(Ocean_state, Time)
   call diag_mediator_end(Time, Ocean_state%diag)
-  if (Ocean_state%use_ice_shelf) &
-    call diag_mediator_IS_end(Time, Ocean_state%diag_IS)
   call MOM_end(Ocean_state%MOM_CSp)
   if (Ocean_state%use_ice_shelf) call ice_shelf_end(Ocean_state%Ice_shelf_CSp)
 end subroutine ocean_model_end

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -182,13 +182,13 @@ type, public :: ocean_state_type ; private
                               !! processes before time stepping the dynamics.
 
   type(directories) :: dirs   !< A structure containing several relevant directory paths.
-  type(mech_forcing), pointer :: forces => NULL() !< A structure with the driving mechanical surface forces
-  type(forcing), pointer      :: fluxes => NULL()   !< A structure containing pointers to
+  type(mech_forcing)          :: forces => NULL() !< A structure with the driving mechanical surface forces
+  type(forcing)               :: fluxes => NULL()   !< A structure containing pointers to
                                                     !! the thermodynamic ocean forcing fields.
-  type(forcing), pointer      :: flux_tmp => NULL() !< A secondary structure containing pointers to the
+  type(forcing)               :: flux_tmp => NULL() !< A secondary structure containing pointers to the
                               !! ocean forcing fields for when multiple coupled
                               !! timesteps are taken per thermodynamic step.
-  type(surface), pointer      :: sfc_state => NULL() !< A structure containing pointers to
+  type(surface)               :: sfc_state => NULL() !< A structure containing pointers to
                               !! the ocean surface state fields.
   type(ocean_grid_type), pointer :: &
     grid => NULL()            !< A pointer to a grid structure containing metrics
@@ -273,9 +273,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
   endif
   allocate(OS)
 
-  allocate(OS%fluxes)
-  allocate(OS%forces)
-  allocate(OS%flux_tmp)
+!  allocate(OS%fluxes)
+!  allocate(OS%forces)
+!  allocate(OS%flux_tmp)
 
   OS%is_ocean_pe = Ocean_sfc%is_ocean_pe
   if (.not.OS%is_ocean_pe) return
@@ -379,7 +379,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
 
   if (OS%use_ice_shelf)  then
     call initialize_ice_shelf(param_file, OS%grid, OS%Time, OS%ice_shelf_CSp, &
-                              OS%diag_IS, OS%forces, OS%fluxes)
+                              OS%diag, OS%forces, OS%fluxes)
   endif
   if (OS%icebergs_alter_ocean)  then
     call marine_ice_init(OS%Time, OS%grid, param_file, OS%diag, OS%marine_ice_CSp)

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -182,13 +182,13 @@ type, public :: ocean_state_type ; private
                               !! processes before time stepping the dynamics.
 
   type(directories) :: dirs   !< A structure containing several relevant directory paths.
-  type(mech_forcing)          :: forces => NULL() !< A structure with the driving mechanical surface forces
-  type(forcing)               :: fluxes => NULL()   !< A structure containing pointers to
+  type(mech_forcing)          :: forces  !< A structure with the driving mechanical surface forces
+  type(forcing)               :: fluxes  !< A structure containing pointers to
                                                     !! the thermodynamic ocean forcing fields.
-  type(forcing)               :: flux_tmp => NULL() !< A secondary structure containing pointers to the
+  type(forcing)               :: flux_tmp !< A secondary structure containing pointers to the
                               !! ocean forcing fields for when multiple coupled
                               !! timesteps are taken per thermodynamic step.
-  type(surface)               :: sfc_state => NULL() !< A structure containing pointers to
+  type(surface)               :: sfc_state   !< A structure containing pointers to
                               !! the ocean surface state fields.
   type(ocean_grid_type), pointer :: &
     grid => NULL()            !< A pointer to a grid structure containing metrics
@@ -365,7 +365,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
     use_melt_pot=.false.
   endif
 
-  allocate(OS%sfc_state)
+  !allocate(OS%sfc_state)
   call allocate_surface_state(OS%sfc_state, OS%grid, use_temperature, do_integrals=.true., &
                               gas_fields_ocn=gas_fields_ocn, use_meltpot=use_melt_pot)
 

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -28,7 +28,6 @@ program MOM_main
   use MOM_cpu_clock,       only : CLOCK_COMPONENT
   use MOM_diag_mediator,   only : enable_averaging, disable_averaging, diag_mediator_end
   use MOM_diag_mediator,   only : diag_ctrl, diag_mediator_close_registration
-  use MOM_IS_diag_mediator,   only : diag_IS_ctrl=>diag_ctrl, diag_mediator_IS_end=>diag_mediator_end
   use MOM,                 only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
   use MOM,                 only : extract_surface_state, finish_MOM_initialization
   use MOM,                 only : get_MOM_state_elements, MOM_state_is_synchronized
@@ -199,8 +198,6 @@ program MOM_main
                               !! that will be used for MOM restart files.
   type(diag_ctrl),           pointer :: &
        diag => NULL()         !< A pointer to the diagnostic regulatory structure
-  type(diag_IS_ctrl), pointer :: &
-      diag_IS => NULL()       !< A pointer to the diagnostic regulatory structure
   !-----------------------------------------------------------------------
 
   character(len=4), parameter :: vers_num = 'v2.0'
@@ -665,7 +662,6 @@ program MOM_main
 
   call callTree_waypoint("End MOM_main")
   call diag_mediator_end(Time, diag, end_diag_manager=.true.)
-  if (use_ice_shelf) call diag_mediator_IS_end(Time, diag_IS)
   if (cpu_steps > 0) call write_cputime(Time, ns-1, write_CPU_CSp, call_end=.true.)
   call cpu_clock_end(termClock)
 

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -80,13 +80,12 @@ program MOM_main
 #include <MOM_memory.h>
 
   ! A structure with the driving mechanical surface forces
-  type(mech_forcing), pointer :: forces => NULL()
+  type(mech_forcing) :: forces
   ! A structure containing pointers to the thermodynamic forcing fields
   ! at the ocean surface.
-  type(forcing), pointer :: fluxes => NULL()
-
+  type(forcing) :: fluxes
   ! A structure containing pointers to the ocean surface state fields.
-  type(surface), pointer :: sfc_state => NULL()
+  type(surface) :: sfc_state
 
   ! A pointer to a structure containing metrics and related information.
   type(ocean_grid_type), pointer :: grid => NULL()
@@ -221,7 +220,7 @@ program MOM_main
 
   call MOM_infra_init() ; call io_infra_init()
 
-  allocate(forces,fluxes,sfc_state)
+  !allocate(forces,fluxes,sfc_state)
 
   ! Initialize the ensemble manager.  If there are no settings for ensemble_size
   ! in input.nml(ensemble.nml), these should not do anything.  In coupled

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -141,7 +141,7 @@ use MOM_offline_main,          only : offline_redistribute_residual, offline_dia
 use MOM_offline_main,          only : offline_fw_fluxes_into_ocean, offline_fw_fluxes_out_ocean
 use MOM_offline_main,          only : offline_advection_layer, offline_transport_end
 use MOM_ALE,                   only : ale_offline_tracer_final, ALE_main_offline
-use MOM_ice_shelf,             only : ice_shelf_CS, ice_shelf_query
+use MOM_ice_shelf,             only : ice_shelf_CS, ice_shelf_query, initialize_ice_shelf
 
 implicit none ; private
 
@@ -2037,7 +2037,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   use_ice_shelf=.false.
   if (present(ice_shelf_CSp)) then
-    if (associated(ice_shelf_CSp)) use_ice_shelf=.true.
+    call get_param(param_file, "MOM", "ICE_SHELF", use_ice_shelf, &
+       "If true, enables the ice shelf model.", default=.false.)
   endif
 
   CS%ensemble_ocean=.false.
@@ -2381,6 +2382,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     endif
 
     if (use_ice_shelf) then
+      ! These arrays are not initialized in most solo cases, but are needed
+      ! when using an ice shelf. Passing the ice shelf diagnostics CS from MOM
+      ! for legacy reasons. The actual ice shelf diag CS is internal to the ice shelf
+      call initialize_ice_shelf(param_file, G_in, Time, ice_shelf_CSp, diag_ptr)
       allocate(frac_shelf_in(G_in%isd:G_in%ied, G_in%jsd:G_in%jed))
       frac_shelf_in(:,:) = 0.0
       allocate(CS%frac_shelf_h(isd:ied, jsd:jed))
@@ -2431,10 +2436,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
       deallocate(frac_shelf_in)
   else
     if (use_ice_shelf) then
+      call initialize_ice_shelf(param_file, G, Time, ice_shelf_CSp, diag_ptr)
       allocate(CS%frac_shelf_h(isd:ied, jsd:jed))
       CS%frac_shelf_h(:,:) = 0.0
       call ice_shelf_query(ice_shelf_CSp,G,CS%frac_shelf_h)
-
       call MOM_initialize_state(CS%u, CS%v, CS%h, CS%tv, Time, G, GV, US, &
           param_file, dirs, restart_CSp, CS%ALE_CSp, CS%tracer_Reg, &
           CS%sponge_CSp, CS%ALE_sponge_CSp, CS%OBC, Time_in, &

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -15,6 +15,7 @@ use MOM_IS_diag_mediator, only : set_axes_info
 use MOM_IS_diag_mediator, only : diag_mediator_init, set_diag_mediator_grid, diag_ctrl, time_type
 use MOM_IS_diag_mediator, only : enable_averages, enable_averaging, disable_averaging
 use MOM_IS_diag_mediator, only : diag_mediator_infrastructure_init, diag_mediator_close_registration
+use MOM_IS_diag_mediator, only : diag_mediator_end
 use MOM_domains, only : MOM_domains_init, clone_MOM_domain
 use MOM_domains, only : pass_var, pass_vector, TO_ALL, CGRID_NE, BGRID_NE, CORNER
 use MOM_dyn_horgrid, only : dyn_horgrid_type, create_dyn_horgrid, destroy_dyn_horgrid
@@ -2059,6 +2060,7 @@ subroutine ice_shelf_end(CS)
 
   if (CS%active_shelf_dynamics) call ice_shelf_dyn_end(CS%dCS)
 
+  call diag_mediator_end(CS%diag)
   deallocate(CS)
 
 end subroutine ice_shelf_end

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1207,7 +1207,6 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
   real    :: col_thick_melt_thresh ! An ocean column thickness below which iceshelf melting
                                    ! does not occur [Z ~> m]
   real, allocatable, dimension(:,:) :: tmp2d ! Temporary array for storing ice shelf input data
-
   type(mech_forcing), pointer :: forces => NULL()
   type(forcing), pointer :: fluxes =>  NULL()
   type(surface), pointer :: sfc_state => NULL()
@@ -1294,6 +1293,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
   call MOM_initialize_topography(dG%bathyT, CS%Grid%max_depth, dG, param_file)
   call rescale_dyn_horgrid_bathymetry(dG, CS%US%Z_to_m)
   call copy_dyngrid_to_MOM_grid(dG,CS%Grid,CS%US)
+  call destroy_dyn_horgrid(dG)
 !  endif
   G=>CS%Grid
 

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -82,14 +82,14 @@ type, public :: ice_shelf_CS ; private
   ! Parameters
   type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< A pointer to the restart control
                                                   !! structure for the ice shelves
-  type(ocean_grid_type)         :: Grid_in        !< un-rotated input grid metric
+  type(ocean_grid_type), pointer         :: Grid_in => NULL()        !< un-rotated input grid metric
   type(hor_index_type), pointer :: HI_in => NULL()  !< Pointer to a horizontal indexing structure for
                                                     !! incoming data which has not been rotated.
   type(hor_index_type), pointer :: HI => NULL()  !< Pointer to a horizontal indexing structure for
                                                  !! incoming data which has not been rotated.
   logical :: rotate_index = .false.   !< True if index map is rotated
   integer :: turns                    !< The number of quarter turns for rotation testing.
-  type(ocean_grid_type), pointer :: Grid => NULL() !< Grid for the ice-shelf model
+  type(ocean_grid_type), pointer                :: Grid => NULL()   !< Grid for the ice-shelf model
   type(unit_scale_type), pointer :: &
     US => NULL()       !< A structure containing various unit conversion factors
   type(ocean_grid_type), pointer :: ocn_grid => NULL() !< A pointer to the ocean model grid
@@ -1248,12 +1248,12 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
 
   ! Set up the ice-shelf domain and grid
   wd_halos(:)=0
-  !allocate(CS%Grid_in)
-  call MOM_domains_init(CS%Grid_in%domain, param_file, min_halo=wd_halos, symmetric=GRID_SYM_,&
+  allocate(CS%Grid)
+  call MOM_domains_init(CS%Grid%domain, param_file, min_halo=wd_halos, symmetric=GRID_SYM_,&
        domain_name='MOM_Ice_Shelf_in')
-  call hor_index_init(CS%Grid_in%Domain, CS%Grid_in%HI, param_file, &
-       local_indexing=.not.global_indexing)
-  call MOM_grid_init(CS%Grid_in, param_file, CS%US, CS%Grid_in%HI)
+  !call hor_index_init(CS%Grid%Domain, CS%Grid%HI, param_file, &
+  !     local_indexing=.not.global_indexing)
+  call MOM_grid_init(CS%Grid, param_file, CS%US)
 
   ! if (CS%rotate_index) then
   !   ! TODO: Index rotation currently only works when index rotation does not
@@ -1284,7 +1284,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
   !   call rotate_dyngrid(dG_in, dG, CS%US, CS%turns)
   !   call copy_dyngrid_to_MOM_grid(dG,CS%Grid,CS%US)
   ! else
-  CS%Grid=>CS%Grid_in
+  !CS%Grid=>CS%Grid_in
   dG=>NULL()
   !CS%Grid%HI=>CS%Grid_in%HI
   call create_dyn_horgrid(dG, CS%Grid%HI)
@@ -1296,7 +1296,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
   call copy_dyngrid_to_MOM_grid(dG,CS%Grid,CS%US)
   call destroy_dyn_horgrid(dG)
 !  endif
-  G=>CS%Grid
+  G=>CS%Grid;CS%Grid_in=>CS%Grid
 
   if (complete_initialization) then
     allocate(CS%diag)

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1727,13 +1727,14 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
     if (G%areaT(i,j)>0.) fluxes%frac_shelf_h(i,j) = ISS%area_shelf_h(i,j) / G%areaT(i,j)
   enddo ; enddo ; endif
 
+  if (.not. complete_initialization) return
+
+
   if (CS%debug) then
     call hchksum(fluxes%frac_shelf_h, "IS init: frac_shelf_h", G%HI, haloshift=0)
     call hchksum(ISS%area_shelf_h, "IS init: area_shelf_h", G%HI, haloshift=0, scale=US%L_to_m*US%L_to_m)
   endif
 
-
-  if (.not. complete_initialization) return
 
   ! Set up the restarts.
 

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -319,12 +319,12 @@ subroutine post_data(diag_field_id, field, diag_cs, is_static, mask)
     endif
   elseif (diag_cs%ave_enabled) then
     if (present(mask)) then
-!      used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
-!                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
-!                       weight=diag_cs%time_int, mask=mask)
       used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
                        is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
-                       weight=diag_cs%time_int)
+                       weight=diag_cs%time_int, mask=mask)
+!      used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
+!                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
+!                       weight=diag_cs%time_int)
     elseif(i_data .and. associated(diag%mask2d)) then
 !      used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
 !                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -304,28 +304,41 @@ subroutine post_data(diag_field_id, field, diag_cs, is_static, mask)
       used = send_data(fms_diag_id, locfield, &
                        is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, mask=mask)
     elseif(i_data .and. associated(diag%mask2d)) then
+!      used = send_data(fms_diag_id, locfield, &
+!           is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, rmask=diag%mask2d)
       used = send_data(fms_diag_id, locfield, &
-                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, rmask=diag%mask2d)
+                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev)
     elseif((.not.i_data) .and. associated(diag%mask2d_comp)) then
+!      used = send_data(fms_diag_id, locfield, &
+!           is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, rmask=diag%mask2d_comp)
       used = send_data(fms_diag_id, locfield, &
-                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, rmask=diag%mask2d_comp)
+                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev)
     else
       used = send_data(fms_diag_id, locfield, &
                        is_in=isv, js_in=jsv, ie_in=iev, je_in=jev)
     endif
   elseif (diag_cs%ave_enabled) then
     if (present(mask)) then
+!      used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
+!                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
+!                       weight=diag_cs%time_int, mask=mask)
       used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
                        is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
-                       weight=diag_cs%time_int, mask=mask)
+                       weight=diag_cs%time_int)
     elseif(i_data .and. associated(diag%mask2d)) then
+!      used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
+!                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
+!                       weight=diag_cs%time_int, rmask=diag%mask2d)
       used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
                        is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
-                       weight=diag_cs%time_int, rmask=diag%mask2d)
+                       weight=diag_cs%time_int)
     elseif((.not.i_data) .and. associated(diag%mask2d_comp)) then
+!      used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
+!                       is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
+!                       weight=diag_cs%time_int, rmask=diag%mask2d_comp)
       used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
                        is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
-                       weight=diag_cs%time_int, rmask=diag%mask2d_comp)
+                       weight=diag_cs%time_int)
     else
       used = send_data(fms_diag_id, locfield, diag_cs%time_end, &
                        is_in=isv, js_in=jsv, ie_in=iev, je_in=jev, &
@@ -483,7 +496,6 @@ function register_MOM_IS_diag_field(module_name, field_name, axes, init_time, &
 
   !Decide what mask to use based on the axes info
   if (primary_id > 0) then
-  !3d masks
     !2d masks
     if (axes%rank == 2) then
       diag%mask2d => null() ; diag%mask2d_comp => null()
@@ -682,7 +694,7 @@ subroutine diag_masks_set(G, missing_value, diag_cs)
   type(diag_ctrl),             intent(inout) :: diag_cs !< A structure that is used to regulate diagnostic output
 
   ! Local variables
-  integer :: i, j, k, NkIce, CatIce
+  integer :: i, j
 
 
   diag_cs%mask2dT  => G%mask2dT
@@ -711,8 +723,7 @@ subroutine diag_mediator_close_registration(diag_CS)
 end subroutine diag_mediator_close_registration
 
 !> Deallocate memory associated with the MOM_IS diag mediator
-subroutine diag_mediator_end(time, diag_CS)
-  type(time_type), intent(in) :: time !< The current model time
+subroutine diag_mediator_end(diag_CS)
   type(diag_ctrl), intent(inout) :: diag_CS !< A structure that is used to regulate diagnostic output
 
   if (diag_CS%doc_unit > -1) then


### PR DESCRIPTION
This PR reverts recent modifications to MOM6 drivers for the ice shelf module.  

* Existing experiments with  ICE_SHELF = True need to modify their diag_table for ice shelf diagnostics. In the first column of the table, "ocean_model" becomes "ice_shelf_model" for ice shelf diagnostics. 