### PR TITLE
Document 245 parameterization variable units

### DIFF
--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -64,9 +64,9 @@ type, public :: int_tide_CS ; private
                         !! is possible (i.e. ridge cells)
                         ! (could be in G control structure)
   real, allocatable, dimension(:,:) :: trans
-                        !< partial transmission coeff for each "coast cell"
+                        !< partial transmission coeff for each "coast cell" [nondim]
   real, allocatable, dimension(:,:) :: residual
-                        !< residual of reflection and transmission coeff for each "coast cell"
+                        !< residual of reflection and transmission coeff for each "coast cell" [nondim]
   real, allocatable, dimension(:,:,:,:) :: cp
                         !< horizontal phase speed [L T-1 ~> m s-1]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_leak_loss
@@ -144,7 +144,7 @@ type, public :: int_tide_CS ; private
              id_allprocesses_loss_mode, &
              id_Ub_mode, &
              id_cp_mode
-  ! Diag handles considering: all modes, freqs, and angles
+  ! Diag handles considering: all modes, frequencies, and angles
   integer, allocatable, dimension(:,:) :: &
              id_En_ang_mode, &
              id_itidal_loss_ang_mode
@@ -185,7 +185,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
                                                         !! mode [L T-1 ~> m s-1].
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),2) :: &
-    test
+    test           ! A test unit vector used to determine grid rotation in halos [nondim]
   real, dimension(SZI_(G),SZJ_(G),CS%nFreq,CS%nMode) :: &
     tot_En_mode, & ! energy summed over angles only [R Z3 T-2 ~> J m-2]
     Ub, &          ! near-bottom horizontal velocity of wave (modal) [L T-1 ~> m s-1]
@@ -196,15 +196,18 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
                    ! energy loss rates summed over angle, freq, and mode [R Z3 T-3 ~> W m-2]
     htot, &        ! The vertical sum of the layer thicknesses [H ~> m or kg m-2]
     drag_scale, &  ! bottom drag scale [T-1 ~> s-1]
-    itidal_loss_mode, allprocesses_loss_mode
-                   ! energy loss rates for a given mode and frequency (summed over angles) [R Z3 T-3 ~> W m-2]
-  real :: frac_per_sector, f2, Kmag2
+    itidal_loss_mode, & ! Energy lost due to small-scale wave drag, summed over angles [R Z3 T-3 ~> W m-2]
+    allprocesses_loss_mode  ! Total energy loss rates for a given mode and frequency (summed over
+                   ! all angles) [R Z3 T-3 ~> W m-2]
+  real :: frac_per_sector ! The inverse of the number of angular, modal and frequency bins [nondim]
+  real :: f2       ! The squared Coriolis parameter interpolated to a tracer point [T-2 ~> s-2]
+  real :: Kmag2    ! A squared horizontal wavenumber [L-2 ~> m-2]
   real :: I_D_here ! The inverse of the local depth [Z-1 ~> m-1]
-  real :: I_rho0  ! The inverse fo the Boussinesq density [R-1 ~> m3 kg-1]
-  real :: freq2 ! The frequency squared [T-2 ~> s-2]
-  real :: c_phase ! The phase speed [L T-1 ~> m s-1]
+  real :: I_rho0   ! The inverse fo the Boussinesq density [R-1 ~> m3 kg-1]
+  real :: freq2    ! The frequency squared [T-2 ~> s-2]
+  real :: c_phase  ! The phase speed [L T-1 ~> m s-1]
   real :: loss_rate  ! An energy loss rate [T-1 ~> s-1]
-  real :: Fr2_max
+  real :: Fr2_max    ! The column maximum internal wave Froude number squared [nondim]
   real :: cn_subRO        ! A tiny wave speed to prevent division by zero [L T-1 ~> m s-1]
   real :: en_subRO        ! A tiny energy to prevent division by zero [R Z3 T-2 ~> J m-2]
   real :: En_new, En_check                           ! Energies for debugging [R Z3 T-2 ~> J m-2]
@@ -223,7 +226,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
   cn_subRO = 1e-30*US%m_s_to_L_T
   en_subRO = 1e-30*US%W_m2_to_RZ3_T3*US%s_to_T
 
-  ! init local arrays
+  ! initialize local arrays
   drag_scale(:,:) = 0.
   Ub(:,:,:,:) = 0.
 
@@ -548,7 +551,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
     if (CS%id_TKE_itidal_input > 0) call post_data(CS%id_TKE_itidal_input, &
                                                    TKE_itidal_input, CS%diag)
 
-    ! Output 2-D energy density (summed over angles) for each freq and mode
+    ! Output 2-D energy density (summed over angles) for each frequency and mode
     do m=1,CS%NMode ; do fr=1,CS%Nfreq ; if (CS%id_En_mode(fr,m) > 0) then
       tot_En(:,:) = 0.0
       do a=1,CS%nAngle ; do j=js,je ; do i=is,ie
@@ -557,7 +560,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
       call post_data(CS%id_En_mode(fr,m), tot_En, CS%diag)
     endif ; enddo ; enddo
 
-    ! Output 3-D (i,j,a) energy density for each freq and mode
+    ! Output 3-D (i,j,a) energy density for each frequency and mode
     do m=1,CS%NMode ; do fr=1,CS%Nfreq ; if (CS%id_En_ang_mode(fr,m) > 0) then
       call post_data(CS%id_En_ang_mode(fr,m), CS%En(:,:,:,fr,m) , CS%diag)
     endif ; enddo ; enddo
@@ -606,7 +609,7 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
       call post_data(CS%id_tot_allprocesses_loss, tot_allprocesses_loss, CS%diag)
     endif
 
-    ! Output 2-D energy loss (summed over angles) for each freq and mode
+    ! Output 2-D energy loss (summed over angles) for each frequency and mode
     do m=1,CS%NMode ; do fr=1,CS%Nfreq
     if (CS%id_itidal_loss_mode(fr,m) > 0 .or. CS%id_allprocesses_loss_mode(fr,m) > 0) then
       itidal_loss_mode(:,:) = 0.0 ! wave-drag processes (could do others as well)
@@ -622,17 +625,17 @@ subroutine propagate_int_tide(h, tv, cn, TKE_itidal_input, vel_btTide, Nb, dt, &
       call post_data(CS%id_allprocesses_loss_mode(fr,m), allprocesses_loss_mode, CS%diag)
     endif ; enddo ; enddo
 
-    ! Output 3-D (i,j,a) energy loss for each freq and mode
+    ! Output 3-D (i,j,a) energy loss for each frequency and mode
     do m=1,CS%NMode ; do fr=1,CS%Nfreq ; if (CS%id_itidal_loss_ang_mode(fr,m) > 0) then
       call post_data(CS%id_itidal_loss_ang_mode(fr,m), CS%TKE_itidal_loss(:,:,:,fr,m) , CS%diag)
     endif ; enddo ; enddo
 
-    ! Output 2-D period-averaged horizontal near-bottom mode velocity for each freq and mode
+    ! Output 2-D period-averaged horizontal near-bottom mode velocity for each frequency and mode
     do m=1,CS%NMode ; do fr=1,CS%Nfreq ; if (CS%id_Ub_mode(fr,m) > 0) then
       call post_data(CS%id_Ub_mode(fr,m), Ub(:,:,fr,m), CS%diag)
     endif ; enddo ; enddo
 
-    ! Output 2-D horizontal phase velocity for each freq and mode
+    ! Output 2-D horizontal phase velocity for each frequency and mode
     do m=1,CS%NMode ; do fr=1,CS%Nfreq ; if (CS%id_cp_mode(fr,m) > 0) then
       call post_data(CS%id_cp_mode(fr,m), CS%cp(:,:,fr,m), CS%diag)
     endif ; enddo ; enddo
@@ -654,9 +657,10 @@ subroutine sum_En(G, US, CS, En, label)
   ! Local variables
   real :: En_sum   ! The total energy in MKS units for potential output [J]
   integer :: a
-  ! real :: En_sum_diff, En_sum_pdiff
+  ! real :: En_sum_diff  ! Change in energy from the expected value [J]
+  ! real :: En_sum_pdiff ! Percentage change in energy from the expected value [nondim]
   ! character(len=160) :: mesg  ! The text of an error message
-  ! real :: days
+  ! real :: days          ! The time in days for use in output messages [days]
 
   En_sum = 0.0
   do a=1,CS%nAngle
@@ -808,29 +812,33 @@ subroutine refract(En, cn, freq, dt, G, US, NAngle, use_PPMang)
   ! Local variables
   integer, parameter :: stencil = 2
   real, dimension(SZI_(G),1-stencil:NAngle+stencil) :: &
-    En2d
+    En2d                  ! The internal gravity wave energy density in zonal slices [R Z3 T-2 ~> J m-2]
   real, dimension(1-stencil:NAngle+stencil) :: &
-    cos_angle, sin_angle
+    cos_angle, sin_angle  ! The cosine and sine of each angle [nondim]
   real, dimension(SZI_(G)) :: &
-    Dk_Dt_Kmag, Dl_Dt_Kmag
+    Dk_Dt_Kmag, Dl_Dt_Kmag ! Rates of angular refraction [T-1 ~> s-1]
   real, dimension(SZI_(G),0:nAngle) :: &
-    Flux_E
+    Flux_E                ! The flux of energy between successive angular wedges within a timestep [R Z3 T-2 ~> J m-2]
   real, dimension(SZI_(G),SZJ_(G),1-stencil:NAngle+stencil) :: &
-    CFL_ang
-  real, dimension(G%IsdB:G%IedB,G%jsd:G%jed) :: cn_u !< Internal wave group velocity at U-point
-  real, dimension(G%isd:G%ied,G%JsdB:G%JedB) :: cn_v !< Internal wave group velocity at V-point
-  real, dimension(G%isd:G%ied,G%jsd:G%jed) :: cnmask !< Local mask for group velocity
+    CFL_ang               ! The CFL number of angular refraction [nondim]
+  real, dimension(G%IsdB:G%IedB,G%jsd:G%jed) :: cn_u !< Internal wave group velocity at U-point [L T-1 ~> m s-1]
+  real, dimension(G%isd:G%ied,G%JsdB:G%JedB) :: cn_v !< Internal wave group velocity at V-point [L T-1 ~> m s-1]
+  real, dimension(G%isd:G%ied,G%jsd:G%jed) :: cnmask !< Local mask for group velocity [nondim]
   real :: f2              ! The squared Coriolis parameter [T-2 ~> s-2].
   real :: favg            ! The average Coriolis parameter at a point [T-1 ~> s-1].
   real :: df_dy, df_dx    ! The x- and y- gradients of the Coriolis parameter [T-1 L-1 ~> s-1 m-1].
   real :: dlnCn_dx        ! The x-gradient of the wave speed divided by itself [L-1 ~> m-1].
   real :: dlnCn_dy        ! The y-gradient of the wave speed divided by itself [L-1 ~> m-1].
-  real :: Angle_size, dt_Angle_size, angle
-  real :: Ifreq, Kmag2, I_Kmag
+  real :: Angle_size      ! The size of each wedge of angles [rad]
+  real :: dt_Angle_size   ! The time step divided by the angle size [T rad-1 ~> s rad-1]
+  real :: angle           ! The central angle of each wedge [rad]
+  real :: Ifreq           ! The inverse of the wave frequency [T ~> s]
+  real :: Kmag2           ! A squared horizontal wavenumber [L-2 ~> m-2]
+  real :: I_Kmag          ! The inverse of the magnitude of the horizontal wavenumber [L ~> m]
   real :: cn_subRO        ! A tiny wave speed to prevent division by zero [L T-1 ~> m s-1]
   integer :: is, ie, js, je, asd, aed, na
   integer :: i, j, a
-  real :: wgt1, wgt2
+  real :: wgt1, wgt2      ! Weights in an average, both of which may be 0 [nondim]
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; na = size(En,3)
   asd = 1-stencil ; aed = NAngle+stencil
@@ -938,18 +946,18 @@ end subroutine refract
 !! piecewise parabolic scheme. This needs to be called from within i and j spatial loops.
 subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
   integer,                   intent(in)    :: NAngle  !< The number of wave orientations in the
-                                                      !! discretized wave energy spectrum.
+                                                      !! discretized wave energy spectrum [nondim]
   real,                      intent(in)    :: dt      !< Time increment [T ~> s].
   integer,                   intent(in)    :: halo_ang !< The halo size in angular space
   real, dimension(1-halo_ang:NAngle+halo_ang),   &
                              intent(in)    :: En2d    !< The internal gravity wave energy density as a
                                                       !! function of angular resolution [R Z3 T-2 ~> J m-2].
   real, dimension(1-halo_ang:NAngle+halo_ang),   &
-                             intent(in)    :: CFL_ang !< The CFL number of the energy advection across angles
+                             intent(in)    :: CFL_ang !< The CFL number of the energy advection across angles [nondim]
   real, dimension(0:NAngle), intent(out)   :: Flux_En !< The time integrated internal wave energy flux
                                                       !! across angles  [R Z3 T-2 ~> J m-2].
   ! Local variables
-  real :: flux
+  real :: flux         ! The internal wave energy flux across angles  [R Z3 T-3 ~> W m-2].
   real :: u_ang        ! Angular propagation speed [Rad T-1 ~> Rad s-1]
   real :: Angle_size   ! The size of each orientation wedge in radians [Rad]
   real :: I_Angle_size ! The inverse of the orientation wedges [Rad-1]
@@ -1052,11 +1060,16 @@ subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle, residual_loss)
   real, dimension(SZI_(G),SZJB_(G)) :: &
     speed_y  ! The magnitude of the group velocity at the Cv points [L T-1 ~> m s-1].
   real, dimension(0:NAngle) :: &
-    cos_angle, sin_angle
+    cos_angle, sin_angle  ! The cosine and sine of each angle [nondim]
   real, dimension(NAngle) :: &
-    Cgx_av, Cgy_av, dCgx, dCgy
+    Cgx_av, &  ! The average projection of the wedge into the x-direction [nondim]
+    Cgy_av, &  ! The average projection of the wedge into the y-direction [nondim]
+    dCgx, &    ! The difference in x-projections between the edges of each angular band [nondim].
+    dCgy       ! The difference in y-projections between the edges of each angular band [nondim].
   real :: f2   ! The squared Coriolis parameter [T-2 ~> s-2].
-  real :: Angle_size, I_Angle_size, angle
+  real :: Angle_size      ! The size of each wedge of angles [rad]
+  real :: I_Angle_size    ! The inverse of the size of each wedge of angles [rad-1]
+  real :: angle           ! The central angle of each wedge [rad]
   real :: Ifreq ! The inverse of the frequency [T ~> s]
   real :: freq2 ! The frequency squared [T-2 ~> s-2]
   type(loop_bounds_type) :: LB
@@ -1172,26 +1185,32 @@ subroutine propagate_corner_spread(En, energized_wedge, NAngle, speed, dt, G, CS
   type(loop_bounds_type), intent(in)    :: LB    !< A structure with the active energy loop bounds.
   ! Local variables
   integer :: i, j, ish, ieh, jsh, jeh, m
-  real :: TwoPi, Angle_size
-  real :: energized_angle ! angle through center of current wedge
-  real :: theta ! angle at edge of wedge
-  real :: Nsubrays     ! number of sub-rays for averaging
+  real :: TwoPi        ! The radius of the circumference of a circle to its radius [nondim]
+  real :: Angle_size   ! The size of each angular wedge [radians]
+  real :: energized_angle ! angle through center of current wedge [radians]
+  real :: theta        ! angle at edge of each sub-wedge [radians]
+  real :: Nsubrays     ! number of sub-rays for averaging [nondim]
                        ! count includes the two rays that bound the current wedge,
                        ! i.e. those at -dtheta/2 and +dtheta/2 from energized angle
-  real :: I_Nsubwedges ! inverse of number of sub-wedges
-  real :: cos_thetaDT, sin_thetaDT ! cos(theta)*dt, sin(theta)*dt
-  real :: xNE,xNW,xSW,xSE,yNE,yNW,ySW,ySE ! corner point coordinates of advected fluid parcel
-  real :: CFL_xNE,CFL_xNW,CFL_xSW,CFL_xSE,CFL_yNE,CFL_yNW,CFL_ySW,CFL_ySE,CFL_max
-  real :: xN,xS,xE,xW,yN,yS,yE,yW ! intersection point coordinates of parcel edges and grid
-  real :: xCrn,yCrn ! grid point contained within advected fluid parcel
-  real :: xg,yg ! grid point of interest
-  real :: slopeN,slopeW,slopeS,slopeE, bN,bW,bS,bE ! parameters defining parcel sides
-  real :: aNE,aN,aNW,aW,aSW,aS,aSE,aE,aC ! sub-areas of advected parcel
-  real :: a_total ! total area of advected parcel
-  ! real :: a1,a2,a3,a4 ! areas used in calculating polygon areas (sub-areas) of advected parcel
-  real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: x,y ! coordinates of cell corners
-  real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: Idx,Idy ! inverse of dx,dy at cell corners
-  real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: dx,dy ! dx,dy at cell corners
+  real :: I_Nsubwedges ! inverse of number of sub-wedges [nondim]
+  real :: cos_thetaDT, sin_thetaDT ! cos(theta)*dt, sin(theta)*dt [T ~> s]
+  real :: xNE, xNW, xSW, xSE ! corner point x-coordinates of advected fluid parcel [L ~> m]
+  real :: yNE, yNW, ySW, ySE ! corner point y-coordinates of advected fluid parcel [L ~> m]
+  real :: CFL_xNE, CFL_xNW, CFL_xSW, CFL_xSE ! Various x-direction CFL numbers for propagation [nondim]
+  real :: CFL_yNE, CFL_yNW, CFL_ySW, CFL_ySE ! Various y-direction CFL numbers for propagation [nondim]
+  real :: CFL_max ! The maximum of the x- and y-CFL numbers for propagation [nondim]
+  real :: xN, xS, xE, xW ! intersection point x-coordinates of parcel edges and grid [L ~> m]
+  real :: yN, yS, yE, yW ! intersection point y-coordinates of parcel edges and grid [L ~> m]
+  real :: xCrn, yCrn ! Coordinates of grid point contained within advected fluid parcel [L ~> m]
+  real :: xg, yg ! Positions of grid point of interest [L ~> m]
+  real :: slopeN, slopeW, slopeS, slopeE ! Coordinate-space slopes of parcel sides [nondim]
+  real :: bN, bW, bS, bE ! parameters defining parcel sides [L ~> m]
+  real :: aNE, aN, aNW, aW, aSW, aS, aSE, aE, aC ! sub-areas of advected parcel [L2 ~> m2]
+  real :: a_total ! total area of advected parcel [L2 ~> m2]
+  ! real :: a1,a2,a3,a4 ! areas used in calculating polygon areas (sub-areas) of advected parcel [L2 ~> m2]
+  real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: x, y ! coordinates of cell corners [L ~> m]
+  real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: Idx, Idy ! inverse of dx,dy at cell corners [L-1 ~> m-1]
+  real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: dx, dy ! dx,dy at cell corners [L ~> m]
   real, dimension(2) :: E_new ! Energy in cell after advection for subray [R Z3 T-2 ~> J m-2]; set size
                               ! here to define Nsubrays - this should be made an input option later!
 
@@ -1449,9 +1468,9 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
   real, dimension(G%IsdB:G%IedB,G%jsd:G%jed),        &
                            intent(in)    :: speed_x !< The magnitude of the group velocity at the
                                                !! Cu points [L T-1 ~> m s-1].
-  real, dimension(Nangle), intent(in)    :: Cgx_av !< The average x-projection in each angular band.
+  real, dimension(Nangle), intent(in)    :: Cgx_av !< The average x-projection in each angular band [nondim]
   real, dimension(Nangle), intent(in)    :: dCgx !< The difference in x-projections between the
-                                               !! edges of each angular band.
+                                               !! edges of each angular band [nondim].
   real,                    intent(in)    :: dt !< Time increment [T ~> s].
   type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   type(int_tide_CS),       intent(in)    :: CS !< Internal tide control structure
@@ -1465,8 +1484,8 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
   real, dimension(SZIB_(G),SZJ_(G)) :: &
     flux_x      ! The internal wave energy flux [R Z3 L2 T-3 ~> J s-1].
   real, dimension(SZIB_(G)) :: &
-    cg_p, flux1
-  !real, dimension(SZI_(G),SZJB_(G),Nangle) :: En_m, En_p
+    cg_p, &     ! The x-direction group velocity [L T-1 ~> m s-1]
+    flux1       ! A 1-d copy of the x-direction internal wave energy flux [R Z3 L2 T-3 ~> J s-1].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle) :: &
     Fdt_m, Fdt_p! Left and right energy fluxes [R Z3 L2 T-2 ~> J]
   integer :: i, j, ish, ieh, jsh, jeh, a
@@ -1545,8 +1564,9 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
     EnL, EnR    ! South and north face energy densities [R Z3 T-2 ~> J m-2].
   real, dimension(SZI_(G),SZJB_(G)) :: &
     flux_y      ! The internal wave energy flux [R Z3 L2 T-3 ~> J s-1].
-  real, dimension(SZI_(G)) :: cg_p, flux1
-  !real, dimension(SZI_(G),SZJB_(G),Nangle) :: En_m, En_p
+  real, dimension(SZI_(G)) :: &
+    cg_p, &     ! The y-direction group velocity [L T-1 ~> m s-1]
+    flux1       ! A 1-d copy of the y-direction internal wave energy flux [R Z3 L2 T-3 ~> J s-1].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle) :: &
     Fdt_m, Fdt_p! South and north energy fluxes [R Z3 L2 T-2 ~> J]
   integer :: i, j, ish, ieh, jsh, jeh, a
@@ -1823,23 +1843,18 @@ subroutine teleport(En, NAngle, CS, G, LB)
   real                        :: TwoPi      ! 2*pi = 6.2831853... [nondim]
   real                        :: Angle_size ! size of beam wedge [rad]
   real, dimension(1:NAngle)   :: angle_i    ! angle of incident ray wrt equator [rad]
-  real, dimension(1:NAngle)   :: cos_angle, sin_angle
+  real, dimension(1:NAngle)   :: cos_angle  ! Cosine of the beam angle relative to eastward [nondim]
+  real, dimension(1:NAngle)   :: sin_angle  ! Sine of the beam angle relative to eastward [nondim]
   real                        :: En_tele    ! energy to be "teleported" [R Z3 T-2 ~> J m-2]
   character(len=160) :: mesg  ! The text of an error message
   integer :: i, j, a
-  !integer :: isd, ied, jsd, jed    ! start and end local indices on data domain
-  !                                 ! (values include halos)
-  !integer :: isc, iec, jsc, jec    ! start and end local indices on PE
-  !                                 ! (values exclude halos)
   integer :: ish, ieh, jsh, jeh     ! start and end local indices on data domain
                                     ! leaving out outdated halo points (march in)
   integer :: id_g, jd_g             ! global (decomposition-invariant) indices
   integer :: jos, ios               ! offsets
-  real    :: cos_normal, sin_normal, angle_wall
-                                    ! cos/sin of cross-ridge normal, ridge angle
+  real    :: cos_normal, sin_normal ! cos/sin of cross-ridge normal direction [nondim]
+  real    :: angle_wall             ! The coastline angle or the complementary angle [radians]
 
-  !isd = G%isd  ; ied = G%ied  ; jsd = G%jsd  ; jed = G%jed
-  !isc = G%isc  ; iec = G%iec  ; jsc = G%jsc  ; jec = G%jec
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh
 
   TwoPi = 8.0*atan(1.0)
@@ -1909,11 +1924,12 @@ subroutine correct_halo_rotation(En, test, G, NAngle)
   real, dimension(SZI_(G),SZJ_(G),2), &
                               intent(in)    :: test !< An x-unit vector that has been passed through
                                        !! the halo updates, to enable the rotation of the
-                                       !! wave energies in the halo region to be corrected.
+                                       !! wave energies in the halo region to be corrected [nondim].
   integer,                    intent(in)    :: NAngle !< The number of wave orientations in the
                                                       !! discretized wave energy spectrum.
   ! Local variables
-  real, dimension(G%isd:G%ied,NAngle) :: En2d
+  real, dimension(G%isd:G%ied,NAngle) :: En2d ! A zonal row of the internal gravity wave energy density
+                                              ! in a frequency band and mode [R Z3 T-2 ~> J m-2].
   integer, dimension(G%isd:G%ied) :: a_shift
   integer :: i_first, i_last, a_new
   integer :: a, i, j, isd, ied, jsd, jed, m, fr
@@ -1960,18 +1976,19 @@ end subroutine correct_halo_rotation
 !> Calculates left/right edge values for PPM reconstruction in x-direction.
 subroutine PPM_reconstruction_x(h_in, h_l, h_r, G, LB, simple_2nd)
   type(ocean_grid_type),            intent(in)  :: G    !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D).
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D).
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D).
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D) [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D) [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D) [R Z3 T-2 ~> J m-2]
   type(loop_bounds_type),           intent(in)  :: LB   !< A structure with the active loop bounds.
   logical,                          intent(in)  :: simple_2nd !< If true, use the arithmetic mean
                                                         !! energy densities as default edge values
                                                         !! for a simple 2nd order scheme.
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slopes.
-  real, parameter :: oneSixth = 1./6.
-  real :: h_ip1, h_im1
-  real :: dMx, dMn
+  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width [R Z3 T-2 ~> J m-2]
+  real, parameter :: oneSixth = 1./6. ! One sixth [nondim]
+  real :: h_ip1, h_im1 ! The energy densities at adjacent points [R Z3 T-2 ~> J m-2]
+  real :: dMx, dMn ! The maximum and minimum of values of energy density at adjacent points
+                   ! relative to the center point [R Z3 T-2 ~> J m-2]
   character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, isl, iel, jsl, jel, stencil
 
@@ -2034,18 +2051,19 @@ end subroutine PPM_reconstruction_x
 !> Calculates left/right edge valus for PPM reconstruction in y-direction.
 subroutine PPM_reconstruction_y(h_in, h_l, h_r, G, LB, simple_2nd)
   type(ocean_grid_type),            intent(in)  :: G    !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D).
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D).
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D).
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D) [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D) [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D) [R Z3 T-2 ~> J m-2]
   type(loop_bounds_type),           intent(in)  :: LB   !< A structure with the active loop bounds.
   logical,                          intent(in)  :: simple_2nd !< If true, use the arithmetic mean
                                                         !! energy densities as default edge values
                                                         !! for a simple 2nd order scheme.
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slopes.
-  real, parameter :: oneSixth = 1./6.
-  real :: h_jp1, h_jm1
-  real :: dMx, dMn
+  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width [R Z3 T-2 ~> J m-2]
+  real, parameter :: oneSixth = 1./6. ! One sixth [nondim]
+  real :: h_jp1, h_jm1 ! The energy densities at adjacent points [R Z3 T-2 ~> J m-2]
+  real :: dMx, dMn ! The maximum and minimum of values of energy density at adjacent points
+                   ! relative to the center point [R Z3 T-2 ~> J m-2]
   character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, isl, iel, jsl, jel, stencil
 
@@ -2105,22 +2123,24 @@ end subroutine PPM_reconstruction_y
 
 !> Limits the left/right edge values of the PPM reconstruction
 !! to give a reconstruction that is positive-definite.  Here this is
-!! reinterpreted as giving a constant thickness if the mean thickness is less
+!! reinterpreted as giving a constant value if the mean value is less
 !! than h_min, with a minimum of h_min otherwise.
 subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, iis, iie, jis, jie)
   type(ocean_grid_type),            intent(in)     :: G     !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)     :: h_in  !< Thickness of layer (2D).
-  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_L   !< Left edge value (2D).
-  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_R   !< Right edge value (2D).
-  real,                             intent(in)     :: h_min !< The minimum thickness that can be
-                                                            !! obtained by a concave parabolic fit.
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)     :: h_in  !< Energy density in each sector (2D) [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_L   !< Left edge value of reconstruction  [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_R   !< Right edge value of reconstruction [R Z3 T-2 ~> J m-2]
+  real,                             intent(in)     :: h_min !< The minimum value that can be
+                                                            !! obtained by a concave parabolic fit [R Z3 T-2 ~> J m-2]
   integer,                          intent(in)     :: iis   !< Start i-index for computations
   integer,                          intent(in)     :: iie   !< End i-index for computations
   integer,                          intent(in)     :: jis   !< Start j-index for computations
   integer,                          intent(in)     :: jie   !< End j-index for computations
   ! Local variables
-  real    :: curv, dh, scale
-  integer :: i,j
+  real    :: curv    ! The cell-area normalized curvature [R Z3 T-2 ~> J m-2]
+  real    :: dh      ! The difference between the edge values [R Z3 T-2 ~> J m-2]
+  real    :: scale   ! A rescaling factor used to give a minimum cell value of at least h_min [nondim]
+  integer :: i, j
 
   do j=jis,jie ; do i=iis,iie
     ! This limiter prevents undershooting minima within the domain with
@@ -2194,12 +2214,12 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   type(int_tide_CS),         intent(inout) :: CS   !< Internal tide control structure
 
   ! Local variables
-  real                              :: Angle_size ! size of wedges, rad
-  real, allocatable                 :: angles(:)  ! orientations of wedge centers, rad
+  real                              :: Angle_size ! size of wedges [rad]
+  real, allocatable                 :: angles(:)  ! orientations of wedge centers [rad]
   real, dimension(:,:), allocatable :: h2         ! topographic roughness scale squared [Z2 ~> m2]
   real                              :: kappa_itides ! characteristic topographic wave number [L-1 ~> m-1]
   real, dimension(:,:), allocatable :: ridge_temp ! array for temporary storage of flags
-                                                  ! of cells with double-reflecting ridges
+                                                  ! of cells with double-reflecting ridges [nondim]
   logical :: use_int_tides, use_temperature
   real    :: kappa_h2_factor    ! A roughness scaling factor [nondim]
   real    :: RMS_roughness_frac ! The maximum RMS topographic roughness as a fraction of the
@@ -2431,7 +2451,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
     if (trim(refl_angle_file) /= '' ) call MOM_error(FATAL, &
                                                      "REFL_ANGLE_FILE: "//trim(filename)//" not found")
   endif
-  ! replace NANs with null value
+  ! replace NaNs with null value
   do j=G%jsc,G%jec ; do i=G%isc,G%iec
     if (is_NaN(CS%refl_angle(i,j))) CS%refl_angle(i,j) = CS%nullangle
   enddo ; enddo
@@ -2526,7 +2546,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                  Time, 'East face unblocked width', 'm', conversion=US%L_to_m)
   CS%id_land_mask = register_diag_field('ocean_model', 'land_mask', diag%axesT1, &
                  Time, 'Land mask', 'nondim')
-  ! Output reflection parameters as diags here (not needed every timestep)
+  ! Output reflection parameters as diagnostics here (not needed every timestep)
   if (CS%id_refl_ang > 0)   call post_data(CS%id_refl_ang, CS%refl_angle, CS%diag)
   if (CS%id_refl_pref > 0)  call post_data(CS%id_refl_pref, CS%refl_pref, CS%diag)
   if (CS%id_trans > 0)      call post_data(CS%id_trans, CS%trans, CS%diag)
@@ -2584,21 +2604,21 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                          axes_ang, is_h_point=.true.)
   do fr=1,CS%nFreq ; write(freq_name(fr), '("freq",i1)') fr ; enddo
   do m=1,CS%nMode ; do fr=1,CS%nFreq
-    ! Register 2-D energy density (summed over angles) for each freq and mode
+    ! Register 2-D energy density (summed over angles) for each frequency and mode
     write(var_name, '("Itide_En_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy density in frequency ",i1," mode ",i1)') fr, m
     CS%id_En_mode(fr,m) = register_diag_field('ocean_model', var_name, &
                  diag%axesT1, Time, var_descript, 'J m-2', conversion=US%RZ3_T3_to_W_m2*US%T_to_s)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
 
-    ! Register 3-D (i,j,a) energy density for each freq and mode
+    ! Register 3-D (i,j,a) energy density for each frequency and mode
     write(var_name, '("Itide_En_ang_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide angular energy density in frequency ",i1," mode ",i1)') fr, m
     CS%id_En_ang_mode(fr,m) = register_diag_field('ocean_model', var_name, &
                  axes_ang, Time, var_descript, 'J m-2 band-1', conversion=US%RZ3_T3_to_W_m2*US%T_to_s)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
 
-    ! Register 2-D energy loss (summed over angles) for each freq and mode
+    ! Register 2-D energy loss (summed over angles) for each frequency and mode
     ! wave-drag only
     write(var_name, '("Itide_wavedrag_loss_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy loss due to wave-drag from frequency ",i1," mode ",i1)') fr, m
@@ -2612,7 +2632,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                  diag%axesT1, Time, var_descript, 'W m-2', conversion=US%RZ3_T3_to_W_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
 
-    ! Register 3-D (i,j,a) energy loss for each freq and mode
+    ! Register 3-D (i,j,a) energy loss for each frequency and mode
     ! wave-drag only
     write(var_name, '("Itide_wavedrag_loss_ang_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy loss due to wave-drag from frequency ",i1," mode ",i1)') fr, m
@@ -2620,14 +2640,14 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                  axes_ang, Time, var_descript, 'W m-2 band-1', conversion=US%RZ3_T3_to_W_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
 
-    ! Register 2-D period-averaged near-bottom horizontal velocity for each freq and mode
+    ! Register 2-D period-averaged near-bottom horizontal velocity for each frequency and mode
     write(var_name, '("Itide_Ub_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Near-bottom horizontal velocity for frequency ",i1," mode ",i1)') fr, m
     CS%id_Ub_mode(fr,m) = register_diag_field('ocean_model', var_name, &
                  diag%axesT1, Time, var_descript, 'm s-1', conversion=US%L_T_to_m_s)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
 
-    ! Register 2-D horizonal phase velocity for each freq and mode
+    ! Register 2-D horizontal phase velocity for each frequency and mode
     write(var_name, '("Itide_cp_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Horizontal phase velocity for frequency ",i1," mode ",i1)') fr, m
     CS%id_cp_mode(fr,m) = register_diag_field('ocean_model', var_name, &
@@ -2643,7 +2663,7 @@ end subroutine internal_tides_init
 
 !> This subroutine deallocates the memory associated with the internal tides control structure
 subroutine internal_tides_end(CS)
-  type(int_tide_CS), intent(inout) :: CS  !<  Internal tide control struct
+  type(int_tide_CS), intent(inout) :: CS  !<  Internal tide control structure
 
   if (allocated(CS%En)) deallocate(CS%En)
   if (allocated(CS%frequency)) deallocate(CS%frequency)

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1,4 +1,4 @@
-!> Thickness diffusion (or Gent McWilliams)
+!> Isopycnal height diffusion (or Gent McWilliams diffusion)
 module MOM_thickness_diffuse
 
 ! This file is part of MOM6. See LICENSE.md for the license.
@@ -33,17 +33,17 @@ public thickness_diffuse_get_KH
 ! their mks counterparts with notation like "a velocity [Z T-1 ~> m s-1]".  If the units
 ! vary with the Boussinesq approximation, the Boussinesq variant is given first.
 
-!> Control structure for thickness diffusion
+!> Control structure for thickness_diffuse
 type, public :: thickness_diffuse_CS ; private
   logical :: initialized = .false. !< True if this control structure has been initialized.
   real    :: Khth                !< Background isopycnal depth diffusivity [L2 T-1 ~> m2 s-1]
   real    :: Khth_Slope_Cff      !< Slope dependence coefficient of Khth [nondim]
-  real    :: max_Khth_CFL        !< Maximum value of the diffusive CFL for thickness diffusion [nondim]
+  real    :: max_Khth_CFL        !< Maximum value of the diffusive CFL for isopycnal height diffusion [nondim]
   real    :: Khth_Min            !< Minimum value of Khth [L2 T-1 ~> m2 s-1]
   real    :: Khth_Max            !< Maximum value of Khth [L2 T-1 ~> m2 s-1], or 0 for no max
-  real    :: Kh_eta_bg           !< Background interface height diffusivity [L2 T-1 ~> m2 s-1]
+  real    :: Kh_eta_bg           !< Background isopycnal height diffusivity [L2 T-1 ~> m2 s-1]
   real    :: Kh_eta_vel          !< Velocity scale that is multiplied by the grid spacing to give
-                                 !! the interface height diffusivity [L T-1 ~> m s-1]
+                                 !! the isopycnal height diffusivity [L T-1 ~> m s-1]
   real    :: slope_max           !< Slopes steeper than slope_max are limited in some way [Z L-1 ~> nondim].
   real    :: kappa_smooth        !< Vertical diffusivity used to interpolate more
                                  !! sensible values of T & S into thin layers [Z2 T-1 ~> m2 s-1].
@@ -70,14 +70,14 @@ type, public :: thickness_diffuse_CS ; private
   logical :: MEKE_GEOMETRIC      !< If true, uses the GM coefficient formulation from the GEOMETRIC
                                  !! framework (Marshall et al., 2012)
   real    :: MEKE_GEOMETRIC_alpha!< The nondimensional coefficient governing the efficiency of
-                                 !! the GEOMETRIC thickness diffusion [nondim]
+                                 !! the GEOMETRIC isopycnal height diffusion [nondim]
   real    :: MEKE_GEOMETRIC_epsilon !< Minimum Eady growth rate for the GEOMETRIC thickness
                                  !! diffusivity [T-1 ~> s-1].
   integer :: MEKE_GEOM_answer_date  !< The vintage of the expressions in the MEKE_GEOMETRIC
                                  !! calculation.  Values below 20190101 recover the answers from the
                                  !! original implementation, while higher values use expressions that
                                  !! satisfy rotational symmetry.
-  logical :: Use_KH_in_MEKE      !< If true, uses the thickness diffusivity calculated here to diffuse MEKE.
+  logical :: Use_KH_in_MEKE      !< If true, uses the isopycnal height diffusivity calculated here to diffuse MEKE.
   real    :: MEKE_min_depth_diff !< The minimum total depth over which to average the diffusivity
                                  !! used for MEKE [H ~> m or kg m-2].  When the total depth is less
                                  !! than this, the diffusivity is scaled away.
@@ -89,16 +89,16 @@ type, public :: thickness_diffuse_CS ; private
                                  !! temperature gradient in the deterministic part of the Stanley parameterization.
                                  !! Negative values disable the scheme. [nondim]
   logical :: read_khth           !< If true, read a file containing the spatially varying horizontal
-                                 !! thickness diffusivity
+                                 !! isopycnal height diffusivity
   logical :: use_stanley_gm      !< If true, also use the Stanley parameterization in MOM_thickness_diffuse
 
   type(diag_ctrl), pointer :: diag => NULL() !< structure used to regulate timing of diagnostics
-  real, allocatable :: GMwork(:,:)        !< Work by thickness diffusivity [R Z L2 T-3 ~> W m-2]
+  real, allocatable :: GMwork(:,:)        !< Work by isopycnal height diffusion [R Z L2 T-3 ~> W m-2]
   real, allocatable :: diagSlopeX(:,:,:)  !< Diagnostic: zonal neutral slope [Z L-1 ~> nondim]
   real, allocatable :: diagSlopeY(:,:,:)  !< Diagnostic: zonal neutral slope [Z L-1 ~> nondim]
 
-  real, allocatable :: Kh_eta_u(:,:)    !< Interface height diffusivities at u points [L2 T-1 ~> m2 s-1]
-  real, allocatable :: Kh_eta_v(:,:)    !< Interface height diffusivities in v points [L2 T-1 ~> m2 s-1]
+  real, allocatable :: Kh_eta_u(:,:)    !< Isopycnal height diffusivities at u points [L2 T-1 ~> m2 s-1]
+  real, allocatable :: Kh_eta_v(:,:)    !< Isopycnal height diffusivities in v points [L2 T-1 ~> m2 s-1]
 
   real, allocatable :: KH_u_GME(:,:,:)  !< Isopycnal height diffusivities in u-columns [L2 T-1 ~> m2 s-1]
   real, allocatable :: KH_v_GME(:,:,:)  !< Isopycnal height diffusivities in v-columns [L2 T-1 ~> m2 s-1]
@@ -116,8 +116,8 @@ end type thickness_diffuse_CS
 
 contains
 
-!> Calculates thickness diffusion coefficients and applies thickness diffusion to layer
-!! thicknesses, h. Diffusivities are limited to ensure stability.
+!> Calculates isopycnal height diffusion coefficients and applies isopycnal height diffusion
+!! by modifying to the layer thicknesses, h. Diffusivities are limited to ensure stability.
 !! Also returns along-layer mass fluxes used in the continuity equation.
 subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp, CS)
   type(ocean_grid_type),                      intent(in)    :: G      !< Ocean grid structure
@@ -133,7 +133,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   type(MEKE_type),                            intent(inout) :: MEKE   !< MEKE fields
   type(VarMix_CS), target,                    intent(in)    :: VarMix !< Variable mixing coefficients
   type(cont_diag_ptrs),                       intent(inout) :: CDp    !< Diagnostics for the continuity equation
-  type(thickness_diffuse_CS),                 intent(inout) :: CS     !< Control structure for thickness diffusion
+  type(thickness_diffuse_CS),                 intent(inout) :: CS     !< Control structure for thickness_diffuse
   ! Local variables
   real :: e(SZI_(G),SZJ_(G),SZK_(GV)+1) ! heights of interfaces, relative to mean
                                          ! sea level [Z ~> m], positive up.
@@ -141,13 +141,13 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   real :: vhD(SZI_(G),SZJB_(G),SZK_(GV)) ! Diffusive v*h fluxes [L2 H T-1 ~> m3 s-1 or kg s-1]
 
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: &
-    KH_u, &       ! interface height diffusivities in u-columns [L2 T-1 ~> m2 s-1]
+    KH_u, &       ! Isopycnal height diffusivities in u-columns [L2 T-1 ~> m2 s-1]
     int_slope_u   ! A nondimensional ratio from 0 to 1 that gives the relative
                   ! weighting of the interface slopes to that calculated also
                   ! using density gradients at u points.  The physically correct
                   ! slopes occur at 0, while 1 is used for numerical closures [nondim].
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: &
-    KH_v, &       ! interface height diffusivities in v-columns [L2 T-1 ~> m2 s-1]
+    KH_v, &       ! Isopycnal height diffusivities in v-columns [L2 T-1 ~> m2 s-1]
     int_slope_v   ! A nondimensional ratio from 0 to 1 that gives the relative
                   ! weighting of the interface slopes to that calculated also
                   ! using density gradients at v points.  The physically correct
@@ -156,23 +156,25 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     KH_t          ! diagnosed diffusivity at tracer points [L2 T-1 ~> m2 s-1]
 
   real, dimension(SZIB_(G),SZJ_(G)) :: &
-    KH_u_CFL      ! The maximum stable interface height diffusivity at u grid points [L2 T-1 ~> m2 s-1]
+    KH_u_CFL      ! The maximum stable isopycnal height diffusivity at u grid points [L2 T-1 ~> m2 s-1]
   real, dimension(SZI_(G),SZJB_(G)) :: &
-    KH_v_CFL      ! The maximum stable interface height diffusivity at v grid points [L2 T-1 ~> m2 s-1]
+    KH_v_CFL      ! The maximum stable isopycnal height diffusivity at v grid points [L2 T-1 ~> m2 s-1]
   real, dimension(SZI_(G),SZJ_(G)) :: &
     htot          ! The sum of the total layer thicknesses [H ~> m or kg m-2]
-  real :: Khth_Loc_u(SZIB_(G),SZJ_(G))
-  real :: Khth_Loc_v(SZI_(G),SZJB_(G))
+  real :: Khth_Loc_u(SZIB_(G),SZJ_(G)) ! The isopycnal height diffusivity at u points [L2 T-1 ~> m2 s-1]
+  real :: Khth_Loc_v(SZI_(G),SZJB_(G)) ! The isopycnal height diffusivity at v points [L2 T-1 ~> m2 s-1]
   real :: h_neglect ! A thickness that is so small it is usually lost
                     ! in roundoff and can be neglected [H ~> m or kg m-2].
   real, dimension(:,:), pointer :: cg1 => null() !< Wave speed [L T-1 ~> m s-1]
+  real :: hu(SZI_(G),SZJ_(G))       ! A thickness-based mask at u points, used for diagnostics [nondim]
+  real :: hv(SZI_(G),SZJ_(G))       ! A thickness-based mask at v points, used for diagnostics [nondim]
+  real :: KH_u_lay(SZI_(G),SZJ_(G)) ! Diagnostic of isopycnal height diffusivities at u-points averaged
+                                    ! to layer centers [L2 T-1 ~> m2 s-1]
+  real :: KH_v_lay(SZI_(G),SZJ_(G)) ! Diagnostic of isopycnal height diffusivities at v-points averaged
+                                    ! to layer centers [L2 T-1 ~> m2 s-1]
   logical :: use_VarMix, Resoln_scaled, Depth_scaled, use_stored_slopes, khth_use_ebt_struct, use_Visbeck
   logical :: use_QG_Leith
   integer :: i, j, k, is, ie, js, je, nz
-  real :: hu(SZI_(G),SZJ_(G))       ! u-thickness [H ~> m or kg m-2]
-  real :: hv(SZI_(G),SZJ_(G))       ! v-thickness [H ~> m or kg m-2]
-  real :: KH_u_lay(SZI_(G),SZJ_(G)) ! Thickness diffusivities [L2 T-1 ~> m2 s-1]
-  real :: KH_v_lay(SZI_(G),SZJ_(G)) ! layer ave thickness diffusivities [L2 T-1 ~> m2 s-1]
 
   if (.not. CS%initialized) call MOM_error(FATAL, "MOM_thickness_diffuse: "//&
          "Module must be initialized before it is used.")
@@ -592,9 +594,9 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   type(unit_scale_type),                        intent(in)  :: US    !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),    intent(in)  :: h     !< Layer thickness [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1),  intent(in)  :: e     !< Interface positions [Z ~> m]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(in)  :: Kh_u  !< Thickness diffusivity on interfaces
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(in)  :: Kh_u  !< Isopycnal height diffusivity
                                                                      !! at u points [L2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(in)  :: Kh_v  !< Thickness diffusivity on interfaces
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(in)  :: Kh_v  !< Isopycnal height diffusivity
                                                                      !! at v points [L2 T-1 ~> m2 s-1]
   type(thermo_var_ptrs),                        intent(in)  :: tv    !< Thermodynamics structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)),   intent(out) :: uhD   !< Zonal mass fluxes
@@ -604,7 +606,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   real, dimension(:,:),                         pointer     :: cg1   !< Wave speed [L T-1 ~> m s-1]
   real,                                         intent(in)  :: dt    !< Time increment [T ~> s]
   type(MEKE_type),                              intent(inout) :: MEKE !< MEKE fields
-  type(thickness_diffuse_CS),                   intent(inout) :: CS  !< Control structure for thickness diffusion
+  type(thickness_diffuse_CS),                   intent(inout) :: CS  !< Control structure for thickness_diffuse
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(in)  :: int_slope_u !< Ratio that determine how much of
                                                                      !! the isopycnal slopes are taken directly from
                                                                      !! the interface slopes without consideration of
@@ -663,8 +665,10 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
     T_hr, &       ! Temperature on the interface at the h (+1) point [C ~> degC].
     S_hr, &       ! Salinity on the interface at the h (+1) point [S ~> ppt].
     pres_hr       ! Pressure on the interface at the h (+1) point [R L2 T-2 ~> Pa].
-  real :: Work_u(SZIB_(G),SZJ_(G)) ! The work being done by the thickness
-  real :: Work_v(SZI_(G),SZJB_(G)) ! diffusion integrated over a cell [R Z L4 T-3  ~> W ]
+  real :: Work_u(SZIB_(G),SZJ_(G)) ! The work done by the isopycnal height diffusion
+                                   ! integrated over u-point water columns [R Z L4 T-3 ~> W]
+  real :: Work_v(SZI_(G),SZJB_(G)) ! The work done by the isopycnal height diffusion
+                                   ! integrated over v-point water columns [R Z L4 T-3 ~> W]
   real :: Work_h        ! The work averaged over an h-cell [R Z L2 T-3 ~> W m-2].
   real :: PE_release_h  ! The amount of potential energy released by GM averaged over an h-cell [L4 Z-1 T-3 ~> m3 s-3]
                         ! The calculation is equal to h * S^2 * N^2 * kappa_GM.
@@ -1436,7 +1440,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   endif
 
   if (find_work) then ; do j=js,je ; do i=is,ie
-    ! Note that the units of Work_v and Work_u are W, while Work_h is W m-2.
+    ! Note that the units of Work_v and Work_u are [R Z L4 T-3 ~> W], while Work_h is in [R Z L2 T-3 ~> W m-2].
     Work_h = 0.5 * G%IareaT(i,j) * &
       ((Work_u(I-1,j) + Work_u(I,j)) + (Work_v(i,J-1) + Work_v(i,J)))
     if (allocated(CS%GMwork)) CS%GMwork(i,j) = Work_h
@@ -1499,28 +1503,28 @@ subroutine streamfn_solver(nk, c2_h, hN2, sfn)
 
 end subroutine streamfn_solver
 
-!> Add a diffusivity that acts on the interface heights, regardless of the densities
+!> Add a diffusivity that acts on the isopycnal heights, regardless of the densities
 subroutine add_interface_Kh(G, GV, US, CS, Kh_u, Kh_v, Kh_u_CFL, Kh_v_CFL, int_slope_u, int_slope_v)
   type(ocean_grid_type),                        intent(in)    :: G    !< Ocean grid structure
   type(verticalGrid_type),                      intent(in)    :: GV   !< Vertical grid structure
   type(unit_scale_type),                        intent(in)    :: US   !< A dimensional unit scaling type
-  type(thickness_diffuse_CS),                   intent(in)    :: CS   !< Control structure for thickness diffusion
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: Kh_u !< Thickness diffusivity on interfaces
+  type(thickness_diffuse_CS),                   intent(in)    :: CS   !< Control structure for thickness_diffuse
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: Kh_u !< Isopycnal height diffusivity
                                                                       !! at u points [L2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: Kh_v !< Thickness diffusivity on interfaces
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: Kh_v !< Isopycnal height diffusivity
                                                                       !! at v points [L2 T-1 ~> m2 s-1]
-  real, dimension(SZIB_(G),SZJ_(G)),            intent(in)    :: Kh_u_CFL !< Maximum stable thickness diffusivity
-                                                                      !! at u points [L2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G),SZJB_(G)),            intent(in)    :: Kh_v_CFL !< Maximum stable thickness diffusivity
-                                                                      !! at v points [L2 T-1 ~> m2 s-1]
+  real, dimension(SZIB_(G),SZJ_(G)),            intent(in)    :: Kh_u_CFL !< Maximum stable isopycnal height
+                                                                      !! diffusivity at u points [L2 T-1 ~> m2 s-1]
+  real, dimension(SZI_(G),SZJB_(G)),            intent(in)    :: Kh_v_CFL !< Maximum stable isopycnal height
+                                                                      !! diffusivity at v points [L2 T-1 ~> m2 s-1]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: int_slope_u !< Ratio that determine how much of
                                                                       !! the isopycnal slopes are taken directly from
                                                                       !! the interface slopes without consideration
-                                                                      !! of density gradients.
+                                                                      !! of density gradients [nondim].
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: int_slope_v !< Ratio that determine how much of
                                                                       !! the isopycnal slopes are taken directly from
                                                                       !! the interface slopes without consideration
-                                                                      !! of density gradients.
+                                                                      !! of density gradients [nondim].
 
   ! Local variables
   integer :: i, j, k, is, ie, js, je, nz
@@ -1541,7 +1545,7 @@ subroutine add_interface_Kh(G, GV, US, CS, Kh_u, Kh_v, Kh_u_CFL, Kh_v_CFL, int_s
 
 end subroutine add_interface_Kh
 
-!> Modifies thickness diffusivities to untangle layer structures
+!> Modifies isopycnal height diffusivities to untangle layer structures
 subroutine add_detangling_Kh(h, e, Kh_u, Kh_v, KH_u_CFL, KH_v_CFL, tv, dt, G, GV, US, CS, &
                              int_slope_u, int_slope_v)
   type(ocean_grid_type),                        intent(in)    :: G    !< Ocean grid structure
@@ -1549,17 +1553,17 @@ subroutine add_detangling_Kh(h, e, Kh_u, Kh_v, KH_u_CFL, KH_v_CFL, tv, dt, G, GV
   type(unit_scale_type),                        intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),    intent(in)    :: h    !< Layer thickness [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1),  intent(in)    :: e    !< Interface positions [Z ~> m]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: Kh_u !< Thickness diffusivity on interfaces
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: Kh_u !< Isopycnal height diffusivity
                                                                       !! at u points [L2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: Kh_v !< Thickness diffusivity on interfaces
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: Kh_v !< Isopycnal height diffusivity
                                                                       !! at v points [L2 T-1 ~> m2 s-1]
-  real, dimension(SZIB_(G),SZJ_(G)),            intent(in)    :: Kh_u_CFL !< Maximum stable thickness diffusivity
-                                                                      !! at u points [L2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G),SZJB_(G)),            intent(in)    :: Kh_v_CFL !< Maximum stable thickness diffusivity
-                                                                      !! at v points [L2 T-1 ~> m2 s-1]
+  real, dimension(SZIB_(G),SZJ_(G)),            intent(in)    :: Kh_u_CFL !< Maximum stable isopycnal height
+                                                                      !! diffusivity at u points [L2 T-1 ~> m2 s-1]
+  real, dimension(SZI_(G),SZJB_(G)),            intent(in)    :: Kh_v_CFL !< Maximum stable isopycnal height
+                                                                      !! diffusivity at v points [L2 T-1 ~> m2 s-1]
   type(thermo_var_ptrs),                        intent(in)    :: tv   !< Thermodynamics structure
   real,                                         intent(in)    :: dt   !< Time increment [T ~> s]
-  type(thickness_diffuse_CS),                   intent(in)    :: CS   !< Control structure for thickness diffusion
+  type(thickness_diffuse_CS),                   intent(in)    :: CS   !< Control structure for thickness_diffuse
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: int_slope_u !< Ratio that determine how much of
                                                                       !! the isopycnal slopes are taken directly from
                                                                       !! the interface slopes without consideration
@@ -1573,10 +1577,10 @@ subroutine add_detangling_Kh(h, e, Kh_u, Kh_v, KH_u_CFL, KH_v_CFL, tv, dt, G, GV
     de_top     ! The distances between the top of a layer and the top of the
                ! region where the detangling is applied [H ~> m or kg m-2].
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: &
-    Kh_lay_u   ! The tentative interface height diffusivity for each layer at
+    Kh_lay_u   ! The tentative isopycnal height diffusivity for each layer at
                ! u points [L2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: &
-    Kh_lay_v   ! The tentative interface height diffusivity for each layer at
+    Kh_lay_v   ! The tentative isopycnal height diffusivity for each layer at
                ! v points [L2 T-1 ~> m2 s-1].
   real, dimension(SZI_(G),SZJ_(G)) :: &
     de_bot     ! The distances from the bottom of the region where the
@@ -1958,7 +1962,7 @@ subroutine add_detangling_Kh(h, e, Kh_u, Kh_v, KH_u_CFL, KH_v_CFL, tv, dt, G, GV
 
 end subroutine add_detangling_Kh
 
-!> Initialize the thickness diffusion module/structure
+!> Initialize the isopycnal height diffusion module and its control structure
 subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
   type(time_type),         intent(in) :: Time    !< Current model time
   type(ocean_grid_type),   intent(in) :: G       !< Ocean grid structure
@@ -1967,7 +1971,7 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
   type(param_file_type),   intent(in) :: param_file !< Parameter file handles
   type(diag_ctrl), target, intent(inout) :: diag !< Diagnostics control structure
   type(cont_diag_ptrs),    intent(inout) :: CDp  !< Continuity equation diagnostics
-  type(thickness_diffuse_CS), intent(inout) :: CS   !< Control structure for thickness diffusion
+  type(thickness_diffuse_CS), intent(inout) :: CS !< Control structure for thickness_diffuse
 
   ! Local variables
   character(len=40)  :: mdl = "MOM_thickness_diffuse" ! This module's name.
@@ -2026,9 +2030,8 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
     call pass_var(CS%khth2d, G%domain)
   endif
   call get_param(param_file, mdl, "KHTH_SLOPE_CFF", CS%KHTH_Slope_Cff, &
-                 "The nondimensional coefficient in the Visbeck formula "//&
-                 "for the interface depth diffusivity", units="nondim", &
-                 default=0.0)
+                 "The nondimensional coefficient in the Visbeck formula for "//&
+                 "the interface depth diffusivity", units="nondim", default=0.0)
   call get_param(param_file, mdl, "KHTH_MIN", CS%KHTH_Min, &
                  "The minimum horizontal thickness diffusivity.", &
                  default=0.0, units="m2 s-1", scale=US%m_to_L**2*US%T_to_s)
@@ -2246,14 +2249,14 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
 
 end subroutine thickness_diffuse_init
 
-!> Copies ubtav and vbtav from private type into arrays
+!> Copies KH_u_GME and KH_v_GME from private type into arrays provided as arguments
 subroutine thickness_diffuse_get_KH(CS, KH_u_GME, KH_v_GME, G, GV)
   type(thickness_diffuse_CS),          intent(in)  :: CS   !< Control structure for this module
   type(ocean_grid_type),               intent(in)  :: G    !< Grid structure
   type(verticalGrid_type),             intent(in)  :: GV   !< Vertical grid structure
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: KH_u_GME !< interface height
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: KH_u_GME !< Isopycnal height
                                                    !! diffusivities at u-faces [L2 T-1 ~> m2 s-1]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: KH_v_GME !< interface height
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: KH_v_GME !< Isopycnal height
                                                    !! diffusivities at v-faces [L2 T-1 ~> m2 s-1]
   ! Local variables
   integer :: i,j,k
@@ -2268,9 +2271,9 @@ subroutine thickness_diffuse_get_KH(CS, KH_u_GME, KH_v_GME, G, GV)
 
 end subroutine thickness_diffuse_get_KH
 
-!> Deallocate the thickness diffusion control structure
+!> Deallocate the thickness_diffus3 control structure
 subroutine thickness_diffuse_end(CS, CDp)
-  type(thickness_diffuse_CS), intent(inout) :: CS !< Control structure for thickness diffusion
+  type(thickness_diffuse_CS), intent(inout) :: CS !< Control structure for thickness_diffuse
   type(cont_diag_ptrs), intent(inout) :: CDp      !< Continuity diagnostic control structure
 
   if (CS%id_slope_x > 0) deallocate(CS%diagSlopeX)
@@ -2292,9 +2295,9 @@ end subroutine thickness_diffuse_end
 
 !> \namespace mom_thickness_diffuse
 !!
-!! \section section_gm Thickness diffusion (aka Gent-McWilliams)
+!! \section section_gm Isopycnal height diffusion (aka Gent-McWilliams)
 !!
-!! Thickness diffusion is implemented via along-layer mass fluxes
+!! Isopycnal height diffusion is implemented via along-layer mass fluxes
 !! \f[
 !! h^\dagger \leftarrow h^n - \Delta t \nabla \cdot ( \vec{uh}^* )
 !! \f]
@@ -2304,7 +2307,8 @@ end subroutine thickness_diffuse_end
 !! \vec{uh}^* = \delta_k \vec{\psi} .
 !! \f]
 !!
-!! The GM implementation of thickness diffusion made the streamfunction proportional to the potential density slope
+!! The GM implementation of isopycnal height diffusion made the streamfunction proportional
+!! to the potential density slope
 !! \f[
 !! \vec{\psi} = - \kappa_h \frac{\nabla_z \rho}{\partial_z \rho}
 !! = \frac{g\kappa_h}{\rho_o} \frac{\nabla \rho}{N^2} = \kappa_h \frac{M^2}{N^2}
@@ -2324,12 +2328,12 @@ end subroutine thickness_diffuse_end
 !! which recovers the previous streamfunction relation in the limit that \f$ c \rightarrow 0 \f$.
 !! Here, \f$c=\max(c_{min},c_g)\f$ is the maximum of either \f$c_{min}\f$ and either the first baroclinic mode
 !! wave-speed or the equivalent barotropic mode wave-speed.
-!! \f$N_*^2 = \max(N^2,0)\f$ is a non-negative form of the square of the Brunt-Vaisala frequency.
+!! \f$N_*^2 = \max(N^2,0)\f$ is a non-negative form of the square of the buoyancy frequency.
 !! The parameter \f$\gamma_F\f$ is used to reduce the vertical smoothing length scale.
 !! \f[
 !! \kappa_h = \left( \kappa_o + \alpha_{s} L_{s}^2 < S N > + \alpha_{M} \kappa_{M} \right) r(\Delta x,L_d)
 !! \f]
-!! where \f$ S \f$ is the isoneutral slope magnitude, \f$ N \f$ is the Brunt-Vaisala frequency,
+!! where \f$ S \f$ is the isoneutral slope magnitude, \f$ N \f$ is the buoyancy frequency,
 !! \f$\kappa_{M}\f$ is the diffusivity calculated by the MEKE parameterization (mom_meke module) and
 !! \f$ r(\Delta x,L_d) \f$ is a function of the local resolution (ratio of grid-spacing, \f$\Delta x\f$,
 !! to deformation radius, \f$L_d\f$). The length \f$L_s\f$ is provided by the mom_lateral_mixing_coeffs module

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -78,7 +78,7 @@ type :: p2d
   integer :: id !< id for FMS external time interpolator
   integer :: nz_data !< The number of vertical levels in the input field
   integer :: num_tlevs !< The number of time records contained in the file
-  real :: scale = 1.0  !< A multiplicative factor by which to rescale input data
+  real :: scale = 1.0  !< A multiplicative factor by which to rescale input data [various]
   real, dimension(:,:), pointer :: p => NULL() !< pointer to the data [various]
   real, dimension(:,:), pointer :: h => NULL() !< pointer the data grid [H ~> m or kg m-2]
   character(len=:), allocatable  :: name  !< The name of the input field

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -619,7 +619,7 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, buoyFlux, Kt, Ks, Kv, &
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: nonLocalTransHeat   !< Temp non-local transport [nondim]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: nonLocalTransScalar !< scalar non-local trans. [nondim]
   type(wave_parameters_CS),                    pointer       :: Waves   !< Wave CS for Langmuir turbulence
-  real, dimension(SZI_(G),SZJ_(G)),  optional, intent(in)    :: lamult  !< Langmuir enhancement multiplier
+  real, dimension(SZI_(G),SZJ_(G)),  optional, intent(in)    :: lamult  !< Langmuir enhancement multiplier [nondim]
 
   ! Local variables
   integer :: i, j, k                            ! Loop indices
@@ -920,7 +920,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   real, dimension(SZI_(G),SZJ_(G)),           intent(in)    :: uStar !< Surface friction velocity [Z T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)   :: buoyFlux !< Surface buoyancy flux [L2 T-3 ~> m2 s-3]
   type(wave_parameters_CS),                   pointer       :: Waves !< Wave CS for Langmuir turbulence
-  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)    :: lamult !< Langmuir enhancement factor
+  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)    :: lamult !< Langmuir enhancement factor [nondim]
 
   ! Local variables
   ! Variables for passing to CVMix routines, often in MKS units

--- a/src/parameterizations/vertical/MOM_CVMix_conv.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_conv.F90
@@ -57,7 +57,7 @@ logical function CVMix_conv_init(Time, G, GV, US, param_file, diag, CS)
   type(diag_ctrl), target, intent(inout) :: diag       !< Diagnostics control structure.
   type(CVMix_conv_cs),     intent(inout) :: CS         !< CVMix convection control structure
 
-  real    :: prandtl_conv !< Turbulent Prandtl number used in convective instabilities.
+  real    :: prandtl_conv !< Turbulent Prandtl number used in convective instabilities [nondim]
   logical :: useEPBL      !< If True, use the ePBL boundary layer scheme.
 
   ! This include declares and sets the variable "version".
@@ -154,10 +154,10 @@ subroutine calculate_CVMix_conv(h, tv, G, GV, US, CS, hbl, Kd, Kv, Kd_aux)
                                                                  !! here [Z2 T-1 ~> m2 s-1].
 
   ! local variables
-  real, dimension(SZK_(GV)) :: rho_lwr !< Adiabatic Water Density, this is a dummy
+  real, dimension(SZK_(GV)) :: rho_lwr !< Adiabatic Water Density [kg m-3], this is a dummy
                                        !! variable since here convection is always
                                        !! computed based on Brunt Vaisala.
-  real, dimension(SZK_(GV)) :: rho_1d  !< water density in a column, this is also
+  real, dimension(SZK_(GV)) :: rho_1d  !< water density in a column [kg m-3], this is also
                                        !! a dummy variable, same reason as above.
   real, dimension(SZK_(GV)+1) :: N2    !< Squared buoyancy frequency [s-2]
   real, dimension(SZK_(GV)+1) :: kv_col !< Viscosities at interfaces in the column [m2 s-1]

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -116,7 +116,7 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS, physical_OBL
   ! Local variables
   real :: Kv                    ! The interior vertical viscosity [Z2 T-1 ~> m2 s-1] - read to set Prandtl
                                 ! number unless it is provided as a parameter
-  real :: prandtl_bkgnd_comp    ! Kv/CS%Kd. Gets compared with user-specified prandtl_bkgnd.
+  real :: prandtl_bkgnd_comp    ! Kv/CS%Kd [nondim]. Gets compared with user-specified prandtl_bkgnd.
 
   ! This include declares and sets the variable "version".
 # include "version_variable.h"

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -59,7 +59,7 @@ type, public :: energetic_PBL_CS ; private
                              !! returned value from the previous guess or bisection before this.
   integer :: max_MLD_its     !< The maximum number of iterations that can be used to find a
                              !! self-consistent mixed layer depth with Use_MLD_iteration.
-  real    :: MixLenExponent  !< Exponent in the mixing length shape-function.
+  real    :: MixLenExponent  !< Exponent in the mixing length shape-function [nondim].
                              !! 1 is law-of-the-wall at top and bottom,
                              !! 2 is more KPP like.
   real    :: MKE_to_TKE_effic !< The efficiency with which mean kinetic energy released by
@@ -68,11 +68,11 @@ type, public :: energetic_PBL_CS ; private
   real    :: ustar_min       !< A minimum value of ustar to avoid numerical problems [Z T-1 ~> m s-1].
                              !! If the value is small enough, this should not affect the solution.
   real    :: Ekman_scale_coef !< A nondimensional scaling factor controlling the inhibition of the
-                             !! diffusive length scale by rotation.  Making this larger decreases
+                             !! diffusive length scale by rotation [nondim].  Making this larger decreases
                              !! the diffusivity in the planetary boundary layer.
   real    :: transLay_scale  !< A scale for the mixing length in the transition layer
                              !! at the edge of the boundary layer as a fraction of the
-                             !! boundary layer thickness.  The default is 0, but a
+                             !! boundary layer thickness [nondim].  The default is 0, but a
                              !! value of 0.1 might be better justified by observations.
   real    :: MLD_tol         !< A tolerance for determining the boundary layer thickness when
                              !! Use_MLD_iteration is true [H ~> m or kg m-2].
@@ -98,7 +98,7 @@ type, public :: energetic_PBL_CS ; private
   integer :: mstar_scheme    !< An encoded integer to determine which formula is used to set mstar
   logical :: MSTAR_FLATCAP=.true. !< Set false to use asymptotic mstar cap.
   real    :: mstar_cap       !< Since MSTAR is restoring undissipated energy to mixing,
-                             !! there must be a cap on how large it can be.  This
+                             !! there must be a cap on how large it can be [nondim].  This
                              !! is definitely a function of latitude (Ekman limit),
                              !! but will be taken as constant for now.
 
@@ -113,45 +113,45 @@ type, public :: energetic_PBL_CS ; private
                              !! for using a fixed mstar is used.
 
   !/ mstar_scheme == 2
-  real :: C_EK = 0.17        !< MSTAR Coefficient in rotation limit for mstar_scheme=OM4
-  real :: MSTAR_COEF = 0.3   !< MSTAR coefficient in rotation/stabilizing balance for mstar_scheme=OM4
+  real :: C_EK = 0.17        !< MSTAR Coefficient in rotation limit for mstar_scheme=OM4 [nondim]
+  real :: MSTAR_COEF = 0.3   !< MSTAR coefficient in rotation/stabilizing balance for mstar_scheme=OM4 [nondim]
 
   !/ mstar_scheme == 3
-  real    :: RH18_mstar_cN1  !< MSTAR_N coefficient 1 (outer-most coefficient for fit).
+  real    :: RH18_mstar_cN1  !< MSTAR_N coefficient 1 (outer-most coefficient for fit) [nondim].
                              !! Value of 0.275 in RH18.  Increasing this
                              !! coefficient increases mechanical mixing for all values of Hf/ust,
                              !! but is most effective at low values (weakly developed OSBLs).
-  real    :: RH18_mstar_cN2  !< MSTAR_N coefficient 2 (coefficient outside of exponential decay).
+  real    :: RH18_mstar_cN2  !< MSTAR_N coefficient 2 (coefficient outside of exponential decay) [nondim].
                              !! Value of 8.0 in RH18.  Increasing this coefficient increases MSTAR
                              !! for all values of HF/ust, with a consistent affect across
                              !! a wide range of Hf/ust.
-  real    :: RH18_mstar_cN3  !< MSTAR_N coefficient 3 (exponential decay coefficient). Value of
+  real    :: RH18_mstar_cN3  !< MSTAR_N coefficient 3 (exponential decay coefficient) [nondim]. Value of
                              !! -5.0 in RH18.  Increasing this increases how quickly the value
                              !! of MSTAR decreases as Hf/ust increases.
-  real    :: RH18_mstar_cS1  !< MSTAR_S coefficient for RH18 in stabilizing limit.
+  real    :: RH18_mstar_cS1  !< MSTAR_S coefficient for RH18 in stabilizing limit [nondim].
                              !! Value of 0.2 in RH18.
-  real    :: RH18_mstar_cS2  !< MSTAR_S exponent for RH18 in stabilizing limit.
+  real    :: RH18_mstar_cS2  !< MSTAR_S exponent for RH18 in stabilizing limit [nondim].
                              !! Value of 0.4 in RH18.
 
   !/ Coefficient for shear/convective turbulence interaction
-  real :: mstar_convect_coef !< Factor to reduce mstar when statically unstable.
+  real :: mstar_convect_coef !< Factor to reduce mstar when statically unstable [nondim].
 
   !/ Langmuir turbulence related parameters
   logical :: Use_LT = .false. !< Flag for using LT in Energy calculation
   integer :: LT_ENHANCE_FORM !< Integer for Enhancement functional form (various options)
-  real    :: LT_ENHANCE_COEF !< Coefficient in fit for Langmuir Enhancement
-  real    :: LT_ENHANCE_EXP  !< Exponent in fit for Langmuir Enhancement
+  real    :: LT_ENHANCE_COEF !< Coefficient in fit for Langmuir Enhancement [nondim]
+  real    :: LT_ENHANCE_EXP  !< Exponent in fit for Langmuir Enhancement [nondim]
   real :: LaC_MLDoEK         !< Coefficient for Langmuir number modification based on the ratio of
-                             !! the mixed layer depth over the Ekman depth.
+                             !! the mixed layer depth over the Ekman depth [nondim].
   real :: LaC_MLDoOB_stab    !< Coefficient for Langmuir number modification based on the ratio of
-                             !! the mixed layer depth over the Obukhov depth with stabilizing forcing.
+                             !! the mixed layer depth over the Obukhov depth with stabilizing forcing [nondim].
   real :: LaC_EKoOB_stab     !< Coefficient for Langmuir number modification based on the ratio of
-                             !! the Ekman depth over the Obukhov depth with stabilizing forcing.
+                             !! the Ekman depth over the Obukhov depth with stabilizing forcing [nondim].
   real :: LaC_MLDoOB_un      !< Coefficient for Langmuir number modification based on the ratio of
-                             !! the mixed layer depth over the Obukhov depth with destabilizing forcing.
+                             !! the mixed layer depth over the Obukhov depth with destabilizing forcing [nondim].
   real :: LaC_EKoOB_un       !< Coefficient for Langmuir number modification based on the ratio of
-                             !! the Ekman depth over the Obukhov depth with destabilizing forcing.
-  real :: Max_Enhance_M = 5. !< The maximum allowed LT enhancement to the mixing.
+                             !! the Ekman depth over the Obukhov depth with destabilizing forcing [nondim].
+  real :: Max_Enhance_M = 5. !< The maximum allowed LT enhancement to the mixing [nondim].
 
   !/ Others
   type(time_type), pointer :: Time=>NULL() !< A pointer to the ocean model's clock.
@@ -229,8 +229,8 @@ logical :: report_avg_its = .false.  !< Report the average number of ePBL iterat
 !> A type for conveniently passing around ePBL diagnostics for a column.
 type, public :: ePBL_column_diags ; private
   !>@{ Local column copies of energy change diagnostics, all in [R Z3 T-3 ~> W m-2].
-  real :: dTKE_conv, dTKE_forcing, dTKE_wind, dTKE_mixing
-  real :: dTKE_MKE, dTKE_mech_decay, dTKE_conv_decay
+  real :: dTKE_conv, dTKE_forcing, dTKE_wind, dTKE_mixing ! Local column diagnostics [R Z3 T-3 ~> W m-2]
+  real :: dTKE_MKE, dTKE_mech_decay, dTKE_conv_decay      ! Local column diagnostics [R Z3 T-3 ~> W m-2]
   !>@}
   real :: LA        !< The value of the Langmuir number [nondim]
   real :: LAmod     !< The modified Langmuir number by convection [nondim]
@@ -570,8 +570,8 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
                     ! during this timestep [R Z3 T-2 ~> J m-2]. A portion nstar_FC
                     ! of conv_PErel is available to drive mixing.
   real :: htot      !   The total depth of the layers above an interface [H ~> m or kg m-2].
-  real :: uhtot     !   The depth integrated zonal and meridional velocities in the
-  real :: vhtot     ! layers above [H L T-1 ~> m2 s-1 or kg m-1 s-1].
+  real :: uhtot     ! The depth integrated zonal velocities in the layers above [H L T-1 ~> m2 s-1 or kg m-1 s-1]
+  real :: vhtot     ! The depth integrated meridional velocities in the layers above [H L T-1 ~> m2 s-1 or kg m-1 s-1]
   real :: Idecay_len_TKE  ! The inverse of a turbulence decay length scale [H-1 ~> m-1 or m2 kg-1].
   real :: h_sum     ! The total thickness of the water column [H ~> m or kg m-2].
 
@@ -612,7 +612,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
   real, dimension(SZK_(GV)+1) :: &
     MixLen_shape, & ! A nondimensional shape factor for the mixing length that
                     ! gives it an appropriate asymptotic value at the bottom of
-                    ! the boundary layer.
+                    ! the boundary layer [nondim].
     Kddt_h          ! The diapycnal diffusivity times a timestep divided by the
                     ! average thicknesses around a layer [H ~> m or kg m-2].
   real :: b1        ! b1 is inverse of the pivot used by the tridiagonal solver [H-1 ~> m-1 or m2 kg-1].
@@ -642,9 +642,9 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
                     ! a surface mixing roughness length given by h_tt_min [H ~> m or kg m-2].
   real :: h_tt_min  ! A surface roughness length [H ~> m or kg m-2].
 
-  real :: C1_3      ! = 1/3.
+  real :: C1_3      ! = 1/3  [nondim]
   real :: I_dtrho   ! 1.0 / (dt * Rho0) times conversion factors in [m3 Z-3 R-1 T2 s-3 ~> m3 kg-1 s-1].
-                    ! This is used convert TKE back into ustar^3.
+                    ! This is used convert TKE back into ustar^3 for use in a cube root.
   real :: vstar     ! An in-situ turbulent velocity [Z T-1 ~> m s-1].
   real :: mstar_total ! The value of mstar used in ePBL [nondim]
   real :: mstar_LT  ! An addition to mstar due to Langmuir turbulence [nondim] (output for diagnostic)
@@ -708,8 +708,8 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
   !    - needed to compute new mixing length.
   real :: MLD_guess, MLD_found ! Mixing Layer depth guessed/found for iteration [H ~> m or kg m-2].
   real :: MLD_guess_Z  ! A guessed mixed layer depth, converted to height units [Z ~> m]
-  real :: min_MLD   ! Iteration bounds [H ~> m or kg m-2], which are adjusted at each step
-  real :: max_MLD   !  - These are initialized based on surface/bottom
+  real :: min_MLD, max_MLD ! Iteration bounds on MLD [H ~> m or kg m-2], which are adjusted at each step
+                    !  - These are initialized based on surface/bottom
                     !  1. The iteration guesses a value (possibly from prev step or neighbor).
                     !  2. The iteration checks if value is converged, too shallow, or too deep.
                     !  3. Based on result adjusts the Max/Min and searches through the water column.
@@ -726,14 +726,24 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
   logical :: OBL_converged ! Flag for convergence of MLD
   integer :: OBL_it        ! Iteration counter
 
-  real :: Surface_Scale ! Surface decay scale for vstar
+  real :: Surface_Scale ! Surface decay scale for vstar [nondim]
   logical :: calc_Te    ! If true calculate the expected final temperature and salinity values.
   logical :: debug      ! This is used as a hard-coded value for debugging.
 
   !  The following arrays are used only for debugging purposes.
-  real :: dPE_debug, mixing_debug
-  real, dimension(20) :: TKE_left_itt, PE_chg_itt, Kddt_h_itt, dPEa_dKd_itt, MKE_src_itt
-  real, dimension(SZK_(GV)) :: mech_TKE_k, conv_PErel_k, nstar_k
+  real :: dPE_debug     ! An estimate of the potential energy change [R Z3 T-2 ~> J m-2]
+  real :: mixing_debug  ! An estimate of the rate of change of potential energy due to mixing [R Z3 T-3 ~> W m-2]
+  real, dimension(20) :: TKE_left_itt   ! The value of TKE_left after each iteration [R Z3 T-2 ~> J m-2]
+  real, dimension(20) :: PE_chg_itt     ! The value of PE_chg after each iteration [R Z3 T-2 ~> J m-2]
+  real, dimension(20) :: Kddt_h_itt     ! The value of Kddt_h_guess after each iteration [H ~> m or kg m-2]
+  real, dimension(20) :: dPEa_dKd_itt   ! The value of dPEc_dKd after each iteration [R Z3 T-2 H-1 ~> J m-3 or J kg-1]
+  real, dimension(20) :: MKE_src_itt    ! The value of MKE_src after each iteration [R Z3 T-2 ~> J m-2]
+  real, dimension(SZK_(GV)) :: mech_TKE_k  ! The mechanically generated turbulent kinetic energy
+                    ! available for mixing over a time step for each layer [R Z3 T-2 ~> J m-2].
+  real, dimension(SZK_(GV)) :: conv_PErel_k ! The potential energy that has been convectively released
+                    ! during this timestep for each layer [R Z3 T-2 ~> J m-2].
+  real, dimension(SZK_(GV)) :: nstar_k   ! The fraction of conv_PErel that can be converted to mixing
+                    ! for each layer [nondim].
   real, dimension(SZK_(GV)) :: dT_expect !< Expected temperature changes [C ~> degC]
   real, dimension(SZK_(GV)) :: dS_expect !< Expected salinity changes [S ~> ppt]
   integer, dimension(SZK_(GV)) :: num_itts
@@ -1185,7 +1195,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
 
             Kddt_h(K) = Kd(K) * dt_h
           elseif (tot_TKE + (MKE_src - PE_chg_g0) >= 0.0) then
-            ! This column is convctively stable and there is energy to support the suggested
+            ! This column is convectively stable and there is energy to support the suggested
             ! mixing.  Keep that estimate.
             Kd(K) = Kd_guess0
             Kddt_h(K) = Kddt_h_g0
@@ -1398,7 +1408,7 @@ subroutine ePBL_column(h, u, v, T0, S0, dSV_dT, dSV_dS, TKE_forcing, B_flux, abs
         MLD_guess = 0.5*(min_MLD + max_MLD)
       else ! Try using the false position method or the returned value instead of simple bisection.
         ! Taking the occasional step with MLD_output empirically helps to converge faster.
-        if ((dMLD_min > 0.0) .and. (dMLD_max < 0.0) .and. (OBL_it > 2) .and. (mod(OBL_it-1,4)>0)) then
+        if ((dMLD_min > 0.0) .and. (dMLD_max < 0.0) .and. (OBL_it > 2) .and. (mod(OBL_it-1,4) > 0)) then
           ! Both bounds have valid change estimates and are probably in the range of possible outputs.
           MLD_Guess = (dMLD_min*max_MLD - dMLD_max*min_MLD) / (dMLD_min - dMLD_max)
         elseif ((MLD_found > min_MLD) .and. (MLD_found < max_MLD)) then
@@ -1809,7 +1819,6 @@ subroutine find_mstar(CS, US, Buoyancy_Flux, UStar, UStar_Mean,&
   MStar = MStar * MStar_Conv_Red
 
   if (present(Langmuir_Number)) then
-    !### In this call, ustar was previously ustar_mean.  Is this change deliberate, Brandon?  -RWH
     call mstar_Langmuir(CS, US, Abs_Coriolis, Buoyancy_Flux, UStar, BLD, Langmuir_Number, MStar, &
                         MStar_LT, Convect_Langmuir_Number)
   endif
@@ -1831,9 +1840,9 @@ subroutine Mstar_Langmuir(CS, US, Abs_Coriolis, Buoyancy_Flux, UStar, BLD, Langm
   real,                  intent(out) :: Convect_Langmuir_number !< Langmuir number including buoyancy flux [nondim]
 
   !/
-  real, parameter :: Max_ratio = 1.0e16  ! The maximum value of a nondimensional ratio.
-  real :: enhance_mstar ! A multiplicative scaling of mstar due to Langmuir turbulence.
-  real :: mstar_LT_add ! A value that is added to mstar due to Langmuir turbulence.
+  real, parameter :: Max_ratio = 1.0e16  ! The maximum value of a nondimensional ratio [nondim].
+  real :: enhance_mstar ! A multiplicative scaling of mstar due to Langmuir turbulence [nondim].
+  real :: mstar_LT_add ! A value that is added to mstar due to Langmuir turbulence [nondim].
   real :: iL_Ekman    ! Inverse of Ekman length scale [Z-1 ~> m-1].
   real :: iL_Obukhov  ! Inverse of Obukhov length scale [Z-1 ~> m-1].
   real :: I_ustar     ! The Adcroft reciprocal of ustar [T Z-1 ~> s m-1]
@@ -1841,10 +1850,14 @@ subroutine Mstar_Langmuir(CS, US, Abs_Coriolis, Buoyancy_Flux, UStar, BLD, Langm
   real :: MLD_Ekman          ! The ratio of the mixed layer depth to the Ekman layer depth [nondim].
   real :: Ekman_Obukhov      ! The Ekman layer thickness divided by the Obukhov depth [nondim].
   real :: MLD_Obukhov        ! The mixed layer depth divided by the Obukhov depth [nondim].
-  real :: MLD_Obukhov_stab   ! Ratios of length scales where MLD is boundary layer depth [nondim].
-  real :: Ekman_Obukhov_stab ! >
-  real :: MLD_Obukhov_un     ! Ratios of length scales where MLD is boundary layer depth
-  real :: Ekman_Obukhov_un   ! >
+  real :: MLD_Obukhov_stab   ! The mixed layer depth divided by the Obukhov depth under stable
+                             ! conditions or 0 under unstable conditions [nondim].
+  real :: Ekman_Obukhov_stab ! The Ekman layer thickness divided by the Obukhov depth under stable
+                             ! conditions or 0 under unstable conditions [nondim].
+  real :: MLD_Obukhov_un     ! The mixed layer depth divided by the Obukhov depth under unstable
+                             ! conditions or 0 under stable conditions [nondim].
+  real :: Ekman_Obukhov_un   ! The Ekman layer thickness divided by the Obukhov depth under unstable
+                             ! conditions or 0 under stable conditions [nondim].
 
   ! Set default values for no Langmuir effects.
   enhance_mstar = 1.0 ; mstar_LT_add = 0.0
@@ -1910,9 +1923,9 @@ subroutine energetic_PBL_get_MLD(CS, MLD, G, US, m_to_MLD_units)
   type(unit_scale_type),            intent(in)  :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G)), intent(out) :: MLD !< Depth of ePBL active mixing layer [Z ~> m] or other units
   real,                   optional, intent(in)  :: m_to_MLD_units !< A conversion factor from meters
-                                                       !! to the desired units for MLD
+                                                       !! to the desired units for MLD, sometimes [m Z-1 ~> 1]
   ! Local variables
-  real :: scale  ! A dimensional rescaling factor
+  real :: scale  ! A dimensional rescaling factor, often [nondim] or [m Z-1 ~> 1]
   integer :: i,j
 
   scale = 1.0 ; if (present(m_to_MLD_units)) scale = US%Z_to_m * m_to_MLD_units
@@ -1939,7 +1952,7 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_energetic_PBL"  ! This module's name.
   character(len=20)  :: tmpstr
-  real :: omega_frac_dflt
+  real :: omega_frac_dflt  ! The default for omega_frac [nondim]
   integer :: isd, ied, jsd, jed
   integer :: mstar_mode, LT_enhance, wT_mode
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
@@ -2390,7 +2403,7 @@ subroutine energetic_PBL_end(CS)
   type(energetic_PBL_CS), intent(inout) :: CS !< Energetic_PBL control structure
 
   character(len=256) :: mesg
-  real :: avg_its
+  real :: avg_its ! The averaged number of iterations used by ePBL [nondim]
 
   if (allocated(CS%ML_depth))            deallocate(CS%ML_depth)
   if (allocated(CS%LA))                  deallocate(CS%LA)

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -1814,9 +1814,9 @@ subroutine find_maxF_kb(h_bl, Sref, Ent_bl, I_dSkbp1, min_ent_in, max_ent_in, &
                                                       !! limited value at ent=max_ent_in in this
                                                       !! array [H ~> m or kg m-2].
   real, dimension(SZI_(G)), &
-                    optional, intent(in)  :: F_thresh !< If F_thresh is present, return the first
-                                                      !! value found that has F > F_thresh, or
-                                                      !! the maximum.
+                    optional, intent(in)  :: F_thresh !< If F_thresh is present, return the first value
+                                                      !! found that has F > F_thresh [H ~> m or kg m-2], or
+                                                      !! the maximum root if it is absent.
 
 ! Maximize F = ent*ds_kb*I_dSkbp1 in the range min_ent < ent < max_ent.
 ! ds_kb may itself be limited to positive values in determine_dSkb, which gives

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -664,8 +664,8 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, dz, &
     pressure, & ! The pressure at an interface [R L2 T-2 ~> Pa].
     T_int, &    ! The temperature interpolated to an interface [C ~> degC].
     Sal_int, &  ! The salinity interpolated to an interface [S ~> ppt].
-    dbuoy_dT, & ! The partial derivatives of buoyancy with changes in temperature
-    dbuoy_dS, & ! and salinity, [Z T-2 C-1 ~> m s-2 degC-1] and [Z T-2 S-1 ~> m s-2 ppt-1].
+    dbuoy_dT, & ! The partial derivative of buoyancy with changes in temperature [Z T-2 C-1 ~> m s-2 degC-1]
+    dbuoy_dS, & ! The partial derivative of buoyancy with changes in salinity [Z T-2 S-1 ~> m s-2 ppt-1]
     I_L2_bdry, &   ! The inverse of the square of twice the harmonic mean
                    ! distance to the top and bottom boundaries [Z-2 ~> m-2].
     K_Q, &         ! Diffusivity divided by TKE [T ~> s].

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -68,7 +68,7 @@ type, public :: opacity_CS ; private
                              !! The default is 10 m-1 - a value for muddy water.
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
                              !! regulate the timing of diagnostic output.
-  logical :: warning_issued  !< A flag that is used to avoid repetative warnings.
+  logical :: warning_issued  !< A flag that is used to avoid repetitive warnings.
 
   !>@{ Diagnostic IDs
   integer :: id_sw_pen = -1, id_sw_vis_pen = -1
@@ -402,7 +402,7 @@ end subroutine opacity_from_chl
 !> This sets the blue-wavelength opacity according to the scheme proposed by
 !! Morel and Antoine (1994).
 function opacity_morel(chl_data)
-  real, intent(in)  :: chl_data !< The chlorophyll-A concentration in mg m-3.
+  real, intent(in)  :: chl_data !< The chlorophyll-A concentration in [mg m-3]
   real :: opacity_morel !< The returned opacity [m-1]
 
   !   The following are coefficients for the optical model taken from Morel and
@@ -411,8 +411,8 @@ function opacity_morel(chl_data)
   ! appropriate when using an interactive ecosystem model that predicts
   ! three-dimensional chl-a values.
   real, dimension(6), parameter :: &
-    Z2_coef = (/7.925, -6.644, 3.662, -1.815, -0.218,  0.502/)
-  real :: Chl, Chl2 ! The log10 of chl_data (in mg m-3), and Chl^2.
+    Z2_coef = (/7.925, -6.644, 3.662, -1.815, -0.218,  0.502/) ! Extinction length coefficients [m]
+  real :: Chl, Chl2 ! The log10 of chl_data (in mg m-3), and Chl^2 [nondim]
 
   Chl = log10(min(max(chl_data,0.02),60.0)) ; Chl2 = Chl*Chl
   opacity_morel = 1.0 / ( (Z2_coef(1) + Z2_coef(2)*Chl) + Chl2 * &
@@ -430,9 +430,9 @@ function SW_pen_frac_morel(chl_data)
   ! chlorophyll-a through the water column.  Other approaches may be more
   ! appropriate when using an interactive ecosystem model that predicts
   ! three-dimensional chl-a values.
-  real :: Chl, Chl2         ! The log10 of chl_data in mg m-3, and Chl^2.
+  real :: Chl, Chl2         ! The log10 of chl_data in mg m-3, and Chl^2 [nondim]
   real, dimension(6), parameter :: &
-    V1_coef = (/0.321,  0.008, 0.132,  0.038, -0.017, -0.007/)
+    V1_coef = (/0.321,  0.008, 0.132,  0.038, -0.017, -0.007/) ! Penetrating fraction coefficients [nondim]
 
   Chl = log10(min(max(chl_data,0.02),60.0)) ; Chl2 = Chl*Chl
   SW_pen_frac_morel = 1.0 - ( (V1_coef(1) + V1_coef(2)*Chl) + Chl2 * &
@@ -442,7 +442,7 @@ end function SW_pen_frac_morel
 !>   This sets the blue-wavelength opacity according to the scheme proposed by
 !! Manizza, M. et al, 2005.
 function opacity_manizza(chl_data)
-  real, intent(in)  :: chl_data !< The chlorophyll-A concentration in mg m-3.
+  real, intent(in)  :: chl_data !< The chlorophyll-A concentration [mg m-3]
   real :: opacity_manizza !< The returned opacity [m-1]
 !   This sets the blue-wavelength opacity according to the scheme proposed by Manizza, M. et al, 2005.
 
@@ -460,15 +460,16 @@ subroutine extract_optics_slice(optics, j, G, GV, opacity, opacity_scale, penSW_
   real, dimension(max(optics%nbands,1),SZI_(G),SZK_(GV)), &
                  optional, intent(out) :: opacity   !< The opacity in each band, i-point, and layer [Z-1 ~> m-1],
                                                     !! but with units that can be altered by opacity_scale.
-  real,          optional, intent(in)  :: opacity_scale !< A factor by which to rescale the opacity.
+  real,          optional, intent(in)  :: opacity_scale !< A factor by which to rescale the opacity [nondim] or
+                                                    !! [Z H-1 ~> 1 or m3 kg-1]
   real, dimension(max(optics%nbands,1),SZI_(G)), &
                  optional, intent(out) :: penSW_top !< The shortwave radiation [Q R Z T-1 ~> W m-2]
                                                     !! at the surface in each of the nbands bands
                                                     !! that penetrates beyond the surface skin layer.
-  real,          optional, intent(in)  :: penSW_scale !< A factor by which to rescale the shortwave flux.
+  real,          optional, intent(in)  :: penSW_scale !< A factor by which to rescale the shortwave flux [nondim]?
 
   ! Local variables
-  real :: scale_opacity, scale_penSW ! Rescaling factors
+  real :: scale_opacity, scale_penSW ! Rescaling factors [nondim]?
   integer :: i, is, ie, k, nz, n
   is = G%isc ; ie = G%iec ; nz = GV%ke
 
@@ -604,7 +605,7 @@ subroutine absorbRemainingSW(G, GV, US, h, opacity_band, nsw, optics, j, dt, H_l
                             ! is moved upward [C H ~> degC m or degC kg m-2]
   real :: SWa               ! fraction of the absorbed shortwave that is
                             ! moved to layers above with adjustAbsorptionProfile [nondim]
-  real :: coSWa_frac        ! The fraction of SWa that is actually moved upward.
+  real :: coSWa_frac        ! The fraction of SWa that is actually moved upward [nondim]
   real :: min_SW_heat       ! A minimum remaining shortwave heating within a timestep that will be simply
                             ! absorbed in the next layer for computational efficiency, instead of
                             ! continuing to penetrate [C H ~> degC m or degC kg m-2].
@@ -617,7 +618,7 @@ subroutine absorbRemainingSW(G, GV, US, h, opacity_band, nsw, optics, j, dt, H_l
                             ! was not entirely absorbed.
   logical :: TKE_calc       ! If true, calculate the implications to the
                             ! TKE budget of the shortwave heating.
-  real :: C1_6, C1_60
+  real :: C1_6, C1_60       ! Rational fractions [nondim]
   integer :: is, ie, nz, i, k, ks, n
 
   if (nsw < 1) return
@@ -830,7 +831,7 @@ subroutine sumSWoverBands(G, GV, US, h, nsw, optics, j, dt, &
   real :: SW_trans        ! fraction of shortwave radiation not
                           ! absorbed in a layer [nondim]
   real :: unabsorbed      ! fraction of the shortwave radiation
-                          ! not absorbed because the layers are too thin.
+                          ! not absorbed because the layers are too thin [nondim].
   real :: Ih_limit        ! inverse of the total depth at which the
                           ! surface fluxes start to be limited [H-1 ~> m-1 or m2 kg-1]
   real :: min_SW_heat     ! A minimum remaining shortwave heating within a timestep that will be simply

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -142,7 +142,7 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
     S_2d, &     !   A 2-d version of tv%S [S ~> ppt].
     Rcv, &      !   A 2-d version of the coordinate density [R ~> kg m-3].
     h_2d_init, &  ! The initial value of h_2d [H ~> m or kg m-2].
-    T_2d_init, &  ! THe initial value of T_2d [C ~> degC].
+    T_2d_init, &  ! The initial value of T_2d [C ~> degC].
     S_2d_init, &  ! The initial value of S_2d [S ~> ppt].
     d_eb, &     !   The downward increase across a layer in the entrainment from
                 ! below [H ~> m or kg m-2].  The sign convention is that positive values of
@@ -176,8 +176,8 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
   real :: h_add     ! The thickness to add to the layers above an interface [H ~> m or kg m-2]
   real :: h_det_tot ! The total thickness detrained by the mixed layers [H ~> m or kg m-2]
   real :: max_def_rat  ! The maximum value of the ratio of the thickness deficit to the minimum depth [nondim]
-  real :: Rcv_min_det  ! The lightest (min) and densest (max) coordinate density
-  real :: Rcv_max_det  ! that can detrain into a layer [R ~> kg m-3].
+  real :: Rcv_min_det  ! The lightest coordinate density that can detrain into a layer [R ~> kg m-3]
+  real :: Rcv_max_det  ! The densest coordinate density that can detrain into a layer [R ~> kg m-3]
 
   real :: int_top, int_bot ! The interface depths above and below a layer [H ~> m or kg m-2], positive upward.
   real :: h_predicted  ! An updated thickness [H ~> m or kg m-2]

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -257,8 +257,8 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
                            ! the depth of each interface [nondim].
   real :: L_direct         ! The value of L above volume Vol_direct [nondim].
   real :: L_max, L_min     ! Upper and lower bounds on the correct value for L  [nondim].
-  real :: Vol_err_max      ! The volume errors for the upper and lower bounds on
-  real :: Vol_err_min      ! the correct value for L [H ~> m or kg m-2].
+  real :: Vol_err_max      ! The volume error for the upper bound on the correct value for L [H ~> m or kg m-2]
+  real :: Vol_err_min      ! The volume error for the lower bound on the correct value for L [H ~> m or kg m-2]
   real :: Vol_0            ! A deeper volume with known width L0 [H ~> m or kg m-2].
   real :: L0               ! The value of L above volume Vol_0 [nondim].
   real :: dVol             ! vol - Vol_0 [H ~> m or kg m-2].

--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -30,11 +30,11 @@ public initialize_sponge, apply_sponge, sponge_end, init_sponge_diags
 
 !> A structure for creating arrays of pointers to 3D arrays
 type, public :: p3d
-  real, dimension(:,:,:), pointer :: p => NULL() !< A pointer to a 3D array
+  real, dimension(:,:,:), pointer :: p => NULL() !< A pointer to a 3D array [various]
 end type p3d
 !> A structure for creating arrays of pointers to 2D arrays
 type, public :: p2d
-  real, dimension(:,:), pointer :: p => NULL() !< A pointer to a 2D array
+  real, dimension(:,:), pointer :: p => NULL() !< A pointer to a 2D array [various]
 end type p2d
 
 !> This control structure holds memory and parameters for the MOM_sponge module
@@ -203,15 +203,15 @@ subroutine set_up_sponge_field(sp_val, f_ptr, G, GV, nlay, CS, sp_val_i_mean)
   type(ocean_grid_type),   intent(in) :: G      !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV     !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in) :: sp_val !< The reference profiles of the quantity being registered.
+                           intent(in) :: sp_val !< The reference profiles of the quantity being registered [various]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                   target, intent(in) :: f_ptr  !< a pointer to the field which will be damped
+                   target, intent(in) :: f_ptr  !< a pointer to the field which will be damped [various]
   integer,                 intent(in) :: nlay   !< the number of layers in this quantity
   type(sponge_CS),         pointer    :: CS     !< A pointer to the control structure for this module that
                                                 !! is set by a previous call to initialize_sponge.
   real, dimension(SZJ_(G),SZK_(GV)),&
                optional, intent(in) :: sp_val_i_mean !< The i-mean reference value for
-                                              !! this field with i-mean sponges.
+                                              !! this field with i-mean sponges [various]
 
   integer :: j, k, col
   character(len=256) :: mesg ! String for error messages
@@ -331,11 +331,11 @@ subroutine apply_sponge(h, dt, G, GV, US, ea, eb, CS, Rcv_ml)
     eta_anom, &    ! Anomalies in the interface height, relative to the i-mean
                    ! target value [Z ~> m].
     fld_anom       ! Anomalies in a tracer concentration, relative to the
-                   ! i-mean target value.
+                   ! i-mean target value [various]
   real, dimension(SZJ_(G), SZK_(GV)+1) :: &
     eta_mean_anom  ! The i-mean interface height anomalies [Z ~> m].
   real, allocatable, dimension(:,:,:) :: &
-    fld_mean_anom  ! THe i-mean tracer concentration anomalies.
+    fld_mean_anom  ! The i-mean tracer concentration anomalies [various]
   real, dimension(SZI_(G), SZK_(GV)+1) :: &
     h_above, &     ! The total thickness above an interface [H ~> m or kg m-2].
     h_below        ! The total thickness below an interface [H ~> m or kg m-2].


### PR DESCRIPTION
  This PR includes a series of 18 commits (1 per file) that add or amend the documentation of the units of 245 internal variables in various parameterization modules.  It also revises the terminology in a number of the comments describing the thickness_diffuse module for greater clarity of language.  This PR might be a good candidate for a squash merge 

  Apart from a few unused variables that eliminated, only comments are changed and all answers are bitwise identical.

  The commits in this PR include:

- NOAA-GFDL/MOM6@492afee31 Better terminology in thickness_diffuse module
- NOAA-GFDL/MOM6@d8191d90f Document units of variables in MOM_tidal_forcing
- NOAA-GFDL/MOM6@62952b6d7 Document units of variables in MOM_internal_tides
- NOAA-GFDL/MOM6@d4ccba775 Document units of 7 variables in MOM_sponge
- NOAA-GFDL/MOM6@65ba87e63 Document units of a variable in MOM_set_viscosity
- NOAA-GFDL/MOM6@d3ecef2ba Document units of a variable in MOM_regularize_layers
- NOAA-GFDL/MOM6@9d293d667 Document units of a variable in MOM_bkgnd_mixing
- NOAA-GFDL/MOM6@d9f8759b4 Document units of 3 variables in MOM_CVMix_conv
- NOAA-GFDL/MOM6@3056040bc Document units of 2 variables in MOM_CVMix_KPP
- NOAA-GFDL/MOM6@045b8af1c Document units of an argument to find_maxF_kb
- NOAA-GFDL/MOM6@ad6559f88 Document units of a variable in MOM_kappa_shear
- NOAA-GFDL/MOM6@b696de2a2 Document units of a variable in MOM_ALE_sponge
- NOAA-GFDL/MOM6@9cd42567b Document units of 14 variables in MOM_tidal_mixing
- NOAA-GFDL/MOM6@49810eca4 Clean up of a get_param call in vertvisc_init
- NOAA-GFDL/MOM6@6ddd871ff Document units of 21 variables in MOM_bulk_mixed_layer
- NOAA-GFDL/MOM6@c499a41de Document units of 16 variables in MOM_opacity
- NOAA-GFDL/MOM6@92ed59919 Document units of variables in MOM_diapyc_energy_req
- NOAA-GFDL/MOM6@b889688d2 Document units of variables in MOM_energetic_PBL
