### PR TITLE
Diag_mediator: Fix non-standard axis support

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1051,6 +1051,7 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
   else
     axes%v_cell_method = ''
   endif
+
   if (present(nz)) axes%nz = nz
   if (present(vertical_coordinate_number)) axes%vertical_coordinate_number = vertical_coordinate_number
   if (present(is_h_point)) axes%is_h_point = is_h_point
@@ -1978,18 +1979,15 @@ integer function register_diag_field(module_name, field_name, axes_in, init_time
   integer :: num_modnm, num_varnm
   logical :: active
 
-  axes => axes_in
-  MOM_missing_value = axes%diag_cs%missing_value
-  if (present(missing_value)) MOM_missing_value = missing_value
+  diag_cs => axes_in%diag_cs
 
-  diag_cs => axes%diag_cs
-  dm_id = -1
-
+  ! Check if the axes match a standard grid axis.
+  ! If not, allocate the new axis and copy the contents.
   if (axes_in%id == diag_cs%axesTL%id) then
     axes => diag_cs%axesTL
   elseif (axes_in%id == diag_cs%axesBL%id) then
     axes => diag_cs%axesBL
-  elseif (axes_in%id == diag_cs%axesCuL%id ) then
+  elseif (axes_in%id == diag_cs%axesCuL%id) then
     axes => diag_cs%axesCuL
   elseif (axes_in%id == diag_cs%axesCvL%id) then
     axes => diag_cs%axesCvL
@@ -1997,11 +1995,20 @@ integer function register_diag_field(module_name, field_name, axes_in, init_time
     axes => diag_cs%axesTi
   elseif (axes_in%id == diag_cs%axesBi%id) then
     axes => diag_cs%axesBi
-  elseif (axes_in%id == diag_cs%axesCui%id ) then
+  elseif (axes_in%id == diag_cs%axesCui%id) then
     axes => diag_cs%axesCui
   elseif (axes_in%id == diag_cs%axesCvi%id) then
     axes => diag_cs%axesCvi
+  else
+    allocate(axes)
+    axes = axes_in
   endif
+
+  MOM_missing_value = axes%diag_cs%missing_value
+  if (present(missing_value)) MOM_missing_value = missing_value
+
+  diag_cs => axes%diag_cs
+  dm_id = -1
 
   module_list = "{"//trim(module_name)
   num_modnm = 1
@@ -2081,6 +2088,20 @@ integer function register_diag_field(module_name, field_name, axes_in, init_time
       endif ! associated(remap_axes)
     endif ! axes%rank == 3
   enddo ! i
+
+  if (is_root_pe() .and. (diag_CS%available_diag_doc_unit > 0)) then
+    msg = ''
+    if (present(cmor_field_name)) msg = 'CMOR equivalent is "'//trim(cmor_field_name)//'"'
+    call attach_cell_methods(-1, axes, cm_string, cell_methods, &
+                             x_cell_method, y_cell_method, v_cell_method, &
+                             v_extensive=v_extensive)
+    module_list = trim(module_list)//"}"
+    if (num_modnm <= 1) module_list = module_name
+    if (num_varnm <= 1) var_list = ""
+
+    call log_available_diag(dm_id>0, module_list, field_name, cm_string, msg, diag_CS, &
+                            long_name, units, standard_name, variants=var_list)
+  endif
 
   !Register downsampled diagnostics
   do dl=2,MAX_DSAMP_LEV
@@ -2188,20 +2209,6 @@ integer function register_diag_field(module_name, field_name, axes_in, init_time
     enddo ! i
   enddo
 
-  if (is_root_pe() .and. (diag_CS%available_diag_doc_unit > 0)) then
-    msg = ''
-    if (present(cmor_field_name)) msg = 'CMOR equivalent is "'//trim(cmor_field_name)//'"'
-    call attach_cell_methods(-1, axes, cm_string, cell_methods, &
-                             x_cell_method, y_cell_method, v_cell_method, &
-                             v_extensive=v_extensive)
-    module_list = trim(module_list)//"}"
-    if (num_modnm <= 1) module_list = module_name
-    if (num_varnm <= 1) var_list = ""
-
-    call log_available_diag(dm_id>0, module_list, field_name, cm_string, msg, diag_CS, &
-                            long_name, units, standard_name, variants=var_list)
-  endif
-
   register_diag_field = dm_id
 
 end function register_diag_field
@@ -2216,7 +2223,7 @@ logical function register_diag_field_expand_cmor(dm_id, module_name, field_name,
   integer,          intent(inout) :: dm_id !< The diag_mediator ID for this diagnostic group
   character(len=*), intent(in) :: module_name !< Name of this module, usually "ocean_model" or "ice_shelf_model"
   character(len=*), intent(in) :: field_name !< Name of the diagnostic field
-  type(axes_grp), target, intent(in) :: axes !< Container w/ up to 3 integer handles that indicates axes
+  type(axes_grp),   intent(in) :: axes !< Container w/ up to 3 integer handles that indicates axes
                                              !! for this field
   type(time_type),  intent(in) :: init_time !< Time at which a field is first available?
   character(len=*), optional, intent(in) :: long_name !< Long name of a field.


### PR DESCRIPTION
When a diagnostic is registered, its axis group is compared to a
standard set of groups along the model grid.  If it matches one of them,
the diagnostic is associated with this axis group.

When it does not match any of the axes, the intention was to retain the
pointer to the input axis group.  However, there was a bug where the
axis group was pointed to the input stack value within the function,
rather than the original axis group.  This caused the diagnostic to be
associated with an axis group which was largely nonsense.

This patch fixes this bug by allocating the new axis group inside the
function to heap, and then copying the contents of the input axis group
to the new allocated group.  This ensures a permanent reference to the
new axis group.

It also probably creates a minor memory leak, but we can sort that out
as part of the overall memory cleanup PR (currently in preparation).

There was literally only one instance of a new axis, namely the use of
angles axes in the internal tide diagnostics.  This patch fixes any runs
which use these diagnostics.

A minor bug associated with logging and the accidental clobbering of the
axes by the desampled (d2) axes was also fixed.  We now call the logging
functions before constructing the d2 axes.