### PR TITLE
MOM6: +Preparations to allow reference heights to change

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -880,21 +880,20 @@ subroutine check_remapping_grid( G, GV, h, dzInterface, msg )
 
   !$OMP parallel do default(shared)
   do j = G%jsc-1,G%jec+1 ; do i = G%isc-1,G%iec+1
-    if (G%mask2dT(i,j)>0.) call check_grid_column( GV%ke, GV%Z_to_H*G%bathyT(i,j), h(i,j,:), dzInterface(i,j,:), msg )
+    if (G%mask2dT(i,j)>0.) call check_grid_column( GV%ke, h(i,j,:), dzInterface(i,j,:), msg )
   enddo ; enddo
 
 end subroutine check_remapping_grid
 
 !> Check that the total thickness of new and old grids are consistent
-subroutine check_grid_column( nk, depth, h, dzInterface, msg )
+subroutine check_grid_column( nk, h, dzInterface, msg )
   integer,               intent(in) :: nk !< Number of cells
-  real,                  intent(in) :: depth !< Depth of bottom [Z ~> m] or arbitrary units
   real, dimension(nk),   intent(in) :: h  !< Cell thicknesses [Z ~> m] or arbitrary units
   real, dimension(nk+1), intent(in) :: dzInterface !< Change in interface positions (same units as h)
   character(len=*),      intent(in) :: msg !< Message to append to errors
   ! Local variables
   integer :: k
-  real    :: eps, total_h_old, total_h_new, h_new, z_old, z_new
+  real    :: eps, total_h_old, total_h_new, h_new
 
   eps =1. ; eps = epsilon(eps)
 
@@ -904,13 +903,8 @@ subroutine check_grid_column( nk, depth, h, dzInterface, msg )
     total_h_old = total_h_old + h(k)
   enddo
 
-  ! Integrate upwards for the interfaces consistent with the rest of MOM6
-  z_old = - depth
-  if (depth == 0.) z_old = - total_h_old
   total_h_new = 0.
   do k = nk,1,-1
-    z_old = z_old + h(k) ! Old interface position above layer k
-    z_new = z_old + dzInterface(k) ! New interface position based on dzInterface
     h_new = h(k) + ( dzInterface(k) - dzInterface(k+1) ) ! New thickness
     if (h_new<0.) then
       write(0,*) 'k,h,hnew=',k,h(k),h_new
@@ -1082,7 +1076,7 @@ subroutine filtered_grid_motion( CS, nk, z_old, z_new, dz_g )
 
 end subroutine filtered_grid_motion
 
-!> Builds a z*-ccordinate grid with partial steps (Adcroft and Campin, 2004).
+!> Builds a z*-coordinate grid with partial steps (Adcroft and Campin, 2004).
 !! z* is defined as
 !!   z* = (z-eta)/(H+eta)*H  s.t. z*=0 when z=eta and z*=-H when z=-H .
 subroutine build_zstar_grid( CS, G, GV, h, dzInterface, frac_shelf_h)
@@ -1118,7 +1112,7 @@ subroutine build_zstar_grid( CS, G, GV, h, dzInterface, frac_shelf_h)
         cycle
       endif
 
-      ! Local depth (G%bathyT is positive)
+      ! Local depth (G%bathyT is positive downward)
       nominalDepth = G%bathyT(i,j)*GV%Z_to_H
 
       ! Determine water column thickness
@@ -1319,7 +1313,7 @@ subroutine build_rho_grid( G, GV, US, h, tv, dzInterface, remapCS, CS, frac_shel
       endif
 
 
-      ! Local depth (G%bathyT is positive)
+      ! Local depth (G%bathyT is positive downward)
       nominalDepth = G%bathyT(i,j)*GV%Z_to_H
 
       ! Determine total water column thickness
@@ -1406,7 +1400,7 @@ end subroutine build_rho_grid
 !! density interpolated from the column profile and a clipping of depth for
 !! each interface to a fixed z* or p* grid.  This should probably be (optionally?)
 !! changed to find the nearest location of the target density.
-!! \remark { Based on Bleck, 2002: An oceanice general circulation model framed in
+!! \remark { Based on Bleck, 2002: An ocean-ice general circulation model framed in
 !! hybrid isopycnic-Cartesian coordinates, Ocean Modelling 37, 55-88.
 !! http://dx.doi.org/10.1016/S1463-5003(01)00012-9 }
 subroutine build_grid_HyCOM1( G, GV, US, h, tv, h_new, dzInterface, CS, frac_shelf_h )
@@ -1575,7 +1569,9 @@ subroutine build_grid_SLight(G, GV, US, h, tv, dzInterface, CS)
   real, dimension(SZK_(GV)+1) :: z_col_new ! Interface positions relative to the surface [H ~> m or kg m-2]
   real, dimension(SZK_(GV)+1) :: dz_col  ! The realized change in z_col [H ~> m or kg m-2]
   real, dimension(SZK_(GV))   :: p_col   ! Layer center pressure [R L2 T-2 ~> Pa]
-  real :: depth
+
+  ! Local variables
+  real :: depth   ! Depth of the ocean relative to the mean sea surface height in thickness units [H ~> m or kg m-2]
   integer :: i, j, k, nz
   real :: h_neglect, h_neglect_edge
 
@@ -1631,8 +1627,8 @@ end subroutine build_grid_SLight
 subroutine adjust_interface_motion( CS, nk, h_old, dz_int )
   type(regridding_CS),      intent(in)    :: CS !< Regridding control structure
   integer,                  intent(in)    :: nk !< Number of layers in h_old
-  real, dimension(nk),      intent(in)    :: h_old !< Minium allowed thickness of h [H ~> m or kg m-2]
-  real, dimension(CS%nk+1), intent(inout) :: dz_int !< Minium allowed thickness of h [H ~> m or kg m-2]
+  real, dimension(nk),      intent(in)    :: h_old !< Minimum allowed thickness of h [H ~> m or kg m-2]
+  real, dimension(CS%nk+1), intent(inout) :: dz_int !< Minimum allowed thickness of h [H ~> m or kg m-2]
   ! Local variables
   integer :: k
   real :: h_new, eps, h_total, h_err
@@ -1710,8 +1706,8 @@ subroutine build_grid_arbitrary( G, GV, h, dzInterface, h_new, CS )
   real      :: total_height
   real      :: delta_h
   real      :: max_depth
-  real      :: eta              ! local elevation
-  real      :: local_depth
+  real      :: eta              ! local elevation [H ~> m or kg m-2]
+  real      :: local_depth      ! The local ocean depth relative to mean sea level in thickness units [H ~> m or kg m-2]
   real      :: x1, y1, x2, y2
   real      :: x, t
 
@@ -1769,7 +1765,7 @@ subroutine build_grid_arbitrary( G, GV, h, dzInterface, h_new, CS )
         endif
       enddo
 
-      ! Chnage in interface position
+      ! Change in interface position
       x = 0. ! Left boundary at x=0
       dzInterface(i,j,1) = 0.
       do k = 2,nz
@@ -1797,7 +1793,7 @@ subroutine inflate_vanished_layers_old( CS, G, GV, h )
 ! objective is to make sure all layers are at least as thick as the minimum
 ! thickness allowed for regridding purposes (this parameter is set in the
 ! MOM_input file or defaulted to 1.0e-3). When layers are too thin, they
-! are inflated up to the minmum thickness.
+! are inflated up to the minimum thickness.
 !------------------------------------------------------------------------------
 
   ! Arguments
@@ -1901,7 +1897,7 @@ function uniformResolution(nk,coordMode,maxDepth,rhoLight,rhoHeavy)
   ! Arguments
   integer,          intent(in) :: nk !< Number of cells in source grid
   character(len=*), intent(in) :: coordMode !< A string indicating the coordinate mode.
-                                            !! See the documenttion for regrid_consts
+                                            !! See the documentation for regrid_consts
                                             !! for the recognized values.
   real,             intent(in) :: maxDepth  !< The range of the grid values in some modes
   real,             intent(in) :: rhoLight  !< The minimum value of the grid in RHO mode

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -373,7 +373,7 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   real                        :: grad        ! gradient during N-R iterations [A]
   integer :: i, k, iter  ! loop indices
   integer :: k_found     ! index of target cell
-  character(len=200) :: mesg
+  character(len=320) :: mesg
   logical :: use_2018_answers  ! If true use older, less acccurate expressions.
 
   eps = NR_OFFSET

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -3802,29 +3802,31 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
     ishift=0;jshift=0
     if (segment%is_E_or_W) then
       allocate(normal_trans_bt(segment%HI%IsdB:segment%HI%IedB,segment%HI%jsd:segment%HI%jed))
-      normal_trans_bt(:,:)=0.0
+      normal_trans_bt(:,:) = 0.0
       if (segment%direction == OBC_DIRECTION_W) ishift=1
       I=segment%HI%IsdB
       do j=segment%HI%jsd,segment%HI%jed
-        segment%Cg(I,j) = sqrt(GV%g_prime(1)*G%bathyT(i+ishift,j))
-        segment%Htot(I,j)=0.0
+        segment%Htot(I,j) = 0.0
         do k=1,GV%ke
           segment%h(I,j,k) = h(i+ishift,j,k)
-          segment%Htot(I,j)=segment%Htot(I,j)+segment%h(I,j,k)
+          segment%Htot(I,j) = segment%Htot(I,j) + segment%h(I,j,k)
         enddo
+        segment%Cg(I,j) = sqrt(GV%g_prime(1)*G%bathyT(i+ishift,j))
+        !### This should be: segment%Cg(I,j) = sqrt(GV%g_prime(1)*segment%Htot(I,j)*GV%H_to_Z)
       enddo
     else! (segment%direction == OBC_DIRECTION_N .or. segment%direction == OBC_DIRECTION_S)
       allocate(normal_trans_bt(segment%HI%isd:segment%HI%ied,segment%HI%JsdB:segment%HI%JedB))
-      normal_trans_bt(:,:)=0.0
+      normal_trans_bt(:,:) = 0.0
       if (segment%direction == OBC_DIRECTION_S) jshift=1
       J=segment%HI%JsdB
       do i=segment%HI%isd,segment%HI%ied
-        segment%Cg(i,J) = sqrt(GV%g_prime(1)*G%bathyT(i,j+jshift))
-        segment%Htot(i,J)=0.0
+        segment%Htot(i,J) = 0.0
         do k=1,GV%ke
           segment%h(i,J,k) = h(i,j+jshift,k)
-          segment%Htot(i,J)=segment%Htot(i,J)+segment%h(i,J,k)
+          segment%Htot(i,J) = segment%Htot(i,J) + segment%h(i,J,k)
         enddo
+        segment%Cg(i,J) = sqrt(GV%g_prime(1)*G%bathyT(i,j+jshift))
+        !### This should be: segment%Cg(i,J) = sqrt(GV%g_prime(1)*segment%Htot(i,J)*GV%H_to_Z)
       enddo
     endif
 
@@ -4715,7 +4717,7 @@ subroutine mask_outside_OBCs(G, US, param_file, OBC)
   integer :: i, j
   integer :: l_seg
   logical :: fatal_error = .False.
-  real    :: min_depth
+  real    :: min_depth ! The minimum depth for ocean points [Z ~> m]
   integer, parameter :: cin = 3, cout = 4, cland = -1, cedge = -2
   character(len=256) :: mesg    ! Message for error messages.
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
@@ -4729,7 +4731,6 @@ subroutine mask_outside_OBCs(G, US, param_file, OBC)
 
   allocate(color(G%isd:G%ied, G%jsd:G%jed)) ; color = 0
   allocate(color2(G%isd:G%ied, G%jsd:G%jed)) ; color2 = 0
-
 
   ! Paint a frame around the outside.
   do j=G%jsd,G%jed

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -444,7 +444,8 @@ subroutine wave_speed(h, tv, G, GV, US, cg1, CS, full_halos, use_ebt_mode, mono_
               hw = 0.5*(Hc(k-1)+Hc(k))
               gp = gprime(K)
               if (l_mono_N2_column_fraction>0. .or. l_mono_N2_depth>=0.) then
-                if ( ((G%bathyT(i,j)-sum_hc < l_mono_N2_column_fraction*G%bathyT(i,j)) .or. &
+                !### Change to: if ( ((htot(i) - sum_hc < l_mono_N2_column_fraction*htot(i)) .or. & ) )
+                if ( ((G%bathyT(i,j) - sum_hc < l_mono_N2_column_fraction*G%bathyT(i,j)) .or. &
                       ((l_mono_N2_depth >= 0.) .and. (sum_hc > l_mono_N2_depth))) .and. &
                      (L2_to_Z2*gp > N2min*hw) ) then
                   ! Filters out regions where N2 increases with depth but only in a lower fraction

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1253,7 +1253,7 @@ end subroutine analytic_int_specific_vol_dp
 !! pressure anomalies across layers, which are required for calculating the
 !! finite-volume form pressure accelerations in a Boussinesq model.
 subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, dpa, &
-                          intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, useMassWghtInterp)
+                          intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, useMassWghtInterp, Z_0p)
   type(hor_index_type), intent(in)  :: HI !< Ocean horizontal index structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T   !< Potential temperature referenced to the surface [degC]
@@ -1292,6 +1292,8 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m]
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
                                            !! interpolate T/S for top and bottom integrals.
+  real,       optional, intent(in)  :: Z_0p !< The height at which the pressure is 0 [Z ~> m]
+
   ! Local variables
   real :: rho_scale  ! A multiplicative factor by which to scale density from kg m-3 to the
                      ! desired units [R m3 kg-1 ~> 1]
@@ -1322,11 +1324,11 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
       if ((rho_scale /= 1.0) .or. (pres_scale /= 1.0)) then
         call int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp, rho_scale, pres_scale)
+                                   dz_neglect, useMassWghtInterp, rho_scale, pres_scale, Z_0p=Z_0p)
       else
         call int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp)
+                                   dz_neglect, useMassWghtInterp, Z_0p=Z_0p)
       endif
     case default
       call MOM_error(FATAL, "No analytic integration option is available with this EOS!")

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -294,9 +294,9 @@ subroutine rescale_dyn_horgrid_bathymetry(G, m_in_new_units)
 
   if (m_in_new_units == 1.0) return
   if (m_in_new_units < 0.0) &
-    call MOM_error(FATAL, "rescale_grid_bathymetry: Negative depth units are not permitted.")
+    call MOM_error(FATAL, "rescale_dyn_horgrid_bathymetry: Negative depth units are not permitted.")
   if (m_in_new_units == 0.0) &
-    call MOM_error(FATAL, "rescale_grid_bathymetry: Zero depth units are not permitted.")
+    call MOM_error(FATAL, "rescale_dyn_horgrid_bathymetry: Zero depth units are not permitted.")
 
   rescale = 1.0 / m_in_new_units
   do j=jsd,jed ; do i=isd,ied

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -496,7 +496,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     enddo ; enddo
 
     do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-      grad_vel_mag_bt_q(I,J) = boundary_mask_q(I,J) * (dvdx_bt(i,j)**2 + dudy_bt(i,j)**2 + &
+      grad_vel_mag_bt_q(I,J) = boundary_mask_q(I,J) * (dvdx_bt(I,J)**2 + dudy_bt(I,J)**2 + &
             (0.25*((dudx_bt(i,j)+dudx_bt(i+1,j+1))+(dudx_bt(i,j+1)+dudx_bt(i+1,j))))**2 + &
             (0.25*((dvdy_bt(i,j)+dvdy_bt(i+1,j+1))+(dvdy_bt(i,j+1)+dvdy_bt(i+1,j))))**2)
     enddo ; enddo
@@ -1389,7 +1389,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         if (grad_vel_mag_bt_h(i,j)>0) then
-          GME_coeff = CS%GME_efficiency * (MIN(G%bathyT(i,j)/CS%GME_h0,1.0)**2) * &
+          GME_coeff = CS%GME_efficiency * (MIN(G%bathyT(i,j) / CS%GME_h0, 1.0)**2) * &
             (0.25*(KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)+KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
         else
           GME_coeff = 0.0
@@ -1405,8 +1405,10 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       enddo ; enddo
 
       do J=js-1,Jeq ; do I=is-1,Ieq
-        if (grad_vel_mag_bt_q(i,j)>0) then
-          GME_coeff = CS%GME_efficiency * (MIN(G%bathyT(i,j)/CS%GME_h0,1.0)**2) * &
+        if (grad_vel_mag_bt_q(I,J)>0) then
+          !### This expression is not rotationally invariant - bathyT is to the SW of q points,
+          !    and it needs parentheses in the sum of the 4 diffusivities.
+          GME_coeff = CS%GME_efficiency * (MIN(G%bathyT(i,j) / CS%GME_h0, 1.0)**2) * &
               (0.25*(KH_u_GME(I,j,k)+KH_u_GME(I,j+1,k)+KH_v_GME(i,J,k)+KH_v_GME(i+1,J,k)))
         else
           GME_coeff = 0.0

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -481,14 +481,19 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
         do j=js,je ; do I=is-1,ie
           hu(I,j)       = 2.0*h(i,j,k)*h(i+1,j,k)/(h(i,j,k)+h(i+1,j,k)+h_neglect)
           if (hu(I,j) /= 0.0) hu(I,j) = 1.0
+          !### The same result would be accomplished with the following without a division:
+          ! hu(I,j) = 0.0 ; if (h(i,j,k)*h(i+1,j,k) /= 0.0) hu(I,j) = 1.0
           KH_u_lay(I,j) = 0.5*(KH_u(I,j,k)+KH_u(I,j,k+1))
         enddo ; enddo
         do J=js-1,je ; do i=is,ie
           hv(i,J)       = 2.0*h(i,j,k)*h(i,j+1,k)/(h(i,j,k)+h(i,j+1,k)+h_neglect)
           if (hv(i,J) /= 0.0) hv(i,J) = 1.0
+          !### The same result would be accomplished with the following without a division:
+          ! hv(i,J) = 0.0 ; if (h(i,j,k)*h(i,j+1,k) /= 0.0) hv(i,J) = 1.0
           KH_v_lay(i,J) = 0.5*(KH_v(i,J,k)+KH_v(i,J,k+1))
         enddo ; enddo
         ! diagnose diffusivity at T-point
+        !### Because hu and hv are nondimensional here, the denominator is dimensionally inconsistent.
         do j=js,je ; do i=is,ie
           Kh_t(i,j,k) = ((hu(I-1,j)*KH_u_lay(i-1,j)+hu(I,j)*KH_u_lay(I,j))  &
                         +(hv(i,J-1)*KH_v_lay(i,J-1)+hv(i,J)*KH_v_lay(i,J))) &
@@ -505,7 +510,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
         enddo
 
         do j=js,je ; do i=is,ie
-          MEKE%Kh_diff(i,j) = MEKE%Kh_diff(i,j) / MAX(1.0,G%bathyT(i,j))
+          MEKE%Kh_diff(i,j) = GV%H_to_Z * MEKE%Kh_diff(i,j) / MAX(1.0*US%m_to_Z, G%bathyT(i,j))
         enddo ; enddo
       endif
 

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -47,7 +47,7 @@ interface set_up_ALE_sponge_vel_field
   module procedure set_up_ALE_sponge_vel_field_varying
 end interface
 
-!> Ddetermine the number of points which are within sponges in this computational domain.
+!> Determine the number of points which are within sponges in this computational domain.
 !!
 !! Only points that have positive values of Iresttime and which mask2dT indicates are ocean
 !! points are included in the sponges.  It also stores the target interface heights.
@@ -90,31 +90,19 @@ end type p2d
 !> ALE sponge control structure
 type, public :: ALE_sponge_CS ; private
   integer :: nz        !< The total number of layers.
-  integer :: nz_data   !< The total number of arbritary layers (used by older code).
-  integer :: isc       !< The starting i-index of the computational domain at h.
-  integer :: iec       !< The ending i-index of the computational domain at h.
-  integer :: jsc       !< The starting j-index of the computational domain at h.
-  integer :: jec       !< The ending j-index of the computational domain at h.
-  integer :: IscB      !< The starting I-index of the computational domain at u/v.
-  integer :: IecB      !< The ending I-index of the computational domain at u/v.
-  integer :: JscB      !< The starting J-index of the computational domain at u/v.
-  integer :: JecB      !< The ending J-index of the computational domain at h.
-  integer :: isd       !< The starting i-index of the data domain at h.
-  integer :: ied       !< The ending i-index of the data domain at h.
-  integer :: jsd       !< The starting j-index of the data domain at h.
-  integer :: jed       !< The ending j-index of the data domain at h.
+  integer :: nz_data   !< The total number of arbitrary layers (used by older code).
   integer :: num_col   !< The number of sponge tracer points within the computational domain.
   integer :: num_col_u !< The number of sponge u-points within the computational domain.
   integer :: num_col_v !< The number of sponge v-points within the computational domain.
   integer :: fldno = 0 !< The number of fields which have already been
                        !! registered by calls to set_up_sponge_field
   logical :: sponge_uv !< Control whether u and v are included in sponge
-  integer, pointer :: col_i(:) => NULL()   !< Array of the i-indicies of each tracer columns being damped.
-  integer, pointer :: col_j(:) => NULL()   !< Array of the j-indicies of each tracer columns being damped.
-  integer, pointer :: col_i_u(:) => NULL() !< Array of the i-indicies of each u-columns being damped.
-  integer, pointer :: col_j_u(:) => NULL() !< Array of the j-indicies of each u-columns being damped.
-  integer, pointer :: col_i_v(:) => NULL() !< Array of the i-indicies of each v-columns being damped.
-  integer, pointer :: col_j_v(:) => NULL() !< Array of the j-indicies of each v-columns being damped.
+  integer, pointer :: col_i(:) => NULL()   !< Array of the i-indices of each tracer column being damped.
+  integer, pointer :: col_j(:) => NULL()   !< Array of the j-indices of each tracer column being damped.
+  integer, pointer :: col_i_u(:) => NULL() !< Array of the i-indices of each u-column being damped.
+  integer, pointer :: col_j_u(:) => NULL() !< Array of the j-indices of each u-column being damped.
+  integer, pointer :: col_i_v(:) => NULL() !< Array of the i-indices of each v-column being damped.
+  integer, pointer :: col_j_v(:) => NULL() !< Array of the j-indices of each v-column being damped.
 
   real, pointer :: Iresttime_col(:)   => NULL() !< The inverse restoring time of each tracer column [T-1 ~> s-1].
   real, pointer :: Iresttime_col_u(:) => NULL() !< The inverse restoring time of each u-column [T-1 ~> s-1].
@@ -124,8 +112,8 @@ type, public :: ALE_sponge_CS ; private
   type(p2d) :: Ref_val(MAX_FIELDS_) !< The values to which the fields are damped.
   type(p2d) :: Ref_val_u  !< The values to which the u-velocities are damped.
   type(p2d) :: Ref_val_v  !< The values to which the v-velocities are damped.
-  type(p3d) :: var_u  !< Pointer to the u velocities. that are being damped.
-  type(p3d) :: var_v  !< Pointer to the v velocities. that are being damped.
+  type(p3d) :: var_u  !< Pointer to the u velocities that are being damped.
+  type(p3d) :: var_v  !< Pointer to the v velocities that are being damped.
   type(p2d) :: Ref_h  !< Grid on which reference data is provided (older code).
   type(p2d) :: Ref_hu !< u-point grid on which reference data is provided (older code).
   type(p2d) :: Ref_hv !< v-point grid on which reference data is provided (older code).
@@ -137,7 +125,7 @@ type, public :: ALE_sponge_CS ; private
   logical :: remap_answers_2018    !< If true, use the order of arithmetic and expressions that
                                    !! recover the answers for remapping from the end of 2018.
                                    !! Otherwise, use more robust forms of the same expressions.
-  logical :: hor_regrid_answers_2018 !< If true, use the order of arithmetic for horizonal regridding
+  logical :: hor_regrid_answers_2018 !< If true, use the order of arithmetic for horizontal regridding
                                    !! that recovers the answers from the end of 2018.  Otherwise, use
                                    !! rotationally symmetric forms of the same expressions.
 
@@ -241,9 +229,6 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
 
   CS%time_varying_sponges = .false.
   CS%nz = GV%ke
-  CS%isc = G%isc ; CS%iec = G%iec ; CS%jsc = G%jsc ; CS%jec = G%jec
-  CS%isd = G%isd ; CS%ied = G%ied ; CS%jsd = G%jsd ; CS%jed = G%jed
-  CS%iscB = G%iscB ; CS%iecB = G%iecB; CS%jscB = G%jscB ; CS%jecB = G%jecB
 
   ! number of columns to be restored
   CS%num_col = 0 ; CS%fldno = 0
@@ -265,7 +250,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
         col = col +1
       endif
     enddo ; enddo
-    ! same for total number of arbritary layers and correspondent data
+    ! same for total number of arbitrary layers and correspondent data
     CS%nz_data = nz_data
     allocate(CS%Ref_h%p(CS%nz_data,CS%num_col))
     do col=1,CS%num_col ; do K=1,CS%nz_data
@@ -295,11 +280,11 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
     if (present(Iresttime_u_in)) then
        Iresttime_u(:,:) = Iresttime_u_in(:,:)
     else
-      do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
         Iresttime_u(I,j) = 0.5 * (Iresttime(i,j) + Iresttime(i+1,j))
       enddo ; enddo
     endif
-    do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+    do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
        if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) &
           CS%num_col_u = CS%num_col_u + 1
     enddo ; enddo
@@ -312,7 +297,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
 
       ! Store the column indices and restoring rates in the CS structure
       col = 1
-      do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
         if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) then
           CS%col_i_u(col) = I ; CS%col_j_u(col) = j
           CS%Iresttime_col_u(col) = Iresttime_u(I,j)
@@ -320,7 +305,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
         endif
       enddo ; enddo
 
-      ! same for total number of arbritary layers and correspondent data
+      ! same for total number of arbitrary layers and correspondent data
       allocate(CS%Ref_hu%p(CS%nz_data,CS%num_col_u))
       do col=1,CS%num_col_u
         I = CS%col_i_u(col) ; j = CS%col_j_u(col)
@@ -339,11 +324,11 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
     if (present(Iresttime_v_in)) then
       Iresttime_v(:,:) = Iresttime_v_in(:,:)
     else
-      do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB; do i=G%isc,G%iec
         Iresttime_v(i,J) = 0.5 * (Iresttime(i,j) + Iresttime(i,j+1))
       enddo ; enddo
     endif
-    do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+    do J=G%jscB,G%jecB; do i=G%isc,G%iec
       if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) &
         CS%num_col_v = CS%num_col_v + 1
     enddo ; enddo
@@ -356,7 +341,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
 
       ! pass indices, restoring time to the CS structure
       col = 1
-      do J=CS%jscB,CS%jecB ; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec
         if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) then
           CS%col_i_v(col) = i ; CS%col_j_v(col) = j
           CS%Iresttime_col_v(col) = Iresttime_v(i,j)
@@ -364,7 +349,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
         endif
       enddo ; enddo
 
-      ! same for total number of arbritary layers and correspondent data
+      ! same for total number of arbitrary layers and correspondent data
       allocate(CS%Ref_hv%p(CS%nz_data,CS%num_col_v))
       do col=1,CS%num_col_v
         i = CS%col_i_v(col) ; J = CS%col_j_v(col)
@@ -430,7 +415,7 @@ subroutine get_ALE_sponge_thicknesses(G, data_h, sponge_mask, CS)
 
 end subroutine get_ALE_sponge_thicknesses
 
-!> This subroutine determines the number of points which are to be restoref in the computational
+!> This subroutine determines the number of points which are to be restored in the computational
 !! domain.  Only points that have positive values of Iresttime and which mask2dT indicates are ocean
 !! points are included in the sponges.
 subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Iresttime_u_in, Iresttime_v_in)
@@ -510,9 +495,6 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
 
   CS%time_varying_sponges = .true.
   CS%nz = GV%ke
-  CS%isc = G%isc ; CS%iec = G%iec ; CS%jsc = G%jsc ; CS%jec = G%jec
-  CS%isd = G%isd ; CS%ied = G%ied ; CS%jsd = G%jsd ; CS%jed = G%jed
-  CS%iscB = G%iscB ; CS%iecB = G%iecB; CS%jscB = G%jscB ; CS%jecB = G%jecB
 
   ! number of columns to be restored
   CS%num_col = 0 ; CS%fldno = 0
@@ -551,12 +533,12 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
     if (present(Iresttime_u_in)) then
       Iresttime_u(:,:) = Iresttime_u_in(:,:)
     else
-      do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
         Iresttime_u(I,j) = 0.5 * (Iresttime(i,j) + Iresttime(i+1,j))
       enddo ; enddo
     endif
     CS%num_col_u = 0 ;
-    do j=CS%jsc,CS%jec; do I=CS%iscB,CS%iecB
+    do j=G%jsc,G%jec; do I=G%iscB,G%iecB
       if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) &
         CS%num_col_u = CS%num_col_u + 1
     enddo ; enddo
@@ -566,14 +548,14 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
       allocate(CS%col_j_u(CS%num_col_u))         ; CS%col_j_u = 0
       ! pass indices, restoring time to the CS structure
       col = 1
-      do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
         if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) then
           CS%col_i_u(col) = i ; CS%col_j_u(col) = j
           CS%Iresttime_col_u(col) = Iresttime_u(i,j)
           col = col + 1
         endif
       enddo ; enddo
-      ! same for total number of arbritary layers and correspondent data
+      ! same for total number of arbitrary layers and correspondent data
     endif
     total_sponge_cols_u = CS%num_col_u
     call sum_across_PEs(total_sponge_cols_u)
@@ -583,12 +565,12 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
     if (present(Iresttime_v_in)) then
       Iresttime_v(:,:) = Iresttime_v_in(:,:)
     else
-      do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB; do i=G%isc,G%iec
         Iresttime_v(i,J) = 0.5 * (Iresttime(i,j) + Iresttime(i,j+1))
       enddo ; enddo
     endif
     CS%num_col_v = 0 ;
-    do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+    do J=G%jscB,G%jecB; do i=G%isc,G%iec
       if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) &
         CS%num_col_v = CS%num_col_v + 1
     enddo ; enddo
@@ -598,7 +580,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
       allocate(CS%col_j_v(CS%num_col_v))         ; CS%col_j_v = 0
       ! pass indices, restoring time to the CS structure
       col = 1
-      do J=CS%jscB,CS%jecB ; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec
         if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) then
           CS%col_i_v(col) = i ; CS%col_j_v(col) = j
           CS%Iresttime_col_v(col) = Iresttime_v(i,j)
@@ -630,16 +612,16 @@ subroutine init_ALE_sponge_diags(Time, G, diag, CS, US)
 
   CS%id_sp_tendency(1) = -1
   CS%id_sp_tendency(1) = register_diag_field('ocean_model', 'sp_tendency_temp', diag%axesTL, Time, &
-       'Time tendency due to temperature restoring', 'degC s-1',conversion=US%s_to_T)
+       'Time tendency due to temperature restoring', 'degC s-1', conversion=US%s_to_T)
   CS%id_sp_tendency(2) = -1
   CS%id_sp_tendency(2) = register_diag_field('ocean_model', 'sp_tendency_salt', diag%axesTL, Time, &
-       'Time tendency due to salinity restoring', 'g kg-1 s-1',conversion=US%s_to_T)
+       'Time tendency due to salinity restoring', 'g kg-1 s-1', conversion=US%s_to_T)
   CS%id_sp_u_tendency = -1
   CS%id_sp_u_tendency = register_diag_field('ocean_model', 'sp_tendency_u', diag%axesCuL, Time, &
-       'Zonal acceleration due to sponges', 'm s-2',conversion=US%L_T2_to_m_s2)
+       'Zonal acceleration due to sponges', 'm s-2', conversion=US%L_T2_to_m_s2)
   CS%id_sp_v_tendency = -1
   CS%id_sp_v_tendency = register_diag_field('ocean_model', 'sp_tendency_v', diag%axesCvL, Time, &
-       'Meridional acceleration due to sponges', 'm s-2',conversion=US%L_T2_to_m_s2)
+       'Meridional acceleration due to sponges', 'm s-2', conversion=US%L_T2_to_m_s2)
 
 end subroutine init_ALE_sponge_diags
 
@@ -718,19 +700,18 @@ subroutine set_up_ALE_sponge_field_varying(filename, fieldname, Time, G, GV, US,
   isd = G%isd; ied = G%ied; jsd = G%jsd; jed = G%jed
   CS%fldno = CS%fldno + 1
   if (CS%fldno > MAX_FIELDS_) then
-    write(mesg,'("Increase MAX_FIELDS_ to at least ",I3," in MOM_memory.h or decrease &
-           &the number of fields to be damped in the call to &
-           &initialize_ALE_sponge." )') CS%fldno
+    write(mesg, '("Increase MAX_FIELDS_ to at least ",I3," in MOM_memory.h or decrease "//&
+           "the number of fields to be damped in the call to initialize_ALE_sponge." )') CS%fldno
     call MOM_error(FATAL,"set_up_ALE_sponge_field: "//mesg)
   endif
-  ! get a unique time interp id for this field. If sponge data is ongrid, then setup
+  ! get a unique time interp id for this field. If sponge data is on-grid, then setup
   ! to only read on the computational domain
   if (CS%spongeDataOngrid) then
     CS%Ref_val(CS%fldno)%id = init_external_field(filename, fieldname, MOM_domain=G%Domain)
   else
     CS%Ref_val(CS%fldno)%id = init_external_field(filename, fieldname)
   endif
-  fld_sz(1:4)=-1
+  fld_sz(1:4) = -1
   call get_external_field_info(CS%Ref_val(CS%fldno)%id, size=fld_sz)
   nz_data = fld_sz(3)
   CS%Ref_val(CS%fldno)%nz_data = nz_data !< individual sponge fields may reside on a different vertical grid
@@ -748,17 +729,19 @@ end subroutine set_up_ALE_sponge_field_varying
 !> This subroutine stores the reference profile at u and v points for the variable
 !! whose address is given by u_ptr and v_ptr.
 subroutine set_up_ALE_sponge_vel_field_fixed(u_val, v_val, G, GV, u_ptr, v_ptr, CS)
-  type(ocean_grid_type),   intent(in) :: G  !< Grid structure (in).
+  type(ocean_grid_type),   intent(in) :: G     !< Grid structure (in).
   type(verticalGrid_type), intent(in) :: GV    !< ocean vertical grid structure
-  type(ALE_sponge_CS),     pointer    :: CS !< Sponge structure (in/out).
+  type(ALE_sponge_CS),     pointer    :: CS    !< Sponge structure (in/out).
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                          intent(in) :: u_val !< u field to be used in the sponge, it has arbritary number of layers but
-                                              !! not to exceed the total number of model layers
+                           intent(in) :: u_val !< u field to be used in the sponge [L T-1 ~> m s-1],
+                                               !! it is provided on its own vertical grid that may
+                                               !! have fewer layers than the model itself, but not more.
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                          intent(in) :: v_val !< v field to be used in the sponge, it has arbritary number of layers but
-                                              !! not to exceed the number of model layers
-  real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u pointer to the field to be damped
-  real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v pointer to the field to be damped
+                           intent(in) :: v_val !< v field to be used in the sponge [L T-1 ~> m s-1],
+                                               !! it is provided on its own vertical grid that may
+                                               !! have fewer layers than the model itself, but not more.
+  real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u-field to be damped [L T-1 ~> m s-1]
+  real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v-field to be damped [L T-1 ~> m s-1]
 
   integer :: j, k, col, fld_sz(4)
   character(len=256) :: mesg ! String for error messages
@@ -794,15 +777,16 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename
   character(len=*), intent(in)    :: filename_v  !< File name for v field
   character(len=*), intent(in)    :: fieldname_v !< Name of v variable in file
   type(time_type),  intent(in)    :: Time        !< Model time
-  type(ocean_grid_type), intent(in) :: G         !< Ocean grid (in)
-  type(verticalGrid_type), intent(in) :: GV    !< ocean vertical grid structure
-  type(unit_scale_type), intent(in)    :: US     !< A dimensional unit scaling type
-  type(ALE_sponge_CS), pointer    :: CS          !< Sponge structure (in/out).
-  real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u pointer to the field to be damped (in).
-  real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v pointer to the field to be damped (in).
+  type(ocean_grid_type),   intent(in) :: G       !< Ocean grid (in)
+  type(verticalGrid_type), intent(in) :: GV      !< ocean vertical grid structure
+  type(unit_scale_type),   intent(in) :: US      !< A dimensional unit scaling type
+  type(ALE_sponge_CS),     pointer    :: CS      !< Sponge structure (in/out).
+  real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u-field to be damped [L T-1 ~> m s-1]
+  real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v-field to be damped [L T-1 ~> m s-1]
+
   ! Local variables
-  real, allocatable, dimension(:,:,:) :: u_val !< U field to be used in the sponge.
-  real, allocatable, dimension(:,:,:) :: v_val !< V field to be used in the sponge.
+  real, allocatable, dimension(:,:,:) :: u_val !< U field to be used in the sponge [L T-1 ~> m s-1].
+  real, allocatable, dimension(:,:,:) :: v_val !< V field to be used in the sponge [L T-1 ~> m s-1].
 
   real, allocatable, dimension(:), target :: z_in, z_edges_in
   real :: missing_value
@@ -892,10 +876,13 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
   real, dimension(:), allocatable :: tmpT1d
   integer :: c, m, nkmb, i, j, k, is, ie, js, je, nz, nz_data
   integer :: col, total_sponge_cols
-  real, allocatable, dimension(:), target :: z_in, z_edges_in
-  real :: missing_value, Idt
-  real :: h_neglect, h_neglect_edge
-  real :: zTopOfCell, zBottomOfCell ! Heights [Z ~> m].
+  real, allocatable, dimension(:), target :: z_in  ! The depths (positive downward) in the input file [Z ~> m]
+  real, allocatable, dimension(:), target :: z_edges_in ! The depths (positive downward) of the
+                                                        ! edges in the input file [Z ~> m]
+  real :: missing_value
+  real :: Idt  ! The inverse of the timestep [T-1 ~> s-1]
+  real :: h_neglect, h_neglect_edge ! Negligible thicknesses [H ~> m or kg m-2]
+  real :: zTopOfCell, zBottomOfCell ! Interface heights (positive upward) in the input dataset [Z ~> m].
   integer :: nPoints
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -1020,7 +1007,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
 
       call pass_var(sp_val, G%Domain)
       call pass_var(mask_z, G%Domain)
-      do j=CS%jsc,CS%jec; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec; do I=G%iscB,G%iecB
         sp_val_u(I,j,1:nz_data) = 0.5*(sp_val(i,j,1:nz_data)+sp_val(i+1,j,1:nz_data))
         mask_u(I,j,1:nz_data) = min(mask_z(i,j,1:nz_data),mask_z(i+1,j,1:nz_data))
       enddo ; enddo
@@ -1068,7 +1055,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
                                           answers_2018=CS%hor_regrid_answers_2018)
       call pass_var(sp_val, G%Domain)
       call pass_var(mask_z, G%Domain)
-      do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB; do i=G%isc,G%iec
         sp_val_v(i,J,1:nz_data) = 0.5*(sp_val(i,j,1:nz_data)+sp_val(i,j+1,1:nz_data))
         mask_v(i,J,1:nz_data) = min(mask_z(i,j,1:nz_data),mask_z(i,j+1,1:nz_data))
       enddo ; enddo
@@ -1107,7 +1094,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
     nz_data = CS%Ref_val_u%nz_data
     allocate(tmp_val2(nz_data))
     if (CS%id_sp_u_tendency > 0) then
-      allocate(tmp_u(G%isdB:G%iedB,G%jsd:G%jed,nz));tmp_u(:,:,:)=0.0
+      allocate(tmp_u(G%isdB:G%iedB,G%jsd:G%jed,nz)) ; tmp_u(:,:,:)=0.0
     endif
     ! u points
     do c=1,CS%num_col_u
@@ -1137,7 +1124,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
     endif
     ! v points
     if (CS%id_sp_v_tendency > 0) then
-      allocate(tmp_v(G%isd:G%ied,G%jsdB:G%jedB,nz));tmp_v(:,:,:)=0.0
+      allocate(tmp_v(G%isd:G%ied,G%jsdB:G%jedB,nz)) ; tmp_v(:,:,:)=0.0
     endif
     nz_data = CS%Ref_val_v%nz_data
     allocate(tmp_val2(nz_data))
@@ -1169,9 +1156,6 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
     endif
     deallocate(tmp_val2)
   endif
-
-
-
 
 end subroutine apply_ALE_sponge
 


### PR DESCRIPTION
  This PR includes various commits that prepare to allow for the reference
heights for bathymetry and interfaces to be changed, or corrects problems that
were exposed in the process of developing that capability, but which do not
themselves change any answers or algorithms.  This set of changes includes the
addition of several new optional arguments, and it adds comments noting (but
does not fix) some buts that seem likely to change answers.  These new
capabilities have been tested and work, but they will not be exercised until the
subsequent commit that implements the ability to change reference heights.  All
answers and output are bitwise identical with the changes in this PR.

  The commits in this PR include:

- NOAA-GFDL/MOM6@5017bf6c6 Added comments highlighting bugs
- NOAA-GFDL/MOM6@c72d441ea (*)Fix dimensionally inconsistent MEKE beta calcs
- NOAA-GFDL/MOM6@62446ec0f Cleanup of comments in MOM_ALE_sponge.F90
- NOAA-GFDL/MOM6@7cc058291 Prep initialization for reference height changes
- NOAA-GFDL/MOM6@e4ffa7654 Corrects the routine indicated in 2 error messages
- NOAA-GFDL/MOM6@4d8d7afc7 +Add optional Z_0p argument to int_density_dz
- NOAA-GFDL/MOM6@db43b353f Longer error string in get_polynomial_coordinate
- NOAA-GFDL/MOM6@a2df3b75e Code cleanup in MOM_regridding
- NOAA-GFDL/MOM6@6f1a19173 +Add optional dZref argument to find_eta
