### PR TITLE
+(*)Add new viscosity options and discourage the use of KVML

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1951,10 +1951,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  default=.false.)
   CS%tv%T_is_conT = use_conT_absS ; CS%tv%S_is_absS = use_conT_absS
   call get_param(param_file, "MOM", "ADIABATIC", CS%adiabatic, &
-                 "There are no diapycnal mass fluxes if ADIABATIC is "//&
-                 "true. This assumes that KD = KDML = 0.0 and that "//&
-                 "there is no buoyancy forcing, but makes the model "//&
-                 "faster by eliminating subroutine calls.", default=.false.)
+                 "There are no diapycnal mass fluxes if ADIABATIC is true.  "//&
+                 "This assumes that KD = 0.0 and that there is no buoyancy forcing, "//&
+                 "but makes the model faster by eliminating subroutine calls.", default=.false.)
   call get_param(param_file, "MOM", "DO_DYNAMICS", CS%do_dynamics, &
                  "If False, skips the dynamics calls that update u & v, as well as "//&
                  "the gravity wave adjustment to h. This may be a fragile feature, "//&

--- a/src/core/MOM_porous_barriers.F90
+++ b/src/core/MOM_porous_barriers.F90
@@ -284,7 +284,7 @@ subroutine calc_eta_at_uv(eta_u, eta_v, interp, dmask, h, tv, G, GV, US, eta_bt)
   real, dimension(SZI_(G),SZJ_(G)), optional,   intent(in) :: eta_bt !< optional barotropic variable
                                                                    !! used to dilate the layer thicknesses
                                                                    !! [H ~> m or kg m-2].
-  real,                                         intent(in) :: dmask !< The depth shaller than which
+  real,                                         intent(in) :: dmask !< The depth shallower than which
                                                                     !! porous barrier is not applied [Z ~> m]
   integer,                                      intent(in) :: interp !< eta interpolation method
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(out) :: eta_u !< Layer interface heights at u points [Z ~> m]
@@ -456,13 +456,13 @@ subroutine porous_barriers_init(Time, US, param_file, diag, CS)
   ! The sign needs to be inverted to be consistent with the sign convention of Davg_[UV]
   CS%mask_depth = -CS%mask_depth
   call get_param(param_file, mdl, "PORBAR_ETA_INTERP", interp_method, &
-                 "A string describing the method that decicdes how the "//&
+                 "A string describing the method that decides how the "//&
                  "interface heights at the velocity points are calculated. "//&
                  "Valid values are:\n"//&
                  "\t MAX (the default) - maximum of the adjacent cells \n"//&
                  "\t MIN - minimum of the adjacent cells \n"//&
                  "\t ARITHMETIC - arithmetic mean of the adjacent cells \n"//&
-                 "\t HARMOINIC - harmonic mean of the adjacent cells \n", &
+                 "\t HARMONIC - harmonic mean of the adjacent cells \n", &
                  default=ETA_INTERP_MAX_STRING)
   select case (interp_method)
     case (ETA_INTERP_MAX_STRING) ; CS%eta_interp = ETA_INTERP_MAX

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -48,6 +48,7 @@ type, public :: mixedlayer_restrat_CS ; private
   logical :: MLE_use_PBL_MLD       !< If true, use the MLD provided by the PBL parameterization.
                                    !! if false, MLE will calculate a MLD based on a density difference
                                    !! based on the parameter MLE_DENSITY_DIFF.
+  real    :: vonKar                !< The von Karman constant as used for mixed layer viscosity [nomdim]
   real    :: MLE_MLD_decay_time    !< Time-scale to use in a running-mean when MLD is retreating [T ~> s].
   real    :: MLE_MLD_decay_time2   !< Time-scale to use in a running-mean when filtered MLD is retreating [T ~> s].
   real    :: MLE_density_diff      !< Density difference used in detecting mixed-layer depth [R ~> kg m-3].
@@ -189,6 +190,8 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
   real :: dh        ! Portion of the layer thickness that is in the mixed layer [H ~> m or kg m-2]
   real :: res_scaling_fac ! The resolution-dependent scaling factor [nondim]
   real :: I_LFront ! The inverse of the frontal length scale [L-1 ~> m-1]
+  real :: vonKar_x_pi2    ! A scaling constant that is approximately the von Karman constant times
+                          ! pi squared [nondim]
   logical :: line_is_empty, keep_going, res_upscale
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
@@ -199,6 +202,8 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
   h_min = 0.5*GV%Angstrom_H ! This should be GV%Angstrom_H, but that value would change answers.
   covTS(:)=0.0 !!Functionality not implemented yet; in future, should be passed in tv
   varS(:)=0.0
+
+  vonKar_x_pi2 = CS%vonKar * 9.8696
 
   if (.not.associated(tv%eqn_of_state)) call MOM_error(FATAL, "MOM_mixedlayer_restrat: "// &
          "An equation of state must be used with this module.")
@@ -380,11 +385,10 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
           ( sqrt( 0.5 * ( G%dxCu(I,j)**2 + G%dyCu(I,j)**2 ) ) * I_LFront ) &
           * min( 1., 0.5*( VarMix%Rd_dx_h(i,j) + VarMix%Rd_dx_h(i+1,j) ) )
 
-    ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
+    ! peak ML visc: u_star * von_Karman * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2
-    ! 0.41 is the von Karmen constant, 9.8696 = pi^2.
     h_vel = 0.5*((htot_fast(i,j) + htot_fast(i+1,j)) + h_neglect) * GV%H_to_Z
-    mom_mixrate = (0.41*9.8696)*u_star**2 / &
+    mom_mixrate = vonKar_x_pi2*u_star**2 / &
                   (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
     timescale = timescale * CS%ml_restrat_coef
@@ -393,7 +397,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
         (Rml_av_fast(i+1,j)-Rml_av_fast(i,j)) * (h_vel**2 * GV%Z_to_H)
     ! As above but using the slow filtered MLD
     h_vel = 0.5*((htot_slow(i,j) + htot_slow(i+1,j)) + h_neglect) * GV%H_to_Z
-    mom_mixrate = (0.41*9.8696)*u_star**2 / &
+    mom_mixrate = vonKar_x_pi2*u_star**2 / &
                   (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
     timescale = timescale * CS%ml_restrat_coef2
@@ -456,11 +460,10 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
           ( sqrt( 0.5 * ( (G%dxCv(i,J))**2 + (G%dyCv(i,J))**2 ) ) * I_LFront ) &
           * min( 1., 0.5*( VarMix%Rd_dx_h(i,j) + VarMix%Rd_dx_h(i,j+1) ) )
 
-    ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
+    ! peak ML visc: u_star * von_Karman * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2
-    ! 0.41 is the von Karmen constant, 9.8696 = pi^2.
     h_vel = 0.5*((htot_fast(i,j) + htot_fast(i,j+1)) + h_neglect) * GV%H_to_Z
-    mom_mixrate = (0.41*9.8696)*u_star**2 / &
+    mom_mixrate = vonKar_x_pi2*u_star**2 / &
                   (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
     timescale = timescale * CS%ml_restrat_coef
@@ -469,7 +472,7 @@ subroutine mixedlayer_restrat_general(h, uhtr, vhtr, tv, forces, dt, MLD_in, Var
         (Rml_av_fast(i,j+1)-Rml_av_fast(i,j)) * (h_vel**2 * GV%Z_to_H)
     ! As above but using the slow filtered MLD
     h_vel = 0.5*((htot_slow(i,j) + htot_slow(i,j+1)) + h_neglect) * GV%H_to_Z
-    mom_mixrate = (0.41*9.8696)*u_star**2 / &
+    mom_mixrate = vonKar_x_pi2*u_star**2 / &
                   (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
     timescale = timescale * CS%ml_restrat_coef2
@@ -617,6 +620,8 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
   real :: h_vel           ! htot interpolated onto velocity points [Z ~> m]. (The units are not H.)
   real :: absf            ! absolute value of f, interpolated to velocity points [T-1 ~> s-1]
   real :: u_star          ! surface friction velocity, interpolated to velocity points [Z T-1 ~> m s-1].
+  real :: vonKar_x_pi2    ! A scaling constant that is approximately the von Karman constant times
+                          ! pi squared [nondim]
   real :: mom_mixrate     ! rate at which momentum is homogenized within mixed layer [T-1 ~> s-1]
   real :: timescale       ! mixing growth timescale [T ~> s]
   real :: h_min           ! The minimum layer thickness [H ~> m or kg m-2].  h_min could be 0.
@@ -653,6 +658,7 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
   uDml(:)    = 0.0 ; vDml(:) = 0.0
   I4dt       = 0.25 / dt
   g_Rho0     = GV%g_Earth / GV%Rho0
+  vonKar_x_pi2 = CS%vonKar * 9.8696
   use_EOS    = associated(tv%eqn_of_state)
   h_neglect  = GV%H_subroundoff
   dz_neglect = GV%H_subroundoff*GV%H_to_Z
@@ -701,10 +707,9 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
 
     u_star = 0.5*(forces%ustar(i,j) + forces%ustar(i+1,j))
     absf = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
-    ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
+    ! peak ML visc: u_star * von_Karman * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2
-    ! 0.41 is the von Karmen constant, 9.8696 = pi^2.
-    mom_mixrate = (0.41*9.8696)*u_star**2 / &
+    mom_mixrate = vonKar_x_pi2*u_star**2 / &
                   (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
 
@@ -748,10 +753,9 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
 
     u_star = 0.5*(forces%ustar(i,j) + forces%ustar(i,j+1))
     absf = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
-    ! peak ML visc: u_star * 0.41 * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
+    ! peak ML visc: u_star * von_Karman * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2
-    ! 0.41 is the von Karmen constant, 9.8696 = pi^2.
-    mom_mixrate = (0.41*9.8696)*u_star**2 / &
+    mom_mixrate = vonKar_x_pi2*u_star**2 / &
                   (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
 
@@ -877,6 +881,9 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   call get_param(param_file, mdl, "USE_STANLEY_ML", CS%use_stanley_ml, &
                  "If true, turn on Stanley SGS T variance parameterization "// &
                  "in ML restrat code.", default=.false.)
+  call get_param(param_file, mdl, 'VON_KARMAN_CONST', CS%vonKar, &
+                 'The value the von Karman constant as used for mixed layer viscosity.', &
+                 units='nondim', default=0.41)
   ! We use GV%nkml to distinguish between the old and new implementation of MLE.
   ! The old implementation only works for the layer model with nkml>0.
   if (GV%nkml==0) then

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -9,7 +9,7 @@ use MOM_debugging,       only : hchksum
 use MOM_diag_mediator,   only : diag_ctrl, time_type, register_diag_field
 use MOM_diag_mediator,   only : post_data
 use MOM_error_handler,   only : MOM_error, FATAL, WARNING, NOTE
-use MOM_file_parser,     only : get_param, log_version, param_file_type
+use MOM_file_parser,     only : get_param, log_param, log_version, param_file_type
 use MOM_file_parser,     only : openParameterBlock, closeParameterBlock
 use MOM_forcing_type,    only : forcing
 use MOM_grid,            only : ocean_grid_type
@@ -63,9 +63,11 @@ type, public :: bkgnd_mixing_cs ; private
   real    :: Kd_tanh_lat_scale      !< A nondimensional scaling for the range of
                                     !! diffusivities with Kd_tanh_lat_fn. Valid values
                                     !! are in the range of -2 to 2; 0.4 reproduces CM2M.
-  real    :: Kdml                   !< mixed layer diapycnal diffusivity [Z2 T-1 ~> m2 s-1]
-                                    !! when bulkmixedlayer==.false.
-  real    :: Hmix                   !< mixed layer thickness [Z ~> m] when bulkmixedlayer==.false.
+  real    :: Kd_tot_ml              !< The mixed layer diapycnal diffusivity [Z2 T-1 ~> m2 s-1]
+                                    !! when no other physically based mixed layer turbulence
+                                    !! parameterization is being used.
+  real    :: Hmix                   !< mixed layer thickness [Z ~> m] when no physically based
+                                    !! ocean surface boundary layer parameterization is used.
   logical :: Kd_tanh_lat_fn         !< If true, use the tanh dependence of Kd_sfc on
                                     !! latitude, like GFDL CM2.1/CM2M.  There is no
                                     !! physical justification for this form, and it can
@@ -92,7 +94,8 @@ type, public :: bkgnd_mixing_cs ; private
              !! where kd is the diapycnal diffusivity. This approach assumes that work done
              !! against gravity is uniformly distributed throughout the column. Whereas, kd=kd_0*e,
              !! as in the original version, concentrates buoyancy work in regions of strong stratification.
-  logical :: bulkmixedlayer !< If true, a refined bulk mixed layer scheme is used
+  logical :: physical_OBL_scheme !< If true, a physically-based scheme is used to determine mixing in the
+                   !! ocean's surface boundary layer, such as ePBL, KPP, or a refined bulk mixed layer scheme.
   logical :: Kd_via_Kdml_bug !< If true and KDML /= KD and a number of other higher precedence
                    !! options are not used, the background diffusivity is set incorrectly using a
                    !! bug that was introduced in March, 2018.
@@ -109,7 +112,7 @@ character(len=40)  :: mdl = "MOM_bkgnd_mixing" !< This module's name.
 contains
 
 !> Initialize the background mixing routine.
-subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
+subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS, physical_OBL_scheme)
 
   type(time_type),         intent(in)    :: Time       !< The current time.
   type(ocean_grid_type),   intent(in)    :: G          !< Grid structure.
@@ -117,15 +120,20 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
   type(unit_scale_type),   intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),   intent(in)    :: param_file !< Run-time parameter file handle
   type(diag_ctrl), target, intent(inout) :: diag       !< Diagnostics control structure.
-  type(bkgnd_mixing_cs),    pointer      :: CS         !< This module's control structure.
+  type(bkgnd_mixing_cs),   pointer       :: CS         !< This module's control structure.
+  logical,                 intent(in)    :: physical_OBL_scheme !< If true, a physically based
+                                                       !! parameterization (like KPP or ePBL or a bulk mixed
+                                                       !! layer) is used outside of set_diffusivity to
+                                                       !! specify the mixing that occurs in the ocean's
+                                                       !! surface boundary layer.
 
   ! Local variables
   real :: Kv                    ! The interior vertical viscosity [Z2 T-1 ~> m2 s-1] - read to set Prandtl
                                 ! number unless it is provided as a parameter
   real :: prandtl_bkgnd_comp    ! Kv/CS%Kd. Gets compared with user-specified prandtl_bkgnd.
 
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
 
   if (associated(CS)) then
     call MOM_error(WARNING, "bkgnd_mixing_init called with an associated "// &
@@ -154,21 +162,38 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
 
   ! The following is needed to set one of the choices of vertical background mixing
 
-  ! BULKMIXEDLAYER is not always defined (e.g., CM2G63L), so the following line by passes
-  ! the need to include BULKMIXEDLAYER in MOM_input
-  CS%bulkmixedlayer = (GV%nkml > 0)
-  if (CS%bulkmixedlayer) then
+  CS%physical_OBL_scheme = physical_OBL_scheme
+  if (CS%physical_OBL_scheme) then
     ! Check that Kdml is not set when using bulk mixed layer
-    call get_param(param_file, mdl, "KDML", CS%Kdml, default=-1.)
-    if (CS%Kdml>0.) call MOM_error(FATAL, &
-                 "bkgnd_mixing_init: KDML cannot be set when using bulk mixed layer.")
-    CS%Kdml = CS%Kd ! This is not used with a bulk mixed layer, but also cannot be a NaN.
+    call get_param(param_file, mdl, "KDML", CS%Kd_tot_ml, default=-1., do_not_log=.true.)
+    if (CS%Kd_tot_ml>0.) call MOM_error(FATAL, &
+                 "bkgnd_mixing_init: KDML is a depricated parameter that should not be used.")
+    call get_param(param_file, mdl, "KD_ML_TOT", CS%Kd_tot_ml, default=-1., do_not_log=.true.)
+    if (CS%Kd_tot_ml>0.) call MOM_error(FATAL, &
+                 "bkgnd_mixing_init: KD_ML_TOT cannot be set when using a physically based ocean "//&
+                 "boundary layer mixing parameterization.")
+    CS%Kd_tot_ml = CS%Kd ! This is not used with a bulk mixed layer, but also cannot be a NaN.
   else
-    call get_param(param_file, mdl, "KDML", CS%Kdml, &
+    call get_param(param_file, mdl, "KD_ML_TOT", CS%Kd_tot_ml, &
+                 "The total diapcynal diffusivity in the surface mixed layer when there is "//&
+                 "not a physically based parameterization of mixing in the mixed layer, such "//&
+                 "as bulk mixed layer or KPP or ePBL.", &
+                 units="m2 s-1", default=CS%Kd*US%Z2_T_to_m2_s, scale=US%m2_s_to_Z2_T, do_not_log=.true.)
+    if (abs(CS%Kd_tot_ml - CS%Kd) <= 1.0e-15*abs(CS%Kd)) then
+      call get_param(param_file, mdl, "KDML", CS%Kd_tot_ml, &
                  "If BULKMIXEDLAYER is false, KDML is the elevated "//&
                  "diapycnal diffusivity in the topmost HMIX of fluid. "//&
                  "KDML is only used if BULKMIXEDLAYER is false.", &
-                 units="m2 s-1", default=CS%Kd*US%Z2_T_to_m2_s, scale=US%m2_s_to_Z2_T)
+                 units="m2 s-1", default=CS%Kd*US%Z2_T_to_m2_s, scale=US%m2_s_to_Z2_T, do_not_log=.true.)
+      if (abs(CS%Kd_tot_ml - CS%Kd) > 1.0e-15*abs(CS%Kd)) &
+        call MOM_error(WARNING, "KDML is a depricated parameter. Use KD_ML_TOT instead.")
+    endif
+    call log_param(param_file, mdl, "KD_ML_TOT", CS%Kd_tot_ml*US%Z2_T_to_m2_s, &
+                 "The total diapcynal diffusivity in the surface mixed layer when there is "//&
+                 "not a physically based parameterization of mixing in the mixed layer, such "//&
+                 "as bulk mixed layer or KPP or ePBL.", &
+                 units="m2 s-1", default=CS%Kd*US%Z2_T_to_m2_s)
+
     call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
                  "The prescribed depth over which the near-surface "//&
                  "viscosity and diffusivity are elevated when the bulk "//&
@@ -290,13 +315,13 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS)
     "MOM_bkgnd_mixing: KD_TANH_LAT_FN can not be used with HENYEY_IGW_BACKGROUND.")
 
   CS%Kd_via_Kdml_bug = .false.
-  if ((CS%Kd /= CS%Kdml) .and. .not.(CS%Kd_tanh_lat_fn .or. CS%bulkmixedlayer .or. &
+  if ((CS%Kd /= CS%Kd_tot_ml) .and. .not.(CS%Kd_tanh_lat_fn .or. CS%physical_OBL_scheme .or. &
                                      CS%Henyey_IGW_background .or. CS%Henyey_IGW_background_new .or. &
                                      CS%horiz_varying_background .or. CS%Bryan_Lewis_diffusivity)) then
     call get_param(param_file, mdl, "KD_BACKGROUND_VIA_KDML_BUG", CS%Kd_via_Kdml_bug, &
                  "If true and KDML /= KD and several other conditions apply, the background "//&
                  "diffusivity is set incorrectly using a bug that was introduced in March, 2018.", &
-                 default=.true.)  ! The default should be changed to false and this parameter obsoleted.
+                 default=.false.)  ! The default should be changed to false and this parameter obsoleted.
   endif
 
 !  call closeParameterBlock(param_file)
@@ -471,7 +496,7 @@ subroutine calculate_bkgnd_mixing(h, tv, N2_lay, Kd_lay, Kd_int, Kv_bkgnd, j, G,
     endif
 
     ! Now set background diffusivies based on these surface values, possibly with vertical structure.
-    if ((.not.CS%bulkmixedlayer) .and. (CS%Kd /= CS%Kdml)) then
+    if ((.not.CS%physical_OBL_scheme) .and. (CS%Kd /= CS%Kd_tot_ml)) then
       ! This is a crude way to put in a diffusive boundary layer without an explicit boundary
       ! layer turbulence scheme.  It should not be used for any realistic ocean models.
       I_Hmix = 1.0 / (CS%Hmix + GV%H_subroundoff*GV%H_to_Z)
@@ -481,16 +506,16 @@ subroutine calculate_bkgnd_mixing(h, tv, N2_lay, Kd_lay, Kd_int, Kv_bkgnd, j, G,
         if (CS%Kd_via_Kdml_bug) then
           ! These two lines should update Kd_lay, not Kd_int.  They were correctly working on the
           ! same variables until MOM6 commit 7a818716 (PR#750), which was added on March 26, 2018.
-          if (depth_c <= CS%Hmix) then ; Kd_int(i,K) = CS%Kdml
+          if (depth_c <= CS%Hmix) then ; Kd_int(i,K) = CS%Kd_tot_ml
           elseif (depth_c >= 2.0*CS%Hmix) then ; Kd_int(i,K) = Kd_sfc(i)
           else
-            Kd_lay(i,k) = ((Kd_sfc(i) - CS%Kdml) * I_Hmix) * depth_c + (2.0*CS%Kdml - Kd_sfc(i))
+            Kd_lay(i,k) = ((Kd_sfc(i) - CS%Kd_tot_ml) * I_Hmix) * depth_c + (2.0*CS%Kd_tot_ml - Kd_sfc(i))
           endif
         else
-          if (depth_c <= CS%Hmix) then ; Kd_lay(i,k) = CS%Kdml
+          if (depth_c <= CS%Hmix) then ; Kd_lay(i,k) = CS%Kd_tot_ml
           elseif (depth_c >= 2.0*CS%Hmix) then ; Kd_lay(i,k) = Kd_sfc(i)
           else
-            Kd_lay(i,k) = ((Kd_sfc(i) - CS%Kdml) * I_Hmix) * depth_c + (2.0*CS%Kdml - Kd_sfc(i))
+            Kd_lay(i,k) = ((Kd_sfc(i) - CS%Kd_tot_ml) * I_Hmix) * depth_c + (2.0*CS%Kd_tot_ml - Kd_sfc(i))
           endif
         endif
 

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -153,8 +153,7 @@ subroutine make_frazil(h, tv, G, GV, US, CS, p_surf, halo)
         pressure(i,1) = ps(i) + (0.5*H_to_RL2_T2)*h(i,j,1)
       enddo
       do k=2,nz ; do i=is,ie
-        pressure(i,k) = pressure(i,k-1) + &
-          (0.5*H_to_RL2_T2) * (h(i,j,k) + h(i,j,k-1))
+        pressure(i,k) = pressure(i,k-1) + (0.5*H_to_RL2_T2) * (h(i,j,k) + h(i,j,k-1))
       enddo ; enddo
     endif
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -2925,6 +2925,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   character(len=48)  :: thickness_units
   character(len=40)  :: var_name
   character(len=160) :: var_descript
+  logical :: physical_OBL_scheme
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz, nbands, m
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -3434,9 +3435,11 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
     call internal_tides_init(Time, G, GV, US, param_file, diag, CS%int_tide)
   endif
 
+  physical_OBL_scheme = (CS%use_bulkmixedlayer .or. CS%use_KPP .or. CS%use_energetic_PBL)
   ! initialize module for setting diffusivities
   call set_diffusivity_init(Time, G, GV, US, param_file, diag, CS%set_diff_CSp, CS%int_tide, &
-                            halo_TS=CS%halo_TS_diff, double_diffuse=CS%double_diffuse)
+                            halo_TS=CS%halo_TS_diff, double_diffuse=CS%double_diffuse, &
+                            physical_OBL_scheme=physical_OBL_scheme)
 
   if (CS%useKPP .and. (CS%double_diffuse .and. .not.CS%use_CVMix_ddiff)) &
     call MOM_error(FATAL, 'diabatic_driver_init: DOUBLE_DIFFUSION (old method) does not work '//&

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -36,8 +36,7 @@ type, public :: energetic_PBL_CS ; private
   logical :: initialized = .false. !< True if this control structure has been initialized.
 
   !/ Constants
-  real    :: VonKar = 0.41   !< The von Karman coefficient.  This should be a runtime parameter,
-                             !! but because it is set to 0.4 at runtime in KPP it might change answers.
+  real    :: VonKar          !< The von Karman coefficient as used in the ePBL module [nondim]
   real    :: omega           !< The Earth's rotation rate [T-1 ~> s-1].
   real    :: omega_frac      !< When setting the decay scale for turbulence, use this fraction of
                              !! the absolute rotation rate blended with the local value of f, as
@@ -1982,6 +1981,9 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
                  "A nondimensional scaling factor controlling the inhibition "//&
                  "of the diffusive length scale by rotation. Making this larger "//&
                  "decreases the PBL diffusivity.", units="nondim", default=1.0)
+  call get_param(param_file, mdl, 'VON_KARMAN_CONST', CS%vonKar, &
+                 'The value the von Karman constant as used for mixed layer viscosity.', &
+                 units='nondim', default=0.41)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
                  default=99991231)

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -1963,7 +1963,7 @@ subroutine set_density_ratios(h, tv, kb, G, GV, US, CS, j, ds_dsp1, rho_0)
 end subroutine set_density_ratios
 
 subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_CSp, halo_TS, &
-                                double_diffuse)
+                                double_diffuse, physical_OBL_scheme)
   type(time_type),          intent(in)    :: Time !< The current model time
   type(ocean_grid_type),    intent(inout) :: G    !< The ocean's grid structure.
   type(verticalGrid_type),  intent(in)    :: GV   !< The ocean's vertical grid structure.
@@ -1974,10 +1974,15 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
   type(set_diffusivity_CS), pointer       :: CS   !< pointer set to point to the module control
                                                   !! structure.
   type(int_tide_CS),        intent(in), target :: int_tide_CSp !< Internal tide control struct
-  integer,        optional, intent(out)   :: halo_TS !< The halo size of tracer points that must be
+  integer,                  intent(out)   :: halo_TS !< The halo size of tracer points that must be
                                                   !! valid for the calculations in set_diffusivity.
   logical,                  intent(out)   :: double_diffuse !< This indicates whether some version
                                                   !! of double diffusion is being used.
+  logical,                  intent(in)    :: physical_OBL_scheme !< If true, a physically based
+                                                  !! parameterization (like KPP or ePBL or a bulk mixed
+                                                  !! layer) is used outside of set_diffusivity to
+                                                  !! specify the mixing that occurs in the ocean's
+                                                  !! surface boundary layer.
 
   ! Local variables
   real :: decay_length
@@ -2164,7 +2169,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
                  default=.false., do_not_log=.not.TKE_to_Kd_used)
 
   ! set params related to the background mixing
-  call bkgnd_mixing_init(Time, G, GV, US, param_file, CS%diag, CS%bkgnd_mixing_csp)
+  call bkgnd_mixing_init(Time, G, GV, US, param_file, CS%diag, CS%bkgnd_mixing_csp, physical_OBL_scheme)
 
   call get_param(param_file, mdl, "KV", CS%Kv, &
                  "The background kinematic viscosity in the interior. "//&

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2050,10 +2050,9 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                  do_not_log=.true.)
   if (adiabatic) then
     call log_param(param_file, mdl, "ADIABATIC",adiabatic, &
-                 "There are no diapycnal mass fluxes if ADIABATIC is "//&
-                 "true. This assumes that KD = KDML = 0.0 and that "//&
-                 "there is no buoyancy forcing, but makes the model "//&
-                 "faster by eliminating subroutine calls.", default=.false.)
+                 "There are no diapycnal mass fluxes if ADIABATIC is true.  "//&
+                 "This assumes that KD = 0.0 and that there is no buoyancy forcing, "//&
+                 "but makes the model faster by eliminating subroutine calls.", default=.false.)
   endif
 
   if (.not.adiabatic) then

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2110,11 +2110,11 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   endif
 
   call get_param(param_file, mdl, "HBBL", CS%Hbbl, &
-                 "The thickness of a bottom boundary layer with a "//&
-                 "viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or "//&
-                 "the thickness over which near-bottom velocities are "//&
-                 "averaged for the drag law if BOTTOMDRAGLAW is defined "//&
-                 "but LINEAR_DRAG is not.", units="m", fail_if_missing=.true.) ! Rescaled later
+                 "The thickness of a bottom boundary layer with a viscosity increased by "//&
+                 "KV_EXTRA_BBL if BOTTOMDRAGLAW is not defined, or the thickness over which "//&
+                 "near-bottom velocities are averaged for the drag law if BOTTOMDRAGLAW is "//&
+                 "defined but LINEAR_DRAG is not.", &
+                 units="m", fail_if_missing=.true.) ! Rescaled later
   if (CS%bottomdraglaw) then
     call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
                  "CDRAG is the drag coefficient relating the magnitude of "//&


### PR DESCRIPTION
  This is a series of commits designed to add new capabilities to handle the
near-surface viscous coupling between thin near-surface layers when there is a
wind stress, and to strongly discourage the use of the KVML-derived viscosities
that scale with the inverse of the distance from the free surface squared. 
These new capabilities have been determined to work as intended in variants of
the double gyre test case with additional thin layers added in the lightest
density range.  These changes should allow us to address the source of the
problems that have plaguing runs with an ice-shelf that do not use a bulk
mixed layer.

  In addition, the friction velocity, forces%ustar, is now being set with several
idealized wind forcing prescriptions where it previously had not been set. 
Also, the von Karman constant had been used as a hard-coded constant in several
places, and it has now been replaced with variables that can be set via run-time
parameters.

  All answers are bitwise identical in the MOM6-examples test suite, and are
unlikely to change in any realistic configurations, but there are new or
corrected entries in the MOM_parameter_doc files.

  The commits in this PR include:

- NOAA-GFDL/MOM6@59b8b06a3 +Made the von Karman constant a runtime parameter
- NOAA-GFDL/MOM6@318303ae3 +(*)Set ustar with wind_forcing_2gyre
- NOAA-GFDL/MOM6@5b53ff998 +Add FIXED_DEPTH_LOTW_ML and LOTW_VISCOUS_ML_FLOOR
- NOAA-GFDL/MOM6@f2674629e Refactor boundary layer code in find_coupling_coef
- NOAA-GFDL/MOM6@4ca424aea +Replace KVML with KV_ML_INVZ2
- NOAA-GFDL/MOM6@fa6d8e314 +Spell HARMONIC right in PORBAR_ETA_INTERP docs
- NOAA-GFDL/MOM6@107d36714 +(*)Replace KVBBL with KV_EXTRA_BBL
- NOAA-GFDL/MOM6@39f8ee08a (*)+Rename KDML to KD_ML_TOT and restrict its use
