### PR TITLE
Autoconf configuration of Python

### DIFF
--- a/ac/Makefile.in
+++ b/ac/Makefile.in
@@ -6,6 +6,7 @@
 
 FC = @FC@
 LD = @FC@
+PYTHON = @PYTHON@
 MAKEDEP = @MAKEDEP@
 
 DEFS = @DEFS@
@@ -32,7 +33,7 @@ rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(su
 .PHONY: depend
 depend: Makefile.dep
 Makefile.dep: $(MAKEDEP) $(call rwildcard,$(SRC_DIRS),*.h *.c *.inc *.F90)
-	$(MAKEDEP) -o Makefile.dep -e $(SRC_DIRS)
+	$(PYTHON) $(MAKEDEP) -o Makefile.dep -e $(SRC_DIRS)
 
 
 # Delete any files associated with configuration (including the Makefile).

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -221,6 +221,13 @@ AC_COMPILE_IFELSE(
 )
 
 
+# Verify that Python is available
+AC_PATH_PROGS([PYTHON], [python python3 python2], [
+  AC_MSG_ERROR([Could not find python.])
+])
+AC_ARG_VAR([PYTHON], [Python interpreter command])
+
+
 # Verify that makedep is available
 AC_PATH_PROG([MAKEDEP], [makedep], [${srcdir}/ac/makedep])
 AC_SUBST([MAKEDEP])

--- a/ac/deps/Makefile.fms.in
+++ b/ac/deps/Makefile.fms.in
@@ -8,6 +8,7 @@ CC = @CC@
 FC = @FC@
 LD = @FC@
 AR = @AR@
+PYTHON = @PYTHON@
 MAKEDEP = @MAKEDEP@
 
 DEFS = @DEFS@
@@ -22,4 +23,4 @@ ARFLAGS = @ARFLAGS@
 .PHONY: depend
 depend: Makefile.dep
 Makefile.dep:
-	$(MAKEDEP) -o Makefile.dep -e -x libFMS.a @srcdir@
+	$(PYTHON) $(MAKEDEP) -o Makefile.dep -e -x libFMS.a @srcdir@

--- a/ac/deps/configure.fms.ac
+++ b/ac/deps/configure.fms.ac
@@ -158,7 +158,14 @@ AX_FC_ALLOW_ARG_MISMATCH
 FCFLAGS="$FCFLAGS $ALLOW_ARG_MISMATCH_FCFLAGS"
 
 
-# Verify makedep
+# Verify that Python is available
+AC_PATH_PROGS([PYTHON], [python python3 python2], [
+  AC_MSG_ERROR([Could not find python.])
+])
+AC_ARG_VAR([PYTHON], [Python interpreter command])
+
+
+# Verify that makedep is available
 AC_PATH_PROGS([MAKEDEP], [makedep], [], ["${PATH}:${srcdir}/../../.."])
 AS_IF([test -n "${MAKEDEP}"], [
   AC_SUBST([MAKEDEP])


### PR DESCRIPTION
The introduction of makedep means that Python is now a dependency of the MOM6 compilation.  On some systems, we cannot assume that `python` is the name of the interpreter, and strictly should not even assume that it exists.

This is notably an issue on the recent MacOS M1 systems, which use `python3` as its interpreter, and do not provide one named `python`.

This patch adds macros to the MOM6 and FMS autoconf builds to detect if Python is on the system, and makes a few attempts to determine the name of the interpreter (python, python3, python2).  Perhaps more can be done here, but this is probably sufficient in nearly all cases.