### PR TITLE
+Rename G%Rad_Earth in grid types

### DIFF
--- a/config_src/drivers/mct_cap/ocn_comp_mct.F90
+++ b/config_src/drivers/mct_cap/ocn_comp_mct.F90
@@ -722,7 +722,7 @@ subroutine ocn_domain_mct( lsize, gsMap_ocn, dom_ocn)
   call mct_gGrid_importRattr(dom_ocn,"lat",data,lsize)
 
   k = 0
-  L2_to_rad2 = grid%US%L_to_m**2 / grid%Rad_Earth**2
+  L2_to_rad2 = 1.0 / grid%Rad_Earth_L**2
   do j = grid%jsc, grid%jec
     do i = grid%isc, grid%iec
       k = k + 1 ! Increment position within gindex

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -1111,7 +1111,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
            k = k + 1 ! Increment position within gindex
            if (mask(k) /= 0) then
               mesh_areas(k) = dataPtr_mesh_areas(k)
-              model_areas(k) = ocean_grid%US%L_to_m**2 * ocean_grid%AreaT(i,j) / ocean_grid%Rad_Earth**2
+              model_areas(k) = ocean_grid%AreaT(i,j) / ocean_grid%Rad_Earth_L**2
               mod2med_areacor(k) = model_areas(k) / mesh_areas(k)
               med2mod_areacor(k) = mesh_areas(k) / model_areas(k)
            end if

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -183,7 +183,7 @@ type, public :: ocean_grid_type
   real :: west_lon      !< The longitude (or x-coordinate) of the first u-line
   real :: len_lat       !< The latitudinal (or y-coord) extent of physical domain
   real :: len_lon       !< The longitudinal (or x-coord) extent of physical domain
-  real :: Rad_Earth     !< The radius of the planet [m]
+  real :: Rad_Earth_mks !< The radius of the planet in mks units [m]
   real :: Rad_Earth_L   !< The radius of the planet in rescaled units [L ~> m]
   real :: max_depth     !< The maximum depth of the ocean in depth units [Z ~> m]
 end type ocean_grid_type

--- a/src/core/MOM_transcribe_grid.F90
+++ b/src/core/MOM_transcribe_grid.F90
@@ -134,7 +134,7 @@ subroutine copy_dyngrid_to_MOM_grid(dG, oG, US)
   oG%areaT_global = dG%areaT_global ; oG%IareaT_global = dG%IareaT_global
   oG%south_lat = dG%south_lat ; oG%west_lon  = dG%west_lon
   oG%len_lat = dG%len_lat ; oG%len_lon = dG%len_lon
-  oG%Rad_Earth = dG%Rad_Earth ; oG%Rad_Earth_L = dG%Rad_Earth_L
+  oG%Rad_Earth_L = dG%Rad_Earth_L ; oG%Rad_Earth_mks = dG%Rad_Earth_mks
   oG%max_depth = dG%max_depth
 
 ! Update the halos in case the dynamic grid has smaller halos than the ocean grid.
@@ -289,7 +289,7 @@ subroutine copy_MOM_grid_to_dyngrid(oG, dG, US)
   dG%areaT_global = oG%areaT_global ; dG%IareaT_global = oG%IareaT_global
   dG%south_lat = oG%south_lat ; dG%west_lon  = oG%west_lon
   dG%len_lat = oG%len_lat ; dG%len_lon = oG%len_lon
-  dG%Rad_Earth = oG%Rad_Earth ; dG%Rad_Earth_L = oG%Rad_Earth_L
+  dG%Rad_Earth_L = oG%Rad_Earth_L ; dG%Rad_Earth_mks = oG%Rad_Earth_mks
   dG%max_depth = oG%max_depth
 
 ! Update the halos in case the dynamic grid has smaller halos than the ocean grid.

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -175,7 +175,7 @@ type, public :: dyn_horgrid_type
   real :: west_lon      !< The longitude (or x-coordinate) of the first u-line
   real :: len_lat       !< The latitudinal (or y-coord) extent of physical domain
   real :: len_lon       !< The longitudinal (or x-coord) extent of physical domain
-  real :: Rad_Earth     !< The radius of the planet [m]
+  real :: Rad_Earth_mks !< The radius of the planet in mks units [m]
   real :: Rad_Earth_L   !< The radius of the planet in rescaled units [L ~> m]
   real :: max_depth     !< The maximum depth of the ocean [Z ~> m]
 end type dyn_horgrid_type
@@ -388,7 +388,7 @@ subroutine rotate_dyn_horgrid(G_in, G, US, turns)
   ! Rotation-invariant fields
   G%areaT_global = G_in%areaT_global
   G%IareaT_global = G_in%IareaT_global
-  G%Rad_Earth = G_in%Rad_Earth
+  G%Rad_Earth_mks = G_in%Rad_Earth_mks
   G%Rad_Earth_L = G_in%Rad_Earth_L
   G%max_depth = G_in%max_depth
 

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -102,13 +102,13 @@ subroutine set_grid_metrics(G, param_file, US)
   end select
   if (G%Rad_Earth_L <= 0.0) then
     ! The grid metrics were set with an option that does not explicitly initialize Rad_Earth.
-    ! ### Rad_Earth should be read as in:
+    ! ### Rad_Earth_L should be read as in:
     !   call get_param(param_file, mdl, "RAD_EARTH", G%Rad_Earth_L, &
     !               "The radius of the Earth.", units="m", default=6.378e6, scale=m_to_L)
     ! but for now it is being set via a hard-coded value to reproduce current behavior.
     G%Rad_Earth_L = 6.378e6*m_to_L
   endif
-  G%Rad_Earth = L_to_m*G%Rad_Earth_L
+  G%Rad_Earth_mks = L_to_m*G%Rad_Earth_L
 
   ! Calculate derived metrics (i.e. reciprocals and products)
   call callTree_enter("set_derived_metrics(), MOM_grid_initialize.F90")


### PR DESCRIPTION
  Renamed G%Rad_Earth to G%Rad_Earth_mks in both the ocean_grid_type and the
dyn_horgrid_type to deliberately cause any code using these variables instead of
G%Rad_Earth_L to fail to compile as a step toward eliminating the un-scaled
variable.  Also modified the two places where the mct and NUOPC drivers were
using G%Rad_Earth to instead use G%Rad_Earth_L.  Were it not for the fact that
there could be code that is using this variable that is not visible to the main
branch of MOM6, this variable would have been simply eliminated.  All answers
are bitwise identical, but there is a deliberate change to an element in two
important transparent types.