### PR TITLE
+Add 7 runtime parameters for user init modules

### DIFF
--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -101,9 +101,11 @@ subroutine benchmark_initialize_thickness(h, depth_tot, G, GV, US, param_file, e
                              ! in depth units [Z ~> m].
   real :: eta1D(SZK_(GV)+1)  ! Interface height relative to the sea surface
                              ! positive upward, in depth units [Z ~> m].
-  real :: SST       !  The initial sea surface temperature [C ~> degC].
-  real :: T_int     !  The initial temperature of an interface [C ~> degC].
-  real :: ML_depth  !  The specified initial mixed layer depth, in depth units [Z ~> m].
+  real :: SST       ! The initial sea surface temperature [C ~> degC].
+  real :: S_ref     ! A default value for salinities [S ~> ppt]
+  real :: T_light   ! A first guess at the temperature of the lightest layer [C ~> degC]
+  real :: T_int     ! The initial temperature of an interface [C ~> degC].
+  real :: ML_depth  ! The specified initial mixed layer depth, in depth units [Z ~> m].
   real :: thermocline_scale ! The e-folding scale of the thermocline, in depth units [Z ~> m].
   real, dimension(SZK_(GV)) :: &
     T0, S0, &       ! Profiles of temperature [C ~> degC] and salinity [S ~> ppt]
@@ -135,6 +137,12 @@ subroutine benchmark_initialize_thickness(h, depth_tot, G, GV, US, param_file, e
   call get_param(param_file, mdl, "BENCHMARK_THERMOCLINE_SCALE", thermocline_scale, &
                  "Initial thermocline depth scale in the benchmark test case.", &
                  default=500.0, units="m", scale=US%m_to_Z, do_not_log=just_read)
+  call get_param(param_file, mdl, "BENCHMARK_T_LIGHT", T_light, &
+                 "A first guess at the temperature of the lightest layer in the benchmark test case.", &
+                 units="degC", default=29.0, scale=US%degC_to_C, do_not_log=just_read)
+  call get_param(param_file, mdl, "S_REF", S_ref, &
+                 "The uniform salinities used to initialize the benchmark test case.", &
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
 
   if (just_read) return ! This subroutine has no run-time parameters.
 
@@ -147,9 +155,9 @@ subroutine benchmark_initialize_thickness(h, depth_tot, G, GV, US, param_file, e
 ! This block calculates T0(k) for the purpose of diagnosing where the
 ! interfaces will be found.
   do k=1,nz
-    pres(k) = P_Ref ; S0(k) = 35.0*US%ppt_to_S
+    pres(k) = P_Ref ; S0(k) = S_ref
   enddo
-  T0(k1) = 29.0*US%degC_to_C
+  T0(k1) = T_light
   call calculate_density(T0(k1), S0(k1), pres(k1), rho_guess(k1), eqn_of_state)
   call calculate_density_derivs(T0(k1), S0(k1), pres(k1), drho_dT(k1), drho_dS(k1), eqn_of_state)
 
@@ -232,25 +240,33 @@ subroutine benchmark_init_temperature_salinity(T, S, G, GV, US, param_file, &
   ! Local variables
   real :: T0(SZK_(GV))       ! A profile of temperatures [C ~> degC]
   real :: S0(SZK_(GV))       ! A profile of salinities [S ~> ppt]
+  real :: S_ref              ! A default value for salinities [S ~> ppt]
+  real :: T_light            ! A first guess at the temperature of the lightest layer [C ~> degC]
   real :: pres(SZK_(GV))     ! Reference pressure [R L2 T-2 ~> Pa]
   real :: drho_dT(SZK_(GV))  ! Derivative of density with temperature [R C-1 ~> kg m-3 degC-1]
   real :: drho_dS(SZK_(GV))  ! Derivative of density with salinity [R S-1 ~> kg m-3 ppt-1]
   real :: rho_guess(SZK_(GV)) ! Potential density at T0 & S0 [R ~> kg m-3]
   real :: PI                 ! 3.1415926... calculated as 4*atan(1)
   real :: SST                !  The initial sea surface temperature [C ~> degC]
+  character(len=40)  :: mdl = "benchmark_init_temperature_salinity" ! This subroutine's name.
   integer :: i, j, k, k1, is, ie, js, je, nz, itt
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+
+  call get_param(param_file, mdl, "S_REF", S_ref, &
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
+  call get_param(param_file, mdl, "BENCHMARK_T_LIGHT", T_light, &
+                 units="degC", default=29.0, scale=US%degC_to_C, do_not_log=.true.)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
   k1 = GV%nk_rho_varies + 1
 
   do k=1,nz
-    pres(k) = P_Ref ; S0(k) = 35.0*US%ppt_to_S
+    pres(k) = P_Ref ; S0(k) = S_ref
   enddo
 
-  T0(k1) = 29.0*US%degC_to_C
+  T0(k1) = T_light
   call calculate_density(T0(k1), S0(k1), pres(k1), rho_guess(k1), eqn_of_state)
   call calculate_density_derivs(T0, S0, pres, drho_dT, drho_dS, eqn_of_state, (/k1,k1/) )
 


### PR DESCRIPTION
  This PR adds 7 new runtime parameters to replace hard-coded dimensional parameters in 4 user initialization modules (benchmark_initialization, DOME2d_initialization, sloshing_initialization and DOME_initialization).  The new runtime parameters that were added are BENCHMARK_T_LIGHT, INITIAL_SSS, DOME2D_T_BAY, DOME2D_EAST_SPONGE_S_RANGE, INITIAL_SSS, SLOSHING_T_PERT and DOME_T_LIGHT.  By default all answers are bitwise identical, but there are new entries in the MOM_parameter_doc.all files for configurations using the four impacted modules.

  The commits in this PR include:

- NOAA-GFDL/MOM6@157b8068e +Add runtime parameters for DOME_initialization
- NOAA-GFDL/MOM6@5831dc6f1 +Add runtime parameters for sloshing_initialization
- NOAA-GFDL/MOM6@dd7c787a1 +Add runtime parameters for DOME2d_initialization
- NOAA-GFDL/MOM6@fcfa2f2bc +Add runtime parameters for benchmark_initialization
