### PR TITLE
FMS2: Replace time_interp_external IDs with a MOM-defined type

### DIFF
--- a/config_src/drivers/mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/mct_cap/mom_surface_forcing_mct.F90
@@ -25,6 +25,7 @@ use MOM_get_input,        only : Get_MOM_Input, directories
 use MOM_grid,             only : ocean_grid_type
 use MOM_interpolate,      only : init_external_field, time_interp_external
 use MOM_interpolate,      only : time_interp_external_init
+use MOM_interpolate,      only : external_field
 use MOM_io,               only : slasher, write_version_number, MOM_read_data
 use MOM_io,               only : stdout
 use MOM_restart,          only : register_restart_field, restart_init, MOM_restart_CS
@@ -134,8 +135,10 @@ type, public :: surface_forcing_CS ; private
                                                     !! in inputdir/temp_restore_mask.nc and the field should
                                                     !! be named 'mask'
   real, pointer, dimension(:,:) :: trestore_mask => NULL() !< mask for SST restoring
-  integer :: id_srestore = -1     !< id number for time_interp_external.
-  integer :: id_trestore = -1     !< id number for time_interp_external.
+  type(external_field) :: srestore_handle
+    !< Handle for time-interpolated salt restoration field
+  type(external_field) :: trestore_handle
+    !< Handle for time-interpolated temperature restoration field
 
   type(forcing_diags), public :: handles !< diagnostics handles
   type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< restart pointer
@@ -348,7 +351,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! Salinity restoring logic
   if (restore_salinity) then
-    call time_interp_external(CS%id_srestore, Time, data_restore, scale=US%ppt_to_S)
+    call time_interp_external(CS%srestore_handle, Time, data_restore, scale=US%ppt_to_S)
     ! open_ocn_mask indicates where to restore salinity (1 means restore, 0 does not)
     open_ocn_mask(:,:) = 1.0
     if (CS%mask_srestore_under_ice) then ! Do not restore under sea-ice
@@ -405,7 +408,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! SST restoring logic
   if (restore_sst) then
-    call time_interp_external(CS%id_trestore, Time, data_restore, scale=US%degC_to_C)
+    call time_interp_external(CS%trestore_handle, Time, data_restore, scale=US%degC_to_C)
     do j=js,je ; do i=is,ie
       delta_sst = data_restore(i,j) - sfc_state%SST(i,j)
       delta_sst = sign(1.0,delta_sst)*min(abs(delta_sst),CS%max_delta_trestore)
@@ -1292,7 +1295,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 
   if (present(restore_salt)) then ; if (restore_salt) then
     salt_file = trim(CS%inputdir) // trim(CS%salt_restore_file)
-    CS%id_srestore = init_external_field(salt_file, CS%salt_restore_var_name, domain=G%Domain%mpp_domain)
+    CS%srestore_handle = init_external_field(salt_file, CS%salt_restore_var_name, domain=G%Domain%mpp_domain)
     call safe_alloc_ptr(CS%srestore_mask,isd,ied,jsd,jed); CS%srestore_mask(:,:) = 1.0
     if (CS%mask_srestore) then ! read a 2-d file containing a mask for restoring fluxes
       flnam = trim(CS%inputdir) // 'salt_restore_mask.nc'
@@ -1302,7 +1305,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 
   if (present(restore_temp)) then ; if (restore_temp) then
     temp_file = trim(CS%inputdir) // trim(CS%temp_restore_file)
-    CS%id_trestore = init_external_field(temp_file, CS%temp_restore_var_name, domain=G%Domain%mpp_domain)
+    CS%trestore_handle = init_external_field(temp_file, CS%temp_restore_var_name, domain=G%Domain%mpp_domain)
     call safe_alloc_ptr(CS%trestore_mask,isd,ied,jsd,jed); CS%trestore_mask(:,:) = 1.0
     if (CS%mask_trestore) then  ! read a 2-d file containing a mask for restoring fluxes
       flnam = trim(CS%inputdir) // 'temp_restore_mask.nc'

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -26,6 +26,7 @@ use MOM_get_input,        only : Get_MOM_Input, directories
 use MOM_grid,             only : ocean_grid_type
 use MOM_interpolate,      only : init_external_field, time_interp_external
 use MOM_interpolate,      only : time_interp_external_init
+use MOM_interpolate,      only : external_field
 use MOM_CFC_cap,          only : CFC_cap_fluxes
 use MOM_io,               only : slasher, write_version_number, MOM_read_data
 use MOM_io,               only : stdout
@@ -146,10 +147,14 @@ type, public :: surface_forcing_CS ; private
   character(len=30)        :: cfc11_var_name        !< name of cfc11 in CFC_BC_file
   character(len=30)        :: cfc12_var_name        !< name of cfc11 in CFC_BC_file
   real, pointer, dimension(:,:) :: trestore_mask => NULL() !< mask for SST restoring
-  integer :: id_srestore = -1    !< id number for time_interp_external.
-  integer :: id_trestore = -1    !< id number for time_interp_external.
-  integer :: id_cfc11_atm = -1   !< id number for time_interp_external.
-  integer :: id_cfc12_atm = -1   !< id number for time_interp_external.
+  type(external_field) :: srestore_handle
+    !< Handle for time-interpolated salt restoration field
+  type(external_field) :: trestore_handle
+    !< Handle for time-interpolated temperature restoration field
+  type(external_field) :: cfc11_atm_handle
+    !< Handle for time-interpolated CFC11 restoration field
+  type(external_field) :: cfc12_atm_handle
+    !< Handle for time-interpolated CFC12 restoration field
 
   ! Diagnostics handles
   type(forcing_diags), public :: handles
@@ -377,7 +382,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! Salinity restoring logic
   if (restore_salinity) then
-    call time_interp_external(CS%id_srestore, Time, data_restore, scale=US%ppt_to_S)
+    call time_interp_external(CS%srestore_handle, Time, data_restore, scale=US%ppt_to_S)
     ! open_ocn_mask indicates where to restore salinity (1 means restore, 0 does not)
     open_ocn_mask(:,:) = 1.0
     if (CS%mask_srestore_under_ice) then ! Do not restore under sea-ice
@@ -434,7 +439,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! SST restoring logic
   if (restore_sst) then
-    call time_interp_external(CS%id_trestore, Time, data_restore, scale=US%degC_to_C)
+    call time_interp_external(CS%trestore_handle, Time, data_restore, scale=US%degC_to_C)
     do j=js,je ; do i=is,ie
       delta_sst = data_restore(i,j) - sfc_state%SST(i,j)
       delta_sst = sign(1.0,delta_sst)*min(abs(delta_sst),CS%max_delta_trestore)
@@ -596,7 +601,8 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! CFCs
   if (CS%use_CFC) then
-    call CFC_cap_fluxes(fluxes, sfc_state, G, US, CS%Rho0, Time, CS%id_cfc11_atm, CS%id_cfc11_atm)
+    call CFC_cap_fluxes(fluxes, sfc_state, G, US, CS%Rho0, Time, &
+        CS%cfc11_atm_handle, CS%cfc11_atm_handle)
   endif
 
   if (associated(IOB%salt_flux)) then
@@ -1394,7 +1400,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 
   if (present(restore_salt)) then ; if (restore_salt) then
     salt_file = trim(CS%inputdir) // trim(CS%salt_restore_file)
-    CS%id_srestore = init_external_field(salt_file, CS%salt_restore_var_name, domain=G%Domain%mpp_domain)
+    CS%srestore_handle = init_external_field(salt_file, CS%salt_restore_var_name, domain=G%Domain%mpp_domain)
     call safe_alloc_ptr(CS%srestore_mask,isd,ied,jsd,jed); CS%srestore_mask(:,:) = 1.0
     if (CS%mask_srestore) then ! read a 2-d file containing a mask for restoring fluxes
       flnam = trim(CS%inputdir) // 'salt_restore_mask.nc'
@@ -1404,7 +1410,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 
   if (present(restore_temp)) then ; if (restore_temp) then
     temp_file = trim(CS%inputdir) // trim(CS%temp_restore_file)
-    CS%id_trestore = init_external_field(temp_file, CS%temp_restore_var_name, domain=G%Domain%mpp_domain)
+    CS%trestore_handle = init_external_field(temp_file, CS%temp_restore_var_name, domain=G%Domain%mpp_domain)
     call safe_alloc_ptr(CS%trestore_mask,isd,ied,jsd,jed); CS%trestore_mask(:,:) = 1.0
     if (CS%mask_trestore) then  ! read a 2-d file containing a mask for restoring fluxes
       flnam = trim(CS%inputdir) // 'temp_restore_mask.nc'
@@ -1430,8 +1436,8 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                    "The name of the variable representing CFC-12 in  "//&
                    "CFC_BC_FILE.", default="CFC_12", do_not_log=.true.)
 
-      CS%id_cfc11_atm = init_external_field(CS%CFC_BC_file, CS%cfc11_var_name, domain=G%Domain%mpp_domain)
-      CS%id_cfc12_atm = init_external_field(CS%CFC_BC_file, CS%cfc12_var_name, domain=G%Domain%mpp_domain)
+      CS%cfc11_atm_handle = init_external_field(CS%CFC_BC_file, CS%cfc11_var_name, domain=G%Domain%mpp_domain)
+      CS%cfc12_atm_handle = init_external_field(CS%CFC_BC_file, CS%cfc12_var_name, domain=G%Domain%mpp_domain)
     endif
   endif
 

--- a/config_src/infra/FMS1/MOM_interp_infra.F90
+++ b/config_src/infra/FMS1/MOM_interp_infra.F90
@@ -18,6 +18,18 @@ public :: horiz_interp_type, horizontal_interp_init
 public :: time_interp_extern, init_extern_field, time_interp_extern_init
 public :: get_external_field_info, axistype, get_axis_data
 public :: run_horiz_interp, build_horiz_interp_weights
+public :: external_field
+
+!< Handle of an external field for interpolation
+type :: external_field
+  private
+  integer :: id
+    !< FMS ID for the interpolated field
+  character(len=:), allocatable :: filename
+    !< Filename containing the field values
+  character(len=:), allocatable :: label
+    !< Field name in the file
+end type external_field
 
 !> Read a field based on model time, and rotate to the model domain.
 interface time_interp_extern
@@ -167,8 +179,8 @@ end function get_extern_field_missing
 
 
 !> Get information about the external fields.
-subroutine get_external_field_info(field_id, size, axes, missing)
-  integer,                                intent(in)    :: field_id !< The integer index of the external
+subroutine get_external_field_info(field, size, axes, missing)
+  type(external_field),                   intent(in)    :: field    !< Handle for time interpolated external
                                                                     !! field returned from a previous
                                                                     !! call to init_external_field()
   integer,        dimension(4), optional, intent(inout) :: size    !< Dimension sizes for the input data
@@ -176,37 +188,35 @@ subroutine get_external_field_info(field_id, size, axes, missing)
   real,                         optional, intent(inout) :: missing !< Missing value for the input data
 
   if (present(size)) then
-    size(1:4) = get_extern_field_size(field_id)
+    size(1:4) = get_extern_field_size(field%id)
   endif
 
   if (present(axes)) then
-    axes(1:4) = get_extern_field_axes(field_id)
+    axes(1:4) = get_extern_field_axes(field%id)
   endif
 
   if (present(missing)) then
-    missing = get_extern_field_missing(field_id)
+    missing = get_extern_field_missing(field%id)
   endif
 
 end subroutine get_external_field_info
 
 
 !> Read a scalar field based on model time.
-subroutine time_interp_extern_0d(field_id, time, data_in, verbose)
-  integer,           intent(in)    :: field_id !< The integer index of the external field returned
-                                               !! from a previous call to init_external_field()
+subroutine time_interp_extern_0d(field, time, data_in, verbose)
+  type(external_field), intent(in) :: field    !< Handle for time interpolated field
   type(time_type),   intent(in)    :: time     !< The target time for the data
   real,              intent(inout) :: data_in  !< The interpolated value
   logical, optional, intent(in)    :: verbose  !< If true, write verbose output for debugging
 
-  call time_interp_external(field_id, time, data_in, verbose=verbose)
+  call time_interp_external(field%id, time, data_in, verbose=verbose)
 end subroutine time_interp_extern_0d
 
 
 !> Read a 2d field from an external based on model time, potentially including horizontal
 !! interpolation and rotation of the data
-subroutine time_interp_extern_2d(field_id, time, data_in, interp, verbose, horz_interp, mask_out)
-  integer,              intent(in)    :: field_id !< The integer index of the external field returned
-                                                  !! from a previous call to init_external_field()
+subroutine time_interp_extern_2d(field, time, data_in, interp, verbose, horz_interp, mask_out)
+  type(external_field), intent(in)    :: field    !< Handle for time interpolated field
   type(time_type),      intent(in)    :: time     !< The target time for the data
   real, dimension(:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
   integer,    optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
@@ -216,15 +226,14 @@ subroutine time_interp_extern_2d(field_id, time, data_in, interp, verbose, horz_
   logical, dimension(:,:), &
               optional, intent(out)   :: mask_out !< An array that is true where there is valid data
 
-  call time_interp_external(field_id, time, data_in, interp=interp, verbose=verbose, &
+  call time_interp_external(field%id, time, data_in, interp=interp, verbose=verbose, &
                             horz_interp=horz_interp, mask_out=mask_out)
 end subroutine time_interp_extern_2d
 
 
 !> Read a 3d field based on model time, and rotate to the model grid
-subroutine time_interp_extern_3d(field_id, time, data_in, interp, verbose, horz_interp, mask_out)
-  integer,                intent(in)    :: field_id !< The integer index of the external field returned
-                                                    !! from a previous call to init_external_field()
+subroutine time_interp_extern_3d(field, time, data_in, interp, verbose, horz_interp, mask_out)
+  type(external_field),   intent(in)    :: field    !< Handle for time interpolated field
   type(time_type),        intent(in)    :: time     !< The target time for the data
   real, dimension(:,:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
   integer,      optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
@@ -234,14 +243,15 @@ subroutine time_interp_extern_3d(field_id, time, data_in, interp, verbose, horz_
   logical, dimension(:,:,:), &
                 optional, intent(out)   :: mask_out !< An array that is true where there is valid data
 
-  call time_interp_external(field_id, time, data_in, interp=interp, verbose=verbose, &
+  call time_interp_external(field%id, time, data_in, interp=interp, verbose=verbose, &
                             horz_interp=horz_interp, mask_out=mask_out)
 end subroutine time_interp_extern_3d
 
 
 !> initialize an external field
-integer function init_extern_field(file, fieldname, MOM_domain, domain, verbose, &
-                                   threading, ierr, ignore_axis_atts, correct_leap_year_inconsistency )
+function init_extern_field(file, fieldname, MOM_domain, domain, verbose, &
+    threading, ierr, ignore_axis_atts, correct_leap_year_inconsistency) &
+    result(field)
 
   character(len=*),         intent(in)  :: file  !< The name of the file to read
   character(len=*),         intent(in)  :: fieldname !< The name of the field in the file
@@ -261,17 +271,17 @@ integer function init_extern_field(file, fieldname, MOM_domain, domain, verbose,
                                                  !! is in use, and (2) the modulo time period of the
                                                  !! data is an integer number of years, then map
                                                  !! a model date of Feb 29. onto a common year on Feb. 28.
+  type(external_field) :: field                  !< Handle to external field
 
   if (present(MOM_Domain)) then
-    init_extern_field = init_external_field(file, fieldname, domain=MOM_domain%mpp_domain, &
+    field%id = init_external_field(file, fieldname, domain=MOM_domain%mpp_domain, &
              verbose=verbose, threading=threading, ierr=ierr, ignore_axis_atts=ignore_axis_atts, &
              correct_leap_year_inconsistency=correct_leap_year_inconsistency)
   else
-    init_extern_field = init_external_field(file, fieldname, domain=domain, &
+    field%id = init_external_field(file, fieldname, domain=domain, &
              verbose=verbose, threading=threading, ierr=ierr, ignore_axis_atts=ignore_axis_atts, &
              correct_leap_year_inconsistency=correct_leap_year_inconsistency)
   endif
-
 end function init_extern_field
 
 end module MOM_interp_infra

--- a/config_src/infra/FMS2/MOM_interp_infra.F90
+++ b/config_src/infra/FMS2/MOM_interp_infra.F90
@@ -18,6 +18,18 @@ public :: horiz_interp_type, horizontal_interp_init
 public :: time_interp_extern, init_extern_field, time_interp_extern_init
 public :: get_external_field_info, axistype, get_axis_data
 public :: run_horiz_interp, build_horiz_interp_weights
+public :: external_field
+
+!< Handle of an external field for interpolation
+type :: external_field
+  private
+  integer :: id
+    !< FMS ID for the interpolated field
+  character(len=:), allocatable :: filename
+    !< Filename containing the field values
+  character(len=:), allocatable :: label
+    !< Field name in the file
+end type external_field
 
 !> Read a field based on model time, and rotate to the model domain.
 interface time_interp_extern
@@ -166,8 +178,8 @@ end function get_extern_field_missing
 
 
 !> Get information about the external fields.
-subroutine get_external_field_info(field_id, size, axes, missing)
-  integer,                                intent(in)    :: field_id !< The integer index of the external
+subroutine get_external_field_info(field, size, axes, missing)
+  type(external_field),                   intent(in)    :: field    !< Handle for time interpolated external
                                                                     !! field returned from a previous
                                                                     !! call to init_external_field()
   integer,        dimension(4), optional, intent(inout) :: size    !< Dimension sizes for the input data
@@ -175,37 +187,35 @@ subroutine get_external_field_info(field_id, size, axes, missing)
   real,                         optional, intent(inout) :: missing !< Missing value for the input data
 
   if (present(size)) then
-    size(1:4) = get_extern_field_size(field_id)
+    size(1:4) = get_extern_field_size(field%id)
   endif
 
   if (present(axes)) then
-    axes(1:4) = get_extern_field_axes(field_id)
+    axes(1:4) = get_extern_field_axes(field%id)
   endif
 
   if (present(missing)) then
-    missing = get_extern_field_missing(field_id)
+    missing = get_extern_field_missing(field%id)
   endif
 
 end subroutine get_external_field_info
 
 
 !> Read a scalar field based on model time.
-subroutine time_interp_extern_0d(field_id, time, data_in, verbose)
-  integer,           intent(in)    :: field_id !< The integer index of the external field returned
-                                               !! from a previous call to init_external_field()
+subroutine time_interp_extern_0d(field, time, data_in, verbose)
+  type(external_field), intent(in) :: field    !< Handle for time interpolated field
   type(time_type),   intent(in)    :: time     !< The target time for the data
   real,              intent(inout) :: data_in  !< The interpolated value
   logical, optional, intent(in)    :: verbose  !< If true, write verbose output for debugging
 
-  call time_interp_external(field_id, time, data_in, verbose=verbose)
+  call time_interp_external(field%id, time, data_in, verbose=verbose)
 end subroutine time_interp_extern_0d
 
 
 !> Read a 2d field from an external based on model time, potentially including horizontal
 !! interpolation and rotation of the data
-subroutine time_interp_extern_2d(field_id, time, data_in, interp, verbose, horz_interp, mask_out)
-  integer,              intent(in)    :: field_id !< The integer index of the external field returned
-                                                  !! from a previous call to init_external_field()
+subroutine time_interp_extern_2d(field, time, data_in, interp, verbose, horz_interp, mask_out)
+  type(external_field), intent(in)    :: field    !< Handle for time interpolated field
   type(time_type),      intent(in)    :: time     !< The target time for the data
   real, dimension(:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
   integer,    optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
@@ -215,15 +225,14 @@ subroutine time_interp_extern_2d(field_id, time, data_in, interp, verbose, horz_
   logical, dimension(:,:), &
               optional, intent(out)   :: mask_out !< An array that is true where there is valid data
 
-  call time_interp_external(field_id, time, data_in, interp=interp, verbose=verbose, &
+  call time_interp_external(field%id, time, data_in, interp=interp, verbose=verbose, &
                             horz_interp=horz_interp, mask_out=mask_out)
 end subroutine time_interp_extern_2d
 
 
 !> Read a 3d field based on model time, and rotate to the model grid
-subroutine time_interp_extern_3d(field_id, time, data_in, interp, verbose, horz_interp, mask_out)
-  integer,                intent(in)    :: field_id !< The integer index of the external field returned
-                                                    !! from a previous call to init_external_field()
+subroutine time_interp_extern_3d(field, time, data_in, interp, verbose, horz_interp, mask_out)
+  type(external_field),   intent(in)    :: field    !< Handle for time interpolated field
   type(time_type),        intent(in)    :: time     !< The target time for the data
   real, dimension(:,:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
   integer,      optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
@@ -233,14 +242,15 @@ subroutine time_interp_extern_3d(field_id, time, data_in, interp, verbose, horz_
   logical, dimension(:,:,:), &
                 optional, intent(out)   :: mask_out !< An array that is true where there is valid data
 
-  call time_interp_external(field_id, time, data_in, interp=interp, verbose=verbose, &
+  call time_interp_external(field%id, time, data_in, interp=interp, verbose=verbose, &
                             horz_interp=horz_interp, mask_out=mask_out)
 end subroutine time_interp_extern_3d
 
 
 !> initialize an external field
-integer function init_extern_field(file, fieldname, MOM_domain, domain, verbose, &
-                                   threading, ierr, ignore_axis_atts, correct_leap_year_inconsistency )
+function init_extern_field(file, fieldname, MOM_domain, domain, verbose, &
+    threading, ierr, ignore_axis_atts, correct_leap_year_inconsistency) &
+    result(field)
 
   character(len=*),         intent(in)  :: file  !< The name of the file to read
   character(len=*),         intent(in)  :: fieldname !< The name of the field in the file
@@ -260,19 +270,20 @@ integer function init_extern_field(file, fieldname, MOM_domain, domain, verbose,
                                                  !! is in use, and (2) the modulo time period of the
                                                  !! data is an integer number of years, then map
                                                  !! a model date of Feb 29. onto a common year on Feb. 28.
+  type(external_field) :: field                  !< Handle to external field
 
-
+  field%filename = file
+  field%label = fieldname
 
   if (present(MOM_Domain)) then
-    init_extern_field = init_external_field(file, fieldname, domain=MOM_domain%mpp_domain, &
+    field%id = init_external_field(file, fieldname, domain=MOM_domain%mpp_domain, &
              verbose=verbose, threading=threading, ierr=ierr, ignore_axis_atts=ignore_axis_atts, &
              correct_leap_year_inconsistency=correct_leap_year_inconsistency)
   else
-    init_extern_field = init_external_field(file, fieldname, domain=domain, &
+    field%id = init_external_field(file, fieldname, domain=domain, &
              verbose=verbose, threading=threading, ierr=ierr, ignore_axis_atts=ignore_axis_atts, &
              correct_leap_year_inconsistency=correct_leap_year_inconsistency)
   endif
-
 end function init_extern_field
 
 end module MOM_interp_infra

--- a/config_src/infra/FMS2/MOM_interp_infra.F90
+++ b/config_src/infra/FMS2/MOM_interp_infra.F90
@@ -8,10 +8,10 @@ use MOM_io,              only : axis_info
 use MOM_io,              only : get_var_axes_info
 use MOM_time_manager,    only : time_type
 use horiz_interp_mod,    only : horiz_interp_new, horiz_interp, horiz_interp_init, horiz_interp_type
-use time_interp_external_mod, only : time_interp_external
-use time_interp_external_mod, only : init_external_field, time_interp_external_init
-use time_interp_external_mod, only : get_external_field_size
-use time_interp_external_mod, only : get_external_field_axes, get_external_field_missing
+use time_interp_external2_mod, only : time_interp_external
+use time_interp_external2_mod, only : init_external_field, time_interp_external_init
+use time_interp_external2_mod, only : get_external_field_size
+use time_interp_external2_mod, only : get_external_field_missing
 
 implicit none ; private
 
@@ -267,12 +267,14 @@ function init_extern_field(file, fieldname, MOM_domain, domain, verbose, &
 
   if (present(MOM_Domain)) then
     field%id = init_external_field(file, fieldname, domain=MOM_domain%mpp_domain, &
-             verbose=verbose, threading=threading, ierr=ierr, ignore_axis_atts=ignore_axis_atts, &
-             correct_leap_year_inconsistency=correct_leap_year_inconsistency)
+             verbose=verbose, ierr=ierr, ignore_axis_atts=ignore_axis_atts, &
+             correct_leap_year_inconsistency=correct_leap_year_inconsistency, &
+             ongrid=.true.)
   else
     field%id = init_external_field(file, fieldname, domain=domain, &
-             verbose=verbose, threading=threading, ierr=ierr, ignore_axis_atts=ignore_axis_atts, &
-             correct_leap_year_inconsistency=correct_leap_year_inconsistency)
+             verbose=verbose, ierr=ierr, ignore_axis_atts=ignore_axis_atts, &
+             correct_leap_year_inconsistency=correct_leap_year_inconsistency, &
+             ongrid=.true.)
   endif
 end function init_extern_field
 

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -16,7 +16,7 @@ use MOM_grid,          only : ocean_grid_type
 use MOM_interpolate,   only : time_interp_external
 use MOM_interp_infra,  only : run_horiz_interp, build_horiz_interp_weights
 use MOM_interp_infra,  only : horiz_interp_type, horizontal_interp_init
-use MOM_interp_infra,  only : axistype, get_external_field_info, get_axis_data
+use MOM_interp_infra,  only : get_external_field_info
 use MOM_interp_infra,  only : external_field
 use MOM_time_manager,  only : time_type
 use MOM_io,            only : axis_info, get_axis_info, get_var_axes_info, MOM_read_data
@@ -668,7 +668,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
   real :: roundoff  ! The magnitude of roundoff, usually ~2e-16 [nondim]
   logical :: add_np
   type(horiz_interp_type) :: Interp
-  type(axistype), dimension(4) :: axes_data
+  type(axis_info), dimension(4) :: axes_data
   integer :: is, ie, js, je     ! compute domain indices
   integer :: isg, ieg, jsg, jeg ! global extent
   integer :: isd, ied, jsd, jed ! data domain indices
@@ -728,8 +728,8 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
   if (PRESENT(spongeOngrid)) is_ongrid = spongeOngrid
   if (.not. is_ongrid) then
     allocate(lon_in(id), lat_in(jd))
-    call get_axis_data(axes_data(1), lon_in)
-    call get_axis_data(axes_data(2), lat_in)
+    call get_axis_info(axes_data(1), ax_data=lon_in)
+    call get_axis_info(axes_data(2), ax_data=lat_in)
   endif
 
   allocate(z_in(kd), z_edges_in(kd+1))
@@ -737,7 +737,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
   allocate(tr_z(isd:ied,jsd:jed,kd), source=0.0)
   allocate(mask_z(isd:ied,jsd:jed,kd), source=0.0)
 
-  call get_axis_data(axes_data(3), z_in)
+  call get_axis_info(axes_data(3), ax_data=z_in)
 
   if (present(m_to_Z)) then ; do k=1,kd ; z_in(k) = m_to_Z * z_in(k) ; enddo ; endif
 

--- a/src/framework/MOM_interpolate.F90
+++ b/src/framework/MOM_interpolate.F90
@@ -9,12 +9,14 @@ use MOM_interp_infra,    only : time_interp_extern, init_external_field=>init_ex
 use MOM_interp_infra,    only : time_interp_external_init=>time_interp_extern_init
 use MOM_interp_infra,    only : horiz_interp_type, get_external_field_info
 use MOM_interp_infra,    only : run_horiz_interp, build_horiz_interp_weights
+use MOM_interp_infra,    only : external_field
 use MOM_time_manager,    only : time_type
 
 implicit none ; private
 
 public :: time_interp_external, init_external_field, time_interp_external_init, get_external_field_info
 public :: horiz_interp_type, run_horiz_interp, build_horiz_interp_weights
+public :: external_field
 
 !> Read a field based on model time, and rotate to the model domain.
 interface time_interp_external
@@ -26,9 +28,8 @@ end interface time_interp_external
 contains
 
 !> Read a scalar field based on model time.
-subroutine time_interp_external_0d(field_id, time, data_in, verbose, scale)
-  integer,           intent(in)    :: field_id !< The integer index of the external field returned
-                                               !! from a previous call to init_external_field()
+subroutine time_interp_external_0d(field, time, data_in, verbose, scale)
+  type(external_field), intent(in) :: field    !< Handle for time interpolated field
   type(time_type),   intent(in)    :: time     !< The target time for the data
   real,              intent(inout) :: data_in  !< The interpolated value
   logical, optional, intent(in)    :: verbose  !< If true, write verbose output for debugging
@@ -48,7 +49,7 @@ subroutine time_interp_external_0d(field_id, time, data_in, verbose, scale)
     data_in = data_in * I_scale
   endif ; endif
 
-  call time_interp_extern(field_id, time, data_in, verbose=verbose)
+  call time_interp_extern(field, time, data_in, verbose=verbose)
 
   if (present(scale)) then ; if (scale /= 1.0) then
     ! Rescale data that has been newly set and restore the scaling of unset data.
@@ -63,10 +64,9 @@ end subroutine time_interp_external_0d
 
 !> Read a 2d field from an external based on model time, potentially including horizontal
 !! interpolation and rotation of the data
-subroutine time_interp_external_2d(field_id, time, data_in, interp, &
+subroutine time_interp_external_2d(field, time, data_in, interp, &
                                    verbose, horz_interp, mask_out, turns, scale)
-  integer,              intent(in)    :: field_id !< The integer index of the external field returned
-                                                  !! from a previous call to init_external_field()
+  type(external_field), intent(in)    :: field    !< Handle for time interpolated field
   type(time_type),      intent(in)    :: time     !< The target time for the data
   real, dimension(:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
   integer,    optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
@@ -105,11 +105,11 @@ subroutine time_interp_external_2d(field_id, time, data_in, interp, &
   qturns = 0 ; if (present(turns)) qturns = modulo(turns, 4)
 
   if (qturns == 0) then
-    call time_interp_extern(field_id, time, data_in, interp=interp, &
+    call time_interp_extern(field, time, data_in, interp=interp, &
                             verbose=verbose, horz_interp=horz_interp)
   else
     call allocate_rotated_array(data_in, [1,1], -qturns, data_pre_rot)
-    call time_interp_extern(field_id, time, data_pre_rot, interp=interp, &
+    call time_interp_extern(field, time, data_pre_rot, interp=interp, &
                             verbose=verbose, horz_interp=horz_interp)
     call rotate_array(data_pre_rot, turns, data_in)
     deallocate(data_pre_rot)
@@ -136,10 +136,9 @@ end subroutine time_interp_external_2d
 
 
 !> Read a 3d field based on model time, and rotate to the model grid
-subroutine time_interp_external_3d(field_id, time, data_in, interp, &
+subroutine time_interp_external_3d(field, time, data_in, interp, &
                                    verbose, horz_interp, mask_out, turns, scale)
-  integer,                intent(in)    :: field_id !< The integer index of the external field returned
-                                                    !! from a previous call to init_external_field()
+  type(external_field), intent(in)      :: field    !< Handle for time interpolated field
   type(time_type),        intent(in)    :: time     !< The target time for the data
   real, dimension(:,:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
   integer,      optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
@@ -178,11 +177,11 @@ subroutine time_interp_external_3d(field_id, time, data_in, interp, &
   qturns = 0 ; if (present(turns)) qturns = modulo(turns, 4)
 
   if (qturns == 0) then
-    call time_interp_extern(field_id, time, data_in, interp=interp, &
+    call time_interp_extern(field, time, data_in, interp=interp, &
                             verbose=verbose, horz_interp=horz_interp)
   else
     call allocate_rotated_array(data_in, [1,1,1], -qturns, data_pre_rot)
-    call time_interp_extern(field_id, time, data_pre_rot, interp=interp, &
+    call time_interp_extern(field, time, data_pre_rot, interp=interp, &
                             verbose=verbose, horz_interp=horz_interp)
     call rotate_array(data_pre_rot, turns, data_in)
     deallocate(data_pre_rot)

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -61,6 +61,7 @@ use MOM_coms, only : reproducing_sum
 use MOM_spatial_means, only : global_area_integral
 use MOM_checksums, only : hchksum, qchksum, chksum, uchksum, vchksum, uvchksum
 use MOM_interpolate, only : init_external_field, time_interp_external, time_interp_external_init
+use MOM_interpolate, only : external_field
 
 implicit none ; private
 
@@ -196,10 +197,10 @@ type, public :: ice_shelf_CS ; private
              id_shelf_sfc_mass_flux = -1
   !>@}
 
-  integer :: id_read_mass !< An integer handle used in time interpolation of
-                          !! the ice shelf mass read from a file
-  integer :: id_read_area !< An integer handle used in time interpolation of
-                          !! the ice shelf mass read from a file
+  type(external_field) :: mass_handle
+    !< Handle for reading the time interpolated ice shelf mass from a file
+  type(external_field) :: area_handle
+    !< Handle for reading the time interpolated ice shelf area from a file
 
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to control diagnostic output.
   type(user_ice_shelf_CS), pointer :: user_CS => NULL() !< A pointer to the control structure for
@@ -1118,7 +1119,7 @@ subroutine add_shelf_flux(G, US, CS, sfc_state, fluxes)
         do j=js,je ; do i=is,ie
           last_hmask(i,j) = ISS%hmask(i,j) ; last_area_shelf_h(i,j) = ISS%area_shelf_h(i,j)
         enddo ; enddo
-        call time_interp_external(CS%id_read_mass, Time0, last_mass_shelf)
+        call time_interp_external(CS%mass_handle, Time0, last_mass_shelf)
         do j=js,je ; do i=is,ie
         ! This should only be done if time_interp_extern did an update.
           last_mass_shelf(i,j) = US%kg_m3_to_R*US%m_to_Z * last_mass_shelf(i,j) ! Rescale after time_interp
@@ -1937,7 +1938,7 @@ subroutine initialize_shelf_mass(G, param_file, CS, ISS, new_sim)
       filename = trim(slasher(inputdir))//trim(shelf_file)
       call log_param(param_file, mdl, "INPUTDIR/SHELF_FILE", filename)
 
-      CS%id_read_mass = init_external_field(filename, shelf_mass_var, &
+      CS%mass_handle = init_external_field(filename, shelf_mass_var, &
                             MOM_domain=CS%Grid_in%Domain, verbose=CS%debug)
 
       if (read_shelf_area) then
@@ -1945,7 +1946,7 @@ subroutine initialize_shelf_mass(G, param_file, CS, ISS, new_sim)
                   "The variable in SHELF_FILE with the shelf area.", &
                   default="shelf_area")
 
-         CS%id_read_area = init_external_field(filename, shelf_area_var, &
+         CS%area_handle = init_external_field(filename, shelf_area_var, &
                                MOM_domain=CS%Grid_in%Domain)
       endif
 
@@ -2040,7 +2041,7 @@ subroutine update_shelf_mass(G, US, CS, ISS, Time)
     allocate(tmp2d(is:ie,js:je), source=0.0)
   endif
 
-  call time_interp_external(CS%id_read_mass, Time, tmp2d)
+  call time_interp_external(CS%mass_handle, Time, tmp2d)
   call rotate_array(tmp2d, CS%turns, ISS%mass_shelf)
   deallocate(tmp2d)
 

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -17,6 +17,7 @@ use MOM_error_handler, only : stdout, stdlog, MOM_error
 use MOM_io, only : SINGLE_FILE
 use MOM_interp_infra, only : init_extern_field, get_external_field_info
 use MOM_interp_infra, only : time_interp_extern
+use MOM_interpolate, only : external_field
 use MOM_remapping,    only : remappingSchemesDoc
 use MOM_time_manager, only : time_type, real_to_time, get_date
 use MOM_time_manager, only : operator(+), operator(>=), operator(/=)
@@ -80,8 +81,8 @@ end type ptr_mpp_domain
 !> A structure containing integer handles for bias adjustment of tracers
 type :: INC_CS
   integer :: fldno = 0 !< The number of tracers
-  integer :: T_id !< The integer handle for the temperature file
-  integer :: S_id !< The integer handle for the salinity file
+  type(external_field) :: T  !< The handle for the temperature file
+  type(external_field) :: S  !< The handle for the salinity file
 end type INC_CS
 
 !> Control structure that contains a transpose of the ocean state across ensemble members.
@@ -391,11 +392,11 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
                 "tendency adjustments", default='temp_salt_adjustment.nc')
 
     inc_file = trim(inputdir) // trim(bias_correction_file)
-    CS%INC_CS%T_id = init_extern_field(inc_file, "temp_increment", &
+    CS%INC_CS%T = init_extern_field(inc_file, "temp_increment", &
           correct_leap_year_inconsistency=.true.,verbose=.true.,domain=G%Domain%mpp_domain)
-    CS%INC_CS%S_id = init_extern_field(inc_file, "salt_increment", &
+    CS%INC_CS%S = init_extern_field(inc_file, "salt_increment", &
           correct_leap_year_inconsistency=.true.,verbose=.true.,domain=G%Domain%mpp_domain)
-    call get_external_field_info(CS%INC_CS%T_id,size=fld_sz)
+    call get_external_field_info(CS%INC_CS%T, size=fld_sz)
     CS%INC_CS%fldno = 2
     if (CS%nk /= fld_sz(3)) call MOM_error(FATAL,'Increment levels /= ODA levels')
 
@@ -578,9 +579,9 @@ subroutine get_bias_correction_tracer(Time, US, CS)
 
 
   call cpu_clock_begin(id_clock_bias_adjustment)
-  call horiz_interp_and_extrap_tracer(CS%INC_CS%T_id, Time, CS%G, T_bias, &
+  call horiz_interp_and_extrap_tracer(CS%INC_CS%T, Time, CS%G, T_bias, &
             valid_flag, z_in, z_edges_in, missing_value, scale=US%degC_to_C*US%s_to_T, spongeOngrid=.true.)
-  call horiz_interp_and_extrap_tracer(CS%INC_CS%S_id, Time, CS%G, S_bias, &
+  call horiz_interp_and_extrap_tracer(CS%INC_CS%S, Time, CS%G, S_bias, &
             valid_flag, z_in, z_edges_in, missing_value, scale=US%ppt_to_S*US%s_to_T, spongeOngrid=.true.)
 
   ! This should be replaced to use mask_z instead of the following lines

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -16,6 +16,7 @@ use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,  only : forcing, extractFluxes1d, forcing_SinglePointPrint
 use MOM_grid,          only : ocean_grid_type
 use MOM_interpolate,   only : init_external_field, time_interp_external, time_interp_external_init
+use MOM_interpolate,   only : external_field
 use MOM_io,            only : slasher
 use MOM_opacity,       only : set_opacity, opacity_CS, extract_optics_slice, extract_optics_fields
 use MOM_opacity,       only : optics_type, optics_nbands, absorbRemainingSW, sumSWoverBands
@@ -64,7 +65,7 @@ type, public :: diabatic_aux_CS ; private
                              !! is added with a temperature of the local SST.
   logical :: var_pen_sw      !<   If true, use one of the CHL_A schemes to determine the
                              !! e-folding depth of incoming shortwave radiation.
-  integer :: sbc_chl         !< An integer handle used in time interpolation of
+  type(external_field) :: sbc_chl   !< A handle used in time interpolation of
                              !! chlorophyll read from a file.
   logical ::  chl_from_file  !< If true, chl_a is read from a file.
 


### PR DESCRIPTION
All instances of an FMS ID to the internal interpolation content is replaced with a derived type containing additional metadata recording the field's origin filename and fieldname.

This additional information is required in order to replicate the axis data from the field, which is no longer provided by FMS2.

The abstraction of this type also allows us to either extend it or redefine it in other frameworks as needed in the future.

This primarily affects the usage of the following functions:

- init_external_field
- time_interp_external
- horiz_interp_and_extrap_tracer

References to FMS1 move data into an `axistype`, but the contents are transferred to an `axis_info` when leaving the FMS1 layer.  FMS2 directly populates the `axis_info` content.

The `get_external_field_info` calls are modified to return `axis_info` rather than `axistype`.

The redundant `get_axis_data` function is also removed from `MOM_interp_infra`, since `get_axis_info` provides an equivalent operation.

The following solvers are updated:

- MOM_open_boundary
- MOM_ice_shelf
- MOM_oda_driver
- MOM_MEKE
- MOM_ALE_sponge
- MOM_diabatic_aux

Of these, OBC was the most significant.  The integer handle (fid) was previously used to determine if each segment field was constant or (if negative) read from a file.  After being replaced by the derived type, a new flag was added to make this determination.

All of the coupled drivers have been modified, since they support time interpolation of T and S fields.

- FMS
- MCT
- NUOPC

The NUOPC driver also includes modifications to its CFC11 and CFC12 fields.  Changes to the MOM CFC modules replaces an `id == -1`-like test, which is not used by the derived type.  This check has been removed, and we now solely rely on the `present(cfc_handle)` test.

----

This does not resolve all of our dependencies on FMS1, since content from `time_interp_external` must be replaced with content from `time_interp_external2`.  But this PR allows us to begin the work of using the replacement module.