### PR TITLE
+Stop logging NEW_SPONGES

### DIFF
--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -93,6 +93,9 @@ subroutine find_obsolete_params(param_file)
   call obsolete_real(param_file, "MIN_Z_DIAG_INTERVAL")
   call obsolete_char(param_file, "Z_OUTPUT_GRID_FILE")
 
+  ! This parameter is on the to-do list to be obsoleted.
+  ! call obsolete_logical(param_file, "NEW_SPONGES", hint="Use INTERPOLATE_SPONGE_TIME_SPACE instead.")
+
   ! Write the file version number to the model log.
   call log_version(param_file, mdl, version)
 


### PR DESCRIPTION
  Stop logging the deprecated run-time parameter NEW_SPONGES, and always log
INTERPOLATE_SPONGE_TIME_SPACE as if NEW_SPONGES were not used.  This commit will
address MOM6 issue #46, which can be closed it is accepted.  This will change
the MOM_parameter_doc entries in some cases, but all answers are bitwise
identical.