### PR TITLE
(*)Fix set_up_ALE_sponge_field call T & S scaling

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2138,15 +2138,16 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
       endif
       ! The remaining calls to set_up_sponge_field can be in any order.
       if ( use_temperature) then
-        call set_up_ALE_sponge_field(filename, potemp_var, Time, G, GV, US, tv%T, ALE_CSp, scale=US%C_to_degC)
-        call set_up_ALE_sponge_field(filename, salin_var, Time, G, GV, US, tv%S, ALE_CSp, scale=US%S_to_ppt)
+        call set_up_ALE_sponge_field(filename, potemp_var, Time, G, GV, US, tv%T, ALE_CSp, scale=US%degC_to_C)
+        call set_up_ALE_sponge_field(filename, salin_var, Time, G, GV, US, tv%S, ALE_CSp, scale=US%ppt_to_S)
       endif
       if (sponge_uv) then
         filename = trim(inputdir)//trim(state_uv_file)
         call log_param(param_file, mdl, "INPUTDIR/SPONGE_STATE_UV_FILE", filename)
         if (.not.file_exists(filename, G%Domain)) &
              call MOM_error(FATAL, " initialize_sponges: Unable to open "//trim(filename))
-        call set_up_ALE_sponge_vel_field(filename, u_var, filename, v_var, Time, G, GV, US, ALE_CSp, u, v)
+        call set_up_ALE_sponge_vel_field(filename, u_var, filename, v_var, Time, G, GV, US, &
+                                         ALE_CSp, u, v, scale=US%m_s_to_L_T)
       endif
     endif
   endif


### PR DESCRIPTION
  Corrected the dimensional rescaling factors in two calls to
set_up_ALE_sponge_field for temperature and salinity for time-varying fields
being read in from an input file.  These had been given the inverse of the
correct values.  An optional scale argument was also added (with its default
value) in the call to set up ALE sponge velocities, for greater clarity of what
this call is doing.  This commit should address an issue noted by Kate Hedstrom
when evaluating the first draft of PR #1577 from dev/gfdl to main.  All answers
are bitwise identical in cases where dimensional rescaling of temperature and
salinity are not being applied, and answers with the rescaling of temperature
and salinity should now reproduce those without the rescaling.