### PR TITLE
+Add 6 runtime parameters for OBC testcase initialization modules

### DIFF
--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -52,11 +52,10 @@ subroutine dumbbell_initialize_topography( D, G, param_file, max_depth )
   logical :: dbrotate ! If true, rotate this configuration
   integer :: i, j
 
-  call get_param(param_file, mdl, "DUMBBELL_LEN",dblen, &
+  call get_param(param_file, mdl, "DUMBBELL_LEN", dblen, &
                 'Lateral Length scale for dumbbell.', &
-                 units='km', default=600., do_not_log=.false.)
-               ! units=G%x_ax_unit_short, default=600., do_not_log=.false.)
-  call get_param(param_file, mdl, "DUMBBELL_FRACTION",dbfrac, &
+                 units=G%x_ax_unit_short, default=600., do_not_log=.false.)
+  call get_param(param_file, mdl, "DUMBBELL_FRACTION", dbfrac, &
                 'Meridional fraction for narrow part of dumbbell.', &
                  units='nondim', default=0.5, do_not_log=.false.)
   call get_param(param_file, mdl, "DUMBBELL_ROTATION", dbrotate, &
@@ -275,8 +274,6 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
-  T_surf = 20.0*US%degC_to_C
-
   ! layer mode
   call get_param(param_file, mdl, "USE_REGRIDDING", use_ALE, default=.false., do_not_log=.true.)
   if (.not. use_ALE) call MOM_error(FATAL,  "dumbbell_initialize_temperature_salinity: "//&
@@ -287,6 +284,9 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
   call get_param(param_file, mdl, "INITIAL_DENSITY_PROFILE", density_profile, &
                  'Initial profile shape. Valid values are "linear", "parabolic" '// &
                  'and "exponential".', default='linear', do_not_log=just_read)
+  call get_param(param_file, mdl, "DUMBBELL_T_SURF", T_surf, &
+                 'Initial surface temperature in the DUMBBELL configuration', &
+                 units='degC', default=20., scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "DUMBBELL_SREF", S_surf, &
                  'DUMBBELL REFERENCE SALINITY', &
                  units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=just_read)
@@ -294,9 +294,8 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
                  'DUMBBELL salinity range (right-left)', &
                  units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "DUMBBELL_LEN", dblen, &
-                'Lateral Length scale for dumbbell ', &
-                 units='km', default=600., do_not_log=just_read)
-               ! units=G%x_ax_unit_short, default=600., do_not_log=.false.)
+                 'Lateral Length scale for dumbbell ', &
+                 units=G%x_ax_unit_short, default=600., do_not_log=just_read)
   call get_param(param_file, mdl, "DUMBBELL_ROTATION", dbrotate, &
                 'Logical for rotation of dumbbell domain.', &
                  default=.false., do_not_log=just_read)
@@ -376,8 +375,8 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
   nz = GV%ke
 
   call get_param(param_file, mdl, "DUMBBELL_SPONGE_TIME_SCALE", sponge_time_scale, &
-       "The time scale in the reservoir for restoring. If zero, the sponge is disabled.", &
-       units="s", default=0., scale=US%s_to_T)
+                 "The time scale in the reservoir for restoring. If zero, the sponge is disabled.", &
+                 units="s", default=0., scale=US%s_to_T)
   call get_param(param_file, mdl, "DUMBBELL_SREF", S_ref, &
                  'DUMBBELL REFERENCE SALINITY', &
                  units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=.true.)

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -25,7 +25,10 @@ public register_tidal_bay_OBC
 
 !> Control structure for tidal bay open boundaries.
 type, public :: tidal_bay_OBC_CS ; private
-  real :: tide_flow = 3.0e6         !< Maximum tidal flux [L2 Z T-1 ~> m3 s-1]
+  real :: tide_flow = 3.0e6  !< Maximum tidal flux with the tidal bay configuration [L2 Z T-1 ~> m3 s-1]
+  real :: tide_period        !< The period associated with the tidal bay configuration [T ~> s-1]
+  real :: tide_ssh_amp       !< The magnitude of the sea surface height anomalies at the inflow
+                             !! with the tidal bay configuration [Z ~> m]
 end type tidal_bay_OBC_CS
 
 contains
@@ -43,6 +46,13 @@ function register_tidal_bay_OBC(param_file, CS, US, OBC_Reg)
   call get_param(param_file, mdl, "TIDAL_BAY_FLOW", CS%tide_flow, &
                  "Maximum total tidal volume flux.", &
                  units="m3 s-1", default=3.0e6, scale=US%m_s_to_L_T*US%m_to_L*US%m_to_Z)
+  call get_param(param_file, mdl, "TIDAL_BAY_PERIOD", CS%tide_period, &
+                 "Period of the inflow in the tidal bay configuration.", &
+                 units="s", default=12.0*3600.0, scale=US%s_to_T)
+  call get_param(param_file, mdl, "TIDAL_BAY_SSH_ANOM", CS%tide_ssh_amp, &
+                 "Magnitude of the sea surface height anomalies at the inflow with the "//&
+                 "tidal bay configuration.", &
+                 units="m", default=0.1, scale=US%m_to_Z)
 
   ! Register the open boundaries.
   call register_OBC(casename, param_file, OBC_Reg)
@@ -63,11 +73,11 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   type(time_type),         intent(in) :: Time !< model time.
 
   ! The following variables are used to set up the transport in the tidal_bay example.
-  real :: time_sec
+  real :: time_sec    ! Elapsed model time [T ~> s]
   real :: cff_eta     ! The total column thickness anomalies associated with the inflow [H ~> m or kg m-2]
   real :: my_flux     ! The vlume flux through the face [L2 Z T-1 ~> m3 s-1]
   real :: total_area  ! The total face area of the OBCs [L Z ~> m2]
-  real :: PI
+  real :: PI          ! The ratio of the circumference of a circle to its diameter [nondim]
   real :: flux_scale  ! A scaling factor for the areas [m2 H-1 L-1 ~> nondim or m3 kg-1]
   real, allocatable :: my_area(:,:) ! The total OBC inflow area [m2]
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz, n
@@ -86,10 +96,10 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
 
   flux_scale = GV%H_to_m*US%L_to_m
 
-  time_sec = time_type_to_real(Time)
-  cff_eta = 0.1*GV%m_to_H * sin(2.0*PI*time_sec/(12.0*3600.0))
-  my_area=0.0
-  my_flux=0.0
+  time_sec = US%s_to_T*time_type_to_real(Time)
+  cff_eta = CS%tide_ssh_amp*GV%Z_to_H * sin(2.0*PI*time_sec / CS%tide_period)
+  my_area = 0.0
+  my_flux = 0.0
   segment => OBC%segment(1)
 
   do j=segment%HI%jsc,segment%HI%jec ; do I=segment%HI%IscB,segment%HI%IecB
@@ -101,7 +111,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
     endif
   enddo ; enddo
   total_area = reproducing_sum(my_area)
-  my_flux = - CS%tide_flow*SIN(2.0*PI*time_sec/(12.0*3600.0))
+  my_flux = - CS%tide_flow * SIN(2.0*PI*time_sec / CS%tide_period)
 
   do n = 1, OBC%number_of_segments
     segment => OBC%segment(n)


### PR DESCRIPTION
  This PR adds 6 new runtime parameters to replace hard-coded dimensional
parameters in 3 user modules (dumbbell_initialization, Kelvin_initialization and
tidal_bay_initialization) that were added to provide tests of the OBC code. The
new runtime parameters that were added are DUMBBELL_T_LIGHT, KELVIN_WAVE_PERIOD,
KELVIN_WAVE_SSH_AMP, KELVIN_WAVE_INFLOW_AMP, TIDAL_BAY_PERIOD and
TIDAL_BAY_SSH_ANOM.  By default all answers are bitwise identical, but there are
new entries in the MOM_parameter_doc.all files for configurations using the
three impacted modules.

  The commits in this PR include:

- NOAA-GFDL/MOM6@7c12ead59 +Add runtime parameters for tidal_bay_initialization
- NOAA-GFDL/MOM6@780ff973e +Add runtime parameters for Kelvin_initialization
- NOAA-GFDL/MOM6@9b3f1ba2f +Add runtime parameter for dumbbell_initialization

