### PR TITLE
+Add query_wave_properties & fix NUOPC wave queries

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -28,8 +28,9 @@ use MOM_file_parser,          only: get_param, log_version, param_file_type, clo
 use MOM_get_input,            only: get_MOM_input, directories
 use MOM_domains,              only: pass_var
 use MOM_error_handler,        only: MOM_error, FATAL, is_root_pe
-use MOM_ocean_model_nuopc,    only: ice_ocean_boundary_type
 use MOM_grid,                 only: ocean_grid_type, get_global_grid_size
+use MOM_wave_interface,       only: query_wave_properties
+use MOM_ocean_model_nuopc,    only: ice_ocean_boundary_type
 use MOM_ocean_model_nuopc,    only: ocean_model_restart, ocean_public_type, ocean_state_type
 use MOM_ocean_model_nuopc,    only: ocean_model_init_sfc
 use MOM_ocean_model_nuopc,    only: ocean_model_init, update_ocean_model, ocean_model_end
@@ -696,7 +697,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   Ice_ocean_boundary%frunoff         = 0.0
 
   if (ocean_state%use_waves) then
-    Ice_ocean_boundary%num_stk_bands=ocean_state%Waves%NumBands
+    call query_wave_properties(ocean_state%Waves, NumBands=Ice_ocean_boundary%num_stk_bands)
     allocate ( Ice_ocean_boundary% ustk0 (isc:iec,jsc:jec),         &
                Ice_ocean_boundary% vstk0 (isc:iec,jsc:jec),         &
                Ice_ocean_boundary% ustkb (isc:iec,jsc:jec,Ice_ocean_boundary%num_stk_bands), &
@@ -704,7 +705,8 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
                Ice_ocean_boundary%stk_wavenumbers (Ice_ocean_boundary%num_stk_bands))
     Ice_ocean_boundary%ustk0           = 0.0
     Ice_ocean_boundary%vstk0           = 0.0
-    Ice_ocean_boundary%stk_wavenumbers = ocean_state%Waves%WaveNum_Cen
+    call query_wave_properties(ocean_state%Waves, WaveNumbers=Ice_ocean_boundary%stk_wavenumbers, &
+                               US=ocean_state%US)
     Ice_ocean_boundary%ustkb           = 0.0
     Ice_ocean_boundary%vstkb           = 0.0
   endif

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -29,12 +29,11 @@ use MOM_get_input,            only: get_MOM_input, directories
 use MOM_domains,              only: pass_var
 use MOM_error_handler,        only: MOM_error, FATAL, is_root_pe
 use MOM_grid,                 only: ocean_grid_type, get_global_grid_size
-use MOM_wave_interface,       only: query_wave_properties
 use MOM_ocean_model_nuopc,    only: ice_ocean_boundary_type
 use MOM_ocean_model_nuopc,    only: ocean_model_restart, ocean_public_type, ocean_state_type
 use MOM_ocean_model_nuopc,    only: ocean_model_init_sfc
 use MOM_ocean_model_nuopc,    only: ocean_model_init, update_ocean_model, ocean_model_end
-use MOM_ocean_model_nuopc,    only: get_ocean_grid, get_eps_omesh
+use MOM_ocean_model_nuopc,    only: get_ocean_grid, get_eps_omesh, query_ocean_state
 use MOM_cap_time,             only: AlarmInit
 use MOM_cap_methods,          only: mom_import, mom_export, mom_set_geomtype, mod2med_areacor
 use MOM_cap_methods,          only: med2mod_areacor, state_diagnose
@@ -422,6 +421,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   character(len=64)                      :: logmsg
   logical                                :: isPresent, isPresentDiro, isPresentLogfile, isSet
   logical                                :: existflag
+  logical                                :: use_waves  ! If true, the wave modules are active.
   integer                                :: userRc
   integer                                :: localPet
   integer                                :: localPeCount
@@ -696,8 +696,9 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   Ice_ocean_boundary%lrunoff         = 0.0
   Ice_ocean_boundary%frunoff         = 0.0
 
-  if (ocean_state%use_waves) then
-    call query_wave_properties(ocean_state%Waves, NumBands=Ice_ocean_boundary%num_stk_bands)
+  call query_ocean_state(ocean_state, use_waves=use_waves)
+  if (use_waves) then
+    call query_ocean_state(ocean_state, NumWaveBands=Ice_ocean_boundary%num_stk_bands)
     allocate ( Ice_ocean_boundary% ustk0 (isc:iec,jsc:jec),         &
                Ice_ocean_boundary% vstk0 (isc:iec,jsc:jec),         &
                Ice_ocean_boundary% ustkb (isc:iec,jsc:jec,Ice_ocean_boundary%num_stk_bands), &
@@ -705,11 +706,12 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
                Ice_ocean_boundary%stk_wavenumbers (Ice_ocean_boundary%num_stk_bands))
     Ice_ocean_boundary%ustk0           = 0.0
     Ice_ocean_boundary%vstk0           = 0.0
-    call query_wave_properties(ocean_state%Waves, WaveNumbers=Ice_ocean_boundary%stk_wavenumbers, &
-                               US=ocean_state%US)
+    call query_ocean_state(ocean_state, WaveNumbers=Ice_ocean_boundary%stk_wavenumbers, unscale=.true.)
     Ice_ocean_boundary%ustkb           = 0.0
     Ice_ocean_boundary%vstkb           = 0.0
   endif
+  ! Consider adding this:
+  ! if (.not.use_waves) Ice_ocean_boundary%num_stk_bands = 0
 
   ocean_internalstate%ptr%ocean_state_type_ptr => ocean_state
   call ESMF_GridCompSetInternalState(gcomp, ocean_internalstate, rc)
@@ -754,7 +756,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   !These are not currently used and changing requires a nuopc dictionary change
   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_runoff_heat_flx"        , "will provide")
   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_calving_heat_flx"       , "will provide")
-  if (ocean_state%use_waves) then
+  if (use_waves) then
     if (Ice_ocean_boundary%num_stk_bands > 3) then
       call MOM_error(FATAL, "Number of Stokes Bands > 3, NUOPC cap not set up for this")
     endif

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -391,12 +391,6 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   ! MOM_wave_interface_init is called regardless of the value of USE_WAVES because
   ! it also initializes statistical waves.
   call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
-  if (OS%use_waves) then
-    ! I do not know why this is being set here.  It seems out of place. -RWH
-    call get_param(param_file,mdl,"SURFBAND_WAVENUMBERS", OS%Waves%WaveNum_Cen, &
-           "Central wavenumbers for surface Stokes drift bands.", &
-           units='rad/m', default=0.12566, scale=OS%US%Z_to_m)
-  endif
 
   if (associated(OS%grid%Domain%maskmap)) then
     call initialize_ocean_public_type(OS%grid%Domain%mpp_domain, Ocean_sfc, &

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -323,10 +323,10 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
          "STK_BAND_COUPLER is the number of Stokes drift bands in the coupler. "// &
          "This has to be consistent with the number of Stokes drift bands in WW3, "//&
          "or the model will fail.",units='', default=1)
+      allocate( CS%WaveNum_Cen(CS%NumBands) )
       call get_param(param_file, mdl, "SURFBAND_WAVENUMBERS", CS%WaveNum_Cen, &
            "Central wavenumbers for surface Stokes drift bands.", &
            units='rad/m', default=0.12566, scale=US%Z_to_m)
-      allocate( CS%WaveNum_Cen(CS%NumBands) )
       allocate( CS%STKx0(G%isdB:G%iedB,G%jsd:G%jed,CS%NumBands))
       allocate( CS%STKy0(G%isdB:G%iedB,G%jsd:G%jed,CS%NumBands))
       CS%WaveNum_Cen(:) = 0.0

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -24,6 +24,7 @@ implicit none ; private
 #include <MOM_memory.h>
 
 public MOM_wave_interface_init ! Public interface to fully initialize the wave routines.
+public query_wave_properties ! Public interface to obtain information from the waves control structure.
 public Update_Surface_Waves ! Public interface to update wave information at the
                             ! coupler/driver level.
 public Update_Stokes_Drift ! Public interface to update the Stokes drift profiles
@@ -322,6 +323,9 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
          "STK_BAND_COUPLER is the number of Stokes drift bands in the coupler. "// &
          "This has to be consistent with the number of Stokes drift bands in WW3, "//&
          "or the model will fail.",units='', default=1)
+      call get_param(param_file, mdl, "SURFBAND_WAVENUMBERS", CS%WaveNum_Cen, &
+           "Central wavenumbers for surface Stokes drift bands.", &
+           units='rad/m', default=0.12566, scale=US%Z_to_m)
       allocate( CS%WaveNum_Cen(CS%NumBands) )
       allocate( CS%STKx0(G%isdB:G%iedB,G%jsd:G%jed,CS%NumBands))
       allocate( CS%STKy0(G%isdB:G%iedB,G%jsd:G%jed,CS%NumBands))
@@ -427,6 +431,30 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
        CS%diag%axesT1,Time,'Surface (turbulent) Langmuir number','nondim')
 
 end subroutine MOM_wave_interface_init
+
+!> This interface provides the caller with information from the waves control structure.
+subroutine query_wave_properties(CS, NumBands, WaveNumbers, US)
+  type(wave_parameters_CS),        pointer     :: CS   !< Wave parameter Control structure
+  integer,               optional, intent(out) :: NumBands    !< If present, this returns the number of
+                                                       !!< wavenumber partitions in the wave discretization
+  real, dimension(:),    optional, intent(out) :: Wavenumbers !< If present this returns the characteristic
+                                                       !! wavenumbers of the wave discretization [m-1 or Z-1 ~> m-1]
+  type(unit_scale_type), optional, intent(in)  :: US   !< A dimensional unit scaling type that is used to undo
+                                                       !! the dimensional scaling of the output variables, if present
+  integer :: n
+
+  if (present(NumBands)) NumBands = CS%NumBands
+  if (present(Wavenumbers)) then
+    if (size(Wavenumbers) < CS%NumBands) call MOM_error(FATAL, "query_wave_properties called "//&
+                                "with a Wavenumbers array that is smaller than the number of bands.")
+    if (present(US)) then
+      do n=1,CS%NumBands ; Wavenumbers(n) = US%m_to_Z * CS%WaveNum_Cen(n) ; enddo
+    else
+      do n=1,CS%NumBands ; Wavenumbers(n) = CS%WaveNum_Cen(n) ; enddo
+    endif
+  endif
+
+end subroutine query_wave_properties
 
 !> Subroutine that handles updating of surface wave/Stokes drift related properties
 subroutine Update_Surface_Waves(G, GV, US, Day, dt, CS, forces)


### PR DESCRIPTION
  Added a new routine, query_wave_properties, that can be call to get
information about the wave properties from the waves control structure, and
added a get_param call for SURFBAND_WAVENUMBERS to MOM_wave_interface_init when
it is using the options that are typical with NUOPC coupler.  These changes
should allow the NUOPC coupler to compile and work again, while still keeping
the same level of opacity in the wave_parameters_CS.  All answers should be
bitwise identical, although the order of some entries in the MOM_parameter_doc
files may change when coupled with waves is WAVE_METHOD=SURFACE_BANDS and
SURFBAND_SOURCE=COUPLER.