### PR TITLE
+*Non-Boussinesq Rossby_front initialization

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -379,7 +379,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
 !            " \t baroclinic_zone - an analytic baroclinic zone. \n"//&
 
       ! Check for incompatible THICKNESS_CONFIG and TS_CONFIG settings
-      if (.not.convert) then ; select case (trim(config))
+      if (new_sim .and. (.not.convert)) then ; select case (trim(config))
         case ("DOME2D", "ISOMIP", "adjustment2d", "baroclinic_zone", "sloshing", &
               "seamount", "dumbbell", "SCM_CVMix_tests", "dense")
           call MOM_error(FATAL, "TS_CONFIG = "//trim(config)//" does not work with thicknesses "//&


### PR DESCRIPTION
  Revised the Rossby_front initialization routines to work directly in thickness units and added completely separate algorithms to initialize the Rossby_front thicknesses and velocities consistently when the Boussinesq approximation is not being made.

   To accommodate this change, error handling was added to detect when the THICKNESS_CONFIG and TS_CONFIG settings are incompatible.  As a part of this commit the units of the h arguments to Rossby_front_initialize_thickness and Rossby_front_initialize_temperature_salinity are changed. MAXIMUM_DEPTH is now read in and rescaled via get_param in the Rossby_front routines rather than simply being pulled from the ocean grid type.

  There are are also changes to the units of 13 internal variables and 14 new internal variables in the Rossby_front routines.

  Also pass max_depth as a new argument the internal function Hml to replace the use of G%max_depth and permit simpler changes to the units being worked with.

  All answers are bitwise identical in Boussinesq mode, but there are substantial changes (improvements?) in answers in non-Boussinesq mode that are now independent of the value of the Boussinesq reference density.  There are changes to the units of arguments to two publicly visible routines.