### PR TITLE
+Move wave module variables into control structure

### DIFF
--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -55,7 +55,7 @@ use MOM_verticalGrid, only : verticalGrid_type
 use MOM_ice_shelf, only : initialize_ice_shelf, shelf_calc_flux, ice_shelf_CS
 use MOM_ice_shelf, only : add_shelf_forces, ice_shelf_end, ice_shelf_save_restart
 use MOM_wave_interface, only: wave_parameters_CS, MOM_wave_interface_init
-use MOM_wave_interface, only: MOM_wave_interface_init_lite, Update_Surface_Waves
+use MOM_wave_interface, only: Update_Surface_Waves
 use iso_fortran_env, only : int64
 
 #include <MOM_memory.h>
@@ -205,7 +205,7 @@ type, public :: ocean_state_type ; private
     marine_ice_CSp => NULL()  !< A pointer to the control structure for the
                               !! marine ice effects module.
   type(wave_parameters_cs), pointer :: &
-    Waves !< A structure containing pointers to the surface wave fields
+    Waves => NULL()           !< A pointer to the surface wave control structure
   type(surface_forcing_CS), pointer :: &
     forcing_CSp => NULL()     !< A pointer to the MOM forcing control structure
   type(MOM_restart_CS), pointer :: &
@@ -382,11 +382,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
 
   call get_param(param_file, mdl, "USE_WAVES", OS%Use_Waves, &
        "If true, enables surface wave modules.", default=.false.)
-  if (OS%use_waves) then
-    call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
-  else
-    call MOM_wave_interface_init_lite(param_file)
-  endif
+  ! MOM_wave_interface_init is called regardless of the value of USE_WAVES because
+  ! it also initCSializes statistical waves.
+  call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
 
   call initialize_ocean_public_type(OS%grid%Domain, Ocean_sfc, OS%diag, &
                                     gas_fields_ocn=gas_fields_ocn)

--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -383,7 +383,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
   call get_param(param_file, mdl, "USE_WAVES", OS%Use_Waves, &
        "If true, enables surface wave modules.", default=.false.)
   ! MOM_wave_interface_init is called regardless of the value of USE_WAVES because
-  ! it also initCSializes statistical waves.
+  ! it also initializes statistical waves.
   call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
 
   call initialize_ocean_public_type(OS%grid%Domain, Ocean_sfc, OS%diag, &

--- a/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
+++ b/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
@@ -61,7 +61,7 @@ use MOM_io,                   only : stdout
 use mpp_mod,                  only : mpp_chksum
 use MOM_EOS,                  only : gsw_sp_from_sr, gsw_pt_from_ct
 use MOM_wave_interface,       only : wave_parameters_CS, MOM_wave_interface_init
-use MOM_wave_interface,       only : MOM_wave_interface_init_lite, Update_Surface_Waves
+use MOM_wave_interface,       only : Update_Surface_Waves
 use time_interp_external_mod, only : time_interp_external_init
 
 ! MCT specfic routines
@@ -205,7 +205,7 @@ type, public :: ocean_state_type ;
     marine_ice_CSp => NULL()  !< A pointer to the control structure for the
                               !! marine ice effects module.
   type(wave_parameters_cs), pointer :: &
-    Waves !< A structure containing pointers to the surface wave fields
+    Waves => NULL()           !< A pointer to the surface wave control structure
   type(surface_forcing_CS), pointer :: &
     forcing_CSp => NULL()     !< A pointer to the MOM forcing control structure
   type(MOM_restart_CS), pointer :: &
@@ -383,11 +383,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
 
   call get_param(param_file, mdl, "USE_WAVES", OS%Use_Waves, &
        "If true, enables surface wave modules.", default=.false.)
-  if (OS%use_waves) then
-    call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
-  else
-    call MOM_wave_interface_init_lite(param_file)
-  endif
+  ! MOM_wave_interface_init is called regardless of the value of USE_WAVES because
+  ! it also initializes statistical waves.
+  call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
 
   if (associated(OS%grid%Domain%maskmap)) then
     call initialize_ocean_public_type(OS%grid%Domain%mpp_domain, Ocean_sfc, &

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -332,7 +332,7 @@ program MOM_main
   call get_param(param_file,mod_name, "USE_WAVES", Use_Waves, &
        "If true, enables surface wave modules.",default=.false.)
   ! MOM_wave_interface_init is called regardless of the value of USE_WAVES because
-  ! it also initCSializes statistical waves.
+  ! it also initializes statistical waves.
   call MOM_wave_interface_init(Time, grid, GV, US, param_file, Waves_CSp, diag)
 
   segment_start_time = Time

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -65,7 +65,7 @@ program MOM_main
   use MOM_variables,       only : surface
   use MOM_verticalGrid,    only : verticalGrid_type
   use MOM_wave_interface,  only : wave_parameters_CS, MOM_wave_interface_init
-  use MOM_wave_interface,  only : MOM_wave_interface_init_lite, Update_Surface_Waves
+  use MOM_wave_interface,  only : Update_Surface_Waves
   use MOM_write_cputime,   only : write_cputime, MOM_write_cputime_init
   use MOM_write_cputime,   only : write_cputime_start_clock, write_cputime_CS
 
@@ -331,11 +331,9 @@ program MOM_main
 
   call get_param(param_file,mod_name, "USE_WAVES", Use_Waves, &
        "If true, enables surface wave modules.",default=.false.)
-  if (use_waves) then
-    call MOM_wave_interface_init(Time, grid, GV, US, param_file, Waves_CSp, diag)
-  else
-    call MOM_wave_interface_init_lite(param_file)
-  endif
+  ! MOM_wave_interface_init is called regardless of the value of USE_WAVES because
+  ! it also initCSializes statistical waves.
+  call MOM_wave_interface_init(Time, grid, GV, US, param_file, Waves_CSp, diag)
 
   segment_start_time = Time
   elapsed_time = 0.0

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -120,7 +120,7 @@ type, public :: wave_parameters_CS ; private
   real, allocatable, dimension(:) :: &
     PrescribedSurfStkY !< Surface Stokes drift if prescribed [L T-1 ~> m s-1]
   real, allocatable, dimension(:,:) :: &
-    La_SL,&            !< SL Langmuir number (directionality factored later)
+    La_SL, &           !< SL Langmuir number (directionality factored later)
                        !! Horizontal -> H points
     La_Turb            !< Aligned Turbulent Langmuir number [nondim]
                        !! Horizontal -> H points
@@ -382,13 +382,9 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
     call MOM_error(FATAL,'Check WAVE_METHOD.')
   end select
 
-  ! Langmuir number Options
-!  call get_param(param_file, mdl, "LA_DEPTH_RATIO", CS%LA_FracHBL,              &
-!         "The depth (normalized by BLD) to average Stokes drift over in "//&
-!         "Langmuir number calculation, where La = sqrt(ust/Stokes).",       &
-!         units="nondim",default=0.04)
-  call get_param(param_file, mdl, "LA_MISALIGNMENT", CS%LA_Misalignment,    &
-         "Flag (logical) if using misalignment bt shear and waves in LA",&
+  ! Langmuir number Options  (Note that CS%LA_FracHBL is set above.)
+  call get_param(param_file, mdl, "LA_MISALIGNMENT", CS%LA_Misalignment, &
+         "Flag (logical) if using misalignment bt shear and waves in LA", &
          default=.false.)
   call get_param(param_file, mdl, "MIN_LANGMUIR", CS%La_min,    &
          "A minimum value for all Langmuir numbers that is not physical, "//&
@@ -427,7 +423,7 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
        CS%diag%axesCvL,Time,'3d Stokes drift (y)', 'm s-1', conversion=US%L_T_to_m_s)
   CS%id_3dstokes_x = register_diag_field('ocean_model','3d_stokes_x', &
        CS%diag%axesCuL,Time,'3d Stokes drift (x)', 'm s-1', conversion=US%L_T_to_m_s)
-  CS%id_La_turb = register_diag_field('ocean_model','La_turbulent',&
+  CS%id_La_turb = register_diag_field('ocean_model','La_turbulent', &
        CS%diag%axesT1,Time,'Surface (turbulent) Langmuir number','nondim')
 
 end subroutine MOM_wave_interface_init
@@ -437,7 +433,7 @@ subroutine Update_Surface_Waves(G, GV, US, Day, dt, CS, forces)
   type(wave_parameters_CS), pointer    :: CS  !< Wave parameter Control structure
   type(ocean_grid_type), intent(inout) :: G   !< Grid structure
   type(verticalGrid_type), intent(in)  :: GV  !< Vertical grid structure
-  type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
+  type(unit_scale_type),   intent(in)  :: US  !< A dimensional unit scaling type
   type(time_type),         intent(in)  :: Day !< Current model time
   type(time_type),         intent(in)  :: dt  !< Timestep as a time-type
   type(mech_forcing),      intent(in), optional  :: forces !< MOM_forcing_type

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -152,7 +152,7 @@ type, public :: wave_parameters_CS ; private
   real    :: TP_WVL       !< Test profile wavelength [Z ~> m]
 
   ! Options for use with the Donelan et al., 1985 (DHH85) spectrum
-  logical :: WaveAgePeakFreq ! Flag to use wave age to determine the peak frequency with DHH85
+  logical :: WaveAgePeakFreq !< Flag to use wave age to determine the peak frequency with DHH85
   logical :: StaticWaves  !< Flag to disable updating DHH85 Stokes drift
   logical :: DHH85_is_set !< The if the wave properties have been set when WaveMethod = DHH85.
   real    :: WaveAge      !< The fixed wave age used with the DHH85 spectrum [nondim]


### PR DESCRIPTION
  Moved 15 module variables into wave_parameters_CS, to follow the coding style
and conventions in the rest of the code.  Also added comments describing 8
enumeration parameters in this same module, and added comments suggesting ways
that the accuracy of the calculations could be improved.  Also incorporated a
factor of 2*PI into the definition of Freq_Cen in this module.  In addition, the
initialization procedure for this module was altered in some more commonly used
cases, so that use MOM_wave_interface_init to set wave parameters, even with a
statistical wave model, and eliminated MOM_wave_interface_init_lite.  I believe
that all solutions should be bitwise identical, but this module is not yet well
tested in the MOM6 regression tests.  The commits in this PR include:

- NOAA-GFDL/MOM6@89447f49e Merge branch 'dev/gfdl' into MOM_wave_control
- NOAA-GFDL/MOM6@38a897e05 Merge branch 'MOM_wave_rescale' into MOM_wave_control
- NOAA-GFDL/MOM6@b2af54d8a +Move wave module variables into control structure
