### PR TITLE
Impose standard indentation in most driver code

### DIFF
--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -1001,7 +1001,7 @@ subroutine Ocean_stock_pe(OS, index, value, time_index)
     case (ISTOCK_HEAT)  ! Return the heat content of the ocean in J.
       call get_ocean_stocks(OS%MOM_CSp, heat=value, on_PE_only=.true.)
     case (ISTOCK_SALT)  ! Return the mass of the salt in the ocean in kg.
-       call get_ocean_stocks(OS%MOM_CSp, salt=value, on_PE_only=.true.)
+      call get_ocean_stocks(OS%MOM_CSp, salt=value, on_PE_only=.true.)
     case default ; value = 0.0
   end select
   ! If the FMS coupler is changed so that Ocean_stock_PE is only called on

--- a/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
+++ b/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
@@ -689,34 +689,34 @@ subroutine ocean_model_restart(OS, timestamp, restartname)
       "restart files can only be created after the buoyancy forcing is applied.")
 
   if (present(restartname)) then
-     call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
+    call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
           OS%restart_CSp, GV=OS%GV, filename=restartname)
-     call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
+    call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
           OS%dirs%restart_output_dir) ! Is this needed?
-     if (OS%use_ice_shelf) then
-        call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, &
+    if (OS%use_ice_shelf) then
+      call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, &
              OS%dirs%restart_output_dir)
-     endif
+    endif
   else
-     if (BTEST(OS%Restart_control,1)) then
-        call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-             OS%restart_CSp, .true., GV=OS%GV)
-        call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
-             OS%dirs%restart_output_dir, .true.)
-        if (OS%use_ice_shelf) then
-           call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir, .true.)
-        endif
-     endif
-     if (BTEST(OS%Restart_control,0)) then
-        call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-             OS%restart_CSp, GV=OS%GV)
-        call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
-             OS%dirs%restart_output_dir)
-        if (OS%use_ice_shelf) then
-           call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir)
-        endif
-     endif
-  end if
+    if (BTEST(OS%Restart_control,1)) then
+      call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
+           OS%restart_CSp, .true., GV=OS%GV)
+      call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
+           OS%dirs%restart_output_dir, .true.)
+      if (OS%use_ice_shelf) then
+        call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir, .true.)
+      endif
+    endif
+    if (BTEST(OS%Restart_control,0)) then
+      call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
+           OS%restart_CSp, GV=OS%GV)
+      call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
+           OS%dirs%restart_output_dir)
+      if (OS%use_ice_shelf) then
+        call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir)
+      endif
+    endif
+  endif
 
 end subroutine ocean_model_restart
 ! </SUBROUTINE> NAME="ocean_model_restart"
@@ -1033,7 +1033,7 @@ subroutine Ocean_stock_pe(OS, index, value, time_index)
     case (ISTOCK_HEAT)  ! Return the heat content of the ocean in J.
       call get_ocean_stocks(OS%MOM_CSp, heat=value, on_PE_only=.true.)
     case (ISTOCK_SALT)  ! Return the mass of the salt in the ocean in kg.
-       call get_ocean_stocks(OS%MOM_CSp, salt=value, on_PE_only=.true.)
+      call get_ocean_stocks(OS%MOM_CSp, salt=value, on_PE_only=.true.)
     case default ; value = 0.0
   end select
   ! If the FMS coupler is changed so that Ocean_stock_PE is only called on

--- a/config_src/drivers/mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/mct_cap/mom_surface_forcing_mct.F90
@@ -289,9 +289,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     call safe_alloc_ptr(fluxes%p_surf,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%p_surf_full,isd,ied,jsd,jed)
     if (CS%use_limited_P_SSH) then
-       fluxes%p_surf_SSH => fluxes%p_surf
+      fluxes%p_surf_SSH => fluxes%p_surf
     else
-       fluxes%p_surf_SSH => fluxes%p_surf_full
+      fluxes%p_surf_SSH => fluxes%p_surf_full
     endif
 
     call safe_alloc_ptr(fluxes%salt_flux,isd,ied,jsd,jed)
@@ -309,7 +309,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     do j=js-2,je+2 ; do i=is-2,ie+2
       fluxes%TKE_tidal(i,j)   = CS%TKE_tidal(i,j)
       fluxes%ustar_tidal(i,j) = CS%ustar_tidal(i,j)
-    enddo; enddo
+    enddo ; enddo
 
     if (restore_temp) call safe_alloc_ptr(fluxes%heat_added,isd,ied,jsd,jed)
 
@@ -333,7 +333,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   if (CS%area_surf < 0.0) then
     do j=js,je ; do i=is,ie
       work_sum(i,j) = US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j)
-    enddo; enddo
+    enddo ; enddo
     CS%area_surf = reproducing_sum(work_sum, isr, ier, jsr, jer)
   endif    ! endif for allocation and initialization
 
@@ -350,7 +350,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   do j=js,je ; do i=is,ie
     fluxes%salt_flux(i,j) = 0.0
     fluxes%vprec(i,j) = 0.0
-  enddo; enddo
+  enddo ; enddo
 
   ! Salinity restoring logic
   if (restore_salinity) then
@@ -360,7 +360,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     if (CS%mask_srestore_under_ice) then ! Do not restore under sea-ice
       do j=js,je ; do i=is,ie
         if (sfc_state%SST(i,j) <= -0.0539*sfc_state%SSS(i,j)) open_ocn_mask(i,j)=0.0
-      enddo; enddo
+      enddo ; enddo
     endif
     if (CS%salt_restore_as_sflux) then
       do j=js,je ; do i=is,ie
@@ -368,7 +368,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
         delta_sss = sign(1.0,delta_sss)*min(abs(delta_sss),CS%max_delta_srestore)
         fluxes%salt_flux(i,j) = 1.e-3*G%mask2dT(i,j) * (CS%Rho0*CS%Flux_const)* &
              (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j)) *delta_sss  ! R Z T-1 ~> kg Salt m-2 s-1
-      enddo; enddo
+      enddo ; enddo
       if (CS%adjust_net_srestore_to_zero) then
         if (CS%adjust_net_srestore_by_scaling) then
           call adjust_area_mean_to_zero(fluxes%salt_flux, G, fluxes%saltFluxGlobalScl, &
@@ -391,7 +391,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
                (CS%Rho0*CS%Flux_const) * &
                delta_sss / (0.5*(sfc_state%SSS(i,j) + data_restore(i,j)))
         endif
-      enddo; enddo
+      enddo ; enddo
       if (CS%adjust_net_srestore_to_zero) then
         if (CS%adjust_net_srestore_by_scaling) then
           call adjust_area_mean_to_zero(fluxes%vprec, G, fluxes%vPrecGlobalScl, &
@@ -403,7 +403,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
           fluxes%vPrecGlobalAdj = reproducing_sum(work_sum(:,:), isr, ier, jsr, jer) / CS%area_surf
           do j=js,je ; do i=is,ie
             fluxes%vprec(i,j) = ( fluxes%vprec(i,j) - kg_m2_s_conversion*fluxes%vPrecGlobalAdj ) * G%mask2dT(i,j)
-          enddo; enddo
+          enddo ; enddo
         endif
       endif
     endif
@@ -417,7 +417,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       delta_sst = sign(1.0,delta_sst)*min(abs(delta_sst),CS%max_delta_trestore)
       fluxes%heat_added(i,j) = G%mask2dT(i,j) * CS%trestore_mask(i,j) * &
                       (CS%Rho0*fluxes%C_p) * delta_sst * CS%Flux_const   ! W m-2
-    enddo; enddo
+    enddo ; enddo
   endif
 
   ! obtain fluxes from IOB; note the staggering of indices
@@ -437,26 +437,26 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
     ! liquid runoff flux
     if (associated(IOB%rofl_flux)) then
-       fluxes%lrunoff(i,j) = kg_m2_s_conversion * IOB%rofl_flux(i-i0,j-j0) * G%mask2dT(i,j)
+      fluxes%lrunoff(i,j) = kg_m2_s_conversion * IOB%rofl_flux(i-i0,j-j0) * G%mask2dT(i,j)
     else if (associated(IOB%runoff)) then
-       fluxes%lrunoff(i,j) = kg_m2_s_conversion * IOB%runoff(i-i0,j-j0) * G%mask2dT(i,j)
+      fluxes%lrunoff(i,j) = kg_m2_s_conversion * IOB%runoff(i-i0,j-j0) * G%mask2dT(i,j)
     end if
 
     ! ice runoff flux
     if (associated(IOB%rofi_flux)) then
-       fluxes%frunoff(i,j) = kg_m2_s_conversion * IOB%rofi_flux(i-i0,j-j0) * G%mask2dT(i,j)
+      fluxes%frunoff(i,j) = kg_m2_s_conversion * IOB%rofi_flux(i-i0,j-j0) * G%mask2dT(i,j)
     else if (associated(IOB%calving)) then
-       fluxes%frunoff(i,j) = kg_m2_s_conversion * IOB%calving(i-i0,j-j0) * G%mask2dT(i,j)
+      fluxes%frunoff(i,j) = kg_m2_s_conversion * IOB%calving(i-i0,j-j0) * G%mask2dT(i,j)
     end if
 
     if (associated(IOB%ustar_berg)) &
-         fluxes%ustar_berg(i,j) = US%m_to_Z * IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)
+      fluxes%ustar_berg(i,j) = US%m_to_Z * IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)
 
     if (associated(IOB%area_berg)) &
-         fluxes%area_berg(i,j) = IOB%area_berg(i-i0,j-j0) * G%mask2dT(i,j)
+      fluxes%area_berg(i,j) = IOB%area_berg(i-i0,j-j0) * G%mask2dT(i,j)
 
     if (associated(IOB%mass_berg)) &
-         fluxes%mass_berg(i,j) = US%m_to_Z*US%kg_m3_to_R * IOB%mass_berg(i-i0,j-j0) * G%mask2dT(i,j)
+      fluxes%mass_berg(i,j) = US%m_to_Z*US%kg_m3_to_R * IOB%mass_berg(i-i0,j-j0) * G%mask2dT(i,j)
 
     ! GMM, cime does not not have an equivalent for heat_content_lrunoff and
     ! heat_content_frunoff. I am setting these to zero for now.
@@ -478,7 +478,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
     ! sea ice and snow melt heat flux [W/m2]
     if (associated(IOB%seaice_melt_heat)) &
-         fluxes%seaice_melt_heat(i,j) = G%mask2dT(i,j) * US%W_m2_to_QRZ_T * IOB%seaice_melt_heat(i-i0,j-j0)
+      fluxes%seaice_melt_heat(i,j) = G%mask2dT(i,j) * US%W_m2_to_QRZ_T * IOB%seaice_melt_heat(i-i0,j-j0)
 
     ! water flux due to sea ice and snow melt [kg/m2/s]
     if (associated(IOB%seaice_melt)) &
@@ -522,22 +522,22 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     fluxes%sw(i,j) = fluxes%sw_vis_dir(i,j) + fluxes%sw_vis_dif(i,j) + &
                      fluxes%sw_nir_dir(i,j) + fluxes%sw_nir_dif(i,j)
 
-  enddo; enddo
+  enddo ; enddo
 
   ! applied surface pressure from atmosphere and cryosphere
   if (associated(IOB%p)) then
-     if (CS%max_p_surf >= 0.0) then
-        do j=js,je ; do i=is,ie
-           fluxes%p_surf_full(i,j) = G%mask2dT(i,j) * US%kg_m3_to_R*US%m_s_to_L_T**2*IOB%p(i-i0,j-j0)
-           fluxes%p_surf(i,j) = MIN(fluxes%p_surf_full(i,j),CS%max_p_surf)
-        enddo; enddo
-     else
-        do j=js,je ; do i=is,ie
-           fluxes%p_surf_full(i,j) = G%mask2dT(i,j) * US%kg_m3_to_R*US%m_s_to_L_T**2*IOB%p(i-i0,j-j0)
-           fluxes%p_surf(i,j) = fluxes%p_surf_full(i,j)
-        enddo; enddo
-     endif
-     fluxes%accumulate_p_surf = .true. ! Multiple components may contribute to surface pressure.
+    if (CS%max_p_surf >= 0.0) then
+      do j=js,je ; do i=is,ie
+        fluxes%p_surf_full(i,j) = G%mask2dT(i,j) * US%kg_m3_to_R*US%m_s_to_L_T**2*IOB%p(i-i0,j-j0)
+        fluxes%p_surf(i,j) = MIN(fluxes%p_surf_full(i,j),CS%max_p_surf)
+      enddo ; enddo
+    else
+      do j=js,je ; do i=is,ie
+        fluxes%p_surf_full(i,j) = G%mask2dT(i,j) * US%kg_m3_to_R*US%m_s_to_L_T**2*IOB%p(i-i0,j-j0)
+        fluxes%p_surf(i,j) = fluxes%p_surf_full(i,j)
+      enddo ; enddo
+    endif
+    fluxes%accumulate_p_surf = .true. ! Multiple components may contribute to surface pressure.
   endif
 
   if (associated(IOB%salt_flux)) then
@@ -558,19 +558,19 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
           (fluxes%evap(i,j)    + fluxes%vprec(i,j)) ) * US%L_to_m**2*G%areaT(i,j)
 
       net_FW2(i,j) = net_FW(i,j) / (US%L_to_m**2*G%areaT(i,j))
-    enddo; enddo
+    enddo ; enddo
 
     if (CS%adjust_net_fresh_water_by_scaling) then
       call adjust_area_mean_to_zero(net_FW2, G, fluxes%netFWGlobalScl)
       do j=js,je ; do i=is,ie
         fluxes%vprec(i,j) = fluxes%vprec(i,j) + kg_m2_s_conversion * &
             (net_FW2(i,j) - net_FW(i,j)/(US%L_to_m**2*G%areaT(i,j))) * G%mask2dT(i,j)
-      enddo; enddo
+      enddo ; enddo
     else
       fluxes%netFWGlobalAdj = reproducing_sum(net_FW(:,:), isr, ier, jsr, jer) / CS%area_surf
       do j=js,je ; do i=is,ie
         fluxes%vprec(i,j) = ( fluxes%vprec(i,j) - kg_m2_s_conversion * fluxes%netFWGlobalAdj ) * G%mask2dT(i,j)
-      enddo; enddo
+      enddo ; enddo
     endif
   endif
 
@@ -680,9 +680,9 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
 
   !applied surface pressure from atmosphere and cryosphere
   if (CS%use_limited_P_SSH) then
-     forces%p_surf_SSH => forces%p_surf
+    forces%p_surf_SSH => forces%p_surf
   else
-     forces%p_surf_SSH => forces%p_surf_full
+    forces%p_surf_SSH => forces%p_surf_full
   endif
   if (associated(IOB%p)) then
     if (CS%max_p_surf >= 0.0) then
@@ -752,7 +752,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
         forces%taux(I,j) = (G%mask2dBu(I,J)*taux_at_q(I,J) + &
                             G%mask2dBu(I,J-1)*taux_at_q(I,J-1)) / &
                            (G%mask2dBu(I,J) + G%mask2dBu(I,J-1))
-    enddo; enddo
+    enddo ; enddo
 
     do J=Jsq,Jeq ; do i=is,ie
       forces%tauy(i,J) = 0.0
@@ -760,7 +760,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
         forces%tauy(i,J) = (G%mask2dBu(I,J)*tauy_at_q(I,J) + &
                             G%mask2dBu(I-1,J)*tauy_at_q(I-1,J)) / &
                            (G%mask2dBu(I,J) + G%mask2dBu(I-1,J))
-    enddo; enddo
+    enddo ; enddo
 
     ! ustar is required for the bulk mixed layer formulation. The background value
     ! of 0.02 Pa is a relatively small value intended to give reasonable behavior
@@ -778,7 +778,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
         if (CS%read_gust_2d) gustiness = CS%gust(i,j)
       endif
       forces%ustar(i,j) = sqrt(gustiness*Irho0 + Irho0*tau_mag)
-    enddo; enddo
+    enddo ; enddo
 
   elseif (wind_stagger == AGRID) then
     call pass_vector(taux_at_h, tauy_at_h, G%Domain, To_All+Omit_Corners, stagger=AGRID, halo=1)
@@ -789,7 +789,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
         forces%taux(I,j) = (G%mask2dT(i,j)*taux_at_h(i,j) + &
                             G%mask2dT(i+1,j)*taux_at_h(i+1,j)) / &
                            (G%mask2dT(i,j) + G%mask2dT(i+1,j))
-    enddo; enddo
+    enddo ; enddo
 
     do J=Jsq,Jeq ; do i=is,ie
       forces%tauy(i,J) = 0.0
@@ -797,14 +797,14 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
         forces%tauy(i,J) = (G%mask2dT(i,j)*tauy_at_h(i,j) + &
                             G%mask2dT(i,J+1)*tauy_at_h(i,j+1)) / &
                            (G%mask2dT(i,j) + G%mask2dT(i,j+1))
-    enddo; enddo
+    enddo ; enddo
 
     do j=js,je ; do i=is,ie
       gustiness = CS%gust_const
       if (CS%read_gust_2d .and. (G%mask2dT(i,j) > 0.0)) gustiness = CS%gust(i,j)
       forces%ustar(i,j) = sqrt(gustiness*Irho0 + Irho0 * G%mask2dT(i,j) * &
                                sqrt(taux_at_h(i,j)**2 + tauy_at_h(i,j)**2))
-    enddo; enddo
+    enddo ; enddo
 
   else ! C-grid wind stresses.
     if (G%symmetric) &
@@ -827,7 +827,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
       else
         forces%ustar(i,j) = sqrt(CS%gust_const*Irho0 + Irho0*sqrt(taux2 + tauy2))
       endif
-    enddo; enddo
+    enddo ; enddo
 
   endif   ! endif for wind related fields
 

--- a/config_src/drivers/mct_cap/ocn_comp_mct.F90
+++ b/config_src/drivers/mct_cap/ocn_comp_mct.F90
@@ -404,10 +404,8 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
 
   if (debug .and. root_pe().eq.pe_here()) print *, "calling seq_infodata_putdata"
 
-  call seq_infodata_PutData( glb%infodata, &
-       ocn_nx = ni , ocn_ny = nj)
-  call seq_infodata_PutData( glb%infodata, &
-       ocn_prognostic=.true., ocnrof_prognostic=.true.)
+  call seq_infodata_PutData(glb%infodata, ocn_nx=ni, ocn_ny=nj)
+  call seq_infodata_PutData(glb%infodata, ocn_prognostic=.true., ocnrof_prognostic=.true.)
 
   if (debug .and. root_pe().eq.pe_here()) print *, "leaving ocean_init_mct"
 
@@ -754,15 +752,15 @@ character(32) function get_runtype()
 
   call seq_infodata_GetData( glb%infodata, start_type=starttype)
 
-    if (   trim(starttype) == trim(seq_infodata_start_type_start)) then
-     get_runtype = "initial"
+  if (   trim(starttype) == trim(seq_infodata_start_type_start)) then
+    get_runtype = "initial"
   else if (trim(starttype) == trim(seq_infodata_start_type_cont) ) then
-     get_runtype = "continue"
+    get_runtype = "continue"
   else if (trim(starttype) == trim(seq_infodata_start_type_brnch)) then
-     get_runtype = "branch"
+    get_runtype = "branch"
   else
-     write(stdout,*) 'ocn_comp_mct ERROR: unknown starttype'
-     call exit(0)
+    write(stdout,*) 'ocn_comp_mct ERROR: unknown starttype'
+    call exit(0)
   end if
   return
 

--- a/config_src/drivers/mct_cap/ocn_cpl_indices.F90
+++ b/config_src/drivers/mct_cap/ocn_cpl_indices.F90
@@ -172,11 +172,11 @@ contains
       ind%x2o_qsw_fracr_col(ncol)   = mct_avect_indexra(x2o,'Foxx_swnet_afracr')
 
       do ncat = 1, ice_ncat
-          write(cncat,'(i2.2)') ncat
-          ncol = ncat+1
-          ind%x2o_frac_col(ncol)      = mct_avect_indexra(x2o,'Si_ifrac_'//cncat)
-          ind%x2o_fracr_col(ncol)     = ind%x2o_frac_col(ncol)
-          ind%x2o_qsw_fracr_col(ncol) = mct_avect_indexra(x2o,'PFioi_swpen_ifrac_'//cncat)
+        write(cncat,'(i2.2)') ncat
+        ncol = ncat+1
+        ind%x2o_frac_col(ncol)      = mct_avect_indexra(x2o,'Si_ifrac_'//cncat)
+        ind%x2o_fracr_col(ncol)     = ind%x2o_frac_col(ncol)
+        ind%x2o_qsw_fracr_col(ncol) = mct_avect_indexra(x2o,'PFioi_swpen_ifrac_'//cncat)
       enddo
     else
       mcog_ncols = 1

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -184,7 +184,7 @@ program MOM_main
     restart_CSp => NULL()     !< A pointer to the restart control structure
                               !! that will be used for MOM restart files.
   type(diag_ctrl),           pointer :: &
-       diag => NULL()         !< A pointer to the diagnostic regulatory structure
+    diag => NULL()            !< A pointer to the diagnostic regulatory structure
   !-----------------------------------------------------------------------
 
   character(len=4), parameter :: vers_num = 'v2.0'

--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -298,7 +298,7 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
       call MOM_error(FATAL, &
        "MOM_surface_forcing: Variable winds defined with no wind config")
     else
-       call MOM_error(FATAL, &
+      call MOM_error(FATAL, &
        "MOM_surface_forcing:Unrecognized wind config "//trim(CS%wind_config))
     endif
   endif
@@ -338,7 +338,7 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
       call MOM_error(FATAL, &
        "MOM_surface_forcing: Variable buoy defined with no buoy config.")
     else
-       call MOM_error(FATAL, &
+      call MOM_error(FATAL, &
        "MOM_surface_forcing: Unrecognized buoy config "//trim(CS%buoy_config))
     endif
   endif


### PR DESCRIPTION
  Corrected unbalanced indentation levels and impose MOM6-standard 2-point
indentation in the config_src/driver codes, including both the FMS and mct caps
and the solo_driver.  The nuopc_cap is excluded from this commit because of the
huge number (over 1000) of lines there that use irregular indentation.  All
answers are bitwise identical, and only white space changes are included.