### PR TITLE
Correct --with-driver args for coupled tests

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -265,9 +265,9 @@ build/openmp/Makefile: MOM_ACFLAGS=--enable-openmp
 build/target/Makefile: MOM_ACFLAGS=
 build/opt/Makefile: MOM_ACFLAGS=
 build/opt_target/Makefile: MOM_ACFLAGS=
-build/coupled/Makefile: MOM_ACFLAGS=--with-driver=coupled_driver
-build/nuopc/Makefile: MOM_ACFLAGS=--with-driver=nuopc_driver
-build/mct/Makefile: MOM_ACFLAGS=--with-driver=mct_driver
+build/coupled/Makefile: MOM_ACFLAGS=--with-driver=FMS_cap
+build/nuopc/Makefile: MOM_ACFLAGS=--with-driver=nuopc_cap
+build/mct/Makefile: MOM_ACFLAGS=--with-driver=mct_cap
 
 # Fetch regression target source code
 build/target/Makefile: | $(TARGET_CODEBASE)


### PR DESCRIPTION
- Ever since a renaming of driver directories, the tests under "test-top-api", that are meant to check we are compatible with
  each "cap", have been failing silently.
- This fixes the wrong arguments but does not fix the ability to fail silently which is somewhere deep inside mkmf.