### PR TITLE
+Argument cleanup in vertical diffusivity code

### DIFF
--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -840,7 +840,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
   real,                      intent(in)    :: dt !< The amount of time covered by this call [T ~> s].
   type(ALE_sponge_CS),       pointer       :: CS !< A pointer to the control structure for this module
                                                  !! that is set by a previous call to initialize_ALE_sponge (in).
-  type(time_type), optional, intent(in)    :: Time !< The current model date
+  type(time_type),           intent(in)    :: Time !< The current model date
 
   real :: damp                                  ! The timestep times the local damping coefficient [nondim].
   real :: I1pdamp                               ! I1pdamp is 1/(1 + damp). [nondim].
@@ -885,8 +885,6 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
   endif
 
   if (CS%time_varying_sponges) then
-    if (.not. present(Time)) &
-      call MOM_error(FATAL,"apply_ALE_sponge: No time information provided")
     do m=1,CS%fldno
       nz_data = CS%Ref_val(m)%nz_data
       call horiz_interp_and_extrap_tracer(CS%Ref_val(m)%id, Time, 1.0, G, sp_val, mask_z, z_in, &
@@ -971,9 +969,6 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
   if (CS%sponge_uv) then
 
     if (CS%time_varying_sponges) then
-      if (.not. present(Time)) &
-         call MOM_error(FATAL,"apply_ALE_sponge: No time information provided")
-
       nz_data = CS%Ref_val_u%nz_data
       ! Interpolate from the external horizontal grid and in time
       call horiz_interp_and_extrap_tracer(CS%Ref_val_u%id, Time, 1.0, G, sp_val, mask_z, z_in, &

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1389,8 +1389,8 @@ subroutine KPP_NonLocalTransport_temp(CS, G, GV, h, nonLocalTrans, surfFlux, &
   type(verticalGrid_type),                    intent(in)    :: GV     !< Ocean vertical grid
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h      !< Layer/level thickness [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)   :: nonLocalTrans !< Non-local transport [nondim]
-  real, dimension(SZI_(G),SZJ_(G)),           intent(in)    :: surfFlux  !< Surface flux of scalar
-                                                                      !! [conc H s-1 ~> conc m s-1 or conc kg m-2 s-1]
+  real, dimension(SZI_(G),SZJ_(G)),           intent(in)    :: surfFlux  !< Surface flux of temperature
+                                                                      !! [degC H s-1 ~> degC m s-1 or degC kg m-2 s-1]
   real,                                       intent(in)    :: dt     !< Time-step [s]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(inout) :: scalar !< temperature
   real,                                       intent(in)    :: C_p    !< Seawater specific heat capacity [J kg-1 degC-1]
@@ -1451,8 +1451,8 @@ subroutine KPP_NonLocalTransport_saln(CS, G, GV, h, nonLocalTrans, surfFlux, dt,
   type(verticalGrid_type),                    intent(in)    :: GV            !< Ocean vertical grid
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)    :: h             !< Layer/level thickness [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)   :: nonLocalTrans !< Non-local transport [nondim]
-  real, dimension(SZI_(G),SZJ_(G)),           intent(in)    :: surfFlux      !< Surface flux of scalar
-                                                                        !! [conc H s-1 ~> conc m s-1 or conc kg m-2 s-1]
+  real, dimension(SZI_(G),SZJ_(G)),           intent(in)    :: surfFlux      !< Surface flux of salt
+                                                                           !! [ppt H s-1 ~> ppt m s-1 or ppt kg m-2 s-1]
   real,                                       intent(in)    :: dt            !< Time-step [s]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(inout) :: scalar        !< Scalar (scalar units [conc])
 

--- a/src/parameterizations/vertical/MOM_CVMix_conv.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_conv.F90
@@ -150,10 +150,10 @@ subroutine calculate_CVMix_conv(h, tv, G, GV, US, CS, hbl, Kd, Kv, Kd_aux)
                                                                 !! by a previous call to CVMix_conv_init.
   real, dimension(SZI_(G),SZJ_(G)),          intent(in)  :: hbl !< Depth of ocean boundary layer [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
-                                   optional, intent(inout) :: Kd !< Diapycnal diffusivity at each interface that
+                                             intent(inout) :: Kd !< Diapycnal diffusivity at each interface that
                                                                  !! will be incremented here [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
-                                   optional, intent(inout) :: KV !< Viscosity at each interface that will be
+                                             intent(inout) :: KV !< Viscosity at each interface that will be
                                                                  !! incremented here [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
                                    optional, intent(inout) :: Kd_aux !< A second diapycnal diffusivity at each
@@ -243,12 +243,10 @@ subroutine calculate_CVMix_conv(h, tv, G, GV, US, CS, hbl, Kd, Kv, Kd_aux)
                              max_nlev=GV%ke, &
                              OBL_ind=kOBL)
 
-      if (present(Kd)) then
-        ! Increment the diffusivity outside of the boundary layer.
-        do K=max(1,kOBL+1),GV%ke+1
-          Kd(i,j,K) = Kd(i,j,K) + US%m2_s_to_Z2_T * kd_col(K)
-        enddo
-      endif
+      ! Increment the diffusivity outside of the boundary layer.
+      do K=max(1,kOBL+1),GV%ke+1
+        Kd(i,j,K) = Kd(i,j,K) + US%m2_s_to_Z2_T * kd_col(K)
+      enddo
       if (present(Kd_aux)) then
         ! Increment the other diffusivity outside of the boundary layer.
         do K=max(1,kOBL+1),GV%ke+1
@@ -256,12 +254,10 @@ subroutine calculate_CVMix_conv(h, tv, G, GV, US, CS, hbl, Kd, Kv, Kd_aux)
         enddo
       endif
 
-      if (present(Kv)) then
-        ! Increment the viscosity outside of the boundary layer.
-        do K=max(1,kOBL+1),GV%ke+1
-          Kv(i,j,K) = Kv(i,j,K) + US%m2_s_to_Z2_T * kv_col(K)
-        enddo
-      endif
+      ! Increment the viscosity outside of the boundary layer.
+      do K=max(1,kOBL+1),GV%ke+1
+        Kv(i,j,K) = Kv(i,j,K) + US%m2_s_to_Z2_T * kv_col(K)
+      enddo
 
       ! Store 3-d arrays for diagnostics.
       if (CS%id_kv_conv > 0) then
@@ -288,8 +284,8 @@ subroutine calculate_CVMix_conv(h, tv, G, GV, US, CS, hbl, Kd, Kv, Kd_aux)
     !   call hchksum(Kd_conv, "MOM_CVMix_conv: Kd_conv", G%HI, haloshift=0, scale=US%Z2_T_to_m2_s)
     ! if (CS%id_kv_conv > 0) &
     !   call hchksum(Kv_conv, "MOM_CVMix_conv: Kv_conv", G%HI, haloshift=0, scale=US%m2_s_to_Z2_T)
-    if (present(Kd)) call hchksum(Kd, "MOM_CVMix_conv: Kd", G%HI, haloshift=0, scale=US%Z2_T_to_m2_s)
-    if (present(Kv)) call hchksum(Kv, "MOM_CVMix_conv: Kv", G%HI, haloshift=0, scale=US%Z2_T_to_m2_s)
+    call hchksum(Kd, "MOM_CVMix_conv: Kd", G%HI, haloshift=0, scale=US%Z2_T_to_m2_s)
+    call hchksum(Kv, "MOM_CVMix_conv: Kv", G%HI, haloshift=0, scale=US%Z2_T_to_m2_s)
   endif
 
   ! send diagnostics to post_data

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -318,7 +318,7 @@ end subroutine differential_diffuse_T_S
 !> This subroutine keeps salinity from falling below a small but positive threshold.
 !! This usually occurs when the ice model attempts to extract more salt then
 !! is actually available to it from the ocean.
-subroutine adjust_salt(h, tv, G, GV, CS, halo)
+subroutine adjust_salt(h, tv, G, GV, CS)
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
@@ -327,7 +327,6 @@ subroutine adjust_salt(h, tv, G, GV, CS, halo)
                                                  !! available thermodynamic fields.
   type(diabatic_aux_CS),   intent(in)    :: CS   !< The control structure returned by a previous
                                                  !! call to diabatic_aux_init.
-  integer,       optional, intent(in)    :: halo !< Halo width over which to work
 
   ! local variables
   real :: salt_add_col(SZI_(G),SZJ_(G)) !< The accumulated salt requirement [ppt R Z ~> gSalt m-2]
@@ -336,9 +335,6 @@ subroutine adjust_salt(h, tv, G, GV, CS, halo)
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-  if (present(halo)) then
-    is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
-  endif
 
 !  call cpu_clock_begin(id_clock_adjust_salt)
 
@@ -1024,7 +1020,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
                  optional, intent(out)   :: dSV_dS !< Partial derivative of specific volume with
                                                !! salinity [R-1 ppt-1 ~> m3 kg-1 ppt-1].
   real, dimension(SZI_(G),SZJ_(G)), &
-                   optional, intent(out) :: SkinBuoyFlux !< Buoyancy flux at surface [Z2 T-3 ~> m2 s-3].
+                 optional, intent(out)   :: SkinBuoyFlux !< Buoyancy flux at surface [Z2 T-3 ~> m2 s-3].
 
   ! Local variables
   integer, parameter :: maxGroundings = 5

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -87,9 +87,9 @@ public adiabatic_driver_init
 ! vary with the Boussinesq approximation, the Boussinesq variant is given first.
 
 !> Control structure for this module
-type, public:: diabatic_CS; private
+type, public :: diabatic_CS ; private
 
-  logical :: use_legacy_diabatic     !< If true (default), use the a legacy version of the diabatic
+  logical :: use_legacy_diabatic     !< If true (default), use a legacy version of the diabatic
                                      !! algorithm. This is temporary and is needed to avoid change
                                      !! in answers.
   logical :: bulkmixedlayer          !< If true, a refined bulk mixed layer is used with
@@ -242,11 +242,14 @@ type, public:: diabatic_CS; private
   type(group_pass_type) :: pass_Kv         !< For group halo pass
   type(diag_grid_storage) :: diag_grids_prev!< Stores diagnostic grids at some previous point in the algorithm
   ! Data arrays for communicating between components
-  real, allocatable, dimension(:,:,:) :: KPP_NLTheat    !< KPP non-local transport for heat [m s-1]
-  real, allocatable, dimension(:,:,:) :: KPP_NLTscalar  !< KPP non-local transport for scalars [m s-1]
+  !### Why are these arrays in this control structure, and not local variables in the various routines?
+  real, allocatable, dimension(:,:,:) :: KPP_NLTheat    !< KPP non-local transport for heat [nondim]
+  real, allocatable, dimension(:,:,:) :: KPP_NLTscalar  !< KPP non-local transport for scalars [nondim]
   real, allocatable, dimension(:,:,:) :: KPP_buoy_flux  !< KPP forcing buoyancy flux [L2 T-3 ~> m2 s-3]
-  real, allocatable, dimension(:,:)   :: KPP_temp_flux  !< KPP effective temperature flux [degC m s-1]
-  real, allocatable, dimension(:,:)   :: KPP_salt_flux  !< KPP effective salt flux [ppt m s-1]
+  real, allocatable, dimension(:,:)   :: KPP_temp_flux  !< KPP effective temperature flux
+                                                        !! [degC H s-1 ~> degC m s-1 or degC kg m-2 s-1]
+  real, allocatable, dimension(:,:)   :: KPP_salt_flux  !< KPP effective salt flux
+                                                        !! [ppt H s-1 ~> ppt m s-1 or ppt kg m-2 s-1]
 
   type(time_type), pointer :: Time !< Pointer to model time (needed for sponges)
 end type diabatic_CS
@@ -274,8 +277,9 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   real, dimension(:,:),                       pointer       :: Hml      !< Active mixed layer depth [Z ~> m]
   type(forcing),                              intent(inout) :: fluxes   !< points to forcing fields
                                                                         !! unused fields have NULL ptrs
-  type(vertvisc_type),                        intent(inout) :: visc     !< vertical viscosities, BBL properies, and
-  type(accel_diag_ptrs),                      intent(inout) :: ADp      !< related points to accelerations in momentum
+  type(vertvisc_type),                        intent(inout) :: visc     !< Structure with vertical viscosities,
+                                                                        !! BBL properties and related fields
+  type(accel_diag_ptrs),                      intent(inout) :: ADp      !< Points to accelerations in momentum
                                                                         !! equations, to enable the later derived
                                                                         !! diagnostics, like energy budgets
   type(cont_diag_ptrs),                       intent(inout) :: CDp      !< points to terms in continuity equations
@@ -465,8 +469,9 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
   real, dimension(:,:),                       pointer       :: Hml      !< Active mixed layer depth [Z ~> m]
   type(forcing),                              intent(inout) :: fluxes   !< points to forcing fields
                                                                         !! unused fields have NULL ptrs
-  type(vertvisc_type),                        intent(inout) :: visc     !< vertical viscosities, BBL properies, and
-  type(accel_diag_ptrs),                      intent(inout) :: ADp      !< related points to accelerations in momentum
+  type(vertvisc_type),                        intent(inout) :: visc     !< Structure with vertical viscosities,
+                                                                        !! BBL properties and related fields
+  type(accel_diag_ptrs),                      intent(inout) :: ADp      !< Points to accelerations in momentum
                                                                         !! equations, to enable the later derived
                                                                         !! diagnostics, like energy budgets
   type(cont_diag_ptrs),                       intent(inout) :: CDp      !< points to terms in continuity equations
@@ -577,11 +582,11 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
   if (CS%debug) &
     call MOM_state_chksum("before set_diffusivity", u, v, h, G, GV, US, haloshift=CS%halo_TS_diff)
   if (CS%double_diffuse) then
-    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, CS%set_diff_CSp, &
-                         Kd_int=Kd_int, Kd_extra_T=Kd_extra_T, Kd_extra_S=Kd_extra_S)
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, Kd_int, G, GV, US, &
+                         CS%set_diff_CSp, Kd_extra_T=Kd_extra_T, Kd_extra_S=Kd_extra_S)
   else
-    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, &
-                         CS%set_diff_CSp, Kd_int=Kd_int)
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, Kd_int, G, GV, US, &
+                         CS%set_diff_CSp)
   endif
   call cpu_clock_end(id_clock_set_diffusivity)
   if (showCallTree) call callTree_waypoint("done with set_diffusivity (diabatic)")
@@ -718,7 +723,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
   ! Calculate vertical mixing due to convection (computed via CVMix)
   if (CS%use_CVMix_conv) then
     ! Increment vertical diffusion and viscosity due to convection
-    call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_CSp, Hml, Kd=Kd_int, Kv=visc%Kv_slow)
+    call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_CSp, Hml, Kd_int, visc%Kv_slow)
   endif
 
   ! This block sets ent_t and ent_s from h and Kd_int.
@@ -1049,8 +1054,9 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
   real, dimension(:,:),                       pointer       :: Hml      !< Active mixed layer depth [Z ~> m]
   type(forcing),                              intent(inout) :: fluxes   !< points to forcing fields
                                                                         !! unused fields have NULL ptrs
-  type(vertvisc_type),                        intent(inout) :: visc     !< vertical viscosities, BBL properies, and
-  type(accel_diag_ptrs),                      intent(inout) :: ADp      !< related points to accelerations in momentum
+  type(vertvisc_type),                        intent(inout) :: visc     !< Structure with vertical viscosities,
+                                                                        !! BBL properties and related fields
+  type(accel_diag_ptrs),                      intent(inout) :: ADp      !< Points to accelerations in momentum
                                                                         !! equations, to enable the later derived
                                                                         !! diagnostics, like energy budgets
   type(cont_diag_ptrs),                       intent(inout) :: CDp      !< points to terms in continuity equations
@@ -1161,11 +1167,11 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
   if (CS%debug) &
     call MOM_state_chksum("before set_diffusivity", u, v, h, G, GV, US, haloshift=CS%halo_TS_diff)
   if (CS%double_diffuse) then
-    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, CS%set_diff_CSp, &
-                         Kd_int=Kd_heat, Kd_extra_T=Kd_extra_T, Kd_extra_S=Kd_extra_S)
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, Kd_heat, G, GV, US, &
+                         CS%set_diff_CSp, Kd_extra_T=Kd_extra_T, Kd_extra_S=Kd_extra_S)
   else
-    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, &
-                         CS%set_diff_CSp, Kd_int=Kd_heat)
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, Kd_heat, G, GV, US, &
+                         CS%set_diff_CSp)
   endif
   call cpu_clock_end(id_clock_set_diffusivity)
   if (showCallTree) call callTree_waypoint("done with set_diffusivity (diabatic)")
@@ -1270,9 +1276,9 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
   if (CS%use_CVMix_conv) then
     ! Increment vertical diffusion and viscosity due to convection
     if (CS%useKPP) then
-      call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_CSp, Hml, Kd=Kd_heat, Kv=visc%Kv_shear, Kd_aux=Kd_salt)
+      call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_CSp, Hml, Kd_heat, visc%Kv_shear, Kd_aux=Kd_salt)
     else
-      call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_CSp, Hml, Kd=Kd_heat, Kv=visc%Kv_slow, Kd_aux=Kd_salt)
+      call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_CSp, Hml, Kd_heat, visc%Kv_slow, Kd_aux=Kd_salt)
     endif
   endif
 
@@ -1558,8 +1564,9 @@ subroutine layered_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_e
   real, dimension(:,:),                       pointer       :: Hml      !< Active mixed layer depth [Z ~> m]
   type(forcing),                              intent(inout) :: fluxes   !< points to forcing fields
                                                                         !! unused fields have NULL ptrs
-  type(vertvisc_type),                        intent(inout) :: visc     !< vertical viscosities, BBL properies, and
-  type(accel_diag_ptrs),                      intent(inout) :: ADp      !< related points to accelerations in momentum
+  type(vertvisc_type),                        intent(inout) :: visc     !< Structure with vertical viscosities,
+                                                                        !! BBL properties and related fields
+  type(accel_diag_ptrs),                      intent(inout) :: ADp      !< Points to accelerations in momentum
                                                                         !! equations, to enable the later derived
                                                                         !! diagnostics, like energy budgets
   type(cont_diag_ptrs),                       intent(inout) :: CDp      !< points to terms in continuity equations
@@ -1764,11 +1771,11 @@ subroutine layered_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_e
   if (CS%debug) &
     call MOM_state_chksum("before set_diffusivity", u, v, h, G, GV, US, haloshift=CS%halo_TS_diff)
   if (CS%double_diffuse) then
-    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, CS%set_diff_CSp, &
-                         Kd_lay=Kd_lay, Kd_int=Kd_int, Kd_extra_T=Kd_extra_T, Kd_extra_S=Kd_extra_S)
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, Kd_int, G, GV, US, &
+                         CS%set_diff_CSp, Kd_lay=Kd_lay, Kd_extra_T=Kd_extra_T, Kd_extra_S=Kd_extra_S)
   else
-    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, US, &
-                         CS%set_diff_CSp, Kd_lay=Kd_lay, Kd_int=Kd_int)
+    call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, Kd_int, G, GV, US, &
+                         CS%set_diff_CSp, Kd_lay=Kd_lay)
   endif
   call cpu_clock_end(id_clock_set_diffusivity)
   if (showCallTree) call callTree_waypoint("done with set_diffusivity (diabatic)")
@@ -1859,7 +1866,7 @@ subroutine layered_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_e
 
   ! Add vertical diff./visc. due to convection (computed via CVMix)
   if (CS%use_CVMix_conv) then
-    call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_CSp, Hml, Kd=Kd_int, Kv=visc%Kv_slow)
+    call calculate_CVMix_conv(h, tv, G, GV, US, CS%CVMix_conv_CSp, Hml, Kd_int, visc%Kv_slow)
   endif
 
   if (CS%useKPP) then
@@ -3194,7 +3201,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
        cmor_standard_name='ocean_vertical_heat_diffusivity',                       &
        cmor_long_name='Ocean vertical heat diffusivity')
   CS%id_Kd_salt = register_diag_field('ocean_model', 'Kd_salt', diag%axesTi, Time, &
-      'Total diapycnal diffusivity for salt at interfaces', 'm2 s-1',  conversion=US%Z2_T_to_m2_s, &
+      'Total diapycnal diffusivity for salt at interfaces', 'm2 s-1', conversion=US%Z2_T_to_m2_s, &
        cmor_field_name='difvso',                                                   &
        cmor_standard_name='ocean_vertical_salt_diffusivity',                       &
        cmor_long_name='Ocean vertical salt diffusivity')
@@ -3205,8 +3212,6 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   if (CS%useKPP) then
     allocate(CS%KPP_NLTheat(isd:ied,jsd:jed,nz+1), source=0.0)
     allocate(CS%KPP_NLTscalar(isd:ied,jsd:jed,nz+1), source=0.0)
-  endif
-  if (CS%useKPP) then
     allocate(CS%KPP_buoy_flux(isd:ied,jsd:jed,nz+1), source=0.0)
     allocate(CS%KPP_temp_flux(isd:ied,jsd:jed), source=0.0)
     allocate(CS%KPP_salt_flux(isd:ied,jsd:jed), source=0.0)

--- a/src/parameterizations/vertical/MOM_full_convection.F90
+++ b/src/parameterizations/vertical/MOM_full_convection.F90
@@ -18,8 +18,7 @@ public full_convection
 contains
 
 !> Calculate new temperatures and salinities that have been subject to full convective mixing.
-subroutine full_convection(G, GV, US, h, tv, T_adj, S_adj, p_surf, Kddt_smooth, &
-                           Kddt_convect, halo)
+subroutine full_convection(G, GV, US, h, tv, T_adj, S_adj, p_surf, Kddt_smooth, halo)
   type(ocean_grid_type),   intent(in)    :: G     !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV    !< The ocean's vertical grid structure
   type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
@@ -34,9 +33,7 @@ subroutine full_convection(G, GV, US, h, tv, T_adj, S_adj, p_surf, Kddt_smooth, 
   real, dimension(:,:),    pointer       :: p_surf !< The pressure at the ocean surface [R L2 T-2 ~> Pa] (or NULL).
   real,                    intent(in)    :: Kddt_smooth  !< A smoothing vertical
                                                   !! diffusivity times a timestep [H2 ~> m2 or kg2 m-4].
-  real,          optional, intent(in)    :: Kddt_convect !< A large convecting vertical
-                                                  !! diffusivity times a timestep [H2 ~> m2 or kg2 m-4].
-  integer,       optional, intent(in)    :: halo  !< Halo width over which to compute
+  integer,                 intent(in)    :: halo  !< Halo width over which to compute
 
   ! Local variables
   real, dimension(SZI_(G),SZK_(GV)+1) :: &
@@ -46,61 +43,53 @@ subroutine full_convection(G, GV, US, h, tv, T_adj, S_adj, p_surf, Kddt_smooth, 
                         ! in roundoff and can be neglected [H ~> m or kg m-2].
 ! logical :: use_EOS    ! If true, density is calculated from T & S using an equation of state.
   real, dimension(SZI_(G),SZK0_(G)) :: &
-    Te_a, & ! A partially updated temperature estimate including the influnce from
+    Te_a, & ! A partially updated temperature estimate including the influence from
             ! mixing with layers above rescaled by a factor of d_a [degC].
-            ! This array is discreted on tracer cells, but contains an extra
+            ! This array is discretized on tracer cells, but contains an extra
             ! layer at the top for algorithmic convenience.
-    Se_a    ! A partially updated salinity estimate including the influnce from
+    Se_a    ! A partially updated salinity estimate including the influence from
             ! mixing with layers above rescaled by a factor of d_a [ppt].
-            ! This array is discreted on tracer cells, but contains an extra
+            ! This array is discretized on tracer cells, but contains an extra
             ! layer at the top for algorithmic convenience.
   real, dimension(SZI_(G),SZK_(GV)+1) :: &
-    Te_b, & ! A partially updated temperature estimate including the influnce from
+    Te_b, & ! A partially updated temperature estimate including the influence from
             ! mixing with layers below rescaled by a factor of d_b [degC].
-            ! This array is discreted on tracer cells, but contains an extra
+            ! This array is discretized on tracer cells, but contains an extra
             ! layer at the bottom for algorithmic convenience.
-    Se_b    ! A partially updated salinity estimate including the influnce from
+    Se_b    ! A partially updated salinity estimate including the influence from
             ! mixing with layers below rescaled by a factor of d_b [ppt].
-            ! This array is discreted on tracer cells, but contains an extra
+            ! This array is discretized on tracer cells, but contains an extra
             ! layer at the bottom for algorithmic convenience.
   real, dimension(SZI_(G),SZK_(GV)+1) :: &
     c_a, &  ! The fractional influence of the properties of the layer below
-            ! in the final properies with a downward-first solver, nondim.
+            ! in the final properties with a downward-first solver [nondim]
     d_a, &  ! The fractional influence of the properties of the layer in question
-            ! and layers above in the final properies with a downward-first solver, nondim.
+            ! and layers above in the final properties with a downward-first solver [nondim]
             ! d_a = 1.0 - c_a
     c_b, &  ! The fractional influence of the properties of the layer above
-            ! in the final properies with a upward-first solver, nondim.
+            ! in the final properties with a upward-first solver [nondim]
     d_b     ! The fractional influence of the properties of the layer in question
-            ! and layers below in the final properies with a upward-first solver, nondim.
+            ! and layers below in the final properties with a upward-first solver [nondim]
             ! d_b = 1.0 - c_b
   real, dimension(SZI_(G),SZK_(GV)+1) :: &
     mix     !< The amount of mixing across the interface between layers [H ~> m or kg m-2].
   real :: mix_len  ! The length-scale of mixing, when it is active [H ~> m or kg m-2]
-  real :: h_b, h_a ! The thicknessses of the layers above and below an interface [H ~> m or kg m-2]
+  real :: h_b, h_a ! The thicknesses of the layers above and below an interface [H ~> m or kg m-2]
   real :: b_b, b_a ! Inverse pivots used by the tridiagonal solver [H-1 ~> m-1 or m2 kg-1].
-
-  real :: kap_dt_x2 ! The product of 2*kappa*dt [H2 ~> m2 or kg2 m-4].
 
   logical, dimension(SZI_(G)) :: do_i ! Do more work on this column.
   logical, dimension(SZI_(G)) :: last_down ! The last setup pass was downward.
   integer, dimension(SZI_(G)) :: change_ct ! The number of interfaces where the
                          ! mixing has changed this iteration.
-  integer :: changed_col ! The number of colums whose mixing changed.
+  integer :: changed_col ! The number of columns whose mixing changed.
   integer :: i, j, k, is, ie, js, je, nz, itt
 
-  if (present(halo)) then
-    is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
-  else
-    is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
-  endif
+  is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
   nz = GV%ke
 
   if (.not.associated(tv%eqn_of_state)) return
 
   h_neglect = GV%H_subroundoff
-  kap_dt_x2 = 0.0
-  if (present(Kddt_convect)) kap_dt_x2 = 2.0*Kddt_convect
   mix_len = (1.0e20 * nz) * (G%max_depth * GV%Z_to_H)
   h0 = 1.0e-16*sqrt(Kddt_smooth) + h_neglect
 
@@ -135,7 +124,6 @@ subroutine full_convection(G, GV, US, h, tv, T_adj, S_adj, p_surf, Kddt_smooth, 
                           Te_a(i,k-2), Te_b(i,k+1), Se_a(i,k-2), Se_b(i,k+1), &
                           d_a(i,K-1), d_b(i,K+1))) then
             mix(i,K) = mix_len
-            if (kap_dt_x2 > 0.0) mix(i,K) = kap_dt_x2 / ((h(i,j,k-1)+h(i,j,k)) + h0)
             change_ct(i) = change_ct(i) + 1
           endif
         endif
@@ -178,7 +166,6 @@ subroutine full_convection(G, GV, US, h, tv, T_adj, S_adj, p_surf, Kddt_smooth, 
                           Te_a(i,k-2), Te_b(i,k+1), Se_a(i,k-2), Se_b(i,k+1), &
                           d_a(i,K-1), d_b(i,K+1))) then
             mix(i,K) = mix_len
-            if (kap_dt_x2 > 0.0) mix(i,K) = kap_dt_x2 / ((h(i,j,k-1)+h(i,j,k)) + h0)
             change_ct(i) = change_ct(i) + 1
           endif
         endif
@@ -260,7 +247,7 @@ subroutine full_convection(G, GV, US, h, tv, T_adj, S_adj, p_surf, Kddt_smooth, 
 
   k = 1 ! A hook for debugging.
 
-  ! The following set of expressions for the final values are derived from the the partial
+  ! The following set of expressions for the final values are derived from the partial
   ! updates for the estimated temperatures and salinities around an interface, then directly
   ! solving for the final temperatures and salinities.  They are here for later reference
   ! and to document an intermediate step in the stability calculation.
@@ -336,7 +323,7 @@ subroutine smoothed_dRdT_dRdS(h, tv, Kddt, dR_dT, dR_dS, G, GV, US, j, p_surf, h
   type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
   integer,                 intent(in)  :: j    !< The j-point to work on.
   real, dimension(:,:),    pointer     :: p_surf !< The pressure at the ocean surface [R L2 T-2 ~> Pa].
-  integer,       optional, intent(in)  :: halo !< Halo width over which to compute
+  integer,                 intent(in)  :: halo !< Halo width over which to compute
 
   ! Local variables
   real :: mix(SZI_(G),SZK_(GV)+1)  ! The diffusive mixing length (kappa*dt)/dz
@@ -352,14 +339,10 @@ subroutine smoothed_dRdT_dRdS(h, tv, Kddt, dR_dT, dR_dS, G, GV, US, j, p_surf, h
   real :: h_neglect, h0            ! Negligible thicknesses to allow for zero thicknesses,
                                    ! [H ~> m or kg m-2].
   real :: h_tr                     ! The thickness at tracer points, plus h_neglect [H ~> m or kg m-2].
-  integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom  ! The i-computational domain for the equation of state
   integer :: i, k, is, ie, nz
 
-  if (present(halo)) then
-    is = G%isc-halo ; ie = G%iec+halo
-  else
-    is = G%isc ; ie = G%iec
-  endif
+  is = G%isc-halo ; ie = G%iec+halo
   nz = GV%ke
 
   h_neglect = GV%H_subroundoff

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -499,7 +499,7 @@ subroutine geothermal_init(Time, G, GV, US, param_file, diag, CS, useALEalgorith
   type(diag_ctrl), target, intent(inout) :: diag !< Structure used to regulate diagnostic output.
   type(geothermal_CS),     pointer       :: CS   !< Pointer pointing to the module control
                                                  !! structure.
-  logical,       optional, intent(in)    :: useALEalgorithm  !< logical for whether to use ALE remapping
+  logical,                 intent(in)    :: useALEalgorithm  !< logical for whether to use ALE remapping
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -587,13 +587,13 @@ subroutine geothermal_init(Time, G, GV, US, param_file, diag, CS, useALEalgorith
         'internal_heat_temp_tendency', diag%axesTL, Time,              &
         'Temperature tendency (in 3D) due to internal (geothermal) sources', &
         'degC s-1', conversion=US%s_to_T, v_extensive=.true.)
-  if (present(useALEalgorithm)) then ; if (.not.useALEalgorithm) then
+  if (.not.useALEalgorithm) then
     ! Do not offer this diagnostic if heating will be in place.
     CS%id_internal_heat_h_tendency=register_diag_field('ocean_model',    &
         'internal_heat_h_tendency', diag%axesTL, Time,                &
         'Thickness tendency (in 3D) due to internal (geothermal) sources', &
         trim(thickness_units)//' s-1', conversion=GV%H_to_MKS*US%s_to_T, v_extensive=.true.)
-  endif ; endif
+  endif
 
 end subroutine geothermal_init
 

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -198,8 +198,8 @@ integer :: id_clock_kappaShear, id_clock_CVMix_ddiff
 
 contains
 
-subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
-                           G, GV, US, CS, Kd_lay, Kd_int, Kd_extra_T, Kd_extra_S)
+subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_int, &
+                           G, GV, US, CS, Kd_lay, Kd_extra_T, Kd_extra_S)
   type(ocean_grid_type),     intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type),   intent(in)    :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type),     intent(in)    :: US   !< A dimensional unit scaling type
@@ -219,13 +219,13 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   type(optics_type),         pointer       :: optics !< A structure describing the optical
                                                    !!  properties of the ocean.
   type(vertvisc_type),       intent(inout) :: visc !< Structure containing vertical viscosities, bottom
-                                                   !! boundary layer properies, and related fields.
+                                                   !! boundary layer properties and related fields.
   real,                      intent(in)    :: dt   !< Time increment [T ~> s].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
+                             intent(out)   :: Kd_int !< Diapycnal diffusivity at each interface [Z2 T-1 ~> m2 s-1].
   type(set_diffusivity_CS),  pointer       :: CS   !< Module control structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                    optional, intent(out)   :: Kd_lay !< Diapycnal diffusivity of each layer [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
-                   optional, intent(out)   :: Kd_int !< Diapycnal diffusivity at each interface [Z2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
                    optional, intent(out)   :: Kd_extra_T !< The extra diffusivity at interfaces of
                                                      !! temperature due to double diffusion relative to
@@ -302,7 +302,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
 
   ! Set Kd_lay, Kd_int and Kv_slow to constant values, mostly to fill the halos.
   if (present(Kd_lay)) Kd_lay(:,:,:) = CS%Kd
-  if (present(Kd_int)) Kd_int(:,:,:) = CS%Kd
+  Kd_int(:,:,:) = CS%Kd
   if (present(Kd_extra_T)) Kd_extra_T(:,:,:) = 0.0
   if (present(Kd_extra_S)) Kd_extra_S(:,:,:) = 0.0
   if (associated(visc%Kv_slow)) visc%Kv_slow(:,:,:) = CS%Kv
@@ -468,98 +468,69 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
 
     ! Add the input turbulent diffusivity.
     if (CS%useKappaShear .or. CS%use_CVMix_shear) then
-      if (present(Kd_int)) then
-        do K=2,nz ; do i=is,ie
-          Kd_int_2d(i,K) = visc%Kd_shear(i,j,K) + 0.5 * (Kd_lay_2d(i,k-1) + Kd_lay_2d(i,k))
-        enddo ; enddo
-        do i=is,ie
-          Kd_int_2d(i,1) = visc%Kd_shear(i,j,1) ! This isn't actually used. It could be 0.
-          Kd_int_2d(i,nz+1) = 0.0
-        enddo
-      endif
+      do K=2,nz ; do i=is,ie
+        Kd_int_2d(i,K) = visc%Kd_shear(i,j,K) + 0.5 * (Kd_lay_2d(i,k-1) + Kd_lay_2d(i,k))
+      enddo ; enddo
+      do i=is,ie
+        Kd_int_2d(i,1) = visc%Kd_shear(i,j,1) ! This isn't actually used. It could be 0.
+        Kd_int_2d(i,nz+1) = 0.0
+      enddo
       do k=1,nz ; do i=is,ie
         Kd_lay_2d(i,k) = Kd_lay_2d(i,k) + 0.5 * (visc%Kd_shear(i,j,K) + visc%Kd_shear(i,j,K+1))
       enddo ; enddo
     else
-      if (present(Kd_int)) then
-        do i=is,ie
-          Kd_int_2d(i,1) = Kd_lay_2d(i,1) ; Kd_int_2d(i,nz+1) = 0.0
-        enddo
-        do K=2,nz ; do i=is,ie
-          Kd_int_2d(i,K) = 0.5 * (Kd_lay_2d(i,k-1) + Kd_lay_2d(i,k))
-        enddo ; enddo
-      endif
-    endif
-
-    if (present(Kd_int)) then
-      ! Add the ML_Rad diffusivity.
-      if (CS%ML_radiation) &
-        call add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, TKE_to_Kd, Kd_lay_2d, Kd_int_2d)
-
-      ! Add the Nikurashin and / or tidal bottom-driven mixing
-      if (CS%use_tidal_mixing) &
-        call calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, maxTKE, G, GV, US, CS%tidal_mixing_CSp, &
-                                    N2_lay, N2_int, Kd_lay_2d, Kd_int_2d, CS%Kd_max, visc%Kv_slow)
-
-      ! This adds the diffusion sustained by the energy extracted from the flow by the bottom drag.
-      if (CS%bottomdraglaw .and. (CS%BBL_effic>0.0)) then
-        if (CS%use_LOTW_BBL_diffusivity) then
-          call add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, G, GV, US, CS,  &
-                                        dd%Kd_BBL, Kd_lay_2d, Kd_int_2d)
-        else
-          call add_drag_diffusivity(h, u, v,  tv, fluxes, visc, j, TKE_to_Kd, &
-                                    maxTKE, kb, G, GV, US, CS, Kd_lay_2d, Kd_int_2d, dd%Kd_BBL)
-        endif
-      endif
-
-      if (CS%limit_dissipation) then
-        ! This calculates the dissipation ONLY from Kd calculated in this routine
-        ! dissip has units of W/m3 (= kg/m3 * m2/s * 1/s2)
-        !   1) a global constant,
-        !   2) a dissipation proportional to N (aka Gargett) and
-        !   3) dissipation corresponding to a (nearly) constant diffusivity.
-        do K=2,nz ; do i=is,ie
-          dissip = max( CS%dissip_min, &   ! Const. floor on dissip.
-                        CS%dissip_N0 + CS%dissip_N1 * sqrt(N2_int(i,K)), & ! Floor aka Gargett
-                        CS%dissip_N2 * N2_int(i,K)) ! Floor of Kd_min*rho0/F_Ri
-          Kd_int_2d(i,K) = max(Kd_int_2d(i,K) , &  ! Apply floor to Kd
-                              dissip * (CS%FluxRi_max / (GV%Rho0 * (N2_int(i,K) + Omega2))))
-        enddo ; enddo
-      endif
-
-      ! Optionally add a uniform diffusivity at the interfaces.
-      if (CS%Kd_add > 0.0) then ; do K=1,nz+1 ; do i=is,ie
-        Kd_int_2d(i,K) = Kd_int_2d(i,K) + CS%Kd_add
-      enddo ; enddo ; endif
-
-      ! Copy the 2-d slices into the 3-d array that is exported.
-      do K=1,nz+1 ; do i=is,ie
-        Kd_int(i,j,K) = Kd_int_2d(i,K)
+      do i=is,ie
+        Kd_int_2d(i,1) = Kd_lay_2d(i,1) ; Kd_int_2d(i,nz+1) = 0.0
+      enddo
+      do K=2,nz ; do i=is,ie
+        Kd_int_2d(i,K) = 0.5 * (Kd_lay_2d(i,k-1) + Kd_lay_2d(i,k))
       enddo ; enddo
-
-    else ! Kd_int is not present.
-
-      ! Add the ML_Rad diffusivity.
-      if (CS%ML_radiation) &
-        call add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, TKE_to_Kd, Kd_lay_2d)
-
-      ! Add the Nikurashin and / or tidal bottom-driven mixing
-      if (CS%use_tidal_mixing) &
-        call calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, maxTKE, G, GV, US, CS%tidal_mixing_CSp, &
-                                    N2_lay, N2_int, Kd_lay_2d, Kd_max=CS%Kd_max, Kv=visc%Kv_slow)
-
-      ! This adds the diffusion sustained by the energy extracted from the flow by the bottom drag.
-      if (CS%bottomdraglaw .and. (CS%BBL_effic>0.0)) then
-        if (CS%use_LOTW_BBL_diffusivity) then
-          call add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, G, GV, US, CS,  &
-                                        dd%Kd_BBL, Kd_lay_2d)
-        else
-          call add_drag_diffusivity(h, u, v,  tv, fluxes, visc, j, TKE_to_Kd, &
-                                    maxTKE, kb, G, GV, US, CS, Kd_lay_2d, Kd_BBL=dd%Kd_BBL)
-        endif
-      endif
-
     endif
+
+    ! Add the ML_Rad diffusivity.
+    if (CS%ML_radiation) &
+      call add_MLrad_diffusivity(h, fluxes, j, Kd_int_2d, G, GV, US, CS, TKE_to_Kd, Kd_lay_2d)
+
+    ! Add the Nikurashin and / or tidal bottom-driven mixing
+    if (CS%use_tidal_mixing) &
+      call calculate_tidal_mixing(h, N2_bot, j, TKE_to_Kd, maxTKE, G, GV, US, CS%tidal_mixing_CSp, &
+                                  N2_lay, N2_int, Kd_lay_2d, Kd_int_2d, CS%Kd_max, visc%Kv_slow)
+
+    ! This adds the diffusion sustained by the energy extracted from the flow by the bottom drag.
+    if (CS%bottomdraglaw .and. (CS%BBL_effic>0.0)) then
+      if (CS%use_LOTW_BBL_diffusivity) then
+        call add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, Kd_int_2d, G, GV, US, CS, &
+                                      dd%Kd_BBL, Kd_lay_2d)
+      else
+        call add_drag_diffusivity(h, u, v,  tv, fluxes, visc, j, TKE_to_Kd, &
+                                  maxTKE, kb, G, GV, US, CS, Kd_lay_2d, Kd_int_2d, dd%Kd_BBL)
+      endif
+    endif
+
+    if (CS%limit_dissipation) then
+      ! This calculates the dissipation ONLY from Kd calculated in this routine
+      ! dissip has units of W/m3 (= kg/m3 * m2/s * 1/s2)
+      !   1) a global constant,
+      !   2) a dissipation proportional to N (aka Gargett) and
+      !   3) dissipation corresponding to a (nearly) constant diffusivity.
+      do K=2,nz ; do i=is,ie
+        dissip = max( CS%dissip_min, &   ! Const. floor on dissip.
+                      CS%dissip_N0 + CS%dissip_N1 * sqrt(N2_int(i,K)), & ! Floor aka Gargett
+                      CS%dissip_N2 * N2_int(i,K)) ! Floor of Kd_min*rho0/F_Ri
+        Kd_int_2d(i,K) = max(Kd_int_2d(i,K) , &  ! Apply floor to Kd
+                            dissip * (CS%FluxRi_max / (GV%Rho0 * (N2_int(i,K) + Omega2))))
+      enddo ; enddo
+    endif
+
+    ! Optionally add a uniform diffusivity at the interfaces.
+    if (CS%Kd_add > 0.0) then ; do K=1,nz+1 ; do i=is,ie
+      Kd_int_2d(i,K) = Kd_int_2d(i,K) + CS%Kd_add
+    enddo ; enddo ; endif
+
+    ! Copy the 2-d slices into the 3-d array that is exported.
+    do K=1,nz+1 ; do i=is,ie
+      Kd_int(i,j,K) = Kd_int_2d(i,K)
+    enddo ; enddo
 
     if (CS%limit_dissipation) then
       ! This calculates the layer dissipation ONLY from Kd calculated in this routine
@@ -1163,7 +1134,7 @@ subroutine add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, &
                                                           !! thermodynamic fields.
   type(forcing),                    intent(in)    :: fluxes !< A structure of thermodynamic surface fluxes
   type(vertvisc_type),              intent(in)    :: visc !< Structure containing vertical viscosities, bottom
-                                                          !! boundary layer properies, and related fields
+                                                          !! boundary layer properties and related fields
   integer,                          intent(in)    :: j    !< j-index of row to work on
   real, dimension(SZI_(G),SZK_(GV)), intent(in)   :: TKE_to_Kd !< The conversion rate between the TKE
                                                           !! TKE dissipated within  a layer and the
@@ -1177,8 +1148,7 @@ subroutine add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, &
   type(set_diffusivity_CS),         pointer       :: CS   !< Diffusivity control structure
   real, dimension(SZI_(G),SZK_(GV)), intent(inout) :: Kd_lay !< The diapycnal diffusivity in layers,
                                                             !! [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZK_(GV)+1), &
-                          optional, intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces,
+  real, dimension(SZI_(G),SZK_(GV)+1), intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces,
                                                             !! [Z2 T-1 ~> m2 s-1].
   real, dimension(:,:,:),           pointer       :: Kd_BBL !< Interface BBL diffusivity [Z2 T-1 ~> m2 s-1].
 
@@ -1330,10 +1300,8 @@ subroutine add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, &
             else
               Kd_lay(i,k) = (TKE_to_layer + TKE_Ray) * TKE_to_Kd(i,k)
             endif
-            if (present(Kd_int)) then
-              Kd_int(i,K)   = Kd_int(i,K)   + 0.5 * delta_Kd
-              Kd_int(i,K+1) = Kd_int(i,K+1) + 0.5 * delta_Kd
-            endif
+            Kd_int(i,K)   = Kd_int(i,K)   + 0.5 * delta_Kd
+            Kd_int(i,K+1) = Kd_int(i,K+1) + 0.5 * delta_Kd
             if (do_diag_Kd_BBL) then
               Kd_BBL(i,j,K) = Kd_BBL(i,j,K) + 0.5 * delta_Kd
               Kd_BBL(i,j,K+1) = Kd_BBL(i,j,K+1) + 0.5 * delta_Kd
@@ -1357,10 +1325,8 @@ subroutine add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, &
             delta_Kd = TKE_here * TKE_to_Kd(i,k)
             if (CS%Kd_max >= 0.0) delta_Kd = min(delta_Kd, CS%Kd_max)
             Kd_lay(i,k) = Kd_lay(i,k) + delta_Kd
-            if (present(Kd_int)) then
-              Kd_int(i,K)   = Kd_int(i,K)   + 0.5 * delta_Kd
-              Kd_int(i,K+1) = Kd_int(i,K+1) + 0.5 * delta_Kd
-            endif
+            Kd_int(i,K)   = Kd_int(i,K)   + 0.5 * delta_Kd
+            Kd_int(i,K+1) = Kd_int(i,K+1) + 0.5 * delta_Kd
             if (do_diag_Kd_BBL) then
               Kd_BBL(i,j,K) = Kd_BBL(i,j,K) + 0.5 * delta_Kd
               Kd_BBL(i,j,K+1) = Kd_BBL(i,j,K+1) + 0.5 * delta_Kd
@@ -1386,8 +1352,8 @@ end subroutine add_drag_diffusivity
 !> Calculates a BBL diffusivity use a Prandtl number 1 diffusivity with a law of the
 !! wall turbulent viscosity, up to a BBL height where the energy used for mixing has
 !! consumed the mechanical TKE input.
-subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, &
-                                    G, GV, US, CS, Kd_BBL, Kd_lay, Kd_int)
+subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, Kd_int, &
+                                    G, GV, US, CS, Kd_BBL, Kd_lay)
   type(ocean_grid_type),    intent(in)    :: G  !< Grid structure
   type(verticalGrid_type),  intent(in)    :: GV !< Vertical grid structure
   type(unit_scale_type),    intent(in)    :: US !< A dimensional unit scaling type
@@ -1401,16 +1367,16 @@ subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, &
                                                 !! thermodynamic fields.
   type(forcing),            intent(in)    :: fluxes !< Surface fluxes structure
   type(vertvisc_type),      intent(in)    :: visc !< Structure containing vertical viscosities, bottom
-                                                  !! boundary layer properies, and related fields.
+                                                  !! boundary layer properties and related fields.
   integer,                  intent(in)    :: j  !< j-index of row to work on
   real, dimension(SZI_(G),SZK_(GV)+1), &
                             intent(in)    :: N2_int !< Square of Brunt-Vaisala at interfaces [T-2 ~> s-2]
+  real, dimension(SZI_(G),SZK_(GV)+1), &
+                            intent(inout) :: Kd_int !< Interface net diffusivity [Z2 T-1 ~> m2 s-1]
   type(set_diffusivity_CS), pointer       :: CS !< Diffusivity control structure
   real, dimension(:,:,:),   pointer       :: Kd_BBL !< Interface BBL diffusivity [Z2 T-1 ~> m2 s-1]
   real, dimension(SZI_(G),SZK_(GV)), &
                   optional, intent(inout) :: Kd_lay !< Layer net diffusivity [Z2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G),SZK_(GV)+1), &
-                  optional, intent(inout) :: Kd_int !< Interface net diffusivity [Z2 T-1 ~> m2 s-1]
 
   ! Local variables
   real :: TKE_column       ! net TKE input into the column [Z3 T-3 ~> m3 s-3]
@@ -1537,7 +1503,7 @@ subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, &
       TKE_remaining = TKE_remaining - TKE_consumed ! Note this will be non-negative
 
       ! Add this BBL diffusivity to the model net diffusivity.
-      if (present(Kd_int)) Kd_int(i,K) = Kd_int(i,K) + Kd_wall
+      Kd_int(i,K) = Kd_int(i,K) + Kd_wall
       if (present(Kd_lay)) Kd_lay(i,k) = Kd_lay(i,k) + 0.5 * (Kd_wall + Kd_lower)
       Kd_lower = Kd_wall ! Store for next layer up.
       if (do_diag_Kd_BBL) Kd_BBL(i,j,K) = Kd_wall
@@ -1547,7 +1513,7 @@ subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, &
 end subroutine add_LOTW_BBL_diffusivity
 
 !> This routine adds effects of mixed layer radiation to the layer diffusivities.
-subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, TKE_to_Kd, Kd_lay, Kd_int)
+subroutine add_MLrad_diffusivity(h, fluxes, j, Kd_int, G, GV, US, CS, TKE_to_Kd, Kd_lay)
   type(ocean_grid_type),            intent(in)    :: G      !< The ocean's grid structure
   type(verticalGrid_type),          intent(in)    :: GV     !< The ocean's vertical grid structure
   type(unit_scale_type),            intent(in)    :: US     !< A dimensional unit scaling type
@@ -1555,6 +1521,8 @@ subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, TKE_to_Kd, Kd_lay,
                                     intent(in)    :: h      !< Layer thicknesses [H ~> m or kg m-2]
   type(forcing),                    intent(in)    :: fluxes !< Surface fluxes structure
   integer,                          intent(in)    :: j      !< The j-index to work on
+  real, dimension(SZI_(G),SZK_(GV)+1), intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces
+                                                            !! [Z2 T-1 ~> m2 s-1].
   type(set_diffusivity_CS),         pointer       :: CS     !< Diffusivity control structure
   real, dimension(SZI_(G),SZK_(GV)), intent(in)   :: TKE_to_Kd !< The conversion rate between the TKE
                                                             !! TKE dissipated within  a layer and the
@@ -1563,9 +1531,6 @@ subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, TKE_to_Kd, Kd_lay,
                                                             !! [Z2 T-1 / Z3 T-3 = T2 Z-1 ~> s2 m-1]
   real, dimension(SZI_(G),SZK_(GV)), &
                           optional, intent(inout) :: Kd_lay !< The diapycnal diffusivity in layers [Z2 T-1 ~> m2 s-1].
-  real, dimension(SZI_(G),SZK_(GV)+1), &
-                          optional, intent(inout) :: Kd_int !< The diapycnal diffusivity at interfaces
-                                                            !! [Z2 T-1 ~> m2 s-1].
 
 ! This routine adds effects of mixed layer radiation to the layer diffusivities.
 
@@ -1639,14 +1604,12 @@ subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, TKE_to_Kd, Kd_lay,
       Kd_lay(i,k) = Kd_lay(i,k) + Kd_mlr_ml(i)
     endif ; enddo ; enddo
   endif
-  if (present(Kd_int)) then
-    do K=2,kml+1 ; do i=is,ie ; if (do_i(i)) then
-      Kd_int(i,K) = Kd_int(i,K) + Kd_mlr_ml(i)
-    endif ; enddo ; enddo
-    if (kml<=nz-1) then ; do i=is,ie ; if (do_i(i)) then
-      Kd_int(i,Kml+2) = Kd_int(i,Kml+2) + 0.5 * Kd_mlr_ml(i)
-    endif ; enddo ; endif
-  endif
+  do K=2,kml+1 ; do i=is,ie ; if (do_i(i)) then
+    Kd_int(i,K) = Kd_int(i,K) + Kd_mlr_ml(i)
+  endif ; enddo ; enddo
+  if (kml<=nz-1) then ; do i=is,ie ; if (do_i(i)) then
+    Kd_int(i,Kml+2) = Kd_int(i,Kml+2) + 0.5 * Kd_mlr_ml(i)
+  endif ; enddo ; endif
 
   do k=kml+2,nz-1
     do_any = .false.
@@ -1674,10 +1637,8 @@ subroutine add_MLrad_diffusivity(h, fluxes, j, G, GV, US, CS, TKE_to_Kd, Kd_lay,
       if (present(Kd_lay)) then
         Kd_lay(i,k) = Kd_lay(i,k) + Kd_mlr
       endif
-      if (present(Kd_int)) then
-        Kd_int(i,K)   = Kd_int(i,K)   + 0.5 * Kd_mlr
-        Kd_int(i,K+1) = Kd_int(i,K+1) + 0.5 * Kd_mlr
-      endif
+      Kd_int(i,K)   = Kd_int(i,K)   + 0.5 * Kd_mlr
+      Kd_int(i,K+1) = Kd_int(i,K+1) + 0.5 * Kd_mlr
 
       TKE_ml_flux(i) = TKE_ml_flux(i) * exp(-z1)
       if (TKE_ml_flux(i) * I_decay(i) < 0.1 * CS%Kd_min * Omega2) then
@@ -1703,7 +1664,7 @@ subroutine set_BBL_TKE(u, v, h, fluxes, visc, G, GV, US, CS, OBC)
                             intent(in)    :: h    !< Layer thicknesses [H ~> m or kg m-2]
   type(forcing),            intent(in)    :: fluxes !< A structure of thermodynamic surface fluxes
   type(vertvisc_type),      intent(in)    :: visc !< Structure containing vertical viscosities, bottom
-                                                  !! boundary layer properies, and related fields.
+                                                  !! boundary layer properties and related fields.
   type(set_diffusivity_CS), pointer       :: CS   !< Diffusivity control structure
   type(ocean_OBC_type),     pointer       :: OBC  !< Open boundaries control structure.
 
@@ -1995,10 +1956,10 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
                                                   !! structure.
   type(int_tide_CS),        pointer       :: int_tide_CSp !< A pointer to the internal tides control
                                                   !! structure
-  integer,        optional, intent(out)   :: halo_TS !< The halo size of tracer points that must be
+  integer,                  intent(out)   :: halo_TS !< The halo size of tracer points that must be
                                                   !! valid for the calculations in set_diffusivity.
-  logical,        optional, intent(out)   :: double_diffuse !< If present, this indicates whether
-                                                  !! some version of double diffusion is being used.
+  logical,                  intent(out)   :: double_diffuse !< This indicates whether some version
+                                                  !! of double diffusion is being used.
 
   ! Local variables
   real :: decay_length
@@ -2323,14 +2284,10 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
          'Double-diffusion density ratio', 'nondim')
   endif
 
-  if (present(halo_TS)) then
-    halo_TS = 0
-    if (CS%Vertex_Shear) halo_TS = 1
-  endif
+  halo_TS = 0
+  if (CS%Vertex_Shear) halo_TS = 1
 
-  if (present(double_diffuse)) then
-    double_diffuse = (CS%double_diffusion .or. CS%use_CVMix_ddiff)
-  endif
+  double_diffuse = (CS%double_diffusion .or. CS%use_CVMix_ddiff)
 
 end subroutine set_diffusivity_init
 


### PR DESCRIPTION
  Cleaned up 26 falsely optional or unused arguments in the vertical
diffusivity code, and related changes.  Several descriptive comments were
also corrected, including the correction of the units of 10 variables related
to CVMix_KPP.  This commit includes:
 - Made the Kd_int arguments to set_diffusivity() and 3 subsidiary routines
   mandatory and reordered the arguments so that the non-optional arguments
   come before the grid types
 - Made the halo_TS and double_diffuse arguments to set_diffusivity_init()
   mandatory.
 - Made the Time argument to ALE_sponge() mandatory.
 - Made the Kd and Kv arguments to calculate_CVMIX_conv() mandatory.
 - Removed the unused halo argument to adjust_salt().
 - Removed the unused Kddt_convect argument to full_convection().
 - Made the halo arguments to full_convection()and smoothed_dRdT_dRdS()
   mandatory.
 - Made the useALEalgorithm argument to geothermal_init() mandatory.
 - Removed the unused initialize_all arguments to Calculate_kappa_shear() and
   Calc_kappa_shear_vertex().
 - Removed the unused I_Ld2_1d and dz_Int_1d arguments to kappa_shear_column().
 - Made 3 arguments to calculate_projected_state() mandatory and reordered the
   arguments accordingly.
 - Eliminating the unused skip_diags arguments to calculateBuoyancyFlux() and
   extractFluxes(), which are now effectively always false.
All answers are bitwise identical, and no output is changed.