### PR TITLE
Replace MOM_control_struct pointers as locals

### DIFF
--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -195,8 +195,8 @@ type, public :: ocean_state_type ; private
   type(unit_scale_type), pointer :: &
     US => NULL()              !< A pointer to a structure containing dimensional
                               !! unit scaling factors.
-  type(MOM_control_struct), pointer :: &
-    MOM_CSp => NULL()         !< A pointer to the MOM control structure
+  type(MOM_control_struct) :: MOM_CSp
+                              !< MOM control structure
   type(ice_shelf_CS), pointer :: &
     Ice_shelf_CSp => NULL()   !< A pointer to the control structure for the
                               !! ice shelf model that couples with MOM6.  This

--- a/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
+++ b/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
@@ -195,8 +195,8 @@ type, public :: ocean_state_type ;
                               !! about the vertical grid.
   type(unit_scale_type), pointer :: US => NULL() !< A pointer to a structure containing
                               !! dimensional unit scaling factors.
-  type(MOM_control_struct), pointer :: &
-    MOM_CSp => NULL()         !< A pointer to the MOM control structure
+  type(MOM_control_struct)    :: MOM_CSp
+                              !< MOM control structure
   type(ice_shelf_CS), pointer :: &
     Ice_shelf_CSp => NULL()   !< A pointer to the control structure for the
                               !! ice shelf model that couples with MOM6.  This

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -197,8 +197,8 @@ type, public :: ocean_state_type ; private
                               !! about the vertical grid.
   type(unit_scale_type), pointer :: US => NULL() !< A pointer to a structure containing
                               !! dimensional unit scaling factors.
-  type(MOM_control_struct), pointer :: &
-    MOM_CSp => NULL()         !< A pointer to the MOM control structure
+  type(MOM_control_struct)    :: MOM_CSp
+                              !< MOM control structure
   type(ice_shelf_CS), pointer :: &
     Ice_shelf_CSp => NULL()   !< A pointer to the control structure for the
                               !! ice shelf model that couples with MOM6.  This

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -180,8 +180,7 @@ program MOM_main
                                  ! and diffusion equation are read in from files stored from
                                  ! a previous integration of the prognostic model
 
-  type(MOM_control_struct),  pointer :: MOM_CSp => NULL()
-  !> A pointer to the tracer flow control structure.
+  type(MOM_control_struct) :: MOM_CSp   !> MOM control structure
   type(tracer_flow_control_CS), pointer :: &
     tracer_flow_CSp => NULL()  !< A pointer to the tracer flow control structure
   type(surface_forcing_CS),  pointer :: surface_forcing_CSp => NULL()

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -3473,16 +3473,18 @@ subroutine diag_mediator_end(time, diag_CS, end_diag_manager)
     call axes_grp_end(diag_cs%remap_axesCvi(i))
   enddo
 
-  deallocate(diag_cs%remap_axesZL)
-  deallocate(diag_cs%remap_axesZi)
-  deallocate(diag_cs%remap_axesTL)
-  deallocate(diag_cs%remap_axesTi)
-  deallocate(diag_cs%remap_axesBL)
-  deallocate(diag_cs%remap_axesBi)
-  deallocate(diag_cs%remap_axesCuL)
-  deallocate(diag_cs%remap_axesCui)
-  deallocate(diag_cs%remap_axesCvL)
-  deallocate(diag_cs%remap_axesCvi)
+  if (diag_cs%num_diag_coords > 0) then
+    deallocate(diag_cs%remap_axesZL)
+    deallocate(diag_cs%remap_axesZi)
+    deallocate(diag_cs%remap_axesTL)
+    deallocate(diag_cs%remap_axesTi)
+    deallocate(diag_cs%remap_axesBL)
+    deallocate(diag_cs%remap_axesBi)
+    deallocate(diag_cs%remap_axesCuL)
+    deallocate(diag_cs%remap_axesCui)
+    deallocate(diag_cs%remap_axesCvL)
+    deallocate(diag_cs%remap_axesCvi)
+  endif
 
   do dl=2,MAX_DSAMP_LEV
     if (allocated(diag_cs%dsamp(dl)%remap_axesTL)) &


### PR DESCRIPTION
The MOM_control_struct is declared and passed as a pointer to a CS
(usually allocated anonymously) and treated as if it were a pointer,
even though there is currently no real advantage to doing so.

After the FMS update, the deallocation of this CS was causing a
segmentation fault in the PGI compilers.  While the underlying cause was
never determined, it is likely due to some automated deallocation of the
CS contents, whose addressing became scrambled.

This problem can be resolved by moving all of the CS contents to stack,
so that the contents are automatically removed upon exiting whatever
function it was instantiated.  Subsequent calls can reference the local
(or parent) stack contents.