### PR TITLE
+Fix some rescaling issues smoked out by the regional Bering domain

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -17,7 +17,7 @@ use MOM_forcing_type, only : mech_forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_io, only : vardesc, var_desc, MOM_read_data, slasher
-use MOM_open_boundary, only : ocean_OBC_type, OBC_SIMPLE, OBC_NONE, open_boundary_query
+use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, open_boundary_query
 use MOM_open_boundary, only : OBC_DIRECTION_E, OBC_DIRECTION_W
 use MOM_open_boundary, only : OBC_DIRECTION_N, OBC_DIRECTION_S, OBC_segment_type
 use MOM_restart, only : register_restart_field, register_restart_pair
@@ -1245,13 +1245,13 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       if (Htot_avg*CS%dy_Cu(I,j) <= 0.0) then
         CS%IDatu(I,j) = 0.0
       elseif (integral_BT_cont) then
-        CS%IDatu(I,j) = CS%dy_Cu(I,j) / (max(find_duhbt_du(ubt(I,j)*dt, BTCL_u(I,j)), &
+        CS%IDatu(I,j) = GV%Z_to_H * CS%dy_Cu(I,j) / (max(find_duhbt_du(ubt(I,j)*dt, BTCL_u(I,j)), &
                                              CS%dy_Cu(I,j)*Htot_avg) )
       elseif (use_BT_cont) then ! Reconsider the max and whether there should be some scaling.
-        CS%IDatu(I,j) = CS%dy_Cu(I,j) / (max(find_duhbt_du(ubt(I,j), BTCL_u(I,j)), &
+        CS%IDatu(I,j) = GV%Z_to_H * CS%dy_Cu(I,j) / (max(find_duhbt_du(ubt(I,j), BTCL_u(I,j)), &
                                              CS%dy_Cu(I,j)*Htot_avg) )
       else
-        CS%IDatu(I,j) = 1.0 / Htot_avg
+        CS%IDatu(I,j) = GV%Z_to_H / Htot_avg
       endif
     endif
 
@@ -1271,13 +1271,13 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       if (Htot_avg*CS%dx_Cv(i,J) <= 0.0) then
         CS%IDatv(i,J) = 0.0
       elseif (integral_BT_cont) then
-        CS%IDatv(i,J) = CS%dx_Cv(i,J) / (max(find_dvhbt_dv(vbt(i,J)*dt, BTCL_v(i,J)), &
+        CS%IDatv(i,J) = GV%Z_to_H * CS%dx_Cv(i,J) / (max(find_dvhbt_dv(vbt(i,J)*dt, BTCL_v(i,J)), &
                                              CS%dx_Cv(i,J)*Htot_avg) )
       elseif (use_BT_cont) then ! Reconsider the max and whether there should be some scaling.
-        CS%IDatv(i,J) = CS%dx_Cv(i,J) / (max(find_dvhbt_dv(vbt(i,J), BTCL_v(i,J)), &
+        CS%IDatv(i,J) = GV%Z_to_H * CS%dx_Cv(i,J) / (max(find_dvhbt_dv(vbt(i,J), BTCL_v(i,J)), &
                                              CS%dx_Cv(i,J)*Htot_avg) )
       else
-        CS%IDatv(i,J) = 1.0 / Htot_avg
+        CS%IDatv(i,J) = GV%Z_to_H / Htot_avg
       endif
     endif
 

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -856,7 +856,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(fms_id,  Time, conversion, G, t
       do k=1,kd
         do j=js,je
           do i=is,ie
-            tr_z(i,j,k)=data_in(i,j,k)
+            tr_z(i,j,k)=data_in(i,j,k) * conversion
             if (.not. ans_2018) mask_z(i,j,k) = 1.
             if (abs(tr_z(i,j,k)-missing_value) < abs(roundoff*missing_value)) mask_z(i,j,k) = 0.
           enddo

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -20,7 +20,7 @@ use MOM_grid, only : ocean_grid_type, isPointInCell
 use MOM_interface_heights, only : find_eta
 use MOM_io, only : file_exists, field_size, MOM_read_data, MOM_read_vector, slasher
 use MOM_open_boundary, only : ocean_OBC_type, open_boundary_init, set_tracer_data
-use MOM_open_boundary, only : OBC_NONE, OBC_SIMPLE
+use MOM_open_boundary, only : OBC_NONE
 use MOM_open_boundary, only : open_boundary_query
 use MOM_open_boundary, only : set_tracer_data, initialize_segment_data
 use MOM_open_boundary, only : open_boundary_test_extern_h

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -143,7 +143,7 @@ contains
 
 !> This subroutine determines the number of points which are within sponges in this computational
 !! domain.  Only points that have positive values of Iresttime and which mask2dT indicates are ocean
-!! points are included in the sponges.  It also stores the target interface heights. This
+!! points are included in the sponges.  It also stores the target interface heights.
 subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h, nz_data, &
                                         Iresttime_u_in, Iresttime_v_in)
 
@@ -944,7 +944,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
     if (CS%time_varying_sponges) then
       nz_data = CS%Ref_val_u%nz_data
       ! Interpolate from the external horizontal grid and in time
-      call horiz_interp_and_extrap_tracer(CS%Ref_val_u%id, Time, 1.0, G, sp_val, mask_z, z_in, &
+      call horiz_interp_and_extrap_tracer(CS%Ref_val_u%id, Time, US%m_s_to_L_T, G, sp_val, mask_z, z_in, &
                                           z_edges_in, missing_value, CS%reentrant_x, CS%tripolar_N, .false., &
                                           spongeOnGrid=CS%SpongeDataOngrid, m_to_Z=US%m_to_Z,&
                                           answers_2018=CS%hor_regrid_answers_2018)
@@ -993,7 +993,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
       deallocate(sp_val, mask_u, mask_z, hsrc)
       nz_data = CS%Ref_val_v%nz_data
       ! Interpolate from the external horizontal grid and in time
-      call horiz_interp_and_extrap_tracer(CS%Ref_val_v%id, Time, 1.0, G, sp_val, mask_z, z_in, &
+      call horiz_interp_and_extrap_tracer(CS%Ref_val_v%id, Time, US%m_s_to_L_T, G, sp_val, mask_z, z_in, &
                                           z_edges_in, missing_value, CS%reentrant_x, CS%tripolar_N, .false., &
                                           spongeOnGrid=CS%SpongeDataOngrid, m_to_Z=US%m_to_Z,&
                                           answers_2018=CS%hor_regrid_answers_2018)

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -1075,7 +1075,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
             if (CS%wT_scheme==wT_from_cRoot_TKE) then
               vstar = CS%vstar_scale_fac * vstar_unit_scale * (I_dtrho*TKE_here)**C1_3
             elseif (CS%wT_scheme==wT_from_RH18) then
-              Surface_Scale = max(0.05, 1.0 - htot/MLD_guess)
+              Surface_Scale = max(0.05, 1.0 - htot * GV%H_to_Z / MLD_guess)
               vstar = CS%vstar_scale_fac * Surface_Scale * (CS%vstar_surf_fac*u_star + &
                         vstar_unit_scale * (CS%wstar_ustar_coef*conv_PErel*I_dtrho)**C1_3)
             endif
@@ -1124,7 +1124,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
                 if (CS%wT_scheme==wT_from_cRoot_TKE) then
                   vstar = CS%vstar_scale_fac * vstar_unit_scale * (I_dtrho*TKE_here)**C1_3
                 elseif (CS%wT_scheme==wT_from_RH18) then
-                  Surface_Scale = max(0.05, 1. - htot/MLD_guess)
+                  Surface_Scale = max(0.05, 1. - htot * GV%H_to_Z / MLD_guess)
                   vstar = CS%vstar_scale_fac * Surface_Scale * (CS%vstar_surf_fac*u_star + &
                                   vstar_unit_scale * (CS%wstar_ustar_coef*conv_PErel*I_dtrho)**C1_3)
                 endif

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -875,7 +875,7 @@ subroutine calculate_CVMix_tidal(h, j, N2_int, G, GV, US, CS, Kv, Kd_lay, Kd_int
       ! remap from input z coordinate to model coordinate:
       tidal_qe_md = 0.0
       call remapping_core_h(CS%remap_cs, size(CS%h_src), CS%h_src, CS%tidal_qe_3d_in(i,j,:), &
-                            GV%ke, h_m, tidal_qe_md)
+                            GV%ke, h_m, tidal_qe_md, GV%H_subroundoff, GV%H_subroundoff)
 
       ! form the Schmittner coefficient that is based on 3D q*E, which is formed from
       ! summing q_i*TidalConstituent_i over the number of constituents.

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -13,7 +13,7 @@ use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_forcing_type,  only : mech_forcing
 use MOM_get_input,     only : directories
 use MOM_grid,          only : ocean_grid_type
-use MOM_open_boundary, only : ocean_OBC_type, OBC_SIMPLE, OBC_NONE, OBC_DIRECTION_E
+use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_DIRECTION_E
 use MOM_open_boundary, only : OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_PointAccel,    only : write_u_accel, write_v_accel, PointAccel_init
 use MOM_PointAccel,    only : PointAccel_CS

--- a/src/tracer/MOM_lateral_boundary_diffusion.F90
+++ b/src/tracer/MOM_lateral_boundary_diffusion.F90
@@ -617,8 +617,10 @@ subroutine fluxes_layer_method(boundary, ke, hbl_L, hbl_R, h_L, h_R, phi_L, phi_
   allocate(F_layer_z(nk), source=0.0)
 
   ! remap tracer to dz_top
-  call remapping_core_h(CS%remap_cs, ke, h_L(:), phi_L(:), nk, dz_top(:), phi_L_z(:))
-  call remapping_core_h(CS%remap_cs, ke, h_R(:), phi_R(:), nk, dz_top(:), phi_R_z(:))
+  call remapping_core_h(CS%remap_cs, ke, h_L(:), phi_L(:), nk, dz_top(:), phi_L_z(:), &
+                        CS%H_subroundoff, CS%H_subroundoff)
+  call remapping_core_h(CS%remap_cs, ke, h_R(:), phi_R(:), nk, dz_top(:), phi_R_z(:), &
+                        CS%H_subroundoff, CS%H_subroundoff)
 
   ! Calculate vertical indices containing the boundary layer in dz_top
   call boundary_k_range(boundary, nk, dz_top, hbl_L, k_top_L, zeta_top_L, k_bot_L, zeta_bot_L)

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -10,7 +10,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
+use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE
 use MOM_open_boundary,   only : OBC_segment_type, register_segment_tracer
 use MOM_tracer_registry, only : tracer_registry_type, tracer_type
 use MOM_tracer_registry, only : tracer_name_lookup

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -8,7 +8,7 @@ use MOM_error_handler,   only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,     only : get_param, log_version, param_file_type
 use MOM_get_input,       only : directories
 use MOM_grid,            only : ocean_grid_type
-use MOM_open_boundary,   only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
+use MOM_open_boundary,   only : ocean_OBC_type, OBC_NONE
 use MOM_open_boundary,   only : OBC_segment_type, register_segment_tracer
 use MOM_open_boundary,   only : OBC_registry_type, register_OBC
 use MOM_time_manager,    only : time_type, time_type_to_real

--- a/src/user/dyed_obcs_initialization.F90
+++ b/src/user/dyed_obcs_initialization.F90
@@ -8,7 +8,7 @@ use MOM_error_handler,   only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,     only : get_param, log_version, param_file_type
 use MOM_get_input,       only : directories
 use MOM_grid,            only : ocean_grid_type
-use MOM_open_boundary,   only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
+use MOM_open_boundary,   only : ocean_OBC_type, OBC_NONE
 use MOM_open_boundary,   only : OBC_segment_type, register_segment_tracer
 use MOM_tracer_registry, only : tracer_registry_type, tracer_name_lookup
 use MOM_tracer_registry, only : tracer_type

--- a/src/user/supercritical_initialization.F90
+++ b/src/user/supercritical_initialization.F90
@@ -7,7 +7,7 @@ use MOM_dyn_horgrid,    only : dyn_horgrid_type
 use MOM_error_handler,  only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser,    only : get_param, log_version, param_file_type
 use MOM_grid,           only : ocean_grid_type
-use MOM_open_boundary,  only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE, OBC_segment_type
+use MOM_open_boundary,  only : ocean_OBC_type, OBC_NONE, OBC_segment_type
 use MOM_time_manager,   only : time_type, time_type_to_real
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -8,7 +8,7 @@ use MOM_dyn_horgrid, only : dyn_horgrid_type
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_SIMPLE
+use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE
 use MOM_open_boundary, only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N
 use MOM_open_boundary, only : OBC_DIRECTION_S
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS


### PR DESCRIPTION
  This PR is a duplicate of https://github.com/NOAA-GFDL/MOM6/pull/104, but is
being done on a branch so that it can be updated to reflect changes to dev/gfdl
without requiring a forced push to ESMG:dev/esmg.  This PR corrects a number of
dimensional rescaling and related issues that were identified with Kate's
regional Bering sea domain.

- Added unit conversion factors to some expressions setting the inverse of the
  total depth to change them from [H-1] to [Z-1] in MOM_barotropic

- Added a missing unit conversion factor in horiz_interp_and_extrap_tracer calls
  in MOM_ALE_sponge

- Eliminated the unused OBC function parse_segment_param_real and 4 other OBC
  encoding integers, and made other OBC functions publicly visible

- Do needed unit conversion on the output arrays returned from
  time_interp_external

- Converted htot (in H) to use the same unit scaling (Z) as MLD_guess in
  MOM_energetic_PBL

- Multiply by a tracer unit conversion factor in MOM_horizontal_regridding

- Added minimal cell and edge thickness arguments to calls to remapping_core_h
  in 5 files, along with run-time arguments to recreate existing solutions

- The unused OBC_SIMPLE module use statement were eliminated in 8 files

  The commits that are actually in this PR include:

- NOAA-GFDL/MOM6@ed850e24f Merge branch 'dev/esmg' of https://github.com/ESMG/MOM6 into Bering_domain_rescaling_fix
- NOAA-GFDL/MOM6@861a8f14d Use ODA_2018_ANSWERS to specify ODA remapping
- NOAA-GFDL/MOM6@b9697e220 Merge branch 'dev/gfdl' into dev/esmg
- NOAA-GFDL/MOM6@138396107 It would be good to initialize CS%answers_2018.
- NOAA-GFDL/MOM6@8d92579b2 Deleted an unused function, made public OBC funcs.
- NOAA-GFDL/MOM6@9c22ff272 Taking out some unused OBC constants.
- NOAA-GFDL/MOM6@3c7bd19ee More cleaning up for issue #54
- NOAA-GFDL/MOM6@4b218c07a Tweaks in response to Hallberg's comments.
- NOAA-GFDL/MOM6@7a2af6cb2 Merge branch 'dev/esmg' of github.com:ESMG/MOM6 into dev/esmg
- NOAA-GFDL/MOM6@57a1a8ae2 Rest of fix for issue #54.
- NOAA-GFDL/MOM6@41757c7a5 Fix the rebase
- NOAA-GFDL/MOM6@f50551ce4 Fix to Z_RESCALE bug in ePBL.
- NOAA-GFDL/MOM6@1e6924e03 More fixes for issue #54.
- NOAA-GFDL/MOM6@24f412d77 Part of the fix for issue #54.

The following are commits that were already in NOAA-GFDL/MOM6:dev/gfdl, but
because they were squashed or rebased, they are present with a different hash. 
They are being imported again to allow the various versions of MOM6 to be fully
synchronized.

These are commits that were on dev/esmg and dev/gfdl with different hashes:
- NOAA-GFDL/MOM6@6f48b9d1d Oops, more cleanup.
- NOAA-GFDL/MOM6@28003a8f7 Adding in that SAL commit again.
- NOAA-GFDL/MOM6@4a9162839 Undoing some patches from others
- NOAA-GFDL/MOM6@11fa11406 Done with EPBL docs?
- NOAA-GFDL/MOM6@918742bbb Working on boundary layer docs.
- NOAA-GFDL/MOM6@a180d3316 return a more accurate error message in MOM_stochasics
- NOAA-GFDL/MOM6@1428a36ac Several little things, one is making sponge less verbose.
- NOAA-GFDL/MOM6@aac6b75dd update to gfdl 20210806 (#74)
- NOAA-GFDL/MOM6@e853f839b additions for stochastic physics and ePBL perts
- NOAA-GFDL/MOM6@406bc59cd Merge remote-tracking branch 'alexandra/main' into dev/esmg
- NOAA-GFDL/MOM6@9c341f06e Merge remote-tracking branch 'gfdl/dev/gfdl' into dev/esmg
- NOAA-GFDL/MOM6@b4a67c1ad Merge remote-tracking branch 'gfdl/dev/gfdl' into dev/esmg
- NOAA-GFDL/MOM6@65b2c8249 Merge remote-tracking branch 'gfdl/dev/gfdl' into dev/esmg
- NOAA-GFDL/MOM6@ebb643af9 Oops, more cleanup.
- NOAA-GFDL/MOM6@65cccb7a0 correction on type in directory name
- NOAA-GFDL/MOM6@45d615191 Adding in that SAL commit again.
- NOAA-GFDL/MOM6@3dbf2f58d Undoing some patches from others
- NOAA-GFDL/MOM6@71908c8fd Done with EPBL docs?
- NOAA-GFDL/MOM6@b7b4141a6 Working on boundary layer docs.
- NOAA-GFDL/MOM6@348a81b63 Several little things, one is making sponge less verbose.

These commits have to do with the stochastics.  Because there are many little
commits, a number of which undo each other, they should have been squashed or
otherwise restructured before they were committed to dev/emc or dev/esmg, but
now that they are on one of the primary development branches, these commits
need to be on all of them.

- NOAA-GFDL/MOM6@1853352a6 correction on type in directory name
- NOAA-GFDL/MOM6@71f7354d9 add comments
- NOAA-GFDL/MOM6@8775c6d41 revert logic wrt increments
- NOAA-GFDL/MOM6@64e83b7aa add logic to remove incrments from restart if outside IAU window
- NOAA-GFDL/MOM6@3e573eb11 add write_stoch_restart_ocn to MOM_stochastics
- NOAA-GFDL/MOM6@8382652d5 doxygen cleanup
- NOAA-GFDL/MOM6@97bbdbf6f move stochastics to external directory
- NOAA-GFDL/MOM6@199126eb7 stochastic physics re-write
- NOAA-GFDL/MOM6@0932b9ec1 remove debug statements
- NOAA-GFDL/MOM6@ebe9d1f6f remove PE_here from mom_ocean_model_nuopc.F90
- NOAA-GFDL/MOM6@077413af9 clean up of mom_ocean_model_nuopc.F90
- NOAA-GFDL/MOM6@b12c09cbb revert MOM_domains.F90
- NOAA-GFDL/MOM6@80fdfb4e8 remove stochastics container
- NOAA-GFDL/MOM6@65e0e71bb clean up of code for MOM6 coding standards
- NOAA-GFDL/MOM6@121ce71b3 correct coupled_driver/ocean_model_MOM.F90 and other cleanup
- NOAA-GFDL/MOM6@045d5c2db make stochastics optional
- NOAA-GFDL/MOM6@f874d1113 clean up MOM_domains
- NOAA-GFDL/MOM6@390fee8d0 re-write of stochastic code to remove CPP directives
- NOAA-GFDL/MOM6@48354da37 fix non stochastic ePBL calculation
- NOAA-GFDL/MOM6@583c6ae1e clean up code
- NOAA-GFDL/MOM6@878543d22 clean up debug statements
- NOAA-GFDL/MOM6@095c36ca4 additions for stochy restarts
- NOAA-GFDL/MOM6@6ff36ec6d add stochy_restart writing to mom_cap
- NOAA-GFDL/MOM6@cefdb81ed Update MOM_diabatic_driver.F90
- NOAA-GFDL/MOM6@2f5d83d3c Update MOM_diabatic_driver.F90
- NOAA-GFDL/MOM6@b6ac287b6 Update MOM_diabatic_driver.F90
- NOAA-GFDL/MOM6@45acf37f1 cleanup of code and enhancement of ePBL perts
- NOAA-GFDL/MOM6@c3ff425ce return a more accurate error message in MOM_stochasics
- NOAA-GFDL/MOM6@9221b5d50 update to gfdl 20210806 (#74)
- NOAA-GFDL/MOM6@59e733f3e add comments
- NOAA-GFDL/MOM6@15e402940 revert logic wrt increments
- NOAA-GFDL/MOM6@78b8d7919 add logic to remove incrments from restart if outside IAU window
- NOAA-GFDL/MOM6@a5d90655d add write_stoch_restart_ocn to MOM_stochastics
- NOAA-GFDL/MOM6@e91c96609 doxygen cleanup
- NOAA-GFDL/MOM6@cf1d29628 move stochastics to external directory
- NOAA-GFDL/MOM6@493717a35 stochastic physics re-write
- NOAA-GFDL/MOM6@a67bc78a2 remove debug statements
- NOAA-GFDL/MOM6@e2431bc81 remove PE_here from mom_ocean_model_nuopc.F90
- NOAA-GFDL/MOM6@ea36db238 clean up of mom_ocean_model_nuopc.F90
- NOAA-GFDL/MOM6@4c931094f revert MOM_domains.F90
- NOAA-GFDL/MOM6@c7531a75f remove stochastics container
- NOAA-GFDL/MOM6@08dc1a44b clean up of code for MOM6 coding standards
- NOAA-GFDL/MOM6@e80d5f57e correct coupled_driver/ocean_model_MOM.F90 and other cleanup
- NOAA-GFDL/MOM6@0bf4ff0a1 make stochastics optional
- NOAA-GFDL/MOM6@9e7029ca8 clean up MOM_domains
- NOAA-GFDL/MOM6@58f1fe98f re-write of stochastic code to remove CPP directives
- NOAA-GFDL/MOM6@15dde3622 fix non stochastic ePBL calculation
- NOAA-GFDL/MOM6@49111ff9f clean up code
- NOAA-GFDL/MOM6@0c48bfc6a clean up debug statements
- NOAA-GFDL/MOM6@becb4420e additions for stochy restarts
- NOAA-GFDL/MOM6@36ce2d108 add stochy_restart writing to mom_cap
- NOAA-GFDL/MOM6@5f6973b4d Update MOM_diabatic_driver.F90
- NOAA-GFDL/MOM6@c48a46ae0 Update MOM_diabatic_driver.F90
- NOAA-GFDL/MOM6@a0e5b56af Update MOM_diabatic_driver.F90
- NOAA-GFDL/MOM6@a534541c5 cleanup of code and enhancement of ePBL perts
- NOAA-GFDL/MOM6@0add693a8 additions for stochastic physics and ePBL perts
