### PR TITLE
(*)Fix bug in CVMix_shear_is_used if USE_PP81=True

### DIFF
--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -89,6 +89,7 @@ subroutine find_obsolete_params(param_file)
 
   call obsolete_logical(param_file, "MSTAR_FIXED", hint="Instead use MSTAR_MODE.")
   call obsolete_logical(param_file, "USE_VISBECK_SLOPE_BUG", .false.)
+  call obsolete_logical(param_file, "Use_PP81", hint="get_param is case sensitive so use USE_PP81.")
 
   call obsolete_logical(param_file, "ALLOW_CLOCKS_IN_OMP_LOOPS", .true.)
   call obsolete_logical(param_file, "LARGE_FILE_SUPPORT", .true.)
@@ -114,7 +115,7 @@ subroutine obsolete_logical(param_file, varname, warning_val, hint)
   logical :: test_logic, fatal_err
   character(len=128) :: hint_msg
 
-  test_logic = .false. ; call read_param(param_file, varname,test_logic)
+  test_logic = .false. ; call read_param(param_file, varname, test_logic)
   fatal_err = .true.
   if (present(warning_val)) fatal_err = (warning_val .neqv. .true.)
   hint_msg = " " ; if (present(hint)) hint_msg = hint

--- a/src/parameterizations/vertical/MOM_CVMix_shear.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_shear.F90
@@ -318,7 +318,7 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
 
 end function CVMix_shear_init
 
-!> Reads the parameters "LMD94" and "PP81" and returns state.
+!> Reads the parameters "USE_LMD94" and "USE_PP81" and returns true if either is true.
 !!   This function allows other modules to know whether this parameterization will
 !! be used without needing to duplicate the log entry.
 logical function CVMix_shear_is_used(param_file)
@@ -326,9 +326,9 @@ logical function CVMix_shear_is_used(param_file)
   ! Local variables
   logical :: LMD94, PP81
   call get_param(param_file, mdl, "USE_LMD94", LMD94, &
-       default=.false., do_not_log=.true.)
-  call get_param(param_file, mdl, "Use_PP81", PP81, &
-       default=.false., do_not_log=.true.)
+                 default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "USE_PP81", PP81, &
+                 default=.false., do_not_log=.true.)
   CVMix_shear_is_used = (LMD94 .or. PP81)
 end function CVMix_shear_is_used
 


### PR DESCRIPTION
  Because `get_param()` is case-sensitive, CVMix_shear_is_used will incorrectly return false if USE_PP81 = True and USE_LMD94 = False.  This would cause such cases to fail to reproduce across restarts or use uninitialized or incorrect arrays, but because the Pacanowski and Philader parameterization is very out-dated it appears not to be used in any active test case.  Moreover, no one has reported any such issues yet.  Therefore, rather than adding a flag to reproduce the old (unreproducing) results, this commit simply corrects this bug. All answers are bitwise identical in all known MOM6 configurations, but this could lead to answer changes in certain unlikely configurations.