### PR TITLE
+More MOM6 framework code restructuring

### DIFF
--- a/config_src/coupled_driver/MOM_surface_forcing_gfdl.F90
+++ b/config_src/coupled_driver/MOM_surface_forcing_gfdl.F90
@@ -5,7 +5,7 @@ module MOM_surface_forcing_gfdl
 !#CTRL# use MOM_controlled_forcing, only : apply_ctrl_forcing, register_ctrl_forcing_restarts
 !#CTRL# use MOM_controlled_forcing, only : controlled_forcing_init, controlled_forcing_end
 !#CTRL# use MOM_controlled_forcing, only : ctrl_forcing_CS
-use MOM_coms,             only : reproducing_sum
+use MOM_coms,             only : reproducing_sum, field_chksum
 use MOM_constants,        only : hlv, hlf
 use MOM_cpu_clock,        only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,        only : CLOCK_SUBCOMPONENT
@@ -21,6 +21,8 @@ use MOM_forcing_type,     only : allocate_forcing_type, deallocate_forcing_type
 use MOM_forcing_type,     only : allocate_mech_forcing, deallocate_mech_forcing
 use MOM_get_input,        only : Get_MOM_Input, directories
 use MOM_grid,             only : ocean_grid_type
+use MOM_interpolate,      only : init_external_field, time_interp_extern
+use MOM_interpolate,      only : time_interp_external_init
 use MOM_io,               only : slasher, write_version_number, MOM_read_data
 use MOM_restart,          only : register_restart_field, restart_init, MOM_restart_CS
 use MOM_restart,          only : restart_init_end, save_restart, restore_state
@@ -36,9 +38,6 @@ use coupler_types_mod,    only : coupler_type_initialized, coupler_type_spawn
 use coupler_types_mod,    only : coupler_type_copy_data
 use data_override_mod,    only : data_override_init, data_override
 use fms_mod,              only : stdout
-use mpp_mod,              only : mpp_chksum
-use time_interp_external_mod, only : init_external_field, time_interp_external
-use time_interp_external_mod, only : time_interp_external_init
 
 implicit none ; private
 
@@ -350,7 +349,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! Salinity restoring logic
   if (CS%restore_salt) then
-    call time_interp_external(CS%id_srestore,Time,data_restore)
+    call time_interp_extern(CS%id_srestore, Time, data_restore)
     ! open_ocn_mask indicates where to restore salinity (1 means restore, 0 does not)
     open_ocn_mask(:,:) = 1.0
     if (CS%mask_srestore_under_ice) then ! Do not restore under sea-ice
@@ -407,7 +406,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! SST restoring logic
   if (CS%restore_temp) then
-    call time_interp_external(CS%id_trestore,Time,data_restore)
+    call time_interp_extern(CS%id_trestore, Time, data_restore)
     do j=js,je ; do i=is,ie
       delta_sst = data_restore(i,j)- sfc_state%SST(i,j)
       delta_sst = sign(1.0,delta_sst)*min(abs(delta_sst),CS%max_delta_trestore)
@@ -1486,7 +1485,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
     enddo ; enddo
   endif
 
-  call time_interp_external_init
+  call time_interp_external_init()
 
   ! Optionally read a x-y gustiness field in place of a global constant.
   call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
@@ -1632,27 +1631,27 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
   outunit = stdout()
 
   write(outunit,*) "BEGIN CHECKSUM(ice_ocean_boundary_type):: ", id, timestep
-  write(outunit,100) 'iobt%u_flux         ', mpp_chksum( iobt%u_flux         )
-  write(outunit,100) 'iobt%v_flux         ', mpp_chksum( iobt%v_flux         )
-  write(outunit,100) 'iobt%t_flux         ', mpp_chksum( iobt%t_flux         )
-  write(outunit,100) 'iobt%q_flux         ', mpp_chksum( iobt%q_flux         )
-  write(outunit,100) 'iobt%salt_flux      ', mpp_chksum( iobt%salt_flux      )
-  write(outunit,100) 'iobt%lw_flux        ', mpp_chksum( iobt%lw_flux        )
-  write(outunit,100) 'iobt%sw_flux_vis_dir', mpp_chksum( iobt%sw_flux_vis_dir)
-  write(outunit,100) 'iobt%sw_flux_vis_dif', mpp_chksum( iobt%sw_flux_vis_dif)
-  write(outunit,100) 'iobt%sw_flux_nir_dir', mpp_chksum( iobt%sw_flux_nir_dir)
-  write(outunit,100) 'iobt%sw_flux_nir_dif', mpp_chksum( iobt%sw_flux_nir_dif)
-  write(outunit,100) 'iobt%lprec          ', mpp_chksum( iobt%lprec          )
-  write(outunit,100) 'iobt%fprec          ', mpp_chksum( iobt%fprec          )
-  write(outunit,100) 'iobt%runoff         ', mpp_chksum( iobt%runoff         )
-  write(outunit,100) 'iobt%calving        ', mpp_chksum( iobt%calving        )
-  write(outunit,100) 'iobt%p              ', mpp_chksum( iobt%p              )
+  write(outunit,100) 'iobt%u_flux         ', field_chksum( iobt%u_flux         )
+  write(outunit,100) 'iobt%v_flux         ', field_chksum( iobt%v_flux         )
+  write(outunit,100) 'iobt%t_flux         ', field_chksum( iobt%t_flux         )
+  write(outunit,100) 'iobt%q_flux         ', field_chksum( iobt%q_flux         )
+  write(outunit,100) 'iobt%salt_flux      ', field_chksum( iobt%salt_flux      )
+  write(outunit,100) 'iobt%lw_flux        ', field_chksum( iobt%lw_flux        )
+  write(outunit,100) 'iobt%sw_flux_vis_dir', field_chksum( iobt%sw_flux_vis_dir)
+  write(outunit,100) 'iobt%sw_flux_vis_dif', field_chksum( iobt%sw_flux_vis_dif)
+  write(outunit,100) 'iobt%sw_flux_nir_dir', field_chksum( iobt%sw_flux_nir_dir)
+  write(outunit,100) 'iobt%sw_flux_nir_dif', field_chksum( iobt%sw_flux_nir_dif)
+  write(outunit,100) 'iobt%lprec          ', field_chksum( iobt%lprec          )
+  write(outunit,100) 'iobt%fprec          ', field_chksum( iobt%fprec          )
+  write(outunit,100) 'iobt%runoff         ', field_chksum( iobt%runoff         )
+  write(outunit,100) 'iobt%calving        ', field_chksum( iobt%calving        )
+  write(outunit,100) 'iobt%p              ', field_chksum( iobt%p              )
   if (associated(iobt%ustar_berg)) &
-    write(outunit,100) 'iobt%ustar_berg     ', mpp_chksum( iobt%ustar_berg )
+    write(outunit,100) 'iobt%ustar_berg     ', field_chksum( iobt%ustar_berg )
   if (associated(iobt%area_berg)) &
-    write(outunit,100) 'iobt%area_berg      ', mpp_chksum( iobt%area_berg  )
+    write(outunit,100) 'iobt%area_berg      ', field_chksum( iobt%area_berg  )
   if (associated(iobt%mass_berg)) &
-    write(outunit,100) 'iobt%mass_berg      ', mpp_chksum( iobt%mass_berg  )
+    write(outunit,100) 'iobt%mass_berg      ', field_chksum( iobt%mass_berg  )
 100 FORMAT("   CHECKSUM::",A20," = ",Z20)
 
   call coupler_type_write_chksums(iobt%fluxes, outunit, 'iobt%')

--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -15,6 +15,7 @@ use MOM, only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
 use MOM, only : extract_surface_state, allocate_surface_state, finish_MOM_initialization
 use MOM, only : get_MOM_state_elements, MOM_state_is_synchronized
 use MOM, only : get_ocean_stocks, step_offline
+use MOM_coms,      only : field_chksum
 use MOM_constants, only : CELSIUS_KELVIN_OFFSET, hlf
 use MOM_diag_mediator, only : diag_ctrl, enable_averaging, disable_averaging
 use MOM_diag_mediator, only : diag_mediator_close_registration, diag_mediator_end
@@ -22,6 +23,7 @@ use MOM_domains, only : pass_var, pass_vector, AGRID, BGRID_NE, CGRID_NE
 use MOM_domains, only : TO_ALL, Omit_Corners
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave
+use MOM_EOS, only : gsw_sp_from_sr, gsw_pt_from_ct
 use MOM_file_parser, only : get_param, log_version, close_param_file, param_file_type
 use MOM_forcing_type, only : forcing, mech_forcing, allocate_forcing_type
 use MOM_forcing_type, only : fluxes_accumulate, get_net_mass_forcing
@@ -48,6 +50,8 @@ use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_ice_shelf, only : initialize_ice_shelf, shelf_calc_flux, ice_shelf_CS
 use MOM_ice_shelf, only : add_shelf_forces, ice_shelf_end, ice_shelf_save_restart
+use MOM_wave_interface, only: wave_parameters_CS, MOM_wave_interface_init
+use MOM_wave_interface, only: MOM_wave_interface_init_lite, Update_Surface_Waves
 use coupler_types_mod, only : coupler_1d_bc_type, coupler_2d_bc_type
 use coupler_types_mod, only : coupler_type_spawn, coupler_type_write_chksums
 use coupler_types_mod, only : coupler_type_initialized, coupler_type_copy_data
@@ -56,10 +60,6 @@ use mpp_domains_mod, only : domain2d, mpp_get_layout, mpp_get_global_domain
 use mpp_domains_mod, only : mpp_define_domains, mpp_get_compute_domain, mpp_get_data_domain
 use atmos_ocean_fluxes_mod, only : aof_set_coupler_flux
 use fms_mod, only : stdout
-use mpp_mod, only : mpp_chksum
-use MOM_EOS, only : gsw_sp_from_sr, gsw_pt_from_ct
-use MOM_wave_interface, only: wave_parameters_CS, MOM_wave_interface_init
-use MOM_wave_interface, only: MOM_wave_interface_init_lite, Update_Surface_Waves
 
 #include <MOM_memory.h>
 
@@ -1130,13 +1130,13 @@ subroutine ocean_public_type_chksum(id, timestep, ocn)
   outunit = stdout()
 
   write(outunit,*) "BEGIN CHECKSUM(ocean_type):: ", id, timestep
-  write(outunit,100) 'ocean%t_surf   ',mpp_chksum(ocn%t_surf )
-  write(outunit,100) 'ocean%s_surf   ',mpp_chksum(ocn%s_surf )
-  write(outunit,100) 'ocean%u_surf   ',mpp_chksum(ocn%u_surf )
-  write(outunit,100) 'ocean%v_surf   ',mpp_chksum(ocn%v_surf )
-  write(outunit,100) 'ocean%sea_lev  ',mpp_chksum(ocn%sea_lev)
-  write(outunit,100) 'ocean%frazil   ',mpp_chksum(ocn%frazil )
-  write(outunit,100) 'ocean%melt_potential  ',mpp_chksum(ocn%melt_potential)
+  write(outunit,100) 'ocean%t_surf   ', field_chksum(ocn%t_surf )
+  write(outunit,100) 'ocean%s_surf   ', field_chksum(ocn%s_surf )
+  write(outunit,100) 'ocean%u_surf   ', field_chksum(ocn%u_surf )
+  write(outunit,100) 'ocean%v_surf   ', field_chksum(ocn%v_surf )
+  write(outunit,100) 'ocean%sea_lev  ', field_chksum(ocn%sea_lev)
+  write(outunit,100) 'ocean%frazil   ', field_chksum(ocn%frazil )
+  write(outunit,100) 'ocean%melt_potential  ', field_chksum(ocn%melt_potential)
   call coupler_type_write_chksums(ocn%fields, outunit, 'ocean%')
 100 FORMAT("   CHECKSUM::",A20," = ",Z20)
 

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -32,6 +32,7 @@ program MOM_main
   use MOM,                 only : extract_surface_state, finish_MOM_initialization
   use MOM,                 only : get_MOM_state_elements, MOM_state_is_synchronized
   use MOM,                 only : step_offline
+  use MOM_coms,            only : Set_PElist
   use MOM_domains,         only : MOM_infra_init, MOM_infra_end
   use MOM_error_handler,   only : MOM_error, MOM_mesg, WARNING, FATAL, is_root_pe
   use MOM_error_handler,   only : callTree_enter, callTree_leave, callTree_waypoint
@@ -41,6 +42,7 @@ program MOM_main
   use MOM_forcing_type,    only : mech_forcing_diags, MOM_forcing_chksum, MOM_mech_forcing_chksum
   use MOM_get_input,       only : directories
   use MOM_grid,            only : ocean_grid_type
+  use MOM_interpolate,     only : time_interp_external_init
   use MOM_io,              only : file_exists, open_file, close_file
   use MOM_io,              only : check_nml_error, io_infra_init, io_infra_end
   use MOM_io,              only : APPEND_FILE, ASCII_FILE, READONLY_FILE, SINGLE_FILE
@@ -64,8 +66,6 @@ program MOM_main
   use MOM_get_input,       only : get_MOM_input
   use ensemble_manager_mod, only : ensemble_manager_init, get_ensemble_size
   use ensemble_manager_mod, only : ensemble_pelist_setup
-  use mpp_mod, only : set_current_pelist => mpp_set_current_pelist
-  use time_interp_external_mod, only : time_interp_external_init
   use fms_affinity_mod,     only : fms_affinity_init, fms_affinity_set,fms_affinity_get
 
   use MOM_ice_shelf, only : initialize_ice_shelf, ice_shelf_end, ice_shelf_CS
@@ -229,7 +229,7 @@ program MOM_main
     allocate(ocean_pelist(nPEs_per))
     call ensemble_pelist_setup(.true., 0, nPEs_per, 0, 0, atm_pelist, ocean_pelist, &
                                land_pelist, ice_pelist)
-    call set_current_pelist(ocean_pelist)
+    call Set_PElist(ocean_pelist)
     deallocate(ocean_pelist)
   endif
 
@@ -286,17 +286,17 @@ program MOM_main
 
 
   if (sum(date_init) > 0) then
-    Start_time = set_date(date_init(1),date_init(2), date_init(3), &
-         date_init(4),date_init(5),date_init(6))
+    Start_time = set_date(date_init(1), date_init(2), date_init(3), &
+                          date_init(4), date_init(5), date_init(6))
   else
     Start_time = real_to_time(0.0)
   endif
 
-  call time_interp_external_init
+  call time_interp_external_init()
 
   if (sum(date) >= 0) then
     ! In this case, the segment starts at a time fixed by ocean_solo.res
-    segment_start_time = set_date(date(1),date(2),date(3),date(4),date(5),date(6))
+    segment_start_time = set_date(date(1), date(2), date(3), date(4), date(5), date(6))
     Time = segment_start_time
   else
     ! In this case, the segment starts at a time read from the MOM restart file

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -24,8 +24,7 @@ use MOM_string_functions,     only : extract_word, remove_spaces
 use MOM_tidal_forcing,        only : astro_longitudes, astro_longitudes_init, eq_phase, nodal_fu, tidal_frequency
 use MOM_time_manager,         only : set_date, time_type, time_type_to_real, operator(-)
 use MOM_tracer_registry,      only : tracer_type, tracer_registry_type, tracer_name_lookup
-use time_interp_external_mod, only : init_external_field, time_interp_external
-use time_interp_external_mod, only : time_interp_external_init
+use MOM_interpolate,          only : init_external_field, time_interp_extern, time_interp_external_init
 use MOM_remapping,            only : remappingSchemesDoc, remappingDefaultScheme, remapping_CS
 use MOM_remapping,            only : initialize_remapping, remapping_core_h, end_remapping
 use MOM_regridding,           only : regridding_CS
@@ -3897,7 +3896,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
 
         ! TODO: Since we conditionally rotate a subset of tmp_buffer_in after
         !   reading the value, it is currently not possible to use the rotated
-        !   implementation of time_interp_external.
+        !   implementation of time_interp_extern.
         !   For now, we must explicitly allocate and rotate this array.
         if (turns /= 0) then
           if (modulo(turns, 2) /= 0) then
@@ -3909,7 +3908,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
           tmp_buffer_in => tmp_buffer
         endif
 
-        call time_interp_external(segment%field(m)%fid,Time, tmp_buffer_in)
+        call time_interp_extern(segment%field(m)%fid,Time, tmp_buffer_in)
         ! NOTE: Rotation of face-points require that we skip the final value
         if (turns /= 0) then
           ! TODO: This is hardcoded for 90 degrees, and needs to be generalized.
@@ -3976,7 +3975,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
         ! no dz for tidal variables
         if (segment%field(m)%nk_src > 1 .and.&
             (index(segment%field(m)%name, 'phase') .le. 0 .and. index(segment%field(m)%name, 'amp') .le. 0)) then
-          call time_interp_external(segment%field(m)%fid_dz,Time, tmp_buffer_in)
+          call time_interp_extern(segment%field(m)%fid_dz,Time, tmp_buffer_in)
           if (turns /= 0) then
             ! TODO: This is hardcoded for 90 degrees, and needs to be generalized.
             if (segment%is_E_or_W &

--- a/src/diagnostics/MOM_obsolete_diagnostics.F90
+++ b/src/diagnostics/MOM_obsolete_diagnostics.F90
@@ -4,10 +4,10 @@ module MOM_obsolete_diagnostics
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use MOM_diag_manager,  only : register_static_field_fms
+use MOM_diag_mediator, only : diag_ctrl
 use MOM_error_handler, only : MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,   only : param_file_type, log_version, get_param
-use MOM_diag_mediator, only : diag_ctrl
-use diag_manager_mod, only  : register_static_field_fms=>register_static_field
 
 implicit none ; private
 

--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -5,22 +5,19 @@ module MOM_coms
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING
-use fms_mod, only : fms_end, MOM_infra_init => fms_init
-use memutils_mod, only : print_memuse_stats
-use mpp_mod, only : PE_here => mpp_pe, root_PE => mpp_root_pe, num_PEs => mpp_npes
-use mpp_mod, only : Set_PElist => mpp_set_current_pelist, Get_PElist => mpp_get_current_pelist
-use mpp_mod, only : broadcast => mpp_broadcast, field_chksum => mpp_chksum
-use mpp_mod, only : sum_across_PEs => mpp_sum, max_across_PEs => mpp_max, min_across_PEs => mpp_min
+use MOM_coms_wrapper, only : PE_here, root_PE, num_PEs, Set_PElist, Get_PElist
+use MOM_coms_wrapper, only : broadcast, field_chksum, MOM_infra_init, MOM_infra_end
+use MOM_coms_wrapper, only : sum_across_PEs, max_across_PEs, min_across_PEs
 
 implicit none ; private
 
 public :: PE_here, root_PE, num_PEs, MOM_infra_init, MOM_infra_end
 public :: broadcast, sum_across_PEs, min_across_PEs, max_across_PEs, field_chksum
+public :: Set_PElist, Get_PElist
 public :: reproducing_sum, reproducing_sum_EFP, EFP_sum_across_PEs, EFP_list_sum_across_PEs
 public :: EFP_plus, EFP_minus, EFP_to_real, real_to_EFP, EFP_real_diff
 public :: operator(+), operator(-), assignment(=)
 public :: query_EFP_overflow_error, reset_EFP_overflow_error
-public :: Set_PElist, Get_PElist
 
 ! This module provides interfaces to the non-domain-oriented communication subroutines.
 
@@ -879,13 +876,5 @@ subroutine EFP_val_sum_across_PEs(EFP, error)
   endif
 
 end subroutine EFP_val_sum_across_PEs
-
-
-!> This subroutine carries out all of the calls required to close out the infrastructure cleanly.
-!! This should only be called in ocean-only runs, as the coupler takes care of this in coupled runs.
-subroutine MOM_infra_end
-  call print_memuse_stats( 'Memory HiWaterMark', always=.TRUE. )
-  call fms_end
-end subroutine MOM_infra_end
 
 end module MOM_coms

--- a/src/framework/MOM_coms_wrapper.F90
+++ b/src/framework/MOM_coms_wrapper.F90
@@ -1,0 +1,160 @@
+!> Thin interfaces to non-domain-oriented mpp communication subroutines
+module MOM_coms_wrapper
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use fms_mod, only : fms_end, MOM_infra_init => fms_init
+use memutils_mod, only : print_memuse_stats
+use mpp_mod, only : PE_here => mpp_pe, root_PE => mpp_root_pe, num_PEs => mpp_npes
+use mpp_mod, only : Set_PElist => mpp_set_current_pelist, Get_PElist => mpp_get_current_pelist
+use mpp_mod, only : mpp_broadcast, mpp_sync, mpp_sync_self, field_chksum => mpp_chksum
+use mpp_mod, only : sum_across_PEs => mpp_sum, max_across_PEs => mpp_max, min_across_PEs => mpp_min
+
+implicit none ; private
+
+public :: PE_here, root_PE, num_PEs, MOM_infra_init, MOM_infra_end, Set_PElist, Get_PElist
+public :: broadcast, sum_across_PEs, min_across_PEs, max_across_PEs, field_chksum
+
+! This module provides interfaces to the non-domain-oriented communication subroutines.
+
+!> Communicate an array, string or scalar from one PE to others
+interface broadcast
+  module procedure broadcast_char, broadcast_int0D, broadcast_int1D
+  module procedure broadcast_real0D, broadcast_real1D, broadcast_real2D
+end interface broadcast
+
+contains
+
+!> Communicate a 1-D array of character strings from one PE to others
+subroutine broadcast_char(dat, length, from_PE, PElist, blocking)
+  character(len=*),  intent(inout) :: dat(:)    !< The data to communicate and destination
+  integer,           intent(in)    :: length    !< The length of each string
+  integer, optional, intent(in)    :: from_PE   !< The source PE, by default the root PE
+  integer, optional, intent(in)    :: PElist(:) !< The list of participating PEs, by default the
+                                                !! active PE set as previously set via Set_PElist.
+  logical, optional, intent(in)    :: blocking  !< If true, barriers are added around the call
+
+  integer :: src_PE   ! The processor that is sending the data
+  logical :: do_block ! If true add synchronizing barriers
+
+  do_block = .false. ; if (present(blocking)) do_block = blocking
+  if (present(from_PE)) then ; src_PE = from_PE ; else ; src_PE = root_PE() ; endif
+
+  if (do_block) call mpp_sync(PElist)
+  call mpp_broadcast(dat, length, src_PE, PElist)
+  if (do_block) call mpp_sync_self(PElist)
+
+end subroutine broadcast_char
+
+!> Communicate an integer from one PE to others
+subroutine broadcast_int0D(dat, from_PE, PElist, blocking)
+  integer,               intent(inout) :: dat       !< The data to communicate and destination
+  integer,     optional, intent(in)    :: from_PE   !< The source PE, by default the root PE
+  integer,     optional, intent(in)    :: PElist(:) !< The list of participating PEs, by default the
+                                                    !! active PE set as previously set via Set_PElist.
+  logical,     optional, intent(in)    :: blocking  !< If true, barriers are added around the call
+
+  integer :: src_PE   ! The processor that is sending the data
+  logical :: do_block ! If true add synchronizing barriers
+
+  do_block = .false. ; if (present(blocking)) do_block = blocking
+  if (present(from_PE)) then ; src_PE = from_PE ; else ; src_PE = root_PE() ; endif
+
+  if (do_block) call mpp_sync(PElist)
+  call mpp_broadcast(dat, src_PE, PElist)
+  if (do_block) call mpp_sync_self(PElist)
+
+end subroutine broadcast_int0D
+
+!> Communicate a 1-D array of integers from one PE to others
+subroutine broadcast_int1D(dat, length, from_PE, PElist, blocking)
+  integer, dimension(:), intent(inout) :: dat       !< The data to communicate and destination
+  integer,               intent(in)    :: length    !< The number of data elements
+  integer,     optional, intent(in)    :: from_PE   !< The source PE, by default the root PE
+  integer,     optional, intent(in)    :: PElist(:) !< The list of participating PEs, by default the
+                                                    !! active PE set as previously set via Set_PElist.
+  logical,     optional, intent(in)    :: blocking  !< If true, barriers are added around the call
+
+  integer :: src_PE   ! The processor that is sending the data
+  logical :: do_block ! If true add synchronizing barriers
+
+  do_block = .false. ; if (present(blocking)) do_block = blocking
+  if (present(from_PE)) then ; src_PE = from_PE ; else ; src_PE = root_PE() ; endif
+
+  if (do_block) call mpp_sync(PElist)
+  call mpp_broadcast(dat, length, src_PE, PElist)
+  if (do_block) call mpp_sync_self(PElist)
+
+end subroutine broadcast_int1D
+
+!> Communicate a real number from one PE to others
+subroutine broadcast_real0D(dat, from_PE, PElist, blocking)
+  real,                 intent(inout) :: dat       !< The data to communicate and destination
+  integer,    optional, intent(in)    :: from_PE   !< The source PE, by default the root PE
+  integer,    optional, intent(in)    :: PElist(:) !< The list of participating PEs, by default the
+                                                   !! active PE set as previously set via Set_PElist.
+  logical,    optional, intent(in)    :: blocking  !< If true, barriers are added around the call
+
+  integer :: src_PE   ! The processor that is sending the data
+  logical :: do_block ! If true add synchronizing barriers
+
+  do_block = .false. ; if (present(blocking)) do_block = blocking
+  if (present(from_PE)) then ; src_PE = from_PE ; else ; src_PE = root_PE() ; endif
+
+  if (do_block) call mpp_sync(PElist)
+  call mpp_broadcast(dat, src_PE, PElist)
+  if (do_block) call mpp_sync_self(PElist)
+
+end subroutine broadcast_real0D
+
+!> Communicate a 1-D array of reals from one PE to others
+subroutine broadcast_real1D(dat, length, from_PE, PElist, blocking)
+  real, dimension(:),   intent(inout) :: dat       !< The data to communicate and destination
+  integer,              intent(in)    :: length    !< The number of data elements
+  integer,    optional, intent(in)    :: from_PE   !< The source PE, by default the root PE
+  integer,    optional, intent(in)    :: PElist(:) !< The list of participating PEs, by default the
+                                                   !! active PE set as previously set via Set_PElist.
+  logical,    optional, intent(in)    :: blocking  !< If true, barriers are added around the call
+
+  integer :: src_PE   ! The processor that is sending the data
+  logical :: do_block ! If true add synchronizing barriers
+
+  do_block = .false. ; if (present(blocking)) do_block = blocking
+  if (present(from_PE)) then ; src_PE = from_PE ; else ; src_PE = root_PE() ; endif
+
+  if (do_block) call mpp_sync(PElist)
+  call mpp_broadcast(dat, length, src_PE, PElist)
+  if (do_block) call mpp_sync_self(PElist)
+
+end subroutine broadcast_real1D
+
+!> Communicate a 2-D array of reals from one PE to others
+subroutine broadcast_real2D(dat, length, from_PE, PElist, blocking)
+  real, dimension(:,:), intent(inout) :: dat       !< The data to communicate and destination
+  integer,              intent(in)    :: length    !< The total number of data elements
+  integer,    optional, intent(in)    :: from_PE   !< The source PE, by default the root PE
+  integer,    optional, intent(in)    :: PElist(:) !< The list of participating PEs, by default the
+                                                   !! active PE set as previously set via Set_PElist.
+  logical,    optional, intent(in)    :: blocking  !< If true, barriers are added around the call
+
+  integer :: src_PE   ! The processor that is sending the data
+  logical :: do_block ! If true add synchronizing barriers
+
+  do_block = .false. ; if (present(blocking)) do_block = blocking
+  if (present(from_PE)) then ; src_PE = from_PE ; else ; src_PE = root_PE() ; endif
+
+  if (do_block) call mpp_sync(PElist)
+  call mpp_broadcast(dat, length, src_PE, PElist)
+  if (do_block) call mpp_sync_self(PElist)
+
+end subroutine broadcast_real2D
+
+
+!> This subroutine carries out all of the calls required to close out the infrastructure cleanly.
+!! This should only be called in ocean-only runs, as the coupler takes care of this in coupled runs.
+subroutine MOM_infra_end
+  call print_memuse_stats( 'Memory HiWaterMark', always=.TRUE. )
+  call fms_end()
+end subroutine MOM_infra_end
+
+end module MOM_coms_wrapper

--- a/src/framework/MOM_diag_manager.F90
+++ b/src/framework/MOM_diag_manager.F90
@@ -1,14 +1,23 @@
-!> A simple (very thin) wrapper for register_diag_field to avoid a compiler bug with PGI
-module MOM_diag_manager_wrapper
+!> A simple (very thin) wrapper for the FMS diag_manager routines, with some name changes
+module MOM_diag_manager
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_time_manager, only : time_type
+use diag_axis_mod, only : diag_axis_init, get_diag_axis_name, EAST, NORTH
+use diag_data_mod, only : null_axis_id
+use diag_manager_mod, only : diag_manager_init, diag_manager_end
+use diag_manager_mod, only : send_data, diag_field_add_attribute, DIAG_FIELD_NOT_FOUND
 use diag_manager_mod, only : register_diag_field
+use diag_manager_mod, only : register_static_field_fms=>register_static_field
+use diag_manager_mod, only : get_diag_field_id_fms=>get_diag_field_id
 
 implicit none ; private
 
-public register_diag_field_fms
+public diag_manager_init, diag_manager_end
+public diag_axis_init, get_diag_axis_name, EAST, NORTH, null_axis_id
+public send_data, diag_field_add_attribute, DIAG_FIELD_NOT_FOUND
+public register_diag_field_fms, register_static_field_fms,  get_diag_field_id_fms
 
 !> A wrapper for register_diag_field_array()
 interface register_diag_field_fms
@@ -85,11 +94,11 @@ integer function register_diag_field_scalar_fms(module_name, field_name, init_ti
 
 end function register_diag_field_scalar_fms
 
-!> \namespace mom_diag_manager_wrapper
+!> \namespace mom_diag_manager
 !!
 !! This module simply wraps register_diag_field() from FMS's diag_manager_mod.
 !! We used to be able to import register_diag_field and rename it to register_diag_field_fms
 !! with a simple "use, only : register_diag_field_fms => register_diag_field" but PGI 16.5
 !! has a bug that refuses to compile this - earlier versions did work.
 
-end module MOM_diag_manager_wrapper
+end module MOM_diag_manager

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -9,37 +9,28 @@ use MOM_checksums,        only : hchksum, uchksum, vchksum, Bchksum
 use MOM_coms,             only : PE_here
 use MOM_cpu_clock,        only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,        only : CLOCK_MODULE, CLOCK_ROUTINE
+use MOM_diag_manager,     only : diag_manager_init, diag_manager_end
+use MOM_diag_manager,     only : diag_axis_init, get_diag_axis_name, null_axis_id
+use MOM_diag_manager,     only : send_data, diag_field_add_attribute, EAST, NORTH
+use MOM_diag_manager,     only : register_diag_field_fms, register_static_field_fms
+use MOM_diag_manager,     only : get_diag_field_id_fms, DIAG_FIELD_NOT_FOUND
+use MOM_diag_remap,       only : diag_remap_ctrl, diag_remap_update, diag_remap_calc_hmask
+use MOM_diag_remap,       only : diag_remap_init, diag_remap_end, diag_remap_do_remap
+use MOM_diag_remap,       only : vertically_reintegrate_diag_field, vertically_interpolate_diag_field
+use MOM_diag_remap,       only : horizontally_average_diag_field, diag_remap_get_axes_info
+use MOM_diag_remap,       only : diag_remap_configure_axes, diag_remap_axes_configured
+use MOM_diag_remap,       only : diag_remap_diag_registration_closed, diag_remap_set_active
+use MOM_EOS,              only : EOS_type
 use MOM_error_handler,    only : MOM_error, FATAL, WARNING, is_root_pe, assert
 use MOM_file_parser,      only : get_param, log_version, param_file_type
 use MOM_grid,             only : ocean_grid_type
-use MOM_io,               only : slasher, vardesc, query_vardesc, mom_read_data
+use MOM_io,               only : slasher, vardesc, query_vardesc, MOM_read_data
 use MOM_io,               only : get_filename_appendix
 use MOM_safe_alloc,       only : safe_alloc_ptr, safe_alloc_alloc
 use MOM_string_functions, only : lowercase
 use MOM_time_manager,     only : time_type
 use MOM_unit_scaling,     only : unit_scale_type
 use MOM_verticalGrid,     only : verticalGrid_type
-use MOM_EOS,              only : EOS_type
-use MOM_diag_remap,       only : diag_remap_ctrl
-use MOM_diag_remap,       only : diag_remap_update
-use MOM_diag_remap,       only : diag_remap_calc_hmask
-use MOM_diag_remap,       only : diag_remap_init, diag_remap_end, diag_remap_do_remap
-use MOM_diag_remap,       only : vertically_reintegrate_diag_field, vertically_interpolate_diag_field
-use MOM_diag_remap,       only : diag_remap_configure_axes, diag_remap_axes_configured
-use MOM_diag_remap,       only : diag_remap_get_axes_info, diag_remap_set_active
-use MOM_diag_remap,       only : diag_remap_diag_registration_closed
-use MOM_diag_remap,       only : horizontally_average_diag_field
-
-use diag_axis_mod, only : get_diag_axis_name
-use diag_data_mod, only : null_axis_id
-use diag_manager_mod, only : diag_manager_init, diag_manager_end
-use diag_manager_mod, only : send_data, diag_axis_init, EAST, NORTH, diag_field_add_attribute
-! The following module is needed for PGI since the following line does not compile with PGI 6.5.0
-! was: use diag_manager_mod, only : register_diag_field_fms=>register_diag_field
-use MOM_diag_manager_wrapper, only : register_diag_field_fms
-use diag_manager_mod, only : register_static_field_fms=>register_static_field
-use diag_manager_mod, only : get_diag_field_id_fms=>get_diag_field_id
-use diag_manager_mod, only : DIAG_FIELD_NOT_FOUND
 
 implicit none ; private
 
@@ -482,9 +473,8 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
   call define_axes_group(diag_cs, (/ id_xh, id_yq /), diag_cs%axesCv1, &
        x_cell_method='mean', y_cell_method='point', is_v_point=.true.)
 
-  ! Axis group for special null axis from diag manager
+  ! Axis group for special null axis from diag manager.  (Could null_axis_id be made MOM specific?)
   call define_axes_group(diag_cs, (/ null_axis_id /), diag_cs%axesNull)
-
 
   !Non-native Non-downsampled
   if (diag_cs%num_diag_coords>0) then

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -60,6 +60,8 @@ module MOM_diag_remap
 use MOM_coms,             only : reproducing_sum_EFP, EFP_to_real
 use MOM_coms,             only : EFP_type, assignment(=), EFP_sum_across_PEs
 use MOM_error_handler,    only : MOM_error, FATAL, assert, WARNING
+use MOM_debugging,        only : check_column_integrals
+use MOM_diag_manager,     only : diag_axis_init
 use MOM_diag_vkernels,    only : interpolate_column, reintegrate_column
 use MOM_file_parser,      only : get_param, log_param, param_file_type
 use MOM_io,               only : slasher, mom_read_data
@@ -80,9 +82,7 @@ use coord_zlike,          only : build_zstar_column
 use coord_sigma,          only : build_sigma_column
 use coord_rho,            only : build_rho_column
 
-use diag_manager_mod,  only : diag_axis_init
 
-use MOM_debugging,     only : check_column_integrals
 implicit none ; private
 
 public diag_remap_ctrl

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -11,10 +11,10 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
-use MOM_io_wrapper,    only : axistype, get_axis_data
-use MOM_time_manager,  only : time_type
 use MOM_interpolate,   only : time_interp_extern, get_external_field_info, horiz_interp_init
 use MOM_interpolate,   only : horiz_interp_new, horiz_interp, horiz_interp_type
+use MOM_io_wrapper,    only : axistype, get_axis_data
+use MOM_time_manager,  only : time_type
 
 use netcdf
 
@@ -23,14 +23,6 @@ implicit none ; private
 #include <MOM_memory.h>
 
 public :: horiz_interp_and_extrap_tracer, myStats
-
-! character(len=40)  :: mdl = "MOM_horizontal_regridding" ! This module's name.
-
-!> Fill grid edges
-! interface fill_boundaries
-!   module procedure fill_boundaries_real
-!   module procedure fill_boundaries_int
-! end interface
 
 !> Extrapolate and interpolate data
 interface horiz_interp_and_extrap_tracer
@@ -80,10 +72,9 @@ subroutine myStats(array, missing, is, ie, js, je, k, mesg)
 
 end subroutine myStats
 
-!> Use ICE-9 algorithm to populate points (fill=1) with
-!! valid data (good=1). If no information is available,
-!! Then use a previous guess (prev). Optionally (smooth)
-!! blend the filled points to achieve a more desirable result.
+!> Use ICE-9 algorithm to populate points (fill=1) with valid data (good=1).  If no information
+!! is available, use a previous guess (prev). Optionally (smooth) blend the filled points to
+!! achieve a more desirable result.
 subroutine fill_miss_2d(aout, good, fill, prev, G, smooth, num_pass, relc, crit, debug, answers_2018)
   use MOM_coms, only : sum_across_PEs
 
@@ -108,15 +99,20 @@ subroutine fill_miss_2d(aout, good, fill, prev, G, smooth, num_pass, relc, crit,
                                                 !! answers as the code did in late 2018.  Otherwise
                                                 !! add parentheses for rotational symmetry.
 
-  real, dimension(SZI_(G),SZJ_(G)) :: b,r
-  real, dimension(SZI_(G),SZJ_(G)) :: fill_pts, good_, good_new
+  real, dimension(SZI_(G),SZJ_(G)) :: a_filled ! The aout with missing values filled in
+  real, dimension(SZI_(G),SZJ_(G)) :: a_chg    ! The change in aout due to an iteration of smoothing
+  real, dimension(SZI_(G),SZJ_(G)) :: fill_pts ! 1 for points that still need to be filled
+  real, dimension(SZI_(G),SZJ_(G)) :: good_    ! The values that are valid for the current iteration
+  real, dimension(SZI_(G),SZJ_(G)) :: good_new ! The values of good_ to use for the next iteration
 
+  real    :: east, west, north, south ! Valid neighboring values or 0 for invalid values
+  real    :: ge, gw, gn, gs  ! Flags indicating which neighbors have valid values
+  real    :: ngood     ! The number of valid values in neighboring points
+  logical :: do_smooth ! Indicates whether to do smoothing of the array
+  real    :: nfill     ! The remaining number of points to fill
+  real    :: nfill_prev ! The previous value of nfill
   character(len=256) :: mesg  ! The text of an error message
-  integer :: i,j,k
-  real    :: east,west,north,south,sor
-  real    :: ge,gw,gn,gs,ngood
-  logical :: do_smooth,siena_bug
-  real    :: nfill, nfill_prev
+  integer :: i, j, k
   integer, parameter :: num_pass_default = 10000
   real, parameter :: relc_default = 0.25, crit_default = 1.e-3
 
@@ -151,15 +147,15 @@ subroutine fill_miss_2d(aout, good, fill, prev, G, smooth, num_pass, relc, crit,
 
   nfill_prev = nfill
   good_(:,:) = good(:,:)
-  r(:,:) = 0.0
+  a_chg(:,:) = 0.0
 
   do while (nfill > 0.0)
 
     call pass_var(good_,G%Domain)
     call pass_var(aout,G%Domain)
 
-    b(:,:)=aout(:,:)
-    good_new(:,:)=good_(:,:)
+    a_filled(:,:) = aout(:,:)
+    good_new(:,:) = good_(:,:)
 
     do j=js,je ; do i=is,ie
 
@@ -180,16 +176,16 @@ subroutine fill_miss_2d(aout, good, fill, prev, G, smooth, num_pass, relc, crit,
       endif
       if (ngood > 0.) then
         if (ans_2018) then
-          b(i,j)=(east+west+north+south)/ngood
+          a_filled(i,j) = (east+west+north+south)/ngood
         else
-          b(i,j) = ((east+west) + (north+south))/ngood
+          a_filled(i,j) = ((east+west) + (north+south))/ngood
         endif
         fill_pts(i,j) = 0.0
         good_new(i,j) = 1.0
       endif
     enddo ; enddo
 
-    aout(is:ie,js:je) = b(is:ie,js:je)
+    aout(is:ie,js:je) = a_filled(is:ie,js:je)
     good_(is:ie,js:je) = good_new(is:ie,js:je)
     nfill_prev = nfill
     nfill = sum(fill_pts(is:ie,js:je))
@@ -209,11 +205,13 @@ subroutine fill_miss_2d(aout, good, fill, prev, G, smooth, num_pass, relc, crit,
       call MOM_error(WARNING, mesg, .true.)
     endif
 
+    ! Determine the number of remaining points to fill globally.
     nfill = sum(fill_pts(is:ie,js:je))
     call sum_across_PEs(nfill)
 
-  enddo
+  enddo ! while block for remaining points to fill.
 
+  ! Do Laplacian smoothing for the points that have been filled in.
   if (do_smooth) then ; do k=1,npass
     call pass_var(aout,G%Domain)
     do j=js,je ; do i=is,ie
@@ -221,22 +219,22 @@ subroutine fill_miss_2d(aout, good, fill, prev, G, smooth, num_pass, relc, crit,
         east = max(good(i+1,j),fill(i+1,j)) ; west = max(good(i-1,j),fill(i-1,j))
         north = max(good(i,j+1),fill(i,j+1)) ; south = max(good(i,j-1),fill(i,j-1))
         if (ans_2018) then
-          r(i,j) = relax_coeff*(south*aout(i,j-1)+north*aout(i,j+1) + &
-                                west*aout(i-1,j)+east*aout(i+1,j) - &
-                               (south+north+west+east)*aout(i,j))
+          a_chg(i,j) = relax_coeff*(south*aout(i,j-1)+north*aout(i,j+1) + &
+                                    west*aout(i-1,j)+east*aout(i+1,j) - &
+                                   (south+north+west+east)*aout(i,j))
         else
-          r(i,j) = relax_coeff*( ((south*aout(i,j-1) + north*aout(i,j+1)) + &
+          a_chg(i,j) = relax_coeff*( ((south*aout(i,j-1) + north*aout(i,j+1)) + &
                                   (west*aout(i-1,j)+east*aout(i+1,j))) - &
                                  ((south+north)+(west+east))*aout(i,j) )
         endif
       else
-        r(i,j) = 0.
+        a_chg(i,j) = 0.
       endif
     enddo ; enddo
     ares = 0.0
     do j=js,je ; do i=is,ie
-      aout(i,j) = r(i,j) + aout(i,j)
-      ares = max(ares, abs(r(i,j)))
+      aout(i,j) = a_chg(i,j) + aout(i,j)
+      ares = max(ares, abs(a_chg(i,j)))
     enddo ; enddo
     call max_across_PEs(ares)
     if (ares <= acrit) exit
@@ -285,9 +283,9 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
                                                      !! extrapolation is performed by this routine
 
   ! Local variables
-  real, dimension(:,:),  allocatable   :: tr_in, tr_inp ! A 2-d array for holding input data on
-                                                     ! native horizontal grid and extended grid
-                                                     ! with poles.
+  real, dimension(:,:),  allocatable   :: tr_in      !< A 2-d array for holding input data on its
+                                                     !! native horizontal grid.
+  real, dimension(:,:),  allocatable   :: tr_inp     !< Native horizontal grid data extended to the poles.
   real, dimension(:,:),  allocatable   :: mask_in    ! A 2-d mask for extended input grid.
 
   real :: PI_180
@@ -295,8 +293,8 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   integer :: i, j, k
   integer, dimension(4) :: start, count, dims, dim_id
   real, dimension(:,:), allocatable :: x_in, y_in
-  real, dimension(:), allocatable  :: lon_in, lat_in
-  real, dimension(:), allocatable  :: lat_inp, last_row
+  real, dimension(:), allocatable  :: lon_in, lat_in ! The longitude and latitude in the input file
+  real, dimension(:), allocatable  :: lat_inp ! The input file latitudes expanded to the pole
   real :: max_lat, min_lat, pole, max_depth, npole
   real :: roundoff  ! The magnitude of roundoff, usually ~2e-16.
   real :: add_offset, scale_factor
@@ -311,12 +309,15 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   integer :: id_clock_read
   character(len=12)  :: dim_name(4)
   logical :: debug=.false.
-  real :: npoints,varAvg
-  real, dimension(SZI_(G),SZJ_(G)) :: lon_out, lat_out, tr_out, mask_out
-  real, dimension(SZI_(G),SZJ_(G)) :: good, fill
-  real, dimension(SZI_(G),SZJ_(G)) :: tr_outf, tr_prev
-  real, dimension(SZI_(G),SZJ_(G)) :: good2, fill2
-  real, dimension(SZI_(G),SZJ_(G)) :: nlevs
+  real :: npoints, varAvg
+  real, dimension(SZI_(G),SZJ_(G)) :: lon_out, lat_out ! The longitude and latitude of points on the model grid
+  real, dimension(SZI_(G),SZJ_(G)) :: tr_out, mask_out ! The tracer and mask on the model grid
+  real, dimension(SZI_(G),SZJ_(G)) :: good    ! Where the data is valid, this is 1.
+  real, dimension(SZI_(G),SZJ_(G)) :: fill    ! 1 where the data needs to be filled in
+  real, dimension(SZI_(G),SZJ_(G)) :: tr_outf ! The tracer concentrations after Ice-9
+  real, dimension(SZI_(G),SZJ_(G)) :: tr_prev ! The tracer concentrations in the layer above
+  real, dimension(SZI_(G),SZJ_(G)) :: good2   ! 1 where the data is valid after Ice-9
+  real, dimension(SZI_(G),SZJ_(G)) :: fill2   ! 1 for points that still need to be filled after Ice-9
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -407,7 +408,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 
   if (present(m_to_Z)) then ; do k=1,kd ; z_in(k) = m_to_Z * z_in(k) ; enddo ; endif
 
-  ! extrapolate the input data to the north pole using the northerm-most latitude
+  ! extrapolate the input data to the north pole using the northern-most latitude
   add_np = .false.
   jdp = jd
   if (.not. is_ongrid) then
@@ -445,7 +446,6 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     allocate(tr_in(id,jd)) ; tr_in(:,:) = 0.0
     allocate(tr_inp(id,jdp)) ; tr_inp(:,:) = 0.0
     allocate(mask_in(id,jdp)) ; mask_in(:,:) = 0.0
-    allocate(last_row(id))    ; last_row(:) = 0.0
   endif
 
   max_depth = maxval(G%bathyT)
@@ -488,11 +488,11 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
              trim(varnam)//" in file "// trim(filename))
 
         if (add_np) then
-          last_row(:)=tr_in(:,jd); pole=0.0;npole=0.0
+          pole = 0.0 ; npole = 0.0
           do i=1,id
             if (abs(tr_in(i,jd)-missing_value) > abs(roundoff*missing_value)) then
-              pole = pole+last_row(i)
-              npole = npole+1.0
+              pole = pole + tr_in(i,jd)
+              npole = npole + 1.0
             endif
           enddo
           if (npole > 0) then
@@ -525,12 +525,12 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
 !   call fms routine horiz_interp to interpolate input level data to model horizontal grid
     if (.not. is_ongrid) then
       if (k == 1) then
-        call horiz_interp_new(Interp,x_in,y_in,lon_out(is:ie,js:je),lat_out(is:ie,js:je), &
-              interp_method='bilinear',src_modulo=.true.)
+        call horiz_interp_new(Interp, x_in, y_in, lon_out(is:ie,js:je), lat_out(is:ie,js:je), &
+              interp_method='bilinear', src_modulo=.true.)
       endif
 
       if (debug) then
-        call myStats(tr_inp,missing_value, is,ie,js,je,k,'Tracer from file')
+        call myStats(tr_inp,missing_value, is, ie, js, je, k,'Tracer from file')
       endif
     endif
 
@@ -538,7 +538,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     if (is_ongrid) then
       tr_out(is:ie,js:je)=tr_in(is:ie,js:je)
     else
-      call horiz_interp(Interp,tr_inp,tr_out(is:ie,js:je), missing_value=missing_value, new_missing_handle=.true.)
+      call horiz_interp(Interp, tr_inp, tr_out(is:ie,js:je), missing_value=missing_value, new_missing_handle=.true.)
     endif
 
     mask_out=1.0
@@ -591,7 +591,9 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     fill2(:,:) = fill(:,:)
 
     call fill_miss_2d(tr_outf, good2, fill2, tr_prev, G, smooth=.true., answers_2018=answers_2018)
-    call myStats(tr_outf, missing_value, is, ie, js, je, k, 'field from fill_miss_2d()')
+    if (debug) then
+      call myStats(tr_outf, missing_value, is, ie, js, je, k, 'field from fill_miss_2d()')
+    endif
 
     tr_z(:,:,k) = tr_outf(:,:) * G%mask2dT(:,:)
     mask_z(:,:,k) = good2(:,:) + fill2(:,:)
@@ -634,9 +636,9 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
                                                      !! add parentheses for rotational symmetry.
 
   ! Local variables
-  real, dimension(:,:),  allocatable   :: tr_in,tr_inp !< A 2-d array for holding input data on
-                                                     !! native horizontal grid and extended grid
-                                                     !! with poles.
+  real, dimension(:,:),  allocatable   :: tr_in      !< A 2-d array for holding input data on its
+                                                     !! native horizontal grid.
+  real, dimension(:,:),  allocatable   :: tr_inp     !< Native horizontal grid data extended to the poles.
   real, dimension(:,:,:), allocatable  :: data_in    !< A buffer for storing the full 3-d time-interpolated array
                                                      !! on the original grid
   real, dimension(:,:),  allocatable   :: mask_in    !< A 2-d mask for extended input grid.
@@ -646,8 +648,8 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   integer :: i,j,k
   integer, dimension(4) :: start, count, dims, dim_id
   real, dimension(:,:), allocatable :: x_in, y_in
-  real, dimension(:), allocatable  :: lon_in, lat_in
-  real, dimension(:), allocatable  :: lat_inp, last_row
+  real, dimension(:), allocatable  :: lon_in, lat_in ! The longitude and latitude in the input file
+  real, dimension(:), allocatable  :: lat_inp ! The input file latitudes expanded to the pole
   real :: max_lat, min_lat, pole, max_depth, npole
   real :: roundoff  ! The magnitude of roundoff, usually ~2e-16.
   logical :: add_np
@@ -663,12 +665,15 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   character(len=12)  :: dim_name(4)
   logical :: debug=.false.
   logical :: spongeDataOngrid
-  real :: npoints,varAvg
-  real, dimension(SZI_(G),SZJ_(G)) :: lon_out, lat_out, tr_out, mask_out
-  real, dimension(SZI_(G),SZJ_(G)) :: good, fill
-  real, dimension(SZI_(G),SZJ_(G)) :: tr_outf,tr_prev
-  real, dimension(SZI_(G),SZJ_(G))  :: good2,fill2
-  real, dimension(SZI_(G),SZJ_(G))  :: nlevs
+  real :: npoints, varAvg
+  real, dimension(SZI_(G),SZJ_(G)) :: lon_out, lat_out ! The longitude and latitude of points on the model grid
+  real, dimension(SZI_(G),SZJ_(G)) :: tr_out, mask_out ! The tracer and mask on the model grid
+  real, dimension(SZI_(G),SZJ_(G)) :: good    ! Where the data is valid, this is 1.
+  real, dimension(SZI_(G),SZJ_(G)) :: fill    ! 1 where the data needs to be filled in
+  real, dimension(SZI_(G),SZJ_(G)) :: tr_outf ! The tracer concentrations after Ice-9
+  real, dimension(SZI_(G),SZJ_(G)) :: tr_prev ! The tracer concentrations in the layer above
+  real, dimension(SZI_(G),SZJ_(G)) :: good2   ! 1 where the data is valid after Ice-9
+  real, dimension(SZI_(G),SZJ_(G)) :: fill2   ! 1 for points that still need to be filled after Ice-9
   integer :: turns
 
   turns = G%HI%turns
@@ -679,7 +684,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
 
   id_clock_read = cpu_clock_id('(Initialize tracer from Z) read', grain=CLOCK_LOOP)
 
-  PI_180=atan(1.0)/45.
+  PI_180 = atan(1.0)/45.
 
   ! Open NetCDF file and if present, extract data and spatial coordinate information
   ! The convention adopted here requires that the data be written in (i,j,k) ordering.
@@ -696,15 +701,15 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
 
   id = fld_sz(1) ; jd  = fld_sz(2) ; kd = fld_sz(3)
 
-  spongeDataOngrid=.false.
-  if (PRESENT(spongeOngrid)) spongeDataOngrid=spongeOngrid
+  spongeDataOngrid = .false.
+  if (PRESENT(spongeOngrid)) spongeDataOngrid = spongeOngrid
   if (.not. spongeDataOngrid) then
-    allocate(lon_in(id),lat_in(jd))
+    allocate(lon_in(id), lat_in(jd))
     call get_axis_data(axes_data(1), lon_in)
     call get_axis_data(axes_data(2), lat_in)
   endif
 
-  allocate(z_in(kd),z_edges_in(kd+1))
+  allocate(z_in(kd), z_edges_in(kd+1))
 
   allocate(tr_z(isd:ied,jsd:jed,kd), mask_z(isd:ied,jsd:jed,kd))
 
@@ -715,9 +720,9 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   call cpu_clock_end(id_clock_read)
 
   if (.not. spongeDataOngrid) then
-    ! extrapolate the input data to the north pole using the northerm-most latitude
+    ! Extrapolate the input data to the north pole using the northerm-most latitude.
     max_lat = maxval(lat_in)
-    add_np=.false.
+    add_np = .false.
     if (max_lat < 90.0) then
       add_np = .true.
       jdp = jd+1
@@ -728,7 +733,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
       allocate(lat_in(1:jdp))
       lat_in(:) = lat_inp(:)
     else
-      jdp=jd
+      jdp = jd
     endif
     call horiz_interp_init()
     lon_in = lon_in*PI_180
@@ -741,7 +746,6 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
     allocate(tr_in(id,jd)) ; tr_in(:,:)=0.0
     allocate(tr_inp(id,jdp)) ; tr_inp(:,:)=0.0
     allocate(mask_in(id,jdp)) ; mask_in(:,:)=0.0
-    allocate(last_row(id))    ; last_row(:)=0.0
   else
     allocate(data_in(isd:ied,jsd:jed,kd))
   endif
@@ -764,40 +768,39 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   if (.not.spongeDataOngrid) then
     if (is_root_pe()) &
       call time_interp_extern(fms_id, Time, data_in, verbose=.true., turns=turns)
-    ! loop through each data level and interpolate to model grid.
-    ! after interpolating, fill in points which will be needed
-    ! to define the layers
+    ! Loop through each data level and interpolate to model grid.
+    ! After interpolating, fill in points which will be needed to define the layers.
     do k=1,kd
       write(laynum,'(I8)') k ; laynum = adjustl(laynum)
       if (is_root_pe()) then
         tr_in(1:id,1:jd) = data_in(1:id,1:jd,k)
         if (add_np) then
-         last_row(:)=tr_in(:,jd); pole=0.0;npole=0.0
-         do i=1,id
-           if (abs(tr_in(i,jd)-missing_value) > abs(roundoff*missing_value)) then
-             pole = pole+last_row(i)
-             npole = npole+1.0
-           endif
-         enddo
-         if (npole > 0) then
-           pole=pole/npole
-         else
-           pole=missing_value
-         endif
-         tr_inp(:,1:jd) = tr_in(:,:)
-         tr_inp(:,jdp) = pole
+          pole = 0.0 ; npole = 0.0
+          do i=1,id
+            if (abs(tr_in(i,jd)-missing_value) > abs(roundoff*missing_value)) then
+              pole = pole + tr_in(i,jd)
+              npole = npole+1.0
+            endif
+          enddo
+          if (npole > 0) then
+            pole = pole / npole
+          else
+            pole = missing_value
+          endif
+          tr_inp(:,1:jd) = tr_in(:,:)
+          tr_inp(:,jdp) = pole
         else
-         tr_inp(:,:) = tr_in(:,:)
+          tr_inp(:,:) = tr_in(:,:)
         endif
       endif
 
       call broadcast(tr_inp, id*jdp, blocking=.true.)
 
-      mask_in=0.0
+      mask_in(:,:) = 0.0
 
       do j=1,jdp ; do i=1,id
         if (abs(tr_inp(i,j)-missing_value) > abs(roundoff*missing_value)) then
-          mask_in(i,j)=1.0
+          mask_in(i,j) = 1.0
           tr_inp(i,j) = tr_inp(i,j) * conversion
         else
           tr_inp(i,j) = missing_value
@@ -837,7 +840,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
         endif
         if ((G%mask2dT(i,j) == 1.0) .and. (z_edges_in(k) <= G%bathyT(i,j)) .and. &
             (mask_out(i,j) < 1.0)) &
-          fill(i,j)=1.0
+          fill(i,j) = 1.0
       enddo ;  enddo
       call pass_var(fill, G%Domain)
       call pass_var(good, G%Domain)
@@ -881,15 +884,15 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
 
     enddo ! kd
   else
-      call time_interp_extern(fms_id, Time, data_in, verbose=.true., turns=turns)
-      do k=1,kd
-        do j=js,je
-          do i=is,ie
-            tr_z(i,j,k)=data_in(i,j,k)
-            if (abs(tr_z(i,j,k)-missing_value) < abs(roundoff*missing_value)) mask_z(i,j,k) = 0.
-          enddo
+    call time_interp_extern(fms_id, Time, data_in, verbose=.true., turns=turns)
+    do k=1,kd
+      do j=js,je
+        do i=is,ie
+          tr_z(i,j,k) = data_in(i,j,k)
+          if (abs(tr_z(i,j,k)-missing_value) < abs(roundoff*missing_value)) mask_z(i,j,k) = 0.
         enddo
       enddo
+    enddo
   endif
 
 end subroutine horiz_interp_and_extrap_tracer_fms_id
@@ -901,9 +904,9 @@ subroutine meshgrid(x, y, x_T, y_T)
   real, dimension(size(x,1),size(y,1)), intent(inout) :: x_T !< output 2-dimensional array
   real, dimension(size(x,1),size(y,1)), intent(inout) :: y_T !< output 2-dimensional array
 
-  integer :: ni,nj,i,j
+  integer :: ni, nj, i, j
 
-  ni=size(x,1) ; nj=size(y,1)
+  ni = size(x,1) ; nj = size(y,1)
 
   do j=1,nj ; do i=1,ni
     x_T(i,j) = x(i)
@@ -914,123 +917,5 @@ subroutine meshgrid(x, y, x_T, y_T)
   enddo ; enddo
 
 end subroutine meshgrid
-
-! None of the subsequent code appears to be used at all.
-
-! !> Fill grid edges for integer data
-! function fill_boundaries_int(m,cyclic_x,tripolar_n) result(mp)
-!   integer, dimension(:,:), intent(in)             :: m !< input array (ND)
-!   logical,                 intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
-!   logical,                 intent(in)             :: tripolar_n !< True if domain has an Arctic fold
-!   integer, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
-
-!   real,    dimension(size(m,1),size(m,2))         :: m_real
-!   real,    dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp_real
-
-!   m_real = real(m)
-
-!   mp_real = fill_boundaries_real(m_real,cyclic_x,tripolar_n)
-
-!   mp = int(mp_real)
-
-! end function fill_boundaries_int
-
-!> Fill grid edges for real data
-! function fill_boundaries_real(m,cyclic_x,tripolar_n) result(mp)
-!   real, dimension(:,:), intent(in)             :: m !< input array (ND)
-!   logical,              intent(in)             :: cyclic_x !< True if domain is zonally re-entrant
-!   logical,              intent(in)             :: tripolar_n !< True if domain has an Arctic fold
-!   real, dimension(0:size(m,1)+1,0:size(m,2)+1) :: mp
-
-!   integer :: ni,nj,i,j
-
-!   ni=size(m,1); nj=size(m,2)
-
-!   mp(1:ni,1:nj)=m(:,:)
-
-!   if (cyclic_x) then
-!     mp(0,1:nj)=m(ni,1:nj)
-!     mp(ni+1,1:nj)=m(1,1:nj)
-!   else
-!     mp(0,1:nj)=m(1,1:nj)
-!     mp(ni+1,1:nj)=m(ni,1:nj)
-!   endif
-
-!   mp(1:ni,0)=m(1:ni,1)
-!   if (tripolar_n) then
-!     do i=1,ni
-!       mp(i,nj+1)=m(ni-i+1,nj)
-!     enddo
-!   else
-!     mp(1:ni,nj+1)=m(1:ni,nj)
-!   endif
-
-! end function fill_boundaries_real
-
-!> Solve del2 (zi) = 0 using successive iterations
-!! with a 5 point stencil. Only points fill==1 are
-!! modified. Except where bad==1, information propagates
-!! isotropically in index space.  The resulting solution
-!! in each region is an approximation to del2(zi)=0 subject to
-!! boundary conditions along the valid points curve bounding this region.
-! subroutine smooth_heights(zi,fill,bad,sor,niter,cyclic_x, tripolar_n)
-!   real,    dimension(:,:),                   intent(inout) :: zi !< input and output array (ND)
-!   integer, dimension(size(zi,1),size(zi,2)), intent(in) :: fill !< same shape as zi, 1=fill
-!   integer, dimension(size(zi,1),size(zi,2)), intent(in) :: bad  !< same shape as zi, 1=bad data
-!   real,                                      intent(in)  :: sor !< relaxation coefficient (ND)
-!   integer,                                   intent(in) :: niter !< maximum number of iterations
-!   logical,                                   intent(in) :: cyclic_x !< true if domain is zonally reentrant
-!   logical,                                   intent(in) :: tripolar_n !< true if domain has an Arctic fold
-
-!   ! Local variables
-!   real, dimension(size(zi,1),size(zi,2)) :: res, m
-!   integer, dimension(size(zi,1),size(zi,2),4) :: B
-!   real, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: mp
-!   integer, dimension(0:size(zi,1)+1,0:size(zi,2)+1) :: nm
-!   integer :: i,j,k,n
-!   integer :: ni,nj
-!   real :: Isum, bsum
-
-!   ni=size(zi,1) ; nj=size(zi,2)
-
-
-!   mp(:,:) = fill_boundaries(zi,cyclic_x,tripolar_n)
-
-!   B(:,:,:) = 0.0
-!   nm(:,:) = fill_boundaries(bad,cyclic_x,tripolar_n)
-
-!   do j=1,nj
-!     do i=1,ni
-!       if (fill(i,j) == 1) then
-!         B(i,j,1)=1-nm(i+1,j);B(i,j,2)=1-nm(i-1,j)
-!         B(i,j,3)=1-nm(i,j+1);B(i,j,4)=1-nm(i,j-1)
-!       endif
-!     enddo
-!   enddo
-
-!   do n=1,niter
-!     do j=1,nj
-!       do i=1,ni
-!         if (fill(i,j) == 1) then
-!           bsum = real(B(i,j,1)+B(i,j,2)+B(i,j,3)+B(i,j,4))
-!           Isum = 1.0/bsum
-!           res(i,j)=Isum*(B(i,j,1)*mp(i+1,j)+B(i,j,2)*mp(i-1,j)+&
-!                    B(i,j,3)*mp(i,j+1)+B(i,j,4)*mp(i,j-1)) - mp(i,j)
-!         endif
-!       enddo
-!     enddo
-!     res(:,:)=res(:,:)*sor
-
-!     do j=1,nj
-!       do i=1,ni
-!         mp(i,j)=mp(i,j)+res(i,j)
-!       enddo
-!     enddo
-
-!     zi(:,:)=mp(1:ni,1:nj)
-!     mp = fill_boundaries(zi,cyclic_x,tripolar_n)
-!   enddo
-
-! end subroutine smooth_heights
 
 end module MOM_horizontal_regridding

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -16,7 +16,8 @@ use MOM_interpolate,   only : horiz_interp_new, horiz_interp, horiz_interp_type
 use MOM_io_wrapper,    only : axistype, get_axis_data
 use MOM_time_manager,  only : time_type
 
-use netcdf
+use netcdf, only : NF90_OPEN, NF90_NOWRITE, NF90_GET_ATT, NF90_GET_VAR
+use netcdf, only : NF90_INQ_VARID, NF90_INQUIRE_VARIABLE, NF90_INQUIRE_DIMENSION
 
 implicit none ; private
 

--- a/src/framework/MOM_interpolate.F90
+++ b/src/framework/MOM_interpolate.F90
@@ -1,0 +1,143 @@
+!> This module wraps the FMS temporal and spatial interpolation routines
+module MOM_interpolate
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_array_transform, only : allocate_rotated_array, rotate_array
+use MOM_error_handler, only : MOM_error, FATAL
+use MOM_io_wrapper, only : axistype
+use horiz_interp_mod,  only : horiz_interp_new, horiz_interp, horiz_interp_init, horiz_interp_type
+use time_interp_external_mod, only : time_interp_external_fms=>time_interp_external
+use time_interp_external_mod, only : init_external_field, time_interp_external_init
+use time_interp_external_mod, only : get_external_field_size
+use time_interp_external_mod, only : get_external_field_axes, get_external_field_missing
+use time_manager_mod, only : time_type
+
+implicit none ; private
+
+public :: time_interp_extern, init_external_field, time_interp_external_init
+public :: get_external_field_info
+public :: horiz_interp_type, horiz_interp_init, horiz_interp, horiz_interp_new
+
+!> Read a field based on model time, and rotate to the model domain.
+! This inerface does not share the name time_interp_external with the module it primarily
+! wraps because of errors (perhaps a bug) that arise with the PGI 19.10.0 compiler.
+interface time_interp_extern
+  module procedure time_interp_external_0d
+  module procedure time_interp_external_2d
+  module procedure time_interp_external_3d
+end interface time_interp_extern
+
+contains
+
+!> Get information about the external fields.
+subroutine get_external_field_info(field_id, size, axes, missing)
+  integer,                                intent(in)    :: field_id !< The integer index of the external
+                                                                    !! field returned from a previous
+                                                                    !! call to init_external_field()
+  integer,        dimension(4), optional, intent(inout) :: size    !< Dimension sizes for the input data
+  type(axistype), dimension(4), optional, intent(inout) :: axes    !< Axis types for the input data
+  real,                         optional, intent(inout) :: missing !< Missing value for the input data
+
+  if (present(size)) then
+    size(1:4) = get_external_field_size(field_id)
+  endif
+
+  if (present(axes)) then
+    axes(1:4) = get_external_field_axes(field_id)
+  endif
+
+  if (present(missing)) then
+    missing = get_external_field_missing(field_id)
+  endif
+
+end subroutine get_external_field_info
+
+
+!> Read a scalar field based on model time.
+subroutine time_interp_external_0d(field_id, time, data_in, verbose)
+  integer,           intent(in)    :: field_id !< The integer index of the external field returned
+                                               !! from a previous call to init_external_field()
+  type(time_type),   intent(in)    :: time     !< The target time for the data
+  real,              intent(inout) :: data_in  !< The interpolated value
+  logical, optional, intent(in)    :: verbose  !< If true, write verbose output for debugging
+
+  call time_interp_external_fms(field_id, time, data_in, verbose=verbose)
+end subroutine time_interp_external_0d
+
+!> Read a 2d field from an external based on model time, potentially including horizontal
+!! interpolation and rotation of the data
+subroutine time_interp_external_2d(field_id, time, data_in, interp, verbose, horz_interp, mask_out, turns)
+  integer,              intent(in)    :: field_id !< The integer index of the external field returned
+                                                  !! from a previous call to init_external_field()
+  type(time_type),      intent(in)    :: time     !< The target time for the data
+  real, dimension(:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
+  integer,    optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
+  logical,    optional, intent(in)    :: verbose  !< If true, write verbose output for debugging
+  type(horiz_interp_type), &
+              optional, intent(in)    :: horz_interp !< A structure to control horizontal interpolation
+  logical, dimension(:,:), &
+              optional, intent(out)   :: mask_out !< An array that is true where there is valid data
+  integer,    optional, intent(in)    :: turns    !< Number of quarter turns to rotate the data
+
+  real, allocatable :: data_pre_rot(:,:) ! The input data before rotation
+  integer :: qturns ! The number of quarter turns to rotate the data
+
+  ! TODO: Mask rotation requires logical array rotation support
+  if (present(mask_out)) &
+    call MOM_error(FATAL, "Rotation of masked output not yet support")
+
+  qturns = 0
+  if (present(turns)) qturns = modulo(turns, 4)
+
+  if (qturns == 0) then
+    call time_interp_external_fms(field_id, time, data_in, interp=interp, &
+                                  verbose=verbose, horz_interp=horz_interp)
+  else
+    call allocate_rotated_array(data_in, [1,1], -qturns, data_pre_rot)
+    call time_interp_external_fms(field_id, time, data_pre_rot, interp=interp, &
+                                  verbose=verbose, horz_interp=horz_interp)
+    call rotate_array(data_pre_rot, turns, data_in)
+    deallocate(data_pre_rot)
+  endif
+end subroutine time_interp_external_2d
+
+
+!> Read a 3d field based on model time, and rotate to the model grid
+subroutine time_interp_external_3d(field_id, time, data_in, interp, &
+    verbose, horz_interp, mask_out, turns)
+  integer,                intent(in)    :: field_id !< The integer index of the external field returned
+                                                    !! from a previous call to init_external_field()
+  type(time_type),        intent(in)    :: time     !< The target time for the data
+  real, dimension(:,:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
+  integer,      optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
+  logical,      optional, intent(in)    :: verbose  !< If true, write verbose output for debugging
+  type(horiz_interp_type), &
+                optional, intent(in)    :: horz_interp !< A structure to control horizontal interpolation
+  logical, dimension(:,:,:), &
+                optional, intent(out)   :: mask_out !< An array that is true where there is valid data
+  integer,      optional, intent(in)    :: turns    !< Number of quarter turns to rotate the data
+
+  real, allocatable :: data_pre_rot(:,:,:) ! The input data before rotation
+  integer :: qturns  ! The number of quarter turns to rotate the data
+
+  ! TODO: Mask rotation requires logical array rotation support
+  if (present(mask_out)) &
+    call MOM_error(FATAL, "Rotation of masked output not yet support")
+
+  qturns = 0
+  if (present(turns)) qturns = modulo(turns, 4)
+
+  if (qturns == 0) then
+    call time_interp_external_fms(field_id, time, data_in, interp=interp, &
+                                  verbose=verbose, horz_interp=horz_interp)
+  else
+    call allocate_rotated_array(data_in, [1,1,1], -qturns, data_pre_rot)
+    call time_interp_external_fms(field_id, time, data_pre_rot, interp=interp, &
+                                  verbose=verbose, horz_interp=horz_interp)
+    call rotate_array(data_pre_rot, turns, data_in)
+    deallocate(data_pre_rot)
+  endif
+end subroutine time_interp_external_3d
+
+end module MOM_interpolate

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -57,8 +57,8 @@ use user_shelf_init, only : user_ice_shelf_CS
 use MOM_coms, only : reproducing_sum
 use MOM_spatial_means, only : global_area_integral
 use MOM_checksums, only : hchksum, qchksum, chksum, uchksum, vchksum, uvchksum
-use time_interp_external_mod, only : init_external_field, time_interp_external
-use time_interp_external_mod, only : time_interp_external_init
+use MOM_interpolate, only : init_external_field, time_interp_extern, time_interp_external_init
+
 implicit none ; private
 
 #include <MOM_memory.h>
@@ -1084,9 +1084,9 @@ subroutine add_shelf_flux(G, US, CS, sfc_state, fluxes)
         do j=js,je ; do i=is,ie
           last_hmask(i,j) = ISS%hmask(i,j) ; last_area_shelf_h(i,j) = ISS%area_shelf_h(i,j)
         enddo ; enddo
-        call time_interp_external(CS%id_read_mass, Time0, last_mass_shelf)
+        call time_interp_extern(CS%id_read_mass, Time0, last_mass_shelf)
         do j=js,je ; do i=is,ie
-        ! This should only be done if time_interp_external did an update.
+        ! This should only be done if time_interp_extern did an update.
           last_mass_shelf(i,j) = US%kg_m3_to_R*US%m_to_Z * last_mass_shelf(i,j) ! Rescale after time_interp
           last_h_shelf(i,j) = last_mass_shelf(i,j) / CS%density_ice
         enddo ; enddo
@@ -1512,7 +1512,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
     if (CS%rotate_index) then
        allocate(tmp2d(CS%Grid_in%isd:CS%Grid_in%ied,CS%Grid_in%jsd:CS%Grid_in%jed));tmp2d(:,:)=0.0
        call MOM_read_data(TideAmp_file, 'tideamp', tmp2d, CS%Grid_in%domain, timelevel=1, scale=US%m_s_to_L_T)
-       call rotate_array(tmp2d,CS%turns, CS%utide)
+       call rotate_array(tmp2d, CS%turns, CS%utide)
        deallocate(tmp2d)
     else
        call MOM_read_data(TideAmp_file, 'tideamp', CS%utide, CS%Grid%domain, timelevel=1, scale=US%m_s_to_L_T)
@@ -1984,8 +1984,8 @@ subroutine update_shelf_mass(G, US, CS, ISS, Time)
     allocate(tmp2d(is:ie,js:je)) ; tmp2d(:,:) = 0.0
   endif
 
-  call time_interp_external(CS%id_read_mass, Time, tmp2d)
-  call rotate_array(tmp2d,CS%turns, ISS%mass_shelf)
+  call time_interp_extern(CS%id_read_mass, Time, tmp2d)
+  call rotate_array(tmp2d, CS%turns, ISS%mass_shelf)
   deallocate(tmp2d)
 
   ! This should only be done if time_interp_external did an update.

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -3,19 +3,15 @@ module MOM_IS_diag_mediator
 
 ! This file is a part of SIS2. See LICENSE.md for the license.
 
-use MOM_grid, only : ocean_grid_type
-
-use MOM_coms, only : PE_here
+use MOM_coms,          only : PE_here
+use MOM_diag_manager,  only : diag_manager_init, send_data, diag_axis_init, EAST, NORTH
+use MOM_diag_manager,  only : register_diag_field_fms, register_static_field_fms
 use MOM_error_handler, only : MOM_error, FATAL, is_root_pe, assert
-use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
-use MOM_safe_alloc, only : safe_alloc_ptr, safe_alloc_alloc
+use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
+use MOM_grid,          only : ocean_grid_type
+use MOM_safe_alloc,    only : safe_alloc_ptr, safe_alloc_alloc
 use MOM_string_functions, only : lowercase, uppercase, slasher
-use MOM_time_manager, only : time_type
-
-use diag_manager_mod, only : diag_manager_init
-use diag_manager_mod, only : send_data, diag_axis_init,EAST,NORTH
-use diag_manager_mod, only : register_diag_field_fms=>register_diag_field
-use diag_manager_mod, only : register_static_field_fms=>register_static_field
+use MOM_time_manager,  only : time_type
 
 implicit none ; private
 

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -15,15 +15,15 @@ use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,  only : forcing, extractFluxes1d, forcing_SinglePointPrint
 use MOM_grid,          only : ocean_grid_type
+use MOM_interpolate,   only : init_external_field, time_interp_extern
+use MOM_interpolate,   only : time_interp_external_init
 use MOM_io,            only : slasher
 use MOM_opacity,       only : set_opacity, opacity_CS, extract_optics_slice, extract_optics_fields
 use MOM_opacity,       only : optics_type, optics_nbands, absorbRemainingSW, sumSWoverBands
 use MOM_tracer_flow_control, only : get_chl_from_model, tracer_flow_control_CS
 use MOM_unit_scaling,  only : unit_scale_type
-use MOM_variables,     only : thermo_var_ptrs ! , vertvisc_type, accel_diag_ptrs
+use MOM_variables,     only : thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type
-use time_interp_external_mod, only : init_external_field, time_interp_external
-use time_interp_external_mod, only : time_interp_external_init
 
 implicit none ; private
 
@@ -621,7 +621,7 @@ subroutine set_pen_shortwave(optics, fluxes, G, GV, US, CS, opacity_CSp, tracer_
     if (CS%chl_from_file) then
       ! Only the 2-d surface chlorophyll can be read in from a file.  The
       ! same value is assumed for all layers.
-      call time_interp_external(CS%sbc_chl, CS%Time, chl_2d)
+      call time_interp_extern(CS%sbc_chl, CS%Time, chl_2d)
       do j=js,je ; do i=is,ie
         if ((G%mask2dT(i,j) > 0.5) .and. (chl_2d(i,j) < 0.0)) then
           write(mesg,'(" Time_interp negative chl of ",(1pe12.4)," at i,j = ",&


### PR DESCRIPTION
  This PR includes three more steps in restructuring the MOM6 framework code to
accommodate the FMS2 related changes, specifically the creation of the new
MOM_coms_wrapper, MOM_interpolate and  MOM_diag_manager modules.  These changes
include new interfaces that are slightly changed from their predecessors by
adding new optional arguments or changing previously mandatory arguments into
optional arguments.  Code outside of the framework directory is not required to
change but in this PR it is changed to exercise the new variants.  With this PR
the changes to the framework code that would be required to rearrange the files
into different directories to support FMS2 are nearly complete.  All answers and
output files are bitwise identical.

  To complete the separation of the framework files into a MOM-specific
directory and an FMS wrapper directory, the files MOM_array_transform.F90,
MOM_coms_wrapper.F90, MOM_constants.F90, MOM_cpu_clock.F90,
MOM_diag_manager.F90, MOM_domains.F90, MOM_error_handler.F90, MOM_io_wrapper.F90
and MOM_time_manager.F90 would be moved to the new infrastructure directory,
with one routine (MOM_domains_init) removed from MOM_domains.F90.

  The commits in this PR include:

- NOAA-GFDL/MOM6@76b3ccce4 Use only for netcdf in MOM_horizontal_regridding
- NOAA-GFDL/MOM6@e4d984a7a +Created MOM_diag_manager to wrap diag_manager
- NOAA-GFDL/MOM6@9dabf3f52 Merge branch 'dev/gfdl' into revise_framework_more
- NOAA-GFDL/MOM6@76cb4718d Cleaned up MOM_horizontal_regridding
- NOAA-GFDL/MOM6@1417dceb4 +Added MOM_interpolate.F90
- NOAA-GFDL/MOM6@571013dad +Added MOM_coms_wrapper.F90
