### PR TITLE
Fix backscatter divide by zero

### DIFF
--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1308,8 +1308,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
           if (Kh(i,j) >= hrat_min(i,j) * CS%Kh_Max_xy(I,J)) then
             visc_bound_rem(i,j) = 0.0
             Kh(i,j) = hrat_min(i,j) * CS%Kh_Max_xy(I,J)
-          elseif (CS%Kh_Max_xy(I,J)>0.) then
             visc_bound_rem(i,j) = 1.0 - Kh(i,j) / (hrat_min(i,j) * CS%Kh_Max_xy(I,J))
+          elseif (hrat_min(I,J)*CS%Kh_Max_xy(I,J)>0.) then
           endif
         endif
 


### PR DESCRIPTION
A bug fix and an associated cleanup:
- Commit f7fd4e4c7f79265 addresses a divide by zero encountered by @ElizabethYankovsky in the NeverWorld2 configuration while trying to use back-scatter.
- Commit fc3e3ac4df430b1 cleans up the capitalization of indices to follow https://mom6.readthedocs.io/en/dev-gfdl/api/generated/pages/Horizontal_Indexing.html#soft-convention-for-loop-variables

One question for @Hallberg-NOAA : could we ever encounter a divide by zero indicated by comment at top of fc3e3ac4df430b1 ?