### PR TITLE
.testing: Create python venv at compile time

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -193,7 +193,7 @@ endif
 # Rules
 
 .PHONY: all build.regressions
-all: $(foreach b,$(BUILDS),build/$(b)/MOM6)
+all: $(foreach b,$(BUILDS),build/$(b)/MOM6) $(VENV_PATH)
 build.regressions: $(foreach b,symmetric target,build/$(b)/MOM6)
 
 # Executable
@@ -361,6 +361,7 @@ check_mom6_api_mct: build/mct/mom_ocean_model_mct.o
 work/local-env:
 	python3 -m venv $@
 	. $@/bin/activate \
+	  && python3 -m pip install --upgrade pip \
 	  && pip3 install wheel \
 	  && pip3 install cython \
 	  && pip3 install numpy \


### PR DESCRIPTION
This patch shifts the creation of the python virtual environment to a
compile-time operation.

The .testing suite creates a Python virtual environment (venv) if the
current environment does not include numpy and the Python netCDF4
modules.

These are detected and set up at runtime rather than compile time, which
can cause issues when run on compile nodes which do not have internet
access since the packages need to be downloaded via Pip.

This patch moves the detection and creation to compile time.  Since
internet access is expected for FMS and mkmf setup, it is consistent to
assume internet access for pip installations.