### PR TITLE
+Add units to 11 log_param calls

### DIFF
--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -857,7 +857,7 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, tides_CS
   CS%GFS_scale = 1.0
   if (GV%g_prime(1) /= GV%g_Earth) CS%GFS_scale = GV%g_prime(1) / GV%g_Earth
 
-  call log_param(param_file, mdl, "GFS / G_EARTH", CS%GFS_scale)
+  call log_param(param_file, mdl, "GFS / G_EARTH", CS%GFS_scale, units="nondim")
 
 end subroutine PressureForce_FV_init
 

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -874,7 +874,7 @@ subroutine PressureForce_Mont_init(Time, G, GV, US, param_file, diag, CS, tides_
   CS%GFS_scale = 1.0
   if (GV%g_prime(1) /= GV%g_Earth) CS%GFS_scale = GV%g_prime(1) / GV%g_Earth
 
-  call log_param(param_file, mdl, "GFS / G_EARTH", CS%GFS_scale)
+  call log_param(param_file, mdl, "GFS / G_EARTH", CS%GFS_scale, units="nondim")
 
 end subroutine PressureForce_Mont_init
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -4804,8 +4804,8 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
   endif
   if ((dtbt_tmp > 0.0) .and. (dtbt_input > 0.0)) calc_dtbt = .false.
 
-  call log_param(param_file, mdl, "DTBT as used", CS%dtbt*US%T_to_s)
-  call log_param(param_file, mdl, "estimated maximum DTBT", CS%dtbt_max*US%T_to_s)
+  call log_param(param_file, mdl, "DTBT as used", CS%dtbt*US%T_to_s, units="s")
+  call log_param(param_file, mdl, "estimated maximum DTBT", CS%dtbt_max*US%T_to_s, units="s")
 
   ! ubtav and vbtav, and perhaps ubt_IC and vbt_IC, are allocated and
   ! initialized in register_barotropic_restarts.

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -176,9 +176,9 @@ subroutine verticalGridInit( param_file, GV, US )
   GV%RZ_to_H = GV%kg_m2_to_H * US%R_to_kg_m3 * US%Z_to_m
 
 ! Log derivative values.
-  call log_param(param_file, mdl, "M to THICKNESS", GV%m_to_H*H_rescale_factor)
-  call log_param(param_file, mdl, "M to THICKNESS rescaled by 2^-n", GV%m_to_H)
-  call log_param(param_file, mdl, "THICKNESS to M rescaled by 2^n", GV%H_to_m)
+  call log_param(param_file, mdl, "M to THICKNESS", GV%m_to_H*H_rescale_factor, units="H m-1")
+  call log_param(param_file, mdl, "M to THICKNESS rescaled by 2^-n", GV%m_to_H, units="2^n H m-1")
+  call log_param(param_file, mdl, "THICKNESS to M rescaled by 2^n", GV%H_to_m, units="2^-n m H-1")
 
   allocate( GV%sInterface(nk+1) )
   allocate( GV%sLayer(nk) )

--- a/src/framework/testing/MOM_file_parser_tests.F90
+++ b/src/framework/testing/MOM_file_parser_tests.F90
@@ -1277,7 +1277,7 @@ subroutine test_log_param_real
   call create_test_file(param_filename)
 
   call open_param_file(param_filename, param)
-  call log_param(param, module_name, sample_param_name, sample, desc=desc)
+  call log_param(param, module_name, sample_param_name, sample, desc=desc, units="")
   call close_param_file(param)
 end subroutine test_log_param_real
 
@@ -1290,7 +1290,7 @@ subroutine test_log_param_real_array
   call create_test_file(param_filename)
 
   call open_param_file(param_filename, param)
-  call log_param(param, module_name, sample_param_name, sample, desc=desc)
+  call log_param(param, module_name, sample_param_name, sample, desc=desc, units="")
   call close_param_file(param)
 end subroutine test_log_param_real_array
 

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -165,7 +165,7 @@ function register_oil_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
       endif
     endif
   enddo
-  call log_param(param_file, mdl, "OIL_DECAY_RATE", US%s_to_T*CS%oil_decay_rate(1:CS%ntr))
+  call log_param(param_file, mdl, "OIL_DECAY_RATE", US%s_to_T*CS%oil_decay_rate(1:CS%ntr), units="s-1")
 
   ! This needs to be changed if the units of tracer are changed above.
   if (GV%Boussinesq) then ; flux_units = "kg s-1"


### PR DESCRIPTION
  Add appropriate units arguments to 11 log_param calls that were missing them.
All answers are bitwise identical, but the logged output can change in some cases.