### PR TITLE
+(*)Improve tracer debugging

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -122,7 +122,7 @@ use MOM_tracer_hor_diff,       only : tracer_hordiff, tracer_hor_diff_init
 use MOM_tracer_hor_diff,       only : tracer_hor_diff_end, tracer_hor_diff_CS
 use MOM_tracer_registry,       only : tracer_registry_type, register_tracer, tracer_registry_init
 use MOM_tracer_registry,       only : register_tracer_diagnostics, post_tracer_diagnostics_at_sync
-use MOM_tracer_registry,       only : post_tracer_transport_diagnostics
+use MOM_tracer_registry,       only : post_tracer_transport_diagnostics, MOM_tracer_chksum
 use MOM_tracer_registry,       only : preALE_tracer_diagnostics, postALE_tracer_diagnostics
 use MOM_tracer_registry,       only : lock_tracer_registry, tracer_registry_end
 use MOM_tracer_flow_control,   only : call_tracer_register, tracer_flow_control_CS
@@ -1288,10 +1288,13 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   else
     x_first = (MODULO(G%first_direction,2) == 0)
   endif
+  if (CS%debug) call MOM_tracer_chksum("Pre-advect ", CS%tracer_Reg, G)
   call advect_tracer(h, CS%uhtr, CS%vhtr, CS%OBC, CS%t_dyn_rel_adv, G, GV, US, &
                      CS%tracer_adv_CSp, CS%tracer_Reg, x_first_in=x_first)
+  if (CS%debug) call MOM_tracer_chksum("Post-advect ", CS%tracer_Reg, G)
   call tracer_hordiff(h, CS%t_dyn_rel_adv, CS%MEKE, CS%VarMix, G, GV, US, &
                       CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
+  if (CS%debug) call MOM_tracer_chksum("Post-diffuse ", CS%tracer_Reg, G)
   if (showCallTree) call callTree_waypoint("finished tracer advection/diffusion (step_MOM)")
   call update_segment_tracer_reservoirs(G, GV, CS%uhtr, CS%vhtr, h, CS%OBC, &
                      CS%t_dyn_rel_adv, CS%tracer_Reg)

--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -323,7 +323,7 @@ subroutine offline_advection_ale(fluxes, Time_start, time_interval, G, GV, US, C
       call hchksum(h_vol, "h_vol before advect", G%HI, scale=HL2_to_kg_scale)
       call uvchksum("[uv]htr_sub before advect", uhtr_sub, vhtr_sub, G%HI, scale=HL2_to_kg_scale)
       write(debug_msg, '(A,I4.4)') 'Before advect ', iter
-      call MOM_tracer_chkinv(debug_msg, G, GV, h_pre, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+      call MOM_tracer_chkinv(debug_msg, G, GV, h_pre, CS%tracer_reg)
     endif
 
     call advect_tracer(h_pre, uhtr_sub, vhtr_sub, CS%OBC, CS%dt_offline, G, GV, US, &
@@ -344,7 +344,7 @@ subroutine offline_advection_ale(fluxes, Time_start, time_interval, G, GV, US, C
       if (CS%debug) then
         call hchksum(h_new,"h_new before ALE", G%HI, scale=GV%H_to_m)
         write(debug_msg, '(A,I4.4)') 'Before ALE ', iter
-        call MOM_tracer_chkinv(debug_msg, G, GV, h_new, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+        call MOM_tracer_chkinv(debug_msg, G, GV, h_new, CS%tracer_reg)
       endif
       call cpu_clock_begin(id_clock_ALE)
       call ALE_main_offline(G, GV, h_new, CS%tv, CS%tracer_Reg, CS%ALE_CSp, CS%OBC, CS%dt_offline)
@@ -353,7 +353,7 @@ subroutine offline_advection_ale(fluxes, Time_start, time_interval, G, GV, US, C
       if (CS%debug) then
         call hchksum(h_new, "h_new after ALE", G%HI, scale=GV%H_to_m)
         write(debug_msg, '(A,I4.4)') 'After ALE ', iter
-        call MOM_tracer_chkinv(debug_msg, G, GV, h_new, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+        call MOM_tracer_chkinv(debug_msg, G, GV, h_new, CS%tracer_reg)
       endif
     endif
 
@@ -395,7 +395,7 @@ subroutine offline_advection_ale(fluxes, Time_start, time_interval, G, GV, US, C
   if (CS%debug) then
     call hchksum(h_pre, "h after offline_advection_ale", G%HI, scale=GV%H_to_m)
     call uvchksum("[uv]htr after offline_advection_ale", uhtr, vhtr, G%HI, scale=HL2_to_kg_scale)
-    call MOM_tracer_chkinv("After offline_advection_ale", G, GV, h_pre, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+    call MOM_tracer_chkinv("After offline_advection_ale", G, GV, h_pre, CS%tracer_reg)
   endif
 
   call cpu_clock_end(CS%id_clock_offline_adv)
@@ -459,7 +459,7 @@ subroutine offline_redistribute_residual(CS, G, GV, US, h_pre, uhtr, vhtr, conve
   if (converged) return
 
   if (CS%debug) then
-    call MOM_tracer_chkinv("Before redistribute ", G, GV, h_pre, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+    call MOM_tracer_chkinv("Before redistribute ", G, GV, h_pre, CS%tracer_reg)
   endif
 
   call cpu_clock_begin(CS%id_clock_redistribute)
@@ -478,7 +478,7 @@ subroutine offline_redistribute_residual(CS, G, GV, US, h_pre, uhtr, vhtr, conve
         call pass_vector(uhtr, vhtr, G%Domain)
 
         if (CS%debug) then
-          call MOM_tracer_chksum("Before upwards redistribute ", CS%tracer_Reg%Tr, CS%tracer_Reg%ntr, G)
+          call MOM_tracer_chksum("Before upwards redistribute ", CS%tracer_Reg, G)
           call uvchksum("[uv]tr before upwards redistribute", uhtr, vhtr, G%HI, scale=HL2_to_kg_scale)
         endif
 
@@ -495,7 +495,7 @@ subroutine offline_redistribute_residual(CS, G, GV, US, h_pre, uhtr, vhtr, conve
                 max_iter_in=1, update_vol_prev=.true., uhr_out=uhr, vhr_out=vhr)
 
         if (CS%debug) then
-          call MOM_tracer_chksum("After upwards redistribute ", CS%tracer_Reg%Tr, CS%tracer_Reg%ntr, G)
+          call MOM_tracer_chksum("After upwards redistribute ", CS%tracer_Reg, G)
         endif
 
         ! Convert h_new back to layer thickness for ALE remapping
@@ -519,7 +519,7 @@ subroutine offline_redistribute_residual(CS, G, GV, US, h_pre, uhtr, vhtr, conve
         call pass_vector(uhtr, vhtr, G%Domain)
 
         if (CS%debug) then
-          call MOM_tracer_chksum("Before barotropic redistribute ", CS%tracer_Reg%Tr, CS%tracer_Reg%ntr, G)
+          call MOM_tracer_chksum("Before barotropic redistribute ", CS%tracer_Reg, G)
           call uvchksum("[uv]tr before upwards redistribute", uhtr, vhtr, G%HI, scale=HL2_to_kg_scale)
         endif
 
@@ -536,7 +536,7 @@ subroutine offline_redistribute_residual(CS, G, GV, US, h_pre, uhtr, vhtr, conve
                 max_iter_in=1, update_vol_prev=.true., uhr_out=uhr, vhr_out=vhr)
 
         if (CS%debug) then
-          call MOM_tracer_chksum("After barotropic redistribute ", CS%tracer_Reg%Tr, CS%tracer_Reg%ntr, G)
+          call MOM_tracer_chksum("After barotropic redistribute ", CS%tracer_Reg, G)
         endif
 
         ! Convert h_new back to layer thickness for ALE remapping
@@ -582,7 +582,7 @@ subroutine offline_redistribute_residual(CS, G, GV, US, h_pre, uhtr, vhtr, conve
   if (CS%debug) then
     call hchksum(h_pre, "h_pre after redistribute", G%HI, scale=GV%H_to_m)
     call uvchksum("uhtr after redistribute", uhtr, vhtr, G%HI, scale=HL2_to_kg_scale)
-    call MOM_tracer_chkinv("after redistribute ", G, GV, h_new, CS%tracer_Reg%Tr, CS%tracer_Reg%ntr)
+    call MOM_tracer_chkinv("after redistribute ", G, GV, h_new, CS%tracer_Reg)
   endif
 
   call cpu_clock_end(CS%id_clock_redistribute)
@@ -663,7 +663,7 @@ subroutine offline_diabatic_ale(fluxes, Time_start, Time_end, G, GV, US, CS, h_p
     call hchksum(h_pre, "h_pre before offline_diabatic_ale", G%HI, scale=GV%H_to_m)
     call hchksum(eatr, "eatr before offline_diabatic_ale", G%HI, scale=GV%H_to_m)
     call hchksum(ebtr, "ebtr before offline_diabatic_ale", G%HI, scale=GV%H_to_m)
-    call MOM_tracer_chkinv("Before offline_diabatic_ale", G, GV, h_pre, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+    call MOM_tracer_chkinv("Before offline_diabatic_ale", G, GV, h_pre, CS%tracer_reg)
   endif
 
   eatr(:,:,:) = 0.
@@ -727,7 +727,7 @@ subroutine offline_diabatic_ale(fluxes, Time_start, Time_end, G, GV, US, CS, h_p
     call hchksum(h_pre, "h_pre after offline_diabatic_ale", G%HI, scale=GV%H_to_m)
     call hchksum(eatr, "eatr after offline_diabatic_ale", G%HI, scale=GV%H_to_m)
     call hchksum(ebtr, "ebtr after offline_diabatic_ale", G%HI, scale=GV%H_to_m)
-    call MOM_tracer_chkinv("After offline_diabatic_ale", G, GV, h_pre, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+    call MOM_tracer_chkinv("After offline_diabatic_ale", G, GV, h_pre, CS%tracer_reg)
   endif
 
   call cpu_clock_end(CS%id_clock_offline_diabatic)
@@ -767,7 +767,7 @@ subroutine offline_fw_fluxes_into_ocean(G, GV, CS, fluxes, h, in_flux_optional)
 
   if (CS%debug) then
     call hchksum(h, "h before fluxes into ocean", G%HI, scale=GV%H_to_m)
-    call MOM_tracer_chkinv("Before fluxes into ocean", G, GV, h, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+    call MOM_tracer_chkinv("Before fluxes into ocean", G, GV, h, CS%tracer_reg)
   endif
   do m = 1,CS%tracer_reg%ntr
     ! Layer thicknesses should only be updated after the last tracer is finished
@@ -777,7 +777,7 @@ subroutine offline_fw_fluxes_into_ocean(G, GV, CS, fluxes, h, in_flux_optional)
   enddo
   if (CS%debug) then
     call hchksum(h, "h after fluxes into ocean", G%HI, scale=GV%H_to_m)
-    call MOM_tracer_chkinv("After fluxes into ocean", G, GV, h, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+    call MOM_tracer_chkinv("After fluxes into ocean", G, GV, h, CS%tracer_reg)
   endif
 
   ! Now that fluxes into the ocean are done, save the negative fluxes for later
@@ -805,7 +805,7 @@ subroutine offline_fw_fluxes_out_ocean(G, GV, CS, fluxes, h, out_flux_optional)
 
   if (CS%debug) then
     call hchksum(h, "h before fluxes out of ocean", G%HI, scale=GV%H_to_m)
-    call MOM_tracer_chkinv("Before fluxes out of ocean", G, GV, h, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+    call MOM_tracer_chkinv("Before fluxes out of ocean", G, GV, h, CS%tracer_reg)
   endif
   do m = 1, CS%tracer_reg%ntr
     ! Layer thicknesses should only be updated after the last tracer is finished
@@ -815,7 +815,7 @@ subroutine offline_fw_fluxes_out_ocean(G, GV, CS, fluxes, h, out_flux_optional)
   enddo
   if (CS%debug) then
     call hchksum(h, "h after fluxes out of ocean", G%HI, scale=GV%H_to_m)
-    call MOM_tracer_chkinv("Before fluxes out of ocean", G, GV, h, CS%tracer_reg%Tr, CS%tracer_reg%ntr)
+    call MOM_tracer_chkinv("Before fluxes out of ocean", G, GV, h, CS%tracer_reg)
   endif
 
 end subroutine offline_fw_fluxes_out_ocean

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -967,7 +967,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
                     (vhr(i,J,k) < 0.0) .and. (segment%direction == OBC_DIRECTION_N)) then
                   vhh(i,J) = vhr(i,J,k)
                   do m=1,ntr
-                    if (allocated(segment%tr_Reg%Tr(m)%t)) then
+                    if (allocated(segment%tr_Reg%Tr(m)%tres)) then
                       flux_y(i,m,J) = vhh(i,J)*OBC%segment(n)%tr_Reg%Tr(m)%tres(i,J,k)
                     else ; flux_y(i,m,J) = vhh(i,J)*OBC%segment(n)%tr_Reg%Tr(m)%OBC_inflow_conc ; endif
                   enddo
@@ -990,7 +990,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
                   (vhr(i,J,k) < 0.0) .and. (G%mask2dT(i,j+1) < 0.5)) then
                 vhh(i,J) = vhr(i,J,k)
                 do m=1,ntr
-                  if (allocated(segment%tr_Reg%Tr(m)%t)) then
+                  if (allocated(segment%tr_Reg%Tr(m)%tres)) then
                     flux_y(i,m,J) = vhh(i,J)*segment%tr_Reg%Tr(m)%tres(i,J,k)
                   else ; flux_y(i,m,J) = vhh(i,J)*segment%tr_Reg%Tr(m)%OBC_inflow_conc ; endif
                 enddo

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -195,7 +195,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, US, CS, Reg, tv, do_online
   endif ; endif
   CS%first_call = .false.
 
-  if (CS%debug) call MOM_tracer_chksum("Before tracer diffusion ", Reg%Tr, ntr, G)
+  if (CS%debug) call MOM_tracer_chksum("Before tracer diffusion ", Reg, G)
 
   use_VarMix = .false. ; Resoln_scaled = .false. ; use_Eady = .false.
   if (VarMix%use_variable_mixing) then
@@ -528,7 +528,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, US, CS, Reg, tv, do_online
 
   if (CS%Diffuse_ML_interior) then
     if (CS%show_call_tree) call callTree_waypoint("Calling epipycnal_ML_diff (tracer_hordiff)")
-    if (CS%debug) call MOM_tracer_chksum("Before epipycnal diff ", Reg%Tr, ntr, G)
+    if (CS%debug) call MOM_tracer_chksum("Before epipycnal diff ", Reg, G)
 
     call cpu_clock_begin(id_clock_epimix)
     call tracer_epipycnal_ML_diff(h, dt, Reg%Tr, ntr, khdt_x, khdt_y, G, GV, US, &
@@ -536,7 +536,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, US, CS, Reg, tv, do_online
     call cpu_clock_end(id_clock_epimix)
   endif
 
-  if (CS%debug) call MOM_tracer_chksum("After tracer diffusion ", Reg%Tr, ntr, G)
+  if (CS%debug) call MOM_tracer_chksum("After tracer diffusion ", Reg, G)
 
   ! post diagnostics for 2d tracer diffusivity
   if (CS%id_KhTr_u > 0) then


### PR DESCRIPTION
  This PR includes commits that simplify the interface to use the tracer
registry to write checksums, while retaining the old interface, and then uses
these new interfaces in additional checksum calls to help with debugging.  It
also corrects a minor problem with that could avoid segmentation faults in
certain cases with y-direction open boundary conditions but no tracer
reservoirs.  All answers in the MOM6-examples test suite are bitwise identical,
and it seems very likely that all cases that previously worked will be bitwise
identical.

  The commits in this PR include:

- NOAA-GFDL/MOM6@4a50417dc (*)Corrected OBC allocated tests in advect_y
- NOAA-GFDL/MOM6@1e1f67913 Added tracer debugging checksum calls
- NOAA-GFDL/MOM6@f4f06749e +Overload MOM_tracer_chksum to use tracer registry
