### PR TITLE
Autoconf: Fix Python test and allow configuration

### DIFF
--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -220,15 +220,21 @@ AC_COMPILE_IFELSE(
   ]
 )
 
+# Python interpreter test
 
-# Verify that Python is available
-AC_PATH_PROGS([PYTHON], [python python3 python2], [
-  AC_MSG_ERROR([Could not find python.])
-])
 AC_ARG_VAR([PYTHON], [Python interpreter command])
 
+AS_VAR_SET_IF([PYTHON], [
+  AC_PATH_PROGS([PYTHON], ["$PYTHON"], [none])
+], [
+  AC_PATH_PROGS([PYTHON], [python python3 python2], [none])
+])
+AS_VAR_IF([PYTHON], [none], [
+  AC_MSG_ERROR([Python interpreter not found.])
+])
 
-# Verify that makedep is available
+
+# Makedep test
 AC_PATH_PROG([MAKEDEP], [makedep], [${srcdir}/ac/makedep])
 AC_SUBST([MAKEDEP])
 


### PR DESCRIPTION
The AC_PATH_PROGS macros used in Python testing were incorrectly using AC_MSG_ERROR in places where a missing value for PYTHON should be if the executable was not found.

It also did not permit for a configurable PYTHON variable, since the autodetect was always run, even if PYTHON were set.

This has been updated so that Python autodetection only runs if PYTHON is unset.  It also correctly reports a failed configuration if PYTHON is not found.

(It does not, however, test of PYTHON is actually a Python interpreter, but we can deal with that at a later date.)