### PR TITLE
+Revise equation of state interfaces for consistency

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -15,8 +15,6 @@ use MOM_diag_mediator,    only : register_diag_field, post_data, diag_ctrl
 use MOM_diag_mediator,    only : time_type, diag_update_remap_grids
 use MOM_diag_vkernels,    only : interpolate_column, reintegrate_column
 use MOM_domains,          only : create_group_pass, do_group_pass, group_pass_type
-use MOM_EOS,              only : calculate_density
-use MOM_domains,          only : create_group_pass, do_group_pass, group_pass_type
 use MOM_error_handler,    only : MOM_error, FATAL, WARNING
 use MOM_error_handler,    only : callTree_showQuery
 use MOM_error_handler,    only : callTree_enter, callTree_leave, callTree_waypoint

--- a/src/ALE/coord_slight.F90
+++ b/src/ALE/coord_slight.F90
@@ -375,7 +375,7 @@ subroutine build_slight_column(CS, eqn_of_state, H_to_pres, H_subroundoff, &
       call calculate_density_derivs(T_int, S_int, p_R, drhoR_dT, drhoR_dS, &
                                     eqn_of_state, (/2,nz/) )
       if (CS%compressibility_fraction > 0.0) then
-        call calculate_compress(T_int, S_int, p_R(:), rho_tmp, drho_dp, 2, nz-1, eqn_of_state)
+        call calculate_compress(T_int, S_int, p_R(:), rho_tmp, drho_dp, eqn_of_state, (/2,nz/))
       else
         do K=2,nz ; drho_dp(K) = 0.0 ; enddo
       endif

--- a/src/core/MOM_density_integrals.F90
+++ b/src/core/MOM_density_integrals.F90
@@ -47,19 +47,19 @@ subroutine int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, US, dpa,
                         intent(in)  :: z_t !< Height at the top of the layer in depth units [Z ~> m]
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: z_b !< Height at the bottom of the layer [Z ~> m]
-  real,                 intent(in)  :: rho_ref !< A mean density [R ~> kg m-3] or [kg m-3], that is
+  real,                 intent(in)  :: rho_ref !< A mean density [R ~> kg m-3], that is
                                            !! subtracted out to reduce the magnitude of each of the
                                            !! integrals.
-  real,                 intent(in)  :: rho_0 !< A density [R ~> kg m-3] or [kg m-3], that is used
+  real,                 intent(in)  :: rho_0 !< A density [R ~> kg m-3], that is used
                                            !! to calculate the pressure (as p~=-z*rho_0*G_e)
                                            !! used in the equation of state.
   real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration
-                                           !! [L2 Z-1 T-2 ~> m s-2] or [m2 Z-1 s-2 ~> m s-2]
+                                           !! [L2 Z-1 T-2 ~> m s-2]
   type(EOS_type),       intent(in)  :: EOS !< Equation of state structure
   type(unit_scale_type), intent(in) :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(HI),SZJ_(HI)), &
                       intent(inout) :: dpa !< The change in the pressure anomaly
-                                           !! across the layer [R L2 T-2 ~> Pa] or [Pa]
+                                           !! across the layer [R L2 T-2 ~> Pa]
   real, dimension(SZI_(HI),SZJ_(HI)), &
             optional, intent(inout) :: intz_dpa !< The integral through the thickness of the
                                            !! layer of the pressure anomaly relative to the
@@ -104,19 +104,19 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                         intent(in)  :: z_t !< Height at the top of the layer in depth units [Z ~> m]
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: z_b !< Height at the bottom of the layer [Z ~> m]
-  real,                 intent(in)  :: rho_ref !< A mean density [R ~> kg m-3] or [kg m-3], that is
+  real,                 intent(in)  :: rho_ref !< A mean density [R ~> kg m-3], that is
                                           !! subtracted out to reduce the magnitude
                                           !! of each of the integrals.
-  real,                 intent(in)  :: rho_0 !< A density [R ~> kg m-3] or [kg m-3], that is used
+  real,                 intent(in)  :: rho_0 !< A density [R ~> kg m-3], that is used
                                           !! to calculate the pressure (as p~=-z*rho_0*G_e)
                                           !! used in the equation of state.
   real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration
-                                          !! [L2 Z-1 T-2 ~> m s-2] or [m2 Z-1 s-2 ~> m s-2]
+                                          !! [L2 Z-1 T-2 ~> m s-2]
   type(EOS_type),       intent(in)  :: EOS !< Equation of state structure
   type(unit_scale_type), intent(in) :: US !< A dimensional unit scaling type
   real, dimension(SZI_(HI),SZJ_(HI)), &
                       intent(inout) :: dpa !< The change in the pressure anomaly
-                                          !! across the layer [R L2 T-2 ~> Pa] or [Pa]
+                                          !! across the layer [R L2 T-2 ~> Pa]
   real, dimension(SZI_(HI),SZJ_(HI)), &
             optional, intent(inout) :: intz_dpa !< The integral through the thickness of the
                                           !! layer of the pressure anomaly relative to the
@@ -141,11 +141,11 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   ! Local variables
   real :: T5(5), S5(5) ! Temperatures and salinities at five quadrature points [degC] and [ppt]
   real :: p5(5)      ! Pressures at five quadrature points, never rescaled from Pa [Pa]
-  real :: r5(5)      ! Densities at five quadrature points [R ~> kg m-3] or [kg m-3]
-  real :: rho_anom   ! The depth averaged density anomaly [R ~> kg m-3] or [kg m-3]
+  real :: r5(5)      ! Densities at five quadrature points [R ~> kg m-3]
+  real :: rho_anom   ! The depth averaged density anomaly [R ~> kg m-3]
   real, parameter :: C1_90 = 1.0/90.0  ! Rational constants.
   real :: GxRho      ! The gravitational acceleration times density and unit conversion factors [Pa Z-1 ~> kg m-2 s-2]
-  real :: I_Rho      ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1] or [m3 kg-1]
+  real :: I_Rho      ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1]
   real :: rho_scale  ! A scaling factor for densities from kg m-3 to R [R m3 kg-1 ~> 1]
   real :: rho_ref_mks ! The reference density in MKS units, never rescaled from kg m-3 [kg m-3]
   real :: dz         ! The layer thickness [Z ~> m]
@@ -158,7 +158,7 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real :: wt_L, wt_R ! The linear weights of the left and right columns [nondim]
   real :: wtT_L, wtT_R ! The weights for tracers from the left and right columns [nondim]
   real :: intz(5)    ! The gravitational acceleration times the integrals of density
-                     ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa] or [Pa]
+                     ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
   logical :: use_rho_ref ! Pass rho_ref to the equation of state for more accurate calculation
                          ! of density anomalies.
@@ -354,9 +354,9 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
                         intent(in)  :: S_b !< Salinity at the cell bottom [ppt]
   real, dimension(SZI_(HI),SZJ_(HI),SZK_(GV)+1), &
                         intent(in)  :: e   !< Height of interfaces [Z ~> m]
-  real,                 intent(in)  :: rho_ref !< A mean density [R ~> kg m-3] or [kg m-3], that is subtracted
+  real,                 intent(in)  :: rho_ref !< A mean density [R ~> kg m-3], that is subtracted
                                            !! out to reduce the magnitude of each of the integrals.
-  real,                 intent(in)  :: rho_0 !< A density [R ~> kg m-3] or [kg m-3], that is used to calculate
+  real,                 intent(in)  :: rho_0 !< A density [R ~> kg m-3], that is used to calculate
                                            !! the pressure (as p~=-z*rho_0*G_e) used in the equation of state.
   real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration [L2 Z-1 T-2 ~> m s-2]
   real,                 intent(in)  :: dz_subroundoff !< A minuscule thickness change [Z ~> m]
@@ -404,9 +404,9 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
   real :: p5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Pressures along a line of subgrid locations, never
                                              ! rescaled from Pa [Pa]
   real :: r5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Densities anomalies along a line of subgrid
-                                             ! locations [R ~> kg m-3] or [kg m-3]
+                                             ! locations [R ~> kg m-3]
   real :: u5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Densities anomalies along a line of subgrid locations
-                                             ! (used for inaccurate form) [R ~> kg m-3] or [kg m-3]
+                                             ! (used for inaccurate form) [R ~> kg m-3]
   real :: T15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Temperatures at an array of subgrid locations [degC]
   real :: S15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Salinities at an array of subgrid locations [ppt]
   real :: T215((15*HI%iscB+1):(15*(HI%iecB+1))) ! SGS temperature variance along a line of subgrid locations [degC2]
@@ -414,15 +414,15 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
   real :: S215((15*HI%iscB+1):(15*(HI%iecB+1))) ! SGS salinity variance along a line of subgrid locations [ppt2]
   real :: p15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Pressures at an array of subgrid locations [Pa]
   real :: r15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Densities at an array of subgrid locations
-                                                 ! [R ~> kg m-3] or [kg m-3]
+                                               ! [R ~> kg m-3]
   real :: wt_t(5), wt_b(5)          ! Top and bottom weights [nondim]
-  real :: rho_anom                  ! A density anomaly [R ~> kg m-3] or [kg m-3]
+  real :: rho_anom                  ! A density anomaly [R ~> kg m-3]
   real :: w_left, w_right           ! Left and right weights [nondim]
   real :: intz(5)    ! The gravitational acceleration times the integrals of density
-                     ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa] or [Pa]
+                     ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa]
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
   real :: GxRho      ! The gravitational acceleration times density and unit conversion factors [Pa Z-1 ~> kg m-2 s-2]
-  real :: I_Rho      ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1] or [m3 kg-1]
+  real :: I_Rho      ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1]
   real :: rho_scale  ! A scaling factor for densities from kg m-3 to R [R m3 kg-1 ~> 1]
   real :: rho_ref_mks ! The reference density in MKS units, never rescaled from kg m-3 [kg m-3]
   real :: dz(HI%iscB:HI%iecB+1)   ! Layer thicknesses at tracer points [Z ~> m]
@@ -796,9 +796,9 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
                         intent(in)  :: S_b !< Salinity at the cell bottom [ppt]
   real, dimension(SZI_(HI),SZJ_(HI),SZK_(GV)+1), &
                         intent(in)  :: e   !< Height of interfaces [Z ~> m]
-  real,                 intent(in)  :: rho_ref !< A mean density [R ~> kg m-3] or [kg m-3], that is
+  real,                 intent(in)  :: rho_ref !< A mean density [R ~> kg m-3], that is
                                            !! subtracted out to reduce the magnitude of each of the integrals.
-  real,                 intent(in)  :: rho_0 !< A density [R ~> kg m-3] or [kg m-3], that is used to calculate
+  real,                 intent(in)  :: rho_0 !< A density [R ~> kg m-3], that is used to calculate
                                            !! the pressure (as p~=-z*rho_0*G_e) used in the equation of state.
   real,                 intent(in)  :: G_e !< The Earth's gravitational acceleration [L2 Z-1 T-2 ~> m s-2]
   real,                 intent(in)  :: dz_subroundoff !< A minuscule thickness change [Z ~> m]
@@ -842,15 +842,15 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
   real :: TS5(5) ! SGS temperature-salinity covariance along a line of subgrid locations [degC ppt]
   real :: S25(5) ! SGS salinity variance along a line of subgrid locations [ppt2]
   real :: p5(5) ! Pressures at five quadrature points, never rescaled from Pa [Pa]
-  real :: r5(5) ! Density anomalies from rho_ref at quadrature points [R ~> kg m-3] or [kg m-3]
+  real :: r5(5) ! Density anomalies from rho_ref at quadrature points [R ~> kg m-3]
   real :: wt_t(5), wt_b(5) ! Top and bottom weights [nondim]
-  real :: rho_anom ! The integrated density anomaly [R ~> kg m-3] or [kg m-3]
+  real :: rho_anom ! The integrated density anomaly [R ~> kg m-3]
   real :: w_left, w_right  ! Left and right weights [nondim]
   real :: intz(5) ! The gravitational acceleration times the integrals of density
-                  ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa] or [Pa]
+                  ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa]
   real, parameter :: C1_90 = 1.0/90.0  ! Rational constants.
   real :: GxRho ! The gravitational acceleration times density and unit conversion factors [Pa Z-1 ~> kg m-2 s-2]
-  real :: I_Rho ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1] or [m3 kg-1]
+  real :: I_Rho ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1]
   real :: rho_scale ! A scaling factor for densities from kg m-3 to R [R m3 kg-1 ~> 1]
   real :: rho_ref_mks ! The reference density in MKS units, never rescaled from kg m-3 [kg m-3]
   real :: dz ! Layer thicknesses at tracer points [Z ~> m]
@@ -1128,9 +1128,9 @@ subroutine int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, US, &
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: S   !< Salinity [ppt]
   real, dimension(SZI_(HI),SZJ_(HI)), &
-                        intent(in)  :: p_t !< Pressure at the top of the layer [R L2 T-2 ~> Pa] or [Pa]
+                        intent(in)  :: p_t !< Pressure at the top of the layer [R L2 T-2 ~> Pa]
   real, dimension(SZI_(HI),SZJ_(HI)), &
-                        intent(in)  :: p_b !< Pressure at the bottom of the layer [R L2 T-2 ~> Pa] or [Pa]
+                        intent(in)  :: p_b !< Pressure at the bottom of the layer [R L2 T-2 ~> Pa]
   real,                 intent(in)  :: alpha_ref !< A mean specific volume that is subtracted out
                             !! to reduce the magnitude of each of the integrals [R-1 ~> m3 kg-1]
                             !! The calculation is mathematically identical with different values of
@@ -1139,24 +1139,24 @@ subroutine int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, US, &
   type(unit_scale_type), intent(in) :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(inout) :: dza !< The change in the geopotential anomaly across
-                            !! the layer [L2 T-2 ~> m2 s-2] or [m2 s-2]
+                            !! the layer [L2 T-2 ~> m2 s-2]
   real, dimension(SZI_(HI),SZJ_(HI)), &
               optional, intent(inout) :: intp_dza !< The integral in pressure through the layer of the
                             !! geopotential anomaly relative to the anomaly at the bottom of the
-                            !! layer [R L4 T-4 ~> Pa m2 s-2] or [Pa m2 s-2]
+                            !! layer [R L4 T-4 ~> Pa m2 s-2]
   real, dimension(SZIB_(HI),SZJ_(HI)), &
               optional, intent(inout) :: intx_dza !< The integral in x of the difference between the
                             !! geopotential anomaly at the top and bottom of the layer divided by
-                            !! the x grid spacing [L2 T-2 ~> m2 s-2] or [m2 s-2]
+                            !! the x grid spacing [L2 T-2 ~> m2 s-2]
   real, dimension(SZI_(HI),SZJB_(HI)), &
               optional, intent(inout) :: inty_dza !< The integral in y of the difference between the
                             !! geopotential anomaly at the top and bottom of the layer divided by
-                            !! the y grid spacing [L2 T-2 ~> m2 s-2] or [m2 s-2]
+                            !! the y grid spacing [L2 T-2 ~> m2 s-2]
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate dza.
   real, dimension(SZI_(HI),SZJ_(HI)), &
-              optional, intent(in)  :: bathyP  !< The pressure at the bathymetry [R L2 T-2 ~> Pa] or [Pa]
+              optional, intent(in)  :: bathyP  !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_tiny !< A minuscule pressure change with
-                            !! the same units as p_t [R L2 T-2 ~> Pa] or [Pa]
+                            !! the same units as p_t [R L2 T-2 ~> Pa]
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
                             !! to interpolate T/S for top and bottom integrals.
 
@@ -1186,9 +1186,9 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: S  !< Salinity of the layer [ppt]
   real, dimension(SZI_(HI),SZJ_(HI)), &
-                        intent(in)  :: p_t !< Pressure atop the layer [R L2 T-2 ~> Pa] or [Pa]
+                        intent(in)  :: p_t !< Pressure atop the layer [R L2 T-2 ~> Pa]
   real, dimension(SZI_(HI),SZJ_(HI)), &
-                        intent(in)  :: p_b !< Pressure below the layer [R L2 T-2 ~> Pa] or [Pa]
+                        intent(in)  :: p_b !< Pressure below the layer [R L2 T-2 ~> Pa]
   real,                 intent(in)  :: alpha_ref !< A mean specific volume that is subtracted out
                             !! to reduce the magnitude of each of the integrals [R-1 ~> m3 kg-1]
                             !! The calculation is mathematically identical with different values of
@@ -1198,24 +1198,24 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
   type(unit_scale_type), intent(in) :: US !< A dimensional unit scaling type
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(inout) :: dza !< The change in the geopotential anomaly
-                            !! across the layer [L2 T-2 ~> m2 s-2] or [m2 s-2]
+                            !! across the layer [L2 T-2 ~> m2 s-2]
   real, dimension(SZI_(HI),SZJ_(HI)), &
               optional, intent(inout) :: intp_dza !< The integral in pressure through the layer of
                             !! the geopotential anomaly relative to the anomaly at the bottom of the
-                            !! layer [R L4 T-4 ~> Pa m2 s-2] or [Pa m2 s-2]
+                            !! layer [R L4 T-4 ~> Pa m2 s-2]
   real, dimension(SZIB_(HI),SZJ_(HI)), &
               optional, intent(inout) :: intx_dza  !< The integral in x of the difference between
                             !! the geopotential anomaly at the top and bottom of the layer divided
-                            !! by the x grid spacing [L2 T-2 ~> m2 s-2] or [m2 s-2]
+                            !! by the x grid spacing [L2 T-2 ~> m2 s-2]
   real, dimension(SZI_(HI),SZJB_(HI)), &
               optional, intent(inout) :: inty_dza  !< The integral in y of the difference between
                             !! the geopotential anomaly at the top and bottom of the layer divided
-                            !! by the y grid spacing [L2 T-2 ~> m2 s-2] or [m2 s-2]
+                            !! by the y grid spacing [L2 T-2 ~> m2 s-2]
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate dza.
   real, dimension(SZI_(HI),SZJ_(HI)), &
-              optional, intent(in)  :: bathyP !< The pressure at the bathymetry [R L2 T-2 ~> Pa] or [Pa]
+              optional, intent(in)  :: bathyP !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_neglect !< A minuscule pressure change with
-                                             !! the same units as p_t [R L2 T-2 ~> Pa] or [Pa]
+                                             !! the same units as p_t [R L2 T-2 ~> Pa]
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
                             !! to interpolate T/S for top and bottom integrals.
 
@@ -1230,7 +1230,7 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
   real :: T5(5)      ! Temperatures at five quadrature points [degC]
   real :: S5(5)      ! Salinities at five quadrature points [ppt]
   real :: p5(5)      ! Pressures at five quadrature points, scaled back to Pa if necessary [Pa]
-  real :: a5(5)      ! Specific volumes at five quadrature points [R-1 ~> m3 kg-1] or [m3 kg-1]
+  real :: a5(5)      ! Specific volumes at five quadrature points [R-1 ~> m3 kg-1]
   real :: alpha_anom ! The depth averaged specific density anomaly [R-1 ~> m3 kg-1]
   real :: dp         ! The pressure change through a layer [R L2 T-2 ~> Pa]
   real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa]
@@ -1405,18 +1405,18 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: S_b  !< Salinity at the bottom the layer [ppt]
   real, dimension(SZI_(HI),SZJ_(HI)), &
-                        intent(in)  :: p_t !< Pressure atop the layer [R L2 T-2 ~> Pa] or [Pa]
+                        intent(in)  :: p_t !< Pressure atop the layer [R L2 T-2 ~> Pa]
   real, dimension(SZI_(HI),SZJ_(HI)), &
-                        intent(in)  :: p_b !< Pressure below the layer [R L2 T-2 ~> Pa] or [Pa]
+                        intent(in)  :: p_b !< Pressure below the layer [R L2 T-2 ~> Pa]
   real,                 intent(in)  :: alpha_ref !< A mean specific volume that is subtracted out
                             !! to reduce the magnitude of each of the integrals [R-1 ~> m3 kg-1]
                             !! The calculation is mathematically identical with different values of
                             !! alpha_ref, but alpha_ref alters the effects of roundoff, and
                             !! answers do change.
   real,                 intent(in)  :: dP_neglect !<!< A miniscule pressure change with
-                                             !! the same units as p_t [R L2 T-2 ~> Pa] or [Pa]
+                                             !! the same units as p_t [R L2 T-2 ~> Pa]
   real, dimension(SZI_(HI),SZJ_(HI)), &
-                        intent(in)  :: bathyP !< The pressure at the bathymetry [R L2 T-2 ~> Pa] or [Pa]
+                        intent(in)  :: bathyP !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
   type(EOS_type),       intent(in)  :: EOS !< Equation of state structure
   type(unit_scale_type), intent(in) :: US !< A dimensional unit scaling type
   real, dimension(SZI_(HI),SZJ_(HI)), &
@@ -1425,15 +1425,15 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
   real, dimension(SZI_(HI),SZJ_(HI)), &
               optional, intent(inout) :: intp_dza !< The integral in pressure through the layer of
                             !! the geopotential anomaly relative to the anomaly at the bottom of the
-                            !! layer [R L4 T-4 ~> Pa m2 s-2] or [Pa m2 s-2]
+                            !! layer [R L4 T-4 ~> Pa m2 s-2]
   real, dimension(SZIB_(HI),SZJ_(HI)), &
               optional, intent(inout) :: intx_dza  !< The integral in x of the difference between
                             !! the geopotential anomaly at the top and bottom of the layer divided
-                            !! by the x grid spacing [L2 T-2 ~> m2 s-2] or [m2 s-2]
+                            !! by the x grid spacing [L2 T-2 ~> m2 s-2]
   real, dimension(SZI_(HI),SZJB_(HI)), &
               optional, intent(inout) :: inty_dza  !< The integral in y of the difference between
                             !! the geopotential anomaly at the top and bottom of the layer divided
-                            !! by the y grid spacing [L2 T-2 ~> m2 s-2] or [m2 s-2]
+                            !! by the y grid spacing [L2 T-2 ~> m2 s-2]
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
                             !! to interpolate T/S for top and bottom integrals.
 
@@ -1447,18 +1447,18 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
   real :: T5(5)      ! Temperatures at five quadrature points [degC]
   real :: S5(5)      ! Salinities at five quadrature points [ppt]
   real :: p5(5)      ! Pressures at five quadrature points, scaled back to Pa as necessary [Pa]
-  real :: a5(5)      ! Specific volumes at five quadrature points [R-1 ~> m3 kg-1] or [m3 kg-1]
+  real :: a5(5)      ! Specific volumes at five quadrature points [R-1 ~> m3 kg-1]
   real :: T15(15)    ! Temperatures at fifteen interior quadrature points [degC]
   real :: S15(15)    ! Salinities at fifteen interior quadrature points [ppt]
   real :: p15(15)    ! Pressures at fifteen quadrature points, scaled back to Pa as necessary [Pa]
-  real :: a15(15)    ! Specific volumes at fifteen quadrature points [R-1 ~> m3 kg-1] or [m3 kg-1]
+  real :: a15(15)    ! Specific volumes at fifteen quadrature points [R-1 ~> m3 kg-1]
   real :: wt_t(5), wt_b(5) ! Weights of top and bottom values at quadrature points [nondim]
   real :: T_top, T_bot ! Horizontally interpolated temperature at the cell top and bottom [degC]
   real :: S_top, S_bot ! Horizontally interpolated salinity at the cell top and bottom [ppt]
   real :: P_top, P_bot ! Horizontally interpolated pressure at the cell top and bottom,
                        ! scaled back to Pa as necessary [Pa]
 
-  real :: alpha_anom ! The depth averaged specific density anomaly [R-1 ~> m3 kg-1] or [m3 kg-1]
+  real :: alpha_anom ! The depth averaged specific density anomaly [R-1 ~> m3 kg-1]
   real :: dp         ! The pressure change through a layer [R L2 T-2 ~> Pa]
   real :: dp_90(2:4) ! The pressure change through a layer divided by 90 [R L2 T-2 ~> Pa]
   real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa]

--- a/src/core/MOM_density_integrals.F90
+++ b/src/core/MOM_density_integrals.F90
@@ -140,14 +140,12 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
 
   ! Local variables
   real :: T5(5), S5(5) ! Temperatures and salinities at five quadrature points [degC] and [ppt]
-  real :: p5(5)      ! Pressures at five quadrature points, never rescaled from Pa [Pa]
+  real :: p5(5)      ! Pressures at five quadrature points [R L2 T-2 ~> Pa]
   real :: r5(5)      ! Densities at five quadrature points [R ~> kg m-3]
   real :: rho_anom   ! The depth averaged density anomaly [R ~> kg m-3]
   real, parameter :: C1_90 = 1.0/90.0  ! Rational constants.
-  real :: GxRho      ! The gravitational acceleration times density and unit conversion factors [Pa Z-1 ~> kg m-2 s-2]
+  real :: GxRho      ! The product of the gravitational acceleration and reference density [R L2 Z-1 T-2 ~> Pa m-1]
   real :: I_Rho      ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1]
-  real :: rho_scale  ! A scaling factor for densities from kg m-3 to R [R m3 kg-1 ~> 1]
-  real :: rho_ref_mks ! The reference density in MKS units, never rescaled from kg m-3 [kg m-3]
   real :: dz         ! The layer thickness [Z ~> m]
   real :: z0pres     ! The height at which the pressure is zero [Z ~> m]
   real :: hWght      ! A pressure-thickness below topography [Z ~> m]
@@ -171,9 +169,7 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   is = HI%isc ; ie = HI%iec
   js = HI%jsc ; je = HI%jec
 
-  rho_scale = US%kg_m3_to_R
-  GxRho = US%RL2_T2_to_Pa * G_e * rho_0
-  rho_ref_mks = rho_ref * US%R_to_kg_m3
+  GxRho = G_e * rho_0
   I_Rho = 1.0 / rho_0
   z0pres = 0.0 ; if (present(Z_0p)) z0pres = Z_0p
   use_rho_ref = .true.
@@ -197,19 +193,11 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
       p5(n) = -GxRho*((z_t(i,j) - z0pres) - 0.25*real(n-1)*dz)
     enddo
     if (use_rho_ref) then
-      if (rho_scale /= 1.0) then
-        call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref=rho_ref_mks, scale=rho_scale)
-      else
-        call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref=rho_ref_mks)
-      endif
+      call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
       ! Use Boole's rule to estimate the pressure anomaly change.
       rho_anom = C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3))
     else
-      if (rho_scale /= 1.0) then
-        call calculate_density(T5, S5, p5, r5, 1, 5, EOS, scale=rho_scale)
-      else
-        call calculate_density(T5, S5, p5, r5, 1, 5, EOS)
-      endif
+      call calculate_density(T5, S5, p5, r5, EOS)
       ! Use Boole's rule to estimate the pressure anomaly change.
       rho_anom = C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)) - rho_ref
     endif
@@ -253,19 +241,11 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
         T5(n) = T5(1) ; S5(n) = S5(1) ; p5(n) = p5(n-1) + GxRho*0.25*dz
       enddo
       if (use_rho_ref) then
-        if (rho_scale /= 1.0) then
-          call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref=rho_ref_mks, scale=rho_scale)
-        else
-          call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref=rho_ref_mks)
-        endif
+        call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
         ! Use Boole's rule to estimate the pressure anomaly change.
         intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)))
       else
-        if (rho_scale /= 1.0) then
-          call calculate_density(T5, S5, p5, r5, 1, 5, EOS, scale=rho_scale)
-        else
-          call calculate_density(T5, S5, p5, r5, 1, 5, EOS)
-        endif
+        call calculate_density(T5, S5, p5, r5, EOS)
         ! Use Boole's rule to estimate the pressure anomaly change.
         intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)) - rho_ref )
       endif
@@ -309,19 +289,11 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
         p5(n) = p5(n-1) + GxRho*0.25*dz
       enddo
       if (use_rho_ref) then
-        if (rho_scale /= 1.0) then
-          call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref=rho_ref_mks, scale=rho_scale)
-        else
-          call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref=rho_ref_mks)
-        endif
+        call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
         ! Use Boole's rule to estimate the pressure anomaly change.
         intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)))
       else
-        if (rho_scale /= 1.0) then
-          call calculate_density(T5, S5, p5, r5, 1, 5, EOS, scale=rho_scale)
-        else
-          call calculate_density(T5, S5, p5, r5, 1, 5, EOS)
-        endif
+        call calculate_density(T5, S5, p5, r5, EOS)
         ! Use Boole's rule to estimate the pressure anomaly change.
         intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)) - rho_ref )
       endif
@@ -401,8 +373,7 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
   real :: T25((5*HI%iscB+1):(5*(HI%iecB+2))) ! SGS temperature variance along a line of subgrid locations [degC2]
   real :: TS5((5*HI%iscB+1):(5*(HI%iecB+2))) ! SGS temp-salt covariance along a line of subgrid locations [degC ppt]
   real :: S25((5*HI%iscB+1):(5*(HI%iecB+2))) ! SGS salinity variance along a line of subgrid locations [ppt2]
-  real :: p5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Pressures along a line of subgrid locations, never
-                                             ! rescaled from Pa [Pa]
+  real :: p5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Pressures along a line of subgrid locations [R L2 T-2 ~> Pa]
   real :: r5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Densities anomalies along a line of subgrid
                                              ! locations [R ~> kg m-3]
   real :: u5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Densities anomalies along a line of subgrid locations
@@ -412,19 +383,16 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
   real :: T215((15*HI%iscB+1):(15*(HI%iecB+1))) ! SGS temperature variance along a line of subgrid locations [degC2]
   real :: TS15((15*HI%iscB+1):(15*(HI%iecB+1))) ! SGS temp-salt covariance along a line of subgrid locations [degC ppt]
   real :: S215((15*HI%iscB+1):(15*(HI%iecB+1))) ! SGS salinity variance along a line of subgrid locations [ppt2]
-  real :: p15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Pressures at an array of subgrid locations [Pa]
-  real :: r15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Densities at an array of subgrid locations
-                                               ! [R ~> kg m-3]
+  real :: p15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Pressures at an array of subgrid locations [R L2 T-2 ~> Pa]
+  real :: r15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Densities at an array of subgrid locations [R ~> kg m-3]
   real :: wt_t(5), wt_b(5)          ! Top and bottom weights [nondim]
   real :: rho_anom                  ! A density anomaly [R ~> kg m-3]
   real :: w_left, w_right           ! Left and right weights [nondim]
   real :: intz(5)    ! The gravitational acceleration times the integrals of density
                      ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa]
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
-  real :: GxRho      ! The gravitational acceleration times density and unit conversion factors [Pa Z-1 ~> kg m-2 s-2]
+  real :: GxRho      ! The product of the gravitational acceleration and reference density [R L2 Z-1 T-2 ~> Pa m-1]
   real :: I_Rho      ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1]
-  real :: rho_scale  ! A scaling factor for densities from kg m-3 to R [R m3 kg-1 ~> 1]
-  real :: rho_ref_mks ! The reference density in MKS units, never rescaled from kg m-3 [kg m-3]
   real :: dz(HI%iscB:HI%iecB+1)   ! Layer thicknesses at tracer points [Z ~> m]
   real :: dz_x(5,HI%iscB:HI%iecB) ! Layer thicknesses along an x-line of subgrid locations [Z ~> m]
   real :: dz_y(5,HI%isc:HI%iec)   ! Layer thicknesses along a y-line of subgrid locations [Z ~> m]
@@ -439,14 +407,15 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
   logical :: use_rho_ref ! Pass rho_ref to the equation of state for more accurate calculation
                          ! of density anomalies.
   logical :: use_varT, use_varS, use_covarTS ! Logicals for SGS variances fields
-  integer :: Isq, Ieq, Jsq, Jeq, i, j, m, n
-  integer :: pos
+  integer, dimension(2) :: EOSdom_q5  ! The 5-point q-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_q15 ! The 3x5-point q-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_h15 ! The 3x5-point h-point i-computational domain for the equation of state
+
+  integer :: Isq, Ieq, Jsq, Jeq, i, j, m, n, pos
 
   Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB
 
-  rho_scale = US%kg_m3_to_R
-  GxRho = US%RL2_T2_to_Pa * G_e * rho_0
-  rho_ref_mks = rho_ref * US%R_to_kg_m3
+  GxRho = G_e * rho_0
   I_Rho = 1.0 / rho_0
   z0pres = 0.0 ; if (present(Z_0p)) z0pres = Z_0p
   massWeightToggle = 0.
@@ -474,6 +443,11 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
     wt_b(n) = 1.0 - wt_t(n)
   enddo
 
+  ! Set the loop ranges for equation of state calculations at various points.
+  EOSdom_q5(1) = 1 ; EOSdom_q5(2) = (ieq-isq+2)*5
+  EOSdom_q15(1) = 1 ; EOSdom_q15(2) = 15*(ieq-isq+1)
+  EOSdom_h15(1) = 1 ; EOSdom_h15(2) = 15*(HI%iec-HI%isc+1)
+
   ! 1. Compute vertical integrals
   do j=Jsq,Jeq+1
     do i = Isq,Ieq+1
@@ -489,27 +463,12 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
       if (use_varS) S25(i*5+1:i*5+5) = tv%varS(i,j,k)
     enddo
     if (use_Stanley_eos) then
-      if (rho_scale /= 1.0) then
-        call calculate_density(T5, S5, p5, T25, TS5, S25, r5, 1, (ieq-isq+2)*5, EOS, &
-                               rho_ref=rho_ref_mks, scale=rho_scale)
-      else
-        call calculate_density(T5, S5, p5, T25, TS5, S25, r5, 1, (ieq-isq+2)*5, EOS, &
-                               rho_ref=rho_ref_mks)
-      endif
+      call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, EOSdom_q5, rho_ref=rho_ref)
     else
       if (use_rho_ref) then
-        if (rho_scale /= 1.0) then
-          call calculate_density(T5, S5, p5, r5, 1, (ieq-isq+2)*5, EOS, rho_ref=rho_ref_mks, &
-                                 scale=rho_scale)
-        else
-          call calculate_density(T5, S5, p5, r5, 1, (ieq-isq+2)*5, EOS, rho_ref=rho_ref_mks)
-        endif
+        call calculate_density(T5, S5, p5, r5, EOS, EOSdom_q5, rho_ref=rho_ref)
       else
-        if (rho_scale /= 1.0) then
-          call calculate_density(T5, S5, p5, r5, 1, (ieq-isq+2)*5, EOS, scale=rho_scale)
-        else
-          call calculate_density(T5, S5, p5, r5, 1, (ieq-isq+2)*5, EOS)
-        endif
+        call calculate_density(T5, S5, p5, r5, EOS, EOSdom_q5)
         u5(:) = r5(:) - rho_ref
       endif
     endif
@@ -606,27 +565,12 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
     enddo
 
     if (use_stanley_eos) then
-      if (rho_scale /= 1.0) then
-        call calculate_density(T15, S15, p15, T215, TS15, S215, r15, 1, 15*(ieq-isq+1), EOS, &
-                               rho_ref=rho_ref_mks, scale=rho_scale)
-      else
-        call calculate_density(T15, S15, p15, T215, TS15, S215, r15, 1, 15*(ieq-isq+1), EOS, &
-                               rho_ref=rho_ref_mks)
-      endif
+      call calculate_density(T15, S15, p15, T215, TS15, S215, r15, EOS, EOSdom_q15, rho_ref=rho_ref)
     else
       if (use_rho_ref) then
-        if (rho_scale /= 1.0) then
-          call calculate_density(T15, S15, p15, r15, 1, 15*(ieq-isq+1), EOS, rho_ref=rho_ref_mks, &
-                                 scale=rho_scale)
-        else
-          call calculate_density(T15, S15, p15, r15, 1, 15*(ieq-isq+1), EOS, rho_ref=rho_ref_mks)
-        endif
+        call calculate_density(T15, S15, p15, r15, EOS, EOSdom_q15, rho_ref=rho_ref)
       else
-        if (rho_scale /= 1.0) then
-          call calculate_density(T15, S15, p15, r15, 1, 15*(ieq-isq+1), EOS, scale=rho_scale)
-        else
-          call calculate_density(T15, S15, p15, r15, 1, 15*(ieq-isq+1), EOS)
-        endif
+        call calculate_density(T15, S15, p15, r15, EOS, EOSdom_q15)
       endif
     endif
 
@@ -717,35 +661,16 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
     enddo
 
     if (use_stanley_eos) then
-      if (rho_scale /= 1.0) then
-        call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
-                               T215(15*HI%isc+1:), TS15(15*HI%isc+1:), S215(15*HI%isc+1:), &
-                               r15(15*HI%isc+1:), 1, 15*(HI%iec-HI%isc+1), EOS, &
-                               rho_ref=rho_ref_mks, scale=rho_scale)
-      else
-        call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
-                               T215(15*HI%isc+1:), TS15(15*HI%isc+1:), S215(15*HI%isc+1:), &
-                               r15(15*HI%isc+1:), 1, 15*(HI%iec-HI%isc+1), EOS, rho_ref=rho_ref_mks)
-      endif
+      call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
+                             T215(15*HI%isc+1:), TS15(15*HI%isc+1:), S215(15*HI%isc+1:), &
+                             r15(15*HI%isc+1:), EOS, EOSdom_h15, rho_ref=rho_ref)
     else
       if (use_rho_ref) then
-        if (rho_scale /= 1.0) then
-          call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
-                                 r15(15*HI%isc+1:), 1, 15*(HI%iec-HI%isc+1), EOS, &
-                                 rho_ref=rho_ref_mks, scale=rho_scale)
-        else
-          call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
-                                 r15(15*HI%isc+1:), 1, 15*(HI%iec-HI%isc+1), EOS, rho_ref=rho_ref_mks)
-        endif
+        call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
+                               r15(15*HI%isc+1:), EOS, EOSdom_h15, rho_ref=rho_ref)
       else
-        if (rho_scale /= 1.0) then
-          call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
-                                 r15(15*HI%isc+1:), 1, 15*(HI%iec-HI%isc+1), EOS, &
-                                 scale=rho_scale)
-        else
-          call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
-                                 r15(15*HI%isc+1:), 1, 15*(HI%iec-HI%isc+1), EOS)
-        endif
+        call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
+                               r15(15*HI%isc+1:), EOS, EOSdom_h15)
       endif
     endif
 
@@ -841,7 +766,7 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
   real :: T25(5) ! SGS temperature variance along a line of subgrid locations [degC2]
   real :: TS5(5) ! SGS temperature-salinity covariance along a line of subgrid locations [degC ppt]
   real :: S25(5) ! SGS salinity variance along a line of subgrid locations [ppt2]
-  real :: p5(5) ! Pressures at five quadrature points, never rescaled from Pa [Pa]
+  real :: p5(5) ! Pressures at five quadrature points [R L2 T-2 ~> Pa]
   real :: r5(5) ! Density anomalies from rho_ref at quadrature points [R ~> kg m-3]
   real :: wt_t(5), wt_b(5) ! Top and bottom weights [nondim]
   real :: rho_anom ! The integrated density anomaly [R ~> kg m-3]
@@ -849,10 +774,8 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
   real :: intz(5) ! The gravitational acceleration times the integrals of density
                   ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa]
   real, parameter :: C1_90 = 1.0/90.0  ! Rational constants.
-  real :: GxRho ! The gravitational acceleration times density and unit conversion factors [Pa Z-1 ~> kg m-2 s-2]
+  real :: GxRho ! The gravitational acceleration times density [R L2 Z-1 T-2 ~> kg m-2 s-2]
   real :: I_Rho ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1]
-  real :: rho_scale ! A scaling factor for densities from kg m-3 to R [R m3 kg-1 ~> 1]
-  real :: rho_ref_mks ! The reference density in MKS units, never rescaled from kg m-3 [kg m-3]
   real :: dz ! Layer thicknesses at tracer points [Z ~> m]
   real :: massWeightToggle ! A non-dimensional toggle factor (0 or 1) [nondim]
   real :: Ttl, Tbl, Tml, Ttr, Tbr, Tmr ! Temperatures at the velocity cell corners [degC]
@@ -872,9 +795,7 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
 
   Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB
 
-  rho_scale = US%kg_m3_to_R
-  GxRho = US%RL2_T2_to_Pa * G_e * rho_0
-  rho_ref_mks = rho_ref * US%R_to_kg_m3
+  GxRho = G_e * rho_0
   I_Rho = 1.0 / rho_0
   z0pres = 0.0 ; if (present(Z_0p)) z0pres = Z_0p
   massWeightToggle = 0.
@@ -918,10 +839,9 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
       if (use_varT) T25(:) = tv%varT(i,j,k)
       if (use_covarTS) TS5(:) = tv%covarTS(i,j,k)
       if (use_varS) S25(:) = tv%varS(i,j,k)
-      call calculate_density(T5, S5, p5, T25, TS5, S25, r5, &
-                             1, 5, EOS, rho_ref=rho_ref_mks, scale=rho_scale)
+      call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, rho_ref=rho_ref)
     else
-      call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref=rho_ref_mks, scale=rho_scale)
+      call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
     endif
 
     ! Use Boole's rule to estimate the pressure anomaly change.
@@ -1007,10 +927,9 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
         if (use_varT) T25(:) = w_left*tv%varT(i,j,k) + w_right*tv%varT(i+1,j,k)
         if (use_covarTS) TS5(:) = w_left*tv%covarTS(i,j,k) + w_right*tv%covarTS(i+1,j,k)
         if (use_varS) S25(:) = w_left*tv%varS(i,j,k) + w_right*tv%varS(i+1,j,k)
-        call calculate_density(T5, S5, p5, T25, TS5, S25, r5, &
-                               1, 5, EOS, rho_ref=rho_ref_mks, scale=rho_scale)
+        call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, rho_ref=rho_ref)
       else
-        call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref=rho_ref_mks, scale=rho_scale)
+        call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
       endif
 
       ! Use Boole's rule to estimate the pressure anomaly change.
@@ -1095,10 +1014,9 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
         if (use_varT) T25(:) = w_left*tv%varT(i,j,k) + w_right*tv%varT(i,j+1,k)
         if (use_covarTS) TS5(:) = w_left*tv%covarTS(i,j,k) + w_right*tv%covarTS(i,j+1,k)
         if (use_varS) S25(:) = w_left*tv%varS(i,j,k) + w_right*tv%varS(i,j+1,k)
-        call calculate_density(T5, S5, p5, T25, TS5, S25, r5, &
-                               1, 5, EOS, rho_ref=rho_ref_mks, scale=rho_scale)
+        call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, rho_ref=rho_ref)
       else
-        call calculate_density(T5, S5, p5, r5, 1, 5, EOS, rho_ref=rho_ref_mks, scale=rho_scale)
+        call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
       endif
 
       ! Use Boole's rule to estimate the pressure anomaly change.
@@ -1229,13 +1147,12 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
   ! Local variables
   real :: T5(5)      ! Temperatures at five quadrature points [degC]
   real :: S5(5)      ! Salinities at five quadrature points [ppt]
-  real :: p5(5)      ! Pressures at five quadrature points, scaled back to Pa if necessary [Pa]
+  real :: p5(5)      ! Pressures at five quadrature points [R L2 T-2 ~> Pa]
   real :: a5(5)      ! Specific volumes at five quadrature points [R-1 ~> m3 kg-1]
   real :: alpha_anom ! The depth averaged specific density anomaly [R-1 ~> m3 kg-1]
   real :: dp         ! The pressure change through a layer [R L2 T-2 ~> Pa]
   real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa]
   real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [R L2 T-2 ~> Pa]
-  real :: alpha_ref_mks ! The reference specific volume in MKS units, never rescaled from m3 kg-1 [m3 kg-1]
   real :: iDenom     ! The inverse of the denominator in the weights [T4 R-2 L-4 ~> Pa-2]
   real :: hWt_LL, hWt_LR ! hWt_LA is the weighted influence of A on the left column [nondim]
   real :: hWt_RL, hWt_RR ! hWt_RA is the weighted influence of A on the right column [nondim]
@@ -1243,9 +1160,6 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
   real :: wtT_L, wtT_R ! The weights for tracers from the left and right columns [nondim]
   real :: intp(5)    ! The integrals of specific volume with pressure at the
                      ! 5 sub-column locations [L2 T-2 ~> m2 s-2]
-  real :: RL2_T2_to_Pa  ! A unit conversion factor from the rescaled units of pressure to Pa [Pa T2 R-1 L-2 ~> 1]
-  real :: SV_scale   ! A multiplicative factor by which to scale specific
-                     ! volume from m3 kg-1 to the desired units [kg m-3 R-1 ~> 1]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant.
   integer :: Isq, Ieq, Jsq, Jeq, ish, ieh, jsh, jeh, i, j, m, n, halo
@@ -1255,10 +1169,6 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
   ish = HI%isc-halo ; ieh = HI%iec+halo ; jsh = HI%jsc-halo ; jeh = HI%jec+halo
   if (present(intx_dza)) then ; ish = MIN(Isq,ish) ; ieh = MAX(Ieq+1,ieh); endif
   if (present(inty_dza)) then ; jsh = MIN(Jsq,jsh) ; jeh = MAX(Jeq+1,jeh); endif
-
-  SV_scale = US%R_to_kg_m3
-  RL2_T2_to_Pa = US%RL2_T2_to_Pa
-  alpha_ref_mks = alpha_ref * US%kg_m3_to_R
 
   do_massWeight = .false.
   if (present(useMassWghtInterp)) then ; if (useMassWghtInterp) then
@@ -1273,14 +1183,10 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
     dp = p_b(i,j) - p_t(i,j)
     do n=1,5
       T5(n) = T(i,j) ; S5(n) = S(i,j)
-      p5(n) = RL2_T2_to_Pa * (p_b(i,j) - 0.25*real(n-1)*dp)
+      p5(n) = p_b(i,j) - 0.25*real(n-1)*dp
     enddo
 
-    if (SV_scale /= 1.0) then
-      call calculate_spec_vol(T5, S5, p5, a5, 1, 5, EOS, alpha_ref_mks, scale=SV_scale)
-    else
-      call calculate_spec_vol(T5, S5, p5, a5, 1, 5, EOS, alpha_ref_mks)
-    endif
+    call calculate_spec_vol(T5, S5, p5, a5, EOS, spv_ref=alpha_ref)
 
     ! Use Boole's rule to estimate the interface height anomaly change.
     alpha_anom = C1_90*(7.0*(a5(1)+a5(5)) + 32.0*(a5(2)+a5(4)) + 12.0*a5(3))
@@ -1316,19 +1222,15 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
 
       ! T, S, and p are interpolated in the horizontal.  The p interpolation
       ! is linear, but for T and S it may be thickness weighted.
-      p5(1) = RL2_T2_to_Pa * (wt_L*p_b(i,j) + wt_R*p_b(i+1,j))
+      p5(1) = wt_L*p_b(i,j) + wt_R*p_b(i+1,j)
       dp = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i+1,j) - p_t(i+1,j))
       T5(1) = wtT_L*T(i,j) + wtT_R*T(i+1,j)
       S5(1) = wtT_L*S(i,j) + wtT_R*S(i+1,j)
 
       do n=2,5
-        T5(n) = T5(1) ; S5(n) = S5(1) ; p5(n) = p5(n-1) - RL2_T2_to_Pa * 0.25*dp
+        T5(n) = T5(1) ; S5(n) = S5(1) ; p5(n) = p5(n-1) - 0.25*dp
       enddo
-      if (SV_scale /= 1.0) then
-        call calculate_spec_vol(T5, S5, p5, a5, 1, 5, EOS, alpha_ref_mks, scale=SV_scale)
-      else
-        call calculate_spec_vol(T5, S5, p5, a5, 1, 5, EOS, alpha_ref_mks)
-      endif
+      call calculate_spec_vol(T5, S5, p5, a5, EOS, spv_ref=alpha_ref)
 
     ! Use Boole's rule to estimate the interface height anomaly change.
       intp(m) = dp*( C1_90*(7.0*(a5(1)+a5(5)) + 32.0*(a5(2)+a5(4)) + &
@@ -1364,18 +1266,14 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
 
       ! T, S, and p are interpolated in the horizontal.  The p interpolation
       ! is linear, but for T and S it may be thickness weighted.
-      p5(1) = RL2_T2_to_Pa * (wt_L*p_b(i,j) + wt_R*p_b(i,j+1))
+      p5(1) = wt_L*p_b(i,j) + wt_R*p_b(i,j+1)
       dp = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i,j+1) - p_t(i,j+1))
       T5(1) = wtT_L*T(i,j) + wtT_R*T(i,j+1)
       S5(1) = wtT_L*S(i,j) + wtT_R*S(i,j+1)
       do n=2,5
-        T5(n) = T5(1) ; S5(n) = S5(1) ; p5(n) = RL2_T2_to_Pa * (p5(n-1) - 0.25*dp)
+        T5(n) = T5(1) ; S5(n) = S5(1) ; p5(n) = p5(n-1) - 0.25*dp
       enddo
-      if (SV_scale /= 1.0) then
-        call calculate_spec_vol(T5, S5, p5, a5, 1, 5, EOS, alpha_ref_mks, scale=SV_scale)
-      else
-        call calculate_spec_vol(T5, S5, p5, a5, 1, 5, EOS, alpha_ref_mks)
-      endif
+      call calculate_spec_vol(T5, S5, p5, a5, EOS, spv_ref=alpha_ref)
 
     ! Use Boole's rule to estimate the interface height anomaly change.
       intp(m) = dp*( C1_90*(7.0*(a5(1)+a5(5)) + 32.0*(a5(2)+a5(4)) + &
@@ -1446,24 +1344,22 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
 
   real :: T5(5)      ! Temperatures at five quadrature points [degC]
   real :: S5(5)      ! Salinities at five quadrature points [ppt]
-  real :: p5(5)      ! Pressures at five quadrature points, scaled back to Pa as necessary [Pa]
+  real :: p5(5)      ! Pressures at five quadrature points [R L2 T-2 ~> Pa]
   real :: a5(5)      ! Specific volumes at five quadrature points [R-1 ~> m3 kg-1]
   real :: T15(15)    ! Temperatures at fifteen interior quadrature points [degC]
   real :: S15(15)    ! Salinities at fifteen interior quadrature points [ppt]
-  real :: p15(15)    ! Pressures at fifteen quadrature points, scaled back to Pa as necessary [Pa]
+  real :: p15(15)    ! Pressures at fifteen quadrature points [R L2 T-2 ~> Pa]
   real :: a15(15)    ! Specific volumes at fifteen quadrature points [R-1 ~> m3 kg-1]
   real :: wt_t(5), wt_b(5) ! Weights of top and bottom values at quadrature points [nondim]
   real :: T_top, T_bot ! Horizontally interpolated temperature at the cell top and bottom [degC]
   real :: S_top, S_bot ! Horizontally interpolated salinity at the cell top and bottom [ppt]
-  real :: P_top, P_bot ! Horizontally interpolated pressure at the cell top and bottom,
-                       ! scaled back to Pa as necessary [Pa]
+  real :: P_top, P_bot ! Horizontally interpolated pressure at the cell top and bottom [R L2 T-2 ~> Pa]
 
   real :: alpha_anom ! The depth averaged specific density anomaly [R-1 ~> m3 kg-1]
   real :: dp         ! The pressure change through a layer [R L2 T-2 ~> Pa]
   real :: dp_90(2:4) ! The pressure change through a layer divided by 90 [R L2 T-2 ~> Pa]
   real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa]
   real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [R L2 T-2 ~> Pa]
-  real :: alpha_ref_mks ! The reference specific volume in MKS units, never rescaled from m3 kg-1 [m3 kg-1]
   real :: iDenom     ! The inverse of the denominator in the weights [T4 R-2 L-4 ~> Pa-2]
   real :: hWt_LL, hWt_LR ! hWt_LA is the weighted influence of A on the left column [nondim]
   real :: hWt_RL, hWt_RR ! hWt_RA is the weighted influence of A on the right column [nondim]
@@ -1471,10 +1367,7 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
   real :: wtT_L, wtT_R ! The weights for tracers from the left and right columns [nondim]
   real :: intp(5)    ! The integrals of specific volume with pressure at the
                      ! 5 sub-column locations [L2 T-2 ~> m2 s-2]
-  real :: RL2_T2_to_Pa  ! A unit conversion factor from the rescaled units of pressure to Pa [Pa T2 R-1 L-2 ~> 1]
-  real :: SV_scale   ! A multiplicative factor by which to scale specific
-                     ! volume from m3 kg-1 to the desired units [kg m-3 R-1 ~> 1]
-  real, parameter :: C1_90 = 1.0/90.0  ! A rational constant.
+  real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
   integer :: Isq, Ieq, Jsq, Jeq, i, j, m, n, pos
 
@@ -1482,10 +1375,6 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
 
   do_massWeight = .false.
   if (present(useMassWghtInterp)) do_massWeight = useMassWghtInterp
-
-  SV_scale = US%R_to_kg_m3
-  RL2_T2_to_Pa = US%RL2_T2_to_Pa
-  alpha_ref_mks = alpha_ref * US%kg_m3_to_R
 
   do n = 1, 5 ! Note that these are reversed from int_density_dz.
     wt_t(n) = 0.25 * real(n-1)
@@ -1496,15 +1385,11 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     dp = p_b(i,j) - p_t(i,j)
     do n=1,5 ! T, S and p are linearly interpolated in the vertical.
-      p5(n) = RL2_T2_to_Pa * (wt_t(n) * p_t(i,j) + wt_b(n) * p_b(i,j))
+      p5(n) = wt_t(n) * p_t(i,j) + wt_b(n) * p_b(i,j)
       S5(n) = wt_t(n) * S_t(i,j) + wt_b(n) * S_b(i,j)
       T5(n) = wt_t(n) * T_t(i,j) + wt_b(n) * T_b(i,j)
     enddo
-    if (SV_scale /= 1.0) then
-      call calculate_spec_vol(T5, S5, p5, a5, 1, 5, EOS, alpha_ref_mks, scale=SV_scale)
-    else
-      call calculate_spec_vol(T5, S5, p5, a5, 1, 5, EOS, alpha_ref_mks)
-    endif
+    call calculate_spec_vol(T5, S5, p5, a5, EOS, spv_ref=alpha_ref)
 
     ! Use Boole's rule to estimate the interface height anomaly change.
     alpha_anom = C1_90*((7.0*(a5(1)+a5(5)) + 32.0*(a5(2)+a5(4))) + 12.0*a5(3))
@@ -1553,17 +1438,13 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
       ! Salinity, temperature and pressure with linear interpolation in the vertical.
       pos = (m-2)*5
       do n=1,5
-        p15(pos+n) = RL2_T2_to_Pa * (wt_t(n) * P_top + wt_b(n) * P_bot)
+        p15(pos+n) = wt_t(n) * P_top + wt_b(n) * P_bot
         S15(pos+n) = wt_t(n) * S_top + wt_b(n) * S_bot
         T15(pos+n) = wt_t(n) * T_top + wt_b(n) * T_bot
       enddo
     enddo
 
-    if (SV_scale /= 1.0) then
-      call calculate_spec_vol(T15, S15, p15, a15, 1, 15, EOS, alpha_ref_mks, scale=SV_scale)
-    else
-      call calculate_spec_vol(T15, S15, p15, a15, 1, 15, EOS, alpha_ref_mks)
-    endif
+    call calculate_spec_vol(T15, S15, p15, a15, EOS, spv_ref=alpha_ref)
 
     intp(1) = dza(i,j) ; intp(5) = dza(i+1,j)
     do m=2,4
@@ -1614,17 +1495,13 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
       ! Salinity, temperature and pressure with linear interpolation in the vertical.
       pos = (m-2)*5
       do n=1,5
-        p15(pos+n) = RL2_T2_to_Pa * (wt_t(n) * P_top + wt_b(n) * P_bot)
+        p15(pos+n) = wt_t(n) * P_top + wt_b(n) * P_bot
         S15(pos+n) = wt_t(n) * S_top + wt_b(n) * S_bot
         T15(pos+n) = wt_t(n) * T_top + wt_b(n) * T_bot
       enddo
     enddo
 
-    if (SV_scale /= 1.0) then
-      call calculate_spec_vol(T15, S15, p15, a15, 1, 15, EOS, alpha_ref_mks, scale=SV_scale)
-    else
-      call calculate_spec_vol(T15, S15, p15, a15, 1, 15, EOS, alpha_ref_mks)
-    endif
+    call calculate_spec_vol(T15, S15, p15, a15, EOS, spv_ref=alpha_ref)
 
     intp(1) = dza(i,j) ; intp(5) = dza(i,j+1)
     do m=2,4

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -11,7 +11,7 @@ use MOM_remapping, only : remapping_CS, initialize_remapping, remapping_core_h
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs
+use MOM_EOS, only : calculate_density_derivs
 
 implicit none ; private
 

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -89,17 +89,17 @@ end interface calculate_specific_vol_derivs
 !> Calculates the second derivatives of density with various combinations of temperature,
 !! salinity, and pressure from T, S and P
 interface calculate_density_second_derivs
-  module procedure calculate_density_second_derivs_scalar, calculate_density_second_derivs_array
+  module procedure calculate_density_second_derivs_scalar, calculate_density_second_derivs_1d
 end interface calculate_density_second_derivs
 
 !> Calculates the freezing point of sea water from T, S and P
 interface calculate_TFreeze
-  module procedure calculate_TFreeze_scalar, calculate_TFreeze_array
+  module procedure calculate_TFreeze_scalar, calculate_TFreeze_1d, calculate_TFreeze_array
 end interface calculate_TFreeze
 
 !> Calculates the compressibility of water from T, S, and P
 interface calculate_compress
-  module procedure calculate_compress_scalar, calculate_compress_array
+  module procedure calculate_compress_scalar, calculate_compress_1d
 end interface calculate_compress
 
 !> A control structure for the equation of state
@@ -166,34 +166,28 @@ subroutine calculate_density_scalar(T, S, pressure, rho, EOS, rho_ref, scale)
   real,           intent(in)  :: pressure !< Pressure [R L2 T-2 ~> Pa]
   real,           intent(out) :: rho      !< Density (in-situ if pressure is local) [R ~> kg m-3]
   type(EOS_type), intent(in)  :: EOS      !< Equation of state structure
-  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+  real, optional, intent(in)  :: rho_ref  !< A reference density [R ~> kg m-3]
   real, optional, intent(in)  :: scale    !< A multiplicative factor by which to scale output density in
                                           !! combination with scaling given by US [various]
 
-  real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
-  real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
+  real :: Ta(1)      ! An array of temperatures [degC]
+  real :: Sa(1)      ! An array of salinities [ppt]
+  real :: pres(1)    ! An mks version of the pressure to use [Pa]
+  real :: rho_mks(1) ! An mks version of the density to be returned [kg m-3]
+  real :: rho_scale  ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
 
-  p_scale = EOS%RL2_T2_to_Pa
+  pres(1) = EOS%RL2_T2_to_Pa * pressure
+  Ta(1) = T ; Sa(1) = S
+  if (present(rho_ref)) then
+    call calculate_density_array(Ta, Sa, pres, rho_mks, 1, 1, EOS, EOS%R_to_kg_m3*rho_ref)
+  else
+    call calculate_density_array(Ta, Sa, pres, rho_mks, 1, 1, EOS)
+  endif
 
-  select case (EOS%form_of_EOS)
-    case (EOS_LINEAR)
-      call calculate_density_linear(T, S, p_scale*pressure, rho, &
-                                    EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS, rho_ref)
-    case (EOS_UNESCO)
-      call calculate_density_unesco(T, S, p_scale*pressure, rho, rho_ref)
-    case (EOS_WRIGHT)
-      call calculate_density_wright(T, S, p_scale*pressure, rho, rho_ref)
-    case (EOS_TEOS10)
-      call calculate_density_teos10(T, S, p_scale*pressure, rho, rho_ref)
-    case (EOS_NEMO)
-      call calculate_density_nemo(T, S, p_scale*pressure, rho, rho_ref)
-    case default
-      call MOM_error(FATAL, "calculate_density_scalar: EOS is not valid.")
-  end select
-
+  ! Rescale the output density to the desired units.
   rho_scale = EOS%kg_m3_to_R
   if (present(scale)) rho_scale = rho_scale * scale
-  rho = rho_scale * rho
+  rho = rho_scale * rho_mks(1)
 
 end subroutine calculate_density_scalar
 
@@ -212,40 +206,34 @@ subroutine calculate_stanley_density_scalar(T, S, pressure, Tvar, TScov, Svar, r
   real,           intent(in)  :: pressure !< Pressure [R L2 T-2 ~> Pa]
   real,           intent(out) :: rho      !< Density (in-situ if pressure is local) [R ~> kg m-3]
   type(EOS_type), intent(in)  :: EOS      !< Equation of state structure
-  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
+  real, optional, intent(in)  :: rho_ref  !< A reference density [R ~> kg m-3].
   real, optional, intent(in)  :: scale    !< A multiplicative factor by which to scale output density in
                                           !! combination with scaling given by US [various]
   ! Local variables
   real :: d2RdTT, d2RdST, d2RdSS, d2RdSp, d2RdTp ! Second derivatives of density wrt T,S,p
-  real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
   real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
 
-  p_scale = EOS%RL2_T2_to_Pa
+  call calculate_density_scalar(T, S, pressure, rho, EOS, rho_ref)
 
+  p_scale = EOS%RL2_T2_to_Pa
   select case (EOS%form_of_EOS)
     case (EOS_LINEAR)
-      call calculate_density_linear(T, S, p_scale*pressure, rho, &
-                                    EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS, rho_ref)
-      call calculate_density_second_derivs_linear(T, S, pressure, d2RdSS, d2RdST, &
+      call calculate_density_second_derivs_linear(T, S, p_scale*pressure, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP)
     case (EOS_WRIGHT)
-      call calculate_density_wright(T, S, p_scale*pressure, rho, rho_ref)
-      call calculate_density_second_derivs_wright(T, S, pressure, d2RdSS, d2RdST, &
+      call calculate_density_second_derivs_wright(T, S, p_scale*pressure, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP)
     case (EOS_TEOS10)
-      call calculate_density_teos10(T, S, p_scale*pressure, rho, rho_ref)
-      call calculate_density_second_derivs_teos10(T, S, pressure, d2RdSS, d2RdST, &
+      call calculate_density_second_derivs_teos10(T, S, p_scale*pressure, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP)
     case default
       call MOM_error(FATAL, "calculate_stanley_density_scalar: EOS is not valid.")
   end select
 
   ! Equation 25 of Stanley et al., 2020.
-  rho = rho + ( 0.5 * d2RdTT * Tvar + ( d2RdST * TScov + 0.5 * d2RdSS * Svar ) )
+  rho = rho + EOS%kg_m3_to_R * ( 0.5 * d2RdTT * Tvar + ( d2RdST * TScov + 0.5 * d2RdSS * Svar ) )
 
-  rho_scale = EOS%kg_m3_to_R
-  if (present(scale)) rho_scale = rho_scale * scale
-  rho = rho_scale * rho
+  if (present(scale)) rho = rho * scale
 
 end subroutine calculate_stanley_density_scalar
 
@@ -355,7 +343,6 @@ subroutine calculate_density_1d(T, S, pressure, rho, EOS, dom, rho_ref, scale)
   real,                  optional, intent(in) :: scale !< A multiplicative factor by which to scale density
                                                    !! in combination with scaling given by US [various]
   ! Local variables
-  real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
   real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
   real :: rho_reference ! rho_ref converted to [kg m-3]
   real, dimension(size(rho)) :: pres  ! Pressure converted to [Pa]
@@ -367,17 +354,15 @@ subroutine calculate_density_1d(T, S, pressure, rho, EOS, dom, rho_ref, scale)
     is = 1 ; ie = size(rho) ; npts = 1 + ie - is
   endif
 
-  p_scale = EOS%RL2_T2_to_Pa
-
-  if ((p_scale == 1.0) .and. (EOS%R_to_kg_m3 == 1.0)) then
+  if ((EOS%RL2_T2_to_Pa == 1.0) .and. (EOS%R_to_kg_m3 == 1.0)) then
     call calculate_density_array(T, S, pressure, rho, is, npts, EOS, rho_ref=rho_ref)
   elseif (present(rho_ref)) then ! This is the same as above, but with some extra work to rescale variables.
-    do i=is,ie ; pres(i) = p_scale * pressure(i) ; enddo
+    do i=is,ie ; pres(i) = EOS%RL2_T2_to_Pa * pressure(i) ; enddo
     rho_reference = EOS%R_to_kg_m3*rho_ref
     call calculate_density_array(T, S, pres, rho, is, npts, EOS, rho_ref=rho_reference)
   else  ! There is rescaling of variables, but rho_ref is not present. Passing a 0 value of rho_ref
         ! changes answers at roundoff for some equations of state, like Wright and UNESCO.
-    do i=is,ie ; pres(i) = p_scale * pressure(i) ; enddo
+    do i=is,ie ; pres(i) = EOS%RL2_T2_to_Pa * pressure(i) ; enddo
     call calculate_density_array(T, S, pres, rho, is, npts, EOS)
   endif
 
@@ -410,7 +395,6 @@ subroutine calculate_stanley_density_1d(T, S, pressure, Tvar, TScov, Svar, rho, 
   real,                  optional, intent(in) :: scale !< A multiplicative factor by which to scale density
                                                    !! in combination with scaling given by US [various]
   ! Local variables
-  real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
   real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
   real :: rho_reference ! rho_ref converted to [kg m-3]
   real, dimension(size(rho)) :: pres  ! Pressure converted to [Pa]
@@ -423,9 +407,8 @@ subroutine calculate_stanley_density_1d(T, S, pressure, Tvar, TScov, Svar, rho, 
     is = 1 ; ie = size(rho) ; npts = 1 + ie - is
   endif
 
-  p_scale = EOS%RL2_T2_to_Pa
   do i=is,ie
-    pres(i) = p_scale * pressure(i)
+    pres(i) = EOS%RL2_T2_to_Pa * pressure(i)
   enddo
 
   ! Rho_ref is seems like it is always present when calculate_Stanley_density is called, so
@@ -435,16 +418,16 @@ subroutine calculate_stanley_density_1d(T, S, pressure, Tvar, TScov, Svar, rho, 
 
   select case (EOS%form_of_EOS)
     case (EOS_LINEAR)
-      call calculate_density_linear(T, S, pres, rho, 1, npts, &
+      call calculate_density_linear(T, S, pres, rho, is, npts, &
                                     EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS, rho_reference)
       call calculate_density_second_derivs_linear(T, S, pres, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP, 1, npts)
     case (EOS_WRIGHT)
-      call calculate_density_wright(T, S, pres, rho, 1, npts, rho_reference)
+      call calculate_density_wright(T, S, pres, rho, is, npts, rho_reference)
       call calculate_density_second_derivs_wright(T, S, pres, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP, 1, npts)
     case (EOS_TEOS10)
-      call calculate_density_teos10(T, S, pres, rho, 1, npts, rho_reference)
+      call calculate_density_teos10(T, S, pres, rho, is, npts, rho_reference)
       call calculate_density_second_derivs_teos10(T, S, pres, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP, 1, npts)
     case default
@@ -518,7 +501,7 @@ subroutine calc_spec_vol_scalar(T, S, pressure, specvol, EOS, spv_ref, scale)
   real,           intent(out) :: specvol  !< In situ or potential specific volume [R-1 ~> m3 kg-1]
                                           !! or other units determined by the scale argument
   type(EOS_type), intent(in)  :: EOS      !< Equation of state structure
-  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [R-1 m3 kg-1]
+  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [R-1 ~> m3 kg-1]
   real, optional, intent(in)  :: scale    !< A multiplicative factor by which to scale specific
                                           !! volume in combination with scaling given by US [various]
 
@@ -561,8 +544,6 @@ subroutine calc_spec_vol_1d(T, S, pressure, specvol, EOS, dom, spv_ref, scale)
                                                        !! scaling given by US [various]
   ! Local variables
   real, dimension(size(specvol)) :: pres  ! Pressure converted to [Pa]
-  real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
-  real :: spv_unscale ! A factor to convert specific volume from R-1 to m3 kg-1 [m3 kg-1 R ~> 1]
   real :: spv_scale ! A factor to convert specific volume from m3 kg-1 to the desired units [kg m-3 R-1 ~> 1]
   real :: spv_reference ! spv_ref converted to [m3 kg-1]
   integer :: i, is, ie, npts
@@ -573,18 +554,15 @@ subroutine calc_spec_vol_1d(T, S, pressure, specvol, EOS, dom, spv_ref, scale)
     is = 1 ; ie = size(specvol) ; npts = 1 + ie - is
   endif
 
-  p_scale = EOS%RL2_T2_to_Pa
-  spv_unscale = EOS%kg_m3_to_R
-
-  if ((p_scale == 1.0) .and. (spv_unscale == 1.0)) then
+  if ((EOS%RL2_T2_to_Pa == 1.0) .and. (EOS%kg_m3_to_R == 1.0)) then
     call calculate_spec_vol_array(T, S, pressure, specvol, is, npts, EOS, spv_ref)
   elseif (present(spv_ref)) then ! This is the same as above, but with some extra work to rescale variables.
-    do i=is,ie ; pres(i) = p_scale * pressure(i) ; enddo
-    spv_reference = spv_unscale*spv_ref
+    do i=is,ie ; pres(i) = EOS%RL2_T2_to_Pa * pressure(i) ; enddo
+    spv_reference = EOS%kg_m3_to_R*spv_ref
     call calculate_spec_vol_array(T, S, pres, specvol, is, npts, EOS, spv_reference)
   else  ! There is rescaling of variables, but spv_ref is not present. Passing a 0 value of spv_ref
         ! changes answers at roundoff for some equations of state, like Wright and UNESCO.
-    do i=is,ie ; pres(i) = p_scale * pressure(i) ; enddo
+    do i=is,ie ; pres(i) = EOS%RL2_T2_to_Pa * pressure(i) ; enddo
     call calculate_spec_vol_array(T, S, pres, specvol, is, npts, EOS)
   endif
 
@@ -674,6 +652,57 @@ subroutine calculate_TFreeze_array(S, pressure, T_fr, start, npts, EOS, pres_sca
 
 end subroutine calculate_TFreeze_array
 
+!> Calls the appropriate subroutine to calculate the freezing point for a 1-D array, taking
+!! dimensionally rescaled arguments with factors stored in EOS.
+subroutine calculate_TFreeze_1d(S, pressure, T_fr, EOS, dom)
+  real, dimension(:), intent(in)    :: S        !< Salinity [ppt]
+  real, dimension(:), intent(in)    :: pressure !< Pressure [R L2 T-2 ~> Pa]
+  real, dimension(:), intent(inout) :: T_fr     !< Freezing point potential temperature referenced
+                                                !! to the surface [degC]
+  type(EOS_type),     intent(in)    :: EOS      !< Equation of state structure
+  integer, dimension(2), optional, intent(in) :: dom   !< The domain of indices to work on, taking
+                                                       !! into account that arrays start at 1.
+
+  ! Local variables
+  real, dimension(size(pressure)) :: pres  ! Pressure converted to [Pa]
+  integer :: i, is, ie, npts
+
+  if (present(dom)) then
+    is = dom(1) ; ie = dom(2) ; npts = 1 + ie - is
+  else
+    is = 1 ; ie = size(T_Fr) ; npts = 1 + ie - is
+  endif
+
+  if (EOS%RL2_T2_to_Pa == 1.0) then
+    select case (EOS%form_of_TFreeze)
+      case (TFREEZE_LINEAR)
+        call calculate_TFreeze_linear(S, pressure, T_fr, is, npts, &
+                                      EOS%TFr_S0_P0, EOS%dTFr_dS, EOS%dTFr_dp)
+      case (TFREEZE_MILLERO)
+        call calculate_TFreeze_Millero(S, pressure, T_fr, is, npts)
+      case (TFREEZE_TEOS10)
+        call calculate_TFreeze_teos10(S, pressure, T_fr, is, npts)
+      case default
+        call MOM_error(FATAL, "calculate_TFreeze_scalar: form_of_TFreeze is not valid.")
+    end select
+  else
+    do i=is,ie ; pres(i) = EOS%RL2_T2_to_Pa * pressure(i) ; enddo
+    select case (EOS%form_of_TFreeze)
+      case (TFREEZE_LINEAR)
+        call calculate_TFreeze_linear(S, pres, T_fr, is, npts, &
+                                      EOS%TFr_S0_P0, EOS%dTFr_dS, EOS%dTFr_dp)
+      case (TFREEZE_MILLERO)
+        call calculate_TFreeze_Millero(S, pres, T_fr, is, npts)
+      case (TFREEZE_TEOS10)
+        call calculate_TFreeze_teos10(S, pres, T_fr, is, npts)
+      case default
+        call MOM_error(FATAL, "calculate_TFreeze_scalar: form_of_TFreeze is not valid.")
+    end select
+  endif
+
+end subroutine calculate_TFreeze_1d
+
+
 !> Calls the appropriate subroutine to calculate density derivatives for 1-D array inputs.
 subroutine calculate_density_derivs_array(T, S, pressure, drho_dT, drho_dS, start, npts, EOS, scale)
   real, dimension(:), intent(in)    :: T        !< Potential temperature referenced to the surface [degC]
@@ -735,7 +764,6 @@ subroutine calculate_density_derivs_1d(T, S, pressure, drho_dT, drho_dS, EOS, do
   ! Local variables
   real, dimension(size(drho_dT)) :: pres  ! Pressure converted to [Pa]
   real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
-  real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
   integer :: i, is, ie, npts
 
   if (present(dom)) then
@@ -744,12 +772,10 @@ subroutine calculate_density_derivs_1d(T, S, pressure, drho_dT, drho_dS, EOS, do
     is = 1 ; ie = size(drho_dT) ; npts = 1 + ie - is
   endif
 
-  p_scale = EOS%RL2_T2_to_Pa
-
-  if (p_scale == 1.0) then
+  if (EOS%RL2_T2_to_Pa == 1.0) then
     call calculate_density_derivs_array(T, S, pressure, drho_dT, drho_dS, is, npts, EOS)
   else
-    do i=is,ie ; pres(i) = p_scale * pressure(i) ; enddo
+    do i=is,ie ; pres(i) = EOS%RL2_T2_to_Pa * pressure(i) ; enddo
     call calculate_density_derivs_array(T, S, pres, drho_dT, drho_dS, is, npts, EOS)
   endif
 
@@ -806,8 +832,8 @@ subroutine calculate_density_derivs_scalar(T, S, pressure, drho_dT, drho_dS, EOS
 end subroutine calculate_density_derivs_scalar
 
 !> Calls the appropriate subroutine to calculate density second derivatives for 1-D array inputs.
-subroutine calculate_density_second_derivs_array(T, S, pressure, drho_dS_dS, drho_dS_dT, drho_dT_dT, &
-                                                 drho_dS_dP, drho_dT_dP, start, npts, EOS, scale)
+subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_dS_dT, drho_dT_dT, &
+                                              drho_dS_dP, drho_dT_dP, EOS, dom, scale)
   real, dimension(:), intent(in)  :: T !< Potential temperature referenced to the surface [degC]
   real, dimension(:), intent(in)  :: S !< Salinity [ppt]
   real, dimension(:), intent(in)  :: pressure   !< Pressure [R L2 T-2 ~> Pa]
@@ -821,46 +847,49 @@ subroutine calculate_density_second_derivs_array(T, S, pressure, drho_dS_dS, drh
                                                   !! [T2 ppt-1 L-2 ~> kg m-3 ppt-1 Pa-1]
   real, dimension(:), intent(inout) :: drho_dT_dP !< Partial derivative of alpha with respect to pressure
                                                   !! [T2 degC-1 L-2 ~> kg m-3 degC-1 Pa-1]
-  integer,            intent(in)  :: start !< Starting index within the array
-  integer,            intent(in)  :: npts  !< The number of values to calculate
-  type(EOS_type),     intent(in)  :: EOS   !< Equation of state structure
-  real,                  optional, intent(in) :: scale !< A multiplicative factor by which to scale density
+  type(EOS_type),     intent(in)    :: EOS        !< Equation of state structure
+  integer, dimension(2), optional, intent(in) :: dom   !< The domain of indices to work on, taking
+                                                  !! into account that arrays start at 1.
+  real,     optional, intent(in)    :: scale      !< A multiplicative factor by which to scale density
                                                   !! in combination with scaling given by US [various]
   ! Local variables
   real, dimension(size(pressure)) :: pres  ! Pressure converted to [Pa]
   real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
-  real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
   real :: I_p_scale ! The inverse of the factor to convert pressure to units of Pa [R L2 T-2 Pa-1 ~> 1]
-  integer :: j
+  integer :: i, is, ie, npts
 
-  p_scale = EOS%RL2_T2_to_Pa
+  if (present(dom)) then
+    is = dom(1) ; ie = dom(2) ; npts = 1 + ie - is
+  else
+    is = 1 ; ie = size(T) ; npts = 1 + ie - is
+  endif
 
-  if (p_scale == 1.0) then
+  if (EOS%RL2_T2_to_Pa == 1.0) then
     select case (EOS%form_of_EOS)
       case (EOS_LINEAR)
         call calculate_density_second_derivs_linear(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, start, npts)
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_WRIGHT)
         call calculate_density_second_derivs_wright(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, start, npts)
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_TEOS10)
         call calculate_density_second_derivs_teos10(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, start, npts)
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case default
         call MOM_error(FATAL, "calculate_density_derivs: EOS%form_of_EOS is not valid.")
     end select
   else
-    do j=start,start+npts-1 ; pres(j) = p_scale * pressure(j) ; enddo
+    do i=is,ie ; pres(i) = EOS%RL2_T2_to_Pa * pressure(i) ; enddo
     select case (EOS%form_of_EOS)
       case (EOS_LINEAR)
         call calculate_density_second_derivs_linear(T, S, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, start, npts)
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_WRIGHT)
         call calculate_density_second_derivs_wright(T, S, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, start, npts)
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_TEOS10)
         call calculate_density_second_derivs_teos10(T, S, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, start, npts)
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case default
         call MOM_error(FATAL, "calculate_density_derivs: EOS%form_of_EOS is not valid.")
     end select
@@ -868,23 +897,23 @@ subroutine calculate_density_second_derivs_array(T, S, pressure, drho_dS_dS, drh
 
   rho_scale = EOS%kg_m3_to_R
   if (present(scale)) rho_scale = rho_scale * scale
-  if (rho_scale /= 1.0) then ; do j=start,start+npts-1
-    drho_dS_dS(j) = rho_scale * drho_dS_dS(j)
-    drho_dS_dT(j) = rho_scale * drho_dS_dT(j)
-    drho_dT_dT(j) = rho_scale * drho_dT_dT(j)
-    drho_dS_dP(j) = rho_scale * drho_dS_dP(j)
-    drho_dT_dP(j) = rho_scale * drho_dT_dP(j)
+  if (rho_scale /= 1.0) then ; do i=is,ie
+    drho_dS_dS(i) = rho_scale * drho_dS_dS(i)
+    drho_dS_dT(i) = rho_scale * drho_dS_dT(i)
+    drho_dT_dT(i) = rho_scale * drho_dT_dT(i)
+    drho_dS_dP(i) = rho_scale * drho_dS_dP(i)
+    drho_dT_dP(i) = rho_scale * drho_dT_dP(i)
   enddo ; endif
 
-  if (p_scale /= 1.0) then
-    I_p_scale = 1.0 / p_scale
-    do j=start,start+npts-1
-      drho_dS_dP(j) = I_p_scale * drho_dS_dP(j)
-      drho_dT_dP(j) = I_p_scale * drho_dT_dP(j)
+  if (EOS%RL2_T2_to_Pa /= 1.0) then
+    I_p_scale = 1.0 / EOS%RL2_T2_to_Pa
+    do i=is,ie
+      drho_dS_dP(i) = I_p_scale * drho_dS_dP(i)
+      drho_dT_dP(i) = I_p_scale * drho_dT_dP(i)
     enddo
   endif
 
-end subroutine calculate_density_second_derivs_array
+end subroutine calculate_density_second_derivs_1d
 
 !> Calls the appropriate subroutine to calculate density second derivatives for scalar nputs.
 subroutine calculate_density_second_derivs_scalar(T, S, pressure, drho_dS_dS, drho_dS_dT, drho_dT_dT, &
@@ -1010,7 +1039,6 @@ subroutine calc_spec_vol_derivs_1d(T, S, pressure, dSV_dT, dSV_dS, EOS, dom, sca
   ! Local variables
   real, dimension(size(dSV_dT)) :: press   ! Pressure converted to [Pa]
   real :: spv_scale ! A factor to convert specific volume from m3 kg-1 to the desired units [kg R-1 m-3 ~> 1]
-  real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
   integer :: i, is, ie, npts
 
   if (present(dom)) then
@@ -1018,12 +1046,11 @@ subroutine calc_spec_vol_derivs_1d(T, S, pressure, dSV_dT, dSV_dS, EOS, dom, sca
   else
     is = 1 ; ie = size(dSV_dT) ; npts = 1 + ie - is
   endif
-  p_scale = EOS%RL2_T2_to_Pa
 
-  if (p_scale == 1.0) then
+  if (EOS%RL2_T2_to_Pa == 1.0) then
     call calculate_spec_vol_derivs_array(T, S, pressure, dSV_dT, dSV_dS, is, npts, EOS)
   else
-    do i=is,ie ; press(i) = p_scale * pressure(i) ; enddo
+    do i=is,ie ; press(i) = EOS%RL2_T2_to_Pa * pressure(i) ; enddo
     call calculate_spec_vol_derivs_array(T, S, press, dSV_dT, dSV_dS, is, npts, EOS)
   endif
 
@@ -1038,8 +1065,8 @@ end subroutine calc_spec_vol_derivs_1d
 
 
 !> Calls the appropriate subroutine to calculate the density and compressibility for 1-D array
-!! inputs.  If US is present, the units of the inputs and outputs are rescaled.
-subroutine calculate_compress_array(T, S, press, rho, drho_dp, start, npts, EOS)
+!! inputs.  The inputs and outputs use dimensionally rescaled units.
+subroutine calculate_compress_1d(T, S, press, rho, drho_dp, EOS, dom)
   real, dimension(:), intent(in)  :: T        !< Potential temperature referenced to the surface [degC]
   real, dimension(:), intent(in)  :: S        !< Salinity [ppt]
   real, dimension(:), intent(in)  :: press    !< Pressure [R L2 T-2 ~> Pa]
@@ -1047,29 +1074,34 @@ subroutine calculate_compress_array(T, S, press, rho, drho_dp, start, npts, EOS)
   real, dimension(:), intent(inout) :: drho_dp  !< The partial derivative of density with pressure
                                                 !! (also the inverse of the square of sound speed)
                                                 !! [T2 L-2 ~> s2 m-2]
-  integer,            intent(in)  :: start    !< Starting index within the array
-  integer,            intent(in)  :: npts     !< The number of values to calculate
   type(EOS_type),     intent(in)  :: EOS      !< Equation of state structure
+  integer, dimension(2), optional, intent(in) :: dom   !< The domain of indices to work on, taking
+                                                       !! into account that arrays start at 1.
 
   ! Local variables
   real, dimension(size(press)) :: pressure  ! Pressure converted to [Pa]
-  integer :: i, is, ie
+  integer :: i, is, ie, npts
 
-  is = start ; ie = is + npts - 1
+  if (present(dom)) then
+    is = dom(1) ; ie = dom(2) ; npts = 1 + ie - is
+  else
+    is = 1 ; ie = size(rho) ; npts = 1 + ie - is
+  endif
+
   do i=is,ie ; pressure(i) = EOS%RL2_T2_to_Pa * press(i) ; enddo
 
   select case (EOS%form_of_EOS)
     case (EOS_LINEAR)
-      call calculate_compress_linear(T, S, pressure, rho, drho_dp, start, npts, &
+      call calculate_compress_linear(T, S, pressure, rho, drho_dp, is, npts, &
                                      EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS)
     case (EOS_UNESCO)
-      call calculate_compress_unesco(T, S, pressure, rho, drho_dp, start, npts)
+      call calculate_compress_unesco(T, S, pressure, rho, drho_dp, is, npts)
     case (EOS_WRIGHT)
-      call calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
+      call calculate_compress_wright(T, S, pressure, rho, drho_dp, is, npts)
     case (EOS_TEOS10)
-      call calculate_compress_teos10(T, S, pressure, rho, drho_dp, start, npts)
+      call calculate_compress_teos10(T, S, pressure, rho, drho_dp, is, npts)
     case (EOS_NEMO)
-      call calculate_compress_nemo(T, S, pressure, rho, drho_dp, start, npts)
+      call calculate_compress_nemo(T, S, pressure, rho, drho_dp, is, npts)
     case default
       call MOM_error(FATAL, "calculate_compress: EOS%form_of_EOS is not valid.")
   end select
@@ -1081,11 +1113,11 @@ subroutine calculate_compress_array(T, S, press, rho, drho_dp, start, npts, EOS)
     drho_dp(i) = EOS%L_T_to_m_s**2 * drho_dp(i)
   enddo ; endif
 
-end subroutine calculate_compress_array
+end subroutine calculate_compress_1d
 
 !> Calculate density and compressibility for a scalar. This just promotes the scalar to an array
-!! with a singleton dimension and calls calculate_compress_array.  If US is present, the units of
-!! the inputs and outputs are rescaled.
+!! with a singleton dimension and calls calculate_compress_1d.  The inputs and outputs use
+!! dimensionally rescaled units.
 subroutine calculate_compress_scalar(T, S, pressure, rho, drho_dp, EOS)
   real, intent(in)        :: T        !< Potential temperature referenced to the surface [degC]
   real, intent(in)        :: S        !< Salinity [ppt]
@@ -1100,7 +1132,7 @@ subroutine calculate_compress_scalar(T, S, pressure, rho, drho_dp, EOS)
 
   Ta(1) = T ; Sa(1) = S; pa(1) = pressure
 
-  call calculate_compress_array(Ta, Sa, pa, rhoa, drho_dpa, 1, 1, EOS)
+  call calculate_compress_1d(Ta, Sa, pa, rhoa, drho_dpa, EOS)
   rho = rhoa(1) ; drho_dp = drho_dpa(1)
 
 end subroutine calculate_compress_scalar

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -855,7 +855,6 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
   ! Local variables
   real, dimension(size(pressure)) :: pres  ! Pressure converted to [Pa]
   real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
-  real :: I_p_scale ! The inverse of the factor to convert pressure to units of Pa [R L2 T-2 Pa-1 ~> 1]
   integer :: i, is, ie, npts
 
   if (present(dom)) then
@@ -905,13 +904,10 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
     drho_dT_dP(i) = rho_scale * drho_dT_dP(i)
   enddo ; endif
 
-  if (EOS%RL2_T2_to_Pa /= 1.0) then
-    I_p_scale = 1.0 / EOS%RL2_T2_to_Pa
-    do i=is,ie
-      drho_dS_dP(i) = I_p_scale * drho_dS_dP(i)
-      drho_dT_dP(i) = I_p_scale * drho_dT_dP(i)
-    enddo
-  endif
+  if (EOS%RL2_T2_to_Pa /= 1.0) then ; do i=is,ie
+    drho_dS_dP(i) = EOS%RL2_T2_to_Pa * drho_dS_dP(i)
+    drho_dT_dP(i) = EOS%RL2_T2_to_Pa * drho_dT_dP(i)
+  enddo ; endif
 
 end subroutine calculate_density_second_derivs_1d
 
@@ -937,7 +933,6 @@ subroutine calculate_density_second_derivs_scalar(T, S, pressure, drho_dS_dS, dr
   ! Local variables
   real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
   real :: p_scale   ! A factor to convert pressure to units of Pa [Pa T2 R-1 L-2 ~> 1]
-  real :: I_p_scale ! The inverse of the factor to convert pressure to units of Pa [R L2 T-2 Pa-1 ~> 1]
 
   p_scale = EOS%RL2_T2_to_Pa
 
@@ -966,9 +961,8 @@ subroutine calculate_density_second_derivs_scalar(T, S, pressure, drho_dS_dS, dr
   endif
 
   if (p_scale /= 1.0) then
-    I_p_scale = 1.0 / p_scale
-    drho_dS_dP = I_p_scale * drho_dS_dP
-    drho_dT_dP = I_p_scale * drho_dT_dP
+    drho_dS_dP = p_scale * drho_dS_dP
+    drho_dT_dP = p_scale * drho_dT_dP
   endif
 
 end subroutine calculate_density_second_derivs_scalar

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -419,17 +419,17 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                         intent(in)  :: z_t      !< Height at the top of the layer in depth units [Z ~> m].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: z_b      !< Height at the top of the layer [Z ~> m].
-  real,                 intent(in)  :: rho_ref  !< A mean density [R ~> kg m-3] or [kg m-3], that is subtracted
+  real,                 intent(in)  :: rho_ref  !< A mean density [R ~> kg m-3], that is subtracted
                                                 !! out to reduce the magnitude of each of the integrals.
                                                 !! (The pressure is calucated as p~=-z*rho_0*G_e.)
-  real,                 intent(in)  :: rho_0    !< Density [R ~> kg m-3] or [kg m-3], that is used
+  real,                 intent(in)  :: rho_0    !< Density [R ~> kg m-3], that is used
                                                 !! to calculate the pressure (as p~=-z*rho_0*G_e)
                                                 !! used in the equation of state.
   real,                 intent(in)  :: G_e      !< The Earth's gravitational acceleration
-                                                !! [L2 Z-1 T-2 ~> m s-2] or [m2 Z-1 s-2 ~> m s-2].
+                                                !! [L2 Z-1 T-2 ~> m s-2].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(inout) :: dpa    !< The change in the pressure anomaly across the
-                                                !! layer [R L2 T-2 ~> Pa] or [Pa].
+                                                !! layer [R L2 T-2 ~> Pa].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(inout) :: intz_dpa !< The integral through the thickness of the layer
                                                 !! of the pressure anomaly relative to the anomaly
@@ -473,9 +473,9 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real :: wt_L, wt_R ! The linear weights of the left and right columns [nondim].
   real :: wtT_L, wtT_R ! The weights for tracers from the left and right columns [nondim].
   real :: intz(5)    ! The gravitational acceleration times the integrals of density
-                     ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa] or [Pa].
+                     ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa].
   real :: Pa_to_RL2_T2 ! A conversion factor of pressures from Pa to the output units indicated by
-                       ! pres_scale [R L2 T-2 Pa-1 ~> 1] or [1].
+                       ! pres_scale [R L2 T-2 Pa-1 ~> 1].
   real :: z0pres     ! The height at which the pressure is zero [Z ~> m]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
   real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants.
@@ -637,37 +637,36 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: S         !< Salinity [PSU].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-                        intent(in)  :: p_t       !< Pressure at the top of the layer [R L2 T-2 ~> Pa] or [Pa].
+                        intent(in)  :: p_t       !< Pressure at the top of the layer [R L2 T-2 ~> Pa]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-                        intent(in)  :: p_b       !< Pressure at the top of the layer [R L2 T-2 ~> Pa] or [Pa].
+                        intent(in)  :: p_b       !< Pressure at the top of the layer [R L2 T-2 ~> Pa]
   real,                 intent(in)  :: spv_ref   !< A mean specific volume that is subtracted out
                             !! to reduce the magnitude of each of the integrals [R-1 ~> m3 kg-1].
                             !! The calculation is mathematically identical with different values of
                             !! spv_ref, but this reduces the effects of roundoff.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(inout) :: dza     !< The change in the geopotential anomaly across
-                                                 !! the layer [T-2 ~> m2 s-2] or [m2 s-2].
+                                                 !! the layer [L2 T-2 ~> m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(inout) :: intp_dza !< The integral in pressure through the layer of
                                                  !! the geopotential anomaly relative to the anomaly
                                                  !! at the bottom of the layer [R L4 T-4 ~> Pa m2 s-2]
-                                                 !! or [Pa m2 s-2].
   real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), &
               optional, intent(inout) :: intx_dza !< The integral in x of the difference between the
                                                  !! geopotential anomaly at the top and bottom of
                                                  !! the layer divided by the x grid spacing
-                                                 !! [L2 T-2 ~> m2 s-2] or [m2 s-2].
+                                                 !! [L2 T-2 ~> m2 s-2].
   real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), &
               optional, intent(inout) :: inty_dza !< The integral in y of the difference between the
                                                  !! geopotential anomaly at the top and bottom of
                                                  !! the layer divided by the y grid spacing
-                                                 !! [L2 T-2 ~> m2 s-2] or [m2 s-2].
+                                                 !! [L2 T-2 ~> m2 s-2].
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate
                                                  !! dza.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-              optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa] or [Pa]
+              optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_neglect !< A miniscule pressure change with
-                                                 !! the same units as p_t [R L2 T-2 ~> Pa] or [Pa]
+                                                 !! the same units as p_t [R L2 T-2 ~> Pa]
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
                             !! to interpolate T/S for top and bottom integrals.
   real,       optional, intent(in)  :: SV_scale  !< A multiplicative factor by which to scale specific

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -336,34 +336,34 @@ subroutine int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0_pres, G_e, HI, &
                         intent(in)  :: z_t       !< Height at the top of the layer in depth units [Z ~> m].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: z_b       !< Height at the top of the layer [Z ~> m].
-  real,                 intent(in)  :: rho_ref   !< A mean density [R ~> kg m-3] or [kg m-3], that
+  real,                 intent(in)  :: rho_ref   !< A mean density [R ~> kg m-3], that
                                                  !! is subtracted out to reduce the magnitude of
                                                  !! each of the integrals.
   real,                 intent(in)  :: rho_0_pres !< A density [R ~> kg m-3], used to calculate
                                                  !! the pressure (as p~=-z*rho_0_pres*G_e) used in
                                                  !! the equation of state. rho_0_pres is not used.
   real,                 intent(in)  :: G_e       !< The Earth's gravitational acceleration
-                                                 !! [L2 Z-1 T-2 ~> m s-2] or [m2 Z-1 s-2 ~> m s-2].
-  real,                 intent(in)  :: Rho_T0_S0 !< The density at T=0, S=0 [R ~> kg m-3] or [kg m-3].
+                                                 !! [L2 Z-1 T-2 ~> m s-2]
+  real,                 intent(in)  :: Rho_T0_S0 !< The density at T=0, S=0 [R ~> kg m-3]
   real,                 intent(in)  :: dRho_dT   !< The derivative of density with temperature,
-                                                 !! [R degC-1 ~> kg m-3 degC-1] or [kg m-3 degC-1].
+                                                 !! [R degC-1 ~> kg m-3 degC-1]
   real,                 intent(in)  :: dRho_dS   !< The derivative of density with salinity,
-                                                 !! in [R ppt-1 ~> kg m-3 ppt-1] or [kg m-3 ppt-1].
+                                                 !! in [R ppt-1 ~> kg m-3 ppt-1]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(out) :: dpa       !< The change in the pressure anomaly across the
-                                                 !! layer [R L2 T-2 ~> Pa] or [Pa].
+                                                 !! layer [R L2 T-2 ~> Pa]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(out) :: intz_dpa  !< The integral through the thickness of the layer
                                                  !! of the pressure anomaly relative to the anomaly
-                                                 !! at the top of the layer [R L2 Z T-2 ~> Pa m] or [Pa m].
+                                                 !! at the top of the layer [R L2 Z T-2 ~> Pa m]
   real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed),  &
               optional, intent(out) :: intx_dpa  !< The integral in x of the difference between the
                                                  !! pressure anomaly at the top and bottom of the
-                                                 !! layer divided by the x grid spacing [R L2 T-2 ~> Pa] or [Pa].
+                                                 !! layer divided by the x grid spacing [R L2 T-2 ~> Pa]
   real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB),  &
               optional, intent(out) :: inty_dpa  !< The integral in y of the difference between the
                                                  !! pressure anomaly at the top and bottom of the
-                                                 !! layer divided by the y grid spacing [R L2 T-2 ~> Pa] or [Pa].
+                                                 !! layer divided by the y grid spacing [R L2 T-2 ~> Pa]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyT    !< The depth of the bathymetry [Z ~> m].
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m].
@@ -382,7 +382,7 @@ subroutine int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0_pres, G_e, HI, &
   real :: wt_L, wt_R ! The linear weights of the left and right columns [nondim].
   real :: wtT_L, wtT_R ! The weights for tracers from the left and right columns [nondim].
   real :: intz(5)    ! The integrals of density with height at the
-                     ! 5 sub-column locations [R L2 T-2 ~> Pa] or [Pa].
+                     ! 5 sub-column locations [R L2 T-2 ~> Pa]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
   real, parameter :: C1_6 = 1.0/6.0, C1_90 = 1.0/90.0  ! Rational constants.
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j, m
@@ -504,56 +504,56 @@ subroutine int_spec_vol_dp_linear(T, S, p_t, p_b, alpha_ref, HI, Rho_T0_S0, &
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  &
                         intent(in)  :: S         !< Salinity [PSU].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  &
-                        intent(in)  :: p_t       !< Pressure at the top of the layer [R L2 T-2 ~> Pa] or [Pa].
+                        intent(in)  :: p_t       !< Pressure at the top of the layer [R L2 T-2 ~> Pa]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  &
-                        intent(in)  :: p_b       !< Pressure at the top of the layer [R L2 T-2 ~> Pa] or [Pa].
+                        intent(in)  :: p_b       !< Pressure at the top of the layer [R L2 T-2 ~> Pa]
   real,                 intent(in)  :: alpha_ref   !< A mean specific volume that is subtracted out
                             !! to reduce the magnitude of each of the integrals [R-1 ~> m3 kg-1].
                             !! The calculation is mathematically identical with different values of
                             !! alpha_ref, but this reduces the effects of roundoff.
-  real,                 intent(in)  :: Rho_T0_S0 !< The density at T=0, S=0 [R ~> kg m-3] or [kg m-3].
+  real,                 intent(in)  :: Rho_T0_S0 !< The density at T=0, S=0 [R ~> kg m-3]
   real,                 intent(in)  :: dRho_dT   !< The derivative of density with temperature
-                                                 !! [R degC-1 ~> kg m-3 degC-1] or [kg m-3 degC-1].
+                                                 !! [R degC-1 ~> kg m-3 degC-1]
   real,                 intent(in)  :: dRho_dS   !< The derivative of density with salinity,
-                                                 !! in [R ppt-1 ~> kg m-3 ppt-1] or [kg m-3 ppt-1].
+                                                 !! in [R ppt-1 ~> kg m-3 ppt-1]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(out) :: dza       !< The change in the geopotential anomaly across
-                                                 !! the layer [L2 T-2 ~> m2 s-2] or [m2 s-2].
+                                                 !! the layer [L2 T-2 ~> m2 s-2]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(out) :: intp_dza  !< The integral in pressure through the layer of the
                                                  !! geopotential anomaly relative to the anomaly at the
-                                                 !! bottom of the layer [R L4 T-4 ~> Pa m2 s-2] or [Pa m2 s-2].
+                                                 !! bottom of the layer [R L4 T-4 ~> Pa m2 s-2]
   real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), &
               optional, intent(out) :: intx_dza  !< The integral in x of the difference between the
                                                  !! geopotential anomaly at the top and bottom of
                                                  !! the layer divided by the x grid spacing
-                                                 !! [L2 T-2 ~> m2 s-2] or [m2 s-2].
+                                                 !! [L2 T-2 ~> m2 s-2]
   real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), &
               optional, intent(out) :: inty_dza  !< The integral in y of the difference between the
                                                  !! geopotential anomaly at the top and bottom of
                                                  !! the layer divided by the y grid spacing
-                                                 !! [L2 T-2 ~> m2 s-2] or [m2 s-2].
+                                                 !! [L2 T-2 ~> m2 s-2]
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate dza.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-              optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa] or [Pa]
+              optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_neglect !< A miniscule pressure change with
-                                                 !! the same units as p_t [R L2 T-2 ~> Pa] or [Pa]
+                                                 !! the same units as p_t [R L2 T-2 ~> Pa]
   logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
                             !! to interpolate T/S for top and bottom integrals.
   ! Local variables
-  real :: dRho_TS       ! The density anomaly due to T and S [R ~> kg m-3] or [kg m-3].
-  real :: alpha_anom    ! The specific volume anomaly from 1/rho_ref [R-1 ~> m3 kg-1] or [m3 kg-1].
-  real :: aaL, aaR      ! The specific volume anomaly to the left and right [R-1 ~> m3 kg-1] or [m3 kg-1].
-  real :: dp, dpL, dpR  ! Layer pressure thicknesses [R L2 T-2 ~> Pa] or [Pa].
-  real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa] or [Pa].
-  real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [R L2 T-2 ~> Pa] or [Pa].
-  real :: iDenom     ! The inverse of the denominator in the weights [T4 R-2 L-4 ~> Pa-2] or [Pa-2].
+  real :: dRho_TS       ! The density anomaly due to T and S [R ~> kg m-3]
+  real :: alpha_anom    ! The specific volume anomaly from 1/rho_ref [R-1 ~> m3 kg-1]
+  real :: aaL, aaR      ! The specific volume anomaly to the left and right [R-1 ~> m3 kg-1]
+  real :: dp, dpL, dpR  ! Layer pressure thicknesses [R L2 T-2 ~> Pa]
+  real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa]
+  real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [R L2 T-2 ~> Pa]
+  real :: iDenom     ! The inverse of the denominator in the weights [T4 R-2 L-4 ~> Pa-2]
   real :: hWt_LL, hWt_LR ! hWt_LA is the weighted influence of A on the left column [nondim].
   real :: hWt_RL, hWt_RR ! hWt_RA is the weighted influence of A on the right column [nondim].
   real :: wt_L, wt_R ! The linear weights of the left and right columns [nondim].
   real :: wtT_L, wtT_R ! The weights for tracers from the left and right columns [nondim].
   real :: intp(5)    ! The integrals of specific volume with pressure at the
-                     ! 5 sub-column locations [L2 T-2 ~> m2 s-2] or [m2 s-2].
+                     ! 5 sub-column locations [L2 T-2 ~> m2 s-2]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
   real, parameter :: C1_6 = 1.0/6.0, C1_90 = 1.0/90.0  ! Rational constants.
   integer :: Isq, Ieq, Jsq, Jeq, ish, ieh, jsh, jeh, i, j, m, halo

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -858,8 +858,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
         ! The second line below would correspond to arguments
         !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
         call calculate_density_second_derivs(T_u, S_u, pres_u, &
-                     scrap, scrap, drho_dT_dT_u, scrap, scrap, &
-                     (is-IsdB+1)-1, ie-is+2, tv%eqn_of_state)
+                     scrap, scrap, drho_dT_dT_u, scrap, scrap, tv%eqn_of_state, EOSdom_u)
       endif
 
       do I=is-1,ie
@@ -1125,8 +1124,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
         ! The second line below would correspond to arguments
         !            drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, &
         call calculate_density_second_derivs(T_v, S_v, pres_v, &
-                     scrap, scrap, drho_dT_dT_v, scrap, scrap, &
-                     is, ie-is+1, tv%eqn_of_state)
+                     scrap, scrap, drho_dT_dT_v, scrap, scrap, tv%eqn_of_state, EOSdom_v)
       endif
       do i=is,ie
         if (calc_derivatives) then

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -8,7 +8,6 @@ module MOM_bkgnd_mixing
 use MOM_debugging,       only : hchksum
 use MOM_diag_mediator,   only : diag_ctrl, time_type, register_diag_field
 use MOM_diag_mediator,   only : post_data
-use MOM_EOS,             only : calculate_density, calculate_density_derivs
 use MOM_error_handler,   only : MOM_error, FATAL, WARNING, NOTE
 use MOM_file_parser,     only : get_param, log_version, param_file_type
 use MOM_file_parser,     only : openParameterBlock, closeParameterBlock

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -171,7 +171,7 @@ type, public :: diabatic_CS ; private
   real    :: MLDdensityDifference    !< Density difference used to determine MLD_user [R ~> kg m-3]
   real    :: dz_subML_N2             !< The distance over which to calculate a diagnostic of the
                                      !! average stratification at the base of the mixed layer [Z ~> m].
-  real    :: MLD_EN_VALS(3)          !< Energy values for energy mixed layer diagnostics
+  real    :: MLD_EN_VALS(3)          !< Energy values for energy mixed layer diagnostics [R Z L2 T-2 ~> J m-2]
 
   !>@{ Diagnostic IDs
   integer :: id_cg1      = -1                 ! diag handle for mode-1 speed

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -19,7 +19,7 @@ use MOM_time_manager,     only : time_type, set_time, operator(+), operator(<=)
 use MOM_unit_scaling,     only : unit_scale_type
 use MOM_variables,        only : thermo_var_ptrs, vertvisc_type, p3d
 use MOM_verticalGrid,     only : verticalGrid_type
-use MOM_EOS,              only : calculate_density, calculate_density_derivs, EOS_domain
+use MOM_EOS,              only : calculate_density_derivs, EOS_domain
 
 implicit none ; private
 

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -13,7 +13,7 @@ use MOM_grid, only : ocean_grid_type
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_domain
+use MOM_EOS, only : calculate_density, EOS_domain
 
 implicit none ; private
 
@@ -227,8 +227,6 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
   !$OMP                                     e,I_dtol,h,tv,debug,h_neglect,p_ref_cv,ea, &
   !$OMP                                     eb,nkml,EOSdom)
   do j=js,je ; if (do_j(j)) then
-
-!  call calculate_density_derivs(T(:,1), S(:,1), p_ref_cv, dRcv_dT, dRcv_dS, tv%eqn_of_state, EOSdom)
 
     do k=1,nz ; do i=is,ie ; d_ea(i,k) = 0.0 ; d_eb(i,k) = 0.0 ; enddo ; enddo
     kmax_d_ea = 0

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -6,7 +6,6 @@ module MOM_tidal_mixing
 use MOM_diag_mediator,      only : diag_ctrl, time_type, register_diag_field
 use MOM_diag_mediator,      only : safe_alloc_ptr, post_data
 use MOM_debugging,          only : hchksum
-use MOM_EOS,                only : calculate_density
 use MOM_error_handler,      only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_file_parser,        only : openParameterBlock, closeParameterBlock
 use MOM_file_parser,        only : get_param, log_param, log_version, param_file_type

--- a/src/user/BFB_initialization.F90
+++ b/src/user/BFB_initialization.F90
@@ -11,7 +11,6 @@ use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use MOM_verticalGrid, only : verticalGrid_type
 implicit none ; private
 

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -13,7 +13,6 @@ use MOM_sponge, only : sponge_CS, set_up_sponge_field, initialize_sponge
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE
 use regrid_consts, only : REGRIDDING_LAYER, REGRIDDING_ZSTAR
 use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -17,7 +17,7 @@ use MOM_tracer_registry, only : tracer_name_lookup
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
+use MOM_EOS, only : calculate_density, calculate_density_derivs
 
 implicit none ; private
 

--- a/src/user/Neverworld_initialization.F90
+++ b/src/user/Neverworld_initialization.F90
@@ -13,7 +13,6 @@ use MOM_tracer_registry, only : tracer_registry_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 
 use random_numbers_mod, only: initializeRandomNumberStream, getRandomNumbers, randomNumberStream
 

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -13,7 +13,6 @@ use MOM_tracer_registry, only : tracer_registry_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 
 implicit none ; private
 

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -21,7 +21,7 @@ use MOM_sponge, only : set_up_sponge_ML_density
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type, EOS_domain
+use MOM_EOS, only : calculate_density, EOS_domain
 implicit none ; private
 
 #include <MOM_memory.h>

--- a/src/user/Rossby_front_2d_initialization.F90
+++ b/src/user/Rossby_front_2d_initialization.F90
@@ -10,7 +10,6 @@ use MOM_grid, only : ocean_grid_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE
 use regrid_consts, only : REGRIDDING_LAYER, REGRIDDING_ZSTAR
 use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -10,7 +10,6 @@ use MOM_grid, only : ocean_grid_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE
 use regrid_consts, only : REGRIDDING_LAYER, REGRIDDING_ZSTAR
 use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -12,7 +12,6 @@ use MOM_grid, only : ocean_grid_type
 use MOM_tracer_registry, only : tracer_registry_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 
 implicit none ; private
 

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -14,7 +14,6 @@ use MOM_tracer_registry, only : tracer_registry_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE
 use regrid_consts, only : REGRIDDING_LAYER, REGRIDDING_ZSTAR
 use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -14,7 +14,6 @@ use MOM_tracer_registry, only : tracer_registry_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE
 use regrid_consts, only : REGRIDDING_LAYER, REGRIDDING_ZSTAR
 use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -14,7 +14,6 @@ use MOM_tracer_registry, only : tracer_registry_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 
 implicit none ; private
 

--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -10,7 +10,6 @@ use MOM_grid, only : ocean_grid_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
 use regrid_consts, only : coordinateMode, DEFAULT_COORDINATE_MODE
 use regrid_consts, only : REGRIDDING_LAYER, REGRIDDING_ZSTAR
 use regrid_consts, only : REGRIDDING_RHO, REGRIDDING_SIGMA

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -16,7 +16,7 @@ use MOM_tracer_registry, only : tracer_registry_type
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs, EOS_type
+
 implicit none ; private
 
 #include <MOM_memory.h>


### PR DESCRIPTION
  This PR includes a series of commits that standardize some of the less-used
interfaces or arguments to the MOM6 equation of state routines and how they are
used in a few places.  There is a particular emphasis on the consistency of
which routines use rescaled variables or MKS variables, so that essentially all
of the dimensional rescaling related to the equation of state now occurs inside
of the routines in MOM_EOS.F90.  By design, there is not expected to be any
noticeable performance impact.  The vast majority of calls to the equation of
state routines are unaltered.  All answers in test cases are bitwise identical,
but there are a few (probably untested) places where the rescaled units of some
arguments are corrected.

  Changes of note include:

 - Refactored MOM_density_integrals to use the newer calculate_density_1d() and
   calculated_stanley_density_1d() interfaces to the equation of state routines,
   and to thereby shift all related dimensional rescaling into MOM_EOS.F90.

 - Revised the calculation of the drho_dT and drho_dS diagnostics to use
   dimensional consistency testing, along with the newer interface to
   calculate_density_1d

 - Added calculate_TFreeze_1d to the overloaded interface calculate_TFreeze,
   with dimensional rescaling of its arguments taken from its EOS_type argument
   and an optional two-element domain, rather than two mandatory integer
   arguments used with calculate_TFreeze_array.  The older interface is also
   retained within the overloaded interface to calculate_TFreeze.

 - Modified calculate_density_scalar and calculate_stanley_density_scalar to use
   units of [R ~> kg m-3] for its rho_ref optional argument, following the
   pattern from calculate_density_1d.  These arguments were not previously used.

 - Renamed the internally visible routine calculate_density_second_derivs_array
   to calculate_density_second_derivs_1d and changed its argument list to take
   an optional two-element domain, rather than two mandatory integer arguments,
   to follow the pattern set by calculate_density_derivs_1d.  Because this
   routine was only being called in two places the older interface is not being
   preserved in the overloaded interface calculate_density_second_derivs.

 - Renamed the internally visible routine calculate_compress_array
   to calculate_compress_1d and changed its argument list to take
   an optional two-element domain, rather than two mandatory integer arguments,
   to follow the pattern set by calculate_density_derivs_1d.  Because this
   routine was only being called in one place the older interface is not being
   preserved in the overloaded interface calculate_compress.

 - Eliminated some unnecessary local variables (mostly p_scale) for brevity and
   code clarity.

 - Modified two calls to calculate_density_second_derivs in
   thickness_diffuse_full to use its revised interface.

 - Modified one call to calculate_compress in build_slight_column to use
   its revised interface.

 - Made the description of units more precise in numerous comments describing
   the equation of state calls.

 - Eliminated numerous unused module use statements for EOS routines

  The commits in this commit include:

- NOAA-GFDL/MOM6@0903609a6 +Make equation of state interfaces more consistent
- NOAA-GFDL/MOM6@f51355476 Clarify argument units for int_density_dz_wright
- NOAA-GFDL/MOM6@75ebb4090 +Refactored MOM_density_integrals
- NOAA-GFDL/MOM6@3a9d51163 Revise how the drho_dT diagnostic is calculated
- NOAA-GFDL/MOM6@07df0bfd7 Clarify units for equation of state arguments
- NOAA-GFDL/MOM6@9c2e57310 Document variables in diagnoseMLDbyEnergy
- NOAA-GFDL/MOM6@548be25b5 Remove unused module use for calculate_density
