### PR TITLE
[WIP] Setup OBC segments for COBALT/BGC tracers

### DIFF
--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -291,10 +291,10 @@ contains
   subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, obc_has, src_file, src_var_name,lfac_in,lfac_out)
     type(g_tracer_type), pointer    :: g_tracer_list !< pointer to the head of the generic tracer list
     type(g_tracer_type), pointer    :: g_tracer !< Pointer to tracer node
-    character(len=*),         intent(in) :: name                   !<tracer name
-    logical,                  intent(out):: obc_has                !<.true. if This tracer has OBC
-    real,            optional,intent(out):: lfac_in,lfac_out       !<OBC reservoir inverse lengthscale factor
-    character(len=*),optional,intent(out):: src_file, src_var_name !<OBC source file and variable in file
+    character(len=*),         intent(in) :: name                   !< tracer name
+    logical,                  intent(out):: obc_has                !< .true. if This tracer has OBC
+    real,            optional,intent(out):: lfac_in,lfac_out       !< OBC reservoir inverse lengthscale factor
+    character(len=*),optional,intent(out):: src_file, src_var_name !< OBC source file and variable in file
   end subroutine g_tracer_get_obc_segment_props
 
   !>Vertical Diffusion of a tracer node

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -290,7 +290,7 @@ contains
   subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, obc_has, src_file, src_var_name,lfac_in,lfac_out)
     type(g_tracer_type), pointer    :: g_tracer_list !< pointer to the head of the generic tracer list
     type(g_tracer_type), pointer    :: g_tracer !< Pointer to tracer node
-    character(len=*),         intent(in) :: name
+    character(len=*),         intent(in) :: name                   !<tracer name
     logical,                  intent(out):: obc_has                !<.true. if This tracer has OBC
     real,            optional,intent(out):: lfac_in,lfac_out       !<OBC reservoir inverse lengthscale factor
     character(len=*),optional,intent(out):: src_file, src_var_name !<OBC source file and variable in file

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -287,11 +287,12 @@ contains
     type(g_tracer_type), pointer :: g_tracer_next !< Pointer to the next tracer node in the list
   end subroutine g_tracer_get_next
 
-  subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, obc_has, src_file, src_var_name)
+  subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, obc_has, src_file, src_var_name,lfac_in,lfac_out)
     type(g_tracer_type), pointer    :: g_tracer_list !< pointer to the head of the generic tracer list
     type(g_tracer_type), pointer    :: g_tracer !< Pointer to tracer node
     character(len=*),         intent(in) :: name
     logical,                  intent(out):: obc_has                !<.true. if This tracer has OBC
+    real,            optional,intent(out):: lfac_in,lfac_out       !<OBC reservoir inverse lengthscale factor
     character(len=*),optional,intent(out):: src_file, src_var_name !<OBC source file and variable in file
   end subroutine g_tracer_get_obc_segment_props
 

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -25,6 +25,8 @@ implicit none ; private
     character(len=fm_string_len) :: src_var_name !< Tracer source variable name
     character(len=fm_string_len) :: src_var_unit !< Tracer source variable units
     character(len=fm_string_len) :: src_var_gridspec !< Tracer source grid file name
+    character(len=fm_string_len) :: obc_src_file_name !< Boundary condition tracer source filename
+    character(len=fm_string_len) :: obc_src_field_name !< Boundary condition tracer source fieldname
     integer :: src_var_record !< Unknown
     logical :: requires_src_info = .false. !< Unknown
     real    :: src_var_unit_conversion = 1.0 !< This factor depends on the tracer. Ask Jasmin
@@ -61,6 +63,7 @@ implicit none ; private
   public :: g_tracer_get_next
   public :: g_tracer_is_prog
   public :: g_diag_type
+  public :: g_tracer_get_obc_segment_props
 
   !> Set the values of various (array) members of the tracer node g_tracer_type
   !!
@@ -283,6 +286,14 @@ contains
     type(g_tracer_type), pointer :: g_tracer !< Pointer to tracer node
     type(g_tracer_type), pointer :: g_tracer_next !< Pointer to the next tracer node in the list
   end subroutine g_tracer_get_next
+
+  subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, obc_has, src_file, src_var_name)
+    type(g_tracer_type), pointer    :: g_tracer_list !< pointer to the head of the generic tracer list
+    type(g_tracer_type), pointer    :: g_tracer !< Pointer to tracer node
+    character(len=*),         intent(in) :: name
+    logical,                  intent(out):: obc_has                !<.true. if This tracer has OBC
+    character(len=*),optional,intent(out):: src_file, src_var_name !<OBC source file and variable in file
+  end subroutine g_tracer_get_obc_segment_props
 
   !>Vertical Diffusion of a tracer node
   !!

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -287,6 +287,7 @@ contains
     type(g_tracer_type), pointer :: g_tracer_next !< Pointer to the next tracer node in the list
   end subroutine g_tracer_get_next
 
+  !> get obc segment properties for each tracer
   subroutine g_tracer_get_obc_segment_props(g_tracer_list, name, obc_has, src_file, src_var_name,lfac_in,lfac_out)
     type(g_tracer_type), pointer    :: g_tracer_list !< pointer to the head of the generic tracer list
     type(g_tracer_type), pointer    :: g_tracer !< Pointer to tracer node

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2514,11 +2514,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
            CS%dyn_unsplit_CSp)
   endif
 
-  ! This subroutine calls user-specified tracer registration routines.
-  ! Additional calls can be added to MOM_tracer_flow_control.F90.
-  call call_tracer_register(HI, GV, US, param_file, CS%tracer_flow_CSp, &
-                            CS%tracer_Reg, restart_CSp)
-
   call MEKE_alloc_register_restart(HI, US, param_file, CS%MEKE, restart_CSp)
   call set_visc_register_restarts(HI, GV, US, param_file, CS%visc, restart_CSp)
   call mixedlayer_restrat_register_restarts(HI, GV, param_file, &
@@ -2548,6 +2543,12 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     if (use_temperature) &
       call register_temp_salt_segments(GV, US, CS%OBC, CS%tracer_Reg, param_file)
 
+    ! This subroutine calls user-specified tracer registration routines.
+    ! Additional calls can be added to MOM_tracer_flow_control.F90.
+    ! Needs to be after registering temperature and salinity OBCs above,
+    ! or else the user-specified tracers will be first.
+    call call_tracer_register(HI, GV, US, param_file, CS%tracer_flow_CSp, &
+                            CS%tracer_Reg, restart_CSp, CS%OBC)
     ! This needs the number of tracers and to have called any code that sets whether
     ! reservoirs are used.
     call open_boundary_register_restarts(HI, GV, US, CS%OBC, CS%tracer_Reg, &

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -357,11 +357,11 @@ end type OBC_registry_type
 
 !> Type to carry OBC information needed for setting segments for OBGC tracers
 type, private :: external_tracers_segments_props
-   type(external_tracers_segments_props), pointer :: next => NULL()
-   character(len=128) :: tracer_name
-   character(len=128) :: tracer_src_file
-   character(len=128) :: tracer_src_field
-   real               :: lfac_in,lfac_out
+   type(external_tracers_segments_props), pointer :: next => NULL() !< pointer to the next node
+   character(len=128) :: tracer_name      !< tracer name
+   character(len=128) :: tracer_src_file  !< tracer source file for BC
+   character(len=128) :: tracer_src_field !< name of the field in source file to extract BC
+   real               :: lfac_in,lfac_out !< multiplicative factors for in and out tracer reservoir length scales
 end type external_tracers_segments_props
 type(external_tracers_segments_props), pointer, save :: obgc_segments_props => NULL() !< Linked-list of obgc tracers properties
 integer, save :: num_obgc_tracers = 0  !< Keeps the total number of obgc tracers

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -361,7 +361,8 @@ type, private :: external_tracers_segments_props
    character(len=128) :: tracer_name      !< tracer name
    character(len=128) :: tracer_src_file  !< tracer source file for BC
    character(len=128) :: tracer_src_field !< name of the field in source file to extract BC
-   real               :: lfac_in,lfac_out !< multiplicative factors for in and out tracer reservoir length scales
+   real               :: lfac_in  !< multiplicative factor for inbound  tracer reservoir length scale
+   real               :: lfac_out !< multiplicative factor for outbound tracer reservoir length scale
 end type external_tracers_segments_props
 type(external_tracers_segments_props), pointer, save :: obgc_segments_props => NULL() !< Linked-list of obgc tracers properties
 integer, save :: num_obgc_tracers = 0  !< Keeps the total number of obgc tracers
@@ -4739,7 +4740,7 @@ subroutine set_obgc_segments_props(tr_name,obc_src_file_name,obc_src_field_name,
   character(len=*),  intent(in) :: tr_name            !< Tracer name
   character(len=*),  intent(in) :: obc_src_file_name  !< OBC source file name
   character(len=*),  intent(in) :: obc_src_field_name !< name of the field in the source file
-  real,              intent(in) :: lfac_in,lfac_out
+  real,              intent(in) :: lfac_in,lfac_out   !< factors for tracer reservoir length scales
   type(external_tracers_segments_props),pointer :: node_ptr => NULL()
   allocate(node_ptr)
   node_ptr%tracer_name = trim(tr_name)
@@ -4753,13 +4754,15 @@ subroutine set_obgc_segments_props(tr_name,obc_src_file_name,obc_src_field_name,
   num_obgc_tracers = num_obgc_tracers+1
 end subroutine set_obgc_segments_props
 
-!> Get the OBC properties of external obgc tracers, such as their source file, field name, reservoir length scale factors
+!> Get the OBC properties of external obgc tracers, such as their source file, field name, 
+!  reservoir length scale factors
 subroutine get_obgc_segments_props(node, tr_name,obc_src_file_name,obc_src_field_name,lfac_in,lfac_out)
-  type(external_tracers_segments_props),pointer :: node
+  type(external_tracers_segments_props),pointer :: node !< pointer to type that keeps the tracer segment properties
   character(len=*), intent(out) :: tr_name            !< Tracer name
   character(len=*), intent(out) :: obc_src_file_name  !< OBC source file name
   character(len=*), intent(out) :: obc_src_field_name !< name of the field in the source file
-  real,             intent(out) :: lfac_in,lfac_out   !< multiplicative factors for inverse reservoir length scale
+  real,             intent(out) :: lfac_in   !< multiplicative factor for inbound  reservoir length scale
+  real,             intent(out) :: lfac_out  !< multiplicative factor for outbound reservoir length scale
   tr_name=trim(node%tracer_name)
   obc_src_file_name=trim(node%tracer_src_file)
   obc_src_field_name=trim(node%tracer_src_field)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -4742,8 +4742,9 @@ subroutine set_obgc_segments_props(tr_name,obc_src_file_name,obc_src_field_name,
   character(len=*),  intent(in) :: obc_src_file_name  !< OBC source file name
   character(len=*),  intent(in) :: obc_src_field_name !< name of the field in the source file
   real,              intent(in) :: lfac_in,lfac_out   !< factors for tracer reservoir length scales
-  type(external_tracers_segments_props),pointer :: node_ptr => NULL() !< pointer to type that keeps 
-                                                                     !the tracer segment properties
+
+  type(external_tracers_segments_props),pointer :: node_ptr => NULL() !pointer to type that keeps
+                                                                    ! the tracer segment properties
   allocate(node_ptr)
   node_ptr%tracer_name = trim(tr_name)
   node_ptr%tracer_src_file = trim(obc_src_file_name)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -364,7 +364,8 @@ type, private :: external_tracers_segments_props
    real               :: lfac_in  !< multiplicative factor for inbound  tracer reservoir length scale
    real               :: lfac_out !< multiplicative factor for outbound tracer reservoir length scale
 end type external_tracers_segments_props
-type(external_tracers_segments_props), pointer, save :: obgc_segments_props => NULL() !< Linked-list of obgc tracers properties
+!> Keeps the OBC segment properties for external tracers
+type(external_tracers_segments_props), pointer, save :: obgc_segments_props => NULL() !< properties
 integer, save :: num_obgc_tracers = 0  !< Keeps the total number of obgc tracers
 integer :: id_clock_pass !< A CPU time clock
 
@@ -4741,7 +4742,8 @@ subroutine set_obgc_segments_props(tr_name,obc_src_file_name,obc_src_field_name,
   character(len=*),  intent(in) :: obc_src_file_name  !< OBC source file name
   character(len=*),  intent(in) :: obc_src_field_name !< name of the field in the source file
   real,              intent(in) :: lfac_in,lfac_out   !< factors for tracer reservoir length scales
-  type(external_tracers_segments_props),pointer :: node_ptr => NULL()
+  type(external_tracers_segments_props),pointer :: node_ptr => NULL() !< pointer to type that keeps 
+                                                                     !the tracer segment properties
   allocate(node_ptr)
   node_ptr%tracer_name = trim(tr_name)
   node_ptr%tracer_src_file = trim(obc_src_file_name)
@@ -4754,10 +4756,10 @@ subroutine set_obgc_segments_props(tr_name,obc_src_file_name,obc_src_field_name,
   num_obgc_tracers = num_obgc_tracers+1
 end subroutine set_obgc_segments_props
 
-!> Get the OBC properties of external obgc tracers, such as their source file, field name, 
+!> Get the OBC properties of external obgc tracers, such as their source file, field name,
 !  reservoir length scale factors
 subroutine get_obgc_segments_props(node, tr_name,obc_src_file_name,obc_src_field_name,lfac_in,lfac_out)
-  type(external_tracers_segments_props),pointer :: node !< pointer to type that keeps the tracer segment properties
+  type(external_tracers_segments_props),pointer :: node !< pointer to tracer segment properties
   character(len=*), intent(out) :: tr_name            !< Tracer name
   character(len=*), intent(out) :: obc_src_file_name  !< OBC source file name
   character(len=*), intent(out) :: obc_src_field_name !< name of the field in the source file

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -83,7 +83,7 @@ module MOM_generic_tracer
     type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
                                                !! regulate the timing of diagnostic output.
     type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< Restart control structure
-    type(ocean_OBC_type), pointer :: OBC => NULL()
+    type(ocean_OBC_type), pointer :: OBC => NULL() !<open boundary condition type
     !> Pointer to the first element of the linked list of generic tracers.
     type(g_tracer_type), pointer :: g_tracer_list => NULL()
 

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -149,7 +149,7 @@ end subroutine call_tracer_flux_init
 
 !> This subroutine determines which tracer packages are to be used and does the calls to
 !! register their tracers to be advected, diffused, and read from restarts.
-subroutine call_tracer_register(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
+subroutine call_tracer_register(HI, GV, US, param_file, CS, tr_Reg, restart_CS, OBC)
   type(hor_index_type),         intent(in) :: HI         !< A horizontal index type structure.
   type(verticalGrid_type),      intent(in) :: GV         !< The ocean's vertical grid structure.
   type(unit_scale_type),        intent(in) :: US         !< A dimensional unit scaling type
@@ -162,7 +162,10 @@ subroutine call_tracer_register(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
                                                          !! advection and diffusion module.
   type(MOM_restart_CS), intent(inout) :: restart_CS !< A pointer to the restart control
                                                          !! structure.
-
+  type(ocean_OBC_type),         pointer    :: OBC        !< This open boundary condition
+                                                         !! type specifies whether, where,
+                                                         !! and what open boundary
+                                                         !! conditions are used.
 
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -259,7 +262,7 @@ subroutine call_tracer_register(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
                         tr_Reg, restart_CS)
   if (CS%use_MOM_generic_tracer) CS%use_MOM_generic_tracer = &
     register_MOM_generic_tracer(HI, GV, param_file,  CS%MOM_generic_tracer_CSp, &
-                                tr_Reg, restart_CS)
+                                tr_Reg, restart_CS, OBC)
   if (CS%use_pseudo_salt_tracer) CS%use_pseudo_salt_tracer = &
     register_pseudo_salt_tracer(HI, GV, param_file,  CS%pseudo_salt_tracer_CSp, &
                                 tr_Reg, restart_CS)


### PR DESCRIPTION
- These are updates required to setup OBC segments for BGC tracers.
- Since COBALT package has more than 50 tracers using the MOM6
  override mechanism for setting up OBC segments is not feasible (OBC_SEGMENT_001_DATA,...). 
  Rather, this update delegates such setup to mechanism used in 
  ocean_BGS tracers leaving mechanism for native MOM6 tracers intact.