### PR TITLE
MOM6: +I/O interface changes, including a new file_type

### DIFF
--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -48,9 +48,9 @@ program MOM_main
   use MOM_ice_shelf,       only : shelf_calc_flux, add_shelf_forces, ice_shelf_save_restart
   use MOM_ice_shelf,       only : initialize_ice_shelf_fluxes, initialize_ice_shelf_forces
   use MOM_interpolate,     only : time_interp_external_init
-  use MOM_io,              only : file_exists, open_file, close_file
+  use MOM_io,              only : file_exists, open_ASCII_file, close_file
   use MOM_io,              only : check_nml_error, io_infra_init, io_infra_end
-  use MOM_io,              only : APPEND_FILE, ASCII_FILE, READONLY_FILE, SINGLE_FILE
+  use MOM_io,              only : APPEND_FILE, READONLY_FILE
   use MOM_restart,         only : MOM_restart_CS, save_restart
   use MOM_string_functions,only : uppercase
   use MOM_surface_forcing, only : set_forcing, forcing_save_restart
@@ -238,7 +238,7 @@ program MOM_main
 
   if (file_exists('input.nml')) then
     ! Provide for namelist specification of the run length and calendar data.
-    call open_file(unit, 'input.nml', form=ASCII_FILE, action=READONLY_FILE)
+    call open_ASCII_file(unit, 'input.nml', action=READONLY_FILE)
     read(unit, ocean_solo_nml, iostat=io_status)
     call close_file(unit)
     ierr = check_nml_error(io_status,'ocean_solo_nml')
@@ -252,15 +252,14 @@ program MOM_main
 
   ! Read ocean_solo restart, which can override settings from the namelist.
   if (file_exists(trim(dirs%restart_input_dir)//'ocean_solo.res')) then
-    call open_file(unit,trim(dirs%restart_input_dir)//'ocean_solo.res', &
-                   form=ASCII_FILE,action=READONLY_FILE)
+    call open_ASCII_file(unit, trim(dirs%restart_input_dir)//'ocean_solo.res', action=READONLY_FILE)
     read(unit,*) calendar_type
     read(unit,*) date_init
     read(unit,*) date
     call close_file(unit)
   else
     calendar = uppercase(calendar)
-    if (calendar(1:6) == 'JULIAN') then ;         calendar_type = JULIAN
+    if (calendar(1:6) == 'JULIAN') then ;        calendar_type = JULIAN
     elseif (calendar(1:9) == 'GREGORIAN') then ; calendar_type = GREGORIAN
     elseif (calendar(1:6) == 'NOLEAP') then ;    calendar_type = NOLEAP
     elseif (calendar(1:10)=='THIRTY_DAY') then ; calendar_type = THIRTY_DAY_MONTHS
@@ -432,15 +431,14 @@ program MOM_main
   call diag_mediator_close_registration(diag)
 
   ! Write out a time stamp file.
-  if (calendar_type /= NO_CALENDAR) then
-    call open_file(unit, 'time_stamp.out', form=ASCII_FILE, action=APPEND_FILE, &
-                   threading=SINGLE_FILE)
+  if (is_root_pe() .and. (calendar_type /= NO_CALENDAR)) then
+    call open_ASCII_file(unit, 'time_stamp.out', action=APPEND_FILE)
     call get_date(Time, date(1), date(2), date(3), date(4), date(5), date(6))
     month = month_name(date(2))
-    if (is_root_pe()) write(unit,'(6i4,2x,a3)') date, month(1:3)
+    write(unit,'(6i4,2x,a3)') date, month(1:3)
     call get_date(Time_end, date(1), date(2), date(3), date(4), date(5), date(6))
     month = month_name(date(2))
-    if (is_root_pe()) write(unit,'(6i4,2x,a3)') date, month(1:3)
+    write(unit,'(6i4,2x,a3)') date, month(1:3)
     call close_file(unit)
   endif
 
@@ -618,19 +616,19 @@ program MOM_main
     if (use_ice_shelf) call ice_shelf_save_restart(ice_shelf_CSp, Time, &
                                 dirs%restart_output_dir)
     ! Write ocean solo restart file.
-    call open_file(unit, trim(dirs%restart_output_dir)//'ocean_solo.res', nohdrs=.true.)
-    if (is_root_pe())then
-        write(unit, '(i6,8x,a)') calendar_type, &
-             '(Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)'
+    if (is_root_pe()) then
+      call open_ASCII_file(unit, trim(dirs%restart_output_dir)//'ocean_solo.res')
+      write(unit, '(i6,8x,a)') calendar_type, &
+            '(Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)'
 
-        call get_date(Start_time, yr, mon, day, hr, mins, sec)
-        write(unit, '(6i6,8x,a)') yr, mon, day, hr, mins, sec, &
-             'Model start time:   year, month, day, hour, minute, second'
-        call get_date(Time, yr, mon, day, hr, mins, sec)
-        write(unit, '(6i6,8x,a)') yr, mon, day, hr, mins, sec, &
-             'Current model time: year, month, day, hour, minute, second'
+      call get_date(Start_time, yr, mon, day, hr, mins, sec)
+      write(unit, '(6i6,8x,a)') yr, mon, day, hr, mins, sec, &
+            'Model start time:   year, month, day, hour, minute, second'
+      call get_date(Time, yr, mon, day, hr, mins, sec)
+      write(unit, '(6i6,8x,a)') yr, mon, day, hr, mins, sec, &
+            'Current model time: year, month, day, hour, minute, second'
+      call close_file(unit)
     endif
-    call close_file(unit)
   endif
 
   if (is_root_pe()) then

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -22,7 +22,7 @@ use MOM_error_handler,    only : callTree_showQuery
 use MOM_error_handler,    only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,      only : get_param, param_file_type, log_param
 use MOM_io,               only : vardesc, var_desc, fieldtype, SINGLE_FILE
-use MOM_io,               only : create_file, write_field, close_file
+use MOM_io,               only : create_file, write_field, close_file, file_type
 use MOM_interface_heights,only : find_eta
 use MOM_open_boundary,    only : ocean_OBC_type, OBC_DIRECTION_E, OBC_DIRECTION_W
 use MOM_open_boundary,    only : OBC_DIRECTION_N, OBC_DIRECTION_S
@@ -1273,7 +1273,7 @@ subroutine ALE_writeCoordinateFile( CS, GV, directory )
   character(len=240) :: filepath
   type(vardesc)      :: vars(2)
   type(fieldtype)    :: fields(2)
-  integer            :: unit
+  type(file_type)    :: IO_handle ! The I/O handle of the fileset
   real               :: ds(GV%ke), dsi(GV%ke+1)
 
   filepath    = trim(directory) // trim("Vertical_coordinate")
@@ -1287,13 +1287,12 @@ subroutine ALE_writeCoordinateFile( CS, GV, directory )
   vars(2) = var_desc('ds_interface', getCoordinateUnits( CS%regridCS ), &
                     'Layer Center Coordinate Separation','1','i','1')
 
-  call create_file(unit, trim(filepath), vars, 2, fields, SINGLE_FILE, GV=GV)
-  call write_field(unit, fields(1), ds)
-  call write_field(unit, fields(2), dsi)
-  call close_file(unit)
+  call create_file(IO_handle, trim(filepath), vars, 2, fields, SINGLE_FILE, GV=GV)
+  call write_field(IO_handle, fields(1), ds)
+  call write_field(IO_handle, fields(2), dsi)
+  call close_file(IO_handle)
 
 end subroutine ALE_writeCoordinateFile
-
 
 !> Set h to coordinate values for fixed coordinate systems
 subroutine ALE_initThicknessToCoord( CS, G, GV, h )

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -15,8 +15,7 @@ use MOM_error_handler, only : MOM_error, NOTE
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : open_file
-use MOM_io, only : APPEND_FILE, ASCII_FILE, MULTIPLE, SINGLE_FILE
+use MOM_io, only : open_ASCII_file, APPEND_FILE, MULTIPLE, SINGLE_FILE
 use MOM_time_manager, only : time_type, get_time, get_date, set_date, operator(-)
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : ocean_internal_state, accel_diag_ptrs, cont_diag_ptrs
@@ -120,8 +119,8 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt_in_T, G, GV, US, CS, vel_rp
   ! Open up the file for output if this is the first call.
     if (CS%u_file < 0) then
       if (len_trim(CS%u_trunc_file) < 1) return
-      call open_file(CS%u_file, trim(CS%u_trunc_file), action=APPEND_FILE, &
-                     form=ASCII_FILE, threading=MULTIPLE, fileset=SINGLE_FILE)
+      call open_ASCII_file(CS%u_file, trim(CS%u_trunc_file), action=APPEND_FILE, &
+                           threading=MULTIPLE, fileset=SINGLE_FILE)
       if (CS%u_file < 0) then
         call MOM_error(NOTE, 'Unable to open file '//trim(CS%u_trunc_file)//'.')
         return
@@ -453,8 +452,8 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt_in_T, G, GV, US, CS, vel_rp
   ! Open up the file for output if this is the first call.
     if (CS%v_file < 0) then
       if (len_trim(CS%v_trunc_file) < 1) return
-      call open_file(CS%v_file, trim(CS%v_trunc_file), action=APPEND_FILE, &
-                     form=ASCII_FILE, threading=MULTIPLE, fileset=SINGLE_FILE)
+      call open_ASCII_file(CS%v_file, trim(CS%v_trunc_file), action=APPEND_FILE, &
+                           threading=MULTIPLE, fileset=SINGLE_FILE)
       if (CS%v_file < 0) then
         call MOM_error(NOTE, 'Unable to open file '//trim(CS%v_trunc_file)//'.')
         return

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -12,9 +12,9 @@ use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_interface_heights, only : find_eta
-use MOM_io, only : create_file, fieldtype, flush_file, open_ASCII_file, reopen_file, stdout
+use MOM_io, only : create_file, file_type, fieldtype, flush_file, reopen_file
 use MOM_io, only : file_exists, slasher, vardesc, var_desc, write_field, get_filename_appendix
-use MOM_io, only : field_size, read_variable, read_attribute
+use MOM_io, only : field_size, read_variable, read_attribute, open_ASCII_file, stdout
 use MOM_io, only : APPEND_FILE, SINGLE_FILE, WRITEONLY_FILE
 use MOM_open_boundary, only : ocean_OBC_type, OBC_segment_type
 use MOM_open_boundary, only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
@@ -122,7 +122,7 @@ type, public :: sum_output_CS ; private
                                 !! to stdout when the energy files are written.
   integer :: previous_calls = 0 !< The number of times write_energy has been called.
   integer :: prev_n = 0         !< The value of n from the last call.
-  integer :: fileenergy_nc      !< NetCDF id of the energy file.
+  type(file_type) :: fileenergy_nc !< The file handle for the netCDF version of the energy file.
   integer :: fileenergy_ascii   !< The unit number of the ascii version of the energy file.
   type(fieldtype), dimension(NUM_FIELDS+MAX_FIELDS_) :: &
              fields             !< fieldtype variables for the output fields.

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -12,10 +12,10 @@ use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_interface_heights, only : find_eta
-use MOM_io, only : create_file, fieldtype, flush_file, open_file, reopen_file, stdout
+use MOM_io, only : create_file, fieldtype, flush_file, open_ASCII_file, reopen_file, stdout
 use MOM_io, only : file_exists, slasher, vardesc, var_desc, write_field, get_filename_appendix
 use MOM_io, only : field_size, read_variable, read_attribute
-use MOM_io, only : APPEND_FILE, ASCII_FILE, SINGLE_FILE, WRITEONLY_FILE
+use MOM_io, only : APPEND_FILE, SINGLE_FILE, WRITEONLY_FILE
 use MOM_open_boundary, only : ocean_OBC_type, OBC_segment_type
 use MOM_open_boundary, only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_time_manager, only : time_type, get_time, get_date, set_time, operator(>)
@@ -583,11 +583,9 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, OBC, dt_
     !  Reopen or create a text output file, with an explanatory header line.
     if (is_root_pe()) then
       if (day > CS%Start_time) then
-        call open_file(CS%fileenergy_ascii, trim(CS%energyfile), &
-                       action=APPEND_FILE, form=ASCII_FILE, nohdrs=.true.)
+        call open_ASCII_file(CS%fileenergy_ascii, trim(CS%energyfile), action=APPEND_FILE)
       else
-        call open_file(CS%fileenergy_ascii, trim(CS%energyfile), &
-                       action=WRITEONLY_FILE, form=ASCII_FILE, nohdrs=.true.)
+        call open_ASCII_file(CS%fileenergy_ascii, trim(CS%energyfile), action=WRITEONLY_FILE)
         if (abs(CS%timeunit - 86400.0) < 1.0) then
           if (CS%use_temperature) then
             write(CS%fileenergy_ascii,'("  Step,",7x,"Day,  Truncs,      &

--- a/src/framework/MOM_array_transform.F90
+++ b/src/framework/MOM_array_transform.F90
@@ -13,9 +13,8 @@
 
 module MOM_array_transform
 
-implicit none
+implicit none ; private
 
-private
 public rotate_array
 public rotate_array_pair
 public rotate_vector

--- a/src/framework/MOM_domain_infra.F90
+++ b/src/framework/MOM_domain_infra.F90
@@ -39,7 +39,7 @@ public :: domain2D, domain1D, group_pass_type
 ! These interfaces are actually implemented or have explicit interfaces in this file.
 public :: create_MOM_domain, clone_MOM_domain, get_domain_components, get_domain_extent
 public :: deallocate_MOM_domain, get_global_shape, compute_block_extent
-public :: pass_var, pass_vector, fill_symmetric_edges
+public :: pass_var, pass_vector, fill_symmetric_edges, rescale_comp_data
 public :: pass_var_start, pass_var_complete, pass_vector_start, pass_vector_complete
 public :: create_group_pass, do_group_pass, start_group_pass, complete_group_pass
 public :: redistribute_array, broadcast_domain, global_field
@@ -97,6 +97,11 @@ interface fill_symmetric_edges
   module procedure fill_vector_symmetric_edges_2d !, fill_vector_symmetric_edges_3d
 !   module procedure fill_scalar_symmetric_edges_2d, fill_scalar_symmetric_edges_3d
 end interface fill_symmetric_edges
+
+!> Rescale the values of an array in its computational domain by a constant factor
+interface rescale_comp_data
+  module procedure rescale_comp_data_4d, rescale_comp_data_3d, rescale_comp_data_2d
+end interface rescale_comp_data
 
 !> Pass an array from one MOM domain to another
 interface redistribute_array
@@ -1228,6 +1233,57 @@ subroutine redistribute_array_3d(Domain1, array1, Domain2, array2, complete)
 end subroutine redistribute_array_3d
 
 
+!> Rescale the values of a 4-D array in its computational domain by a constant factor
+subroutine rescale_comp_data_4d(domain, array, scale)
+  type(MOM_domain_type),    intent(in)    :: domain !< MOM domain from which to extract information
+  real, dimension(:,:,:,:), intent(inout) :: array  !< The array which is having the data in its
+                                                    !! computational domain rescaled
+  real,                     intent(in)    :: scale  !< A scaling factor by which to multiply the
+                                                    !! values in the computational domain of array
+  integer :: is, ie, js, je
+
+  if (scale == 1.0) return
+
+  call get_simple_array_i_ind(domain, size(array,1), is, ie)
+  call get_simple_array_j_ind(domain, size(array,2), js, je)
+  array(is:ie,js:je,:,:) = scale*array(is:ie,js:je,:,:)
+
+end subroutine rescale_comp_data_4d
+
+!> Rescale the values of a 3-D array in its computational domain by a constant factor
+subroutine rescale_comp_data_3d(domain, array, scale)
+  type(MOM_domain_type),  intent(in)    :: domain !< MOM domain from which to extract information
+  real, dimension(:,:,:), intent(inout) :: array  !< The array which is having the data in its
+                                                  !! computational domain rescaled
+  real,                   intent(in)    :: scale  !< A scaling factor by which to multiply the
+                                                  !! values in the computational domain of array
+  integer :: is, ie, js, je
+
+  if (scale == 1.0) return
+
+  call get_simple_array_i_ind(domain, size(array,1), is, ie)
+  call get_simple_array_j_ind(domain, size(array,2), js, je)
+  array(is:ie,js:je,:) = scale*array(is:ie,js:je,:)
+
+end subroutine rescale_comp_data_3d
+
+!> Rescale the values of a 2-D array in its computational domain by a constant factor
+subroutine rescale_comp_data_2d(domain, array, scale)
+  type(MOM_domain_type), intent(in)    :: domain !< MOM domain from which to extract information
+  real, dimension(:,:),  intent(inout) :: array  !< The array which is having the data in its
+                                                 !! computational domain rescaled
+  real,                  intent(in)    :: scale  !< A scaling factor by which to multiply the
+                                                 !! values in the computational domain of array
+  integer :: is, ie, js, je
+
+  if (scale == 1.0) return
+
+  call get_simple_array_i_ind(domain, size(array,1), is, ie)
+  call get_simple_array_j_ind(domain, size(array,2), js, je)
+  array(is:ie,js:je) = scale*array(is:ie,js:je)
+
+end subroutine rescale_comp_data_2d
+
 !> create_MOM_domain creates and initializes a MOM_domain_type variables, based on the information
 !! provided in arguments.
 subroutine create_MOM_domain(MOM_dom, n_global, n_halo, reentrant, tripolar_N, layout, io_layout, &
@@ -1742,7 +1798,6 @@ subroutine get_domain_extent_d2D(Domain, isc, iec, jsc, jec, isd, ied, jsd, jed)
   if (present(jed)) jed = jed_
 
 end subroutine get_domain_extent_d2D
-
 
 !> Return the (potentially symmetric) computational domain i-bounds for an array
 !! passed without index specifications (i.e. indices start at 1) based on an array size.

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -15,7 +15,7 @@ use MOM_domain_infra,     only : pass_var_start, pass_var_complete
 use MOM_domain_infra,     only : pass_vector_start, pass_vector_complete
 use MOM_domain_infra,     only : create_group_pass, do_group_pass
 use MOM_domain_infra,     only : start_group_pass, complete_group_pass
-use MOM_domain_infra,     only : global_field, redistribute_array, broadcast_domain
+use MOM_domain_infra,     only : rescale_comp_data, global_field, redistribute_array, broadcast_domain
 use MOM_domain_infra,     only : MOM_thread_affinity_set, set_MOM_thread_affinity
 use MOM_domain_infra,     only : AGRID, BGRID_NE, CGRID_NE, SCALAR_PAIR, BITWISE_EXACT_SUM
 use MOM_domain_infra,     only : CORNER, CENTER, NORTH_FACE, EAST_FACE
@@ -28,22 +28,24 @@ use MOM_string_functions, only : slasher
 implicit none ; private
 
 public :: MOM_infra_init, MOM_infra_end
-!      Domain types and creation and destruction routines
+!  Domain types and creation and destruction routines
 public :: MOM_domain_type, domain2D, domain1D
 public :: MOM_domains_init, create_MOM_domain, clone_MOM_domain, deallocate_MOM_domain
 public :: MOM_thread_affinity_set, set_MOM_thread_affinity
-!      Domain query routines
+!  Domain query routines
 public :: get_domain_extent, get_domain_components, compute_block_extent, get_global_shape
 public :: PE_here, root_PE, num_PEs
-!      Single call communication routines
+!  Single call communication routines
 public :: pass_var, pass_vector, fill_symmetric_edges, broadcast
-!      Non-blocking communication routines
+!  Non-blocking communication routines
 public :: pass_var_start, pass_var_complete, pass_vector_start, pass_vector_complete
-!      Multi-variable group communication routines and type
+!  Multi-variable group communication routines and type
 public :: create_group_pass, do_group_pass, group_pass_type, start_group_pass, complete_group_pass
-!      Global reduction routines
+!  Global reduction routines
 public :: sum_across_PEs, min_across_PEs, max_across_PEs
 public :: global_field, redistribute_array, broadcast_domain
+!  Simple index-convention-invariant array manipulation routine
+public :: rescale_comp_data
 !> These encoding constants are used to indicate the staggering of scalars and vectors
 public :: AGRID, BGRID_NE, CGRID_NE, SCALAR_PAIR
 !> These encoding constants are used to indicate the discretization position of a variable

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -14,9 +14,9 @@ use MOM_grid,             only : ocean_grid_type
 use MOM_io_infra,         only : MOM_read_data, MOM_read_vector, read_field_chksum
 use MOM_io_infra,         only : read_data=>MOM_read_data ! read_data will be removed soon.
 use MOM_io_infra,         only : file_exists, get_file_info, get_file_fields, get_field_atts
-use MOM_io_infra,         only : open_file, close_file, get_field_size, fieldtype, field_exists
-use MOM_io_infra,         only : flush_file, get_filename_suffix
-use MOM_io_infra,         only : get_file_times, axistype, get_axis_data
+use MOM_io_infra,         only : open_file, open_ASCII_file, close_file, flush_file
+use MOM_io_infra,         only : get_field_size, fieldtype, field_exists
+use MOM_io_infra,         only : get_file_times, axistype, get_axis_data, get_filename_suffix
 use MOM_io_infra,         only : write_field, write_metadata, write_version
 use MOM_io_infra,         only : MOM_namelist_file, check_namelist_error, io_infra_init, io_infra_end
 use MOM_io_infra,         only : APPEND_FILE, ASCII_FILE, MULTIPLE, NETCDF_FILE, OVERWRITE_FILE
@@ -40,8 +40,8 @@ public :: open_namelist_file, check_namelist_error, check_nml_error
 public :: get_var_sizes, verify_variable_units, num_timelevels, read_variable, read_attribute
 public :: open_file_to_read, close_file_to_read
 ! The following are simple pass throughs of routines from MOM_io_infra or other modules.
-public :: file_exists, open_file, close_file, flush_file, get_filename_appendix
-public :: get_file_info, field_exists, get_file_fields, get_file_times
+public :: file_exists, open_file, open_ASCII_file, close_file, flush_file
+public :: get_file_info, field_exists, get_file_fields, get_file_times, get_filename_appendix
 public :: fieldtype, field_size, get_field_atts
 public :: axistype, get_axis_data
 public :: MOM_read_data, MOM_read_vector, read_field_chksum

--- a/src/framework/MOM_io_infra.F90
+++ b/src/framework/MOM_io_infra.F90
@@ -3,8 +3,7 @@ module MOM_io_infra
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_domain_infra,     only : MOM_domain_type, AGRID, BGRID_NE, CGRID_NE
-use MOM_domain_infra,     only : get_simple_array_i_ind, get_simple_array_j_ind
+use MOM_domain_infra,     only : MOM_domain_type, rescale_comp_data, AGRID, BGRID_NE, CGRID_NE
 use MOM_domain_infra,     only : domain2d, domain1d, CENTER, CORNER, NORTH_FACE, EAST_FACE
 use MOM_error_infra,      only : MOM_error=>MOM_err, NOTE, FATAL, WARNING
 
@@ -397,15 +396,11 @@ subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
 
-  integer :: is, ie, js, je
-
   call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
                  timelevel=timelevel, position=position)
 
   if (present(scale)) then ; if (scale /= 1.0) then
-    call get_simple_array_i_ind(MOM_Domain, size(data,1), is, ie)
-    call get_simple_array_j_ind(MOM_Domain, size(data,2), js, je)
-    data(is:ie,js:je) = scale*data(is:ie,js:je)
+    call rescale_comp_data(MOM_Domain, data, scale)
   endif ; endif
 
 end subroutine MOM_read_data_2d
@@ -439,8 +434,12 @@ subroutine MOM_read_data_2d_region(filename, fieldname, data, start, nread, MOM_
   endif
 
   if (present(scale)) then ; if (scale /= 1.0) then
-    ! Dangerously rescale the whole array
-    data(:,:) = scale*data(:,:)
+    if (present(MOM_Domain)) then
+      call rescale_comp_data(MOM_Domain, data, scale)
+    else
+      ! Dangerously rescale the whole array
+      data(:,:) = scale*data(:,:)
+    endif
   endif ; endif
 
 end subroutine MOM_read_data_2d_region
@@ -460,15 +459,11 @@ subroutine MOM_read_data_3d(filename, fieldname, data, MOM_Domain, &
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
 
-  integer :: is, ie, js, je
-
   call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
                  timelevel=timelevel, position=position)
 
   if (present(scale)) then ; if (scale /= 1.0) then
-    call get_simple_array_i_ind(MOM_Domain, size(data,1), is, ie)
-    call get_simple_array_j_ind(MOM_Domain, size(data,2), js, je)
-    data(is:ie,js:je,:) = scale*data(is:ie,js:je,:)
+    call rescale_comp_data(MOM_Domain, data, scale)
   endif ; endif
 
 end subroutine MOM_read_data_3d
@@ -488,15 +483,11 @@ subroutine MOM_read_data_4d(filename, fieldname, data, MOM_Domain, &
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
 
-  integer :: is, ie, js, je
-
   call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
                  timelevel=timelevel, position=position)
 
   if (present(scale)) then ; if (scale /= 1.0) then
-    call get_simple_array_i_ind(MOM_Domain, size(data,1), is, ie)
-    call get_simple_array_j_ind(MOM_Domain, size(data,2), js, je)
-    data(is:ie,js:je,:,:) = scale*data(is:ie,js:je,:,:)
+    call rescale_comp_data(MOM_Domain, data, scale)
   endif ; endif
 
 end subroutine MOM_read_data_4d
@@ -544,7 +535,6 @@ subroutine MOM_read_vector_2d(filename, u_fieldname, v_fieldname, u_data, v_data
   logical,      optional, intent(in)    :: scalar_pair !< If true, a pair of scalars are to be read
   real,         optional, intent(in)    :: scale     !< A scaling factor that the fields are multiplied
                                                      !! by before they are returned.
-  integer :: is, ie, js, je
   integer :: u_pos, v_pos
 
   u_pos = EAST_FACE ; v_pos = NORTH_FACE
@@ -560,12 +550,8 @@ subroutine MOM_read_vector_2d(filename, u_fieldname, v_fieldname, u_data, v_data
                  timelevel=timelevel, position=v_pos)
 
   if (present(scale)) then ; if (scale /= 1.0) then
-    call get_simple_array_i_ind(MOM_Domain, size(u_data,1), is, ie)
-    call get_simple_array_j_ind(MOM_Domain, size(u_data,2), js, je)
-    u_data(is:ie,js:je) = scale*u_data(is:ie,js:je)
-    call get_simple_array_i_ind(MOM_Domain, size(v_data,1), is, ie)
-    call get_simple_array_j_ind(MOM_Domain, size(v_data,2), js, je)
-    v_data(is:ie,js:je) = scale*v_data(is:ie,js:je)
+    call rescale_comp_data(MOM_Domain, u_data, scale)
+    call rescale_comp_data(MOM_Domain, v_data, scale)
   endif ; endif
 
 end subroutine MOM_read_vector_2d
@@ -589,7 +575,6 @@ subroutine MOM_read_vector_3d(filename, u_fieldname, v_fieldname, u_data, v_data
   real,         optional, intent(in)    :: scale     !< A scaling factor that the fields are multiplied
                                                      !! by before they are returned.
 
-  integer :: is, ie, js, je
   integer :: u_pos, v_pos
 
   u_pos = EAST_FACE ; v_pos = NORTH_FACE
@@ -605,12 +590,8 @@ subroutine MOM_read_vector_3d(filename, u_fieldname, v_fieldname, u_data, v_data
                  timelevel=timelevel, position=v_pos)
 
   if (present(scale)) then ; if (scale /= 1.0) then
-    call get_simple_array_i_ind(MOM_Domain, size(u_data,1), is, ie)
-    call get_simple_array_j_ind(MOM_Domain, size(u_data,2), js, je)
-    u_data(is:ie,js:je,:) = scale*u_data(is:ie,js:je,:)
-    call get_simple_array_i_ind(MOM_Domain, size(v_data,1), is, ie)
-    call get_simple_array_j_ind(MOM_Domain, size(v_data,2), js, je)
-    v_data(is:ie,js:je,:) = scale*v_data(is:ie,js:je,:)
+    call rescale_comp_data(MOM_Domain, u_data, scale)
+    call rescale_comp_data(MOM_Domain, v_data, scale)
   endif ; endif
 
 end subroutine MOM_read_vector_3d

--- a/src/framework/MOM_write_cputime.F90
+++ b/src/framework/MOM_write_cputime.F90
@@ -3,11 +3,11 @@ module MOM_write_cputime
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_coms, only : sum_across_PEs, num_pes
+use MOM_coms,          only : sum_across_PEs, num_pes
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, is_root_pe
-use MOM_io, only : open_file, close_file, APPEND_FILE, ASCII_FILE, WRITEONLY_FILE
-use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
-use MOM_time_manager, only : time_type, get_time, operator(>)
+use MOM_io,            only : open_ASCII_file, close_file, APPEND_FILE, WRITEONLY_FILE
+use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
+use MOM_time_manager,  only : time_type, get_time, operator(>)
 
 implicit none ; private
 
@@ -181,11 +181,9 @@ subroutine write_cputime(day, n, CS, nmax, call_end)
   !  Reopen or create a text output file.
   if ((CS%previous_calls == 0) .and. (is_root_pe())) then
     if (day > CS%Start_time) then
-      call open_file(CS%fileCPU_ascii, trim(CS%CPUfile), &
-                     action=APPEND_FILE, form=ASCII_FILE, nohdrs=.true.)
+      call open_ASCII_file(CS%fileCPU_ascii, trim(CS%CPUfile), action=APPEND_FILE)
     else
-      call open_file(CS%fileCPU_ascii, trim(CS%CPUfile), &
-                     action=WRITEONLY_FILE, form=ASCII_FILE, nohdrs=.true.)
+      call open_ASCII_file(CS%fileCPU_ascii, trim(CS%CPUfile), action=WRITEONLY_FILE)
     endif
   endif
 

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -9,7 +9,7 @@ use MOM_error_handler,    only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler,    only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,      only : get_param, read_param, log_param, param_file_type, log_version
 use MOM_io,               only : MOM_read_data, close_file, create_file, fieldtype, file_exists
-use MOM_io,               only : write_field, vardesc, var_desc, SINGLE_FILE, MULTIPLE
+use MOM_io,               only : MOM_write_field, vardesc, var_desc, SINGLE_FILE, MULTIPLE
 use MOM_string_functions, only : slasher, uppercase
 use MOM_unit_scaling,     only : unit_scale_type
 use MOM_variables,        only : thermo_var_ptrs
@@ -526,8 +526,8 @@ subroutine write_vertgrid_file(GV, US, param_file, directory)
 
   call create_file(unit, trim(filepath), vars, 2, fields, SINGLE_FILE, GV=GV)
 
-  call write_field(unit, fields(1), US%R_to_kg_m3*GV%Rlay(:))
-  call write_field(unit, fields(2), US%L_T_to_m_s**2*US%m_to_Z*GV%g_prime(:))
+  call MOM_write_field(unit, fields(1), GV%Rlay, scale=US%R_to_kg_m3)
+  call MOM_write_field(unit, fields(2), GV%g_prime, scale=US%L_T_to_m_s**2*US%m_to_Z)
 
   call close_file(unit)
 

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -8,8 +8,9 @@ use MOM_EOS,              only : calculate_density, EOS_type
 use MOM_error_handler,    only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler,    only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,      only : get_param, read_param, log_param, param_file_type, log_version
-use MOM_io,               only : MOM_read_data, close_file, create_file, fieldtype, file_exists
-use MOM_io,               only : MOM_write_field, vardesc, var_desc, SINGLE_FILE, MULTIPLE
+use MOM_io,               only : close_file, create_file, file_type, fieldtype, file_exists
+use MOM_io,               only : MOM_read_data, MOM_write_field, vardesc, var_desc
+use MOM_io,               only : SINGLE_FILE, MULTIPLE
 use MOM_string_functions, only : slasher, uppercase
 use MOM_unit_scaling,     only : unit_scale_type
 use MOM_variables,        only : thermo_var_ptrs
@@ -517,19 +518,19 @@ subroutine write_vertgrid_file(GV, US, param_file, directory)
   character(len=240) :: filepath
   type(vardesc) :: vars(2)
   type(fieldtype) :: fields(2)
-  integer :: unit
+  type(file_type) :: IO_handle ! The I/O handle of the fileset
 
   filepath = trim(directory) // trim("Vertical_coordinate")
 
   vars(1) = var_desc("R","kilogram meter-3","Target Potential Density",'1','L','1')
   vars(2) = var_desc("g","meter second-2","Reduced gravity",'1','L','1')
 
-  call create_file(unit, trim(filepath), vars, 2, fields, SINGLE_FILE, GV=GV)
+  call create_file(IO_handle, trim(filepath), vars, 2, fields, SINGLE_FILE, GV=GV)
 
-  call MOM_write_field(unit, fields(1), GV%Rlay, scale=US%R_to_kg_m3)
-  call MOM_write_field(unit, fields(2), GV%g_prime, scale=US%L_T_to_m_s**2*US%m_to_Z)
+  call MOM_write_field(IO_handle, fields(1), GV%Rlay, scale=US%R_to_kg_m3)
+  call MOM_write_field(IO_handle, fields(2), GV%g_prime, scale=US%L_T_to_m_s**2*US%m_to_Z)
 
-  call close_file(unit)
+  call close_file(IO_handle)
 
 end subroutine write_vertgrid_file
 

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -11,9 +11,9 @@ use MOM_dyn_horgrid, only : dyn_horgrid_type
 use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser, only : get_param, log_param, param_file_type, log_version
-use MOM_io, only : close_file, create_file, fieldtype, file_exists, field_size, stdout
-use MOM_io, only : MOM_read_data, MOM_read_vector, read_variable, SINGLE_FILE, MULTIPLE
-use MOM_io, only : open_file_to_read, close_file_to_read
+use MOM_io, only : close_file, create_file, file_type, fieldtype, file_exists, field_size
+use MOM_io, only : MOM_read_data, MOM_read_vector, read_variable, stdout
+use MOM_io, only : open_file_to_read, close_file_to_read, SINGLE_FILE, MULTIPLE
 use MOM_io, only : slasher, vardesc, MOM_write_field, var_desc
 use MOM_string_functions, only : uppercase
 use MOM_unit_scaling, only : unit_scale_type
@@ -1189,10 +1189,10 @@ subroutine write_ocean_geometry_file(G, param_file, directory, geom_file, US)
   integer, parameter :: nFlds=23
   type(vardesc) :: vars(nFlds)
   type(fieldtype) :: fields(nFlds)
-  real :: Z_to_m_scale ! A unit conversion factor from Z to m.
-  real :: s_to_T_scale ! A unit conversion factor from T-1 to s-1.
-  real :: L_to_m_scale ! A unit conversion factor from L to m.
-  integer :: unit
+  real :: Z_to_m_scale ! A unit conversion factor from Z to m
+  real :: s_to_T_scale ! A unit conversion factor from T-1 to s-1
+  real :: L_to_m_scale ! A unit conversion factor from L to m
+  type(file_type) :: IO_handle ! The I/O handle of the fileset
   integer :: file_threading
   integer :: nFlds_used
   logical :: multiple_files
@@ -1255,40 +1255,40 @@ subroutine write_ocean_geometry_file(G, param_file, directory, geom_file, US)
   file_threading = SINGLE_FILE
   if (multiple_files) file_threading = MULTIPLE
 
-  call create_file(unit, trim(filepath), vars, nFlds_used, fields, file_threading, dG=G)
+  call create_file(IO_handle, trim(filepath), vars, nFlds_used, fields, file_threading, dG=G)
 
-  call MOM_write_field(unit, fields(1), G%Domain, G%geoLatBu)
-  call MOM_write_field(unit, fields(2), G%Domain, G%geoLonBu)
-  call MOM_write_field(unit, fields(3), G%Domain, G%geoLatT)
-  call MOM_write_field(unit, fields(4), G%Domain, G%geoLonT)
+  call MOM_write_field(IO_handle, fields(1), G%Domain, G%geoLatBu)
+  call MOM_write_field(IO_handle, fields(2), G%Domain, G%geoLonBu)
+  call MOM_write_field(IO_handle, fields(3), G%Domain, G%geoLatT)
+  call MOM_write_field(IO_handle, fields(4), G%Domain, G%geoLonT)
 
-  call MOM_write_field(unit, fields(5), G%Domain, G%bathyT, scale=Z_to_m_scale)
-  call MOM_write_field(unit, fields(6), G%Domain, G%CoriolisBu, scale=s_to_T_scale)
+  call MOM_write_field(IO_handle, fields(5), G%Domain, G%bathyT, scale=Z_to_m_scale)
+  call MOM_write_field(IO_handle, fields(6), G%Domain, G%CoriolisBu, scale=s_to_T_scale)
 
-  call MOM_write_field(unit, fields(7),  G%Domain, G%dxCv, scale=L_to_m_scale)
-  call MOM_write_field(unit, fields(8),  G%Domain, G%dyCu, scale=L_to_m_scale)
-  call MOM_write_field(unit, fields(9),  G%Domain, G%dxCu, scale=L_to_m_scale)
-  call MOM_write_field(unit, fields(10), G%Domain, G%dyCv, scale=L_to_m_scale)
-  call MOM_write_field(unit, fields(11), G%Domain, G%dxT, scale=L_to_m_scale)
-  call MOM_write_field(unit, fields(12), G%Domain, G%dyT, scale=L_to_m_scale)
-  call MOM_write_field(unit, fields(13), G%Domain, G%dxBu, scale=L_to_m_scale)
-  call MOM_write_field(unit, fields(14), G%Domain, G%dyBu, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(7),  G%Domain, G%dxCv, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(8),  G%Domain, G%dyCu, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(9),  G%Domain, G%dxCu, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(10), G%Domain, G%dyCv, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(11), G%Domain, G%dxT, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(12), G%Domain, G%dyT, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(13), G%Domain, G%dxBu, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(14), G%Domain, G%dyBu, scale=L_to_m_scale)
 
-  call MOM_write_field(unit, fields(15), G%Domain, G%areaT, scale=L_to_m_scale**2)
-  call MOM_write_field(unit, fields(16), G%Domain, G%areaBu, scale=L_to_m_scale**2)
+  call MOM_write_field(IO_handle, fields(15), G%Domain, G%areaT, scale=L_to_m_scale**2)
+  call MOM_write_field(IO_handle, fields(16), G%Domain, G%areaBu, scale=L_to_m_scale**2)
 
-  call MOM_write_field(unit, fields(17), G%Domain, G%dx_Cv, scale=L_to_m_scale)
-  call MOM_write_field(unit, fields(18), G%Domain, G%dy_Cu, scale=L_to_m_scale)
-  call MOM_write_field(unit, fields(19), G%Domain, G%mask2dT)
+  call MOM_write_field(IO_handle, fields(17), G%Domain, G%dx_Cv, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(18), G%Domain, G%dy_Cu, scale=L_to_m_scale)
+  call MOM_write_field(IO_handle, fields(19), G%Domain, G%mask2dT)
 
   if (G%bathymetry_at_vel) then
-    call MOM_write_field(unit, fields(20), G%Domain, G%Dblock_u, scale=Z_to_m_scale)
-    call MOM_write_field(unit, fields(21), G%Domain, G%Dopen_u, scale=Z_to_m_scale)
-    call MOM_write_field(unit, fields(22), G%Domain, G%Dblock_v, scale=Z_to_m_scale)
-    call MOM_write_field(unit, fields(23), G%Domain, G%Dopen_v, scale=Z_to_m_scale)
+    call MOM_write_field(IO_handle, fields(20), G%Domain, G%Dblock_u, scale=Z_to_m_scale)
+    call MOM_write_field(IO_handle, fields(21), G%Domain, G%Dopen_u, scale=Z_to_m_scale)
+    call MOM_write_field(IO_handle, fields(22), G%Domain, G%Dblock_v, scale=Z_to_m_scale)
+    call MOM_write_field(IO_handle, fields(23), G%Domain, G%Dopen_v, scale=Z_to_m_scale)
   endif
 
-  call close_file(unit)
+  call close_file(IO_handle)
 
   call callTree_leave('write_ocean_geometry_file()')
 end subroutine write_ocean_geometry_file

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -190,8 +190,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   call get_param(PF, mdl, "DEBUG", debug, default=.false.)
   call get_param(PF, mdl, "DEBUG_OBC", debug_obc, default=.false.)
 
-  new_sim = determine_is_new_run(dirs%input_filename, dirs%restart_input_dir, &
-                                 G, restart_CS)
+  new_sim = determine_is_new_run(dirs%input_filename, dirs%restart_input_dir, G, restart_CS)
   just_read = .not.new_sim
 
   call get_param(PF, mdl, "INPUTDIR", inputdir, &
@@ -485,8 +484,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   if (.not.new_sim) then ! This block restores the state from a restart file.
     !    This line calls a subroutine that reads the initial conditions
     !  from a previously generated file.
-    call restore_state(dirs%input_filename, dirs%restart_input_dir, Time, &
-                       G, restart_CS)
+    call restore_state(dirs%input_filename, dirs%restart_input_dir, Time, G, restart_CS)
     if (present(Time_in)) Time = Time_in
     if ((GV%m_to_H_restart /= 0.0) .and. (GV%m_to_H_restart /= GV%m_to_H)) then
       H_rescale = GV%m_to_H / GV%m_to_H_restart


### PR DESCRIPTION
  Revised the interfaces for I/O to prepare for the substantial differences
between the FMS1 and FMS2 interfaces, by adding a MOM6-specific file_type,
clearly separating calls for ASCII file I/O and netCDF I/O, and other related
changes. Although there are nontrivial I/O interface changes, all answers and
output files are bitwise identical.  The commits in this PR include:

- NOAA-GFDL/MOM6@21c269684 +Use file_type as the handle for I/O
- NOAA-GFDL/MOM6@76b9ffa80 Simplify write_ocean_geometry_file
- NOAA-GFDL/MOM6@ae9995c6a +Add rescale_comp_data & scale to MOM_write_field
- NOAA-GFDL/MOM6@27cd1c44f +Added open_ASCII_file