### PR TITLE
*Change defaults for KV_ML_INVZ2 and 3 bug flags

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4476,7 +4476,7 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                  "If true, the tidal self-attraction and loading anomaly in the barotropic "//&
                  "solver has the wrong sign, replicating a long-standing bug with a scalar "//&
                  "self-attraction and loading term or the SAL term from a previous simulation.", &
-                 default=.true., do_not_log=(det_de==0.0))
+                 default=.false., do_not_log=(det_de==0.0))
   call get_param(param_file, mdl, "SADOURNY", CS%Sadourny, &
                  "If true, the Coriolis terms are discretized with the "//&
                  "Sadourny (1975) energy conserving scheme, otherwise "//&

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2651,7 +2651,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  "If true use an expression with a vertical indexing bug for extrapolating the "//&
                  "densities at the bottom of unstable profiles from data when finding the "//&
                  "initial interface locations in layered mode from a dataset of T and S.", &
-                 default=.true., do_not_log=just_read)
+                 default=.false., do_not_log=just_read)
     ! Reusing MINIMUM_DEPTH for the default mixed layer depth may be a strange choice, but
     ! it reproduces previous answers.
   endif

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -80,20 +80,6 @@ type, public :: bkgnd_mixing_cs ; private
              !! Henyey et al, JGR (1986) latitudinal scaling for the background diapycnal diffusivity,
              !! which gives a marked decrease in the diffusivity near the equator.  The simplification
              !! here is to assume that the in-situ stratification is the same as the reference stratificaiton.
-  logical :: Henyey_IGW_background_new !< same as Henyey_IGW_background
-             !! but incorporate the effect of stratification on TKE dissipation,
-             !! e = f/f_0 * acosh(N/f) / acosh(N_0/f_0) * e_0
-             !! where e is the TKE dissipation, and N_0 and f_0
-             !! are the reference buoyancy frequency and inertial frequencies respectively.
-             !! e_0 is the reference dissipation at (N_0,f_0). In the previous version, N=N_0.
-             !! Additionally, the squared inverse relationship between  diapycnal diffusivities
-             !! and stratification is included:
-             !!
-             !! kd = e/N^2
-             !!
-             !! where kd is the diapycnal diffusivity. This approach assumes that work done
-             !! against gravity is uniformly distributed throughout the column. Whereas, kd=kd_0*e,
-             !! as in the original version, concentrates buoyancy work in regions of strong stratification.
   logical :: physical_OBL_scheme !< If true, a physically-based scheme is used to determine mixing in the
                    !! ocean's surface boundary layer, such as ePBL, KPP, or a refined bulk mixed layer scheme.
   logical :: Kd_via_Kdml_bug !< If true and KDML /= KD and a number of other higher precedence
@@ -276,13 +262,6 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS, physical_OBL
                  "Harrison & Hallberg, JPO 2008.", default=.false.)
   if (CS%Henyey_IGW_background) call check_bkgnd_scheme(CS, "HENYEY_IGW_BACKGROUND")
 
-
-  call get_param(param_file, mdl, "HENYEY_IGW_BACKGROUND_NEW", CS%Henyey_IGW_background_new, &
-                 "If true, use a better latitude-dependent scaling for the "//&
-                 "background diffusivity, as described in "//&
-                 "Harrison & Hallberg, JPO 2008. This option is obsolete.", default=.false.)
-  if (CS%Henyey_IGW_background_new) call check_bkgnd_scheme(CS, "HENYEY_IGW_BACKGROUND_NEW")
-
   if (CS%Kd>0.0 .and. (trim(CS%bkgnd_scheme_str)=="BRYAN_LEWIS_DIFFUSIVITY" .or.&
                           trim(CS%bkgnd_scheme_str)=="HORIZ_VARYING_BACKGROUND" )) then
     call MOM_error(WARNING, "bkgnd_mixing_init: a nonzero constant background "//&
@@ -321,7 +300,7 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS, physical_OBL
     call get_param(param_file, mdl, "KD_BACKGROUND_VIA_KDML_BUG", CS%Kd_via_Kdml_bug, &
                  "If true and KDML /= KD and several other conditions apply, the background "//&
                  "diffusivity is set incorrectly using a bug that was introduced in March, 2018.", &
-                 default=.false.)  ! The default should be changed to false and this parameter obsoleted.
+                 default=.false.)  ! This parameter should be obsoleted.
   endif
 
 !  call closeParameterBlock(param_file)

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -1858,7 +1858,7 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
   call get_param(param_file, mdl, "KAPPA_SHEAR_VERTEX_PSURF_BUG", CS%psurf_bug, &
                  "If true, do a simple average of the cell surface pressures to get a pressure "//&
                  "at the corner if VERTEX_SHEAR=True.  Otherwise mask out any land points in "//&
-                 "the average.", default=.true., do_not_log=(just_read .or. (.not.CS%KS_at_vertex)))
+                 "the average.", default=.false., do_not_log=(just_read .or. (.not.CS%KS_at_vertex)))
 
   call get_param(param_file, mdl, "KAPPA_SHEAR_ITER_BUG", CS%dKdQ_iteration_bug, &
                  "If true, use an older, dimensionally inconsistent estimate of the "//&

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1785,7 +1785,6 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
 
   ! Local variables
 
-  real :: Kv_dflt ! A default viscosity [m2 s-1].
   real :: Kv_BBL  ! A viscosity in the bottom boundary layer with a simple scheme [Z2 T-1 ~> m2 s-1].
   real :: Hmix_m  ! A boundary layer thickness [m].
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
@@ -1913,7 +1912,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
   call get_param(param_file, mdl, "KV", CS%Kv, &
                  "The background kinematic viscosity in the interior. "//&
                  "The molecular value, ~1e-6 m2 s-1, may be used.", &
-                 units="m2 s-1", fail_if_missing=.true., scale=US%m2_s_to_Z2_T, unscaled=Kv_dflt)
+                 units="m2 s-1", fail_if_missing=.true., scale=US%m2_s_to_Z2_T)
 
   CS%Kvml_invZ2 = 0.0
   if (GV%nkml < 1) then
@@ -1928,11 +1927,11 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
     if (CS%Kvml_invZ2 < 0.0) then
       call get_param(param_file, mdl, "KVML", CS%Kvml_invZ2, &
                  "The scale for an extra kinematic viscosity in the mixed layer", &
-                 units="m2 s-1", default=Kv_dflt, scale=US%m2_s_to_Z2_T, do_not_log=.true.)
+                 units="m2 s-1", default=0.0, scale=US%m2_s_to_Z2_T, do_not_log=.true.)
       if (CS%Kvml_invZ2 >= 0.0) &
         call MOM_error(WARNING, "KVML is a deprecated parameter. Use KV_ML_INVZ2 instead.")
     endif
-    if (CS%Kvml_invZ2 < 0.0) CS%Kvml_invZ2 = CS%Kv  ! Change this default later to 0.0.
+    if (CS%Kvml_invZ2 < 0.0) CS%Kvml_invZ2 = 0.0
     call log_param(param_file, mdl, "KV_ML_INVZ2", US%Z2_T_to_m2_s*CS%Kvml_invZ2, &
                  "An extra kinematic viscosity in a mixed layer of thickness HMIX_FIXED, "//&
                  "with the actual viscosity scaling as 1/(z*HMIX_FIXED)^2, where z is the "//&
@@ -1940,7 +1939,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
                  "transmitted through infinitesimally thin surface layers.  This is an "//&
                  "older option for numerical convenience without a strong physical basis, "//&
                  "and its use is now discouraged.", &
-                 units="m2 s-1", default=Kv_dflt)
+                 units="m2 s-1", default=0.0)
   endif
 
   if (.not.CS%bottomdraglaw) then


### PR DESCRIPTION
  Updated the default values for KV_ML_INVZ2, BAROTROPIC_TIDAL_SAL_BUG,
LAYER_Z_INIT_IC_EXTRAP_BUG, and KAPPA_SHEAR_VERTEX_PSURF_BUG. Also completed obsoleting of HENYEY_IGW_BACKGROUND_NEW.  This PR will change answers in some cases, unless the MOM_input files already included lines with the following settings, or otherwise explicitly set these parameters:

  KV_ML_INVZ2 = 0.0
  BAROTROPIC_TIDAL_SAL_BUG = False
  LAYER_Z_INIT_IC_EXTRAP_BUG = False
  KAPPA_SHEAR_VERTEX_PSURF_BUG = False

For each of these parameters, there is another parameter (such as BULKMIXEDLAYER or TIDES) whose value determines whether they might be used in a particular case.  To determine whether or why answers for a particular configuration might change with this PR, compare the MOM_parameter_doc.all files from equivalent runs before and after these code changes to determine whether any of these parameters are taking the default value.  This commit could change answers in some cases that use default values for these parameters, and the entries in some MOM_parameter_doc files will change.  The answers in the MOM6-examples test suite are bitwise identical, due to some entries that were recently added to the MOM_input files for these cases.