### PR TITLE
Document 476 framework argument and variable units

### DIFF
--- a/src/diagnostics/MOM_spatial_means.F90
+++ b/src/diagnostics/MOM_spatial_means.F90
@@ -22,21 +22,33 @@ public :: global_area_integral
 public :: global_volume_mean, global_mass_integral, global_mass_int_EFP
 public :: adjust_area_mean_to_zero
 
+! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
+! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
+! their mks counterparts with notation like "a velocity [Z T-1 ~> m s-1]".  If the units
+! vary with the Boussinesq approximation, the Boussinesq variant is given first.
+! The functions in this module work with variables with arbitrary units, in which case the
+! arbitrary rescaled units are indicated with [A ~> a], while the unscaled units are just [a].
+
 contains
 
 !> Return the global area mean of a variable. This uses reproducing sums.
 function global_area_mean(var, G, scale, tmp_scale)
   type(ocean_grid_type),             intent(in)  :: G    !< The ocean's grid structure
-  real, dimension(SZI_(G), SZJ_(G)), intent(in)  :: var  !< The variable to average
-  real,                    optional, intent(in)  :: scale !< A rescaling factor for the variable
-  real,                    optional, intent(in)  :: tmp_scale !< A temporary rescaling factor for the
-                                                         !! variable that is reversed in the return value
-  real :: global_area_mean
+  real, dimension(SZI_(G),SZJ_(G)),  intent(in)  :: var  !< The variable to average in
+                                                         !! arbitrary, possibly rescaled units [A ~> a]
+  real,                    optional, intent(in)  :: scale !< A rescaling factor for the variable [a A-1 ~> 1]
+                                                         !! that converts it back to unscaled (e.g., mks)
+                                                         !! units to enable the use of the reproducing sums
+  real,                    optional, intent(in)  :: tmp_scale !< A temporary rescaling factor for the variable
+                                                         !! that is reversed in the return value [a A-1 ~> 1]
+  real :: global_area_mean  ! The mean of the variable in arbitrary unscaled units [a] or scaled units [A ~> a]
 
   ! Local variables
-  real, dimension(SZI_(G), SZJ_(G))              :: tmpForSumming
-  real :: scalefac  ! An overall scaling factor for the areas and variable.
-  real :: temp_scale ! A temporary scaling factor.
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! An unscaled cell integral [a m2]
+  real :: scalefac   ! An overall scaling factor for the areas and variable [a m2 A-1 L-2 ~> 1]
+  real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
   integer :: i, j, is, ie, js, je
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
@@ -58,16 +70,23 @@ end function global_area_mean
 !> Return the global area mean of a variable. This uses reproducing sums.
 function global_area_mean_v(var, G, tmp_scale)
   type(ocean_grid_type),             intent(in)  :: G    !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJB_(G)), intent(in)  :: var  !< The variable to average
+  real, dimension(SZI_(G),SZJB_(G)), intent(in)  :: var  !< The variable to average in
+                                                         !! arbitrary, possibly rescaled units [A ~> a]
   real,                    optional, intent(in)  :: tmp_scale !< A temporary rescaling factor for the
-                                                         !! variable that is reversed in the return value
+                                                         !! variable that converts it back to unscaled
+                                                         !! (e.g., mks) units to enable the use of the
+                                                         !! reproducing sums [a A-1 ~> 1], but is reversed
+                                                         !! before output so that the return value has
+                                                         !! the same units as var
 
-  real :: global_area_mean_v
+  real :: global_area_mean_v  ! The mean of the variable in the same arbitrary units as var [A ~> a]
 
   ! Local variables
-  real, dimension(SZI_(G), SZJ_(G))              :: tmpForSumming
-  real :: scalefac   ! An overall scaling factor for the areas and variable.
-  real :: temp_scale ! A temporary scaling factor
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! An unscaled cell integral [a m2]
+  real :: scalefac   ! An overall scaling factor for the areas and variable [a m2 A-1 L-2 ~> 1]
+  real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
   integer :: i, j, is, ie, js, je, isB, ieB, jsB, jeB
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -91,14 +110,22 @@ end function global_area_mean_v
 !> Return the global area mean of a variable on U grid. This uses reproducing sums.
 function global_area_mean_u(var, G, tmp_scale)
   type(ocean_grid_type),             intent(in)  :: G    !< The ocean's grid structure
-  real, dimension(SZIB_(G),SZJ_(G)), intent(in)  :: var  !< The variable to average
+  real, dimension(SZIB_(G),SZJ_(G)), intent(in)  :: var  !< The variable to average in
+                                                         !! arbitrary, possibly rescaled units [A ~> a]
   real,                    optional, intent(in)  :: tmp_scale !< A temporary rescaling factor for the
-                                                         !! variable that is reversed in the return value
-  real :: global_area_mean_u
+                                                         !! variable that converts it back to unscaled
+                                                         !! (e.g., mks) units to enable the use of the
+                                                         !! reproducing sums [a A-1 ~> 1], but is reversed
+                                                         !! before output so that the return value has
+                                                         !! the same units as var
+  real :: global_area_mean_u  ! The mean of the variable in the same arbitrary units as var [A ~> a]
 
-  real, dimension(SZI_(G), SZJ_(G))              :: tmpForSumming
-  real :: scalefac   ! An overall scaling factor for the areas and variable.
-  real :: temp_scale ! A temporary scaling factor
+  ! Local variables
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! An unscaled cell integral [a m2]
+  real :: scalefac   ! An overall scaling factor for the areas and variable [a m2 A-1 L-2 ~> 1]
+  real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
   integer :: i, j, is, ie, js, je, isB, ieB, jsB, jeB
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -123,18 +150,24 @@ end function global_area_mean_u
 !! grid, but an alternate could be used instead.  This uses reproducing sums.
 function global_area_integral(var, G, scale, area, tmp_scale)
   type(ocean_grid_type),            intent(in)  :: G     !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: var   !< The variable to integrate
-  real,                   optional, intent(in)  :: scale !< A rescaling factor for the variable
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: var   !< The variable to integrate in
+                                                         !! arbitrary, possibly rescaled units [A ~> a]
+  real,                   optional, intent(in)  :: scale !< A rescaling factor for the variable [a A-1 ~> 1]
+                                                         !! that converts it back to unscaled (e.g., mks)
+                                                         !! units to enable the use of the reproducing sums
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: area !< The alternate area to use, including
                                                          !! any required masking [L2 ~> m2].
   real,                   optional, intent(in)  :: tmp_scale !< A temporary rescaling factor for the
-                                                         !! variable that is reversed in the return value
-  real :: global_area_integral !< The returned area integral, usually in the units of var times [m2].
+                                                         !! variable that is reversed in the return value [a A-1 ~> 1]
+  real :: global_area_integral !< The returned area integral, usually in the units of var times an area,
+                               !! [a m2] or [A m2 ~> a m2] depending on which optional arguments are provided
 
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! An unscaled cell integral [a m2]
   real :: scalefac  ! An overall scaling factor for the areas and variable.
-  real :: temp_scale ! A temporary scaling factor.
+  real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
   integer :: i, j, is, ie, js, je
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
@@ -163,18 +196,28 @@ end function global_area_integral
 function global_layer_mean(var, h, G, GV, scale, tmp_scale)
   type(ocean_grid_type),                     intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type),                   intent(in)  :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: var  !< The variable to average
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: var  !< The variable to average in
+                                                                 !! arbitrary, possibly rescaled units [A ~> a]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h    !< Layer thicknesses [H ~> m or kg m-2]
-  real,                            optional, intent(in)  :: scale !< A rescaling factor for the variable
+  real,                            optional, intent(in)  :: scale !< A rescaling factor for the variable [a A-1 ~> 1]
+                                                                 !! that converts it back to unscaled (e.g., mks)
+                                                                 !! units to enable the use of the reproducing sums
   real,                            optional, intent(in)  :: tmp_scale !< A temporary rescaling factor for the
-                                                         !! variable that is reversed in the return value
-  real, dimension(SZK_(GV))                   :: global_layer_mean
+                                                         !! variable that is reversed in the return value [a A-1 ~> 1]
+  real, dimension(SZK_(GV)) :: global_layer_mean  !< The mean of the variable in the arbitrary scaled [A]
+                                                  !! or unscaled [a] units of var, depending on which optional
+                                                  !! arguments are provided
 
-  real, dimension(G%isc:G%iec, G%jsc:G%jec, SZK_(GV)) :: tmpForSumming, weight
+  ! Local variables
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  real, dimension(G%isc:G%iec,G%jsc:G%jec,SZK_(GV)) :: tmpForSumming  ! An unscaled cell integral [a m3]
+  real, dimension(G%isc:G%iec,G%jsc:G%jec,SZK_(GV)) :: weight  ! The volume of each cell, used as a weight [m3]
   type(EFP_type), dimension(2*SZK_(GV)) :: laysums
-  real, dimension(SZK_(GV)) :: global_temp_scalar, global_weight_scalar
-  real :: temp_scale ! A temporary scaling factor
-  real :: scalefac  ! A scaling factor for the variable.
+  real, dimension(SZK_(GV)) :: global_temp_scalar    ! The global integral of the tracer in each layer [a m3]
+  real, dimension(SZK_(GV)) :: global_weight_scalar  ! The global integral of the volume of each layer [m3]
+  real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
+  real :: scalefac  ! A scaling factor for the variable [a A-1 ~> 1]
   integer :: i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -202,18 +245,26 @@ function global_volume_mean(var, h, G, GV, scale, tmp_scale)
   type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)  :: var  !< The variable being averaged
+                           intent(in)  :: var  !< The variable being averaged in
+                                               !! arbitrary, possibly rescaled units [A ~> a]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(in)  :: h    !< Layer thicknesses [H ~> m or kg m-2]
-  real,          optional, intent(in)  :: scale !< A rescaling factor for the variable
+  real,          optional, intent(in)  :: scale !< A rescaling factor for the variable [a A-1 ~> 1]
+                                               !! that converts it back to unscaled (e.g., mks)
+                                               !! units to enable the use of the reproducing sums
   real,          optional, intent(in)  :: tmp_scale !< A temporary rescaling factor for the
-                                               !! variable that is reversed in the return value
-  real :: global_volume_mean  !< The thickness-weighted average of var
+                                               !! variable that is reversed in the return value [a A-1 ~> 1]
+  real :: global_volume_mean  !< The thickness-weighted average of var in the arbitrary scaled [A] or
+                              !! unscaled [a] units of var, depending on which optional arguments are provided
 
-  real :: temp_scale ! A temporary scaling factor
-  real :: scalefac  ! A scaling factor for the variable.
-  real :: weight_here
-  real, dimension(SZI_(G), SZJ_(G)) :: tmpForSumming, sum_weight
+  ! Local variables
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
+  real :: scalefac   ! A scaling factor for the variable [a A-1 ~> 1]
+  real :: weight_here ! The volume of a grid cell [m3]
+  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! The volume integral of the variable in a column [a m3]
+  real, dimension(SZI_(G),SZJ_(G)) :: sum_weight  ! The volume of each column of water [m3]
   integer :: i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -239,19 +290,25 @@ function global_mass_integral(h, G, GV, var, on_PE_only, scale, tmp_scale)
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(in)  :: h    !< Layer thicknesses [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                 optional, intent(in)  :: var  !< The variable being integrated
-  logical,       optional, intent(in)  :: on_PE_only  !< If present and true, the sum is only
-                                !! done on the local PE, and it is _not_ order invariant.
-  real,          optional, intent(in)  :: scale !< A rescaling factor for the variable
+                 optional, intent(in)  :: var  !< The variable being integrated in
+                                               !! arbitrary, possibly rescaled units [A ~> a]
+  logical,       optional, intent(in)  :: on_PE_only  !< If present and true, the sum is only done
+                                               !! on the local PE, and it is _not_ order invariant.
+  real,          optional, intent(in)  :: scale !< A rescaling factor for the variable [a A-1 ~> 1]
+                                               !! that converts it back to unscaled (e.g., mks)
+                                               !! units to enable the use of the reproducing sums
   real,          optional, intent(in)  :: tmp_scale !< A temporary rescaling factor for the
-                                               !! variable that is reversed in the return value
+                                               !! variable that is reversed in the return value [a A-1 ~> 1]
   real :: global_mass_integral  !< The mass-weighted integral of var (or 1) in
-                                !! kg times the units of var
+                                !! kg times the arbitrary units of var [kg a] or [kg A ~> kg a]
 
-  real, dimension(SZI_(G), SZJ_(G)) :: tmpForSumming
-  real :: scalefac  ! An overall scaling factor for the areas and variable.
-  real :: temp_scale ! A temporary scaling factor.
-  logical :: global_sum
+  ! Local variables
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! The mass-weighted integral of the variable in a column [kg a]
+  real :: scalefac   ! An overall scaling factor for the cell mass and variable [a kg A-1 H-1 L-2 ~> kg m-3 or 1]
+  real :: temp_scale ! A temporary scaling factor [1] or [a A-1 ~> 1]
+  logical :: global_sum ! If true do the sum globally, but if false only do the sum on the current PE.
   integer :: i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -293,16 +350,21 @@ function global_mass_int_EFP(h, G, GV, var, on_PE_only, scale)
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(in)  :: h    !< Layer thicknesses [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                 optional, intent(in)  :: var  !< The variable being integrated
+                 optional, intent(in)  :: var  !< The variable being integrated in
+                                               !! arbitrary, possibly rescaled units [A ~> a]
   logical,       optional, intent(in)  :: on_PE_only  !< If present and true, the sum is only done
                                                !! on the local PE, but it is still order invariant.
-  real,          optional, intent(in)  :: scale !< A rescaling factor for the variable
+  real,          optional, intent(in)  :: scale !< A rescaling factor for the variable [a A-1 ~> 1]
+                                                !! that converts it back to unscaled (e.g., mks)
+                                                !! units to enable the use of the reproducing sums
   type(EFP_type) :: global_mass_int_EFP  !< The mass-weighted integral of var (or 1) in
-                                         !! kg times the units of var
+                                         !! kg times the arbitrary units of var [kg a]
 
   ! Local variables
-  real, dimension(SZI_(G), SZJ_(G)) :: tmpForSum
-  real :: scalefac  ! An overall scaling factor for the areas and variable.
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSum ! The mass-weighted integral of the variable in a column [kg a]
+  real :: scalefac  ! An overall scaling factor for the cell mass and variable [a kg A-1 H-1 L-2 ~> kg m-3 or 1]
   integer :: i, j, k, is, ie, js, je, nz, isr, ier, jsr, jer
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -333,19 +395,25 @@ end function global_mass_int_EFP
 !! in a 1-d array using the local indexing. This uses reproducing sums.
 subroutine global_i_mean(array, i_mean, G, mask, scale, tmp_scale)
   type(ocean_grid_type),            intent(inout) :: G    !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: array  !< The variable being averaged
-  real, dimension(SZJ_(G)),         intent(out)   :: i_mean !< Global mean of array along its i-axis
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: array  !< The variable being averaged in
+                                                            !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(SZJ_(G)),         intent(out)   :: i_mean !< Global mean of array along its i-axis [a] or [A ~> a]
   real, dimension(SZI_(G),SZJ_(G)), &
-                          optional, intent(in)    :: mask  !< An array used for weighting the i-mean
-  real,                   optional, intent(in)    :: scale !< A rescaling factor for the output variable
+                          optional, intent(in)    :: mask  !< An array used for weighting the i-mean [nondim]
+  real,                   optional, intent(in)    :: scale !< A rescaling factor for the output variable [a A-1 ~> 1]
+                                                           !! that converts it back to unscaled (e.g., mks)
+                                                           !! units to enable the use of the reproducing sums
   real,                   optional, intent(in)    :: tmp_scale !< A rescaling factor for the internal
-                                                           !! calculations that is removed from the output
+                                                           !! calculations that is removed from the output [a A-1 ~> 1]
 
   ! Local variables
-  type(EFP_type), allocatable, dimension(:) :: asum, mask_sum
-  real :: scalefac  ! A scaling factor for the variable.
-  real :: unscale   ! A factor for undoing any internal rescaling before output.
-  real :: mask_sum_r
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  type(EFP_type), allocatable, dimension(:) :: asum      ! The masked sum of the variable in each row [a]
+  type(EFP_type), allocatable, dimension(:) :: mask_sum  ! The sum of the mask values in each row [nondim]
+  real :: scalefac  ! A scaling factor for the variable [a A-1 ~> 1]
+  real :: unscale   ! A factor for undoing any internal rescaling before output [A a-1 ~> 1]
+  real :: mask_sum_r ! The sum of the mask values in a row [nondim]
   integer :: is, ie, js, je, idg_off, jdg_off
   integer :: i, j
 
@@ -419,19 +487,25 @@ end subroutine global_i_mean
 !! in a 1-d array using the local indexing. This uses reproducing sums.
 subroutine global_j_mean(array, j_mean, G, mask, scale, tmp_scale)
   type(ocean_grid_type),            intent(inout) :: G    !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: array  !< The variable being averaged
-  real, dimension(SZI_(G)),         intent(out)   :: j_mean !<  Global mean of array along its j-axis
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: array  !< The variable being averaged in
+                                                            !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(SZI_(G)),         intent(out)   :: j_mean !<  Global mean of array along its j-axis [a] or [A ~> a]
   real, dimension(SZI_(G),SZJ_(G)), &
                           optional, intent(in)    :: mask  !< An array used for weighting the j-mean
-  real,                   optional, intent(in)    :: scale !< A rescaling factor for the output variable
+  real,                   optional, intent(in)    :: scale !< A rescaling factor for the output variable [a A-1 ~> 1]
+                                                           !! that converts it back to unscaled (e.g., mks)
+                                                           !! units to enable the use of the reproducing sums
   real,                   optional, intent(in)    :: tmp_scale !< A rescaling factor for the internal
-                                                           !! calculations that is removed from the output
+                                                           !! calculations that is removed from the output [a A-1 ~> 1]
 
   ! Local variables
-  type(EFP_type), allocatable, dimension(:) :: asum, mask_sum
-  real :: mask_sum_r
-  real :: scalefac  ! A scaling factor for the variable.
-  real :: unscale   ! A factor for undoing any internal rescaling before output.
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  type(EFP_type), allocatable, dimension(:) :: asum      ! The masked sum of the variable in each row [a]
+  type(EFP_type), allocatable, dimension(:) :: mask_sum  ! The sum of the mask values in each row [nondim]
+  real :: mask_sum_r ! The sum of the mask values in a row [nondim]
+  real :: scalefac  ! A scaling factor for the variable [a A-1 ~> 1]
+  real :: unscale   ! A factor for undoing any internal rescaling before output [A a-1 ~> 1]
   integer :: is, ie, js, je, idg_off, jdg_off
   integer :: i, j
 
@@ -504,16 +578,23 @@ end subroutine global_j_mean
 !> Adjust 2d array such that area mean is zero without moving the zero contour
 subroutine adjust_area_mean_to_zero(array, G, scaling, unit_scale)
   type(ocean_grid_type),            intent(in)    :: G       !< Grid structure
-  real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: array   !< 2D array to be adjusted
-  real, optional,                   intent(out)   :: scaling !< The scaling factor used
-  real,                   optional, intent(in)    :: unit_scale !< A rescaling factor for the variable
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: array   !< 2D array to be adjusted in
+                                                             !! arbitrary, possibly rescaled units [A ~> a]
+  real, optional,                   intent(out)   :: scaling !< The scaling factor used [nondim]
+  real,                   optional, intent(in)    :: unit_scale !< A rescaling factor for the variable [a A-1 ~> 1]
+                                                             !! that converts it back to unscaled (e.g., mks)
+                                                             !! units to enable the use of the reproducing sums
   ! Local variables
-  real, dimension(G%isc:G%iec, G%jsc:G%jec) :: posVals, negVals, areaXposVals, areaXnegVals
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
+  ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
+  real, dimension(G%isc:G%iec, G%jsc:G%jec) :: posVals, negVals ! The positive or negative values in a cell or 0 [a]
+  real, dimension(G%isc:G%iec, G%jsc:G%jec) :: areaXposVals, areaXnegVals ! The cell area integral of the values [m2 a]
+  type(EFP_type), dimension(2) :: areaInt_EFP ! An EFP version integral of the values on the current PE [m2 a]
+  real :: scalefac  ! A scaling factor for the variable [a A-1 ~> 1]
+  real :: I_scalefac ! The Adcroft reciprocal of scalefac [A a-1 ~> 1]
+  real :: areaIntPosVals, areaIntNegVals ! The global area integral of the positive and negative values [m2 a]
+  real :: posScale, negScale ! The scaling factor to apply to positive or negative values [nondim]
   integer :: i,j
-  type(EFP_type), dimension(2) :: areaInt_EFP
-  real :: scalefac  ! A scaling factor for the variable.
-  real :: I_scalefac ! The Adcroft reciprocal of scalefac
-  real :: areaIntPosVals, areaIntNegVals, posScale, negScale
 
   scalefac = 1.0 ; if (present(unit_scale)) scalefac = unit_scale
   I_scalefac = 0.0 ; if (scalefac /= 0.0) I_scalefac = 1.0 / scalefac

--- a/src/framework/MOM_array_transform.F90
+++ b/src/framework/MOM_array_transform.F90
@@ -71,9 +71,9 @@ contains
 
 !> Rotate the elements of a 2d real array along first and second axes.
 subroutine rotate_array_real_2d(A_in, turns, A)
-  real, intent(in) :: A_in(:,:) !< Unrotated array
+  real, intent(in) :: A_in(:,:) !< Unrotated array [arbitrary]
   integer, intent(in) :: turns  !< Number of quarter turns
-  real, intent(out) :: A(:,:)   !< Rotated array
+  real, intent(out) :: A(:,:)   !< Rotated array [arbitrary]
 
   integer :: m, n
 
@@ -96,9 +96,9 @@ end subroutine rotate_array_real_2d
 
 !> Rotate the elements of a 3d real array along first and second axes.
 subroutine rotate_array_real_3d(A_in, turns, A)
-  real, intent(in) :: A_in(:,:,:) !< Unrotated array
+  real, intent(in) :: A_in(:,:,:) !< Unrotated array [arbitrary]
   integer, intent(in) :: turns    !< Number of quarter turns
-  real, intent(out) :: A(:,:,:)   !< Rotated array
+  real, intent(out) :: A(:,:,:)   !< Rotated array [arbitrary]
 
   integer :: k
 
@@ -110,9 +110,9 @@ end subroutine rotate_array_real_3d
 
 !> Rotate the elements of a 4d real array along first and second axes.
 subroutine rotate_array_real_4d(A_in, turns, A)
-  real, intent(in) :: A_in(:,:,:,:) !< Unrotated array
+  real, intent(in) :: A_in(:,:,:,:) !< Unrotated array [arbitrary]
   integer, intent(in) :: turns      !< Number of quarter turns
-  real, intent(out) :: A(:,:,:,:)   !< Rotated array
+  real, intent(out) :: A(:,:,:,:)   !< Rotated array [arbitrary]
 
   integer :: n
 
@@ -174,11 +174,11 @@ end subroutine rotate_array_logical
 
 !> Rotate the elements of a 2d real array pair along first and second axes.
 subroutine rotate_array_pair_real_2d(A_in, B_in, turns, A, B)
-  real, intent(in) :: A_in(:,:)   !< Unrotated scalar array pair
-  real, intent(in) :: B_in(:,:)   !< Unrotated scalar array pair
+  real, intent(in) :: A_in(:,:)   !< Unrotated scalar array pair [arbitrary]
+  real, intent(in) :: B_in(:,:)   !< Unrotated scalar array pair [arbitrary]
   integer, intent(in) :: turns    !< Number of quarter turns
-  real, intent(out) :: A(:,:)     !< Rotated scalar array pair
-  real, intent(out) :: B(:,:)     !< Rotated scalar array pair
+  real, intent(out) :: A(:,:)     !< Rotated scalar array pair [arbitrary]
+  real, intent(out) :: B(:,:)     !< Rotated scalar array pair [arbitrary]
 
   if (modulo(turns, 2) /= 0) then
     call rotate_array(B_in, turns, A)
@@ -192,11 +192,11 @@ end subroutine rotate_array_pair_real_2d
 
 !> Rotate the elements of a 3d real array pair along first and second axes.
 subroutine rotate_array_pair_real_3d(A_in, B_in, turns, A, B)
-  real, intent(in) :: A_in(:,:,:)   !< Unrotated scalar array pair
-  real, intent(in) :: B_in(:,:,:)   !< Unrotated scalar array pair
+  real, intent(in) :: A_in(:,:,:)   !< Unrotated scalar array pair [arbitrary]
+  real, intent(in) :: B_in(:,:,:)   !< Unrotated scalar array pair [arbitrary]
   integer, intent(in) :: turns      !< Number of quarter turns
-  real, intent(out) :: A(:,:,:)     !< Rotated scalar array pair
-  real, intent(out) :: B(:,:,:)     !< Rotated scalar array pair
+  real, intent(out) :: A(:,:,:)     !< Rotated scalar array pair [arbitrary]
+  real, intent(out) :: B(:,:,:)     !< Rotated scalar array pair [arbitrary]
 
   integer :: k
 
@@ -227,11 +227,11 @@ end subroutine rotate_array_pair_integer
 
 !> Rotate the elements of a 2d real vector along first and second axes.
 subroutine rotate_vector_real_2d(A_in, B_in, turns, A, B)
-  real, intent(in) :: A_in(:,:) !< First component of unrotated vector
-  real, intent(in) :: B_in(:,:) !< Second component of unrotated vector
+  real, intent(in) :: A_in(:,:) !< First component of unrotated vector [arbitrary]
+  real, intent(in) :: B_in(:,:) !< Second component of unrotated vector [arbitrary]
   integer, intent(in) :: turns  !< Number of quarter turns
-  real, intent(out) :: A(:,:)   !< First component of rotated vector
-  real, intent(out) :: B(:,:)   !< Second component of unrotated vector
+  real, intent(out) :: A(:,:)   !< First component of rotated vector [arbitrary]
+  real, intent(out) :: B(:,:)   !< Second component of unrotated vector [arbitrary]
 
   call rotate_array_pair(A_in, B_in, turns, A, B)
 
@@ -245,11 +245,11 @@ end subroutine rotate_vector_real_2d
 
 !> Rotate the elements of a 3d real vector along first and second axes.
 subroutine rotate_vector_real_3d(A_in, B_in, turns, A, B)
-  real, intent(in) :: A_in(:,:,:) !< First component of unrotated vector
-  real, intent(in) :: B_in(:,:,:) !< Second component of unrotated vector
+  real, intent(in) :: A_in(:,:,:) !< First component of unrotated vector [arbitrary]
+  real, intent(in) :: B_in(:,:,:) !< Second component of unrotated vector [arbitrary]
   integer, intent(in) :: turns    !< Number of quarter turns
-  real, intent(out) :: A(:,:,:)   !< First component of rotated vector
-  real, intent(out) :: B(:,:,:)   !< Second component of unrotated vector
+  real, intent(out) :: A(:,:,:)   !< First component of rotated vector [arbitrary]
+  real, intent(out) :: B(:,:,:)   !< Second component of unrotated vector [arbitrary]
 
   integer :: k
 
@@ -261,11 +261,11 @@ end subroutine rotate_vector_real_3d
 
 !> Rotate the elements of a 4d real vector along first and second axes.
 subroutine rotate_vector_real_4d(A_in, B_in, turns, A, B)
-  real, intent(in) :: A_in(:,:,:,:) !< First component of unrotated vector
-  real, intent(in) :: B_in(:,:,:,:) !< Second component of unrotated vector
+  real, intent(in) :: A_in(:,:,:,:) !< First component of unrotated vector [arbitrary]
+  real, intent(in) :: B_in(:,:,:,:) !< Second component of unrotated vector [arbitrary]
   integer, intent(in) :: turns      !< Number of quarter turns
-  real, intent(out) :: A(:,:,:,:)   !< First component of rotated vector
-  real, intent(out) :: B(:,:,:,:)   !< Second component of unrotated vector
+  real, intent(out) :: A(:,:,:,:)   !< First component of rotated vector [arbitrary]
+  real, intent(out) :: B(:,:,:,:)   !< Second component of unrotated vector [arbitrary]
 
   integer :: n
 
@@ -280,9 +280,9 @@ end subroutine rotate_vector_real_4d
 subroutine allocate_rotated_array_real_2d(A_in, lb, turns, A)
   ! NOTE: lb must be declared before A_in
   integer, intent(in) :: lb(2)                !< Lower index bounds of A_in
-  real, intent(in) :: A_in(lb(1):, lb(2):)    !< Reference array
+  real, intent(in) :: A_in(lb(1):, lb(2):)    !< Reference array [arbitrary]
   integer, intent(in) :: turns                !< Number of quarter turns
-  real, allocatable, intent(inout) :: A(:,:)  !< Array on rotated index
+  real, allocatable, intent(inout) :: A(:,:)  !< Array on rotated index [arbitrary]
 
   integer :: ub(2)
 
@@ -300,9 +300,9 @@ end subroutine allocate_rotated_array_real_2d
 subroutine allocate_rotated_array_real_3d(A_in, lb, turns, A)
   ! NOTE: lb must be declared before A_in
   integer, intent(in) :: lb(3)                    !< Lower index bounds of A_in
-  real, intent(in) :: A_in(lb(1):, lb(2):, lb(3):)  !< Reference array
+  real, intent(in) :: A_in(lb(1):, lb(2):, lb(3):)  !< Reference array [arbitrary]
   integer, intent(in) :: turns                    !< Number of quarter turns
-  real, allocatable, intent(inout) :: A(:,:,:)    !< Array on rotated index
+  real, allocatable, intent(inout) :: A(:,:,:)    !< Array on rotated index [arbitrary]
 
   integer :: ub(3)
 
@@ -320,9 +320,9 @@ end subroutine allocate_rotated_array_real_3d
 subroutine allocate_rotated_array_real_4d(A_in, lb, turns, A)
   ! NOTE: lb must be declared before A_in
   integer, intent(in) :: lb(4)                    !< Lower index bounds of A_in
-  real, intent(in) :: A_in(lb(1):,lb(2):,lb(3):,lb(4):) !< Reference array
+  real, intent(in) :: A_in(lb(1):,lb(2):,lb(3):,lb(4):) !< Reference array [arbitrary]
   integer, intent(in) :: turns                    !< Number of quarter turns
-  real, allocatable, intent(inout) :: A(:,:,:,:)  !< Array on rotated index
+  real, allocatable, intent(inout) :: A(:,:,:,:)  !< Array on rotated index [arbitrary]
 
   integer:: ub(4)
 

--- a/src/framework/MOM_intrinsic_functions.F90
+++ b/src/framework/MOM_intrinsic_functions.F90
@@ -13,9 +13,9 @@ contains
 !> Evaluate the inverse cosh, either using a math library or an
 !! equivalent expression
 function invcosh(x)
-  real, intent(in) :: x !< The argument of the inverse of cosh.  NaNs will
+  real, intent(in) :: x !< The argument of the inverse of cosh [nondim].  NaNs will
                         !! occur if x<1, but there is no error checking
-  real :: invcosh
+  real :: invcosh  ! The inverse of cosh of x [nondim]
 
 #ifdef __INTEL_COMPILER
   invcosh = acosh(x)

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -27,29 +27,36 @@ public restart_registry_lock, restart_init_end, vardesc
 public restart_files_exist, determine_is_new_run, is_new_run
 public register_restart_field_as_obsolete, register_restart_pair
 
+! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
+! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
+! their mks counterparts with notation like "a velocity [Z T-1 ~> m s-1]".  If the units
+! vary with the Boussinesq approximation, the Boussinesq variant is given first.
+! The functions in this module work with variables with arbitrary units, in which case the
+! arbitrary rescaled units are indicated with [A ~> a], while the unscaled units are just [a].
+
 !> A type for making arrays of pointers to 4-d arrays
 type p4d
-  real, dimension(:,:,:,:), pointer :: p => NULL() !< A pointer to a 4d array
+  real, dimension(:,:,:,:), pointer :: p => NULL() !< A pointer to a 4d array in arbitrary rescaled units [A ~> a]
 end type p4d
 
 !> A type for making arrays of pointers to 3-d arrays
 type p3d
-  real, dimension(:,:,:), pointer :: p => NULL() !< A pointer to a 3d array
+  real, dimension(:,:,:), pointer :: p => NULL() !< A pointer to a 3d array in arbitrary rescaled units [A ~> a]
 end type p3d
 
 !> A type for making arrays of pointers to 2-d arrays
 type p2d
-  real, dimension(:,:), pointer :: p => NULL() !< A pointer to a 2d array
+  real, dimension(:,:), pointer :: p => NULL() !< A pointer to a 2d array in arbitrary rescaled units [A ~> a]
 end type p2d
 
 !> A type for making arrays of pointers to 1-d arrays
 type p1d
-  real, dimension(:), pointer :: p => NULL() !< A pointer to a 1d array
+  real, dimension(:), pointer :: p => NULL() !< A pointer to a 1d array in arbitrary rescaled units [A ~> a]
 end type p1d
 
 !> A type for making arrays of pointers to scalars
 type p0d
-  real, pointer :: p => NULL() !< A pointer to a scalar
+  real, pointer :: p => NULL() !< A pointer to a scalar in arbitrary rescaled units [A ~> a]
 end type p0d
 
 !> A structure with information about a single restart field
@@ -62,8 +69,8 @@ type field_restart
   character(len=32) :: var_name !< A name by which a variable may be queried.
   real    :: conv = 1.0         !< A factor by which a restart field should be multiplied before it
                                 !! is written to a restart file, usually to convert it to MKS or
-                                !! other standard units.  When read, the restart field is multiplied
-                                !! by the Adcroft reciprocal of this factor.
+                                !! other standard units [a A-1 ~> 1].  When read, the restart field
+                                !! is multiplied by the Adcroft reciprocal of this factor.
 end type field_restart
 
 !> A structure to store information about restart fields that are no longer used
@@ -171,12 +178,13 @@ end subroutine register_restart_field_as_obsolete
 subroutine register_restart_field_ptr3d(f_ptr, var_desc, mandatory, CS, conversion)
   real, dimension(:,:,:), &
                       target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   type(vardesc),              intent(in) :: var_desc  !< A structure with metadata about this variable
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
   type(MOM_restart_CS),       intent(inout) :: CS     !< MOM restart control struct
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
 
   if (.not.CS%initialized) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
@@ -208,12 +216,13 @@ end subroutine register_restart_field_ptr3d
 subroutine register_restart_field_ptr4d(f_ptr, var_desc, mandatory, CS, conversion)
   real, dimension(:,:,:,:), &
                       target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   type(vardesc),              intent(in) :: var_desc  !< A structure with metadata about this variable
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
   type(MOM_restart_CS),       intent(inout) :: CS     !< MOM restart control struct
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
 
   if (.not.CS%initialized) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
@@ -245,12 +254,13 @@ end subroutine register_restart_field_ptr4d
 subroutine register_restart_field_ptr2d(f_ptr, var_desc, mandatory, CS, conversion)
   real, dimension(:,:), &
                       target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   type(vardesc),              intent(in) :: var_desc  !< A structure with metadata about this variable
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
   type(MOM_restart_CS),       intent(inout) :: CS     !< MOM restart control struct
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
 
   if (.not.CS%initialized) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
@@ -281,12 +291,13 @@ end subroutine register_restart_field_ptr2d
 !> Register a 1-d field for restarts, providing the metadata in a structure
 subroutine register_restart_field_ptr1d(f_ptr, var_desc, mandatory, CS, conversion)
   real, dimension(:), target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   type(vardesc),              intent(in) :: var_desc  !< A structure with metadata about this variable
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
   type(MOM_restart_CS),       intent(inout) :: CS     !< MOM restart control struct
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
 
   if (.not.CS%initialized) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
@@ -317,12 +328,13 @@ end subroutine register_restart_field_ptr1d
 !> Register a 0-d field for restarts, providing the metadata in a structure
 subroutine register_restart_field_ptr0d(f_ptr, var_desc, mandatory, CS, conversion)
   real,               target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   type(vardesc),              intent(in) :: var_desc  !< A structure with metadata about this variable
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
   type(MOM_restart_CS),       intent(inout) :: CS     !< MOM restart control struct
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
 
   if (.not.CS%initialized) call MOM_error(FATAL, "MOM_restart " // &
       "register_restart_field: Module must be initialized before it is used.")
@@ -355,13 +367,15 @@ end subroutine register_restart_field_ptr0d
 subroutine register_restart_pair_ptr2d(a_ptr, b_ptr, a_desc, b_desc, &
                 mandatory, CS, conversion)
   real, dimension(:,:), target, intent(in) :: a_ptr   !< First field pointer
+                                                      !! in arbitrary rescaled units [A ~> a]
   real, dimension(:,:), target, intent(in) :: b_ptr   !< Second field pointer
+                                                      !! in arbitrary rescaled units [A ~> a]
   type(vardesc),                intent(in) :: a_desc  !< First field descriptor
   type(vardesc),                intent(in) :: b_desc  !< Second field descriptor
   logical,                      intent(in) :: mandatory !< If true, abort if field is missing
   type(MOM_restart_CS),      intent(inout) :: CS      !< MOM restart control structure
   real,               optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
 
   call lock_check(CS, a_desc)
 
@@ -378,14 +392,16 @@ end subroutine register_restart_pair_ptr2d
 !> Register a pair of rotationally equivalent 3d restart fields
 subroutine register_restart_pair_ptr3d(a_ptr, b_ptr, a_desc, b_desc, &
                 mandatory, CS, conversion)
-  real, dimension(:,:,:), target, intent(in) :: a_ptr   !< First field pointer
-  real, dimension(:,:,:), target, intent(in) :: b_ptr   !< Second field pointer
+  real, dimension(:,:,:), target, intent(in) :: a_ptr !< First field pointer
+                                                      !! in arbitrary rescaled units [A ~> a]
+  real, dimension(:,:,:), target, intent(in) :: b_ptr !< Second field pointer
+                                                      !! in arbitrary rescaled units [A ~> a]
   type(vardesc),                intent(in) :: a_desc  !< First field descriptor
   type(vardesc),                intent(in) :: b_desc  !< Second field descriptor
   logical,                      intent(in) :: mandatory !< If true, abort if field is missing
   type(MOM_restart_CS),      intent(inout) :: CS      !< MOM restart control structure
   real,               optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
 
   call lock_check(CS, a_desc)
 
@@ -403,13 +419,15 @@ end subroutine register_restart_pair_ptr3d
 subroutine register_restart_pair_ptr4d(a_ptr, b_ptr, a_desc, b_desc, &
                 mandatory, CS, conversion)
   real, dimension(:,:,:,:), target, intent(in) :: a_ptr !< First field pointer
+                                                      !! in arbitrary rescaled units [A ~> a]
   real, dimension(:,:,:,:), target, intent(in) :: b_ptr !< Second field pointer
+                                                      !! in arbitrary rescaled units [A ~> a]
   type(vardesc),                intent(in) :: a_desc  !< First field descriptor
   type(vardesc),                intent(in) :: b_desc  !< Second field descriptor
   logical,                      intent(in) :: mandatory !< If true, abort if field is missing
   type(MOM_restart_CS),      intent(inout) :: CS      !< MOM restart control structure
   real,               optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
 
   call lock_check(CS, a_desc)
 
@@ -430,6 +448,7 @@ subroutine register_restart_field_4d(f_ptr, name, mandatory, CS, longname, units
                                      hor_grid, z_grid, t_grid)
   real, dimension(:,:,:,:), &
                       target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   character(len=*),           intent(in) :: name      !< variable name to be used in the restart file
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
@@ -437,7 +456,7 @@ subroutine register_restart_field_4d(f_ptr, name, mandatory, CS, longname, units
   character(len=*), optional, intent(in) :: longname  !< variable long name
   character(len=*), optional, intent(in) :: units     !< variable units
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
   character(len=*), optional, intent(in) :: hor_grid  !< variable horizontal staggering, 'h' if absent
   character(len=*), optional, intent(in) :: z_grid    !< variable vertical staggering, 'L' if absent
   character(len=*), optional, intent(in) :: t_grid    !< time description: s, p, or 1, 's' if absent
@@ -462,6 +481,7 @@ subroutine register_restart_field_3d(f_ptr, name, mandatory, CS, longname, units
                                      hor_grid, z_grid, t_grid)
   real, dimension(:,:,:), &
                       target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   character(len=*),           intent(in) :: name      !< variable name to be used in the restart file
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
@@ -469,7 +489,7 @@ subroutine register_restart_field_3d(f_ptr, name, mandatory, CS, longname, units
   character(len=*), optional, intent(in) :: longname  !< variable long name
   character(len=*), optional, intent(in) :: units     !< variable units
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
   character(len=*), optional, intent(in) :: hor_grid  !< variable horizontal staggering, 'h' if absent
   character(len=*), optional, intent(in) :: z_grid    !< variable vertical staggering, 'L' if absent
   character(len=*), optional, intent(in) :: t_grid    !< time description: s, p, or 1, 's' if absent
@@ -494,6 +514,7 @@ subroutine register_restart_field_2d(f_ptr, name, mandatory, CS, longname, units
                                      hor_grid, z_grid, t_grid)
   real, dimension(:,:), &
                       target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   character(len=*),           intent(in) :: name      !< variable name to be used in the restart file
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
@@ -501,7 +522,7 @@ subroutine register_restart_field_2d(f_ptr, name, mandatory, CS, longname, units
   character(len=*), optional, intent(in) :: longname  !< variable long name
   character(len=*), optional, intent(in) :: units     !< variable units
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
   character(len=*), optional, intent(in) :: hor_grid  !< variable horizontal staggering, 'h' if absent
   character(len=*), optional, intent(in) :: z_grid    !< variable vertical staggering, '1' if absent
   character(len=*), optional, intent(in) :: t_grid    !< time description: s, p, or 1, 's' if absent
@@ -528,6 +549,7 @@ end subroutine register_restart_field_2d
 subroutine register_restart_field_1d(f_ptr, name, mandatory, CS, longname, units, conversion, &
                                      hor_grid, z_grid, t_grid)
   real, dimension(:), target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   character(len=*),           intent(in) :: name      !< variable name to be used in the restart file
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
@@ -535,7 +557,7 @@ subroutine register_restart_field_1d(f_ptr, name, mandatory, CS, longname, units
   character(len=*), optional, intent(in) :: longname  !< variable long name
   character(len=*), optional, intent(in) :: units     !< variable units
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
   character(len=*), optional, intent(in) :: hor_grid  !< variable horizontal staggering, '1' if absent
   character(len=*), optional, intent(in) :: z_grid    !< variable vertical staggering, 'L' if absent
   character(len=*), optional, intent(in) :: t_grid    !< time description: s, p, or 1, 's' if absent
@@ -562,6 +584,7 @@ end subroutine register_restart_field_1d
 subroutine register_restart_field_0d(f_ptr, name, mandatory, CS, longname, units, conversion, &
                                      t_grid)
   real,               target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+                                                      !! in arbitrary rescaled units [A ~> a]
   character(len=*),           intent(in) :: name      !< variable name to be used in the restart file
   logical,                    intent(in) :: mandatory !< If true, the run will abort if this field is not
                                                       !! successfully read from the restart file.
@@ -569,7 +592,7 @@ subroutine register_restart_field_0d(f_ptr, name, mandatory, CS, longname, units
   character(len=*), optional, intent(in) :: longname  !< variable long name
   character(len=*), optional, intent(in) :: units     !< variable units
   real,             optional, intent(in) :: conversion !< A factor to multiply a restart field by
-                                                      !! before it is written, 1 by default.
+                                                      !! before it is written [a A-1 ~> 1], 1 by default.
   character(len=*), optional, intent(in) :: t_grid    !< time description: s, p, or 1, 's' if absent
 
   type(vardesc) :: vd
@@ -622,7 +645,7 @@ end function query_initialized_name
 
 !> Indicate whether the field pointed to by f_ptr has been initialized from a restart file.
 function query_initialized_0d(f_ptr, CS) result(query_initialized)
-  real,         target, intent(in) :: f_ptr !< A pointer to the field that is being queried
+  real,         target, intent(in) :: f_ptr !< A pointer to the field that is being queried [arbitrary]
   type(MOM_restart_CS), intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
 
@@ -646,7 +669,7 @@ end function query_initialized_0d
 
 !> Indicate whether the field pointed to by f_ptr has been initialized from a restart file.
 function query_initialized_1d(f_ptr, CS) result(query_initialized)
-  real, dimension(:), target, intent(in) :: f_ptr !< A pointer to the field that is being queried
+  real, dimension(:), target, intent(in) :: f_ptr !< A pointer to the field that is being queried [arbitrary]
   type(MOM_restart_CS),       intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
 
@@ -671,7 +694,7 @@ end function query_initialized_1d
 !> Indicate whether the field pointed to by f_ptr has been initialized from a restart file.
 function query_initialized_2d(f_ptr, CS) result(query_initialized)
   real, dimension(:,:), &
-                target, intent(in) :: f_ptr !< A pointer to the field that is being queried
+                target, intent(in) :: f_ptr !< A pointer to the field that is being queried [arbitrary]
   type(MOM_restart_CS), intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
 
@@ -696,7 +719,7 @@ end function query_initialized_2d
 !> Indicate whether the field pointed to by f_ptr has been initialized from a restart file.
 function query_initialized_3d(f_ptr, CS) result(query_initialized)
   real, dimension(:,:,:), &
-                target, intent(in) :: f_ptr !< A pointer to the field that is being queried
+                target, intent(in) :: f_ptr !< A pointer to the field that is being queried [arbitrary]
   type(MOM_restart_CS), intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
 
@@ -721,7 +744,7 @@ end function query_initialized_3d
 !> Indicate whether the field pointed to by f_ptr has been initialized from a restart file.
 function query_initialized_4d(f_ptr, CS) result(query_initialized)
   real, dimension(:,:,:,:),  &
-                target, intent(in) :: f_ptr !< A pointer to the field that is being queried
+                target, intent(in) :: f_ptr !< A pointer to the field that is being queried [arbitrary]
   type(MOM_restart_CS), intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
 
@@ -746,7 +769,7 @@ end function query_initialized_4d
 !> Indicate whether the field stored in f_ptr or with the specified variable
 !! name has been initialized from a restart file.
 function query_initialized_0d_name(f_ptr, name, CS) result(query_initialized)
-  real,         target, intent(in) :: f_ptr !< The field that is being queried
+  real,         target, intent(in) :: f_ptr !< The field that is being queried [arbitrary]
   character(len=*),     intent(in) :: name  !< The name of the field that is being queried
   type(MOM_restart_CS), intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
@@ -779,7 +802,7 @@ end function query_initialized_0d_name
 !! name has been initialized from a restart file.
 function query_initialized_1d_name(f_ptr, name, CS) result(query_initialized)
   real, dimension(:),  &
-                target, intent(in) :: f_ptr !< The field that is being queried
+                target, intent(in) :: f_ptr !< The field that is being queried [arbitrary]
   character(len=*),     intent(in) :: name  !< The name of the field that is being queried
   type(MOM_restart_CS), intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
@@ -812,7 +835,7 @@ end function query_initialized_1d_name
 !! name has been initialized from a restart file.
 function query_initialized_2d_name(f_ptr, name, CS) result(query_initialized)
   real, dimension(:,:),  &
-                target, intent(in) :: f_ptr !< The field that is being queried
+                target, intent(in) :: f_ptr !< The field that is being queried [arbitrary]
   character(len=*),     intent(in) :: name  !< The name of the field that is being queried
   type(MOM_restart_CS), intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
@@ -845,7 +868,7 @@ end function query_initialized_2d_name
 !! name has been initialized from a restart file.
 function query_initialized_3d_name(f_ptr, name, CS) result(query_initialized)
   real, dimension(:,:,:),  &
-                target, intent(in) :: f_ptr !< The field that is being queried
+                target, intent(in) :: f_ptr !< The field that is being queried [arbitrary]
   character(len=*),     intent(in) :: name  !< The name of the field that is being queried
   type(MOM_restart_CS), intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
@@ -878,7 +901,7 @@ end function query_initialized_3d_name
 !! name has been initialized from a restart file.
 function query_initialized_4d_name(f_ptr, name, CS) result(query_initialized)
   real, dimension(:,:,:,:),  &
-                target, intent(in) :: f_ptr !< The field that is being queried
+                target, intent(in) :: f_ptr !< The field that is being queried [arbitrary]
   character(len=*),     intent(in) :: name  !< The name of the field that is being queried
   type(MOM_restart_CS), intent(in) :: CS    !< MOM restart control struct
   logical :: query_initialized
@@ -929,7 +952,7 @@ end subroutine set_initialized_name
 
 !> Record that the array in f_ptr with the given name has been initialized.
 subroutine set_initialized_0d_name(f_ptr, name, CS)
-  real,         target, intent(in)    :: f_ptr !< The variable that has been initialized
+  real,         target, intent(in)    :: f_ptr !< The variable that has been initialized [arbitrary]
   character(len=*),     intent(in)    :: name  !< The name of the field that has been initialized
   type(MOM_restart_CS), intent(inout) :: CS    !< MOM restart control struct
 
@@ -954,7 +977,7 @@ end subroutine set_initialized_0d_name
 !> Record that the array in f_ptr with the given name has been initialized.
 subroutine set_initialized_1d_name(f_ptr, name, CS)
   real, dimension(:),  &
-                target, intent(in)    :: f_ptr !< The array that has been initialized
+                target, intent(in)    :: f_ptr !< The array that has been initialized [arbitrary]
   character(len=*),     intent(in)    :: name  !< The name of the field that has been initialized
   type(MOM_restart_CS), intent(inout) :: CS    !< MOM restart control struct
 
@@ -979,7 +1002,7 @@ end subroutine set_initialized_1d_name
 !> Record that the array in f_ptr with the given name has been initialized.
 subroutine set_initialized_2d_name(f_ptr, name, CS)
   real, dimension(:,:),  &
-                target, intent(in)    :: f_ptr !< The array that has been initialized
+                target, intent(in)    :: f_ptr !< The array that has been initialized [arbitrary]
   character(len=*),     intent(in)    :: name  !< The name of the field that has been initialized
   type(MOM_restart_CS), intent(inout) :: CS    !< MOM restart control struct
 
@@ -1004,7 +1027,7 @@ end subroutine set_initialized_2d_name
 !> Record that the array in f_ptr with the given name has been initialized.
 subroutine set_initialized_3d_name(f_ptr, name, CS)
   real, dimension(:,:,:),  &
-                target, intent(in)    :: f_ptr !< The array that has been initialized
+                target, intent(in)    :: f_ptr !< The array that has been initialized [arbitrary]
   character(len=*),     intent(in)    :: name  !< The name of the field that has been initialized
   type(MOM_restart_CS), intent(inout) :: CS    !< MOM restart control struct
 
@@ -1029,7 +1052,7 @@ end subroutine set_initialized_3d_name
 !> Record that the array in f_ptr with the given name has been initialized.
 subroutine set_initialized_4d_name(f_ptr, name, CS)
   real, dimension(:,:,:,:),  &
-                target, intent(in)    :: f_ptr !< The array that has been initialized
+                target, intent(in)    :: f_ptr !< The array that has been initialized [arbitrary]
   character(len=*),     intent(in)    :: name  !< The name of the field that has been initialized
   type(MOM_restart_CS), intent(inout) :: CS    !< MOM restart control struct
 
@@ -1058,6 +1081,7 @@ end subroutine set_initialized_4d_name
 subroutine only_read_restart_field_4d(varname, f_ptr, G, CS, position, filename, directory, success, scale)
   character(len=*),                intent(in)    :: varname   !< The variable name to be used in the restart file
   real, dimension(:,:,:,:),        intent(inout) :: f_ptr     !< The array for the field to be read
+                                                              !! in arbitrary rescaled units [A ~> a]
   type(ocean_grid_type),           intent(in)    :: G         !< The ocean's grid structure
   type(MOM_restart_CS),            intent(in)    :: CS        !< MOM restart control struct
   integer,               optional, intent(in)    :: position  !< A coded integer indicating the horizontal
@@ -1067,6 +1091,8 @@ subroutine only_read_restart_field_4d(varname, f_ptr, G, CS, position, filename,
   character(len=*),      optional, intent(in)    :: directory !< The directory in which to seek restart files.
   logical,               optional, intent(out)   :: success   !< True if the field was read successfully
   real,                  optional, intent(in)    :: scale     !< A factor by which the field will be scaled
+                                                              !! [A a-1 ~> 1] to convert from the units in
+                                                              !! the file to the internal units of this field
 
   ! Local variables
   character(len=:), allocatable :: file_path ! The full path to the file with the variable
@@ -1087,6 +1113,7 @@ end subroutine only_read_restart_field_4d
 subroutine only_read_restart_field_3d(varname, f_ptr, G, CS, position, filename, directory, success, scale)
   character(len=*),                intent(in)    :: varname   !< The variable name to be used in the restart file
   real, dimension(:,:,:),          intent(inout) :: f_ptr     !< The array for the field to be read
+                                                              !! in arbitrary rescaled units [A ~> a]
   type(ocean_grid_type),           intent(in)    :: G         !< The ocean's grid structure
   type(MOM_restart_CS),            intent(in)    :: CS        !< MOM restart control struct
   integer,               optional, intent(in)    :: position  !< A coded integer indicating the horizontal
@@ -1096,6 +1123,8 @@ subroutine only_read_restart_field_3d(varname, f_ptr, G, CS, position, filename,
   character(len=*),      optional, intent(in)    :: directory !< The directory in which to seek restart files.
   logical,               optional, intent(out)   :: success   !< True if the field was read successfully
   real,                  optional, intent(in)    :: scale     !< A factor by which the field will be scaled
+                                                              !! [A a-1 ~> 1] to convert from the units in
+                                                              !! the file to the internal units of this field
 
   ! Local variables
   character(len=:), allocatable :: file_path ! The full path to the file with the variable
@@ -1116,6 +1145,7 @@ end subroutine only_read_restart_field_3d
 subroutine only_read_restart_field_2d(varname, f_ptr, G, CS, position, filename, directory, success, scale)
   character(len=*),                intent(in)    :: varname   !< The variable name to be used in the restart file
   real, dimension(:,:),            intent(inout) :: f_ptr     !< The array for the field to be read
+                                                              !! in arbitrary rescaled units [A ~> a]
   type(ocean_grid_type),           intent(in)    :: G         !< The ocean's grid structure
   type(MOM_restart_CS),            intent(in)    :: CS        !< MOM restart control struct
   integer,               optional, intent(in)    :: position  !< A coded integer indicating the horizontal
@@ -1125,6 +1155,8 @@ subroutine only_read_restart_field_2d(varname, f_ptr, G, CS, position, filename,
   character(len=*),      optional, intent(in)    :: directory !< The directory in which to seek restart files.
   logical,               optional, intent(out)   :: success   !< True if the field was read successfully
   real,                  optional, intent(in)    :: scale     !< A factor by which the field will be scaled
+                                                              !! [A a-1 ~> 1] to convert from the units in
+                                                              !! the file to the internal units of this field
 
   ! Local variables
   character(len=:), allocatable :: file_path ! The full path to the file with the variable
@@ -1146,7 +1178,9 @@ end subroutine only_read_restart_field_2d
 subroutine only_read_restart_pair_3d(a_ptr, b_ptr, a_name, b_name, G, CS, &
                                      stagger, filename, directory, success, scale)
   real, dimension(:,:,:),          intent(inout) :: a_ptr     !< The array for the first field to be read
+                                                              !! in arbitrary rescaled units [A ~> a]
   real, dimension(:,:,:),          intent(inout) :: b_ptr     !< The array for the second field to be read
+                                                              !! in arbitrary rescaled units [A ~> a]
   character(len=*),                intent(in)    :: a_name    !< The first variable name to be used in the restart file
   character(len=*),                intent(in)    :: b_name    !< The second variable name to be used in the restart file
   type(ocean_grid_type),           intent(in)    :: G         !< The ocean's grid structure
@@ -1157,7 +1191,9 @@ subroutine only_read_restart_pair_3d(a_ptr, b_ptr, a_name, b_name, G, CS, &
                                                               !! character 'r' to read automatically named files
   character(len=*),      optional, intent(in)    :: directory !< The directory in which to seek restart files.
   logical,               optional, intent(out)   :: success   !< True if the field was read successfully
-  real,                  optional, intent(in)    :: scale     !< A factor by which the field will be scaled
+  real,                  optional, intent(in)    :: scale     !< A factor by which the fields will be scaled
+                                                              !! [A a-1 ~> 1] to convert from the units in
+                                                              !! the file to the internal units of this field
 
   ! Local variables
   character(len=:), allocatable :: file_path_a ! The full path to the file with the first variable
@@ -1277,8 +1313,8 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
   integer :: num_files                  ! The number of restart files that will be used.
   integer :: seconds, days, year, month, hour, minute
   character(len=8) :: hor_grid, z_grid, t_grid ! Variable grid info.
-  real :: conv                          ! Shorthand for the conversion factor
-  real :: restart_time
+  real :: conv                          ! Shorthand for the conversion factor [a A-1 ~> 1]
+  real :: restart_time                  ! The model time at whic the restart file is being written [days]
   character(len=32) :: filename_appendix = '' ! Appendix to filename for ensemble runs
   integer :: length                     ! The length of a text string.
   integer(kind=8) :: check_val(CS%max_fields,1)
@@ -1456,8 +1492,9 @@ subroutine restore_state(filename, directory, day, G, CS)
   type(MOM_restart_CS),  intent(inout) :: CS      !< MOM restart control struct
 
   ! Local variables
-  real :: scale  ! A scaling factor for reading a field
-  real :: conv   ! The output conversion factor for writing a field
+  real :: scale  ! A scaling factor for reading a field [A a-1 ~> 1] to convert
+                 ! from the units in the file to the internal units of this field
+  real :: conv   ! The output conversion factor for writing a field [a A-1 ~> 1]
   character(len=512) :: mesg      ! A message for warnings.
   character(len=80) :: varname    ! A variable's name.
   integer :: num_file        ! The number of files (restart files and others
@@ -1471,8 +1508,8 @@ subroutine restore_state(filename, directory, day, G, CS)
   logical :: unit_is_global(CS%max_fields) ! True if the file is global.
 
   character(len=8)   :: hor_grid ! Variable grid info.
-  real    :: t1, t2 ! Two times.
-  real, allocatable :: time_vals(:)
+  real    :: t1, t2 ! Two times from the start of different files [days].
+  real, allocatable :: time_vals(:)  ! Times from a file extracted with getl_file_times [days]
   type(MOM_field), allocatable :: fields(:)
   logical            :: is_there_a_checksum ! Is there a valid checksum that should be checked.
   integer(kind=8)    :: checksum_file  ! The checksum value recorded in the input file.


### PR DESCRIPTION
  This PR includes a series of 7 commits (1 per file) that add or amend the documentation of the units of 476 arguments and internal variables, in large part to clearly indicate which variables must be unscaled and which may be scaled.  Only comments are changed, and all answers are bitwise identical.

  The commits in this PR include:

-NOAA-GFDL/MOM6@f8751de55 Document units of invcosh and its argument
-NOAA-GFDL/MOM6@dd946158b Revise argument units in MOM_horizontal_regridding
-NOAA-GFDL/MOM6@f8f127521 Document units of arguments in MOM_array_transform
-NOAA-GFDL/MOM6@f7f2de9d2 Document units of arguments in MOM_restart
-NOAA-GFDL/MOM6@625ff637c Document units of arguments in MOM_io
-NOAA-GFDL/MOM6@ccd62c1eb Document units of variables in MOM_checksums
-NOAA-GFDL/MOM6@251d9be2b Document units of variables in MOM_spatial_means
