### PR TITLE
(+)Modified some optional arguments

### DIFF
--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -197,7 +197,7 @@ end type transport_diag_IDs
 contains
 !> Diagnostics not more naturally calculated elsewhere are computed here.
 subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
-                                       dt, diag_pre_sync, G, GV, US, CS, eta_bt)
+                                       dt, diag_pre_sync, G, GV, US, CS)
   type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
@@ -227,11 +227,6 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
   type(diag_grid_storage), intent(in)    :: diag_pre_sync !< Target grids from previous timestep
   type(diagnostics_CS),    intent(inout) :: CS   !< Control structure returned by a
                                                  !! previous call to diagnostics_init.
-  real, dimension(SZI_(G),SZJ_(G)), &
-                  optional, intent(in)   :: eta_bt !< An optional barotropic
-    !! variable that gives the "correct" free surface height (Boussinesq) or total water column
-    !! mass per unit area (non-Boussinesq).  This is used to dilate the layer thicknesses when
-    !! calculating interface heights [H ~> m or kg m-2].
 
   ! Local variables
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)) :: usq ! squared eastward velocity  [L2 T-2 ~> m2 s-2]
@@ -390,7 +385,7 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
   endif
 
   if (associated(CS%e)) then
-    call find_eta(h, tv, G, GV, US, CS%e, eta_bt)
+    call find_eta(h, tv, G, GV, US, CS%e)
     if (CS%id_e > 0) call post_data(CS%id_e, CS%e, CS%diag)
   endif
 
@@ -400,7 +395,7 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
         CS%e_D(i,j,k) = CS%e(i,j,k) + G%bathyT(i,j)
       enddo ; enddo ; enddo
     else
-      call find_eta(h, tv, G, GV, US, CS%e_D, eta_bt)
+      call find_eta(h, tv, G, GV, US, CS%e_D)
       do k=1,nz+1 ; do j=js,je ; do i=is,ie
         CS%e_D(i,j,k) = CS%e_D(i,j,k) + G%bathyT(i,j)
       enddo ; enddo ; enddo
@@ -1935,7 +1930,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
     call wave_speed_init(CS%wave_speed_CSp, remap_answers_2018=remap_answers_2018, &
                          better_speed_est=better_speed_est, min_speed=wave_speed_min, &
                          wave_speed_tol=wave_speed_tol)
-    call wave_speed_init(CS%wave_speed_CSp, remap_answers_2018=remap_answers_2018)
+!###    call wave_speed_init(CS%wave_speed_CSp, remap_answers_2018=remap_answers_2018)
     call safe_alloc_ptr(CS%cg1,isd,ied,jsd,jed)
     if (CS%id_Rd1>0)       call safe_alloc_ptr(CS%Rd1,isd,ied,jsd,jed)
     if (CS%id_Rd_ebt>0)    call safe_alloc_ptr(CS%Rd1,isd,ied,jsd,jed)

--- a/src/framework/MOM_unit_scaling.F90
+++ b/src/framework/MOM_unit_scaling.F90
@@ -54,8 +54,8 @@ contains
 
 !> Allocates and initializes the ocean model unit scaling type
 subroutine unit_scaling_init( param_file, US )
-  type(param_file_type), optional, intent(in) :: param_file !< Parameter file handle/type
-  type(unit_scale_type), optional, pointer    :: US         !< A dimensional unit scaling type
+  type(param_file_type), intent(in) :: param_file !< Parameter file handle/type
+  type(unit_scale_type), pointer    :: US         !< A dimensional unit scaling type
 
   ! This routine initializes a unit_scale_type structure (US).
 
@@ -66,39 +66,33 @@ subroutine unit_scaling_init( param_file, US )
 # include "version_variable.h"
   character(len=16) :: mdl = "MOM_unit_scaling"
 
-  if (.not.present(US)) return
-
   if (associated(US)) call MOM_error(FATAL, &
      'unit_scaling_init: called with an associated US pointer.')
   allocate(US)
 
-  if (present(param_file)) then
-    ! Read all relevant parameters and write them to the model log.
-    call log_version(param_file, mdl, version, &
-                 "Parameters for doing unit scaling of variables.", debugging=.true.)
-    call get_param(param_file, mdl, "Z_RESCALE_POWER", Z_power, &
-                 "An integer power of 2 that is used to rescale the model's "//&
-                 "internal units of depths and heights.  Valid values range from -300 to 300.", &
+  ! Read all relevant parameters and write them to the model log.
+  call log_version(param_file, mdl, version, &
+               "Parameters for doing unit scaling of variables.", debugging=.true.)
+  call get_param(param_file, mdl, "Z_RESCALE_POWER", Z_power, &
+               "An integer power of 2 that is used to rescale the model's "//&
+               "internal units of depths and heights.  Valid values range from -300 to 300.", &
+               units="nondim", default=0, debuggingParam=.true.)
+  call get_param(param_file, mdl, "L_RESCALE_POWER", L_power, &
+               "An integer power of 2 that is used to rescale the model's "//&
+               "internal units of lateral distances.  Valid values range from -300 to 300.", &
+               units="nondim", default=0, debuggingParam=.true.)
+  call get_param(param_file, mdl, "T_RESCALE_POWER", T_power, &
+               "An integer power of 2 that is used to rescale the model's "//&
+               "internal units of time.  Valid values range from -300 to 300.", &
+               units="nondim", default=0, debuggingParam=.true.)
+  call get_param(param_file, mdl, "R_RESCALE_POWER", R_power, &
+               "An integer power of 2 that is used to rescale the model's "//&
+               "internal units of density.  Valid values range from -300 to 300.", &
+               units="nondim", default=0, debuggingParam=.true.)
+  call get_param(param_file, mdl, "Q_RESCALE_POWER", Q_power, &
+               "An integer power of 2 that is used to rescale the model's "//&
+                 "internal units of heat content.  Valid values range from -300 to 300.", &
                  units="nondim", default=0, debuggingParam=.true.)
-    call get_param(param_file, mdl, "L_RESCALE_POWER", L_power, &
-                 "An integer power of 2 that is used to rescale the model's "//&
-                 "internal units of lateral distances.  Valid values range from -300 to 300.", &
-                 units="nondim", default=0, debuggingParam=.true.)
-    call get_param(param_file, mdl, "T_RESCALE_POWER", T_power, &
-                 "An integer power of 2 that is used to rescale the model's "//&
-                 "internal units of time.  Valid values range from -300 to 300.", &
-                 units="nondim", default=0, debuggingParam=.true.)
-    call get_param(param_file, mdl, "R_RESCALE_POWER", R_power, &
-                 "An integer power of 2 that is used to rescale the model's "//&
-                 "internal units of density.  Valid values range from -300 to 300.", &
-                 units="nondim", default=0, debuggingParam=.true.)
-    call get_param(param_file, mdl, "Q_RESCALE_POWER", Q_power, &
-                 "An integer power of 2 that is used to rescale the model's "//&
-                   "internal units of heat content.  Valid values range from -300 to 300.", &
-                   units="nondim", default=0, debuggingParam=.true.)
-  else
-    Z_power = 0 ; L_power = 0 ; T_power = 0 ; R_power = 0 ; Q_power = 0
-  endif
 
   if (abs(Z_power) > 300) call MOM_error(FATAL, "unit_scaling_init: "//&
                  "Z_RESCALE_POWER is outside of the valid range of -300 to 300.")

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2509,6 +2509,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, MEKE, ADp)
   if (CS%Laplacian .or. get_all) then
   endif
 end subroutine hor_visc_init
+
 !> Calculates factors in the anisotropic orientation tensor to be align with the grid.
 !! With n1=1 and n2=0, this recovers the approach of Large et al, 2001.
 subroutine align_aniso_tensor_to_grid(CS, n1, n2)
@@ -2525,6 +2526,7 @@ subroutine align_aniso_tensor_to_grid(CS, n1, n2)
   CS%n1n1_m_n2n2_h(:,:) = ( n1 * n1 - n2 * n2 ) * recip_n2_norm
   CS%n1n1_m_n2n2_q(:,:) = ( n1 * n1 - n2 * n2 ) * recip_n2_norm
 end subroutine align_aniso_tensor_to_grid
+
 !> Apply a 1-1-4-1-1 Laplacian filter one time on GME diffusive flux to reduce any
 !! horizontal two-grid-point noise
 subroutine smooth_GME(CS,G,GME_flux_h,GME_flux_q)
@@ -2589,6 +2591,7 @@ subroutine smooth_GME(CS,G,GME_flux_h,GME_flux_q)
     endif
   enddo ! s-loop
 end subroutine smooth_GME
+
 !> Deallocates any variables allocated in hor_visc_init.
 subroutine hor_visc_end(CS)
   type(hor_visc_CS), pointer :: CS !< The control structure returned by a

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -3084,8 +3084,6 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
         'Salinity', 'PSU')
   endif
 
-
-  !call set_diffusivity_init(Time, G, param_file, diag, CS%set_diff_CSp, CS%int_tide_CSp)
   CS%id_Kd_int = register_diag_field('ocean_model', 'Kd_interface', diag%axesTi, Time, &
       'Total diapycnal diffusivity at interfaces', 'm2 s-1', conversion=US%Z2_T_to_m2_s)
   if (CS%use_energetic_PBL) then

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1888,7 +1888,7 @@ end subroutine vertvisc_init
 subroutine updateCFLtruncationValue(Time, CS, activate)
   type(time_type), target, intent(in)    :: Time     !< Current model time
   type(vertvisc_CS),       pointer       :: CS       !< Vertical viscosity control structure
-  logical, optional,       intent(in)    :: activate !< Specifiy whether to record the value of
+  logical, optional,       intent(in)    :: activate !< Specify whether to record the value of
                                                      !! Time as the beginning of the ramp period
 
   ! Local variables


### PR DESCRIPTION
Modified optional arguments in 4 modules to reflect their actual usage.

1. Eliminated the optional argument full_prec to zonal_flux_adjust and
   meridional_flux_adjust, which were always called with the hard-coded value
   "true", and made the optional arguments monotonic and simple_2nd to
   PPM_reconstruction_[xy] mandatory.

2. Eliminated the optional argument eta_bt to calculate_diagnostic_fields, which
   was never present.

3. Made the two optional arguments to unit_scaling_init mandatory.

4. Eliminated the optional do_i argument to F_to_ent, which was never present
   in calls, and made the parameter just_read_params to entrain_diffusive_init
   mandatory.

All answers are bitwise identical.