### PR TITLE
+*Change defaults for 4 parameters to better values

### DIFF
--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1644,7 +1644,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
                  units="m s-1", default=0.0, scale=US%m_s_to_L_T)
   call get_param(param_file, mdl, "INTERNAL_WAVE_SPEED_BETTER_EST", better_speed_est, &
                  "If true, use a more robust estimate of the first mode wave speed as the "//&
-                 "starting point for iterations.", default=.false.) !### Change the default.
+                 "starting point for iterations.", default=.true.)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=.false.)

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -68,7 +68,6 @@ subroutine find_obsolete_params(param_file)
                      hint="Use NUM_DIAG_COORDS, DIAG_COORDS and DIAG_COORD_DEF_Z")
 
   call obsolete_real(param_file, "VSTAR_SCALE_FACTOR", hint="Use EPBL_VEL_SCALE_FACTOR instead.")
-  call obsolete_logical(param_file, "ORIG_MLD_ITERATION", .false.)
 
   call obsolete_real(param_file, "VSTAR_SCALE_COEF")
   call obsolete_real(param_file, "ZSTAR_RIGID_SURFACE_THRESHOLD")
@@ -88,6 +87,7 @@ subroutine find_obsolete_params(param_file)
   call obsolete_logical(param_file, "MSTAR_FIXED", hint="Instead use MSTAR_MODE.")
   call obsolete_logical(param_file, "USE_VISBECK_SLOPE_BUG", .false.)
 
+  call obsolete_logical(param_file, "LARGE_FILE_SUPPORT", .true.)
   call obsolete_real(param_file, "MIN_Z_DIAG_INTERVAL")
   call obsolete_char(param_file, "Z_OUTPUT_GRID_FILE")
 

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -75,8 +75,6 @@ type, public :: MOM_restart_CS ; private
   integer :: num_obsolete_vars = 0  !< The number of obsolete restart fields that have been registered.
   logical :: parallel_restartfiles  !< If true, each PE writes its own restart file,
                                     !! otherwise they are combined internally.
-  logical :: large_file_support     !< If true, NetCDF 3.6 or later is being used
-                                    !! and large-file-support is enabled.
   logical :: new_run                !< If true, the input filenames and restart file existence will
                                     !! result in a new run that is not initialized from restart files.
   logical :: new_run_set = .false.  !< If true, new_run has been determined for this restart_CS.
@@ -885,9 +883,10 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
                                         ! to the name of files after the first.
   integer(kind=8) :: var_sz, size_in_file ! The size in bytes of each variable
                                         ! and the variables already in a file.
-  integer(kind=8) :: max_file_size = 2147483647_8 ! The maximum size in bytes
-                                        ! for any one file.  With NetCDF3,
-                                        ! this should be 2 Gb or less.
+  integer(kind=8), parameter :: max_file_size = 4294967292_8 ! The maximum size in bytes for the
+                                        ! starting position of each variable in a file's record,
+                                        ! based on the use of NetCDF 3.6 or later.  For earlier
+                                        ! versions of NetCDF, the value was 2147483647_8.
   integer :: start_var, next_var        ! The starting variables of the
                                         ! current and next files.
   type(file_type) :: IO_handle          ! The I/O handle of the open fileset
@@ -910,10 +909,6 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
   if (CS%novars > CS%max_fields) call restart_error(CS)
 
   ! With parallel read & write, it is possible to disable the following...
-
-  ! The maximum file size is 4294967292, according to the NetCDF documentation.
-  if (CS%large_file_support) max_file_size = 4294967292_8
-
   num_files = 0
   next_var = 0
   nz = 1 ; if (present(GV)) nz = GV%ke
@@ -1540,14 +1535,12 @@ subroutine restart_init(param_file, CS, restart_root)
 
   ! Determine whether all paramters are set to their default values.
   call get_param(param_file, mdl, "PARALLEL_RESTARTFILES", CS%parallel_restartfiles, &
-                 default=.false., do_not_log=.true.)
-  call get_param(param_file, mdl, "LARGE_FILE_SUPPORT", CS%large_file_support, &
                  default=.true., do_not_log=.true.)
   call get_param(param_file, mdl, "MAX_FIELDS", CS%max_fields, default=100, do_not_log=.true.)
   call get_param(param_file, mdl, "RESTART_CHECKSUMS_REQUIRED", CS%checksum_required, &
                  default=.true., do_not_log=.true.)
-  all_default = ((.not.CS%parallel_restartfiles) .and. (CS%large_file_support) .and. &
-                 (CS%max_fields == 100) .and. (CS%checksum_required))
+  all_default = ((CS%parallel_restartfiles) .and. (CS%max_fields == 100) .and. &
+                 (CS%checksum_required))
   if (.not.present(restart_root)) then
     call get_param(param_file, mdl, "RESTARTFILE", CS%restartfile, &
                    default="MOM.res", do_not_log=.true.)
@@ -1557,9 +1550,10 @@ subroutine restart_init(param_file, CS, restart_root)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "", all_default=all_default)
   call get_param(param_file, mdl, "PARALLEL_RESTARTFILES", CS%parallel_restartfiles, &
-                 "If true, each processor writes its own restart file, "//&
-                 "otherwise a single restart file is generated", &
-                 default=.false.)
+                 "If true, the IO layout is used to group processors that write to the same "//&
+                 "restart file or each processor writes its own (numbered) restart file. "//&
+                 "If false, a single restart file is generated combining output from all PEs.", &
+                 default=.true.)
 
   if (present(restart_root)) then
     CS%restartfile = restart_root
@@ -1568,10 +1562,6 @@ subroutine restart_init(param_file, CS, restart_root)
     call get_param(param_file, mdl, "RESTARTFILE", CS%restartfile, &
                  "The name-root of the restart file.", default="MOM.res")
   endif
-  call get_param(param_file, mdl, "LARGE_FILE_SUPPORT", CS%large_file_support, &
-                 "If true, use the file-size limits with NetCDF large "//&
-                 "file support (4Gb), otherwise the limit is 2Gb.", &
-                 default=.true.)
   call get_param(param_file, mdl, "MAX_FIELDS", CS%max_fields, &
                  "The maximum number of restart fields that can be used.", &
                  default=100)

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1535,7 +1535,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  units="m s-1", default=0.0, scale=US%m_s_to_L_T)
     call get_param(param_file, mdl, "INTERNAL_WAVE_SPEED_BETTER_EST", better_speed_est, &
                  "If true, use a more robust estimate of the first mode wave speed as the "//&
-                 "starting point for iterations.", default=.false.) !### Change the default.
+                 "starting point for iterations.", default=.true.)
     call wave_speed_init(CS%wave_speed_CSp, use_ebt_mode=CS%Resoln_use_ebt, &
                          mono_N2_depth=N2_filter_depth, remap_answers_2018=remap_answers_2018, &
                          better_speed_est=better_speed_est, min_speed=wave_speed_min, &

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -2181,7 +2181,7 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
                  "If true, use bisection with the iterative determination of the self-consistent "//&
                  "mixed layer depth.  Otherwise use the false position after a maximum and minimum "//&
                  "bound have been evaluated and the returned value or bisection before this.", &
-                 default=.true., do_not_log=.not.CS%Use_MLD_iteration) !### The default should become false.
+                 default=.false., do_not_log=.not.CS%Use_MLD_iteration)
   call get_param(param_file, mdl, "EPBL_MLD_MAX_ITS", CS%max_MLD_its, &
                  "The maximum number of iterations that can be used to find a self-consistent "//&
                  "mixed layer depth.  If EPBL_MLD_BISECTION is true, the maximum number "//&


### PR DESCRIPTION
  Updated the defaults of 4 run-time parameters (INTERNAL_WAVE_SPEED_BETTER_EST,
PARALLEL_RESTARTFILES, EPBL_MLD_BISECTION, and BBL_USE_EOS) to more appropriate
values.  In each case, the previous default was simply the older setting, and
not the better recommendation.  It also adds logic determining whether
SIMPLE_TKE_TO_KD does anything, and only log its setting if it does.  These
default changes were discussed by the MOM6 consortium as a whole in June, 2021
and were widely agreed to. In addition this commit removes the old obsoleted
runtime parameter ORIG_MLD_ITERATION, and obsoletes the runtime parameter
LARGE_FILE_SUPPORT, and it adds comments describing several real variables and
their units.  Because this changes several default values, it will change
answers unless these parameters are explicitly set in the MOM_input files.
However, because MOM6-examples PR #344 does set these values to their old
defaults where they are used, no answers are changed in the MOM6-examples
regression suite, although there are changes to the MOM_parameter_doc files.