### PR TITLE
+Restored public interface to post_data_1d_k

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -41,6 +41,9 @@ implicit none ; private
 public set_axes_info, post_data, register_diag_field, time_type
 public post_product_u, post_product_sum_u, post_product_v, post_product_sum_v
 public set_masks_for_axes
+! post_data_1d_k is a deprecated interface that can be replaced by a call to post_data, but
+! it is being retained for backward compatibility to older versions of the ocean_BGC code.
+public post_data_1d_k
 public safe_alloc_ptr, safe_alloc_alloc
 public enable_averaging, enable_averages, disable_averaging, query_averaging_enabled
 public diag_mediator_init, diag_mediator_end, set_diag_mediator_grid


### PR DESCRIPTION
  Made post_data_1d_k publicly visible once again, rather than requiring calls
to use post_data, to support backward compatibility with older versions of the
ocean_BGC code.  This interface was removed from public visibility as a part of
github.com/NOAA-GFDL/MOM6/pull/107, but it caused problems with some of GFDL's
Earth System Models, as noted in https://github.com/NOAA-GFDL/MOM6/issues/168.
All answers are bitwise identical for any cases that compiled before.