### PR TITLE
Removal of FMS1 I/O from FMS2 I/O infra

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -8,12 +8,12 @@ use mpp_domains_mod,          only: mpp_get_compute_domains
 use mpp_domains_mod,          only: mpp_get_ntile_count, mpp_get_pelist, mpp_get_global_domain
 use mpp_domains_mod,          only: mpp_get_domain_npes
 
-use MOM_time_manager,         only: set_calendar_type, time_type, set_time, set_date, month_name
+use MOM_time_manager,         only: set_calendar_type, time_type, set_time, set_date
 use MOM_time_manager,         only: GREGORIAN, JULIAN, NOLEAP
 use MOM_time_manager,         only: operator( <= ), operator( < ), operator( >= )
 use MOM_time_manager,         only: operator( + ),  operator( - ), operator( / )
 use MOM_time_manager,         only: operator( * ), operator( /= ), operator( > )
-use MOM_domains,              only: MOM_infra_init, MOM_infra_end, num_pes, root_pe, pe_here
+use MOM_domains,              only: MOM_infra_init, MOM_infra_end
 use MOM_file_parser,          only: get_param, log_version, param_file_type, close_param_file
 use MOM_get_input,            only: get_MOM_input, directories
 use MOM_domains,              only: pass_var

--- a/config_src/infra/FMS1/MOM_domain_infra.F90
+++ b/config_src/infra/FMS1/MOM_domain_infra.F90
@@ -1489,7 +1489,7 @@ end subroutine get_domain_components_d2D
 !> clone_MD_to_MD copies one MOM_domain_type into another, while allowing
 !! some properties of the new type to differ from the original one.
 subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain_name, &
-                          turns, refine, extra_halo)
+                          turns, refine, extra_halo, io_layout)
   type(MOM_domain_type), target, intent(in) :: MD_in  !< An existing MOM_domain
   type(MOM_domain_type), pointer :: MOM_dom
                                   !< A pointer to a MOM_domain that will be
@@ -1512,6 +1512,8 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
   integer, optional, intent(in) :: refine  !< A factor by which to enhance the grid resolution.
   integer, optional, intent(in) :: extra_halo !< An extra number of points in the halos
                                   !! compared with MD_in
+  integer, optional, intent(in) :: io_layout(2)
+    !< A user-defined IO layout to replace the domain's IO layout
 
   logical :: mask_table_exists
   integer, dimension(:), allocatable :: exni ! The extents of the grid for each i-row of the layout.
@@ -1520,9 +1522,16 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
                                              ! The sum of exni must equal MOM_dom%niglobal.
   integer :: qturns ! The number of quarter turns, restricted to the range of 0 to 3.
   integer :: i, j, nl1, nl2
+  integer :: io_layout_in(2)
 
   qturns = 0
   if (present(turns)) qturns = modulo(turns, 4)
+
+  if (present(io_layout)) then
+    io_layout_in(:) = io_layout(:)
+  else
+    io_layout_in(:) = MD_in%io_layout(:)
+  endif
 
   if (.not.associated(MOM_dom)) then
     allocate(MOM_dom)
@@ -1542,7 +1551,7 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
 
     MOM_dom%X_FLAGS = MD_in%Y_FLAGS ; MOM_dom%Y_FLAGS = MD_in%X_FLAGS
     MOM_dom%layout(:) = MD_in%layout(2:1:-1)
-    MOM_dom%io_layout(:) = MD_in%io_layout(2:1:-1)
+    MOM_dom%io_layout(:) = io_layout_in(2:1:-1)
   else
     MOM_dom%niglobal = MD_in%niglobal ; MOM_dom%njglobal = MD_in%njglobal
     MOM_dom%nihalo = MD_in%nihalo ; MOM_dom%njhalo = MD_in%njhalo
@@ -1550,7 +1559,7 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
 
     MOM_dom%X_FLAGS = MD_in%X_FLAGS ; MOM_dom%Y_FLAGS = MD_in%Y_FLAGS
     MOM_dom%layout(:) = MD_in%layout(:)
-    MOM_dom%io_layout(:) = MD_in%io_layout(:)
+    MOM_dom%io_layout(:) = io_layout_in(:)
   endif
 
   ! Ensure that the points per processor are the same on the source and densitation grids.

--- a/config_src/infra/FMS2/MOM_domain_infra.F90
+++ b/config_src/infra/FMS2/MOM_domain_infra.F90
@@ -23,7 +23,7 @@ use mpp_domains_mod, only : CYCLIC_GLOBAL_DOMAIN, FOLD_NORTH_EDGE
 use mpp_domains_mod, only : To_East => WUPDATE, To_West => EUPDATE, Omit_Corners => EDGEUPDATE
 use mpp_domains_mod, only : To_North => SUPDATE, To_South => NUPDATE
 use mpp_domains_mod, only : CENTER, CORNER, NORTH_FACE => NORTH, EAST_FACE => EAST
-use fms_io_mod,      only : file_exist, parse_mask_table
+use fms_io_utils_mod, only : file_exists, parse_mask_table
 use fms_affinity_mod, only : fms_affinity_init, fms_affinity_set, fms_affinity_get
 
 ! This subroutine is not in MOM6/src but may be required by legacy drivers
@@ -1390,7 +1390,7 @@ subroutine create_MOM_domain(MOM_dom, n_global, n_halo, reentrant, tripolar_N, l
   endif
 
   if (present(mask_table)) then
-    mask_table_exists = file_exist(mask_table)
+    mask_table_exists = file_exists(mask_table)
     if (mask_table_exists) then
       allocate(MOM_dom%maskmap(layout(1), layout(2)))
       call parse_mask_table(mask_table, MOM_dom%maskmap, MOM_dom%name)

--- a/config_src/infra/FMS2/MOM_domain_infra.F90
+++ b/config_src/infra/FMS2/MOM_domain_infra.F90
@@ -1491,7 +1491,7 @@ end subroutine get_domain_components_d2D
 !> clone_MD_to_MD copies one MOM_domain_type into another, while allowing
 !! some properties of the new type to differ from the original one.
 subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain_name, &
-                          turns, refine, extra_halo)
+                          turns, refine, extra_halo, io_layout)
   type(MOM_domain_type), target, intent(in) :: MD_in  !< An existing MOM_domain
   type(MOM_domain_type), pointer :: MOM_dom
                                   !< A pointer to a MOM_domain that will be
@@ -1514,6 +1514,9 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
   integer, optional, intent(in) :: refine  !< A factor by which to enhance the grid resolution.
   integer, optional, intent(in) :: extra_halo !< An extra number of points in the halos
                                   !! compared with MD_in
+  integer, optional, intent(in) :: io_layout(2)
+    !< A user-defined IO layout to replace the domain's IO layout
+
 
   integer :: global_indices(4)
   logical :: mask_table_exists
@@ -1523,9 +1526,16 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
                                              ! The sum of exni must equal MOM_dom%niglobal.
   integer :: qturns ! The number of quarter turns, restricted to the range of 0 to 3.
   integer :: i, j, nl1, nl2
+  integer :: io_layout_in(2)
 
   qturns = 0
   if (present(turns)) qturns = modulo(turns, 4)
+
+  if (present(io_layout)) then
+    io_layout_in(:) = io_layout(:)
+  else
+    io_layout_in(:) = MD_in%io_layout(:)
+  endif
 
   if (.not.associated(MOM_dom)) then
     allocate(MOM_dom)
@@ -1545,7 +1555,7 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
 
     MOM_dom%X_FLAGS = MD_in%Y_FLAGS ; MOM_dom%Y_FLAGS = MD_in%X_FLAGS
     MOM_dom%layout(:) = MD_in%layout(2:1:-1)
-    MOM_dom%io_layout(:) = MD_in%io_layout(2:1:-1)
+    MOM_dom%io_layout(:) = io_layout_in(2:1:-1)
   else
     MOM_dom%niglobal = MD_in%niglobal ; MOM_dom%njglobal = MD_in%njglobal
     MOM_dom%nihalo = MD_in%nihalo ; MOM_dom%njhalo = MD_in%njhalo
@@ -1553,7 +1563,7 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
 
     MOM_dom%X_FLAGS = MD_in%X_FLAGS ; MOM_dom%Y_FLAGS = MD_in%Y_FLAGS
     MOM_dom%layout(:) = MD_in%layout(:)
-    MOM_dom%io_layout(:) = MD_in%io_layout(:)
+    MOM_dom%io_layout(:) = io_layout_in(:)
   endif
 
   ! Ensure that the points per processor are the same on the source and densitation grids.

--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -9,6 +9,7 @@ use MOM_error_infra,      only : MOM_error=>MOM_err, NOTE, FATAL, WARNING, is_ro
 use MOM_string_functions, only : lowercase
 
 use fms2_io_mod,          only : fms2_open_file => open_file, check_if_open, fms2_close_file => close_file
+use fms2_io_mod,          only : fms2_flush_file => flush_file
 use fms2_io_mod,          only : FmsNetcdfDomainFile_t, FmsNetcdfFile_t, fms2_read_data => read_data
 use fms2_io_mod,          only : get_unlimited_dimension_name, get_num_dimensions, get_num_variables
 use fms2_io_mod,          only : get_variable_names, variable_exists, get_variable_size, get_variable_units
@@ -18,29 +19,27 @@ use fms2_io_mod,          only : get_variable_dimension_names, is_dimension_regi
 use fms2_io_mod,          only : is_dimension_unlimited, register_axis, unlimited
 use fms2_io_mod,          only : get_global_io_domain_indices
 use fms_io_utils_mod,     only : fms2_file_exist => file_exists
+use fms_io_utils_mod,     only : get_filename_appendix
 
 use fms_mod,              only : write_version_number, check_nml_error
-use fms_io_mod,           only : file_exist, field_exist, field_size, read_data
-use fms_io_mod,           only : fms_io_exit, get_filename_appendix
 use mpp_domains_mod,      only : mpp_get_compute_domain, mpp_get_global_domain
-use mpp_io_mod,           only : mpp_open, mpp_close, mpp_flush
-use mpp_io_mod,           only : mpp_write_meta, mpp_write
-use mpp_io_mod,           only : mpp_get_atts, mpp_attribute_exist
-use mpp_io_mod,           only : mpp_get_axes, mpp_axistype=>axistype, mpp_get_axis_data
-use mpp_io_mod,           only : mpp_get_fields, mpp_fieldtype=>fieldtype
-use mpp_io_mod,           only : mpp_get_info, mpp_get_times
-use mpp_io_mod,           only : mpp_io_init
 use mpp_mod,              only : stdout_if_root=>stdout
 use mpp_mod,              only : mpp_pe, mpp_root_pe, mpp_npes
 use mpp_mod,              only : mpp_get_current_pelist_name
-! These are encoding constants.
-use mpp_io_mod,           only : APPEND_FILE=>MPP_APPEND, WRITEONLY_FILE=>MPP_WRONLY
-use mpp_io_mod,           only : OVERWRITE_FILE=>MPP_OVERWR, READONLY_FILE=>MPP_RDONLY
-use mpp_io_mod,           only : NETCDF_FILE=>MPP_NETCDF, ASCII_FILE=>MPP_ASCII
-use mpp_io_mod,           only : MULTIPLE=>MPP_MULTI, SINGLE_FILE=>MPP_SINGLE
 use iso_fortran_env,      only : int64
 
 implicit none ; private
+
+! Duplication of FMS1 parameter values
+! NOTE: Only kept to emulate FMS1 behavior, and may be removed in the future.
+integer, parameter :: WRITEONLY_FILE = 100
+integer, parameter :: READONLY_FILE = 101
+integer, parameter :: APPEND_FILE = 102
+integer, parameter :: OVERWRITE_FILE = 103
+integer, parameter :: ASCII_FILE = 200
+integer, parameter :: NETCDF_FILE = 203
+integer, parameter :: SINGLE_FILE = 400
+integer, parameter :: MULTIPLE = 401
 
 ! These interfaces are actually implemented or have explicit interfaces in this file.
 public :: open_file, open_ASCII_file, file_is_open, close_file, flush_file, file_exists
@@ -62,11 +61,6 @@ interface file_exists
   module procedure FMS_file_exists
   module procedure MOM_file_exists
 end interface
-
-!> Open a file (or fileset) for parallel or single-file I/O.
-interface open_file
-  module procedure open_file_type, open_file_unit
-end interface open_file
 
 !> Read a data field from a file
 interface read_field
@@ -104,11 +98,6 @@ interface close_file
   module procedure close_file_type, close_file_unit
 end interface close_file
 
-!> Ensure that the output stream associated with a file handle is fully sent to disk
-interface flush_file
-  module procedure flush_file_type, flush_file_unit
-end interface flush_file
-
 !> Type for holding a handle to an open file and related information
 type :: file_type ; private
   integer :: unit = -1 !< The framework identfier or netCDF unit number of an output file
@@ -119,31 +108,23 @@ type :: file_type ; private
   logical :: open_to_write = .false. !< If true, this file or fileset can be written to
   integer :: num_times !< The number of time levels in this file
   real    :: file_time !< The time of the latest entry in the file.
-  logical :: FMS2_file !< If true, this file-type is to be used with FMS2 interfaces.
 end type file_type
 
 !> This type is a container for information about a variable in a file.
 type :: fieldtype ; private
   character(len=256)  :: name !< The name of this field in the files.
-  type(mpp_fieldtype) :: FT !< The FMS1 field-type that this type wraps
   character(len=:), allocatable :: longname !< The long name for this field
   character(len=:), allocatable :: units    !< The units for this field
   integer(kind=int64) :: chksum_read !< A checksum that has been read from a file
   logical :: valid_chksum !< If true, this field has a valid checksum value.
-  logical :: FMS2_field  !< If true, this field-type should be used with FMS2 interfaces.
 end type fieldtype
 
 !> This type is a container for information about an axis in a file.
 type :: axistype ; private
   character(len=256) :: name !< The name of this axis in the files.
-  type(mpp_axistype) :: AT   !< The FMS1 axis-type that this type wraps
   real, allocatable, dimension(:) :: ax_data !< The values of the data on the axis.
   logical :: domain_decomposed = .false.  !< True if axis is domain-decomposed
 end type axistype
-
-!> For now, these module-variables are hard-coded to exercise the new FMS2 interfaces.
-logical :: FMS2_reads  = .true.
-logical :: FMS2_writes = .true.
 
 contains
 
@@ -165,11 +146,10 @@ logical function MOM_file_exists(filename, MOM_Domain)
   character(len=*),       intent(in) :: filename   !< The name of the file being inquired about
   type(MOM_domain_type),  intent(in) :: MOM_Domain !< The MOM_Domain that describes the decomposition
 
-! This function uses the fms_io function file_exist to determine whether
-! a named file (or its decomposed variant) exists.
+  type(FmsNetcdfDomainFile_t) :: fileobj
 
-  MOM_file_exists = file_exist(filename, MOM_Domain%mpp_domain)
-
+  MOM_file_exists = fms2_open_file(fileobj, filename, "read", MOM_Domain%mpp_domain)
+  if (MOM_file_exists) call fms2_close_file(fileobj)
 end function MOM_file_exists
 
 !> Returns true if the named file or its domain-decomposed variant exists.
@@ -196,14 +176,15 @@ subroutine close_file_type(IO_handle)
   if (associated(IO_handle%fileobj)) then
     call fms2_close_file(IO_handle%fileobj)
     deallocate(IO_handle%fileobj)
-  else
-    call mpp_close(IO_handle%unit)
   endif
   if (allocated(IO_handle%filename)) deallocate(IO_handle%filename)
   IO_handle%open_to_read = .false. ; IO_handle%open_to_write = .false.
   IO_handle%num_times = 0 ; IO_handle%file_time = 0.0
-  IO_handle%FMS2_file = .false.
 end subroutine close_file_type
+
+! TODO: close_file_unit is only used for ASCII files, which are opened outside
+! of the framework, so this could probably be removed, and those calls could
+! just be replaced with close(unit).
 
 !> closes a file.  If the unit does not point to an open file,
 !! close_file_unit simply returns without doing anything.
@@ -212,45 +193,30 @@ subroutine close_file_unit(iounit)
 
   logical :: unit_is_open
 
-  ! NOTE: Files opened by `mpp_open` must be closed by `mpp_close`.  Otherwise,
-  ! an error will occur during `fms_io_exit`.
-  !
-  ! Since there is no way to check if `fms_io_init` was called, we are forced
-  ! to visually confirm that the input unit was not created by `mpp_open`.
-  !
-  ! After `mpp_open` has been removed, this message can be deleted.
   inquire(iounit, opened=unit_is_open)
   if (unit_is_open) close(iounit)
 end subroutine close_file_unit
 
 !> Ensure that the output stream associated with a file handle is fully sent to disk.
-subroutine flush_file_type(IO_handle)
+subroutine flush_file(IO_handle)
   type(file_type), intent(in) :: IO_handle    !< The I/O handle for the file to flush
 
   if (associated(IO_handle%fileobj)) then
-    ! There does not appear to be an fms2 flush call.
-  else
-    call mpp_flush(IO_handle%unit)
+    call fms2_flush_file(IO_handle%fileobj)
   endif
-end subroutine flush_file_type
-
-!> Ensure that the output stream associated with a unit is fully sent to disk.
-subroutine flush_file_unit(unit)
-  integer, intent(in) :: unit    !< The I/O unit for the file to flush
-
-  call mpp_flush(unit)
-end subroutine flush_file_unit
+end subroutine flush_file
 
 !> Initialize the underlying I/O infrastructure
 subroutine io_infra_init(maxunits)
   integer,   optional, intent(in) :: maxunits !< An optional maximum number of file
                                               !! unit numbers that can be used.
-  call mpp_io_init(maxunit=maxunits)
+
+  ! FMS2 requires no explicit initialization, so this is a null function.
 end subroutine io_infra_init
 
 !> Gracefully close out and terminate the underlying I/O infrastructure
 subroutine io_infra_end()
-  call fms_io_exit()
+  ! FMS2 requires no explicit finalization, so this is a null function.
 end subroutine io_infra_end
 
 !> Open a single namelist file that is potentially readable by all PEs.
@@ -299,35 +265,7 @@ subroutine write_version(version, tag, unit)
 end subroutine write_version
 
 !> open_file opens a file for parallel or single-file I/O.
-subroutine open_file_unit(unit, filename, action, form, threading, fileset, nohdrs, domain, MOM_domain)
-  integer,                  intent(out) :: unit   !< The I/O unit for the opened file
-  character(len=*),         intent(in)  :: filename !< The name of the file being opened
-  integer,        optional, intent(in)  :: action !< A flag indicating whether the file can be read
-                                                  !! or written to and how to handle existing files.
-  integer,        optional, intent(in)  :: form   !< A flag indicating the format of a new file.  The
-                                                  !! default is ASCII_FILE, but NETCDF_FILE is also common.
-  integer,        optional, intent(in)  :: threading !< A flag indicating whether one (SINGLE_FILE)
-                                                  !! or multiple PEs (MULTIPLE) participate in I/O.
-                                                  !! With the default, the root PE does I/O.
-  integer,        optional, intent(in)  :: fileset !< A flag indicating whether multiple PEs doing I/O due
-                                                  !! to threading=MULTIPLE write to the same file (SINGLE_FILE)
-                                                  !! or to one file per PE (MULTIPLE, the default).
-  logical,        optional, intent(in)  :: nohdrs !< If nohdrs is .TRUE., headers are not written to
-                                                  !! ASCII files.  The default is .false.
-  type(domain2d), optional, intent(in)  :: domain !< A domain2d type that describes the decomposition
-  type(MOM_domain_type), optional, intent(in) :: MOM_Domain !< A MOM_Domain that describes the decomposition
-
-  if (present(MOM_Domain)) then
-    call mpp_open(unit, filename, action=action, form=form, threading=threading, fileset=fileset, &
-                  nohdrs=nohdrs, domain=MOM_Domain%mpp_domain)
-  else
-    call mpp_open(unit, filename, action=action, form=form, threading=threading, fileset=fileset, &
-                  nohdrs=nohdrs, domain=domain)
-  endif
-end subroutine open_file_unit
-
-!> open_file opens a file for parallel or single-file I/O.
-subroutine open_file_type(IO_handle, filename, action, MOM_domain, threading, fileset)
+subroutine open_file(IO_handle, filename, action, MOM_domain, threading, fileset)
   type(file_type),          intent(inout) :: IO_handle !< The handle for the opened file
   character(len=*),         intent(in)    :: filename !< The path name of the file being opened
   integer,        optional, intent(in)    :: action !< A flag indicating whether the file can be read
@@ -355,63 +293,59 @@ subroutine open_file_type(IO_handle, filename, action, MOM_domain, threading, fi
   integer :: index_nc
 
   if (IO_handle%open_to_write) then
-    call MOM_error(WARNING, "open_file_type called for file "//trim(filename)//&
+    call MOM_error(WARNING, "open_file called for file "//trim(filename)//&
         " with an IO_handle that is already open to to write.")
     return
   endif
   if (IO_handle%open_to_read) then
-    call MOM_error(FATAL, "open_file_type called for file "//trim(filename)//&
+    call MOM_error(FATAL, "open_file called for file "//trim(filename)//&
         " with an IO_handle that is already open to to read.")
   endif
 
   file_mode = WRITEONLY_FILE ; if (present(action)) file_mode = action
 
-  if (FMS2_writes .and. present(MOM_Domain)) then
-    if (.not.associated(IO_handle%fileobj)) allocate (IO_handle%fileobj)
+  ! Domains are currently required to use FMS I/O.
+  ! NOTE: We restrict FMS2 IO usage to domain-based files due to issues with
+  ! string-based attributes in certain compilers.
+  ! But we may relax this requirement in the future.
+  if (.not. present(MOM_Domain)) &
+    call MOM_error(FATAL, 'open_file: FMS I/O requires a domain input.')
 
-    ! The FMS1 interface automatically appends .nc if necessary, but FMS2 interface does not.
-    index_nc = index(trim(filename), ".nc")
-    if (index_nc > 0) then
-      filename_tmp = trim(filename)
-    else
-      filename_tmp = trim(filename)//".nc"
-      if (is_root_PE()) call MOM_error(WARNING, "Open_file is appending .nc to the filename "//trim(filename))
-    endif
+  if (.not.associated(IO_handle%fileobj)) allocate (IO_handle%fileobj)
 
-    if (file_mode == WRITEONLY_FILE) then ; mode = "write"
-    elseif (file_mode == APPEND_FILE) then ; mode = "append"
-    elseif (file_mode == OVERWRITE_FILE) then ; mode = "overwrite"
-    elseif (file_mode == READONLY_FILE) then ; mode = "read"
-    else
-      call MOM_error(FATAL, "open_file_type called with unrecognized action.")
-    endif
-
-    IO_handle%num_times = 0
-    IO_handle%file_time = 0.0
-    if ((file_mode == APPEND_FILE) .and. file_exists(filename_tmp, MOM_Domain)) then
-      ! Determine the latest file time and number of records so far.
-      success = fms2_open_file(fileObj_read, trim(filename_tmp), "read", MOM_domain%mpp_domain)
-      call get_unlimited_dimension_name(fileObj_read, dim_unlim_name)
-      if (len_trim(dim_unlim_name) > 0) &
-        call get_dimension_size(fileObj_read, trim(dim_unlim_name), IO_handle%num_times)
-      if (IO_handle%num_times > 0) &
-        call fms2_read_data(fileObj_read, trim(dim_unlim_name), IO_handle%file_time, &
-                            unlim_dim_level=IO_handle%num_times)
-      call fms2_close_file(fileObj_read)
-    endif
-
-    success = fms2_open_file(IO_handle%fileobj, trim(filename_tmp), trim(mode), MOM_domain%mpp_domain)
-    if (.not.success) call MOM_error(FATAL, "Unable to open file "//trim(filename_tmp))
-    IO_handle%FMS2_file = .true.
-  elseif (present(MOM_Domain)) then
-    call mpp_open(IO_handle%unit, filename, action=file_mode, form=NETCDF_FILE, threading=threading, &
-                  fileset=fileset, domain=MOM_Domain%mpp_domain)
-    IO_handle%FMS2_file = .false.
+  ! The FMS1 interface automatically appends .nc if necessary, but FMS2 interface does not.
+  index_nc = index(trim(filename), ".nc")
+  if (index_nc > 0) then
+    filename_tmp = trim(filename)
   else
-    call mpp_open(IO_handle%unit, filename, action=file_mode, form=NETCDF_FILE, threading=threading, &
-                  fileset=fileset)
-    IO_handle%FMS2_file = .false.
+    filename_tmp = trim(filename)//".nc"
+    if (is_root_PE()) call MOM_error(WARNING, "Open_file is appending .nc to the filename "//trim(filename))
   endif
+
+  if (file_mode == WRITEONLY_FILE) then ; mode = "write"
+  elseif (file_mode == APPEND_FILE) then ; mode = "append"
+  elseif (file_mode == OVERWRITE_FILE) then ; mode = "overwrite"
+  elseif (file_mode == READONLY_FILE) then ; mode = "read"
+  else
+    call MOM_error(FATAL, "open_file called with unrecognized action.")
+  endif
+
+  IO_handle%num_times = 0
+  IO_handle%file_time = 0.0
+  if ((file_mode == APPEND_FILE) .and. file_exists(filename_tmp, MOM_Domain)) then
+    ! Determine the latest file time and number of records so far.
+    success = fms2_open_file(fileObj_read, trim(filename_tmp), "read", MOM_domain%mpp_domain)
+    call get_unlimited_dimension_name(fileObj_read, dim_unlim_name)
+    if (len_trim(dim_unlim_name) > 0) &
+      call get_dimension_size(fileObj_read, trim(dim_unlim_name), IO_handle%num_times)
+    if (IO_handle%num_times > 0) &
+      call fms2_read_data(fileObj_read, trim(dim_unlim_name), IO_handle%file_time, &
+                          unlim_dim_level=IO_handle%num_times)
+    call fms2_close_file(fileObj_read)
+  endif
+
+  success = fms2_open_file(IO_handle%fileobj, trim(filename_tmp), trim(mode), MOM_domain%mpp_domain)
+  if (.not.success) call MOM_error(FATAL, "Unable to open file "//trim(filename_tmp))
   IO_handle%filename = trim(filename)
 
   if (file_mode == READONLY_FILE) then
@@ -420,7 +354,7 @@ subroutine open_file_type(IO_handle, filename, action, MOM_domain, threading, fi
     IO_handle%open_to_read = .false. ; IO_handle%open_to_write = .true.
   endif
 
-end subroutine open_file_type
+end subroutine open_file
 
 !> open_file opens an ascii file for parallel or single-file I/O using Fortran read and write calls.
 subroutine open_ASCII_file(unit, file, action, threading, fileset)
@@ -539,23 +473,14 @@ subroutine get_file_info(IO_handle, ndim, nvar, ntime)
   character(len=256) :: dim_unlim_name ! name of the unlimited dimension in the file
   integer :: ndims, nvars, natts, ntimes
 
-  if (IO_handle%FMS2_file) then
-    if (present(ndim)) ndim = get_num_dimensions(IO_handle%fileobj)
-    if (present(nvar)) nvar = get_num_variables(IO_handle%fileobj)
-    if (present(ntime)) then
-      ntime = 0
-      call get_unlimited_dimension_name(IO_handle%fileobj, dim_unlim_name)
-      if (len_trim(dim_unlim_name) > 0) &
-        call get_dimension_size(IO_handle%fileobj, trim(dim_unlim_name), ntime)
-    endif
-  else
-    call mpp_get_info(IO_handle%unit, ndims, nvars, natts, ntimes )
-
-    if (present(ndim)) ndim = ndims
-    if (present(nvar)) nvar = nvars
-    if (present(ntime)) ntime = ntimes
+  if (present(ndim)) ndim = get_num_dimensions(IO_handle%fileobj)
+  if (present(nvar)) nvar = get_num_variables(IO_handle%fileobj)
+  if (present(ntime)) then
+    ntime = 0
+    call get_unlimited_dimension_name(IO_handle%fileobj, dim_unlim_name)
+    if (len_trim(dim_unlim_name) > 0) &
+      call get_dimension_size(IO_handle%fileobj, trim(dim_unlim_name), ntime)
   endif
-
 end subroutine get_file_info
 
 
@@ -575,12 +500,8 @@ subroutine get_file_times(IO_handle, time_values, ntime)
   if (present(ntime)) ntime = ntimes
   if (ntimes > 0) then
     allocate(time_values(ntimes))
-    if (IO_handle%FMS2_file) then
-      call get_unlimited_dimension_name(IO_handle%fileobj, dim_unlim_name)
-      call fms2_read_data(IO_handle%fileobj, trim(dim_unlim_name), time_values)
-    else
-      call mpp_get_times(IO_handle%unit, time_values)
-    endif
+    call get_unlimited_dimension_name(IO_handle%fileobj, dim_unlim_name)
+    call fms2_read_data(IO_handle%fileobj, trim(dim_unlim_name), time_values)
   endif
 end subroutine get_file_times
 
@@ -590,7 +511,6 @@ subroutine get_file_fields(IO_handle, fields)
   type(file_type),               intent(in)    :: IO_handle !< Handle for a file that is open for I/O
   type(fieldtype), dimension(:), intent(inout) :: fields !< Field-type descriptions of all of
                                                          !! the variables in a file.
-  type(mpp_fieldtype), dimension(size(fields)) :: mpp_fields ! Fieldtype structures for the variables
   character(len=256),  dimension(size(fields)) :: var_names ! The names of all variables
   character(len=256)  :: units    ! The units of a variable as recorded in the file
   character(len=2048) :: longname ! The long-name of a variable as recorded in the file
@@ -601,39 +521,25 @@ subroutine get_file_fields(IO_handle, fields)
 
   nvar = size(fields)
   ! Local variables
-  if (IO_handle%FMS2_file) then
-    call get_variable_names(IO_handle%fileobj, var_names)
-    do i=1,nvar
-      fields(i)%name = trim(var_names(i))
-      longname = ""
-      if (variable_att_exists(IO_handle%fileobj, var_names(i), "long_name")) &
-        call get_variable_attribute(IO_handle%fileobj, var_names(i), "long_name", longname)
-      fields(i)%longname = trim(longname)
-      units = ""
-      if (variable_att_exists(IO_handle%fileobj, var_names(i), "units")) &
-        call get_variable_attribute(IO_handle%fileobj, var_names(i), "units", units)
-      fields(i)%units = trim(units)
+  call get_variable_names(IO_handle%fileobj, var_names)
+  do i=1,nvar
+    fields(i)%name = trim(var_names(i))
+    longname = ""
+    if (variable_att_exists(IO_handle%fileobj, var_names(i), "long_name")) &
+      call get_variable_attribute(IO_handle%fileobj, var_names(i), "long_name", longname)
+    fields(i)%longname = trim(longname)
+    units = ""
+    if (variable_att_exists(IO_handle%fileobj, var_names(i), "units")) &
+      call get_variable_attribute(IO_handle%fileobj, var_names(i), "units", units)
+    fields(i)%units = trim(units)
 
-      fields(i)%valid_chksum = variable_att_exists(IO_handle%fileobj, var_names(i), "checksum")
-      if (fields(i)%valid_chksum) then
-        call get_variable_attribute(IO_handle%fileobj, var_names(i), 'checksum', checksum_char)
-        ! If there are problems, there might need to be code added to handle commas.
-        read (checksum_char(1:16), '(Z16)') fields(i)%chksum_read
-      endif
-    enddo
-  else
-    call mpp_get_fields(IO_handle%unit, mpp_fields)
-    do i=1,nvar
-      fields(i)%FT = mpp_fields(i)
-      call mpp_get_atts(fields(i)%FT, name=fields(i)%name, units=units, longname=longname, &
-                        checksum=checksum_file)
-      fields(i)%longname = trim(longname)
-      fields(i)%units = trim(units)
-      fields(i)%valid_chksum = mpp_attribute_exist(fields(i)%FT, "checksum")
-      if (fields(i)%valid_chksum) fields(i)%chksum_read = checksum_file(1)
-    enddo
-  endif
-
+    fields(i)%valid_chksum = variable_att_exists(IO_handle%fileobj, var_names(i), "checksum")
+    if (fields(i)%valid_chksum) then
+      call get_variable_attribute(IO_handle%fileobj, var_names(i), 'checksum', checksum_char)
+      ! If there are problems, there might need to be code added to handle commas.
+      read (checksum_char(1:16), '(Z16)') fields(i)%chksum_read
+    endif
+  enddo
 end subroutine get_file_fields
 
 !> Extract information from a field type, as stored or as found in a file
@@ -678,33 +584,26 @@ function field_exists(filename, field_name, domain, no_domain, MOM_domain)
     domainless = no_domain
   endif
 
-  if (FMS2_reads) then
-    field_exists = .false.
-    if (file_exists(filename)) then
-      if (domainless) then
-        success = fms2_open_file(fileObj_simple, trim(filename), "read")
-        if (success) then
-          field_exists = variable_exists(fileObj_simple, field_name)
-          call fms2_close_file(fileObj_simple)
-        endif
+  field_exists = .false.
+  if (file_exists(filename)) then
+    if (domainless) then
+      success = fms2_open_file(fileObj_simple, trim(filename), "read")
+      if (success) then
+        field_exists = variable_exists(fileObj_simple, field_name)
+        call fms2_close_file(fileObj_simple)
+      endif
+    else
+      if (present(MOM_domain)) then
+        success = fms2_open_file(fileObj_dd, trim(filename), "read", MOM_domain%mpp_domain)
       else
-        if (present(MOM_domain)) then
-          success = fms2_open_file(fileObj_dd, trim(filename), "read", MOM_domain%mpp_domain)
-        else
-          success = fms2_open_file(fileObj_dd, trim(filename), "read", domain)
-        endif
-        if (success) then
-          field_exists = variable_exists(fileobj_dd, field_name)
-          call fms2_close_file(fileObj_dd)
-        endif
+        success = fms2_open_file(fileObj_dd, trim(filename), "read", domain)
+      endif
+      if (success) then
+        field_exists = variable_exists(fileobj_dd, field_name)
+        call fms2_close_file(fileObj_dd)
       endif
     endif
-  elseif (present(MOM_domain)) then
-    field_exists = field_exist(filename, field_name, domain=MOM_domain%mpp_domain, no_domain=no_domain)
-  else
-    field_exists = field_exist(filename, field_name, domain=domain, no_domain=no_domain)
   endif
-
 end function field_exists
 
 !> Given filename and fieldname, this subroutine returns the size of the field in the file
@@ -728,72 +627,68 @@ subroutine get_field_size(filename, fieldname, sizes, field_found, no_domain)
   integer :: size_indices(4)        ! Mapping of size index to FMS1 convention
   integer :: idx, swap
 
-  if (FMS2_reads) then
-    field_exists = .false.
-    if (file_exists(filename)) then
-      success = fms2_open_file(fileObj_read, trim(filename), "read")
-      if (success) then
-        field_exists = variable_exists(fileobj_read, fieldname)
-        if (field_exists) then
-          ndims = get_variable_num_dimensions(fileobj_read, fieldname)
-          if (ndims > size(sizes)) call MOM_error(FATAL, &
-            "get_field_size called with too few sizes for "//trim(fieldname)//" in "//trim(filename))
-          call get_variable_size(fileobj_read, fieldname, sizes(1:ndims))
+  field_exists = .false.
+  if (file_exists(filename)) then
+    success = fms2_open_file(fileObj_read, trim(filename), "read")
+    if (success) then
+      field_exists = variable_exists(fileobj_read, fieldname)
+      if (field_exists) then
+        ndims = get_variable_num_dimensions(fileobj_read, fieldname)
+        if (ndims > size(sizes)) call MOM_error(FATAL, &
+          "get_field_size called with too few sizes for "//trim(fieldname)//" in "//trim(filename))
+        call get_variable_size(fileobj_read, fieldname, sizes(1:ndims))
 
-          do i=ndims+1,size(sizes) ; sizes(i) = 0 ; enddo
+        do i=ndims+1,size(sizes) ; sizes(i) = 0 ; enddo
 
-          ! If sizes exceeds ndims, then we fallback to the FMS1 convention
-          ! where sizes has at least 4 dimension, and try to position values.
-          if (size(sizes) > ndims)  then
-            ! Assume FMS1 positioning rules: (nx, ny, nz, nt, ...)
-            if (size(sizes) < 4) &
-              call MOM_error(FATAL, "If sizes(:) exceeds field dimensions, "&
-                  &"then its length must be at least 4.")
+        ! If sizes exceeds ndims, then we fallback to the FMS1 convention
+        ! where sizes has at least 4 dimension, and try to position values.
+        if (size(sizes) > ndims)  then
+          ! Assume FMS1 positioning rules: (nx, ny, nz, nt, ...)
+          if (size(sizes) < 4) &
+            call MOM_error(FATAL, "If sizes(:) exceeds field dimensions, "&
+                &"then its length must be at least 4.")
 
-            ! Fall back to the FMS1 default values of 1 (from mpp field%size)
-            sizes(ndims+1:) = 1
+          ! Fall back to the FMS1 default values of 1 (from mpp field%size)
+          sizes(ndims+1:) = 1
 
-            ! Gather the field dimension names
-            allocate(dimnames(ndims))
-            dimnames(:) = ""
-            call get_variable_dimension_names(fileObj_read, trim(fieldname), &
-                                              dimnames)
+          ! Gather the field dimension names
+          allocate(dimnames(ndims))
+          dimnames(:) = ""
+          call get_variable_dimension_names(fileObj_read, trim(fieldname), &
+                                            dimnames)
 
-            ! Test the dimensions against standard (x,y,t) names and attributes
-            allocate(is_x(ndims), is_y(ndims), is_t(ndims))
-            is_x(:) = .false.
-            is_y(:) = .false.
-            is_t(:) = .false.
-            call categorize_axes(fileObj_read, filename, ndims, dimnames, &
-                                 is_x, is_y, is_t)
+          ! Test the dimensions against standard (x,y,t) names and attributes
+          allocate(is_x(ndims), is_y(ndims), is_t(ndims))
+          is_x(:) = .false.
+          is_y(:) = .false.
+          is_t(:) = .false.
+          call categorize_axes(fileObj_read, filename, ndims, dimnames, &
+                               is_x, is_y, is_t)
 
-            ! Currently no z-test is supported, so disable assignment with 0
-            size_indices = [ &
-                find_index(is_x), &
-                find_index(is_y), &
-                0, &
-                find_index(is_t) &
-            ]
+          ! Currently no z-test is supported, so disable assignment with 0
+          size_indices = [ &
+              find_index(is_x), &
+              find_index(is_y), &
+              0, &
+              find_index(is_t) &
+          ]
 
-            do i = 1, size(size_indices)
-              idx = size_indices(i)
-              if (idx > 0) then
-                swap = sizes(i)
-                sizes(i) = sizes(idx)
-                sizes(idx) = swap
-              endif
-            enddo
+          do i = 1, size(size_indices)
+            idx = size_indices(i)
+            if (idx > 0) then
+              swap = sizes(i)
+              sizes(i) = sizes(idx)
+              sizes(idx) = swap
+            endif
+          enddo
 
-            deallocate(is_x, is_y, is_t)
-            deallocate(dimnames)
-          endif
+          deallocate(is_x, is_y, is_t)
+          deallocate(dimnames)
         endif
       endif
     endif
-    if (present(field_found)) field_found = field_exists
-  else
-    call field_size(filename, fieldname, sizes, field_found=field_found, no_domain=no_domain)
   endif
+  if (present(field_found)) field_found = field_exists
 end subroutine get_field_size
 
 
@@ -830,10 +725,7 @@ subroutine get_axis_data( axis, dat )
     if (size(axis%ax_data) > size(dat)) call MOM_error(FATAL, &
       "get_axis_data called with too small of an output data array for "//trim(axis%name))
     do i=1,size(axis%ax_data) ; dat(i) = axis%ax_data(i) ; enddo
-  elseif (.not.FMS2_writes) then
-    call mpp_get_axis_data( axis%AT, dat )
   endif
-
 end subroutine get_axis_data
 
 !> This routine uses the fms_io subroutine read_data to read a scalar named
@@ -859,7 +751,7 @@ subroutine read_field_0d(filename, fieldname, data, timelevel, scale, MOM_Domain
   logical :: has_time_dim          ! True if the variable has an unlimited time axis.
   logical :: success               ! True if the file was successfully opened
 
-  if (present(MOM_Domain) .and. FMS2_reads) then
+  if (present(MOM_Domain)) then
     ! Open the FMS2 file-set.
     success = fms2_open_file(fileobj_DD, filename, "read", MOM_domain%mpp_domain)
     if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
@@ -877,7 +769,7 @@ subroutine read_field_0d(filename, fieldname, data, timelevel, scale, MOM_Domain
 
     ! Close the file-set.
     if (check_if_open(fileobj_DD)) call fms2_close_file(fileobj_DD)
-  elseif (FMS2_reads) then
+  else
     ! Open the FMS2 file-set.
     success = fms2_open_file(fileObj, trim(filename), "read")
     if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
@@ -896,10 +788,6 @@ subroutine read_field_0d(filename, fieldname, data, timelevel, scale, MOM_Domain
 
     ! Close the file-set.
     if (check_if_open(fileobj)) call fms2_close_file(fileobj)
-  elseif (present(MOM_Domain)) then ! Read the variable using the FMS-1 interface.
-    call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, timelevel=timelevel)
-  else
-    call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
   endif
 
   if (present(scale)) then ; if (scale /= 1.0) then
@@ -931,7 +819,7 @@ subroutine read_field_1d(filename, fieldname, data, timelevel, scale, MOM_Domain
   logical :: has_time_dim          ! True if the variable has an unlimited time axis.
   logical :: success               ! True if the file was successfully opened
 
-  if (present(MOM_Domain) .and. FMS2_reads) then
+  if (present(MOM_Domain)) then
     ! Open the FMS2 file-set.
     success = fms2_open_file(fileobj_DD, filename, "read", MOM_domain%mpp_domain)
     if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
@@ -949,7 +837,7 @@ subroutine read_field_1d(filename, fieldname, data, timelevel, scale, MOM_Domain
 
     ! Close the file-set.
     if (check_if_open(fileobj_DD)) call fms2_close_file(fileobj_DD)
-  elseif (FMS2_reads) then
+  else
     ! Open the FMS2 file-set.
     success = fms2_open_file(fileObj, trim(filename), "read")
     if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
@@ -968,10 +856,6 @@ subroutine read_field_1d(filename, fieldname, data, timelevel, scale, MOM_Domain
 
     ! Close the file-set.
     if (check_if_open(fileobj)) call fms2_close_file(fileobj)
-  elseif (present(MOM_Domain)) then ! Read the variable using the FMS-1 interface.
-    call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, timelevel=timelevel)
-  else
-    call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
   endif
 
   if (present(scale)) then ; if (scale /= 1.0) then
@@ -1004,28 +888,23 @@ subroutine read_field_2d(filename, fieldname, data, MOM_Domain, &
   logical :: has_time_dim          ! True if the variable has an unlimited time axis.
   logical :: success               ! True if the file was successfully opened
 
-  if (FMS2_reads) then
-    ! Open the FMS2 file-set.
-    success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
-    if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
+  ! Open the FMS2 file-set.
+  success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
+  if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
 
-    ! Find the matching case-insensitive variable name in the file and prepare to read it.
-    call prepare_to_read_var(fileobj, fieldname, "read_field_2d: ", filename, &
-                             var_to_read, has_time_dim, timelevel, position)
+  ! Find the matching case-insensitive variable name in the file and prepare to read it.
+  call prepare_to_read_var(fileobj, fieldname, "read_field_2d: ", filename, &
+                           var_to_read, has_time_dim, timelevel, position)
 
-    ! Read the data.
-    if (present(timelevel) .and. has_time_dim) then
-      call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
-    else
-      call fms2_read_data(fileobj, var_to_read, data)
-    endif
-
-    ! Close the file-set.
-    if (check_if_open(fileobj)) call fms2_close_file(fileobj)
-  else ! Read the variable using the FMS-1 interface.
-    call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
-                   timelevel=timelevel, position=position)
+  ! Read the data.
+  if (present(timelevel) .and. has_time_dim) then
+    call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
+  else
+    call fms2_read_data(fileobj, var_to_read, data)
   endif
+
+  ! Close the file-set.
+  if (check_if_open(fileobj)) call fms2_close_file(fileobj)
 
   if (present(scale)) then ; if (scale /= 1.0) then
     call rescale_comp_data(MOM_Domain, data, scale)
@@ -1060,7 +939,7 @@ subroutine read_field_2d_region(filename, fieldname, data, start, nread, MOM_dom
   character(len=96) :: var_to_read ! Name of variable to read from the netcdf file
   logical :: success               ! True if the file was successfully opened
 
-  if (present(MOM_Domain) .and. FMS2_reads) then
+  if (present(MOM_Domain)) then
     ! Open the FMS2 file-set.
     success = fms2_open_file(fileobj_DD, filename, "read", MOM_domain%mpp_domain)
     if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
@@ -1074,7 +953,7 @@ subroutine read_field_2d_region(filename, fieldname, data, start, nread, MOM_dom
 
     ! Close the file-set.
     if (check_if_open(fileobj_DD)) call fms2_close_file(fileobj_DD)
-  elseif (FMS2_reads) then
+  else
     ! Open the FMS2 file-set.
     success = fms2_open_file(fileObj, trim(filename), "read")
     if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
@@ -1088,11 +967,6 @@ subroutine read_field_2d_region(filename, fieldname, data, start, nread, MOM_dom
 
     ! Close the file-set.
     if (check_if_open(fileobj)) call fms2_close_file(fileobj)
-  elseif (present(MOM_Domain)) then ! Read the variable using the FMS-1 interface.
-    call read_data(filename, fieldname, data, start, nread, domain=MOM_Domain%mpp_domain, &
-                   no_domain=no_domain)
-  else
-    call read_data(filename, fieldname, data, start, nread, no_domain=no_domain)
   endif
 
   if (present(scale)) then ; if (scale /= 1.0) then
@@ -1130,28 +1004,23 @@ subroutine read_field_3d(filename, fieldname, data, MOM_Domain, &
   logical :: has_time_dim          ! True if the variable has an unlimited time axis.
   logical :: success               ! True if the file was successfully opened
 
-  if (FMS2_reads) then
-    ! Open the FMS2 file-set.
-    success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
-    if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
+  ! Open the FMS2 file-set.
+  success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
+  if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
 
-    ! Find the matching case-insensitive variable name in the file and prepare to read it.
-    call prepare_to_read_var(fileobj, fieldname, "read_field_3d: ", filename, &
-                             var_to_read, has_time_dim, timelevel, position)
+  ! Find the matching case-insensitive variable name in the file and prepare to read it.
+  call prepare_to_read_var(fileobj, fieldname, "read_field_3d: ", filename, &
+                           var_to_read, has_time_dim, timelevel, position)
 
-    ! Read the data.
-    if (present(timelevel) .and. has_time_dim) then
-      call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
-    else
-      call fms2_read_data(fileobj, var_to_read, data)
-    endif
-
-    ! Close the file-set.
-    if (check_if_open(fileobj)) call fms2_close_file(fileobj)
-  else ! Read the variable using the FMS-1 interface.
-    call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
-                   timelevel=timelevel, position=position)
+  ! Read the data.
+  if (present(timelevel) .and. has_time_dim) then
+    call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
+  else
+    call fms2_read_data(fileobj, var_to_read, data)
   endif
+
+  ! Close the file-set.
+  if (check_if_open(fileobj)) call fms2_close_file(fileobj)
 
   if (present(scale)) then ; if (scale /= 1.0) then
     call rescale_comp_data(MOM_Domain, data, scale)
@@ -1182,28 +1051,23 @@ subroutine read_field_4d(filename, fieldname, data, MOM_Domain, &
   character(len=96) :: var_to_read ! Name of variable to read from the netcdf file
   logical :: success  ! True if the file was successfully opened
 
-  if (FMS2_reads) then
-    ! Open the FMS2 file-set.
-    success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
-    if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
+  ! Open the FMS2 file-set.
+  success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
+  if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
 
-    ! Find the matching case-insensitive variable name in the file and prepare to read it.
-    call prepare_to_read_var(fileobj, fieldname, "read_field_4d: ", filename, &
-                             var_to_read, has_time_dim, timelevel, position)
+  ! Find the matching case-insensitive variable name in the file and prepare to read it.
+  call prepare_to_read_var(fileobj, fieldname, "read_field_4d: ", filename, &
+                           var_to_read, has_time_dim, timelevel, position)
 
-    ! Read the data.
-    if (present(timelevel) .and. has_time_dim) then
-      call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
-    else
-      call fms2_read_data(fileobj, var_to_read, data)
-    endif
-
-    ! Close the file-set.
-    if (check_if_open(fileobj)) call fms2_close_file(fileobj)
-  else ! Read the variable using the FMS-1 interface.
-    call read_data(filename, fieldname, data, MOM_Domain%mpp_domain, &
-                   timelevel=timelevel, position=position)
+  ! Read the data.
+  if (present(timelevel) .and. has_time_dim) then
+    call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
+  else
+    call fms2_read_data(fileobj, var_to_read, data)
   endif
+
+  ! Close the file-set.
+  if (check_if_open(fileobj)) call fms2_close_file(fileobj)
 
   if (present(scale)) then ; if (scale /= 1.0) then
     call rescale_comp_data(MOM_Domain, data, scale)
@@ -1226,29 +1090,25 @@ subroutine read_field_0d_int(filename, fieldname, data, timelevel)
   logical :: success               ! If true, the file was opened successfully
 
   ! This routine might not be needed for MOM6.
-  if (FMS2_reads) then
-    ! Open the FMS2 file-set.
-    success = fms2_open_file(fileObj, trim(filename), "read")
-    if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
 
-    ! Find the matching case-insensitive variable name in the file, and determine whether it
-    ! has a time dimension.
-    call find_varname_in_file(fileObj, fieldname, "read_field_0d_int: ", filename, &
-                              var_to_read, has_time_dim, timelevel)
+  ! Open the FMS2 file-set.
+  success = fms2_open_file(fileObj, trim(filename), "read")
+  if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
 
-    ! Read the data.
-    if (present(timelevel) .and. has_time_dim) then
-      call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
-    else
-      call fms2_read_data(fileobj, var_to_read, data)
-    endif
+  ! Find the matching case-insensitive variable name in the file, and determine whether it
+  ! has a time dimension.
+  call find_varname_in_file(fileObj, fieldname, "read_field_0d_int: ", filename, &
+                            var_to_read, has_time_dim, timelevel)
 
-    ! Close the file-set.
-    if (check_if_open(fileobj)) call fms2_close_file(fileobj)
+  ! Read the data.
+  if (present(timelevel) .and. has_time_dim) then
+    call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
   else
-    call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
+    call fms2_read_data(fileobj, var_to_read, data)
   endif
 
+  ! Close the file-set.
+  if (check_if_open(fileobj)) call fms2_close_file(fileobj)
 end subroutine read_field_0d_int
 
 !> This routine uses the fms_io subroutine read_data to read a 1-D integer
@@ -1267,29 +1127,25 @@ subroutine read_field_1d_int(filename, fieldname, data, timelevel)
   logical :: success               ! If true, the file was opened successfully
 
   ! This routine might not be needed for MOM6.
-  if (FMS2_reads) then
-    ! Open the FMS2 file-set.
-    success = fms2_open_file(fileObj, trim(filename), "read")
-    if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
 
-    ! Find the matching case-insensitive variable name in the file, and determine whether it
-    ! has a time dimension.
-    call find_varname_in_file(fileObj, fieldname, "read_field_1d_int: ", filename, &
-                              var_to_read, has_time_dim, timelevel)
+  ! Open the FMS2 file-set.
+  success = fms2_open_file(fileObj, trim(filename), "read")
+  if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
 
-    ! Read the data.
-    if (present(timelevel) .and. has_time_dim) then
-      call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
-    else
-      call fms2_read_data(fileobj, var_to_read, data)
-    endif
+  ! Find the matching case-insensitive variable name in the file, and determine whether it
+  ! has a time dimension.
+  call find_varname_in_file(fileObj, fieldname, "read_field_1d_int: ", filename, &
+                            var_to_read, has_time_dim, timelevel)
 
-    ! Close the file-set.
-    if (check_if_open(fileobj)) call fms2_close_file(fileobj)
+  ! Read the data.
+  if (present(timelevel) .and. has_time_dim) then
+    call fms2_read_data(fileobj, var_to_read, data, unlim_dim_level=timelevel)
   else
-    call read_data(filename, fieldname, data, timelevel=timelevel, no_domain=.true.)
+    call fms2_read_data(fileobj, var_to_read, data)
   endif
 
+  ! Close the file-set.
+  if (check_if_open(fileobj)) call fms2_close_file(fileobj)
 end subroutine read_field_1d_int
 
 
@@ -1325,35 +1181,28 @@ subroutine read_vector_2d(filename, u_fieldname, v_fieldname, u_data, v_data, MO
     elseif (stagger == AGRID) then ; u_pos = CENTER ; v_pos = CENTER ; endif
   endif
 
-  if (FMS2_reads) then
-    ! Open the FMS2 file-set.
-    success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
-    if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
+  ! Open the FMS2 file-set.
+  success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
+  if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
 
-    ! Find the matching case-insensitive u- and v-variable names in the file and prepare to read them.
-    call prepare_to_read_var(fileobj, u_fieldname, "read_vector_2d: ", filename, &
-                             u_var, has_time_dim, timelevel, position=u_pos)
-    call prepare_to_read_var(fileobj, v_fieldname, "read_vector_2d: ", filename, &
-                             v_var, has_time_dim, timelevel, position=v_pos)
+  ! Find the matching case-insensitive u- and v-variable names in the file and prepare to read them.
+  call prepare_to_read_var(fileobj, u_fieldname, "read_vector_2d: ", filename, &
+                           u_var, has_time_dim, timelevel, position=u_pos)
+  call prepare_to_read_var(fileobj, v_fieldname, "read_vector_2d: ", filename, &
+                           v_var, has_time_dim, timelevel, position=v_pos)
 
-    ! Read the u-data and v-data. There would already been an error message for one
-    ! of the variables if they are inconsistent in having an unlimited dimension.
-    if (present(timelevel) .and. has_time_dim) then
-      call fms2_read_data(fileobj, u_var, u_data, unlim_dim_level=timelevel)
-      call fms2_read_data(fileobj, v_var, v_data, unlim_dim_level=timelevel)
-    else
-      call fms2_read_data(fileobj, u_var, u_data)
-      call fms2_read_data(fileobj, v_var, v_data)
-    endif
-
-    ! Close the file-set.
-    if (check_if_open(fileobj)) call fms2_close_file(fileobj)
-  else ! Read the variable using the FMS-1 interface.
-    call read_data(filename, u_fieldname, u_data, MOM_Domain%mpp_domain, &
-                   timelevel=timelevel, position=u_pos)
-    call read_data(filename, v_fieldname, v_data, MOM_Domain%mpp_domain, &
-                   timelevel=timelevel, position=v_pos)
+  ! Read the u-data and v-data. There would already been an error message for one
+  ! of the variables if they are inconsistent in having an unlimited dimension.
+  if (present(timelevel) .and. has_time_dim) then
+    call fms2_read_data(fileobj, u_var, u_data, unlim_dim_level=timelevel)
+    call fms2_read_data(fileobj, v_var, v_data, unlim_dim_level=timelevel)
+  else
+    call fms2_read_data(fileobj, u_var, u_data)
+    call fms2_read_data(fileobj, v_var, v_data)
   endif
+
+  ! Close the file-set.
+  if (check_if_open(fileobj)) call fms2_close_file(fileobj)
 
   if (present(scale)) then ; if (scale /= 1.0) then
     call rescale_comp_data(MOM_Domain, u_data, scale)
@@ -1395,35 +1244,28 @@ subroutine read_vector_3d(filename, u_fieldname, v_fieldname, u_data, v_data, MO
     elseif (stagger == AGRID) then ; u_pos = CENTER ; v_pos = CENTER ; endif
   endif
 
-  if (FMS2_reads) then
-    ! Open the FMS2 file-set.
-    success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
-    if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
+  ! Open the FMS2 file-set.
+  success = fms2_open_file(fileobj, filename, "read", MOM_domain%mpp_domain)
+  if (.not.success) call MOM_error(FATAL, "Failed to open "//trim(filename))
 
-    ! Find the matching case-insensitive u- and v-variable names in the file and prepare to read them.
-    call prepare_to_read_var(fileobj, u_fieldname, "read_vector_3d: ", filename, &
-                             u_var, has_time_dim, timelevel, position=u_pos)
-    call prepare_to_read_var(fileobj, v_fieldname, "read_vector_3d: ", filename, &
-                             v_var, has_time_dim, timelevel, position=v_pos)
+  ! Find the matching case-insensitive u- and v-variable names in the file and prepare to read them.
+  call prepare_to_read_var(fileobj, u_fieldname, "read_vector_3d: ", filename, &
+                           u_var, has_time_dim, timelevel, position=u_pos)
+  call prepare_to_read_var(fileobj, v_fieldname, "read_vector_3d: ", filename, &
+                           v_var, has_time_dim, timelevel, position=v_pos)
 
-    ! Read the u-data and v-data, dangerously assuming either both or neither have time dimensions.
-    ! There would already been an error message for one of the variables if they are inconsistent.
-    if (present(timelevel) .and. has_time_dim) then
-      call fms2_read_data(fileobj, u_var, u_data, unlim_dim_level=timelevel)
-      call fms2_read_data(fileobj, v_var, v_data, unlim_dim_level=timelevel)
-    else
-      call fms2_read_data(fileobj, u_var, u_data)
-      call fms2_read_data(fileobj, v_var, v_data)
-    endif
-
-    ! Close the file-set.
-    if (check_if_open(fileobj)) call fms2_close_file(fileobj)
-  else ! Read the variable using the FMS-1 interface.
-    call read_data(filename, u_fieldname, u_data, MOM_Domain%mpp_domain, &
-                   timelevel=timelevel, position=u_pos)
-    call read_data(filename, v_fieldname, v_data, MOM_Domain%mpp_domain, &
-                   timelevel=timelevel, position=v_pos)
+  ! Read the u-data and v-data, dangerously assuming either both or neither have time dimensions.
+  ! There would already been an error message for one of the variables if they are inconsistent.
+  if (present(timelevel) .and. has_time_dim) then
+    call fms2_read_data(fileobj, u_var, u_data, unlim_dim_level=timelevel)
+    call fms2_read_data(fileobj, v_var, v_data, unlim_dim_level=timelevel)
+  else
+    call fms2_read_data(fileobj, u_var, u_data)
+    call fms2_read_data(fileobj, v_var, v_data)
   endif
+
+  ! Close the file-set.
+  if (check_if_open(fileobj)) call fms2_close_file(fileobj)
 
   if (present(scale)) then ; if (scale /= 1.0) then
     call rescale_comp_data(MOM_Domain, u_data, scale)
@@ -1807,14 +1649,11 @@ subroutine write_field_4d(IO_handle, field_md, MOM_domain, field, tstamp, tile_c
   ! Local variables
   integer :: time_index
 
-  if (IO_handle%FMS2_file .and. present(tstamp)) then
+  if (present(tstamp)) then
     time_index = write_time_if_later(IO_handle, tstamp)
     call write_data(IO_handle%fileobj, trim(field_md%name), field, unlim_dim_level=time_index)
-  elseif (IO_handle%FMS2_file) then
-    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   else
-    call mpp_write(IO_handle%unit, field_md%FT, MOM_domain%mpp_domain, field, tstamp=tstamp, &
-                   tile_count=tile_count, default_data=fill_value)
+    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   endif
 end subroutine write_field_4d
 
@@ -1831,14 +1670,11 @@ subroutine write_field_3d(IO_handle, field_md, MOM_domain, field, tstamp, tile_c
   ! Local variables
   integer :: time_index
 
-  if (IO_handle%FMS2_file .and. present(tstamp)) then
+  if (present(tstamp)) then
     time_index = write_time_if_later(IO_handle, tstamp)
     call write_data(IO_handle%fileobj, trim(field_md%name), field, unlim_dim_level=time_index)
-  elseif (IO_handle%FMS2_file) then
-    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   else
-    call mpp_write(IO_handle%unit, field_md%FT, MOM_domain%mpp_domain, field, tstamp=tstamp, &
-                   tile_count=tile_count, default_data=fill_value)
+    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   endif
 end subroutine write_field_3d
 
@@ -1855,14 +1691,11 @@ subroutine write_field_2d(IO_handle, field_md, MOM_domain, field, tstamp, tile_c
   ! Local variables
   integer :: time_index
 
-  if (IO_handle%FMS2_file .and. present(tstamp)) then
+  if (present(tstamp)) then
     time_index = write_time_if_later(IO_handle, tstamp)
     call write_data(IO_handle%fileobj, trim(field_md%name), field, unlim_dim_level=time_index)
-  elseif (IO_handle%FMS2_file) then
-    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   else
-    call mpp_write(IO_handle%unit, field_md%FT, MOM_domain%mpp_domain, field, tstamp=tstamp, &
-                   tile_count=tile_count, default_data=fill_value)
+    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   endif
 end subroutine write_field_2d
 
@@ -1876,13 +1709,11 @@ subroutine write_field_1d(IO_handle, field_md, field, tstamp)
   ! Local variables
   integer :: time_index
 
-  if (IO_handle%FMS2_file .and. present(tstamp)) then
+  if (present(tstamp)) then
     time_index = write_time_if_later(IO_handle, tstamp)
     call write_data(IO_handle%fileobj, trim(field_md%name), field, unlim_dim_level=time_index)
-  elseif (IO_handle%FMS2_file) then
-    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   else
-    call mpp_write(IO_handle%unit, field_md%FT, field, tstamp=tstamp)
+    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   endif
 end subroutine write_field_1d
 
@@ -1896,13 +1727,11 @@ subroutine write_field_0d(IO_handle, field_md, field, tstamp)
   ! Local variables
   integer :: time_index
 
-  if (IO_handle%FMS2_file .and. present(tstamp)) then
+  if (present(tstamp)) then
     time_index = write_time_if_later(IO_handle, tstamp)
     call write_data(IO_handle%fileobj, trim(field_md%name), field, unlim_dim_level=time_index)
-  elseif (IO_handle%FMS2_file) then
-    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   else
-    call mpp_write(IO_handle%unit, field_md%FT, field, tstamp=tstamp)
+    call write_data(IO_handle%fileobj, trim(field_md%name), field)
   endif
 end subroutine write_field_0d
 
@@ -1918,11 +1747,9 @@ integer function write_time_if_later(IO_handle, field_time)
   if ((field_time > IO_handle%file_time) .or. (IO_handle%num_times == 0)) then
     IO_handle%file_time = field_time
     IO_handle%num_times = IO_handle%num_times + 1
-    if (IO_handle%FMS2_file) then
-      call get_unlimited_dimension_name(IO_handle%fileobj, dim_unlim_name)
-      call write_data(IO_handle%fileobj, trim(dim_unlim_name), (/field_time/), &
-                      corner=(/IO_handle%num_times/), edge_lengths=(/1/))
-    endif
+    call get_unlimited_dimension_name(IO_handle%fileobj, dim_unlim_name)
+    call write_data(IO_handle%fileobj, trim(dim_unlim_name), (/field_time/), &
+                    corner=(/IO_handle%num_times/), edge_lengths=(/1/))
   endif
 
   write_time_if_later = IO_handle%num_times
@@ -1935,18 +1762,13 @@ subroutine MOM_write_axis(IO_handle, axis)
 
   integer :: is, ie
 
-  if (IO_handle%FMS2_file) then
-    if (axis%domain_decomposed) then
-      ! FMS2 does not domain-decompose 1d arrays, so we explicitly slice it
-      call get_global_io_domain_indices(IO_handle%fileobj, trim(axis%name), is, ie)
-      call write_data(IO_handle%fileobj, trim(axis%name), axis%ax_data(is:ie))
-    else
-      call write_data(IO_handle%fileobj, trim(axis%name), axis%ax_data)
-    endif
+  if (axis%domain_decomposed) then
+    ! FMS2 does not domain-decompose 1d arrays, so we explicitly slice it
+    call get_global_io_domain_indices(IO_handle%fileobj, trim(axis%name), is, ie)
+    call write_data(IO_handle%fileobj, trim(axis%name), axis%ax_data(is:ie))
   else
-    call mpp_write(IO_handle%unit, axis%AT)
+    call write_data(IO_handle%fileobj, trim(axis%name), axis%ax_data)
   endif
-
 end subroutine MOM_write_axis
 
 !> Store information about an axis in a previously defined axistype and write this
@@ -1973,12 +1795,10 @@ subroutine write_metadata_axis(IO_handle, axis, name, units, longname, cartesian
   integer :: position    ! A flag indicating the axis staggering position.
   integer :: i, isc, iec, global_size
 
-  if (IO_handle%FMS2_file) then
-    if (is_dimension_registered(IO_handle%fileobj, trim(name))) then
-      call MOM_error(FATAL, "write_metadata_axis was called more than once for axis "//trim(name)//&
-                            " in file "//trim(IO_handle%filename))
-      return
-    endif
+  if (is_dimension_registered(IO_handle%fileobj, trim(name))) then
+    call MOM_error(FATAL, "write_metadata_axis was called more than once for axis "//trim(name)//&
+                          " in file "//trim(IO_handle%filename))
+    return
   endif
 
   axis%name = trim(name)
@@ -1986,82 +1806,73 @@ subroutine write_metadata_axis(IO_handle, axis, name, units, longname, cartesian
         "Data is already allocated in a call to write_metadata_axis for axis "//&
         trim(name)//" in file "//trim(IO_handle%filename))
 
-  if (IO_handle%FMS2_file) then
-    is_x = .false. ; is_y = .false. ; is_t = .false.
-    position = CENTER
-    if (present(cartesian)) then
-      cart = trim(adjustl(cartesian))
-      if ((index(cart, "X") == 1) .or. (index(cart, "x") == 1)) is_x = .true.
-      if ((index(cart, "Y") == 1) .or. (index(cart, "y") == 1)) is_y = .true.
-      if ((index(cart, "T") == 1) .or. (index(cart, "t") == 1)) is_t = .true.
-    endif
+  is_x = .false. ; is_y = .false. ; is_t = .false.
+  position = CENTER
+  if (present(cartesian)) then
+    cart = trim(adjustl(cartesian))
+    if ((index(cart, "X") == 1) .or. (index(cart, "x") == 1)) is_x = .true.
+    if ((index(cart, "Y") == 1) .or. (index(cart, "y") == 1)) is_y = .true.
+    if ((index(cart, "T") == 1) .or. (index(cart, "t") == 1)) is_t = .true.
+  endif
 
-    ! For now, we assume that all horizontal axes are domain-decomposed.
-    if (is_x .or. is_y) &
-      axis%domain_decomposed = .true.
+  ! For now, we assume that all horizontal axes are domain-decomposed.
+  if (is_x .or. is_y) &
+    axis%domain_decomposed = .true.
 
-    if (is_x) then
-      if (present(edge_axis)) then ; if (edge_axis) position = EAST_FACE ; endif
-      call register_axis(IO_handle%fileobj, trim(name), 'x', domain_position=position)
-    elseif (is_y) then
-      if (present(edge_axis)) then ; if (edge_axis) position = NORTH_FACE ; endif
-      call register_axis(IO_handle%fileobj, trim(name), 'y', domain_position=position)
-    elseif (is_t .and. .not.present(data)) then
-      ! This is the unlimited (time) dimension.
-      call register_axis(IO_handle%fileobj, trim(name), unlimited)
-    else
-      if (.not.present(data)) call MOM_error(FATAL,"MOM_io:register_diagnostic_axis: "//&
-                        "An axis_length argument is required to register the axis "//trim(name))
-      call register_axis(IO_handle%fileobj, trim(name), size(data))
-    endif
-
-    if (present(data)) then
-      ! With FMS2, the data for the axis labels has to match the computational domain on this PE.
-      if (present(domain)) then
-        ! The commented-out code on the next ~11 lines runs but there is missing data in the output file
-        ! call mpp_get_compute_domain(domain, isc, iec)
-        ! call mpp_get_global_domain(domain, size=global_size)
-        ! if (size(data) == global_size) then
-        !   allocate(axis%ax_data(iec+1-isc)) ; axis%ax_data(:) = data(isc:iec)
-        !   ! A simpler set of labels: do i=1,iec-isc ; axis%ax_data(i) = real(isc + i) - 1.0 ; enddo
-        ! elseif (size(data) == global_size+1) then
-        !   ! This is an edge axis.  Note the effective SW indexing convention here.
-        !   allocate(axis%ax_data(iec+2-isc)) ; axis%ax_data(:) = data(isc:iec+1)
-        !   ! A simpler set of labels: do i=1,iec+1-isc ; axis%ax_data(i) = real(isc + i) - 1.5 ; enddo
-        ! else
-        !   call MOM_error(FATAL, "Unexpected size of data for "//trim(name)//" in write_metadata_axis.")
-        ! endif
-
-        ! This works for a simple 1x1 IO layout, but gives errors for nontrivial IO layouts
-        allocate(axis%ax_data(size(data))) ; axis%ax_data(:) = data(:)
-
-      else  ! Store the entire array of axis labels.
-        allocate(axis%ax_data(size(data))) ; axis%ax_data(:) = data(:)
-      endif
-    endif
-
-
-    ! Now create the variable that describes this axis.
-    call register_field(IO_handle%fileobj, trim(name), "double", dimensions=(/name/))
-    if (len_trim(longname) > 0) &
-      call register_variable_attribute(IO_handle%fileobj, trim(name), 'long_name', &
-                                       trim(longname), len_trim(longname))
-    if (len_trim(units) > 0) &
-      call register_variable_attribute(IO_handle%fileobj, trim(name), 'units', &
-                                       trim(units), len_trim(units))
-    if (present(cartesian)) &
-      call register_variable_attribute(IO_handle%fileobj, trim(name), 'cartesian_axis', &
-                                       trim(cartesian), len_trim(cartesian))
-    if (present(sense)) &
-      call register_variable_attribute(IO_handle%fileobj, trim(name), 'sense', sense)
+  if (is_x) then
+    if (present(edge_axis)) then ; if (edge_axis) position = EAST_FACE ; endif
+    call register_axis(IO_handle%fileobj, trim(name), 'x', domain_position=position)
+  elseif (is_y) then
+    if (present(edge_axis)) then ; if (edge_axis) position = NORTH_FACE ; endif
+    call register_axis(IO_handle%fileobj, trim(name), 'y', domain_position=position)
+  elseif (is_t .and. .not.present(data)) then
+    ! This is the unlimited (time) dimension.
+    call register_axis(IO_handle%fileobj, trim(name), unlimited)
   else
-    if (present(data)) then
+    if (.not.present(data)) call MOM_error(FATAL,"MOM_io:register_diagnostic_axis: "//&
+                      "An axis_length argument is required to register the axis "//trim(name))
+    call register_axis(IO_handle%fileobj, trim(name), size(data))
+  endif
+
+  if (present(data)) then
+    ! With FMS2, the data for the axis labels has to match the computational domain on this PE.
+    if (present(domain)) then
+      ! The commented-out code on the next ~11 lines runs but there is missing data in the output file
+      ! call mpp_get_compute_domain(domain, isc, iec)
+      ! call mpp_get_global_domain(domain, size=global_size)
+      ! if (size(data) == global_size) then
+      !   allocate(axis%ax_data(iec+1-isc)) ; axis%ax_data(:) = data(isc:iec)
+      !   ! A simpler set of labels: do i=1,iec-isc ; axis%ax_data(i) = real(isc + i) - 1.0 ; enddo
+      ! elseif (size(data) == global_size+1) then
+      !   ! This is an edge axis.  Note the effective SW indexing convention here.
+      !   allocate(axis%ax_data(iec+2-isc)) ; axis%ax_data(:) = data(isc:iec+1)
+      !   ! A simpler set of labels: do i=1,iec+1-isc ; axis%ax_data(i) = real(isc + i) - 1.5 ; enddo
+      ! else
+      !   call MOM_error(FATAL, "Unexpected size of data for "//trim(name)//" in write_metadata_axis.")
+      ! endif
+
+      ! This works for a simple 1x1 IO layout, but gives errors for nontrivial IO layouts
+      allocate(axis%ax_data(size(data))) ; axis%ax_data(:) = data(:)
+
+    else  ! Store the entire array of axis labels.
       allocate(axis%ax_data(size(data))) ; axis%ax_data(:) = data(:)
     endif
-
-    call mpp_write_meta(IO_handle%unit, axis%AT, name, units, longname, cartesian=cartesian, sense=sense, &
-                        domain=domain, data=data, calendar=calendar)
   endif
+
+
+  ! Now create the variable that describes this axis.
+  call register_field(IO_handle%fileobj, trim(name), "double", dimensions=(/name/))
+  if (len_trim(longname) > 0) &
+    call register_variable_attribute(IO_handle%fileobj, trim(name), 'long_name', &
+                                     trim(longname), len_trim(longname))
+  if (len_trim(units) > 0) &
+    call register_variable_attribute(IO_handle%fileobj, trim(name), 'units', &
+                                     trim(units), len_trim(units))
+  if (present(cartesian)) &
+    call register_variable_attribute(IO_handle%fileobj, trim(name), 'cartesian_axis', &
+                                     trim(cartesian), len_trim(cartesian))
+  if (present(sense)) &
+    call register_variable_attribute(IO_handle%fileobj, trim(name), 'sense', sense)
 end subroutine write_metadata_axis
 
 !> Store information about an output variable in a previously defined fieldtype and write this
@@ -2083,35 +1894,27 @@ subroutine write_metadata_field(IO_handle, field, axes, name, units, longname, &
 
   ! Local variables
   character(len=256), dimension(size(axes)) :: dim_names ! The names of the dimensions
-  type(mpp_axistype), dimension(size(axes)) :: mpp_axes  ! The array of mpp_axistypes for this variable
   character(len=16) :: prec_string     ! A string specifying the precision with which to save this variable
   character(len=64) :: checksum_string ! checksum character array created from checksum argument
   integer :: i, ndims
 
   ndims = size(axes)
-  if (IO_handle%FMS2_file) then
-    do i=1,ndims ; dim_names(i) = trim(axes(i)%name) ; enddo
-    prec_string = "double" ; if (present(pack)) then ; if (pack > 1) prec_string = "float" ; endif
-    call register_field(IO_handle%fileobj, trim(name), trim(prec_string), dimensions=dim_names)
-    if (len_trim(longname) > 0) &
-      call register_variable_attribute(IO_handle%fileobj, trim(name), 'long_name', &
-                                       trim(longname), len_trim(longname))
-    if (len_trim(units) > 0) &
-      call register_variable_attribute(IO_handle%fileobj, trim(name), 'units', &
-                                       trim(units), len_trim(units))
-    if (present(standard_name)) &
-      call register_variable_attribute(IO_handle%fileobj, trim(name), 'standard_name', &
-                                       trim(standard_name), len_trim(standard_name))
-    if (present(checksum)) then
-      write (checksum_string,'(Z16)') checksum(1) ! Z16 is the hexadecimal format code
-      call register_variable_attribute(IO_handle%fileobj, trim(name), "checksum", &
-                                       trim(checksum_string), len_trim(checksum_string))
-    endif
-  else
-    do i=1,ndims ; mpp_axes(i) = axes(i)%AT ; enddo
-    call mpp_write_meta(IO_handle%unit, field%FT, mpp_axes, name, units, longname, &
-                        pack=pack, standard_name=standard_name, checksum=checksum)
-    ! unused opt. args: min=min, max=max, fill=fill, scale=scale, add=add, &
+  do i=1,ndims ; dim_names(i) = trim(axes(i)%name) ; enddo
+  prec_string = "double" ; if (present(pack)) then ; if (pack > 1) prec_string = "float" ; endif
+  call register_field(IO_handle%fileobj, trim(name), trim(prec_string), dimensions=dim_names)
+  if (len_trim(longname) > 0) &
+    call register_variable_attribute(IO_handle%fileobj, trim(name), 'long_name', &
+                                     trim(longname), len_trim(longname))
+  if (len_trim(units) > 0) &
+    call register_variable_attribute(IO_handle%fileobj, trim(name), 'units', &
+                                     trim(units), len_trim(units))
+  if (present(standard_name)) &
+    call register_variable_attribute(IO_handle%fileobj, trim(name), 'standard_name', &
+                                     trim(standard_name), len_trim(standard_name))
+  if (present(checksum)) then
+    write (checksum_string,'(Z16)') checksum(1) ! Z16 is the hexadecimal format code
+    call register_variable_attribute(IO_handle%fileobj, trim(name), "checksum", &
+                                     trim(checksum_string), len_trim(checksum_string))
   endif
 
   ! Store information in the field-type, regardless of which interfaces are used.
@@ -2129,12 +1932,7 @@ subroutine write_metadata_global(IO_handle, name, attribute)
   character(len=*),           intent(in)    :: name      !< The name in the file of this global attribute
   character(len=*),           intent(in)    :: attribute !< The value of this attribute
 
-  if (IO_handle%FMS2_file) then
-    call register_global_attribute(IO_handle%fileobj, name, attribute, len_trim(attribute))
-  else
-    call mpp_write_meta(IO_handle%unit, name, cval=attribute)
-  endif
-
+  call register_global_attribute(IO_handle%fileobj, name, attribute, len_trim(attribute))
 end subroutine write_metadata_global
 
 end module MOM_io_infra

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -1456,7 +1456,7 @@ subroutine ALE_writeCoordinateFile( CS, GV, directory )
 
   character(len=240) :: filepath
 
-  filepath = trim(directory) // trim("Vertical_coordinate")
+  filepath = trim(directory) // trim("Vertical_coordinate.nc")
 
   call write_regrid_file(CS%regridCS, GV, filepath)
 

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -7,7 +7,7 @@ use MOM_error_handler, only : MOM_error, FATAL, WARNING, assert
 use MOM_file_parser,   only : param_file_type, get_param, log_param
 use MOM_io,            only : file_exists, field_exists, field_size, MOM_read_data
 use MOM_io,            only : vardesc, var_desc, SINGLE_FILE
-use MOM_io,            only : MOM_infra_file, MOM_field
+use MOM_io,            only : MOM_netCDF_file, MOM_field
 use MOM_io,            only : create_MOM_file, MOM_write_field
 use MOM_io,            only : verify_variable_units, slasher
 use MOM_unit_scaling,  only : unit_scale_type
@@ -2082,7 +2082,7 @@ subroutine write_regrid_file( CS, GV, filepath )
 
   type(vardesc)      :: vars(2)
   type(MOM_field)    :: fields(2)
-  type(MOM_infra_file) :: IO_handle ! The I/O handle of the fileset
+  type(MOM_netCDF_file) :: IO_handle ! The I/O handle of the fileset
   real               :: ds(GV%ke), dsi(GV%ke+1)
 
   if (CS%regridding_scheme == REGRIDDING_HYBGEN) then

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -332,13 +332,16 @@ subroutine create_MOM_file(IO_handle, filename, vars, novars, fields, &
     IsgB = dG%IsgB ; IegB = dG%IegB ; JsgB = dG%JsgB ; JegB = dG%JegB
   endif
 
-  if (domain_set .and. (num_PEs() == 1)) thread = SINGLE_FILE
-
   one_file = .true.
   if (domain_set) one_file = (thread == SINGLE_FILE)
 
   if (one_file) then
-    call IO_handle%open(filename, action=OVERWRITE_FILE, threading=thread)
+    if (domain_set) then
+      call IO_handle%open(filename, action=OVERWRITE_FILE, &
+          MOM_domain=domain, threading=thread)
+    else
+      call IO_handle%open(filename, action=OVERWRITE_FILE, threading=thread)
+    endif
   else
     call IO_handle%open(filename, action=OVERWRITE_FILE, MOM_domain=Domain)
   endif

--- a/src/framework/MOM_io_file.F90
+++ b/src/framework/MOM_io_file.F90
@@ -6,6 +6,8 @@ module MOM_io_file
 use, intrinsic :: iso_fortran_env, only : int64
 
 use MOM_domains, only : MOM_domain_type, domain1D
+use MOM_domains, only : clone_MOM_domain
+use MOM_domains, only : deallocate_MOM_domain
 use MOM_io_infra, only : file_type, get_file_info, get_file_fields
 use MOM_io_infra, only : open_file, close_file, flush_file
 use MOM_io_infra, only : fms2_file_is_open => file_is_open
@@ -14,6 +16,7 @@ use MOM_io_infra, only : get_file_times, axistype
 use MOM_io_infra, only : write_field, write_metadata
 use MOM_io_infra, only : get_field_atts
 use MOM_io_infra, only : read_field_chksum
+use MOM_io_infra, only : SINGLE_FILE
 
 use MOM_hor_index, only : hor_index_type
 use MOM_hor_index, only : hor_index_init
@@ -247,6 +250,9 @@ end type MOM_file
 !> MOM file from the supporting framework ("infra") layer
 type, extends(MOM_file) :: MOM_infra_file
   private
+
+  type(MOM_domain_type), public, pointer :: domain => null()
+    !< Internal domain used for single-file IO
 
   ! NOTE: This will be made private after the API transition
   type(file_type), public :: handle_infra
@@ -919,8 +925,23 @@ subroutine open_file_infra(handle, filename, action, MOM_domain, threading, file
   integer, intent(in), optional :: threading
   integer, intent(in), optional :: fileset
 
-  call open_file(handle%handle_infra, filename, action=action, &
-      MOM_domain=MOM_domain, threading=threading, fileset=fileset)
+  logical :: use_single_file_domain
+    ! True if the domain is replaced with a single-file IO layout.
+
+  use_single_file_domain = .false.
+  if (present(MOM_domain) .and. present(threading)) then
+    if (threading == SINGLE_FILE) &
+      use_single_file_domain = .true.
+  endif
+
+  if (use_single_file_domain) then
+    call clone_MOM_domain(MOM_domain, handle%domain, io_layout=[1,1])
+    call open_file(handle%handle_infra, filename, action=action, &
+        MOM_domain=handle%domain, threading=threading, fileset=fileset)
+  else
+    call open_file(handle%handle_infra, filename, action=action, &
+        MOM_domain=MOM_domain, threading=threading, fileset=fileset)
+  endif
 
   call handle%axes%init()
   call handle%fields%init()
@@ -929,6 +950,9 @@ end subroutine open_file_infra
 !> Close a MOM framework file
 subroutine close_file_infra(handle)
   class(MOM_infra_file), intent(inout) :: handle
+
+  if (associated(handle%domain)) &
+    call deallocate_MOM_domain(handle%domain)
 
   call close_file(handle%handle_infra)
   call handle%axes%finalize()

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1860,7 +1860,7 @@ function open_restart_units(filename, directory, G, CS, IO_handles, file_paths, 
           nf = nf + 1
           if (present(IO_handles)) &
             call IO_handles(nf)%open(trim(filepath), READONLY_FILE, &
-                           threading=MULTIPLE, fileset=SINGLE_FILE)
+                MOM_domain=G%Domain, threading=MULTIPLE, fileset=SINGLE_FILE)
           if (present(global_files)) global_files(nf) = .true.
           if (present(file_paths)) file_paths(nf) = filepath
         elseif (CS%parallel_restartfiles) then
@@ -1892,7 +1892,7 @@ function open_restart_units(filename, directory, G, CS, IO_handles, file_paths, 
         nf = nf + 1
         if (present(IO_handles)) &
           call IO_handles(nf)%open(trim(filepath), READONLY_FILE, &
-                       threading=MULTIPLE, fileset=SINGLE_FILE)
+              MOM_Domain=G%Domain, threading=MULTIPLE, fileset=SINGLE_FILE)
         if (present(global_files)) global_files(nf) = .true.
         if (present(file_paths)) file_paths(nf) = filepath
         if (is_root_pe() .and. (present(IO_handles))) &

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -9,7 +9,7 @@ use MOM_error_handler,    only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler,    only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,      only : get_param, read_param, log_param, param_file_type, log_version
 use MOM_io,               only : create_MOM_file, file_exists
-use MOM_io,               only : MOM_infra_file, MOM_field
+use MOM_io,               only : MOM_netCDF_file, MOM_field
 use MOM_io,               only : MOM_read_data, MOM_write_field, vardesc, var_desc, SINGLE_FILE
 use MOM_string_functions, only : slasher, uppercase
 use MOM_unit_scaling,     only : unit_scale_type
@@ -528,12 +528,12 @@ subroutine write_vertgrid_file(GV, US, param_file, directory)
   character(len=240) :: filepath
   type(vardesc) :: vars(2)
   type(MOM_field) :: fields(2)
-  type(MOM_infra_file) :: IO_handle ! The I/O handle of the fileset
+  type(MOM_netCDF_file) :: IO_handle ! The I/O handle of the fileset
 
-  filepath = trim(directory) // trim("Vertical_coordinate")
+  filepath = trim(directory) // trim("Vertical_coordinate.nc")
 
   vars(1) = var_desc("R","kilogram meter-3","Target Potential Density",'1','L','1')
-  vars(2) = var_desc("g","meter second-2","Reduced gravity",'1','L','1')
+  vars(2) = var_desc("g","meter second-2","Reduced gravity",'1','i','1')
 
   call create_MOM_file(IO_handle, trim(filepath), vars, 2, fields, &
       SINGLE_FILE, GV=GV)


### PR DESCRIPTION
This patch removes the calls to FMS1 I/O (fms_io_mod, mpp_io_mod) from the FMS2 infra layer, and now exclusively uses FMS2 for those operations.

FMS2 I/O is currently restricted to files which use domains; files which do not use them are delegated to the native netCDF layer.  The reasoning for this is that FMS is required to define the formatting of domain-decomposed I/O; for single-file I/O, this is not necessary.

This does not remove all references to FMS1 I/O from MOM6, only those in the I/O layer.

Several minor changes are included to accommodate the change:

* MOM restart I/O now always reports its MOM domain.  Previously, the domian was omitted when PARALLEL_RESTARTFILES was false, in order to trick FMS into handling this as a single file.  We now generate a new domain with an IO layout of [1,1] when single-file restarts are requested.

* The interface acceleration (g') was incorrectly set to the layer grid (Nk) rather than the interface grid (Nk+1).  This did not appear to change any answers, but when Vertical_coordinate.nc was moved to the netCDF layer, it detected this error.  This is fixed in this patch.