### PR TITLE
+Enhanced support for novel axes in MOM_io

### DIFF
--- a/config_src/infra/FMS1/MOM_io_infra.F90
+++ b/config_src/infra/FMS1/MOM_io_infra.F90
@@ -78,7 +78,7 @@ end interface MOM_read_vector
 
 !> Write metadata about a variable or axis to a file and store it for later reuse
 interface write_metadata
-  module procedure write_metadata_axis, write_metadata_field
+  module procedure write_metadata_axis, write_metadata_field, write_metadata_global
 end interface write_metadata
 
 !> Close a file (or fileset).  If the file handle does not point to an open file,
@@ -792,5 +792,14 @@ subroutine write_metadata_field(IO_handle, field, axes, name, units, longname, &
   ! unused opt. args: min=min, max=max, fill=fill, scale=scale, add=add, &
 
 end subroutine write_metadata_field
+
+!> Write a global text attribute to a file.
+subroutine write_metadata_global(IO_handle, name, attribute)
+  type(file_type),            intent(in)    :: IO_handle !< Handle for a file that is open for writing
+  character(len=*),           intent(in)    :: name      !< The name in the file of this global attribute
+  character(len=*),           intent(in)    :: attribute !< The value of this attribute
+
+  call mpp_write_meta(IO_handle%unit, name, cval=attribute)
+end subroutine write_metadata_global
 
 end module MOM_io_infra


### PR DESCRIPTION
  Added support for new IO capabilities that are needed by SIS2 to use the MOM6
framework and infrastructure code, but should also be useful within MOM6
itself.  These new capabilities include writing global attributes to files,
using create_file named axes that are not derived from a MOM6 grid type, and new
options and elements in the vardesc type to support a wider array of axes and to
provide the position of the grid staggering via an integer position variable
instead of the short character strings that had been used.

  As a part of this commit, there are the new opaques type axis_info and
attribute_info, and the new routines set_axis_info, delete_axis_info,
set_attribute_info and delete_attribute_info to facilitate these new
capabilities, as well as the publicly visible function position_from_horgrid to
translate the vardesc%hor_grid character strings into the integer position flag
used elsewhere in the MOM6 and FMS codes.  Within the MOM_io_infra, there is a
new variant of the overloaded interface write_meta to handle writing global
attributes. There are also two new optional arguments to create_file and
reopen_file, and two new optional arguments to var_desc, modify_vardesc, and
query_vardesc.  All answers and output are bitwise identical.