### PR TITLE
+Add runtime parameter CHANNEL_DRAG_MAX_BBL_THICK

### DIFF
--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -74,25 +74,27 @@ type, public :: set_visc_CS ; private
                             !! the properties of the bottom boundary layer.
   logical :: linear_drag    !< If true, the drag law is cdrag*`DRAG_BG_VEL`*u.
                             !! Runtime parameter `LINEAR_DRAG`.
-  logical :: Channel_drag   !< If true, the drag is exerted directly on each
-                            !! layer according to what fraction of the bottom
-                            !! they overlie.
+  logical :: Channel_drag   !< If true, the drag is exerted directly on each layer
+                            !! according to what fraction of the bottom they overlie.
+  real    :: Chan_drag_max_vol !< The maximum bottom boundary layer volume within which the
+                            !! channel drag is applied, normalized by the the full cell area,
+                            !! or a negative value to apply no maximum [H ~> m or kg m-2].
   logical :: correct_BBL_bounds !< If true, uses the correct bounds on the BBL thickness and
                             !! viscosity so that the bottom layer feels the intended drag.
   logical :: RiNo_mix       !< If true, use Richardson number dependent mixing.
   logical :: dynamic_viscous_ML !< If true, use a bulk Richardson number criterion to
                             !! determine the mixed layer thickness for viscosity.
   real    :: bulk_Ri_ML     !< The bulk mixed layer used to determine the
-                            !! thickness of the viscous mixed layer.  Nondim.
+                            !! thickness of the viscous mixed layer [nondim]
   real    :: omega          !<   The Earth's rotation rate [T-1 ~> s-1].
   real    :: ustar_min      !< A minimum value of ustar to avoid numerical
                             !! problems [Z T-1 ~> m s-1].  If the value is small enough,
                             !! this should not affect the solution.
   real    :: TKE_decay      !< The ratio of the natural Ekman depth to the TKE
-                            !! decay scale, nondimensional.
-  real    :: omega_frac     !<   When setting the decay scale for turbulence, use
-                            !! this fraction of the absolute rotation rate blended
-                            !! with the local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+                            !! decay scale [nondim]
+  real    :: omega_frac     !<   When setting the decay scale for turbulence, use this
+                            !! fraction of the absolute rotation rate blended with the local
+                            !! value of f, as sqrt((1-of)*f^2 + of*4*omega^2) [nondim]
   integer :: answer_date    !< The vintage of the order of arithmetic and expressions in the set
                             !! viscosity calculations.  Values below 20190101 recover the answers
                             !! from the end of 2018, while higher values use updated and more robust
@@ -233,6 +235,9 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
   real :: a2x48_apb3, Iapb, Ibma_2 ! Combinations of a and slope [H-1 ~> m-1 or m2 kg-1].
   ! All of the following "volumes" have units of thickness because they are normalized
   ! by the full horizontal area of a velocity cell.
+  real :: Vol_bbl_chan     ! The volume of the bottom boundary layer as used in the channel
+                           ! drag parameterization, normalized by the full horizontal area
+                           ! of the velocity cell [H ~> m or kg m-2].
   real :: Vol_open         ! The cell volume above which it is open [H ~> m or kg m-2].
   real :: Vol_direct       ! With less than Vol_direct [H ~> m or kg m-2], there is a direct
                            ! solution of a cubic equation for L.
@@ -733,6 +738,9 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
         if (bbl_thick < CS%BBL_thick_min) bbl_thick = CS%BBL_thick_min
       endif
 
+      ! Store the normalized bottom boundary layer volume.
+      if (CS%Channel_drag) Vol_bbl_chan = bbl_thick
+
       ! If there is Richardson number dependent mixing, that determines
       ! the vertical extent of the bottom boundary layer, and there is no
       ! need to set that scale here.  In fact, viscously reducing the
@@ -746,9 +754,12 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
       if (CS%body_force_drag) bbl_thick = h_bbl_drag(i)
 
       if (CS%Channel_drag) then
-        ! The drag within the bottommost bbl_thick is applied as a part of
+        ! The drag within the bottommost Vol_bbl_chan is applied as a part of
         ! an enhanced bottom viscosity, while above this the drag is applied
         ! directly to the layers in question as a Rayleigh drag term.
+
+        ! Restrict the volume over which the channel drag is applied.
+        if (CS%Chan_drag_max_vol >= 0.0) Vol_bbl_chan = min(Vol_bbl_chan, CS%Chan_drag_max_vol)
 
         !### The harmonic mean edge depths here are not invariant to offsets!
         if (m==1) then
@@ -931,8 +942,8 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
           ! Determine the drag contributing to the bottom boundary layer
           ! and the Rayleigh drag that acts on each layer.
           if (L(K) > L(K+1)) then
-            if (vol_below < bbl_thick) then
-              BBL_frac = (1.0-vol_below/bbl_thick)**2
+            if (vol_below < Vol_bbl_chan) then
+              BBL_frac = (1.0-vol_below/Vol_bbl_chan)**2
               BBL_visc_frac = BBL_visc_frac + BBL_frac*(L(K) - L(K+1))
             else
               BBL_frac = 0.0
@@ -1957,6 +1968,8 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   real    :: omega_frac_dflt ! The default value for the fraction of the absolute rotation rate that
                              ! is used in place of the absolute value of the local Coriolis
                              ! parameter in the denominator of some expressions [nondim]
+  real    :: Chan_max_thick_dflt ! The default value for CHANNEL_DRAG_MAX_THICK [m]
+
   real    :: Z_rescale     ! A rescaling factor for heights from the representation in
                            ! a restart file to the internal representation in this run.
   real    :: I_T_rescale   ! A rescaling factor for time from the internal representation in this run
@@ -2154,9 +2167,6 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                  "The thickness over which near-surface velocities are "//&
                  "averaged for the drag law under an ice shelf.  By "//&
                  "default this is the same as HBBL", units="m", default=CS%Hbbl, scale=GV%m_to_H)
-  ! These unit conversions are out outside the get_param calls because the are also defaults.
-  CS%Hbbl = CS%Hbbl * GV%m_to_H                   ! Rescale
-  CS%BBL_thick_min = CS%BBL_thick_min * GV%m_to_H ! Rescale
 
   call get_param(param_file, mdl, "KV", Kv_background, &
                  "The background kinematic viscosity in the interior. "//&
@@ -2195,8 +2205,23 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
     if (CS%c_Smag < 0.0) CS%c_Smag = 0.15
   endif
 
+  Chan_max_thick_dflt = -1.0
+  if (CS%RiNo_mix) Chan_max_thick_dflt = 0.5*CS%Hbbl
+  if (CS%body_force_drag) Chan_max_thick_dflt = CS%Hbbl
+  call get_param(param_file, mdl, "CHANNEL_DRAG_MAX_BBL_THICK", CS%Chan_drag_max_vol, &
+                 "The maximum bottom boundary layer thickness over which the channel drag is "//&
+                 "exerted, or a negative value for no fixed limit, instead basing the BBL "//&
+                 "thickness on the bottom stress, rotation and stratification.  The default is "//&
+                 "proportional to HBBL if USE_JACKSON_PARAM or DRAG_AS_BODY_FORCE is true.", &
+                 units="m", default=Chan_max_thick_dflt, scale=GV%m_to_H, &
+                 do_not_log=.not.CS%Channel_drag)
+
   call get_param(param_file, mdl, "MLE_USE_PBL_MLD", MLE_use_PBL_MLD, &
                  default=.false., do_not_log=.true.)
+
+  ! These unit conversions are out outside the get_param calls because they are also defaults.
+  CS%Hbbl = CS%Hbbl * GV%m_to_H                   ! Rescale
+  CS%BBL_thick_min = CS%BBL_thick_min * GV%m_to_H ! Rescale
 
   if (CS%RiNo_mix .and. kappa_shear_at_vertex(param_file)) then
     ! This is necessary for reproduciblity across restarts in non-symmetric mode.


### PR DESCRIPTION
  Added the new runtime parameter CHANNEL_DRAG_MAX_BBL_THICK, to allow the
CHANNEL_DRAG parameterization to use the full dynamically determined depth of
the bottom boundary layer, or to use a fixed maximum thickness, regardless of
the settings of other parameters, although for now the default value is set
based on the settings of USE_JACKSON_PARAM and DRAG_AS_BODY_FORCE in order to
reproduce existing solutions by default.  There are new entries in some
MOM_parameter_doc files.  All answers in the MOM6-examples test suite are
bitwise identical, and this test suite has been tested and works with revised
values of this parameter.