### PR TITLE
Fixes minor issues with ac/make process

### DIFF
--- a/ac/Makefile.in
+++ b/ac/Makefile.in
@@ -24,10 +24,14 @@ Makefile: @srcdir@/ac/Makefile.in config.status
 	./config.status
 
 
+# Recursive wildcard (finds all files in $1 with suffixes in $2)
+rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
+
+
 # Generate dependencies
 .PHONY: depend
 depend: Makefile.dep
-Makefile.dep:
+Makefile.dep: $(MAKEDEP) $(call rwildcard,$(SRC_DIRS),*.h *.c *.inc *.F90)
 	$(MAKEDEP) -o Makefile.dep -e $(SRC_DIRS)
 
 

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -231,7 +231,7 @@ AC_SUBST([MAKEDEP])
 AC_SUBST([SRC_DIRS],
     ["${srcdir}/src ${MODEL_FRAMEWORK} ${srcdir}/config_src/external ${DRIVER_DIR} ${MEM_LAYOUT}"]
 )
-AC_CONFIG_COMMANDS([Makefile.dep], [make depend])
+AC_CONFIG_COMMANDS(Makefile.dep, [make depend])
 
 
 # setjmp verification


### PR DESCRIPTION
Where we had placed the dependency discovery (makedep) was leading to some small annoyances:
- The dependency generation was being invoked twice
- The dependency generation was not invoked when source code was changed.

Now:
- `./configure` creates config.status Makefile and Makefile.dep
- `./config.status` recreates Makefile and Makefile.dep
- `make depend` recreates Makefile.dep
- `make` will conditionally recreate Makefile.dep

Changes:
- Add dependency of Makefile.dep on source code in Makefile.in. This allows `make` to know when to run `makedep`.
- Fix syntax issue for AC_CONFIG_COMMANDS which caused errors to be issued without stopping.

Side note: the system works perfectly well if we comment out the "AC_CONFIG_COMMANDS" line in configure.ac to invoke makedep. This is because `make` now knows how