### PR TITLE
Fix bugs in output files with rescaled heights

### DIFF
--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -1357,7 +1357,7 @@ subroutine get_depth_list_checksums(G, US, depth_chksum, area_chksum)
 
   ! Depth checksum
   do j=G%jsc,G%jec ; do i=G%isc,G%iec
-    field(i,j) = G%bathyT(i,j) + G%Z_ref
+    field(i,j) = US%Z_to_m*(G%bathyT(i,j) + G%Z_ref)
   enddo ; enddo
   write(depth_chksum, '(Z16)') field_chksum(field(:,:))
 

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -217,7 +217,7 @@ subroutine diag_remap_configure_axes(remap_cs, GV, US, param_file)
   allocate(interfaces(remap_cs%nz+1))
   allocate(layers(remap_cs%nz))
 
-  interfaces(:) = getCoordinateInterfaces(remap_cs%regrid_cs)
+  interfaces(:) = getCoordinateInterfaces(remap_cs%regrid_cs, undo_scaling=.true.)
   layers(:) = 0.5 * ( interfaces(1:remap_cs%nz) + interfaces(2:remap_cs%nz+1) )
 
   remap_cs%interface_axes_id = MOM_diag_axis_init(lowercase(trim(remap_cs%diag_coord_name))//'_i', &


### PR DESCRIPTION
  Fixed two minor bugs in the MOM6 output when run with Z_RESCALE_POWER not
equal to 0.  All solutions are bitwise identical, but some of the diagnostic
output files have minor changes.  With these corrections, several output files
are now unaltered by internal dimensional rescaling.  The specific bug fixes
are:

 - Avoid using a rescaled depth as the vertical coordinate label in z-space
   output files.  Only the coordinate label is impacted, but this bug fix avoids
   the chance of having silly values for this coordinate.

 - Rescale the depths back to mks units before taking their checksum for storage
   in the MOM_sum_output file.  With this bug, the depth list file might be
   unnecessarily recreated with a new run with different scaling, but the file
   itself is fine.