### PR TITLE
+Refactor internal_tides interface

### DIFF
--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -67,7 +67,6 @@ use MOM_unit_scaling,        only : unit_scale_type
 use MOM_variables,           only : thermo_var_ptrs, vertvisc_type, accel_diag_ptrs
 use MOM_variables,           only : cont_diag_ptrs, MOM_thermovar_chksum, p3d
 use MOM_verticalGrid,        only : verticalGrid_type, get_thickness_units
-use MOM_wave_speed,          only : wave_speeds, wave_speed_CS, wave_speed_init
 use MOM_wave_interface,      only : wave_parameters_CS
 use MOM_stochastics,         only : stochastic_CS
 
@@ -123,9 +122,6 @@ type, public :: diabatic_CS ; private
                                      !! shear and ePBL diffusivities are used.
   real    :: ePBL_Prandtl            !< The Prandtl number used by ePBL to convert vertical
                                      !! diffusivities into viscosities [nondim].
-  integer :: nMode = 1               !< Number of baroclinic modes to consider
-  real    :: uniform_test_cg         !< Uniform group velocity of internal tide
-                                     !! for testing internal tides [L T-1 ~> m s-1]
   logical :: useALEalgorithm         !< If true, use the ALE algorithm rather than layered
                                      !! isopycnal/stacked shallow water mode. This logical
                                      !! passed by argument to diabatic_driver_init.
@@ -239,7 +235,6 @@ type, public :: diabatic_CS ; private
   type(int_tide_CS) :: int_tide                     !< Internal tide control structure
   type(opacity_CS) :: opacity                       !< Opacity control structure
   type(regularize_layers_CS) :: regularize_layers   !< Regularize layer control structure
-  type(wave_speed_CS) :: wave_speed                 !< Wave speed control struct
 
   type(group_pass_type) :: pass_hold_eb_ea !< For group halo pass
   type(group_pass_type) :: pass_Kv         !< For group halo pass
@@ -297,8 +292,6 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   ! local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: &
     eta      ! Interface heights before diapycnal mixing [Z ~> m]
-  real, dimension(SZI_(G),SZJ_(G),CS%nMode) :: &
-    cn_IGW   ! baroclinic internal gravity wave speeds [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: temp_diag  ! Previous temperature for diagnostics [C ~> degC]
   real, dimension(SZI_(G)) :: T_freeze, & ! The freezing potential temperature at the current salinity [C ~> degC].
                               ps          ! Surface pressure [R L2 T-2 ~> Pa]
@@ -392,17 +385,8 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     ! This block provides an interface for the unresolved low-mode internal tide module.
     call set_int_tide_input(u, v, h, tv, fluxes, CS%int_tide_input, dt, G, GV, US, &
                             CS%int_tide_input_CSp)
-    cn_IGW(:,:,:) = 0.0
-    if (CS%uniform_test_cg > 0.0) then
-      do m=1,CS%nMode ; cn_IGW(:,:,m) = CS%uniform_test_cg ; enddo
-    else
-      call wave_speeds(h, tv, G, GV, US, CS%nMode, cn_IGW, CS%wave_speed, CS%int_tide%w_struct, &
-                       CS%int_tide%u_struct, CS%int_tide%u_struct_max, CS%int_tide%u_struct_bot, &
-                       CS%int_tide_input%Nb, CS%int_tide%int_w2, CS%int_tide%int_U2, CS%int_tide%int_N2w2, &
-                       full_halos=.true.)
-    endif
 
-    call propagate_int_tide(h, tv, cn_IGW, CS%int_tide_input%TKE_itidal_input, CS%int_tide_input%tideamp, &
+    call propagate_int_tide(h, tv, CS%int_tide_input%TKE_itidal_input, CS%int_tide_input%tideamp, &
                             CS%int_tide_input%Nb, dt, G, GV, US, CS%int_tide)
     if (showCallTree) call callTree_waypoint("done with propagate_int_tide (diabatic)")
   endif ! end CS%use_int_tides
@@ -504,10 +488,6 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
   if ((CS%id_MLD_EN1 > 0) .or. (CS%id_MLD_EN2 > 0) .or. (CS%id_MLD_EN3 > 0)) then
     call diagnoseMLDbyEnergy((/CS%id_MLD_EN1, CS%id_MLD_EN2, CS%id_MLD_EN3/),&
                              h, tv, G, GV, US, CS%MLD_En_vals, CS%diag)
-  endif
-  if (CS%use_int_tides) then
-    if (CS%id_cg1 > 0) call post_data(CS%id_cg1, cn_IGW(:,:,1),CS%diag)
-    do m=1,CS%nMode ; if (CS%id_cn(m) > 0) call post_data(CS%id_cn(m), cn_IGW(:,:,m), CS%diag) ; enddo
   endif
 
   if (stoch_CS%do_sppt .and. stoch_CS%id_sppt_wts > 0) &
@@ -2979,8 +2959,6 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
   ! Local variables
   real    :: Kd  ! A diffusivity used in the default for other tracer diffusivities [Z2 T-1 ~> m2 s-1]
-  real    :: IGW_c1_thresh ! A threshold first mode internal wave speed below which all higher
-                 ! mode speeds are not calculated but simply assigned a speed of 0 [L T-1 ~> m s-1].
   logical :: use_temperature
   character(len=20) :: EN1, EN2, EN3
 
@@ -3073,23 +3051,8 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   call get_param(param_file, mdl, "INTERNAL_TIDES", CS%use_int_tides, &
                  "If true, use the code that advances a separate set of "//&
                  "equations for the internal tide energy density.", default=.false.)
-  CS%nMode = 1
-  if (CS%use_int_tides) then
-    call get_param(param_file, mdl, "INTERNAL_TIDE_MODES", CS%nMode, &
-                 "The number of distinct internal tide modes "//&
-                 "that will be calculated.", default=1, do_not_log=.true.)
-    call get_param(param_file, mdl, "INTERNAL_WAVE_CG1_THRESH", IGW_c1_thresh, &
-                 "A minimal value of the first mode internal wave speed below which all higher "//&
-                 "mode speeds are not calculated but are simply reported as 0.  This must be "//&
-                 "non-negative for the wave_speeds routine to be used.", &
-                 units="m s-1", default=0.01, scale=US%m_s_to_L_T)
-    call get_param(param_file, mdl, "UNIFORM_TEST_CG", CS%uniform_test_cg, &
-                 "If positive, a uniform group velocity of internal tide for test case", &
-                 default=-1., units="m s-1", scale=US%m_s_to_L_T)
-  endif
 
-  call get_param(param_file, mdl, "MASSLESS_MATCH_TARGETS", &
-                                CS%massless_match_targets, &
+  call get_param(param_file, mdl, "MASSLESS_MATCH_TARGETS", CS%massless_match_targets, &
                  "If true, the temperature and salinity of massless layers "//&
                  "are kept consistent with their target densities. "//&
                  "Otherwise the properties of massless layers evolve "//&
@@ -3195,19 +3158,6 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
       call safe_alloc_ptr(ADp%du_dt_dia,IsdB,IedB,jsd,jed,nz)
     if ((CS%id_dvdt_dia > 0) .or. (CS%id_hf_dvdt_dia_2d > 0)) &
       call safe_alloc_ptr(ADp%dv_dt_dia,isd,ied,JsdB,JedB,nz)
-  endif
-
-  if (CS%use_int_tides) then
-    CS%id_cg1 = register_diag_field('ocean_model', 'cn1', diag%axesT1, &
-                 Time, 'First baroclinic mode (eigen) speed', 'm s-1', conversion=US%L_T_to_m_s)
-    allocate(CS%id_cn(CS%nMode), source=-1)
-    do m=1,CS%nMode
-      write(var_name, '("cn_mode",i1)') m
-      write(var_descript, '("Baroclinic (eigen) speed of mode ",i1)') m
-      CS%id_cn(m) = register_diag_field('ocean_model',var_name, diag%axesT1, &
-                   Time, var_descript, 'm s-1', conversion=US%L_T_to_m_s)
-      call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
-    enddo
   endif
 
   if (use_temperature) then
@@ -3504,7 +3454,6 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
     call int_tide_input_init(Time, G, GV, US, param_file, diag, CS%int_tide_input_CSp, &
                              CS%int_tide_input)
     call internal_tides_init(Time, G, GV, US, param_file, diag, CS%int_tide)
-    call wave_speed_init(CS%wave_speed, c1_thresh=IGW_c1_thresh)
   endif
 
   physical_OBL_scheme = (CS%use_bulkmixedlayer .or. CS%use_KPP .or. CS%use_energetic_PBL)


### PR DESCRIPTION
  Refactors the internal tide code in MOM_internal_tides and MOM_diabatic_driver to consolidate it in the MOM_internal_tides module and allow the control structure for that module to be made opaque.  This includes moving the internal wave speed diagnostics and the call to wave_speeds or other code setting the internal wave speeds into propagate_int_tide.  The get_param calls for INTERNAL_WAVE_CG1_THRESH and UNIFORM_TEST_CG were moved from the diabatic module to the MOM_internal_tides module. The wave_speed_CS and uniform_test_cg were removed from diabatic_CS and added to int_tide_CS.  The Nb argument to propagate_int_tide has been made intent inout, as it is now usually set via the call to wave_speeds in that routine, but for certain tests it could use the value passed in from diabatic_driver.

  All answers are bitwise identical, but there are changes to public interfaces and types, and the order of some entries in the MOM_parameter_doc files and the available_diags files is changed for some cases.