### PR TITLE
bugfix: static h_new shape remaining_transport_sum

### DIFF
--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -599,7 +599,7 @@ real function remaining_transport_sum(G, GV, US, uhtr, vhtr, h_new)
                               intent(in   ) :: uhtr  !< Zonal mass transport [H L2 ~> m3 or kg]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
                               intent(in   ) :: vhtr  !< Meridional mass transport [H L2 ~> m3 or kg]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                               intent(in   ) :: h_new !< Layer thicknesses [H ~> m or kg m-2]
 
   ! Local variables


### PR DESCRIPTION
This patch redefines `h_new` to match the shape of a center-point rather
than a v-face point.

Dynamic memory builds would have been unaffected by this, and older GCC
(~7.3.0) compilers appear to have not objected to the shape mismatch,
but this raised an error in newer GCCs (~9.3.0).

~This should not affect answers, since the loops never strayed into these
redundant undefined regions.~