### PR TITLE
Code cleanup in drivers/solo_driver forcing files

### DIFF
--- a/config_src/drivers/solo_driver/MESO_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MESO_surface_forcing.F90
@@ -31,7 +31,7 @@ type, public :: MESO_surface_forcing_CS ; private
   real :: G_Earth            !< The gravitational acceleration [L2 Z-1 T-2 ~> m s-2].
   real :: Flux_const         !< The restoring rate at the surface [Z T-1 ~> m s-1].
   real :: gust_const         !< A constant unresolved background gustiness
-                             !! that contributes to ustar [Pa].
+                             !! that contributes to ustar [R L Z T-1 ~> Pa]
   real, dimension(:,:), pointer :: &
     T_Restore(:,:) => NULL(), & !< The temperature to restore the SST toward [degC].
     S_Restore(:,:) => NULL(), & !< The salinity to restore the sea surface salnity toward [ppt]
@@ -138,7 +138,7 @@ subroutine MESO_buoyancy_forcing(sfc_state, fluxes, day, dt, G, US, CS)
     ! Set whichever fluxes are to be used here.  Any fluxes that
     ! are always zero do not need to be changed here.
     do j=js,je ; do i=is,ie
-      ! Fluxes of fresh water through the surface are in units of [kg m-2 s-1]
+      ! Fluxes of fresh water through the surface are in units of [R Z T-1 ~> kg m-2 s-1]
       ! and are positive downward - i.e. evaporation should be negative.
       fluxes%evap(i,j) = -0.0 * G%mask2dT(i,j)
       fluxes%lprec(i,j) =  CS%PmE(i,j) * CS%Rho0 * G%mask2dT(i,j)

--- a/config_src/drivers/solo_driver/user_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/user_surface_forcing.F90
@@ -27,7 +27,7 @@ public USER_wind_forcing, USER_buoyancy_forcing, USER_surface_forcing_init
 !! It can be readily modified for a specific case, and because it is private there
 !! will be no changes needed in other code (although they will have to be recompiled).
 type, public :: user_surface_forcing_CS ; private
-  !   The variables in the cannonical example are used for some common
+  !   The variables in the canonical example are used for some common
   ! cases, but do not need to be used.
 
   logical :: use_temperature !< If true, temperature and salinity are used as state variables.
@@ -221,7 +221,7 @@ subroutine USER_buoyancy_forcing(sfc_state, fluxes, day, dt, G, US, CS)
       buoy_rest_const = -1.0 * (CS%G_Earth * CS%Flux_const) / CS%Rho0
       do j=js,je ; do i=is,ie
        !   Set density_restore to an expression for the surface potential
-       ! density [kg m-3] that is being restored toward.
+       ! density [R ~> kg m-3] that is being restored toward.
         density_restore = 1030.0*US%kg_m3_to_R
 
         fluxes%buoy(i,j) = G%mask2dT(i,j) * buoy_rest_const * &


### PR DESCRIPTION
Code cleanup in the drivers/FMS_cap directory forcing files, including:

-   Rescaled several internal wind stress variables in the control structure for solo_driver/MOM_surface_forcing.F90 for improved dimensional consistency testing.
-   Added the variable Pa_to_RLZ_T2 to help clarify the conversion factors being applied to several hard-coded constant stresses.  These hard-coded constant wind stress magnitudes should be replaced with variables in wind_forcing_2gyre(), wind_forcing_1gyre() and Neverworld_wind_forcing() but this needs to be done carefully to avoid breaking existing solutions.
-   Removed or commented out unused variables, as appropriate.
-   Corrected or added documented units
-   Added comments describing all real variables in this directory.
-   Fixed spelling errors in several comments.

All answers and output are bitwise identical.