### PR TITLE
Autoconf: Explicit MOM_memory.h configuration

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -246,7 +246,8 @@ COV_LDFLAGS := LDFLAGS="$(LDFLAGS_COVERAGE) $(LDFLAGS_DEPS) $(LDFLAGS_USER)"
 
 # Environment variable configuration
 build/symmetric/Makefile: MOM_ENV=$(PATH_FMS) $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
-build/asymmetric/Makefile: MOM_ENV=$(PATH_FMS) $(ASYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
+build/asymmetric/Makefile: MOM_ENV=$(PATH_FMS) $(ASYMMETRIC_FCFLAGS) $(MOM_LDFLAGS) \
+  MOM_MEMORY=../../../config_src/memory/dynamic_nonsymmetric/MOM_memory.h
 build/repro/Makefile: MOM_ENV=$(PATH_FMS) $(REPRO_FCFLAGS) $(MOM_LDFLAGS)
 build/openmp/Makefile: MOM_ENV=$(PATH_FMS) $(OPENMP_FCFLAGS) $(MOM_LDFLAGS)
 build/target/Makefile: MOM_ENV=$(PATH_FMS) $(TARGET_FCFLAGS) $(MOM_LDFLAGS)
@@ -260,7 +261,7 @@ build/unit/Makefile: MOM_ENV=$(PATH_FMS) $(COV_FCFLAGS) $(COV_LDFLAGS)
 
 # Configure script flags
 build/symmetric/Makefile: MOM_ACFLAGS=
-build/asymmetric/Makefile: MOM_ACFLAGS=--enable-asymmetric
+build/asymmetric/Makefile: MOM_ACFLAGS=
 build/repro/Makefile: MOM_ACFLAGS=
 build/openmp/Makefile: MOM_ACFLAGS=--enable-openmp
 build/target/Makefile: MOM_ACFLAGS=

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -39,14 +39,30 @@ AC_CONFIG_MACRO_DIR([m4])
 srcdir=$srcdir/..
 
 
-# Default to symmetric grid
-# NOTE: --enable is more properly used to add a feature, rather than to select
-#   a compile-time mode, so this is not exactly being used as intended.
-MEM_LAYOUT=${srcdir}/config_src/memory/dynamic_symmetric
-AC_ARG_ENABLE([asymmetric],
-  AS_HELP_STRING([--enable-asymmetric], [Use the asymmetric grid]))
-AS_IF([test "$enable_asymmetric" = yes],
-  [MEM_LAYOUT=${srcdir}/config_src/memory/dynamic_nonsymmetric])
+# Configure the memory layout header
+
+AC_ARG_VAR([MOM_MEMORY],
+  [Path to MOM_memory.h header, describing the field memory layout: dynamic
+   symmetric (default), dynamic asymmetric, or static.]
+)
+
+AS_VAR_IF([MOM_MEMORY], [],
+  [MOM_MEMORY=${srcdir}/config_src/memory/dynamic_symmetric/MOM_memory.h]
+)
+
+# Confirm that MOM_MEMORY is named 'MOM_memory.h'
+AS_IF([test $(basename "${MOM_MEMORY}") == "MOM_memory.h"], [],
+ [AC_MSG_ERROR([MOM_MEMORY header ${MOM_MEMORY} must be named 'MOM_memory.h'])]
+)
+
+# Confirm that the file exists
+AC_CHECK_FILE(["$MOM_MEMORY"], [],
+  [AC_MSG_ERROR([MOM_MEMORY header ${MOM_MEMORY} not found.])]
+)
+
+MOM_MEMORY_DIR=$(AS_DIRNAME(["${MOM_MEMORY}"]))
+AC_SUBST([MOM_MEMORY_DIR])
+
 
 # Default to solo_driver
 DRIVER_DIR=${srcdir}/config_src/drivers/solo_driver
@@ -234,8 +250,12 @@ AC_SUBST([MAKEDEP])
 
 
 # Generate source list and configure dependency command
-AC_SUBST([SRC_DIRS],
-    ["${srcdir}/src ${MODEL_FRAMEWORK} ${srcdir}/config_src/external ${DRIVER_DIR} ${MEM_LAYOUT}"]
+AC_SUBST([SRC_DIRS], ["\\
+  ${srcdir}/src \\
+  ${MODEL_FRAMEWORK} \\
+  ${srcdir}/config_src/external \\
+  ${DRIVER_DIR} \\
+  ${MOM_MEMORY_DIR}"]
 )
 AC_CONFIG_COMMANDS(Makefile.dep, [make depend])
 


### PR DESCRIPTION
MOM6 requires an explicit MOM_memory.h header to define its numerical field memory layout.  Previously, autoconf provided a flag to configure this with `--enable-*`, but was prone to two issues:

* The binary choice of symmetric/nonsymmetric prevented use of static headers.

* It was an incorrect use of `--enable-*`, which is intended to enable additional internal features; it is not used to select a mode.

To address these issues, we drop the flag and replace it with an AC_ARG_VAR variable, MOM_MEMORY, which is a path to the file.  This variable will default to dynamic symmetric mode,

    config_src/memory/dynamic_symmetric/MOM_memory.h

so there should be no change for existing users.

To the best of my knowledge, no one used the `--enable-*` flag, nor was it used in any automated systems (outside of .testing), so there should be no issue with dropping it.

.testing/Makefile was updated to use MOM_MEMORY.