### PR TITLE
+Pass ocean_grid_type to call_tracer_register

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2177,7 +2177,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "at the end of the step.", default=.false.)
 
   if (CS%split) then
-    call get_param(param_file, "MOM", "DTBT", dtbt, default=-0.98)
+    call get_param(param_file, "MOM", "DTBT", dtbt, units="s or nondim", default=-0.98)
     default_val = US%T_to_s*CS%dt_therm ; if (dtbt > 0.0) default_val = -1.0
     CS%dtbt_reset_period = -1.0
     call get_param(param_file, "MOM", "DTBT_RESET_PERIOD", CS%dtbt_reset_period, &
@@ -2637,7 +2637,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   ! This subroutine calls user-specified tracer registration routines.
   ! Additional calls can be added to MOM_tracer_flow_control.F90.
-  call call_tracer_register(HI, GV, US, param_file, CS%tracer_flow_CSp, &
+  call call_tracer_register(G, GV, US, param_file, CS%tracer_flow_CSp, &
                             CS%tracer_Reg, restart_CSp)
 
   call MEKE_alloc_register_restart(HI, US, param_file, CS%MEKE, restart_CSp)
@@ -2661,7 +2661,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   if (associated(CS%OBC)) then
     ! Set up remaining information about open boundary conditions that is needed for OBCs.
-    call call_OBC_register(param_file, CS%update_OBC_CSp, US, CS%OBC, CS%tracer_Reg)
+    call call_OBC_register(G, GV, US, param_file, CS%update_OBC_CSp, CS%OBC, CS%tracer_Reg)
   !### Package specific changes to OBCs need to go here?
 
     ! This is the equivalent to 2 calls to register_segment_tracer (per segment), which

--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -59,12 +59,14 @@ contains
 !> The following subroutines and associated definitions provide the
 !! machinery to register and call the subroutines that initialize
 !! open boundary conditions.
-subroutine call_OBC_register(param_file, CS, US, OBC, tr_Reg)
-  type(param_file_type),     intent(in) :: param_file !< Parameter file to parse
-  type(update_OBC_CS),       pointer    :: CS         !< Control structure for OBCs
-  type(unit_scale_type),     intent(in) :: US         !< A dimensional unit scaling type
-  type(ocean_OBC_type),      pointer    :: OBC        !< Open boundary structure
-  type(tracer_registry_type), pointer   :: tr_Reg     !< Tracer registry.
+subroutine call_OBC_register(G, GV, US, param_file, CS, OBC, tr_Reg)
+  type(ocean_grid_type),      intent(in) :: G    !< Ocean grid structure
+  type(verticalGrid_type),    intent(in) :: GV   !< Ocean vertical grid structure
+  type(unit_scale_type),      intent(in) :: US   !< A dimensional unit scaling type
+  type(param_file_type),      intent(in) :: param_file !< Parameter file to parse
+  type(update_OBC_CS),        pointer    :: CS         !< Control structure for OBCs
+  type(ocean_OBC_type),       pointer    :: OBC        !< Open boundary structure
+  type(tracer_registry_type), pointer    :: tr_Reg     !< Tracer registry.
 
   ! Local variables
   character(len=200) :: config
@@ -124,7 +126,7 @@ subroutine call_OBC_register(param_file, CS, US, OBC, tr_Reg)
     register_Kelvin_OBC(param_file, CS%Kelvin_OBC_CSp, US, &
                OBC%OBC_Reg)
   if (CS%use_shelfwave) CS%use_shelfwave = &
-    register_shelfwave_OBC(param_file, CS%shelfwave_OBC_CSp, US, &
+    register_shelfwave_OBC(param_file, CS%shelfwave_OBC_CSp, G, US, &
                OBC%OBC_Reg)
   if (CS%use_dyed_channel) CS%use_dyed_channel = &
     register_dyed_channel_OBC(param_file, CS%dyed_channel_OBC_CSp, US, &

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -152,8 +152,8 @@ end subroutine call_tracer_flux_init
 
 !> This subroutine determines which tracer packages are to be used and does the calls to
 !! register their tracers to be advected, diffused, and read from restarts.
-subroutine call_tracer_register(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
-  type(hor_index_type),         intent(in) :: HI         !< A horizontal index type structure.
+subroutine call_tracer_register(G, GV, US, param_file, CS, tr_Reg, restart_CS)
+  type(ocean_grid_type),        intent(in) :: G          !< The ocean's grid structure.
   type(verticalGrid_type),      intent(in) :: GV         !< The ocean's vertical grid structure.
   type(unit_scale_type),        intent(in) :: US         !< A dimensional unit scaling type
   type(param_file_type),        intent(in) :: param_file !< A structure to parse for run-time
@@ -163,7 +163,7 @@ subroutine call_tracer_register(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   type(tracer_registry_type),   pointer    :: tr_Reg     !< A pointer that is set to point to the
                                                          !! control structure for the tracer
                                                          !! advection and diffusion module.
-  type(MOM_restart_CS), intent(inout) :: restart_CS !< A pointer to the restart control
+  type(MOM_restart_CS), intent(inout) :: restart_CS      !< A pointer to the restart control
                                                          !! structure.
 
   ! This include declares and sets the variable "version".
@@ -230,49 +230,49 @@ subroutine call_tracer_register(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
 !  tracer package registration call returns a logical false if it cannot be run
 !  for some reason.  This then overrides the run-time selection from above.
   if (CS%use_USER_tracer_example) CS%use_USER_tracer_example = &
-    USER_register_tracer_example(HI, GV, param_file, CS%USER_tracer_example_CSp, &
+    USER_register_tracer_example(G%HI, GV, param_file, CS%USER_tracer_example_CSp, &
                                  tr_Reg, restart_CS)
   if (CS%use_DOME_tracer) CS%use_DOME_tracer = &
-    register_DOME_tracer(HI, GV, param_file, CS%DOME_tracer_CSp, &
+    register_DOME_tracer(G%HI, GV, param_file, CS%DOME_tracer_CSp, &
                          tr_Reg, restart_CS)
   if (CS%use_ISOMIP_tracer) CS%use_ISOMIP_tracer = &
-    register_ISOMIP_tracer(HI, GV, param_file, CS%ISOMIP_tracer_CSp, &
+    register_ISOMIP_tracer(G%HI, GV, param_file, CS%ISOMIP_tracer_CSp, &
                            tr_Reg, restart_CS)
   if (CS%use_RGC_tracer) CS%use_RGC_tracer = &
-    register_RGC_tracer(HI, GV, param_file, CS%RGC_tracer_CSp, &
+    register_RGC_tracer(G, GV, param_file, CS%RGC_tracer_CSp, &
                            tr_Reg, restart_CS)
   if (CS%use_ideal_age) CS%use_ideal_age = &
-    register_ideal_age_tracer(HI, GV, param_file,  CS%ideal_age_tracer_CSp, &
+    register_ideal_age_tracer(G%HI, GV, param_file, CS%ideal_age_tracer_CSp, &
                               tr_Reg, restart_CS)
   if (CS%use_regional_dyes) CS%use_regional_dyes = &
-    register_dye_tracer(HI, GV, US, param_file,  CS%dye_tracer_CSp, &
+    register_dye_tracer(G%HI, GV, US, param_file, CS%dye_tracer_CSp, &
                         tr_Reg, restart_CS)
   if (CS%use_oil) CS%use_oil = &
-    register_oil_tracer(HI, GV, US, param_file,  CS%oil_tracer_CSp, &
+    register_oil_tracer(G%HI, GV, US, param_file,  CS%oil_tracer_CSp, &
                         tr_Reg, restart_CS)
   if (CS%use_advection_test_tracer) CS%use_advection_test_tracer = &
-    register_advection_test_tracer(HI, GV, param_file, CS%advection_test_tracer_CSp, &
+    register_advection_test_tracer(G, GV, param_file, CS%advection_test_tracer_CSp, &
                                    tr_Reg, restart_CS)
   if (CS%use_OCMIP2_CFC) CS%use_OCMIP2_CFC = &
-    register_OCMIP2_CFC(HI, GV, param_file,  CS%OCMIP2_CFC_CSp, &
+    register_OCMIP2_CFC(G%HI, GV, param_file, CS%OCMIP2_CFC_CSp, &
                         tr_Reg, restart_CS)
   if (CS%use_CFC_cap) CS%use_CFC_cap = &
-    register_CFC_cap(HI, GV, param_file,  CS%CFC_cap_CSp, &
+    register_CFC_cap(G%HI, GV, param_file, CS%CFC_cap_CSp, &
                         tr_Reg, restart_CS)
   if (CS%use_MOM_generic_tracer) CS%use_MOM_generic_tracer = &
-    register_MOM_generic_tracer(HI, GV, param_file,  CS%MOM_generic_tracer_CSp, &
+    register_MOM_generic_tracer(G%HI, GV, param_file, CS%MOM_generic_tracer_CSp, &
                                 tr_Reg, restart_CS)
   if (CS%use_pseudo_salt_tracer) CS%use_pseudo_salt_tracer = &
-    register_pseudo_salt_tracer(HI, GV, param_file,  CS%pseudo_salt_tracer_CSp, &
+    register_pseudo_salt_tracer(G%HI, GV, param_file, CS%pseudo_salt_tracer_CSp, &
                                 tr_Reg, restart_CS)
   if (CS%use_boundary_impulse_tracer) CS%use_boundary_impulse_tracer = &
-    register_boundary_impulse_tracer(HI, GV, US, param_file,  CS%boundary_impulse_tracer_CSp, &
+    register_boundary_impulse_tracer(G%HI, GV, US, param_file, CS%boundary_impulse_tracer_CSp, &
                                      tr_Reg, restart_CS)
   if (CS%use_dyed_obc_tracer) CS%use_dyed_obc_tracer = &
-    register_dyed_obc_tracer(HI, GV, param_file, CS%dyed_obc_tracer_CSp, &
+    register_dyed_obc_tracer(G%HI, GV, param_file, CS%dyed_obc_tracer_CSp, &
                              tr_Reg, restart_CS)
   if (CS%use_nw2_tracers) CS%use_nw2_tracers = &
-    register_nw2_tracers(HI, GV, US, param_file,  CS%nw2_tracers_CSp, tr_Reg, restart_CS)
+    register_nw2_tracers(G%HI, GV, US, param_file, CS%nw2_tracers_CSp, tr_Reg, restart_CS)
 
 end subroutine call_tracer_register
 

--- a/src/tracer/RGC_tracer.F90
+++ b/src/tracer/RGC_tracer.F90
@@ -60,10 +60,9 @@ end type RGC_tracer_CS
 
 contains
 
-
 !> This subroutine is used to register tracer fields
-function register_RGC_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
-  type(hor_index_type),       intent(in) :: HI   !< A horizontal index type structure.
+function register_RGC_tracer(G, GV, param_file, CS, tr_Reg, restart_CS)
+  type(ocean_grid_type),      intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type),    intent(in) :: GV   !< The ocean's vertical grid structure.
   type(param_file_type),      intent(in) :: param_file !<A structure indicating the open file to parse
                                                  !! for model parameter values.
@@ -80,7 +79,7 @@ function register_RGC_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   real, pointer :: tr_ptr(:,:,:) => NULL() ! A pointer to one of the tracers in this module [kg kg-1]
   logical :: register_RGC_tracer
   integer :: isd, ied, jsd, jed, nz, m
-  isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = GV%ke
 
   if (associated(CS)) then
     call MOM_error(FATAL, "RGC_register_tracer called with an "// &
@@ -108,13 +107,11 @@ function register_RGC_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
 
   call get_param(param_file, mdl, "CONT_SHELF_LENGTH", CS%CSL, &
                  "The length of the continental shelf (x dir, km).", &
-                 units="km", default=15.0)
-               ! units=G%x_ax_unit_short, default=15.0)
+                 units=G%x_ax_unit_short, default=15.0)
 
   call get_param(param_file, mdl, "LENSPONGE", CS%lensponge, &
                  "The length of the sponge layer (km).", &
-                 units="km", default=10.0)
-               ! units=G%x_ax_unit_short, default=10.0)
+                 units=G%x_ax_unit_short, default=10.0)
 
   allocate(CS%tr(isd:ied,jsd:jed,nz,NTR), source=0.0)
   if (CS%mask_tracers) then
@@ -130,7 +127,7 @@ function register_RGC_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     ! This is needed to force the compiler not to do a copy in the registration calls.
     tr_ptr => CS%tr(:,:,:,m)
     ! Register the tracer for horizontal advection & diffusion.
-    call register_tracer(tr_ptr, tr_Reg, param_file, HI, GV, &
+    call register_tracer(tr_ptr, tr_Reg, param_file, G%HI, GV, &
                          name=name, longname=longname, units="kg kg-1", &
                          registry_diags=.true., flux_units="kg/s", &
                          restart_CS=restart_CS)

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -28,29 +28,30 @@ public register_shelfwave_OBC, shelfwave_OBC_end
 
 !> Control structure for shelfwave open boundaries.
 type, public :: shelfwave_OBC_CS ; private
-  real :: Lx = 100.0        !< Long-shore length scale of bathymetry [km]
-  real :: Ly = 50.0         !< Cross-shore length scale [km]
-  real :: f0 = 1.e-4        !< Coriolis parameter [T-1 ~> s-1]
-  real :: jj = 1.0          !< Cross-shore wave mode [nondim]
-  real :: kk                !< Cross-shore wavenumber [km-1]
-  real :: ll                !< Longshore wavenumber [km-1]
-  real :: alpha             !< Exponential decay rate in the y-direction [km-1]
-  real :: omega             !< Frequency of the shelf wave [T-1 ~> s-1]
+  real :: my_amp        !< Amplitude of the open boundary current inflows [L T-1 ~> m s-1]
+  real :: Lx = 100.0    !< Long-shore length scale of bathymetry [km] or [m]
+  real :: Ly = 50.0     !< Cross-shore length scale [km] or [m]
+  real :: f0 = 1.e-4    !< Coriolis parameter [T-1 ~> s-1]
+  real :: jj = 1.0      !< Cross-shore wave mode [nondim]
+  real :: kk            !< Cross-shore wavenumber [km-1] or [m-1]
+  real :: ll            !< Longshore wavenumber [km-1] or [m-1]
+  real :: alpha         !< Exponential decay rate in the y-direction [km-1] or [m-1]
+  real :: omega         !< Frequency of the shelf wave [T-1 ~> s-1]
 end type shelfwave_OBC_CS
 
 contains
 
 !> Add shelfwave to OBC registry.
-function register_shelfwave_OBC(param_file, CS, US, OBC_Reg)
+function register_shelfwave_OBC(param_file, CS, G, US, OBC_Reg)
   type(param_file_type),    intent(in) :: param_file !< parameter file.
   type(shelfwave_OBC_CS),   pointer    :: CS         !< shelfwave control structure.
+  type(ocean_grid_type),    intent(in) :: G          !< The ocean's grid structure.
   type(unit_scale_type),    intent(in) :: US         !< A dimensional unit scaling type
   type(OBC_registry_type),  pointer    :: OBC_Reg    !< Open boundary condition registry.
   logical                              :: register_shelfwave_OBC
+
   ! Local variables
   real :: PI      ! The ratio of the circumference of a circle to its diameter [nondim]
-  real :: len_lat ! Y-direction size of the domain [km]
-
   character(len=32)  :: casename = "shelfwave"       !< This case's name.
 
   PI = 4.0*atan(1.0)
@@ -62,30 +63,26 @@ function register_shelfwave_OBC(param_file, CS, US, OBC_Reg)
   endif
   allocate(CS)
 
-  !### Revise these parameters once the ocean_grid_type is available.
-
   ! Register the tracer for horizontal advection & diffusion.
   call register_OBC(casename, param_file, OBC_Reg)
   call get_param(param_file, mdl, "F_0", CS%f0, &
                  default=0.0, units="s-1", scale=US%T_to_s, do_not_log=.true.)
-  call get_param(param_file, mdl, "LENLAT", len_lat, &
-                 units="km", do_not_log=.true., fail_if_missing=.true.)
   call get_param(param_file, mdl,"SHELFWAVE_X_WAVELENGTH", CS%Lx, &
                  "Length scale of shelfwave in x-direction.",&
-                 units="km", default=100.)
-!                 units="km", default=100.0, scale=1.0e3*US%m_to_L)
-               ! units=G%x_ax_unit_short, default=100.)
+                 units=G%x_ax_unit_short, default=100.)
   call get_param(param_file, mdl, "SHELFWAVE_Y_LENGTH_SCALE", CS%Ly, &
                  "Length scale of exponential dropoff of topography in the y-direction.", &
-                 units="km", default=50.)
-!                 units="km", default=50.0, scale=1.0e3*US%m_to_L)
-               ! units=G%y_ax_unit_short, default=50.)
+                 units=G%y_ax_unit_short, default=50.)
   call get_param(param_file, mdl, "SHELFWAVE_Y_MODE", CS%jj, &
                  "Cross-shore wave mode.",               &
                  units="nondim", default=1.)
+  call get_param(param_file, mdl, "SHELFWAVE_AMPLITUDE", CS%my_amp, &
+                 "Amplitude of the open boundary current inflows in the shelfwave configuration.", &
+                 units="m s-1", default=1.0, scale=US%m_s_to_L_T)
+
   CS%alpha = 1. / CS%Ly
   CS%ll = 2. * PI / CS%Lx
-  CS%kk = CS%jj * PI / len_lat
+  CS%kk = CS%jj * PI / G%len_lat
   CS%omega = 2 * CS%alpha * CS%f0 * CS%ll / &
              (CS%kk*CS%kk + CS%alpha*CS%alpha + CS%ll*CS%ll)
   register_shelfwave_OBC = .true.
@@ -111,16 +108,16 @@ subroutine shelfwave_initialize_topography( D, G, param_file, max_depth, US )
   type(unit_scale_type),           intent(in)  :: US !< A dimensional unit scaling type
 
   ! Local variables
-  real      :: y    ! Position relative to the southern boundary [km] or [degrees_N]
-  real      :: rLy  ! Exponential decay rate of the topography [km-1] or [degrees_N-1]
-  real      :: Ly   ! Exponential decay lengthscale of the topography [km] or [degrees_N]
+  real      :: y    ! Position relative to the southern boundary [km] or [m] or [degrees_N]
+  real      :: rLy  ! Exponential decay rate of the topography [km-1] or [m-1] or [degrees_N-1]
+  real      :: Ly   ! Exponential decay lengthscale of the topography [km] or [m] or [degrees_N]
   real      :: H0   ! The minimum depth of the ocean [Z ~> m]
   integer   :: i, j
 
   call get_param(param_file, mdl,"SHELFWAVE_Y_LENGTH_SCALE", Ly, &
                  units=G%y_ax_unit_short, default=50., do_not_log=.true.)
   call get_param(param_file, mdl,"MINIMUM_DEPTH", H0, &
-                 default=10., units="m", scale=US%m_to_Z, do_not_log=.true.)
+                 units="m", default=10., scale=US%m_to_Z, do_not_log=.true.)
 
   rLy = 0. ; if (Ly>0.) rLy = 1. / Ly
 
@@ -145,15 +142,10 @@ subroutine shelfwave_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   type(time_type),         intent(in) :: Time !< model time.
 
   ! The following variables are used to set up the transport in the shelfwave example.
-  real :: my_amp ! Amplitude of the open boundary current inflows [L T-1 ~> m s-1]
   real :: time_sec ! The time in the run [T ~> s]
   real :: cos_wt, sin_wt ! Cosine and sine associated with the propagating x-direction structure [nondim]
   real :: cos_ky, sin_ky ! Cosine and sine associated with the y-direction structure [nondim]
-  real :: omega  ! Frequency of the shelf wave [T-1 ~> s-1]
-  real :: alpha  ! Exponential decay rate in the y-direction [km-1]
-  real :: x, y   ! Positions relative to the western and southern boundaries [km]
-  real :: kk     ! y-direction wavenumber of the wave [km-1]
-  real :: ll     ! x-direction wavenumber of the wave [km-1]
+  real :: x, y   ! Positions relative to the western and southern boundaries [km] or [m] or [degrees]
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed, n
   integer :: IsdB, IedB, JsdB, JedB
   type(OBC_segment_type), pointer :: segment => NULL()
@@ -165,11 +157,6 @@ subroutine shelfwave_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   if (.not.associated(OBC)) return
 
   time_sec = US%s_to_T*time_type_to_real(Time)
-  omega = CS%omega
-  alpha = CS%alpha
-  my_amp = 1.0*US%m_s_to_L_T
-  kk = CS%kk
-  ll = CS%ll
   do n = 1, OBC%number_of_segments
     segment => OBC%segment(n)
     if (.not. segment%on_pe) cycle
@@ -180,15 +167,15 @@ subroutine shelfwave_set_OBC_data(OBC, CS, G, GV, US, h, Time)
     do j=jsd,jed ; do I=IsdB,IedB
       x = G%geoLonCu(I,j) - G%west_lon
       y = G%geoLatCu(I,j) - G%south_lat
-      sin_wt = sin(ll*x - omega*time_sec)
-      cos_wt = cos(ll*x - omega*time_sec)
-      sin_ky = sin(kk * y)
-      cos_ky = cos(kk * y)
-      segment%normal_vel_bt(I,j) = my_amp * exp(- alpha * y) * cos_wt * &
-           (alpha * sin_ky + kk * cos_ky)
-!     segment%tangential_vel_bt(I,j) = my_amp * ll * exp(- alpha * y) * sin_wt * sin_ky
-!     segment%vorticity_bt(I,j) = my_amp * exp(- alpha * y) * cos_wt * sin_ky&
-!           (ll*ll + kk*kk + alpha*alpha)
+      sin_wt = sin(CS%ll*x - CS%omega*time_sec)
+      cos_wt = cos(CS%ll*x - CS%omega*time_sec)
+      sin_ky = sin(CS%kk * y)
+      cos_ky = cos(CS%kk * y)
+      segment%normal_vel_bt(I,j) = CS%my_amp * exp(- CS%alpha * y) * cos_wt * &
+           (CS%alpha * sin_ky + CS%kk * cos_ky)
+!     segment%tangential_vel_bt(I,j) = CS%my_amp * CS%ll * exp(- CS%alpha * y) * sin_wt * sin_ky
+!     segment%vorticity_bt(I,j) = CS%my_amp * exp(- CS%alpha * y) * cos_wt * sin_ky&
+!           (CS%ll**2 + CS%kk**2 + CS%alpha**2)
     enddo ; enddo
   enddo
 


### PR DESCRIPTION
  Pass ocean_grid_type arguments to call_tracer_register and call_OBC_register in place of the hor_index_type arguments that had been used previously.  Also use these ocean_grid_type arguments in calls to register_shelfwave_OBC, register_RGC_tracer and register_advection_test_tracer.  Within these three routines, the contents of the ocean_grid_type are now used to specify axis units. The new runtime parameter SHELFWAVE_AMPLITUDE was added to allow for run-time control of the amplitude of the shelfwave test case.  By default all answers are bitwise identical, but there are some changes in the units of parameters as documented in the MOM_parameter_doc files and a new entry in these files for the shelfwave test case.