### PR TITLE
+Add ANSWER_DATE runtime parameters

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -128,9 +128,10 @@ type, public :: surface_forcing_CS ; private
   real    :: max_delta_srestore             !< Maximum delta salinity used for restoring
   real    :: max_delta_trestore             !< Maximum delta sst used for restoring
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< Mask for surface salinity restoring by basin
-  logical :: answers_2018       !< If true, use the order of arithmetic and expressions that recover
-                                !! the answers from the end of 2018.  Otherwise, use a simpler
-                                !! expression to calculate gustiness.
+  integer :: answer_date        !< The vintage of the order of arithmetic and expressions in the
+                                !! gustiness calculations.  Values below 20190101 recover the answers
+                                !! from the end of 2018, while higher values use a simpler expression
+                                !! to calculate gustiness.
   logical :: fix_ustar_gustless_bug         !< If true correct a bug in the time-averaging of the
                                             !! gustless wind friction velocity.
   logical :: check_no_land_fluxes           !< Return warning if IOB flux over land is non-zero
@@ -532,7 +533,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       if (CS%check_no_land_fluxes) &
         call check_mask_val_consistency(IOB%sw_flux_nir_dif(i-i0,j-j0), G%mask2dT(i,j), i, j, 'sw_flux_nir_dif', G)
     endif
-    if (CS%answers_2018) then
+    if (CS%answer_date < 20190101) then
       fluxes%sw(i,j) = fluxes%sw_vis_dir(i,j) + fluxes%sw_vis_dif(i,j) + &
                        fluxes%sw_nir_dir(i,j) + fluxes%sw_nir_dif(i,j)
     else
@@ -1037,7 +1038,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, taux, tauy, 
         endif
         ustar(i,j) = sqrt(gustiness*IRho0 + IRho0*Pa_conversion*IOB%stress_mag(i-i0,j-j0))
       enddo ; enddo ; endif
-      if (CS%answers_2018) then
+      if (CS%answer_date < 20190101) then
         if (do_gustless) then ; do j=js,je ; do i=is,ie
           gustless_ustar(i,j) = sqrt(Pa_conversion*US%L_to_Z*IOB%stress_mag(i-i0,j-j0) / CS%Rho0)
         enddo ; enddo ; endif
@@ -1059,7 +1060,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, taux, tauy, 
           if (CS%read_gust_2d) gustiness = CS%gust(i,j)
         endif
         if (do_ustar) ustar(i,j) = sqrt(gustiness*IRho0 + IRho0 * tau_mag)
-        if (CS%answers_2018) then
+        if (CS%answer_date < 20190101) then
           if (do_gustless) gustless_ustar(i,j) = sqrt(US%L_to_Z*tau_mag / CS%Rho0)
         else
           if (do_gustless) gustless_ustar(i,j) = sqrt(IRho0 * tau_mag)
@@ -1071,7 +1072,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, taux, tauy, 
         gustiness = CS%gust_const
         if (CS%read_gust_2d .and. (G%mask2dT(i,j) > 0.0)) gustiness = CS%gust(i,j)
         if (do_ustar) ustar(i,j) = sqrt(gustiness*IRho0 + IRho0 * tau_mag)
-        if (CS%answers_2018) then
+        if (CS%answer_date < 20190101) then
           if (do_gustless) gustless_ustar(i,j) = sqrt(US%L_to_Z*tau_mag / CS%Rho0)
         else
           if (do_gustless) gustless_ustar(i,j) = sqrt(IRho0 * tau_mag)
@@ -1092,7 +1093,7 @@ subroutine extract_IOB_stresses(IOB, index_bounds, Time, G, US, CS, taux, tauy, 
         if (CS%read_gust_2d) gustiness = CS%gust(i,j)
 
         if (do_ustar) ustar(i,j) = sqrt(gustiness*IRho0 + IRho0 * tau_mag)
-        if (CS%answers_2018) then
+        if (CS%answer_date < 20190101) then
           if (do_gustless) gustless_ustar(i,j) = sqrt(US%L_to_Z*tau_mag / CS%Rho0)
         else
           if (do_gustless) gustless_ustar(i,j) = sqrt(IRho0 * tau_mag)
@@ -1249,7 +1250,11 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
   real :: utide  ! The RMS tidal velocity [Z T-1 ~> m s-1].
   type(directories)  :: dirs
   logical            :: new_sim, iceberg_flux_diags
-  logical            :: default_2018_answers
+  integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
+  logical :: answers_2018         ! If true, use the order of arithmetic and expressions that recover
+                                  ! the answers from the end of 2018.  Otherwise, use a simpler
+                                  ! expression to calculate gustiness.
   type(time_type)    :: Time_frc
   character(len=200) :: TideAmp_file, gust_file, salt_file, temp_file ! Input file names.
   ! This include declares and sets the variable "version".
@@ -1530,13 +1535,26 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
     call MOM_read_data(gust_file, 'gustiness', CS%gust, G%domain, timelevel=1, &
                scale=US%kg_m3_to_R*US%m_s_to_L_T**2*US%L_to_Z) ! units in file should be Pa
   endif
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=.false.)
-  call get_param(param_file, mdl, "SURFACE_FORCING_2018_ANSWERS", CS%answers_2018, &
+                 default=(default_answer_date<20190101))
+  call get_param(param_file, mdl, "SURFACE_FORCING_2018_ANSWERS", answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the answers "//&
                  "from the end of 2018.  Otherwise, use a simpler expression to calculate gustiness.", &
                  default=default_2018_answers)
+                 ! Revise inconsistent default answer dates.
+  if (answers_2018 .and. (default_answer_date >= 20190101)) default_answer_date = 20181231
+  if (.not.answers_2018 .and. (default_answer_date < 20190101)) default_answer_date = 20190101
+  call get_param(param_file, mdl, "SURFACE_FORCING_ANSWER_DATE", CS%answer_date, &
+                 "The vintage of the order of arithmetic and expressions in the gustiness "//&
+                 "calculations.  Values below 20190101 recover the answers from the end "//&
+                 "of 2018, while higher values use a simpler expression to calculate gustiness.  "//&
+                 "If both SURFACE_FORCING_2018_ANSWERS and SURFACE_FORCING_ANSWER_DATE are "//&
+                 "specified, the latter takes precedence.", default=default_answer_date)
+
   call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", CS%fix_ustar_gustless_bug, &
                  "If true correct a bug in the time-averaging of the gustless wind friction velocity", &
                  default=.true.)

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -94,7 +94,7 @@ type, public :: ALE_CS ; private
   integer :: answer_date    !< The vintage of the expressions and order of arithmetic to use for
                             !! remapping. Values below 20190101 result in the use of older, less
                             !! accurate expressions that were in use at the end of 2018.  Higher
-                            !! values result inthe use of more robust and accurate forms of
+                            !! values result in the use of more robust and accurate forms of
                             !! mathematically equivalent expressions.
 
   logical :: debug   !< If true, write verbose checksums for debugging purposes.
@@ -226,7 +226,7 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
                  "extrapolated instead of piecewise constant", default=.false.)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231, do_not_log=.true.)
+                 default=99991231)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=(default_answer_date<20190101))
@@ -234,11 +234,17 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  if (answers_2018) then
-    CS%answer_date = 20181231
-  else
-    CS%answer_date = 20190101
-  endif
+  ! Revise inconsistent default answer dates for remapping.
+  if (answers_2018 .and. (default_answer_date >= 20190101)) default_answer_date = 20181231
+  if (.not.answers_2018 .and. (default_answer_date < 20190101)) default_answer_date = 20190101
+  call get_param(param_file, mdl, "REMAPPING_ANSWER_DATE", CS%answer_date, &
+                 "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
+                 "Values below 20190101 result in the use of older, less accurate expressions "//&
+                 "that were in use at the end of 2018.  Higher values result in the use of more "//&
+                 "robust and accurate forms of mathematically equivalent expressions.  "//&
+                 "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_answer_date)
+
   call initialize_remapping( CS%remapCS, string, &
                              boundary_extrapolation=remap_boundary_extrap, &
                              check_reconstruction=check_reconstruction, &

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -91,9 +91,11 @@ type, public :: ALE_CS ; private
 
   logical :: remap_after_initialization !< Indicates whether to regrid/remap after initializing the state.
 
-  logical :: answers_2018   !< If true, use the order of arithmetic and expressions for remapping
-                            !! that recover the answers from the end of 2018.  Otherwise, use more
-                            !! robust and accurate forms of mathematically equivalent expressions.
+  integer :: answer_date    !< The vintage of the expressions and order of arithmetic to use for
+                            !! remapping. Values below 20190101 result in the use of older, less
+                            !! accurate expressions that were in use at the end of 2018.  Higher
+                            !! values result inthe use of more robust and accurate forms of
+                            !! mathematically equivalent expressions.
 
   logical :: debug   !< If true, write verbose checksums for debugging purposes.
   logical :: show_call_tree !< For debugging
@@ -163,7 +165,11 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
   character(len=40) :: mdl = "MOM_ALE" ! This module's name.
   character(len=80) :: string, vel_string ! Temporary strings
   real              :: filter_shallow_depth, filter_deep_depth
-  logical           :: default_2018_answers
+  integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
+  logical :: answers_2018   ! If true, use the order of arithmetic and expressions for remapping
+                            ! that recover the answers from the end of 2018.  Otherwise, use more
+                            ! robust and accurate forms of mathematically equivalent expressions.
   logical           :: check_reconstruction
   logical           :: check_remapping
   logical           :: force_bounds_in_subcell
@@ -218,25 +224,33 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
   call get_param(param_file, mdl, "REMAP_BOUNDARY_EXTRAP", remap_boundary_extrap, &
                  "If true, values at the interfaces of boundary cells are "//&
                  "extrapolated instead of piecewise constant", default=.false.)
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231, do_not_log=.true.)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=.false.)
-  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", CS%answers_2018, &
+                 default=(default_answer_date<20190101))
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
+  if (answers_2018) then
+    CS%answer_date = 20181231
+  else
+    CS%answer_date = 20190101
+  endif
   call initialize_remapping( CS%remapCS, string, &
                              boundary_extrapolation=remap_boundary_extrap, &
                              check_reconstruction=check_reconstruction, &
                              check_remapping=check_remapping, &
                              force_bounds_in_subcell=force_bounds_in_subcell, &
-                             answers_2018=CS%answers_2018)
+                             answer_date=CS%answer_date)
   call initialize_remapping( CS%vel_remapCS, vel_string, &
                              boundary_extrapolation=remap_boundary_extrap, &
                              check_reconstruction=check_reconstruction, &
                              check_remapping=check_remapping, &
                              force_bounds_in_subcell=force_bounds_in_subcell, &
-                             answers_2018=CS%answers_2018)
+                             answer_date=CS%answer_date)
 
   call get_param(param_file, mdl, "PARTIAL_CELL_VELOCITY_REMAP", CS%partial_cell_vel_remap, &
                  "If true, use partial cell thicknesses at velocity points that are masked out "//&
@@ -590,8 +604,8 @@ subroutine ALE_offline_inputs(CS, G, GV, h, tv, Reg, uhtr, vhtr, Kd, debug, OBC)
     endif
   enddo ; enddo
 
-  call ALE_remap_scalar(CS%remapCS, G, GV, nk, h, tv%T, h_new, tv%T, answers_2018=CS%answers_2018)
-  call ALE_remap_scalar(CS%remapCS, G, GV, nk, h, tv%S, h_new, tv%S, answers_2018=CS%answers_2018)
+  call ALE_remap_scalar(CS%remapCS, G, GV, nk, h, tv%T, h_new, tv%T, answer_date=CS%answer_date)
+  call ALE_remap_scalar(CS%remapCS, G, GV, nk, h, tv%S, h_new, tv%S, answer_date=CS%answer_date)
 
   if (debug) call MOM_tracer_chkinv("After ALE_offline_inputs", G, GV, h_new, Reg%Tr, Reg%ntr)
 
@@ -742,7 +756,7 @@ subroutine ALE_regrid_accelerated(CS, G, GV, h, tv, n_itt, u, v, OBC, Reg, dt, d
   if (present(dt)) &
     call ALE_update_regrid_weights(dt, CS)
 
-  if (.not. CS%answers_2018) then
+  if (CS%answer_date >= 20190101) then
     h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
   elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H * 1.0e-30 ; h_neglect_edge = GV%m_to_H * 1.0e-10
@@ -843,7 +857,7 @@ subroutine remap_all_state_vars(CS, G, GV, h_old, h_new, Reg, OBC, &
                           "and u/v are to be remapped")
   endif
 
-  if (.not.CS%answers_2018) then
+  if (CS%answer_date >= 20190101) then
     h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
   elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
@@ -1092,7 +1106,8 @@ end subroutine mask_near_bottom_vel
 !> Remaps a single scalar between grids described by thicknesses h_src and h_dst.
 !! h_dst must be dimensioned as a model array with GV%ke layers while h_src can
 !! have an arbitrary number of layers specified by nk_src.
-subroutine ALE_remap_scalar(CS, G, GV, nk_src, h_src, s_src, h_dst, s_dst, all_cells, old_remap, answers_2018 )
+subroutine ALE_remap_scalar(CS, G, GV, nk_src, h_src, s_src, h_dst, s_dst, all_cells, old_remap, &
+                            answers_2018, answer_date )
   type(remapping_CS),                      intent(in)    :: CS        !< Remapping control structure
   type(ocean_grid_type),                   intent(in)    :: G         !< Ocean grid structure
   type(verticalGrid_type),                 intent(in)    :: GV        !< Ocean vertical grid structure
@@ -1112,6 +1127,8 @@ subroutine ALE_remap_scalar(CS, G, GV, nk_src, h_src, s_src, h_dst, s_dst, all_c
                                                                       !! and expressions that recover the answers for
                                                                       !! remapping from the end of 2018. Otherwise,
                                                                       !! use more robust forms of the same expressions.
+  integer,                       optional, intent(in)    :: answer_date !< The vintage of the expressions to use
+                                                                      !! for remapping
   ! Local variables
   integer :: i, j, k, n_points
   real :: dx(GV%ke+1)
@@ -1124,6 +1141,7 @@ subroutine ALE_remap_scalar(CS, G, GV, nk_src, h_src, s_src, h_dst, s_dst, all_c
   if (present(old_remap)) use_remapping_core_w = old_remap
   n_points = nk_src
   use_2018_remap = .true. ; if (present(answers_2018)) use_2018_remap = answers_2018
+  if (present(answer_date)) use_2018_remap = (answer_date < 20190101)
 
   if (.not.use_2018_remap) then
     h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
@@ -1206,7 +1224,7 @@ subroutine ALE_PLM_edge_values( CS, G, GV, h, Q, bdry_extrap, Q_t, Q_b )
   real :: mslp
   real :: h_neglect
 
-  if (.not.CS%answers_2018) then
+  if (CS%answer_date >= 20190101) then
     h_neglect = GV%H_subroundoff
   elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30
@@ -1275,7 +1293,7 @@ subroutine TS_PPM_edge_values( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_extrap
       ppol_coefs        ! Coefficients of polynomial, all in [degC] or [ppt]
   real :: h_neglect, h_neglect_edge ! Tiny thicknesses [H ~> m or kg m-2]
 
-  if (.not.CS%answers_2018) then
+  if (CS%answer_date >= 20190101) then
     h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
   elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
@@ -1295,9 +1313,9 @@ subroutine TS_PPM_edge_values( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_extrap
     ppol_E(:,:) = 0.0
     ppol_coefs(:,:) = 0.0
     call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=h_neglect_edge, &
-                                  answers_2018=CS%answers_2018 )
+                                  answer_date=CS%answer_date )
     call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect, &
-                                  answers_2018=CS%answers_2018 )
+                                  answer_date=CS%answer_date )
     if (bdry_extrap) &
       call PPM_boundary_extrapolation( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )
 
@@ -1310,15 +1328,15 @@ subroutine TS_PPM_edge_values( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_extrap
     ppol_E(:,:) = 0.0
     ppol_coefs(:,:) = 0.0
     tmp(:) = tv%T(i,j,:)
-    if (CS%answers_2018) then
+    if (CS%answer_date < 20190101) then
       call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=1.0e-10*GV%m_to_H, &
-                                  answers_2018=CS%answers_2018 )
+                                  answer_date=CS%answer_date )
     else
       call edge_values_implicit_h4( GV%ke, hTmp, tmp, ppol_E, h_neglect=GV%H_subroundoff, &
-                                  answers_2018=CS%answers_2018 )
+                                  answer_date=CS%answer_date )
     endif
     call PPM_reconstruction( GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect, &
-                                  answers_2018=CS%answers_2018 )
+                                  answer_date=CS%answer_date )
     if (bdry_extrap) &
       call PPM_boundary_extrapolation(GV%ke, hTmp, tmp, ppol_E, ppol_coefs, h_neglect )
 

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -34,8 +34,9 @@ type, public :: remapping_CS
   logical :: check_remapping = .false.
   !> If true, the intermediate values used in remapping are forced to be bounded.
   logical :: force_bounds_in_subcell = .false.
-  !> If true use older, less acccurate expressions.
-  logical :: answers_2018 = .true.
+  !> The vintage of the expressions to use for remapping. Values below 20190101 result
+  !! in the use of older, less accurate expressions.
+  integer :: answer_date = 20181231  !### Change to 99991231?
 end type
 
 ! The following routines are visible to the outside world
@@ -93,7 +94,7 @@ contains
 
 !> Set parameters within remapping object
 subroutine remapping_set_param(CS, remapping_scheme, boundary_extrapolation,  &
-               check_reconstruction, check_remapping, force_bounds_in_subcell, answers_2018)
+               check_reconstruction, check_remapping, force_bounds_in_subcell, answers_2018, answer_date)
   type(remapping_CS),         intent(inout) :: CS !< Remapping control structure
   character(len=*), optional, intent(in)    :: remapping_scheme !< Remapping scheme to use
   logical, optional,          intent(in)    :: boundary_extrapolation !< Indicate to extrapolate in boundary cells
@@ -101,6 +102,7 @@ subroutine remapping_set_param(CS, remapping_scheme, boundary_extrapolation,  &
   logical, optional,          intent(in)    :: check_remapping !< Indicate to check results of remapping
   logical, optional,          intent(in)    :: force_bounds_in_subcell !< Force subcells values to be bounded
   logical, optional,          intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer, optional,          intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   if (present(remapping_scheme)) then
     call setReconstructionType( remapping_scheme, CS )
@@ -118,8 +120,16 @@ subroutine remapping_set_param(CS, remapping_scheme, boundary_extrapolation,  &
     CS%force_bounds_in_subcell = force_bounds_in_subcell
   endif
   if (present(answers_2018)) then
-    CS%answers_2018 = answers_2018
+    if (answers_2018) then
+      CS%answer_date = 20181231
+    else
+      CS%answer_date = 20190101
+    endif
   endif
+  if (present(answer_date)) then
+    CS%answer_date = answer_date
+  endif
+
 end subroutine remapping_set_param
 
 subroutine extract_member_remapping_CS(CS, remapping_scheme, degree, boundary_extrapolation, check_reconstruction, &
@@ -424,46 +434,46 @@ subroutine build_reconstructions_1d( CS, n0, h0, u0, ppoly_r_coefs, &
         call PLM_boundary_extrapolation( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect )
       iMethod = INTEGRATION_PLM
     case ( REMAPPING_PPM_H4 )
-      call edge_values_explicit_h4( n0, h0, u0, ppoly_r_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answers_2018=CS%answers_2018 )
+      call edge_values_explicit_h4( n0, h0, u0, ppoly_r_E, h_neglect_edge, answer_date=CS%answer_date )
+      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answer_date=CS%answer_date )
       if ( CS%boundary_extrapolation ) then
         call PPM_boundary_extrapolation( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect )
       endif
       iMethod = INTEGRATION_PPM
     case ( REMAPPING_PPM_IH4 )
-      call edge_values_implicit_h4( n0, h0, u0, ppoly_r_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answers_2018=CS%answers_2018 )
+      call edge_values_implicit_h4( n0, h0, u0, ppoly_r_E, h_neglect_edge, answer_date=CS%answer_date )
+      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answer_date=CS%answer_date )
       if ( CS%boundary_extrapolation ) then
         call PPM_boundary_extrapolation( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect )
       endif
       iMethod = INTEGRATION_PPM
     case ( REMAPPING_PPM_HYBGEN )
       call hybgen_PPM_coefs(u0, h0, ppoly_r_E, n0, 1, h_neglect)
-      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answers_2018=.false. )
+      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answer_date=99991231 )
       if ( CS%boundary_extrapolation ) &
         call PPM_boundary_extrapolation( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect )
       iMethod = INTEGRATION_PPM
     case ( REMAPPING_WENO_HYBGEN )
       call hybgen_weno_coefs(u0, h0, ppoly_r_E, n0, 1, h_neglect)
-      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answers_2018=.false. )
+      call PPM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect, answer_date=99991231 )
       if ( CS%boundary_extrapolation ) &
         call PPM_boundary_extrapolation( n0, h0, u0, ppoly_r_E, ppoly_r_coefs, h_neglect )
       iMethod = INTEGRATION_PPM
     case ( REMAPPING_PQM_IH4IH3 )
-      call edge_values_implicit_h4( n0, h0, u0, ppoly_r_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-      call edge_slopes_implicit_h3( n0, h0, u0, ppoly_r_S, h_neglect, answers_2018=CS%answers_2018 )
+      call edge_values_implicit_h4( n0, h0, u0, ppoly_r_E, h_neglect_edge, answer_date=CS%answer_date )
+      call edge_slopes_implicit_h3( n0, h0, u0, ppoly_r_S, h_neglect, answer_date=CS%answer_date )
       call PQM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_S, ppoly_r_coefs, h_neglect, &
-                               answers_2018=CS%answers_2018 )
+                               answer_date=CS%answer_date )
       if ( CS%boundary_extrapolation ) then
         call PQM_boundary_extrapolation_v1( n0, h0, u0, ppoly_r_E, ppoly_r_S, &
                                             ppoly_r_coefs, h_neglect )
       endif
       iMethod = INTEGRATION_PQM
     case ( REMAPPING_PQM_IH6IH5 )
-      call edge_values_implicit_h6( n0, h0, u0, ppoly_r_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-      call edge_slopes_implicit_h5( n0, h0, u0, ppoly_r_S, h_neglect, answers_2018=CS%answers_2018 )
+      call edge_values_implicit_h6( n0, h0, u0, ppoly_r_E, h_neglect_edge, answer_date=CS%answer_date )
+      call edge_slopes_implicit_h5( n0, h0, u0, ppoly_r_S, h_neglect, answer_date=CS%answer_date )
       call PQM_reconstruction( n0, h0, u0, ppoly_r_E, ppoly_r_S, ppoly_r_coefs, h_neglect, &
-                               answers_2018=CS%answers_2018 )
+                               answer_date=CS%answer_date )
       if ( CS%boundary_extrapolation ) then
         call PQM_boundary_extrapolation_v1( n0, h0, u0, ppoly_r_E, ppoly_r_S, &
                                             ppoly_r_coefs, h_neglect )
@@ -1593,7 +1603,7 @@ end subroutine dzFromH1H2
 
 !> Constructor for remapping control structure
 subroutine initialize_remapping( CS, remapping_scheme, boundary_extrapolation, &
-                check_reconstruction, check_remapping, force_bounds_in_subcell, answers_2018)
+                check_reconstruction, check_remapping, force_bounds_in_subcell, answers_2018, answer_date)
   ! Arguments
   type(remapping_CS), intent(inout) :: CS !< Remapping control structure
   character(len=*),   intent(in)    :: remapping_scheme !< Remapping scheme to use
@@ -1602,11 +1612,12 @@ subroutine initialize_remapping( CS, remapping_scheme, boundary_extrapolation, &
   logical, optional,  intent(in)    :: check_remapping !< Indicate to check results of remapping
   logical, optional,  intent(in)    :: force_bounds_in_subcell !< Force subcells values to be bounded
   logical, optional,  intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer, optional,  intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Note that remapping_scheme is mandatory for initialize_remapping()
   call remapping_set_param(CS, remapping_scheme=remapping_scheme, boundary_extrapolation=boundary_extrapolation,  &
                check_reconstruction=check_reconstruction, check_remapping=check_remapping, &
-               force_bounds_in_subcell=force_bounds_in_subcell, answers_2018=answers_2018)
+               force_bounds_in_subcell=force_bounds_in_subcell, answers_2018=answers_2018, answer_date=answer_date)
 
 end subroutine initialize_remapping
 
@@ -1681,15 +1692,15 @@ logical function remapping_unit_tests(verbose)
   data h2 /6*0.5/  ! 6 uniform layers with total depth of 3
   type(remapping_CS) :: CS !< Remapping control structure
   real, allocatable, dimension(:,:) :: ppoly0_E, ppoly0_S, ppoly0_coefs
-  logical :: answers_2018 !  If true use older, less acccurate expressions.
+  integer :: answer_date  ! The vintage of the expressions to test
   integer :: i
   real :: err, h_neglect, h_neglect_edge
   logical :: thisTest, v
 
   v = verbose
-  answers_2018 = .false. ! .true.
+  answer_date = 20190101 ! 20181231
   h_neglect = hNeglect_dflt
-  h_neglect_edge = hNeglect_dflt ; if (answers_2018) h_neglect_edge = 1.0e-10
+  h_neglect_edge = hNeglect_dflt ; if (answer_date < 20190101) h_neglect_edge = 1.0e-10
 
   write(stdout,*) '==== MOM_remapping: remapping_unit_tests ================='
   remapping_unit_tests = .false. ! Normally return false
@@ -1711,7 +1722,7 @@ logical function remapping_unit_tests(verbose)
   remapping_unit_tests = remapping_unit_tests .or. thisTest
 
   thisTest = .false.
-  call initialize_remapping(CS, 'PPM_H4', answers_2018=answers_2018)
+  call initialize_remapping(CS, 'PPM_H4', answer_date=answer_date)
   if (verbose) write(stdout,*) 'h0 (test data)'
   if (verbose) call dumpGrid(n0,h0,x0,u0)
 
@@ -1735,8 +1746,8 @@ logical function remapping_unit_tests(verbose)
   ppoly0_S(:,:) = 0.0
   ppoly0_coefs(:,:) = 0.0
 
-  call edge_values_explicit_h4( n0, h0, u0, ppoly0_E, h_neglect=1e-10, answers_2018=answers_2018 )
-  call PPM_reconstruction( n0, h0, u0, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=answers_2018 )
+  call edge_values_explicit_h4( n0, h0, u0, ppoly0_E, h_neglect=1e-10, answer_date=answer_date )
+  call PPM_reconstruction( n0, h0, u0, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=answer_date )
   call PPM_boundary_extrapolation( n0, h0, u0, ppoly0_E, ppoly0_coefs, h_neglect )
   u1(:) = 0.
   call remapByProjection( n0, h0, u0, ppoly0_E, ppoly0_coefs, &
@@ -1866,7 +1877,7 @@ logical function remapping_unit_tests(verbose)
     test_answer(v, 3, ppoly0_coefs(:,2), (/0.,4.,0./), 'Non-uniform line PLM: P1')
 
   call edge_values_explicit_h4( 5, (/1.,1.,1.,1.,1./), (/1.,3.,5.,7.,9./), ppoly0_E, &
-                                h_neglect=1e-10, answers_2018=answers_2018 )
+                                h_neglect=1e-10, answer_date=answer_date )
   ! The next two tests currently fail due to roundoff, but pass when given a reasonable tolerance.
   thisTest = test_answer(v, 5, ppoly0_E(:,1), (/0.,2.,4.,6.,8./), 'Line H4: left edges', tol=8.0e-15)
   remapping_unit_tests = remapping_unit_tests .or. thisTest
@@ -1875,7 +1886,7 @@ logical function remapping_unit_tests(verbose)
   ppoly0_E(:,1) = (/0.,2.,4.,6.,8./)
   ppoly0_E(:,2) = (/2.,4.,6.,8.,10./)
   call PPM_reconstruction(5, (/1.,1.,1.,1.,1./), (/1.,3.,5.,7.,9./), ppoly0_E(1:5,:), &
-                              ppoly0_coefs(1:5,:), h_neglect, answers_2018=answers_2018 )
+                              ppoly0_coefs(1:5,:), h_neglect, answer_date=answer_date )
   remapping_unit_tests = remapping_unit_tests .or. &
     test_answer(v, 5, ppoly0_coefs(:,1), (/1.,2.,4.,6.,9./), 'Line PPM: P0')
   remapping_unit_tests = remapping_unit_tests .or. &
@@ -1884,7 +1895,7 @@ logical function remapping_unit_tests(verbose)
     test_answer(v, 5, ppoly0_coefs(:,3), (/0.,0.,0.,0.,0./), 'Line PPM: P2')
 
   call edge_values_explicit_h4( 5, (/1.,1.,1.,1.,1./), (/1.,1.,7.,19.,37./), ppoly0_E, &
-                                h_neglect=1e-10, answers_2018=answers_2018 )
+                                h_neglect=1e-10, answer_date=answer_date )
   ! The next two tests are now passing when answers_2018 = .false., but otherwise only work to roundoff.
   thisTest = test_answer(v, 5, ppoly0_E(:,1), (/3.,0.,3.,12.,27./), 'Parabola H4: left edges', tol=2.7e-14)
   remapping_unit_tests = remapping_unit_tests .or. thisTest
@@ -1893,7 +1904,7 @@ logical function remapping_unit_tests(verbose)
   ppoly0_E(:,1) = (/0.,0.,3.,12.,27./)
   ppoly0_E(:,2) = (/0.,3.,12.,27.,48./)
   call PPM_reconstruction(5, (/1.,1.,1.,1.,1./), (/0.,1.,7.,19.,37./), ppoly0_E(1:5,:), &
-                          ppoly0_coefs(1:5,:), h_neglect, answers_2018=answers_2018 )
+                          ppoly0_coefs(1:5,:), h_neglect, answer_date=answer_date )
   remapping_unit_tests = remapping_unit_tests .or. &
     test_answer(v, 5, ppoly0_E(:,1), (/0.,0.,3.,12.,37./), 'Parabola PPM: left edges')
   remapping_unit_tests = remapping_unit_tests .or. &
@@ -1908,7 +1919,7 @@ logical function remapping_unit_tests(verbose)
   ppoly0_E(:,1) = (/0.,0.,6.,10.,15./)
   ppoly0_E(:,2) = (/0.,6.,12.,17.,15./)
   call PPM_reconstruction(5, (/1.,1.,1.,1.,1./), (/0.,5.,7.,16.,15./), ppoly0_E(1:5,:), &
-                          ppoly0_coefs(1:5,:), h_neglect, answers_2018=answers_2018 )
+                          ppoly0_coefs(1:5,:), h_neglect, answer_date=answer_date )
   remapping_unit_tests = remapping_unit_tests .or. &
     test_answer(v, 5, ppoly0_E(:,1), (/0.,3.,6.,16.,15./), 'Limits PPM: left edges')
   remapping_unit_tests = remapping_unit_tests .or. &

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -1896,7 +1896,7 @@ logical function remapping_unit_tests(verbose)
 
   call edge_values_explicit_h4( 5, (/1.,1.,1.,1.,1./), (/1.,1.,7.,19.,37./), ppoly0_E, &
                                 h_neglect=1e-10, answer_date=answer_date )
-  ! The next two tests are now passing when answers_2018 = .false., but otherwise only work to roundoff.
+  ! The next two tests are now passing when answer_date >= 20190101, but otherwise only work to roundoff.
   thisTest = test_answer(v, 5, ppoly0_E(:,1), (/3.,0.,3.,12.,27./), 'Parabola H4: left edges', tol=2.7e-14)
   remapping_unit_tests = remapping_unit_tests .or. thisTest
   thisTest = test_answer(v, 5, ppoly0_E(:,2), (/0.,3.,12.,27.,48./), 'Parabola H4: right edges', tol=4.8e-14)

--- a/src/ALE/P1M_functions.F90
+++ b/src/ALE/P1M_functions.F90
@@ -24,7 +24,7 @@ contains
 !!
 !! It is assumed that the size of the array 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed here.
-subroutine P1M_interpolation( N, h, u, edge_values, ppoly_coef, h_neglect, answers_2018 )
+subroutine P1M_interpolation( N, h, u, edge_values, ppoly_coef, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell average properties (size N) [A]
@@ -33,13 +33,15 @@ subroutine P1M_interpolation( N, h, u, edge_values, ppoly_coef, h_neglect, answe
                                            !! piecewise polynomial coefficients, mainly [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   integer   :: k            ! loop index
   real      :: u0_l, u0_r   ! edge values (left and right)
 
   ! Bound edge values (routine found in 'edge_values.F90')
-  call bound_edge_values( N, h, u, edge_values, h_neglect, answers_2018 )
+  call bound_edge_values( N, h, u, edge_values, h_neglect, &
+                          answers_2018=answers_2018, answer_date=answer_date )
 
   ! Systematically average discontinuous edge values (routine found in
   ! 'edge_values.F90')

--- a/src/ALE/P1M_functions.F90
+++ b/src/ALE/P1M_functions.F90
@@ -24,7 +24,7 @@ contains
 !!
 !! It is assumed that the size of the array 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed here.
-subroutine P1M_interpolation( N, h, u, edge_values, ppoly_coef, h_neglect, answers_2018, answer_date )
+subroutine P1M_interpolation( N, h, u, edge_values, ppoly_coef, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell average properties (size N) [A]
@@ -32,7 +32,6 @@ subroutine P1M_interpolation( N, h, u, edge_values, ppoly_coef, h_neglect, answe
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Potentially modified
                                            !! piecewise polynomial coefficients, mainly [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -40,8 +39,7 @@ subroutine P1M_interpolation( N, h, u, edge_values, ppoly_coef, h_neglect, answe
   real      :: u0_l, u0_r   ! edge values (left and right)
 
   ! Bound edge values (routine found in 'edge_values.F90')
-  call bound_edge_values( N, h, u, edge_values, h_neglect, &
-                          answers_2018=answers_2018, answer_date=answer_date )
+  call bound_edge_values( N, h, u, edge_values, h_neglect, answer_date=answer_date )
 
   ! Systematically average discontinuous edge values (routine found in
   ! 'edge_values.F90')
@@ -155,7 +153,7 @@ end subroutine P1M_boundary_extrapolation
 !! linearly interpolating between them.
 !
 !! Once the edge values are estimated, the limiting process takes care of
-!! ensuring that (1) edge values are bounded by neighoring cell averages
+!! ensuring that (1) edge values are bounded by neighboring cell averages
 !! and (2) discontinuous edge values are averaged in order to provide a
 !! fully continuous interpolant throughout the domain. This last step is
 !! essential for the regridding problem to yield a unique solution.

--- a/src/ALE/P3M_functions.F90
+++ b/src/ALE/P3M_functions.F90
@@ -25,7 +25,7 @@ contains
 !!
 !! It is assumed that the size of the array 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed here.
-subroutine P3M_interpolation( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, answers_2018, answer_date )
+subroutine P3M_interpolation( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell averages (size N) in arbitrary units [A]
@@ -34,7 +34,6 @@ subroutine P3M_interpolation( N, h, u, edge_values, ppoly_S, ppoly_coef, h_negle
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Coefficients of polynomial [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for the
                                           !! purpose of cell reconstructions [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Call the limiter for p3m, which takes care of everything from
@@ -43,7 +42,7 @@ subroutine P3M_interpolation( N, h, u, edge_values, ppoly_S, ppoly_coef, h_negle
   ! 'P3M_interpolation' first but we do that to provide an homogeneous
   ! interface.
   call P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, &
-                    answers_2018=answers_2018, answer_date=answer_date )
+                    answer_date=answer_date )
 
 end subroutine P3M_interpolation
 
@@ -60,7 +59,7 @@ end subroutine P3M_interpolation
 !!    c. If not, monotonize cubic curve and rebuild it
 !!
 !! Step 3 of the monotonization process leaves all edge values unchanged.
-subroutine P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, answers_2018, answer_date )
+subroutine P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell averages (size N) in arbitrary units [A]
@@ -69,7 +68,6 @@ subroutine P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, an
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Coefficients of polynomial [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for
                                            !! the purpose of cell reconstructions [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -89,7 +87,7 @@ subroutine P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, an
   eps = 1e-10
 
   ! 1. Bound edge values (boundary cells are assumed to be local extrema)
-  call bound_edge_values( N, h, u, edge_values, hNeglect, answers_2018=answers_2018, answer_date=answer_date )
+  call bound_edge_values( N, h, u, edge_values, hNeglect, answer_date=answer_date )
 
   ! 2. Systematically average discontinuous edge values
   call average_discontinuous_edge_values( N, edge_values )
@@ -386,7 +384,7 @@ end subroutine build_cubic_interpolant
 !! Hence, we check whether the roots (if any) lie inside this interval. If there
 !! is no root or if both roots lie outside this interval, the cubic is monotonic.
 logical function is_cubic_monotonic( ppoly_coef, k )
-  real, dimension(:,:), intent(in) :: ppoly_coef !< Coefficients of cubic polynomial in arbitary units [A]
+  real, dimension(:,:), intent(in) :: ppoly_coef !< Coefficients of cubic polynomial in arbitrary units [A]
   integer,              intent(in) :: k  !< The index of the cell to work on
   ! Local variables
   real :: a, b, c   ! Coefficients of the first derivative of the cubic [A]

--- a/src/ALE/P3M_functions.F90
+++ b/src/ALE/P3M_functions.F90
@@ -25,7 +25,7 @@ contains
 !!
 !! It is assumed that the size of the array 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed here.
-subroutine P3M_interpolation( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, answers_2018 )
+subroutine P3M_interpolation( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell averages (size N) in arbitrary units [A]
@@ -35,13 +35,15 @@ subroutine P3M_interpolation( N, h, u, edge_values, ppoly_S, ppoly_coef, h_negle
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for the
                                           !! purpose of cell reconstructions [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Call the limiter for p3m, which takes care of everything from
   ! computing the coefficients of the cubic to monotonizing it.
   ! This routine could be called directly instead of having to call
   ! 'P3M_interpolation' first but we do that to provide an homogeneous
   ! interface.
-  call P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, answers_2018 )
+  call P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, &
+                    answers_2018=answers_2018, answer_date=answer_date )
 
 end subroutine P3M_interpolation
 
@@ -58,7 +60,7 @@ end subroutine P3M_interpolation
 !!    c. If not, monotonize cubic curve and rebuild it
 !!
 !! Step 3 of the monotonization process leaves all edge values unchanged.
-subroutine P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, answers_2018 )
+subroutine P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell averages (size N) in arbitrary units [A]
@@ -68,6 +70,7 @@ subroutine P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, an
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for
                                            !! the purpose of cell reconstructions [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   integer :: k            ! loop index
@@ -86,7 +89,7 @@ subroutine P3M_limiter( N, h, u, edge_values, ppoly_S, ppoly_coef, h_neglect, an
   eps = 1e-10
 
   ! 1. Bound edge values (boundary cells are assumed to be local extrema)
-  call bound_edge_values( N, h, u, edge_values, hNeglect, answers_2018 )
+  call bound_edge_values( N, h, u, edge_values, hNeglect, answers_2018=answers_2018, answer_date=answer_date )
 
   ! 2. Systematically average discontinuous edge values
   call average_discontinuous_edge_values( N, edge_values )

--- a/src/ALE/PCM_functions.F90
+++ b/src/ALE/PCM_functions.F90
@@ -42,7 +42,7 @@ end subroutine PCM_reconstruction
 !! Date of creation: 2008.06.06
 !! L. White
 !!
-!! This module contains routines that handle one-dimensionnal finite volume
+!! This module contains routines that handle one-dimensional finite volume
 !! reconstruction using the piecewise constant method (PCM).
 
 end module PCM_functions

--- a/src/ALE/PLM_functions.F90
+++ b/src/ALE/PLM_functions.F90
@@ -156,7 +156,7 @@ real elemental pure function PLM_monotonized_slope(u_l, u_c, u_r, s_l, s_c, s_r)
 end function PLM_monotonized_slope
 
 !> Returns a PLM slope using h2 extrapolation from a cell to the left.
-!! Use the negative to extrapolate from the a cell to the right.
+!! Use the negative to extrapolate from the cell to the right.
 real elemental pure function PLM_extrapolate_slope(h_l, h_c, h_neglect, u_l, u_c)
   real, intent(in) :: h_l !< Thickness of left cell [units of grid thickness]
   real, intent(in) :: h_c !< Thickness of center cell [units of grid thickness]
@@ -305,7 +305,7 @@ end subroutine PLM_boundary_extrapolation
 !! Date of creation: 2008.06.06
 !! L. White
 !!
-!! This module contains routines that handle one-dimensionnal finite volume
+!! This module contains routines that handle one-dimensional finite volume
 !! reconstruction using the piecewise linear method (PLM).
 
 end module PLM_functions

--- a/src/ALE/PPM_functions.F90
+++ b/src/ALE/PPM_functions.F90
@@ -25,14 +25,13 @@ real, parameter :: hNeglect_dflt = 1.E-30
 contains
 
 !> Builds quadratic polynomials coefficients from cell mean and edge values.
-subroutine PPM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect, answers_2018, answer_date)
+subroutine PPM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect, answer_date)
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< Cell widths [H]
   real, dimension(N),   intent(in)    :: u !< Cell averages [A]
   real, dimension(N,2), intent(inout) :: edge_values !< Edge values [A]
   real, dimension(N,3), intent(inout) :: ppoly_coef !< Polynomial coefficients, mainly [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -40,7 +39,7 @@ subroutine PPM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect, answ
   real      :: edge_l, edge_r ! Edge values (left and right)
 
   ! PPM limiter
-  call PPM_limiter_standard( N, h, u, edge_values, h_neglect, answers_2018=answers_2018, answer_date=answer_date )
+  call PPM_limiter_standard( N, h, u, edge_values, h_neglect, answer_date=answer_date )
 
   ! Loop over all cells
   do k = 1,N
@@ -60,13 +59,12 @@ end subroutine PPM_reconstruction
 !> Adjusts edge values using the standard PPM limiter (Colella & Woodward, JCP 1984)
 !! after first checking that the edge values are bounded by neighbors cell averages
 !! and that the edge values are monotonic between cell averages.
-subroutine PPM_limiter_standard( N, h, u, edge_values, h_neglect, answers_2018, answer_date )
+subroutine PPM_limiter_standard( N, h, u, edge_values, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell average properties (size N) [A]
   real, dimension(:,:), intent(inout) :: edge_values !< Potentially modified edge values [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -76,7 +74,7 @@ subroutine PPM_limiter_standard( N, h, u, edge_values, h_neglect, answers_2018, 
   real      :: expr1, expr2
 
   ! Bound edge values
-  call bound_edge_values( N, h, u, edge_values, h_neglect, answers_2018=answers_2018, answer_date=answer_date )
+  call bound_edge_values( N, h, u, edge_values, h_neglect, answer_date=answer_date )
 
   ! Make discontinuous edge values monotonic
   call check_discontinuous_edge_values( N, u, edge_values )
@@ -112,7 +110,7 @@ subroutine PPM_limiter_standard( N, h, u, edge_values, h_neglect, answers_2018, 
     endif
     ! This checks that the difference in edge values is representable
     ! and avoids overshoot problems due to round off.
-    !### The 1.e-60 needs to have units of [A], so this dimensionally inconsisent.
+    !### The 1.e-60 needs to have units of [A], so this dimensionally inconsistent.
     if ( abs( edge_r - edge_l )<max(1.e-60,epsilon(u_c)*abs(u_c)) ) then
       edge_l = u_c
       edge_r = u_c

--- a/src/ALE/PPM_functions.F90
+++ b/src/ALE/PPM_functions.F90
@@ -25,7 +25,7 @@ real, parameter :: hNeglect_dflt = 1.E-30
 contains
 
 !> Builds quadratic polynomials coefficients from cell mean and edge values.
-subroutine PPM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect, answers_2018)
+subroutine PPM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect, answers_2018, answer_date)
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< Cell widths [H]
   real, dimension(N),   intent(in)    :: u !< Cell averages [A]
@@ -33,13 +33,14 @@ subroutine PPM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect, answ
   real, dimension(N,3), intent(inout) :: ppoly_coef !< Polynomial coefficients, mainly [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   integer   :: k              ! Loop index
   real      :: edge_l, edge_r ! Edge values (left and right)
 
   ! PPM limiter
-  call PPM_limiter_standard( N, h, u, edge_values, h_neglect, answers_2018 )
+  call PPM_limiter_standard( N, h, u, edge_values, h_neglect, answers_2018=answers_2018, answer_date=answer_date )
 
   ! Loop over all cells
   do k = 1,N
@@ -59,13 +60,14 @@ end subroutine PPM_reconstruction
 !> Adjusts edge values using the standard PPM limiter (Colella & Woodward, JCP 1984)
 !! after first checking that the edge values are bounded by neighbors cell averages
 !! and that the edge values are monotonic between cell averages.
-subroutine PPM_limiter_standard( N, h, u, edge_values, h_neglect, answers_2018 )
+subroutine PPM_limiter_standard( N, h, u, edge_values, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell average properties (size N) [A]
   real, dimension(:,:), intent(inout) :: edge_values !< Potentially modified edge values [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   integer   :: k              ! Loop index
@@ -74,7 +76,7 @@ subroutine PPM_limiter_standard( N, h, u, edge_values, h_neglect, answers_2018 )
   real      :: expr1, expr2
 
   ! Bound edge values
-  call bound_edge_values( N, h, u, edge_values, h_neglect, answers_2018 )
+  call bound_edge_values( N, h, u, edge_values, h_neglect, answers_2018=answers_2018, answer_date=answer_date )
 
   ! Make discontinuous edge values monotonic
   call check_discontinuous_edge_values( N, u, edge_values )

--- a/src/ALE/PQM_functions.F90
+++ b/src/ALE/PQM_functions.F90
@@ -17,7 +17,7 @@ contains
 !!
 !! It is assumed that the dimension of 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed.
-subroutine PQM_reconstruction( N, h, u, edge_values, edge_slopes, ppoly_coef, h_neglect, answers_2018 )
+subroutine PQM_reconstruction( N, h, u, edge_values, edge_slopes, ppoly_coef, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell averages (size N) [A]
@@ -27,6 +27,7 @@ subroutine PQM_reconstruction( N, h, u, edge_values, edge_slopes, ppoly_coef, h_
   real,       optional, intent(in)    :: h_neglect  !< A negligibly small width for
                                            !! the purpose of cell reconstructions [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   integer   :: k                ! loop index
@@ -36,7 +37,7 @@ subroutine PQM_reconstruction( N, h, u, edge_values, edge_slopes, ppoly_coef, h_
   real      :: a, b, c, d, e    ! parabola coefficients
 
   ! PQM limiter
-  call PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_2018 )
+  call PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_2018=answers_2018, answer_date=answer_date )
 
   ! Loop on cells to construct the cubic within each cell
   do k = 1,N
@@ -72,7 +73,7 @@ end subroutine PQM_reconstruction
 !!
 !! It is assumed that the dimension of 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed.
-subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_2018 )
+subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell average properties (size N) [A]
@@ -81,6 +82,7 @@ subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_20
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for
                                            !! the purpose of cell reconstructions [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   integer :: k            ! loop index
@@ -102,7 +104,7 @@ subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_20
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
   ! Bound edge values
-  call bound_edge_values( N, h, u, edge_values, hNeglect, answers_2018 )
+  call bound_edge_values( N, h, u, edge_values, hNeglect, answers_2018=answers_2018, answer_date=answer_date )
 
   ! Make discontinuous edge values monotonic (thru averaging)
   call check_discontinuous_edge_values( N, u, edge_values )

--- a/src/ALE/PQM_functions.F90
+++ b/src/ALE/PQM_functions.F90
@@ -17,7 +17,7 @@ contains
 !!
 !! It is assumed that the dimension of 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed.
-subroutine PQM_reconstruction( N, h, u, edge_values, edge_slopes, ppoly_coef, h_neglect, answers_2018, answer_date )
+subroutine PQM_reconstruction( N, h, u, edge_values, edge_slopes, ppoly_coef, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell averages (size N) [A]
@@ -26,7 +26,6 @@ subroutine PQM_reconstruction( N, h, u, edge_values, edge_slopes, ppoly_coef, h_
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Coefficients of polynomial, mainly [A]
   real,       optional, intent(in)    :: h_neglect  !< A negligibly small width for
                                            !! the purpose of cell reconstructions [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -37,7 +36,7 @@ subroutine PQM_reconstruction( N, h, u, edge_values, edge_slopes, ppoly_coef, h_
   real      :: a, b, c, d, e    ! parabola coefficients
 
   ! PQM limiter
-  call PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_2018=answers_2018, answer_date=answer_date )
+  call PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answer_date=answer_date )
 
   ! Loop on cells to construct the cubic within each cell
   do k = 1,N
@@ -73,7 +72,7 @@ end subroutine PQM_reconstruction
 !!
 !! It is assumed that the dimension of 'u' is equal to the number of cells
 !! defining 'grid' and 'ppoly'. No consistency check is performed.
-subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_2018, answer_date )
+subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell average properties (size N) [A]
@@ -81,7 +80,6 @@ subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_20
   real, dimension(:,:), intent(inout) :: edge_slopes !< Potentially modified edge slopes [A H-1]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for
                                            !! the purpose of cell reconstructions [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -104,7 +102,7 @@ subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_20
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
   ! Bound edge values
-  call bound_edge_values( N, h, u, edge_values, hNeglect, answers_2018=answers_2018, answer_date=answer_date )
+  call bound_edge_values( N, h, u, edge_values, hNeglect, answer_date=answer_date )
 
   ! Make discontinuous edge values monotonic (thru averaging)
   call check_discontinuous_edge_values( N, u, edge_values )
@@ -160,7 +158,7 @@ subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answers_20
 
     ! Edge values are bounded and averaged when discontinuous and not
     ! monotonic, edge slopes are consistent and the cell is not an extremum.
-    ! We now need to check and encorce the monotonicity of the quartic within
+    ! We now need to check and enforce the monotonicity of the quartic within
     ! the cell
     if ( (inflexion_l == 0) .AND. (inflexion_r == 0) ) then
 
@@ -835,7 +833,7 @@ end subroutine PQM_boundary_extrapolation_v1
 !! Date of creation: 2008.06.06
 !! L. White
 !!
-!! This module contains routines that handle one-dimensionnal finite volume
+!! This module contains routines that handle one-dimensional finite volume
 !! reconstruction using the piecewise quartic method (PQM).
 
 end module PQM_functions

--- a/src/ALE/regrid_edge_values.F90
+++ b/src/ALE/regrid_edge_values.F90
@@ -1,4 +1,4 @@
-!> Edge value estimation for high-order resconstruction
+!> Edge value estimation for high-order reconstruction
 module regrid_edge_values
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -40,26 +40,24 @@ contains
 !!
 !! Both boundary edge values are set equal to the boundary cell averages.
 !! Any extrapolation scheme is applied after this routine has been called.
-!! Therefore, boundary cells are treated as if they were local extrama.
-subroutine bound_edge_values( N, h, u, edge_val, h_neglect, answers_2018, answer_date )
+!! Therefore, boundary cells are treated as if they were local extrema.
+subroutine bound_edge_values( N, h, u, edge_val, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_val !< Potentially modified edge values [A]; the
                                            !! second index is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   real    :: sigma_l, sigma_c, sigma_r    ! left, center and right van Leer slopes [A H-1] or [A]
   real    :: slope_x_h     ! retained PLM slope times  half grid step [A]
   real    :: hNeglect      ! A negligible thickness [H].
-  logical :: use_2018_answers  ! If true use older, less acccurate expressions.
+  logical :: use_2018_answers  ! If true use older, less accurate expressions.
   integer :: k, km1, kp1   ! Loop index and the values to either side.
 
-  use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
-  if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
+  use_2018_answers = .true. ; if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
   if (use_2018_answers) then
     hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
   endif
@@ -221,23 +219,22 @@ end subroutine edge_values_explicit_h2
 !! available interpolant.
 !!
 !! For this fourth-order scheme, at least four cells must exist.
-subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answers_2018, answer_date )
+subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_val !< Returned edge values [A]; the second index
                                            !! is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   real :: h0, h1, h2, h3        ! temporary thicknesses [H]
   real :: h_min                 ! A minimal cell width [H]
   real :: f1, f2, f3            ! auxiliary variables with various units
-  real :: et1, et2, et3         ! terms the expresson for edge values [A H]
+  real :: et1, et2, et3         ! terms the expression for edge values [A H]
   real :: I_h12                 ! The inverse of the sum of the two central thicknesses [H-1]
-  real :: I_h012, I_h123        ! Inverses of sums of three succesive thicknesses [H-1]
+  real :: I_h012, I_h123        ! Inverses of sums of three successive thicknesses [H-1]
   real :: I_den_et2, I_den_et3  ! Inverses of denominators in edge value terms [H-2]
   real, dimension(5)    :: x          ! Coordinate system with 0 at edges [H]
   real, dimension(4)    :: dz               ! A temporary array of limited layer thicknesses [H]
@@ -248,10 +245,9 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answers_2018, 
   real, dimension(4)    :: B, C
   real      :: hNeglect ! A negligible thickness in the same units as h.
   integer               :: i, j
-  logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
+  logical   :: use_2018_answers  ! If true use older, less accurate expressions.
 
-  use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
-  if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
+  use_2018_answers = .true. ; if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
   if (use_2018_answers) then
     hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
   else
@@ -387,14 +383,13 @@ end subroutine edge_values_explicit_h4
 !!
 !! There are N+1 unknowns and we are able to write N-1 equations. The
 !! boundary conditions close the system.
-subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answers_2018, answer_date )
+subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_val !< Returned edge values [A]; the second index
                                            !! is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -421,10 +416,9 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answers_2018, 
                            tri_b, &     ! tridiagonal system (right hand side) [A]
                            tri_x        ! tridiagonal system (solution vector) [A]
   real      :: hNeglect          ! A negligible thickness [H]
-  logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
+  logical   :: use_2018_answers  ! If true use older, less accurate expressions.
 
-  use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
-  if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
+  use_2018_answers = .true. ; if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
   if (use_2018_answers) then
     hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
   else
@@ -590,7 +584,7 @@ subroutine end_value_h4(dz, u, Csys)
  !   Csys(4) = ((u(2)-u(1)) - 2.0 * (u(3)-u(2)) + (u(4)-u(3))) * (0.5*C1_3)
  ! else
 
-  ! Express the coefficients as sums of the differences between properties of succesive layers.
+  ! Express the coefficients as sums of the differences between properties of successive layers.
 
   h1 = dz(1) ; h2 = dz(2) ; h3 = dz(3) ; h4 = dz(4)
   ! Some of the weights used below are proportional to (h1/(h2+h3))**2 or (h1/(h2+h3))*(h2/(h3+h4))
@@ -697,14 +691,13 @@ end subroutine end_value_h4
 !!
 !! There are N+1 unknowns and we are able to write N-1 equations. The
 !! boundary conditions close the system.
-subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answers_2018, answer_date )
+subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_slopes !< Returned edge slopes [A H-1]; the
                                            !! second index is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -733,12 +726,11 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answers_201
                            tri_x        ! tridiagonal system (solution vector) [A H-1]
   real      :: hNeglect  ! A negligible thickness [H].
   real      :: hNeglect3 ! hNeglect^3 [H3].
-  logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
+  logical   :: use_2018_answers  ! If true use older, less accurate expressions.
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect))  hNeglect = h_neglect
   hNeglect3 = hNeglect**3
-  use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
-  if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
+  use_2018_answers = .true. ; if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
 
   ! Loop on cells (except last one)
   do i = 1,N-1
@@ -869,14 +861,13 @@ end subroutine edge_slopes_implicit_h3
 
 !------------------------------------------------------------------------------
 !> Compute ih5 edge slopes (implicit fifth order accurate)
-subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answers_2018, answer_date )
+subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_slopes !< Returned edge slopes [A H-1]; the
                                            !! second index is for the two edges of each cell.
   real, optional,       intent(in)    :: h_neglect !< A negligibly small width [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
 ! -----------------------------------------------------------------------------
@@ -1141,14 +1132,13 @@ end subroutine edge_slopes_implicit_h5
 !!          become computationally expensive if regridding is carried out
 !!          often. Figuring out closed-form expressions for these coefficients
 !!          on nonuniform meshes turned out to be intractable.
-subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answers_2018, answer_date )
+subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties (size N) in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_val  !< Returned edge values [A]; the second index
                                            !! is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
-  logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables

--- a/src/ALE/regrid_edge_values.F90
+++ b/src/ALE/regrid_edge_values.F90
@@ -41,7 +41,7 @@ contains
 !! Both boundary edge values are set equal to the boundary cell averages.
 !! Any extrapolation scheme is applied after this routine has been called.
 !! Therefore, boundary cells are treated as if they were local extrama.
-subroutine bound_edge_values( N, h, u, edge_val, h_neglect, answers_2018 )
+subroutine bound_edge_values( N, h, u, edge_val, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
@@ -49,6 +49,8 @@ subroutine bound_edge_values( N, h, u, edge_val, h_neglect, answers_2018 )
                                            !! second index is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
+
   ! Local variables
   real    :: sigma_l, sigma_c, sigma_r    ! left, center and right van Leer slopes [A H-1] or [A]
   real    :: slope_x_h     ! retained PLM slope times  half grid step [A]
@@ -57,6 +59,7 @@ subroutine bound_edge_values( N, h, u, edge_val, h_neglect, answers_2018 )
   integer :: k, km1, kp1   ! Loop index and the values to either side.
 
   use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
+  if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
   if (use_2018_answers) then
     hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
   endif
@@ -218,7 +221,7 @@ end subroutine edge_values_explicit_h2
 !! available interpolant.
 !!
 !! For this fourth-order scheme, at least four cells must exist.
-subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
+subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
@@ -226,6 +229,7 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
                                            !! is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   real :: h0, h1, h2, h3        ! temporary thicknesses [H]
@@ -247,6 +251,7 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
   logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
 
   use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
+  if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
   if (use_2018_answers) then
     hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
   else
@@ -382,7 +387,7 @@ end subroutine edge_values_explicit_h4
 !!
 !! There are N+1 unknowns and we are able to write N-1 equations. The
 !! boundary conditions close the system.
-subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
+subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
@@ -390,6 +395,7 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
                                            !! is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   integer               :: i, j                 ! loop indexes
@@ -418,6 +424,7 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answers_2018 )
   logical   :: use_2018_answers  ! If true use older, less acccurate expressions.
 
   use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
+  if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
   if (use_2018_answers) then
     hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
   else
@@ -690,7 +697,7 @@ end subroutine end_value_h4
 !!
 !! There are N+1 unknowns and we are able to write N-1 equations. The
 !! boundary conditions close the system.
-subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answers_2018 )
+subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
@@ -698,6 +705,8 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answers_201
                                            !! second index is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
+
   ! Local variables
   integer               :: i, j                 ! loop indexes
   real                  :: h0, h1               ! cell widths [H or nondim]
@@ -729,6 +738,7 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answers_201
   hNeglect = hNeglect_dflt ; if (present(h_neglect))  hNeglect = h_neglect
   hNeglect3 = hNeglect**3
   use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
+  if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
 
   ! Loop on cells (except last one)
   do i = 1,N-1
@@ -859,7 +869,7 @@ end subroutine edge_slopes_implicit_h3
 
 !------------------------------------------------------------------------------
 !> Compute ih5 edge slopes (implicit fifth order accurate)
-subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answers_2018 )
+subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
@@ -867,6 +877,8 @@ subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answers_201
                                            !! second index is for the two edges of each cell.
   real, optional,       intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
+
 ! -----------------------------------------------------------------------------
 ! Fifth-order implicit estimates of edge slopes are based on a four-cell,
 ! three-edge stencil. A tridiagonal system is set up and is based on
@@ -1129,7 +1141,7 @@ end subroutine edge_slopes_implicit_h5
 !!          become computationally expensive if regridding is carried out
 !!          often. Figuring out closed-form expressions for these coefficients
 !!          on nonuniform meshes turned out to be intractable.
-subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answers_2018 )
+subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answers_2018, answer_date )
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< cell widths [H]
   real, dimension(N),   intent(in)    :: u !< cell average properties (size N) in arbitrary units [A]
@@ -1137,6 +1149,7 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answers_2018 )
                                            !! is for the two edges of each cell.
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
   logical,    optional, intent(in)    :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   real :: h0, h1, h2, h3       ! cell widths [H]

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -31,12 +31,12 @@ type, public :: interp_CS_type ; private
   !! boundary cells
   logical :: boundary_extrapolation
 
-   !> If true use older, less acccurate expressions.
-  logical :: answers_2018 = .true.
+  !> The vintage of the expressions to use for remapping
+  integer :: answer_date = 20181231  !### Change to 99991231?
+  !### There is no point where the value of answer_date is reset.
 end type interp_CS_type
 
-public regridding_set_ppolys, interpolate_grid
-public build_and_interpolate_grid
+public regridding_set_ppolys, build_and_interpolate_grid
 public set_interp_scheme, set_interp_extrap
 
 ! List of interpolation schemes
@@ -107,7 +107,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_P1M_H2 )
       degree = DEGREE_1
       call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
       if (extrapolate) then
         call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
       endif
@@ -115,11 +115,11 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_P1M_H4 )
       degree = DEGREE_1
       if ( n0 >= 4 ) then
-        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
+        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answer_date=CS%answer_date )
       else
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
       endif
-      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
       if (extrapolate) then
         call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
       endif
@@ -127,11 +127,11 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_P1M_IH4 )
       degree = DEGREE_1
       if ( n0 >= 4 ) then
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answer_date=CS%answer_date )
       else
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
       endif
-      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+      call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
       if (extrapolate) then
         call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
       endif
@@ -146,8 +146,8 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_PPM_H4 )
       if ( n0 >= 4 ) then
         degree = DEGREE_2
-        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+        call edge_values_explicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answer_date=CS%answer_date )
+        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, &
                                            ppoly0_coefs, h_neglect )
@@ -155,7 +155,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       else
         degree = DEGREE_1
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -164,8 +164,8 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_PPM_IH4 )
       if ( n0 >= 4 ) then
         degree = DEGREE_2
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answer_date=CS%answer_date )
+        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, &
                                            ppoly0_coefs, h_neglect )
@@ -173,7 +173,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       else
         degree = DEGREE_1
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -182,10 +182,10 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_P3M_IH4IH3 )
       if ( n0 >= 4 ) then
         degree = DEGREE_3
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answer_date=CS%answer_date )
+        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect, answer_date=CS%answer_date )
         call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
-                                ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+                                ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call P3M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                            ppoly0_coefs, h_neglect, h_neglect_edge )
@@ -193,7 +193,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       else
         degree = DEGREE_1
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -202,10 +202,10 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_P3M_IH6IH5 )
       if ( n0 >= 6 ) then
         degree = DEGREE_3
-        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
+        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge, answer_date=CS%answer_date )
+        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect, answer_date=CS%answer_date )
         call P3M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
-                                ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+                                ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call P3M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_S, &
                    ppoly0_coefs, h_neglect, h_neglect_edge )
@@ -213,7 +213,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       else
         degree = DEGREE_1
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -222,10 +222,10 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_PQM_IH4IH3 )
       if ( n0 >= 4 ) then
         degree = DEGREE_4
-        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
+        call edge_values_implicit_h4( n0, h0, densities, ppoly0_E, h_neglect_edge, answer_date=CS%answer_date )
+        call edge_slopes_implicit_h3( n0, h0, densities, ppoly0_S, h_neglect, answer_date=CS%answer_date )
         call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, &
-                                 ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+                                 ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call PQM_boundary_extrapolation_v1( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                  ppoly0_coefs, h_neglect )
@@ -233,7 +233,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       else
         degree = DEGREE_1
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -242,10 +242,10 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
     case ( INTERPOLATION_PQM_IH6IH5 )
       if ( n0 >= 6 ) then
         degree = DEGREE_4
-        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge, answers_2018=CS%answers_2018 )
-        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect, answers_2018=CS%answers_2018 )
+        call edge_values_implicit_h6( n0, h0, densities, ppoly0_E, h_neglect_edge, answer_date=CS%answer_date )
+        call edge_slopes_implicit_h5( n0, h0, densities, ppoly0_S, h_neglect, answer_date=CS%answer_date )
         call PQM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_S, &
-                                 ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+                                 ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call PQM_boundary_extrapolation_v1( n0, h0, densities, ppoly0_E, ppoly0_S, &
                                  ppoly0_coefs, h_neglect )
@@ -253,7 +253,7 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       else
         degree = DEGREE_1
         call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
-        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answers_2018=CS%answers_2018 )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
         if (extrapolate) then
           call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
         endif
@@ -268,7 +268,7 @@ end subroutine regridding_set_ppolys
 !! 'ppoly0' (possibly discontinuous), the coordinates of the new grid 'grid1'
 !! are determined by finding the corresponding target interface densities.
 subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
-                             target_values, degree, n1, h1, x1, answers_2018 )
+                             target_values, degree, n1, h1, x1, answer_date )
   integer,               intent(in)     :: n0            !< Number of points on source grid
   integer,               intent(in)     :: n1            !< Number of points on target grid
   real, dimension(n0),   intent(in)     :: h0            !< Thicknesses of source grid cells [H]
@@ -280,7 +280,7 @@ subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
   integer,                intent(in)    :: degree        !< Degree of interpolating polynomials
   real, dimension(n1),    intent(inout) :: h1            !< Thicknesses of target grid cells [H]
   real, dimension(n1+1),  intent(inout) :: x1            !< Target interface positions [H]
-  logical,      optional, intent(in)    :: answers_2018  !< If true use older, less acccurate expressions.
+  integer,      optional, intent(in)    :: answer_date   !< The vintage of the expressions to use
 
   ! Local variables
   integer        :: k ! loop index
@@ -295,7 +295,7 @@ subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
   do k = 2,n1
     t = target_values(k)
     x1(k) = get_polynomial_coordinate ( n0, h0, x0, ppoly0_E, ppoly0_coefs, t, degree, &
-                                        answers_2018=answers_2018 )
+                                        answer_date=answer_date )
     h1(k-1) = x1(k) - x1(k-1)
   enddo
   h1(n1) = x1(n1+1) - x1(n1)
@@ -329,7 +329,7 @@ subroutine build_and_interpolate_grid(CS, densities, n0, h0, x0, target_values, 
   call regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, ppoly0_C, &
        degree, h_neglect, h_neglect_edge)
   call interpolate_grid(n0, h0, x0, ppoly0_E, ppoly0_C, target_values, degree, &
-       n1, h1, x1, answers_2018=CS%answers_2018)
+       n1, h1, x1, answer_date=CS%answer_date)
 end subroutine build_and_interpolate_grid
 
 !> Given a target value, find corresponding coordinate for given polynomial
@@ -349,7 +349,7 @@ end subroutine build_and_interpolate_grid
 !! It is assumed that the number of cells defining 'grid' and 'ppoly' are the
 !! same.
 function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
-                                    target_value, degree, answers_2018 ) result ( x_tgt )
+                                    target_value, degree, answer_date ) result ( x_tgt )
   ! Arguments
   integer,              intent(in) :: N            !< Number of grid cells
   real, dimension(N),   intent(in) :: h            !< Grid cell thicknesses [H]
@@ -358,7 +358,7 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   real, dimension(N,DEGREE_MAX+1), intent(in) :: ppoly_coefs  !< Coefficients of interpolating polynomials [A]
   real,                 intent(in) :: target_value !< Target value to find position for [A]
   integer,              intent(in) :: degree       !< Degree of the interpolating polynomials
-  logical,    optional, intent(in) :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,              intent(in) :: answer_date  !< The vintage of the expressions to use
   real                             :: x_tgt        !< The position of x_g at which target_value is found [H]
 
   ! Local variables
@@ -373,11 +373,11 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   integer :: i, k, iter  ! loop indices
   integer :: k_found     ! index of target cell
   character(len=320) :: mesg
-  logical :: use_2018_answers  ! If true use older, less acccurate expressions.
+  logical :: use_2018_answers  ! If true use older, less accurate expressions.
 
   eps = NR_OFFSET
   k_found = -1
-  use_2018_answers = .true. ; if (present(answers_2018)) use_2018_answers = answers_2018
+  use_2018_answers = (answer_date < 20190101)
 
   ! If the target value is outside the range of all values, we
   ! force the target coordinate to be equal to the lowest or

--- a/src/ALE/regrid_solvers.F90
+++ b/src/ALE/regrid_solvers.F90
@@ -16,12 +16,11 @@ contains
 !! This routine uses Gauss's algorithm to transform the system's original
 !! matrix into an upper triangular matrix. Back substitution yields the answer.
 !! The matrix A must be square, with the first index varing down the column.
-subroutine solve_linear_system( A, R, X, N, answers_2018, answer_date )
+subroutine solve_linear_system( A, R, X, N, answer_date )
   integer,              intent(in)    :: N  !< The size of the system
   real, dimension(N,N), intent(inout) :: A  !< The matrix being inverted [nondim]
   real, dimension(N),   intent(inout) :: R  !< system right-hand side [A]
   real, dimension(N),   intent(inout) :: X  !< solution vector [A]
-  logical,    optional, intent(in)    :: answers_2018 !< If true or absent use older, less efficient expressions.
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
   ! Local variables
   real, parameter       :: eps = 0.0        ! Minimum pivot magnitude allowed
@@ -32,8 +31,7 @@ subroutine solve_linear_system( A, R, X, N, answers_2018, answer_date )
   logical :: old_answers  ! If true, use expressions that give the original (2008 through 2018) MOM6 answers
   integer :: i, j, k
 
-  old_answers = .true. ; if (present(answers_2018)) old_answers = answers_2018
-  if (present(answer_date)) old_answers = (answer_date < 20190101)
+  old_answers = .true. ; if (present(answer_date)) old_answers = (answer_date < 20190101)
 
   ! Loop on rows to transform the problem into multiplication by an upper-right matrix.
   do i = 1,N-1
@@ -175,14 +173,13 @@ end subroutine linear_solver
 !!
 !! This routine uses Thomas's algorithm to solve the tridiagonal system AX = R.
 !! (A is made up of lower, middle and upper diagonals)
-subroutine solve_tridiagonal_system( Al, Ad, Au, R, X, N, answers_2018, answer_date )
+subroutine solve_tridiagonal_system( Al, Ad, Au, R, X, N, answer_date )
   integer,            intent(in)  :: N   !< The size of the system
   real, dimension(N), intent(in)  :: Ad  !< Matrix center diagonal
   real, dimension(N), intent(in)  :: Al  !< Matrix lower diagonal
   real, dimension(N), intent(in)  :: Au  !< Matrix upper diagonal
   real, dimension(N), intent(in)  :: R   !< system right-hand side
   real, dimension(N), intent(out) :: X   !< solution vector
-  logical,  optional, intent(in)  :: answers_2018 !< If true use older, less acccurate expressions.
   integer,  optional, intent(in)  :: answer_date  !< The vintage of the expressions to use
   ! Local variables
   real, dimension(N) :: pivot, Al_piv
@@ -191,8 +188,7 @@ subroutine solve_tridiagonal_system( Al, Ad, Au, R, X, N, answers_2018, answer_d
   integer :: k        ! Loop index
   logical :: old_answers  ! If true, use expressions that give the original (2008 through 2018) MOM6 answers
 
-  old_answers = .true. ; if (present(answers_2018)) old_answers = answers_2018
-  if (present(answer_date)) old_answers = (answer_date < 20190101)
+  old_answers = .true. ; if (present(answer_date)) old_answers = (answer_date < 20190101)
 
   if (old_answers) then
     ! This version gives the same answers as the original (2008 through 2018) MOM6 code

--- a/src/ALE/regrid_solvers.F90
+++ b/src/ALE/regrid_solvers.F90
@@ -16,12 +16,13 @@ contains
 !! This routine uses Gauss's algorithm to transform the system's original
 !! matrix into an upper triangular matrix. Back substitution yields the answer.
 !! The matrix A must be square, with the first index varing down the column.
-subroutine solve_linear_system( A, R, X, N, answers_2018 )
+subroutine solve_linear_system( A, R, X, N, answers_2018, answer_date )
   integer,              intent(in)    :: N  !< The size of the system
   real, dimension(N,N), intent(inout) :: A  !< The matrix being inverted [nondim]
   real, dimension(N),   intent(inout) :: R  !< system right-hand side [A]
   real, dimension(N),   intent(inout) :: X  !< solution vector [A]
   logical,    optional, intent(in)    :: answers_2018 !< If true or absent use older, less efficient expressions.
+  integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
   ! Local variables
   real, parameter       :: eps = 0.0        ! Minimum pivot magnitude allowed
   real    :: factor       ! The factor that eliminates the leading nonzero element in a row.
@@ -32,6 +33,7 @@ subroutine solve_linear_system( A, R, X, N, answers_2018 )
   integer :: i, j, k
 
   old_answers = .true. ; if (present(answers_2018)) old_answers = answers_2018
+  if (present(answer_date)) old_answers = (answer_date < 20190101)
 
   ! Loop on rows to transform the problem into multiplication by an upper-right matrix.
   do i = 1,N-1
@@ -173,7 +175,7 @@ end subroutine linear_solver
 !!
 !! This routine uses Thomas's algorithm to solve the tridiagonal system AX = R.
 !! (A is made up of lower, middle and upper diagonals)
-subroutine solve_tridiagonal_system( Al, Ad, Au, R, X, N, answers_2018 )
+subroutine solve_tridiagonal_system( Al, Ad, Au, R, X, N, answers_2018, answer_date )
   integer,            intent(in)  :: N   !< The size of the system
   real, dimension(N), intent(in)  :: Ad  !< Matrix center diagonal
   real, dimension(N), intent(in)  :: Al  !< Matrix lower diagonal
@@ -181,6 +183,7 @@ subroutine solve_tridiagonal_system( Al, Ad, Au, R, X, N, answers_2018 )
   real, dimension(N), intent(in)  :: R   !< system right-hand side
   real, dimension(N), intent(out) :: X   !< solution vector
   logical,  optional, intent(in)  :: answers_2018 !< If true use older, less acccurate expressions.
+  integer,  optional, intent(in)  :: answer_date  !< The vintage of the expressions to use
   ! Local variables
   real, dimension(N) :: pivot, Al_piv
   real, dimension(N) :: c1       ! Au / pivot for the backward sweep
@@ -189,6 +192,7 @@ subroutine solve_tridiagonal_system( Al, Ad, Au, R, X, N, answers_2018 )
   logical :: old_answers  ! If true, use expressions that give the original (2008 through 2018) MOM6 answers
 
   old_answers = .true. ; if (present(answers_2018)) old_answers = answers_2018
+  if (present(answer_date)) old_answers = (answer_date < 20190101)
 
   if (old_answers) then
     ! This version gives the same answers as the original (2008 through 2018) MOM6 code

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -333,9 +333,10 @@ type, public :: MOM_control_struct ; private
   real    :: bad_val_sst_min    !< Minimum SST before triggering bad value message [degC]
   real    :: bad_val_sss_max    !< Maximum SSS before triggering bad value message [ppt]
   real    :: bad_val_col_thick  !< Minimum column thickness before triggering bad value message [Z ~> m]
-  logical :: answers_2018       !< If true, use expressions for the surface properties that recover
-                                !! the answers from the end of 2018. Otherwise, use more appropriate
-                                !! expressions that differ at roundoff for non-Boussinesq cases.
+  integer :: answer_date        !< The vintage of the expressions for the surface properties.  Values
+                                !! below 20190101 recover the answers from the end of 2018, while
+                                !! higher values use more appropriate expressions that differ at
+                                !! roundoff for non-Boussinesq cases.
   logical :: use_particles      !< Turns on the particles package
   character(len=10) :: particle_type !< Particle types include: surface(default), profiling and sail drone.
 
@@ -1823,7 +1824,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                                ! with accumulated heat deficit returned to surface ocean.
   logical :: bound_salinity    ! If true, salt is added to keep salinity above
                                ! a minimum value, and the deficit is reported.
+  integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
+  logical :: answers_2018      ! If true, use expressions for the surface properties that recover
+                               ! the answers from the end of 2018. Otherwise, use more appropriate
+                               ! expressions that differ at roundoff for non-Boussinesq cases.
   logical :: use_conT_absS     ! If true, the prognostics T & S are conservative temperature
                                ! and absolute salinity. Care should be taken to convert them
                                ! to potential temperature and practical salinity before
@@ -2147,13 +2152,26 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "triggered, if CHECK_BAD_SURFACE_VALS is true.", &
                  units="m", default=0.0, scale=US%m_to_Z)
   endif
+  call get_param(param_file, "MOM", "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231)
   call get_param(param_file, "MOM", "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=.false.)
-  call get_param(param_file, "MOM", "SURFACE_2018_ANSWERS", CS%answers_2018, &
+                 default=(default_answer_date<20190101))
+  call get_param(param_file, "MOM", "SURFACE_2018_ANSWERS", answers_2018, &
                  "If true, use expressions for the surface properties that recover the answers "//&
                  "from the end of 2018. Otherwise, use more appropriate expressions that differ "//&
                  "at roundoff for non-Boussinesq cases.", default=default_2018_answers)
+  ! Revise inconsistent default answer dates.
+  if (answers_2018 .and. (default_answer_date >= 20190101)) default_answer_date = 20181231
+  if (.not.answers_2018 .and. (default_answer_date < 20190101)) default_answer_date = 20190101
+  call get_param(param_file, "MOM", "SURFACE_ANSWER_DATE", CS%answer_date, &
+               "The vintage of the expressions for the surface properties.  Values below "//&
+               "20190101 recover the answers from the end of 2018, while higher values "//&
+               "use updated and more robust forms of the same expressions.  "//&
+               "If both SURFACE_2018_ANSWERS and SURFACE_ANSWER_DATE are specified, the "//&
+               "latter takes precedence.", default=default_answer_date)
+
   call get_param(param_file, "MOM", "USE_DIABATIC_TIME_BUG", CS%use_diabatic_time_bug, &
                  "If true, uses the wrong calendar time for diabatic processes, as was "//&
                  "done in MOM6 versions prior to February 2018. This is not recommended.", &
@@ -3343,9 +3361,9 @@ subroutine extract_surface_state(CS, sfc_state_in)
     enddo ; enddo
 
   else  ! (CS%Hmix >= 0.0)
-    H_rescale = 1.0 ; if (CS%answers_2018) H_rescale = GV%H_to_Z
+    H_rescale = 1.0 ; if (CS%answer_date < 20190101) H_rescale = GV%H_to_Z
     depth_ml = CS%Hmix
-    if (.not.CS%answers_2018) depth_ml = CS%Hmix*GV%Z_to_H
+    if (CS%answer_date >= 20190101) depth_ml = CS%Hmix*GV%Z_to_H
     ! Determine the mean tracer properties of the uppermost depth_ml fluid.
 
     !$OMP parallel do default(shared) private(depth,dh)
@@ -3377,7 +3395,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
       enddo ; enddo
   ! Calculate the average properties of the mixed layer depth.
       do i=is,ie
-        if (CS%answers_2018) then
+        if (CS%answer_date < 20190101) then
           if (depth(i) < GV%H_subroundoff*H_rescale) &
               depth(i) = GV%H_subroundoff*H_rescale
           if (use_temperature) then
@@ -3416,7 +3434,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
     !       This assumes that u and v halos have already been updated.
     if (CS%Hmix_UV>0.) then
       depth_ml = CS%Hmix_UV
-      if (.not.CS%answers_2018) depth_ml = CS%Hmix_UV*GV%Z_to_H
+      if (CS%answer_date >= 20190101) depth_ml = CS%Hmix_UV*GV%Z_to_H
       !$OMP parallel do default(shared) private(depth,dh,hv)
       do J=js-1,ie
         do i=is,ie

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -625,7 +625,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
           "round off.", default=.false.,do_not_log=.true.)
     call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231, do_not_log=.true.)
+                 default=99991231)
     call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=(default_answer_date<20190101))
@@ -633,11 +633,16 @@ subroutine open_boundary_config(G, US, param_file, OBC)
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-    if (answers_2018) then
-      OBC%remap_answer_date = 20181231
-    else
-      OBC%remap_answer_date = 20190101
-    endif
+    ! Revise inconsistent default answer dates for remapping.
+    if (answers_2018 .and. (default_answer_date >= 20190101)) default_answer_date = 20181231
+    if (.not.answers_2018 .and. (default_answer_date < 20190101)) default_answer_date = 20190101
+    call get_param(param_file, mdl, "REMAPPING_ANSWER_DATE", OBC%remap_answer_date, &
+                 "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
+                 "Values below 20190101 result in the use of older, less accurate expressions "//&
+                 "that were in use at the end of 2018.  Higher values result in the use of more "//&
+                 "robust and accurate forms of mathematically equivalent expressions.  "//&
+                 "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_answer_date)
 
     allocate(OBC%remap_CS)
     call initialize_remapping(OBC%remap_CS, remappingScheme, boundary_extrapolation = .false., &

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1587,7 +1587,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
                  "starting point for iterations.", default=.true.)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231, do_not_log=.true.)
+                 default=99991231)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=(default_answer_date<20190101))
@@ -1595,11 +1595,16 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  if (remap_answers_2018) then
-    remap_answer_date = 20181231
-  else
-    remap_answer_date = 20190101
-  endif
+  ! Revise inconsistent default answer dates for remapping.
+  if (remap_answers_2018 .and. (default_answer_date >= 20190101)) default_answer_date = 20181231
+  if (.not.remap_answers_2018 .and. (default_answer_date < 20190101)) default_answer_date = 20190101
+  call get_param(param_file, mdl, "REMAPPING_ANSWER_DATE", remap_answer_date, &
+                 "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
+                 "Values below 20190101 result in the use of older, less accurate expressions "//&
+                 "that were in use at the end of 2018.  Higher values result in the use of more "//&
+                 "robust and accurate forms of mathematically equivalent expressions.  "//&
+                 "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_answer_date)
 
   call get_param(param_file, mdl, "SPLIT", split, default=.true., do_not_log=.true.)
 

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1551,7 +1551,13 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   character(len=40)  :: mdl = "MOM_diagnostics" ! This module's name.
   character(len=48) :: thickness_units, flux_units
   logical :: use_temperature, adiabatic
-  logical :: default_2018_answers, remap_answers_2018
+  integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
+  integer :: remap_answer_date    ! The vintage of the order of arithmetic and expressions to use
+                                  ! for remapping.  Values below 20190101 recover the remapping
+                                  ! answers from 2018, while higher values use more robust
+                                  ! forms of the same remapping expressions.
+  logical :: remap_answers_2018
 
   CS%initialized = .true.
 
@@ -1579,13 +1585,22 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   call get_param(param_file, mdl, "INTERNAL_WAVE_SPEED_BETTER_EST", better_speed_est, &
                  "If true, use a more robust estimate of the first mode wave speed as the "//&
                  "starting point for iterations.", default=.true.)
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231, do_not_log=.true.)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=.false.)
+                 default=(default_answer_date<20190101))
   call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", remap_answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
+  if (remap_answers_2018) then
+    remap_answer_date = 20181231
+  else
+    remap_answer_date = 20190101
+  endif
+
   call get_param(param_file, mdl, "SPLIT", split, default=.true., do_not_log=.true.)
 
   if (GV%Boussinesq) then
@@ -1813,7 +1828,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   if ((CS%id_cg1>0) .or. (CS%id_Rd1>0) .or. (CS%id_cfl_cg1>0) .or. &
       (CS%id_cfl_cg1_x>0) .or. (CS%id_cfl_cg1_y>0) .or. &
       (CS%id_cg_ebt>0) .or. (CS%id_Rd_ebt>0) .or. (CS%id_p_ebt>0)) then
-    call wave_speed_init(CS%wave_speed, remap_answers_2018=remap_answers_2018, &
+    call wave_speed_init(CS%wave_speed, remap_answer_date=remap_answer_date, &
                          better_speed_est=better_speed_est, min_speed=wave_speed_min, &
                          wave_speed_tol=wave_speed_tol)
   endif

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -3181,7 +3181,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
                  default=1)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231, do_not_log=.true.)
+                 default=99991231)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=(default_answer_date<20190101))
@@ -3189,11 +3189,16 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  if (remap_answers_2018) then
-    remap_answer_date = 20181231
-  else
-    remap_answer_date = 20190101
-  endif
+  ! Revise inconsistent default answer dates for remapping.
+  if (remap_answers_2018 .and. (default_answer_date >= 20190101)) default_answer_date = 20181231
+  if (.not.remap_answers_2018 .and. (default_answer_date < 20190101)) default_answer_date = 20190101
+  call get_param(param_file, mdl, "REMAPPING_ANSWER_DATE", remap_answer_date, &
+                 "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
+                 "Values below 20190101 result in the use of older, less accurate expressions "//&
+                 "that were in use at the end of 2018.  Higher values result in the use of more "//&
+                 "robust and accurate forms of mathematically equivalent expressions.  "//&
+                 "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_answer_date)
   call get_param(param_file, mdl, 'USE_GRID_SPACE_DIAGNOSTIC_AXES', diag_cs%grid_space_axes, &
                  'If true, use a grid index coordinate convention for diagnostic axes. ',&
                  default=.false.)

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2491,6 +2491,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                                   ! answers from 2018, while higher values use more robust
                                   ! forms of the same remapping expressions.
   logical :: hor_regrid_answers_2018
+  integer :: default_hor_reg_ans_date ! The default setting for hor_regrid_answer_date
   integer :: hor_regrid_answer_date  ! The vintage of the order of arithmetic and expressions to use
                                   ! for horizontal regridding.  Values below 20190101 recover the
                                   ! answers from 2018, while higher values use expressions that have
@@ -2603,7 +2604,17 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  "If true, use the order of arithmetic for horizonal regridding that recovers "//&
                  "the answers from the end of 2018.  Otherwise, use rotationally symmetric "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  hor_regrid_answer_date = 20190101 ; if (hor_regrid_answers_2018) hor_regrid_answer_date = 20181231
+  ! Revise inconsistent default answer dates for horizontal regridding.
+  default_hor_reg_ans_date = default_answer_date
+  if (hor_regrid_answers_2018 .and. (default_hor_reg_ans_date >= 20190101)) default_hor_reg_ans_date = 20181231
+  if (.not.hor_regrid_answers_2018 .and. (default_hor_reg_ans_date < 20190101)) default_hor_reg_ans_date = 20190101
+  call get_param(PF, mdl, "HOR_REGRID_ANSWER_DATE", hor_regrid_answer_date, &
+                 "The vintage of the order of arithmetic for horizontal regridding.  "//&
+                 "Dates before 20190101 give the same answers as the code did in late 2018, "//&
+                 "while later versions add parentheses for rotational symmetry.  "//&
+                 "If both HOR_REGRID_2018_ANSWERS and HOR_REGRID_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_hor_reg_ans_date)
+
   if (.not.useALEremapping) then
     call get_param(PF, mdl, "ADJUST_THICKNESS", correct_thickness, &
                  "If true, all mass below the bottom removed if the "//&

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1194,21 +1194,21 @@ subroutine trim_for_ice(PF, G, GV, US, ALE_CSp, tv, h, just_read)
                  "file SURFACE_PRESSURE_FILE into a surface pressure.", &
                  units="file dependent", default=1., do_not_log=just_read)
   call get_param(PF, mdl, "MIN_THICKNESS", min_thickness, 'Minimum layer thickness', &
-                 units='m', default=1.e-3, do_not_log=just_read, scale=US%m_to_Z)
+                 units='m', default=1.e-3, scale=US%m_to_Z, do_not_log=just_read)
   call get_param(PF, mdl, "TRIMMING_USES_REMAPPING", use_remapping, &
                  'When trimming the column, also remap T and S.', &
                  default=.false., do_not_log=just_read)
   if (use_remapping) then
     call get_param(PF, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231)
+                 default=99991231, do_not_log=just_read)
     call get_param(PF, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=(default_answer_date<20190101))
+                 default=(default_answer_date<20190101), do_not_log=just_read)
     call get_param(PF, mdl, "REMAPPING_2018_ANSWERS", remap_answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
-                 "forms of the same expressions.", default=default_2018_answers)
+                 "forms of the same expressions.", default=default_2018_answers, do_not_log=just_read)
     ! Revise inconsistent default answer dates for remapping.
     if (remap_answers_2018 .and. (default_answer_date >= 20190101)) default_answer_date = 20181231
     if (.not.remap_answers_2018 .and. (default_answer_date < 20190101)) default_answer_date = 20190101
@@ -1218,7 +1218,7 @@ subroutine trim_for_ice(PF, G, GV, US, ALE_CSp, tv, h, just_read)
                  "that were in use at the end of 2018.  Higher values result in the use of more "//&
                  "robust and accurate forms of mathematically equivalent expressions.  "//&
                  "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
-                 "latter takes precedence.", default=default_answer_date)
+                 "latter takes precedence.", default=default_answer_date, do_not_log=just_read)
   else
     remap_answer_date = 20181231
   endif
@@ -2574,20 +2574,20 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  default=.false., do_not_log=just_read)
   call get_param(PF, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231)
+                 default=99991231, do_not_log=just_read)
   call get_param(PF, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=(default_answer_date<20190101))
+                 default=(default_answer_date<20190101), do_not_log=just_read)
   call get_param(PF, mdl, "TEMP_SALT_INIT_VERTICAL_REMAP_ONLY", pre_gridded, &
                  "If true, initial conditions are on the model horizontal grid. " //&
                  "Extrapolation over missing ocean values is done using an ICE-9 "//&
                  "procedure with vertical ALE remapping .", &
-                 default=.false.)
+                 default=.false., do_not_log=just_read)
   if (useALEremapping) then
     call get_param(PF, mdl, "REMAPPING_2018_ANSWERS", remap_answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
-                 "forms of the same expressions.", default=default_2018_answers)
+                 "forms of the same expressions.", default=default_2018_answers, do_not_log=just_read)
     ! Revise inconsistent default answer dates for remapping.
     default_remap_ans_date = default_answer_date
     if (remap_answers_2018 .and. (default_remap_ans_date >= 20190101)) default_remap_ans_date = 20181231
@@ -2598,12 +2598,12 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  "that were in use at the end of 2018.  Higher values result in the use of more "//&
                  "robust and accurate forms of mathematically equivalent expressions.  "//&
                  "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
-                 "latter takes precedence.", default=default_remap_ans_date)
+                 "latter takes precedence.", default=default_remap_ans_date, do_not_log=just_read)
   endif
   call get_param(PF, mdl, "HOR_REGRID_2018_ANSWERS", hor_regrid_answers_2018, &
                  "If true, use the order of arithmetic for horizonal regridding that recovers "//&
                  "the answers from the end of 2018.  Otherwise, use rotationally symmetric "//&
-                 "forms of the same expressions.", default=default_2018_answers)
+                 "forms of the same expressions.", default=default_2018_answers, do_not_log=just_read)
   ! Revise inconsistent default answer dates for horizontal regridding.
   default_hor_reg_ans_date = default_answer_date
   if (hor_regrid_answers_2018 .and. (default_hor_reg_ans_date >= 20190101)) default_hor_reg_ans_date = 20181231
@@ -2613,7 +2613,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  "Dates before 20190101 give the same answers as the code did in late 2018, "//&
                  "while later versions add parentheses for rotational symmetry.  "//&
                  "If both HOR_REGRID_2018_ANSWERS and HOR_REGRID_ANSWER_DATE are specified, the "//&
-                 "latter takes precedence.", default=default_hor_reg_ans_date)
+                 "latter takes precedence.", default=default_hor_reg_ans_date, do_not_log=just_read)
 
   if (.not.useALEremapping) then
     call get_param(PF, mdl, "ADJUST_THICKNESS", correct_thickness, &

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -83,6 +83,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   logical :: remap_answers_2018   ! If true, use the order of arithmetic and expressions that
                                   ! recover the remapping answers from 2018.  If false, use more
                                   ! robust forms of the same remapping expressions.
+  integer :: default_remap_ans_date ! The default setting for remap_answer_date
   integer :: remap_answer_date    ! The vintage of the order of arithmetic and expressions to use
                                   ! for remapping.  Values below 20190101 recover the remapping
                                   ! answers from 2018, while higher values use more robust
@@ -115,7 +116,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                  default="PLM")
   call get_param(PF, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231, do_not_log=.true.)
+                 default=99991231)
   call get_param(PF, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=(default_answer_date<20190101))
@@ -124,11 +125,17 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-   if (remap_answers_2018) then
-      remap_answer_date = 20181231
-    else
-      remap_answer_date = 20190101
-    endif
+    ! Revise inconsistent default answer dates for remapping.
+    default_remap_ans_date = default_answer_date
+    if (remap_answers_2018 .and. (default_remap_ans_date >= 20190101)) default_remap_ans_date = 20181231
+    if (.not.remap_answers_2018 .and. (default_remap_ans_date < 20190101)) default_remap_ans_date = 20190101
+    call get_param(PF, mdl, "REMAPPING_ANSWER_DATE", remap_answer_date, &
+                 "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
+                 "Values below 20190101 result in the use of older, less accurate expressions "//&
+                 "that were in use at the end of 2018.  Higher values result in the use of more "//&
+                 "robust and accurate forms of mathematically equivalent expressions.  "//&
+                 "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_remap_ans_date)
   endif
   call get_param(PF, mdl, "HOR_REGRID_2018_ANSWERS", hor_regrid_answers_2018, &
                  "If true, use the order of arithmetic for horizonal regridding that recovers "//&

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -89,6 +89,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                                   ! answers from 2018, while higher values use more robust
                                   ! forms of the same remapping expressions.
   logical :: hor_regrid_answers_2018
+  integer :: default_hor_reg_ans_date ! The default setting for hor_regrid_answer_date
   integer :: hor_regrid_answer_date  ! The vintage of the order of arithmetic and expressions to use
                                   ! for horizontal regridding.  Values below 20190101 recover the
                                   ! answers from 2018, while higher values use expressions that have
@@ -141,7 +142,16 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                  "If true, use the order of arithmetic for horizonal regridding that recovers "//&
                  "the answers from the end of 2018.  Otherwise, use rotationally symmetric "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  hor_regrid_answer_date = 20190101 ; if (hor_regrid_answers_2018) hor_regrid_answer_date = 20181231
+  ! Revise inconsistent default answer dates for horizontal regridding.
+  default_hor_reg_ans_date = default_answer_date
+  if (hor_regrid_answers_2018 .and. (default_hor_reg_ans_date >= 20190101)) default_hor_reg_ans_date = 20181231
+  if (.not.hor_regrid_answers_2018 .and. (default_hor_reg_ans_date < 20190101)) default_hor_reg_ans_date = 20190101
+  call get_param(PF, mdl, "HOR_REGRID_ANSWER_DATE", hor_regrid_answer_date, &
+                 "The vintage of the order of arithmetic for horizontal regridding.  "//&
+                 "Dates before 20190101 give the same answers as the code did in late 2018, "//&
+                 "while later versions add parentheses for rotational symmetry.  "//&
+                 "If both HOR_REGRID_2018_ANSWERS and HOR_REGRID_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_hor_reg_ans_date)
 
   ! These are model grid properties, but being applied to the data grid for now.
   ! need to revisit this (mjh)

--- a/src/ocean_data_assim/MOM_oda_incupd.F90
+++ b/src/ocean_data_assim/MOM_oda_incupd.F90
@@ -230,8 +230,9 @@ subroutine initialize_oda_incupd( G, GV, US, param_file, CS, data_h, nz_data, re
   !### Doing a halo update here on CS%Ref_h%p would avoid needing halo updates each timestep.
 
   ! Call the constructor for remapping control structure
+  !### Revisit this hard-coded answer_date.
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
-                            answers_2018=.false.)
+                            answer_date=20190101)
 end subroutine initialize_oda_incupd
 
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1543,7 +1543,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     allocate(CS%cg1(isd:ied,jsd:jed), source=0.0)
     call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231, do_not_log=.true.)
+                 default=99991231)
     call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=(default_answer_date<20190101))
@@ -1551,11 +1551,17 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-    if (remap_answers_2018) then
-      remap_answer_date = 20181231
-    else
-      remap_answer_date = 20190101
-    endif
+    ! Revise inconsistent default answer dates for remapping.
+    if (remap_answers_2018 .and. (default_answer_date >= 20190101)) default_answer_date = 20181231
+    if (.not.remap_answers_2018 .and. (default_answer_date < 20190101)) default_answer_date = 20190101
+    call get_param(param_file, mdl, "REMAPPING_ANSWER_DATE", remap_answer_date, &
+                 "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
+                 "Values below 20190101 result in the use of older, less accurate expressions "//&
+                 "that were in use at the end of 2018.  Higher values result in the use of more "//&
+                 "robust and accurate forms of mathematically equivalent expressions.  "//&
+                 "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_answer_date)
+
     call get_param(param_file, mdl, "INTERNAL_WAVE_SPEED_TOL", wave_speed_tol, &
                  "The fractional tolerance for finding the wave speeds.", &
                  units="nondim", default=0.001)

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -180,6 +180,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
   logical :: remap_answers_2018   ! If true, use the order of arithmetic and expressions that
                                   ! recover the remapping answers from 2018.  If false, use more
                                   ! robust forms of the same remapping expressions.
+  integer :: default_remap_ans_date ! The default setting for remap_answer_date
   logical :: hor_regrid_answers_2018 ! If true, use the order of arithmetic for horizontal regridding
                                   ! that recovers the answers from the end of 2018.  Otherwise, use
                                   ! rotationally symmetric forms of the same expressions.
@@ -219,7 +220,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
                  default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231, do_not_log=.true.)
+                 default=99991231)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=(default_answer_date<20190101))
@@ -227,7 +228,17 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  CS%remap_answer_date = 20190101 ; if (remap_answers_2018) CS%remap_answer_date = 20181231
+  ! Revise inconsistent default answer dates for remapping.
+  default_remap_ans_date = default_answer_date
+  if (remap_answers_2018 .and. (default_remap_ans_date >= 20190101)) default_remap_ans_date = 20181231
+  if (.not.remap_answers_2018 .and. (default_remap_ans_date < 20190101)) default_remap_ans_date = 20190101
+  call get_param(param_file, mdl, "REMAPPING_ANSWER_DATE", CS%remap_answer_date, &
+                 "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
+                 "Values below 20190101 result in the use of older, less accurate expressions "//&
+                 "that were in use at the end of 2018.  Higher values result in the use of more "//&
+                 "robust and accurate forms of mathematically equivalent expressions.  "//&
+                 "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_remap_ans_date)
   call get_param(param_file, mdl, "HOR_REGRID_2018_ANSWERS", hor_regrid_answers_2018, &
                  "If true, use the order of arithmetic for horizontal regridding that recovers "//&
                  "the answers from the end of 2018.  Otherwise, use rotationally symmetric "//&
@@ -453,6 +464,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
   logical :: remap_answers_2018   ! If true, use the order of arithmetic and expressions that
                                   ! recover the remapping answers from 2018.  If false, use more
                                   ! robust forms of the same remapping expressions.
+  integer :: default_remap_ans_date ! The default setting for remap_answer_date
   logical :: hor_regrid_answers_2018 ! If true, use the order of arithmetic for horizontal regridding
                                   ! that recovers the answers from the end of 2018.  Otherwise, use
                                   ! rotationally symmetric forms of the same expressions.
@@ -486,7 +498,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
                  default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231, do_not_log=.true.)
+                 default=99991231)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=(default_answer_date<20190101))
@@ -494,7 +506,17 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  CS%remap_answer_date = 20190101 ; if (remap_answers_2018) CS%remap_answer_date = 20181231
+  ! Revise inconsistent default answer dates for remapping.
+  default_remap_ans_date = default_answer_date
+  if (remap_answers_2018 .and. (default_remap_ans_date >= 20190101)) default_remap_ans_date = 20181231
+  if (.not.remap_answers_2018 .and. (default_remap_ans_date < 20190101)) default_remap_ans_date = 20190101
+  call get_param(param_file, mdl, "REMAPPING_ANSWER_DATE", CS%remap_answer_date, &
+                 "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
+                 "Values below 20190101 result in the use of older, less accurate expressions "//&
+                 "that were in use at the end of 2018.  Higher values result in the use of more "//&
+                 "robust and accurate forms of mathematically equivalent expressions.  "//&
+                 "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_remap_ans_date)
   call get_param(param_file, mdl, "HOR_REGRID_2018_ANSWERS", hor_regrid_answers_2018, &
                  "If true, use the order of arithmetic for horizontal regridding that recovers "//&
                  "the answers from the end of 2018 and retain a bug in the 3-dimensional mask "//&

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -118,12 +118,14 @@ type, public :: ALE_sponge_CS ; private
                                    !! timing of diagnostic output.
 
   type(remapping_cs) :: remap_cs   !< Remapping parameters and work arrays
-  logical :: remap_answers_2018    !< If true, use the order of arithmetic and expressions that
-                                   !! recover the answers for remapping from the end of 2018.
-                                   !! Otherwise, use more robust forms of the same expressions.
-  logical :: hor_regrid_answers_2018 !< If true, use the order of arithmetic for horizontal regridding
-                                   !! that recovers the answers from the end of 2018.  Otherwise, use
-                                   !! rotationally symmetric forms of the same expressions.
+  integer :: remap_answer_date     !< The vintage of the order of arithmetic and expressions to use
+                                   !! for remapping.  Values below 20190101 recover the remapping
+                                   !! answers from 2018, while higher values use more robust
+                                   !! forms of the same remapping expressions.
+  integer :: hor_regrid_answer_date !< The vintage of the order of arithmetic and expressions to use
+                                   !! for horizontal regridding.  Values below 20190101 recover the
+                                   !! answers from 2018, while higher values use expressions that have
+                                   !! been rearranged for rotational invariance.
 
   logical :: time_varying_sponges  !< True if using newer sponge code
   logical :: spongeDataOngrid !< True if the sponge data are on the model horizontal grid
@@ -173,7 +175,14 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
   character(len=64)  :: remapScheme
   logical :: use_sponge
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
-  logical :: default_2018_answers
+  integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
+  logical :: remap_answers_2018   ! If true, use the order of arithmetic and expressions that
+                                  ! recover the remapping answers from 2018.  If false, use more
+                                  ! robust forms of the same remapping expressions.
+  logical :: hor_regrid_answers_2018 ! If true, use the order of arithmetic for horizontal regridding
+                                  ! that recovers the answers from the end of 2018.  Otherwise, use
+                                  ! rotationally symmetric forms of the same expressions.
   integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
 
   if (associated(CS)) then
@@ -208,17 +217,22 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
                  "than PCM. E.g., if PPM is used for remapping, a "//&
                  "PPM reconstruction will also be used within boundary cells.", &
                  default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231, do_not_log=.true.)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=.false.)
-  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", CS%remap_answers_2018, &
+                 default=(default_answer_date<20190101))
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", remap_answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  call get_param(param_file, mdl, "HOR_REGRID_2018_ANSWERS", CS%hor_regrid_answers_2018, &
+  CS%remap_answer_date = 20190101 ; if (remap_answers_2018) CS%remap_answer_date = 20181231
+  call get_param(param_file, mdl, "HOR_REGRID_2018_ANSWERS", hor_regrid_answers_2018, &
                  "If true, use the order of arithmetic for horizontal regridding that recovers "//&
                  "the answers from the end of 2018.  Otherwise, use rotationally symmetric "//&
                  "forms of the same expressions.", default=default_2018_answers)
+  CS%hor_regrid_answer_date = 20190101 ; if (hor_regrid_answers_2018) CS%hor_regrid_answer_date = 20181231
   call get_param(param_file, mdl, "REENTRANT_X", CS%reentrant_x, &
                  "If true, the domain is zonally reentrant.", default=.true.)
   call get_param(param_file, mdl, "TRIPOLAR_N", CS%tripolar_N, &
@@ -261,7 +275,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
 
 ! Call the constructor for remapping control structure
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
-                            answers_2018=CS%remap_answers_2018)
+                            answer_date=CS%remap_answer_date)
 
   call log_param(param_file, mdl, "!Total sponge columns at h points", total_sponge_cols, &
                  "The total number of columns where sponges are applied at h points.", like_default=.true.)
@@ -434,7 +448,14 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
   character(len=64)  :: remapScheme
   logical :: use_sponge
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
-  logical :: default_2018_answers
+  integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
+  logical :: remap_answers_2018   ! If true, use the order of arithmetic and expressions that
+                                  ! recover the remapping answers from 2018.  If false, use more
+                                  ! robust forms of the same remapping expressions.
+  logical :: hor_regrid_answers_2018 ! If true, use the order of arithmetic for horizontal regridding
+                                  ! that recovers the answers from the end of 2018.  Otherwise, use
+                                  ! rotationally symmetric forms of the same expressions.
   integer :: i, j, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
 
   if (associated(CS)) then
@@ -463,19 +484,24 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
                  "than PCM. E.g., if PPM is used for remapping, a "//&
                  "PPM reconstruction will also be used within boundary cells.", &
                  default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231, do_not_log=.true.)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=.false.)
-  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", CS%remap_answers_2018, &
+                 default=(default_answer_date<20190101))
+  call get_param(param_file, mdl, "REMAPPING_2018_ANSWERS", remap_answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  call get_param(param_file, mdl, "HOR_REGRID_2018_ANSWERS", CS%hor_regrid_answers_2018, &
+  CS%remap_answer_date = 20190101 ; if (remap_answers_2018) CS%remap_answer_date = 20181231
+  call get_param(param_file, mdl, "HOR_REGRID_2018_ANSWERS", hor_regrid_answers_2018, &
                  "If true, use the order of arithmetic for horizontal regridding that recovers "//&
                  "the answers from the end of 2018 and retain a bug in the 3-dimensional mask "//&
                  "returned in certain cases.  Otherwise, use rotationally symmetric "//&
                  "forms of the same expressions and initialize the mask properly.", &
                  default=default_2018_answers)
+  CS%hor_regrid_answer_date = 20190101 ; if (hor_regrid_answers_2018) CS%hor_regrid_answer_date = 20181231
   call get_param(param_file, mdl, "SPONGE_DATA_ONGRID", CS%spongeDataOngrid, &
                  "When defined, the incoming sponge data are "//&
                  "assumed to be on the model grid " , &
@@ -514,7 +540,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
 
 ! Call the constructor for remapping control structure
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
-                            answers_2018=CS%remap_answers_2018)
+                            answer_date=CS%remap_answer_date)
   call log_param(param_file, mdl, "!Total sponge columns at h points", total_sponge_cols, &
                  "The total number of columns where sponges are applied at h points.", like_default=.true.)
   if (CS%sponge_uv) then
@@ -868,7 +894,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
 
   Idt = 1.0/dt
 
-  if (.not.CS%remap_answers_2018) then
+  if (CS%remap_answer_date >= 20190101) then
     h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
   elseif (GV%Boussinesq) then
     h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
@@ -882,7 +908,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
       call horiz_interp_and_extrap_tracer(CS%Ref_val(m)%id, Time, CS%Ref_val(m)%scale, G, sp_val, &
                      mask_z, z_in, z_edges_in,  missing_value, CS%reentrant_x, CS%tripolar_N, .false., &
                      spongeOnGrid=CS%SpongeDataOngrid, m_to_Z=US%m_to_Z, &
-                     answers_2018=CS%hor_regrid_answers_2018)
+                     answer_date=CS%hor_regrid_answer_date)
       allocate( hsrc(nz_data) )
       allocate( tmpT1d(nz_data) )
       do c=1,CS%num_col
@@ -966,7 +992,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
       call horiz_interp_and_extrap_tracer(CS%Ref_val_u%id, Time, CS%Ref_val_u%scale, G, sp_val, &
                           mask_z, z_in, z_edges_in, missing_value, CS%reentrant_x, CS%tripolar_N, .false., &
                           spongeOnGrid=CS%SpongeDataOngrid, m_to_Z=US%m_to_Z,&
-                          answers_2018=CS%hor_regrid_answers_2018)
+                          answer_date=CS%hor_regrid_answer_date)
 
       ! Initialize mask_z halos to zero before pass_var, in case of no update
       mask_z(G%isc-1, G%jsc:G%jec, :) = 0.
@@ -1015,7 +1041,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
       call horiz_interp_and_extrap_tracer(CS%Ref_val_v%id, Time, CS%Ref_val_v%scale, G, sp_val, &
                           mask_z, z_in, z_edges_in, missing_value, CS%reentrant_x, CS%tripolar_N, .false., &
                           spongeOnGrid=CS%SpongeDataOngrid, m_to_Z=US%m_to_Z,&
-                          answers_2018=CS%hor_regrid_answers_2018)
+                          answer_date=CS%hor_regrid_answer_date)
       ! Initialize mask_z halos to zero before pass_var, in case of no update
       mask_z(G%isc:G%iec, G%jsc-1, :) = 0.
       mask_z(G%isc:G%iec, G%jec+1, :) = 0.

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -184,6 +184,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
   logical :: hor_regrid_answers_2018 ! If true, use the order of arithmetic for horizontal regridding
                                   ! that recovers the answers from the end of 2018.  Otherwise, use
                                   ! rotationally symmetric forms of the same expressions.
+  integer :: default_hor_reg_ans_date ! The default setting for hor_regrid_answer_date
   integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
 
   if (associated(CS)) then
@@ -243,7 +244,16 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
                  "If true, use the order of arithmetic for horizontal regridding that recovers "//&
                  "the answers from the end of 2018.  Otherwise, use rotationally symmetric "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  CS%hor_regrid_answer_date = 20190101 ; if (hor_regrid_answers_2018) CS%hor_regrid_answer_date = 20181231
+  ! Revise inconsistent default answer dates for horizontal regridding.
+  default_hor_reg_ans_date = default_answer_date
+  if (hor_regrid_answers_2018 .and. (default_hor_reg_ans_date >= 20190101)) default_hor_reg_ans_date = 20181231
+  if (.not.hor_regrid_answers_2018 .and. (default_hor_reg_ans_date < 20190101)) default_hor_reg_ans_date = 20190101
+  call get_param(param_file, mdl, "HOR_REGRID_ANSWER_DATE", CS%hor_regrid_answer_date, &
+                 "The vintage of the order of arithmetic for horizontal regridding.  "//&
+                 "Dates before 20190101 give the same answers as the code did in late 2018, "//&
+                 "while later versions add parentheses for rotational symmetry.  "//&
+                 "If both HOR_REGRID_2018_ANSWERS and HOR_REGRID_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_hor_reg_ans_date)
   call get_param(param_file, mdl, "REENTRANT_X", CS%reentrant_x, &
                  "If true, the domain is zonally reentrant.", default=.true.)
   call get_param(param_file, mdl, "TRIPOLAR_N", CS%tripolar_N, &
@@ -468,6 +478,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
   logical :: hor_regrid_answers_2018 ! If true, use the order of arithmetic for horizontal regridding
                                   ! that recovers the answers from the end of 2018.  Otherwise, use
                                   ! rotationally symmetric forms of the same expressions.
+  integer :: default_hor_reg_ans_date ! The default setting for hor_regrid_answer_date
   integer :: i, j, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
 
   if (associated(CS)) then
@@ -523,7 +534,16 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, param_file, CS, Irest
                  "returned in certain cases.  Otherwise, use rotationally symmetric "//&
                  "forms of the same expressions and initialize the mask properly.", &
                  default=default_2018_answers)
-  CS%hor_regrid_answer_date = 20190101 ; if (hor_regrid_answers_2018) CS%hor_regrid_answer_date = 20181231
+  ! Revise inconsistent default answer dates for horizontal regridding.
+  default_hor_reg_ans_date = default_answer_date
+  if (hor_regrid_answers_2018 .and. (default_hor_reg_ans_date >= 20190101)) default_hor_reg_ans_date = 20181231
+  if (.not.hor_regrid_answers_2018 .and. (default_hor_reg_ans_date < 20190101)) default_hor_reg_ans_date = 20190101
+  call get_param(param_file, mdl, "HOR_REGRID_ANSWER_DATE", CS%hor_regrid_answer_date, &
+                 "The vintage of the order of arithmetic for horizontal regridding.  "//&
+                 "Dates before 20190101 give the same answers as the code did in late 2018, "//&
+                 "while later versions add parentheses for rotational symmetry.  "//&
+                 "If both HOR_REGRID_2018_ANSWERS and HOR_REGRID_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_hor_reg_ans_date)
   call get_param(param_file, mdl, "SPONGE_DATA_ONGRID", CS%spongeDataOngrid, &
                  "When defined, the incoming sponge data are "//&
                  "assumed to be on the model grid " , &

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -93,8 +93,9 @@ type, public :: set_visc_CS ; private
   real    :: omega_frac     !<   When setting the decay scale for turbulence, use
                             !! this fraction of the absolute rotation rate blended
                             !! with the local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
-  logical :: answers_2018   !< If true, use the order of arithmetic and expressions that recover the
-                            !! answers from the end of 2018.  Otherwise, use updated and more robust
+  integer :: answer_date    !< The vintage of the order of arithmetic and expressions in the set
+                            !! viscosity calculations.  Values below 20190101 recover the answers
+                            !! from the end of 2018, while higher values use updated and more robust
                             !! forms of the same expressions.
   logical :: debug          !< If true, write verbose checksums for debugging purposes.
   logical :: BBL_use_tidal_bg !< If true, use a tidal background amplitude for the bottom velocity
@@ -864,7 +865,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
 
               use_L0 = .false.
               do_one_L_iter = .false.
-              if (CS%answers_2018) then
+              if (CS%answer_date < 20190101) then
                 curv_tol = GV%Angstrom_H*dV_dL2**2 &
                            * (0.25 * dV_dL2 * GV%Angstrom_H - a * L0 * dVol)
                 do_one_L_iter = (a * a * dVol**3) < curv_tol
@@ -1961,7 +1962,11 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                            ! representation in a restart file to the internal representation in this run.
   integer :: i, j, k, is, ie, js, je
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
-  logical :: default_2018_answers
+  integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
+  logical :: answers_2018  ! If true, use the order of arithmetic and expressions that recover the
+                           ! answers from the end of 2018.  Otherwise, use updated and more robust
+                           ! forms of the same expressions.
   logical :: adiabatic, use_omega, MLE_use_PBL_MLD
   logical :: use_KPP
   logical :: use_regridding  ! If true, use the ALE algorithm rather than layered
@@ -1987,13 +1992,25 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   CS%RiNo_mix = .false.
   call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
   CS%inputdir = slasher(CS%inputdir)
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
-                 default=.false.)
-  call get_param(param_file, mdl, "SET_VISC_2018_ANSWERS", CS%answers_2018, &
+                 default=(default_answer_date<20190101))
+  call get_param(param_file, mdl, "SET_VISC_2018_ANSWERS", answers_2018, &
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
+  ! Revise inconsistent default answer dates.
+  if (answers_2018 .and. (default_answer_date >= 20190101)) default_answer_date = 20181231
+  if (.not.answers_2018 .and. (default_answer_date < 20190101)) default_answer_date = 20190101
+  call get_param(param_file, mdl, "SET_VISC_ANSWER_DATE", CS%answer_date, &
+                 "The vintage of the order of arithmetic and expressions in the set viscosity "//&
+                 "calculations.  Values below 20190101 recover the answers from the end of 2018, "//&
+                 "while higher values use updated and more robust forms of the same expressions.  "//&
+                 "If both SET_VISC_2018_ANSWERS and SET_VISC_ANSWER_DATE are specified, "//&
+                 "the latter takes precedence.", default=default_answer_date)
   call get_param(param_file, mdl, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
                  "If true, the bottom stress is calculated with a drag "//&
                  "law of the form c_drag*|u|*u. The velocity magnitude "//&

--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -229,6 +229,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, int_tide_CSp, di
   logical :: remap_answers_2018   ! If true, use the order of arithmetic and expressions that
                                   ! recover the remapping answers from 2018.  If false, use more
                                   ! robust forms of the same remapping expressions.
+  integer :: default_remap_ans_date ! The default setting for remap_answer_date
   character(len=20)  :: tmpstr, int_tide_profile_str
   character(len=20)  :: CVMix_tidal_scheme_str, tidal_energy_type
   character(len=200) :: filename, h2_file, Niku_TKE_input_file
@@ -279,7 +280,7 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, int_tide_CSp, di
 
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231, do_not_log=.true.)
+                 default=99991231)
   call get_param(param_file, mdl, "DEFAULT_2018_ANSWERS", default_2018_answers, &
                  "This sets the default value for the various _2018_ANSWERS parameters.", &
                  default=(default_answer_date<20190101))
@@ -291,11 +292,17 @@ logical function tidal_mixing_init(Time, G, GV, US, param_file, int_tide_CSp, di
                  "If true, use the order of arithmetic and expressions that recover the "//&
                  "answers from the end of 2018.  Otherwise, use updated and more robust "//&
                  "forms of the same expressions.", default=default_2018_answers)
-  if (remap_answers_2018) then
-    CS%remap_answer_date = 20181231
-  else
-    CS%remap_answer_date = 20190101
-  endif
+  ! Revise inconsistent default answer dates for remapping.
+  default_remap_ans_date = default_answer_date
+  if (remap_answers_2018 .and. (default_remap_ans_date >= 20190101)) default_remap_ans_date = 20181231
+  if (.not.remap_answers_2018 .and. (default_remap_ans_date < 20190101)) default_remap_ans_date = 20190101
+  call get_param(param_file, mdl, "REMAPPING_ANSWER_DATE", CS%remap_answer_date, &
+                 "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
+                 "Values below 20190101 result in the use of older, less accurate expressions "//&
+                 "that were in use at the end of 2018.  Higher values result in the use of more "//&
+                 "robust and accurate forms of mathematically equivalent expressions.  "//&
+                 "If both REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the "//&
+                 "latter takes precedence.", default=default_remap_ans_date)
 
   if (CS%int_tide_dissipation) then
 

--- a/src/tracer/MOM_lateral_boundary_diffusion.F90
+++ b/src/tracer/MOM_lateral_boundary_diffusion.F90
@@ -124,8 +124,9 @@ logical function lateral_boundary_diffusion_init(Time, G, GV, param_file, diag, 
                  "for vertical remapping for all variables. "//&
                  "It can be one of the following schemes: "//&
                  trim(remappingSchemesDoc), default=remappingDefaultScheme)
+  !### Revisit this hard-coded answer_date.
   call initialize_remapping( CS%remap_CS, string, boundary_extrapolation = boundary_extrap ,&
-       check_reconstruction=.false., check_remapping=.false., answers_2018=.false.)
+       check_reconstruction=.false., check_remapping=.false., answer_date=20190101)
   call extract_member_remapping_CS(CS%remap_CS, degree=CS%deg)
   call get_param(param_file, mdl, "LBD_DEBUG", CS%debug, &
                  "If true, write out verbose debugging data in the LBD module.", &


### PR DESCRIPTION
  This PR includes a series of commits that replace the logical answers_2018
variables with 8-digit answer_date variables.  Setting these new variables to
20181231 or lower values is equivalent to setting the corresponding answers_2018
variables to True, while the larger values (or dates) will be used to allow
for a succession of newer answers to eventually be supported.  There are 16 new
runtime parameters, and corresponding new entries in the MOM_parameter_doc
files, but all answers are bitwise identical by default.  Once these new
parameters have become a part of the main branch, the various experiments
should be modified so that the older ANSWERS_2018 parameters can eventually
be obsoleted.

  The commits in this PR include:

- NOAA-GFDL/MOM6@ecbb8d5c9 +Add do_not_log=just_read args in get_param calls
- NOAA-GFDL/MOM6@08a502fee +Added 6 more ..._ANSWER_DATE runtime parameters
- NOAA-GFDL/MOM6@a32b840bd +Added 9 ..._ANSWER_DATE runtime parameters
- NOAA-GFDL/MOM6@ab1e5140c +Add the runtime parameter HOR_REGRID_ANSWER_DATE
- NOAA-GFDL/MOM6@927701393 +Add the runtime parameter REMAPPING_ANSWER_DATE
- NOAA-GFDL/MOM6@7a9c8a8dc +Eliminate unused answers_2018 optional arguments
- NOAA-GFDL/MOM6@7c7237734 +Use answer_date to specify remapping
- NOAA-GFDL/MOM6@ecb85cb8b +Use answer_date to specify remapping in ALE
- NOAA-GFDL/MOM6@8fd122990 +Add answer_date optional arguments
