### PR TITLE
+(*)Better initialization of non-Boussinesq models

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -1463,17 +1463,23 @@ subroutine ALE_writeCoordinateFile( CS, GV, directory )
 end subroutine ALE_writeCoordinateFile
 
 !> Set h to coordinate values for fixed coordinate systems
-subroutine ALE_initThicknessToCoord( CS, G, GV, h )
+subroutine ALE_initThicknessToCoord( CS, G, GV, h, height_units )
   type(ALE_CS), intent(inout)                            :: CS  !< module control structure
   type(ocean_grid_type), intent(in)                      :: G   !< module grid structure
   type(verticalGrid_type), intent(in)                    :: GV  !< Ocean vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: h   !< layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: h   !< layer thickness in thickness units
+                                                                !! [H ~> m or kg m-2] or height units [Z ~> m]
+  logical,                          optional, intent(in) :: height_units !< If present and true, the
+                                                                !! thicknesses are in height units
 
   ! Local variables
+  real :: scale ! A scaling value for the thicknesses [nondim] or [H Z-1 ~> nondim or kg m-3]
   integer :: i, j
 
+  scale = GV%Z_to_H
+  if (present(height_units)) then ; if (height_units) scale = 1.0 ; endif
   do j = G%jsd,G%jed ; do i = G%isd,G%ied
-    h(i,j,:) = GV%Z_to_H * getStaticThickness( CS%regridCS, 0., G%bathyT(i,j)+G%Z_ref )
+    h(i,j,:) = scale * getStaticThickness( CS%regridCS, 0., G%bathyT(i,j)+G%Z_ref )
   enddo ; enddo
 
 end subroutine ALE_initThicknessToCoord

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -56,6 +56,7 @@ subroutine find_obsolete_params(param_file)
          hint="Instead use OBC_SEGMENT_xxx_VELOCITY_NUDGING_TIMESCALES.")
   enddo
 
+  call obsolete_logical(param_file, "CONVERT_THICKNESS_UNITS", .true.)
   call obsolete_logical(param_file, "MASK_MASSLESS_TRACERS", .false.)
 
   call obsolete_logical(param_file, "SALT_REJECT_BELOW_ML", .false.)

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -98,7 +98,7 @@ subroutine DOME2d_initialize_thickness ( h, depth_tot, G, GV, US, param_file, ju
   type(verticalGrid_type), intent(in)  :: GV !< Vertical grid structure
   type(unit_scale_type),   intent(in)  :: US !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+                           intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot   !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -158,16 +158,16 @@ subroutine DOME2d_initialize_thickness ( h, depth_tot, G, GV, US, param_file, ju
           eta1D(k) = e0(k)
           if (eta1D(k) < (eta1D(k+1) + GV%Angstrom_Z)) then
             eta1D(k) = eta1D(k+1) + GV%Angstrom_Z
-            h(i,j,k) = GV%Angstrom_H
+            h(i,j,k) = GV%Angstrom_Z
           else
-            h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+            h(i,j,k) = eta1D(k) - eta1D(k+1)
           endif
         enddo
 
         x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon
         if ( x <= dome2d_width_bay ) then
-          h(i,j,1:nz-1) = GV%Angstrom_H
-          h(i,j,nz) = GV%Z_to_H * dome2d_depth_bay * G%max_depth - (nz-1) * GV%Angstrom_H
+          h(i,j,1:nz-1) = GV%Angstrom_Z
+          h(i,j,nz) = dome2d_depth_bay * G%max_depth - (nz-1) * GV%Angstrom_Z
         endif
 
       enddo ; enddo
@@ -180,16 +180,16 @@ subroutine DOME2d_initialize_thickness ( h, depth_tot, G, GV, US, param_file, ju
  !         eta1D(k) = e0(k)
  !         if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
  !           eta1D(k) = eta1D(k+1) + min_thickness
- !           h(i,j,k) = GV%Z_to_H * min_thickness
+ !           h(i,j,k) = min_thickness
  !         else
- !           h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+ !           h(i,j,k) = eta1D(k) - eta1D(k+1)
  !         endif
  !       enddo
  !
  !       x = G%geoLonT(i,j) / G%len_lon
  !       if ( x <= dome2d_width_bay ) then
- !         h(i,j,1:nz-1) = GV%Z_to_H * min_thickness
- !         h(i,j,nz) = GV%Z_to_H * (dome2d_depth_bay * G%max_depth - (nz-1) * min_thickness)
+ !         h(i,j,1:nz-1) = min_thickness
+ !         h(i,j,nz) = dome2d_depth_bay * G%max_depth - (nz-1) * min_thickness
  !       endif
  !
  !    enddo ; enddo
@@ -202,16 +202,16 @@ subroutine DOME2d_initialize_thickness ( h, depth_tot, G, GV, US, param_file, ju
           eta1D(k) = e0(k)
           if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
             eta1D(k) = eta1D(k+1) + min_thickness
-            h(i,j,k) = GV%Z_to_H * min_thickness
+            h(i,j,k) = min_thickness
           else
-            h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+            h(i,j,k) = eta1D(k) - eta1D(k+1)
           endif
         enddo
       enddo ; enddo
 
     case ( REGRIDDING_SIGMA )
       do j=js,je ; do i=is,ie
-        h(i,j,:) = GV%Z_to_H*depth_tot(i,j) / nz
+        h(i,j,:) = depth_tot(i,j) / nz
       enddo ; enddo
 
     case default
@@ -225,11 +225,11 @@ end subroutine DOME2d_initialize_thickness
 
 !> Initialize temperature and salinity in the 2d DOME configuration
 subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, GV, US, param_file, just_read)
-  type(ocean_grid_type),                     intent(in)  :: G !< Ocean grid structure
+  type(ocean_grid_type),                     intent(in)  :: G  !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)  :: GV !< The ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T !< Potential temperature [C ~> degC]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S !< Salinity [S ~> ppt]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T  !< Potential temperature [C ~> degC]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S  !< Salinity [S ~> ppt]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h  !< Layer thickness [Z ~> m]
   type(unit_scale_type),                     intent(in)  :: US !< A dimensional unit scaling type
   type(param_file_type),                     intent(in)  :: param_file !< Parameter file structure
   logical,                                   intent(in)  :: just_read !< If true, this call will
@@ -287,7 +287,7 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, GV, US, param_fi
       do j=js,je ; do i=is,ie
         xi0 = 0.0
         do k = 1,nz
-          xi1 = xi0 + (GV%H_to_Z * h(i,j,k)) / G%max_depth
+          xi1 = xi0 + h(i,j,k) / G%max_depth
           S(i,j,k) = S_surf + 0.5 * S_range * (xi0 + xi1)
           xi0 = xi1
         enddo
@@ -298,7 +298,7 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, GV, US, param_fi
       do j=js,je ; do i=is,ie
         xi0 = 0.0
         do k = 1,nz
-          xi1 = xi0 + (GV%H_to_Z * h(i,j,k)) / G%max_depth
+          xi1 = xi0 + h(i,j,k) / G%max_depth
           S(i,j,k) = S_surf + 0.5 * S_range * (xi0 + xi1)
           xi0 = xi1
         enddo

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -9,6 +9,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
+use MOM_interface_heights, only : dz_to_thickness, dz_to_thickness_simple
 use MOM_sponge, only : sponge_CS, set_up_sponge_field, initialize_sponge
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
@@ -373,7 +374,8 @@ subroutine DOME2d_initialize_sponges(G, GV, US, tv, depth_tot, param_file, use_A
   ! Local variables
   real :: T(SZI_(G),SZJ_(G),SZK_(GV))  ! A temporary array for temp [C ~> degC]
   real :: S(SZI_(G),SZJ_(G),SZK_(GV))  ! A temporary array for salt [S ~> ppt]
-  real :: h(SZI_(G),SZJ_(G),SZK_(GV))  ! A temporary array for thickness [H ~> m or kg m-2].
+  real :: dz(SZI_(G),SZJ_(G),SZK_(GV)) ! A temporary array for thickness in height units [Z ~> m]
+  real :: h(SZI_(G),SZJ_(G),SZK_(GV))  ! A temporary array for thickness [H ~> m or kg m-2]
   real :: eta(SZI_(G),SZJ_(G),SZK_(GV)+1) ! A temporary array for interface heights [Z ~> m]
   real :: Idamp(SZI_(G),SZJ_(G))       ! The sponge damping rate [T-1 ~> s-1]
   real :: S_ref                        ! Reference salinity within the surface layer [S ~> ppt]
@@ -478,29 +480,37 @@ subroutine DOME2d_initialize_sponges(G, GV, US, tv, depth_tot, param_file, use_A
         eta1D(k) = e0(k)
         if (eta1D(k) < (eta1D(k+1) + GV%Angstrom_Z)) then
           eta1D(k) = eta1D(k+1) + GV%Angstrom_Z
-          h(i,j,k) = GV%Angstrom_H
+          dz(i,j,k) = GV%Angstrom_Z
         else
-          h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+          dz(i,j,k) = eta1D(k) - eta1D(k+1)
         endif
       enddo
     enddo ; enddo
-    ! Store the grid on which the T/S sponge data will reside
-    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, h, nz)
 
     ! Construct temperature and salinity on the arbitrary grid
     T(:,:,:) = 0.0 ; S(:,:,:) = 0.0
     do j=js,je ; do i=is,ie
       z = -depth_tot(i,j)
       do k = nz,1,-1
-        z = z + 0.5 * GV%H_to_Z * h(i,j,k) ! Position of the center of layer k
+        z = z + 0.5 * dz(i,j,k) ! Position of the center of layer k
         ! Use salinity stratification in the eastern sponge.
         S(i,j,k) = S_surf - S_range_sponge * (z / G%max_depth)
         ! Use a constant salinity in the western sponge.
         if ( ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon < dome2d_west_sponge_width ) &
           S(i,j,k) = S_ref + S_range
-        z = z + 0.5 *  GV%H_to_Z * h(i,j,k) ! Position of the interface k
+        z = z + 0.5 * dz(i,j,k) ! Position of the interface k
       enddo
     enddo ; enddo
+
+    ! Convert thicknesses from height units to thickness units
+    if (associated(tv%eqn_of_state)) then
+      call dz_to_thickness(dz, T, S, tv%eqn_of_state, h, G, GV, US)
+    else
+      call dz_to_thickness_simple(dz, h, G, GV, US, layer_mode=.true.)
+    endif
+
+    ! Store damping rates and the grid on which the T/S sponge data will reside
+    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, h, nz)
 
     if ( associated(tv%T) ) call set_up_ALE_sponge_field(T, G, GV, tv%T, ACSp, 'temp', &
         sp_long_name='temperature', sp_unit='degC s-1')

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -105,7 +105,7 @@ subroutine DOME_initialize_thickness(h, depth_tot, G, GV, param_file, just_read)
   type(ocean_grid_type),   intent(in)  :: G           !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+                           intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot   !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -141,9 +141,9 @@ subroutine DOME_initialize_thickness(h, depth_tot, G, GV, param_file, just_read)
       eta1D(K) = e0(K)
       if (eta1D(K) < (eta1D(K+1) + GV%Angstrom_Z)) then
         eta1D(K) = eta1D(K+1) + GV%Angstrom_Z
-        h(i,j,k) = GV%Angstrom_H
+        h(i,j,k) = GV%Angstrom_Z
       else
-        h(i,j,k) = GV%Z_to_H * (eta1D(K) - eta1D(K+1))
+        h(i,j,k) = eta1D(K) - eta1D(K+1)
       endif
     enddo
   enddo ; enddo

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -10,6 +10,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe, WARNING
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
+use MOM_interface_heights, only : dz_to_thickness
 use MOM_io, only : file_exists, MOM_read_data, slasher
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
@@ -146,8 +147,7 @@ subroutine ISOMIP_initialize_thickness ( h, depth_tot, G, GV, US, param_file, tv
                            intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot   !< The nominal total depth of the ocean [Z ~> m]
-  type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
-                                                      !! to parse for model parameter values.
+  type(param_file_type),   intent(in)  :: param_file  !< A structure to parse for model parameter values
   type(thermo_var_ptrs),   intent(in)  :: tv          !< A structure containing pointers to any
                                                       !! available thermodynamic fields, including
                                                       !! the eqn. of state.
@@ -440,27 +440,25 @@ end subroutine ISOMIP_initialize_temperature_salinity
 ! the values towards which the interface heights and an arbitrary
 ! number of tracers should be restored within each sponge.
 subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp, ACSp)
-  type(ocean_grid_type), intent(in) :: G    !< The ocean's grid structure.
-  type(verticalGrid_type), intent(in) :: GV !< The ocean's vertical grid structure.
-  type(unit_scale_type),   intent(in) :: US !< A dimensional unit scaling type
-  type(thermo_var_ptrs), intent(in) :: tv   !< A structure containing pointers
-                                            !! to any available thermodynamic
-                                            !! fields, potential temperature and
-                                            !! salinity or mixed layer density.
-                                            !! Absent fields have NULL ptrs.
+  type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure.
+  type(unit_scale_type),   intent(in) :: US   !< A dimensional unit scaling type
+  type(thermo_var_ptrs),   intent(in) :: tv   !< A structure containing pointers to any available
+                                              !! thermodynamic fields, potential temperature and
+                                              !! salinity or mixed layer density.
+                                              !! Absent fields have NULL ptrs.
   real, dimension(SZI_(G),SZJ_(G)), &
-                           intent(in)  :: depth_tot  !< The nominal total depth of the ocean [Z ~> m]
-  type(param_file_type), intent(in) :: PF   !< A structure indicating the
-                                            !! open file to parse for model
-                                            !! parameter values.
-  logical, intent(in) :: use_ALE            !< If true, indicates model is in ALE mode
-  type(sponge_CS),   pointer    :: CSp      !< Layer-mode sponge structure
-  type(ALE_sponge_CS),   pointer    :: ACSp !< ALE-mode sponge structure
+                           intent(in) :: depth_tot !< The nominal total depth of the ocean [Z ~> m]
+  type(param_file_type),   intent(in) :: PF   !< A structure to parse for model parameter values
+  logical,                 intent(in) :: use_ALE !< If true, indicates model is in ALE mode
+  type(sponge_CS),         pointer    :: CSp  !< Layer-mode sponge structure
+  type(ALE_sponge_CS),     pointer    :: ACSp !< ALE-mode sponge structure
   ! Local variables
   real :: T(SZI_(G),SZJ_(G),SZK_(GV)) ! A temporary array for temp [C ~> degC]
   real :: S(SZI_(G),SZJ_(G),SZK_(GV)) ! A temporary array for salt [S ~> ppt]
   ! real :: RHO(SZI_(G),SZJ_(G),SZK_(GV)) ! A temporary array for RHO [R ~> kg m-3]
-  real :: h(SZI_(G),SZJ_(G),SZK_(GV)) ! A temporary array for thickness [H ~> m or kg m-2]
+  real :: dz(SZI_(G),SZJ_(G),SZK_(GV)) ! Sponge layer thicknesses in height units [Z ~> m]
+  real :: h(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge layer thicknesses [H ~> m or kg m-2]
   real :: Idamp(SZI_(G),SZJ_(G))    ! The sponge damping rate [T-1 ~> s-1]
   real :: TNUDG                     ! Nudging time scale [T ~> s]
   real :: S_sur, S_bot              ! Surface and bottom salinities in the sponge region [S ~> ppt]
@@ -582,9 +580,9 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp,
             eta1D(k) = e0(k)
             if (eta1D(k) < (eta1D(k+1) + GV%Angstrom_Z)) then
               eta1D(k) = eta1D(k+1) + GV%Angstrom_Z
-              h(i,j,k) = GV%Angstrom_H
+              dz(i,j,k) = GV%Angstrom_Z
             else
-              h(i,j,k) = GV%Z_to_H*(eta1D(k) - eta1D(k+1))
+              dz(i,j,k) = eta1D(k) - eta1D(k+1)
             endif
           enddo
         enddo ; enddo
@@ -596,16 +594,16 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp,
             eta1D(k) =  -G%max_depth * real(k-1) / real(nz)
             if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
               eta1D(k) = eta1D(k+1) + min_thickness
-              h(i,j,k) = min_thickness * GV%Z_to_H
+              dz(i,j,k) = min_thickness
             else
-              h(i,j,k) = GV%Z_to_H*(eta1D(k) - eta1D(k+1))
+              dz(i,j,k) = eta1D(k) - eta1D(k+1)
             endif
           enddo
         enddo ; enddo
 
       case ( REGRIDDING_SIGMA )             ! Initial thicknesses for sigma coordinates
         do j=js,je ; do i=is,ie
-          h(i,j,:) = GV%Z_to_H * (depth_tot(i,j) / real(nz))
+          dz(i,j,:) = depth_tot(i,j) / real(nz)
         enddo ; enddo
 
       case default
@@ -614,21 +612,25 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp,
 
     end select
 
-    !  This call sets up the damping rates and interface heights.
-    !  This sets the inverse damping timescale fields in the sponges.
-    call initialize_ALE_sponge(Idamp, G, GV, PF, ACSp, h, nz)
-
     dS_dz = (S_sur - S_bot) / G%max_depth
     dT_dz = (T_sur - T_bot) / G%max_depth
     do j=js,je ; do i=is,ie
       xi0 = -depth_tot(i,j)
       do k = nz,1,-1
-        xi0 = xi0 + 0.5 * h(i,j,k) * GV%H_to_Z ! Depth in middle of layer
+        xi0 = xi0 + 0.5 * dz(i,j,k)  ! Depth in middle of layer
         S(i,j,k) = S_sur + dS_dz * xi0
         T(i,j,k) = T_sur + dT_dz * xi0
-        xi0 = xi0 + 0.5 * h(i,j,k) * GV%H_to_Z ! Depth at top of layer
+        xi0 = xi0 + 0.5 * dz(i,j,k)  ! Depth at top of layer
       enddo
     enddo ; enddo
+
+    ! Convert thicknesses from height units to thickness units
+    if (associated(tv%eqn_of_state)) then
+      call dz_to_thickness(dz, T, S, tv%eqn_of_state, h, G, GV, US)
+    else
+      call MOM_error(FATAL, "The ISOMIP test case requires an equation of state.")
+    endif
+
     ! for debugging
     !i=G%iec; j=G%jec
     !do k = 1,nz
@@ -636,6 +638,9 @@ subroutine ISOMIP_initialize_sponges(G, GV, US, tv, depth_tot, PF, use_ALE, CSp,
     !  write(mesg,*) 'Sponge - k,h,T,S,rho,Rlay',k,h(i,j,k),T(i,j,k),S(i,j,k),rho_tmp,GV%Rlay(k)
     !  call MOM_mesg(mesg,5)
     !enddo
+
+    ! This call sets up the damping rates and interface heights in the sponges.
+    call initialize_ALE_sponge(Idamp, G, GV, PF, ACSp, h, nz)
 
     !   Now register all of the fields which are damped in the sponge.   !
     ! By default, momentum is advected vertically within the sponge, but !

--- a/src/user/Neverworld_initialization.F90
+++ b/src/user/Neverworld_initialization.F90
@@ -243,7 +243,7 @@ subroutine Neverworld_initialize_thickness(h, depth_tot, G, GV, US, param_file, 
   type(verticalGrid_type), intent(in) :: GV                   !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in) :: US                   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: h !< The thickness that is being
-                                                              !! initialized [H ~> m or kg m-2].
+                                                              !! initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in) :: depth_tot  !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in) :: param_file           !< A structure indicating the open
@@ -288,12 +288,12 @@ subroutine Neverworld_initialize_thickness(h, depth_tot, G, GV, US, param_file, 
   do j=js,je ; do i=is,ie
     e_interface = -depth_tot(i,j)
     do k=nz,2,-1
-      h(i,j,k) = GV%Z_to_H * (e0(k) - e_interface) ! Nominal thickness
+      h(i,j,k) = e0(k) - e_interface ! Nominal thickness
       x = (G%geoLonT(i,j)-G%west_lon)/G%len_lon
       y = (G%geoLatT(i,j)-G%south_lat)/G%len_lat
       r1 = sqrt((x-0.7)**2+(y-0.2)**2)
       r2 = sqrt((x-0.3)**2+(y-0.25)**2)
-      h(i,j,k) = h(i,j,k) + pert_amp * (e0(k) - e0(nz+1)) * GV%Z_to_H * &
+      h(i,j,k) = h(i,j,k) + pert_amp * (e0(k) - e0(nz+1)) * &
                             (spike(r1,0.15)-spike(r2,0.15)) ! Prescribed perturbation
       if (h_noise /= 0.) then
         rns = initializeRandomNumberStream( int( 4096*(x + (y+1.)) ) )
@@ -301,11 +301,11 @@ subroutine Neverworld_initialize_thickness(h, depth_tot, G, GV, US, param_file, 
         noise = h_noise * 2. * ( noise - 0.5 ) ! range -h_noise to h_noise
         h(i,j,k) = ( 1. + noise ) * h(i,j,k)
       endif
-      h(i,j,k) = max( GV%Angstrom_H, h(i,j,k) ) ! Limit to non-negative
-      e_interface = e_interface + GV%H_to_Z * h(i,j,k) ! Actual position of upper interface
+      h(i,j,k) = max( GV%Angstrom_Z, h(i,j,k) ) ! Limit to non-negative
+      e_interface = e_interface + h(i,j,k) ! Actual position of upper interface
     enddo
-    h(i,j,1) = GV%Z_to_H * (e0(1) - e_interface) ! Nominal thickness
-    h(i,j,1) = max( GV%Angstrom_H, h(i,j,1) ) ! Limit to non-negative
+    h(i,j,1) = e0(1) - e_interface ! Nominal thickness
+    h(i,j,1) = max( GV%Angstrom_Z, h(i,j,1) ) ! Limit to non-negative
   enddo ; enddo
 
 end subroutine Neverworld_initialize_thickness

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -39,7 +39,7 @@ subroutine Phillips_initialize_thickness(h, depth_tot, G, GV, US, param_file, ju
   type(verticalGrid_type), intent(in)  :: GV         !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US         !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h          !< The thickness that is being initialized [H ~> m or kg m-2]
+                           intent(out) :: h          !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot  !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file !< A structure indicating the open file
@@ -116,9 +116,9 @@ subroutine Phillips_initialize_thickness(h, depth_tot, G, GV, US, param_file, ju
       eta1D(K) = eta_im(j,K)
       if (eta1D(K) < (eta1D(K+1) + GV%Angstrom_Z)) then
         eta1D(K) = eta1D(K+1) + GV%Angstrom_Z
-        h(i,j,k) = GV%Angstrom_H
+        h(i,j,k) = GV%Angstrom_Z
       else
-        h(i,j,k) = GV%Z_to_H * (eta1D(K) - eta1D(K+1))
+        h(i,j,k) = eta1D(K) - eta1D(K+1)
       endif
     enddo
   enddo ; enddo

--- a/src/user/Rossby_front_2d_initialization.F90
+++ b/src/user/Rossby_front_2d_initialization.F90
@@ -40,7 +40,7 @@ subroutine Rossby_front_initialize_thickness(h, G, GV, US, param_file, just_read
   type(verticalGrid_type), intent(in)  :: GV          !< Vertical grid structure
   type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2]
+                           intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,                 intent(in)  :: just_read   !< If true, this call will only read
@@ -83,7 +83,7 @@ subroutine Rossby_front_initialize_thickness(h, G, GV, US, param_file, just_read
         stretch = ( ( G%max_depth + eta ) / G%max_depth )
         h0 = ( G%max_depth / real(nz) ) * stretch
         do k = 1, nz
-          h(i,j,k) = h0 * GV%Z_to_H
+          h(i,j,k) = h0
         enddo
       enddo ; enddo
 
@@ -94,7 +94,7 @@ subroutine Rossby_front_initialize_thickness(h, G, GV, US, param_file, just_read
         stretch = ( ( G%max_depth + eta ) / G%max_depth )
         h0 = ( G%max_depth / real(nz) ) * stretch
         do k = 1, nz
-          h(i,j,k) = h0 * GV%Z_to_H
+          h(i,j,k) = h0
         enddo
       enddo ; enddo
 
@@ -114,7 +114,7 @@ subroutine Rossby_front_initialize_temperature_salinity(T, S, h, G, GV, US, &
   type(verticalGrid_type),                   intent(in)  :: GV !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T  !< Potential temperature [C ~> degC]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S  !< Salinity [S ~> ppt]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h  !< Thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h  !< Thickness [Z ~> m]
   type(unit_scale_type),                     intent(in)  :: US !< A dimensional unit scaling type
   type(param_file_type),                     intent(in)  :: param_file   !< Parameter file handle
   logical,                                   intent(in)  :: just_read !< If true, this call will
@@ -125,7 +125,7 @@ subroutine Rossby_front_initialize_temperature_salinity(T, S, h, G, GV, US, &
   real      :: S_ref        ! Reference salinity within the surface layer [S ~> ppt]
   real      :: T_range      ! Range of temperatures over the vertical [C ~> degC]
   real      :: zc           ! Position of the middle of the cell [Z ~> m]
-  real      :: zi           ! Bottom interface position relative to the sea surface [H ~> m or kg m-2]
+  real      :: zi           ! Bottom interface position relative to the sea surface [Z ~> m]
   real      :: dTdz         ! Vertical temperature gradient [C Z-1 ~> degC m-1]
   character(len=40) :: verticalCoordinate
 
@@ -149,8 +149,8 @@ subroutine Rossby_front_initialize_temperature_salinity(T, S, h, G, GV, US, &
   do j = G%jsc,G%jec ; do i = G%isc,G%iec
     zi = 0.
     do k = 1, nz
-      zi = zi - h(i,j,k)              ! Bottom interface position
-      zc = GV%H_to_Z * (zi - 0.5*h(i,j,k))    ! Position of middle of cell
+      zi = zi - h(i,j,k)           ! Bottom interface position
+      zc = zi - 0.5*h(i,j,k)       ! Position of middle of cell
       zc = min( zc, -Hml(G, G%geoLatT(i,j)) ) ! Bound by depth of mixed layer
       T(i,j,k) = T_ref + dTdz * zc ! Linear temperature profile
     enddo

--- a/src/user/SCM_CVMix_tests.F90
+++ b/src/user/SCM_CVMix_tests.F90
@@ -57,7 +57,7 @@ subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, US, param_file, just_read)
   type(verticalGrid_type),                   intent(in)  :: GV !< Vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T  !< Potential temperature [C ~> degC]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S  !< Salinity [S ~> ppt]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h  !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h  !< Layer thickness [Z ~> m]
   type(unit_scale_type),                     intent(in)  :: US !< A dimensional unit scaling type
   type(param_file_type),                     intent(in)  :: param_file !< Input parameter structure
   logical,                                   intent(in)  :: just_read !< If present and true, this call
@@ -108,7 +108,7 @@ subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, US, param_file, just_read)
     top = 0. ! Reference to surface
     bottom = 0.
     do k=1,nz
-      bottom = bottom - h(i,j,k)*GV%H_to_Z ! Interface below layer [Z ~> m]
+      bottom = bottom - h(i,j,k)       ! Interface below layer [Z ~> m]
       zC = 0.5*( top + bottom )        ! Z of middle of layer [Z ~> m]
       DZ = min(0., zC + UpperLayerTempMLD)
       T(i,j,k) = max(LowerLayerMinTemp,LowerLayerTemp + LowerLayerdTdZ * DZ)

--- a/src/user/baroclinic_zone_initialization.F90
+++ b/src/user/baroclinic_zone_initialization.F90
@@ -86,7 +86,7 @@ subroutine baroclinic_zone_init_temperature_salinity(T, S, h, depth_tot, G, GV, 
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: S          !< Salinity [S ~> ppt]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)  :: h          !< The model thicknesses [H ~> m or kg m-2]
+                           intent(in)  :: h          !< The model thicknesses [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot  !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file !< A structure indicating the open file
@@ -135,8 +135,8 @@ subroutine baroclinic_zone_init_temperature_salinity(T, S, h, depth_tot, G, GV, 
       fn = xs
     endif
     do k = nz, 1, -1
-      zc = zi + 0.5*h(i,j,k)*GV%H_to_Z ! Position of middle of cell
-      zi = zi + h(i,j,k)*GV%H_to_Z    ! Top interface position
+      zc = zi + 0.5*h(i,j,k)          ! Position of middle of cell
+      zi = zi + h(i,j,k)              ! Top interface position
       T(i,j,k) = T_ref + dTdz * zc  & ! Linear temperature stratification
                  + dTdx * x         & ! Linear gradient
                  + delta_T * fn       ! Smooth fn of width L_zone

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -84,7 +84,7 @@ subroutine benchmark_initialize_thickness(h, depth_tot, G, GV, US, param_file, e
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+                           intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot   !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -184,9 +184,9 @@ subroutine benchmark_initialize_thickness(h, depth_tot, G, GV, US, param_file, e
 
     do k=1,nz ; e_pert(K) = 0.0 ; enddo
 
-    !   This sets the initial thickness (in [H ~> m or kg m-2]) of the layers.  The thicknesses
+    !   This sets the initial thickness (in [Z ~> m]) of the layers.  The thicknesses
     ! are set to insure that:
-    !   1. each layer is at least GV%Angstrom_H thick, and
+    !   1. each layer is at least GV%Angstrom_Z thick, and
     !   2. the interfaces are where they should be based on the resting depths and
     !      interface height perturbations, as long at this doesn't interfere with 1.
     eta1D(nz+1) = -depth_tot(i,j)
@@ -211,9 +211,9 @@ subroutine benchmark_initialize_thickness(h, depth_tot, G, GV, US, param_file, e
       if (eta1D(K) < eta1D(K+1) + GV%Angstrom_Z) &
         eta1D(K) = eta1D(K+1) + GV%Angstrom_Z
 
-      h(i,j,k) = max(GV%Z_to_H * (eta1D(K) - eta1D(K+1)), GV%Angstrom_H)
+      h(i,j,k) = max(eta1D(K) - eta1D(K+1), GV%Angstrom_Z)
     enddo
-    h(i,j,1) = max(GV%Z_to_H * (0.0 - eta1D(2)), GV%Angstrom_H)
+    h(i,j,1) = max(0.0 - eta1D(2), GV%Angstrom_Z)
 
   enddo ; enddo
 

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -105,7 +105,7 @@ subroutine dense_water_initialize_TS(G, GV, US, param_file, T, S, h, just_read)
   type(param_file_type),                     intent(in)  :: param_file !< Parameter file structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T !< Output temperature [C ~> degC]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S !< Output salinity [S ~> ppt]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thicknesses [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thicknesses [Z ~> m]
   logical,                                   intent(in)  :: just_read !< If true, this call will
                                                       !! only read parameters without changing T & S.
   ! Local variables
@@ -137,7 +137,7 @@ subroutine dense_water_initialize_TS(G, GV, US, param_file, T, S, h, just_read)
       zi = 0.
       do k = 1,nz
         ! nondimensional middle of layer
-        zmid = zi + 0.5 * h(i,j,k) / (GV%Z_to_H * G%max_depth)
+        zmid = zi + 0.5 * h(i,j,k) / G%max_depth
 
         if (zmid < mld) then
           ! use reference salinity in the mixed layer
@@ -147,7 +147,7 @@ subroutine dense_water_initialize_TS(G, GV, US, param_file, T, S, h, just_read)
           S(i,j,k) = S_ref + S_range * (zmid - mld) / (1.0 - mld)
         endif
 
-        zi = zi + h(i,j,k) / (GV%Z_to_H * G%max_depth)
+        zi = zi + h(i,j,k) / G%max_depth
       enddo
     enddo
   enddo

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -9,6 +9,7 @@ use MOM_dyn_horgrid,   only : dyn_horgrid_type
 use MOM_EOS,           only : EOS_type
 use MOM_error_handler, only : MOM_error, FATAL
 use MOM_file_parser,   only : get_param, param_file_type
+use MOM_interface_heights, only : dz_to_thickness, dz_to_thickness_simple
 use MOM_grid,          only : ocean_grid_type
 use MOM_sponge,        only : sponge_CS
 use MOM_unit_scaling,  only : unit_scale_type
@@ -172,7 +173,8 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
   real :: east_sponge_width ! The fraction of the domain in which the eastern (outflow) sponge is active [nondim]
 
   real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale [T-1 ~> s-1]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h  ! sponge thicknesses [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: dz ! sponge layer thicknesses in height units [Z ~> m]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h  ! sponge layer thicknesses [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: T  ! sponge temperature [C ~> degC]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: S  ! sponge salinity [S ~> ppt]
   real, dimension(SZK_(GV)+1) :: e0, eta1D ! interface positions for ALE sponge [Z ~> m]
@@ -256,15 +258,13 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
           if (eta1D(k) < (eta1D(k+1) + GV%Angstrom_Z)) then
             ! is this layer vanished?
             eta1D(k) = eta1D(k+1) + GV%Angstrom_Z
-            h(i,j,k) = GV%Angstrom_H
+            dz(i,j,k) = GV%Angstrom_Z
           else
-            h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+            dz(i,j,k) = eta1D(k) - eta1D(k+1)
           endif
         enddo
       enddo
     enddo
-
-    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, h, nz)
 
     ! construct temperature and salinity for the sponge
     ! start with initial condition
@@ -277,7 +277,7 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
         x = (G%geoLonT(i,j) - G%west_lon) / G%len_lon
         do k = 1,nz
           ! nondimensional middle of layer
-          zmid = zi + 0.5 * h(i,j,k) / (GV%Z_to_H * G%max_depth)
+          zmid = zi + 0.5 * dz(i,j,k) / G%max_depth
 
           if (x > (1. - east_sponge_width)) then
             !if (zmid >= 0.9 * sill_frac) &
@@ -288,10 +288,20 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
               S(i,j,k) = S_ref + S_range * (zmid - mld) / (1.0 - mld)
           endif
 
-          zi = zi + h(i,j,k) / (GV%Z_to_H * G%max_depth)
+          zi = zi + dz(i,j,k) / G%max_depth
         enddo
       enddo
     enddo
+
+    ! Convert thicknesses from height units to thickness units
+    if (associated(tv%eqn_of_state)) then
+      call dz_to_thickness(dz, T, S, tv%eqn_of_state, h, G, GV, US)
+    else
+      call dz_to_thickness_simple(dz, h, G, GV, US, layer_mode=.true.)
+    endif
+
+    ! This call sets up the damping rates and interface heights in the sponges.
+    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, h, nz)
 
     if ( associated(tv%T) ) call set_up_ALE_sponge_field(T, G, GV, tv%T, ACSp, 'temp', &
         sp_long_name='temperature', sp_unit='degC s-1')

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -96,7 +96,7 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+                           intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot   !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -126,7 +126,7 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   if (.not.just_read) &
-    call MOM_mesg("MOM_initialization.F90, initialize_thickness_uniform: setting thickness")
+    call MOM_mesg("dumbbell_initialization.F90, dumbbell_initialize_thickness: setting thickness")
 
   if (.not.just_read) call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl,"MIN_THICKNESS", min_thickness, &
@@ -174,7 +174,7 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
           enddo
         endif
         do k=1,nz
-          h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+          h(i,j,k) = eta1D(k) - eta1D(k+1)
         enddo
       enddo
     enddo
@@ -217,9 +217,9 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
         eta1D(k) = e0(k)
         if (eta1D(k) < (eta1D(k+1) + GV%Angstrom_Z)) then
           eta1D(k) = eta1D(k+1) + GV%Angstrom_Z
-          h(i,j,k) = GV%Angstrom_H
+          h(i,j,k) = GV%Angstrom_Z
         else
-          h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+          h(i,j,k) = eta1D(k) - eta1D(k+1)
         endif
       enddo
     enddo ; enddo
@@ -232,9 +232,9 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
         eta1D(k) = -G%max_depth * real(k-1) / real(nz)
         if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
           eta1D(k) = eta1D(k+1) + min_thickness
-          h(i,j,k) = GV%Z_to_H * min_thickness
+          h(i,j,k) = min_thickness
         else
-          h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+          h(i,j,k) = eta1D(k) - eta1D(k+1)
         endif
       enddo
     enddo ; enddo
@@ -242,7 +242,7 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
   case ( REGRIDDING_SIGMA )             ! Initial thicknesses for sigma coordinates
     if (just_read) return ! All run-time parameters have been read, so return.
     do j=js,je ; do i=is,ie
-      h(i,j,:) = GV%Z_to_H * depth_tot(i,j) / real(nz)
+      h(i,j,:) = depth_tot(i,j) / real(nz)
     enddo ; enddo
 
 end select
@@ -255,7 +255,7 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
   type(verticalGrid_type),                   intent(in)  :: GV !< Vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T !< Potential temperature [C ~> degC]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S !< Salinity [S ~> ppt]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thickness [Z ~> m]
   type(unit_scale_type),                     intent(in)  :: US !< A dimensional unit scaling type
   type(param_file_type),                     intent(in)  :: param_file !< Parameter file structure
   logical,                                   intent(in)  :: just_read !< If true, this call will

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -9,6 +9,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
+use MOM_interface_heights, only : dz_to_thickness, dz_to_thickness_simple
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
 use MOM_unit_scaling, only : unit_scale_type
@@ -349,8 +350,11 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
   real :: sponge_time_scale  ! The damping time scale [T ~> s]
 
   real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale [T-1 ~> s-1]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h ! sponge thicknesses [H ~> m or kg m-2]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: S ! sponge salinities [S ~> ppt]
+  real :: dz(SZI_(G),SZJ_(G),SZK_(GV)) ! Sponge thicknesses in height units [Z ~> m]
+  real :: h(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge thicknesses [H ~> m or kg m-2]
+  real :: S(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge salinities [S ~> ppt]
+  real :: T(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge tempertures [C ~> degC], used only to convert thicknesses
+                                       ! in non-Boussinesq mode
   real, dimension(SZK_(GV)+1) :: eta1D ! Interface positions for ALE sponge [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: eta ! A temporary array for interface heights [Z ~> m].
 
@@ -359,6 +363,7 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
   real :: dblen          ! The size of the dumbbell test case [km] or [m]
   real :: min_thickness  ! The minimum layer thickness [Z ~> m]
   real :: S_ref, S_range ! A reference salinity and the range of salinities in this test case [S ~> ppt]
+  real :: T_surf         ! The surface temperature [C ~> degC]
   logical :: dbrotate    ! If true, rotate the domain.
 
   call get_param(param_file, mdl,"DUMBBELL_LEN",dblen, &
@@ -377,6 +382,9 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
   call get_param(param_file, mdl, "DUMBBELL_SPONGE_TIME_SCALE", sponge_time_scale, &
                  "The time scale in the reservoir for restoring. If zero, the sponge is disabled.", &
                  units="s", default=0., scale=US%s_to_T)
+  call get_param(param_file, mdl, "DUMBBELL_T_SURF", T_surf, &
+                 'Initial surface temperature in the DUMBBELL configuration', &
+                 units='degC', default=20., scale=US%degC_to_C, do_not_log=.true.)
   call get_param(param_file, mdl, "DUMBBELL_SREF", S_ref, &
                  'DUMBBELL REFERENCE SALINITY', &
                  units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=.true.)
@@ -419,18 +427,17 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
         eta1D(k) = -G%max_depth * real(k-1) / real(nz)
         if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
           eta1D(k) = eta1D(k+1) + min_thickness
-          h(i,j,k) = GV%Z_to_H * min_thickness
+          dz(i,j,k) = min_thickness
         else
-          h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+          dz(i,j,k) = eta1D(k) - eta1D(k+1)
         endif
       enddo
     enddo ; enddo
 
-    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, h, nz)
-
     ! construct temperature and salinity for the sponge
     ! start with initial condition
     S(:,:,:) = 0.0
+    T(:,:,:) = T_surf
 
     do j=G%jsc,G%jec ; do i=G%isc,G%iec
       ! Compute normalized zonal coordinates (x,y=0 at center of domain)
@@ -451,7 +458,18 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
         enddo
       endif
     enddo ; enddo
-  if (associated(tv%S)) call set_up_ALE_sponge_field(S, G, GV, tv%S, ACSp, 'salt', &
+
+    ! Convert thicknesses from height units to thickness units
+    if (associated(tv%eqn_of_state)) then
+      call dz_to_thickness(dz, T, S, tv%eqn_of_state, h, G, GV, US)
+    else
+      call dz_to_thickness_simple(dz, h, G, GV, US, layer_mode=.true.)
+    endif
+
+    ! Store damping rates and the grid on which the T/S sponge data will reside
+    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, h, nz)
+
+    if (associated(tv%S)) call set_up_ALE_sponge_field(S, G, GV, tv%S, ACSp, 'salt', &
                           sp_long_name='salinity', sp_unit='g kg-1 s-1')
   else
     do j=G%jsc,G%jec ; do i=G%isc,G%iec

--- a/src/user/external_gwave_initialization.F90
+++ b/src/user/external_gwave_initialization.F90
@@ -30,7 +30,7 @@ subroutine external_gwave_initialize_thickness(h, G, GV, US, param_file, just_re
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+                           intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,                 intent(in)  :: just_read   !< If true, this call will only read
@@ -73,7 +73,7 @@ subroutine external_gwave_initialize_thickness(h, G, GV, US, param_file, just_re
     enddo
     eta1D(nz+1) = -G%max_depth ! Force bottom interface to bottom
     do k=1,nz
-      h(i,j,k) = GV%Z_to_H * (eta1D(K) - eta1D(K+1))
+      h(i,j,k) = eta1D(K) - eta1D(K+1)
     enddo
   enddo ; enddo
 

--- a/src/user/lock_exchange_initialization.F90
+++ b/src/user/lock_exchange_initialization.F90
@@ -28,7 +28,7 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, US, param_file, just_rea
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+                           intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
                                                       !! to parse for model parameter values.
   logical,                 intent(in)  :: just_read   !< If true, this call will only read
@@ -80,7 +80,7 @@ subroutine lock_exchange_initialize_thickness(h, G, GV, US, param_file, just_rea
       eta1D(K) = min( eta1D(K), eta1D(K-1) - GV%Angstrom_Z )
     enddo
     do k=nz,1,-1
-      h(i,j,k) = GV%Z_to_H * (eta1D(K) - eta1D(K+1))
+      h(i,j,k) = eta1D(K) - eta1D(K+1)
     enddo
   enddo ; enddo
 

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -84,7 +84,7 @@ subroutine seamount_initialize_thickness (h, depth_tot, G, GV, US, param_file, j
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+                           intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot   !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
@@ -105,7 +105,7 @@ subroutine seamount_initialize_thickness (h, depth_tot, G, GV, US, param_file, j
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   if (.not.just_read) &
-    call MOM_mesg("MOM_initialization.F90, initialize_thickness_uniform: setting thickness")
+    call MOM_mesg("seamount_initialization.F90, seamount_initialize_thickness: setting thickness")
 
   call get_param(param_file, mdl,"MIN_THICKNESS",min_thickness, &
                 'Minimum thickness for layer', &
@@ -164,9 +164,9 @@ subroutine seamount_initialize_thickness (h, depth_tot, G, GV, US, param_file, j
         eta1D(k) = e0(k)
         if (eta1D(k) < (eta1D(k+1) + GV%Angstrom_Z)) then
           eta1D(k) = eta1D(k+1) + GV%Angstrom_Z
-          h(i,j,k) = GV%Angstrom_H
+          h(i,j,k) = GV%Angstrom_Z
         else
-          h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+          h(i,j,k) = eta1D(k) - eta1D(k+1)
         endif
       enddo
     enddo ; enddo
@@ -179,9 +179,9 @@ subroutine seamount_initialize_thickness (h, depth_tot, G, GV, US, param_file, j
         eta1D(k) =  -G%max_depth * real(k-1) / real(nz)
         if (eta1D(k) < (eta1D(k+1) + min_thickness)) then
           eta1D(k) = eta1D(k+1) + min_thickness
-          h(i,j,k) = GV%Z_to_H * min_thickness
+          h(i,j,k) = min_thickness
         else
-          h(i,j,k) = GV%Z_to_H * (eta1D(k) - eta1D(k+1))
+          h(i,j,k) = eta1D(k) - eta1D(k+1)
         endif
       enddo
     enddo ; enddo
@@ -189,7 +189,7 @@ subroutine seamount_initialize_thickness (h, depth_tot, G, GV, US, param_file, j
   case ( REGRIDDING_SIGMA )             ! Initial thicknesses for sigma coordinates
     if (just_read) return ! All run-time parameters have been read, so return.
     do j=js,je ; do i=is,ie
-      h(i,j,:) = GV%Z_to_H * depth_tot(i,j) / real(nz)
+      h(i,j,:) = depth_tot(i,j) / real(nz)
     enddo ; enddo
 
 end select
@@ -202,7 +202,7 @@ subroutine seamount_initialize_temperature_salinity(T, S, h, G, GV, US, param_fi
   type(verticalGrid_type),                   intent(in)  :: GV !< Vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T !< Potential temperature [C ~> degC]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S !< Salinity [S ~> ppt]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h !< Layer thickness [Z ~> m]
   type(unit_scale_type),                     intent(in)  :: US !< A dimensional unit scaling type
   type(param_file_type),                     intent(in)  :: param_file !< Parameter file structure
   logical,                                   intent(in)  :: just_read !< If true, this call will
@@ -282,7 +282,7 @@ subroutine seamount_initialize_temperature_salinity(T, S, h, G, GV, US, param_fi
       do j=js,je ; do i=is,ie
         xi0 = 0.0
         do k = 1,nz
-          xi1 = xi0 + GV%H_to_Z * h(i,j,k) / G%max_depth
+          xi1 = xi0 + h(i,j,k) / G%max_depth
           select case ( trim(density_profile) )
             case ('linear')
              !S(i,j,k) = S_surf + S_range * 0.5 * (xi0 + xi1)

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -57,7 +57,7 @@ subroutine sloshing_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
   type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US          !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h           !< The thickness that is being initialized [H ~> m or kg m-2].
+                           intent(out) :: h           !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot   !< The nominal total depth of the ocean [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file  !< A structure to parse for model parameter values.
@@ -160,7 +160,7 @@ subroutine sloshing_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
 
     ! 4. Define layers
     do k = 1,nz
-      h(i,j,k) = GV%Z_to_H * (z_inter(k) - z_inter(k+1))
+      h(i,j,k) = z_inter(k) - z_inter(k+1)
     enddo
 
   enddo ; enddo
@@ -179,7 +179,7 @@ subroutine sloshing_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
   type(verticalGrid_type),                   intent(in)  :: GV !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: T  !< Potential temperature [C ~> degC].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: S  !< Salinity [S ~> ppt].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h  !< Layer thickness [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h  !< Layer thickness [Z ~> m].
   type(unit_scale_type),                     intent(in)  :: US !< A dimensional unit scaling type
   type(param_file_type),                     intent(in)  :: param_file !< A structure to parse
                                                                !! for model parameter values.

--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -32,7 +32,7 @@ subroutine soliton_initialize_thickness(h, depth_tot, G, GV, US)
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h    !< The thickness that is being initialized [H ~> m or kg m-2].
+                           intent(out) :: h    !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot !< The nominal total depth of the ocean [Z ~> m]
 
@@ -55,7 +55,7 @@ subroutine soliton_initialize_thickness(h, depth_tot, G, GV, US)
       y = G%geoLatT(i,j)-y0
       val3 = exp(-val1*x)
       val4 = val2 * ( 2.0*val3 / (1.0 + (val3*val3)) )**2
-      h(i,j,k) = GV%Z_to_H * (0.25*val4*(6.0*y*y + 3.0) * exp(-0.5*y*y) + depth_tot(i,j))
+      h(i,j,k) = (0.25*val4*(6.0*y*y + 3.0) * exp(-0.5*y*y) + depth_tot(i,j))
     enddo
   enddo ; enddo
 
@@ -63,12 +63,11 @@ end subroutine soliton_initialize_thickness
 
 
 !> Initialization of u and v in the equatorial Rossby soliton test
-subroutine soliton_initialize_velocity(u, v, h, G, GV, US)
+subroutine soliton_initialize_velocity(u, v, G, GV, US)
   type(ocean_grid_type),                      intent(in)  :: G  !< Grid structure
   type(verticalGrid_type),                    intent(in)  :: GV !< The ocean's vertical grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(out) :: u  !< i-component of velocity [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(out) :: v  !< j-component of velocity [L T-1 ~> m s-1]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h  !< Thickness [H ~> m or kg m-2]
   type(unit_scale_type),                      intent(in)  :: US !< A dimensional unit scaling type
 
   ! Local variables

--- a/src/user/user_initialization.F90
+++ b/src/user/user_initialization.F90
@@ -76,12 +76,12 @@ subroutine USER_initialize_topography(D, G, param_file, max_depth, US)
 
 end subroutine USER_initialize_topography
 
-!> initialize thicknesses.
+!> Initialize thicknesses in depth units.  These will be converted to thickness units later.
 subroutine USER_initialize_thickness(h, G, GV, param_file, just_read)
   type(ocean_grid_type),   intent(in)  :: G  !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out) :: h  !< The thicknesses being initialized [H ~> m or kg m-2].
+                           intent(out) :: h  !< The thicknesses being initialized [Z ~> m]
   type(param_file_type),   intent(in)  :: param_file !< A structure indicating the open
                                              !! file to parse for model parameter values.
   logical,                 intent(in)  :: just_read !< If true, this call will
@@ -93,7 +93,8 @@ subroutine USER_initialize_thickness(h, G, GV, param_file, just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
-  h(:,:,1) = 0.0 ! h should be set [H ~> m or kg m-2].
+  h(:,:,1:GV%ke) = 0.0 ! h should be set in [Z ~> m].  It will be converted to thickness units
+                       ! [H ~> m or kg m-2] once the temperatures and salinities are known.
 
   if (first_call) call write_user_log(param_file)
 


### PR DESCRIPTION
  This PR includes a series of commits that improve the accuracy with which MOM6 is initialized in certain non-Boussinesq configurations and which extend the capabilities of the MOM_interface_heights module to include new routines to properly convert the vertical extent of layers (in height units) to thicknesses (even when in non-Boussinesq mode).  These changes lead to a notable simplification of the code in some places where the calculations are working in, depth space, and to the elimination of the use of GV%H_to_Z or GV%Z_to_H, especially in a number of user modules.  These changes greatly reduce the dependence of non-Boussinesq configurations on the value of the Boussinesq reference density, and they will lead to more accurate initialization of non-Boussinesq models.  The changes in this PR include:

 - Eliminate the unused optional argument eta_to_m to the find_eta routines

 - Initialize the thicknesses in height units in 26 modules, and pass  thicknesses in height units to temperature and salinity initialization  routines in many of these same modules before systematically converting the thicknesses to thickness units after the temperatures and salinities are known and it can be done properly in non-Boussinesq models

 - Refactor `MOM_initialize_state()` to more clearly group initialization calls into well-defined phases

 - Add a new optional height_units argument to `ALE_initThicknessToCoord()`

 - Obsolete the runtime parameter CONVERT_THICKNESS_UNITS

 - Add code to handle initialization of thicknesses from a file that is already in mass units, as indicated when THICKNESS_CONFIG = "mass_file"

 - Eliminate unused thickness arguments to `soliton_initialize_velocity()` and `determine_temperature()`

 - Add the new overloaded interface `dz_to_thickness()` and the new public routine `dz_to_thickness_simple()` to the MOM_interface_heights module

 - Refactor `trim_for_ice()` to have a separate, simpler form appropriate for use in non-Boussinesq mode

 - Refactor `initialize_sponges_file()` to work in depth-space variables before using `dz_to_thickness()` to convert to thicknesses, but also to properly handle the case where the input file has a different number of vertical layers than the model is using, avoiding a possible segmentation fault

 - Reorder code in `MOM_temp_salt_initialize_from_Z()` to more clearly group it into distinct phases, and also use the new `dz_to_thickness()` routine to convert input depths into thicknesses

 - Use `dz_to_thickness()` to convert vertical distances to layer thicknesses in the sponge initialization routines in 4 user modules

  There are a number of interface changes associated with these commits, and there are some changes to the MOM_parameter_doc files. However, by design all answers are bitwise identical in all known test cases, with some answer-changing simplifications in non-Boussinesq mode deferred to a subsequent PR.

  The commits in this PR include:

- NOAA-GFDL/MOM6@9ed06995b (*)Use dz_to_thickness in 4 user modules
- NOAA-GFDL/MOM6@e7337bf16 (*)Improve non-Boussinesq initialization
- NOAA-GFDL/MOM6@6080ea615 +Add the new overloaded interface dz_to_thickness
- NOAA-GFDL/MOM6@a499f36c9 +Initialize thicknesses in height units
- NOAA-GFDL/MOM6@975651ae7 +Remove optional argument eta_to_m from find_eta
