### PR TITLE
Re-factored GFDL gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,34 +1,69 @@
 stages:
+  - setup
   - builds
   - run
   - tests
   - cleanup
 
+# JOB_DIR points to a persistent working space used for most stages in this pipeline but
+# it is unique to this pipeline.
+# We use the "fetch" strategy to speed up the startup of stages
 variables:
-  CACHE_DIR: "/lustre/f2/scratch/oar.gfdl.ogrp-account/runner/cache/"
+  JOB_DIR: "/lustre/f2/scratch/oar.gfdl.ogrp-account/runner/builds/$CI_PIPELINE_ID"
+  GIT_STRATEGY: fetch
 
-
-# Merges MOM6 with dev/gfdl. Changes directory to test directory, if it exists.
-# - set cache location
-# - get MOM6-examples/tools/MRS scripts by cloning Gaea-stats and then MOM6-examples
-# - set working directory to MOM6-examples
-# - pull down latest of dev/gfdl (MOM6-examples might be ahead of Gaea-stats)
+# Start all stages in $JOB_DIR/.../MOM6-examples
+# Exception: for "setup" stages MOM6-examples has not yet been cloned so the stage starts in $JOB_DIR
 before_script:
-  - echo Cache directory set to $CACHE_DIR
-  - echo -e "\e[0Ksection_start:`date +%s`:before[collapsed=true]\r\e[0KPre-script"
-  - git clone https://gitlab.gfdl.noaa.gov/ogrp/Gaea-stats-MOM6-examples.git tests
-  - cd tests && git submodule init && git submodule update
-  - cd MOM6-examples && git checkout dev/gfdl && git pull
-  - echo -e "\e[0Ksection_end:`date +%s`:before\r\e[0K"
+  - echo -e "\e[0Ksection_start:`date +%s`:dir_stuff[collapsed=true]\r\e[0KChanging directories to $JOB_DIR"
+  - echo Job directory set to $JOB_DIR
+  - mkdir -p $JOB_DIR
+  - cd $JOB_DIR
+  - test -d Gaea-stats-MOM6-examples/MOM6-examples && cd Gaea-stats-MOM6-examples/MOM6-examples
+  - pwd
+  - echo -e "\e[0Ksection_end:`date +%s`:dir_stuff\r\e[0K"
 
-# Tests that merge with dev/gfdl works.
+# Test that merge with dev/gfdl works.
 merge:
-  stage: builds
+  stage: setup
   tags:
     - ncrc4
   script:
     - cd $CI_PROJECT_DIR
     - git pull --no-edit https://github.com/NOAA-GFDL/MOM6.git dev/gfdl
+
+# Setup the persistent JOB_DIR for all subsequent stages
+clone:
+  stage: setup
+  tags:
+    - ncrc4
+  before_script:
+    - echo -e "\e[0Ksection_start:`date +%s`:dir_stuff[collapsed=true]\r\e[0KChanging directories to $JOB_DIR"
+    - cd $CI_PROJECT_DIR
+    - git submodule init ; git submodule update
+    - echo Job directory set to $JOB_DIR
+    - mkdir -p $JOB_DIR
+    - cd $JOB_DIR
+    - test -d Gaea-stats-MOM6-examples && rm -rf Gaea-stats-MOM6-examples # In case we are re-running this stage
+    - pwd
+    - echo -e "\e[0Ksection_end:`date +%s`:dir_stuff\r\e[0K"
+  script:
+    - echo -e "\e[0Ksection_start:`date +%s`:clone[collapsed=true]\r\e[0KCloning repository tree"
+    - git clone https://gitlab.gfdl.noaa.gov/ogrp/Gaea-stats-MOM6-examples.git
+    - cd Gaea-stats-MOM6-examples
+    - git submodule init
+    - git submodule update
+    - cd MOM6-examples
+    - git checkout dev/gfdl
+    - git submodule init
+    - git submodule deinit src/MOM6 # No need to clone the version recorded in MOM6-examples
+    - git submodule update --recursive
+    - make -f tools/MRS/Makefile.clone clone_gfdl # Extras and link to datasets
+    - bash tools/MRS/generate_manifest.sh . tools/MRS/excluded-expts.txt > manifest.mk
+    - cd src
+    - rm -rf MOM6
+    - cp -rp $CI_PROJECT_DIR MOM6
+    - echo -e "\e[0Ksection_end:`date +%s`:clone\r\e[0K"
 
 # Compiles
 gnu:repro:
@@ -36,51 +71,85 @@ gnu:repro:
   tags:
     - ncrc4
   script:
-    - time make -f tools/MRS/Makefile MOM6_SRC=../.. pipeline-build-repro-gnu -s -j
-    - time make -f tools/MRS/Makefile MOM6_SRC=../.. pipeline-build-static-gnu -s -j
-
-gnu:ocean-only-nolibs:
-  stage: builds
-  tags:
-    - ncrc4
-  script:
-    - make -f tools/MRS/Makefile MOM6_SRC=../.. pipeline-build-gnu-oceanonly-nolibs
-
-gnu:ice-ocean-nolibs:
-  stage: builds
-  tags:
-    - ncrc4
-  script:
-    - make -f tools/MRS/Makefile MOM6_SRC=../.. pipeline-build-gnu-iceocean-nolibs
-
-intel:repro:
-  stage: builds
-  tags:
-    - ncrc4
-  script:
-    - time make -f tools/MRS/Makefile MOM6_SRC=../.. pipeline-build-repro-intel -s -j
-
-pgi:repro:
-  stage: builds
-  tags:
-    - ncrc4
-  script:
-    - time make -f tools/MRS/Makefile MOM6_SRC=../.. pipeline-build-repro-pgi -s -j
+    - echo -e "\e[0Ksection_start:`date +%s`:compile[collapsed=true]\r\e[0KCompiling target repro_gnu"
+    - time make -f tools/MRS/Makefile.build repro_gnu -s -j
+    - echo -e "\e[0Ksection_end:`date +%s`:compile\r\e[0K"
+    - echo -e "\e[0Ksection_start:`date +%s`:compile2[collapsed=true]\r\e[0KCompiling target static_gnu"
+    - time make -f tools/MRS/Makefile.build static_gnu -s -j
+    - echo -e "\e[0Ksection_end:`date +%s`:compile2\r\e[0K"
 
 gnu:debug:
   stage: builds
   tags:
     - ncrc4
   script:
-    - time make -f tools/MRS/Makefile MOM6_SRC=../.. pipeline-build-debug-gnu -s -j
+    - echo -e "\e[0Ksection_start:`date +%s`:compile2[collapsed=true]\r\e[0KCompiling target debug_gnu"
+    - time make -f tools/MRS/Makefile.build debug_gnu -s -j
+    - echo -e "\e[0Ksection_end:`date +%s`:compile\r\e[0K"
+
+gnu:ocean-only-nolibs:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - echo -e "\e[0Ksection_start:`date +%s`:compile[collapsed=true]\r\e[0KCompiling target gnu ocean-only no-libs"
+    - mkdir -p build-ocean-only-nolibs
+    - cd build-ocean-only-nolibs
+    - make -f ../tools/MRS/Makefile.build ./gnu/env BUILD=. -s
+    - ../src/mkmf/bin/list_paths -l ../src/MOM6/config_src/{drivers/solo_driver,memory/dynamic_symmetric,infra/FMS1,ext*} ../src/MOM6/src ../src/FMS1
+    - sed -i '/FMS1\/.*\/test_/d' path_names
+    - ../src/mkmf/bin/mkmf -t ../src/mkmf/templates/ncrc-gnu.mk -p MOM6 -c"-Duse_libMPI -Duse_netCDF" path_names
+    - (source gnu/env ; make NETCDF=3 REPRO=1 MOM6 -s -j)
+    - echo -e "\e[0Ksection_end:`date +%s`:compile\r\e[0K"
+
+gnu:ice-ocean-nolibs:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - echo -e "\e[0Ksection_start:`date +%s`:compile[collapsed=true]\r\e[0KCompiling target gnu ice-ocean-SIS2 no-libs"
+    - mkdir -p build-ice-ocean-SIS2-nolibs
+    - cd build-ice-ocean-SIS2-nolibs
+    - make -f ../tools/MRS/Makefile.build ./gnu/env BUILD=. -s
+    - ../src/mkmf/bin/list_paths -l ../src/MOM6/config_src/{drivers/FMS_cap,memory/dynamic_symmetric,infra/FMS1,ext*} ../src/MOM6/src ../src/SIS2/*src ../src/{FMS1,coupler,icebergs,ice_param,land_null,atmos_null}
+    - sed -i '/FMS1\/.*\/test_/d' path_names
+    - ../src/mkmf/bin/mkmf -t ../src/mkmf/templates/ncrc-gnu.mk -p MOM6 -c"-Duse_libMPI -Duse_netCDF -D_USE_LEGACY_LAND_ -Duse_AM3_physics" path_names
+    - (source gnu/env ; make NETCDF=3 REPRO=1 MOM6 -s -j)
+    - echo -e "\e[0Ksection_end:`date +%s`:compile\r\e[0K"
+
+intel:repro:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - echo -e "\e[0Ksection_start:`date +%s`:compile[collapsed=true]\r\e[0KCompiling target repro_intel"
+    - time make -f tools/MRS/Makefile.build repro_intel -s -j
+    - echo -e "\e[0Ksection_end:`date +%s`:compile\r\e[0K"
+
+pgi:repro:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - echo -e "\e[0Ksection_start:`date +%s`:compile[collapsed=true]\r\e[0KCompiling target repro_pgi"
+    - time make -f tools/MRS/Makefile.build repro_pgi -s -j
+    - echo -e "\e[0Ksection_end:`date +%s`:compile\r\e[0K"
 
 # Runs
+# 
+# The main "run" stage uses the script .gitlab/mom6-ci-run-script.sh
+
 run:
   stage: run
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-run
+    - sbatch --clusters=c3,c4 --nodes=30 --time=1:00:00 --account=gfdl_o --qos=debug --job-name=mom6_examples_tests --output=log.$CI_PIPELINE_ID --wait src/MOM6/.gitlab/mom6-ci-run-script.sh && ( egrep -v 'pagefaults|HiWaterMark=' log.$CI_PIPELINE_ID ; echo Job returned normally ) || ( cat log.$CI_PIPELINE_ID ; echo Job failed ; exit 911 )
+    - test -f .CI-BATCH-SUCCESS || ( echo Batch job did not complete ; exit 911 )
+    - git checkout . # reset working space so we can use it to compare against
+
+# These "run" stages replace the "before_script" and so start in the transient work-space provided by gitlab
+# We work here to avoid collisions with parallel jobs
 
 gnu.testing:
   stage: run
@@ -119,47 +188,65 @@ intel.testing:
     - sbatch --clusters=c3,c4 --nodes=5 --time=0:05:00 --account=gfdl_o --qos=debug --job-name=MOM6.gnu.testing --output=log.$CI_PIPELINE_ID --wait job.sh && make test || cat log.$CI_PIPELINE_ID
 
 # Tests
-gnu:non-symmetric:
-  stage: tests
-  tags:
-    - ncrc4
-  script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-gnu_non_symmetric
+#
+# stats file tests involve comparing the check sums of the generated files against the check sums in the stats-repo
+# log file tests involve comparing the check sums of the generated files against the check sums in MOM6-examples
 
 gnu:symmetric:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-gnu_symmetric
+    - tar --one-top-level -xf gnu_all_sym.tar
+    - ( cd gnu_all_sym/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
 
-gnu:memory:
+gnu:non-symmetric:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-gnu_memory
+    - tar --one-top-level -xf gnu_all_nonsym.tar
+    - ( cd gnu_all_nonsym/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
+
+gnu:layout:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - tar --one-top-level -xf gnu_all_layout.tar
+    - ( cd gnu_all_layout/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
 
 gnu:static:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-gnu_static
+    - tar --one-top-level -xf gnu_all_static.tar
+    - ( cd gnu_all_static/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
+
+gnu:debugx:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - tar --one-top-level -xf gnu_ocean_only_debug.tar
+    - ( cd gnu_ocean_only_debug/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
 
 gnu:restart:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-gnu_restarts
+    - tar xf gnu_restarts.tar # NOTE this unpacks in MOM6-examples (not a new directory)
+    - make -f tools/MRS/Makefile.restart restart_gnu_ocean_only restart_gnu_ice_ocean_SIS2 -s -k
 
 gnu:params:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-params_gnu_symmetric
+    - tar --one-top-level -xf gnu_params.tar
+    - ( cd gnu_params/ ; md5sum `find * -type f` ) | md5sum -c
   allow_failure: true
 
 intel:symmetric:
@@ -167,48 +254,73 @@ intel:symmetric:
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-intel_symmetric
+    - tar --one-top-level -xf intel_all_sym.tar
+    - ( cd intel_all_sym/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
 
 intel:non-symmetric:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-intel_non_symmetric
+    - tar --one-top-level -xf intel_all_nonsym.tar
+    - ( cd intel_all_nonsym/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
 
-intel:memory:
+intel:layout:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-intel_memory
+    - tar --one-top-level -xf intel_all_layout.tar
+    - ( cd intel_all_layout/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
+
+intel:params:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - tar --one-top-level -xf intel_params.tar
+    - ( cd intel_params/ ; md5sum `find * -type f` ) | md5sum -c
+  allow_failure: true
 
 pgi:symmetric:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-pgi_symmetric
+    - tar --one-top-level -xf pgi_all_sym.tar
+    - ( cd pgi_all_sym/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
 
 pgi:non-symmetric:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-pgi_non_symmetric
+    - tar --one-top-level -xf pgi_all_nonsym.tar
+    - ( cd pgi_all_nonsym/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
 
-pgi:memory:
+pgi:layout:
   stage: tests
   tags:
     - ncrc4
   script:
-    - make -f tools/MRS/Makefile mom6-pipeline-test-pgi_memory
+    - tar --one-top-level -xf pgi_all_layout.tar
+    - ( cd pgi_all_layout/ ; md5sum `find * -type f` ) | ( cd ../regressions/ ; md5sum -c )
 
+pgi:params:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - tar --one-top-level -xf pgi_params.tar
+    - ( cd pgi_params/ ; md5sum `find * -type f` ) | md5sum -c
+  allow_failure: true
+
+# We cleanup ONLY if the preceding stages were completed successfully
 cleanup:
   stage: cleanup
   tags:
     - ncrc4
   before_script:
-    - echo Skipping submodule update
+    - echo Skipping usual preamble
   script:
-    - rm $CACHE_DIR/*$CI_PIPELINE_ID.tgz
+    - rm -rf $JOB_DIR

--- a/.gitlab/mom6-ci-run-script.sh
+++ b/.gitlab/mom6-ci-run-script.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+sect=none
+clean_stats () { # fn to clean up stats files
+  find [oicl]* -name "*.stats.*[a-z][a-z][a-z]" -delete
+}
+section_start () { # fn to print fold-able banner in CI
+  echo -e "\e[0Ksection_start:`date +%s`:$1[collapsed=true]\r\e[0K$2"
+  sect=$1
+}
+section_end () { # fn to close fold-able banner in CI and clean up stats
+  echo -e "\e[0Ksection_end:`date +%s`:$sect\r\e[0K"
+  clean_stats
+}
+check_for_core_files () {
+  EXIT_CODE=0
+  find [oilc]* -name core | grep . && EXIT_CODE=1
+  if [[ $EXIT_CODE -gt 0 ]]
+  then
+    echo "Error: core files found!"
+    exit 911
+  fi
+}
+
+# Make sure we have a clean start
+clean_stats
+find [oilc]* -name core -delete
+rm -f .CI-BATCH-SUCCESS
+
+set -e
+set -v
+
+# Run symmetric gnu regressions
+section_start gnu_all_sym "Running symmetric gnu"
+time make -f tools/MRS/Makefile.run gnu_all -s -j
+tar cf gnu_all_sym.tar `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"`
+tar cf gnu_params.tar `find [oicl]* -name "*_parameter_doc.*"`
+check_for_core_files
+section_end
+
+# Run non-symmetric gnu regressions
+section_start gnu_all_nonsym "Running nonsymmetric gnu"
+time make -f tools/MRS/Makefile.run ocean_only/circle_obcs/ocean.stats.gnu -s # work around
+time make -f tools/MRS/Makefile.run gnu_all -s -j MEMORY=dynamic_nonsymmetric
+tar cf gnu_all_nonsym.tar `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"`
+check_for_core_files
+section_end
+
+# Run symmetric gnu regressions with alternate layout
+section_start gnu_all_layout "Running symmetric gnu with alternate layouts"
+time make -f tools/MRS/Makefile.run gnu_all -s -j LAYOUT=alt
+tar cf gnu_all_layout.tar `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"`
+check_for_core_files
+section_end
+
+# Run symmetric gnu regressions with debug executable
+section_start gnu_ocean_only_debug "Running symmetric gnu_ocean_only with debug executable"
+time make -f tools/MRS/Makefile.run gnu_ocean_only -s -j MODE=debug
+tar cf gnu_ocean_only_debug.tar `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"`
+check_for_core_files
+section_end
+
+# Run symmetric static gnu regressions
+section_start gnu_all_static "Running symmetric gnu with static executable"
+time make -f tools/MRS/Makefile.run gnu_static_ocean_only MEMORY=static -s -j
+tar cf gnu_all_static.tar `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"`
+check_for_core_files
+section_end
+
+section_start gnu_restarts "Running symmetric gnu restart tests"
+time make -f tools/MRS/Makefile.restart gnu_ocean_only -s -j RESTART_STAGE=01
+time make -f tools/MRS/Makefile.restart gnu_ice_ocean_SIS2 -s -j RESTART_STAGE=01
+time make -f tools/MRS/Makefile.restart gnu_ocean_only -s -j RESTART_STAGE=02
+time make -f tools/MRS/Makefile.restart gnu_ice_ocean_SIS2 -s -j RESTART_STAGE=02
+time make -f tools/MRS/Makefile.restart gnu_ocean_only -s -j RESTART_STAGE=12
+time make -f tools/MRS/Makefile.restart gnu_ice_ocean_SIS2 -s -j RESTART_STAGE=12
+tar cf gnu_restarts.tar `find [oilc]*/ -path "*/??.ignore/*" -name "ocean.stats.*[a-z][a-z][a-z]"`
+check_for_core_files
+find [oilc]* -name "*.ignore" -type d -prune -exec rm -rf {} \;
+section_end
+
+# Run symmetric intel regressions
+section_start intel_all_sym "Running symmetric intel"
+time make -f tools/MRS/Makefile.run intel_all -s -j
+tar cf intel_all_sym.tar `find [a-z]* -name "*.stats.*[a-z][a-z][a-z]"`
+tar cf intel_params.tar `find [a-z]* -name "*_parameter_doc.*"`
+check_for_core_files
+section_end
+
+# Run non-symmetric intel regressions
+section_start intel_all_nonsym "Running nonsymmetric intel"
+time make -f tools/MRS/Makefile.run ocean_only/circle_obcs/ocean.stats.intel -s # work around
+time make -f tools/MRS/Makefile.run intel_all -s -j MEMORY=dynamic_nonsymmetric
+tar cf intel_all_nonsym.tar `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"`
+check_for_core_files
+section_end
+
+# Run symmetric intel regressions with alternate layout
+section_start intel_all_layout "Running symmetric intel with alternate layouts"
+time make -f tools/MRS/Makefile.run intel_all -s -j LAYOUT=alt
+tar cf intel_all_layout.tar `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"`
+check_for_core_files
+section_end
+
+# Run symmetric pgi regressions
+section_start pgi_all_sym "Running symmetric pgi"
+time make -f tools/MRS/Makefile.run pgi_all -s -j
+tar cf pgi_all_sym.tar `find [a-z]* -name "*.stats.*[a-z][a-z][a-z]"`
+tar cf pgi_params.tar `find [a-z]* -name "*_parameter_doc.*"`
+check_for_core_files
+section_end
+
+# Run non-symmetric pgi regressions
+section_start pgi_all_nonsym "Running nonsymmetric pgi"
+time make -f tools/MRS/Makefile.run ocean_only/circle_obcs/ocean.stats.pgi -s # work around
+time make -f tools/MRS/Makefile.run pgi_all -s -j MEMORY=dynamic_nonsymmetric
+tar cf pgi_all_nonsym.tar `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"`
+check_for_core_files
+section_end
+
+# Run symmetric pgi regressions with alternate layout
+section_start pgi_all_layout "Running symmetric pgi with alternate layouts"
+time make -f tools/MRS/Makefile.run gnu_all -s -j LAYOUT=alt
+tar cf pgi_all_layout.tar `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"`
+check_for_core_files
+section_end
+
+# Indicate all went well
+touch .CI-BATCH-SUCCESS


### PR DESCRIPTION
The MOM6 pipeline commands were scripted using make in the file MOM6-examples/tools/MRS/Makefile. This was trying to encapsulate the commands used in the pipeline so they could also be used at the command line (for emulating the pipeline). However, it required emulating the temporary/transient work-spaces provided by gitlab. Also, the Makefile was impenetrable.

New approach:
- Create a persistent working space for each pipeline, just as you'd work interactively in a single working directory
- Use the same commands in .gitlab-ci.yml as we'd use interactively (these still use the tools/MRS Makefile.build and Makefile.run)
- The compute stage of tasks is now a bash script (.gitlab/mom6-ci-run-script.sh) which will work/can be submitted from your working directory
- The caching of results from each run (gnu/intel/pgi, symmetric/nonsymmetric/layout/etc) is stored locally in the same working directory so we don't have to look elsewhere for the results
- Using the "fetch" strategy allows later stages to startup in mere seconds (previously re-cloning the repo took minutes)

This does not shorten the turn around significantly but I believe it is a lot easy to follow and emulate.

An example pipeline is https://gitlab.gfdl.noaa.gov/ogrp/MOM6/-/pipelines/15815 (GFDL-only)

Todo:
- split up the run stage to reduce it from 41+ minutes to ~13 minutes.