### PR TITLE
*Fix bug with TIDAL_ENERGY_TYPE = "ER03"

### DIFF
--- a/src/parameterizations/vertical/MOM_tidal_mixing.F90
+++ b/src/parameterizations/vertical/MOM_tidal_mixing.F90
@@ -1647,8 +1647,8 @@ subroutine read_tidal_constituents(G, US, tidal_energy_file, CS)
   call MOM_read_data(tidal_energy_file, 'K1', tc_k1, G%domain)
   call MOM_read_data(tidal_energy_file, 'O1', tc_o1, G%domain)
   ! Note the hard-coded assumption that z_t and z_w in the file are in centimeters.
-  call MOM_read_data(tidal_energy_file, 'z_t', z_t, scale=100.0*US%m_to_Z)
-  call MOM_read_data(tidal_energy_file, 'z_w', z_w, scale=100.0*US%m_to_Z)
+  call MOM_read_data(tidal_energy_file, 'z_t', z_t, scale=0.01*US%m_to_Z)
+  call MOM_read_data(tidal_energy_file, 'z_w', z_w, scale=0.01*US%m_to_Z)
 
   do j=js,je ; do i=is,ie
     if (abs(G%geoLatT(i,j)) < 30.0) then


### PR DESCRIPTION
  Corrected a bug in converting depths read from an input file from units of cm to m when the ER03 version of tidal mixing is used.  This commit will change answers when INT_TIDE_DISSIPATION = True, USE_CVMix_TIDAL = True, and TIDAL_ENERGY_TYPE = "ER03".  There are no such configurations in the MOM6-examples pipeline tests, and it is not clear whether or where such a configuration has ever been used.

  This bug was introduced into dev/gfdl on Nov. 19, 2018 as a part of PR #883 in
commit https://github.com/NOAA-GFDL/MOM6/commit/967e470, which was supposed to be a refactoring of this portion of the code without changing answers, but introduced this bug.  This commit should restore solutions with impacted configurations to what they would have been before that earlier commit.