### PR TITLE
+Revise horiz_interp_and_extrap and set related params

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2737,6 +2737,10 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  units="1e-3", default=1.0e-3, scale=US%ppt_to_S, do_not_log=just_read)
 
   if (just_read) then
+    if ((.not.useALEremapping) .and. adjust_temperature) &
+      ! This call is just here to read and log the determine_temperature parameters
+      call determine_temperature(tv%T, tv%S, GV%Rlay(1:nz), eos, tv%P_Ref, 0, &
+                                 h, 0, G, GV, US, PF, just_read=.true.)
     call cpu_clock_end(id_clock_routine)
     return ! All run-time parameters have been read, so return.
   endif
@@ -2957,8 +2961,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
     if (adjust_temperature) then
       ! Finally adjust to target density
       ks = 1 ; if (separate_mixed_layer) ks = GV%nk_rho_varies + 1
-      call determine_temperature(tv%T, tv%S, GV%Rlay(1:nz), tv%P_Ref, niter, &
-                                 h, ks, G, GV, US, eos)
+      call determine_temperature(tv%T, tv%S, GV%Rlay(1:nz), eos, tv%P_Ref, niter, &
+                                 h, ks, G, GV, US, PF, just_read)
     endif
 
   endif ! useALEremapping

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -41,11 +41,12 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   type(unit_scale_type),      intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                               intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
-  real, dimension(:,:,:),     pointer       :: tr  !< Pointer to array to be initialized
+  real, dimension(:,:,:),     pointer       :: tr  !< Pointer to array to be initialized [CU ~> conc]
   type(param_file_type),      intent(in)    :: PF  !< parameter file
   character(len=*),           intent(in)    :: src_file !< source filename
   character(len=*),           intent(in)    :: src_var_nam !< variable name in file
-  real,             optional, intent(in)    :: src_var_unit_conversion !< optional multiplicative unit conversion
+  real,             optional, intent(in)    :: src_var_unit_conversion !< optional multiplicative unit conversion,
+                                                   !! often used for rescaling into model units [CU conc-1 ~> 1]
   integer,          optional, intent(in)    :: src_var_record  !< record to read for multiple time-level files
   logical,          optional, intent(in)    :: homogenize !< optionally homogenize to mean value
   logical,          optional, intent(in)    :: useALEremapping !< to remap or not (optional)
@@ -53,11 +54,11 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   character(len=*), optional, intent(in)    :: src_var_gridspec !< Source variable name in a gridspec file.
                                                                 !! This is not implemented yet.
   ! Local variables
-  real :: land_fill = 0.0
-  real               :: convert
+  real :: land_fill = 0.0  ! A value to use to replace missing values [CU ~> conc]
+  real :: convert ! A conversion factor into the model's internal units [CU conc-1 ~> 1]
   integer            :: recnum
   character(len=64)  :: remapScheme
-  logical            :: homog,useALE
+  logical            :: homog, useALE
 
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -66,8 +67,12 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   integer :: is, ie, js, je, nz ! compute domain indices
   integer :: isd, ied, jsd, jed ! data domain indices
   integer :: i, j, k, kd
-  real, allocatable, dimension(:,:,:), target :: tr_z, mask_z
-  real, allocatable, dimension(:), target :: z_edges_in, z_in
+  real, allocatable, dimension(:,:,:), target :: tr_z   ! Tracer array on the horizontal model grid
+                                                        ! and input-file vertical levels [CU ~> conc]
+  real, allocatable, dimension(:,:,:), target :: mask_z ! Missing value mask on the horizontal model grid
+                                                        ! and input-file vertical levels [nondim]
+  real, allocatable, dimension(:), target :: z_edges_in ! Cell edge depths for input data [Z ~> m]
+  real, allocatable, dimension(:), target :: z_in       ! Cell center depths for input data [Z ~> m]
 
   ! Local variables for ALE remapping
   real, dimension(:,:,:), allocatable :: hSrc ! Source thicknesses [H ~> m or kg m-2].
@@ -75,8 +80,8 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   real :: zTopOfCell, zBottomOfCell, z_bathy  ! Heights [Z ~> m].
   type(remapping_CS) :: remapCS ! Remapping parameters and work arrays
 
-  real :: missing_value
-  integer :: nPoints
+  real :: missing_value ! A value indicating that there is no valid input data at this point [CU ~> conc]
+  integer :: nPoints    ! The number of valid input data points in a column
   integer :: id_clock_routine, id_clock_ALE
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
@@ -94,7 +99,6 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                                   ! for horizontal regridding.  Values below 20190101 recover the
                                   ! answers from 2018, while higher values use expressions that have
                                   ! been rearranged for rotational invariance.
-  logical :: reentrant_x, tripolar_n
 
   id_clock_routine = cpu_clock_id('(Initialize tracer from Z)', grain=CLOCK_ROUTINE)
   id_clock_ALE = cpu_clock_id('(Initialize tracer from Z) ALE', grain=CLOCK_LOOP)
@@ -153,22 +157,17 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                  "If both HOR_REGRID_2018_ANSWERS and HOR_REGRID_ANSWER_DATE are specified, the "//&
                  "latter takes precedence.", default=default_hor_reg_ans_date)
 
-  ! These are model grid properties, but being applied to the data grid for now.
-  ! need to revisit this (mjh)
-  reentrant_x = .false. ;  call get_param(PF, mdl, "REENTRANT_X", reentrant_x,default=.true.)
-  tripolar_n = .false. ;  call get_param(PF, mdl, "TRIPOLAR_N", tripolar_n, default=.false.)
-
   if (PRESENT(homogenize)) homog=homogenize
   if (PRESENT(useALEremapping)) useALE=useALEremapping
   if (PRESENT(remappingScheme)) remapScheme=remappingScheme
-  recnum=1
+  recnum = 1
   if (PRESENT(src_var_record)) recnum = src_var_record
-  convert=1.0
+  convert = 1.0
   if (PRESENT(src_var_unit_conversion)) convert = src_var_unit_conversion
 
-  call horiz_interp_and_extrap_tracer(src_file, src_var_nam, convert, recnum, &
-       G, tr_z, mask_z, z_in, z_edges_in, missing_value, reentrant_x, tripolar_n, &
-       homog, m_to_Z=US%m_to_Z, answer_date=hor_regrid_answer_date)
+  call horiz_interp_and_extrap_tracer(src_file, src_var_nam, recnum, &
+            G, tr_z, mask_z, z_in, z_edges_in, missing_value, &
+            scale=convert, homogenize=homog, m_to_Z=US%m_to_Z, answer_date=hor_regrid_answer_date)
 
   kd = size(z_edges_in,1)-1
   call pass_var(tr_z,G%Domain)
@@ -221,7 +220,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
 ! Fill land values
   do k=1,nz ; do j=js,je ; do i=is,ie
     if (tr(i,j,k) == missing_value) then
-      tr(i,j,k)=land_fill
+      tr(i,j,k) = land_fill
     endif
   enddo ; enddo ; enddo
 

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -69,8 +69,8 @@ type :: p3d
   integer :: id !< id for FMS external time interpolator
   integer :: nz_data !< The number of vertical levels in the input field.
   integer :: num_tlevs !< The number of time records contained in the file
-  real, dimension(:,:,:), pointer :: p => NULL() !< pointer to the data.
-  real, dimension(:,:,:), pointer :: h => NULL() !< pointer to the data grid.
+  real, dimension(:,:,:), pointer :: p => NULL() !< pointer to the data [various]
+  real, dimension(:,:,:), pointer :: h => NULL() !< pointer to the data grid [H ~> m or kg m-2]
 end type p3d
 
 !> A structure for creating arrays of pointers to 2D arrays with extra gridding information
@@ -79,8 +79,8 @@ type :: p2d
   integer :: nz_data !< The number of vertical levels in the input field
   integer :: num_tlevs !< The number of time records contained in the file
   real :: scale = 1.0  !< A multiplicative factor by which to rescale input data
-  real, dimension(:,:), pointer :: p => NULL() !< pointer the data.
-  real, dimension(:,:), pointer :: h => NULL() !< pointer the data grid.
+  real, dimension(:,:), pointer :: p => NULL() !< pointer to the data [various]
+  real, dimension(:,:), pointer :: h => NULL() !< pointer the data grid [H ~> m or kg m-2]
   character(len=:), allocatable  :: name  !< The name of the input field
   character(len=:), allocatable  :: long_name !< The long name of the input field
   character(len=:), allocatable  :: unit !< The unit of the input field
@@ -687,9 +687,9 @@ subroutine set_up_ALE_sponge_field_fixed(sp_val, G, GV, f_ptr, CS,  &
   type(ALE_sponge_CS),     pointer    :: CS !< ALE sponge control structure (in/out).
   real, dimension(SZI_(G),SZJ_(G),CS%nz_data), &
                            intent(in) :: sp_val !< Field to be used in the sponge, it can have an
-                                            !! arbitrary number of layers.
+                                            !! arbitrary number of layers [various]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                   target, intent(in) :: f_ptr !< Pointer to the field to be damped
+                   target, intent(in) :: f_ptr !< Pointer to the field to be damped [various]
   character(len=*),        intent(in) :: sp_name  !< The name of the tracer field
   character(len=*),        optional, &
                            intent(in) :: sp_long_name !< The long name of the tracer field
@@ -698,9 +698,10 @@ subroutine set_up_ALE_sponge_field_fixed(sp_val, G, GV, f_ptr, CS,  &
                            intent(in) :: sp_unit !< The unit of the tracer field
                                                  !! if not given, use the none
   real,          optional, intent(in) :: scale !< A factor by which to rescale the input data, including any
-                                               !! contributions due to dimensional rescaling.  The default is 1.
+                                               !! contributions due to dimensional rescaling [various ~> 1].
+                                               !! The default is 1.
 
-  real :: scale_fac  ! A factor by which to scale sp_val before storing it.
+  real :: scale_fac  ! A factor by which to scale sp_val before storing it [various ~> 1]
   integer :: k, col
   character(len=256) :: mesg ! String for error messages
   character(len=256) :: long_name ! The long name of the tracer field
@@ -749,7 +750,7 @@ subroutine set_up_ALE_sponge_field_varying(filename, fieldname, Time, G, GV, US,
   type(verticalGrid_type), intent(in) :: GV    !< ocean vertical grid structure
   type(unit_scale_type),   intent(in) :: US    !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                   target, intent(in) :: f_ptr !< Pointer to the field to be damped (in).
+                   target, intent(in) :: f_ptr !< Pointer to the field to be damped (in) [various].
   type(ALE_sponge_CS),     pointer    :: CS    !< Sponge control structure (in/out).
   character(len=*),        intent(in) :: sp_name  !< The name of the tracer field
   character(len=*),        optional,  &
@@ -759,7 +760,8 @@ subroutine set_up_ALE_sponge_field_varying(filename, fieldname, Time, G, GV, US,
                            intent(in) :: sp_unit !< The unit of the tracer field
                                                  !! if not given, use 'none'
   real,          optional, intent(in) :: scale !< A factor by which to rescale the input data, including any
-                                               !! contributions due to dimensional rescaling.  The default is 1.
+                                               !! contributions due to dimensional rescaling [various ~> 1].
+                                               !! The default is 1.
 
   ! Local variables
   integer :: isd, ied, jsd, jed
@@ -824,9 +826,10 @@ subroutine set_up_ALE_sponge_vel_field_fixed(u_val, v_val, G, GV, u_ptr, v_ptr, 
   real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u-field to be damped [L T-1 ~> m s-1]
   real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v-field to be damped [L T-1 ~> m s-1]
   real,          optional, intent(in) :: scale !< A factor by which to rescale the input data, including any
-                                               !! contributions due to dimensional rescaling.  The default is 1.
+                                               !! contributions due to dimensional rescaling [various ~> 1].
+                                               !! The default is 1.
 
-  real :: scale_fac
+  real :: scale_fac  ! A dimensional rescaling factor [various ~> 1]
   integer :: k, col
 
   if (.not.associated(CS)) return
@@ -867,8 +870,9 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename
   real, target, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u_ptr !< u-field to be damped [L T-1 ~> m s-1]
   real, target, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: v_ptr !< v-field to be damped [L T-1 ~> m s-1]
   real,          optional, intent(in) :: scale   !< A factor by which to rescale the input data, including any
-                                                 !! contributions due to dimensional rescaling.  For varying
-                                                 !! velocities the default is the same using US%m_s_to_L_T.
+                                                 !! contributions due to dimensional rescaling, often in
+                                                 !! [L s T-1 m-1 ~> 1].  For varying velocities the
+                                                 !! default is the same as using US%m_s_to_L_T.
 
   ! Local variables
   logical :: override
@@ -931,16 +935,19 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
 
   real :: damp                                  ! The timestep times the local damping coefficient [nondim].
   real :: I1pdamp                               ! I1pdamp is 1/(1 + damp). [nondim].
-  real, allocatable, dimension(:) :: tmp_val2   ! data values on the original grid
-  real, dimension(SZK_(GV)) :: tmp_val1         ! data values remapped to model grid
+  real, allocatable, dimension(:) :: tmp_val2   ! data values on the original grid [various]
+  real, dimension(SZK_(GV)) :: tmp_val1         ! data values remapped to model grid [various]
   real, dimension(SZK_(GV)) :: h_col            ! A column of thicknesses at h, u or v points [H ~> m or kg m-2]
-  real, allocatable, dimension(:,:,:) :: sp_val ! A temporary array for fields
-  real, allocatable, dimension(:,:,:) :: mask_z ! A temporary array for field mask at h pts
-  real, allocatable, dimension(:,:,:) :: mask_u ! A temporary array for field mask at u pts
-  real, allocatable, dimension(:,:,:) :: mask_v ! A temporary array for field mask at v pts
-  real, allocatable, dimension(:,:,:) :: tmp    !< A temporary array for thermodynamic sponge tendency diagnostics,
+  real, allocatable, dimension(:,:,:) :: sp_val ! A temporary array for fields [various]
+  real, allocatable, dimension(:,:,:) :: mask_z ! A temporary array for field mask at h pts [nondim]
+  real, allocatable, dimension(:,:,:) :: mask_u ! A temporary array for field mask at u pts [nondim]
+  real, allocatable, dimension(:,:,:) :: mask_v ! A temporary array for field mask at v pts [nondim]
+  real, allocatable, dimension(:,:,:) :: tmp    !< A temporary array for thermodynamic sponge tendency
+                                                !! diagnostics [various]
   real, allocatable, dimension(:,:,:) :: tmp_u  !< A temporary array for u sponge acceleration diagnostics
+                                                !! first in [L T-1 ~> m s-1] then in [L T-2 ~> m s-2]
   real, allocatable, dimension(:,:,:) :: tmp_v  !< A temporary array for v sponge acceleration diagnostics
+                                                !! first in [L T-1 ~> m s-1] then in [L T-2 ~> m s-2]
   real, dimension(:), allocatable :: hsrc       ! Source thicknesses [Z ~> m].
   ! Local variables for ALE remapping
   real, dimension(:), allocatable :: tmpT1d
@@ -948,12 +955,12 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
   real, allocatable, dimension(:), target :: z_in  ! The depths (positive downward) in the input file [Z ~> m]
   real, allocatable, dimension(:), target :: z_edges_in ! The depths (positive downward) of the
                                                         ! edges in the input file [Z ~> m]
-  real :: missing_value
+  real :: missing_value  ! The missing value in the input data field [various]
   real :: Idt  ! The inverse of the timestep [T-1 ~> s-1]
   real :: h_neglect, h_neglect_edge ! Negligible thicknesses [H ~> m or kg m-2]
   real :: zTopOfCell, zBottomOfCell ! Interface heights (positive upward) in the input dataset [Z ~> m].
-  real :: sp_val_u ! Interpolation of sp_val to u-points
-  real :: sp_val_v ! Interpolation of sp_val to v-points
+  real :: sp_val_u ! Interpolation of sp_val to u-points, often a velocity in [L T-1 ~> m s-1]
+  real :: sp_val_v ! Interpolation of sp_val to v-points, often a velocity in [L T-1 ~> m s-1]
   integer :: nPoints
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -982,7 +989,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
         i = CS%col_i(c) ; j = CS%col_j(c)
         CS%Ref_val(m)%p(1:nz_data,c) = sp_val(i,j,1:nz_data)
         ! Build the source grid
-        zTopOfCell = 0. ; zBottomOfCell = 0. ; nPoints = 0; hsrc(:) = 0.0; tmpT1d(:) = -99.9
+        zTopOfCell = 0. ; zBottomOfCell = 0. ; nPoints = 0 ; hsrc(:) = 0.0 ; tmpT1d(:) = -99.9
         do k=1,nz_data
           if (mask_z(CS%col_i(c),CS%col_j(c),k) == 1.0) then
             zBottomOfCell = -min( z_edges_in(k+1) - G%Z_ref, G%bathyT(CS%col_i(c),CS%col_j(c)) )
@@ -1012,7 +1019,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
     enddo
   endif
 
-  tmp_val1(:)=0.0;h_col(:)=0.0
+  tmp_val1(:) = 0.0 ; h_col(:) = 0.0
   do m=1,CS%fldno
     nz_data = CS%Ref_val(m)%nz_data
     allocate(tmp_val2(CS%Ref_val(m)%nz_data))
@@ -1086,7 +1093,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
           CS%Ref_val_u%p(1:nz_data,c) = 0.0
         endif
         ! Build the source grid
-        zTopOfCell = 0. ; zBottomOfCell = 0. ; nPoints = 0; hsrc(:) = 0.0
+        zTopOfCell = 0. ; zBottomOfCell = 0. ; nPoints = 0 ; hsrc(:) = 0.0
         do k=1,nz_data
           if (mask_u(i,j,k) == 1.0) then
             zBottomOfCell = -min( z_edges_in(k+1) - G%Z_ref, G%bathyT(i,j) )
@@ -1134,7 +1141,7 @@ subroutine apply_ALE_sponge(h, dt, G, GV, US, CS, Time)
           CS%Ref_val_v%p(1:nz_data,c) = 0.0
         endif
         ! Build the source grid
-        zTopOfCell = 0. ; zBottomOfCell = 0. ; nPoints = 0; hsrc(:) = 0.0
+        zTopOfCell = 0. ; zBottomOfCell = 0. ; nPoints = 0 ; hsrc(:) = 0.0
         do k=1,nz_data
           if (mask_v(i,j,k) == 1.0) then
             zBottomOfCell = -min( z_edges_in(k+1) - G%Z_ref, G%bathyT(i,j) )
@@ -1241,10 +1248,13 @@ subroutine rotate_ALE_sponge(sponge_in, G_in, sponge, G, GV, turns, param_file)
   !   3. Call initialize_ALE_sponge using new grid and rotated Iresttime(:,:)
   ! All the index adjustment should follow from the Iresttime rotation
 
-  real, dimension(:,:), allocatable :: Iresttime_in, Iresttime
-  real, dimension(:,:,:), allocatable :: data_h_in, data_h
-  real, dimension(:,:,:), allocatable :: sp_val_in, sp_val
-  real, dimension(:,:,:), pointer :: sp_ptr => NULL()
+  real, dimension(:,:), allocatable :: Iresttime_in ! Restoring rate on the input sponges [T-1 ~> s-1]
+  real, dimension(:,:), allocatable :: Iresttime    ! Restoring rate on the output sponges [T-1 ~> s-1]
+  real, dimension(:,:,:), allocatable :: data_h_in  ! Grid for the input sponges [H ~> m or kg m-2]
+  real, dimension(:,:,:), allocatable :: data_h     ! Grid for the output sponges [H ~> m or kg m-2]
+  real, dimension(:,:,:), allocatable :: sp_val_in  ! Target data for the input sponges [various]
+  real, dimension(:,:,:), allocatable :: sp_val     ! Target data for the output sponges [various]
+  real, dimension(:,:,:), pointer :: sp_ptr => NULL() ! Target data for the input sponges [various]
   integer :: c, c_i, c_j
   integer :: k, nz_data
   integer :: n
@@ -1365,11 +1375,11 @@ end subroutine rotate_ALE_sponge
 subroutine update_ALE_sponge_field(sponge, p_old, G, GV, p_new)
   type(ALE_sponge_CS),     intent(inout) :: sponge !< ALE sponge control struct
   real, dimension(:,:,:), &
-                   target, intent(in) :: p_old !< The previous array of target values
+                   target, intent(in) :: p_old !< The previous array of target values [various]
   type(ocean_grid_type),   intent(in) :: G     !< The updated ocean grid structure
   type(verticalGrid_type), intent(in) :: GV    !< ocean vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                   target, intent(in) :: p_new !< The new array of target values
+                   target, intent(in) :: p_new !< The new array of target values [various]
 
   integer :: n
 

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -4,7 +4,7 @@ module MOM_tracer_Z_init
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_error_handler, only : MOM_error, FATAL, WARNING, MOM_mesg, is_root_pe
-! use MOM_file_parser, only : get_param, log_version, param_file_type
+use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : MOM_read_data, get_var_sizes, read_attribute, read_variable
 use MOM_io, only : open_file_to_read, close_file_to_read
@@ -556,8 +556,8 @@ end function find_limited_slope
 
 !> This subroutine determines the potential temperature and salinity that
 !! is consistent with the target density using provided initial guess
-subroutine determine_temperature(temp, salt, R_tgt, p_ref, niter, h, k_start, G, GV, US, &
-                                 EOS, h_massless)
+subroutine determine_temperature(temp, salt, R_tgt, EOS, p_ref, niter, h, k_start, G, GV, US, &
+                                 PF, just_read, h_massless)
   type(ocean_grid_type),         intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),       intent(in)    :: GV   !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
@@ -565,6 +565,7 @@ subroutine determine_temperature(temp, salt, R_tgt, p_ref, niter, h, k_start, G,
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                                  intent(inout) :: salt !< salinity [S ~> ppt]
   real, dimension(SZK_(GV)),     intent(in)    :: R_tgt !< desired potential density [R ~> kg m-3].
+  type(EOS_type),                intent(in)    :: EOS !< seawater equation of state control structure
   real,                          intent(in)    :: p_ref !< reference pressure [R L2 T-2 ~> Pa].
   integer,                       intent(in)    :: niter !< maximum number of iterations
   integer,                       intent(in)    :: k_start !< starting index (i.e. below the buffer layer)
@@ -572,7 +573,10 @@ subroutine determine_temperature(temp, salt, R_tgt, p_ref, niter, h, k_start, G,
                                  intent(in)    :: h   !< layer thickness, used only to avoid working on
                                                       !! massless layers [H ~> m or kg m-2]
   type(unit_scale_type),         intent(in)    :: US  !< A dimensional unit scaling type
-  type(EOS_type),                intent(in)    :: EOS !< seawater equation of state control structure
+  type(param_file_type),         intent(in)    :: PF  !< A structure indicating the open file
+                                                      !! to parse for model parameter values.
+  logical,                       intent(in)    :: just_read !< If true, this call will only read
+                                                      !! parameters without changing T or S.
   real,                optional, intent(in)    :: h_massless !< A threshold below which a layer is
                                                       !! determined to be massless [H ~> m or kg m-2]
 
@@ -600,29 +604,69 @@ subroutine determine_temperature(temp, salt, R_tgt, p_ref, niter, h, k_start, G,
                     ! when old_fit is true [C ~> degC]
   real :: max_s_adj ! The largest permitted salinity changes with each iteration
                     ! when old_fit is true [S ~> ppt]
-  logical :: adjust_salt, old_fit
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
+  character(len=40)  :: mdl = "determine_temperature" ! This subroutine's name.
+  logical :: adjust_salt, fit_together
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, k, is, ie, js, je, nz, itt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
-  ! These hard coded parameters need to be set properly.
-  S_min = 0.5*US%ppt_to_S ; S_max = 65.0*US%ppt_to_S
-  T_max = 31.0*US%degC_to_C ; T_min = -2.0*US%degC_to_C
-  max_t_adj = 1.0*US%degC_to_C
-  max_s_adj = 0.5*US%ppt_to_S
-  tol_T = 1.0e-4*US%degC_to_C
-  tol_S = 1.0e-4*US%ppt_to_S
-  tol_rho = 1.0e-4*US%kg_m3_to_R
-  old_fit = .true.   ! reproduces siena behavior
+  ! ### The algorithms of determine_temperature subroutine needs to be reexamined.
 
-  dT_dS_gauge = 10.0*US%degC_to_C*US%S_to_ppt  ! 10 degC is weighted equivalently to 1 ppt.
 
-  ! ### The whole determine_temperature subroutine needs to be reexamined, both the algorithms
-  !     and the extensive use of hard-coded dimensional parameters.
+  call log_version(PF, mdl, version, "")
 
-  ! We will switch to the newer method which simultaneously adjusts
+  ! We should switch the default to the newer method which simultaneously adjusts
   ! temp and salt based on the ratio of the thermal and haline coefficients, once it is tested.
+  call get_param(PF, mdl, "DETERMINE_TEMP_ADJUST_T_AND_S", fit_together, &
+                 "If true, simltaneously adjust the estimates of the temperature and salinity "//&
+                 "based on the ratio of the thermal and haline coefficients.  Otherwise try to "//&
+                 "match the density by only adjusting temperatures within a maximum range before "//&
+                 "revising estimates of the salinity.", default=.false., do_not_log=just_read)
+  ! These hard coded parameters need to be set properly.
+  call get_param(PF, mdl, "DETERMINE_TEMP_T_MIN", T_min, &
+                 "The minimum temperature that can be found by determine_temperature.", &
+                 units="degC", default=-2.0, scale=US%degC_to_C, do_not_log=just_read)
+  call get_param(PF, mdl, "DETERMINE_TEMP_T_MAX", T_max, &
+                 "The maximum temperature that can be found by determine_temperature.", &
+                 units="degC", default=31.0, scale=US%degC_to_C, do_not_log=just_read)
+  call get_param(PF, mdl, "DETERMINE_TEMP_S_MIN", S_min, &
+                 "The minimum salinity that can be found by determine_temperature.", &
+                 units="1e-3", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
+  call get_param(PF, mdl, "DETERMINE_TEMP_S_MAX", S_max, &
+                 "The maximum salinity that can be found by determine_temperature.", &
+                 units="1e-3", default=65.0, scale=US%ppt_to_S, do_not_log=just_read)
+  call get_param(PF, mdl, "DETERMINE_TEMP_T_TOLERANCE", tol_T, &
+                 "The convergence tolerance for temperature in determine_temperature.", &
+                 units="degC", default=1.0e-4, scale=US%degC_to_C, do_not_log=just_read)
+  call get_param(PF, mdl, "DETERMINE_TEMP_S_TOLERANCE", tol_S, &
+                 "The convergence tolerance for temperature in determine_temperature.", &
+                 units="1e-3", default=1.0e-4, scale=US%ppt_to_S, do_not_log=just_read)
+  call get_param(PF, mdl, "DETERMINE_TEMP_RHO_TOLERANCE", tol_rho, &
+                 "The convergence tolerance for density in determine_temperature.", &
+                 units="kg m-3", default=1.0e-4, scale=US%kg_m3_to_R, do_not_log=just_read)
+  if (fit_together) then
+    ! By default 10 degC is weighted equivalently to 1 ppt when minimizing changes.
+    call get_param(PF, mdl, "DETERMINE_TEMP_DT_DS_WEIGHT", dT_dS_gauge, &
+                 "When extrapolating T & S to match the layer target densities, this "//&
+                 "factor (in deg C / PSU) is combined with the derivatives of density "//&
+                 "with T & S to determine what direction is orthogonal to density contours.  "//&
+                 "It could be based on a typical value of (dR/dS) / (dR/dT) in oceanic profiles.", &
+                 units="degC PSU-1", default=10.0, scale=US%degC_to_C*US%S_to_ppt)
+  else
+    call get_param(PF, mdl, "DETERMINE_TEMP_T_ADJ_RANGE", max_t_adj, &
+                 "The maximum amount by which the initial layer temperatures can be "//&
+                 "modified in determine_temperature.", &
+                 units="degC", default=1.0, scale=US%degC_to_C, do_not_log=just_read)
+    call get_param(PF, mdl, "DETERMINE_TEMP_S_ADJ_RANGE", max_S_adj, &
+                 "The maximum amount by which the initial layer salinities can be "//&
+                 "modified in determine_temperature.", &
+                 units="1e-3", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
+  endif
+
+  if (just_read) return ! All run-time parameters have been read, so return.
 
   press(:) = p_ref
   EOSdom(:) = EOS_domain(G%HI)
@@ -643,7 +687,7 @@ subroutine determine_temperature(temp, salt, R_tgt, p_ref, niter, h, k_start, G,
       do k=k_start,nz ; do i=is,ie
 !       if (abs(rho(i,k)-R_tgt(k))>tol_rho .and. hin(i,k)>h_massless .and. abs(T(i,k)-land_fill) < epsln) then
         if (abs(rho(i,k)-R_tgt(k))>tol_rho) then
-          if (old_fit) then
+          if (.not.fit_together) then
             dT(i,k) = max(min((R_tgt(k)-rho(i,k)) / drho_dT(i,k), max_t_adj), -max_t_adj)
             T(i,k) = max(min(T(i,k)+dT(i,k), T_max), T_min)
           else
@@ -662,7 +706,7 @@ subroutine determine_temperature(temp, salt, R_tgt, p_ref, niter, h, k_start, G,
       endif
     enddo iter_loop
 
-    if (adjust_salt .and. old_fit) then ; do itt = 1,niter
+    if (adjust_salt .and. .not.fit_together) then ; do itt = 1,niter
       do k=1,nz
         call calculate_density(T(:,k), S(:,k), press, rho(:,k), EOS, EOSdom )
         call calculate_density_derivs(T(:,k), S(:,k), press, drho_dT(:,k), drho_dS(:,k), &


### PR DESCRIPTION
  This series of commits revises the interfaces to horiz_interp_and_extrap to eliminate two unused arguments and rename a third from conversion to scale for consistency with other MOM6 interfaces.  It also adds a set of 20 runtime parameters to replace hard coded dimensional variables, including tolerances for use with horiz_interp_and_extrap, tolerances and bounds in determine_temperature and default dynamic ice shelf temperatures.  It also adds comments documenting the units of a number of internal variables in MOM_ALE_sponge.  By default all answers are bitwise identical, but there are new parameters in several MOM_parameter_doc files.

  The commits in this PR include:

- NOAA-GFDL/MOM6@9ffa1bbc8 +Add 2 runtime params for ice shelf temperatures
- NOAA-GFDL/MOM6@dda6d4535 +Add 11 runtime params for determine_temperature
- NOAA-GFDL/MOM6@e9300da23 Document the units of variables in MOM_ALE_sponge
- NOAA-GFDL/MOM6@2ed7cb194 +Add 7 runtime variables for hard-coded tolerances
- NOAA-GFDL/MOM6@0e2490da4 +Revise interfaces to horiz_interp_and_extract
