### PR TITLE
Explicitly set (1x1) io_domain as a default

### DIFF
--- a/config_src/infra/FMS1/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS1/MOM_diag_manager_infra.F90
@@ -20,9 +20,9 @@ use diag_manager_mod, only : DIAG_FIELD_NOT_FOUND
 use diag_manager_mod, only : register_diag_field_fms => register_diag_field
 use diag_manager_mod, only : register_static_field_fms => register_static_field
 use diag_manager_mod, only : get_diag_field_id_fms => get_diag_field_id
-use time_manager_mod, only : time_type
+use MOM_time_manager, only : time_type
 use MOM_domain_infra, only : MOM_domain_type
-use MOM_error_handler, only : MOM_error, FATAL, WARNING
+use MOM_error_infra,  only : MOM_error => MOM_err, FATAL, WARNING
 
 implicit none ; private
 

--- a/config_src/infra/FMS1/MOM_domain_infra.F90
+++ b/config_src/infra/FMS1/MOM_domain_infra.F90
@@ -4,7 +4,7 @@ module MOM_domain_infra
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_coms_infra,  only : PE_here, root_PE, num_PEs
-use MOM_cpu_clock,   only : cpu_clock_begin, cpu_clock_end
+use MOM_cpu_clock_infra, only : cpu_clock_begin, cpu_clock_end
 use MOM_error_infra, only : MOM_error=>MOM_err, NOTE, WARNING, FATAL
 
 use mpp_domains_mod, only : domain2D, domain1D
@@ -1689,6 +1689,8 @@ subroutine clone_MD_to_d2D(MD_in, mpp_domain, min_halo, halo_size, symmetric, &
   if ((MD_in%io_layout(1) + MD_in%io_layout(2) > 0) .and. &
       (MD_in%layout(1)*MD_in%layout(2) > 1)) then
     call mpp_define_io_domain(mpp_domain, MD_in%io_layout)
+  else
+    call mpp_define_io_domain(mpp_domain, (/ 1, 1 /) )
   endif
 
 end subroutine clone_MD_to_d2D


### PR DESCRIPTION
  Added code to explicitly set a (1x1) io_domain when no other io_layout is
specified, complying with changing requirements for 2020 and later versions of
FMS, and following the default behavior of previous versions.  Also corrected
three module use statements in infra/FMS1 to eliminate any dependencies of code
in config_src/infra/FMS1 on code in src/framework.  These use statements
eventually point to the same place as before, but with less indirection.  This
change should facilitate later steps to compile everything in and under the
config_src/infra directories as libraries.  All answers are bitwise identical.

  This change will allow MOM6 to work with newer versions of FMS than 2019.01.03, and
it will enable efforts to debug why these newer versions are giving unexpected runtime
errors with the PGI 19.10.0 compiler.