### PR TITLE
Bug fix for categorize_axes causing crash

### DIFF
--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -1680,6 +1680,7 @@ subroutine categorize_axes(fileObj, filename, ndims, dim_names, is_x, is_y, is_t
     ! First look for indicative variable attributes
     if (.not.is_t(i)) then
       if (variable_exists(fileobj, trim(dim_names(i)))) then
+        cartesian = ""
         if (variable_att_exists(fileobj, trim(dim_names(i)), "cartesian_axis")) then
           call get_variable_attribute(fileobj, trim(dim_names(i)), "cartesian_axis", cartesian)
         elseif (variable_att_exists(fileobj, trim(dim_names(i)), "axis")) then

--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -1686,6 +1686,12 @@ subroutine categorize_axes(fileObj, filename, ndims, dim_names, is_x, is_y, is_t
           if ((index(cartesian, "X") == 1) .or. (index(cartesian, "x") == 1)) is_x(i) = .true.
           if ((index(cartesian, "Y") == 1) .or. (index(cartesian, "y") == 1)) is_y(i) = .true.
           if ((index(cartesian, "T") == 1) .or. (index(cartesian, "t") == 1)) is_t(i) = .true.
+        elseif (variable_att_exists(fileobj, trim(dim_names(i)), "axis")) then
+          call get_variable_attribute(fileobj, trim(dim_names(i)), "axis", cartesian)
+          cartesian = adjustl(cartesian)
+          if ((index(cartesian, "X") == 1) .or. (index(cartesian, "x") == 1)) is_x(i) = .true.
+          if ((index(cartesian, "Y") == 1) .or. (index(cartesian, "y") == 1)) is_y(i) = .true.
+          if ((index(cartesian, "T") == 1) .or. (index(cartesian, "t") == 1)) is_t(i) = .true.
         endif
       endif
     endif

--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -1682,17 +1682,13 @@ subroutine categorize_axes(fileObj, filename, ndims, dim_names, is_x, is_y, is_t
       if (variable_exists(fileobj, trim(dim_names(i)))) then
         if (variable_att_exists(fileobj, trim(dim_names(i)), "cartesian_axis")) then
           call get_variable_attribute(fileobj, trim(dim_names(i)), "cartesian_axis", cartesian)
-          cartesian = adjustl(cartesian)
-          if ((index(cartesian, "X") == 1) .or. (index(cartesian, "x") == 1)) is_x(i) = .true.
-          if ((index(cartesian, "Y") == 1) .or. (index(cartesian, "y") == 1)) is_y(i) = .true.
-          if ((index(cartesian, "T") == 1) .or. (index(cartesian, "t") == 1)) is_t(i) = .true.
         elseif (variable_att_exists(fileobj, trim(dim_names(i)), "axis")) then
           call get_variable_attribute(fileobj, trim(dim_names(i)), "axis", cartesian)
-          cartesian = adjustl(cartesian)
-          if ((index(cartesian, "X") == 1) .or. (index(cartesian, "x") == 1)) is_x(i) = .true.
-          if ((index(cartesian, "Y") == 1) .or. (index(cartesian, "y") == 1)) is_y(i) = .true.
-          if ((index(cartesian, "T") == 1) .or. (index(cartesian, "t") == 1)) is_t(i) = .true.
         endif
+        cartesian = adjustl(cartesian)
+        if ((index(cartesian, "X") == 1) .or. (index(cartesian, "x") == 1)) is_x(i) = .true.
+        if ((index(cartesian, "Y") == 1) .or. (index(cartesian, "y") == 1)) is_y(i) = .true.
+        if ((index(cartesian, "T") == 1) .or. (index(cartesian, "t") == 1)) is_t(i) = .true.
       endif
     endif
     if (is_x(i)) x_found = .true.


### PR DESCRIPTION
Closes #220 

- The subroutine categorize_axes cannot find the axes in ice restart files and gives warnings
        WARNING from PE     0: categorize_axes: Failed to identify x- and y- axes in the axis list (xaxis_1, yaxis_1, Time) of a variable being read fr
om I
    NPUT/ice_model.res.nc
- This leads to an incorrect initializations and a subsequent sat.vap.press.overflow crash when using
        infra/FMS2
- Same experiment runs fine with infra/FMS1
- After the fix the infra/FMS1 and infra/FMS2 answers are bitwise
        identical

- Thanks @uramirez8707 for suggesting this fix.