### PR TITLE
MacOS CI fix + verbose builds on error

### DIFF
--- a/.github/actions/testing-setup/action.yml
+++ b/.github/actions/testing-setup/action.yml
@@ -32,7 +32,7 @@ runs:
       run: |
         echo "::group::Compile FMS library"
         cd .testing
-        make deps/lib/libFMS.a -s -j
+        REPORT_ERROR_LOGS=true make deps/lib/libFMS.a -s -j
         echo "::endgroup::"
 
     - name: Store compiler flags used in Makefile

--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: macOS-latest
 
     env:
-      CC: gcc-11
-      FC: gfortran-11
+      FC: gfortran
 
     defaults:
       run:

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: macOS-latest
 
     env:
-      CC: gcc-11
-      FC: gfortran-11
+      FC: gfortran
 
     defaults:
       run:

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -116,6 +116,9 @@ DO_COVERAGE ?=
 # Report failure if coverage report is not uploaded
 REQUIRE_COVERAGE_UPLOAD ?=
 
+# Print logs if an error is encountered
+REPORT_ERROR_LOGS ?=
+
 # Time measurement (configurable by the CI)
 TIME ?= time
 
@@ -330,7 +333,10 @@ $(TARGET_CODEBASE):
 # FMS
 
 # Set up the FMS build environment variables
-FMS_ENV = PATH="${PATH}:$(realpath ../ac)" FCFLAGS="$(FCFLAGS_FMS)"
+FMS_ENV = \
+  PATH="${PATH}:$(realpath ../ac)" \
+  FCFLAGS="$(FCFLAGS_FMS)" \
+  REPORT_ERROR_LOGS="$(REPORT_ERROR_LOGS)"
 
 deps/lib/libFMS.a: deps/fms/build/libFMS.a
 	$(MAKE) -C deps lib/libFMS.a

--- a/ac/deps/Makefile
+++ b/ac/deps/Makefile
@@ -14,11 +14,14 @@ FMS_COMMIT ?= 2019.01.03
 # List of source files to link this Makefile's dependencies to model Makefiles
 # Assumes a depth of two, and the following extensions: F90 inc c h
 # (1): Root directory
-# NOTE: extensions could be a second variable
 SOURCE = \
   $(foreach ext,F90 inc c h,$(wildcard $(1)/*/*.$(ext) $(1)/*/*/*.$(ext)))
 
 FMS_SOURCE = $(call SOURCE,fms/src)
+
+
+# If `true`, print logs if an error is encountered.
+REPORT_ERROR_LOGS ?=
 
 
 #---
@@ -33,13 +36,8 @@ all: lib/libFMS.a
 
 # NOTE: We emulate the automake `make install` stage by storing libFMS.a to
 #   ${srcdir}/deps/lib and copying module files to ${srcdir}/deps/include.
-#   This is a flawed approach, since module files are untracked and could be
-#   handled more safely, but this is adequate for now.
-
-
-# TODO: track *.mod copy?
 lib/libFMS.a: fms/build/libFMS.a
-	mkdir -p {lib,include}
+	mkdir -p lib include
 	cp fms/build/libFMS.a lib/libFMS.a
 	cp fms/build/*.mod include
 
@@ -51,10 +49,15 @@ fms/build/libFMS.a: fms/build/Makefile
 fms/build/Makefile: Makefile.fms.in fms/src/configure
 	mkdir -p fms/build
 	cp Makefile.fms.in fms/src/Makefile.in
-	cd $(@D) && ../src/configure --srcdir=../src
+	cd $(@D) && { \
+	  ../src/configure --srcdir=../src \
+	  || { \
+	    if [ "${REPORT_ERROR_LOGS}" = true ]; then cat config.log ; fi ; \
+	    false; \
+	  } \
+	}
 
 
-# TODO: Track m4 macros?
 fms/src/configure: configure.fms.ac $(FMS_SOURCE) | fms/src
 	cp configure.fms.ac fms/src/configure.ac
 	cp -r m4 $(@D)


### PR DESCRIPTION
Two changes in this PR:

* Resolves the MacOS build issues by removing the environment variables pointing to gcc-11 and gfortran-11 compiler (which seem to no longer be supported). The CC is removed and FC now just points to gfortran.

* If the dependency ./configure fails for any reason, the config.log output is now streamed to the CI log, which should make future debugging easier.