### PR TITLE
+Add x_ax_unit_short to ocean_grid_type

### DIFF
--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -146,8 +146,12 @@ type, public :: ocean_grid_type
     gridLonB => NULL()    !< The longitude of B points for the purpose of labeling the output axes.
                           !! On many grids this is the same as geoLonBu.
   character(len=40) :: &
+    ! Except on a Cartesian grid, these are usually some variant of "degrees".
     x_axis_units, &     !< The units that are used in labeling the x coordinate axes.
-    y_axis_units        !< The units that are used in labeling the y coordinate axes.
+    y_axis_units, &     !< The units that are used in labeling the y coordinate axes.
+    ! These are internally generated names, including "m", "km", "deg_E" and "deg_N".
+    x_ax_unit_short, &  !< A short description of the x-axis units for documenting parameter units
+    y_ax_unit_short     !< A short description of the y-axis units for documenting parameter units
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
     bathyT           !< Ocean bottom depth at tracer points, in depth units [Z ~> m].

--- a/src/core/MOM_transcribe_grid.F90
+++ b/src/core/MOM_transcribe_grid.F90
@@ -133,6 +133,7 @@ subroutine copy_dyngrid_to_MOM_grid(dG, oG, US)
 
   ! Copy various scalar variables and strings.
   oG%x_axis_units = dG%x_axis_units ; oG%y_axis_units = dG%y_axis_units
+  oG%x_ax_unit_short = dG%x_ax_unit_short ; oG%y_ax_unit_short = dG%y_ax_unit_short
   oG%areaT_global = dG%areaT_global ; oG%IareaT_global = dG%IareaT_global
   oG%south_lat = dG%south_lat ; oG%west_lon  = dG%west_lon
   oG%len_lat = dG%len_lat ; oG%len_lon = dG%len_lon
@@ -291,6 +292,7 @@ subroutine copy_MOM_grid_to_dyngrid(oG, dG, US)
 
   ! Copy various scalar variables and strings.
   dG%x_axis_units = oG%x_axis_units ; dG%y_axis_units = oG%y_axis_units
+  dG%x_ax_unit_short = oG%x_ax_unit_short ; dG%y_ax_unit_short = oG%y_ax_unit_short
   dG%areaT_global = oG%areaT_global ; dG%IareaT_global = oG%IareaT_global
   dG%south_lat = oG%south_lat ; dG%west_lon  = oG%west_lon
   dG%len_lat = oG%len_lat ; dG%len_lon = oG%len_lon

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -145,9 +145,12 @@ type, public :: dyn_horgrid_type
         !< The longitude of B points for the purpose of labeling the output axes.
         !! On many grids this is the same as geoLonBu.
   character(len=40) :: &
+    ! Except on a Cartesian grid, these are usually some variant of "degrees".
     x_axis_units, &     !< The units that are used in labeling the x coordinate axes.
-    y_axis_units        !< The units that are used in labeling the y coordinate axes.
-    ! Except on a Cartesian grid, these are usually  some variant of "degrees".
+    y_axis_units, &     !< The units that are used in labeling the y coordinate axes.
+    ! These are internally generated names, including "m", "km", "deg_E" and "deg_N".
+    x_ax_unit_short, &  !< A short description of the x-axis units for documenting parameter units
+    y_ax_unit_short     !< A short description of the y-axis units for documenting parameter units
 
   real, allocatable, dimension(:,:) :: &
     bathyT        !< Ocean bottom depth at tracer points, in depth units [Z ~> m].
@@ -382,6 +385,8 @@ subroutine rotate_dyn_horgrid(G_in, G, US, turns)
 
   G%x_axis_units = G_in%y_axis_units
   G%y_axis_units = G_in%x_axis_units
+  G%x_ax_unit_short = G_in%y_ax_unit_short
+  G%y_ax_unit_short = G_in%x_ax_unit_short
   G%south_lat = G_in%south_lat
   G%west_lon = G_in%west_lon
   G%len_lat = G_in%len_lat

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -42,8 +42,9 @@ type, private :: diag_type
   integer :: fms_diag_id         !< underlying FMS diag id
   character(len=24) :: name      !< The diagnostic name
   real :: conversion_factor = 0. !< A factor to multiply data by before posting to FMS, if non-zero.
-  real, pointer, dimension(:,:)   :: mask2d => null()      !< A 2-d mask on the data domain for this diagnostic
-  real, pointer, dimension(:,:)   :: mask2d_comp => null() !< A 2-d mask on the computational domain for this diagnostic
+  real, pointer, dimension(:,:)   :: mask2d => null()      !< A 2-d mask on the data domain for this diagnostic [nondim]
+  real, pointer, dimension(:,:)   :: mask2d_comp => null() !< A 2-d mask on the computational domain
+                                                           !! for this diagnostic [nondim]
 end type diag_type
 
 !>   The SIS_diag_ctrl data type contains times to regulate diagnostics along with masks and
@@ -64,7 +65,7 @@ type, public :: diag_ctrl
   integer :: ied !< The end i-index of cell centers within the data domain
   integer :: jsd !< The start j-index of cell centers within the data domain
   integer :: jed !< The end j-index of cell centers within the data domain
-  real :: time_int              !< The time interval in s for any fields that are offered for averaging.
+  real :: time_int              !< The time interval for any fields that are offered for averaging [s].
   type(time_type) :: time_end   !< The end time of the valid interval for any offered field.
   logical :: ave_enabled = .false. !< .true. if averaging is enabled.
 
@@ -89,7 +90,7 @@ type, public :: diag_ctrl
 #define DIAG_ALLOC_CHUNK_SIZE 15
   type(diag_type), dimension(:), allocatable :: diags !< The array of diagnostics
   integer :: next_free_diag_id !< The next unused diagnostic ID
-  !> default missing value to be sent to ALL diagnostics registerations
+  !> default missing value to be sent to ALL diagnostics registerations [various]
   real :: missing_value = -1.0e34
 
   type(unit_scale_type), pointer :: US => null() !< A dimensional unit scaling type
@@ -101,8 +102,8 @@ contains
 !> Set up the grid and axis information for use by the ice shelf model.
 subroutine set_IS_axes_info(G, param_file, diag_cs, axes_set_name)
   type(ocean_grid_type), intent(inout) :: G   !< The horizontal grid type
-  type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
-  type(diag_ctrl),     intent(inout) :: diag_cs !< A structure that is used to regulate diagnostic output
+  type(param_file_type), intent(in)    :: param_file !< A structure to parse for run-time parameters
+  type(diag_ctrl),       intent(inout) :: diag_cs !< A structure that is used to regulate diagnostic output
   character(len=*), optional, intent(in) :: axes_set_name !<  A name to use for this set of axes.
                                                 !! The default is "ice".
 !   This subroutine sets up the grid and axis information for use by the ice shelf model.
@@ -111,8 +112,8 @@ subroutine set_IS_axes_info(G, param_file, diag_cs, axes_set_name)
   integer :: id_xq, id_yq, id_xh, id_yh
   logical :: Cartesian_grid
   character(len=80) :: grid_config, units_temp, set_name
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "MOM_IS_diag_mediator" ! This module's name.
 
   set_name = "ice_shelf" ; if (present(axes_set_name)) set_name = trim(axes_set_name)
@@ -128,8 +129,9 @@ subroutine set_IS_axes_info(G, param_file, diag_cs, axes_set_name)
                  "\t spherical - a spherical grid \n"//&
                  "\t mercator  - a Mercator grid", fail_if_missing=.true.)
 
-  G%x_axis_units = "degrees_E"
-  G%y_axis_units = "degrees_N"
+  G%x_axis_units = "degrees_E" ; G%y_axis_units = "degrees_N"
+  G%x_ax_unit_short = "degrees_E" ; G%y_ax_unit_short = "degrees_N"
+
   if (index(lowercase(trim(grid_config)),"cartesian") > 0) then
     ! This is a cartesian grid, and may have different axis units.
     Cartesian_grid = .true.
@@ -141,8 +143,10 @@ subroutine set_IS_axes_info(G, param_file, diag_cs, axes_set_name)
                  "implemented.", default='degrees')
     if (units_temp(1:1) == 'k') then
       G%x_axis_units = "kilometers" ; G%y_axis_units = "kilometers"
+      G%x_ax_unit_short = "km" ; G%y_ax_unit_short = "km"
     elseif (units_temp(1:1) == 'm') then
       G%x_axis_units = "meters" ; G%y_axis_units = "meters"
+      G%x_ax_unit_short = "m" ; G%y_ax_unit_short = "m"
     endif
     call log_param(param_file, mdl, "explicit AXIS_UNITS", G%x_axis_units)
   else
@@ -343,12 +347,11 @@ end subroutine post_IS_data
 
 !> Enable the accumulation of time averages over the specified time interval.
 subroutine enable_averaging(time_int_in, time_end_in, diag_cs)
-  real,                intent(in)    :: time_int_in !< The time interval over which any values
-!                                                   !! that are offered are valid [s].
-  type(time_type),     intent(in)    :: time_end_in !< The end time of the valid interval.
-  type(diag_ctrl), intent(inout) :: diag_cs !< A structure that is used to regulate diagnostic output
-! This subroutine enables the accumulation of time averages over the
-! specified time interval.
+  real,            intent(in)    :: time_int_in !< The time interval over which any values
+                                                !! that are offered are valid [s].
+  type(time_type), intent(in)    :: time_end_in !< The end time of the valid interval.
+  type(diag_ctrl), intent(inout) :: diag_cs     !< A structure that is used to regulate diagnostic output
+  ! This subroutine enables the accumulation of time averages over the specified time interval.
 
 !  if (num_file==0) return
   diag_cs%time_int = time_int_in
@@ -371,8 +374,8 @@ subroutine enable_averages(time_int, time_end, diag_CS, T_to_s)
                                              !! that are offered are valid [T ~> s].
   type(time_type), intent(in)    :: time_end !< The end time of the valid interval.
   type(diag_ctrl), intent(inout) :: diag_CS  !< A structure that is used to regulate diagnostic output
-  real,  optional, intent(in)    :: T_to_s   !< A conversion factor for time_int to [s].
-! This subroutine enables the accumulation of time averages over the specified time interval.
+  real,  optional, intent(in)    :: T_to_s   !< A conversion factor for time_int to seconds [s T-1 ~> 1].
+  ! This subroutine enables the accumulation of time averages over the specified time interval.
 
   if (present(T_to_s)) then
     diag_cs%time_int = time_int*T_to_s

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -59,11 +59,11 @@ subroutine circle_obcs_initialize_thickness(h, depth_tot, G, GV, param_file, jus
   ! Parameters read by cartesian grid initialization
   call get_param(param_file, mdl, "DISK_RADIUS", diskrad, &
                  "The radius of the initially elevated disk in the "//&
-                 "circle_obcs test case.", units=G%x_axis_units, &
+                 "circle_obcs test case.", units=G%x_ax_unit_short, &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "DISK_X_OFFSET", xOffset, &
                  "The x-offset of the initially elevated disk in the "//&
-                 "circle_obcs test case.", units=G%x_axis_units, &
+                 "circle_obcs test case.", units=G%x_ax_unit_short, &
                  default = 0.0, do_not_log=just_read)
   call get_param(param_file, mdl, "DISK_IC_AMPLITUDE", IC_amp, &
                  "Initial amplitude of interface height displacements "//&


### PR DESCRIPTION
  Added the new elements x_ax_unit_short and y_ax_unit_short to the ocean_grid_type and the dyn_horgrid_type to facilitate the documentation of the units of variables when they depend on the units of the axes.  This includes modifying some units that were being reported as the meaningless "[k]" into the meaningful "[km]", and some units that were being reported as just "[degrees]" are now being reported with the more specific "[degrees_E]" or "[degrees_N]". These new elements are also being used in the baroclinic_zone_initialization and circle_OBCs modules, and comments describing the units of a number of the internal variables in the former module were added or modified.  The description of the AXIS_UNITS parameter was expanded to provide some of the other working options.  All answers are bitwise identical, but there are minor changes in a number of the MOM_parameter_doc files.