### PR TITLE
(*)Rescale DENSE_WATER_EAST_SPONGE_SALT

### DIFF
--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -40,10 +40,13 @@ subroutine dense_water_initialize_topography(D, G, param_file, max_depth)
   real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
 
   ! Local variables
-  real, dimension(5) :: domain_params ! nondimensional widths of all domain sections
-  real :: sill_frac, shelf_frac
+  real, dimension(5) :: domain_params ! nondimensional widths of all domain sections [nondim]
+  real :: sill_frac     ! Depth of the sill separating downslope from upslope, as a fraction of
+                        ! the basin depth [nondim]
+  real :: shelf_frac    ! Depth of the shelf region accumulating dense water for overflow,
+                        ! as a fraction the basin depth [nondim]
+  real :: x             ! Horizontal position normalized by the domain width [nondim]
   integer :: i, j
-  real :: x
 
   call get_param(param_file, mdl, "DENSE_WATER_DOMAIN_PARAMS", domain_params, &
        "Fractional widths of all the domain sections for the dense water experiment.\n"//&
@@ -106,8 +109,10 @@ subroutine dense_water_initialize_TS(G, GV, US, param_file, T, S, h, just_read)
   logical,                                   intent(in)  :: just_read !< If true, this call will
                                                       !! only read parameters without changing T & S.
   ! Local variables
-  real :: mld, S_ref, S_range, T_ref
-  real :: zi, zmid
+  real :: mld             ! The initial mixed layer depth as a fraction of the maximum depth [nondim]
+  real :: S_ref, S_range  ! The reference salinity and its range in the initial conditions [S ~> ppt]
+  real :: T_ref           ! The reference temperature [C ~> degC]
+  real :: zi, zmid        ! Depths from the surface nondimensionalized by the maximum depth [nondim]
   integer :: i, j, k, nz
 
   nz = GV%ke
@@ -160,43 +165,52 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
   logical,                 intent(in) :: use_ALE !< ALE flag
   type(sponge_CS),         pointer    :: CSp !< Layered sponge control structure pointer
   type(ALE_sponge_CS),     pointer    :: ACSp !< ALE sponge control structure pointer
+
   ! Local variables
   real :: west_sponge_time_scale, east_sponge_time_scale ! Sponge timescales [T ~> s]
-  real :: west_sponge_width, east_sponge_width
+  real :: west_sponge_width ! The fraction of the domain in which the western (outflow) sponge is active [nondim]
+  real :: east_sponge_width ! The fraction of the domain in which the eastern (outflow) sponge is active [nondim]
 
   real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h  ! sponge thicknesses [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: T  ! sponge temperature [C ~> degC]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: S  ! sponge salinity [S ~> ppt]
   real, dimension(SZK_(GV)+1) :: e0, eta1D ! interface positions for ALE sponge [Z ~> m]
-
+  real :: x         ! Horizontal position normalized by the domain width [nondim]
+  real :: zi, zmid  ! Depths from the surface nondimensionalized by the maximum depth [nondim]
+  real :: dist      ! Distance from the edge of a sponge normalized by the width of that sponge [nondim]
+  real :: mld       ! The initial mixed layer depth as a fraction of the maximum depth [nondim]
+  real :: S_ref, S_range  ! The reference salinity and its range in the initial conditions [S ~> ppt]
+  real :: S_dense   ! The salinity of the dense water being formed on the shelf [S ~> ppt]
+  real :: T_ref     ! The reference temperature [C ~> degC]
+  real :: sill_frac ! Fractional depths of the sill, relative to the maximum depth [nondim]
   integer :: i, j, k, nz
-  real :: x, zi, zmid, dist
-  real :: mld, S_ref, S_range, S_dense, T_ref, sill_height
 
   nz = GV%ke
 
   call get_param(param_file, mdl, "DENSE_WATER_WEST_SPONGE_TIME_SCALE", west_sponge_time_scale, &
-       "The time scale on the west (outflow) of the domain for restoring. If zero, the sponge is disabled.", &
-       units="s", default=0., scale=US%s_to_T)
+                 "The time scale on the west (outflow) of the domain for restoring. "//&
+                 "If zero, the sponge is disabled.", units="s", default=0., scale=US%s_to_T)
   call get_param(param_file, mdl, "DENSE_WATER_WEST_SPONGE_WIDTH", west_sponge_width, &
-       "The fraction of the domain in which the western (outflow) sponge is active.", &
-       units="nondim", default=0.1)
+                 "The fraction of the domain in which the western (outflow) sponge is active.", &
+                 units="nondim", default=0.1)
   call get_param(param_file, mdl, "DENSE_WATER_EAST_SPONGE_TIME_SCALE", east_sponge_time_scale, &
-       "The time scale on the east (outflow) of the domain for restoring. If zero, the sponge is disabled.", &
-       units="s", default=0., scale=US%s_to_T)
+                 "The time scale on the east (outflow) of the domain for restoring. "//&
+                 "If zero, the sponge is disabled.", units="s", default=0., scale=US%s_to_T)
   call get_param(param_file, mdl, "DENSE_WATER_EAST_SPONGE_WIDTH", east_sponge_width, &
-       "The fraction of the domain in which the eastern (outflow) sponge is active.", &
-       units="nondim", default=0.1)
-
+                 "The fraction of the domain in which the eastern (outflow) sponge is active.", &
+                 units="nondim", default=0.1)
   call get_param(param_file, mdl, "DENSE_WATER_EAST_SPONGE_SALT", S_dense, &
-       "Salt anomaly of the dense water being formed in the overflow region.", &
-       units="1e-3", default=4.0)
+                 "Salt anomaly of the dense water being formed in the overflow region.", &
+                 units="1e-3", default=4.0, scale=US%ppt_to_S)
 
-  call get_param(param_file, mdl, "DENSE_WATER_MLD", mld, default=default_mld, do_not_log=.true.)
-  call get_param(param_file, mdl, "DENSE_WATER_SILL_HEIGHT", sill_height, default=default_sill, do_not_log=.true.)
+  call get_param(param_file, mdl, "DENSE_WATER_MLD", mld, &
+                 units="nondim", default=default_mld, do_not_log=.true.)
+  call get_param(param_file, mdl, "DENSE_WATER_SILL_DEPTH", sill_frac, &
+                 units="nondim", default=default_sill, do_not_log=.true.)
 
-  call get_param(param_file, mdl, "S_REF", S_ref, default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
+  call get_param(param_file, mdl, "S_REF", S_ref, &
+                 units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "S_RANGE", S_range, &
                  units='1e-3', default=2.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "T_REF", T_ref, &
@@ -266,12 +280,12 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
           zmid = zi + 0.5 * h(i,j,k) / (GV%Z_to_H * G%max_depth)
 
           if (x > (1. - east_sponge_width)) then
-            !if (zmid >= 0.9 * sill_height) &
-                 S(i,j,k) = S_ref + S_dense
+            !if (zmid >= 0.9 * sill_frac) &
+              S(i,j,k) = S_ref + S_dense
           else
             ! linear between bottom of mixed layer and bottom
             if (zmid >= mld) &
-                 S(i,j,k) = S_ref + S_range * (zmid - mld) / (1.0 - mld)
+              S(i,j,k) = S_ref + S_range * (zmid - mld) / (1.0 - mld)
           endif
 
           zi = zi + h(i,j,k) / (GV%Z_to_H * G%max_depth)
@@ -300,7 +314,7 @@ end module dense_water_initialization
 !! The nondimensional widths of the 5 regions are controlled by the
 !! <code>DENSE_WATER_DOMAIN_PARAMS</code>, and the heights of the sill and shelf
 !! as a fraction of the total domain depth are controlled by
-!! <code>DENSE_WATER_SILL_HEIGHT</code> and <code>DENSE_WATER_SHELF_HEIGHT</code>.
+!! <code>DENSE_WATER_SILL_DEPTH</code> and <code>DENSE_WATER_SHELF_DEPTH</code>.
 !!
 !! The density in the domain is governed by a linear equation of state, and
 !! is set up with a mixed layer of non-dimensional depth <code>DENSE_WATER_MLD</code>


### PR DESCRIPTION
  Added a missing scale factor in the DENSE_WATER_EAST_SPONGE_SALT get_param call in dense_water_initialize_sponges, and added comments describing the local variables (and their units) throughout the dense_water_initialization module. Comments were added noting that the variable set by DENSE_WATER_SILL_HEIGHT is unused, and that perhaps this should have been DENSE_WATER_SILL_DEPTH.  Units arguments were also added to two of the unlogged get_param calls in this module.  Without this change, this test case would not reproduce with dimensional rescaling due to a scale factor that was omitted when salinity was being rescaled on May 3, 2022, which became a part of PR #122 to dev/gfdl, but answers should not change when dimensional rescaling of salinities is not used. All answers and output in the MOM6-examples test suite are bitwise identical.