### PR TITLE
+(*)Restore ability to use decomposed restart files

### DIFF
--- a/src/framework/MOM_io_infra.F90
+++ b/src/framework/MOM_io_infra.F90
@@ -315,17 +315,23 @@ subroutine get_axis_data( axis, dat )
   call mpp_get_axis_data( axis, dat )
 end subroutine get_axis_data
 
-!> This routine uses the fms_io subroutine read_data to read a scalar
-!! data field named "fieldname" from file "filename".
-subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale)
+!> This routine uses the fms_io subroutine read_data to read a scalar named
+!! "fieldname" from a single or domain-decomposed file "filename".
+subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Domain)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real,                   intent(inout) :: data      !< The 1-dimensional array into which the data
   integer,      optional, intent(in)    :: timelevel !< The time level in the file to read
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
+  type(MOM_domain_type), &
+                optional, intent(in)    :: MOM_Domain !< The MOM_Domain that describes the decomposition
 
-  call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
+  if (present(MOM_Domain)) then
+    call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, timelevel=timelevel)
+  else
+    call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
+  endif
 
   if (present(scale)) then ; if (scale /= 1.0) then
     data = scale*data
@@ -333,17 +339,23 @@ subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale)
 
 end subroutine MOM_read_data_0d
 
-!> This routine uses the fms_io subroutine read_data to read a 1-D
-!! data field named "fieldname" from file "filename".
-subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale)
+!> This routine uses the fms_io subroutine read_data to read a 1-D data field named
+!! "fieldname" from a single or domain-decomposed file "filename".
+subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Domain)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:),     intent(inout) :: data      !< The 1-dimensional array into which the data
   integer,      optional, intent(in)    :: timelevel !< The time level in the file to read
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before they are returned.
+  type(MOM_domain_type), &
+                optional, intent(in)    :: MOM_Domain !< The MOM_Domain that describes the decomposition
 
-  call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
+  if (present(MOM_Domain)) then
+    call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, timelevel=timelevel)
+  else
+    call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
+  endif
 
   if (present(scale)) then ; if (scale /= 1.0) then
     data(:) = scale*data(:)

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1202,10 +1202,12 @@ subroutine restore_state(filename, directory, day, G, CS)
 
           if (associated(CS%var_ptr1d(m)%p))  then
             ! Read a 1d array, which should be invariant to domain decomposition.
-            call MOM_read_data(unit_path(n), varname, CS%var_ptr1d(m)%p, timelevel=1)
+            call MOM_read_data(unit_path(n), varname, CS%var_ptr1d(m)%p, &
+                               timelevel=1, MOM_Domain=G%Domain)
             if (is_there_a_checksum) checksum_data = chksum(CS%var_ptr1d(m)%p)
           elseif (associated(CS%var_ptr0d(m)%p)) then ! Read a scalar...
-            call MOM_read_data(unit_path(n), varname, CS%var_ptr0d(m)%p, timelevel=1)
+            call MOM_read_data(unit_path(n), varname, CS%var_ptr0d(m)%p, &
+                               timelevel=1, MOM_Domain=G%Domain)
             if (is_there_a_checksum) checksum_data = chksum(CS%var_ptr0d(m)%p, pelist=(/PE_here()/))
           elseif (associated(CS%var_ptr2d(m)%p)) then  ! Read a 2d array.
             if (pos /= 0) then


### PR DESCRIPTION
  Added optional MOM_Domain arguments to the 0-d and 1-d versions of
MOM_read_data, enabling them to read from a domain-decomposed file if the single
file is not present.  The MOM_read_data calls in restore_state were modified to
use these new optional arguments, thereby restoring the ability of MOM6 to read
from domain-decomposed restart files, which had been broken by a known miscreant
on January 3, 2021 with MOM6 commit aea16f73.  All answers and output are
bitwise identical in cases that worked.