### PR TITLE
+Add CPP macro _USE_OCEAN_BGC_PR20 to avoid bug

### DIFF
--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -512,7 +512,12 @@ contains
     !
     g_tracer=>CS%g_tracer_list
     do
+! After ocean_BGC PR #20 has been merged in for a while, the following CPP macro can be removed.
+#ifdef _USE_OCEAN_BGC_PR20
       if (_ALLOCATED(g_tracer%trunoff) .and. (.NOT. g_tracer%runoff_added_to_stf)) then
+#else
+      if (_ALLOCATED(g_tracer%trunoff)) then
+#endif
         call g_tracer_get_alias(g_tracer,g_tracer_name)
         call g_tracer_get_pointer(g_tracer,g_tracer_name,'stf',   stf_array)
         call g_tracer_get_pointer(g_tracer,g_tracer_name,'trunoff',trunoff_array)
@@ -521,7 +526,10 @@ contains
         runoff_tracer_flux_array(:,:) = trunoff_array(:,:) * &
                  US%RZ_T_to_kg_m2s*fluxes%lrunoff(:,:)
         stf_array = stf_array + runoff_tracer_flux_array
+! After ocean_BGC PR #20 has been merged in for a while, the following CPP macro can be removed.
+#ifdef _USE_OCEAN_BGC_PR20
         g_tracer%runoff_added_to_stf = .true.
+#endif
       endif
 
       !traverse the linked list till hit NULL


### PR DESCRIPTION
  Added the new CPP macro _USE_OCEAN_BGC_PR20 to deal with the fact that the recently added element runoff_added_to_stf does not yet exist within the ocean_BGC version of the g_tracer_type, although it was added to the version in confic_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90 as a part of PR#246.  This caused the latest version of MOM6 to be unable to compile with the ocean_BGC code.  With this new CPP macro, the code will once again compile, and these bits of code can be enabled once the ocean_BGC code has this new element in its version of the g_tracer_type.  Once there is sufficiently widespread adoption of newer versions of the ocean_BGC code, these newly added macros can be eliminated altogether.  This commit should address the issued documented under github.com/NOAA-GFDL/MOM6/issues/278.  Note that the use of CPP macros in this way is generally strongly discouraged in MOM6, but it does seem like a viable solution for addressing an interface change across two separately managed code repositories.