### PR TITLE
Bug fix for FMS2 issue #761, broadcast from root pe

### DIFF
--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1092,7 +1092,6 @@ subroutine restore_state(filename, directory, day, G, CS)
 
   ! Check the remaining files for different times and issue a warning
   ! if they differ from the first time.
-  if (is_root_pe()) then
     do m = n+1,num_file
       call get_file_times(IO_handles(n), time_vals, ntime)
       if (ntime < 1) cycle
@@ -1107,7 +1106,6 @@ subroutine restore_state(filename, directory, day, G, CS)
         call MOM_error(WARNING, "MOM_restart: "//mesg)
       endif
     enddo
-  endif
 
   ! Read each variable from the first file in which it is found.
   do n=1,num_file


### PR DESCRIPTION
- This addresses the FMS issue $761
https://github.com/NOAA-GFDL/FMS/issues/761

- There is a mpp_broadcast in the FMS2 subroutine
get_unlimited_dimension_name() and this subroutine has to be called by
all pes, so it cannot be inside a if(is_root_pe()) block