### PR TITLE
Minor diagnostics code improvements and unit annotations

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -406,8 +406,8 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
 
   if (CS%debug) then
     call MOM_state_chksum("Start predictor ", u, v, h, uh, vh, G, GV, US, symmetric=sym)
-    call check_redundant("Start predictor u ", u, v, G)
-    call check_redundant("Start predictor uh ", uh, vh, G)
+    call check_redundant("Start predictor u ", u, v, G, unscale=US%L_T_to_m_s)
+    call check_redundant("Start predictor uh ", uh, vh, G, unscale=GV%H_to_m*US%L_to_m**2*US%s_to_T)
   endif
 
   dyn_p_surf = associated(p_surf_begin) .and. associated(p_surf_end)
@@ -543,10 +543,10 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
     call MOM_accel_chksum("pre-btstep accel", CS%CAu_pred, CS%CAv_pred, CS%PFu, CS%PFv, &
                           CS%diffu, CS%diffv, G, GV, US, CS%pbce, u_bc_accel, v_bc_accel, &
                           symmetric=sym)
-    call check_redundant("pre-btstep CS%CA ", CS%CAu_pred, CS%CAv_pred, G)
-    call check_redundant("pre-btstep CS%PF ", CS%PFu, CS%PFv, G)
-    call check_redundant("pre-btstep CS%diff ", CS%diffu, CS%diffv, G)
-    call check_redundant("pre-btstep u_bc_accel ", u_bc_accel, v_bc_accel, G)
+    call check_redundant("pre-btstep CS%CA ", CS%CAu_pred, CS%CAv_pred, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("pre-btstep CS%PF ", CS%PFu, CS%PFv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("pre-btstep CS%diff ", CS%diffu, CS%diffv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("pre-btstep u_bc_accel ", u_bc_accel, v_bc_accel, G, unscale=US%L_T2_to_m_s2)
   endif
 
   call cpu_clock_begin(id_clock_vertvisc)
@@ -649,8 +649,8 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
              CS%diffu, CS%diffv, G, GV, US, CS%pbce, CS%u_accel_bt, CS%v_accel_bt, symmetric=sym)
     call MOM_state_chksum("Predictor 1 init", u, v, h, uh, vh, G, GV, US, haloshift=2, &
                           symmetric=sym)
-    call check_redundant("Predictor 1 up", up, vp, G)
-    call check_redundant("Predictor 1 uh", uh, vh, G)
+    call check_redundant("Predictor 1 up", up, vp, G, unscale=US%L_T_to_m_s)
+    call check_redundant("Predictor 1 uh", uh, vh, G, unscale=GV%H_to_m*US%L_to_m**2*US%s_to_T)
   endif
 
 ! up <- up + dt_pred d/dz visc d/dz up
@@ -778,8 +778,8 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
     call uvchksum("Predictor avg [uv]", u_av, v_av, G%HI, haloshift=1, symmetric=sym, scale=US%L_T_to_m_s)
     call hchksum(h_av, "Predictor avg h", G%HI, haloshift=0, scale=GV%H_to_m)
   ! call MOM_state_chksum("Predictor avg ", u_av, v_av, h_av, uh, vh, G, GV, US)
-    call check_redundant("Predictor up ", up, vp, G)
-    call check_redundant("Predictor uh ", uh, vh, G)
+    call check_redundant("Predictor up ", up, vp, G, unscale=US%L_T_to_m_s)
+    call check_redundant("Predictor uh ", uh, vh, G, unscale=GV%H_to_m*US%L_to_m**2*US%s_to_T)
   endif
 
 ! diffu = horizontal viscosity terms (u_av)
@@ -820,10 +820,10 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
     call MOM_accel_chksum("corr pre-btstep accel", CS%CAu, CS%CAv, CS%PFu, CS%PFv, &
                           CS%diffu, CS%diffv, G, GV, US, CS%pbce, u_bc_accel, v_bc_accel, &
                           symmetric=sym)
-    call check_redundant("corr pre-btstep CS%CA ", CS%CAu, CS%CAv, G)
-    call check_redundant("corr pre-btstep CS%PF ", CS%PFu, CS%PFv, G)
-    call check_redundant("corr pre-btstep CS%diff ", CS%diffu, CS%diffv, G)
-    call check_redundant("corr pre-btstep u_bc_accel ", u_bc_accel, v_bc_accel, G)
+    call check_redundant("corr pre-btstep CS%CA ", CS%CAu, CS%CAv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("corr pre-btstep CS%PF ", CS%PFu, CS%PFv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("corr pre-btstep CS%diff ", CS%diffu, CS%diffv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("corr pre-btstep u_bc_accel ", u_bc_accel, v_bc_accel, G, unscale=US%L_T2_to_m_s2)
   endif
 
   ! u_accel_bt = layer accelerations due to barotropic solver
@@ -848,7 +848,7 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
   if (showCallTree) call callTree_leave("btstep()")
 
   if (CS%debug) then
-    call check_redundant("u_accel_bt ", CS%u_accel_bt, CS%v_accel_bt, G)
+    call check_redundant("u_accel_bt ", CS%u_accel_bt, CS%v_accel_bt, G, unscale=US%L_T2_to_m_s2)
   endif
 
   ! u = u + dt*( u_bc_accel + u_accel_bt )

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -76,11 +76,11 @@ logical :: debug_redundant = .true. !< Check redundant values on PE boundaries
 contains
 
 !> MOM_debugging_init initializes the MOM_debugging module, and sets
-!! the parameterts that control which checks are active for MOM6.
+!! the parameters that control which checks are active for MOM6.
 subroutine MOM_debugging_init(param_file)
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "MOM_debugging" ! This module's name.
 
   call log_version(param_file, mdl, version, debugging=.true.)
@@ -102,19 +102,24 @@ end subroutine MOM_debugging_init
 
 !> Check for consistency between the duplicated points of a 3-D C-grid vector
 subroutine check_redundant_vC3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                                direction)
+                                direction, unscale)
   character(len=*),                    intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),               intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%jsd:,:),   intent(in)    :: u_comp !< The u-component of the vector
-                                                               !! to be checked for consistency
-  real, dimension(G%isd:,G%JsdB:,:),   intent(in)    :: v_comp !< The u-component of the vector
-                                                               !! to be checked for consistency
+  real, dimension(G%IsdB:,G%jsd:,:),   intent(in)    :: u_comp !< The u-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:,:),   intent(in)    :: v_comp !< The u-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
   integer,                   optional, intent(in)    :: is     !< The starting i-index to check
   integer,                   optional, intent(in)    :: ie     !< The ending i-index to check
   integer,                   optional, intent(in)    :: js     !< The starting j-index to check
   integer,                   optional, intent(in)    :: je     !< The ending j-index to check
   integer,                   optional, intent(in)    :: direction !< the direction flag to be
                                                                !! passed to pass_vector
+  real,                      optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                               !! arrays to give consistent output [a A-1 ~> 1]
+
   ! Local variables
   character(len=24) :: mesg_k
   integer :: k
@@ -126,30 +131,37 @@ subroutine check_redundant_vC3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_vC2d(trim(mesg)//trim(mesg_k), u_comp(:,:,k), &
-             v_comp(:,:,k), G, is, ie, js, je, direction)
+             v_comp(:,:,k), G, is, ie, js, je, direction, unscale)
   enddo
 end subroutine  check_redundant_vC3d
 
 !> Check for consistency between the duplicated points of a 2-D C-grid vector
 subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                                direction)
+                                direction, unscale)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),           intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector
-                                                           !! to be checked for consistency
-  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The u-component of the vector
-                                                           !! to be checked for consistency
+  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The u-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
   integer,               optional, intent(in)    :: is     !< The starting i-index to check
   integer,               optional, intent(in)    :: ie     !< The ending i-index to check
   integer,               optional, intent(in)    :: js     !< The starting j-index to check
   integer,               optional, intent(in)    :: je     !< The ending j-index to check
   integer,               optional, intent(in)    :: direction !< the direction flag to be
                                                            !! passed to pass_vector
+  real,                  optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
-  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: u_resym(G%IsdB:G%IedB,G%jsd:G%jed)
-  real :: v_resym(G%isd:G%ied,G%JsdB:G%JedB)
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input vector while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)  ! A nonsymmetric version of u_comp [A ~> a]
+  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)  ! A nonsymmetric version of v_comp [A ~> a]
+  real :: u_resym(G%IsdB:G%IedB,G%jsd:G%jed) ! A reconstructed symmetric version of u_comp [A ~> a]
+  real :: v_resym(G%isd:G%ied,G%JsdB:G%JedB) ! A reconstructed symmetric version of v_comp [A ~> a]
+  real :: sc  ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -162,6 +174,8 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     ! This only works with symmetric memory, so otherwise return.
     if ((isd == IsdB) .and. (jsd == JsdB)) return
   endif
+
+  sc  = 1.0 ; if (present(unscale)) sc = unscale
 
   do i=isd,ied ; do j=jsd,jed
     u_nonsym(i,j) = u_comp(i,j) ; v_nonsym(i,j) = v_comp(i,j)
@@ -187,7 +201,7 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
         redundant_prints(3) < max_redundant_prints) then
       write(mesg2,'(" redundant u-components",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           u_comp(i,j), u_resym(i,j),u_comp(i,j)-u_resym(i,j),i,j,pe_here()
+           sc*u_comp(i,j), sc*u_resym(i,j), sc*(u_comp(i,j)-u_resym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(3) = redundant_prints(3) + 1
     endif
@@ -197,7 +211,7 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
         redundant_prints(3) < max_redundant_prints) then
       write(mesg2,'(" redundant v-comps",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)," on pe ",i4)') &
-           v_comp(i,j), v_resym(i,j),v_comp(i,j)-v_resym(i,j),i,j, &
+           sc*v_comp(i,j), sc*v_resym(i,j), sc*(v_comp(i,j)-v_resym(i,j)), i, j, &
            G%geoLonBu(i,j), G%geoLatBu(i,j), pe_here()
       write(0,'(A155)') trim(mesg)//trim(mesg2)
       redundant_prints(3) = redundant_prints(3) + 1
@@ -207,14 +221,17 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
 end subroutine  check_redundant_vC2d
 
 !> Check for consistency between the duplicated points of a 3-D scalar at corner points
-subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je)
+subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je, unscale)
   character(len=*),                     intent(in)    :: mesg  !< An identifying message
   type(ocean_grid_type),                intent(inout) :: G     !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%JsdB:,:),   intent(in)    :: array !< The array to be checked for consistency
+  real, dimension(G%IsdB:,G%JsdB:,:),   intent(in)    :: array !< The array to be checked for consistency in
+                                                               !! arbitrary, possibly rescaled units [A ~> a]
   integer,                    optional, intent(in)    :: is    !< The starting i-index to check
   integer,                    optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                    optional, intent(in)    :: js    !< The starting j-index to check
   integer,                    optional, intent(in)    :: je    !< The ending j-index to check
+  real,                       optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                               !! arrays to give consistent output [a A-1 ~> 1]
 
   ! Local variables
   character(len=24) :: mesg_k
@@ -227,22 +244,28 @@ subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je)
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_sB2d(trim(mesg)//trim(mesg_k), array(:,:,k), &
-                              G, is, ie, js, je)
+                              G, is, ie, js, je, unscale)
   enddo
 end subroutine  check_redundant_sB3d
 
 !> Check for consistency between the duplicated points of a 2-D scalar at corner points
-subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
+subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je, unscale)
   character(len=*),                 intent(in)    :: mesg  !< An identifying message
   type(ocean_grid_type),            intent(inout) :: G     !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: array !< The array to be checked for consistency
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: array !< The array to be checked for consistency in
+                                                           !! arbitrary, possibly rescaled units [A ~> a]
   integer,                optional, intent(in)    :: is    !< The starting i-index to check
   integer,                optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                optional, intent(in)    :: js    !< The starting j-index to check
   integer,                optional, intent(in)    :: je    !< The ending j-index to check
+  real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
-  real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: a_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input array while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)    ! A nonsymmetric version of array [A ~> a]
+  real :: a_resym(G%IsdB:G%IedB,G%JsdB:G%JedB) ! A reconstructed symmetric version of array [A ~> a]
+  real :: sc  ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -255,6 +278,8 @@ subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
     ! This only works with symmetric memory, so otherwise return.
     if ((isd == IsdB) .and. (jsd == JsdB)) return
   endif
+
+  sc = 1.0 ; if (present(unscale)) sc = unscale
 
   do i=isd,ied ; do j=jsd,jed
     a_nonsym(i,j) = array(i,j)
@@ -281,7 +306,7 @@ subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
         redundant_prints(2) < max_redundant_prints) then
       write(mesg2,'(" Redundant points",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           array(i,j), a_resym(i,j),array(i,j)-a_resym(i,j),i,j,pe_here()
+           sc*array(i,j), sc*a_resym(i,j), sc*(array(i,j)-a_resym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(2) = redundant_prints(2) + 1
     endif
@@ -291,19 +316,23 @@ end subroutine  check_redundant_sB2d
 
 !> Check for consistency between the duplicated points of a 3-D B-grid vector
 subroutine check_redundant_vB3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                                direction)
+                                direction, unscale)
   character(len=*),                    intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),               intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%JsdB:,:),  intent(in)    :: u_comp !< The u-component of the vector
-                                                           !! to be checked for consistency
-  real, dimension(G%IsdB:,G%JsdB:,:),  intent(in)    :: v_comp !< The v-component of the vector
-                                                           !! to be checked for consistency
+  real, dimension(G%IsdB:,G%JsdB:,:),  intent(in)    :: u_comp !< The u-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
+  real, dimension(G%IsdB:,G%JsdB:,:),  intent(in)    :: v_comp !< The v-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
   integer,                   optional, intent(in)    :: is     !< The starting i-index to check
   integer,                   optional, intent(in)    :: ie     !< The ending i-index to check
   integer,                   optional, intent(in)    :: js     !< The starting j-index to check
   integer,                   optional, intent(in)    :: je     !< The ending j-index to check
   integer,                   optional, intent(in)    :: direction !< the direction flag to be
                                                                !! passed to pass_vector
+  real,                      optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                               !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
   character(len=24) :: mesg_k
   integer :: k
@@ -315,30 +344,37 @@ subroutine check_redundant_vB3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_vB2d(trim(mesg)//trim(mesg_k), u_comp(:,:,k), &
-             v_comp(:,:,k), G, is, ie, js, je, direction)
+             v_comp(:,:,k), G, is, ie, js, je, direction, unscale)
   enddo
 end subroutine  check_redundant_vB3d
 
 !> Check for consistency between the duplicated points of a 2-D B-grid vector
 subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                                direction)
+                                direction, unscale)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),            intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: u_comp !< The u-component of the vector
-                                                            !! to be checked for consistency
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector
-                                                            !! to be checked for consistency
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                            !! checked for consistency in arbitrary,
+                                                            !! possibly rescaled units [A ~> a]
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector to be
+                                                            !! checked for consistency in arbitrary,
+                                                            !! possibly rescaled units [A ~> a]
   integer,                optional, intent(in)    :: is     !< The starting i-index to check
   integer,                optional, intent(in)    :: ie     !< The ending i-index to check
   integer,                optional, intent(in)    :: js     !< The starting j-index to check
   integer,                optional, intent(in)    :: je     !< The ending j-index to check
   integer,                optional, intent(in)    :: direction !< the direction flag to be
                                                             !! passed to pass_vector
+  real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                            !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
-  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: u_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
-  real :: v_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input vector while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)    ! A nonsymmetric version of u_comp [A ~> a]
+  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)    ! A nonsymmetric version of v_comp [A ~> a]
+  real :: u_resym(G%IsdB:G%IedB,G%JsdB:G%JedB) ! A reconstructed symmetric version of u_comp [A ~> a]
+  real :: v_resym(G%IsdB:G%IedB,G%JsdB:G%JedB) ! A reconstructed symmetric version of v_comp [A ~> a]
+  real :: sc  ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -351,6 +387,8 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     ! This only works with symmetric memory, so otherwise return.
     if ((isd == IsdB) .and. (jsd == JsdB)) return
   endif
+
+  sc = 1.0 ; if (present(unscale)) sc = unscale
 
   do i=isd,ied ; do j=jsd,jed
     u_nonsym(i,j) = u_comp(i,j) ; v_nonsym(i,j) = v_comp(i,j)
@@ -377,7 +415,7 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
         redundant_prints(2) < max_redundant_prints) then
       write(mesg2,'(" redundant u-components",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           u_comp(i,j), u_resym(i,j),u_comp(i,j)-u_resym(i,j),i,j,pe_here()
+           sc*u_comp(i,j), sc*u_resym(i,j), sc*(u_comp(i,j)-u_resym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(2) = redundant_prints(2) + 1
     endif
@@ -387,7 +425,7 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
         redundant_prints(2) < max_redundant_prints) then
       write(mesg2,'(" redundant v-comps",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)," on pe ",i4)') &
-           v_comp(i,j), v_resym(i,j),v_comp(i,j)-v_resym(i,j),i,j, &
+           sc*v_comp(i,j), sc*v_resym(i,j), sc*(v_comp(i,j)-v_resym(i,j)), i, j, &
            G%geoLonBu(i,j), G%geoLatBu(i,j), pe_here()
       write(0,'(A155)') trim(mesg)//trim(mesg2)
       redundant_prints(2) = redundant_prints(2) + 1
@@ -397,14 +435,17 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
 end subroutine  check_redundant_vB2d
 
 !> Check for consistency between the duplicated points of a 3-D scalar at tracer points
-subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je)
+subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je, unscale)
   character(len=*),                     intent(in)    :: mesg  !< An identifying message
   type(ocean_grid_type),                intent(inout) :: G     !< The ocean's grid structure
-  real, dimension(G%isd:,G%jsd:,:),     intent(in)    :: array !< The array to be checked for consistency
+  real, dimension(G%isd:,G%jsd:,:),     intent(in)    :: array !< The array to be checked for consistency in
+                                                               !! arbitrary, possibly rescaled units [A ~> a]
   integer,                    optional, intent(in)    :: is    !< The starting i-index to check
   integer,                    optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                    optional, intent(in)    :: js    !< The starting j-index to check
   integer,                    optional, intent(in)    :: je    !< The ending j-index to check
+  real,                       optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                               !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
   character(len=24) :: mesg_k
   integer :: k
@@ -416,22 +457,28 @@ subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je)
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_sT2d(trim(mesg)//trim(mesg_k), array(:,:,k), &
-                              G, is, ie, js, je)
+                              G, is, ie, js, je, unscale)
   enddo
 end subroutine  check_redundant_sT3d
 
 
 !> Check for consistency between the duplicated points of a 2-D scalar at tracer points
-subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
+subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je, unscale)
   character(len=*),                 intent(in)    :: mesg  !< An identifying message
   type(ocean_grid_type),            intent(inout) :: G     !< The ocean's grid structure
-  real, dimension(G%isd:,G%jsd:),   intent(in)    :: array !< The array to be checked for consistency
+  real, dimension(G%isd:,G%jsd:),   intent(in)    :: array !< The array to be checked for consistency in
+                                                           !! arbitrary, possibly rescaled units [A ~> a]
   integer,                optional, intent(in)    :: is    !< The starting i-index to check
   integer,                optional, intent(in)    :: ie    !< The ending i-index to check
   integer,                optional, intent(in)    :: js    !< The starting j-index to check
   integer,                optional, intent(in)    :: je    !< The ending j-index to check
+  real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
-  real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input array while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)  ! A version of array with halo points updated by message passing [A ~> a]
+  real :: sc ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
 
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
@@ -441,6 +488,8 @@ subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
   is_ch = G%isc ; ie_ch = G%iec ; js_ch = G%jsc ; je_ch = G%jec
   if (present(is)) is_ch = is ; if (present(ie)) ie_ch = ie
   if (present(js)) js_ch = js ; if (present(js)) je_ch = je
+
+  sc = 1.0 ; if (present(unscale)) sc = unscale
 
   ! This only works on points outside of the standard computational domain.
   if ((is_ch == G%isc) .and. (ie_ch == G%iec) .and. &
@@ -457,7 +506,7 @@ subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
         redundant_prints(1) < max_redundant_prints) then
       write(mesg2,'(" Redundant points",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           array(i,j), a_nonsym(i,j),array(i,j)-a_nonsym(i,j),i,j,pe_here()
+           sc*array(i,j), sc*a_nonsym(i,j), sc*(array(i,j)-a_nonsym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(1) = redundant_prints(1) + 1
     endif
@@ -467,19 +516,23 @@ end subroutine  check_redundant_sT2d
 
 !> Check for consistency between the duplicated points of a 3-D A-grid vector
 subroutine check_redundant_vT3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                               direction)
+                               direction, unscale)
   character(len=*),                    intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),               intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%isd:,G%jsd:,:),    intent(in)    :: u_comp !< The u-component of the vector
-                                                           !! to be checked for consistency
-  real, dimension(G%isd:,G%jsd:,:),    intent(in)    :: v_comp !< The v-component of the vector
-                                                           !! to be checked for consistency
+  real, dimension(G%isd:,G%jsd:,:),    intent(in)    :: u_comp !< The u-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%jsd:,:),    intent(in)    :: v_comp !< The v-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
   integer,                   optional, intent(in)    :: is     !< The starting i-index to check
   integer,                   optional, intent(in)    :: ie     !< The ending i-index to check
   integer,                   optional, intent(in)    :: js     !< The starting j-index to check
   integer,                   optional, intent(in)    :: je     !< The ending j-index to check
   integer,                   optional, intent(in)    :: direction !< the direction flag to be
                                                            !! passed to pass_vector
+  real,                      optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
   character(len=24) :: mesg_k
   integer :: k
@@ -491,28 +544,35 @@ subroutine check_redundant_vT3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_vT2d(trim(mesg)//trim(mesg_k), u_comp(:,:,k), &
-             v_comp(:,:,k), G, is, ie, js, je, direction)
+             v_comp(:,:,k), G, is, ie, js, je, direction, unscale)
   enddo
 end subroutine  check_redundant_vT3d
 
 !> Check for consistency between the duplicated points of a 2-D A-grid vector
 subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                               direction)
+                               direction, unscale)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),           intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%isd:,G%jsd:),  intent(in)    :: u_comp !< The u-component of the vector
-                                                           !! to be checked for consistency
-  real, dimension(G%isd:,G%jsd:),  intent(in)    :: v_comp !< The v-component of the vector
-                                                           !! to be checked for consistency
+  real, dimension(G%isd:,G%jsd:),  intent(in)    :: u_comp !< The u-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%jsd:),  intent(in)    :: v_comp !< The v-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
   integer,               optional, intent(in)    :: is     !< The starting i-index to check
   integer,               optional, intent(in)    :: ie     !< The ending i-index to check
   integer,               optional, intent(in)    :: js     !< The starting j-index to check
   integer,               optional, intent(in)    :: je     !< The ending j-index to check
   integer,               optional, intent(in)    :: direction !< the direction flag to be
                                                            !! passed to pass_vector
+  real,                  optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
-  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input vector while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed) ! A version of u_comp with halo points updated by message passing [A ~> a]
+  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed) ! A version of v_comp with halo points updated by message passing [A ~> a]
+  real :: sc ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
 
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
@@ -524,6 +584,8 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   is_ch = G%isc ; ie_ch = G%iec ; js_ch = G%jsc ; je_ch = G%jec
   if (present(is)) is_ch = is ; if (present(ie)) ie_ch = ie
   if (present(js)) js_ch = js ; if (present(js)) je_ch = je
+
+  sc = 1.0 ; if (present(unscale)) sc = unscale
 
   ! This only works on points outside of the standard computational domain.
   if ((is_ch == G%isc) .and. (ie_ch == G%iec) .and. &
@@ -540,7 +602,7 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
         redundant_prints(1) < max_redundant_prints) then
       write(mesg2,'(" redundant u-components",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           u_comp(i,j), u_nonsym(i,j),u_comp(i,j)-u_nonsym(i,j),i,j,pe_here()
+           sc*u_comp(i,j), sc*u_nonsym(i,j), sc*(u_comp(i,j)-u_nonsym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(1) = redundant_prints(1) + 1
     endif
@@ -550,7 +612,7 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
         redundant_prints(1) < max_redundant_prints) then
       write(mesg2,'(" redundant v-comps",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)," on pe ",i4)') &
-           v_comp(i,j), v_nonsym(i,j),v_comp(i,j)-v_nonsym(i,j),i,j, &
+           sc*v_comp(i,j), sc*v_nonsym(i,j), sc*(v_comp(i,j)-v_nonsym(i,j)), i, j, &
            G%geoLonBu(i,j), G%geoLatBu(i,j), pe_here()
       write(0,'(A155)') trim(mesg)//trim(mesg2)
       redundant_prints(1) = redundant_prints(1) + 1
@@ -559,163 +621,202 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
 
 end subroutine  check_redundant_vT2d
 
+
+! It appears that none of the other routines in this file are ever called.
+
 !> Do a checksum and redundant point check on a 3d C-grid vector.
-subroutine chksum_vec_C3d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine chksum_vec_C3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),                  intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),             intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                             !! checked for consistency in arbitrary,
+                                                             !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component of the vector to be
+                                                             !! checked for consistency in arbitrary,
+                                                             !! possibly rescaled units [A ~> a]
   integer,                 optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                 optional, intent(in)    :: scalars !< If true this is a pair of
                                                              !! scalars that are being checked.
+  real,                    optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                             !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call uvchksum(mesg, u_comp, v_comp, G%HI, halos)
+    call uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_C(mesg, u_comp, v_comp, G)
+      call check_redundant_C(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine chksum_vec_C3d
 
 !> Do a checksum and redundant point check on a 2d C-grid vector.
-subroutine chksum_vec_C2d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine chksum_vec_C2d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),           intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
   integer,               optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,               optional, intent(in)    :: scalars !< If true this is a pair of
                                                            !! scalars that are being checked.
+  real,                  optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call uvchksum(mesg, u_comp, v_comp, G%HI, halos)
+    call uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_C(mesg, u_comp, v_comp, G)
+      call check_redundant_C(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine chksum_vec_C2d
 
 !> Do a checksum and redundant point check on a 3d B-grid vector.
-subroutine chksum_vec_B3d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine chksum_vec_B3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),                   intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),              intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%JsdB:,:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%IsdB:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%JsdB:,:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                              !! checked for consistency in arbitrary,
+                                                              !! possibly rescaled units [A ~> a]
+  real, dimension(G%IsdB:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component of the vector to be
+                                                              !! checked for consistency in arbitrary,
+                                                              !! possibly rescaled units [A ~> a]
   integer,                  optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                  optional, intent(in)    :: scalars !< If true this is a pair of
                                                               !! scalars that are being checked.
+  real,                     optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                              !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call Bchksum(u_comp, mesg//"(u)", G%HI, halos)
-    call Bchksum(v_comp, mesg//"(v)", G%HI, halos)
+    call Bchksum(u_comp, mesg//"(u)", G%HI, halos, scale=unscale)
+    call Bchksum(v_comp, mesg//"(v)", G%HI, halos, scale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_B(mesg, u_comp, v_comp, G)
+      call check_redundant_B(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine chksum_vec_B3d
 
 ! Do a checksum and redundant point check on a 2d B-grid vector.
-subroutine chksum_vec_B2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric)
+subroutine chksum_vec_B2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric, unscale)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),            intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                            !! checked for consistency in arbitrary,
+                                                            !! possibly rescaled units [A ~> a]
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector to be
+                                                            !! checked for consistency in arbitrary,
+                                                            !! possibly rescaled units [A ~> a]
   integer,                optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                optional, intent(in)    :: scalars !< If true this is a pair of
                                                             !! scalars that are being checked.
   logical,                optional, intent(in)    :: symmetric !< If true, do the checksums on the
                                                             !! full symmetric computational domain.
+  real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                            !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call Bchksum(u_comp, mesg//"(u)", G%HI, halos, symmetric=symmetric)
-    call Bchksum(v_comp, mesg//"(v)", G%HI, halos, symmetric=symmetric)
+    call Bchksum(u_comp, mesg//"(u)", G%HI, halos, symmetric=symmetric, scale=unscale)
+    call Bchksum(v_comp, mesg//"(v)", G%HI, halos, symmetric=symmetric, scale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_B(mesg, u_comp, v_comp, G)
+      call check_redundant_B(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine chksum_vec_B2d
 
 !> Do a checksum and redundant point check on a 3d C-grid vector.
-subroutine chksum_vec_A3d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine chksum_vec_A3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),            intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%isd:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%jsd:,:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%isd:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                            !! checked for consistency in arbitrary,
+                                                            !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%jsd:,:), intent(in)    :: v_comp !< The v-component of the vector to be
+                                                            !! checked for consistency in arbitrary,
+                                                            !! possibly rescaled units [A ~> a]
   integer,                optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                optional, intent(in)    :: scalars !< If true this is a pair of
                                                             !! scalars that are being checked.
+  real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                            !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call hchksum(u_comp, mesg//"(u)", G%HI, halos)
-    call hchksum(v_comp, mesg//"(v)", G%HI, halos)
+    call hchksum(u_comp, mesg//"(u)", G%HI, halos, scale=unscale)
+    call hchksum(v_comp, mesg//"(v)", G%HI, halos, scale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_T(mesg, u_comp, v_comp, G)
+      call check_redundant_T(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine chksum_vec_A3d
 
 !> Do a checksum and redundant point check on a 2d C-grid vector.
-subroutine chksum_vec_A2d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine chksum_vec_A2d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),               intent(in)    :: mesg   !< An identifying message
   type(ocean_grid_type),          intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%isd:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%jsd:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%isd:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                          !! checked for consistency in arbitrary,
+                                                          !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%jsd:), intent(in)    :: v_comp !< The v-component of the vector to be
+                                                          !! checked for consistency in arbitrary,
+                                                          !! possibly rescaled units [A ~> a]
   integer,              optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,              optional, intent(in)    :: scalars !< If true this is a pair of
                                                           !! scalars that are being checked.
+  real,                 optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                          !! arrays to give consistent output [a A-1 ~> 1]
   ! Local variables
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call hchksum(u_comp, mesg//"(u)", G%HI, halos)
-    call hchksum(v_comp, mesg//"(v)", G%HI, halos)
+    call hchksum(u_comp, mesg//"(u)", G%HI, halos, scale=unscale)
+    call hchksum(v_comp, mesg//"(v)", G%HI, halos, scale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_T(mesg, u_comp, v_comp, G)
+      call check_redundant_T(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
@@ -725,12 +826,12 @@ end subroutine chksum_vec_A2d
 !! processors of hThick*stuff, where stuff is a 3-d array at tracer points.
 function totalStuff(HI, hThick, areaT, stuff)
   type(hor_index_type),               intent(in) :: HI     !< A horizontal index type
-  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: hThick !< The array of thicknesses to use as weights
+  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: hThick !< The array of thicknesses to use as weights [m]
   real, dimension(HI%isd:,HI%jsd:),   intent(in) :: areaT  !< The array of cell areas [m2]
-  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: stuff  !< The array of stuff to be summed
-  real                                         :: totalStuff !< the globally integrated amoutn of stuff
+  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: stuff  !< The array of stuff to be summed in arbitrary units [a]
+  real                                         :: totalStuff !< the globally integrated amount of stuff [a m3]
   ! Local variables
-  real, dimension(HI%isc:HI%iec, HI%jsc:HI%jec) :: tmp_for_sum
+  real, dimension(HI%isc:HI%iec, HI%jsc:HI%jec) :: tmp_for_sum ! The column integrated amount of stuff in a cell [a m3]
   integer :: i, j, k, nz
 
   nz = size(hThick,3)
@@ -746,18 +847,22 @@ end function totalStuff
 !! as well as the change since the last call.
 subroutine totalTandS(HI, hThick, areaT, temperature, salinity, mesg)
   type(hor_index_type),               intent(in) :: HI     !< A horizontal index type
-  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: hThick !< The array of thicknesses to use as weights
+  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: hThick !< The array of thicknesses to use as weights [m]
   real, dimension(HI%isd:,HI%jsd:),   intent(in) :: areaT  !< The array of cell areas [m2]
-  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: temperature !< The temperature field to sum
-  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: salinity    !< The salinity field to sum
+  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: temperature !< The temperature field to sum [degC]
+  real, dimension(HI%isd:,HI%jsd:,:), intent(in) :: salinity    !< The salinity field to sum [ppt]
   character(len=*),                   intent(in) :: mesg        !< An identifying message
   ! NOTE: This subroutine uses "save" data which is not thread safe and is purely for
   ! extreme debugging without a proper debugger.
-  real, save :: totalH = 0., totalT = 0., totalS = 0.
+  real, save :: totalH = 0.   ! The total ocean volume, saved for the next call [m3]
+  real, save :: totalT = 0.   ! The total volume integrated ocean temperature, saved for the next call [degC m3]
+  real, save :: totalS = 0.   ! The total volume integrated ocean salinity, saved for the next call [ppt m3]
   ! Local variables
   logical, save :: firstCall = .true.
-  real, dimension(HI%isc:HI%iec, HI%jsc:HI%jec) :: tmp_for_sum
-  real :: thisH, thisT, thisS, delH, delT, delS
+  real, dimension(HI%isc:HI%iec, HI%jsc:HI%jec) :: tmp_for_sum ! The volume of each column [m3]
+  real :: thisH, delH  ! The total ocean volume and the change from the last call [m3]
+  real :: thisT, delT  ! The current total volume integrated temperature and the change from the last call [degC m3]
+  real :: thisS, delS  ! The current total volume integrated salinity and the change from the last call [ppt m3]
   integer :: i, j, k, nz
 
   nz = size(hThick,3)
@@ -788,11 +893,13 @@ end subroutine totalTandS
 !> Returns false if the column integral of a given quantity is within roundoff
 logical function check_column_integral(nk, field, known_answer)
   integer,             intent(in) :: nk           !< Number of levels in column
-  real, dimension(nk), intent(in) :: field        !< Field to be summed
-  real, optional,      intent(in) :: known_answer !< If present is the expected sum,
+  real, dimension(nk), intent(in) :: field        !< Field to be summed [arbitrary]
+  real, optional,      intent(in) :: known_answer !< If present is the expected sum [arbitrary],
                                                   !! If missing, assumed zero
   ! Local variables
-  real    :: u_sum, error, expected
+  real    :: u_sum    ! The vertical sum of the field [arbitrary]
+  real    :: error    ! An estimate of the roundoff error in the sum [arbitrary]
+  real    :: expected ! The expected vertical sum [arbitrary]
   integer :: k
 
   u_sum = field(1)
@@ -824,12 +931,15 @@ end function check_column_integral
 logical function check_column_integrals(nk_1, field_1, nk_2, field_2, missing_value)
   integer,               intent(in) :: nk_1           !< Number of levels in field 1
   integer,               intent(in) :: nk_2           !< Number of levels in field 2
-  real, dimension(nk_1), intent(in) :: field_1        !< First field to be summed
-  real, dimension(nk_2), intent(in) :: field_2        !< Second field to be summed
+  real, dimension(nk_1), intent(in) :: field_1        !< First field to be summed [arbitrary]
+  real, dimension(nk_2), intent(in) :: field_2        !< Second field to be summed [arbitrary]
   real, optional,        intent(in) :: missing_value  !< If column contains missing values,
-                                                      !! mask them from the sum
+                                                      !! mask them from the sum [arbitrary]
   ! Local variables
-  real    :: u1_sum, error1, u2_sum, error2, misval
+  real    :: u1_sum, u2_sum ! The vertical sums of the two fields [arbitrary]
+  real    :: error1, error2 ! Estimates of the roundoff errors in the sums [arbitrary]
+  real    :: misval         ! The missing value flag, indicating elements that are to be omitted
+                            ! from the sums [arbitrary]
   integer :: k
 
   ! Assign missing value
@@ -844,7 +954,7 @@ logical function check_column_integrals(nk_1, field_1, nk_2, field_2, missing_va
 
   ! Reintegrate and sum roundoff errors
   do k=2,nk_1
-    if (field_1(k)/=misval) then
+    if (field_1(k) /= misval) then
       u1_sum = u1_sum + field_1(k)
       error1 = error1 + EPSILON(u1_sum)*MAX(ABS(u1_sum),ABS(field_1(k)))
     endif
@@ -855,7 +965,7 @@ logical function check_column_integrals(nk_1, field_1, nk_2, field_2, missing_va
 
   ! Reintegrate and sum roundoff errors
   do k=2,nk_2
-    if (field_2(k)/=misval) then
+    if (field_2(k) /= misval) then
       u2_sum = u2_sum + field_2(k)
       error2 = error2 + EPSILON(u2_sum)*MAX(ABS(u2_sum),ABS(field_2(k)))
     endif

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -54,7 +54,7 @@ type, public :: diagnostics_CS ; private
   logical :: initialized = .false.     !< True if this control structure has been initialized.
   real :: mono_N2_column_fraction = 0. !< The lower fraction of water column over which N2 is limited as
                                        !! monotonic for the purposes of calculating the equivalent
-                                       !! barotropic wave speed.
+                                       !! barotropic wave speed [nondim].
   real :: mono_N2_depth = -1.          !< The depth below which N2 is limited as monotonic for the purposes of
                                        !! calculating the equivalent barotropic wave speed [Z ~> m].
 
@@ -203,7 +203,7 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
                                             ! including [nondim] and [H ~> m or kg m-2].
   real :: uh_tmp(SZIB_(G),SZJ_(G),SZK_(GV)) ! A temporary zonal transport [H L2 T-1 ~> m3 s-1 or kg s-1]
   real :: vh_tmp(SZI_(G),SZJB_(G),SZK_(GV)) ! A temporary meridional transport [H L2 T-1 ~> m3 s-1 or kg s-1]
-  real :: work_2d(SZI_(G),SZJ_(G))         ! A 2-d temporary work array.
+  real :: mass_cell(SZI_(G),SZJ_(G))       ! The vertically integrated mass in a grid cell [kg]
   real :: rho_in_situ(SZI_(G))             ! In situ density [R ~> kg m-3]
   real :: cg1(SZI_(G),SZJ_(G))             ! First baroclinic gravity wave speed [L T-1 ~> m s-1]
   real :: Rd1(SZI_(G),SZJ_(G))             ! First baroclinic deformation radius [L ~> m]
@@ -221,13 +221,13 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
 
   integer :: k_list
 
-  real, dimension(SZK_(GV)) :: temp_layer_ave ! The average temperature in a layer [degC]
-  real, dimension(SZK_(GV)) :: salt_layer_ave ! The average salinity in a layer [degC]
-  real :: thetaoga  ! The volume mean potential temperature [degC]
-  real :: soga      ! The volume mean ocean salinity [ppt]
+  real, dimension(SZK_(GV)) :: temp_layer_ave ! The average temperature in a layer [C ~> degC]
+  real, dimension(SZK_(GV)) :: salt_layer_ave ! The average salinity in a layer [S ~> ppt]
+  real :: thetaoga  ! The volume mean potential temperature [C ~> degC]
+  real :: soga      ! The volume mean ocean salinity [S ~> ppt]
   real :: masso     ! The total mass of the ocean [kg]
-  real :: tosga     ! The area mean sea surface temperature [degC]
-  real :: sosga     ! The area mean sea surface salinity [ppt]
+  real :: tosga     ! The area mean sea surface temperature [C ~> degC]
+  real :: sosga     ! The area mean sea surface salinity [S ~> ppt]
 
   is  = G%isc  ; ie   = G%iec  ; js  = G%jsc  ; je  = G%jec
   Isq = G%IscB ; Ieq  = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -334,11 +334,11 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
 
   ! mass of liquid ocean (for Bouss, use Rho0). The reproducing sum requires the use of MKS units.
   if (CS%id_masso > 0) then
-    work_2d(:,:) = 0.0
+    mass_cell(:,:) = 0.0
     do k=1,nz ; do j=js,je ; do i=is,ie
-      work_2d(i,j) = work_2d(i,j) + (GV%H_to_kg_m2*h(i,j,k)) * US%L_to_m**2*G%areaT(i,j)
+      mass_cell(i,j) = mass_cell(i,j) + (GV%H_to_kg_m2*h(i,j,k)) * US%L_to_m**2*G%areaT(i,j)
     enddo ; enddo ; enddo
-    masso = reproducing_sum(work_2d)
+    masso = reproducing_sum(mass_cell)
     call post_data(CS%id_masso, masso, CS%diag)
   endif
 
@@ -458,37 +458,37 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
 
   ! volume mean potential temperature
   if (CS%id_thetaoga>0) then
-    thetaoga = global_volume_mean(tv%T, h, G, GV, scale=US%C_to_degC)
+    thetaoga = global_volume_mean(tv%T, h, G, GV, tmp_scale=US%C_to_degC)
     call post_data(CS%id_thetaoga, thetaoga, CS%diag)
   endif
 
   ! area mean SST
   if (CS%id_tosga > 0) then
-    tosga = global_area_mean(tv%T(:,:,1), G, scale=US%C_to_degC)
+    tosga = global_area_mean(tv%T(:,:,1), G, tmp_scale=US%C_to_degC)
     call post_data(CS%id_tosga, tosga, CS%diag)
   endif
 
   ! volume mean salinity
   if (CS%id_soga>0) then
-    soga = global_volume_mean(tv%S, h, G, GV, scale=US%S_to_ppt)
+    soga = global_volume_mean(tv%S, h, G, GV, tmp_scale=US%S_to_ppt)
     call post_data(CS%id_soga, soga, CS%diag)
   endif
 
   ! area mean SSS
   if (CS%id_sosga > 0) then
-    sosga = global_area_mean(tv%S(:,:,1), G, scale=US%S_to_ppt)
+    sosga = global_area_mean(tv%S(:,:,1), G, tmp_scale=US%S_to_ppt)
     call post_data(CS%id_sosga, sosga, CS%diag)
   endif
 
   ! layer mean potential temperature
   if (CS%id_temp_layer_ave>0) then
-    temp_layer_ave = global_layer_mean(tv%T, h, G, GV, scale=US%C_to_degC)
+    temp_layer_ave = global_layer_mean(tv%T, h, G, GV, tmp_scale=US%C_to_degC)
     call post_data(CS%id_temp_layer_ave, temp_layer_ave, CS%diag)
   endif
 
   ! layer mean salinity
   if (CS%id_salt_layer_ave>0) then
-    salt_layer_ave = global_layer_mean(tv%S, h, G, GV, scale=US%S_to_ppt)
+    salt_layer_ave = global_layer_mean(tv%S, h, G, GV, tmp_scale=US%S_to_ppt)
     call post_data(CS%id_salt_layer_ave, salt_layer_ave, CS%diag)
   endif
 
@@ -834,7 +834,7 @@ subroutine calculate_vertical_integrals(h, tv, p_surf, G, GV, US, CS)
   type(diagnostics_CS),    intent(inout) :: CS   !< Control structure returned by a
                                                  !! previous call to diagnostics_init.
 
-  real, dimension(SZI_(G), SZJ_(G)) :: &
+  real, dimension(SZI_(G),SZJ_(G)) :: &
     z_top, &  ! Height of the top of a layer or the ocean [Z ~> m].
     z_bot, &  ! Height of the bottom of a layer (for id_mass) or the
               ! (positive) depth of the ocean (for id_col_ht) [Z ~> m].
@@ -891,7 +891,6 @@ subroutine calculate_vertical_integrals(h, tv, p_surf, G, GV, US, CS)
     if (GV%Boussinesq) then
       if (associated(tv%eqn_of_state)) then
         IG_Earth = 1.0 / GV%g_Earth
-!       do j=js,je ; do i=is,ie ; z_bot(i,j) = -P_SURF(i,j)/GV%H_to_Pa ; enddo ; enddo
         do j=G%jscB,G%jecB+1 ; do i=G%iscB,G%iecB+1
           z_bot(i,j) = 0.0
         enddo ; enddo
@@ -1207,9 +1206,10 @@ end subroutine calculate_energy_diagnostics
 subroutine register_time_deriv(lb, f_ptr, deriv_ptr, CS)
   integer, intent(in), dimension(3) :: lb     !< Lower index bound of f_ptr
   real, dimension(lb(1):,lb(2):,:), target :: f_ptr
-                                              !< Time derivative operand
+                                              !< Time derivative operand, in arbitrary units [A ~> a]
   real, dimension(lb(1):,lb(2):,:), target :: deriv_ptr
-                                              !< Time derivative of f_ptr
+                                              !< Time derivative of f_ptr, in units derived from
+                                              !! the arbitrary units of f_ptr [A T-1 ~> a s-1]
   type(diagnostics_CS), intent(inout) :: CS   !< Control structure returned by previous call to
                                               !! diagnostics_init.
 
@@ -1329,7 +1329,7 @@ subroutine post_surface_thermo_diags(IDs, G, GV, US, diag, dt_int, sfc_state, tv
   real, dimension(SZI_(G),SZJ_(G)), intent(in) :: ssh_ibc !< Time mean surface height with corrections
                                               !! for ice displacement and the inverse barometer [Z ~> m]
 
-  real, dimension(SZI_(G),SZJ_(G)) :: work_2d  ! A 2-d work array
+  real, dimension(SZI_(G),SZJ_(G)) :: work_2d  ! A 2-d work array [various]
   real, dimension(SZI_(G),SZJ_(G)) :: &
     zos  ! dynamic sea lev (zero area mean) from inverse-barometer adjusted ssh [Z ~> m]
   real :: I_time_int    ! The inverse of the time interval [T-1 ~> s-1].
@@ -1475,10 +1475,10 @@ subroutine post_transport_diagnostics(G, GV, US, uhtr, vhtr, h, IDs, diag_pre_dy
   type(tracer_registry_type), pointer     :: Reg !< Pointer to the tracer registry
 
   ! Local variables
-  real, dimension(SZIB_(G), SZJ_(G)) :: umo2d ! Diagnostics of integrated mass transport [R Z L2 T-1 ~> kg s-1]
-  real, dimension(SZI_(G), SZJB_(G)) :: vmo2d ! Diagnostics of integrated mass transport [R Z L2 T-1 ~> kg s-1]
-  real, dimension(SZIB_(G), SZJ_(G),SZK_(GV)) :: umo ! Diagnostics of layer mass transport [R Z L2 T-1 ~> kg s-1]
-  real, dimension(SZI_(G), SZJB_(G),SZK_(GV)) :: vmo ! Diagnostics of layer mass transport [R Z L2 T-1 ~> kg s-1]
+  real, dimension(SZIB_(G),SZJ_(G)) :: umo2d ! Diagnostics of integrated mass transport [R Z L2 T-1 ~> kg s-1]
+  real, dimension(SZI_(G),SZJB_(G)) :: vmo2d ! Diagnostics of integrated mass transport [R Z L2 T-1 ~> kg s-1]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: umo ! Diagnostics of layer mass transport [R Z L2 T-1 ~> kg s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vmo ! Diagnostics of layer mass transport [R Z L2 T-1 ~> kg s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))   :: h_tend ! Change in layer thickness due to dynamics
                           ! [H T-1 ~> m s-1 or kg m-2 s-1].
   real :: Idt             ! The inverse of the time interval [T-1 ~> s-1]
@@ -1637,11 +1637,11 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   flux_units = get_flux_units(GV)
   convert_H = GV%H_to_MKS
 
-  CS%id_masscello = register_diag_field('ocean_model', 'masscello', diag%axesTL,&
+  CS%id_masscello = register_diag_field('ocean_model', 'masscello', diag%axesTL, &
       Time, 'Mass per unit area of liquid ocean grid cell', 'kg m-2', & !### , conversion=GV%H_to_kg_m2, &
       standard_name='sea_water_mass_per_unit_area', v_extensive=.true.)
 
-  CS%id_masso = register_scalar_field('ocean_model', 'masso', Time,  &
+  CS%id_masso = register_scalar_field('ocean_model', 'masso', Time, &
       diag, 'Mass of liquid ocean', 'kg', standard_name='sea_water_mass')
 
   CS%id_thkcello = register_diag_field('ocean_model', 'thkcello', diag%axesTL, Time, &
@@ -1683,38 +1683,38 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
         standard_name='Salinity Squared')
 
     CS%id_temp_layer_ave = register_diag_field('ocean_model', 'temp_layer_ave', &
-        diag%axesZL, Time, 'Layer Average Ocean Temperature', 'degC')
+        diag%axesZL, Time, 'Layer Average Ocean Temperature', units='degC', conversion=US%C_to_degC)
     CS%id_salt_layer_ave = register_diag_field('ocean_model', 'salt_layer_ave', &
-        diag%axesZL, Time, 'Layer Average Ocean Salinity', 'psu')
+        diag%axesZL, Time, 'Layer Average Ocean Salinity', units='psu', conversion=US%S_to_ppt)
 
     CS%id_thetaoga = register_scalar_field('ocean_model', 'thetaoga', &
-        Time, diag, 'Global Mean Ocean Potential Temperature', 'degC', &
+        Time, diag, 'Global Mean Ocean Potential Temperature', units='degC', conversion=US%C_to_degC, &
         standard_name='sea_water_potential_temperature')
     CS%id_soga = register_scalar_field('ocean_model', 'soga', &
-        Time, diag, 'Global Mean Ocean Salinity', 'psu', &
+        Time, diag, 'Global Mean Ocean Salinity', units='psu', conversion=US%S_to_ppt, &
         standard_name='sea_water_salinity')
 
-    CS%id_tosga = register_scalar_field('ocean_model', 'sst_global', Time, diag,&
-        long_name='Global Area Average Sea Surface Temperature',                &
-        units='degC', standard_name='sea_surface_temperature',                  &
-        cmor_field_name='tosga', cmor_standard_name='sea_surface_temperature',  &
+    CS%id_tosga = register_scalar_field('ocean_model', 'sst_global', Time, diag, &
+        long_name='Global Area Average Sea Surface Temperature', &
+        units='degC', conversion=US%C_to_degC, standard_name='sea_surface_temperature', &
+        cmor_field_name='tosga', cmor_standard_name='sea_surface_temperature', &
         cmor_long_name='Sea Surface Temperature')
-    CS%id_sosga = register_scalar_field('ocean_model', 'sss_global', Time, diag,&
-        long_name='Global Area Average Sea Surface Salinity',                   &
-        units='psu', standard_name='sea_surface_salinity',                      &
-        cmor_field_name='sosga', cmor_standard_name='sea_surface_salinity',     &
+    CS%id_sosga = register_scalar_field('ocean_model', 'sss_global', Time, diag, &
+        long_name='Global Area Average Sea Surface Salinity', &
+        units='psu', conversion=US%S_to_ppt, standard_name='sea_surface_salinity', &
+        cmor_field_name='sosga', cmor_standard_name='sea_surface_salinity', &
         cmor_long_name='Sea Surface Salinity')
   endif
 
-  CS%id_u = register_diag_field('ocean_model', 'u', diag%axesCuL, Time,              &
+  CS%id_u = register_diag_field('ocean_model', 'u', diag%axesCuL, Time, &
       'Zonal velocity', 'm s-1', conversion=US%L_T_to_m_s, cmor_field_name='uo', &
       cmor_standard_name='sea_water_x_velocity', cmor_long_name='Sea Water X Velocity')
-  CS%id_v = register_diag_field('ocean_model', 'v', diag%axesCvL, Time,                  &
+  CS%id_v = register_diag_field('ocean_model', 'v', diag%axesCvL, Time, &
       'Meridional velocity', 'm s-1', conversion=US%L_T_to_m_s, cmor_field_name='vo', &
       cmor_standard_name='sea_water_y_velocity', cmor_long_name='Sea Water Y Velocity')
-  CS%id_usq = register_diag_field('ocean_model', 'usq', diag%axesCuL, Time,              &
+  CS%id_usq = register_diag_field('ocean_model', 'usq', diag%axesCuL, Time, &
       'Zonal velocity squared', 'm2 s-2', conversion=US%L_T_to_m_s**2)
-  CS%id_vsq = register_diag_field('ocean_model', 'vsq', diag%axesCvL, Time,                  &
+  CS%id_vsq = register_diag_field('ocean_model', 'vsq', diag%axesCvL, Time, &
       'Meridional velocity squared', 'm2 s-2', conversion=US%L_T_to_m_s**2)
   CS%id_uv = register_diag_field('ocean_model', 'uv', diag%axesTL, Time, &
       'Product between zonal and meridional velocities at h-points', &
@@ -1864,22 +1864,22 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
                          wave_speed_tol=wave_speed_tol)
   endif
 
-  CS%id_mass_wt = register_diag_field('ocean_model', 'mass_wt', diag%axesT1, Time,  &
+  CS%id_mass_wt = register_diag_field('ocean_model', 'mass_wt', diag%axesT1, Time, &
       'The column mass for calculating mass-weighted average properties', 'kg m-2', conversion=US%RZ_to_kg_m2)
 
   if (use_temperature) then
-    CS%id_temp_int = register_diag_field('ocean_model', 'temp_int', diag%axesT1, Time,                &
+    CS%id_temp_int = register_diag_field('ocean_model', 'temp_int', diag%axesT1, Time, &
         'Density weighted column integrated potential temperature', &
         'degC kg m-2', conversion=US%C_to_degC*US%RZ_to_kg_m2, &
-        cmor_field_name='opottempmint',                                                               &
-        cmor_long_name='integral_wrt_depth_of_product_of_sea_water_density_and_potential_temperature',&
+        cmor_field_name='opottempmint', &
+        cmor_long_name='integral_wrt_depth_of_product_of_sea_water_density_and_potential_temperature', &
         cmor_standard_name='Depth integrated density times potential temperature')
 
-    CS%id_salt_int = register_diag_field('ocean_model', 'salt_int', diag%axesT1, Time,   &
+    CS%id_salt_int = register_diag_field('ocean_model', 'salt_int', diag%axesT1, Time, &
         'Density weighted column integrated salinity', &
         'psu kg m-2', conversion=US%S_to_ppt*US%RZ_to_kg_m2, &
-        cmor_field_name='somint',                                                        &
-        cmor_long_name='integral_wrt_depth_of_product_of_sea_water_density_and_salinity',&
+        cmor_field_name='somint', &
+        cmor_long_name='integral_wrt_depth_of_product_of_sea_water_density_and_salinity', &
         cmor_standard_name='Depth integrated density times salinity')
   endif
 
@@ -1909,18 +1909,18 @@ subroutine register_surface_diags(Time, G, US, IDs, diag, tv)
   type(thermo_var_ptrs),   intent(in)    :: tv    !< A structure pointing to various thermodynamic variables
 
   ! Vertically integrated, budget, and surface state diagnostics
-  IDs%id_volo = register_scalar_field('ocean_model', 'volo', Time, diag,&
-      long_name='Total volume of liquid ocean', units='m3',            &
+  IDs%id_volo = register_scalar_field('ocean_model', 'volo', Time, diag, &
+      long_name='Total volume of liquid ocean', units='m3', &
       standard_name='sea_water_volume')
-  IDs%id_zos = register_diag_field('ocean_model', 'zos', diag%axesT1, Time,&
-      standard_name = 'sea_surface_height_above_geoid',                   &
+  IDs%id_zos = register_diag_field('ocean_model', 'zos', diag%axesT1, Time, &
+      standard_name = 'sea_surface_height_above_geoid', &
       long_name= 'Sea surface height above geoid', units='m', conversion=US%Z_to_m)
-  IDs%id_zossq = register_diag_field('ocean_model', 'zossq', diag%axesT1, Time,&
-      standard_name='square_of_sea_surface_height_above_geoid',             &
+  IDs%id_zossq = register_diag_field('ocean_model', 'zossq', diag%axesT1, Time, &
+      standard_name='square_of_sea_surface_height_above_geoid', &
       long_name='Square of sea surface height above geoid', units='m2', conversion=US%Z_to_m**2)
   IDs%id_ssh = register_diag_field('ocean_model', 'SSH', diag%axesT1, Time, &
       'Sea Surface Height', 'm', conversion=US%Z_to_m)
-  IDs%id_ssh_ga = register_scalar_field('ocean_model', 'ssh_ga', Time, diag,&
+  IDs%id_ssh_ga = register_scalar_field('ocean_model', 'ssh_ga', Time, diag, &
       long_name='Area averaged sea surface height', units='m', conversion=US%Z_to_m, &
       standard_name='area_averaged_sea_surface_height')
   IDs%id_ssu = register_diag_field('ocean_model', 'SSU', diag%axesCu1, Time, &
@@ -1931,7 +1931,7 @@ subroutine register_surface_diags(Time, G, US, IDs, diag, tv)
       'Sea Surface Speed', 'm s-1', conversion=US%L_T_to_m_s)
 
   if (associated(tv%T)) then
-    IDs%id_sst = register_diag_field('ocean_model', 'SST', diag%axesT1, Time,     &
+    IDs%id_sst = register_diag_field('ocean_model', 'SST', diag%axesT1, Time, &
         'Sea Surface Temperature', 'degC', conversion=US%C_to_degC, &
         cmor_field_name='tos', cmor_long_name='Sea Surface Temperature', &
         cmor_standard_name='sea_surface_temperature')
@@ -1948,11 +1948,11 @@ subroutine register_surface_diags(Time, G, US, IDs, diag, tv)
         cmor_field_name='sossq', cmor_long_name='Square of Sea Surface Salinity ', &
         cmor_standard_name='square_of_sea_surface_salinity')
     if (tv%T_is_conT) then
-      IDs%id_sstcon = register_diag_field('ocean_model', 'conSST', diag%axesT1, Time,     &
+      IDs%id_sstcon = register_diag_field('ocean_model', 'conSST', diag%axesT1, Time, &
           'Sea Surface Conservative Temperature', 'Celsius', conversion=US%C_to_degC)
     endif
     if (tv%S_is_absS) then
-      IDs%id_sssabs = register_diag_field('ocean_model', 'absSSS', diag%axesT1, Time,     &
+      IDs%id_sssabs = register_diag_field('ocean_model', 'absSSS', diag%axesT1, Time, &
           'Sea Surface Absolute Salinity', 'g kg-1', conversion=US%S_to_ppt)
     endif
     if (associated(tv%frazil)) then
@@ -1970,7 +1970,7 @@ subroutine register_surface_diags(Time, G, US, IDs, diag, tv)
   IDs%id_Heat_PmE = register_diag_field('ocean_model', 'Heat_PmE', diag%axesT1, Time, &
          'Heat flux into ocean from mass flux into ocean', &
          'W m-2', conversion=US%QRZ_T_to_W_m2)
-  IDs%id_intern_heat = register_diag_field('ocean_model', 'internal_heat', diag%axesT1, Time,&
+  IDs%id_intern_heat = register_diag_field('ocean_model', 'internal_heat', diag%axesT1, Time, &
          'Heat flux into ocean from geothermal or other internal sources', &
          'W m-2', conversion=US%QRZ_T_to_W_m2)
 
@@ -1981,15 +1981,13 @@ subroutine register_transport_diags(Time, G, GV, US, IDs, diag)
   type(time_type),          intent(in)    :: Time  !< current model time
   type(ocean_grid_type),    intent(in)    :: G     !< ocean grid structure
   type(verticalGrid_type),  intent(in)    :: GV    !< ocean vertical grid structure
-  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
+  type(unit_scale_type),    intent(in)    :: US    !< A dimensional unit scaling type
   type(transport_diag_IDs), intent(inout) :: IDs   !< A structure with the diagnostic IDs.
   type(diag_ctrl),          intent(inout) :: diag  !< regulates diagnostic output
 
-  real :: H_convert
   character(len=48) :: thickness_units, accum_flux_units
 
   thickness_units = get_thickness_units(GV)
-  H_convert = GV%H_to_MKS
   if (GV%Boussinesq) then
     accum_flux_units = "m3"
   else
@@ -1999,10 +1997,10 @@ subroutine register_transport_diags(Time, G, GV, US, IDs, diag)
   ! Diagnostics related to tracer and mass transport
   IDs%id_uhtr = register_diag_field('ocean_model', 'uhtr', diag%axesCuL, Time, &
       'Accumulated zonal thickness fluxes to advect tracers', &
-      accum_flux_units, y_cell_method='sum', v_extensive=.true., conversion=H_convert*US%L_to_m**2)
+      accum_flux_units, y_cell_method='sum', v_extensive=.true., conversion=GV%H_to_MKS*US%L_to_m**2)
   IDs%id_vhtr = register_diag_field('ocean_model', 'vhtr', diag%axesCvL, Time, &
       'Accumulated meridional thickness fluxes to advect tracers', &
-      accum_flux_units, x_cell_method='sum', v_extensive=.true., conversion=H_convert*US%L_to_m**2)
+      accum_flux_units, x_cell_method='sum', v_extensive=.true., conversion=GV%H_to_MKS*US%L_to_m**2)
   IDs%id_umo = register_diag_field('ocean_model', 'umo', &
       diag%axesCuL, Time, 'Ocean Mass X Transport', &
       'kg s-1', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
@@ -2019,10 +2017,10 @@ subroutine register_transport_diags(Time, G, GV, US, IDs, diag)
       diag%axesCv1, Time, 'Ocean Mass Y Transport Vertical Sum', &
       'kg s-1', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
       standard_name='ocean_mass_y_transport_vertical_sum', x_cell_method='sum')
-  IDs%id_dynamics_h = register_diag_field('ocean_model','dynamics_h',  &
+  IDs%id_dynamics_h = register_diag_field('ocean_model','dynamics_h', &
       diag%axesTl, Time, 'Layer thicknesses prior to horizontal dynamics', &
       thickness_units, conversion=GV%H_to_MKS, v_extensive=.true.)
-  IDs%id_dynamics_h_tendency = register_diag_field('ocean_model','dynamics_h_tendency',  &
+  IDs%id_dynamics_h_tendency = register_diag_field('ocean_model','dynamics_h_tendency', &
       diag%axesTl, Time, 'Change in layer thicknesses due to horizontal dynamics', &
       trim(thickness_units)//" s-1", conversion=GV%H_to_MKS*US%s_to_T, v_extensive=.true.)
 
@@ -2037,7 +2035,7 @@ subroutine write_static_fields(G, GV, US, tv, diag)
   type(diag_ctrl), target, intent(inout) :: diag !< regulates diagnostic output
 
   ! Local variables
-  real :: work_2d(SZI_(G),SZJ_(G))         ! A 2-d temporary work array.
+  real :: work_2d(SZI_(G),SZJ_(G))         ! A 2-d temporary work array [Z ~> m]
   integer :: id, i, j
   logical :: use_temperature
 
@@ -2104,10 +2102,10 @@ subroutine write_static_fields(G, GV, US, tv, diag)
         x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
   if (id > 0) call post_data(id, G%areaBu, diag, .true.)
 
-  id = register_static_field('ocean_model', 'depth_ocean', diag%axesT1,  &
+  id = register_static_field('ocean_model', 'depth_ocean', diag%axesT1, &
         'Depth of the ocean at tracer points', 'm', conversion=US%Z_to_m, &
-        standard_name='sea_floor_depth_below_geoid',                     &
-        cmor_field_name='deptho', cmor_long_name='Sea Floor Depth',      &
+        standard_name='sea_floor_depth_below_geoid', &
+        cmor_field_name='deptho', cmor_long_name='Sea Floor Depth', &
         cmor_standard_name='sea_floor_depth_below_geoid', area=diag%axesT1%id_area, &
         x_cell_method='mean', y_cell_method='mean', area_cell_method='mean')
   if (id > 0) then


### PR DESCRIPTION
  This PR has three commits that improve the diagnostics code, by adding to the description of internal variables and their units, by using rescaled units for 6 globally averaged temperature and salinity diagnostics, and by adding unscale arguments to the various check_redundant and chksum_vec routines that can be used to give debugging error messages that are invariant to dimensional rescaling.  A separate commit adds unscale arguments to the various check_redundant calls so that any error messages that are generated by inconsistent redundant points will be invariant to the unit scaling that is in use.  All answers and typical output are bitwise identical, but there are new optional arguments to several publicly visible routines.

  The commits in this PR include:

- NOAA-GFDL/MOM6@c4176e5b7 Use unscale args to check_redundant calls
- NOAA-GFDL/MOM6@7d3bec493 +Add optional unscale argument to check_redundant
- NOAA-GFDL/MOM6@c5284bef5 Use rescaled variables for global mean T & S diags