### PR TITLE
+Add and use US%Pa_to_RL2_T2 and US%Pa_to_RLZ_T2

### DIFF
--- a/config_src/drivers/solo_driver/MESO_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MESO_surface_forcing.F90
@@ -242,7 +242,7 @@ subroutine MESO_surface_forcing_init(Time, G, US, param_file, diag, CS)
                  units="kg m-3", default=1035.0, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", units="Pa", default=0.0, &
-                 scale=US%kg_m3_to_R*US%m_s_to_L_T**2*US%L_to_Z)
+                 scale=US%Pa_to_RLZ_T2)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back "//&

--- a/config_src/drivers/solo_driver/user_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/user_surface_forcing.F90
@@ -78,7 +78,7 @@ subroutine USER_wind_forcing(sfc_state, forces, day, G, US, CS)
   ! calculation of ustar - otherwise the lower bound would be Isq.
   do j=js,je ; do I=is-1,Ieq
     ! Change this to the desired expression.
-    forces%taux(I,j) = G%mask2dCu(I,j) * 0.0*US%kg_m3_to_R*US%m_s_to_L_T**2*US%L_to_Z
+    forces%taux(I,j) = G%mask2dCu(I,j) * 0.0*US%Pa_to_RLZ_T2
   enddo ; enddo
   do J=js-1,Jeq ; do i=is,ie
     forces%tauy(i,J) = G%mask2dCv(i,J) * 0.0  ! Change this to the desired expression.
@@ -271,7 +271,7 @@ subroutine USER_surface_forcing_init(Time, G, US, param_file, diag, CS)
                  units="kg m-3", default=1035.0, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", &
-                 units="Pa", default=0.0, scale=US%kg_m3_to_R*US%m_s_to_L_T**2*US%L_to_Z)
+                 units="Pa", default=0.0, scale=US%Pa_to_RLZ_T2)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back "//&

--- a/src/ALE/MOM_hybgen_regrid.F90
+++ b/src/ALE/MOM_hybgen_regrid.F90
@@ -100,7 +100,7 @@ subroutine init_hybgen_regrid(CS, GV, US, param_file)
                  "The pressure that is used for calculating the coordinate "//&
                  "density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.) "//&
                  "This is only used if USE_EOS and ENABLE_THERMODYNAMICS are true.", &
-                 units="Pa", default=2.0e7, scale=US%kg_m3_to_R*US%m_s_to_L_T**2)
+                 units="Pa", default=2.0e7, scale=US%Pa_to_RL2_T2)
 
   call get_param(param_file, mdl, "HYBGEN_MIN_THICKNESS", CS%min_thickness, &
                  "The minimum layer thickness allowed when regridding with Hybgen.",  &

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -534,7 +534,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
   endif
 
   ! ensure CS%ref_pressure is rescaled properly
-  CS%ref_pressure = (US%kg_m3_to_R * US%m_s_to_L_T**2) * CS%ref_pressure
+  CS%ref_pressure = US%Pa_to_RL2_T2 * CS%ref_pressure
 
   if (allocated(rho_target)) then
     call set_target_densities(CS, US%kg_m3_to_R*rho_target)
@@ -556,13 +556,13 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
                    "The pressure that is used for calculating the coordinate "//&
                    "density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.) "//&
                    "This is only used if USE_EOS and ENABLE_THERMODYNAMICS are true.", &
-                   units="Pa", default=2.0e7, scale=US%kg_m3_to_R*US%m_s_to_L_T**2)
+                   units="Pa", default=2.0e7, scale=US%Pa_to_RL2_T2)
     else
       call get_param(param_file, mdl, create_coord_param(param_prefix, "P_REF", param_suffix), P_Ref, &
                    "The pressure that is used for calculating the diagnostic coordinate "//&
                    "density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.) "//&
                    "This is only used for the RHO coordinate.", &
-                   units="Pa", default=2.0e7, scale=US%kg_m3_to_R*US%m_s_to_L_T**2)
+                   units="Pa", default=2.0e7, scale=US%Pa_to_RL2_T2)
     endif
     call get_param(param_file, mdl, create_coord_param(param_prefix, "REGRID_COMPRESSIBILITY_FRACTION", param_suffix), &
                  tmpReal, &

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2198,7 +2198,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   ! This is here in case these values are used inappropriately.
   use_frazil = .false. ; bound_salinity = .false.
-  CS%tv%P_Ref = 2.0e7*US%kg_m3_to_R*US%m_s_to_L_T**2
+  CS%tv%P_Ref = 2.0e7*US%Pa_to_RL2_T2
   if (use_temperature) then
     call get_param(param_file, "MOM", "FRAZIL", use_frazil, &
                  "If true, water freezes if it gets too cold, and the "//&
@@ -2234,7 +2234,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "The pressure that is used for calculating the coordinate "//&
                  "density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.) "//&
                  "This is only used if USE_EOS and ENABLE_THERMODYNAMICS are true.", &
-                 units="Pa", default=2.0e7, scale=US%kg_m3_to_R*US%m_s_to_L_T**2)
+                 units="Pa", default=2.0e7, scale=US%Pa_to_RL2_T2)
 
   if (bulkmixedlayer) then
     call get_param(param_file, "MOM", "NKML", nkml, &

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -188,7 +188,7 @@ subroutine PressureForce_FV_nonBouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_
       p(i,j,1) = p_atm(i,j)
     enddo ; enddo
   else
-    ! oneatm = 101325.0 * US%kg_m3_to_R * US%m_s_to_L_T**2 ! 1 atm scaled to [R L2 T-2 ~> Pa]
+    ! oneatm = 101325.0 * US%Pa_to_RL2_T2 ! 1 atm scaled to [R L2 T-2 ~> Pa]
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       p(i,j,1) = 0.0 ! or oneatm

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -635,7 +635,7 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
       if (CS%id_rhopot0 > 0) call post_data(CS%id_rhopot0, Rcv, CS%diag)
     endif
     if (CS%id_rhopot2 > 0) then
-      pressure_1d(:) = 2.0e7*US%kg_m3_to_R*US%m_s_to_L_T**2 ! 2000 dbars
+      pressure_1d(:) = 2.0e7*US%Pa_to_RL2_T2 ! 2000 dbars
       !$OMP parallel do default(shared)
       do k=1,nz ; do j=js,je
         call calculate_density(tv%T(:,j,k), tv%S(:,j,k),  pressure_1d, Rcv(:,j,k), &

--- a/src/framework/MOM_unit_scaling.F90
+++ b/src/framework/MOM_unit_scaling.F90
@@ -30,10 +30,10 @@ type, public :: unit_scale_type
   real :: kg_m3_to_R !< A constant that translates kilograms per meter cubed to the units of density  [R m3 kg-1 ~> 1]
   real :: Q_to_J_kg  !< A constant that translates the units of enthalpy to Joules per kilogram      [J kg-1 Q-1 ~> 1]
   real :: J_kg_to_Q  !< A constant that translates Joules per kilogram to the units of enthalpy        [Q kg J-1 ~> 1]
-  real :: C_to_degC  !< A constant that translates the units of temperature to degrees Celsius    [degC C-1 ~> 1]
-  real :: degC_to_C  !< A constant that translates degrees Celsius to the units of temperature    [C degC-1 ~> 1]
-  real :: S_to_ppt   !< A constant that translates the units of salinity to parts per thousand     [ppt S-1 ~> 1]
-  real :: ppt_to_S   !< A constant that translates parts per thousand to the units of salinity     [S ppt-1 ~> 1]
+  real :: C_to_degC  !< A constant that translates the units of temperature to degrees Celsius         [degC C-1 ~> 1]
+  real :: degC_to_C  !< A constant that translates degrees Celsius to the units of temperature         [C degC-1 ~> 1]
+  real :: S_to_ppt   !< A constant that translates the units of salinity to parts per thousand          [ppt S-1 ~> 1]
+  real :: ppt_to_S   !< A constant that translates parts per thousand to the units of salinity          [S ppt-1 ~> 1]
 
   ! These are useful combinations of the fundamental scale conversion factors above.
   real :: Z_to_L          !< Convert vertical distances to lateral lengths                                [L Z-1 ~> 1]
@@ -52,7 +52,8 @@ type, public :: unit_scale_type
   real :: RZ3_T3_to_W_m2  !< Convert turbulent kinetic energy fluxes from R Z3 T-3 to W m-2    [W T3 R-1 Z-3 m-2 ~> 1]
   real :: W_m2_to_RZ3_T3  !< Convert turbulent kinetic energy fluxes from W m-2 to R Z3 T-3     [R Z3 m2 T-3 W-1 ~> 1]
   real :: RL2_T2_to_Pa    !< Convert pressures from R L2 T-2 to Pa                                [Pa T2 R-1 L-2 ~> 1]
-  ! Not used enough:  real :: Pa_to_RL2_T2    !< Convert pressures from Pa to R L2 T-2            [R L2 T-2 Pa-1 ~> 1]
+  real :: Pa_to_RL2_T2    !< Convert pressures from Pa to R L2 T-2                                [R L2 T-2 Pa-1 ~> 1]
+  real :: Pa_to_RLZ_T2    !< Convert wind stresses from Pa to R L Z T-2                          [R L Z T-2 Pa-1 ~> 1]
 
   ! These are used for changing scaling across restarts.
   real :: m_to_Z_restart = 0.0 !< A copy of the m_to_Z that is used in restart files.
@@ -218,8 +219,9 @@ subroutine set_unit_scaling_combos(US)
   US%QRZ_T_to_W_m2 = US%Q_to_J_kg * US%R_to_kg_m3 * US%Z_to_m * US%s_to_T
   ! Pressures:
   US%RL2_T2_to_Pa = US%R_to_kg_m3 * US%L_T_to_m_s**2
-    ! It does not seem like US%Pa_to_RL2_T2 would be used enough in MOM6 to justify its existence.
-  ! US%Pa_to_RL2_T2 = US%kg_m3_to_R * US%m_s_to_L_T**2
+  US%Pa_to_RL2_T2 = US%kg_m3_to_R * US%m_s_to_L_T**2
+  ! Wind stresses:
+  US%Pa_to_RLZ_T2 = US%kg_m3_to_R * US%m_s_to_L_T**2 * US%L_to_Z
 
 end subroutine set_unit_scaling_combos
 

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1262,7 +1262,7 @@ subroutine trim_for_ice(PF, G, GV, US, ALE_CSp, tv, h, just_read)
   if (just_read) return ! All run-time parameters have been read, so return.
 
   call MOM_read_data(filename, p_surf_var, p_surf, G%Domain, &
-                     scale=scale_factor*US%kg_m3_to_R*US%m_s_to_L_T**2)
+                     scale=scale_factor*US%Pa_to_RL2_T2)
 
   if (use_remapping) then
     allocate(remap_CS)

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -167,7 +167,7 @@ logical function neutral_diffusion_init(Time, G, GV, US, param_file, diag, EOS, 
   call get_param(param_file, mdl, "NDIFF_REF_PRES", CS%ref_pres,                    &
                  "The reference pressure (Pa) used for the derivatives of "//&
                  "the equation of state. If negative (default), local pressure is used.", &
-                 units="Pa", default=-1., scale=US%kg_m3_to_R*US%m_s_to_L_T**2)
+                 units="Pa", default=-1., scale=US%Pa_to_RL2_T2)
   call get_param(param_file, mdl, "NDIFF_INTERIOR_ONLY", CS%interior_only, &
                  "If true, only applies neutral diffusion in the ocean interior."//&
                  "That is, the algorithm will exclude the surface and bottom"//&

--- a/src/user/Idealized_Hurricane.F90
+++ b/src/user/Idealized_Hurricane.F90
@@ -102,7 +102,7 @@ subroutine idealized_hurricane_wind_init(Time, G, US, param_file, CS)
 
   ! Local variables
   real :: dP  ! The pressure difference across the hurricane [R L2 T-2 ~> Pa]
-  real :: C
+  real :: C   ! A temporary variable [nondim]
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   logical :: default_2018_answers ! The default setting for the various 2018_ANSWERS flags.
   logical :: answers_2018         ! If true, use expressions driving the idealized hurricane test
@@ -132,10 +132,10 @@ subroutine idealized_hurricane_wind_init(Time, G, US, param_file, CS)
                  units='kg/m3', default=1.2, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "IDL_HURR_AMBIENT_PRESSURE", CS%pressure_ambient, &
                  "Ambient pressure used in the idealized hurricane wind profile.", &
-                 units='Pa', default=101200., scale=US%m_s_to_L_T**2*US%kg_m3_to_R)
+                 units='Pa', default=101200., scale=US%Pa_to_RL2_T2)
   call get_param(param_file, mdl, "IDL_HURR_CENTRAL_PRESSURE", CS%pressure_central, &
                  "Central pressure used in the idealized hurricane wind profile.", &
-                 units='Pa', default=96800., scale=US%m_s_to_L_T**2*US%kg_m3_to_R)
+                 units='Pa', default=96800., scale=US%Pa_to_RL2_T2)
   call get_param(param_file, mdl, "IDL_HURR_RAD_MAX_WIND", &
                  CS%rad_max_wind, "Radius of maximum winds used in the "//&
                  "idealized hurricane wind profile.", &

--- a/src/user/dumbbell_surface_forcing.F90
+++ b/src/user/dumbbell_surface_forcing.F90
@@ -210,7 +210,7 @@ subroutine dumbbell_surface_forcing_init(Time, G, US, param_file, diag, CS)
                  units="kg m-3", default=1035.0, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "DUMBBELL_SLP_AMP", CS%slp_amplitude, &
                  "Amplitude of SLP forcing in reservoirs.", &
-                 units="Pa", default=10000.0, scale=US%kg_m3_to_R*US%m_s_to_L_T**2)
+                 units="Pa", default=10000.0, scale=US%Pa_to_RL2_T2)
   call get_param(param_file, mdl, "DUMBBELL_SLP_PERIOD", CS%slp_period, &
                  "Periodicity of SLP forcing in reservoirs.", &
                  units="days", default=1.0)


### PR DESCRIPTION
  This PR adds the new elements Pa_to_RL2_T2 and Pa_to_RLZ_T2 to the unit_scale_type and then uses them to simplify the expressions rescaling various input pressures and wind stresses.  I find this convenient in part because I find myself having to reconstruct the combination of basic mks units that are Pascals when evaluating the correctness of expressions using it, whereas I think that this combined scaling factor makes the consistency more readily apparent,
while also making the code shorter.  In addition the new runtime parameter TAUX_MAGNITUDE was added for several ocean-only configurations to replace some previously hard-coded dimensional constants, with default values that match
those hard-coded constants in each case.  By default, all answers are bitwise identical, but there are two new elements in a transparent public type, and there are new entries in some MOM_parameter_doc.short files.

  The commits in this PR include:

- NOAA-GFDL/MOM6@a62ea7155 +Add runtime parameter TAUX_MAGNITUDE
- NOAA-GFDL/MOM6@e25c4cddb Use US%Pa_to_RL2_T2 to rescale pressures
- NOAA-GFDL/MOM6@3b70880cd +Add Pa_to_RL2_T2 and Pa_to_RLZ_T2 to US type
