### PR TITLE
POSIX: generic wrappers for all setjmp.h symbols

### DIFF
--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -242,12 +242,24 @@ AC_CONFIG_COMMANDS(Makefile.dep, [make depend])
 
 # POSIX verification tests
 
-# These symbols may be defined as macros, making them inaccessible by Fortran.
-# These three exist in modern BSD and Linux libc, so we just confirm them.
-# But one day, we many need to handle them more carefully.
-AX_FC_CHECK_BIND_C([setjmp], [], [AC_MSG_ERROR([Could not find setjmp.])])
-AX_FC_CHECK_BIND_C([longjmp], [], [AC_MSG_ERROR([Could not find longjmp.])])
-AX_FC_CHECK_BIND_C([siglongjmp], [], [AC_MSG_ERROR([Could not find siglongjmp.])])
+# Symbols in <setjmp.h> may be defined as macros, making them inaccessible by
+# Fortran C bindings.  `sigsetjmp` is known to have an internal symbol in
+# glibc, so we check for this possibility.  For the others, we only check for
+# existence.
+
+# If the need arises, we may want to define these under a standalone macro.
+
+# Validate the setjmp symbol
+AX_FC_CHECK_BIND_C([setjmp],
+  [SETJMP="setjmp"], [SETJMP="setjmp_missing"]
+)
+AC_DEFINE_UNQUOTED([SETJMP_NAME], ["${SETJMP}"])
+
+# Validate the longjmp symbol
+AX_FC_CHECK_BIND_C([longjmp],
+  [LONGJMP="longjmp"], [LONGJMP="longjmp_missing"]
+)
+AC_DEFINE_UNQUOTED([LONGJMP_NAME], ["${LONGJMP}"])
 
 # Determine the sigsetjmp symbol.  If missing, then point to sigsetjmp_missing.
 #
@@ -262,6 +274,13 @@ for sigsetjmp_fn in sigsetjmp __sigsetjmp; do
   ])
 done
 AC_DEFINE_UNQUOTED([SIGSETJMP_NAME], ["${SIGSETJMP}"])
+
+# Validate the siglongjmp symbol
+AX_FC_CHECK_BIND_C([siglongjmp],
+  [SIGLONGJMP="siglongjmp"], [SETJMP="siglongjmp_missing"]
+)
+AC_DEFINE_UNQUOTED([SIGLONGJMP_NAME], ["${SIGLONGJMP}"])
+
 
 # Verify the size of nonlocal jump buffer structs
 # NOTE: This requires C compiler, but can it be done with a Fortran compiler?

--- a/src/framework/posix.h
+++ b/src/framework/posix.h
@@ -12,12 +12,24 @@
 #define SIZEOF_SIGJMP_BUF SIZEOF_JMP_BUF
 #endif
 
-! glibc defines sigsetjmp as __sigsetjmp via macro readable from <setjmp.h>.
+! Wrappers to <setjmp.h> are disabled on default.
+#ifndef SETJMP_NAME
+#define SETJMP_NAME "setjmp_missing"
+#endif
+
+#ifndef LONGJMP_NAME
+#define LONGJMP_NAME "longjmp_missing"
+#endif
+
 #ifndef SIGSETJMP_NAME
 #define SIGSETJMP_NAME "sigsetjmp_missing"
 #endif
 
-! This should be defined by /usr/include/signal.h
+#ifndef SIGLONGJMP_NAME
+#define SIGLONGJMP_NAME "siglongjmp_missing"
+#endif
+
+! This should be defined by <signal.h>;
 ! If unset, we use the most common (x86) value
 #ifndef POSIX_SIGUSR1
 #define POSIX_SIGUSR1 10


### PR DESCRIPTION
This patch extends the generic wrappers of sigsetjmp to all of the *jmp wrapper functions in <setjmp.h>

The C standard allows these to be defined as macros, rather than explicit functions, which cannot be referenced by Fortran C bindings, so we cannot assume that these functions exist, even when using a compliant libc.

As with sigsetjmp, these functions are now disabled on default, and raise a runtime error if called by the program.  Realistically, they will only be defined by an autoconf-configured build.

This is required for older Linux distributions where libc does not define longjmp.