### PR TITLE
Autoconf: External FMS build configuration 

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -331,32 +331,23 @@ FMS_ENV = \
   FCFLAGS="$(FCFLAGS_FMS)" \
   REPORT_ERROR_LOGS="$(REPORT_ERROR_LOGS)"
 
-deps/lib/libFMS.a: deps/fms/build/libFMS.a
-	$(MAKE) -C deps lib/libFMS.a
+deps/lib/libFMS.a: deps/Makefile deps/Makefile.fms.in deps/configure.fms.ac deps/m4
+	$(FMS_ENV) $(MAKE) -C deps lib/libFMS.a
 
-deps/fms/build/libFMS.a: deps/fms/build/Makefile
-	$(MAKE) -C deps fms/build/libFMS.a
+deps/Makefile: ../ac/deps/Makefile | deps
+	cp ../ac/deps/Makefile deps/Makefile
 
-deps/fms/build/Makefile: deps/fms/src/configure deps/Makefile.fms.in
-	$(FMS_ENV) $(MAKE) -C deps fms/build/Makefile
+deps/Makefile.fms.in: ../ac/deps/Makefile.fms.in | deps
+	cp ../ac/deps/Makefile.fms.in deps/Makefile.fms.in
 
-deps/Makefile.fms.in: ../ac/deps/Makefile.fms.in deps/Makefile
-	cp $< deps
+deps/configure.fms.ac: ../ac/deps/configure.fms.ac | deps
+	cp ../ac/deps/configure.fms.ac deps/configure.fms.ac
 
-# TODO: m4 dependencies?
-deps/fms/src/configure: ../ac/deps/configure.fms.ac deps/Makefile $(FMS_SOURCE) | deps/fms/src
-	cp ../ac/deps/configure.fms.ac deps
-	cp -r ../ac/deps/m4 deps
-	$(MAKE) -C deps fms/src/configure
+deps/m4: ../ac/deps/m4 | deps
+	cp -r ../ac/deps/m4 deps/
 
-deps/fms/src: deps/Makefile
-	make -C deps fms/src
-
-# Dependency init
-deps/Makefile: ../ac/deps/Makefile
-	mkdir -p $(@D)
-	cp $< $@
-
+deps:
+	mkdir -p deps
 
 #---
 # The following block does a non-library build of a coupled driver interface to

--- a/ac/deps/Makefile
+++ b/ac/deps/Makefile
@@ -41,33 +41,36 @@ lib/libFMS.a: fms/build/libFMS.a
 	cp fms/build/libFMS.a lib/libFMS.a
 	cp fms/build/*.mod include
 
-
 fms/build/libFMS.a: fms/build/Makefile
-	make -C fms/build libFMS.a
+	$(MAKE) -C fms/build libFMS.a
 
-
-fms/build/Makefile: Makefile.fms.in fms/src/configure
-	mkdir -p fms/build
-	cp Makefile.fms.in fms/src/Makefile.in
+fms/build/Makefile: fms/build/Makefile.in fms/build/configure
 	cd $(@D) && { \
-	  ../src/configure --srcdir=../src \
+	  ./configure --srcdir=../src \
 	  || { \
 	    if [ "${REPORT_ERROR_LOGS}" = true ]; then cat config.log ; fi ; \
 	    false; \
 	  } \
 	}
 
+fms/build/Makefile.in: Makefile.fms.in | fms/build
+	cp Makefile.fms.in fms/build/Makefile.in
 
-fms/src/configure: configure.fms.ac $(FMS_SOURCE) | fms/src
-	cp configure.fms.ac fms/src/configure.ac
-	cp -r m4 $(@D)
-	cd $(@D) && autoreconf -i
+fms/build/configure: fms/build/configure.ac $(FMS_SOURCE) | fms/src
+	autoreconf fms/build
 
+fms/build/configure.ac: configure.fms.ac m4 | fms/build
+	cp configure.fms.ac fms/build/configure.ac
+	cp -r m4 fms/build
+
+fms/build:
+	mkdir -p fms/build
 
 fms/src:
 	git clone $(FMS_URL) $@
 	git -C $@ checkout $(FMS_COMMIT)
 
+# Cleanup
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This patch modifies the `ac/deps` Makefile used to build the FMS depedency.  The autoconf compilation is now done entirely outside of the `ac/deps/fms/src` directory.  This keeps the FMS checkout unchanged and allows us to better track any development changes in that library during development.

The .testing/Makefile was also modified to use existing rules in deps/Makefile rather than duplicating them.