### PR TITLE
+Add a restart registry lock & fix OBC call order

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -41,7 +41,7 @@ use MOM_io,                   only : MOM_io_init, vardesc, var_desc
 use MOM_io,                   only : slasher, file_exists, MOM_read_data
 use MOM_obsolete_params,      only : find_obsolete_params
 use MOM_restart,              only : register_restart_field, register_restart_pair
-use MOM_restart,              only : query_initialized, save_restart
+use MOM_restart,              only : query_initialized, save_restart, restart_registry_lock
 use MOM_restart,              only : restart_init, is_new_run, determine_is_new_run, MOM_restart_CS
 use MOM_spatial_means,        only : global_mass_integral
 use MOM_time_manager,         only : time_type, real_to_time, time_type_to_real, operator(+)
@@ -2152,8 +2152,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     if (associated(OBC_in)) then
       ! TODO: General OBC index rotations is not yet supported.
       if (modulo(turns, 4) /= 1) &
-        call MOM_error(FATAL, "OBC index rotation of 180 and 270 degrees is " &
-          // "not yet unsupported.")
+        call MOM_error(FATAL, "OBC index rotation of 180 and 270 degrees is not yet supported.")
       allocate(CS%OBC)
       call rotate_OBC_config(OBC_in, dG_in, CS%OBC, dG, turns)
     endif
@@ -2173,8 +2172,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   call callTree_waypoint("grids initialized (initialize_MOM)")
 
   call MOM_timing_init(CS)
-
-  if (associated(CS%OBC)) call call_OBC_register(param_file, CS%update_OBC_CSp, US, CS%OBC)
 
   call tracer_registry_init(param_file, CS%tracer_Reg)
 
@@ -2229,21 +2226,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                            flux_scale=conv2salt, convergence_units='kg m-2 s-1', &
                            convergence_scale=0.001*GV%H_to_kg_m2, CMOR_tendprefix="osalt", diag_form=2)
     endif
-    ! NOTE: register_temp_salt_segments includes allocation of tracer fields
-    !   along segments.  Bit reproducibility requires that MOM_initialize_state
-    !   be called on the input index map, so we must setup both OBC and OBC_in.
-    !
-    ! XXX: This call on OBC_in allocates the tracer fields on the unrotated
-    !   grid, but also incorrectly stores a pointer to a tracer_type for the
-    !   rotated registry (e.g. segment%tr_reg%Tr(n)%Tr) from CS%tracer_reg.
-    !
-    !   While incorrect and potentially dangerous, it does not seem that this
-    !   pointer is used during initialization, so we leave it for now.
-    if (CS%rotate_index .and. associated(OBC_in)) &
-      call register_temp_salt_segments(GV, OBC_in, CS%tracer_Reg, param_file)
-    if (associated(CS%OBC)) &
-      call register_temp_salt_segments(GV, CS%OBC, CS%tracer_Reg, param_file)
   endif
+
   if (use_frazil) then
     allocate(CS%tv%frazil(isd:ied,jsd:jed)) ; CS%tv%frazil(:,:) = 0.0
   endif
@@ -2336,11 +2320,38 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   call mixedlayer_restrat_register_restarts(dG%HI, param_file, &
            CS%mixedlayer_restrat_CSp, restart_CSp)
 
-  if (associated(CS%OBC)) &
+  if (CS%rotate_index .and. associated(OBC_in) .and. use_temperature) then
+    ! NOTE: register_temp_salt_segments includes allocation of tracer fields
+    !   along segments.  Bit reproducibility requires that MOM_initialize_state
+    !   be called on the input index map, so we must setup both OBC and OBC_in.
+    !
+    ! XXX: This call on OBC_in allocates the tracer fields on the unrotated
+    !   grid, but also incorrectly stores a pointer to a tracer_type for the
+    !   rotated registry (e.g. segment%tr_reg%Tr(n)%Tr) from CS%tracer_reg.
+    !
+    !   While incorrect and potentially dangerous, it does not seem that this
+    !   pointer is used during initialization, so we leave it for now.
+    call register_temp_salt_segments(GV, OBC_in, CS%tracer_Reg, param_file)
+  endif
+
+  if (associated(CS%OBC)) then
+    ! Set up remaining information about open boundary conditions that is needed for OBCs.
+    call call_OBC_register(param_file, CS%update_OBC_CSp, US, CS%OBC, CS%tracer_Reg)
+  !### Package specific changes to OBCs need to go here?
+
+    ! This is the equivalent to 2 calls to register_segment_tracer (per segment), which
+    ! could occur with the call to update_OBC_data or after the main initialization.
+    if (use_temperature) &
+      call register_temp_salt_segments(GV, CS%OBC, CS%tracer_Reg, param_file)
+
+    ! This needs the number of tracers and to have called any code that sets whether
+    ! reservoirs are used.
     call open_boundary_register_restarts(dg%HI, GV, CS%OBC, CS%tracer_Reg, &
                           param_file, restart_CSp, use_temperature)
+  endif
 
   call callTree_waypoint("restart registration complete (initialize_MOM)")
+  call restart_registry_lock(restart_CSp)
 
   !   Shift from using the temporary dynamic grid type to using the final
   ! (potentially static) ocean-specific grid type.
@@ -2438,7 +2449,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
         turns, CS%u, CS%v, CS%h, CS%T, CS%S)
 
     if (associated(sponge_in_CSp)) then
-      ! TODO: Implementation and testing of non-ALE spong rotation
+      ! TODO: Implementation and testing of non-ALE sponge rotation
       call MOM_error(FATAL, "Index rotation of non-ALE sponge is not yet implemented.")
     endif
 
@@ -2478,18 +2489,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   endif
 
   if (use_ice_shelf .and. CS%debug) &
-    call hchksum(CS%frac_shelf_h, "MOM:frac_shelf_h", G%HI, &
-        haloshift=0)
+    call hchksum(CS%frac_shelf_h, "MOM:frac_shelf_h", G%HI, haloshift=0)
 
   call cpu_clock_end(id_clock_MOM_init)
   call callTree_waypoint("returned from MOM_initialize_state() (initialize_MOM)")
-
-! ! Need this after MOM_initialize_state for DOME OBC stuff.
-! if (associated(CS%OBC)) &
-!   call open_boundary_register_restarts(G%HI, GV, CS%OBC, CS%tracer_Reg, &
-!                         param_file, restart_CSp, use_temperature)
-
-! call callTree_waypoint("restart registration complete (initialize_MOM)")
 
   ! From this point, there may be pointers being set, so the final grid type
   ! that will persist throughout the run has to be used.
@@ -2845,6 +2848,7 @@ subroutine finish_MOM_initialization(Time, dirs, CS, restart_CSp)
   if (CS%write_IC) then
     allocate(restart_CSp_tmp)
     restart_CSp_tmp = restart_CSp
+    call restart_registry_lock(restart_CSp_tmp, unlocked=.true.)
     allocate(z_interface(SZI_(G),SZJ_(G),SZK_(GV)+1))
     call find_eta(CS%h, CS%tv, G, GV, US, z_interface, eta_to_m=1.0)
     call register_restart_field(z_interface, "eta", .true., restart_CSp_tmp, &

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -22,10 +22,9 @@ use MOM_verticalGrid,  only : verticalGrid_type
 implicit none ; private
 
 public restart_init, restart_end, restore_state, register_restart_field
-public save_restart, query_initialized, restart_init_end, vardesc
+public save_restart, query_initialized, restart_registry_lock, restart_init_end, vardesc
 public restart_files_exist, determine_is_new_run, is_new_run
-public register_restart_field_as_obsolete
-public register_restart_pair
+public register_restart_field_as_obsolete, register_restart_pair
 
 !> A type for making arrays of pointers to 4-d arrays
 type p4d
@@ -87,6 +86,8 @@ type, public :: MOM_restart_CS ; private
                                     !! in which case the checksums will not match and cause crash.
   character(len=240) :: restartfile !< The name or name root for MOM restart files.
   integer :: turns                  !< Number of quarter turns from input to model domain
+  logical :: locked = .false.       !< If true this registry has been locked and no further restart
+                                    !! fields can be added without explicitly unlocking the registry.
 
   !> An array of descriptions of the registered fields
   type(field_restart), pointer :: restart_field(:) => NULL()
@@ -155,6 +156,8 @@ subroutine register_restart_field_ptr3d(f_ptr, var_desc, mandatory, CS)
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
 
+  call lock_check(CS, var_desc)
+
   CS%novars = CS%novars+1
   if (CS%novars > CS%max_fields) return ! This is an error that will be reported
                                      ! once the total number of fields is known.
@@ -185,6 +188,8 @@ subroutine register_restart_field_ptr4d(f_ptr, var_desc, mandatory, CS)
 
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
+
+  call lock_check(CS, var_desc)
 
   CS%novars = CS%novars+1
   if (CS%novars > CS%max_fields) return ! This is an error that will be reported
@@ -217,6 +222,8 @@ subroutine register_restart_field_ptr2d(f_ptr, var_desc, mandatory, CS)
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
 
+  call lock_check(CS, var_desc)
+
   CS%novars = CS%novars+1
   if (CS%novars > CS%max_fields) return ! This is an error that will be reported
                                      ! once the total number of fields is known.
@@ -246,6 +253,8 @@ subroutine register_restart_field_ptr1d(f_ptr, var_desc, mandatory, CS)
 
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
+
+  call lock_check(CS, var_desc)
 
   CS%novars = CS%novars+1
   if (CS%novars > CS%max_fields) return ! This is an error that will be reported
@@ -277,6 +286,8 @@ subroutine register_restart_field_ptr0d(f_ptr, var_desc, mandatory, CS)
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
 
+  call lock_check(CS, var_desc)
+
   CS%novars = CS%novars+1
   if (CS%novars > CS%max_fields) return ! This is an error that will be reported
                                      ! once the total number of fields is known.
@@ -307,6 +318,8 @@ subroutine register_restart_pair_ptr2d(a_ptr, b_ptr, a_desc, b_desc, &
   logical, intent(in) :: mandatory      !< If true, abort if field is missing
   type(MOM_restart_CS), pointer :: CS   !< MOM restart control structure
 
+  call lock_check(CS, a_desc)
+
   if (modulo(CS%turns, 2) /= 0) then
     call register_restart_field(b_ptr, a_desc, mandatory, CS)
     call register_restart_field(a_ptr, b_desc, mandatory, CS)
@@ -327,6 +340,8 @@ subroutine register_restart_pair_ptr3d(a_ptr, b_ptr, a_desc, b_desc, &
   logical, intent(in) :: mandatory      !< If true, abort if field is missing
   type(MOM_restart_CS), pointer :: CS   !< MOM restart control structure
 
+  call lock_check(CS, a_desc)
+
   if (modulo(CS%turns, 2) /= 0) then
     call register_restart_field(b_ptr, a_desc, mandatory, CS)
     call register_restart_field(a_ptr, b_desc, mandatory, CS)
@@ -346,6 +361,8 @@ subroutine register_restart_pair_ptr4d(a_ptr, b_ptr, a_desc, b_desc, &
   type(vardesc), intent(in) :: b_desc   !< Second field descriptor
   logical, intent(in) :: mandatory      !< If true, abort if field is missing
   type(MOM_restart_CS), pointer :: CS   !< MOM restart control structure
+
+  call lock_check(CS, a_desc)
 
   if (modulo(CS%turns, 2) /= 0) then
     call register_restart_field(b_ptr, a_desc, mandatory, CS)
@@ -379,6 +396,9 @@ subroutine register_restart_field_4d(f_ptr, name, mandatory, CS, longname, units
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart: " // &
       "register_restart_field_4d: Module must be initialized before "//&
       "it is used to register "//trim(name))
+
+  call lock_check(CS, name=name)
+
   vd = var_desc(name, units=units, longname=longname, hor_grid=hor_grid, &
                 z_grid=z_grid, t_grid=t_grid)
 
@@ -406,6 +426,9 @@ subroutine register_restart_field_3d(f_ptr, name, mandatory, CS, longname, units
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart: " // &
       "register_restart_field_3d: Module must be initialized before "//&
       "it is used to register "//trim(name))
+
+  call lock_check(CS, name=name)
+
   vd = var_desc(name, units=units, longname=longname, hor_grid=hor_grid, &
                 z_grid=z_grid, t_grid=t_grid)
 
@@ -435,6 +458,9 @@ subroutine register_restart_field_2d(f_ptr, name, mandatory, CS, longname, units
       "register_restart_field_2d: Module must be initialized before "//&
       "it is used to register "//trim(name))
   zgrid = '1' ; if (present(z_grid)) zgrid = z_grid
+
+  call lock_check(CS, name=name)
+
   vd = var_desc(name, units=units, longname=longname, hor_grid=hor_grid, &
                 z_grid=zgrid, t_grid=t_grid)
 
@@ -463,6 +489,9 @@ subroutine register_restart_field_1d(f_ptr, name, mandatory, CS, longname, units
       "register_restart_field_3d: Module must be initialized before "//&
       "it is used to register "//trim(name))
   hgrid = '1' ; if (present(hor_grid)) hgrid = hor_grid
+
+  call lock_check(CS, name=name)
+
   vd = var_desc(name, units=units, longname=longname, hor_grid=hgrid, &
                 z_grid=z_grid, t_grid=t_grid)
 
@@ -483,9 +512,13 @@ subroutine register_restart_field_0d(f_ptr, name, mandatory, CS, longname, units
   character(len=*), optional, intent(in) :: t_grid    !< time description: s, p, or 1, 's' if absent
 
   type(vardesc) :: vd
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart: " // &
       "register_restart_field_0d: Module must be initialized before "//&
       "it is used to register "//trim(name))
+
+  call lock_check(CS, name=name)
+
   vd = var_desc(name, units=units, longname=longname, hor_grid='1', &
                 z_grid='1', t_grid=t_grid)
 
@@ -502,6 +535,7 @@ function query_initialized_name(name, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -533,6 +567,7 @@ function query_initialized_0d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -557,6 +592,7 @@ function query_initialized_1d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -582,6 +618,7 @@ function query_initialized_2d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -607,6 +644,7 @@ function query_initialized_3d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -632,6 +670,7 @@ function query_initialized_4d(f_ptr, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -658,6 +697,7 @@ function query_initialized_0d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -691,6 +731,7 @@ function query_initialized_1d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -724,6 +765,7 @@ function query_initialized_2d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -757,6 +799,7 @@ function query_initialized_3d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -790,6 +833,7 @@ function query_initialized_4d_name(f_ptr, name, CS) result(query_initialized)
   logical :: query_initialized
 
   integer :: m, n
+
   if (.not.associated(CS)) call MOM_error(FATAL, "MOM_restart " // &
       "query_initialized: Module must be initialized before it is used.")
   if (CS%novars > CS%max_fields) call restart_error(CS)
@@ -1235,6 +1279,9 @@ subroutine restore_state(filename, directory, day, G, CS)
     endif
   enddo
 
+  ! Lock the restart registry so that no further variables can be registered.
+  CS%locked = .true.
+
 end subroutine restore_state
 
 !> restart_files_exist determines whether any restart files exist.
@@ -1482,8 +1529,8 @@ subroutine restart_init(param_file, CS, restart_root)
 
   logical :: rotate_index
 
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "MOM_restart"   ! This module's name.
   logical :: all_default   ! If true, all parameters are using their default values.
 
@@ -1555,13 +1602,47 @@ subroutine restart_init(param_file, CS, restart_root)
   allocate(CS%var_ptr3d(CS%max_fields))
   allocate(CS%var_ptr4d(CS%max_fields))
 
+  CS%locked = .false.
+
 end subroutine restart_init
 
-!> Indicate that all variables have now been registered.
+!> Issue an error message if the restart_registry is locked.
+subroutine lock_check(CS, var_desc, name)
+  type(MOM_restart_CS),       intent(in) :: CS        !< A MOM_restart_CS object (intent in)
+  type(vardesc),    optional, intent(in) :: var_desc  !< A structure with metadata about this variable
+  character(len=*), optional, intent(in) :: name      !< variable name to be used in the restart file
+
+  character(len=256) :: var_name  ! A variable name.
+
+  if (CS%locked) then
+    if (present(var_desc)) then
+      call query_vardesc(var_desc, name=var_name)
+      call MOM_error(FATAL, "Attempted to register "//trim(var_name)//" but the restart registry is locked.")
+    elseif (present(name)) then
+      call MOM_error(FATAL, "Attempted to register "//trim(name)//" but the restart registry is locked.")
+    else
+      call MOM_error(FATAL, "Attempted to register a variable but the restart registry is locked.")
+    endif
+  endif
+
+end subroutine lock_check
+
+!> Lock the restart registry so that an error is issued if any further restart variables are registered.
+subroutine restart_registry_lock(CS, unlocked)
+  type(MOM_restart_CS), intent(inout) :: CS        !< A MOM_restart_CS object (intent inout)
+  logical, optional,    intent(in)    :: unlocked  !< If present and true, unlock the registry
+
+  CS%locked = .true.
+  if (present(unlocked)) CS%locked = .not.unlocked
+end subroutine restart_registry_lock
+
+!> Indicate that all variables have now been registered and lock the registry.
 subroutine restart_init_end(CS)
   type(MOM_restart_CS),  pointer    :: CS !< A pointer to a MOM_restart_CS object
 
   if (associated(CS)) then
+    CS%locked = .true.
+
     if (CS%novars == 0) call restart_end(CS)
   endif
 


### PR DESCRIPTION
  Added code to lock the restart registry once all registration should have
occurred or if the restart has been read, along with a new public interface,
restart_registry_lock, to allow this lock to be set or unset.  All calls to
register restart fields now check the state of this lock and issue a fatal error
if the registry is locked.  This PR addresses MOM6 issue #1214.

  In the process of adding this restart lock, the new error messages revealed
that some of the restart registration calls related to some types of open
boundary conditions were not happening early enough.  To avoid this, a new
interface, register_DOME_OBC, was added to the DOME_initialization module and is
being called from call_OBC_register, and a number of the OBC-related calls
during the initialization were collected in the same (appropriate) place.  Some
OBC error messages were also corrected.  All answers are bitwise identical, but
there are two new public interfaces and the order of some OBC-related entries in
the MOM_parameter_doc calls changed.