### PR TITLE
Made STANLEY_COEFF<0 warnings be fatal

### DIFF
--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -869,10 +869,8 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, tides_CS
     call get_param(param_file, mdl, "STANLEY_COEFF", Stanley_coeff, &
                  "Coefficient correlating the temperature gradient and SGS T variance.", &
                  units="nondim", default=-1.0, do_not_log=.true.)
-    if (Stanley_coeff < 0.0) then
-      call MOM_error(WARNING, "STANLEY_COEFF must be set >= 0 if USE_STANLEY_PGF is true.")
-      CS%use_stanley_pgf = .false.
-    endif
+    if (Stanley_coeff < 0.0) call MOM_error(FATAL, &
+                 "STANLEY_COEFF must be set >= 0 if USE_STANLEY_PGF is true.")
 
     CS%id_rho_pgf = register_diag_field('ocean_model', 'rho_pgf', diag%axesTL, &
         Time, 'rho in PGF', 'kg m-3', conversion=US%R_to_kg_m3)

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1214,10 +1214,8 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     call get_param(param_file, mdl, "STANLEY_COEFF", Stanley_coeff, &
                  "Coefficient correlating the temperature gradient and SGS T variance.", &
                  units="nondim", default=-1.0, do_not_log=.true.)
-    if (Stanley_coeff < 0.0) then
-      call MOM_error(WARNING, "STANLEY_COEFF must be set >= 0 if USE_STANLEY_ISO is true.")
-      CS%use_stanley_iso = .false.
-    endif
+    if (Stanley_coeff < 0.0) call MOM_error(FATAL, &
+                 "STANLEY_COEFF must be set >= 0 if USE_STANLEY_ISO is true.")
   endif
 
   if (CS%Resoln_use_ebt .or. CS%khth_use_ebt_struct) then

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -897,10 +897,8 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
     call get_param(param_file, mdl, "STANLEY_COEFF", Stanley_coeff, &
                  "Coefficient correlating the temperature gradient and SGS T variance.", &
                  units="nondim", default=-1.0, do_not_log=.true.)
-    if (Stanley_coeff < 0.0) then
-      call MOM_error(WARNING, "STANLEY_COEFF must be set >= 0 if USE_STANLEY_ML is true.")
-      CS%use_stanley_ml = .false.
-    endif
+    if (Stanley_coeff < 0.0) call MOM_error(FATAL, &
+             "STANLEY_COEFF must be set >= 0 if USE_STANLEY_ML is true.")
   endif
   call get_param(param_file, mdl, 'VON_KARMAN_CONST', CS%vonKar, &
                  'The value the von Karman constant as used for mixed layer viscosity.', &

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -2107,10 +2107,8 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
     call get_param(param_file, mdl, "STANLEY_COEFF", Stanley_coeff, &
                  "Coefficient correlating the temperature gradient and SGS T variance.", &
                  units="nondim", default=-1.0, do_not_log=.true.)
-    if (Stanley_coeff < 0.0) then
-      call MOM_error(WARNING, "STANLEY_COEFF must be set >= 0 if USE_STANLEY_GM is true.")
-      CS%use_stanley_gm = .false.
-    endif
+    if (Stanley_coeff < 0.0) call MOM_error(FATAL, &
+                 "STANLEY_COEFF must be set >= 0 if USE_STANLEY_GM is true.")
   endif
   call get_param(param_file, mdl, "OMEGA", omega, &
                  "The rotation rate of the earth.", &


### PR DESCRIPTION
We were issuing a WARNING when the user indicates to use the STANLEY contribution to density with a logical flag but if the coefficient is negative we were toggling the logical flag with logging and only issuing a warning. This would lead to users getting a result they were not expecting, regardless of whether they were informed. Better for the run to fail so they can set the coefficient to non-negative.