### PR TITLE
Bugfix: empty restart_input_dir for *_solo.res

### DIFF
--- a/config_src/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/ice_solo_driver/ice_shelf_driver.F90
@@ -185,6 +185,8 @@ program Shelf_main
     endif
   endif
 
+  call Get_MOM_Input(param_file, dirs)
+
   ! Read ocean_solo restart, which can override settings from the namelist.
   if (file_exists(trim(dirs%restart_input_dir)//'ice_solo.res')) then
     call open_ASCII_file(unit, trim(dirs%restart_input_dir)//'ice_solo.res', action=READONLY_FILE)
@@ -215,7 +217,6 @@ program Shelf_main
     Start_time = real_to_time(0.0)
   endif
 
-  call Get_MOM_Input(param_file, dirs)
   ! Determining the internal unit scaling factors for this run.
   call unit_scaling_init(param_file, US)
 

--- a/config_src/solo_driver/MOM_driver.F90
+++ b/config_src/solo_driver/MOM_driver.F90
@@ -250,6 +250,10 @@ program MOM_main
   ! This call sets the number and affinity of threads with openMP.
   !$  call set_MOM_thread_affinity(ocean_nthreads, use_hyper_thread)
 
+  ! This call is required to initiate dirs%restart_input_dir for ocean_solo.res
+  ! The contents of dirs will be reread in initialize_MOM.
+  call get_MOM_input(dirs=dirs)
+
   ! Read ocean_solo restart, which can override settings from the namelist.
   if (file_exists(trim(dirs%restart_input_dir)//'ocean_solo.res')) then
     call open_ASCII_file(unit, trim(dirs%restart_input_dir)//'ocean_solo.res', action=READONLY_FILE)


### PR DESCRIPTION
The ocean/ice solo drivers look for "ocean_solo.res" and "ice_solo.res" in `dirs%restart_input_dir`. However, `dirs` is only initiated after the call of `file_exist` for the ".res" files.

This PR fixes this issue (https://github.com/NOAA-GFDL/MOM6/issues/1313) by moving `get_MOM_input` in `ice_self_driver.F90` and adding an additional `get_MOM_input` in `MOM_driver.F90`, respectively. 