### PR TITLE
+Add thickness_to_dz, calc_derived_thermo and avg_specific_vol

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -91,7 +91,7 @@ use MOM_grid,                  only : ocean_grid_type, MOM_grid_init, MOM_grid_e
 use MOM_grid,                  only : set_first_direction, rescale_grid_bathymetry
 use MOM_hor_index,             only : hor_index_type, hor_index_init
 use MOM_hor_index,             only : rotate_hor_index
-use MOM_interface_heights,     only : find_eta
+use MOM_interface_heights,     only : find_eta, calc_derived_thermo
 use MOM_interface_filter,      only : interface_filter, interface_filter_init, interface_filter_end
 use MOM_interface_filter,      only : interface_filter_CS
 use MOM_lateral_mixing_coeffs, only : calc_slope_functions, VarMix_init, VarMix_end
@@ -1400,6 +1400,12 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
       call create_group_pass(pass_T_S, CS%tv%T, G%Domain, To_All+Omit_Corners, halo=1)
       call create_group_pass(pass_T_S, CS%tv%S, G%Domain, To_All+Omit_Corners, halo=1)
       call do_group_pass(pass_T_S, G%Domain, clock=id_clock_pass)
+      halo_sz = 1
+    endif
+
+    ! Update derived thermodynamic quantities.
+    if (allocated(CS%tv%SpV_avg)) then
+      call calc_derived_thermo(CS%tv, h, G, GV, US, halo=halo_sz)
     endif
   endif
 
@@ -1581,6 +1587,11 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     call create_group_pass(pass_uv_T_S_h, h, G%Domain, halo=dynamics_stencil)
     call do_group_pass(pass_uv_T_S_h, G%Domain, clock=id_clock_pass)
 
+    ! Update derived thermodynamic quantities.
+    if (allocated(tv%SpV_avg)) then
+      call calc_derived_thermo(tv, h, G, GV, US, halo=dynamics_stencil)
+    endif
+
     if (CS%debug .and. CS%use_ALE_algorithm) then
       call MOM_state_chksum("Post-ALE ", u, v, h, CS%uh, CS%vh, G, GV, US)
       call hchksum(tv%T, "Post-ALE T", G%HI, haloshift=1, scale=US%C_to_degC)
@@ -1623,12 +1634,18 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
     call cpu_clock_end(id_clock_adiabatic)
 
     if (associated(tv%T)) then
-      call create_group_pass(pass_T_S, tv%T, G%Domain, To_All+Omit_Corners, halo=1)
-      call create_group_pass(pass_T_S, tv%S, G%Domain, To_All+Omit_Corners, halo=1)
+      dynamics_stencil = min(3, G%Domain%nihalo, G%Domain%njhalo)
+      call create_group_pass(pass_T_S, tv%T, G%Domain, To_All+Omit_Corners, halo=dynamics_stencil)
+      call create_group_pass(pass_T_S, tv%S, G%Domain, To_All+Omit_Corners, halo=dynamics_stencil)
       call do_group_pass(pass_T_S, G%Domain, clock=id_clock_pass)
       if (CS%debug) then
         if (associated(tv%T)) call hchksum(tv%T, "Post-diabatic T", G%HI, haloshift=1, scale=US%C_to_degC)
         if (associated(tv%S)) call hchksum(tv%S, "Post-diabatic S", G%HI, haloshift=1, scale=US%S_to_ppt)
+      endif
+
+      ! Update derived thermodynamic quantities.
+      if (allocated(tv%SpV_avg)) then
+        call calc_derived_thermo(tv, h, G, GV, US, halo=dynamics_stencil)
       endif
     endif
 
@@ -1676,6 +1693,8 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
 
   type(time_type), pointer :: accumulated_time => NULL()
   type(time_type), pointer :: vertical_time => NULL()
+  integer :: dynamics_stencil  ! The computational stencil for the calculations
+                               ! in the dynamic core.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
 
   ! 3D pointers
@@ -1847,6 +1866,12 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
   call pass_var(CS%h, G%Domain)
 
   fluxes%fluxes_used = .true.
+
+  ! Update derived thermodynamic quantities.
+  if (allocated(CS%tv%SpV_avg)) then
+    dynamics_stencil = min(3, G%Domain%nihalo, G%Domain%njhalo)
+    call calc_derived_thermo(CS%tv, CS%h, G, GV, US, halo=dynamics_stencil)
+  endif
 
   if (last_iter) then
     accumulated_time = real_to_time(0.0)
@@ -2817,6 +2842,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     endif
   endif
 
+  ! Allocate any derived equation of state fields.
+  if (use_temperature .and. .not.(GV%Boussinesq .or. GV%semi_Boussinesq)) then
+    allocate(CS%tv%SpV_avg(isd:ied,jsd:jed,nz), source=0.0)
+  endif
+
   if (use_ice_shelf .and. CS%debug) then
     call hchksum(CS%frac_shelf_h, "MOM:frac_shelf_h", G%HI, haloshift=0)
     call hchksum(CS%mass_shelf, "MOM:mass_shelf", G%HI, haloshift=0,scale=US%RZ_to_kg_m2)
@@ -3102,6 +3132,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   call create_group_pass(pass_uv_T_S_h, CS%h, G%Domain, halo=dynamics_stencil)
 
   call do_group_pass(pass_uv_T_S_h, G%Domain)
+
+  ! Update derived thermodynamic quantities.
+  if (allocated(CS%tv%SpV_avg)) then
+    call calc_derived_thermo(CS%tv, CS%h, G, GV, US, halo=dynamics_stencil)
+  endif
 
   if (associated(CS%visc%Kv_shear)) &
     call pass_var(CS%visc%Kv_shear, G%Domain, To_All+Omit_Corners, halo=1)
@@ -3931,6 +3966,7 @@ subroutine MOM_end(CS)
   if (associated(CS%Hml)) deallocate(CS%Hml)
   if (associated(CS%tv%salt_deficit)) deallocate(CS%tv%salt_deficit)
   if (associated(CS%tv%frazil)) deallocate(CS%tv%frazil)
+  if (allocated(CS%tv%SpV_avg)) deallocate(CS%tv%SpV_avg)
 
   if (associated(CS%tv%T)) then
     DEALLOC_(CS%T) ; CS%tv%T => NULL() ; DEALLOC_(CS%S) ; CS%tv%S => NULL()

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -93,6 +93,9 @@ type, public :: thermo_var_ptrs
   logical :: S_is_absS = .false. !< If true, the salinity variable tv%S is
                          !! actually the absolute salinity in units of [gSalt kg-1].
   real :: min_salinity   !< The minimum value of salinity when BOUND_SALINITY=True [S ~> ppt].
+  real, allocatable, dimension(:,:,:) :: SpV_avg
+                         !< The layer averaged in situ specific volume [R-1 ~> m3 kg-1].
+
   ! These arrays are accumulated fluxes for communication with other components.
   real, dimension(:,:), pointer :: frazil => NULL()
                          !< The energy needed to heat the ocean column to the

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -10,7 +10,7 @@ implicit none ; private
 public calculate_compress_wright, calculate_density_wright, calculate_spec_vol_wright
 public calculate_density_derivs_wright, calculate_specvol_derivs_wright
 public calculate_density_second_derivs_wright, calc_density_second_derivs_wright_buggy
-public EoS_fit_range_Wright
+public EoS_fit_range_Wright, avg_spec_vol_Wright
 public int_density_dz_wright, int_spec_vol_dp_wright
 
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
@@ -547,6 +547,42 @@ subroutine calculate_compress_wright(T, S, pressure, rho, drho_dp, start, npts)
   enddo
 end subroutine calculate_compress_wright
 
+!> Calculates analytical and nearly-analytical integrals, in pressure across layers, to determine
+!! the layer-average specific volumes.  There are essentially no free assumptions, apart from a
+!! truncation in the series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
+subroutine avg_spec_vol_Wright(T, S, p_t, dp, SpV_avg, start, npts)
+  real, dimension(:), intent(in)    :: T         !< Potential temperature relative to the surface
+                                                 !! [degC].
+  real, dimension(:), intent(in)    :: S         !< Salinity [PSU].
+  real, dimension(:), intent(in)    :: p_t       !< Pressure at the top of the layer [Pa]
+  real, dimension(:), intent(in)    :: dp        !< Pressure change in the layer [Pa]
+  real, dimension(:), intent(inout) :: SpV_avg   !< The vertical average specific volume
+                                                 !! in the layer [m3 kg-1]
+  integer,            intent(in)    :: start     !< the starting point in the arrays.
+  integer,            intent(in)    :: npts      !< the number of values to calculate.
+
+  ! Local variables
+  real :: al0        ! A term in the Wright EOS [m3 kg-1]
+  real :: p0         ! A term in the Wright EOS [Pa]
+  real :: lambda     ! A term in the Wright EOS [m2 s-2]
+  real :: eps2       ! The square of a nondimensional ratio [nondim]
+  real :: I_pterm    ! The inverse of p0 plus p_ave [Pa-1].
+  real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0, C1_9 = 1.0/9.0 ! Rational constants [nondim]
+  integer :: j
+
+  !  alpha(j) = al0 + lambda / (pressure(j) + p0)
+  do j=start,start+npts-1
+    al0 = a0 + (a1*T(j) + a2*S(j))
+    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
+    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+
+    I_pterm = 1.0 / (p0 + (p_t(j) + 0.5*dp(j)))
+    eps2 = (0.5 * dp(j) * I_pterm)**2
+    SpV_avg(j) = al0 + (lambda * I_pterm) * &
+                         (1.0 + eps2*(C1_3 + eps2*(0.2 + eps2*(C1_7 + eps2*C1_9))))
+  enddo
+end subroutine avg_spec_vol_Wright
+
 !> Return the range of temperatures, salinities and pressures for which the reduced-range equation
 !! of state from Wright (1997) has been fitted to observations.  Care should be taken when applying
 !! this equation of state outside of its fit range.
@@ -1065,6 +1101,7 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
                            12.0*intp(3))
   enddo ; enddo ; endif
 end subroutine int_spec_vol_dp_wright
+
 
 !> \namespace mom_eos_wright
 !!

--- a/src/equation_of_state/MOM_EOS_Wright_full.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_full.F90
@@ -11,6 +11,7 @@ public calculate_compress_wright_full, calculate_density_wright_full, calculate_
 public calculate_density_derivs_wright_full, calculate_specvol_derivs_wright_full
 public calculate_density_second_derivs_wright_full, EoS_fit_range_Wright_full
 public int_density_dz_wright_full, int_spec_vol_dp_wright_full
+public avg_spec_vol_Wright_full
 
 !> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
 !! a reference density, from salinity in practical salinity units ([PSU]), potential
@@ -449,6 +450,42 @@ subroutine calculate_compress_wright_full(T, S, pressure, rho, drho_dp, start, n
     drho_dp(j) = lambda * I_denom**2
   enddo
 end subroutine calculate_compress_wright_full
+
+!> Calculates analytical and nearly-analytical integrals, in pressure across layers, to determine
+!! the layer-average specific volumes.  There are essentially no free assumptions, apart from a
+!! truncation in the series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
+subroutine avg_spec_vol_Wright_full(T, S, p_t, dp, SpV_avg, start, npts)
+  real, dimension(:), intent(in)    :: T         !< Potential temperature relative to the surface
+                                                 !! [degC].
+  real, dimension(:), intent(in)    :: S         !< Salinity [PSU].
+  real, dimension(:), intent(in)    :: p_t       !< Pressure at the top of the layer [Pa]
+  real, dimension(:), intent(in)    :: dp        !< Pressure change in the layer [Pa]
+  real, dimension(:), intent(inout) :: SpV_avg   !< The vertical average specific volume
+                                                 !! in the layer [m3 kg-1]
+  integer,            intent(in)    :: start     !< the starting point in the arrays.
+  integer,            intent(in)    :: npts      !< the number of values to calculate.
+
+  ! Local variables
+  real :: al0        ! A term in the Wright EOS [m3 kg-1]
+  real :: p0         ! A term in the Wright EOS [Pa]
+  real :: lambda     ! A term in the Wright EOS [m2 s-2]
+  real :: eps2       ! The square of a nondimensional ratio [nondim]
+  real :: I_pterm    ! The inverse of p0 plus p_ave [Pa-1].
+  real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0, C1_9 = 1.0/9.0 ! Rational constants [nondim]
+  integer :: j
+
+  !  alpha(j) = al0 + lambda / (pressure(j) + p0)
+  do j=start,start+npts-1
+    al0 = a0 + (a1*T(j) + a2*S(j))
+    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
+    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+
+    I_pterm = 1.0 / (p0 + (p_t(j) + 0.5*dp(j)))
+    eps2 = (0.5 * dp(j) * I_pterm)**2
+    SpV_avg(j) = al0 + (lambda * I_pterm) * &
+                         (1.0 + eps2*(C1_3 + eps2*(0.2 + eps2*(C1_7 + eps2*C1_9))))
+  enddo
+end subroutine avg_spec_vol_Wright_full
 
 !> Return the range of temperatures, salinities and pressures for which full-range equation
 !! of state from Wright (1997) has been fitted to observations.  Care should be taken when applying
@@ -971,6 +1008,7 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
                            12.0*intp(3))
   enddo ; enddo ; endif
 end subroutine int_spec_vol_dp_wright_full
+
 
 !> \namespace mom_eos_wright_full
 !!


### PR DESCRIPTION
  This PR includes a pair of commits that add code to calculate the layer averaged specific volumes, either using analytical expressions or quadrature, and the new routines `thickness_to_dz` and `calc_derived_thermo` to make use of this to convert layer thicknesses to vertical distances in all cases.  There is new unit testing of the layer averaged specific volumes included in this PR.  The `thickness_to_dz` calls have been extensively tested (and appear to be correct) in much more extensive changes on a separate branch that will be in coming PRs, but they are not yet being exercised with this commit.   The new public interfaces include `avg_specific_vol`, `average_specific_vol`, `avg_spec_vol_Wright`, `avg_spec_vol_Wright_full`, `avg_spec_vol_Wright_red`, `avg_spec_vol_linear`, `thickness_to_dz` and `calc_derived_thermo`, and there is a new array (`tv%SpV_avg`) in the transparent `thermo_vars_ptr` type.

  All answers are bitwise identical, but there are new publicly visible interfaces.  The commits in this PR include:

- NOAA-GFDL/MOM6@f4ed37d57 +Add thickness_to_dz and calc_derived_thermo
- NOAA-GFDL/MOM6@24fb992d6 +Code to calculate layer averaged specific volumes
