### PR TITLE
Separate self-attraction and loading as a new module

### DIFF
--- a/src/core/MOM_PressureForce.F90
+++ b/src/core/MOM_PressureForce.F90
@@ -13,6 +13,7 @@ use MOM_PressureForce_FV, only : PressureForce_FV_CS
 use MOM_PressureForce_Mont, only : PressureForce_Mont_Bouss, PressureForce_Mont_nonBouss
 use MOM_PressureForce_Mont, only : PressureForce_Mont_init
 use MOM_PressureForce_Mont, only : PressureForce_Mont_CS
+use MOM_self_attr_load, only : SAL_CS
 use MOM_tidal_forcing, only : tidal_forcing_CS
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs
@@ -80,7 +81,7 @@ subroutine PressureForce(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm, pbce, e
 end subroutine Pressureforce
 
 !> Initialize the pressure force control structure
-subroutine PressureForce_init(Time, G, GV, US, param_file, diag, CS, tides_CSp)
+subroutine PressureForce_init(Time, G, GV, US, param_file, diag, CS, SAL_CSp, tides_CSp)
   type(time_type), target, intent(in)    :: Time !< Current model time
   type(ocean_grid_type),   intent(in)    :: G    !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< Vertical grid structure
@@ -88,7 +89,8 @@ subroutine PressureForce_init(Time, G, GV, US, param_file, diag, CS, tides_CSp)
   type(param_file_type),   intent(in)    :: param_file !< Parameter file handles
   type(diag_ctrl), target, intent(inout) :: diag !< Diagnostics control structure
   type(PressureForce_CS),  intent(inout) :: CS   !< Pressure force control structure
-  type(tidal_forcing_CS), intent(inout), optional :: tides_CSp !< Tide control structure
+  type(SAL_CS),           intent(in), optional :: SAL_CSp !< SAL control structure
+  type(tidal_forcing_CS), intent(in), optional :: tides_CSp !< Tide control structure
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_PressureForce" ! This module's name.
 
@@ -103,10 +105,10 @@ subroutine PressureForce_init(Time, G, GV, US, param_file, diag, CS, tides_CSp)
 
   if (CS%Analytic_FV_PGF) then
     call PressureForce_FV_init(Time, G, GV, US, param_file, diag, &
-             CS%PressureForce_FV, tides_CSp)
+             CS%PressureForce_FV, SAL_CSp, tides_CSp)
   else
     call PressureForce_Mont_init(Time, G, GV, US, param_file, diag, &
-             CS%PressureForce_Mont, tides_CSp)
+             CS%PressureForce_Mont, SAL_CSp, tides_CSp)
   endif
 end subroutine PressureForce_init
 

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -315,7 +315,8 @@ subroutine PressureForce_FV_nonBouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_
     ! Find and add the self-attraction and loading geopotential anomaly.
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      SSH(i,j) = (za(i,j) - alpha_ref*p(i,j,1)) * I_gEarth - G%Z_ref
+      SSH(i,j) = (za(i,j) - alpha_ref*p(i,j,1)) * I_gEarth - G%Z_ref &
+                 - max(-G%bathyT(i,j)-G%Z_ref, 0.0)
     enddo ; enddo
     call calc_SAL(SSH, e_sal, G, CS%SAL_CSp)
   else
@@ -567,7 +568,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1
       do i=Isq,Ieq+1
-        SSH(i,j) = -G%bathyT(i,j) - G%Z_ref
+        SSH(i,j) = min(-G%bathyT(i,j) - G%Z_ref, 0.0)
       enddo
       do k=1,nz ; do i=Isq,Ieq+1
         SSH(i,j) = SSH(i,j) + h(i,j,k)*GV%H_to_Z

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -191,7 +191,7 @@ subroutine PressureForce_Mont_nonBouss(h, tv, PFu, PFv, G, GV, US, CS, p_atm, pb
     ! of self-attraction and loading.
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      SSH(i,j) = -G%bathyT(i,j) - G%Z_ref
+      SSH(i,j) = min(-G%bathyT(i,j) - G%Z_ref, 0.0)
     enddo ; enddo
     if (use_EOS) then
       !$OMP parallel do default(shared)
@@ -468,7 +468,7 @@ subroutine PressureForce_Mont_Bouss(h, tv, PFu, PFv, G, GV, US, CS, p_atm, pbce,
     ! barotropic tides.
     !$OMP parallel do default(shared)
     do j=Jsq,Jeq+1
-      do i=Isq,Ieq+1 ; SSH(i,j) = -G%bathyT(i,j) - G%Z_ref ; enddo
+      do i=Isq,Ieq+1 ; SSH(i,j) = min(-G%bathyT(i,j) - G%Z_ref, 0.0) ; enddo
       do k=1,nz ; do i=Isq,Ieq+1
         SSH(i,j) = SSH(i,j) + h(i,j,k)*GV%H_to_Z
       enddo ; enddo

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -87,7 +87,8 @@ use MOM_open_boundary, only : radiation_open_bdry_conds
 use MOM_open_boundary, only : open_boundary_zero_normal_flow
 use MOM_PressureForce, only : PressureForce, PressureForce_init, PressureForce_CS
 use MOM_set_visc, only : set_viscous_ML, set_visc_CS
-use MOM_tidal_forcing, only : tidal_forcing_init, tidal_forcing_CS
+use MOM_self_attr_load, only : SAL_init, SAL_end, SAL_CS
+use MOM_tidal_forcing, only : tidal_forcing_init, tidal_forcing_end, tidal_forcing_CS
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_vert_friction, only : vertvisc, vertvisc_coef, vertvisc_init, vertvisc_CS
 use MOM_verticalGrid, only : verticalGrid_type, get_thickness_units
@@ -120,6 +121,8 @@ type, public :: MOM_dyn_unsplit_CS ; private
                                  !! and in the calculation of the turbulent mixed layer properties
                                  !! for viscosity.  The default should be true, but it is false.
   logical :: debug           !< If true, write verbose checksums for debugging purposes.
+  logical :: calculate_SAL        !< If true, calculate self-attraction and loading.
+  logical :: use_tides            !< If true, tidal forcing is enabled.
 
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
 
@@ -153,6 +156,8 @@ type, public :: MOM_dyn_unsplit_CS ; private
   type(vertvisc_CS), pointer :: vertvisc_CSp => NULL()
   !> A pointer to the set_visc control structure
   type(set_visc_CS), pointer :: set_visc_CSp => NULL()
+  !> A pointer to the SAL control structure
+  type(SAL_CS) :: SAL_CSp
   !> A pointer to the tidal forcing control structure
   type(tidal_forcing_CS) :: tides_CSp
   !> A pointer to the ALE control structure.
@@ -625,7 +630,6 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, US, param_file, diag, CS
   character(len=48) :: flux_units
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  logical :: use_tides
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -650,8 +654,10 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, US, param_file, diag, CS
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
-  call get_param(param_file, mdl, "TIDES", use_tides, &
+  call get_param(param_file, mdl, "TIDES", CS%use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
+  call get_param(param_file, mdl, "CALCULATE_SAL", CS%calculate_SAL, &
+                 "If true, calculate self-attraction and loading.", default=CS%use_tides)
 
   allocate(CS%taux_bot(IsdB:IedB,jsd:jed), source=0.0)
   allocate(CS%tauy_bot(isd:ied,JsdB:JedB), source=0.0)
@@ -668,9 +674,10 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, US, param_file, diag, CS
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)
-  if (use_tides) call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp)
+  if (CS%calculate_SAL) call SAL_init(G, US, param_file, CS%SAL_CSp)
+  if (CS%use_tides) call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp)
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, &
-                          CS%tides_CSp)
+                          CS%SAL_CSp, CS%tides_CSp)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
                      ntrunc, CS%vertvisc_CSp)
@@ -721,6 +728,9 @@ subroutine end_dyn_unsplit(CS)
   DEALLOC_(CS%diffu) ; DEALLOC_(CS%diffv)
   DEALLOC_(CS%CAu)   ; DEALLOC_(CS%CAv)
   DEALLOC_(CS%PFu)   ; DEALLOC_(CS%PFv)
+
+  if (CS%calculate_SAL) call SAL_end(CS%SAL_CSp)
+  if (CS%use_tides) call tidal_forcing_end(CS%tides_CSp)
 
   deallocate(CS)
 end subroutine end_dyn_unsplit

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -86,7 +86,8 @@ use MOM_open_boundary, only : radiation_open_bdry_conds
 use MOM_open_boundary, only : open_boundary_zero_normal_flow
 use MOM_PressureForce, only : PressureForce, PressureForce_init, PressureForce_CS
 use MOM_set_visc, only : set_viscous_ML, set_visc_CS
-use MOM_tidal_forcing, only : tidal_forcing_init, tidal_forcing_CS
+use MOM_self_attr_load, only : SAL_init, SAL_end, SAL_CS
+use MOM_tidal_forcing, only : tidal_forcing_init, tidal_forcing_end, tidal_forcing_CS
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_vert_friction, only : vertvisc, vertvisc_coef, vertvisc_init, vertvisc_CS
 use MOM_verticalGrid, only : verticalGrid_type, get_thickness_units
@@ -123,6 +124,8 @@ type, public :: MOM_dyn_unsplit_RK2_CS ; private
                                  !! turbulent mixed layer properties for viscosity.
                                  !! The default should be true, but it is false.
   logical :: debug   !< If true, write verbose checksums for debugging purposes.
+  logical :: calculate_SAL        !< If true, calculate self-attraction and loading.
+  logical :: use_tides            !< If true, tidal forcing is enabled.
 
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
 
@@ -156,6 +159,8 @@ type, public :: MOM_dyn_unsplit_RK2_CS ; private
   type(vertvisc_CS), pointer :: vertvisc_CSp => NULL()
   !> A pointer to the set_visc control structure
   type(set_visc_CS), pointer :: set_visc_CSp => NULL()
+  !> A pointer to the SAL control structure
+  type(SAL_CS) :: SAL_CSp
   !> A pointer to the tidal forcing control structure
   type(tidal_forcing_CS) :: tides_CSp
   !> A pointer to the ALE control structure.
@@ -573,7 +578,6 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, US, param_file, diag
   character(len=48) :: flux_units
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  logical :: use_tides
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -614,8 +618,10 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, US, param_file, diag
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
-  call get_param(param_file, mdl, "TIDES", use_tides, &
+  call get_param(param_file, mdl, "TIDES", CS%use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
+  call get_param(param_file, mdl, "CALCULATE_SAL", CS%calculate_SAL, &
+                 "If true, calculate self-attraction and loading.", default=CS%use_tides)
 
   allocate(CS%taux_bot(IsdB:IedB,jsd:jed), source=0.0)
   allocate(CS%tauy_bot(isd:ied,JsdB:JedB), source=0.0)
@@ -632,9 +638,10 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, US, param_file, diag
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)
-  if (use_tides) call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp)
+  if (CS%calculate_SAL) call SAL_init(G, US, param_file, CS%SAL_CSp)
+  if (CS%use_tides) call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp)
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, &
-                          CS%tides_CSp)
+                          CS%SAL_CSp, CS%tides_CSp)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
                      ntrunc, CS%vertvisc_CSp)
@@ -684,6 +691,9 @@ subroutine end_dyn_unsplit_RK2(CS)
   DEALLOC_(CS%diffu) ; DEALLOC_(CS%diffv)
   DEALLOC_(CS%CAu)   ; DEALLOC_(CS%CAv)
   DEALLOC_(CS%PFu)   ; DEALLOC_(CS%PFv)
+
+  if (CS%calculate_SAL) call SAL_end(CS%SAL_CSp)
+  if (CS%use_tides) call tidal_forcing_end(CS%tides_CSp)
 
   deallocate(CS)
 end subroutine end_dyn_unsplit_RK2

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -111,6 +111,11 @@ subroutine find_obsolete_params(param_file)
 
   call obsolete_logical(param_file, "SMOOTH_RI", hint="Instead use N_SMOOTH_RI.")
 
+  call obsolete_logical(param_file, "TIDE_USE_SAL_SCALAR", hint="Use SAL_SCALAR_APPROX instead.")
+  call obsolete_logical(param_file, "TIDAL_SAL_SHT", hint="Use SAL_HARMONICS instead.")
+  call obsolete_int(param_file, "TIDAL_SAL_SHT_DEGREE", hint="Use SAL_HARMONICS_DEGREE instead.")
+  call obsolete_real(param_file, "RHO_E", hint="Use RHO_SOLID_EARTH instead.")
+
   ! Write the file version number to the model log.
   call log_version(param_file, mdl, version)
 

--- a/src/parameterizations/lateral/MOM_load_love_numbers.F90
+++ b/src/parameterizations/lateral/MOM_load_love_numbers.F90
@@ -1452,30 +1452,32 @@ real, dimension(4, lmax+1), parameter :: &
             /), (/4, lmax+1/)) !< Load Love numbers
 
 !> \namespace mom_load_love_numbers
-!! This module serves the sole purpose of storing load Love number. The Love numbers are used for the self-attraction
-!! and loading (SAL) calculation, which is currently embedded in MOM_tidal_forcing module. This separate module ensures
-!! the readability of the tidal module.
+!! This module serves the sole purpose of storing load Love number. The Love numbers are used for the spherical harmonic
+!! self-attraction and loading (SAL) calculation in MOM_self_attr_load module. This separate module ensures readability
+!! of the SAL module.
 !!
 !! Variable Love_Data stores the Love numbers up to degree 1440. From left to right: degree, h, l, and k. Data in this
 !! module is imported from SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean developed by Los Alamos
-!! National Laboratory and University of Michigan (Barton et al. (2022) and Brus et al. (2022)). The load Love numbers
+!! National Laboratory and University of Michigan [Barton et al. (2022) and Brus et al. (2022)]. The load Love numbers
 !! are from Wang et al. (2012), which are in the center of mass of total Earth system reference frame (CM). When used,
-!! Love numbers with degree<2 should be converted to center of mass solid Earth reference frame (CF) (Blewitt (2003)),
+!! Love numbers with degree<2 should be converted to center of mass solid Earth reference frame (CF) [Blewitt (2003)],
 !! as in subroutine calc_love_scaling in MOM_tidal_forcing module.
 !!
 !! References:
 !!
-!! Barton, K.N., Nairita, P., Brus, S.R., Petersen, M.R., Arbic, B.K., Engwirda, D., Roberts, A.F., Westerink, J.,
-!! Wirasaet, D., and Schindelegger, M., 2022: Performance of Model for Prediction Across Scales (MPAS) Ocean as a
-!! Global Barotropic Tide Model. Journal of Advances in Modeling Earth Systems, in review.
+!! Barton, K.N., Pal, N., Brus, S.R., Petersen, M.R., Arbic, B.K., Engwirda, D., Roberts, A.F., Westerink, J.J.,
+!! Wirasaet, D. and Schindelegger, M., 2022. Global Barotropic Tide Modeling Using Inline Self‐Attraction and Loading in
+!! MPAS‐Ocean. Journal of Advances in Modeling Earth Systems, 14(11), p.e2022MS003207.
+!! https://doi.org/10.1029/2022MS003207
 !!
 !! Blewitt, G., 2003. Self‐consistency in reference frames, geocenter definition, and surface loading of the solid
 !! Earth. Journal of geophysical research: solid earth, 108(B2).
 !! https://doi.org/10.1029/2002JB002082
 !!
-!! Brus, S.R., Barton, K.N., Nairita, P., Roberts, A.F., Engwirda, D., Petersen, M.R., Arbic, B.K., Wirasaet, D.,
-!! Westerink, J., and Schindelegger, M., 2022: Scalable self attraction and loading calculations for unstructured ocean
-!! models. Ocean Modelling, in review.
+!! Brus, S.R., Barton, K.N., Pal, N., Roberts, A.F., Engwirda, D., Petersen, M.R., Arbic, B.K., Wirasaet, D.,
+!! Westerink, J.J. and Schindelegger, M., 2023. Scalable self attraction and loading calculations for unstructured ocean
+!! tide models. Ocean Modelling, p.102160.
+!! https://doi.org/10.1016/j.ocemod.2023.102160
 !!
 !! Wang, H., Xiang, L., Jia, L., Jiang, L., Wang, Z., Hu, B. and Gao, P., 2012. Load Love numbers and Green's functions
 !! for elastic Earth models PREM, iasp91, ak135, and modified models with refined crustal structure from Crust 2.0.

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -1,0 +1,271 @@
+module MOM_self_attr_load
+
+use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_MODULE
+use MOM_domains,       only : pass_var
+use MOM_error_handler, only : MOM_error, FATAL, WARNING
+use MOM_file_parser,   only : get_param, log_version, param_file_type
+use MOM_grid,          only : ocean_grid_type
+use MOM_unit_scaling,  only : unit_scale_type
+use MOM_spherical_harmonics, only : spherical_harmonics_init, spherical_harmonics_end, order2index, calc_lmax
+use MOM_spherical_harmonics, only : spherical_harmonics_forward, spherical_harmonics_inverse
+use MOM_spherical_harmonics, only : sht_CS
+use MOM_load_love_numbers, only : Love_Data
+
+implicit none ; private
+
+public calc_SAL, scalar_SAL_sensitivity, SAL_init, SAL_end
+
+#include <MOM_memory.h>
+
+!> The control structure for the MOM_self_attr_load module
+type, public :: SAL_CS ; private
+  logical :: use_sal_scalar !< If true, use the scalar approximation when
+                      !! calculating self-attraction and loading.
+  real    :: sal_scalar !< The constant of proportionality between sea surface
+                      !! height (really it should be bottom pressure) anomalies
+                      !! and bottom geopotential anomalies [nondim].
+  logical :: use_prev_tides !< If true, use the SAL from the previous iteration of the tides
+                            !! to facilitate convergence.
+  logical :: use_sal_sht !< If true, use online spherical harmonics to calculate SAL
+  type(sht_CS) :: sht !< Spherical harmonic transforms (SHT) for SAL
+  integer :: sal_sht_Nd !< Maximum degree for SHT [nodim]
+  real, allocatable :: Love_Scaling(:) !< Love number for each SHT mode [nodim]
+  real, allocatable :: Snm_Re(:), & !< Real and imaginary SHT coefficient for SHT SAL
+                       Snm_Im(:)    !< [Z ~> m]
+end type SAL_CS
+
+integer :: id_clock_SAL   !< CPU clock for self-attraction and loading
+
+contains
+
+!> This subroutine calculates seawater self-attraction and loading based on sea surface height. This should
+!! be changed into bottom pressure anomaly in the future. Note that the SAL calculation applies to all motions
+!! across the spectrum. Tidal-specific methods that assume periodicity, i.e. iterative and read-in SAL, are
+!! stored in MOM_tidal_forcing module.
+subroutine calc_SAL(eta, eta_sal, G, CS)
+  type(ocean_grid_type), intent(in)  :: G  !< The ocean's grid structure.
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: eta     !< The sea surface height anomaly from
+                                                           !! a time-mean geoid [Z ~> m].
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: eta_sal !< The sea surface height anomaly from
+                                                           !! self-attraction and loading [Z ~> m].
+  type(SAL_CS), intent(inout) :: CS !< The control structure returned by a previous call to SAL_init.
+
+  ! Local variables
+  integer :: n, m, l
+  integer :: Isq, Ieq, Jsq, Jeq
+  integer :: i, j
+  real :: eta_prop
+
+  call cpu_clock_begin(id_clock_SAL)
+
+  Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
+
+  ! use the scalar approximation, iterative tidal SAL or no SAL
+  call scalar_SAL_sensitivity(CS, eta_prop)
+  do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    eta_sal(i,j) = eta_prop*eta(i,j)
+  enddo ; enddo
+
+  if (CS%use_sal_sht) then ! use the spherical harmonics method
+    call spherical_harmonics_forward(G, CS%sht, eta, CS%Snm_Re, CS%Snm_Im, CS%sal_sht_Nd)
+
+    ! Multiply scaling factors to each mode
+    do m = 0,CS%sal_sht_Nd
+      l = order2index(m, CS%sal_sht_Nd)
+      do n = m,CS%sal_sht_Nd
+        CS%Snm_Re(l+n-m) = CS%Snm_Re(l+n-m) * CS%Love_Scaling(l+n-m)
+        CS%Snm_Im(l+n-m) = CS%Snm_Im(l+n-m) * CS%Love_Scaling(l+n-m)
+      enddo
+    enddo
+
+    call spherical_harmonics_inverse(G, CS%sht, CS%Snm_Re, CS%Snm_Im, eta_sal, CS%sal_sht_Nd)
+
+    call pass_var(eta_sal, G%domain)
+  endif
+
+  call cpu_clock_end(id_clock_SAL)
+end subroutine calc_SAL
+
+!>   This subroutine calculates the partial derivative of the local geopotential height with the input
+!! sea surface height due to the scalar approximation of self-attraction and loading.
+subroutine scalar_SAL_sensitivity(CS, deta_sal_deta)
+  type(SAL_CS), intent(in)  :: CS !< The control structure returned by a previous call to SAL_init.
+  real,         intent(out) :: deta_sal_deta !< The partial derivative of eta_sal with
+                                             !! the local value of eta [nondim].
+
+  if (CS%USE_SAL_SCALAR .and. CS%USE_PREV_TIDES) then
+    deta_sal_deta = 2.0*CS%SAL_SCALAR
+  elseif (CS%USE_SAL_SCALAR .or. CS%USE_PREV_TIDES) then
+    deta_sal_deta = CS%SAL_SCALAR
+  else
+    deta_sal_deta = 0.0
+  endif
+end subroutine scalar_SAL_sensitivity
+
+!> This subroutine calculates coefficients of the spherical harmonic modes for self-attraction and loading.
+!! The algorithm is based on the SAL implementation in MPAS-ocean, which was modified by Kristin Barton from
+!! routine written by K. Quinn (March 2010) and modified by M. Schindelegger (May 2017).
+subroutine calc_love_scaling(nlm, rhoW, rhoE, Love_Scaling)
+  integer, intent(in) :: nlm  !< Maximum spherical harmonics degree [nondim]
+  real,    intent(in) :: rhoW !< The average density of sea water [R ~> kg m-3]
+  real,    intent(in) :: rhoE !< The average density of Earth [R ~> kg m-3]
+  real, dimension(:), intent(out) :: Love_Scaling !< Scaling factors for inverse SHT [nondim]
+
+  ! Local variables
+  real, dimension(:), allocatable :: HDat, LDat, KDat ! Love numbers converted in CF reference frames
+  real :: H1, L1, K1 ! Temporary variables to store degree 1 Love numbers
+  integer :: n_tot ! Size of the stored Love numbers
+  integer :: n, m, l
+
+  n_tot = size(Love_Data, dim=2)
+
+  if (nlm+1 > n_tot) call MOM_error(FATAL, "MOM_tidal_forcing " // &
+    "calc_love_scaling: maximum spherical harmonics degree is larger than " // &
+    "the size of the stored Love numbers in MOM_load_love_number.")
+
+  allocate(HDat(nlm+1), LDat(nlm+1), KDat(nlm+1))
+  HDat(:) = Love_Data(2,1:nlm+1) ; LDat(:) = Love_Data(3,1:nlm+1) ; KDat(:) = Love_Data(4,1:nlm+1)
+
+  ! Convert reference frames from CM to CF
+  if (nlm > 0) then
+    H1 = HDat(2) ; L1 = LDat(2) ;  K1 = KDat(2)
+    HDat(2) = ( 2.0 / 3.0) * (H1 - L1)
+    LDat(2) = (-1.0 / 3.0) * (H1 - L1)
+    KDat(2) = (-1.0 / 3.0) * H1 - (2.0 / 3.0) * L1 - 1.0
+  endif
+
+  do m=0,nlm ; do n=m,nlm
+    l = order2index(m,nlm)
+    Love_Scaling(l+n-m) = (3.0 / real(2*n+1)) * (rhoW / rhoE) * (1.0 + KDat(n+1) - HDat(n+1))
+  enddo ; enddo
+end subroutine calc_love_scaling
+
+!> This subroutine initializeds the self-attraction and loading control structure.
+subroutine SAL_init(G, US, param_file, CS)
+  type(ocean_grid_type),  intent(inout) :: G    !< The ocean's grid structure.
+  type(unit_scale_type),  intent(in)    :: US   !< A dimensional unit scaling type
+  type(param_file_type),  intent(in)    :: param_file !< A structure to parse for run-time parameters.
+  type(SAL_CS), intent(inout) :: CS   !< Self-attraction and loading control structure
+
+# include "version_variable.h"
+  character(len=40)  :: mdl = "MOM_self_attr_load" ! This module's name.
+  integer :: lmax ! Total modes of the real spherical harmonics [nondim]
+  real :: rhoW    ! The average density of sea water [R ~> kg m-3].
+  real :: rhoE    ! The average density of Earth [R ~> kg m-3].
+
+  logical :: calculate_sal
+  logical :: tides, tidal_sal_from_file
+
+  ! Read all relevant parameters and write them to the model log.
+  call log_version(param_file, mdl, version, "")
+
+  call get_param(param_file, '', "TIDES", tides, default=.false., do_not_log=.True.)
+
+  CS%use_prev_tides = .false.
+  tidal_sal_from_file = .false.
+  if (tides) then
+    call get_param(param_file, '', "USE_PREVIOUS_TIDES", CS%use_prev_tides,&
+                   default=.false., do_not_log=.True.)
+    call get_param(param_file, '', "TIDAL_SAL_FROM_FILE", tidal_sal_from_file,&
+                   default=.false., do_not_log=.True.)
+  endif
+
+  call get_param(param_file, mdl, "TIDE_USE_SAL_SCALAR", CS%use_sal_scalar, &
+                "If true and TIDES is true, use the scalar approximation "//&
+                "when calculating self-attraction and loading.", &
+                default=.not.tidal_sal_from_file)
+  if (CS%use_sal_scalar .or. CS%use_prev_tides) &
+    call get_param(param_file, mdl, "TIDE_SAL_SCALAR_VALUE", CS%sal_scalar, &
+                  "The constant of proportionality between sea surface "//&
+                  "height (really it should be bottom pressure) anomalies "//&
+                  "and bottom geopotential anomalies. This is only used if "//&
+                  "TIDES and TIDE_USE_SAL_SCALAR are true.", units="m m-1", &
+                  fail_if_missing=.true.)
+
+  call get_param(param_file, mdl, "TIDAL_SAL_SHT", CS%use_sal_sht, &
+                 "If true, use the online spherical harmonics method to calculate "//&
+                 "self-attraction and loading term in tides.", default=.false.)
+
+  call get_param(param_file, mdl, "CALCULATE_SAL", calculate_sal, &
+                 "If true, calculate self-attraction and loading.", default=tides)
+
+  ! ! Default USE_SAL is TRUE for now to keep backward compatibility with old MOM_INPUT files. It should be changed to
+  ! ! FALSE in the future (mostly to avoid the SSH calculations in MOM_PressureForce). In that case, the following check
+  ! ! informs prior tidal experiments that use scalar or iterative SAL to include USE_SAL flag, as the USE_SAL flag
+  ! ! overrules the option flags.
+  ! if ((.not. calculate_sal) .and. (CS%use_prev_tides .or. CS%use_sal_scalar .or. CS%use_sal_sht)) &
+  !   call MOM_error(FATAL, trim(mdl)//": USE_SAL is False but one of the options is True. Nothing will happen.")
+
+  if (CS%use_sal_sht) then
+    call get_param(param_file, mdl, "TIDAL_SAL_SHT_DEGREE", CS%sal_sht_Nd, &
+                   "The maximum degree of the spherical harmonics transformation used for "// &
+                   "calculating the self-attraction and loading term.", &
+                   default=0, do_not_log=.not. CS%use_sal_sht)
+    call get_param(param_file, mdl, "RHO_0", rhoW, default=1035.0, scale=US%kg_m3_to_R, do_not_log=.True.)
+    call get_param(param_file, mdl, "RHO_E", rhoE, &
+                   "The mean solid earth density.  This is used for calculating the "// &
+                   "self-attraction and loading term.", units="kg m-3", &
+                   default=5517.0, scale=US%kg_m3_to_R, do_not_log=.not. CS%use_sal_sht)
+    lmax = calc_lmax(CS%sal_sht_Nd)
+    allocate(CS%Snm_Re(lmax)); CS%Snm_Re(:) = 0.0
+    allocate(CS%Snm_Im(lmax)); CS%Snm_Im(:) = 0.0
+
+    allocate(CS%Love_Scaling(lmax)); CS%Love_Scaling(:) = 0.0
+    call calc_love_scaling(CS%sal_sht_Nd, rhoW, rhoE, CS%Love_Scaling)
+    call spherical_harmonics_init(G, param_file, CS%sht)
+  endif
+
+  id_clock_SAL = cpu_clock_id('(Ocean SAL)', grain=CLOCK_MODULE)
+
+end subroutine SAL_init
+
+!> This subroutine deallocates memory associated with the SAL module.
+subroutine SAL_end(CS)
+  type(SAL_CS), intent(inout) :: CS !< The control structure returned by a previous call
+                                    !! to SAL_init; it is deallocated here.
+  if (CS%use_sal_sht) then
+    if (allocated(CS%Love_Scaling)) deallocate(CS%Love_Scaling)
+    if (allocated(CS%Snm_Re)) deallocate(CS%Snm_Re)
+    if (allocated(CS%Snm_Im)) deallocate(CS%Snm_Im)
+    call spherical_harmonics_end(CS%sht)
+  endif
+end subroutine SAL_end
+
+!> \namespace self_attr_load
+!!
+!! This module contains methods to calculate self-attraction and loading (SAL) as a function of sea surface height (SSH)
+!! (rather, it should be bottom pressure anomaly). SAL is primarily used for fast evolving processes like tides or
+!! storm surges, but the effect applys to all motions.
+!!
+!!     If TIDE_USE_SAL_SCALAR is true, a scalar approximiation is applied (Accad and Pekeris 1978) and the SAL is simply
+!! a fraction (set by TIDE_SAL_SCALAR_VALUE, usualy around 10% for global tides) of local SSH . For the tides, the
+!! scalar approximation can also be used to iterate the SAL to convergence [see USE_PREVIOUS_TIDES in MOM_tidal_forcing,
+!! Arbic et al. (2004)].
+!!
+!!    If TIDAL_SAL_SHT is true, a more accurate online spherical harmonic transforms are used to calculate SAL.
+!! Subroutines in module MOM_spherical_harmonics are called and the degree of spherical harmonic transforms is set by
+!! TIDAL_SAL_SHT_DEGREE. The algorithm is based on SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean
+!! developed by Los Alamos National Laboratory and University of Michigan [Barton et al. (2022) and Brus et al. (2023)].
+!!
+!! References:
+!!
+!! Accad, Y. and Pekeris, C.L., 1978. Solution of the tidal equations for the M2 and S2 tides in the world oceans from a
+!! knowledge of the tidal potential alone. Philosophical Transactions of the Royal Society of London. Series A,
+!! Mathematical and Physical Sciences, 290(1368), pp.235-266.
+!! https://doi.org/10.1098/rsta.1978.0083
+!!
+!! Arbic, B.K., Garner, S.T., Hallberg, R.W. and Simmons, H.L., 2004. The accuracy of surface elevations in forward
+!! global barotropic and baroclinic tide models. Deep Sea Research Part II: Topical Studies in Oceanography, 51(25-26),
+!! pp.3069-3101.
+!! https://doi.org/10.1016/j.dsr2.2004.09.014
+!!
+!! Barton, K.N., Pal, N., Brus, S.R., Petersen, M.R., Arbic, B.K., Engwirda, D., Roberts, A.F., Westerink, J.J.,
+!! Wirasaet, D. and Schindelegger, M., 2022. Global Barotropic Tide Modeling Using Inline Self‐Attraction and Loading in
+!! MPAS‐Ocean. Journal of Advances in Modeling Earth Systems, 14(11), p.e2022MS003207.
+!! https://doi.org/10.1029/2022MS003207
+!!
+!! Brus, S.R., Barton, K.N., Pal, N., Roberts, A.F., Engwirda, D., Petersen, M.R., Arbic, B.K., Wirasaet, D.,
+!! Westerink, J.J. and Schindelegger, M., 2023. Scalable self attraction and loading calculations for unstructured ocean
+!! tide models. Ocean Modelling, p.102160.
+!! https://doi.org/10.1016/j.ocemod.2023.102160
+end module MOM_self_attr_load

--- a/src/parameterizations/lateral/MOM_spherical_harmonics.F90
+++ b/src/parameterizations/lateral/MOM_spherical_harmonics.F90
@@ -330,7 +330,7 @@ end function order2index
 !! Currently, the transforms are for t-cell fields only.
 !!
 !! This module is stemmed from SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean developed by Los
-!! Alamos National Laboratory and University of Michigan (Barton et al. (2022) and Brus et al. (2022)). The algorithm
+!! Alamos National Laboratory and University of Michigan [Barton et al. (2022) and Brus et al. (2023)]. The algorithm
 !! for forward and inverse transforms loosely follows Schaeffer (2013).
 !!
 !! In forward transform, a two-dimensional physical field can be projected into a series of spherical harmonics. The
@@ -368,13 +368,15 @@ end function order2index
 !!
 !! References:
 !!
-!! Barton, K.N., Nairita, P., Brus, S.R., Petersen, M.R., Arbic, B.K., Engwirda, D., Roberts, A.F., Westerink, J.,
-!! Wirasaet, D., and Schindelegger, M., 2022: Performance of Model for Prediction Across Scales (MPAS) Ocean as a
-!! Global Barotropic Tide Model. Journal of Advances in Modeling Earth Systems, in review.
+!! Barton, K.N., Pal, N., Brus, S.R., Petersen, M.R., Arbic, B.K., Engwirda, D., Roberts, A.F., Westerink, J.J.,
+!! Wirasaet, D. and Schindelegger, M., 2022. Global Barotropic Tide Modeling Using Inline Self‐Attraction and Loading in
+!! MPAS‐Ocean. Journal of Advances in Modeling Earth Systems, 14(11), p.e2022MS003207.
+!! https://doi.org/10.1029/2022MS003207
 !!
-!! Brus, S.R., Barton, K.N., Nairita, P., Roberts, A.F., Engwirda, D., Petersen, M.R., Arbic, B.K., Wirasaet, D.,
-!! Westerink, J., and Schindelegger, M., 2022: Scalable self attraction and loading calculations for unstructured ocean
-!! models. Ocean Modelling, in review.
+!! Brus, S.R., Barton, K.N., Pal, N., Roberts, A.F., Engwirda, D., Petersen, M.R., Arbic, B.K., Wirasaet, D.,
+!! Westerink, J.J. and Schindelegger, M., 2023. Scalable self attraction and loading calculations for unstructured ocean
+!! tide models. Ocean Modelling, p.102160.
+!! https://doi.org/10.1016/j.ocemod.2023.102160
 !!
 !! Schaeffer, N., 2013. Efficient spherical harmonic transforms aimed at pseudospectral numerical simulations.
 !! Geochemistry, Geophysics, Geosystems, 14(3), pp.751-758.

--- a/src/parameterizations/lateral/MOM_spherical_harmonics.F90
+++ b/src/parameterizations/lateral/MOM_spherical_harmonics.F90
@@ -217,7 +217,7 @@ subroutine spherical_harmonics_init(G, param_file, CS)
   integer :: is, ie, js, je
   integer :: i, j, k
   integer :: m, n
-  integer :: Nd_tidal_SAL ! Maximum degree for tidal SAL
+  integer :: Nd_SAL ! Maximum degree for SAL
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40) :: mdl = "MOM_spherical_harmonics" ! This module's name.
@@ -228,11 +228,8 @@ subroutine spherical_harmonics_init(G, param_file, CS)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
   call log_version(param_file, mdl, version, "")
-  call get_param(param_file, mdl, "TIDAL_SAL_SHT_DEGREE", Nd_tidal_SAL, &
-                 "The maximum degree of the spherical harmonics transformation used for "// &
-                 "calculating the self-attraction and loading term for tides.", &
-                 default=0, do_not_log=.true.)
-  CS%ndegree = Nd_tidal_SAL
+  call get_param(param_file, mdl, "SAL_HARMONICS_DEGREE", Nd_SAL, "", default=0, do_not_log=.true.)
+  CS%ndegree = Nd_SAL
   CS%lmax = calc_lmax(CS%ndegree)
   call get_param(param_file, mdl, "SHT_REPRODUCING_SUM", CS%reprod_sum, &
                  "If true, use reproducing sums (invariant to PE layout) in inverse transform "// &
@@ -361,7 +358,7 @@ end function order2index
 !! array vectorization.
 !!
 !! The maximum degree of the spherical harmonics is a runtime parameter and the maximum used by all SHT applications.
-!! At the moment, it is only decided by TIDAL_SAL_SHT_DEGREE.
+!! At the moment, it is only decided by SAL_HARMONICS_DEGREE.
 !!
 !! The forward transforms involve a global summation. Runtime flag SHT_REPRODUCING_SUM controls whether this is done
 !! in a bit-wise reproducing way or not.

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -356,7 +356,7 @@ subroutine tidal_forcing_init(Time, G, US, param_file, CS)
   ! If it is being used, sal_scalar MUST be specified in param_file.
   if (CS%use_tidal_sal_prev) &
     call get_param(param_file, mdl, "SAL_SCALAR_VALUE", CS%sal_scalar, fail_if_missing=.true., &
-                   do_not_log=.True.)
+                   units="m m-1", do_not_log=.True.)
 
   if (nc > MAX_CONSTITUENTS) then
     write(mesg,'("Increase MAX_CONSTITUENTS in MOM_tidal_forcing.F90 to at least",I3, &


### PR DESCRIPTION
Calculation for self-attraction and loading (SAL) is taken out from `MOM_tidal_forcing` and housed in a new module (`MOM_self_attr_load`) as SAL is a process not limited to tides.

The new module includes both online spherical harmonics method and scalar approximation. Read-in method (TIDAL_SAL_FROM_FILE) is kept in the tidal forcing module as it is specific to tides. For the iterative method (USE_PREV_TIDES), the updating part that is tied to the scalar approximation is moved to the new SAL model, while the read-in part remains in the tidal_forcing module.

Module `MOM_tidal_forcing` is designated only to calculations of the astronomical forcing and periodic tidal SAL that is based on previous solutions from input files. This makes the tidal forcing module now only contain calculations independent from the ocean's state and the only input variable it needs is the current time.

* A new parameter `CALCULATE_SAL` is added to control if SAL is calculated. At the moment, the default is linked to if `TIDES` is used.
* A bug with SSH used for SAL with flooding points are now fixed.
* New diagnostics on the SAL, equilibrium tides and tidal SAL are added.
* Input parameters are renamed to remove 'TIDAL' or 'TIDES' from the SAL fields. This is done in a non-disruptive way. Old parameters with scalar SAL are still accepted but with a warning message.

## Answer changes
Due to the rearrangement of the summations, answers are changed at bit level.
* For FV Pressure Force in Boussinesq mode, a `TIDES_ANSWER_DATE` runtime flag is added to restore old answers. Any integer > 20230701 gives the new answer. The current default is 20230630.
* For the other options, FV Pressure in non-Boussinesq and Montgomery Pressure Force, which presumably are rarely used for tides and not included in the testing suites, answers are expected to change. 