### PR TITLE
+Improve style compliance in config_src/external code

### DIFF
--- a/config_src/external/ODA_hooks/ocean_da_types.F90
+++ b/config_src/external/ODA_hooks/ocean_da_types.F90
@@ -1,90 +1,88 @@
 !> Dummy aata structures and methods for ocean data assimilation.
 module ocean_da_types_mod
 
-  use MOM_time_manager, only : time_type
+use MOM_time_manager, only : time_type
 
-  implicit none
+implicit none ; private
 
-  private
+!> Example type for ocean ensemble DA state
+type, public :: OCEAN_CONTROL_STRUCT
+  integer :: ensemble_size        !< ensemble size
+  real, pointer, dimension(:,:,:)   :: SSH => NULL() !< sea surface height across ensembles [m]
+  real, pointer, dimension(:,:,:,:) :: h => NULL() !< layer thicknesses across ensembles [m or kg m-2]
+  real, pointer, dimension(:,:,:,:) :: T => NULL() !< layer potential temperature across ensembles [degC]
+  real, pointer, dimension(:,:,:,:) :: S => NULL() !< layer salinity across ensembles [ppt]
+  real, pointer, dimension(:,:,:,:) :: U => NULL() !< layer zonal velocity across ensembles [m s-1]
+  real, pointer, dimension(:,:,:,:) :: V => NULL() !< layer meridional velocity across ensembles [m s-1]
+end type OCEAN_CONTROL_STRUCT
 
-  !> Example type for ocean ensemble DA state
-  type, public :: OCEAN_CONTROL_STRUCT
-     integer :: ensemble_size        !< ensemble size
-     real, pointer, dimension(:,:,:)   :: SSH=>NULL() !<sea surface height (m) across ensembles
-     real, pointer, dimension(:,:,:,:) :: h=>NULL() !<layer thicknesses (m or kg) across ensembles
-     real, pointer, dimension(:,:,:,:) :: T=>NULL() !<layer potential temperature (degC) across ensembles
-     real, pointer, dimension(:,:,:,:) :: S=>NULL() !<layer salinity (psu or g kg-1) across ensembles
-     real, pointer, dimension(:,:,:,:) :: U=>NULL() !<layer zonal velocity (m s-1) across ensembles
-     real, pointer, dimension(:,:,:,:) :: V=>NULL() !<layer meridional velocity (m s-1) across ensembles
-  end type OCEAN_CONTROL_STRUCT
+!> Example of a profile type
+type, public :: ocean_profile_type
+  integer :: inst_type !< A numeric code indicating the type of instrument (e.g. ARGO drifter, CTD, ...)
+  logical :: initialized !< a True value indicates that this profile has been allocated for use
+  logical :: colocated !< a True value indicated that the measurements of (num_variables) data are
+                       !! co-located in space-time
+  integer :: ensemble_size !< size of the ensemble of model states used in association with this profile
+  integer :: num_variables !< number of measurement types associated with this profile.
+  integer, pointer, dimension(:) :: var_id !< variable ids are defined by the ocean_types module
+  integer :: platform !< platform types are defined by platform class (e.g. MOORING, DROP, etc.)
+                      !! and instrument type (XBT, CDT, etc.)
+  integer :: levels !< number of levels in the current profile
+  integer :: basin_mask !< 1:Southern Ocean, 2:Atlantic Ocean, 3:Pacific Ocean,
+                        !! 4:Arctic Ocean, 5:Indian Ocean, 6:Mediterranean Sea, 7:Black Sea,
+                        !! 8:Hudson Bay, 9:Baltic Sea, 10:Red Sea, 11:Persian Gulf
+  integer :: profile_flag !< an overall flag for the profile
+  real :: lat      !< latitude [degrees_N]
+  real :: lon      !< longitude [degrees_E]
+  logical :: accepted !< logical flag to disable a profile
+  type(time_type) :: time_window !< The time window associated with this profile
+  real, pointer, dimension(:) :: obs_error  !< The observation error by variable [various units]
+  real  :: loc_dist   !< The impact radius of this observation [m]
+  type(ocean_profile_type), pointer :: next => NULL() !< all profiles are stored as linked list.
+  type(ocean_profile_type), pointer :: prev => NULL() !< previous
+  type(ocean_profile_type), pointer :: cnext => NULL() !< current profiles are stored as linked list.
+  type(ocean_profile_type), pointer :: cprev => NULL() !< previous
+  integer :: nbr_xi !< x nearest neighbor model gridpoint for the profile
+  integer :: nbr_yi !< y nearest neighbor model gridpoint for the profile
+  real :: nbr_dist !< distance to nearest neighbor model gridpoint [m]
+  logical :: compute !< profile is within current compute domain
+  real, dimension(:,:), pointer :: depth => NULL() !< depth of measurement [m]
+  real, dimension(:,:), pointer :: data => NULL() !< data by variable type [various units]
+  integer, dimension(:,:), pointer :: flag => NULL() !< flag by depth and variable type
+  real, dimension(:,:,:), pointer :: forecast => NULL() !< ensemble member first guess
+  real, dimension(:,:,:), pointer :: analysis => NULL() !< ensemble member analysis
+  type(forward_operator_type), pointer :: obs_def => NULL() !< observation forward operator
+  type(time_type) :: time !< profile time type
+  real :: i_index !< model longitude indices respectively
+  real :: j_index !< model latitude indices respectively
+  real, dimension(:,:), pointer :: k_index !< model depth indices
+  type(time_type) :: tdiff !< difference between model time and observation time
+  character(len=128) :: filename !< a filename
+end type ocean_profile_type
 
-  !> Example of a profile type
-  type, public :: ocean_profile_type
-     integer :: inst_type !< A numeric code indicating the type of instrument (e.g. ARGO drifter, CTD, ...)
-     logical :: initialized !< a True value indicates that this profile has been allocated for use
-     logical :: colocated !< a True value indicated that the measurements of (num_variables) data are
-                          !! co-located in space-time
-     integer :: ensemble_size !< size of the ensemble of model states used in association with this profile
-     integer :: num_variables !< number of measurement types associated with this profile.
-     integer, pointer, dimension(:) :: var_id !< variable ids are defined by the ocean_types module
-     integer :: platform !< platform types are defined by platform class (e.g. MOORING, DROP, etc.)
-                         !! and instrument type (XBT, CDT, etc.)
-     integer :: levels !< number of levels in the current profile
-     integer :: basin_mask !< 1:Southern Ocean, 2:Atlantic Ocean, 3:Pacific Ocean,
-                           !! 4:Arctic Ocean, 5:Indian Ocean, 6:Mediterranean Sea, 7:Black Sea,
-                           !! 8:Hudson Bay, 9:Baltic Sea, 10:Red Sea, 11:Persian Gulf
-     integer :: profile_flag !< an overall flag for the profile
-     real :: lat      !< latitude [degrees_N]
-     real :: lon      !< longitude [degrees_E]
-     logical :: accepted !< logical flag to disable a profile
-     type(time_type) :: time_window !< The time window associated with this profile [s]
-     real, pointer, dimension(:) :: obs_error  !< The observation error by variable
-     real  :: loc_dist   !< The impact radius of this observation (m)
-     type(ocean_profile_type), pointer :: next=>NULL() !< all profiles are stored as linked list.
-     type(ocean_profile_type), pointer :: prev=>NULL() !< previous
-     type(ocean_profile_type), pointer :: cnext=>NULL() !< current profiles are stored as linked list.
-     type(ocean_profile_type), pointer :: cprev=>NULL() !< previous
-     integer :: nbr_xi !< x nearest neighbor model gridpoint for the profile
-     integer :: nbr_yi !< y nearest neighbor model gridpoint for the profile
-     real :: nbr_dist !< distance to nearest neighbor model gridpoint
-     logical :: compute !< profile is within current compute domain
-     real, dimension(:,:), pointer :: depth => NULL() !< depth of measurement [m]
-     real, dimension(:,:), pointer :: data => NULL() !< data by variable type
-     integer, dimension(:,:), pointer :: flag => NULL() !< flag by depth and variable type
-     real, dimension(:,:,:), pointer :: forecast => NULL() !< ensemble member first guess
-     real, dimension(:,:,:), pointer :: analysis => NULL() !< ensemble member analysis
-     type(forward_operator_type), pointer :: obs_def => NULL() !< observation forward operator
-     type(time_type) :: time !< profile time type
-     real :: i_index !< model longitude indices respectively
-     real :: j_index !< model latitude indices respectively
-     real, dimension(:,:), pointer :: k_index !< model depth indices
-     type(time_type) :: tdiff !< difference between model time and observation time
-     character(len=128) :: filename !< a filename
-  end type ocean_profile_type
+!>  Example forward operator type.
+type, public :: forward_operator_type
+  integer :: num                      !< how many?
+  integer, dimension(2) :: state_size !< for
+  integer, dimension(:), pointer :: state_var_index !< for flattened data
+  integer, dimension(:), pointer :: i_index !< i-dimension index
+  integer, dimension(:), pointer :: j_index !< j-dimension index
+  real, dimension(:), pointer :: coef !< coefficient
+end type forward_operator_type
 
-  !>  Example forward operator type.
-  type, public :: forward_operator_type
-     integer :: num                      !< how many?
-     integer, dimension(2) :: state_size !< for
-     integer, dimension(:), pointer :: state_var_index !< for flattened data
-     integer, dimension(:), pointer :: i_index !< i-dimension index
-     integer, dimension(:), pointer :: j_index !< j-dimension index
-     real, dimension(:), pointer :: coef !< coefficient
-  end type forward_operator_type
-
-  !> Grid type for DA
-  type, public :: grid_type
-     real, pointer, dimension(:,:) :: x=>NULL()    !< x
-     real, pointer, dimension(:,:) :: y=>NULL()    !< y
-     real, pointer, dimension(:,:,:) :: z=>NULL()  !< z
-     real, pointer, dimension(:,:,:) :: h=>NULL()  !< h
-     real, pointer, dimension(:,:) :: basin_mask => NULL() !< basin mask
-     real, pointer, dimension(:,:,:) :: mask => NULL()     !< land mask?
-     real, pointer, dimension(:,:) :: bathyT => NULL()     !< bathymetry at T points
-     logical :: tripolar_N    !< True for tripolar grids
-     integer :: ni !< ni
-     integer :: nj !< nj
-     integer :: nk !< nk
-  end type grid_type
+!> Grid type for DA
+type, public :: grid_type
+  real, pointer, dimension(:,:) :: x => NULL()    !< x
+  real, pointer, dimension(:,:) :: y => NULL()    !< y
+  real, pointer, dimension(:,:,:) :: z => NULL()  !< z
+  real, pointer, dimension(:,:,:) :: h => NULL()  !< h
+  real, pointer, dimension(:,:) :: basin_mask => NULL() !< basin mask
+  real, pointer, dimension(:,:,:) :: mask => NULL()     !< land mask?
+  real, pointer, dimension(:,:) :: bathyT => NULL()     !< bathymetry at T points [m]
+  logical :: tripolar_N    !< True for tripolar grids
+  integer :: ni !< ni
+  integer :: nj !< nj
+  integer :: nk !< nk
+end type grid_type
 
 end module ocean_da_types_mod

--- a/config_src/external/ODA_hooks/write_ocean_obs.F90
+++ b/config_src/external/ODA_hooks/write_ocean_obs.F90
@@ -1,16 +1,12 @@
 !> Dummy interfaces for writing ODA data
 module write_ocean_obs_mod
 
+use ocean_da_types_mod, only : ocean_profile_type
+use MOM_time_manager, only : time_type, get_time, set_date
 
- use ocean_da_types_mod, only : ocean_profile_type
- use MOM_time_manager, only : time_type, get_time, set_date
+implicit none ; private
 
- implicit none
-
- private
-
- public :: open_profile_file, write_profile, close_profile_file, &
-            write_ocean_obs_init
+public :: open_profile_file, write_profile, close_profile_file, write_ocean_obs_init
 
 contains
 

--- a/config_src/external/drifters/MOM_particles.F90
+++ b/config_src/external/drifters/MOM_particles.F90
@@ -1,26 +1,28 @@
 !> A set of dummy interfaces for compiling the MOM6 drifters code
 module MOM_particles_mod
 
+! This file is part of MOM6. See LICENSE.md for the license.
+
 use MOM_grid,         only : ocean_grid_type
 use MOM_time_manager, only : time_type, get_date, operator(-)
 use MOM_variables,    only : thermo_var_ptrs
+use particles_types_mod, only : particles, particles_gridded
 
+implicit none ; private
 
-use particles_types_mod, only: particles, particles_gridded
-
-public particles_run, particles_init, particles_save_restart, particles_end
+public particles, particles_run, particles_init, particles_save_restart, particles_end
 
 contains
 
 !> Initializes particles container "parts"
 subroutine particles_init(parts, Grid, Time, dt, u, v)
   ! Arguments
- type(particles), pointer, intent(out) :: parts !< Container for all types and memory
- type(ocean_grid_type), target, intent(in) :: Grid !< Grid type from parent model
- type(time_type), intent(in) :: Time !< Time type from parent model
- real, intent(in)            :: dt !< particle timestep in seconds
- real, dimension(:,:,:),intent(in)      :: u !< Zonal velocity field
- real, dimension(:,:,:),intent(in)      :: v !< Meridional velocity field
+  type(particles), pointer, intent(out) :: parts !< Container for all types and memory
+  type(ocean_grid_type), target, intent(in) :: Grid !< Grid type from parent model
+  type(time_type), intent(in) :: Time !< Time type from parent model
+  real, intent(in)            :: dt   !< particle timestep [s]
+  real, dimension(:,:,:), intent(in)    :: u !< Zonal velocity field [m s-1]
+  real, dimension(:,:,:), intent(in)    :: v !< Meridional velocity field [m s-1]
 
 end subroutine particles_init
 
@@ -29,30 +31,30 @@ subroutine particles_run(parts, time, uo, vo, ho, tv, stagger)
   ! Arguments
   type(particles), pointer :: parts !< Container for all types and memory
   type(time_type), intent(in) :: time !< Model time
-  real, dimension(:,:,:),intent(in) :: uo !< Ocean zonal velocity (m/s)
-  real, dimension(:,:,:),intent(in) :: vo !< Ocean meridional velocity (m/s)
-  real, dimension(:,:,:),intent(in) :: ho !< Ocean layer thickness [H ~> m or kg m-2]
-  type(thermo_var_ptrs), intent(in) :: tv !< structure containing pointers to available thermodynamic fields
+  real, dimension(:,:,:), intent(in) :: uo !< Ocean zonal velocity [m s-1]
+  real, dimension(:,:,:), intent(in) :: vo !< Ocean meridional velocity [m s-1]
+  real, dimension(:,:,:), intent(in) :: ho !< Ocean layer thickness [H ~> m or kg m-2]
+  type(thermo_var_ptrs),  intent(in) :: tv !< structure containing pointers to available thermodynamic fields
   integer, optional, intent(in) :: stagger !< Flag for whether velocities are staggered
 
 end subroutine particles_run
 
 
 !>Save particle locations (and sometimes other vars) to restart file
-subroutine particles_save_restart(parts,temp,salt)
-! Arguments
-type(particles), pointer :: parts !< Container for all types and memory
-real,dimension(:,:,:),optional,intent(in) :: temp !< Optional container for temperature
-real,dimension(:,:,:),optional,intent(in) ::  salt !< Optional container for salinity
+subroutine particles_save_restart(parts, temp, salt)
+  ! Arguments
+  type(particles), pointer :: parts !< Container for all types and memory
+  real, dimension(:,:,:), optional, intent(in) :: temp !< Optional container for temperature
+  real, dimension(:,:,:), optional, intent(in) :: salt !< Optional container for salinity
 
 end subroutine particles_save_restart
 
 !> Deallocate all memory and disassociated pointer
-subroutine particles_end(parts,temp,salt)
-! Arguments
-type(particles), pointer :: parts !< Container for all types and memory
-real,dimension(:,:,:),optional,intent(in) :: temp !< Optional container for temperature
-real,dimension(:,:,:),optional,intent(in) :: salt !< Optional container for salinity
+subroutine particles_end(parts, temp, salt)
+  ! Arguments
+  type(particles), pointer :: parts !< Container for all types and memory
+  real, dimension(:,:,:), optional, intent(in) :: temp !< Optional container for temperature
+  real, dimension(:,:,:), optional, intent(in) :: salt !< Optional container for salinity
 
 end subroutine particles_end
 

--- a/config_src/external/drifters/MOM_particles_types.F90
+++ b/config_src/external/drifters/MOM_particles_types.F90
@@ -1,12 +1,15 @@
 !> Dummy data structures and methods for drifters package
 module particles_types_mod
 
-use MOM_grid, only : ocean_grid_type
-use mpp_domains_mod, only: domain2D
+! This file is part of MOM6. See LICENSE.md for the license.
 
+use MOM_grid, only : ocean_grid_type
+use MOM_domains, only: domain2D
+
+implicit none ; private
 
 !> Container for gridded fields
-type :: particles_gridded
+type, public :: particles_gridded
   type(domain2D), pointer :: domain !< MPP parallel domain
   integer :: halo !< Nominal halo width
   integer :: isc !< Start i-index of computational domain
@@ -60,7 +63,7 @@ end type particles_gridded
 
 
 !>xyt is a data structure containing particle position and velocity fields.
-type :: xyt
+type, public :: xyt
   real :: lon !< Longitude of particle (degree N or unit of grid coordinate)
   real :: lat !< Latitude of particle (degree N or unit of grid coordinate)
   real :: day      !< Day of this record (days)
@@ -77,7 +80,7 @@ type :: xyt
 end type xyt
 
 !>particle types are data structures describing a tracked particle
-type :: particle
+type, public :: particle
   type(particle), pointer :: prev=>null() !< Previous link in list
   type(particle), pointer :: next=>null() !< Next link in list
 ! State variables (specific to the particles, needed for restarts)
@@ -109,19 +112,19 @@ end type particle
 
 
 !>A buffer structure for message passing
-type :: buffer
+type, public :: buffer
   integer :: size=0 !< Size of buffer
   real, dimension(:,:), pointer :: data !< Buffer memory
 end type buffer
 
 !> A wrapper for the particle linked list (since an array of pointers is not allowed)
-type :: linked_list
+type, public :: linked_list
   type(particle), pointer :: first=>null() !< Pointer to the beginning of a linked list of parts
 end type linked_list
 
 
 !> A grand data structure for the particles in the local MOM domain
-type :: particles !; private
+type, public :: particles !; private
   type(particles_gridded) :: grd !< Container with all gridded data
   type(linked_list), dimension(:,:), allocatable :: list !< Linked list of particles
   type(xyt), pointer :: trajectories=>null() !< A linked list for detached segments of trajectories

--- a/config_src/external/stochastic_physics/get_stochy_pattern.F90
+++ b/config_src/external/stochastic_physics/get_stochy_pattern.F90
@@ -1,0 +1,22 @@
+! The are stubs for ocean stochastic physics
+! the fully functional code is available at
+! http://github.com/noaa-psd/stochastic_physics
+module get_stochy_pattern_mod
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+implicit none ; private
+
+public  :: write_stoch_restart_ocn
+
+contains
+
+!> Write the restart file for the stochastic physics perturbations.
+subroutine write_stoch_restart_ocn(sfile)
+  character(len=*) :: sfile   !< name of restart file
+
+  ! This stub function does not actually do anything.
+  return
+end subroutine write_stoch_restart_ocn
+
+end module get_stochy_pattern_mod

--- a/config_src/external/stochastic_physics/stochastic_physics.F90
+++ b/config_src/external/stochastic_physics/stochastic_physics.F90
@@ -3,66 +3,56 @@
 ! http://github.com/noaa-psd/stochastic_physics
 module stochastic_physics
 
-implicit none
+! This file is part of MOM6. See LICENSE.md for the license.
 
-private
+use MOM_error_handler, only : MOM_error, WARNING
+
+implicit none ; private
 
 public :: init_stochastic_physics_ocn
 public :: run_stochastic_physics_ocn
 
 contains
 
-!!!!!!!!!!!!!!!!!!!!
-subroutine init_stochastic_physics_ocn(delt,geoLonT,geoLatT,nx,ny,nz,pert_epbl_in,do_sppt_in, &
+!> Initializes the stochastic physics perturbations.
+subroutine init_stochastic_physics_ocn(delt, geoLonT, geoLatT, nx, ny, nz, pert_epbl_in, do_sppt_in, &
                                        mpiroot, mpicomm, iret)
-implicit none
-real,intent(in)       :: delt !< timestep in seconds between calls to run_stochastic_physics_ocn
-integer,intent(in)    :: nx   !< number of gridpoints in the x-direction of the compute grid
-integer,intent(in)    :: ny   !< number of gridpoints in the y-direction of the compute grid
-integer,intent(in)    :: nz   !< number of gridpoints in the z-direction of the compute grid
-real,intent(in)       :: geoLonT(nx,ny) !< Longitude in degrees
-real,intent(in)       :: geoLatT(nx,ny) !< Latitude in degrees
-logical,intent(in)    :: pert_epbl_in !< logical flag, if true generate random pattern for ePBL perturbations
-logical,intent(in)    :: do_sppt_in   !< logical flag, if true generate random pattern for SPPT perturbations
-integer,intent(in)    :: mpiroot !< root processor
-integer,intent(in)    :: mpicomm !< mpi communicator
-integer, intent(out)  :: iret    !< return code
+  real,    intent(in)    :: delt !< timestep in seconds between calls to run_stochastic_physics_ocn [s]
+  integer, intent(in)    :: nx   !< number of gridpoints in the x-direction of the compute grid
+  integer, intent(in)    :: ny   !< number of gridpoints in the y-direction of the compute grid
+  integer, intent(in)    :: nz   !< number of gridpoints in the z-direction of the compute grid
+  real,    intent(in)    :: geoLonT(nx,ny) !< Longitude in degrees
+  real,    intent(in)    :: geoLatT(nx,ny) !< Latitude in degrees
+  logical, intent(in)    :: pert_epbl_in !< logical flag, if true generate random pattern for ePBL perturbations
+  logical, intent(in)    :: do_sppt_in   !< logical flag, if true generate random pattern for SPPT perturbations
+  integer, intent(in)    :: mpiroot !< root processor
+  integer, intent(in)    :: mpicomm !< mpi communicator
+  integer, intent(out)   :: iret    !< return code
 
-iret=0
-if (pert_epbl_in .EQV. .true. ) then
-   print*,'pert_epbl needs to be false if using the stub'
-   iret=-1
-endif
-if (do_sppt_in.EQV. .true. ) then
-   print*,'do_sppt needs to be false if using the stub'
-   iret=-1
-endif
-return
+  iret=0
+  if (pert_epbl_in) then
+    call MOM_error(WARNING, 'init_stochastic_physics_ocn: pert_epbl needs to be false if using the stub')
+    iret=-1
+  endif
+  if (do_sppt_in) then
+    call MOM_error(WARNING, 'init_stochastic_physics_ocn: do_sppt needs to be false if using the stub')
+    iret=-1
+  endif
+
+  ! This stub function does not actually do anything.
+  return
 end subroutine init_stochastic_physics_ocn
 
-subroutine run_stochastic_physics_ocn(sppt_wts,t_rp1,t_rp2)
-implicit none
-real, intent(inout) :: sppt_wts(:,:) !< array containing random weights for SPPT range [0,2]
-real, intent(inout) :: t_rp1(:,:)    !< array containing random weights for ePBL
-                                     !! perturbations (KE generation) range [0,2]
-real, intent(inout) :: t_rp2(:,:)    !< array containing random weights for ePBL
-                                     !! perturbations (KE dissipation) range [0,2]
-return
+!> Determines the stochastic physics perturbations.
+subroutine run_stochastic_physics_ocn(sppt_wts, t_rp1, t_rp2)
+  real, intent(inout) :: sppt_wts(:,:) !< array containing random weights for SPPT range [0,2]
+  real, intent(inout) :: t_rp1(:,:)    !< array containing random weights for ePBL
+                                       !! perturbations (KE generation) range [0,2]
+  real, intent(inout) :: t_rp2(:,:)    !< array containing random weights for ePBL
+                                       !! perturbations (KE dissipation) range [0,2]
+
+  ! This stub function does not actually do anything.
+  return
 end subroutine run_stochastic_physics_ocn
 
 end module stochastic_physics
-
-module get_stochy_pattern_mod
-
-private
-
-public  :: write_stoch_restart_ocn
-
-contains
-subroutine write_stoch_restart_ocn(sfile)
-
-character(len=*) :: sfile   !< name of restart file
-return
-end subroutine write_stoch_restart_ocn
-
-end module get_stochy_pattern_mod

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -16,8 +16,8 @@ use MOM_string_functions, only : uppercase
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_wave_interface, only: wave_parameters_CS, Get_Langmuir_Number
-use MOM_stochastics,         only : stochastic_CS
+use MOM_wave_interface, only : wave_parameters_CS, Get_Langmuir_Number
+use MOM_stochastics,    only : stochastic_CS
 
 implicit none ; private
 
@@ -118,7 +118,7 @@ type, public :: energetic_PBL_CS ; private
   real :: MSTAR_COEF = 0.3   !< MSTAR coefficient in rotation/stabilizing balance for mstar_scheme=OM4
 
   !/ mstar_scheme == 3
-  real    :: RH18_mstar_cN1  !< MSTAR_N coefficient 1 (outter-most coefficient for fit).
+  real    :: RH18_mstar_cN1  !< MSTAR_N coefficient 1 (outer-most coefficient for fit).
                              !! Value of 0.275 in RH18.  Increasing this
                              !! coefficient increases mechanical mixing for all values of Hf/ust,
                              !! but is most effective at low values (weakly developed OSBLs).
@@ -140,18 +140,18 @@ type, public :: energetic_PBL_CS ; private
   !/ Langmuir turbulence related parameters
   logical :: Use_LT = .false. !< Flag for using LT in Energy calculation
   integer :: LT_ENHANCE_FORM !< Integer for Enhancement functional form (various options)
-  real    :: LT_ENHANCE_COEF !< Coefficient in fit for Langmuir Enhancment
+  real    :: LT_ENHANCE_COEF !< Coefficient in fit for Langmuir Enhancement
   real    :: LT_ENHANCE_EXP  !< Exponent in fit for Langmuir Enhancement
   real :: LaC_MLDoEK         !< Coefficient for Langmuir number modification based on the ratio of
                              !! the mixed layer depth over the Ekman depth.
   real :: LaC_MLDoOB_stab    !< Coefficient for Langmuir number modification based on the ratio of
-                             !! the mixed layer depth over the Obukov depth with stablizing forcing.
+                             !! the mixed layer depth over the Obukhov depth with stabilizing forcing.
   real :: LaC_EKoOB_stab     !< Coefficient for Langmuir number modification based on the ratio of
-                             !! the Ekman depth over the Obukov depth with stablizing forcing.
+                             !! the Ekman depth over the Obukhov depth with stabilizing forcing.
   real :: LaC_MLDoOB_un      !< Coefficient for Langmuir number modification based on the ratio of
-                             !! the mixed layer depth over the Obukov depth with destablizing forcing.
+                             !! the mixed layer depth over the Obukhov depth with destabilizing forcing.
   real :: LaC_EKoOB_un       !< Coefficient for Langmuir number modification based on the ratio of
-                             !! the Ekman depth over the Obukov depth with destablizing forcing.
+                             !! the Ekman depth over the Obukhov depth with destabilizing forcing.
   real :: Max_Enhance_M = 5. !< The maximum allowed LT enhancement to the mixing.
 
   !/ Others
@@ -205,11 +205,11 @@ integer, parameter :: Use_Fixed_MStar = 0  !< The value of mstar_scheme to use a
 integer, parameter :: MStar_from_Ekman = 2 !< The value of mstar_scheme to base mstar on the ratio
                                            !! of the Ekman layer depth to the Obukhov depth
 integer, parameter :: MStar_from_RH18 = 3  !< The value of mstar_scheme to base mstar of of RH18
-integer, parameter :: No_Langmuir = 0      !< The value of LT_ENHANCE_FORM not use Langmuir turbolence.
+integer, parameter :: No_Langmuir = 0      !< The value of LT_ENHANCE_FORM not use Langmuir turbulence.
 integer, parameter :: Langmuir_rescale = 2 !< The value of LT_ENHANCE_FORM to use a multiplicative
                                            !! rescaling of mstar to account for Langmuir turbulence.
 integer, parameter :: Langmuir_add = 3     !< The value of LT_ENHANCE_FORM to add a contribution to
-                                           !! mstar from Langmuir turblence to other contributions.
+                                           !! mstar from Langmuir turbulence to other contributions.
 integer, parameter :: wT_from_cRoot_TKE = 0 !< Use a constant times the cube root of remaining TKE
                                            !! to calculate the turbulent velocity.
 integer, parameter :: wT_from_RH18 = 1     !< Use a scheme based on a combination of w* and v* as
@@ -278,7 +278,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
                            intent(out)   :: Kd_int !< The diagnosed diffusivities at interfaces
                                                    !! [Z2 T-1 ~> m2 s-1].
-  type(energetic_PBL_CS),  intent(inout) :: CS     !< Energetic PBL control struct
+  type(energetic_PBL_CS),  intent(inout) :: CS     !< Energetic PBL control structure
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)    :: buoy_flux !< The surface buoyancy flux [Z2 T-3 ~> m2 s-3].
   type(wave_parameters_CS), pointer      :: Waves  !< Waves control structure for Langmuir turbulence
@@ -298,7 +298,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
 ! mixing.
 !
 !   The key parameters for the mixed layer are found in the control structure.
-!   To use the classic constant mstar mixied layers choose MSTAR_SCHEME=CONSTANT.
+!   To use the classic constant mstar mixed layers choose MSTAR_SCHEME=CONSTANT.
 ! The key parameters then include mstar, nstar, TKE_decay, and conv_decay.
 ! For the Oberhuber (1993) mixed layer,the values of these are:
 !      mstar = 1.25,  nstar = 1, TKE_decay = 2.5, conv_decay = 0.5
@@ -329,7 +329,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
     v               ! The meridional velocity [L T-1 ~> m s-1].
   real, dimension(SZK_(GV)+1) :: &
     Kd, &           ! The diapycnal diffusivity [Z2 T-1 ~> m2 s-1].
-    mixvel, &       ! A turbulent mixing veloxity [Z T-1 ~> m s-1].
+    mixvel, &       ! A turbulent mixing velocity [Z T-1 ~> m s-1].
     mixlen          ! A turbulent mixing length [Z ~> m].
   real :: h_neglect ! A thickness that is so small it is usually lost
                     ! in roundoff and can be neglected [H ~> m or kg m-2].
@@ -427,7 +427,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
         call ePBL_column(h, u, v, T0, S0, dSV_dT_1d, dSV_dS_1d, TKE_forcing, B_flux, absf, &
                          u_star, u_star_mean, dt, MLD_io, Kd, mixvel, mixlen, GV, &
                          US, CS, eCD, Waves, G, i, j, &
-                         epbl1_wt=stoch_CS%epbl1_wts(i,j),epbl2_wt=stoch_CS%epbl2_wts(i,j))
+                         TKE_gen_stoch=stoch_CS%epbl1_wts(i,j), TKE_diss_stoch=stoch_CS%epbl2_wts(i,j))
       else
         call ePBL_column(h, u, v, T0, S0, dSV_dT_1d, dSV_dS_1d, TKE_forcing, B_flux, absf, &
                          u_star, u_star_mean, dt, MLD_io, Kd, mixvel, mixlen, GV, &
@@ -450,7 +450,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
         CS%diag_TKE_conv_decay(i,j) = CS%diag_TKE_conv_decay(i,j) + eCD%dTKE_conv_decay
        ! CS%diag_TKE_unbalanced(i,j) = CS%diag_TKE_unbalanced(i,j) + eCD%dTKE_unbalanced
       endif
-      ! Write to 3-D for outputing Mixing length and velocity scale.
+      ! Write to 3-D for outputting Mixing length and velocity scale.
       if (CS%id_Mixing_Length>0) then ; do k=1,nz
         CS%Mixing_Length(i,j,k) = mixlen(k)
       enddo ; endif
@@ -488,10 +488,11 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
   if (CS%id_LA > 0)       call post_data(CS%id_LA, CS%LA, CS%diag)
   if (CS%id_LA_MOD > 0)   call post_data(CS%id_LA_MOD, CS%LA_MOD, CS%diag)
   if (CS%id_MSTAR_LT > 0) call post_data(CS%id_MSTAR_LT, CS%MSTAR_LT, CS%diag)
-  if  (stoch_CS%pert_epbl) then
+  if (stoch_CS%pert_epbl) then
     if (stoch_CS%id_epbl1_wts > 0) call post_data(stoch_CS%id_epbl1_wts, stoch_CS%epbl1_wts, CS%diag)
     if (stoch_CS%id_epbl2_wts > 0) call post_data(stoch_CS%id_epbl2_wts, stoch_CS%epbl2_wts, CS%diag)
   endif
+
 end subroutine energetic_PBL
 
 
@@ -500,7 +501,7 @@ end subroutine energetic_PBL
 !!  mixed layer model for a single column of water.
 subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, absf, &
                        u_star, u_star_mean, dt, MLD_io, Kd, mixvel, mixlen, GV, US, CS, eCD, &
-                       Waves, G, i, j, epbl1_wt, epbl2_wt)
+                       Waves, G, i, j, TKE_gen_stoch, TKE_diss_stoch)
   type(verticalGrid_type), intent(in)    :: GV     !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   real, dimension(SZK_(GV)), intent(in)  :: h      !< Layer thicknesses [H ~> m or kg m-2].
@@ -535,12 +536,12 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
                                                    !! [Z T-1 ~> m s-1].
   real, dimension(SZK_(GV)+1), &
                            intent(out)   :: mixlen !< The mixing length scale used in Kd [Z ~> m].
-  type(energetic_PBL_CS),  intent(inout) :: CS     !< Energetic PBL control struct
+  type(energetic_PBL_CS),  intent(inout) :: CS     !< Energetic PBL control structure
   type(ePBL_column_diags), intent(inout) :: eCD    !< A container for passing around diagnostics.
   type(wave_parameters_CS), pointer      :: Waves  !< Waves control structure for Langmuir turbulence
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure.
-  real,          optional, intent(in)    :: epbl1_wt !< random number to perturb KE generation
-  real,          optional, intent(in)    :: epbl2_wt !< random number to perturb KE dissipation
+  real,          optional, intent(in)    :: TKE_gen_stoch  !< random factor used to perturb TKE generation [nondim]
+  real,          optional, intent(in)    :: TKE_diss_stoch !< random factor used to perturb TKE dissipation [nondim]
   integer,                 intent(in)    :: i      !< The i-index to work on (used for Waves)
   integer,                 intent(in)    :: j      !< The i-index to work on (used for Waves)
 
@@ -610,7 +611,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
                     ! mixing effects with other yet lower layers [ppt H ~> ppt m or ppt kg m-2].
   real, dimension(SZK_(GV)+1) :: &
     MixLen_shape, & ! A nondimensional shape factor for the mixing length that
-                    ! gives it an appropriate assymptotic value at the bottom of
+                    ! gives it an appropriate asymptotic value at the bottom of
                     ! the boundary layer.
     Kddt_h          ! The diapycnal diffusivity times a timestep divided by the
                     ! average thicknesses around a layer [H ~> m or kg m-2].
@@ -691,7 +692,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
   real :: dKddt_h_Newt ! The change between guesses at Kddt_h(K) with Newton's method [H ~> m or kg m-2].
   real :: Kddt_h_newt  ! The Newton's method next guess for Kddt_h(K) [H ~> m or kg m-2].
   real :: exp_kh    ! The nondimensional decay of TKE across a layer [nondim].
-  real :: vstar_unit_scale ! A unit converion factor for turbulent velocities [Z T-1 s m-1 ~> 1]
+  real :: vstar_unit_scale ! A unit conversion factor for turbulent velocities [Z T-1 s m-1 ~> 1]
   logical :: use_Newt  ! Use Newton's method for the next guess at Kddt_h(K).
   logical :: convectively_stable ! If true the water column is convectively stable at this interface.
   logical :: sfc_connected   ! If true the ocean is actively turbulent from the present
@@ -830,8 +831,8 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
       else
         mech_TKE = MSTAR_total * (dt*GV%Rho0* u_star**3)
       endif
-      ! stochastically pertrub mech_TKE in the UFS
-      if (present(epbl1_wt)) mech_TKE=mech_TKE*epbl1_wt
+      ! stochastically perturb mech_TKE in the UFS
+      if (present(TKE_gen_stoch)) mech_TKE = mech_TKE*TKE_gen_stoch
 
       if (CS%TKE_diagnostics) then
         eCD%dTKE_conv = 0.0 ; eCD%dTKE_mixing = 0.0
@@ -914,8 +915,8 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
         if (Idecay_len_TKE > 0.0) exp_kh = exp(-h(k-1)*Idecay_len_TKE)
         if (CS%TKE_diagnostics) &
           eCD%dTKE_mech_decay = eCD%dTKE_mech_decay + (exp_kh-1.0) * mech_TKE * I_dtdiag
-        if (present(epbl2_wt)) then ! perturb the TKE destruction
-          mech_TKE = mech_TKE * (1.0 + (exp_kh-1.0) * epbl2_wt)
+        if (present(TKE_diss_stoch)) then ! perturb the TKE destruction
+          mech_TKE = mech_TKE * (1.0 + (exp_kh-1.0) * TKE_diss_stoch)
         else
           mech_TKE = mech_TKE * exp_kh
         endif
@@ -989,7 +990,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
         ! mixing at higher interfaces.  It is an approximation to the more
         ! complete test dPEc_dKd_Kd0 >= 0.0, that would include the effects of
         ! mixing across interface K-1.  The dT_to_dColHt here are effectively
-        ! mass-weigted estimates of dSV_dT.
+        ! mass-weighted estimates of dSV_dT.
         Convectively_stable = ( 0.0 <= &
              ( (dT_to_dColHt(k) + dT_to_dColHt(k-1) ) * (T0(k-1)-T0(k)) + &
                (dS_to_dColHt(k) + dS_to_dColHt(k-1) ) * (S0(k-1)-S0(k)) ) )
@@ -1426,7 +1427,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
 end subroutine ePBL_column
 
 !> This subroutine calculates the change in potential energy and or derivatives
-!! for several changes in an interfaces's diapycnal diffusivity times a timestep.
+!! for several changes in an interface's diapycnal diffusivity times a timestep.
 subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
                        dT_to_dPE_a, dS_to_dPE_a, dT_to_dPE_b, dS_to_dPE_b, &
                        pres_Z, dT_to_dColHt_a, dS_to_dColHt_a, dT_to_dColHt_b, dS_to_dColHt_b, &
@@ -1452,7 +1453,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
                                 !! above, including implicit mixing effects with other
                                 !! yet higher layers [degC H ~> degC m or degC kg m-2].
   real, intent(in)  :: Th_b     !< An effective temperature times a thickness in the layer
-                                !! below, including implicit mixfing effects with other
+                                !! below, including implicit mixing effects with other
                                 !! yet lower layers [degC H ~> degC m or degC kg m-2].
   real, intent(in)  :: Sh_b     !< An effective salinity times a thickness in the layer
                                 !! below, including implicit mixing effects with other
@@ -1498,7 +1499,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
   real, optional, intent(out) :: dPEc_dKd !< The partial derivative of PE_chg with Kddt_h
                                           !! [R Z3 T-2 H-1 ~> J m-3 or J kg-1].
   real, optional, intent(out) :: dPE_max  !< The maximum change in column potential energy that could
-                                          !! be realizedd by applying a huge value of Kddt_h at the
+                                          !! be realized by applying a huge value of Kddt_h at the
                                           !! present interface [R Z3 T-2 ~> J m-2].
   real, optional, intent(out) :: dPEc_dKd_0 !< The partial derivative of PE_chg with Kddt_h in the
                                             !! limit where Kddt_h = 0 [R Z3 T-2 H-1 ~> J m-3 or J kg-1].
@@ -1521,7 +1522,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
   !   The expression for the change in potential energy used here is derived
   ! from the expression for the final estimates of the changes in temperature
   ! and salinities, and then extensively manipulated to get it into its most
-  ! succint form. The derivation is not necessarily obvious, but it demonstrably
+  ! succinct form. The derivation is not necessarily obvious, but it demonstrably
   ! works by comparison with separate calculations of the energy changes after
   ! the tridiagonal solver for the final changes in temperature and salinity are
   ! applied.
@@ -1571,7 +1572,7 @@ subroutine find_PE_chg(Kddt_h0, dKddt_h, hp_a, hp_b, Th_a, Sh_a, Th_b, Sh_b, &
 end subroutine find_PE_chg
 
 !> This subroutine calculates the change in potential energy and or derivatives
-!! for several changes in an interfaces's diapycnal diffusivity times a timestep
+!! for several changes in an interface's diapycnal diffusivity times a timestep
 !! using the original form used in the first version of ePBL.
 subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
                        dT_km1_t2, dS_km1_t2, dT_to_dPE_k, dS_to_dPE_k, &
@@ -1635,7 +1636,7 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
   real, optional, intent(out) :: dPEc_dKd !< The partial derivative of PE_chg with Kddt_h
                                           !! [R Z3 T-2 H-1 ~> J m-3 or J kg-1].
   real, optional, intent(out) :: dPE_max  !< The maximum change in column potential energy that could
-                                          !! be realizedd by applying a huge value of Kddt_h at the
+                                          !! be realized by applying a huge value of Kddt_h at the
                                           !! present interface [R Z3 T-2 ~> J m-2].
   real, optional, intent(out) :: dPEc_dKd_0 !< The partial derivative of PE_chg with Kddt_h in the
                                           !! limit where Kddt_h = 0 [R Z3 T-2 H-1 ~> J m-3 or J kg-1].
@@ -1734,10 +1735,10 @@ subroutine find_mstar(CS, US, Buoyancy_Flux, UStar, UStar_Mean,&
   type(unit_scale_type), intent(in)  :: US    !< A dimensional unit scaling type
   real,                  intent(in)  :: UStar !< ustar w/ gustiness [Z T-1 ~> m s-1]
   real,                  intent(in)  :: UStar_Mean !< ustar w/o gustiness [Z T-1 ~> m s-1]
-  real,                  intent(in)  :: Abs_Coriolis !< abolute value of the Coriolis parameter [T-1 ~> s-1]
+  real,                  intent(in)  :: Abs_Coriolis !< absolute value of the Coriolis parameter [T-1 ~> s-1]
   real,                  intent(in)  :: Buoyancy_Flux !< Buoyancy flux [Z2 T-3 ~> m2 s-3]
   real,                  intent(in)  :: BLD   !< boundary layer depth [Z ~> m]
-  real,                  intent(out) :: Mstar !< Ouput mstar (Mixing/ustar**3) [nondim]
+  real,                  intent(out) :: Mstar !< Output mstar (Mixing/ustar**3) [nondim]
   real,        optional, intent(in)  :: Langmuir_Number !< Langmuir number [nondim]
   real,        optional, intent(out) :: MStar_LT !< Mstar increase due to Langmuir turbulence [nondim]
   real,        optional, intent(out) :: Convect_Langmuir_number !< Langmuir number including buoyancy flux [nondim]
@@ -1902,7 +1903,7 @@ end subroutine Mstar_Langmuir
 
 !> Copies the ePBL active mixed layer depth into MLD, in units of [Z ~> m] unless other units are specified.
 subroutine energetic_PBL_get_MLD(CS, MLD, G, US, m_to_MLD_units)
-  type(energetic_PBL_CS),           intent(in)  :: CS  !< Energetic PBL control struct
+  type(energetic_PBL_CS),           intent(in)  :: CS  !< Energetic PBL control structure
   type(ocean_grid_type),            intent(in)  :: G   !< Grid structure
   type(unit_scale_type),            intent(in)  :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G)), intent(out) :: MLD !< Depth of ePBL active mixing layer [Z ~> m] or other units
@@ -1929,7 +1930,7 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
   type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic output
-  type(energetic_PBL_CS),  intent(inout) :: CS   !< Energetic PBL control struct
+  type(energetic_PBL_CS),  intent(inout) :: CS   !< Energetic PBL control structure
 
   ! Local variables
   ! This include declares and sets the variable "version".
@@ -2366,7 +2367,7 @@ end subroutine energetic_PBL_init
 
 !> Clean up and deallocate memory associated with the energetic_PBL module.
 subroutine energetic_PBL_end(CS)
-  type(energetic_PBL_CS), intent(inout) :: CS !< Energetic_PBL control struct
+  type(energetic_PBL_CS), intent(inout) :: CS !< Energetic_PBL control structure
 
   character(len=256) :: mesg
   real :: avg_its


### PR DESCRIPTION
  This PR is a series of commits that will bring the code in three of the
config_src/external directories into closer alignment with the MOM6 style guide
at https://github.com/mom-ocean/MOM6/wiki/Code-style-guide.  There are also some
stochastics-related code changes in two parameterization/vertical files.  All
answers are bitwise identical, but there are some minor changes to interfaces.

The commits in this PR include:
- NOAA-GFDL/MOM6@e5175bfd1 Style compliance in external/ODA_hooks code
- NOAA-GFDL/MOM6@f72b143b2 +Style compliance in external/drifters code
- NOAA-GFDL/MOM6@c1c3fa786 +Revised stochastics code for style compliance
