### PR TITLE
+(*)Fix rescaling issue with MOM_stoch_eos

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -295,7 +295,10 @@ type, public :: MOM_control_struct ; private
                                      !! calculated, and if it is 0, dtbt is calculated every step.
   type(time_type) :: dtbt_reset_interval !< A time_time representation of dtbt_reset_period.
   type(time_type) :: dtbt_reset_time     !< The next time DTBT should be calculated.
-  real            :: dt_obc_seg_period   !< The time interval between OBC segment updates for OBGC tracers
+  real            :: dt_obc_seg_period   !< The time interval between OBC segment updates for OBGC
+                                         !! tracers [T ~> s], or a negative value if the segment
+                                         !! data are time-invarant, or zero to update the OBGC
+                                         !! segment data with every call to update_OBC_segment_data.
   type(time_type) :: dt_obc_seg_interval !< A time_time representation of dt_obc_seg_period.
   type(time_type) :: dt_obc_seg_time     !< The next time OBC segment update is applied to OBGC tracers.
 
@@ -2167,12 +2170,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  units="s", default=default_val, do_not_read=(dtbt > 0.0))
   endif
 
-  CS%dt_obc_seg_period = -1.0
   call get_param(param_file, "MOM", "DT_OBC_SEG_UPDATE_OBGC", CS%dt_obc_seg_period, &
                "The time between OBC segment data updates for OBGC tracers. "//&
                "This must be an integer multiple of DT and DT_THERM. "//&
                "The default is set to DT.", &
-               units="s", default=US%T_to_s*CS%dt, do_not_log=.not.associated(CS%OBC))
+               units="s", default=US%T_to_s*CS%dt, scale=US%s_to_T, do_not_log=.not.associated(CS%OBC))
 
   ! This is here in case these values are used inappropriately.
   use_frazil = .false. ; bound_salinity = .false.
@@ -2947,7 +2949,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     call interface_filter_init(Time, G, GV, US, param_file, diag, CS%CDp, CS%interface_filter_CSp)
 
   new_sim = is_new_run(restart_CSp)
-  call MOM_stoch_eos_init(G,Time,param_file,CS%stoch_eos_CS,restart_CSp,diag)
+  call MOM_stoch_eos_init(Time, G, US, param_file, diag, CS%stoch_eos_CS, restart_CSp)
 
   if (CS%use_porbar) &
     call porous_barriers_init(Time, US, param_file, diag, CS%por_bar_CS)

--- a/src/core/MOM_stoch_eos.F90
+++ b/src/core/MOM_stoch_eos.F90
@@ -2,19 +2,18 @@
 module MOM_stoch_eos
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-use MOM_grid,            only : ocean_grid_type
-use MOM_hor_index,       only : hor_index_type
-use MOM_file_parser,     only : get_param, param_file_type
-use MOM_random,          only : PRNG,random_2d_constructor,random_2d_norm
-use MOM_time_manager,    only : time_type
-use MOM_io,              only : vardesc, var_desc
-use MOM_restart,         only : MOM_restart_CS,is_new_run
-use MOM_diag_mediator,   only : register_diag_field,post_data,diag_ctrl,safe_alloc_ptr
-use MOM_variables,       only : thermo_var_ptrs
-use MOM_verticalGrid,    only : verticalGrid_type
-use MOM_restart,         only : register_restart_field
-use MOM_isopycnal_slopes,only : vert_fill_TS
-!use random_numbers_mod, only : getRandomNumbers,initializeRandomNumberStream,randomNumberStream
+use MOM_diag_mediator,    only : register_diag_field, post_data, diag_ctrl
+use MOM_file_parser,      only : get_param, param_file_type
+use MOM_grid,             only : ocean_grid_type
+use MOM_hor_index,        only : hor_index_type
+use MOM_isopycnal_slopes, only : vert_fill_TS
+use MOM_random,           only : PRNG, random_2d_constructor, random_2d_norm
+use MOM_restart,          only : MOM_restart_CS, is_new_run, register_restart_field
+use MOM_time_manager,     only : time_type
+use MOM_unit_scaling,     only : unit_scale_type
+use MOM_variables,        only : thermo_var_ptrs
+use MOM_verticalGrid,     only : verticalGrid_type
+!use random_numbers_mod,  only : getRandomNumbers, initializeRandomNumberStream, randomNumberStream
 
 implicit none; private
 #include <MOM_memory.h>
@@ -26,22 +25,18 @@ public MOM_calc_varT
 !> Describes parameters of the stochastic component of the EOS
 !! correction, described in Stanley et al. JAMES 2020.
 type, public :: MOM_stoch_eos_CS
-  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: l2_inv
-                                    !< One over sum of the T cell side side lengths squared
-  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: rgauss
-                                    !< nondimensional random Gaussian
-  real        :: tfac=0.27          !< Nondimensional decorrelation time factor, ~1/3.7
-  real        :: amplitude=0.624499 !< Nondimensional std dev of Gaussian
+  real, allocatable :: l2_inv(:,:)  !< One over sum of the T cell side side lengths squared [L-2 ~> m-2]
+  real, allocatable :: rgauss(:,:)  !< nondimensional random Gaussian [nondim]
+  real        :: tfac=0.27          !< Nondimensional decorrelation time factor, ~1/3.7 [nondim]
+  real        :: amplitude=0.624499 !< Nondimensional std dev of Gaussian [nondim]
   integer     :: seed               !< PRNG seed
   type(PRNG)  ::  rn_CS             !< PRNG control structure
-  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: pattern
-                          !< Random pattern for stochastic EOS [nondim]
-  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: phi
-                          !< temporal correlation stochastic EOS [nondim]
+  real, allocatable :: pattern(:,:) !< Random pattern for stochastic EOS [nondim]
+  real, allocatable :: phi(:,:)     !< temporal correlation stochastic EOS [nondim]
   logical :: use_stoch_eos!< If true, use the stochastic equation of state (Stanley et al. 2020)
   real :: stanley_coeff   !< Coefficient correlating the temperature gradient
-                          !! and SGS T variance; if <0, turn off scheme in all codes
-  real :: stanley_a       !< a in exp(aX) in stochastic coefficient
+                          !! and SGS T variance [nondim]; if <0, turn off scheme in all codes
+  real :: stanley_a       !< a in exp(aX) in stochastic coefficient [nondim]
   real :: kappa_smooth    !< A diffusivity for smoothing T/S in vanished layers [Z2 T-1 ~> m2 s-1]
 
   !>@{ Diagnostic IDs
@@ -53,20 +48,20 @@ end type MOM_stoch_eos_CS
 contains
 
 !> Initializes MOM_stoch_eos module.
-subroutine MOM_stoch_eos_init(G, Time, param_file, CS, restart_CS, diag)
-  type(param_file_type),  intent(in)    :: param_file   !< structure indicating parameter file to parse
-  type(ocean_grid_type),  intent(in)    :: G            !< The ocean's grid structure.
-  type(time_type),        intent(in)    :: Time         !< Time for stochastic process
-  type(MOM_stoch_eos_CS), intent(inout) :: CS           !< Stochastic control structure
-  type(MOM_restart_CS),   pointer       :: restart_CS   !< A pointer to the restart control structure.
-  type(diag_ctrl),        target, intent(inout) :: diag !< to control diagnostics
+subroutine MOM_stoch_eos_init(Time, G, US, param_file, diag, CS, restart_CS)
+  type(time_type),         intent(in)    :: Time       !< Time for stochastic process
+  type(ocean_grid_type),   intent(in)    :: G          !< The ocean's grid structure.
+  type(unit_scale_type),   intent(in)    :: US         !< A dimensional unit scaling type
+  type(param_file_type),   intent(in)    :: param_file !< structure indicating parameter file to parse
+  type(diag_ctrl), target, intent(inout) :: diag       !< to control diagnostics
+  type(MOM_stoch_eos_CS),  intent(inout) :: CS         !< Stochastic control structure
+  type(MOM_restart_CS),    pointer       :: restart_CS !< A pointer to the restart control structure.
 
   ! local variables
   integer :: i,j
-  type(vardesc) :: vd
-  CS%seed=0
-  ! contants
-  !pi=2*acos(0.0)
+
+  CS%seed = 0
+
   call get_param(param_file, "MOM_stoch_eos", "STOCH_EOS", CS%use_stoch_eos, &
                  "If true, stochastic perturbations are applied "//&
                  "to the EOS in the PGF.", default=.false.)
@@ -79,17 +74,17 @@ subroutine MOM_stoch_eos_init(G, Time, param_file, CS, restart_CS, diag)
   call get_param(param_file, "MOM_stoch_eos", "KD_SMOOTH", CS%kappa_smooth, &
                  "A diapycnal diffusivity that is used to interpolate "//&
                  "more sensible values of T & S into thin layers.", &
-                 units="m2 s-1", default=1.0e-6)
+                 units="m2 s-1", default=1.0e-6, scale=US%m_to_Z**2*US%T_to_s)
 
-  !don't run anything if STANLEY_COEFF < 0
+  ! Don't run anything if STANLEY_COEFF < 0
   if (CS%stanley_coeff >= 0.0) then
 
-    ALLOC_(CS%pattern(G%isd:G%ied,G%jsd:G%jed)) ; CS%pattern(:,:) = 0.0
-    vd = var_desc("stoch_eos_pattern","nondim","Random pattern for stoch EOS",'h','1')
-    call register_restart_field(CS%pattern, vd, .false., restart_CS)
-    ALLOC_(CS%phi(G%isd:G%ied,G%jsd:G%jed)) ; CS%phi(:,:) = 0.0
-    ALLOC_(CS%l2_inv(G%isd:G%ied,G%jsd:G%jed))
-    ALLOC_(CS%rgauss(G%isd:G%ied,G%jsd:G%jed))
+    allocate(CS%pattern(G%isd:G%ied,G%jsd:G%jed), source=0.0)
+    call register_restart_field(CS%pattern, "stoch_eos_pattern", .false., restart_CS, &
+                                "Random pattern for stoch EOS", "nondim")
+    allocate(CS%phi(G%isd:G%ied,G%jsd:G%jed), source=0.0)
+    allocate(CS%l2_inv(G%isd:G%ied,G%jsd:G%jed), source=0.0)
+    allocate(CS%rgauss(G%isd:G%ied,G%jsd:G%jed), source=0.0)
     call get_param(param_file, "MOM_stoch_eos", "SEED_STOCH_EOS", CS%seed, &
                  "Specfied seed for random number sequence ", default=0)
     call random_2d_constructor(CS%rn_CS, G%HI, Time, CS%seed)
@@ -98,13 +93,13 @@ subroutine MOM_stoch_eos_init(G, Time, param_file, CS, restart_CS, diag)
     ! time-scale calculation
     do j=G%jsc,G%jec
       do i=G%isc,G%iec
-        CS%l2_inv(i,j)=1.0/(G%dxT(i,j)**2+G%dyT(i,j)**2)
+        CS%l2_inv(i,j) = 1.0/(G%dxT(i,j)**2+G%dyT(i,j)**2)
       enddo
     enddo
     if (is_new_run(restart_CS)) then
       do j=G%jsc,G%jec
         do i=G%isc,G%iec
-          CS%pattern(i,j)=CS%amplitude*CS%rgauss(i,j)
+          CS%pattern(i,j) = CS%amplitude*CS%rgauss(i,j)
         enddo
       enddo
     endif
@@ -135,9 +130,9 @@ subroutine MOM_stoch_eos_run(G, u, v, delt, Time, CS, diag)
   type(diag_ctrl), target, intent(inout) :: diag !< to control diagnostics
 
   ! local variables
-  integer ::  i,j
-  integer :: yr,mo,dy,hr,mn,sc
-  real    :: phi,ubar,vbar
+  real    :: ubar, vbar ! Averaged velocities [L T-1 ~> m s-1]
+  real    :: phi        ! A temporal correlation factor [nondim]
+  integer :: i, j
 
   call random_2d_constructor(CS%rn_CS, G%HI, Time, CS%seed)
   call random_2d_norm(CS%rn_CS, G%HI, CS%rgauss)
@@ -145,11 +140,11 @@ subroutine MOM_stoch_eos_run(G, u, v, delt, Time, CS, diag)
   ! advance AR(1)
   do j=G%jsc,G%jec
     do i=G%isc,G%iec
-      ubar=0.5*(u(I,j,1)*G%mask2dCu(I,j)+u(I-1,j,1)*G%mask2dCu(I-1,j))
-      vbar=0.5*(v(i,J,1)*G%mask2dCv(i,J)+v(i,J-1,1)*G%mask2dCv(i,J-1))
-      phi=exp(-delt*CS%tfac*sqrt((ubar**2+vbar**2)*CS%l2_inv(i,j)))
-      CS%pattern(i,j)=phi*CS%pattern(i,j) + CS%amplitude*sqrt(1-phi**2)*CS%rgauss(i,j)
-      CS%phi(i,j)=phi
+      ubar = 0.5*(u(I,j,1)*G%mask2dCu(I,j)+u(I-1,j,1)*G%mask2dCu(I-1,j))
+      vbar = 0.5*(v(i,J,1)*G%mask2dCv(i,J)+v(i,J-1,1)*G%mask2dCv(i,J-1))
+      phi = exp(-delt*CS%tfac*sqrt((ubar**2+vbar**2)*CS%l2_inv(i,j)))
+      CS%pattern(i,j) = phi*CS%pattern(i,j) + CS%amplitude*sqrt(1-phi**2)*CS%rgauss(i,j)
+      CS%phi(i,j) = phi
     enddo
   enddo
 
@@ -171,15 +166,14 @@ subroutine MOM_calc_varT(G, GV, h, tv, CS, dt)
                   !! in massless layers filled vertically by diffusion.
     S             !> The filled salinity [S ~> ppt], with the values in
                   !! in massless layers filled vertically by diffusion.
-  integer :: i, j, k
   real :: hl(5)              !> Copy of local stencil of H [H ~> m]
   real :: dTdi2, dTdj2       !> Differences in T variance [C2 ~> degC2]
+  integer :: i, j, k
 
   ! This block does a thickness weighted variance calculation and helps control for
   ! extreme gradients along layers which are vanished against topography. It is
   ! still a poor approximation in the interior when coordinates are strongly tilted.
-  if (.not. associated(tv%varT)) call safe_alloc_ptr(tv%varT, G%isd, G%ied, G%jsd, G%jed, GV%ke)
-
+  if (.not. associated(tv%varT)) allocate(tv%varT(G%isd:G%ied, G%jsd:G%jed, GV%ke), source=0.0)
   call vert_fill_TS(h, tv%T, tv%S, CS%kappa_smooth*dt, T, S, G, GV, halo_here=1, larger_h_denom=.true.)
 
   do k=1,G%ke
@@ -193,12 +187,12 @@ subroutine MOM_calc_varT(G, GV, h, tv, CS, dt)
 
         ! SGS variance in i-direction [C2 ~> degC2]
         dTdi2 = ( ( G%mask2dCu(I  ,j) * G%IdxCu(I  ,j) * ( T(i+1,j,k) - T(i,j,k) ) &
-              + G%mask2dCu(I-1,j) * G%IdxCu(I-1,j) * ( T(i,j,k) - T(i-1,j,k) ) &
-              ) * G%dxT(i,j) * 0.5 )**2
+                  + G%mask2dCu(I-1,j) * G%IdxCu(I-1,j) * ( T(i,j,k) - T(i-1,j,k) ) &
+                ) * G%dxT(i,j) * 0.5 )**2
         ! SGS variance in j-direction [C2 ~> degC2]
         dTdj2 = ( ( G%mask2dCv(i,J  ) * G%IdyCv(i,J  ) * ( T(i,j+1,k) - T(i,j,k) ) &
-              + G%mask2dCv(i,J-1) * G%IdyCv(i,J-1) * ( T(i,j,k) - T(i,j-1,k) ) &
-              ) * G%dyT(i,j) * 0.5 )**2
+                  + G%mask2dCv(i,J-1) * G%IdyCv(i,J-1) * ( T(i,j,k) - T(i,j-1,k) ) &
+                ) * G%dyT(i,j) * 0.5 )**2
         tv%varT(i,j,k) = CS%stanley_coeff * ( dTdi2 + dTdj2 )
         ! Turn off scheme near land
         tv%varT(i,j,k) = tv%varT(i,j,k) * (minval(hl) / (maxval(hl) + GV%H_subroundoff))
@@ -210,7 +204,7 @@ subroutine MOM_calc_varT(G, GV, h, tv, CS, dt)
     do k=1,G%ke
       do j=G%jsc,G%jec
         do i=G%isc,G%iec
-          tv%varT(i,j,k) = exp (CS%stanley_a * CS%pattern(i,j)) * tv%varT(i,j,k)
+          tv%varT(i,j,k) = exp(CS%stanley_a * CS%pattern(i,j)) * tv%varT(i,j,k)
         enddo
       enddo
     enddo


### PR DESCRIPTION
  Added a missing dimensional rescaling factor in the get_param calls for KD_SMOOTH in MOM_stoch_eos_init and another for the recently added variable DT_OBC_SEG_UPDATE_OBGC in initialize_MOM, both of which would have caused certain cases to fail the dimensional consistency tests.  This correction required the addition of a new unit_scale_type argument to MOM_stoch_eos_init, and this change in interface presented an opportunity to reorder the arguments to this routine to match the order used in every other init call.

  There was also some modest refactoring of the MOM_stoch_eos code.  Four arrays in the MOM_stoch_eos_CS type that had been declared to optionally use static memory allocation were modified to be simple allocatables, as they are not used in the vast majority of MOM6 cases, and there is no reason to always assign memory to them.  Also, the register_restart_field call for "stoch_eos_pattern" was revised to use the newer, more direct form rather than working via a vardesc type.  The comments describing several real variables in this module were added or modified to describe their units using the standard format.  The module use statements at the start of this module were updated to reflect these changes.

  All answers are bitwise identical in cases that do not use dimensional rescaling, but answers will change (be corrected) in some cases that do use dimensional consistency tests.  The public interface to MOM_stoch_eos_init was altered.