### PR TITLE
fix bug in wave_speeds when openmp is on

### DIFF
--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -759,7 +759,7 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos)
   min_h_frac = tol_Hfrac / real(nz)
   !$OMP parallel do default(private) shared(is,ie,js,je,nz,h,G,GV,US,min_h_frac,use_EOS,T,S, &
   !$OMP                                     Z_to_pres,tv,cn,g_Rho0,nmodes,cg1_min2,better_est, &
-  !$OMP                                     c1_thresh,tol_solve,tol_merge)
+  !$OMP                                     c1_thresh,tol_solve,tol_merge,c2_scale)
   do j=js,je
     !   First merge very thin layers with the one above (or below if they are
     ! at the top).  This also transposes the row order so that columns can


### PR DESCRIPTION
`c2_scale` was missing in the list of shared variables hence inducing the generation of spurious values in cn1 when internal_tides are active and openmp is used in the OM4 configuration:

![prodopenmp_cn](https://user-images.githubusercontent.com/14662821/158046734-775e919b-10a8-4bcd-a864-6d591ceae7dc.png)

solutions are now bitwise identical between openmp and non-openmp OM4 runs.
