### PR TITLE
(*) N2_floor init fix when FGNV streamfn disabled

### DIFF
--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1995,6 +1995,7 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
   call get_param(param_file, mdl, "OMEGA", omega, &
                  "The rotation rate of the earth.", &
                  default=7.2921e-5, units="s-1", scale=US%T_to_s, do_not_log=.not.CS%use_FGNV_streamfn)
+  CS%N2_floor = 0.
   if (CS%use_FGNV_streamfn) CS%N2_floor = (strat_floor*omega)**2
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &


### PR DESCRIPTION
The `N2_floor` buoyancy frequency was left unset when
`KHTH_USE_FGNV_STREAMFUNCTION` was disabled.  This could potentially
cause errors, such as floating point exceptions.

Ideally we would restrict the calculations of `hN2_[uv]` to when the
streamfunction is enabled.  But due to propagation to these values to
`hN2_[xy]_PE` fields, which may be used outside of the streamfunction,
it is perhaps best to just initialize `N2_floor` to zero.

Although this would mostly likely be initialized to zero in production,
there is a chance that this could modify answers derived from random
initialization.

Thanks to @wfcooke for reporting this.  It was also independently (and
inexplicably) detected during removal of MEKE pointers, suggesting some
memory volatility.