### PR TITLE
Memory management cleanup and initialization fixes

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -24,7 +24,8 @@ use MOM_diag_mediator,        only : diag_grid_storage, diag_grid_storage_init
 use MOM_diag_mediator,        only : diag_save_grids, diag_restore_grids
 use MOM_diag_mediator,        only : diag_copy_storage_to_diag, diag_copy_diag_to_storage
 use MOM_domains,              only : MOM_domains_init
-use MOM_domains,              only : sum_across_PEs, pass_var, pass_vector, clone_MOM_domain
+use MOM_domains,              only : sum_across_PEs, pass_var, pass_vector
+use MOM_domains,              only : clone_MOM_domain, deallocate_MOM_domain
 use MOM_domains,              only : To_North, To_East, To_South, To_West
 use MOM_domains,              only : To_All, Omit_corners, CGRID_NE, SCALAR_PAIR
 use MOM_domains,              only : create_group_pass, do_group_pass, group_pass_type
@@ -63,6 +64,7 @@ use MOM_diagnostics,           only : register_transport_diags, post_transport_d
 use MOM_diagnostics,           only : register_surface_diags, write_static_fields
 use MOM_diagnostics,           only : post_surface_dyn_diags, post_surface_thermo_diags
 use MOM_diagnostics,           only : diagnostics_CS, surface_diag_IDs, transport_diag_IDs
+use MOM_diagnostics,           only : MOM_diagnostics_end
 use MOM_dynamics_unsplit,      only : step_MOM_dyn_unsplit, register_restarts_dyn_unsplit
 use MOM_dynamics_unsplit,      only : initialize_dyn_unsplit, end_dyn_unsplit
 use MOM_dynamics_unsplit,      only : MOM_dyn_unsplit_CS
@@ -83,9 +85,10 @@ use MOM_grid,                  only : set_first_direction, rescale_grid_bathymet
 use MOM_hor_index,             only : hor_index_type, hor_index_init
 use MOM_hor_index,             only : rotate_hor_index
 use MOM_interface_heights,     only : find_eta
-use MOM_lateral_mixing_coeffs, only : calc_slope_functions, VarMix_init
+use MOM_lateral_mixing_coeffs, only : calc_slope_functions, VarMix_init, VarMix_end
 use MOM_lateral_mixing_coeffs, only : calc_resoln_function, calc_depth_function, VarMix_CS
-use MOM_MEKE,                  only : MEKE_init, MEKE_alloc_register_restart, step_forward_MEKE, MEKE_CS
+use MOM_MEKE,                  only : MEKE_alloc_register_restart, step_forward_MEKE
+use MOM_MEKE,                  only : MEKE_CS, MEKE_init, MEKE_end
 use MOM_MEKE_types,            only : MEKE_type
 use MOM_mixed_layer_restrat,   only : mixedlayer_restrat, mixedlayer_restrat_init, mixedlayer_restrat_CS
 use MOM_mixed_layer_restrat,   only : mixedlayer_restrat_register_restarts
@@ -95,15 +98,18 @@ use MOM_open_boundary,         only : register_temp_salt_segments
 use MOM_open_boundary,         only : open_boundary_register_restarts
 use MOM_open_boundary,         only : update_segment_tracer_reservoirs
 use MOM_open_boundary,         only : rotate_OBC_config, rotate_OBC_init
-use MOM_set_visc,              only : set_viscous_BBL, set_viscous_ML, set_visc_init
+use MOM_set_visc,              only : set_viscous_BBL, set_viscous_ML
 use MOM_set_visc,              only : set_visc_register_restarts, set_visc_CS
+use MOM_set_visc,              only : set_visc_init, set_visc_end
 use MOM_shared_initialization, only : write_ocean_geometry_file
 use MOM_sponge,                only : init_sponge_diags, sponge_CS
 use MOM_state_initialization,  only : MOM_initialize_state
 use MOM_sum_output,            only : write_energy, accumulate_net_input
-use MOM_sum_output,            only : MOM_sum_output_init, sum_output_CS
+use MOM_sum_output,            only : MOM_sum_output_init, MOM_sum_output_end
+use MOM_sum_output,            only : sum_output_CS
 use MOM_ALE_sponge,            only : init_ALE_sponge_diags, ALE_sponge_CS
-use MOM_thickness_diffuse,     only : thickness_diffuse, thickness_diffuse_init, thickness_diffuse_CS
+use MOM_thickness_diffuse,     only : thickness_diffuse, thickness_diffuse_init
+use MOM_thickness_diffuse,     only : thickness_diffuse_end, thickness_diffuse_CS
 use MOM_tracer_advect,         only : advect_tracer, tracer_advect_init
 use MOM_tracer_advect,         only : tracer_advect_end, tracer_advect_CS
 use MOM_tracer_hor_diff,       only : tracer_hordiff, tracer_hor_diff_init
@@ -3530,28 +3536,28 @@ end subroutine get_ocean_stocks
 subroutine MOM_end(CS)
   type(MOM_control_struct), pointer :: CS   !< MOM control structure
 
+  call MOM_sum_output_end(CS%sum_output_CSp)
+
   if (CS%use_ALE_algorithm) call ALE_end(CS%ALE_CSp)
 
-  DEALLOC_(CS%u) ; DEALLOC_(CS%v) ; DEALLOC_(CS%h)
-  DEALLOC_(CS%uh) ; DEALLOC_(CS%vh)
-
-  if (associated(CS%tv%T)) then
-    DEALLOC_(CS%T) ; CS%tv%T => NULL() ; DEALLOC_(CS%S) ; CS%tv%S => NULL()
-  endif
-  if (associated(CS%tv%frazil)) deallocate(CS%tv%frazil)
-  if (associated(CS%tv%salt_deficit)) deallocate(CS%tv%salt_deficit)
-  if (associated(CS%Hml)) deallocate(CS%Hml)
+  ! NOTE: Allocated in PressureForce_FV_Bouss
+  if (associated(CS%tv%varT)) deallocate(CS%tv%varT)
 
   call tracer_advect_end(CS%tracer_adv_CSp)
   call tracer_hor_diff_end(CS%tracer_diff_CSp)
   call tracer_registry_end(CS%tracer_Reg)
   call tracer_flow_control_end(CS%tracer_flow_CSp)
 
-  call diabatic_driver_end(CS%diabatic_CSp)
+  if (.not. CS%adiabatic) then
+    call diabatic_driver_end(CS%diabatic_CSp)
+    deallocate(CS%diabatic_CSp)
+  endif
+
+  call MOM_diagnostics_end(CS%diagnostics_CSp, CS%ADp, CS%CDp)
+  deallocate(CS%diagnostics_CSp)
 
   if (CS%offline_tracer_mode) call offline_transport_end(CS%offline_CSp)
 
-  DEALLOC_(CS%uhtr) ; DEALLOC_(CS%vhtr)
   if (CS%split) then
     call end_dyn_split_RK2(CS%dyn_split_RK2_CSp)
   elseif (CS%use_RK2) then
@@ -3559,15 +3565,63 @@ subroutine MOM_end(CS)
   else
     call end_dyn_unsplit(CS%dyn_unsplit_CSp)
   endif
+
+  call thickness_diffuse_end(CS%thickness_diffuse_CSp, CS%CDp)
+  deallocate(CS%thickness_diffuse_CSp)
+
+  if (associated(CS%VarMix)) then
+    call VarMix_end(CS%VarMix)
+    deallocate(CS%VarMix)
+  endif
+
+  if (associated(CS%mixedlayer_restrat_CSp)) &
+    deallocate(CS%mixedlayer_restrat_CSp)
+
+  if (associated(CS%set_visc_CSp)) &
+    call set_visc_end(CS%visc, CS%set_visc_CSp)
+
+  if (associated(CS%MEKE_CSp)) deallocate(CS%MEKE_CSp)
+
+  if (associated(CS%MEKE)) then
+    call MEKE_end(CS%MEKE)
+    deallocate(CS%MEKE)
+  endif
+
+  if (associated(CS%tv%internal_heat)) deallocate(CS%tv%internal_heat)
+  if (associated(CS%tv%TempxPmE)) deallocate(CS%tv%TempxPmE)
+
   DEALLOC_(CS%ave_ssh_ibc) ; DEALLOC_(CS%ssh_rint)
+
+  ! TODO: debug_truncations deallocation
+
+  DEALLOC_(CS%uhtr) ; DEALLOC_(CS%vhtr)
+
+  if (associated(CS%Hml)) deallocate(CS%Hml)
+  if (associated(CS%tv%salt_deficit)) deallocate(CS%tv%salt_deficit)
+  if (associated(CS%tv%frazil)) deallocate(CS%tv%frazil)
+
+  if (associated(CS%tv%T)) then
+    DEALLOC_(CS%T) ; CS%tv%T => NULL() ; DEALLOC_(CS%S) ; CS%tv%S => NULL()
+  endif
+
+  DEALLOC_(CS%u) ; DEALLOC_(CS%v) ; DEALLOC_(CS%h)
+  DEALLOC_(CS%uh) ; DEALLOC_(CS%vh)
+
   if (associated(CS%update_OBC_CSp)) call OBC_register_end(CS%update_OBC_CSp)
 
   call verticalGridEnd(CS%GV)
   call unit_scaling_end(CS%US)
   call MOM_grid_end(CS%G)
 
-  deallocate(CS)
+  if (CS%debug .or. CS%G%symmetric) &
+    call deallocate_MOM_domain(CS%G%Domain_aux)
 
+  if (CS%rotate_index) &
+    call deallocate_MOM_domain(CS%G%Domain)
+
+  call deallocate_MOM_domain(CS%G_in%domain)
+
+  deallocate(CS)
 end subroutine MOM_end
 
 !> \namespace mom

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -1330,8 +1330,7 @@ end subroutine CoriolisAdv_init
 
 !> Destructor for coriolisadv_cs
 subroutine CoriolisAdv_end(CS)
-  type(CoriolisAdv_CS), pointer :: CS !< Control structure fro MOM_CoriolisAdv
-  deallocate(CS)
+  type(CoriolisAdv_CS), intent(inout) :: CS !< Control structure fro MOM_CoriolisAdv
 end subroutine CoriolisAdv_end
 
 !> \namespace mom_coriolisadv

--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -120,15 +120,13 @@ end subroutine PressureForce_init
 
 !> Deallocate the pressure force control structure
 subroutine PressureForce_end(CS)
-  type(PressureForce_CS), pointer :: CS !< Pressure force control structure
+  type(PressureForce_CS), intent(inout) :: CS  !< Pressure force control structure
 
   if (CS%Analytic_FV_PGF) then
     call PressureForce_FV_end(CS%PressureForce_FV_CSp)
   else
     call PressureForce_Mont_end(CS%PressureForce_Mont_CSp)
   endif
-
-  if (associated(CS)) deallocate(CS)
 end subroutine PressureForce_end
 
 !> \namespace mom_pressureforce

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -7,10 +7,10 @@ use MOM_debugging, only : hchksum, uvchksum
 use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
 use MOM_diag_mediator, only : post_data, query_averaging_enabled, register_diag_field
 use MOM_diag_mediator, only : safe_alloc_ptr, diag_ctrl, enable_averaging
-use MOM_domains, only : min_across_PEs, clone_MOM_domain, pass_vector
+use MOM_domains, only : min_across_PEs, clone_MOM_domain, deallocate_MOM_domain
 use MOM_domains, only : To_All, Scalar_Pair, AGRID, CORNER, MOM_domain_type
 use MOM_domains, only : create_group_pass, do_group_pass, group_pass_type
-use MOM_domains, only : start_group_pass, complete_group_pass, pass_var
+use MOM_domains, only : start_group_pass, complete_group_pass, pass_var, pass_vector
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : mech_forcing
@@ -4998,19 +4998,25 @@ end subroutine barotropic_get_tav
 
 !> Clean up the barotropic control structure.
 subroutine barotropic_end(CS)
-  type(barotropic_CS), pointer :: CS  !< Control structure to clear out.
-  DEALLOC_(CS%frhatu)   ; DEALLOC_(CS%frhatv)
-  DEALLOC_(CS%IDatu)    ; DEALLOC_(CS%IDatv)
-  DEALLOC_(CS%ubtav)    ; DEALLOC_(CS%vbtav)
-  DEALLOC_(CS%eta_cor)
-  DEALLOC_(CS%ua_polarity) ; DEALLOC_(CS%va_polarity)
-  if (CS%bound_BT_corr) then
-    DEALLOC_(CS%eta_cor_bound)
-  endif
+  type(barotropic_CS), intent(inout) :: CS  !< Control structure to clear out.
 
   call destroy_BT_OBC(CS%BT_OBC)
 
-  deallocate(CS)
+  ! Allocated in barotropic_init, called in timestep initialization
+  DEALLOC_(CS%ua_polarity) ; DEALLOC_(CS%va_polarity)
+  DEALLOC_(CS%IDatu)    ; DEALLOC_(CS%IDatv)
+  if (CS%bound_BT_corr) then
+    DEALLOC_(CS%eta_cor_bound)
+  endif
+  DEALLOC_(CS%eta_cor)
+  DEALLOC_(CS%frhatu)   ; DEALLOC_(CS%frhatv)
+
+  if (associated(CS%frhatu1)) deallocate(CS%frhatu1)
+  if (associated(CS%frhatv1)) deallocate(CS%frhatv1)
+  call deallocate_MOM_domain(CS%BT_domain)
+
+  ! Allocated in restart registration, prior to timestep initialization
+  DEALLOC_(CS%ubtav)    ; DEALLOC_(CS%vbtav)
 end subroutine barotropic_end
 
 !> This subroutine is used to register any fields from MOM_barotropic.F90

--- a/src/core/MOM_continuity.F90
+++ b/src/core/MOM_continuity.F90
@@ -167,14 +167,11 @@ end function continuity_stencil
 
 !> Destructor for continuity_cs.
 subroutine continuity_end(CS)
-  type(continuity_CS), pointer :: CS !< Control structure for mom_continuity.
+  type(continuity_CS), intent(inout) :: CS !< Control structure for mom_continuity.
 
   if (CS%continuity_scheme == PPM_SCHEME) then
     call continuity_PPM_end(CS%PPM_CSp)
   endif
-
-  deallocate(CS)
-
 end subroutine continuity_end
 
 end module MOM_continuity

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -36,27 +36,33 @@ use MOM_time_manager,      only : operator(-), operator(>), operator(*), operato
 use MOM_ALE,                   only : ALE_CS
 use MOM_barotropic,            only : barotropic_init, btstep, btcalc, bt_mass_source
 use MOM_barotropic,            only : register_barotropic_restarts, set_dtbt, barotropic_CS
+use MOM_barotropic,            only : barotropic_end
 use MOM_boundary_update,       only : update_OBC_data, update_OBC_CS
-use MOM_continuity,            only : continuity, continuity_init, continuity_CS
+use MOM_continuity,            only : continuity, continuity_CS
+use MOM_continuity,            only : continuity_init, continuity_end
 use MOM_continuity,            only : continuity_stencil
-use MOM_CoriolisAdv,           only : CorAdCalc, CoriolisAdv_init, CoriolisAdv_CS
+use MOM_CoriolisAdv,           only : CorAdCalc, CoriolisAdv_CS
+use MOM_CoriolisAdv,           only : CoriolisAdv_init, CoriolisAdv_end
 use MOM_debugging,             only : check_redundant
 use MOM_grid,                  only : ocean_grid_type
 use MOM_hor_index,             only : hor_index_type
-use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_init, hor_visc_CS
+use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_CS
+use MOM_hor_visc,              only : hor_visc_init, hor_visc_end
 use MOM_interface_heights,     only : find_eta
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types,            only : MEKE_type
 use MOM_open_boundary,         only : ocean_OBC_type, radiation_open_bdry_conds
 use MOM_open_boundary,         only : open_boundary_zero_normal_flow
 use MOM_open_boundary,         only : open_boundary_test_extern_h, update_OBC_ramp
-use MOM_PressureForce,         only : PressureForce, PressureForce_init, PressureForce_CS
+use MOM_PressureForce,         only : PressureForce, PressureForce_CS
+use MOM_PressureForce,         only : PressureForce_init, PressureForce_end
 use MOM_set_visc,              only : set_viscous_ML, set_visc_CS
 use MOM_thickness_diffuse,     only : thickness_diffuse_CS
-use MOM_tidal_forcing,         only : tidal_forcing_init, tidal_forcing_CS
+use MOM_tidal_forcing,         only : tidal_forcing_CS
+use MOM_tidal_forcing,         only : tidal_forcing_init, tidal_forcing_end
 use MOM_unit_scaling,          only : unit_scale_type
 use MOM_vert_friction,         only : vertvisc, vertvisc_coef, vertvisc_remnant
-use MOM_vert_friction,         only : vertvisc_init, vertvisc_CS
+use MOM_vert_friction,         only : vertvisc_init, vertvisc_end, vertvisc_CS
 use MOM_vert_friction,         only : updateCFLtruncationValue
 use MOM_verticalGrid,          only : verticalGrid_type, get_thickness_units
 use MOM_verticalGrid,          only : get_flux_units, get_tr_flux_units
@@ -1529,6 +1535,28 @@ end subroutine initialize_dyn_split_RK2
 !> Close the dyn_split_RK2 module
 subroutine end_dyn_split_RK2(CS)
   type(MOM_dyn_split_RK2_CS), pointer :: CS  !< module control structure
+
+  call barotropic_end(CS%barotropic_CSp)
+  deallocate(CS%barotropic_CSp)
+
+  call vertvisc_end(CS%vertvisc_CSp)
+  deallocate(CS%vertvisc_CSp)
+
+  call hor_visc_end(CS%hor_visc_CSp)
+
+  call PressureForce_end(CS%PressureForce_CSp)
+  deallocate(CS%PressureForce_CSp)
+
+  if (associated(CS%tides_CSp)) then
+    call tidal_forcing_end(CS%tides_CSp)
+    deallocate(CS%tides_CSp)
+  endif
+
+  call CoriolisAdv_end(CS%CoriolisAdv_Csp)
+  deallocate(CS%CoriolisAdv_CSp)
+
+  call continuity_end(CS%continuity_CSp)
+  deallocate(CS%continuity_CSp)
 
   DEALLOC_(CS%diffu) ; DEALLOC_(CS%diffv)
   DEALLOC_(CS%CAu)   ; DEALLOC_(CS%CAv)

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -597,6 +597,13 @@ end subroutine allocate_metrics
 subroutine MOM_grid_end(G)
   type(ocean_grid_type), intent(inout) :: G !< The horizontal grid type
 
+  deallocate(G%Block)
+
+  if (G%bathymetry_at_vel) then
+    DEALLOC_(G%Dblock_u) ; DEALLOC_(G%Dopen_u)
+    DEALLOC_(G%Dblock_v) ; DEALLOC_(G%Dopen_v)
+  endif
+
   DEALLOC_(G%dxT)  ; DEALLOC_(G%dxCu)  ; DEALLOC_(G%dxCv)  ; DEALLOC_(G%dxBu)
   DEALLOC_(G%IdxT) ; DEALLOC_(G%IdxCu) ; DEALLOC_(G%IdxCv) ; DEALLOC_(G%IdxBu)
 
@@ -621,11 +628,6 @@ subroutine MOM_grid_end(G)
   DEALLOC_(G%bathyT)  ; DEALLOC_(G%CoriolisBu)
   DEALLOC_(G%dF_dx)  ; DEALLOC_(G%dF_dy)
   DEALLOC_(G%sin_rot) ; DEALLOC_(G%cos_rot)
-
-  if (G%bathymetry_at_vel) then
-    DEALLOC_(G%Dblock_u) ; DEALLOC_(G%Dopen_u)
-    DEALLOC_(G%Dblock_v) ; DEALLOC_(G%Dopen_v)
-  endif
 
   deallocate(G%gridLonT) ; deallocate(G%gridLatT)
   deallocate(G%gridLonB) ; deallocate(G%gridLatB)

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -2297,11 +2297,13 @@ subroutine set_dependent_diagnostics(MIS, ADp, CDp, G, GV, CS)
 end subroutine set_dependent_diagnostics
 
 !> Deallocate memory associated with the diagnostics module
-subroutine MOM_diagnostics_end(CS, ADp)
-  type(diagnostics_CS),   pointer       :: CS  !< Control structure returned by a
-                                               !! previous call to diagnostics_init.
-  type(accel_diag_ptrs),  intent(inout) :: ADp !< structure with pointers to
-                                               !! accelerations in momentum equation.
+subroutine MOM_diagnostics_end(CS, ADp, CDp)
+  type(diagnostics_CS),  intent(inout) :: CS  !< Control structure returned by a
+                                              !! previous call to diagnostics_init.
+  type(accel_diag_ptrs), intent(inout) :: ADp !< structure with pointers to
+                                              !! accelerations in momentum equation.
+  type(cont_diag_ptrs),  intent(inout) :: CDp !< Structure pointing to terms in continuity
+                                              !! equation.
   integer :: m
 
   if (associated(CS%e))          deallocate(CS%e)
@@ -2336,10 +2338,12 @@ subroutine MOM_diagnostics_end(CS, ADp)
   if (associated(ADp%diag_hfrac_u)) deallocate(ADp%diag_hfrac_u)
   if (associated(ADp%diag_hfrac_v)) deallocate(ADp%diag_hfrac_v)
 
+  ! NOTE: [uv]hGM may be allocated either here or the thickness diffuse module
+  if (associated(CDp%uhGM)) deallocate(CDp%uhGM)
+  if (associated(CDp%vhGM)) deallocate(CDp%vhGM)
+  if (associated(CDp%diapyc_vel)) deallocate(CDp%diapyc_vel)
+
   do m=1,CS%num_time_deriv ; deallocate(CS%prev_val(m)%p) ; enddo
-
-  deallocate(CS)
-
 end subroutine MOM_diagnostics_end
 
 end module MOM_diagnostics

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -34,7 +34,8 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public write_energy, accumulate_net_input, MOM_sum_output_init
+public write_energy, accumulate_net_input
+public MOM_sum_output_init, MOM_sum_output_end
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -72,6 +72,7 @@ use MOM_EOS,              only : EOS_type
 use MOM_remapping,        only : remapping_CS, initialize_remapping
 use MOM_remapping,        only : remapping_core_h
 use MOM_regridding,       only : regridding_CS, initialize_regridding
+use MOM_regridding,       only : end_regridding
 use MOM_regridding,       only : set_regrid_params, get_regrid_size
 use MOM_regridding,       only : getCoordinateInterfaces
 use MOM_regridding,       only : get_zlike_CS, get_sigma_CS, get_rho_CS
@@ -148,6 +149,7 @@ subroutine diag_remap_end(remap_cs)
   type(diag_remap_ctrl), intent(inout) :: remap_cs !< Diag remapping control structure
 
   if (allocated(remap_cs%h)) deallocate(remap_cs%h)
+
   remap_cs%configured = .false.
   remap_cs%initialized = .false.
   remap_cs%used = .false.
@@ -165,6 +167,7 @@ subroutine diag_remap_diag_registration_closed(remap_cs)
 
   if (.not. remap_cs%used) then
     call diag_remap_end(remap_cs)
+    call end_regridding(remap_cs%regrid_cs)
   endif
 
 end subroutine diag_remap_diag_registration_closed

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -5,7 +5,7 @@ module MOM_dyn_horgrid
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_hor_index, only : hor_index_type
-use MOM_domains, only : MOM_domain_type
+use MOM_domains, only : MOM_domain_type, deallocate_MOM_domain
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING
 use MOM_unit_scaling, only : unit_scale_type
 
@@ -413,8 +413,10 @@ subroutine destroy_dyn_horgrid(G)
   deallocate(G%gridLonT) ; deallocate(G%gridLatT)
   deallocate(G%gridLonB) ; deallocate(G%gridLatB)
 
-  deallocate(G%Domain%mpp_domain)
-  deallocate(G%Domain)
+  ! CS%debug is required to validate Domain_aux, so use allocation test
+  if (associated(G%Domain_aux)) call deallocate_MOM_domain(G%Domain_aux)
+
+  call deallocate_MOM_domain(G%Domain)
 
   deallocate(G)
 

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -196,6 +196,8 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
   CS%iounit(i) = iounit
   CS%filename(i) = filename
   CS%NetCDF_file(i) = Netcdf_file
+
+  if (associated(CS%blockName)) deallocate(CS%blockName)
   allocate(block) ; block%name = '' ; CS%blockName => block
 
   call MOM_mesg("open_param_file: "// trim(filename)// &
@@ -332,6 +334,7 @@ subroutine close_param_file(CS, quiet_close, component)
     deallocate (CS%param_data(i)%line)
     deallocate (CS%param_data(i)%line_used)
   enddo
+  deallocate(CS%blockName)
 
   if (is_root_pe() .and. (num_unused>0) .and. CS%unused_params_fatal) &
     call MOM_error(FATAL, "Run stopped because of unused parameter lines.")

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1421,26 +1421,23 @@ subroutine MEKE_alloc_register_restart(HI, param_file, MEKE, restart_CS)
 
 end subroutine MEKE_alloc_register_restart
 
-!> Deallocates any variables allocated in MEKE_init or
-!! MEKE_alloc_register_restart.
-subroutine MEKE_end(MEKE, CS)
-  type(MEKE_type), pointer :: MEKE !< A structure with MEKE-related fields.
-  type(MEKE_CS),   pointer :: CS   !< The control structure for MOM_MEKE.
+!> Deallocates any variables allocated in MEKE_alloc_register_restart.
+subroutine MEKE_end(MEKE)
+  type(MEKE_type), intent(inout) :: MEKE !< A structure with MEKE-related fields.
 
-  if (associated(CS)) deallocate(CS)
+  ! NOTE: MEKE will always be allocated by MEKE_init, even if MEKE is disabled.
+  !  So these must all be conditional, even though MEKE%MEKE and MEKE%Rd_dx_h
+  !  are always allocated (when MEKE is enabled)
 
-  if (.not.associated(MEKE)) return
-
-  if (associated(MEKE%MEKE)) deallocate(MEKE%MEKE)
-  if (associated(MEKE%GM_src)) deallocate(MEKE%GM_src)
-  if (associated(MEKE%mom_src)) deallocate(MEKE%mom_src)
-  if (associated(MEKE%GME_snk)) deallocate(MEKE%GME_snk)
-  if (associated(MEKE%Kh)) deallocate(MEKE%Kh)
+  if (associated(MEKE%Au)) deallocate(MEKE%Au)
   if (associated(MEKE%Kh_diff)) deallocate(MEKE%Kh_diff)
   if (associated(MEKE%Ku)) deallocate(MEKE%Ku)
-  if (associated(MEKE%Au)) deallocate(MEKE%Au)
-  deallocate(MEKE)
-
+  if (associated(MEKE%Rd_dx_h)) deallocate(MEKE%Rd_dx_h)
+  if (associated(MEKE%Kh)) deallocate(MEKE%Kh)
+  if (associated(MEKE%GME_snk)) deallocate(MEKE%GME_snk)
+  if (associated(MEKE%mom_src)) deallocate(MEKE%mom_src)
+  if (associated(MEKE%GM_src)) deallocate(MEKE%GM_src)
+  if (associated(MEKE%MEKE)) deallocate(MEKE%MEKE)
 end subroutine MEKE_end
 
 !> \namespace mom_meke

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2583,10 +2583,10 @@ subroutine hor_visc_end(CS)
       DEALLOC_(CS%Ah_Max_xx) ; DEALLOC_(CS%Ah_Max_xy)
     endif
     if (CS%Smagorinsky_Ah) then
-      DEALLOC_(CS%Biharm6_const_xx) ; DEALLOC_(CS%Biharm6_const_xy)
+      DEALLOC_(CS%Biharm_const_xx) ; DEALLOC_(CS%Biharm_const_xy)
     endif
     if (CS%Leith_Ah) then
-      DEALLOC_(CS%Biharm_const_xx) ; DEALLOC_(CS%Biharm_const_xy)
+      DEALLOC_(CS%Biharm6_const_xx) ; DEALLOC_(CS%Biharm6_const_xy)
     endif
     if (CS%Re_Ah > 0.0) then
       DEALLOC_(CS%Re_Ah_const_xx) ; DEALLOC_(CS%Re_Ah_const_xy)

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -2116,10 +2116,23 @@ subroutine thickness_diffuse_get_KH(CS, KH_u_GME, KH_v_GME, G, GV)
 end subroutine thickness_diffuse_get_KH
 
 !> Deallocate the thickness diffusion control structure
-subroutine thickness_diffuse_end(CS)
-  type(thickness_diffuse_CS), pointer :: CS !< Control structure for thickness diffusion
+subroutine thickness_diffuse_end(CS, CDp)
+  type(thickness_diffuse_CS), intent(inout) :: CS !< Control structure for thickness diffusion
+  type(cont_diag_ptrs), intent(inout) :: CDp      !< Continuity diagnostic control structure
 
-  if (associated(CS)) deallocate(CS)
+  if (CS%id_slope_x > 0) deallocate(CS%diagSlopeX)
+  if (CS%id_slope_y > 0) deallocate(CS%diagSlopeY)
+
+  if (CS%id_GMwork > 0) deallocate(CS%GMwork)
+
+  ! NOTE: [uv]hGM may be allocated either here or the diagnostic module
+  if (associated(CDp%uhGM)) deallocate(CDp%uhGM)
+  if (associated(CDp%vhGM)) deallocate(CDp%vhGM)
+
+  if (CS%use_GME_thickness_diffuse) then
+    deallocate(CS%KH_u_GME)
+    deallocate(CS%KH_v_GME)
+  endif
 end subroutine thickness_diffuse_end
 
 !> \namespace mom_thickness_diffuse

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -667,8 +667,8 @@ end subroutine calc_tidal_forcing
 
 !> This subroutine deallocates memory associated with the tidal forcing module.
 subroutine tidal_forcing_end(CS)
-  type(tidal_forcing_CS), pointer :: CS !< The control structure returned by a previous call
-                                        !! to tidal_forcing_init; it is deallocated here.
+  type(tidal_forcing_CS), intent(inout) :: CS !< The control structure returned by a previous call
+                                              !! to tidal_forcing_init; it is deallocated here.
 
   if (associated(CS%sin_struct)) deallocate(CS%sin_struct)
   if (associated(CS%cos_struct)) deallocate(CS%cos_struct)
@@ -680,9 +680,6 @@ subroutine tidal_forcing_end(CS)
   if (associated(CS%cosphase_prev)) deallocate(CS%cosphase_prev)
   if (associated(CS%sinphase_prev)) deallocate(CS%sinphase_prev)
   if (associated(CS%amp_prev))      deallocate(CS%amp_prev)
-
-  if (associated(CS)) deallocate(CS)
-
 end subroutine tidal_forcing_end
 
 !> \namespace tidal_forcing

--- a/src/parameterizations/vertical/MOM_CVMix_conv.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_conv.F90
@@ -68,7 +68,6 @@ logical function CVMix_conv_init(Time, G, GV, US, param_file, diag, CS)
                             "control structure.")
     return
   endif
-  allocate(CS)
 
   ! Read parameters
   call get_param(param_file, mdl, "USE_CVMix_CONVECTION", CVMix_conv_init, default=.false., do_not_log=.true.)
@@ -83,6 +82,7 @@ logical function CVMix_conv_init(Time, G, GV, US, param_file, diag, CS)
                  default=.false.)
 
   if (.not. CVMix_conv_init) return
+  allocate(CS)
 
   call get_param(param_file, mdl, "ENERGETICS_SFC_PBL", useEPBL, default=.false., &
                 do_not_log=.true.)
@@ -310,14 +310,10 @@ logical function CVMix_conv_is_used(param_file)
 end function CVMix_conv_is_used
 
 !> Clear pointers and dealocate memory
+! NOTE: Placeholder destructor
 subroutine CVMix_conv_end(CS)
   type(CVMix_conv_cs), pointer :: CS !< Control structure for this module that
                                      !! will be deallocated in this subroutine
-
-  if (.not. associated(CS)) return
-
-  deallocate(CS)
-
 end subroutine CVMix_conv_end
 
 end module MOM_CVMix_conv

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -65,7 +65,6 @@ logical function CVMix_ddiff_init(Time, G, GV, US, param_file, diag, CS)
                             "control structure.")
     return
   endif
-  allocate(CS)
 
   ! Read parameters
   call get_param(param_file, mdl, "USE_CVMIX_DDIFF", CVMix_ddiff_init, default=.false., do_not_log=.true.)
@@ -79,6 +78,7 @@ logical function CVMix_ddiff_init(Time, G, GV, US, param_file, diag, CS)
                  default=.false.)
 
   if (.not. CVMix_ddiff_init) return
+  allocate(CS)
 
   call get_param(param_file, mdl, 'DEBUG', CS%debug, default=.False., do_not_log=.True.)
 
@@ -279,12 +279,10 @@ logical function CVMix_ddiff_is_used(param_file)
 end function CVMix_ddiff_is_used
 
 !> Clear pointers and dealocate memory
+! NOTE: Placeholder destructor
 subroutine CVMix_ddiff_end(CS)
   type(CVMix_ddiff_cs), pointer :: CS !< Control structure for this module that
                                       !! will be deallocated in this subroutine
-
-  deallocate(CS)
-
 end subroutine CVMix_ddiff_end
 
 end module MOM_CVMix_ddiff

--- a/src/parameterizations/vertical/MOM_CVMix_shear.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_shear.F90
@@ -211,6 +211,9 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
   ! Local variables
   integer :: NumberTrue=0
   logical :: use_JHL
+  logical :: use_LMD94
+  logical :: use_PP81
+
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
@@ -219,28 +222,23 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
                             "control structure.")
     return
   endif
-  allocate(CS)
 
 ! Set default, read and log parameters
-  call get_param(param_file, mdl, "USE_LMD94", CS%use_LMD94, default=.false., do_not_log=.true.)
-  call get_param(param_file, mdl, "USE_PP81", CS%use_PP81, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "USE_LMD94", use_LMD94, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "USE_PP81", use_PP81, default=.false., do_not_log=.true.)
   call log_version(param_file, mdl, version, &
            "Parameterization of shear-driven turbulence via CVMix (various options)", &
-            all_default=.not.(CS%use_PP81.or.CS%use_LMD94))
-  call get_param(param_file, mdl, "USE_LMD94", CS%use_LMD94, &
+            all_default=.not.(use_PP81.or.use_LMD94))
+  call get_param(param_file, mdl, "USE_LMD94", use_LMD94, &
                  "If true, use the Large-McWilliams-Doney (JGR 1994) "//&
                  "shear mixing parameterization.", default=.false.)
-  if (CS%use_LMD94) then
+  if (use_LMD94) &
     NumberTrue=NumberTrue + 1
-    CS%Mix_Scheme='KPP'
-  endif
-  call get_param(param_file, mdl, "USE_PP81", CS%use_PP81, &
+  call get_param(param_file, mdl, "USE_PP81", use_PP81, &
                  "If true, use the Pacanowski and Philander (JPO 1981) "//&
                  "shear mixing parameterization.", default=.false.)
-  if (CS%use_PP81) then
+  if (use_PP81) &
     NumberTrue = NumberTrue + 1
-    CS%Mix_Scheme='PP'
-  endif
   use_JHL=kappa_shear_is_used(param_file)
   if (use_JHL) NumberTrue = NumberTrue + 1
   ! After testing for interior schemes, make sure only 0 or 1 are enabled.
@@ -250,10 +248,20 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
            'Multiple shear driven internal mixing schemes selected,'//&
            ' please disable all but one scheme to proceed.')
   endif
-  CVMix_shear_init=(CS%use_PP81.or.CS%use_LMD94)
 
-! Forego remainder of initialization if not using this scheme
+  CVMix_shear_init = use_PP81 .or. use_LMD94
+
+  ! Forego remainder of initialization if not using this scheme
   if (.not. CVMix_shear_init) return
+
+  allocate(CS)
+  CS%use_LMD94 = use_LMD94
+  CS%use_PP81 = use_PP81
+  if (use_LMD94) &
+    CS%Mix_Scheme = 'KPP'
+  if (use_PP81) &
+    CS%Mix_Scheme = 'PP'
+
   call get_param(param_file, mdl, "NU_ZERO", CS%Nu_Zero, &
                  "Leading coefficient in KPP shear mixing.", &
                  units="nondim", default=5.e-3)
@@ -326,16 +334,11 @@ end function CVMix_shear_is_used
 
 !> Clear pointers and dealocate memory
 subroutine CVMix_shear_end(CS)
-  type(CVMix_shear_cs), pointer :: CS !< Control structure for this module that
-                                      !! will be deallocated in this subroutine
-
-  if (.not. associated(CS)) return
-
+  type(CVMix_shear_cs), intent(inout) :: CS !< Control structure for this module that
+                                            !! will be deallocated in this subroutine
   if (CS%id_N2 > 0) deallocate(CS%N2)
   if (CS%id_S2 > 0) deallocate(CS%S2)
   if (CS%id_ri_grad > 0) deallocate(CS%ri_grad)
-  deallocate(CS)
-
 end subroutine CVMix_shear_end
 
 end module MOM_CVMix_shear

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -599,11 +599,9 @@ end subroutine geothermal_init
 
 !> Clean up and deallocate memory associated with the geothermal heating module.
 subroutine geothermal_end(CS)
-  type(geothermal_CS), pointer :: CS !< Geothermal heating control structure that
-                                     !! will be deallocated in this subroutine.
-
-  if (associated(CS%geo_heat)) deallocate(CS%geo_heat)
-  if (associated(CS)) deallocate(CS)
+  type(geothermal_CS), intent(inout) :: CS !< Geothermal heating control structure that
+                                           !! will be deallocated in this subroutine.
+  deallocate(CS%geo_heat)
 end subroutine geothermal_end
 
 !> \namespace mom_geothermal

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -1123,8 +1123,12 @@ subroutine opacity_end(CS, optics)
   if (associated(CS)) deallocate(CS)
 
   if (present(optics)) then ; if (associated(optics)) then
-    if (associated(optics%opacity_band)) deallocate(optics%opacity_band)
     if (associated(optics%sw_pen_band)) deallocate(optics%sw_pen_band)
+    if (associated(optics%opacity_band)) deallocate(optics%opacity_band)
+    if (associated(optics%max_wavelength_band)) &
+      deallocate(optics%max_wavelength_band)
+    if (associated(optics%min_wavelength_band)) &
+      deallocate(optics%min_wavelength_band)
   endif ; endif
 
 end subroutine opacity_end

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -355,7 +355,8 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   endif
 
   ! set up arrays for tidal mixing diagnostics
-  call setup_tidal_diagnostics(G, GV, CS%tidal_mixing_CSp)
+  if (CS%use_tidal_mixing) &
+    call setup_tidal_diagnostics(G, GV, CS%tidal_mixing_CSp)
 
   if (CS%useKappaShear) then
     if (CS%debug) then
@@ -665,7 +666,9 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   if (CS%id_Kv_bkgnd > 0) call post_data(CS%id_Kv_bkgnd, dd%Kv_bkgnd, CS%diag)
 
   ! tidal mixing
-  call post_tidal_diagnostics(G, GV, h, CS%tidal_mixing_CSp)
+  if (CS%use_tidal_mixing) &
+    call post_tidal_diagnostics(G, GV, h, CS%tidal_mixing_CSp)
+
   if (CS%id_N2 > 0)         call post_data(CS%id_N2,        dd%N2_3d,     CS%diag)
   if (CS%id_Kd_Work > 0)    call post_data(CS%id_Kd_Work,   dd%Kd_Work,   CS%diag)
   if (CS%id_maxTKE > 0)     call post_data(CS%id_maxTKE,    dd%maxTKE,    CS%diag)
@@ -693,6 +696,8 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   if (associated(dd%KS_extra)) deallocate(dd%KS_extra)
   if (associated(dd%drho_rat)) deallocate(dd%drho_rat)
   if (associated(dd%Kd_BBL)) deallocate(dd%Kd_BBL)
+  if (associated(dd%Kd_bkgnd)) deallocate(dd%Kd_bkgnd)
+  if (associated(dd%Kv_bkgnd)) deallocate(dd%Kv_bkgnd)
 
   if (showCallTree) call callTree_leave("set_diffusivity()")
 
@@ -2344,22 +2349,26 @@ end subroutine set_diffusivity_init
 
 !> Clear pointers and dealocate memory
 subroutine set_diffusivity_end(CS)
-  type(set_diffusivity_CS), pointer :: CS !< Control structure for this module
-
-  if (.not.associated(CS)) return
+  type(set_diffusivity_CS), intent(inout) :: CS !< Control structure for this module
 
   call bkgnd_mixing_end(CS%bkgnd_mixing_csp)
 
-  if (CS%use_tidal_mixing) call tidal_mixing_end(CS%tidal_mixing_CSp)
+  if (CS%use_tidal_mixing) then
+    call tidal_mixing_end(CS%tidal_mixing_CSp)
+    deallocate(CS%tidal_mixing_CSp)
+  endif
 
   if (CS%user_change_diff) call user_change_diff_end(CS%user_change_diff_CSp)
 
-  if (CS%use_CVMix_shear)  call CVMix_shear_end(CS%CVMix_shear_csp)
+  if (associated(CS%CVMix_ddiff_CSp)) deallocate(CS%CVMix_ddiff_CSp)
 
-  if (CS%use_CVMix_ddiff)  call CVMix_ddiff_end(CS%CVMix_ddiff_csp)
+  if (CS%use_CVMix_shear) then
+    call CVMix_shear_end(CS%CVMix_shear_CSp)
+    deallocate(CS%CVMix_shear_CSp)
+  endif
 
-  if (associated(CS)) deallocate(CS)
-
+  ! NOTE: CS%kappaShear_CSp is always allocated, even if unused
+  deallocate(CS%kappaShear_CSp)
 end subroutine set_diffusivity_end
 
 end module MOM_set_diffusivity

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -219,6 +219,8 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, CS)
   type(tidal_mixing_cs),    pointer       :: CS         !< This module's control structure.
 
   ! Local variables
+  logical :: use_CVMix_tidal
+  logical :: int_tide_dissipation
   logical :: read_tideamp
   logical :: default_2018_answers
   character(len=20)  :: tmpstr, int_tide_profile_str
@@ -229,6 +231,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, CS)
   real :: Niku_scale ! local variable for scaling the Nikurashin TKE flux data
   integer :: i, j, is, ie, js, je
   integer :: isd, ied, jsd, jed
+
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_tidal_mixing"     !< This module's name.
@@ -238,38 +241,42 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, diag, CS)
                             "is already associated.")
     return
   endif
-  allocate(CS)
-  allocate(CS%dd)
-
-  CS%debug = CS%debug.and.is_root_pe()
 
   is  = G%isc ; ie  = G%iec ; js  = G%jsc ; je  = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
-  CS%diag => diag
-
   ! Read parameters
-  call get_param(param_file, mdl, "USE_CVMix_TIDAL", CS%use_CVMix_tidal, &
+  ! NOTE: These are read twice because logfile output is streamed and we want
+  !   to preserve the ordering of module header before parameters.
+  call get_param(param_file, mdl, "USE_CVMix_TIDAL", use_CVMix_tidal, &
                  default=.false., do_not_log=.true.)
-  call get_param(param_file, mdl, "INT_TIDE_DISSIPATION", CS%int_tide_dissipation, &
-                 default=CS%use_CVMix_tidal, do_not_log=.true.)
+  call get_param(param_file, mdl, "INT_TIDE_DISSIPATION", int_tide_dissipation, &
+                 default=use_CVMix_tidal, do_not_log=.true.)
   call log_version(param_file, mdl, version, &
                  "Vertical Tidal Mixing Parameterization", &
-                 all_default=.not.(CS%use_CVMix_tidal .or. CS%int_tide_dissipation))
-  call get_param(param_file, mdl, "USE_CVMix_TIDAL", CS%use_CVMix_tidal, &
+                 all_default=.not.(use_CVMix_tidal .or. int_tide_dissipation))
+
+  call get_param(param_file, mdl, "USE_CVMix_TIDAL", use_CVMix_tidal, &
                  "If true, turns on tidal mixing via CVMix", &
                  default=.false.)
+  call get_param(param_file, mdl, "INT_TIDE_DISSIPATION", int_tide_dissipation, &
+                 "If true, use an internal tidal dissipation scheme to "//&
+                 "drive diapycnal mixing, along the lines of St. Laurent "//&
+                 "et al. (2002) and Simmons et al. (2004).", default=use_CVMix_tidal)
+
+  ! return if tidal mixing is inactive
+  tidal_mixing_init = int_tide_dissipation
+  if (.not. tidal_mixing_init) return
+
+  allocate(CS)
+  allocate(CS%dd)
+  CS%debug = CS%debug.and.is_root_pe()
+  CS%diag => diag
+  CS%use_CVmix_tidal = use_CVmix_tidal
+  CS%int_tide_dissipation = int_tide_dissipation
 
   call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".",do_not_log=.true.)
   CS%inputdir = slasher(CS%inputdir)
-  call get_param(param_file, mdl, "INT_TIDE_DISSIPATION", CS%int_tide_dissipation, &
-                 "If true, use an internal tidal dissipation scheme to "//&
-                 "drive diapycnal mixing, along the lines of St. Laurent "//&
-                 "et al. (2002) and Simmons et al. (2004).", default=CS%use_CVMix_tidal)
-
-  ! return if tidal mixing is inactive
-  tidal_mixing_init = CS%int_tide_dissipation
-  if (.not. tidal_mixing_init) return
 
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
@@ -1720,18 +1727,14 @@ end subroutine read_tidal_constituents
 
 !> Clear pointers and deallocate memory
 subroutine tidal_mixing_end(CS)
-  type(tidal_mixing_cs), pointer :: CS !< This module's control structure, which
-                                       !! will be deallocated in this routine.
+  type(tidal_mixing_cs), intent(inout) :: CS !< This module's control structure, which
+                                             !! will be deallocated in this routine.
 
-  if (.not.associated(CS)) return
-
-  !TODO deallocate all the dynamically allocated members here ...
+  ! TODO: deallocate all the dynamically allocated members here ...
   if (allocated(CS%tidal_qe_2d))    deallocate(CS%tidal_qe_2d)
   if (allocated(CS%tidal_qe_3d_in)) deallocate(CS%tidal_qe_3d_in)
   if (allocated(CS%h_src))          deallocate(CS%h_src)
   deallocate(CS%dd)
-  deallocate(CS)
-
 end subroutine tidal_mixing_end
 
 end module MOM_tidal_mixing

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1885,14 +1885,16 @@ end subroutine updateCFLtruncationValue
 
 !> Clean up and deallocate the vertical friction module
 subroutine vertvisc_end(CS)
-  type(vertvisc_CS), pointer :: CS !< Vertical viscosity control structure that
-                                   !! will be deallocated in this subroutine.
+  type(vertvisc_CS), intent(inout) :: CS  !< Vertical viscosity control structure that
+                                          !! will be deallocated in this subroutine.
+
+  if ((len_trim(CS%u_trunc_file) > 0) .or. (len_trim(CS%v_trunc_file) > 0)) &
+    deallocate(CS%PointAccel_CSp)
 
   DEALLOC_(CS%a_u) ; DEALLOC_(CS%h_u)
   DEALLOC_(CS%a_v) ; DEALLOC_(CS%h_v)
   if (associated(CS%a1_shelf_u)) deallocate(CS%a1_shelf_u)
   if (associated(CS%a1_shelf_v)) deallocate(CS%a1_shelf_v)
-  deallocate(CS)
 end subroutine vertvisc_end
 
 !> \namespace mom_vert_friction

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -332,12 +332,16 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, CS, p_surf)
     ! TODO: add similar code for BOTTOM boundary layer
   endif
 
-  if (.not.CS%remap_answers_2018) then
-    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
-  elseif (GV%Boussinesq) then
-    h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
-  else
-    h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
+  h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
+
+  if (.not. CS%continuous_reconstruction) then
+    if (CS%remap_answers_2018) then
+      if (GV%Boussinesq) then
+        h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
+      else
+        h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
+      endif
+    endif
   endif
 
   ! If doing along isopycnal diffusion (as opposed to neutral diffusion, set the reference pressure)
@@ -572,10 +576,12 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, dt, Reg, US, CS)
   real :: Idt  ! The inverse of the time step [T-1 ~> s-1]
   real :: h_neglect, h_neglect_edge
 
-  if (.not.CS%remap_answers_2018) then
-    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
-  else
-    h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
+  h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
+
+  if (.not. CS%continuous_reconstruction) then
+    if (CS%remap_answers_2018) then
+      h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
+    endif
   endif
 
   nk = GV%ke


### PR DESCRIPTION
This patch fixes up and enables several of the derived type destructor
functions (`_end()`) used to handle memory management of the model.

- Two uninitialized logical flags which would cause errors in optimized
  builds have also been fixed.

  * `Visbeck_S_max` in thickness diffusion is now initialized to zero,
    which acts to disable it in subsequent operations.

  * `remap_answers_2018` is now unset when `NDIFF_CONTINUOUS` is false.

- Several of the destructor functions were restructured so that they do
  not explicitly deallocate their pointer inputs.  This will allow us to
  stage the functions as formal destructors for the derived types via
  the `final` keyword in a later patch.  It also allows us to pass the
  inputs on stack rather than as pointers.

  * `barotropic_end`
  * `continuity_end`
  * `CoriolisAdv_end`
  * `deallocate_MOM_domain`
  * `diabatic_driver_end`
  * `geothermal_end`
  * `hor_visc_end`
  * `MEKE_end`
  * `MOM_CVMix_conv_end`
  * `MOM_CVMix_ddiff_end`
  * `MOM_CVMix_shear_end`
  * `MOM_diagnostics_end`
  * `MOM_regridding_end`
  * `MOM_sum_output_end`
  * `PressureForce_end`
  * `set_diffusivity_end`
  * `thickness_diffuse_end`
  * `tidal_forcing_end`
  * `VarMix_end`
  * `vertvisc_end`

- In a few cases, the deallocations were re-ordered to match the
  reversed order of allocation.

  * `MOM_CVMix_conv_mod`
  * `MOM_CVMix_ddiff_mod`
  * `MOM_CVMix_shear_mod`

- A few constructors always initialized their control structures, even
  when disabled.  In some of these cases, the allocation is now skipped
  if the corresponding feature is disabled.

- `diag_mediator_end` now includes the following changes:

  * `axes_grp_end` was introduced to deallocate axes_grp types.
    The `remap_axes*` are now deallocated.

  * We now cycles through the diagnostic list and deallocate the
    supplemental diagnostics.

  * Downsampled diagnostic masks and remaps are now deallocated

- The initialized `blockName` of the param file parser are now
  dellocated before reinitializing them.  Although the existing value is
  still lost, it is at least now deallocated from heap.

- A bug was fixed in `hor_visc_end`; Smag_Ah and Leith_Ah areas were
  incorrectly swapped.

The principal motivation for this work is to eliminate any errors
detected by valgrind, and to integrated automated memcheck testing to
the verification test suite.