### PR TITLE
github workflows: update to use actions/checkout@v3

### DIFF
--- a/.github/workflows/coupled-api.yml
+++ b/.github/workflows/coupled-api.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/documentation-and-style.yml
+++ b/.github/workflows/documentation-and-style.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/expression.yml
+++ b/.github/workflows/expression.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -16,7 +16,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -16,7 +16,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/perfmon.yml
+++ b/.github/workflows/perfmon.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/stencil.yml
+++ b/.github/workflows/stencil.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 


### PR DESCRIPTION
- Updates actions/checkout from v2 to v3 . This simply uses the newer version of checkout and has no immediate impact, but does anticipate the inevitable need to roll forward.

Suggestion comes from https://github.com/NCAR/MOM6/pull/231#issuecomment-1347224581 thanks to @jedwards4b) . I had imagined this commit was going to be cherry-picked some time ago but it seems it was not.
