### PR TITLE
Fix a rescaling bug with MEKE_EQUILIBRIUM_ALT

### DIFF
--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -721,7 +721,7 @@ subroutine MEKE_equilibrium(CS, MEKE, G, GV, US, SN_u, SN_v, drag_rate_visc, I_m
     SN = min(SN_u(I,j), SN_u(I-1,j), SN_v(i,J), SN_v(i,J-1))
 
     if (CS%MEKE_equilibrium_alt) then
-      MEKE%MEKE(i,j) = (CS%MEKE_GEOMETRIC_alpha * SN * US%Z_to_m*depth_tot(i,j))**2 / cd2
+      MEKE%MEKE(i,j) = (CS%MEKE_GEOMETRIC_alpha * SN * US%Z_to_L*depth_tot(i,j))**2 / cd2
     else
       FatH = 0.25*((G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J-1)) + &
                    (G%CoriolisBu(I-1,J) + G%CoriolisBu(I,J-1))) ! Coriolis parameter at h points


### PR DESCRIPTION
  Corrected a bug in a dimensional rescaling factor that will cause test cases
using MEKE with MEKE_EQUILIBRIUM_ALT = True to fail dimensional consistency
testing.  However, answers are unchanged when no rescaling is used.  This minor
bug has been in the code since the MEKE_EQUILIBRIUM_ALT was first introduced in
2019.  All answers in the existing MOM6-examples test suite are bitwise
identical.