### PR TITLE
Switch from mpich to openmpi in GitHub workflows

### DIFF
--- a/.github/actions/ubuntu-setup/action.yml
+++ b/.github/actions/ubuntu-setup/action.yml
@@ -13,7 +13,7 @@ runs:
         sudo apt-get install netcdf-bin
         sudo apt-get install libnetcdf-dev
         sudo apt-get install libnetcdff-dev
-        sudo apt-get install mpich
-        sudo apt-get install libmpich-dev
+        sudo apt-get install openmpi-bin
+        sudo apt-get install libopenmpi-dev
         sudo apt-get install linux-tools-common
         echo "::endgroup::"


### PR DESCRIPTION
GitHub switched images from focal to jammy a few days ago. Since then linking to libFMS.a has been failing. I'm not sure why, but using OpenMPI instead of mpich works. I suggest making this switch to revive the GH workflows.