### PR TITLE
+Document axis and other units in user modules

### DIFF
--- a/src/diagnostics/MOM_wave_structure.F90
+++ b/src/diagnostics/MOM_wave_structure.F90
@@ -57,10 +57,9 @@ type, public :: wave_structure_CS ; !private
                                    !< Squared buoyancy frequency at each interface [T-2 ~> s-2].
   integer, allocatable, dimension(:,:):: num_intfaces
                                    !< Number of layer interfaces (including surface and bottom) [nondim].
-  real    :: int_tide_source_x     !< X Location of generation site
-                                   !! for internal tide for testing (BDM)
-  real    :: int_tide_source_y     !< Y Location of generation site
-                                   !! for internal tide for testing (BDM)
+  ! logical :: int_tide_source_test  !< If true, apply an arbitrary generation site for internal tide testing
+  ! integer :: int_tide_source_i     !< I Location of generation site
+  ! integer :: int_tide_source_j     !< J Location of generation site
   logical :: debug                 !< debugging prints
 
 end type wave_structure_CS
@@ -143,7 +142,7 @@ subroutine wave_structure(h, tv, G, GV, US, cn, ModeNum, freq, CS, En, full_halo
     HxR_here       !< A layer integrated density [R Z ~> kg m-2]
   real :: I_Hnew   !< The inverse of a new layer thickness [Z-1 ~> m-1]
   real :: drxh_sum !< The sum of density differences across interfaces times thicknesses [R Z ~> kg m-2]
-  real, parameter :: tol1  = 0.0001, tol2 = 0.001
+  real, parameter :: tol1  = 0.0001, tol2 = 0.001 ! Nondimensional tolerances [nondim]
   real :: g_Rho0  !< G_Earth/Rho0 in [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1].
   ! real :: rescale, I_rescale
   integer :: kf(SZI_(G))
@@ -281,7 +280,7 @@ subroutine wave_structure(h, tv, G, GV, US, cn, ModeNum, freq, CS, En, full_halo
     do i=is,ie ; if (cn(i,j) > 0.0) then
       !----for debugging, remove later----
       ig = i + G%idg_offset ; jg = j + G%jdg_offset
-      !if (ig == CS%int_tide_source_x .and. jg == CS%int_tide_source_y) then
+      !if (ig == CS%int_tide_source_i .and. jg == CS%int_tide_source_j) then
       !-----------------------------------
       if (G%mask2dT(i,j) > 0.0) then
 
@@ -762,10 +761,15 @@ subroutine wave_structure_init(Time, G, GV, param_file, diag, CS)
 
   CS%initialized = .true.
 
-  call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_X", CS%int_tide_source_x, &
-                 "X Location of generation site for internal tide", default=1.)
-  call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_Y", CS%int_tide_source_y, &
-                 "Y Location of generation site for internal tide", default=1.)
+  ! call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_TEST", CS%int_tide_source_test, &
+  !                "If true, apply an arbitrary generation site for internal tide testing", &
+  !                default=.false.)
+  ! if (CS%int_tide_source_test) then
+  !   call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_I", CS%int_tide_source_i, &
+  !                "I Location of generation site for internal tide", default=0)
+  !   call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_J", CS%int_tide_source_j, &
+  !                "J Location of generation site for internal tide", default=0)
+  ! endif
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "debugging prints", default=.false.)
 

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -48,13 +48,12 @@ type, public :: int_tide_input_CS ; private
   character(len=200) :: inputdir !< The directory for input files.
 
   logical :: int_tide_source_test    !< If true, apply an arbitrary generation site
-                                     !! for internal tide testing (BDM)
+                                     !! for internal tide testing
   type(time_type) :: time_max_source !< A time for use in testing internal tides
   real    :: int_tide_source_x       !< X Location of generation site
-                                     !! for internal tide for testing (BDM)
-                                     !! for internal tide for testing (BDM)
+                                     !! for internal tide for testing [degrees_E] or [km]
   real    :: int_tide_source_y       !< Y Location of generation site
-                                     !! for internal tide for testing (BDM)
+                                     !! for internal tide for testing [degrees_N] or [km]
   integer :: int_tide_source_i       !< I Location of generation site
   integer :: int_tide_source_j       !< J Location of generation site
   logical :: int_tide_use_glob_ij    !< Use global indices for generation site
@@ -417,11 +416,11 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
     call get_param(param_file, mdl, "INTERNAL_TIDE_USE_GLOB_IJ", CS%int_tide_use_glob_ij, &
                  "Use global IJ for internal tide generation source test", default=.false.)
     call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_X", CS%int_tide_source_x, &
-                 "X Location of generation site for internal tide", default=1., &
-                 do_not_log=CS%int_tide_use_glob_ij)
+                 "X Location of generation site for internal tide", &
+                 units=G%x_ax_unit_short, default=1.0, do_not_log=CS%int_tide_use_glob_ij)
     call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_Y", CS%int_tide_source_y, &
-                 "Y Location of generation site for internal tide", default=1., &
-                 do_not_log=CS%int_tide_use_glob_ij)
+                 "Y Location of generation site for internal tide", &
+                 units=G%y_ax_unit_short, default=1.0, do_not_log=CS%int_tide_use_glob_ij)
     call get_param(param_file, mdl, "INTERNAL_TIDE_SOURCE_I", CS%int_tide_source_i, &
                  "I Location of generation site for internal tide", default=0, &
                  do_not_log=.not.CS%int_tide_use_glob_ij)

--- a/src/tracer/RGC_tracer.F90
+++ b/src/tracer/RGC_tracer.F90
@@ -47,13 +47,11 @@ type, public :: RGC_tracer_CS ; private
   character(len = 200) :: tracer_IC_file !< The full path to the IC file, or " " to initialize internally.
   type(time_type), pointer :: Time !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry.
-  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package.
-  real, pointer :: tr_aux(:,:,:,:) => NULL() !< The masked tracer concentration.
-  real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out.
-  real :: lenlat           !< the latitudinal or y-direction length of the domain.
-  real :: lenlon           !< the longitudinal or x-direction length of the domain.
-  real :: CSL              !< The length of the continental shelf (x dir, km)
-  real :: lensponge        !< the length of the sponge layer.
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package [kg kg-1]
+  real, pointer :: tr_aux(:,:,:,:) => NULL() !< The masked tracer concentration  [kg kg-1]
+  real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out [kg kg-1]
+  real :: CSL              !< The length of the continental shelf (x direction) [km]
+  real :: lensponge        !< the length of the sponge layer [km]
   logical :: mask_tracers  !< If true, tracers are masked out in massless layers.
   logical :: use_sponge    !< If true, sponges may be applied somewhere in the domain.
   type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the timing of diagnostic output.
@@ -72,14 +70,14 @@ function register_RGC_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   type(RGC_tracer_CS),        pointer    :: CS   !< A pointer that is set to point to the control
                                                  !! structure for this module (in/out).
   type(tracer_registry_type), pointer    :: tr_Reg !< A pointer to the tracer registry.
-  type(MOM_restart_CS),    intent(inout) :: restart_CS !< MOM restart control struct
+  type(MOM_restart_CS),    intent(inout) :: restart_CS !< MOM restart control structure
 
   character(len=80)  :: name, longname
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "RGC_tracer" ! This module's name.
   character(len=200) :: inputdir
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! A pointer to one of the tracers in this module [kg kg-1]
   logical :: register_RGC_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
@@ -108,21 +106,15 @@ function register_RGC_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
                  "The exact location and properties of those sponges are \n"//&
                  "specified from MOM_initialization.F90.", default=.false.)
 
-  call get_param(param_file, mdl, "LENLAT", CS%lenlat, &
-                 "The latitudinal or y-direction length of the domain", &
-                 fail_if_missing=.true., do_not_log=.true.)
-
-  call get_param(param_file, mdl, "LENLON", CS%lenlon, &
-                 "The longitudinal or x-direction length of the domain", &
-                 fail_if_missing=.true., do_not_log=.true.)
-
   call get_param(param_file, mdl, "CONT_SHELF_LENGTH", CS%CSL, &
                  "The length of the continental shelf (x dir, km).", &
-                 default=15.0)
+                 units="km", default=15.0)
+               ! units=G%x_ax_unit_short, default=15.0)
 
   call get_param(param_file, mdl, "LENSPONGE", CS%lensponge, &
                  "The length of the sponge layer (km).", &
-                 default=10.0)
+                 units="km", default=10.0)
+               ! units=G%x_ax_unit_short, default=10.0)
 
   allocate(CS%tr(isd:ied,jsd:jed,nz,NTR), source=0.0)
   if (CS%mask_tracers) then
@@ -153,13 +145,13 @@ end function register_RGC_tracer
 subroutine initialize_RGC_tracer(restart, day, G, GV, h, diag, OBC, CS, &
                                     layer_CSp, sponge_CSp)
 
-  type(ocean_grid_type),   intent(in) :: G !< Grid structure.
-  type(verticalGrid_type), intent(in) :: GV !< The ocean's vertical grid structure.
+  type(ocean_grid_type),   intent(in) :: G   !< Grid structure.
+  type(verticalGrid_type), intent(in) :: GV  !< The ocean's vertical grid structure.
   logical,                 intent(in) :: restart !< .true. if the fields have already
                                              !! been read from a restart file.
   type(time_type), target, intent(in) :: day !< Time of the start of the run.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in) :: h !< Layer thickness, in m or kg m-2.
+                           intent(in) :: h   !< Layer thickness [H ~> m or kg m-2]
   type(diag_ctrl), target, intent(in) :: diag !< Structure used to regulate diagnostic output.
   type(ocean_OBC_type),    pointer    :: OBC !< This open boundary condition type specifies
                                              !! whether, where, and what open boundary
@@ -170,9 +162,9 @@ subroutine initialize_RGC_tracer(restart, day, G, GV, h, diag, OBC, CS, &
   type(ALE_sponge_CS),     pointer    :: sponge_CSp !< A pointer to the control structure for the
                                              !! sponges, if they are in use.  Otherwise this may be unassociated.
 
-  real, allocatable :: temp(:,:,:)
+  real, allocatable :: temp(:,:,:) ! A temporary array used for several sponge target values [various]
   character(len=16) :: name     ! A variable's name in a NetCDF file.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! A pointer to one of the tracers in this module [kg kg-1]
   real :: h_neglect         ! A thickness that is so small it is usually lost
                             ! in roundoff and can be neglected [H ~> m or kg m-2].
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, m
@@ -224,7 +216,7 @@ subroutine initialize_RGC_tracer(restart, day, G, GV, h, diag, OBC, CS, &
       if (nzdata>0) then
         allocate(temp(G%isd:G%ied,G%jsd:G%jed,nzdata))
         do k=1,nzdata ; do j=js,je ; do i=is,ie
-          if (G%geoLonT(i,j) >= (CS%lenlon - CS%lensponge) .AND. G%geoLonT(i,j) <= CS%lenlon) then
+          if (G%geoLonT(i,j) >= (G%len_lon - CS%lensponge) .AND. G%geoLonT(i,j) <= G%len_lon) then
             temp(i,j,k) = 0.0
           endif
         enddo ; enddo ; enddo
@@ -240,7 +232,7 @@ subroutine initialize_RGC_tracer(restart, day, G, GV, h, diag, OBC, CS, &
       if (nz>0) then
         allocate(temp(G%isd:G%ied,G%jsd:G%jed,nz))
         do k=1,nz ; do j=js,je ; do i=is,ie
-          if (G%geoLonT(i,j) >= (CS%lenlon - CS%lensponge) .AND. G%geoLonT(i,j) <= CS%lenlon) then
+          if (G%geoLonT(i,j) >= (G%len_lon - CS%lensponge) .AND. G%geoLonT(i,j) <= G%len_lon) then
             temp(i,j,k) = 0.0
           endif
         enddo ; enddo ; enddo
@@ -263,8 +255,8 @@ end subroutine initialize_RGC_tracer
 !! This is a simple example of a set of advected passive tracers.
 subroutine RGC_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV, US, CS, &
                               evap_CFL_limit, minimum_forcing_depth)
-  type(ocean_grid_type),                 intent(in) :: G !< The ocean's grid structure.
-  type(verticalGrid_type),               intent(in) :: GV !< The ocean's vertical grid structure.
+  type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(in) :: h_old !< Layer thickness before entrainment [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
@@ -283,22 +275,20 @@ subroutine RGC_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV, 
   type(unit_scale_type),   intent(in) :: US   !< A dimensional unit scaling type
   type(RGC_tracer_CS),     pointer    :: CS   !< The control structure returned by a previous call.
   real,          optional, intent(in) :: evap_CFL_limit !< Limit on the fraction of the water that can be
-                                               !! fluxed out of the top layer in a timestep [nondim].
+                                              !! fluxed out of the top layer in a timestep [nondim].
   real,          optional, intent(in) :: minimum_forcing_depth !< The smallest depth over which fluxes
-                                               !! can be applied [H ~> m or kg m-2].
+                                              !! can be applied [H ~> m or kg m-2].
 
 ! The arguments to this subroutine are redundant in that
 !     h_new[k] = h_old[k] + ea[k] - eb[k-1] + eb[k] - ea[k+1]
 
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
-  real :: in_flux(SZI_(G),SZJ_(G),2)  ! total amount of tracer to be injected
 
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   if (.not.associated(CS)) return
 
-  in_flux(:,:,:) = 0.0
   m=1
   do j=js,je ; do i=is,ie
     ! set tracer to 1.0 in the surface of the continental shelf
@@ -313,7 +303,7 @@ subroutine RGC_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV, 
         h_work(i,j,k) = h_old(i,j,k)
       enddo ; enddo ; enddo;
       call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m) , dt, fluxes, h_work, &
-                                          evap_CFL_limit, minimum_forcing_depth, in_flux(:,:,m))
+                                          evap_CFL_limit, minimum_forcing_depth)
 
       call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
     enddo

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -41,14 +41,18 @@ public dye_stock, regional_dyes_end
 type, public :: dye_tracer_CS ; private
   integer :: ntr    !< The number of tracers that are actually used.
   logical :: coupled_tracers = .false.  !< These tracers are not offered to the coupler.
-  real, allocatable, dimension(:) :: dye_source_minlon !< Minimum longitude of region dye will be injected.
-  real, allocatable, dimension(:) :: dye_source_maxlon !< Maximum longitude of region dye will be injected.
-  real, allocatable, dimension(:) :: dye_source_minlat !< Minimum latitude of region dye will be injected.
-  real, allocatable, dimension(:) :: dye_source_maxlat !< Maximum latitude of region dye will be injected.
+  real, allocatable, dimension(:) :: dye_source_minlon !< Minimum longitude of region dye will be
+                                                       !! injected, in [m] or [km] or [degrees_E]
+  real, allocatable, dimension(:) :: dye_source_maxlon !< Maximum longitude of region dye will be
+                                                       !! injected, in [m] or [km] or [degrees_E]
+  real, allocatable, dimension(:) :: dye_source_minlat !< Minimum latitude of region dye will be
+                                                       !! injected, in [m] or [km] or [degrees_N]
+  real, allocatable, dimension(:) :: dye_source_maxlat !< Maximum latitude of region dye will be
+                                                       !! injected, in [m] or [km] or [degrees_N]
   real, allocatable, dimension(:) :: dye_source_mindepth !< Minimum depth of region dye will be injected [Z ~> m].
   real, allocatable, dimension(:) :: dye_source_maxdepth !< Maximum depth of region dye will be injected [Z ~> m].
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
-  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine, in g m-3?
+  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine [CU ~> conc]
 
   integer, allocatable, dimension(:) :: ind_tr !< Indices returned by atmos_ocn_coupler_flux if it is used and the
                                                !! surface tracer concentrations are to be provided to the coupler.
@@ -74,7 +78,7 @@ function register_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
                                                  !! structure for this module
   type(tracer_registry_type), pointer    :: tr_Reg !< A pointer that is set to point to the control
                                                  !! structure for the tracer advection and diffusion module.
-  type(MOM_restart_CS), target, intent(inout) :: restart_CS !< MOM restart control struct
+  type(MOM_restart_CS), target, intent(inout) :: restart_CS !< MOM restart control structure
 
   ! Local variables
   character(len=40)  :: mdl = "regional_dyes" ! This module's name.
@@ -82,7 +86,7 @@ function register_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   character(len=48)  :: desc_name ! The variable's descriptor.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! A pointer to one of the tracers [CU ~> conc]
   logical :: register_dye_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
@@ -110,28 +114,32 @@ function register_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   CS%dye_source_minlon(:) = -1.e30
   call get_param(param_file, mdl, "DYE_SOURCE_MINLON", CS%dye_source_minlon, &
                  "This is the starting longitude at which we start injecting dyes.", &
-                 fail_if_missing=.true.)
+                 units="degrees_E", fail_if_missing=.true.)
+               ! units=G%x_ax_unit_short, fail_if_missing=.true.)
   if (minval(CS%dye_source_minlon(:)) < -1.e29) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MINLON ")
 
   CS%dye_source_maxlon(:) = -1.e30
   call get_param(param_file, mdl, "DYE_SOURCE_MAXLON", CS%dye_source_maxlon, &
                  "This is the ending longitude at which we finish injecting dyes.", &
-                 fail_if_missing=.true.)
+                 units="degrees_E", fail_if_missing=.true.)
+               ! units=G%x_ax_unit_short, fail_if_missing=.true.)
   if (minval(CS%dye_source_maxlon(:)) < -1.e29) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MAXLON ")
 
   CS%dye_source_minlat(:) = -1.e30
   call get_param(param_file, mdl, "DYE_SOURCE_MINLAT", CS%dye_source_minlat, &
                  "This is the starting latitude at which we start injecting dyes.", &
-                 fail_if_missing=.true.)
+                 units="degrees_N", fail_if_missing=.true.)
+               ! units=G%y_ax_unit_short, fail_if_missing=.true.)
   if (minval(CS%dye_source_minlat(:)) < -1.e29) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MINLAT ")
 
   CS%dye_source_maxlat(:) = -1.e30
   call get_param(param_file, mdl, "DYE_SOURCE_MAXLAT", CS%dye_source_maxlat, &
                  "This is the ending latitude at which we finish injecting dyes.", &
-                 fail_if_missing=.true.)
+                 units="degrees_N", fail_if_missing=.true.)
+               ! units=G%y_ax_unit_short, fail_if_missing=.true.)
   if (minval(CS%dye_source_maxlat(:)) < -1.e29) &
     call MOM_error(FATAL, "register_dye_tracer: Not enough values provided for DYE_SOURCE_MAXLAT ")
 
@@ -211,10 +219,10 @@ subroutine initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_C
   do m= 1, CS%ntr
     do j=G%jsd,G%jed ; do i=G%isd,G%ied
       ! A dye is set dependent on the center of the cell being inside the rectangular box.
-      if (CS%dye_source_minlon(m)<G%geoLonT(i,j) .and. &
-          CS%dye_source_maxlon(m)>=G%geoLonT(i,j) .and. &
-          CS%dye_source_minlat(m)<G%geoLatT(i,j) .and. &
-          CS%dye_source_maxlat(m)>=G%geoLatT(i,j) .and. &
+      if (CS%dye_source_minlon(m) < G%geoLonT(i,j) .and. &
+          CS%dye_source_maxlon(m) >= G%geoLonT(i,j) .and. &
+          CS%dye_source_minlat(m) < G%geoLatT(i,j) .and. &
+          CS%dye_source_maxlat(m) >= G%geoLatT(i,j) .and. &
           G%mask2dT(i,j) > 0.0 ) then
         z_bot = 0.0
         do k = 1, GV%ke
@@ -264,7 +272,7 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
                                               !! fluxes can be applied [H ~> m or kg m-2]
 
 ! Local variables
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-3]
   real    :: z_bot    ! Height of the bottom of the layer relative to the sea surface [Z ~> m]
   real    :: z_center ! Height of the center of the layer relative to the sea surface [Z ~> m]
   integer :: i, j, k, is, ie, js, je, nz, m
@@ -292,10 +300,10 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
   do m=1,CS%ntr
     do j=G%jsd,G%jed ; do i=G%isd,G%ied
       ! A dye is set dependent on the center of the cell being inside the rectangular box.
-      if (CS%dye_source_minlon(m)<G%geoLonT(i,j) .and. &
-          CS%dye_source_maxlon(m)>=G%geoLonT(i,j) .and. &
-          CS%dye_source_minlat(m)<G%geoLatT(i,j) .and. &
-          CS%dye_source_maxlat(m)>=G%geoLatT(i,j) .and. &
+      if (CS%dye_source_minlon(m) < G%geoLonT(i,j) .and. &
+          CS%dye_source_maxlon(m) >= G%geoLonT(i,j) .and. &
+          CS%dye_source_minlat(m) < G%geoLatT(i,j) .and. &
+          CS%dye_source_maxlat(m) >= G%geoLatT(i,j) .and. &
           G%mask2dT(i,j) > 0.0 ) then
         z_bot = 0.0
         do k=1,nz

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -126,10 +126,10 @@ function register_oil_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
                  "found in the restart files of a restarted run.", &
                  default=.false.)
   call get_param(param_file, mdl, "OIL_SOURCE_LONGITUDE", CS%oil_source_longitude, &
-                 "The geographic longitude of the oil source.", units="degrees E", &
+                 "The geographic longitude of the oil source.", units="degrees_E", &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "OIL_SOURCE_LATITUDE", CS%oil_source_latitude, &
-                 "The geographic latitude of the oil source.", units="degrees N", &
+                 "The geographic latitude of the oil source.", units="degrees_N", &
                  fail_if_missing=.true.)
   call get_param(param_file, mdl, "OIL_SOURCE_LAYER", CS%oil_source_k, &
                  "The layer into which the oil is introduced, or a "//&

--- a/src/user/BFB_surface_forcing.F90
+++ b/src/user/BFB_surface_forcing.F90
@@ -31,8 +31,8 @@ type, public :: BFB_surface_forcing_CS ; private
   real :: Flux_const         !< The restoring rate at the surface [Z T-1 ~> m s-1].
   real :: SST_s              !< SST at the southern edge of the linear forcing ramp [C ~> degC]
   real :: SST_n              !< SST at the northern edge of the linear forcing ramp [C ~> degC]
-  real :: lfrslat            !< Southern latitude where the linear forcing ramp begins [degLat]
-  real :: lfrnlat            !< Northern latitude where the linear forcing ramp ends [degLat]
+  real :: lfrslat            !< Southern latitude where the linear forcing ramp begins [degrees_N] or [km]
+  real :: lfrnlat            !< Northern latitude where the linear forcing ramp ends [degrees_N] or [km]
   real :: drho_dt            !< Rate of change of density with temperature [R C-1 ~> kg m-3 degC-1].
                              !!   Note that temperature is being used as a dummy variable here.
                              !! All temperatures are converted into density.
@@ -206,10 +206,10 @@ subroutine BFB_surface_forcing_init(Time, G, US, param_file, diag, CS)
                  units="kg m-3", default=1035.0, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "LFR_SLAT", CS%lfrslat, &
                  "Southern latitude where the linear forcing ramp begins.", &
-                 units="degrees", default=20.0)
+                 units=G%y_ax_unit_short, default=20.0)
   call get_param(param_file, mdl, "LFR_NLAT", CS%lfrnlat, &
                  "Northern latitude where the linear forcing ramp ends.", &
-                 units="degrees", default=40.0)
+                 units=G%y_ax_unit_short, default=40.0)
   call get_param(param_file, mdl, "SST_S", CS%SST_s, &
                  "SST at the southern edge of the linear forcing ramp.", &
                  units="degC", default=20.0, scale=US%degC_to_C)

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -48,19 +48,20 @@ subroutine ISOMIP_initialize_topography(D, G, param_file, max_depth, US)
   type(unit_scale_type),           intent(in)  :: US !< A dimensional unit scaling type
 
   ! Local variables
-  real :: min_depth ! The minimum and maximum depths [Z ~> m].
+  real :: min_depth       ! The minimum depth of the ocean [Z ~> m].
   ! The following variables are used to set up the bathymetry in the ISOMIP example.
-  real :: bmax            ! max depth of bedrock topography [Z ~> m]
-  real :: b0,b2,b4,b6     ! first, second, third and fourth bedrock topography coeffs [Z ~> m]
-  real :: xbar            ! characteristic along-flow length scale of the bedrock
+  real :: bmax            ! maximum depth of bedrock topography [Z ~> m]
+  real :: b0, b2, b4, b6  ! first, second, third and fourth bedrock topography coeffs [Z ~> m]
+  real :: xbar            ! characteristic along-flow length scale of the bedrock [L ~> m]
   real :: dc              ! depth of the trough compared with side walls [Z ~> m].
-  real :: fc              ! characteristic width of the side walls of the channel
-  real :: wc              ! half-width of the trough
-  real :: ly              ! domain width (across ice flow)
-  real :: bx, by          ! dummy vatiables [Z ~> m].
-  real :: xtil            ! dummy vatiable
-  logical :: is_2D         ! If true, use 2D setup
-! This include declares and sets the variable "version".
+  real :: fc              ! characteristic width of the side walls of the channel [L ~> m]
+  real :: wc              ! half-width of the trough [L ~> m]
+  real :: ly              ! domain width (across ice flow) [L ~> m]
+  real :: bx, by          ! The x- and y- contributions to the bathymetric profiles at a point [Z ~> m]
+  real :: xtil            ! x-positon normalized by the characteristic along-flow length scale [nondim]
+  real :: km_to_L         ! The conversion factor from the axis units to L [L km-1 ~> 1e3]
+  logical :: is_2D        ! If true, use a 2D setup
+  ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "ISOMIP_initialize_topography" ! This subroutine's name.
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
@@ -72,27 +73,39 @@ subroutine ISOMIP_initialize_topography(D, G, param_file, max_depth, US)
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "MINIMUM_DEPTH", min_depth, &
                  "The minimum depth of the ocean.", units="m", default=0.0, scale=US%m_to_Z)
-  call get_param(param_file, mdl, "ISOMIP_2D",is_2D,'If true, use a 2D setup.', default=.false.)
+  call get_param(param_file, mdl, "ISOMIP_2D", is_2D, 'If true, use a 2D setup.', default=.false.)
+  call get_param(param_file, mdl, "ISOMIP_MAX_BEDROCK", bmax, &
+                 "Maximum depth of bedrock topography in the ISOMIP configuration.", &
+                 units="m", default=720.0, scale=US%m_to_Z)
+  call get_param(param_file, mdl, "ISOMIP_TROUGH_DEPTH", dc, &
+                 "Depth of the trough compared with side walls in the ISOMIP configuration.", &
+                 units="m", default=500.0, scale=US%m_to_Z)
+  call get_param(param_file, mdl, "ISOMIP_BEDROCK_LENGTH", xbar, &
+                 "Characteristic along-flow length scale of the bedrock in the ISOMIP configuration.", &
+                 units="m", default=300.0e3, scale=US%m_to_L)
+  call get_param(param_file, mdl, "ISOMIP_TROUGH_WIDTH", wc, &
+                 "Half-width of the trough in the ISOMIP configuration.", &
+                 units="m", default=24.0e3, scale=US%m_to_L)
+  call get_param(param_file, mdl, "ISOMIP_DOMAIN_WIDTH", ly, &
+                 "Domain width (across ice flow) in the ISOMIP configuration.", &
+                 units="m", default=80.0e3, scale=US%m_to_L)
+  call get_param(param_file, mdl, "ISOMIP_SIDE_WIDTH", fc, &
+                 "Characteristic width of the side walls of the channel in the ISOMIP configuration.", &
+                 units="m", default=4.0e3, scale=US%m_to_L)
 
-  ! The following variables should be transformed into runtime parameters?
-  bmax = 720.0*US%m_to_Z ; dc = 500.0*US%m_to_Z
+  km_to_L = 1.0e3*US%m_to_L
+
+  ! The following variables should be transformed into runtime parameters.
   b0 = -150.0*US%m_to_Z ; b2 = -728.8*US%m_to_Z ; b4 = 343.91*US%m_to_Z ; b6 = -50.57*US%m_to_Z
-  xbar = 300.0e3 ; fc = 4.0e3 ; wc = 24.0e3 ; ly = 80.0e3
-  bx = 0.0 ; by = 0.0 ; xtil = 0.0
-
 
   if (is_2D) then
     do j=js,je ; do i=is,ie
-      ! 2D setup
-      xtil = G%geoLonT(i,j)*1.0e3/xbar
-      !xtil = 450*1.0e3/xbar
+      ! For the 2D setup take a slice through the middle of the domain
+      xtil = G%geoLonT(i,j)*km_to_L / xbar
+      !xtil = 450.*km_to_L / xbar
       bx = b0 + b2*xtil**2 + b4*xtil**4 + b6*xtil**6
-      !by = (dc/(1.+exp(-2.*(G%geoLatT(i,j)*1.0e3- ly/2. - wc)/fc))) + &
-      !        (dc/(1.+exp(2.*(G%geoLatT(i,j)*1.0e3- ly/2. + wc)/fc)))
 
-      ! slice at y = 40 km
-      by = (dc / (1.+exp(-2.*(40.0*1.0e3- ly/2. - wc)/fc))) + &
-           (dc / (1.+exp(2.*(40.0*1.0e3- ly/2. + wc)/fc)))
+      by = 2.0 * dc / (1.0 + exp(2.0*wc / fc))
 
       D(i,j) = -max(bx+by, -bmax)
       if (D(i,j) > max_depth) D(i,j) = max_depth
@@ -104,17 +117,17 @@ subroutine ISOMIP_initialize_topography(D, G, param_file, max_depth, US)
       ! 3D setup
       ! ===== TEST =====
       !if (G%geoLonT(i,j)<500.) then
-      !  xtil = 500.*1.0e3/xbar
+      !  xtil = 500.*km_to_L / xbar
       !else
-      !  xtil = G%geoLonT(i,j)*1.0e3/xbar
+      !  xtil = G%geoLonT(i,j)*km_to_L / xbar
       !endif
       ! ===== TEST =====
 
-      xtil = G%geoLonT(i,j)*1.0e3/xbar
+      xtil = G%geoLonT(i,j)*km_to_L / xbar
 
       bx = b0 + b2*xtil**2 + b4*xtil**4 + b6*xtil**6
-      by = (dc / (1.+exp(-2.*(G%geoLatT(i,j)*1.0e3- ly/2. - wc)/fc))) + &
-           (dc / (1.+exp(2.*(G%geoLatT(i,j)*1.0e3- ly/2. + wc)/fc)))
+      by = (dc / (1.0 + exp(-2.*(G%geoLatT(i,j)*km_to_L - 0.5*ly - wc) / fc))) + &
+           (dc / (1.0 + exp(2.*(G%geoLatT(i,j)*km_to_L - 0.5*ly + wc) / fc)))
 
       D(i,j) = -max(bx+by, -bmax)
       if (D(i,j) > max_depth) D(i,j) = max_depth
@@ -264,17 +277,12 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, depth_tot, G, GV, U
   logical,                                   intent(in)  :: just_read !< If true, this call will
                                                       !! only read parameters without changing T & S.
   ! Local variables
-  integer   :: i, j, k, is, ie, js, je, nz, itt
   real      :: rho_sur, rho_bot  ! Surface and bottom densities [R ~> kg m-3]
   real      :: xi0, xi1 ! Heights in depth units [Z ~> m].
   real      :: S_sur, S_bot ! Salinity at the surface and bottom [S ~> ppt]
   real      :: T_sur, T_bot ! Temperature at the surface and bottom [C ~> degC]
   real      :: dT_dz  ! Vertical gradient of temperature [C Z-1 ~> degC m-1].
   real      :: dS_dz  ! Vertical gradient of salinity [S Z-1 ~> ppt m-1].
-  !character(len=256) :: mesg ! The text of an error message
-  character(len=40) :: verticalCoordinate
-  !real :: rho_tmp
-  logical :: fit_salin       ! If true, accept the prescribed temperature and fit the salinity.
   real :: T0(SZK_(GV))       ! A profile of temperatures [C ~> degC]
   real :: S0(SZK_(GV))       ! A profile of salinities [S ~> ppt]
   real :: drho_dT(SZK_(GV))  ! Derivative of density with temperature [R C-1 ~> kg m-3 degC-1].
@@ -283,7 +291,14 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, depth_tot, G, GV, U
   real :: pres(SZK_(GV))     ! An array of the reference pressure [R L2 T-2 ~> Pa]. (zero here)
   real :: drho_dT1           ! A prescribed derivative of density with temperature [R C-1 ~> kg m-3 degC-1]
   real :: drho_dS1           ! A prescribed derivative of density with salinity [R S-1 ~> kg m-3 ppt-1].
-  real :: T_Ref, S_Ref
+  real :: T_ref              ! Default value for other temperatures [C ~> degC]
+  real :: S_ref              ! Default value for other salinities [S ~> ppt]
+  logical :: fit_salin       ! If true, accept the prescribed temperature and fit the salinity.
+  !real :: rho_tmp    ! A temporary density used for debugging [R ~> kg m-3]
+  !character(len=256) :: mesg ! The text of an error message
+  character(len=40) :: verticalCoordinate
+  integer   :: i, j, k, is, ie, js, je, nz, itt
+
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   pres(:) = 0.0
 
@@ -343,8 +358,8 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, depth_tot, G, GV, U
                   "A reference temperature used in initialization.", &
                   units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
       call get_param(param_file, mdl, "S_REF", S_Ref, &
-                  "A reference salinity used in initialization.", units="PSU", &
-                  default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                  "A reference salinity used in initialization.", &
+                  units="PSU", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
       if (just_read) return ! All run-time parameters have been read, so return.
 
       ! write(mesg,*) 'read drho_dS, drho_dT', drho_dS1, drho_dT1
@@ -450,7 +465,8 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp,
   real :: TNUDG                     ! Nudging time scale [T ~> s]
   real :: S_sur, S_bot              ! Surface and bottom salinities in the sponge region [S ~> ppt]
   real :: T_sur, T_bot              ! Surface and bottom temperatures in the sponge region [C ~> degC]
-  real :: t_ref, s_ref              ! reference (default) T [degC] and S [ppt]
+  real :: T_ref                     ! Default value for other temperatures [C ~> degC]
+  real :: S_ref                     ! Default value for other salinities [S ~> ppt]
   real :: rho_sur, rho_bot          ! Surface and bottom densities [R ~> kg m-3]
   real :: rho_range                 ! The range of densities [R ~> kg m-3]
   real :: dT_dz                     ! Vertical gradient of temperature [C Z-1 ~> degC m-1]
@@ -460,9 +476,10 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp,
                                     ! negative because it is positive upward.
   real :: eta1D(SZK_(GV)+1)         ! Interface height relative to the sea surface, positive upward [Z ~> m].
   real :: eta(SZI_(G),SZJ_(G),SZK_(GV)+1) ! A temporary array for interface heights [Z ~> m].
-  real :: min_depth, dummy1
-  real :: min_thickness, xi0
-  !real :: rho_tmp
+  real :: min_depth                 ! The minimum depth of the ocean [Z ~> m]
+  real :: min_thickness             ! The minimum layer thickness [Z ~> m]
+  real :: xi0                       ! Interface heights in depth units [Z ~> m], usually negative.
+  !real :: rho_tmp                   ! A temporary density used for debugging [R ~> kg m-3]
   character(len=40) :: verticalCoordinate, filename, state_file
   character(len=40) :: temp_var, salt_var, eta_var, inputdir
 
@@ -481,27 +498,27 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp,
   call get_param(PF, mdl, "ISOMIP_TNUDG", TNUDG, "Nudging time scale for sponge layers", &
                  units="days", default=0.0, scale=86400.0*US%s_to_T)
 
-  call get_param(PF, mdl, "T_REF", t_ref, "Reference temperature", &
-                 units="degC", default=10.0, scale=1.0, do_not_log=.true.)
+  call get_param(PF, mdl, "T_REF", T_ref, "Reference temperature", &
+                 units="degC", default=10.0, scale=US%degC_to_C, do_not_log=.true.)
 
   call get_param(PF, mdl, "S_REF", s_ref, "Reference salinity", &
-                 units="ppt", default=35.0, scale=1.0, do_not_log=.true.)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
 
   call get_param(PF, mdl, "ISOMIP_S_SUR_SPONGE", s_sur, &
                  "Surface salinity in sponge layer.", &
-                 units="ppt", default=s_ref, scale=US%ppt_to_S)
+                 units="ppt", default=US%S_to_ppt*S_ref, scale=US%ppt_to_S)
 
   call get_param(PF, mdl, "ISOMIP_S_BOT_SPONGE", s_bot, &
                  "Bottom salinity in sponge layer.", &
-                 units="ppt", default=s_ref, scale=US%ppt_to_S)
+                 units="ppt", default=US%S_to_ppt*S_ref, scale=US%ppt_to_S)
 
   call get_param(PF, mdl, "ISOMIP_T_SUR_SPONGE", t_sur, &
                  "Surface temperature in sponge layer.", &
-                 units="degC", default=t_ref, scale=US%degC_to_C)
+                 units="degC", default=US%C_to_degC*T_ref, scale=US%degC_to_C)
 
   call get_param(PF, mdl, "ISOMIP_T_BOT_SPONGE", t_bot, &
                  "Bottom temperature in sponge layer.", &
-                 units="degC", default=t_ref, scale=US%degC_to_C)
+                 units="degC", default=US%C_to_degC*T_ref, scale=US%degC_to_C)
 
   T(:,:,:) = 0.0 ; S(:,:,:) = 0.0 ; Idamp(:,:) = 0.0 !; RHO(:,:,:) = 0.0
 
@@ -523,8 +540,7 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp,
     if (depth_tot(i,j) <= min_depth) then
       Idamp(i,j) = 0.0
     elseif (G%geoLonT(i,j) >= 790.0 .AND. G%geoLonT(i,j) <= 800.0) then
-      dummy1 = (G%geoLonT(i,j)-790.0)/(800.0-790.0)
-      Idamp(i,j) = (1.0/TNUDG) * max(0.0,dummy1)
+      Idamp(i,j) = (1.0/TNUDG) * max(0.0, (G%geoLonT(i,j)-790.0) / (800.0-790.0))
     else
       Idamp(i,j) = 0.0
     endif

--- a/src/user/Neverworld_initialization.F90
+++ b/src/user/Neverworld_initialization.F90
@@ -40,12 +40,13 @@ subroutine Neverworld_initialize_topography(D, G, param_file, max_depth)
 
   ! Local variables
   real :: PI                   ! 3.1415926... calculated as 4*atan(1)
-  real :: x, y
+  real :: x, y ! Lateral positions normalized by the domain size [nondim]
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "Neverworld_initialize_topography" ! This subroutine's name.
+  real :: nl_top_amp       ! Amplitude of large-scale topographic features as a fraction of the maximum depth [nondim]
+  real :: nl_roughness_amp ! Amplitude of topographic roughness as a fraction of the maximum depth [nondim]
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed
-  real :: nl_roughness_amp, nl_top_amp
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
@@ -53,16 +54,16 @@ subroutine Neverworld_initialize_topography(D, G, param_file, max_depth)
 
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "NL_ROUGHNESS_AMP", nl_roughness_amp, &
-                 "Amplitude of wavy signal in bathymetry.", default=0.05)
+                 "Amplitude of wavy signal in bathymetry.", units="nondim", default=0.05)
   call get_param(param_file, mdl, "NL_CONTINENT_AMP", nl_top_amp, &
-                 "Scale factor for topography - 0.0 for no continents.", default=1.0)
+                 "Scale factor for topography - 0.0 for no continents.", units="nondim", default=1.0)
 
   PI = 4.0*atan(1.0)
 
 !  Calculate the depth of the bottom.
   do j=js,je ; do i=is,ie
     x = (G%geoLonT(i,j)-G%west_lon) / G%len_lon
-    y =( G%geoLatT(i,j)-G%south_lat) / G%len_lat
+    y = (G%geoLatT(i,j)-G%south_lat) / G%len_lat
 !  This sets topography that has a reentrant channel to the south.
     D(i,j) = 1.0 - 1.1 * spike(y-1,0.12) - 1.1 * spike(y,0.12) - & !< The great northern wall and Antarctica
               nl_top_amp*( &
@@ -83,8 +84,8 @@ end subroutine Neverworld_initialize_topography
 
 !> Returns the value of a cosine-bell function evaluated at x/L
 real function cosbell(x, L)
-  real , intent(in) :: x       !< non-dimensional position
-  real , intent(in) :: L       !< non-dimensional width
+  real , intent(in) :: x       !< non-dimensional position [nondim]
+  real , intent(in) :: L       !< non-dimensional width [nondim]
   real              :: PI      !< 3.1415926... calculated as 4*atan(1)
 
   PI      = 4.0*atan(1.0)
@@ -94,8 +95,8 @@ end function cosbell
 !> Returns the value of a sin-spike function evaluated at x/L
 real function spike(x, L)
 
-  real , intent(in) :: x       !< non-dimensional position
-  real , intent(in) :: L       !< non-dimensional width
+  real , intent(in) :: x       !< non-dimensional position [nondim]
+  real , intent(in) :: L       !< non-dimensional width [nondim]
   real              :: PI      !< 3.1415926... calculated as 4*atan(1)
 
   PI    = 4.0*atan(1.0)
@@ -126,6 +127,8 @@ real function scurve(x, x0, L)
   s = max( 0., min( 1.,( x - x0 ) / L ) )
   scurve = ( 3. - 2.*s ) * ( s * s )
 end function scurve
+
+! None of the following 7 functions appear to be used.
 
 !> Returns a "coastal" profile.
 real function cstprof(x, x0, L, lf, bf, sf, sh)
@@ -228,7 +231,7 @@ real function circ_ridge(lon, lat, lon0, lat0, ring_radius, ring_thickness, ridg
   r = sqrt( (lon - lon0)**2 + (lat - lat0)**2 ) ! Pseudo-distance from a point
   r = abs( r - ring_radius) ! Pseudo-distance from a circle
   r = cone(r, 0., ring_thickness, ridge_height) ! 0 .. frac_ridge_height
-  circ_ridge = 1. - r ! nondim depths (1-frac_ridge_height) .. 1
+  circ_ridge = 1. - r ! Fractional depths (1-frac_ridge_height) .. 1
 end function circ_ridge
 
 !> This subroutine initializes layer thicknesses for the Neverworld test case,
@@ -253,10 +256,13 @@ subroutine Neverworld_initialize_thickness(h, depth_tot, G, GV, US, param_file, 
                             ! usually negative because it is positive upward.
   real, dimension(SZK_(GV)) :: h_profile ! Vector of initial thickness profile [Z ~> m].
   real :: e_interface ! Current interface position [Z ~> m].
-  real :: x,y,r1,r2 ! x,y and radial coordinates for computation of initial pert.
-  real :: pert_amp ! Amplitude of perturbations measured in Angstrom_H
-  real :: h_noise ! Amplitude of noise to scale h by
-  real :: noise ! Noise
+  real :: x, y    ! horizontal coordinates for computation of the initial perturbation normalized
+                  ! by the domain sizes [nondim]
+  real :: r1, r2  ! radial coordinates for computation of initial perturbation, normalized
+                  ! by the domain sizes [nondim]
+  real :: pert_amp ! Amplitude of perturbations as a fraction of layer thicknesses [nondim]
+  real :: h_noise ! Amplitude of noise to scale h by [nondim]
+  real :: noise   ! Fractional noise in the layer thicknesses [nondim]
   type(randomNumberStream) :: rns ! Random numbers for stochastic tidal parameterization
   character(len=40)  :: mdl = "Neverworld_initialize_thickness" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, nz
@@ -283,10 +289,10 @@ subroutine Neverworld_initialize_thickness(h, depth_tot, G, GV, US, param_file, 
     e_interface = -depth_tot(i,j)
     do k=nz,2,-1
       h(i,j,k) = GV%Z_to_H * (e0(k) - e_interface) ! Nominal thickness
-      x=(G%geoLonT(i,j)-G%west_lon)/G%len_lon
-      y=(G%geoLatT(i,j)-G%south_lat)/G%len_lat
-      r1=sqrt((x-0.7)**2+(y-0.2)**2)
-      r2=sqrt((x-0.3)**2+(y-0.25)**2)
+      x = (G%geoLonT(i,j)-G%west_lon)/G%len_lon
+      y = (G%geoLatT(i,j)-G%south_lat)/G%len_lat
+      r1 = sqrt((x-0.7)**2+(y-0.2)**2)
+      r2 = sqrt((x-0.3)**2+(y-0.25)**2)
       h(i,j,k) = h(i,j,k) + pert_amp * (e0(k) - e0(nz+1)) * GV%Z_to_H * &
                             (spike(r1,0.15)-spike(r2,0.15)) ! Prescribed perturbation
       if (h_noise /= 0.) then

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -45,7 +45,7 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
                                             !! to any available thermodynamic
                                             !! fields, potential temperature and
                                             !! salinity or mixed layer density.
-                                            !! Absent fields have NULL ptrs.
+                                            !! Absent fields have NULL pointers.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
                  target, intent(in) :: u    !< Array with the u velocity [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
@@ -72,7 +72,6 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
   real :: min_depth                 ! The minimum depth of the ocean [Z ~> m]
   real :: dummy1                    ! The position relative to the sponge width [nondim]
   real :: min_thickness             ! A minimum layer thickness [H ~> m or kg m-2] (unused)
-  real :: lenlat, lenlon            ! The sizes of the domain [km]
   real :: lensponge                 ! The width of the sponge [km]
   character(len=40) :: filename, state_file
   character(len=40) :: temp_var, salt_var, eta_var, inputdir, h_var
@@ -92,17 +91,9 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
   call get_param(PF, mdl, "RGC_TNUDG", TNUDG, 'Nudging time scale for sponge layers', &
                  units='days', default=0.0, scale=86400.0*US%s_to_T)
 
-  call get_param(PF, mdl, "LENLAT", lenlat, &
-                  "The latitudinal or y-direction length of the domain", &
-                 fail_if_missing=.true., do_not_log=.true.)
-
-  call get_param(PF, mdl, "LENLON", lenlon, &
-                  "The longitudinal or x-direction length of the domain", &
-                 fail_if_missing=.true., do_not_log=.true.)
-
   call get_param(PF, mdl, "LENSPONGE", lensponge, &
-                 "The length of the sponge layer (km).", &
-                 default=10.0)
+                 "The length of the sponge layer.", &
+                 units=G%x_ax_unit_short, default=10.0)
 
   call get_param(PF, mdl, "SPONGE_UV", sponge_uv, &
                  "Nudge velocities (u and v) towards zero in the sponge layer.", &
@@ -126,8 +117,8 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
   do i=is,ie ; do j=js,je
     if ((depth_tot(i,j) <= min_depth) .or. (G%geoLonT(i,j) <= lensponge)) then
       Idamp(i,j) = 0.0
-    elseif (G%geoLonT(i,j) >= (lenlon - lensponge) .AND. G%geoLonT(i,j) <= lenlon) then
-      dummy1 = (G%geoLonT(i,j)-(lenlon - lensponge))/(lensponge)
+    elseif (G%geoLonT(i,j) >= (G%len_lon - lensponge) .AND. G%geoLonT(i,j) <= G%len_lon) then
+      dummy1 = (G%geoLonT(i,j)-(G%len_lon - lensponge))/(lensponge)
       Idamp(i,j) = (1.0/TNUDG) * max(0.0,dummy1)
     else
       Idamp(i,j) = 0.0

--- a/src/user/basin_builder.F90
+++ b/src/user/basin_builder.F90
@@ -34,7 +34,7 @@ subroutine basin_builder_topography(D, G, param_file, max_depth)
   character(len=17) :: pname1, pname2 ! For construction of parameter names
   character(len=20) :: funcs ! Basin build function
   real, dimension(20) :: pars ! Parameters for each function
-  real :: lon ! Longitude [degrees_E}
+  real :: lon ! Longitude [degrees_E]
   real :: lat ! Latitude [degrees_N]
   integer :: i, j, n, n_funcs
 

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -41,18 +41,21 @@ contains
 subroutine dumbbell_initialize_topography( D, G, param_file, max_depth )
   type(dyn_horgrid_type),  intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                           intent(out) :: D !< Ocean bottom depth in the units of depth_max
+                           intent(out) :: D !< Ocean bottom depth [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file !< Parameter file structure
-  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
+  real,                    intent(in)  :: max_depth !< Maximum ocean depth [Z ~> m]
 
   ! Local variables
-  integer   :: i, j
-  real      :: x, y, dblen, dbfrac
-  logical   :: dbrotate
+  real    :: x, y   ! Fractional x- and y- positions [nondim]
+  real    :: dblen  ! Lateral length scale for dumbbell [km] or [m]
+  real    :: dbfrac ! Meridional fraction for narrow part of dumbbell [nondim]
+  logical :: dbrotate ! If true, rotate this configuration
+  integer :: i, j
 
   call get_param(param_file, mdl, "DUMBBELL_LEN",dblen, &
                 'Lateral Length scale for dumbbell.', &
                  units='km', default=600., do_not_log=.false.)
+               ! units=G%x_ax_unit_short, default=600., do_not_log=.false.)
   call get_param(param_file, mdl, "DUMBBELL_FRACTION",dbfrac, &
                 'Meridional fraction for narrow part of dumbbell.', &
                  units='nondim', default=0.5, do_not_log=.false.)
@@ -60,8 +63,8 @@ subroutine dumbbell_initialize_topography( D, G, param_file, max_depth )
                 'Logical for rotation of dumbbell domain.', &
                  default=.false., do_not_log=.false.)
 
-  if (G%x_axis_units == 'm') then
-    dblen=dblen*1.e3
+  if (G%x_axis_units(1:1) == 'm') then
+    dblen = dblen*1.e3
   endif
 
   if (dbrotate) then
@@ -107,11 +110,12 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
   real :: eta1D(SZK_(GV)+1) ! Interface height relative to the sea surface
                           ! positive upward [Z ~> m].
   real :: min_thickness   ! The minimum layer thicknesses [Z ~> m].
-  real :: S_ref           ! A default value for salinities [ppt].
+  real :: S_ref           ! A default value for salinities [S ~> ppt].
   real :: S_surf          ! The surface salinity [S ~> ppt]
   real :: S_range         ! The range of salinities in this test case [S ~> ppt]
   real :: S_light, S_dense ! The lightest and densest salinities in the sponges [S ~> ppt].
-  real :: eta_IC_quanta   ! The granularity of quantization of intial interface heights [Z-1 ~> m-1].
+  real :: eta_IC_quanta   ! The granularity of quantization of initial interface heights [Z-1 ~> m-1].
+  real :: x               ! Along-channel position in the axis units [m] or [km] or [deg]
   logical :: dbrotate     ! If true, rotate the domain.
   logical :: use_ALE      ! True if ALE is being used, False if in layered mode
 
@@ -119,7 +123,6 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
 # include "version_variable.h"
   character(len=20) :: verticalCoordinate
   integer :: i, j, k, is, ie, js, je, nz
-  real :: x, y
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -153,7 +156,7 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
                  default=.false., do_not_log=just_read)
     do j=js,je
       do i=is,ie
-       ! Compute normalized zonal coordinates (x,y=0 at center of domain)
+        ! Compute normalized zonal coordinates (x,y=0 at center of domain)
         if (dbrotate) then
           ! This is really y in the rotated case
           x = G%geoLatT(i,j)
@@ -174,18 +177,20 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
         do k=1,nz
           h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
         enddo
-    enddo; enddo
+      enddo
+    enddo
 
   case ( REGRIDDING_RHO, REGRIDDING_HYCOM1) ! Initial thicknesses for isopycnal coordinates
     call get_param(param_file, mdl, "INITIAL_SSS", S_surf, &
                    units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "INITIAL_S_RANGE", S_range, &
                    units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=.true.)
-    call get_param(param_file, mdl, "S_REF", S_ref, default=35.0, do_not_log=.true.)
+    call get_param(param_file, mdl, "S_REF", S_ref, &
+                   units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, &
-                   units='1e-3', default=S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                   units='1e-3', default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, &
-                   units='1e-3', default=S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                   units='1e-3', default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "INTERFACE_IC_QUANTA", eta_IC_quanta, &
                    "The granularity of initial interface height values "//&
                    "per meter, to avoid sensivity to order-of-arithmetic changes.", &
@@ -263,9 +268,9 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
   real    :: S_range   ! The range of salinities in this test case [S ~> ppt]
   real    :: T_surf    ! The surface temperature [C ~> degC]
   real    :: x         ! The fractional position in the domain [nondim]
-  real    :: dblen     ! The size of the dumbbell test case [axis_units]
+  real    :: dblen     ! The size of the dumbbell test case [km] or [m]
   logical :: dbrotate  ! If true, rotate the domain.
-  logical :: use_ALE     ! If false, use layer mode.
+  logical :: use_ALE   ! If false, use layer mode.
   character(len=20) :: verticalCoordinate, density_profile
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -291,11 +296,12 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
   call get_param(param_file, mdl, "DUMBBELL_LEN", dblen, &
                 'Lateral Length scale for dumbbell ', &
                  units='km', default=600., do_not_log=just_read)
+               ! units=G%x_ax_unit_short, default=600., do_not_log=.false.)
   call get_param(param_file, mdl, "DUMBBELL_ROTATION", dbrotate, &
                 'Logical for rotation of dumbbell domain.', &
                  default=.false., do_not_log=just_read)
 
-  if (G%x_axis_units == 'm') then
+  if (G%x_axis_units(1:1) == 'm') then
     dblen = dblen*1.e3
   endif
 
@@ -346,12 +352,12 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
   real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h ! sponge thicknesses [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: S ! sponge salinities [S ~> ppt]
-  real, dimension(SZK_(GV)+1) :: eta1D ! interface positions for ALE sponge
+  real, dimension(SZK_(GV)+1) :: eta1D ! Interface positions for ALE sponge [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: eta ! A temporary array for interface heights [Z ~> m].
 
   integer :: i, j, k, nz
   real :: x              ! The fractional position in the domain [nondim]
-  real :: dblen          ! The size of the dumbbell test case [axis_units]
+  real :: dblen          ! The size of the dumbbell test case [km] or [m]
   real :: min_thickness  ! The minimum layer thickness [Z ~> m]
   real :: S_ref, S_range ! A reference salinity and the range of salinities in this test case [S ~> ppt]
   logical :: dbrotate    ! If true, rotate the domain.
@@ -363,8 +369,8 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
                 'Logical for rotation of dumbbell domain.', &
                  default=.false., do_not_log=.true.)
 
-  if (G%x_axis_units == 'm') then
-    dblen=dblen*1.e3
+  if (G%x_axis_units(1:1) == 'm') then
+    dblen = dblen*1.e3
   endif
 
   nz = GV%ke
@@ -448,7 +454,7 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
     enddo ; enddo
   if (associated(tv%S)) call set_up_ALE_sponge_field(S, G, GV, tv%S, ACSp, 'salt', &
                           sp_long_name='salinity', sp_unit='g kg-1 s-1')
- else
+  else
     do j=G%jsc,G%jec ; do i=G%isc,G%iec
       eta(i,j,1) = 0.0
       do k=2,nz
@@ -466,7 +472,7 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
 
     !  The remaining calls to set_up_sponge_field can be in any order. !
     if ( associated(tv%S) ) call set_up_sponge_field(S, tv%S, G, GV, nz, CSp)
- endif
+  endif
 
 end subroutine dumbbell_initialize_sponges
 

--- a/src/user/external_gwave_initialization.F90
+++ b/src/user/external_gwave_initialization.F90
@@ -39,7 +39,7 @@ subroutine external_gwave_initialize_thickness(h, G, GV, US, param_file, just_re
   real :: eta1D(SZK_(GV)+1)  ! Interface height relative to the sea surface
                              ! positive upward [Z ~> m].
   real :: ssh_anomaly_height ! Vertical height of ssh anomaly [Z ~> m]
-  real :: ssh_anomaly_width ! Lateral width of anomaly [degrees]
+  real :: ssh_anomaly_width  ! Lateral width of anomaly, often in [km] or [degrees_E]
   character(len=40)  :: mdl = "external_gwave_initialize_thickness" ! This subroutine's name.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -53,11 +53,11 @@ subroutine external_gwave_initialize_thickness(h, G, GV, US, param_file, just_re
 
   if (.not.just_read) call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "SSH_ANOMALY_HEIGHT", ssh_anomaly_height, &
-                 "The vertical displacement of the SSH anomaly. ", units="m", scale=US%m_to_Z, &
-                 fail_if_missing=.not.just_read, do_not_log=just_read)
+                 "The vertical displacement of the SSH anomaly. ", &
+                 units="m", scale=US%m_to_Z, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "SSH_ANOMALY_WIDTH", ssh_anomaly_width, &
-                 "The lateral width of the SSH anomaly. ", units="coordinate", &
-                 fail_if_missing=.not.just_read, do_not_log=just_read)
+                 "The lateral width of the SSH anomaly. ", &
+                 units=G%x_ax_unit_short, fail_if_missing=.not.just_read, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -40,25 +40,28 @@ contains
 subroutine seamount_initialize_topography( D, G, param_file, max_depth )
   type(dyn_horgrid_type),  intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                           intent(out) :: D !< Ocean bottom depth in the units of depth_max
+                           intent(out) :: D !< Ocean bottom depth [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file !< Parameter file structure
-  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
+  real,                    intent(in)  :: max_depth !< Maximum ocean depth [Z ~> m]
 
   ! Local variables
+  real :: delta     ! Height of the seamount as a fraction of the maximum ocean depth [nondim]
+  real :: x, y      ! Normalized positions relative to the domain center [nondim]
+  real :: Lx, Ly    ! Seamount length scales normalized by the relevant domain sizes [nondim]
+  real :: rLx, rLy  ! The Adcroft reciprocals of Lx and Ly [nondim]
   integer   :: i, j
-  real      :: x, y, delta, Lx, rLx, Ly, rLy
 
-  call get_param(param_file, mdl,"SEAMOUNT_DELTA",delta, &
+  call get_param(param_file, mdl,"SEAMOUNT_DELTA", delta, &
                  "Non-dimensional height of seamount.", &
-                 units="non-dim", default=0.5)
-  call get_param(param_file, mdl,"SEAMOUNT_X_LENGTH_SCALE",Lx, &
+                 units="nondim", default=0.5)
+  call get_param(param_file, mdl,"SEAMOUNT_X_LENGTH_SCALE", Lx, &
                  "Length scale of seamount in x-direction. "//&
                  "Set to zero make topography uniform in the x-direction.", &
-                 units="Same as x,y", default=20.)
-  call get_param(param_file, mdl,"SEAMOUNT_Y_LENGTH_SCALE",Ly, &
+                 units=G%x_ax_unit_short, default=20.)
+  call get_param(param_file, mdl,"SEAMOUNT_Y_LENGTH_SCALE", Ly, &
                  "Length scale of seamount in y-direction. "//&
                  "Set to zero make topography uniform in the y-direction.", &
-                 units="Same as x,y", default=0.)
+                 units=G%y_ax_unit_short, default=0.)
 
   Lx = Lx / G%len_lon
   Ly = Ly / G%len_lat
@@ -93,7 +96,7 @@ subroutine seamount_initialize_thickness (h, depth_tot, G, GV, US, param_file, j
                           ! negative because it is positive upward.
   real :: eta1D(SZK_(GV)+1) ! Interface height relative to the sea surface, positive upward [Z ~> m]
   real :: min_thickness   ! The minimum layer thicknesses [Z ~> m].
-  real :: S_ref           ! A default value for salinities [ppt].
+  real :: S_ref           ! A default value for salinities [S ~> ppt].
   real :: S_surf, S_range, S_light, S_dense ! Various salinities [S ~> ppt].
   real :: eta_IC_quanta   ! The granularity of quantization of intial interface heights [Z-1 ~> m-1].
   character(len=20) :: verticalCoordinate
@@ -129,11 +132,11 @@ subroutine seamount_initialize_thickness (h, depth_tot, G, GV, US, param_file, j
     call get_param(param_file, mdl,"INITIAL_S_RANGE", S_range, &
                    units="ppt", default=2., scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "S_REF", S_ref, &
-                   units="ppt", default=35.0, scale=1.0, do_not_log=.true.)
+                   units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, &
-                   units="ppt", default=S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, &
-                   units="ppt", default=S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "INTERFACE_IC_QUANTA", eta_IC_quanta, &
                    "The granularity of initial interface height values "//&
                    "per meter, to avoid sensivity to order-of-arithmetic changes.", &
@@ -208,8 +211,8 @@ subroutine seamount_initialize_temperature_salinity(T, S, h, G, GV, US, param_fi
   ! Local variables
   real :: xi0, xi1  ! Fractional positions within the depth range [nondim]
   real :: r         ! A nondimensional sharpness parameter with an exponetial profile [nondim]
-  real :: S_Ref     ! Default salinity range parameters [ppt].
-  real :: T_Ref     ! Default temperature range parameters [degC].
+  real :: S_Ref     ! Default salinity range parameters [S ~> ppt].
+  real :: T_Ref     ! Default temperature range parameters [C ~> degC].
   real :: S_Light, S_Dense, S_surf, S_range ! Salinity range parameters [S ~> ppt].
   real :: T_Light, T_Dense, T_surf, T_range ! Temperature range parameters [C ~> degC].
   real :: res_rat   ! The ratio of density space resolution in the denser part
@@ -245,17 +248,17 @@ subroutine seamount_initialize_temperature_salinity(T, S, h, G, GV, US, param_fi
     case ( REGRIDDING_LAYER ) ! Initial thicknesses for layer isopycnal coordinates
       ! These parameters are used in MOM_fixed_initialization.F90 when CONFIG_COORD="ts_range"
       call get_param(param_file, mdl, "T_REF", T_ref, &
-                 units="degC", default=10.0, do_not_log=.true.)
+                 units="degC", default=10.0, scale=US%degC_to_C, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_T_LIGHT", T_light, &
-                 units="degC", default=T_Ref, scale=US%degC_to_C, do_not_log=.true.)
+                 units="degC", default=US%C_to_degC*T_Ref, scale=US%degC_to_C, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_T_DENSE", T_dense, &
-                 units="degC", default=T_Ref, scale=US%degC_to_C, do_not_log=.true.)
+                 units="degC", default=US%C_to_degC*T_Ref, scale=US%degC_to_C, do_not_log=.true.)
       call get_param(param_file, mdl, "S_REF", S_ref, &
-                 units="1e-3", default=35.0, scale=1.0, do_not_log=.true.)
+                 units="1e-3", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, &
-                 units="1e-3", default=S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="1e-3", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, &
-                 units="1e-3", default=S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="1e-3", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_RESOLN_RATIO", res_rat, &
                  units="nondim", default=1.0, do_not_log=.true.)
       if (just_read) return ! All run-time parameters have been read, so return.

--- a/src/user/user_change_diffusivity.F90
+++ b/src/user/user_change_diffusivity.F90
@@ -230,7 +230,7 @@ subroutine user_change_diff_init(Time, G, GV, US, param_file, diag, CS)
                  "applied.  The four values specify the latitudes at "//&
                  "which the extra diffusivity starts to increase from 0, "//&
                  "hits its full value, starts to decrease again, and is "//&
-                 "back to 0.", units="degree", default=-1.0e9)
+                 "back to 0.", units="degrees_N", default=-1.0e9)
     call get_param(param_file, mdl, "USER_KD_ADD_RHO_RANGE", CS%rho_range(:), &
                  "Four successive values that define a range of potential "//&
                  "densities over which the user-given extra diffusivity "//&


### PR DESCRIPTION
  The series of commits in this PR adds or modify units arguments to 22 get_param calls in 14 user or tracer modules, and it uses elements of the ocean_grid_type to specify the units of some horizontal position related variables or to determine the domain size.  It also includes a commit that cleans up the internal tide debugging source locations and another that adds 6 new runtime parameters to replace hard-coded values in the ISOMIP configuration. These commits also add comments describing many internal real variables and their units in these same files.  All answers and output are bitwise identical, but there are changes in some of the MOM_parameter_doc files.

  This series of commits includes many of the changes that are required to make the units argument mandatory for calls to get_param_real.  The changes in each file are independent of each other, and the public interfaces do not change.

  The commits in this PR include:

- NOAA-GFDL/MOM6@c002974f9 +Document units in dye_example
- NOAA-GFDL/MOM6@522fe7395 +Document variable units in shelfwave_initialization
- NOAA-GFDL/MOM6@e23bd1f15 +Rescale default salinity in dumbbell_initialization
- NOAA-GFDL/MOM6@19f7d9ad3 +Document units in adjustment_initialization
- NOAA-GFDL/MOM6@6109aba1a +Document units in RGC_initialization & RGC_tracer
- NOAA-GFDL/MOM6@a22801c7c +Document units in Neverworld_initialization
- NOAA-GFDL/MOM6@14672c8a7 +Standard seamount_initialization axis unit docs
- NOAA-GFDL/MOM6@590b2555d +Document and rescale ISOMIP parameters
- NOAA-GFDL/MOM6@f67883df0 +Standardize user module axis unit documentation
- NOAA-GFDL/MOM6@ba5e51c9a (+)Correct units of INTERNAL_TIDE_SOURCE_X params
