### PR TITLE
+Cleanup of framework module use and wrapping

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -27,7 +27,7 @@ use MOM_error_handler,     only : MOM_set_verbosity, callTree_showQuery
 use MOM_error_handler,     only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,       only : get_param, log_version, param_file_type
 use MOM_get_input,         only : directories
-use MOM_io,                only : MOM_io_init, vardesc, var_desc
+use MOM_io,                only : vardesc, var_desc
 use MOM_restart,           only : register_restart_field, register_restart_pair
 use MOM_restart,           only : query_initialized, save_restart
 use MOM_restart,           only : restart_init, is_new_run, MOM_restart_CS

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -68,7 +68,6 @@ use MOM_domains, only : To_South, To_West, To_All, CGRID_NE, SCALAR_PAIR
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
-use MOM_io, only : MOM_io_init
 use MOM_restart, only : register_restart_field, query_initialized, save_restart
 use MOM_restart, only : restart_init, MOM_restart_CS
 use MOM_time_manager, only : time_type, real_to_time, operator(+)

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -67,7 +67,6 @@ use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : MOM_set_verbosity
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
-use MOM_io, only : MOM_io_init
 use MOM_restart, only : register_restart_field, query_initialized, save_restart
 use MOM_restart, only : restart_init, MOM_restart_CS
 use MOM_time_manager, only : time_type, time_type_to_real, operator(+)

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -80,7 +80,6 @@ use coord_zlike,          only : build_zstar_column
 use coord_sigma,          only : build_sigma_column
 use coord_rho,            only : build_rho_column
 
-use diag_axis_mod,     only : get_diag_axis_name
 use diag_manager_mod,  only : diag_axis_init
 
 use MOM_debugging,     only : check_column_integrals

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -24,15 +24,12 @@ use MOM_time_manager, only : init_external_field
 use MOM_time_manager, only : get_external_field_axes, get_external_field_missing
 use MOM_transform_FMS, only : time_interp_external => rotated_time_interp_external
 use MOM_variables, only : thermo_var_ptrs
-use mpp_io_mod, only : axistype
-use mpp_domains_mod, only  : mpp_global_field, mpp_get_compute_domain
-use mpp_mod, only          : mpp_broadcast,mpp_root_pe,mpp_sync,mpp_sync_self
-use mpp_mod, only          : mpp_max
-use horiz_interp_mod, only : horiz_interp_new, horiz_interp,horiz_interp_type
+
+use mpp_io_mod, only : axistype, mpp_get_axis_data
+use mpp_mod, only          : mpp_broadcast, mpp_sync, mpp_sync_self, mpp_max
+use horiz_interp_mod, only : horiz_interp_new, horiz_interp, horiz_interp_type
 use horiz_interp_mod, only : horiz_interp_init, horiz_interp_del
 
-use mpp_io_mod, only : mpp_get_axis_data
-use mpp_io_mod, only : MPP_SINGLE
 use netcdf
 
 implicit none ; private

--- a/src/framework/MOM_random.F90
+++ b/src/framework/MOM_random.F90
@@ -11,7 +11,7 @@ use MersenneTwister_mod, only : new_RandomNumberSequence ! Constructor/initializ
 use MersenneTwister_mod, only : getRandomReal ! Generates a random number
 use MersenneTwister_mod, only : getRandomPositiveInt ! Generates a random positive integer
 
-use MOM_io, only : stdout, stderr
+use iso_fortran_env,     only : stdout=>output_unit, stderr=>error_unit
 
 implicit none ; private
 
@@ -22,8 +22,6 @@ public :: random_2d_constructor
 public :: random_2d_01
 public :: random_2d_norm
 public :: random_unit_tests
-
-#include <MOM_memory.h>
 
 !> Container for pseudo-random number generators
 type, public :: PRNG ; private
@@ -63,7 +61,7 @@ end function random_norm
 subroutine random_2d_01(CS, HI, rand)
   type(PRNG),           intent(inout) :: CS !< Container for pseudo-random number generators
   type(hor_index_type), intent(in)    :: HI !< Horizontal index structure
-  real, dimension(SZI_(HI),SZJ_(HI)), intent(out) :: rand !< Random numbers between 0 and 1
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), intent(out) :: rand !< Random numbers between 0 and 1
   ! Local variables
   integer :: i,j
 
@@ -80,7 +78,7 @@ end subroutine random_2d_01
 subroutine random_2d_norm(CS, HI, rand)
   type(PRNG),           intent(inout) :: CS !< Container for pseudo-random number generators
   type(hor_index_type), intent(in)    :: HI !< Horizontal index structure
-  real, dimension(SZI_(HI),SZJ_(HI)), intent(out) :: rand !< Random numbers between 0 and 1
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), intent(out) :: rand !< Random numbers between 0 and 1
   ! Local variables
   integer :: i,j,n
 

--- a/src/framework/MOM_transform_FMS.F90
+++ b/src/framework/MOM_transform_FMS.F90
@@ -7,7 +7,7 @@ use horiz_interp_mod, only : horiz_interp_type
 use MOM_error_handler, only : MOM_error, FATAL
 use MOM_io, only : fieldtype, write_field
 use mpp_domains_mod, only : domain2D
-use fms_mod, only : mpp_chksum
+use mpp_mod, only : mpp_chksum
 use time_manager_mod, only : time_type
 use time_interp_external_mod, only : time_interp_external
 

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -4,27 +4,17 @@ module MOM_tracer_initialization_from_Z
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_debugging, only : hchksum
-use MOM_coms, only : max_across_PEs, min_across_PEs
 use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
-use MOM_cpu_clock, only :  CLOCK_ROUTINE, CLOCK_LOOP
-use MOM_density_integrals, only : int_specific_vol_dp
-use MOM_domains, only : pass_var, pass_vector, sum_across_PEs, broadcast
-use MOM_domains, only : root_PE, To_All, SCALAR_PAIR, CGRID_NE, AGRID
-use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
+use MOM_cpu_clock, only : CLOCK_ROUTINE, CLOCK_LOOP
+use MOM_domains, only : pass_var
+use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
-use MOM_file_parser, only : get_param, read_param, log_param, param_file_type
-use MOM_file_parser, only : log_version
-use MOM_get_input, only : directories
-use MOM_grid, only : ocean_grid_type, isPointInCell
+use MOM_file_parser, only : get_param, param_file_type, log_version
+use MOM_grid, only : ocean_grid_type
 use MOM_horizontal_regridding, only : myStats, horiz_interp_and_extrap_tracer
-use MOM_regridding, only : regridding_CS
 use MOM_remapping, only : remapping_CS, initialize_remapping
-use MOM_remapping, only : remapping_core_h
-use MOM_string_functions, only : uppercase
 use MOM_unit_scaling, only : unit_scale_type
-use MOM_variables, only : thermo_var_ptrs
-use MOM_verticalGrid, only : verticalGrid_type, setVerticalGridAxes
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
+use MOM_verticalGrid, only : verticalGrid_type
 use MOM_ALE, only : ALE_remap_scalar
 
 implicit none ; private
@@ -42,7 +32,7 @@ character(len=40)  :: mdl = "MOM_tracer_initialization_from_Z" !< This module's 
 
 contains
 
-!> Initializes a tracer from a z-space data file.
+!> Initializes a tracer from a z-space data file, including any lateral regridding that is needed.
 subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_nam, &
                           src_var_unit_conversion, src_var_record, homogenize, &
                           useALEremapping, remappingScheme, src_var_gridspec )

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -9,7 +9,7 @@ use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
-use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_io, only : slasher, vardesc, var_desc, query_vardesc
 use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -9,7 +9,7 @@ use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
-use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_io, only : vardesc, var_desc, query_vardesc
 use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
@@ -18,8 +18,7 @@ use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_unit_scaling, only : unit_scale_type
-use MOM_variables, only : surface
-use MOM_variables, only : thermo_var_ptrs
+use MOM_variables, only : surface, thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 
 use coupler_types_mod, only : coupler_type_set_data, ind_csurf

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -9,7 +9,7 @@ use MOM_file_parser,        only : get_param, log_param, log_version, param_file
 use MOM_forcing_type,       only : forcing
 use MOM_grid,               only : ocean_grid_type
 use MOM_hor_index,          only : hor_index_type
-use MOM_io,                 only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_io,                 only : vardesc, var_desc, query_vardesc
 use MOM_open_boundary,      only : ocean_OBC_type
 use MOM_restart,            only : query_initialized, MOM_restart_CS
 use MOM_sponge,             only : set_up_sponge_field, sponge_CS

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -11,7 +11,7 @@ use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
-use MOM_io, only : file_exists, read_data, slasher, vardesc, var_desc, query_vardesc
+use MOM_io, only : vardesc, var_desc, query_vardesc
 use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
@@ -20,8 +20,7 @@ use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_unit_scaling, only : unit_scale_type
-use MOM_variables, only : surface
-use MOM_variables, only : thermo_var_ptrs
+use MOM_variables, only : surface, thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 
 use coupler_types_mod, only : coupler_type_set_data, ind_csurf

--- a/src/user/BFB_surface_forcing.F90
+++ b/src/user/BFB_surface_forcing.F90
@@ -10,7 +10,6 @@ use MOM_error_handler, only : MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, param_file_type, log_version
 use MOM_forcing_type, only : forcing, allocate_forcing_type
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : file_exists, read_data
 use MOM_safe_alloc, only : safe_alloc_ptr
 use MOM_time_manager, only : time_type, operator(+), operator(/)
 use MOM_tracer_flow_control, only : call_tracer_set_forcing

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -10,9 +10,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe, WARNING
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : file_exists
-use MOM_io, only : MOM_read_data
-use MOM_io, only : slasher
+use MOM_io, only : file_exists, MOM_read_data, slasher
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -28,8 +28,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe, WARNING
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : file_exists, read_data
-use MOM_io, only : slasher
+use MOM_io, only : file_exists, MOM_read_data, slasher
 use MOM_sponge, only : sponge_CS, set_up_sponge_field, initialize_sponge
 use MOM_sponge, only : set_up_sponge_ML_density
 use MOM_unit_scaling, only : unit_scale_type
@@ -173,12 +172,12 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, PF, use_ALE, CSp, ACSp)
   filename = trim(inputdir)//trim(state_file)
   if (.not.file_exists(filename, G%Domain)) &
       call MOM_error(FATAL, " RGC_initialize_sponges: Unable to open "//trim(filename))
-  call read_data(filename,temp_var,T(:,:,:), domain=G%Domain%mpp_domain)
-  call read_data(filename,salt_var,S(:,:,:), domain=G%Domain%mpp_domain)
+  call MOM_read_data(filename, temp_var, T(:,:,:), G%Domain)
+  call MOM_read_data(filename, salt_var, S(:,:,:), G%Domain)
 
   if (use_ALE) then
 
-    call read_data(filename,h_var,h(:,:,:), domain=G%Domain%mpp_domain)
+    call MOM_read_data(filename, h_var, h(:,:,:), G%Domain)
     call pass_var(h, G%domain)
 
     !call initialize_ALE_sponge(Idamp, h, nz, G, PF, ACSp)
@@ -201,7 +200,7 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, PF, use_ALE, CSp, ACSp)
   else ! layer mode
 
     !read eta
-    call read_data(filename,eta_var,eta(:,:,:), domain=G%Domain%mpp_domain)
+    call MOM_read_data(filename, eta_var, eta(:,:,:), G%Domain)
 
     ! Set the inverse damping rates so that the model will know where to
     ! apply the sponges, along with the interface heights.

--- a/src/user/dumbbell_surface_forcing.F90
+++ b/src/user/dumbbell_surface_forcing.F90
@@ -10,7 +10,6 @@ use MOM_error_handler, only : MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, param_file_type, log_version
 use MOM_forcing_type, only : forcing, allocate_forcing_type
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : file_exists, read_data
 use MOM_safe_alloc, only : safe_alloc_ptr
 use MOM_time_manager, only : time_type, operator(+), operator(/), get_time
 use MOM_tracer_flow_control, only : call_tracer_set_forcing

--- a/src/user/user_revise_forcing.F90
+++ b/src/user/user_revise_forcing.F90
@@ -8,7 +8,7 @@ use MOM_error_handler, only : MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : file_exists, read_data
+use MOM_io, only : file_exists, MOM_read_data
 use MOM_restart, only : register_restart_field, MOM_restart_CS
 use MOM_time_manager, only : time_type, operator(+), operator(/)
 use MOM_tracer_flow_control, only : call_tracer_set_forcing


### PR DESCRIPTION
  This PR cleans up or eliminates module use statements related to the framework
code and makes minor changes the framework code to localize the dependencies on
the FMS framework into fewer files.  This should be helpful for scoping out an
appropriate and limited set of changes for the migration to use FMS2, and all of
these are no-regrets changes that will not alter answers or output.  The list of
commits in this PR include:

- NOAA-GFDL/MOM6@aea16f730 Use read_field_chksum in MOM_restart
- NOAA-GFDL/MOM6@aed5a680b +Add the new routine read_field_chksum to MOM_io
- NOAA-GFDL/MOM6@0b019b667 Avoid using memory macros in MOM_random.F90
- NOAA-GFDL/MOM6@611132731 Use MOM_read_data in RGC_initialization
- NOAA-GFDL/MOM6@9b0b8db88 Use MOM framework routines in MOM_open_boundary
- NOAA-GFDL/MOM6@1e6bdd6a1 Remove unused module use statements
