### PR TITLE
Display hash of submodules in gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,10 @@ setup:
     - test -d MOM6-examples/src/LM3 || make -f MRS/Makefile.clone clone_gfdl -s
     - make -f MRS/Makefile.clone MOM6-examples/.datasets -s
     - env > gitlab_session.log
+    # Show hashes for final setup
+    - git show --oneline
+    - git submodule status
+    - (cd MOM6-examples && git submodule status --recursive src)
     # Cache everything under tests to unpack for each subsequent stage
     - cd ../ ; time tar zcf $CACHE_DIR/tests_$CI_PIPELINE_ID.tgz tests
 


### PR DESCRIPTION
- This adds a few git commands at the end of the "setup" job in the gitlab pipeline to show the hash of every submodule we care about.
- We recently found it hard to retroactively figure out the exact state of the pipeline because it updates to the latest of MOM6-examples at the time of running, and that might change between the run and when you examine the logs.
