### PR TITLE
Testing: Rotation support for MOM_read_data

### DIFF
--- a/config_src/infra/FMS1/MOM_domain_infra.F90
+++ b/config_src/infra/FMS1/MOM_domain_infra.F90
@@ -156,6 +156,7 @@ type, public :: MOM_domain_type
                                 !! would be contain only land points and are not
                                 !! assigned to actual processors. This need not be
                                 !! assigned if all logical processors are used.
+  integer :: turns              !< Number of quarter-turns from input to this grid.
 end type MOM_domain_type
 
 integer, parameter :: To_All = To_East + To_West + To_North + To_South !< A flag for passing in all directions
@@ -1396,6 +1397,9 @@ subroutine create_MOM_domain(MOM_dom, n_global, n_halo, reentrant, tripolar_N, l
     mask_table_exists = .false.
   endif
 
+  ! Initialize as an unrotated domain
+  MOM_dom%turns = 0
+
   call clone_MD_to_d2D(MOM_dom, MOM_dom%mpp_domain)
 
   !For downsampled domain, recommend a halo of 1 (or 0?) since we're not doing wide-stencil computations.
@@ -1531,6 +1535,7 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
   MOM_dom%symmetric = MD_in%symmetric
   MOM_dom%nonblocking_updates = MD_in%nonblocking_updates
   MOM_dom%thin_halo_updates = MD_in%thin_halo_updates
+  MOM_dom%turns = qturns
 
   if (modulo(qturns, 2) /= 0) then
     MOM_dom%niglobal = MD_in%njglobal ; MOM_dom%njglobal = MD_in%niglobal
@@ -1620,7 +1625,6 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
   endif
 
   call clone_MD_to_d2D(MOM_dom, MOM_dom%mpp_domain, xextent=exni, yextent=exnj)
-
   call clone_MD_to_d2D(MOM_dom, MOM_dom%mpp_domain_d2, domain_name=MOM_dom%name, coarsen=2)
 
 end subroutine clone_MD_to_MD

--- a/config_src/infra/FMS2/MOM_domain_infra.F90
+++ b/config_src/infra/FMS2/MOM_domain_infra.F90
@@ -156,6 +156,7 @@ type, public :: MOM_domain_type
                                 !! would be contain only land points and are not
                                 !! assigned to actual processors. This need not be
                                 !! assigned if all logical processors are used.
+  integer :: turns              !< Number of quarter-turns from input to this grid.
 end type MOM_domain_type
 
 integer, parameter :: To_All = To_East + To_West + To_North + To_South !< A flag for passing in all directions
@@ -1396,6 +1397,9 @@ subroutine create_MOM_domain(MOM_dom, n_global, n_halo, reentrant, tripolar_N, l
     mask_table_exists = .false.
   endif
 
+  ! Initialize as an unrotated domain
+  MOM_dom%turns = 0
+
   call clone_MD_to_d2D(MOM_dom, MOM_dom%mpp_domain)
 
   !For downsampled domain, recommend a halo of 1 (or 0?) since we're not doing wide-stencil computations.
@@ -1403,7 +1407,6 @@ subroutine create_MOM_domain(MOM_dom, n_global, n_halo, reentrant, tripolar_N, l
   !error: downsample_diag_indices_get: peculiar size 28 in i-direction\ndoes not match one of 24 25 26 27
   ! call clone_MD_to_d2D(MOM_dom, MOM_dom%mpp_domain_d2, halo_size=(MOM_dom%nihalo/2), coarsen=2)
   call clone_MD_to_d2D(MOM_dom, MOM_dom%mpp_domain_d2, coarsen=2)
-
 end subroutine create_MOM_domain
 
 !> dealloc_MOM_domain deallocates memory associated with a pointer to a MOM_domain_type

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -333,7 +333,8 @@ subroutine set_grid_metrics_from_mosaic(G, param_file, US)
   start(2) = 2 ; nread(1) = ni+1 ; nread(2) = 2
   allocate( tmpGlbl(ni+1,2) )
   if (is_root_PE()) &
-    call MOM_read_data(filename, "x", tmpGlbl, start, nread, no_domain=.TRUE.)
+    call MOM_read_data(filename, "x", tmpGlbl, start, nread, &
+        no_domain=.TRUE., turns=G%HI%turns)
   call broadcast(tmpGlbl, 2*(ni+1), root_PE())
 
   ! I don't know why the second axis is 1 or 2 here. -RWH
@@ -351,7 +352,8 @@ subroutine set_grid_metrics_from_mosaic(G, param_file, US)
   start(:) = 1 ; nread(:) = 1
   start(1) = int(ni/4)+1 ; nread(2) = nj+1
   if (is_root_PE()) &
-    call MOM_read_data(filename, "y", tmpGlbl, start, nread, no_domain=.TRUE.)
+    call MOM_read_data(filename, "y", tmpGlbl, start, nread, &
+        no_domain=.TRUE., turns=G%HI%turns)
   call broadcast(tmpGlbl, nj+1, root_PE())
 
   do j=G%jsg,G%jeg


### PR DESCRIPTION
This patch adds an interface and several implementations of
`MOM_read_data` and `MOM_read_vector` functions which support rotational
testing.

The MOM_domain_type now carries a scalar, `turns`, indicating the number
of quarter-turns from the input grid to the model grid.  If this number
is nonzero, then a field is read into an array based on the input grid
and rotates the field to a new array based on the model grid.  This
final result is returned by the function.

If the domain's `turns` is zero, then it is assumed to be a call from a
non-rotated domain and no rotation is applied.  Functions outside of MOM
(such as calls within drivers) do not apply this rotation.

For the "domain-less" reads of 2d arrays, an explicit `turns` argument
is supported.  This only appears to be necessary in one part of grid
initialization.

This is now the third place where `turns` is tracked: the first is HI
(horizontal index tracking) of the MOM grid, the second in `restart_CS`,
and now in `MOM_Domain`.  However, I believe this is a reasonable place
to track the domains while also avoiding a need for
users to explicitly rotate fields every time `read_data` is called.