### PR TITLE
Autoconf: Find Python, even if PYTHON is empty

### DIFF
--- a/ac/Makefile.in
+++ b/ac/Makefile.in
@@ -56,3 +56,4 @@ ac-clean: distclean
 	rm -f @srcdir@/ac/aclocal.m4
 	rm -rf @srcdir@/ac/autom4te.cache
 	rm -f @srcdir@/ac/configure
+	rm -f @srcdir@/ac/configure~

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -238,8 +238,13 @@ AC_COMPILE_IFELSE(
 
 # Python interpreter test
 
+# Declare the Python interpreter variable
 AC_ARG_VAR([PYTHON], [Python interpreter command])
 
+# If PYTHON is set to an empty string, then unset it
+AS_VAR_IF([PYTHON], [], [AS_UNSET([PYTHON])], [])
+
+# Now attempt to find a Python interpreter if PYTHON is unset
 AS_VAR_SET_IF([PYTHON], [
   AC_PATH_PROGS([PYTHON], ["$PYTHON"], [none])
 ], [


### PR DESCRIPTION
The autoconf Python interpreter search was slightly modified to search for Python even if $PYTHON is set to an empty string.  This is done by unsetting PYTHON if it is set but empty, then following the usual macro.

This was required since `export PYTHON` in a Makefile will create the `PYTHON` variable but will assign it no value (i.e. empty string). This causes issues in some build environments.

The backup `configure~` script was also added to the developer `ac-clean` cleanup rule.