### PR TITLE
MOM6: +Pass total depths as arguments

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -880,21 +880,20 @@ subroutine check_remapping_grid( G, GV, h, dzInterface, msg )
 
   !$OMP parallel do default(shared)
   do j = G%jsc-1,G%jec+1 ; do i = G%isc-1,G%iec+1
-    if (G%mask2dT(i,j)>0.) call check_grid_column( GV%ke, GV%Z_to_H*G%bathyT(i,j), h(i,j,:), dzInterface(i,j,:), msg )
+    if (G%mask2dT(i,j)>0.) call check_grid_column( GV%ke, h(i,j,:), dzInterface(i,j,:), msg )
   enddo ; enddo
 
 end subroutine check_remapping_grid
 
 !> Check that the total thickness of new and old grids are consistent
-subroutine check_grid_column( nk, depth, h, dzInterface, msg )
+subroutine check_grid_column( nk, h, dzInterface, msg )
   integer,               intent(in) :: nk !< Number of cells
-  real,                  intent(in) :: depth !< Depth of bottom [Z ~> m] or arbitrary units
   real, dimension(nk),   intent(in) :: h  !< Cell thicknesses [Z ~> m] or arbitrary units
   real, dimension(nk+1), intent(in) :: dzInterface !< Change in interface positions (same units as h)
   character(len=*),      intent(in) :: msg !< Message to append to errors
   ! Local variables
   integer :: k
-  real    :: eps, total_h_old, total_h_new, h_new, z_old, z_new
+  real    :: eps, total_h_old, total_h_new, h_new
 
   eps =1. ; eps = epsilon(eps)
 
@@ -904,13 +903,8 @@ subroutine check_grid_column( nk, depth, h, dzInterface, msg )
     total_h_old = total_h_old + h(k)
   enddo
 
-  ! Integrate upwards for the interfaces consistent with the rest of MOM6
-  z_old = - depth
-  if (depth == 0.) z_old = - total_h_old
   total_h_new = 0.
   do k = nk,1,-1
-    z_old = z_old + h(k) ! Old interface position above layer k
-    z_new = z_old + dzInterface(k) ! New interface position based on dzInterface
     h_new = h(k) + ( dzInterface(k) - dzInterface(k+1) ) ! New thickness
     if (h_new<0.) then
       write(0,*) 'k,h,hnew=',k,h(k),h_new
@@ -1082,7 +1076,7 @@ subroutine filtered_grid_motion( CS, nk, z_old, z_new, dz_g )
 
 end subroutine filtered_grid_motion
 
-!> Builds a z*-ccordinate grid with partial steps (Adcroft and Campin, 2004).
+!> Builds a z*-coordinate grid with partial steps (Adcroft and Campin, 2004).
 !! z* is defined as
 !!   z* = (z-eta)/(H+eta)*H  s.t. z*=0 when z=eta and z*=-H when z=-H .
 subroutine build_zstar_grid( CS, G, GV, h, dzInterface, frac_shelf_h)
@@ -1118,7 +1112,7 @@ subroutine build_zstar_grid( CS, G, GV, h, dzInterface, frac_shelf_h)
         cycle
       endif
 
-      ! Local depth (G%bathyT is positive)
+      ! Local depth (G%bathyT is positive downward)
       nominalDepth = G%bathyT(i,j)*GV%Z_to_H
 
       ! Determine water column thickness
@@ -1319,7 +1313,7 @@ subroutine build_rho_grid( G, GV, US, h, tv, dzInterface, remapCS, CS, frac_shel
       endif
 
 
-      ! Local depth (G%bathyT is positive)
+      ! Local depth (G%bathyT is positive downward)
       nominalDepth = G%bathyT(i,j)*GV%Z_to_H
 
       ! Determine total water column thickness
@@ -1406,7 +1400,7 @@ end subroutine build_rho_grid
 !! density interpolated from the column profile and a clipping of depth for
 !! each interface to a fixed z* or p* grid.  This should probably be (optionally?)
 !! changed to find the nearest location of the target density.
-!! \remark { Based on Bleck, 2002: An oceanice general circulation model framed in
+!! \remark { Based on Bleck, 2002: An ocean-ice general circulation model framed in
 !! hybrid isopycnic-Cartesian coordinates, Ocean Modelling 37, 55-88.
 !! http://dx.doi.org/10.1016/S1463-5003(01)00012-9 }
 subroutine build_grid_HyCOM1( G, GV, US, h, tv, h_new, dzInterface, CS, frac_shelf_h )
@@ -1575,7 +1569,9 @@ subroutine build_grid_SLight(G, GV, US, h, tv, dzInterface, CS)
   real, dimension(SZK_(GV)+1) :: z_col_new ! Interface positions relative to the surface [H ~> m or kg m-2]
   real, dimension(SZK_(GV)+1) :: dz_col  ! The realized change in z_col [H ~> m or kg m-2]
   real, dimension(SZK_(GV))   :: p_col   ! Layer center pressure [R L2 T-2 ~> Pa]
-  real :: depth
+
+  ! Local variables
+  real :: depth   ! Depth of the ocean relative to the mean sea surface height in thickness units [H ~> m or kg m-2]
   integer :: i, j, k, nz
   real :: h_neglect, h_neglect_edge
 
@@ -1631,8 +1627,8 @@ end subroutine build_grid_SLight
 subroutine adjust_interface_motion( CS, nk, h_old, dz_int )
   type(regridding_CS),      intent(in)    :: CS !< Regridding control structure
   integer,                  intent(in)    :: nk !< Number of layers in h_old
-  real, dimension(nk),      intent(in)    :: h_old !< Minium allowed thickness of h [H ~> m or kg m-2]
-  real, dimension(CS%nk+1), intent(inout) :: dz_int !< Minium allowed thickness of h [H ~> m or kg m-2]
+  real, dimension(nk),      intent(in)    :: h_old !< Minimum allowed thickness of h [H ~> m or kg m-2]
+  real, dimension(CS%nk+1), intent(inout) :: dz_int !< Minimum allowed thickness of h [H ~> m or kg m-2]
   ! Local variables
   integer :: k
   real :: h_new, eps, h_total, h_err
@@ -1710,8 +1706,8 @@ subroutine build_grid_arbitrary( G, GV, h, dzInterface, h_new, CS )
   real      :: total_height
   real      :: delta_h
   real      :: max_depth
-  real      :: eta              ! local elevation
-  real      :: local_depth
+  real      :: eta              ! local elevation [H ~> m or kg m-2]
+  real      :: local_depth      ! The local ocean depth relative to mean sea level in thickness units [H ~> m or kg m-2]
   real      :: x1, y1, x2, y2
   real      :: x, t
 
@@ -1769,7 +1765,7 @@ subroutine build_grid_arbitrary( G, GV, h, dzInterface, h_new, CS )
         endif
       enddo
 
-      ! Chnage in interface position
+      ! Change in interface position
       x = 0. ! Left boundary at x=0
       dzInterface(i,j,1) = 0.
       do k = 2,nz
@@ -1797,7 +1793,7 @@ subroutine inflate_vanished_layers_old( CS, G, GV, h )
 ! objective is to make sure all layers are at least as thick as the minimum
 ! thickness allowed for regridding purposes (this parameter is set in the
 ! MOM_input file or defaulted to 1.0e-3). When layers are too thin, they
-! are inflated up to the minmum thickness.
+! are inflated up to the minimum thickness.
 !------------------------------------------------------------------------------
 
   ! Arguments
@@ -1901,7 +1897,7 @@ function uniformResolution(nk,coordMode,maxDepth,rhoLight,rhoHeavy)
   ! Arguments
   integer,          intent(in) :: nk !< Number of cells in source grid
   character(len=*), intent(in) :: coordMode !< A string indicating the coordinate mode.
-                                            !! See the documenttion for regrid_consts
+                                            !! See the documentation for regrid_consts
                                             !! for the recognized values.
   real,             intent(in) :: maxDepth  !< The range of the grid values in some modes
   real,             intent(in) :: rhoLight  !< The minimum value of the grid in RHO mode

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -373,7 +373,7 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   real                        :: grad        ! gradient during N-R iterations [A]
   integer :: i, k, iter  ! loop indices
   integer :: k_found     ! index of target cell
-  character(len=200) :: mesg
+  character(len=320) :: mesg
   logical :: use_2018_answers  ! If true use older, less acccurate expressions.
 
   eps = NR_OFFSET

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -3802,29 +3802,31 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
     ishift=0;jshift=0
     if (segment%is_E_or_W) then
       allocate(normal_trans_bt(segment%HI%IsdB:segment%HI%IedB,segment%HI%jsd:segment%HI%jed))
-      normal_trans_bt(:,:)=0.0
+      normal_trans_bt(:,:) = 0.0
       if (segment%direction == OBC_DIRECTION_W) ishift=1
       I=segment%HI%IsdB
       do j=segment%HI%jsd,segment%HI%jed
-        segment%Cg(I,j) = sqrt(GV%g_prime(1)*G%bathyT(i+ishift,j))
-        segment%Htot(I,j)=0.0
+        segment%Htot(I,j) = 0.0
         do k=1,GV%ke
           segment%h(I,j,k) = h(i+ishift,j,k)
-          segment%Htot(I,j)=segment%Htot(I,j)+segment%h(I,j,k)
+          segment%Htot(I,j) = segment%Htot(I,j) + segment%h(I,j,k)
         enddo
+        segment%Cg(I,j) = sqrt(GV%g_prime(1)*G%bathyT(i+ishift,j))
+        !### This should be: segment%Cg(I,j) = sqrt(GV%g_prime(1)*segment%Htot(I,j)*GV%H_to_Z)
       enddo
     else! (segment%direction == OBC_DIRECTION_N .or. segment%direction == OBC_DIRECTION_S)
       allocate(normal_trans_bt(segment%HI%isd:segment%HI%ied,segment%HI%JsdB:segment%HI%JedB))
-      normal_trans_bt(:,:)=0.0
+      normal_trans_bt(:,:) = 0.0
       if (segment%direction == OBC_DIRECTION_S) jshift=1
       J=segment%HI%JsdB
       do i=segment%HI%isd,segment%HI%ied
-        segment%Cg(i,J) = sqrt(GV%g_prime(1)*G%bathyT(i,j+jshift))
-        segment%Htot(i,J)=0.0
+        segment%Htot(i,J) = 0.0
         do k=1,GV%ke
           segment%h(i,J,k) = h(i,j+jshift,k)
-          segment%Htot(i,J)=segment%Htot(i,J)+segment%h(i,J,k)
+          segment%Htot(i,J) = segment%Htot(i,J) + segment%h(i,J,k)
         enddo
+        segment%Cg(i,J) = sqrt(GV%g_prime(1)*G%bathyT(i,j+jshift))
+        !### This should be: segment%Cg(i,J) = sqrt(GV%g_prime(1)*segment%Htot(i,J)*GV%H_to_Z)
       enddo
     endif
 
@@ -4715,7 +4717,7 @@ subroutine mask_outside_OBCs(G, US, param_file, OBC)
   integer :: i, j
   integer :: l_seg
   logical :: fatal_error = .False.
-  real    :: min_depth
+  real    :: min_depth ! The minimum depth for ocean points [Z ~> m]
   integer, parameter :: cin = 3, cout = 4, cland = -1, cedge = -2
   character(len=256) :: mesg    ! Message for error messages.
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
@@ -4729,7 +4731,6 @@ subroutine mask_outside_OBCs(G, US, param_file, OBC)
 
   allocate(color(G%isd:G%ied, G%jsd:G%jed)) ; color = 0
   allocate(color2(G%isd:G%ied, G%jsd:G%jed)) ; color2 = 0
-
 
   ! Paint a frame around the outside.
   do j=G%jsd,G%jed

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -444,7 +444,8 @@ subroutine wave_speed(h, tv, G, GV, US, cg1, CS, full_halos, use_ebt_mode, mono_
               hw = 0.5*(Hc(k-1)+Hc(k))
               gp = gprime(K)
               if (l_mono_N2_column_fraction>0. .or. l_mono_N2_depth>=0.) then
-                if ( ((G%bathyT(i,j)-sum_hc < l_mono_N2_column_fraction*G%bathyT(i,j)) .or. &
+                !### Change to: if ( ((htot(i) - sum_hc < l_mono_N2_column_fraction*htot(i)) .or. & ) )
+                if ( ((G%bathyT(i,j) - sum_hc < l_mono_N2_column_fraction*G%bathyT(i,j)) .or. &
                       ((l_mono_N2_depth >= 0.) .and. (sum_hc > l_mono_N2_depth))) .and. &
                      (L2_to_Z2*gp > N2min*hw) ) then
                   ! Filters out regions where N2 increases with depth but only in a lower fraction

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1253,7 +1253,7 @@ end subroutine analytic_int_specific_vol_dp
 !! pressure anomalies across layers, which are required for calculating the
 !! finite-volume form pressure accelerations in a Boussinesq model.
 subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, dpa, &
-                          intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, useMassWghtInterp)
+                          intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, useMassWghtInterp, Z_0p)
   type(hor_index_type), intent(in)  :: HI !< Ocean horizontal index structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T   !< Potential temperature referenced to the surface [degC]
@@ -1292,6 +1292,8 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m]
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
                                            !! interpolate T/S for top and bottom integrals.
+  real,       optional, intent(in)  :: Z_0p !< The height at which the pressure is 0 [Z ~> m]
+
   ! Local variables
   real :: rho_scale  ! A multiplicative factor by which to scale density from kg m-3 to the
                      ! desired units [R m3 kg-1 ~> 1]
@@ -1322,11 +1324,11 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
       if ((rho_scale /= 1.0) .or. (pres_scale /= 1.0)) then
         call int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp, rho_scale, pres_scale)
+                                   dz_neglect, useMassWghtInterp, rho_scale, pres_scale, Z_0p=Z_0p)
       else
         call int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp)
+                                   dz_neglect, useMassWghtInterp, Z_0p=Z_0p)
       endif
     case default
       call MOM_error(FATAL, "No analytic integration option is available with this EOS!")

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -294,9 +294,9 @@ subroutine rescale_dyn_horgrid_bathymetry(G, m_in_new_units)
 
   if (m_in_new_units == 1.0) return
   if (m_in_new_units < 0.0) &
-    call MOM_error(FATAL, "rescale_grid_bathymetry: Negative depth units are not permitted.")
+    call MOM_error(FATAL, "rescale_dyn_horgrid_bathymetry: Negative depth units are not permitted.")
   if (m_in_new_units == 0.0) &
-    call MOM_error(FATAL, "rescale_grid_bathymetry: Zero depth units are not permitted.")
+    call MOM_error(FATAL, "rescale_dyn_horgrid_bathymetry: Zero depth units are not permitted.")
 
   rescale = 1.0 / m_in_new_units
   do j=jsd,jed ; do i=isd,ied

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -496,7 +496,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     enddo ; enddo
 
     do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-      grad_vel_mag_bt_q(I,J) = boundary_mask_q(I,J) * (dvdx_bt(i,j)**2 + dudy_bt(i,j)**2 + &
+      grad_vel_mag_bt_q(I,J) = boundary_mask_q(I,J) * (dvdx_bt(I,J)**2 + dudy_bt(I,J)**2 + &
             (0.25*((dudx_bt(i,j)+dudx_bt(i+1,j+1))+(dudx_bt(i,j+1)+dudx_bt(i+1,j))))**2 + &
             (0.25*((dvdy_bt(i,j)+dvdy_bt(i+1,j+1))+(dvdy_bt(i,j+1)+dvdy_bt(i+1,j))))**2)
     enddo ; enddo
@@ -1389,7 +1389,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         if (grad_vel_mag_bt_h(i,j)>0) then
-          GME_coeff = CS%GME_efficiency * (MIN(G%bathyT(i,j)/CS%GME_h0,1.0)**2) * &
+          GME_coeff = CS%GME_efficiency * (MIN(G%bathyT(i,j) / CS%GME_h0, 1.0)**2) * &
             (0.25*(KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)+KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
         else
           GME_coeff = 0.0
@@ -1405,8 +1405,10 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       enddo ; enddo
 
       do J=js-1,Jeq ; do I=is-1,Ieq
-        if (grad_vel_mag_bt_q(i,j)>0) then
-          GME_coeff = CS%GME_efficiency * (MIN(G%bathyT(i,j)/CS%GME_h0,1.0)**2) * &
+        if (grad_vel_mag_bt_q(I,J)>0) then
+          !### This expression is not rotationally invariant - bathyT is to the SW of q points,
+          !    and it needs parentheses in the sum of the 4 diffusivities.
+          GME_coeff = CS%GME_efficiency * (MIN(G%bathyT(i,j) / CS%GME_h0, 1.0)**2) * &
               (0.25*(KH_u_GME(I,j,k)+KH_u_GME(I,j+1,k)+KH_v_GME(i,J,k)+KH_v_GME(i+1,J,k)))
         else
           GME_coeff = 0.0

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -481,14 +481,19 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
         do j=js,je ; do I=is-1,ie
           hu(I,j)       = 2.0*h(i,j,k)*h(i+1,j,k)/(h(i,j,k)+h(i+1,j,k)+h_neglect)
           if (hu(I,j) /= 0.0) hu(I,j) = 1.0
+          !### The same result would be accomplished with the following without a division:
+          ! hu(I,j) = 0.0 ; if (h(i,j,k)*h(i+1,j,k) /= 0.0) hu(I,j) = 1.0
           KH_u_lay(I,j) = 0.5*(KH_u(I,j,k)+KH_u(I,j,k+1))
         enddo ; enddo
         do J=js-1,je ; do i=is,ie
           hv(i,J)       = 2.0*h(i,j,k)*h(i,j+1,k)/(h(i,j,k)+h(i,j+1,k)+h_neglect)
           if (hv(i,J) /= 0.0) hv(i,J) = 1.0
+          !### The same result would be accomplished with the following without a division:
+          ! hv(i,J) = 0.0 ; if (h(i,j,k)*h(i,j+1,k) /= 0.0) hv(i,J) = 1.0
           KH_v_lay(i,J) = 0.5*(KH_v(i,J,k)+KH_v(i,J,k+1))
         enddo ; enddo
         ! diagnose diffusivity at T-point
+        !### Because hu and hv are nondimensional here, the denominator is dimensionally inconsistent.
         do j=js,je ; do i=is,ie
           Kh_t(i,j,k) = ((hu(I-1,j)*KH_u_lay(i-1,j)+hu(I,j)*KH_u_lay(I,j))  &
                         +(hv(i,J-1)*KH_v_lay(i,J-1)+hv(i,J)*KH_v_lay(i,J))) &
@@ -505,7 +510,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
         enddo
 
         do j=js,je ; do i=is,ie
-          MEKE%Kh_diff(i,j) = MEKE%Kh_diff(i,j) / MAX(1.0,G%bathyT(i,j))
+          MEKE%Kh_diff(i,j) = GV%H_to_Z * MEKE%Kh_diff(i,j) / MAX(1.0*US%m_to_Z, G%bathyT(i,j))
         enddo ; enddo
       endif
 

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -47,7 +47,7 @@ interface set_up_ALE_sponge_vel_field
   module procedure set_up_ALE_sponge_vel_field_varying
 end interface
 
-!> Ddetermine the number of points which are within sponges in this computational domain.
+!> Determine the number of points which are within sponges in this computational domain.
 !!
 !! Only points that have positive values of Iresttime and which mask2dT indicates are ocean
 !! points are included in the sponges.  It also stores the target interface heights.
@@ -90,31 +90,19 @@ end type p2d
 !> ALE sponge control structure
 type, public :: ALE_sponge_CS ; private
   integer :: nz        !< The total number of layers.
-  integer :: nz_data   !< The total number of arbritary layers (used by older code).
-  integer :: isc       !< The starting i-index of the computational domain at h.
-  integer :: iec       !< The ending i-index of the computational domain at h.
-  integer :: jsc       !< The starting j-index of the computational domain at h.
-  integer :: jec       !< The ending j-index of the computational domain at h.
-  integer :: IscB      !< The starting I-index of the computational domain at u/v.
-  integer :: IecB      !< The ending I-index of the computational domain at u/v.
-  integer :: JscB      !< The starting J-index of the computational domain at u/v.
-  integer :: JecB      !< The ending J-index of the computational domain at h.
-  integer :: isd       !< The starting i-index of the data domain at h.
-  integer :: ied       !< The ending i-index of the data domain at h.
-  integer :: jsd       !< The starting j-index of the data domain at h.
-  integer :: jed       !< The ending j-index of the data domain at h.
+  integer :: nz_data   !< The total number of arbitrary layers (used by older code).
   integer :: num_col   !< The number of sponge tracer points within the computational domain.
   integer :: num_col_u !< The number of sponge u-points within the computational domain.
   integer :: num_col_v !< The number of sponge v-points within the computational domain.
   integer :: fldno = 0 !< The number of fields which have already been
                        !! registered by calls to set_up_sponge_field
   logical :: sponge_uv !< Control whether u and v are included in sponge
-  integer, pointer :: col_i(:) => NULL()   !< Array of the i-indicies of each tracer columns being damped.
-  integer, pointer :: col_j(:) => NULL()   !< Array of the j-indicies of each tracer columns being damped.
-  integer, pointer :: col_i_u(:) => NULL() !< Array of the i-indicies of each u-columns being damped.
-  integer, pointer :: col_j_u(:) => NULL() !< Array of the j-indicies of each u-columns being damped.
-  integer, pointer :: col_i_v(:) => NULL() !< Array of the i-indicies of each v-columns being damped.
-  integer, pointer :: col_j_v(:) => NULL() !< Array of the j-indicies of each v-columns being damped.
+  integer, pointer :: col_i(:) => NULL()   !< Array of the i-indices of each tracer column being damped.
+  integer, pointer :: col_j(:) => NULL()   !< Array of the j-indices of each tracer column being damped.
+  integer, pointer :: col_i_u(:) => NULL() !< Array of the i-indices of each u-column being damped.
+  integer, pointer :: col_j_u(:) => NULL() !< Array of the j-indices of each u-column being damped.
+  integer, pointer :: col_i_v(:) => NULL() !< Array of the i-indices of each v-column being damped.
+  integer, pointer :: col_j_v(:) => NULL() !< Array of the j-indices of each v-column being damped.
 
   real, pointer :: Iresttime_col(:)   => NULL() !< The inverse restoring time of each tracer column [T-1 ~> s-1].
   real, pointer :: Iresttime_col_u(:) => NULL() !< The inverse restoring time of each u-column [T-1 ~> s-1].
@@ -124,8 +112,8 @@ type, public :: ALE_sponge_CS ; private
   type(p2d) :: Ref_val(MAX_FIELDS_) !< The values to which the fields are damped.
   type(p2d) :: Ref_val_u  !< The values to which the u-velocities are damped.
   type(p2d) :: Ref_val_v  !< The values to which the v-velocities are damped.
-  type(p3d) :: var_u  !< Pointer to the u velocities. that are being damped.
-  type(p3d) :: var_v  !< Pointer to the v velocities. that are being damped.
+  type(p3d) :: var_u  !< Pointer to the u velocities that are being damped.
+  type(p3d) :: var_v  !< Pointer to the v velocities that are being damped.
   type(p2d) :: Ref_h  !< Grid on which reference data is provided (older code).
   type(p2d) :: Ref_hu !< u-point grid on which reference data is provided (older code).
   type(p2d) :: Ref_hv !< v-point grid on which reference data is provided (older code).
@@ -137,7 +125,7 @@ type, public :: ALE_sponge_CS ; private
   logical :: remap_answers_2018    !< If true, use the order of arithmetic and expressions that
                                    !! recover the answers for remapping from the end of 2018.
                                    !! Otherwise, use more robust forms of the same expressions.
-  logical :: hor_regrid_answers_2018 !< If true, use the order of arithmetic for horizonal regridding
+  logical :: hor_regrid_answers_2018 !< If true, use the order of arithmetic for horizontal regridding
                                    !! that recovers the answers from the end of 2018.  Otherwise, use
                                    !! rotationally symmetric forms of the same expressions.
 
@@ -241,9 +229,6 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
 
   CS%time_varying_sponges = .false.
   CS%nz = GV%ke
-  CS%isc = G%isc ; CS%iec = G%iec ; CS%jsc = G%jsc ; CS%jec = G%jec
-  CS%isd = G%isd ; CS%ied = G%ied ; CS%jsd = G%jsd ; CS%jed = G%jed
-  CS%iscB = G%iscB ; CS%iecB = G%iecB; CS%jscB = G%jscB ; CS%jecB = G%jecB
 
   ! number of columns to be restored
   CS%num_col = 0 ; CS%fldno = 0
@@ -265,7 +250,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
         col = col +1
       endif
     enddo ; enddo
-    ! same for total number of arbritary layers and correspondent data
+    ! same for total number of arbitrary layers and correspondent data
     CS%nz_data = nz_data
     allocate(CS%Ref_h%p(CS%nz_data,CS%num_col))
     do col=1,CS%num_col ; do K=1,CS%nz_data
@@ -295,11 +280,11 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
     if (present(Iresttime_u_in)) then
        Iresttime_u(:,:) = Iresttime_u_in(:,:)
     else
-      do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
         Iresttime_u(I,j) = 0.5 * (Iresttime(i,j) + Iresttime(i+1,j))
       enddo ; enddo
     endif
-    do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+    do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
        if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) &
           CS%num_col_u = CS%num_col_u + 1
     enddo ; enddo
@@ -312,7 +297,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
 
       ! Store the column indices and restoring rates in the CS structure
       col = 1
-      do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
         if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) then
           CS%col_i_u(col) = I ; CS%col_j_u(col) = j
           CS%Iresttime_col_u(col) = Iresttime_u(I,j)
@@ -320,7 +305,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
         endif
       enddo ; enddo
 
-      ! same for total number of arbritary layers and correspondent data
+      ! same for total number of arbitrary layers and correspondent data
       allocate(CS%Ref_hu%p(CS%nz_data,CS%num_col_u))
       do col=1,CS%num_col_u
         I = CS%col_i_u(col) ; j = CS%col_j_u(col)
@@ -339,11 +324,11 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
     if (present(Iresttime_v_in)) then
       Iresttime_v(:,:) = Iresttime_v_in(:,:)
     else
-      do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB; do i=G%isc,G%iec
         Iresttime_v(i,J) = 0.5 * (Iresttime(i,j) + Iresttime(i,j+1))
       enddo ; enddo
     endif
-    do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+    do J=G%jscB,G%jecB; do i=G%isc,G%iec
       if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) &
         CS%num_col_v = CS%num_col_v + 1
     enddo ; enddo
@@ -356,7 +341,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
 
       ! pass indices, restoring time to the CS structure
       col = 1
-      do J=CS%jscB,CS%jecB ; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec
         if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) then
           CS%col_i_v(col) = i ; CS%col_j_v(col) = j
           CS%Iresttime_col_v(col) = Iresttime_v(i,j)
@@ -364,7 +349,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
         endif
       enddo ; enddo
 
-      ! same for total number of arbritary layers and correspondent data
+      ! same for total number of arbitrary layers and correspondent data
       allocate(CS%Ref_hv%p(CS%nz_data,CS%num_col_v))
       do col=1,CS%num_col_v
         i = CS%col_i_v(col) ; J = CS%col_j_v(col)
@@ -430,7 +415,7 @@ subroutine get_ALE_sponge_thicknesses(G, data_h, sponge_mask, CS)
 
 end subroutine get_ALE_sponge_thicknesses
 
-!> This subroutine determines the number of points which are to be restoref in the computational
+!> This subroutine determines the number of points which are to be restored in the computational
 !! domain.  Only points that have positive values of Iresttime and which mask2dT indicates are ocean
 !! points are included in the sponges.
 subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Iresttime_u_in, Iresttime_v_in)
@@ -510,9 +495,6 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
 
   CS%time_varying_sponges = .true.
   CS%nz = GV%ke
-  CS%isc = G%isc ; CS%iec = G%iec ; CS%jsc = G%jsc ; CS%jec = G%jec
-  CS%isd = G%isd ; CS%ied = G%ied ; CS%jsd = G%jsd ; CS%jed = G%jed
-  CS%iscB = G%iscB ; CS%iecB = G%iecB; CS%jscB = G%jscB ; CS%jecB = G%jecB
 
   ! number of columns to be restored
   CS%num_col = 0 ; CS%fldno = 0
@@ -551,12 +533,12 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
     if (present(Iresttime_u_in)) then
       Iresttime_u(:,:) = Iresttime_u_in(:,:)
     else
-      do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
         Iresttime_u(I,j) = 0.5 * (Iresttime(i,j) + Iresttime(i+1,j))
       enddo ; enddo
     endif
     CS%num_col_u = 0 ;
-    do j=CS%jsc,CS%jec; do I=CS%iscB,CS%iecB
+    do j=G%jsc,G%jec; do I=G%iscB,G%iecB
       if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) &
         CS%num_col_u = CS%num_col_u + 1
     enddo ; enddo
@@ -566,14 +548,14 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
       allocate(CS%col_j_u(CS%num_col_u))         ; CS%col_j_u = 0
       ! pass indices, restoring time to the CS structure
       col = 1
-      do j=CS%jsc,CS%jec ; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec ; do I=G%iscB,G%iecB
         if ((Iresttime_u(I,j)>0.0) .and. (G%mask2dCu(I,j)>0)) then
           CS%col_i_u(col) = i ; CS%col_j_u(col) = j
           CS%Iresttime_col_u(col) = Iresttime_u(i,j)
           col = col + 1
         endif
       enddo ; enddo
-      ! same for total number of arbritary layers and correspondent data
+      ! same for total number of arbitrary layers and correspondent data
     endif
     total_sponge_cols_u = CS%num_col_u
     call sum_across_PEs(total_sponge_cols_u)
@@ -583,12 +565,12 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
     if (present(Iresttime_v_in)) then
       Iresttime_v(:,:) = Iresttime_v_in(:,:)
     else
-      do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB; do i=G%isc,G%iec
         Iresttime_v(i,J) = 0.5 * (Iresttime(i,j) + Iresttime(i,j+1))
       enddo ; enddo
     endif
     CS%num_col_v = 0 ;
-    do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+    do J=G%jscB,G%jecB; do i=G%isc,G%iec
       if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) &
         CS%num_col_v = CS%num_col_v + 1
     enddo ; enddo
@@ -598,7 +580,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
       allocate(CS%col_j_v(CS%num_col_v))         ; CS%col_j_v = 0
       ! pass indices, restoring time to the CS structure
       col = 1
-      do J=CS%jscB,CS%jecB ; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec
         if ((Iresttime_v(i,J)>0.0) .and. (G%mask2dCv(i,J)>0)) then
           CS%col_i_v(col) = i ; CS%col_j_v(col) = j
           CS%Iresttime_col_v(col) = Iresttime_v(i,j)
@@ -630,16 +612,16 @@ subroutine init_ALE_sponge_diags(Time, G, diag, CS, US)
 
   CS%id_sp_tendency(1) = -1
   CS%id_sp_tendency(1) = register_diag_field('ocean_model', 'sp_tendency_temp', diag%axesTL, Time, &
-       'Time tendency due to temperature restoring', 'degC s-1',conversion=US%s_to_T)
+       'Time tendency due to temperature restoring', 'degC s-1', conversion=US%s_to_T)
   CS%id_sp_tendency(2) = -1
   CS%id_sp_tendency(2) = register_diag_field('ocean_model', 'sp_tendency_salt', diag%axesTL, Time, &
-       'Time tendency due to salinity restoring', 'g kg-1 s-1',conversion=US%s_to_T)
+       'Time tendency due to salinity restoring', 'g kg-1 s-1', conversion=US%s_to_T)
   CS%id_sp_u_tendency = -1
   CS%id_sp_u_tendency = register_diag_field('ocean_model', 'sp_tendency_u', diag%axesCuL, Time, &
-       'Zonal acceleration due to sponges', 'm s-2',conversion=US%L_T2_to_m_s2)
+       'Zonal acceleration due to sponges', 'm s-2', conversion=US%L_T2_to_m_s2)
   CS%id_sp_v_tendency = -1
   CS%id_sp_v_tendency = register_diag_field('ocean_model', 'sp_tendency_v', diag%axesCvL, Time, &
-       'Meridional acceleration due to sponges', 'm s-2',conversion=US%L_T2_to_m_s2)
+       'Meridional acceleration due to sponges', 'm s-2', conversion=US%L_T2_to_m_s2)
 
 end subroutine init_ALE_sponge_diags
 
@@ -718,19 +700,18 @@ subroutine set_up_ALE_sponge_field_varying(filename, fieldname, Time, G, GV, US,
   isd = G%isd; ied = G%ied; jsd = G%jsd; jed = G%jed
   CS%fldno = CS%fldno + 1
   if (CS%fldno > MAX_FIELDS_) then
-    write(mesg,'("Increase MAX_FIELDS_ to at least ",I3," in MOM_memory.h or decrease &
-           &the number of fields to be damped in the call to &
-           &initialize_ALE_sponge." )') CS%fldno
+    write(mesg, '("Increase MAX_FIELDS_ to at least ",I3," in MOM_memory.h or decrease "//&
+           "the number of fields to be damped in the call to initialize_ALE_sponge." )') CS%fldno
     call MOM_error(FATAL,"set_up_ALE_sponge_field: "//mesg)
   endif
-  ! get a unique time interp id for this field. If sponge data is ongrid, then setup
+  ! get a unique time interp id for this field. If sponge data is on-grid, then setup
   ! to only read on the computational domain
   if (CS%spongeDataOngrid) then
     CS%Ref_val(CS%fldno)%id = init_external_field(filename, fieldname, MOM_domain=G%Domain)
   else
     CS%Ref_val(CS%fldno)%id = init_external_field(filename, fieldname)
   endif
-  fld_sz(1:4)=-1
+  fld_sz(1:4) = -1
   call get_external_field_info(CS%Ref_val(CS%fldno)%id, size=fld_sz)
   nz_data = fld_sz(3)
   CS%Ref_val(CS%fldno)%nz_data = nz_data !< individual sponge fields may reside on a different vertical grid
@@ -748,17 +729,19 @@ end subroutine set_up_ALE_sponge_field_varying
 !> This subroutine stores the reference profile at u and v points for the variable
 !! whose address is given by u_ptr and v_ptr.
 subroutine set_up_ALE_sponge_vel_field_fixed(u_val, v_val, G, GV, u_ptr, v_ptr, CS)
-  type(ocean_grid_type),   intent(in) :: G  !< Grid structure (in).
+  type(ocean_grid_type),   intent(in) :: G     !< Grid structure (in).
   type(verticalGrid_type), intent(in) :: GV    !< ocean vertical grid structure
-  type(ALE_sponge_CS),     pointer    :: CS !< Sponge structure (in/out).
+  type(ALE_sponge_CS),     pointer    :: CS    !< Sponge structure (in/out).
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                          intent(in) :: u_val !< u field to be used in the sponge, it has arbritary number of layers but
-                                              !! not to exceed the total number of model layers
+                           intent(in) :: u_val !< u field to be used in the sponge [L T-1 ~> m s-1],
+                                               !! it is provided on its own vertical grid that may
+                                               !! have fewer layers than the model itself, but not more.
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                          intent(in) :: v_val !< v field to be used in the sponge, it has arbritary number of layers but
-                                              !! not to exceed the number of model layers
-  real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u pointer to the field to be damped
-  real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v pointer to the field to be damped
+                           intent(in) :: v_val !< v field to be used in the sponge [L T-1 ~> m s-1],
+                                               !! it is provided on its own vertical grid that may
+                                               !! have fewer layers than the model itself, but not more.
+  real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u-field to be damped [L T-1 ~> m s-1]
+  real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v-field to be damped [L T-1 ~> m s-1]
 
   integer :: j, k, col, fld_sz(4)
   character(len=256) :: mesg ! String for error messages
@@ -794,15 +777,16 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename
   character(len=*), intent(in)    :: filename_v  !< File name for v field
   character(len=*), intent(in)    :: fieldname_v !< Name of v variable in file
   type(time_type),  intent(in)    :: Time        !< Model time
-  type(ocean_grid_type), intent(in) :: G         !< Ocean grid (in)
-  type(verticalGrid_type), intent(in) :: GV    !< ocean vertical grid structure
-  type(unit_scale_type), intent(in)    :: US     !< A dimensional unit scaling type
-  type(ALE_sponge_CS), pointer    :: CS          !< Sponge structure (in/out).
-  real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u pointer to the field to be damped (in).
-  real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v pointer to the field to be damped (in).
+  type(ocean_grid_type),   intent(in) :: G       !< Ocean grid (in)
+  type(verticalGrid_type), intent(in) :: GV      !< ocean vertical grid structure
+  type(unit_scale_type),   intent(in) :: US      !< A dimensional unit scaling type
+  type(ALE_sponge_CS),     pointer    :: CS      !< Sponge structure (in/out).
+  real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u-field to be damped [L T-1 ~> m s-1]
+  real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v-field to be damped [L T-1 ~> m s-1]
+
   ! Local variables
-  real, allocatable, dimension(:,:,:) :: u_val !< U field to be used in the sponge.
-  real, allocatable, dimension(:,:,:) :: v_val !< V field to be used in the sponge.
+  real, allocatable, dimension(:,:,:) :: u_val !< U field to be used in the sponge [L T-1 ~> m s-1].
+  real, allocatable, dimension(:,:,:) :: v_val !< V field to be used in the sponge [L T-1 ~> m s-1].
 
   real, allocatable, dimension(:), target :: z_in, z_edges_in
   real :: missing_value
@@ -892,10 +876,13 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
   real, dimension(:), allocatable :: tmpT1d
   integer :: c, m, nkmb, i, j, k, is, ie, js, je, nz, nz_data
   integer :: col, total_sponge_cols
-  real, allocatable, dimension(:), target :: z_in, z_edges_in
-  real :: missing_value, Idt
-  real :: h_neglect, h_neglect_edge
-  real :: zTopOfCell, zBottomOfCell ! Heights [Z ~> m].
+  real, allocatable, dimension(:), target :: z_in  ! The depths (positive downward) in the input file [Z ~> m]
+  real, allocatable, dimension(:), target :: z_edges_in ! The depths (positive downward) of the
+                                                        ! edges in the input file [Z ~> m]
+  real :: missing_value
+  real :: Idt  ! The inverse of the timestep [T-1 ~> s-1]
+  real :: h_neglect, h_neglect_edge ! Negligible thicknesses [H ~> m or kg m-2]
+  real :: zTopOfCell, zBottomOfCell ! Interface heights (positive upward) in the input dataset [Z ~> m].
   integer :: nPoints
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -1020,7 +1007,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
 
       call pass_var(sp_val, G%Domain)
       call pass_var(mask_z, G%Domain)
-      do j=CS%jsc,CS%jec; do I=CS%iscB,CS%iecB
+      do j=G%jsc,G%jec; do I=G%iscB,G%iecB
         sp_val_u(I,j,1:nz_data) = 0.5*(sp_val(i,j,1:nz_data)+sp_val(i+1,j,1:nz_data))
         mask_u(I,j,1:nz_data) = min(mask_z(i,j,1:nz_data),mask_z(i+1,j,1:nz_data))
       enddo ; enddo
@@ -1068,7 +1055,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
                                           answers_2018=CS%hor_regrid_answers_2018)
       call pass_var(sp_val, G%Domain)
       call pass_var(mask_z, G%Domain)
-      do J=CS%jscB,CS%jecB; do i=CS%isc,CS%iec
+      do J=G%jscB,G%jecB; do i=G%isc,G%iec
         sp_val_v(i,J,1:nz_data) = 0.5*(sp_val(i,j,1:nz_data)+sp_val(i,j+1,1:nz_data))
         mask_v(i,J,1:nz_data) = min(mask_z(i,j,1:nz_data),mask_z(i,j+1,1:nz_data))
       enddo ; enddo
@@ -1107,7 +1094,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
     nz_data = CS%Ref_val_u%nz_data
     allocate(tmp_val2(nz_data))
     if (CS%id_sp_u_tendency > 0) then
-      allocate(tmp_u(G%isdB:G%iedB,G%jsd:G%jed,nz));tmp_u(:,:,:)=0.0
+      allocate(tmp_u(G%isdB:G%iedB,G%jsd:G%jed,nz)) ; tmp_u(:,:,:)=0.0
     endif
     ! u points
     do c=1,CS%num_col_u
@@ -1137,7 +1124,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
     endif
     ! v points
     if (CS%id_sp_v_tendency > 0) then
-      allocate(tmp_v(G%isd:G%ied,G%jsdB:G%jedB,nz));tmp_v(:,:,:)=0.0
+      allocate(tmp_v(G%isd:G%ied,G%jsdB:G%jedB,nz)) ; tmp_v(:,:,:)=0.0
     endif
     nz_data = CS%Ref_val_v%nz_data
     allocate(tmp_val2(nz_data))
@@ -1169,9 +1156,6 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
     endif
     deallocate(tmp_val2)
   endif
-
-
-
 
 end subroutine apply_ALE_sponge
 

--- a/src/user/BFB_initialization.F90
+++ b/src/user/BFB_initialization.F90
@@ -76,13 +76,15 @@ end subroutine BFB_set_coord
 
 !> This subroutine sets up the sponges for the southern bouundary of the domain. Maximum damping occurs
 !! within 2 degrees lat of the boundary. The damping linearly decreases northward over the next 2 degrees.
-subroutine BFB_initialize_sponges_southonly(G, GV, US, use_temperature, tv, param_file, CSp, h)
+subroutine BFB_initialize_sponges_southonly(G, GV, US, use_temperature, tv, depth_tot, param_file, CSp, h)
   type(ocean_grid_type),   intent(in) :: G  !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in) :: US !< A dimensional unit scaling type
   logical,                 intent(in) :: use_temperature !< If true, temperature and salinity are used as
                                             !! state variables.
   type(thermo_var_ptrs),   intent(in) :: tv   !< A structure pointing to various thermodynamic variables
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in) :: depth_tot !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
   type(sponge_CS),         pointer    :: CSp  !< A pointer to the sponge control structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
@@ -129,7 +131,7 @@ subroutine BFB_initialize_sponges_southonly(G, GV, US, use_temperature, tv, para
   max_damping = 1.0  / (86400.0*US%s_to_T)
 
   do j=js,je ; do i=is,ie
-    if (G%bathyT(i,j) <= min_depth) then ; Idamp(i,j) = 0.0
+    if (depth_tot(i,j) <= min_depth) then ; Idamp(i,j) = 0.0
     elseif (G%geoLatT(i,j) < slat+2.0) then ; Idamp(i,j) = max_damping
     elseif (G%geoLatT(i,j) < slat+4.0) then
       Idamp(i,j) = max_damping * (slat+4.0-G%geoLatT(i,j))/2.0

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -186,6 +186,7 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   real :: lambda       ! Offshore decay scale [L-1 ~> m-1]
   real :: omega        ! Wave frequency [T-1 ~> s-1]
   real :: PI
+  real :: depth_tot(SZI_(G),SZJ_(G))  ! The total depth of the ocean [Z ~> m]
   integer :: i, j, k, n, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB
   real    :: mag_SSH ! An overall magnitude of the external wave sea surface height at the coastline [Z ~> m]
@@ -208,6 +209,17 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   time_sec = US%s_to_T*time_type_to_real(Time)
   PI = 4.0*atan(1.0)
   km_to_L_scale = 1000.0*US%m_to_L
+
+  do j=jsd,jed ; do i=isd,ied
+    depth_tot(i,j) = G%bathyT(i,j)
+  enddo ; enddo
+  !### Instead this should be:
+  ! do j=jsd,jed ; do i=isd,ied
+  !   depth_tot(i,j) = 0.0
+  ! enddo ; enddo
+  ! do j=jsd,jed ; do i=isd,ied
+  !   depth_tot(i,j) = depth_tot(i,j) + GV%H_to_Z * h(i,j,k)
+  ! enddo ; enddo
 
   if (CS%mode == 0) then
     mag_SSH = 1.0*US%m_to_Z
@@ -245,20 +257,17 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
         y = -(x1 - CS%coast_offset1) * sina + y1 * cosa
         if (CS%mode == 0) then
           ! Use inside bathymetry
-          cff = sqrt(GV%g_Earth * G%bathyT(i+1,j) )
+          cff = sqrt(GV%g_Earth * depth_tot(i+1,j) )
           val2 = mag_SSH * exp(- CS%F_0 * y / cff)
           segment%eta(I,j) = GV%Z_to_H*val2 * cos(omega * time_sec)
-          segment%normal_vel_bt(I,j) = (val2 * (val1 * cff * cosa / &
-                 (G%bathyT(i+1,j) )) )
+          segment%normal_vel_bt(I,j) = val2 * (val1 * cff * cosa / depth_tot(i+1,j) )
           if (segment%nudged) then
             do k=1,nz
-              segment%nudged_normal_vel(I,j,k) = (val2 * (val1 * cff * cosa / &
-                     (G%bathyT(i+1,j))) )
+              segment%nudged_normal_vel(I,j,k) = val2 * (val1 * cff * cosa / depth_tot(i+1,j) )
             enddo
           elseif (segment%specified) then
             do k=1,nz
-              segment%normal_vel(I,j,k) = (val2 * (val1 * cff * cosa / &
-                     (G%bathyT(i+1,j) )) )
+              segment%normal_vel(I,j,k) = val2 * (val1 * cff * cosa / depth_tot(i+1,j) )
               segment%normal_trans(I,j,k) = segment%normal_vel(I,j,k) * h(i+1,j,k) * G%dyCu(I,j)
             enddo
           endif
@@ -288,11 +297,11 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
           y1 = km_to_L_scale * G%geoLatBu(I,J)
           x = (x1 - CS%coast_offset1) * cosa + y1 * sina
           y = - (x1 - CS%coast_offset1) * sina + y1 * cosa
-          cff = sqrt(GV%g_Earth * G%bathyT(i+1,j) )
+          cff = sqrt(GV%g_Earth * depth_tot(i+1,j) )
           val2 = mag_SSH * exp(- CS%F_0 * y / cff)
           if (CS%mode == 0) then ; do k=1,nz
             segment%tangential_vel(I,J,k) = (val1 * val2 * cff * sina) / &
-               ( 0.5*(G%bathyT(i+1,j+1) +  G%bathyT(i+1,j) ) )
+               ( 0.5*(depth_tot(i+1,j+1) +  depth_tot(i+1,j) ) )
 
           enddo ; endif
         enddo ; enddo
@@ -306,20 +315,17 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
         x = (x1 - CS%coast_offset1) * cosa + y1 * sina
         y = - (x1 - CS%coast_offset1) * sina + y1 * cosa
         if (CS%mode == 0) then
-          cff = sqrt(GV%g_Earth * G%bathyT(i,j+1) )
+          cff = sqrt(GV%g_Earth * depth_tot(i,j+1) )
           val2 = mag_SSH * exp(- 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J)) * y / cff)
           segment%eta(I,j) = GV%Z_to_H*val2 * cos(omega * time_sec)
-          segment%normal_vel_bt(I,j) = (val1 * cff * sina / &
-                 (G%bathyT(i,j+1) )) * val2
+          segment%normal_vel_bt(I,j) = (val1 * cff * sina / depth_tot(i,j+1) ) * val2
           if (segment%nudged) then
             do k=1,nz
-              segment%nudged_normal_vel(I,j,k) = (val1 * cff * sina / &
-                     (G%bathyT(i,j+1) )) * val2
+              segment%nudged_normal_vel(I,j,k) = (val1 * cff * sina / depth_tot(i,j+1)) * val2
             enddo
           elseif (segment%specified) then
             do k=1,nz
-              segment%normal_vel(I,j,k) = (val1 * cff * sina / &
-                     (G%bathyT(i,j+1) )) * val2
+              segment%normal_vel(I,j,k) = (val1 * cff * sina / depth_tot(i,j+1) ) * val2
               segment%normal_trans(i,J,k) = segment%normal_vel(i,J,k) * h(i,j+1,k) * G%dxCv(i,J)
             enddo
           endif
@@ -347,11 +353,11 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
           y1 = km_to_L_scale * G%geoLatBu(I,J)
           x = (x1 - CS%coast_offset1) * cosa + y1 * sina
           y = - (x1 - CS%coast_offset1) * sina + y1 * cosa
-          cff = sqrt(GV%g_Earth * G%bathyT(i,j+1) )
+          cff = sqrt(GV%g_Earth * depth_tot(i,j+1) )
           val2 = mag_SSH * exp(- 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J)) * y / cff)
           if (CS%mode == 0) then ; do k=1,nz
-            segment%tangential_vel(I,J,k) = ((val1 * val2 * cff * sina) / &
-                ( 0.5*((G%bathyT(i+1,j+1)) + G%bathyT(i,j+1))) )
+            segment%tangential_vel(I,J,k) = (val1 * val2 * cff * sina) / &
+                ( 0.5*(depth_tot(i+1,j+1) + depth_tot(i,j+1)) )
           enddo ; endif
         enddo ; enddo
       endif

--- a/src/user/Neverworld_initialization.F90
+++ b/src/user/Neverworld_initialization.F90
@@ -239,12 +239,14 @@ end function circ_ridge
 !! by finding the depths of interfaces in a specified latitude-dependent
 !! temperature profile with an exponentially decaying thermocline on top of a
 !! linear stratification.
-subroutine Neverworld_initialize_thickness(h, G, GV, US, param_file, eqn_of_state, P_ref)
+subroutine Neverworld_initialize_thickness(h, depth_tot, G, GV, US, param_file, eqn_of_state, P_ref)
   type(ocean_grid_type),   intent(in) :: G                    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in) :: GV                   !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in) :: US                   !< A dimensional unit scaling type
-  real, intent(out), dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h !< The thickness that is being
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: h !< The thickness that is being
                                                               !! initialized [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in) :: depth_tot  !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in) :: param_file           !< A structure indicating the open
                                                               !! file to parse for model
                                                               !! parameter values.
@@ -283,7 +285,7 @@ subroutine Neverworld_initialize_thickness(h, G, GV, US, param_file, eqn_of_stat
   enddo
 
   do j=js,je ; do i=is,ie
-    e_interface = -G%bathyT(i,j)
+    e_interface = -depth_tot(i,j)
     do k=nz,2,-1
       h(i,j,k) = GV%Z_to_H * (e0(k) - e_interface) ! Nominal thickness
       x=(G%geoLonT(i,j)-G%west_lon)/G%len_lon

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -35,12 +35,14 @@ public Phillips_initialize_topography
 contains
 
 !> Initialize the thickness field for the Phillips model test case.
-subroutine Phillips_initialize_thickness(h, G, GV, US, param_file, just_read_params)
+subroutine Phillips_initialize_thickness(h, depth_tot, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G          !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV         !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h          !< The thickness that is being initialized [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)  :: depth_tot  !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file !< A structure indicating the open file
                                                      !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -113,7 +115,7 @@ subroutine Phillips_initialize_thickness(h, G, GV, US, param_file, just_read_par
     ! thicknesses are set to insure that: 1. each layer is at least an Angstrom thick, and
     ! 2. the interfaces are where they should be based on the resting depths and interface
     !    height perturbations, as long at this doesn't interfere with 1.
-    eta1D(nz+1) = -G%bathyT(i,j)
+    eta1D(nz+1) = -depth_tot(i,j)
     do k=nz,1,-1
       eta1D(K) = eta_im(j,K)
       if (eta1D(K) < (eta1D(K+1) + GV%Angstrom_Z)) then

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -57,8 +57,8 @@ subroutine adjustment_initialize_thickness ( h, G, GV, US, param_file, just_read
   real    :: target_values(SZK_(GV)+1)  ! Target densities or density anomalies [R ~> kg m-3]
   logical :: just_read    ! If true, just read parameters but set nothing.
   character(len=20) :: verticalCoordinate
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -193,13 +193,15 @@ subroutine adjustment_initialize_thickness ( h, G, GV, US, param_file, just_read
 end subroutine adjustment_initialize_thickness
 
 !> Initialization of temperature and salinity in the adjustment test case
-subroutine adjustment_initialize_temperature_salinity(T, S, h, G, GV, param_file, &
+subroutine adjustment_initialize_temperature_salinity(T, S, h, depth_tot, G, GV, param_file, &
                                                       eqn_of_state, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T !< The temperature that is being initialized.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S !< The salinity that is being initialized.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< The model thicknesses [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)  :: depth_tot !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in) :: param_file   !< A structure indicating the open file to
                                                       !! parse for model parameter values.
   type(EOS_type),                 pointer     :: eqn_of_state !< Equation of state.
@@ -260,7 +262,7 @@ subroutine adjustment_initialize_temperature_salinity(T, S, h, G, GV, param_file
     case ( REGRIDDING_ZSTAR, REGRIDDING_SIGMA )
       dSdz = -delta_S_strat / G%max_depth
       do j=js,je ; do i=is,ie
-        eta1d(nz+1) = -G%bathyT(i,j)
+        eta1d(nz+1) = -depth_tot(i,j)
         do k=nz,1,-1
           eta1d(k) = eta1d(k+1) + h(i,j,k)*GV%H_to_Z
         enddo

--- a/src/user/baroclinic_zone_initialization.F90
+++ b/src/user/baroclinic_zone_initialization.F90
@@ -75,7 +75,7 @@ subroutine bcz_params(G, GV, US, param_file, S_ref, dSdz, delta_S, dSdx, T_ref, 
 end subroutine bcz_params
 
 !> Initialization of temperature and salinity with the baroclinic zone initial conditions
-subroutine baroclinic_zone_init_temperature_salinity(T, S, h, G, GV, US, param_file, &
+subroutine baroclinic_zone_init_temperature_salinity(T, S, h, depth_tot, G, GV, US, param_file, &
                                                      just_read_params)
   type(ocean_grid_type),                     intent(in)  :: G  !< Grid structure
   type(verticalGrid_type),                   intent(in)  :: GV !< The ocean's vertical grid structure.
@@ -83,6 +83,8 @@ subroutine baroclinic_zone_init_temperature_salinity(T, S, h, G, GV, US, param_f
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T  !< Potential temperature [degC]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S  !< Salinity [ppt]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h  !< The model thicknesses [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)  :: depth_tot !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),                     intent(in)  :: param_file  !< Parameter file handle
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
                                                       !! only read parameters without changing T & S.
@@ -109,7 +111,7 @@ subroutine baroclinic_zone_init_temperature_salinity(T, S, h, G, GV, US, param_f
   PI = 4.*atan(1.)
 
   do j = G%jsc,G%jec ; do i = G%isc,G%iec
-    zi = -G%bathyT(i,j)
+    zi = -depth_tot(i,j)
     x = G%geoLonT(i,j) - (G%west_lon + 0.5*G%len_lon) ! Relative to center of domain
     xd = x / G%len_lon ! -1/2 < xd 1/2
     y = G%geoLatT(i,j) - (G%south_lat + 0.5*G%len_lat) ! Relative to center of domain

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -82,13 +82,15 @@ end subroutine benchmark_initialize_topography
 !! by finding the depths of interfaces in a specified latitude-dependent
 !! temperature profile with an exponentially decaying thermocline on top of a
 !! linear stratification.
-subroutine benchmark_initialize_thickness(h, G, GV, US, param_file, eqn_of_state, &
+subroutine benchmark_initialize_thickness(h, depth_tot, G, GV, US, param_file, eqn_of_state, &
                                           P_Ref, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)  :: depth_tot !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   type(EOS_type),          pointer     :: eqn_of_state !< Equation of state structure
@@ -181,7 +183,7 @@ subroutine benchmark_initialize_thickness(h, G, GV, US, param_file, eqn_of_state
     ! are set to insure that: 1. each layer is at least  Gv%Angstrom_m thick, and
     ! 2. the interfaces are where they should be based on the resting depths and interface
     ! height perturbations, as long at this doesn't interfere with 1.
-    eta1D(nz+1) = -G%bathyT(i,j)
+    eta1D(nz+1) = -depth_tot(i,j)
 
     do k=nz,2,-1
       T_int = 0.5*(T0(k) + T0(k-1))

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -28,11 +28,13 @@ public circle_obcs_initialize_thickness
 contains
 
 !> This subroutine initializes layer thicknesses for the circle_obcs experiment.
-subroutine circle_obcs_initialize_thickness(h, G, GV, param_file, just_read_params)
+subroutine circle_obcs_initialize_thickness(h, depth_tot, G, GV, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G   !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV  !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)  :: depth_tot   !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -79,8 +81,8 @@ subroutine circle_obcs_initialize_thickness(h, G, GV, param_file, just_read_para
   enddo
 
   ! Uniform thicknesses for base state
-  do j=js,je ; do i=is,ie                        !
-    eta1D(nz+1) = -G%bathyT(i,j)
+  do j=js,je ; do i=is,ie
+    eta1D(nz+1) = -depth_tot(i,j)
     do k=nz,1,-1
       eta1D(K) = e0(K)
       if (eta1D(K) < (eta1D(K+1) + GV%Angstrom_Z)) then

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -152,11 +152,13 @@ subroutine dense_water_initialize_TS(G, GV, param_file, eqn_of_state, T, S, h, j
 end subroutine dense_water_initialize_TS
 
 !> Initialize the restoring sponges for the dense water experiment
-subroutine dense_water_initialize_sponges(G, GV, US, tv, param_file, use_ALE, CSp, ACSp)
+subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, use_ALE, CSp, ACSp)
   type(ocean_grid_type),   intent(in) :: G !< Horizontal grid control structure
   type(verticalGrid_type), intent(in) :: GV !< Vertical grid control structure
   type(unit_scale_type),   intent(in) :: US !< A dimensional unit scaling type
   type(thermo_var_ptrs),   intent(in) :: tv !< Thermodynamic variables
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in) :: depth_tot  !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in) :: param_file !< Parameter file structure
   logical,                 intent(in) :: use_ALE !< ALE flag
   type(sponge_CS),         pointer    :: CSp !< Layered sponge control structure pointer
@@ -234,7 +236,7 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, param_file, use_ALE, CS
 
     do j = G%jsc,G%jec
       do i = G%isc,G%iec
-        eta1D(nz+1) = -G%bathyT(i,j)
+        eta1D(nz+1) = -depth_tot(i,j)
         do k = nz,1,-1
           eta1D(k) = e0(k)
 

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -77,12 +77,14 @@ end subroutine seamount_initialize_topography
 
 !> Initialization of thicknesses.
 !! This subroutine initializes the layer thicknesses to be uniform.
-subroutine seamount_initialize_thickness ( h, G, GV, US, param_file, just_read_params)
+subroutine seamount_initialize_thickness (h, depth_tot, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)  :: depth_tot  !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -152,7 +154,7 @@ subroutine seamount_initialize_thickness ( h, G, GV, US, param_file, just_read_p
       e0(K) = max(-G%max_depth, e0(K)) ! Bound by bottom
     enddo
     do j=js,je ; do i=is,ie
-      eta1D(nz+1) = -G%bathyT(i,j)
+      eta1D(nz+1) = -depth_tot(i,j)
       do k=nz,1,-1
         eta1D(k) = e0(k)
         if (eta1D(k) < (eta1D(k+1) + GV%Angstrom_Z)) then
@@ -167,7 +169,7 @@ subroutine seamount_initialize_thickness ( h, G, GV, US, param_file, just_read_p
   case ( REGRIDDING_ZSTAR )                       ! Initial thicknesses for z coordinates
     if (just_read) return ! All run-time parameters have been read, so return.
     do j=js,je ; do i=is,ie
-      eta1D(nz+1) = -G%bathyT(i,j)
+      eta1D(nz+1) = -depth_tot(i,j)
       do k=nz,1,-1
         eta1D(k) =  -G%max_depth * real(k-1) / real(nz)
         if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
@@ -182,7 +184,7 @@ subroutine seamount_initialize_thickness ( h, G, GV, US, param_file, just_read_p
   case ( REGRIDDING_SIGMA )             ! Initial thicknesses for sigma coordinates
     if (just_read) return ! All run-time parameters have been read, so return.
     do j=js,je ; do i=is,ie
-      h(i,j,:) = GV%Z_to_H * G%bathyT(i,j) / dfloat(nz)
+      h(i,j,:) = GV%Z_to_H * depth_tot(i,j) / dfloat(nz)
     enddo ; enddo
 
 end select

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -53,12 +53,14 @@ end subroutine sloshing_initialize_topography
 !! same thickness but all interfaces (except bottom and sea surface) are
 !! displaced according to a half-period cosine, with maximum value on the
 !! left and minimum value on the right. This sets off a regular sloshing motion.
-subroutine sloshing_initialize_thickness ( h, G, GV, US, param_file, just_read_params)
+subroutine sloshing_initialize_thickness ( h, depth_tot, G, GV, US, param_file, just_read_params)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)  :: depth_tot  !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -152,7 +154,7 @@ subroutine sloshing_initialize_thickness ( h, G, GV, US, param_file, just_read_p
     enddo
 
     ! 3. The last interface must coincide with the seabed
-    z_inter(nz+1) = -G%bathyT(i,j)
+    z_inter(nz+1) = -depth_tot(i,j)
     ! Modify interface heights to make sure all thicknesses are strictly positive
     do k = nz,1,-1
       if ( z_inter(k) < (z_inter(k+1) + GV%Angstrom_Z) ) then

--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -28,12 +28,14 @@ public soliton_initialize_velocity
 contains
 
 !> Initialization of thicknesses in Equatorial Rossby soliton test
-subroutine soliton_initialize_thickness(h, G, GV, US)
+subroutine soliton_initialize_thickness(h, depth_tot, G, GV, US)
   type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: h    !< The thickness that is being initialized [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)  :: depth_tot !< The nominal total depth of the ocean [Z ~> m]
 
   integer :: i, j, k, is, ie, js, je, nz
   real    :: x, y, x0, y0
@@ -55,7 +57,7 @@ subroutine soliton_initialize_thickness(h, G, GV, US)
       y = G%geoLatT(i,j)-y0
       val3 = exp(-val1*x)
       val4 = val2 * ( 2.0*val3 / (1.0 + (val3*val3)) )**2
-      h(i,j,k) = GV%Z_to_H * (0.25*val4*(6.0*y*y + 3.0) * exp(-0.5*y*y) + G%bathyT(i,j))
+      h(i,j,k) = GV%Z_to_H * (0.25*val4*(6.0*y*y + 3.0) * exp(-0.5*y*y) + depth_tot(i,j))
     enddo
   enddo ; enddo
 

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -247,7 +247,7 @@ end subroutine write_user_log
 !!  - u - Zonal velocity [Z T-1 ~> m s-1].
 !!  - v - Meridional velocity [Z T-1 ~> m s-1].
 !!  - h - Layer thickness [H ~> m or kg m-2].  (Must be positive.)
-!!  - G%bathyT - Basin depth [Z ~> m].  (Must be positive.)
+!!  - G%bathyT - Basin depth [Z ~> m].
 !!  - G%CoriolisBu - The Coriolis parameter [T-1 ~> s-1].
 !!  - GV%g_prime - The reduced gravity at each interface [L2 Z-1 T-2 ~> m s-2].
 !!  - GV%Rlay - Layer potential density (coordinate variable) [R ~> kg m-3].


### PR DESCRIPTION
  This PR makes changes to explicitly pass total ocean depths as arguments to
various initialization routines or routines within MOM_MEKE, rather than relying
on the values of G%bathyT.  This PR builds upon MOM6 PR #1467, and should only
be evaluated once that PR has been dealt with.  All answers and output are
bitwise identical with the changes in this PR.

  The commits in this PR include:

- NOAA-GFDL/MOM6@8a0ae944d +Pass depth_tot around within MOM_MEKE
- NOAA-GFDL/MOM6@3cda6fd68 +Pass depth_tot to initialization routines
