### PR TITLE
Fix non-standard indentation

### DIFF
--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -97,10 +97,10 @@ subroutine build_rho_column(CS, nz, depth, h, T, S, eqn_of_state, z_interface, &
   real, dimension(nz), intent(in)    :: S  !< Salinity for source column [ppt]
   type(EOS_type),      pointer       :: eqn_of_state !< Equation of state structure
   real, dimension(CS%nk+1), &
-       intent(inout) :: z_interface !< Absolute positions of interfaces
-  real, optional,           intent(in)    :: z_rigid_top !< The height of a rigid top (positive upward in the same
+                       intent(inout) :: z_interface !< Absolute positions of interfaces
+  real, optional,      intent(in)    :: z_rigid_top !< The height of a rigid top (positive upward in the same
   !! units as depth) [Z ~> m] or [H ~> m or kg m-2]
-  real, optional,           intent(in)    :: eta_orig !< The actual original height of the top in the same
+  real, optional,      intent(in)    :: eta_orig !< The actual original height of the top in the same
                                                    !! units as depth) [Z ~> m] or [H ~> m or kg m-2]
   real,      optional, intent(in)    :: h_neglect !< A negligibly small width for the purpose
                                              !! of cell reconstructions [H ~> m or kg m-2]
@@ -127,7 +127,7 @@ subroutine build_rho_column(CS, nz, depth, h, T, S, eqn_of_state, z_interface, &
     z0_top = z_rigid_top
     eta=z0_top
     if (present(eta_orig)) then
-       eta=eta_orig
+      eta=eta_orig
     endif
   endif
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3280,13 +3280,13 @@ subroutine extract_surface_state(CS, sfc_state_in)
       enddo ; enddo
 
       do i=is,ie
-       ! set melt_potential to zero to avoid passing previous values
-       sfc_state%melt_potential(i,j) = 0.0
+        ! set melt_potential to zero to avoid passing previous values
+        sfc_state%melt_potential(i,j) = 0.0
 
-       if (G%mask2dT(i,j)>0.) then
-         ! instantaneous melt_potential [Q R Z ~> J m-2]
-         sfc_state%melt_potential(i,j) = CS%tv%C_p * GV%Rho0 * delT(i)
-       endif
+        if (G%mask2dT(i,j)>0.) then
+          ! instantaneous melt_potential [Q R Z ~> J m-2]
+          sfc_state%melt_potential(i,j) = CS%tv%C_p * GV%Rho0 * delT(i)
+        endif
       enddo
     enddo ! end of j loop
   endif   ! melt_potential

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1265,7 +1265,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
       do j=js,je ; do i=is,ie ; CS%eta(i,j) = -GV%Z_to_H * G%bathyT(i,j) ; enddo ; enddo
     endif
     do k=1,nz ; do j=js,je ; do i=is,ie
-       CS%eta(i,j) = CS%eta(i,j) + h(i,j,k)
+      CS%eta(i,j) = CS%eta(i,j) + h(i,j,k)
     enddo ; enddo ; enddo
   elseif ((GV%m_to_H_restart /= 0.0) .and. (GV%m_to_H_restart /= GV%m_to_H)) then
     H_rescale = GV%m_to_H / GV%m_to_H_restart

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -4958,16 +4958,16 @@ subroutine open_boundary_register_restarts(HI, GV, OBC, Reg, param_file, restart
   type(OBC_segment_type), pointer :: segment=>NULL()
 
   if (.not. associated(OBC)) &
-       call MOM_error(FATAL, "open_boundary_register_restarts: Called with "//&
+    call MOM_error(FATAL, "open_boundary_register_restarts: Called with "//&
                       "uninitialized OBC control structure")
 
   if (associated(OBC%rx_normal) .or. associated(OBC%ry_normal) .or. &
       associated(OBC%rx_oblique) .or. associated(OBC%ry_oblique) .or. associated(OBC%cff_normal)) &
-       call MOM_error(FATAL, "open_boundary_register_restarts: Restart "//&
+    call MOM_error(FATAL, "open_boundary_register_restarts: Restart "//&
                       "arrays were previously allocated")
 
   if (associated(OBC%tres_x) .or. associated(OBC%tres_y)) &
-       call MOM_error(FATAL, "open_boundary_register_restarts: Restart "//&
+    call MOM_error(FATAL, "open_boundary_register_restarts: Restart "//&
                       "arrays were previously allocated")
 
   ! *** This is a temporary work around for restarts with OBC segments.
@@ -5188,8 +5188,8 @@ subroutine adjustSegmentEtaToFitBathymetry(G, GV, US, segment,fld)
     ! previous call to open_boundary_impose_normal_slope
     do k=nz+1,1,-1
       if (-eta(i,j,k) > segment%Htot(i,j)*GV%H_to_Z + hTolerance) then
-         eta(i,j,k) = -segment%Htot(i,j)*GV%H_to_Z
-         contractions = contractions + 1
+        eta(i,j,k) = -segment%Htot(i,j)*GV%H_to_Z
+        contractions = contractions + 1
       endif
     enddo
 
@@ -5197,27 +5197,27 @@ subroutine adjustSegmentEtaToFitBathymetry(G, GV, US, segment,fld)
       ! Collapse layers to thinnest possible if the thickness less than
       ! the thinnest possible (or negative).
       if (eta(i,j,K) < (eta(i,j,K+1) + GV%Angstrom_Z)) then
-         eta(i,j,K) = eta(i,j,K+1) + GV%Angstrom_Z
-         segment%field(fld)%dz_src(i,j,k) = GV%Angstrom_Z
+        eta(i,j,K) = eta(i,j,K+1) + GV%Angstrom_Z
+        segment%field(fld)%dz_src(i,j,k) = GV%Angstrom_Z
       else
-         segment%field(fld)%dz_src(i,j,k) = (eta(i,j,K) - eta(i,j,K+1))
+        segment%field(fld)%dz_src(i,j,k) = (eta(i,j,K) - eta(i,j,K+1))
       endif
     enddo
 
     !   The whole column is dilated to accommodate deeper topography than
     ! the bathymetry would indicate.
     if (-eta(i,j,nz+1) < (segment%Htot(i,j) * GV%H_to_Z) - hTolerance) then
-       dilations = dilations + 1
-       ! expand bottom-most cell only
-       eta(i,j,nz+1) = -(segment%Htot(i,j) * GV%H_to_Z)
-       segment%field(fld)%dz_src(i,j,nz)= eta(i,j,nz)-eta(i,j,nz+1)
-       ! if (eta(i,j,1) <= eta(i,j,nz+1)) then
-       !   do k=1,nz ; segment%field(fld)%dz_src(i,j,k) = (eta(i,j,1) + G%bathyT(i,j)) / real(nz) ; enddo
-       ! else
-       !   dilate = (eta(i,j,1) + G%bathyT(i,j)) / (eta(i,j,1) - eta(i,j,nz+1))
-       !   do k=1,nz ; segment%field(fld)%dz_src(i,j,k) = segment%field(fld)%dz_src(i,j,k) * dilate ; enddo
-       ! endif
-       !do k=nz,2,-1 ; eta(i,j,K) = eta(i,j,K+1) + segment%field(fld)%dz_src(i,j,k) ; enddo
+      dilations = dilations + 1
+      ! expand bottom-most cell only
+      eta(i,j,nz+1) = -(segment%Htot(i,j) * GV%H_to_Z)
+      segment%field(fld)%dz_src(i,j,nz)= eta(i,j,nz)-eta(i,j,nz+1)
+      ! if (eta(i,j,1) <= eta(i,j,nz+1)) then
+      !   do k=1,nz ; segment%field(fld)%dz_src(i,j,k) = (eta(i,j,1) + G%bathyT(i,j)) / real(nz) ; enddo
+      ! else
+      !   dilate = (eta(i,j,1) + G%bathyT(i,j)) / (eta(i,j,1) - eta(i,j,nz+1))
+      !   do k=1,nz ; segment%field(fld)%dz_src(i,j,k) = segment%field(fld)%dz_src(i,j,k) * dilate ; enddo
+      ! endif
+      !do k=nz,2,-1 ; eta(i,j,K) = eta(i,j,K+1) + segment%field(fld)%dz_src(i,j,k) ; enddo
     endif
     ! Now convert thicknesses to units of H.
     do k=1,nz
@@ -5240,8 +5240,6 @@ subroutine adjustSegmentEtaToFitBathymetry(G, GV, US, segment,fld)
   !    call MOM_error(WARNING, 'adjustEtaToFitBathymetry: '//mesg)
   ! endif
   deallocate(eta)
-
-
 
 end subroutine adjustSegmentEtaToFitBathymetry
 

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -501,7 +501,7 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
   ! area mean SST
   if (CS%id_tosga > 0) then
     do j=js,je ; do i=is,ie
-       surface_field(i,j) = tv%T(i,j,1)
+      surface_field(i,j) = tv%T(i,j,1)
     enddo ; enddo
     tosga = global_area_mean(surface_field, G)
     call post_data(CS%id_tosga, tosga, CS%diag)
@@ -1024,9 +1024,9 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
 
   if (.not.G%symmetric) then
     if (associated(CS%dKE_dt) .OR. associated(CS%PE_to_KE) .OR. associated(CS%KE_BT) .OR. &
-       associated(CS%KE_CorAdv) .OR. associated(CS%KE_adv) .OR. associated(CS%KE_visc) .OR. &
-       associated(CS%KE_horvisc) .OR. associated(CS%KE_dia) ) then
-        call create_group_pass(CS%pass_KE_uv, KE_u, KE_v, G%Domain, To_North+To_East)
+        associated(CS%KE_CorAdv) .OR. associated(CS%KE_adv) .OR. associated(CS%KE_visc) .OR. &
+        associated(CS%KE_horvisc) .OR. associated(CS%KE_dia) ) then
+      call create_group_pass(CS%pass_KE_uv, KE_u, KE_v, G%Domain, To_North+To_East)
     endif
   endif
 

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -1022,8 +1022,8 @@ subroutine accumulate_net_input(fluxes, sfc_state, tv, dt, G, US, CS)
     enddo ; enddo ; endif
 
     if (associated(fluxes%seaice_melt_heat)) then ; do j=js,je ; do i=is,ie
-       heat_in(i,j) = heat_in(i,j) + dt * QRZL2_to_J * G%areaT(i,j) * &
-                                     fluxes%seaice_melt_heat(i,j)
+      heat_in(i,j) = heat_in(i,j) + dt * QRZL2_to_J * G%areaT(i,j) * &
+                                    fluxes%seaice_melt_heat(i,j)
     enddo ; enddo ; endif
 
     ! smg: new code

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -475,66 +475,66 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     write(laynum,'(I8)') k ; laynum = adjustl(laynum)
     mask_in = 0.0
     if (is_ongrid) then
-       start(1) = is+G%HI%idg_offset ; start(2) = js+G%HI%jdg_offset ; start(3) = k
-       count(1) = ie-is+1 ; count(2) = je-js+1; count(3) = 1
-       rcode = NF90_GET_VAR(ncid,varid, tr_in, start, count)
-       if (rcode /= 0) call MOM_error(FATAL,"hinterp_and_extract_from_Fie: "//&
-            "error reading level "//trim(laynum)//" of variable "//&
-            trim(varnam)//" in file "// trim(filename))
+      start(1) = is+G%HI%idg_offset ; start(2) = js+G%HI%jdg_offset ; start(3) = k
+      count(1) = ie-is+1 ; count(2) = je-js+1; count(3) = 1
+      rcode = NF90_GET_VAR(ncid,varid, tr_in, start, count)
+      if (rcode /= 0) call MOM_error(FATAL,"hinterp_and_extract_from_Fie: "//&
+           "error reading level "//trim(laynum)//" of variable "//&
+           trim(varnam)//" in file "// trim(filename))
 
-       do j=js,je
-         do i=is,ie
-           if (abs(tr_in(i,j)-missing_value) > abs(roundoff*missing_value)) then
-              mask_in(i,j) = 1.0
-              tr_in(i,j) = (tr_in(i,j)*scale_factor+add_offset) * conversion
-           else
-              tr_in(i,j) = missing_value
-           endif
-         enddo
-       enddo
+      do j=js,je
+        do i=is,ie
+          if (abs(tr_in(i,j)-missing_value) > abs(roundoff*missing_value)) then
+            mask_in(i,j) = 1.0
+            tr_in(i,j) = (tr_in(i,j)*scale_factor+add_offset) * conversion
+          else
+            tr_in(i,j) = missing_value
+          endif
+        enddo
+      enddo
 
     else
-       if (is_root_pe()) then
-          start = 1 ; start(3) = k ; count(:) = 1 ; count(1) = id ; count(2) = jd
-          rcode = NF90_GET_VAR(ncid,varid, tr_in, start, count)
-          if (rcode /= 0) call MOM_error(FATAL,"hinterp_and_extract_from_Fie: "//&
-               "error reading level "//trim(laynum)//" of variable "//&
-               trim(varnam)//" in file "// trim(filename))
+      if (is_root_pe()) then
+        start = 1 ; start(3) = k ; count(:) = 1 ; count(1) = id ; count(2) = jd
+        rcode = NF90_GET_VAR(ncid,varid, tr_in, start, count)
+        if (rcode /= 0) call MOM_error(FATAL,"hinterp_and_extract_from_Fie: "//&
+             "error reading level "//trim(laynum)//" of variable "//&
+             trim(varnam)//" in file "// trim(filename))
 
-          if (add_np) then
-             last_row(:)=tr_in(:,jd); pole=0.0;npole=0.0
-             do i=1,id
-               if (abs(tr_in(i,jd)-missing_value) > abs(roundoff*missing_value)) then
-                  pole = pole+last_row(i)
-                  npole = npole+1.0
-               endif
-             enddo
-             if (npole > 0) then
-                pole=pole/npole
-             else
-                pole=missing_value
-             endif
-             tr_inp(:,1:jd) = tr_in(:,:)
-             tr_inp(:,jdp) = pole
+        if (add_np) then
+          last_row(:)=tr_in(:,jd); pole=0.0;npole=0.0
+          do i=1,id
+            if (abs(tr_in(i,jd)-missing_value) > abs(roundoff*missing_value)) then
+              pole = pole+last_row(i)
+              npole = npole+1.0
+            endif
+          enddo
+          if (npole > 0) then
+            pole=pole/npole
           else
-             tr_inp(:,:) = tr_in(:,:)
+            pole=missing_value
           endif
-       endif
+          tr_inp(:,1:jd) = tr_in(:,:)
+          tr_inp(:,jdp) = pole
+        else
+          tr_inp(:,:) = tr_in(:,:)
+        endif
+      endif
 
-       call mpp_sync()
-       call mpp_broadcast(tr_inp, id*jdp, root_PE())
-       call mpp_sync_self()
+      call mpp_sync()
+      call mpp_broadcast(tr_inp, id*jdp, root_PE())
+      call mpp_sync_self()
 
-       do j=1,jdp
-         do i=1,id
-           if (abs(tr_inp(i,j)-missing_value) > abs(roundoff*missing_value)) then
-              mask_in(i,j) = 1.0
-              tr_inp(i,j) = (tr_inp(i,j)*scale_factor+add_offset) * conversion
-           else
-              tr_inp(i,j) = missing_value
-           endif
-         enddo
-       enddo
+      do j=1,jdp
+        do i=1,id
+          if (abs(tr_inp(i,j)-missing_value) > abs(roundoff*missing_value)) then
+            mask_in(i,j) = 1.0
+            tr_inp(i,j) = (tr_inp(i,j)*scale_factor+add_offset) * conversion
+          else
+            tr_inp(i,j) = missing_value
+          endif
+        enddo
+      enddo
 
     endif
 
@@ -542,21 +542,21 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 
 !   call fms routine horiz_interp to interpolate input level data to model horizontal grid
     if (.not. is_ongrid) then
-       if (k == 1) then
-          call horiz_interp_new(Interp,x_in,y_in,lon_out(is:ie,js:je),lat_out(is:ie,js:je), &
-               interp_method='bilinear',src_modulo=.true.)
-       endif
+      if (k == 1) then
+        call horiz_interp_new(Interp,x_in,y_in,lon_out(is:ie,js:je),lat_out(is:ie,js:je), &
+              interp_method='bilinear',src_modulo=.true.)
+      endif
 
-       if (debug) then
-          call myStats(tr_inp,missing_value, is,ie,js,je,k,'Tracer from file')
-       endif
+      if (debug) then
+        call myStats(tr_inp,missing_value, is,ie,js,je,k,'Tracer from file')
+      endif
     endif
 
     tr_out(:,:) = 0.0
     if (is_ongrid) then
-       tr_out(is:ie,js:je)=tr_in(is:ie,js:je)
+      tr_out(is:ie,js:je)=tr_in(is:ie,js:je)
     else
-       call horiz_interp(Interp,tr_inp,tr_out(is:ie,js:je), missing_value=missing_value, new_missing_handle=.true.)
+      call horiz_interp(Interp,tr_inp,tr_out(is:ie,js:je), missing_value=missing_value, new_missing_handle=.true.)
     endif
 
     mask_out=1.0
@@ -591,14 +591,14 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 
     ! Horizontally homogenize data to produce perfectly "flat" initial conditions
     if (PRESENT(homogenize)) then
-       if (homogenize) then
-          call sum_across_PEs(nPoints)
-          call sum_across_PEs(varAvg)
-          if (nPoints>0) then
-             varAvg = varAvg/real(nPoints)
-          endif
-          tr_out(:,:) = varAvg
-       endif
+      if (homogenize) then
+        call sum_across_PEs(nPoints)
+        call sum_across_PEs(varAvg)
+        if (nPoints>0) then
+          varAvg = varAvg/real(nPoints)
+        endif
+        tr_out(:,:) = varAvg
+      endif
     endif
 
     ! tr_out contains input z-space data on the model grid with missing values

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -331,10 +331,10 @@ subroutine create_file(unit, filename, vars, novars, fields, threading, timeunit
     pack = 1
 
     if (present(checksums)) then
-       call mpp_write_meta(unit, fields(k), axes(1:numaxes), vars(k)%name, vars(k)%units, &
+      call mpp_write_meta(unit, fields(k), axes(1:numaxes), vars(k)%name, vars(k)%units, &
            vars(k)%longname, pack = pack, checksum=checksums(k,:))
     else
-       call mpp_write_meta(unit, fields(k), axes(1:numaxes), vars(k)%name, vars(k)%units, &
+      call mpp_write_meta(unit, fields(k), axes(1:numaxes), vars(k)%name, vars(k)%units, &
            vars(k)%longname, pack = pack)
     endif
   enddo

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1419,15 +1419,15 @@ function open_restart_units(filename, directory, G, CS, units, file_paths, &
       do while (err == 0)
         restartname = trim(CS%restartfile)
 
-       !query fms_io if there is a filename_appendix (for ensemble runs)
-       call get_filename_appendix(filename_appendix)
-       if (len_trim(filename_appendix) > 0) then
-         length = len_trim(restartname)
-         if (restartname(length-2:length) == '.nc') then
-           restartname = restartname(1:length-3)//'.'//trim(filename_appendix)//'.nc'
-         else
-           restartname = restartname(1:length)  //'.'//trim(filename_appendix)
-         endif
+        ! query fms_io if there is a filename_appendix (for ensemble runs)
+        call get_filename_appendix(filename_appendix)
+        if (len_trim(filename_appendix) > 0) then
+          length = len_trim(restartname)
+          if (restartname(length-2:length) == '.nc') then
+            restartname = restartname(1:length-3)//'.'//trim(filename_appendix)//'.nc'
+          else
+            restartname = restartname(1:length)  //'.'//trim(filename_appendix)
+          endif
         endif
         filepath = trim(directory) // trim(restartname)
 

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1510,12 +1510,12 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
     inputdir = slasher(inputdir)
     TideAmp_file = trim(inputdir) // trim(TideAmp_file)
     if (CS%rotate_index) then
-       allocate(tmp2d(CS%Grid_in%isd:CS%Grid_in%ied,CS%Grid_in%jsd:CS%Grid_in%jed));tmp2d(:,:)=0.0
-       call MOM_read_data(TideAmp_file, 'tideamp', tmp2d, CS%Grid_in%domain, timelevel=1, scale=US%m_s_to_L_T)
-       call rotate_array(tmp2d,CS%turns, CS%utide)
-       deallocate(tmp2d)
+      allocate(tmp2d(CS%Grid_in%isd:CS%Grid_in%ied,CS%Grid_in%jsd:CS%Grid_in%jed)) ; tmp2d(:,:)=0.0
+      call MOM_read_data(TideAmp_file, 'tideamp', tmp2d, CS%Grid_in%domain, timelevel=1, scale=US%m_s_to_L_T)
+      call rotate_array(tmp2d,CS%turns, CS%utide)
+      deallocate(tmp2d)
     else
-       call MOM_read_data(TideAmp_file, 'tideamp', CS%utide, CS%Grid%domain, timelevel=1, scale=US%m_s_to_L_T)
+      call MOM_read_data(TideAmp_file, 'tideamp', CS%utide, CS%Grid%domain, timelevel=1, scale=US%m_s_to_L_T)
     endif
   else
     call get_param(param_file, mdl, "UTIDE", utide, &
@@ -1592,7 +1592,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
 
     if (new_sim) then
       ! new simulation, initialize ice thickness as in the static case
-       call initialize_ice_thickness(ISS%h_shelf, ISS%area_shelf_h, ISS%hmask, CS%Grid, CS%Grid_in, US, param_file,  &
+      call initialize_ice_thickness(ISS%h_shelf, ISS%area_shelf_h, ISS%hmask, CS%Grid, CS%Grid_in, US, param_file,  &
             CS%rotate_index, CS%turns)
 
     ! next make sure mass is consistent with thickness
@@ -1703,11 +1703,11 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
                               "ice sheet/shelf thickness", "m")
   if (PRESENT(sfc_state_in)) then
     if (allocated(sfc_state%taux_shelf) .and. allocated(sfc_state%tauy_shelf)) then
-       u_desc = var_desc("taux_shelf", "Pa", "the zonal stress on the ocean under ice shelves", &
+      u_desc = var_desc("taux_shelf", "Pa", "the zonal stress on the ocean under ice shelves", &
             hor_grid='Cu',z_grid='1')
-       v_desc = var_desc("tauy_shelf", "Pa", "the meridional stress on the ocean under ice shelves", &
+      v_desc = var_desc("tauy_shelf", "Pa", "the meridional stress on the ocean under ice shelves", &
             hor_grid='Cv',z_grid='1')
-       call register_restart_pair(sfc_state%taux_shelf, sfc_state%tauy_shelf, u_desc,v_desc, &
+      call register_restart_pair(sfc_state%taux_shelf, sfc_state%tauy_shelf, u_desc, v_desc, &
             .false., CS%restart_CSp)
     endif
   endif
@@ -1868,11 +1868,11 @@ subroutine initialize_ice_shelf_forces(CS, ocn_grid, US, forces_in)
   call MOM_mesg("MOM_ice_shelf.F90, initialize_ice_shelf: allocating forces.")
   call allocate_mech_forcing(CS%Grid_in, forces_in, ustar=.true., shelf=.true., press=.true.)
   if (CS%rotate_index) then
-     allocate(forces)
-     call allocate_mech_forcing(forces_in, CS%Grid, forces)
-     call rotate_mech_forcing(forces_in, CS%turns, forces)
+    allocate(forces)
+    call allocate_mech_forcing(forces_in, CS%Grid, forces)
+    call rotate_mech_forcing(forces_in, CS%turns, forces)
   else
-     forces=>forces_in
+    forces=>forces_in
   endif
 
   call add_shelf_forces(ocn_grid, US, CS, forces, do_shelf_area=.not.CS%solo_ice_sheet)

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -483,9 +483,9 @@ function register_MOM_IS_diag_field(module_name, field_name, axes, init_time, &
 
   if (is_root_pe() .and. diag_CS%doc_unit > 0) then
     if (primary_id > 0) then
-       mesg = '"'//trim(module_name)//'", "'//trim(field_name)//'"  [Used]'
+      mesg = '"'//trim(module_name)//'", "'//trim(field_name)//'"  [Used]'
     else
-       mesg = '"'//trim(module_name)//'", "'//trim(field_name)//'"  [Unused]'
+      mesg = '"'//trim(module_name)//'", "'//trim(field_name)//'"  [Unused]'
     endif
     write(diag_CS%doc_unit, '(a)') trim(mesg)
     if (present(long_name)) call describe_option("long_name", long_name, diag_CS)

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -402,7 +402,7 @@ function opacity_morel(chl_data)
   ! appropriate when using an interactive ecosystem model that predicts
   ! three-dimensional chl-a values.
   real, dimension(6), parameter :: &
-       Z2_coef=(/7.925, -6.644, 3.662, -1.815, -0.218,  0.502/)
+    Z2_coef = (/7.925, -6.644, 3.662, -1.815, -0.218,  0.502/)
   real :: Chl, Chl2 ! The log10 of chl_data (in mg m-3), and Chl^2.
 
   Chl = log10(min(max(chl_data,0.02),60.0)) ; Chl2 = Chl*Chl
@@ -423,7 +423,7 @@ function SW_pen_frac_morel(chl_data)
   ! three-dimensional chl-a values.
   real :: Chl, Chl2         ! The log10 of chl_data in mg m-3, and Chl^2.
   real, dimension(6), parameter :: &
-       V1_coef=(/0.321,  0.008, 0.132,  0.038, -0.017, -0.007/)
+    V1_coef = (/0.321,  0.008, 0.132,  0.038, -0.017, -0.007/)
 
   Chl = log10(min(max(chl_data,0.02),60.0)) ; Chl2 = Chl*Chl
   SW_pen_frac_morel = 1.0 - ( (V1_coef(1) + V1_coef(2)*Chl) + Chl2 * &

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -969,7 +969,7 @@ subroutine vertvisc_coef(u, v, h, forces, visc, dt, G, GV, US, CS, OBC)
             botfn = 1.0 / (1.0 + 0.09*z2*z2*z2*z2*z2*z2)
             hvel(i,k) = (1.0-botfn)*h_arith(i,k) + botfn*h_harm(i,k)
           endif
-       endif
+        endif
 
       endif ; enddo ; enddo ! i & k loops
     endif

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -727,7 +727,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
   real, dimension(SZI_(G),ntr,SZJ_(G)) :: &
     slope_y                     ! The concentration slope per grid point [conc].
   real, dimension(SZI_(G),ntr,SZJB_(G)) :: &
-       flux_y                      ! The tracer flux across a boundary [H m2 conc ~> m3 conc or kg conc].
+    flux_y                      ! The tracer flux across a boundary [H m2 conc ~> m3 conc or kg conc].
   real, dimension(SZI_(G),ntr,SZJB_(G)) :: &
     T_tmp               ! The copy of the tracer concentration at constant i,k [H m2 conc ~> m3 conc or kg conc].
   real :: maxslope              ! The maximum concentration slope per grid point
@@ -796,10 +796,10 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
       !else
       !  slope_y(i,m,j) = G%mask2dCv(i,J) * G%mask2dCv(i,J-1) * 0.5*maxslope
       !endif
-       Tp = Tr(m)%t(i,j+1,k) ; Tc = Tr(m)%t(i,j,k) ; Tm = Tr(m)%t(i,j-1,k)
-       dMx = max( Tp, Tc, Tm ) - Tc
-       dMn= Tc - min( Tp, Tc, Tm )
-       slope_y(i,m,j) = G%mask2dCv(i,J)*G%mask2dCv(i,J-1) * &
+      Tp = Tr(m)%t(i,j+1,k) ; Tc = Tr(m)%t(i,j,k) ; Tm = Tr(m)%t(i,j-1,k)
+      dMx = max( Tp, Tc, Tm ) - Tc
+      dMn = Tc - min( Tp, Tc, Tm )
+      slope_y(i,m,j) = G%mask2dCv(i,J)*G%mask2dCv(i,J-1) * &
            sign( min(0.5*abs(Tp-Tm), 2.0*dMx, 2.0*dMn), Tp-Tm )
     enddo ; enddo ; endif ; enddo ! End of i-, m-, & j- loops.
   endif ! usePLMslope

--- a/src/tracer/MOM_tracer_diabatic.F90
+++ b/src/tracer/MOM_tracer_diabatic.F90
@@ -191,8 +191,7 @@ subroutine tracer_vertdiff(h_old, ea, eb, dt, tr, G, GV, &
         b1(i) = 1.0 / (b_denom_1 + eb(i,j,1))
         d1(i) = h_tr * b1(i)
         tr(i,j,1) = (b1(i)*h_tr)*tr(i,j,1) + sfc_src(i,j)
-       endif
-      enddo
+      endif ; enddo
       do k=2,nz-1 ; do i=is,ie ; if (G%mask2dT(i,j) > -0.5) then
         c1(i,k) = eb(i,j,k-1) * b1(i)
         h_tr = h_old(i,j,k) + h_neglect
@@ -391,8 +390,7 @@ subroutine tracer_vertdiff_Eulerian(h_old, ent, dt, tr, G, GV, &
         b1(i) = 1.0 / (b_denom_1 + ent(i,j,2))
         d1(i) = h_tr * b1(i)
         tr(i,j,1) = (b1(i)*h_tr)*tr(i,j,1) + sfc_src(i,j)
-       endif
-      enddo
+      endif ; enddo
       do k=2,nz-1 ; do i=is,ie ; if (G%mask2dT(i,j) > -0.5) then
         c1(i,k) = ent(i,j,K) * b1(i)
         h_tr = h_old(i,j,k) + h_neglect

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -193,7 +193,7 @@ subroutine DOME_initialize_sponges(G, GV, US, tv, PF, CSp)
 
     if (G%geoLonT(i,j) > 1400.0) then ; damp_new = 10.0
     elseif (G%geoLonT(i,j) > 1300.0) then
-       damp_new = 10.0 * (G%geoLonT(i,j)-1300.0)/100.0
+      damp_new = 10.0 * (G%geoLonT(i,j)-1300.0)/100.0
     else ; damp_new = 0.0
     endif
 

--- a/src/user/Idealized_Hurricane.F90
+++ b/src/user/Idealized_Hurricane.F90
@@ -520,7 +520,7 @@ subroutine SCM_idealized_hurricane_wind_forcing(sfc_state, forces, day, G, US, C
     C = CS%max_windspeed / sqrt( US%R_to_kg_m3*dP )
     B = C**2 * US%R_to_kg_m3*CS%rho_a * exp(1.0)
     if (BR_Bench) then ! rho_a reset to value used in generated wind for benchmark test
-       B = C**2 * 1.2 * exp(1.0)
+      B = C**2 * 1.2 * exp(1.0)
     endif
   elseif (BR_Bench) then ! rho_a reset to value used in generated wind for benchmark test
     B = (CS%max_windspeed**2 / dP ) * 1.2*US%kg_m3_to_R * exp(1.0)

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -69,42 +69,42 @@ type, public :: wave_parameters_CS ; private
 
   ! Surface Wave Dependent 1d/2d/3d vars
   real, allocatable, dimension(:), public :: &
-       WaveNum_Cen        !< Wavenumber bands for read/coupled [m-1]
+    WaveNum_Cen        !< Wavenumber bands for read/coupled [m-1]
   real, allocatable, dimension(:), public :: &
-       Freq_Cen           !< Frequency bands for read/coupled [s-1]
+    Freq_Cen           !< Frequency bands for read/coupled [s-1]
   real, allocatable, dimension(:), public :: &
-       PrescribedSurfStkX !< Surface Stokes drift if prescribed [m s-1]
+    PrescribedSurfStkX !< Surface Stokes drift if prescribed [m s-1]
   real, allocatable, dimension(:), public :: &
-       PrescribedSurfStkY !< Surface Stokes drift if prescribed [m s-1]
+    PrescribedSurfStkY !< Surface Stokes drift if prescribed [m s-1]
   real, allocatable, dimension(:,:,:), public :: &
-       Us_x               !< 3d zonal Stokes drift profile [m s-1]
-                          !! Horizontal -> U points
-                          !! Vertical -> Mid-points
+    Us_x               !< 3d zonal Stokes drift profile [m s-1]
+                       !! Horizontal -> U points
+                       !! Vertical -> Mid-points
   real, allocatable, dimension(:,:,:), public :: &
-       Us_y               !< 3d meridional Stokes drift profile [m s-1]
-                          !! Horizontal -> V points
-                          !! Vertical -> Mid-points
+    Us_y               !< 3d meridional Stokes drift profile [m s-1]
+                       !! Horizontal -> V points
+                       !! Vertical -> Mid-points
   real, allocatable, dimension(:,:), public :: &
-       La_SL,&            !< SL Langmuir number (directionality factored later)
-                          !! Horizontal -> H points
-       La_Turb            !< Aligned Turbulent Langmuir number
-                          !! Horizontal -> H points
+    La_SL,&            !< SL Langmuir number (directionality factored later)
+                       !! Horizontal -> H points
+    La_Turb            !< Aligned Turbulent Langmuir number
+                       !! Horizontal -> H points
   real, allocatable, dimension(:,:), public :: &
-       US0_x              !< Surface Stokes Drift (zonal, m/s)
-                          !! Horizontal -> U points
+    US0_x              !< Surface Stokes Drift (zonal, m/s)
+                       !! Horizontal -> U points
   real, allocatable, dimension(:,:), public :: &
-       US0_y              !< Surface Stokes Drift (meridional, m/s)
-                          !! Horizontal -> V points
+    US0_y              !< Surface Stokes Drift (meridional, m/s)
+                       !! Horizontal -> V points
   real, allocatable, dimension(:,:,:), public :: &
-       STKx0              !< Stokes Drift spectrum (zonal, m/s)
-                          !! Horizontal -> U points
-                          !! 3rd dimension -> Freq/Wavenumber
+    STKx0              !< Stokes Drift spectrum (zonal, m/s)
+                       !! Horizontal -> U points
+                       !! 3rd dimension -> Freq/Wavenumber
   real, allocatable, dimension(:,:,:), public :: &
-       STKy0              !< Stokes Drift spectrum (meridional, m/s)
-                          !! Horizontal -> V points
-                          !! 3rd dimension -> Freq/Wavenumber
+    STKy0              !< Stokes Drift spectrum (meridional, m/s)
+                       !! Horizontal -> V points
+                       !! 3rd dimension -> Freq/Wavenumber
   real, allocatable, dimension(:,:,:), public :: &
-       KvS                !< Viscosity for Stokes Drift shear [Z2 T-1 ~> m2 s-1]
+    KvS                !< Viscosity for Stokes Drift shear [Z2 T-1 ~> m2 s-1]
 
   ! Pointers to auxiliary fields
   type(time_type), pointer, public :: Time !< A pointer to the ocean model's clock.
@@ -475,14 +475,14 @@ end subroutine Update_Surface_Waves
 !> Constructs the Stokes Drift profile on the model grid based on
 !! desired coupling options
 subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar)
-  type(wave_parameters_CS),  pointer     :: CS    !< Wave parameter Control structure
-  type(ocean_grid_type),   intent(inout) :: G     !< Grid structure
-  type(verticalGrid_type), intent(in)    :: GV    !< Vertical grid structure
-  type(unit_scale_type),   intent(in)    :: US    !< A dimensional unit scaling type
+  type(wave_parameters_CS), pointer       :: CS    !< Wave parameter Control structure
+  type(ocean_grid_type),    intent(inout) :: G     !< Grid structure
+  type(verticalGrid_type),  intent(in)    :: GV    !< Vertical grid structure
+  type(unit_scale_type),    intent(in)    :: US    !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-       intent(in)    :: h     !< Thickness [H ~> m or kg m-2]
+                            intent(in)    :: h     !< Thickness [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G)), &
-       intent(in)    :: ustar !< Wind friction velocity [Z T-1 ~> m s-1].
+                            intent(in)    :: ustar !< Wind friction velocity [Z T-1 ~> m s-1].
   ! Local Variables
   real    :: Top, MidPoint, Bottom, one_cm
   real    :: DecayScale


### PR DESCRIPTION
  Fixed non-standard 5- and 7-point initial indentation on scattered lines
throughout the code in MOM6/src.  All answers are bitwise identical, and there
are only changes in white-space.