### PR TITLE
Fixes an uninitialized logical in FMS_cap

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -1461,6 +1461,8 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
     call get_param(param_file, mdl, "SPEAR_ECDA_SST_RESTORE_TFREEZE", CS%trestore_SPEAR_ECDA, &
                  "If true, modify SST restoring field using SSS state. This only modifies the "//&
                  "restoring data that is within 0.0001degC of -1.8degC.", default=.false.)
+  else
+    CS%trestore_SPEAR_ECDA = .false. ! Needed to toggle logging of SPEAR_DTFREEZE_DS
   endif
   call get_param(param_file, mdl, "SPEAR_DTFREEZE_DS", CS%SPEAR_dTf_dS, &
                  "The derivative of the freezing temperature with salinity.", &


### PR DESCRIPTION
- A do_not_log depends on a logical that is only set conditionally. This initializes that logical when the corresponding parameter is not being read.
- Unfortunately, this change MOM_parameter_doc.all for the coupled models. The .all pipeline uses the gnu compiler which was initializing this logical as .true. and thus logging the new parameter when it should not have been. Intel and PGI were initializing with .false.