### PR TITLE
Fatal error if a tracer package is registered twice

### DIFF
--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -67,10 +67,10 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(tracer_registry_type), pointer    :: tr_Reg !< A pointer to the tracer registry.
   type(MOM_restart_CS), intent(inout)    :: restart_CS !< MOM restart control struct
 
-! Local variables
+  ! Local variables
   character(len=80)  :: name, longname
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "DOME_tracer" ! This module's name.
   character(len=48) :: flux_units ! The units for tracer fluxes, usually
                             ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
@@ -81,9 +81,8 @@ function register_DOME_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "DOME_register_tracer called with an "// &
-                            "associated control structure.")
-    return
+    call MOM_error(FATAL, "DOME_register_tracer called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -74,8 +74,8 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(MOM_restart_CS),    intent(inout) :: restart_CS !< MOM restart control struct
 
   character(len=80)  :: name, longname
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "ISOMIP_tracer" ! This module's name.
   character(len=200) :: inputdir
   character(len=48)  :: flux_units ! The units for tracer fluxes, usually
@@ -86,9 +86,8 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "ISOMIP_register_tracer called with an "// &
+    call MOM_error(FATAL, "ISOMIP_register_tracer called with an "// &
                             "associated control structure.")
-    return
   endif
   allocate(CS)
 

--- a/src/tracer/MOM_CFC_cap.F90
+++ b/src/tracer/MOM_CFC_cap.F90
@@ -83,7 +83,7 @@ function register_CFC_cap(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=40)  :: mdl = "MOM_CFC_cap" ! This module's name.
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
   ! This include declares and sets the variable "version".
-#include "version_variable.h"
+# include "version_variable.h"
   real, dimension(:,:,:), pointer :: tr_ptr => NULL()
   character(len=200) :: dummy      ! Dummy variable to store params that need to be logged here.
   character :: m2char
@@ -93,9 +93,8 @@ function register_CFC_cap(HI, GV, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "register_CFC_cap called with an "// &
-                            "associated control structure.")
-    return
+    call MOM_error(FATAL, "register_CFC_cap called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -113,9 +113,8 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "register_OCMIP2_CFC called with an "// &
-                            "associated control structure.")
-    return
+    call MOM_error(FATAL, "register_OCMIP2_CFC called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -119,9 +119,8 @@ contains
 
     register_MOM_generic_tracer = .false.
     if (associated(CS)) then
-      call MOM_error(WARNING, "register_MOM_generic_tracer called with an "// &
-            "associated control structure.")
-      return
+      call MOM_error(FATAL, "register_MOM_generic_tracer called with an "// &
+                            "associated control structure.")
     endif
     allocate(CS)
 

--- a/src/tracer/RGC_tracer.F90
+++ b/src/tracer/RGC_tracer.F90
@@ -75,8 +75,8 @@ function register_RGC_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(MOM_restart_CS),    intent(inout) :: restart_CS !< MOM restart control struct
 
   character(len=80)  :: name, longname
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "RGC_tracer" ! This module's name.
   character(len=200) :: inputdir
   real, pointer :: tr_ptr(:,:,:) => NULL()
@@ -85,9 +85,8 @@ function register_RGC_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "RGC_register_tracer called with an "// &
-                            "associated control structure.")
-    return
+    call MOM_error(FATAL, "RGC_register_tracer called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -89,9 +89,8 @@ function register_advection_test_tracer(HI, GV, param_file, CS, tr_Reg, restart_
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "register_advection_test_tracer called with an "// &
-                            "associated control structure.")
-    return
+    call MOM_error(FATAL, "register_advection_test_tracer called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -87,9 +87,8 @@ function register_boundary_impulse_tracer(HI, GV, US, param_file, CS, tr_Reg, re
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "register_boundary_impulse_tracer called with an "// &
-                             "associated control structure.")
-    return
+    call MOM_error(FATAL, "register_boundary_impulse_tracer called with an "// &
+                           "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -88,9 +88,8 @@ function register_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "register_dye_tracer called with an "// &
-                             "associated control structure.")
-    return
+    call MOM_error(FATAL, "register_dye_tracer called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -58,10 +58,10 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(tracer_registry_type), pointer    :: tr_Reg !< A pointer to the tracer registry.
   type(MOM_restart_CS), target, intent(inout) :: restart_CS !< MOM restart control struct
 
-! Local variables
+  ! Local variables
   character(len=80)  :: name, longname
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "dyed_obc_tracer" ! This module's name.
   character(len=200) :: inputdir
   character(len=48)  :: flux_units ! The units for tracer fluxes, usually
@@ -72,9 +72,8 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "dyed_obc_register_tracer called with an "// &
-                            "associated control structure.")
-    return
+    call MOM_error(FATAL, "dyed_obc_register_tracer called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -92,9 +92,8 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "register_ideal_age_tracer called with an "// &
-                             "associated control structure.")
-    return
+    call MOM_error(FATAL, "register_ideal_age_tracer called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/nw2_tracers.F90
+++ b/src/tracer/nw2_tracers.F90
@@ -55,8 +55,8 @@ logical function register_nw2_tracers(HI, GV, US, param_file, CS, tr_Reg, restar
                                                   !! diffusion module
   type(MOM_restart_CS), target, intent(inout) :: restart_CS !< MOM restart control struct
 
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "nw2_tracers" ! This module's name.
   character(len=8)  :: var_name ! The variable's name.
   real, pointer :: tr_ptr(:,:,:) => NULL()
@@ -69,7 +69,6 @@ logical function register_nw2_tracers(HI, GV, US, param_file, CS, tr_Reg, restar
   if (associated(CS)) then
     call MOM_error(FATAL, "register_nw2_tracer called with an "// &
                           "associated control structure.")
-    return
   endif
   allocate(CS)
 

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -98,9 +98,8 @@ function register_oil_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "register_oil_tracer called with an "// &
-                             "associated control structure.")
-    return
+    call MOM_error(FATAL, "register_oil_tracer called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -79,10 +79,8 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "register_pseudo_salt_tracer called with an "// &
-                             "associated control structure.")
-    register_pseudo_salt_tracer = .false.
-    return
+    call MOM_error(FATAL, "register_pseudo_salt_tracer called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -79,9 +79,8 @@ function USER_register_tracer_example(HI, GV, param_file, CS, tr_Reg, restart_CS
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
   if (associated(CS)) then
-    call MOM_error(WARNING, "USER_register_tracer_example called with an "// &
-                            "associated control structure.")
-    return
+    call MOM_error(FATAL, "USER_register_tracer_example called with an "// &
+                          "associated control structure.")
   endif
   allocate(CS)
 


### PR DESCRIPTION
  Made the WARNING error messages that were issued if a tracer package
registration routine is called with an associated control structure into FATAL
errors, as suggested by github.com/mom-ocean/MOM6/issues/1444.  A tracer package
could be used twice, but it would require the use of separate control structures
for each instance.  This change will bring down the model in a case that
probably should not be running.  All solutions are bitwise identical in any
cases that run, and all MOM6-examples test cases work exactly as before.