### PR TITLE
Document units in 8 lat_param or diag modules

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4614,6 +4614,8 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                  "gravity waves) to 1 (for a backward Euler treatment). "//&
                  "In practice, BEBT must be greater than about 0.05.", &
                  units="nondim", default=0.1)
+  ! Note that dtbt_input is not rescaled because it has different units for
+  ! positive [s] and negative [nondim] values.
   call get_param(param_file, mdl, "DTBT", dtbt_input, &
                  "The barotropic time step, in s. DTBT is only used with "//&
                  "the split explicit time stepping. To set the time step "//&
@@ -4621,8 +4623,8 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
                  "a negative value gives the fraction of the stable value. "//&
                  "Setting DTBT to 0 is the same as setting it to -0.98. "//&
                  "The value of DTBT that will actually be used is an "//&
-                 "integer fraction of DT, rounding down.", units="s or nondim",&
-                 default = -0.98)
+                 "integer fraction of DT, rounding down.", &
+                 units="s or nondim", default=-0.98)
   call get_param(param_file, mdl, "BT_USE_OLD_CORIOLIS_BRACKET_BUG", &
                  CS%use_old_coriolis_bracket_bug , &
                  "If True, use an order of operations that is not bitwise "//&

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -4,6 +4,7 @@ module MOM_sum_output
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use iso_fortran_env, only : int64
+use MOM_checksums,     only : is_NaN
 use MOM_coms,          only : sum_across_PEs, PE_here, root_PE, num_PEs, max_across_PEs, field_chksum
 use MOM_coms,          only : reproducing_sum, reproducing_sum_EFP, EFP_to_real, real_to_EFP
 use MOM_coms,          only : EFP_type, operator(+), operator(-), assignment(=), EFP_sum_across_PEs
@@ -108,14 +109,16 @@ type, public :: sum_output_CS ; private
                                                !! of calls to write_energy and revert to the standard
                                                !! energysavedays interval
 
-  real    :: timeunit           !<  The length of the units for the time axis [s].
+  real    :: timeunit           !< The length of the units for the time axis and certain input parameters
+                                !! including ENERGYSAVEDAYS [s].
+
   logical :: date_stamped_output !< If true, use dates (not times) in messages to stdout.
   type(time_type) :: Start_time !< The start time of the simulation.
                                 ! Start_time is set in MOM_initialization.F90
   integer, pointer :: ntrunc => NULL() !< The number of times the velocity has been
                                 !! truncated since the last call to write_energy.
   real    :: max_Energy         !< The maximum permitted energy per unit mass.  If there is
-                                !! more energy than this, the model should stop [m2 s-2].
+                                !! more energy than this, the model should stop [L2 T-2 ~> m2 s-2].
   integer :: maxtrunc           !< The number of truncations per energy save
                                 !! interval at which the run is stopped.
   logical :: write_stocks       !< If true, write the integrated tracer amounts
@@ -147,13 +150,12 @@ subroutine MOM_sum_output_init(G, GV, US, param_file, directory, ntrnc, &
   type(Sum_output_CS),     pointer       :: CS         !< A pointer that is set to point to the
                                                        !! control structure for this module.
   ! Local variables
-  real :: Time_unit ! The time unit in seconds for ENERGYSAVEDAYS [s]
-  real :: maxvel    ! The maximum permitted velocity [m s-1]
+  real :: maxvel    ! The maximum permitted velocity [L T-1 ~> m s-1]
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_sum_output" ! This module's name.
   character(len=200) :: energyfile  ! The name of the energy file.
-  character(len=32) :: filename_appendix = '' !fms appendix to filename for ensemble runs
+  character(len=32) :: filename_appendix = '' ! FMS appendix to filename for ensemble runs
 
   if (associated(CS)) then
     call MOM_error(WARNING, "MOM_sum_output_init called with associated control structure.")
@@ -190,13 +192,13 @@ subroutine MOM_sum_output_init(G, GV, US, param_file, directory, ntrnc, &
                  "The maximum permitted average energy per unit mass; the "//&
                  "model will be stopped if there is more energy than "//&
                  "this.  If zero or negative, this is set to 10*MAXVEL^2.", &
-                 units="m2 s-2", default=0.0)
+                 units="m2 s-2", default=0.0, scale=US%m_s_to_L_T**2)
   if (CS%max_Energy <= 0.0) then
     call get_param(param_file, mdl, "MAXVEL", maxvel, &
                  "The maximum velocity allowed before the velocity "//&
-                 "components are truncated.", units="m s-1", default=3.0e8)
+                 "components are truncated.", units="m s-1", default=3.0e8, scale=US%m_s_to_L_T)
     CS%max_Energy = 10.0 * maxvel**2
-    call log_param(param_file, mdl, "MAX_ENERGY as used", CS%max_Energy)
+    call log_param(param_file, mdl, "MAX_ENERGY as used", US%L_T_to_m_s**2*CS%max_Energy, units="m2 s-2")
   endif
 
   call get_param(param_file, mdl, "ENERGYFILE", energyfile, &
@@ -218,12 +220,11 @@ subroutine MOM_sum_output_init(G, GV, US, param_file, directory, ntrnc, &
   call get_param(param_file, mdl, "DATE_STAMPED_STDOUT", CS%date_stamped_output, &
                  "If true, use dates (not times) in messages to stdout", &
                  default=.true.)
+  ! Note that the units of CS%Timeunit are the MKS units of [s].
   call get_param(param_file, mdl, "TIMEUNIT", CS%Timeunit, &
                  "The time unit in seconds a number of input fields", &
                  units="s", default=86400.0)
   if (CS%Timeunit < 0.0) CS%Timeunit = 86400.0
-
-
 
   if (CS%do_APE_calc) then
     call get_param(param_file, mdl, "READ_DEPTH_LIST", CS%read_depth_list, &
@@ -257,18 +258,15 @@ subroutine MOM_sum_output_init(G, GV, US, param_file, directory, ntrnc, &
     CS%DL%listsize = 1
   endif
 
-  call get_param(param_file, mdl, "TIMEUNIT", Time_unit, &
-                 "The time unit for ENERGYSAVEDAYS.", &
-                 units="s", default=86400.0)
   call get_param(param_file, mdl, "ENERGYSAVEDAYS",CS%energysavedays, &
                  "The interval in units of TIMEUNIT between saves of the "//&
                  "energies of the run and other globally summed diagnostics.",&
-                 default=set_time(0,days=1), timeunit=Time_unit)
+                 default=set_time(0,days=1), timeunit=CS%Timeunit)
   call get_param(param_file, mdl, "ENERGYSAVEDAYS_GEOMETRIC",CS%energysavedays_geometric, &
                  "The starting interval in units of TIMEUNIT for the first call "//&
                  "to save the energies of the run and other globally summed diagnostics. "//&
                  "The interval increases by a factor of 2. after each call to write_energy.",&
-                 default=set_time(seconds=0), timeunit=Time_unit)
+                 default=set_time(seconds=0), timeunit=CS%Timeunit)
 
   if ((time_type_to_real(CS%energysavedays_geometric) > 0.) .and. &
      (CS%energysavedays_geometric < CS%energysavedays)) then
@@ -328,7 +326,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   real :: PE_tot       ! The total available potential energy [J].
   real :: Z_0APE(SZK_(GV)+1) ! The uniform depth which overlies the same
                        ! volume as is below an interface [Z ~> m].
-  real :: H_0APE(SZK_(GV)+1) ! A version of Z_0APE, converted to m, usually positive.
+  real :: H_0APE(SZK_(GV)+1) ! A version of Z_0APE, converted to m, usually positive [m].
   real :: toten        ! The total kinetic & potential energies of
                        ! all layers [J] (i.e. kg m2 s-2).
   real :: En_mass      ! The total kinetic and potential energies divided by
@@ -381,7 +379,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   real :: CFL_lin      ! A simpler definition of the CFL number [nondim].
   real :: max_CFL(2)   ! The maxima of the CFL numbers [nondim].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: &
-    tmp1               ! A temporary array
+    tmp1               ! A temporary array used in reproducing sums [various]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: &
     PE_pt              ! The potential energy at each point [J].
   real, dimension(SZI_(G),SZJ_(G)) :: &
@@ -398,21 +396,26 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
                                  ! lbelow & labove are lower & upper limits for li
                                  ! in the search for the entry in lH to use.
   integer :: start_of_day, num_days
-  real    :: reday, var
+  real    :: reday  ! Time in units given by CS%Timeunit, but often [days]
   character(len=240) :: energypath_nc
   character(len=200) :: mesg
   character(len=32)  :: mesg_intro, time_units, day_str, n_str, date_str
   logical :: date_stamped
   type(time_type) :: dt_force ! A time_type version of the forcing timestep.
-  real :: Tr_stocks(MAX_FIELDS_) ! The total amounts of each of the registered tracers
-  real :: Tr_min(MAX_FIELDS_)   ! The global minimum unmasked value of the tracers
-  real :: Tr_max(MAX_FIELDS_)   ! The global maximum unmasked value of the tracers
+  ! The units of the tracer stock vary between tracers, with [conc] given explicitly by Tr_units.
+  real :: Tr_stocks(MAX_FIELDS_) ! The total amounts of each of the registered tracers [kg conc]
+  real :: Tr_min(MAX_FIELDS_)   ! The global minimum unmasked value of the tracers [conc]
+  real :: Tr_max(MAX_FIELDS_)   ! The global maximum unmasked value of the tracers [conc]
   real :: Tr_min_x(MAX_FIELDS_) ! The x-positions of the global tracer minima
+                                ! in the units of G%geoLonT, often [degrees_E] or [km]
   real :: Tr_min_y(MAX_FIELDS_) ! The y-positions of the global tracer minima
-  real :: Tr_min_z(MAX_FIELDS_) ! The z-positions of the global tracer minima
+                                ! in the units of G%geoLatT, often [degrees_N] or [km]
+  real :: Tr_min_z(MAX_FIELDS_) ! The z-positions of the global tracer minima [layer]
   real :: Tr_max_x(MAX_FIELDS_) ! The x-positions of the global tracer maxima
+                                ! in the units of G%geoLonT, often [degrees_E] or [km]
   real :: Tr_max_y(MAX_FIELDS_) ! The y-positions of the global tracer maxima
-  real :: Tr_max_z(MAX_FIELDS_) ! The z-positions of the global tracer maxima
+                                ! in the units of G%geoLatT, often [degrees_N] or [km]
+  real :: Tr_max_z(MAX_FIELDS_) ! The z-positions of the global tracer maxima [layer]
   logical :: Tr_minmax_avail(MAX_FIELDS_) ! A flag indicating whether the global minimum and
                                 ! maximum information are available for each of the tracers
   character(len=40), dimension(MAX_FIELDS_) :: &
@@ -860,8 +863,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
     endif
   endif
 
-  var = real(CS%ntrunc)
-  call write_field(CS%fileenergy_nc, CS%fields(1), var, reday)
+  call write_field(CS%fileenergy_nc, CS%fields(1), real(CS%ntrunc), reday)
   call write_field(CS%fileenergy_nc, CS%fields(2), toten, reday)
   call write_field(CS%fileenergy_nc, CS%fields(3), PE, reday)
   call write_field(CS%fileenergy_nc, CS%fields(4), KE, reday)
@@ -891,13 +893,12 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
 
   call flush_file(CS%fileenergy_nc)
 
-  ! The second (impossible-looking) test looks for a NaN in En_mass.
-  if ((En_mass>CS%max_Energy) .or. &
-     ((En_mass>CS%max_Energy) .and. (En_mass<CS%max_Energy))) then
+  if (is_NaN(En_mass)) then
+    call MOM_error(FATAL, "write_energy : NaNs in total model energy forced model termination.")
+  elseif (En_mass > US%L_T_to_m_s**2*CS%max_Energy) then
     write(mesg,'("Energy per unit mass of ",ES11.4," exceeds ",ES11.4)') &
-                  En_mass, CS%max_Energy
-    call MOM_error(FATAL, &
-      "write_energy : Excessive energy per unit mass or NaNs forced model termination.")
+                  En_mass, US%L_T_to_m_s**2*CS%max_Energy
+    call MOM_error(FATAL, "write_energy : Excessive energy per unit mass forced model termination.")
   endif
   if (CS%ntrunc>CS%maxtrunc) then
     call MOM_error(FATAL, "write_energy : Ocean velocity has been truncated too many times.")
@@ -913,7 +914,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
 
 end subroutine write_energy
 
-!> This subroutine accumates the net input of volume, salt and heat, through
+!> This subroutine accumulates the net input of volume, salt and heat, through
 !! the ocean surface for use in diagnosing conservation.
 subroutine accumulate_net_input(fluxes, sfc_state, tv, dt, G, US, CS)
   type(forcing),         intent(in) :: fluxes !< A structure containing pointers to any possible
@@ -1100,7 +1101,7 @@ end subroutine depth_list_setup
 subroutine create_depth_list(G, DL, min_depth_inc)
   type(ocean_grid_type), intent(in)    :: G  !< The ocean's grid structure.
   type(Depth_List),      intent(inout) :: DL !< The list of depths, areas and volumes to create
-  real,                  intent(in)    :: min_depth_inc !< The minimum increment bewteen depths in the list [Z ~> m]
+  real,                  intent(in)    :: min_depth_inc !< The minimum increment between depths in the list [Z ~> m]
 
   ! Local variables
   real, dimension(G%Domain%niglobal*G%Domain%njglobal + 1) :: &
@@ -1110,7 +1111,7 @@ subroutine create_depth_list(G, DL, min_depth_inc)
     indx2     !< The position of an element in the original unsorted list.
   real    :: Dnow  !< The depth now being considered for sorting [Z ~> m].
   real    :: Dprev !< The most recent depth that was considered [Z ~> m].
-  real    :: vol   !< The running sum of open volume below a deptn [Z L2 ~> m3].
+  real    :: vol   !< The running sum of open volume below a depth [Z L2 ~> m3].
   real    :: area  !< The open area at the current depth [L2 ~> m2].
   real    :: D_list_prev !< The most recent depth added to the list [Z ~> m].
   logical :: add_to_list !< This depth should be included as an entry on the list.
@@ -1360,7 +1361,7 @@ subroutine get_depth_list_checksums(G, US, depth_chksum, area_chksum)
   character(len=16), intent(out) :: area_chksum   !< Area checksum hexstring
 
   integer :: i, j
-  real, allocatable :: field(:,:)
+  real, allocatable :: field(:,:)  ! A temporary array for output converted to MKS units [m] or [m2]
 
   allocate(field(G%isc:G%iec, G%jsc:G%jec))
 

--- a/src/framework/testing/MOM_file_parser_tests.F90
+++ b/src/framework/testing/MOM_file_parser_tests.F90
@@ -1468,7 +1468,7 @@ subroutine test_get_param_real
   call create_test_file(param_filename)
 
   call open_param_file(param_filename, param)
-  call get_param(param, module_name, sample_param_name, sample)
+  call get_param(param, module_name, sample_param_name, sample, units="")
   call close_param_file(param)
 end subroutine test_get_param_real
 
@@ -1480,7 +1480,7 @@ subroutine test_get_param_real_no_read_no_log
   call create_test_file(param_filename)
 
   call open_param_file(param_filename, param)
-  call get_param(param, module_name, sample_param_name, sample, &
+  call get_param(param, module_name, sample_param_name, sample, units="", &
       do_not_read=.true., do_not_log=.true.)
   call close_param_file(param)
 end subroutine test_get_param_real_no_read_no_log
@@ -1493,7 +1493,7 @@ subroutine test_get_param_real_array
   call create_test_file(param_filename)
 
   call open_param_file(param_filename, param)
-  call get_param(param, module_name, sample_param_name, sample)
+  call get_param(param, module_name, sample_param_name, sample, units="")
   call close_param_file(param)
 end subroutine test_get_param_real_array
 
@@ -1505,7 +1505,7 @@ subroutine test_get_param_real_array_no_read_no_log
   call create_test_file(param_filename)
 
   call open_param_file(param_filename, param)
-  call get_param(param, module_name, sample_param_name, sample, &
+  call get_param(param, module_name, sample_param_name, sample, units="", &
       do_not_read=.true., do_not_log=.true.)
   call close_param_file(param)
 end subroutine test_get_param_real_array_no_read_no_log

--- a/src/parameterizations/lateral/MOM_MEKE_types.F90
+++ b/src/parameterizations/lateral/MOM_MEKE_types.F90
@@ -26,8 +26,8 @@ type, public :: MEKE_type
   ! Parameters
   real :: KhTh_fac = 1.0 !< Multiplier to map Kh(MEKE) to KhTh [nondim]
   real :: KhTr_fac = 1.0 !< Multiplier to map Kh(MEKE) to KhTr [nondim].
-  real :: backscatter_Ro_pow = 0.0 !< Power in Rossby number function for backscatter.
-  real :: backscatter_Ro_c = 0.0 !< Coefficient in Rossby number function for backscatter.
+  real :: backscatter_Ro_pow = 0.0 !< Power in Rossby number function for backscatter [nondim].
+  real :: backscatter_Ro_c = 0.0 !< Coefficient in Rossby number function for backscatter [nondim].
 
 end type MEKE_type
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -52,7 +52,7 @@ type, public :: hor_visc_CS ; private
   logical :: better_bound_Ah !< If true, use a more careful bounding of the
                              !! biharmonic viscosity to guarantee stability.
   real    :: Re_Ah           !! If nonzero, the biharmonic coefficient is scaled
-                             !< so that the biharmonic Reynolds number is equal to this.
+                             !< so that the biharmonic Reynolds number is equal to this [nondim].
   real    :: bound_coef      !< The nondimensional coefficient of the ratio of
                              !! the viscosity bounds to the theoretical maximum
                              !! for stability without considering other terms [nondim].
@@ -123,8 +123,8 @@ type, public :: hor_visc_CS ; private
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
     Kh_Max_xx,      & !< The maximum permitted Laplacian viscosity [L2 T-1 ~> m2 s-1].
     Ah_Max_xx,      & !< The maximum permitted biharmonic viscosity [L4 T-1 ~> m4 s-1].
-    n1n2_h,         & !< Factor n1*n2 in the anisotropic direction tensor at h-points
-    n1n1_m_n2n2_h,  & !< Factor n1**2-n2**2 in the anisotropic direction tensor at h-points
+    n1n2_h,         & !< Factor n1*n2 in the anisotropic direction tensor at h-points [nondim]
+    n1n1_m_n2n2_h,  & !< Factor n1**2-n2**2 in the anisotropic direction tensor at h-points [nondim]
     grid_sp_h2,     & !< Harmonic mean of the squares of the grid [L2 ~> m2]
     grid_sp_h3        !< Harmonic mean of the squares of the grid^(3/2) [L3 ~> m3]
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: Kh_bg_xy
@@ -141,8 +141,8 @@ type, public :: hor_visc_CS ; private
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &
     Kh_Max_xy,      & !< The maximum permitted Laplacian viscosity [L2 T-1 ~> m2 s-1].
     Ah_Max_xy,      & !< The maximum permitted biharmonic viscosity [L4 T-1 ~> m4 s-1].
-    n1n2_q,         & !< Factor n1*n2 in the anisotropic direction tensor at q-points
-    n1n1_m_n2n2_q     !< Factor n1**2-n2**2 in the anisotropic direction tensor at q-points
+    n1n2_q,         & !< Factor n1*n2 in the anisotropic direction tensor at q-points [nondim]
+    n1n1_m_n2n2_q     !< Factor n1**2-n2**2 in the anisotropic direction tensor at q-points [nondim]
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
     dx2h,   & !< Pre-calculated dx^2 at h points [L2 ~> m2]
@@ -181,8 +181,10 @@ type, public :: hor_visc_CS ; private
 
   type(diag_ctrl), pointer :: diag => NULL() !< structure to regulate diagnostics
 
-  ! real, allocatable :: hf_diffu(:,:,:)  ! Zonal hor. visc. accel. x fract. thickness [L T-2 ~> m s-2].
-  ! real, allocatable :: hf_diffv(:,:,:)  ! Meridional hor. visc. accel. x fract. thickness [L T-2 ~> m s-2].
+  ! real, allocatable :: hf_diffu(:,:,:)  ! Zonal horizontal viscous acceleleration times
+  !                                       ! fractional thickness [L T-2 ~> m s-2].
+  ! real, allocatable :: hf_diffv(:,:,:)  ! Meridional horizontal viscous acceleleration times
+  !                                       ! fractional thickness [L T-2 ~> m s-2].
   ! 3D diagnostics hf_diffu(diffv) are commented because there is no clarity on proper remapping grid option.
   ! The code is retained for debugging purposes in the future.
 
@@ -242,12 +244,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
                                                        !! of along-coordinate stress tensor [L T-2 ~> m s-2].
   type(MEKE_type),               intent(inout) :: MEKE !< MEKE fields
                                                        !! related to Mesoscale Eddy Kinetic Energy.
-  type(VarMix_CS),               intent(inout) :: VarMix !< Variable mixing control struct
+  type(VarMix_CS),               intent(inout) :: VarMix !< Variable mixing control structure
   type(unit_scale_type),         intent(in)  :: US     !< A dimensional unit scaling type
-  type(hor_visc_CS),             intent(in)  :: CS     !< Horizontal viscosity control struct
+  type(hor_visc_CS),             intent(in)  :: CS     !< Horizontal viscosity control structure
   type(ocean_OBC_type), optional, pointer    :: OBC    !< Pointer to an open boundary condition type
-  type(barotropic_CS), intent(in), optional  :: BT     !< Barotropic control struct
-  type(thickness_diffuse_CS), intent(in), optional :: TD  !< Thickness diffusion control struct
+  type(barotropic_CS), intent(in), optional  :: BT     !< Barotropic control structure
+  type(thickness_diffuse_CS), intent(in), optional :: TD  !< Thickness diffusion control structure
   type(accel_diag_ptrs), intent(in), optional :: ADp   !< Acceleration diagnostics
 
   ! Local variables
@@ -256,20 +258,21 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     h_u, &        ! Thickness interpolated to u points [H ~> m or kg m-2].
     vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
     div_xx_dx, &  ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
-    ubtav         ! zonal barotropic vel. ave. over baroclinic time-step [L T-1 ~> m s-1]
+    ubtav         ! zonal barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G)) :: &
     Del2v, &      ! The v-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
     h_v, &        ! Thickness interpolated to v points [H ~> m or kg m-2].
     vort_xy_dx, & ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
     div_xx_dy, &  ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
-    vbtav         ! meridional barotropic vel. ave. over baroclinic time-step [L T-1 ~> m s-1]
+    vbtav         ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G)) :: &
     dudx_bt, dvdy_bt, & ! components in the barotropic horizontal tension [T-1 ~> s-1]
     div_xx, &     ! Estimate of horizontal divergence at h-points [T-1 ~> s-1]
     sh_xx, &      ! horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
     sh_xx_bt, &   ! barotropic horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
-    str_xx,&      ! str_xx is the diagonal term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2]
-    str_xx_GME,&  ! smoothed diagonal term in the stress tensor from GME [H L2 T-2 ~> m3 s-2 or kg s-2]
+    str_xx,&      ! str_xx is the diagonal term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
+                  ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
+    str_xx_GME,&  ! smoothed diagonal term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
     bhstr_xx, &   ! A copy of str_xx that only contains the biharmonic contribution [H L2 T-2 ~> m3 s-2 or kg s-2]
     FrictWorkIntz, & ! depth integrated energy dissipated by lateral friction [R L2 T-3 ~> W m-2]
     grad_vort_mag_h, & ! Magnitude of vorticity gradient at h-points [L-1 T-1 ~> m-1 s-1]
@@ -288,8 +291,9 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     dvdx_bt, dudy_bt,   & ! components in the barotropic shearing strain [T-1 ~> s-1]
     sh_xy,  &     ! horizontal shearing strain (du/dy + dv/dx) including metric terms [T-1 ~> s-1]
     sh_xy_bt, &   ! barotropic horizontal shearing strain (du/dy + dv/dx) inc. metric terms [T-1 ~> s-1]
-    str_xy, &     ! str_xy is the cross term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2]
-    str_xy_GME, & ! smoothed cross term in the stress tensor from GME [H L2 T-2 ~> m3 s-2 or kg s-2]
+    str_xy, &     ! str_xy is the cross term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
+                  ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
+    str_xy_GME, & ! smoothed cross term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
     bhstr_xy, &   ! A copy of str_xy that only contains the biharmonic contribution [H L2 T-2 ~> m3 s-2 or kg s-2]
     vort_xy, &    ! Vertical vorticity (dv/dx - du/dy) including metric terms [T-1 ~> s-1]
     grad_vort_mag_q, & ! Magnitude of vorticity gradient at q-points [L-1 T-1 ~> m-1 s-1]
@@ -310,9 +314,9 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     GME_coeff_q, &  !< GME coeff. at q-points [L2 T-1 ~> m2 s-1]
     ShSt         ! A diagnostic array of shear stress [T-1 ~> s-1].
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: &
-    KH_u_GME  !< interface height diffusivities in u-columns [L2 T-1 ~> m2 s-1]
+    KH_u_GME     !< Isopycnal height diffusivities in u-columns [L2 T-1 ~> m2 s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: &
-    KH_v_GME  !< interface height diffusivities in v-columns [L2 T-1 ~> m2 s-1]
+    KH_v_GME     !< Isopycnal height diffusivities in v-columns [L2 T-1 ~> m2 s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: &
     Ah_h, &          ! biharmonic viscosity at thickness points [L4 T-1 ~> m4 s-1]
     Kh_h, &          ! Laplacian viscosity at thickness points [L2 T-1 ~> m2 s-1]
@@ -324,7 +328,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: &
     grid_Re_Kh, &    ! Grid Reynolds number for Laplacian horizontal viscosity at h points [nondim]
     grid_Re_Ah, &    ! Grid Reynolds number for Biharmonic horizontal viscosity at h points [nondim]
-    GME_coeff_h      ! GME coeff. at h-points [L2 T-1 ~> m2 s-1]
+    GME_coeff_h      ! GME coefficient at h-points [L2 T-1 ~> m2 s-1]
   real :: AhSm       ! Smagorinsky biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: AhLth      ! 2D Leith biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: Shear_mag_bc  ! Shear_mag value in backscatter [T-1 ~> s-1]
@@ -342,7 +346,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   real :: RoScl     ! The scaling function for MEKE source term [nondim]
   real :: FatH      ! abs(f) at h-point for MEKE source term [T-1 ~> s-1]
   real :: local_strain ! Local variable for interpolating computed strain rates [T-1 ~> s-1].
-  real :: meke_res_fn ! A copy of the resolution scaling factor if being applied to MEKE. Otherwise =1.
+  real :: meke_res_fn ! A copy of the resolution scaling factor if being applied to MEKE [nondim]. Otherwise = 1.
   real :: GME_coeff ! The GME (negative) viscosity coefficient [L2 T-1 ~> m2 s-1]
   real :: DY_dxBu   ! Ratio of meridional over zonal grid spacing at vertices [nondim]
   real :: DX_dyBu   ! Ratio of zonal over meridional grid spacing at vertices [nondim]
@@ -352,7 +356,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   real :: KE        ! Local kinetic energy [L2 T-2 ~> m2 s-2]
   real :: d_del2u   ! dy-weighted Laplacian(u) diff in x [L-2 T-1 ~> m-2 s-1]
   real :: d_del2v   ! dx-weighted Laplacian(v) diff in y [L-2 T-1 ~> m-2 s-1]
-  real :: d_str     ! Stress tensor update [H L2 T-2 ~> m3 s-2 or kg s-2]
+  real :: d_str     ! Stress tensor update [L2 T-2 ~> m2 s-2]
   real :: grad_vort ! Vorticity gradient magnitude [L-1 T-1 ~> m-1 s-1]
   real :: grad_vort_qg ! QG-based vorticity gradient magnitude [L-1 T-1 ~> m-1 s-1]
   real :: grid_Kh   ! Laplacian viscosity bound by grid [L2 T-1 ~> m2 s-1]
@@ -365,7 +369,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   logical :: use_MEKE_Au
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: i, j, k, n
-  real :: inv_PI3, inv_PI2, inv_PI6
+  real :: inv_PI3, inv_PI2, inv_PI6 ! Powers of the inverse of pi [nondim]
 
   ! Fields evaluated on active layers, used for constructing 3D stress fields
   ! NOTE: The position of these declarations can impact performance, due to the
@@ -419,7 +423,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     if ((rescale_Kh .or. CS%res_scale_MEKE) &
         .and. (.not. allocated(VarMix%Res_fn_h) .or. .not. allocated(VarMix%Res_fn_q))) &
       call MOM_error(FATAL, "MOM_hor_visc: VarMix%Res_fn_h and VarMix%Res_fn_q "//&
-        "both need to be associated with Resoln_scaled_Kh or RES_SCALE_MEKE_VISC.")
+                     "both need to be associated with Resoln_scaled_Kh or RES_SCALE_MEKE_VISC.")
   elseif (CS%res_scale_MEKE) then
     call MOM_error(FATAL, "MOM_hor_visc: VarMix needs to be associated if "//&
                           "RES_SCALE_MEKE_VISC is True.")
@@ -430,7 +434,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
   if (CS%use_GME) then
 
-    ! initialize diag. array with zeros
+    ! Initialize diagnostic arrays with zeros
     GME_coeff_h(:,:,:) = 0.0
     GME_coeff_q(:,:,:) = 0.0
     str_xx_GME(:,:) = 0.0
@@ -1418,11 +1422,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       call smooth_GME(CS, G, GME_flux_h=str_xx_GME)
       call smooth_GME(CS, G, GME_flux_q=str_xy_GME)
 
+      ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = (str_xx(i,j) + str_xx_GME(i,j)) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
 
-      ! GME is applied below
+      ! This adds in GME and changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
         do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = (str_xy(I,J) + str_xy_GME(I,J)) * (hq(I,J) * CS%reduction_xy(I,J))
@@ -1434,10 +1439,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       endif
 
     else ! .not. use_GME
+      ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       do J=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = str_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
 
+      ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
         do J=js-1,Jeq ; do I=is-1,Ieq
           str_xy(I,J) = str_xy(I,J) * (hq(I,J) * CS%reduction_xy(I,J))
@@ -1685,10 +1692,9 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   type(hor_visc_CS),       intent(inout) :: CS   !< Horizontal viscosity control structure
   type(accel_diag_ptrs), intent(in), optional :: ADp !< Acceleration diagnostics
 
-  real, dimension(SZIB_(G),SZJ_(G)) :: u0u, u0v
-  real, dimension(SZI_(G),SZJB_(G)) :: v0u, v0v
-                ! u0v is the Laplacian sensitivities to the v velocities
-                ! at u points [L-2 ~> m-2], with u0u, v0u, and v0v defined similarly.
+  ! u0v is the Laplacian sensitivities to the v velocities at u points, with u0u, v0u, and v0v defined analogously.
+  real, dimension(SZIB_(G),SZJ_(G)) :: u0u, u0v ! Laplacian sensitivities at u points [L-2 ~> m-2]
+  real, dimension(SZI_(G),SZJB_(G)) :: v0u, v0v ! Laplacian sensitivities at v points [L-2 ~> m-2]
   real :: grid_sp_h2       ! Harmonic mean of the squares of the grid [L2 ~> m2]
   real :: grid_sp_h3       ! Harmonic mean of the squares of the grid^(3/2) [L3 ~> m3]
   real :: grid_sp_q2       ! spacings at h and q points [L2 ~> m2]
@@ -1708,19 +1714,19 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   real :: Kh_vel_scale     ! this speed [L T-1 ~> m s-1] times grid spacing gives Laplacian viscosity
   real :: Ah_vel_scale     ! this speed [L T-1 ~> m s-1] times grid spacing cubed gives biharmonic viscosity
   real :: Ah_time_scale    ! damping time-scale for biharmonic visc [T ~> s]
-  real :: Smag_Lap_const   ! nondimensional Laplacian Smagorinsky constant
-  real :: Smag_bi_const    ! nondimensional biharmonic Smagorinsky constant
-  real :: Leith_Lap_const  ! nondimensional Laplacian Leith constant
-  real :: Leith_bi_const   ! nondimensional biharmonic Leith constant
+  real :: Smag_Lap_const   ! nondimensional Laplacian Smagorinsky constant [nondim]
+  real :: Smag_bi_const    ! nondimensional biharmonic Smagorinsky constant [nondim]
+  real :: Leith_Lap_const  ! nondimensional Laplacian Leith constant [nondim]
+  real :: Leith_bi_const   ! nondimensional biharmonic Leith constant [nondim]
   real :: dt               ! The dynamics time step [T ~> s]
   real :: Idt              ! The inverse of dt [T-1 ~> s-1]
-  real :: denom            ! work variable; the denominator of a fraction
-  real :: maxvel           ! largest permitted velocity components [m s-1]
+  real :: denom            ! work variable; the denominator of a fraction [L-2 ~> m-2] or [L-4 ~> m-4]
+  real :: maxvel           ! largest permitted velocity components [L T-1 ~> m s-1]
   real :: bound_Cor_vel    ! grid-scale velocity variations at which value
                            ! the quadratically varying biharmonic viscosity
                            ! balances Coriolis acceleration [L T-1 ~> m s-1]
   real :: Kh_sin_lat       ! Amplitude of latitudinally dependent viscosity [L2 T-1 ~> m2 s-1]
-  real :: Kh_pwr_of_sine   ! Power used to raise sin(lat) when using Kh_sin_lat
+  real :: Kh_pwr_of_sine   ! Power used to raise sin(lat) when using Kh_sin_lat [nondim]
   logical :: bound_Cor_def ! parameter setting of BOUND_CORIOLIS
   logical :: split         ! If true, use the split time stepping scheme.
                            ! If false and USE_GME = True, issue a FATAL error.
@@ -1732,9 +1738,9 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags
   character(len=200) :: inputdir, filename ! Input file names and paths
   character(len=80) ::  Kh_var ! Input variable names
-  real    :: deg2rad       ! Converts degrees to radians
-  real    :: slat_fn       ! sin(lat)**Kh_pwr_of_sine
-  real    :: aniso_grid_dir(2) ! Vector (n1,n2) for anisotropic direction
+  real    :: deg2rad       ! Converts degrees to radians [radians degree-1]
+  real    :: slat_fn       ! sin(lat)**Kh_pwr_of_sine [nondim]
+  real    :: aniso_grid_dir(2) ! Vector (n1,n2) for anisotropic direction [nondim]
   integer :: aniso_mode    ! Selects the mode for setting the anisotropic direction
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -1945,12 +1951,13 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
                  "value of BOUND_CORIOLIS (or false).", default=bound_Cor_def, &
                  do_not_log=.not.CS%Smagorinsky_Ah)
   if (.not.CS%Smagorinsky_Ah) CS%bound_Coriolis = .false.
-  call get_param(param_file, mdl, "MAXVEL", maxvel, default=3.0e8)
+  call get_param(param_file, mdl, "MAXVEL", maxvel, &
+                 units="m s-1", default=3.0e8, scale=US%m_s_to_L_T)
   call get_param(param_file, mdl, "BOUND_CORIOLIS_VEL", bound_Cor_vel, &
                  "The velocity scale at which BOUND_CORIOLIS_BIHARM causes "//&
                  "the biharmonic drag to have comparable magnitude to the "//&
                  "Coriolis acceleration.  The default is set by MAXVEL.", &
-                 units="m s-1", default=maxvel, scale=US%m_s_to_L_T, &
+                 units="m s-1", default=maxvel*US%L_T_to_m_s, scale=US%m_s_to_L_T, &
                  do_not_log=.not.(CS%Smagorinsky_Ah .and. CS%bound_Coriolis))
 
   call get_param(param_file, mdl, "LEITH_BI_CONST", Leith_bi_const, &
@@ -2229,8 +2236,8 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       CS%Idxdy2v(i,J) = G%IdxCv(i,J) * (G%IdyCv(i,J)*G%IdyCv(i,J))
     enddo ; enddo
     CS%Ah_bg_xy(:,:) = 0.0
-   ! The 0.3 below was 0.4 in MOM1.10.  The change in hq requires
-   ! this to be less than 1/3, rather than 1/2 as before.
+    ! The 0.3 below was 0.4 in HIM 1.10.  The change in hq requires
+    ! this to be less than 1/3, rather than 1/2 as before.
     if (CS%better_bound_Ah .or. CS%bound_Ah) Ah_Limit = 0.3 / (dt*64.0)
     if (CS%Smagorinsky_Ah .and. CS%bound_Coriolis) &
       BoundCorConst = 1.0 / (5.0*(bound_Cor_vel*bound_Cor_vel))
@@ -2533,10 +2540,10 @@ subroutine align_aniso_tensor_to_grid(CS, n1, n2)
   real,              intent(in) :: n1 !< i-component of direction vector [nondim]
   real,              intent(in) :: n2 !< j-component of direction vector [nondim]
   ! Local variables
-  real :: recip_n2_norm
+  real :: recip_n2_norm ! The inverse of the squared magnitude of n1 and n2 [nondim]
   ! For normalizing n=(n1,n2) in case arguments are not a unit vector
   recip_n2_norm = n1**2 + n2**2
-  if (recip_n2_norm > 0.) recip_n2_norm = 1./recip_n2_norm
+  if (recip_n2_norm > 0.) recip_n2_norm = 1. / recip_n2_norm
   CS%n1n2_h(:,:) = 2. * ( n1 * n2 ) * recip_n2_norm
   CS%n1n2_q(:,:) = 2. * ( n1 * n2 ) * recip_n2_norm
   CS%n1n1_m_n2n2_h(:,:) = ( n1 * n1 - n2 * n2 ) * recip_n2_norm
@@ -2549,13 +2556,13 @@ subroutine smooth_GME(CS, G, GME_flux_h, GME_flux_q)
   type(hor_visc_CS),                            intent(in)    :: CS        !< Control structure
   type(ocean_grid_type),                        intent(in)    :: G         !< Ocean grid
   real, dimension(SZI_(G),SZJ_(G)),   optional, intent(inout) :: GME_flux_h!< GME diffusive flux
-                                                              !! at h points
+                                                              !! at h points [L2 T-2 ~> m2 s-2]
   real, dimension(SZIB_(G),SZJB_(G)), optional, intent(inout) :: GME_flux_q!< GME diffusive flux
-                                                              !! at q points
+                                                              !! at q points [L2 T-2 ~> m2 s-2]
   ! local variables
-  real, dimension(SZI_(G),SZJ_(G)) :: GME_flux_h_original
-  real, dimension(SZIB_(G),SZJB_(G)) :: GME_flux_q_original
-  real :: wc, ww, we, wn, ws ! averaging weights for smoothing
+  real, dimension(SZI_(G),SZJ_(G)) :: GME_flux_h_original ! The previous value of GME_flux_h [L2 T-2 ~> m2 s-2]
+  real, dimension(SZIB_(G),SZJB_(G)) :: GME_flux_q_original ! The previous value of GME_flux_q [L2 T-2 ~> m2 s-2]
+  real :: wc, ww, we, wn, ws ! averaging weights for smoothing [nondim]
   integer :: i, j, s, halosz
   integer :: xh, xq  ! The number of valid extra halo points for h and q points.
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq
@@ -2618,7 +2625,7 @@ end subroutine smooth_GME
 
 !> Deallocates any variables allocated in hor_visc_init.
 subroutine hor_visc_end(CS)
-  type(hor_visc_CS), intent(inout) :: CS !< Horizontal viscosity control struct
+  type(hor_visc_CS), intent(inout) :: CS !< Horizontal viscosity control structure
   if (CS%Laplacian .or. CS%biharmonic) then
     DEALLOC_(CS%dx2h) ; DEALLOC_(CS%dx2q) ; DEALLOC_(CS%dy2h) ; DEALLOC_(CS%dy2q)
     DEALLOC_(CS%dx_dyT) ; DEALLOC_(CS%dy_dxT) ; DEALLOC_(CS%dx_dyBu) ; DEALLOC_(CS%dy_dxBu)

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -379,13 +379,14 @@ subroutine call_tracer_register_obc_segments(GV, param_file, CS, tr_Reg, OBC)
       call register_MOM_generic_tracer_segments(CS%MOM_generic_tracer_CSp, GV, OBC, tr_Reg, param_file)
 
 end subroutine call_tracer_register_obc_segments
+
 !> This subroutine extracts the chlorophyll concentrations from the model state, if possible
 subroutine get_chl_from_model(Chl_array, G, GV, CS)
   type(ocean_grid_type),        intent(in)  :: G         !< The ocean's grid structure.
   type(verticalGrid_type),      intent(in)  :: GV        !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                                 intent(out) :: Chl_array !< The array in which to store the model's
-                                                         !! Chlorophyll-A concentrations in mg m-3.
+                                                         !! Chlorophyll-A concentrations [mg m-3].
   type(tracer_flow_control_CS), pointer     :: CS        !< The control structure returned by a
                                                          !! previous call to call_tracer_register.
 
@@ -635,21 +636,28 @@ subroutine call_tracer_stocks(h, stock_values, G, GV, US, CS, stock_names, stock
   logical, dimension(:), &
                       optional, intent(inout) :: got_min_max !< Indicates whether the global min and
                                                              !! max are found for each tracer
-  real, dimension(:), optional, intent(out)   :: global_min  !< The global minimum of each tracer
-  real, dimension(:), optional, intent(out)   :: global_max  !< The global maximum of each tracer
-  real, dimension(:), optional, intent(out)   :: xgmin       !< The x-position of the global minimum
-  real, dimension(:), optional, intent(out)   :: ygmin       !< The y-position of the global minimum
-  real, dimension(:), optional, intent(out)   :: zgmin       !< The z-position of the global minimum
-  real, dimension(:), optional, intent(out)   :: xgmax       !< The x-position of the global maximum
-  real, dimension(:), optional, intent(out)   :: ygmax       !< The y-position of the global maximum
-  real, dimension(:), optional, intent(out)   :: zgmax       !< The z-position of the global maximum
+  real, dimension(:), optional, intent(out)   :: global_min  !< The global minimum of each tracer [conc]
+  real, dimension(:), optional, intent(out)   :: global_max  !< The global maximum of each tracer [conc]
+  real, dimension(:), optional, intent(out)   :: xgmin       !< The x-position of the global minimum in the
+                                                             !! units of G%geoLonT, often [degrees_E] or [km]
+  real, dimension(:), optional, intent(out)   :: ygmin       !< The y-position of the global minimum in the
+                                                             !! units of G%geoLatT, often [degrees_N] or [km]
+  real, dimension(:), optional, intent(out)   :: zgmin       !< The z-position of the global minimum [layer]
+  real, dimension(:), optional, intent(out)   :: xgmax       !< The x-position of the global maximum in the
+                                                             !! units of G%geoLonT, often [degrees_E] or [km]
+  real, dimension(:), optional, intent(out)   :: ygmax       !< The y-position of the global maximum in the
+                                                             !! units of G%geoLatT, often [degrees_N] or [km]
+  real, dimension(:), optional, intent(out)   :: zgmax       !< The z-position of the global maximum [layer]
 
   ! Local variables
   character(len=200), dimension(MAX_FIELDS_) :: names, units
   character(len=200) :: set_pkg_name
-  ! real, dimension(MAX_FIELDS_) :: values
-  type(EFP_type), dimension(MAX_FIELDS_) :: values_EFP
-  type(EFP_type), dimension(MAX_FIELDS_) :: stock_val_EFP
+  ! real, dimension(MAX_FIELDS_) :: values ! Globally integrated tracer amounts in a
+                                           ! new list for each tracer package [kg conc]
+  type(EFP_type), dimension(MAX_FIELDS_) :: values_EFP     ! Globally integrated tracer amounts in a
+                                                           ! new list for each tracer package [kg conc]
+  type(EFP_type), dimension(MAX_FIELDS_) :: stock_val_EFP  ! Globally integrated tracer amounts in a
+                                                           ! single master list for all tracers [kg conc]
   integer :: max_ns, ns_tot, ns, index, nn, n
 
   if (.not. associated(CS)) call MOM_error(FATAL, "call_tracer_stocks: "// &
@@ -758,12 +766,12 @@ subroutine store_stocks(pkg_name, ns, names, units, values, index, stock_values,
   character(len=*), dimension(:), &
                       intent(in)    :: units   !< Units to use in the metadata for each stock.
   type(EFP_type), dimension(:), &
-                      intent(in)    :: values  !< The values of the tracer stocks
+                      intent(in)    :: values  !< The values of the tracer stocks [conc kg]
   integer,            intent(in)    :: index   !< The integer stock index from
                              !! stocks_constants_mod of the stock to be returned.  If this is
                              !! present and greater than 0, only a single stock can be returned.
   type(EFP_type), dimension(:), &
-                      intent(inout) :: stock_values !< The master list of stock values
+                      intent(inout) :: stock_values !< The master list of stock values [conc kg]
   character(len=*),   intent(inout) :: set_pkg_name !< The name of the last tracer package whose
                                                !! stocks were stored for a specific index.  This is
                                                !! used to trigger an error if there are redundant stocks.


### PR DESCRIPTION
  Documented numerous internal variables and their units in 3 lateral parameterization modules (MOM_hor_visc, MOM_lateral_mixing_coeffs, MOM_MEKE_types) and the write_cputime module.  In addition, the units of a number of internal variables in the MOM_sum_output module and arguments to call_tracer_stocks were added to their descriptions in comments.  This commit includes the addition of units or scale=1.0 arguments in 9 unlogged get_param calls.  A number of spelling errors were also corrected in comments.  All answers and output are bitwise identical.