### PR TITLE
+Set thickness_units for use by deta_dt diagnostic

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1324,6 +1324,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
   call cpu_clock_end(id_clock_pass_init)
 
   flux_units = get_flux_units(GV)
+  thickness_units = get_thickness_units(GV)
   CS%id_uh = register_diag_field('ocean_model', 'uh', diag%axesCuL, Time, &
       'Zonal Thickness Flux', flux_units, conversion=GV%H_to_MKS*US%L_to_m**2*US%s_to_T, &
       y_cell_method='sum', v_extensive=.true.)


### PR DESCRIPTION
  Added a call to set thickness_units, which are used in the units description
for the diagnostic deta_dt, which was recently added by
https://github.com/NOAA-GFDL/MOM6/pull/99, but with an uninitialized variable
being used for the units description.  This changes contents of one entry in the
MOM_available_diags, which will once again reproduce across runs and compilers.
All solutions are bitwise identical.