### PR TITLE
Reorder i- and j-loops to be stride-1 in memory

### DIFF
--- a/src/diagnostics/MOM_spatial_means.F90
+++ b/src/diagnostics/MOM_spatial_means.F90
@@ -367,7 +367,7 @@ subroutine global_i_mean(array, i_mean, G, mask, scale, tmp_scale)
       asum(j) = real_to_EFP(0.0) ; mask_sum(j) = real_to_EFP(0.0)
     enddo
 
-    do i=is,ie ; do j=js,je
+    do j=js,je ; do i=is,ie
       asum(j+jdg_off) = asum(j+jdg_off) + real_to_EFP(scalefac*array(i,j)*mask(i,j))
       mask_sum(j+jdg_off) = mask_sum(j+jdg_off) + real_to_EFP(mask(i,j))
     enddo ; enddo
@@ -392,7 +392,7 @@ subroutine global_i_mean(array, i_mean, G, mask, scale, tmp_scale)
   else
     do j=G%jsg,G%jeg ; asum(j) = real_to_EFP(0.0) ; enddo
 
-    do i=is,ie ; do j=js,je
+    do j=js,je ; do i=is,ie
       asum(j+jdg_off) = asum(j+jdg_off) + real_to_EFP(scalefac*array(i,j))
     enddo ; enddo
 

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -323,12 +323,12 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
   PI = 4.0*atan(1.0)
 
   if (trim(topog_config) == "flat") then
-    do i=is,ie ; do j=js,je ; D(i,j) = max_depth ; enddo ; enddo
+    do j=js,je ; do i=is,ie ; D(i,j) = max_depth ; enddo ; enddo
   elseif (trim(topog_config) == "spoon") then
     D0 = (max_depth - Dedge) / &
              ((1.0 - exp(-0.5*G%len_lat*G%Rad_Earth_L*PI/(180.0 *expdecay))) * &
               (1.0 - exp(-0.5*G%len_lat*G%Rad_Earth_L*PI/(180.0 *expdecay))))
-    do i=is,ie ; do j=js,je
+    do j=js,je ; do i=is,ie
   !  This sets a bowl shaped (sort of) bottom topography, with a       !
   !  maximum depth of max_depth.                                   !
       D(i,j) =  Dedge + D0 * &
@@ -343,7 +343,7 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
 
   !  This sets a bowl shaped (sort of) bottom topography, with a
   !  maximum depth of max_depth.
-    do i=is,ie ; do j=js,je
+    do j=js,je ; do i=is,ie
       D(i,j) =  Dedge + D0 * &
              (sin(PI * (G%geoLonT(i,j) - G%west_lon) / G%len_lon) * &
              ((1.0 - exp(-(G%geoLatT(i,j) - G%south_lat)*G%Rad_Earth_L*PI/ &
@@ -353,7 +353,7 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
     enddo ; enddo
   elseif (trim(topog_config) == "halfpipe") then
     D0 = max_depth - Dedge
-    do i=is,ie ; do j=js,je
+    do j=js,je ; do i=is,ie
       D(i,j) =  Dedge + D0 * ABS(sin(PI*(G%geoLatT(i,j) - G%south_lat)/G%len_lat))
     enddo ; enddo
   else
@@ -362,7 +362,7 @@ subroutine initialize_topography_named(D, G, param_file, topog_config, max_depth
   endif
 
   ! This is here just for safety.  Hopefully it doesn't do anything.
-  do i=is,ie ; do j=js,je
+  do j=js,je ; do i=is,ie
     if (D(i,j) > max_depth) D(i,j) = max_depth
     if (D(i,j) < min_depth) D(i,j) = 0.5*min_depth
   enddo ; enddo

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -157,7 +157,7 @@ subroutine advect_tracer(h_end, uhtr, vhtr, OBC, dt, G, GV, US, CS, Reg, x_first
     !   This loop reconstructs the thickness field the last time that the
     ! tracers were updated, probably just after the diabatic forcing.  A useful
     ! diagnostic could be to compare this reconstruction with that older value.
-      do i=is,ie ; do j=js,je
+      do j=js,je ; do i=is,ie
         hprev(i,j,k) = max(0.0, G%areaT(i,j)*h_end(i,j,k) + &
              ((uhr(I,j,k) - uhr(I-1,j,k)) + (vhr(i,J,k) - vhr(i,J-1,k))))
     ! In the case that the layer is now dramatically thinner than it was previously,
@@ -167,7 +167,7 @@ subroutine advect_tracer(h_end, uhtr, vhtr, OBC, dt, G, GV, US, CS, Reg, x_first
                        max(0.0, 1.0e-13*hprev(i,j,k) - G%areaT(i,j)*h_end(i,j,k))
       enddo ; enddo
     else
-      do i=is,ie ; do j=js,je
+      do j=js,je ; do i=is,ie
         hprev(i,j,k) = vol_prev(i,j,k)
       enddo ; enddo
     endif

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -68,7 +68,7 @@ subroutine Phillips_initialize_thickness(h, depth_tot, G, GV, US, param_file, ju
   if (.not.just_read) call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "HALF_STRAT_DEPTH", half_strat, &
                  "The fractional depth where the stratification is centered.", &
-                 units="nondim", default = 0.5, do_not_log=just_read)
+                 units="nondim", default=0.5, do_not_log=just_read)
   call get_param(param_file, mdl, "JET_WIDTH", jet_width, &
                  "The width of the zonal-mean jet.", units="km", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
@@ -262,10 +262,10 @@ subroutine Phillips_initialize_sponges(G, GV, US, tv, param_file, CSp, h)
   first_call = .false.
   call get_param(param_file, mdl, "HALF_STRAT_DEPTH", half_strat, &
                  "The fractional depth where the stratificaiton is centered.", &
-                 units="nondim", default = 0.5)
+                 units="nondim", default=0.5)
   call get_param(param_file, mdl, "SPONGE_RATE", damp_rate, &
                  "The rate at which the zonal-mean sponges damp.", &
-                 units="s-1", default = 1.0/(10.0*86400.0), scale=US%T_to_s)
+                 units="s-1", default=1.0/(10.0*86400.0), scale=US%T_to_s)
 
   call get_param(param_file, mdl, "JET_WIDTH", jet_width, &
                  "The width of the zonal-mean jet.", units="km", &
@@ -352,7 +352,7 @@ subroutine Phillips_initialize_topography(D, G, param_file, max_depth, US)
   y1=G%south_lat+0.5*G%len_lat+offset-0.5*Wtop; y2=y1+Wtop
   x1=G%west_lon+0.1*G%len_lon; x2=x1+Ltop; x3=x1+dist; x4=x3+3.0/2.0*Ltop
 
-  do i=is,ie ; do j=js,je
+  do j=js,je ; do i=is,ie
     D(i,j)=0.0
     if (G%geoLonT(i,j)>x1 .and. G%geoLonT(i,j)<x2) then
       D(i,j) = Htop*sin(PI*(G%geoLonT(i,j)-x1)/(x2-x1))**2

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -123,7 +123,7 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
   !  will automatically set up the sponges only where Idamp is positive
   !  and mask2dT is 1.
 
-  do i=is,ie ; do j=js,je
+  do j=js,je ; do i=is,ie
     if ((depth_tot(i,j) <= min_depth) .or. (G%geoLonT(i,j) <= lensponge)) then
       Idamp(i,j) = 0.0
     elseif (G%geoLonT(i,j) >= (lenlon - lensponge) .AND. G%geoLonT(i,j) <= lenlon) then

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -268,12 +268,12 @@ subroutine benchmark_init_temperature_salinity(T, S, G, GV, US, param_file, &
     enddo
   enddo
 
-  do k=1,nz ; do i=is,ie ; do j=js,je
+  do k=1,nz ; do j=js,je ; do i=is,ie
     T(i,j,k) = T0(k)
     S(i,j,k) = S0(k)
   enddo ; enddo ; enddo
   PI = 4.0*atan(1.0)
-  do i=is,ie ; do j=js,je
+  do j=js,je ; do i=is,ie
     SST = 0.5*(T0(k1)+T0(nz)) - 0.9*0.5*(T0(k1)-T0(nz)) * &
                                cos(PI*(G%geoLatT(i,j)-G%south_lat)/(G%len_lat))
     do k=1,k1-1


### PR DESCRIPTION
  Swapped the order of the i- and j- loops in 13 places in 6 files so that they will be stride-1 in memory for efficiency, and to follow the established patterns elsewhere in the MOM6 code.  All answers are bitwise identical.