### PR TITLE
Correct wave and spherical harmonics unit descriptions

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2678,7 +2678,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   endif
 
   if (present(waves_CSp)) then
-    call waves_register_restarts(waves_CSp, HI, GV, param_file, restart_CSp)
+    call waves_register_restarts(waves_CSp, HI, GV, US, param_file, restart_CSp)
   endif
 
   call callTree_waypoint("restart registration complete (initialize_MOM)")

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -5324,11 +5324,11 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
   integer :: i, j, k, m, n, ntr, nz
   integer :: ishift, idir, jshift, jdir
   real :: b_in, b_out     ! The 0 and 1 switch for tracer reservoirs
-                          ! 1 if the length scale of reservoir is zero [nodim]
+                          ! 1 if the length scale of reservoir is zero [nondim]
   real :: a_in, a_out     ! The 0 and 1(-1) switch for reservoir source weights
                           ! e.g. a_in is -1 only if b_in ==1 and uhr or vhr is inward
                           ! e.g. a_out is 1 only if b_out==1 and uhr or vhr is outward
-                          ! It's clear that a_in and a_out cannot be both non-zero [nodim]
+                          ! It's clear that a_in and a_out cannot be both non-zero [nondim]
   nz = GV%ke
   ntr = Reg%ntr
 

--- a/src/parameterizations/lateral/MOM_spherical_harmonics.F90
+++ b/src/parameterizations/lateral/MOM_spherical_harmonics.F90
@@ -18,9 +18,9 @@ public spherical_harmonics_forward, spherical_harmonics_inverse
 !> Control structure for spherical harmonic transforms
 type, public :: sht_CS ; private
   logical :: initialized = .False. !< True if this control structure has been initialized.
-  integer :: ndegree !< Maximum degree of the spherical harmonics [nodim].
+  integer :: ndegree !< Maximum degree of the spherical harmonics [nondim].
   integer :: lmax !< Number of associated Legendre polynomials of nonnegative m
-                  !! [lmax=(ndegree+1)*(ndegree+2)/2] [nodim].
+                  !! [lmax=(ndegree+1)*(ndegree+2)/2] [nondim].
   real, allocatable :: cos_clatT(:,:) !< Precomputed cosine of colatitude at the t-cells [nondim].
   real, allocatable :: Pmm(:,:,:) !< Precomputed associated Legendre polynomials (m=n) at the t-cells [nondim].
   real, allocatable :: cos_lonT(:,:,:), & !< Precomputed cosine factors at the t-cells [nondim].
@@ -46,18 +46,18 @@ subroutine spherical_harmonics_forward(G, CS, var, Snm_Re, Snm_Im, Nd)
   type(ocean_grid_type), intent(in)    :: G            !< The ocean's grid structure.
   type(sht_CS),          intent(inout) :: CS           !< Control structure for SHT
   real, dimension(SZI_(G),SZJ_(G)), &
-                         intent(in)    :: var          !< Input 2-D variable []
-  real,                  intent(out)   :: Snm_Re(:)    !< SHT coefficients for the real modes (cosine)
-  real,                  intent(out)   :: Snm_Im(:)    !< SHT coefficients for the imaginary modes (sine)
+                         intent(in)    :: var          !< Input 2-D variable [A]
+  real,                  intent(out)   :: Snm_Re(:)    !< SHT coefficients for the real modes (cosine) [A]
+  real,                  intent(out)   :: Snm_Im(:)    !< SHT coefficients for the imaginary modes (sine) [A]
   integer,     optional, intent(in)    :: Nd           !< Maximum degree of the spherical harmonics
                                                        !! overriding ndegree in the CS [nondim]
   ! local variables
-  integer :: Nmax ! Local copy of the maximum degree of the spherical harmonics [nodim]
-  integer :: Ltot ! Local copy of the number of spherical harmonics [nodim]
+  integer :: Nmax ! Local copy of the maximum degree of the spherical harmonics [nondim]
+  integer :: Ltot ! Local copy of the number of spherical harmonics [nondim]
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    pmn,   & ! Current associated Legendre polynomials of degree n and order m [nodim]
-    pmnm1, & ! Associated Legendre polynomials of degree n-1 and order m [nodim]
-    pmnm2    ! Associated Legendre polynomials of degree n-2 and order m [nodim]
+    pmn,   & ! Current associated Legendre polynomials of degree n and order m [nondim]
+    pmnm1, & ! Associated Legendre polynomials of degree n-1 and order m [nondim]
+    pmnm2    ! Associated Legendre polynomials of degree n-2 and order m [nondim]
   integer :: i, j, k
   integer :: is, ie, js, je, isd, ied, jsd, jed
   integer :: m, n, l
@@ -143,19 +143,19 @@ end subroutine spherical_harmonics_forward
 subroutine spherical_harmonics_inverse(G, CS, Snm_Re, Snm_Im, var, Nd)
   type(ocean_grid_type), intent(in)  :: G            !< The ocean's grid structure.
   type(sht_CS),          intent(in)  :: CS           !< Control structure for SHT
-  real,                  intent(in)  :: Snm_Re(:)    !< SHT coefficients for the real modes (cosine)
-  real,                  intent(in)  :: Snm_Im(:)    !< SHT coefficients for the imaginary modes (sine)
+  real,                  intent(in)  :: Snm_Re(:)    !< SHT coefficients for the real modes (cosine) [A]
+  real,                  intent(in)  :: Snm_Im(:)    !< SHT coefficients for the imaginary modes (sine) [A]
   real, dimension(SZI_(G),SZJ_(G)), &
-                         intent(out) :: var          !< Output 2-D variable []
+                         intent(out) :: var          !< Output 2-D variable [A]
   integer,     optional, intent(in)  :: Nd           !< Maximum degree of the spherical harmonics
                                                      !! overriding ndegree in the CS [nondim]
   ! local variables
-  integer :: Nmax ! Local copy of the maximum degree of the spherical harmonics [nodim]
-  real    :: mFac ! A constant multiplier. mFac = 1 (if m==0) or 2 (if m>0) [nodim]
+  integer :: Nmax ! Local copy of the maximum degree of the spherical harmonics [nondim]
+  real    :: mFac ! A constant multiplier. mFac = 1 (if m==0) or 2 (if m>0) [nondim]
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    pmn,   & ! Current associated Legendre polynomials of degree n and order m [nodim]
-    pmnm1, & ! Associated Legendre polynomials of degree n-1 and order m [nodim]
-    pmnm2    ! Associated Legendre polynomials of degree n-2 and order m [nodim]
+    pmn,   & ! Current associated Legendre polynomials of degree n and order m [nondim]
+    pmnm1, & ! Associated Legendre polynomials of degree n-1 and order m [nondim]
+    pmnm2    ! Associated Legendre polynomials of degree n-2 and order m [nondim]
   integer :: i, j, k
   integer :: is, ie, js, je, isd, ied, jsd, jed
   integer :: m, n, l
@@ -210,7 +210,7 @@ subroutine spherical_harmonics_init(G, param_file, CS)
   type(sht_CS), intent(inout)       :: CS !< Control structure for spherical harmonic transforms
 
   ! local variables
-  real, parameter :: PI = 4.0*atan(1.0) ! 3.1415926... calculated as 4*atan(1) [nodim]
+  real, parameter :: PI = 4.0*atan(1.0) ! 3.1415926... calculated as 4*atan(1) [nondim]
   real, parameter :: RADIAN = PI / 180.0 ! Degree to Radian constant [rad/degree]
   real, dimension(SZI_(G),SZJ_(G)) :: sin_clatT ! sine of colatitude at the t-cells [nondim].
   real :: Pmm_coef ! = sqrt{ 1.0/(4.0*PI) * prod[(2k+1)/2k)] } [nondim].
@@ -305,8 +305,8 @@ end subroutine spherical_harmonics_end
 
 !> Calculates the number of real elements (cosine) of spherical harmonics given maximum degree Nd.
 function calc_lmax(Nd) result(lmax)
-  integer :: lmax           !< Number of real spherical harmonic modes [nodim]
-  integer, intent(in) :: Nd !< Maximum degree [nodim]
+  integer :: lmax           !< Number of real spherical harmonic modes [nondim]
+  integer, intent(in) :: Nd !< Maximum degree [nondim]
 
   lmax = (Nd+2) * (Nd+1) / 2
 end function calc_lmax
@@ -314,9 +314,9 @@ end function calc_lmax
 !> Calculates the one-dimensional index number at (n=0, m=m), given order m and maximum degree Nd.
 !! It is sequenced with degree (n) changing first and order (m) changing second.
 function order2index(m, Nd) result(l)
-  integer :: l              !< One-dimensional index number [nodim]
-  integer, intent(in) :: m  !< Current order number [nodim]
-  integer, intent(in) :: Nd !< Maximum degree [nodim]
+  integer :: l              !< One-dimensional index number [nondim]
+  integer, intent(in) :: m  !< Current order number [nondim]
+  integer, intent(in) :: Nd !< Maximum degree [nondim]
 
   l = ((Nd+1) + (Nd+1-(m-1)))*m/2 + 1
 end function order2index

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -1993,7 +1993,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_set_diffusivity"  ! This module's name.
-  real    :: vonKar          ! The von Karman constant as used for mixed layer viscosity [nomdim]
+  real    :: vonKar          ! The von Karman constant as used for mixed layer viscosity [nondim]
   real    :: omega_frac_dflt ! The default value for the fraction of the absolute rotation rate
                              ! that is used in place of the absolute value of the local Coriolis
                              ! parameter in the denominator of some expressions [nondim]

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -51,7 +51,7 @@ type, public :: vertvisc_CS ; private
   real    :: Hbbl            !< The static bottom boundary layer thickness [H ~> m or kg m-2].
   real    :: Kv_extra_bbl    !< An extra vertical viscosity in the bottom boundary layer of thickness
                              !! Hbbl when there is not a bottom drag law in use [Z2 T-1 ~> m2 s-1].
-  real    :: vonKar          !< The von Karman constant as used for mixed layer viscosity [nomdim]
+  real    :: vonKar          !< The von Karman constant as used for mixed layer viscosity [nondim]
 
   real    :: maxvel          !< Velocity components greater than maxvel are truncated [L T-1 ~> m s-1].
   real    :: vel_underflow   !< Velocity components smaller than vel_underflow

--- a/src/user/Rossby_front_2d_initialization.F90
+++ b/src/user/Rossby_front_2d_initialization.F90
@@ -257,7 +257,7 @@ real function dTdy( G, dT, lat, US )
   real :: PI   ! The ratio of the circumference of a circle to its diameter [nondim]
   real :: dHML ! The range of the mixed layer depths [Z ~> m]
   real :: dHdy ! The mixed layer depth gradient [Z L-1 ~> m m-1]
-  real :: km_to_L ! Horizontal axis unit conversion factor when AXIS_UNITS = 'k' (1000 m) [L km-1]
+  real :: km_to_L ! Horizontal axis unit conversion factor when AXIS_UNITS = 'k' (1000 m) [L km-1 ~> 1000]
 
   PI = 4.0 * atan(1.0)
   km_to_L = 1.0e3*US%m_to_L

--- a/src/user/user_change_diffusivity.F90
+++ b/src/user/user_change_diffusivity.F90
@@ -7,7 +7,7 @@ use MOM_diag_mediator, only : diag_ctrl, time_type
 use MOM_error_handler, only : MOM_error, is_root_pe, FATAL, WARNING, NOTE
 use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
-use MOM_unit_scaling, only : unit_scale_type
+use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs, vertvisc_type, p3d
 use MOM_verticalGrid,  only : verticalGrid_type
 use MOM_EOS,           only : calculate_density, EOS_domain
@@ -29,7 +29,7 @@ type, public :: user_change_diff_CS ; private
   real :: Kd_add        !< The scale of a diffusivity that is added everywhere
                         !! without any filtering or scaling [Z2 T-1 ~> m2 s-1].
   real :: lat_range(4)  !< 4 values that define the latitude range over which
-                        !! a diffusivity scaled by Kd_add is added [degLat].
+                        !! a diffusivity scaled by Kd_add is added [degrees_N].
   real :: rho_range(4)  !< 4 values that define the coordinate potential
                         !! density range over which a diffusivity scaled by
                         !! Kd_add is added [R ~> kg m-3].


### PR DESCRIPTION
  This PR includes a series of commits to correct the documentation of variable units, especially in the MOM_spherical_harmonics and MOM_wave_interface modules. It also includes the addition of conversion factors to the register_diag_field calls for the two "developmental" diagnostics dudt_Stokes and dvdt_Stokes whose documented units were corrected, and to the register_restart calls for Us_x_prev and Us_y_prev.  This also required the addition of a unit_scale_type argument to waves_register_restarts.  All answers are bitwise identical.

  The commits in this PR include:

- NOAA-GFDL/MOM6@b819d9778 +Correct MOM_wave_interface unit descriptions
- NOAA-GFDL/MOM6@ea699efb0 Correct scattered unit description syntax
- NOAA-GFDL/MOM6@2ca2d19f9 Unit descriptions in MOM_spherical_harmonics
