### PR TITLE
Add KE_visc_gl90 diagnostic

### DIFF
--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -83,7 +83,7 @@ type, public :: diagnostics_CS ; private
   integer :: id_PE_to_KE       = -1, id_KE_BT          = -1
   integer :: id_KE_Coradv      = -1, id_KE_adv         = -1
   integer :: id_KE_visc        = -1, id_KE_stress      = -1
-  integer :: id_KE_visc_gl90 = -1
+  integer :: id_KE_visc_gl90   = -1
   integer :: id_KE_horvisc     = -1, id_KE_dia         = -1
   integer :: id_uh_Rlay        = -1, id_vh_Rlay        = -1
   integer :: id_uhGM_Rlay      = -1, id_vhGM_Rlay      = -1
@@ -1135,7 +1135,7 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
         call do_group_pass(CS%pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
     call post_data(CS%id_KE_visc_gl90, KE_term, CS%diag)

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -83,6 +83,7 @@ type, public :: diagnostics_CS ; private
   integer :: id_PE_to_KE       = -1, id_KE_BT          = -1
   integer :: id_KE_Coradv      = -1, id_KE_adv         = -1
   integer :: id_KE_visc        = -1, id_KE_stress      = -1
+  integer :: id_KE_visc_gl90 = -1
   integer :: id_KE_horvisc     = -1, id_KE_dia         = -1
   integer :: id_uh_Rlay        = -1, id_vh_Rlay        = -1
   integer :: id_uhGM_Rlay      = -1, id_vhGM_Rlay      = -1
@@ -1121,6 +1122,25 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
     call post_data(CS%id_KE_visc, KE_term, CS%diag)
   endif
 
+  if (CS%id_KE_visc_gl90 > 0) then
+    ! Calculate the KE source from GL90 vertical viscosity [H L2 T-3 ~> m3 s-3].
+    do k=1,nz
+      do j=js,je ; do I=Isq,Ieq
+        KE_u(I,j) = uh(I,j,k) * G%dxCu(I,j) * ADp%du_dt_visc_gl90(I,j,k)
+      enddo ; enddo
+      do J=Jsq,Jeq ; do i=is,ie
+        KE_v(i,J) = vh(i,J,k) * G%dyCv(i,J) * ADp%dv_dt_visc_gl90(i,J,k)
+      enddo ; enddo
+      if (.not.G%symmetric) &
+        call do_group_pass(CS%pass_KE_uv, G%domain)
+      do j=js,je ; do i=is,ie
+        KE_term(i,j,k) = 0.5 * G%IareaT(i,j) &
+            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+      enddo ; enddo
+    enddo
+    call post_data(CS%id_KE_visc_gl90, KE_term, CS%diag)
+  endif
+
   if (CS%id_KE_stress > 0) then
     ! Calculate the KE source from surface stress (included in KE_visc) [H L2 T-3 ~> m3 s-3].
     do k=1,nz
@@ -1803,6 +1823,9 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   CS%id_KE_visc = register_diag_field('ocean_model', 'KE_visc', diag%axesTL, Time, &
       'Kinetic Energy Source from Vertical Viscosity and Stresses', &
       'm3 s-3', conversion=GV%H_to_m*(US%L_T_to_m_s**2)*US%s_to_T)
+  CS%id_KE_visc_gl90 = register_diag_field('ocean_model', 'KE_visc_gl90', diag%axesTL, Time, &
+      'Kinetic Energy Source from GL90 Vertical Viscosity', &
+      'm3 s-3', conversion=GV%H_to_m*(US%L_T_to_m_s**2)*US%s_to_T)
   CS%id_KE_stress = register_diag_field('ocean_model', 'KE_stress', diag%axesTL, Time, &
       'Kinetic Energy Source from Surface Stresses or Body Wind Stress', &
       'm3 s-3', conversion=GV%H_to_m*(US%L_T_to_m_s**2)*US%s_to_T)
@@ -2231,7 +2254,10 @@ subroutine set_dependent_diagnostics(MIS, ADp, CDp, G, GV, CS)
     call safe_alloc_ptr(ADp%du_dt_visc,IsdB,IedB,jsd,jed,nz)
     call safe_alloc_ptr(ADp%dv_dt_visc,isd,ied,JsdB,JedB,nz)
   endif
-
+  if (CS%id_KE_visc_gl90 > 0) then
+    call safe_alloc_ptr(ADp%du_dt_visc_gl90,IsdB,IedB,jsd,jed,nz)
+    call safe_alloc_ptr(ADp%dv_dt_visc_gl90,isd,ied,JsdB,JedB,nz)
+  endif
   if (CS%id_KE_stress > 0) then
     call safe_alloc_ptr(ADp%du_dt_str,IsdB,IedB,jsd,jed,nz)
     call safe_alloc_ptr(ADp%dv_dt_str,isd,ied,JsdB,JedB,nz)
@@ -2245,7 +2271,8 @@ subroutine set_dependent_diagnostics(MIS, ADp, CDp, G, GV, CS)
 
   CS%KE_term_on = ((CS%id_dKEdt > 0) .or. (CS%id_PE_to_KE > 0) .or. (CS%id_KE_BT > 0) .or. &
                    (CS%id_KE_Coradv > 0) .or. (CS%id_KE_adv > 0) .or. (CS%id_KE_visc > 0) .or. &
-                   (CS%id_KE_stress > 0) .or. (CS%id_KE_horvisc > 0) .or. (CS%id_KE_dia > 0))
+                   (CS%id_KE_visc_gl90 > 0) .or. (CS%id_KE_stress > 0) .or. (CS%id_KE_horvisc > 0) .or. &
+                   (CS%id_KE_dia > 0))
 
   if (CS%id_h_du_dt > 0) call safe_alloc_ptr(ADp%diag_hu,IsdB,IedB,jsd,jed,nz)
   if (CS%id_h_dv_dt > 0) call safe_alloc_ptr(ADp%diag_hv,isd,ied,JsdB,JedB,nz)

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -2481,7 +2481,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
       'Meridional Acceleration from Vertical Viscosity', 'm s-2', conversion=US%L_T2_to_m_s2)
   if (CS%id_dv_dt_visc > 0) call safe_alloc_ptr(ADp%dv_dt_visc,isd,ied,JsdB,JedB,nz)
   CS%id_GLwork = register_diag_field('ocean_model', 'GLwork', diag%axesTL, Time, &
-      'Kinetic Energy Source from GL90 Vertical Viscosity', &
+      'Sign-definite Kinetic Energy Source from GL90 Vertical Viscosity', &
       'm3 s-3', conversion=GV%H_to_m*(US%L_T_to_m_s**2)*US%s_to_T)
   CS%id_du_dt_visc_gl90 = register_diag_field('ocean_model', 'du_dt_visc_gl90', diag%axesCuL, Time, &
       'Zonal Acceleration from GL90 Vertical Viscosity', 'm s-2', conversion=US%L_T2_to_m_s2)


### PR DESCRIPTION
Follow-up from PR #293.

`KE_visc_gl90` is an alternative to the diagnostic `GLwork`. Both diagnostics describe the energetics of the GL90 parameterization, as part of the kinetic energy budget.

* `KE_visc_gl90` is consistent with `KE_visc`, and the remaining KE diagnostics. In particular, it is true that `KE_visc_gl90` is exactly contained in `KE_visc`, i.e., we have that `KE_visc` - `KE_visc_gl90` represents exactly the energetics of all viscosity contributions except the GL90 viscosity.

* GLwork is not directly compatible with `KE_visc`, but is guaranteed to be sign-definite if summed in the vertical.

The figures below show **snapshots** of the vertically summed diagnostics `KE_visc_gl90` and `GLwork`.

<img src="https://user-images.githubusercontent.com/23617395/211410850-dd720b4e-b198-4204-8fd5-7a6d04b910cb.png" width="200"><img src="https://user-images.githubusercontent.com/23617395/211410949-d8a12e8a-26a7-44af-8dc6-5e861b1d3891.png" width="200">
