### PR TITLE
Keep track of whether runoff has been added to stf

### DIFF
--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -28,6 +28,7 @@ implicit none ; private
     character(len=fm_string_len) :: obc_src_file_name !< Boundary condition tracer source filename
     character(len=fm_string_len) :: obc_src_field_name !< Boundary condition tracer source fieldname
     integer :: src_var_record !< Unknown
+    logical :: runoff_added_to_stf = .false. !< Has flux in from runoff been added to stf?
     logical :: requires_src_info = .false. !< Unknown
     real    :: src_var_unit_conversion = 1.0 !< This factor depends on the tracer. Ask Jasmin
     real    :: src_var_valid_min = 0.0 !< Unknown

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -512,7 +512,7 @@ contains
     !
     g_tracer=>CS%g_tracer_list
     do
-      if (_ALLOCATED(g_tracer%trunoff)) then
+      if (_ALLOCATED(g_tracer%trunoff) .and. (.NOT. g_tracer%runoff_added_to_stf)) then
         call g_tracer_get_alias(g_tracer,g_tracer_name)
         call g_tracer_get_pointer(g_tracer,g_tracer_name,'stf',   stf_array)
         call g_tracer_get_pointer(g_tracer,g_tracer_name,'trunoff',trunoff_array)
@@ -521,6 +521,7 @@ contains
         runoff_tracer_flux_array(:,:) = trunoff_array(:,:) * &
                  US%RZ_T_to_kg_m2s*fluxes%lrunoff(:,:)
         stf_array = stf_array + runoff_tracer_flux_array
+        g_tracer%runoff_added_to_stf = .true.
       endif
 
       !traverse the linked list till hit NULL


### PR DESCRIPTION
This PR is my attempt to fix the issue #217, which affected generic tracers that had fluxes into the ocean from runoff. During a thermodynamics time step, MOM6 adds the river tracer flux to the surface tracer flux `stf`. If more than one thermodynamics time step is done per coupler time step, the river input gets added to `stf` multiple times. This PR fixes this bug by checking each tracer for a new logical flag `runoff_added_to_stf`. If this flag is false, the runoff is added to `stf` and then the flag is set to true. 

For this PR to work in configurations using generic tracers, it will need to be paired with a PR I have to ocean_BGC (https://github.com/NOAA-GFDL/ocean_BGC/pull/20) that adds `runoff_added_to_stf` to `g_tracer_type` and resets the flag to false after updates to `stf` using `g_tracer_set_2D` or `g_tracer_set_real`. For configurations not using generic tracers, this PR to MOM6 also adds the `runoff_added_to_stf` flag to `g_tracer_type` in config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90, so things should compile as before and no answers should change.

I have submitted this as a draft PR to see if the solution makes sense, and so the ocean_BGC PR can be merged first if so. 