### PR TITLE
+Add DOME_tracer and tracer_example runtime params

### DIFF
--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -178,8 +178,7 @@ subroutine call_tracer_register(G, GV, US, param_file, CS, tr_Reg, restart_CS)
 
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
-  call get_param(param_file, mdl, "USE_USER_TRACER_EXAMPLE", &
-                                CS%use_USER_tracer_example, &
+  call get_param(param_file, mdl, "USE_USER_TRACER_EXAMPLE", CS%use_USER_tracer_example, &
                  "If true, use the USER_tracer_example tracer package.", &
                  default=.false.)
   call get_param(param_file, mdl, "USE_DOME_TRACER", CS%use_DOME_tracer, &
@@ -230,10 +229,10 @@ subroutine call_tracer_register(G, GV, US, param_file, CS, tr_Reg, restart_CS)
 !  tracer package registration call returns a logical false if it cannot be run
 !  for some reason.  This then overrides the run-time selection from above.
   if (CS%use_USER_tracer_example) CS%use_USER_tracer_example = &
-    USER_register_tracer_example(G%HI, GV, param_file, CS%USER_tracer_example_CSp, &
+    USER_register_tracer_example(G, GV, US, param_file, CS%USER_tracer_example_CSp, &
                                  tr_Reg, restart_CS)
   if (CS%use_DOME_tracer) CS%use_DOME_tracer = &
-    register_DOME_tracer(G%HI, GV, param_file, CS%DOME_tracer_CSp, &
+    register_DOME_tracer(G, GV, US, param_file, CS%DOME_tracer_CSp, &
                          tr_Reg, restart_CS)
   if (CS%use_ISOMIP_tracer) CS%use_ISOMIP_tracer = &
     register_ISOMIP_tracer(G%HI, GV, param_file, CS%ISOMIP_tracer_CSp, &


### PR DESCRIPTION
  Added the new runtime parameters DOME_TRACER_STRIPE_WIDTH, DOME_TRACER_STRIPE_LAT and DOME_TRACER_SHEET_SPACING to specify the previously hard-coded dimensional parameters in the DOME_tracer module, and added the runtime parameters TRACER_EXAMPLE_STRIPE_WIDTH and TRACER_EXAMPLE_STRIPE_LAT to specify parameters used by tracer_example.  This change requires that an ocean grid type be passed to register_DOME_tracer and USER_register_tracer_example instead of a hor_index type.

  Descriptions of the units of a number of internal variables were added to both modules.  In addition, the confusing (and dimensionally heterogeneous) trdc array in tracer_column_physics was replaced with 3 internal variables with more suggestive names.

  By default all answers are bitwise identical, but there are new entries in the MOM_parameter_doc.all files for cases that have USE_DOME_TRACER=True or USE_USER_TRACER_EXAMPLE=True.