### PR TITLE
Profiling: subparameter parser support

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -733,7 +733,8 @@ prof.p0: $(WORKSPACE)/work/p0/opt/clocks.json $(WORKSPACE)/work/p0/opt_target/cl
 	python tools/compare_clocks.py $^
 
 $(WORKSPACE)/work/p0/%/clocks.json: $(WORKSPACE)/work/p0/%/std.out
-	python tools/parse_fms_clocks.py -d $(@D) $^ > $@
+	python tools/parse_fms_clocks.py -d $(@D) $^ > $@ \
+	  || !( rm $@ )
 
 $(WORKSPACE)/work/p0/opt/std.out: build/opt/MOM6
 $(WORKSPACE)/work/p0/opt_target/std.out: build/opt_target/MOM6


### PR DESCRIPTION
The very crude MOM_input parser in the automatic profiler did not support subparameters (e.g. MLE% ... %MLE), which caused an error when trying to read the FMS clock output.

This patch adds the support, or at least enough support to avoid errors.