### PR TITLE
Refactor of `save_MOM6_internal_state`

### DIFF
--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -14,7 +14,8 @@ module ocean_model_mod
 use MOM, only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
 use MOM, only : extract_surface_state, allocate_surface_state, finish_MOM_initialization
 use MOM, only : get_MOM_state_elements, MOM_state_is_synchronized
-use MOM, only : get_ocean_stocks, step_offline, save_MOM6_internal_state
+use MOM, only : get_ocean_stocks, step_offline
+use MOM, only : save_MOM_restart
 use MOM_coms,      only : field_chksum
 use MOM_constants, only : CELSIUS_KELVIN_OFFSET, hlf
 use MOM_coupler_types, only : coupler_1d_bc_type, coupler_2d_bc_type
@@ -37,7 +38,6 @@ use MOM_get_input, only : Get_MOM_Input, directories
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : write_version_number, stdout_if_root
 use MOM_marine_ice, only : iceberg_forces, iceberg_fluxes, marine_ice_init, marine_ice_CS
-use MOM_restart, only : MOM_restart_CS, save_restart
 use MOM_string_functions, only : uppercase
 use MOM_surface_forcing_gfdl, only : surface_forcing_init, convert_IOB_to_fluxes
 use MOM_surface_forcing_gfdl, only : convert_IOB_to_forces, ice_ocn_bnd_type_chksum
@@ -209,9 +209,6 @@ type, public :: ocean_state_type ; private
     Waves => NULL()           !< A pointer to the surface wave control structure
   type(surface_forcing_CS), pointer :: &
     forcing_CSp => NULL()     !< A pointer to the MOM forcing control structure
-  type(MOM_restart_CS), pointer :: &
-    restart_CSp => NULL()     !< A pointer set to the restart control structure
-                              !! that will be used for MOM restart files.
   type(diag_ctrl), pointer :: &
     diag => NULL()            !< A pointer to the diagnostic regulatory structure
 end type ocean_state_type
@@ -279,7 +276,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
   ! initialization of ice shelf parameters and arrays.
 
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &
-                      OS%restart_CSp, Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
+                      Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       diag_ptr=OS%diag, count_calls=.true., ice_shelf_CSp=OS%ice_shelf_CSp, &
                       waves_CSp=OS%Waves)
   call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%C_p, &
@@ -572,7 +569,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
   endif
 
   if ((OS%nstep==0) .and. (OS%nstep_thermo==0)) then ! This is the first call to update_ocean_model.
-    call finish_MOM_initialization(OS%Time, OS%dirs, OS%MOM_CSp, OS%restart_CSp)
+    call finish_MOM_initialization(OS%Time, OS%dirs, OS%MOM_CSp)
   endif
 
   Time_thermo_start = OS%Time
@@ -693,24 +690,22 @@ subroutine ocean_model_restart(OS, timestamp)
       "restart files can only be created after the buoyancy forcing is applied.")
 
   if (BTEST(OS%Restart_control,1)) then
-    call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-                      OS%restart_CSp, .true., GV=OS%GV)
+    call save_MOM_restart(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, &
+        OS%grid, time_stamped=.true., GV=OS%GV)
     call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
                               OS%dirs%restart_output_dir, .true.)
     if (OS%use_ice_shelf) then
       call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir, .true.)
     endif
-    call save_MOM6_internal_state(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, .true.)
   endif
   if (BTEST(OS%Restart_control,0)) then
-    call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-                      OS%restart_CSp, GV=OS%GV)
+    call save_MOM_restart(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, &
+        OS%grid, GV=OS%GV)
     call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
                               OS%dirs%restart_output_dir)
     if (OS%use_ice_shelf) then
       call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir)
     endif
-    call save_MOM6_internal_state(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time)
   endif
 
 end subroutine ocean_model_restart
@@ -758,16 +753,13 @@ subroutine ocean_model_save_restart(OS, Time, directory, filename_suffix)
   if (present(directory)) then ; restart_dir = directory
   else ; restart_dir = OS%dirs%restart_output_dir ; endif
 
-  call save_restart(restart_dir, Time, OS%grid, OS%restart_CSp, GV=OS%GV)
+  call save_MOM_restart(OS%MOM_CSp, restart_dir, Time, OS%grid, GV=OS%GV)
 
   call forcing_save_restart(OS%forcing_CSp, OS%grid, Time, restart_dir)
 
   if (OS%use_ice_shelf) then
     call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir)
   endif
-
-  call save_MOM6_internal_state(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time)
-
 end subroutine ocean_model_save_restart
 
 !> Initialize the public ocean type

--- a/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
+++ b/config_src/drivers/mct_cap/mom_ocean_model_mct.F90
@@ -14,7 +14,8 @@ module MOM_ocean_model_mct
 use MOM,                      only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
 use MOM,                      only : extract_surface_state, allocate_surface_state, finish_MOM_initialization
 use MOM,                      only : get_MOM_state_elements, MOM_state_is_synchronized
-use MOM,                      only : get_ocean_stocks, step_offline, save_MOM6_internal_state
+use MOM,                      only : get_ocean_stocks, step_offline
+use MOM,                      only : save_MOM_restart
 use MOM_coms,                 only : field_chksum
 use MOM_constants,            only : CELSIUS_KELVIN_OFFSET, hlf
 use MOM_diag_mediator,        only : diag_ctrl, enable_averages, disable_averaging
@@ -34,7 +35,6 @@ use MOM_get_input,            only : Get_MOM_Input, directories
 use MOM_grid,                 only : ocean_grid_type
 use MOM_io,                   only : close_file, file_exists, read_data, write_version_number
 use MOM_marine_ice,           only : iceberg_forces, iceberg_fluxes, marine_ice_init, marine_ice_CS
-use MOM_restart,              only : MOM_restart_CS, save_restart
 use MOM_string_functions,     only : uppercase
 use MOM_surface_forcing_mct,  only : surface_forcing_init, convert_IOB_to_fluxes
 use MOM_surface_forcing_mct,  only : convert_IOB_to_forces, ice_ocn_bnd_type_chksum
@@ -207,9 +207,6 @@ type, public :: ocean_state_type ;
     Waves => NULL()           !< A pointer to the surface wave control structure
   type(surface_forcing_CS), pointer :: &
     forcing_CSp => NULL()     !< A pointer to the MOM forcing control structure
-  type(MOM_restart_CS), pointer :: &
-    restart_CSp => NULL()     !< A pointer set to the restart control structure
-                              !! that will be used for MOM restart files.
   type(diag_ctrl), pointer :: &
     diag => NULL()            !< A pointer to the diagnostic regulatory structure
 end type ocean_state_type
@@ -271,7 +268,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
 
   OS%Time = Time_in
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &
-                      OS%restart_CSp, Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
+                      Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       input_restart_file=input_restart_file, &
                       diag_ptr=OS%diag, count_calls=.true., waves_CSp=OS%Waves)
   call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%C_p, &
@@ -575,7 +572,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   endif
 
   if (OS%nstep==0) then
-    call finish_MOM_initialization(OS%Time, OS%dirs, OS%MOM_CSp, OS%restart_CSp)
+    call finish_MOM_initialization(OS%Time, OS%dirs, OS%MOM_CSp)
   endif
 
   call disable_averaging(OS%diag)
@@ -689,35 +686,32 @@ subroutine ocean_model_restart(OS, timestamp, restartname)
       "restart files can only be created after the buoyancy forcing is applied.")
 
   if (present(restartname)) then
-    call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-          OS%restart_CSp, GV=OS%GV, filename=restartname)
+    call save_MOM_restart(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, &
+        OS%grid, GV=OS%GV, filename=restartname)
     call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
           OS%dirs%restart_output_dir) ! Is this needed?
     if (OS%use_ice_shelf) then
       call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, &
              OS%dirs%restart_output_dir)
     endif
-    call save_MOM6_internal_state(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time)
   else
     if (BTEST(OS%Restart_control,1)) then
-      call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-           OS%restart_CSp, .true., GV=OS%GV)
+      call save_MOM_restart(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, &
+          OS%grid, time_stamped=.true., GV=OS%GV)
       call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
            OS%dirs%restart_output_dir, .true.)
       if (OS%use_ice_shelf) then
         call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir, .true.)
       endif
-      call save_MOM6_internal_state(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, .true.)
     endif
     if (BTEST(OS%Restart_control,0)) then
-      call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-           OS%restart_CSp, GV=OS%GV)
+      call save_MOM_restart(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, &
+          OS%grid, GV=OS%GV)
       call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
            OS%dirs%restart_output_dir)
       if (OS%use_ice_shelf) then
         call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir)
       endif
-      call save_MOM6_internal_state(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time)
     endif
   endif
 
@@ -768,7 +762,7 @@ subroutine ocean_model_save_restart(OS, Time, directory, filename_suffix)
   if (present(directory)) then ; restart_dir = directory
   else ; restart_dir = OS%dirs%restart_output_dir ; endif
 
-  call save_restart(restart_dir, Time, OS%grid, OS%restart_CSp, GV=OS%GV)
+  call save_MOM_restart(OS%MOM_CSp, restart_dir, Time, OS%grid, GV=OS%GV)
 
   call forcing_save_restart(OS%forcing_CSp, OS%grid, Time, restart_dir)
 

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -14,7 +14,8 @@ module MOM_ocean_model_nuopc
 use MOM,                     only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
 use MOM,                     only : extract_surface_state, allocate_surface_state, finish_MOM_initialization
 use MOM,                     only : get_MOM_state_elements, MOM_state_is_synchronized
-use MOM,                     only : get_ocean_stocks, step_offline, save_MOM6_internal_state
+use MOM,                     only : get_ocean_stocks, step_offline
+use MOM,                     only : save_MOM_restart
 use MOM_coms,                only : field_chksum
 use MOM_constants,           only : CELSIUS_KELVIN_OFFSET, hlf
 use MOM_diag_mediator,       only : diag_ctrl, enable_averages, disable_averaging
@@ -34,7 +35,6 @@ use MOM_get_input,           only : Get_MOM_Input, directories
 use MOM_grid,                only : ocean_grid_type
 use MOM_io,                  only : close_file, file_exists, read_data, write_version_number
 use MOM_marine_ice,          only : iceberg_forces, iceberg_fluxes, marine_ice_init, marine_ice_CS
-use MOM_restart,             only : MOM_restart_CS, save_restart
 use MOM_string_functions,    only : uppercase
 use MOM_time_manager,        only : time_type, get_time, set_time, operator(>)
 use MOM_time_manager,        only : operator(+), operator(-), operator(*), operator(/)
@@ -214,9 +214,6 @@ type, public :: ocean_state_type ; private
     Waves => NULL()           !< A pointer to the surface wave control structure
   type(surface_forcing_CS), pointer :: &
     forcing_CSp => NULL()     !< A pointer to the MOM forcing control structure
-  type(MOM_restart_CS), pointer :: &
-    restart_CSp => NULL()     !< A pointer set to the restart control structure
-                              !! that will be used for MOM restart files.
   type(diag_ctrl), pointer :: &
     diag => NULL()            !< A pointer to the diagnostic regulatory structure
 end type ocean_state_type
@@ -281,7 +278,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
 
   OS%Time = Time_in
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &
-                      OS%restart_CSp, Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
+                      Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       input_restart_file=input_restart_file, &
                       diag_ptr=OS%diag, count_calls=.true., waves_CSp=OS%Waves)
   call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%C_p, &
@@ -407,7 +404,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
 
   ! MOM_wave_interface_init is called regardless of the value of USE_WAVES because
   ! it also initializes statistical waves.
-  call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag, OS%restart_CSp)
+  call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
 
   if (associated(OS%grid%Domain%maskmap)) then
     call initialize_ocean_public_type(OS%grid%Domain%mpp_domain, Ocean_sfc, &
@@ -608,7 +605,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   endif
 
   if (OS%nstep==0) then
-    call finish_MOM_initialization(OS%Time, OS%dirs, OS%MOM_CSp, OS%restart_CSp)
+    call finish_MOM_initialization(OS%Time, OS%dirs, OS%MOM_CSp)
   endif
 
   call disable_averaging(OS%diag)
@@ -730,36 +727,32 @@ subroutine ocean_model_restart(OS, timestamp, restartname, stoch_restartname, nu
       "restart files can only be created after the buoyancy forcing is applied.")
 
   if (present(restartname)) then
-    call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-         OS%restart_CSp, GV=OS%GV, filename=restartname, num_rest_files=num_rest_files)
+    call save_MOM_restart(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, &
+        OS%grid, GV=OS%GV, filename=restartname, num_rest_files=num_rest_files)
     call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
          OS%dirs%restart_output_dir) ! Is this needed?
     if (OS%use_ice_shelf) then
       call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, &
            OS%dirs%restart_output_dir)
     endif
-
-    call save_MOM6_internal_state(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time)
   else
     if (BTEST(OS%Restart_control,1)) then
-      call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-           OS%restart_CSp, .true., GV=OS%GV)
+      call save_MOM_restart(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, &
+          OS%grid, time_stamped=.true., GV=OS%GV)
       call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
-           OS%dirs%restart_output_dir, .true.)
+           OS%dirs%restart_output_dir, time_stamped=.true.)
       if (OS%use_ice_shelf) then
         call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir, .true.)
       endif
-      call save_MOM6_internal_state(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, .true.)
     endif
     if (BTEST(OS%Restart_control,0)) then
-      call save_restart(OS%dirs%restart_output_dir, OS%Time, OS%grid, &
-           OS%restart_CSp, GV=OS%GV)
+      call save_MOM_restart(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time, &
+          OS%grid, GV=OS%GV)
       call forcing_save_restart(OS%forcing_CSp, OS%grid, OS%Time, &
            OS%dirs%restart_output_dir)
       if (OS%use_ice_shelf) then
         call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir)
       endif
-      call save_MOM6_internal_state(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time)
     endif
   endif
   if (present(stoch_restartname)) then
@@ -814,16 +807,13 @@ subroutine ocean_model_save_restart(OS, Time, directory, filename_suffix)
   if (present(directory)) then ; restart_dir = directory
   else ; restart_dir = OS%dirs%restart_output_dir ; endif
 
-  call save_restart(restart_dir, Time, OS%grid, OS%restart_CSp, GV=OS%GV)
+  call save_MOM_restart(OS%MOM_CSp, restart_dir, Time, OS%grid, GV=OS%GV)
 
   call forcing_save_restart(OS%forcing_CSp, OS%grid, Time, restart_dir)
 
   if (OS%use_ice_shelf) then
     call ice_shelf_save_restart(OS%Ice_shelf_CSp, OS%Time, OS%dirs%restart_output_dir)
   endif
-
-  call save_MOM6_internal_start(OS%MOM_CSp, OS%dirs%restart_output_dir, OS%Time)
-
 end subroutine ocean_model_save_restart
 
 !> Initialize the public ocean type

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -31,7 +31,8 @@ program MOM6
   use MOM,                 only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
   use MOM,                 only : extract_surface_state, finish_MOM_initialization
   use MOM,                 only : get_MOM_state_elements, MOM_state_is_synchronized
-  use MOM,                 only : step_offline, save_MOM6_internal_state
+  use MOM,                 only : step_offline
+  use MOM,                 only : save_MOM_restart
   use MOM_coms,            only : Set_PElist
   use MOM_domains,         only : MOM_infra_init, MOM_infra_end, set_MOM_thread_affinity
   use MOM_ensemble_manager, only : ensemble_manager_init, get_ensemble_size
@@ -52,7 +53,6 @@ program MOM6
   use MOM_io,              only : file_exists, open_ASCII_file, close_file
   use MOM_io,              only : check_nml_error, io_infra_init, io_infra_end
   use MOM_io,              only : APPEND_FILE, READONLY_FILE
-  use MOM_restart,         only : MOM_restart_CS, save_restart
   use MOM_string_functions,only : uppercase
   use MOM_surface_forcing, only : set_forcing, forcing_save_restart
   use MOM_surface_forcing, only : surface_forcing_init, surface_forcing_CS
@@ -177,9 +177,6 @@ program MOM6
   logical                            :: override_shelf_fluxes !< If true, and shelf dynamics are active,
                                         !! the data_override feature is enabled (only for MOSAIC grid types)
   type(wave_parameters_cs),  pointer :: waves_CSp => NULL()
-  type(MOM_restart_CS),      pointer :: &
-    restart_CSp => NULL()     !< A pointer to the restart control structure
-                              !! that will be used for MOM restart files.
   type(diag_ctrl),           pointer :: &
     diag => NULL()            !< A pointer to the diagnostic regulatory structure
   !-----------------------------------------------------------------------
@@ -281,7 +278,7 @@ program MOM6
   if (segment_start_time_set) then
     ! In this case, the segment starts at a time fixed by ocean_solo.res
     Time = segment_start_time
-    call initialize_MOM(Time, Start_time, param_file, dirs, MOM_CSp, restart_CSp, &
+    call initialize_MOM(Time, Start_time, param_file, dirs, MOM_CSp, &
                         segment_start_time, offline_tracer_mode=offline_tracer_mode, &
                         diag_ptr=diag, tracer_flow_CSp=tracer_flow_CSp, ice_shelf_CSp=ice_shelf_CSp, &
                         waves_CSp=Waves_CSp)
@@ -289,7 +286,7 @@ program MOM6
     ! In this case, the segment starts at a time read from the MOM restart file
     ! or is left at Start_time by MOM_initialize.
     Time = Start_time
-    call initialize_MOM(Time, Start_time, param_file, dirs, MOM_CSp, restart_CSp, &
+    call initialize_MOM(Time, Start_time, param_file, dirs, MOM_CSp, &
                         offline_tracer_mode=offline_tracer_mode, diag_ptr=diag, &
                         tracer_flow_CSp=tracer_flow_CSp, ice_shelf_CSp=ice_shelf_CSp, waves_CSp=Waves_CSp)
   endif
@@ -473,7 +470,7 @@ program MOM6
     endif
 
     if (ns==1) then
-      call finish_MOM_initialization(Time, dirs, MOM_CSp, restart_CSp)
+      call finish_MOM_initialization(Time, dirs, MOM_CSp)
     endif
 
     ! This call steps the model over a time dt_forcing.
@@ -564,22 +561,19 @@ program MOM6
     if ((permit_incr_restart) .and. (fluxes%fluxes_used) .and. &
         (Time + (Time_step_ocean/2) > restart_time)) then
       if (BTEST(Restart_control,1)) then
-        call save_restart(dirs%restart_output_dir, Time, grid, &
-                          restart_CSp, .true., GV=GV)
+        call save_MOM_restart(MOM_CSp, dirs%restart_output_dir, Time, grid, &
+            time_stamped=.true., GV=GV)
         call forcing_save_restart(surface_forcing_CSp, grid, Time, &
                             dirs%restart_output_dir, .true.)
         if (use_ice_shelf) call ice_shelf_save_restart(ice_shelf_CSp, Time, &
                                     dirs%restart_output_dir, .true.)
-        call save_MOM6_internal_state(MOM_CSp, dirs%restart_output_dir, Time, .true.)
       endif
       if (BTEST(Restart_control,0)) then
-        call save_restart(dirs%restart_output_dir, Time, grid, &
-                          restart_CSp, GV=GV)
+        call save_MOM_restart(MOM_CSp, dirs%restart_output_dir, Time, grid, GV=GV)
         call forcing_save_restart(surface_forcing_CSp, grid, Time, &
                             dirs%restart_output_dir)
         if (use_ice_shelf) call ice_shelf_save_restart(ice_shelf_CSp, Time, &
                                     dirs%restart_output_dir)
-        call save_MOM6_internal_state(MOM_CSp, dirs%restart_output_dir, Time)
       endif
       restart_time = restart_time + restint
     endif
@@ -600,10 +594,9 @@ program MOM6
          "For conservation, the ocean restart files can only be "//&
          "created after the buoyancy forcing is applied.")
 
-    call save_restart(dirs%restart_output_dir, Time, grid, restart_CSp, GV=GV)
+    call save_MOM_restart(MOM_CSp, dirs%restart_output_dir, Time, grid, GV=GV)
     if (use_ice_shelf) call ice_shelf_save_restart(ice_shelf_CSp, Time, &
                                 dirs%restart_output_dir)
-    call save_MOM6_internal_state(MOM_CSp, dirs%restart_output_dir, Time)
 
     ! Write the ocean solo restart file.
     call write_ocean_solo_res(Time, Start_time, calendar_type, &

--- a/src/framework/MOM_get_input.F90
+++ b/src/framework/MOM_get_input.F90
@@ -11,7 +11,7 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : open_param_file, param_file_type
 use MOM_io, only : file_exists, close_file, slasher, ensembler
 use MOM_io, only : open_namelist_file, check_nml_error
-use posix, only : mkdir
+use posix, only : mkdir, stat, stat_buf
 
 implicit none ; private
 
@@ -55,6 +55,8 @@ subroutine get_MOM_input(param_file, dirs, check_params, default_input_filename,
   character(len=240) :: output_dir
   integer :: unit, io, ierr, valid_param_files
 
+  type(stat_buf) :: buf
+
   namelist /MOM_input_nml/ output_directory, input_filename, parameter_filename, &
                            restart_input_dir, restart_output_dir
 
@@ -97,7 +99,7 @@ subroutine get_MOM_input(param_file, dirs, check_params, default_input_filename,
 
     ! Create the RESTART directory if absent
     if (is_root_PE()) then
-      if (.not. file_exists(dirs%restart_output_dir)) then
+      if (stat(trim(dirs%restart_output_dir), buf) == -1) then
         ierr = mkdir(trim(dirs%restart_output_dir), int(o'700'))
         if (ierr == -1) &
           call MOM_error(FATAL, 'Restart directory could not be created.')

--- a/src/framework/posix.F90
+++ b/src/framework/posix.F90
@@ -52,6 +52,21 @@ interface
       !< Function return code
   end function chmod_posix
 
+  !> C interface to POSIX mkdir()
+  !! Users should use the Fortran-defined mkdir() function.
+  function mkdir_posix(path, mode) result(rc) bind(c, name="mkdir")
+    ! #include <sys/stat.h>
+    ! int mkdir(const char *path, mode_t mode);
+    import :: c_char, c_int
+
+    character(kind=c_char), dimension(*), intent(in) :: path
+      !< Zero-delimited file path
+    integer(kind=c_int), value, intent(in) :: mode
+      !< File permission to be assigned to file.
+    integer(kind=c_int) :: rc
+      !< Function return code
+  end function mkdir_posix
+
   !> C interface to POSIX signal()
   !! Users should use the Fortran-defined signal() function.
   function signal_posix(sig, func) result(handle) bind(c, name="signal")
@@ -239,6 +254,23 @@ function chmod(path, mode) result(rc)
   rc_c = chmod_posix(path//c_null_char, mode_c)
   rc = int(rc_c)
 end function chmod
+
+!> Create a file directory
+!!
+!! This creates a new directory named `path` with permissons set by `mode`.
+!! If successful, it returns zero.  Otherwise, it returns -1.
+function mkdir(path, mode) result(rc)
+  character(len=*), intent(in) :: path
+  integer, intent(in) :: mode
+  integer :: rc
+
+  integer(kind=c_int) :: mode_c
+  integer(kind=c_int) :: rc_c
+
+  mode_c = int(mode, kind=c_int)
+  rc_c = mkdir_posix(path//c_null_char, mode_c)
+  rc = int(rc_c)
+end function mkdir
 
 !> Create a signal handler `handle` to be called when `sig` is detected.
 !!

--- a/src/framework/posix.F90
+++ b/src/framework/posix.F90
@@ -13,6 +13,16 @@ use, intrinsic :: iso_c_binding, only : c_f_procpointer
 
 implicit none
 
+!> Container for file metadata from stat
+!!
+!! NOTE: This is currently just a placeholder containing fields, such as size,
+!! uid, mode, etc.  A readable Fortran type may be used in the future.
+type, bind(c) :: stat_buf
+  private
+  character(kind=c_char) :: state(SIZEOF_STAT_BUF)
+    !< Byte array containing file metadata
+end type stat_buf
+
 !> Container for the jump point buffer created by setjmp().
 !!
 !! The buffer typically contains the current register values, stack pointers,
@@ -66,6 +76,19 @@ interface
     integer(kind=c_int) :: rc
       !< Function return code
   end function mkdir_posix
+
+  !> C interface to POSIX stat()
+  !! Users should use the Fortran-defined stat() function.
+  function stat_posix(path, buf) result(rc) bind(c, name="stat")
+    import :: c_char, stat_buf, c_int
+
+    character(kind=c_char), dimension(*), intent(in) :: path
+      !< Pathname of a POSIX file
+    type(stat_buf), intent(in) :: buf
+      !< Information describing the file if it exists
+    integer(kind=c_int) :: rc
+      !< Function return code
+  end function
 
   !> C interface to POSIX signal()
   !! Users should use the Fortran-defined signal() function.
@@ -272,6 +295,27 @@ function mkdir(path, mode) result(rc)
   rc = int(rc_c)
 end function mkdir
 
+!> Get file status
+!!
+!! This obtains information about the named file and writes it to buf.
+!! If found, it returns zero.  Otherwise, it returns -1.
+function stat(path, buf) result(rc)
+  character(len=*), intent(in) :: path
+    !< Pathname of file to be inspected
+  type(stat_buf), intent(out) :: buf
+    !< Buffer containing information about the file if it exists
+    ! NOTE: Currently the contents of buf are not readable, but we could move
+    ! the contents into a readable Fortran type.
+  integer :: rc
+    !< Function return code
+
+  integer(kind=c_int) :: rc_c
+
+  rc_c = stat_posix(path//c_null_char, buf)
+
+  rc = int(rc_c)
+end function stat
+
 !> Create a signal handler `handle` to be called when `sig` is detected.
 !!
 !! If successful, the previous handler for `sig` is returned.  Otherwise,
@@ -391,6 +435,9 @@ function setjmp_missing(env) result(rc) bind(c)
   print '(a)', 'ERROR: setjmp() is not implemented in this build.'
   print '(a)', 'Recompile with autoconf or -DSETJMP_NAME=\"<symbol name>\".'
   error stop
+
+  ! NOTE: compilers may expect a return value, even if it is unreachable
+  rc = -1
 end function setjmp_missing
 
 !> Placeholder function for a missing or unconfigured longjmp
@@ -418,7 +465,7 @@ function sigsetjmp_missing(env, savesigs) result(rc) bind(c)
   print '(a)', 'Recompile with autoconf or -DSIGSETJMP_NAME=\"<symbol name>\".'
   error stop
 
-  ! NOTE: Compilers may expect a return value, even if it is unreachable
+  ! NOTE: compilers may expect a return value, even if it is unreachable
   rc = -1
 end function sigsetjmp_missing
 

--- a/src/framework/posix.h
+++ b/src/framework/posix.h
@@ -1,6 +1,12 @@
 #ifndef MOM6_POSIX_H_
 #define MOM6_POSIX_H_
 
+! STAT_BUF_SIZE should be set to sizeof(stat).
+! The default value is based on glibc 2.28.
+#ifndef SIZEOF_STAT_BUF
+#define SIZEOF_STAT_BUF 144
+#endif
+
 ! JMP_BUF_SIZE should be set to sizeof(jmp_buf).
 ! If unset, then use a typical glibc value (25 long ints)
 #ifndef SIZEOF_JMP_BUF

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -259,7 +259,7 @@ character*(7), parameter  :: EFACTOR_STRING   = "EFACTOR"       !< EFACTOR (base
 contains
 
 !> Initializes parameters related to MOM_wave_interface
-subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag, restart_CSp)
+subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
   type(time_type), target, intent(in)    :: Time       !< Model time
   type(ocean_grid_type),   intent(inout) :: G          !< Grid structure
   type(verticalGrid_type), intent(in)    :: GV         !< Vertical grid structure
@@ -267,7 +267,6 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag, restar
   type(param_file_type),   intent(in)    :: param_file !< Input parameter structure
   type(wave_parameters_CS), pointer      :: CS         !< Wave parameter control structure
   type(diag_ctrl), target, intent(inout) :: diag       !< Diagnostic Pointer
-  type(MOM_restart_CS), optional, pointer:: restart_CSp!< Restart control structure
 
   ! Local variables
   character(len=40)  :: mdl = "MOM_wave_interface" !< This module's name.


### PR DESCRIPTION
This PR refactors the implementation of `save_MOM6_internal_state` by also including the MOM6 `save_restart` function, and renaming it to `save_MOM_restart`, which now acts as a generic placeholder for all MOM restart operations.

The `restart_CS` is now wholly contained within the top-level MOM control structure (usually `MOM_CS`) and all restart operations must be routed through `MOM_CS`.

This PR also includes a commit which creates the restart directory (usually `RESTART`) if it is missing.