### PR TITLE
add residual loss term for internal tides

### DIFF
--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -65,6 +65,10 @@ type, public :: int_tide_CS ; private
                         !< identifies reflection cells where double reflection
                         !! is possible (i.e. ridge cells)
                         ! (could be in G control structure)
+  real, allocatable, dimension(:,:) :: trans
+                        !< partial transmission coeff for each "coast cell"
+  real, allocatable, dimension(:,:) :: residual
+                        !< residual of reflection and transmission coeff for each "coast cell"
   real, allocatable, dimension(:,:,:,:) :: cp
                         !< horizontal phase speed [L T-1 ~> m s-1]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_leak_loss
@@ -79,6 +83,8 @@ type, public :: int_tide_CS ; private
                         !! the energy losses in [R Z3 T-3 ~> W m-2]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_itidal_loss
                         !< energy lost due to small-scale wave drag [R Z3 T-3 ~> W m-2]
+  real, allocatable, dimension(:,:,:,:,:) :: TKE_residual_loss
+                        !< internal tide energy loss due to the residual at slopes [R Z3 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: tot_leak_loss !< Energy loss rates due to misc bakground processes,
                         !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: tot_quad_loss !< Energy loss rates due to quadratic bottom drag,
@@ -86,6 +92,8 @@ type, public :: int_tide_CS ; private
   real, allocatable, dimension(:,:) :: tot_itidal_loss !< Energy loss rates due to small-scale drag,
                         !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: tot_Froude_loss !< Energy loss rates due to wave breaking,
+                        !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
+  real, allocatable, dimension(:,:) :: tot_residual_loss !< Energy loss rates due to residual on slopes,
                         !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: tot_allprocesses_loss !< Energy loss rates due to all processes,
                         !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
@@ -107,6 +115,8 @@ type, public :: int_tide_CS ; private
                         !< If true, apply scattering due to small-scale roughness as a sink.
   logical :: apply_Froude_drag
                         !< If true, apply wave breaking as a sink.
+  logical :: apply_residual_drag
+                        !< If true, apply sink from residual term of reflection/transmission.
   real, allocatable :: En(:,:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,frequency,mode)
                         !! integrated within an angular and frequency band [R Z3 T-2 ~> J m-2]
@@ -122,10 +132,11 @@ type, public :: int_tide_CS ; private
   ! Diag handles relevant to all modes, frequencies, and angles
   integer :: id_tot_En = -1, id_TKE_itidal_input = -1, id_itide_drag = -1
   integer :: id_refl_pref = -1, id_refl_ang = -1, id_land_mask = -1
+  integer :: id_trans = -1, id_residual = -1
   integer :: id_dx_Cv = -1, id_dy_Cu = -1
   ! Diag handles considering: sums over all modes, frequencies, and angles
   integer :: id_tot_leak_loss = -1, id_tot_quad_loss = -1, id_tot_itidal_loss = -1
-  integer :: id_tot_Froude_loss = -1, id_tot_allprocesses_loss = -1
+  integer :: id_tot_Froude_loss = -1, id_tot_residual_loss = -1, id_tot_allprocesses_loss = -1
   ! Diag handles considering: all modes & freqs; summed over angles
   integer, allocatable, dimension(:,:) :: &
              id_En_mode, &
@@ -184,7 +195,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
     flux_prec_y
   real, dimension(SZI_(G),SZJ_(G)) :: &
     tot_En, &      ! energy summed over angles, modes, frequencies [R Z3 T-2 ~> J m-2]
-    tot_leak_loss, tot_quad_loss, tot_itidal_loss, tot_Froude_loss, tot_allprocesses_loss, &
+    tot_leak_loss, tot_quad_loss, tot_itidal_loss, tot_Froude_loss, tot_residual_loss, tot_allprocesses_loss, &
                    ! energy loss rates summed over angle, freq, and mode [R Z3 T-3 ~> W m-2]
     htot, &        ! The vertical sum of the layer thicknesses [H ~> m or kg m-2]
     drag_scale, &  ! bottom drag scale [T-1 ~> s-1]
@@ -198,6 +209,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
   real :: loss_rate  ! An energy loss rate [T-1 ~> s-1]
   real :: Fr2_max
   real :: cn_subRO        ! A tiny wave speed to prevent division by zero [L T-1 ~> m s-1]
+  real :: en_subRO        ! A tiny energy to prevent division by zero [R Z3 T-2 ~> J m-2]
   real :: En_new, En_check                           ! Energies for debugging [R Z3 T-2 ~> J m-2]
   real :: En_initial, Delta_E_check                  ! Energies for debugging [R Z3 T-2 ~> J m-2]
   real :: TKE_Froude_loss_check, TKE_Froude_loss_tot ! Energy losses for debugging [R Z3 T-3 ~> W m-2]
@@ -211,7 +223,8 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nAngle = CS%NAngle
   I_rho0 = 1.0 / GV%Rho0
-  cn_subRO = 1e-100*US%m_s_to_L_T  ! The hard-coded value here might need to increase.
+  cn_subRO = 1e-30*US%m_s_to_L_T
+  en_subRO = 1e-30*US%W_m2_to_RZ3_T3*US%s_to_T
 
   ! init local arrays
   drag_scale(:,:) = 0.
@@ -286,8 +299,11 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
 
   ! Propagate the waves.
   do m=1,CS%NMode ; do fr=1,CS%Nfreq
+
+    CS%TKE_residual_loss(:,:,:,fr,m) = 0.
+
     call propagate(CS%En(:,:,:,fr,m), cn(:,:,m), CS%frequency(fr), dt, &
-                   G, US, CS, CS%NAngle)
+                   G, US, CS, CS%NAngle, CS%TKE_residual_loss(:,:,:,fr,m))
   enddo ; enddo
 
   ! Check for En<0 - for debugging, delete later
@@ -502,6 +518,23 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
     enddo ; enddo
   enddo ; enddo ; enddo
 
+  ! loss from residual of reflection/transmission coefficients
+  if (CS%apply_residual_drag) then
+
+    do m=1,CS%nMode ; do fr=1,CS%nFreq ; do a=1,CS%nAngle ; do j=jsd,jed ; do i=isd,ied
+      ! implicit form
+      !CS%En(i,j,a,fr,m) = CS%En(i,j,a,fr,m) / (1.0 + dt * CS%TKE_residual_loss(i,j,a,fr,m) / &
+      !                                        (CS%En(i,j,a,fr,m) + en_subRO))
+      ! rewritten to minimize number of divisions:
+      CS%En(i,j,a,fr,m) = (CS%En(i,j,a,fr,m) * (CS%En(i,j,a,fr,m) + en_subRO)) / &
+                         ((CS%En(i,j,a,fr,m) + en_subRO) + dt * CS%TKE_residual_loss(i,j,a,fr,m))
+
+      ! explicit form
+      !CS%En(i,j,a,fr,m) = CS%En(i,j,a,fr,m) - dt * CS%TKE_residual_loss(i,j,a,fr,m)
+    enddo ; enddo ; enddo ; enddo ; enddo
+  endif
+
+
   ! Check for energy conservation on computational domain.*************************
   do m=1,CS%NMode ; do fr=1,CS%Nfreq
     call sum_En(G,CS,CS%En(:,:,:,fr,m),'prop_int_tide')
@@ -537,21 +570,25 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
     tot_quad_loss(:,:)   = 0.0
     tot_itidal_loss(:,:) = 0.0
     tot_Froude_loss(:,:) = 0.0
+    tot_residual_loss(:,:) = 0.0
     tot_allprocesses_loss(:,:) = 0.0
     do m=1,CS%NMode ; do fr=1,CS%Nfreq ; do a=1,CS%nAngle ; do j=js,je ; do i=is,ie
       tot_leak_loss(i,j)   = tot_leak_loss(i,j)   + CS%TKE_leak_loss(i,j,a,fr,m)
       tot_quad_loss(i,j)   = tot_quad_loss(i,j)   + CS%TKE_quad_loss(i,j,a,fr,m)
       tot_itidal_loss(i,j) = tot_itidal_loss(i,j) + CS%TKE_itidal_loss(i,j,a,fr,m)
       tot_Froude_loss(i,j) = tot_Froude_loss(i,j) + CS%TKE_Froude_loss(i,j,a,fr,m)
+      tot_residual_loss(i,j) = tot_residual_loss(i,j) + CS%TKE_residual_loss(i,j,a,fr,m)
     enddo ; enddo ; enddo ; enddo ; enddo
     do j=js,je ; do i=is,ie
-      tot_allprocesses_loss(i,j) = tot_leak_loss(i,j) + tot_quad_loss(i,j) + &
-                          tot_itidal_loss(i,j) + tot_Froude_loss(i,j)
+      tot_allprocesses_loss(i,j) = ((((tot_leak_loss(i,j) + tot_quad_loss(i,j)) + &
+                          tot_itidal_loss(i,j)) + tot_Froude_loss(i,j)) + &
+                          tot_residual_loss(i,j))
     enddo ; enddo
     CS%tot_leak_loss         = tot_leak_loss
     CS%tot_quad_loss         = tot_quad_loss
     CS%tot_itidal_loss       = tot_itidal_loss
     CS%tot_Froude_loss       = tot_Froude_loss
+    CS%tot_residual_loss     = tot_residual_loss
     CS%tot_allprocesses_loss = tot_allprocesses_loss
     if (CS%id_tot_leak_loss > 0) then
       call post_data(CS%id_tot_leak_loss, tot_leak_loss, CS%diag)
@@ -565,6 +602,9 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
     if (CS%id_tot_Froude_loss > 0) then
       call post_data(CS%id_tot_Froude_loss, tot_Froude_loss, CS%diag)
     endif
+    if (CS%id_tot_residual_loss > 0) then
+      call post_data(CS%id_tot_residual_loss, tot_residual_loss, CS%diag)
+    endif
     if (CS%id_tot_allprocesses_loss > 0) then
       call post_data(CS%id_tot_allprocesses_loss, tot_allprocesses_loss, CS%diag)
     endif
@@ -577,8 +617,9 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
       do a=1,CS%nAngle ; do j=js,je ; do i=is,ie
         itidal_loss_mode(i,j)       = itidal_loss_mode(i,j) + CS%TKE_itidal_loss(i,j,a,fr,m)
         allprocesses_loss_mode(i,j) = allprocesses_loss_mode(i,j) + &
-                                 CS%TKE_leak_loss(i,j,a,fr,m) + CS%TKE_quad_loss(i,j,a,fr,m) + &
-                                 CS%TKE_itidal_loss(i,j,a,fr,m) + CS%TKE_Froude_loss(i,j,a,fr,m)
+                                 ((((CS%TKE_leak_loss(i,j,a,fr,m) + CS%TKE_quad_loss(i,j,a,fr,m)) + &
+                                 CS%TKE_itidal_loss(i,j,a,fr,m)) + CS%TKE_Froude_loss(i,j,a,fr,m)) + &
+                                 CS%TKE_residual_loss(i,j,a,fr,m))
       enddo ; enddo ; enddo
       call post_data(CS%id_itidal_loss_mode(fr,m), itidal_loss_mode, CS%diag)
       call post_data(CS%id_allprocesses_loss_mode(fr,m), allprocesses_loss_mode, CS%diag)
@@ -992,7 +1033,7 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
 end subroutine PPM_angular_advect
 
 !> Propagates internal waves at a single frequency.
-subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle)
+subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle, residual_loss)
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure.
   integer,               intent(in)    :: NAngle !< The number of wave orientations in the
                                                !! discretized wave energy spectrum.
@@ -1006,7 +1047,9 @@ subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle)
   real,                  intent(in)    :: dt   !< Time step [T ~> s].
   type(unit_scale_type), intent(in)    :: US   !< A dimensional unit scaling type
   type(int_tide_CS),     intent(in)    :: CS   !< Internal tide control struct
-
+  real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
+                         intent(inout) :: residual_loss !< internal tide energy loss due
+                                                        !! to the residual at slopes [R Z3 T-3 ~> W m-2].
   ! Local variables
   real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB) :: &
     speed  ! The magnitude of the group velocity at the q points for corner adv [L T-1 ~> m s-1].
@@ -1097,18 +1140,19 @@ subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle)
 
     ! Apply propagation in x-direction (reflection included)
     LB%jsh = jsh ; LB%jeh = jeh ; LB%ish = ish ; LB%ieh = ieh
-    call propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, CS%nAngle, CS, LB)
+    call propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, CS%nAngle, CS, LB, residual_loss)
 
     ! Check for energy conservation on computational domain (for debugging)
     !call sum_En(G, CS, En, 'post-propagate_x')
 
     ! Update halos
     call pass_var(En, G%domain)
+    call pass_var(residual_loss, G%domain)
 
     ! Apply propagation in y-direction (reflection included)
     ! LB%jsh = js ; LB%jeh = je ; LB%ish = is ; LB%ieh = ie ! Use if no teleport
     LB%jsh = jsh ; LB%jeh = jeh ; LB%ish = ish ; LB%ieh = ieh
-    call propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, CS%nAngle, CS, LB)
+    call propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, CS%nAngle, CS, LB, residual_loss)
 
     ! Check for energy conservation on computational domain (for debugging)
     !call sum_En(G, CS, En, 'post-propagate_y')
@@ -1383,7 +1427,7 @@ subroutine propagate_corner_spread(En, energized_wedge, NAngle, speed, dt, G, CS
 end subroutine propagate_corner_spread
 
 !> Propagates the internal wave energy in the logical x-direction.
-subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB)
+subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, residual_loss)
   type(ocean_grid_type),   intent(in)    :: G  !< The ocean's grid structure.
   integer,                 intent(in)    :: NAngle !< The number of wave orientations in the
                                                !! discretized wave energy spectrum.
@@ -1400,6 +1444,9 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB)
   type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   type(int_tide_CS),       intent(in)    :: CS !< Internal tide control struct
   type(loop_bounds_type),  intent(in)    :: LB !< A structure with the active energy loop bounds.
+  real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle),   &
+                           intent(inout) :: residual_loss !< internal tide energy loss due
+                                                          !! to the residual at slopes [R Z3 T-3 ~> W m-2].
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     EnL, EnR    ! Left and right face energy densities [R Z3 T-2 ~> J m-2].
@@ -1436,6 +1483,10 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB)
     do j=jsh,jeh ; do i=ish,ieh
       Fdt_m(i,j,a) = dt*flux_x(I-1,j) ! left face influx  [R Z3 L2 T-2 ~> J]
       Fdt_p(i,j,a) = -dt*flux_x(I,j)  ! right face influx [R Z3 L2 T-2 ~> J]
+
+      residual_loss(i,j,a) = residual_loss(i,j,a) + &
+                            (abs(flux_x(I-1,j)) * CS%residual(i,j) * G%IareaT(i,j) + &
+                             abs(flux_x(I,j)) * CS%residual(i,j) * G%IareaT(i,j))
     enddo ; enddo
 
   enddo ! a-loop
@@ -1457,7 +1508,7 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB)
 end subroutine propagate_x
 
 !> Propagates the internal wave energy in the logical y-direction.
-subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB)
+subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, residual_loss)
   type(ocean_grid_type),   intent(in)    :: G  !< The ocean's grid structure.
   integer,                 intent(in)    :: NAngle !< The number of wave orientations in the
                                                !! discretized wave energy spectrum.
@@ -1474,6 +1525,9 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB)
   type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   type(int_tide_CS),       intent(in)    :: CS !< Internal tide control struct
   type(loop_bounds_type),  intent(in)    :: LB !< A structure with the active energy loop bounds.
+  real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle),   &
+                           intent(inout) :: residual_loss !< internal tide energy loss due
+                                                          !! to the residual at slopes [R Z3 T-3 ~> W m-2].
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     EnL, EnR    ! South and north face energy densities [R Z3 T-2 ~> J m-2].
@@ -1511,6 +1565,11 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB)
     do j=jsh,jeh ; do i=ish,ieh
       Fdt_m(i,j,a) = dt*flux_y(i,J-1) ! south face influx [R Z3 L2 T-2 ~> J]
       Fdt_p(i,j,a) = -dt*flux_y(i,J)  ! north face influx [R Z3 L2 T-2 ~> J]
+
+      residual_loss(i,j,a) = residual_loss(i,j,a) + &
+                            (abs(flux_y(i,J-1)) * CS%residual(i,j) * G%IareaT(i,j) + &
+                             abs(flux_y(i,J)) * CS%residual(i,j) * G%IareaT(i,j))
+
       !if ((En(i,j,a) + G%IareaT(i,j)*(Fdt_m(i,j,a) + Fdt_p(i,j,a))) < 0.0) then ! for debugging
       !  call MOM_error(WARNING, "propagate_y: OutFlux>Available prior to reflection", .true.)
       !  write(mesg,*) "flux_y_south=",flux_y(i,J-1),"flux_y_north=",flux_y(i,J),"En=",En(i,j,a), &
@@ -2150,7 +2209,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   character(len=160) :: var_descript
   character(len=200) :: filename
   character(len=200) :: refl_angle_file, land_mask_file
-  character(len=200) :: refl_pref_file, refl_dbl_file
+  character(len=200) :: refl_pref_file, refl_dbl_file, trans_file
   character(len=200) :: dy_Cu_file, dx_Cv_file
   character(len=200) :: h2_file
 
@@ -2269,6 +2328,9 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   call get_param(param_file, mdl, "INTERNAL_TIDE_WAVE_DRAG", CS%apply_wave_drag, &
                  "If true, apply scattering due to small-scale roughness as a sink.", &
                  default=.false.)
+  call get_param(param_file, mdl, "INTERNAL_TIDE_RESIDUAL_DRAG", CS%apply_residual_drag, &
+                 "If true, TBD", &
+                 default=.false.)
   call get_param(param_file, mdl, "INTERNAL_TIDE_DRAG_MIN_DEPTH", CS%drag_min_depth, &
                  "The minimum total ocean thickness that will be used in the denominator "//&
                  "of the quadratic drag terms for internal tides.", &
@@ -2307,10 +2369,12 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   allocate(CS%TKE_quad_loss(isd:ied,jsd:jed,num_angle,num_freq,num_mode), source=0.0)
   allocate(CS%TKE_itidal_loss(isd:ied,jsd:jed,num_angle,num_freq,num_mode), source=0.0)
   allocate(CS%TKE_Froude_loss(isd:ied,jsd:jed,num_angle,num_freq,num_mode), source=0.0)
+  allocate(CS%TKE_residual_loss(isd:ied,jsd:jed,num_angle,num_freq,num_mode), source=0.0)
   allocate(CS%tot_leak_loss(isd:ied,jsd:jed), source=0.0)
   allocate(CS%tot_quad_loss(isd:ied,jsd:jed), source=0.0)
   allocate(CS%tot_itidal_loss(isd:ied,jsd:jed), source=0.0)
   allocate(CS%tot_Froude_loss(isd:ied,jsd:jed), source=0.0)
+  allocate(CS%tot_residual_loss(isd:ied,jsd:jed), source=0.0)
 
   ! Compute the fixed part of the bottom drag loss from baroclinic modes
   call get_param(param_file, mdl, "H2_FILE", h2_file, &
@@ -2406,6 +2470,32 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
     else ; CS%refl_dbl(i,j) = .false. ; endif
   enddo ; enddo
 
+  ! Read in the transmission coefficient and infer the residual
+  call get_param(param_file, mdl, "TRANS_FILE", trans_file, &
+               "The path to the file containing the transmission coefficent for internal tides.", &
+               fail_if_missing=.false., default='')
+  filename = trim(CS%inputdir) // trim(trans_file)
+  allocate(CS%trans(isd:ied,jsd:jed), source=0.0)
+  if (file_exists(filename, G%domain)) then
+    call log_param(param_file, mdl, "INPUTDIR/TRANS_FILE", filename)
+    call MOM_read_data(filename, 'trans', CS%trans, G%domain)
+  else
+    if (trim(trans_file) /= '' ) call MOM_error(FATAL, &
+                                                "TRANS_FILE: "//trim(filename)//" not found")
+  endif
+
+  call pass_var(CS%trans,G%domain)
+  ! residual
+  allocate(CS%residual(isd:ied,jsd:jed), source=0.0)
+  do j=jsd,jed
+    do i=isd,ied
+      if (CS%refl_pref_logical(i,j)) then
+        CS%residual(i,j) = 1. - CS%refl_pref(i,j) - CS%trans(i,j)
+      endif
+    enddo
+  enddo
+  call pass_var(CS%residual,G%domain)
+
   ! Read in prescribed land mask from file (if overwriting -BDM).
   ! This should be done in MOM_initialize_topography subroutine
   ! defined in MOM_fixed_initialization.F90 (BDM)
@@ -2445,6 +2535,10 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                  Time, 'Local angle of coastline/ridge/shelf with respect to equator', 'rad')
   CS%id_refl_pref = register_diag_field('ocean_model', 'refl_pref', diag%axesT1, &
                  Time, 'Partial reflection coefficients', '')
+  CS%id_trans = register_diag_field('ocean_model', 'trans', diag%axesT1, &
+                 Time, 'Partial transmission coefficients', '')
+  CS%id_residual = register_diag_field('ocean_model', 'residual', diag%axesT1, &
+                 Time, 'Residual of reflection and transmission coefficients', '')
   CS%id_dx_Cv = register_diag_field('ocean_model', 'dx_Cv', diag%axesT1, &
                  Time, 'North face unblocked width', 'm', conversion=US%L_to_m)
   CS%id_dy_Cu = register_diag_field('ocean_model', 'dy_Cu', diag%axesT1, &
@@ -2454,6 +2548,8 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   ! Output reflection parameters as diags here (not needed every timestep)
   if (CS%id_refl_ang > 0)   call post_data(CS%id_refl_ang, CS%refl_angle, CS%diag)
   if (CS%id_refl_pref > 0)  call post_data(CS%id_refl_pref, CS%refl_pref, CS%diag)
+  if (CS%id_trans > 0)      call post_data(CS%id_trans, CS%trans, CS%diag)
+  if (CS%id_residual > 0)   call post_data(CS%id_residual, CS%residual, CS%diag)
   if (CS%id_dx_Cv > 0)      call post_data(CS%id_dx_Cv, G%dx_Cv, CS%diag)
   if (CS%id_dy_Cu > 0)      call post_data(CS%id_dy_Cu, G%dy_Cu, CS%diag)
   if (CS%id_land_mask > 0)  call post_data(CS%id_land_mask, G%mask2dT, CS%diag)
@@ -2482,6 +2578,9 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                 'W m-2', conversion=US%RZ3_T3_to_W_m2)
   CS%id_tot_Froude_loss = register_diag_field('ocean_model', 'ITide_tot_Froude_loss', diag%axesT1, &
                 Time, 'Internal tide energy loss to wave breaking', &
+                'W m-2', conversion=US%RZ3_T3_to_W_m2)
+  CS%id_tot_residual_loss = register_diag_field('ocean_model', 'ITide_tot_residual_loss', diag%axesT1, &
+                Time, 'Internal tide energy loss to residual on slopes', &
                 'W m-2', conversion=US%RZ3_T3_to_W_m2)
   CS%id_tot_allprocesses_loss = register_diag_field('ocean_model', 'ITide_tot_allprocesses_loss', diag%axesT1, &
                 Time, 'Internal tide energy loss summed over all processes', &


### PR DESCRIPTION
this term uses the residual from the reflection/transmission coefficients to compute the energy loss due to scattering to higher modes on the slopes. Replacement for PR #33 with clean history