### PR TITLE
+Make MOM_read_data work when 4-d arrays exist

### DIFF
--- a/config_src/infra/FMS1/MOM_io_infra.F90
+++ b/config_src/infra/FMS1/MOM_io_infra.F90
@@ -11,7 +11,7 @@ use fms_mod,              only : write_version_number, open_namelist_file, check
 use fms_io_mod,           only : file_exist, field_exist, field_size, read_data
 use fms_io_mod,           only : fms_io_exit, get_filename_appendix
 use mpp_io_mod,           only : mpp_open, mpp_close, mpp_flush
-use mpp_io_mod,           only : mpp_write_meta, mpp_write
+use mpp_io_mod,           only : mpp_write_meta, mpp_write, mpp_read
 use mpp_io_mod,           only : mpp_get_atts, mpp_attribute_exist
 use mpp_io_mod,           only : mpp_get_axes, axistype, mpp_get_axis_data
 use mpp_io_mod,           only : mpp_get_fields, fieldtype
@@ -22,6 +22,7 @@ use mpp_io_mod,           only : APPEND_FILE=>MPP_APPEND, WRITEONLY_FILE=>MPP_WR
 use mpp_io_mod,           only : OVERWRITE_FILE=>MPP_OVERWR, READONLY_FILE=>MPP_RDONLY
 use mpp_io_mod,           only : NETCDF_FILE=>MPP_NETCDF, ASCII_FILE=>MPP_ASCII
 use mpp_io_mod,           only : MULTIPLE=>MPP_MULTI, SINGLE_FILE=>MPP_SINGLE
+use mpp_mod,              only : lowercase
 use iso_fortran_env,      only : int64
 
 implicit none ; private
@@ -413,7 +414,7 @@ end subroutine get_axis_data
 
 !> This routine uses the fms_io subroutine read_data to read a scalar named
 !! "fieldname" from a single or domain-decomposed file "filename".
-subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Domain)
+subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Domain, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real,                   intent(inout) :: data      !< The 1-dimensional array into which the data
@@ -422,8 +423,36 @@ subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Dom
                                                      !! by before it is returned.
   type(MOM_domain_type), &
                 optional, intent(in)    :: MOM_Domain !< The MOM_Domain that describes the decomposition
+  logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays,
+                                                     !! in which case a more elaborate set of calls
+                                                     !! is needed to read it due to FMS limitations.
 
-  if (present(MOM_Domain)) then
+  ! Local variables
+  character(len=80)  :: varname             ! The name of a variable in the file
+  type(fieldtype), allocatable :: fields(:) ! An array of types describing all the variables in the file
+  logical :: use_fms_read_data
+  integer :: n, unit, ndim, nvar, natt, ntime
+
+  use_fms_read_data = .true. ; if (present(file_may_be_4d)) use_fms_read_data = .not.file_may_be_4d
+
+  if (.not.use_fms_read_data) then
+    call mpp_open(unit, trim(filename), form=NETCDF_FILE, action=READONLY_FILE, &
+                  threading=MULTIPLE, fileset=SINGLE_FILE) !, domain=MOM_Domain%mpp_domain )
+    call mpp_get_info(unit, ndim, nvar, natt, ntime)
+    allocate(fields(nvar))
+    call mpp_get_fields(unit, fields(1:nvar))
+    do n=1, nvar
+      call mpp_get_atts(fields(n), name=varname)
+      if (lowercase(trim(varname)) == lowercase(trim(fieldname))) then
+        ! Maybe something should be done depending on the value of ntime.
+        call mpp_read(unit, fields(n), data, timelevel)
+        exit
+      endif
+    enddo
+
+    deallocate(fields)
+    call mpp_close(unit)
+  elseif (present(MOM_Domain)) then
     call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, timelevel=timelevel)
   else
     call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
@@ -437,7 +466,7 @@ end subroutine MOM_read_data_0d
 
 !> This routine uses the fms_io subroutine read_data to read a 1-D data field named
 !! "fieldname" from a single or domain-decomposed file "filename".
-subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Domain)
+subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Domain, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:),     intent(inout) :: data      !< The 1-dimensional array into which the data
@@ -446,8 +475,36 @@ subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Dom
                                                      !! by before they are returned.
   type(MOM_domain_type), &
                 optional, intent(in)    :: MOM_Domain !< The MOM_Domain that describes the decomposition
+  logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays,
+                                                     !! in which case a more elaborate set of calls
+                                                     !! is needed to read it due to FMS limitations.
 
-  if (present(MOM_Domain)) then
+  ! Local variables
+  character(len=80)  :: varname             ! The name of a variable in the file
+  type(fieldtype), allocatable :: fields(:) ! An array of types describing all the variables in the file
+  logical :: use_fms_read_data
+  integer :: n, unit, ndim, nvar, natt, ntime
+
+  use_fms_read_data = .true. ; if (present(file_may_be_4d)) use_fms_read_data = .not.file_may_be_4d
+
+  if (.not.use_fms_read_data) then
+    call mpp_open(unit, trim(filename), form=NETCDF_FILE, action=READONLY_FILE, &
+                  threading=MULTIPLE, fileset=SINGLE_FILE) !, domain=MOM_Domain%mpp_domain )
+    call mpp_get_info(unit, ndim, nvar, natt, ntime)
+    allocate(fields(nvar))
+    call mpp_get_fields(unit, fields(1:nvar))
+    do n=1, nvar
+      call mpp_get_atts(fields(n), name=varname)
+      if (lowercase(trim(varname)) == lowercase(trim(fieldname))) then
+        ! Maybe something should be done depending on the value of ntime.
+        call mpp_read(unit, fields(n), data, timelevel)
+        exit
+      endif
+    enddo
+
+    deallocate(fields)
+    call mpp_close(unit)
+  elseif (present(MOM_Domain)) then
     call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, timelevel=timelevel)
   else
     call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
@@ -463,7 +520,7 @@ end subroutine MOM_read_data_1d
 !! 2-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
-                            timelevel, position, scale)
+                            timelevel, position, scale, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:,:),   intent(inout) :: data      !< The 2-dimensional array into which the data
@@ -473,9 +530,39 @@ subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
   integer,      optional, intent(in)    :: position  !< A flag indicating where this data is located
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
+  logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays,
+                                                     !! in which case a more elaborate set of calls
+                                                     !! is needed to read it due to FMS limitations.
 
-  call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
-                 timelevel=timelevel, position=position)
+  ! Local variables
+  character(len=80)  :: varname             ! The name of a variable in the file
+  type(fieldtype), allocatable :: fields(:) ! An array of types describing all the variables in the file
+  logical :: use_fms_read_data
+  integer :: n, unit, ndim, nvar, natt, ntime
+
+  use_fms_read_data = .true. ; if (present(file_may_be_4d)) use_fms_read_data = .not.file_may_be_4d
+
+  if (use_fms_read_data) then
+    call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
+                   timelevel=timelevel, position=position)
+  else
+    call mpp_open(unit, trim(filename), form=NETCDF_FILE, action=READONLY_FILE, &
+                  threading=MULTIPLE, fileset=SINGLE_FILE) !, domain=MOM_Domain%mpp_domain )
+    call mpp_get_info(unit, ndim, nvar, natt, ntime)
+    allocate(fields(nvar))
+    call mpp_get_fields(unit, fields(1:nvar))
+    do n=1, nvar
+      call mpp_get_atts(fields(n), name=varname)
+      if (lowercase(trim(varname)) == lowercase(trim(fieldname))) then
+        ! Maybe something should be done depending on the value of ntime.
+        call mpp_read(unit, fields(n), MOM_Domain%mpp_domain, data, timelevel)
+        exit
+      endif
+    enddo
+
+    deallocate(fields)
+    call mpp_close(unit)
+  endif
 
   if (present(scale)) then ; if (scale /= 1.0) then
     call rescale_comp_data(MOM_Domain, data, scale)
@@ -526,7 +613,7 @@ end subroutine MOM_read_data_2d_region
 !! 3-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_3d(filename, fieldname, data, MOM_Domain, &
-                            timelevel, position, scale)
+                            timelevel, position, scale, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:,:,:), intent(inout) :: data      !< The 3-dimensional array into which the data
@@ -536,9 +623,39 @@ subroutine MOM_read_data_3d(filename, fieldname, data, MOM_Domain, &
   integer,      optional, intent(in)    :: position  !< A flag indicating where this data is located
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
+  logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays,
+                                                     !! in which case a more elaborate set of calls
+                                                     !! is needed to read it due to FMS limitations.
 
-  call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
-                 timelevel=timelevel, position=position)
+  ! Local variables
+  character(len=80)  :: varname             ! The name of a variable in the file
+  type(fieldtype), allocatable :: fields(:) ! An array of types describing all the variables in the file
+  logical :: use_fms_read_data
+  integer :: n, unit, ndim, nvar, natt, ntime
+
+  use_fms_read_data = .true. ; if (present(file_may_be_4d)) use_fms_read_data = .not.file_may_be_4d
+
+  if (use_fms_read_data) then
+    call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
+                   timelevel=timelevel, position=position)
+  else
+    call mpp_open(unit, trim(filename), form=NETCDF_FILE, action=READONLY_FILE, &
+                  threading=MULTIPLE, fileset=SINGLE_FILE) !, domain=MOM_Domain%mpp_domain )
+    call mpp_get_info(unit, ndim, nvar, natt, ntime)
+    allocate(fields(nvar))
+    call mpp_get_fields(unit, fields(1:nvar))
+    do n=1, nvar
+      call mpp_get_atts(fields(n), name=varname)
+      if (lowercase(trim(varname)) == lowercase(trim(fieldname))) then
+        ! Maybe something should be done depending on the value of ntime.
+        call mpp_read(unit, fields(n), MOM_Domain%mpp_domain, data, timelevel)
+        exit
+      endif
+    enddo
+
+    deallocate(fields)
+    call mpp_close(unit)
+  endif
 
   if (present(scale)) then ; if (scale /= 1.0) then
     call rescale_comp_data(MOM_Domain, data, scale)
@@ -561,8 +678,34 @@ subroutine MOM_read_data_4d(filename, fieldname, data, MOM_Domain, &
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
 
-  call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
-                 timelevel=timelevel, position=position)
+  ! Local variables
+  character(len=80)  :: varname             ! The name of a variable in the file
+  type(fieldtype), allocatable :: fields(:) ! An array of types describing all the variables in the file
+  logical :: use_fms_read_data
+  integer :: n, unit, ndim, nvar, natt, ntime
+  integer :: is, ie, js, je
+
+  ! This single call does not work for a 4-d array due to FMS limitations, so multiple calls are
+  ! needed.
+  ! call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
+  !                timelevel=timelevel, position=position)
+
+  call mpp_open(unit, trim(filename), form=NETCDF_FILE, action=READONLY_FILE, &
+                threading=MULTIPLE, fileset=SINGLE_FILE) !, domain=MOM_Domain%mpp_domain )
+  call mpp_get_info(unit, ndim, nvar, natt, ntime)
+  allocate(fields(nvar))
+  call mpp_get_fields(unit, fields(1:nvar))
+  do n=1, nvar
+    call mpp_get_atts(fields(n), name=varname)
+    if (lowercase(trim(varname)) == lowercase(trim(fieldname))) then
+      ! Maybe something should be done depending on the value of ntime.
+      call mpp_read(unit, fields(n), MOM_Domain%mpp_domain, data, timelevel)
+      exit
+    endif
+  enddo
+
+  deallocate(fields)
+  call mpp_close(unit)
 
   if (present(scale)) then ; if (scale /= 1.0) then
     call rescale_comp_data(MOM_Domain, data, scale)

--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -655,7 +655,8 @@ end subroutine get_axis_data
 
 !> This routine uses the fms_io subroutine read_data to read a scalar named
 !! "fieldname" from a single or domain-decomposed file "filename".
-subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Domain, file_may_be_4d)
+subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Domain, &
+                            global_file, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real,                   intent(inout) :: data      !< The 1-dimensional array into which the data
@@ -664,6 +665,7 @@ subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Dom
                                                      !! by before it is returned.
   type(MOM_domain_type), &
                 optional, intent(in)    :: MOM_Domain !< The MOM_Domain that describes the decomposition
+  logical,      optional, intent(in)    :: global_file !< If true, read from a single global file
   logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays, but
                                                      !! with the FMS2 I/O interfaces this does not matter.
 
@@ -725,7 +727,8 @@ end subroutine MOM_read_data_0d
 
 !> This routine uses the fms_io subroutine read_data to read a 1-D data field named
 !! "fieldname" from a single or domain-decomposed file "filename".
-subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Domain, file_may_be_4d)
+subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Domain, &
+                            global_file, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:),     intent(inout) :: data      !< The 1-dimensional array into which the data
@@ -734,6 +737,7 @@ subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Dom
                                                      !! by before they are returned.
   type(MOM_domain_type), &
                 optional, intent(in)    :: MOM_Domain !< The MOM_Domain that describes the decomposition
+  logical,      optional, intent(in)    :: global_file !< If true, read from a single global file
   logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays, but
                                                      !! with the FMS2 I/O interfaces this does not matter.
 
@@ -797,7 +801,7 @@ end subroutine MOM_read_data_1d
 !! 2-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
-                            timelevel, position, scale, file_may_be_4d)
+                            timelevel, position, scale, global_file, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:,:),   intent(inout) :: data      !< The 2-dimensional array into which the data
@@ -807,6 +811,7 @@ subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
   integer,      optional, intent(in)    :: position  !< A flag indicating where this data is located
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
+  logical,      optional, intent(in)    :: global_file !< If true, read from a single global file
   logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays, but
                                                      !! with the FMS2 I/O interfaces this does not matter.
 
@@ -922,7 +927,7 @@ end subroutine MOM_read_data_2d_region
 !! 3-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_3d(filename, fieldname, data, MOM_Domain, &
-                            timelevel, position, scale, file_may_be_4d)
+                            timelevel, position, scale, global_file, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:,:,:), intent(inout) :: data      !< The 3-dimensional array into which the data
@@ -932,6 +937,7 @@ subroutine MOM_read_data_3d(filename, fieldname, data, MOM_Domain, &
   integer,      optional, intent(in)    :: position  !< A flag indicating where this data is located
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
+  logical,      optional, intent(in)    :: global_file !< If true, read from a single global file
   logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays, but
                                                      !! with the FMS2 I/O interfaces this does not matter.
 
@@ -974,7 +980,7 @@ end subroutine MOM_read_data_3d
 !! 4-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_4d(filename, fieldname, data, MOM_Domain, &
-                            timelevel, position, scale)
+                            timelevel, position, scale, global_file)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:,:,:,:), intent(inout) :: data    !< The 4-dimensional array into which the data
@@ -984,6 +990,7 @@ subroutine MOM_read_data_4d(filename, fieldname, data, MOM_Domain, &
   integer,      optional, intent(in)    :: position  !< A flag indicating where this data is located
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
+  logical,      optional, intent(in)    :: global_file !< If true, read from a single global file
 
 
   ! Local variables

--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -655,7 +655,7 @@ end subroutine get_axis_data
 
 !> This routine uses the fms_io subroutine read_data to read a scalar named
 !! "fieldname" from a single or domain-decomposed file "filename".
-subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Domain)
+subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Domain, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real,                   intent(inout) :: data      !< The 1-dimensional array into which the data
@@ -664,6 +664,8 @@ subroutine MOM_read_data_0d(filename, fieldname, data, timelevel, scale, MOM_Dom
                                                      !! by before it is returned.
   type(MOM_domain_type), &
                 optional, intent(in)    :: MOM_Domain !< The MOM_Domain that describes the decomposition
+  logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays, but
+                                                     !! with the FMS2 I/O interfaces this does not matter.
 
   ! Local variables
   type(FmsNetcdfFile_t)       :: fileObj ! A handle to a non-domain-decomposed file
@@ -723,7 +725,7 @@ end subroutine MOM_read_data_0d
 
 !> This routine uses the fms_io subroutine read_data to read a 1-D data field named
 !! "fieldname" from a single or domain-decomposed file "filename".
-subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Domain)
+subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Domain, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:),     intent(inout) :: data      !< The 1-dimensional array into which the data
@@ -732,6 +734,8 @@ subroutine MOM_read_data_1d(filename, fieldname, data, timelevel, scale, MOM_Dom
                                                      !! by before they are returned.
   type(MOM_domain_type), &
                 optional, intent(in)    :: MOM_Domain !< The MOM_Domain that describes the decomposition
+  logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays, but
+                                                     !! with the FMS2 I/O interfaces this does not matter.
 
   ! Local variables
   type(FmsNetcdfFile_t)       :: fileObj ! A handle to a non-domain-decomposed file
@@ -793,7 +797,7 @@ end subroutine MOM_read_data_1d
 !! 2-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
-                            timelevel, position, scale)
+                            timelevel, position, scale, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:,:),   intent(inout) :: data      !< The 2-dimensional array into which the data
@@ -803,6 +807,8 @@ subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
   integer,      optional, intent(in)    :: position  !< A flag indicating where this data is located
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
+  logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays, but
+                                                     !! with the FMS2 I/O interfaces this does not matter.
 
   ! Local variables
   type(FmsNetcdfDomainFile_t) :: fileobj ! A handle to a domain-decomposed file object
@@ -916,7 +922,7 @@ end subroutine MOM_read_data_2d_region
 !! 3-D data field named "fieldname" from file "filename".  Valid values for
 !! "position" include CORNER, CENTER, EAST_FACE and NORTH_FACE.
 subroutine MOM_read_data_3d(filename, fieldname, data, MOM_Domain, &
-                            timelevel, position, scale)
+                            timelevel, position, scale, file_may_be_4d)
   character(len=*),       intent(in)    :: filename  !< The name of the file to read
   character(len=*),       intent(in)    :: fieldname !< The variable name of the data in the file
   real, dimension(:,:,:), intent(inout) :: data      !< The 3-dimensional array into which the data
@@ -926,6 +932,8 @@ subroutine MOM_read_data_3d(filename, fieldname, data, MOM_Domain, &
   integer,      optional, intent(in)    :: position  !< A flag indicating where this data is located
   real,         optional, intent(in)    :: scale     !< A scaling factor that the field is multiplied
                                                      !! by before it is returned.
+  logical,      optional, intent(in)    :: file_may_be_4d !< If true, this file may have 4-d arrays, but
+                                                     !! with the FMS2 I/O interfaces this does not matter.
 
   ! Local variables
   type(FmsNetcdfDomainFile_t) :: fileobj ! A handle to a domain-decomposed file object


### PR DESCRIPTION
  Added internal branches of the infra/FMS1 version of MOM_read_data that work
when there are 4-d arrays with a fifth time dimension in the file that is being
read, which was previously failing even if the variable that is being read has
fewer dimensions, due to code limitations within the fms_io read_data routines.
These new branches are selected via the new optional argument file_may_be_4d.
The infra/FMS2 versions also have the same new optional argument, although in
that case it does nothing.  All answers are bitwise identical in the cases that
worked previously, but SIS2 restart files can now be read via the MOM6
infrastructure interfaces.