### PR TITLE
infra, FMS_cap: stdout_if_root()

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -27,7 +27,8 @@ use MOM_get_input,        only : Get_MOM_Input, directories
 use MOM_grid,             only : ocean_grid_type
 use MOM_interpolate,      only : init_external_field, time_interp_external
 use MOM_interpolate,      only : time_interp_external_init
-use MOM_io,               only : slasher, write_version_number, MOM_read_data, stdout
+use MOM_io,               only : slasher, write_version_number, MOM_read_data
+use MOM_io,               only : stdout_if_root
 use MOM_restart,          only : register_restart_field, restart_init, MOM_restart_CS
 use MOM_restart,          only : restart_init_end, save_restart, restore_state
 use MOM_string_functions, only : uppercase
@@ -1628,8 +1629,8 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
   logical :: root    ! True only on the root PE
   integer :: outunit ! The output unit to write to
 
-  outunit = stdout
   root = is_root_pe()
+  outunit = stdout_if_root()
 
   if (root) write(outunit,*) "BEGIN CHECKSUM(ice_ocean_boundary_type):: ", id, timestep
   chks = field_chksum( iobt%u_flux         ) ; if (root) write(outunit,100) 'iobt%u_flux         ', chks

--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -35,7 +35,7 @@ use MOM_forcing_type, only : copy_back_forcing_fields
 use MOM_forcing_type, only : forcing_diagnostics, mech_forcing_diags
 use MOM_get_input, only : Get_MOM_Input, directories
 use MOM_grid, only : ocean_grid_type
-use MOM_io, only : write_version_number, stdout
+use MOM_io, only : write_version_number, stdout_if_root
 use MOM_marine_ice, only : iceberg_forces, iceberg_fluxes, marine_ice_init, marine_ice_CS
 use MOM_restart, only : MOM_restart_CS, save_restart
 use MOM_string_functions, only : uppercase
@@ -1107,8 +1107,8 @@ subroutine ocean_public_type_chksum(id, timestep, ocn)
   logical :: root    ! True only on the root PE
   integer :: outunit ! The output unit to write to
 
-  outunit = stdout
   root = is_root_pe()
+  outunit = stdout_if_root()
 
   if (root) write(outunit,*) "BEGIN CHECKSUM(ocean_type):: ", id, timestep
   chks = field_chksum(ocn%t_surf ) ; if (root) write(outunit,100) 'ocean%t_surf   ', chks

--- a/config_src/infra/FMS1/MOM_io_infra.F90
+++ b/config_src/infra/FMS1/MOM_io_infra.F90
@@ -17,6 +17,7 @@ use mpp_io_mod,           only : mpp_get_axes, axistype, mpp_get_axis_data
 use mpp_io_mod,           only : mpp_get_fields, fieldtype
 use mpp_io_mod,           only : mpp_get_info, mpp_get_times
 use mpp_io_mod,           only : mpp_io_init
+use mpp_mod,              only : stdout_if_root=>stdout
 ! These are encoding constants.
 use mpp_io_mod,           only : APPEND_FILE=>MPP_APPEND, WRITEONLY_FILE=>MPP_WRONLY
 use mpp_io_mod,           only : OVERWRITE_FILE=>MPP_OVERWR, READONLY_FILE=>MPP_RDONLY
@@ -33,6 +34,7 @@ public :: get_file_info, get_file_fields, get_file_times, get_filename_suffix
 public :: MOM_read_data, MOM_read_vector, write_metadata, write_field
 public :: field_exists, get_field_atts, get_field_size, get_axis_data, read_field_chksum
 public :: io_infra_init, io_infra_end, MOM_namelist_file, check_namelist_error, write_version
+public :: stdout_if_root
 ! These types are inherited from underlying infrastructure code, to act as containers for
 ! information about fields and axes, respectively, and are opaque to this module.
 public :: fieldtype, axistype

--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -29,6 +29,7 @@ use mpp_io_mod,           only : mpp_get_axes, mpp_axistype=>axistype, mpp_get_a
 use mpp_io_mod,           only : mpp_get_fields, mpp_fieldtype=>fieldtype
 use mpp_io_mod,           only : mpp_get_info, mpp_get_times
 use mpp_io_mod,           only : mpp_io_init
+use mpp_mod,              only : stdout_if_root=>stdout
 ! These are encoding constants.
 use mpp_io_mod,           only : APPEND_FILE=>MPP_APPEND, WRITEONLY_FILE=>MPP_WRONLY
 use mpp_io_mod,           only : OVERWRITE_FILE=>MPP_OVERWR, READONLY_FILE=>MPP_RDONLY
@@ -44,6 +45,7 @@ public :: get_file_info, get_file_fields, get_file_times, get_filename_suffix
 public :: MOM_read_data, MOM_read_vector, write_metadata, write_field
 public :: field_exists, get_field_atts, get_field_size, get_axis_data, read_field_chksum
 public :: io_infra_init, io_infra_end, MOM_namelist_file, check_namelist_error, write_version
+public :: stdout_if_root
 ! These types act as containers for information about files, fields and axes, respectively,
 ! and may also wrap opaque types from the underlying infrastructure.
 public :: file_type, fieldtype, axistype

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -19,6 +19,7 @@ use MOM_io_infra,         only : get_field_size, fieldtype, field_exists, get_fi
 use MOM_io_infra,         only : get_file_times, axistype, get_axis_data, get_filename_suffix
 use MOM_io_infra,         only : write_field, write_metadata, write_version
 use MOM_io_infra,         only : MOM_namelist_file, check_namelist_error, io_infra_init, io_infra_end
+use MOM_io_infra,         only : stdout_if_root
 use MOM_io_infra,         only : APPEND_FILE, ASCII_FILE, MULTIPLE, NETCDF_FILE, OVERWRITE_FILE
 use MOM_io_infra,         only : READONLY_FILE, SINGLE_FILE, WRITEONLY_FILE
 use MOM_io_infra,         only : CENTER, CORNER, NORTH_FACE, EAST_FACE
@@ -47,6 +48,7 @@ public :: axistype, get_axis_data
 public :: MOM_read_data, MOM_read_vector, read_field_chksum
 public :: slasher, write_field, write_version_number
 public :: io_infra_init, io_infra_end
+public :: stdout_if_root
 ! This is used to set up information descibing non-domain-decomposed axes.
 public :: axis_info, set_axis_info, delete_axis_info
 ! This is used to set up global file attributes


### PR DESCRIPTION
This patch adds `get_root_stdout` to the MOM_io API, and points to the
FMS `stdout()` function in the FMS infra implementations.

This change was required because calls to `coupler_type_write_chksums`
handles both its own checksums across ranks and its own IO to `outunit`.
Typically only the root PE will write the result.

The FMS `stdout()` function would return the designated stdout unit for
the root PE, and the internal `etc_unit` for other PEs, usually set to
`/dev/null`.

When MOM_io switched from using the FMS `stdout()` function to the
`stdout` unit as defined in `iso_fortran_env`, this functionality was
lost and every PE would write the same result to stdout.

Normally this was controlled with `if (root)`-like tests, but this
cannot be used in functions like `coupler_type_write_checksums`, which
require participation of all PEs.

We decided the only resolution here was to introduce a new function,
`get_root_stdout` which replicates the original behavior of `stdout()`.

Additional comments:

* The `if (root)` checks were retained, since it is presumably still a
  good idea to avoid the `write()` calls when possible, even to
  `/dev/null`.

* This patch only updates the FMS coulper driver, but I would recommend
  that the other driver maintainers review their own calls to this
  function.