### PR TITLE
Some touch-ups to porous barrier

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -103,7 +103,8 @@ use MOM_open_boundary,         only : register_temp_salt_segments
 use MOM_open_boundary,         only : open_boundary_register_restarts
 use MOM_open_boundary,         only : update_segment_tracer_reservoirs
 use MOM_open_boundary,         only : rotate_OBC_config, rotate_OBC_init
-use MOM_porous_barriers,       only : porous_barrier_CS, porous_widths, porous_barriers_init
+use MOM_porous_barriers,       only : porous_widths_layer, porous_widths_interface, porous_barriers_init
+use MOM_porous_barriers,       only : porous_barrier_CS
 use MOM_set_visc,              only : set_viscous_BBL, set_viscous_ML
 use MOM_set_visc,              only : set_visc_register_restarts, set_visc_CS
 use MOM_set_visc,              only : set_visc_init, set_visc_end
@@ -1083,7 +1084,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
 
   ! Update porous barrier fractional cell metrics
   call enable_averages(dt, Time_local, CS%diag)
-  call porous_widths(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
+  call porous_widths_layer(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
   call disable_averaging(CS%diag)
   call pass_vector(CS%pbv%por_face_areaU, CS%pbv%por_face_areaV, &
                    G%Domain, direction=To_All+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
@@ -1403,7 +1404,7 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     ! and set_viscous_BBL is called as a part of the dynamic stepping.
     call cpu_clock_begin(id_clock_BBL_visc)
     !update porous barrier fractional cell metrics
-    call porous_widths(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
+    call porous_widths_interface(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
     call pass_vector(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV, &
                      G%Domain, direction=To_ALL+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
     call set_viscous_BBL(u, v, h, tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -103,6 +103,7 @@ use MOM_open_boundary,         only : register_temp_salt_segments
 use MOM_open_boundary,         only : open_boundary_register_restarts
 use MOM_open_boundary,         only : update_segment_tracer_reservoirs
 use MOM_open_boundary,         only : rotate_OBC_config, rotate_OBC_init
+use MOM_porous_barriers,       only : porous_barrier_CS, porous_widths, porous_barriers_init
 use MOM_set_visc,              only : set_viscous_BBL, set_viscous_ML
 use MOM_set_visc,              only : set_visc_register_restarts, set_visc_CS
 use MOM_set_visc,              only : set_visc_init, set_visc_end
@@ -140,8 +141,6 @@ use MOM_verticalGrid,          only : fix_restart_scaling
 use MOM_verticalGrid,          only : get_thickness_units, get_flux_units, get_tr_flux_units
 use MOM_wave_interface,        only : wave_parameters_CS, waves_end, waves_register_restarts
 use MOM_wave_interface,        only : Update_Stokes_Drift
-
-use MOM_porous_barriers,      only : porous_widths
 
 ! ODA modules
 use MOM_oda_driver_mod,        only : ODA_CS, oda, init_oda, oda_end
@@ -397,6 +396,8 @@ type, public :: MOM_control_struct ; private
     !< Pointer to the MOM diagnostics control structure
   type(offline_transport_CS),    pointer :: offline_CSp => NULL()
     !< Pointer to the offline tracer transport control structure
+  type(porous_barrier_CS)                :: por_bar_CS
+    !< Control structure for porous barrier
 
   logical               :: ensemble_ocean !< if true, this run is part of a
                                 !! larger ensemble for the purpose of data assimilation
@@ -1082,8 +1083,10 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
     call diag_update_remap_grids(CS%diag)
   endif
 
-  !update porous barrier fractional cell metrics
-  call porous_widths(h, CS%tv, G, GV, US, eta_por, CS%pbv)
+  ! Update porous barrier fractional cell metrics
+  call enable_averages(dt, Time_local, CS%diag)
+  call porous_widths(h, CS%tv, G, GV, US, eta_por, CS%pbv, CS%por_bar_CS)
+  call disable_averaging(CS%diag)
 
   ! The bottom boundary layer properties need to be recalculated.
   if (bbl_time_int > 0.0) then
@@ -1401,7 +1404,7 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     ! and set_viscous_BBL is called as a part of the dynamic stepping.
     call cpu_clock_begin(id_clock_BBL_visc)
     !update porous barrier fractional cell metrics
-    call porous_widths(h, CS%tv, G, GV, US, eta_por, CS%pbv)
+    call porous_widths(h, CS%tv, G, GV, US, eta_por, CS%pbv, CS%por_bar_CS)
     call set_viscous_BBL(u, v, h, tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)
     call cpu_clock_end(id_clock_BBL_visc)
     if (showCallTree) call callTree_wayPoint("done with set_viscous_BBL (step_MOM_thermo)")
@@ -2793,6 +2796,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   new_sim = is_new_run(restart_CSp)
   call MOM_stoch_eos_init(G,Time,param_file,CS%stoch_eos_CS,restart_CSp,diag)
+  call porous_barriers_init(Time, US, param_file, diag, CS%por_bar_CS)
+
   if (CS%split) then
     allocate(eta(SZI_(G),SZJ_(G)), source=0.0)
     call initialize_dyn_split_RK2(CS%u, CS%v, CS%h, CS%uh, CS%vh, eta, Time, &

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1044,8 +1044,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
 
-  real, dimension(SZI_(CS%G),SZJ_(CS%G),SZK_(CS%G)+1) :: eta_por ! layer interface heights
-                                                    !! for porous topo. [Z ~> m or 1/eta_to_m]
   G => CS%G ; GV => CS%GV ; US => CS%US ; IDs => CS%IDs
   is   = G%isc  ; ie   = G%iec  ; js   = G%jsc  ; je   = G%jec ; nz = GV%ke
   Isq  = G%IscB ; Ieq  = G%IecB ; Jsq  = G%JscB ; Jeq  = G%JecB
@@ -1085,8 +1083,12 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
 
   ! Update porous barrier fractional cell metrics
   call enable_averages(dt, Time_local, CS%diag)
-  call porous_widths(h, CS%tv, G, GV, US, eta_por, CS%pbv, CS%por_bar_CS)
+  call porous_widths(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
   call disable_averaging(CS%diag)
+  call pass_vector(CS%pbv%por_face_areaU, CS%pbv%por_face_areaV, &
+                   G%Domain, direction=To_All+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
+  ! call pass_vector(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV, &
+  !                  G%Domain, direction=To_All+SCALAR_PAIR clock=id_clock_pass, halo=CS%cont_stencil)
 
   ! The bottom boundary layer properties need to be recalculated.
   if (bbl_time_int > 0.0) then
@@ -1365,9 +1367,6 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
   integer :: halo_sz ! The size of a halo where data must be valid.
   integer :: is, ie, js, je, nz
 
-  real, dimension(SZI_(CS%G),SZJ_(CS%G),SZK_(CS%G)+1) :: eta_por ! layer interface heights
-                                                    !! for porous topo. [Z ~> m or 1/eta_to_m]
-
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   showCallTree = callTree_showQuery()
   if (showCallTree) call callTree_enter("step_MOM_thermo(), MOM.F90")
@@ -1404,7 +1403,9 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     ! and set_viscous_BBL is called as a part of the dynamic stepping.
     call cpu_clock_begin(id_clock_BBL_visc)
     !update porous barrier fractional cell metrics
-    call porous_widths(h, CS%tv, G, GV, US, eta_por, CS%pbv, CS%por_bar_CS)
+    call porous_widths(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
+    call pass_vector(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV, &
+                     G%Domain, direction=To_ALL+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
     call set_viscous_BBL(u, v, h, tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)
     call cpu_clock_end(id_clock_BBL_visc)
     if (showCallTree) call callTree_wayPoint("done with set_viscous_BBL (step_MOM_thermo)")

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -406,6 +406,7 @@ type, public :: MOM_control_struct ; private
   type(ODA_CS), pointer :: odaCS => NULL() !< a pointer to the control structure for handling
                                 !! ensemble model state vectors and data assimilation
                                 !! increments and priors
+  logical :: use_porbar
   type(porous_barrier_ptrs) :: pbv !< porous barrier fractional cell metrics
   type(particles), pointer :: particles => NULL() !<Lagrangian particles
   type(stochastic_CS), pointer :: stoch_CS => NULL() !< a pointer to the stochastics control structure
@@ -1083,13 +1084,13 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
   endif
 
   ! Update porous barrier fractional cell metrics
-  call enable_averages(dt, Time_local, CS%diag)
-  call porous_widths_layer(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
-  call disable_averaging(CS%diag)
-  call pass_vector(CS%pbv%por_face_areaU, CS%pbv%por_face_areaV, &
-                   G%Domain, direction=To_All+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
-  ! call pass_vector(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV, &
-  !                  G%Domain, direction=To_All+SCALAR_PAIR clock=id_clock_pass, halo=CS%cont_stencil)
+  if (CS%use_porbar) then
+    call enable_averages(dt, Time_local, CS%diag)
+    call porous_widths_layer(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
+    call disable_averaging(CS%diag)
+    call pass_vector(CS%pbv%por_face_areaU, CS%pbv%por_face_areaV, &
+                     G%Domain, direction=To_All+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
+  endif
 
   ! The bottom boundary layer properties need to be recalculated.
   if (bbl_time_int > 0.0) then
@@ -1404,9 +1405,11 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     ! and set_viscous_BBL is called as a part of the dynamic stepping.
     call cpu_clock_begin(id_clock_BBL_visc)
     !update porous barrier fractional cell metrics
-    call porous_widths_interface(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
-    call pass_vector(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV, &
-                     G%Domain, direction=To_ALL+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
+    if (CS%use_porbar) then
+      call porous_widths_interface(h, CS%tv, G, GV, US, CS%pbv, CS%por_bar_CS)
+      call pass_vector(CS%pbv%por_layer_widthU, CS%pbv%por_layer_widthV, &
+                      G%Domain, direction=To_ALL+SCALAR_PAIR, clock=id_clock_pass, halo=CS%cont_stencil)
+    endif
     call set_viscous_BBL(u, v, h, tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)
     call cpu_clock_end(id_clock_BBL_visc)
     if (showCallTree) call callTree_wayPoint("done with set_viscous_BBL (step_MOM_thermo)")
@@ -1981,6 +1984,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "This is only used if THICKNESSDIFFUSE is true.", &
                  default=.false.)
   if (.not.CS%thickness_diffuse) CS%thickness_diffuse_first = .false.
+  call get_param(param_file, "MOM", "USE_POROUS_BARRIER", CS%use_porbar, &
+                 "If true, use porous barrier to constrain the widths "//&
+                 " and face areas at the edges of the grid cells. ", &
+                 default=.true.) ! The default should be false after tests.
   call get_param(param_file, "MOM", "BATHYMETRY_AT_VEL", bathy_at_vel, &
                  "If true, there are separate values for the basin depths "//&
                  "at velocity points.  Otherwise the effects of topography "//&
@@ -2798,7 +2805,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   new_sim = is_new_run(restart_CSp)
   call MOM_stoch_eos_init(G,Time,param_file,CS%stoch_eos_CS,restart_CSp,diag)
-  call porous_barriers_init(Time, US, param_file, diag, CS%por_bar_CS)
+
+  if (CS%use_porbar) &
+    call porous_barriers_init(Time, US, param_file, diag, CS%por_bar_CS)
 
   if (CS%split) then
     allocate(eta(SZI_(G),SZJ_(G)), source=0.0)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2465,10 +2465,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   CS%time_in_cycle = 0.0 ; CS%time_in_thermo_cycle = 0.0
 
   !allocate porous topography variables
-  ALLOC_(CS%pbv%por_face_areaU(IsdB:IedB,jsd:jed,nz)) ; CS%pbv%por_face_areaU(:,:,:) = 1.0
-  ALLOC_(CS%pbv%por_face_areaV(isd:ied,JsdB:JedB,nz)) ; CS%pbv%por_face_areaV(:,:,:) = 1.0
-  ALLOC_(CS%pbv%por_layer_widthU(IsdB:IedB,jsd:jed,nz+1)) ; CS%pbv%por_layer_widthU(:,:,:) = 1.0
-  ALLOC_(CS%pbv%por_layer_widthV(isd:ied,JsdB:JedB,nz+1)) ; CS%pbv%por_layer_widthV(:,:,:) = 1.0
+  allocate(CS%pbv%por_face_areaU(IsdB:IedB,jsd:jed,nz)) ; CS%pbv%por_face_areaU(:,:,:) = 1.0
+  allocate(CS%pbv%por_face_areaV(isd:ied,JsdB:JedB,nz)) ; CS%pbv%por_face_areaV(:,:,:) = 1.0
+  allocate(CS%pbv%por_layer_widthU(IsdB:IedB,jsd:jed,nz+1)) ; CS%pbv%por_layer_widthU(:,:,:) = 1.0
+  allocate(CS%pbv%por_layer_widthV(isd:ied,JsdB:JedB,nz+1)) ; CS%pbv%por_layer_widthV(:,:,:) = 1.0
 
   ! Use the Wright equation of state by default, unless otherwise specified
   ! Note: this line and the following block ought to be in a separate
@@ -3763,8 +3763,8 @@ subroutine MOM_end(CS)
   if (CS%use_ALE_algorithm) call ALE_end(CS%ALE_CSp)
 
   !deallocate porous topography variables
-  DEALLOC_(CS%pbv%por_face_areaU) ; DEALLOC_(CS%pbv%por_face_areaV)
-  DEALLOC_(CS%pbv%por_layer_widthU) ; DEALLOC_(CS%pbv%por_layer_widthV)
+  deallocate(CS%pbv%por_face_areaU) ; deallocate(CS%pbv%por_face_areaV)
+  deallocate(CS%pbv%por_layer_widthU) ; deallocate(CS%pbv%por_layer_widthV)
 
   ! NOTE: Allocated in PressureForce_FV_Bouss
   if (associated(CS%tv%varT)) deallocate(CS%tv%varT)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -134,7 +134,7 @@ use MOM_transcribe_grid,       only : copy_dyngrid_to_MOM_grid, copy_MOM_grid_to
 use MOM_unit_scaling,          only : unit_scale_type, unit_scaling_init
 use MOM_unit_scaling,          only : unit_scaling_end, fix_restart_unit_scaling
 use MOM_variables,             only : surface, allocate_surface_state, deallocate_surface_state
-use MOM_variables,             only : thermo_var_ptrs, vertvisc_type, porous_barrier_ptrs
+use MOM_variables,             only : thermo_var_ptrs, vertvisc_type, porous_barrier_type
 use MOM_variables,             only : accel_diag_ptrs, cont_diag_ptrs, ocean_internal_state
 use MOM_variables,             only : rotate_surface_state
 use MOM_verticalGrid,          only : verticalGrid_type, verticalGridInit, verticalGridEnd
@@ -407,7 +407,7 @@ type, public :: MOM_control_struct ; private
                                 !! ensemble model state vectors and data assimilation
                                 !! increments and priors
   logical :: use_porbar
-  type(porous_barrier_ptrs) :: pbv !< porous barrier fractional cell metrics
+  type(porous_barrier_type) :: pbv !< porous barrier fractional cell metrics
   type(particles), pointer :: particles => NULL() !<Lagrangian particles
   type(stochastic_CS), pointer :: stoch_CS => NULL() !< a pointer to the stochastics control structure
 end type MOM_control_struct
@@ -1986,7 +1986,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   if (.not.CS%thickness_diffuse) CS%thickness_diffuse_first = .false.
   call get_param(param_file, "MOM", "USE_POROUS_BARRIER", CS%use_porbar, &
                  "If true, use porous barrier to constrain the widths "//&
-                 " and face areas at the edges of the grid cells. ", &
+                 "and face areas at the edges of the grid cells. ", &
                  default=.true.) ! The default should be false after tests.
   call get_param(param_file, "MOM", "BATHYMETRY_AT_VEL", bathy_at_vel, &
                  "If true, there are separate values for the basin depths "//&

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -406,7 +406,8 @@ type, public :: MOM_control_struct ; private
   type(ODA_CS), pointer :: odaCS => NULL() !< a pointer to the control structure for handling
                                 !! ensemble model state vectors and data assimilation
                                 !! increments and priors
-  logical :: use_porbar
+  logical :: use_porbar !< If true, use porous barrier to constrain the widths and face areas
+                        !! at the edges of the grid cells.
   type(porous_barrier_type) :: pbv !< porous barrier fractional cell metrics
   type(particles), pointer :: particles => NULL() !<Lagrangian particles
   type(stochastic_CS), pointer :: stoch_CS => NULL() !< a pointer to the stochastics control structure

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -405,14 +405,6 @@ type, public :: MOM_control_struct ; private
                                 !! ensemble model state vectors and data assimilation
                                 !! increments and priors
   type(porous_barrier_ptrs) :: pbv !< porous barrier fractional cell metrics
-  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) &
-                            :: por_face_areaU !< fractional open area of U-faces [nondim]
-  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) &
-                            :: por_face_areaV !< fractional open area of V-faces [nondim]
-  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NK_INTERFACE_) &
-                            :: por_layer_widthU !< fractional open width of U-faces [nondim]
-  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NK_INTERFACE_) &
-                            :: por_layer_widthV !< fractional open width of V-faces [nondim]
   type(particles), pointer :: particles => NULL() !<Lagrangian particles
   type(stochastic_CS), pointer :: stoch_CS => NULL() !< a pointer to the stochastics control structure
 end type MOM_control_struct
@@ -2460,12 +2452,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   CS%time_in_cycle = 0.0 ; CS%time_in_thermo_cycle = 0.0
 
   !allocate porous topography variables
-  ALLOC_(CS%por_face_areaU(IsdB:IedB,jsd:jed,nz)) ; CS%por_face_areaU(:,:,:) = 1.0
-  ALLOC_(CS%por_face_areaV(isd:ied,JsdB:JedB,nz)) ; CS%por_face_areaV(:,:,:) = 1.0
-  ALLOC_(CS%por_layer_widthU(IsdB:IedB,jsd:jed,nz+1)) ; CS%por_layer_widthU(:,:,:) = 1.0
-  ALLOC_(CS%por_layer_widthV(isd:ied,JsdB:JedB,nz+1)) ; CS%por_layer_widthV(:,:,:) = 1.0
-  CS%pbv%por_face_areaU => CS%por_face_areaU; CS%pbv%por_face_areaV=> CS%por_face_areaV
-  CS%pbv%por_layer_widthU => CS%por_layer_widthU; CS%pbv%por_layer_widthV => CS%por_layer_widthV
+  ALLOC_(CS%pbv%por_face_areaU(IsdB:IedB,jsd:jed,nz)) ; CS%pbv%por_face_areaU(:,:,:) = 1.0
+  ALLOC_(CS%pbv%por_face_areaV(isd:ied,JsdB:JedB,nz)) ; CS%pbv%por_face_areaV(:,:,:) = 1.0
+  ALLOC_(CS%pbv%por_layer_widthU(IsdB:IedB,jsd:jed,nz+1)) ; CS%pbv%por_layer_widthU(:,:,:) = 1.0
+  ALLOC_(CS%pbv%por_layer_widthV(isd:ied,JsdB:JedB,nz+1)) ; CS%pbv%por_layer_widthV(:,:,:) = 1.0
+
   ! Use the Wright equation of state by default, unless otherwise specified
   ! Note: this line and the following block ought to be in a separate
   ! initialization routine for tv.
@@ -3755,8 +3746,8 @@ subroutine MOM_end(CS)
   if (CS%use_ALE_algorithm) call ALE_end(CS%ALE_CSp)
 
   !deallocate porous topography variables
-  DEALLOC_(CS%por_face_areaU) ; DEALLOC_(CS%por_face_areaV)
-  DEALLOC_(CS%por_layer_widthU) ; DEALLOC_(CS%por_layer_widthV)
+  DEALLOC_(CS%pbv%por_face_areaU) ; DEALLOC_(CS%pbv%por_face_areaV)
+  DEALLOC_(CS%pbv%por_layer_widthU) ; DEALLOC_(CS%pbv%por_layer_widthV)
 
   ! NOTE: Allocated in PressureForce_FV_Bouss
   if (associated(CS%tv%varT)) deallocate(CS%tv%varT)

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -16,7 +16,7 @@ use MOM_open_boundary, only : ocean_OBC_type, OBC_DIRECTION_E, OBC_DIRECTION_W
 use MOM_open_boundary, only : OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_string_functions, only : uppercase
 use MOM_unit_scaling,  only : unit_scale_type
-use MOM_variables,     only : accel_diag_ptrs, porous_barrier_ptrs
+use MOM_variables,     only : accel_diag_ptrs, porous_barrier_type
 use MOM_verticalGrid,  only : verticalGrid_type
 use MOM_wave_interface, only : wave_parameters_CS
 
@@ -140,7 +140,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   type(accel_diag_ptrs),                      intent(inout) :: AD  !< Storage for acceleration diagnostics
   type(unit_scale_type),                      intent(in)    :: US  !< A dimensional unit scaling type
   type(CoriolisAdv_CS),                       intent(in)    :: CS  !< Control structure for MOM_CoriolisAdv
-  type(porous_barrier_ptrs),                  intent(in)    :: pbv !< porous barrier fractional cell metrics
+  type(porous_barrier_type),                  intent(in)    :: pbv !< porous barrier fractional cell metrics
   type(Wave_parameters_CS),         optional, pointer       :: Waves !< An optional pointer to Stokes drift CS
 
   ! Local variables

--- a/src/core/MOM_continuity.F90
+++ b/src/core/MOM_continuity.F90
@@ -13,7 +13,7 @@ use MOM_string_functions, only : uppercase
 use MOM_grid, only : ocean_grid_type
 use MOM_open_boundary, only : ocean_OBC_type
 use MOM_unit_scaling, only : unit_scale_type
-use MOM_variables, only : BT_cont_type, porous_barrier_ptrs
+use MOM_variables, only : BT_cont_type, porous_barrier_type
 use MOM_verticalGrid, only : verticalGrid_type
 
 implicit none ; private
@@ -61,7 +61,7 @@ subroutine continuity(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhbt, v
   type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
   type(continuity_CS),     intent(in)    :: CS  !< Control structure for mom_continuity.
   type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
-  type(porous_barrier_ptrs), intent(in)  :: pbv !< porous barrier fractional cell metrics
+  type(porous_barrier_type), intent(in)  :: pbv !< porous barrier fractional cell metrics
   real, dimension(SZIB_(G),SZJ_(G)), &
                  optional, intent(in)    :: uhbt !< The vertically summed volume
                                                 !! flux through zonal faces [H L2 T-1 ~> m3 s-1 or kg s-1].

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -11,7 +11,7 @@ use MOM_grid, only : ocean_grid_type
 use MOM_open_boundary, only : ocean_OBC_type, OBC_segment_type, OBC_NONE
 use MOM_open_boundary, only : OBC_DIRECTION_E, OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_unit_scaling, only : unit_scale_type
-use MOM_variables, only : BT_cont_type, porous_barrier_ptrs
+use MOM_variables, only : BT_cont_type, porous_barrier_type
 use MOM_verticalGrid, only : verticalGrid_type
 
 implicit none ; private
@@ -90,7 +90,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
   type(continuity_PPM_CS), intent(in)    :: CS  !< Module's control structure.
   type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
-  type(porous_barrier_ptrs), intent(in)  :: pbv !< pointers to porous barrier fractional cell metrics
+  type(porous_barrier_type), intent(in)  :: pbv !< pointers to porous barrier fractional cell metrics
   real, dimension(SZIB_(G),SZJ_(G)), &
                  optional, intent(in)    :: uhbt !< The summed volume flux through zonal faces
                                                  !! [H L2 T-1 ~> m3 s-1 or kg s-1].

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -3,7 +3,7 @@ module MOM_dynamics_split_RK2
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_variables,    only : vertvisc_type, thermo_var_ptrs, porous_barrier_ptrs
+use MOM_variables,    only : vertvisc_type, thermo_var_ptrs, porous_barrier_type
 use MOM_variables,    only : BT_cont_type, alloc_bt_cont_type, dealloc_bt_cont_type
 use MOM_variables,    only : accel_diag_ptrs, ocean_internal_state, cont_diag_ptrs
 use MOM_forcing_type, only : mech_forcing
@@ -297,7 +297,7 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
   type(MEKE_type),                   intent(inout) :: MEKE         !< MEKE fields
   type(thickness_diffuse_CS),        intent(inout) :: thickness_diffuse_CSp !< Pointer to a structure containing
                                                                    !! interface height diffusivities
-  type(porous_barrier_ptrs),         intent(in)    :: pbv          !< porous barrier fractional cell metrics
+  type(porous_barrier_type),         intent(in)    :: pbv          !< porous barrier fractional cell metrics
   type(wave_parameters_CS), optional, pointer      :: Waves        !< A pointer to a structure containing
                                                                    !! fields related to the surface wave conditions
 
@@ -1152,7 +1152,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
                                                                 !! the number of times the velocity is
                                                                 !! truncated (this should be 0).
   logical,                          intent(out)   :: calc_dtbt  !< If true, recalculate the barotropic time step
-  type(porous_barrier_ptrs),        intent(in)    :: pbv        !< porous barrier fractional cell metrics
+  type(porous_barrier_type),        intent(in)    :: pbv        !< porous barrier fractional cell metrics
   integer,                          intent(out)   :: cont_stencil !< The stencil for thickness
                                                                 !! from the continuity solver.
 

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -50,7 +50,7 @@ module MOM_dynamics_unsplit
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
-use MOM_variables, only : vertvisc_type, thermo_var_ptrs, porous_barrier_ptrs
+use MOM_variables, only : vertvisc_type, thermo_var_ptrs, porous_barrier_type
 use MOM_variables, only : accel_diag_ptrs, ocean_internal_state, cont_diag_ptrs
 use MOM_forcing_type, only : mech_forcing
 use MOM_checksum_packages, only : MOM_thermo_chksum, MOM_state_chksum, MOM_accel_chksum
@@ -217,7 +217,7 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
                                                    !! initialize_dyn_unsplit.
   type(VarMix_CS),         intent(inout) :: VarMix !< Variable mixing control structure
   type(MEKE_type),         intent(inout) :: MEKE   !< MEKE fields
-  type(porous_barrier_ptrs), intent(in) :: pbv     !< porous barrier fractional cell metrics
+  type(porous_barrier_type), intent(in) :: pbv     !< porous barrier fractional cell metrics
   type(wave_parameters_CS), optional, pointer :: Waves !< A pointer to a structure containing
                                  !! fields related to the surface wave conditions
 

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -48,7 +48,7 @@ module MOM_dynamics_unsplit_RK2
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
-use MOM_variables, only : vertvisc_type, thermo_var_ptrs, porous_barrier_ptrs
+use MOM_variables, only : vertvisc_type, thermo_var_ptrs, porous_barrier_type
 use MOM_variables, only : ocean_internal_state, accel_diag_ptrs, cont_diag_ptrs
 use MOM_forcing_type, only : mech_forcing
 use MOM_checksum_packages, only : MOM_thermo_chksum, MOM_state_chksum, MOM_accel_chksum
@@ -230,7 +230,7 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   type(MEKE_type),                   intent(inout) :: MEKE    !< MEKE fields
                                                               !! fields related to the Mesoscale
                                                               !! Eddy Kinetic Energy.
-  type(porous_barrier_ptrs), intent(in) :: pbv                !< porous barrier fractional cell metrics
+  type(porous_barrier_type), intent(in) :: pbv                !< porous barrier fractional cell metrics
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: h_av ! Averaged layer thicknesses [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: hp ! Predicted layer thicknesses [H ~> m or kg m-2]

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -113,13 +113,13 @@ type, public :: ocean_grid_type
     areaCv       !< The areas of the v-grid cells [L2 ~> m2].
 
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_) :: &
-    porous_DminU, & !< minimum topographic height of U-face [Z ~> m]
-    porous_DmaxU, & !< maximum topographic height of U-face [Z ~> m]
+    porous_DminU, & !< minimum topographic height (deepest) of U-face [Z ~> m]
+    porous_DmaxU, & !< maximum topographic height (shallowest) of U-face [Z ~> m]
     porous_DavgU    !< average topographic height of U-face [Z ~> m]
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_) :: &
-    porous_DminV, & !< minimum topographic height of V-face [Z ~> m]
-    porous_DmaxV, & !< maximum topographic height of V-face [Z ~> m]
+    porous_DminV, & !< minimum topographic height (deepest) of V-face [Z ~> m]
+    porous_DmaxV, & !< maximum topographic height (shallowest) of V-face [Z ~> m]
     porous_DavgV    !< average topographic height of V-face [Z ~> m]
 
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &

--- a/src/core/MOM_porous_barriers.F90
+++ b/src/core/MOM_porous_barriers.F90
@@ -23,6 +23,7 @@ public porous_widths_layer, porous_widths_interface, porous_barriers_init
 
 #include <MOM_memory.h>
 
+!> The control structure for the MOM_porous_barriers module
 type, public :: porous_barrier_CS; private
   logical :: initialized = .false.  !< True if this control structure has been initialized.
   type(diag_ctrl), pointer :: &
@@ -35,8 +36,10 @@ type, public :: porous_barrier_CS; private
   integer :: answer_date            !< The vintage of the porous barrier weight function calculations.
                                     !! Values below 20220806 recover the old answers in which the layer
                                     !! averaged weights are not strictly limited by an upper-bound of 1.0 .
+  !>@{ Diagnostic IDs
   integer :: id_por_layer_widthU = -1, id_por_layer_widthV = -1, &
              id_por_face_areaU = -1, id_por_face_areaV = -1
+  !>@}
 end type porous_barrier_CS
 
 integer :: id_clock_porous_barrier !< CPU clock for porous barrier
@@ -302,6 +305,11 @@ subroutine calc_eta_at_uv(eta_u, eta_v, interp, dmask, h, tv, G, GV, US, eta_bt)
   Z_to_eta = 1.0
   H_to_eta = GV%H_to_m * US%m_to_Z * Z_to_eta
   h_neglect = GV%H_subroundoff * H_to_eta
+
+  do K=1,nk+1
+    do j=js,je ; do I=Isq,Ieq ; eta_u(I,j,K) = dmask ; enddo ; enddo
+    do J=Jsq,Jeq ; do i=is,ie ; eta_v(i,J,K) = dmask ; enddo ; enddo
+  enddo
 
   select case (interp)
     case (ETA_INTERP_MAX)   ! The shallower interface height

--- a/src/core/MOM_porous_barriers.F90
+++ b/src/core/MOM_porous_barriers.F90
@@ -19,19 +19,20 @@ use MOM_debugging,         only : hchksum, uvchksum
 
 implicit none ; private
 
-public porous_widths, porous_barriers_init
+public porous_widths_layer, porous_widths_interface, porous_barriers_init
 
 #include <MOM_memory.h>
 
 type, public :: porous_barrier_CS; private
   logical :: initialized = .false.  !< True if this control structure has been initialized.
   type(diag_ctrl), pointer :: diag => Null()   !< A structure to regulate diagnostic output timing
-  logical :: debug  !< If true, write verbose checksums for debugging purposes.
-  real :: mask_depth  !< The depth below which porous barrier is not applied.
+  logical :: debug !< If true, write verbose checksums for debugging purposes.
+  real    :: mask_depth !< The depth below which porous barrier is not applied.
   integer :: eta_interp !< An integer indicating how the interface heights at the velocity points
                         !! are calculated. Valid values are given by the parameters defined below:
                         !! MAX, MIN, ARITHMETIC and HARMONIC.
-  integer :: id_por_layer_widthU = -1, id_por_layer_widthV = -1, id_por_face_areaU = -1, id_por_face_areaV = -1
+  integer :: id_por_layer_widthU = -1, id_por_layer_widthV = -1, &
+             id_por_face_areaU = -1, id_por_face_areaV = -1
 end type porous_barrier_CS
 
 integer :: id_clock_porous_barrier !< CPU clock for porous barrier
@@ -49,41 +50,34 @@ character(len=20), parameter :: ETA_INTERP_HARM_STRING = "HARMONIC"
 
 contains
 
-!> subroutine to assign cell face areas and layer widths for porous topography
-subroutine porous_widths(h, tv, G, GV, US, pbv, CS, eta_bt, halo_size, eta_to_m)
+!> subroutine to assign porous barrier widths averaged over a layer
+subroutine porous_widths_layer(h, tv, G, GV, US, pbv, CS, eta_bt)
   !eta_bt, halo_size, eta_to_m not currently used
   !variables needed to call find_eta
-  type(ocean_grid_type),                      intent(in)  :: G   !< The ocean's grid structure.
-  type(verticalGrid_type),                    intent(in)  :: GV     !< The ocean's vertical grid structure.
-  type(unit_scale_type),                      intent(in)  :: US     !< A dimensional unit scaling type
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h      !< Layer thicknesses [H ~> m or kg m-2]
-  type(thermo_var_ptrs),                      intent(in)  :: tv     !< A structure pointing to various
-                                                                    !! thermodynamic variables.
-  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)  :: eta_bt !< optional barotropic
-             !! variable that gives the "correct" free surface height (Boussinesq) or total water
-             !! column mass per unit area (non-Boussinesq).  This is used to dilate the layer.
-             !! thicknesses when calculating interfaceheights [H ~> m or kg m-2].
-  integer,                          optional, intent(in)  :: halo_size !< width of halo points on
-                                                                       !! which to calculate eta.
-
-  real,                             optional, intent(in)  :: eta_to_m  !< The conversion factor from
-             !! the units of eta to m; by default this is US%Z_to_m.
-  type(porous_barrier_ptrs),           intent(inout) :: pbv  !< porous barrier fractional cell metrics
-  type(porous_barrier_CS), intent(in) :: CS
+  type(ocean_grid_type),                      intent(in) :: G   !< The ocean's grid structure.
+  type(verticalGrid_type),                    intent(in) :: GV  !< The ocean's vertical grid structure.
+  type(unit_scale_type),                      intent(in) :: US  !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in) :: h   !< Layer thicknesses [H ~> m or kg m-2]
+  type(thermo_var_ptrs),                      intent(in) :: tv  !< A structure pointing to various
+                                                                !! thermodynamic variables.
+  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: eta_bt !< optional barotropic variable
+                                                                   !! used to dilate the layer thicknesses
+                                                                   !! [H ~> m or kg m-2].
+  type(porous_barrier_ptrs),                  intent(inout) :: pbv  !< porous barrier fractional cell metrics
+  type(porous_barrier_CS),                    intent(in) :: CS      !< Control structure for porous barrier
 
   !local variables
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1):: eta ! Layer interface heights [Z ~> m or 1/eta_to_m].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: eta_u ! Layer interface heights at u points [Z ~> m]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: eta_v ! Layer interface heights at v points [Z ~> m]
   real, dimension(SZIB_(G),SZJB_(G)) :: A_layer_prev ! Integral of fractional open width from the bottom
                                                      ! to the previous layer at u or v points [Z ~> m]
-  real, dimension(SZIB_(G),SZJB_(G)) :: eta_prev ! Layter interface height of the previous layer
-                                                 ! at u or v points [Z ~> m]
-  real :: A_layer, & ! Integral of fractional open width from bottom to current layer [Z ~> m]
-          eta_s ! Layer height used for fit [Z ~> m]
+  real :: A_layer ! Integral of fractional open width from bottom to current layer [Z ~> m]
   real :: Z_to_eta, H_to_eta ! Unit conversion factors for eta.
-  real :: h_neglect, & ! ! Negligible thicknesses, often [Z ~> m]
+  real :: h_neglect, & ! Negligible thicknesses, often [Z ~> m]
           h_min ! ! The minimum layer thickness, often [Z ~> m]
-  real :: dmask ! The depth below which porous barrier is not applied.
+  real :: dmask ! The depth below which porous barrier is not applied [Z ~> m]
   integer :: i, j, k, nk, is, ie, js, je, Isq, Ieq, Jsq, Jeq
+  logical :: do_next
 
   if (.not.CS%initialized) call MOM_error(FATAL, &
       "MOM_Porous_barrier: Module must be initialized before it is used.")
@@ -95,136 +89,261 @@ subroutine porous_widths(h, tv, G, GV, US, pbv, CS, eta_bt, halo_size, eta_to_m)
 
   dmask = CS%mask_depth
 
-  !eta is zero at surface and decreases downward
-  !currently no treatment for using optional find_eta arguments if present
-  call find_eta(h, tv, G, GV, US, eta, halo_size=1)
+  call calc_eta_at_uv(eta_u, eta_v, CS%eta_interp, dmask, h, tv, G, GV, US)
 
-  Z_to_eta = 1.0 ; if (present(eta_to_m)) Z_to_eta = US%Z_to_m / eta_to_m
+  Z_to_eta = 1.0
   H_to_eta = GV%H_to_m * US%m_to_Z * Z_to_eta
-  h_neglect = GV%H_subroundoff * H_to_eta
   h_min = GV%Angstrom_H * H_to_eta
 
   ! u-points
   do j=js,je ; do I=Isq,Ieq ; if (G%porous_DavgU(I,j) < dmask) then
-    eta_prev(I,j) = eta_at_uv(eta(i,j,nk+1), eta(i+1,j,nk+1), CS%eta_interp, h_neglect)
-    ! eta_prev(I,j) = max(eta(i,j,nk+1), eta(i+1,j,nk+1))
     call calc_por_layer(G%porous_DminU(I,j), G%porous_DmaxU(I,j), G%porous_DavgU(I,j), &
-                       eta_prev(I,j), pbv%por_layer_widthU(I,j,nk+1), A_layer_prev(I,j))
+                        eta_u(I,j,nk+1), A_layer_prev(I,j), do_next)
   endif ; enddo ; enddo
 
-  do k = nk,1,-1; do j=js,je; do I=Isq,Ieq ; if (G%porous_DavgU(I,j) < dmask) then
-    eta_s = eta_at_uv(eta(i,j,K), eta(i+1,j,K), CS%eta_interp, h_neglect)
-    ! eta_s = max(eta(i,j,K), eta(i+1,j,K))
-    if ((eta_s - eta_prev(I,j)) > 0.0) then
+  do k=nk,1,-1 ; do j=js,je ; do I=Isq,Ieq ; if (G%porous_DavgU(I,j) < dmask) then
+    if ((eta_u(I,j,K) - eta_u(I,j,K+1)) > 0.0) then
       call calc_por_layer(G%porous_DminU(I,j), G%porous_DmaxU(I,j), G%porous_DavgU(I,j), &
-                          eta_s, pbv%por_layer_widthU(I,j,K), A_layer)
-      pbv%por_face_areaU(I,j,k) = (A_layer - A_layer_prev(I,j)) / (eta_s - eta_prev(I,j))
+                          eta_u(I,j,K), A_layer, do_next)
+      pbv%por_face_areaU(I,j,k) = (A_layer - A_layer_prev(I,j)) / (eta_u(I,j,K) - eta_u(I,j,K+1))
     else
       pbv%por_face_areaU(I,j,k) = 0.0
     endif
-    eta_prev(I,j) = eta_s
     A_layer_prev(I,j) = A_layer
   endif ; enddo ; enddo ; enddo
 
   ! v-points
   do J=Jsq,Jeq ; do i=is,ie ; if (G%porous_DavgV(i,J) < dmask) then
-    eta_prev(i,J) = eta_at_uv(eta(i,j,nk+1), eta(i,j+1,nk+1), CS%eta_interp, h_neglect)
-    ! eta_prev(i,J) = max(eta(i,j,nk+1), eta(i,j+1,nk+1))
     call calc_por_layer(G%porous_DminV(i,J), G%porous_DmaxV(i,J), G%porous_DavgV(i,J), &
-                        eta_prev(i,J), pbv%por_layer_widthV(i,J,nk+1), A_layer_prev(i,J))
+                        eta_v(i,J,nk+1), A_layer_prev(i,J), do_next)
   endif ; enddo ; enddo
 
-  do k = nk,1,-1; do J=Jsq,Jeq ; do i=is,ie ;if (G%porous_DavgV(i,J) < dmask) then
-    eta_s = eta_at_uv(eta(i,j,K), eta(i,j+1,K), CS%eta_interp, h_neglect)
-    ! eta_s = max(eta(i,j,K), eta(i,j+1,K))
-    if ((eta_s - eta_prev(i,J)) > 0.0) then
+  do k=nk,1,-1 ; do J=Jsq,Jeq ; do i=is,ie ; if (G%porous_DavgV(i,J) < dmask) then
+    if ((eta_v(i,J,K) - eta_v(i,J,K+1)) > 0.0) then
       call calc_por_layer(G%porous_DminV(i,J), G%porous_DmaxV(i,J), G%porous_DavgV(i,J), &
-                         eta_s, pbv%por_layer_widthV(i,J,K), A_layer)
-      pbv%por_face_areaV(i,J,k) = (A_layer - A_layer_prev(i,J)) / (eta_s - eta_prev(i,J))
+                          eta_v(i,J,K), A_layer, do_next)
+      pbv%por_face_areaV(i,J,k) = (A_layer - A_layer_prev(i,J)) / (eta_v(i,J,K) - eta_v(i,J,K+1))
     else
       pbv%por_face_areaV(i,J,k) = 0.0
     endif
-    eta_prev(i,J) = eta_s
     A_layer_prev(i,J) = A_layer
   endif ; enddo ; enddo ; enddo
 
   if (CS%debug) then
-    call hchksum(eta, "Interface height used by porous barrier", G%HI, haloshift=0, scale=GV%H_to_m)
-    call uvchksum("Porous barrier weights at the layer-interface: por_layer_width[UV]", &
-                   pbv%por_layer_widthU, pbv%por_layer_widthV, G%HI, haloshift=0)
+    call uvchksum("Interface height used by porous barrier for layer weights", &
+                  eta_u, eta_v, G%HI, haloshift=0)
     call uvchksum("Porous barrier layer-averaged weights: por_face_area[UV]", &
-                   pbv%por_face_areaU, pbv%por_face_areaV, G%HI, haloshift=0)
+                  pbv%por_face_areaU, pbv%por_face_areaV, G%HI, haloshift=0)
   endif
 
-  if (CS%id_por_layer_widthU > 0) call post_data(CS%id_por_layer_widthU, pbv%por_layer_widthU, CS%diag)
-  if (CS%id_por_layer_widthV > 0) call post_data(CS%id_por_layer_widthV, pbv%por_layer_widthV, CS%diag)
   if (CS%id_por_face_areaU > 0) call post_data(CS%id_por_face_areaU, pbv%por_face_areaU, CS%diag)
   if (CS%id_por_face_areaV > 0) call post_data(CS%id_por_face_areaV, pbv%por_face_areaV, CS%diag)
 
   call cpu_clock_end(id_clock_porous_barrier)
-end subroutine porous_widths
+end subroutine porous_widths_layer
+
+!> subroutine to assign porous barrier widths at the layer interfaces
+subroutine porous_widths_interface(h, tv, G, GV, US, pbv, CS, eta_bt)
+  !eta_bt, halo_size, eta_to_m not currently used
+  !variables needed to call find_eta
+  type(ocean_grid_type),                      intent(in) :: G   !< The ocean's grid structure.
+  type(verticalGrid_type),                    intent(in) :: GV  !< The ocean's vertical grid structure.
+  type(unit_scale_type),                      intent(in) :: US  !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in) :: h   !< Layer thicknesses [H ~> m or kg m-2]
+  type(thermo_var_ptrs),                      intent(in) :: tv  !< A structure pointing to various
+                                                                !! thermodynamic variables.
+  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: eta_bt !< optional barotropic variable
+                                                                   !! used to dilate the layer thicknesses
+                                                                   !! [H ~> m or kg m-2].
+  type(porous_barrier_ptrs),                  intent(inout) :: pbv  !< porous barrier fractional cell metrics
+  type(porous_barrier_CS),                    intent(in) :: CS !< Control structure for porous barrier
+
+  !local variables
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: eta_u ! Layer interface height at u points [Z ~> m]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: eta_v ! Layer interface height at v points [Z ~> m]
+  real :: Z_to_eta, H_to_eta ! Unit conversion factors for eta.
+  real :: h_neglect ! Negligible thicknesses, often [Z ~> m]
+  real :: dmask ! The depth below which porous barrier is not applied [Z ~> m]
+  integer :: i, j, k, nk, is, ie, js, je, Isq, Ieq, Jsq, Jeq
+  logical :: do_next
+
+  if (.not.CS%initialized) call MOM_error(FATAL, &
+      "MOM_Porous_barrier: Module must be initialized before it is used.")
+
+  call cpu_clock_begin(id_clock_porous_barrier)
+
+  is = G%isc; ie = G%iec; js = G%jsc; je = G%jec; nk = GV%ke
+  Isq = G%IscB; Ieq = G%IecB; Jsq = G%JscB; Jeq = G%JecB
+
+  dmask = CS%mask_depth
+
+  call calc_eta_at_uv(eta_u, eta_v, CS%eta_interp, dmask, h, tv, G, GV, US)
+
+  ! u-points
+  do K=1,nk+1 ; do j=js,je ; do I=Isq,Ieq ; if (G%porous_DavgU(I,j) < dmask) then
+     call calc_por_interface(G%porous_DminU(I,j), G%porous_DmaxU(I,j), G%porous_DavgU(I,j), &
+                             eta_u(I,j,K), pbv%por_layer_widthU(I,j,K), do_next)
+  endif ; enddo ; enddo ; enddo
+
+  ! v-points
+  do K=1,nk+1 ; do J=Jsq,Jeq ; do i=is,ie ; if (G%porous_DavgV(i,J) < dmask) then
+    call calc_por_interface(G%porous_DminV(i,J), G%porous_DmaxV(i,J), G%porous_DavgV(i,J), &
+                            eta_v(i,J,K), pbv%por_layer_widthV(i,J,K), do_next)
+  endif ; enddo ; enddo ; enddo
+
+  if (CS%debug) then
+    call uvchksum("Interface height used by porous barrier for interface weights", &
+                  eta_u, eta_v, G%HI, haloshift=0)
+    call uvchksum("Porous barrier weights at the layer-interface: por_layer_width[UV]", &
+                  pbv%por_layer_widthU, pbv%por_layer_widthV, G%HI, haloshift=0)
+  endif
+
+  if (CS%id_por_layer_widthU > 0) call post_data(CS%id_por_layer_widthU, pbv%por_layer_widthU, CS%diag)
+  if (CS%id_por_layer_widthV > 0) call post_data(CS%id_por_layer_widthV, pbv%por_layer_widthV, CS%diag)
+
+  call cpu_clock_end(id_clock_porous_barrier)
+end subroutine porous_widths_interface
+
+subroutine calc_eta_at_uv(eta_u, eta_v, interp, dmask, h, tv, G, GV, US, eta_bt)
+  !variables needed to call find_eta
+  type(ocean_grid_type),                        intent(in) :: G   !< The ocean's grid structure.
+  type(verticalGrid_type),                      intent(in) :: GV  !< The ocean's vertical grid structure.
+  type(unit_scale_type),                        intent(in) :: US  !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),    intent(in) :: h   !< Layer thicknesses [H ~> m or kg m-2]
+  type(thermo_var_ptrs),                        intent(in) :: tv  !< A structure pointing to various
+                                                                  !! thermodynamic variables.
+  real, dimension(SZI_(G),SZJ_(G)), optional,   intent(in) :: eta_bt !< optional barotropic variable
+                                                                   !! used to dilate the layer thicknesses
+                                                                   !! [H ~> m or kg m-2].
+  real,                                         intent(in) :: dmask !< The depth below which
+                                                                    !! porous barrier is not applied [Z ~> m]
+  integer,                                      intent(in) :: interp !< eta interpolation method
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(out) :: eta_u !< Layer interface heights at u points [Z ~> m]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(out) :: eta_v !< Layer interface heights at v points [Z ~> m]
+
+  ! local variables
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: eta ! Layer interface heights [Z ~> m or 1/eta_to_m].
+  real :: Z_to_eta, H_to_eta ! Unit conversion factors for eta.
+  real :: h_neglect ! Negligible thicknesses, often [Z ~> m]
+  integer :: i, j, k, nk, is, ie, js, je, Isq, Ieq, Jsq, Jeq
+
+  is = G%isc; ie = G%iec; js = G%jsc; je = G%jec; nk = GV%ke
+  Isq = G%IscB; Ieq = G%IecB; Jsq = G%JscB; Jeq = G%JecB
+
+  ! currently no treatment for using optional find_eta arguments if present
+  call find_eta(h, tv, G, GV, US, eta, halo_size=1)
+
+  Z_to_eta = 1.0
+  H_to_eta = GV%H_to_m * US%m_to_Z * Z_to_eta
+  h_neglect = GV%H_subroundoff * H_to_eta
+
+  select case (interp)
+    case (ETA_INTERP_MAX)   ! The shallower interface height
+      do K=1,nk+1
+        do j=js,je ; do I=Isq,Ieq ; if (G%porous_DavgU(I,j) < dmask) then
+          eta_u(I,j,K) = max(eta(i,j,K), eta(i+1,j,K))
+        endif ; enddo ; enddo
+        do J=Jsq,Jeq ; do i=is,ie ; if (G%porous_DavgV(i,J) < dmask) then
+          eta_v(i,J,K) = max(eta(i,j,K), eta(i,j+1,K))
+        endif ; enddo ; enddo
+      enddo
+    case (ETA_INTERP_MIN)   ! The deeper interface height
+      do K=1,nk+1
+        do j=js,je ; do I=Isq,Ieq ; if (G%porous_DavgU(I,j) < dmask) then
+          eta_u(I,j,K) = min(eta(i,j,K), eta(i+1,j,K))
+        endif ; enddo ; enddo
+        do J=Jsq,Jeq ; do i=is,ie ; if (G%porous_DavgV(i,J) < dmask) then
+          eta_v(i,J,K) = min(eta(i,j,K), eta(i,j+1,K))
+        endif ; enddo ; enddo
+      enddo
+    case (ETA_INTERP_ARITH) ! Arithmetic mean
+      do K=1,nk+1
+        do j=js,je ; do I=Isq,Ieq ; if (G%porous_DavgU(I,j) < dmask) then
+          eta_u(I,j,K) = 0.5 * (eta(i,j,K) + eta(i+1,j,K))
+        endif ; enddo ; enddo
+        do J=Jsq,Jeq ; do i=is,ie ; if (G%porous_DavgV(i,J) < dmask) then
+          eta_v(i,J,K) = 0.5 * (eta(i,j,K) + eta(i,j+1,K))
+        endif ; enddo ; enddo
+      enddo
+    case (ETA_INTERP_HARM)  ! Harmonic mean
+      do K=1,nk+1
+        do j=js,je ; do I=Isq,Ieq ; if (G%porous_DavgU(I,j) < dmask) then
+          eta_u(I,j,K) = 2.0 * (eta(i,j,K) * eta(i+1,j,K)) / (eta(i,j,K) + eta(i+1,j,K) + h_neglect)
+        endif ; enddo ; enddo
+        do J=Jsq,Jeq ; do i=is,ie ; if (G%porous_DavgV(i,J) < dmask) then
+          eta_v(i,J,K) = 2.0 * (eta(i,j,K) * eta(i,j+1,K)) / (eta(i,j,K) + eta(i,j+1,K) + h_neglect)
+        endif ; enddo ; enddo
+      enddo
+    case default
+      call MOM_error(FATAL, "porous_widths::calc_eta_at_uv: "//&
+                     "invalid value for eta interpolation method.")
+  end select
+end subroutine calc_eta_at_uv
 
 !> subroutine to calculate the profile fit (the three parameter fit from Adcroft 2013)
 ! for a single layer in a column
-subroutine calc_por_layer(D_min, D_max, D_avg, eta_layer, w_layer, A_layer)
-  real, intent(in)  :: D_min !< minimum topographic height [Z ~> m]
-  real, intent(in)  :: D_max !< maximum topographic height [Z ~> m]
+subroutine calc_por_layer(D_min, D_max, D_avg, eta_layer, A_layer, do_next)
+  real, intent(in)  :: D_min !< minimum topographic height (deepest) [Z ~> m]
+  real, intent(in)  :: D_max !< maximum topographic height (shallowest) [Z ~> m]
   real, intent(in)  :: D_avg !< mean topographic height [Z ~> m]
   real, intent(in)  :: eta_layer !< height of interface [Z ~> m]
-  real, intent(out) :: w_layer !< frac. open interface width of current layer [nondim]
-  real, intent(out) :: A_layer !< frac. open face area of current layer [Z ~> m]
+  real, intent(out) :: A_layer !< frac. open face area of below eta_layer [Z ~> m]
+  logical, intent(out) :: do_next !< False if eta_layer > D_max
+
+  ! local variables
+  real :: m,  &  ! convenience constant for fit [nondim]
+          zeta   ! normalized vertical coordinate [nondim]
+
+  do_next = .True.
+  if (eta_layer <= D_min) then
+    A_layer = 0.0
+  elseif (eta_layer > D_max) then
+    A_layer = eta_layer - D_avg
+    do_next = .False.
+  else
+    m = (D_avg - D_min) / (D_max - D_min)
+    zeta = (eta_layer - D_min) / (D_max - D_min)
+    if (m < 0.5) then
+      A_layer = (D_max - D_min) * ((1.0 - m) * zeta**(1.0 / (1.0 - m)))
+    elseif (m == 0.5) then
+      A_layer = (D_max - D_min) * (0.5 * zeta * zeta)
+    else
+      A_layer = (D_max - D_min) * (zeta - m + m * ((1.0 - zeta)**(1.0 / m)))
+    endif
+  endif
+end subroutine calc_por_layer
+
+subroutine calc_por_interface(D_min, D_max, D_avg, eta_layer, w_layer, do_next)
+  real, intent(in)  :: D_min !< minimum topographic height (deepest) [Z ~> m]
+  real, intent(in)  :: D_max !< maximum topographic height (shallowest) [Z ~> m]
+  real, intent(in)  :: D_avg !< mean topographic height [Z ~> m]
+  real, intent(in)  :: eta_layer !< height of interface [Z ~> m]
+  real, intent(out) :: w_layer !< frac. open interface width at eta_layer [nondim]
+  logical, intent(out) :: do_next !< False if eta_layer > D_max
 
   ! local variables
   real :: m, a, &  ! convenience constant for fit [nondim]
-          zeta, &  ! normalized vertical coordinate [nondim]
-          psi, &   ! fractional width of layer between D_min and D_max [nondim]
-          psi_int  ! integral of psi from 0 to zeta
+          zeta     ! normalized vertical coordinate [nondim]
 
+  do_next = .True.
   if (eta_layer <= D_min) then
     w_layer = 0.0
-    A_layer = 0.0
   elseif (eta_layer > D_max) then
     w_layer = 1.0
-    A_layer = eta_layer - D_avg
+    do_next = .False.
   else
     m = (D_avg - D_min) / (D_max - D_min)
     a = (1.0 - m) / m
     zeta = (eta_layer - D_min) / (D_max - D_min)
     if (m < 0.5) then
-      psi = zeta**(1.0 / a)
-      psi_int = (1.0 - m) * zeta**(1.0 / (1.0 - m))
+      w_layer = zeta**(1.0 / a)
     elseif (m == 0.5) then
-      psi = zeta
-      psi_int = 0.5 * zeta * zeta
+      w_layer = zeta
     else
-      psi = 1.0 - (1.0 - zeta)**a
-      psi_int = zeta - m + m * ((1.0 - zeta)**(1 / m))
+      w_layer = 1.0 - (1.0 - zeta)**a
     endif
-    w_layer = psi
-    A_layer = (D_max - D_min)*psi_int
   endif
-end subroutine calc_por_layer
-
-function eta_at_uv(e1, e2, interp, h_neglect) result(eatuv)
-  real, intent(in) :: e1, e2 ! Interface heights at the adjacent tracer cells [Z ~> m]
-  real, intent(in) :: h_neglect ! Negligible thicknesses, often [Z ~> m]
-  integer, intent(in) :: interp ! Interpolation method coded by an integer
-  real :: eatuv
-
-  select case (interp)
-    case (ETA_INTERP_MAX)   ! The shallower interface height
-      eatuv = max(e1, e2)
-    case (ETA_INTERP_MIN)   ! The deeper interface height
-      eatuv = min(e1, e2)
-    case (ETA_INTERP_ARITH) ! Arithmetic mean
-      eatuv = 0.5 * (e1 + e2)
-    case (ETA_INTERP_HARM)  ! Harmonic mean
-      eatuv = 2.0 * e1 * e2 / (e1 + e2 + h_neglect)
-    case default
-      call MOM_error(FATAL, "porous_widths::eta_at_uv: "//&
-                     "invalid value for eta interpolation method.")
-  end select
-end function eta_at_uv
+end subroutine calc_por_interface
 
 subroutine porous_barriers_init(Time, US, param_file, diag, CS)
   type(porous_barrier_CS), intent(inout) :: CS !< Module control structure

--- a/src/core/MOM_porous_barriers.F90
+++ b/src/core/MOM_porous_barriers.F90
@@ -205,6 +205,7 @@ subroutine porous_barriers_init(Time, US, param_file, diag, CS)
                  "The depth below which porous barrier is not applied.  "//&
                  "This criterion is tested against TOPO_AT_VEL_VARNAME_U_AVE and TOPO_AT_VEL_VARNAME_V_AVE.", &
                  units="m", default=0.0, scale=US%m_to_Z)
+  CS%mask_depth = -CS%mask_depth
 
   CS%id_por_layer_widthU = register_diag_field('ocean_model', 'por_layer_widthU', diag%axesCui, Time, &
      'Porous barrier open width fraction (at the layer interfaces) of the u-faces', 'nondim')

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -310,15 +310,15 @@ type, public :: BT_cont_type
 end type BT_cont_type
 
 !> Container for grids modifying cell metric at porous barriers
-! TODO: rename porous_barrier_ptrs to porous_barrier_type
-type, public :: porous_barrier_ptrs
+! TODO: rename porous_barrier_type to porous_barrier_type
+type, public :: porous_barrier_type
   ! Each of the following fields has nz layers.
   real, allocatable :: por_face_areaU(:,:,:) !< fractional open area of U-faces [nondim]
   real, allocatable :: por_face_areaV(:,:,:) !< fractional open area of V-faces [nondim]
   ! Each of the following fields is found at nz+1 interfaces.
   real, allocatable :: por_layer_widthU(:,:,:) !< fractional open width of U-faces [nondim]
   real, allocatable :: por_layer_widthV(:,:,:) !< fractional open width of V-faces [nondim]
-end type porous_barrier_ptrs
+end type porous_barrier_type
 
 contains
 

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -309,15 +309,16 @@ type, public :: BT_cont_type
   type(group_pass_type) :: pass_FA_uv !< Structure for face area group halo updates
 end type BT_cont_type
 
-
-!> pointers to grids modifying cell metric at porous barriers
+!> Container for grids modifying cell metric at porous barriers
+! TODO: rename porous_barrier_ptrs to porous_barrier_type
 type, public :: porous_barrier_ptrs
-  real, pointer, dimension(:,:,:) :: por_face_areaU => NULL() !< fractional open area of U-faces [nondim]
-  real, pointer, dimension(:,:,:) :: por_face_areaV => NULL() !< fractional open area of V-faces [nondim]
-  real, pointer, dimension(:,:,:) :: por_layer_widthU => NULL() !< fractional open width of U-faces [nondim]
-  real, pointer, dimension(:,:,:) :: por_layer_widthV => NULL() !< fractional open width of V-faces [nondim]
+  ! Each of the following fields has nz layers.
+  real, allocatable :: por_face_areaU(:,:,:) !< fractional open area of U-faces [nondim]
+  real, allocatable :: por_face_areaV(:,:,:) !< fractional open area of V-faces [nondim]
+  ! Each of the following fields is found at nz+1 interfaces.
+  real, allocatable :: por_layer_widthU(:,:,:) !< fractional open width of U-faces [nondim]
+  real, allocatable :: por_layer_widthV(:,:,:) !< fractional open width of V-faces [nondim]
 end type porous_barrier_ptrs
-
 
 contains
 

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -110,13 +110,13 @@ type, public :: dyn_horgrid_type
     areaCv       !< The areas of the v-grid cells [L2 ~> m2].
 
   real, allocatable, dimension(:,:) :: &
-    porous_DminU, & !< minimum topographic height of U-face [Z ~> m]
-    porous_DmaxU, & !< maximum topographic height of U-face [Z ~> m]
+    porous_DminU, & !< minimum topographic height (deepest) of U-face [Z ~> m]
+    porous_DmaxU, & !< maximum topographic height (shallowest) of U-face [Z ~> m]
     porous_DavgU    !< average topographic height of U-face [Z ~> m]
 
   real, allocatable, dimension(:,:) :: &
-    porous_DminV, & !< minimum topographic height of V-face [Z ~> m]
-    porous_DmaxV, & !< maximum topographic height of V-face [Z ~> m]
+    porous_DminV, & !< minimum topographic height (deepest) of V-face [Z ~> m]
+    porous_DmaxV, & !< maximum topographic height (shallowest) of V-face [Z ~> m]
     porous_DavgV    !< average topographic height of V-face [Z ~> m]
 
   real, allocatable, dimension(:,:) :: &

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -23,6 +23,7 @@ use MOM_shared_initialization, only : initialize_topography_named, limit_topogra
 use MOM_shared_initialization, only : set_rotation_planetary, set_rotation_beta_plane, initialize_grid_rotation_angle
 use MOM_shared_initialization, only : reset_face_lengths_named, reset_face_lengths_file, reset_face_lengths_list
 use MOM_shared_initialization, only : read_face_length_list, set_velocity_depth_max, set_velocity_depth_min
+use MOM_shared_initialization, only : set_subgrid_topo_at_vel_from_file
 use MOM_shared_initialization, only : compute_global_grid_integrals, write_ocean_geometry_file
 use MOM_unit_scaling, only : unit_scale_type
 
@@ -62,6 +63,7 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF, write_geom, output_dir)
   ! Local
   character(len=200) :: inputdir   ! The directory where NetCDF input files are.
   character(len=200) :: config
+  logical            :: read_porous_file
   character(len=40)  :: mdl = "MOM_fixed_initialization" ! This module's name.
   logical :: debug
 ! This include declares and sets the variable "version".
@@ -141,6 +143,13 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF, write_geom, output_dir)
         "Unrecognized velocity depth configuration "//trim(config))
     end select
   endif
+
+  ! Read sub-grid scale topography parameters at velocity points used for porous barrier calculation
+  call get_param(PF, mdl, "SUBGRID_TOPO_AT_VEL", read_porous_file, &
+                 "If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.", &
+                 default=.False.)
+  if (read_porous_file) &
+    call set_subgrid_topo_at_vel_from_file(G, PF, US)
 
 !    Calculate the value of the Coriolis parameter at the latitude   !
 !  of the q grid points [T-1 ~> s-1].

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -1171,12 +1171,16 @@ end subroutine read_face_length_list
 !! for the use of porous barrier.
 !! Note that we assume the depth values in the sub-grid bathymetry file of the same
 !! convention as in-cell bathymetry file, i.e. positive below the sea surface and
-!! increasing downward. This is the opposite of the convention in subroutine
-!! porous_widths. Therefore, all signs of the variable are reverted here.
+!! increasing downward; while in subroutine reset_face_lengths_list, it is implied
+!! that read-in fields min_bathy, max_bathy and avg_bathy from the input file
+!! CHANNEL_LIST_FILE all have negative values below the surface. Therefore, to ensure
+!! backward compatibility, all signs of the variable are inverted here.
+!! And porous_Dmax[UV] = shallowest point, porous_Dmin[UV] = deepest point
 subroutine set_subgrid_topo_at_vel_from_file(G, param_file, US)
-  type(dyn_horgrid_type), intent(inout) :: G !< The dynamic horizontal grid type
+  type(dyn_horgrid_type), intent(inout) :: G          !< The dynamic horizontal grid type
   type(param_file_type),  intent(in)    :: param_file !< Parameter file structure
-  type(unit_scale_type),  intent(in)    :: US !< A dimensional unit scaling type
+  type(unit_scale_type),  intent(in)    :: US         !< A dimensional unit scaling type
+
   ! Local variables
   character(len=200) :: filename, topo_file, inputdir ! Strings for file/path
   character(len=200) :: varname_uhi, varname_ulo, varname_uav, &
@@ -1225,8 +1229,8 @@ subroutine set_subgrid_topo_at_vel_from_file(G, param_file, US)
   call MOM_read_vector(filename, trim(varname_uav), trim(varname_vav), &
                        G%porous_DavgU, G%porous_DavgV, G%Domain, stagger=CGRID_NE, scale=US%m_to_Z)
 
-  ! The signs of the depth parameters need to be reverted to comply with subroutine calc_por_layer,
-  ! which assumes depth is negative below the sea surface.
+  ! The signs of the depth parameters need to be inverted to be backward compatible with input files
+  ! used by subroutine reset_face_lengths_list, which assumes depth is negative below the sea surface.
   G%porous_DmaxU = -G%porous_DmaxU; G%porous_DminU = -G%porous_DminU; G%porous_DavgU = -G%porous_DavgU
   G%porous_DmaxV = -G%porous_DmaxV; G%porous_DminV = -G%porous_DminV; G%porous_DavgV = -G%porous_DavgV
 

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -27,6 +27,7 @@ public initialize_topography_named, limit_topography, diagnoseMaximumDepth
 public set_rotation_planetary, set_rotation_beta_plane, initialize_grid_rotation_angle
 public reset_face_lengths_named, reset_face_lengths_file, reset_face_lengths_list
 public read_face_length_list, set_velocity_depth_max, set_velocity_depth_min
+public set_subgrid_topo_at_vel_from_file
 public compute_global_grid_integrals, write_ocean_geometry_file
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
@@ -1163,6 +1164,78 @@ subroutine read_face_length_list(iounit, filename, num_lines, lines)
                   "Error while reading file "//trim(filename))
 
 end subroutine read_face_length_list
+! -----------------------------------------------------------------------------
+
+! -----------------------------------------------------------------------------
+!> Read from a file the maximum, minimum and average bathymetry at velocity points,
+!! for the use of porous barrier.
+!! Note that we assume the depth values in the sub-grid bathymetry file of the same
+!! convention as in-cell bathymetry file, i.e. positive below the sea surface and
+!! increasing downward. This is the opposite of the convention in subroutine
+!! porous_widths. Therefore, all signs of the variable are reverted here.
+subroutine set_subgrid_topo_at_vel_from_file(G, param_file, US)
+  type(dyn_horgrid_type), intent(inout) :: G !< The dynamic horizontal grid type
+  type(param_file_type),  intent(in)    :: param_file !< Parameter file structure
+  type(unit_scale_type),  intent(in)    :: US !< A dimensional unit scaling type
+  ! Local variables
+  character(len=200) :: filename, topo_file, inputdir ! Strings for file/path
+  character(len=200) :: varname_uhi, varname_ulo, varname_uav, &
+                        varname_vhi, varname_vlo, varname_vav     ! Variable names in file
+  character(len=40)  :: mdl = "set_subgrid_topo_at_vel_from_file" ! This subroutine's name.
+  integer :: i, j
+
+  call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
+
+  call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
+  inputdir = slasher(inputdir)
+  call get_param(param_file, mdl, "TOPO_AT_VEL_FILE", topo_file, &
+                 "The file from which the bathymetry parameters at the velocity points are read.  "//&
+                 "While the names of the parameters reflect their physical locations, i.e. HIGH is above LOW, "//&
+                 "their signs follow the model's convention, which is positive below the sea surface", &
+                 default="topog_edge.nc")
+  call get_param(param_file, mdl, "TOPO_AT_VEL_VARNAME_U_HIGH", varname_uhi, &
+                 "The variable name of the highest bathymetry at the u-cells in TOPO_AT_VEL_FILE.", &
+                 default="depthu_hi")
+  call get_param(param_file, mdl, "TOPO_AT_VEL_VARNAME_U_LOW",  varname_ulo, &
+                 "The variable name of the lowest bathymetry at the u-cells in TOPO_AT_VEL_FILE.", &
+                 default="depthu_lo")
+  call get_param(param_file, mdl, "TOPO_AT_VEL_VARNAME_U_AVE",  varname_uav, &
+                 "The variable name of the average bathymetry at the u-cells in TOPO_AT_VEL_FILE.", &
+                 default="depthu_av")
+  call get_param(param_file, mdl, "TOPO_AT_VEL_VARNAME_V_HIGH", varname_vhi, &
+                 "The variable name of the highest bathymetry at the v-cells in TOPO_AT_VEL_FILE.", &
+                 default="depthv_hi")
+  call get_param(param_file, mdl, "TOPO_AT_VEL_VARNAME_V_LOW",  varname_vlo, &
+                 "The variable name of the lowest bathymetry at the v-cells in TOPO_AT_VEL_FILE.", &
+                 default="depthv_lo")
+  call get_param(param_file, mdl, "TOPO_AT_VEL_VARNAME_V_AVE",  varname_vav, &
+                 "The variable name of the average bathymetry at the v-cells in TOPO_AT_VEL_FILE.", &
+                 default="depthv_av")
+
+  filename = trim(inputdir)//trim(topo_file)
+  call log_param(param_file, mdl, "INPUTDIR/TOPO_AT_VEL_FILE", filename)
+
+  if (.not.file_exists(filename, G%Domain)) call MOM_error(FATAL, &
+       " set_subgrid_topo_at_vel_from_file: Unable to open "//trim(filename))
+
+  call MOM_read_vector(filename, trim(varname_uhi), trim(varname_vhi), &
+                       G%porous_DmaxU, G%porous_DmaxV, G%Domain, stagger=CGRID_NE, scale=US%m_to_Z)
+  call MOM_read_vector(filename, trim(varname_ulo), trim(varname_vlo), &
+                       G%porous_DminU, G%porous_DminV, G%Domain, stagger=CGRID_NE, scale=US%m_to_Z)
+  call MOM_read_vector(filename, trim(varname_uav), trim(varname_vav), &
+                       G%porous_DavgU, G%porous_DavgV, G%Domain, stagger=CGRID_NE, scale=US%m_to_Z)
+
+  ! The signs of the depth parameters need to be reverted to comply with subroutine calc_por_layer,
+  ! which assumes depth is negative below the sea surface.
+  G%porous_DmaxU = -G%porous_DmaxU; G%porous_DminU = -G%porous_DminU; G%porous_DavgU = -G%porous_DavgU
+  G%porous_DmaxV = -G%porous_DmaxV; G%porous_DminV = -G%porous_DminV; G%porous_DavgV = -G%porous_DavgV
+
+  call pass_vector(G%porous_DmaxU, G%porous_DmaxV, G%Domain, To_All+SCALAR_PAIR, CGRID_NE)
+  call pass_vector(G%porous_DminU, G%porous_DminV, G%Domain, To_All+SCALAR_PAIR, CGRID_NE)
+  call pass_vector(G%porous_DavgU, G%porous_DavgV, G%Domain, To_All+SCALAR_PAIR, CGRID_NE)
+
+  call callTree_leave(trim(mdl)//'()')
+end subroutine set_subgrid_topo_at_vel_from_file
 ! -----------------------------------------------------------------------------
 
 ! -----------------------------------------------------------------------------

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -23,7 +23,7 @@ use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_C
 use MOM_restart, only : register_restart_field_as_obsolete
 use MOM_safe_alloc, only : safe_alloc_ptr, safe_alloc_alloc
 use MOM_unit_scaling, only : unit_scale_type
-use MOM_variables, only : thermo_var_ptrs, vertvisc_type, porous_barrier_ptrs
+use MOM_variables, only : thermo_var_ptrs, vertvisc_type, porous_barrier_type
 use MOM_verticalGrid, only : verticalGrid_type
 use MOM_EOS, only : calculate_density, calculate_density_derivs
 use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_DIRECTION_E
@@ -137,7 +137,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
                                                   !! related fields.
   type(set_visc_CS),        intent(inout) :: CS   !< The control structure returned by a previous
                                                   !! call to set_visc_init.
-  type(porous_barrier_ptrs),intent(in)    :: pbv  !< porous barrier fractional cell metrics
+  type(porous_barrier_type),intent(in)    :: pbv  !< porous barrier fractional cell metrics
 
   ! Local variables
   real, dimension(SZIB_(G)) :: &


### PR DESCRIPTION
This PR introduces some small changes to the porous barrier feature.
Edit: There are a number of small commits, maybe a squash commit should be done instead?

New features:
* Added a new subroutine in `MOM_fixed_initialization` to read global sub-grid scale topography parameters at velocity points.
* Added a new parameter to choose different interpolation method for velocity point interface height.
* Diagnostics of the weight functions, CPU clocks and chksum debugs are added.
* A control structure is added in module `MOM_porous_barriers` to manage relevant input parameters, diagnostics, and etc.
* Added a global switch for porous barrier functionality to prevent unnecessary calculations and stacks when this feature is not used. The default at the moment is .True. (switched on) though, for backward compatibility. 

Bug fixes:
* Previously there is a bug in loop range in which the velocity points on the north/east edges of the domains are not calculated and there was not halo update to cover these points. This is fixed by change the loop range from data domain to computation domain + halo update
* There was a bug with potentially incorrect `eta_prev` and `A_layer_prev` values, which was caused by a misplace of their updates inside an if-block. This is fixed after restructuring the corresponding code blocks
* There was an implicit assumption that porous barrier is only applied to ocean depth below 0.0, which precluded wetting/drying. This is fixed by adding an additional parameter `PORBAR_MASKING_DEPTH` to control this critical depth. 

Refactors:
* Grouped porous barrier variables in `MOM_variables` is change from pointer to allocatable.
* The calculations of the interface and layer weight functions are now split. Currently, there are two update of porous barriers in the `step_MOM`, which in fact target the layers and interfaces separately.  In the future, it might be helpful to use fortran interface to unify the subroutine names.
* The loops are re-arranged to increase readability.
* An updating `do_next` mask is added to skip weight function calculation for all points above the shallowest point. This can make multi-layer runs (most layers in the open ocean are shallower than the topography) a bit more efficient. 
* An upper bound of 1.0 is applied to the layer-averaged weight function. 
* The above two points do give answers that are not bit-for-bit with the old runs. For consistency purposes, the newly-introduced `ANSWER_DATE` flag is used to recover old results. (Question: the current value of `PORBAR_ANSWER_DATE` is 20220806, should it be instead some future date when this PR is merged? )
