### PR TITLE
MOM6: +Document MOM_io routines

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -35,7 +35,7 @@ use MOM_forcing_type, only : copy_back_forcing_fields
 use MOM_forcing_type, only : forcing_diagnostics, mech_forcing_diags
 use MOM_get_input, only : Get_MOM_Input, directories
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : close_file, file_exists, read_data, write_version_number, stdout
+use MOM_io, only : write_version_number, stdout
 use MOM_marine_ice, only : iceberg_forces, iceberg_fluxes, marine_ice_init, marine_ice_CS
 use MOM_restart, only : MOM_restart_CS, save_restart
 use MOM_string_functions, only : uppercase

--- a/config_src/solo_driver/user_surface_forcing.F90
+++ b/config_src/solo_driver/user_surface_forcing.F90
@@ -11,7 +11,6 @@ use MOM_file_parser, only : get_param, param_file_type, log_version
 use MOM_forcing_type, only : forcing, mech_forcing
 use MOM_forcing_type, only : allocate_forcing_type, allocate_mech_forcing
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : file_exists, read_data
 use MOM_time_manager, only : time_type, operator(+), operator(/)
 use MOM_tracer_flow_control, only : call_tracer_set_forcing
 use MOM_tracer_flow_control, only : tracer_flow_control_CS

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -30,7 +30,8 @@ use coord_hycom,  only : init_coord_hycom, hycom_CS, set_hycom_params, build_hyc
 use coord_slight, only : init_coord_slight, slight_CS, set_slight_params, build_slight_column, end_coord_slight
 use coord_adapt,  only : init_coord_adapt, adapt_CS, set_adapt_params, build_adapt_column, end_coord_adapt
 
-use netcdf ! Used by check_grid_def()
+! Direct netcdf calls are used by check_grid_def()
+use netcdf, only : NF90_open, NF90_inq_varid, NF90_get_att, NF90_NOERR, NF90_NOWRITE
 
 implicit none ; private
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -9,13 +9,12 @@ use MOM_coms,                 only : sum_across_PEs, Set_PElist, Get_PElist, PE_
 use MOM_cpu_clock,            only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
 use MOM_diag_mediator,        only : diag_ctrl, time_type
 use MOM_domains,              only : pass_var, pass_vector
-use MOM_domains,              only : To_All, SCALAR_PAIR, CGRID_NE, CORNER
+use MOM_domains,              only : To_All, EAST_FACE, NORTH_FACE, SCALAR_PAIR, CGRID_NE, CORNER
 use MOM_error_handler,        only : MOM_mesg, MOM_error, FATAL, WARNING, NOTE, is_root_pe
 use MOM_file_parser,          only : get_param, log_version, param_file_type, log_param
 use MOM_grid,                 only : ocean_grid_type, hor_index_type
 use MOM_dyn_horgrid,          only : dyn_horgrid_type
-use MOM_io,                   only : EAST_FACE, NORTH_FACE
-use MOM_io,                   only : slasher, read_data, field_size, SINGLE_FILE
+use MOM_io,                   only : slasher, field_size, SINGLE_FILE
 use MOM_io,                   only : vardesc, query_vardesc, var_desc
 use MOM_restart,              only : register_restart_field, register_restart_pair
 use MOM_restart,              only : query_initialized, MOM_restart_CS

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -26,7 +26,10 @@ use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface, thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 
-use netcdf
+use netcdf, only : NF90_create, NF90_def_dim, NF90_def_var, NF90_put_att, NF90_enddef
+use netcdf, only : NF90_put_var, NF90_open, NF90_close, NF90_inquire_variable, NF90_strerror
+use netcdf, only : NF90_inq_varid, NF90_inquire_dimension, NF90_get_var, NF90_get_att
+use netcdf, only : NF90_DOUBLE, NF90_NOERR, NF90_NOWRITE, NF90_GLOBAL, NF90_ENOTATT
 
 implicit none ; private
 
@@ -1351,7 +1354,7 @@ subroutine read_depth_list(G, US, CS, filename)
   character(len=240) :: var_name, var_msg
   real, allocatable :: tmp(:)
   integer :: ncid, status, varid, list_size, k
-  integer :: ndim, len, var_dim_ids(NF90_MAX_VAR_DIMS)
+  integer :: ndim, len, var_dim_ids(8)
   character(len=16) :: depth_file_chksum, depth_grid_chksum
   character(len=16) :: area_file_chksum, area_grid_chksum
   integer :: depth_attr_status, area_attr_status

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -64,8 +64,6 @@ use MOM_debugging,        only : check_column_integrals
 use MOM_diag_manager,     only : diag_axis_init
 use MOM_diag_vkernels,    only : interpolate_column, reintegrate_column
 use MOM_file_parser,      only : get_param, log_param, param_file_type
-use MOM_io,               only : slasher, mom_read_data
-use MOM_io,               only : file_exists, field_size
 use MOM_string_functions, only : lowercase, extractWord
 use MOM_grid,             only : ocean_grid_type
 use MOM_unit_scaling,     only : unit_scale_type

--- a/src/framework/MOM_io_infra.F90
+++ b/src/framework/MOM_io_infra.F90
@@ -5,20 +5,18 @@ module MOM_io_infra
 
 use MOM_domain_infra,     only : MOM_domain_type, AGRID, BGRID_NE, CGRID_NE
 use MOM_domain_infra,     only : get_simple_array_i_ind, get_simple_array_j_ind
-use MOM_domain_infra,     only : domain2d, CENTER, CORNER, NORTH_FACE, EAST_FACE
+use MOM_domain_infra,     only : domain2d, domain1d, CENTER, CORNER, NORTH_FACE, EAST_FACE
 use MOM_error_infra,      only : MOM_error=>MOM_err, NOTE, FATAL, WARNING
 
-use ensemble_manager_mod, only : get_ensemble_id
 use fms_mod,              only : write_version_number, open_namelist_file, check_nml_error
 use fms_io_mod,           only : file_exist, field_exist, field_size, read_data
 use fms_io_mod,           only : fms_io_exit, get_filename_appendix
 use mpp_io_mod,           only : mpp_open, mpp_close, mpp_flush
-use mpp_io_mod,           only : write_metadata=>mpp_write_meta, mpp_write
+use mpp_io_mod,           only : mpp_write_meta, mpp_write
 use mpp_io_mod,           only : mpp_get_atts, mpp_attribute_exist
-use mpp_io_mod,           only : mpp_get_axes, axistype, get_axis_data=>mpp_get_axis_data
+use mpp_io_mod,           only : mpp_get_axes, axistype, mpp_get_axis_data
 use mpp_io_mod,           only : mpp_get_fields, fieldtype
-use mpp_io_mod,           only : mpp_get_info
-use mpp_io_mod,           only : get_file_times=>mpp_get_times
+use mpp_io_mod,           only : mpp_get_info, mpp_get_times
 use mpp_io_mod,           only : mpp_io_init
 ! These are encoding constants.
 use mpp_io_mod,           only : APPEND_FILE=>MPP_APPEND, ASCII_FILE=>MPP_ASCII
@@ -29,16 +27,15 @@ use mpp_io_mod,           only : SINGLE_FILE=>MPP_SINGLE, WRITEONLY_FILE=>MPP_WR
 implicit none ; private
 
 ! These interfaces are actually implemented or have explicit interfaces in this file.
-public :: MOM_read_data, MOM_read_vector, write_field, open_file, close_file, flush_file
-public :: file_exists, field_exists, read_field_chksum
-public :: get_file_info, get_file_fields, get_field_atts, io_infra_init, io_infra_end
-! The following are simple pass throughs of routines from other modules.  They need
-! to have explicit interfaces added to this file.
-public :: fieldtype, axistype, field_size, get_filename_appendix
-public :: get_file_times, read_data, get_axis_data
-public :: write_metadata, write_version_number, get_ensemble_id
-public :: open_namelist_file, check_nml_error
-! These are encoding constants.
+public :: open_file, close_file, flush_file, file_exists, get_filename_suffix
+public :: get_file_info, get_file_fields, get_file_times
+public :: MOM_read_data, MOM_read_vector, write_metadata, write_field
+public :: field_exists, get_field_atts, get_field_size, get_axis_data, read_field_chksum
+public :: io_infra_init, io_infra_end, MOM_namelist_file, check_namelist_error, write_version
+! These types are inherited from underlying infrastructure code, to act as containers for
+! information about fields and axes, respectively, and are opaque to this module.
+public :: fieldtype, axistype
+! These are encoding constant parmeters.
 public :: APPEND_FILE, ASCII_FILE, MULTIPLE, NETCDF_FILE, OVERWRITE_FILE
 public :: READONLY_FILE, SINGLE_FILE, WRITEONLY_FILE
 public :: CENTER, CORNER, NORTH_FACE, EAST_FACE
@@ -53,7 +50,7 @@ end interface
 interface MOM_read_data
   module procedure MOM_read_data_4d
   module procedure MOM_read_data_3d
-  module procedure MOM_read_data_2d
+  module procedure MOM_read_data_2d, MOM_read_data_2d_region
   module procedure MOM_read_data_1d
   module procedure MOM_read_data_0d
 end interface
@@ -72,7 +69,12 @@ end interface write_field
 interface MOM_read_vector
   module procedure MOM_read_vector_3d
   module procedure MOM_read_vector_2d
-end interface
+end interface MOM_read_vector
+
+!> Write metadata about a variable or axis to a file and store it for later reuse
+interface write_metadata
+  module procedure write_metadata_axis, write_metadata_field
+end interface write_metadata
 
 contains
 
@@ -150,6 +152,30 @@ subroutine io_infra_end()
   call fms_io_exit()
 end subroutine io_infra_end
 
+!> Open a single namelist file that is potentially readable by all PEs.
+function MOM_namelist_file(file) result(unit)
+  character(len=*), optional, intent(in) :: file !< The file to open, by default "input.nml".
+  integer                                :: unit !< The opened unit number of the namelist file
+  unit = open_namelist_file(file)
+end function MOM_namelist_file
+
+!> Checks the iostat argument that is returned after reading a namelist variable and writes a
+!! message if there is an error.
+subroutine check_namelist_error(IOstat, nml_name)
+  integer,          intent(in) :: IOstat   !< An I/O status field from a namelist read call
+  character(len=*), intent(in) :: nml_name !< The name of the namelist
+  integer :: ierr
+  ierr = check_nml_error(IOstat, nml_name)
+end subroutine check_namelist_error
+
+!> Write a file version number to the log file or other output file
+subroutine write_version(version, tag, unit)
+  character(len=*),           intent(in) :: version !< A string that contains the routine name and version
+  character(len=*), optional, intent(in) :: tag  !< A tag name to add to the message
+  integer,          optional, intent(in) :: unit !< An alternate unit number for output
+
+  call write_version_number(version, tag, unit)
+end subroutine write_version
 
 !> open_file opens a file for parallel or single-file I/O.
 subroutine open_file(unit, file, action, form, threading, fileset, nohdrs, domain, MOM_domain)
@@ -179,6 +205,14 @@ subroutine open_file(unit, file, action, form, threading, fileset, nohdrs, domai
   endif
 end subroutine open_file
 
+!> Provide a string to append to filenames, to differentiate ensemble members, for example.
+subroutine get_filename_suffix(suffix)
+  character(len=*), intent(out) :: suffix !< A string to append to filenames
+
+  call get_filename_appendix(suffix)
+end subroutine get_filename_suffix
+
+
 !> Get information about the number of dimensions, variables, global attributes and time levels
 !! in the file associated with an open file unit
 subroutine get_file_info(unit, ndim, nvar, natt, ntime)
@@ -199,6 +233,25 @@ subroutine get_file_info(unit, ndim, nvar, natt, ntime)
   if (present(ntime)) ntime = ntimes
 
 end subroutine get_file_info
+
+
+!> Get the times of records from a file
+ !### Modify this to also convert to time_type, using information about the dimensions?
+subroutine get_file_times(unit, time_values, ntime)
+  integer,                         intent(in)    :: unit  !< The I/O unit for the open file
+  real, allocatable, dimension(:), intent(inout) :: time_values !< The real times for the records in file.
+  integer,               optional, intent(out)   :: ntime !< The number of time levels in the file
+
+  integer :: ntimes
+
+  if (allocated(time_values)) deallocate(time_values)
+  call get_file_info(unit, ntime=ntimes)
+  if (present(ntime)) ntime = ntimes
+  if (ntimes > 0) then
+    allocate(time_values(ntimes))
+    call mpp_get_times(unit, time_values)
+  endif
+end subroutine get_file_times
 
 !> Set up the field information (e.g., names and metadata) for all of the variables in a file.  The
 !! argument fields must be allocated with a size that matches the number of variables in a file.
@@ -238,7 +291,30 @@ function field_exists(filename, field_name, domain, no_domain, MOM_domain)
 
 end function field_exists
 
-!> This function uses the fms_io function read_data to read a scalar
+!> Given filename and fieldname, this subroutine returns the size of the field in the file
+subroutine get_field_size(filename, fieldname, sizes, field_found, no_domain)
+  character(len=*),      intent(in)    :: filename  !< The name of the file to read
+  character(len=*),      intent(in)    :: fieldname !< The name of the variable whose sizes are returned
+  integer, dimension(:), intent(inout) :: sizes     !< The sizes of the variable in each dimension
+  logical,     optional, intent(out)   :: field_found !< This indicates whether the field was found in
+                                                    !! the input file.  Without this argument, there
+                                                    !! is a fatal error if the field is not found.
+  logical,     optional, intent(in)    :: no_domain !< If present and true, do not check for file
+                                                    !! names with an appended tile number
+
+  call field_size(filename, fieldname, sizes, field_found=field_found, no_domain=no_domain)
+
+end subroutine get_field_size
+
+!> Extracts and returns the axis data stored in an axistype.
+subroutine get_axis_data( axis, dat )
+  type(axistype),     intent(in)  :: axis !< An axis type
+  real, dimension(:), intent(out) :: dat  !< The data in the axis variable
+
+  call mpp_get_axis_data( axis, dat )
+end subroutine get_axis_data
+
+!> This routine uses the fms_io subroutine read_data to read a scalar
 !! data field named "fieldname" from file "filename".
 subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
@@ -256,7 +332,7 @@ subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale)
 
 end subroutine MOM_read_data_0d
 
-!> This function uses the fms_io function read_data to read a 1-D
+!> This routine uses the fms_io subroutine read_data to read a 1-D
 !! data field named "fieldname" from file "filename".
 subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
@@ -274,7 +350,7 @@ subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale)
 
 end subroutine MOM_read_data_1d
 
-!> This function uses the fms_io function read_data to read a distributed
+!> This routine uses the fms_io subroutine read_data to read a distributed
 !! 2-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
@@ -302,7 +378,42 @@ subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
 
 end subroutine MOM_read_data_2d
 
-!> This function uses the fms_io function read_data to read a distributed
+!> This routine uses the fms_io subroutine read_data to read a region from a distributed or
+!! global 2-D data field named "fieldname" from file "filename".
+subroutine MOM_read_data_2d_region(filename, fieldname, data, start, nread, MOM_domain, &
+                                   no_domain, scale)
+  character(len=*),       intent(in)    :: filename  !< The name of the file to read
+  character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
+  real, dimension(:,:),   intent(inout) :: data      !< The 2-dimensional array into which the data
+                                                     !! should be read
+  integer, dimension(:),  intent(in)    :: start     !< The starting index to read in each of 4
+                                                     !! dimensions.  For this 2-d read, the 3rd
+                                                     !! and 4th values are always 1.
+  integer, dimension(:),  intent(in)    :: nread     !< The number of points to read in each of 4
+                                                     !! dimensions.  For this 2-d read, the 3rd
+                                                     !! and 4th values are always 1.
+  type(MOM_domain_type), &
+                optional, intent(in)    :: MOM_Domain !< The MOM_Domain that describes the decomposition
+  logical,      optional, intent(in)    :: no_domain !< If present and true, this variable does not
+                                                     !! use domain decomposion.
+  real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
+                                                     !! by before it is returned.
+
+  if (present(MOM_Domain)) then
+    call read_data(filename, fieldname, data, start, nread, domain=MOM_Domain%mpp_domain, &
+                   no_domain=no_domain)
+  else
+    call read_data(filename, fieldname, data, start, nread, no_domain=no_domain)
+  endif
+
+  if (present(scale)) then ; if (scale /= 1.0) then
+    ! Dangerously rescale the whole array
+    data(:,:) = scale*data(:,:)
+  endif ; endif
+
+end subroutine MOM_read_data_2d_region
+
+!> This routine uses the fms_io subroutine read_data to read a distributed
 !! 3-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_3d(filename, fieldname, data, MOM_Domain, &
@@ -330,7 +441,7 @@ subroutine MOM_read_data_3d(filename, fieldname, data, MOM_Domain, &
 
 end subroutine MOM_read_data_3d
 
-!> This function uses the fms_io function read_data to read a distributed
+!> This routine uses the fms_io subroutine read_data to read a distributed
 !! 4-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_4d(filename, fieldname, data, MOM_Domain, &
@@ -359,7 +470,7 @@ subroutine MOM_read_data_4d(filename, fieldname, data, MOM_Domain, &
 end subroutine MOM_read_data_4d
 
 
-!> This function uses the fms_io function read_data to read a pair of distributed
+!> This routine uses the fms_io subroutine read_data to read a pair of distributed
 !! 2-D data fields with names given by "[uv]_fieldname" from file "filename".  Valid values for
 !! "stagger" include CGRID_NE, BGRID_NE, and AGRID.
 subroutine MOM_read_vector_2d(filename, u_fieldname, v_fieldname, u_data, v_data, MOM_Domain, &
@@ -403,7 +514,7 @@ subroutine MOM_read_vector_2d(filename, u_fieldname, v_fieldname, u_data, v_data
 
 end subroutine MOM_read_vector_2d
 
-!> This function uses the fms_io function read_data to read a pair of distributed
+!> This routine uses the fms_io subroutine read_data to read a pair of distributed
 !! 3-D data fields with names given by "[uv]_fieldname" from file "filename".  Valid values for
 !! "stagger" include CGRID_NE, BGRID_NE, and AGRID.
 subroutine MOM_read_vector_3d(filename, u_fieldname, v_fieldname, u_data, v_data, MOM_Domain, &
@@ -511,6 +622,7 @@ subroutine write_field_0d(io_unit, field_md, field, tstamp)
   call mpp_write(io_unit, field_md, field, tstamp=tstamp)
 end subroutine write_field_0d
 
+!> Write the data for an axis
 subroutine MOM_write_axis(io_unit, axis)
   integer,        intent(in)  :: io_unit    !< File I/O unit handle
   type(axistype), intent(in)  :: axis       !< An axis type variable with information to write
@@ -518,5 +630,55 @@ subroutine MOM_write_axis(io_unit, axis)
   call mpp_write(io_unit, axis)
 
 end subroutine MOM_write_axis
+
+!> Store information about an axis in a previously defined axistype and write this
+!! information to the file indicated by unit.
+subroutine write_metadata_axis( unit, axis, name, units, longname, cartesian, sense, domain, data, calendar)
+  integer,                    intent(in)    :: unit  !< The I/O unit for the file to write to
+  type(axistype),             intent(inout) :: axis  !< The axistype where this information is stored.
+  character(len=*),           intent(in)    :: name  !< The name in the file of this axis
+  character(len=*),           intent(in)    :: units !< The units of this axis
+  character(len=*),           intent(in)    :: longname !< The long description of this axis
+  character(len=*), optional, intent(in)    :: cartesian !< A variable indicating which direction
+                                                     !! this axis corresponds with. Valid values
+                                                     !! include 'X', 'Y', 'Z', 'T', and 'N' for none.
+  integer,          optional, intent(in)    :: sense !< This is 1 for axes whose values increase upward, or
+                                                     !! -1 if they increase downward.
+  type(domain1D),   optional, intent(in)    :: domain !< The domain decomposion for this axis
+  real, dimension(:), optional, intent(in)  :: data   !< The coordinate values of the points on this axis
+  character(len=*), optional, intent(in)    :: calendar !< The name of the calendar used with a time axis
+
+  call mpp_write_meta(unit, axis, name, units, longname, cartesian=cartesian, sense=sense, &
+                      domain=domain, data=data, calendar=calendar)
+end subroutine write_metadata_axis
+
+!> Store information about an output variable in a previously defined fieldtype and write this
+!! information to the file indicated by unit.
+subroutine write_metadata_field(unit, field, axes, name, units, longname, &
+                                min, max, fill, scale, add, pack, standard_name, checksum)
+  integer,                    intent(in)    :: unit  !< The I/O unit for the file to write to
+  type(fieldtype),            intent(inout) :: field !< The fieldtype where this information is stored
+  type(axistype), dimension(:), intent(in)  :: axes  !< Handles for the axis used for this variable
+  character(len=*),           intent(in)    :: name  !< The name in the file of this variable
+  character(len=*),           intent(in)    :: units !< The units of this variable
+  character(len=*),           intent(in)    :: longname !< The long description of this variable
+  real,             optional, intent(in)    :: min   !< The minimum valid value for this variable
+  real,             optional, intent(in)    :: max   !< The maximum valid value for this variable
+  real,             optional, intent(in)    :: fill  !< Missing data fill value
+  real,             optional, intent(in)    :: scale !< An multiplicative factor by which to scale
+                                                     !! the variable before output
+  real,             optional, intent(in)    :: add   !< An offset to add to the variable before output
+  integer,          optional, intent(in)    :: pack  !< A precision reduction factor with which the
+                                                     !! variable.  The default, 1, has no reduction,
+                                                     !! but 2 is not uncommon.
+  character(len=*), optional, intent(in)    :: standard_name !< The standard (e.g., CMOR) name for this variable
+  integer(kind=8), dimension(:), &
+                    optional, intent(in)    :: checksum !< Checksum values that can be used to verify reads.
+
+
+  call mpp_write_meta( unit, field, axes, name, units, longname, &
+         min=min, max=max, fill=fill, scale=scale, add=add, pack=pack, standard_name=standard_name, checksum=checksum)
+
+end subroutine write_metadata_field
 
 end module MOM_io_infra

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1084,7 +1084,7 @@ subroutine restore_state(filename, directory, day, G, CS)
   integer :: i, n, m, missing_fields
   integer :: isL, ieL, jsL, jeL, is0, js0
   integer :: sizes(7)
-  integer :: ndim, nvar, natt, ntime, pos
+  integer :: nvar, ntime, pos
 
   integer :: unit(CS%max_fields) ! The I/O units of all open files.
   character(len=200) :: unit_path(CS%max_fields) ! The file names.
@@ -1119,11 +1119,9 @@ subroutine restore_state(filename, directory, day, G, CS)
 
 ! Get the time from the first file in the list that has one.
   do n=1,num_file
-    call get_file_info(unit(n), ndim, nvar, natt, ntime)
+    call get_file_times(unit(n), time_vals, ntime)
     if (ntime < 1) cycle
 
-    allocate(time_vals(ntime))
-    call get_file_times(unit(n), time_vals)
     t1 = time_vals(1)
     deallocate(time_vals)
 
@@ -1138,11 +1136,9 @@ subroutine restore_state(filename, directory, day, G, CS)
 ! if they differ from the first time.
   if (is_root_pe()) then
     do m = n+1,num_file
-      call get_file_info(unit(n), ndim, nvar, natt, ntime)
+      call get_file_times(unit(n), time_vals, ntime)
       if (ntime < 1) cycle
 
-      allocate(time_vals(ntime))
-      call get_file_times(unit(n), time_vals)
       t2 = time_vals(1)
       deallocate(time_vals)
 
@@ -1157,7 +1153,7 @@ subroutine restore_state(filename, directory, day, G, CS)
 
 ! Read each variable from the first file in which it is found.
   do n=1,num_file
-    call get_file_info(unit(n), ndim, nvar, natt, ntime)
+    call get_file_info(unit(n), nvar=nvar)
 
     allocate(fields(nvar))
     call get_file_fields(unit(n), fields(1:nvar))
@@ -1216,8 +1212,9 @@ subroutine restore_state(filename, directory, day, G, CS)
               call MOM_read_data(unit_path(n), varname, CS%var_ptr2d(m)%p, &
                                  G%Domain, timelevel=1, position=pos)
             else ! This array is not domain-decomposed.  This variant may be under-tested.
-              call read_data(unit_path(n), varname, CS%var_ptr2d(m)%p, &
-                             no_domain=.true., timelevel=1)
+              call MOM_error(FATAL, &
+                        "MOM_restart does not support 2-d arrays without domain decomposition.")
+              ! call read_data(unit_path(n), varname, CS%var_ptr2d(m)%p,no_domain=.true., timelevel=1)
             endif
             if (is_there_a_checksum) checksum_data = chksum(CS%var_ptr2d(m)%p(isL:ieL,jsL:jeL))
           elseif (associated(CS%var_ptr3d(m)%p)) then  ! Read a 3d array.
@@ -1225,8 +1222,9 @@ subroutine restore_state(filename, directory, day, G, CS)
               call MOM_read_data(unit_path(n), varname, CS%var_ptr3d(m)%p, &
                                  G%Domain, timelevel=1, position=pos)
             else ! This array is not domain-decomposed.  This variant may be under-tested.
-              call read_data(unit_path(n), varname, CS%var_ptr3d(m)%p, &
-                             no_domain=.true., timelevel=1)
+              call MOM_error(FATAL, &
+                        "MOM_restart does not support 3-d arrays without domain decomposition.")
+              ! call read_data(unit_path(n), varname, CS%var_ptr3d(m)%p, no_domain=.true., timelevel=1)
             endif
             if (is_there_a_checksum) checksum_data = chksum(CS%var_ptr3d(m)%p(isL:ieL,jsL:jeL,:))
           elseif (associated(CS%var_ptr4d(m)%p)) then  ! Read a 4d array.
@@ -1234,8 +1232,9 @@ subroutine restore_state(filename, directory, day, G, CS)
               call MOM_read_data(unit_path(n), varname, CS%var_ptr4d(m)%p, &
                                  G%Domain, timelevel=1, position=pos)
             else ! This array is not domain-decomposed.  This variant may be under-tested.
-              call read_data(unit_path(n), varname, CS%var_ptr4d(m)%p, &
-                             no_domain=.true., timelevel=1)
+              call MOM_error(FATAL, &
+                        "MOM_restart does not support 4-d arrays without domain decomposition.")
+              ! call read_data(unit_path(n), varname, CS%var_ptr4d(m)%p, no_domain=.true., timelevel=1)
             endif
             if (is_there_a_checksum) checksum_data = chksum(CS%var_ptr4d(m)%p(isL:ieL,jsL:jeL,:,:))
           else

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -17,8 +17,6 @@ use MOM_verticalGrid,     only : verticalGrid_type, setVerticalGridAxes
 use user_initialization,  only : user_set_coord
 use BFB_initialization,   only : BFB_set_coord
 
-use netcdf
-
 implicit none ; private
 
 public MOM_initialize_coord

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -17,7 +17,6 @@ use MOM_open_boundary, only : ocean_OBC_type
 use MOM_open_boundary, only : open_boundary_config, open_boundary_query
 use MOM_open_boundary, only : open_boundary_impose_normal_slope
 use MOM_open_boundary, only : open_boundary_impose_land_mask
-! use MOM_shared_initialization, only : MOM_shared_init_init
 use MOM_shared_initialization, only : MOM_initialize_rotation, MOM_calculate_grad_Coriolis
 use MOM_shared_initialization, only : initialize_topography_from_file, apply_topography_edits_from_file
 use MOM_shared_initialization, only : initialize_topography_named, limit_topography, diagnoseMaximumDepth
@@ -41,8 +40,6 @@ use dumbbell_initialization, only : dumbbell_initialize_topography
 use shelfwave_initialization, only : shelfwave_initialize_topography
 use Phillips_initialization, only : Phillips_initialize_topography
 use dense_water_initialization, only : dense_water_initialize_topography
-
-use netcdf
 
 implicit none ; private
 

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -12,7 +12,7 @@ use MOM_dyn_horgrid,   only : dyn_horgrid_type, set_derived_dyn_horgrid
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
-use MOM_io,            only : MOM_read_data, read_data, slasher, file_exists, stdout
+use MOM_io,            only : MOM_read_data, slasher, file_exists, stdout
 use MOM_io,            only : CORNER, NORTH_FACE, EAST_FACE
 use MOM_unit_scaling,  only : unit_scale_type
 
@@ -333,7 +333,7 @@ subroutine set_grid_metrics_from_mosaic(G, param_file, US)
   start(2) = 2 ; nread(1) = ni+1 ; nread(2) = 2
   allocate( tmpGlbl(ni+1,2) )
   if (is_root_PE()) &
-    call read_data(filename, "x", tmpGlbl, start, nread, no_domain=.TRUE.)
+    call MOM_read_data(filename, "x", tmpGlbl, start, nread, no_domain=.TRUE.)
   call broadcast(tmpGlbl, 2*(ni+1), root_PE())
 
   ! I don't know why the second axis is 1 or 2 here. -RWH
@@ -351,7 +351,7 @@ subroutine set_grid_metrics_from_mosaic(G, param_file, US)
   start(:) = 1 ; nread(:) = 1
   start(1) = int(ni/4)+1 ; nread(2) = nj+1
   if (is_root_PE()) &
-    call read_data(filename, "y", tmpGlbl, start, nread, no_domain=.TRUE.)
+    call MOM_read_data(filename, "y", tmpGlbl, start, nread, no_domain=.TRUE.)
   call broadcast(tmpGlbl, nj+1, root_PE())
 
   do j=G%jsg,G%jeg

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -17,7 +17,8 @@ use MOM_io, only : slasher, vardesc, MOM_write_field, var_desc
 use MOM_string_functions, only : uppercase
 use MOM_unit_scaling, only : unit_scale_type
 
-use netcdf
+use netcdf, only : NF90_open, NF90_inq_varid, NF90_get_var, NF90_close
+use netcdf, only : NF90_inq_dimid, NF90_inquire_dimension, NF90_NOWRITE, NF90_NOERR
 
 implicit none ; private
 
@@ -189,7 +190,7 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
   type(param_file_type),            intent(in)    :: param_file !< Parameter file structure
   type(unit_scale_type),  optional, intent(in)    :: US !< A dimensional unit scaling type
 
-  ! Local variables
+  ! Local variablesNF
   real :: m_to_Z  ! A dimensional rescaling factor.
   character(len=200) :: topo_edits_file, inputdir ! Strings for file/path
   character(len=40)  :: mdl = "apply_topography_edits_from_file" ! This subroutine's name.

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -190,7 +190,7 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
   type(param_file_type),            intent(in)    :: param_file !< Parameter file structure
   type(unit_scale_type),  optional, intent(in)    :: US !< A dimensional unit scaling type
 
-  ! Local variablesNF
+  ! Local variables
   real :: m_to_Z  ! A dimensional rescaling factor.
   character(len=200) :: topo_edits_file, inputdir ! Strings for file/path
   character(len=40)  :: mdl = "apply_topography_edits_from_file" ! This subroutine's name.

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -11,7 +11,9 @@ use MOM_EOS, only : EOS_type, calculate_density, calculate_density_derivs, EOS_d
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_verticalGrid, only : verticalGrid_type
 
-use netcdf
+use netcdf, only : NF90_open, NF90_inq_varid, NF90_inquire_variable, NF90_get_var
+use netcdf, only : NF90_get_att, NF90_inquire_dimension, NF90_close, NF90_strerror
+use netcdf, only : NF90_NOWRITE, NF90_NOERR
 
 implicit none ; private
 
@@ -402,7 +404,7 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
   character(len=120) :: dim_name, edge_name, tr_msg, dim_msg
   logical :: monotonic
   integer :: ncid, status, intid, tr_id, layid, k
-  integer :: nz_edge, ndim, tr_dim_ids(NF90_MAX_VAR_DIMS)
+  integer :: nz_edge, ndim, tr_dim_ids(8)
 
   mdl = "MOM_tracer_Z_init read_Z_edges: "
   tr_msg = trim(tr_name)//" in "//trim(filename)

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -18,6 +18,9 @@ use MOM_variables,     only : thermo_var_ptrs, surface
 use MOM_verticalgrid,  only : verticalGrid_type
 use data_override_mod, only : data_override_init, data_override
 
+use netcdf, only : NF90_open, NF90_inq_varid, NF90_inquire_variable, NF90_get_var
+use netcdf, only : NF90_inquire_dimension, NF90_close, NF90_NOWRITE, NF90_NOERR
+
 implicit none ; private
 
 #include <MOM_memory.h>
@@ -773,12 +776,12 @@ end subroutine Update_Stokes_Drift
 !> A subroutine to fill the Stokes drift from a NetCDF file
 !! using the data_override procedures.
 subroutine Surface_Bands_by_data_override(day_center, G, GV, US, CS)
-  use NETCDF
   type(time_type),          intent(in) :: day_center !< Center of timestep
   type(wave_parameters_CS), pointer    :: CS         !< Wave structure
   type(ocean_grid_type), intent(inout) :: G          !< Grid structure
   type(verticalGrid_type),  intent(in) :: GV         !< Vertical grid structure
   type(unit_scale_type),    intent(in) :: US         !< A dimensional unit scaling type
+
   ! Local variables
   real    :: temp_x(SZI_(G),SZJ_(G)) ! Pseudo-zonal Stokes drift of band at h-points [m s-1]
   real    :: temp_y(SZI_(G),SZJ_(G)) ! Psuedo-meridional Stokes drift of band at h-points [m s-1]
@@ -894,6 +897,10 @@ subroutine Surface_Bands_by_data_override(day_center, G, GV, US, CS)
         CS%WaveNum_Cen(b) = (2.*PI*CS%Freq_Cen(b)*US%T_to_s)**2 / (US%L_to_Z**2*GV%g_Earth)
       enddo
     endif
+
+    rcode_wn = NF90_close(ncid)
+    if (rcode_wn /= 0) call MOM_error(WARNING, &
+            "Error closing file "//trim(SurfBandFileName)//" in MOM_wave_interface.")
 
   endif
 


### PR DESCRIPTION
  This PR includes a commits that completes the documentation of the interfaces
for all routines that are accessed via MOM_io.F90 and MOM_io_infra.F90.  There
are some localized changes to I/O interfaces to better fit with their use in
MOM6.  All answers and output files are bitwise identical.  The commits in this
PR include:

- NOAA-GFDL/MOM6@9d9a74d10 +Document all MOM_io interfaces
- NOAA-GFDL/MOM6@ca25594d3 Removed unused module use statements for I/O
