### PR TITLE
Fixes badge for doc build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Read The Docs Status](https://readthedocs.org/projects/mom6/badge/?badge=latest)](http://mom6.readthedocs.io/)
+[![Read The Docs Status](https://readthedocs.org/projects/mom6/badge/?version=main)](https://mom6.readthedocs.io/en/main/?badge=main)
 [![codecov](https://codecov.io/gh/NOAA-GFDL/MOM6/branch/dev/gfdl/graph/badge.svg?token=uF8SVydCdp)](https://codecov.io/gh/NOAA-GFDL/MOM6)
 
 # MOM6


### PR DESCRIPTION
- url was pointing to "latest" which is not a version. Pointing to "main" instead.