### PR TITLE
Autoconf: Fortran-netCDF C compatibility test

### DIFF
--- a/.github/actions/macos-setup/action.yml
+++ b/.github/actions/macos-setup/action.yml
@@ -10,7 +10,7 @@ runs:
       shell: bash
       run: |
         echo "::group::Install packages"
-        brew update
+        brew reinstall gcc
         brew install automake
         brew install netcdf
         brew install netcdf-fortran

--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: macOS-latest
 
     env:
-      CC: gcc-11
-      FC: gfortran-11
+      CC: gcc
+      FC: gfortran
 
     defaults:
       run:

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: macOS-latest
 
     env:
-      CC: gcc-11
-      FC: gfortran-11
+      CC: gcc
+      FC: gfortran
 
     defaults:
       run:

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -105,7 +105,7 @@ AX_FC_CHECK_MODULE([mpi],
 
 # netCDF configuration
 
-# Search for the Fortran netCDF module, fallback to nf-config.
+# Search for the Fortran netCDF module.
 AX_FC_CHECK_MODULE([netcdf], [], [
   AS_UNSET([ax_fc_cv_mod_netcdf])
   AC_PATH_PROG([NF_CONFIG], [nf-config])
@@ -118,39 +118,37 @@ AX_FC_CHECK_MODULE([netcdf], [], [
   ])
 ])
 
-# FMS may invoke netCDF C calls, so we link to libnetcdf.
-AC_LANG_PUSH([C])
-AC_CHECK_LIB([netcdf], [nc_create], [], [
-  AS_UNSET([ac_cv_lib_netcdf_nc_create])
+# Confirm that the Fortran compiler can link the netCDF C library
+AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
+  AS_UNSET([ax_fc_cv_c_lib_netcdf_nc_create])
   AC_PATH_PROG([NC_CONFIG], [nc-config])
   AS_IF([test -n "$NC_CONFIG"], [
-    AC_SUBST([LDFLAGS],
-      ["$LDFLAGS -L$($NC_CONFIG --libdir)"]
-    )
-    ], [AC_MSG_ERROR([Could not find nc-config.])]
-  )
-  AC_CHECK_LIB([netcdf], [nc_create], [], [
-    AC_MSG_ERROR([Could not find libnetcdf.])
+    AC_SUBST([LDFLAGS], ["$LDFLAGS -L$($NC_CONFIG --libdir)"])
+  ], [
+    AC_MSG_ERROR([Could not find nc-config.])
+  ])
+  AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
+    AC_MSG_ERROR([Could not find netCDF C library.])
   ])
 ])
-AC_LANG_POP([C])
 
-# NOTE: We test for nf_create, rather than nf90_create, because AX_FC_CHECK_LIB
-#   is currently not yet able to properly probe inside modules.
-# NOTE: nf-config does not have --libdir, so we use the first term of flibs.
-
-# Link to Fortran netCDF library, netcdff
+# Confirm that the Fortran compiler can link to the netCDF Fortran library.
+# NOTE:
+#   - We test nf_create, rather than nf90_create, since AX_FC_CHECK_LIB can
+#     not currently probe the Fortran 90 interfaces.
+#   - nf-config does not have --libdir, so we parse the --flibs output.
 AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
   AS_UNSET([ax_fc_cv_lib_netcdff_nf_create])
   AC_PATH_PROG([NF_CONFIG], [nf-config])
   AS_IF([test -n "$NF_CONFIG"], [
     AC_SUBST([LDFLAGS],
-      ["$LDFLAGS $($NF_CONFIG --flibs | cut -f1 -d" ")"]
+      ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
     )
-    ], [AC_MSG_ERROR([Could not find nf_create.])]
-  )
+  ], [
+    AC_MSG_ERROR([Could not find nf-config.])
+  ])
   AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-    AC_MSG_ERROR([Could not find libnetcdff.])
+    AC_MSG_ERROR([Could not find netCDF Fortran library.])
   ])
 ])
 
@@ -268,4 +266,3 @@ AC_LANG_POP([C])
 AC_SUBST([CPPFLAGS])
 AC_CONFIG_FILES([Makefile:${srcdir}/ac/Makefile.in])
 AC_OUTPUT
-

--- a/ac/m4/ax_fc_check_c_lib.m4
+++ b/ac/m4/ax_fc_check_c_lib.m4
@@ -1,0 +1,45 @@
+dnl AX_FC_CHECK_C_LIB(LIBRARY, FUNCTION,
+dnl                   [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND],
+dnl                   [OTHER-LDFLAGS], [OTHER-LIBS])
+dnl
+dnl This macro checks if a C binding is available to the compiler.
+dnl
+dnl Equivalently, it checks if the Fortran compiler can see a C function.
+dnl
+dnl Results are cached in `ax_fc_cv_c_lib_LIBRARY_FUNCTION`.
+dnl
+AC_DEFUN([AX_FC_CHECK_C_LIB], [
+  AS_VAR_PUSHDEF([ax_fc_C_Lib], [ax_fc_cv_c_lib_$1_$2])
+  m4_ifval([$5],
+    [ax_fc_c_lib_msg_LDFLAGS=" with $5"],
+    [ax_fc_c_lib_msg_LDFLAGS=""]
+  )
+  AC_CACHE_CHECK(
+    [for $2 in -l$1$ax_fc_c_lib_msg_LDFLAGS], [ax_fc_cv_c_lib_$1_$2], [
+      ax_fc_check_c_lib_save_LDFLAGS=$LDFLAGS
+      LDFLAGS="$6 $LDFLAGS"
+      ax_fc_check_c_lib_save_LIBS=$LIBS
+      LIBS="-l$1 $7 $LIBS"
+      AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([],[dnl
+dnl begin code block
+        interface
+        subroutine test() bind(c, name="$2")
+        end subroutine test
+        end interface
+        call test])
+dnl end code block
+        ],
+        [AS_VAR_SET([ax_fc_C_Lib], [yes])],
+        [AS_VAR_SET([ax_fc_C_Lib], [no])]
+      )
+      LDFLAGS=$ax_fc_check_c_lib_save_LDFLAGS
+      LIBS=$ax_fc_check_c_lib_save_LIBS
+    ]
+  )
+  AS_VAR_IF([ax_fc_C_Lib], [yes],
+    [m4_default([$3], [LIBS="-l$1 $LIBS"])],
+    [$4]
+  )
+  AS_VAR_POPDEF([ax_fc_C_Lib])
+])


### PR DESCRIPTION
This patch introduces a new autoconf macro, `AX_FC_CHECK_C_LIB`, which confirms if the Fortran compiler can be linked to the netCDF C library. As with other netCDF tests, the `nc-config` tool is used if necessary (and available).

This resolves some recent issues on platforms where netCDF and netCDF-Fortran are installed in separate locations, with different library directories (`-L`).

It also resolves some false assumptions in configure.ac which presumed equivalent access by the configured C and Fortran compilers. Previously, we would test if the C compiler could be linked to netCDF, and then assume that the Fortran compiler shared the same relationship. We now use the Fortran compiler for both C and Fortran tests.

This patch fixes many issues observed on MacOS systems, including some persistent problems on the GitHub Actions MacOS tests.  For example, we can now use the default GCC 12 compilers, rather than forcing a rollback to GCC 11.