### PR TITLE
+Rescale driver timestep variables and step_MOM args

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -221,7 +221,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   type(time_type),         intent(in)    :: Time   !< The time of the fluxes, used for interpolating the
                                                    !! salinity to the right time, when it is being restored.
   real,                    intent(in)    :: valid_time !< The amount of time over which these fluxes
-                                                   !! should be applied [s].
+                                                   !! should be applied [T ~> s].
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure
   type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   type(surface_forcing_CS),pointer       :: CS     !< A pointer to the control structure returned by a
@@ -333,7 +333,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! Indicate that there are new unused fluxes.
   fluxes%fluxes_used = .false.
-  fluxes%dt_buoy_accum = US%s_to_T*valid_time
+  fluxes%dt_buoy_accum = valid_time
 
   fluxes%heat_added(:,:) = 0.0
   fluxes%salt_flux_added(:,:) = 0.0
@@ -581,7 +581,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 !#CTRL#     SSS_mean(i,j) = 0.5*(sfc_state%SSS(i,j) + CS%S_Restore(i,j))
 !#CTRL#   enddo ; enddo
 !#CTRL#   call apply_ctrl_forcing(SST_anom, SSS_anom, SSS_mean, fluxes%heat_added, &
-!#CTRL#                           fluxes%vprec, day, US%s_to_T*valid_time, G, US, CS%ctrl_forcing_CSp)
+!#CTRL#                           fluxes%vprec, day, valid_time, G, US, CS%ctrl_forcing_CSp)
 !#CTRL# endif
 
   ! adjust the NET fresh-water flux to zero, if flagged
@@ -663,7 +663,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS, dt_
                                                    !! previous call to surface_forcing_init.
   real,          optional, intent(in)    :: dt_forcing !< A time interval over which to apply the
                                                    !! current value of ustar as a weighted running
-                                                   !! average [s], or if 0 do not average ustar.
+                                                   !! average [T ~> s], or if 0 do not average ustar.
                                                    !! Missing is equivalent to 0.
   logical,       optional, intent(in)    :: reset_avg !< If true, reset the time average.
 

--- a/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
+++ b/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
@@ -512,17 +512,17 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
     ! Add ice shelf fluxes
     if (OS%use_ice_shelf) then
       if (do_thermo) &
-        call shelf_calc_flux(OS%sfc_state, OS%fluxes, OS%Time, OS%US%T_to_s*dt_coupling, OS%Ice_shelf_CSp)
+        call shelf_calc_flux(OS%sfc_state, OS%fluxes, OS%Time, dt_coupling, OS%Ice_shelf_CSp)
       if (do_dyn) &
         call add_shelf_forces(OS%grid, OS%US, OS%Ice_shelf_CSp, OS%forces)
     endif
     if (OS%icebergs_alter_ocean)  then
       if (do_dyn) &
         call iceberg_forces(OS%grid, OS%forces, OS%use_ice_shelf, &
-                            OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
+                            OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
       if (do_thermo) &
         call iceberg_fluxes(OS%grid, OS%US, OS%fluxes, OS%use_ice_shelf, &
-                          OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
+                          OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
     endif
 
     ! Fields that exist in both the forcing and mech_forcing types must be copied.
@@ -543,17 +543,17 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
 
     if (OS%use_ice_shelf) then
       if (do_thermo) &
-        call shelf_calc_flux(OS%sfc_state, OS%flux_tmp, OS%Time, OS%US%T_to_s*dt_coupling, OS%Ice_shelf_CSp)
+        call shelf_calc_flux(OS%sfc_state, OS%flux_tmp, OS%Time, dt_coupling, OS%Ice_shelf_CSp)
       if (do_dyn) &
         call add_shelf_forces(OS%grid, OS%US, OS%Ice_shelf_CSp, OS%forces)
     endif
     if (OS%icebergs_alter_ocean)  then
       if (do_dyn) &
         call iceberg_forces(OS%grid, OS%forces, OS%use_ice_shelf, &
-                            OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
+                            OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
       if (do_thermo) &
         call iceberg_fluxes(OS%grid, OS%US, OS%flux_tmp, OS%use_ice_shelf, &
-                          OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
+                          OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
     endif
 
     call forcing_accumulate(OS%flux_tmp, OS%forces, OS%fluxes, OS%grid, weight)
@@ -582,16 +582,16 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   Master_time = OS%Time ; Time1 = OS%Time
 
   if(OS%offline_tracer_mode) then
-    call step_offline(OS%forces, OS%fluxes, OS%sfc_state, Time1, OS%US%T_to_s*dt_coupling, OS%MOM_CSp)
+    call step_offline(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp)
 
   elseif ((.not.do_thermo) .or. (.not.do_dyn)) then
     ! The call sequence is being orchestrated from outside of update_ocean_model.
-    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, OS%US%T_to_s*dt_coupling, OS%MOM_CSp, &
+    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp, &
                   Waves=OS%Waves, do_dynamics=do_thermo, do_thermodynamics=do_dyn, &
                   reset_therm=Ocn_fluxes_used)
 
   elseif (OS%single_step_call) then
-    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, OS%US%T_to_s*dt_coupling, OS%MOM_CSp, Waves=OS%Waves)
+    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp, Waves=OS%Waves)
 
   else
     n_max = 1 ; if (dt_coupling > OS%dt) n_max = ceiling(dt_coupling/OS%dt - 0.001)
@@ -615,18 +615,18 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
             "THERMO_SPANS_COUPLING and DIABATIC_FIRST.")
         if (modulo(n-1,nts)==0) then
           dtdia = dt_dyn*min(nts,n_max-(n-1))
-          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dtdia, OS%MOM_CSp, &
+          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dtdia, OS%MOM_CSp, &
                         Waves=OS%Waves, do_dynamics=.false., do_thermodynamics=.true., &
-                        start_cycle=(n==1), end_cycle=.false., cycle_length=OS%US%T_to_s*dt_coupling)
+                        start_cycle=(n==1), end_cycle=.false., cycle_length=dt_coupling)
         endif
 
-        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dt_dyn, OS%MOM_CSp, &
+        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dt_dyn, OS%MOM_CSp, &
                       Waves=OS%Waves, do_dynamics=.true., do_thermodynamics=.false., &
-                      start_cycle=.false., end_cycle=(n==n_max), cycle_length=OS%US%T_to_s*dt_coupling)
+                      start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_coupling)
       else
-        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dt_dyn, OS%MOM_CSp, &
+        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dt_dyn, OS%MOM_CSp, &
                       Waves=OS%Waves, do_dynamics=.true., do_thermodynamics=.false., &
-                      start_cycle=(n==1), end_cycle=.false., cycle_length=OS%US%T_to_s*dt_coupling)
+                      start_cycle=(n==1), end_cycle=.false., cycle_length=dt_coupling)
 
         step_thermo = .false.
         if (thermo_does_span_coupling) then
@@ -641,9 +641,9 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
         if (step_thermo) then
           ! Back up Time2 to the start of the thermodynamic segment.
           Time2 = Time2 - set_time(int(floor(OS%US%T_to_s*(dtdia - dt_dyn) + 0.5)))
-          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dtdia, OS%MOM_CSp, &
+          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dtdia, OS%MOM_CSp, &
                         Waves=OS%Waves, do_dynamics=.false., do_thermodynamics=.true., &
-                        start_cycle=.false., end_cycle=(n==n_max), cycle_length=OS%US%T_to_s*dt_coupling)
+                        start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_coupling)
         endif
       endif
 
@@ -655,7 +655,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   OS%Time = Master_time + Ocean_coupling_time_step
   OS%nstep = OS%nstep + 1
 
-  call mech_forcing_diags(OS%forces, OS%US%T_to_s*dt_coupling, OS%grid, OS%Time, OS%diag, OS%forcing_CSp%handles)
+  call mech_forcing_diags(OS%forces, dt_coupling, OS%grid, OS%Time, OS%diag, OS%forcing_CSp%handles)
 
   if (OS%fluxes%fluxes_used) then
     call forcing_diagnostics(OS%fluxes, OS%sfc_state, OS%grid, OS%US, OS%Time, OS%diag, OS%forcing_CSp%handles)

--- a/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
+++ b/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
@@ -17,7 +17,7 @@ use MOM,                      only : get_MOM_state_elements, MOM_state_is_synchr
 use MOM,                      only : get_ocean_stocks, step_offline
 use MOM_coms,                 only : field_chksum
 use MOM_constants,            only : CELSIUS_KELVIN_OFFSET, hlf
-use MOM_diag_mediator,        only : diag_ctrl, enable_averaging, disable_averaging
+use MOM_diag_mediator,        only : diag_ctrl, enable_averages, disable_averaging
 use MOM_diag_mediator,        only : diag_mediator_close_registration, diag_mediator_end
 use MOM_domains,              only : pass_var, pass_vector, AGRID, BGRID_NE, CGRID_NE
 use MOM_domains,              only : TO_ALL, Omit_Corners
@@ -170,8 +170,8 @@ type, public :: ocean_state_type ;
                               !! If false, the two phases are advanced with
                               !! separate calls. The default is true.
   ! The following 3 variables are only used here if single_step_call is false.
-  real    :: dt               !< (baroclinic) dynamics time step (seconds)
-  real    :: dt_therm         !< thermodynamics time step (seconds)
+  real    :: dt               !< (baroclinic) dynamics time step [T ~> s]
+  real    :: dt_therm         !< thermodynamics time step [T ~> s]
   logical :: thermo_spans_coupling !< If true, thermodynamic and tracer time
                               !! steps can span multiple coupled time steps.
   logical :: diabatic_first   !< If true, apply diabatic and thermodynamic
@@ -285,16 +285,17 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                  "including both dynamics and thermodynamics.  If false, "//&
                  "the two phases are advanced with separate calls.", default=.true.)
   call get_param(param_file, mdl, "DT", OS%dt, &
-                 "The (baroclinic) dynamics time step.  The time-step that "//&
-                 "is actually used will be an integer fraction of the "//&
-                 "forcing time-step.", units="s", fail_if_missing=.true.)
+                 "The (baroclinic) dynamics time step.  The time-step that is actually "//&
+                 "used will be an integer fraction of the forcing time-step.", &
+                 units="s", scale=OS%US%s_to_T, fail_if_missing=.true.)
   call get_param(param_file, mdl, "DT_THERM", OS%dt_therm, &
                  "The thermodynamic and tracer advection time step. "//&
                  "Ideally DT_THERM should be an integer multiple of DT "//&
                  "and less than the forcing or coupling time-step, unless "//&
                  "THERMO_SPANS_COUPLING is true, in which case DT_THERM "//&
                  "can be an integer multiple of the coupling timestep.  By "//&
-                 "default DT_THERM is set to DT.", units="s", default=OS%dt)
+                 "default DT_THERM is set to DT.", &
+                 units="s", scale=OS%US%s_to_T, default=OS%US%T_to_s*OS%dt)
   call get_param(param_file, "MOM", "THERMO_SPANS_COUPLING", OS%thermo_spans_coupling, &
                  "If true, the MOM will take thermodynamic and tracer "//&
                  "timesteps that can be longer than the coupling timestep. "//&
@@ -448,13 +449,13 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   integer :: index_bnds(4)       ! The computational domain index bounds in the
                                  ! ice-ocean boundary type.
   real :: weight          ! Flux accumulation weight
-  real :: dt_coupling     ! The coupling time step in seconds.
+  real :: dt_coupling     ! The coupling time step [T ~> s]
   integer :: nts          ! The number of baroclinic dynamics time steps
                           ! within dt_coupling.
-  real :: dt_therm        ! A limited and quantized version of OS%dt_therm (sec)
-  real :: dt_dyn          ! The dynamics time step in sec.
-  real :: dtdia           ! The diabatic time step in sec.
-  real :: t_elapsed_seg   ! The elapsed time in this update segment, in s.
+  real :: dt_therm        ! A limited and quantized version of OS%dt_therm [T ~> s]
+  real :: dt_dyn          ! The dynamics time step [T ~> s]
+  real :: dtdia           ! The diabatic time step [T ~> s]
+  real :: t_elapsed_seg   ! The elapsed time in this update segment [T ~> s]
   integer :: n, n_max, n_last_thermo
   type(time_type) :: Time2  ! A temporary time.
   logical :: thermo_does_span_coupling ! If true, thermodynamic forcing spans
@@ -467,7 +468,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
 
   call callTree_enter("update_ocean_model(), MOM_ocean_model_mct.F90")
   call get_time(Ocean_coupling_time_step, secs, days)
-  dt_coupling = 86400.0*real(days) + real(secs)
+  dt_coupling = OS%US%s_to_T*(86400.0*real(days) + real(secs))
 
   if (time_start_update /= OS%Time) then
     call MOM_error(WARNING, "update_ocean_model: internal clock does not "//&
@@ -501,7 +502,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   if (OS%fluxes%fluxes_used) then
 
     ! GMM, is enable_averaging needed now?
-    call enable_averaging(dt_coupling, OS%Time + Ocean_coupling_time_step, OS%diag)
+    call enable_averages(dt_coupling, OS%Time + Ocean_coupling_time_step, OS%diag)
 
     if (do_thermo) &
       call convert_IOB_to_fluxes(Ice_ocean_boundary, OS%fluxes, index_bnds, OS%Time, dt_coupling, &
@@ -511,24 +512,24 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
     ! Add ice shelf fluxes
     if (OS%use_ice_shelf) then
       if (do_thermo) &
-        call shelf_calc_flux(OS%sfc_state, OS%fluxes, OS%Time, dt_coupling, OS%Ice_shelf_CSp)
+        call shelf_calc_flux(OS%sfc_state, OS%fluxes, OS%Time, OS%US%T_to_s*dt_coupling, OS%Ice_shelf_CSp)
       if (do_dyn) &
         call add_shelf_forces(OS%grid, OS%US, OS%Ice_shelf_CSp, OS%forces)
     endif
     if (OS%icebergs_alter_ocean)  then
       if (do_dyn) &
         call iceberg_forces(OS%grid, OS%forces, OS%use_ice_shelf, &
-                            OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
+                            OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
       if (do_thermo) &
         call iceberg_fluxes(OS%grid, OS%US, OS%fluxes, OS%use_ice_shelf, &
-                          OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
+                          OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
     endif
 
     ! Fields that exist in both the forcing and mech_forcing types must be copied.
     call copy_common_forcing_fields(OS%forces, OS%fluxes, OS%grid)
 
 #ifdef _USE_GENERIC_TRACER
-    call enable_averaging(dt_coupling, OS%Time + Ocean_coupling_time_step, OS%diag) !Is this needed?
+    call enable_averages(dt_coupling, OS%Time + Ocean_coupling_time_step, OS%diag) !Is this needed?
     call MOM_generic_tracer_fluxes_accumulate(OS%fluxes, weight) !here weight=1, just saving the current fluxes
 #endif
 
@@ -542,17 +543,17 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
 
     if (OS%use_ice_shelf) then
       if (do_thermo) &
-        call shelf_calc_flux(OS%sfc_state, OS%flux_tmp, OS%Time, dt_coupling, OS%Ice_shelf_CSp)
+        call shelf_calc_flux(OS%sfc_state, OS%flux_tmp, OS%Time, OS%US%T_to_s*dt_coupling, OS%Ice_shelf_CSp)
       if (do_dyn) &
         call add_shelf_forces(OS%grid, OS%US, OS%Ice_shelf_CSp, OS%forces)
     endif
     if (OS%icebergs_alter_ocean)  then
       if (do_dyn) &
         call iceberg_forces(OS%grid, OS%forces, OS%use_ice_shelf, &
-                            OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
+                            OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
       if (do_thermo) &
         call iceberg_fluxes(OS%grid, OS%US, OS%flux_tmp, OS%use_ice_shelf, &
-                          OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
+                          OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
     endif
 
     call forcing_accumulate(OS%flux_tmp, OS%forces, OS%fluxes, OS%grid, weight)
@@ -581,16 +582,16 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   Master_time = OS%Time ; Time1 = OS%Time
 
   if(OS%offline_tracer_mode) then
-    call step_offline(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp)
+    call step_offline(OS%forces, OS%fluxes, OS%sfc_state, Time1, OS%US%T_to_s*dt_coupling, OS%MOM_CSp)
 
   elseif ((.not.do_thermo) .or. (.not.do_dyn)) then
     ! The call sequence is being orchestrated from outside of update_ocean_model.
-    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp, &
+    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, OS%US%T_to_s*dt_coupling, OS%MOM_CSp, &
                   Waves=OS%Waves, do_dynamics=do_thermo, do_thermodynamics=do_dyn, &
                   reset_therm=Ocn_fluxes_used)
 
   elseif (OS%single_step_call) then
-    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp, Waves=OS%Waves)
+    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, OS%US%T_to_s*dt_coupling, OS%MOM_CSp, Waves=OS%Waves)
 
   else
     n_max = 1 ; if (dt_coupling > OS%dt) n_max = ceiling(dt_coupling/OS%dt - 0.001)
@@ -614,18 +615,18 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
             "THERMO_SPANS_COUPLING and DIABATIC_FIRST.")
         if (modulo(n-1,nts)==0) then
           dtdia = dt_dyn*min(nts,n_max-(n-1))
-          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dtdia, OS%MOM_CSp, &
+          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dtdia, OS%MOM_CSp, &
                         Waves=OS%Waves, do_dynamics=.false., do_thermodynamics=.true., &
-                        start_cycle=(n==1), end_cycle=.false., cycle_length=dt_coupling)
+                        start_cycle=(n==1), end_cycle=.false., cycle_length=OS%US%T_to_s*dt_coupling)
         endif
 
-        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dt_dyn, OS%MOM_CSp, &
+        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dt_dyn, OS%MOM_CSp, &
                       Waves=OS%Waves, do_dynamics=.true., do_thermodynamics=.false., &
-                      start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_coupling)
+                      start_cycle=.false., end_cycle=(n==n_max), cycle_length=OS%US%T_to_s*dt_coupling)
       else
-        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dt_dyn, OS%MOM_CSp, &
+        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dt_dyn, OS%MOM_CSp, &
                       Waves=OS%Waves, do_dynamics=.true., do_thermodynamics=.false., &
-                      start_cycle=(n==1), end_cycle=.false., cycle_length=dt_coupling)
+                      start_cycle=(n==1), end_cycle=.false., cycle_length=OS%US%T_to_s*dt_coupling)
 
         step_thermo = .false.
         if (thermo_does_span_coupling) then
@@ -639,22 +640,22 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
 
         if (step_thermo) then
           ! Back up Time2 to the start of the thermodynamic segment.
-          Time2 = Time2 - set_time(int(floor((dtdia - dt_dyn) + 0.5)))
-          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dtdia, OS%MOM_CSp, &
+          Time2 = Time2 - set_time(int(floor(OS%US%T_to_s*(dtdia - dt_dyn) + 0.5)))
+          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dtdia, OS%MOM_CSp, &
                         Waves=OS%Waves, do_dynamics=.false., do_thermodynamics=.true., &
-                        start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_coupling)
+                        start_cycle=.false., end_cycle=(n==n_max), cycle_length=OS%US%T_to_s*dt_coupling)
         endif
       endif
 
       t_elapsed_seg = t_elapsed_seg + dt_dyn
-      Time2 = Time1 + set_time(int(floor(t_elapsed_seg + 0.5)))
+      Time2 = Time1 + set_time(int(floor(OS%US%T_to_s*t_elapsed_seg + 0.5)))
     enddo
   endif
 
   OS%Time = Master_time + Ocean_coupling_time_step
   OS%nstep = OS%nstep + 1
 
-  call mech_forcing_diags(OS%forces, dt_coupling, OS%grid, OS%Time, OS%diag, OS%forcing_CSp%handles)
+  call mech_forcing_diags(OS%forces, OS%US%T_to_s*dt_coupling, OS%grid, OS%Time, OS%diag, OS%forcing_CSp%handles)
 
   if (OS%fluxes%fluxes_used) then
     call forcing_diagnostics(OS%fluxes, OS%sfc_state, OS%grid, OS%US, OS%Time, OS%diag, OS%forcing_CSp%handles)

--- a/config_src/drivers/mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/mct_cap/mom_surface_forcing_mct.F90
@@ -206,7 +206,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   type(time_type),         intent(in)    :: Time   !< The time of the fluxes, used for interpolating the
                                                    !! salinity to the right time, when it is being restored.
   real,                    intent(in)    :: valid_time !< The amount of time over which these fluxes
-                                                   !! should be applied [s].
+                                                   !! should be applied [T ~> s].
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure
   type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   type(surface_forcing_CS),pointer       :: CS     !< A pointer to the control structure returned by a
@@ -334,7 +334,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! Indicate that there are new unused fluxes.
   fluxes%fluxes_used = .false.
-  fluxes%dt_buoy_accum = US%s_to_T*valid_time
+  fluxes%dt_buoy_accum = valid_time
 
   if (CS%allow_flux_adjustments) then
     fluxes%heat_added(:,:) = 0.0

--- a/config_src/drivers/mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/mct_cap/mom_surface_forcing_mct.F90
@@ -444,7 +444,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     end if
 
     if (associated(IOB%ustar_berg)) &
-      fluxes%ustar_berg(i,j) = US%m_to_Z * IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)
+      fluxes%ustar_berg(i,j) = US%m_to_Z*US%T_to_s * IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)
 
     if (associated(IOB%area_berg)) &
       fluxes%area_berg(i,j) = IOB%area_berg(i-i0,j-j0) * G%mask2dT(i,j)

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -17,7 +17,7 @@ use MOM,                     only : get_MOM_state_elements, MOM_state_is_synchro
 use MOM,                     only : get_ocean_stocks, step_offline
 use MOM_coms,                only : field_chksum
 use MOM_constants,           only : CELSIUS_KELVIN_OFFSET, hlf
-use MOM_diag_mediator,       only : diag_ctrl, enable_averaging, disable_averaging
+use MOM_diag_mediator,       only : diag_ctrl, enable_averages, disable_averaging
 use MOM_diag_mediator,       only : diag_mediator_close_registration, diag_mediator_end
 use MOM_domains,             only : pass_var, pass_vector, AGRID, BGRID_NE, CGRID_NE
 use MOM_domains,             only : TO_ALL, Omit_Corners
@@ -171,7 +171,7 @@ type, public :: ocean_state_type ; private
                               !! separate calls. The default is true.
   ! The following 3 variables are only used here if single_step_call is false.
   real    :: dt               !< (baroclinic) dynamics time step (seconds)
-  real    :: dt_therm         !< thermodynamics time step (seconds)
+  real    :: dt_therm         !< thermodynamics time step [T ~> s]
   logical :: thermo_spans_coupling !< If true, thermodynamic and tracer time
                               !! steps can span multiple coupled time steps.
   logical :: diabatic_first   !< If true, apply diabatic and thermodynamic
@@ -295,16 +295,17 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                  "including both dynamics and thermodynamics.  If false, "//&
                  "the two phases are advanced with separate calls.", default=.true.)
   call get_param(param_file, mdl, "DT", OS%dt, &
-                 "The (baroclinic) dynamics time step.  The time-step that "//&
-                 "is actually used will be an integer fraction of the "//&
-                 "forcing time-step.", units="s", fail_if_missing=.true.)
+                 "The (baroclinic) dynamics time step.  The time-step that is actually "//&
+                 "used will be an integer fraction of the forcing time-step.", &
+                 units="s", scale=OS%US%s_to_T, fail_if_missing=.true.)
   call get_param(param_file, mdl, "DT_THERM", OS%dt_therm, &
                  "The thermodynamic and tracer advection time step. "//&
                  "Ideally DT_THERM should be an integer multiple of DT "//&
                  "and less than the forcing or coupling time-step, unless "//&
                  "THERMO_SPANS_COUPLING is true, in which case DT_THERM "//&
                  "can be an integer multiple of the coupling timestep.  By "//&
-                 "default DT_THERM is set to DT.", units="s", default=OS%dt)
+                 "default DT_THERM is set to DT.", &
+                 units="s", default=OS%US%T_to_s*OS%dt, scale=OS%US%s_to_T)
   call get_param(param_file, "MOM", "THERMO_SPANS_COUPLING", OS%thermo_spans_coupling, &
                  "If true, the MOM will take thermodynamic and tracer "//&
                  "timesteps that can be longer than the coupling timestep. "//&
@@ -489,13 +490,13 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   integer :: index_bnds(4)       ! The computational domain index bounds in the
                                  ! ice-ocean boundary type.
   real :: weight          ! Flux accumulation weight
-  real :: dt_coupling     ! The coupling time step in seconds.
+  real :: dt_coupling     ! The coupling time step in rescaled seconds [T ~> s].
   integer :: nts          ! The number of baroclinic dynamics time steps
                           ! within dt_coupling.
-  real :: dt_therm        ! A limited and quantized version of OS%dt_therm (sec)
-  real :: dt_dyn          ! The dynamics time step in sec.
-  real :: dtdia           ! The diabatic time step in sec.
-  real :: t_elapsed_seg   ! The elapsed time in this update segment, in s.
+  real :: dt_therm        ! A limited and quantized version of OS%dt_therm [T ~> s]
+  real :: dt_dyn          ! The dynamics time step [T ~> s]
+  real :: dtdia           ! The diabatic time step [T ~> s]
+  real :: t_elapsed_seg   ! The elapsed time in this update segment [T ~> s]
   integer :: n, n_max, n_last_thermo
   type(time_type) :: Time2  ! A temporary time.
   logical :: thermo_does_span_coupling ! If true, thermodynamic forcing spans
@@ -508,7 +509,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
 
   call callTree_enter("update_ocean_model(), MOM_ocean_model_nuopc.F90")
   call get_time(Ocean_coupling_time_step, secs, days)
-  dt_coupling = 86400.0*real(days) + real(secs)
+  dt_coupling = OS%US%s_to_T*(86400.0*real(days) + real(secs))
 
   if (time_start_update /= OS%Time) then
     call MOM_error(WARNING, "update_ocean_model: internal clock does not "//&
@@ -547,45 +548,45 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
     ! Add ice shelf fluxes
     if (OS%use_ice_shelf) then
       if (do_thermo) &
-        call shelf_calc_flux(OS%sfc_state, OS%fluxes, OS%Time, dt_coupling, OS%Ice_shelf_CSp)
+        call shelf_calc_flux(OS%sfc_state, OS%fluxes, OS%Time, OS%US%T_to_s*dt_coupling, OS%Ice_shelf_CSp)
       if (do_dyn) &
         call add_shelf_forces(OS%grid, OS%US, OS%Ice_shelf_CSp, OS%forces)
     endif
     if (OS%icebergs_alter_ocean)  then
       if (do_dyn) &
         call iceberg_forces(OS%grid, OS%forces, OS%use_ice_shelf, &
-                            OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
+                            OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
       if (do_thermo) &
         call iceberg_fluxes(OS%grid, OS%US, OS%fluxes, OS%use_ice_shelf, &
-                          OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
+                          OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
     endif
 
     ! Fields that exist in both the forcing and mech_forcing types must be copied.
     call copy_common_forcing_fields(OS%forces, OS%fluxes, OS%grid, skip_pres=.true.)
 
 #ifdef _USE_GENERIC_TRACER
-    call enable_averaging(dt_coupling, OS%Time + Ocean_coupling_time_step, OS%diag) !Is this needed?
+    call enable_averages(dt_coupling, OS%Time + Ocean_coupling_time_step, OS%diag) !Is this needed?
     call MOM_generic_tracer_fluxes_accumulate(OS%fluxes, weight) !here weight=1, just saving the current fluxes
 #endif
   else
     OS%flux_tmp%C_p = OS%fluxes%C_p
     if (do_thermo) &
       call convert_IOB_to_fluxes(Ice_ocean_boundary, OS%flux_tmp, index_bnds, OS%Time, dt_coupling, &
-                               OS%grid, OS%US, OS%forcing_CSp, OS%sfc_state, OS%restore_salinity,OS%restore_temp)
+                               OS%grid, OS%US, OS%forcing_CSp, OS%sfc_state, OS%restore_salinity, OS%restore_temp)
 
     if (OS%use_ice_shelf) then
       if (do_thermo) &
-        call shelf_calc_flux(OS%sfc_state, OS%flux_tmp, OS%Time, dt_coupling, OS%Ice_shelf_CSp)
+        call shelf_calc_flux(OS%sfc_state, OS%flux_tmp, OS%Time, OS%US%T_to_s*dt_coupling, OS%Ice_shelf_CSp)
       if (do_dyn) &
         call add_shelf_forces(OS%grid, OS%US, OS%Ice_shelf_CSp, OS%forces)
     endif
     if (OS%icebergs_alter_ocean)  then
       if (do_dyn) &
         call iceberg_forces(OS%grid, OS%forces, OS%use_ice_shelf, &
-                            OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
+                            OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
       if (do_thermo) &
         call iceberg_fluxes(OS%grid, OS%US, OS%flux_tmp, OS%use_ice_shelf, &
-                          OS%sfc_state, dt_coupling, OS%marine_ice_CSp)
+                          OS%sfc_state, OS%US%T_to_s*dt_coupling, OS%marine_ice_CSp)
     endif
 
     call forcing_accumulate(OS%flux_tmp, OS%forces, OS%fluxes, OS%grid, weight)
@@ -614,16 +615,16 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   Master_time = OS%Time ; Time1 = OS%Time
 
   if (OS%offline_tracer_mode) then
-    call step_offline(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp)
+    call step_offline(OS%forces, OS%fluxes, OS%sfc_state, Time1, OS%US%T_to_s*dt_coupling, OS%MOM_CSp)
   elseif ((.not.do_thermo) .or. (.not.do_dyn)) then
     ! The call sequence is being orchestrated from outside of update_ocean_model.
-    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp, &
+    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, OS%US%T_to_s*dt_coupling, OS%MOM_CSp, &
                   Waves=OS%Waves, do_dynamics=do_thermo, do_thermodynamics=do_dyn, &
                   reset_therm=Ocn_fluxes_used)
- !### What to do with these?   , start_cycle=(n==1), end_cycle=.false., cycle_length=dt_coupling)
+ !### What to do with these?   , start_cycle=(n==1), end_cycle=.false., cycle_length=OS%US%T_to_s*dt_coupling)
 
   elseif (OS%single_step_call) then
-    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp, Waves=OS%Waves)
+    call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, OS%US%T_to_s*dt_coupling, OS%MOM_CSp, Waves=OS%Waves)
   else
     n_max = 1 ; if (dt_coupling > OS%dt) n_max = ceiling(dt_coupling/OS%dt - 0.001)
     dt_dyn = dt_coupling / real(n_max)
@@ -646,18 +647,18 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
             "THERMO_SPANS_COUPLING and DIABATIC_FIRST.")
         if (modulo(n-1,nts)==0) then
           dtdia = dt_dyn*min(nts,n_max-(n-1))
-          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dtdia, OS%MOM_CSp, &
+          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dtdia, OS%MOM_CSp, &
                         Waves=OS%Waves, do_dynamics=.false., do_thermodynamics=.true., &
-                        start_cycle=(n==1), end_cycle=.false., cycle_length=dt_coupling)
+                        start_cycle=(n==1), end_cycle=.false., cycle_length=OS%US%T_to_s*dt_coupling)
         endif
 
-        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dt_dyn, OS%MOM_CSp, &
+        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dt_dyn, OS%MOM_CSp, &
                       Waves=OS%Waves, do_dynamics=.true., do_thermodynamics=.false., &
-                      start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_coupling)
+                      start_cycle=.false., end_cycle=(n==n_max), cycle_length=OS%US%T_to_s*dt_coupling)
       else
-        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dt_dyn, OS%MOM_CSp, &
+        call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dt_dyn, OS%MOM_CSp, &
                       Waves=OS%Waves, do_dynamics=.true., do_thermodynamics=.false., &
-                      start_cycle=(n==1), end_cycle=.false., cycle_length=dt_coupling)
+                      start_cycle=(n==1), end_cycle=.false., cycle_length=OS%US%T_to_s*dt_coupling)
 
         step_thermo = .false.
         if (thermo_does_span_coupling) then
@@ -671,22 +672,22 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
 
         if (step_thermo) then
           ! Back up Time2 to the start of the thermodynamic segment.
-          Time2 = Time2 - set_time(int(floor((dtdia - dt_dyn) + 0.5)))
-          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, dtdia, OS%MOM_CSp, &
+          Time2 = Time2 - set_time(int(floor(OS%US%T_to_s*(dtdia - dt_dyn) + 0.5)))
+          call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time2, OS%US%T_to_s*dtdia, OS%MOM_CSp, &
                         Waves=OS%Waves, do_dynamics=.false., do_thermodynamics=.true., &
-                        start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_coupling)
+                        start_cycle=.false., end_cycle=(n==n_max), cycle_length=OS%US%T_to_s*dt_coupling)
         endif
       endif
 
       t_elapsed_seg = t_elapsed_seg + dt_dyn
-      Time2 = Time1 + set_time(int(floor(t_elapsed_seg + 0.5)))
+      Time2 = Time1 + set_time(int(floor(OS%US%T_to_s*t_elapsed_seg + 0.5)))
     enddo
   endif
 
   OS%Time = Master_time + Ocean_coupling_time_step
   OS%nstep = OS%nstep + 1
 
-  call mech_forcing_diags(OS%forces, dt_coupling, OS%grid, OS%Time, OS%diag, OS%forcing_CSp%handles)
+  call mech_forcing_diags(OS%forces, OS%US%T_to_s*dt_coupling, OS%grid, OS%Time, OS%diag, OS%forcing_CSp%handles)
 
   if (OS%fluxes%fluxes_used) then
     if (cesm_coupled) then

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -233,7 +233,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   type(time_type),         intent(in)    :: Time   !< The time of the fluxes, used for interpolating the
                                                    !! salinity to the right time, when it is being restored.
   real,                    intent(in)    :: valid_time !< The amount of time over which these fluxes
-                                                   !! should be applied [s].
+                                                   !! should be applied [T ~> s].
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure
   type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
   type(surface_forcing_CS),pointer       :: CS     !< A pointer to the control structure returned by a
@@ -363,7 +363,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! Indicate that there are new unused fluxes.
   fluxes%fluxes_used = .false.
-  fluxes%dt_buoy_accum = US%s_to_T*valid_time
+  fluxes%dt_buoy_accum = valid_time
 
   if (CS%allow_flux_adjustments) then
     fluxes%heat_added(:,:)=0.0

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -27,8 +27,7 @@ program MOM6
   use MOM_cpu_clock,       only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
   use MOM_cpu_clock,       only : CLOCK_COMPONENT
   use MOM_data_override,   only : data_override_init
-  use MOM_diag_mediator,   only : enable_averaging, disable_averaging, diag_mediator_end
-  use MOM_diag_mediator,   only : diag_ctrl, diag_mediator_close_registration
+  use MOM_diag_mediator,   only : diag_mediator_end, diag_ctrl, diag_mediator_close_registration
   use MOM,                 only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
   use MOM,                 only : extract_surface_state, finish_MOM_initialization
   use MOM,                 only : get_MOM_state_elements, MOM_state_is_synchronized
@@ -122,20 +121,18 @@ program MOM6
   type(time_type) :: Time_step_ocean    ! A time_type version of dt_forcing.
   logical :: segment_start_time_set     ! True if segment_start_time has been set to a valid value.
 
-  real    :: elapsed_time = 0.0   ! Elapsed time in this run  [s].
-  logical :: elapsed_time_master  ! If true, elapsed time is used to set the
-                                  ! model's master clock (Time).  This is needed
-                                  ! if Time_step_ocean is not an exact
-                                  ! representation of dt_forcing.
-  real :: dt_forcing              ! The coupling time step [s].
-  real :: dt                      ! The nominal baroclinic dynamics time step [s].
-  integer :: ntstep               ! The number of baroclinic dynamics time steps
-                                  ! within dt_forcing.
-  real :: dt_therm                ! The thermodynamic timestep [s]
-  real :: dt_dyn                  ! The actual dynamic timestep used [s].  The value of dt_dyn is
-                                  ! chosen so that dt_forcing is an integer multiple of dt_dyn.
-  real :: dtdia                   ! The diabatic timestep [s]
-  real :: t_elapsed_seg           ! The elapsed time in this run segment [s]
+  real    :: elapsed_time = 0.0   ! Elapsed time in this run [T ~> s].
+  logical :: elapsed_time_master  ! If true, elapsed time is used to set the model's master
+                                  ! clock (Time).  This is needed if Time_step_ocean is not
+                                  ! an exact representation of dt_forcing.
+  real :: dt_forcing              ! The coupling time step [T ~> s].
+  real :: dt                      ! The nominal baroclinic dynamics time step [T ~> s].
+  integer :: ntstep               ! The number of baroclinic dynamics time steps within dt_forcing.
+  real :: dt_therm                ! The thermodynamic timestep [T ~> s]
+  real :: dt_dyn                  ! The actual dynamic timestep used [T ~> s].  The value of dt_dyn
+                                  ! is chosen so that dt_forcing is an integer multiple of dt_dyn.
+  real :: dtdia                   ! The diabatic timestep [T ~> s]
+  real :: t_elapsed_seg           ! The elapsed time in this run segment [T ~> s]
   integer :: n, ns, n_max, nts, n_last_thermo
   logical :: diabatic_first, single_step_call
   type(time_type) :: Time2, time_chg ! Temporary time variables
@@ -331,25 +328,28 @@ program MOM6
 
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mod_name, version, "")
-  call get_param(param_file, mod_name, "DT", dt, fail_if_missing=.true.)
+  call get_param(param_file, mod_name, "DT", dt, &
+                 units="s", scale=US%s_to_T, fail_if_missing=.true.)
   call get_param(param_file, mod_name, "DT_FORCING", dt_forcing, &
                  "The time step for changing forcing, coupling with other "//&
                  "components, or potentially writing certain diagnostics. "//&
-                 "The default value is given by DT.", units="s", default=dt)
+                 "The default value is given by DT.", &
+                 units="s", default=US%T_to_s*dt, scale=US%s_to_T)
   if (offline_tracer_mode) then
     call get_param(param_file, mod_name, "DT_OFFLINE", dt_forcing, &
                    "Length of time between reading in of input fields", &
-                   units='s', fail_if_missing=.true.)
+                   units="s", scale=US%s_to_T, fail_if_missing=.true.)
     dt = dt_forcing
   endif
   ntstep = MAX(1,ceiling(dt_forcing/dt - 0.001))
 
-  Time_step_ocean = real_to_time(dt_forcing)
-  elapsed_time_master = (abs(dt_forcing - time_type_to_real(Time_step_ocean)) > 1.0e-12*dt_forcing)
+  Time_step_ocean = real_to_time(US%T_to_s*dt_forcing)
+  elapsed_time_master = (abs(dt_forcing - US%s_to_T*time_type_to_real(Time_step_ocean)) > 1.0e-12*dt_forcing)
   if (elapsed_time_master) &
     call MOM_mesg("Using real elapsed time for the master clock.", 2)
 
   ! Determine the segment end time, either from the namelist file or parsed input file.
+  ! Note that Time_unit always is in [s].
   call get_param(param_file, mod_name, "TIMEUNIT", Time_unit, &
                  "The time unit for DAYMAX, ENERGYSAVEDAYS, and RESTINT.", &
                  units="s", default=86400.0)
@@ -384,7 +384,8 @@ program MOM6
                  "and less than the forcing or coupling time-step, unless "//&
                  "THERMO_SPANS_COUPLING is true, in which case DT_THERM "//&
                  "can be an integer multiple of the coupling timestep.  By "//&
-                 "default DT_THERM is set to DT.", units="s", default=dt)
+                 "default DT_THERM is set to DT.", &
+                 units="s", default=US%T_to_s*dt, scale=US%s_to_T)
   call get_param(param_file, mod_name, "DIABATIC_FIRST", diabatic_first, &
                  "If true, apply diabatic and thermodynamic processes, "//&
                  "including buoyancy forcing and mass gain or loss, "//&
@@ -461,11 +462,11 @@ program MOM6
     endif
 
     if (use_ice_shelf) then
-      call shelf_calc_flux(sfc_state, fluxes, Time, dt_forcing, ice_shelf_CSp)
+      call shelf_calc_flux(sfc_state, fluxes, Time, US%T_to_s*dt_forcing, ice_shelf_CSp)
       call add_shelf_forces(grid, US, Ice_shelf_CSp, forces, external_call=.true.)
     endif
     fluxes%fluxes_used = .false.
-    fluxes%dt_buoy_accum = US%s_to_T*dt_forcing
+    fluxes%dt_buoy_accum = dt_forcing
 
     if (use_waves) then
       call Update_Surface_Waves(grid, GV, US, time, time_step_ocean, waves_csp)
@@ -478,9 +479,9 @@ program MOM6
     ! This call steps the model over a time dt_forcing.
     Time1 = Master_Time ; Time = Master_Time
     if (offline_tracer_mode) then
-      call step_offline(forces, fluxes, sfc_state, Time1, dt_forcing, MOM_CSp)
+      call step_offline(forces, fluxes, sfc_state, Time1, US%T_to_s*dt_forcing, MOM_CSp)
     elseif (single_step_call) then
-      call step_MOM(forces, fluxes, sfc_state, Time1, dt_forcing, MOM_CSp, Waves=Waves_CSP)
+      call step_MOM(forces, fluxes, sfc_state, Time1, US%T_to_s*dt_forcing, MOM_CSp, Waves=Waves_CSP)
     else
       n_max = 1 ; if (dt_forcing > dt) n_max = ceiling(dt_forcing/dt - 0.001)
       dt_dyn = dt_forcing / real(n_max)
@@ -493,51 +494,51 @@ program MOM6
         if (diabatic_first) then
           if (modulo(n-1,nts)==0) then
             dtdia = dt_dyn*min(ntstep,n_max-(n-1))
-            call step_MOM(forces, fluxes, sfc_state, Time2, dtdia, MOM_CSp, &
+            call step_MOM(forces, fluxes, sfc_state, Time2, US%T_to_s*dtdia, MOM_CSp, &
                           do_dynamics=.false., do_thermodynamics=.true., &
-                          start_cycle=(n==1), end_cycle=.false., cycle_length=dt_forcing)
+                          start_cycle=(n==1), end_cycle=.false., cycle_length=US%T_to_s*dt_forcing)
           endif
 
-          call step_MOM(forces, fluxes, sfc_state, Time2, dt_dyn, MOM_CSp, &
+          call step_MOM(forces, fluxes, sfc_state, Time2, US%T_to_s*dt_dyn, MOM_CSp, &
                         do_dynamics=.true., do_thermodynamics=.false., &
-                        start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_forcing)
+                        start_cycle=.false., end_cycle=(n==n_max), cycle_length=US%T_to_s*dt_forcing)
         else
-          call step_MOM(forces, fluxes, sfc_state, Time2, dt_dyn, MOM_CSp, &
+          call step_MOM(forces, fluxes, sfc_state, Time2, US%T_to_s*dt_dyn, MOM_CSp, &
                         do_dynamics=.true., do_thermodynamics=.false., &
-                        start_cycle=(n==1), end_cycle=.false., cycle_length=dt_forcing)
+                        start_cycle=(n==1), end_cycle=.false., cycle_length=US%T_to_s*dt_forcing)
 
           if ((modulo(n,nts)==0) .or. (n==n_max)) then
             dtdia = dt_dyn*(n - n_last_thermo)
             ! Back up Time2 to the start of the thermodynamic segment.
             if (n > n_last_thermo+1) &
-              Time2 = Time2 - real_to_time(dtdia - dt_dyn)
-            call step_MOM(forces, fluxes, sfc_state, Time2, dtdia, MOM_CSp, &
+              Time2 = Time2 - real_to_time(US%T_to_s*(dtdia - dt_dyn))
+            call step_MOM(forces, fluxes, sfc_state, Time2, US%T_to_s*dtdia, MOM_CSp, &
                           do_dynamics=.false., do_thermodynamics=.true., &
-                          start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_forcing)
+                          start_cycle=.false., end_cycle=(n==n_max), cycle_length=US%T_to_s*dt_forcing)
             n_last_thermo = n
           endif
         endif
 
         t_elapsed_seg = t_elapsed_seg + dt_dyn
-        Time2 = Time1 + real_to_time(t_elapsed_seg)
+        Time2 = Time1 + real_to_time(US%T_to_s*t_elapsed_seg)
       enddo
     endif
 
 !   Time = Time + Time_step_ocean
 !   This is here to enable fractional-second time steps.
     elapsed_time = elapsed_time + dt_forcing
-    if (elapsed_time > 2e9) then
+    if (elapsed_time > 2.0e9*US%s_to_T) then
       ! This is here to ensure that the conversion from a real to an integer can be accurately
       ! represented in long runs (longer than ~63 years). It will also ensure that elapsed time
       ! does not lose resolution of order the timetype's resolution, provided that the timestep and
       ! tick are larger than 10-5 seconds.  If a clock with a finer resolution is used, a smaller
       ! value would be required.
-      time_chg = real_to_time(elapsed_time)
+      time_chg = real_to_time(US%T_to_s*elapsed_time)
       segment_start_time = segment_start_time + time_chg
-      elapsed_time = elapsed_time - time_type_to_real(time_chg)
+      elapsed_time = elapsed_time - US%s_to_T*time_type_to_real(time_chg)
     endif
     if (elapsed_time_master) then
-      Master_Time = segment_start_time + real_to_time(elapsed_time)
+      Master_Time = segment_start_time + real_to_time(US%T_to_s*elapsed_time)
     else
       Master_Time = Master_Time + Time_step_ocean
     endif
@@ -547,7 +548,7 @@ program MOM6
       call write_cputime(Time, ns+ntstep-1, write_CPU_CSp, nmax)
     endif ; endif
 
-    call mech_forcing_diags(forces, dt_forcing, grid, Time, diag, surface_forcing_CSp%handles)
+    call mech_forcing_diags(forces, US%T_to_s*dt_forcing, grid, Time, diag, surface_forcing_CSp%handles)
 
     if (.not. offline_tracer_mode) then
       if (fluxes%fluxes_used) then

--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -1300,7 +1300,7 @@ subroutine buoyancy_forcing_from_data_override(sfc_state, fluxes, day, dt, G, US
 !#CTRL#     SSS_mean(i,j) = 0.5*(sfc_state%SSS(i,j) + CS%S_Restore(i,j))
 !#CTRL#   enddo ; enddo
 !#CTRL#   call apply_ctrl_forcing(SST_anom, SSS_anom, SSS_mean, fluxes%heat_added, &
-!#CTRL#                           fluxes%vprec, day, US%T_to_s*dt, G, US, CS%ctrl_forcing_CSp)
+!#CTRL#                           fluxes%vprec, day, dt, G, US, CS%ctrl_forcing_CSp)
 !#CTRL# endif
 
   call callTree_leave("buoyancy_forcing_from_data_override")

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -10,7 +10,7 @@ use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOC
 use MOM_debugging,     only : hchksum, uvchksum
 use MOM_diag_mediator, only : post_data, register_diag_field, register_scalar_field
 use MOM_diag_mediator, only : time_type, diag_ctrl, safe_alloc_alloc, query_averaging_enabled
-use MOM_diag_mediator, only : enable_averages, enable_averaging, disable_averaging
+use MOM_diag_mediator, only : enable_averages, disable_averaging
 use MOM_EOS,           only : calculate_density_derivs, EOS_domain
 use MOM_error_handler, only : MOM_error, FATAL, WARNING
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
@@ -2310,7 +2310,7 @@ end subroutine copy_back_forcing_fields
 !! fields registered as part of register_forcing_type_diags.
 subroutine mech_forcing_diags(forces_in, dt, G, time_end, diag, handles)
   type(mech_forcing), target, intent(in) :: forces_in !< mechanical forcing input fields
-  real,                  intent(in)    :: dt       !< time step for the forcing [s]
+  real,                  intent(in)    :: dt       !< time step for the forcing [T ~> s]
   type(ocean_grid_type), intent(in)    :: G        !< grid type
   type(time_type),       intent(in)    :: time_end !< The end time of the diagnostic interval.
   type(diag_ctrl),       intent(inout) :: diag     !< diagnostic type
@@ -2335,7 +2335,7 @@ subroutine mech_forcing_diags(forces_in, dt, G, time_end, diag, handles)
   endif
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
-  call enable_averaging(dt, time_end, diag)
+  call enable_averages(dt, time_end, diag)
   ! if (query_averaging_enabled(diag)) then
 
     if ((handles%id_taux > 0) .and. associated(forces%taux)) &

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -255,7 +255,7 @@ type, public :: mech_forcing
     rigidity_ice_v => NULL()    !< Depth-integrated lateral viscosity of ice shelves or sea ice at
                                 !! v-points [L4 Z-1 T-1 ~> m3 s-1]
   real :: dt_force_accum = -1.0 !< The amount of time over which the mechanical forcing fluxes
-                                !! have been averaged [s].
+                                !! have been averaged [T ~> s].
   logical :: net_mass_src_set = .false. !< If true, an estimate of net_mass_src has been provided.
   logical :: accumulate_p_surf = .false. !< If true, the surface pressure due to the atmosphere
                                 !! and various types of ice needs to be accumulated, and the

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -220,16 +220,16 @@ contains
 !! formulation (optional to use just two equations).
 !! See \ref section_ICE_SHELF_equations
 subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
-  type(surface), target,         intent(inout) :: sfc_state_in !< A structure containing fields that
-                                                !! describe the surface state of the ocean.  The
-                                                !! intent is only inout to allow for halo updates.
-  type(forcing),  target, intent(inout)        :: fluxes_in !< structure containing pointers to any
-                                                !! possible thermodynamic or mass-flux forcing fields.
-  type(time_type),       intent(in)    :: Time  !< Start time of the fluxes.
-  real,                  intent(in)    :: time_step_in !< Length of time over which these fluxes
-                                                !! will be applied [s].
-  type(ice_shelf_CS),    pointer       :: CS    !< A pointer to the control structure returned
-                                                !! by a previous call to initialize_ice_shelf.
+  type(surface), target,  intent(inout) :: sfc_state_in !< A structure containing fields that
+                                                 !! describe the surface state of the ocean.  The
+                                                 !! intent is only inout to allow for halo updates.
+  type(forcing),  target, intent(inout) :: fluxes_in !< structure containing pointers to any
+                                                 !! possible thermodynamic or mass-flux forcing fields.
+  type(time_type),        intent(in)    :: Time  !< Start time of the fluxes.
+  real,                   intent(in)    :: time_step_in !< Length of time over which these fluxes
+                                                 !! will be applied [T ~> s].
+  type(ice_shelf_CS),     pointer       :: CS    !< A pointer to the control structure returned
+                                                 !! by a previous call to initialize_ice_shelf.
 
   ! Local variables
   type(ocean_grid_type), pointer :: G => NULL()  !< The grid structure used by the ice shelf.
@@ -326,7 +326,7 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
 
   G => CS%grid ; US => CS%US
   ISS => CS%ISS
-  time_step = US%s_to_T*time_step_in
+  time_step = time_step_in
 
   if (CS%data_override_shelf_fluxes .and. CS%active_shelf_dynamics) then
     call data_override(G%Domain, 'shelf_sfc_mass_flux', fluxes_in%shelf_sfc_mass_flux, CS%Time, &

--- a/src/ice_shelf/MOM_marine_ice.F90
+++ b/src/ice_shelf/MOM_marine_ice.F90
@@ -48,7 +48,7 @@ subroutine iceberg_forces(G, forces, use_ice_shelf, sfc_state, time_step, CS)
   type(surface),         intent(inout) :: sfc_state !< A structure containing fields that
                                                     !! describe the surface state of the ocean.
   logical,               intent(in)    :: use_ice_shelf  !< If true, this configuration uses ice shelves.
-  real,                  intent(in)    :: time_step  !< The coupling time step [s].
+  real,                  intent(in)    :: time_step  !< The coupling time step [T ~> s].
   type(marine_ice_CS),   pointer       :: CS      !< Pointer to the control structure for MOM_marine_ice
 
   real :: kv_rho_ice ! The viscosity of ice divided by its density [L4 Z-2 T-1 R-1 ~> m5 kg-1 s-1].
@@ -106,7 +106,7 @@ subroutine iceberg_fluxes(G, US, fluxes, use_ice_shelf, sfc_state, time_step, CS
   type(surface),         intent(inout) :: sfc_state !< A structure containing fields that
                                                     !! describe the surface state of the ocean.
   logical,               intent(in)    :: use_ice_shelf  !< If true, this configuration uses ice shelves.
-  real,                  intent(in)    :: time_step   !< The coupling time step [s].
+  real,                  intent(in)    :: time_step   !< The coupling time step [T ~> s].
   type(marine_ice_CS),   pointer       :: CS      !< Pointer to the control structure for MOM_marine_ice
 
   real :: fraz      ! refreezing rate [R Z T-1 ~> kg m-2 s-1]
@@ -138,7 +138,7 @@ subroutine iceberg_fluxes(G, US, fluxes, use_ice_shelf, sfc_state, time_step, CS
 
   !Zero'ing out other fluxes under the tabular icebergs
   if (CS%berg_area_threshold >= 0.) then
-    I_dt_LHF = 1.0 / (US%s_to_T*time_step * CS%latent_heat_fusion)
+    I_dt_LHF = 1.0 / (time_step * CS%latent_heat_fusion)
     do j=jsd,jed ; do i=isd,ied
       if (fluxes%frac_shelf_h(i,j) > CS%berg_area_threshold) then
         ! Only applying for ice shelf covering most of cell.

--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -205,7 +205,7 @@ subroutine offline_advection_ale(fluxes, Time_start, time_interval, G, GV, US, C
                                  h_pre, uhtr, vhtr, converged)
   type(forcing),           intent(inout) :: fluxes        !< pointers to forcing fields
   type(time_type),         intent(in)    :: Time_start    !< starting time of a segment, as a time type
-  real,                    intent(in)    :: time_interval !< time interval covered by this call [s]
+  real,                    intent(in)    :: time_interval !< time interval covered by this call [T ~> s]
   type(ocean_grid_type),   intent(inout) :: G             !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV            !< Vertical grid structure
   type(unit_scale_type),   intent(in)    :: US            !< A dimensional unit scaling type
@@ -846,7 +846,7 @@ end subroutine offline_fw_fluxes_out_ocean
 subroutine offline_advection_layer(fluxes, Time_start, time_interval, G, GV, US, CS, h_pre, eatr, ebtr, uhtr, vhtr)
   type(forcing),              intent(inout) :: fluxes        !< pointers to forcing fields
   type(time_type),            intent(in)    :: Time_start    !< starting time of a segment, as a time type
-  real,                       intent(in)    :: time_interval !< Offline transport time interval [s]
+  real,                       intent(in)    :: time_interval !< Offline transport time interval [T ~> s]
   type(ocean_grid_type),      intent(inout) :: G             !< Ocean grid structure
   type(verticalGrid_type),    intent(in)    :: GV            !< Vertical grid structure
   type(unit_scale_type),      intent(in)    :: US            !< A dimensional unit scaling type
@@ -894,7 +894,7 @@ subroutine offline_advection_layer(fluxes, Time_start, time_interval, G, GV, US,
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
-  dt_iter = US%s_to_T * time_interval / real(max(1, CS%num_off_iter))
+  dt_iter = time_interval / real(max(1, CS%num_off_iter))
   x_before_y = CS%x_before_y
 
   do iter=1,CS%num_off_iter


### PR DESCRIPTION
  This pull request applies dimensional rescaling to units of [T ~> s] for a
number of timestep variables in all of the driver codes and for some of the
arguments to step_MOM and 6 other routines.  With this change, the rescaling
increasingly takes place at the driver level, especially on lines converting
time_types to real variables.  All answers and output are bitwise identical, but
the scaling for several arguments in publicly visible interfaces have changed.

  The commits in this PR include:

- NOAA-GFDL/MOM6@604cd0a33 +Rescaled real time arguments to step_MOM
- NOAA-GFDL/MOM6@81284483f +Rescaled time variables in all MOM6 drivers
