### PR TITLE
*Bugfix for ALE sponges (pass non-zero target thickness to remapping)

### DIFF
--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -964,11 +964,9 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
 
         call remapping_core_h(CS%remap_cs, nz_data, CS%Ref_val(m)%h(1:nz_data,c), tmp_val2, &
              CS%nz, h(i,j,:), tmp_val1, h_neglect, h_neglect_edge)
-         print *,'calling remapping_core_h',h(i,j,:),tmp_val2(:),tmp_val1(:)
       else
         call remapping_core_h(CS%remap_cs, nz_data, CS%Ref_h%p(1:nz_data,c), tmp_val2, &
              CS%nz, h(i,j,:), tmp_val1, h_neglect, h_neglect_edge)
-         print *,'Calling remapping_core_h',h(i,j,1),tmp_val1(1)
       endif
       !Backward Euler method
       if (CS%id_sp_tendency(m) > 0) tmp(i,j,1:nz) = CS%var(m)%p(i,j,1:nz)

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -961,11 +961,14 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
       I1pdamp = 1.0 / (1.0 + damp)
       tmp_val2(1:nz_data) = CS%Ref_val(m)%p(1:nz_data,c)
       if (CS%time_varying_sponges) then
+
         call remapping_core_h(CS%remap_cs, nz_data, CS%Ref_val(m)%h(1:nz_data,c), tmp_val2, &
-                              CS%nz, h_col, tmp_val1, h_neglect, h_neglect_edge)
+             CS%nz, h(i,j,:), tmp_val1, h_neglect, h_neglect_edge)
+         print *,'calling remapping_core_h',h(i,j,:),tmp_val2(:),tmp_val1(:)
       else
         call remapping_core_h(CS%remap_cs, nz_data, CS%Ref_h%p(1:nz_data,c), tmp_val2, &
-                              CS%nz, h_col, tmp_val1, h_neglect, h_neglect_edge)
+             CS%nz, h(i,j,:), tmp_val1, h_neglect, h_neglect_edge)
+         print *,'Calling remapping_core_h',h(i,j,1),tmp_val1(1)
       endif
       !Backward Euler method
       if (CS%id_sp_tendency(m) > 0) tmp(i,j,1:nz) = CS%var(m)%p(i,j,1:nz)

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -960,13 +960,16 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
       damp = dt * CS%Iresttime_col(c)
       I1pdamp = 1.0 / (1.0 + damp)
       tmp_val2(1:nz_data) = CS%Ref_val(m)%p(1:nz_data,c)
+      do k=1,nz
+        h_col(k)=h(i,j,k)
+      enddo
       if (CS%time_varying_sponges) then
 
         call remapping_core_h(CS%remap_cs, nz_data, CS%Ref_val(m)%h(1:nz_data,c), tmp_val2, &
-             CS%nz, h(i,j,:), tmp_val1, h_neglect, h_neglect_edge)
+             CS%nz, h_col, tmp_val1, h_neglect, h_neglect_edge)
       else
         call remapping_core_h(CS%remap_cs, nz_data, CS%Ref_h%p(1:nz_data,c), tmp_val2, &
-             CS%nz, h(i,j,:), tmp_val1, h_neglect, h_neglect_edge)
+             CS%nz, h_col, tmp_val1, h_neglect, h_neglect_edge)
       endif
       !Backward Euler method
       if (CS%id_sp_tendency(m) > 0) tmp(i,j,1:nz) = CS%var(m)%p(i,j,1:nz)


### PR DESCRIPTION
	- this addresses a bug in the apply_ALE_sponge routine which
  	had been passing zero values to the remapping routine for the
	target grid thicknesses. This bug was identified by @abocez 