### PR TITLE
Add PPM_CM and HYCOM1_ONLY_IMPROVES

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -206,12 +206,12 @@ subroutine ALE_init( param_file, GV, US, max_depth, CS)
   call get_param(param_file, mdl, "REMAPPING_SCHEME", string, &
                  "This sets the reconstruction scheme used "//&
                  "for vertical remapping for all variables. "//&
-                 "It can be one of the following schemes: "//&
+                 "It can be one of the following schemes: \n"//&
                  trim(remappingSchemesDoc), default=remappingDefaultScheme)
   call get_param(param_file, mdl, "VELOCITY_REMAPPING_SCHEME", vel_string, &
                  "This sets the reconstruction scheme used for vertical remapping "//&
                  "of velocities. By default it is the same as REMAPPING_SCHEME. "//&
-                 "It can be one of the following schemes: "//&
+                 "It can be one of the following schemes: \n"//&
                  trim(remappingSchemesDoc), default=trim(string))
   call get_param(param_file, mdl, "FATAL_CHECK_RECONSTRUCTIONS", check_reconstruction, &
                  "If true, cell-by-cell reconstructions are checked for "//&

--- a/src/ALE/coord_hycom.F90
+++ b/src/ALE/coord_hycom.F90
@@ -4,8 +4,10 @@ module coord_hycom
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_error_handler, only : MOM_error, FATAL
+use MOM_remapping,     only : remapping_CS, remapping_core_h
 use MOM_EOS,           only : EOS_type, calculate_density
-use regrid_interp,     only : interp_CS_type, build_and_interpolate_grid
+use regrid_interp,     only : interp_CS_type, build_and_interpolate_grid, regridding_set_ppolys
+use regrid_interp,     only : DEGREE_MAX
 
 implicit none ; private
 
@@ -26,6 +28,9 @@ type, public :: hycom_CS ; private
 
   !> Maximum thicknesses of layers [H ~> m or kg m-2]
   real, allocatable, dimension(:) :: max_layer_thickness
+
+  !> If true, an interface only moves if it improves the density fit
+  logical :: only_improves = .false.
 
   !> Interpolation control structure
   type(interp_CS_type) :: interp_CS
@@ -69,10 +74,11 @@ subroutine end_coord_hycom(CS)
 end subroutine end_coord_hycom
 
 !> This subroutine can be used to set the parameters for the coord_hycom module
-subroutine set_hycom_params(CS, max_interface_depths, max_layer_thickness, interp_CS)
+subroutine set_hycom_params(CS, max_interface_depths, max_layer_thickness, only_improves, interp_CS)
   type(hycom_CS),                 pointer    :: CS !< Coordinate control structure
   real, dimension(:),   optional, intent(in) :: max_interface_depths !< Maximum depths of interfaces [H ~> m or kg m-2]
   real, dimension(:),   optional, intent(in) :: max_layer_thickness  !< Maximum thicknesses of layers [H ~> m or kg m-2]
+  logical, optional, intent(in) :: only_improves !< If true, an interface only moves if it improves the density fit
   type(interp_CS_type), optional, intent(in) :: interp_CS !< Controls for interpolation
 
   if (.not. associated(CS)) call MOM_error(FATAL, "set_hycom_params: CS not associated")
@@ -91,13 +97,16 @@ subroutine set_hycom_params(CS, max_interface_depths, max_layer_thickness, inter
     CS%max_layer_thickness(:) = max_layer_thickness(:)
   endif
 
+  if (present(only_improves)) CS%only_improves = only_improves
+
   if (present(interp_CS)) CS%interp_CS = interp_CS
 end subroutine set_hycom_params
 
 !> Build a HyCOM coordinate column
-subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, &
+subroutine build_hycom1_column(CS, remapCS, eqn_of_state, nz, depth, h, T, S, p_col, &
                                z_col, z_col_new, zScale, h_neglect, h_neglect_edge)
   type(hycom_CS),        intent(in)    :: CS    !< Coordinate control structure
+  type(remapping_CS),    intent(in)    :: remapCS !< Remapping parameters and options
   type(EOS_type),        intent(in)    :: eqn_of_state !< Equation of state structure
   integer,               intent(in)    :: nz    !< Number of levels
   real,                  intent(in)    :: depth !< Depth of ocean bottom (positive [H ~> m or kg m-2])
@@ -116,8 +125,17 @@ subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, &
 
   ! Local variables
   integer   :: k
-  real, dimension(nz) :: rho_col ! Layer densities in a column [R ~> kg m-3]
-  real, dimension(CS%nk) :: h_col_new ! New layer thicknesses
+  real, dimension(nz)      :: rho_col   ! Layer densities in a column [R ~> kg m-3]
+  real, dimension(CS%nk)   :: h_col_new ! New layer thicknesses [H ~> m or kg m-2]
+  real, dimension(CS%nk)   :: r_col_new ! New layer densities [R ~> kg m-3]
+  real, dimension(CS%nk)   :: T_col_new ! New layer temperatures [C ~> degC]
+  real, dimension(CS%nk)   :: S_col_new ! New layer salinities [S ~> ppt]
+  real, dimension(CS%nk)   :: p_col_new ! New layer pressure [R L2 T-2 ~> Pa]
+  real, dimension(CS%nk+1) :: RiA_ini   ! Initial nk+1 interface density anomaly w.r.t. the
+                                        ! interface target densities [R ~> kg m-3]
+  real, dimension(CS%nk+1) :: RiA_new   ! New interface density anomaly w.r.t. the
+                                        ! interface target densities [R ~> kg m-3]
+  real :: z_1, z_nz  ! mid point of 1st and last layers [H ~> m or kg m-2]
   real :: z_scale    ! A scaling factor from the input thicknesses to the target thicknesses,
                      ! perhaps 1 or a factor in [H Z-1 ~> 1 or kg m-3]
   real :: stretching ! z* stretching, converts z* to z [nondim].
@@ -130,18 +148,43 @@ subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, &
 
   z_scale = 1.0 ; if (present(zScale)) z_scale = zScale
 
-  ! Work bottom recording potential density
-  call calculate_density(T, S, p_col, rho_col, eqn_of_state)
-  ! This ensures the potential density profile is monotonic
-  ! although not necessarily single valued.
-  do k = nz-1, 1, -1
-    rho_col(k) = min( rho_col(k), rho_col(k+1) )
-  enddo
+  if (CS%only_improves .and. nz == CS%nk) then
+    call build_hycom1_target_anomaly(CS, remapCS, eqn_of_state, CS%nk, depth, &
+        h, T, S, p_col, rho_col, RiA_ini, h_neglect, h_neglect_edge)
+  else
+    ! Work bottom recording potential density
+    call calculate_density(T, S, p_col, rho_col, eqn_of_state)
+    ! This ensures the potential density profile is monotonic
+    ! although not necessarily single valued.
+    do k = nz-1, 1, -1
+      rho_col(k) = min( rho_col(k), rho_col(k+1) )
+    enddo
+  endif
 
   ! Interpolates for the target interface position with the rho_col profile
   ! Based on global density profile, interpolate to generate a new grid
   call build_and_interpolate_grid(CS%interp_CS, rho_col, nz, h(:), z_col, &
            CS%target_density, CS%nk, h_col_new, z_col_new, h_neglect, h_neglect_edge)
+  if (CS%only_improves .and. nz == CS%nk) then
+    ! Only move an interface if it improves the density fit
+    z_1 = 0.5 * ( z_col(1) + z_col(2) )
+    z_nz  = 0.5 * ( z_col(nz) + z_col(nz+1) )
+    do k = 1,CS%nk
+      p_col_new(k) = p_col(1) + ( 0.5 * ( z_col_new(K) + z_col_new(K+1) ) - z_1 ) / ( z_nz - z_1 ) * &
+          ( p_col(nz) - p_col(1) )
+    enddo
+    ! Remap from original h and T,S to get T,S_col_new
+    call remapping_core_h(remapCS, nz, h(:), T, CS%nk, h_col_new, T_col_new, h_neglect, h_neglect_edge)
+    call remapping_core_h(remapCS, nz, h(:), S, CS%nk, h_col_new, S_col_new, h_neglect, h_neglect_edge)
+    call build_hycom1_target_anomaly(CS, remapCS, eqn_of_state, CS%nk, depth, &
+        h_col_new, T_col_new, S_col_new, p_col_new, r_col_new, RiA_new, h_neglect, h_neglect_edge)
+    do k= 2,CS%nk
+      if     ( abs(RiA_ini(K)) <= abs(RiA_new(K)) .and. z_col(K) > z_col_new(K-1) .and. &
+               z_col(K) < z_col_new(K+1)) then
+        z_col_new(K) = z_col(K)
+      endif
+    enddo
+  endif !only_improves
 
   ! Sweep down the interfaces and make sure that the interface is at least
   ! as deep as a nominal target z* grid
@@ -164,5 +207,60 @@ subroutine build_hycom1_column(CS, eqn_of_state, nz, depth, h, T, S, p_col, &
     z_col_new(K) = min(z_col_new(K), z_col_new(K-1) + CS%max_layer_thickness(k-1))
   enddo ; endif
 end subroutine build_hycom1_column
+
+!> Calculate interface density anomaly w.r.t. the target.
+subroutine build_hycom1_target_anomaly(CS, remapCS, eqn_of_state, nz, depth, h, T, S, p_col, &
+                                       R, RiAnom, h_neglect, h_neglect_edge)
+  type(hycom_CS),        intent(in)  :: CS     !< Coordinate control structure
+  type(remapping_CS),    intent(in)  :: remapCS !< Remapping parameters and options
+  type(EOS_type),        intent(in)  :: eqn_of_state !< Equation of state structure
+  integer,               intent(in)  :: nz     !< Number of levels
+  real,                  intent(in)  :: depth  !< Depth of ocean bottom (positive [H ~> m or kg m-2])
+  real, dimension(nz),   intent(in)  :: T      !< Temperature of column [C ~> degC]
+  real, dimension(nz),   intent(in)  :: S      !< Salinity of column [S ~> ppt]
+  real, dimension(nz),   intent(in)  :: h      !< Layer thicknesses [H ~> m or kg m-2]
+  real, dimension(nz),   intent(in)  :: p_col  !< Layer pressure [R L2 T-2 ~> Pa]
+                                               !! to desired units for zInterface, perhaps GV%Z_to_H.
+  real, dimension(nz),   intent(out) :: R      !< Layer density [R ~> kg m-3]
+  real, dimension(nz+1), intent(out) :: RiAnom !< The interface density anomaly
+                                               !! w.r.t. the interface target
+                                               !! densities [R ~> kg m-3]
+  real,        optional, intent(in)  :: h_neglect !< A negligibly small width for the purpose of
+                                               !! cell reconstruction [H ~> m or kg m-2]
+  real,        optional, intent(in)  :: h_neglect_edge !< A negligibly small width for the purpose of
+                                                !! edge value calculation [H ~> m or kg m-2]
+  ! Local variables
+  integer   :: degree,k
+  real, dimension(nz)   :: rho_col ! Layer densities in a column [R ~> kg m-3]
+  real, dimension(nz,2) :: ppoly_E ! Polynomial edge values [R ~> kg m-3]
+  real, dimension(nz,2) :: ppoly_S ! Polynomial edge slopes [R H-1]
+  real, dimension(nz,DEGREE_MAX+1) :: ppoly_C ! Polynomial interpolant coeficients on the local 0-1 grid [R ~> kg m-3]
+
+  ! Work bottom recording potential density
+  call calculate_density(T, S, p_col, rho_col, eqn_of_state)
+  ! This ensures the potential density profile is monotonic
+  ! although not necessarily single valued.
+  do k = nz-1, 1, -1
+    rho_col(k) = min( rho_col(k), rho_col(k+1) )
+  enddo
+
+  call regridding_set_ppolys(CS%interp_CS, rho_col, nz, h, ppoly_E, ppoly_S, ppoly_C, &
+                             degree, h_neglect, h_neglect_edge)
+
+  R(1) = rho_col(1)
+  RiAnom(1) = ppoly_E(1,1) - CS%target_density(1)
+  do k= 2,nz
+    R(k) = rho_col(k)
+    if (ppoly_E(k-1,2) > CS%target_density(k)) then
+      RiAnom(k) = ppoly_E(k-1,2) - CS%target_density(k)  !interface is heavier than target
+    elseif (ppoly_E(k,1) < CS%target_density(k)) then
+      RiAnom(k) = ppoly_E(k,1)   - CS%target_density(k)  !interface is lighter than target
+    else
+      RiAnom(k) = 0.0  !interface spans the target
+    endif
+  enddo
+  RiAnom(nz+1) = ppoly_E(nz,2) - CS%target_density(nz+1)
+
+end subroutine build_hycom1_target_anomaly
 
 end module coord_hycom

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -7,11 +7,13 @@ use MOM_error_handler, only : MOM_error, FATAL
 use MOM_string_functions, only : uppercase
 
 use regrid_edge_values, only : edge_values_explicit_h2, edge_values_explicit_h4
+use regrid_edge_values, only : edge_values_explicit_h4cw
 use regrid_edge_values, only : edge_values_implicit_h4, edge_values_implicit_h6
 use regrid_edge_values, only : edge_slopes_implicit_h3, edge_slopes_implicit_h5
 
 use PLM_functions, only : PLM_reconstruction, PLM_boundary_extrapolation
 use PPM_functions, only : PPM_reconstruction, PPM_boundary_extrapolation
+use PPM_functions, only : PPM_monotonicity
 use PQM_functions, only : PQM_reconstruction, PQM_boundary_extrapolation_v1
 
 use P1M_functions, only : P1M_interpolation, P1M_boundary_extrapolation
@@ -45,6 +47,7 @@ integer, parameter :: INTERPOLATION_P1M_H2     = 0 !< O(h^2)
 integer, parameter :: INTERPOLATION_P1M_H4     = 1 !< O(h^2)
 integer, parameter :: INTERPOLATION_P1M_IH4    = 2 !< O(h^2)
 integer, parameter :: INTERPOLATION_PLM        = 3 !< O(h^2)
+integer, parameter :: INTERPOLATION_PPM_CW     =10 !< O(h^3)
 integer, parameter :: INTERPOLATION_PPM_H4     = 4 !< O(h^3)
 integer, parameter :: INTERPOLATION_PPM_IH4    = 5 !< O(h^3)
 integer, parameter :: INTERPOLATION_P3M_IH4IH3 = 6 !< O(h^4)
@@ -142,6 +145,25 @@ subroutine regridding_set_ppolys(CS, densities, n0, h0, ppoly0_E, ppoly0_S, &
       call PLM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
       if (extrapolate) then
         call PLM_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect )
+      endif
+
+    case ( INTERPOLATION_PPM_CW )
+      if ( n0 >= 4 ) then
+        degree = DEGREE_2
+        call edge_values_explicit_h4cw( n0, h0, densities, ppoly0_E, h_neglect_edge )
+        call PPM_monotonicity(   n0,     densities, ppoly0_E )
+        call PPM_reconstruction( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
+        if (extrapolate) then
+          call PPM_boundary_extrapolation( n0, h0, densities, ppoly0_E, &
+                                           ppoly0_coefs, h_neglect )
+        endif
+      else
+        degree = DEGREE_1
+        call edge_values_explicit_h2( n0, h0, densities, ppoly0_E )
+        call P1M_interpolation( n0, h0, densities, ppoly0_E, ppoly0_coefs, h_neglect, answer_date=CS%answer_date )
+        if (extrapolate) then
+          call P1M_boundary_extrapolation( n0, h0, densities, ppoly0_E, ppoly0_coefs )
+        endif
       endif
 
     case ( INTERPOLATION_PPM_H4 )
@@ -486,7 +508,7 @@ end function get_polynomial_coordinate
 !> Numeric value of interpolation_scheme corresponding to scheme name
 integer function interpolation_scheme(interp_scheme)
   character(len=*), intent(in) :: interp_scheme !< Name of the interpolation scheme
-        !! Valid values include "P1M_H2", "P1M_H4", "P1M_IH2", "PLM", "PPM_H4",
+        !! Valid values include "P1M_H2", "P1M_H4", "P1M_IH2", "PLM", "PPM_CW", "PPM_H4",
         !!   "PPM_IH4", "P3M_IH4IH3", "P3M_IH6IH5", "PQM_IH4IH3", and "PQM_IH6IH5"
 
   select case ( uppercase(trim(interp_scheme)) )
@@ -494,6 +516,7 @@ integer function interpolation_scheme(interp_scheme)
     case ("P1M_H4");     interpolation_scheme = INTERPOLATION_P1M_H4
     case ("P1M_IH2");    interpolation_scheme = INTERPOLATION_P1M_IH4
     case ("PLM");        interpolation_scheme = INTERPOLATION_PLM
+    case ("PPM_CW");     interpolation_scheme = INTERPOLATION_PPM_CW
     case ("PPM_H4");     interpolation_scheme = INTERPOLATION_PPM_H4
     case ("PPM_IH4");    interpolation_scheme = INTERPOLATION_PPM_IH4
     case ("P3M_IH4IH3"); interpolation_scheme = INTERPOLATION_P3M_IH4IH3
@@ -509,7 +532,7 @@ end function interpolation_scheme
 subroutine set_interp_scheme(CS, interp_scheme)
   type(interp_CS_type), intent(inout) :: CS  !< A control structure for regrid_interp
   character(len=*),     intent(in) :: interp_scheme !< Name of the interpolation scheme
-        !! Valid values include "P1M_H2", "P1M_H4", "P1M_IH2", "PLM", "PPM_H4",
+        !! Valid values include "P1M_H2", "P1M_H4", "P1M_IH2", "PLM", "PPM_CW", "PPM_H4",
         !!   "PPM_IH4", "P3M_IH4IH3", "P3M_IH6IH5", "PQM_IH4IH3", and "PQM_IH6IH5"
 
   CS%interpolation_scheme = interpolation_scheme(interp_scheme)


### PR DESCRIPTION
Add "PPM_CW" as an option for INTERPOLATION_SCHEME and REMAPPING_SCHEME. This implements the original Colella and Woodward (1984) edge calculation for PPM. It computes 4th order explicit edge values but constrains them to produce a monotonic profile, which is particularly effective for remapping.

INTERPOLATION_SCHEME="PPM_CW" is identical to "REMAPPING_PPM_HYBGEN", but hybgen_PPM_coefs has been replaced by edge_values_explicit_h4cw and PPM_monotonicity for flexibility and to simplify upgrades. Answers with existing INTERPOLATION_SCHEME options are unchanged.

REMAPPING_SCHEME="PPM_CW" is a new option which can perform better than "P1M_H2" when used with INTERPOLATION_SCHEME="PPM_CW".  Answers with existing REMAPPING_SCHEME options are unchanged.

HYCOM1 regridding walks a monotonic density profile to locate the new interface locations where the interface density equals the target density.  However, it assumes that moving one interface has no effect on the density at all other interfaces and this need not be the case. When regridding, with HYCOM1_ONLY_IMPROVES=True, an interface is only moved if this improves the fit to its target density.  The default of False does not change answers.