### PR TITLE
Avoid using the unscaled argument to MOM_get_param

### DIFF
--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -1801,9 +1801,8 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
                  "parameters from vertical units of m to kg m-2.", &
                  units="kg m-3", default=1035.0, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
-                 "If true, the buoyancy fluxes drive the model back "//&
-                 "toward some specified surface state with a rate "//&
-                 "given by FLUXCONST.", default= .false.)
+                 "If true, the buoyancy fluxes drive the model back toward some "//&
+                 "specified surface state with a rate given by FLUXCONST.", default=.false.)
   call get_param(param_file, mdl, "LATENT_HEAT_FUSION", CS%latent_heat_fusion, &
                  "The latent heat of fusion.", default=hlf, &
                  units="J/kg", scale=US%J_kg_to_Q)
@@ -1814,22 +1813,19 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes to the relative "//&
                  "surface anomalies (akin to a piston velocity).  Note the non-MKS units.", &
-                 default=0.0, units="m day-1", scale=US%m_to_Z*US%T_to_s/86400.0, &
-                 unscaled=flux_const_default)
+                 default=0.0, units="m day-1", scale=US%m_to_Z*US%T_to_s/86400.0)
 
     if (CS%use_temperature) then
+      call get_param(param_file, mdl, "FLUXCONST", flux_const_default, &
+                 default=0.0, units="m day-1", do_not_log=.true.)
       call get_param(param_file, mdl, "FLUXCONST_T", CS%Flux_const_T, &
-           "The constant that relates the restoring surface temperature "//&
-           "flux to the relative surface anomaly (akin to a piston "//&
-           "velocity).  Note the non-MKS units.", &
-           units="m day-1", scale=US%m_to_Z*US%T_to_s/86400.0, &
-           default=flux_const_default)
+                 "The constant that relates the restoring surface temperature flux to the "//&
+                 "relative surface anomaly (akin to a piston velocity).  Note the non-MKS units.", &
+                 units="m day-1", scale=US%m_to_Z*US%T_to_s/86400.0, default=flux_const_default)
       call get_param(param_file, mdl, "FLUXCONST_S", CS%Flux_const_S, &
-           "The constant that relates the restoring surface salinity "//&
-           "flux to the relative surface anomaly (akin to a piston "//&
-           "velocity).  Note the non-MKS units.", &
-           units="m day-1", scale=US%m_to_Z*US%T_to_s/86400.0, &
-           default=flux_const_default)
+                 "The constant that relates the restoring surface salinity flux to the "//&
+                 "relative surface anomaly (akin to a piston velocity).  Note the non-MKS units.", &
+                 units="m day-1", scale=US%m_to_Z*US%T_to_s/86400.0, default=flux_const_default)
     endif
 
     if (trim(CS%buoy_config) == "linear") then
@@ -1853,7 +1849,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
   endif
   call get_param(param_file, mdl, "G_EARTH", CS%G_Earth, &
                  "The gravitational acceleration of the Earth.", &
-                 units="m s-2", default = 9.80, scale=US%m_to_L**2*US%Z_to_m*US%T_to_s**2)
+                 units="m s-2", default=9.80, scale=US%m_to_L**2*US%Z_to_m*US%T_to_s**2)
 
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", &

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -3363,7 +3363,7 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
   real :: BL_detrain_time_dflt ! The default value for BUFFER_LAY_DETRAIN_TIME [s]
   real :: omega_frac_dflt  ! The default value for ML_OMEGA_FRAC [nondim]
   real :: ustar_min_dflt   ! The default value for BML_USTAR_MIN [Z T-1 ~> m s-1]
-  real :: Hmix_min_m       ! The unscaled value of HMIX_MIN [m]
+  real :: Hmix_min_z       ! The default value of HMIX_MIN [Z ~> m]
   integer :: isd, ied, jsd, jed
   logical :: use_temperature, use_omega
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -3419,10 +3419,10 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
   call get_param(param_file, mdl, 'VON_KARMAN_CONST', CS%vonKar, &
                  'The value the von Karman constant as used for mixed layer viscosity.', &
                  units='nondim', default=0.41)
-  call get_param(param_file, mdl, "HMIX_MIN", CS%Hmix_min, &
+  call get_param(param_file, mdl, "HMIX_MIN", Hmix_min_Z, &
                  "The minimum mixed layer depth if the mixed layer depth "//&
-                 "is determined dynamically.", units="m", default=0.0, scale=GV%m_to_H, &
-                 unscaled=Hmix_min_m)
+                 "is determined dynamically.", units="m", default=0.0, scale=US%m_to_Z)
+  CS%Hmix_min = GV%Z_to_H * Hmix_min_Z
 
   call get_param(param_file, mdl, "LIMIT_BUFFER_DETRAIN", CS%limit_det, &
                  "If true, limit the detrainment from the buffer layers "//&
@@ -3466,7 +3466,7 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
   call get_param(param_file, mdl, "DEPTH_LIMIT_FLUXES", CS%H_limit_fluxes, &
                  "The surface fluxes are scaled away when the total ocean "//&
                  "depth is less than DEPTH_LIMIT_FLUXES.", &
-                 units="m", default=0.1*Hmix_min_m, scale=GV%m_to_H)
+                 units="m", default=0.1*US%Z_to_m*Hmix_min_z, scale=GV%m_to_H)
   call get_param(param_file, mdl, "OMEGA", CS%omega, &
                  "The rotation rate of the earth.", &
                  default=7.2921e-5, units="s-1", scale=US%T_to_s)

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1790,7 +1790,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
   ! Local variables
 
   real :: Kv_BBL  ! A viscosity in the bottom boundary layer with a simple scheme [Z2 T-1 ~> m2 s-1].
-  real :: Hmix_m  ! A boundary layer thickness [m].
+  real :: Hmix_z  ! A boundary layer thickness [Z ~> m].
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
   logical :: answers_2018   !< If true, use the order of arithmetic and expressions that recover the
@@ -1894,17 +1894,18 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
                  default=0.0, units="nondim")
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
 
-  if (GV%nkml < 1) &
-    call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix, &
-                 "The prescribed depth over which the near-surface "//&
-                 "viscosity and diffusivity are elevated when the bulk "//&
-                 "mixed layer is not used.", units="m", scale=GV%m_to_H, &
-                 unscaled=Hmix_m, fail_if_missing=.true.)
+  if (GV%nkml < 1) then
+    call get_param(param_file, mdl, "HMIX_FIXED", Hmix_z, &
+                 "The prescribed depth over which the near-surface viscosity and "//&
+                 "diffusivity are elevated when the bulk mixed layer is not used.", &
+                 units="m", scale=US%m_to_Z, fail_if_missing=.true.)
+    CS%Hmix = GV%Z_to_H * Hmix_z
+  endif
   if (CS%direct_stress) then
     if (GV%nkml < 1) then
       call get_param(param_file, mdl, "HMIX_STRESS", CS%Hmix_stress, &
                  "The depth over which the wind stress is applied if DIRECT_STRESS is true.", &
-                 units="m", default=Hmix_m, scale=GV%m_to_H)
+                 units="m", default=US%Z_to_m*Hmix_z, scale=GV%m_to_H)
     else
       call get_param(param_file, mdl, "HMIX_STRESS", CS%Hmix_stress, &
                  "The depth over which the wind stress is applied if DIRECT_STRESS is true.", &


### PR DESCRIPTION
  Avoid using the unscaled argument to MOM_get_param in 5 places in 4 files, and
made related changes to avoid using some unscaled variables:

- Replace Hmix_min_m (in [m]) with Hmix_min_z (in [Z ~> m]) in bulkmixedlayer_init and then set CS%Hmix_min by rescaling Hmix_min_z to [H ~> m or kg m-2].

- Replace Hmix_m (in [m]) with Hmix_z (in [Z ~> m]) in vertvisc_init, and then set CS%Hmix by rescaling Hmix_z to [H ~> m or kg m-2].

- Add a separate unlogged and unscaled get_param call for FLUXCONST for flux_const_default in the solo_driver surface_forcing_init

- Do not rescale FLUXCONST when it is read in the FMS_cap surface_forcing_init.

- The Flux_const element of the FMS_cap surface_forcing_CS was not actually being used apart from setting a default for Flux_const_temp and Flux_const_salt, so it was replaced with a local variable in surface_forcing_init.

- Added comments better describing the internal variables in surface_forcing_init.

All answers and output are bitwise identical.