### PR TITLE
+*Ignore SURFACE_ANSWER_DATE when non-Boussinesq

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2103,7 +2103,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call get_param(param_file, "MOM", "CALC_RHO_FOR_SEA_LEVEL", CS%calc_rho_for_sea_lev, &
                  "If true, the in-situ density is used to calculate the "//&
                  "effective sea level that is returned to the coupler. If false, "//&
-                 "the Boussinesq parameter RHO_0 is used.", default=.false.)
+                 "the Boussinesq parameter RHO_0 is used.", default=non_Bous)
   call get_param(param_file, "MOM", "ENABLE_THERMODYNAMICS", use_temperature, &
                  "If true, Temperature and salinity are used as state "//&
                  "variables.", default=.true.)
@@ -2892,8 +2892,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     endif
   endif
 
-  ! Allocate any derived equation of state fields.
-  if (use_temperature .and. .not.(GV%Boussinesq .or. GV%semi_Boussinesq)) then
+  ! Allocate any derived densities or other equation of state derived fields.
+  if (.not.(GV%Boussinesq .or. GV%semi_Boussinesq)) then
     allocate(CS%tv%SpV_avg(isd:ied,jsd:jed,nz), source=0.0)
     CS%tv%valid_SpV_halo = -1  ! This array does not yet have any valid data.
   endif


### PR DESCRIPTION
  Ignore SURFACE_ANSWER_DATE in non-Boussinesq mode and always allocate tv%SpV_avg in fully non-Boussinesq mode, setting it to the inverse of the layer densities in calc_derived_thermo() if there is no equation of state.  Also when in fully non-Boussinesq mode cancelled out some rescaling factors in dz_to_thickness_EOS and dz_to_thickness_tv.  Also revised dz_to_thickness_simple in non-Boussinesq and non-layered mode to use RHO_KV_CONVERT instead of RHO_0 to rescale vertical distances to thicknesses.  Also set the default value of CALC_RHO_FOR_SEA_LEVEL to true when fully non-Boussinesq.  All Boussinesq answers are bitwise identical, but some non-Boussinesq answers do change and become less dependent on the Boussinesq reference density.  Because SURFACE_ANSWER_DATE is no longer being used in non-Boussinesq mode, is is no longer being logged in the MOM_parameter_doc files for these experiments.