### PR TITLE
CI: Restore MacOS compiler variables

### DIFF
--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: macOS-latest
 
     env:
-      FC: gfortran
+      CC: gcc-11
+      FC: gfortran-11
 
     defaults:
       run:

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: macOS-latest
 
     env:
-      FC: gfortran
+      CC: gcc-11
+      FC: gfortran-11
 
     defaults:
       run:


### PR DESCRIPTION
GitHub appears to have restored their compiler alias conventions on
their MacOS nodes.  This patch restores those variables.