### PR TITLE
Additional memory cleanups

### DIFF
--- a/config_src/infra/FMS1/MOM_interp_infra.F90
+++ b/config_src/infra/FMS1/MOM_interp_infra.F90
@@ -5,7 +5,8 @@ module MOM_interp_infra
 
 use MOM_domain_infra,    only : MOM_domain_type, domain2d
 use MOM_time_manager,    only : time_type
-use horiz_interp_mod,    only : horiz_interp_new, horiz_interp, horiz_interp_init, horiz_interp_type
+use horiz_interp_mod,    only : horiz_interp_new, horiz_interp, horiz_interp_type
+use horiz_interp_mod,    only : horiz_interp_init, horiz_interp_del
 use mpp_io_mod,          only : axistype, mpp_get_axis_data
 use time_interp_external_mod, only : time_interp_external
 use time_interp_external_mod, only : init_external_field, time_interp_external_init
@@ -14,7 +15,7 @@ use time_interp_external_mod, only : get_external_field_axes, get_external_field
 
 implicit none ; private
 
-public :: horiz_interp_type, horiz_interp_init
+public :: horiz_interp_type, horiz_interp_init, horiz_interp_del
 public :: time_interp_extern, init_extern_field, time_interp_external_init
 public :: get_external_field_info, axistype, get_axis_data
 public :: run_horiz_interp, build_horiz_interp_weights

--- a/config_src/infra/FMS2/MOM_interp_infra.F90
+++ b/config_src/infra/FMS2/MOM_interp_infra.F90
@@ -5,7 +5,8 @@ module MOM_interp_infra
 
 use MOM_domain_infra,    only : MOM_domain_type, domain2d
 use MOM_time_manager,    only : time_type
-use horiz_interp_mod,    only : horiz_interp_new, horiz_interp, horiz_interp_init, horiz_interp_type
+use horiz_interp_mod,    only : horiz_interp_new, horiz_interp, horiz_interp_type
+use horiz_interp_mod,    only : horiz_interp_init, horiz_interp_del
 use mpp_io_mod,          only : axistype, mpp_get_axis_data
 use time_interp_external_mod, only : time_interp_external
 use time_interp_external_mod, only : init_external_field, time_interp_external_init
@@ -14,7 +15,7 @@ use time_interp_external_mod, only : get_external_field_axes, get_external_field
 
 implicit none ; private
 
-public :: horiz_interp_type, horiz_interp_init
+public :: horiz_interp_type, horiz_interp_init, horiz_interp_del
 public :: time_interp_extern, init_extern_field, time_interp_external_init
 public :: get_external_field_info, axistype, get_axis_data
 public :: run_horiz_interp, build_horiz_interp_weights

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -656,9 +656,10 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
       call set_regrid_max_depths(CS, z_max, GV%m_to_H)
     elseif (index(trim(string),'FNC1:')==1) then
       call dz_function1( trim(string(6:)), dz_max )
-      if ((coordinateMode(coord_mode) == REGRIDDING_SLIGHT) .and. &
-          (dz_fixed_sfc > 0.0)) then
-        do k=1,nz_fixed_sfc ; dz_max(k) = dz_fixed_sfc ; enddo
+      if (coordinateMode(coord_mode) == REGRIDDING_SLIGHT) then
+        if (dz_fixed_sfc > 0.0) then
+          do k=1,nz_fixed_sfc ; dz_max(k) = dz_fixed_sfc ; enddo
+        endif
       endif
       z_max(1) = 0.0 ; do K=1,ke ; z_max(K+1) = z_max(K) + dz_max(K) ; enddo
       call log_param(param_file, mdl, "!MAXIMUM_INT_DEPTHS", z_max, &

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -268,6 +268,8 @@ subroutine close_param_file(CS, quiet_close, component)
     enddo
     CS%log_open = .false.
     call doc_end(CS%doc)
+    deallocate(CS%doc)
+    deallocate(CS%blockName)
     return
   endif ; endif
 
@@ -334,14 +336,15 @@ subroutine close_param_file(CS, quiet_close, component)
     deallocate (CS%param_data(i)%line)
     deallocate (CS%param_data(i)%line_used)
   enddo
-  deallocate(CS%blockName)
 
   if (is_root_pe() .and. (num_unused>0) .and. CS%unused_params_fatal) &
     call MOM_error(FATAL, "Run stopped because of unused parameter lines.")
 
   CS%log_open = .false.
   call doc_end(CS%doc)
+  deallocate(CS%doc)
 
+  deallocate(CS%blockName)
 end subroutine close_param_file
 
 !> Read the contents of a parameter input file, and store the contents in a

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -11,16 +11,13 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
-use MOM_interpolate,   only : time_interp_external, horiz_interp_init
+use MOM_interpolate,   only : time_interp_external, horiz_interp_init, horiz_interp_del
 use MOM_interpolate,   only : build_horiz_interp_weights, run_horiz_interp, horiz_interp_type
 use MOM_interp_infra,  only : axistype, get_external_field_info, get_axis_data
 use MOM_time_manager,  only : time_type
 
 use netcdf, only : NF90_OPEN, NF90_NOWRITE, NF90_GET_ATT, NF90_GET_VAR
 use netcdf, only : NF90_INQ_VARID, NF90_INQUIRE_VARIABLE, NF90_INQUIRE_DIMENSION
-
-! Temporarily pull from FMS
-use horiz_interp_mod, only : horiz_interp_del
 
 implicit none ; private
 

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -19,6 +19,9 @@ use MOM_time_manager,  only : time_type
 use netcdf, only : NF90_OPEN, NF90_NOWRITE, NF90_GET_ATT, NF90_GET_VAR
 use netcdf, only : NF90_INQ_VARID, NF90_INQUIRE_VARIABLE, NF90_INQUIRE_DIMENSION
 
+! Temporarily pull from FMS
+use horiz_interp_mod, only : horiz_interp_del
+
 implicit none ; private
 
 #include <MOM_memory.h>
@@ -607,6 +610,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
     endif
 
   enddo ! kd
+  call horiz_interp_del(Interp)
 
 end subroutine horiz_interp_and_extrap_tracer_record
 

--- a/src/framework/MOM_interpolate.F90
+++ b/src/framework/MOM_interpolate.F90
@@ -7,14 +7,15 @@ use MOM_array_transform, only : allocate_rotated_array, rotate_array
 use MOM_error_handler,   only : MOM_error, FATAL
 use MOM_interp_infra,    only : time_interp_extern, init_external_field=>init_extern_field
 use MOM_interp_infra,    only : time_interp_external_init, get_external_field_info
-use MOM_interp_infra,    only : horiz_interp_type, horiz_interp_init
+use MOM_interp_infra,    only : horiz_interp_type, horiz_interp_init, horiz_interp_del
 use MOM_interp_infra,    only : run_horiz_interp, build_horiz_interp_weights
 use MOM_time_manager,    only : time_type
 
 implicit none ; private
 
 public :: time_interp_external, init_external_field, time_interp_external_init, get_external_field_info
-public :: horiz_interp_type, horiz_interp_init, run_horiz_interp, build_horiz_interp_weights
+public :: horiz_interp_type, run_horiz_interp, build_horiz_interp_weights
+public :: horiz_interp_init, horiz_interp_del
 
 !> Read a field based on model time, and rotate to the model domain.
 interface time_interp_external

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -1730,10 +1730,16 @@ subroutine tidal_mixing_end(CS)
   type(tidal_mixing_cs), intent(inout) :: CS !< This module's control structure, which
                                              !! will be deallocated in this routine.
 
-  ! TODO: deallocate all the dynamically allocated members here ...
   if (allocated(CS%tidal_qe_2d))    deallocate(CS%tidal_qe_2d)
   if (allocated(CS%tidal_qe_3d_in)) deallocate(CS%tidal_qe_3d_in)
   if (allocated(CS%h_src))          deallocate(CS%h_src)
+
+  if (associated(CS%tideamp)) deallocate(CS%tideamp)
+  if (associated(CS%mask_itidal)) deallocate(CS%mask_itidal)
+  if (associated(CS%TKE_itidal)) deallocate(CS%TKE_itidal)
+  if (associated(CS%h2)) deallocate(CS%h2)
+  if (associated(CS%Nb)) deallocate(CS%Nb)
+
   deallocate(CS%dd)
 end subroutine tidal_mixing_end
 


### PR DESCRIPTION
This PR contains three patches, mainly related to ice-ocean simulations.

- Three more deallocation cleanups.  Most notable is use of `horiz_interp_del` after `horiz_interp_and_extrap_tracer_record` calls.  The others are more generic final-type calls.
- A few short-circuit if-block fixes
- A linked list was added to the diag mediator to handle non-standard grid axes.  This was introduced to track and deallocate the internal copies of these axis groups.

Details are in the individual commit logs.