### PR TITLE
Use fileset rather than threading for decompositon

### DIFF
--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -338,12 +338,14 @@ subroutine create_MOM_file(IO_handle, filename, vars, novars, fields, &
   if (one_file) then
     if (domain_set) then
       call IO_handle%open(filename, action=OVERWRITE_FILE, &
-          MOM_domain=domain, threading=thread)
+          MOM_domain=domain, threading=thread, fileset=SINGLE_FILE)
     else
-      call IO_handle%open(filename, action=OVERWRITE_FILE, threading=thread)
+      call IO_handle%open(filename, action=OVERWRITE_FILE, threading=thread, &
+          fileset=SINGLE_FILE)
     endif
   else
-    call IO_handle%open(filename, action=OVERWRITE_FILE, MOM_domain=Domain)
+    call IO_handle%open(filename, action=OVERWRITE_FILE, MOM_domain=Domain, &
+        threading=thread, fileset=thread)
   endif
 
 ! Define the coordinates.

--- a/src/framework/MOM_io_file.F90
+++ b/src/framework/MOM_io_file.F90
@@ -929,8 +929,8 @@ subroutine open_file_infra(handle, filename, action, MOM_domain, threading, file
     ! True if the domain is replaced with a single-file IO layout.
 
   use_single_file_domain = .false.
-  if (present(MOM_domain) .and. present(threading)) then
-    if (threading == SINGLE_FILE) &
+  if (present(MOM_domain) .and. present(fileset)) then
+    if (fileset == SINGLE_FILE) &
       use_single_file_domain = .true.
   endif
 


### PR DESCRIPTION
MOM IO was using the `threading` flag rather than `fileset` to determine whether a file should be forced as single file rather than domain-decomposed.  This patch applies the correct flag.