### PR TITLE
Always stream job logs in gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,8 +117,9 @@ run:
     - time tar zxf $CACHE_DIR/build-pgi-repro-$CI_PIPELINE_ID.tgz
     # time tar zxf $CACHE_DIR/build-gnu-debug-$CI_PIPELINE_ID.tgz
     - (echo '#!/bin/tcsh';echo 'make -f MRS/Makefile.tests all') > job.sh
-    - sbatch --clusters=c3,c4 --nodes=29 --time=0:34:00 --account=gfdl_o --qos=debug --job-name=mom6_regressions --output=log.$CI_PIPELINE_ID --wait job.sh
+    - sbatch --clusters=c3,c4 --nodes=29 --time=0:34:00 --account=gfdl_o --qos=debug --job-name=mom6_regressions --output=log.$CI_PIPELINE_ID --wait job.sh || MJOB_RETURN_STATE=Fail
     - cat log.$CI_PIPELINE_ID
+    - test -z "$MJOB_RETURN_STATE"
     - test -f restart_results_gnu.tar.gz
     - time tar zvcf $CACHE_DIR/results-$CI_PIPELINE_ID.tgz *.tar.gz
 


### PR DESCRIPTION
- When a batch job fails on the gitlab pipeline we used to see the job logs but we suspect this behavior changed a long time ago.
- This commit intercepts an error from the sbatch command and causes the pipeline to fail only after streaming the log, which is the very next command after sbatch.
- A test of the interception working as intended uses the notorious #1283. This pipeline was failing without the logs being produced. With this cherry-picked commit the logs are now visible: https://gitlab.gfdl.noaa.gov/ogrp/MOM6/-/jobs/59699 (GFDL-only).