### PR TITLE
Point gitmodules to mom-ocean forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "pkg/CVMix-src"]
 	path = pkg/CVMix-src
-	url = https://github.com/CVMix/CVMix-src.git
+	url = https://github.com/mom-ocean/CVMix-src.git
 [submodule "pkg/GSW-Fortran"]
 	path = pkg/GSW-Fortran
-	url = https://github.com/TEOS-10/GSW-Fortran.git
+	url = https://github.com/mom-ocean/GSW-Fortran.git


### PR DESCRIPTION
This patch modifies the URLs of the git modulues from the main
repositories to local mirrors at @mom-ocean.

Since the MOM6 sourc code is hard-coded to particular hashes, there is
no benefit to linking to the most recent versions of these codes.  And
linking to local forks controlled by us will protect us from potential
removal of the commits in these repositories.