### PR TITLE
Correct diagnostic coordinate interpolation scheme

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -263,7 +263,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
       param_name = create_coord_param(param_prefix, "INTERP_SCHEME", param_suffix)
       string2 = 'PPM_H4' ! Default for diagnostics
     endif
-    call get_param(param_file, mdl, "INTERPOLATION_SCHEME", string, &
+    call get_param(param_file, mdl, param_name, string, &
                  "This sets the interpolation scheme to use to "//&
                  "determine the new grid. These parameters are "//&
                  "only relevant when REGRIDDING_COORDINATE_MODE is "//&


### PR DESCRIPTION
The interpolation scheme for state-dependent diagnostic coordinates was incorrectly registering as the same parameter as for the main model ("INTERPOLATION_SCHEME"). This meant it was never possible to change the diagnostics vertical interpolation scheme from the default (which was not the same as the main model).

This fix registers the generated parameter name which was always computed but not used. A typical example of the generated parameter is "DIAG_COORD_INTERP_SCHEME_RHO2".

Affects these doc files:
- ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.all
- ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
- ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
- ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
- ice_ocean_SIS2/OM_1deg/MOM_parameter_doc.all

The fix removes one of the many warnings we've been ignoring for a long time.