### PR TITLE
Document units of 30 driver variables

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -92,7 +92,7 @@ type, public :: surface_forcing_CS ; private
                                 !! contributes to ustar [R L Z T-1 ~> Pa].  gust is used when read_gust_2d is true.
   real, pointer, dimension(:,:) :: &
     ustar_tidal => NULL()       !< Tidal contribution to the bottom friction velocity [Z T-1 ~> m s-1]
-  real :: cd_tides              !< Drag coefficient that applies to the tides (nondimensional)
+  real :: cd_tides              !< Drag coefficient that applies to the tides [nondim]
   real :: utide                 !< Constant tidal velocity to use if read_tideamp is false [Z T-1 ~> m s-1].
   logical :: read_tideamp       !< If true, spatially varying tidal amplitude read from a file.
 
@@ -127,7 +127,7 @@ type, public :: surface_forcing_CS ; private
   logical :: mask_srestore_marginal_seas    !< If true, then mask SSS restoring in marginal seas
   real    :: max_delta_srestore             !< Maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_trestore             !< Maximum delta sst used for restoring [C ~> degC]
-  real, pointer, dimension(:,:) :: basin_mask => NULL() !< Mask for surface salinity restoring by basin
+  real, pointer, dimension(:,:) :: basin_mask => NULL() !< Mask for surface salinity restoring by basin [nondim]
   integer :: answer_date        !< The vintage of the order of arithmetic and expressions in the
                                 !! gustiness calculations.  Values below 20190101 recover the answers
                                 !! from the end of 2018, while higher values use a simpler expression
@@ -144,14 +144,14 @@ type, public :: surface_forcing_CS ; private
                                               !! salinity restoring fluxes. The masking file should be
                                               !! in inputdir/salt_restore_mask.nc and the field should
                                               !! be named 'mask'
-  real, pointer, dimension(:,:) :: srestore_mask => NULL() !< mask for SSS restoring
+  real, pointer, dimension(:,:) :: srestore_mask => NULL() !< mask for SSS restoring [nondim]
   character(len=200) :: temp_restore_file     !< Filename for sst restoring data
   character(len=30)  :: temp_restore_var_name !< Name of surface temperature in temp_restore_file
   logical            :: mask_trestore         !< If true, apply a 2-dimensional mask to the surface
                                               !! temperature restoring fluxes. The masking file should be
                                               !! in inputdir/temp_restore_mask.nc and the field should
                                               !! be named 'mask'
-  real, pointer, dimension(:,:) :: trestore_mask => NULL() !< Mask for SST restoring
+  real, pointer, dimension(:,:) :: trestore_mask => NULL() !< Mask for SST restoring [nondim]
   integer :: id_srestore = -1  !< An id number for time_interp_external.
   integer :: id_trestore = -1  !< An id number for time_interp_external.
 
@@ -250,7 +250,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
                               ! mass fluxes [R Z s m2 kg-1 T-1 ~> 1]
   real :: rhoXcp              ! Reference density times heat capacity times unit scaling
                               ! factors [Q R C-1 ~> J m-3 degC-1]
-  real :: sign_for_net_FW_bug ! Should be +1. but an old bug can be recovered by using -1.
+  real :: sign_for_net_FW_bug ! Should be +1. but an old bug can be recovered by using -1 [nondim]
 
   call cpu_clock_begin(id_clock_forcing)
 
@@ -1169,7 +1169,10 @@ subroutine apply_force_adjustments(G, US, CS, Time, forces)
   real, dimension(SZI_(G),SZJ_(G)) :: tempy_at_h ! Delta to meridional wind stress at h points [R Z L T-2 ~> Pa]
 
   integer :: isc, iec, jsc, jec, i, j
-  real :: dLonDx, dLonDy, rDlon, cosA, sinA, zonal_tau, merid_tau
+  real :: dLonDx, dLonDy ! The change in longitude across the cell in the x- and y-directions [degrees_E]
+  real :: rDlon ! The magnitude of the change in longitude [degrees_E] and then its inverse [degrees_E-1]
+  real :: cosA, sinA  ! The cosine and sine of the angle between the grid and true north [nondim]
+  real :: zonal_tau, merid_tau ! True zonal and meridional wind stresses [R Z L T-2 ~> Pa]
   real :: Pa_conversion ! A unit conversion factor from Pa to the internal units [R Z L T-2 Pa-1 ~> 1]
   logical :: overrode_x, overrode_y
 
@@ -1714,8 +1717,8 @@ end subroutine ice_ocn_bnd_type_chksum
 !> Check the values passed by IOB over land are zero
 subroutine check_mask_val_consistency(val, mask, i, j, varname, G)
 
-  real, intent(in) :: val  !< value of flux/variable passed by IOB
-  real, intent(in) :: mask !< value of ocean mask
+  real, intent(in) :: val  !< value of flux/variable passed by IOB [various]
+  real, intent(in) :: mask !< value of ocean mask [nondim]
   integer, intent(in) :: i !< model grid cell indices
   integer, intent(in) :: j !< model grid cell indices
   character(len=*), intent(in) :: varname !< variable name

--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -462,7 +462,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
                             ! internal modules.
   type(time_type) :: Time1  ! The value of the ocean model's time at the start of a call to step_MOM.
   integer :: index_bnds(4)  ! The computational domain index bounds in the ice-ocean boundary type.
-  real :: weight            ! Flux accumulation weight of the current fluxes.
+  real :: weight            ! Flux accumulation weight of the current fluxes [nondim].
   real :: dt_coupling       ! The coupling time step [T ~> s].
   real :: dt_therm          ! A limited and quantized version of OS%dt_therm [T ~> s].
   real :: dt_dyn            ! The dynamics time step [T ~> s].
@@ -834,7 +834,6 @@ subroutine convert_state_to_ocean_type(sfc_state, Ocean_sfc, G, US, patm, press_
   real,        optional, intent(in)    :: press_to_z !< A conversion factor between pressure and ocean
                                                !! depth, usually 1/(rho_0*g) [Z T2 R-1 L-2 ~> m Pa-1]
   ! Local variables
-  real :: IgR0
   character(len=48)  :: val_str
   integer :: isc_bnd, iec_bnd, jsc_bnd, jec_bnd
   integer :: i, j, i0, j0, is, ie, js, je
@@ -989,7 +988,7 @@ subroutine Ocean_stock_pe(OS, index, value, time_index)
   type(ocean_state_type), pointer     :: OS         !< A structure containing the internal ocean state.
                                                     !! The data in OS is intent in.
   integer,                intent(in)  :: index      !< The stock index for the quantity of interest.
-  real,                   intent(out) :: value      !< Sum returned for the conservation quantity of interest.
+  real,                   intent(out) :: value      !< Sum returned for the conservation quantity of interest [various]
   integer,      optional, intent(in)  :: time_index !< An unused optional argument, present only for
                                                     !! interfacial compatibility with other models.
 ! Arguments: OS - A structure containing the internal ocean state.
@@ -997,23 +996,23 @@ subroutine Ocean_stock_pe(OS, index, value, time_index)
 !  (in)      value -  Sum returned for the conservation quantity of interest.
 !  (in,opt)  time_index - Index for time level to use if this is necessary.
 
-  real :: salt
+  real :: salt ! The total salt in the ocean [kg]
 
   value = 0.0
   if (.not.associated(OS)) return
   if (.not.OS%is_ocean_pe) return
 
   select case (index)
-    case (ISTOCK_WATER)  ! Return the mass of fresh water in the ocean in kg.
+    case (ISTOCK_WATER)  ! Return the mass of fresh water in the ocean in [kg].
       if (OS%GV%Boussinesq) then
         call get_ocean_stocks(OS%MOM_CSp, mass=value, on_PE_only=.true.)
       else  ! In non-Boussinesq mode, the mass of salt needs to be subtracted.
         call get_ocean_stocks(OS%MOM_CSp, mass=value, salt=salt, on_PE_only=.true.)
         value = value - salt
       endif
-    case (ISTOCK_HEAT)  ! Return the heat content of the ocean in J.
+    case (ISTOCK_HEAT)  ! Return the heat content of the ocean in [J].
       call get_ocean_stocks(OS%MOM_CSp, heat=value, on_PE_only=.true.)
-    case (ISTOCK_SALT)  ! Return the mass of the salt in the ocean in kg.
+    case (ISTOCK_SALT)  ! Return the mass of the salt in the ocean in [kg].
       call get_ocean_stocks(OS%MOM_CSp, salt=value, on_PE_only=.true.)
     case default ; value = 0.0
   end select
@@ -1032,7 +1031,7 @@ subroutine ocean_model_data2D_get(OS, Ocean, name, array2D, isc, jsc)
                                                   !! visible ocean surface fields.
   character(len=*)          , intent(in) :: name  !< The name of the field to extract
   real, dimension(isc:,jsc:), intent(out):: array2D !< The values of the named field, it must
-                                                  !! cover only the computational domain
+                                                  !! cover only the computational domain [various]
   integer                   , intent(in) :: isc   !< The starting i-index of array2D
   integer                   , intent(in) :: jsc   !< The starting j-index of array2D
 
@@ -1092,8 +1091,8 @@ subroutine ocean_model_data1D_get(OS, Ocean, name, value)
                                                   !! internal ocean state (intent in).
   type(ocean_public_type),    intent(in) :: Ocean !< A structure containing various publicly
                                                   !! visible ocean surface fields.
-  character(len=*)          , intent(in) :: name  !< The name of the field to extract
-  real                      , intent(out):: value !< The value of the named field
+  character(len=*),           intent(in) :: name  !< The name of the field to extract
+  real,                       intent(out):: value !< The value of the named field [various]
 
   if (.not.associated(OS)) return
   if (.not.OS%is_ocean_pe) return
@@ -1155,7 +1154,7 @@ subroutine ocean_model_get_UV_surf(OS, Ocean, name, array2D, isc, jsc)
                                                   !! visible ocean surface fields.
   character(len=*)          , intent(in) :: name  !< The name of the current (ua or va) to extract
   real, dimension(isc:,jsc:), intent(out):: array2D !< The values of the named field, it must
-                                                  !! cover only the computational domain
+                                                  !! cover only the computational domain [L T-1 ~> m s-1]
   integer                   , intent(in) :: isc   !< The starting i-index of array2D
   integer                   , intent(in) :: jsc   !< The starting j-index of array2D
 

--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -73,8 +73,8 @@ type, public :: surface_forcing_CS ; private
   logical :: adiabatic          !< if true, no diapycnal mass fluxes or surface buoyancy forcing
   logical :: variable_winds     !< if true, wind stresses vary with time
   logical :: variable_buoyforce !< if true, buoyancy forcing varies with time.
-  real    :: south_lat          !< southern latitude of the domain
-  real    :: len_lat            !< domain length in latitude
+  real    :: south_lat          !< southern latitude of the domain [degrees_N] or [km] or [m]
+  real    :: len_lat            !< domain length in latitude [degrees_N] or [km] or [m]
 
   real :: Rho0                  !< Boussinesq reference density [R ~> kg m-3]
   real :: G_Earth               !< gravitational acceleration [L2 Z-1 T-2 ~> m s-2]
@@ -104,7 +104,7 @@ type, public :: surface_forcing_CS ; private
   real :: gyres_taux_const   !< A constant wind stress [R L Z T-1 ~> Pa].
   real :: gyres_taux_sin_amp !< The amplitude of cosine wind stress gyres [R L Z T-1 ~> Pa], if WIND_CONFIG=='gyres'
   real :: gyres_taux_cos_amp !< The amplitude of cosine wind stress gyres [R L Z T-1 ~> Pa], if WIND_CONFIG=='gyres'
-  real :: gyres_taux_n_pis   !< The number of sine lobes in the basin if WIND_CONFIG=='gyres'
+  real :: gyres_taux_n_pis   !< The number of sine lobes in the basin if WIND_CONFIG=='gyres' [nondim]
   integer :: answer_date     !< This 8-digit integer gives the approximate date with which the order
                              !! of arithmetic and expressions were added to the code.
                              !! Dates before 20190101 use original answers.

--- a/config_src/drivers/unit_drivers/MOM_sum_driver.F90
+++ b/config_src/drivers/unit_drivers/MOM_sum_driver.F90
@@ -51,7 +51,7 @@ program MOM_sum_driver
   logical :: unit_in_use
 
   real, allocatable, dimension(:) :: &
-    depth_tot_R, depth_tot_std, depth_tot_fastR
+    depth_tot_R, depth_tot_std, depth_tot_fastR ! Various sums of the depths [m]
   integer :: reproClock, fastreproClock, stdClock, initClock
 
   !-----------------------------------------------------------------------
@@ -175,16 +175,17 @@ contains
 subroutine benchmark_init_topog_local(D, G, param_file, max_depth)
   type(dyn_horgrid_type),           intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                                    intent(out) :: D !< Ocean bottom depth in m or [Z ~> m] if US is present
+                                    intent(out) :: D !< Ocean bottom depth in [m]
   type(param_file_type),            intent(in)  :: param_file !< A structure to parse for run-time parameters
   real,                             intent(in)  :: max_depth !< The maximum ocean depth [m]
 
-  real :: min_depth            ! The minimum ocean depth in m.
-  real :: PI                   ! 3.1415926... calculated as 4*atan(1)
-  real :: D0                   ! A constant to make the maximum     !
-                               ! basin depth MAXIMUM_DEPTH.         !
-  real :: m_to_Z  ! A dimensional rescaling factor.
-  real :: x, y
+  real :: min_depth            ! The minimum ocean depth in [m].
+  real :: PI                   ! 3.1415926... calculated as 4*atan(1) [nondim]
+  real :: D0                   ! A constant to make the maximum
+                               ! basin depth MAXIMUM_DEPTH [m]
+  real :: m_to_Z  ! A dimensional rescaling factor [m ~> Z]
+  real :: x ! A fractional position in the x-direction [nondim]
+  real :: y ! A fractional position in the y-direction [nondim]
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "benchmark_init_topog_local" ! This subroutine's name.
@@ -203,8 +204,8 @@ subroutine benchmark_init_topog_local(D, G, param_file, max_depth)
 
 !  Calculate the depth of the bottom.
   do i=is,ie ; do j=js,je
-    x=(G%geoLonT(i,j)-G%west_lon)/G%len_lon
-    y=(G%geoLatT(i,j)-G%south_lat)/G%len_lat
+    x = (G%geoLonT(i,j)-G%west_lon)/G%len_lon
+    y = (G%geoLatT(i,j)-G%south_lat)/G%len_lat
 !  This sets topography that has a reentrant channel to the south.
     D(i,j) = -D0 * ( y*(1.0 + 0.6*cos(4.0*PI*x)) &
                    + 0.75*exp(-6.0*y) &


### PR DESCRIPTION
  Added or amended comments to document the units of 30 variables in FMS_cap/MOM_surface_forcing_gfdl.F90, FMS_cap/ocean_model_MOM.F90, solo_driver/MOM_surface_forcing and unit_drivers/MOM_sum_driver.F90.  Only comments are changed, and all answers are bitwise identical.