### PR TITLE
Add sphinx bibtex extension configuration parameter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,6 +140,7 @@ extensions = [
         'sphinxcontrib.autodoc_doxygen',
         'sphinxfortran.fortran_domain',
 ]
+bibtex_bibfiles = ['ocean.bib', 'references.bib', 'zotero.bib']
 
 autosummary_generate = ['api/modules.rst', 'api/pages.rst']
 doxygen_xml = 'xml'


### PR DESCRIPTION
Adds `bibtex_bibfiles` to conf.py to properly configure the updated sphixcontrib-bibtex extension being used by read the docs.

Closes #1302 