### PR TITLE
+Add G%Rad_Earth_L and related code simplification

### DIFF
--- a/src/core/MOM_checksum_packages.F90
+++ b/src/core/MOM_checksum_packages.F90
@@ -97,7 +97,7 @@ subroutine MOM_state_chksum_3arg(mesg, u, v, h, G, GV, US, haloshift, symmetric)
   integer,               optional, intent(in) :: haloshift !< The width of halos to check (default 0).
   logical,               optional, intent(in) :: symmetric !< If true, do checksums on the fully
                                                     !! symmetric computational domain.
-  real :: L_T_to_m_s ! A rescaling factor for velocities [m T s-1 L-1 ~> nondim] or [nondim]
+  real :: L_T_to_m_s ! A rescaling factor for velocities [m T s-1 L-1 ~> 1] or [1]
   integer :: hs
   logical :: sym
 

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -171,10 +171,11 @@ type, public :: ocean_grid_type
   ! initialization routines (but not all)
   real :: south_lat     !< The latitude (or y-coordinate) of the first v-line
   real :: west_lon      !< The longitude (or x-coordinate) of the first u-line
-  real :: len_lat = 0.  !< The latitudinal (or y-coord) extent of physical domain
-  real :: len_lon = 0.  !< The longitudinal (or x-coord) extent of physical domain
-  real :: Rad_Earth = 6.378e6 !< The radius of the planet [m].
-  real :: max_depth     !< The maximum depth of the ocean in depth units [Z ~> m].
+  real :: len_lat       !< The latitudinal (or y-coord) extent of physical domain
+  real :: len_lon       !< The longitudinal (or x-coord) extent of physical domain
+  real :: Rad_Earth     !< The radius of the planet [m]
+  real :: Rad_Earth_L   !< The radius of the planet in rescaled units [L ~> m]
+  real :: max_depth     !< The maximum depth of the ocean in depth units [Z ~> m]
 end type ocean_grid_type
 
 contains

--- a/src/core/MOM_transcribe_grid.F90
+++ b/src/core/MOM_transcribe_grid.F90
@@ -126,7 +126,8 @@ subroutine copy_dyngrid_to_MOM_grid(dG, oG, US)
   oG%areaT_global = dG%areaT_global ; oG%IareaT_global = dG%IareaT_global
   oG%south_lat = dG%south_lat ; oG%west_lon  = dG%west_lon
   oG%len_lat = dG%len_lat ; oG%len_lon = dG%len_lon
-  oG%Rad_Earth = dG%Rad_Earth ; oG%max_depth = dG%max_depth
+  oG%Rad_Earth = dG%Rad_Earth ; oG%Rad_Earth_L = dG%Rad_Earth_L
+  oG%max_depth = dG%max_depth
 
 ! Update the halos in case the dynamic grid has smaller halos than the ocean grid.
   call pass_var(oG%areaT, oG%Domain)
@@ -272,7 +273,8 @@ subroutine copy_MOM_grid_to_dyngrid(oG, dG, US)
   dG%areaT_global = oG%areaT_global ; dG%IareaT_global = oG%IareaT_global
   dG%south_lat = oG%south_lat ; dG%west_lon  = oG%west_lon
   dG%len_lat = oG%len_lat ; dG%len_lon = oG%len_lon
-  dG%Rad_Earth = oG%Rad_Earth ; dG%max_depth = oG%max_depth
+  dG%Rad_Earth = oG%Rad_Earth ; dG%Rad_Earth_L = oG%Rad_Earth_L
+  dG%max_depth = oG%max_depth
 
 ! Update the halos in case the dynamic grid has smaller halos than the ocean grid.
   call pass_var(dG%areaT, dG%Domain)

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -390,9 +390,9 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
     Temp_int, Salt_int ! Layer and cell integrated heat and salt [J] and [g Salt].
   real :: HL2_to_kg    ! A conversion factor from a thickness-volume to mass [kg H-1 L-2 ~> kg m-3 or 1]
   real :: KE_scale_factor   ! The combination of unit rescaling factors in the kinetic energy
-                            ! calculation [kg T2 H-1 L-2 s-2 ~> kg m-3 or nondim]
+                            ! calculation [kg T2 H-1 L-2 s-2 ~> kg m-3 or 1]
   real :: PE_scale_factor   ! The combination of unit rescaling factors in the potential energy
-                            ! calculation [kg T2 R-1 Z-1 L-2 s-2 ~> nondim]
+                            ! calculation [kg T2 R-1 Z-1 L-2 s-2 ~> 1]
   integer :: num_nc_fields  ! The number of fields that will actually go into
                             ! the NetCDF file.
   integer :: i, j, k, is, ie, js, je, ns, nz, m, Isq, Ieq, Jsq, Jeq, isr, ier, jsr, jer

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -163,10 +163,11 @@ type, public :: dyn_horgrid_type
   ! initialization routines (but not all)
   real :: south_lat     !< The latitude (or y-coordinate) of the first v-line
   real :: west_lon      !< The longitude (or x-coordinate) of the first u-line
-  real :: len_lat = 0.  !< The latitudinal (or y-coord) extent of physical domain
-  real :: len_lon = 0.  !< The longitudinal (or x-coord) extent of physical domain
-  real :: Rad_Earth = 6.378e6 !< The radius of the planet [m].
-  real :: max_depth     !< The maximum depth of the ocean [Z ~> m].
+  real :: len_lat       !< The latitudinal (or y-coord) extent of physical domain
+  real :: len_lon       !< The longitudinal (or x-coord) extent of physical domain
+  real :: Rad_Earth     !< The radius of the planet [m]
+  real :: Rad_Earth_L   !< The radius of the planet in rescaled units [L ~> m]
+  real :: max_depth     !< The maximum depth of the ocean [Z ~> m]
 end type dyn_horgrid_type
 
 contains
@@ -361,6 +362,7 @@ subroutine rotate_dyn_horgrid(G_in, G, US, turns)
   G%areaT_global = G_in%areaT_global
   G%IareaT_global = G_in%IareaT_global
   G%Rad_Earth = G_in%Rad_Earth
+  G%Rad_Earth_L = G_in%Rad_Earth_L
   G%max_depth = G_in%max_depth
 
   call set_derived_dyn_horgrid(G, US)
@@ -406,12 +408,8 @@ subroutine set_derived_dyn_horgrid(G, US)
   type(unit_scale_type), optional, intent(in) :: US !< A dimensional unit scaling type
 !    Various inverse grid spacings and derived areas are calculated within this
 !  subroutine.
-  real :: m_to_L  ! A unit conversion factor [L m-1 ~> nondim]
-  real :: L_to_m  ! A unit conversion factor [L m-1 ~> nondim]
   integer :: i, j, isd, ied, jsd, jed
   integer :: IsdB, IedB, JsdB, JedB
-  m_to_L = 1.0 ; if (present(US)) m_to_L = US%m_to_L
-  L_to_m = 1.0 ; if (present(US)) L_to_m = US%L_to_m
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -95,7 +95,7 @@ subroutine MOM_calculate_grad_Coriolis(dF_dx, dF_dy, G, US)
   type(unit_scale_type),    optional, intent(in)    :: US !< A dimensional unit scaling type
   ! Local variables
   integer :: i,j
-  real :: m_to_L  ! A unit conversion factor [L m-1 ~> nondim]
+  real :: m_to_L  ! A unit conversion factor [L m-1 ~> 1]
   real :: f1, f2
 
   m_to_L = 1.0 ; if (present(US)) m_to_L = US%m_to_L
@@ -298,13 +298,13 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
   ! This subroutine places the bottom depth in m into D(:,:), shaped according to the named config.
 
   ! Local variables
-  real :: m_to_Z               ! A dimensional rescaling factor.
+  real :: m_to_Z               ! A dimensional rescaling factor [Z m-1 ~> 1]
+  real :: m_to_L               ! A dimensional rescaling factor [L m-1 ~> 1]
   real :: min_depth            ! The minimum depth [Z ~> m].
   real :: PI                   ! 3.1415926... calculated as 4*atan(1)
-  real :: D0                   ! A constant to make the maximum  basin depth MAXIMUM_DEPTH.
-  real :: expdecay             ! A decay scale of associated with the sloping boundaries [m].
-  real :: Dedge                ! The depth [Z ~> m], at the basin edge
-! real :: south_lat, west_lon, len_lon, len_lat, Rad_earth
+  real :: D0                   ! A constant to make the maximum basin depth MAXIMUM_DEPTH [Z ~> m]
+  real :: expdecay             ! A decay scale of associated with the sloping boundaries [L ~> m]
+  real :: Dedge                ! The depth at the basin edge [Z ~> m]
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
   character(len=40)  :: mdl = "initialize_topography_named" ! This subroutine's name.
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -315,6 +315,7 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
                  "TOPO_CONFIG = "//trim(topog_config), 5)
 
   m_to_Z = 1.0 ; if (present(US)) m_to_Z = US%m_to_Z
+  m_to_L = 1.0 ; if (present(US)) m_to_L = US%m_to_L
 
   call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0, scale=m_to_Z)
@@ -325,23 +326,9 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
     call get_param(param_file, mdl, "EDGE_DEPTH", Dedge, &
                    "The depth at the edge of one of the named topographies.", &
                    units="m", default=100.0, scale=m_to_Z)
-!   call get_param(param_file, mdl, "SOUTHLAT", south_lat, &
-!                  "The southern latitude of the domain.", units="degrees", &
-!                  fail_if_missing=.true.)
-!   call get_param(param_file, mdl, "LENLAT", len_lat, &
-!                  "The latitudinal length of the domain.", units="degrees", &
-!                  fail_if_missing=.true.)
-!   call get_param(param_file, mdl, "WESTLON", west_lon, &
-!                  "The western longitude of the domain.", units="degrees", &
-!                  default=0.0)
-!   call get_param(param_file, mdl, "LENLON", len_lon, &
-!                  "The longitudinal length of the domain.", units="degrees", &
-!                  fail_if_missing=.true.)
-!   call get_param(param_file, mdl, "RAD_EARTH", Rad_Earth, &
-!                  "The radius of the Earth.", units="m", default=6.378e6)
     call get_param(param_file, mdl, "TOPOG_SLOPE_SCALE", expdecay, &
                    "The exponential decay scale used in defining some of "//&
-                   "the named topographies.", units="m", default=400000.0)
+                   "the named topographies.", units="m", default=400000.0, scale=m_to_L)
   endif
 
 
@@ -351,30 +338,30 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
     do i=is,ie ; do j=js,je ; D(i,j) = max_depth ; enddo ; enddo
   elseif (trim(topog_config) == "spoon") then
     D0 = (max_depth - Dedge) / &
-             ((1.0 - exp(-0.5*G%len_lat*G%Rad_earth*PI/(180.0 *expdecay))) * &
-              (1.0 - exp(-0.5*G%len_lat*G%Rad_earth*PI/(180.0 *expdecay))))
+             ((1.0 - exp(-0.5*G%len_lat*G%Rad_Earth_L*PI/(180.0 *expdecay))) * &
+              (1.0 - exp(-0.5*G%len_lat*G%Rad_Earth_L*PI/(180.0 *expdecay))))
     do i=is,ie ; do j=js,je
   !  This sets a bowl shaped (sort of) bottom topography, with a       !
   !  maximum depth of max_depth.                                   !
       D(i,j) =  Dedge + D0 * &
              (sin(PI * (G%geoLonT(i,j) - (G%west_lon)) / G%len_lon) * &
-           (1.0 - exp((G%geoLatT(i,j) - (G%south_lat+G%len_lat))*G%Rad_earth*PI / &
+           (1.0 - exp((G%geoLatT(i,j) - (G%south_lat+G%len_lat))*G%Rad_Earth_L*PI / &
                       (180.0*expdecay)) ))
     enddo ; enddo
   elseif (trim(topog_config) == "bowl") then
     D0 = (max_depth - Dedge) / &
-             ((1.0 - exp(-0.5*G%len_lat*G%Rad_earth*PI/(180.0 *expdecay))) * &
-              (1.0 - exp(-0.5*G%len_lat*G%Rad_earth*PI/(180.0 *expdecay))))
+             ((1.0 - exp(-0.5*G%len_lat*G%Rad_Earth_L*PI/(180.0 *expdecay))) * &
+              (1.0 - exp(-0.5*G%len_lat*G%Rad_Earth_L*PI/(180.0 *expdecay))))
 
   !  This sets a bowl shaped (sort of) bottom topography, with a
   !  maximum depth of max_depth.
     do i=is,ie ; do j=js,je
       D(i,j) =  Dedge + D0 * &
              (sin(PI * (G%geoLonT(i,j) - G%west_lon) / G%len_lon) * &
-             ((1.0 - exp(-(G%geoLatT(i,j) - G%south_lat)*G%Rad_Earth*PI/ &
+             ((1.0 - exp(-(G%geoLatT(i,j) - G%south_lat)*G%Rad_Earth_L*PI/ &
                           (180.0*expdecay))) * &
              (1.0 - exp((G%geoLatT(i,j) - (G%south_lat+G%len_lat))* &
-                         G%Rad_Earth*PI/(180.0*expdecay)))))
+                         G%Rad_Earth_L*PI/(180.0*expdecay)))))
     enddo ; enddo
   elseif (trim(topog_config) == "halfpipe") then
     D0 = max_depth - Dedge
@@ -510,10 +497,13 @@ subroutine set_rotation_beta_plane(f, G, param_file, US)
 ! This subroutine sets up the Coriolis parameter for a beta-plane
   integer :: I, J
   real    :: f_0    ! The reference value of the Coriolis parameter [T-1 ~> s-1]
-  real    :: beta   ! The meridional gradient of the Coriolis parameter [T-1 m-1 ~> s-1 m-1]
-  real    :: beta_lat_ref  ! The reference latitude for the beta plane [degrees/km/m/cm]
-  real    :: y_scl, Rad_Earth
-  real    :: T_to_s ! A time unit conversion factor
+  real    :: beta   ! The meridional gradient of the Coriolis parameter [T-1 L-1 ~> s-1 m-1]
+  real    :: beta_lat_ref ! The reference latitude for the beta plane [degrees/km/m/cm]
+  real    :: Rad_Earth_L  ! The radius of the planet in rescaled units [L ~> m]
+  real    :: y_scl  ! A scaling factor from the units of latitude [L lat-1 ~> m lat-1]
+  real    :: T_to_s ! A time unit conversion factor [s T-1 ~> 1]
+  real    :: m_to_L  ! A length unit conversion factor [L m-1 ~> 1]
+  real    :: L_to_m  ! A length unit conversion factor [m L-1 ~> 1]
   real    :: PI
   character(len=40)  :: mdl = "set_rotation_beta_plane" ! This subroutine's name.
   character(len=200) :: axis_units
@@ -522,28 +512,30 @@ subroutine set_rotation_beta_plane(f, G, param_file, US)
   call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
 
   T_to_s = 1.0 ; if (present(US)) T_to_s = US%T_to_s
+  m_to_L = 1.0 ; if (present(US)) m_to_L = US%m_to_L
+  L_to_m = 1.0 ; if (present(US)) L_to_m = US%L_to_m
 
   call get_param(param_file, mdl, "F_0", f_0, &
                  "The reference value of the Coriolis parameter with the "//&
                  "betaplane option.", units="s-1", default=0.0, scale=T_to_s)
   call get_param(param_file, mdl, "BETA", beta, &
                  "The northward gradient of the Coriolis parameter with "//&
-                 "the betaplane option.", units="m-1 s-1", default=0.0, scale=T_to_s)
+                 "the betaplane option.", units="m-1 s-1", default=0.0, scale=T_to_s*L_to_m)
   call get_param(param_file, mdl, "AXIS_UNITS", axis_units, default="degrees")
 
   PI = 4.0*atan(1.0)
   select case (axis_units(1:1))
     case ("d")
-      call get_param(param_file, mdl, "RAD_EARTH", Rad_Earth, &
-                   "The radius of the Earth.", units="m", default=6.378e6)
+      call get_param(param_file, mdl, "RAD_EARTH", Rad_Earth_L, &
+                   "The radius of the Earth.", units="m", default=6.378e6, scale=m_to_L)
       beta_lat_ref_units = "degrees"
-      y_scl = PI * Rad_Earth/ 180.
+      y_scl = PI * Rad_Earth_L / 180.
     case ("k")
       beta_lat_ref_units = "kilometers"
-      y_scl = 1.E3
+      y_scl = 1.E3 * m_to_L
     case ("m")
       beta_lat_ref_units = "meters"
-      y_scl = 1.
+      y_scl = 1. * m_to_L
     case default ; call MOM_error(FATAL, &
       " set_rotation_beta_plane: unknown AXIS_UNITS = "//trim(axis_units))
   end select
@@ -644,8 +636,8 @@ subroutine reset_face_lengths_named(G, param_file, name, US)
 
   ! Local variables
   character(len=256) :: mesg    ! Message for error messages.
-  real :: m_to_L  ! A unit conversion factor [L m-1 ~> nondim]
-  real :: L_to_m  ! A unit conversion factor [m L-1 ~> nondim]
+  real :: m_to_L  ! A unit conversion factor [L m-1 ~> 1]
+  real :: L_to_m  ! A unit conversion factor [m L-1 ~> 1]
   real    :: dx_2 = -1.0, dy_2 = -1.0
   real    :: pi_180
   integer :: option = -1
@@ -772,8 +764,8 @@ subroutine reset_face_lengths_file(G, param_file, US)
   character(len=40)  :: mdl = "reset_face_lengths_file" ! This subroutine's name.
   character(len=256) :: mesg    ! Message for error messages.
   character(len=200) :: filename, chan_file, inputdir ! Strings for file/path
-  real :: m_to_L  ! A unit conversion factor [L m-1 ~> nondim]
-  real :: L_to_m  ! A unit conversion factor [m L-1 ~> nondim]
+  real :: m_to_L  ! A unit conversion factor [L m-1 ~> 1]
+  real :: L_to_m  ! A unit conversion factor [m L-1 ~> 1]
   integer :: i, j, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -850,8 +842,8 @@ subroutine reset_face_lengths_list(G, param_file, US)
   integer, allocatable, dimension(:) :: &
     u_line_no, v_line_no, &  ! The line numbers in lines of u- and v-face lines
     u_line_used, v_line_used ! The number of times each u- and v-line is used.
-  real    :: m_to_L       ! A unit conversion factor [L m-1 ~> nondim]
-  real    :: L_to_m       ! A unit conversion factor [m L-1 ~> nondim]
+  real    :: m_to_L       ! A unit conversion factor [L m-1 ~> 1]
+  real    :: L_to_m       ! A unit conversion factor [m L-1 ~> 1]
   real    :: lat, lon     ! The latitude and longitude of a point.
   real    :: len_lon      ! The periodic range of longitudes, usually 360 degrees.
   real    :: len_lat      ! The range of latitudes, usually 180 degrees.
@@ -1022,7 +1014,7 @@ subroutine reset_face_lengths_list(G, param_file, US)
            ((lon_p >= u_lon(1,npt)) .and. (lon_p <= u_lon(2,npt))) .or. &
            ((lon_m >= u_lon(1,npt)) .and. (lon_m <= u_lon(2,npt)))) ) then
 
-        G%dy_Cu(I,j) = G%mask2dCu(I,j) * m_to_L*min(L_to_m*G%dyCu(I,j), max(u_width(npt), 0.0))
+        G%dy_Cu(I,j) = G%mask2dCu(I,j) * min(G%dyCu(I,j), max(m_to_L*u_width(npt), 0.0))
         if (j>=G%jsc .and. j<=G%jec .and. I>=G%isc .and. I<=G%iec) then ! Limit messages/checking to compute domain
           if ( G%mask2dCu(I,j) == 0.0 )  then
             write(stdout,'(A,2F8.2,A,4F8.2,A)') "read_face_lengths_list : G%mask2dCu=0 at ",lat,lon," (",&
@@ -1052,7 +1044,7 @@ subroutine reset_face_lengths_list(G, param_file, US)
           (((lon >= v_lon(1,npt)) .and. (lon <= v_lon(2,npt))) .or. &
            ((lon_p >= v_lon(1,npt)) .and. (lon_p <= v_lon(2,npt))) .or. &
            ((lon_m >= v_lon(1,npt)) .and. (lon_m <= v_lon(2,npt)))) ) then
-        G%dx_Cv(i,J) = G%mask2dCv(i,J) * m_to_L*min(L_to_m*G%dxCv(i,J), max(v_width(npt), 0.0))
+        G%dx_Cv(i,J) = G%mask2dCv(i,J) * min(G%dxCv(i,J), max(m_to_L*v_width(npt), 0.0))
         if (i>=G%isc .and. i<=G%iec .and. J>=G%jsc .and. J<=G%jec) then ! Limit messages/checking to compute domain
           if ( G%mask2dCv(i,J) == 0.0 )  then
             write(stdout,'(A,2F8.2,A,4F8.2,A)') "read_face_lengths_list : G%mask2dCv=0 at ",lat,lon," (",&

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -641,7 +641,7 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, buoyFlux, Kt, Ks, Kv, &
 
   real :: surfFricVel, surfBuoyFlux
   real :: sigma, sigmaRatio
-  real :: buoy_scale ! A unit conversion factor for buoyancy fluxes [m2 T3 L-2 s-3 ~> nondim]
+  real :: buoy_scale ! A unit conversion factor for buoyancy fluxes [m2 T3 L-2 s-3 ~> 1]
   real :: dh    ! The local thickness used for calculating interface positions [m]
   real :: hcorr ! A cumulative correction arising from inflation of vanished layers [m]
 
@@ -948,7 +948,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   real :: zBottomMinusOffset   ! Height of bottom plus a little bit [m]
   real :: SLdepth_0d           ! Surface layer depth = surf_layer_ext*OBLdepth.
   real :: hTot                 ! Running sum of thickness used in the surface layer average [m]
-  real :: buoy_scale           ! A unit conversion factor for buoyancy fluxes [m2 T3 L-2 s-3 ~> nondim]
+  real :: buoy_scale           ! A unit conversion factor for buoyancy fluxes [m2 T3 L-2 s-3 ~> 1]
   real :: delH                 ! Thickness of a layer [m]
   real :: surfHtemp, surfTemp  ! Integral and average of temp over the surface layer
   real :: surfHsalt, surfSalt  ! Integral and average of saln over the surface layer

--- a/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
+++ b/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
@@ -1193,7 +1193,7 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
   real :: b1Kd          ! Temporary array [nondim]
   real :: ColHt_chg     ! The change in column thickness [Z ~> m].
   real :: dColHt_max    ! The change in column thickness for infinite diffusivity [Z ~> m].
-  real :: dColHt_dKd    ! The partial derivative of column thickness with Kddt_h [Z H-1 ~> 1 or m3 kg-1].
+  real :: dColHt_dKd    ! The partial derivative of column thickness with Kddt_h [Z H-1 ~> nondim or m3 kg-1]
   real :: dT_k, dT_km1  ! Temperature changes in layers k and k-1 [degC]
   real :: dS_k, dS_km1  ! Salinity changes in layers k and k-1 [ppt]
   real :: I_Kr_denom    ! Temporary array [H-2 ~> m-2 or m4 kg-2]

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -636,7 +636,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
   real :: LA        ! The value of the Langmuir number [nondim]
   real :: LAmod     ! The modified Langmuir number by convection [nondim]
   real :: hbs_here  ! The local minimum of hb_hs and MixLen_shape, times a
-                    ! conversion factor from H to Z [Z H-1 ~> 1 or m3 kg-1].
+                    ! conversion factor from H to Z [Z H-1 ~> nondim or m3 kg-1].
   real :: nstar_FC  ! The fraction of conv_PErel that can be converted to mixing [nondim].
   real :: TKE_reduc ! The fraction by which TKE and other energy fields are
                     ! reduced to support mixing [nondim]. between 0 and 1.
@@ -1634,7 +1634,7 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
   real :: b1Kd          ! Temporary array [nondim]
   real :: ColHt_chg     ! The change in column thickness [Z ~> m].
   real :: dColHt_max    ! The change in column thickness for infinite diffusivity [Z ~> m].
-  real :: dColHt_dKd    ! The partial derivative of column thickness with Kddt_h [Z H-1 ~> 1 or m3 kg-1].
+  real :: dColHt_dKd    ! The partial derivative of column thickness with Kddt_h [Z H-1 ~> nondim or m3 kg-1]
   real :: dT_k, dT_km1  ! Temperature changes in layers k and k-1 [degC]
   real :: dS_k, dS_km1  ! Salinity changes in layers k and k-1 [ppt]
   real :: I_Kr_denom    ! Temporary array [H-2 ~> m-2 or m4 kg-2]

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -502,7 +502,7 @@ subroutine geothermal_init(Time, G, GV, US, param_file, diag, CS, useALEalgorith
   ! Local variables
   character(len=200) :: inputdir, geo_file, filename, geotherm_var
   real :: geo_scale  ! A constant heat flux or dimensionally rescaled geothermal flux scaling factor
-                     ! [Q R Z T-1 ~> W m-2] or [Q R Z m2 s J-1 T-1 ~> 1]
+                     ! [Q R Z T-1 ~> W m-2] or [Q R Z m2 s J-1 T-1 ~> nondim]
   integer :: i, j, isd, ied, jsd, jed, id
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -177,7 +177,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS)
                            ! Rho0 divided by G_Earth and the conversion
                            ! from m to thickness units [H R ~> kg m-2 or kg2 m-5].
   real :: cdrag_sqrt_Z     ! Square root of the drag coefficient, times a unit conversion
-                           ! factor from lateral lengths to vertical depths [Z L-1 ~> 1].
+                           ! factor from lateral lengths to vertical depths [Z L-1 ~> nondim].
   real :: cdrag_sqrt       ! Square root of the drag coefficient [nondim].
   real :: oldfn            ! The integrated energy required to
                            ! entrain up to the bottom of the layer,
@@ -256,7 +256,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS)
   real :: Cell_width       ! The transverse width of the velocity cell [L ~> m].
   real :: Rayleigh         ! A nondimensional value that is multiplied by the layer's
                            ! velocity magnitude to give the Rayleigh drag velocity, times
-                           ! a lateral to vertical distance conversion factor [Z L-1 ~> 1].
+                           ! a lateral to vertical distance conversion factor [Z L-1 ~> nondim].
   real :: gam              ! The ratio of the change in the open interface width
                            ! to the open interface width atop a cell [nondim].
   real :: BBL_frac         ! The fraction of a layer's drag that goes into the
@@ -947,10 +947,10 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS)
           ! set kv_bbl to the bound and recompute bbl_thick to be consistent
           ! but with a ridiculously large upper bound on thickness (for Cd u*=0)
           kv_bbl = CS%Kv_BBL_min
-          if (cdrag_sqrt*ustar(i)*BBL_visc_frac*G%Rad_Earth*US%m_to_Z > kv_bbl) then
+          if (cdrag_sqrt*ustar(i)*BBL_visc_frac*G%Rad_Earth_L*US%L_to_Z > kv_bbl) then
             bbl_thick_Z = kv_bbl / ( cdrag_sqrt*ustar(i)*BBL_visc_frac )
           else
-            bbl_thick_Z = G%Rad_Earth * US%m_to_Z
+            bbl_thick_Z = G%Rad_Earth_L * US%L_to_Z
           endif
         else
           kv_bbl = cdrag_sqrt*ustar(i)*bbl_thick_Z*BBL_visc_frac
@@ -979,10 +979,10 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS)
           ! set kv_bbl to the bound and recompute bbl_thick to be consistent
           ! but with a ridiculously large upper bound on thickness (for Cd u*=0)
           kv_bbl = CS%Kv_BBL_min
-          if (cdrag_sqrt*ustar(i)*G%Rad_Earth*US%m_to_Z > kv_bbl) then
+          if (cdrag_sqrt*ustar(i)*G%Rad_Earth_L*US%L_to_Z > kv_bbl) then
             bbl_thick_Z = kv_bbl / ( cdrag_sqrt*ustar(i) )
           else
-            bbl_thick_Z = G%Rad_Earth * US%m_to_Z
+            bbl_thick_Z = G%Rad_Earth_L * US%L_to_Z
           endif
         else
           kv_bbl = cdrag_sqrt*ustar(i)*bbl_thick_Z
@@ -1214,7 +1214,7 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS)
                       ! Rho0 divided by G_Earth and the conversion
                       ! from m to thickness units [H R ~> kg m-2 or kg2 m-5].
   real :: cdrag_sqrt_Z  ! Square root of the drag coefficient, times a unit conversion
-                      ! factor from lateral lengths to vertical depths [Z L-1 ~> 1].
+                      ! factor from lateral lengths to vertical depths [Z L-1 ~> nondim]
   real :: cdrag_sqrt  ! Square root of the drag coefficient [nondim].
   real :: oldfn       ! The integrated energy required to
                       ! entrain up to the bottom of the layer,

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -310,7 +310,7 @@ subroutine tracer_flow_control_init(restart, day, G, GV, US, h, param_file, diag
 
 !  Add other user-provided calls here.
   if (CS%use_USER_tracer_example) &
-    call USER_initialize_tracer(restart, day, G, GV, h, diag, OBC, CS%USER_tracer_example_CSp, &
+    call USER_initialize_tracer(restart, day, G, GV, US, h, diag, OBC, CS%USER_tracer_example_CSp, &
                                 sponge_CSp)
   if (CS%use_DOME_tracer) &
     call initialize_DOME_tracer(restart, day, G, GV, US, h, diag, OBC, CS%DOME_tracer_CSp, &


### PR DESCRIPTION
  Add a dimensionally rescaled variable with the radius of the Earth in [L ~> m]
to the ocean_grid_type and dyn_hor_grid type to expand dimensional consistency
testing.  For now it exists along-side the previous variable with the radius of
the Earth in [m], which might be used in other drivers or user code that we are
not aware of.  All instances in the MOM6 code that were using the unscaled
variable G%Rad_Earth were changed to use the dimensionally scaled variable
G%Rad_Earth_L.  In addition, the code for setting up the grid metrics was
simplfied by completing the dimensional rescaling of its internal variables
and some grid rescaling factors that were no longer in use were eliminated.
As a part of this change, a unit_scale_type argument was added to the interface
for USER_initialize_tracer.

  In addition, a number of comments were changed to clearly distinguish between
dimensionally scaled variables that scale back to a nondimensional variable that
can take on a range of values (using the syntax [... ~> nondim]), as opposed to
variables that are only a combination of dimensional scaling factors that
resolve back to 1 in MKS units (using the syntax [... ~> 1]).

  All answers are bitwise identical, but there is one minor interface change
and there are new elements in several widely used transparent types.