### PR TITLE
+Clean up dimensional rescaling in OBC code

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -602,7 +602,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
 
   ! This controls user code for setting open boundary data
   if (associated(OBC)) then
-    call initialize_segment_data(G, OBC, PF) !   call initialize_segment_data(G, OBC, param_file)
+    call initialize_segment_data(G, GV, US, OBC, PF)
 !     call open_boundary_config(G, US, PF, OBC)
     ! Call this once to fill boundary arrays from fixed values
     if (.not. OBC%needs_IO_for_data)  &

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -390,9 +390,8 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, US, param_file, tr_Reg)
     ! Temperature is tracer 1 for the OBCs.
     allocate(segment%field(1)%buffer_src(segment%HI%isd:segment%HI%ied,segment%HI%JsdB:segment%HI%JedB,nz))
     do k=1,nz ; do J=JsdB,JedB ; do i=isd,ied
-      ! Because of the challenges in rescaling the data as it is being read in when using certain
-      ! modes, buffer_src keeps the data in unscaled (mks) units.  They will be rescaled later.
-      segment%field(1)%buffer_src(i,j,k) = US%C_to_degC*T0(k)
+      ! With the revised OBC code, buffer_src uses the same rescaled units as for tracers.
+      segment%field(1)%buffer_src(i,j,k) = T0(k)
     enddo ; enddo ; enddo
     name = 'temp'
     call tracer_name_lookup(tr_Reg, tr_ptr, name)


### PR DESCRIPTION
  Use the new scale argument to time_interp_external to standardize where the
dimensional rescaling occurs for the OBC code, and to use properly dimensionally
rescaled internal variables.  This includes the addition of the new function
scale_factor_from_name, and there are new verticalGrid_type and unit_scale_type
arguments to initialize_segment_data.  All answers are bitwise identical and
are passing dimensional consistency testing, including in Alex Bozec's Gulf of
Mexico regional configuration, but there are new arguments to public interfaces.