### PR TITLE
+Add remapping of auxiliary variables in restarts

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -554,7 +554,7 @@ subroutine ALE_offline_inputs(CS, G, GV, h, tv, Reg, uhtr, vhtr, Kd, debug, OBC)
       if (check_column_integrals(nk, h_src, nk, h_dest)) then
         call MOM_error(FATAL, "ALE_offline_inputs: Kd interpolation columns do not match")
       endif
-      call interpolate_column(nk, h(i,j,:), Kd(i,j,:), nk, h_new(i,j,:), Kd(i,j,:))
+      call interpolate_column(nk, h(i,j,:), Kd(i,j,:), nk, h_new(i,j,:), Kd(i,j,:), .true.)
     endif
   enddo ; enddo
 

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -129,6 +129,8 @@ public ALE_regrid_accelerated
 public ALE_remap_scalar
 public ALE_remap_tracers
 public ALE_remap_velocities
+public ALE_remap_interface_vals
+public ALE_remap_vertex_vals
 public ALE_PLM_edge_values
 public TS_PLM_edge_values
 public TS_PPM_edge_values
@@ -289,10 +291,10 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
   call set_regrid_params(CS%regridCS, depth_of_time_filter_shallow=filter_shallow_depth, &
                          depth_of_time_filter_deep=filter_deep_depth)
   call get_param(param_file, mdl, "REGRID_USE_OLD_DIRECTION", local_logical, &
-                 "If true, the regridding ntegrates upwards from the bottom for "//&
+                 "If true, the regridding integrates upwards from the bottom for "//&
                  "interface positions, much as the main model does. If false "//&
-                 "regridding integrates downward, consistant with the remapping "//&
-                 "code.", default=.true., do_not_log=.true.)
+                 "regridding integrates downward, consistent with the remapping code.", &
+                 default=.true., do_not_log=.true.)
   call set_regrid_params(CS%regridCS, integrate_downward_for_e=.not.local_logical)
 
   call get_param(param_file, mdl, "REMAP_VEL_MASK_BBL_THICK", CS%BBL_h_vel_mask, &
@@ -549,7 +551,7 @@ subroutine ALE_offline_inputs(CS, G, GV, h, tv, Reg, uhtr, vhtr, Kd, debug, OBC)
     endif
   enddo ; enddo
 
-  do j = jsc,jec ; do i=isc,iec
+  do j=jsc,jec ; do i=isc,iec
     if (G%mask2dT(i,j)>0.) then
       if (check_column_integrals(nk, h_src, nk, h_dest)) then
         call MOM_error(FATAL, "ALE_offline_inputs: Kd interpolation columns do not match")
@@ -974,6 +976,89 @@ subroutine ALE_remap_velocities(CS, G, GV, h_old, h_new, u, v, OBC, dzInterface,
 
 end subroutine ALE_remap_velocities
 
+!> Interpolate to find an updated array of values at interfaces after remapping.
+subroutine ALE_remap_interface_vals(CS, G, GV, h_old, h_new, int_val)
+  type(ALE_CS),                              intent(in)    :: CS       !< ALE control structure
+  type(ocean_grid_type),                     intent(in)    :: G        !< Ocean grid structure
+  type(verticalGrid_type),                   intent(in)    :: GV       !< Ocean vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_old    !< Thickness of source grid
+                                                                       !! [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_new    !< Thickness of destination grid
+                                                                       !! [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), &
+                                             intent(inout) :: int_val  !< The interface values to interpolate [A]
+
+  real :: val_src(GV%ke+1)  ! A column of interface values on the source grid [A]
+  real :: val_tgt(GV%ke+1)  ! A column of interface values on the target grid [A]
+  real :: h_src(GV%ke)      ! A column of source grid layer thicknesses [H ~> m or kg m-2]
+  real :: h_tgt(GV%ke)      ! A column of target grid layer thicknesses [H ~> m or kg m-2]
+  integer :: i, j, k, nz
+
+  nz = GV%ke
+
+  do j=G%jsc,G%jec ; do i=G%isc,G%iec ; if (G%mask2dT(i,j)>0.) then
+    do k=1,nz
+      h_src(k) = h_old(i,j,k)
+      h_tgt(k) = h_new(i,j,k)
+    enddo
+
+    do K=1,nz+1
+      val_src(K) = int_val(i,j,K)
+    enddo
+
+    call interpolate_column(nz, h_src, val_src, nz, h_tgt, val_tgt, .false.)
+
+    do K=1,nz+1
+      int_val(i,j,K) = val_tgt(K)
+    enddo
+  endif ; enddo ; enddo
+
+end subroutine ALE_remap_interface_vals
+
+!> Interpolate to find an updated array of values at vertices of tracer cells after remapping.
+subroutine ALE_remap_vertex_vals(CS, G, GV, h_old, h_new, vert_val)
+  type(ALE_CS),                              intent(in)    :: CS       !< ALE control structure
+  type(ocean_grid_type),                     intent(in)    :: G        !< Ocean grid structure
+  type(verticalGrid_type),                   intent(in)    :: GV       !< Ocean vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_old    !< Thickness of source grid
+                                                                       !! [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_new    !< Thickness of destination grid
+                                                                       !! [H ~> m or kg m-2]
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)+1), &
+                                             intent(inout) :: vert_val  !< The interface values to interpolate [A]
+
+  real :: val_src(GV%ke+1)  ! A column of interface values on the source grid [A]
+  real :: val_tgt(GV%ke+1)  ! A column of interface values on the target grid [A]
+  real :: h_src(GV%ke)      ! A column of source grid layer thicknesses [H ~> m or kg m-2]
+  real :: h_tgt(GV%ke)      ! A column of target grid layer thicknesses [H ~> m or kg m-2]
+  real :: I_mask_sum        ! The inverse of the tracer point masks surrounding a corner [nondim]
+  integer :: i, j, k, nz
+
+  nz = GV%ke
+
+  do J=G%JscB,G%JecB ; do I=G%IscB,G%IecB
+    if ((G%mask2dT(i,j) + G%mask2dT(i+1,j+1)) + (G%mask2dT(i+1,j) + G%mask2dT(i,j+1)) > 0.0 ) then
+      I_mask_sum = 1.0 / ((G%mask2dT(i,j) + G%mask2dT(i+1,j+1)) + (G%mask2dT(i+1,j) + G%mask2dT(i,j+1)))
+
+    do k=1,nz
+      h_src(k) = ((G%mask2dT(i,j) * h_old(i,j,k) + G%mask2dT(i+1,j+1) * h_old(i+1,j+1,k)) + &
+                  (G%mask2dT(i+1,j) * h_old(i+1,j,k) + G%mask2dT(i,j+1) * h_old(i,j+1,k)) ) * I_mask_sum
+      h_tgt(k) = ((G%mask2dT(i,j) * h_new(i,j,k) + G%mask2dT(i+1,j+1) * h_new(i+1,j+1,k)) + &
+                  (G%mask2dT(i+1,j) * h_new(i+1,j,k) + G%mask2dT(i,j+1) * h_new(i,j+1,k)) ) * I_mask_sum
+    enddo
+
+    do K=1,nz+1
+      val_src(K) = vert_val(I,J,K)
+    enddo
+
+    call interpolate_column(nz, h_src, val_src, nz, h_tgt, val_tgt, .false.)
+
+    do K=1,nz+1
+      vert_val(I,J,K) = val_tgt(K)
+    enddo
+  endif ; enddo ; enddo
+
+end subroutine ALE_remap_vertex_vals
 
 !> Mask out thicknesses to 0 when their running sum exceeds a specified value.
 subroutine apply_partial_cell_mask(h1, h_mask)

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -608,7 +608,7 @@ subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, sta
         h_src(:) = 0.5 * (h(i_lo,j,:) + h(i_hi,j,:))
         h_dest(:) = 0.5 * (remap_cs%h(i_lo,j,:) + remap_cs%h(i_hi,j,:))
         call interpolate_column(nz_src, h_src, field(I1,j,:), &
-                                nz_dest, h_dest, interpolated_field(I1,j,:))
+                                nz_dest, h_dest, interpolated_field(I1,j,:), .true.)
       enddo
     enddo
   elseif (staggered_in_y .and. .not. staggered_in_x) then
@@ -623,7 +623,7 @@ subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, sta
         h_src(:) = 0.5 * (h(i,j_lo,:) + h(i,j_hi,:))
         h_dest(:) = 0.5 * (remap_cs%h(i,j_lo,:) + remap_cs%h(i,j_hi,:))
         call interpolate_column(nz_src, h_src, field(i,J1,:), &
-                                nz_dest, h_dest, interpolated_field(i,J1,:))
+                                nz_dest, h_dest, interpolated_field(i,J1,:), .true.)
       enddo
     enddo
   elseif ((.not. staggered_in_x) .and. (.not. staggered_in_y)) then
@@ -636,7 +636,7 @@ subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, sta
         h_src(:) = h(i,j,:)
         h_dest(:) = remap_cs%h(i,j,:)
         call interpolate_column(nz_src, h_src, field(i,j,:), &
-                                nz_dest, h_dest, interpolated_field(i,j,:))
+                                nz_dest, h_dest, interpolated_field(i,j,:), .true.)
       enddo
     enddo
   else

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -4,37 +4,39 @@ module MOM_set_visc
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_debugging, only : uvchksum, hchksum
-use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
+use MOM_ALE,           only : ALE_CS, ALE_remap_velocities, ALE_remap_interface_vals, ALE_remap_vertex_vals
+use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
+use MOM_debugging,     only : uvchksum, hchksum
 use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl, time_type
-use MOM_domains, only : pass_var, CORNER
+use MOM_domains,       only : pass_var, CORNER
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
-use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
-use MOM_forcing_type, only : forcing, mech_forcing
-use MOM_grid, only : ocean_grid_type
-use MOM_hor_index, only : hor_index_type
-use MOM_io, only : slasher, MOM_read_data
-use MOM_kappa_shear, only : kappa_shear_is_used, kappa_shear_at_vertex
-use MOM_cvmix_shear, only : cvmix_shear_is_used
-use MOM_cvmix_conv,  only : cvmix_conv_is_used
-use MOM_CVMix_ddiff, only : CVMix_ddiff_is_used
-use MOM_restart, only : register_restart_field, query_initialized, MOM_restart_CS
-use MOM_restart, only : register_restart_field_as_obsolete
-use MOM_safe_alloc, only : safe_alloc_ptr, safe_alloc_alloc
-use MOM_unit_scaling, only : unit_scale_type
-use MOM_variables, only : thermo_var_ptrs, vertvisc_type, porous_barrier_type
-use MOM_verticalGrid, only : verticalGrid_type
-use MOM_EOS, only : calculate_density, calculate_density_derivs
+use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
+use MOM_forcing_type,  only : forcing, mech_forcing
+use MOM_grid,          only : ocean_grid_type
+use MOM_hor_index,     only : hor_index_type
+use MOM_io,            only : slasher, MOM_read_data
+use MOM_kappa_shear,   only : kappa_shear_is_used, kappa_shear_at_vertex
+use MOM_cvmix_shear,   only : cvmix_shear_is_used
+use MOM_cvmix_conv,    only : cvmix_conv_is_used
+use MOM_CVMix_ddiff,   only : CVMix_ddiff_is_used
+use MOM_restart,       only : register_restart_field, query_initialized, MOM_restart_CS
+use MOM_restart,       only : register_restart_field_as_obsolete
+use MOM_safe_alloc,    only : safe_alloc_ptr, safe_alloc_alloc
+use MOM_unit_scaling,  only : unit_scale_type
+use MOM_variables,     only : thermo_var_ptrs, vertvisc_type, porous_barrier_type
+use MOM_verticalGrid,  only : verticalGrid_type
+use MOM_EOS,           only : calculate_density, calculate_density_derivs
 use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_DIRECTION_E
 use MOM_open_boundary, only : OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_open_boundary, only : OBC_segment_type
+
 implicit none ; private
 
 #include <MOM_memory.h>
 
 public set_viscous_BBL, set_viscous_ML, set_visc_init, set_visc_end
-public set_visc_register_restarts
+public set_visc_register_restarts, remap_vertvisc_aux_vars
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
@@ -1942,6 +1944,34 @@ subroutine set_visc_register_restarts(HI, GV, US, param_file, visc, restart_CS)
 
 end subroutine set_visc_register_restarts
 
+!> This subroutine does remapping for the auxiliary restart variables in a vertvisc_type
+!! that are used across timesteps
+subroutine remap_vertvisc_aux_vars(G, GV, visc, h_old, h_new, ALE_CSp, OBC)
+  type(ocean_grid_type),            intent(inout) :: G        !< ocean grid structure
+  type(verticalGrid_type),          intent(in)    :: GV       !< ocean vertical grid structure
+  type(vertvisc_type),              intent(inout) :: visc     !< A structure containing vertical
+                                                              !! viscosities and related fields.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                    intent(in)    :: h_old    !< Thickness of source grid  [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                    intent(in)    :: h_new    !< Thickness of destination grid [H ~> m or kg m-2]
+  type(ALE_CS),                     pointer       :: ALE_CSp  !< ALE control structure to use when remapping
+  type(ocean_OBC_type),             pointer       :: OBC      !< Open boundary structure
+
+  if (associated(visc%Kd_shear)) then
+    call ALE_remap_interface_vals(ALE_CSp, G, GV, h_old, h_new, visc%Kd_shear)
+  endif
+
+  if (associated(visc%Kv_shear)) then
+    call ALE_remap_interface_vals(ALE_CSp, G, GV, h_old, h_new, visc%Kv_shear)
+  endif
+
+  if (associated(visc%Kv_shear_Bu)) then
+    call ALE_remap_vertex_vals(ALE_CSp, G, GV, h_old, h_new, visc%Kv_shear_Bu)
+  endif
+
+end subroutine remap_vertvisc_aux_vars
+
 !> Initializes the MOM_set_visc control structure
 subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS, OBC)
   type(time_type), target, intent(in)    :: Time !< The current model time.
@@ -1953,7 +1983,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
   type(diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic
                                                  !! output.
   type(vertvisc_type),     intent(inout) :: visc !< A structure containing vertical viscosities and
-                                                 !! related fields.  Allocated here.
+                                                 !! related fields.
   type(set_visc_CS),       intent(inout) :: CS   !< Vertical viscosity control structure
   type(MOM_restart_CS),    intent(inout) :: restart_CS !< MOM restart control structure
   type(ocean_OBC_type),    pointer       :: OBC  !< A pointer to an open boundary condition structure


### PR DESCRIPTION
  This PR consists of a series of commits that add the capability, selected at
runtime via the new parameter REMAP_AUXILIARY_VARS, to remap all of the 3-d
variables that are registered for restarts but were not previously remapped.
This PR addresses the issue at github.com/NOAA-GFDL/MOM6/issues/203 in cases
using ALE remapping, but it may also be worthwhile to examine this issue in
non-ALE cases as well.  There are several new interfaces and a new runtime
parameter, so the contents of the MOM_parameter_doc files change, but by
default all answers are bitwise identical.

  The commits in this PR include:

- NOAA-GFDL/MOM6@987a0ef3e +Add REMAP_AUXILIARY_VARS to remap accelerations
- NOAA-GFDL/MOM6@ba145bff7 +Add ALE_remap_interface_vals and ALE_remap_vertex_vals
- NOAA-GFDL/MOM6@949392b2d +Add mask_edges argument to interpolate_column

(This PR was updated via a force-push at 6 AM on 11/18/2022 to correct bugs found during its review.)