### PR TITLE
corrections to beta-plane

### DIFF
--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -511,9 +511,6 @@ subroutine set_rotation_beta_plane(f, G, param_file, US)
     case ("m")
       beta_lat_ref_units = "meters"
       y_scl = 1.
-    case ("c")
-      beta_lat_ref_units = "centimeters"
-      y_scl = 1.E-2
     case default ; call MOM_error(FATAL, &
       " set_rotation_beta_plane: unknown AXIS_UNITS = "//trim(axis_units))
   end select

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -478,6 +478,7 @@ subroutine set_rotation_beta_plane(f, G, param_file, US)
   integer :: I, J
   real    :: f_0    ! The reference value of the Coriolis parameter [T-1 ~> s-1]
   real    :: beta   ! The meridional gradient of the Coriolis parameter [T-1 m-1 ~> s-1 m-1]
+  real    :: lat_0  ! The reference latitude for the beta plane [degrees]
   real    :: y_scl, Rad_Earth
   real    :: T_to_s ! A time unit conversion factor
   real    :: PI
@@ -494,6 +495,9 @@ subroutine set_rotation_beta_plane(f, G, param_file, US)
   call get_param(param_file, mdl, "BETA", beta, &
                  "The northward gradient of the Coriolis parameter with "//&
                  "the betaplane option.", units="m-1 s-1", default=0.0, scale=T_to_s)
+  call get_param(param_file, mdl, "LAT_0", lat_0, &
+                 "The reference latitude (origin) of the beta-plane", &
+                 units="degrees", default=0.0)
   call get_param(param_file, mdl, "AXIS_UNITS", axis_units, default="degrees")
 
   PI = 4.0*atan(1.0)
@@ -501,7 +505,7 @@ subroutine set_rotation_beta_plane(f, G, param_file, US)
     case ("d")
       call get_param(param_file, mdl, "RAD_EARTH", Rad_Earth, &
                    "The radius of the Earth.", units="m", default=6.378e6)
-      y_scl = Rad_Earth/PI
+      y_scl = PI * Rad_Earth/ 180.
     case ("k"); y_scl = 1.E3
     case ("m"); y_scl = 1.
     case ("c"); y_scl = 1.E-2
@@ -510,7 +514,7 @@ subroutine set_rotation_beta_plane(f, G, param_file, US)
   end select
 
   do I=G%IsdB,G%IedB ; do J=G%JsdB,G%JedB
-    f(I,J) = f_0 + beta * ( G%geoLatBu(I,J) * y_scl )
+    f(I,J) = f_0 + beta * ( (G%geoLatBu(I,J) - lat_0) * y_scl )
   enddo ; enddo
 
   call callTree_leave(trim(mdl)//'()')


### PR DESCRIPTION
Setting up a channel with beta-plane configuration (center lat = 40N) with the following parameters resulted in abnormally large values of `Coriolis` leading to numerical instability. 

```
GRID_CONFIG = "spherical"       
SOUTHLAT = 10.0
LENLAT = 75.0
WESTLON = -200.0
LENLON = 100.0
ROTATION = "betaplane"
F_0 = 9.35E-05
BETA = 1.75E-11
```

Detail of the computation of parameters as follows:

```python
def betaplane(lat0, Rearth=6.378e6):
    """ write f0 and beta for a beta plane centered on lat0 (deg)"""
    import numpy as np
    omega = (2*np.pi/86400.) # earth rotation rate 2 pi / lenght of day
    deg2rad = 2*np.pi/360
    lat0r = deg2rad * lat0
    f0 = 2 * omega * np.sin(lat0r)
    beta = 2 * omega * np.cos(lat0r) / Rearth
    return f0, beta

f0_wide, beta_wide = betaplane(40)
print(f'wide channel: f0 = {f0_wide}, beta = {beta_wide}')
```

```
wide channel: f0 = 9.348966816711922e-05, beta = 1.7468900581468308e-11
```

I believe the y-scaling needs to be corrected according to this PR and an origin for the beta-plane is added for applications other
than the equatorial beta-plane. Experiment with updated code behaves as expected.