### PR TITLE
+Set input file variable names via runtime params

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -139,7 +139,7 @@ type, public :: ice_shelf_CS ; private
   real :: time_step    !< this is the shortest timestep that the ice shelf sees [T ~> s], and
                        !! is equal to the forcing timestep (it is passed in when the shelf
                        !! is initialized - so need to reorganize MOM driver.
-                       !! it will be the prognistic timestep ... maybe.
+                       !! it will be the prognostic timestep ... maybe.
 
   logical :: solo_ice_sheet !< whether the ice model is running without being
                             !! coupled to the ocean
@@ -288,13 +288,13 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
   real :: n_star_term ! A term in the expression for nstar [T3 Z-2 ~> s3 m-2]
   real :: absf     ! The absolute value of the Coriolis parameter [T-1 ~> s-1]
   real :: dIns_dwB !< The partial derivative of I_n_star with wB_flux, in [T3 Z-2 ~> s3 m-2]
-  real :: dT_ustar ! The difference between the the freezing point and the ocean boundary layer
+  real :: dT_ustar ! The difference between the freezing point and the ocean boundary layer
                    ! temperature times the friction velocity [C Z T-1 ~> degC m s-1]
   real :: dS_ustar ! The difference between the salinity at the ice-ocean interface and the ocean
                    ! boundary layer salinity times the friction velocity [S Z T-1 ~> ppt m s-1]
   real :: ustar_h  ! The friction velocity in the water below the ice shelf [Z T-1 ~> m s-1]
   real :: Gam_turb ! [nondim]
-  real :: Gam_mol_t, Gam_mol_s ! Relative coefficients of molecular diffusivites [nondim]
+  real :: Gam_mol_t, Gam_mol_s ! Relative coefficients of molecular diffusivities [nondim]
   real :: RhoCp     ! A typical ocean density times the heat capacity of water [Q R C-1 ~> J m-3 degC-1]
   real :: ln_neut
   real :: mass_exch ! A mass exchange rate [R Z T-1 ~> kg m-2 s-1]
@@ -312,7 +312,7 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
   real :: Irho0        ! The inverse of the mean density times a unit conversion factor [R-1 L Z-1 ~> m3 kg-1]
   logical :: Sb_min_set, Sb_max_set
   logical :: update_ice_vel ! If true, it is time to update the ice shelf velocities.
-  logical :: coupled_GL     ! If true, the grouding line position is determined based on
+  logical :: coupled_GL     ! If true, the grounding line position is determined based on
                             ! coupled ice-ocean dynamics.
 
   real, parameter :: c2_3 = 2.0/3.0
@@ -524,7 +524,7 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
             wB_flux = dB_dS * (dS_ustar * I_Gam_S) + dB_dT * wT_flux
 
             if (wB_flux < 0.0) then
-              ! The buoyancy flux is stabilizing and will reduce the tubulent
+              ! The buoyancy flux is stabilizing and will reduce the turbulent
               ! fluxes, and iteration is required.
               n_star_term = (ZETA_N/RC) * (hBL_neut * VK) / (ustar_h)**3
               do it3 = 1,30
@@ -572,9 +572,9 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
             exch_vel_s(i,j) = ustar_h * I_Gam_S
 
             ! Calculate the heat flux inside the ice shelf.
-            ! Vertical adv/diff as in H+J 1999, eqns (26) & approx from (31).
+            ! Vertical adv/diff as in H+J 1999, equations (26) & approx from (31).
             !   Q_ice = density_ice * CS%Cp_ice * K_ice * dT/dz (at interface)
-            ! vertical adv/diff as in H+J 1999, eqs (31) & (26)...
+            ! vertical adv/diff as in H+J 1999, equations (31) & (26)...
             !   dT/dz ~= min( (lprec/(density_ice*K_ice))*(CS%Temp_Ice-T_freeze) , 0.0 )
             ! If this approximation is not made, iterations are required... See H+J Fig 3.
 
@@ -1012,7 +1012,7 @@ subroutine add_shelf_flux(G, US, CS, sfc_state, fluxes)
   real :: balancing_area   !< total area where the balancing flux is applied [m2]
   type(time_type) :: dTime !< The time step as a time_type
   type(time_type) :: Time0 !< The previous time (Time-dt)
-  real, dimension(SZDI_(G),SZDJ_(G)) :: bal_frac  !< Fraction of the cel1 where the mass flux
+  real, dimension(SZDI_(G),SZDJ_(G)) :: bal_frac  !< Fraction of the cell where the mass flux
                           !! balancing the net melt flux occurs, 0 to 1 [nondim]
   real, dimension(SZDI_(G),SZDJ_(G)) :: last_mass_shelf !< Ice shelf mass
                           !! at at previous time (Time-dt) [R Z ~> kg m-2]
@@ -1235,13 +1235,14 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
   logical :: new_sim, save_IC
   !This include declares and sets the variable "version".
 # include "version_variable.h"
-  character(len=200) :: IC_file, inputdir
+  character(len=200) :: IC_file, inputdir  ! Input file names or paths
   character(len=40)  :: mdl = "MOM_ice_shelf"  ! This module's name.
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed, Isdq, Iedq, Jsdq, Jedq
   integer :: wd_halos(2)
   logical :: read_TideAmp, shelf_mass_is_dynamic, debug
   logical :: global_indexing
-  character(len=240) :: Tideamp_file
+  character(len=240) :: Tideamp_file  ! Input file names
+  character(len=80)  :: tideamp_var ! Input file variable names
   real    :: utide  ! A tidal velocity [L T-1 ~> m s-1]
   real    :: col_thick_melt_thresh ! An ocean column thickness below which iceshelf melting
                                    ! does not occur [Z ~> m]
@@ -1397,7 +1398,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
                  "consistency to calculate the fluxes at the ice-ocean "//&
                  "interface.", default=.true.)
   call get_param(param_file, mdl, "SHELF_INSULATOR", CS%insulator, &
-                 "If true, the ice shelf is a perfect insulatior "//&
+                 "If true, the ice shelf is a perfect insulator "//&
                  "(no conduction).", default=.false.)
   call get_param(param_file, mdl, "MELTING_CUTOFF_DEPTH", CS%cutoff_depth, &
                  "Depth above which the melt is set to zero (it must be >= 0) "//&
@@ -1491,7 +1492,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
                  "The viscosity of the ice.", &
                  units="m2 s-1", default=1.0e10, scale=US%Z_to_L**2*US%m_to_L**2*US%T_to_s)
   call get_param(param_file, mdl, "KV_MOLECULAR", CS%kv_molec, &
-                 "The molecular kinimatic viscosity of sea water at the freezing temperature.", &
+                 "The molecular kinematic viscosity of sea water at the freezing temperature.", &
                  units="m2 s-1", default=1.95e-6, scale=US%m2_s_to_Z2_T)
   call get_param(param_file, mdl, "ICE_SHELF_SALINITY", CS%Salin_ice, &
                  "The salinity of the ice inside the ice shelf.", &
@@ -1537,19 +1538,21 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, forces_in,
 
   if (read_TIDEAMP) then
     call get_param(param_file, mdl, "TIDEAMP_FILE", TideAmp_file, &
-                 "The path to the file containing the spatially varying "//&
-                 "tidal amplitudes.", &
+                 "The path to the file containing the spatially varying tidal amplitudes.", &
                  default="tideamp.nc")
-    call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
+    call get_param(param_file, mdl, "TIDEAMP_VARNAME", tideamp_var, &
+                 "The name of the tidal amplitude variable in the input file.", &
+                 default="tideamp")
+     call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     inputdir = slasher(inputdir)
     TideAmp_file = trim(inputdir) // trim(TideAmp_file)
     if (CS%rotate_index) then
       allocate(tmp2d(CS%Grid_in%isd:CS%Grid_in%ied,CS%Grid_in%jsd:CS%Grid_in%jed), source=0.0)
-      call MOM_read_data(TideAmp_file, 'tideamp', tmp2d, CS%Grid_in%domain, timelevel=1, scale=US%m_s_to_L_T)
+      call MOM_read_data(TideAmp_file, tideamp_var, tmp2d, CS%Grid_in%domain, timelevel=1, scale=US%m_s_to_L_T)
       call rotate_array(tmp2d, CS%turns, CS%utide)
       deallocate(tmp2d)
     else
-      call MOM_read_data(TideAmp_file, 'tideamp', CS%utide, CS%Grid%domain, timelevel=1, scale=US%m_s_to_L_T)
+      call MOM_read_data(TideAmp_file, tideamp_var, CS%utide, CS%Grid%domain, timelevel=1, scale=US%m_s_to_L_T)
     endif
   else
     call get_param(param_file, mdl, "UTIDE", utide, &
@@ -2192,7 +2195,7 @@ subroutine solo_step_ice_shelf(CS, time_interval, nsteps, Time, min_time_step_in
   real :: min_time_step     ! The minimal required timestep that would indicate a fatal problem [T ~> s]
   character(len=240) :: mesg
   logical :: update_ice_vel ! If true, it is time to update the ice shelf velocities.
-  logical :: coupled_GL     ! If true the grouding line position is determined based on
+  logical :: coupled_GL     ! If true the grounding line position is determined based on
                             ! coupled ice-ocean dynamics.
   integer :: is, iec, js, jec
 
@@ -2261,7 +2264,7 @@ end subroutine solo_step_ice_shelf
 !!  update_shelf_mass - updates ice shelf mass via netCDF file
 !!                      USER_update_shelf_mass (TODO).
 !!    solo_step_ice_shelf - called only in ice-only mode.
-!!    shelf_calc_flux - after melt rate & fluxes are calculated, ice dynamics are done. currently mass_shelf is
+!!    shelf_calc_flux - after melt rate & fluxes are calculated, ice dynamics are done. Currently mass_shelf is
 !! updated immediately after ice_shelf_advect in fully dynamic mode.
 !!
 !!   NOTES: be aware that hmask(:,:) has a number of functions; it is used for front advancement,

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -174,6 +174,7 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
   integer :: npes_pm, ens_info(6)
   character(len=30) :: coord_mode
   character(len=200) :: inputdir, basin_file
+  character(len=80) :: basin_var
   character(len=80) :: remap_scheme
   character(len=80) :: bias_correction_file, inc_file
   logical :: answers_2018  ! If true, use the order of arithmetic and expressions that recover the
@@ -348,27 +349,28 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
 
   if (CS%use_basin_mask) then
     call get_param(PF, 'oda_driver', "BASIN_FILE", basin_file, &
-          "A file in which to find the basin masks, in variable 'basin'.", &
-          default="basin.nc")
+          "A file in which to find the basin masks.", default="basin.nc")
     basin_file = trim(inputdir) // trim(basin_file)
+    call get_param(PF, 'oda_driver', "BASIN_VAR", basin_var, &
+          "The basin mask variable in BASIN_FILE.", default="basin")
     allocate(CS%oda_grid%basin_mask(isd:ied,jsd:jed), source=0.0)
-    call MOM_read_data(basin_file,'basin',CS%oda_grid%basin_mask,CS%Grid%domain, timelevel=1)
+    call MOM_read_data(basin_file, basin_var, CS%oda_grid%basin_mask, CS%Grid%domain, timelevel=1)
   endif
 
   ! set up diag variables for analysis increments
   CS%diag_CS => diag_CS
-  CS%id_inc_t=register_diag_field('ocean_model','temp_increment',diag_CS%axesTL,&
+  CS%id_inc_t = register_diag_field('ocean_model', 'temp_increment', diag_CS%axesTL, &
        Time, 'ocean potential temperature increments', 'degC', conversion=US%C_to_degC)
-  CS%id_inc_s=register_diag_field('ocean_model','salt_increment',diag_CS%axesTL,&
+  CS%id_inc_s = register_diag_field('ocean_model', 'salt_increment', diag_CS%axesTL, &
        Time, 'ocean salinity increments', 'psu', conversion=US%S_to_ppt)
 
   !!  get global grid information from ocean model needed for ODA initialization
-  T_grid=>NULL()
+  T_grid => NULL()
   call set_up_global_tgrid(T_grid, CS, G)
 
   call ocean_da_core_init(CS%mpp_domain, T_grid, CS%Profiles, Time)
   deallocate(T_grid)
-  CS%Time=Time
+  CS%Time = Time
   !! switch back to ensemble member pelist
   call set_PElist(CS%ensemble_pelist(CS%ensemble_id,:))
 

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -185,7 +185,7 @@ subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, US, N2_bot)
                                                                  !! smooth out the values in thin layers [S ~> ppt].
   real, dimension(SZI_(G),SZJ_(G)),          intent(in)  :: h2   !< Bottom topographic roughness [Z2 ~> m2].
   type(forcing),                             intent(in)  :: fluxes !< A structure of thermodynamic surface fluxes
-  real, dimension(SZI_(G),SZJ_(G)),          intent(out) :: N2_bot !< The squared buoyancy freqency at the
+  real, dimension(SZI_(G),SZJ_(G)),          intent(out) :: N2_bot !< The squared buoyancy frequency at the
                                                                  !! ocean bottom [T-2 ~> s-2].
   ! Local variables
   real, dimension(SZI_(G),SZK_(GV)+1) :: &
@@ -304,7 +304,8 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_int_tide_input"  ! This module's name.
-  character(len=200) :: filename, tideamp_file, h2_file
+  character(len=200) :: filename, tideamp_file, h2_file ! Input file names or paths
+  character(len=80)  :: tideamp_var, rough_var ! Input file variable names
 
   real :: mask_itidal        ! A multiplicative land mask, 0 or 1 [nondim]
   real :: max_frac_rough     ! The fraction relating the maximum topographic roughness
@@ -386,7 +387,10 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
                "tidal amplitudes with INT_TIDE_DISSIPATION.", default="tideamp.nc")
     filename = trim(CS%inputdir) // trim(tideamp_file)
     call log_param(param_file, mdl, "INPUTDIR/TIDEAMP_FILE", filename)
-    call MOM_read_data(filename, 'tideamp', itide%tideamp, G%domain, scale=US%m_s_to_L_T)
+    call get_param(param_file, mdl, "TIDEAMP_VARNAME", tideamp_var, &
+               "The name of the tidal amplitude variable in the input file.", &
+               default="tideamp")
+    call MOM_read_data(filename, tideamp_var, itide%tideamp, G%domain, scale=US%m_s_to_L_T)
   endif
 
   call get_param(param_file, mdl, "H2_FILE", h2_file, &
@@ -395,7 +399,10 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
                fail_if_missing=.true.)
   filename = trim(CS%inputdir) // trim(h2_file)
   call log_param(param_file, mdl, "INPUTDIR/H2_FILE", filename)
-  call MOM_read_data(filename, 'h2', itide%h2, G%domain, scale=US%m_to_Z**2)
+  call get_param(param_file, mdl, "ROUGHNESS_VARNAME", rough_var, &
+                 "The name in the input file of the squared sub-grid-scale "//&
+                 "topographic roughness amplitude variable.", default="h2")
+  call MOM_read_data(filename, rough_var, itide%h2, G%domain, scale=US%m_to_Z**2)
 
   call get_param(param_file, mdl, "FRACTIONAL_ROUGHNESS_MAX", max_frac_rough, &
                  "The maximum topographic roughness amplitude as a fraction of the mean depth, "//&
@@ -408,7 +415,7 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
                  default=.false.)
   if (CS%int_tide_source_test)then
     call get_param(param_file, mdl, "INTERNAL_TIDE_USE_GLOB_IJ", CS%int_tide_use_glob_ij, &
-                 "Use global IJ for interal tide generation source test", default=.false.)
+                 "Use global IJ for internal tide generation source test", default=.false.)
     call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_X", CS%int_tide_source_x, &
                  "X Location of generation site for internal tide", default=1., &
                  do_not_log=CS%int_tide_use_glob_ij)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -77,7 +77,7 @@ type, public :: set_visc_CS ; private
   logical :: Channel_drag   !< If true, the drag is exerted directly on each layer
                             !! according to what fraction of the bottom they overlie.
   real    :: Chan_drag_max_vol !< The maximum bottom boundary layer volume within which the
-                            !! channel drag is applied, normalized by the the full cell area,
+                            !! channel drag is applied, normalized by the full cell area,
                             !! or a negative value to apply no maximum [H ~> m or kg m-2].
   logical :: correct_BBL_bounds !< If true, uses the correct bounds on the BBL thickness and
                             !! viscosity so that the bottom layer feels the intended drag.
@@ -134,7 +134,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
                             intent(in)    :: h    !< Layer thicknesses [H ~> m or kg m-2].
   type(thermo_var_ptrs),    intent(in)    :: tv   !< A structure containing pointers to any
                                                   !! available thermodynamic fields. Absent fields
-                                                  !! have NULL ptrs.
+                                                  !! have NULL pointers.
   type(vertvisc_type),      intent(inout) :: visc !< A structure containing vertical viscosities and
                                                   !! related fields.
   type(set_visc_CS),        intent(inout) :: CS   !< The control structure returned by a previous
@@ -1192,7 +1192,7 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS)
                            intent(in)    :: h    !< Layer thicknesses [H ~> m or kg m-2].
   type(thermo_var_ptrs),   intent(in)    :: tv   !< A structure containing pointers to any available
                                                  !! thermodynamic fields. Absent fields have
-                                                 !! NULL ptrs.
+                                                 !! NULL pointers.
   type(mech_forcing),      intent(in)    :: forces !< A structure with the driving mechanical forces
   type(vertvisc_type),     intent(inout) :: visc !< A structure containing vertical viscosities and
                                                  !! related fields.
@@ -1236,7 +1236,7 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS)
                 ! viscous mixed layer.
   real :: Uh2   ! The squared magnitude of the difference between the velocity
                 ! integrated through the mixed layer and the velocity of the
-                ! interior layer layer times the depth of the the mixed layer
+                ! interior layer layer times the depth of the mixed layer
                 ! [H2 L2 T-2 ~> m4 s-2 or kg2 m-2 s-2].
   real :: htot_vel  ! Sum of the layer thicknesses up to some point [H ~> m or kg m-2].
   real :: hwtot     ! Sum of the thicknesses used to calculate
@@ -1253,8 +1253,8 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS)
   real :: S_lay     ! The layer salinity at velocity points [S ~> ppt].
   real :: Rlay      ! The layer potential density at velocity points [R ~> kg m-3].
   real :: Rlb       ! The potential density of the layer below [R ~> kg m-3].
-  real :: v_at_u    ! The meridonal velocity at a zonal velocity point [L T-1 ~> m s-1].
-  real :: u_at_v    ! The zonal velocity at a meridonal velocity point [L T-1 ~> m s-1].
+  real :: v_at_u    ! The meridional velocity at a zonal velocity point [L T-1 ~> m s-1].
+  real :: u_at_v    ! The zonal velocity at a meridional velocity point [L T-1 ~> m s-1].
   real :: gHprime   ! The mixed-layer internal gravity wave speed squared, based
                     ! on the mixed layer thickness and density difference across
                     ! the base of the mixed layer [L2 T-2 ~> m2 s-2].
@@ -1863,7 +1863,7 @@ subroutine set_visc_register_restarts(HI, GV, US, param_file, visc, restart_CS)
   type(vertvisc_type),     intent(inout) :: visc       !< A structure containing vertical
                                                        !! viscosities and related fields.
                                                        !! Allocated here.
-  type(MOM_restart_CS),    intent(inout) :: restart_CS !< MOM restart control struct
+  type(MOM_restart_CS),    intent(inout) :: restart_CS !< MOM restart control structure
   ! Local variables
   logical :: use_kappa_shear, KS_at_vertex
   logical :: adiabatic, useKPP, useEPBL
@@ -1954,14 +1954,14 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                                                  !! output.
   type(vertvisc_type),     intent(inout) :: visc !< A structure containing vertical viscosities and
                                                  !! related fields.  Allocated here.
-  type(set_visc_CS),       intent(inout) :: CS   !< Vertical viscosity control struct
-  type(MOM_restart_CS),    intent(inout) :: restart_CS !< MOM restart control struct
+  type(set_visc_CS),       intent(inout) :: CS   !< Vertical viscosity control structure
+  type(MOM_restart_CS),    intent(inout) :: restart_CS !< MOM restart control structure
   type(ocean_OBC_type),    pointer       :: OBC  !< A pointer to an open boundary condition structure
 
   ! Local variables
   real    :: Csmag_chan_dflt ! The default value for SMAG_CONST_CHANNEL [nondim]
   real    :: smag_const1     ! The default value for the Smagorinsky Laplacian coefficient [nondim]
-  real    :: TKE_decay_dflt  ! The default value of a coeficient scaling the vertical decay
+  real    :: TKE_decay_dflt  ! The default value of a coefficient scaling the vertical decay
                              ! rate of TKE [nondim]
   real    :: bulk_Ri_ML_dflt ! The default bulk Richardson number for a bulk mixed layer [nondim]
   real    :: Kv_background   ! The background kinematic viscosity in the interior [m2 s-1]
@@ -1989,7 +1989,8 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                              ! isopycnal or stacked shallow water mode.
   logical :: use_temperature ! If true, temperature and salinity are used as state variables.
   logical :: use_EOS         ! If true, density calculated from T & S using an equation of state.
-  character(len=200) :: filename, tideamp_file
+  character(len=200) :: filename, tideamp_file ! Input file names or paths
+  character(len=80)  :: tideamp_var ! Input file variable names
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_set_visc"  ! This module's name.
@@ -2090,7 +2091,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                    "scale for turbulence.", default=.false., do_not_log=.true.)
     omega_frac_dflt = 0.0
     if (use_omega) then
-      call MOM_error(WARNING, "ML_USE_OMEGA is depricated; use ML_OMEGA_FRAC=1.0 instead.")
+      call MOM_error(WARNING, "ML_USE_OMEGA is deprecated; use ML_OMEGA_FRAC=1.0 instead.")
       omega_frac_dflt = 1.0
     endif
     call get_param(param_file, mdl, "ML_OMEGA_FRAC", CS%omega_frac, &
@@ -2130,6 +2131,9 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
       call get_param(param_file, mdl, "TIDEAMP_FILE", tideamp_file, &
                    "The path to the file containing the spatially varying "//&
                    "tidal amplitudes with INT_TIDE_DISSIPATION.", default="tideamp.nc")
+      call get_param(param_file, mdl, "TIDEAMP_VARNAME", tideamp_var, &
+                   "The name of the tidal amplitude variable in the input file.", &
+                   default="tideamp")
     else
       call get_param(param_file, mdl, "DRAG_BG_VEL", CS%drag_bg_vel, &
                    "DRAG_BG_VEL is either the assumed bottom velocity (with "//&
@@ -2223,7 +2227,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   CS%BBL_thick_min = CS%BBL_thick_min * GV%m_to_H ! Rescale
 
   if (CS%RiNo_mix .and. kappa_shear_at_vertex(param_file)) then
-    ! This is necessary for reproduciblity across restarts in non-symmetric mode.
+    ! This is necessary for reproducibility across restarts in non-symmetric mode.
     call pass_var(visc%Kv_shear_Bu, G%Domain, position=CORNER, complete=.true.)
   endif
 
@@ -2257,7 +2261,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
       allocate(CS%tideamp(isd:ied,jsd:jed), source=0.0)
       filename = trim(CS%inputdir) // trim(tideamp_file)
       call log_param(param_file, mdl, "INPUTDIR/TIDEAMP_FILE", filename)
-      call MOM_read_data(filename, 'tideamp', CS%tideamp, G%domain, scale=US%m_to_Z*US%T_to_s)
+      call MOM_read_data(filename, tideamp_var, CS%tideamp, G%domain, scale=US%m_to_Z*US%T_to_s)
       call pass_var(CS%tideamp,G%domain)
     endif
   endif


### PR DESCRIPTION
  Added calls to get_param to set 12 input variable names in files via runtime parameters, including TIDEAMP_VARNAME, TEMP_COORD_VAR, SALT_COORD_VAR, THICKNESS_IC_VAR, INTERFACE_IC_RESCALE, TEMP_IC_VAR, SALT_IC_VAR, BASIN_VAR, TIDAL_DISSIPATION_VAR, ROUGHNESS_VARNAME, TIDEAMP_VARNAME and KH_BG_2D_VARNAME. Also added two new runtime parameters, THICKNESS_IC_RESCALE and INTERFACE_IC_RESCALE, to allow input thickness and interface height fields to be rescaled.  A number of spelling errors in comments or output messages in the files that were being modified as a part of this commit, including changes in the documentation that appears in MOM_parameter_doc files.

  A second commit added calls to get_param to set 4 more input variable names in files via runtime parameters, including U_IC_VAR, V_IC_VAR, OPEN_DY_CU_VAR and OPEN_DX_CV_VAR.  Also added or amended comments describing internal variables to describe their units more consistently in MOM_shared_initialization.

  All answers are bitwise identical, but there are new entries and minor changes in many MOM_parameter_doc files.