### PR TITLE
Make sure EBT structure is computed when desired

### DIFF
--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1182,7 +1182,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  default=1.0e-17, units="s-1", scale=US%T_to_s)
   call get_param(param_file, mdl, "KHTH_USE_FGNV_STREAMFUNCTION", use_FGNV_streamfn, &
                  default=.false., do_not_log=.true.)
-  CS%calculate_cg1 = CS%calculate_cg1 .or. use_FGNV_streamfn
+  CS%calculate_cg1 = CS%calculate_cg1 .or. use_FGNV_streamfn .or. CS%khth_use_ebt_struct
   CS%calculate_Rd_dx = CS%calculate_Rd_dx .or. use_MEKE
   ! Indicate whether to calculate the Eady growth rate
   CS%calculate_Eady_growth_rate = use_MEKE .or. (KhTr_Slope_Cff>0.) .or. (KhTh_Slope_Cff>0.)


### PR DESCRIPTION
### Issue

I ran two (supposedly) identical MOM6 experiments, both with the following parameters in `MOM_input`:

```
THICKNESSDIFFUSE = True
KHTH = 800.0
USE_VARIABLE_MIXING = True
KHTH_USE_EBT_STRUCT = True
```

In the first experiment (left), MOM6 imposed the desired EBT structure for the interface height diffusivity, diagnosed via `KHTH_t`. In the second experiment (right), MOM6 set the interface height diffusivity to zero, except for in the uppermost layer.

<img src="https://user-images.githubusercontent.com/23617395/205411357-f2c3c0e8-6cec-4619-b3eb-0688b8ecbe39.png" width="400"><img src="https://user-images.githubusercontent.com/23617395/205411354-c7e24e33-79da-4205-b127-790a9a1bb2b8.png" width="400">

### What happened?

In the first case, I was lucky, and somewhat unrelatedly asked for the `Rd_dx` diagnostic in the `diag_table`. In the second case, I did not ask for the `Rd_dx` diagnostic. That's what made the difference.

More generally and for future reference, here is what happens in the code before this PR:

* If `KHTH_USE_EBT_STRUCT` = True, an array for CS%ebt_struct gets allocated and initialized to 0.
* But this array never got filled (with values other than 0) unless the user selects any of the following options too: 

1. `KHTH_USE_FGNV_STREAMFUNCTION` = True
2. `USE_MEKE` = True
3. `KhTr_passivity_coeff` > 0
4. `MLE_front_length` > 0
5. Output the diagnostic `Rd_dx`
6. Use resolution scaling for the a) Laplacian viscosity, b) interface height diffusivity, c) tracer diffusivity, OR d) the MEKE viscosity contribution.

(I guess, OM4 uses a few of these options, which is why this problem has not been detected before?)

The one-line fix by this PR makes sure that the allocated array always gets filled if `KHTH_USE_EBT_STRUCT` = True.