### PR TITLE
Remove unused variables

### DIFF
--- a/config_src/drivers/solo_driver/MESO_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MESO_surface_forcing.F90
@@ -77,8 +77,6 @@ subroutine MESO_buoyancy_forcing(sfc_state, fluxes, day, dt, G, US, CS)
 !  are in W m-2 and positive for heat going into the ocean.  All fresh water
 !  fluxes are in kg m-2 s-1 and positive for water moving into the ocean.
 
-  real :: Temp_restore   ! The temperature that is being restored toward [degC].
-  real :: Salin_restore  ! The salinity that is being restored toward [ppt]
   real :: density_restore  ! The potential density that is being restored toward [R ~> kg m-3].
   real :: rhoXcp ! The mean density times the heat capacity [Q R degC-1 ~> J m-3 degC-1].
   real :: buoy_rest_const  ! A constant relating density anomalies to the

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -129,7 +129,6 @@ program MOM_main
                                   ! representation of dt_forcing.
   real :: dt_forcing              ! The coupling time step [s].
   real :: dt                      ! The nominal baroclinic dynamics time step [s].
-  real :: dt_off                  ! Offline time step [s].
   integer :: ntstep               ! The number of baroclinic dynamics time steps
                                   ! within dt_forcing.
   real :: dt_therm                ! The thermodynamic timestep [s]

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -185,7 +185,6 @@ contains
     integer, optional,        intent(in) :: ntau !< Unknown
     logical, optional,        intent(in) :: positive !< Unknown
     real, dimension(isd:,jsd:,:), intent(out):: array !< Unknown
-    integer :: tau
     character(len=fm_string_len), parameter :: sub_name = 'g_tracer_get_3D_val'
   end subroutine g_tracer_get_3D_val
 
@@ -257,7 +256,6 @@ contains
 
   subroutine g_tracer_send_diag(g_tracer_list,model_time,tau)
     type(g_tracer_type), pointer    :: g_tracer_list !< pointer to the head of the generic tracer list
-    type(g_tracer_type), pointer    :: g_tracer !< Pointer to tracer node
     type(time_type),     intent(in) :: model_time !< Time
     integer,             intent(in) :: tau !< The time step for the %field 4D field to be reported
   end subroutine g_tracer_send_diag

--- a/config_src/infra/FMS1/MOM_couplertype_infra.F90
+++ b/config_src/infra/FMS1/MOM_couplertype_infra.F90
@@ -409,8 +409,6 @@ subroutine CT_set_data(array_in, bc_index, field_index, var, &
                                                          !! the second dimension of the output array
                                                          !! in a non-decreasing list
 
-  integer :: subfield ! An integer indicating which field to set.
-
   call coupler_type_set_data(array_in, bc_index, field_index, var, scale_factor, halo_size, idim, jdim)
 
 end subroutine CT_set_data

--- a/config_src/infra/FMS1/MOM_domain_infra.F90
+++ b/config_src/infra/FMS1/MOM_domain_infra.F90
@@ -241,8 +241,8 @@ subroutine pass_var_2d(array, MOM_dom, sideflag, complete, position, halo, inner
   ! Local variables
   real, allocatable, dimension(:,:) :: tmp
   integer :: pos, i_halo, j_halo
-  integer :: isc, iec, jsc, jec, isd, ied, jsd, jed, IscB, IecB, JscB, JecB
-  integer :: inner, i, j, isfw, iefw, isfe, iefe, jsfs, jefs, jsfn, jefn
+  integer :: isc, iec, jsc, jec, isd, ied, jsd, jed
+  integer :: i, j, isfw, iefw, isfe, iefe, jsfs, jefs, jsfn, jefn
   integer :: dirflag
   logical :: block_til_complete
 
@@ -593,7 +593,6 @@ subroutine fill_vector_symmetric_edges_2d(u_cmpt, v_cmpt, MOM_dom, stagger, scal
   integer :: dirflag
   integer :: i, j, isc, iec, jsc, jec, isd, ied, jsd, jed, IscB, IecB, JscB, JecB
   real, allocatable, dimension(:) :: sbuff_x, sbuff_y, wbuff_x, wbuff_y
-  logical :: block_til_complete
 
   if (.not. MOM_dom%symmetric) then
       return
@@ -1328,10 +1327,8 @@ subroutine create_MOM_domain(MOM_dom, n_global, n_halo, reentrant, tripolar_N, l
                                                       !! nonblocking halo updates, or false if missing.
 
   ! local variables
-  integer, dimension(4) :: global_indices ! The lower and upper global i- and j-index bounds
   integer :: X_FLAGS  ! A combination of integers encoding the x-direction grid connectivity.
   integer :: Y_FLAGS  ! A combination of integers encoding the y-direction grid connectivity.
-  integer :: xhalo_d2, yhalo_d2
   character(len=200) :: mesg    ! A string for use in error messages
   logical :: mask_table_exists  ! Mask_table is present and the file it points to exists
 
@@ -1516,7 +1513,6 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
   integer, optional, intent(in) :: extra_halo !< An extra number of points in the halos
                                   !! compared with MD_in
 
-  integer :: global_indices(4)
   logical :: mask_table_exists
   integer, dimension(:), allocatable :: exni ! The extents of the grid for each i-row of the layout.
                                              ! The sum of exni must equal MOM_dom%niglobal.
@@ -1819,7 +1815,7 @@ subroutine get_domain_extent_d2D(Domain, isc, iec, jsc, jec, isd, ied, jsd, jed)
   integer, optional, intent(out) :: jed    !< The end j-index of the data domain
 
   ! Local variables
-  integer :: isd_, ied_, jsd_, jed_, jsg_, jeg_, isg_, ieg_
+  integer :: isd_, ied_, jsd_, jed_
 
   call mpp_get_compute_domain(Domain, isc, iec, jsc, jec)
   call mpp_get_data_domain(Domain, isd_, ied_, jsd_, jed_)

--- a/config_src/infra/FMS1/MOM_io_infra.F90
+++ b/config_src/infra/FMS1/MOM_io_infra.F90
@@ -715,9 +715,8 @@ subroutine read_field_4d(filename, fieldname, data, MOM_Domain, &
   ! Local variables
   character(len=80)  :: varname             ! The name of a variable in the file
   type(fieldtype), allocatable :: fields(:) ! An array of types describing all the variables in the file
-  logical :: use_fms_read_data, file_is_global
+  logical :: file_is_global
   integer :: n, unit, ndim, nvar, natt, ntime
-  integer :: is, ie, js, je
 
   ! This single call does not work for a 4-d array due to FMS limitations, so multiple calls are
   ! needed.

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -162,7 +162,6 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
   type(ALE_CS),            pointer    :: CS         !< Module control structure
 
   ! Local variables
-  real, allocatable :: dz(:)
   character(len=40) :: mdl = "MOM_ALE" ! This module's name.
   character(len=80) :: string, vel_string ! Temporary strings
   real              :: filter_shallow_depth, filter_deep_depth
@@ -1427,7 +1426,7 @@ subroutine ALE_initThicknessToCoord( CS, G, GV, h )
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: h   !< layer thickness [H ~> m or kg m-2]
 
   ! Local variables
-  integer :: i, j, k
+  integer :: i, j
 
   do j = G%jsd,G%jed ; do i = G%isd,G%ied
     h(i,j,:) = GV%Z_to_H * getStaticThickness( CS%regridCS, 0., G%bathyT(i,j)+G%Z_ref )

--- a/src/ALE/MOM_hybgen_regrid.F90
+++ b/src/ALE/MOM_hybgen_regrid.F90
@@ -386,7 +386,7 @@ subroutine hybgen_regrid(G, GV, US, dp, tv, CS, dzInterface, PCM_cell)
                             ! each target layer, in the unusual case where the the input grid is
                             ! larger than the new grid.  This situation only occurs during certain
                             ! types of initialization or when generating output diagnostics.
-  integer :: i, j, k, nk, m, k2, nk_in
+  integer :: i, j, k, nk, k2, nk_in
 
   nk = CS%nk
 
@@ -532,8 +532,6 @@ subroutine hybgen_column_init(nk, nsigma, dp0k, ds0k, dp00i, topiso_i_j, &
   ! --- --------------------------------------------------------------
 
   ! Local variables
-  character(len=256) :: mesg  ! A string for output messages
-  real :: hybrlx  ! The relaxation rate in the hybrid region [timestep-1]?
   real :: qdep    ! Total water column thickness as a fraction of dp0k (vs ds0k) [nondim]
   real :: q       ! A portion of the thickness that contributes to the new cell [H ~> m or kg m-2]
   real :: p_int(nk+1)  ! Interface depths [H ~> m or kg m-2]
@@ -641,8 +639,6 @@ real function cushn(delp, dp0)
   real, intent(in) :: delp  ! A thickness change [H ~> m or kg m-2]
   real, intent(in) :: dp0   ! A non-negative reference thickness [H ~> m or kg m-2]
 
-  real :: qq  ! A limited ratio of delp/dp0 [nondim]
-
   ! These are the nondimensional parameters that define the cushion function.
   real, parameter :: qqmn=-4.0, qqmx=2.0  ! shifted range for cushn [nondim]
 ! real, parameter :: qqmn=-2.0, qqmx=4.0  ! traditional range for cushn [nondim]
@@ -705,7 +701,6 @@ subroutine hybgen_column_regrid(CS, nk, thkbot, onem, epsil, Rcv_tgt, &
   real :: h_hat0 ! A first guess at thickness movement upward across the interface
                  ! between layers k and k-1 [H ~> m or kg m-2]
   real :: dh_cor ! Thickness changes [H ~> m or kg m-2]
-  real :: h1_tgt ! A target thickness for the top layer [H ~> m or kg m-2]
   real :: tenm   ! ten m  in pressure units [H ~> m or kg m-2]
   real :: onemm  ! one mm in pressure units [H ~> m or kg m-2]
   logical :: trap_errors

--- a/src/ALE/MOM_hybgen_remap.F90
+++ b/src/ALE/MOM_hybgen_remap.F90
@@ -267,7 +267,6 @@ subroutine hybgen_weno_coefs(s, h_src, edges, nk, ns, thin, PCM_lay)
   real :: seh1, seh2  ! Tracer slopes at the cell edges times the cell grid spacing [A]
   real :: q01, q02    ! Various tracer differences between a cell average and the edge values [A]
   real :: q001, q002  ! Tracer slopes at the cell edges times the cell grid spacing [A]
-  real :: ds2a, ds2b  ! Squared tracer differences between a cell average and the edge values [A2]
   logical :: PCM_layer(nk) ! True for layers that should use PCM remapping, either because they are
                       ! very thin, or because this is specified by PCM_lay.
   real :: dp(nk)      ! Input grid layer thicknesses, but with a minimum thickness given by thin [H ~> m or kg m-2]

--- a/src/ALE/MOM_hybgen_unmix.F90
+++ b/src/ALE/MOM_hybgen_unmix.F90
@@ -59,8 +59,6 @@ subroutine init_hybgen_unmix(CS, GV, US, param_file, hybgen_regridCS)
   type(param_file_type),   intent(in) :: param_file !< Parameter file
   type(hybgen_regrid_CS),  pointer    :: hybgen_regridCS !< Control structure for hybgen
                                              !! regridding for sharing parameters.
-
-  character(len=40)               :: mdl = "MOM_hybgen" ! This module's name.
   integer :: k
 
   if (associated(CS)) call MOM_error(FATAL, "init_hybgen_unmix: CS already associated!")
@@ -315,7 +313,6 @@ subroutine hybgen_column_unmix(CS, nk, Rcv_tgt, temp, saln, Rcv, eqn_of_state, &
                       ! used for updating the concentration of passive tracers [nondim]
   real :: swap_T      ! A swap variable for temperature [degC]
   real :: swap_S      ! A swap variable for salinity [ppt]
-  real :: swap_R      ! A swap variable for the coordinate potential density [R ~> kg m-3]
   real :: swap_tr     ! A temporary swap variable for the tracers [conc]
   logical, parameter :: lunmix=.true.     ! unmix a too light deepest layer
   integer :: k, ka, kp, kt, m

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -202,10 +202,10 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
   character(len=200) :: inputdir, fileName
   character(len=320) :: message ! Temporary strings
   character(len=12) :: expected_units, alt_units ! Temporary strings
-  logical :: tmpLogical, fix_haloclines, set_max, do_sum, main_parameters
+  logical :: tmpLogical, fix_haloclines, do_sum, main_parameters
   logical :: coord_is_state_dependent, ierr
   logical :: default_2018_answers, remap_answers_2018
-  real :: filt_len, strat_tol, index_scale, tmpReal, P_Ref
+  real :: filt_len, strat_tol, tmpReal, P_Ref
   real :: maximum_depth ! The maximum depth of the ocean [m] (not in Z).
   real :: dz_fixed_sfc, Rho_avg_depth, nlay_sfc_int
   real :: adaptTimeRatio, adaptZoom, adaptZoomCoeff, adaptBuoyCoeff, adaptAlpha
@@ -1152,7 +1152,10 @@ subroutine build_zstar_grid( CS, G, GV, h, dzInterface, frac_shelf_h)
   real, dimension(SZI_(G),SZJ_(G)), optional,intent(in)    :: frac_shelf_h !< Fractional
                                                                  !! ice shelf coverage [nondim].
   ! Local variables
-  real    :: nominalDepth, minThickness, totalThickness, dh  ! Depths and thicknesses [H ~> m or kg m-2]
+  real   :: nominalDepth, minThickness, totalThickness  ! Depths and thicknesses [H ~> m or kg m-2]
+#ifdef __DO_SAFETY_CHECKS__
+  real :: dh                                            ! [H ~> m or kg m-2]
+#endif
   real, dimension(SZK_(GV)+1) :: zOld    ! Previous coordinate interface heights [H ~> m or kg m-2]
   real, dimension(CS%nk+1)    :: zNew    ! New coordinate interface heights [H ~> m or kg m-2]
   integer :: i, j, k, nz
@@ -1165,7 +1168,10 @@ subroutine build_zstar_grid( CS, G, GV, h, dzInterface, frac_shelf_h)
 !$OMP parallel do default(none) shared(G,GV,dzInterface,CS,nz,h,frac_shelf_h, &
 !$OMP                                  ice_shelf,minThickness) &
 !$OMP                          private(nominalDepth,totalThickness, &
-!$OMP                                  zNew,dh,zOld)
+#ifdef __DO_SAFETY_CHECKS__
+!$OMP                                  dh, &
+#endif
+!$OMP                                  zNew,zOld)
   do j = G%jsc-1,G%jec+1
     do i = G%isc-1,G%iec+1
 
@@ -1257,7 +1263,10 @@ subroutine build_sigma_grid( CS, G, GV, h, dzInterface )
   ! Local variables
   integer :: i, j, k
   integer :: nz
-  real    :: nominalDepth, totalThickness, dh
+  real    :: nominalDepth, totalThickness
+#ifdef __DO_SAFETY_CHECKS__
+  real :: dh
+#endif
   real, dimension(SZK_(GV)+1) :: zOld    ! Previous coordinate interface heights [H ~> m or kg m-2]
   real, dimension(CS%nk+1)    :: zNew    ! New coordinate interface heights [H ~> m or kg m-2]
 
@@ -1503,7 +1512,7 @@ subroutine build_grid_HyCOM1( G, GV, US, h, tv, h_new, dzInterface, CS, frac_she
   real, dimension(CS%nk+1) :: z_col_new ! New interface positions relative to the surface [H ~> m or kg m-2]
   real, dimension(CS%nk+1) :: dz_col    ! The realized change in z_col [H ~> m or kg m-2]
   integer   :: i, j, k, nki
-  real :: depth, nominalDepth
+  real :: nominalDepth
   real :: h_neglect, h_neglect_edge
   real :: z_top_col, totalThickness
   logical :: ice_shelf

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -213,8 +213,6 @@ subroutine remapping_core_h(CS, n0, h0, u0, n1, h1, u1, h_neglect, h_neglect_edg
   real, dimension(n0,2)           :: ppoly_r_E     ! Edge value of polynomial
   real, dimension(n0,2)           :: ppoly_r_S     ! Edge slope of polynomial
   real, dimension(n0,CS%degree+1) :: ppoly_r_coefs ! Coefficients of polynomial
-  real :: edges(n0,2)  ! Interpolation edge values [A]
-  real :: slope(n0)    ! Interpolation slopes per cell width [A]
   real :: h0tot, h0err ! Sum of source cell widths and round-off error in this sum [H]
   real :: h1tot, h1err ! Sum of target cell widths and round-off error in this sum [H]
   real :: u0tot, u0err ! Integrated values on the source grid and round-off error in this sum [H A]
@@ -298,7 +296,7 @@ subroutine remapping_core_w( CS, n0, h0, u0, n1, dx, u1, h_neglect, h_neglect_ed
   real, dimension(n0,2)           :: ppoly_r_S            !Edge slope of polynomial
   real, dimension(n0,CS%degree+1) :: ppoly_r_coefs !Coefficients of polynomial
   integer :: k
-  real :: eps, h0tot, h0err, h1tot, h1err
+  real :: h0tot, h0err, h1tot, h1err
   real :: u0tot, u0err, u0min, u0max, u1tot, u1err, u1min, u1max, uh_err
   real, dimension(n1) :: h1 !< Cell widths on target grid
   real :: hNeglect, hNeglect_edge
@@ -389,8 +387,6 @@ subroutine build_reconstructions_1d( CS, n0, h0, u0, ppoly_r_coefs, &
 
   ! Local variables
   integer :: local_remapping_scheme
-  integer :: remapping_scheme !< Remapping scheme
-  logical :: boundary_extrapolation !< Extrapolate at boundaries if true
   integer :: k, n
 
   ! Reset polynomial

--- a/src/ALE/PLM_functions.F90
+++ b/src/ALE/PLM_functions.F90
@@ -197,11 +197,9 @@ subroutine PLM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect )
 
   ! Local variables
   integer       :: k                    ! loop index
-  real          :: u_l, u_c, u_r        ! left, center and right cell averages
-  real          :: h_l, h_c, h_r, h_cn  ! left, center and right cell widths
+  real          :: u_l, u_r             ! left and right cell averages
   real          :: slope                ! retained PLM slope
-  real          :: a, b                 ! auxiliary variables
-  real          :: u_min, u_max, e_l, e_r, edge
+  real          :: e_r, edge
   real          :: almost_one
   real, dimension(N) :: slp, mslp
   real    :: hNeglect

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -235,13 +235,11 @@ subroutine build_slight_column(CS, eqn_of_state, H_to_pres, H_subroundoff, &
   real :: Lfilt       ! A filtering lengthscale [H ~> m or kg m-2].
   logical :: maximum_depths_set ! If true, the maximum depths of interface have been set.
   logical :: maximum_h_set      ! If true, the maximum layer thicknesses have been set.
-  real :: k2_used, k2here, dz_sum, z_max
-  integer :: k2
   real :: h_tr, b_denom_1, b1, d1 ! Temporary variables used by the tridiagonal solver.
   real, dimension(nz) :: c1  ! Temporary variables used by the tridiagonal solver.
   integer :: kur1, kur2  ! The indicies at the top and bottom of an unreliable region.
   integer :: kur_ss      ! The index to start with in the search for the next unstable region.
-  integer :: i, j, k, nkml
+  integer :: k, nkml
 
   maximum_depths_set = allocated(CS%max_interface_depths)
   maximum_h_set = allocated(CS%max_layer_thickness)

--- a/src/ALE/regrid_edge_values.F90
+++ b/src/ALE/regrid_edge_values.F90
@@ -229,7 +229,6 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
 
   ! Local variables
   real :: h0, h1, h2, h3        ! temporary thicknesses [H]
-  real :: h_sum                 ! A sum of adjacent thicknesses [H]
   real :: h_min                 ! A minimal cell width [H]
   real :: f1, f2, f3            ! auxiliary variables with various units
   real :: et1, et2, et3         ! terms the expresson for edge values [A H]
@@ -240,7 +239,7 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
   real, dimension(4)    :: dz               ! A temporary array of limited layer thicknesses [H]
   real, dimension(4)    :: u_tmp            ! A temporary array of cell average properties [A]
   real, parameter       :: C1_12 = 1.0 / 12.0
-  real                  :: dx, xavg         ! Differences and averages of successive values of x [H]
+  real                  :: dx               ! Difference of successive values of x [H]
   real, dimension(4,4)  :: A                ! values near the boundaries
   real, dimension(4)    :: B, C
   real      :: hNeglect ! A negligible thickness in the same units as h.
@@ -394,9 +393,8 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
 
   ! Local variables
   integer               :: i, j                 ! loop indexes
-  real                  :: h0, h1, h2           ! cell widths [H]
+  real                  :: h0, h1               ! cell widths [H]
   real                  :: h_min                ! A minimal cell width [H]
-  real                  :: h_sum                ! A sum of adjacent thicknesses [H]
   real                  :: h0_2, h1_2, h0h1
   real                  :: h0ph1_2, h0ph1_4
   real                  :: alpha, beta          ! stencil coefficients [nondim]
@@ -407,7 +405,7 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
   real, parameter       :: C1_3 = 1.0 / 3.0
   real, dimension(4)    :: dz                   ! A temporary array of limited layer thicknesses [H]
   real, dimension(4)    :: u_tmp                ! A temporary array of cell average properties [A]
-  real                  :: dx, xavg             ! Differences and averages of successive values of x [H]
+  real                  :: dx                   ! Differences and averages of successive values of x [H]
   real, dimension(4,4)  :: Asys                 ! boundary conditions
   real, dimension(4)    :: Bsys, Csys
   real, dimension(N+1)  :: tri_l, &     ! tridiagonal system (lower diagonal) [nondim]
@@ -569,7 +567,6 @@ subroutine end_value_h4(dz, u, Csys)
   real :: I_denB3         ! The inverse of the product of three sums of thicknesses [H-3]
   real :: min_frac = 1.0e-6  ! The square of min_frac should be much larger than roundoff [nondim]
   real, parameter :: C1_3 = 1.0 / 3.0
-  integer :: i, j, k
 
   ! These are only used for code verification
   ! real, dimension(4) :: Atest  ! The  coefficients of an expression that is being tested.
@@ -706,7 +703,6 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answers_201
   real                  :: h0, h1               ! cell widths [H or nondim]
   real                  :: h0_2, h1_2, h0h1     ! products of cell widths [H2 or nondim]
   real                  :: h0_3, h1_3           ! products of three cell widths [H3 or nondim]
-  real                  :: h_min                ! A minimal cell width [H]
   real                  :: d                    ! A temporary variable [H3]
   real                  :: I_d                  ! A temporary variable [nondim]
   real                  :: I_h                  ! Inverses of thicknesses [H-1]
@@ -716,7 +712,7 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answers_201
   real, dimension(4)    :: dz                   ! A temporary array of limited layer thicknesses [H]
   real, dimension(4)    :: u_tmp                ! A temporary array of cell average properties [A]
   real, dimension(5)    :: x          ! Coordinate system with 0 at edges [H]
-  real                  :: dx, xavg   ! Differences and averages of successive values of x [H]
+  real                  :: dx         ! Differences and averages of successive values of x [H]
   real, dimension(4,4)  :: Asys       ! matrix used to find boundary conditions
   real, dimension(4)    :: Bsys, Csys
   real, dimension(3)    :: Dsys
@@ -927,7 +923,7 @@ subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answers_201
                            tri_b, &             ! trid. system (unknowns vector)
                            tri_x                ! trid. system (rhs)
   real :: h_Min_Frac = 1.0e-4
-  integer :: i, j, k              ! loop indexes
+  integer :: i, k   ! loop indexes
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
@@ -1162,7 +1158,7 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answers_2018 )
                            tri_u, &             ! trid. system (upper diagonal)
                            tri_b, &             ! trid. system (unknowns vector)
                            tri_x                ! trid. system (rhs)
-  integer :: i, j, k              ! loop indexes
+  integer :: i, k   ! loop indexes
 
   hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -283,7 +283,6 @@ subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
   logical,      optional, intent(in)    :: answers_2018  !< If true use older, less acccurate expressions.
 
   ! Local variables
-  logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
   integer        :: k ! loop index
   real           :: t ! current interface target density
 

--- a/src/ALE/regrid_solvers.F90
+++ b/src/ALE/regrid_solvers.F90
@@ -119,7 +119,6 @@ subroutine linear_solver( N, A, R, X )
   real    :: factor       ! The factor that eliminates the leading nonzero element in a row.
   real    :: I_pivot      ! The reciprocal of the pivot value [inverse of the input units of a row of A]
   real    :: swap
-  logical :: found_pivot  ! If true, a pivot has been found
   integer :: i, j, k
 
   ! Loop on rows to transform the problem into multiplication by an upper-right matrix.

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -178,11 +178,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv)
     dvdx, dudy, & ! Contributions to the circulation around q-points [L2 T-1 ~> m2 s-1]
     rel_vort, & ! Relative vorticity at q-points [T-1 ~> s-1].
     abs_vort, & ! Absolute vorticity at q-points [T-1 ~> s-1].
-    q2, &       ! Relative vorticity over thickness [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
-    max_fvq, &  ! The maximum of the adjacent values of (-u) times absolute vorticity [L T-2 ~> m s-2].
-    min_fvq, &  ! The minimum of the adjacent values of (-u) times absolute vorticity [L T-2 ~> m s-2].
-    max_fuq, &  ! The maximum of the adjacent values of u times absolute vorticity [L T-2 ~> m s-2].
-    min_fuq     ! The minimum of the adjacent values of u times absolute vorticity [L T-2 ~> m s-2].
+    q2          ! Relative vorticity over thickness [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
   real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)) :: &
     PV, &       ! A diagnostic array of the potential vorticities [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
     RV          ! A diagnostic array of the relative vorticities [T-1 ~> s-1].
@@ -193,9 +189,6 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv)
 
   real, parameter :: C1_12=1.0/12.0 ! C1_12 = 1/12
   real, parameter :: C1_24=1.0/24.0 ! C1_24 = 1/24
-  real :: absolute_vorticity     ! Absolute vorticity [T-1 ~> s-1].
-  real :: relative_vorticity     ! Relative vorticity [T-1 ~> s-1].
-  real :: Ih                     ! Inverse of thickness [H-1 ~> m-1 or m2 kg-1].
   real :: max_Ihq, min_Ihq       ! The maximum and minimum of the nearby Ihq [H-1 ~> m-1 or m2 kg-1].
   real :: hArea_q                ! The sum of area times thickness of the cells
                                  ! surrounding a q point [H L2 ~> m3 or kg].

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -831,7 +831,7 @@ subroutine PressureForce_Mont_init(Time, G, GV, US, param_file, diag, CS, tides_
   type(tidal_forcing_CS), intent(in), target, optional :: tides_CSp !< Tides control structure
 
   ! Local variables
-  logical :: use_temperature, use_EOS
+  logical :: use_EOS
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl   ! This module's name.

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2776,7 +2776,6 @@ subroutine set_dtbt(G, GV, US, CS, eta, pbce, BT_cont, gtot_est, SSH_add)
   logical :: use_BT_cont
   type(memory_size_type) :: MS
 
-  character(len=200) :: mesg
   integer :: i, j, k, is, ie, js, je, nz
 
   if (.not.CS%module_is_initialized) call MOM_error(FATAL, &
@@ -3086,10 +3085,9 @@ subroutine set_up_BT_OBC(OBC, eta, BT_OBC, BT_Domain, G, GV, US, MS, halo, use_B
 
   ! Local variables
   real :: I_dt      ! The inverse of the time interval of this call [T-1 ~> s-1].
-  integer :: i, j, k, is, ie, js, je, n, nz, Isq, Ieq, Jsq, Jeq
+  integer :: i, j, k, is, ie, js, je, n, nz
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   integer :: isdw, iedw, jsdw, jedw
-  logical :: OBC_used
   type(OBC_segment_type), pointer  :: segment !< Open boundary segment
 
   is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
@@ -3306,7 +3304,6 @@ subroutine btcalc(h, G, GV, CS, h_u, h_v, may_use_default, OBC)
                                ! in roundoff and can be neglected [H ~> m or kg m-2].
   real :: wt_arith             ! The weight for the arithmetic mean thickness [nondim].
                                ! The harmonic mean uses a weight of (1 - wt_arith).
-  real :: Rh                   ! A ratio of summed thicknesses [nondim]
   real :: e_u(SZIB_(G),SZK_(GV)+1) ! The interface heights at u-velocity points [H ~> m or kg m-2]
   real :: e_v(SZI_(G),SZK_(GV)+1)  ! The interface heights at v-velocity points [H ~> m or kg m-2]
   real :: D_shallow_u(SZI_(G)) ! The height of the shallower of the adjacent bathymetric depths
@@ -3622,8 +3619,6 @@ function uhbt_to_ubt(uhbt, BTC) result(ubt)
   real :: uherr_min, uherr_max   ! The bounding values of the transport error [H L2 T-1 ~> m3 s-1 or kg s-1]
                                  ! or [H L2 ~> m3 or kg].
   real, parameter :: tol = 1.0e-10 ! A fractional match tolerance [nondim]
-  real :: dvel  ! Temporary variable used in the limiting the velocity [L T-1 ~> m s-1] or [L ~> m].
-  real :: vsr   ! Temporary variable used in the limiting the velocity [nondim].
   real, parameter :: vs1 = 1.25  ! Nondimensional parameters used in limiting
   real, parameter :: vs2 = 2.0   ! the velocity, starting at vs1, with the
                                  ! maximum increase of vs2, both [nondim].
@@ -3757,8 +3752,6 @@ function vhbt_to_vbt(vhbt, BTC) result(vbt)
   real :: vherr_min, vherr_max   ! The bounding values of the transport error [H L2 T-1 ~> m3 s-1 or kg s-1]
                                  ! or [H L2 ~> m3 or kg].
   real, parameter :: tol = 1.0e-10 ! A fractional match tolerance [nondim]
-  real :: dvel  ! Temporary variable used in the limiting the velocity [L T-1 ~> m s-1] or [L ~> m].
-  real :: vsr   ! Temporary variable used in the limiting the velocity [nondim].
   real, parameter :: vs1 = 1.25  ! Nondimensional parameters used in limiting
   real, parameter :: vs2 = 2.0   ! the velocity, starting at vs1, with the
                                  ! maximum increase of vs2, both [nondim].
@@ -4295,8 +4288,6 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                                        ! name in wave_drag_file.
   real :: vel_rescale ! A rescaling factor for horizontal velocity from the representation in
                       ! a restart file to the internal representation in this run.
-  real :: uH_rescale  ! A rescaling factor for thickness transports from the representation in
-                      ! a restart file to the internal representation in this run.
   real :: mean_SL     ! The mean sea level that is used along with the bathymetry to estimate the
                       ! geometry when LINEARIZED_BT_CORIOLIS is true or BT_NONLIN_STRESS is false [Z ~> m].
   real :: det_de      ! The partial derivative due to self-attraction and loading of the reference
@@ -4309,7 +4300,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
   type(group_pass_type) :: pass_static_data, pass_q_D_Cor
   type(group_pass_type) :: pass_bt_hbt_btav, pass_a_polarity
   logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
-  logical :: apply_bt_drag, use_BT_cont_type
+  logical :: use_BT_cont_type
   character(len=48) :: thickness_units, flux_units
   character*(40) :: hvel_str
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -269,7 +269,6 @@ subroutine zonal_mass_flux(u, h_in, uh, dt, G, GV, US, CS, LB, OBC, por_face_are
   integer :: l_seg
   logical :: local_specified_BC, use_visc_rem, set_BT_cont, any_simple_OBC
   logical :: local_Flather_OBC, local_open_BC, is_simple
-  type(OBC_segment_type), pointer :: segment => NULL()
 
   use_visc_rem = present(visc_rem_u)
   local_specified_BC = .false. ; set_BT_cont = .false. ; local_Flather_OBC = .false.
@@ -1097,7 +1096,6 @@ subroutine meridional_mass_flux(v, h_in, vh, dt, G, GV, US, CS, LB, OBC, por_fac
   integer :: l_seg
   logical :: local_specified_BC, use_visc_rem, set_BT_cont, any_simple_OBC
   logical :: local_Flather_OBC, is_simple, local_open_BC
-  type(OBC_segment_type), pointer :: segment => NULL()
 
   use_visc_rem = present(visc_rem_v)
   local_specified_BC = .false. ; set_BT_cont = .false. ; local_Flather_OBC = .false.

--- a/src/core/MOM_density_integrals.F90
+++ b/src/core/MOM_density_integrals.F90
@@ -143,7 +143,6 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real :: p5(5)      ! Pressures at five quadrature points, never rescaled from Pa [Pa]
   real :: r5(5)      ! Densities at five quadrature points [R ~> kg m-3] or [kg m-3]
   real :: rho_anom   ! The depth averaged density anomaly [R ~> kg m-3] or [kg m-3]
-  real :: w_left, w_right ! Left and right weights [nondim]
   real, parameter :: C1_90 = 1.0/90.0  ! Rational constants.
   real :: GxRho      ! The gravitational acceleration times density and unit conversion factors [Pa Z-1 ~> kg m-2 s-2]
   real :: I_Rho      ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1] or [m3 kg-1]
@@ -1726,7 +1725,7 @@ end subroutine find_depth_of_pressure_in_cell
 
 
 !> Returns change in anomalous pressure change from top to non-dimensional
-!! position pos between z_t and z_b
+!! position pos between z_t and z_b [R L2 T-2 ~> Pa]
 real function frac_dp_at_pos(T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, G_e, pos, EOS)
   real,           intent(in)  :: T_t !< Potential temperature at the cell top [degC]
   real,           intent(in)  :: T_b !< Potential temperature at the cell bottom [degC]
@@ -1739,8 +1738,7 @@ real function frac_dp_at_pos(T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, G_e, pos, EO
   real,           intent(in)  :: G_e !< The Earth's gravitational acceleration [L2 Z-1 T-2 ~> m s-2]
   real,           intent(in)  :: pos !< The fractional vertical position, 0 to 1 [nondim]
   type(EOS_type), intent(in)  :: EOS !< Equation of state structure
-  real                        :: fract_dp_at_pos !< The change in pressure from the layer top to
-                                     !! fractional position pos [R L2 T-2 ~> Pa]
+
   ! Local variables
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
   real :: dz                 ! Distance from the layer top [Z ~> m]

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -997,7 +997,6 @@ subroutine register_restarts_dyn_split_RK2(HI, GV, US, param_file, CS, restart_C
                          target, intent(inout) :: vh !< merid volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
 
   type(vardesc)      :: vd(2)
-  character(len=40)  :: mdl = "MOM_dynamics_split_RK2" ! This module's name.
   character(len=48)  :: thickness_units, flux_units
 
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -536,7 +536,6 @@ subroutine register_restarts_dyn_unsplit(HI, GV, param_file, CS)
   type(MOM_dyn_unsplit_CS),  pointer    :: CS         !< The control structure set up by
                                                       !! initialize_dyn_unsplit.
 
-  character(len=40)  :: mdl = "MOM_dynamics_unsplit" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
@@ -619,7 +618,7 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, US, param_file, diag, CS
 
   ! Local variables
   character(len=40) :: mdl = "MOM_dynamics_unsplit" ! This module's name.
-  character(len=48) :: thickness_units, flux_units
+  character(len=48) :: flux_units
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   logical :: use_tides

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -566,7 +566,7 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, US, param_file, diag
 
   ! Local variables
   character(len=40) :: mdl = "MOM_dynamics_unsplit_RK2" ! This module's name.
-  character(len=48) :: thickness_units, flux_units
+  character(len=48) :: flux_units
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   logical :: use_tides

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1985,8 +1985,8 @@ subroutine fluxes_accumulate(flux_tmp, fluxes, G, wt2, forces)
   ! applied based on the time interval stored in flux_tmp.
 
   real :: wt1  ! The relative weight of the previous fluxes [nondim]
-  integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq, i0, j0
-  integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, isr, ier, jsr, jer
+  integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq
+  integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   is   = G%isc   ; ie   = G%iec    ; js   = G%jsc   ; je   = G%jec
   Isq  = G%IscB  ; Ieq  = G%IecB   ; Jsq  = G%JscB  ; Jeq  = G%JecB
   isd  = G%isd   ; ied  = G%ied    ; jsd  = G%jsd   ; jed  = G%jed
@@ -2284,7 +2284,7 @@ subroutine mech_forcing_diags(forces_in, dt, G, time_end, diag, handles)
   type(diag_ctrl),       intent(inout) :: diag     !< diagnostic type
   type(forcing_diags),   intent(inout) :: handles  !< diagnostic id for diag_manager
 
-  integer :: i,j,is,ie,js,je
+  integer :: is, ie, js, je
 
   type(mech_forcing), pointer :: forces
   integer :: turns
@@ -2958,7 +2958,6 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
 
   ! Local variables
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
-  logical :: heat_water
   logical :: shelf_sfc_acc
 
   isd  = G%isd   ; ied  = G%ied    ; jsd  = G%jsd   ; jed  = G%jed
@@ -3096,7 +3095,6 @@ subroutine allocate_mech_forcing_by_group(G, forces, stress, ustar, shelf, &
 
   ! Local variables
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
-  logical :: heat_water
 
   isd  = G%isd   ; ied  = G%ied    ; jsd  = G%jsd   ; jed  = G%jed
   IsdB = G%IsdB  ; IedB = G%IedB   ; JsdB = G%JsdB  ; JedB = G%JedB
@@ -3565,12 +3563,8 @@ subroutine homogenize_forcing(fluxes, G, GV, US)
   type(verticalGrid_type), intent(in)    :: GV     !< ocean vertical grid structure
   type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
 
-  real :: avg   ! Global average of a variable, in the same units as that variable
   logical :: do_ustar, do_water, do_heat, do_salt, do_press, do_shelf, &
       do_iceberg, do_heat_added, do_buoy
-  integer :: i, j, is, ie, js, je, isB, ieB, jsB, jeB
-  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
-  isB = G%iscB ; ieB = G%iecB ; jsB = G%jscB ; jeB = G%jecB
 
   call get_forcing_groups(fluxes, do_water, do_heat, do_ustar, do_press, &
       do_shelf, do_iceberg, do_salt, do_heat_added, do_buoy)

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -207,7 +207,7 @@ subroutine MOM_grid_init(G, param_file, US, HI, global_indexing, bathymetry_at_v
 
   ! Local variables
   real :: mean_SeaLev_scale ! A scaling factor for the reference height variable [1] or [Z m-1 ~> 1]
-  integer :: isd, ied, jsd, jed, nk
+  integer :: isd, ied, jsd, jed
   integer :: IsdB, IedB, JsdB, JedB
   integer :: ied_max, jed_max
   integer :: niblock, njblock, nihalo, njhalo, nblocks, n, i, j

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -98,7 +98,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, &
   real :: slope         ! The slope of density surfaces, calculated in a way
                         ! that is always between -1 and 1. [Z L-1 ~> nondim]
   real :: mag_grad2     ! The squared magnitude of the 3-d density gradient [R2 Z-2 ~> kg2 m-8].
-  real :: slope2_Ratio  ! The ratio of the slope squared to slope_max squared.
   real :: h_neglect     ! A thickness that is so small it is usually lost
                         ! in roundoff and can be neglected [H ~> m or kg m-2].
   real :: h_neglect2    ! h_neglect^2 [H2 ~> m2 or kg2 m-4].
@@ -219,7 +218,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, &
   !$OMP                          private(drdiA,drdiB,drdkL,drdkR,pres_u,T_u,S_u,      &
   !$OMP                                  drho_dT_u,drho_dS_u,hg2A,hg2B,hg2L,hg2R,haA, &
   !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
-  !$OMP                                  drdx,mag_grad2,slope,slope2_Ratio,l_seg)
+  !$OMP                                  drdx,mag_grad2,slope,l_seg)
   do j=js,je ; do K=nz,2,-1
     if (.not.(use_EOS)) then
       drdiA = 0.0 ; drdiB = 0.0
@@ -329,7 +328,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, &
   !$OMP                          private(drdjA,drdjB,drdkL,drdkR,pres_v,T_v,S_v,      &
   !$OMP                                  drho_dT_v,drho_dS_v,hg2A,hg2B,hg2L,hg2R,haA, &
   !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
-  !$OMP                                  drdy,mag_grad2,slope,slope2_Ratio,l_seg)
+  !$OMP                                  drdy,mag_grad2,slope,l_seg)
   do j=js-1,je ; do K=nz,2,-1
     if (.not.(use_EOS)) then
       drdjA = 0.0 ; drdjB = 0.0

--- a/src/core/MOM_porous_barriers.F90
+++ b/src/core/MOM_porous_barriers.F90
@@ -48,7 +48,7 @@ subroutine por_widths(h, tv, G, GV, US, eta, pbv, eta_bt, halo_size, eta_to_m)
   type(porous_barrier_ptrs),           intent(inout) :: pbv  !< porous barrier fractional cell metrics
 
   !local variables
-  integer ii, i, j, k, nk, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+  integer i, j, k, nk, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   real w_layer, & ! fractional open width of layer interface [nondim]
        A_layer, & ! integral of fractional open width from bottom to current layer[Z ~> m]
        A_layer_prev, & ! integral of fractional open width from bottom to previous layer [Z ~> m]

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -441,9 +441,8 @@ subroutine deallocate_surface_state(sfc_state)
 end subroutine deallocate_surface_state
 
 !> Rotate the surface state fields from the input to the model indices.
-subroutine rotate_surface_state(sfc_state_in, G_in, sfc_state, G, turns)
+subroutine rotate_surface_state(sfc_state_in, sfc_state, G, turns)
   type(surface), intent(in) :: sfc_state_in
-  type(ocean_grid_type), intent(in) :: G_in
   type(surface), intent(inout) :: sfc_state
   type(ocean_grid_type), intent(in) :: G
   integer, intent(in) :: turns

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -435,7 +435,7 @@ subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
   character(len=128) :: mesg2
 
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
-  integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed
+  integer :: isd, ied, jsd, jed
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   is_ch = G%isc ; ie_ch = G%iec ; js_ch = G%jsc ; je_ch = G%jec

--- a/src/diagnostics/MOM_obsolete_diagnostics.F90
+++ b/src/diagnostics/MOM_obsolete_diagnostics.F90
@@ -64,8 +64,6 @@ logical function diag_found(diag, varName, newVarName)
   type(diag_ctrl),            intent(in) :: diag       !< A structure used to control diagnostics.
   character(len=*),           intent(in) :: varName    !< The obsolete diagnostic name
   character(len=*), optional, intent(in) :: newVarName !< The valid name of this diagnostic
-  ! Local
-  integer :: handle ! Integer handle returned from diag_manager
 
   diag_found = found_in_diagtable(diag, varName)
 

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -23,8 +23,8 @@ subroutine find_obsolete_params(param_file)
   character(len=40)  :: mdl = "find_obsolete_params" ! This module's name.
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  integer :: test_int, l_seg, nseg
-  logical :: test_logic, test_logic2, test_logic3, split
+  integer :: l_seg, nseg
+  logical :: test_logic, split
   character(len=40)  :: temp_string
 
   if (.not.is_root_pe()) return

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -348,16 +348,12 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   real :: Salt_anom    ! The change in salt that cannot be accounted for by
                        ! the surface fluxes [ppt kg].
   real :: salin        ! The mean salinity of the ocean [ppt].
-  real :: salin_chg    ! The change in total salt since the last call
-                       ! to this subroutine divided by total mass [ppt].
   real :: salin_anom   ! The change in total salt that cannot be accounted for by
                        ! the surface fluxes divided by total mass [ppt].
   real :: Heat         ! The total amount of Heat in the ocean [J].
   real :: Heat_chg     ! The change in total ocean heat since the last call to this subroutine [J].
   real :: Heat_anom    ! The change in heat that cannot be accounted for by the surface fluxes [J].
   real :: temp         ! The mean potential temperature of the ocean [degC].
-  real :: temp_chg     ! The change in total heat divided by total heat capacity
-                       ! of the ocean since the last call to this subroutine, degC.
   real :: temp_anom    ! The change in total heat that cannot be accounted for
                        ! by the surface fluxes, divided by the total heat
                        ! capacity of the ocean [degC].
@@ -397,7 +393,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
                             ! calculation [kg T2 R-1 Z-1 L-2 s-2 ~> 1]
   integer :: num_nc_fields  ! The number of fields that will actually go into
                             ! the NetCDF file.
-  integer :: i, j, k, is, ie, js, je, ns, nz, m, Isq, Ieq, Jsq, Jeq, isr, ier, jsr, jer
+  integer :: i, j, k, is, ie, js, je, nz, m, Isq, Ieq, Jsq, Jeq, isr, ier, jsr, jer
   integer :: li, lbelow, labove  ! indices of deep_area_vol, used to find Z_0APE.
                                  ! lbelow & labove are lower & upper limits for li
                                  ! in the search for the entry in lH to use.
@@ -936,12 +932,6 @@ subroutine accumulate_net_input(fluxes, sfc_state, tv, dt, G, US, CS)
                ! over a time step [ppt kg].
     heat_in    ! The total heat added by surface fluxes, integrated
                ! over a time step [J].
-  real :: FW_input   ! The net fresh water input, integrated over a timestep
-                     ! and summed over space [kg].
-  real :: salt_input ! The total salt added by surface fluxes, integrated
-                     ! over a time step and summed over space [ppt kg].
-  real :: heat_input ! The total heat added by boundary fluxes, integrated
-                     ! over a time step and summed over space [J].
   real :: RZL2_to_kg ! A combination of scaling factors for mass [kg R-1 Z-1 L-2 ~> 1]
   real :: QRZL2_to_J ! A combination of scaling factors for heat [J Q-1 R-1 Z-1 L-2 ~> 1]
 
@@ -953,7 +943,6 @@ subroutine accumulate_net_input(fluxes, sfc_state, tv, dt, G, US, CS)
     heat_in_EFP      ! The total heat added by boundary fluxes, integrated
                      ! over a time step and summed over space [J].
 
-  real :: inputs(3)   ! A mixed array for combining the sums
   integer :: i, j, is, ie, js, je, isr, ier, jsr, jer
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -1287,8 +1276,7 @@ subroutine read_depth_list(G, US, DL, filename, require_chksum, file_matches)
 
   ! Local variables
   character(len=240) :: var_msg
-  real, allocatable :: tmp(:)
-  integer :: ncid, list_size, k, ndim, sizes(4)
+  integer :: list_size, ndim, sizes(4)
   character(len=:), allocatable :: depth_file_chksum, area_file_chksum
   character(len=16) :: depth_grid_chksum, area_grid_chksum
   logical :: depth_att_found, area_att_found

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -103,7 +103,7 @@ subroutine wave_speed(h, tv, G, GV, US, cg1, CS, full_halos, use_ebt_mode, mono_
     Rc, &         ! A column of layer densities after convective istabilities are removed [R ~> kg m-3]
     Hc_H          ! Hc(:) rescaled from Z to thickness units [H ~> m or kg m-2]
   real :: I_Htot  ! The inverse of the total filtered thicknesses [Z ~> m]
-  real :: det, ddet, detKm1, detKm2, ddetKm1, ddetKm2
+  real :: det, ddet
   real :: lam     ! The eigenvalue [T2 L-2 ~> s2 m-2]
   real :: dlam    ! The change in estimates of the eigenvalue [T2 L-2 ~> s2 m-2]
   real :: lam0    ! The first guess of the eigenvalue [T2 L-2 ~> s2 m-2]
@@ -207,7 +207,7 @@ subroutine wave_speed(h, tv, G, GV, US, cg1, CS, full_halos, use_ebt_mode, mono_
 !$OMP                                  Rc,speed2_tot,Igl,Igu,lam0,lam,lam_it,dlam, &
 !$OMP                                  mode_struct,sum_hc,N2min,gp,hw,                 &
 !$OMP                                  ms_min,ms_max,ms_sq,H_top,H_bot,I_Htot,merge,   &
-!$OMP                                  det,ddet,detKm1,ddetKm1,detKm2,ddetKm2,det_it,ddet_it)
+!$OMP                                  det,ddet,det_it,ddet_it)
   do j=js,je
     !   First merge very thin layers with the one above (or below if they are
     ! at the top).  This also transposes the row order so that columns can
@@ -722,7 +722,7 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, full_halos)
   logical :: sub_rootfound ! if true, subdivision has located root
   integer :: kc         ! The number of layers in the column after merging
   integer :: sub, sub_it
-  integer :: i, j, k, k2, itt, is, ie, js, je, nz, row, iint, m, ig, jg
+  integer :: i, j, k, k2, itt, is, ie, js, je, nz, iint, m
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 

--- a/src/diagnostics/MOM_wave_structure.F90
+++ b/src/diagnostics/MOM_wave_structure.F90
@@ -128,8 +128,7 @@ subroutine wave_structure(h, tv, G, GV, US, cn, ModeNum, freq, CS, En, full_halo
     Hc, &         !< A column of layer thicknesses after convective instabilities are removed [Z ~> m]
     Tc, &         !< A column of layer temperatures after convective instabilities are removed [degC]
     Sc, &         !< A column of layer salinites after convective instabilities are removed [ppt]
-    Rc, &         !< A column of layer densities after convective instabilities are removed [R ~> kg m-3]
-    det, ddet
+    Rc            !< A column of layer densities after convective instabilities are removed [R ~> kg m-3]
   real, dimension(SZI_(G),SZJ_(G)) :: &
     htot              !< The vertical sum of the thicknesses [Z ~> m]
   real :: lam         !< inverse of wave speed squared [T2 L-2 ~> s2 m-2]
@@ -141,7 +140,6 @@ subroutine wave_structure(h, tv, G, GV, US, cn, ModeNum, freq, CS, En, full_halo
     HxT_here, &    !< A layer integrated temperature [degC Z ~> degC m]
     HxS_here, &    !< A layer integrated salinity [ppt Z ~> ppt m]
     HxR_here       !< A layer integrated density [R Z ~> kg m-2]
-  real :: speed2_tot
   real :: I_Hnew   !< The inverse of a new layer thickness [Z-1 ~> m-1]
   real :: drxh_sum !< The sum of density diffrences across interfaces times thicknesses [R Z ~> kg m-2]
   real, parameter :: tol1  = 0.0001, tol2 = 0.001
@@ -613,7 +611,6 @@ subroutine tridiag_solver(a, b, c, h, y, method, x)
                                           ! intermediate values for solvers
   real    :: Q_prime, beta                ! intermediate values for solver
   integer :: k                            ! row (e.g. interface) index
-  integer :: i,j
 
   nrow = size(y)
   allocate(c_prime(nrow))

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -769,7 +769,6 @@ subroutine calculate_density_derivs_scalar(T, S, pressure, drho_dT, drho_dS, EOS
   ! Local variables
   real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
   real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
-  integer :: j
 
   p_scale = EOS%RL2_T2_to_Pa
 
@@ -947,7 +946,6 @@ subroutine calculate_spec_vol_derivs_array(T, S, pressure, dSV_dT, dSV_dS, start
   type(EOS_type),     intent(in)  :: EOS    !< Equation of state structure
 
   ! Local variables
-  real, dimension(size(T)) :: press   ! Pressure converted to [Pa]
   real, dimension(size(T)) :: rho     ! In situ density [kg m-3]
   real, dimension(size(T)) :: dRho_dT ! Derivative of density with temperature [kg m-3 degC-1]
   real, dimension(size(T)) :: dRho_dS ! Derivative of density with salinity [kg m-3 ppt-1]
@@ -1160,10 +1158,6 @@ subroutine analytic_int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
                             !! the same units as p_t [R L2 T-2 ~> Pa] or [Pa]
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
                             !! to interpolate T/S for top and bottom integrals.
-  ! Local variables
-  real :: pres_scale    ! A unit conversion factor from the rescaled units of pressure to Pa [Pa T2 R-1 L-2 ~> 1]
-  real :: SV_scale      ! A multiplicative factor by which to scale specific
-                        ! volume from m3 kg-1 to the desired units [kg m-3 R-1 ~> 1]
 
   ! We should never reach this point with quadrature. EOS_quadrature indicates that numerical
   ! integration be used instead of analytic. This is a safety check.
@@ -1453,8 +1447,7 @@ subroutine convert_temp_salt_for_TEOS10(T, S, HI, kd, mask_z, EOS)
   type(EOS_type),        intent(in)    :: EOS !< Equation of state structure
 
   integer :: i, j, k
-  real :: gsw_sr_from_sp, gsw_ct_from_pt, gsw_sa_from_sp
-  real :: p
+  real :: gsw_sr_from_sp, gsw_ct_from_pt
 
   if ((EOS%form_of_EOS /= EOS_TEOS10) .and. (EOS%form_of_EOS /= EOS_NEMO)) return
 

--- a/src/equation_of_state/MOM_EOS_NEMO.F90
+++ b/src/equation_of_state/MOM_EOS_NEMO.F90
@@ -184,8 +184,6 @@ subroutine calculate_density_scalar_nemo(T, S, pressure, rho, rho_ref)
   real,           intent(out) :: rho      !< In situ density [kg m-3].
   real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
 
-  real :: al0, p0, lambda
-  integer :: j
   real, dimension(1) :: T0, S0, pressure0
   real, dimension(1) :: rho0
 
@@ -212,7 +210,7 @@ subroutine calculate_density_array_nemo(T, S, pressure, rho, start, npts, rho_re
   real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
 
   ! Local variables
-  real :: zp, zt, zh, zs, zr0, zn, zn0, zn1, zn2, zn3, zs0
+  real :: zp, zt, zs, zr0, zn, zn0, zn1, zn2, zn3, zs0
   integer :: j
 
   do j=start,start+npts-1
@@ -276,7 +274,7 @@ subroutine calculate_density_derivs_array_nemo(T, S, pressure, drho_dT, drho_dS,
   integer, intent(in)                :: npts     !< The number of values to calculate.
 
   ! Local variables
-  real :: zp,zt , zh , zs , zr0, zn , zn0, zn1, zn2, zn3
+  real :: zp, zt, zs, zn, zn0, zn1, zn2, zn3
   integer :: j
 
   do j=start,start+npts-1
@@ -347,8 +345,6 @@ subroutine calculate_density_derivs_scalar_nemo(T, S, pressure, drho_dt, drho_ds
   real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
                                    !! in [kg m-3 ppt-1].
   ! Local variables
-  real :: al0, p0, lambda
-  integer :: j
   real, dimension(1) :: T0, S0, pressure0
   real, dimension(1) :: drdt0, drds0
 

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -351,7 +351,7 @@ subroutine calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start
   integer, intent(in)                  :: npts     !< The number of values to calculate.
 
   ! Local variables
-  real :: al0, p0, lambda, I_denom
+  real :: p0, lambda, I_denom
   integer :: j
 
   do j=start,start+npts-1

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -117,8 +117,6 @@ subroutine calculate_spec_vol_scalar_linear(T, S, pressure, specvol, &
   real,    intent(in)  :: dRho_dT  !< The derivatives of density with temperature [kg m-3 degC-1].
   real,    intent(in)  :: dRho_dS  !< The derivatives of density with salinity [kg m-3 ppt-1].
   real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
-  ! Local variables
-  integer :: j
 
   if (present(spv_ref)) then
     specvol = ((1.0 - Rho_T0_S0*spv_ref) + spv_ref*(dRho_dT*T + dRho_dS*S)) / &

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -531,7 +531,6 @@ subroutine chksum_pair_B_3d(mesg, arrayA, arrayB, HI, haloshift, symmetric, &
   logical,                   optional, intent(in) :: scalar_pair !< If true, then the arrays describe
                                                               !! a scalar, rather than vector
 
-  logical :: sym
   logical :: vector_pair
   integer :: turns
   type(hor_index_type), pointer :: HI_in

--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -245,11 +245,11 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
 
   integer(kind=8), dimension(ni)  :: ints_sum
   integer(kind=8) :: prec_error
-  real    :: rsum(1), rs
+  real    :: rsum(1)
   logical :: repro, do_sum_across_PEs
   character(len=256) :: mesg
   type(EFP_type) :: EFP_val ! An extended fixed point version of the sum
-  integer :: i, j, n, is, ie, js, je
+  integer :: i, j, is, ie, js, je
 
   if (num_PEs() > max_count_prec) call MOM_error(FATAL, &
     "reproducing_sum: Too many processors are being used for the value of "//&

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -348,7 +348,7 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
   ! Local variables
   integer :: id_xq, id_yq, id_zl, id_zi, id_xh, id_yh, id_null
   integer :: id_zl_native, id_zi_native
-  integer :: i, j, k, nz
+  integer :: i, j, nz
   real :: zlev(GV%ke), zinter(GV%ke+1)
   logical :: set_vert
   real, allocatable, dimension(:) :: IaxB,iax
@@ -586,7 +586,7 @@ subroutine set_axes_info_dsamp(G, GV, param_file, diag_cs, id_zl_native, id_zi_n
 
   ! Local variables
   integer :: id_xq, id_yq, id_zl, id_zi, id_xh, id_yh
-  integer :: i, j, k, nz, dl
+  integer :: i, j, nz, dl
   real, dimension(:), pointer :: gridLonT_dsamp =>NULL()
   real, dimension(:), pointer :: gridLatT_dsamp =>NULL()
   real, dimension(:), pointer :: gridLonB_dsamp =>NULL()
@@ -754,7 +754,7 @@ subroutine set_masks_for_axes(G, diag_cs)
   type(diag_ctrl),               pointer    :: diag_cs !< A pointer to a type with many variables
                                                        !! used for diagnostics
   ! Local variables
-  integer :: c, nk, i, j, k, ii, jj
+  integer :: c, nk, i, j, k
   type(axes_grp), pointer :: axes => NULL(), h_axes => NULL() ! Current axes, for convenience
 
   do c=1, diag_cs%num_diag_coords
@@ -852,9 +852,8 @@ subroutine set_masks_for_axes_dsamp(G, diag_cs)
   type(diag_ctrl),               pointer    :: diag_cs !< A pointer to a type with many variables
                                                        !! used for diagnostics
   ! Local variables
-  integer :: c, nk, i, j, k, ii, jj
-  integer :: dl
-  type(axes_grp), pointer :: axes => NULL(), h_axes => NULL() ! Current axes, for convenience
+  integer :: c, dl
+  type(axes_grp), pointer :: axes => NULL() ! Current axes, for convenience
 
   !Each downsampled axis needs both downsampled and non-downsampled mask
   !The downsampled mask is needed for sending out the diagnostics output via diag_manager
@@ -1377,7 +1376,7 @@ subroutine post_data_2d_low(diag, field, diag_cs, is_static, mask)
   character(len=300) :: mesg
   logical :: used, is_stat
   integer :: cszi, cszj, dszi, dszj
-  integer :: isv, iev, jsv, jev, i, j, chksum, isv_o,jsv_o
+  integer :: isv, iev, jsv, jev, i, j, isv_o,jsv_o
   real, dimension(:,:), allocatable, target :: locfield_dsamp
   real, dimension(:,:), allocatable, target :: locmask_dsamp
   integer :: dl
@@ -1522,7 +1521,6 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
 
   ! Local variables
   type(diag_type), pointer :: diag => null()
-  integer :: nz, i, j, k
   real, dimension(:,:,:), allocatable :: remapped_field
   logical :: staggered_in_x, staggered_in_y
   real, dimension(:,:,:), pointer :: h_diag => NULL()
@@ -1647,7 +1645,6 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
   logical :: is_stat
   integer :: cszi, cszj, dszi, dszj
   integer :: isv, iev, jsv, jev, ks, ke, i, j, k, isv_c, jsv_c, isv_o,jsv_o
-  integer :: chksum
   real, dimension(:,:,:), allocatable, target :: locfield_dsamp
   real, dimension(:,:,:), allocatable, target :: locmask_dsamp
   integer :: dl
@@ -2914,7 +2911,7 @@ function register_static_field(module_name, field_name, axes, &
   real :: MOM_missing_value
   type(diag_ctrl), pointer :: diag_cs => null()
   type(diag_type), pointer :: diag => null(), cmor_diag => null()
-  integer :: dm_id, fms_id, cmor_id
+  integer :: dm_id, fms_id
   character(len=256) :: posted_cmor_units, posted_cmor_standard_name, posted_cmor_long_name
   character(len=9) :: axis_name
 
@@ -3858,7 +3855,7 @@ end subroutine diag_restore_grids
 subroutine diag_grid_storage_end(grid_storage)
   type(diag_grid_storage), intent(inout) :: grid_storage !< Structure containing a snapshot of the target grids
   ! Local variables
-  integer :: m, nz
+  integer :: m
 
   ! Don't do anything else if there are no remapped coordinates
   if (grid_storage%num_diag_coords < 1) return
@@ -3881,7 +3878,7 @@ subroutine downsample_diag_masks_set(G, nz, diag_cs)
   type(diag_ctrl),               pointer    :: diag_cs !< A pointer to a type with many variables
                                                        !! used for diagnostics
   ! Local variables
-  integer :: i,j,k,ii,jj,dl
+  integer :: k, dl
 
 !print*,'original c extents ',G%isc,G%iec,G%jsc,G%jec
 !print*,'original c extents ',G%iscb,G%iecb,G%jscb,G%jecb
@@ -4297,7 +4294,6 @@ subroutine downsample_field_2d(field_in, field_out, dl, method, mask, diag_cs, d
   character(len=240) :: mesg
   integer :: i,j,ii,jj,i0,j0,f1,f2,f_in1,f_in2
   real :: ave, total_weight, weight
-  real :: epsilon = 1.0e-20  ! A negligibly small count of weights [nondim]
   real :: eps_area  ! A negligibly small area [L2 ~> m2]
   real :: eps_len   ! A negligibly small horizontal length [L ~> m]
 

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -189,16 +189,11 @@ subroutine diag_remap_configure_axes(remap_cs, GV, US, param_file)
   type(verticalGrid_type), intent(in)    :: GV !< ocean vertical grid structure
   type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< Parameter file structure
+
   ! Local variables
-  integer :: nzi(4), nzl(4), k
-  character(len=200) :: inputdir, string, filename, int_varname, layer_varname
   character(len=40)  :: mod  = "MOM_diag_remap" ! This module's name.
-  character(len=8)   :: units, expected_units
-  character(len=34)  :: longname, string2
-
-  character(len=256) :: err_msg
-  logical :: ierr
-
+  character(len=8)   :: units
+  character(len=34)  :: longname
   real, allocatable, dimension(:) :: interfaces, layers
 
   call initialize_regridding(remap_cs%regrid_cs, GV, US, GV%max_depth, param_file, mod, &
@@ -363,7 +358,7 @@ subroutine diag_remap_do_remap(remap_cs, G, GV, h, staggered_in_x, staggered_in_
   real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2]
   real :: h_neglect, h_neglect_edge ! Negligible thicknesses [H ~> m or kg m-2]
   integer :: nz_src, nz_dest
-  integer :: i, j, k                !< Grid index
+  integer :: i, j                   !< Grid index
   integer :: i1, j1                 !< 1-based index
   integer :: i_lo, i_hi, j_lo, j_hi !< (uv->h) interpolation indices
   integer :: shift                  !< Symmetric offset for 1-based indexing
@@ -502,7 +497,7 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered
   real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2]
   real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2]
   integer :: nz_src, nz_dest
-  integer :: i, j, k                !< Grid index
+  integer :: i, j                   !< Grid index
   integer :: i1, j1                 !< 1-based index
   integer :: i_lo, i_hi, j_lo, j_hi !< (uv->h) interpolation indices
   integer :: shift                  !< Symmetric offset for 1-based indexing
@@ -582,7 +577,7 @@ subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, sta
   real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2]
   real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2]
   integer :: nz_src, nz_dest
-  integer :: i, j, k                !< Grid index
+  integer :: i, j                   !< Grid index
   integer :: i1, j1                 !< 1-based index
   integer :: i_lo, i_hi, j_lo, j_hi !< (uv->h) interpolation indices
   integer :: shift                  !< Symmetric offset for 1-based indexing

--- a/src/framework/MOM_diag_vkernels.F90
+++ b/src/framework/MOM_diag_vkernels.F90
@@ -98,12 +98,11 @@ subroutine reintegrate_column(nsrc, h_src, uh_src, ndest, h_dest, missing_value,
   real, dimension(ndest), intent(in)    :: h_dest !< Thickness of destination cells
   real,                   intent(in)    :: missing_value !< Value to assign in vanished cells
   real, dimension(ndest), intent(inout) :: uh_dest !< Interpolated value at destination cell interfaces
+
   ! Local variables
-  real :: x_dest ! Relative position of target interface
   real :: h_src_rem, h_dest_rem, dh ! Incremental thicknesses
-  real :: uh_src_rem, uh_dest_rem, duh ! Incremental amounts of stuff
+  real :: uh_src_rem, duh ! Incremental amounts of stuff
   integer :: k_src, k_dest ! Index of cell in src and dest columns
-  integer :: iter
   logical :: src_ran_out, src_exists
 
   uh_dest(:) = missing_value
@@ -294,7 +293,6 @@ logical function test_interp(verbose, missing_value, msg, nsrc, h_src, u_src, nd
   real, dimension(ndest+1) :: u_dest ! Interpolated value at destination cell interfaces
   integer :: k
   real :: error
-  logical :: print_results
 
   ! Interpolate from src to dest
   call interpolate_column(nsrc, h_src, u_src, ndest, h_dest, missing_value, u_dest)
@@ -333,7 +331,6 @@ logical function test_reintegrate(verbose, missing_value, msg, nsrc, h_src, uh_s
   real, dimension(ndest) :: uh_dest ! Reintegrated value on destination cells
   integer :: k
   real :: error
-  logical :: print_results
 
   ! Interpolate from src to dest
   call reintegrate_column(nsrc, h_src, uh_src, ndest, h_dest, missing_value, uh_dest)

--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -389,7 +389,6 @@ subroutine doc_openBlock(doc, blockName, desc)
   character(len=*), optional, intent(in) :: desc !< A description of the parameter block being opened
 ! This subroutine handles documentation for opening a parameter block.
   character(len=mLen) :: mesg
-  character(len=doc%commentColumn) :: valstring
 
   if (.not. (is_root_pe() .and. associated(doc))) return
   call open_doc_file(doc)
@@ -413,7 +412,6 @@ subroutine doc_closeBlock(doc, blockName)
   character(len=*), intent(in) :: blockName !< The name of the parameter block being closed
 ! This subroutine handles documentation for closing a parameter block.
   character(len=mLen) :: mesg
-  character(len=doc%commentColumn) :: valstring
   integer :: i
 
   if (.not. (is_root_pe() .and. associated(doc))) return

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -311,9 +311,6 @@ subroutine rotate_dyn_horgrid(G_in, G, US, turns)
   type(unit_scale_type),  intent(in)    :: US     !< A dimensional unit scaling type
   integer, intent(in) :: turns                    !< Number of quarter turns
 
-  integer :: jsc, jec, jscB, jecB
-  integer :: qturn
-
   ! Center point
   call rotate_array(G_in%geoLonT, turns, G%geoLonT)
   call rotate_array(G_in%geoLatT, turns, G%geoLatT)

--- a/src/framework/MOM_error_handler.F90
+++ b/src/framework/MOM_error_handler.F90
@@ -85,7 +85,6 @@ subroutine disable_fatal_errors(env)
   type(sigjmp_buf), intent(in) :: env
     !> Process recovery state after FATAL errors
 
-  integer :: rc
   integer :: sig
 
   ignore_fatal = .true.
@@ -110,7 +109,6 @@ end subroutine disable_fatal_errors
 
 !> Disable the error handler and abort on FATAL
 subroutine enable_fatal_errors()
-  integer :: rc
   integer :: sig
   procedure(handler_interface), pointer :: dummy
 

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -136,7 +136,7 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
                                          !! the documentation files.  The default is effectively './'.
 
   ! Local variables
-  logical :: file_exists, unit_in_use, Netcdf_file, may_check, reopened_file
+  logical :: file_exists, Netcdf_file, may_check, reopened_file
   integer :: ios, iounit, strlen, i
   character(len=240) :: doc_path
   type(parameter_block), pointer :: block => NULL()
@@ -927,7 +927,7 @@ function max_input_line_length(CS, pf_num) result(max_len)
   character(len=FILENAME_LENGTH) :: filename
   character :: last_char
   integer :: ipf, ipf_s, ipf_e
-  integer :: last, last1, line_len, count, contBufSize
+  integer :: last, line_len, count, contBufSize
   logical :: continuedLine
 
   max_len = 0
@@ -1580,7 +1580,7 @@ subroutine log_param_time(CS, modulename, varname, value, desc, units, &
   logical :: use_timeunit, date_format
   character(len=240) :: mesg, myunits
   character(len=80) :: date_string, default_string
-  integer :: days, secs, ticks, ticks_per_sec
+  integer :: days, secs, ticks
 
   use_timeunit = .false.
   date_format = .false. ; if (present(log_date)) date_format = log_date
@@ -2021,7 +2021,7 @@ subroutine get_param_time(CS, modulename, varname, value, desc, units, &
   logical,          optional, intent(in)    :: log_as_date  !< If true, log the time_type in date
                                          !! format. The default is false.
 
-  logical :: do_read, do_log, date_format, log_date
+  logical :: do_read, do_log, log_date
 
   do_read = .true. ; if (present(do_not_read)) do_read = .not.do_not_read
   do_log  = .true. ; if (present(do_not_log))  do_log  = .not.do_not_log

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -295,13 +295,13 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   real, dimension(:,:),  allocatable   :: mask_in    ! A 2-d mask for extended input grid.
 
   real :: PI_180
-  integer :: rcode, ncid, varid, ndims, id, jd, kd, jdp
+  integer :: id, jd, kd, jdp
   integer :: i, j, k
-  integer, dimension(4) :: start, count, dims, dim_id
+  integer, dimension(4) :: start, count
   real, dimension(:,:), allocatable :: x_in, y_in
   real, dimension(:), allocatable  :: lon_in, lat_in ! The longitude and latitude in the input file
   real, dimension(:), allocatable  :: lat_inp ! The input file latitudes expanded to the pole
-  real :: max_lat, min_lat, pole, max_depth, npole
+  real :: max_lat, pole, max_depth, npole
   real :: roundoff  ! The magnitude of roundoff, usually ~2e-16.
   real :: add_offset, scale_factor
   logical :: found_attr
@@ -311,11 +311,9 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam,  conversion, 
   type(horiz_interp_type) :: Interp
   type(axis_info), dimension(4) :: axes_info ! Axis information used for regridding
   integer :: is, ie, js, je     ! compute domain indices
-  integer :: isc, iec, jsc, jec ! global compute domain indices
   integer :: isg, ieg, jsg, jeg ! global extent
   integer :: isd, ied, jsd, jed ! data domain indices
   integer :: id_clock_read
-  character(len=12)  :: dim_name(4)
   logical :: debug=.false.
   real :: npoints, varAvg
   real, dimension(SZI_(G),SZJ_(G)) :: lon_out, lat_out ! The longitude and latitude of points on the model grid
@@ -618,25 +616,22 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
   real, dimension(:,:),  allocatable   :: mask_in    !< A 2-d mask for extended input grid.
 
   real :: PI_180
-  integer :: rcode, ncid, varid, ndims, id, jd, kd, jdp
+  integer :: id, jd, kd, jdp
   integer :: i,j,k
-  integer, dimension(4) :: start, count, dims, dim_id
   real, dimension(:,:), allocatable :: x_in, y_in
   real, dimension(:), allocatable :: lon_in, lat_in ! The longitude and latitude in the input file
   real, dimension(:), allocatable :: lat_inp ! The input file latitudes expanded to the pole
-  real :: max_lat, min_lat, pole, max_depth, npole
+  real :: max_lat, pole, max_depth, npole
   real :: roundoff  ! The magnitude of roundoff, usually ~2e-16.
   logical :: add_np
   character(len=8)  :: laynum
   type(horiz_interp_type) :: Interp
   type(axistype), dimension(4) :: axes_data
   integer :: is, ie, js, je     ! compute domain indices
-  integer :: isc,iec,jsc,jec    ! global compute domain indices
   integer :: isg, ieg, jsg, jeg ! global extent
   integer :: isd, ied, jsd, jed ! data domain indices
   integer :: id_clock_read
   integer, dimension(4) :: fld_sz
-  character(len=12)  :: dim_name(4)
   logical :: debug=.false.
   logical :: spongeDataOngrid
   logical :: ans_2018

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -603,7 +603,7 @@ function num_timelevels(filename, varname, min_dims) result(n_time)
   integer :: n_time                           !< number of time levels varname has in filename
 
   character(len=256) :: msg
-  integer :: ncid, status, varid, ndims
+  integer :: ndims
   integer :: sizes(8)
 
   n_time = -1
@@ -926,7 +926,6 @@ subroutine read_variable_2d(filename, varname, var, start, nread, ncid_in)
   integer, allocatable :: field_start(:), field_nread(:)
   integer :: i, rc
   character(len=*), parameter :: hdr = "read_variable_2d: "
-  character(len=128) :: msg
 
   ! Validate shape of start and nread
   if (present(start)) then
@@ -2108,7 +2107,6 @@ subroutine MOM_write_field_4d(IO_handle, field_md, MOM_domain, field, tstamp, ti
   real, allocatable :: field_rot(:,:,:,:)  ! A rotated version of field, with the same units or rescaled
   real :: scale_fac ! A scaling factor to use before writing the array
   integer :: qturns ! The number of quarter turns through which to rotate field
-  integer :: is, ie, js, je ! The extent of the computational domain
 
   qturns = 0 ; if (present(turns)) qturns = modulo(turns, 4)
   scale_fac = 1.0 ; if (present(scale)) scale_fac = scale
@@ -2143,7 +2141,6 @@ subroutine MOM_write_field_3d(IO_handle, field_md, MOM_domain, field, tstamp, ti
   real, allocatable :: field_rot(:,:,:)  ! A rotated version of field, with the same units or rescaled
   real :: scale_fac ! A scaling factor to use before writing the array
   integer :: qturns ! The number of quarter turns through which to rotate field
-  integer :: is, ie, js, je ! The extent of the computational domain
 
   qturns = 0 ; if (present(turns)) qturns = modulo(turns, 4)
   scale_fac = 1.0 ; if (present(scale)) scale_fac = scale
@@ -2178,7 +2175,6 @@ subroutine MOM_write_field_2d(IO_handle, field_md, MOM_domain, field, tstamp, ti
   real, allocatable :: field_rot(:,:)  ! A rotated version of field, with the same units
   real :: scale_fac ! A scaling factor to use before writing the array
   integer :: qturns ! The number of quarter turns through which to rotate field
-  integer :: is, ie, js, je ! The extent of the computational domain
 
   qturns = 0 ; if (present(turns)) qturns = modulo(turns, 4)
   scale_fac = 1.0 ; if (present(scale)) scale_fac = scale
@@ -2307,7 +2303,7 @@ function ensembler(name, ens_no_in) result(en_nm)
   character(10) :: ens_num_char
   character(3)  :: code_str
   integer :: ens_no
-  integer :: n, is, ie
+  integer :: n, is
 
   en_nm = trim(name)
   if (index(name,"%") == 0) return
@@ -2408,7 +2404,6 @@ subroutine get_var_axes_info(filename, fieldname, axes_info)
   integer ::  ncid, varid, ndims
   integer :: id, jd, kd
   integer, dimension(4) :: dims, dim_id
-  real :: missing_value
   character(len=128)  :: dim_name(4)
   integer, dimension(1) :: start, count
   !! cartesian axis data

--- a/src/framework/MOM_random.F90
+++ b/src/framework/MOM_random.F90
@@ -192,7 +192,7 @@ integer function seed_from_index(HI, i, j)
   integer,              intent(in) :: i !< i-index (of h-cell)
   integer,              intent(in) :: j !< j-index (of h-cell)
   ! Local variables
-  integer :: ig, jg, ni, nj, ij
+  integer :: ig, jg, ni, nj
 
   ni = HI%niglobal
   nj = HI%njglobal

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -949,7 +949,6 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
   integer :: num_files                  ! The number of restart files that will be used.
   integer :: seconds, days, year, month, hour, minute
   character(len=8) :: hor_grid, z_grid, t_grid ! Variable grid info.
-  character(len=64) :: var_name         ! A variable's name.
   real :: conv                          ! Shorthand for the conversion factor
   real :: restart_time
   character(len=32) :: filename_appendix = '' ! Appendix to filename for ensemble runs
@@ -1131,17 +1130,12 @@ subroutine restore_state(filename, directory, day, G, CS)
   ! Local variables
   real :: scale  ! A scaling factor for reading a field
   real :: conv   ! The output conversion factor for writing a field
-  character(len=200) :: filepath  ! The path (dir/file) to the file being opened.
-  character(len=80) :: fname      ! The name of the current file.
-  character(len=8)  :: suffix     ! A suffix (like "_2") that is added to any
-                                  ! additional restart files.
   character(len=512) :: mesg      ! A message for warnings.
   character(len=80) :: varname    ! A variable's name.
   integer :: num_file        ! The number of files (restart files and others
                              ! explicitly in filename) that are open.
   integer :: i, n, m, missing_fields
-  integer :: isL, ieL, jsL, jeL, is0, js0
-  integer :: sizes(7)
+  integer :: isL, ieL, jsL, jeL
   integer :: nvar, ntime, pos
 
   type(file_type) :: IO_handles(CS%max_fields) ! The I/O units of all open files.

--- a/src/framework/MOM_string_functions.F90
+++ b/src/framework/MOM_string_functions.F90
@@ -247,7 +247,6 @@ integer function extract_integer(string, separators, n, missing_value)
   integer,            intent(in) :: n          !< Number of word to extract
   integer, optional,  intent(in) :: missing_value !< Value to assign if word is missing
   ! Local variables
-  integer :: ns, i, b, e, nw
   character(len=20) :: word
 
   word = extract_word(string, separators, n)
@@ -271,7 +270,6 @@ real function extract_real(string, separators, n, missing_value)
   integer,          intent(in) :: n          !< Number of word to extract
   real, optional,   intent(in) :: missing_value !< Value to assign if word is missing
   ! Local variables
-  integer :: ns, i, b, e, nw
   character(len=20) :: word
 
   word = extract_word(string, separators, n)

--- a/src/framework/MOM_write_cputime.F90
+++ b/src/framework/MOM_write_cputime.F90
@@ -138,7 +138,6 @@ subroutine write_cputime(day, n, CS, nmax, call_end)
                            ! this subroutine.
   integer :: new_cputime   ! The CPU time returned by SYSTEM_CLOCK
   real    :: reday         ! A real version of day.
-  character(len=256) :: mesg  ! The text of an error message
   integer :: start_of_day, num_days
 
   if (.not.associated(CS)) call MOM_error(FATAL, &

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -105,8 +105,7 @@ subroutine set_IS_axes_info(G, param_file, diag_cs, axes_set_name)
 !   This subroutine sets up the grid and axis information for use by the ice shelf model.
 
   ! Local variables
-  integer :: id_xq, id_yq, id_zl, id_zi, id_xh, id_yh, id_ct, id_ct0
-  integer :: k
+  integer :: id_xq, id_yq, id_xh, id_yh
   logical :: Cartesian_grid
   character(len=80) :: grid_config, units_temp, set_name
 ! This include declares and sets the variable "version".
@@ -531,7 +530,6 @@ integer function register_MOM_IS_static_field(module_name, field_name, axes, &
   integer,          optional, intent(in) :: tile_count   !< no clue (not used in MOM_IS?)
 
   ! Local variables
-  character(len=240) :: mesg
   real :: MOM_missing_value
   integer :: primary_id, fms_id
   type(diag_ctrl), pointer :: diag_cs !< A structure that is used to regulate diagnostic output
@@ -564,7 +562,7 @@ subroutine describe_option(opt_name, value, diag_CS)
 
   ! Local variables
   character(len=240) :: mesg
-  integer :: start_ind = 1, end_ind, len_ind
+  integer :: len_ind
 
   len_ind = len_trim(value)
 

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -45,7 +45,6 @@ subroutine initialize_ice_thickness(h_shelf, area_shelf_h, hmask, G, G_in, US, P
   logical, intent(in), optional        :: rotate_index !< If true, this is a rotation test
   integer, intent(in), optional        :: turns !< Number of turns for rotation test
 
-  integer :: i, j
   character(len=40)  :: mdl = "initialize_ice_thickness" ! This subroutine's name.
   character(len=200) :: config
   logical :: rotate = .false.
@@ -105,7 +104,7 @@ subroutine initialize_ice_thickness_from_file(h_shelf, area_shelf_h, hmask, G, U
   character(len=40)  :: mdl = "initialize_ice_thickness_from_file" ! This subroutine's name.
   integer :: i, j, isc, jsc, iec, jec
   logical :: hmask_set
-  real :: len_sidestress, mask, udh
+  real :: len_sidestress, udh
 
   call MOM_mesg("Initialize_ice_thickness_from_file: reading thickness")
 
@@ -196,7 +195,7 @@ subroutine initialize_ice_thickness_channel(h_shelf, area_shelf_h, hmask, G, US,
 
   character(len=40)  :: mdl = "initialize_ice_shelf_thickness_channel" ! This subroutine's name.
   real :: max_draft, min_draft, flat_shelf_width, c1, slope_pos
-  real :: edge_pos, shelf_slope_scale, Rho_ocean
+  real :: edge_pos, shelf_slope_scale
   integer :: i, j, jsc, jec, jsd, jed, jedg, nyh, isc, iec, isd, ied
   integer :: j_off
 
@@ -314,11 +313,10 @@ subroutine initialize_ice_shelf_boundary_channel(u_face_mask_bdry, v_face_mask_b
   type(param_file_type), intent(in)    :: PF !< A structure to parse for run-time parameters
 
   character(len=40)  :: mdl = "initialize_ice_shelf_boundary_channel" ! This subroutine's name.
-  integer :: i, j, isd, jsd, is, js, iegq, jegq, giec, gjec, gisc, gjsc,gisd,gjsd, isc, jsc, iec, jec, ied, jed
+  integer :: i, j, isd, jsd, giec, gjec, gisc, gjsc,gisd,gjsd, isc, jsc, iec, jec, ied, jed
   real    :: input_thick ! The input ice shelf thickness [Z ~> m]
   real    :: input_vel  ! The input ice velocity per  [L Z T-1 ~> m s-1]
   real    :: lenlat, len_stress, westlon, lenlon, southlat ! The input positions of the channel boundarises
-
 
   call get_param(PF, mdl, "LENLAT", lenlat, fail_if_missing=.true.)
 
@@ -417,8 +415,7 @@ subroutine initialize_ice_flow_from_file(bed_elev,u_shelf, v_shelf,float_cond,&
   character(len=200) :: ushelf_varname, vshelf_varname, &
                         ice_visc_varname, floatfr_varname, bed_varname  ! Variable name in file
   character(len=40)  :: mdl = "initialize_ice_velocity_from_file" ! This subroutine's name.
-  integer :: i, j, isc, jsc, iec, jec
-  real :: len_sidestress, mask, udh
+  real :: len_sidestress
 
   call MOM_mesg("  MOM_ice_shelf_init_profile.F90, initialize_velocity_from_file: reading velocity")
 
@@ -461,7 +458,6 @@ subroutine initialize_ice_flow_from_file(bed_elev,u_shelf, v_shelf,float_cond,&
 
   filename = trim(inputdir)//trim(bed_topo_file)
   call MOM_read_data(filename,trim(bed_varname), bed_elev, G%Domain, scale=1.)
-!  isc = G%isc ; jsc = G%jsc ; iec = G%iec ; jec = G%jec
 
 
 end subroutine initialize_ice_flow_from_file

--- a/src/ice_shelf/user_shelf_init.F90
+++ b/src/ice_shelf/user_shelf_init.F90
@@ -57,12 +57,7 @@ subroutine USER_initialize_shelf_mass(mass_shelf, area_shelf_h, h_shelf, hmask, 
                                                    !! being started from a restart file.
 
 ! This subroutine sets up the initial mass and area covered by the ice shelf.
-  real :: max_draft  ! The maximum ocean draft of the ice shelf [Z ~> m].
-  real :: min_draft  ! The minimum ocean draft of the ice shelf [Z ~> m].
-  real :: flat_shelf_width ! The range over which the shelf is min_draft thick.
-  real :: c1 ! The maximum depths in m.
   character(len=40) :: mdl = "USER_initialize_shelf_mass" ! This subroutine's name.
-  integer :: i, j
 
   ! call MOM_error(FATAL, "USER_shelf_init.F90, USER_set_shelf_mass: " // &
   !  "Unmodified user routine called - you must edit the routine to use it")

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -312,7 +312,7 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, US, param_file, eqn_of_sta
   real :: a1, frac_dense, k_frac  ! Nondimensional temporary variables [nondim]
   integer :: k, nz, k_light
   character(len=40)  :: mdl = "set_coord_from_TS_range" ! This subroutine's name.
-  character(len=200) :: filename, coord_file, inputdir ! Strings for file/path
+
   nz = GV%ke
 
   call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -172,10 +172,6 @@ subroutine set_grid_metrics_from_mosaic(G, param_file, US)
   type(param_file_type),  intent(in)    :: param_file  !< Parameter file structure
   type(unit_scale_type),  intent(in)    :: US    !< A dimensional unit scaling type
   ! Local variables
-  real, dimension(G%isd :G%ied ,G%jsd :G%jed ) :: tempH1, tempH2, tempH3, tempH4
-  real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB) :: tempQ1, tempQ2, tempQ3, tempQ4
-  real, dimension(G%IsdB:G%IedB,G%jsd :G%jed ) :: tempE1, tempE2
-  real, dimension(G%isd :G%ied ,G%JsdB:G%JedB) :: tempN1, tempN2
   ! These arrays are a holdover from earlier code in which the arrays in G were
   ! macros and may have had reduced dimensions.
   real, dimension(G%isd :G%ied ,G%jsd :G%jed ) :: dxT, dyT, areaT
@@ -527,7 +523,7 @@ subroutine set_grid_metrics_spherical(G, param_file, US)
   integer :: i_offset, j_offset
   real :: grid_latT(G%jsd:G%jed), grid_latB(G%JsdB:G%JedB)
   real :: grid_lonT(G%isd:G%ied), grid_lonB(G%IsdB:G%IedB)
-  real :: dLon,dLat,latitude,longitude,dL_di
+  real :: dLon, dLat, latitude, dL_di
   character(len=48)  :: mdl  = "MOM_grid_init set_grid_metrics_spherical"
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -661,7 +657,6 @@ subroutine set_grid_metrics_mercator(G, param_file, US)
   integer :: i, j, isd, ied, jsd, jed
   integer :: I_off, J_off
   type(GPS) :: GP
-  character(len=128) :: warnmesg
   character(len=48)  :: mdl = "MOM_grid_init set_grid_metrics_mercator"
   real :: PI, PI_2! PI = 3.1415926... as 4*atan(1), PI_2 = (PI) /2.0
   real :: y_q, y_h, jd, x_q, x_h, id
@@ -677,7 +672,7 @@ subroutine set_grid_metrics_mercator(G, param_file, US)
                           ! Int_dj_dy at a latitude or longitude that is
   real :: jRef, iRef      ! being set to be at grid index jRef or iRef.
   integer :: itt1, itt2
-  logical :: debug = .FALSE., simple_area = .true.
+  logical, parameter :: simple_area = .true.
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, IsdB, IedB, JsdB, JedB
 
   !   All of the metric terms should be defined over the domain from

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -802,7 +802,7 @@ subroutine reset_face_lengths_list(G, param_file, US)
   ! Local variables
   character(len=120), pointer, dimension(:) :: lines => NULL()
   character(len=120) :: line
-  character(len=200) :: filename, chan_file, inputdir, mesg ! Strings for file/path
+  character(len=200) :: filename, chan_file, inputdir   ! Strings for file/path
   character(len=40)  :: mdl = "reset_face_lengths_list" ! This subroutine's name.
   real, allocatable, dimension(:,:) :: &
     u_lat, u_lon, v_lat, v_lon ! The latitude and longitude ranges of faces [degrees]
@@ -826,7 +826,7 @@ subroutine reset_face_lengths_list(G, param_file, US)
   logical :: fatal_unused_lengths
   integer :: unused
   integer :: ios, iounit, isu, isv
-  integer :: last, num_lines, nl_read, ln, npt, u_pt, v_pt
+  integer :: num_lines, nl_read, ln, npt, u_pt, v_pt
   integer :: i, j, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   integer :: isu_por, isv_por
   logical :: found_u_por, found_v_por
@@ -1124,7 +1124,7 @@ subroutine read_face_length_list(iounit, filename, num_lines, lines)
   ! list file, after removing comments.
   character(len=120) :: line, line_up
   logical :: found_u, found_v
-  integer :: isu, isv, icom, verbose
+  integer :: isu, isv, icom
   integer :: last
 
   num_lines = 0

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -54,8 +54,6 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                                                                 !! This is not implemented yet.
   ! Local variables
   real :: land_fill = 0.0
-  character(len=200) :: inputdir ! The directory where NetCDF input files are.
-  character(len=200) :: mesg
   real               :: convert
   integer            :: recnum
   character(len=64)  :: remapScheme

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -161,22 +161,14 @@ subroutine init_oda(Time, G, GV, diag_CS, CS)
   type(directories) :: dirs
 
   type(grid_type), pointer :: T_grid !< global tracer grid
-  real, dimension(:,:), allocatable :: global2D, global2D_old
-  real, dimension(:), allocatable :: lon1D, lat1D, glon1D, glat1D
   type(param_file_type) :: PF
-  integer :: n, m, k, i, j, nk
-  integer :: is,ie,js,je,isd,ied,jsd,jed
-  integer :: isg,ieg,jsg,jeg
-  integer :: idg_offset, jdg_offset
-  integer :: stdout_unit
+  integer :: n
+  integer :: isd, ied, jsd, jed
   integer, dimension(4) :: fld_sz
   character(len=32) :: assim_method
-  integer :: npes_pm, ens_info(6), ni, nj
-  character(len=128) :: mesg
-  character(len=32) :: fldnam
+  integer :: npes_pm, ens_info(6)
   character(len=30) :: coord_mode
   character(len=200) :: inputdir, basin_file
-  logical :: reentrant_x, reentrant_y, tripolar_N, symmetric
   character(len=80) :: remap_scheme
   character(len=80) :: bias_correction_file, inc_file
 
@@ -388,14 +380,8 @@ subroutine set_prior_tracer(Time, G, GV, h, tv, CS)
 
   type(ODA_CS), pointer :: CS !< ocean DA control structure
   real, dimension(SZI_(G),SZJ_(G),CS%nk) :: T, S
-  type(ocean_grid_type), pointer :: Grid=>NULL()
-  integer :: i,j, m, n, ss
-  integer :: is, ie, js, je
+  integer :: i, j, m
   integer :: isc, iec, jsc, jec
-  integer :: isd, ied, jsd, jed
-  integer :: isg, ieg, jsg, jeg, idg_offset, jdg_offset
-  integer :: id
-  logical :: used, symmetric
 
   ! return if not time for analysis
   if (Time < CS%Time) return
@@ -449,8 +435,8 @@ subroutine get_posterior_tracer(Time, CS, h, tv, increment)
   logical, optional, intent(in) :: increment !< True if returning increment only
 
   type(ocean_control_struct), pointer :: Ocean_increment=>NULL()
-  integer :: i, j, m
-  logical :: used, get_inc
+  integer :: m
+  logical :: get_inc
   integer :: seconds_per_hour = 3600.
 
   ! return if not analysis time (retain pointers for h and tv)
@@ -506,10 +492,6 @@ end subroutine get_posterior_tracer
 subroutine oda(Time, CS)
   type(time_type), intent(in) :: Time !< the current model time
   type(oda_CS), pointer :: CS !< A pointer the ocean DA control structure
-
-  integer :: i, j
-  integer :: m
-  integer :: yr, mon, day, hr, min, sec
 
   if ( Time >= CS%Time ) then
 
@@ -581,7 +563,7 @@ subroutine init_ocean_ensemble(CS,Grid,GV,ens_size)
   type(verticalGrid_type), pointer :: GV !< Pointer to DA vertical grid
   integer, intent(in) :: ens_size !< ensemble size
 
-  integer :: n,is,ie,js,je,nk
+  integer :: is, ie, js, je, nk
 
   nk=GV%ke
   is=Grid%isd;ie=Grid%ied
@@ -642,8 +624,7 @@ subroutine apply_oda_tracer_increments(dt, Time_end, G, GV, tv, h, CS)
   type(ODA_CS), pointer                   :: CS !< the data assimilation structure
 
   !! local variables
-  integer :: yr, mon, day, hr, min, sec
-  integer :: i, j, k
+  integer :: i, j
   integer :: isc, iec, jsc, jec
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: T_inc !< an adjustment to the temperature
                                                     !! tendency [degC T-1 -> degC s-1]
@@ -651,7 +632,6 @@ subroutine apply_oda_tracer_increments(dt, Time_end, G, GV, tv, h, CS)
                                                     !! tendency [g kg-1 T-1 -> g kg-1 s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(CS%Grid)) :: T !< The updated temperature [degC]
   real, dimension(SZI_(G),SZJ_(G),SZK_(CS%Grid)) :: S !< The updated salinity [g kg-1]
-  real :: missing_value
 
   if (.not. associated(CS)) return
   if (CS%assim_method == NO_ASSIM .and. (.not. CS%do_bias_adjustment)) return

--- a/src/ocean_data_assim/MOM_oda_incupd.F90
+++ b/src/ocean_data_assim/MOM_oda_incupd.F90
@@ -1,6 +1,6 @@
 !> This module contains the routines used to apply incremental updates
 !! from data assimilation.
-!!
+!
 !! Applying incremental updates requires the following:
 !! 1. initialize_oda_incupd_fixed and initialize_oda_incupd
 !! 2. set_up_oda_incupd_field (tracers) and set_up_oda_incupd_vel_field (vel)
@@ -137,7 +137,6 @@ subroutine initialize_oda_incupd( G, GV, US, param_file, CS, data_h, nz_data, re
   logical :: reset_ncount
   integer :: i, j, k
   real    :: nhours_incupd, dt, dt_therm
-  type(vardesc) :: vd
   character(len=256) :: mesg
   character(len=64)  :: remapScheme
   if (.not.associated(CS)) then
@@ -338,7 +337,6 @@ subroutine calc_oda_increments(h, tv, u, v, G, GV, US, CS)
   integer :: isB, ieB, jsB, jeB
   real :: h_neglect, h_neglect_edge  ! Negligible thicknesses [H ~> m or kg m-2]
   real :: sum_h1, sum_h2 ! vertical sums of h's [H ~> m or kg m-2]
-  character(len=256) :: mesg
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   isB = G%iscB ; ieB = G%iecB ; jsB = G%jscB ; jeB = G%jecB
@@ -523,7 +521,6 @@ subroutine apply_oda_incupd(h, tv, u, v, dt, G, GV, US, CS)
   type(oda_incupd_CS),       pointer       :: CS !< A pointer to the control structure for this module
                                                  !! that is set by a previous call to initialize_oda_incupd (in).
 
-  real :: m_to_Z                                ! A unit conversion factor from m to Z.
   real, allocatable, dimension(:) :: tmp_val2   ! data values on the increment grid
   real, dimension(SZK_(GV)) :: tmp_val1         ! data values remapped to model grid
   real, dimension(SZK_(GV)) :: hu, hv           ! A column of thicknesses at u or v points [H ~> m or kg m-2]

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -705,8 +705,6 @@ subroutine MEKE_equilibrium(CS, MEKE, G, GV, US, SN_u, SN_v, drag_rate_visc, I_m
   real :: tolerance ! Width of EKE bracket [L2 T-2 ~> m2 s-2].
   logical :: useSecant, debugIteration
 
-  real :: Lgrid, Ldeform, Lfrict
-
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
   debugIteration = .false.
@@ -1036,7 +1034,7 @@ logical function MEKE_init(Time, G, US, param_file, diag, CS, MEKE, restart_CS)
   real    :: MEKE_restoring_timescale ! The timescale used to nudge MEKE toward its equilibrium value.
   real :: cdrag            ! The default bottom drag coefficient [nondim].
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
-  logical :: laplacian, biharmonic, useVarMix, coldStart
+  logical :: laplacian, biharmonic, coldStart
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_MEKE" ! This module's name.

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -291,8 +291,6 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     str_xy_GME, & ! smoothed cross term in the stress tensor from GME [H L2 T-2 ~> m3 s-2 or kg s-2]
     bhstr_xy, &   ! A copy of str_xy that only contains the biharmonic contribution [H L2 T-2 ~> m3 s-2 or kg s-2]
     vort_xy, &    ! Vertical vorticity (dv/dx - du/dy) including metric terms [T-1 ~> s-1]
-    Leith_Kh_q, & ! Leith Laplacian viscosity at q-points [L2 T-1 ~> m2 s-1]
-    Leith_Ah_q, & ! Leith bi-harmonic viscosity at q-points [L4 T-1 ~> m4 s-1]
     grad_vort_mag_q, & ! Magnitude of vorticity gradient at q-points [L-1 T-1 ~> m-1 s-1]
     grad_vort_mag_q_2d, & ! Magnitude of 2d vorticity gradient at q-points [L-1 T-1 ~> m-1 s-1]
     Del2vort_q, & ! Laplacian of vorticity at q-points [L-2 T-1 ~> m-2 s-1]
@@ -328,9 +326,6 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     GME_coeff_h      ! GME coeff. at h-points [L2 T-1 ~> m2 s-1]
   real :: AhSm       ! Smagorinsky biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: AhLth      ! 2D Leith biharmonic viscosity [L4 T-1 ~> m4 s-1]
-  real :: mod_Leith  ! nondimensional coefficient for divergence part of modified Leith
-                     ! viscosity. Here set equal to nondimensional Laplacian Leith constant.
-                     ! This is set equal to zero if modified Leith is not used.
   real :: Shear_mag_bc  ! Shear_mag value in backscatter [T-1 ~> s-1]
   real :: sh_xx_sq   ! Square of tension (sh_xx) [T-2 ~> s-2]
   real :: sh_xy_sq   ! Square of shearing strain (sh_xy) [T-2 ~> s-2]
@@ -343,23 +338,16 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   real :: h_neglect  ! thickness so small it can be lost in roundoff and so neglected [H ~> m or kg m-2]
   real :: h_neglect3 ! h_neglect^3 [H3 ~> m3 or kg3 m-6]
   real :: h_min      ! Minimum h at the 4 neighboring velocity points [H ~> m]
-  real :: Kh_scale  ! A factor between 0 and 1 by which the horizontal
-                    ! Laplacian viscosity is rescaled [nondim]
   real :: RoScl     ! The scaling function for MEKE source term [nondim]
   real :: FatH      ! abs(f) at h-point for MEKE source term [T-1 ~> s-1]
   real :: local_strain ! Local variable for interpolating computed strain rates [T-1 ~> s-1].
   real :: meke_res_fn ! A copy of the resolution scaling factor if being applied to MEKE. Otherwise =1.
   real :: GME_coeff ! The GME (negative) viscosity coefficient [L2 T-1 ~> m2 s-1]
-  real :: GME_coeff_limiter ! Maximum permitted value of the GME coefficient [L2 T-1 ~> m2 s-1]
-  real :: FWfrac    ! Fraction of maximum theoretical energy transfer to use when scaling GME coefficient [nondim]
   real :: DY_dxBu   ! Ratio of meridional over zonal grid spacing at vertices [nondim]
   real :: DX_dyBu   ! Ratio of zonal over meridiononal grid spacing at vertices [nondim]
-  real :: DY_dxCv   ! Ratio of meridional over zonal grid spacing at faces [nondim]
-  real :: DX_dyCu   ! Ratio of zonal over meridional grid spacing at faces [nondim]
   real :: Sh_F_pow  ! The ratio of shear over the absolute value of f raised to some power and rescaled [nondim]
   real :: backscat_subround ! The ratio of f over Shear_mag that is so small that the backscatter
                     ! calculation gives the same value as if f were 0 [nondim].
-  real :: H0_GME    ! Depth used to scale down GME coefficient in shallow areas [Z ~> m]
   real :: KE        ! Local kinetic energy [L2 T-2 ~> m2 s-2]
   real :: d_del2u   ! dy-weighted Laplacian(u) diff in x [L-2 T-1 ~> m-2 s-1]
   real :: d_del2v   ! dx-weighted Laplacian(v) diff in y [L-2 T-1 ~> m-2 s-1]
@@ -391,14 +379,6 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     vert_vort_mag, &  ! magnitude of the vertical vorticity gradient (h or q) [L-1 T-1 ~> m-1 s-1]
     hrat_min, &     ! h_min divided by the thickness at the stress point (h or q) [nondim]
     visc_bound_rem  ! fraction of overall viscous bounds that remain to be applied (h or q) [nondim]
-
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
-    hf_diffu_2d, &    ! Depth sum of hf_diffu, hf_diffv [L T-2 ~> m s-2]
-    intz_diffu_2d     ! Depth-integral of diffu [H L T-2 ~> m2 s-2]
-
-  real, dimension(SZI_(G),SZJB_(G)) :: &
-    hf_diffv_2d, &    ! Depth sum of hf_diffu, hf_diffv [L T-2 ~> m s-2]
-    intz_diffv_2d     ! Depth-integral of diffv [H L T-2 ~> m2 s-2]
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -542,8 +522,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   !$OMP   is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, &
   !$OMP   apply_OBC, rescale_Kh, legacy_bound, find_FrictWork, &
   !$OMP   use_MEKE_Ku, use_MEKE_Au, &
-  !$OMP   backscat_subround, GME_coeff_limiter, GME_effic_h, GME_effic_q, &
-  !$OMP   h_neglect, h_neglect3, FWfrac, inv_PI3, inv_PI6, H0_GME, &
+  !$OMP   backscat_subround, GME_effic_h, GME_effic_q, &
+  !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
   !$OMP   diffu, diffv, Kh_h, Kh_q, Ah_h, Ah_q, FrictWork, FrictWork_GME, &
   !$OMP   div_xx_h, sh_xx_h, vort_xy_q, sh_xy_q, GME_coeff_h, GME_coeff_q, &
   !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt &
@@ -560,7 +540,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   !$OMP   meke_res_fn, Shear_mag, Shear_mag_bc, vert_vort_mag, h_min, hrat_min, visc_bound_rem, &
   !$OMP   grid_Ah, grid_Kh, d_Del2u, d_Del2v, d_str, &
   !$OMP   Kh, Ah, AhSm, AhLth, local_strain, Sh_F_pow, &
-  !$OMP   dDel2vdx, dDel2udy, DY_dxCv, DX_dyCu, Del2vort_q, Del2vort_h, KE, &
+  !$OMP   dDel2vdx, dDel2udy, Del2vort_q, Del2vort_h, KE, &
   !$OMP   h2uq, h2vq, hu, hv, hq, FatH, RoScl, GME_coeff &
   !$OMP )
   do k=1,nz
@@ -2553,7 +2533,7 @@ subroutine smooth_GME(CS, G, GME_flux_h, GME_flux_q)
   real, dimension(SZI_(G),SZJ_(G)) :: GME_flux_h_original
   real, dimension(SZIB_(G),SZJB_(G)) :: GME_flux_q_original
   real :: wc, ww, we, wn, ws ! averaging weights for smoothing
-  integer :: i, j, k, s, halosz
+  integer :: i, j, s, halosz
   integer :: xh, xq  ! The number of valid extra halo points for h and q points.
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -216,7 +216,7 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS)
   real :: dx_term ! A term in the denominator [L2 T-2 ~> m2 s-2] or [m2 s-2]
   integer :: power_2
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
-  integer :: i, j, k
+  integer :: i, j
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
@@ -526,7 +526,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
   real :: Hup, Hdn      ! Thickness from above, below [H ~> m or kg m-2]
   real :: H_geom        ! The geometric mean of Hup*Hdn [H ~> m or kg m-2].
   integer :: is, ie, js, je, nz
-  integer :: i, j, k, kb_max
+  integer :: i, j, k
   integer :: l_seg
   real :: S2max, wNE, wSE, wSW, wNW
   real :: H_u(SZIB_(G)), H_v(SZI_(G))
@@ -876,7 +876,7 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e, calculate_slop
   real :: H_geom        ! The geometric mean of Hup*Hdn [H ~> m or kg m-2].
   real :: one_meter     ! One meter in thickness units [H ~> m or kg m-2].
   integer :: is, ie, js, je, nz
-  integer :: i, j, k, kb_max
+  integer :: i, j, k
   integer :: l_seg
   real    :: S2N2_u_local(SZIB_(G), SZJ_(G),SZK_(GV))
   real    :: S2N2_v_local(SZI_(G), SZJB_(G),SZK_(GV))

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -154,7 +154,6 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     htot          ! The sum of the total layer thicknesses [H ~> m or kg m-2]
   real :: Khth_Loc_u(SZIB_(G),SZJ_(G))
   real :: Khth_Loc_v(SZI_(G),SZJB_(G))
-  real :: Khth_Loc(SZIB_(G),SZJB_(G))  ! locally calculated thickness diffusivity [L2 T-1 ~> m2 s-1]
   real :: h_neglect ! A thickness that is so small it is usually lost
                     ! in roundoff and can be neglected [H ~> m or kg m-2].
   real, dimension(:,:), pointer :: cg1 => null() !< Wave speed [L T-1 ~> m s-1]

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -246,11 +246,9 @@ subroutine tidal_forcing_init(Time, G, US, param_file, CS)
   real, dimension(MAX_CONSTITUENTS) :: amp_def  ! Default amplitude for each tidal constituent [m]
   real, dimension(MAX_CONSTITUENTS) :: love_def ! Default love number for each constituent [nondim]
   integer, dimension(3) :: tide_ref_date !< Reference date (t = 0) for tidal forcing.
-  logical :: use_const  ! True if a constituent is being used.
   logical :: use_M2, use_S2, use_N2, use_K2, use_K1, use_O1, use_P1, use_Q1
   logical :: use_MF, use_MM
   logical :: tides      ! True if a tidal forcing is to be used.
-  logical :: FAIL_IF_MISSING = .true.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_tidal_forcing" ! This module's name.

--- a/src/parameterizations/stochastic/MOM_stochastics.F90
+++ b/src/parameterizations/stochastic/MOM_stochastics.F90
@@ -58,7 +58,6 @@ subroutine stochastics_init(dt, grid, GV, CS, param_file, diag, Time)
   integer :: mom_comm          ! list of pes for this instance of the ocean
   integer :: num_procs         ! number of processors to pass to stochastic physics
   integer :: iret              ! return code from stochastic physics
-  integer :: me                !  my pe
   integer :: pe_zero           !  root pe
   integer :: nx                ! number of x-points including halo
   integer :: ny                ! number of x-points including halo

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -434,8 +434,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
   logical :: use_sponge
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
   logical :: default_2018_answers
-  logical :: spongeDataOngrid = .false.
-  integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
+  integer :: i, j, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
 
   if (associated(CS)) then
     call MOM_error(WARNING, "initialize_ALE_sponge_varying called with an associated "// &
@@ -628,7 +627,7 @@ subroutine set_up_ALE_sponge_field_fixed(sp_val, G, GV, f_ptr, CS)
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                    target, intent(in) :: f_ptr !< Pointer to the field to be damped
 
-  integer :: j, k, col
+  integer :: k, col
   character(len=256) :: mesg ! String for error messages
 
   if (.not.associated(CS)) return
@@ -670,19 +669,11 @@ subroutine set_up_ALE_sponge_field_varying(filename, fieldname, Time, G, GV, US,
   type(ALE_sponge_CS),     pointer    :: CS    !< Sponge control structure (in/out).
 
   ! Local variables
-  real, allocatable, dimension(:,:,:) :: sp_val !< Field to be used in the sponge
-  real, allocatable, dimension(:,:,:) :: mask_z !< Field mask for the sponge data
-  real, allocatable, dimension(:), target :: z_in, z_edges_in ! Heights [Z ~> m].
-  real :: missing_value
-  integer :: j, k, col
-  integer :: isd,ied,jsd,jed
-  integer :: nPoints
+  integer :: isd, ied, jsd, jed
   integer, dimension(4) :: fld_sz
   integer :: nz_data !< the number of vertical levels in this input field
   character(len=256) :: mesg ! String for error messages
   ! Local variables for ALE remapping
-  real :: zTopOfCell, zBottomOfCell ! Heights [Z ~> m].
-  type(remapping_CS) :: remapCS ! Remapping parameters and work arrays
 
   if (.not.associated(CS)) return
   ! initialize time interpolator module
@@ -731,8 +722,7 @@ subroutine set_up_ALE_sponge_vel_field_fixed(u_val, v_val, G, GV, u_ptr, v_ptr, 
   real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u-field to be damped [L T-1 ~> m s-1]
   real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v-field to be damped [L T-1 ~> m s-1]
 
-  integer :: j, k, col, fld_sz(4)
-  character(len=256) :: mesg ! String for error messages
+  integer :: k, col
 
   if (.not.associated(CS)) return
 
@@ -771,19 +761,10 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename
   real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v-field to be damped [L T-1 ~> m s-1]
 
   ! Local variables
-  real, allocatable, dimension(:,:,:) :: u_val !< U field to be used in the sponge [L T-1 ~> m s-1].
-  real, allocatable, dimension(:,:,:) :: v_val !< V field to be used in the sponge [L T-1 ~> m s-1].
-
-  real, allocatable, dimension(:), target :: z_in, z_edges_in
-  real :: missing_value
   logical :: override
-
-  integer :: j, k, col
   integer :: isd, ied, jsd, jed
   integer :: isdB, iedB, jsdB, jedB
   integer, dimension(4) :: fld_sz
-  character(len=256) :: mesg ! String for error messages
-  integer :: tmp
   if (.not.associated(CS)) return
 
   override =.true.
@@ -838,7 +819,6 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
 
   real :: damp                                  ! The timestep times the local damping coefficient [nondim].
   real :: I1pdamp                               ! I1pdamp is 1/(1 + damp). [nondim].
-  real :: m_to_Z                                ! A unit conversion factor from m to Z.
   real, allocatable, dimension(:) :: tmp_val2   ! data values on the original grid
   real, dimension(SZK_(GV)) :: tmp_val1         ! data values remapped to model grid
   real, dimension(SZK_(GV)) :: h_col            ! A column of thicknesses at h, u or v points [H ~> m or kg m-2]
@@ -852,8 +832,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
   real, dimension(:), allocatable :: hsrc       ! Source thicknesses [Z ~> m].
   ! Local variables for ALE remapping
   real, dimension(:), allocatable :: tmpT1d
-  integer :: c, m, nkmb, i, j, k, is, ie, js, je, nz, nz_data
-  integer :: col, total_sponge_cols
+  integer :: c, m, i, j, k, is, ie, js, je, nz, nz_data
   real, allocatable, dimension(:), target :: z_in  ! The depths (positive downward) in the input file [Z ~> m]
   real, allocatable, dimension(:), target :: z_edges_in ! The depths (positive downward) of the
                                                         ! edges in the input file [Z ~> m]

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -199,7 +199,6 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive)
   character(len=20) :: string          !< local temporary string
   character(len=20) :: langmuir_mixing_opt = 'NONE' !< langmuir mixing opt to be passed to CVMix, e.g., LWF16
   character(len=20) :: langmuir_entrainment_opt = 'NONE' !< langmuir entrainment opt to be passed to CVMix, e.g., LWF16
-  character(len=20) :: wave_method
   logical :: CS_IS_ONE=.false.         !< Logical for setting Cs based on Non-local
   logical :: lnoDGat1=.false.          !< True => G'(1) = 0 (shape function)
                                        !! False => compute G'(1) as in LMD94
@@ -947,7 +946,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   real :: surfFricVel, surfBuoyFlux, Coriolis
   real :: GoRho  ! Gravitational acceleration divided by density in MKS units [m R-1 s-2 ~> m4 kg-1 s-2]
   real :: pRef   ! The interface pressure [R L2 T-2 ~> Pa]
-  real :: rho1, rhoK, Uk, Vk, sigma, sigmaRatio
+  real :: Uk, Vk
 
   real :: zBottomMinusOffset   ! Height of bottom plus a little bit [m]
   real :: SLdepth_0d           ! Surface layer depth = surf_layer_ext*OBLdepth.
@@ -966,11 +965,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   real :: LangEnhVt2   ! Langmuir enhancement for unresolved shear
   real, dimension(GV%ke) :: U_H, V_H
   real :: MLD_GUESS, LA
-  real :: surfHuS, surfHvS, surfUs, surfVs, wavedir, currentdir
-  real :: VarUp, VarDn, M, VarLo, VarAvg
-  real :: H10pct, H20pct,CMNFACT, USx20pct, USy20pct, enhvt2
-  integer :: B
-  real :: WST
+  real :: surfHuS, surfHvS, surfUs, surfVs
 
   if (CS%Stokes_Mixing .and. .not.associated(Waves)) call MOM_error(FATAL, &
       "KPP_compute_BLD: The Waves control structure must be associated if STOKES_MIXING is True.")
@@ -995,7 +990,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   !$OMP                           surfHvS, hTot, delH, surftemp, surfsalt, surfu, surfv,    &
   !$OMP                           surfUs, surfVs, Uk, Vk, deltaU2, km1, kk, pres_1D,        &
   !$OMP                           Temp_1D, salt_1D, surfBuoyFlux2, MLD_GUESS, LA, rho_1D,   &
-  !$OMP                           deltarho, N2_1d, ws_1d, LangEnhVT2, enhvt2, wst,          &
+  !$OMP                           deltarho, N2_1d, ws_1d, LangEnhVT2,                       &
   !$OMP                           BulkRi_1d, zBottomMinusOffset) &
   !$OMP                           shared(G, GV, CS, US, uStar, h, buoy_scale, buoyFlux,     &
   !$OMP                           Temp, Salt, waves, tv, GoRho, u, v, lamult)

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -174,7 +174,6 @@ subroutine compute_ddiff_coeffs(h, tv, G, GV, US, j, Kd_T, Kd_S, CS, R_rho)
     Kd1_S          !< Diapycanal diffusivity of salinity [m2 s-1].
 
   real, dimension(SZK_(GV)+1) :: iFaceHeight !< Height of interfaces [m]
-  integer :: kOBL                        !< level of OBL extent
   real :: dh, hcorr
   integer :: i, k
 

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -321,7 +321,7 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, US, C
   logical :: write_diags  ! If true, write out diagnostics with this step.
   logical :: reset_diags  ! If true, zero out the accumulated diagnostics.
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
-  integer :: i, j, k, is, ie, js, je, nz, nkmb, n
+  integer :: i, j, k, is, ie, js, je, nz, nkmb
   integer :: nsw    ! The number of bands of penetrating shortwave radiation.
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -783,8 +783,6 @@ subroutine convective_adjustment(h, u, v, R0, Rcv, T, S, eps, d_eb, &
 
   ! Local variables
   real, dimension(SZI_(G)) :: &
-    htot, &     !   The total depth of the layers being considered for
-                ! entrainment [H ~> m or kg m-2].
     R0_tot, &   !   The integrated potential density referenced to the surface
                 ! of the layers which are fully entrained [H R ~> kg m-2 or kg2 m-5].
     Rcv_tot, &  !   The integrated coordinate value potential density of the
@@ -1001,7 +999,6 @@ subroutine mixedlayer_convection(h, d_eb, htot, Ttot, Stot, uhtot, vhtot,      &
                        ! shortwave radiation, integrated over a layer
                        ! [H R ~> kg m-2 or kg2 m-5].
   real :: Idt          ! 1.0/dt [T-1 ~> s-1]
-  real :: netHeatOut   ! accumulated heat content of mass leaving ocean
   integer :: is, ie, nz, i, k, ks, itt, n
   real, dimension(max(nsw,1)) :: &
     C2, &              ! Temporary variable R H-1 ~> kg m-4 or m-1].
@@ -2297,7 +2294,6 @@ subroutine mixedlayer_detrain_2(h, T, S, R0, Rcv, RcvTgt, dt, dt_diag, d_ea, j, 
   real :: Angstrom                ! The minumum layer thickness [H ~> m or kg m-2].
 
   real :: h2_to_k1_lim, T_new, S_new, T_max, T_min, S_max, S_min
-  character(len=200) :: mesg
 
   integer :: i, k, k0, k1, is, ie, nz, kb1, kb2, nkmb
   is = G%isc ; ie = G%iec ; nz = GV%ke

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -607,7 +607,7 @@ subroutine set_pen_shortwave(optics, fluxes, G, GV, US, CS, opacity, tracer_flow
   real, dimension(SZI_(G),SZJ_(G))          :: chl_2d !< Vertically uniform chlorophyll-A concentractions [mg m-3]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: chl_3d !< The chlorophyll-A concentractions of each layer [mg m-3]
   character(len=128) :: mesg
-  integer :: i, j, k, is, ie, js, je
+  integer :: i, j, is, ie, js, je
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
   if (.not.associated(optics)) return
@@ -820,7 +820,6 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, diagPtr)
   real, dimension(SZK_(GV)) :: Z_L, Z_U, dZ, Rho_c, pRef_MLD
   real, dimension(3) :: PE_threshold
 
-  real :: ig, E_g
   real :: PE_Threshold_fraction, PE, PE_Mixed, PE_Mixed_TST
   real :: RhoDZ_ML, H_ML, RhoDZ_ML_TST, H_ML_TST
   real :: Rho_ML
@@ -1078,7 +1077,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   logical :: calculate_energetics
   logical :: calculate_buoyancy
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
-  integer :: i, j, is, ie, js, je, k, nz, n, nb
+  integer :: i, j, is, ie, js, je, k, nz, nb
   character(len=45) :: mesg
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -1558,14 +1557,13 @@ subroutine diabatic_aux_init(Time, G, GV, US, param_file, diag, CS, useALEalgori
 ! This "include" declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl  = "MOM_diabatic_aux" ! This module's name.
-  character(len=48)  :: thickness_units
   character(len=200) :: inputdir   ! The directory where NetCDF input files
   character(len=240) :: chl_filename ! A file from which chl_a concentrations are to be read.
   character(len=128) :: chl_file ! Data containing chl_a concentrations. Used
                                  ! when var_pen_sw is defined and reading from file.
   character(len=32)  :: chl_varname ! Name of chl_a variable in chl_file.
   logical :: use_temperature     ! True if thermodynamics are enabled.
-  integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz, nbands
+  integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 

--- a/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
+++ b/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
@@ -70,7 +70,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, US, CS, Kd_int)
   real :: ustar, absf, htot
   real :: energy_Kd ! The energy used by diapycnal mixing [R Z L2 T-3 ~> W m-2].
   real :: tmp1  ! A temporary array.
-  integer :: i, j, k, is, ie, js, je, nz, itt
+  integer :: i, j, k, is, ie, js, je, nz
   logical :: may_print
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -159,8 +159,6 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
     Te_b, Se_b, & ! Running incomplete estimates of the new temperatures and salinities [degC] and [ppt].
     Tf, Sf, &   ! New final values of the temperatures and salinities [degC] and [ppt].
     dTe, dSe, & ! Running (1-way) estimates of temperature and salinity change [degC] and [ppt].
-    dTe_a, dSe_a, & ! Running (1-way) estimates of temperature and salinity change [degC] and [ppt].
-    dTe_b, dSe_b, & ! Running (1-way) estimates of temperature and salinity change [degC] and [ppt].
     Th_a, &     ! An effective temperature times a thickness in the layer above, including implicit
                 ! mixing effects with other yet higher layers [degC H ~> degC m or degC kg m-2].
     Sh_a, &     ! An effective salinity times a thickness in the layer above, including implicit
@@ -218,10 +216,7 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
                     ! accumulating the diffusivities [R Z L2 T-2 ~> J m-2].
     ColHt_cor_k     ! The correction to the potential energy change due to
                     ! changes in the net column height [R Z L2 T-2 ~> J m-2].
-  real :: &
-    b1              ! b1 is used by the tridiagonal solver [H-1 ~> m-1 or m2 kg-1].
-  real :: &
-    I_b1            ! The inverse of b1 [H ~> m or kg m-2].
+  real :: b1        ! b1 is used by the tridiagonal solver [H-1 ~> m-1 or m2 kg-1].
   real :: Kd0       ! The value of Kddt_h that has already been applied [H ~> m or kg m-2].
   real :: dKd       ! The change in the value of Kddt_h [H ~> m or kg m-2].
   real :: h_neglect ! A thickness that is so small it is usually lost
@@ -233,10 +228,6 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
   real :: Kddt_h_guess ! A guess of the final value of Kddt_h [H ~> m or kg m-2].
   real :: dMass     ! The mass per unit area within a layer [R Z ~> kg m-2].
   real :: dPres     ! The hydrostatic pressure change across a layer [R L2 T-2 ~> Pa].
-  real :: dMKE_max  ! The maximum amount of mean kinetic energy that could be
-                    ! converted to turbulent kinetic energy if the velocity in
-                    ! the layer below an interface were homogenized with all of
-                    ! the water above the interface [R Z L2 T-2 ~> J m-2 = kg s-2].
   real :: rho_here  ! The in-situ density [R ~> kg m-3].
   real :: PE_change ! The change in column potential energy from applying Kddt_h at the
                     ! present interface [R L2 Z T-2 ~> J m-2].
@@ -259,9 +250,8 @@ subroutine diapyc_energy_req_calc(h_in, T_in, S_in, Kd, energy_Kd, dt, tv, &
   real :: PE_chg_tot1D, PE_chg_tot2D, T_chg_totD
   real, dimension(GV%ke+1)  :: dPEchg_dKd
   real :: PE_chg(6)
-  real, dimension(6) :: dT_k_itt, dS_k_itt, dT_km1_itt, dS_km1_itt
 
-  integer :: k, nz, itt, max_itt, k_cent
+  integer :: k, nz, itt, k_cent
   logical :: surface_BL, bottom_BL, central, halves, debug
   logical :: old_PE_calc
   nz = GV%ke
@@ -1281,11 +1271,9 @@ subroutine diapyc_energy_req_init(Time, G, GV, US, param_file, diag, CS)
   type(diag_ctrl),    target, intent(inout) :: diag        !< structure to regulate diagnostic output
   type(diapyc_energy_req_CS), pointer       :: CS          !< module control structure
 
-  integer, save :: init_calls = 0
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_diapyc_energy_req" ! This module's name.
-  character(len=256) :: mesg    ! Message for error messages.
 
   if (.not.associated(CS)) then ; allocate(CS)
   else ; return ; endif

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -721,7 +721,6 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
                     !    can improve this.
   real :: dMLD_min  ! The change in diagnosed mixed layer depth when the guess is min_MLD [Z ~> m]
   real :: dMLD_max  ! The change in diagnosed mixed layer depth when the guess is max_MLD [Z ~> m]
-  logical :: FIRST_OBL     ! Flag for computing "found" Mixing layer depth
   logical :: OBL_converged ! Flag for convergence of MLD
   integer :: OBL_it        ! Iteration counter
 
@@ -730,7 +729,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
   logical :: debug      ! This is used as a hard-coded value for debugging.
 
   !  The following arrays are used only for debugging purposes.
-  real :: dPE_debug, mixing_debug, taux2, tauy2
+  real :: dPE_debug, mixing_debug
   real, dimension(20) :: TKE_left_itt, PE_chg_itt, Kddt_h_itt, dPEa_dKd_itt, MKE_src_itt
   real, dimension(SZK_(GV)) :: mech_TKE_k, conv_PErel_k, nstar_k
   real, dimension(SZK_(GV)) :: dT_expect !< Expected temperature changes [degC]

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -112,7 +112,7 @@ subroutine geothermal_entraining(h, tv, dt, ea, eb, G, GV, US, CS, halo)
 
   logical :: do_i(SZI_(G))
   logical :: compute_h_old, compute_T_old
-  integer :: i, j, k, is, ie, js, je, nz, k2, i2
+  integer :: i, j, k, is, ie, js, je, nz, k2
   integer :: isj, iej, num_left, nkmb, k_tgt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -388,7 +388,7 @@ subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, halo)
   real :: Idt           ! inverse of the timestep [T-1 ~> s-1]
   logical :: do_any     ! True if there is more to be done on the current j-row.
   logical :: calc_diags ! True if diagnostic tendencies are needed.
-  integer :: i, j, k, is, ie, js, je, nz, i2, isj, iej
+  integer :: i, j, k, is, ie, js, je, nz, isj, iej
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   if (present(halo)) then

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -103,7 +103,7 @@ subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, US, CS)
   logical :: avg_enabled  ! for testing internal tides (BDM)
   type(time_type) :: time_end        !< For use in testing internal tides (BDM)
 
-  integer :: i, j, k, is, ie, js, je, nz, isd, ied, jsd, jed
+  integer :: i, j, is, ie, js, je, nz, isd, ied, jsd, jed
   integer :: i_global, j_global
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -185,7 +185,6 @@ subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, US, N2_bot)
                                                                  !! smooth out the values in thin layers [ppt].
   real, dimension(SZI_(G),SZJ_(G)),          intent(in)  :: h2   !< Bottom topographic roughness [Z2 ~> m2].
   type(forcing),                             intent(in)  :: fluxes !< A structure of thermodynamic surface fluxes
-  type(int_tide_input_CS),                   pointer     :: CS   !<  This module's control structure.
   real, dimension(SZI_(G),SZJ_(G)),          intent(out) :: N2_bot !< The squared buoyancy freqency at the
                                                                  !! ocean bottom [T-2 ~> s-2].
   ! Local variables
@@ -301,12 +300,10 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
   type(int_tide_input_type), pointer       :: itide !< A structure containing fields related
                                                    !! to the internal tide sources.
   ! Local variables
-  type(vardesc) :: vd
   logical :: read_tideamp
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_int_tide_input"  ! This module's name.
-  character(len=20)  :: tmpstr
   character(len=200) :: filename, tideamp_file, h2_file
 
   real :: mask_itidal        ! A multiplicative land mask, 0 or 1 [nondim]

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -393,7 +393,6 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
   real :: I_Prandtl     ! The inverse of the turbulent Prandtl number [nondim].
   logical :: use_temperature  !  If true, temperature and salinity have been
                         ! allocated and are being used as state variables.
-  logical :: do_i       ! If true, work on this column.
 
   integer, dimension(SZK_(GV)+1) :: kc ! The index map between the original
                         ! interfaces and the interfaces with massless layers
@@ -704,9 +703,6 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, dz, &
   logical :: use_temperature  !  If true, temperature and salinity have been
                         ! allocated and are being used as state variables.
   integer :: ks_kappa, ke_kappa  ! The k-range with nonzero kappas.
-  integer :: dt_halvings   ! The number of times that the time-step is halved
-                           ! in seeking an acceptable timestep.  If none is
-                           ! found, dt_rem*0.5^dt_halvings is used.
   integer :: dt_refinements ! The number of 2-fold refinements that will be used
                            ! to estimate the maximum permitted time step.  I.e.,
                            ! the resolution is 1/2^dt_refinements.
@@ -1269,7 +1265,7 @@ subroutine find_kappa_tke(N2, S2, kappa_in, Idz, dz_Int, I_L2_bdry, f2, &
 
   ! These variables are used only for debugging.
   logical, parameter :: debug_soln = .false.
-  real :: K_err_lin, Q_err_lin, TKE_src_norm
+  real :: K_err_lin, Q_err_lin
   real, dimension(nz+1) :: &
     I_Ld2_debug, & ! A separate version of I_Ld2 for debugging [Z-2 ~> m-2].
     kappa_prev, & ! The value of kappa at the start of the current iteration [Z2 T-1 ~> m2 s-1].

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -110,9 +110,7 @@ subroutine set_opacity(optics, sw_total, sw_vis_dir, sw_vis_dif, sw_nir_dir, sw_
   real :: inv_sw_pen_scale  ! The inverse of the e-folding scale [Z-1 ~> m-1].
   real :: Inv_nbands        ! The inverse of the number of bands of penetrating
                             ! shortwave radiation [nondim]
-  logical :: call_for_surface  ! if horizontal slice is the surface layer
   real :: tmp(SZI_(G),SZJ_(G),SZK_(GV)) ! A 3-d temporary array for diagnosing opacity [Z-1 ~> m-1]
-  real :: chl(SZI_(G),SZJ_(G),SZK_(GV)) ! The concentration of chlorophyll-A [mg m-3].
   real :: Pen_SW_tot(SZI_(G),SZJ_(G))   ! The penetrating shortwave radiation
                                         ! summed across all bands [Q R Z T-1 ~> W m-2].
   real :: op_diag_len       ! A tiny lengthscale [Z ~> m] used to remap diagnostics of opacity
@@ -245,7 +243,6 @@ subroutine opacity_from_chl(optics, sw_total, sw_vis_dir, sw_vis_dif, sw_nir_dir
                             ! radiation [Q R Z T-1 ~> W m-2].
   real :: SW_nir_tot        ! The sum across the near infrared bands of shortwave
                             ! radiation [Q R Z T-1 ~> W m-2].
-  type(time_type) :: day
   character(len=128) :: mesg
   integer :: i, j, k, n, is, ie, js, je, nz, nbands
   logical :: multiband_vis_input, multiband_nir_input, total_sw_input
@@ -845,7 +842,7 @@ subroutine sumSWoverBands(G, GV, US, h, nsw, optics, j, dt, &
   logical :: SW_Remains   ! If true, some column has shortwave radiation that
                           ! was not entirely absorbed.
 
-  integer :: is, ie, nz, i, k, ks, n
+  integer :: is, ie, nz, i, k, n
   SW_Remains = .false.
 
   I_Habs = 1e3*GV%H_to_m ! optics%PenSW_absorb_Invlen
@@ -962,7 +959,6 @@ subroutine opacity_init(Time, G, GV, US, param_file, diag, CS, optics)
                                 ! flux when that flux drops below PEN_SW_FLUX_ABSORB [H ~> m or kg m-2]
   real :: PenSW_minthick_dflt ! The default for PenSW_absorb_minthick [m]
   logical :: default_2018_answers
-  logical :: use_scheme
   integer :: isd, ied, jsd, jed, nz, n
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = GV%ke
 

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -87,11 +87,6 @@ subroutine regularize_layers(h, tv, dt, ea, eb, G, GV, US, CS)
   type(unit_scale_type),      intent(in)    :: US !< A dimensional unit scaling type
   type(regularize_layers_CS), intent(in)    :: CS !< Regularize layer control struct
 
-  ! Local variables
-  integer :: i, j, k, is, ie, js, je, nz
-
-  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-
   if (.not. CS%initialized) call MOM_error(FATAL, "MOM_regularize_layers: "//&
          "Module must be initialized before it is used.")
 
@@ -163,7 +158,6 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
     h_prev_1d     ! The previous thicknesses [H ~> m or kg m-2].
   real :: I_dtol  ! The inverse of the tolerance changes [nondim].
   real :: I_dtol34 ! The inverse of the tolerance changes [nondim].
-  real :: h1, h2  ! Temporary thicknesses [H ~> m or kg m-2].
   real :: e_e, e_w, e_n, e_s  ! Temporary interface heights [H ~> m or kg m-2].
   real :: wt    ! The weight of the filted interfaces in setting the targets [nondim].
   real :: scale ! A scaling factor [nondim].
@@ -184,7 +178,7 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
 
   logical :: cols_left, ent_any, more_ent_i(SZI_(G)), ent_i(SZI_(G))
   logical :: det_any, det_i(SZI_(G))
-  logical :: do_j(SZJ_(G)), do_i(SZI_(G)), find_i(SZI_(G))
+  logical :: do_j(SZJ_(G)), do_i(SZI_(G))
   logical :: debug = .false.
   logical :: fatal_error
   character(len=256) :: mesg    ! Message for error messages.
@@ -717,7 +711,6 @@ subroutine regularize_layers_init(Time, G, GV, param_file, diag, CS)
 
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_regularize_layers"  ! This module's name.
-  logical :: use_temperature
   logical :: default_2018_answers
   logical :: just_read
   integer :: isd, ied, jsd, jed

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -907,7 +907,6 @@ subroutine find_N2(h, tv, T_f, S_f, fluxes, j, G, GV, US, CS, dRho_int, &
     hb,        &  ! The thickness of the bottom layer [Z ~> m].
     z_from_bot    ! The hieght above the bottom [Z ~> m].
 
-  real :: Rml_base  ! density of the deepest variable density layer
   real :: dz_int    ! thickness associated with an interface [Z ~> m].
   real :: G_Rho0    ! gravitation acceleration divided by Bouss reference density
                     ! times some unit conversion factors [Z T-2 R-1 ~> m4 s-2 kg-1].
@@ -1984,7 +1983,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
   logical :: use_regridding  ! If true, use the ALE algorithm rather than layered
                              ! isopycnal or stacked shallow water mode.
   logical :: TKE_to_Kd_used  ! If true, TKE_to_Kd and maxTKE need to be calculated.
-  integer :: i, j, is, ie, js, je
+  integer :: is, ie, js, je
   integer :: isd, ied, jsd, jed
 
   if (associated(CS)) then

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1925,17 +1925,16 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                            ! to the representation in a restart file.
   real    :: Z2_T_rescale  ! A rescaling factor for vertical diffusivities and viscosities from the
                            ! representation in a restart file to the internal representation in this run.
-  integer :: i, j, k, is, ie, js, je, n
+  integer :: i, j, k, is, ie, js, je
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
   logical :: default_2018_answers
-  logical :: use_kappa_shear, adiabatic, use_omega, MLE_use_PBL_MLD
+  logical :: adiabatic, use_omega, MLE_use_PBL_MLD
   logical :: use_KPP
   logical :: use_regridding  ! If true, use the ALE algorithm rather than layered
                              ! isopycnal or stacked shallow water mode.
   logical :: use_temperature ! If true, temperature and salinity are used as state variables.
   logical :: use_EOS         ! If true, density calculated from T & S using an equation of state.
   character(len=200) :: filename, tideamp_file
-  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to OBC segment type
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_set_visc"  ! This module's name.

--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -273,7 +273,6 @@ subroutine set_up_sponge_ML_density(sp_val, G, CS, sp_val_i_mean)
                                             !! layer density [R ~> kg m-3], for use if Iresttime_i_mean > 0.
 
   integer :: j, col
-  character(len=256) :: mesg ! String for error messages
 
   if (.not.associated(CS)) return
 

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -1026,9 +1026,7 @@ subroutine add_int_tide_diffusivity(h, j, N2_bot, N2_lay, TKE_to_Kd, max_TKE, &
   real :: TKE_lowmode_tot ! TKE from all low modes [R Z3 T-3 ~> W m-2] (BDM)
 
   logical :: use_Polzin, use_Simmons
-  character(len=160) :: mesg  ! The text of an error message
   integer :: i, k, is, ie, nz
-  integer :: a, fr, m
 
   is = G%isc ; ie = G%iec ; nz = GV%ke
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1626,7 +1626,6 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
 
   ! Local variables
 
-  real :: hmix_str_dflt
   real :: Kv_dflt ! A default viscosity [m2 s-1].
   real :: Hmix_m  ! A boundary layer thickness [m].
   logical :: default_2018_answers

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -156,18 +156,8 @@ subroutine initialize_DOME_tracer(restart, day, G, GV, US, h, diag, OBC, CS, &
 
 ! Local variables
   real, allocatable :: temp(:,:,:)
-  real, pointer, dimension(:,:,:) :: &
-    OBC_tr1_u => NULL(), & ! These arrays should be allocated and set to
-    OBC_tr1_v => NULL()    ! specify the values of tracer 1 that should come
-                           ! in through u- and v- points through the open
-                           ! boundary conditions, in the same units as tr.
   character(len=16) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for tracer fluxes, usually
-                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()  ! A pointer to the tracer field
-  real :: PI     ! 3.1415926... calculated as 4*atan(1)
   real :: tr_y   ! Initial zonally uniform tracer concentrations.
   real :: h_neglect         ! A thickness that is so small it is usually lost
                             ! in roundoff and can be neglected [H ~> m or kg m-2].
@@ -370,8 +360,6 @@ end subroutine DOME_tracer_surface_state
 subroutine DOME_tracer_end(CS)
   type(DOME_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                       !! call to DOME_register_tracer.
-  integer :: m
-
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
     deallocate(CS)

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -163,18 +163,7 @@ subroutine initialize_ISOMIP_tracer(restart, day, G, GV, h, diag, OBC, CS, &
                                                        !! the sponges, if they are in use.  Otherwise this
                                                        !! may be unassociated.
 
-  real, allocatable :: temp(:,:,:)
-  real, pointer, dimension(:,:,:) :: &
-    OBC_tr1_u => NULL(), & ! These arrays should be allocated and set to
-    OBC_tr1_v => NULL()    ! specify the values of tracer 1 that should come
-                           ! in through u- and v- points through the open
-                           ! boundary conditions, in the same units as tr.
   character(len=16) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for tracer fluxes, usually
-                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
   real :: h_neglect         ! A thickness that is so small it is usually lost
                             ! in roundoff and can be neglected [H ~> m or kg m-2].
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, m
@@ -276,7 +265,6 @@ subroutine ISOMIP_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, G
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
   real :: melt(SZI_(G),SZJ_(G)) ! melt water (positive for melting, negative for freezing) [R Z T-1 ~> kg m-2 s-1]
   real :: mmax                ! The global maximum melting rate [R Z T-1 ~> kg m-2 s-1]
-  character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -354,7 +342,6 @@ end subroutine ISOMIP_tracer_surface_state
 subroutine ISOMIP_tracer_end(CS)
   type(ISOMIP_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                         !! call to ISOMIP_register_tracer.
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)

--- a/src/tracer/MOM_CFC_cap.F90
+++ b/src/tracer/MOM_CFC_cap.F90
@@ -88,7 +88,7 @@ function register_CFC_cap(HI, GV, param_file, CS, tr_Reg, restart_CS)
   real, dimension(:,:,:), pointer :: tr_ptr => NULL()
   character(len=200) :: dummy      ! Dummy variable to store params that need to be logged here.
   logical :: register_CFC_cap
-  integer :: isd, ied, jsd, jed, nz, m
+  integer :: isd, ied, jsd, jed, nz
 
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
@@ -192,9 +192,6 @@ subroutine initialize_CFC_cap(restart, day, G, GV, US, h, diag, OBC, CS)
                                                            !! open boundary conditions are used.
   type(CFC_cap_CS),              pointer    :: CS          !< The control structure returned by a
                                                            !! previous call to register_CFC_cap.
-
-  ! local variables
-  logical :: from_file = .false.
 
   if (.not.associated(CS)) return
 
@@ -307,7 +304,7 @@ subroutine CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, C
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
-  integer :: i, j, k, m, is, ie, js, je, nz
+  integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -434,7 +431,7 @@ subroutine CFC_cap_fluxes(fluxes, sfc_state, G, US, Rho0, Time, id_cfc11_atm, id
   real :: kw_coeff     ! A coefficient used to compute the piston velocity [Z T-1 T2 L-2 = Z T L-2 ~> s / m]
   real, parameter :: pa_to_atm = 9.8692316931427e-6 ! factor for converting from Pa to atm [atm Pa-1].
   real :: press_to_atm ! converts from model pressure units to atm [atm T2 R-1 L-2 ~> atm Pa-1]
-  integer :: i, j, m, is, ie, js, je
+  integer :: i, j, is, ie, js, je
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
@@ -577,8 +574,6 @@ end subroutine comp_CFC_schmidt
 subroutine CFC_cap_end(CS)
   type(CFC_cap_CS), pointer :: CS !< The control structure returned by a
                                   !! previous call to register_CFC_cap.
-  ! local variables
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%CFC11)) deallocate(CS%CFC11)

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -108,7 +108,7 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   real :: e11_dflt(3), e12_dflt(3) ! Schmidt numbers [various units by element].
   character(len=48) :: flux_units ! The units for tracer fluxes.
   logical :: register_OCMIP2_CFC
-  integer :: isd, ied, jsd, jed, nz, m
+  integer :: isd, ied, jsd, jed, nz
 
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
@@ -438,7 +438,7 @@ subroutine OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
     CFC11_flux, &    ! The fluxes of CFC11 and CFC12 into the ocean, in unscaled units of
     CFC12_flux       ! CFC concentrations times meters per second [CU R Z T-1 ~> CU kg m-2 s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
-  integer :: i, j, k, m, is, ie, js, je, nz, idim(4), jdim(4)
+  integer :: i, j, k, is, ie, js, je, nz, idim(4), jdim(4)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   idim(:) = (/G%isd, is, ie, G%ied/) ; jdim(:) = (/G%jsd, js, je, G%jed/)
@@ -543,7 +543,7 @@ subroutine OCMIP2_CFC_surface_state(sfc_state, h, G, GV, CS)
   real :: alpha_12  ! The solubility of CFC 12 [mol m-3 pptv-1].
   real :: sc_11, sc_12 ! The Schmidt numbers of CFC 11 and CFC 12.
   real :: sc_no_term   ! A term related to the Schmidt number.
-  integer :: i, j, m, is, ie, js, je, idim(4), jdim(4)
+  integer :: i, j, is, ie, js, je, idim(4), jdim(4)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   idim(:) = (/G%isd, is, ie, G%ied/) ; jdim(:) = (/G%jsd, js, je, G%jed/)
@@ -599,7 +599,6 @@ subroutine OCMIP2_CFC_end(CS)
 !   This subroutine deallocates the memory owned by this module.
 ! Argument: CS - The control structure returned by a previous call to
 !                register_OCMIP2_CFC.
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%CFC11)) deallocate(CS%CFC11)

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -109,7 +109,7 @@ contains
     character(len=200) :: inputdir ! The directory where NetCDF input files are.
     ! These can be overridden later in via the field manager?
 
-    integer :: ntau, k,i,j,axes(3)
+    integer :: ntau, axes(3)
     type(g_tracer_type), pointer      :: g_tracer,g_tracer_next
     character(len=fm_string_len)      :: g_tracer_name,longname,units
     real, dimension(:,:,:,:), pointer   :: tr_field
@@ -657,7 +657,7 @@ contains
     real, dimension(:,:,:),pointer :: grid_tmask
     integer :: isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau
 
-    integer :: i, j, k, is, ie, js, je, m
+    integer :: k, is, ie, js, je, m
     real, allocatable, dimension(:) :: geo_z
 
     is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -747,7 +747,6 @@ contains
     real    :: tmax, tmin   ! Maximum and minimum tracer values, in the same units as tr_array
     real    :: tmax0, tmin0 ! First-guest values of tmax and tmin.
     integer :: itmax, jtmax, ktmax, itmin, jtmin, ktmin
-    integer :: igmax, jgmax, kgmax, igmin, jgmin, kgmin
     real    :: fudge ! A factor that is close to 1 that is used to find the location of the extrema.
 
      ! arrays to enable vectorization
@@ -851,7 +850,6 @@ contains
     character(len=128), parameter :: sub_name = 'MOM_generic_tracer_surface_state'
     real, dimension(G%isd:G%ied,G%jsd:G%jed,1:GV%ke,1) :: rho0
     real, dimension(G%isd:G%ied,G%jsd:G%jed,1:GV%ke) ::  dzt
-    type(g_tracer_type), pointer :: g_tracer
 
     !Set coupler values
     !nnz: fake rho0
@@ -884,9 +882,6 @@ contains
   subroutine MOM_generic_flux_init(verbosity)
     integer, optional, intent(in) :: verbosity  !< A 0-9 integer indicating a level of verbosity.
 
-    integer :: ind
-    character(len=fm_string_len)   :: g_tracer_name,longname, package,units,old_package,file_in,file_out
-    real :: const_init_value
     character(len=128), parameter :: sub_name = 'MOM_generic_flux_init'
     type(g_tracer_type), pointer :: g_tracer_list,g_tracer,g_tracer_next
 

--- a/src/tracer/MOM_lateral_boundary_diffusion.F90
+++ b/src/tracer/MOM_lateral_boundary_diffusion.F90
@@ -79,7 +79,6 @@ logical function lateral_boundary_diffusion_init(Time, G, GV, param_file, diag, 
 
   ! local variables
   character(len=80)  :: string ! Temporary strings
-  integer :: ke, nk            ! Number of levels in the LBD and native grids, respectively
   logical :: boundary_extrap   ! controls if boundary extrapolation is used in the LBD code
 
   if (ASSOCIATED(CS)) then
@@ -167,7 +166,6 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: tendency    !< tendency array for diagnostic [conc T-1 ~> conc s-1]
   real, dimension(SZI_(G),SZJ_(G))           :: tendency_2d !< depth integrated content tendency for diagn
   type(tracer_type), pointer                 :: tracer => NULL() !< Pointer to the current tracer
-  real, dimension(SZK_(GV)) :: tracer_1d                    !< 1d-array used to remap tracer change to native grid
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: tracer_old  !< local copy of the initial tracer concentration,
                                                             !! only used to compute tendencies.
   real :: tracer_int_prev !< Globally integrated tracer before LBD is applied, in mks units [conc kg]
@@ -584,13 +582,14 @@ subroutine fluxes_layer_method(boundary, ke, hbl_L, hbl_R, h_L, h_R, phi_L, phi_
   real, allocatable :: F_layer_z(:)  !< Diffusive flux at U/V-point in the ztop grid    [H L2 conc ~> m3 conc]
   real              :: h_vel(ke)     !< Thicknesses at u- and v-points in the native grid
                                      !! The harmonic mean is used to avoid zero values      [H ~> m or kg m-2]
-  real    :: khtr_avg                !< Thickness-weighted diffusivity at the velocity-point [L2 T-1 ~> m2 s-1]
-                                     !! This is just to remind developers that khtr_avg should be
-                                     !! computed once khtr is 3D.
   real    :: htot                    !< Total column thickness                              [H ~> m or kg m-2]
-  integer :: k, k_bot_min, k_top_max !< k-indices, min and max for bottom and top, respectively
-  integer :: k_bot_max, k_top_min    !< k-indices, max and min for bottom and top, respectively
-  integer :: k_bot_diff, k_top_diff  !< different between left and right k-indices for bottom and top, respectively
+  integer :: k
+  integer :: k_bot_min               !< Minimum k-index for the bottom
+  integer :: k_bot_max               !< Maximum k-index for the bottom
+  integer :: k_bot_diff              !< Difference between bottom left and right k-indices
+  !integer :: k_top_max              !< Minimum k-index for the top
+  !integer :: k_top_min              !< Maximum k-index for the top
+  !integer :: k_top_diff             !< Difference between top left and right k-indices
   integer :: k_top_L, k_bot_L        !< k-indices left native grid
   integer :: k_top_R, k_bot_R        !< k-indices right native grid
   real    :: zeta_top_L, zeta_top_R  !< distance from the top of a layer to the boundary

--- a/src/tracer/MOM_offline_aux.F90
+++ b/src/tracer/MOM_offline_aux.F90
@@ -53,7 +53,7 @@ subroutine update_h_horizontal_flux(G, GV, uhtr, vhtr, h_pre, h_new)
                            intent(inout) :: h_new !< Updated layer thicknesses [H ~> m or kg m-2]
 
   ! Local variables
-  integer :: i, j, k, m, is, ie, js, je, nz
+  integer :: i, j, k, is, ie, js, je, nz
   ! Set index-related variables for fields on T-grid
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -88,7 +88,7 @@ subroutine update_h_vertical_flux(G, GV, ea, eb, h_pre, h_new)
                            intent(inout) :: h_new !< Updated layer thicknesses [H ~> m or kg m-2]
 
   ! Local variables
-  integer :: i, j, k, m, is, ie, js, je, nz
+  integer :: i, j, k, is, ie, js, je, nz
   ! Set index-related variables for fields on T-grid
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -139,7 +139,7 @@ subroutine limit_mass_flux_3d(G, GV, uh, vh, ea, eb, h_pre)
   real :: hvol     ! Cell volume [H L2 ~> m3 or kg]
   real :: scale_factor  ! A nondimensional rescaling factor between 0 and 1 [nondim]
   real :: max_off_cfl   ! The maximum permitted fraction that can leave in a timestep [nondim]
-  integer :: i, j, k, m, is, ie, js, je, nz
+  integer :: i, j, k, is, ie, js, je, nz
 
   max_off_cfl = 0.5
 
@@ -227,7 +227,7 @@ subroutine distribute_residual_uh_barotropic(G, GV, hvol, uh)
   real :: abs_uh_sum  ! The vertical sum of the absolute value of the transports [H L2 ~> m3 or kg]
   real :: new_uh_sum  ! The vertically summed transports after redistribution [H L2 ~> m3 or kg]
   real :: uh_neglect  ! A negligible transport [H L2 ~> m3 or kg]
-  integer :: i, j, k, m, is, ie, js, je, nz
+  integer :: i, j, k, is, ie, js, je, nz
 
   ! Set index-related variables for fields on T-grid
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -306,7 +306,7 @@ subroutine distribute_residual_vh_barotropic(G, GV, hvol, vh)
   real :: abs_vh_sum  ! The vertical sum of the absolute value of the transports [H L2 ~> m3 or kg]
   real :: new_vh_sum  ! The vertically summed transports after redistribution [H L2 ~> m3 or kg]
   real :: vh_neglect  ! A negligible transport [H L2 ~> m3 or kg]
-  integer :: i, j, k, m, is, ie, js, je, nz
+  integer :: i, j, k, is, ie, js, je, nz
 
   ! Set index-related variables for fields on T-grid
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -380,10 +380,10 @@ subroutine distribute_residual_uh_upwards(G, GV, hvol, uh)
   real, dimension(SZIB_(G),SZK_(GV))  :: uh2d  ! A slice of transports [H L2 ~> m3 or kg]
   real, dimension(SZI_(G),SZK_(GV))   :: h2d   ! A slice of updated cell volumes [H L2 ~> m3 or kg]
 
-  real  :: uh_neglect, uh_remain, uh_add, uh_sum, uh_col, uh_max ! Transports [H L2 ~> m3 or kg]
+  real  :: uh_neglect, uh_remain, uh_sum, uh_col  ! Transports [H L2 ~> m3 or kg]
   real  :: hup, hlos ! Various cell volumes [H L2 ~> m3 or kg]
   real  :: min_h     ! A minimal layer thickness [H ~> m or kg m-2]
-  integer :: i, j, k, m, is, ie, js, je, nz, k_rev
+  integer :: i, j, k, is, ie, js, je, nz, k_rev
 
   ! Set index-related variables for fields on T-grid
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -475,14 +475,12 @@ subroutine distribute_residual_vh_upwards(G, GV, hvol, vh)
 
   ! Local variables
   real, dimension(SZJB_(G),SZK_(GV))  :: vh2d     ! A slice of transports [H L2 ~> m3 or kg]
-  real, dimension(SZJB_(G))           :: vh2d_sum ! Summed transports [H L2 ~> m3 or kg]
   real, dimension(SZJ_(G),SZK_(GV))   :: h2d      ! A slice of updated cell volumes [H L2 ~> m3 or kg]
-  real, dimension(SZJ_(G))            :: h2d_sum  ! Summed cell volumes [H L2 ~> m3 or kg]
 
   real  :: vh_neglect, vh_remain, vh_col, vh_sum  ! Transports [H L2 ~> m3 or kg]
   real  :: hup, hlos ! Various cell volumes [H L2 ~> m3 or kg]
   real  :: min_h     ! A minimal layer thickness [H ~> m or kg m-2]
-  integer :: i, j, k, m, is, ie, js, je, nz, k_rev
+  integer :: i, j, k, is, ie, js, je, nz, k_rev
 
   ! Set index-related variables for fields on T-grid
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke

--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -233,10 +233,9 @@ subroutine offline_advection_ale(fluxes, Time_start, time_interval, G, GV, US, C
   integer :: niter, iter
   real    :: Inum_iter    ! The inverse of the number of iterations [nondim]
   character(len=256) :: mesg  ! The text of an error message
-  integer :: i, j, k, m, is, ie, js, je, isd, ied, jsd, jed, nz
-  integer :: isv, iev, jsv, jev ! The valid range of the indices.
+  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB
-  logical :: z_first, x_before_y
+  logical :: x_before_y
   real :: evap_CFL_limit  ! Limit on the fraction of the water that can be fluxed out of the
                           ! top layer in a timestep [nondim]
   real :: minimum_forcing_depth ! The smallest depth over which fluxes can be applied [H ~> m or kg m-2]
@@ -432,7 +431,7 @@ subroutine offline_redistribute_residual(CS, G, GV, US, h_pre, uhtr, vhtr, conve
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vhr  !< Remaining meridional mass transport [H L2 ~> m3 or kg]
 
   character(len=256) :: mesg  ! The text of an error message
-  integer :: i, j, k, m, is, ie, js, je, isd, ied, jsd, jed, nz, iter
+  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, iter
   real :: HL2_to_kg_scale ! Unit conversion factors to cell mass [kg H-1 L-2 ~> kg m-3 or 1]
   real :: prev_tot_residual, tot_residual ! The absolute value of the remaining transports [H L2 ~> m3 or kg]
 
@@ -862,16 +861,11 @@ subroutine offline_advection_layer(fluxes, Time_start, time_interval, G, GV, US,
       h_new, &  ! Updated thicknesses [H ~> m or kg m-2]
       h_vol     ! Cell volumes [H L2 ~> m3 or kg]
   ! Work arrays for temperature and salinity
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: &
-      temp_old, temp_mean, &  ! Temperatures [degC]
-      salt_old, salt_mean     ! Salinities [ppt]
-  integer :: niter, iter
+  integer :: iter
   real    :: dt_iter  ! The timestep of each iteration [T ~> s]
   real    :: HL2_to_kg_scale ! Unit conversion factors to cell mass [kg H-1 L-2 ~> kg m-3 or 1]
-  logical :: converged
   character(len=160) :: mesg  ! The text of an error message
-  integer :: i, j, k, m, is, ie, js, je, isd, ied, jsd, jed, nz
-  integer :: isv, iev, jsv, jev ! The valid range of the indices.
+  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB
   logical :: z_first, x_before_y
 
@@ -1317,7 +1311,7 @@ subroutine offline_transport_init(param_file, CS, diabatic_CSp, G, GV, US)
   character(len=20)  :: redistribute_method
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
+  integer :: is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB
 
   is   = G%isc   ; ie   = G%iec  ; js   = G%jsc  ; je   = G%jec ; nz = GV%ke
@@ -1475,7 +1469,7 @@ subroutine read_all_input(CS, G, GV, US)
   type(verticalGrid_type),    intent(in)    :: GV    !< Vertical grid structure
   type(unit_scale_type),      intent(in)    :: US    !< A dimensional unit scaling type
 
-  integer :: is, ie, js, je, isd, ied, jsd, jed, nz, t, ntime
+  integer :: isd, ied, jsd, jed, nz, t, ntime
   integer :: IsdB, IedB, JsdB, JedB
 
   nz = GV%ke ; ntime = CS%numtime

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -38,18 +38,11 @@ function tracer_Z_init(tr, h, filename, tr_name, G, GV, US, missing_val, land_va
                          intent(in)    :: h    !< Layer thicknesses [H ~> m or kg m-2]
   character(len=*),      intent(in)    :: filename !< The name of the file to read from
   character(len=*),      intent(in)    :: tr_name !< The name of the tracer in the file
-! type(param_file_type), intent(in)    :: param_file !< A structure to parse for run-time parameters
   real,        optional, intent(in)    :: missing_val !< The missing value for the tracer
   real,        optional, intent(in)    :: land_val !< A value to use to fill in land points
 
-  !   This function initializes a tracer by reading a Z-space file, returning true if this
-  ! appears to have been successful, and false otherwise.
-!
-  integer, save :: init_calls = 0
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mdl = "MOM_tracer_Z_init" ! This module's name.
-  character(len=256) :: mesg    ! Message for error messages.
 
   real, allocatable, dimension(:,:,:) :: &
     tr_in   ! The z-space array of tracer concentrations that is read in.
@@ -299,7 +292,6 @@ subroutine tracer_z_init_array(tr_in, z_edges, nk_data, e, land_fill, G, nlay, n
   ! Local variables
   real, dimension(nk_data) :: tr_1d !< a copy of the input tracer concentrations in a column.
   real, dimension(nlay+1)  :: e_1d  ! A 1-d column of intreface heights, in the same units as e.
-  real, dimension(nlay)    :: tr_   ! A 1-d column of output tracer concentrations
   integer :: k_top, k_bot, k_bot_prev, kstart
   real    :: sl_tr    ! The tracer concentration slope times the layer thickness, in tracer units.
   real, dimension(nk_data) :: wt !< The fractional weight for each layer in the range between z1 and z2
@@ -398,12 +390,12 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
   !   This subroutine reads the vertical coordinate data for a field from a
   ! NetCDF file.  It also might read the missing value attribute for that same field.
   character(len=32) :: mdl
-  character(len=120) :: dim_name, tr_msg, dim_msg
+  character(len=120) :: tr_msg, dim_msg
   character(:), allocatable :: edge_name
   character(len=256) :: dim_names(4)
   logical :: monotonic
-  integer :: ncid, status, intid, tr_id, layid, k
-  integer :: nz_edge, ndim, tr_dim_ids(8), sizes(4)
+  integer :: ncid, k
+  integer :: nz_edge, ndim, sizes(4)
 
   mdl = "MOM_tracer_Z_init read_Z_edges: "
   tr_msg = trim(tr_name)//" in "//trim(filename)
@@ -599,7 +591,7 @@ subroutine determine_temperature(temp, salt, R_tgt, p_ref, niter, land_fill, h, 
   real :: tol_rho  ! The tolerance for density matches [R ~> kg m-3]
   real :: max_t_adj, max_s_adj
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
-  integer :: i, j, k, kz, is, ie, js, je, nz, itt
+  integer :: i, j, k, is, ie, js, je, nz, itt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -355,8 +355,6 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
   real, dimension(SZI_(G),ntr) :: &
     T_tmp               ! The copy of the tracer concentration at constant i,k [conc].
 
-  real :: maxslope      ! The maximum concentration slope per grid point
-                        ! consistent with monotonicity [conc].
   real :: hup, hlos     ! hup is the upwind volume, hlos is the
                         ! part of that volume that might be lost
                         ! due to advection out the other side of
@@ -382,7 +380,6 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
   real :: mA            ! Average of the reconstruction tracer edge values [conc]
   real :: a6            ! Curvature of the reconstruction tracer values [conc]
   logical :: do_i(SZIB_(G),SZJ_(G))     ! If true, work on given points.
-  logical :: do_any_i
   logical :: usePLMslope
   integer :: i, j, m, n, i_up, stencil
   type(OBC_segment_type), pointer :: segment=>NULL()
@@ -726,8 +723,6 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
     flux_y                      ! The tracer flux across a boundary [H L2 conc ~> m3 conc or kg conc].
   real, dimension(SZI_(G),ntr,SZJB_(G)) :: &
     T_tmp               ! The copy of the tracer concentration at constant i,k [conc].
-  real :: maxslope              ! The maximum concentration slope per grid point
-                                ! consistent with monotonicity [conc].
   real :: vhh(SZI_(G),SZJB_(G)) ! The meridional flux that occurs during the
                                 ! current iteration [H L2 ~> m3 or kg].
   real :: hup, hlos             ! hup is the upwind volume, hlos is the
@@ -754,7 +749,6 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
   real :: a6            ! Curvature of the reconstruction tracer values [conc]
   logical :: do_j_tr(SZJ_(G))   ! If true, calculate the tracer profiles.
   logical :: do_i(SZIB_(G), SZJ_(G))     ! If true, work on given points.
-  logical :: do_any_i
   logical :: usePLMslope
   integer :: i, j, j2, m, n, j_up, stencil
   type(OBC_segment_type), pointer :: segment=>NULL()
@@ -1075,8 +1069,6 @@ subroutine tracer_advect_init(Time, G, US, param_file, diag, CS)
   type(param_file_type),   intent(in)    :: param_file  !< open file to parse for model parameters
   type(diag_ctrl), target, intent(inout) :: diag        !< regulates diagnostic output
   type(tracer_advect_CS),  pointer       :: CS          !< module control structure
-
-  integer, save :: init_calls = 0
 
   ! This include declares and sets the variable "version".
 # include "version_variable.h"

--- a/src/tracer/MOM_tracer_diabatic.F90
+++ b/src/tracer/MOM_tracer_diabatic.F90
@@ -465,7 +465,7 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, evap_CFL_lim
   real :: hGrounding(maxGroundings) ! The remaining fresh water flux that was not able to be
                                ! supplied from a column that grounded out [H ~> m or kg m-2]
   logical :: update_h
-  integer :: i, j, is, ie, js, je, k, nz, n, nsw
+  integer :: i, j, is, ie, js, je, k, nz
   character(len=45) :: mesg
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -124,7 +124,7 @@ subroutine call_tracer_flux_init(verbosity)
 
   type(param_file_type) :: param_file ! A structure to parse for run-time parameters
   character(len=40)  :: mdl = "call_tracer_flux_init"  ! This module's name.
-  logical :: use_OCMIP_CFCs, use_MOM_generic_tracer, use_CFC_caps
+  logical :: use_OCMIP_CFCs, use_MOM_generic_tracer
 
   ! Determine which tracer routines with tracer fluxes are to be called.  Note
   ! that not every tracer package is required to have a flux_init call.
@@ -615,7 +615,7 @@ subroutine call_tracer_stocks(h, stock_values, G, GV, US, CS, stock_names, stock
   ! real, dimension(MAX_FIELDS_) :: values
   type(EFP_type), dimension(MAX_FIELDS_) :: values_EFP
   type(EFP_type), dimension(MAX_FIELDS_) :: stock_val_EFP
-  integer :: max_ns, ns_tot, ns, index, pkg, max_pkgs, nn, n
+  integer :: max_ns, ns_tot, ns, index, nn, n
 
   if (.not. associated(CS)) call MOM_error(FATAL, "call_tracer_stocks: "// &
        "Module must be initialized via call_tracer_register before it is used.")

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -154,7 +154,6 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, US, CS, Reg, tv, do_online
   real :: khdt_max ! The local limiting value of khdt_x or khdt_y [L2 ~> m2].
   real :: max_CFL ! The global maximum of the diffusive CFL number.
   logical :: use_VarMix, Resoln_scaled, do_online, use_Eady
-  integer :: S_idx, T_idx ! Indices for temperature and salinity if needed
   integer :: i, j, k, m, is, ie, js, je, nz, ntr, itt, num_itts
   real :: I_numitts  ! The inverse of the number of iterations, num_itts.
   real :: scale      ! The fraction of khdt_x or khdt_y that is applied in this
@@ -692,7 +691,6 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
   integer :: isd, ied, jsd, jed, IsdB, IedB, k_size
   integer :: kL, kR, kLa, kLb, kRa, kRb, nP, itt, ns, max_itt
   integer :: PEmax_kRho
-  integer :: isv, iev, jsv, jev ! The valid range of the indices.
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -1444,7 +1442,6 @@ subroutine tracer_hor_diff_init(Time, G, GV, US, param_file, diag, EOS, diabatic
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_tracer_hor_diff" ! This module's name.
-  character(len=256) :: mesg    ! Message for error messages.
 
   if (associated(CS)) then
     call MOM_error(WARNING, "tracer_hor_diff_init called with associated control structure.")

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -367,7 +367,6 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE)
   character(len=120) :: cmor_longname ! The CMOR long name of that variable.
   character(len=120) :: var_lname      ! A temporary longname for a diagnostic.
   character(len=120) :: cmor_var_lname ! The temporary CMOR long name for a diagnostic
-  character(len=72)  :: cmor_varname ! The temporary CMOR name for a diagnostic
   type(tracer_type), pointer :: Tr=>NULL()
   integer :: i, j, k, is, ie, js, je, nz, m, m2, nTr_in
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB

--- a/src/tracer/RGC_tracer.F90
+++ b/src/tracer/RGC_tracer.F90
@@ -172,16 +172,7 @@ subroutine initialize_RGC_tracer(restart, day, G, GV, h, diag, OBC, CS, &
                                              !! sponges, if they are in use.  Otherwise this may be unassociated.
 
   real, allocatable :: temp(:,:,:)
-  real, pointer, dimension(:,:,:) :: &
-    OBC_tr1_u => NULL(), & ! These arrays should be allocated and set to
-    OBC_tr1_v => NULL()    ! specify the values of tracer 1 that should come
-                           ! in through u- and v- points through the open
-                           ! boundary conditions, in the same units as tr.
   character(len=16) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for tracer fluxes, usually
-                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()
   real :: h_neglect         ! A thickness that is so small it is usually lost
                             ! in roundoff and can be neglected [H ~> m or kg m-2].
@@ -337,7 +328,6 @@ end subroutine RGC_tracer_column_physics
 
 subroutine RGC_tracer_end(CS)
   type(RGC_tracer_CS), pointer :: CS !< The control structure returned by a previous call to RGC_register_tracer.
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -182,23 +182,12 @@ subroutine initialize_advection_test_tracer(restart, day, G, GV, h,diag, OBC, CS
   type(sponge_CS),                    pointer    :: sponge_CSp !< Pointer to the control structure for the sponges.
 
   ! Local variables
-  real, allocatable :: temp(:,:,:)
-  real, pointer, dimension(:,:,:) :: &
-    OBC_tr1_u => NULL(), & ! These arrays should be allocated and set to
-    OBC_tr1_v => NULL()    ! specify the values of tracer 1 that should come
-                           ! in through u- and v- points through the open
-                           ! boundary conditions, in the same units as tr.
   character(len=16) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for tracer fluxes, usually
-                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
   real :: h_neglect         ! A thickness that is so small it is usually lost
                             ! in roundoff and can be neglected [H ~> m or kg m-2].
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, m
   integer :: IsdB, IedB, JsdB, JedB
-  real :: tmpx, tmpy, locx, locy
+  real :: locx, locy
 
   if (.not.associated(CS)) return
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -360,7 +349,7 @@ function advection_test_stock(h, stocks, G, GV, CS, names, units, stock_index)
   integer                                           :: advection_test_stock !< the number of stocks calculated here.
 
   ! Local variables
-  integer :: i, j, k, is, ie, js, je, nz, m
+  integer :: is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   advection_test_stock = 0
@@ -386,8 +375,6 @@ end function advection_test_stock
 subroutine advection_test_tracer_end(CS)
   type(advection_test_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                               !! call to register_advection_test_tracer.
-  integer :: m
-
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
     deallocate(CS)

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -75,9 +75,7 @@ function register_boundary_impulse_tracer(HI, GV, US, param_file, CS, tr_Reg, re
 
   ! Local variables
   character(len=40)  :: mdl = "boundary_impulse_tracer" ! This module's name.
-  character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
-  character(len=3)   :: name_tag ! String for creating identifying boundary_impulse
   character(len=48)  :: flux_units ! The units for tracer fluxes, usually
                             ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   ! This include declares and sets the variable "version".
@@ -85,7 +83,7 @@ function register_boundary_impulse_tracer(HI, GV, US, param_file, CS, tr_Reg, re
   real, pointer :: tr_ptr(:,:,:) => NULL()
   real, pointer :: rem_time_ptr => NULL()
   logical :: register_boundary_impulse_tracer
-  integer :: isd, ied, jsd, jed, nz, m, i, j
+  integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
@@ -169,11 +167,6 @@ subroutine initialize_boundary_impulse_tracer(restart, day, G, GV, US, h, diag, 
                                                          !! thermodynamic variables
   ! Local variables
   character(len=16) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for age tracer fluxes, either
-                                ! years m3 s-1 or years kg s-1.
-  logical :: OK
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, m
   integer :: IsdB, IedB, JsdB, JedB
 
@@ -245,10 +238,7 @@ subroutine boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, 
 !     h_new(k) = h_old(k) + ea(k) - eb(k-1) + eb(k) - ea(k+1)
 
   ! Local variables
-  real :: Isecs_per_year = 1.0 / (365.0*86400.0)
-  real :: year, h_total, scale, htot, Ih_limit
-  integer :: secs, days
-  integer :: i, j, k, is, ie, js, je, nz, m, k_max
+  integer :: i, j, k, is, ie, js, je, nz, m
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -364,8 +354,6 @@ end subroutine boundary_impulse_tracer_surface_state
 subroutine boundary_impulse_tracer_end(CS)
   type(boundary_impulse_tracer_CS), pointer :: CS   !< The control structure returned by a previous
                                                     !! call to register_boundary_impulse_tracer.
-  integer :: m
-
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
     deallocate(CS)

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -78,7 +78,6 @@ function register_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
 
   ! Local variables
   character(len=40)  :: mdl = "regional_dyes" ! This module's name.
-  character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   character(len=48)  :: desc_name ! The variable's descriptor.
   ! This include declares and sets the variable "version".
@@ -200,14 +199,8 @@ subroutine initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_C
                                                                   !! for the sponges, if they are in use.
 
 ! Local variables
-  character(len=24) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for age tracer fluxes, either
-                                ! years m3 s-1 or years kg s-1.
   real    :: z_bot    ! Height of the bottom of the layer relative to the sea surface [Z ~> m]
   real    :: z_center ! Height of the center of the layer relative to the sea surface [Z ~> m]
-  logical :: OK
   integer :: i, j, k, m
 
   if (.not.associated(CS)) return
@@ -273,12 +266,8 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
 
 ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified
-  real :: sfc_val  ! The surface value for the tracers.
-  real :: Isecs_per_year  ! The number of seconds in a year.
-  real :: year            ! The time in years.
   real    :: z_bot    ! Height of the bottom of the layer relative to the sea surface [Z ~> m]
   real    :: z_center ! Height of the center of the layer relative to the sea surface [Z ~> m]
-  integer :: secs, days   ! Integer components of the time type.
   integer :: i, j, k, is, ie, js, je, nz, m
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -402,7 +391,6 @@ end subroutine dye_tracer_surface_state
 subroutine regional_dyes_end(CS)
   type(dye_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                      !! call to register_dye_tracer.
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -143,18 +143,7 @@ subroutine initialize_dyed_obc_tracer(restart, day, G, GV, h, diag, OBC, CS)
                                                                !! call to dyed_obc_register_tracer.
 
 ! Local variables
-  real, allocatable :: temp(:,:,:)
-  real, pointer, dimension(:,:,:) :: &
-    OBC_tr1_u => NULL(), & ! These arrays should be allocated and set to
-    OBC_tr1_v => NULL()    ! specify the values of tracer 1 that should come
-                           ! in through u- and v- points through the open
-                           ! boundary conditions, in the same units as tr.
   character(len=24) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for tracer fluxes, usually
-                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
   real :: h_neglect         ! A thickness that is so small it is usually lost
                             ! in roundoff and can be neglected [H ~> m or kg m-2].
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, m
@@ -253,7 +242,6 @@ end subroutine dyed_obc_tracer_column_physics
 subroutine dyed_obc_tracer_end(CS)
   type(dyed_obc_tracer_CS), pointer :: CS   !< The control structure returned by a previous
                                             !! call to dyed_obc_register_tracer.
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -217,11 +217,6 @@ subroutine initialize_ideal_age_tracer(restart, day, G, GV, US, h, diag, OBC, CS
 
   ! Local variables
   character(len=24) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for age tracer fluxes, either
-                                ! years m3 s-1 or years kg s-1.
-  character(len=72) :: cmorname ! The CMOR name of that variable.
   logical :: OK
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, m
   integer :: IsdB, IedB, JsdB, JedB
@@ -387,8 +382,7 @@ function ideal_age_stock(h, stocks, G, GV, CS, names, units, stock_index)
   integer                                           :: ideal_age_stock !< The number of stocks calculated here.
 
   ! Local variables
-  integer :: i, j, k, is, ie, js, je, nz, m
-  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+  integer :: m
 
   ideal_age_stock = 0
   if (.not.associated(CS)) return
@@ -447,8 +441,6 @@ end subroutine ideal_age_tracer_surface_state
 subroutine ideal_age_example_end(CS)
   type(ideal_age_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                            !! call to register_ideal_age_tracer.
-
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)

--- a/src/tracer/nw2_tracers.F90
+++ b/src/tracer/nw2_tracers.F90
@@ -58,10 +58,8 @@ logical function register_nw2_tracers(HI, GV, US, param_file, CS, tr_Reg, restar
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "nw2_tracers" ! This module's name.
-  character(len=200) :: inputdir ! The directory where the input files are.
   character(len=8)  :: var_name ! The variable's name.
   real, pointer :: tr_ptr(:,:,:) => NULL()
-  logical :: do_nw2
   integer :: isd, ied, jsd, jed, nz, m, ig
   integer :: n_groups ! Number of groups of three tracers (i.e. # tracers/3)
   real, allocatable, dimension(:) :: timescale_in_days ! Damping timescale [days]
@@ -300,8 +298,6 @@ end function nw2_tracer_dist
 subroutine nw2_tracers_end(CS)
   type(nw2_tracers_CS), pointer :: CS !< The control structure returned by a previous
                                       !! call to register_nw2_tracers.
-
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -94,7 +94,7 @@ function register_oil_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
                             ! kg(oil) s-1 or kg(oil) m-3 kg(water) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()
   logical :: register_oil_tracer
-  integer :: isd, ied, jsd, jed, nz, m, i, j
+  integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
@@ -220,10 +220,6 @@ subroutine initialize_oil_tracer(restart, day, G, GV, US, h, diag, OBC, CS, &
 
   ! Local variables
   character(len=16) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for age tracer fluxes, either
-                                ! years m3 s-1 or years kg s-1.
   logical :: OK
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, m
   integer :: IsdB, IedB, JsdB, JedB
@@ -479,7 +475,6 @@ end subroutine oil_tracer_surface_state
 subroutine oil_tracer_end(CS)
   type(oil_tracer_CS), pointer :: CS !< The control structure returned by a previous
                                      !! call to register_oil_tracer.
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -160,10 +160,6 @@ subroutine USER_initialize_tracer(restart, day, G, GV, US, h, diag, OBC, CS, &
 ! Local variables
   real, allocatable :: temp(:,:,:)
   character(len=32) :: name     ! A variable's name in a NetCDF file.
-  character(len=72) :: longname ! The long name of that variable.
-  character(len=48) :: units    ! The dimensions of the variable.
-  character(len=48) :: flux_units ! The units for tracer fluxes, usually
-                            ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   real, pointer :: tr_ptr(:,:,:) => NULL()
   real :: PI     ! 3.1415926... calculated as 4*atan(1)
   real :: tr_y   ! Initial zonally uniform tracer concentrations.
@@ -249,7 +245,8 @@ subroutine USER_initialize_tracer(restart, day, G, GV, US, h, diag, OBC, CS, &
     endif
     ! All tracers but the first have 0 concentration in their inflows. As this
     ! is the default value, the following calls are unnecessary.
-    do m=2,lntr
+    !do m=2,lntr
+    do m=2,ntr
       call query_vardesc(CS%tr_desc(m), name, caller="USER_initialize_tracer")
       ! Steal from updated DOME in the fullness of time.
     enddo
@@ -435,7 +432,6 @@ end subroutine USER_tracer_surface_state
 subroutine USER_tracer_example_end(CS)
   type(USER_tracer_example_CS), pointer :: CS !< The control structure returned by a previous
                                               !! call to register_USER_tracer.
-  integer :: m
 
   if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -110,7 +110,6 @@ subroutine DOME2d_initialize_thickness ( h, depth_tot, G, GV, US, param_file, ju
                            ! positive upward, in depth units [Z ~> m].
   integer :: i, j, k, is, ie, js, je, nz
   real    :: x
-  real    :: delta_h
   real    :: min_thickness
   real    :: dome2d_width_bay, dome2d_width_bottom, dome2d_depth_bay
   character(len=40) :: verticalCoordinate
@@ -233,7 +232,7 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
   integer   :: i, j, k, is, ie, js, je, nz
   real      :: x
   integer   :: index_bay_z
-  real      :: delta_S, delta_T
+  real      :: delta_S
   real      :: S_ref, T_ref         ! Reference salinity and temperature within surface layer
   real      :: S_range, T_range     ! Range of salinities and temperatures over the vertical
   real      :: xi0, xi1

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -100,7 +100,6 @@ subroutine DOME_initialize_thickness(h, depth_tot, G, GV, param_file, just_read)
                             ! negative because it is positive upward [Z ~> m].
   real :: eta1D(SZK_(GV)+1) ! Interface height relative to the sea surface
                             ! positive upward [Z ~> m].
-  character(len=40)  :: mdl = "DOME_initialize_thickness" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -163,7 +162,6 @@ subroutine DOME_initialize_sponges(G, GV, US, tv, depth_tot, PF, CSp)
   real :: peak_damping ! The maximum sponge damping rates as the edges [days-1]
   real :: edge_dist    ! The distance to an edge, in the same units as longitude [km]
   real :: sponge_width ! The width of the sponges, in the same units as longitude [km]
-  real :: e_dense      ! The depth of the densest interfaces [Z ~> m]
   character(len=40)  :: mdl = "DOME_initialize_sponges" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
 
@@ -301,7 +299,6 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, US, param_file, tr_Reg)
                             ! in the same units as G%geoLon [km]
   real :: Ri_trans          ! The shear Richardson number in the transition
                             ! region of the specified shear profile [nondim]
-  character(len=40)  :: mdl = "DOME_set_OBC_data" ! This subroutine's name.
   character(len=32)  :: name ! The name of a tracer field.
   integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, m, nz, ntherm
   integer :: IsdB, IedB, JsdB, JedB

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -145,12 +145,11 @@ subroutine ISOMIP_initialize_thickness ( h, depth_tot, G, GV, US, param_file, tv
                           !  usually negative because it is positive upward.
   real :: eta1D(SZK_(GV)+1) ! Interface height relative to the sea surface
                             ! positive upward, in depth units [Z ~> m].
-  integer :: i, j, k, is, ie, js, je, nz, tmp1
-  real    :: x
+  integer :: i, j, k, is, ie, js, je, nz
   real    :: min_thickness, s_sur, s_bot, t_sur, t_bot
   real    :: rho_sur, rho_bot  ! Surface and bottom densities [R ~> kg m-3]
   real    :: rho_range    ! The range of densities [R ~> kg m-3]
-  character(len=256) :: mesg  ! The text of an error message
+  !character(len=256) :: mesg  ! The text of an error message
   character(len=40) :: verticalCoordinate
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -260,17 +259,15 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, depth_tot, G, GV, U
                                                       !! only read parameters without changing T & S.
   ! Local variables
   integer   :: i, j, k, is, ie, js, je, nz, itt
-  real      :: x, ds, dt
   real      :: rho_sur, rho_bot  ! Surface and bottom densities [R ~> kg m-3]
   real      :: xi0, xi1 ! Heights in depth units [Z ~> m].
   real      :: S_sur, S_bot ! Salinity at the surface and bottom [ppt]
   real      :: T_sur, T_bot ! Temperature at the bottom [degC]
   real      :: dT_dz  ! Vertical gradient of temperature [degC Z-1 ~> degC m-1].
   real      :: dS_dz  ! Vertical gradient of salinity [ppt Z-1 ~> ppt m-1].
-  real      :: z            ! vertical position in z space [Z ~> m]
-  character(len=256) :: mesg ! The text of an error message
-  character(len=40) :: verticalCoordinate, density_profile
-  real :: rho_tmp
+  !character(len=256) :: mesg ! The text of an error message
+  character(len=40) :: verticalCoordinate
+  !real :: rho_tmp
   logical :: fit_salin       ! If true, accept the prescribed temperature and fit the salinity.
   real :: T0(SZK_(GV))       ! A profile of temperatures [degC]
   real :: S0(SZK_(GV))       ! A profile of salinities [ppt]
@@ -450,8 +447,9 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp,
                                     ! negative because it is positive upward.
   real :: eta1D(SZK_(GV)+1)         ! Interface height relative to the sea surface, positive upward [Z ~> m].
   real :: eta(SZI_(G),SZJ_(G),SZK_(GV)+1) ! A temporary array for interface heights [Z ~> m].
-  real :: min_depth, dummy1, z
-  real :: rho_dummy, min_thickness, rho_tmp, xi0
+  real :: min_depth, dummy1
+  real :: min_thickness, xi0
+  !real :: rho_tmp
   character(len=40) :: verticalCoordinate, filename, state_file
   character(len=40) :: temp_var, salt_var, eta_var, inputdir
 

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -127,7 +127,6 @@ subroutine Kelvin_initialize_topography(D, G, param_file, max_depth, US)
   ! Local variables
   character(len=40)  :: mdl = "Kelvin_initialize_topography" ! This subroutine's name.
   real :: min_depth ! The minimum and maximum depths [Z ~> m].
-  real :: PI ! 3.1415...
   real :: coast_offset1, coast_offset2, coast_angle, right_angle
   integer :: i, j
 

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -458,7 +458,7 @@ subroutine Update_Surface_Waves(G, GV, US, Day, dt, CS, forces)
   type(time_type),         intent(in)  :: dt  !< Timestep as a time-type
   type(mech_forcing),      intent(in), optional  :: forces !< MOM_forcing_type
   ! Local variables
-  integer :: ii, jj, kk, b
+  integer :: ii, jj, b
   type(time_type) :: Day_Center
 
   ! Computing central time of time step
@@ -1108,9 +1108,9 @@ subroutine get_StokesSL_LiFoxKemper(ustar, hbl, GV, US, CS, UStokes_SL, LA)
   real :: z0       ! The boundary layer depth [Z ~> m]
   real :: z0i      ! The inverse of theboundary layer depth [Z-1 ~> m-1]
   real :: r1, r2, r3, r4  ! Nondimensional ratios [nondim]
-  real :: r5       ! A single expression that combines r3 and r4 [nondim]
-  real :: root_2kz ! The square root of twice the peak wavenumber times the
-                   ! boundary layer depth [nondim]
+  ! real :: r5       ! A single expression that combines r3 and r4 [nondim]
+  ! real :: root_2kz ! The square root of twice the peak wavenumber times the
+  !                  ! boundary layer depth [nondim]
   real :: u10      ! The 10 m wind speed [L T-1 ~> m s-1]
   real :: PI       ! 3.1415926535...
 

--- a/src/user/Neverworld_initialization.F90
+++ b/src/user/Neverworld_initialization.F90
@@ -41,8 +41,6 @@ subroutine Neverworld_initialize_topography(D, G, param_file, max_depth)
 
   ! Local variables
   real :: PI                   ! 3.1415926... calculated as 4*atan(1)
-  real :: D0                   ! A constant to make the maximum     !
-                               ! basin depth MAXIMUM_DEPTH.         !
   real :: x, y
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -167,7 +165,6 @@ real function dist_line_fixed_y(x, y, x0, x1, y0)
   real, intent(in) :: x0      !< x-position of line segment end[nondim]
   real, intent(in) :: x1      !< x-position of line segment end[nondim]
   real, intent(in) :: y0      !< y-position of line segment [nondim]
-  real :: dx, yr, dy
 
   dist_line_fixed_y = dist_line_fixed_x(y, x, y0, x0, x1)
 end function dist_line_fixed_y
@@ -263,7 +260,7 @@ subroutine Neverworld_initialize_thickness(h, depth_tot, G, GV, US, param_file, 
   real :: noise ! Noise
   type(randomNumberStream) :: rns ! Random numbers for stochastic tidal parameterization
   character(len=40)  :: mdl = "Neverworld_initialize_thickness" ! This subroutine's name.
-  integer :: i, j, k, k1, is, ie, js, je, nz, itt
+  integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -250,7 +250,7 @@ subroutine Phillips_initialize_sponges(G, GV, US, tv, param_file, CSp, h)
   logical :: reentrant_y  ! If true, model is re-entrant in the y direction
   character(len=40)  :: mdl = "Phillips_initialize_sponges" ! This subroutine's name.
 
-  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
+  integer :: j, k, is, ie, js, je, isd, ied, jsd, jed, nz
   logical, save :: first_call = .true.
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -79,7 +79,7 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
 
   character(len=40)  :: mdl = "RGC_initialize_sponges" ! This subroutine's name.
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
-  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, iscB, iecB, jscB, jecB
+  integer :: i, j, is, ie, js, je, isd, ied, jsd, jed, nz, iscB, iecB, jscB, jecB
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed

--- a/src/user/Rossby_front_2d_initialization.F90
+++ b/src/user/Rossby_front_2d_initialization.F90
@@ -120,9 +120,8 @@ subroutine Rossby_front_initialize_temperature_salinity(T, S, h, G, GV, &
   integer   :: i, j, k, is, ie, js, je, nz
   real      :: T_ref, S_ref ! Reference salinity and temerature within surface layer
   real      :: T_range      ! Range of salinities and temperatures over the vertical
-  real      :: y, zc, zi, dTdz
+  real      :: zc, zi, dTdz
   character(len=40) :: verticalCoordinate
-  real      :: PI                   ! 3.1415926... calculated as 4*atan(1)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -170,7 +169,6 @@ subroutine Rossby_front_initialize_velocity(u, v, h, G, GV, US, param_file, just
   logical,                    intent(in)  :: just_read !< If present and true, this call will only
                                                 !! read parameters without setting u & v.
 
-  real    :: y            ! Non-dimensional coordinate across channel, 0..pi
   real    :: T_range      ! Range of salinities and temperatures over the vertical
   real    :: dUdT         ! Factor to convert dT/dy into dU/dz, g*alpha/f [L2 Z-1 T-1 degC-1 ~> m s-1 degC-1]
   real    :: dRho_dT      ! The partial derivative of density with temperature [R degC-1 ~> kg m-3 degC-1]
@@ -219,7 +217,7 @@ real function yPseudo( G, lat )
   type(ocean_grid_type), intent(in) :: G   !< Grid structure
   real,                  intent(in) :: lat !< Latitude
   ! Local
-  real :: y, PI
+  real :: PI
 
   PI = 4.0 * atan(1.0)
   yPseudo = ( ( lat - G%south_lat ) / G%len_lat ) - 0.5 ! -1/2 .. 1/.2

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -205,12 +205,11 @@ subroutine adjustment_initialize_temperature_salinity(T, S, h, depth_tot, G, GV,
 
   integer   :: i, j, k, is, ie, js, je, nz
   real      :: x, y, yy
-  integer   :: index_bay_z
   real      :: S_ref, T_ref         ! Reference salinity and temerature within
                                     ! surface layer
   real      :: S_range, T_range     ! Range of salinities and temperatures over the
                                     ! vertical
-  real      :: xi0, xi1, dSdz, delta_S, delta_S_strat
+  real      :: dSdz, delta_S, delta_S_strat
   real      :: adjustment_width, adjustment_deltaS
   real       :: front_wave_amp, front_wave_length, front_wave_asym
   real      :: eta1d(SZK_(GV)+1)

--- a/src/user/basin_builder.F90
+++ b/src/user/basin_builder.F90
@@ -218,7 +218,6 @@ real function dist_line_fixed_y(x, y, x0, x1, y0)
   real, intent(in) :: x0      !< x-position of line segment end[nondim]
   real, intent(in) :: x1      !< x-position of line segment end[nondim]
   real, intent(in) :: y0      !< y-position of line segment [nondim]
-  real :: dx, yr, dy
 
   dist_line_fixed_y = dist_line_fixed_x(y, x, y0, x0, x1)
 end function dist_line_fixed_y

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -238,7 +238,6 @@ subroutine benchmark_init_temperature_salinity(T, S, G, GV, US, param_file, &
   real :: rho_guess(SZK_(GV)) ! Potential density at T0 & S0 [R ~> kg m-3]
   real :: PI                 ! 3.1415926... calculated as 4*atan(1)
   real :: SST                !  The initial sea surface temperature [degC]
-  character(len=40)  :: mdl = "benchmark_init_temperature_salinity" ! This subroutine's name.
   integer :: i, j, k, k1, is, ie, js, je, nz, itt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -45,7 +45,7 @@ subroutine circle_obcs_initialize_thickness(h, depth_tot, G, GV, param_file, jus
   real :: eta1D(SZK_(GV)+1)! Interface height relative to the sea surface
                            ! positive upward, in depth units [Z ~> m].
   real :: IC_amp           ! The amplitude of the initial height displacement [H ~> m or kg m-2].
-  real :: diskrad, rad, xCenter, xRadius, lonC, latC, xOffset
+  real :: diskrad, rad, lonC, latC, xOffset
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "circle_obcs_initialization"   ! This module's name.

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -48,7 +48,7 @@ subroutine dumbbell_initialize_topography( D, G, param_file, max_depth )
 
   ! Local variables
   integer   :: i, j
-  real      :: x, y, delta, dblen, dbfrac
+  real      :: x, y, dblen, dbfrac
   logical   :: dbrotate
 
   call get_param(param_file, mdl, "DUMBBELL_LEN",dblen, &
@@ -217,10 +217,9 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, param_file
                                                       !! only read parameters without changing h.
 
   ! Local variables
-  integer :: i, j, k, is, ie, js, je, nz, k_light
-  real    :: xi0, xi1, dxi, r, S_surf, T_surf, S_range, T_range
-  real    :: x, y, dblen
-  real    :: T_ref, T_Light, T_Dense, S_ref, S_Light, S_Dense, a1, frac_dense, k_frac, res_rat
+  integer :: i, j, k, is, ie, js, je, nz
+  real    :: S_surf, T_surf, S_range
+  real    :: x, dblen
   logical :: dbrotate     ! If true, rotate the domain.
   character(len=20) :: verticalCoordinate, density_profile
 
@@ -293,12 +292,12 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, depth_tot, param_file, use
   real :: sponge_time_scale  ! The damping time scale [T ~> s]
 
   real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale [T-1 ~> s-1]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h, T, S ! sponge thicknesses, temp and salt
-  real, dimension(SZK_(GV)+1) :: e0, eta1D ! interface positions for ALE sponge
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h, S ! sponge thicknesses, temp and salt
+  real, dimension(SZK_(GV)+1) :: eta1D ! interface positions for ALE sponge
 
   integer :: i, j, k, nz
-  real :: x, zi, zmid, dist, min_thickness, dblen
-  real :: mld, S_ref, S_range, S_dense, T_ref, sill_height
+  real :: x, min_thickness, dblen
+  real :: S_ref, S_range
   logical :: dbrotate    ! If true, rotate the domain.
 
   call get_param(param_file, mdl,"DUMBBELL_LEN",dblen, &

--- a/src/user/dumbbell_surface_forcing.F90
+++ b/src/user/dumbbell_surface_forcing.F90
@@ -58,8 +58,6 @@ subroutine dumbbell_buoyancy_forcing(sfc_state, fluxes, day, dt, G, US, CS)
   type(dumbbell_surface_forcing_CS),  pointer  :: CS     !< A control structure returned by a previous
                                                          !! call to dumbbell_surface_forcing_init
   ! Local variables
-  real :: Temp_restore   ! The temperature that is being restored toward [degC].
-  real :: Salin_restore  ! The salinity that is being restored toward [ppt].
   integer :: i, j, is, ie, js, je
   integer :: isd, ied, jsd, jed
 
@@ -182,7 +180,7 @@ subroutine dumbbell_surface_forcing_init(Time, G, US, param_file, diag, CS)
   ! Local variables
   real :: S_surf  ! Initial surface salinity [ppt]
   real :: S_range ! Range of the initial vertical distribution of salinity [ppt]
-  real :: x, y    ! Latitude and longitude normalized by the domain size [nondim]
+  real :: x       ! Latitude normalized by the domain size [nondim]
   integer :: i, j
   logical :: dbrotate    ! If true, rotate the domain.
 # include "version_variable.h"

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -93,10 +93,8 @@ subroutine dyed_channel_set_OBC_tracer_data(OBC, G, GV, param_file, tr_Reg)
   ! Local variables
   character(len=40)  :: mdl = "dyed_channel_set_OBC_tracer_data" ! This subroutine's name.
   character(len=80)  :: name, longname
-  integer :: i, j, k, l, itt, isd, ied, jsd, jed, m, n
-  integer :: IsdB, IedB, JsdB, JedB
+  integer :: m, n
   real :: dye
-  type(OBC_segment_type), pointer :: segment => NULL()
   type(tracer_type), pointer      :: tr_ptr => NULL()
 
   if (.not.associated(OBC)) call MOM_error(FATAL, 'dyed_channel_initialization.F90: '// &
@@ -143,12 +141,10 @@ subroutine dyed_channel_update_flow(OBC, CS, G, GV, US, Time)
   type(unit_scale_type),      intent(in) :: US  !< A dimensional unit scaling type
   type(time_type),            intent(in) :: Time !< model time.
   ! Local variables
-  character(len=40)  :: mdl = "dyed_channel_update_flow" ! This subroutine's name.
-  character(len=80)  :: name
   real :: flow      ! The OBC velocity [L T-1 ~> m s-1]
   real :: PI        ! 3.1415926535...
   real :: time_sec  ! The elapsed time since the start of the calendar [T ~> s]
-  integer :: i, j, k, l, itt, isd, ied, jsd, jed, m, n
+  integer :: i, j, k, l, isd, ied, jsd, jed
   integer :: IsdB, IedB, JsdB, JedB
   type(OBC_segment_type), pointer :: segment => NULL()
 

--- a/src/user/dyed_obcs_initialization.F90
+++ b/src/user/dyed_obcs_initialization.F90
@@ -39,10 +39,9 @@ subroutine dyed_obcs_set_OBC_data(OBC, G, GV, param_file, tr_Reg)
   ! Local variables
   character(len=40)  :: mdl = "dyed_obcs_set_OBC_data" ! This subroutine's name.
   character(len=80)  :: name, longname
-  integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, m, n, nz
+  integer :: is, ie, js, je, isd, ied, jsd, jed, m, n, nz
   integer :: IsdB, IedB, JsdB, JedB
   real :: dye
-  type(OBC_segment_type), pointer :: segment => NULL()
   type(tracer_type), pointer      :: tr_ptr => NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke

--- a/src/user/lock_exchange_initialization.F90
+++ b/src/user/lock_exchange_initialization.F90
@@ -34,9 +34,6 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, US, param_file, just_rea
   logical,                 intent(in)  :: just_read   !< If true, this call will only read
                                                       !! parameters without changing h.
 
-  real :: e0(SZK_(GV))     ! The resting interface heights [Z ~> m], usually
-                           ! negative because it is positive upward.
-  real :: e_pert(SZK_(GV)) ! Interface height perturbations, positive upward [Z ~> m].
   real :: eta1D(SZK_(GV)+1)! Interface height relative to the sea surface
                            ! positive upward [Z ~> m].
   real :: front_displacement ! Vertical displacement acrodd front

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -201,7 +201,7 @@ subroutine seamount_initialize_temperature_salinity(T, S, h, G, GV, param_file, 
 
   ! Local variables
   integer :: i, j, k, is, ie, js, je, nz, k_light
-  real    :: xi0, xi1, dxi, r, S_surf, T_surf, S_range, T_range
+  real    :: xi0, xi1, r, S_surf, T_surf, S_range, T_range
   real    :: T_ref, T_Light, T_Dense, S_ref, S_Light, S_Dense, a1, frac_dense, k_frac, res_rat
   character(len=20) :: verticalCoordinate, density_profile
 

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -48,7 +48,7 @@ function register_shelfwave_OBC(param_file, CS, US, OBC_Reg)
   type(OBC_registry_type),  pointer    :: OBC_Reg    !< OBC registry.
   logical                              :: register_shelfwave_OBC
   ! Local variables
-  real :: kk, ll, PI, len_lat
+  real :: PI, len_lat
 
   character(len=32)  :: casename = "shelfwave"       !< This case's name.
 
@@ -144,8 +144,7 @@ subroutine shelfwave_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   real :: omega  ! Frequency of the shelf wave [T-1 ~> s-1]
   real :: alpha
   real :: x, y, jj, kk, ll
-  character(len=40)  :: mdl = "shelfwave_set_OBC_data" ! This subroutine's name.
-  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, n
+  integer :: i, j, is, ie, js, je, isd, ied, jsd, jed, n
   integer :: IsdB, IedB, JsdB, JedB
   type(OBC_segment_type), pointer :: segment => NULL()
 

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -78,7 +78,7 @@ subroutine sloshing_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
 # include "version_variable.h"
   character(len=40)  :: mdl = "sloshing_initialization" !< This module's name.
 
-  integer :: i, j, k, is, ie, js, je, nx, nz
+  integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -189,7 +189,7 @@ subroutine sloshing_initialize_temperature_salinity ( T, S, h, G, GV, param_file
                                                       !! only read parameters without changing T & S.
 
   integer :: i, j, k, is, ie, js, je, nz
-  real    :: delta_S, delta_T
+  real    :: delta_T
   real    :: S_ref, T_ref;      ! Reference salinity and temerature within
                                 ! surface layer
   real    :: S_range, T_range;  ! Range of salinities and temperatures over the

--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -40,7 +40,6 @@ subroutine soliton_initialize_thickness(h, depth_tot, G, GV, US)
   integer :: i, j, k, is, ie, js, je, nz
   real    :: x, y, x0, y0
   real    :: val1, val2, val3, val4
-  character(len=40) :: verticalCoordinate
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -70,8 +70,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   real :: PI
   real :: flux_scale  ! A scaling factor for the areas [m2 H-1 L-1 ~> nondim or m3 kg-1]
   real, allocatable :: my_area(:,:) ! The total OBC inflow area [m2]
-  character(len=40)  :: mdl = "tidal_bay_set_OBC_data" ! This subroutine's name.
-  integer :: i, j, k, itt, is, ie, js, je, isd, ied, jsd, jed, nz, n
+  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, n
   integer :: IsdB, IedB, JsdB, JedB
   type(OBC_segment_type), pointer :: segment => NULL()
 

--- a/src/user/user_change_diffusivity.F90
+++ b/src/user/user_change_diffusivity.F90
@@ -77,8 +77,6 @@ subroutine user_change_diff(h, tv, G, GV, US, CS, Kd_lay, Kd_int, T_f, S_f, Kd_i
   integer :: i, j, k, is, ie, js, je, nz
   integer :: isd, ied, jsd, jed
 
-  real :: kappa_fill  ! diffusivity used to fill massless layers
-  real :: dt_fill     ! timestep used to fill massless layers
   character(len=200) :: mesg
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -209,7 +207,6 @@ subroutine user_change_diff_init(Time, G, GV, US, param_file, diag, CS)
 # include "version_variable.h"
   character(len=40)  :: mdl = "user_set_diffusivity"  ! This module's name.
   character(len=200) :: mesg
-  integer :: i, j, is, ie, js, je
 
   if (associated(CS)) then
     call MOM_error(WARNING, "diabatic_entrain_init called with an associated "// &
@@ -219,9 +216,6 @@ subroutine user_change_diff_init(Time, G, GV, US, param_file, diag, CS)
   allocate(CS)
 
   CS%initialized = .true.
-
-  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
-
   CS%diag => diag
 
   ! Read all relevant parameters and write them to the model log.


### PR DESCRIPTION
This patch removes any unused variables detected by -Wunused-variables
in GCC.

This may include variables which are referenced in commented "zombie
code".  In some cases, the variables were preserved in comments, but no
in all cases.  If the zombie code is restored, it should be possible to
reconstruct the original declaration.  (All known cases were simple
scalars, such as loop indices).

In one case, a variable was conditionally used within a preprocessor
`#ifdef __DO_SAFETY_CHECKS__` block.  This patch moves the declaration
into another `#ifdef` block, but perhaps it is preferable to remove the
block.

Certain documentation variables such as `mdl`, which typically contain
the function name, have been removed if unused.

The strongest motivation for this patch is to allow us to enable the
`-Wall` flag, which includes unused variables, and will strengthen our
ability to detect potential errors in the codebase.