### PR TITLE
Bugfix: cpu clock sync error

### DIFF
--- a/config_src/infra/FMS1/MOM_cpu_clock_infra.F90
+++ b/config_src/infra/FMS1/MOM_cpu_clock_infra.F90
@@ -85,8 +85,13 @@ integer function cpu_clock_id(name, sync, grain)
   integer :: clock_flags
 
   clock_flags = clock_flag_default
-  if (present(sync)) &
-    clock_flags = ibset(clock_flags, 0)
+  if (present(sync)) then
+    if (sync) then
+      clock_flags = ibset(clock_flags, 0)
+    else
+      clock_flags = ibclr(clock_flags, 0)
+    endif
+  endif
 
   cpu_clock_id = mpp_clock_id(name, flags=clock_flags, grain=grain)
 end function cpu_clock_id

--- a/config_src/infra/FMS2/MOM_cpu_clock_infra.F90
+++ b/config_src/infra/FMS2/MOM_cpu_clock_infra.F90
@@ -85,8 +85,13 @@ integer function cpu_clock_id(name, sync, grain)
   integer :: clock_flags
 
   clock_flags = clock_flag_default
-  if (present(sync)) &
-    clock_flags = ibset(clock_flags, 0)
+  if (present(sync)) then
+    if (sync) then
+      clock_flags = ibset(clock_flags, 0)
+    else
+      clock_flags = ibclr(clock_flags, 0)
+    endif
+  endif
 
   cpu_clock_id = mpp_clock_id(name, flags=clock_flags, grain=grain)
 end function cpu_clock_id


### PR DESCRIPTION
This patch fixes an error in the `sync` flag of the cpu clocks.

Previously, we would set the sync bit of a flag based on the presence of
sync, rather than testing if the value was true.  This would cause
potential hangs in any clock that set `sync`, including `.false.`.

This patch correctly replaces the single `ibset` call with an if-block
to either `ibset` or `ibclr`.