### PR TITLE
Call variable_att_exists before get_variable_att

### DIFF
--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -498,10 +498,12 @@ subroutine get_file_fields(IO_handle, fields)
     do i=1,nvar
       fields(i)%name = trim(var_names(i))
       longname = ""
-      call get_variable_attribute(IO_handle%fileobj, var_names(i), 'long_name', longname)
+      if (variable_att_exists(IO_handle%fileobj, var_names(i), "long_name")) &
+        call get_variable_attribute(IO_handle%fileobj, var_names(i), "long_name", longname)
       fields(i)%longname = trim(longname)
       units = ""
-      call get_variable_attribute(IO_handle%fileobj, var_names(i), 'units', units)
+      if (variable_att_exists(IO_handle%fileobj, var_names(i), "units")) &
+        call get_variable_attribute(IO_handle%fileobj, var_names(i), "units", units)
       fields(i)%units = trim(units)
 
       fields(i)%valid_chksum = variable_att_exists(IO_handle%fileobj, var_names(i), "checksum")


### PR DESCRIPTION
  Added variable_att_exists calls before two calls to get_variable_attribute in
the FMS2 version of get_file_fields so that runs do not crash if there are
variables being read that do not have a long_name or units attribute.  All
answers are bitwise identical in cases that did not crash.