### PR TITLE
+Partial consolidation of netcdf calls in MOM_io

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -193,7 +193,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
   character(len=40)  :: coord_units, param_name, coord_res_param ! Temporary strings
   character(len=200) :: inputdir, fileName
   character(len=320) :: message ! Temporary strings
-  character(len=12) :: expected_units ! Temporary strings
+  character(len=12) :: expected_units, alt_units ! Temporary strings
   logical :: tmpLogical, fix_haloclines, set_max, do_sum, main_parameters
   logical :: coord_is_state_dependent, ierr
   logical :: default_2018_answers, remap_answers_2018
@@ -360,16 +360,16 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
    !if (.not. field_exists(fileName,trim(varName))) call MOM_error(FATAL,trim(mdl)//", initialize_regridding: "// &
    !             "Specified field not found: Looking for '"//trim(varName)//"' ("//trim(string)//")")
     if (CS%regridding_scheme == REGRIDDING_SIGMA) then
-      expected_units = 'nondim'
+      expected_units = 'nondim' ; alt_units = expected_units
     elseif (CS%regridding_scheme == REGRIDDING_RHO) then
-      expected_units = 'kg m-3'
+      expected_units = 'kg m-3' ; alt_units = expected_units
     else
-      expected_units = 'meters'
+      expected_units = 'meters' ; alt_units = 'm'
     endif
     if (index(trim(varName),'interfaces=')==1) then
       varName=trim(varName(12:))
-      call verify_variable_units(filename, varName, expected_units, message, ierr)
-      if (ierr) call MOM_error(FATAL,trim(mdl)//", initialize_regridding: "//&
+      call verify_variable_units(filename, varName, expected_units, message, ierr, alt_units)
+      if (ierr) call MOM_error(FATAL, trim(mdl)//", initialize_regridding: "//&
                   "Unsupported format in grid definition '"//trim(filename)//"'. Error message "//trim(message))
       call field_size(trim(fileName), trim(varName), nzf)
       ke = nzf(1)-1

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -14,6 +14,7 @@ use MOM_grid, only : ocean_grid_type
 use MOM_interface_heights, only : find_eta
 use MOM_io, only : create_file, fieldtype, flush_file, open_file, reopen_file, stdout
 use MOM_io, only : file_exists, slasher, vardesc, var_desc, write_field, get_filename_appendix
+use MOM_io, only : field_size, read_variable, read_attribute
 use MOM_io, only : APPEND_FILE, ASCII_FILE, SINGLE_FILE, WRITEONLY_FILE
 use MOM_open_boundary, only : ocean_OBC_type, OBC_segment_type
 use MOM_open_boundary, only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
@@ -26,10 +27,8 @@ use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface, thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
 
-use netcdf, only : NF90_create, NF90_def_dim, NF90_def_var, NF90_put_att, NF90_enddef
-use netcdf, only : NF90_put_var, NF90_open, NF90_close, NF90_inquire_variable, NF90_strerror
-use netcdf, only : NF90_inq_varid, NF90_inquire_dimension, NF90_get_var, NF90_get_att
-use netcdf, only : NF90_DOUBLE, NF90_NOERR, NF90_NOWRITE, NF90_GLOBAL, NF90_ENOTATT
+use netcdf, only : NF90_create, NF90_def_dim, NF90_def_var, NF90_enddef, NF90_put_att, NF90_put_var
+use netcdf, only : NF90_close, NF90_strerror, NF90_DOUBLE, NF90_NOERR, NF90_GLOBAL
 
 implicit none ; private
 
@@ -1269,75 +1268,75 @@ subroutine write_depth_list(G, US, CS, filename, list_size)
 
   status = NF90_CREATE(filename, 0, ncid)
   if (status /= NF90_NOERR) then
-    call MOM_error(WARNING, filename//trim(NF90_STRERROR(status)))
+    call MOM_error(WARNING, trim(filename)//trim(NF90_STRERROR(status)))
     return
   endif
 
   status = NF90_DEF_DIM(ncid, "list", list_size, dimid(1))
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//trim(NF90_STRERROR(status)))
+      trim(filename)//trim(NF90_STRERROR(status)))
 
   status = NF90_DEF_VAR(ncid, "depth", NF90_DOUBLE, dimid, Did)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" depth "//trim(NF90_STRERROR(status)))
+      trim(filename)//" depth "//trim(NF90_STRERROR(status)))
   status = NF90_PUT_ATT(ncid, Did, "long_name", "Sorted depth")
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" depth "//trim(NF90_STRERROR(status)))
+      trim(filename)//" depth "//trim(NF90_STRERROR(status)))
   status = NF90_PUT_ATT(ncid, Did, "units", "m")
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" depth "//trim(NF90_STRERROR(status)))
+      trim(filename)//" depth "//trim(NF90_STRERROR(status)))
 
   status = NF90_DEF_VAR(ncid, "area", NF90_DOUBLE, dimid, Aid)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" area "//trim(NF90_STRERROR(status)))
+      trim(filename)//" area "//trim(NF90_STRERROR(status)))
   status = NF90_PUT_ATT(ncid, Aid, "long_name", "Open area at depth")
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" area "//trim(NF90_STRERROR(status)))
+      trim(filename)//" area "//trim(NF90_STRERROR(status)))
   status = NF90_PUT_ATT(ncid, Aid, "units", "m2")
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" area "//trim(NF90_STRERROR(status)))
+      trim(filename)//" area "//trim(NF90_STRERROR(status)))
 
   status = NF90_DEF_VAR(ncid, "vol_below", NF90_DOUBLE, dimid, Vid)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" vol_below "//trim(NF90_STRERROR(status)))
+      trim(filename)//" vol_below "//trim(NF90_STRERROR(status)))
   status = NF90_PUT_ATT(ncid, Vid, "long_name", "Open volume below depth")
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" vol_below "//trim(NF90_STRERROR(status)))
+      trim(filename)//" vol_below "//trim(NF90_STRERROR(status)))
   status = NF90_PUT_ATT(ncid, Vid, "units", "m3")
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" vol_below "//trim(NF90_STRERROR(status)))
+      trim(filename)//" vol_below "//trim(NF90_STRERROR(status)))
 
   ! Dependency checksums
   status = NF90_PUT_ATT(ncid, NF90_GLOBAL, depth_chksum_attr, depth_chksum)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" "//depth_chksum_attr//" "//trim(NF90_STRERROR(status)))
+      trim(filename)//" "//depth_chksum_attr//" "//trim(NF90_STRERROR(status)))
 
   status = NF90_PUT_ATT(ncid, NF90_GLOBAL, area_chksum_attr, area_chksum)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" "//area_chksum_attr//" "//trim(NF90_STRERROR(status)))
+      trim(filename)//" "//area_chksum_attr//" "//trim(NF90_STRERROR(status)))
 
   status = NF90_ENDDEF(ncid)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//trim(NF90_STRERROR(status)))
+      trim(filename)//trim(NF90_STRERROR(status)))
 
   do k=1,list_size ; tmp(k) = US%Z_to_m*CS%DL(k)%depth ; enddo
   status = NF90_PUT_VAR(ncid, Did, tmp)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" depth "//trim(NF90_STRERROR(status)))
+      trim(filename)//" depth "//trim(NF90_STRERROR(status)))
 
   do k=1,list_size ; tmp(k) = US%L_to_m**2*CS%DL(k)%area ; enddo
   status = NF90_PUT_VAR(ncid, Aid, tmp)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" area "//trim(NF90_STRERROR(status)))
+      trim(filename)//" area "//trim(NF90_STRERROR(status)))
 
   do k=1,list_size ; tmp(k) = US%Z_to_m*US%L_to_m**2*CS%DL(k)%vol_below ; enddo
   status = NF90_PUT_VAR(ncid, Vid, tmp)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//" vol_below "//trim(NF90_STRERROR(status)))
+      trim(filename)//" vol_below "//trim(NF90_STRERROR(status)))
 
   status = NF90_CLOSE(ncid)
   if (status /= NF90_NOERR) call MOM_error(WARNING, &
-      filename//trim(NF90_STRERROR(status)))
+      trim(filename)//trim(NF90_STRERROR(status)))
 
 end subroutine write_depth_list
 
@@ -1350,30 +1349,18 @@ subroutine read_depth_list(G, US, CS, filename)
                                            !! previous call to MOM_sum_output_init.
   character(len=*),      intent(in) :: filename !< The path to the depth list file to read.
   ! Local variables
-  character(len=32) :: mdl
-  character(len=240) :: var_name, var_msg
+  character(len=240) :: var_msg
   real, allocatable :: tmp(:)
-  integer :: ncid, status, varid, list_size, k
-  integer :: ndim, len, var_dim_ids(8)
+  integer :: ncid, list_size, k, ndim, sizes(4)
   character(len=16) :: depth_file_chksum, depth_grid_chksum
   character(len=16) :: area_file_chksum, area_grid_chksum
-  integer :: depth_attr_status, area_attr_status
+  logical :: depth_att_found, area_att_found
 
-  mdl = "MOM_sum_output read_depth_list:"
+  ! Check bathymetric consistency between this configuration and the depth list file.
+  call read_attribute(filename, depth_chksum_attr, depth_file_chksum, found=depth_att_found)
+  call read_attribute(filename, area_chksum_attr, area_file_chksum, found=area_att_found)
 
-  status = NF90_OPEN(filename, NF90_NOWRITE, ncid)
-  if (status /= NF90_NOERR) then
-    call MOM_error(FATAL,mdl//" Difficulties opening "//trim(filename)// &
-        " - "//trim(NF90_STRERROR(status)))
-  endif
-
-  ! Check bathymetric consistency
-  depth_attr_status = NF90_GET_ATT(ncid, NF90_GLOBAL, depth_chksum_attr, &
-                                   depth_file_chksum)
-  area_attr_status = NF90_GET_ATT(ncid, NF90_GLOBAL, area_chksum_attr, &
-                                  area_file_chksum)
-
-  if (any([depth_attr_status, area_attr_status] == NF90_ENOTATT)) then
+  if ((.not.depth_att_found) .or. (.not.area_att_found)) then
     var_msg = trim(CS%depth_list_file) // " checksums are missing;"
     if (CS%require_depth_list_chksum) then
       call MOM_error(FATAL, trim(var_msg) // " aborting.")
@@ -1387,25 +1374,9 @@ subroutine read_depth_list(G, US, CS, filename)
         trim(var_msg) // " some diagnostics may not be reproducible.")
     endif
   else
-    ! Validate netCDF call
-    if (depth_attr_status /= NF90_NOERR) then
-      var_msg = mdl // "Failed to read " // trim(filename) // ":" &
-                // depth_chksum_attr
-      call MOM_error(FATAL, &
-        trim(var_msg) // " - " // NF90_STRERROR(depth_attr_status))
-    endif
-
-    if (area_attr_status /= NF90_NOERR) then
-      var_msg = mdl // "Failed to read " // trim(filename) // ":" &
-                // area_chksum_attr
-      call MOM_error(FATAL, &
-        trim(var_msg) // " - " // NF90_STRERROR(area_attr_status))
-    endif
-
     call get_depth_list_checksums(G, depth_grid_chksum, area_grid_chksum)
 
-    if (depth_grid_chksum /= depth_file_chksum &
-            .or. area_grid_chksum /= area_file_chksum) then
+    if ((depth_grid_chksum /= depth_file_chksum) .or. (area_grid_chksum /= area_file_chksum)) then
       var_msg = trim(CS%depth_list_file) // " checksums do not match;"
       if (CS%require_depth_list_chksum) then
         call MOM_error(FATAL, trim(var_msg) // " aborting.")
@@ -1415,74 +1386,29 @@ subroutine read_depth_list(G, US, CS, filename)
         call write_depth_list(G, US, CS, CS%depth_list_file, CS%list_size+1)
         return
       else
-        call MOM_error(WARNING, &
-          trim(var_msg) // " some diagnostics may not be reproducible.")
+        call MOM_error(WARNING, trim(var_msg) // " some diagnostics may not be reproducible.")
       endif
     endif
   endif
 
-  var_name = "depth"
-  var_msg = trim(var_name)//" in "//trim(filename)//" - "
-  status = NF90_INQ_VARID(ncid, var_name, varid)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
-        " Difficulties finding variable "//trim(var_msg)//&
-        trim(NF90_STRERROR(status)))
-
-  status = NF90_INQUIRE_VARIABLE(ncid, varid, ndims=ndim, dimids=var_dim_ids)
-  if (status /= NF90_NOERR) then
-    call MOM_ERROR(FATAL,mdl//" cannot inquire about "//trim(var_msg)//&
-        trim(NF90_STRERROR(status)))
-  elseif (ndim > 1) then
-    call MOM_ERROR(FATAL,mdl//" "//trim(var_msg)//&
-         " has too many or too few dimensions.")
-  endif
-
   ! Get the length of the list.
-  status = NF90_INQUIRE_DIMENSION(ncid, var_dim_ids(1), len=list_size)
-  if (status /= NF90_NOERR) call MOM_ERROR(FATAL,mdl// &
-        " cannot inquire about dimension(1) of "//trim(var_msg)//&
-        trim(NF90_STRERROR(status)))
+  call field_size(filename, "depth", sizes, ndims=ndim)
+  if (ndim /= 1) call MOM_ERROR(FATAL, "MOM_sum_output read_depth_list: depth in "//&
+                                trim(filename)//" has too many or too few dimensions.")
+  list_size = sizes(1)
 
   CS%list_size = list_size-1
   allocate(CS%DL(list_size))
   allocate(tmp(list_size))
 
-  status = NF90_GET_VAR(ncid, varid, tmp)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
-        " Difficulties reading variable "//trim(var_msg)//&
-        trim(NF90_STRERROR(status)))
-
+  call read_variable(filename, "depth", tmp)
   do k=1,list_size ; CS%DL(k)%depth = US%m_to_Z*tmp(k) ; enddo
 
-  var_name = "area"
-  var_msg = trim(var_name)//" in "//trim(filename)//" - "
-  status = NF90_INQ_VARID(ncid, var_name, varid)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
-        " Difficulties finding variable "//trim(var_msg)//&
-        trim(NF90_STRERROR(status)))
-  status = NF90_GET_VAR(ncid, varid, tmp)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
-        " Difficulties reading variable "//trim(var_msg)//&
-        trim(NF90_STRERROR(status)))
-
+  call read_variable(filename, "area", tmp)
   do k=1,list_size ; CS%DL(k)%area = US%m_to_L**2*tmp(k) ; enddo
 
-  var_name = "vol_below"
-  var_msg = trim(var_name)//" in "//trim(filename)
-  status = NF90_INQ_VARID(ncid, var_name, varid)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
-        " Difficulties finding variable "//trim(var_msg)//&
-        trim(NF90_STRERROR(status)))
-  status = NF90_GET_VAR(ncid, varid, tmp)
-  if (status /= NF90_NOERR) call MOM_error(FATAL,mdl// &
-        " Difficulties reading variable "//trim(var_msg)//&
-        trim(NF90_STRERROR(status)))
-
+  call read_variable(filename, "vol_below", tmp)
   do k=1,list_size ; CS%DL(k)%vol_below = US%m_to_Z*US%m_to_L**2*tmp(k) ; enddo
-
-  status = NF90_CLOSE(ncid)
-  if (status /= NF90_NOERR) call MOM_error(WARNING, mdl// &
-    " Difficulties closing "//trim(filename)//" - "//trim(NF90_STRERROR(status)))
 
   deallocate(tmp)
 

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -1352,8 +1352,8 @@ subroutine read_depth_list(G, US, CS, filename)
   character(len=240) :: var_msg
   real, allocatable :: tmp(:)
   integer :: ncid, list_size, k, ndim, sizes(4)
-  character(len=16) :: depth_file_chksum, depth_grid_chksum
-  character(len=16) :: area_file_chksum, area_grid_chksum
+  character(len=:), allocatable :: depth_file_chksum, area_file_chksum
+  character(len=16) :: depth_grid_chksum, area_grid_chksum
   logical :: depth_att_found, area_att_found
 
   ! Check bathymetric consistency between this configuration and the depth list file.
@@ -1376,7 +1376,8 @@ subroutine read_depth_list(G, US, CS, filename)
   else
     call get_depth_list_checksums(G, depth_grid_chksum, area_grid_chksum)
 
-    if ((depth_grid_chksum /= depth_file_chksum) .or. (area_grid_chksum /= area_file_chksum)) then
+    if ((trim(depth_grid_chksum) /= trim(depth_file_chksum)) .or. &
+        (trim(area_grid_chksum) /= trim(area_file_chksum)) ) then
       var_msg = trim(CS%depth_list_file) // " checksums do not match;"
       if (CS%require_depth_list_chksum) then
         call MOM_error(FATAL, trim(var_msg) // " aborting.")
@@ -1390,6 +1391,8 @@ subroutine read_depth_list(G, US, CS, filename)
       endif
     endif
   endif
+  if (allocated(area_file_chksum)) deallocate(area_file_chksum)
+  if (allocated(depth_file_chksum)) deallocate(depth_file_chksum)
 
   ! Get the length of the list.
   call field_size(filename, "depth", sizes, ndims=ndim)

--- a/src/framework/MOM_coms_infra.F90
+++ b/src/framework/MOM_coms_infra.F90
@@ -236,10 +236,10 @@ end subroutine broadcast_real2D
 !> Compute a checksum for a field distributed over a PE list.  If no PE list is
 !! provided, then the current active PE list is used.
 function field_chksum_real_0d(field, pelist, mask_val) result(chksum)
-  real, intent(in) :: field                   !< Input scalar
+  real,              intent(in) :: field      !< Input scalar
   integer, optional, intent(in) :: pelist(:)  !< PE list of ranks to checksum
-  real, optional, intent(in) :: mask_val      !< FMS mask value
-  integer :: chksum                           !< checksum of array
+  real,    optional, intent(in) :: mask_val   !< FMS mask value
+  integer(kind=int64) :: chksum               !< checksum of array
 
   chksum = mpp_chksum(field, pelist, mask_val)
 end function field_chksum_real_0d
@@ -248,9 +248,9 @@ end function field_chksum_real_0d
 !! provided, then the current active PE list is used.
 function field_chksum_real_1d(field, pelist, mask_val) result(chksum)
   real, dimension(:), intent(in) :: field     !< Input array
-  integer, optional, intent(in) :: pelist(:)  !< PE list of ranks to checksum
-  real, optional, intent(in) :: mask_val      !< FMS mask value
-  integer :: chksum                           !< checksum of array
+  integer,  optional, intent(in) :: pelist(:) !< PE list of ranks to checksum
+  real,     optional, intent(in) :: mask_val  !< FMS mask value
+  integer(kind=int64) :: chksum               !< checksum of array
 
   chksum = mpp_chksum(field, pelist, mask_val)
 end function field_chksum_real_1d
@@ -258,10 +258,10 @@ end function field_chksum_real_1d
 !> Compute a checksum for a field distributed over a PE list.  If no PE list is
 !! provided, then the current active PE list is used.
 function field_chksum_real_2d(field, pelist, mask_val) result(chksum)
-  real, dimension(:,:), intent(in) :: field   !< Unrotated input field
-  integer, optional, intent(in) :: pelist(:)  !< PE list of ranks to checksum
-  real, optional, intent(in) :: mask_val      !< FMS mask value
-  integer :: chksum                           !< checksum of array
+  real, dimension(:,:), intent(in) :: field     !< Unrotated input field
+  integer,    optional, intent(in) :: pelist(:) !< PE list of ranks to checksum
+  real,       optional, intent(in) :: mask_val  !< FMS mask value
+  integer(kind=int64) :: chksum                 !< checksum of array
 
   chksum = mpp_chksum(field, pelist, mask_val)
 end function field_chksum_real_2d
@@ -269,10 +269,10 @@ end function field_chksum_real_2d
 !> Compute a checksum for a field distributed over a PE list.  If no PE list is
 !! provided, then the current active PE list is used.
 function field_chksum_real_3d(field, pelist, mask_val) result(chksum)
-  real, dimension(:,:,:), intent(in) :: field !< Unrotated input field
-  integer, optional, intent(in) :: pelist(:)  !< PE list of ranks to checksum
-  real, optional, intent(in) :: mask_val      !< FMS mask value
-  integer :: chksum                           !< checksum of array
+  real, dimension(:,:,:), intent(in) :: field     !< Unrotated input field
+  integer,      optional, intent(in) :: pelist(:) !< PE list of ranks to checksum
+  real,         optional, intent(in) :: mask_val  !< FMS mask value
+  integer(kind=int64) :: chksum               !< checksum of array
 
   chksum = mpp_chksum(field, pelist, mask_val)
 end function field_chksum_real_3d
@@ -280,10 +280,10 @@ end function field_chksum_real_3d
 !> Compute a checksum for a field distributed over a PE list.  If no PE list is
 !! provided, then the current active PE list is used.
 function field_chksum_real_4d(field, pelist, mask_val) result(chksum)
-  real, dimension(:,:,:,:), intent(in) :: field !< Unrotated input field
-  integer, optional, intent(in) :: pelist(:)    !< PE list of ranks to checksum
-  real, optional, intent(in) :: mask_val        !< FMS mask value
-  integer :: chksum                             !< checksum of array
+  real, dimension(:,:,:,:), intent(in) :: field     !< Unrotated input field
+  integer,        optional, intent(in) :: pelist(:) !< PE list of ranks to checksum
+  real,           optional, intent(in) :: mask_val  !< FMS mask value
+  integer(kind=int64) :: chksum               !< checksum of array
 
   chksum = mpp_chksum(field, pelist, mask_val)
 end function field_chksum_real_4d

--- a/src/framework/MOM_coms_infra.F90
+++ b/src/framework/MOM_coms_infra.F90
@@ -23,7 +23,7 @@ public :: field_chksum, MOM_infra_init, MOM_infra_end
 
 !> Communicate an array, string or scalar from one PE to others
 interface broadcast
-  module procedure broadcast_char, broadcast_int0D, broadcast_int1D
+  module procedure broadcast_char, broadcast_int32_0D, broadcast_int64_0D, broadcast_int1D
   module procedure broadcast_real0D, broadcast_real1D, broadcast_real2D
 end interface broadcast
 
@@ -129,8 +129,8 @@ subroutine broadcast_char(dat, length, from_PE, PElist, blocking)
 end subroutine broadcast_char
 
 !> Communicate an integer from one PE to others
-subroutine broadcast_int0D(dat, from_PE, PElist, blocking)
-  integer,               intent(inout) :: dat       !< The data to communicate and destination
+subroutine broadcast_int64_0D(dat, from_PE, PElist, blocking)
+  integer(kind=int64),   intent(inout) :: dat       !< The data to communicate and destination
   integer,     optional, intent(in)    :: from_PE   !< The source PE, by default the root PE
   integer,     optional, intent(in)    :: PElist(:) !< The list of participating PEs, by default the
                                                     !! active PE set as previously set via Set_PElist.
@@ -146,7 +146,28 @@ subroutine broadcast_int0D(dat, from_PE, PElist, blocking)
   call mpp_broadcast(dat, src_PE, PElist)
   if (do_block) call mpp_sync_self(PElist)
 
-end subroutine broadcast_int0D
+end subroutine broadcast_int64_0D
+
+
+!> Communicate an integer from one PE to others
+subroutine broadcast_int32_0D(dat, from_PE, PElist, blocking)
+  integer(kind=int32),   intent(inout) :: dat       !< The data to communicate and destination
+  integer,     optional, intent(in)    :: from_PE   !< The source PE, by default the root PE
+  integer,     optional, intent(in)    :: PElist(:) !< The list of participating PEs, by default the
+                                                    !! active PE set as previously set via Set_PElist.
+  logical,     optional, intent(in)    :: blocking  !< If true, barriers are added around the call
+
+  integer :: src_PE   ! The processor that is sending the data
+  logical :: do_block ! If true add synchronizing barriers
+
+  do_block = .false. ; if (present(blocking)) do_block = blocking
+  if (present(from_PE)) then ; src_PE = from_PE ; else ; src_PE = root_PE() ; endif
+
+  if (do_block) call mpp_sync(PElist)
+  call mpp_broadcast(dat, src_PE, PElist)
+  if (do_block) call mpp_sync_self(PElist)
+
+end subroutine broadcast_int32_0D
 
 !> Communicate a 1-D array of integers from one PE to others
 subroutine broadcast_int1D(dat, length, from_PE, PElist, blocking)

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -73,6 +73,8 @@ interface read_variable
   module procedure read_variable_1d, read_variable_1d_int
 end interface read_variable
 
+!> Read a global or variable attribute from a named netCDF file using netCDF calls
+!! directly, in some cases reading from the root PE before broadcasting to the other PEs.
 interface read_attribute
   module procedure read_attribute_str, read_attribute_real
   module procedure read_attribute_int32, read_attribute_int64

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -11,14 +11,11 @@ use MOM_dyn_horgrid, only : dyn_horgrid_type
 use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser, only : get_param, log_param, param_file_type, log_version
-use MOM_io, only : close_file, create_file, fieldtype, file_exists, stdout
-use MOM_io, only : MOM_read_data, MOM_read_vector, SINGLE_FILE, MULTIPLE
+use MOM_io, only : close_file, create_file, fieldtype, file_exists, field_size, stdout
+use MOM_io, only : MOM_read_data, MOM_read_vector, read_variable, SINGLE_FILE, MULTIPLE
 use MOM_io, only : slasher, vardesc, MOM_write_field, var_desc
 use MOM_string_functions, only : uppercase
 use MOM_unit_scaling, only : unit_scale_type
-
-use netcdf, only : NF90_open, NF90_inq_varid, NF90_get_var, NF90_close
-use netcdf, only : NF90_inq_dimid, NF90_inquire_dimension, NF90_NOWRITE, NF90_NOERR
 
 implicit none ; private
 
@@ -192,11 +189,12 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
 
   ! Local variables
   real :: m_to_Z  ! A dimensional rescaling factor.
+  real, dimension(:), allocatable :: new_depth ! The new values of the depths [m]
+  integer, dimension(:), allocatable :: ig, jg ! The global indicies of the points to modify
   character(len=200) :: topo_edits_file, inputdir ! Strings for file/path
   character(len=40)  :: mdl = "apply_topography_edits_from_file" ! This subroutine's name.
-  integer :: n_edits, n, ashape(5), i, j, ncid, id, ncstatus, iid, jid, zid
-  integer, dimension(:), allocatable :: ig, jg
-  real, dimension(:), allocatable :: new_depth
+  integer :: i, j, n, n_edits, i_file, j_file, ndims, sizes(8)
+  logical :: found
 
   call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
@@ -211,72 +209,30 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
   if (len_trim(topo_edits_file)==0) return
 
   topo_edits_file = trim(inputdir)//trim(topo_edits_file)
-  if (.not.file_exists(topo_edits_file, G%Domain)) call MOM_error(FATAL, &
-     'initialize_topography_from_file: Unable to open '//trim(topo_edits_file))
+  if (.not.file_exists(topo_edits_file, G%Domain)) &
+     call MOM_error(FATAL, trim(mdl)//': Unable to find file '//trim(topo_edits_file))
 
-  ncstatus = nf90_open(trim(topo_edits_file), NF90_NOWRITE, ncid)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                                'Failed to open '//trim(topo_edits_file))
+  ! Read and check the values of ni and nj in the file for consistency with this configuration.
+  call read_variable(topo_edits_file, 'ni', i_file)
+  call read_variable(topo_edits_file, 'nj', j_file)
+  if (i_file /= G%ieg) call MOM_error(FATAL, trim(mdl)//': Incompatible i-dimension of grid in '//&
+                                      trim(topo_edits_file))
+  if (j_file /= G%jeg) call MOM_error(FATAL, trim(mdl)//': Incompatible j-dimension of grid in '//&
+                                      trim(topo_edits_file))
 
   ! Get nEdits
-  ncstatus = nf90_inq_dimid(ncid, 'nEdits', id)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                                'Failed to inq_dimid nEdits for '//trim(topo_edits_file))
-  ncstatus = nf90_inquire_dimension(ncid, id, len=n_edits)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                                'Failed to inquire_dimension nEdits for '//trim(topo_edits_file))
-
-  ! Read ni
-  ncstatus = nf90_inq_varid(ncid, 'ni', id)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                                'Failed to inq_varid ni for '//trim(topo_edits_file))
-  ncstatus = nf90_get_var(ncid, id, i)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                              'Failed to get_var ni for '//trim(topo_edits_file))
-  if (i /= G%ieg) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                              'Incompatible i-dimension of grid in '//trim(topo_edits_file))
-
-  ! Read nj
-  ncstatus = nf90_inq_varid(ncid, 'nj', id)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                                'Failed to inq_varid nj for '//trim(topo_edits_file))
-  ncstatus = nf90_get_var(ncid, id, j)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                              'Failed to get_var nj for '//trim(topo_edits_file))
-  if (j /= G%jeg) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                              'Incompatible j-dimension of grid in '//trim(topo_edits_file))
-
-  ! Read iEdit
-  ncstatus = nf90_inq_varid(ncid, 'iEdit', id)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                                'Failed to inq_varid iEdit for '//trim(topo_edits_file))
+  call field_size(topo_edits_file, 'zEdit', sizes, ndims=ndims)
+  if (ndims /= 1) call MOM_error(FATAL, "The variable zEdit has an "//&
+            "unexpected number of dimensions in "//trim(topo_edits_file) )
+  n_edits = sizes(1)
   allocate(ig(n_edits))
-  ncstatus = nf90_get_var(ncid, id, ig)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                              'Failed to get_var iEdit for '//trim(topo_edits_file))
-
-  ! Read jEdit
-  ncstatus = nf90_inq_varid(ncid, 'jEdit', id)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                                'Failed to inq_varid jEdit for '//trim(topo_edits_file))
   allocate(jg(n_edits))
-  ncstatus = nf90_get_var(ncid, id, jg)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                              'Failed to get_var jEdit for '//trim(topo_edits_file))
-
-  ! Read zEdit
-  ncstatus = nf90_inq_varid(ncid, 'zEdit', id)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                                'Failed to inq_varid zEdit for '//trim(topo_edits_file))
   allocate(new_depth(n_edits))
-  ncstatus = nf90_get_var(ncid, id, new_depth)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                              'Failed to get_var zEdit for '//trim(topo_edits_file))
 
-  ! Close file
-  ncstatus = nf90_close(ncid)
-  if (ncstatus /= NF90_NOERR) call MOM_error(FATAL, 'apply_topography_edits_from_file: '//&
-                                'Failed to close '//trim(topo_edits_file))
+  ! Read iEdit, jEdit and zEdit
+  call read_variable(topo_edits_file, 'iEdit', ig)
+  call read_variable(topo_edits_file, 'jEdit', jg)
+  call read_variable(topo_edits_file, 'zEdit', new_depth)
 
   do n = 1, n_edits
     i = ig(n) - G%isd_global + 2 ! +1 for python indexing and +1 for ig-isd_global+1
@@ -284,11 +240,11 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
     if (i>=G%isc .and. i<=G%iec .and. j>=G%jsc .and. j<=G%jec) then
       if (new_depth(n)/=0.) then
         write(stdout,'(a,3i5,f8.2,a,f8.2,2i4)') &
-          'Ocean topography edit: ',n,ig(n),jg(n),D(i,j)/m_to_Z,'->',abs(new_depth(n)),i,j
+          'Ocean topography edit: ', n, ig(n), jg(n), D(i,j)/m_to_Z, '->', abs(new_depth(n)), i, j
         D(i,j) = abs(m_to_Z*new_depth(n)) ! Allows for height-file edits (i.e. converts negatives)
       else
-        call MOM_error(FATAL, ' apply_topography_edits_from_file: '//&
-          "A zero depth edit would change the land mask and is not allowed in"//trim(topo_edits_file))
+        call MOM_error(FATAL, trim(mdl)//': A zero depth edit would change the land mask and '//&
+          "is not allowed in"//trim(topo_edits_file))
       endif
     endif
   enddo

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -6,14 +6,10 @@ module MOM_tracer_Z_init
 use MOM_error_handler, only : MOM_error, FATAL, WARNING, MOM_mesg, is_root_pe
 ! use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : MOM_read_data
+use MOM_io, only : MOM_read_data, get_var_sizes, read_attribute, read_variable
 use MOM_EOS, only : EOS_type, calculate_density, calculate_density_derivs, EOS_domain
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_verticalGrid, only : verticalGrid_type
-
-use netcdf, only : NF90_open, NF90_inq_varid, NF90_inquire_variable, NF90_get_var
-use netcdf, only : NF90_get_att, NF90_inquire_dimension, NF90_close, NF90_strerror
-use netcdf, only : NF90_NOWRITE, NF90_NOERR
 
 implicit none ; private
 
@@ -402,97 +398,36 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
   ! NetCDF file.  It also might read the missing value attribute for that same field.
   character(len=32) :: mdl
   character(len=120) :: dim_name, edge_name, tr_msg, dim_msg
+  character(len=256) :: dim_names(4)
   logical :: monotonic
   integer :: ncid, status, intid, tr_id, layid, k
-  integer :: nz_edge, ndim, tr_dim_ids(8)
+  integer :: nz_edge, ndim, tr_dim_ids(8), sizes(4)
 
   mdl = "MOM_tracer_Z_init read_Z_edges: "
   tr_msg = trim(tr_name)//" in "//trim(filename)
 
-  status = NF90_OPEN(filename, NF90_NOWRITE, ncid)
-  if (status /= NF90_NOERR) then
-    call MOM_error(WARNING,mdl//" Difficulties opening "//trim(filename)//&
-        " - "//trim(NF90_STRERROR(status)))
-    nz_out = -1 ; return
-  endif
+  call get_var_sizes(filename, tr_name, ndim, sizes, dim_names=dim_names)
+  if ((ndim < 3) .or. (ndim > 4)) &
+    call MOM_ERROR(FATAL, mdl//" "//trim(tr_msg)//" has too many or too few dimensions.")
+  nz_out = sizes(3)
 
-  status = NF90_INQ_VARID(ncid, tr_name, tr_id)
-  if (status /= NF90_NOERR) then
-    call MOM_error(WARNING,mdl//" Difficulties finding variable "//&
-        trim(tr_msg)//" - "//trim(NF90_STRERROR(status)))
-    nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
-  endif
-  status = NF90_INQUIRE_VARIABLE(ncid, tr_id, ndims=ndim, dimids=tr_dim_ids)
-  if (status /= NF90_NOERR) then
-    call MOM_ERROR(WARNING,mdl//" cannot inquire about "//trim(tr_msg))
-  elseif ((ndim < 3) .or. (ndim > 4)) then
-    call MOM_ERROR(WARNING,mdl//" "//trim(tr_msg)//&
-         " has too many or too few dimensions.")
-    nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
-  endif
-
-  if (.not.use_missing) then
-    ! Try to find the missing value from the dataset.
-    status = NF90_GET_ATT(ncid, tr_id, "missing_value", missing)
-    if (status /= NF90_NOERR) use_missing = .true.
-  endif
-
-  ! Get the axis name and length.
-  status = NF90_INQUIRE_DIMENSION(ncid, tr_dim_ids(3), dim_name, len=nz_out)
-  if (status /= NF90_NOERR) then
-    call MOM_ERROR(WARNING,mdl//" cannot inquire about dimension(3) of "//&
-                    trim(tr_msg))
-  endif
-
-  dim_msg = trim(dim_name)//" in "//trim(filename)
-  status = NF90_INQ_VARID(ncid, dim_name, layid)
-  if (status /= NF90_NOERR) then
-    call MOM_error(WARNING,mdl//" Difficulties finding variable "//&
-        trim(dim_msg)//" - "//trim(NF90_STRERROR(status)))
-    nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
+  if (.not.use_missing) then  ! Try to find the missing value from the dataset.
+    call read_attribute(filename, "missing_value", missing, varname=tr_name, found=use_missing)
   endif
   ! Find out if the Z-axis has an edges attribute
-  status = NF90_GET_ATT(ncid, layid, "edges", edge_name)
-  if (status /= NF90_NOERR) then
-    call MOM_mesg(mdl//" "//trim(dim_msg)//&
-         " has no readable edges attribute - "//trim(NF90_STRERROR(status)))
-    has_edges = .false.
-  else
-    has_edges = .true.
-    status = NF90_INQ_VARID(ncid, edge_name, intid)
-    if (status /= NF90_NOERR) then
-      call MOM_error(WARNING,mdl//" Difficulties finding edge variable "//&
-          trim(edge_name)//" in "//trim(filename)//" - "//trim(NF90_STRERROR(status)))
-      has_edges = .false.
-    endif
-  endif
+  call read_attribute(filename, "edges", edge_name, varname=dim_names(3), found=has_edges)
 
-  nz_edge = nz_out ; if (has_edges) nz_edge = nz_out+1
+  nz_edge = sizes(3) ; if (has_edges) nz_edge = sizes(3)+1
   allocate(z_edges(nz_edge)) ; z_edges(:) = 0.0
 
   if (nz_out < 1) return
 
   ! Read the right variable.
   if (has_edges) then
-    dim_msg = trim(edge_name)//" in "//trim(filename)
-    status = NF90_GET_VAR(ncid, intid, z_edges)
-    if (status /= NF90_NOERR) then
-      call MOM_error(WARNING,mdl//" Difficulties reading variable "//&
-          trim(dim_msg)//" - "//trim(NF90_STRERROR(status)))
-      nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
-    endif
+    call read_variable(filename, edge_name, z_edges)
   else
-    status = NF90_GET_VAR(ncid, layid, z_edges)
-    if (status /= NF90_NOERR) then
-      call MOM_error(WARNING,mdl//" Difficulties reading variable "//&
-          trim(dim_msg)//" - "//trim(NF90_STRERROR(status)))
-      nz_out = -1 ; status = NF90_CLOSE(ncid) ; return
-    endif
+    call read_variable(filename, dim_names(3), z_edges)
   endif
-
-  status = NF90_CLOSE(ncid)
-  if (status /= NF90_NOERR) call MOM_error(WARNING, mdl// &
-    " Difficulties closing "//trim(filename)//" - "//trim(NF90_STRERROR(status)))
 
   ! z_edges should be montonically decreasing with our sign convention.
   ! Change the sign sign convention if it looks like z_edges is increasing.
@@ -502,8 +437,7 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
   ! Check that z_edges is now monotonically decreasing.
   monotonic = .true.
   do k=2,nz_edge ; if (z_edges(k) >= z_edges(k-1)) monotonic = .false. ; enddo
-  if (.not.monotonic) &
-    call MOM_error(WARNING,mdl//" "//trim(dim_msg)//" is not monotonic.")
+  if (.not.monotonic) call MOM_error(WARNING,mdl//" "//trim(dim_msg)//" is not monotonic.")
 
   if (scale /= 1.0) then ; do k=1,nz_edge ; z_edges(k) = scale*z_edges(k) ; enddo ; endif
 

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -397,7 +397,8 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
   !   This subroutine reads the vertical coordinate data for a field from a
   ! NetCDF file.  It also might read the missing value attribute for that same field.
   character(len=32) :: mdl
-  character(len=120) :: dim_name, edge_name, tr_msg, dim_msg
+  character(len=120) :: dim_name, tr_msg, dim_msg
+  character(:), allocatable :: edge_name
   character(len=256) :: dim_names(4)
   logical :: monotonic
   integer :: ncid, status, intid, tr_id, layid, k
@@ -428,6 +429,7 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
   else
     call read_variable(filename, dim_names(3), z_edges)
   endif
+  if (allocated(edge_name)) deallocate(edge_name)
 
   ! z_edges should be montonically decreasing with our sign convention.
   ! Change the sign sign convention if it looks like z_edges is increasing.


### PR DESCRIPTION
  Took preliminary steps to consolidate the direct calls to netcdf in
MOM_io.F90. Renamed check_grid_def to verify_variable_units and moved it to
MOM_io, where it can be used more widely than just in MOM_regridding.F90.  Also
split get_var_sizes and get_varid out of num_timelevels and made them publicly
visible.  All answers are bitwise identical, but there are new public interfaces
and the renaming of one routine.