### PR TITLE
*+Refactor, correct and augment the MOM6 EoS code

### DIFF
--- a/src/core/MOM_unit_tests.F90
+++ b/src/core/MOM_unit_tests.F90
@@ -11,6 +11,7 @@ use MOM_neutral_diffusion,          only : neutral_diffusion_unit_tests
 use MOM_random,                     only : random_unit_tests
 use MOM_lateral_boundary_diffusion, only : near_boundary_unit_tests
 use MOM_CFC_cap,                    only : CFC_cap_unit_tests
+use MOM_EOS,                        only : EOS_unit_tests
 implicit none ; private
 
 public unit_tests
@@ -30,6 +31,8 @@ subroutine unit_tests(verbosity)
   if (is_root_pe()) then ! The following need only be tested on 1 PE
     if (string_functions_unit_tests(verbose)) call MOM_error(FATAL, &
        "MOM_unit_tests: string_functions_unit_tests FAILED")
+    if (EOS_unit_tests(verbose)) call MOM_error(FATAL, &
+       "MOM_unit_tests: EOS_unit_tests FAILED")
     if (remapping_unit_tests(verbose)) call MOM_error(FATAL, &
        "MOM_unit_tests: remapping_unit_tests FAILED")
     if (neutral_diffusion_unit_tests(verbose)) call MOM_error(FATAL, &

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -27,7 +27,7 @@ use MOM_EOS_Jackett06, only : calculate_density_Jackett06, calculate_spec_vol_Ja
 use MOM_EOS_Jackett06, only : calculate_density_derivs_Jackett06, calculate_specvol_derivs_Jackett06
 use MOM_EOS_Jackett06, only : calculate_compress_Jackett06, calculate_density_second_derivs_Jackett06
 use MOM_EOS_UNESCO, only : calculate_density_unesco, calculate_spec_vol_unesco
-use MOM_EOS_UNESCO, only : calculate_density_derivs_unesco, calculate_density_unesco
+use MOM_EOS_UNESCO, only : calculate_density_derivs_unesco, calculate_specvol_derivs_UNESCO
 use MOM_EOS_UNESCO, only : calculate_density_second_derivs_UNESCO, calculate_compress_unesco
 use MOM_EOS_NEMO,   only : calculate_density_nemo
 use MOM_EOS_NEMO,   only : calculate_density_derivs_nemo
@@ -331,7 +331,7 @@ subroutine calculate_density_array(T, S, pressure, rho, start, npts, EOS, rho_re
       call calculate_density_linear(T, S, pressure, rho, start, npts, &
                                     EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS, rho_ref)
     case (EOS_UNESCO)
-      call calculate_density_unesco(T, S, pressure, rho, start, npts, rho_ref)
+      call calculate_density_UNESCO(T, S, pressure, rho, start, npts, rho_ref)
     case (EOS_WRIGHT)
       call calculate_density_wright(T, S, pressure, rho, start, npts, rho_ref)
     case (EOS_WRIGHT_FULL)
@@ -636,7 +636,7 @@ subroutine calculate_spec_vol_array(T, S, pressure, specvol, start, npts, EOS, s
       call calculate_spec_vol_linear(T, S, pressure, specvol, start, npts, &
                EOS%rho_T0_S0, EOS%drho_dT, EOS%drho_dS, spv_ref)
     case (EOS_UNESCO)
-      call calculate_spec_vol_unesco(T, S, pressure, specvol, start, npts, spv_ref)
+      call calculate_spec_vol_UNESCO(T, S, pressure, specvol, start, npts, spv_ref)
     case (EOS_WRIGHT)
       call calculate_spec_vol_wright(T, S, pressure, specvol, start, npts, spv_ref)
     case (EOS_WRIGHT_FULL)
@@ -931,7 +931,7 @@ subroutine calculate_density_derivs_array(T, S, pressure, drho_dT, drho_dS, star
       call calculate_density_derivs_linear(T, S, pressure, drho_dT, drho_dS, EOS%Rho_T0_S0, &
                                            EOS%dRho_dT, EOS%dRho_dS, start, npts)
     case (EOS_UNESCO)
-      call calculate_density_derivs_unesco(T, S, pressure, drho_dT, drho_dS, start, npts)
+      call calculate_density_derivs_UNESCO(T, S, pressure, drho_dT, drho_dS, start, npts)
     case (EOS_WRIGHT)
       call calculate_density_derivs_wright(T, S, pressure, drho_dT, drho_dS, start, npts)
     case (EOS_WRIGHT_FULL)
@@ -1333,12 +1333,7 @@ subroutine calculate_spec_vol_derivs_array(T, S, pressure, dSV_dT, dSV_dS, start
       call calculate_specvol_derivs_linear(T, S, pressure, dSV_dT, dSV_dS, start, &
                                            npts, EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS)
     case (EOS_UNESCO)
-      call calculate_density_unesco(T, S, pressure, rho, start, npts)
-      call calculate_density_derivs_unesco(T, S, pressure, drho_dT, drho_dS, start, npts)
-      do j=start,start+npts-1
-        dSV_dT(j) = -dRho_DT(j)/(rho(j)**2)
-        dSV_dS(j) = -dRho_DS(j)/(rho(j)**2)
-      enddo
+      call calculate_specvol_derivs_UNESCO(T, S, pressure, dSV_dT, dSV_dS, start, npts)
     case (EOS_WRIGHT)
       call calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start, npts)
     case (EOS_WRIGHT_FULL)
@@ -1455,7 +1450,7 @@ subroutine calculate_compress_1d(T, S, pressure, rho, drho_dp, EOS, dom)
       call calculate_compress_linear(Ta, Sa, pres, rho, drho_dp, is, npts, &
                                      EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS)
     case (EOS_UNESCO)
-      call calculate_compress_unesco(Ta, Sa, pres, rho, drho_dp, is, npts)
+      call calculate_compress_UNESCO(Ta, Sa, pres, rho, drho_dp, is, npts)
     case (EOS_WRIGHT)
       call calculate_compress_wright(Ta, Sa, pres, rho, drho_dp, is, npts)
     case (EOS_WRIGHT_FULL)

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -28,6 +28,7 @@ use MOM_EOS_UNESCO, only : calculate_density_derivs_unesco, calculate_density_un
 use MOM_EOS_UNESCO, only : calculate_compress_unesco
 use MOM_EOS_NEMO,   only : calculate_density_nemo
 use MOM_EOS_NEMO,   only : calculate_density_derivs_nemo, calculate_density_nemo
+use MOM_EOS_NEMO,   only : calculate_density_second_derivs_NEMO
 use MOM_EOS_NEMO,   only : calculate_compress_nemo
 use MOM_EOS_TEOS10, only : calculate_density_teos10, calculate_spec_vol_teos10
 use MOM_EOS_TEOS10, only : calculate_density_derivs_teos10
@@ -267,8 +268,8 @@ subroutine calculate_stanley_density_scalar(T, S, pressure, Tvar, TScov, Svar, r
       call MOM_error(FATAL, "calculate_stanley_density_scalar: "//&
                      "EOS_UNESCO is not set up to calculate second derivatives yet.")
     case (EOS_NEMO)
-      call MOM_error(FATAL, "calculate_stanley_density_scalar: "//&
-                     "EOS_NEMO is not set up to calculate second derivatives yet.")
+      call calculate_density_second_derivs_NEMO(T_scale*T, S_scale*S, p_scale*pressure, &
+                                                  d2RdSS, d2RdST, d2RdTT, d2RdSp, d2RdTP)
     case (EOS_TEOS10)
       call calculate_density_second_derivs_teos10(T_scale*T, S_scale*S, p_scale*pressure, &
                                                   d2RdSS, d2RdST, d2RdTT, d2RdSp, d2RdTP)
@@ -377,8 +378,8 @@ subroutine calculate_stanley_density_array(T, S, pressure, Tvar, TScov, Svar, rh
                      "EOS_UNESCO is not set up to calculate second derivatives yet.")
     case (EOS_NEMO)
       call calculate_density_NEMO(T, S, pressure, rho, start, npts, rho_ref)
-      call MOM_error(FATAL, "calculate_stanley_density_array: "//&
-                     "EOS_NEMO is not set up to calculate second derivatives yet.")
+      call calculate_density_second_derivs_NEMO(T, S, pressure, d2RdSS, d2RdST, &
+                                                  d2RdTT, d2RdSp, d2RdTP, start, npts)
     case (EOS_TEOS10)
       call calculate_density_teos10(T, S, pressure, rho, start, npts, rho_ref)
       call calculate_density_second_derivs_teos10(T, S, pressure, d2RdSS, d2RdST, &
@@ -531,8 +532,8 @@ subroutine calculate_stanley_density_1d(T, S, pressure, Tvar, TScov, Svar, rho, 
                      "EOS_UNESCO is not set up to calculate second derivatives yet.")
     case (EOS_NEMO)
       call calculate_density_NEMO(Ta, Sa, pres, rho, is, npts, rho_reference)
-      call MOM_error(FATAL, "calculate_stanley_density_1d: "//&
-                     "EOS_NEMO is not set up to calculate second derivatives yet.")
+      call calculate_density_second_derivs_NEMO(Ta, Sa, pres, d2RdSS, d2RdST, &
+                                                  d2RdTT, d2RdSp, d2RdTP, is, npts)
     case (EOS_TEOS10)
       call calculate_density_teos10(Ta, Sa, pres, rho, is, npts, rho_reference)
       call calculate_density_second_derivs_teos10(Ta, Sa, pres, d2RdSS, d2RdST, &
@@ -1054,8 +1055,8 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
         call MOM_error(FATAL, "calculate_density_second_derivs: "//&
                        "EOS_UNESCO is not set up to calculate second derivatives yet.")
       case (EOS_NEMO)
-        call MOM_error(FATAL, "calculate_density_second_derivs: "//&
-                       "EOS_NEMO is not set up to calculate second derivatives yet.")
+        call calculate_density_second_derivs_NEMO(T, S, pressure, drho_dS_dS, drho_dS_dT, &
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_TEOS10)
         call calculate_density_second_derivs_teos10(T, S, pressure, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
@@ -1085,8 +1086,8 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
         call MOM_error(FATAL, "calculate_density_second_derivs: "//&
                        "EOS_UNESCO is not set up to calculate second derivatives yet.")
       case (EOS_NEMO)
-        call MOM_error(FATAL, "calculate_density_second_derivs: "//&
-                       "EOS_NEMO is not set up to calculate second derivatives yet.")
+        call calculate_density_second_derivs_NEMO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_TEOS10)
         call calculate_density_second_derivs_teos10(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
@@ -1170,8 +1171,8 @@ subroutine calculate_density_second_derivs_scalar(T, S, pressure, drho_dS_dS, dr
       call MOM_error(FATAL, "calculate_density_second_derivs: "//&
                      "EOS_UNESCO is not set up to calculate second derivatives yet.")
     case (EOS_NEMO)
-      call MOM_error(FATAL, "calculate_density_second_derivs: "//&
-                     "EOS_NEMO is not set up to calculate second derivatives yet.")
+      call calculate_density_second_derivs_NEMO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
+                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
     case (EOS_TEOS10)
       call calculate_density_second_derivs_teos10(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                   drho_dT_dT, drho_dS_dP, drho_dT_dP)
@@ -2008,12 +2009,11 @@ logical function EOS_unit_tests(verbose)
   if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT EOS has failed some self-consistency tests.")
   EOS_unit_tests = EOS_unit_tests .or. fail
 
-  ! The NEMO equation of state is not passing some self consistency tests yet.
-  ! call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_NEMO)
-  ! fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "NEMO", &
-  !                             rho_check=1027.4238566366823*EOS_tmp%kg_m3_to_R)
-  ! if (verbose .and. fail) call MOM_error(WARNING, "NEMO EOS has failed some self-consistency tests.")
-  ! EOS_unit_tests = EOS_unit_tests .or. fail
+  call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_NEMO)
+  fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "NEMO", &
+                              rho_check=1027.4238566366823*EOS_tmp%kg_m3_to_R)
+  if (verbose .and. fail) call MOM_error(WARNING, "NEMO EOS has failed some self-consistency tests.")
+  EOS_unit_tests = EOS_unit_tests .or. fail
 
   ! The TEOS10 equation of state is not passing some self consistency tests yet.
   ! call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_TEOS10)

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -58,8 +58,6 @@ use MOM_unit_scaling, only : unit_scale_type
 
 implicit none ; private
 
-#include <MOM_memory.h>
-
 public EOS_domain
 public EOS_init
 public EOS_manual_init

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -174,9 +174,9 @@ integer, parameter, public :: EOS_LINEAR = 1 !< A named integer specifying an eq
 integer, parameter, public :: EOS_UNESCO = 2 !< A named integer specifying an equation of state
 integer, parameter, public :: EOS_WRIGHT = 3 !< A named integer specifying an equation of state
 integer, parameter, public :: EOS_WRIGHT_FULL = 4 !< A named integer specifying an equation of state
-integer, parameter, public :: EOS_WRIGHT_RED = 5 !< A named integer specifying an equation of state
+integer, parameter, public :: EOS_WRIGHT_REDUCED = 5 !< A named integer specifying an equation of state
 integer, parameter, public :: EOS_TEOS10 = 6 !< A named integer specifying an equation of state
-integer, parameter, public :: EOS_ROQUET_RHO   = 7 !< A named integer specifying an equation of state
+integer, parameter, public :: EOS_ROQUET_RHO = 7 !< A named integer specifying an equation of state
 integer, parameter, public :: EOS_ROQUET_SPV = 8 !< A named integer specifying an equation of state
 integer, parameter, public :: EOS_JACKETT06 = 9 !< A named integer specifying an equation of state
 
@@ -184,7 +184,7 @@ character*(12), parameter :: EOS_LINEAR_STRING = "LINEAR" !< A string for specif
 character*(12), parameter :: EOS_UNESCO_STRING = "UNESCO" !< A string for specifying the equation of state
 character*(12), parameter :: EOS_JACKETT_STRING = "JACKETT_MCD" !< A string for specifying the equation of state
 character*(12), parameter :: EOS_WRIGHT_STRING = "WRIGHT" !< A string for specifying the equation of state
-character*(12), parameter :: EOS_WRIGHT_RED_STRING = "WRIGHT_RED" !< A string for specifying the equation of state
+character*(16), parameter :: EOS_WRIGHT_RED_STRING = "WRIGHT_REDUCED" !< A string for specifying the equation of state
 character*(12), parameter :: EOS_WRIGHT_FULL_STRING = "WRIGHT_FULL" !< A string for specifying the equation of state
 character*(12), parameter :: EOS_TEOS10_STRING = "TEOS10" !< A string for specifying the equation of state
 character*(12), parameter :: EOS_NEMO_STRING   = "NEMO"   !< A string for specifying the equation of state
@@ -302,7 +302,7 @@ subroutine calculate_density_array(T, S, pressure, rho, start, npts, EOS, rho_re
       call calculate_density_wright(T, S, pressure, rho, start, npts, rho_ref)
     case (EOS_WRIGHT_FULL)
       call calculate_density_wright_full(T, S, pressure, rho, start, npts, rho_ref)
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       call calculate_density_wright_red(T, S, pressure, rho, start, npts, rho_ref)
     case (EOS_TEOS10)
       call calculate_density_teos10(T, S, pressure, rho, start, npts, rho_ref)
@@ -449,7 +449,7 @@ subroutine calculate_spec_vol_array(T, S, pressure, specvol, start, npts, EOS, s
       call calculate_spec_vol_wright(T, S, pressure, specvol, start, npts, spv_ref)
     case (EOS_WRIGHT_FULL)
       call calculate_spec_vol_wright_full(T, S, pressure, specvol, start, npts, spv_ref)
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       call calculate_spec_vol_wright_red(T, S, pressure, specvol, start, npts, spv_ref)
     case (EOS_TEOS10)
       call calculate_spec_vol_teos10(T, S, pressure, specvol, start, npts, spv_ref)
@@ -754,7 +754,7 @@ subroutine calculate_density_derivs_array(T, S, pressure, drho_dT, drho_dS, star
       call calculate_density_derivs_wright(T, S, pressure, drho_dT, drho_dS, start, npts)
     case (EOS_WRIGHT_FULL)
       call calculate_density_derivs_wright_full(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       call calculate_density_derivs_wright_red(T, S, pressure, drho_dT, drho_dS, start, npts)
     case (EOS_TEOS10)
       call calculate_density_derivs_teos10(T, S, pressure, drho_dT, drho_dS, start, npts)
@@ -865,7 +865,7 @@ subroutine calculate_density_derivs_scalar(T, S, pressure, drho_dT, drho_dS, EOS
       call calculate_density_derivs_wright(Ta(1), Sa(1), pres(1),drho_dT, drho_dS)
     case (EOS_WRIGHT_FULL)
       call calculate_density_derivs_wright_full(Ta(1), Sa(1), pres(1),drho_dT, drho_dS)
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       call calculate_density_derivs_wright_red(Ta(1), Sa(1), pres(1),drho_dT, drho_dS)
     case (EOS_TEOS10)
       call calculate_density_derivs_teos10(Ta(1), Sa(1), pres(1), drho_dT, drho_dS)
@@ -938,7 +938,7 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
       case (EOS_WRIGHT_FULL)
         call calculate_density_second_derivs_wright_full(T, S, pressure, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_WRIGHT_RED)
+      case (EOS_WRIGHT_REDUCED)
         call calculate_density_second_derivs_wright_red(T, S, pressure, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_UNESCO)
@@ -980,7 +980,7 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
       case (EOS_WRIGHT_FULL)
         call calculate_density_second_derivs_wright_full(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_WRIGHT_RED)
+      case (EOS_WRIGHT_REDUCED)
         call calculate_density_second_derivs_wright_red(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_UNESCO)
@@ -1076,7 +1076,7 @@ subroutine calculate_density_second_derivs_scalar(T, S, pressure, drho_dS_dS, dr
     case (EOS_WRIGHT_FULL)
       call calculate_density_second_derivs_wright_full(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                   drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       call calculate_density_second_derivs_wright_red(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                   drho_dT_dT, drho_dS_dP, drho_dT_dP)
     case (EOS_UNESCO)
@@ -1156,7 +1156,7 @@ subroutine calculate_spec_vol_derivs_array(T, S, pressure, dSV_dT, dSV_dS, start
       call calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start, npts)
     case (EOS_WRIGHT_FULL)
       call calculate_specvol_derivs_wright_full(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       call calculate_specvol_derivs_wright_red(T, S, pressure, dSV_dT, dSV_dS, start, npts)
     case (EOS_TEOS10)
       call calculate_specvol_derivs_teos10(T, S, pressure, dSV_dT, dSV_dS, start, npts)
@@ -1273,7 +1273,7 @@ subroutine calculate_compress_1d(T, S, pressure, rho, drho_dp, EOS, dom)
       call calculate_compress_wright(Ta, Sa, pres, rho, drho_dp, is, npts)
     case (EOS_WRIGHT_FULL)
       call calculate_compress_wright_full(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       call calculate_compress_wright_red(Ta, Sa, pres, rho, drho_dp, is, npts)
     case (EOS_TEOS10)
       call calculate_compress_teos10(Ta, Sa, pres, rho, drho_dp, is, npts)
@@ -1345,7 +1345,7 @@ subroutine EoS_fit_range(EOS, T_min, T_max, S_min, S_max, p_min, p_max)
       call EoS_fit_range_Wright(T_min, T_max, S_min, S_max, p_min, p_max)
     case (EOS_WRIGHT_FULL)
       call EoS_fit_range_Wright_full(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       call EoS_fit_range_Wright_red(T_min, T_max, S_min, S_max, p_min, p_max)
     case (EOS_TEOS10)
       call EoS_fit_range_TEOS10(T_min, T_max, S_min, S_max, p_min, p_max)
@@ -1453,7 +1453,7 @@ subroutine analytic_int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
                                   inty_dza, halo_size, bathyP, dP_tiny, useMassWghtInterp, &
                                   SV_scale=EOS%R_to_kg_m3, pres_scale=EOS%RL2_T2_to_Pa, &
                                   temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt)
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       call int_spec_vol_dp_wright_red(T, S, p_t, p_b, alpha_ref, HI, dza, intp_dza, intx_dza, &
                                   inty_dza, halo_size, bathyP, dP_tiny, useMassWghtInterp, &
                                   SV_scale=EOS%R_to_kg_m3, pres_scale=EOS%RL2_T2_to_Pa, &
@@ -1560,7 +1560,7 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
                                    dz_neglect, useMassWghtInterp, Z_0p=Z_0p)
       endif
-    case (EOS_WRIGHT_RED)
+    case (EOS_WRIGHT_REDUCED)
       rho_scale = EOS%kg_m3_to_R
       pres_scale = EOS%RL2_T2_to_Pa
       if ((rho_scale /= 1.0) .or. (pres_scale /= 1.0) .or. (EOS%C_to_degC /= 1.0) .or. (EOS%S_to_ppt /= 1.0)) then
@@ -1606,7 +1606,7 @@ subroutine EOS_init(param_file, EOS, US)
   call get_param(param_file, mdl, "EQN_OF_STATE", tmpstr, &
                  "EQN_OF_STATE determines which ocean equation of state should be used.  "//&
                  'Currently, the valid choices are "LINEAR", "UNESCO", "JACKETT_MCD", '//&
-                 '"WRIGHT", "WRIGHT_RED", "WRIGHT_FULL", "NEMO", "ROQUET_RHO", "ROQUET_SPV" '//&
+                 '"WRIGHT", "WRIGHT_REDUCED", "WRIGHT_FULL", "NEMO", "ROQUET_RHO", "ROQUET_SPV" '//&
                  'and "TEOS10".  This is only used if USE_EOS is true.', default=EOS_DEFAULT)
   select case (uppercase(tmpstr))
     case (EOS_LINEAR_STRING)
@@ -1618,7 +1618,7 @@ subroutine EOS_init(param_file, EOS, US)
     case (EOS_WRIGHT_STRING)
       EOS%form_of_EOS = EOS_WRIGHT
     case (EOS_WRIGHT_RED_STRING)
-      EOS%form_of_EOS = EOS_WRIGHT_RED
+      EOS%form_of_EOS = EOS_WRIGHT_REDUCED
     case (EOS_WRIGHT_FULL_STRING)
       EOS%form_of_EOS = EOS_WRIGHT_FULL
     case (EOS_TEOS10_STRING)
@@ -1661,7 +1661,7 @@ subroutine EOS_init(param_file, EOS, US)
 
   EOS_quad_default = .not.((EOS%form_of_EOS == EOS_LINEAR) .or. &
                            (EOS%form_of_EOS == EOS_WRIGHT) .or. &
-                           (EOS%form_of_EOS == EOS_WRIGHT_RED) .or. &
+                           (EOS%form_of_EOS == EOS_WRIGHT_REDUCED) .or. &
                            (EOS%form_of_EOS == EOS_WRIGHT_FULL))
   call get_param(param_file, mdl, "EOS_QUADRATURE", EOS%EOS_quadrature, &
                  "If true, always use the generic (quadrature) code "//&
@@ -2061,17 +2061,17 @@ logical function EOS_unit_tests(verbose)
   if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT_FULL EOS has failed some self-consistency tests.")
   EOS_unit_tests = EOS_unit_tests .or. fail
 
-  call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_WRIGHT_RED)
-  fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "WRIGHT_RED", &
+  call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_WRIGHT_REDUCED)
+  fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "WRIGHT_REDUCED", &
                               rho_check=1027.54303596346*EOS_tmp%kg_m3_to_R)
-  if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT_RED EOS has failed some self-consistency tests.")
+  if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT_REDUCED EOS has failed some self-consistency tests.")
   EOS_unit_tests = EOS_unit_tests .or. fail
 
-  ! This test is deliberately outside of the fit range for WRIGHT_RED, and it results in the expected warnings.
-  ! call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_WRIGHT_RED)
-  ! fail = test_EOS_consistency(25.0, 15.0, 1.0e7, EOS_tmp, verbose, "WRIGHT_RED", &
+  ! This test is deliberately outside of the fit range for WRIGHT_REDUCED, and it results in the expected warnings.
+  ! call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_WRIGHT_REDUCED)
+  ! fail = test_EOS_consistency(25.0, 15.0, 1.0e7, EOS_tmp, verbose, "WRIGHT_REDUCED", &
   !                             rho_check=1012.625699301455*EOS_tmp%kg_m3_to_R)
-  ! if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT_RED EOS has failed some self-consistency tests.")
+  ! if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT_REDUCED EOS has failed some self-consistency tests.")
   ! EOS_unit_tests = EOS_unit_tests .or. fail
 
   call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_WRIGHT)

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -34,10 +34,10 @@ use MOM_EOS_UNESCO, only : calculate_density_unesco, calculate_spec_vol_unesco
 use MOM_EOS_UNESCO, only : calculate_density_derivs_unesco, calculate_specvol_derivs_UNESCO
 use MOM_EOS_UNESCO, only : calculate_density_second_derivs_UNESCO, calculate_compress_unesco
 use MOM_EOS_UNESCO, only : EoS_fit_range_UNESCO
-use MOM_EOS_NEMO,   only : calculate_density_nemo
-use MOM_EOS_NEMO,   only : calculate_density_derivs_nemo
-use MOM_EOS_NEMO,   only : calculate_density_second_derivs_NEMO, calculate_compress_nemo
-use MOM_EOS_NEMO,   only : EoS_fit_range_NEMO
+use MOM_EOS_Roquet_rho, only : calculate_density_Roquet_rho
+use MOM_EOS_Roquet_rho, only : calculate_density_derivs_Roquet_rho
+use MOM_EOS_Roquet_rho, only : calculate_density_second_derivs_Roquet_rho, calculate_compress_Roquet_rho
+use MOM_EOS_Roquet_rho, only : EoS_fit_range_Roquet_rho
 use MOM_EOS_Roquet_SpV, only : calculate_density_Roquet_SpV, calculate_spec_vol_Roquet_SpV
 use MOM_EOS_Roquet_SpV, only : calculate_density_derivs_Roquet_SpV, calculate_specvol_derivs_Roquet_SpV
 use MOM_EOS_Roquet_SpV, only : calculate_compress_Roquet_SpV, calculate_density_second_derivs_Roquet_SpV
@@ -177,7 +177,7 @@ integer, parameter, public :: EOS_WRIGHT = 3 !< A named integer specifying an eq
 integer, parameter, public :: EOS_WRIGHT_FULL = 4 !< A named integer specifying an equation of state
 integer, parameter, public :: EOS_WRIGHT_RED = 5 !< A named integer specifying an equation of state
 integer, parameter, public :: EOS_TEOS10 = 6 !< A named integer specifying an equation of state
-integer, parameter, public :: EOS_NEMO   = 7 !< A named integer specifying an equation of state
+integer, parameter, public :: EOS_ROQUET_RHO   = 7 !< A named integer specifying an equation of state
 integer, parameter, public :: EOS_ROQUET_SPV = 8 !< A named integer specifying an equation of state
 integer, parameter, public :: EOS_JACKETT06 = 9 !< A named integer specifying an equation of state
 
@@ -293,8 +293,8 @@ subroutine calculate_stanley_density_scalar(T, S, pressure, Tvar, TScov, Svar, r
     case (EOS_UNESCO)
       call calculate_density_second_derivs_UNESCO(T_scale*T, S_scale*S, p_scale*pressure, &
                                                   d2RdSS, d2RdST, d2RdTT, d2RdSp, d2RdTP)
-    case (EOS_NEMO)
-      call calculate_density_second_derivs_NEMO(T_scale*T, S_scale*S, p_scale*pressure, &
+    case (EOS_ROQUET_RHO)
+      call calculate_density_second_derivs_Roquet_rho(T_scale*T, S_scale*S, p_scale*pressure, &
                                                   d2RdSS, d2RdST, d2RdTT, d2RdSp, d2RdTP)
     case (EOS_ROQUET_SPV)
       call calculate_density_second_derivs_Roquet_SpV(T_scale*T, S_scale*S, p_scale*pressure, &
@@ -347,8 +347,8 @@ subroutine calculate_density_array(T, S, pressure, rho, start, npts, EOS, rho_re
       call calculate_density_wright_red(T, S, pressure, rho, start, npts, rho_ref)
     case (EOS_TEOS10)
       call calculate_density_teos10(T, S, pressure, rho, start, npts, rho_ref)
-    case (EOS_NEMO)
-      call calculate_density_nemo(T, S, pressure, rho, start, npts, rho_ref)
+    case (EOS_ROQUET_RHO)
+      call calculate_density_Roquet_rho(T, S, pressure, rho, start, npts, rho_ref)
     case (EOS_ROQUET_SPV)
       call calculate_density_Roquet_SpV(T, S, pressure, rho, start, npts, rho_ref)
     case (EOS_JACKETT06)
@@ -418,9 +418,9 @@ subroutine calculate_stanley_density_array(T, S, pressure, Tvar, TScov, Svar, rh
       call calculate_density_UNESCO(T, S, pressure, rho, start, npts, rho_ref)
       call calculate_density_second_derivs_UNESCO(T, S, pressure, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP, start, npts)
-    case (EOS_NEMO)
-      call calculate_density_NEMO(T, S, pressure, rho, start, npts, rho_ref)
-      call calculate_density_second_derivs_NEMO(T, S, pressure, d2RdSS, d2RdST, &
+    case (EOS_ROQUET_RHO)
+      call calculate_density_Roquet_rho(T, S, pressure, rho, start, npts, rho_ref)
+      call calculate_density_second_derivs_Roquet_rho(T, S, pressure, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP, start, npts)
     case (EOS_ROQUET_SPV)
       call calculate_density_Roquet_SpV(T, S, pressure, rho, start, npts, rho_ref)
@@ -586,9 +586,9 @@ subroutine calculate_stanley_density_1d(T, S, pressure, Tvar, TScov, Svar, rho, 
       call calculate_density_UNESCO(Ta, Sa, pres, rho, is, npts, rho_reference)
       call calculate_density_second_derivs_UNESCO(Ta, Sa, pres, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP, is, npts)
-    case (EOS_NEMO)
-      call calculate_density_NEMO(Ta, Sa, pres, rho, is, npts, rho_reference)
-      call calculate_density_second_derivs_NEMO(Ta, Sa, pres, d2RdSS, d2RdST, &
+    case (EOS_ROQUET_RHO)
+      call calculate_density_Roquet_rho(Ta, Sa, pres, rho, is, npts, rho_reference)
+      call calculate_density_second_derivs_Roquet_rho(Ta, Sa, pres, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP, is, npts)
     case (EOS_ROQUET_SPV)
       call calculate_density_Roquet_SpV(Ta, Sa, pres, rho, is, npts, rho_reference)
@@ -652,8 +652,8 @@ subroutine calculate_spec_vol_array(T, S, pressure, specvol, start, npts, EOS, s
       call calculate_spec_vol_wright_red(T, S, pressure, specvol, start, npts, spv_ref)
     case (EOS_TEOS10)
       call calculate_spec_vol_teos10(T, S, pressure, specvol, start, npts, spv_ref)
-    case (EOS_NEMO)
-      call calculate_density_nemo(T, S, pressure, rho, start, npts)
+    case (EOS_ROQUET_RHO)
+      call calculate_density_Roquet_rho(T, S, pressure, rho, start, npts)
       if (present(spv_ref)) then
         specvol(:) = 1.0 / rho(:) - spv_ref
       else
@@ -947,8 +947,8 @@ subroutine calculate_density_derivs_array(T, S, pressure, drho_dT, drho_dS, star
       call calculate_density_derivs_wright_red(T, S, pressure, drho_dT, drho_dS, start, npts)
     case (EOS_TEOS10)
       call calculate_density_derivs_teos10(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case (EOS_NEMO)
-      call calculate_density_derivs_nemo(T, S, pressure, drho_dT, drho_dS, start, npts)
+    case (EOS_ROQUET_RHO)
+      call calculate_density_derivs_Roquet_rho(T, S, pressure, drho_dT, drho_dS, start, npts)
     case (EOS_ROQUET_SPV)
       call calculate_density_derivs_Roquet_SpV(T, S, pressure, drho_dT, drho_dS, start, npts)
     case (EOS_JACKETT06)
@@ -1133,8 +1133,8 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
       case (EOS_UNESCO)
         call calculate_density_second_derivs_UNESCO(T, S, pressure, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_NEMO)
-        call calculate_density_second_derivs_NEMO(T, S, pressure, drho_dS_dS, drho_dS_dT, &
+      case (EOS_ROQUET_RHO)
+        call calculate_density_second_derivs_Roquet_rho(T, S, pressure, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_ROQUET_SPV)
         call calculate_density_second_derivs_Roquet_SpV(T, S, pressure, drho_dS_dS, drho_dS_dT, &
@@ -1175,8 +1175,8 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
       case (EOS_UNESCO)
         call calculate_density_second_derivs_UNESCO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_NEMO)
-        call calculate_density_second_derivs_NEMO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
+      case (EOS_ROQUET_RHO)
+        call calculate_density_second_derivs_Roquet_rho(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_ROQUET_SpV)
         call calculate_density_second_derivs_Roquet_SpV(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
@@ -1271,8 +1271,8 @@ subroutine calculate_density_second_derivs_scalar(T, S, pressure, drho_dS_dS, dr
     case (EOS_UNESCO)
       call calculate_density_second_derivs_UNESCO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                   drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case (EOS_NEMO)
-      call calculate_density_second_derivs_NEMO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
+    case (EOS_ROQUET_RHO)
+      call calculate_density_second_derivs_Roquet_rho(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                   drho_dT_dT, drho_dS_dP, drho_dT_dP)
     case (EOS_ROQUET_SPV)
       call calculate_density_second_derivs_Roquet_SpV(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
@@ -1349,9 +1349,9 @@ subroutine calculate_spec_vol_derivs_array(T, S, pressure, dSV_dT, dSV_dS, start
       call calculate_specvol_derivs_wright_red(T, S, pressure, dSV_dT, dSV_dS, start, npts)
     case (EOS_TEOS10)
       call calculate_specvol_derivs_teos10(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-    case (EOS_NEMO)
-      call calculate_density_nemo(T, S, pressure, rho, start, npts)
-      call calculate_density_derivs_nemo(T, S, pressure, drho_dT, drho_dS, start, npts)
+    case (EOS_ROQUET_RHO)
+      call calculate_density_Roquet_rho(T, S, pressure, rho, start, npts)
+      call calculate_density_derivs_Roquet_rho(T, S, pressure, drho_dT, drho_dS, start, npts)
       do j=start,start+npts-1
         dSV_dT(j) = -dRho_DT(j)/(rho(j)**2)
         dSV_dS(j) = -dRho_DS(j)/(rho(j)**2)
@@ -1466,8 +1466,8 @@ subroutine calculate_compress_1d(T, S, pressure, rho, drho_dp, EOS, dom)
       call calculate_compress_wright_red(Ta, Sa, pres, rho, drho_dp, is, npts)
     case (EOS_TEOS10)
       call calculate_compress_teos10(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case (EOS_NEMO)
-      call calculate_compress_nemo(Ta, Sa, pres, rho, drho_dp, is, npts)
+    case (EOS_ROQUET_RHO)
+      call calculate_compress_Roquet_rho(Ta, Sa, pres, rho, drho_dp, is, npts)
     case (EOS_ROQUET_SpV)
       call calculate_compress_Roquet_SpV(Ta, Sa, pres, rho, drho_dp, is, npts)
     case (EOS_JACKETT06)
@@ -1538,8 +1538,8 @@ subroutine EoS_fit_range(EOS, T_min, T_max, S_min, S_max, p_min, p_max)
       call EoS_fit_range_Wright_red(T_min, T_max, S_min, S_max, p_min, p_max)
     case (EOS_TEOS10)
       call EoS_fit_range_TEOS10(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_NEMO)
-      call EoS_fit_range_NEMO(T_min, T_max, S_min, S_max, p_min, p_max)
+    case (EOS_ROQUET_RHO)
+      call EoS_fit_range_Roquet_rho(T_min, T_max, S_min, S_max, p_min, p_max)
     case (EOS_ROQUET_SpV)
       call EoS_fit_range_Roquet_SpV(T_min, T_max, S_min, S_max, p_min, p_max)
     case (EOS_JACKETT06)
@@ -1813,9 +1813,9 @@ subroutine EOS_init(param_file, EOS, US)
     case (EOS_TEOS10_STRING)
       EOS%form_of_EOS = EOS_TEOS10
     case (EOS_NEMO_STRING)
-      EOS%form_of_EOS = EOS_NEMO
+      EOS%form_of_EOS = EOS_ROQUET_RHO
     case (EOS_ROQUET_RHO_STRING)
-      EOS%form_of_EOS = EOS_NEMO
+      EOS%form_of_EOS = EOS_ROQUET_RHO
     case (EOS_ROQUET_SPV_STRING)
       EOS%form_of_EOS = EOS_ROQUET_SPV
     case (EOS_JACKETT06_STRING)
@@ -1857,7 +1857,7 @@ subroutine EOS_init(param_file, EOS, US)
                  "code for the integrals of density.", default=EOS_quad_default)
 
   TFREEZE_DEFAULT = TFREEZE_LINEAR_STRING
-  if ((EOS%form_of_EOS == EOS_TEOS10 .or. EOS%form_of_EOS == EOS_NEMO .or. &
+  if ((EOS%form_of_EOS == EOS_TEOS10 .or. EOS%form_of_EOS == EOS_ROQUET_RHO .or. &
        EOS%form_of_EOS == EOS_ROQUET_SPV)) &
     TFREEZE_DEFAULT = TFREEZE_TEOS10_STRING
   call get_param(param_file, mdl, "TFREEZE_FORM", tmpstr, &
@@ -1894,9 +1894,10 @@ subroutine EOS_init(param_file, EOS, US)
                  units="deg C Pa-1", default=0.0)
   endif
 
-  if ((EOS%form_of_EOS == EOS_TEOS10 .or. EOS%form_of_EOS == EOS_NEMO .or. EOS%form_of_EOS == EOS_ROQUET_SPV) .and. &
+  if ((EOS%form_of_EOS == EOS_TEOS10 .or. EOS%form_of_EOS == EOS_ROQUET_RHO .or. &
+       EOS%form_of_EOS == EOS_ROQUET_SPV) .and. &
       (EOS%form_of_TFreeze /= TFREEZE_TEOS10)) then
-    call MOM_error(FATAL, "interpret_eos_selection:  EOS_TEOS10 or EOS_NEMO or EOS_ROQUET_SPV "//&
+    call MOM_error(FATAL, "interpret_eos_selection:  EOS_TEOS10 or EOS_ROQUET_RHO or EOS_ROQUET_SPV "//&
                    "should only be used along with TFREEZE_FORM = TFREEZE_TEOS10 .")
   endif
 
@@ -1987,7 +1988,7 @@ subroutine convert_temp_salt_for_TEOS10(T, S, HI, kd, mask_z, EOS)
   real :: gsw_ct_from_pt ! Conservative temperature after conversion from potential temperature [degC]
   integer :: i, j, k
 
-  if ((EOS%form_of_EOS /= EOS_TEOS10) .and. (EOS%form_of_EOS /= EOS_NEMO) .and. &
+  if ((EOS%form_of_EOS /= EOS_TEOS10) .and. (EOS%form_of_EOS /= EOS_ROQUET_RHO) .and. &
       (EOS%form_of_EOS /= EOS_ROQUET_SPV)) return
 
   do k=1,kd ; do j=HI%jsc,HI%jec ; do i=HI%isc,HI%iec
@@ -2176,10 +2177,10 @@ logical function EOS_unit_tests(verbose)
   if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT EOS has failed some self-consistency tests.")
   EOS_unit_tests = EOS_unit_tests .or. fail
 
-  call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_NEMO)
-  fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "NEMO", &
+  call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_ROQUET_RHO)
+  fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "ROQUET_RHO", &
                               rho_check=1027.42385663668*EOS_tmp%kg_m3_to_R)
-  if (verbose .and. fail) call MOM_error(WARNING, "NEMO EOS has failed some self-consistency tests.")
+  if (verbose .and. fail) call MOM_error(WARNING, "ROQUET_RHO EOS has failed some self-consistency tests.")
   EOS_unit_tests = EOS_unit_tests .or. fail
 
   call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_ROQUET_SPV)
@@ -2205,11 +2206,11 @@ logical function EOS_unit_tests(verbose)
   if (verbose .and. fail) call MOM_error(WARNING, "TEOS10 EOS has failed some self-consistency tests.")
   EOS_unit_tests = EOS_unit_tests .or. fail
 
-  call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_NEMO)
-  fail = test_EOS_consistency(10.0, 30.0, 1.0e7, EOS_tmp, verbose, "NEMO", &
+  call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_ROQUET_RHO)
+  fail = test_EOS_consistency(10.0, 30.0, 1.0e7, EOS_tmp, verbose, "ROQUET_RHO", &
                               rho_check=1027.45140117152*EOS_tmp%kg_m3_to_R)
   ! The corresponding check value published by Roquet et al. (2015) is 1027.45140 [kg m-3].
-  if (verbose .and. fail) call MOM_error(WARNING, "NEMO EOS has failed some self-consistency tests.")
+  if (verbose .and. fail) call MOM_error(WARNING, "Roquet_rho EOS has failed some self-consistency tests.")
   EOS_unit_tests = EOS_unit_tests .or. fail
 
   call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_ROQUET_SPV)
@@ -2578,5 +2579,5 @@ end module MOM_EOS
 !> \namespace mom_eos
 !!
 !! The MOM_EOS module is a wrapper for various equations of state (i.e. Linear, Wright,
-!! Wright_full, Wright_red, UNESCO, TEOS10, Roquet_SpV or NEMO) and provides a uniform
+!! Wright_full, Wright_red, UNESCO, TEOS10, Roquet_SpV or Roquet_rho) and provides a uniform
 !! interface to the rest of the model independent of which equation of state is being used.

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -25,6 +25,7 @@ use MOM_EOS_Wright_red,  only : calculate_compress_wright_red, int_spec_vol_dp_w
 use MOM_EOS_Wright_red,  only : calculate_density_second_derivs_wright_red
 use MOM_EOS_UNESCO, only : calculate_density_unesco, calculate_spec_vol_unesco
 use MOM_EOS_UNESCO, only : calculate_density_derivs_unesco, calculate_density_unesco
+use MOM_EOS_UNESCO, only : calculate_density_second_derivs_UNESCO
 use MOM_EOS_UNESCO, only : calculate_compress_unesco
 use MOM_EOS_NEMO,   only : calculate_density_nemo
 use MOM_EOS_NEMO,   only : calculate_density_derivs_nemo, calculate_density_nemo
@@ -265,8 +266,8 @@ subroutine calculate_stanley_density_scalar(T, S, pressure, Tvar, TScov, Svar, r
       call calculate_density_second_derivs_wright_red(T_scale*T, S_scale*S, p_scale*pressure, &
                                                   d2RdSS, d2RdST, d2RdTT, d2RdSp, d2RdTP)
     case (EOS_UNESCO)
-      call MOM_error(FATAL, "calculate_stanley_density_scalar: "//&
-                     "EOS_UNESCO is not set up to calculate second derivatives yet.")
+      call calculate_density_second_derivs_UNESCO(T_scale*T, S_scale*S, p_scale*pressure, &
+                                                  d2RdSS, d2RdST, d2RdTT, d2RdSp, d2RdTP)
     case (EOS_NEMO)
       call calculate_density_second_derivs_NEMO(T_scale*T, S_scale*S, p_scale*pressure, &
                                                   d2RdSS, d2RdST, d2RdTT, d2RdSp, d2RdTP)
@@ -374,8 +375,9 @@ subroutine calculate_stanley_density_array(T, S, pressure, Tvar, TScov, Svar, rh
       call calculate_density_second_derivs_wright_red(T, S, pressure, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP, start, npts)
     case (EOS_UNESCO)
-      call MOM_error(FATAL, "calculate_stanley_density_array: "//&
-                     "EOS_UNESCO is not set up to calculate second derivatives yet.")
+      call calculate_density_UNESCO(T, S, pressure, rho, start, npts, rho_ref)
+      call calculate_density_second_derivs_UNESCO(T, S, pressure, d2RdSS, d2RdST, &
+                                                  d2RdTT, d2RdSp, d2RdTP, start, npts)
     case (EOS_NEMO)
       call calculate_density_NEMO(T, S, pressure, rho, start, npts, rho_ref)
       call calculate_density_second_derivs_NEMO(T, S, pressure, d2RdSS, d2RdST, &
@@ -528,8 +530,9 @@ subroutine calculate_stanley_density_1d(T, S, pressure, Tvar, TScov, Svar, rho, 
       call calculate_density_second_derivs_wright_red(Ta, Sa, pres, d2RdSS, d2RdST, &
                                                   d2RdTT, d2RdSp, d2RdTP, is, npts)
     case (EOS_UNESCO)
-      call MOM_error(FATAL, "calculate_stanley_density_1d: "//&
-                     "EOS_UNESCO is not set up to calculate second derivatives yet.")
+      call calculate_density_UNESCO(Ta, Sa, pres, rho, is, npts, rho_reference)
+      call calculate_density_second_derivs_UNESCO(Ta, Sa, pres, d2RdSS, d2RdST, &
+                                                  d2RdTT, d2RdSp, d2RdTP, is, npts)
     case (EOS_NEMO)
       call calculate_density_NEMO(Ta, Sa, pres, rho, is, npts, rho_reference)
       call calculate_density_second_derivs_NEMO(Ta, Sa, pres, d2RdSS, d2RdST, &
@@ -1052,8 +1055,8 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
         call calculate_density_second_derivs_wright_red(T, S, pressure, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_UNESCO)
-        call MOM_error(FATAL, "calculate_density_second_derivs: "//&
-                       "EOS_UNESCO is not set up to calculate second derivatives yet.")
+        call calculate_density_second_derivs_UNESCO(T, S, pressure, drho_dS_dS, drho_dS_dT, &
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_NEMO)
         call calculate_density_second_derivs_NEMO(T, S, pressure, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
@@ -1083,8 +1086,8 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
         call calculate_density_second_derivs_wright_red(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_UNESCO)
-        call MOM_error(FATAL, "calculate_density_second_derivs: "//&
-                       "EOS_UNESCO is not set up to calculate second derivatives yet.")
+        call calculate_density_second_derivs_UNESCO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
+                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
       case (EOS_NEMO)
         call calculate_density_second_derivs_NEMO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                     drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
@@ -1168,8 +1171,8 @@ subroutine calculate_density_second_derivs_scalar(T, S, pressure, drho_dS_dS, dr
       call calculate_density_second_derivs_wright_red(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                   drho_dT_dT, drho_dS_dP, drho_dT_dP)
     case (EOS_UNESCO)
-      call MOM_error(FATAL, "calculate_density_second_derivs: "//&
-                     "EOS_UNESCO is not set up to calculate second derivatives yet.")
+      call calculate_density_second_derivs_UNESCO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
+                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
     case (EOS_NEMO)
       call calculate_density_second_derivs_NEMO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
                                                   drho_dT_dT, drho_dS_dP, drho_dT_dP)
@@ -1985,7 +1988,7 @@ logical function EOS_unit_tests(verbose)
   EOS_unit_tests = .false. ! Normally return false
 
   call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_UNESCO)
-  fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "UNESCO", skip_2nd=.true., &
+  fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "UNESCO", &
                               rho_check=1027.5434579611974*EOS_tmp%kg_m3_to_R)
   if (verbose .and. fail) call MOM_error(WARNING, "UNESCO EOS has failed some self-consistency tests.")
   EOS_unit_tests = EOS_unit_tests .or. fail

--- a/src/equation_of_state/MOM_EOS_Jackett06.F90
+++ b/src/equation_of_state/MOM_EOS_Jackett06.F90
@@ -9,7 +9,7 @@ implicit none ; private
 
 public calculate_compress_Jackett06, calculate_density_Jackett06, calculate_spec_vol_Jackett06
 public calculate_density_derivs_Jackett06, calculate_specvol_derivs_Jackett06
-public calculate_density_second_derivs_Jackett06
+public calculate_density_second_derivs_Jackett06, EoS_fit_range_Jackett06
 
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
 !! a reference density, from salinity in practical salinity units ([PSU]), potential
@@ -541,6 +541,28 @@ subroutine calculate_density_second_derivs_scalar_Jackett(T, S, P, drho_ds_ds, d
 
 end subroutine calculate_density_second_derivs_scalar_Jackett
 
+!> Return the range of temperatures, salinities and pressures for which the Jackett et al. (2006)
+!! equation of state has been fitted to observations.  Care should be taken when applying this
+!! equation of state outside of its fit range.
+subroutine EoS_fit_range_Jackett06(T_min, T_max, S_min, S_max, p_min, p_max)
+  real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: S_max !< The maximum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+  real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  ! Note that the actual fit range is given for the surface range of temperatures and salinities,
+  ! but Jackett et al. use a more limited range of properties at higher pressures.
+  if (present(T_min)) T_min = -4.5
+  if (present(T_max)) T_max = 40.0
+  if (present(S_min)) S_min =  0.0
+  if (present(S_max)) S_max = 42.0
+  if (present(p_min)) p_min = 0.0
+  if (present(p_max)) p_max = 8.5e7
+
+end subroutine EoS_fit_range_Jackett06
+
 !> \namespace mom_eos_Jackett06
 !!
 !! \section section_EOS_Jackett06 Jackett et al. 2006 (Hycom-25-term) equation of state
@@ -550,6 +572,13 @@ end subroutine calculate_density_second_derivs_scalar_Jackett
 !! frequently used in Hycom for a potential density, at which point it only has 17 terms
 !! and so is commonly called the "17-term equation of state" there.  Here the full expressions
 !! for the in situ densities are used.
+!!
+!! The functional form of this equation of state includes terms proportional to salinity to the
+!! 3/2 power.  This introduces a singularity in the second derivative of density with salinity
+!! at a salinity of 0, but this has been addressed here by setting a floor of 1e-8 PSU on the
+!! salinity that is used in the denominator of these second derivative expressions.  This value
+!! was chosen to imply a contribution that is smaller than numerical roundoff in the expression for
+!! density, which is the field for which the Jackett et al. equation of state was originally derived.
 !!
 !! \subsection section_EOS_Jackett06_references References
 !!

--- a/src/equation_of_state/MOM_EOS_Jackett06.F90
+++ b/src/equation_of_state/MOM_EOS_Jackett06.F90
@@ -1,0 +1,561 @@
+!> The equation of state using the Jackett et al 2006 expressions that are often used in Hycom
+module MOM_EOS_Jackett06
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_hor_index, only : hor_index_type
+
+implicit none ; private
+
+public calculate_compress_Jackett06, calculate_density_Jackett06, calculate_spec_vol_Jackett06
+public calculate_density_derivs_Jackett06, calculate_specvol_derivs_Jackett06
+public calculate_density_second_derivs_Jackett06
+
+!> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
+!! a reference density, from salinity in practical salinity units ([PSU]), potential
+!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
+!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
+interface calculate_density_Jackett06
+  module procedure calculate_density_scalar_Jackett, calculate_density_array_Jackett
+end interface calculate_density_Jackett06
+
+!> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
+!! to a reference specific volume, from salinity in practical salinity units ([PSU]), potential
+!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
+!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
+interface calculate_spec_vol_Jackett06
+  module procedure calculate_spec_vol_scalar_Jackett, calculate_spec_vol_array_Jackett
+end interface calculate_spec_vol_Jackett06
+
+!> Compute the derivatives of density with temperature and salinity
+interface calculate_density_derivs_Jackett06
+  module procedure calculate_density_derivs_scalar_Jackett, calculate_density_derivs_array_Jackett
+end interface calculate_density_derivs_Jackett06
+
+!> Compute the second derivatives of density with various combinations
+!! of temperature, salinity, and pressure
+interface calculate_density_second_derivs_Jackett06
+  module procedure calculate_density_second_derivs_scalar_Jackett, calculate_density_second_derivs_array_Jackett
+end interface calculate_density_second_derivs_Jackett06
+
+!>@{ Parameters in the Jackett et al. equation of state, which is a fit to the Fiestel (2003)
+!    equation of state for the range: -2 < theta < 40 [degC], 0 < S < 42 [PSU], 0 < p < 1e8 [Pa].
+!    The notation here is for terms in the numerator of the expression for density of
+!    RNabc for terms proportional to S**a * T**b * P**c, and terms in the denominator as RDabc.
+!    For terms proportional to S**1.5, 6 is used in this notation.
+
+! --- coefficients for 25-term rational function sigloc().
+real, parameter :: &
+  RN000 =  9.9984085444849347d+02, & ! Density numerator constant coefficient [kg m-3]
+  RN001 =  1.1798263740430364d-06, & ! Density numerator P       coefficient [kg m-3 Pa-1]
+  RN002 = -2.5862187075154352d-16, & ! Density numerator P^2     coefficient [kg m-3 Pa-2]
+  RN010 =  7.3471625860981584d+00, & ! Density numerator T       coefficient [kg m-3 degC-1]
+  RN020 = -5.3211231792841769d-02, & ! Density numerator T^2     coefficient [kg m-3 degC-2]
+  RN021 =  9.8920219266399117d-12, & ! Density numerator T^2 P   coefficient [kg m-3 degC-2 Pa-1]
+  RN022 = -3.2921414007960662d-20, & ! Density numerator T^2 P^2 coefficient [kg m-3 degC-2 Pa-2]
+  RN030 =  3.6492439109814549d-04, & ! Density numerator T^3     coefficient [kg m-3 degC-3]
+  RN100 =  2.5880571023991390d+00, & ! Density numerator S       coefficient [kg m-3 PSU-1]
+  RN101 =  4.6996642771754730d-10, & ! Density numerator S P     coefficient [kg m-3 PSU-1 Pa-1]
+  RN110 = -6.7168282786692355d-03, & ! Density numerator S T     coefficient [kg m-3 degC-1 PSU-1]
+  RN200 =  1.9203202055760151d-03, & ! Density numerator S^2      coefficient [kg m-3]
+
+  RD001 =  6.7103246285651894d-10, & ! Density denominator P       coefficient [Pa-1]
+  RD010 =  7.2815210113327091d-03, & ! Density denominator T       coefficient [degC-1]
+  RD013 = -9.1534417604289062d-30, & ! Density denominator T P^3   coefficient [degC-1 Pa-3]
+  RD020 = -4.4787265461983921d-05, & ! Density denominator T^2     coefficient [degC-2]
+  RD030 =  3.3851002965802430d-07, & ! Density denominator T^3     coefficient [degC-3]
+  RD032 = -2.4461698007024582d-25, & ! Density denominator T^3 P^2 coefficient [degC-3  Pa-2]
+  RD040 =  1.3651202389758572d-10, & ! Density denominator T^4     coefficient [degC-4]
+  RD100 =  1.7632126669040377d-03, & ! Density denominator S       coefficient [PSU-1]
+  RD110 = -8.8066583251206474d-06, & ! Density denominator S T     coefficient [degC-1 PSU-1]
+  RD130 = -1.8832689434804897d-10, & ! Density denominator S T^3   coefficient [degC-3 PSU-1]
+  RD600 =  5.7463776745432097d-06, & ! Density denominator S^1.5   coefficient [PSU-1.5]
+  RD620 =  1.4716275472242334d-09    ! Density denominator S^1.5 T^2 coefficient [degC-2 PSU-1.5]
+!>@}
+
+contains
+
+!> Computes the in situ density of sea water for 1-d array inputs and outputs.
+!!
+!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
+!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
+subroutine calculate_density_array_Jackett(T, S, pres, rho, start, npts, rho_ref)
+  real, dimension(:), intent(in)    :: T        !< Potential temperature relative to the surface [degC].
+  real, dimension(:), intent(in)    :: S        !< Salinity [PSU].
+  real, dimension(:), intent(in)    :: pres     !< Pressure [Pa].
+  real, dimension(:), intent(inout) :: rho      !< In situ density [kg m-3].
+  integer,            intent(in)    :: start    !< The starting point in the arrays.
+  integer,            intent(in)    :: npts     !< The number of values to calculate.
+  real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3].
+
+  ! Local variables
+  real :: num_STP ! State dependent part of the numerator of the rational expresion
+                  ! for density [kg m-3]
+  real :: den     ! Denominator of the rational expresion for density [nondim]
+  real :: den_STP ! State dependent part of the denominator of the rational expresion
+                  ! for density [nondim]
+  real :: I_den   ! The inverse of the denominator of the rational expresion for density [nondim]
+  real :: T2      ! Temperature squared [degC2]
+  real :: S1_2    ! Limited square root of salinity [PSU1/2]
+  real :: rho0    ! The surface density of fresh water at 0 degC, perhaps less the refernce density [kg m-3]
+  integer :: j
+
+  do j=start,start+npts-1
+    S1_2 = sqrt(max(0.0,s(j)))
+    T2 = T(j)*T(j)
+
+    num_STP = (T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
+               S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
+              pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022)))
+    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
+                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+                 pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013)) )
+    I_den = 1.0 / den
+
+    rho0 = RN000
+    if (present(rho_ref)) rho0 = RN000 - rho_ref*den
+
+    rho(j) = (rho0 + num_STP)*I_den
+  enddo
+
+end subroutine calculate_density_array_Jackett
+
+!> Computes the Jackett et al. in situ specific volume of sea water for 1-d array inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
+!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
+!! If spv_ref is present, specvol is an anomaly from spv_ref.
+subroutine calculate_spec_vol_array_Jackett(T, S, pres, specvol, start, npts, spv_ref)
+  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the
+                                                !! surface [degC].
+  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
+  real, dimension(:), intent(in)    :: pres     !< pressure [Pa].
+  real, dimension(:), intent(inout) :: specvol  !< in situ specific volume [m3 kg-1].
+  integer,            intent(in)    :: start    !< the starting point in the arrays.
+  integer,            intent(in)    :: npts     !< the number of values to calculate.
+  real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1].
+
+  ! Local variables
+  real :: num_STP ! State dependent part of the numerator of the rational expresion
+                  ! for density (not specific volume) [kg m-3]
+  real :: den_STP ! State dependent part of the denominator of the rational expresion
+                  ! for density (not specific volume) [nondim]
+  real :: I_num   ! The inverse of the numerator of the rational expresion for density [nondim]
+  real :: T2      ! Temperature squared [degC2]
+  real :: S1_2    ! Limited square root of salinity [PSU1/2]
+  integer :: j
+
+  do j=start,start+npts-1
+    S1_2 = sqrt(max(0.0,s(j)))
+    T2 = T(j)*T(j)
+
+    num_STP = (T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
+               S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
+              pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022)))
+    den_STP = (T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
+               S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+              pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013))
+    I_num = 1.0 / (RN000 + num_STP)
+    if (present(spv_ref)) then
+      ! This form is slightly more complicated, but it cancels the leading terms better.
+      specvol(j) = ((1.0 - spv_ref*RN000) + (den_STP - spv_ref*num_STP)) * I_num
+    else
+      specvol(j) = (1.0 + den_STP) * I_num
+    endif
+  enddo
+
+end subroutine calculate_spec_vol_array_Jackett
+
+!> Return the thermal/haline expansion coefficients for 1-d array inputs and outputs
+subroutine calculate_density_derivs_array_Jackett(T, S, pres, drho_dT, drho_dS, start, npts)
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the
+                                                   !! surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pres     !< pressure [Pa].
+  real,    intent(inout), dimension(:) :: drho_dT  !< The partial derivative of density with potential
+                                                   !! temperature [kg m-3 degC-1].
+  real,    intent(inout), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
+                                                   !! in [kg m-3 PSU-1].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
+
+  ! Local variables
+  real :: num     ! Numerator of the rational expresion for density [kg m-3]
+  real :: den     ! Denominator of the rational expresion for density [nondim]
+  real :: I_denom2 ! The inverse of the square of the denominator of the rational expression
+                  ! for density [nondim]
+  real :: dnum_dT ! The derivative of num with potential temperature [kg m-3 degC-1]
+  real :: dnum_dS ! The derivative of num with salinity [kg m-3 PSU-1]
+  real :: dden_dT ! The derivative of den with potential temperature [degC-1]
+  real :: dden_dS ! The derivative of den with salinity PSU-1]
+  real :: T2      ! Temperature squared [degC2]
+  real :: S1_2    ! Limited square root of salinity [PSU1/2]
+  integer :: j
+
+  do j=start,start+npts-1
+    S1_2 = sqrt(max(0.0,s(j)))
+    T2 = T(j)*T(j)
+
+    num = RN000 + ((T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
+                    S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
+                   pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022))) )
+    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
+                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+                 pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013)) )
+
+    dnum_dT = ((RN010 + T(j)*(2.*RN020 + T(j)*(3.*RN030))) + S(j)*RN110) + &
+              pres(j)*T(j)*(2.*RN021 + pres(j)*(2.*RN022))
+    dnum_dS = (RN100 + (T(j)*RN110 + S(j)*(2.*RN200))) + pres(j)*RN101
+    dden_dT = ((RD010 + T(j)*((2.*RD020) + T(j)*((3.*RD030) + T(j)*(4.*RD040)))) + &
+               S(j)*((RD110 + T2*(3.*RD130)) + S1_2*T(j)*(2.*RD620)) ) + &
+              pres(j)**2*(T2*3.*RD032 + pres(j)*RD013)
+    dden_dS = RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(1.5*RD600 + T2*(1.5*RD620)))
+    I_denom2 = 1.0 / den**2
+
+    ! rho(j) = num / den
+    drho_dT(j) = (dnum_dT * den - num * dden_dT) * I_denom2
+    drho_dS(j) = (dnum_dS * den - num * dden_dS) * I_denom2
+  enddo
+
+end subroutine calculate_density_derivs_array_Jackett
+
+!> Return the partial derivatives of specific volume with temperature and salinity
+!! for 1-d array inputs and outputs
+subroutine calculate_specvol_derivs_Jackett06(T, S, pres, dSV_dT, dSV_dS, start, npts)
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pres     !< Pressure [Pa].
+  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
+                                                   !! potential temperature [m3 kg-1 degC-1].
+  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
+                                                   !! salinity [m3 kg-1 PSU-1].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
+
+  ! Local variables
+  real :: num     ! Numerator of the rational expresion for density (not specific volume) [kg m-3]
+  real :: den     ! Denominator of the rational expresion for density (not specific volume) [nondim]
+  real :: I_num2  ! The inverse of the square of the numerator of the rational expression
+                  ! for density [nondim]
+  real :: dnum_dT ! The derivative of num with potential temperature [kg m-3 degC-1]
+  real :: dnum_dS ! The derivative of num with salinity [kg m-3 PSU-1]
+  real :: dden_dT ! The derivative of den with potential temperature [degC-1]
+  real :: dden_dS ! The derivative of den with salinity PSU-1]
+  real :: T2      ! Temperature squared [degC2]
+  real :: S1_2    ! Limited square root of salinity [PSU1/2]
+  integer :: j
+
+  do j=start,start+npts-1
+    S1_2 = sqrt(max(0.0,s(j)))
+    T2 = T(j)*T(j)
+
+    num = RN000 + ((T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
+                    S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
+                   pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022))) )
+    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
+                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+                 pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013)) )
+
+    dnum_dT = ((RN010 + T(j)*(2.*RN020 + T(j)*(3.*RN030))) + S(j)*RN110) + &
+              pres(j)*T(j)*(2.*RN021 + pres(j)*(2.*RN022))
+    dnum_dS = (RN100 + (T(j)*RN110 + S(j)*(2.*RN200))) + pres(j)*RN101
+    dden_dT = ((RD010 + T(j)*((2.*RD020) + T(j)*((3.*RD030) + T(j)*(4.*RD040)))) + &
+               S(j)*((RD110 + T2*(3.*RD130)) + S1_2*T(j)*(2.*RD620)) ) + &
+              pres(j)**2*(T2*3.*RD032 + pres(j)*RD013)
+    dden_dS = RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(1.5*RD600 + T2*(1.5*RD620)))
+    I_num2 = 1.0 / num**2
+
+    ! SV(j) = den / num
+    dSV_dT(j) = (num * dden_dT - dnum_dT * den) * I_num2
+    dSV_dS(j) = (num * dden_dS - dnum_dS * den) * I_num2
+  enddo
+
+end subroutine calculate_specvol_derivs_Jackett06
+
+!> Computes the compressibility of seawater for 1-d array inputs and outputs
+subroutine calculate_compress_Jackett06(T, S, pres, rho, drho_dp, start, npts)
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pres     !< Pressure [Pa].
+  real,    intent(inout), dimension(:) :: rho      !< In situ density [kg m-3].
+  real,    intent(inout), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
+                                                   !! (also the inverse of the square of sound speed)
+                                                   !! [s2 m-2].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
+
+  ! Local variables
+  real :: num     ! Numerator of the rational expresion for density [kg m-3]
+  real :: den     ! Denominator of the rational expresion for density [nondim]
+  real :: I_den   ! The inverse of the denominator of the rational expression for density [nondim]
+  real :: dnum_dp ! The derivative of num with pressure [kg m-3 dbar-1]
+  real :: dden_dp ! The derivative of den with pressure [dbar-1]
+  real :: T2      ! Temperature squared [degC2]
+  real :: S1_2    ! Limited square root of salinity [PSU1/2]
+  integer :: j
+
+  do j=start,start+npts-1
+    S1_2 = sqrt(max(0.0,s(j)))
+    T2 = T(j)*T(j)
+
+    num = RN000 + ((T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
+                    S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
+                   pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022))) )
+    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
+                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+                 pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013)) )
+    dnum_dp = RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(2.*RN002 + T2*(2.*RN022)))
+    dden_dp = RD001 + pres(j)*T(j)*(T2*(2.*RD032) + pres(j)*(3.*RD013))
+
+    I_den  = 1.0 / den
+    rho(j) = num * I_den
+    drho_dp(j) = (dnum_dp * den - num * dden_dp) * I_den**2
+  enddo
+end subroutine calculate_compress_Jackett06
+
+!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
+subroutine calculate_density_second_derivs_array_Jackett(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+                                                         drho_ds_dp, drho_dt_dp, start, npts)
+  real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
+  real, dimension(:), intent(in   ) :: S !< Salinity [PSU]
+  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
+  real, dimension(:), intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+                                                  !! to S [kg m-3 PSU-2]
+  real, dimension(:), intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+                                                  !! to T [kg m-3 PSU-1 degC-1]
+  real, dimension(:), intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                                  !! to T [kg m-3 degC-2]
+  real, dimension(:), intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+                                                  !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real, dimension(:), intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                                  !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  integer,            intent(in   ) :: start !< Starting index in T,S,P
+  integer,            intent(in   ) :: npts  !< Number of points to loop over
+
+  ! Local variables
+  real :: num         ! Numerator of the rational expresion for density [kg m-3]
+  real :: den         ! Denominator of the rational expresion for density [nondim]
+  real :: I_num2      ! The inverse of the square of the numerator of the rational expression
+                      ! for density [nondim]
+  real :: dnum_dT     ! The derivative of num with potential temperature [kg m-3 degC-1]
+  real :: dnum_dS     ! The derivative of num with salinity [kg m-3 PSU-1]
+  real :: dden_dT     ! The derivative of den with potential temperature [degC-1]
+  real :: dden_dS     ! The derivative of den with salinity PSU-1]
+  real :: dnum_dp     ! The derivative of num with pressure [kg m-3 dbar-1]
+  real :: dden_dp     ! The derivative of det with pressure [dbar-1]
+  real :: d2num_dT2   ! The second derivative of num with potential temperature [kg m-3 degC-2]
+  real :: d2num_dT_dS ! The second derivative of num with potential temperature and
+                      ! salinity [kg m-3 degC-1 PSU-1]
+  real :: d2num_dS2   ! The second derivative of num with salinity [kg m-3 PSU-2]
+  real :: d2num_dT_dp ! The second derivative of num with potential temperature and
+                      ! pressure [kg m-3 degC-1 dbar-1]
+  real :: d2num_dS_dp ! The second derivative of num with salinity and
+                      ! pressure [kg m-3 PSU-1 dbar-1]
+  real :: d2den_dT2   ! The second derivative of den with potential temperature [degC-2]
+  real :: d2den_dT_dS ! The second derivative of den with potential temperature and salinity [degC-1 PSU-1]
+  real :: d2den_dS2   ! The second derivative of den with salinity [PSU-2]
+  real :: d2den_dT_dp ! The second derivative of den with potential temperature and pressure [degC-1 dbar-1]
+  real :: d2den_dS_dp ! The second derivative of den with salinity and pressure [PSU-1 dbar-1]
+  real :: T2          ! Temperature squared [degC2]
+  real :: S1_2        ! Limited square root of salinity [PSU1/2]
+  real :: I_s12       ! The inverse of the square root of salinity [PSU-1/2]
+  real :: I_denom2    ! The inverse of the square of the denominator of the rational expression
+                      ! for density [nondim]
+  real :: I_denom3    ! The inverse of the cube of the denominator of the rational expression
+                      ! for density [nondim]
+  integer :: j
+
+  do j = start,start+npts-1
+    S1_2 = sqrt(max(0.0,s(j)))
+    T2 = T(j)*T(j)
+
+    num = RN000 + ((T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
+                    S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
+                   P(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + P(j)*(RN002 + T2*RN022))) )
+    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
+                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+                 P(j)*(RD001 + P(j)*T(j)*(T2*RD032 + P(j)*RD013)) )
+    ! rho(j) = num*I_den
+
+    dnum_dT = ((RN010 + T(j)*(2.*RN020 + T(j)*(3.*RN030))) + S(j)*RN110) + &
+              P(j)*T(j)*(2.*RN021 + P(j)*(2.*RN022))
+    dnum_dS = (RN100 + (T(j)*RN110 + S(j)*(2.*RN200))) + P(j)*RN101
+    dnum_dp = RN001 + ((T2*RN021 + S(j)*RN101) + P(j)*(2.*RN002 + T2*(2.*RN022)))
+    d2num_dT2 = 2.*RN020 + T(j)*(6.*RN030) + P(j)*(2.*RN021 + P(j)*(2.*RN022))
+    d2num_dT_dS = RN110
+    d2num_dS2 = 2.*RN200
+    d2num_dT_dp = T(j)*(2.*RN021 + P(j)*(4.*RN022))
+    d2num_dS_dp = RN101
+
+    dden_dT = ((RD010 + T(j)*((2.*RD020) + T(j)*((3.*RD030) + T(j)*(4.*RD040)))) + &
+               S(j)*((RD110 + T2*(3.*RD130)) + S1_2*T(j)*(2.*RD620)) ) + &
+              P(j)**2*(T2*3.*RD032 + P(j)*RD013)
+    dden_dS = RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(1.5*RD600 + T2*(1.5*RD620)))
+    dden_dp = RD001 + P(j)*T(j)*(T2*(2.*RD032) + P(j)*(3.*RD013))
+
+    d2den_dT2 = (((2.*RD020) + T(j)*((6.*RD030) + T(j)*(12.*RD040))) + &
+                 S(j)*(T(j)*(6.*RD130) + S1_2*(2.*RD620)) ) + P(j)**2*(T(j)*(6.*RD032))
+    d2den_dT_dS = (RD110 + T2*3.*RD130) + (T(j)*S1_2)*(3.0*RD620)
+    d2den_dT_dp = P(j)*(T2*(6.*RD032) + P(j)*(3.*RD013))
+    d2den_dS_dp = 0.0
+
+    ! The Jackett et al. 2006 equation of state is a fit to density, but it chooses a form that
+    ! exhibits a singularity in the second derivatives with salinity for fresh water.  To avoid
+    ! this, the square root of salinity can be treated with a floor such that the contribution from
+    ! the S**1.5 terms to both the surface density and the secant bulk modulus are lost to roundoff.
+    ! This salinity is given by (~1e-16/RD600)**(2/3) ~= 7e-8 PSU, or S1_2 ~= 2.6e-4
+    I_S12 = 1.0 / (max(S1_2, 1.0e-4))
+    d2den_dS2 = (0.75*RD600 + T2*(0.75*RD620)) * I_S12
+
+    I_denom3 = 1.0 / den**3
+
+    ! In deriving the following, it is useful to note that:
+    !   drho_dp(j) = (dnum_dp * den - num * dden_dp) / den**2
+    !   drho_dT(j) = (dnum_dT * den - num * dden_dT) / den**2
+    !   drho_dS(j) = (dnum_dS * den - num * dden_dS) / den**2
+    drho_dS_dS(j) = (den*(den*d2num_dS2 - 2.*dnum_dS*dden_dS) + num*(2.*dden_dS**2 - den*d2den_dS2)) * I_denom3
+    drho_dS_dt(j) = (den*(den*d2num_dT_dS - (dnum_dT*dden_dS + dnum_dS*dden_dT)) + &
+                     num*(2.*dden_dT*dden_dS - den*d2den_dT_dS)) * I_denom3
+    drho_dT_dT(j) = (den*(den*d2num_dT2 - 2.*dnum_dT*dden_dT) + num*(2.*dden_dT**2 - den*d2den_dT2)) * I_denom3
+
+    drho_dS_dp(j) = (den*(den*d2num_dS_dp - (dnum_dp*dden_dS + dnum_dS*dden_dp)) + &
+                     num*(2.*dden_dS*dden_dp - den*d2den_dS_dp)) * I_denom3
+    drho_dT_dp(j) = (den*(den*d2num_dT_dp - (dnum_dp*dden_dT + dnum_dT*dden_dp)) + &
+                     num*(2.*dden_dT*dden_dp - den*d2den_dT_dp)) * I_denom3
+  enddo
+
+end subroutine calculate_density_second_derivs_array_Jackett
+
+!> Computes the in situ density of sea water for scalar inputs and outputs.
+!!
+!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
+!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
+subroutine calculate_density_scalar_Jackett(T, S, pressure, rho, rho_ref)
+  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC].
+  real,           intent(in)  :: S        !< Salinity [PSU].
+  real,           intent(in)  :: pressure !< pressure [Pa].
+  real,           intent(out) :: rho      !< In situ density [kg m-3].
+  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
+
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
+  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: rho0  ! A 1-d array with a copy of the density [kg m-3]
+
+  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
+  call calculate_density_array_Jackett(T0, S0, pressure0, rho0, 1, 1, rho_ref)
+  rho = rho0(1)
+
+end subroutine calculate_density_scalar_Jackett
+
+!> Computes the Jackett et al. 2006 in situ specific volume of sea water for scalar inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
+!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
+!! If spv_ref is present, specvol is an anomaly from spv_ref.
+subroutine calculate_spec_vol_scalar_Jackett(T, S, pressure, specvol, spv_ref)
+  real,           intent(in)  :: T        !< potential temperature relative to the surface [degC].
+  real,           intent(in)  :: S        !< salinity [PSU].
+  real,           intent(in)  :: pressure !< pressure [Pa].
+  real,           intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
+  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
+
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
+  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
+
+  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
+  call calculate_spec_vol_array_Jackett(T0, S0, pressure0, spv0, 1, 1, spv_ref)
+  specvol = spv0(1)
+end subroutine calculate_spec_vol_scalar_Jackett
+
+!> Return the thermal/haline expansion coefficients for scalar inputs and outputs
+!!
+!! The scalar version of calculate_density_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
+subroutine calculate_density_derivs_scalar_Jackett(T, S, pressure, drho_dT, drho_dS)
+  real,    intent(in)  :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in)  :: S        !< Salinity [PSU].
+  real,    intent(in)  :: pressure !< pressure [Pa].
+  real,    intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                   !! temperature [kg m-3 degC-1].
+  real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                   !! in [kg m-3 PSU-1].
+
+  ! Local variables needed to promote the input/output scalars to 1-element arrays
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
+  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: drdt0 ! The derivative of density with temperature [kg m-3 degC-1]
+  real, dimension(1) :: drds0 ! The derivative of density with salinity [kg m-3 PSU-1]
+
+  T0(1) = T ; S0(1) = S ; P0(1) = pressure
+  call calculate_density_derivs_array_Jackett(T0, S0, P0, drdt0, drds0, 1, 1)
+  drho_dT = drdt0(1) ; drho_dS = drds0(1)
+
+end subroutine calculate_density_derivs_scalar_Jackett
+
+!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
+!!
+!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
+subroutine calculate_density_second_derivs_scalar_Jackett(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+                                                         drho_ds_dp, drho_dt_dp)
+  real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
+  real, intent(in   ) :: S          !< Salinity [PSU]
+  real, intent(in   ) :: P          !< pressure [Pa]
+  real, intent(  out) :: drho_ds_ds !< Partial derivative of beta with respect
+                                    !! to S [kg m-3 PSU-2]
+  real, intent(  out) :: drho_ds_dt !< Partial derivative of beta with respect
+                                    !! to T [kg m-3 PSU-1 degC-1]
+  real, intent(  out) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                    !! to T [kg m-3 degC-2]
+  real, intent(  out) :: drho_ds_dp !< Partial derivative of beta with respect
+                                    !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real, intent(  out) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                    !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
+  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 PSU-2]
+  real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
+                               ! temperature [kg m-3 PSU-1 degC-1]
+  real, dimension(1) :: drdtdt ! The second derivative of density with temperature [kg m-3 degC-2]
+  real, dimension(1) :: drdsdp ! The second derivative of density with salinity and
+                               ! pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real, dimension(1) :: drdtdp ! The second derivative of density with temperature and
+                               ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+
+  T0(1) = T ; S0(1) = S ; P0(1) = P
+  call calculate_density_second_derivs_array_Jackett(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
+  drho_ds_ds = drdsds(1) ; drho_ds_dt = drdsdt(1) ; drho_dt_dt = drdtdt(1)
+  drho_ds_dp = drdsdp(1) ; drho_dt_dp = drdtdp(1)
+
+end subroutine calculate_density_second_derivs_scalar_Jackett
+
+!> \namespace mom_eos_Jackett06
+!!
+!! \section section_EOS_Jackett06 Jackett et al. 2006 (Hycom-25-term) equation of state
+!!
+!! Jackett et al. (2006) provide an approximation for the in situ density as a function of
+!! potential temperature, salinity, and pressure.  This 25 term equation of state is
+!! frequently used in Hycom for a potential density, at which point it only has 17 terms
+!! and so is commonly called the "17-term equation of state" there.  Here the full expressions
+!! for the in situ densities are used.
+!!
+!! \subsection section_EOS_Jackett06_references References
+!!
+!! Jackett, D., T. McDougall, R. Feistel, D. Wright and S. Griffies (2006),
+!!   Algorithms for density, potential temperature, conservative
+!!   temperature, and the freezing temperature of seawater, JAOT
+!!   doi.org/10.1175/JTECH1946.1
+
+end module MOM_EOS_Jackett06

--- a/src/equation_of_state/MOM_EOS_NEMO.F90
+++ b/src/equation_of_state/MOM_EOS_NEMO.F90
@@ -10,7 +10,7 @@ implicit none ; private
 public calculate_compress_nemo, calculate_density_nemo
 public calculate_density_derivs_nemo
 public calculate_density_scalar_nemo, calculate_density_array_nemo
-public calculate_density_second_derivs_nemo
+public calculate_density_second_derivs_nemo, EoS_fit_range_NEMO
 
 !> Compute the in situ density of sea water [kg m-3], or its anomaly with respect to
 !! a reference density, from absolute salinity [g kg-1], conservative temperature [degC],
@@ -583,6 +583,26 @@ subroutine calculate_density_second_derivs_scalar_NEMO(T, S, P, drho_ds_ds, drho
   drho_dt_dp = drdtdp(1)
 
 end subroutine calculate_density_second_derivs_scalar_NEMO
+
+!> Return the range of temperatures, salinities and pressures for which the Roquet et al. (2015)
+!! expression for in situ density has been fitted to observations.  Care should be taken when
+!! applying this equation of state outside of its fit range.
+subroutine EoS_fit_range_NEMO(T_min, T_max, S_min, S_max, p_min, p_max)
+  real, optional, intent(out) :: T_min !< The minimum conservative temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: T_max !< The maximum conservative temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: S_min !< The minimum absolute salinity over which this EoS is fitted [g kg-1]
+  real, optional, intent(out) :: S_max !< The maximum absolute salinity over which this EoS is fitted [g kg-1]
+  real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+  real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  if (present(T_min)) T_min = -6.0
+  if (present(T_max)) T_max = 40.0
+  if (present(S_min)) S_min =  0.0
+  if (present(S_max)) S_max = 42.0
+  if (present(p_min)) p_min = 0.0
+  if (present(p_max)) p_max = 1.0e8
+
+end subroutine EoS_fit_range_NEMO
 
 !> \namespace mom_eos_NEMO
 !!

--- a/src/equation_of_state/MOM_EOS_Roquet_SpV.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_SpV.F90
@@ -1,0 +1,790 @@
+!> The equation of state for specific volume (SpV) using the expressions of Roquet et al. 2015
+module MOM_EOS_Roquet_Spv
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+!use gsw_mod_toolbox, only : gsw_sr_from_sp, gsw_ct_from_pt
+
+implicit none ; private
+
+public calculate_compress_Roquet_SpV, calculate_density_Roquet_SpV, calculate_spec_vol_Roquet_SpV
+public calculate_density_derivs_Roquet_SpV, calculate_specvol_derivs_Roquet_SpV
+public calculate_density_scalar_Roquet_SpV, calculate_density_array_Roquet_SpV
+public calculate_density_second_derivs_Roquet_SpV
+
+!> Compute the in situ density of sea water [kg m-3], or its anomaly with respect to
+!! a reference density, from absolute salinity [g kg-1], conservative temperature [degC],
+!! and pressure [Pa], using the specific volume polynomial fit from Roquet et al. (2015)
+interface calculate_density_Roquet_SpV
+  module procedure calculate_density_scalar_Roquet_SpV, calculate_density_array_Roquet_SpV
+end interface calculate_density_Roquet_SpV
+
+!> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
+!! to a reference specific volume, from absolute salinity ([g kg-1]), conservative
+!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the specific volume
+!! polynomial fit from Roquet et al. (2015)
+interface calculate_spec_vol_Roquet_SpV
+  module procedure calculate_spec_vol_scalar_Roquet_SpV, calculate_spec_vol_array_Roquet_SpV
+end interface calculate_spec_vol_Roquet_SpV
+
+!> For a given thermodynamic state, return the derivatives of density with conservative temperature
+!! and absolute salinity, using the specific volume polynomial fit from Roquet et al. (2015)
+interface calculate_density_derivs_Roquet_SpV
+  module procedure calculate_density_derivs_scalar_Roquet_SpV, calculate_density_derivs_array_Roquet_SpV
+end interface calculate_density_derivs_Roquet_SpV
+
+!> Compute the second derivatives of density with various combinations of temperature, salinity
+!! and pressure using the specific volume polynomial fit from Roquet et al. (2015)
+interface calculate_density_second_derivs_Roquet_SpV
+  module procedure calculate_density_second_derivs_scalar_Roquet_SpV
+  module procedure calculate_density_second_derivs_array_Roquet_SpV
+end interface calculate_density_second_derivs_Roquet_SpV
+
+real, parameter :: Pa2db  = 1.e-4 !< Conversion factor between Pa and dbar [dbar Pa-1]
+!>@{ Parameters in the Roquet specific volume polynomial equation of state
+real, parameter :: rdeltaS = 24.    ! An offset to salinity before taking its square root [g kg-1]
+real, parameter :: r1_S0  = 0.875/35.16504  ! The inverse of a plausible range of oceanic salinities [kg g-1]
+real, parameter :: r1_T0  = 1./40.  ! The inverse of a plausible range of oceanic temperatures [degC-1]
+real, parameter :: r1_P0  = 1.e-4   ! The inverse of a plausible range of oceanic pressures [dbar-1]
+real, parameter :: V00 = -4.4015007269e-05 ! Contribution to SpV00p proportional to zp [m3 kg-1]
+real, parameter :: V01 = 6.9232335784e-06  ! Contribution to SpV00p proportional to zp**2 [m3 kg-1]
+real, parameter :: V02 = -7.5004675975e-07 ! Contribution to SpV00p proportional to zp**3 [m3 kg-1]
+real, parameter :: V03 = 1.7009109288e-08  ! Contribution to SpV00p proportional to zp**4 [m3 kg-1]
+real, parameter :: V04 = -1.6884162004e-08 ! Contribution to SpV00p proportional to zp**5 [m3 kg-1]
+real, parameter :: V05 = 1.9613503930e-09  ! Contribution to SpV00p proportional to zp**6 [m3 kg-1]
+
+! The following terms are contributions to specific volume as a function of the normalized square root of salinity
+! with an offset (zs),  temperature (zt) and pressure (zp), with a contribution SPVabc * zs**a * zt**b * zp**c
+real, parameter :: SPV000 = 1.0772899069e-03  ! A constant specific volume (SpV) contribution [m3 kg-1]
+real, parameter :: SPV100 = -3.1263658781e-04 ! Coefficient of SpV proportional to zs [m3 kg-1]
+real, parameter :: SPV200 = 6.7615860683e-04  ! Coefficient of SpV proportional to zs**2 [m3 kg-1]
+real, parameter :: SPV300 = -8.6127884515e-04 ! Coefficient of SpV proportional to zs**3 [m3 kg-1]
+real, parameter :: SPV400 = 5.9010812596e-04  ! Coefficient of SpV proportional to zs**4 [m3 kg-1]
+real, parameter :: SPV500 = -2.1503943538e-04 ! Coefficient of SpV proportional to zs**5 [m3 kg-1]
+real, parameter :: SPV600 = 3.2678954455e-05  ! Coefficient of SpV proportional to zs**6 [m3 kg-1]
+real, parameter :: SPV010 = -1.4949652640e-05 ! Coefficient of SpV proportional to zt [m3 kg-1]
+real, parameter :: SPV110 = 3.1866349188e-05  ! Coefficient of SpV proportional to zs * zt [m3 kg-1]
+real, parameter :: SPV210 = -3.8070687610e-05 ! Coefficient of SpV proportional to zs**2 * zt [m3 kg-1]
+real, parameter :: SPV310 = 2.9818473563e-05  ! Coefficient of SpV proportional to zs**3 * zt [m3 kg-1]
+real, parameter :: SPV410 = -1.0011321965e-05 ! Coefficient of SpV proportional to zs**4 * zt [m3 kg-1]
+real, parameter :: SPV510 = 1.0751931163e-06  ! Coefficient of SpV proportional to zs**5 * zt [m3 kg-1]
+real, parameter :: SPV020 = 2.7546851539e-05  ! Coefficient of SpV proportional to zt**2 [m3 kg-1]
+real, parameter :: SPV120 = -3.6597334199e-05 ! Coefficient of SpV proportional to zs * zt**2 [m3 kg-1]
+real, parameter :: SPV220 = 3.4489154625e-05  ! Coefficient of SpV proportional to zs**2 * zt**2 [m3 kg-1]
+real, parameter :: SPV320 = -1.7663254122e-05 ! Coefficient of SpV proportional to zs**3 * zt**2 [m3 kg-1]
+real, parameter :: SPV420 = 3.5965131935e-06  ! Coefficient of SpV proportional to zs**4 * zt**2 [m3 kg-1]
+real, parameter :: SPV030 = -1.6506828994e-05 ! Coefficient of SpV proportional to zt**3 [m3 kg-1]
+real, parameter :: SPV130 = 2.4412359055e-05  ! Coefficient of SpV proportional to zs * zt**3 [m3 kg-1]
+real, parameter :: SPV230 = -1.4606740723e-05 ! Coefficient of SpV proportional to zs**2 * zt**3 [m3 kg-1]
+real, parameter :: SPV330 = 2.3293406656e-06  ! Coefficient of SpV proportional to zs**3 * zt**3 [m3 kg-1]
+real, parameter :: SPV040 = 6.7896174634e-06  ! Coefficient of SpV proportional to zt**4 [m3 kg-1]
+real, parameter :: SPV140 = -8.7951832993e-06 ! Coefficient of SpV proportional to zs * zt**4 [m3 kg-1]
+real, parameter :: SPV240 = 4.4249040774e-06  ! Coefficient of SpV proportional to zs**2 * zt**4 [m3 kg-1]
+real, parameter :: SPV050 = -7.2535743349e-07 ! Coefficient of SpV proportional to zt**5 [m3 kg-1]
+real, parameter :: SPV150 = -3.4680559205e-07 ! Coefficient of SpV proportional to zs * zt**5 [m3 kg-1]
+real, parameter :: SPV060 = 1.9041365570e-07  ! Coefficient of SpV proportional to zt**6 [m3 kg-1]
+real, parameter :: SPV001 = -1.6889436589e-05 ! Coefficient of SpV proportional to zp [m3 kg-1]
+real, parameter :: SPV101 = 2.1106556158e-05  ! Coefficient of SpV proportional to zs * zp [m3 kg-1]
+real, parameter :: SPV201 = -2.1322804368e-05 ! Coefficient of SpV proportional to zs**2 * zp [m3 kg-1]
+real, parameter :: SPV301 = 1.7347655458e-05  ! Coefficient of SpV proportional to zs**3 * zp [m3 kg-1]
+real, parameter :: SPV401 = -4.3209400767e-06 ! Coefficient of SpV proportional to zs**4 * zp [m3 kg-1]
+real, parameter :: SPV011 = 1.5355844621e-05  ! Coefficient of SpV proportional to zt * zp [m3 kg-1]
+real, parameter :: SPV111 = 2.0914122241e-06  ! Coefficient of SpV proportional to zs * zt * zp [m3 kg-1]
+real, parameter :: SPV211 = -5.7751479725e-06 ! Coefficient of SpV proportional to zs**2 * zt * zp [m3 kg-1]
+real, parameter :: SPV311 = 1.0767234341e-06  ! Coefficient of SpV proportional to zs**3 * zt * zp [m3 kg-1]
+real, parameter :: SPV021 = -9.6659393016e-06 ! Coefficient of SpV proportional to zt**2 * zp [m3 kg-1]
+real, parameter :: SPV121 = -7.0686982208e-07 ! Coefficient of SpV proportional to zs * zt**2 * zp [m3 kg-1]
+real, parameter :: SPV221 = 1.4488066593e-06  ! Coefficient of SpV proportional to zs**2 * zt**2 * zp [m3 kg-1]
+real, parameter :: SPV031 = 3.1134283336e-06  ! Coefficient of SpV proportional to zt**3 * zp [m3 kg-1]
+real, parameter :: SPV131 = 7.9562529879e-08  ! Coefficient of SpV proportional to zs * zt**3 * zp [m3 kg-1]
+real, parameter :: SPV041 = -5.6590253863e-07 ! Coefficient of SpV proportional to zt * zp [m3 kg-1]
+real, parameter :: SPV002 = 1.0500241168e-06  ! Coefficient of SpV proportional to zp**2 [m3 kg-1]
+real, parameter :: SPV102 = 1.9600661704e-06  ! Coefficient of SpV proportional to zs * zp**2 [m3 kg-1]
+real, parameter :: SPV202 = -2.1666693382e-06 ! Coefficient of SpV proportional to zs**2 * zp**2 [m3 kg-1]
+real, parameter :: SPV012 = -3.8541359685e-06 ! Coefficient of SpV proportional to zt * zp**2 [m3 kg-1]
+real, parameter :: SPV112 = 1.0157632247e-06  ! Coefficient of SpV proportional to zs * zt * zp**2 [m3 kg-1]
+real, parameter :: SPV022 = 1.7178343158e-06  ! Coefficient of SpV proportional to zt**2 * zp**2 [m3 kg-1]
+real, parameter :: SPV003 = -4.1503454190e-07 ! Coefficient of SpV proportional to zp**3 [m3 kg-1]
+real, parameter :: SPV103 = 3.5627020989e-07  ! Coefficient of SpV proportional to zs * zp**3 [m3 kg-1]
+real, parameter :: SPV013 = -1.1293871415e-07 ! Coefficient of SpV proportional to zt * zp**3 [m3 kg-1]
+
+real, parameter :: ALP000 =    SPV010*r1_T0   ! Constant in the dSpV_dT fit [m3 kg-1 degC-1]
+real, parameter :: ALP100 =    SPV110*r1_T0   ! Coefficient of the dSpV_dT fit zs term [m3 kg-1 degC-1]
+real, parameter :: ALP200 =    SPV210*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 term [m3 kg-1 degC-1]
+real, parameter :: ALP300 =    SPV310*r1_T0   ! Coefficient of the dSpV_dT fit zs**3 term [m3 kg-1 degC-1]
+real, parameter :: ALP400 =    SPV410*r1_T0   ! Coefficient of the dSpV_dT fit zs**4 term [m3 kg-1 degC-1]
+real, parameter :: ALP500 =    SPV510*r1_T0   ! Coefficient of the dSpV_dT fit zs**5 term [m3 kg-1 degC-1]
+real, parameter :: ALP010 = 2.*SPV020*r1_T0   ! Coefficient of the dSpV_dT fit zt term [m3 kg-1 degC-1]
+real, parameter :: ALP110 = 2.*SPV120*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt term [m3 kg-1 degC-1]
+real, parameter :: ALP210 = 2.*SPV220*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zt term [m3 kg-1 degC-1]
+real, parameter :: ALP310 = 2.*SPV320*r1_T0   ! Coefficient of the dSpV_dT fit zs**3 * zt term [m3 kg-1 degC-1]
+real, parameter :: ALP410 = 2.*SPV420*r1_T0   ! Coefficient of the dSpV_dT fit zs**4 * zt term [m3 kg-1 degC-1]
+real, parameter :: ALP020 = 3.*SPV030*r1_T0   ! Coefficient of the dSpV_dT fit zt**2 term [m3 kg-1 degC-1]
+real, parameter :: ALP120 = 3.*SPV130*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt**2 term [m3 kg-1 degC-1]
+real, parameter :: ALP220 = 3.*SPV230*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zt**2 term [m3 kg-1 degC-1]
+real, parameter :: ALP320 = 3.*SPV330*r1_T0   ! Coefficient of the dSpV_dT fit zs**3 * zt**2 term [m3 kg-1 degC-1]
+real, parameter :: ALP030 = 4.*SPV040*r1_T0   ! Coefficient of the dSpV_dT fit zt**3 term [m3 kg-1 degC-1]
+real, parameter :: ALP130 = 4.*SPV140*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt**3 term [m3 kg-1 degC-1]
+real, parameter :: ALP230 = 4.*SPV240*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zt**3 term [m3 kg-1 degC-1]
+real, parameter :: ALP040 = 5.*SPV050*r1_T0   ! Coefficient of the dSpV_dT fit zt**4 term [m3 kg-1 degC-1]
+real, parameter :: ALP140 = 5.*SPV150*r1_T0   ! Coefficient of the dSpV_dT fit zs* * zt**4 term [m3 kg-1 degC-1]
+real, parameter :: ALP050 = 6.*SPV060*r1_T0   ! Coefficient of the dSpV_dT fit zt**5 term [m3 kg-1 degC-1]
+real, parameter :: ALP001 =    SPV011*r1_T0   ! Coefficient of the dSpV_dT fit zp term [m3 kg-1 degC-1]
+real, parameter :: ALP101 =    SPV111*r1_T0   ! Coefficient of the dSpV_dT fit zs * zp term [m3 kg-1 degC-1]
+real, parameter :: ALP201 =    SPV211*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zp term [m3 kg-1 degC-1]
+real, parameter :: ALP301 =    SPV311*r1_T0   ! Coefficient of the dSpV_dT fit zs**3 * zp term [m3 kg-1 degC-1]
+real, parameter :: ALP011 = 2.*SPV021*r1_T0   ! Coefficient of the dSpV_dT fit zt * zp term [m3 kg-1 degC-1]
+real, parameter :: ALP111 = 2.*SPV121*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt * zp term [m3 kg-1 degC-1]
+real, parameter :: ALP211 = 2.*SPV221*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zt * zp term [m3 kg-1 degC-1]
+real, parameter :: ALP021 = 3.*SPV031*r1_T0   ! Coefficient of the dSpV_dT fit zt**2 * zp term [m3 kg-1 degC-1]
+real, parameter :: ALP121 = 3.*SPV131*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt**2 * zp term [m3 kg-1 degC-1]
+real, parameter :: ALP031 = 4.*SPV041*r1_T0   ! Coefficient of the dSpV_dT fit zt**3 * zp term [m3 kg-1 degC-1]
+real, parameter :: ALP002 =    SPV012*r1_T0   ! Coefficient of the dSpV_dT fit zp**2 term [m3 kg-1 degC-1]
+real, parameter :: ALP102 =    SPV112*r1_T0   ! Coefficient of the dSpV_dT fit zs * zp**2 term [m3 kg-1 degC-1]
+real, parameter :: ALP012 = 2.*SPV022*r1_T0   ! Coefficient of the dSpV_dT fit zt * zp**2 term [m3 kg-1 degC-1]
+real, parameter :: ALP003 =    SPV013*r1_T0   ! Coefficient of the dSpV_dT fit zp**3 term [m3 kg-1 degC-1]
+
+real, parameter :: BET000 = 0.5*SPV100*r1_S0  ! Constant in the dSpV_dS fit [m3 kg-1 ppt-1]
+real, parameter :: BET100 =     SPV200*r1_S0  ! Coefficient of the dSpV_dS fit zs term [m3 kg-1 ppt-1]
+real, parameter :: BET200 = 1.5*SPV300*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 term [m3 kg-1 ppt-1]
+real, parameter :: BET300 = 2.0*SPV400*r1_S0  ! Coefficient of the dSpV_dS fit zs**3 term [m3 kg-1 ppt-1]
+real, parameter :: BET400 = 2.5*SPV500*r1_S0  ! Coefficient of the dSpV_dS fit zs**4 term [m3 kg-1 ppt-1]
+real, parameter :: BET500 = 3.0*SPV600*r1_S0  ! Coefficient of the dSpV_dS fit zs**5 term [m3 kg-1 ppt-1]
+real, parameter :: BET010 = 0.5*SPV110*r1_S0  ! Coefficient of the dSpV_dS fit zt term [m3 kg-1 ppt-1]
+real, parameter :: BET110 =     SPV210*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt term [m3 kg-1 ppt-1]
+real, parameter :: BET210 = 1.5*SPV310*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zt term [m3 kg-1 ppt-1]
+real, parameter :: BET310 = 2.0*SPV410*r1_S0  ! Coefficient of the dSpV_dS fit zs**3 * zt term [m3 kg-1 ppt-1]
+real, parameter :: BET410 = 2.5*SPV510*r1_S0  ! Coefficient of the dSpV_dS fit zs**4 * zt term [m3 kg-1 ppt-1]
+real, parameter :: BET020 = 0.5*SPV120*r1_S0  ! Coefficient of the dSpV_dS fit zt**2 term [m3 kg-1 ppt-1]
+real, parameter :: BET120 =     SPV220*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt**2 term [m3 kg-1 ppt-1]
+real, parameter :: BET220 = 1.5*SPV320*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zt**2 term [m3 kg-1 ppt-1]
+real, parameter :: BET320 = 2.0*SPV420*r1_S0  ! Coefficient of the dSpV_dS fit zs**3 * zt**2 term [m3 kg-1 ppt-1]
+real, parameter :: BET030 = 0.5*SPV130*r1_S0  ! Coefficient of the dSpV_dS fit zt**3 term [m3 kg-1 ppt-1]
+real, parameter :: BET130 =     SPV230*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt**3 term [m3 kg-1 ppt-1]
+real, parameter :: BET230 = 1.5*SPV330*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zt**3 term [m3 kg-1 ppt-1]
+real, parameter :: BET040 = 0.5*SPV140*r1_S0  ! Coefficient of the dSpV_dS fit zt**4 term [m3 kg-1 ppt-1]
+real, parameter :: BET140 =     SPV240*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt**4 term [m3 kg-1 ppt-1]
+real, parameter :: BET050 = 0.5*SPV150*r1_S0  ! Coefficient of the dSpV_dS fit zt**5 term [m3 kg-1 ppt-1]
+real, parameter :: BET001 = 0.5*SPV101*r1_S0  ! Coefficient of the dSpV_dS fit zp term [m3 kg-1 ppt-1]
+real, parameter :: BET101 =     SPV201*r1_S0  ! Coefficient of the dSpV_dS fit zs * zp term [m3 kg-1 ppt-1]
+real, parameter :: BET201 = 1.5*SPV301*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zp term [m3 kg-1 ppt-1]
+real, parameter :: BET301 = 2.0*SPV401*r1_S0  ! Coefficient of the dSpV_dS fit zs**3 * zp term [m3 kg-1 ppt-1]
+real, parameter :: BET011 = 0.5*SPV111*r1_S0  ! Coefficient of the dSpV_dS fit zt * zp term [m3 kg-1 ppt-1]
+real, parameter :: BET111 =     SPV211*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt * zp term [m3 kg-1 ppt-1]
+real, parameter :: BET211 = 1.5*SPV311*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zt * zp term [m3 kg-1 ppt-1]
+real, parameter :: BET021 = 0.5*SPV121*r1_S0  ! Coefficient of the dSpV_dS fit zt**2 * zp term [m3 kg-1 ppt-1]
+real, parameter :: BET121 =     SPV221*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt**2 * zp term [m3 kg-1 ppt-1]
+real, parameter :: BET031 = 0.5*SPV131*r1_S0  ! Coefficient of the dSpV_dS fit zt**3 * zp term [m3 kg-1 ppt-1]
+real, parameter :: BET002 = 0.5*SPV102*r1_S0  ! Coefficient of the dSpV_dS fit zp**2 term [m3 kg-1 ppt-1]
+real, parameter :: BET102 =     SPV202*r1_S0  ! Coefficient of the dSpV_dS fit zs * zp**2 term [m3 kg-1 ppt-1]
+real, parameter :: BET012 = 0.5*SPV112*r1_S0  ! Coefficient of the dSpV_dS fit zt * zp**2 term [m3 kg-1 ppt-1]
+real, parameter :: BET003 = 0.5*SPV103*r1_S0  ! Coefficient of the dSpV_dS fit zp**3 term [m3 kg-1 ppt-1]
+!>@}
+
+contains
+
+!> Computes the Roquet et al. in situ specific volume of sea water for scalar inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from absolute salinity (S [g kg-1]),
+!! conservative  temperature (T [degC]) and pressure [Pa].  It uses the specific volume polynomial
+!! fit from Roquet et al. (2015).
+!! If spv_ref is present, specvol is an anomaly from spv_ref.
+subroutine calculate_spec_vol_scalar_Roquet_SpV(T, S, pressure, specvol, spv_ref)
+  real,           intent(in)  :: T        !< Conservative temperature [degC]
+  real,           intent(in)  :: S        !< Absolute salinity [g kg-1]
+  real,           intent(in)  :: pressure !< Pressure [Pa]
+  real,           intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
+  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the absolutes salinity [g kg-1]
+  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
+
+  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
+
+  call calculate_spec_vol_array_Roquet_SpV(T0, S0, pressure0, spv0, 1, 1, spv_ref)
+  specvol = spv0(1)
+
+end subroutine calculate_spec_vol_scalar_Roquet_SpV
+
+!> Computes the Roquet et al. in situ specific volume of sea water for 1-d array inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from absolute salinity (S [g kg-1]),
+!! conservative temperature (T [degC]) and pressure [Pa].  It uses the specific volume polynomial
+!! fit from Roquet et al. (2015).
+!! If spv_ref is present, specvol is an anomaly from spv_ref.
+subroutine calculate_spec_vol_array_Roquet_SpV(T, S, pressure, specvol, start, npts, spv_ref)
+  real, dimension(:), intent(in)    :: T        !< Conservative temperature [degC]
+  real, dimension(:), intent(in)    :: S        !< Absolute salinity [g kg-1]
+  real, dimension(:), intent(in)    :: pressure !< pressure [Pa]
+  real, dimension(:), intent(inout) :: specvol  !< in situ specific volume [m3 kg-1]
+  integer,            intent(in)    :: start    !< The starting index for calculations
+  integer,            intent(in)    :: npts     !< the number of values to calculate
+  real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+  ! Local variables
+  real :: zp  ! Pressure, first in [dbar], then normalized by an assumed pressure range [nondim]
+  real :: zt  ! Conservative temperature, first in [degC], then normalized by an assumed temperature range [nondim]
+  real :: zs  ! Absolute salinity, first in [g kg-1], then the square root of salinity with an offset normalized
+              ! by an assumed salinity range [nondim]
+  real :: SV_00p ! A pressure-dependent but temperature and salinity independent contribution to
+                 ! specific volume at the reference temperature and salinity [m3 kg-1]
+  real :: SV_TS  ! Specific volume without a pressure-dependent contribution [m3 kg-1]
+  real :: SV_TS0 ! A contribution to specific volume from temperature and salinity anomalies at
+                 ! the surface pressure [m3 kg-1]
+  real :: SV_TS1 ! A temperature and salinity dependent specific volume contribution that is
+                 ! proportional to pressure [m3 kg-1]
+  real :: SV_TS2 ! A temperature and salinity dependent specific volume contribution that is
+                 ! proportional to pressure**2 [m3 kg-1]
+  real :: SV_TS3 ! A temperature and salinity dependent specific volume contribution that is
+                 ! proportional to pressure**3 [m3 kg-1]
+  real :: SV_0S0 ! Salinity dependent specific volume at the surface pressure and zero temperature [m3 kg-1]
+  integer :: j
+
+  ! The following algorithm was published by Roquet et al. (2015), intended for use in non-Boussinesq ocean models.
+  do j=start,start+npts-1
+    ! Conversions to the units used here.
+    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
+    zp = pressure(j) * (Pa2db*r1_P0)    ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+
+    ! The next two lines should be used if it is necessary to convert potential temperature and
+    ! practical salinity to conservative temperature and absolute salinity.
+    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
+
+    SV_TS3 = SPV003 + (zs*SPV103 + zt*SPV013)
+    SV_TS2 = SPV002 + (zs*(SPV102 +  zs*SPV202) &
+                     + zt*(SPV012 + (zs*SPV112 + zt*SPV022)) )
+    SV_TS1 = SPV001 + (zs*(SPV101 +  zs*(SPV201 +  zs*(SPV301 +  zs*SPV401))) &
+                     + zt*(SPV011 + (zs*(SPV111 +  zs*(SPV211 +  zs*SPV311)) &
+                                   + zt*(SPV021 + (zs*(SPV121 +  zs*SPV221) &
+                                                 + zt*(SPV031 + (zs*SPV131 + zt*SPV041))  )) )) )
+    SV_TS0 = zt*(SPV010 &
+               + (zs*(SPV110 +  zs*(SPV210 +  zs*(SPV310 +  zs*(SPV410 +  zs*SPV510)))) &
+                + zt*(SPV020 + (zs*(SPV120 +  zs*(SPV220 +  zs*(SPV320 +  zs*SPV420))) &
+                              + zt*(SPV030 + (zs*(SPV130 +  zs*(SPV230 +  zs*SPV330)) &
+                                            + zt*(SPV040 + (zs*(SPV140 +  zs*SPV240) &
+                                                          + zt*(SPV050 + (zs*SPV150 + zt*SPV060)) )) )) )) ) )
+
+    SV_0S0 = SPV000 + zs*(SPV100 + zs*(SPV200 + zs*(SPV300 + zs*(SPV400 + zs*(SPV500 + zs*SPV600)))))
+
+    SV_00p = zp*(V00 + zp*(V01 + zp*(V02 + zp*(V03 + zp*(V04 + zp*V05)))))
+
+    if (present(spv_ref)) SV_0S0 = SV_0S0 - spv_ref
+
+    SV_TS  = (SV_TS0 + SV_0S0) + zp*(SV_TS1 + zp*(SV_TS2 +  zp*SV_TS3))
+    specvol(j) = SV_TS + SV_00p  ! In situ specific volume [m3 kg-1]
+  enddo
+
+end subroutine calculate_spec_vol_array_Roquet_SpV
+
+
+!> Compute the in situ density of sea water at a point (rho in [kg m-3]) from absolute
+!! salinity (S [g kg-1]), conservative temperature (T [degC]) and pressure [Pa], using the
+!! specific volume polynomial fit from Roquet et al. (2015).
+subroutine calculate_density_scalar_Roquet_SpV(T, S, pressure, rho, rho_ref)
+  real,           intent(in)  :: T        !< Conservative temperature [degC]
+  real,           intent(in)  :: S        !< Absolute salinity [g kg-1]
+  real,           intent(in)  :: pressure !< Pressure [Pa]
+  real,           intent(out) :: rho      !< In situ density [kg m-3]
+  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
+  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: spv   ! A 1-d array with the specific volume [m3 kg-1]
+
+  T0(1) = T
+  S0(1) = S
+  pressure0(1) = pressure
+
+  if (present(rho_ref)) then
+    call calculate_spec_vol_array_Roquet_SpV(T0, S0, pressure0, spv, 1, 1, spv_ref=1.0/rho_ref)
+    rho = -rho_ref**2*spv(1) / (rho_ref*spv(1) + 1.0)  ! In situ density [kg m-3]
+  else
+    call calculate_spec_vol_array_Roquet_SpV(T0, S0, pressure0, spv, 1, 1)
+    rho = 1.0 / spv(1)
+  endif
+
+end subroutine calculate_density_scalar_Roquet_SpV
+
+!> Compute an array of in situ densities of sea water (rho in [kg m-3]) from absolute
+!! salinity (S [g kg-1]), conservative temperature (T [degC]) and pressure [Pa],
+!! using the specific volume polynomial fit from Roquet et al. (2015).
+subroutine calculate_density_array_Roquet_SpV(T, S, pressure, rho, start, npts, rho_ref)
+  real, dimension(:), intent(in)  :: T        !< Conservative temperature [degC]
+  real, dimension(:), intent(in)  :: S        !< Absolute salinity [g kg-1]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate
+  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+
+  ! Local variables
+  real, dimension(size(T)) :: spv   ! The specific volume [m3 kg-1]
+  integer :: j
+
+  if (present(rho_ref)) then
+    call calculate_spec_vol_array_Roquet_SpV(T, S, pressure, spv, start, npts, spv_ref=1.0/rho_ref)
+    do j=start,start+npts-1
+      rho(j) = -rho_ref**2*spv(j) / (rho_ref*spv(j) + 1.0)  ! In situ density [kg m-3]
+    enddo
+  else
+    call calculate_spec_vol_array_Roquet_SpV(T, S, pressure, spv, start, npts)
+    do j=start,start+npts-1
+      rho(j) = 1.0 / spv(j)  ! In situ density [kg m-3]
+    enddo
+  endif
+
+end subroutine calculate_density_array_Roquet_SpV
+
+!> Return the partial derivatives of specific volume with temperature and salinity for 1-d array
+!! inputs and outputs, using the specific volume polynomial fit from Roquet et al. (2015).
+subroutine calculate_specvol_derivs_Roquet_SpV(T, S, pressure, dSV_dT, dSV_dS, start, npts)
+  real,    intent(in),    dimension(:) :: T        !< Conservative temperature [degC]
+  real,    intent(in),    dimension(:) :: S        !< Absolute salinity [g kg-1]
+  real,    intent(in),    dimension(:) :: pressure !< Pressure [Pa]
+  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
+                                                   !! conservative temperature [m3 kg-1 degC-1]
+  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
+                                                   !! absolute salinity [m3 kg-1 ppt-1]
+  integer, intent(in)                  :: start    !< The starting index for calculations
+  integer, intent(in)                  :: npts     !< The number of values to calculate
+
+  real :: zp  ! Pressure, first in [dbar], then normalized by an assumed pressure range [nondim]
+  real :: zt  ! Conservative temperature, first in [degC], then normalized by an assumed temperature range [nondim]
+  real :: zs  ! Absolute salinity, first in [g kg-1], then the square root of salinity with an offset normalized
+              ! by an assumed salinity range [nondim]
+  real :: dSVdzt0 ! A contribution to the partial derivative of specific volume with temperature [m3 kg-1 degC-1]
+                  ! from temperature anomalies at the surface pressure
+  real :: dSVdzt1 ! A contribution to the partial derivative of specific volume with temperature [m3 kg-1 degC-1]
+                  ! that is proportional to pressure
+  real :: dSVdzt2 ! A contribution to the partial derivative of specific volume with temperature [m3 kg-1 degC-1]
+                  ! that is proportional to pressure^2
+  real :: dSVdzt3 ! A contribution to the partial derivative of specific volume with temperature [m3 kg-1 degC-1]
+                  ! that is proportional to pressure^3
+  real :: dSVdzs0 ! A contribution to the partial derivative of specific volume with
+                  ! salinity [m3 kg-1 ppt-1] from temperature anomalies at the surface pressure
+  real :: dSVdzs1 ! A contribution to the partial derivative of specific volume with
+                  ! salinity [m3 kg-1 ppt-1] proportional to pressure
+  real :: dSVdzs2 ! A contribution to the partial derivative of specific volume with
+                  ! salinity [m3 kg-1 ppt-1] proportional to pressure^2
+  real :: dSVdzs3 ! A contribution to the partial derivative of specific volume with
+                  ! salinity [m3 kg-1 ppt-1] proportional to pressure^3
+  integer :: j
+
+  do j=start,start+npts-1
+    ! Conversions to the units used here.
+    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
+    zp = pressure(j) * (Pa2db*r1_P0)    ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+
+    ! The next two lines should be used if it is necessary to convert potential temperature and
+    ! practical salinity to conservative temperature and absolute salinity.
+    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
+
+    ! Find the partial derivative of specific volume with temperature
+    dSVdzt3 = ALP003
+    dSVdzt2 = ALP002 + (zs*ALP102 + zt*ALP012)
+    dSVdzt1 = ALP001 + (zs*(ALP101 + zs*(ALP201 + zs*ALP301)) &
+                      + zt*(ALP011 + (zs*(ALP111 + zs*ALP211) &
+                                    + zt*(ALP021 + (zs*ALP121 + zt*ALP031)) )) )
+    dSVdzt0 = ALP000 + (zs*(ALP100 +  zs*(ALP200 +  zs*(ALP300 + zs*(ALP400 + zs*ALP500)))) &
+                      + zt*(ALP010 + (zs*(ALP110 +  zs*(ALP210 + zs*(ALP310 + zs*ALP410))) &
+                                    + zt*(ALP020 + (zs*(ALP120 + zs*(ALP220 + zs*ALP320)) &
+                                                  + zt*(ALP030 + (zt*(ALP040 + (zs*ALP140 + zt*ALP050)) &
+                                                                + zs*(ALP130 + zs*ALP230) )) )) )) )
+
+    dSV_dT(j) = dSVdzt0 + zp*(dSVdzt1 + zp*(dSVdzt2 + zp*dSVdzt3))
+
+    ! Find the partial derivative of specific volume with salinity
+    dSVdzs3 = BET003
+    dSVdzs2 = BET002 + (zs*BET102 + zt*BET012)
+    dSVdzs1 = BET001 + (zs*(BET101 + zs*(BET201 + zs*BET301)) &
+                      + zt*(BET011 + (zs*(BET111 + zs*BET211) &
+                                    + zt*(BET021 + (zs*BET121 + zt*BET031)) )) )
+    dSVdzs0 = BET000 + (zs*(BET100 + zs*(BET200 + zs*(BET300 + zs*(BET400 + zs*BET500)))) &
+                      + zt*(BET010 + (zs*(BET110 + zs*(BET210 + zs*(BET310 + zs*BET410))) &
+                                    + zt*(BET020 + (zs*(BET120 + zs*(BET220 + zs*BET320)) &
+                                                  + zt*(BET030 + (zt*(BET040 + (zs*BET140 + zt*BET050)) &
+                                                                + zs*(BET130 + zs*BET230) )) )) )) )
+
+    ! The division by zs here is because zs = sqrt(S + S0), so dSV_dS = dzs_dS * dSV_dzs = (0.5 / zs) * dSV_dzs
+    dSV_dS(j) = (dSVdzs0 + zp*(dSVdzs1 + zp*(dSVdzs2 + zp * dSVdzs3))) / zs
+  enddo
+
+end subroutine calculate_specvol_derivs_Roquet_SpV
+
+
+!> Compute an array of derivatives of densities of sea water with temperature (drho_dT in [kg m-3 degC-1])
+!! and salinity (drho_dS in [kg m-3 ppt-1]) from absolute salinity (S [g kg-1]), conservative temperature
+!! (T [degC]) and pressure [Pa], using the specific volume polynomial fit from Roquet et al. (2015).
+subroutine calculate_density_derivs_array_Roquet_SpV(T, S, pressure, drho_dT, drho_dS, start, npts)
+  real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC]
+  real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1]
+  real,    intent(in),  dimension(:) :: pressure !< pressure [Pa]
+  real,    intent(out), dimension(:) :: drho_dT  !< The partial derivative of density with
+                                                 !! conservative temperature [kg m-3 degC-1]
+  real,    intent(out), dimension(:) :: drho_dS  !< The partial derivative of density with
+                                                 !! absolute salinity [kg m-3 ppt-1]
+  integer, intent(in)                :: start    !< The starting index for calculations
+  integer, intent(in)                :: npts     !< The number of values to calculate
+
+  ! Local variables
+  real, dimension(size(T)) :: specvol  ! The specific volume [m3 kg-1]
+  real, dimension(size(T)) :: dSV_dT   ! The partial derivative of specific volume with
+                                       ! conservative temperature [m3 kg-1 degC-1]
+  real, dimension(size(T)) :: dSV_dS   ! The partial derivative of specific volume with
+                                       ! absolute salinity [m3 kg-1 ppt-1]
+  real :: rho  ! The in situ density [kg m-3]
+  integer :: j
+
+  call calculate_spec_vol_array_Roquet_SpV(T, S, pressure, specvol, start, npts)
+  call calculate_specvol_derivs_Roquet_SpV(T, S, pressure, dSV_dT, dSV_dS, start, npts)
+
+  do j=start,start+npts-1
+    rho = 1.0 / specvol(j)
+    drho_dT(j) = -dSv_dT(j) * rho**2
+    drho_dS(j) = -dSv_dS(j) * rho**2
+  enddo
+
+end subroutine calculate_density_derivs_array_Roquet_SpV
+
+!> Wrapper to calculate_density_derivs_array_Roquet_SpV for scalar inputs
+subroutine calculate_density_derivs_scalar_Roquet_SpV(T, S, pressure, drho_dt, drho_ds)
+  real,    intent(in)  :: T        !< Conservative temperature [degC]
+  real,    intent(in)  :: S        !< Absolute salinity [g kg-1]
+  real,    intent(in)  :: pressure !< Pressure [Pa]
+  real,    intent(out) :: drho_dT  !< The partial derivative of density with
+                                   !! conservative temperature [kg m-3 degC-1]
+  real,    intent(out) :: drho_dS  !< The partial derivative of density with
+                                   !! absolute salinity [kg m-3 ppt-1]
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
+  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: drdt0 ! A 1-d array with a copy of the derivative of density
+                              ! with conservative temperature [kg m-3 degC-1]
+  real, dimension(1) :: drds0 ! A 1-d array with a copy of the derivative of density
+                              ! with absolute salinity [kg m-3 ppt-1]
+
+  T0(1) = T
+  S0(1) = S
+  pressure0(1) = pressure
+
+  call calculate_density_derivs_array_Roquet_SpV(T0, S0, pressure0, drdt0, drds0, 1, 1)
+  drho_dt = drdt0(1)
+  drho_ds = drds0(1)
+end subroutine calculate_density_derivs_scalar_Roquet_SpV
+
+!> Compute the in situ density of sea water (rho in [kg m-3]) and the compressibility
+!! (drho/dp = C_sound^-2, stored as drho_dp [s2 m-2]) from absolute salinity (sal [g kg-1]),
+!! conservative temperature (T [degC]), and pressure [Pa], using the specific volume
+!! polynomial fit from Roquet et al. (2015).
+subroutine calculate_compress_Roquet_SpV(T, S, pressure, rho, drho_dp, start, npts)
+  real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC]
+  real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1]
+  real,    intent(in),  dimension(:) :: pressure !< pressure [Pa]
+  real,    intent(out), dimension(:) :: rho      !< In situ density [kg m-3]
+  real,    intent(out), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
+                                                 !! (also the inverse of the square of sound speed)
+                                                 !! [s2 m-2]
+  integer, intent(in)                :: start    !< The starting index for calculations
+  integer, intent(in)                :: npts     !< The number of values to calculate.
+
+  ! Local variables
+  real :: zp  ! Pressure normalized by an assumed pressure range [nondim]
+  real :: zt  ! Conservative temperature normalized by an assumed temperature range [nondim]
+  real :: zs  ! The square root of absolute salinity with an offset normalized
+              ! by an assumed salinity range [nondim]
+  real :: dSV_00p_dp ! Derivative of the pressure-dependent reference specific volume profile with
+                 ! normalized pressure [m3 kg-1]
+  real :: dSV_TS_dp  ! Derivative of the specific volume anomaly from the reference profile with
+                 ! normalized pressure [m3 kg-1]
+  real :: SV_00p ! A pressure-dependent but temperature and salinity independent contribution to
+                 ! specific volume at the reference temperature and salinity [m3 kg-1]
+  real :: SV_TS  ! specific volume without a pressure-dependent contribution [m3 kg-1]
+  real :: SV_TS0 ! A contribution to specific volume from temperature and salinity anomalies at
+                 ! the surface pressure [m3 kg-1]
+  real :: SV_TS1 ! A temperature and salinity dependent specific volume contribution that is
+                 ! proportional to pressure [m3 kg-1]
+  real :: SV_TS2 ! A temperature and salinity dependent specific volume contribution that is
+                 ! proportional to pressure**2 [m3 kg-1]
+  real :: SV_TS3 ! A temperature and salinity dependent specific volume contribution that is
+                 ! proportional to pressure**3 [m3 kg-1]
+  real :: SV_0S0 ! Salinity dependent specific volume at the surface pressure and zero temperature [m3 kg-1]
+  real :: dSpecVol_dp ! The partial derivative of specific volume with pressure [m3 kg-1 Pa-1]
+  integer :: j
+
+  ! The following algorithm was published by Roquet et al. (2015), intended for use
+  ! with NEMO, but it is not necessarily the algorithm used in NEMO ocean model.
+  do j=start,start+npts-1
+    ! Conversions to the units used here.
+    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
+    zp = pressure(j) * (Pa2db*r1_P0)    ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+
+    ! The next two lines should be used if it is necessary to convert potential temperature and
+    ! practical salinity to conservative temperature and absolute salinity.
+    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
+
+    SV_TS3 = SPV003 + (zs*SPV103 + zt*SPV013)
+    SV_TS2 = SPV002 + (zs*(SPV102 +  zs*SPV202) &
+                     + zt*(SPV012 + (zs*SPV112 + zt*SPV022)) )
+    SV_TS1 = SPV001 + (zs*(SPV101 +  zs*(SPV201 +  zs*(SPV301 +  zs*SPV401))) &
+                     + zt*(SPV011 + (zs*(SPV111 +  zs*(SPV211 +  zs*SPV311)) &
+                                   + zt*(SPV021 + (zs*(SPV121 +  zs*SPV221) &
+                                                 + zt*(SPV031 + (zs*SPV131 + zt*SPV041))  )) )) )
+
+    SV_TS0 = zt*(SPV010 &
+               + (zs*(SPV110 +  zs*(SPV210 +  zs*(SPV310 +  zs*(SPV410 +  zs*SPV510)))) &
+                + zt*(SPV020 + (zs*(SPV120 +  zs*(SPV220 +  zs*(SPV320 +  zs*SPV420))) &
+                              + zt*(SPV030 + (zs*(SPV130 +  zs*(SPV230 +  zs*SPV330)) &
+                                            + zt*(SPV040 + (zs*(SPV140 +  zs*SPV240) &
+                                                          + zt*(SPV050 + (zs*SPV150 + zt*SPV060)) )) )) )) ) )
+
+    SV_0S0 = SPV000 + zs*(SPV100 + zs*(SPV200 + zs*(SPV300 + zs*(SPV400 + zs*(SPV500 + zs*SPV600)))))
+
+    SV_00p = zp*(V00 + zp*(V01 + zp*(V02 + zp*(V03 + zp*(V04 + zp*V05)))))
+
+    SV_TS  = (SV_TS0 + SV_0S0) + zp*(SV_TS1 + zp*(SV_TS2 +  zp*SV_TS3))
+    ! specvol = SV_TS + SV_00p ! In situ specific volume [m3 kg-1]
+    rho(j) = 1.0 / (SV_TS + SV_00p) ! In situ density [kg m-3]
+
+    dSV_00p_dp = V00 + zp*(2.*V01 + zp*(3.*V02 + zp*(4.*V03 + zp*(5.*V04 + zp*(6.*V05)))))
+    dSV_TS_dp  = SV_TS1 + zp*(2.*SV_TS2 + zp*(3.*SV_TS3))
+    dSpecVol_dp = (dSV_TS_dp + dSV_00p_dp) * (Pa2db*r1_P0)  !  [m3 kg-1 Pa-1]
+    drho_dp(j) = -dSpecVol_dp * rho(j)**2 ! Compressibility [s2 m-2]
+
+  enddo
+end subroutine calculate_compress_Roquet_SpV
+
+
+!> Second derivatives of specific volume with respect to temperature, salinity, and pressure for a
+!! 1-d array inputs and outputs using the specific volume polynomial fit from Roquet et al. (2015).
+subroutine calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_ds_dt, dSV_dt_dt, &
+                                                        dSV_ds_dp, dSV_dt_dp, start, npts)
+  real, dimension(:), intent(in   ) :: T !< Conservative temperature [degC]
+  real, dimension(:), intent(in   ) :: S !< Absolute salinity [g kg-1]
+  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
+  real, dimension(:), intent(inout) :: dSV_ds_ds  !< Second derivative of specific volume with respect
+                                                  !! to salinity [m3 kg-1 ppt-2]
+  real, dimension(:), intent(inout) :: dSV_ds_dt  !< Second derivative of specific volume with respect
+                                                  !! to salinity and temperature [m3 kg-1 ppt-1 degC-1]
+  real, dimension(:), intent(inout) :: dSV_dt_dt  !< Second derivative of specific volume with respect
+                                                  !! to temperature [m3 kg-1 degC-2]
+  real, dimension(:), intent(inout) :: dSV_ds_dp  !< Second derivative of specific volume with respect to pressure
+                                                  !! and salinity [m3 kg-1 ppt-1 Pa-1]
+  real, dimension(:), intent(inout) :: dSV_dt_dp  !< Second derivative of specific volume with respect to pressure
+                                                  !! and temperature [m3 kg-1 degC-1 Pa-1]
+  integer,            intent(in   ) :: start !< Starting index in T,S,P
+  integer,            intent(in   ) :: npts  !< Number of points to loop over
+
+  ! Local variables
+  real :: zp  ! Pressure normalized by an assumed pressure range [nondim]
+  real :: zt  ! Conservative temperature normalized by an assumed temperature range [nondim]
+  real :: zs  ! The square root of absolute salinity with an offset normalized
+              ! by an assumed salinity range [nondim]
+  real :: I_s ! The inverse of zs [nondim]
+  real :: d2SV_p0 ! A contribution to one of the second derivatives that is independent of pressure [various]
+  real :: d2SV_p1 ! A contribution to one of the second derivatives that is proportional to pressure [various]
+  real :: d2SV_p2 ! A contribution to one of the second derivatives that is proportional to pressure^2 [various]
+  real :: d2SV_p3 ! A contribution to one of the second derivatives that is proportional to pressure^3 [various]
+  integer :: j
+
+  do j = start,start+npts-1
+    ! Conversions to the units used here.
+    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
+    zp = P(j) * (Pa2db*r1_P0)     ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+
+    ! The next two lines should be used if it is necessary to convert potential temperature and
+    ! practical salinity to conservative temperature and absolute salinity.
+    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 )  ! Convert S from practical to absolute salinity.
+
+    I_s = 1.0 / zs
+
+    ! Find dSV_ds_ds
+    d2SV_p3 = -SPV103*I_s**2
+    d2SV_p2 = -(SPV102 + zt*SPV112)*I_s**2
+    d2SV_p1 = (3.*SPV301 + (zt*(3.*SPV311) + zs*(8.*SPV401))) &
+              - ( SPV101 + zt*(SPV111 + zt*(SPV121 + zt*SPV131)) )*I_s**2
+    d2SV_p0 = (3.*SPV300 + (zs*(8.*SPV400 + zs*(15.*SPV500 + zs*(24.*SPV600))) &
+                          + zt*(3.*SPV310 + (zs*(8.*SPV410 + zs*(15.*SPV510)) &
+                                           + zt*(3.*SPV320 + (zs*(8.*SPV420) + zt*(3.*SPV330))) )) )) &
+              - (SPV100 + zt*(SPV110 + zt*(SPV120 + zt*(SPV130 + zt*(SPV140 + zt*SPV150)))) )*I_s**2
+    dSV_dS_dS(j) = (0.5*r1_S0)**2 * ((d2SV_p0 + zp*(d2SV_p1 + zp*(d2SV_p2 + zp*d2SV_p3))) * I_s)
+
+    ! Find dSV_ds_dt
+    d2SV_p2 = SPV112
+    d2SV_p1 = SPV111 + (zs*(2.*SPV211 +  zs*(3.*SPV311)) &
+                      + zt*(2.*SPV121 + (zs*(4.*SPV221) + zt*(3.*SPV131))) )
+    d2SV_p0 = SPV110 + (zs*(2.*SPV210 +  zs*(3.*SPV310 +  zs*(4.*SPV410 +  zs*(5.*SPV510)))) &
+                      + zt*(2.*SPV120 + (zs*(4.*SPV220 +  zs*(6.*SPV320 +  zs*(8.*SPV420))) &
+                                       + zt*(3.*SPV130 + (zs*(6.*SPV230 +  zs*(9.*SPV330)) &
+                                                        + zt*(4.*SPV140 + (zs*(8.*SPV240) &
+                                                                         + zt*(5.*SPV150))) )) )) )
+    dSV_ds_dt(j) = (0.5*r1_S0*r1_T0) * ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s)
+
+    ! Find dSV_dt_dt
+    d2SV_p2 = 2.*SPV022
+    d2SV_p1 = 2.*SPV021 + (zs*(2.*SPV121 +  zs*(2.*SPV221)) &
+                         + zt*(6.*SPV031 + (zs*(6.*SPV131) + zt*(12.*SPV041))) )
+    d2SV_p0 = 2.*SPV020 + (zs*(2.*SPV120 +  zs*( 2.*SPV220 +  zs*( 2.*SPV320 + zs * (2.*SPV420)))) &
+                         + zt*(6.*SPV030 + (zs*( 6.*SPV130 +  zs*( 6.*SPV230 + zs * (6.*SPV330))) &
+                                          + zt*(12.*SPV040 + (zs*(12.*SPV140 + zs *(12.*SPV240)) &
+                                                            + zt*(20.*SPV050 + (zs*(20.*SPV150) &
+                                                                              + zt*(30.*SPV060) )) )) )) )
+    dSV_dt_dt(j) = (d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * r1_T0**2
+
+    ! Find dSV_ds_dp
+    d2SV_p2 = 3.*SPV103
+    d2SV_p1 = 2.*SPV102 + (zs*(4.*SPV202) + zt*(2.*SPV112))
+    d2SV_p0 = SPV101 + (zs*(2.*SPV201 + zs*(3.*SPV301 +  zs*(4.*SPV401))) &
+                      + zt*(SPV111 +   (zs*(2.*SPV211 +  zs*(3.*SPV311)) &
+                                      + zt*(   SPV121 + (zs*(2.*SPV221) + zt*SPV131)) )) )
+    dSV_ds_dp(j) =  ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s) * (0.5*r1_S0 * Pa2db*r1_P0)
+
+    ! Find dSV_dt_dp
+    d2SV_p2 = 3.*SPV013
+    d2SV_p1 = 2.*SPV012 + (zs*(2.*SPV112) + zt*(4.*SPV022))
+    d2SV_p0 = SPV011 + (zs*(SPV111     + zs*(   SPV211 +  zs*    SPV311)) &
+                      + zt*(2.*SPV021 + (zs*(2.*SPV121 +  zs*(2.*SPV221)) &
+                                       + zt*(3.*SPV031 + (zs*(3.*SPV131) + zt*(4.*SPV041))) )) )
+    dSV_dt_dp(j) =  (d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * (Pa2db*r1_P0* r1_T0)
+  enddo
+
+end subroutine calc_spec_vol_second_derivs_array_Roquet_SpV
+
+
+!> Second derivatives of density with respect to temperature, salinity, and pressure for a
+!! 1-d array inputs and outputs using the specific volume polynomial fit from Roquet et al. (2015).
+subroutine calculate_density_second_derivs_array_Roquet_SpV(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+                                                            drho_ds_dp, drho_dt_dp, start, npts)
+  real, dimension(:), intent(in   ) :: T !< Conservative temperature [degC]
+  real, dimension(:), intent(in   ) :: S !< Absolute salinity [g kg-1]
+  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
+  real, dimension(:), intent(inout) :: drho_ds_ds !< Second derivative of density with respect
+                                                  !! to salinity [kg m-3 ppt-2]
+  real, dimension(:), intent(inout) :: drho_ds_dt !< Second derivative of density with respect
+                                                  !! to salinity and temperature [kg m-3 ppt-1 degC-1]
+  real, dimension(:), intent(inout) :: drho_dt_dt !< Second derivative of density with respect
+                                                  !! to temperature [kg m-3 degC-2]
+  real, dimension(:), intent(inout) :: drho_ds_dp !< Second derivative of density with respect to pressure
+                                                  !! and salinity [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
+  real, dimension(:), intent(inout) :: drho_dt_dp !< Second derivative of density with respect to pressure
+                                                  !! and temperature [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  integer,            intent(in   ) :: start !< Starting index in T,S,P
+  integer,            intent(in   ) :: npts  !< Number of points to loop over
+
+  ! Local variables
+  real, dimension(size(T)) :: rho       ! The in situ density [kg m-3]
+  real, dimension(size(T)) :: drho_dp   ! The partial derivative of density with pressure
+                                        ! (also the inverse of the square of sound speed)  [s2 m-2]
+  real, dimension(size(T)) :: dSV_dT    ! The partial derivative of specific volume with
+                                        ! conservative temperature [m3 kg-1 degC-1]
+  real, dimension(size(T)) :: dSV_dS    ! The partial derivative of specific volume with
+                                        ! absolute salinity [m3 kg-1 ppt-1]
+  real, dimension(size(T)) :: dSV_ds_ds ! Second derivative of specific volume with respect
+                                        ! to salinity [m3 kg-1 ppt-2]
+  real, dimension(size(T)) :: dSV_ds_dt ! Second derivative of specific volume with respect
+                                        ! to salinity and temperature [m3 kg-1 ppt-1 degC-1]
+  real, dimension(size(T)) :: dSV_dt_dt ! Second derivative of specific volume with respect
+                                        ! to temperature [m3 kg-1 degC-2]
+  real, dimension(size(T)) :: dSV_ds_dp ! Second derivative of specific volume with respect to pressure
+                                        ! and salinity [m3 kg-1 ppt-1 Pa-1]
+  real, dimension(size(T)) :: dSV_dt_dp ! Second derivative of specific volume with respect to pressure
+                                        ! and temperature [m3 kg-1 degC-1 Pa-1]
+  integer :: j
+
+  call calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_ds_dt, dSV_dt_dt, &
+                                                    dSV_ds_dp, dSV_dt_dp, start, npts)
+  call calculate_specvol_derivs_Roquet_SpV(T, S, P, dSV_dT, dSV_dS, start, npts)
+  call calculate_compress_Roquet_SpV(T, S, P, rho, drho_dp, start, npts)
+
+  do j = start,start+npts-1
+    ! Find drho_ds_ds
+    drho_dS_dS(j) = rho(j)**2 * (2.0*rho(j)*dSV_dS(j)**2 - dSV_dS_dS(j))
+
+    ! Find drho_ds_dt
+    drho_ds_dt(j) = rho(j)**2 * (2.0*rho(j)*(dSV_dT(j)*dSV_dS(j)) - dSV_dS_dT(j))
+
+    ! Find drho_dt_dt
+    drho_dT_dT(j) = rho(j)**2 * (2.0*rho(j)*dSV_dT(j)**2 - dSV_dT_dT(j))
+
+    ! Find drho_ds_dp
+    drho_ds_dp(j) =  -rho(j) * (2.0*dSV_dS(j) * drho_dp(j) + rho(j) * dSV_dS_dp(j))
+
+    ! Find drho_dt_dp
+    drho_dt_dp(j) =  -rho(j) * (2.0*dSV_dT(j) * drho_dp(j) + rho(j) * dSV_dT_dp(j))
+  enddo
+
+end subroutine calculate_density_second_derivs_array_Roquet_SpV
+
+!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
+!!
+!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
+subroutine calculate_density_second_derivs_scalar_Roquet_SpV(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+                                                             drho_ds_dp, drho_dt_dp)
+  real, intent(in   ) :: T          !< Conservative temperature [degC]
+  real, intent(in   ) :: S          !< Absolute salinity [g kg-1]
+  real, intent(in   ) :: P          !< pressure [Pa]
+  real, intent(  out) :: drho_ds_ds !< Second derivative of density with respect
+                                    !! to salinity [kg m-3 ppt-2]
+  real, intent(  out) :: drho_ds_dt !< Second derivative of density with respect
+                                    !! to salinity and temperature [kg m-3 ppt-1 degC-1]
+  real, intent(  out) :: drho_dt_dt !< Second derivative of density with respect
+                                    !! to temperature [kg m-3 degC-2]
+  real, intent(  out) :: drho_ds_dp !< Second derivative of density with respect to pressure
+                                    !! and salinity [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
+  real, intent(  out) :: drho_dt_dp !< Second derivative of density with respect to pressure
+                                    !! and temperature [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [g kg-1]
+  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 ppt-2]
+  real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
+                               ! temperature [kg m-3 ppt-1 degC-1]
+  real, dimension(1) :: drdtdt ! The second derivative of density with temperature [kg m-3 degC-2]
+  real, dimension(1) :: drdsdp ! The second derivative of density with salinity and
+                               ! pressure [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
+  real, dimension(1) :: drdtdp ! The second derivative of density with temperature and
+                               ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+
+  T0(1) = T
+  S0(1) = S
+  P0(1) = P
+  call calculate_density_second_derivs_array_Roquet_SpV(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
+  drho_ds_ds = drdsds(1)
+  drho_ds_dt = drdsdt(1)
+  drho_dt_dt = drdtdt(1)
+  drho_ds_dp = drdsdp(1)
+  drho_dt_dp = drdtdp(1)
+
+end subroutine calculate_density_second_derivs_scalar_Roquet_SpV
+
+!> \namespace mom_eos_Roquet_SpV
+!!
+!! \section section_EOS_Roquet_SpV NEMO equation of state
+!!
+!!  Fabien Roquet and colleagues developed this equation of state using a simple polynomial fit
+!! to the TEOS-10 equation of state expressions for specific, for efficiency when used with a
+!! non-Boussinesq ocean model.  This particular equation of state is a balance between an
+!! accuracy that matches the TEOS-10 density to better than observational uncertainty with a
+!! polynomial form that can be evaluated quickly despite having 55 terms.
+!!
+!! \subsection section_EOS_Roquet_Spv_references References
+!!
+!! Roquet, F., Madec, G., McDougall, T. J., and Barker, P. M., 2015:
+!!  Accurate polynomial expressions for the density and specific volume
+!!  of seawater using the TEOS-10 standard. Ocean Modelling, 90:29-43.
+
+end module MOM_EOS_Roquet_Spv

--- a/src/equation_of_state/MOM_EOS_Roquet_SpV.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_SpV.F90
@@ -40,145 +40,148 @@ interface calculate_density_second_derivs_Roquet_SpV
   module procedure calculate_density_second_derivs_array_Roquet_SpV
 end interface calculate_density_second_derivs_Roquet_SpV
 
-real, parameter :: Pa2db  = 1.e-4 !< Conversion factor between Pa and dbar [dbar Pa-1]
+real, parameter :: Pa2kb  = 1.e-8 !< Conversion factor between Pa and kbar [kbar Pa-1]
 !>@{ Parameters in the Roquet specific volume polynomial equation of state
-real, parameter :: rdeltaS = 24.    ! An offset to salinity before taking its square root [g kg-1]
-real, parameter :: r1_S0  = 0.875/35.16504  ! The inverse of a plausible range of oceanic salinities [kg g-1]
-real, parameter :: r1_T0  = 1./40.  ! The inverse of a plausible range of oceanic temperatures [degC-1]
-real, parameter :: r1_P0  = 1.e-4   ! The inverse of a plausible range of oceanic pressures [dbar-1]
-real, parameter :: V00 = -4.4015007269e-05 ! Contribution to SpV00p proportional to zp [m3 kg-1]
-real, parameter :: V01 = 6.9232335784e-06  ! Contribution to SpV00p proportional to zp**2 [m3 kg-1]
-real, parameter :: V02 = -7.5004675975e-07 ! Contribution to SpV00p proportional to zp**3 [m3 kg-1]
-real, parameter :: V03 = 1.7009109288e-08  ! Contribution to SpV00p proportional to zp**4 [m3 kg-1]
-real, parameter :: V04 = -1.6884162004e-08 ! Contribution to SpV00p proportional to zp**5 [m3 kg-1]
-real, parameter :: V05 = 1.9613503930e-09  ! Contribution to SpV00p proportional to zp**6 [m3 kg-1]
+real, parameter :: rdeltaS = 24.          ! An offset to salinity before taking its square root [g kg-1]
+real, parameter :: r1_S0 = 0.875/35.16504 ! The inverse of a plausible range of oceanic salinities [kg g-1]
+real, parameter :: I_Ts = 0.025           ! The inverse of a plausible range of oceanic temperatures [degC-1]
+! The following are the coefficients of the fit to the reference density profile (rho00p) as a function of
+! pressure (P), with a contribution R0c * P**(c+1).  The nomenclature follows Roquet.
+real, parameter :: V00 = -4.4015007269e-05*Pa2kb    ! SpV00p P coef.    [m3 kg-1 Pa-1]
+real, parameter :: V01 = 6.9232335784e-06*Pa2kb**2  ! SpV00p P**2 coef. [m3 kg-1 Pa-2]
+real, parameter :: V02 = -7.5004675975e-07*Pa2kb**3 ! SpV00p P**3 coef. [m3 kg-1 Pa-3]
+real, parameter :: V03 = 1.7009109288e-08*Pa2kb**4  ! SpV00p P**4 coef. [m3 kg-1 Pa-4]
+real, parameter :: V04 = -1.6884162004e-08*Pa2kb**5 ! SpV00p P**5 coef. [m3 kg-1 Pa-5]
+real, parameter :: V05 = 1.9613503930e-09*Pa2kb**6  ! SpV00p P**6 coef. [m3 kg-1 Pa-6]
 
-! The following terms are contributions to specific volume as a function of the normalized square root of salinity
-! with an offset (zs),  temperature (zt) and pressure (zp), with a contribution SPVabc * zs**a * zt**b * zp**c
-real, parameter :: SPV000 = 1.0772899069e-03  ! A constant specific volume (SpV) contribution [m3 kg-1]
-real, parameter :: SPV100 = -3.1263658781e-04 ! Coefficient of SpV proportional to zs [m3 kg-1]
-real, parameter :: SPV200 = 6.7615860683e-04  ! Coefficient of SpV proportional to zs**2 [m3 kg-1]
-real, parameter :: SPV300 = -8.6127884515e-04 ! Coefficient of SpV proportional to zs**3 [m3 kg-1]
-real, parameter :: SPV400 = 5.9010812596e-04  ! Coefficient of SpV proportional to zs**4 [m3 kg-1]
-real, parameter :: SPV500 = -2.1503943538e-04 ! Coefficient of SpV proportional to zs**5 [m3 kg-1]
-real, parameter :: SPV600 = 3.2678954455e-05  ! Coefficient of SpV proportional to zs**6 [m3 kg-1]
-real, parameter :: SPV010 = -1.4949652640e-05 ! Coefficient of SpV proportional to zt [m3 kg-1]
-real, parameter :: SPV110 = 3.1866349188e-05  ! Coefficient of SpV proportional to zs * zt [m3 kg-1]
-real, parameter :: SPV210 = -3.8070687610e-05 ! Coefficient of SpV proportional to zs**2 * zt [m3 kg-1]
-real, parameter :: SPV310 = 2.9818473563e-05  ! Coefficient of SpV proportional to zs**3 * zt [m3 kg-1]
-real, parameter :: SPV410 = -1.0011321965e-05 ! Coefficient of SpV proportional to zs**4 * zt [m3 kg-1]
-real, parameter :: SPV510 = 1.0751931163e-06  ! Coefficient of SpV proportional to zs**5 * zt [m3 kg-1]
-real, parameter :: SPV020 = 2.7546851539e-05  ! Coefficient of SpV proportional to zt**2 [m3 kg-1]
-real, parameter :: SPV120 = -3.6597334199e-05 ! Coefficient of SpV proportional to zs * zt**2 [m3 kg-1]
-real, parameter :: SPV220 = 3.4489154625e-05  ! Coefficient of SpV proportional to zs**2 * zt**2 [m3 kg-1]
-real, parameter :: SPV320 = -1.7663254122e-05 ! Coefficient of SpV proportional to zs**3 * zt**2 [m3 kg-1]
-real, parameter :: SPV420 = 3.5965131935e-06  ! Coefficient of SpV proportional to zs**4 * zt**2 [m3 kg-1]
-real, parameter :: SPV030 = -1.6506828994e-05 ! Coefficient of SpV proportional to zt**3 [m3 kg-1]
-real, parameter :: SPV130 = 2.4412359055e-05  ! Coefficient of SpV proportional to zs * zt**3 [m3 kg-1]
-real, parameter :: SPV230 = -1.4606740723e-05 ! Coefficient of SpV proportional to zs**2 * zt**3 [m3 kg-1]
-real, parameter :: SPV330 = 2.3293406656e-06  ! Coefficient of SpV proportional to zs**3 * zt**3 [m3 kg-1]
-real, parameter :: SPV040 = 6.7896174634e-06  ! Coefficient of SpV proportional to zt**4 [m3 kg-1]
-real, parameter :: SPV140 = -8.7951832993e-06 ! Coefficient of SpV proportional to zs * zt**4 [m3 kg-1]
-real, parameter :: SPV240 = 4.4249040774e-06  ! Coefficient of SpV proportional to zs**2 * zt**4 [m3 kg-1]
-real, parameter :: SPV050 = -7.2535743349e-07 ! Coefficient of SpV proportional to zt**5 [m3 kg-1]
-real, parameter :: SPV150 = -3.4680559205e-07 ! Coefficient of SpV proportional to zs * zt**5 [m3 kg-1]
-real, parameter :: SPV060 = 1.9041365570e-07  ! Coefficient of SpV proportional to zt**6 [m3 kg-1]
-real, parameter :: SPV001 = -1.6889436589e-05 ! Coefficient of SpV proportional to zp [m3 kg-1]
-real, parameter :: SPV101 = 2.1106556158e-05  ! Coefficient of SpV proportional to zs * zp [m3 kg-1]
-real, parameter :: SPV201 = -2.1322804368e-05 ! Coefficient of SpV proportional to zs**2 * zp [m3 kg-1]
-real, parameter :: SPV301 = 1.7347655458e-05  ! Coefficient of SpV proportional to zs**3 * zp [m3 kg-1]
-real, parameter :: SPV401 = -4.3209400767e-06 ! Coefficient of SpV proportional to zs**4 * zp [m3 kg-1]
-real, parameter :: SPV011 = 1.5355844621e-05  ! Coefficient of SpV proportional to zt * zp [m3 kg-1]
-real, parameter :: SPV111 = 2.0914122241e-06  ! Coefficient of SpV proportional to zs * zt * zp [m3 kg-1]
-real, parameter :: SPV211 = -5.7751479725e-06 ! Coefficient of SpV proportional to zs**2 * zt * zp [m3 kg-1]
-real, parameter :: SPV311 = 1.0767234341e-06  ! Coefficient of SpV proportional to zs**3 * zt * zp [m3 kg-1]
-real, parameter :: SPV021 = -9.6659393016e-06 ! Coefficient of SpV proportional to zt**2 * zp [m3 kg-1]
-real, parameter :: SPV121 = -7.0686982208e-07 ! Coefficient of SpV proportional to zs * zt**2 * zp [m3 kg-1]
-real, parameter :: SPV221 = 1.4488066593e-06  ! Coefficient of SpV proportional to zs**2 * zt**2 * zp [m3 kg-1]
-real, parameter :: SPV031 = 3.1134283336e-06  ! Coefficient of SpV proportional to zt**3 * zp [m3 kg-1]
-real, parameter :: SPV131 = 7.9562529879e-08  ! Coefficient of SpV proportional to zs * zt**3 * zp [m3 kg-1]
-real, parameter :: SPV041 = -5.6590253863e-07 ! Coefficient of SpV proportional to zt * zp [m3 kg-1]
-real, parameter :: SPV002 = 1.0500241168e-06  ! Coefficient of SpV proportional to zp**2 [m3 kg-1]
-real, parameter :: SPV102 = 1.9600661704e-06  ! Coefficient of SpV proportional to zs * zp**2 [m3 kg-1]
-real, parameter :: SPV202 = -2.1666693382e-06 ! Coefficient of SpV proportional to zs**2 * zp**2 [m3 kg-1]
-real, parameter :: SPV012 = -3.8541359685e-06 ! Coefficient of SpV proportional to zt * zp**2 [m3 kg-1]
-real, parameter :: SPV112 = 1.0157632247e-06  ! Coefficient of SpV proportional to zs * zt * zp**2 [m3 kg-1]
-real, parameter :: SPV022 = 1.7178343158e-06  ! Coefficient of SpV proportional to zt**2 * zp**2 [m3 kg-1]
-real, parameter :: SPV003 = -4.1503454190e-07 ! Coefficient of SpV proportional to zp**3 [m3 kg-1]
-real, parameter :: SPV103 = 3.5627020989e-07  ! Coefficient of SpV proportional to zs * zp**3 [m3 kg-1]
-real, parameter :: SPV013 = -1.1293871415e-07 ! Coefficient of SpV proportional to zt * zp**3 [m3 kg-1]
+! The following terms are contributions to specific volume (SpV) as a function of the square root of
+! normalized absolute salinity with an offset (zs), temperature (T) and pressure (P), with a contribution
+! SPVabc * zs**a * T**b * P**c.  The numbers here are copied directly from Roquet et al. (2015), but
+! the expressions here do not use the same nondimensionalization for pressure or temperature as they do.
+real, parameter :: SPV000 = 1.0772899069e-03                  ! Constant SpV contribution  [m3 kg-1]
+real, parameter :: SPV100 = -3.1263658781e-04                 ! SpV zs coef.               [m3 kg-1]
+real, parameter :: SPV200 = 6.7615860683e-04                  ! SpV zs**2 coef.            [m3 kg-1]
+real, parameter :: SPV300 = -8.6127884515e-04                 ! SpV zs**3 coef.            [m3 kg-1]
+real, parameter :: SPV400 = 5.9010812596e-04                  ! SpV zs**4 coef.            [m3 kg-1]
+real, parameter :: SPV500 = -2.1503943538e-04                 ! SpV zs**5 coef.            [m3 kg-1]
+real, parameter :: SPV600 = 3.2678954455e-05                  ! SpV zs**6 coef.            [m3 kg-1]
+real, parameter :: SPV010 = -1.4949652640e-05*I_Ts            ! SpV T coef.         [m3 kg-1 degC-1]
+real, parameter :: SPV110 = 3.1866349188e-05*I_Ts             ! SpV zs * T coef.    [m3 kg-1 degC-1]
+real, parameter :: SPV210 = -3.8070687610e-05*I_Ts            ! SpV zs**2 * T coef. [m3 kg-1 degC-1]
+real, parameter :: SPV310 = 2.9818473563e-05*I_Ts             ! SpV zs**3 * T coef. [m3 kg-1 degC-1]
+real, parameter :: SPV410 = -1.0011321965e-05*I_Ts            ! SpV zs**4 * T coef. [m3 kg-1 degC-1]
+real, parameter :: SPV510 = 1.0751931163e-06*I_Ts             ! SpV zs**5 * T coef. [m3 kg-1 degC-1]
+real, parameter :: SPV020 = 2.7546851539e-05*I_Ts**2          ! SpV T**2 coef.      [m3 kg-1 degC-2]
+real, parameter :: SPV120 = -3.6597334199e-05*I_Ts**2         ! SpV zs * T**2 coef. [m3 kg-1 degC-2]
+real, parameter :: SPV220 = 3.4489154625e-05*I_Ts**2          ! SpV zs**2 * T**2 coef. [m3 kg-1 degC-2]
+real, parameter :: SPV320 = -1.7663254122e-05*I_Ts**2         ! SpV zs**3 * T**2 coef. [m3 kg-1 degC-2]
+real, parameter :: SPV420 = 3.5965131935e-06*I_Ts**2          ! SpV zs**4 * T**2 coef. [m3 kg-1 degC-2]
+real, parameter :: SPV030 = -1.6506828994e-05*I_Ts**3         ! SpV T**3 coef.      [m3 kg-1 degC-3]
+real, parameter :: SPV130 = 2.4412359055e-05*I_Ts**3          ! SpV zs * T**3 coef. [m3 kg-1 degC-3]
+real, parameter :: SPV230 = -1.4606740723e-05*I_Ts**3         ! SpV zs**2 * T**3 coef. [m3 kg-1 degC-3]
+real, parameter :: SPV330 = 2.3293406656e-06*I_Ts**3          ! SpV zs**3 * T**3 coef. [m3 kg-1 degC-3]
+real, parameter :: SPV040 = 6.7896174634e-06*I_Ts**4          ! SpV T**4 coef.      [m3 kg-1 degC-4]
+real, parameter :: SPV140 = -8.7951832993e-06*I_Ts**4         ! SpV zs * T**4 coef. [m3 kg-1 degC-4]
+real, parameter :: SPV240 = 4.4249040774e-06*I_Ts**4          ! SpV zs**2 * T**4 coef. [m3 kg-1 degC-4]
+real, parameter :: SPV050 = -7.2535743349e-07*I_Ts**5         ! SpV T**5 coef.      [m3 kg-1 degC-5]
+real, parameter :: SPV150 = -3.4680559205e-07*I_Ts**5         ! SpV zs * T**5 coef. [m3 kg-1 degC-5]
+real, parameter :: SPV060 = 1.9041365570e-07*I_Ts**6          ! SpV T**6 coef.      [m3 kg-1 degC-6]
+real, parameter :: SPV001 = -1.6889436589e-05*Pa2kb           ! SpV P coef.           [m3 kg-1 Pa-1]
+real, parameter :: SPV101 = 2.1106556158e-05*Pa2kb            ! SpV zs * P coef.      [m3 kg-1 Pa-1]
+real, parameter :: SPV201 = -2.1322804368e-05*Pa2kb           ! SpV zs**2 * P coef.   [m3 kg-1 Pa-1]
+real, parameter :: SPV301 = 1.7347655458e-05*Pa2kb            ! SpV zs**3 * P coef.   [m3 kg-1 Pa-1]
+real, parameter :: SPV401 = -4.3209400767e-06*Pa2kb           ! SpV zs**4 * P coef.   [m3 kg-1 Pa-1]
+real, parameter :: SPV011 = 1.5355844621e-05*(I_Ts*Pa2kb)     ! SpV T * P coef. [m3 kg-1 degC-1 Pa-1]
+real, parameter :: SPV111 = 2.0914122241e-06*(I_Ts*Pa2kb)     ! SpV zs * T * P coef. [m3 kg-1 degC-1 Pa-1]
+real, parameter :: SPV211 = -5.7751479725e-06*(I_Ts*Pa2kb)    ! SpV zs**2 * T * P coef. [m3 kg-1 degC-1 Pa-1]
+real, parameter :: SPV311 = 1.0767234341e-06*(I_Ts*Pa2kb)     ! SpV zs**3 * T * P coef. [m3 kg-1 degC-1 Pa-1]
+real, parameter :: SPV021 = -9.6659393016e-06*(I_Ts**2*Pa2kb) ! SpV T**2 * P coef. [m3 kg-1 degC-2 Pa-1]
+real, parameter :: SPV121 = -7.0686982208e-07*(I_Ts**2*Pa2kb) ! SpV zs * T**2 * P coef. [m3 kg-1 degC-2 Pa-1]
+real, parameter :: SPV221 = 1.4488066593e-06*(I_Ts**2*Pa2kb)  ! SpV zs**2 * T**2 * P coef. [m3 kg-1 degC-2 Pa-1]
+real, parameter :: SPV031 = 3.1134283336e-06*(I_Ts**3*Pa2kb)  ! SpV T**3 * P coef. [m3 kg-1 degC-3 Pa-1]
+real, parameter :: SPV131 = 7.9562529879e-08*(I_Ts**3*Pa2kb)  ! SpV zs * T**3 * P coef. [m3 kg-1 degC-3 Pa-1]
+real, parameter :: SPV041 = -5.6590253863e-07*(I_Ts**4*Pa2kb) ! SpV T**4 * P coef. [m3 kg-1 degC-4 Pa-1]
+real, parameter :: SPV002 = 1.0500241168e-06*Pa2kb**2         ! SpV P**2 coef.        [m3 kg-1 Pa-2]
+real, parameter :: SPV102 = 1.9600661704e-06*Pa2kb**2         ! SpV zs * P**2 coef.   [m3 kg-1 Pa-2]
+real, parameter :: SPV202 = -2.1666693382e-06*Pa2kb**2        ! SpV zs**2 * P**2 coef. [m3 kg-1 Pa-2]
+real, parameter :: SPV012 = -3.8541359685e-06*(I_Ts*Pa2kb**2) ! SpV T * P**2 coef. [m3 kg-1 degC-1 Pa-2]
+real, parameter :: SPV112 = 1.0157632247e-06*(I_Ts*Pa2kb**2)  ! SpV zs * T * P**2 coef. [m3 kg-1 degC-1 Pa-2]
+real, parameter :: SPV022 = 1.7178343158e-06*(I_Ts**2*Pa2kb**2) ! SpV T**2 * P**2 coef. [m3 kg-1 degC-2 Pa-2]
+real, parameter :: SPV003 = -4.1503454190e-07*Pa2kb**3        ! SpV P**3 coef.        [m3 kg-1 Pa-3]
+real, parameter :: SPV103 = 3.5627020989e-07*Pa2kb**3         ! SpV zs * P**3 coef.   [m3 kg-1 Pa-3]
+real, parameter :: SPV013 = -1.1293871415e-07*(I_Ts*Pa2kb**3) ! SpV T * P**3 coef. [m3 kg-1 degC-1 Pa-3]
 
-real, parameter :: ALP000 =    SPV010*r1_T0   ! Constant in the dSpV_dT fit [m3 kg-1 degC-1]
-real, parameter :: ALP100 =    SPV110*r1_T0   ! Coefficient of the dSpV_dT fit zs term [m3 kg-1 degC-1]
-real, parameter :: ALP200 =    SPV210*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 term [m3 kg-1 degC-1]
-real, parameter :: ALP300 =    SPV310*r1_T0   ! Coefficient of the dSpV_dT fit zs**3 term [m3 kg-1 degC-1]
-real, parameter :: ALP400 =    SPV410*r1_T0   ! Coefficient of the dSpV_dT fit zs**4 term [m3 kg-1 degC-1]
-real, parameter :: ALP500 =    SPV510*r1_T0   ! Coefficient of the dSpV_dT fit zs**5 term [m3 kg-1 degC-1]
-real, parameter :: ALP010 = 2.*SPV020*r1_T0   ! Coefficient of the dSpV_dT fit zt term [m3 kg-1 degC-1]
-real, parameter :: ALP110 = 2.*SPV120*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt term [m3 kg-1 degC-1]
-real, parameter :: ALP210 = 2.*SPV220*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zt term [m3 kg-1 degC-1]
-real, parameter :: ALP310 = 2.*SPV320*r1_T0   ! Coefficient of the dSpV_dT fit zs**3 * zt term [m3 kg-1 degC-1]
-real, parameter :: ALP410 = 2.*SPV420*r1_T0   ! Coefficient of the dSpV_dT fit zs**4 * zt term [m3 kg-1 degC-1]
-real, parameter :: ALP020 = 3.*SPV030*r1_T0   ! Coefficient of the dSpV_dT fit zt**2 term [m3 kg-1 degC-1]
-real, parameter :: ALP120 = 3.*SPV130*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt**2 term [m3 kg-1 degC-1]
-real, parameter :: ALP220 = 3.*SPV230*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zt**2 term [m3 kg-1 degC-1]
-real, parameter :: ALP320 = 3.*SPV330*r1_T0   ! Coefficient of the dSpV_dT fit zs**3 * zt**2 term [m3 kg-1 degC-1]
-real, parameter :: ALP030 = 4.*SPV040*r1_T0   ! Coefficient of the dSpV_dT fit zt**3 term [m3 kg-1 degC-1]
-real, parameter :: ALP130 = 4.*SPV140*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt**3 term [m3 kg-1 degC-1]
-real, parameter :: ALP230 = 4.*SPV240*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zt**3 term [m3 kg-1 degC-1]
-real, parameter :: ALP040 = 5.*SPV050*r1_T0   ! Coefficient of the dSpV_dT fit zt**4 term [m3 kg-1 degC-1]
-real, parameter :: ALP140 = 5.*SPV150*r1_T0   ! Coefficient of the dSpV_dT fit zs* * zt**4 term [m3 kg-1 degC-1]
-real, parameter :: ALP050 = 6.*SPV060*r1_T0   ! Coefficient of the dSpV_dT fit zt**5 term [m3 kg-1 degC-1]
-real, parameter :: ALP001 =    SPV011*r1_T0   ! Coefficient of the dSpV_dT fit zp term [m3 kg-1 degC-1]
-real, parameter :: ALP101 =    SPV111*r1_T0   ! Coefficient of the dSpV_dT fit zs * zp term [m3 kg-1 degC-1]
-real, parameter :: ALP201 =    SPV211*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zp term [m3 kg-1 degC-1]
-real, parameter :: ALP301 =    SPV311*r1_T0   ! Coefficient of the dSpV_dT fit zs**3 * zp term [m3 kg-1 degC-1]
-real, parameter :: ALP011 = 2.*SPV021*r1_T0   ! Coefficient of the dSpV_dT fit zt * zp term [m3 kg-1 degC-1]
-real, parameter :: ALP111 = 2.*SPV121*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt * zp term [m3 kg-1 degC-1]
-real, parameter :: ALP211 = 2.*SPV221*r1_T0   ! Coefficient of the dSpV_dT fit zs**2 * zt * zp term [m3 kg-1 degC-1]
-real, parameter :: ALP021 = 3.*SPV031*r1_T0   ! Coefficient of the dSpV_dT fit zt**2 * zp term [m3 kg-1 degC-1]
-real, parameter :: ALP121 = 3.*SPV131*r1_T0   ! Coefficient of the dSpV_dT fit zs * zt**2 * zp term [m3 kg-1 degC-1]
-real, parameter :: ALP031 = 4.*SPV041*r1_T0   ! Coefficient of the dSpV_dT fit zt**3 * zp term [m3 kg-1 degC-1]
-real, parameter :: ALP002 =    SPV012*r1_T0   ! Coefficient of the dSpV_dT fit zp**2 term [m3 kg-1 degC-1]
-real, parameter :: ALP102 =    SPV112*r1_T0   ! Coefficient of the dSpV_dT fit zs * zp**2 term [m3 kg-1 degC-1]
-real, parameter :: ALP012 = 2.*SPV022*r1_T0   ! Coefficient of the dSpV_dT fit zt * zp**2 term [m3 kg-1 degC-1]
-real, parameter :: ALP003 =    SPV013*r1_T0   ! Coefficient of the dSpV_dT fit zp**3 term [m3 kg-1 degC-1]
+real, parameter :: ALP000 =    SPV010   ! Constant in the dSpV_dT fit               [m3 kg-1 degC-1]
+real, parameter :: ALP100 =    SPV110   ! dSpV_dT fit zs coef.                      [m3 kg-1 degC-1]
+real, parameter :: ALP200 =    SPV210   ! dSpV_dT fit zs**2 coef.                   [m3 kg-1 degC-1]
+real, parameter :: ALP300 =    SPV310   ! dSpV_dT fit zs**3 coef.                   [m3 kg-1 degC-1]
+real, parameter :: ALP400 =    SPV410   ! dSpV_dT fit zs**4 coef.                   [m3 kg-1 degC-1]
+real, parameter :: ALP500 =    SPV510   ! dSpV_dT fit zs**5 coef.                   [m3 kg-1 degC-1]
+real, parameter :: ALP010 = 2.*SPV020   ! dSpV_dT fit T coef.                       [m3 kg-1 degC-2]
+real, parameter :: ALP110 = 2.*SPV120   ! dSpV_dT fit zs * T coef.                  [m3 kg-1 degC-2]
+real, parameter :: ALP210 = 2.*SPV220   ! dSpV_dT fit zs**2 * T coef.               [m3 kg-1 degC-2]
+real, parameter :: ALP310 = 2.*SPV320   ! dSpV_dT fit zs**3 * T coef.               [m3 kg-1 degC-2]
+real, parameter :: ALP410 = 2.*SPV420   ! dSpV_dT fit zs**4 * T coef.               [m3 kg-1 degC-2]
+real, parameter :: ALP020 = 3.*SPV030   ! dSpV_dT fit T**2 coef.                    [m3 kg-1 degC-3]
+real, parameter :: ALP120 = 3.*SPV130   ! dSpV_dT fit zs * T**2 coef.               [m3 kg-1 degC-3]
+real, parameter :: ALP220 = 3.*SPV230   ! dSpV_dT fit zs**2 * T**2 coef.            [m3 kg-1 degC-3]
+real, parameter :: ALP320 = 3.*SPV330   ! dSpV_dT fit zs**3 * T**2 coef.            [m3 kg-1 degC-3]
+real, parameter :: ALP030 = 4.*SPV040   ! dSpV_dT fit T**3 coef.                    [m3 kg-1 degC-4]
+real, parameter :: ALP130 = 4.*SPV140   ! dSpV_dT fit zs * T**3 coef.               [m3 kg-1 degC-4]
+real, parameter :: ALP230 = 4.*SPV240   ! dSpV_dT fit zs**2 * T**3 coef.            [m3 kg-1 degC-4]
+real, parameter :: ALP040 = 5.*SPV050   ! dSpV_dT fit T**4 coef.                    [m3 kg-1 degC-5]
+real, parameter :: ALP140 = 5.*SPV150   ! dSpV_dT fit zs* * T**4 coef.              [m3 kg-1 degC-5]
+real, parameter :: ALP050 = 6.*SPV060   ! dSpV_dT fit T**5 coef.                    [m3 kg-1 degC-6]
+real, parameter :: ALP001 =    SPV011   ! dSpV_dT fit P coef.                  [m3 kg-1 degC-1 Pa-1]
+real, parameter :: ALP101 =    SPV111   ! dSpV_dT fit zs * P coef.             [m3 kg-1 degC-1 Pa-1]
+real, parameter :: ALP201 =    SPV211   ! dSpV_dT fit zs**2 * P coef.          [m3 kg-1 degC-1 Pa-1]
+real, parameter :: ALP301 =    SPV311   ! dSpV_dT fit zs**3 * P coef.          [m3 kg-1 degC-1 Pa-1]
+real, parameter :: ALP011 = 2.*SPV021   ! dSpV_dT fit T * P coef.              [m3 kg-1 degC-2 Pa-1]
+real, parameter :: ALP111 = 2.*SPV121   ! dSpV_dT fit zs * T * P coef.         [m3 kg-1 degC-2 Pa-1]
+real, parameter :: ALP211 = 2.*SPV221   ! dSpV_dT fit zs**2 * T * P coef.      [m3 kg-1 degC-2 Pa-1]
+real, parameter :: ALP021 = 3.*SPV031   ! dSpV_dT fit T**2 * P coef.           [m3 kg-1 degC-3 Pa-1]
+real, parameter :: ALP121 = 3.*SPV131   ! dSpV_dT fit zs * T**2 * P coef.      [m3 kg-1 degC-3 Pa-1]
+real, parameter :: ALP031 = 4.*SPV041   ! dSpV_dT fit T**3 * P coef.           [m3 kg-1 degC-4 Pa-1]
+real, parameter :: ALP002 =    SPV012   ! dSpV_dT fit P**2 coef.               [m3 kg-1 degC-1 Pa-2]
+real, parameter :: ALP102 =    SPV112   ! dSpV_dT fit zs * P**2 coef.          [m3 kg-1 degC-1 Pa-2]
+real, parameter :: ALP012 = 2.*SPV022   ! dSpV_dT fit T * P**2 coef.           [m3 kg-1 degC-2 Pa-2]
+real, parameter :: ALP003 =    SPV013   ! dSpV_dT fit P**3 coef.               [m3 kg-1 degC-1 Pa-3]
 
-real, parameter :: BET000 = 0.5*SPV100*r1_S0  ! Constant in the dSpV_dS fit [m3 kg-1 ppt-1]
-real, parameter :: BET100 =     SPV200*r1_S0  ! Coefficient of the dSpV_dS fit zs term [m3 kg-1 ppt-1]
-real, parameter :: BET200 = 1.5*SPV300*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 term [m3 kg-1 ppt-1]
-real, parameter :: BET300 = 2.0*SPV400*r1_S0  ! Coefficient of the dSpV_dS fit zs**3 term [m3 kg-1 ppt-1]
-real, parameter :: BET400 = 2.5*SPV500*r1_S0  ! Coefficient of the dSpV_dS fit zs**4 term [m3 kg-1 ppt-1]
-real, parameter :: BET500 = 3.0*SPV600*r1_S0  ! Coefficient of the dSpV_dS fit zs**5 term [m3 kg-1 ppt-1]
-real, parameter :: BET010 = 0.5*SPV110*r1_S0  ! Coefficient of the dSpV_dS fit zt term [m3 kg-1 ppt-1]
-real, parameter :: BET110 =     SPV210*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt term [m3 kg-1 ppt-1]
-real, parameter :: BET210 = 1.5*SPV310*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zt term [m3 kg-1 ppt-1]
-real, parameter :: BET310 = 2.0*SPV410*r1_S0  ! Coefficient of the dSpV_dS fit zs**3 * zt term [m3 kg-1 ppt-1]
-real, parameter :: BET410 = 2.5*SPV510*r1_S0  ! Coefficient of the dSpV_dS fit zs**4 * zt term [m3 kg-1 ppt-1]
-real, parameter :: BET020 = 0.5*SPV120*r1_S0  ! Coefficient of the dSpV_dS fit zt**2 term [m3 kg-1 ppt-1]
-real, parameter :: BET120 =     SPV220*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt**2 term [m3 kg-1 ppt-1]
-real, parameter :: BET220 = 1.5*SPV320*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zt**2 term [m3 kg-1 ppt-1]
-real, parameter :: BET320 = 2.0*SPV420*r1_S0  ! Coefficient of the dSpV_dS fit zs**3 * zt**2 term [m3 kg-1 ppt-1]
-real, parameter :: BET030 = 0.5*SPV130*r1_S0  ! Coefficient of the dSpV_dS fit zt**3 term [m3 kg-1 ppt-1]
-real, parameter :: BET130 =     SPV230*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt**3 term [m3 kg-1 ppt-1]
-real, parameter :: BET230 = 1.5*SPV330*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zt**3 term [m3 kg-1 ppt-1]
-real, parameter :: BET040 = 0.5*SPV140*r1_S0  ! Coefficient of the dSpV_dS fit zt**4 term [m3 kg-1 ppt-1]
-real, parameter :: BET140 =     SPV240*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt**4 term [m3 kg-1 ppt-1]
-real, parameter :: BET050 = 0.5*SPV150*r1_S0  ! Coefficient of the dSpV_dS fit zt**5 term [m3 kg-1 ppt-1]
-real, parameter :: BET001 = 0.5*SPV101*r1_S0  ! Coefficient of the dSpV_dS fit zp term [m3 kg-1 ppt-1]
-real, parameter :: BET101 =     SPV201*r1_S0  ! Coefficient of the dSpV_dS fit zs * zp term [m3 kg-1 ppt-1]
-real, parameter :: BET201 = 1.5*SPV301*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zp term [m3 kg-1 ppt-1]
-real, parameter :: BET301 = 2.0*SPV401*r1_S0  ! Coefficient of the dSpV_dS fit zs**3 * zp term [m3 kg-1 ppt-1]
-real, parameter :: BET011 = 0.5*SPV111*r1_S0  ! Coefficient of the dSpV_dS fit zt * zp term [m3 kg-1 ppt-1]
-real, parameter :: BET111 =     SPV211*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt * zp term [m3 kg-1 ppt-1]
-real, parameter :: BET211 = 1.5*SPV311*r1_S0  ! Coefficient of the dSpV_dS fit zs**2 * zt * zp term [m3 kg-1 ppt-1]
-real, parameter :: BET021 = 0.5*SPV121*r1_S0  ! Coefficient of the dSpV_dS fit zt**2 * zp term [m3 kg-1 ppt-1]
-real, parameter :: BET121 =     SPV221*r1_S0  ! Coefficient of the dSpV_dS fit zs * zt**2 * zp term [m3 kg-1 ppt-1]
-real, parameter :: BET031 = 0.5*SPV131*r1_S0  ! Coefficient of the dSpV_dS fit zt**3 * zp term [m3 kg-1 ppt-1]
-real, parameter :: BET002 = 0.5*SPV102*r1_S0  ! Coefficient of the dSpV_dS fit zp**2 term [m3 kg-1 ppt-1]
-real, parameter :: BET102 =     SPV202*r1_S0  ! Coefficient of the dSpV_dS fit zs * zp**2 term [m3 kg-1 ppt-1]
-real, parameter :: BET012 = 0.5*SPV112*r1_S0  ! Coefficient of the dSpV_dS fit zt * zp**2 term [m3 kg-1 ppt-1]
-real, parameter :: BET003 = 0.5*SPV103*r1_S0  ! Coefficient of the dSpV_dS fit zp**3 term [m3 kg-1 ppt-1]
+real, parameter :: BET000 = 0.5*SPV100*r1_S0  ! Constant in the dSpV_dS fit          [m3 kg-1 ppt-1]
+real, parameter :: BET100 =     SPV200*r1_S0  ! dSpV_dS fit zs coef.                 [m3 kg-1 ppt-1]
+real, parameter :: BET200 = 1.5*SPV300*r1_S0  ! dSpV_dS fit zs**2 coef.              [m3 kg-1 ppt-1]
+real, parameter :: BET300 = 2.0*SPV400*r1_S0  ! dSpV_dS fit zs**3 coef.              [m3 kg-1 ppt-1]
+real, parameter :: BET400 = 2.5*SPV500*r1_S0  ! dSpV_dS fit zs**4 coef.              [m3 kg-1 ppt-1]
+real, parameter :: BET500 = 3.0*SPV600*r1_S0  ! dSpV_dS fit zs**5 coef.              [m3 kg-1 ppt-1]
+real, parameter :: BET010 = 0.5*SPV110*r1_S0  ! dSpV_dS fit T coef.           [m3 kg-1 ppt-1 degC-1]
+real, parameter :: BET110 =     SPV210*r1_S0  ! dSpV_dS fit zs * T coef.      [m3 kg-1 ppt-1 degC-1]
+real, parameter :: BET210 = 1.5*SPV310*r1_S0  ! dSpV_dS fit zs**2 * T coef.   [m3 kg-1 ppt-1 degC-1]
+real, parameter :: BET310 = 2.0*SPV410*r1_S0  ! dSpV_dS fit zs**3 * T coef.   [m3 kg-1 ppt-1 degC-1]
+real, parameter :: BET410 = 2.5*SPV510*r1_S0  ! dSpV_dS fit zs**4 * T coef.   [m3 kg-1 ppt-1 degC-1]
+real, parameter :: BET020 = 0.5*SPV120*r1_S0  ! dSpV_dS fit T**2 coef.        [m3 kg-1 ppt-1 degC-2]
+real, parameter :: BET120 =     SPV220*r1_S0  ! dSpV_dS fit zs * T**2 coef.   [m3 kg-1 ppt-1 degC-2]
+real, parameter :: BET220 = 1.5*SPV320*r1_S0  ! dSpV_dS fit zs**2 * T**2 coef. [m3 kg-1 ppt-1 degC-2]
+real, parameter :: BET320 = 2.0*SPV420*r1_S0  ! dSpV_dS fit zs**3 * T**2 coef. [m3 kg-1 ppt-1 degC-2]
+real, parameter :: BET030 = 0.5*SPV130*r1_S0  ! dSpV_dS fit T**3 coef.        [m3 kg-1 ppt-1 degC-3]
+real, parameter :: BET130 =     SPV230*r1_S0  ! dSpV_dS fit zs * T**3 coef.   [m3 kg-1 ppt-1 degC-3]
+real, parameter :: BET230 = 1.5*SPV330*r1_S0  ! dSpV_dS fit zs**2 * T**3 coef. [m3 kg-1 ppt-1 degC-3]
+real, parameter :: BET040 = 0.5*SPV140*r1_S0  ! dSpV_dS fit T**4 coef.        [m3 kg-1 ppt-1 degC-4]
+real, parameter :: BET140 =     SPV240*r1_S0  ! dSpV_dS fit zs * T**4 coef.   [m3 kg-1 ppt-1 degC-4]
+real, parameter :: BET050 = 0.5*SPV150*r1_S0  ! dSpV_dS fit T**5 coef.        [m3 kg-1 ppt-1 degC-5]
+real, parameter :: BET001 = 0.5*SPV101*r1_S0  ! dSpV_dS fit P coef.             [m3 kg-1 ppt-1 Pa-1]
+real, parameter :: BET101 =     SPV201*r1_S0  ! dSpV_dS fit zs * P coef.        [m3 kg-1 ppt-1 Pa-1]
+real, parameter :: BET201 = 1.5*SPV301*r1_S0  ! dSpV_dS fit zs**2 * P coef.     [m3 kg-1 ppt-1 Pa-1]
+real, parameter :: BET301 = 2.0*SPV401*r1_S0  ! dSpV_dS fit zs**3 * P coef.     [m3 kg-1 ppt-1 Pa-1]
+real, parameter :: BET011 = 0.5*SPV111*r1_S0  ! dSpV_dS fit T * P coef.  [m3 kg-1 ppt-1 degC-1 Pa-1]
+real, parameter :: BET111 =     SPV211*r1_S0  ! dSpV_dS fit zs * T * P coef. [m3 kg-1 ppt-1 degC-1 Pa-1]
+real, parameter :: BET211 = 1.5*SPV311*r1_S0  ! dSpV_dS fit zs**2 * T * P coef. [m3 kg-1 ppt-1 degC-1 Pa-1]
+real, parameter :: BET021 = 0.5*SPV121*r1_S0  ! dSpV_dS fit T**2 * P coef. [m3 kg-1 ppt-1 degC-2 Pa-1]
+real, parameter :: BET121 =     SPV221*r1_S0  ! dSpV_dS fit zs * T**2 * P coef. [m3 kg-1 ppt-1 degC-2 Pa-1]
+real, parameter :: BET031 = 0.5*SPV131*r1_S0  ! dSpV_dS fit T**3 * P coef. [m3 kg-1 ppt-1 degC-3 Pa-1]
+real, parameter :: BET002 = 0.5*SPV102*r1_S0  ! dSpV_dS fit P**2 coef.          [m3 kg-1 ppt-1 Pa-2]
+real, parameter :: BET102 =     SPV202*r1_S0  ! dSpV_dS fit zs * P**2 coef.     [m3 kg-1 ppt-1 Pa-2]
+real, parameter :: BET012 = 0.5*SPV112*r1_S0  ! dSpV_dS fit T * P**2 coef. [m3 kg-1 ppt-1 degC-1 Pa-2]
+real, parameter :: BET003 = 0.5*SPV103*r1_S0  ! dSpV_dS fit P**3 coef.          [m3 kg-1 ppt-1 Pa-3]
 !>@}
 
 contains
@@ -186,7 +189,7 @@ contains
 !> Computes the Roquet et al. in situ specific volume of sea water for scalar inputs and outputs.
 !!
 !! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from absolute salinity (S [g kg-1]),
-!! conservative  temperature (T [degC]) and pressure [Pa].  It uses the specific volume polynomial
+!! conservative temperature (T [degC]) and pressure [Pa].  It uses the specific volume polynomial
 !! fit from Roquet et al. (2015).
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_scalar_Roquet_SpV(T, S, pressure, specvol, spv_ref)
@@ -199,12 +202,12 @@ subroutine calculate_spec_vol_scalar_Roquet_SpV(T, S, pressure, specvol, spv_ref
   ! Local variables
   real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
   real, dimension(1) :: S0    ! A 1-d array with a copy of the absolutes salinity [g kg-1]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: pres0 ! A 1-d array with a copy of the pressure [Pa]
   real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
 
-  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
+  T0(1) = T ; S0(1) = S ; pres0(1) = pressure
 
-  call calculate_spec_vol_array_Roquet_SpV(T0, S0, pressure0, spv0, 1, 1, spv_ref)
+  call calculate_spec_vol_array_Roquet_SpV(T0, S0, pres0, spv0, 1, 1, spv_ref)
   specvol = spv0(1)
 
 end subroutine calculate_spec_vol_scalar_Roquet_SpV
@@ -225,34 +228,34 @@ subroutine calculate_spec_vol_array_Roquet_SpV(T, S, pressure, specvol, start, n
   real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1]
 
   ! Local variables
-  real :: zp  ! Pressure, first in [dbar], then normalized by an assumed pressure range [nondim]
-  real :: zt  ! Conservative temperature, first in [degC], then normalized by an assumed temperature range [nondim]
-  real :: zs  ! Absolute salinity, first in [g kg-1], then the square root of salinity with an offset normalized
-              ! by an assumed salinity range [nondim]
+  real :: zp     ! Pressure [Pa]
+  real :: zt     ! Conservative temperature [degC]
+  real :: zs     ! The square root of absolute salinity with an offset normalized
+                 ! by an assumed salinity range [nondim]
   real :: SV_00p ! A pressure-dependent but temperature and salinity independent contribution to
                  ! specific volume at the reference temperature and salinity [m3 kg-1]
   real :: SV_TS  ! Specific volume without a pressure-dependent contribution [m3 kg-1]
   real :: SV_TS0 ! A contribution to specific volume from temperature and salinity anomalies at
                  ! the surface pressure [m3 kg-1]
   real :: SV_TS1 ! A temperature and salinity dependent specific volume contribution that is
-                 ! proportional to pressure [m3 kg-1]
+                 ! proportional to pressure [m3 kg-1 Pa-1]
   real :: SV_TS2 ! A temperature and salinity dependent specific volume contribution that is
-                 ! proportional to pressure**2 [m3 kg-1]
+                 ! proportional to pressure**2 [m3 kg-1 Pa-2]
   real :: SV_TS3 ! A temperature and salinity dependent specific volume contribution that is
-                 ! proportional to pressure**3 [m3 kg-1]
+                 ! proportional to pressure**3 [m3 kg-1 Pa-3]
   real :: SV_0S0 ! Salinity dependent specific volume at the surface pressure and zero temperature [m3 kg-1]
   integer :: j
 
   ! The following algorithm was published by Roquet et al. (2015), intended for use in non-Boussinesq ocean models.
   do j=start,start+npts-1
     ! Conversions to the units used here.
-    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zt = T(j)
     zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = pressure(j) * (Pa2db*r1_P0)    ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+    zp = pressure(j)
 
     ! The next two lines should be used if it is necessary to convert potential temperature and
     ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
     ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
 
     SV_TS3 = SPV003 + (zs*SPV103 + zt*SPV013)
@@ -261,7 +264,7 @@ subroutine calculate_spec_vol_array_Roquet_SpV(T, S, pressure, specvol, start, n
     SV_TS1 = SPV001 + (zs*(SPV101 +  zs*(SPV201 +  zs*(SPV301 +  zs*SPV401))) &
                      + zt*(SPV011 + (zs*(SPV111 +  zs*(SPV211 +  zs*SPV311)) &
                                    + zt*(SPV021 + (zs*(SPV121 +  zs*SPV221) &
-                                                 + zt*(SPV031 + (zs*SPV131 + zt*SPV041))  )) )) )
+                                                 + zt*(SPV031 + (zs*SPV131 + zt*SPV041)) )) )) )
     SV_TS0 = zt*(SPV010 &
                + (zs*(SPV110 +  zs*(SPV210 +  zs*(SPV310 +  zs*(SPV410 +  zs*SPV510)))) &
                 + zt*(SPV020 + (zs*(SPV120 +  zs*(SPV220 +  zs*(SPV320 +  zs*SPV420))) &
@@ -294,18 +297,18 @@ subroutine calculate_density_scalar_Roquet_SpV(T, S, pressure, rho, rho_ref)
 
   real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
   real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: pres0 ! A 1-d array with a copy of the pressure [Pa]
   real, dimension(1) :: spv   ! A 1-d array with the specific volume [m3 kg-1]
 
   T0(1) = T
   S0(1) = S
-  pressure0(1) = pressure
+  pres0(1) = pressure
 
   if (present(rho_ref)) then
-    call calculate_spec_vol_array_Roquet_SpV(T0, S0, pressure0, spv, 1, 1, spv_ref=1.0/rho_ref)
+    call calculate_spec_vol_array_Roquet_SpV(T0, S0, pres0, spv, 1, 1, spv_ref=1.0/rho_ref)
     rho = -rho_ref**2*spv(1) / (rho_ref*spv(1) + 1.0)  ! In situ density [kg m-3]
   else
-    call calculate_spec_vol_array_Roquet_SpV(T0, S0, pressure0, spv, 1, 1)
+    call calculate_spec_vol_array_Roquet_SpV(T0, S0, pres0, spv, 1, 1)
     rho = 1.0 / spv(1)
   endif
 
@@ -354,37 +357,37 @@ subroutine calculate_specvol_derivs_Roquet_SpV(T, S, pressure, dSV_dT, dSV_dS, s
   integer, intent(in)                  :: start    !< The starting index for calculations
   integer, intent(in)                  :: npts     !< The number of values to calculate
 
-  real :: zp  ! Pressure, first in [dbar], then normalized by an assumed pressure range [nondim]
-  real :: zt  ! Conservative temperature, first in [degC], then normalized by an assumed temperature range [nondim]
-  real :: zs  ! Absolute salinity, first in [g kg-1], then the square root of salinity with an offset normalized
-              ! by an assumed salinity range [nondim]
-  real :: dSVdzt0 ! A contribution to the partial derivative of specific volume with temperature [m3 kg-1 degC-1]
-                  ! from temperature anomalies at the surface pressure
-  real :: dSVdzt1 ! A contribution to the partial derivative of specific volume with temperature [m3 kg-1 degC-1]
-                  ! that is proportional to pressure
-  real :: dSVdzt2 ! A contribution to the partial derivative of specific volume with temperature [m3 kg-1 degC-1]
-                  ! that is proportional to pressure^2
-  real :: dSVdzt3 ! A contribution to the partial derivative of specific volume with temperature [m3 kg-1 degC-1]
-                  ! that is proportional to pressure^3
+  real :: zp      ! Pressure [Pa]
+  real :: zt      ! Conservative temperature [degC]
+  real :: zs      ! The square root of absolute salinity with an offset normalized
+                  ! by an assumed salinity range [nondim]
+  real :: dSVdzt0 ! A contribution to the partial derivative of specific volume with temperature
+                  ! from temperature anomalies at the surface pressure [m3 kg-1 degC-1]
+  real :: dSVdzt1 ! A contribution to the partial derivative of specific volume with temperature
+                  ! that is proportional to pressure [m3 kg-1 degC-1 Pa-1]
+  real :: dSVdzt2 ! A contribution to the partial derivative of specific volume with temperature
+                  ! that is proportional to pressure**2 [m3 kg-1 degC-1 Pa-2]
+  real :: dSVdzt3 ! A contribution to the partial derivative of specific volume with temperature
+                  ! that is proportional to pressure**3 [m3 kg-1 degC-1 Pa-3]
   real :: dSVdzs0 ! A contribution to the partial derivative of specific volume with
                   ! salinity [m3 kg-1 ppt-1] from temperature anomalies at the surface pressure
   real :: dSVdzs1 ! A contribution to the partial derivative of specific volume with
-                  ! salinity [m3 kg-1 ppt-1] proportional to pressure
+                  ! salinity [m3 kg-1 ppt-1 Pa-1] proportional to pressure
   real :: dSVdzs2 ! A contribution to the partial derivative of specific volume with
-                  ! salinity [m3 kg-1 ppt-1] proportional to pressure^2
+                  ! salinity [m3 kg-1 ppt-1 Pa-2] proportional to pressure**2
   real :: dSVdzs3 ! A contribution to the partial derivative of specific volume with
-                  ! salinity [m3 kg-1 ppt-1] proportional to pressure^3
+                  ! salinity [m3 kg-1 ppt-1 Pa-3] proportional to pressure**3
   integer :: j
 
   do j=start,start+npts-1
     ! Conversions to the units used here.
-    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zt = T(j)
     zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = pressure(j) * (Pa2db*r1_P0)    ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+    zp = pressure(j)
 
     ! The next two lines should be used if it is necessary to convert potential temperature and
     ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
     ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
 
     ! Find the partial derivative of specific volume with temperature
@@ -466,7 +469,7 @@ subroutine calculate_density_derivs_scalar_Roquet_SpV(T, S, pressure, drho_dt, d
   ! Local variables
   real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
   real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: pres0 ! A 1-d array with a copy of the pressure [Pa]
   real, dimension(1) :: drdt0 ! A 1-d array with a copy of the derivative of density
                               ! with conservative temperature [kg m-3 degC-1]
   real, dimension(1) :: drds0 ! A 1-d array with a copy of the derivative of density
@@ -474,9 +477,9 @@ subroutine calculate_density_derivs_scalar_Roquet_SpV(T, S, pressure, drho_dt, d
 
   T0(1) = T
   S0(1) = S
-  pressure0(1) = pressure
+  pres0(1) = pressure
 
-  call calculate_density_derivs_array_Roquet_SpV(T0, S0, pressure0, drdt0, drds0, 1, 1)
+  call calculate_density_derivs_array_Roquet_SpV(T0, S0, pres0, drdt0, drds0, 1, 1)
   drho_dt = drdt0(1)
   drho_ds = drds0(1)
 end subroutine calculate_density_derivs_scalar_Roquet_SpV
@@ -494,28 +497,28 @@ subroutine calculate_compress_Roquet_SpV(T, S, pressure, rho, drho_dp, start, np
                                                  !! (also the inverse of the square of sound speed)
                                                  !! [s2 m-2]
   integer, intent(in)                :: start    !< The starting index for calculations
-  integer, intent(in)                :: npts     !< The number of values to calculate.
+  integer, intent(in)                :: npts     !< The number of values to calculate
 
   ! Local variables
-  real :: zp  ! Pressure normalized by an assumed pressure range [nondim]
-  real :: zt  ! Conservative temperature normalized by an assumed temperature range [nondim]
-  real :: zs  ! The square root of absolute salinity with an offset normalized
-              ! by an assumed salinity range [nondim]
+  real :: zp     ! Pressure [Pa]
+  real :: zt     ! Conservative temperature [degC]
+  real :: zs     ! The square root of absolute salinity with an offset normalized
+                 ! by an assumed salinity range [nondim]
   real :: dSV_00p_dp ! Derivative of the pressure-dependent reference specific volume profile with
-                 ! normalized pressure [m3 kg-1]
+                 ! pressure [m3 kg-1 Pa-1]
   real :: dSV_TS_dp  ! Derivative of the specific volume anomaly from the reference profile with
-                 ! normalized pressure [m3 kg-1]
+                 ! pressure [m3 kg-1 Pa-1]
   real :: SV_00p ! A pressure-dependent but temperature and salinity independent contribution to
                  ! specific volume at the reference temperature and salinity [m3 kg-1]
   real :: SV_TS  ! specific volume without a pressure-dependent contribution [m3 kg-1]
   real :: SV_TS0 ! A contribution to specific volume from temperature and salinity anomalies at
                  ! the surface pressure [m3 kg-1]
   real :: SV_TS1 ! A temperature and salinity dependent specific volume contribution that is
-                 ! proportional to pressure [m3 kg-1]
+                 ! proportional to pressure [m3 kg-1 Pa-1]
   real :: SV_TS2 ! A temperature and salinity dependent specific volume contribution that is
-                 ! proportional to pressure**2 [m3 kg-1]
+                 ! proportional to pressure**2 [m3 kg-1 Pa-2]
   real :: SV_TS3 ! A temperature and salinity dependent specific volume contribution that is
-                 ! proportional to pressure**3 [m3 kg-1]
+                 ! proportional to pressure**3 [m3 kg-1 Pa-3]
   real :: SV_0S0 ! Salinity dependent specific volume at the surface pressure and zero temperature [m3 kg-1]
   real :: dSpecVol_dp ! The partial derivative of specific volume with pressure [m3 kg-1 Pa-1]
   integer :: j
@@ -524,13 +527,13 @@ subroutine calculate_compress_Roquet_SpV(T, S, pressure, rho, drho_dp, start, np
   ! with NEMO, but it is not necessarily the algorithm used in NEMO ocean model.
   do j=start,start+npts-1
     ! Conversions to the units used here.
-    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zt = T(j)
     zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = pressure(j) * (Pa2db*r1_P0)    ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+    zp = pressure(j)
 
     ! The next two lines should be used if it is necessary to convert potential temperature and
     ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
     ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
 
     SV_TS3 = SPV003 + (zs*SPV103 + zt*SPV013)
@@ -539,7 +542,7 @@ subroutine calculate_compress_Roquet_SpV(T, S, pressure, rho, drho_dp, start, np
     SV_TS1 = SPV001 + (zs*(SPV101 +  zs*(SPV201 +  zs*(SPV301 +  zs*SPV401))) &
                      + zt*(SPV011 + (zs*(SPV111 +  zs*(SPV211 +  zs*SPV311)) &
                                    + zt*(SPV021 + (zs*(SPV121 +  zs*SPV221) &
-                                                 + zt*(SPV031 + (zs*SPV131 + zt*SPV041))  )) )) )
+                                                 + zt*(SPV031 + (zs*SPV131 + zt*SPV041)) )) )) )
 
     SV_TS0 = zt*(SPV010 &
                + (zs*(SPV110 +  zs*(SPV210 +  zs*(SPV310 +  zs*(SPV410 +  zs*SPV510)))) &
@@ -558,7 +561,7 @@ subroutine calculate_compress_Roquet_SpV(T, S, pressure, rho, drho_dp, start, np
 
     dSV_00p_dp = V00 + zp*(2.*V01 + zp*(3.*V02 + zp*(4.*V03 + zp*(5.*V04 + zp*(6.*V05)))))
     dSV_TS_dp  = SV_TS1 + zp*(2.*SV_TS2 + zp*(3.*SV_TS3))
-    dSpecVol_dp = (dSV_TS_dp + dSV_00p_dp) * (Pa2db*r1_P0)  !  [m3 kg-1 Pa-1]
+    dSpecVol_dp = dSV_TS_dp + dSV_00p_dp  !  [m3 kg-1 Pa-1]
     drho_dp(j) = -dSpecVol_dp * rho(j)**2 ! Compressibility [s2 m-2]
 
   enddo
@@ -582,30 +585,30 @@ subroutine calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_
                                                   !! and salinity [m3 kg-1 ppt-1 Pa-1]
   real, dimension(:), intent(inout) :: dSV_dt_dp  !< Second derivative of specific volume with respect to pressure
                                                   !! and temperature [m3 kg-1 degC-1 Pa-1]
-  integer,            intent(in   ) :: start !< Starting index in T,S,P
-  integer,            intent(in   ) :: npts  !< Number of points to loop over
+  integer,            intent(in   ) :: start      !< The starting index for calculations
+  integer,            intent(in   ) :: npts       !< The number of values to calculate
 
   ! Local variables
-  real :: zp  ! Pressure normalized by an assumed pressure range [nondim]
-  real :: zt  ! Conservative temperature normalized by an assumed temperature range [nondim]
-  real :: zs  ! The square root of absolute salinity with an offset normalized
-              ! by an assumed salinity range [nondim]
-  real :: I_s ! The inverse of zs [nondim]
+  real :: zp      ! Pressure [Pa]
+  real :: zt      ! Conservative temperature [degC]
+  real :: zs      ! The square root of absolute salinity with an offset normalized
+                  ! by an assumed salinity range [nondim]
+  real :: I_s     ! The inverse of zs [nondim]
   real :: d2SV_p0 ! A contribution to one of the second derivatives that is independent of pressure [various]
   real :: d2SV_p1 ! A contribution to one of the second derivatives that is proportional to pressure [various]
-  real :: d2SV_p2 ! A contribution to one of the second derivatives that is proportional to pressure^2 [various]
-  real :: d2SV_p3 ! A contribution to one of the second derivatives that is proportional to pressure^3 [various]
+  real :: d2SV_p2 ! A contribution to one of the second derivatives that is proportional to pressure**2 [various]
+  real :: d2SV_p3 ! A contribution to one of the second derivatives that is proportional to pressure**3 [various]
   integer :: j
 
   do j = start,start+npts-1
     ! Conversions to the units used here.
-    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zt = T(j)
     zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = P(j) * (Pa2db*r1_P0)     ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+    zp = P(j)
 
     ! The next two lines should be used if it is necessary to convert potential temperature and
     ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
     ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 )  ! Convert S from practical to absolute salinity.
 
     I_s = 1.0 / zs
@@ -630,7 +633,7 @@ subroutine calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_
                                        + zt*(3.*SPV130 + (zs*(6.*SPV230 +  zs*(9.*SPV330)) &
                                                         + zt*(4.*SPV140 + (zs*(8.*SPV240) &
                                                                          + zt*(5.*SPV150))) )) )) )
-    dSV_ds_dt(j) = (0.5*r1_S0*r1_T0) * ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s)
+    dSV_ds_dt(j) = (0.5*r1_S0) * ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s)
 
     ! Find dSV_dt_dt
     d2SV_p2 = 2.*SPV022
@@ -641,7 +644,7 @@ subroutine calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_
                                           + zt*(12.*SPV040 + (zs*(12.*SPV140 + zs *(12.*SPV240)) &
                                                             + zt*(20.*SPV050 + (zs*(20.*SPV150) &
                                                                               + zt*(30.*SPV060) )) )) )) )
-    dSV_dt_dt(j) = (d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * r1_T0**2
+    dSV_dt_dt(j) = d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)
 
     ! Find dSV_ds_dp
     d2SV_p2 = 3.*SPV103
@@ -649,7 +652,7 @@ subroutine calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_
     d2SV_p0 = SPV101 + (zs*(2.*SPV201 + zs*(3.*SPV301 +  zs*(4.*SPV401))) &
                       + zt*(SPV111 +   (zs*(2.*SPV211 +  zs*(3.*SPV311)) &
                                       + zt*(   SPV121 + (zs*(2.*SPV221) + zt*SPV131)) )) )
-    dSV_ds_dp(j) =  ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s) * (0.5*r1_S0 * Pa2db*r1_P0)
+    dSV_ds_dp(j) =  ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s) * (0.5*r1_S0)
 
     ! Find dSV_dt_dp
     d2SV_p2 = 3.*SPV013
@@ -657,7 +660,7 @@ subroutine calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_
     d2SV_p0 = SPV011 + (zs*(SPV111     + zs*(   SPV211 +  zs*    SPV311)) &
                       + zt*(2.*SPV021 + (zs*(2.*SPV121 +  zs*(2.*SPV221)) &
                                        + zt*(3.*SPV031 + (zs*(3.*SPV131) + zt*(4.*SPV041))) )) )
-    dSV_dt_dp(j) =  (d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * (Pa2db*r1_P0* r1_T0)
+    dSV_dt_dp(j) =  d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)
   enddo
 
 end subroutine calc_spec_vol_second_derivs_array_Roquet_SpV
@@ -680,8 +683,8 @@ subroutine calculate_density_second_derivs_array_Roquet_SpV(T, S, P, drho_ds_ds,
                                                   !! and salinity [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
   real, dimension(:), intent(inout) :: drho_dt_dp !< Second derivative of density with respect to pressure
                                                   !! and temperature [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  integer,            intent(in   ) :: start !< Starting index in T,S,P
-  integer,            intent(in   ) :: npts  !< Number of points to loop over
+  integer,            intent(in   ) :: start      !< The starting index for calculations
+  integer,            intent(in   ) :: npts       !< The number of values to calculate
 
   ! Local variables
   real, dimension(size(T)) :: rho       ! The in situ density [kg m-3]
@@ -747,9 +750,9 @@ subroutine calculate_density_second_derivs_scalar_Roquet_SpV(T, S, P, drho_ds_ds
   real, intent(  out) :: drho_dt_dp !< Second derivative of density with respect to pressure
                                     !! and temperature [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
   ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [g kg-1]
-  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: T0     ! A 1-d array with a copy of the temperature [degC]
+  real, dimension(1) :: S0     ! A 1-d array with a copy of the salinity [g kg-1]
+  real, dimension(1) :: p0     ! A 1-d array with a copy of the pressure [Pa]
   real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 ppt-2]
   real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
                                ! temperature [kg m-3 ppt-1 degC-1]

--- a/src/equation_of_state/MOM_EOS_Roquet_SpV.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_SpV.F90
@@ -10,7 +10,7 @@ implicit none ; private
 public calculate_compress_Roquet_SpV, calculate_density_Roquet_SpV, calculate_spec_vol_Roquet_SpV
 public calculate_density_derivs_Roquet_SpV, calculate_specvol_derivs_Roquet_SpV
 public calculate_density_scalar_Roquet_SpV, calculate_density_array_Roquet_SpV
-public calculate_density_second_derivs_Roquet_SpV
+public calculate_density_second_derivs_Roquet_SpV, EoS_fit_range_Roquet_SpV
 
 !> Compute the in situ density of sea water [kg m-3], or its anomaly with respect to
 !! a reference density, from absolute salinity [g kg-1], conservative temperature [degC],
@@ -770,6 +770,26 @@ subroutine calculate_density_second_derivs_scalar_Roquet_SpV(T, S, P, drho_ds_ds
   drho_dt_dp = drdtdp(1)
 
 end subroutine calculate_density_second_derivs_scalar_Roquet_SpV
+
+!> Return the range of temperatures, salinities and pressures for which the Roquet et al. (2015)
+!! expression for specific volume has been fitted to observations.  Care should be taken when
+!! applying this equation of state outside of its fit range.
+subroutine EoS_fit_range_Roquet_SpV(T_min, T_max, S_min, S_max, p_min, p_max)
+  real, optional, intent(out) :: T_min !< The minimum conservative temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: T_max !< The maximum conservative temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: S_min !< The minimum absolute salinity over which this EoS is fitted [g kg-1]
+  real, optional, intent(out) :: S_max !< The maximum absolute salinity over which this EoS is fitted [g kg-1]
+  real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+  real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  if (present(T_min)) T_min = -6.0
+  if (present(T_max)) T_max = 40.0
+  if (present(S_min)) S_min =  0.0
+  if (present(S_max)) S_max = 42.0
+  if (present(p_min)) p_min = 0.0
+  if (present(p_max)) p_max = 1.0e8
+
+end subroutine EoS_fit_range_Roquet_SpV
 
 !> \namespace mom_eos_Roquet_SpV
 !!

--- a/src/equation_of_state/MOM_EOS_Roquet_rho.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_rho.F90
@@ -28,148 +28,153 @@ end interface calculate_density_derivs_Roquet_rho
 !> Compute the second derivatives of density with various combinations of temperature,
 !! salinity, and pressure using the expressions for density from Roquet et al. (2015)
 interface calculate_density_second_derivs_Roquet_rho
-  module procedure calculate_density_second_derivs_scalar_Roquet_rho, calculate_density_second_derivs_array_Roquet_rho
+  module procedure calculate_density_second_derivs_scalar_Roquet_rho
+  module procedure calculate_density_second_derivs_array_Roquet_rho
 end interface calculate_density_second_derivs_Roquet_rho
 
-real, parameter :: Pa2db  = 1.e-4 !< Conversion factor between Pa and dbar [dbar Pa-1]
+real, parameter :: Pa2kb  = 1.e-8 !< Conversion factor between Pa and kbar [kbar Pa-1]
 !>@{ Parameters in the Roquet_rho (Roquet density) equation of state
-real, parameter :: rdeltaS = 32.           ! An offset to salinity before taking its square root [g kg-1]
-real, parameter :: r1_S0 = 0.875/35.16504  ! The inverse of a plausible range of oceanic salinities [kg g-1]
-real, parameter :: r1_T0 = 1./40.          ! The inverse of a plausible range of oceanic temperatures [degC-1]
-real, parameter :: r1_P0 = 1.e-4           ! The inverse of a plausible range of oceanic pressures [dbar-1]
-real, parameter :: R00 = 4.6494977072e+01  ! Contribution to rho00p proportional to zp [kg m-3]
-real, parameter :: R01 = -5.2099962525     ! Contribution to rho00p proportional to zp**2 [kg m-3]
-real, parameter :: R02 = 2.2601900708e-01  ! Contribution to rho00p proportional to zp**3 [kg m-3]
-real, parameter :: R03 = 6.4326772569e-02  ! Contribution to rho00p proportional to zp**4 [kg m-3]
-real, parameter :: R04 = 1.5616995503e-02  ! Contribution to rho00p proportional to zp**5 [kg m-3]
-real, parameter :: R05 = -1.7243708991e-03 ! Contribution to rho00p proportional to zp**6 [kg m-3]
+real, parameter :: rdeltaS = 32.          ! An offset to salinity before taking its square root [g kg-1]
+real, parameter :: r1_S0 = 0.875/35.16504 ! The inverse of a plausible range of oceanic salinities [kg g-1]
+real, parameter :: I_Ts = 0.025           ! The inverse of a plausible range of oceanic temperatures [degC-1]
 
-! The following terms are contributions to density as a function of the normalized square root of salinity
-! with an offset (zs), temperature (zt) and pressure (zp), with a contribution EOSabc * zs**a * zt**b * zp**c
-real, parameter :: EOS000 = 8.0189615746e+02  ! A constant density contribution [kg m-3]
-real, parameter :: EOS100 = 8.6672408165e+02  ! Coefficient of the EOS proportional to zs [kg m-3]
-real, parameter :: EOS200 = -1.7864682637e+03 ! Coefficient of the EOS proportional to zs**2 [kg m-3]
-real, parameter :: EOS300 = 2.0375295546e+03  ! Coefficient of the EOS proportional to zs**3 [kg m-3]
-real, parameter :: EOS400 = -1.2849161071e+03 ! Coefficient of the EOS proportional to zs**4 [kg m-3]
-real, parameter :: EOS500 = 4.3227585684e+02  ! Coefficient of the EOS proportional to zs**5 [kg m-3]
-real, parameter :: EOS600 = -6.0579916612e+01 ! Coefficient of the EOS proportional to zs**6 [kg m-3]
-real, parameter :: EOS010 = 2.6010145068e+01  ! Coefficient of the EOS proportional to zt [kg m-3]
-real, parameter :: EOS110 = -6.5281885265e+01 ! Coefficient of the EOS proportional to zs * zt [kg m-3]
-real, parameter :: EOS210 = 8.1770425108e+01  ! Coefficient of the EOS proportional to zs**2 * zt [kg m-3]
-real, parameter :: EOS310 = -5.6888046321e+01 ! Coefficient of the EOS proportional to zs**3 * zt [kg m-3]
-real, parameter :: EOS410 = 1.7681814114e+01  ! Coefficient of the EOS proportional to zs**2 * zt [kg m-3]
-real, parameter :: EOS510 = -1.9193502195     ! Coefficient of the EOS proportional to zs**5 * zt [kg m-3]
-real, parameter :: EOS020 = -3.7074170417e+01 ! Coefficient of the EOS proportional to zt**2 [kg m-3]
-real, parameter :: EOS120 = 6.1548258127e+01  ! Coefficient of the EOS proportional to zs * zt**2 [kg m-3]
-real, parameter :: EOS220 = -6.0362551501e+01 ! Coefficient of the EOS proportional to zs**2 * zt**2 [kg m-3]
-real, parameter :: EOS320 = 2.9130021253e+01  ! Coefficient of the EOS proportional to s**3 * zt**2 [kg m-3]
-real, parameter :: EOS420 = -5.4723692739     ! Coefficient of the EOS proportional to zs**4 * zt**2 [kg m-3]
-real, parameter :: EOS030 = 2.1661789529e+01  ! Coefficient of the EOS proportional to zt**3 [kg m-3]
-real, parameter :: EOS130 = -3.3449108469e+01 ! Coefficient of the EOS proportional to zs * zt**3 [kg m-3]
-real, parameter :: EOS230 = 1.9717078466e+01  ! Coefficient of the EOS proportional to zs**2 * zt**3 [kg m-3]
-real, parameter :: EOS330 = -3.1742946532     ! Coefficient of the EOS proportional to zs**3 * zt**3 [kg m-3]
-real, parameter :: EOS040 = -8.3627885467     ! Coefficient of the EOS proportional to zt**4 [kg m-3]
-real, parameter :: EOS140 = 1.1311538584e+01  ! Coefficient of the EOS proportional to zs * zt**4 [kg m-3]
-real, parameter :: EOS240 = -5.3563304045     ! Coefficient of the EOS proportional to zs**2 * zt**4 [kg m-3]
-real, parameter :: EOS050 = 5.4048723791e-01  ! Coefficient of the EOS proportional to zt**5 [kg m-3]
-real, parameter :: EOS150 = 4.8169980163e-01  ! Coefficient of the EOS proportional to zs * zt**5 [kg m-3]
-real, parameter :: EOS060 = -1.9083568888e-01 ! Coefficient of the EOS proportional to zt**6 [kg m-3]
-real, parameter :: EOS001 = 1.9681925209e+01  ! Coefficient of the EOS proportional to zp [kg m-3]
-real, parameter :: EOS101 = -4.2549998214e+01 ! Coefficient of the EOS proportional to zs * zp [kg m-3]
-real, parameter :: EOS201 = 5.0774768218e+01  ! Coefficient of the EOS proportional to zs**2 * zp [kg m-3]
-real, parameter :: EOS301 = -3.0938076334e+01 ! Coefficient of the EOS proportional to zs**3 * zp [kg m-3]
-real, parameter :: EOS401 = 6.6051753097      ! Coefficient of the EOS proportional to zs**4 * zp [kg m-3]
-real, parameter :: EOS011 = -1.3336301113e+01 ! Coefficient of the EOS proportional to zt * zp [kg m-3]
-real, parameter :: EOS111 = -4.4870114575     ! Coefficient of the EOS proportional to zs * zt * zp [kg m-3]
-real, parameter :: EOS211 = 5.0042598061      ! Coefficient of the EOS proportional to zs**2 * zt * zp [kg m-3]
-real, parameter :: EOS311 = -6.5399043664e-01 ! Coefficient of the EOS proportional to zs**3 * zt * zp [kg m-3]
-real, parameter :: EOS021 = 6.7080479603      ! Coefficient of the EOS proportional to zt**2 * zp [kg m-3]
-real, parameter :: EOS121 = 3.5063081279      ! Coefficient of the EOS proportional to zs * zt**2 * zp [kg m-3]
-real, parameter :: EOS221 = -1.8795372996     ! Coefficient of the EOS proportional to zs**2 * zt**2 * zp [kg m-3]
-real, parameter :: EOS031 = -2.4649669534     ! Coefficient of the EOS proportional to zt**3 * zp [kg m-3]
-real, parameter :: EOS131 = -5.5077101279e-01 ! Coefficient of the EOS proportional to zs * zt**3 * zp [kg m-3]
-real, parameter :: EOS041 = 5.5927935970e-01  ! Coefficient of the EOS proportional to zt**4 * zp [kg m-3]
-real, parameter :: EOS002 = 2.0660924175      ! Coefficient of the EOS proportional to zp**2 [kg m-3]
-real, parameter :: EOS102 = -4.9527603989     ! Coefficient of the EOS proportional to zs * zp**2 [kg m-3]
-real, parameter :: EOS202 = 2.5019633244      ! Coefficient of the EOS proportional to zs**2 * zp**2 [kg m-3]
-real, parameter :: EOS012 = 2.0564311499      ! Coefficient of the EOS proportional to zt * zp**2 [kg m-3]
-real, parameter :: EOS112 = -2.1311365518e-01 ! Coefficient of the EOS proportional to zs * zt * zp**2 [kg m-3]
-real, parameter :: EOS022 = -1.2419983026     ! Coefficient of the EOS proportional to zt**2 * zp**2 [kg m-3]
-real, parameter :: EOS003 = -2.3342758797e-02 ! Coefficient of the EOS proportional to zp**3 [kg m-3]
-real, parameter :: EOS103 = -1.8507636718e-02 ! Coefficient of the EOS proportional to zs * zp**3 [kg m-3]
-real, parameter :: EOS013 = 3.7969820455e-01  ! Coefficient of the EOS proportional to zt * zp**3 [kg m-3]
+! The following are the coefficients of the fit to the reference density profile (rho00p) as a function of
+! pressure (P), with a contribution R0c * P**(c+1).  The nomenclature follows Roquet.
+real, parameter :: R00 = 4.6494977072e+01*Pa2kb     ! rho00p P coef.    [kg m-3 Pa-1]
+real, parameter :: R01 = -5.2099962525*Pa2kb**2     ! rho00p P**2 coef. [kg m-3 Pa-2]
+real, parameter :: R02 = 2.2601900708e-01*Pa2kb**3  ! rho00p P**3 coef. [kg m-3 Pa-3]
+real, parameter :: R03 = 6.4326772569e-02*Pa2kb**4  ! rho00p P**4 coef. [kg m-3 Pa-4]
+real, parameter :: R04 = 1.5616995503e-02*Pa2kb**5  ! rho00p P**5 coef. [kg m-3 Pa-5]
+real, parameter :: R05 = -1.7243708991e-03*Pa2kb**6 ! rho00p P**6 coef. [kg m-3 Pa-6]
 
-real, parameter :: ALP000 =    EOS010*r1_T0   ! Constant in the drho_dT fit [kg m-3 degC-1]
-real, parameter :: ALP100 =    EOS110*r1_T0   ! Coefficient of the drho_dT fit zs term [kg m-3 degC-1]
-real, parameter :: ALP200 =    EOS210*r1_T0   ! Coefficient of the drho_dT fit zs**2 term [kg m-3 degC-1]
-real, parameter :: ALP300 =    EOS310*r1_T0   ! Coefficient of the drho_dT fit zs**3 term [kg m-3 degC-1]
-real, parameter :: ALP400 =    EOS410*r1_T0   ! Coefficient of the drho_dT fit zs**4 term [kg m-3 degC-1]
-real, parameter :: ALP500 =    EOS510*r1_T0   ! Coefficient of the drho_dT fit zs**5 term [kg m-3 degC-1]
-real, parameter :: ALP010 = 2.*EOS020*r1_T0   ! Coefficient of the drho_dT fit zt term [kg m-3 degC-1]
-real, parameter :: ALP110 = 2.*EOS120*r1_T0   ! Coefficient of the drho_dT fit zs * zt term [kg m-3 degC-1]
-real, parameter :: ALP210 = 2.*EOS220*r1_T0   ! Coefficient of the drho_dT fit zs**2 * zt term [kg m-3 degC-1]
-real, parameter :: ALP310 = 2.*EOS320*r1_T0   ! Coefficient of the drho_dT fit zs**3 * zt term [kg m-3 degC-1]
-real, parameter :: ALP410 = 2.*EOS420*r1_T0   ! Coefficient of the drho_dT fit zs**4 * zt term [kg m-3 degC-1]
-real, parameter :: ALP020 = 3.*EOS030*r1_T0   ! Coefficient of the drho_dT fit zt**2 term [kg m-3 degC-1]
-real, parameter :: ALP120 = 3.*EOS130*r1_T0   ! Coefficient of the drho_dT fit zs * zt**2 term [kg m-3 degC-1]
-real, parameter :: ALP220 = 3.*EOS230*r1_T0   ! Coefficient of the drho_dT fit zs**2 * zt**2 term [kg m-3 degC-1]
-real, parameter :: ALP320 = 3.*EOS330*r1_T0   ! Coefficient of the drho_dT fit zs**3 * zt**2 term [kg m-3 degC-1]
-real, parameter :: ALP030 = 4.*EOS040*r1_T0   ! Coefficient of the drho_dT fit zt**3 term [kg m-3 degC-1]
-real, parameter :: ALP130 = 4.*EOS140*r1_T0   ! Coefficient of the drho_dT fit zs * zt**3 term [kg m-3 degC-1]
-real, parameter :: ALP230 = 4.*EOS240*r1_T0   ! Coefficient of the drho_dT fit zs**2 * zt**3 term [kg m-3 degC-1]
-real, parameter :: ALP040 = 5.*EOS050*r1_T0   ! Coefficient of the drho_dT fit zt**4 term [kg m-3 degC-1]
-real, parameter :: ALP140 = 5.*EOS150*r1_T0   ! Coefficient of the drho_dT fit zs* * zt**4 term [kg m-3 degC-1]
-real, parameter :: ALP050 = 6.*EOS060*r1_T0   ! Coefficient of the drho_dT fit zt**5 term [kg m-3 degC-1]
-real, parameter :: ALP001 =    EOS011*r1_T0   ! Coefficient of the drho_dT fit zp term [kg m-3 degC-1]
-real, parameter :: ALP101 =    EOS111*r1_T0   ! Coefficient of the drho_dT fit zs * zp term [kg m-3 degC-1]
-real, parameter :: ALP201 =    EOS211*r1_T0   ! Coefficient of the drho_dT fit zs**2 * zp term [kg m-3 degC-1]
-real, parameter :: ALP301 =    EOS311*r1_T0   ! Coefficient of the drho_dT fit zs**3 * zp term [kg m-3 degC-1]
-real, parameter :: ALP011 = 2.*EOS021*r1_T0   ! Coefficient of the drho_dT fit zt * zp term [kg m-3 degC-1]
-real, parameter :: ALP111 = 2.*EOS121*r1_T0   ! Coefficient of the drho_dT fit zs * zt * zp term [kg m-3 degC-1]
-real, parameter :: ALP211 = 2.*EOS221*r1_T0   ! Coefficient of the drho_dT fit zs**2 * zt * zp term [kg m-3 degC-1]
-real, parameter :: ALP021 = 3.*EOS031*r1_T0   ! Coefficient of the drho_dT fit zt**2 * zp term [kg m-3 degC-1]
-real, parameter :: ALP121 = 3.*EOS131*r1_T0   ! Coefficient of the drho_dT fit zs * zt**2 * zp term [kg m-3 degC-1]
-real, parameter :: ALP031 = 4.*EOS041*r1_T0   ! Coefficient of the drho_dT fit zt**3 * zp term [kg m-3 degC-1]
-real, parameter :: ALP002 =    EOS012*r1_T0   ! Coefficient of the drho_dT fit zp**2 term [kg m-3 degC-1]
-real, parameter :: ALP102 =    EOS112*r1_T0   ! Coefficient of the drho_dT fit zs * zp**2 term [kg m-3 degC-1]
-real, parameter :: ALP012 = 2.*EOS022*r1_T0   ! Coefficient of the drho_dT fit zt * zp**2 term [kg m-3 degC-1]
-real, parameter :: ALP003 =    EOS013*r1_T0   ! Coefficient of the drho_dT fit zp**3 term [kg m-3 degC-1]
+! The following are coefficients of contributions to density as a function of the square root
+! of normalized salinity with an offset (zs), temperature (T) and pressure (P), with a contribution
+! EOSabc * zs**a * T**b * P**c.  The numbers here are copied directly from Roquet et al. (2015), but
+! the expressions here do not use the same nondimensionalization for pressure or temperature as they do.
+real, parameter :: EOS000 = 8.0189615746e+02                  ! A constant density contribution [kg m-3]
+real, parameter :: EOS100 = 8.6672408165e+02                  ! EoS zs coef.                [kg m-3]
+real, parameter :: EOS200 = -1.7864682637e+03                 ! EoS zs**2 coef.             [kg m-3]
+real, parameter :: EOS300 = 2.0375295546e+03                  ! EoS zs**3 coef.             [kg m-3]
+real, parameter :: EOS400 = -1.2849161071e+03                 ! EoS zs**4 coef.             [kg m-3]
+real, parameter :: EOS500 = 4.3227585684e+02                  ! EoS zs**5 coef.             [kg m-3]
+real, parameter :: EOS600 = -6.0579916612e+01                 ! EoS zs**6 coef.             [kg m-3]
+real, parameter :: EOS010 = 2.6010145068e+01*I_Ts             ! EoS T coef.          [kg m-3 degC-1]
+real, parameter :: EOS110 = -6.5281885265e+01*I_Ts            ! EoS zs * T coef.     [kg m-3 degC-1]
+real, parameter :: EOS210 = 8.1770425108e+01*I_Ts             ! EoS zs**2 * T coef.  [kg m-3 degC-1]
+real, parameter :: EOS310 = -5.6888046321e+01*I_Ts            ! EoS zs**3 * T coef.  [kg m-3 degC-1]
+real, parameter :: EOS410 = 1.7681814114e+01*I_Ts             ! EoS zs**2 * T coef.  [kg m-3 degC-1]
+real, parameter :: EOS510 = -1.9193502195*I_Ts                ! EoS zs**5 * T coef.  [kg m-3 degC-1]
+real, parameter :: EOS020 = -3.7074170417e+01*I_Ts**2         ! EoS T**2 coef.       [kg m-3 degC-2]
+real, parameter :: EOS120 = 6.1548258127e+01*I_Ts**2          ! EoS zs * T**2 coef.  [kg m-3 degC-2]
+real, parameter :: EOS220 = -6.0362551501e+01*I_Ts**2         ! EoS zs**2 * T**2 coef. [kg m-3 degC-2]
+real, parameter :: EOS320 = 2.9130021253e+01*I_Ts**2          ! EoS zs**3 * T**2 coef. [kg m-3 degC-2]
+real, parameter :: EOS420 = -5.4723692739*I_Ts**2             ! EoS zs**4 * T**2 coef. [kg m-3 degC-2]
+real, parameter :: EOS030 = 2.1661789529e+01*I_Ts**3          ! EoS T**3 coef.       [kg m-3 degC-3]
+real, parameter :: EOS130 = -3.3449108469e+01*I_Ts**3         ! EoS zs * T**3 coef.  [kg m-3 degC-3]
+real, parameter :: EOS230 = 1.9717078466e+01*I_Ts**3          ! EoS zs**2 * T**3 coef. [kg m-3 degC-3]
+real, parameter :: EOS330 = -3.1742946532*I_Ts**3             ! EoS zs**3 * T**3 coef. [kg m-3 degC-3]
+real, parameter :: EOS040 = -8.3627885467*I_Ts**4             ! EoS T**4 coef.       [kg m-3 degC-4]
+real, parameter :: EOS140 = 1.1311538584e+01*I_Ts**4          ! EoS zs * T**4 coef.  [kg m-3 degC-4]
+real, parameter :: EOS240 = -5.3563304045*I_Ts**4             ! EoS zs**2 * T**4 coef. [kg m-3 degC-4]
+real, parameter :: EOS050 = 5.4048723791e-01*I_Ts**5          ! EoS T**5 coef.       [kg m-3 degC-5]
+real, parameter :: EOS150 = 4.8169980163e-01*I_Ts**5          ! EoS zs * T**5 coef.  [kg m-3 degC-5]
+real, parameter :: EOS060 = -1.9083568888e-01*I_Ts**6         ! EoS T**6             [kg m-3 degC-6]
+real, parameter :: EOS001 = 1.9681925209e+01*Pa2kb            ! EoS P coef.            [kg m-3 Pa-1]
+real, parameter :: EOS101 = -4.2549998214e+01*Pa2kb           ! EoS zs * P coef.       [kg m-3 Pa-1]
+real, parameter :: EOS201 = 5.0774768218e+01*Pa2kb            ! EoS zs**2 * P coef.    [kg m-3 Pa-1]
+real, parameter :: EOS301 = -3.0938076334e+01*Pa2kb           ! EoS zs**3 * P coef.    [kg m-3 Pa-1]
+real, parameter :: EOS401 = 6.6051753097*Pa2kb                ! EoS zs**4 * P coef.    [kg m-3 Pa-1]
+real, parameter :: EOS011 = -1.3336301113e+01*(I_Ts*Pa2kb)    ! EoS T * P coef. [kg m-3 degC-1 Pa-1]
+real, parameter :: EOS111 = -4.4870114575*(I_Ts*Pa2kb)        ! EoS zs * T * P coef. [kg m-3 degC-1 Pa-1]
+real, parameter :: EOS211 = 5.0042598061*(I_Ts*Pa2kb)         ! EoS zs**2 * T * P coef. [kg m-3 degC-1 Pa-1]
+real, parameter :: EOS311 = -6.5399043664e-01*(I_Ts*Pa2kb)    ! EoS zs**3 * T * P coef. [kg m-3 degC-1 Pa-1]
+real, parameter :: EOS021 = 6.7080479603*(I_Ts**2*Pa2kb)      ! EoS T**2 * P coef. [kg m-3 degC-2 Pa-1]
+real, parameter :: EOS121 = 3.5063081279*(I_Ts**2*Pa2kb)      ! EoS zs * T**2 * P coef. [kg m-3 degC-2 Pa-1]
+real, parameter :: EOS221 = -1.8795372996*(I_Ts**2*Pa2kb)     ! EoS zs**2 * T**2 * P coef. [kg m-3 degC-2 Pa-1]
+real, parameter :: EOS031 = -2.4649669534*(I_Ts**3*Pa2kb)     ! EoS T**3 * P coef. [kg m-3 degC-3 Pa-1]
+real, parameter :: EOS131 = -5.5077101279e-01*(I_Ts**3*Pa2kb) ! EoS zs * T**3 * P coef. [kg m-3 degC-3 Pa-1]
+real, parameter :: EOS041 = 5.5927935970e-01*(I_Ts**4*Pa2kb)  ! EoS T**4 * P coef. [kg m-3 degC-4 Pa-1]
+real, parameter :: EOS002 = 2.0660924175*Pa2kb**2             ! EoS P**2 coef.         [kg m-3 Pa-2]
+real, parameter :: EOS102 = -4.9527603989*Pa2kb**2            ! EoS zs * P**2 coef.    [kg m-3 Pa-2]
+real, parameter :: EOS202 = 2.5019633244*Pa2kb**2             ! EoS zs**2 * P**2 coef. [kg m-3 Pa-2]
+real, parameter :: EOS012 = 2.0564311499*(I_Ts*Pa2kb**2)      ! EoS T * P**2 coef. [kg m-3 degC-1 Pa-2]
+real, parameter :: EOS112 = -2.1311365518e-01*(I_Ts*Pa2kb**2) ! EoS zs * T * P**2 coef. [kg m-3 degC-1 Pa-2]
+real, parameter :: EOS022 = -1.2419983026*(I_Ts**2*Pa2kb**2)  ! EoS T**2 * P**2 coef. [kg m-3 degC-2 Pa-2]
+real, parameter :: EOS003 = -2.3342758797e-02*Pa2kb**3        ! EoS P**3 coef.         [kg m-3 Pa-3]
+real, parameter :: EOS103 = -1.8507636718e-02*Pa2kb**3        ! EoS zs * P**3 coef.    [kg m-3 Pa-3]
+real, parameter :: EOS013 = 3.7969820455e-01*(I_Ts*Pa2kb**3)  ! EoS T * P**3 coef. [kg m-3 degC-1 Pa-3]
 
-real, parameter :: BET000 = 0.5*EOS100*r1_S0  ! Constant in the drho_dS fit [kg m-3 ppt-1]
-real, parameter :: BET100 =     EOS200*r1_S0  ! Coefficient of the drho_dS fit zs term [kg m-3 ppt-1]
-real, parameter :: BET200 = 1.5*EOS300*r1_S0  ! Coefficient of the drho_dS fit zs**2 term [kg m-3 ppt-1]
-real, parameter :: BET300 = 2.0*EOS400*r1_S0  ! Coefficient of the drho_dS fit zs**3 term [kg m-3 ppt-1]
-real, parameter :: BET400 = 2.5*EOS500*r1_S0  ! Coefficient of the drho_dS fit zs**4 term [kg m-3 ppt-1]
-real, parameter :: BET500 = 3.0*EOS600*r1_S0  ! Coefficient of the drho_dS fit zs**5 term [kg m-3 ppt-1]
-real, parameter :: BET010 = 0.5*EOS110*r1_S0  ! Coefficient of the drho_dS fit zt term [kg m-3 ppt-1]
-real, parameter :: BET110 =     EOS210*r1_S0  ! Coefficient of the drho_dS fit zs * zt term [kg m-3 ppt-1]
-real, parameter :: BET210 = 1.5*EOS310*r1_S0  ! Coefficient of the drho_dS fit zs**2 * zt term [kg m-3 ppt-1]
-real, parameter :: BET310 = 2.0*EOS410*r1_S0  ! Coefficient of the drho_dS fit zs**3 * zt term [kg m-3 ppt-1]
-real, parameter :: BET410 = 2.5*EOS510*r1_S0  ! Coefficient of the drho_dS fit zs**4 * zt term [kg m-3 ppt-1]
-real, parameter :: BET020 = 0.5*EOS120*r1_S0  ! Coefficient of the drho_dS fit zt**2 term [kg m-3 ppt-1]
-real, parameter :: BET120 =     EOS220*r1_S0  ! Coefficient of the drho_dS fit zs * zt**2 term [kg m-3 ppt-1]
-real, parameter :: BET220 = 1.5*EOS320*r1_S0  ! Coefficient of the drho_dS fit zs**2 * zt**2 term [kg m-3 ppt-1]
-real, parameter :: BET320 = 2.0*EOS420*r1_S0  ! Coefficient of the drho_dS fit zs**3 * zt**2 term [kg m-3 ppt-1]
-real, parameter :: BET030 = 0.5*EOS130*r1_S0  ! Coefficient of the drho_dS fit zt**3 term [kg m-3 ppt-1]
-real, parameter :: BET130 =     EOS230*r1_S0  ! Coefficient of the drho_dS fit zs * zt**3 term [kg m-3 ppt-1]
-real, parameter :: BET230 = 1.5*EOS330*r1_S0  ! Coefficient of the drho_dS fit zs**2 * zt**3 term [kg m-3 ppt-1]
-real, parameter :: BET040 = 0.5*EOS140*r1_S0  ! Coefficient of the drho_dS fit zt**4 term [kg m-3 ppt-1]
-real, parameter :: BET140 =     EOS240*r1_S0  ! Coefficient of the drho_dS fit zs * zt**4 term [kg m-3 ppt-1]
-real, parameter :: BET050 = 0.5*EOS150*r1_S0  ! Coefficient of the drho_dS fit zt**5 term [kg m-3 ppt-1]
-real, parameter :: BET001 = 0.5*EOS101*r1_S0  ! Coefficient of the drho_dS fit zp term [kg m-3 ppt-1]
-real, parameter :: BET101 =     EOS201*r1_S0  ! Coefficient of the drho_dS fit zs * zp term [kg m-3 ppt-1]
-real, parameter :: BET201 = 1.5*EOS301*r1_S0  ! Coefficient of the drho_dS fit zs**2 * zp term [kg m-3 ppt-1]
-real, parameter :: BET301 = 2.0*EOS401*r1_S0  ! Coefficient of the drho_dS fit zs**3 * zp term [kg m-3 ppt-1]
-real, parameter :: BET011 = 0.5*EOS111*r1_S0  ! Coefficient of the drho_dS fit zt * zp term [kg m-3 ppt-1]
-real, parameter :: BET111 =     EOS211*r1_S0  ! Coefficient of the drho_dS fit zs * zt * zp term [kg m-3 ppt-1]
-real, parameter :: BET211 = 1.5*EOS311*r1_S0  ! Coefficient of the drho_dS fit zs**2 * zt * zp term [kg m-3 ppt-1]
-real, parameter :: BET021 = 0.5*EOS121*r1_S0  ! Coefficient of the drho_dS fit zt**2 * zp term [kg m-3 ppt-1]
-real, parameter :: BET121 =     EOS221*r1_S0  ! Coefficient of the drho_dS fit zs * zt**2 * zp term [kg m-3 ppt-1]
-real, parameter :: BET031 = 0.5*EOS131*r1_S0  ! Coefficient of the drho_dS fit zt**3 * zp term [kg m-3 ppt-1]
-real, parameter :: BET002 = 0.5*EOS102*r1_S0  ! Coefficient of the drho_dS fit zp**2 term [kg m-3 ppt-1]
-real, parameter :: BET102 =     EOS202*r1_S0  ! Coefficient of the drho_dS fit zs * zp**2 term [kg m-3 ppt-1]
-real, parameter :: BET012 = 0.5*EOS112*r1_S0  ! Coefficient of the drho_dS fit zt * zp**2 term [kg m-3 ppt-1]
-real, parameter :: BET003 = 0.5*EOS103*r1_S0  ! Coefficient of the drho_dS fit zp**3 term [kg m-3 ppt-1]
+real, parameter :: ALP000 =    EOS010   ! Constant in the drho_dT fit                [kg m-3 degC-1]
+real, parameter :: ALP100 =    EOS110   ! drho_dT fit zs coef.                       [kg m-3 degC-1]
+real, parameter :: ALP200 =    EOS210   ! drho_dT fit zs**2 coef.                    [kg m-3 degC-1]
+real, parameter :: ALP300 =    EOS310   ! drho_dT fit zs**3 coef.                    [kg m-3 degC-1]
+real, parameter :: ALP400 =    EOS410   ! drho_dT fit zs**4 coef.                    [kg m-3 degC-1]
+real, parameter :: ALP500 =    EOS510   ! drho_dT fit zs**5 coef.                    [kg m-3 degC-1]
+real, parameter :: ALP010 = 2.*EOS020   ! drho_dT fit T coef.                        [kg m-3 degC-2]
+real, parameter :: ALP110 = 2.*EOS120   ! drho_dT fit zs * T coef.                   [kg m-3 degC-2]
+real, parameter :: ALP210 = 2.*EOS220   ! drho_dT fit zs**2 * T coef.                [kg m-3 degC-2]
+real, parameter :: ALP310 = 2.*EOS320   ! drho_dT fit zs**3 * T coef.                [kg m-3 degC-2]
+real, parameter :: ALP410 = 2.*EOS420   ! drho_dT fit zs**4 * T coef.                [kg m-3 degC-2]
+real, parameter :: ALP020 = 3.*EOS030   ! drho_dT fit T**2 coef.                     [kg m-3 degC-3]
+real, parameter :: ALP120 = 3.*EOS130   ! drho_dT fit zs * T**2 coef.                [kg m-3 degC-3]
+real, parameter :: ALP220 = 3.*EOS230   ! drho_dT fit zs**2 * T**2 coef.             [kg m-3 degC-3]
+real, parameter :: ALP320 = 3.*EOS330   ! drho_dT fit zs**3 * T**2 coef.             [kg m-3 degC-3]
+real, parameter :: ALP030 = 4.*EOS040   ! drho_dT fit T**3 coef.                     [kg m-3 degC-4]
+real, parameter :: ALP130 = 4.*EOS140   ! drho_dT fit zs * T**3 coef.                [kg m-3 degC-4]
+real, parameter :: ALP230 = 4.*EOS240   ! drho_dT fit zs**2 * T**3 coef.             [kg m-3 degC-4]
+real, parameter :: ALP040 = 5.*EOS050   ! drho_dT fit T**4 coef.                     [kg m-3 degC-5]
+real, parameter :: ALP140 = 5.*EOS150   ! drho_dT fit zs* * T**4 coef.               [kg m-3 degC-5]
+real, parameter :: ALP050 = 6.*EOS060   ! drho_dT fit T**5 coef.                     [kg m-3 degC-6]
+real, parameter :: ALP001 =    EOS011   ! drho_dT fit P coef.                   [kg m-3 degC-1 Pa-1]
+real, parameter :: ALP101 =    EOS111   ! drho_dT fit zs * P coef.              [kg m-3 degC-1 Pa-1]
+real, parameter :: ALP201 =    EOS211   ! drho_dT fit zs**2 * P coef.           [kg m-3 degC-1 Pa-1]
+real, parameter :: ALP301 =    EOS311   ! drho_dT fit zs**3 * P coef.           [kg m-3 degC-1 Pa-1]
+real, parameter :: ALP011 = 2.*EOS021   ! drho_dT fit T * P coef.               [kg m-3 degC-2 Pa-1]
+real, parameter :: ALP111 = 2.*EOS121   ! drho_dT fit zs * T * P coef.          [kg m-3 degC-2 Pa-1]
+real, parameter :: ALP211 = 2.*EOS221   ! drho_dT fit zs**2 * T * P coef.       [kg m-3 degC-2 Pa-1]
+real, parameter :: ALP021 = 3.*EOS031   ! drho_dT fit T**2 * P coef.            [kg m-3 degC-3 Pa-1]
+real, parameter :: ALP121 = 3.*EOS131   ! drho_dT fit zs * T**2 * P coef.       [kg m-3 degC-3 Pa-1]
+real, parameter :: ALP031 = 4.*EOS041   ! drho_dT fit T**3 * P coef.            [kg m-3 degC-4 Pa-1]
+real, parameter :: ALP002 =    EOS012   ! drho_dT fit P**2 coef.                [kg m-3 degC-1 Pa-2]
+real, parameter :: ALP102 =    EOS112   ! drho_dT fit zs * P**2 coef.           [kg m-3 degC-1 Pa-2]
+real, parameter :: ALP012 = 2.*EOS022   ! drho_dT fit T * P**2 coef.            [kg m-3 degC-2 Pa-2]
+real, parameter :: ALP003 =    EOS013   ! drho_dT fit P**3 coef.                [kg m-3 degC-1 Pa-3]
+
+real, parameter :: BET000 = 0.5*EOS100*r1_S0  ! Constant in the drho_dS fit           [kg m-3 ppt-1]
+real, parameter :: BET100 =     EOS200*r1_S0  ! drho_dS fit zs coef.                  [kg m-3 ppt-1]
+real, parameter :: BET200 = 1.5*EOS300*r1_S0  ! drho_dS fit zs**2 coef.               [kg m-3 ppt-1]
+real, parameter :: BET300 = 2.0*EOS400*r1_S0  ! drho_dS fit zs**3 coef.               [kg m-3 ppt-1]
+real, parameter :: BET400 = 2.5*EOS500*r1_S0  ! drho_dS fit zs**4 coef.               [kg m-3 ppt-1]
+real, parameter :: BET500 = 3.0*EOS600*r1_S0  ! drho_dS fit zs**5 coef.               [kg m-3 ppt-1]
+real, parameter :: BET010 = 0.5*EOS110*r1_S0  ! drho_dS fit T coef.            [kg m-3 ppt-1 degC-1]
+real, parameter :: BET110 =     EOS210*r1_S0  ! drho_dS fit zs * T coef.       [kg m-3 ppt-1 degC-1]
+real, parameter :: BET210 = 1.5*EOS310*r1_S0  ! drho_dS fit zs**2 * T coef.    [kg m-3 ppt-1 degC-1]
+real, parameter :: BET310 = 2.0*EOS410*r1_S0  ! drho_dS fit zs**3 * T coef.    [kg m-3 ppt-1 degC-1]
+real, parameter :: BET410 = 2.5*EOS510*r1_S0  ! drho_dS fit zs**4 * T coef.    [kg m-3 ppt-1 degC-1]
+real, parameter :: BET020 = 0.5*EOS120*r1_S0  ! drho_dS fit T**2 coef.         [kg m-3 ppt-1 degC-2]
+real, parameter :: BET120 =     EOS220*r1_S0  ! drho_dS fit zs * T**2 coef.    [kg m-3 ppt-1 degC-2]
+real, parameter :: BET220 = 1.5*EOS320*r1_S0  ! drho_dS fit zs**2 * T**2 coef. [kg m-3 ppt-1 degC-2]
+real, parameter :: BET320 = 2.0*EOS420*r1_S0  ! drho_dS fit zs**3 * T**2 coef. [kg m-3 ppt-1 degC-2]
+real, parameter :: BET030 = 0.5*EOS130*r1_S0  ! drho_dS fit T**3 coef.         [kg m-3 ppt-1 degC-3]
+real, parameter :: BET130 =     EOS230*r1_S0  ! drho_dS fit zs * T**3 coef.    [kg m-3 ppt-1 degC-3]
+real, parameter :: BET230 = 1.5*EOS330*r1_S0  ! drho_dS fit zs**2 * T**3 coef. [kg m-3 ppt-1 degC-3]
+real, parameter :: BET040 = 0.5*EOS140*r1_S0  ! drho_dS fit T**4 coef.         [kg m-3 ppt-1 degC-4]
+real, parameter :: BET140 =     EOS240*r1_S0  ! drho_dS fit zs * T**4 coef.    [kg m-3 ppt-1 degC-4]
+real, parameter :: BET050 = 0.5*EOS150*r1_S0  ! drho_dS fit T**5 coef.         [kg m-3 ppt-1 degC-5]
+real, parameter :: BET001 = 0.5*EOS101*r1_S0  ! drho_dS fit P coef.              [kg m-3 ppt-1 Pa-1]
+real, parameter :: BET101 =     EOS201*r1_S0  ! drho_dS fit zs * P coef.         [kg m-3 ppt-1 Pa-1]
+real, parameter :: BET201 = 1.5*EOS301*r1_S0  ! drho_dS fit zs**2 * P coef.      [kg m-3 ppt-1 Pa-1]
+real, parameter :: BET301 = 2.0*EOS401*r1_S0  ! drho_dS fit zs**3 * P coef.      [kg m-3 ppt-1 Pa-1]
+real, parameter :: BET011 = 0.5*EOS111*r1_S0  ! drho_dS fit T * P coef.   [kg m-3 ppt-1 degC-1 Pa-1]
+real, parameter :: BET111 =     EOS211*r1_S0  ! drho_dS fit zs * T * P coef. [kg m-3 ppt-1 degC-1 Pa-1]
+real, parameter :: BET211 = 1.5*EOS311*r1_S0  ! drho_dS fit zs**2 * T * P coef. [kg m-3 ppt-1 degC-1 Pa-1]
+real, parameter :: BET021 = 0.5*EOS121*r1_S0  ! drho_dS fit T**2 * P coef. [kg m-3 ppt-1 degC-2 Pa-1]
+real, parameter :: BET121 =     EOS221*r1_S0  ! drho_dS fit zs * T**2 * P coef. [kg m-3 ppt-1 degC-2 Pa-1]
+real, parameter :: BET031 = 0.5*EOS131*r1_S0  ! drho_dS fit T**3 * P coef. [kg m-3 ppt-1 degC-3 Pa-1]
+real, parameter :: BET002 = 0.5*EOS102*r1_S0  ! drho_dS fit P**2 coef.           [kg m-3 ppt-1 Pa-2]
+real, parameter :: BET102 =     EOS202*r1_S0  ! drho_dS fit zs * P**2 coef.      [kg m-3 ppt-1 Pa-2]
+real, parameter :: BET012 = 0.5*EOS112*r1_S0  ! drho_dS fit T * P**2 coef. [kg m-3 ppt-1 degC-1 Pa-2]
+real, parameter :: BET003 = 0.5*EOS103*r1_S0  ! drho_dS fit P**3 coef.           [kg m-3 ppt-1 Pa-3]
 !>@}
 
 contains
@@ -177,23 +182,23 @@ contains
 !> This subroutine computes the in situ density of sea water (rho in [kg m-3])
 !! from absolute salinity (S [g kg-1]), conservative temperature (T [degC])
 !! and pressure [Pa], using the density polynomial fit EOS from Roquet et al. (2015).
-subroutine calculate_density_scalar_Roquet_rho(T, S, pressure, rho, rho_ref)
+subroutine calculate_density_scalar_Roquet_rho(T, S, pres, rho, rho_ref)
   real,           intent(in)  :: T        !< Conservative temperature [degC]
   real,           intent(in)  :: S        !< Absolute salinity [g kg-1]
-  real,           intent(in)  :: pressure !< Pressure [Pa]
+  real,           intent(in)  :: pres     !< Pressure [Pa]
   real,           intent(out) :: rho      !< In situ density [kg m-3]
   real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
 
   real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
   real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: pres0 ! A 1-d array with a copy of the pressure [Pa]
   real, dimension(1) :: rho0  ! A 1-d array with a copy of the density [kg m-3]
 
   T0(1) = T
   S0(1) = S
-  pressure0(1) = pressure
+  pres0(1) = pres
 
-  call calculate_density_array_Roquet_rho(T0, S0, pressure0, rho0, 1, 1, rho_ref)
+  call calculate_density_array_Roquet_rho(T0, S0, pres0, rho0, 1, 1, rho_ref)
   rho = rho0(1)
 
 end subroutine calculate_density_scalar_Roquet_rho
@@ -201,40 +206,41 @@ end subroutine calculate_density_scalar_Roquet_rho
 !> This subroutine computes an array of in situ densities of sea water (rho in [kg m-3])
 !! from absolute salinity (S [g kg-1]), conservative temperature (T [degC]), and pressure
 !! [Pa], using the density polynomial fit EOS from Roquet et al. (2015).
-subroutine calculate_density_array_Roquet_rho(T, S, pressure, rho, start, npts, rho_ref)
+subroutine calculate_density_array_Roquet_rho(T, S, pres, rho, start, npts, rho_ref)
   real, dimension(:), intent(in)  :: T        !< Conservative temperature [degC]
   real, dimension(:), intent(in)  :: S        !< Absolute salinity [g kg-1]
-  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(in)  :: pres     !< Pressure [Pa]
   real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
   integer,            intent(in)  :: start    !< The starting index for calculations
   integer,            intent(in)  :: npts     !< The number of values to calculate
   real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
 
   ! Local variables
-  real :: zp  ! Pressure, first in [dbar], then normalized by an assumed pressure range [nondim]
-  real :: zt  ! Conservative temperature, first in [degC], then normalized by an assumed temperature range [nondim]
-  real :: zs  ! Absolute salinity, first in [g kg-1], then the square root of salinity with an offset normalized
-              ! by an assumed salinity range [nondim]
+  real :: zp     ! Pressure [Pa]
+  real :: zt     ! Conservative temperature [degC]
+  real :: zs     ! The square root of absolute salinity with an offset normalized
+                 ! by an assumed salinity range [nondim]
   real :: rho00p ! A pressure-dependent but temperature and salinity independent contribution to
                  ! density at the reference temperature and salinity [kg m-3]
   real :: rhoTS  ! Density without a pressure-dependent contribution [kg m-3]
-  real :: rhoTS0 ! A contribution to density from temperature and salinity anomalies at the surface pressure [kg m-3]
-  real :: rhoTS1 ! A temperature and salinity dependent density contribution proportional to pressure [kg m-3]
-  real :: rhoTS2 ! A temperature and salinity dependent density contribution proportional to pressure**2 [kg m-3]
-  real :: rhoTS3 ! A temperature and salinity dependent density contribution proportional to pressure**3 [kg m-3]
+  real :: rhoTS0 ! A contribution to density from temperature and salinity anomalies at the
+                 ! surface pressure [kg m-3]
+  real :: rhoTS1 ! A density contribution proportional to pressure [kg m-3 Pa-1]
+  real :: rhoTS2 ! A density contribution proportional to pressure**2 [kg m-3 Pa-2]
+  real :: rhoTS3 ! A density contribution proportional to pressure**3 [kg m-3 Pa-3]
   real :: rho0S0 ! Salinity dependent density at the surface pressure and zero temperature [kg m-3]
   integer :: j
 
   ! The following algorithm was published by Roquet et al. (2015), intended for use with NEMO.
   do j=start,start+npts-1
     ! Conversions to the units used here.
-    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zt = T(j)
     zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = pressure(j) * (Pa2db*r1_P0)    ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+    zp = pres(j)
 
     ! The next two lines should be used if it is necessary to convert potential temperature and
     ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
     ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
 
     rhoTS3 = EOS003 + (zs*EOS103 + zt*EOS013)
@@ -243,7 +249,7 @@ subroutine calculate_density_array_Roquet_rho(T, S, pressure, rho, start, npts, 
     rhoTS1 = EOS001 + (zs*(EOS101 +  zs*(EOS201 +  zs*(EOS301 +  zs*EOS401))) &
                      + zt*(EOS011 + (zs*(EOS111 +  zs*(EOS211 +  zs*EOS311)) &
                                    + zt*(EOS021 + (zs*(EOS121 +  zs*EOS221) &
-                                                 + zt*(EOS031 + (zs*EOS131 + zt*EOS041))  )) )) )
+                                                 + zt*(EOS031 + (zs*EOS131 + zt*EOS041)) )) )) )
     rhoTS0 = zt*(EOS010 &
                + (zs*(EOS110 +  zs*(EOS210 +  zs*(EOS310 +  zs*(EOS410 +  zs*EOS510)))) &
                 + zt*(EOS020 + (zs*(EOS120 +  zs*(EOS220 +  zs*(EOS320 +  zs*EOS420))) &
@@ -265,10 +271,10 @@ end subroutine calculate_density_array_Roquet_rho
 
 !> For a given thermodynamic state, calculate the derivatives of density with conservative
 !! temperature and absolute salinity, using the density polynomial fit EOS from Roquet et al. (2015).
-subroutine calculate_density_derivs_array_Roquet_rho(T, S, pressure, drho_dT, drho_dS, start, npts)
+subroutine calculate_density_derivs_array_Roquet_rho(T, S, pres, drho_dT, drho_dS, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC]
   real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1]
-  real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa]
+  real,    intent(in),  dimension(:) :: pres     !< Pressure [Pa]
   real,    intent(out), dimension(:) :: drho_dT  !< The partial derivative of density with
                                                  !! conservative temperature [kg m-3 degC-1]
   real,    intent(out), dimension(:) :: drho_dS  !< The partial derivative of density with
@@ -277,37 +283,37 @@ subroutine calculate_density_derivs_array_Roquet_rho(T, S, pressure, drho_dT, dr
   integer, intent(in)                :: npts     !< The number of values to calculate
 
   ! Local variables
-  real :: zp  ! Pressure, first in [dbar], then normalized by an assumed pressure range [nondim]
-  real :: zt  ! Conservative temperature, first in [degC], then normalized by an assumed temperature range [nondim]
-  real :: zs  ! Absolute salinity, first in [g kg-1], then the square root of salinity with an offset normalized
-              ! by an assumed salinity range [nondim]
+  real :: zp      ! Pressure [Pa]
+  real :: zt      ! Conservative temperature [degC]
+  real :: zs      ! The square root of absolute salinity with an offset normalized
+                  ! by an assumed salinity range [nondim]
   real :: dRdzt0  ! A contribution to the partial derivative of density with temperature [kg m-3 degC-1]
                   ! from temperature anomalies at the surface pressure
-  real :: dRdzt1  ! A contribution to the partial derivative of density with temperature [kg m-3 degC-1]
+  real :: dRdzt1  ! A contribution to the partial derivative of density with temperature [kg m-3 degC-1 Pa-1]
                   ! proportional to pressure
-  real :: dRdzt2  ! A contribution to the partial derivative of density with temperature [kg m-3 degC-1]
+  real :: dRdzt2  ! A contribution to the partial derivative of density with temperature [kg m-3 degC-1 Pa-2]
                   ! proportional to pressure**2
-  real :: dRdzt3  ! A contribution to the partial derivative of density with temperature [kg m-3 degC-1]
+  real :: dRdzt3  ! A contribution to the partial derivative of density with temperature [kg m-3 degC-1 Pa-3]
                   ! proportional to pressure**3
   real :: dRdzs0  ! A contribution to the partial derivative of density with
                   ! salinity [kg m-3 ppt-1] from temperature anomalies at the surface pressure
   real :: dRdzs1  ! A contribution to the partial derivative of density with
-                  ! salinity [kg m-3 ppt-1] proportional to pressure
+                  ! salinity [kg m-3 ppt-1 Pa-1] proportional to pressure
   real :: dRdzs2  ! A contribution to the partial derivative of density with
-                  ! salinity [kg m-3 ppt-1] proportional to pressure**2
+                  ! salinity [kg m-3 ppt-1 Pa-2] proportional to pressure**2
   real :: dRdzs3  ! A contribution to the partial derivative of density with
-                  ! salinity [kg m-3 ppt-1] proportional to pressure**3
+                  ! salinity [kg m-3 ppt-1 Pa-3] proportional to pressure**3
   integer :: j
 
   do j=start,start+npts-1
     ! Conversions to the units used here.
-    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zt = T(j)
     zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = pressure(j) * (Pa2db*r1_P0)    ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+    zp = pres(j)
 
     ! The next two lines should be used if it is necessary to convert potential temperature and
     ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
     ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
 
     ! Find the partial derivative of density with temperature
@@ -343,10 +349,10 @@ subroutine calculate_density_derivs_array_Roquet_rho(T, S, pressure, drho_dT, dr
 end subroutine calculate_density_derivs_array_Roquet_rho
 
 !> Wrapper to calculate_density_derivs_array for scalar inputs
-subroutine calculate_density_derivs_scalar_Roquet_rho(T, S, pressure, drho_dt, drho_ds)
+subroutine calculate_density_derivs_scalar_Roquet_rho(T, S, pres, drho_dt, drho_ds)
   real,    intent(in)  :: T        !< Conservative temperature [degC]
   real,    intent(in)  :: S        !< Absolute salinity [g kg-1]
-  real,    intent(in)  :: pressure !< Pressure [Pa]
+  real,    intent(in)  :: pres     !< Pressure [Pa]
   real,    intent(out) :: drho_dT  !< The partial derivative of density with
                                    !! conservative temperature [kg m-3 degC-1]
   real,    intent(out) :: drho_dS  !< The partial derivative of density with
@@ -354,7 +360,7 @@ subroutine calculate_density_derivs_scalar_Roquet_rho(T, S, pressure, drho_dt, d
   ! Local variables
   real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
   real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: pres0 ! A 1-d array with a copy of the pressure [Pa]
   real, dimension(1) :: drdt0 ! A 1-d array with a copy of the derivative of density
                               ! with conservative temperature [kg m-3 degC-1]
   real, dimension(1) :: drds0 ! A 1-d array with a copy of the derivative of density
@@ -362,9 +368,9 @@ subroutine calculate_density_derivs_scalar_Roquet_rho(T, S, pressure, drho_dt, d
 
   T0(1) = T
   S0(1) = S
-  pressure0(1) = pressure
+  pres0(1) = pres
 
-  call calculate_density_derivs_array_Roquet_rho(T0, S0, pressure0, drdt0, drds0, 1, 1)
+  call calculate_density_derivs_array_Roquet_rho(T0, S0, pres0, drdt0, drds0, 1, 1)
   drho_dt = drdt0(1)
   drho_ds = drds0(1)
 end subroutine calculate_density_derivs_scalar_Roquet_rho
@@ -373,10 +379,10 @@ end subroutine calculate_density_derivs_scalar_Roquet_rho
 !! (drho/dp = C_sound^-2, stored as drho_dp [s2 m-2]) from absolute salinity (sal [g kg-1]),
 !! conservative temperature (T [degC]), and pressure [Pa], using the density polynomial
 !! fit EOS from Roquet et al. (2015).
-subroutine calculate_compress_Roquet_rho(T, S, pressure, rho, drho_dp, start, npts)
+subroutine calculate_compress_Roquet_rho(T, S, pres, rho, drho_dp, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC]
   real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1]
-  real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa]
+  real,    intent(in),  dimension(:) :: pres     !< Pressure [Pa]
   real,    intent(out), dimension(:) :: rho      !< In situ density [kg m-3]
   real,    intent(out), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
                                                  !! (also the inverse of the square of sound speed)
@@ -385,31 +391,33 @@ subroutine calculate_compress_Roquet_rho(T, S, pressure, rho, drho_dp, start, np
   integer, intent(in)                :: npts     !< The number of values to calculate
 
   ! Local variables
-  real :: zp  ! Pressure normalized by an assumed pressure range [nondim]
-  real :: zt  ! Conservative temperature normalized by an assumed temperature range [nondim]
-  real :: zs  ! The square root of absolute salinity with an offset normalized
-              ! by an assumed salinity range [nondim]
-  real :: drho00p_dp ! Derivative of the pressure-dependent reference density profile with normalized pressure [kg m-3]
-  real :: drhoTS_dp  ! Derivative of the density anomaly from the reference profile with normalized pressure [kg m-3]
-  real :: rho00p ! The pressure-dependent (but temperature and salinity independent) reference density profile [kg m-3]
+  real :: zp     ! Pressure [Pa]
+  real :: zt     ! Conservative temperature [degC]
+  real :: zs     ! The square root of absolute salinity with an offset normalized
+                 ! by an assumed salinity range [nondim]
+  real :: drho00p_dp ! Derivative of the pressure-dependent reference density profile with pressure [kg m-3 Pa-1]
+  real :: drhoTS_dp  ! Derivative of the density anomaly from the reference profile with pressure [kg m-3 Pa-1]
+  real :: rho00p ! The pressure-dependent (but temperature and salinity independent) reference
+                 ! density profile [kg m-3]
   real :: rhoTS  ! Density anomaly from the reference profile [kg m-3]
-  real :: rhoTS0 ! A contribution to density from temperature and salinity anomalies at the surface pressure [kg m-3]
-  real :: rhoTS1 ! A temperature and salinity dependent density contribution proportional to pressure [kg m-3]
-  real :: rhoTS2 ! A temperature and salinity dependent density contribution proportional to pressure**2 [kg m-3]
-  real :: rhoTS3 ! A temperature and salinity dependent density contribution proportional to pressure**3 [kg m-3]
+  real :: rhoTS0 ! A contribution to density from temperature and salinity anomalies at the
+                 ! surface pressure [kg m-3]
+  real :: rhoTS1 ! A density contribution proportional to pressure [kg m-3 Pa-1]
+  real :: rhoTS2 ! A density contribution proportional to pressure**2 [kg m-3 Pa-2]
+  real :: rhoTS3 ! A density contribution proportional to pressure**3 [kg m-3 Pa-3]
   real :: rho0S0 ! Salinity dependent density at the surface pressure and zero temperature [kg m-3]
   integer :: j
 
   ! The following algorithm was published by Roquet et al. (2015), intended for use with NEMO.
   do j=start,start+npts-1
     ! Conversions to the units used here.
-    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zt = T(j)
     zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = pressure(j) * (Pa2db*r1_P0)    ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+    zp = pres(j)
 
     ! The next two lines should be used if it is necessary to convert potential temperature and
     ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
     ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
 
     rhoTS3 = EOS003 + (zs*EOS103 + zt*EOS013)
@@ -418,7 +426,7 @@ subroutine calculate_compress_Roquet_rho(T, S, pressure, rho, drho_dp, start, np
     rhoTS1 = EOS001 + (zs*(EOS101 +  zs*(EOS201 +  zs*(EOS301 +  zs*EOS401))) &
                      + zt*(EOS011 + (zs*(EOS111 +  zs*(EOS211 +  zs*EOS311)) &
                                    + zt*(EOS021 + (zs*(EOS121 +  zs*EOS221) &
-                                                 + zt*(EOS031 + (zs*EOS131 + zt*EOS041))  )) )) )
+                                                 + zt*(EOS031 + (zs*EOS131 + zt*EOS041)) )) )) )
 
     rhoTS0 = zt*(EOS010 &
                + (zs*(EOS110 +  zs*(EOS210 +  zs*(EOS310 +  zs*(EOS410 +  zs*EOS510)))) &
@@ -436,18 +444,19 @@ subroutine calculate_compress_Roquet_rho(T, S, pressure, rho, drho_dp, start, np
 
     drho00p_dp = R00 + zp*(2.*R01 + zp*(3.*R02 + zp*(4.*R03 + zp*(5.*R04 + zp*(6.*R05)))))
     drhoTS_dp  = rhoTS1 + zp*(2.*rhoTS2 + zp*(3.*rhoTS3))
-    drho_dp(j) = (drhoTS_dp + drho00p_dp) * (Pa2db*r1_P0) ! Compressibility [s2 m-2]
+    drho_dp(j) = drhoTS_dp + drho00p_dp ! Compressibility [s2 m-2]
 
   enddo
 end subroutine calculate_compress_Roquet_rho
 
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
+!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array
+!! inputs and outputs.
 subroutine calculate_density_second_derivs_array_Roquet_rho(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                       drho_ds_dp, drho_dt_dp, start, npts)
-  real, dimension(:), intent(in   ) :: T !< Conservative temperature [degC]
-  real, dimension(:), intent(in   ) :: S !< Absolute salinity [PSU]
-  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
+  real, dimension(:), intent(in   ) :: T          !< Conservative temperature [degC]
+  real, dimension(:), intent(in   ) :: S          !< Absolute salinity [g kg-1] = [ppt]
+  real, dimension(:), intent(in   ) :: P          !< Pressure [Pa]
   real, dimension(:), intent(inout) :: drho_ds_ds !< Second derivative of density with respect
                                                   !! to salinity [kg m-3 ppt-2]
   real, dimension(:), intent(inout) :: drho_ds_dt !< Second derivative of density with respect
@@ -458,15 +467,15 @@ subroutine calculate_density_second_derivs_array_Roquet_rho(T, S, P, drho_ds_ds,
                                                   !! and salinity [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
   real, dimension(:), intent(inout) :: drho_dt_dp !< Second derivative of density with respect to pressure
                                                   !! and temperature [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  integer,            intent(in   ) :: start !< Starting index in T,S,P
-  integer,            intent(in   ) :: npts  !< Number of points to loop over
+  integer,            intent(in   ) :: start      !< The starting index for calculations
+  integer,            intent(in   ) :: npts       !< The number of values to calculate
 
   ! Local variables
-  real :: zp  ! Pressure normalized by an assumed pressure range [nondim]
-  real :: zt  ! Conservative temperature normalized by an assumed temperature range [nondim]
-  real :: zs  ! The square root of absolute salinity with an offset normalized
-              ! by an assumed salinity range [nondim]
-  real :: I_s ! The inverse of zs [nondim]
+  real :: zp     ! Pressure [Pa]
+  real :: zt     ! Conservative temperature [degC]
+  real :: zs     ! The square root of absolute salinity with an offset normalized
+                 ! by an assumed salinity range [nondim]
+  real :: I_s    ! The inverse of zs [nondim]
   real :: d2R_p0 ! A contribution to one of the second derivatives that is independent of pressure [various]
   real :: d2R_p1 ! A contribution to one of the second derivatives that is proportional to pressure [various]
   real :: d2R_p2 ! A contribution to one of the second derivatives that is proportional to pressure**2 [various]
@@ -475,13 +484,13 @@ subroutine calculate_density_second_derivs_array_Roquet_rho(T, S, P, drho_ds_ds,
 
   do j = start,start+npts-1
     ! Conversions to the units used here.
-    zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
+    zt = T(j)
     zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = P(j) * (Pa2db*r1_P0)     ! Convert pressure from Pascals to kilobars to normalize it [nondim]
+    zp = P(j)
 
     ! The next two lines should be used if it is necessary to convert potential temperature and
     ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = r1_T0 * gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
+    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
     ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 )  ! Convert S from practical to absolute salinity.
 
     I_s = 1.0 / zs
@@ -506,7 +515,7 @@ subroutine calculate_density_second_derivs_array_Roquet_rho(T, S, P, drho_ds_ds,
                                       + zt*(3.*EOS130 + (zs*(6.*EOS230 +  zs*(9.*EOS330)) &
                                                        + zt*(4.*EOS140 + (zs*(8.*EOS240) &
                                                                         + zt*(5.*EOS150))) )) )) )
-    drho_ds_dt(j) = (0.5*r1_S0*r1_T0) * ((d2R_p0 + zp*(d2R_p1 + zp*d2R_p2)) * I_s)
+    drho_ds_dt(j) = (0.5*r1_S0) * ((d2R_p0 + zp*(d2R_p1 + zp*d2R_p2)) * I_s)
 
     ! Find drho_dt_dt
     d2R_p2 = 2.*EOS022
@@ -517,7 +526,7 @@ subroutine calculate_density_second_derivs_array_Roquet_rho(T, S, P, drho_ds_ds,
                                          + zt*(12.*EOS040 + (zs*(12.*EOS140 + zs *(12.*EOS240)) &
                                                            + zt*(20.*EOS050 + (zs*(20.*EOS150) &
                                                                              + zt*(30.*EOS060) )) )) )) )
-    drho_dt_dt(j) = (d2R_p0 + zp*(d2R_p1 + zp*d2R_p2)) * r1_T0**2
+    drho_dt_dt(j) = (d2R_p0 + zp*(d2R_p1 + zp*d2R_p2))
 
     ! Find drho_ds_dp
     d2R_p2 = 3.*EOS103
@@ -525,7 +534,7 @@ subroutine calculate_density_second_derivs_array_Roquet_rho(T, S, P, drho_ds_ds,
     d2R_p0 = EOS101 + (zs*(2.*EOS201 + zs*(3.*EOS301 +  zs*(4.*EOS401))) &
                      + zt*(EOS111 +   (zs*(2.*EOS211 +  zs*(3.*EOS311)) &
                                      + zt*(   EOS121 + (zs*(2.*EOS221) + zt*EOS131)) )) )
-    drho_ds_dp(j) =  ((d2R_p0 + zp*(d2R_p1 + zp*d2R_p2)) * I_s) * (0.5*r1_S0 * Pa2db*r1_P0)
+    drho_ds_dp(j) =  ((d2R_p0 + zp*(d2R_p1 + zp*d2R_p2)) * I_s) * (0.5*r1_S0)
 
     ! Find drho_dt_dp
     d2R_p2 = 3.*EOS013
@@ -533,7 +542,7 @@ subroutine calculate_density_second_derivs_array_Roquet_rho(T, S, P, drho_ds_ds,
     d2R_p0 = EOS011 + (zs*(EOS111     + zs*(   EOS211 +  zs*    EOS311)) &
                      + zt*(2.*EOS021 + (zs*(2.*EOS121 +  zs*(2.*EOS221)) &
                                       + zt*(3.*EOS031 + (zs*(3.*EOS131) + zt*(4.*EOS041))) )) )
-    drho_dt_dp(j) =  (d2R_p0 + zp*(d2R_p1 + zp*d2R_p2)) * (Pa2db*r1_P0* r1_T0)
+    drho_dt_dp(j) =  (d2R_p0 + zp*(d2R_p1 + zp*d2R_p2))
   enddo
 
 end subroutine calculate_density_second_derivs_array_Roquet_rho
@@ -545,7 +554,7 @@ end subroutine calculate_density_second_derivs_array_Roquet_rho
 subroutine calculate_density_second_derivs_scalar_Roquet_rho(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                        drho_ds_dp, drho_dt_dp)
   real, intent(in   ) :: T          !< Conservative temperature [degC]
-  real, intent(in   ) :: S          !< Absolute salinity [PSU]
+  real, intent(in   ) :: S          !< Absolute salinity [g kg-1]
   real, intent(in   ) :: P          !< pressure [Pa]
   real, intent(  out) :: drho_ds_ds !< Second derivative of density with respect
                                     !! to salinity [kg m-3 ppt-2]
@@ -558,15 +567,15 @@ subroutine calculate_density_second_derivs_scalar_Roquet_rho(T, S, P, drho_ds_ds
   real, intent(  out) :: drho_dt_dp !< Second derivative of density with respect to pressure
                                     !! and temperature [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
   ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 PSU-2]
+  real, dimension(1) :: T0     ! A 1-d array with a copy of the temperature [degC]
+  real, dimension(1) :: S0     ! A 1-d array with a copy of the salinity [g kg-1] = [ppt]
+  real, dimension(1) :: p0     ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 ppt-2]
   real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
-                               ! temperature [kg m-3 PSU-1 degC-1]
+                               ! temperature [kg m-3 ppt-1 degC-1]
   real, dimension(1) :: drdtdt ! The second derivative of density with temperature [kg m-3 degC-2]
   real, dimension(1) :: drdsdp ! The second derivative of density with salinity and
-                               ! pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+                               ! pressure [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
   real, dimension(1) :: drdtdp ! The second derivative of density with temperature and
                                ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
 

--- a/src/equation_of_state/MOM_EOS_Roquet_rho.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_rho.F90
@@ -1,5 +1,5 @@
-!> The equation of state using the expressions of Roquet et al. that are used in NEMO
-module MOM_EOS_NEMO
+!> The equation of state using the expressions of Roquet et al. (2015) that are used in NEMO
+module MOM_EOS_Roquet_rho
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
@@ -7,32 +7,32 @@ module MOM_EOS_NEMO
 
 implicit none ; private
 
-public calculate_compress_nemo, calculate_density_nemo
-public calculate_density_derivs_nemo
-public calculate_density_scalar_nemo, calculate_density_array_nemo
-public calculate_density_second_derivs_nemo, EoS_fit_range_NEMO
+public calculate_compress_Roquet_rho, calculate_density_Roquet_rho
+public calculate_density_derivs_Roquet_rho
+public calculate_density_scalar_Roquet_rho, calculate_density_array_Roquet_rho
+public calculate_density_second_derivs_Roquet_rho, EoS_fit_range_Roquet_rho
 
 !> Compute the in situ density of sea water [kg m-3], or its anomaly with respect to
 !! a reference density, from absolute salinity [g kg-1], conservative temperature [degC],
 !! and pressure [Pa], using the expressions for density from Roquet et al. (2015)
-interface calculate_density_nemo
-  module procedure calculate_density_scalar_nemo, calculate_density_array_nemo
-end interface calculate_density_nemo
+interface calculate_density_Roquet_rho
+  module procedure calculate_density_scalar_Roquet_rho, calculate_density_array_Roquet_rho
+end interface calculate_density_Roquet_rho
 
 !> For a given thermodynamic state, return the derivatives of density with conservative temperature
 !! and absolute salinity, using the expressions for density from Roquet et al. (2015)
-interface calculate_density_derivs_nemo
-  module procedure calculate_density_derivs_scalar_nemo, calculate_density_derivs_array_nemo
-end interface calculate_density_derivs_nemo
+interface calculate_density_derivs_Roquet_rho
+  module procedure calculate_density_derivs_scalar_Roquet_rho, calculate_density_derivs_array_Roquet_rho
+end interface calculate_density_derivs_Roquet_rho
 
 !> Compute the second derivatives of density with various combinations of temperature,
 !! salinity, and pressure using the expressions for density from Roquet et al. (2015)
-interface calculate_density_second_derivs_nemo
-  module procedure calculate_density_second_derivs_scalar_nemo, calculate_density_second_derivs_array_nemo
-end interface calculate_density_second_derivs_nemo
+interface calculate_density_second_derivs_Roquet_rho
+  module procedure calculate_density_second_derivs_scalar_Roquet_rho, calculate_density_second_derivs_array_Roquet_rho
+end interface calculate_density_second_derivs_Roquet_rho
 
 real, parameter :: Pa2db  = 1.e-4 !< Conversion factor between Pa and dbar [dbar Pa-1]
-!>@{ Parameters in the NEMO (Roquet density) equation of state
+!>@{ Parameters in the Roquet_rho (Roquet density) equation of state
 real, parameter :: rdeltaS = 32.           ! An offset to salinity before taking its square root [g kg-1]
 real, parameter :: r1_S0 = 0.875/35.16504  ! The inverse of a plausible range of oceanic salinities [kg g-1]
 real, parameter :: r1_T0 = 1./40.          ! The inverse of a plausible range of oceanic temperatures [degC-1]
@@ -177,7 +177,7 @@ contains
 !> This subroutine computes the in situ density of sea water (rho in [kg m-3])
 !! from absolute salinity (S [g kg-1]), conservative temperature (T [degC])
 !! and pressure [Pa], using the density polynomial fit EOS from Roquet et al. (2015).
-subroutine calculate_density_scalar_nemo(T, S, pressure, rho, rho_ref)
+subroutine calculate_density_scalar_Roquet_rho(T, S, pressure, rho, rho_ref)
   real,           intent(in)  :: T        !< Conservative temperature [degC]
   real,           intent(in)  :: S        !< Absolute salinity [g kg-1]
   real,           intent(in)  :: pressure !< Pressure [Pa]
@@ -193,15 +193,15 @@ subroutine calculate_density_scalar_nemo(T, S, pressure, rho, rho_ref)
   S0(1) = S
   pressure0(1) = pressure
 
-  call calculate_density_array_nemo(T0, S0, pressure0, rho0, 1, 1, rho_ref)
+  call calculate_density_array_Roquet_rho(T0, S0, pressure0, rho0, 1, 1, rho_ref)
   rho = rho0(1)
 
-end subroutine calculate_density_scalar_nemo
+end subroutine calculate_density_scalar_Roquet_rho
 
 !> This subroutine computes an array of in situ densities of sea water (rho in [kg m-3])
 !! from absolute salinity (S [g kg-1]), conservative temperature (T [degC]), and pressure
 !! [Pa], using the density polynomial fit EOS from Roquet et al. (2015).
-subroutine calculate_density_array_nemo(T, S, pressure, rho, start, npts, rho_ref)
+subroutine calculate_density_array_Roquet_rho(T, S, pressure, rho, start, npts, rho_ref)
   real, dimension(:), intent(in)  :: T        !< Conservative temperature [degC]
   real, dimension(:), intent(in)  :: S        !< Absolute salinity [g kg-1]
   real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
@@ -225,8 +225,7 @@ subroutine calculate_density_array_nemo(T, S, pressure, rho, start, npts, rho_re
   real :: rho0S0 ! Salinity dependent density at the surface pressure and zero temperature [kg m-3]
   integer :: j
 
-  ! The following algorithm was published by Roquet et al. (2015), intended for use
-  ! with NEMO, but it is not necessarily the algorithm used in NEMO ocean model.
+  ! The following algorithm was published by Roquet et al. (2015), intended for use with NEMO.
   do j=start,start+npts-1
     ! Conversions to the units used here.
     zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
@@ -262,11 +261,11 @@ subroutine calculate_density_array_nemo(T, S, pressure, rho, start, npts, rho_re
     rho(j) = rhoTS + rho00p  ! In situ density [kg m-3]
 
   enddo
-end subroutine calculate_density_array_nemo
+end subroutine calculate_density_array_Roquet_rho
 
 !> For a given thermodynamic state, calculate the derivatives of density with conservative
 !! temperature and absolute salinity, using the density polynomial fit EOS from Roquet et al. (2015).
-subroutine calculate_density_derivs_array_nemo(T, S, pressure, drho_dT, drho_dS, start, npts)
+subroutine calculate_density_derivs_array_Roquet_rho(T, S, pressure, drho_dT, drho_dS, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC]
   real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1]
   real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa]
@@ -341,10 +340,10 @@ subroutine calculate_density_derivs_array_nemo(T, S, pressure, drho_dT, drho_dS,
     drho_dS(j) = (dRdzs0 + zp*(dRdzs1 + zp*(dRdzs2 + zp * dRdzs3))) / zs
   enddo
 
-end subroutine calculate_density_derivs_array_nemo
+end subroutine calculate_density_derivs_array_Roquet_rho
 
 !> Wrapper to calculate_density_derivs_array for scalar inputs
-subroutine calculate_density_derivs_scalar_nemo(T, S, pressure, drho_dt, drho_ds)
+subroutine calculate_density_derivs_scalar_Roquet_rho(T, S, pressure, drho_dt, drho_ds)
   real,    intent(in)  :: T        !< Conservative temperature [degC]
   real,    intent(in)  :: S        !< Absolute salinity [g kg-1]
   real,    intent(in)  :: pressure !< Pressure [Pa]
@@ -365,16 +364,16 @@ subroutine calculate_density_derivs_scalar_nemo(T, S, pressure, drho_dt, drho_ds
   S0(1) = S
   pressure0(1) = pressure
 
-  call calculate_density_derivs_array_nemo(T0, S0, pressure0, drdt0, drds0, 1, 1)
+  call calculate_density_derivs_array_Roquet_rho(T0, S0, pressure0, drdt0, drds0, 1, 1)
   drho_dt = drdt0(1)
   drho_ds = drds0(1)
-end subroutine calculate_density_derivs_scalar_nemo
+end subroutine calculate_density_derivs_scalar_Roquet_rho
 
 !> Compute the in situ density of sea water (rho in [kg m-3]) and the compressibility
 !! (drho/dp = C_sound^-2, stored as drho_dp [s2 m-2]) from absolute salinity (sal [g kg-1]),
 !! conservative temperature (T [degC]), and pressure [Pa], using the density polynomial
 !! fit EOS from Roquet et al. (2015).
-subroutine calculate_compress_nemo(T, S, pressure, rho, drho_dp, start, npts)
+subroutine calculate_compress_Roquet_rho(T, S, pressure, rho, drho_dp, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC]
   real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1]
   real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa]
@@ -401,8 +400,7 @@ subroutine calculate_compress_nemo(T, S, pressure, rho, drho_dp, start, npts)
   real :: rho0S0 ! Salinity dependent density at the surface pressure and zero temperature [kg m-3]
   integer :: j
 
-  ! The following algorithm was published by Roquet et al. (2015), intended for use
-  ! with NEMO, but it is not necessarily the algorithm used in NEMO ocean model.
+  ! The following algorithm was published by Roquet et al. (2015), intended for use with NEMO.
   do j=start,start+npts-1
     ! Conversions to the units used here.
     zt = T(j) * r1_T0  ! Conservative temperature normalized by a plausible oceanic range [nondim]
@@ -441,11 +439,11 @@ subroutine calculate_compress_nemo(T, S, pressure, rho, drho_dp, start, npts)
     drho_dp(j) = (drhoTS_dp + drho00p_dp) * (Pa2db*r1_P0) ! Compressibility [s2 m-2]
 
   enddo
-end subroutine calculate_compress_nemo
+end subroutine calculate_compress_Roquet_rho
 
 
 !> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
-subroutine calculate_density_second_derivs_array_NEMO(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+subroutine calculate_density_second_derivs_array_Roquet_rho(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                       drho_ds_dp, drho_dt_dp, start, npts)
   real, dimension(:), intent(in   ) :: T !< Conservative temperature [degC]
   real, dimension(:), intent(in   ) :: S !< Absolute salinity [PSU]
@@ -538,13 +536,13 @@ subroutine calculate_density_second_derivs_array_NEMO(T, S, P, drho_ds_ds, drho_
     drho_dt_dp(j) =  (d2R_p0 + zp*(d2R_p1 + zp*d2R_p2)) * (Pa2db*r1_P0* r1_T0)
   enddo
 
-end subroutine calculate_density_second_derivs_array_NEMO
+end subroutine calculate_density_second_derivs_array_Roquet_rho
 
 !> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
 !!
 !! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
 !! and then demotes the output back to a scalar
-subroutine calculate_density_second_derivs_scalar_NEMO(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+subroutine calculate_density_second_derivs_scalar_Roquet_rho(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                        drho_ds_dp, drho_dt_dp)
   real, intent(in   ) :: T          !< Conservative temperature [degC]
   real, intent(in   ) :: S          !< Absolute salinity [PSU]
@@ -575,19 +573,19 @@ subroutine calculate_density_second_derivs_scalar_NEMO(T, S, P, drho_ds_ds, drho
   T0(1) = T
   S0(1) = S
   P0(1) = P
-  call calculate_density_second_derivs_array_NEMO(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
+  call calculate_density_second_derivs_array_Roquet_rho(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
   drho_ds_ds = drdsds(1)
   drho_ds_dt = drdsdt(1)
   drho_dt_dt = drdtdt(1)
   drho_ds_dp = drdsdp(1)
   drho_dt_dp = drdtdp(1)
 
-end subroutine calculate_density_second_derivs_scalar_NEMO
+end subroutine calculate_density_second_derivs_scalar_Roquet_rho
 
 !> Return the range of temperatures, salinities and pressures for which the Roquet et al. (2015)
 !! expression for in situ density has been fitted to observations.  Care should be taken when
 !! applying this equation of state outside of its fit range.
-subroutine EoS_fit_range_NEMO(T_min, T_max, S_min, S_max, p_min, p_max)
+subroutine EoS_fit_range_Roquet_rho(T_min, T_max, S_min, S_max, p_min, p_max)
   real, optional, intent(out) :: T_min !< The minimum conservative temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: T_max !< The maximum conservative temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: S_min !< The minimum absolute salinity over which this EoS is fitted [g kg-1]
@@ -602,11 +600,11 @@ subroutine EoS_fit_range_NEMO(T_min, T_max, S_min, S_max, p_min, p_max)
   if (present(p_min)) p_min = 0.0
   if (present(p_max)) p_max = 1.0e8
 
-end subroutine EoS_fit_range_NEMO
+end subroutine EoS_fit_range_Roquet_rho
 
-!> \namespace mom_eos_NEMO
+!> \namespace mom_eos_Roquet_rho
 !!
-!! \section section_EOS_NEMO NEMO equation of state
+!! \section section_EOS_Roquet_rho Roquet_rho equation of state
 !!
 !!  Fabien Roquet and colleagues developed this equation of state using a simple polynomial fit
 !! to the TEOS-10 equation of state, for efficiency when used in the NEMO ocean model.  Fabien
@@ -617,15 +615,10 @@ end subroutine EoS_fit_range_NEMO
 !! observational uncertainty with a polynomial form that can be evaluated quickly despite having
 !! 52 terms.
 !!
-!! The NEMO label used to describe this equation of state reflects that it was used in the NEMO
-!! ocean model before it was used in MOM6, but it probably should be described as the Roquet
-!! equation of state.   However, these algorithms, especially as modified here, are not from
-!! the standard NEMO codebase.
-!!
-!! \subsection section_EOS_NEMO_references References
+!! \subsection section_EOS_Roquet_rho_references References
 !!
 !! Roquet, F., Madec, G., McDougall, T. J., and Barker, P. M., 2015:
 !!  Accurate polynomial expressions for the density and specific volume
 !!  of seawater using the TEOS-10 standard. Ocean Modelling, 90:29-43.
 
-end module MOM_EOS_NEMO
+end module MOM_EOS_Roquet_rho

--- a/src/equation_of_state/MOM_EOS_TEOS10.F90
+++ b/src/equation_of_state/MOM_EOS_TEOS10.F90
@@ -17,9 +17,8 @@ use gsw_mod_toolbox, only : gsw_rho_second_derivatives
 implicit none ; private
 
 public calculate_compress_teos10, calculate_density_teos10, calculate_spec_vol_teos10
-public calculate_density_derivs_teos10
-public calculate_specvol_derivs_teos10
-public calculate_density_second_derivs_teos10
+public calculate_density_derivs_teos10, calculate_specvol_derivs_teos10
+public calculate_density_second_derivs_teos10, EoS_fit_range_teos10
 public gsw_sp_from_sr, gsw_pt_from_ct
 
 !> Compute the in situ density of sea water ([kg m-3]), or its anomaly with respect to
@@ -368,5 +367,26 @@ subroutine calculate_compress_teos10(T, S, pressure, rho, drho_dp, start, npts)
     endif
   enddo
 end subroutine calculate_compress_teos10
+
+
+!> Return the range of temperatures, salinities and pressures for which the TEOS-10
+!! equation of state has been fitted to observations.  Care should be taken when
+!! applying this equation of state outside of its fit range.
+subroutine EoS_fit_range_teos10(T_min, T_max, S_min, S_max, p_min, p_max)
+  real, optional, intent(out) :: T_min !< The minimum conservative temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: T_max !< The maximum conservative temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: S_min !< The minimum absolute salinity over which this EoS is fitted [g kg-1]
+  real, optional, intent(out) :: S_max !< The maximum absolute salinity over which this EoS is fitted [g kg-1]
+  real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+  real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  if (present(T_min)) T_min = -6.0
+  if (present(T_max)) T_max = 40.0
+  if (present(S_min)) S_min =  0.0
+  if (present(S_max)) S_max = 42.0
+  if (present(p_min)) p_min = 0.0
+  if (present(p_max)) p_max = 1.0e8
+
+end subroutine EoS_fit_range_teos10
 
 end module MOM_EOS_TEOS10

--- a/src/equation_of_state/MOM_EOS_UNESCO.F90
+++ b/src/equation_of_state/MOM_EOS_UNESCO.F90
@@ -52,8 +52,7 @@ real, parameter :: R02 = 4.8314e-4    ! A coefficient in the fit for rho0 [kg m-
 
 ! The following constants are used to calculate the secant bulk modulus.
 ! The notation here is Sab for terms proportional to T^a*S^b,
-! Spab for terms proportional to p*T^a*S^b, and SP0ab for terms
-! proportional to p^2*T^a*S^b.
+! SpABC for terms proportional to p^A*T^B*S^C.
 !   Note that these values differ from those in Appendix 3 of Gill (1982) because the expressions
 ! from Jackett and MacDougall (1995) use potential temperature, rather than in situ temperature.
 real, parameter :: S00 = 1.965933e4   ! A coefficient in the secant bulk modulus fit [bar]
@@ -69,21 +68,21 @@ real, parameter :: S032 = 3.886640e-1   ! A coefficient in the secant bulk modul
 real, parameter :: S132 = 9.085835e-3   ! A coefficient in the secant bulk modulus fit [bar degC-1 PSU-3/2]
 real, parameter :: S232 = -4.619924e-4  ! A coefficient in the secant bulk modulus fit [bar degC-2 PSU-3/2]
 
-real, parameter :: Sp00 = 3.186519      ! A coefficient in the secant bulk modulus fit [nondim]
-real, parameter :: Sp10 = 2.212276e-2   ! A coefficient in the secant bulk modulus fit [degC-1]
-real, parameter :: Sp20 = -2.984642e-4  ! A coefficient in the secant bulk modulus fit [degC-2]
-real, parameter :: Sp30 = 1.956415e-6   ! A coefficient in the secant bulk modulus fit [degC-3]
-real, parameter :: Sp01 = 6.704388e-3   ! A coefficient in the secant bulk modulus fit [PSU-1]
-real, parameter :: Sp11 = -1.847318e-4  ! A coefficient in the secant bulk modulus fit [degC-1 PSU-1]
-real, parameter :: Sp21 = 2.059331e-7   ! A coefficient in the secant bulk modulus fit [degC-2 PSU-1]
-real, parameter :: Sp032 = 1.480266e-4  ! A coefficient in the secant bulk modulus fit [PSU-3/2]
+real, parameter :: Sp100 = 3.186519      ! A coefficient in the secant bulk modulus fit [nondim]
+real, parameter :: Sp110 = 2.212276e-2   ! A coefficient in the secant bulk modulus fit [degC-1]
+real, parameter :: Sp120 = -2.984642e-4  ! A coefficient in the secant bulk modulus fit [degC-2]
+real, parameter :: Sp130 = 1.956415e-6   ! A coefficient in the secant bulk modulus fit [degC-3]
+real, parameter :: Sp101 = 6.704388e-3   ! A coefficient in the secant bulk modulus fit [PSU-1]
+real, parameter :: Sp111 = -1.847318e-4  ! A coefficient in the secant bulk modulus fit [degC-1 PSU-1]
+real, parameter :: Sp121 = 2.059331e-7   ! A coefficient in the secant bulk modulus fit [degC-2 PSU-1]
+real, parameter :: Sp1032 = 1.480266e-4  ! A coefficient in the secant bulk modulus fit [PSU-3/2]
 
-real, parameter :: SP000 = 2.102898e-4  ! A coefficient in the secant bulk modulus fit [bar-1]
-real, parameter :: SP010 = -1.202016e-5 ! A coefficient in the secant bulk modulus fit [bar-1 degC-1]
-real, parameter :: SP020 = 1.394680e-7  ! A coefficient in the secant bulk modulus fit [bar-1 degC-2]
-real, parameter :: SP001 = -2.040237e-6 ! A coefficient in the secant bulk modulus fit [bar-1 PSU-1]
-real, parameter :: SP011 = 6.128773e-8  ! A coefficient in the secant bulk modulus fit [bar-1 degC-1 PSU-1]
-real, parameter :: SP021 = 6.207323e-10 ! A coefficient in the secant bulk modulus fit [bar-1 degC-1 PSU-2]
+real, parameter :: Sp200 = 2.102898e-4  ! A coefficient in the secant bulk modulus fit [bar-1]
+real, parameter :: Sp210 = -1.202016e-5 ! A coefficient in the secant bulk modulus fit [bar-1 degC-1]
+real, parameter :: Sp220 = 1.394680e-7  ! A coefficient in the secant bulk modulus fit [bar-1 degC-2]
+real, parameter :: Sp201 = -2.040237e-6 ! A coefficient in the secant bulk modulus fit [bar-1 PSU-1]
+real, parameter :: Sp211 = 6.128773e-8  ! A coefficient in the secant bulk modulus fit [bar-1 degC-1 PSU-1]
+real, parameter :: Sp221 = 6.207323e-10 ! A coefficient in the secant bulk modulus fit [bar-1 degC-1 PSU-2]
 !>@}
 
 contains
@@ -93,11 +92,11 @@ contains
 !! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
 !! If rho_ref is present, rho is an anomaly from rho_ref.
 subroutine calculate_density_scalar_UNESCO(T, S, pressure, rho, rho_ref)
-  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC].
-  real,           intent(in)  :: S        !< Salinity [PSU].
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: rho      !< In situ density [kg m-3].
-  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
+  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,           intent(in)  :: S        !< Salinity [PSU]
+  real,           intent(in)  :: pressure !< Pressure [Pa]
+  real,           intent(out) :: rho      !< In situ density [kg m-3]
+  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
 
   ! Local variables
   real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
@@ -119,51 +118,42 @@ end subroutine calculate_density_scalar_UNESCO
 !! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
 !! If rho_ref is present, rho is an anomaly from rho_ref.
 subroutine calculate_density_array_UNESCO(T, S, pressure, rho, start, npts, rho_ref)
-  real, dimension(:), intent(in)  :: T        !< potential temperature relative to the surface [degC].
-  real, dimension(:), intent(in)  :: S        !< salinity [PSU].
-  real, dimension(:), intent(in)  :: pressure !< pressure [Pa].
-  real, dimension(:), intent(out) :: rho      !< in situ density [kg m-3].
-  integer,            intent(in)  :: start    !< the starting point in the arrays.
-  integer,            intent(in)  :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
+  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate
+  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
 
   ! Local variables
-  real :: t_local     ! A copy of the temperature at a point [degC]
-  real :: t2, t3      ! Temperature squared [degC2] and cubed [degC3]
-  real :: t4, t5      ! Temperature to the 4th power [degC4] and 5th power [degC5]
-  real :: s_local     ! A copy of the salinity at a point [PSU]
-  real :: s32         ! The square root of salinity cubed [PSU3/2]
-  real :: s2          ! Salinity squared [PSU2].
-  real :: p1, p2      ! Pressure (in bars) to the 1st and 2nd power [bar] and [bar2].
-  real :: rho0        ! Density at 1 bar pressure [kg m-3].
-  real :: sig0        ! The anomaly of rho0 from R00 [kg m-3].
-  real :: ks          ! The secant bulk modulus [bar].
+  real :: t1   ! A copy of the temperature at a point [degC]
+  real :: s1   ! A copy of the salinity at a point [PSU]
+  real :: p1   ! Pressure converted to bars [bar]
+  real :: s12  ! The square root of salinity [PSU1/2]
+  real :: rho0 ! Density at 1 bar pressure [kg m-3]
+  real :: sig0 ! The anomaly of rho0 from R00 [kg m-3]
+  real :: ks   ! The secant bulk modulus [bar]
   integer :: j
 
   do j=start,start+npts-1
-    if (S(j) < -1.0e-10) then !Can we assume safely that this is a missing value?
-      rho(j) = 1000.0
-      cycle
-    endif
-
-    p1 = pressure(j)*1.0e-5 ; p2 = p1*p1
-    t_local = T(j) ; t2 = t_local*t_local ; t3 = t_local*t2 ; t4 = t2*t2 ; t5 = t3*t2
-    s_local = S(j) ; s2 = s_local*s_local ; s32 = s_local*sqrt(s_local)
+    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
+    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
 
 !  Compute rho(s,theta,p=0) - (same as rho(s,t_insitu,p=0) ).
 
-    sig0 = R10*t_local + R20*t2 + R30*t3 + R40*t4 + R50*t5 + &
-           s_local*(R01 + R11*t_local + R21*t2 + R31*t3 + R41*t4) + &
-           s32*(R032 + R132*t_local + R232*t2) + R02*s2
+    sig0 = ( t1*(R10 + t1*(R20 + t1*(R30 + t1*(R40 + R50*t1)))) + &
+             s1*((R01 + t1*(R11 + t1*(R21 + t1*(R31 + R41*t1)))) + &
+                 (s12*(R032 + t1*(R132 + R232*t1)) + R02*s1)) )
     rho0 = R00 + sig0
 
 !  Compute rho(s,theta,p), first calculating the secant bulk modulus.
 
-    ks = S00 + S10*t_local + S20*t2 + S30*t3 + S40*t4 + s_local*(S01 + S11*t_local + S21*t2 + S31*t3) + &
-         s32*(S032 + S132*t_local + S232*t2) + &
-         p1*(Sp00 + Sp10*t_local + Sp20*t2 + Sp30*t3 + &
-             s_local*(Sp01 + Sp11*t_local + Sp21*t2) + Sp032*s32) + &
-         p2*(SP000 + SP010*t_local + SP020*t2 + s_local*(SP001 + SP011*t_local + SP021*t2))
+    ks = (S00 + ( t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
+                  s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1))) )) + &
+         p1*( (Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
+                         s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )) + &
+              p1*(Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )) )
 
     if (present(rho_ref)) then
       rho(j) = ((R00 - rho_ref)*ks + (sig0*ks + p1*rho_ref)) / (ks - p1)
@@ -178,12 +168,11 @@ end subroutine calculate_density_array_UNESCO
 !! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_scalar_UNESCO(T, S, pressure, specvol, spv_ref)
-  real,           intent(in)  :: T        !< potential temperature relative to the surface
-                                          !! [degC].
-  real,           intent(in)  :: S        !< salinity [PSU].
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
-  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
+  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,           intent(in)  :: S        !< Salinity [PSU]
+  real,           intent(in)  :: pressure !< Pressure [Pa]
+  real,           intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
+  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
 
   ! Local variables
   real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
@@ -202,51 +191,41 @@ end subroutine calculate_spec_vol_scalar_UNESCO
 !! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_array_UNESCO(T, S, pressure, specvol, start, npts, spv_ref)
-  real, dimension(:), intent(in)  :: T        !< potential temperature relative to the surface
-                                              !! [degC].
-  real, dimension(:), intent(in)  :: S        !< salinity [PSU].
-  real, dimension(:), intent(in)  :: pressure !< pressure [Pa].
-  real, dimension(:), intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
-  integer,            intent(in)  :: start    !< the starting point in the arrays.
-  integer,            intent(in)  :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
+  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate
+  real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
 
   ! Local variables
-  real :: t_local     ! A copy of the temperature at a point [degC]
-  real :: t2, t3      ! Temperature squared [degC2] and cubed [degC3]
-  real :: t4, t5      ! Temperature to the 4th power [degC4] and 5th power [degC5]
-  real :: s_local     ! A copy of the salinity at a point [PSU]
-  real :: s32         ! The square root of salinity cubed [PSU3/2]
-  real :: s2          ! Salinity squared [PSU2].
-  real :: p1, p2       ! Pressure (in bars) to the 1st and 2nd power [bar] and [bar2].
-  real :: rho0         ! Density at 1 bar pressure [kg m-3].
-  real :: ks           ! The secant bulk modulus [bar].
+  real :: t1   ! A copy of the temperature at a point [degC]
+  real :: s1   ! A copy of the salinity at a point [PSU]
+  real :: p1   ! Pressure converted to bars [bar]
+  real :: s12  ! The square root of salinity [PSU1/2]l553
+  real :: rho0 ! Density at 1 bar pressure [kg m-3]
+  real :: ks   ! The secant bulk modulus [bar]
   integer :: j
 
   do j=start,start+npts-1
-    if (S(j) < -1.0e-10) then !Can we assume safely that this is a missing value?
-      specvol(j) = 0.001
-      if (present(spv_ref)) specvol(j) = 0.001 - spv_ref
-      cycle
-    endif
 
-    p1 = pressure(j)*1.0e-5 ; p2 = p1*p1
-    t_local = T(j) ; t2 = t_local*t_local ; t3 = t_local*t2 ; t4 = t2*t2 ; t5 = t3*t2
-    s_local = S(j) ; s2 = s_local*s_local ; s32 = s_local*sqrt(s_local)
+    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
+    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
 
-!  Compute rho(s,theta,p=0) - (same as rho(s,t_insitu,p=0) ).
+    ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
 
-    rho0 = R00 + R10*t_local + R20*t2 + R30*t3 + R40*t4 + R50*t5 + &
-           s_local*(R01 + R11*t_local + R21*t2 + R31*t3 + R41*t4) + &
-           s32*(R032 + R132*t_local + R232*t2) + R02*s2
+    rho0 = R00 + ( t1*(R10 + t1*(R20 + t1*(R30 + t1*(R40 + R50*t1)))) + &
+                   s1*((R01 + t1*(R11 + t1*(R21 + t1*(R31 + R41*t1)))) + &
+                       (s12*(R032 + t1*(R132 + R232*t1)) + R02*s1)) )
 
-!  Compute rho(s,theta,p), first calculating the secant bulk modulus.
+    ! Compute rho(s,theta,p), first calculating the secant bulk modulus.
 
-    ks = S00 + S10*t_local + S20*t2 + S30*t3 + S40*t4 + s_local*(S01 + S11*t_local + S21*t2 + S31*t3) + &
-         s32*(S032 + S132*t_local + S232*t2) + &
-         p1*(Sp00 + Sp10*t_local + Sp20*t2 + Sp30*t3 + &
-             s_local*(Sp01 + Sp11*t_local + Sp21*t2) + Sp032*s32) + &
-         p2*(SP000 + SP010*t_local + SP020*t2 + s_local*(SP001 + SP011*t_local + SP021*t2))
+    ks = (S00 + ( t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
+                  s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1))) )) + &
+         p1*( (Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
+                         s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )) + &
+              p1*(Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )) )
 
     if (present(spv_ref)) then
       specvol(j) = (ks*(1.0 - (rho0*spv_ref)) - p1) / (rho0*ks)
@@ -257,73 +236,63 @@ subroutine calculate_spec_vol_array_UNESCO(T, S, pressure, specvol, start, npts,
 end subroutine calculate_spec_vol_array_UNESCO
 
 
-!> This subroutine calculates the partial derivatives of density
-!! with potential temperature and salinity.
+!> Calculate the partial derivatives of density with potential temperature and salinity
+!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
 subroutine calculate_density_derivs_UNESCO(T, S, pressure, drho_dT, drho_dS, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface
-                                                 !! [degC].
-  real,    intent(in),  dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa].
+  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface [degC]
+  real,    intent(in),  dimension(:) :: S        !< Salinity [PSU]
+  real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa]
   real,    intent(out), dimension(:) :: drho_dT  !< The partial derivative of density with potential
-                                                 !! temperature [kg m-3 degC-1].
+                                                 !! temperature [kg m-3 degC-1]
   real,    intent(out), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
-                                                 !! in [kg m-3 PSU-1].
-  integer, intent(in)                :: start    !< The starting point in the arrays.
-  integer, intent(in)                :: npts     !< The number of values to calculate.
+                                                 !! in [kg m-3 PSU-1]
+  integer, intent(in)                :: start    !< The starting index for calculations
+  integer, intent(in)                :: npts     !< The number of values to calculate
 
   ! Local variables
-  real :: t_local     ! A copy of the temperature at a point [degC]
-  real :: t2, t3      ! Temperature squared [degC2] and cubed [degC3]
-  real :: t4, t5      ! Temperature to the 4th power [degC4] and 5th power [degC5]
-  real :: s12         ! The square root of salinity [PSU1/2]
-  real :: s_local     ! A copy of the salinity at a point [PSU]
-  real :: s32         ! The square root of salinity cubed [PSU3/2]
-  real :: s2          ! Salinity squared [PSU2].
-  real :: p1, p2          ! Pressure to the 1st & 2nd power [bar] and [bar2].
-  real :: rho0            ! Density at 1 bar pressure [kg m-3].
-  real :: ks              ! The secant bulk modulus [bar].
-  real :: drho0_dT        ! Derivative of rho0 with T [kg m-3 degC-1].
-  real :: drho0_dS        ! Derivative of rho0 with S [kg m-3 PSU-1].
-  real :: dks_dT          ! Derivative of ks with T [bar degC-1].
-  real :: dks_dS          ! Derivative of ks with S [bar psu-1].
-  real :: denom           ! 1.0 / (ks - p1) [bar-1].
+  real :: t1       ! A copy of the temperature at a point [degC]
+  real :: s1       ! A copy of the salinity at a point [PSU]
+  real :: p1       ! Pressure converted to bars [bar]
+  real :: s12      ! The square root of salinity [PSU1/2]
+  real :: rho0     ! Density at 1 bar pressure [kg m-3]
+  real :: ks       ! The secant bulk modulus [bar]
+  real :: drho0_dT ! Derivative of rho0 with T [kg m-3 degC-1]
+  real :: drho0_dS ! Derivative of rho0 with S [kg m-3 PSU-1]
+  real :: dks_dT   ! Derivative of ks with T [bar degC-1]
+  real :: dks_dS   ! Derivative of ks with S [bar psu-1]
+  real :: denom    ! 1.0 / (ks - p1) [bar-1]
   integer :: j
 
   do j=start,start+npts-1
-    if (S(j) < -1.0e-10) then !Can we assume safely that this is a missing value?
-      drho_dT(j) = 0.0 ; drho_dS(j) = 0.0
-      cycle
-    endif
 
-    p1 = pressure(j)*1.0e-5 ; p2 = p1*p1
-    t_local = T(j) ; t2 = t_local*t_local ; t3 = t_local*t2 ; t4 = t2*t2 ; t5 = t3*t2
-    s_local = S(j) ; s2 = s_local*s_local ; s12 = sqrt(s_local) ; s32 = s_local*s12
+    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
+    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
 
-!       compute rho(s,theta,p=0) - (same as rho(s,t_insitu,p=0) )
+    ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
 
-    rho0 = R00 + R10*t_local + R20*t2 + R30*t3 + R40*t4 + R50*t5 + &
-           s_local*(R01 + R11*t_local + R21*t2 + R31*t3 + R41*t4) + &
-           s32*(R032 + R132*t_local + R232*t2) + R02*s2
-    drho0_dT = R10 + 2.0*R20*t_local + 3.0*R30*t2 + 4.0*R40*t3 + 5.0*R50*t4 + &
-               s_local*(R11 + 2.0*R21*t_local + 3.0*R31*t2 + 4.0*R41*t3) + &
-               s32*(R132 + 2.0*R232*t_local)
-    drho0_dS = (R01 + R11*t_local + R21*t2 + R31*t3 + R41*t4) + &
-               1.5*s12*(R032 + R132*t_local + R232*t2) + 2.0*R02*s_local
+    rho0 = R00 + ( t1*(R10 + t1*(R20 + t1*(R30 + t1*(R40 + R50*t1)))) + &
+                   s1*((R01 + t1*(R11 + t1*(R21 + t1*(R31 + R41*t1)))) + &
+                       (s12*(R032 + t1*(R132 + R232*t1)) + R02*s1)) )
+    drho0_dT = R10 + ( t1*(2.0*R20 + t1*(3.0*R30 + t1*(4.0*R40 + 5.0*R50*t1))) + &
+                       s1*(R11 + (t1*(2.0*R21 + t1*(3.0*R31 + 4.0*R41*t1)) + &
+                                  s12*(R132 + 2.0*R232*t1))) )
+    drho0_dS = R01 + ( t1*(R11 + t1*(R21 + t1*(R31 + R41*t1))) + &
+                       (1.5*s12*(R032 + t1*(R132 + R232*t1)) + 2.0*R02*s1) )
 
-!       compute rho(s,theta,p)
+    ! Compute rho(s,theta,p), first calculating the secant bulk modulus.
 
-    ks = S00 + S10*t_local + S20*t2 + S30*t3 + S40*t4 + s_local*(S01 + S11*t_local + S21*t2 + S31*t3) + &
-         s32*(S032 + S132*t_local + S232*t2) + &
-         p1*(Sp00 + Sp10*t_local + Sp20*t2 + Sp30*t3 + &
-             s_local*(Sp01 + Sp11*t_local + Sp21*t2) + Sp032*s32) + &
-         p2*(SP000 + SP010*t_local + SP020*t2 + s_local*(SP001 + SP011*t_local + SP021*t2))
-    dks_dT = S10 + 2.0*S20*t_local + 3.0*S30*t2 + 4.0*S40*t3 + &
-             s_local*(S11 + 2.0*S21*t_local + 3.0*S31*t2) + s32*(S132 + 2.0*S232*t_local) + &
-             p1*(Sp10 + 2.0*Sp20*t_local + 3.0*Sp30*t2 + s_local*(Sp11 + 2.0*Sp21*t_local)) + &
-             p2*(SP010 + 2.0*SP020*t_local + s_local*(SP011 + 2.0*SP021*t_local))
-    dks_dS = (S01 + S11*t_local + S21*t2 + S31*t3) + 1.5*s12*(S032 + S132*t_local + S232*t2) + &
-             p1*(Sp01 + Sp11*t_local + Sp21*t2 + 1.5*Sp032*s12) + &
-             p2*(SP001 + SP011*t_local + SP021*t2)
+    ks = ( S00 + (t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
+                  s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1)))) ) + &
+         p1*( (Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
+                         s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )) + &
+              p1*(Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )) )
+    dks_dT = ( S10 + (t1*(2.0*S20 + t1*(3.0*S30 + t1*4.0*S40)) + &
+                      s1*((S11 + t1*(2.0*S21 + 3.0*S31*t1)) + s12*(S132 + 2.0*S232*t1))) ) + &
+             p1*((Sp110 + t1*(2.0*Sp120 + 3.0*Sp130*t1) + s1*(Sp111 + 2.0*Sp121*t1)) + &
+                 p1*(Sp210 + 2.0*Sp220*t1 + s1*(Sp211 + 2.0*Sp221*t1)))
+    dks_dS = ( S01 + (t1*(S11 + t1*(S21 + S31*t1)) + 1.5*s12*(S032 + t1*(S132 + S232*t1))) ) + &
+             p1*((Sp101 + t1*(Sp111 + Sp121*t1) + 1.5*Sp1032*s12) + &
+                 p1*(Sp201 + t1*(Sp211 + Sp221*t1)))
 
     denom = 1.0 / (ks - p1)
     drho_dT(j) = denom*(ks*drho0_dT - rho0*p1*denom*dks_dT)
@@ -332,65 +301,57 @@ subroutine calculate_density_derivs_UNESCO(T, S, pressure, drho_dT, drho_dS, sta
 
 end subroutine calculate_density_derivs_UNESCO
 
-!> This subroutine computes the in situ density of sea water (rho)
-!! and the compressibility (drho/dp == C_sound^-2) at the given
-!! salinity, potential temperature, and pressure.
+!> Compute the in situ density of sea water (rho) and the compressibility (drho/dp == C_sound^-2)
+!! at the given salinity, potential temperature and pressure using the UNESCO (1981)
+!! equation of state, as refit by Jackett and McDougall (1995).
 subroutine calculate_compress_UNESCO(T, S, pressure, rho, drho_dp, start, npts)
   real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface
-                                                 !! [degC].
-  real,    intent(in),  dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa].
-  real,    intent(out), dimension(:) :: rho      !< In situ density [kg m-3].
+                                                 !! [degC]
+  real,    intent(in),  dimension(:) :: S        !< Salinity [PSU]
+  real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa]
+  real,    intent(out), dimension(:) :: rho      !< In situ density [kg m-3]
   real,    intent(out), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
                                                  !! (also the inverse of the square of sound speed)
-                                                 !! [s2 m-2].
-  integer, intent(in)                :: start    !< The starting point in the arrays.
-  integer, intent(in)                :: npts     !< The number of values to calculate.
+                                                 !! [s2 m-2]
+  integer, intent(in)                :: start    !< The starting index for calculations
+  integer, intent(in)                :: npts     !< The number of values to calculate
 
   ! Local variables
-  real :: t_local     ! A copy of the temperature at a point [degC]
-  real :: t2, t3      ! Temperature squared [degC2] and cubed [degC3]
-  real :: t4, t5      ! Temperature to the 4th power [degC4] and 5th power [degC5]
-  real :: s_local     ! A copy of the salinity at a point [PSU]
-  real :: s32         ! The square root of salinity cubed [PSU3/2]
-  real :: s2          ! Salinity squared [PSU2].
-  real :: p1, p2  ! Pressure to the 1st & 2nd power [bar] and [bar2].
-  real :: rho0    ! Density at 1 bar pressure [kg m-3].
-  real :: ks      ! The secant bulk modulus [bar].
-  real :: ks_0    ! The secant bulk modulus at zero pressure [bar].
+  real :: t1      ! A copy of the temperature at a point [degC]
+  real :: s1      ! A copy of the salinity at a point [PSU]
+  real :: p1      ! Pressure converted to bars [bar]
+  real :: s12     ! The square root of salinity [PSU1/2]
+  real :: rho0    ! Density at 1 bar pressure [kg m-3]
+  real :: ks      ! The secant bulk modulus [bar]
+  real :: ks_0    ! The secant bulk modulus at zero pressure [bar]
   real :: ks_1    ! The linear pressure dependence of the secant bulk modulus at zero pressure [nondim]
   real :: ks_2    ! The quadratic pressure dependence of the secant bulk modulus at zero pressure [bar-1]
   real :: dks_dp  ! The derivative of the secant bulk modulus with pressure [nondim]
   integer :: j
 
   do j=start,start+npts-1
-    if (S(j) < -1.0e-10) then !Can we assume safely that this is a missing value?
-      rho(j) = 1000.0 ; drho_dP(j) = 0.0
-      cycle
-    endif
+    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
+    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
 
-    p1 = pressure(j)*1.0e-5 ; p2 = p1*p1
-    t_local = T(j) ; t2 = t_local*t_local ; t3 = t_local*t2 ; t4 = t2*t2 ; t5 = t3*t2
-    s_local = S(j) ; s2 = s_local*s_local ; s32 = s_local*sqrt(s_local)
+    ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
 
-!  Compute rho(s,theta,p=0) - (same as rho(s,t_insitu,p=0) ).
+    rho0 = R00 + ( t1*(R10 + t1*(R20 + t1*(R30 + t1*(R40 + R50*t1)))) + &
+                   s1*((R01 + t1*(R11 + t1*(R21 + t1*(R31 + R41*t1)))) + &
+                       (s12*(R032 + t1*(R132 + R232*t1)) + R02*s1)) )
 
-    rho0 = R00 + R10*t_local + R20*t2 + R30*t3 + R40*t4 + R50*t5 + &
-           s_local*(R01 + R11*t_local + R21*t2 + R31*t3 + R41*t4) + &
-           s32*(R032 + R132*t_local + R232*t2) + R02*s2
+    ! Calculate the secant bulk modulus and its derivative with pressure.
+    ks_0 = S00 + ( t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
+                   s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1))) )
+    ks_1 = Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
+                     s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )
+    ks_2 = Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )
 
-!  Compute rho(s,theta,p), first calculating the secant bulk modulus.
-    ks_0 = S00 + S10*t_local + S20*t2 + S30*t3 + S40*t4 + &
-           s_local*(S01 + S11*t_local + S21*t2 + S31*t3) + s32*(S032 + S132*t_local + S232*t2)
-    ks_1 = Sp00 + Sp10*t_local + Sp20*t2 + Sp30*t3 + &
-           s_local*(Sp01 + Sp11*t_local + Sp21*t2) + Sp032*s32
-    ks_2 = SP000 + SP010*t_local + SP020*t2 + s_local*(SP001 + SP011*t_local + SP021*t2)
-
-    ks = ks_0 + p1*ks_1 + p2*ks_2
+    ks = ks_0 + p1*(ks_1 + p1*ks_2)
     dks_dp = ks_1 + 2.0*p1*ks_2
 
+    ! Compute the in situ density, rho(s,theta,p), and its derivative with pressure.
     rho(j) = rho0*ks / (ks - p1)
-! The factor of 1.0e-5 is because pressure here is in bars, not Pa.
+    ! The factor of 1.0e-5 is because pressure here is in bars, not Pa.
     drho_dp(j) = 1.0e-5 * (rho(j) / (ks - p1)) * (1.0 - dks_dp*p1/ks)
   enddo
 end subroutine calculate_compress_UNESCO
@@ -463,36 +424,36 @@ subroutine calculate_density_second_derivs_array_UNESCO(T, S, P, drho_ds_ds, drh
     drho0_dS = R01 + ( t1*(R11 + t1*(R21 + t1*(R31 + R41*t1))) + &
                        (1.5*s12*(R032 + t1*(R132 + R232*t1)) + 2.0*R02*s1) )
     d2rho0_dS2 = 0.75*(R032 + t1*(R132 + R232*t1))*I_s12 + 2.0*R02
-    d2rho0_dSdT = R11 + ( t1*(2.*R21 + t1*(3.*R31 + 4.*R41*t1)) + 1.5*s12*(R132 + 2.*R232*t1) )
+    d2rho0_dSdT = R11 + ( t1*(2.0*R21 + t1*(3.0*R31 + 4.0*R41*t1)) + 1.5*s12*(R132 + 2.0*R232*t1) )
     d2rho0_dT2 = 2.0*R20 + ( t1*(6.0*R30 + t1*(12.0*R40 + 20.0*R50*t1)) + &
                              s1*((2.0*R21 + t1*(6.0*R31 + 12.0*R41*t1)) + 2.0*R232*s12) )
 
     !  Calculate the secant bulk modulus and its derivatives
     ks_0 = S00 + ( t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
                    s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1))) )
-    ks_1 = Sp00 + ( t1*(Sp10 + t1*(Sp20 + Sp30*t1)) + &
-                    s1*((Sp01 + t1*(Sp11 + Sp21*t1)) + Sp032*s12) )
-    ks_2 = SP000 + ( t1*(SP010 + SP020*t1) + s1*(SP001 + t1*(SP011 + SP021*t1)) )
+    ks_1 = Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
+                     s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )
+    ks_2 = Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )
 
     ks = ks_0 + p1*(ks_1 + p1*ks_2)
     dks_dp = ks_1 + 2.0*p1*ks_2
     dks_dT = (S10 + ( t1*(2.0*S20 + t1*(3.0*S30 + t1*4.0*S40)) + &
                       s1*((S11 + t1*(2.0*S21 + 3.0*S31*t1)) + s12*(S132 + 2.0*S232*t1)) )) + &
-             p1*((Sp10 + t1*(2.0*Sp20 + 3.0*Sp30*t1) + s1*(Sp11 + 2.0*Sp21*t1)) + &
-                 p1*(SP010 + 2.0*SP020*t1 + s1*(SP011 + 2.0*SP021*t1)))
+             p1*((Sp110 + t1*(2.0*Sp120 + 3.0*Sp130*t1) + s1*(Sp111 + 2.0*Sp121*t1)) + &
+                 p1*(Sp210 + 2.0*Sp220*t1 + s1*(Sp211 + 2.0*Sp221*t1)))
     dks_dS = (S01 + ( t1*(S11 + t1*(S21 + S31*t1)) + 1.5*s12*(S032 + t1*(S132 + S232*t1)) )) + &
-             p1*((Sp01 + t1*(Sp11 + Sp21*t1) + 1.5*Sp032*s12) + &
-                 p1*(SP001 + t1*(SP011 + SP021*t1)))
-    d2ks_dS2 = 0.75*((S032 + t1*(S132 + S232*t1)) + p1*Sp032)*I_s12
-    d2ks_dSdT = (S11 + ( t1*(2.*S21 + 3.*S31*t1) + 1.5*s12*(S132 + 2.*S232*t1) )) + &
-                p1*((Sp11 + 2.*Sp21*t1) +  p1*(SP011 + 2.0*SP021*t1))
+             p1*((Sp101 + t1*(Sp111 + Sp121*t1) + 1.5*Sp1032*s12) + &
+                 p1*(Sp201 + t1*(Sp211 + Sp221*t1)))
+    d2ks_dS2 = 0.75*((S032 + t1*(S132 + S232*t1)) + p1*Sp1032)*I_s12
+    d2ks_dSdT = (S11 + ( t1*(2.0*S21 + 3.0*S31*t1) + 1.5*s12*(S132 + 2.0*S232*t1) )) + &
+                p1*((Sp111 + 2.0*Sp121*t1) +  p1*(Sp211 + 2.0*Sp221*t1))
     d2ks_dT2 = 2.0*(S20 + ( t1*(3.0*S30 + 6.0*S40*t1) + s1*((S21 + 3.0*S31*t1) + S232*s12) )) + &
-               2.0*p1*((Sp20 + (3.0*Sp30*t1 + Sp21*s1)) + p1*(SP020 + SP021*s1))
+               2.0*p1*((Sp120 + (3.0*Sp130*t1 + Sp121*s1)) + p1*(Sp220 + Sp221*s1))
 
-    d2ks_dSdp = (Sp01 + (t1*(Sp11 + Sp21*t1) + 1.5*Sp032*s12)) + &
-                2.*p1*(SP001 + t1*(SP011 + SP021*t1))
-    d2ks_dTdp = (Sp10 + (t1*(2.0*Sp20 + 3.0*Sp30*t1) + s1*(Sp11 + 2.0*Sp21*t1))) + &
-                2.*p1*(SP010 + 2.0*SP020*t1 + s1*(SP011 + 2.0*SP021*t1))
+    d2ks_dSdp = (Sp101 + (t1*(Sp111 + Sp121*t1) + 1.5*Sp1032*s12)) + &
+                2.0*p1*(Sp201 + t1*(Sp211 + Sp221*t1))
+    d2ks_dTdp = (Sp110 + (t1*(2.0*Sp120 + 3.0*Sp130*t1) + s1*(Sp111 + 2.0*Sp121*t1))) + &
+                2.0*p1*(Sp210 + 2.0*Sp220*t1 + s1*(Sp211 + 2.0*Sp221*t1))
     I_denom = 1.0 / (ks - p1)
 
     ! Expressions for density and its first derivatives are copied here for reference:
@@ -521,13 +482,14 @@ subroutine calculate_density_second_derivs_array_UNESCO(T, S, P, drho_ds_ds, drh
 
 end subroutine calculate_density_second_derivs_array_UNESCO
 
-!> Second derivatives of density with respect to temperature, salinity and pressure for scalar inputs.
+!> Second derivatives of density with respect to temperature, salinity and pressure for scalar inputs
+!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
 !! Inputs are promoted to 1-element arrays and outputs are demoted to scalars.
 subroutine calculate_density_second_derivs_scalar_UNESCO(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                          drho_ds_dp, drho_dt_dp)
   real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
   real, intent(in   ) :: S          !< Salinity [PSU]
-  real, intent(in   ) :: P          !< pressure [Pa]
+  real, intent(in   ) :: P          !< Pressure [Pa]
   real, intent(  out) :: drho_ds_ds !< Partial derivative of beta with respect
                                     !! to S [kg m-3 PSU-2]
   real, intent(  out) :: drho_ds_dt !< Partial derivative of beta with respect
@@ -567,13 +529,13 @@ end subroutine calculate_density_second_derivs_scalar_UNESCO
 !!
 !! \section section_EOS_UNESCO UNESCO (Jackett & McDougall) equation of state
 !!
-!! The UNESCO (1981) equation of state is an interationally defined standard fit valid over the
-!! range of pressures up to 10000 dbar, tempertures between the freezing point and 40 degC, and
+!! The UNESCO (1981) equation of state is an internationally defined standard fit valid over the
+!! range of pressures up to 10000 dbar, temperatures between the freezing point and 40 degC, and
 !! salinities between 0 and 42 PSU.  Unfortunately, these expressions used in situ temperatures,
 !! whereas ocean models (including MOM6) effectively use potential temperatures as their state
 !! variables.  To avoid needing multiple conversions, Jackett and McDougall (1995) refit the
 !! UNESCO equation of state to take potential temperature as a state variable, over the same
-!! valid range and funtional form as the original UNESCO expressions.  It is this refit from
+!! valid range and functional form as the original UNESCO expressions.  It is this refit from
 !! Jackett and McDougall (1995) that is coded up in this module.
 !!
 !! The functional form of the equation of state includes terms proportional to salinity to the
@@ -583,13 +545,17 @@ end subroutine calculate_density_second_derivs_scalar_UNESCO
 !! was chosen to imply a contribution that is smaller than numerical roundoff in the expression
 !! for density, which is the field for which the UNESCO equation of state was originally derived.
 !!
-!! Originally coded in 1999 by J. Stephens.
+!! Originally coded in 1999 by J. Stephens, revised in 2023 to unambiguously specify the order
+!! of arithmetic with parenthesis in every real sum of three or more terms.
 !!
 !! \subsection section_EOS_UNESCO_references References
 !!
-!! Jackett, D. and T. McDougall, 1995: J. Atmos. Ocean. Tech., 12, 381-389.
+!! Gill, A. E., 1982: Atmosphere-Ocean Dynamics. Academic Press, 662 pp.
+!!
+!! Jackett, D. and T. McDougall, 1995: Minimal adjustment of hydrographic profiles to
+!!     achieve static stability.  J. Atmos. Ocean. Tech., 12, 381-389.
 !!
 !! UNESCO, 1981: Tenth report of the joint panel on oceanographic tables and standards.
-!!    UNESCO Technical Palers in Maricen Sci. No. 36, UNESCO, Paris.
+!!    UNESCO Technical Papers in Marine Sci. No. 36, UNESCO, Paris.
 
 end module MOM_EOS_UNESCO

--- a/src/equation_of_state/MOM_EOS_UNESCO.F90
+++ b/src/equation_of_state/MOM_EOS_UNESCO.F90
@@ -6,7 +6,7 @@ module MOM_EOS_UNESCO
 implicit none ; private
 
 public calculate_compress_UNESCO, calculate_density_UNESCO, calculate_spec_vol_UNESCO
-public calculate_density_derivs_UNESCO
+public calculate_density_derivs_UNESCO, calculate_specvol_derivs_UNESCO
 public calculate_density_scalar_UNESCO, calculate_density_array_UNESCO
 public calculate_density_second_derivs_UNESCO
 
@@ -32,57 +32,56 @@ end interface calculate_density_second_derivs_UNESCO
 
 
 !>@{ Parameters in the UNESCO equation of state, as published in appendix A3 of Gill, 1982.
-! The following constants are used to calculate rho0, the density of seawater at 1
-! atmosphere pressure.  The notation is Rab for the contribution to rho0 from T^a*S^b.
+! The following constants are used to calculate rho0, the density of seawater at 1 atmosphere pressure.
+! The notation is Rab for the contribution to rho0 from S^a*T^b, with 6 used for the 1.5 power.
 real, parameter :: R00 = 999.842594   ! A coefficient in the fit for rho0 [kg m-3]
-real, parameter :: R10 = 6.793952e-2  ! A coefficient in the fit for rho0 [kg m-3 degC-1]
-real, parameter :: R20 = -9.095290e-3 ! A coefficient in the fit for rho0 [kg m-3 degC-2]
-real, parameter :: R30 = 1.001685e-4  ! A coefficient in the fit for rho0 [kg m-3 degC-3]
-real, parameter :: R40 = -1.120083e-6 ! A coefficient in the fit for rho0 [kg m-3 degC-4]
-real, parameter :: R50 = 6.536332e-9  ! A coefficient in the fit for rho0 [kg m-3 degC-5]
-real, parameter :: R01 = 0.824493     ! A coefficient in the fit for rho0 [kg m-3 PSU-1]
+real, parameter :: R01 = 6.793952e-2  ! A coefficient in the fit for rho0 [kg m-3 degC-1]
+real, parameter :: R02 = -9.095290e-3 ! A coefficient in the fit for rho0 [kg m-3 degC-2]
+real, parameter :: R03 = 1.001685e-4  ! A coefficient in the fit for rho0 [kg m-3 degC-3]
+real, parameter :: R04 = -1.120083e-6 ! A coefficient in the fit for rho0 [kg m-3 degC-4]
+real, parameter :: R05 = 6.536332e-9  ! A coefficient in the fit for rho0 [kg m-3 degC-5]
+real, parameter :: R10 = 0.824493     ! A coefficient in the fit for rho0 [kg m-3 PSU-1]
 real, parameter :: R11 = -4.0899e-3   ! A coefficient in the fit for rho0 [kg m-3 degC-1 PSU-1]
-real, parameter :: R21 = 7.6438e-5    ! A coefficient in the fit for rho0 [kg m-3 degC-2 PSU-1]
-real, parameter :: R31 = -8.2467e-7   ! A coefficient in the fit for rho0 [kg m-3 degC-3 PSU-1]
-real, parameter :: R41 = 5.3875e-9    ! A coefficient in the fit for rho0 [kg m-3 degC-4 PSU-1]
-real, parameter :: R032 = -5.72466e-3 ! A coefficient in the fit for rho0 [kg m-3 PSU-3/2]
-real, parameter :: R132 = 1.0227e-4   ! A coefficient in the fit for rho0 [kg m-3 degC-1 PSU-3/2]
-real, parameter :: R232 = -1.6546e-6  ! A coefficient in the fit for rho0 [kg m-3 degC-2 PSU-3/2]
-real, parameter :: R02 = 4.8314e-4    ! A coefficient in the fit for rho0 [kg m-3 PSU-2]
+real, parameter :: R12 = 7.6438e-5    ! A coefficient in the fit for rho0 [kg m-3 degC-2 PSU-1]
+real, parameter :: R13 = -8.2467e-7   ! A coefficient in the fit for rho0 [kg m-3 degC-3 PSU-1]
+real, parameter :: R14 = 5.3875e-9    ! A coefficient in the fit for rho0 [kg m-3 degC-4 PSU-1]
+real, parameter :: R60 = -5.72466e-3  ! A coefficient in the fit for rho0 [kg m-3 PSU-1.5]
+real, parameter :: R61 = 1.0227e-4    ! A coefficient in the fit for rho0 [kg m-3 degC-1 PSU-1.5]
+real, parameter :: R62 = -1.6546e-6   ! A coefficient in the fit for rho0 [kg m-3 degC-2 PSU-1.5]
+real, parameter :: R20 = 4.8314e-4    ! A coefficient in the fit for rho0 [kg m-3 PSU-2]
 
 ! The following constants are used to calculate the secant bulk modulus.
-! The notation here is Sab for terms proportional to T^a*S^b,
-! SpABC for terms proportional to p^A*T^B*S^C.
+! The notation here is Sabc for terms proportional to S^a*T^b*P^c, with 6 used for the 1.5 power.
 !   Note that these values differ from those in Appendix 3 of Gill (1982) because the expressions
 ! from Jackett and MacDougall (1995) use potential temperature, rather than in situ temperature.
-real, parameter :: S00 = 1.965933e4   ! A coefficient in the secant bulk modulus fit [bar]
-real, parameter :: S10 = 1.444304e2   ! A coefficient in the secant bulk modulus fit [bar degC-1]
-real, parameter :: S20 = -1.706103    ! A coefficient in the secant bulk modulus fit [bar degC-2]
-real, parameter :: S30 = 9.648704e-3  ! A coefficient in the secant bulk modulus fit [bar degC-3]
-real, parameter :: S40 = -4.190253e-5 ! A coefficient in the secant bulk modulus fit [bar degC-4]
-real, parameter :: S01 = 52.84855     ! A coefficient in the secant bulk modulus fit [bar PSU-1]
-real, parameter :: S11 = -3.101089e-1 ! A coefficient in the secant bulk modulus fit [bar degC-1 PSU-1]
-real, parameter :: S21 = 6.283263e-3  ! A coefficient in the secant bulk modulus fit [bar degC-2 PSU-1]
-real, parameter :: S31 = -5.084188e-5 ! A coefficient in the secant bulk modulus fit [bar degC-3 PSU-1]
-real, parameter :: S032 = 3.886640e-1   ! A coefficient in the secant bulk modulus fit [bar PSU-3/2]
-real, parameter :: S132 = 9.085835e-3   ! A coefficient in the secant bulk modulus fit [bar degC-1 PSU-3/2]
-real, parameter :: S232 = -4.619924e-4  ! A coefficient in the secant bulk modulus fit [bar degC-2 PSU-3/2]
+real, parameter :: S000 = 1.965933e4   ! A coefficient in the secant bulk modulus fit [bar]
+real, parameter :: S010 = 1.444304e2   ! A coefficient in the secant bulk modulus fit [bar degC-1]
+real, parameter :: S020 = -1.706103    ! A coefficient in the secant bulk modulus fit [bar degC-2]
+real, parameter :: S030 = 9.648704e-3  ! A coefficient in the secant bulk modulus fit [bar degC-3]
+real, parameter :: S040 = -4.190253e-5 ! A coefficient in the secant bulk modulus fit [bar degC-4]
+real, parameter :: S100 = 52.84855     ! A coefficient in the secant bulk modulus fit [bar PSU-1]
+real, parameter :: S110 = -3.101089e-1 ! A coefficient in the secant bulk modulus fit [bar degC-1 PSU-1]
+real, parameter :: S120 = 6.283263e-3  ! A coefficient in the secant bulk modulus fit [bar degC-2 PSU-1]
+real, parameter :: S130 = -5.084188e-5 ! A coefficient in the secant bulk modulus fit [bar degC-3 PSU-1]
+real, parameter :: S600 = 3.886640e-1  ! A coefficient in the secant bulk modulus fit [bar PSU-1.5]
+real, parameter :: S610 = 9.085835e-3  ! A coefficient in the secant bulk modulus fit [bar degC-1 PSU-1.5]
+real, parameter :: S620 = -4.619924e-4 ! A coefficient in the secant bulk modulus fit [bar degC-2 PSU-1.5]
 
-real, parameter :: Sp100 = 3.186519      ! A coefficient in the secant bulk modulus fit [nondim]
-real, parameter :: Sp110 = 2.212276e-2   ! A coefficient in the secant bulk modulus fit [degC-1]
-real, parameter :: Sp120 = -2.984642e-4  ! A coefficient in the secant bulk modulus fit [degC-2]
-real, parameter :: Sp130 = 1.956415e-6   ! A coefficient in the secant bulk modulus fit [degC-3]
-real, parameter :: Sp101 = 6.704388e-3   ! A coefficient in the secant bulk modulus fit [PSU-1]
-real, parameter :: Sp111 = -1.847318e-4  ! A coefficient in the secant bulk modulus fit [degC-1 PSU-1]
-real, parameter :: Sp121 = 2.059331e-7   ! A coefficient in the secant bulk modulus fit [degC-2 PSU-1]
-real, parameter :: Sp1032 = 1.480266e-4  ! A coefficient in the secant bulk modulus fit [PSU-3/2]
+real, parameter :: S001 = 3.186519     ! A coefficient in the secant bulk modulus fit [nondim]
+real, parameter :: S011 = 2.212276e-2  ! A coefficient in the secant bulk modulus fit [degC-1]
+real, parameter :: S021 = -2.984642e-4 ! A coefficient in the secant bulk modulus fit [degC-2]
+real, parameter :: S031 = 1.956415e-6  ! A coefficient in the secant bulk modulus fit [degC-3]
+real, parameter :: S101 = 6.704388e-3  ! A coefficient in the secant bulk modulus fit [PSU-1]
+real, parameter :: S111 = -1.847318e-4 ! A coefficient in the secant bulk modulus fit [degC-1 PSU-1]
+real, parameter :: S121 = 2.059331e-7  ! A coefficient in the secant bulk modulus fit [degC-2 PSU-1]
+real, parameter :: S601 = 1.480266e-4  ! A coefficient in the secant bulk modulus fit [PSU-1.5]
 
-real, parameter :: Sp200 = 2.102898e-4  ! A coefficient in the secant bulk modulus fit [bar-1]
-real, parameter :: Sp210 = -1.202016e-5 ! A coefficient in the secant bulk modulus fit [bar-1 degC-1]
-real, parameter :: Sp220 = 1.394680e-7  ! A coefficient in the secant bulk modulus fit [bar-1 degC-2]
-real, parameter :: Sp201 = -2.040237e-6 ! A coefficient in the secant bulk modulus fit [bar-1 PSU-1]
-real, parameter :: Sp211 = 6.128773e-8  ! A coefficient in the secant bulk modulus fit [bar-1 degC-1 PSU-1]
-real, parameter :: Sp221 = 6.207323e-10 ! A coefficient in the secant bulk modulus fit [bar-1 degC-1 PSU-2]
+real, parameter :: S002 = 2.102898e-4  ! A coefficient in the secant bulk modulus fit [bar-1]
+real, parameter :: S012 = -1.202016e-5 ! A coefficient in the secant bulk modulus fit [bar-1 degC-1]
+real, parameter :: S022 = 1.394680e-7  ! A coefficient in the secant bulk modulus fit [bar-1 degC-2]
+real, parameter :: S102 = -2.040237e-6 ! A coefficient in the secant bulk modulus fit [bar-1 PSU-1]
+real, parameter :: S112 = 6.128773e-8  ! A coefficient in the secant bulk modulus fit [bar-1 degC-1 PSU-1]
+real, parameter :: S122 = 6.207323e-10 ! A coefficient in the secant bulk modulus fit [bar-1 degC-2 PSU-1]
 !>@}
 
 contains
@@ -142,18 +141,18 @@ subroutine calculate_density_array_UNESCO(T, S, pressure, rho, start, npts, rho_
 
 !  Compute rho(s,theta,p=0) - (same as rho(s,t_insitu,p=0) ).
 
-    sig0 = ( t1*(R10 + t1*(R20 + t1*(R30 + t1*(R40 + R50*t1)))) + &
-             s1*((R01 + t1*(R11 + t1*(R21 + t1*(R31 + R41*t1)))) + &
-                 (s12*(R032 + t1*(R132 + R232*t1)) + R02*s1)) )
+    sig0 = ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+             s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                 (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
     rho0 = R00 + sig0
 
 !  Compute rho(s,theta,p), first calculating the secant bulk modulus.
 
-    ks = (S00 + ( t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
-                  s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1))) )) + &
-         p1*( (Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
-                         s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )) + &
-              p1*(Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )) )
+    ks = (S000 + ( t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                   s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )) + &
+         p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                        s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+              p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
 
     if (present(rho_ref)) then
       rho(j) = ((R00 - rho_ref)*ks + (sig0*ks + p1*rho_ref)) / (ks - p1)
@@ -215,17 +214,17 @@ subroutine calculate_spec_vol_array_UNESCO(T, S, pressure, specvol, start, npts,
 
     ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
 
-    rho0 = R00 + ( t1*(R10 + t1*(R20 + t1*(R30 + t1*(R40 + R50*t1)))) + &
-                   s1*((R01 + t1*(R11 + t1*(R21 + t1*(R31 + R41*t1)))) + &
-                       (s12*(R032 + t1*(R132 + R232*t1)) + R02*s1)) )
+    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
 
     ! Compute rho(s,theta,p), first calculating the secant bulk modulus.
 
-    ks = (S00 + ( t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
-                  s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1))) )) + &
-         p1*( (Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
-                         s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )) + &
-              p1*(Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )) )
+    ks = (S000 + ( t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                   s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )) + &
+         p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                        s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+              p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
 
     if (present(spv_ref)) then
       specvol(j) = (ks*(1.0 - (rho0*spv_ref)) - p1) / (rho0*ks)
@@ -260,46 +259,106 @@ subroutine calculate_density_derivs_UNESCO(T, S, pressure, drho_dT, drho_dS, sta
   real :: drho0_dS ! Derivative of rho0 with S [kg m-3 PSU-1]
   real :: dks_dT   ! Derivative of ks with T [bar degC-1]
   real :: dks_dS   ! Derivative of ks with S [bar psu-1]
-  real :: denom    ! 1.0 / (ks - p1) [bar-1]
+  real :: I_denom  ! 1.0 / (ks - p1) [bar-1]
   integer :: j
 
   do j=start,start+npts-1
-
     p1 = pressure(j)*1.0e-5 ; t1 = T(j)
     s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
 
-    ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
+    ! Compute rho(s,theta,p=0) and its derivatives with temperature and salinity
+    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+    drho0_dT = R01 + ( t1*(2.0*R02 + t1*(3.0*R03 + t1*(4.0*R04 + t1*(5.0*R05)))) + &
+                       s1*(R11 + (t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + &
+                                  s12*(R61 + t1*(2.0*R62)) )) )
+    drho0_dS = R10 + ( t1*(R11 + t1*(R12 + t1*(R13 + t1*R14))) + &
+                       (1.5*(s12*(R60 + t1*(R61 + t1*R62))) + s1*(2.0*R20)) )
 
-    rho0 = R00 + ( t1*(R10 + t1*(R20 + t1*(R30 + t1*(R40 + R50*t1)))) + &
-                   s1*((R01 + t1*(R11 + t1*(R21 + t1*(R31 + R41*t1)))) + &
-                       (s12*(R032 + t1*(R132 + R232*t1)) + R02*s1)) )
-    drho0_dT = R10 + ( t1*(2.0*R20 + t1*(3.0*R30 + t1*(4.0*R40 + 5.0*R50*t1))) + &
-                       s1*(R11 + (t1*(2.0*R21 + t1*(3.0*R31 + 4.0*R41*t1)) + &
-                                  s12*(R132 + 2.0*R232*t1))) )
-    drho0_dS = R01 + ( t1*(R11 + t1*(R21 + t1*(R31 + R41*t1))) + &
-                       (1.5*s12*(R032 + t1*(R132 + R232*t1)) + 2.0*R02*s1) )
+    ! Compute the secant bulk modulus and its derivatives with temperature and salinity
+    ks = ( S000 + (t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                   s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620)))) ) + &
+         p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                        s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+              p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
+    dks_dT = ( S010 + (t1*(2.0*S020 + t1*(3.0*S030 + t1*(4.0*S040))) + &
+                       s1*((S110 + t1*(2.0*S120 + t1*(3.0*S130))) + s12*(S610 + t1*(2.0*S620)))) ) + &
+             p1*(((S011 + t1*(2.0*S021 + t1*(3.0*S031))) + s1*(S111 + t1*(2.0*S121)) ) + &
+                 p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122))) )
+    dks_dS = ( S100 + (t1*(S110 + t1*(S120 + t1*S130)) + 1.5*(s12*(S600 + t1*(S610 + t1*S620)))) ) + &
+             p1*((S101 + t1*(S111 + t1*S121) + s12*(1.5*S601)) + &
+                 p1*(S102 + t1*(S112 + t1*S122)) )
 
-    ! Compute rho(s,theta,p), first calculating the secant bulk modulus.
-
-    ks = ( S00 + (t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
-                  s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1)))) ) + &
-         p1*( (Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
-                         s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )) + &
-              p1*(Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )) )
-    dks_dT = ( S10 + (t1*(2.0*S20 + t1*(3.0*S30 + t1*4.0*S40)) + &
-                      s1*((S11 + t1*(2.0*S21 + 3.0*S31*t1)) + s12*(S132 + 2.0*S232*t1))) ) + &
-             p1*((Sp110 + t1*(2.0*Sp120 + 3.0*Sp130*t1) + s1*(Sp111 + 2.0*Sp121*t1)) + &
-                 p1*(Sp210 + 2.0*Sp220*t1 + s1*(Sp211 + 2.0*Sp221*t1)))
-    dks_dS = ( S01 + (t1*(S11 + t1*(S21 + S31*t1)) + 1.5*s12*(S032 + t1*(S132 + S232*t1))) ) + &
-             p1*((Sp101 + t1*(Sp111 + Sp121*t1) + 1.5*Sp1032*s12) + &
-                 p1*(Sp201 + t1*(Sp211 + Sp221*t1)))
-
-    denom = 1.0 / (ks - p1)
-    drho_dT(j) = denom*(ks*drho0_dT - rho0*p1*denom*dks_dT)
-    drho_dS(j) = denom*(ks*drho0_dS - rho0*p1*denom*dks_dS)
+    I_denom = 1.0 / (ks - p1)
+    drho_dT(j) = (ks*drho0_dT - dks_dT*((rho0*p1)*I_denom)) * I_denom
+    drho_dS(j) = (ks*drho0_dS - dks_dS*((rho0*p1)*I_denom)) * I_denom
   enddo
 
 end subroutine calculate_density_derivs_UNESCO
+
+!> Return the partial derivatives of specific volume with temperature and salinity
+!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
+subroutine calculate_specvol_derivs_UNESCO(T, S, pressure, dSV_dT, dSV_dS, start, npts)
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pressure !< Pressure [Pa].
+  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
+                                                   !! potential temperature [m3 kg-1 degC-1].
+  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
+                                                   !! salinity [m3 kg-1 PSU-1].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
+
+  ! Local variables
+  real :: t1       ! A copy of the temperature at a point [degC]
+  real :: s1       ! A copy of the salinity at a point [PSU]
+  real :: p1       ! Pressure converted to bars [bar]
+  real :: s12      ! The square root of salinity [PSU1/2]
+  real :: rho0     ! Density at 1 bar pressure [kg m-3]
+  real :: ks       ! The secant bulk modulus [bar]
+  real :: drho0_dT ! Derivative of rho0 with T [kg m-3 degC-1]
+  real :: drho0_dS ! Derivative of rho0 with S [kg m-3 PSU-1]
+  real :: dks_dT   ! Derivative of ks with T [bar degC-1]
+  real :: dks_dS   ! Derivative of ks with S [bar psu-1]
+  real :: I_denom2 ! 1.0 / (rho0*ks)**2 [m6 kg-2 bar-2]
+  integer :: j
+
+  do j=start,start+npts-1
+    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
+    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
+
+    ! Compute rho(s,theta,p=0) and its derivatives with temperature and salinity
+    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+    drho0_dT = R01 + ( t1*(2.0*R02 + t1*(3.0*R03 + t1*(4.0*R04 + t1*(5.0*R05)))) + &
+                       s1*(R11 + (t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + &
+                                  s12*(R61 + t1*(2.0*R62)) )) )
+    drho0_dS = R10 + ( t1*(R11 + t1*(R12 + t1*(R13 + t1*R14))) + &
+                       (1.5*(s12*(R60 + t1*(R61 + t1*R62))) + s1*(2.0*R20)) )
+
+    ! Compute the secant bulk modulus and its derivatives with temperature and salinity
+    ks = ( S000 + (t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                   s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620)))) ) + &
+         p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                        s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+              p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
+    dks_dT = ( S010 + (t1*(2.0*S020 + t1*(3.0*S030 + t1*(4.0*S040))) + &
+                       s1*((S110 + t1*(2.0*S120 + t1*(3.0*S130))) + s12*(S610 + t1*(2.0*S620)))) ) + &
+             p1*(((S011 + t1*(2.0*S021 + t1*(3.0*S031))) + s1*(S111 + t1*(2.0*S121)) ) + &
+                 p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122))) )
+    dks_dS = ( S100 + (t1*(S110 + t1*(S120 + t1*S130)) + 1.5*(s12*(S600 + t1*(S610 + t1*S620)))) ) + &
+             p1*((S101 + t1*(S111 + t1*S121) + s12*(1.5*S601)) + &
+                 p1*(S102 + t1*(S112 + t1*S122)) )
+
+    ! specvol(j) = (ks - p1) / (rho0*ks) = 1/rho0 - p1/(rho0*ks)
+    I_denom2 = 1.0 / (rho0*ks)**2
+    dSV_dT(j) = ((p1*rho0)*dks_dT + ((p1 - ks)*ks)*drho0_dT) * I_denom2
+    dSV_dS(j) = ((p1*rho0)*dks_dS + ((p1 - ks)*ks)*drho0_dS) * I_denom2
+  enddo
+
+end subroutine calculate_specvol_derivs_UNESCO
 
 !> Compute the in situ density of sea water (rho) and the compressibility (drho/dp == C_sound^-2)
 !! at the given salinity, potential temperature and pressure using the UNESCO (1981)
@@ -327,6 +386,7 @@ subroutine calculate_compress_UNESCO(T, S, pressure, rho, drho_dp, start, npts)
   real :: ks_1    ! The linear pressure dependence of the secant bulk modulus at zero pressure [nondim]
   real :: ks_2    ! The quadratic pressure dependence of the secant bulk modulus at zero pressure [bar-1]
   real :: dks_dp  ! The derivative of the secant bulk modulus with pressure [nondim]
+  real :: I_denom  ! 1.0 / (ks - p1) [bar-1]
   integer :: j
 
   do j=start,start+npts-1
@@ -335,24 +395,25 @@ subroutine calculate_compress_UNESCO(T, S, pressure, rho, drho_dp, start, npts)
 
     ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
 
-    rho0 = R00 + ( t1*(R10 + t1*(R20 + t1*(R30 + t1*(R40 + R50*t1)))) + &
-                   s1*((R01 + t1*(R11 + t1*(R21 + t1*(R31 + R41*t1)))) + &
-                       (s12*(R032 + t1*(R132 + R232*t1)) + R02*s1)) )
+    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
 
     ! Calculate the secant bulk modulus and its derivative with pressure.
-    ks_0 = S00 + ( t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
-                   s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1))) )
-    ks_1 = Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
-                     s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )
-    ks_2 = Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )
+    ks_0 = S000 + ( t1*( S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                    s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )
+    ks_1 = S001 + ( t1*( S011 + t1*(S021 + t1*S031)) + &
+                    s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )
+    ks_2 = S002 + ( t1*( S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )
 
     ks = ks_0 + p1*(ks_1 + p1*ks_2)
     dks_dp = ks_1 + 2.0*p1*ks_2
+    I_denom = 1.0 / (ks - p1)
 
     ! Compute the in situ density, rho(s,theta,p), and its derivative with pressure.
-    rho(j) = rho0*ks / (ks - p1)
+    rho(j) = rho0*ks * I_denom
     ! The factor of 1.0e-5 is because pressure here is in bars, not Pa.
-    drho_dp(j) = 1.0e-5 * (rho(j) / (ks - p1)) * (1.0 - dks_dp*p1/ks)
+    drho_dp(j) = 1.0e-5 * ((rho0 * (ks - p1*dks_dp)) * I_denom**2)
   enddo
 end subroutine calculate_compress_UNESCO
 
@@ -411,49 +472,49 @@ subroutine calculate_density_second_derivs_array_UNESCO(T, S, P, drho_ds_ds, drh
     ! singularity in the second derivatives with salinity for fresh water.  To avoid this, the
     ! square root of salinity can be treated with a floor such that the contribution from the
     ! S**1.5 terms to both the surface density and the secant bulk modulus are lost to roundoff.
-    ! This salinity is given by (~1e-16*S00/S032)**(2/3) ~= 3e-8 PSU, or S12 ~= 1.7e-4
+    ! This salinity is given by (~1e-16*S000/S600)**(2/3) ~= 3e-8 PSU, or S12 ~= 1.7e-4
     I_s12 = 1.0 / (max(s12, 1.0e-4))
 
     ! Calculate the density at sea level pressure and its derivatives
-    rho0 = R00 + ( t1*(R10 + t1*(R20 + t1*(R30 + t1*(R40 + R50*t1)))) + &
-                   s1*((R01 + t1*(R11 + t1*(R21 + t1*(R31 + R41*t1)))) + &
-                       (s12*(R032 + t1*(R132 + R232*t1)) + R02*s1)) )
-    drho0_dT = R10 + ( t1*(2.0*R20 + t1*(3.0*R30 + t1*(4.0*R40 + 5.0*R50*t1))) + &
-                       s1*(R11 + ( t1*(2.0*R21 + t1*(3.0*R31 + 4.0*R41*t1)) + &
-                                   s12*(R132 + 2.0*R232*t1) ) ) )
-    drho0_dS = R01 + ( t1*(R11 + t1*(R21 + t1*(R31 + R41*t1))) + &
-                       (1.5*s12*(R032 + t1*(R132 + R232*t1)) + 2.0*R02*s1) )
-    d2rho0_dS2 = 0.75*(R032 + t1*(R132 + R232*t1))*I_s12 + 2.0*R02
-    d2rho0_dSdT = R11 + ( t1*(2.0*R21 + t1*(3.0*R31 + 4.0*R41*t1)) + 1.5*s12*(R132 + 2.0*R232*t1) )
-    d2rho0_dT2 = 2.0*R20 + ( t1*(6.0*R30 + t1*(12.0*R40 + 20.0*R50*t1)) + &
-                             s1*((2.0*R21 + t1*(6.0*R31 + 12.0*R41*t1)) + 2.0*R232*s12) )
+    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+    drho0_dT = R01 + ( t1*(2.0*R02 + t1*(3.0*R03 + t1*(4.0*R04 + t1*(5.0*R05)))) + &
+                       s1*(R11 + ( t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + &
+                                   s12*(R61 + t1*(2.0*R62)) ) ) )
+    drho0_dS = R10 + ( t1*(R11 + t1*(R12 + t1*(R13 + t1*R14))) + &
+                       (1.5*(s12*(R60 + t1*(R61 + t1*R62))) + s1*(2.0*R20)) )
+    d2rho0_dS2 = 0.75*(R60 + t1*(R61 + t1*R62))*I_s12 + 2.0*R20
+    d2rho0_dSdT = R11 + ( t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + s12*(1.5*R61 + t1*(3.0*R62)) )
+    d2rho0_dT2 = 2.0*R02 + ( t1*(6.0*R03 + t1*(12.0*R04 + t1*(20.0*R05))) + &
+                             s1*((2.0*R12 + t1*(6.0*R13 + t1*(12.0*R14))) + s12*(2.0*R62)) )
 
     !  Calculate the secant bulk modulus and its derivatives
-    ks_0 = S00 + ( t1*(S10 + t1*(S20 + t1*(S30 + S40*t1))) + &
-                   s1*((S01 + t1*(S11 + t1*(S21 + S31*t1))) + s12*(S032 + t1*(S132 + S232*t1))) )
-    ks_1 = Sp100 + ( t1*(Sp110 + t1*(Sp120 + Sp130*t1)) + &
-                     s1*((Sp101 + t1*(Sp111 + Sp121*t1)) + Sp1032*s12) )
-    ks_2 = Sp200 + ( t1*(Sp210 + Sp220*t1) + s1*(Sp201 + t1*(Sp211 + Sp221*t1)) )
+    ks_0 = S000 + ( t1*( S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                    s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )
+    ks_1 = S001 + ( t1*( S011 + t1*(S021 + t1*S031)) + &
+                    s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )
+    ks_2 = S002 + ( t1*( S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )
 
     ks = ks_0 + p1*(ks_1 + p1*ks_2)
     dks_dp = ks_1 + 2.0*p1*ks_2
-    dks_dT = (S10 + ( t1*(2.0*S20 + t1*(3.0*S30 + t1*4.0*S40)) + &
-                      s1*((S11 + t1*(2.0*S21 + 3.0*S31*t1)) + s12*(S132 + 2.0*S232*t1)) )) + &
-             p1*((Sp110 + t1*(2.0*Sp120 + 3.0*Sp130*t1) + s1*(Sp111 + 2.0*Sp121*t1)) + &
-                 p1*(Sp210 + 2.0*Sp220*t1 + s1*(Sp211 + 2.0*Sp221*t1)))
-    dks_dS = (S01 + ( t1*(S11 + t1*(S21 + S31*t1)) + 1.5*s12*(S032 + t1*(S132 + S232*t1)) )) + &
-             p1*((Sp101 + t1*(Sp111 + Sp121*t1) + 1.5*Sp1032*s12) + &
-                 p1*(Sp201 + t1*(Sp211 + Sp221*t1)))
-    d2ks_dS2 = 0.75*((S032 + t1*(S132 + S232*t1)) + p1*Sp1032)*I_s12
-    d2ks_dSdT = (S11 + ( t1*(2.0*S21 + 3.0*S31*t1) + 1.5*s12*(S132 + 2.0*S232*t1) )) + &
-                p1*((Sp111 + 2.0*Sp121*t1) +  p1*(Sp211 + 2.0*Sp221*t1))
-    d2ks_dT2 = 2.0*(S20 + ( t1*(3.0*S30 + 6.0*S40*t1) + s1*((S21 + 3.0*S31*t1) + S232*s12) )) + &
-               2.0*p1*((Sp120 + (3.0*Sp130*t1 + Sp121*s1)) + p1*(Sp220 + Sp221*s1))
+    dks_dT = (S010 + ( t1*(2.0*S020 + t1*(3.0*S030 + t1*(4.0*S040))) + &
+                       s1*((S110 + t1*(2.0*S120 + t1*(3.0*S130))) + s12*(S610 + t1*(2.0*S620))) )) + &
+             p1*((S011 + t1*(2.0*S021 + t1*(3.0*S031)) + s1*(S111 + t1*(2.0*S121))) + &
+                 p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122))))
+    dks_dS = (S100 + ( t1*(S110 + t1*(S120 + t1*S130)) + 1.5*(s12*(S600 + t1*(S610 + t1*S620))) )) + &
+             p1*((S101 + t1*(S111 + t1*S121) + s12*(1.5*S601)) + &
+                 p1*(S102 + t1*(S112 + t1*S122)))
+    d2ks_dS2 = 0.75*((S600 + t1*(S610 + t1*S620)) + p1*S601)*I_s12
+    d2ks_dSdT = (S110 + ( t1*(2.0*S120 + t1*(3.0*S130)) + s12*(1.5*S610 + t1*(3.0*S620)) )) + &
+                p1*((S111 + t1*(2.0*S121)) +  p1*(S112 + t1*(2.0*S122)))
+    d2ks_dT2 = 2.0*(S020 + ( t1*(3.0*S030 + t1*(6.0*S040)) + s1*((S120 + t1*(3.0*S130)) + s12*S620) )) + &
+               2.0*p1*((S021 + (t1*(3.0*S031) + s1*S121)) + p1*(S022 + s1*S122))
 
-    d2ks_dSdp = (Sp101 + (t1*(Sp111 + Sp121*t1) + 1.5*Sp1032*s12)) + &
-                2.0*p1*(Sp201 + t1*(Sp211 + Sp221*t1))
-    d2ks_dTdp = (Sp110 + (t1*(2.0*Sp120 + 3.0*Sp130*t1) + s1*(Sp111 + 2.0*Sp121*t1))) + &
-                2.0*p1*(Sp210 + 2.0*Sp220*t1 + s1*(Sp211 + 2.0*Sp221*t1))
+    d2ks_dSdp = (S101 + (t1*(S111 + t1*S121) + s12*(1.5*S601))) + &
+                2.0*p1*(S102 + t1*(S112 + t1*S122))
+    d2ks_dTdp = (S011 + (t1*(2.0*S021 + t1*(3.0*S031)) + s1*(S111 + t1*(2.0*S121)))) + &
+                2.0*p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122)))
     I_denom = 1.0 / (ks - p1)
 
     ! Expressions for density and its first derivatives are copied here for reference:
@@ -467,7 +528,7 @@ subroutine calculate_density_second_derivs_array_UNESCO(T, S, P, drho_ds_ds, drh
                       (2.0*drho0_dS*dks_dS + rho0*(d2ks_dS2 - 2.0*dks_dS**2*I_denom)) )
     drho_dS_dT(j) = I_denom * (ks * d2rho0_dSdT - (p1*I_denom) * &
                         ((drho0_dT*dks_dS + drho0_dS*dks_dT) + &
-                          rho0*(d2ks_dSdT - 2.0*(dks_dS*dks_dT)*I_denom)) )
+                         rho0*(d2ks_dSdT - 2.0*(dks_dS*dks_dT)*I_denom)) )
     drho_dT_dT(j) = I_denom * ( ks*d2rho0_dT2 - (p1*I_denom) * &
                       (2.0*drho0_dT*dks_dT + rho0*(d2ks_dT2 - 2.0*dks_dT**2*I_denom)) )
 

--- a/src/equation_of_state/MOM_EOS_UNESCO.F90
+++ b/src/equation_of_state/MOM_EOS_UNESCO.F90
@@ -8,7 +8,7 @@ implicit none ; private
 public calculate_compress_UNESCO, calculate_density_UNESCO, calculate_spec_vol_UNESCO
 public calculate_density_derivs_UNESCO, calculate_specvol_derivs_UNESCO
 public calculate_density_scalar_UNESCO, calculate_density_array_UNESCO
-public calculate_density_second_derivs_UNESCO
+public calculate_density_second_derivs_UNESCO, EoS_fit_range_UNESCO
 
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
 !! a reference density, from salinity [PSU], potential temperature [degC] and pressure [Pa],
@@ -585,6 +585,26 @@ subroutine calculate_density_second_derivs_scalar_UNESCO(T, S, P, drho_ds_ds, dr
   drho_dt_dp = drdtdp(1)
 
 end subroutine calculate_density_second_derivs_scalar_UNESCO
+
+!> Return the range of temperatures, salinities and pressures for which Jackett and McDougall (1995)
+!! refit the UNESCO equation of state has been fitted to observations.  Care should be taken when
+!! applying this equation of state outside of its fit range.
+subroutine EoS_fit_range_UNESCO(T_min, T_max, S_min, S_max, p_min, p_max)
+  real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: S_max !< The maximum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+  real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  if (present(T_min)) T_min = -2.5
+  if (present(T_max)) T_max = 40.0
+  if (present(S_min)) S_min =  0.0
+  if (present(S_max)) S_max = 42.0
+  if (present(p_min)) p_min = 0.0
+  if (present(p_max)) p_max = 1.0e8
+
+end subroutine EoS_fit_range_UNESCO
 
 !> \namespace mom_eos_UNESCO
 !!

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -7,8 +7,6 @@ use MOM_hor_index, only : hor_index_type
 
 implicit none ; private
 
-#include <MOM_memory.h>
-
 public calculate_compress_wright, calculate_density_wright, calculate_spec_vol_wright
 public calculate_density_derivs_wright, calculate_specvol_derivs_wright
 public calculate_density_second_derivs_wright, calc_density_second_derivs_wright_buggy

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -12,6 +12,7 @@ implicit none ; private
 public calculate_compress_wright, calculate_density_wright, calculate_spec_vol_wright
 public calculate_density_derivs_wright, calculate_specvol_derivs_wright
 public calculate_density_second_derivs_wright, calc_density_second_derivs_wright_buggy
+public EoS_fit_range_Wright
 public int_density_dz_wright, int_spec_vol_dp_wright
 
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
@@ -547,6 +548,26 @@ subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
     drho_dp(j) = lambda * I_denom * I_denom
   enddo
 end subroutine calculate_compress_wright
+
+!> Return the range of temperatures, salinities and pressures for which the reduced-range equation
+!! of state from Wright (1997) has been fitted to observations.  Care should be taken when applying
+!! this equation of state outside of its fit range.
+subroutine EoS_fit_range_Wright(T_min, T_max, S_min, S_max, p_min, p_max)
+  real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: S_max !< The maximum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+  real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  if (present(T_min)) T_min = -2.0
+  if (present(T_max)) T_max = 30.0
+  if (present(S_min)) S_min = 28.0
+  if (present(S_max)) S_max = 38.0
+  if (present(p_min)) p_min = 0.0
+  if (present(p_max)) p_max = 5.0e7
+
+end subroutine EoS_fit_range_Wright
 
 !> Calculates analytical and nearly-analytical integrals, in geopotential across layers, of pressure
 !! anomalies, which are required for calculating the finite-volume form pressure accelerations in a

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -11,12 +11,12 @@ implicit none ; private
 
 public calculate_compress_wright, calculate_density_wright, calculate_spec_vol_wright
 public calculate_density_derivs_wright, calculate_specvol_derivs_wright
-public calculate_density_second_derivs_wright
+public calculate_density_second_derivs_wright, calc_density_second_derivs_wright_buggy
 public int_density_dz_wright, int_spec_vol_dp_wright
 
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
 !! a reference density, from salinity in practical salinity units ([PSU]), potential
-!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
+!! temperature (in degrees Celsius [degC]) and pressure [Pa], using the expressions from
 !! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 interface calculate_density_wright
   module procedure calculate_density_scalar_wright, calculate_density_array_wright
@@ -24,7 +24,7 @@ end interface calculate_density_wright
 
 !> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
 !! to a reference specific volume, from salinity in practical salinity units ([PSU]), potential
-!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
+!! temperature (in degrees Celsius [degC]) and pressure [Pa], using the expressions from
 !! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 interface calculate_spec_vol_wright
   module procedure calculate_spec_vol_scalar_wright, calculate_spec_vol_array_wright
@@ -36,10 +36,18 @@ interface calculate_density_derivs_wright
 end interface calculate_density_derivs_wright
 
 !> Compute the second derivatives of density with various combinations
-!! of temperature, salinity, and pressure
+!! of temperature, salinity and pressure, using the expressions from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 interface calculate_density_second_derivs_wright
   module procedure calculate_density_second_derivs_scalar_wright, calculate_density_second_derivs_array_wright
 end interface calculate_density_second_derivs_wright
+
+!> Compute the second derivatives of density with various combinations of temperature, salinity and
+!! pressure, but deliberately retaining a bug that reproduces older answers for the second
+!! derivative of density with temperature and the second derivative with temperature and pressure
+interface calc_density_second_derivs_wright_buggy
+  module procedure calc_dens_second_derivs_buggy_scalar_wright, calc_dens_second_derivs_buggy_array_wright
+end interface calc_density_second_derivs_wright_buggy
 
 !>@{ Parameters in the Wright equation of state using the reduced range formula, which is a fit to the UNESCO
 !    equation of state for the restricted range: -2 < theta < 30 [degC], 28 < S < 38 [PSU], 0  < p < 5e7 [Pa].
@@ -69,7 +77,7 @@ contains
 !> Computes the in situ density of sea water for scalar inputs and outputs.
 !!
 !! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
-!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
 !! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
   real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC].
@@ -96,7 +104,7 @@ end subroutine calculate_density_scalar_wright
 !> Computes the in situ density of sea water for 1-d array inputs and outputs.
 !!
 !! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
-!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
 !! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_ref)
   real, dimension(:), intent(in)    :: T        !< potential temperature relative to the surface [degC].
@@ -263,8 +271,114 @@ subroutine calculate_density_derivs_scalar_wright(T, S, pressure, drho_dT, drho_
 
 end subroutine calculate_density_derivs_scalar_wright
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
+!> Second derivatives of density with respect to temperature, salinity and pressure for 1-d array inputs and outputs.
 subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+                                                         drho_ds_dp, drho_dt_dp, start, npts)
+  real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
+  real, dimension(:), intent(in   ) :: S !< Salinity [PSU]
+  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
+  real, dimension(:), intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+                                                  !! to S [kg m-3 PSU-2]
+  real, dimension(:), intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+                                                  !! to T [kg m-3 PSU-1 degC-1]
+  real, dimension(:), intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                                  !! to T [kg m-3 degC-2]
+  real, dimension(:), intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+                                                  !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real, dimension(:), intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                                  !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  integer,            intent(in   ) :: start !< Starting index in T,S,P
+  integer,            intent(in   ) :: npts  !< Number of points to loop over
+
+  ! Local variables
+  real :: z0, z1 ! Local work variables [Pa]
+  real :: z2, z4 ! Local work variables [m2 s-2]
+  real :: z3, z5 ! Local work variables [Pa degC-1]
+  real :: z6, z8 ! Local work variables [m2 s-2 degC-1]
+  real :: z7     ! A local work variable [m2 s-2 PSU-1]
+  real :: z9     ! A local work variable [m3 kg-1]
+  real :: z10    ! A local work variable [Pa PSU-1]
+  real :: z11    ! A local work variable [Pa m2 s-2 PSU-1] = [kg m s-4 PSU-1]
+  real :: z2_2   ! A local work variable [m4 s-4]
+  real :: z2_3   ! A local work variable [m6 s-6]
+  integer :: j
+  ! See the counterpart in MOM_EOS_Wright_full.F90 for a more numerically stable
+  ! and/or efficient, but mathematically equivalent expression
+
+  do j = start,start+npts-1
+    z0 = T(j)*(b1 + b5*S(j) + T(j)*(b2 + b3*T(j)))
+    z1 = (b0 + P(j) + b4*S(j) + z0)
+    z3 = (b1 + b5*S(j) + T(j)*(2.*b2 + 3.*b3*T(j)))
+    z4 = (c0 + c4*S(j) + T(j)*(c1 + c5*S(j) + T(j)*(c2 + c3*T(j))))
+    z5 = (b1 + b5*S(j) + T(j)*(b2 + b3*T(j)) + T(j)*(b2 + 2.*b3*T(j)))
+    z6 = c1 + c5*S(j) + T(j)*(c2 + c3*T(j)) + T(j)*(c2 + 2.*c3*T(j))
+    z7 = (c4 + c5*T(j) + a2*z1)
+    z8 = (c1 + c5*S(j) + T(j)*(2.*c2 + 3.*c3*T(j)) + a1*z1)
+    z9 = (a0 + a2*S(j) + a1*T(j))
+    z10 = (b4 + b5*T(j))
+    z11 = (z10*z4 - z1*z7)
+    z2 = (c0 + c4*S(j) + T(j)*(c1 + c5*S(j) + T(j)*(c2 + c3*T(j))) + z9*z1)
+    z2_2 = z2*z2
+    z2_3 = z2_2*z2
+
+    drho_ds_ds(j) = (z10*(c4 + c5*T(j)) - a2*z10*z1 - z10*z7)/z2_2 - (2.*(c4 + c5*T(j) + z9*z10 + a2*z1)*z11)/z2_3
+    drho_ds_dt(j) = (z10*z6 - z1*(c5 + a2*z5) + b5*z4 - z5*z7)/z2_2 - (2.*(z6 + z9*z5 + a1*z1)*z11)/z2_3
+    drho_dt_dt(j) = (z3*z6 - z1*(2.*c2 + 6.*c3*T(j) + a1*z5) + (2.*b2 + 6.*b3*T(j))*z4 - z5*z8)/z2_2 - &
+                    (2.*(z6 + z9*z5 + a1*z1)*(z3*z4 - z1*z8))/z2_3
+    drho_ds_dp(j) = (-c4 - c5*T(j) - 2.*a2*z1)/z2_2 - (2.*z9*z11)/z2_3
+    drho_dt_dp(j) = (-c1 - c5*S(j) - T(j)*(2.*c2 + 3.*c3*T(j)) - 2.*a1*z1)/z2_2 - (2.*z9*(z3*z4 - z1*z8))/z2_3
+  enddo
+
+end subroutine calculate_density_second_derivs_array_wright
+
+!> Second derivatives of density with respect to temperature, salinity and pressure for scalar inputs.
+!!
+!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
+subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+                                                         drho_ds_dp, drho_dt_dp)
+  real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
+  real, intent(in   ) :: S          !< Salinity [PSU]
+  real, intent(in   ) :: P          !< pressure [Pa]
+  real, intent(  out) :: drho_ds_ds !< Partial derivative of beta with respect
+                                    !! to S [kg m-3 PSU-2]
+  real, intent(  out) :: drho_ds_dt !< Partial derivative of beta with respect
+                                    !! to T [kg m-3 PSU-1 degC-1]
+  real, intent(  out) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                    !! to T [kg m-3 degC-2]
+  real, intent(  out) :: drho_ds_dp !< Partial derivative of beta with respect
+                                    !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real, intent(  out) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                    !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
+  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 PSU-2]
+  real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
+                               ! temperature [kg m-3 PSU-1 degC-1]
+  real, dimension(1) :: drdtdt ! The second derivative of density with temperature [kg m-3 degC-2]
+  real, dimension(1) :: drdsdp ! The second derivative of density with salinity and
+                               ! pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real, dimension(1) :: drdtdp ! The second derivative of density with temperature and
+                               ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+
+  T0(1) = T
+  S0(1) = S
+  P0(1) = P
+  call calculate_density_second_derivs_array_wright(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
+  drho_ds_ds = drdsds(1)
+  drho_ds_dt = drdsdt(1)
+  drho_dt_dt = drdtdt(1)
+  drho_ds_dp = drdsdp(1)
+  drho_dt_dp = drdtdp(1)
+
+end subroutine calculate_density_second_derivs_scalar_wright
+
+!> Second derivatives of density with respect to temperature, salinity and pressure for 1-d array
+!! inputs and outputs, but deliberately including a bug to reproduce previous answers, in which
+!! some terms in the expressions for drho_dt_dt and drho_dt_dp are 2/3 of what they should be.
+subroutine calc_dens_second_derivs_buggy_array_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                          drho_ds_dp, drho_dt_dp, start, npts)
   real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
   real, dimension(:), intent(in   ) :: S !< Salinity [PSU]
@@ -322,13 +436,14 @@ subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drh
     drho_dt_dp(j) = (-c1 - c5*S(j) - T(j)*(2.*c2 + 3.*c3*T(j)) - 2.*a1*z1)/z2_2 - (2.*z9*(z3*z4 - z1*z8))/z2_3
   enddo
 
-end subroutine calculate_density_second_derivs_array_wright
+end subroutine calc_dens_second_derivs_buggy_array_wright
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
+!> Second derivatives of density with respect to temperature, salinity and pressure for scalar
+!! inputs, but deliberately including a bug to reproduce previous answers.
 !!
 !! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
 !! and then demotes the output back to a scalar
-subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+subroutine calc_dens_second_derivs_buggy_scalar_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                          drho_ds_dp, drho_dt_dp)
   real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
   real, intent(in   ) :: S          !< Salinity [PSU]
@@ -366,7 +481,7 @@ subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, dr
   drho_ds_dp = drdsdp(1)
   drho_dt_dp = drdtdp(1)
 
-end subroutine calculate_density_second_derivs_scalar_wright
+end subroutine calc_dens_second_derivs_buggy_scalar_wright
 
 !> Return the partial derivatives of specific volume with temperature and salinity
 !! for 1-d array inputs and outputs
@@ -872,7 +987,7 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
       wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
       wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
 
-      ! T, S, and p are interpolated in the horizontal.  The p interpolation
+      ! T, S and p are interpolated in the horizontal.  The p interpolation
       ! is linear, but for T and S it may be thickness weighted.
       al0 = wtT_L*al0_2d(i,j) + wtT_R*al0_2d(i+1,j)
       p0 = wtT_L*p0_2d(i,j) + wtT_R*p0_2d(i+1,j)
@@ -913,7 +1028,7 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
       wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
       wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
 
-      ! T, S, and p are interpolated in the horizontal.  The p interpolation
+      ! T, S and p are interpolated in the horizontal.  The p interpolation
       ! is linear, but for T and S it may be thickness weighted.
       al0 = wt_L*al0_2d(i,j) + wt_R*al0_2d(i,j+1)
       p0 = wt_L*p0_2d(i,j) + wt_R*p0_2d(i,j+1)
@@ -937,7 +1052,7 @@ end subroutine int_spec_vol_dp_wright
 !! \section section_EOS_Wright Wright equation of state
 !!
 !! Wright, 1997, provide an approximation for the in situ density as a function of
-!! potential temperature, salinity, and pressure. The formula follow the Tumlirz
+!! potential temperature, salinity and pressure. The formula follow the Tumlirz
 !! equation of state which are easier to evaluate and make efficient.
 !!
 !! Two ranges are provided by Wright: a "full" range and "reduced" range. The version in this

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -300,7 +300,7 @@ subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drh
   do j = start,start+npts-1
     z0 = T(j)*(b1 + b5*S(j) + T(j)*(b2 + b3*T(j)))
     z1 = (b0 + P(j) + b4*S(j) + z0)
-    z3 = (b1 + b5*S(j) + T(j)*(2.*b2 + 2.*b3*T(j)))
+    z3 = (b1 + b5*S(j) + T(j)*(2.*b2 + 2.*b3*T(j))) ! BUG: This should be z3 = b1 + b5*S(j) + T(j)*(2.*b2 + 3.*b3*T(j))
     z4 = (c0 + c4*S(j) + T(j)*(c1 + c5*S(j) + T(j)*(c2 + c3*T(j))))
     z5 = (b1 + b5*S(j) + T(j)*(b2 + b3*T(j)) + T(j)*(b2 + 2.*b3*T(j)))
     z6 = c1 + c5*S(j) + T(j)*(c2 + c3*T(j)) + T(j)*(c2 + 2.*c3*T(j))
@@ -315,6 +315,7 @@ subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drh
 
     drho_ds_ds(j) = (z10*(c4 + c5*T(j)) - a2*z10*z1 - z10*z7)/z2_2 - (2.*(c4 + c5*T(j) + z9*z10 + a2*z1)*z11)/z2_3
     drho_ds_dt(j) = (z10*z6 - z1*(c5 + a2*z5) + b5*z4 - z5*z7)/z2_2 - (2.*(z6 + z9*z5 + a1*z1)*z11)/z2_3
+    ! BUG: In the following line: (2.*b2 + 4.*b3*T(j)) should be (2.*b2 + 6.*b3*T(j))
     drho_dt_dt(j) = (z3*z6 - z1*(2.*c2 + 6.*c3*T(j) + a1*z5) + (2.*b2 + 4.*b3*T(j))*z4 - z5*z8)/z2_2 - &
                     (2.*(z6 + z9*z5 + a1*z1)*(z3*z4 - z1*z8))/z2_3
     drho_ds_dp(j) = (-c4 - c5*T(j) - 2.*a2*z1)/z2_2 - (2.*z9*z11)/z2_3

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -3,12 +3,6 @@ module MOM_EOS_Wright
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!***********************************************************************
-!*  The subroutines in this file implement the equation of state for   *
-!*  sea water using the formulae given by  Wright, 1997, J. Atmos.     *
-!*  Ocean. Tech., 14, 735-740.  Coded by R. Hallberg, 7/00.            *
-!***********************************************************************
-
 use MOM_hor_index, only : hor_index_type
 
 implicit none ; private
@@ -20,16 +14,10 @@ public calculate_density_derivs_wright, calculate_specvol_derivs_wright
 public calculate_density_second_derivs_wright
 public int_density_dz_wright, int_spec_vol_dp_wright
 
-! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
-! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
-! their mks counterparts with notation like "a velocity [Z T-1 ~> m s-1]".  If the units
-! vary with the Boussinesq approximation, the Boussinesq variant is given first.
-
-
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
 !! a reference density, from salinity in practical salinity units ([PSU]), potential
 !! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 interface calculate_density_wright
   module procedure calculate_density_scalar_wright, calculate_density_array_wright
 end interface calculate_density_wright
@@ -37,23 +25,23 @@ end interface calculate_density_wright
 !> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
 !! to a reference specific volume, from salinity in practical salinity units ([PSU]), potential
 !! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 interface calculate_spec_vol_wright
   module procedure calculate_spec_vol_scalar_wright, calculate_spec_vol_array_wright
 end interface calculate_spec_vol_wright
 
-!> For a given thermodynamic state, return the derivatives of density with temperature and salinity
+!> Compute the derivatives of density with temperature and salinity
 interface calculate_density_derivs_wright
   module procedure calculate_density_derivs_scalar_wright, calculate_density_derivs_array_wright
 end interface calculate_density_derivs_wright
 
-!> For a given thermodynamic state, return the second derivatives of density with various combinations
+!> Compute the second derivatives of density with various combinations
 !! of temperature, salinity, and pressure
 interface calculate_density_second_derivs_wright
   module procedure calculate_density_second_derivs_scalar_wright, calculate_density_second_derivs_array_wright
 end interface calculate_density_second_derivs_wright
 
-!>@{ Parameters in the Wright equation of state using the  restricted range formula, which is a fit to the UNESCO
+!>@{ Parameters in the Wright equation of state using the reduced range formula, which is a fit to the UNESCO
 !    equation of state for the restricted range: -2 < theta < 30 [degC], 28 < S < 38 [PSU], 0  < p < 5e7 [Pa].
 
   ! Note that a0/a1 ~= 2028 [degC] ; a0/a2 ~= -6343 [PSU]
@@ -78,10 +66,11 @@ real, parameter :: c5 = -3.079464    ! A parameter in the Wright lambda fit [m2 
 
 contains
 
-!> This subroutine computes the in situ density of sea water (rho in
-!! [kg m-3]) from salinity (S [PSU]), potential temperature
-!! (T [degC]), and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!> Computes the in situ density of sea water for scalar inputs and outputs.
+!!
+!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
+!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
   real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC].
   real,           intent(in)  :: S        !< Salinity [PSU].
@@ -89,14 +78,7 @@ subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
   real,           intent(out) :: rho      !< In situ density [kg m-3].
   real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
 
-! *====================================================================*
-! *  This subroutine computes the in situ density of sea water (rho in *
-! *  [kg m-3]) from salinity (S [PSU]), potential temperature          *
-! *  (T [degC]), and pressure [Pa].  It uses the expression from       *
-! *  Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.                *
-! *  Coded by R. Hallberg, 7/00                                        *
-! *====================================================================*
-
+  ! Local variables
   real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
   real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
   real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
@@ -111,10 +93,11 @@ subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
 
 end subroutine calculate_density_scalar_wright
 
-!> This subroutine computes the in situ density of sea water (rho in
-!! [kg m-3]) from salinity (S [PSU]), potential temperature
-!! (T [degC]), and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!> Computes the in situ density of sea water for 1-d array inputs and outputs.
+!!
+!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
+!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_ref)
   real, dimension(:), intent(in)    :: T        !< potential temperature relative to the surface [degC].
   real, dimension(:), intent(in)    :: S        !< salinity [PSU].
@@ -124,7 +107,6 @@ subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_
   integer,            intent(in)    :: npts     !< the number of values to calculate.
   real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3].
 
-  ! Original coded by R. Hallberg, 7/00, anomaly coded in 3/18.
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
@@ -155,10 +137,11 @@ subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_
 
 end subroutine calculate_density_array_wright
 
-!> This subroutine computes the in situ specific volume of sea water (specvol in
-!! [m3 kg-1]) from salinity (S [PSU]), potential temperature (T [degC])
-!! and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!> Computes the Wright in situ specific volume of sea water for scalar inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_scalar_wright(T, S, pressure, specvol, spv_ref)
   real,           intent(in)  :: T        !< potential temperature relative to the surface [degC].
@@ -179,10 +162,11 @@ subroutine calculate_spec_vol_scalar_wright(T, S, pressure, specvol, spv_ref)
   specvol = spv0(1)
 end subroutine calculate_spec_vol_scalar_wright
 
-!> This subroutine computes the in situ specific volume of sea water (specvol in
-!! [m3 kg-1]) from salinity (S [PSU]), potential temperature (T [degC])
-!! and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!> Computes the Wright in situ specific volume of sea water for 1-d array inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts, spv_ref)
   real, dimension(:), intent(in)    :: T        !< potential temperature relative to the
@@ -213,7 +197,7 @@ subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts,
   enddo
 end subroutine calculate_spec_vol_array_wright
 
-!> For a given thermodynamic state, return the thermal/haline expansion coefficients
+!> Return the thermal/haline expansion coefficients for 1-d array inputs and outputs
 subroutine calculate_density_derivs_array_wright(T, S, pressure, drho_dT, drho_dS, start, npts)
   real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the
                                                    !! surface [degC].
@@ -250,8 +234,10 @@ subroutine calculate_density_derivs_array_wright(T, S, pressure, drho_dT, drho_d
 
 end subroutine calculate_density_derivs_array_wright
 
-!> The scalar version of calculate_density_derivs which promotes scalar inputs to a 1-element array and then
-!! demotes the output back to a scalar
+!> Return the thermal/haline expansion coefficients for scalar inputs and outputs
+!!
+!! The scalar version of calculate_density_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
 subroutine calculate_density_derivs_scalar_wright(T, S, pressure, drho_dT, drho_dS)
   real,    intent(in)  :: T        !< Potential temperature relative to the surface [degC].
   real,    intent(in)  :: S        !< Salinity [PSU].
@@ -277,7 +263,7 @@ subroutine calculate_density_derivs_scalar_wright(T, S, pressure, drho_dT, drho_
 
 end subroutine calculate_density_derivs_scalar_wright
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure
+!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
 subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                          drho_ds_dp, drho_dt_dp, start, npts)
   real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
@@ -337,8 +323,10 @@ subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drh
 
 end subroutine calculate_density_second_derivs_array_wright
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs. Inputs
-!! promoted to 1-element array and output demoted to scalar
+!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
+!!
+!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
 subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                          drho_ds_dp, drho_dt_dp)
   real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
@@ -379,8 +367,8 @@ subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, dr
 
 end subroutine calculate_density_second_derivs_scalar_wright
 
-!> For a given thermodynamic state, return the partial derivatives of specific volume
-!! with temperature and salinity
+!> Return the partial derivatives of specific volume with temperature and salinity
+!! for 1-d array inputs and outputs
 subroutine calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start, npts)
   real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
   real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
@@ -414,11 +402,7 @@ subroutine calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start
 
 end subroutine calculate_specvol_derivs_wright
 
-!> This subroutine computes the in situ density of sea water (rho in [kg m-3])
-!! and the compressibility (drho/dp = C_sound^-2) (drho_dp [s2 m-2]) from
-!! salinity (sal [PSU]), potential temperature (T [degC]), and pressure [Pa].
-!! It uses the expressions from Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
-!! Coded by R. Hallberg, 1/01
+!> Computes the compressibility of seawater for 1-d array inputs and outputs
 subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
   real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
   real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
@@ -430,7 +414,6 @@ subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
   integer, intent(in)                  :: start    !< The starting point in the arrays.
   integer, intent(in)                  :: npts     !< The number of values to calculate.
 
-  ! Coded by R. Hallberg, 1/01
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
@@ -449,9 +432,11 @@ subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
   enddo
 end subroutine calculate_compress_wright
 
-!> This subroutine calculates analytical and nearly-analytical integrals of
-!! pressure anomalies across layers, which are required for calculating the
-!! finite-volume form pressure accelerations in a Boussinesq model.
+!> Calculates analytical and nearly-analytical integrals, in geopotential across layers, of pressure
+!! anomalies, which are required for calculating the finite-volume form pressure accelerations in a
+!! Boussinesq model.  There are essentially no free assumptions, apart from the use of Boole's rule
+!! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
+!! that assumes that |eps| < 0.34.
 subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                  dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, &
                                  useMassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
@@ -707,12 +692,11 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
 
 end subroutine int_density_dz_wright
 
-!>   This subroutine calculates analytical and nearly-analytical integrals in
-!! pressure across layers of geopotential anomalies, which are required for
-!! calculating the finite-volume form pressure accelerations in a non-Boussinesq
-!! model.  There are essentially no free assumptions, apart from the use of
-!! Boole's rule to do the horizontal integrals, and from a truncation in the
-!! series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
+!> Calculates analytical and nearly-analytical integrals, in pressure across layers, of geopotential
+!! anomalies, which are required for calculating the finite-volume form pressure accelerations in a
+!! non-Boussinesq model.  There are essentially no free assumptions, apart from the use of Boole's
+!! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
+!! that assumes that |eps| < 0.34.
 subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
                                   intp_dza, intx_dza, inty_dza, halo_size, bathyP, dP_neglect, &
                                   useMassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
@@ -946,5 +930,25 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
                            12.0*intp(3))
   enddo ; enddo ; endif
 end subroutine int_spec_vol_dp_wright
+
+!> \namespace mom_eos_wright
+!!
+!! \section section_EOS_Wright Wright equation of state
+!!
+!! Wright, 1997, provide an approximation for the in situ density as a function of
+!! potential temperature, salinity, and pressure. The formula follow the Tumlirz
+!! equation of state which are easier to evaluate and make efficient.
+!!
+!! Two ranges are provided by Wright: a "full" range and "reduced" range. The version in this
+!! module uses the reduced range.
+!!
+!! Originally coded in 2000 by R. Hallberg.
+!! Anomaly form coded in 3/18.
+!!
+!! \subsection section_EOS_Wright_references References
+!!
+!! Wright, D., 1997: An Equation of State for Use in Ocean Models: Eckart's Formula Revisited.
+!! J. Ocean. Atmosph. Tech., 14 (3), 735-740.
+!! https://journals.ametsoc.org/doi/abs/10.1175/1520-0426%281997%29014%3C0735%3AAEOSFU%3E2.0.CO%3B2
 
 end module MOM_EOS_Wright

--- a/src/equation_of_state/MOM_EOS_Wright_full.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_full.F90
@@ -11,7 +11,7 @@ implicit none ; private
 
 public calculate_compress_wright_full, calculate_density_wright_full, calculate_spec_vol_wright_full
 public calculate_density_derivs_wright_full, calculate_specvol_derivs_wright_full
-public calculate_density_second_derivs_wright_full
+public calculate_density_second_derivs_wright_full, EoS_fit_range_Wright_full
 public int_density_dz_wright_full, int_spec_vol_dp_wright_full
 
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
@@ -441,6 +441,26 @@ subroutine calculate_compress_wright_full(T, S, pressure, rho, drho_dp, start, n
     drho_dp(j) = lambda * I_denom**2
   enddo
 end subroutine calculate_compress_wright_full
+
+!> Return the range of temperatures, salinities and pressures for which full-range equation
+!! of state from Wright (1997) has been fitted to observations.  Care should be taken when applying
+!! this equation of state outside of its fit range.
+subroutine EoS_fit_range_Wright_full(T_min, T_max, S_min, S_max, p_min, p_max)
+  real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: S_max !< The maximum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+  real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  if (present(T_min)) T_min = -2.0
+  if (present(T_max)) T_max = 40.0
+  if (present(S_min)) S_min =  0.0
+  if (present(S_max)) S_max = 40.0
+  if (present(p_min)) p_min = 0.0
+  if (present(p_max)) p_max = 1.0e8
+
+end subroutine EoS_fit_range_Wright_full
 
 !> Calculates analytical and nearly-analytical integrals, in geopotential across layers, of pressure
 !! anomalies, which are required for calculating the finite-volume form pressure accelerations in a

--- a/src/equation_of_state/MOM_EOS_Wright_full.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_full.F90
@@ -942,7 +942,7 @@ end subroutine int_spec_vol_dp_wright_full
 
 !> \namespace mom_eos_wright_full
 !!
-!! \section section_EOS_Wright Wright equation of state
+!! \section section_EOS_Wright_full Wright equation of state
 !!
 !! Wright, 1997, provide an approximation for the in situ density as a function of
 !! potential temperature, salinity, and pressure. The formula follow the Tumlirz
@@ -954,7 +954,7 @@ end subroutine int_spec_vol_dp_wright_full
 !! Originally coded in 2000 by R. Hallberg.
 !! Anomaly form coded in 3/18.
 !!
-!! \subsection section_EOS_Wright_references References
+!! \subsection section_EOS_Wright_full_references References
 !!
 !! Wright, D., 1997: An Equation of State for Use in Ocean Models: Eckart's Formula Revisited.
 !! J. Ocean. Atmosph. Tech., 14 (3), 735-740.

--- a/src/equation_of_state/MOM_EOS_Wright_full.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_full.F90
@@ -1,5 +1,5 @@
 !> The equation of state using the Wright 1997 expressions
-module MOM_EOS_Wright
+module MOM_EOS_Wright_full
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
@@ -15,10 +15,10 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public calculate_compress_wright, calculate_density_wright, calculate_spec_vol_wright
-public calculate_density_derivs_wright, calculate_specvol_derivs_wright
-public calculate_density_second_derivs_wright
-public int_density_dz_wright, int_spec_vol_dp_wright
+public calculate_compress_wright_full, calculate_density_wright_full, calculate_spec_vol_wright_full
+public calculate_density_derivs_wright_full, calculate_specvol_derivs_wright_full
+public calculate_density_second_derivs_wright_full
+public int_density_dz_wright_full, int_spec_vol_dp_wright_full
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
@@ -30,50 +30,50 @@ public int_density_dz_wright, int_spec_vol_dp_wright
 !! a reference density, from salinity in practical salinity units ([PSU]), potential
 !! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
 !! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
-interface calculate_density_wright
+interface calculate_density_wright_full
   module procedure calculate_density_scalar_wright, calculate_density_array_wright
-end interface calculate_density_wright
+end interface calculate_density_wright_full
 
 !> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
 !! to a reference specific volume, from salinity in practical salinity units ([PSU]), potential
 !! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
 !! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
-interface calculate_spec_vol_wright
+interface calculate_spec_vol_wright_full
   module procedure calculate_spec_vol_scalar_wright, calculate_spec_vol_array_wright
-end interface calculate_spec_vol_wright
+end interface calculate_spec_vol_wright_full
 
 !> For a given thermodynamic state, return the derivatives of density with temperature and salinity
-interface calculate_density_derivs_wright
+interface calculate_density_derivs_wright_full
   module procedure calculate_density_derivs_scalar_wright, calculate_density_derivs_array_wright
-end interface calculate_density_derivs_wright
+end interface calculate_density_derivs_wright_full
 
 !> For a given thermodynamic state, return the second derivatives of density with various combinations
 !! of temperature, salinity, and pressure
-interface calculate_density_second_derivs_wright
+interface calculate_density_second_derivs_wright_full
   module procedure calculate_density_second_derivs_scalar_wright, calculate_density_second_derivs_array_wright
-end interface calculate_density_second_derivs_wright
+end interface calculate_density_second_derivs_wright_full
 
-!>@{ Parameters in the Wright equation of state using the  restricted range formula, which is a fit to the UNESCO
-!    equation of state for the restricted range: -2 < theta < 30 [degC], 28 < S < 38 [PSU], 0  < p < 5e7 [Pa].
+!>@{ Parameters in the Wright equation of state using the full range formula, which is a fit to the UNESCO
+!    equation of state for the full range: -2 < theta < 40 [degC], 0 < S < 40 [PSU], 0  < p < 1e8 [Pa].
 
-  ! Note that a0/a1 ~= 2028 [degC] ; a0/a2 ~= -6343 [PSU]
-  !           b0/b1 ~= 165 [degC]  ; b0/b4 ~= 974 [PSU]
-  !           c0/c1 ~= 216 [degC]  ; c0/c4 ~= -740 [PSU]
-real, parameter :: a0 = 7.057924e-4  ! A parameter in the Wright alpha_0 fit [m3 kg-1]
-real, parameter :: a1 = 3.480336e-7  ! A parameter in the Wright alpha_0 fit [m3 kg-1 degC-1]
-real, parameter :: a2 = -1.112733e-7 ! A parameter in the Wright alpha_0 fit [m3 kg-1 PSU-1]
-real, parameter :: b0 = 5.790749e8   ! A parameter in the Wright p_0 fit [Pa]
-real, parameter :: b1 = 3.516535e6   ! A parameter in the Wright p_0 fit [Pa degC-1]
-real, parameter :: b2 = -4.002714e4  ! A parameter in the Wright p_0 fit [Pa degC-2]
-real, parameter :: b3 = 2.084372e2   ! A parameter in the Wright p_0 fit [Pa degC-3]
-real, parameter :: b4 = 5.944068e5   ! A parameter in the Wright p_0 fit [Pa PSU-1]
-real, parameter :: b5 = -9.643486e3  ! A parameter in the Wright p_0 fit [Pa degC-1 PSU-1]
-real, parameter :: c0 = 1.704853e5   ! A parameter in the Wright lambda fit [m2 s-2]
-real, parameter :: c1 = 7.904722e2   ! A parameter in the Wright lambda fit [m2 s-2 degC-1]
-real, parameter :: c2 = -7.984422    ! A parameter in the Wright lambda fit [m2 s-2 degC-2]
-real, parameter :: c3 = 5.140652e-2  ! A parameter in the Wright lambda fit [m2 s-2 degC-3]
-real, parameter :: c4 = -2.302158e2  ! A parameter in the Wright lambda fit [m2 s-2 PSU-1]
-real, parameter :: c5 = -3.079464    ! A parameter in the Wright lambda fit [m2 s-2 degC-1 PSU-1]
+  ! Note that a0/a1 ~= 2618 [degC] ; a0/a2 ~= -4333 [PSU]
+  !           b0/b1 ~= 156 [degC]  ; b0/b4 ~= 974 [PSU]
+  !           c0/c1 ~= 216 [degC]  ; c0/c4 ~= -741 [PSU]
+real, parameter :: a0 = 7.133718e-4  ! A parameter in the Wright alpha_0 fit [m3 kg-1]
+real, parameter :: a1 = 2.724670e-7  ! A parameter in the Wright alpha_0 fit [m3 kg-1 degC-1]
+real, parameter :: a2 = -1.646582e-7 ! A parameter in the Wright alpha_0 fit [m3 kg-1 PSU-1]
+real, parameter :: b0 = 5.613770e8   ! A parameter in the Wright p_0 fit [Pa]
+real, parameter :: b1 = 3.600337e6   ! A parameter in the Wright p_0 fit [Pa degC-1]
+real, parameter :: b2 = -3.727194e4  ! A parameter in the Wright p_0 fit [Pa degC-2]
+real, parameter :: b3 = 1.660557e2   ! A parameter in the Wright p_0 fit [Pa degC-3]
+real, parameter :: b4 = 6.844158e5   ! A parameter in the Wright p_0 fit [Pa PSU-1]
+real, parameter :: b5 = -8.389457e3  ! A parameter in the Wright p_0 fit [Pa degC-1 PSU-1]
+real, parameter :: c0 = 1.609893e5   ! A parameter in the Wright lambda fit [m2 s-2]
+real, parameter :: c1 = 8.427815e2   ! A parameter in the Wright lambda fit [m2 s-2 degC-1]
+real, parameter :: c2 = -6.931554    ! A parameter in the Wright lambda fit [m2 s-2 degC-2]
+real, parameter :: c3 = 3.869318e-2  ! A parameter in the Wright lambda fit [m2 s-2 degC-3]
+real, parameter :: c4 = -1.664201e2  ! A parameter in the Wright lambda fit [m2 s-2 PSU-1]
+real, parameter :: c5 = -2.765195    ! A parameter in the Wright lambda fit [m2 s-2 degC-1 PSU-1]
 !>@}
 
 contains
@@ -381,7 +381,7 @@ end subroutine calculate_density_second_derivs_scalar_wright
 
 !> For a given thermodynamic state, return the partial derivatives of specific volume
 !! with temperature and salinity
-subroutine calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start, npts)
+subroutine calculate_specvol_derivs_wright_full(T, S, pressure, dSV_dT, dSV_dS, start, npts)
   real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
   real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
   real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
@@ -412,14 +412,14 @@ subroutine calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start
                 (I_denom**2 * lambda) *  (b4 + b5*T(j))
   enddo
 
-end subroutine calculate_specvol_derivs_wright
+end subroutine calculate_specvol_derivs_wright_full
 
 !> This subroutine computes the in situ density of sea water (rho in [kg m-3])
 !! and the compressibility (drho/dp = C_sound^-2) (drho_dp [s2 m-2]) from
 !! salinity (sal [PSU]), potential temperature (T [degC]), and pressure [Pa].
 !! It uses the expressions from Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
 !! Coded by R. Hallberg, 1/01
-subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
+subroutine calculate_compress_wright_full(T, S, pressure, rho, drho_dp, start, npts)
   real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
   real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
   real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
@@ -447,12 +447,12 @@ subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
     rho(j) = (pressure(j) + p0) * I_denom
     drho_dp(j) = lambda * I_denom * I_denom
   enddo
-end subroutine calculate_compress_wright
+end subroutine calculate_compress_wright_full
 
 !> This subroutine calculates analytical and nearly-analytical integrals of
 !! pressure anomalies across layers, which are required for calculating the
 !! finite-volume form pressure accelerations in a Boussinesq model.
-subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
+subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                  dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, &
                                  useMassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
   type(hor_index_type), intent(in)  :: HI       !< The horizontal index type for the arrays.
@@ -705,7 +705,7 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
     inty_dpa(i,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + 12.0*intz(3))
   enddo ; enddo ; endif
 
-end subroutine int_density_dz_wright
+end subroutine int_density_dz_wright_full
 
 !>   This subroutine calculates analytical and nearly-analytical integrals in
 !! pressure across layers of geopotential anomalies, which are required for
@@ -713,7 +713,7 @@ end subroutine int_density_dz_wright
 !! model.  There are essentially no free assumptions, apart from the use of
 !! Boole's rule to do the horizontal integrals, and from a truncation in the
 !! series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
-subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
+subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
                                   intp_dza, intx_dza, inty_dza, halo_size, bathyP, dP_neglect, &
                                   useMassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
   type(hor_index_type), intent(in)  :: HI        !< The ocean's horizontal index type.
@@ -945,6 +945,6 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
     inty_dza(i,j) = C1_90*(7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4)) + &
                            12.0*intp(3))
   enddo ; enddo ; endif
-end subroutine int_spec_vol_dp_wright
+end subroutine int_spec_vol_dp_wright_full
 
-end module MOM_EOS_Wright
+end module MOM_EOS_Wright_full

--- a/src/equation_of_state/MOM_EOS_Wright_full.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_full.F90
@@ -3,12 +3,6 @@ module MOM_EOS_Wright_full
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!***********************************************************************
-!*  The subroutines in this file implement the equation of state for   *
-!*  sea water using the formulae given by  Wright, 1997, J. Atmos.     *
-!*  Ocean. Tech., 14, 735-740.  Coded by R. Hallberg, 7/00.            *
-!***********************************************************************
-
 use MOM_hor_index, only : hor_index_type
 
 implicit none ; private
@@ -20,16 +14,10 @@ public calculate_density_derivs_wright_full, calculate_specvol_derivs_wright_ful
 public calculate_density_second_derivs_wright_full
 public int_density_dz_wright_full, int_spec_vol_dp_wright_full
 
-! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
-! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
-! their mks counterparts with notation like "a velocity [Z T-1 ~> m s-1]".  If the units
-! vary with the Boussinesq approximation, the Boussinesq variant is given first.
-
-
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
 !! a reference density, from salinity in practical salinity units ([PSU]), potential
 !! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
 interface calculate_density_wright_full
   module procedure calculate_density_scalar_wright, calculate_density_array_wright
 end interface calculate_density_wright_full
@@ -37,7 +25,7 @@ end interface calculate_density_wright_full
 !> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
 !! to a reference specific volume, from salinity in practical salinity units ([PSU]), potential
 !! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
 interface calculate_spec_vol_wright_full
   module procedure calculate_spec_vol_scalar_wright, calculate_spec_vol_array_wright
 end interface calculate_spec_vol_wright_full
@@ -78,10 +66,11 @@ real, parameter :: c5 = -2.765195    ! A parameter in the Wright lambda fit [m2 
 
 contains
 
-!> This subroutine computes the in situ density of sea water (rho in
-!! [kg m-3]) from salinity (S [PSU]), potential temperature
-!! (T [degC]), and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!> Computes the in situ density of sea water for scalar inputs and outputs.
+!!
+!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
+!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
 subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
   real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC].
   real,           intent(in)  :: S        !< Salinity [PSU].
@@ -89,14 +78,7 @@ subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
   real,           intent(out) :: rho      !< In situ density [kg m-3].
   real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
 
-! *====================================================================*
-! *  This subroutine computes the in situ density of sea water (rho in *
-! *  [kg m-3]) from salinity (S [PSU]), potential temperature          *
-! *  (T [degC]), and pressure [Pa].  It uses the expression from       *
-! *  Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.                *
-! *  Coded by R. Hallberg, 7/00                                        *
-! *====================================================================*
-
+  ! Local variables
   real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
   real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
   real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
@@ -111,10 +93,11 @@ subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
 
 end subroutine calculate_density_scalar_wright
 
-!> This subroutine computes the in situ density of sea water (rho in
-!! [kg m-3]) from salinity (S [PSU]), potential temperature
-!! (T [degC]), and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!> Computes the in situ density of sea water for 1-d array inputs and outputs.
+!!
+!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
+!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
 subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_ref)
   real, dimension(:), intent(in)    :: T        !< potential temperature relative to the surface [degC].
   real, dimension(:), intent(in)    :: S        !< salinity [PSU].
@@ -124,7 +107,6 @@ subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_
   integer,            intent(in)    :: npts     !< the number of values to calculate.
   real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3].
 
-  ! Original coded by R. Hallberg, 7/00, anomaly coded in 3/18.
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
@@ -155,10 +137,11 @@ subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_
 
 end subroutine calculate_density_array_wright
 
-!> This subroutine computes the in situ specific volume of sea water (specvol in
-!! [m3 kg-1]) from salinity (S [PSU]), potential temperature (T [degC])
-!! and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!> Computes the Wright in situ specific volume of sea water for scalar inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_scalar_wright(T, S, pressure, specvol, spv_ref)
   real,           intent(in)  :: T        !< potential temperature relative to the surface [degC].
@@ -179,10 +162,11 @@ subroutine calculate_spec_vol_scalar_wright(T, S, pressure, specvol, spv_ref)
   specvol = spv0(1)
 end subroutine calculate_spec_vol_scalar_wright
 
-!> This subroutine computes the in situ specific volume of sea water (specvol in
-!! [m3 kg-1]) from salinity (S [PSU]), potential temperature (T [degC])
-!! and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
+!> Computes the Wright in situ specific volume of sea water for 1-d array inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
 !! If spv_ref is present, specvol is an anomaly from spv_ref.
 subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts, spv_ref)
   real, dimension(:), intent(in)    :: T        !< potential temperature relative to the
@@ -213,7 +197,7 @@ subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts,
   enddo
 end subroutine calculate_spec_vol_array_wright
 
-!> For a given thermodynamic state, return the thermal/haline expansion coefficients
+!> Return the thermal/haline expansion coefficients for 1-d array inputs and outputs
 subroutine calculate_density_derivs_array_wright(T, S, pressure, drho_dT, drho_dS, start, npts)
   real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the
                                                    !! surface [degC].
@@ -250,8 +234,10 @@ subroutine calculate_density_derivs_array_wright(T, S, pressure, drho_dT, drho_d
 
 end subroutine calculate_density_derivs_array_wright
 
-!> The scalar version of calculate_density_derivs which promotes scalar inputs to a 1-element array and then
-!! demotes the output back to a scalar
+!> Return the thermal/haline expansion coefficients for scalar inputs and outputs
+!!
+!! The scalar version of calculate_density_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
 subroutine calculate_density_derivs_scalar_wright(T, S, pressure, drho_dT, drho_dS)
   real,    intent(in)  :: T        !< Potential temperature relative to the surface [degC].
   real,    intent(in)  :: S        !< Salinity [PSU].
@@ -277,7 +263,7 @@ subroutine calculate_density_derivs_scalar_wright(T, S, pressure, drho_dT, drho_
 
 end subroutine calculate_density_derivs_scalar_wright
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure
+!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
 subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                          drho_ds_dp, drho_dt_dp, start, npts)
   real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
@@ -337,8 +323,10 @@ subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drh
 
 end subroutine calculate_density_second_derivs_array_wright
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs. Inputs
-!! promoted to 1-element array and output demoted to scalar
+!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
+!!
+!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
 subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
                                                          drho_ds_dp, drho_dt_dp)
   real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
@@ -379,8 +367,8 @@ subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, dr
 
 end subroutine calculate_density_second_derivs_scalar_wright
 
-!> For a given thermodynamic state, return the partial derivatives of specific volume
-!! with temperature and salinity
+!> Return the partial derivatives of specific volume with temperature and salinity
+!! for 1-d array inputs and outputs
 subroutine calculate_specvol_derivs_wright_full(T, S, pressure, dSV_dT, dSV_dS, start, npts)
   real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
   real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
@@ -414,11 +402,7 @@ subroutine calculate_specvol_derivs_wright_full(T, S, pressure, dSV_dT, dSV_dS, 
 
 end subroutine calculate_specvol_derivs_wright_full
 
-!> This subroutine computes the in situ density of sea water (rho in [kg m-3])
-!! and the compressibility (drho/dp = C_sound^-2) (drho_dp [s2 m-2]) from
-!! salinity (sal [PSU]), potential temperature (T [degC]), and pressure [Pa].
-!! It uses the expressions from Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740.
-!! Coded by R. Hallberg, 1/01
+!> Computes the compressibility of seawater for 1-d array inputs and outputs
 subroutine calculate_compress_wright_full(T, S, pressure, rho, drho_dp, start, npts)
   real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
   real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
@@ -430,7 +414,6 @@ subroutine calculate_compress_wright_full(T, S, pressure, rho, drho_dp, start, n
   integer, intent(in)                  :: start    !< The starting point in the arrays.
   integer, intent(in)                  :: npts     !< The number of values to calculate.
 
-  ! Coded by R. Hallberg, 1/01
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
@@ -449,9 +432,11 @@ subroutine calculate_compress_wright_full(T, S, pressure, rho, drho_dp, start, n
   enddo
 end subroutine calculate_compress_wright_full
 
-!> This subroutine calculates analytical and nearly-analytical integrals of
-!! pressure anomalies across layers, which are required for calculating the
-!! finite-volume form pressure accelerations in a Boussinesq model.
+!> Calculates analytical and nearly-analytical integrals, in geopotential across layers, of pressure
+!! anomalies, which are required for calculating the finite-volume form pressure accelerations in a
+!! Boussinesq model.  There are essentially no free assumptions, apart from the use of Boole's rule
+!! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
+!! that assumes that |eps| < 0.34.
 subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                  dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, &
                                  useMassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
@@ -707,12 +692,11 @@ subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
 
 end subroutine int_density_dz_wright_full
 
-!>   This subroutine calculates analytical and nearly-analytical integrals in
-!! pressure across layers of geopotential anomalies, which are required for
-!! calculating the finite-volume form pressure accelerations in a non-Boussinesq
-!! model.  There are essentially no free assumptions, apart from the use of
-!! Boole's rule to do the horizontal integrals, and from a truncation in the
-!! series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
+!> Calculates analytical and nearly-analytical integrals, in pressure across layers, of geopotential
+!! anomalies, which are required for calculating the finite-volume form pressure accelerations in a
+!! non-Boussinesq model.  There are essentially no free assumptions, apart from the use of Boole's
+!! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
+!! that assumes that |eps| < 0.34.
 subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
                                   intp_dza, intx_dza, inty_dza, halo_size, bathyP, dP_neglect, &
                                   useMassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
@@ -946,5 +930,25 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
                            12.0*intp(3))
   enddo ; enddo ; endif
 end subroutine int_spec_vol_dp_wright_full
+
+!> \namespace mom_eos_wright_full
+!!
+!! \section section_EOS_Wright Wright equation of state
+!!
+!! Wright, 1997, provide an approximation for the in situ density as a function of
+!! potential temperature, salinity, and pressure. The formula follow the Tumlirz
+!! equation of state which are easier to evaluate and make efficient.
+!!
+!! Two ranges are provided by Wright: a "full" range and "reduced" range. The version in this
+!! module uses the full range.
+!!
+!! Originally coded in 2000 by R. Hallberg.
+!! Anomaly form coded in 3/18.
+!!
+!! \subsection section_EOS_Wright_references References
+!!
+!! Wright, D., 1997: An Equation of State for Use in Ocean Models: Eckart's Formula Revisited.
+!! J. Ocean. Atmosph. Tech., 14 (3), 735-740.
+!! https://journals.ametsoc.org/doi/abs/10.1175/1520-0426%281997%29014%3C0735%3AAEOSFU%3E2.0.CO%3B2
 
 end module MOM_EOS_Wright_full

--- a/src/equation_of_state/MOM_EOS_Wright_full.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_full.F90
@@ -7,8 +7,6 @@ use MOM_hor_index, only : hor_index_type
 
 implicit none ; private
 
-#include <MOM_memory.h>
-
 public calculate_compress_wright_full, calculate_density_wright_full, calculate_spec_vol_wright_full
 public calculate_density_derivs_wright_full, calculate_specvol_derivs_wright_full
 public calculate_density_second_derivs_wright_full, EoS_fit_range_Wright_full

--- a/src/equation_of_state/MOM_EOS_Wright_red.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_red.F90
@@ -7,8 +7,6 @@ use MOM_hor_index, only : hor_index_type
 
 implicit none ; private
 
-#include <MOM_memory.h>
-
 public calculate_compress_wright_red, calculate_density_wright_red, calculate_spec_vol_wright_red
 public calculate_density_derivs_wright_red, calculate_specvol_derivs_wright_red
 public calculate_density_second_derivs_wright_red, EoS_fit_range_Wright_red

--- a/src/equation_of_state/MOM_EOS_Wright_red.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_red.F90
@@ -1,0 +1,963 @@
+!> The equation of state using the Wright 1997 expressions
+module MOM_EOS_Wright_red
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_hor_index, only : hor_index_type
+
+implicit none ; private
+
+#include <MOM_memory.h>
+
+public calculate_compress_wright_red, calculate_density_wright_red, calculate_spec_vol_wright_red
+public calculate_density_derivs_wright_red, calculate_specvol_derivs_wright_red
+public calculate_density_second_derivs_wright_red
+public int_density_dz_wright_red, int_spec_vol_dp_wright_red
+
+!> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
+!! a reference density, from salinity in practical salinity units ([PSU]), potential
+!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
+interface calculate_density_wright_red
+  module procedure calculate_density_scalar_wright, calculate_density_array_wright
+end interface calculate_density_wright_red
+
+!> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
+!! to a reference specific volume, from salinity in practical salinity units ([PSU]), potential
+!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
+interface calculate_spec_vol_wright_red
+  module procedure calculate_spec_vol_scalar_wright, calculate_spec_vol_array_wright
+end interface calculate_spec_vol_wright_red
+
+!> Compute the derivatives of density with temperature and salinity
+interface calculate_density_derivs_wright_red
+  module procedure calculate_density_derivs_scalar_wright, calculate_density_derivs_array_wright
+end interface calculate_density_derivs_wright_red
+
+!> Compute the second derivatives of density with various combinations
+!! of temperature, salinity, and pressure
+interface calculate_density_second_derivs_wright_red
+  module procedure calculate_density_second_derivs_scalar_wright, calculate_density_second_derivs_array_wright
+end interface calculate_density_second_derivs_wright_red
+
+!>@{ Parameters in the Wright equation of state using the reduced range formula, which is a fit to the UNESCO
+!    equation of state for the restricted range: -2 < theta < 30 [degC], 28 < S < 38 [PSU], 0  < p < 5e7 [Pa].
+
+  ! Note that a0/a1 ~= 2028 [degC] ; a0/a2 ~= -6343 [PSU]
+  !           b0/b1 ~= 165 [degC]  ; b0/b4 ~= 974 [PSU]
+  !           c0/c1 ~= 216 [degC]  ; c0/c4 ~= -740 [PSU]
+real, parameter :: a0 = 7.057924e-4  ! A parameter in the Wright alpha_0 fit [m3 kg-1]
+real, parameter :: a1 = 3.480336e-7  ! A parameter in the Wright alpha_0 fit [m3 kg-1 degC-1]
+real, parameter :: a2 = -1.112733e-7 ! A parameter in the Wright alpha_0 fit [m3 kg-1 PSU-1]
+real, parameter :: b0 = 5.790749e8   ! A parameter in the Wright p_0 fit [Pa]
+real, parameter :: b1 = 3.516535e6   ! A parameter in the Wright p_0 fit [Pa degC-1]
+real, parameter :: b2 = -4.002714e4  ! A parameter in the Wright p_0 fit [Pa degC-2]
+real, parameter :: b3 = 2.084372e2   ! A parameter in the Wright p_0 fit [Pa degC-3]
+real, parameter :: b4 = 5.944068e5   ! A parameter in the Wright p_0 fit [Pa PSU-1]
+real, parameter :: b5 = -9.643486e3  ! A parameter in the Wright p_0 fit [Pa degC-1 PSU-1]
+real, parameter :: c0 = 1.704853e5   ! A parameter in the Wright lambda fit [m2 s-2]
+real, parameter :: c1 = 7.904722e2   ! A parameter in the Wright lambda fit [m2 s-2 degC-1]
+real, parameter :: c2 = -7.984422    ! A parameter in the Wright lambda fit [m2 s-2 degC-2]
+real, parameter :: c3 = 5.140652e-2  ! A parameter in the Wright lambda fit [m2 s-2 degC-3]
+real, parameter :: c4 = -2.302158e2  ! A parameter in the Wright lambda fit [m2 s-2 PSU-1]
+real, parameter :: c5 = -3.079464    ! A parameter in the Wright lambda fit [m2 s-2 degC-1 PSU-1]
+!>@}
+
+contains
+
+!> Computes the in situ density of sea water for scalar inputs and outputs.
+!!
+!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
+!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
+subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
+  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC].
+  real,           intent(in)  :: S        !< Salinity [PSU].
+  real,           intent(in)  :: pressure !< pressure [Pa].
+  real,           intent(out) :: rho      !< In situ density [kg m-3].
+  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
+
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
+  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: rho0  ! A 1-d array with a copy of the density [kg m-3]
+
+  T0(1) = T
+  S0(1) = S
+  pressure0(1) = pressure
+
+  call calculate_density_array_wright(T0, S0, pressure0, rho0, 1, 1, rho_ref)
+  rho = rho0(1)
+
+end subroutine calculate_density_scalar_wright
+
+!> Computes the in situ density of sea water for 1-d array inputs and outputs.
+!!
+!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
+!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
+subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_ref)
+  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the surface [degC].
+  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
+  real, dimension(:), intent(in)    :: pressure !< pressure [Pa].
+  real, dimension(:), intent(inout) :: rho      !< in situ density [kg m-3].
+  integer,            intent(in)    :: start    !< the starting point in the arrays.
+  integer,            intent(in)    :: npts     !< the number of values to calculate.
+  real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3].
+
+  ! Local variables
+  real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
+  real :: p0      ! The pressure offset in the Wright EOS [Pa]
+  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
+  real :: al_TS   ! The contributions of temperature and salinity to al0 [m3 kg-1]
+  real :: p_TSp   ! A combination of the pressure and the temperature and salinity contributions to p0 [Pa]
+  real :: lam_TS  ! The contributions of temperature and salinity to lambda [m2 s-2]
+  real :: pa_000  ! A corrected offset to the pressure, including contributions from rho_ref [Pa]
+  integer :: j
+
+  if (present(rho_ref)) pa_000 = b0*(1.0 - a0*rho_ref) - rho_ref*c0
+  if (present(rho_ref)) then ; do j=start,start+npts-1
+    al_TS = a1*T(j) + a2*S(j)
+    al0 = a0 + al_TS
+    p_TSp = pressure(j) + (b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))))
+    lam_TS = c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j)))
+
+    ! The following two expressions are mathematically equivalent.
+    ! rho(j) = (b0 + p0_TSp) / ((c0 + lam_TS) + al0*(b0 + p0_TSp)) - rho_ref
+    rho(j) = (pa_000 + (p_TSp - rho_ref*(p_TSp*al0 + (b0*al_TS + lam_TS)))) / &
+             ( (c0 + lam_TS) + al0*(b0 + p_TSp) )
+  enddo ; else ; do j=start,start+npts-1
+    al0 = a0 + (a1*T(j) + a2*S(j))
+    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
+    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+    rho(j) = (pressure(j) + p0) / (lambda + al0*(pressure(j) + p0))
+  enddo ; endif
+
+end subroutine calculate_density_array_wright
+
+!> Computes the Wright in situ specific volume of sea water for scalar inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
+!! If spv_ref is present, specvol is an anomaly from spv_ref.
+subroutine calculate_spec_vol_scalar_wright(T, S, pressure, specvol, spv_ref)
+  real,           intent(in)  :: T        !< potential temperature relative to the surface [degC].
+  real,           intent(in)  :: S        !< salinity [PSU].
+  real,           intent(in)  :: pressure !< pressure [Pa].
+  real,           intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
+  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
+
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
+  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
+
+  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
+
+  call calculate_spec_vol_array_wright(T0, S0, pressure0, spv0, 1, 1, spv_ref)
+  specvol = spv0(1)
+end subroutine calculate_spec_vol_scalar_wright
+
+!> Computes the Wright in situ specific volume of sea water for 1-d array inputs and outputs.
+!!
+!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
+!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
+!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
+!! If spv_ref is present, specvol is an anomaly from spv_ref.
+subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts, spv_ref)
+  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the
+                                                !! surface [degC].
+  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
+  real, dimension(:), intent(in)    :: pressure !< pressure [Pa].
+  real, dimension(:), intent(inout) :: specvol  !< in situ specific volume [m3 kg-1].
+  integer,            intent(in)    :: start    !< the starting point in the arrays.
+  integer,            intent(in)    :: npts     !< the number of values to calculate.
+  real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1].
+
+  ! Local variables
+  real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
+  real :: p0      ! The pressure offset in the Wright EOS [Pa]
+  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
+  integer :: j
+
+  do j=start,start+npts-1
+    al0 = a0 + (a1*T(j) + a2*S(j))
+    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
+    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+
+    if (present(spv_ref)) then
+      specvol(j) = (lambda + (al0 - spv_ref)*(pressure(j) + p0)) / (pressure(j) + p0)
+    else
+      specvol(j) = (lambda + al0*(pressure(j) + p0)) / (pressure(j) + p0)
+    endif
+  enddo
+end subroutine calculate_spec_vol_array_wright
+
+!> Return the thermal/haline expansion coefficients for 1-d array inputs and outputs
+subroutine calculate_density_derivs_array_wright(T, S, pressure, drho_dT, drho_dS, start, npts)
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the
+                                                   !! surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
+  real,    intent(inout), dimension(:) :: drho_dT  !< The partial derivative of density with potential
+                                                   !! temperature [kg m-3 degC-1].
+  real,    intent(inout), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
+                                                   !! in [kg m-3 PSU-1].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
+
+  ! Local variables
+  real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
+  real :: p0      ! The pressure offset in the Wright EOS [Pa]
+  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
+  real :: I_denom2 ! The inverse of the square of the denominator of density in the Wright EOS [s4 m-4]
+  integer :: j
+
+  do j=start,start+npts-1
+    al0 = a0 + (a1*T(j) + a2*S(j))
+    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
+    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+
+    I_denom2 = 1.0 / (lambda + al0*(pressure(j) + p0))**2
+    drho_dT(j) = I_denom2 * (lambda * (b1 + (T(j)*(2.0*b2 + 3.0*b3*T(j)) + b5*S(j))) - &
+       (pressure(j)+p0) * ( (pressure(j)+p0)*a1 + (c1 + (T(j)*(c2*2.0 + c3*3.0*T(j)) + c5*S(j))) ))
+    drho_dS(j) = I_denom2 * (lambda * (b4 + b5*T(j)) - &
+       (pressure(j)+p0) * ( (pressure(j)+p0)*a2 + (c4 + c5*T(j)) ))
+  enddo
+
+end subroutine calculate_density_derivs_array_wright
+
+!> Return the thermal/haline expansion coefficients for scalar inputs and outputs
+!!
+!! The scalar version of calculate_density_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
+subroutine calculate_density_derivs_scalar_wright(T, S, pressure, drho_dT, drho_dS)
+  real,    intent(in)  :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in)  :: S        !< Salinity [PSU].
+  real,    intent(in)  :: pressure !< pressure [Pa].
+  real,    intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                   !! temperature [kg m-3 degC-1].
+  real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                   !! in [kg m-3 PSU-1].
+
+  ! Local variables needed to promote the input/output scalars to 1-element arrays
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
+  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: drdt0 ! The derivative of density with temperature [kg m-3 degC-1]
+  real, dimension(1) :: drds0 ! The derivative of density with salinity [kg m-3 PSU-1]
+
+  T0(1) = T
+  S0(1) = S
+  P0(1) = pressure
+  call calculate_density_derivs_array_wright(T0, S0, P0, drdt0, drds0, 1, 1)
+  drho_dT = drdt0(1)
+  drho_dS = drds0(1)
+
+end subroutine calculate_density_derivs_scalar_wright
+
+!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
+subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+                                                         drho_ds_dp, drho_dt_dp, start, npts)
+  real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
+  real, dimension(:), intent(in   ) :: S !< Salinity [PSU]
+  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
+  real, dimension(:), intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+                                                  !! to S [kg m-3 PSU-2]
+  real, dimension(:), intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+                                                  !! to T [kg m-3 PSU-1 degC-1]
+  real, dimension(:), intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                                  !! to T [kg m-3 degC-2]
+  real, dimension(:), intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+                                                  !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real, dimension(:), intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                                  !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  integer,            intent(in   ) :: start !< Starting index in T,S,P
+  integer,            intent(in   ) :: npts  !< Number of points to loop over
+
+  ! Local variables
+  real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
+  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
+  real :: p_p0    ! A local work variable combining the pressure and pressure
+                  ! offset (p0 elsewhere) in the Wright EOS [Pa]
+  real :: dp0_dT  ! The partial derivative of p0 with temperature [Pa degC-1]
+  real :: dp0_dS  ! The partial derivative of p0 with salinity [Pa PSU-1]
+  real :: dlam_dT ! The partial derivative of lambda with temperature [m2 s-2 degC-1]
+  real :: dlam_dS ! The partial derivative of lambda with salinity [m2 s-2 degC-1]
+  real :: dRdT_num  ! The numerator in the expression for drho_dT [Pa m2 s-2 degC-1] = [kg m s-4 degC-1]
+  real :: dRdS_num  ! The numerator in the expression for drho_ds [Pa m2 s-2 PSU-1] = [kg m s-4 PSU-1]
+  real :: ddenom_dT ! The derivative of the denominator of density in the Wright EOS with temperature [m2 s-2 deg-1]
+  real :: ddenom_dS ! The derivative of the denominator of density in the Wright EOS with salinity [m2 s-2 PSU-1]
+  real :: I_denom   ! The inverse of the denominator of density in the Wright EOS [s2 m-2]
+  real :: I_denom2  ! The inverse of the square of the denominator of density in the Wright EOS [s4 m-4]
+  real :: I_denom3  ! The inverse of the cube of the denominator of density in the Wright EOS [s6 m-6]
+  integer :: j
+
+  do j = start,start+npts-1
+    al0 = a0 + (a1*T(j) + a2*S(j))
+    p_p0 = P(j) + ( b0 + (b4*S(j) + T(j)*(b1 + (b5*S(j) + T(j)*(b2 + b3*T(j))))) ) ! P + p0
+    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+    dp0_dT = b1 + (b5*S(j) + T(j)*(2.*b2 + 3.*b3*T(j)))
+    dp0_dS = b4 + b5*T(j)
+    dlam_dT = c1 + (c5*S(j) + T(j)*(2.*c2 + 3.*c3*T(j)))
+    dlam_dS = c4 + c5*T(j)
+    I_denom = 1.0 / (lambda + al0*p_p0)
+    I_denom2 = I_denom*I_denom
+    I_denom3 = I_denom*I_denom2
+
+    ddenom_dS = (dlam_dS + a2*p_p0) + al0*dp0_dS
+    ddenom_dT = (dlam_dT + a1*p_p0) + al0*dp0_dT
+    dRdS_num = dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)
+    dRdT_num = dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)
+
+    ! In deriving the following, it is useful to note that:
+    !   rho(j) = p_p0 / (lambda + al0*p_p0)
+    !   drho_dp(j) = lambda * I_denom2
+    !   drho_dT(j) = (dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)) * I_denom2 = dRdT_num * I_denom2
+    !   drho_dS(j) = (dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)) * I_denom2 = dRdS_num * I_denom2
+    drho_ds_ds(j) = -2.*(p_p0*(a2*dp0_dS)) * I_denom2 - 2.*(dRdS_num*ddenom_dS) * I_denom3
+    drho_ds_dt(j) = ((b5*lambda - p_p0*(c5 + 2.*a2*dp0_dT)) + (dp0_dS*dlam_dT - dp0_dT*dlam_dS))*I_denom2 - &
+                    2.*(ddenom_dT*dRdS_num) * I_denom3
+    drho_dt_dt(j) = 2.*((b2 + 3.*b3*T(j))*lambda - p_p0*((c2 + 3.*c3*T(j)) + a1*dp0_dT))*I_denom2 - &
+                    2.*(dRdT_num * ddenom_dT) * I_denom3
+
+    ! The following is a rearranged form that is equivalent to
+    ! drho_ds_dp(j) = dlam_dS * I_denom2 - 2.0 * lambda * (dlam_dS + a2*p_p0 + al0*dp0_ds) * Idenom3
+    drho_ds_dp(j) = (-dlam_dS - 2.*a2*p_p0) * I_denom2 - (2.*al0*dRdS_num) * I_denom3
+    drho_dt_dp(j) = (-dlam_dT - 2.*a1*p_p0) * I_denom2 - (2.*al0*dRdT_num) * I_denom3
+  enddo
+
+end subroutine calculate_density_second_derivs_array_wright
+
+!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
+!!
+!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
+!! and then demotes the output back to a scalar
+subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
+                                                         drho_ds_dp, drho_dt_dp)
+  real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
+  real, intent(in   ) :: S          !< Salinity [PSU]
+  real, intent(in   ) :: P          !< pressure [Pa]
+  real, intent(  out) :: drho_ds_ds !< Partial derivative of beta with respect
+                                    !! to S [kg m-3 PSU-2]
+  real, intent(  out) :: drho_ds_dt !< Partial derivative of beta with respect
+                                    !! to T [kg m-3 PSU-1 degC-1]
+  real, intent(  out) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                    !! to T [kg m-3 degC-2]
+  real, intent(  out) :: drho_ds_dp !< Partial derivative of beta with respect
+                                    !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real, intent(  out) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                    !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  ! Local variables
+  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
+  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
+  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
+  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 PSU-2]
+  real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
+                               ! temperature [kg m-3 PSU-1 degC-1]
+  real, dimension(1) :: drdtdt ! The second derivative of density with temperature [kg m-3 degC-2]
+  real, dimension(1) :: drdsdp ! The second derivative of density with salinity and
+                               ! pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real, dimension(1) :: drdtdp ! The second derivative of density with temperature and
+                               ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+
+  T0(1) = T
+  S0(1) = S
+  P0(1) = P
+  call calculate_density_second_derivs_array_wright(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
+  drho_ds_ds = drdsds(1)
+  drho_ds_dt = drdsdt(1)
+  drho_dt_dt = drdtdt(1)
+  drho_ds_dp = drdsdp(1)
+  drho_dt_dp = drdtdp(1)
+
+end subroutine calculate_density_second_derivs_scalar_wright
+
+!> Return the partial derivatives of specific volume with temperature and salinity
+!! for 1-d array inputs and outputs
+subroutine calculate_specvol_derivs_wright_red(T, S, pressure, dSV_dT, dSV_dS, start, npts)
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
+  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
+                                                   !! potential temperature [m3 kg-1 degC-1].
+  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
+                                                   !! salinity [m3 kg-1 PSU-1].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
+
+  ! Local variables
+  real :: p0      ! The pressure offset in the Wright EOS [Pa]
+  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
+  real :: I_denom ! The inverse of the denominator of specific volume in the Wright EOS [Pa-1]
+  integer :: j
+
+  do j=start,start+npts-1
+!    al0 = a0 + (a1*T(j) + a2*S(j))
+    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
+    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+
+    ! SV = al0 + lambda / (pressure(j) + p0)
+
+    I_denom = 1.0 / (pressure(j) + p0)
+    dSV_dT(j) = a1 + I_denom * ((c1 + (T(j)*(2.0*c2 + 3.0*c3*T(j)) + c5*S(j))) - &
+                                (I_denom * lambda) * (b1 + (T(j)*(2.0*b2 + 3.0*b3*T(j)) + b5*S(j))))
+    dSV_dS(j) = a2 + I_denom * ((c4 + c5*T(j)) - &
+                                (I_denom * lambda) * (b4 + b5*T(j)))
+  enddo
+
+end subroutine calculate_specvol_derivs_wright_red
+
+!> Computes the compressibility of seawater for 1-d array inputs and outputs
+subroutine calculate_compress_wright_red(T, S, pressure, rho, drho_dp, start, npts)
+  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
+  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
+  real,    intent(inout), dimension(:) :: rho      !< In situ density [kg m-3].
+  real,    intent(inout), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
+                                                   !! (also the inverse of the square of sound speed)
+                                                   !! [s2 m-2].
+  integer, intent(in)                  :: start    !< The starting point in the arrays.
+  integer, intent(in)                  :: npts     !< The number of values to calculate.
+
+  ! Local variables
+  real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
+  real :: p0      ! The pressure offset in the Wright EOS [Pa]
+  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
+  real :: I_denom ! The inverse of the denominator of density in the Wright EOS [s2 m-2]
+  integer :: j
+
+  do j=start,start+npts-1
+    al0 = a0 + (a1*T(j) + a2*S(j))
+    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
+    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+
+    I_denom = 1.0 / (lambda + al0*(pressure(j) + p0))
+    rho(j) = (pressure(j) + p0) * I_denom
+    drho_dp(j) = lambda * I_denom**2
+  enddo
+end subroutine calculate_compress_wright_red
+
+!> Calculates analytical and nearly-analytical integrals, in geopotential across layers, of pressure
+!! anomalies, which are required for calculating the finite-volume form pressure accelerations in a
+!! Boussinesq model.  There are essentially no free assumptions, apart from the use of Boole's rule
+!! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
+!! that assumes that |eps| < 0.34.
+subroutine int_density_dz_wright_red(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
+                                 dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, &
+                                 useMassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
+  type(hor_index_type), intent(in)  :: HI       !< The horizontal index type for the arrays.
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: T        !< Potential temperature relative to the surface
+                                                !! [C ~> degC].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: S        !< Salinity [S ~> PSU].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: z_t      !< Height at the top of the layer in depth units [Z ~> m].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: z_b      !< Height at the top of the layer [Z ~> m].
+  real,                 intent(in)  :: rho_ref  !< A mean density [R ~> kg m-3], that is subtracted
+                                                !! out to reduce the magnitude of each of the integrals.
+                                                !! (The pressure is calculated as p~=-z*rho_0*G_e.)
+  real,                 intent(in)  :: rho_0    !< Density [R ~> kg m-3], that is used
+                                                !! to calculate the pressure (as p~=-z*rho_0*G_e)
+                                                !! used in the equation of state.
+  real,                 intent(in)  :: G_e      !< The Earth's gravitational acceleration
+                                                !! [L2 Z-1 T-2 ~> m s-2].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(inout) :: dpa    !< The change in the pressure anomaly across the
+                                                !! layer [R L2 T-2 ~> Pa].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(inout) :: intz_dpa !< The integral through the thickness of the layer
+                                                !! of the pressure anomaly relative to the anomaly
+                                                !! at the top of the layer [R Z L2 T-2 ~> Pa m].
+  real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), &
+              optional, intent(inout) :: intx_dpa !< The integral in x of the difference between the
+                                                !! pressure anomaly at the top and bottom of the
+                                                !! layer divided by the x grid spacing [R L2 T-2 ~> Pa].
+  real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), &
+              optional, intent(inout) :: inty_dpa !< The integral in y of the difference between the
+                                                !! pressure anomaly at the top and bottom of the
+                                                !! layer divided by the y grid spacing [R L2 T-2 ~> Pa].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(in)  :: bathyT   !< The depth of the bathymetry [Z ~> m].
+  real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m].
+  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
+                                                !! interpolate T/S for top and bottom integrals.
+  real,       optional, intent(in)  :: rho_scale !< A multiplicative factor by which to scale density
+                                                 !! from kg m-3 to the desired units [R m3 kg-1 ~> 1]
+  real,       optional, intent(in)  :: pres_scale !< A multiplicative factor to convert pressure
+                                                 !! into Pa [Pa T2 R-1 L-2 ~> 1].
+  real,       optional, intent(in)  :: temp_scale  !< A multiplicative factor by which to scale
+                            !! temperature into degC [degC C-1 ~> 1]
+  real,       optional, intent(in)  :: saln_scale !< A multiplicative factor to convert pressure
+                            !! into PSU [PSU S-1 ~> 1].
+  real,       optional, intent(in)  :: Z_0p      !< The height at which the pressure is 0 [Z ~> m]
+
+  ! Local variables
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed) :: al0_2d ! A term in the Wright EOS [m3 kg-1]
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed) :: p0_2d  ! A term in the Wright EOS [Pa]
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed) :: lambda_2d ! A term in the Wright EOS [m2 s-2]
+  real :: al0        ! A term in the Wright EOS [m3 kg-1]
+  real :: p0         ! A term in the Wright EOS [Pa]
+  real :: lambda     ! A term in the Wright EOS [m2 s-2]
+  real :: rho_anom   ! The density anomaly from rho_ref [kg m-3].
+  real :: eps, eps2  ! A nondimensional ratio and its square [nondim]
+  real :: rem        ! [kg m-1 s-2]
+  real :: GxRho      ! The gravitational acceleration times density and unit conversion factors [Pa Z-1 ~> kg m-2 s-2]
+  real :: g_Earth    ! The gravitational acceleration [m2 Z-1 s-2 ~> m s-2]
+  real :: I_Rho      ! The inverse of the Boussinesq density [m3 kg-1]
+  real :: rho_ref_mks ! The reference density in MKS units [kg m-3]
+  real :: p_ave      ! The layer averaged pressure [Pa]
+  real :: I_al0      ! The inverse of al0 [kg m-3]
+  real :: I_Lzz      ! The inverse of the denominator [Pa-1]
+  real :: dz         ! The layer thickness [Z ~> m].
+  real :: hWght      ! A pressure-thickness below topography [Z ~> m].
+  real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [Z ~> m].
+  real :: iDenom     ! The inverse of the denominator in the weights [Z-2 ~> m-2].
+  real :: hWt_LL, hWt_LR ! hWt_LA is the weighted influence of A on the left column [nondim].
+  real :: hWt_RL, hWt_RR ! hWt_RA is the weighted influence of A on the right column [nondim].
+  real :: wt_L, wt_R ! The linear weights of the left and right columns [nondim].
+  real :: wtT_L, wtT_R ! The weights for tracers from the left and right columns [nondim].
+  real :: intz(5)    ! The gravitational acceleration times the integrals of density
+                     ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa].
+  real :: Pa_to_RL2_T2 ! A conversion factor of pressures from Pa to the output units indicated by
+                       ! pres_scale [R L2 T-2 Pa-1 ~> 1].
+  real :: z0pres     ! The height at which the pressure is zero [Z ~> m]
+  real :: a1s        ! Partly rescaled version of a1 [m3 kg-1 C-1 ~> m3 kg-1 degC-1]
+  real :: a2s        ! Partly rescaled version of a2 [m3 kg-1 S-1 ~> m3 kg-1 PSU-1]
+  real :: b1s        ! Partly rescaled version of b1 [Pa C-1 ~> Pa degC-1]
+  real :: b2s        ! Partly rescaled version of b2 [Pa C-2 ~> Pa degC-2]
+  real :: b3s        ! Partly rescaled version of b3 [Pa C-3 ~> Pa degC-3]
+  real :: b4s        ! Partly rescaled version of b4 [Pa S-1 ~> Pa PSU-1]
+  real :: b5s        ! Partly rescaled version of b5 [Pa C-1 S-1 ~> Pa degC-1 PSU-1]
+  real :: c1s        ! Partly rescaled version of c1 [m2 s-2 C-1 ~> m2 s-2 degC-1]
+  real :: c2s        ! Partly rescaled version of c2 [m2 s-2 C-2 ~> m2 s-2 degC-2]
+  real :: c3s        ! Partly rescaled version of c3 [m2 s-2 C-3 ~> m2 s-2 degC-3]
+  real :: c4s        ! Partly rescaled version of c4 [m2 s-2 S-1 ~> m2 s-2 PSU-1]
+  real :: c5s        ! Partly rescaled version of c5 [m2 s-2 C-1 S-1 ~> m2 s-2 degC-1 PSU-1]
+  logical :: do_massWeight ! Indicates whether to do mass weighting.
+  real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants [nondim]
+  real, parameter :: C1_9 = 1.0/9.0, C1_90 = 1.0/90.0  ! Rational constants [nondim]
+  integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j, m
+
+  ! These array bounds work for the indexing convention of the input arrays, but
+  ! on the computational domain defined for the output arrays.
+  Isq = HI%IscB ; Ieq = HI%IecB
+  Jsq = HI%JscB ; Jeq = HI%JecB
+  is = HI%isc ; ie = HI%iec
+  js = HI%jsc ; je = HI%jec
+
+  if (present(pres_scale)) then
+    GxRho = pres_scale * G_e * rho_0 ; g_Earth = pres_scale * G_e
+    Pa_to_RL2_T2 = 1.0 / pres_scale
+  else
+    GxRho = G_e * rho_0 ; g_Earth = G_e
+    Pa_to_RL2_T2 = 1.0
+  endif
+  if (present(rho_scale)) then
+    g_Earth = g_Earth * rho_scale
+    rho_ref_mks = rho_ref / rho_scale ; I_Rho = rho_scale / rho_0
+  else
+    rho_ref_mks = rho_ref ; I_Rho = 1.0 / rho_0
+  endif
+  z0pres = 0.0 ; if (present(Z_0p)) z0pres = Z_0p
+
+  a1s = a1 ; a2s = a2
+  b1s = b1 ; b2s = b2 ; b3s = b3 ; b4s = b4 ; b5s = b5
+  c1s = c1 ; c2s = c2 ; c3s = c3 ; c4s = c4 ; c5s = c5
+
+  if (present(temp_scale)) then ; if (temp_scale /= 1.0) then
+    a1s = a1s * temp_scale
+    b1s = b1s * temp_scale    ; b2s = b2s * temp_scale**2
+    b3s = b3s * temp_scale**3 ; b5s = b5s * temp_scale
+    c1s = c1s * temp_scale    ; c2s = c2s * temp_scale**2
+    c3s = c3s * temp_scale**3 ; c5s = c5s * temp_scale
+  endif ; endif
+
+  if (present(saln_scale)) then ; if (saln_scale /= 1.0) then
+    a2s = a2s * saln_scale
+    b4s = b4s * saln_scale ; b5s = b5s * saln_scale
+    c4s = c4s * saln_scale ; c5s = c5s * saln_scale
+  endif ; endif
+
+  do_massWeight = .false.
+  if (present(useMassWghtInterp)) then ; if (useMassWghtInterp) then
+    do_massWeight = .true.
+  ! if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
+  !     "bathyT must be present if useMassWghtInterp is present and true.")
+  ! if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
+  !     "dz_neglect must be present if useMassWghtInterp is present and true.")
+  endif ; endif
+
+  do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    al0_2d(i,j) = a0 + (a1s*T(i,j) + a2s*S(i,j))
+    p0_2d(i,j) = b0 + ( b4s*S(i,j) + T(i,j) * (b1s + (T(i,j)*(b2s + b3s*T(i,j)) + b5s*S(i,j))) )
+    lambda_2d(i,j) = c0 + ( c4s*S(i,j) + T(i,j) * (c1s + (T(i,j)*(c2s + c3s*T(i,j)) + c5s*S(i,j))) )
+
+    al0 = al0_2d(i,j) ; p0 = p0_2d(i,j) ; lambda = lambda_2d(i,j)
+
+    dz = z_t(i,j) - z_b(i,j)
+    p_ave = -GxRho*(0.5*(z_t(i,j)+z_b(i,j)) - z0pres)
+
+    I_al0 = 1.0 / al0
+    I_Lzz = 1.0 / ((p0 + p_ave) + lambda * I_al0)
+    eps = 0.5*(GxRho*dz)*I_Lzz ; eps2 = eps*eps
+
+!     rho(j) = (pressure(j) + p0) / (lambda + al0*(pressure(j) + p0))
+
+    rho_anom = (p0 + p_ave)*(I_Lzz*I_al0) - rho_ref_mks
+    rem = (I_Rho * (lambda * I_al0**2)) * (eps2 * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2))))
+    dpa(i,j) = Pa_to_RL2_T2 * ((g_Earth*rho_anom)*dz - 2.0*eps*rem)
+    if (present(intz_dpa)) &
+      intz_dpa(i,j) = Pa_to_RL2_T2 * (0.5*(g_Earth*rho_anom)*dz**2 - dz*((1.0+eps)*rem))
+  enddo ; enddo
+
+  if (present(intx_dpa)) then ; do j=js,je ; do I=Isq,Ieq
+    ! hWght is the distance measure by which the cell is violation of
+    ! hydrostatic consistency. For large hWght we bias the interpolation of
+    ! T & S along the top and bottom integrals, akin to thickness weighting.
+    hWght = 0.0
+    if (do_massWeight) &
+      hWght = max(0., -bathyT(i,j)-z_t(i+1,j), -bathyT(i+1,j)-z_t(i,j))
+    if (hWght > 0.) then
+      hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
+      hR = (z_t(i+1,j) - z_b(i+1,j)) + dz_neglect
+      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+    else
+      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
+    endif
+
+    intz(1) = dpa(i,j) ; intz(5) = dpa(i+1,j)
+    do m=2,4
+      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+
+      al0 = wtT_L*al0_2d(i,j) + wtT_R*al0_2d(i+1,j)
+      p0 = wtT_L*p0_2d(i,j) + wtT_R*p0_2d(i+1,j)
+      lambda = wtT_L*lambda_2d(i,j) + wtT_R*lambda_2d(i+1,j)
+
+      dz = wt_L*(z_t(i,j) - z_b(i,j)) + wt_R*(z_t(i+1,j) - z_b(i+1,j))
+      p_ave = -GxRho*(0.5*(wt_L*(z_t(i,j)+z_b(i,j)) + wt_R*(z_t(i+1,j)+z_b(i+1,j))) - z0pres)
+
+      I_al0 = 1.0 / al0
+      I_Lzz = 1.0 / ((p0 + p_ave) + lambda * I_al0)
+      eps = 0.5*(GxRho*dz)*I_Lzz ; eps2 = eps*eps
+
+      intz(m) = Pa_to_RL2_T2 * ( (g_Earth*dz) * ((p0 + p_ave)*(I_Lzz*I_al0) - rho_ref_mks) - 2.0*eps * &
+                  (I_Rho * (lambda * I_al0**2)) * (eps2 * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2)))) )
+    enddo
+    ! Use Boole's rule to integrate the values.
+    intx_dpa(i,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + 12.0*intz(3))
+  enddo ; enddo ; endif
+
+  if (present(inty_dpa)) then ; do J=Jsq,Jeq ; do i=is,ie
+    ! hWght is the distance measure by which the cell is violation of
+    ! hydrostatic consistency. For large hWght we bias the interpolation of
+    ! T & S along the top and bottom integrals, akin to thickness weighting.
+    hWght = 0.0
+    if (do_massWeight) &
+      hWght = max(0., -bathyT(i,j)-z_t(i,j+1), -bathyT(i,j+1)-z_t(i,j))
+    if (hWght > 0.) then
+      hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
+      hR = (z_t(i,j+1) - z_b(i,j+1)) + dz_neglect
+      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+    else
+      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
+    endif
+
+    intz(1) = dpa(i,j) ; intz(5) = dpa(i,j+1)
+    do m=2,4
+      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+
+      al0 = wtT_L*al0_2d(i,j) + wtT_R*al0_2d(i,j+1)
+      p0 = wtT_L*p0_2d(i,j) + wtT_R*p0_2d(i,j+1)
+      lambda = wtT_L*lambda_2d(i,j) + wtT_R*lambda_2d(i,j+1)
+
+      dz = wt_L*(z_t(i,j) - z_b(i,j)) + wt_R*(z_t(i,j+1) - z_b(i,j+1))
+      p_ave = -GxRho*(0.5*(wt_L*(z_t(i,j)+z_b(i,j)) + wt_R*(z_t(i,j+1)+z_b(i,j+1))) - z0pres)
+
+      I_al0 = 1.0 / al0
+      I_Lzz = 1.0 / ((p0 + p_ave) + lambda * I_al0)
+      eps = 0.5*(GxRho*dz)*I_Lzz ; eps2 = eps*eps
+
+      intz(m) = Pa_to_RL2_T2 * ( (g_Earth*dz) * ((p0 + p_ave)*(I_Lzz*I_al0) - rho_ref_mks) - 2.0*eps * &
+                  (I_Rho * (lambda * I_al0**2)) * (eps2 * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2)))) )
+    enddo
+    ! Use Boole's rule to integrate the values.
+    inty_dpa(i,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + 12.0*intz(3))
+  enddo ; enddo ; endif
+
+end subroutine int_density_dz_wright_red
+
+!> Calculates analytical and nearly-analytical integrals, in pressure across layers, of geopotential
+!! anomalies, which are required for calculating the finite-volume form pressure accelerations in a
+!! non-Boussinesq model.  There are essentially no free assumptions, apart from the use of Boole's
+!! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
+!! that assumes that |eps| < 0.34.
+subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
+                                  intp_dza, intx_dza, inty_dza, halo_size, bathyP, dP_neglect, &
+                                  useMassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
+  type(hor_index_type), intent(in)  :: HI        !< The ocean's horizontal index type.
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: T         !< Potential temperature relative to the surface
+                                                 !! [C ~> degC].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: S         !< Salinity [S ~> PSU].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: p_t       !< Pressure at the top of the layer [R L2 T-2 ~> Pa]
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(in)  :: p_b       !< Pressure at the top of the layer [R L2 T-2 ~> Pa]
+  real,                 intent(in)  :: spv_ref   !< A mean specific volume that is subtracted out
+                            !! to reduce the magnitude of each of the integrals [R-1 ~> m3 kg-1].
+                            !! The calculation is mathematically identical with different values of
+                            !! spv_ref, but this reduces the effects of roundoff.
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+                        intent(inout) :: dza     !< The change in the geopotential anomaly across
+                                                 !! the layer [L2 T-2 ~> m2 s-2].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(inout) :: intp_dza !< The integral in pressure through the layer of
+                                                 !! the geopotential anomaly relative to the anomaly
+                                                 !! at the bottom of the layer [R L4 T-4 ~> Pa m2 s-2]
+  real, dimension(HI%IsdB:HI%IedB,HI%jsd:HI%jed), &
+              optional, intent(inout) :: intx_dza !< The integral in x of the difference between the
+                                                 !! geopotential anomaly at the top and bottom of
+                                                 !! the layer divided by the x grid spacing
+                                                 !! [L2 T-2 ~> m2 s-2].
+  real, dimension(HI%isd:HI%ied,HI%JsdB:HI%JedB), &
+              optional, intent(inout) :: inty_dza !< The integral in y of the difference between the
+                                                 !! geopotential anomaly at the top and bottom of
+                                                 !! the layer divided by the y grid spacing
+                                                 !! [L2 T-2 ~> m2 s-2].
+  integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate
+                                                 !! dza.
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
+  real,       optional, intent(in)  :: dP_neglect !< A miniscule pressure change with
+                                                 !! the same units as p_t [R L2 T-2 ~> Pa]
+  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
+                            !! to interpolate T/S for top and bottom integrals.
+  real,       optional, intent(in)  :: SV_scale  !< A multiplicative factor by which to scale specific
+                            !! volume from m3 kg-1 to the desired units [kg m-3 R-1 ~> 1]
+  real,       optional, intent(in)  :: pres_scale !< A multiplicative factor to convert pressure
+                            !! into Pa [Pa T2 R-1 L-2 ~> 1].
+  real,       optional, intent(in)  :: temp_scale  !< A multiplicative factor by which to scale
+                            !! temperature into degC [degC C-1 ~> 1]
+  real,       optional, intent(in)  :: saln_scale !< A multiplicative factor to convert pressure
+                            !! into PSU [PSU S-1 ~> 1].
+
+  ! Local variables
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed) :: al0_2d ! A term in the Wright EOS [R-1 ~> m3 kg-1]
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed) :: p0_2d  ! A term in the Wright EOS [R L2 T-2 ~> Pa]
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed) :: lambda_2d ! A term in the Wright EOS [L2 T-2 ~> m2 s-2]
+  real :: al0        ! A term in the Wright EOS [R-1 ~> m3 kg-1]
+  real :: p0         ! A term in the Wright EOS [R L2 T-2 ~> Pa]
+  real :: lambda     ! A term in the Wright EOS [L2 T-2 ~> m2 s-2]
+  real :: al0_scale  ! Scaling factor to convert al0 from MKS units [R-1 kg m-3 ~> 1]
+  real :: p0_scale   ! Scaling factor to convert p0 from MKS units [R L2 T-2 Pa-1 ~> 1]
+  real :: lam_scale  ! Scaling factor to convert lambda from MKS units [L2 s2 T-2 m-2 ~> 1]
+  real :: p_ave      ! The layer average pressure [R L2 T-2 ~> Pa]
+  real :: rem        ! [L2 T-2 ~> m2 s-2]
+  real :: eps, eps2  ! A nondimensional ratio and its square [nondim]
+  real :: alpha_anom ! The depth averaged specific volume anomaly [R-1 ~> m3 kg-1].
+  real :: dp         ! The pressure change through a layer [R L2 T-2 ~> Pa].
+  real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa].
+  real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [R L2 T-2 ~> Pa].
+  real :: iDenom     ! The inverse of the denominator in the weights [T4 R-2 L-4 ~> Pa-2].
+  real :: hWt_LL, hWt_LR ! hWt_LA is the weighted influence of A on the left column [nondim].
+  real :: hWt_RL, hWt_RR ! hWt_RA is the weighted influence of A on the right column [nondim].
+  real :: wt_L, wt_R ! The linear weights of the left and right columns [nondim].
+  real :: wtT_L, wtT_R ! The weights for tracers from the left and right columns [nondim].
+  real :: intp(5)    ! The integrals of specific volume with pressure at the
+                     ! 5 sub-column locations [L2 T-2 ~> m2 s-2].
+  real :: a1s        ! Partly rescaled version of a1 [m3 kg-1 C-1 ~> m3 kg-1 degC-1]
+  real :: a2s        ! Partly rescaled version of a2 [m3 kg-1 S-1 ~> m3 kg-1 PSU-1]
+  real :: b1s        ! Partly rescaled version of b1 [Pa C-1 ~> Pa degC-1]
+  real :: b2s        ! Partly rescaled version of b2 [Pa C-2 ~> Pa degC-2]
+  real :: b3s        ! Partly rescaled version of b3 [Pa C-3 ~> Pa degC-3]
+  real :: b4s        ! Partly rescaled version of b4 [Pa S-1 ~> Pa PSU-1]
+  real :: b5s        ! Partly rescaled version of b5 [Pa C-1 S-1 ~> Pa degC-1 PSU-1]
+  real :: c1s        ! Partly rescaled version of c1 [m2 s-2 C-1 ~> m2 s-2 degC-1]
+  real :: c2s        ! Partly rescaled version of c2 [m2 s-2 C-2 ~> m2 s-2 degC-2]
+  real :: c3s        ! Partly rescaled version of c3 [m2 s-2 C-3 ~> m2 s-2 degC-3]
+  real :: c4s        ! Partly rescaled version of c4 [m2 s-2 S-1 ~> m2 s-2 PSU-1]
+  real :: c5s        ! Partly rescaled version of c5 [m2 s-2 C-1 S-1 ~> m2 s-2 degC-1 PSU-1]
+  logical :: do_massWeight ! Indicates whether to do mass weighting.
+  real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants [nondim]
+  real, parameter :: C1_9 = 1.0/9.0, C1_90 = 1.0/90.0  ! Rational constants [nondim]
+  integer :: Isq, Ieq, Jsq, Jeq, ish, ieh, jsh, jeh, i, j, m, halo
+
+  Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB
+  halo = 0 ; if (present(halo_size)) halo = MAX(halo_size,0)
+  ish = HI%isc-halo ; ieh = HI%iec+halo ; jsh = HI%jsc-halo ; jeh = HI%jec+halo
+  if (present(intx_dza)) then ; ish = MIN(Isq,ish) ; ieh = MAX(Ieq+1,ieh) ; endif
+  if (present(inty_dza)) then ; jsh = MIN(Jsq,jsh) ; jeh = MAX(Jeq+1,jeh) ; endif
+
+
+  al0_scale = 1.0 ; if (present(SV_scale)) al0_scale = SV_scale
+  p0_scale = 1.0
+  if (present(pres_scale)) then ; if (pres_scale /= 1.0) then
+    p0_scale = 1.0 / pres_scale
+  endif ; endif
+  lam_scale = al0_scale * p0_scale
+
+  a1s = a1 ; a2s = a2
+  b1s = b1 ; b2s = b2 ; b3s = b3 ; b4s = b4 ; b5s = b5
+  c1s = c1 ; c2s = c2 ; c3s = c3 ; c4s = c4 ; c5s = c5
+
+  if (present(temp_scale)) then ; if (temp_scale /= 1.0) then
+    a1s = a1s * temp_scale
+    b1s = b1s * temp_scale    ; b2s = b2s * temp_scale**2
+    b3s = b3s * temp_scale**3 ; b5s = b5s * temp_scale
+    c1s = c1s * temp_scale    ; c2s = c2s * temp_scale**2
+    c3s = c3s * temp_scale**3 ; c5s = c5s * temp_scale
+  endif ; endif
+
+  if (present(saln_scale)) then ; if (saln_scale /= 1.0) then
+    a2s = a2s * saln_scale
+    b4s = b4s * saln_scale ; b5s = b5s * saln_scale
+    c4s = c4s * saln_scale ; c5s = c5s * saln_scale
+  endif ; endif
+
+  do_massWeight = .false.
+  if (present(useMassWghtInterp)) then ; if (useMassWghtInterp) then
+    do_massWeight = .true.
+!    if (.not.present(bathyP)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
+!        "bathyP must be present if useMassWghtInterp is present and true.")
+!    if (.not.present(dP_neglect)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
+!        "dP_neglect must be present if useMassWghtInterp is present and true.")
+  endif ; endif
+
+  !  alpha(j) = (lambda + al0*(pressure(j) + p0)) / (pressure(j) + p0)
+  do j=jsh,jeh ; do i=ish,ieh
+    al0_2d(i,j) = al0_scale * ( a0 + (a1s*T(i,j) + a2s*S(i,j)) )
+    p0_2d(i,j) = p0_scale * ( b0 + ( b4s*S(i,j) + T(i,j) * (b1s + (T(i,j)*(b2s + b3s*T(i,j)) + b5s*S(i,j))) ) )
+    lambda_2d(i,j) = lam_scale * ( c0 + ( c4s*S(i,j) + T(i,j) * (c1s + (T(i,j)*(c2s + c3s*T(i,j)) + c5s*S(i,j))) ) )
+
+    al0 = al0_2d(i,j) ; p0 = p0_2d(i,j) ; lambda = lambda_2d(i,j)
+    dp = p_b(i,j) - p_t(i,j)
+    p_ave = 0.5*(p_t(i,j)+p_b(i,j))
+
+    eps = 0.5 * dp / (p0 + p_ave) ; eps2 = eps*eps
+    alpha_anom = (al0 - spv_ref) + lambda / (p0 + p_ave)
+    rem = (lambda * eps2) * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2)))
+    dza(i,j) = alpha_anom*dp + 2.0*eps*rem
+    if (present(intp_dza)) &
+      intp_dza(i,j) = 0.5*alpha_anom*dp**2 - dp*((1.0-eps)*rem)
+  enddo ; enddo
+
+  if (present(intx_dza)) then ; do j=HI%jsc,HI%jec ; do I=Isq,Ieq
+    ! hWght is the distance measure by which the cell is violation of
+    ! hydrostatic consistency. For large hWght we bias the interpolation of
+    ! T & S along the top and bottom integrals, akin to thickness weighting.
+    hWght = 0.0
+    if (do_massWeight) &
+      hWght = max(0., bathyP(i,j)-p_t(i+1,j), bathyP(i+1,j)-p_t(i,j))
+    if (hWght > 0.) then
+      hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
+      hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
+      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+    else
+      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
+    endif
+
+    intp(1) = dza(i,j) ; intp(5) = dza(i+1,j)
+    do m=2,4
+      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+
+      ! T, S, and p are interpolated in the horizontal.  The p interpolation
+      ! is linear, but for T and S it may be thickness weighted.
+      al0 = wtT_L*al0_2d(i,j) + wtT_R*al0_2d(i+1,j)
+      p0 = wtT_L*p0_2d(i,j) + wtT_R*p0_2d(i+1,j)
+      lambda = wtT_L*lambda_2d(i,j) + wtT_R*lambda_2d(i+1,j)
+
+      dp = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i+1,j) - p_t(i+1,j))
+      p_ave = 0.5*(wt_L*(p_t(i,j)+p_b(i,j)) + wt_R*(p_t(i+1,j)+p_b(i+1,j)))
+
+      eps = 0.5 * dp / (p0 + p_ave) ; eps2 = eps*eps
+      intp(m) = ((al0 - spv_ref) + lambda / (p0 + p_ave))*dp + 2.0*eps* &
+               lambda * eps2 * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2)))
+    enddo
+    ! Use Boole's rule to integrate the values.
+    intx_dza(i,j) = C1_90*(7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4)) + &
+                           12.0*intp(3))
+  enddo ; enddo ; endif
+
+  if (present(inty_dza)) then ; do J=Jsq,Jeq ; do i=HI%isc,HI%iec
+    ! hWght is the distance measure by which the cell is violation of
+    ! hydrostatic consistency. For large hWght we bias the interpolation of
+    ! T & S along the top and bottom integrals, akin to thickness weighting.
+    hWght = 0.0
+    if (do_massWeight) &
+      hWght = max(0., bathyP(i,j)-p_t(i,j+1), bathyP(i,j+1)-p_t(i,j))
+    if (hWght > 0.) then
+      hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
+      hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect
+      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+    else
+      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
+    endif
+
+    intp(1) = dza(i,j) ; intp(5) = dza(i,j+1)
+    do m=2,4
+      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+
+      ! T, S, and p are interpolated in the horizontal.  The p interpolation
+      ! is linear, but for T and S it may be thickness weighted.
+      al0 = wt_L*al0_2d(i,j) + wt_R*al0_2d(i,j+1)
+      p0 = wt_L*p0_2d(i,j) + wt_R*p0_2d(i,j+1)
+      lambda = wt_L*lambda_2d(i,j) + wt_R*lambda_2d(i,j+1)
+
+      dp = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i,j+1) - p_t(i,j+1))
+      p_ave = 0.5*(wt_L*(p_t(i,j)+p_b(i,j)) + wt_R*(p_t(i,j+1)+p_b(i,j+1)))
+
+      eps = 0.5 * dp / (p0 + p_ave) ; eps2 = eps*eps
+      intp(m) = ((al0 - spv_ref) + lambda / (p0 + p_ave))*dp + 2.0*eps* &
+               lambda * eps2 * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2)))
+    enddo
+    ! Use Boole's rule to integrate the values.
+    inty_dza(i,j) = C1_90*(7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4)) + &
+                           12.0*intp(3))
+  enddo ; enddo ; endif
+end subroutine int_spec_vol_dp_wright_red
+
+!> \namespace mom_eos_wright_red
+!!
+!! \section section_EOS_Wright Wright equation of state
+!!
+!! Wright, 1997, provide an approximation for the in situ density as a function of
+!! potential temperature, salinity, and pressure. The formula follow the Tumlirz
+!! equation of state which are easier to evaluate and make efficient.
+!!
+!! Two ranges are provided by Wright: a "full" range and "reduced" range. The version in this
+!! module uses the reduced range.
+!!
+!! Originally coded in 2000 by R. Hallberg.
+!! Anomaly form coded in 3/18.
+!!
+!! \subsection section_EOS_Wright_references References
+!!
+!! Wright, D., 1997: An Equation of State for Use in Ocean Models: Eckart's Formula Revisited.
+!! J. Ocean. Atmosph. Tech., 14 (3), 735-740.
+!! https://journals.ametsoc.org/doi/abs/10.1175/1520-0426%281997%29014%3C0735%3AAEOSFU%3E2.0.CO%3B2
+
+end module MOM_EOS_Wright_red

--- a/src/equation_of_state/MOM_EOS_Wright_red.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_red.F90
@@ -179,20 +179,30 @@ subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts,
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
-  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
+  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2], perhaps with
+                  ! an offset to account for spv_ref
+  real :: al_TS   ! The contributions of temperature and salinity to al0 [m3 kg-1]
+  real :: p_TSp   ! A combination of the pressure and the temperature and salinity contributions to p0 [Pa]
+  real :: lam_000 ! A corrected offset to lambda, including contributions from spv_ref [m2 s-2]
   integer :: j
 
-  do j=start,start+npts-1
-    al0 = a0 + (a1*T(j) + a2*S(j))
-    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
-
-    if (present(spv_ref)) then
-      specvol(j) = (lambda + (al0 - spv_ref)*(pressure(j) + p0)) / (pressure(j) + p0)
-    else
-      specvol(j) = (lambda + al0*(pressure(j) + p0)) / (pressure(j) + p0)
-    endif
-  enddo
+  if (present(spv_ref)) then
+    lam_000 = c0 + (a0 - spv_ref)*b0
+    do j=start,start+npts-1
+      al_TS = a1*T(j) + a2*S(j)
+      p_TSp = pressure(j) + (b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))))
+      lambda = lam_000 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+      ! This is equivalent to the expression below minus spv_ref, but less sensitive to roundoff.
+      specvol(j) = al_TS + (lambda + (a0 - spv_ref)*p_TSp) / (b0 + p_TSp)
+    enddo
+  else
+    do j=start,start+npts-1
+      al0 = a0 + (a1*T(j) + a2*S(j))
+      p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
+      lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+      specvol(j) = al0 + lambda / (pressure(j) + p0)
+    enddo
+  endif
 end subroutine calculate_spec_vol_array_wright
 
 !> Return the thermal/haline expansion coefficients for 1-d array inputs and outputs
@@ -793,6 +803,7 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
   real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa].
   real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [R L2 T-2 ~> Pa].
   real :: iDenom     ! The inverse of the denominator in the weights [T4 R-2 L-4 ~> Pa-2].
+  real :: I_pterm    ! The inverse of p0 plus p_ave [T2 R-1 L-2 ~> Pa-1].
   real :: hWt_LL, hWt_LR ! hWt_LA is the weighted influence of A on the left column [nondim].
   real :: hWt_RL, hWt_RR ! hWt_RA is the weighted influence of A on the right column [nondim].
   real :: wt_L, wt_R ! The linear weights of the left and right columns [nondim].
@@ -866,9 +877,10 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
     al0 = al0_2d(i,j) ; p0 = p0_2d(i,j) ; lambda = lambda_2d(i,j)
     dp = p_b(i,j) - p_t(i,j)
     p_ave = 0.5*(p_t(i,j)+p_b(i,j))
+    I_pterm = 1.0 / (p0 + p_ave)
 
-    eps = 0.5 * dp / (p0 + p_ave) ; eps2 = eps*eps
-    alpha_anom = (al0 - spv_ref) + lambda / (p0 + p_ave)
+    eps = 0.5 * dp * I_pterm ; eps2 = eps*eps
+    alpha_anom = (al0 - spv_ref) + lambda * I_pterm
     rem = (lambda * eps2) * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2)))
     dza(i,j) = alpha_anom*dp + 2.0*eps*rem
     if (present(intp_dza)) &
@@ -906,9 +918,10 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
 
       dp = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i+1,j) - p_t(i+1,j))
       p_ave = 0.5*(wt_L*(p_t(i,j)+p_b(i,j)) + wt_R*(p_t(i+1,j)+p_b(i+1,j)))
+      I_pterm = 1.0 / (p0 + p_ave)
 
-      eps = 0.5 * dp / (p0 + p_ave) ; eps2 = eps*eps
-      intp(m) = ((al0 - spv_ref) + lambda / (p0 + p_ave))*dp + 2.0*eps* &
+      eps = 0.5 * dp * I_pterm ; eps2 = eps*eps
+      intp(m) = ((al0 - spv_ref) + lambda * I_pterm)*dp + 2.0*eps* &
                lambda * eps2 * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2)))
     enddo
     ! Use Boole's rule to integrate the values.
@@ -947,9 +960,10 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
 
       dp = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i,j+1) - p_t(i,j+1))
       p_ave = 0.5*(wt_L*(p_t(i,j)+p_b(i,j)) + wt_R*(p_t(i,j+1)+p_b(i,j+1)))
+      I_pterm = 1.0 / (p0 + p_ave)
 
-      eps = 0.5 * dp / (p0 + p_ave) ; eps2 = eps*eps
-      intp(m) = ((al0 - spv_ref) + lambda / (p0 + p_ave))*dp + 2.0*eps* &
+      eps = 0.5 * dp * I_pterm ; eps2 = eps*eps
+      intp(m) = ((al0 - spv_ref) + lambda * I_pterm)*dp + 2.0*eps* &
                lambda * eps2 * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2)))
     enddo
     ! Use Boole's rule to integrate the values.

--- a/src/equation_of_state/MOM_EOS_Wright_red.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_red.F90
@@ -11,7 +11,7 @@ implicit none ; private
 
 public calculate_compress_wright_red, calculate_density_wright_red, calculate_spec_vol_wright_red
 public calculate_density_derivs_wright_red, calculate_specvol_derivs_wright_red
-public calculate_density_second_derivs_wright_red
+public calculate_density_second_derivs_wright_red, EoS_fit_range_Wright_red
 public int_density_dz_wright_red, int_spec_vol_dp_wright_red
 
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
@@ -441,6 +441,26 @@ subroutine calculate_compress_wright_red(T, S, pressure, rho, drho_dp, start, np
     drho_dp(j) = lambda * I_denom**2
   enddo
 end subroutine calculate_compress_wright_red
+
+!> Return the range of temperatures, salinities and pressures for which the reduced-range equation
+!! of state from Wright (1997) has been fitted to observations.  Care should be taken when applying
+!! this equation of state outside of its fit range.
+subroutine EoS_fit_range_Wright_red(T_min, T_max, S_min, S_max, p_min, p_max)
+  real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: S_max !< The maximum practical salinity over which this EoS is fitted [PSU]
+  real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+  real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  if (present(T_min)) T_min = -2.0
+  if (present(T_max)) T_max = 30.0
+  if (present(S_min)) S_min = 28.0
+  if (present(S_max)) S_max = 38.0
+  if (present(p_min)) p_min = 0.0
+  if (present(p_max)) p_max = 5.0e7
+
+end subroutine EoS_fit_range_Wright_red
 
 !> Calculates analytical and nearly-analytical integrals, in geopotential across layers, of pressure
 !! anomalies, which are required for calculating the finite-volume form pressure accelerations in a

--- a/src/equation_of_state/MOM_EOS_Wright_red.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_red.F90
@@ -942,7 +942,7 @@ end subroutine int_spec_vol_dp_wright_red
 
 !> \namespace mom_eos_wright_red
 !!
-!! \section section_EOS_Wright Wright equation of state
+!! \section section_EOS_Wright_red Wright equation of state
 !!
 !! Wright, 1997, provide an approximation for the in situ density as a function of
 !! potential temperature, salinity, and pressure. The formula follow the Tumlirz
@@ -954,7 +954,7 @@ end subroutine int_spec_vol_dp_wright_red
 !! Originally coded in 2000 by R. Hallberg.
 !! Anomaly form coded in 3/18.
 !!
-!! \subsection section_EOS_Wright_references References
+!! \subsection section_EOS_Wright_red_references References
 !!
 !! Wright, D., 1997: An Equation of State for Use in Ocean Models: Eckart's Formula Revisited.
 !! J. Ocean. Atmosph. Tech., 14 (3), 735-740.

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -13,7 +13,7 @@ public calculate_compress_linear, calculate_density_linear, calculate_spec_vol_l
 public calculate_density_derivs_linear, calculate_density_derivs_scalar_linear
 public calculate_specvol_derivs_linear
 public calculate_density_scalar_linear, calculate_density_array_linear
-public calculate_density_second_derivs_linear
+public calculate_density_second_derivs_linear, EoS_fit_range_linear
 public int_density_dz_linear, int_spec_vol_dp_linear
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
@@ -319,6 +319,26 @@ subroutine calculate_compress_linear(T, S, pressure, rho, drho_dp, start, npts,&
     drho_dp(j) = 0.0
   enddo
 end subroutine calculate_compress_linear
+
+!> Return the range of temperatures, salinities and pressures for which the reduced-range equation
+!! of state from Wright (1997) has been fitted to observations.  Care should be taken when applying
+!! this equation of state outside of its fit range.
+subroutine EoS_fit_range_linear(T_min, T_max, S_min, S_max, p_min, p_max)
+  real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
+  real, optional, intent(out) :: S_min !< The minimum salinity over which this EoS is fitted [ppt]
+  real, optional, intent(out) :: S_max !< The maximum salinity over which this EoS is fitted [ppt]
+  real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+  real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  if (present(T_min)) T_min = -273.0
+  if (present(T_max)) T_max = 100.0
+  if (present(S_min)) S_min = 0.0
+  if (present(S_max)) S_max = 1000.0
+  if (present(p_min)) p_min = 0.0
+  if (present(p_max)) p_max = 1.0e9
+
+end subroutine EoS_fit_range_linear
 
 !>   This subroutine calculates analytical and nearly-analytical integrals of
 !! pressure anomalies across layers, which are required for calculating the

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -7,8 +7,6 @@ use MOM_hor_index, only : hor_index_type
 
 implicit none ; private
 
-#include <MOM_memory.h>
-
 public calculate_compress_linear, calculate_density_linear, calculate_spec_vol_linear
 public calculate_density_derivs_linear, calculate_density_derivs_scalar_linear
 public calculate_specvol_derivs_linear

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -119,7 +119,7 @@ subroutine calculate_spec_vol_scalar_linear(T, S, pressure, specvol, &
   real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
 
   if (present(spv_ref)) then
-    specvol = ((1.0 - Rho_T0_S0*spv_ref) + spv_ref*(dRho_dT*T + dRho_dS*S)) / &
+    specvol = ((1.0 - Rho_T0_S0*spv_ref) - spv_ref*(dRho_dT*T + dRho_dS*S)) / &
              ( Rho_T0_S0 + (dRho_dT*T + dRho_dS*S))
   else
     specvol = 1.0 / ( Rho_T0_S0 + (dRho_dT*T + dRho_dS*S))
@@ -148,7 +148,7 @@ subroutine calculate_spec_vol_array_linear(T, S, pressure, specvol, start, npts,
   integer :: j
 
   if (present(spv_ref)) then ; do j=start,start+npts-1
-    specvol(j) = ((1.0 - Rho_T0_S0*spv_ref) + spv_ref*(dRho_dT*T(j) + dRho_dS*S(j))) / &
+    specvol(j) = ((1.0 - Rho_T0_S0*spv_ref) - spv_ref*(dRho_dT*T(j) + dRho_dS*S(j))) / &
                  ( Rho_T0_S0 + (dRho_dT*T(j) + dRho_dS*S(j)))
   enddo ; else ; do j=start,start+npts-1
     specvol(j) = 1.0 / ( Rho_T0_S0 + (dRho_dT*T(j) + dRho_dS*S(j)))

--- a/src/equation_of_state/MOM_TFreeze.F90
+++ b/src/equation_of_state/MOM_TFreeze.F90
@@ -5,13 +5,14 @@ module MOM_TFreeze
 
 !********+*********+*********+*********+*********+*********+*********+**
 !*  The subroutines in this file determine the potential temperature   *
-!* at which sea-water freezes.                                         *
+!* or conservative temperature at which sea-water freezes.             *
 !********+*********+*********+*********+*********+*********+*********+**
 use gsw_mod_toolbox, only : gsw_ct_freezing_exact
 
 implicit none ; private
 
 public calculate_TFreeze_linear, calculate_TFreeze_Millero, calculate_TFreeze_teos10
+public calculate_TFreeze_TEOS_poly
 
 !> Compute the freezing point potential temperature [degC] from salinity [ppt] and
 !! pressure [Pa] using a simple linear expression, with coefficients passed in as arguments.
@@ -34,11 +35,17 @@ interface calculate_TFreeze_teos10
   module procedure calculate_TFreeze_teos10_scalar, calculate_TFreeze_teos10_array
 end interface calculate_TFreeze_teos10
 
+!> Compute the freezing point conservative temperature [degC] from absolute salinity [g kg-1] and
+!! pressure [Pa] using a rescaled and refactored version of the expressions from the TEOS10 package.
+interface calculate_TFreeze_TEOS_poly
+  module procedure calculate_TFreeze_TEOS_poly_scalar, calculate_TFreeze_TEOS_poly_array
+end interface calculate_TFreeze_TEOS_poly
+
 contains
 
-!>  This subroutine computes the freezing point potential temperature
-!!  [degC] from salinity [ppt], and pressure [Pa] using a simple
-!!  linear expression, with coefficients passed in as arguments.
+!>  This subroutine computes the freezing point potential temperature [degC] from
+!!  salinity [ppt], and pressure [Pa] using a simple linear expression,
+!!  with coefficients passed in as arguments.
 subroutine calculate_TFreeze_linear_scalar(S, pres, T_Fr, TFr_S0_P0, &
                                            dTFr_dS, dTFr_dp)
   real,  intent(in)  :: S         !< salinity [ppt].
@@ -66,7 +73,7 @@ subroutine calculate_TFreeze_linear_array(S, pres, T_Fr, start, npts, &
   integer,             intent(in)  :: npts      !< the number of values to calculate.
   real,                intent(in)  :: TFr_S0_P0 !< The freezing point at S=0, p=0, [degC].
   real,                intent(in)  :: dTFr_dS   !< The derivative of freezing point with salinity,
-                                                !! [degC PSU-1].
+                                                !! [degC ppt-1].
   real,                intent(in)  :: dTFr_dp   !< The derivative of freezing point with pressure,
                                                 !! [degC Pa-1].
   integer :: j
@@ -94,13 +101,13 @@ subroutine calculate_TFreeze_Millero_scalar(S, pres, T_Fr)
   real, parameter :: cS2 = -2.154996e-4 ! A term in the freezing point fit [degC PSU-2]
   real, parameter :: dTFr_dp = -7.75e-8 ! Derivative of freezing point with pressure [degC Pa-1]
 
-  T_Fr = S*(cS1 + (cS3_2 * sqrt(max(S,0.0)) + cS2 * S)) + dTFr_dp*pres
+  T_Fr = S*(cS1 + (cS3_2 * sqrt(max(S, 0.0)) + cS2 * S)) + dTFr_dp*pres
 
 end subroutine calculate_TFreeze_Millero_scalar
 
 !> This subroutine computes the freezing point potential temperature
 !! [degC] from salinity [ppt], and pressure [Pa] using the expression
-!! from Millero (1978) (and in appendix A of Gill 1982), but with the of the
+!! from Millero (1978) (and in appendix A of Gill 1982), but with the
 !! pressure dependence changed from 7.53e-8 to 7.75e-8 to make this an
 !! expression for potential temperature (not in situ temperature), using a
 !! value that is correct at the freezing point at 35 PSU and 5e6 Pa (500 dbar).
@@ -119,11 +126,81 @@ subroutine calculate_TFreeze_Millero_array(S, pres, T_Fr, start, npts)
   integer :: j
 
   do j=start,start+npts-1
-    T_Fr(j) = S(j)*(cS1 + (cS3_2 * sqrt(max(S(j),0.0)) + cS2 * S(j))) + &
+    T_Fr(j) = S(j)*(cS1 + (cS3_2 * sqrt(max(S(j), 0.0)) + cS2 * S(j))) + &
               dTFr_dp*pres(j)
   enddo
 
 end subroutine calculate_TFreeze_Millero_array
+
+!> This subroutine computes the freezing point conservative temperature [degC]
+!! from absolute salinity [g kg-1], and pressure [Pa] using a rescaled and
+!! refactored version of the polynomial expressions from the TEOS10 package.
+subroutine calculate_TFreeze_TEOS_poly_scalar(S, pres, T_Fr)
+  real,    intent(in)  :: S    !< Absolute salinity [g kg-1].
+  real,    intent(in)  :: pres !< Pressure [Pa].
+  real,    intent(out) :: T_Fr !< Freezing point conservative temperature [degC].
+
+  ! Local variables
+  real, dimension(1) :: S0    ! Salinity at a point [g kg-1]
+  real, dimension(1) :: pres0 ! Pressure at a point [Pa]
+  real, dimension(1) :: tfr0  ! The freezing temperature [degC]
+
+  S0(1) = S
+  pres0(1) = pres
+
+  call calculate_TFreeze_TEOS_poly_array(S0, pres0, tfr0, 1, 1)
+  T_Fr = tfr0(1)
+
+end subroutine calculate_TFreeze_TEOS_poly_scalar
+
+!> This subroutine computes the freezing point conservative temperature [degC]
+!! from absolute salinity [g kg-1], and pressure [Pa] using a rescaled and
+!! refactored version of the polynomial expressions from the TEOS10 package.
+subroutine calculate_TFreeze_TEOS_poly_array(S, pres, T_Fr, start, npts)
+  real, dimension(:), intent(in)  :: S     !< absolute salinity [g kg-1].
+  real, dimension(:), intent(in)  :: pres  !< Pressure [Pa].
+  real, dimension(:), intent(out) :: T_Fr  !< Freezing point conservative temperature [degC].
+  integer,            intent(in)  :: start !< The starting point in the arrays
+  integer,            intent(in)  :: npts  !< The number of values to calculate
+
+  ! Local variables
+  real :: Sa    ! Absolute salinity [g kg-1] = [ppt]
+  real :: rS    ! Square root of salinity [ppt1/2]
+  ! The coefficients here use the notation TFab for contributions proportional to S**a/2 * P**b.
+  real, parameter :: TF00 =  0.017947064327968736  ! Freezing point coefficient [degC]
+  real, parameter :: TF20 = -6.076099099929818e-2  ! Freezing point coefficient [degC ppt-1]
+  real, parameter :: TF30 =  4.883198653547851e-3  ! Freezing point coefficient [degC ppt-3/2]
+  real, parameter :: TF40 = -1.188081601230542e-3  ! Freezing point coefficient [degC ppt-2]
+  real, parameter :: TF50 =  1.334658511480257e-4  ! Freezing point coefficient [degC ppt-5/2]
+  real, parameter :: TF60 = -8.722761043208607e-6  ! Freezing point coefficient [degC ppt-3]
+  real, parameter :: TF70 =  2.082038908808201e-7  ! Freezing point coefficient [degC ppt-7/2]
+  real, parameter :: TF01 = -7.389420998107497e-8  ! Freezing point coefficient [degC Pa-1]
+  real, parameter :: TF21 = -9.891538123307282e-11 ! Freezing point coefficient [degC ppt-1 Pa-1]
+  real, parameter :: TF31 = -8.987150128406496e-13 ! Freezing point coefficient [degC ppt-3/2 Pa-1]
+  real, parameter :: TF41 =  1.054318231187074e-12 ! Freezing point coefficient [degC ppt-2 Pa-1]
+  real, parameter :: TF51 =  3.850133554097069e-14 ! Freezing point coefficient [degC ppt-5/2 Pa-1]
+  real, parameter :: TF61 = -2.079022768390933e-14 ! Freezing point coefficient [degC ppt-3 Pa-1]
+  real, parameter :: TF71 =  1.242891021876471e-15 ! Freezing point coefficient [degC ppt-7/2 Pa-1]
+  real, parameter :: TF02 = -2.110913185058476e-16 ! Freezing point coefficient [degC Pa-2]
+  real, parameter :: TF22 =  3.831132432071728e-19 ! Freezing point coefficient [degC ppt-1 Pa-2]
+  real, parameter :: TF32 =  1.065556599652796e-19 ! Freezing point coefficient [degC ppt-3/2 Pa-2]
+  real, parameter :: TF42 = -2.078616693017569e-20 ! Freezing point coefficient [degC ppt-2 Pa-2]
+  real, parameter :: TF52 =  1.596435439942262e-21 ! Freezing point coefficient [degC ppt-5/2 Pa-2]
+  real, parameter :: TF03 =  2.295491578006229e-25 ! Freezing point coefficient [degC Pa-3]
+  real, parameter :: TF23 = -7.997496801694032e-27 ! Freezing point coefficient [degC ppt-1 Pa-3]
+  real, parameter :: TF33 =  8.756340772729538e-28 ! Freezing point coefficient [degC ppt-3/2 Pa-3]
+  real, parameter :: TF43 =  1.338002171109174e-29 ! Freezing point coefficient [degC ppt-2 Pa-3]
+  integer :: j
+
+  do j=start,start+npts-1
+    rS = sqrt(max(S(j), 0.0))
+    T_Fr(j) =       (TF00 + S(j)*(TF20 + rS*(TF30 + rS*(TF40 + rS*(TF50 + rS*(TF60 + rS*TF70)))))) &
+        + pres(j)*( (TF01 + S(j)*(TF21 + rS*(TF31 + rS*(TF41 + rS*(TF51 + rS*(TF61 + rS*TF71)))))) &
+         + pres(j)*((TF02 + S(j)*(TF22 + rS*(TF32 + rS*(TF42 + rS* TF52)))) &
+          + pres(j)*(TF03 + S(j)*(TF23 + rS*(TF33 + rS* TF43))) ) )
+  enddo
+
+end subroutine calculate_TFreeze_TEOS_poly_array
 
 !> This subroutine computes the freezing point conservative temperature [degC]
 !! from absolute salinity [g kg-1], and pressure [Pa] using the
@@ -158,7 +235,6 @@ subroutine calculate_TFreeze_teos10_array(S, pres, T_Fr, start, npts)
 
   ! Local variables
   real, parameter :: Pa2db  = 1.e-4  ! The conversion factor from Pa to dbar [dbar Pa-1]
-  real :: zs    ! Salinity at a point [g kg-1]
   real :: zp    ! Pressures in [dbar]
   integer :: j
   ! Assume sea-water contains no dissolved air.
@@ -166,11 +242,10 @@ subroutine calculate_TFreeze_teos10_array(S, pres, T_Fr, start, npts)
 
   do j=start,start+npts-1
     !Conversions
-    zs = S(j)
     zp = pres(j)* Pa2db         !Convert pressure from Pascal to decibar
 
     if (S(j) < -1.0e-10) cycle !Can we assume safely that this is a missing value?
-    T_Fr(j) = gsw_ct_freezing_exact(zs,zp,saturation_fraction)
+    T_Fr(j) = gsw_ct_freezing_exact(S(j), zp, saturation_fraction)
   enddo
 
 end subroutine calculate_TFreeze_teos10_array

--- a/src/equation_of_state/MOM_temperature_convert.F90
+++ b/src/equation_of_state/MOM_temperature_convert.F90
@@ -1,0 +1,166 @@
+!> Functions to convert between conservative and potential temperature
+module MOM_temperature_convert
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+implicit none ; private
+
+public poTemp_to_consTemp, consTemp_to_poTemp
+
+!>@{ Parameters in the temperature conversion code
+real, parameter :: Sprac_Sref = (35.0/35.16504) ! The TEOS 10 conversion factor to go from
+                                    ! reference salinity to practical salinity [nondim]
+real, parameter :: I_S0 = 0.025*Sprac_Sref ! The inverse of a plausible range of oceanic salinities [kg g-1]
+real, parameter :: I_Ts = 0.025          ! The inverse of a plausible range of oceanic temperatures [degC-1]
+real, parameter :: I_cp0 = 1.0/3991.86795711963 ! The inverse of the "specific heat" for use
+                      !  with Conservative Temperature, as defined with TEOS10 [degC kg J-1]
+
+! The following are coefficients of contributions to conservative temperature as a function of the square root
+! of normalized absolute salinity with an offset (zS) and potential temperature (T) with a contribution
+! Hab * zS**a * T**b.  The numbers here are copied directly from the corresponding gsw module, but
+! the expressions here do not use the same nondimensionalization for pressure or temperature as they do.
+
+real, parameter :: H00 = 61.01362420681071*I_cp0             ! Tp to Tc fit constant [degC]
+real, parameter :: H01 = 168776.46138048015*(I_cp0*I_Ts)     ! Tp to Tc fit T coef. [nondim]
+real, parameter :: H02 = -2735.2785605119625*(I_cp0*I_Ts**2) ! Tp to Tc fit T**2 coef. [degC-1]
+real, parameter :: H03 = 2574.2164453821433*(I_cp0*I_Ts**3)  ! Tp to Tc fit T**3 coef. [degC-2]
+real, parameter :: H04 = -1536.6644434977543*(I_cp0*I_Ts**4) ! Tp to Tc fit T**4 coef. [degC-3]
+real, parameter :: H05 = 545.7340497931629*(I_cp0*I_Ts**5)   ! Tp to Tc fit T**5 coef. [degC-4]
+real, parameter :: H06 = -50.91091728474331*(I_cp0*I_Ts**6)  ! Tp to Tc fit T**6 coef. [degC-5]
+real, parameter :: H07 = -18.30489878927802*(I_cp0*I_Ts**7)  ! Tp to Tc fit T**7 coef. [degC-6]
+real, parameter :: H20 = 268.5520265845071*I_cp0             ! Tp to Tc fit zS**2 coef. [degC]
+real, parameter :: H21 = -12019.028203559312*(I_cp0*I_Ts)    ! Tp to Tc fit zS**2 * T coef. [nondim]
+real, parameter :: H22 = 3734.858026725145*(I_cp0*I_Ts**2)   ! Tp to Tc fit zS**2 * T**2 coef. [degC-1]
+real, parameter :: H23 = -2046.7671145057618*(I_cp0*I_Ts**3) ! Tp to Tc fit zS**2 * T**3 coef. [degC-2]
+real, parameter :: H24 = 465.28655623826234*(I_cp0*I_Ts**4)  ! Tp to Tc fit zS**2 * T**4 coef. [degC-3]
+real, parameter :: H25 = -0.6370820302376359*(I_cp0*I_Ts**5) ! Tp to Tc fit zS**2 * T**5 coef. [degC-4]
+real, parameter :: H26 = -10.650848542359153*(I_cp0*I_Ts**6) ! Tp to Tc fit zS**2 * T**6 coef. [degC-5]
+real, parameter :: H30 = 937.2099110620707*I_cp0             ! Tp to Tc fit zS**3 coef. [degC]
+real, parameter :: H31 = 588.1802812170108*(I_cp0*I_Ts)      ! Tp to Tc fit zS** 3* T coef. [nondim]
+real, parameter :: H32 = 248.39476522971285*(I_cp0*I_Ts**2)  ! Tp to Tc fit zS**3 * T**2 coef. [degC-1]
+real, parameter :: H33 = -3.871557904936333*(I_cp0*I_Ts**3)  ! Tp to Tc fit zS**3 * T**3 coef. [degC-2]
+real, parameter :: H34 = -2.6268019854268356*(I_cp0*I_Ts**4) ! Tp to Tc fit zS**3 * T**4 coef. [degC-3]
+real, parameter :: H40 = -1687.914374187449*I_cp0            ! Tp to Tc fit zS**4 coef. [degC]
+real, parameter :: H41 = 936.3206544460336*(I_cp0*I_Ts)      ! Tp to Tc fit zS**4 * T coef. [nondim]
+real, parameter :: H42 = -942.7827304544439*(I_cp0*I_Ts**2)  ! Tp to Tc fit zS**4 * T**2 coef. [degC-1]
+real, parameter :: H43 = 369.4389437509002*(I_cp0*I_Ts**3)   ! Tp to Tc fit zS**4 * T**3 coef. [degC-2]
+real, parameter :: H44 = -33.83664947895248*(I_cp0*I_Ts**4)  ! Tp to Tc fit zS**4 * T**4 coef. [degC-3]
+real, parameter :: H45 = -9.987880382780322*(I_cp0*I_Ts**5)  ! Tp to Tc fit zS**4 * T**5 coef. [degC-4]
+real, parameter :: H50 = 246.9598888781377*I_cp0             ! Tp to Tc fit zS**5 coef. [degC]
+real, parameter :: H60 = 123.59576582457964*I_cp0            ! Tp to Tc fit zS**6 coef. [degC]
+real, parameter :: H70 = -48.5891069025409*I_cp0             ! Tp to Tc fit zS**7 coef. [degC]
+
+!>@}
+
+contains
+
+!> Convert input potential temperature [degC] and absolute salinity [g kg-1] to returned
+!! conservative temperature [degC] using the polynomial expressions from TEOS-10.
+elemental real function poTemp_to_consTemp(T, Sa) result(Tc)
+  real, intent(in) :: T  !< Potential temperature [degC]
+  real, intent(in) :: Sa !< Absolute salinity [g kg-1]
+
+  ! Local variables
+  real :: x2 ! Absolute salinity normalized by a plausible salinity range [nondim]
+  real :: x  ! Square root of normalized absolute salinity [nondim]
+
+  x2 = max(I_S0 * Sa, 0.0)
+  x = sqrt(x2)
+
+  Tc = H00 + (T*(H01 + T*(H02 +  T*(H03 +  T*(H04  + T*(H05 + T*(H06 + T* H07)))))) &
+                    + x2*(H20 + (T*(H21 +  T*(H22  + T*(H23 + T*(H24 + T*(H25 + T*H26))))) &
+                              +  x*(H30 + (T*(H31  + T*(H32 + T*(H33 + T* H34))) &
+                                         + x*(H40 + (T*(H41 + T*(H42 + T*(H43 + T*(H44 + T*H45)))) &
+                                                  +  x*(H50 + x*(H60 + x* H70)) )) )) )) )
+
+end function poTemp_to_consTemp
+
+
+!> Return the partial derivative of conservative temperature with potential temperature [nondim]
+!! based on the polynomial expressions from TEOS-10.
+elemental real function dTc_dTp(T, Sa)
+  real, intent(in) :: T  !< Potential temperature [degC]
+  real, intent(in) :: Sa !< Absolute salinity [g kg-1]
+
+  ! Local variables
+  real :: x2 ! Absolute salinity normalized by a plausible salinity range [nondim]
+  real :: x  ! Square root of normalized absolute salinity [nondim]
+
+  x2 = max(I_S0 * Sa, 0.0)
+  x = sqrt(x2)
+
+  dTc_dTp = (     H01 + T*(2.*H02 + T*(3.*H03 + T*(4.*H04 + T*(5.*H05 + T*(6.*H06 + T*(7.*H07)))))) ) &
+      + x2*(     (H21 + T*(2.*H22 + T*(3.*H23 + T*(4.*H24 + T*(5.*H25 + T*(6.*H26)))))) &
+         +  x*(  (H31 + T*(2.*H32 + T*(3.*H33 + T*(4.*H34)))) &
+             + x*(H41 + T*(2.*H42 + T*(3.*H43 + T*(4.*H44 + T*(5.*H45))))) ) )
+
+end function dTc_dTp
+
+
+
+!> Convert input potential temperature [degC] and absolute salinity [g kg-1] to returned
+!! conservative temperature [degC] by inverting the polynomial expressions from TEOS-10.
+elemental real function consTemp_to_poTemp(Tc, Sa) result(Tp)
+  real, intent(in) :: Tc !< Conservative temperature [degC]
+  real, intent(in) :: Sa !< Absolute salinity [g kg-1]
+
+  real :: Tp_num    ! The numerator  of a simple expression for potential temperature [degC]
+  real :: I_Tp_den  ! The inverse of the denominator of a simple expression for potential temperature [nondim]
+  real :: Tc_diff   ! The difference between an estimate of conservative temperature and its target [degC]
+  real :: Tp_old    ! A previous estimate of the potential tempearture [degC]
+  real :: dTp_dTc   ! The partial derivative of potential temperature with conservative temperature [nondim]
+  ! The following are coefficients in the nominator (TPNxx) or denominator (TPDxx) of a simple rational
+  ! expression that approximately converts conservative temperature to potential temperature.
+  real, parameter :: TPN00 = -1.446013646344788e-2               ! Simple fit numerator constant [degC]
+  real, parameter :: TPN10 = -3.305308995852924e-3*Sprac_Sref    ! Simple fit numerator Sa coef. [degC ppt-1]
+  real, parameter :: TPN20 =  1.062415929128982e-4*Sprac_Sref**2 ! Simple fit numerator Sa**2 coef. [degC ppt-2]
+  real, parameter :: TPN01 =  9.477566673794488e-1               ! Simple fit numerator Tc coef. [nondim]
+  real, parameter :: TPN11 =  2.166591947736613e-3*Sprac_Sref    ! Simple fit numerator Sa * Tc coef. [ppt-1]
+  real, parameter :: TPN02 =  3.828842955039902e-3               ! Simple fit numerator Tc**2 coef. [degC-1]
+  real, parameter :: TPD10 =  6.506097115635800e-4*Sprac_Sref    ! Simple fit denominator Sa coef. [ppt-1]
+  real, parameter :: TPD01 =  3.830289486850898e-3               ! Simple fit denominator Tc coef. [degC-1]
+  real, parameter :: TPD02 =  1.247811760368034e-6               ! Simple fit denominator Tc**2 coef. [degC-2]
+
+  ! Estimate the potential temperature and its derivative from an approximate rational function fit.
+  Tp_num = TPN00 + (Sa*(TPN10 + TPN20*Sa) + Tc*(TPN01 + (TPN11*Sa + TPN02*Tc)))
+  I_Tp_den = 1.0 / (1.0 + (TPD10*Sa + Tc*(TPD01 + TPD02*Tc)))
+  Tp = Tp_num*I_Tp_den
+  dTp_dTc = ((TPN01 + (TPN11*Sa + 2.*TPN02*Tc)) - (TPD01 + 2.*TPD02*Tc)*Tp)*I_Tp_den
+
+  ! Start the 1.5 iterations through the modified Newton-Raphson iterative method, which is also known
+  ! as the Newton-McDougall method.  In this case 1.5 iterations converge to 64-bit machine precision
+  ! for oceanographically relevant temperatures and salinities.
+
+  Tc_diff = poTemp_to_consTemp(Tp, Sa) - Tc
+  Tp_old = Tp
+  Tp = Tp_old - Tc_diff*dTp_dTc
+
+  dTp_dTc = 1.0 / dTc_dTp(0.5*(Tp + Tp_old), Sa)
+
+  Tp = Tp_old - Tc_diff*dTp_dTc
+  Tc_diff = poTemp_to_consTemp(Tp, Sa) - Tc
+  Tp_old = Tp
+
+  Tp = Tp_old - Tc_diff*dTp_dTc
+
+end function consTemp_to_poTemp
+
+!> \namespace MOM_temperature_conv
+!!
+!! \section MOM_temperature_conv Temperature conversions
+!!
+!!   This module has functions that convert potential temperature to conservative temperature
+!! and the reverse, as described in the TEOS-10 manual.  This code was originally derived
+!! from their corresponding routines in the gsw code package, but has had some refactoring so that the
+!! answers are more likely to reproduce across compilers and levels of optimization.  A complete
+!! discussion of the thermodynamics of seawater and the definition of conservative temperature
+!! can be found in IOC et al. (2010).
+!!
+!! \subsection section_temperature_conv_references References
+!!
+!! IOC, SCOR and IAPSO, 2010: The international thermodynamic equation of seawater - 2010:
+!!   Calculation and use of thermodynamic properties. Intergovernmental Oceanographic Commission,
+!!   Manuals and Guides No. 56, UNESCO (English), 196 pp.
+!!   (Available from www.teos-10.org/pubs/TEOS-10_Manual.pdf)
+
+end module MOM_temperature_convert

--- a/src/equation_of_state/_Equation_of_State.dox
+++ b/src/equation_of_state/_Equation_of_State.dox
@@ -2,9 +2,10 @@
 
 Within MOM6, there is a wrapper for the equation of state, so that all calls look
 the same from the rest of the model. The equation of state code has to calculate
-not just in situ density, but also the compressibility and various derivatives of
-the density. There is also code for computing specific volume and the
-freezing temperature.
+not just in situ or potential density, but also the compressibility and various
+derivatives of the density. There is also code for computing specific volume and the
+freezing temperature, and for converting between potential and conservative
+temperatures and between practical and reference (or absolute) salinity.
 
 \section Linear_EOS Linear Equation of State
 
@@ -12,51 +13,96 @@ Compute the required quantities with uniform values for \f$\alpha = \frac{\parti
 \rho}{\partial T}\f$ and \f$\beta = \frac{\partial \rho}{\partial S}\f$, (DRHO_DT,
 DRHO_DS in MOM_input, also uses RHO_T0_S0).
 
-\section Wright_EOS Wright Equation of State
+\section Wright_EOS Wright reduced range Equation of State
 
-Compute the required quantities using the equation of state from \cite wright1997.
-This equation of state is in the form:
+Compute the required quantities using the equation of state from \cite wright1997
+as a function of potential temperature and practical salinity, with
+coefficients based on the reduced-range (salinity from 28 to 38 PSU, temperature
+from -2 to 30 degC and pressure up to 5000 dbar) fit to the UNESCO 1981 data. This
+equation of state is in the form:
 \f[
    \alpha(s, \theta, p) = A(s, \theta) + \frac{\lambda(s, \theta)}{P(s, \theta) + p}
 \f]
 where \f$A, \lambda\f$ and \f$P\f$ are functions only of \f$s\f$ and \f$\theta\f$
 and \f$\alpha = 1/ \rho\f$ is the specific volume. This form is useful for the
-pressure gradient computation as discussed in \ref section_PG.
+pressure gradient computation as discussed in \ref section_PG.  This EoS is selected
+by setting EQN_OF_STATE = WRIGHT or WRIGHT_RED, which are mathematically equivalent,
+but the latter is refactored for consistent answers between compiler settings.
 
-\section NEMO_EOS NEMO Equation of State
+\section Wright_full_EOS Wright full range Equation of State
 
-Compute the required quantities using the equation of state from \cite roquet2015.
+Compute the required quantities using the equation of state from \cite wright1997
+as a function of potential temperature and practical salinity, with
+coefficients based on a fit to the UNESCO 1981 data over the full range of
+validity of that data (salinity from 0 to 40 PSU, temperatures from -2 to 40
+degC, and pressures up to 10000 dbar).  The functional form of the WRIGHT_FULL
+equation of state is the same as for WRIGHT or WRIGHT_RED, but with different
+coefficients.
+
+\section Jackett06_EOS Jackett et al. (2006) Equation of State
+
+Compute the required quantities using the equation of state from Jackett et al.
+(2006) as a function of potential temperature and practical salinity, with
+coefficients based on a fit to the updated data that were later used to define
+the TEOS-10 equation of state over the full range of validity of that data
+(salinity from 0 to 42 PSU, temperatures from the freezing point to 40 degC, and
+pressures up to 8500 dbar), but focused on the "oceanographic funnel" of
+thermodynamic properties observed in the ocean.  This equation of state is
+commonly used in realistic Hycom simulations.
 
 \section UNESCO_EOS UNESCO Equation of State
 
-Compute the required quantities using the equation of state from \cite jackett1995.
+Compute the required quantities using the equation of state from \cite jackett1995,
+which uses potential temperature and practical salinity as state variables and is
+a fit to the 1981 UNESCO equation of state with the same functional form but a
+replacement of the temperature variable (the original uses <em>in situ</em> temperature).
+
+\section ROQUET_RHO_EOS ROQUET_RHO Equation of State
+
+Compute the required quantities using the equation of state from \cite roquet2015,
+which uses a 75-member polynomial for density as a function of conservative temperature
+and absolute salinity, in a fit to the output from the full TEOS-10 equation of state.
+
+\section ROQUET_SPV_EOS ROQUET_SPV Equation of State
+
+Compute the required quantities using the specific volume oriented equation of state from
+\cite roquet2015, which uses a 75-member polynomial for specific volume as a function of
+conservative temperature and absolute salinity, in a fit to the output from the full
+TEOS-10 equation of state.
 
 \section TEOS-10_EOS TEOS-10 Equation of State
 
 Compute the required quantities using the equation of state from
-[TEOS-10](http://www.teos-10.org/).
+[TEOS-10](http://www.teos-10.org/), with calls directly to the subroutines
+in that code package.
 
 \section section_TFREEZE Freezing Temperature of Sea Water
 
-There are three choices for computing the freezing point of sea water:
+There are four choices for computing the freezing point of sea water:
 
 \li Linear The freezing temperature is a linear function of the salinity and
 pressure:
 \f[
    T_{Fr} = (T_{Fr0} + a\,S) + b\,P
 \f]
-where \f$T_{Fr0},a,b\f$ are contants which can be set in MOM_input (TFREEZE_S0_P0,
+where \f$T_{Fr0},a,b\f$ are constants which can be set in MOM_input (TFREEZE_S0_P0,
 DTFREEZE_DS, DTFREEZE_DP).
 
-\li Millero The \cite millero1978 equation is used, but modified so that it is a function
-of potential temperature rather than <em>in situ</em> temperature:
+\li Millero The \cite millero1978 equation is used to calculate the freezing
+point from practical salinity and pressure, but modified so that returns a
+potential temperature rather than an <em>in situ</em> temperature:
 \f[
    T_{Fr} = S(a + (b \sqrt{\max(S,0.0)} + c\, S)) + d\,P
 \f]
-where \f$a,b, c, d\f$ are fixed contants.
+where \f$a,b, c, d\f$ are fixed constants.
 
-\li TEOS-10 The TEOS-10 package is used to compute the freezing conservative temperature
-[degC] from absolute salinity [g/kg], and pressure [Pa]. This one must be used
-if you are using the NEMO or TEOS-10 equation of state.
+\li TEOS-10 The TEOS-10 package is used to compute the freezing conservative
+temperature [degC] from absolute salinity [g/kg], and pressure [Pa]. This one or
+TEOS_poly must be used if you are using the ROQUET_RHO, ROQUET_SPV or TEOS-10
+equation of state.
+
+\li TEOS_poly A 23-term polynomial fit refactored from the TEOS-10 package is
+used to compute the freezing conservative temperature [degC] from absolute
+salinity [g/kg], and pressure [Pa].
 
 */


### PR DESCRIPTION
  This PR includes a series of commits that add 4 new equation of state (EoS) modules, add and deploy unit testing to the EoS modules, correct actual bugs in every one of the pre-existing modules, adds missing routines to the previous modules, and adds parentheses to most of the EoS modules (but not LINEAR or WRIGHT) to specify the order of arithmetic so that they will reproduce answers across compilers and levels of optimization.  By default, answers are bitwise identical when EQN_OF_STATE = LINEAR or EQN_OF_STATE = WRIGHT, but a survey of the community suggested that the other equations of state were not being used yet, so answers will change due to both bug-fixes and changes in the order of arithmetic for all the other equations of state.  Despite all of these changes, answers are bitwise identical for all of the cases in the MOM6-examples test suite and the TC tests, and the same is likely to be true of other currently used MOM6 configurations.

  The new equation of state modules or settings for EQN_OF_STATE include:

 - JACKETT_MCD: This is equivalent to UNESCO, but the name emphasizes that this is actually the refit to the UNESCO EoS using potential temperature instead of in-situ temperature as published by Jackett and McDougall (2005).
 - JACKETT06: This EoS uses potential temperature and practical salinity with fits to data that significantly updated beyond what was available with the UNESCO equation of state, as published by Jackett et al. (2006).
 - ROQUET_RHO: This is equivalent to NEMO, and it uses the polynomial expression for density as a function of conservative temperature and absolute salinity, as published by Roquet et al. (2015).
 - ROQUET_SPV: This EoS is the polynomial expression for specific volume as a function of conservative temperature and absolute salinity, as published by Roquet et al. (2015).
 - WRIGHT_FULL: This is the full-range Tumlitz form fit for the EoS as a function of potential temperature and practical salinity, as published by Wright (1997).
 - WRIGHT_REDUCED: This is the reduced-range Tumlitz form fit for the EoS as a function of potential temperature and practical salinity, as published by Wright (1997).  Because it is not a fit covering brackish or fresh water, it is probably not appropriate for coastal simulations.  It is mostly mathematically equivalent to WRIGHT, but with bugs fixed and parentheses added.

  The WRIGHT and TEOS10 equations of state give identical answers to  what was there before.

  The LINEAR equation of state for density is identical to what was there before, but a bug was fixed in the calculation of specific volume with a reference value was fixed; that but probably would have led to immediate failures of any case that used it.

 The UNESCO and NEMO equations of state have been extensively refactored or had internal inconsistencies corrected and missing routines added, but the expressions for density are mathematically equivalent to what was there before.

  The commits in this PR include:

- NOAA-GFDL/MOM6@07e0602fa +Rename WRIGHT_RED to WRIGHT_REDUCED
- NOAA-GFDL/MOM6@4ad02283f +Make calculate_density_array private
- NOAA-GFDL/MOM6@dc87fd03c +Eliminate use_TEOS arg to cons_temp_to_pot_temp
- NOAA-GFDL/MOM6@9b9b0223d Update _Equation_of_State.dox
- NOAA-GFDL/MOM6@bf8f41428 +*Add MOM_temperature_convert.F90
- NOAA-GFDL/MOM6@7bf2b3a3c +Add calculate_TFreeze_TEOS_poly
- NOAA-GFDL/MOM6@493df68b5 *Avoid re-rescaling T and p in MOM_EOS_Roquet_rho
- NOAA-GFDL/MOM6@ce225b2aa +Renamed MOM_EOS_NEMO to MOM_EOS_Roquet_rho
- NOAA-GFDL/MOM6@4b9e96067 *Refactor calculate_specific_vol_wright_full
- NOAA-GFDL/MOM6@8dbccd245 Do not include MOM_memory.h in EoS modules
- NOAA-GFDL/MOM6@d3c5f468e +Add EOS_fit_range and analogs for each EoS
- NOAA-GFDL/MOM6@31cc8a982 *+Add calculate_specvol_derivs_UNESCO
- NOAA-GFDL/MOM6@d214a2049 +Add MOM_EOS_Jackett06.F90
- NOAA-GFDL/MOM6@66c432a9d +Add MOM_EOS_Roquet_SpV.F90
- NOAA-GFDL/MOM6@d4fe2d91d *Refactor MOM_EOS_NEMO.F90
- NOAA-GFDL/MOM6@6aa5e19be *Refactor MOM_EOS_UNESCO.F90
- NOAA-GFDL/MOM6@e7d54c79f (*)+Added calc_density_second_derivs_wright_buggy
- NOAA-GFDL/MOM6@6a1845337 +Add calculate_density_second_derivs_UNESCO
- NOAA-GFDL/MOM6@c28d5d75f *+NEMO equation of state self-consistency
- NOAA-GFDL/MOM6@e2e2c3e06 Fix doxygen labels in EOS_Wright_full and _red
- NOAA-GFDL/MOM6@8b4e3141f +Add EOS_unit_tests
- NOAA-GFDL/MOM6@70b22be29 *Fix bug in calculate_spec_vol_linear with spv_ref
- NOAA-GFDL/MOM6@88015d832 +Created the new module MOM_EOS_Wright_red
- NOAA-GFDL/MOM6@98051f757 (*)Rearranged parentheses in MOM_EOS_Wright_full
- NOAA-GFDL/MOM6@010b4dce5 Fix and tidy Wright_EOS API documentation
- NOAA-GFDL/MOM6@7a040189f +Add MOM_EOS_Wright_Full