### PR TITLE
+Add 12 runtime parameters for parameterization modules

### DIFF
--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -113,6 +113,8 @@ type, public :: int_tide_CS ; private
                         !< If true, apply scattering due to small-scale roughness as a sink.
   logical :: apply_Froude_drag
                         !< If true, apply wave breaking as a sink.
+  real :: En_check_tol  !< An energy density tolerance for flagging points with an imbalance in the
+                        !! internal tide energy budget when apply_Froude_drag is True [R Z3 T-2 ~> J m-2]
   logical :: apply_residual_drag
                         !< If true, apply sink from residual term of reflection/transmission.
   real, allocatable :: En(:,:,:,:,:)
@@ -474,7 +476,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
               ! Re-scale (reduce) energy due to breaking
               CS%En(i,j,a,fr,m) = CS%En(i,j,a,fr,m)/Fr2_max
               ! Check (for debugging only)
-              if (abs(En_new - En_check) > 1e-10*US%kg_m3_to_R*US%m_to_Z**3*US%T_to_s**2) then
+              if (abs(En_new - En_check) > CS%En_check_tol) then
                 call MOM_error(WARNING, "MOM_internal_tides: something is wrong with Fr-breaking.", &
                                all_print=.true.)
                 write(mesg,*) "En_new=", En_new , "En_check=", En_check
@@ -485,7 +487,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
             Delta_E_check = En_initial - sum(CS%En(i,j,:,fr,m))
             TKE_Froude_loss_check = abs(Delta_E_check)/dt
             TKE_Froude_loss_tot = sum(CS%TKE_Froude_loss(i,j,:,fr,m))
-            if (abs(TKE_Froude_loss_check - TKE_Froude_loss_tot) > 1e-10) then
+            if (abs(TKE_Froude_loss_check - TKE_Froude_loss_tot)*dt > CS%En_check_tol) then
               call MOM_error(WARNING, "MOM_internal_tides: something is wrong with Fr energy update.", &
                              all_print=.true.)
               write(mesg,*) "TKE_Froude_loss_check=", TKE_Froude_loss_check, &
@@ -2344,6 +2346,11 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   call get_param(param_file, mdl, "INTERNAL_TIDE_FROUDE_DRAG", CS%apply_Froude_drag, &
                  "If true, apply wave breaking as a sink.", &
                  default=.false.)
+  call get_param(param_file, mdl, "EN_CHECK_TOLERANCE", CS%En_check_tol, &
+                 "An energy density tolerance for flagging points with an imbalance in the "//&
+                 "internal tide energy budget when INTERNAL_TIDE_FROUDE_DRAG is True.", &
+                 units="J m-2", default=1.0e-10, scale=US%W_m2_to_RZ3_T3*US%s_to_T, &
+                 do_not_log=.not.CS%apply_Froude_drag)
   call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
                  "CDRAG is the drag coefficient relating the magnitude of "//&
                  "the velocity field to the bottom stress.", &


### PR DESCRIPTION
  This PR adds 12 new runtime parameters to replace hard-coded dimensional parameters in 11 parameterization modules (MOM_lateral_mixing_coeffs.F90, MOM_internal_tides.F90, MOM_CVMix_KPP.F90, MOM_kappa_shear.F90, MOM_MEKE.F90, MOM_thickness_diffuse.F90, MOM_entrain_diffusive.F90, MOM_diabatic_aux.F90, MOM_bulk_mixed_layer.F90, MOM_ALE_sponge.F90 and MOM_regularize_layers.F90).  The new runtime parameters that were added are MEKE_MIN_DEPTH_TOT, MEKE_LSCALE_MAX_VAL, EN_CHECK_TOLERANCE, MIN_DZ_FOR_SLOPE_N2, MEKE_MIN_DEPTH_DIFF, ENTRAIN_DIFFUSIVE_MAX_ENT, KD_SEED_KAPPA_SHEAR, KPP_LT_MLD_GUESS_MIN,  REG_SFC_SUFFICIENT_ADJ, SALT_EXTRACTION_LIMIT, MECH_TKE_FLOOR and VARYING_SPONGE_MASK_THICKNESS).

  This PR also includes a commit that makes the optional argument dz_subML to `diagnoseMLDbyDensityDifference()` in MOM_diabatic_aux.F90 mandatory (via an error message) if it will be used, and changes a tiny floor on the minimum thickness
over which to apply buoyancy forcing in `applyBoundaryFluxesInOut()` in a way that seems unlikely (but not impossible) to slightly change answers.

  The doxygen trailer describing the MOM_diabatic_aux module had been inappropriately borrowed from another module and did not describe the contents of that module at all, so it was completely rewritten to describe what the routines in this module actually do.  The missing doxygen description of the subroutine `set_pen_shortwave()` was also added.

  All answers are bitwise identical in the MOM6-examples test suite, but there are new entries in the MOM_parameter_doc.all files for configurations using the ten impacted modules.

  The commits in this PR include:

- NOAA-GFDL/MOM6@80abd6ddf +Add runtime parameter VARYING_SPONGE_MASK_THICKNESS
- NOAA-GFDL/MOM6@794f81a1f +Add runtime parameter MECH_TKE_FLOOR
- NOAA-GFDL/MOM6@f388abbc3 +Add runtime parameter SALT_EXTRACTION_LIMIT
- NOAA-GFDL/MOM6@994c29cdd +Add runtime parameter REG_SFC_SUFFICIENT_ADJ
- NOAA-GFDL/MOM6@48034c90f +Add runtime parameter KPP_LT_MLD_GUESS_MIN
- NOAA-GFDL/MOM6@be159dfad +Add runtime parameter ENTRAIN_DIFFUSIVE_MAX_ENT
- NOAA-GFDL/MOM6@0e0a18ad5 +Add runtime parameter KD_SEED_KAPPA_SHEAR
- NOAA-GFDL/MOM6@b328b480c (*)Require dz_subML to calculate the sub-ML N2
- NOAA-GFDL/MOM6@193d25ab2 +Add runtime parameter MEKE_MIN_DEPTH_DIFF
- NOAA-GFDL/MOM6@5663d56e4 +Add runtime parameter MEKE_LSCALE_MAX_VAL
- NOAA-GFDL/MOM6@4bec0ee43 +Add runtime parameter EN_CHECK_TOLERANCE
- NOAA-GFDL/MOM6@48cd3ef36 +Add runtime parameter MIN_DZ_FOR_SLOPE_N2