### PR TITLE
*Fix indexing bugs in get_field_nc

### DIFF
--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -2057,15 +2057,16 @@ subroutine MOM_read_data_2d(filename, fieldname, data, MOM_Domain, &
 end subroutine MOM_read_data_2d
 
 
-!> Read a 2d array from file using native netCDF I/O.
+!> Read a 2d array (which might have halos) from a file using native netCDF I/O.
 subroutine read_netCDF_data_2d(filename, fieldname, values, MOM_Domain, &
                             timelevel, position, rescale)
   character(len=*), intent(in) :: filename
     !< Input filename
   character(len=*), intent(in)  :: fieldname
     !< Field variable name
-  real, intent(out) :: values(:,:)
-    !< Field value
+  real, intent(inout) :: values(:,:)
+    !< Field values read from the file.  It would be intent(out) but for the
+    !! need to preserve any initialized values in the halo regions.
   type(MOM_domain_type), intent(in) :: MOM_Domain
     !< Model domain decomposition
   integer, optional, intent(in) :: timelevel
@@ -2073,7 +2074,7 @@ subroutine read_netCDF_data_2d(filename, fieldname, values, MOM_Domain, &
   integer, optional, intent(in) :: position
     !< Grid positioning flag
   real, optional, intent(in) :: rescale
-    !< Rescale factor
+    !< Rescale factor, omitting this is the same as setting it to 1.
 
   integer :: turns
     ! Number of quarter-turns from input to model grid

--- a/src/framework/MOM_io_file.F90
+++ b/src/framework/MOM_io_file.F90
@@ -1681,15 +1681,18 @@ subroutine read_field_chksum_nc(handle, field, chksum, valid_chksum)
 end subroutine read_field_chksum_nc
 
 
-!> Read the values of a netCDF field
+!> Read the values of a netCDF field into an array that might have halos
 subroutine get_field_nc(handle, label, values, rescale)
   class(MOM_netcdf_file), intent(in) :: handle
-    ! Handle of netCDF file to be read
+    !< Handle of netCDF file to be read
   character(len=*), intent(in) :: label
-    ! Field variable name
-  real, intent(out) :: values(:,:)
-    ! Field values read from file
+    !< Field variable name
+  real, intent(inout) :: values(:,:)
+    !< Field values read from the file.  It would be intent(out) but for the
+    !! need to preserve any initialized values in the halo regions.
   real, optional, intent(in) :: rescale
+    !< A multiplicative rescaling factor for the values that are read.
+    !! Omitting this is the same as setting it to 1.
 
   logical :: data_domain
     ! True if values matches the data domain size
@@ -1729,10 +1732,8 @@ subroutine get_field_nc(handle, label, values, rescale)
 
   field_nc = handle%fields%get(label)
 
-  if (data_domain) then
+  if (data_domain) &
     allocate(values_c(1:iec-isc+1,1:jec-jsc+1))
-    values(:,:) = 0.
-  endif
 
   if (handle%domain_decomposed) then
     bounds(1,:) = [isc, jsc] + [handle%HI%idg_offset, handle%HI%jdg_offset]

--- a/src/framework/MOM_netcdf.F90
+++ b/src/framework/MOM_netcdf.F90
@@ -665,8 +665,10 @@ subroutine get_netcdf_fields(handle, axes, fields)
   call check_netcdf_call(rc, 'get_netcdf_fields', &
       'File "' // trim(handle%filename) // '"')
 
-  allocate(axes(ndims))
+  ! Initialize unlim_index with an unreachable value (outside [1,ndims])
   unlim_index = -1
+
+  allocate(axes(ndims))
   do i = 1, ndims
     rc = nf90_inquire_dimension(handle%ncid, dimids(i), name=label, len=len)
     call check_netcdf_call(rc, 'get_netcdf_fields', &

--- a/src/framework/MOM_netcdf.F90
+++ b/src/framework/MOM_netcdf.F90
@@ -666,6 +666,7 @@ subroutine get_netcdf_fields(handle, axes, fields)
       'File "' // trim(handle%filename) // '"')
 
   allocate(axes(ndims))
+  unlim_index = -1
   do i = 1, ndims
     rc = nf90_inquire_dimension(handle%ncid, dimids(i), name=label, len=len)
     call check_netcdf_call(rc, 'get_netcdf_fields', &


### PR DESCRIPTION
  Fixed two horizontal indexing bugs in `get_field_nc()`, where the difference between the array starting index (always 1 in this subroutine) and the values in the handle argument were not being taken into account when the array was being passed in with only its computational domain.  Also initialized the internal `unlim_index` array in `get_netcdf_fields()` to fix a problem with using an uninitialized array that was being flagged when run in debug mode.  With this commit, the model is once again reproducing the expected answers when rescaling is applied for vertical distances or time.  All answers are bitwise identical in cases that were working before.

  This commit addresses the issue at github.com/NOAA-GFDL/MOM6/issues/333, which can be closed once this commit is merged into dev/gfdl.