### PR TITLE
Report error logs from codecov upload fail

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -602,6 +602,7 @@ report.cov: run.cov codecov
 	  2> build/cov/codecov.err \
 	  && echo -e "${MAGENTA}Report uploaded to codecov.${RESET}" \
 	  || { \
+	    cat build/cov/codecov.err ; \
 	    echo -e "${RED}Failed to upload report.${RESET}" ; \
 		if [ "$(REQUIRE_COVERAGE_UPLOAD)" = true ] ; then false ; fi ; \
 	  }
@@ -740,6 +741,7 @@ report.cov.unit: build/unit/MOM_file_parser_tests.F90.gcov codecov
 	    2> build/unit/codecov.err \
 	  && echo -e "${MAGENTA}Report uploaded to codecov.${RESET}" \
 	  || { \
+	    cat build/unit/codecov.err ; \
 	    echo -e "${RED}Failed to upload report.${RESET}" ; \
 		if [ "$(REQUIRE_COVERAGE_UPLOAD)" = true ] ; then false ; fi ; \
 	  }


### PR DESCRIPTION
This patch extends the REPORT_ERROR_LOGS flag behavior to also report
the error log of failed codecov uploads.

I expect there's little we can do on our end, but more information will
at least help to understand the problem.