### PR TITLE
MOM6: +(*)Write unscaled restart files.

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -972,9 +972,10 @@ end subroutine step_MOM_dyn_split_RK2
 !> This subroutine sets up any auxiliary restart variables that are specific
 !! to the split-explicit time stepping scheme.  All variables registered here should
 !! have the ability to be recreated if they are not present in a restart file.
-subroutine register_restarts_dyn_split_RK2(HI, GV, param_file, CS, restart_CS, uh, vh)
+subroutine register_restarts_dyn_split_RK2(HI, GV, US, param_file, CS, restart_CS, uh, vh)
   type(hor_index_type),          intent(in)    :: HI         !< Horizontal index structure
   type(verticalGrid_type),       intent(in)    :: GV         !< ocean vertical grid structure
+  type(unit_scale_type),         intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),         intent(in)    :: param_file !< parameter file
   type(MOM_dyn_split_RK2_CS),    pointer       :: CS         !< module control structure
   type(MOM_restart_CS),          intent(inout) :: restart_CS !< MOM restart control structure
@@ -1016,29 +1017,32 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, param_file, CS, restart_CS, u
   flux_units = get_flux_units(GV)
 
   if (GV%Boussinesq) then
-    vd(1) = var_desc("sfc",thickness_units,"Free surface Height",'h','1')
+    call register_restart_field(CS%eta, "sfc", .false., restart_CS, &
+             longname="Free surface Height", units=thickness_units, conversion=GV%H_to_mks)
   else
-    vd(1) = var_desc("p_bot",thickness_units,"Bottom Pressure",'h','1')
+    call register_restart_field(CS%eta, "p_bot", .false., restart_CS, &
+             longname="Bottom Pressure", units=thickness_units, conversion=GV%H_to_mks)
   endif
-  call register_restart_field(CS%eta, vd(1), .false., restart_CS)
 
-  vd(1) = var_desc("u2","m s-1","Auxiliary Zonal velocity",'u','L')
-  vd(2) = var_desc("v2","m s-1","Auxiliary Meridional velocity",'v','L')
-  call register_restart_pair(CS%u_av, CS%v_av, vd(1), vd(2), .false., restart_CS)
+  vd(1) = var_desc("u2", "m s-1", "Auxiliary Zonal velocity", 'u', 'L')
+  vd(2) = var_desc("v2", "m s-1", "Auxiliary Meridional velocity", 'v', 'L')
+  call register_restart_pair(CS%u_av, CS%v_av, vd(1), vd(2), .false., restart_CS, &
+                             conversion=US%L_T_to_m_s)
 
-  vd(1) = var_desc("h2",thickness_units,"Auxiliary Layer Thickness",'h','L')
-  call register_restart_field(CS%h_av, vd(1), .false., restart_CS)
+  call register_restart_field(CS%h_av, "h2", .false., restart_CS, &
+           longname="Auxiliary Layer Thickness", units=thickness_units, conversion=GV%H_to_mks)
 
-  vd(1) = var_desc("uh",flux_units,"Zonal thickness flux",'u','L')
-  vd(2) = var_desc("vh",flux_units,"Meridional thickness flux",'v','L')
-  call register_restart_pair(uh, vh, vd(1), vd(2), .false., restart_CS)
+  vd(1) = var_desc("uh", flux_units, "Zonal thickness flux", 'u', 'L')
+  vd(2) = var_desc("vh", flux_units, "Meridional thickness flux", 'v', 'L')
+  call register_restart_pair(uh, vh, vd(1), vd(2), .false., restart_CS, &
+                             conversion=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
 
-  vd(1) = var_desc("diffu","m s-2","Zonal horizontal viscous acceleration",'u','L')
-  vd(2) = var_desc("diffv","m s-2","Meridional horizontal viscous acceleration",'v','L')
-  call register_restart_pair(CS%diffu, CS%diffv, vd(1), vd(2), .false., restart_CS)
+  vd(1) = var_desc("diffu", "m s-2", "Zonal horizontal viscous acceleration", 'u', 'L')
+  vd(2) = var_desc("diffv", "m s-2", "Meridional horizontal viscous acceleration", 'v', 'L')
+  call register_restart_pair(CS%diffu, CS%diffv, vd(1), vd(2), .false., restart_CS, &
+                             conversion=US%L_T2_to_m_s2)
 
-  call register_barotropic_restarts(HI, GV, param_file, CS%barotropic_CSp, &
-                                    restart_CS)
+  call register_barotropic_restarts(HI, GV, US, param_file, CS%barotropic_CSp, restart_CS)
 
 end subroutine register_restarts_dyn_split_RK2
 
@@ -1238,8 +1242,8 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
     do k=1,nz ; do j=js,je ; do i=is,ie
       CS%eta(i,j) = CS%eta(i,j) + h(i,j,k)
     enddo ; enddo ; enddo
-  elseif ((GV%m_to_H_restart /= 0.0) .and. (GV%m_to_H_restart /= GV%m_to_H)) then
-    H_rescale = GV%m_to_H / GV%m_to_H_restart
+  elseif ((GV%m_to_H_restart /= 0.0) .and. (GV%m_to_H_restart /= 1.0)) then
+    H_rescale = 1.0 / GV%m_to_H_restart
     do j=js,je ; do i=is,ie ; CS%eta(i,j) = H_rescale * CS%eta(i,j) ; enddo ; enddo
   endif
   ! Copy eta into an output array.
@@ -1251,14 +1255,12 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
 
   if (.not. query_initialized(CS%diffu,"diffu",restart_CS) .or. &
       .not. query_initialized(CS%diffv,"diffv",restart_CS)) then
-    call horizontal_viscosity(u, v, h, CS%diffu, CS%diffv, MEKE, VarMix, &
-                              G, GV, US, CS%hor_visc, &
-                              OBC=CS%OBC, BT=CS%barotropic_CSp, &
-                              TD=thickness_diffuse_CSp)
+    call horizontal_viscosity(u, v, h, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
+                              OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp)
   else
     if ( (US%s_to_T_restart * US%m_to_L_restart /= 0.0) .and. &
-         (US%m_to_L * US%s_to_T_restart**2 /= US%m_to_L_restart * US%s_to_T**2) ) then
-      accel_rescale = (US%m_to_L * US%s_to_T_restart**2) / (US%m_to_L_restart * US%s_to_T**2)
+         (US%s_to_T_restart**2 /= US%m_to_L_restart) ) then
+      accel_rescale = US%s_to_T_restart**2 / US%m_to_L_restart
       do k=1,nz ; do j=js,je ; do I=G%IscB,G%IecB
         CS%diffu(I,j,k) = accel_rescale * CS%diffu(I,j,k)
       enddo ; enddo ; enddo
@@ -1273,8 +1275,8 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
     do k=1,nz ; do j=jsd,jed ; do I=IsdB,IedB ; CS%u_av(I,j,k) = u(I,j,k) ; enddo ; enddo ; enddo
     do k=1,nz ; do J=JsdB,JedB ; do i=isd,ied ; CS%v_av(i,J,k) = v(i,J,k) ; enddo ; enddo ; enddo
   elseif ( (US%s_to_T_restart * US%m_to_L_restart /= 0.0) .and. &
-         ((US%m_to_L * US%s_to_T_restart) /= (US%m_to_L_restart * US%s_to_T)) ) then
-    vel_rescale = (US%m_to_L * US%s_to_T_restart) /  (US%m_to_L_restart * US%s_to_T)
+           (US%s_to_T_restart /= US%m_to_L_restart) ) then
+    vel_rescale = US%s_to_T_restart / US%m_to_L_restart
     do k=1,nz ; do j=jsd,jed ; do I=IsdB,IedB ; CS%u_av(I,j,k) = vel_rescale * CS%u_av(I,j,k) ; enddo ; enddo ; enddo
     do k=1,nz ; do J=JsdB,JedB ; do i=isd,ied ; CS%v_av(i,J,k) = vel_rescale * CS%v_av(i,J,k) ; enddo ; enddo ; enddo
   endif
@@ -1291,15 +1293,13 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
   else
     if (.not. query_initialized(CS%h_av,"h2",restart_CS)) then
       CS%h_av(:,:,:) = h(:,:,:)
-    elseif ((GV%m_to_H_restart /= 0.0) .and. (GV%m_to_H_restart /= GV%m_to_H)) then
-      H_rescale = GV%m_to_H / GV%m_to_H_restart
+    elseif ((GV%m_to_H_restart /= 0.0) .and. (GV%m_to_H_restart /= 1.0)) then
+      H_rescale = 1.0 / GV%m_to_H_restart
       do k=1,nz ; do j=js,je ; do i=is,ie ; CS%h_av(i,j,k) = H_rescale * CS%h_av(i,j,k) ; enddo ; enddo ; enddo
     endif
     if ( (GV%m_to_H_restart * US%s_to_T_restart * US%m_to_L_restart /= 0.0) .and. &
-         ((GV%m_to_H * US%m_to_L**2 * US%s_to_T_restart) /= &
-          (GV%m_to_H_restart * US%m_to_L_restart**2 * US%s_to_T)) ) then
-      uH_rescale = (GV%m_to_H * US%m_to_L**2 * US%s_to_T_restart) / &
-                   (GV%m_to_H_restart * US%m_to_L_restart**2 * US%s_to_T)
+         (US%s_to_T_restart /= (GV%m_to_H_restart * US%m_to_L_restart**2)) ) then
+      uH_rescale = US%s_to_T_restart / (GV%m_to_H_restart * US%m_to_L_restart**2)
       do k=1,nz ; do j=js,je ; do I=G%IscB,G%IecB ; uh(I,j,k) = uH_rescale * uh(I,j,k) ; enddo ; enddo ; enddo
       do k=1,nz ; do J=G%JscB,G%JecB ; do i=is,ie ; vh(i,J,k) = uH_rescale * vh(i,J,k) ; enddo ; enddo ; enddo
     endif

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -188,10 +188,17 @@ subroutine verticalGridInit( param_file, GV, US )
 end subroutine verticalGridInit
 
 !> Set the scaling factors for restart files to the scaling factors for this run.
-subroutine fix_restart_scaling(GV)
+subroutine fix_restart_scaling(GV, unscaled)
   type(verticalGrid_type), intent(inout) :: GV   !< The ocean's vertical grid structure
+  logical,       optional, intent(in)    :: unscaled !< If true, set the restart factors as though the
+                                             !! model would be unscaled, which is appropriate if the
+                                             !! scaling is undone when writing a restart file.
 
   GV%m_to_H_restart = GV%m_to_H
+  if (present(unscaled)) then ; if (unscaled) then
+    GV%m_to_H_restart = 1.0
+  endif ; endif
+
 end subroutine fix_restart_scaling
 
 !> Returns the model's thickness units, usually m or kg/m^2.

--- a/src/framework/MOM_unit_scaling.F90
+++ b/src/framework/MOM_unit_scaling.F90
@@ -196,14 +196,25 @@ end subroutine set_unit_scaling_combos
 
 !> Set the unit scaling factors for output to restart files to the unit scaling
 !! factors for this run.
-subroutine fix_restart_unit_scaling(US)
+subroutine fix_restart_unit_scaling(US, unscaled)
   type(unit_scale_type), intent(inout) :: US !< A dimensional unit scaling type
+  logical,     optional, intent(in)    :: unscaled !< If true, set the restart factors as though the
+                                             !! model would be unscaled, which is appropriate if the
+                                             !! scaling is undone when writing a restart file.
 
   US%m_to_Z_restart = US%m_to_Z
   US%m_to_L_restart = US%m_to_L
   US%s_to_T_restart = US%s_to_T
   US%kg_m3_to_R_restart = US%kg_m3_to_R
   US%J_kg_to_Q_restart = US%J_kg_to_Q
+
+  if (present(unscaled)) then ; if (unscaled) then
+    US%m_to_Z_restart = 1.0
+    US%m_to_L_restart = 1.0
+    US%s_to_T_restart = 1.0
+    US%kg_m3_to_R_restart = 1.0
+    US%J_kg_to_Q_restart = 1.0
+  endif ; endif
 
 end subroutine fix_restart_unit_scaling
 

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -309,7 +309,7 @@ subroutine initialize_ice_shelf_boundary_channel(u_face_mask_bdry, v_face_mask_b
                           intent(inout) :: hmask !< A mask indicating which tracer points are
                                               !! partly or fully covered by an ice-shelf
    real, dimension(SZDI_(G),SZDJ_(G)), &
-                          intent(inout) :: h_shelf !< Ice-shelf thickness
+                          intent(inout) :: h_shelf !< Ice-shelf thickness [Z ~> m]
    type(unit_scale_type), intent(in)    :: US !< A structure containing unit conversion factors
    type(param_file_type), intent(in)    :: PF !< A structure to parse for run-time parameters
 
@@ -330,7 +330,7 @@ subroutine initialize_ice_shelf_boundary_channel(u_face_mask_bdry, v_face_mask_b
 
    call get_param(PF, mdl, "INPUT_VEL_ICE_SHELF", input_vel, &
                   "inflow ice velocity at upstream boundary", &
-                  units="m s-1", default=0., scale=US%m_s_to_L_T*US%m_to_Z)
+                  units="m s-1", default=0., scale=US%m_s_to_L_T*US%m_to_Z) !### This conversion factor is wrong?
    call get_param(PF, mdl, "INPUT_THICK_ICE_SHELF", input_thick, &
                   "flux thickness at upstream boundary", &
                   units="m", default=1000., scale=US%m_to_Z)
@@ -409,7 +409,7 @@ subroutine initialize_ice_flow_from_file(bed_elev,u_shelf, v_shelf,float_cond,&
 
   real, dimension(SZDI_(G),SZDJ_(G)), &
                          intent(inout)    :: float_cond !< An array indicating where the ice
-                                                !! shelf is floating: 0 if floating, 1 if not.
+                                                !! shelf is floating: 0 if floating, 1 if not. [nondim]
 !  real, dimension(SZDI_(G),SZDJ_(G)), &
 !                         intent(in) :: hmask !< A mask indicating which tracer points are
                                              !! partly or fully covered by an ice-shelf
@@ -461,13 +461,14 @@ subroutine initialize_ice_flow_from_file(bed_elev,u_shelf, v_shelf,float_cond,&
 
   floatfr_varname = "float_frac"
 
- call MOM_read_data(filename, trim(ushelf_varname), u_shelf, G%Domain, position=CORNER,scale=1.0)
- call MOM_read_data(filename,trim(vshelf_varname), v_shelf, G%Domain, position=CORNER,scale=1.0)
-! call MOM_read_data(filename,trim(ice_visc_varname), ice_visc, G%Domain,position=CORNER,scale=1.0)
- call MOM_read_data(filename,trim(floatfr_varname), float_cond, G%Domain, scale=1.)
+  !### I think that the following two lines should have ..., scale=US%m_s_to_L_T
+  call MOM_read_data(filename, trim(ushelf_varname), u_shelf, G%Domain, position=CORNER, scale=1.0)
+  call MOM_read_data(filename, trim(vshelf_varname), v_shelf, G%Domain, position=CORNER, scale=1.0)
+! call MOM_read_data(filename, trim(ice_visc_varname), ice_visc, G%Domain,position=CORNER,scale=1.0)
+  call MOM_read_data(filename, trim(floatfr_varname), float_cond, G%Domain, scale=1.)
 
- filename = trim(inputdir)//trim(bed_topo_file)
- call MOM_read_data(filename,trim(bed_varname), bed_elev, G%Domain, scale=1.)
+  filename = trim(inputdir)//trim(bed_topo_file)
+  call MOM_read_data(filename,trim(bed_varname), bed_elev, G%Domain, scale=1.)
 !  isc = G%isc ; jsc = G%jsc ; iec = G%iec ; jec = G%jec
 
 
@@ -480,18 +481,19 @@ subroutine initialize_ice_shelf_boundary_from_file(u_face_mask_bdry, v_face_mask
 
    type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
    real, dimension(SZIB_(G),SZJB_(G)), &
-                          intent(inout) :: u_face_mask_bdry !< A boundary-type mask at B-grid u faces
+                          intent(inout) :: u_face_mask_bdry !< A boundary-type mask at B-grid u faces [nondim]
    real, dimension(SZIB_(G),SZJB_(G)), &
-                          intent(inout) :: v_face_mask_bdry !< A boundary-type mask at B-grid v faces
+                          intent(inout) :: v_face_mask_bdry !< A boundary-type mask at B-grid v faces [nondim]
    real, dimension(SZIB_(G),SZJB_(G)), &
                           intent(inout) :: u_bdry_val !< The zonal ice shelf velocity at open
                                                        !! boundary vertices [L T-1 ~> m s-1].
    real, dimension(SZIB_(G),SZJB_(G)), &
                           intent(inout) :: v_bdry_val !< The meridional ice shelf velocity at open
+                                                       !! boundary vertices [L T-1 ~> m s-1].
    real, dimension(SZDIB_(G),SZDJB_(G)), &
-                          intent(inout) :: umask !< A mask foor ice shelf velocity
+                          intent(inout) :: umask !< A mask for ice shelf velocity [nondim]
    real, dimension(SZDIB_(G),SZDJB_(G)), &
-                          intent(inout) :: vmask !< A mask foor ice shelf velocity
+                          intent(inout) :: vmask !< A mask for ice shelf velocity [nondim]
    real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(inout) :: thickness_bdry_val !< The ice shelf thickness at open boundaries [Z ~> m]
                                                           !! boundary vertices [L T-1 ~> m s-1].
@@ -499,9 +501,9 @@ subroutine initialize_ice_shelf_boundary_from_file(u_face_mask_bdry, v_face_mask
                           intent(inout) :: h_bdry_val !< The ice shelf thickness at open boundaries [Z ~> m]
    real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(inout) :: hmask !< A mask indicating which tracer points are
-                                              !! partly or fully covered by an ice-shelf
+                                              !! partly or fully covered by an ice-shelf [nondim]
    real, dimension(SZDI_(G),SZDJ_(G)), &
-                          intent(in) :: h_shelf !< Ice-shelf thickness
+                          intent(in) :: h_shelf !< Ice-shelf thickness [Z ~> m]
    type(unit_scale_type), intent(in)    :: US !< A structure containing unit conversion factors
    type(param_file_type), intent(in)    :: PF !< A structure to parse for run-time parameters
 
@@ -557,16 +559,17 @@ subroutine initialize_ice_shelf_boundary_from_file(u_face_mask_bdry, v_face_mask
        " initialize_ice_shelf_velocity_from_file: Unable to open "//trim(filename))
 
 
- call MOM_read_data(filename, trim(ufcmskbdry_varname),u_face_mask_bdry, G%Domain,position=CORNER,scale=1.0)
- call MOM_read_data(filename,trim(vfcmskbdry_varname), v_face_mask_bdry, G%Domain, position=CORNER,scale=1.0)
- call MOM_read_data(filename,trim(ubdryv_varname), u_bdry_val, G%Domain, position=CORNER,scale=1.0)
- call MOM_read_data(filename,trim(vbdryv_varname), v_bdry_val, G%Domain, position=CORNER,scale=1.)
- call MOM_read_data(filename,trim(umask_varname), umask, G%Domain, position=CORNER,scale=1.)
- call MOM_read_data(filename,trim(vmask_varname), vmask, G%Domain, position=CORNER,scale=1.)
- filename = trim(inputdir)//trim(icethick_file)
+  call MOM_read_data(filename, trim(ufcmskbdry_varname), u_face_mask_bdry, G%Domain, position=CORNER, scale=1.0)
+  call MOM_read_data(filename, trim(vfcmskbdry_varname), v_face_mask_bdry, G%Domain, position=CORNER, scale=1.0)
+  !### I think that the following two lines should have ..., scale=US%m_s_to_L_T
+  call MOM_read_data(filename, trim(ubdryv_varname), u_bdry_val, G%Domain, position=CORNER, scale=1.0)
+  call MOM_read_data(filename, trim(vbdryv_varname), v_bdry_val, G%Domain, position=CORNER, scale=1.)
+  call MOM_read_data(filename, trim(umask_varname), umask, G%Domain, position=CORNER, scale=1.)
+  call MOM_read_data(filename, trim(vmask_varname), vmask, G%Domain, position=CORNER, scale=1.)
+  filename = trim(inputdir)//trim(icethick_file)
 
 ! call MOM_read_data(filename, trim(h_varname), h_shelf, G%Domain, scale=US%m_to_Z)
- call MOM_read_data(filename,trim(hmsk_varname), hmask, G%Domain, scale=1.)
+  call MOM_read_data(filename,trim(hmsk_varname), hmask, G%Domain, scale=1.)
   isc = G%isc ; jsc = G%jsc ; iec = G%iec ; jec = G%jec
 
   do j=jsc,jec

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -16,7 +16,7 @@ use MOM_domains, only       : group_pass_type, start_group_pass, complete_group_
 use MOM_error_handler, only : MOM_error, FATAL, WARNING, MOM_mesg, is_root_pe
 use MOM_file_parser, only   : read_param, get_param, log_param, log_version, param_file_type
 use MOM_grid, only          : ocean_grid_type
-use MOM_io, only            : slasher, vardesc, MOM_read_data, file_exists
+use MOM_io, only            : slasher, MOM_read_data, file_exists
 use MOM_restart, only       : register_restart_field, MOM_restart_CS, restart_init, save_restart
 use MOM_spatial_means, only : global_area_mean
 use MOM_time_manager, only  : time_type, time_type_to_real, operator(+), operator(/), operator(-)
@@ -2086,7 +2086,6 @@ end subroutine PPM_limit_pos
 !   ! This subroutine is used to allocate and register any fields in this module
 !   ! that should be written to or read from the restart file.
 !   logical :: use_int_tides
-!   type(vardesc) :: vd
 !   integer :: num_freq, num_angle , num_mode, period_1
 !   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, a
 !   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -2108,10 +2107,9 @@ end subroutine PPM_limit_pos
 !   call read_param(param_file, "INTERNAL_TIDE_ANGLES", num_angle)
 !   allocate(CS%En_restart(isd:ied, jsd:jed, num_angle), source=0.0)
 
-!   vd = vardesc("En_restart", &
-!     "The internal wave energy density as a function of (i,j,angle,frequency,mode)", &
-!     'h','1','1',"J m-2")
-!   call register_restart_field(CS%En_restart, vd, .false., restart_CS)
+!   call register_restart_field(CS%En_restart, "En_restart", .false., restart_CS, &
+!            longname="The internal wave energy density as a function of (i,j,angle,frequency,mode)", &
+!            units="J m-2", conversion=US%RZ3_T3_to_W_m2*US%T_to_s, z_grid='1')
 
 ! end subroutine register_int_tide_restarts
 

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -138,7 +138,7 @@ function register_boundary_impulse_tracer(HI, GV, US, param_file, CS, tr_Reg, re
   rem_time_ptr => CS%remaining_source_time
   call register_restart_field(rem_time_ptr, "bir_remain_time", &
                               .not.CS%tracers_may_reinit, restart_CS, &
-                              "Remaining time to apply BIR source", "s")
+                              "Remaining time to apply BIR source", "s", conversion=US%T_to_s)
 
   CS%tr_Reg => tr_Reg
   CS%restart_CSp => restart_CS
@@ -196,8 +196,8 @@ subroutine initialize_boundary_impulse_tracer(restart, day, G, GV, US, h, diag, 
     endif
   enddo ! Tracer loop
 
-  if (restart .and. (US%s_to_T_restart /= 0.0) .and. (US%s_to_T /= US%s_to_T_restart) ) then
-    CS%remaining_source_time = (US%s_to_T / US%s_to_T_restart) * CS%remaining_source_time
+  if (restart .and. (US%s_to_T_restart /= 0.0) .and. (US%s_to_T_restart /= 1.0) ) then
+    CS%remaining_source_time = (1.0 / US%s_to_T_restart) * CS%remaining_source_time
   endif
 
   if (associated(OBC)) then


### PR DESCRIPTION
  This PR introduces code changes so that MOM6 writes out restart files in which
the dimensional rescaling of variables has been undone, although it is still
able to properly read older restart files that do have dimensionally rescaled
variables.  This PR also includes some new optional arguments to the framework
code that will allow SIS2 to do the same; this has been tested and works, but
will have to come in a subsequent PR to SIS2 after the version of MOM6 in
coupled configurations is updated.  In testing with this PR, the output
differences between cases with and without dimensional rescaling are confined to
MOM_parameter_doc.debug files.  This PR includes a number of new subroutine
arguments, but the solutions are bitwise identical.

  The commits in this PR include: 

- NOAA-GFDL/MOM6@7c3f31bd4 +(*)Write unscaled MOM6 restart files
- NOAA-GFDL/MOM6@11d03b13b +Add unit conversion capability for restarts
