### PR TITLE
(*)Fix a bug with BULKMIXEDLAYER & ML_MIX_FIRST>0

### DIFF
--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1783,6 +1783,7 @@ subroutine layered_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_e
         call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt*CS%ML_mix_first, &
                             eaml, ebml, G, GV, US, CS%bulkmixedlayer, CS%optics, &
                             Hml, CS%aggregate_FW_forcing, dt, last_call=.false.)
+      else
         ! Changes: h, tv%T, tv%S, eaml and ebml  (G is also inout???)
         call bulkmixedlayer(h, u_h, v_h, tv, fluxes, dt, eaml, ebml, &
                             G, GV, US, CS%bulkmixedlayer, CS%optics, &


### PR DESCRIPTION
  Restored an else that was inadvertently deleted as a part of code clean up in MOM-ocean/MOM6 PR #1127 on June 5, 2020.  This bug causes bulkmixedlayer to be called twice (with cumulative effects) when 0. < ML_MIX_FIRST < 1., and not to be called at all when ML_MIX_FIRST = 1.  This bug only applies to cases where the bulk mixed layer is enabled by setting BULKMIXEDLAYER=True and USE_REGRIDDING=False (i.e., in layered mode configurations with active thermodynamics), however because the default value of ML_MIX_FIRST = 0, this bug does not appear to be used in any active test cases, and it went undetected when it was introduced.  All answers in the MOM6-examples test suite are bitwise identical, but this could change answers in some cases.