### PR TITLE
Fix to codecov file path search

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -521,9 +521,10 @@ work/%/$(1)/ocean.stats work/%/$(1)/chksum_diag: build/$(2)/MOM6 $(VENV_PATH)
 	@echo -e "$(DONE): $$*.$(1); no runtime errors."
 	if [ $(3) ]; then \
 	  mkdir -p results/$$* ; \
-	  bash <(curl -s https://codecov.io/bash) -n $$@ \
-	    > work/$$*/codecov.$(1).out \
-	    2> work/$$*/codecov.$(1).err \
+	  cd build/symmetric \
+	    && bash <(curl -s https://codecov.io/bash) -Z -n $$@ \
+	      > codecov.$$*.$(1).out \
+	      2> codecov.$$*.$(1).err \
 	    && echo -e "${MAGENTA}Report uploaded to codecov.${RESET}"; \
 	fi
 endef


### PR DESCRIPTION
The codecov.io upload script appears to rely on the filepath of source
codes at compile time, and was unable to find the output when called
from .testing or the work directories.  In this patch, we now move to
`.testing/build/symmetric` (the gcov-enabled build) before running the
uploader script.

This is possibly required after the recent security alert connected to
the codecov.io uploader script.  Sadly, our coverage report failures
went undetected for several months.

The `-Z` flag has also been added to the script, which returns a nonzero
error code if it fails, although it would not have caught the previous issue.