### PR TITLE
FMS2: open_ASCII_file and open_namelist_file

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -182,14 +182,25 @@ endif
 SOURCE = \
   $(foreach ext,F90 inc c h,$(wildcard $(1)/*/*.$(ext) $(1)/*/*/*.$(ext)))
 
-MOM_SOURCE = $(call SOURCE,../src) \
-  $(wildcard ../config_src/infra/FMS1/*.F90) \
+MOM_SOURCE = \
+  $(call SOURCE,../src) \
   $(wildcard ../config_src/drivers/solo_driver/*.F90) \
   $(wildcard ../config_src/ext*/*/*.F90)
-TARGET_SOURCE = $(call SOURCE,build/target_codebase/src) \
-  $(wildcard build/target_codebase/config_src/infra/FMS1/*.F90) \
+
+TARGET_SOURCE = \
+  $(call SOURCE,build/target_codebase/src) \
   $(wildcard build/target_codebase/config_src/drivers/solo_driver/*.F90) \
   $(wildcard build/target_codebase/config_src/ext*/*.F90)
+
+# NOTE: Current default framework is FMS1, but this could change.
+ifeq ($(FRAMEWORK), fms2)
+  MOM_SOURCE +=$(wildcard ../config_src/infra/FMS2/*.F90)
+  TARGET_SOURCE += $(wildcard build/target_codebase/config_src/infra/FMS2/*.F90)
+else
+  MOM_SOURCE += $(wildcard ../config_src/infra/FMS1/*.F90)
+  TARGET_SOURCE += $(wildcard build/target_codebase/config_src/infra/FMS1/*.F90)
+endif
+
 FMS_SOURCE = $(call SOURCE,deps/fms/src)
 
 


### PR DESCRIPTION
This patch re-implements the FMS2 implementations of `open_ASCII_file` and `open_namelist_file` to remove their dependency on FMS1 functions which have been staged for deletion.

Note that if a file is opened with `mpp_open` but closed with `close_file_unit`, then it will raise an error in `fms_io_exit`. This will no longer be an issue after all references to `mpp_open` have been removed.  But in the meantime, we will need to ensure that all unit-based `close_file` calls were not opened with `mpp_open`.

There is also a minor patch to `.testing/Makefile` which selects the framework ("infra") source dependency, rather than hard-set to FMS1.