### PR TITLE
*+Non-Boussinesq form of mixedlayer_restrat

### DIFF
--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -19,7 +19,7 @@ use MOM_restart,       only : register_restart_field, query_initialized, MOM_res
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type, get_thickness_units
-use MOM_EOS,           only : calculate_density, EOS_domain
+use MOM_EOS,           only : calculate_density, calculate_spec_vol, EOS_domain
 
 implicit none ; private
 
@@ -86,15 +86,17 @@ type, public :: mixedlayer_restrat_CS ; private
 
   type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the
                                    !! timing of diagnostic output.
-  logical :: use_stanley_ml        !< If true, use the Stanley parameterization of SGS T variance
-  real    :: ustar_min             !< A minimum value of ustar to avoid numerical problems [Z T-1 ~> m s-1]
+  logical :: use_Stanley_ML        !< If true, use the Stanley parameterization of SGS T variance
+  real    :: ustar_min             !< A minimum value of ustar in thickness units to avoid numerical
+                                   !! problems [H T-1 ~> m s-1 or kg m-2 s-1]
   real    :: Kv_restrat            !< A viscosity that sets a floor on the momentum mixing rate
-                                   !! during restratification [Z2 T-1 ~> m2 s-1]
+                                   !! during restratification, rescaled into thickness-based
+                                   !! units [H2 T-1 ~> m2 s-1 or kg2 m-4 s-1]
 
   real, dimension(:,:), allocatable :: &
          MLD_filtered, &           !< Time-filtered MLD [H ~> m or kg m-2]
          MLD_filtered_slow, &      !< Slower time-filtered MLD [H ~> m or kg m-2]
-         wpup_filtered             !< Time-filtered vertical momentum flux [Z2 T-2 ~> m2 s-2]
+         wpup_filtered             !< Time-filtered vertical momentum flux [H L T-2 ~> m2 s-2 or kg m-1 s-2]
 
   !>@{
   !! Diagnostic identifier
@@ -173,7 +175,7 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
   type(mech_forcing),                         intent(in)    :: forces !< A structure with the driving mechanical forces
   real,                                       intent(in)    :: dt     !< Time increment [T ~> s]
   real, dimension(:,:),                       pointer       :: MLD_in !< Mixed layer depth provided by the
-                                                                      !! PBL scheme [Z ~> m] (not H)
+                                                                      !! PBL scheme [Z ~> m]
   type(VarMix_CS),                            intent(in)    :: VarMix !< Variable mixing control structure
   type(mixedlayer_restrat_CS),                intent(inout) :: CS     !< Module control structure
 
@@ -184,27 +186,37 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
     h_avail               ! The volume available for diffusion out of each face of each
                           ! sublayer of the mixed layer, divided by dt [H L2 T-1 ~> m3 s-1 or kg s-1].
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    U_star_2d, &          ! The wind friction velocity, calculated using
+    U_star_2d, &          ! The wind friction velocity in thickness-based units, calculated using
                           ! the Boussinesq reference density or the time-evolving surface density
-                          ! in non-Boussinesq mode [Z T-1 ~> m s-1]
+                          ! in non-Boussinesq mode [H T-1 ~> m s-1 or kg m-2 s-1]
     MLD_fast, &           ! Mixed layer depth actually used in MLE restratification parameterization [H ~> m or kg m-2]
     htot_fast, &          ! The sum of the thicknesses of layers in the mixed layer [H ~> m or kg m-2]
-    Rml_av_fast, &        ! g_Rho0 times the average mixed layer density [L2 Z-1 T-2 ~> m s-2]
+    Rml_av_fast, &        ! Negative g_Rho0 times the average mixed layer density or G_Earth
+                          ! times the average specific volume [L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2]
     MLD_slow, &           ! Mixed layer depth actually used in MLE restratification parameterization [H ~> m or kg m-2]
     htot_slow, &          ! The sum of the thicknesses of layers in the mixed layer [H ~> m or kg m-2]
-    Rml_av_slow           ! g_Rho0 times the average mixed layer density [L2 Z-1 T-2 ~> m s-2]
-  real :: g_Rho0          ! G_Earth/Rho0 [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
+    Rml_av_slow           ! Negative g_Rho0 times the average mixed layer density or G_Earth
+                          ! times the average specific volume [L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2]
+  real :: g_Rho0          ! G_Earth/Rho0 times a thickness conversion factor
+                          ! [L2 H-1 T-2 R-1 ~> m4 s-2 kg-1 or m7 s-2 kg-2]
   real :: rho_ml(SZI_(G)) ! Potential density relative to the surface [R ~> kg m-3]
+  real :: rml_int_fast(SZI_(G)) ! The integral of density over the mixed layer depth [R H ~> kg m-2 or kg2 m-3]
+  real :: rml_int_slow(SZI_(G)) ! The integral of density over the mixed layer depth [R H ~> kg m-2 or kg2 m-3]
+  real :: SpV_ml(SZI_(G)) ! Specific volume evaluated at the surface pressure [R-1 ~> m3 kg-1]
+  real :: SpV_int_fast(SZI_(G)) ! Specific volume integrated through the mixed layer [H R-1 ~> m4 kg-1 or m]
+  real :: SpV_int_slow(SZI_(G)) ! Specific volume integrated through the mixed layer [H R-1 ~> m4 kg-1 or m]
+  real :: H_mld(SZI_(G))  ! The thickness of water within the topmost MLD_in of height [H ~> m or kg m-2]
+  real :: MLD_rem(SZI_(G))  ! The vertical extent of the MLD_in that has not yet been accounted for [Z ~> m]
   real :: p0(SZI_(G))     ! A pressure of 0 [R L2 T-2 ~> Pa]
 
-  real :: h_vel           ! htot interpolated onto velocity points [Z ~> m] (not H).
+  real :: h_vel           ! htot interpolated onto velocity points [H ~> m or kg m-2]
   real :: absf            ! absolute value of f, interpolated to velocity points [T-1 ~> s-1]
-  real :: u_star          ! surface friction velocity, interpolated to velocity points [Z T-1 ~> m s-1].
+  real :: u_star          ! surface friction velocity, interpolated to velocity points and recast into
+                          ! thickness-based units [H T-1 ~> m s-1 or kg m-2 s-1].
   real :: mom_mixrate     ! rate at which momentum is homogenized within mixed layer [T-1 ~> s-1]
   real :: timescale       ! mixing growth timescale [T ~> s]
   real :: h_min           ! The minimum layer thickness [H ~> m or kg m-2].  h_min could be 0.
   real :: h_neglect       ! tiny thickness usually lost in roundoff so can be neglected [H ~> m or kg m-2]
-  real :: dz_neglect      ! A tiny thickness that is usually lost in roundoff so can be neglected [Z ~> m]
   real :: I4dt            ! 1/(4 dt) [T-1 ~> s-1]
   real :: Ihtot,Ihtot_slow! Inverses of the total mixed layer thickness [H-1 ~> m-1 or m2 kg-1]
   real :: a(SZK_(GV))     ! A non-dimensional value relating the overall flux
@@ -256,9 +268,12 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
   if (.not. allocated(VarMix%Rd_dx_h) .and. CS%front_length > 0.) &
     call MOM_error(FATAL, "mixedlayer_restrat_OM4: "// &
          "The resolution argument, Rd/dx, was not associated.")
+  if (CS%use_Stanley_ML .and. .not.GV%Boussinesq) call MOM_error(FATAL, &
+       "MOM_mixedlayer_restrat: The Stanley parameterization is not"//&
+       "available without the Boussinesq approximation.")
 
   ! Extract the friction velocity from the forcing type.
-  call find_ustar(forces, tv, U_star_2d, G, GV, US, halo=1)
+  call find_ustar(forces, tv, U_star_2d, G, GV, US, halo=1, H_T_units=.true.)
 
   if (CS%MLE_density_diff > 0.) then ! We need to calculate a mixed layer depth, MLD.
     !! TODO: use derivatives and mid-MLD pressure. Currently this is sigma-0. -AJA
@@ -304,9 +319,30 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
       enddo
     enddo ! j-loop
   elseif (CS%MLE_use_PBL_MLD) then
-    do j = js-1, je+1 ; do i = is-1, ie+1
-      MLD_fast(i,j) = (CS%MLE_MLD_stretch * GV%Z_to_H) * MLD_in(i,j)
-    enddo ; enddo
+    if (GV%Boussinesq .or. (.not.allocated(tv%SpV_avg))) then
+      do j = js-1, je+1 ; do i = is-1, ie+1
+        MLD_fast(i,j) = CS%MLE_MLD_stretch * GV%Z_to_H * MLD_in(i,j)
+      enddo ; enddo
+    else  ! The fully non-Boussinesq conversion between height in MLD_in and thickness.
+      do j=js-1,je+1
+        do i=is-1,ie+1 ; MLD_rem(i) = MLD_in(i,j) ; H_mld(i) = 0.0 ; enddo
+        do k=1,nz
+          keep_going = .false.
+          do i=is-1,ie+1 ; if (MLD_rem(i) > 0.0) then
+            if (MLD_rem(i) > GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)) then
+              H_mld(i) = H_mld(i) + h(i,j,k)
+              MLD_rem(i) = MLD_rem(i) - GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)
+              keep_going = .true.
+            else
+              H_mld(i) = H_mld(i) + GV%RZ_to_H * MLD_rem(i) / tv%SpV_avg(i,j,k)
+              MLD_rem(i) = 0.0
+            endif
+          endif ; enddo
+          if (.not.keep_going) exit
+        enddo
+        do i=is-1,ie+1 ; MLD_fast(i,j) = CS%MLE_MLD_stretch * H_mld(i) ; enddo
+      enddo
+    endif
   else
     call MOM_error(FATAL, "mixedlayer_restrat_OM4: "// &
          "No MLD to use for MLE parameterization.")
@@ -315,7 +351,7 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
   ! Apply time filter (to remove diurnal cycle)
   if (CS%MLE_MLD_decay_time>0.) then
     if (CS%debug) then
-      call hchksum(CS%MLD_filtered, 'mixed_layer_restrat: MLD_filtered', G%HI, haloshift=1, scale=GV%H_to_m)
+      call hchksum(CS%MLD_filtered, 'mixed_layer_restrat: MLD_filtered', G%HI, haloshift=1, scale=GV%H_to_mks)
       call hchksum(MLD_in, 'mixed_layer_restrat: MLD in', G%HI, haloshift=1, scale=US%Z_to_m)
     endif
     aFac = CS%MLE_MLD_decay_time / ( dt + CS%MLE_MLD_decay_time )
@@ -332,8 +368,8 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
   ! Apply slower time filter (to remove seasonal cycle) on already filtered MLD_fast
   if (CS%MLE_MLD_decay_time2>0.) then
     if (CS%debug) then
-      call hchksum(CS%MLD_filtered_slow,'mixed_layer_restrat: MLD_filtered_slow',G%HI,haloshift=1,scale=GV%H_to_m)
-      call hchksum(MLD_fast,'mixed_layer_restrat: MLD fast',G%HI,haloshift=1,scale=GV%H_to_m)
+      call hchksum(CS%MLD_filtered_slow, 'mixed_layer_restrat: MLD_filtered_slow', G%HI, haloshift=1, scale=GV%H_to_mks)
+      call hchksum(MLD_fast, 'mixed_layer_restrat: MLD fast', G%HI, haloshift=1, scale=GV%H_to_mks)
     endif
     aFac = CS%MLE_MLD_decay_time2 / ( dt + CS%MLE_MLD_decay_time2 )
     bFac = dt / ( dt + CS%MLE_MLD_decay_time2 )
@@ -353,9 +389,8 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
   uDml(:) = 0.0 ; vDml(:) = 0.0
   uDml_slow(:) = 0.0 ; vDml_slow(:) = 0.0
   I4dt = 0.25 / dt
-  g_Rho0 = GV%g_Earth / GV%Rho0
+  g_Rho0 = GV%H_to_Z * GV%g_Earth / GV%Rho0
   h_neglect = GV%H_subroundoff
-  dz_neglect = GV%H_subroundoff*GV%H_to_Z
   if (CS%front_length>0.) then
     res_upscale = .true.
     I_LFront = 1. / CS%front_length
@@ -366,58 +401,106 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
   p0(:) = 0.0
   EOSdom(:) = EOS_domain(G%HI, halo=1)
   !$OMP parallel default(shared) private(rho_ml,h_vel,u_star,absf,mom_mixrate,timescale, &
-  !$OMP                                line_is_empty, keep_going,res_scaling_fac,      &
+  !$OMP                                SpV_ml,SpV_int_fast,SpV_int_slow,Rml_int_fast,Rml_int_slow, &
+  !$OMP                                line_is_empty,keep_going,res_scaling_fac, &
   !$OMP                                a,IhTot,b,Ihtot_slow,zpb,hAtVel,zpa,dh)         &
   !$OMP                        firstprivate(uDml,vDml,uDml_slow,vDml_slow)
-  !$OMP do
-  do j=js-1,je+1
-    do i=is-1,ie+1
-      htot_fast(i,j) = 0.0 ; Rml_av_fast(i,j) = 0.0
-      htot_slow(i,j) = 0.0 ; Rml_av_slow(i,j) = 0.0
-    enddo
-    keep_going = .true.
-    do k=1,nz
-      do i=is-1,ie+1
-        h_avail(i,j,k) = max(I4dt*G%areaT(i,j)*(h(i,j,k)-GV%Angstrom_H),0.0)
-      enddo
-      if (keep_going) then
-        if (CS%use_Stanley_ML) then
-          call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, tv%varT(:,j,k), covTS, varS, &
-            rho_ml(:), tv%eqn_of_state, EOSdom)
-        else
-          call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, rho_ml(:), tv%eqn_of_state, EOSdom)
-        endif
-        line_is_empty = .true.
-        do i=is-1,ie+1
-          if (htot_fast(i,j) < MLD_fast(i,j)) then
-            dh = min( h(i,j,k), MLD_fast(i,j)-htot_fast(i,j) )
-            Rml_av_fast(i,j) = Rml_av_fast(i,j) + dh*rho_ml(i)
-            htot_fast(i,j) = htot_fast(i,j) + dh
-            line_is_empty = .false.
-          endif
-          if (htot_slow(i,j) < MLD_slow(i,j)) then
-            dh = min( h(i,j,k), MLD_slow(i,j)-htot_slow(i,j) )
-            Rml_av_slow(i,j) = Rml_av_slow(i,j) + dh*rho_ml(i)
-            htot_slow(i,j) = htot_slow(i,j) + dh
-            line_is_empty = .false.
-          endif
-        enddo
-        if (line_is_empty) keep_going=.false.
-      endif
-    enddo
 
-    do i=is-1,ie+1
-      Rml_av_fast(i,j) = -(g_Rho0*Rml_av_fast(i,j)) / (htot_fast(i,j) + h_neglect)
-      Rml_av_slow(i,j) = -(g_Rho0*Rml_av_slow(i,j)) / (htot_slow(i,j) + h_neglect)
+  if (GV%Boussinesq .or. GV%semi_Boussinesq) then
+    !$OMP do
+    do j=js-1,je+1
+      do i=is-1,ie+1
+        htot_fast(i,j) = 0.0 ; Rml_int_fast(i) = 0.0
+        htot_slow(i,j) = 0.0 ; Rml_int_slow(i) = 0.0
+      enddo
+      keep_going = .true.
+      do k=1,nz
+        do i=is-1,ie+1
+          h_avail(i,j,k) = max(I4dt*G%areaT(i,j)*(h(i,j,k)-GV%Angstrom_H),0.0)
+        enddo
+        if (keep_going) then
+          if (CS%use_Stanley_ML) then
+            call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, tv%varT(:,j,k), covTS, varS, &
+                                   rho_ml(:), tv%eqn_of_state, EOSdom)
+          else
+            call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, rho_ml(:), tv%eqn_of_state, EOSdom)
+          endif
+          line_is_empty = .true.
+          do i=is-1,ie+1
+            if (htot_fast(i,j) < MLD_fast(i,j)) then
+              dh = min( h(i,j,k), MLD_fast(i,j)-htot_fast(i,j) )
+              Rml_int_fast(i) = Rml_int_fast(i) + dh*rho_ml(i)
+              htot_fast(i,j) = htot_fast(i,j) + dh
+              line_is_empty = .false.
+            endif
+            if (htot_slow(i,j) < MLD_slow(i,j)) then
+              dh = min( h(i,j,k), MLD_slow(i,j)-htot_slow(i,j) )
+              Rml_int_slow(i) = Rml_int_slow(i) + dh*rho_ml(i)
+              htot_slow(i,j) = htot_slow(i,j) + dh
+              line_is_empty = .false.
+            endif
+          enddo
+          if (line_is_empty) keep_going=.false.
+        endif
+      enddo
+
+      do i=is-1,ie+1
+        Rml_av_fast(i,j) = -(g_Rho0*Rml_int_fast(i)) / (htot_fast(i,j) + h_neglect)
+        Rml_av_slow(i,j) = -(g_Rho0*Rml_int_slow(i)) / (htot_slow(i,j) + h_neglect)
+      enddo
     enddo
-  enddo
+  else  ! This is only used in non-Boussinesq mode.
+    !$OMP do
+    do j=js-1,je+1
+      do i=is-1,ie+1
+        htot_fast(i,j) = 0.0 ; SpV_int_fast(i) = 0.0
+        htot_slow(i,j) = 0.0 ; SpV_int_slow(i) = 0.0
+      enddo
+      keep_going = .true.
+      do k=1,nz
+        do i=is-1,ie+1
+          h_avail(i,j,k) = max(I4dt*G%areaT(i,j)*(h(i,j,k)-GV%Angstrom_H),0.0)
+        enddo
+        if (keep_going) then
+          ! if (CS%use_Stanley_ML) then  ! This is not implemented yet in the EoS code.
+          !   call calculate_spec_vol(tv%T(:,j,k), tv%S(:,j,k), p0, tv%varT(:,j,k), covTS, varS, &
+          !                          rho_ml(:), tv%eqn_of_state, EOSdom)
+          ! else
+            call calculate_spec_vol(tv%T(:,j,k), tv%S(:,j,k), p0, SpV_ml, tv%eqn_of_state, EOSdom)
+          ! endif
+          line_is_empty = .true.
+          do i=is-1,ie+1
+            if (htot_fast(i,j) < MLD_fast(i,j)) then
+              dh = min( h(i,j,k), MLD_fast(i,j)-htot_fast(i,j) )
+              SpV_int_fast(i) = SpV_int_fast(i) + dh*SpV_ml(i)
+              htot_fast(i,j) = htot_fast(i,j) + dh
+              line_is_empty = .false.
+            endif
+            if (htot_slow(i,j) < MLD_slow(i,j)) then
+              dh = min( h(i,j,k), MLD_slow(i,j)-htot_slow(i,j) )
+              SpV_int_slow(i) = SpV_int_slow(i) + dh*SpV_ml(i)
+              htot_slow(i,j) = htot_slow(i,j) + dh
+              line_is_empty = .false.
+            endif
+          enddo
+          if (line_is_empty) keep_going=.false.
+        endif
+      enddo
+
+      ! Convert the vertically integrated specific volume into a positive variable with units of density.
+      do i=is-1,ie+1
+        Rml_av_fast(i,j) = (GV%H_to_RZ*GV%g_Earth * SpV_int_fast(i)) / (htot_fast(i,j) + h_neglect)
+        Rml_av_slow(i,j) = (GV%H_to_RZ*GV%g_Earth * SpV_int_slow(i)) / (htot_slow(i,j) + h_neglect)
+      enddo
+    enddo
+  endif
 
   if (CS%debug) then
-    call hchksum(h,'mixed_layer_restrat: h', G%HI, haloshift=1, scale=GV%H_to_m)
-    call hchksum(U_star_2d, 'mixed_layer_restrat: u*', G%HI, haloshift=1, scale=US%Z_to_m*US%s_to_T)
-    call hchksum(MLD_fast,'mixed_layer_restrat: MLD', G%HI, haloshift=1, scale=GV%H_to_m)
-    call hchksum(Rml_av_fast,'mixed_layer_restrat: rml', G%HI, haloshift=1, &
-                 scale=US%m_to_Z*US%L_T_to_m_s**2)
+    call hchksum(h, 'mixed_layer_restrat: h', G%HI, haloshift=1, scale=GV%H_to_mks)
+    call hchksum(U_star_2d, 'mixed_layer_restrat: u*', G%HI, haloshift=1, scale=GV%H_to_m*US%s_to_T)
+    call hchksum(MLD_fast, 'mixed_layer_restrat: MLD', G%HI, haloshift=1, scale=GV%H_to_mks)
+    call hchksum(Rml_av_fast, 'mixed_layer_restrat: rml', G%HI, haloshift=1, &
+                 scale=GV%m_to_H*US%L_T_to_m_s**2)
   endif
 
 ! TO DO:
@@ -437,34 +520,34 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
 
     ! peak ML visc: u_star * von_Karman * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2
-    h_vel = 0.5*((htot_fast(i,j) + htot_fast(i+1,j)) + h_neglect) * GV%H_to_Z
+    h_vel = 0.5*((htot_fast(i,j) + htot_fast(i+1,j)) + h_neglect)
 
     ! NOTE: growth_time changes answers on some systems, see below.
-    ! timescale = growth_time(u_star, h_vel, absf, dz_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef)
+    ! timescale = growth_time(u_star, h_vel, absf, h_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef)
 
     mom_mixrate = vonKar_x_pi2*u_star**2 / &
-                  (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
+                  (absf*h_vel**2 + 4.0*(h_vel+h_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
     timescale = timescale * CS%ml_restrat_coef
 
     if (res_upscale) timescale = timescale * res_scaling_fac
     uDml(I) = timescale * G%OBCmaskCu(I,j)*G%dyCu(I,j)*G%IdxCu(I,j) * &
-        (Rml_av_fast(i+1,j)-Rml_av_fast(i,j)) * (h_vel**2 * GV%Z_to_H)
+        (Rml_av_fast(i+1,j)-Rml_av_fast(i,j)) * (h_vel**2)
 
     ! As above but using the slow filtered MLD
-    h_vel = 0.5*((htot_slow(i,j) + htot_slow(i+1,j)) + h_neglect) * GV%H_to_Z
+    h_vel = 0.5*((htot_slow(i,j) + htot_slow(i+1,j)) + h_neglect)
 
     ! NOTE: growth_time changes answers on some systems, see below.
-    ! timescale = growth_time(u_star, h_vel, absf, dz_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef2)
+    ! timescale = growth_time(u_star, h_vel, absf, h_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef2)
 
     mom_mixrate = vonKar_x_pi2*u_star**2 / &
-                  (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
+                  (absf*h_vel**2 + 4.0*(h_vel+h_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
     timescale = timescale * CS%ml_restrat_coef2
 
     if (res_upscale) timescale = timescale * res_scaling_fac
     uDml_slow(I) = timescale * G%OBCmaskCu(I,j)*G%dyCu(I,j)*G%IdxCu(I,j) * &
-        (Rml_av_slow(i+1,j)-Rml_av_slow(i,j)) * (h_vel**2 * GV%Z_to_H)
+        (Rml_av_slow(i+1,j)-Rml_av_slow(i,j)) * (h_vel**2)
 
     if (uDml(I) + uDml_slow(I) == 0.) then
       do k=1,nz ; uhml(I,j,k) = 0.0 ; enddo
@@ -524,34 +607,34 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, MLD_in, VarMix,
 
     ! peak ML visc: u_star * von_Karman * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2
-    h_vel = 0.5*((htot_fast(i,j) + htot_fast(i,j+1)) + h_neglect) * GV%H_to_Z
+    h_vel = 0.5*((htot_fast(i,j) + htot_fast(i,j+1)) + h_neglect)
 
     ! NOTE: growth_time changes answers on some systems, see below.
-    ! timescale = growth_time(u_star, h_vel, absf, dz_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef)
+    ! timescale = growth_time(u_star, h_vel, absf, h_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef)
 
     mom_mixrate = vonKar_x_pi2*u_star**2 / &
-                  (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
+                  (absf*h_vel**2 + 4.0*(h_vel+h_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
     timescale = timescale * CS%ml_restrat_coef
 
     if (res_upscale) timescale = timescale * res_scaling_fac
     vDml(i) = timescale * G%OBCmaskCv(i,J)*G%dxCv(i,J)*G%IdyCv(i,J) * &
-        (Rml_av_fast(i,j+1)-Rml_av_fast(i,j)) * (h_vel**2 * GV%Z_to_H)
+        (Rml_av_fast(i,j+1)-Rml_av_fast(i,j)) * (h_vel**2)
 
     ! As above but using the slow filtered MLD
-    h_vel = 0.5*((htot_slow(i,j) + htot_slow(i,j+1)) + h_neglect) * GV%H_to_Z
+    h_vel = 0.5*((htot_slow(i,j) + htot_slow(i,j+1)) + h_neglect)
 
     ! NOTE: growth_time changes answers on some systems, see below.
-    ! timescale = growth_time(u_star, h_vel, absf, dz_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef2)
+    ! timescale = growth_time(u_star, h_vel, absf, h_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef2)
 
     mom_mixrate = vonKar_x_pi2*u_star**2 / &
-                  (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
+                  (absf*h_vel**2 + 4.0*(h_vel+h_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
     timescale = timescale * CS%ml_restrat_coef2
 
     if (res_upscale) timescale = timescale * res_scaling_fac
     vDml_slow(i) = timescale * G%OBCmaskCv(i,J)*G%dxCv(i,J)*G%IdyCv(i,J) * &
-        (Rml_av_slow(i,j+1)-Rml_av_slow(i,j)) * (h_vel**2 * GV%Z_to_H)
+        (Rml_av_slow(i,j+1)-Rml_av_slow(i,j)) * (h_vel**2)
 
     if (vDml(i) + vDml_slow(i) == 0.) then
       do k=1,nz ; vhml(i,J,k) = 0.0 ; enddo
@@ -710,31 +793,40 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
   real :: vol_dt_avail(SZI_(G),SZJ_(G),SZK_(GV)) ! The volume available for exchange out of each face of
                           ! each layer, divided by dt [H L2 T-1 ~> m3 s-1 or kg s-1]
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    little_h, &           ! "Little h" representing active mixing layer depth [Z ~> m]
-    big_H, &              ! "Big H" representing the mixed layer depth [Z ~> m]
+    little_h, &           ! "Little h" representing active mixing layer depth [H ~> m or kg m-2]
+    big_H, &              ! "Big H" representing the mixed layer depth [H ~> m or kg m-2]
     htot, &               ! The sum of the thicknesses of layers in the mixed layer [H ~> m or kg m-2]
-    buoy_av, &            ! g_Rho0 times the average mixed layer density [L2 Z-1 T-2 ~> m s-2]
-    wpup                  ! Turbulent vertical momentum [ ????? ~> m2 s-2]
+    buoy_av, &            ! g_Rho0 times the average mixed layer density or G_Earth
+                          ! times the average specific volume [L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2]
+    wpup                  ! Turbulent vertical momentum [L H T-2 ~> m2 s-2 or kg m-1 s-2]
   real :: uDml_diag(SZIB_(G),SZJ_(G))  ! A 2D copy of uDml for diagnostics [H L2 T-1 ~> m3 s-1 or kg s-1]
   real :: vDml_diag(SZI_(G),SZJB_(G))  ! A 2D copy of vDml for diagnostics [H L2 T-1 ~> m3 s-1 or kg s-1]
   real :: U_star_2d(SZI_(G),SZJ_(G))   ! The wind friction velocity, calculated using the Boussinesq
                           ! reference density or the time-evolving surface density in non-Boussinesq
                           ! mode [Z T-1 ~> m s-1]
-  real :: covTS(SZI_(G))  ! SGS TS covariance in Stanley param; currently 0 [degC ppt]
-  real :: varS(SZI_(G))   ! SGS S variance in Stanley param; currently 0    [ppt2]
+  real :: BLD_in_H(SZI_(G)) ! The thickness of the active boundary layer with the topmost BLD of
+                          ! height [H ~> m or kg m-2]
+  real :: covTS(SZI_(G))  ! SGS TS covariance in Stanley param; currently 0 [C S ~> degC ppt]
+  real :: varS(SZI_(G))   ! SGS S variance in Stanley param; currently 0 [S2 ~> ppt2]
   real :: dmu(SZK_(GV))   ! Change in mu(z) across layer k [nondim]
+  real :: Rml_int(SZI_(G)) ! Potential density integrated through the mixed layer [R H ~> kg m-2 or kg2 m-5]
+  real :: SpV_ml(SZI_(G)) ! Specific volume evaluated at the surface pressure [R-1 ~> m3 kg-1]
+  real :: SpV_int(SZI_(G)) ! Specific volume integrated through the mixed layer [H R-1 ~> m4 kg-1 or m]
+  real :: H_mld(SZI_(G))  ! The thickness of water within the topmost BLD of height [H ~> m or kg m-2]
+  real :: MLD_rem(SZI_(G))  ! The vertical extent of the BLD that has not yet been accounted for [Z ~> m]
   real :: rho_ml(SZI_(G)) ! Potential density relative to the surface [R ~> kg m-3]
   real :: p0(SZI_(G))     ! A pressure of 0 [R L2 T-2 ~> Pa]
-  real :: g_Rho0          ! G_Earth/Rho0 [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
+  real :: g_Rho0          ! G_Earth/Rho0 times a thickness conversion factor
+                          ! [L2 H-1 T-2 R-1 ~> m4 s-2 kg-1 or m7 s-2 kg-2]
   real :: h_vel           ! htot interpolated onto velocity points [H ~> m or kg m-2]
   real :: w_star3         ! Cube of turbulent convective velocity [m3 s-3]
   real :: u_star3         ! Cube of surface fruction velocity [m3 s-3]
-  real :: r_wpup          ! reciprocal of vertical momentum flux [Z-2 T2 ~> m-2 s2]
+  real :: r_wpup          ! reciprocal of vertical momentum flux [T2 L-1 H-1 ~> s2 m-2 or m s2 kg-1]
   real :: absf            ! absolute value of f, interpolated to velocity points [T-1 ~> s-1]
   real :: grid_dsd        ! combination of grid scales [L2 ~> m2]
-  real :: h_sml           ! "Little h", the active mixing depth with diurnal cycle removed [Z ~> m]
-  real :: h_big           ! "Big H", the mixed layer depth based on a time filtered "little h" [Z ~> m]
-  real :: grd_b           ! The vertically average gradient of buoyancy [L Z-1 T-2 ~> s-2]
+  real :: h_sml           ! "Little h", the active mixing depth with diurnal cycle removed [H ~> m or kg m-2]
+  real :: h_big           ! "Big H", the mixed layer depth based on a time filtered "little h" [H ~> m or kg m-2]
+  real :: grd_b           ! The vertically average gradient of buoyancy [L H-1 T-2 ~> s-2 or m-3 kg-1 s-2]
   real :: psi_mag         ! Magnitude of stream function [L2 H T-1 ~> m3 s-1 or kg s-1]
   real :: h_neglect       ! tiny thickness usually lost in roundoff so can be neglected [H ~> m or kg m-2]
   real :: I4dt            ! 1/(4 dt) [T-1 ~> s-1]
@@ -754,7 +846,7 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
   I4dt = 0.25 / dt
-  g_Rho0 = GV%g_Earth / GV%Rho0
+  g_Rho0 = GV%H_to_Z * GV%g_Earth / GV%Rho0
   h_neglect = GV%H_subroundoff
 
   covTS(:) = 0.0 ! Might be in tv% in the future. Not implemented for the time being.
@@ -775,24 +867,49 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
   call find_ustar(forces, tv, U_star_2d, G, GV, US, halo=1)
 
   if (CS%debug) then
-    call hchksum(h,'mixed_Bodner: h', G%HI, haloshift=1, scale=GV%H_to_m)
+    call hchksum(h,'mixed_Bodner: h', G%HI, haloshift=1, scale=GV%H_to_mks)
     call hchksum(BLD, 'mle_Bodner: BLD in', G%HI, haloshift=1, scale=US%Z_to_m)
     if (associated(bflux)) &
       call hchksum(bflux, 'mle_Bodner: bflux', G%HI, haloshift=1, scale=US%Z_to_m**2*US%s_to_T**3)
     call hchksum(U_star_2d, 'mle_Bodner: u*', G%HI, haloshift=1, scale=US%Z_to_m*US%s_to_T)
     call hchksum(CS%MLD_filtered, 'mle_Bodner: MLD_filtered 1', &
-                 G%HI, haloshift=1, scale=US%Z_to_m)
+                 G%HI, haloshift=1, scale=GV%H_to_mks)
     call hchksum(CS%MLD_filtered_slow,'mle_Bodner: MLD_filtered_slow 1', &
-                 G%HI, haloshift=1, scale=US%Z_to_m)
+                 G%HI, haloshift=1, scale=GV%H_to_mks)
   endif
 
   ! Apply time filter to BLD (to remove diurnal cycle) to obtain "little h".
   ! "little h" is representative of the active mixing layer depth, used in B22 formula (eq 27).
-  do j = js-1, je+1 ; do i = is-1, ie+1
-    little_h(i,j) = rmean2ts(BLD(i,j), CS%MLD_filtered(i,j), &
-                             CS%BLD_growing_Tfilt, CS%BLD_decaying_Tfilt, dt)
-    CS%MLD_filtered(i,j) = little_h(i,j)
-  enddo ; enddo
+  if (GV%Boussinesq .or. (.not.allocated(tv%SpV_avg))) then
+    do j = js-1, je+1 ; do i = is-1, ie+1
+      little_h(i,j) = rmean2ts(GV%Z_to_H*BLD(i,j), CS%MLD_filtered(i,j), &
+                               CS%BLD_growing_Tfilt, CS%BLD_decaying_Tfilt, dt)
+      CS%MLD_filtered(i,j) = little_h(i,j)
+    enddo ; enddo
+  else ! The fully non-Boussinesq conversion between height in BLD and thickness.
+    do j=js-1,je+1
+      do i=is-1,ie+1 ; MLD_rem(i) = BLD(i,j) ; H_mld(i) = 0.0 ; enddo
+      do k=1,nz
+        keep_going = .false.
+        do i=is-1,ie+1 ; if (MLD_rem(i) > 0.0) then
+          if (MLD_rem(i) > GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)) then
+            H_mld(i) = H_mld(i) + h(i,j,k)
+            MLD_rem(i) = MLD_rem(i) - GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)
+            keep_going = .true.
+          else
+            H_mld(i) = H_mld(i) + GV%RZ_to_H * MLD_rem(i) / tv%SpV_avg(i,j,k)
+            MLD_rem(i) = 0.0
+          endif
+        endif ; enddo
+        if (.not.keep_going) exit
+      enddo
+      do i=is-1,ie+1
+        little_h(i,j) = rmean2ts(H_mld(i), CS%MLD_filtered(i,j), &
+                                 CS%BLD_growing_Tfilt, CS%BLD_decaying_Tfilt, dt)
+        CS%MLD_filtered(i,j) = little_h(i,j)
+      enddo
+    enddo
+  endif
 
   ! Calculate "big H", representative of the mixed layer depth, used in B22 formula (eq 27).
   do j = js-1, je+1 ; do i = is-1, ie+1
@@ -804,11 +921,11 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
   ! Estimate w'u' at h-points
   do j = js-1, je+1 ; do i = is-1, ie+1
     w_star3 = max(0., -bflux(i,j)) * BLD(i,j) & ! (this line in Z3 T-3 ~> m3 s-3)
-              * ( ( US%Z_to_m * US%s_to_T )**3 ) ! m3 s-3
+              * ( ( US%Z_to_m * US%s_to_T )**3 ) ! [m3 T3 Z-3 s-3 ~> 1]
     u_star3 = ( US%Z_to_m * US%s_to_T * U_star_2d(i,j) )**3 ! m3 s-3
     wpup(i,j) = max( CS%min_wstar2, &           ! The max() avoids division by zero later
                 ( CS%mstar * u_star3 + CS%nstar * w_star3 )**two_thirds ) & ! (this line m2 s-2)
-                * ( ( US%m_to_Z * US%T_to_s )**2 ) ! Z2 T-2 ~> m2 s-2
+                * ( US%m_to_L * GV%m_to_H * US%T_to_s**2 ) ! [L H s2 m-2 T-2 ~> 1 or kg m-3]
     ! We filter w'u' with the same time scales used for "little h"
     wpup(i,j) = rmean2ts(wpup(i,j), CS%wpup_filtered(i,j), &
                          CS%BLD_growing_Tfilt, CS%BLD_decaying_Tfilt, dt)
@@ -816,13 +933,13 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
   enddo ; enddo
 
   if (CS%debug) then
-    call hchksum(little_h,'mle_Bodner: little_h', G%HI, haloshift=1, scale=US%Z_to_m)
-    call hchksum(big_H,'mle_Bodner: big_H', G%HI, haloshift=1, scale=US%Z_to_m)
+    call hchksum(little_h,'mle_Bodner: little_h', G%HI, haloshift=1, scale=GV%H_to_mks)
+    call hchksum(big_H,'mle_Bodner: big_H', G%HI, haloshift=1, scale=GV%H_to_mks)
     call hchksum(CS%MLD_filtered,'mle_Bodner: MLD_filtered 2', &
-                 G%HI, haloshift=1, scale=US%Z_to_m)
+                 G%HI, haloshift=1, scale=GV%H_to_mks)
     call hchksum(CS%MLD_filtered_slow,'mle_Bodner: MLD_filtered_slow 2', &
-                 G%HI, haloshift=1, scale=US%Z_to_m)
-    call hchksum(wpup,'mle_Bodner: wpup', G%HI, haloshift=1, scale=(US%Z_to_m*US%s_to_T)**2)
+                 G%HI, haloshift=1, scale=GV%H_to_mks)
+    call hchksum(wpup,'mle_Bodner: wpup', G%HI, haloshift=1, scale=US%L_to_m*GV%H_to_mks*US%s_to_T**2)
   endif
 
   ! Calculate the average density in the "mixed layer".
@@ -834,11 +951,13 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
   !$OMP default(shared) &
   !$OMP private(i, j, k, keep_going, line_is_empty, dh, &
   !$OMP   grid_dsd, absf, h_sml, h_big, grd_b, r_wpup, psi_mag, IhTot, &
-  !$OMP   sigint, muzb, muza, hAtVel)
+  !$OMP   sigint, muzb, muza, hAtVel, Rml_int, SpV_int)
+
   !$OMP do
   do j=js-1,je+1
+    rho_ml(:) = 0.0 ; SpV_ml(:) = 0.0
     do i=is-1,ie+1
-      htot(i,j) = 0.0 ; buoy_av(i,j) = 0.0
+      htot(i,j) = 0.0 ; Rml_int(i) = 0.0 ; SpV_int(i) = 0.0
     enddo
     keep_going = .true.
     do k=1,nz
@@ -846,17 +965,22 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
         vol_dt_avail(i,j,k) = max(I4dt*G%areaT(i,j)*(h(i,j,k)-GV%Angstrom_H),0.0)
       enddo
       if (keep_going) then
-        if (CS%use_Stanley_ML) then
-          call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, tv%varT(:,j,k), covTS, varS, &
-                                 rho_ml(:), tv%eqn_of_state, EOSdom)
+        if (GV%Boussinesq .or. GV%semi_Boussinesq) then
+          if (CS%use_Stanley_ML) then
+            call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, tv%varT(:,j,k), covTS, varS, &
+                                   rho_ml, tv%eqn_of_state, EOSdom)
+          else
+            call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, rho_ml, tv%eqn_of_state, EOSdom)
+          endif
         else
-          call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, rho_ml(:), tv%eqn_of_state, EOSdom)
+          call calculate_spec_vol(tv%T(:,j,k), tv%S(:,j,k), p0, SpV_ml, tv%eqn_of_state, EOSdom)
         endif
         line_is_empty = .true.
         do i=is-1,ie+1
-          if (htot(i,j) < big_H(i,j)*GV%Z_to_H) then
-            dh = min( h(i,j,k), big_H(i,j)*GV%Z_to_H - htot(i,j) )
-            buoy_av(i,j) = buoy_av(i,j) + dh*rho_ml(i) ! Here, buoy_av has units of R H ~> kg m-2
+          if (htot(i,j) < big_H(i,j)) then
+            dh = min( h(i,j,k), big_H(i,j) - htot(i,j) )
+            Rml_int(i) = Rml_int(i) + dh*rho_ml(i) ! Rml_int has units of [R H ~> kg m-2]
+            SpV_int(i) = SpV_int(i) + dh*SpV_ml(i) ! SpV_int has units of [H R-1 ~> m4 kg-1 or m]
             htot(i,j) = htot(i,j) + dh
             line_is_empty = .false.
           endif
@@ -865,18 +989,24 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
       endif
     enddo
 
-    do i=is-1,ie+1
-      ! Hereafter, buoy_av has units (L2 Z-1 T-2 R-1) * (R H) * H-1 = L2 Z-1 T-2 ~> m s-2
-      buoy_av(i,j) = -( g_Rho0 * buoy_av(i,j) ) / (htot(i,j) + h_neglect)
-    enddo
+    if (GV%Boussinesq .or. GV%semi_Boussinesq) then
+      do i=is-1,ie+1
+        ! Buoy_av has units (L2 H-1 T-2 R-1) * (R H) * H-1 = L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2
+        buoy_av(i,j) = -( g_Rho0 * Rml_int(i) ) / (htot(i,j) + h_neglect)
+      enddo
+    else
+      do i=is-1,ie+1
+        ! Buoy_av has units (R L2 H-1 T-2) * (R-1 H) * H-1 = L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2
+        buoy_av(i,j) = (GV%H_to_RZ*GV%g_Earth * SpV_int(i)) / (htot(i,j) + h_neglect)
+      enddo
+    endif
   enddo
 
   if (CS%debug) then
-    call hchksum(htot,'mle_Bodner: htot', G%HI, haloshift=1, scale=GV%H_to_m)
+    call hchksum(htot,'mle_Bodner: htot', G%HI, haloshift=1, scale=GV%H_to_mks)
     call hchksum(vol_dt_avail,'mle_Bodner: vol_dt_avail', G%HI, haloshift=1, &
-                 scale=US%L_to_m**2*GV%H_to_m*US%s_to_T)
-    call hchksum(buoy_av,'mle_Bodner: buoy_av', G%HI, haloshift=1, &
-                 scale=US%m_to_Z*US%L_T_to_m_s**2)
+                 scale=US%L_to_m**2*GV%H_to_mks*US%s_to_T)
+    call hchksum(buoy_av,'mle_Bodner: buoy_av', G%HI, haloshift=1, scale=GV%m_to_H*US%L_T_to_m_s**2)
   endif
 
   ! U - Component
@@ -885,12 +1015,12 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
     if (G%OBCmaskCu(I,j) > 0.) then
       grid_dsd = sqrt(0.5*( G%dxCu(I,j)**2 + G%dyCu(I,j)**2 )) * G%dyCu(I,j) ! L2 ~> m2
       absf = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))  ! T-1 ~> s-1
-      h_sml = 0.5*( little_h(i,j) + little_h(i+1,j) )                 ! Z ~> m
-      h_big = 0.5*( big_H(i,j) + big_H(i+1,j) )                       ! Z ~> m
-      grd_b = ( buoy_av(i+1,j) - buoy_av(i,j) ) * G%IdxCu(I,j)        ! L Z-1 T-2 ~> s-2
-      r_wpup = 2. / ( wpup(i,j) + wpup(i+1,j) )                       ! Z-2 T2 ~> m-2 s2
+      h_sml = 0.5*( little_h(i,j) + little_h(i+1,j) )                 ! H ~> m or kg m-3
+      h_big = 0.5*( big_H(i,j) + big_H(i+1,j) )                       ! H ~> m or kg m-3
+      grd_b = ( buoy_av(i+1,j) - buoy_av(i,j) ) * G%IdxCu(I,j)        ! L H-1 T-2 ~> s-2 or m3 kg-1 s-2
+      r_wpup = 2. / ( wpup(i,j) + wpup(i+1,j) )                       ! T2 L-1 H-1 ~> s2 m-2 or m s2 kg-1
       psi_mag = ( ( ( CS%Cr * grid_dsd ) * ( absf * h_sml ) ) &       ! L2 H T-1 ~> m3 s-1 or kg s-1
-                  * ( ( h_big**2 ) * grd_b ) ) * r_wpup * US%L_to_Z * GV%Z_to_H
+                  * ( ( h_big**2 ) * grd_b ) ) * r_wpup
     else  ! There is no flux on land and no gradient at open boundary points.
       psi_mag = 0.0
     endif
@@ -926,12 +1056,12 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
     if (G%OBCmaskCv(i,J) > 0.) then
       grid_dsd = sqrt(0.5*( G%dxCv(i,J)**2 + G%dyCv(i,J)**2 )) * G%dxCv(i,J) ! L2 ~> m2
       absf = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))  ! T-1 ~> s-1
-      h_sml = 0.5*( little_h(i,j) + little_h(i,j+1) )                 ! Z ~> m
-      h_big = 0.5*( big_H(i,j) + big_H(i,j+1) )                       ! Z ~> m
-      grd_b = ( buoy_av(i,j+1) - buoy_av(i,j) ) * G%IdyCv(I,j)        ! L Z-1 T-2 ~> s-2
-      r_wpup = 2. / ( wpup(i,j) + wpup(i,j+1) )                       ! Z-2 T2 ~> m-2 s2
+      h_sml = 0.5*( little_h(i,j) + little_h(i,j+1) )                 ! H ~> m or kg m-3
+      h_big = 0.5*( big_H(i,j) + big_H(i,j+1) )                       ! H ~> m or kg m-3
+      grd_b = ( buoy_av(i,j+1) - buoy_av(i,j) ) * G%IdyCv(I,j)        ! L H-1 T-2 ~> s-2 or m3 kg-1 s-2
+      r_wpup = 2. / ( wpup(i,j) + wpup(i,j+1) )                       ! T2 L-1 H-1 ~> s2 m-2 or m s2 kg-1
       psi_mag = ( ( ( CS%Cr * grid_dsd ) * ( absf * h_sml ) ) &       ! L2 H T-1 ~> m3 s-1 or kg s-1
-                  * ( ( h_big**2 ) * grd_b ) ) * r_wpup * US%L_to_Z * GV%Z_to_H
+                  * ( ( h_big**2 ) * grd_b ) ) * r_wpup
     else  ! There is no flux on land and no gradient at open boundary points.
       psi_mag = 0.0
     endif
@@ -1065,25 +1195,30 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
     h_avail               ! The volume available for diffusion out of each face of each
                           ! sublayer of the mixed layer, divided by dt [H L2 T-1 ~> m3 s-1 or kg s-1].
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    U_star_2d, &          ! The wind friction velocity, calculated using
+    U_star_2d, &          ! The wind friction velocity in thickness-based units, calculated using
                           ! the Boussinesq reference density or the time-evolving surface density
-                          ! in non-Boussinesq mode [Z T-1 ~> m s-1]
+                          ! in non-Boussinesq mode [H T-1 ~> m s-1 or kg m-2 s-1]
     htot, &               ! The sum of the thicknesses of layers in the mixed layer [H ~> m or kg m-2]
-    Rml_av                ! g_Rho0 times the average mixed layer density [L2 Z-1 T-2 ~> m s-2]
-  real :: g_Rho0          ! G_Earth/Rho0 [L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
-  real :: Rho0(SZI_(G))   ! Potential density relative to the surface [R ~> kg m-3]
+    Rml_av                ! g_Rho0 times the average mixed layer density or negative G_Earth
+                          ! times the average specific volume [L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2]
+  real :: g_Rho0          ! G_Earth/Rho0 times a thickness conversion factor
+                          ! [L2 H-1 T-2 R-1 ~> m4 s-2 kg-1 or m7 s-2 kg-2]
+  real :: Rho_ml(SZI_(G)) ! Potential density relative to the surface [R ~> kg m-3]
+  real :: rho_int(SZI_(G)) ! The integral of density over the mixed layer depth [R H ~> kg m-2 or kg2 m-3]
+  real :: SpV_ml(SZI_(G)) ! Specific volume evaluated at the surface pressure [R-1 ~> m3 kg-1]
+  real :: SpV_int(SZI_(G)) ! Specific volume integrated through the surface layer [H R-1 ~> m4 kg-1 or m]
   real :: p0(SZI_(G))     ! A pressure of 0 [R L2 T-2 ~> Pa]
 
-  real :: h_vel           ! htot interpolated onto velocity points [Z ~> m]. (The units are not H.)
+  real :: h_vel           ! htot interpolated onto velocity points [H ~> m or kg m-2]
   real :: absf            ! absolute value of f, interpolated to velocity points [T-1 ~> s-1]
-  real :: u_star          ! surface friction velocity, interpolated to velocity points [Z T-1 ~> m s-1].
+  real :: u_star          ! surface friction velocity, interpolated to velocity points and recast into
+                          ! thickness-based units [H T-1 ~> m s-1 or kg m-2 s-1].
   real :: vonKar_x_pi2    ! A scaling constant that is approximately the von Karman constant times
                           ! pi squared [nondim]
   real :: mom_mixrate     ! rate at which momentum is homogenized within mixed layer [T-1 ~> s-1]
   real :: timescale       ! mixing growth timescale [T ~> s]
   real :: h_min           ! The minimum layer thickness [H ~> m or kg m-2].  h_min could be 0.
   real :: h_neglect       ! tiny thickness usually lost in roundoff and can be neglected [H ~> m or kg m-2]
-  real :: dz_neglect      ! tiny thickness that usually lost in roundoff and can be neglected [Z ~> m]
   real :: I4dt            ! 1/(4 dt) [T-1 ~> s-1]
   real :: I2htot          ! Twice the total mixed layer thickness at velocity points [H ~> m or kg m-2]
   real :: z_topx2         ! depth of the top of a layer at velocity points [H ~> m or kg m-2]
@@ -1113,11 +1248,10 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
   h_min = 0.5*GV%Angstrom_H ! This should be GV%Angstrom_H, but that value would change answers.
   uDml(:)    = 0.0 ; vDml(:) = 0.0
   I4dt       = 0.25 / dt
-  g_Rho0     = GV%g_Earth / GV%Rho0
+  g_Rho0     = GV%H_to_Z * GV%g_Earth / GV%Rho0
   vonKar_x_pi2 = CS%vonKar * 9.8696
   use_EOS    = associated(tv%eqn_of_state)
   h_neglect  = GV%H_subroundoff
-  dz_neglect = GV%H_subroundoff*GV%H_to_Z
 
   if (.not.use_EOS) call MOM_error(FATAL, "mixedlayer_restrat_BML: "// &
          "An equation of state must be used with this module.")
@@ -1126,33 +1260,56 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
          "The Stanley parameterization is not available with the BML.")
 
   ! Extract the friction velocity from the forcing type.
-  call find_ustar(forces, tv, U_star_2d, G, GV, US, halo=1)
+  call find_ustar(forces, tv, U_star_2d, G, GV, US, halo=1, H_T_units=.true.)
 
   ! Fix this later for nkml >= 3.
 
   p0(:) = 0.0
   EOSdom(:) = EOS_domain(G%HI, halo=1)
-  !$OMP parallel default(shared) private(Rho0,h_vel,u_star,absf,mom_mixrate,timescale, &
-  !$OMP                               I2htot,z_topx2,hx2,a)                            &
+  !$OMP parallel default(shared) private(Rho_ml,rho_int,h_vel,u_star,absf,mom_mixrate,timescale, &
+  !$OMP                                  SpV_ml,SpV_int,I2htot,z_topx2,hx2,a) &
   !$OMP                       firstprivate(uDml,vDml)
-  !$OMP do
-  do j=js-1,je+1
-    do i=is-1,ie+1
-      htot(i,j) = 0.0 ; Rml_av(i,j) = 0.0
-    enddo
-    do k=1,nkml
-      call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, Rho0(:), tv%eqn_of_state, EOSdom)
+
+  if (GV%Boussinesq .or. GV%semi_Boussinesq) then
+    !$OMP do
+    do j=js-1,je+1
       do i=is-1,ie+1
-        Rml_av(i,j) = Rml_av(i,j) + h(i,j,k)*Rho0(i)
-        htot(i,j) = htot(i,j) + h(i,j,k)
-        h_avail(i,j,k) = max(I4dt*G%areaT(i,j)*(h(i,j,k)-GV%Angstrom_H),0.0)
+        htot(i,j) = 0.0 ; rho_int(i) = 0.0
+      enddo
+      do k=1,nkml
+        call calculate_density(tv%T(:,j,k), tv%S(:,j,k), p0, Rho_ml(:), tv%eqn_of_state, EOSdom)
+        do i=is-1,ie+1
+          rho_int(i) = rho_int(i) + h(i,j,k)*Rho_ml(i)
+          htot(i,j) = htot(i,j) + h(i,j,k)
+          h_avail(i,j,k) = max(I4dt*G%areaT(i,j)*(h(i,j,k)-GV%Angstrom_H),0.0)
+        enddo
+      enddo
+
+      do i=is-1,ie+1
+        Rml_av(i,j) = (g_Rho0*rho_int(i)) / (htot(i,j) + h_neglect)
       enddo
     enddo
+  else  ! This is only used in non-Boussinesq mode.
+    !$OMP do
+    do j=js-1,je+1
+      do i=is-1,ie+1
+        htot(i,j) = 0.0 ; SpV_int(i) = 0.0
+      enddo
+      do k=1,nkml
+        call calculate_spec_vol(tv%T(:,j,k), tv%S(:,j,k), p0, SpV_ml, tv%eqn_of_state, EOSdom)
+        do i=is-1,ie+1
+          SpV_int(i) = SpV_int(i) + h(i,j,k)*SpV_ml(i)  ! [H R-1 ~> m4 kg-1 or m]
+          htot(i,j) = htot(i,j) + h(i,j,k)
+          h_avail(i,j,k) = max(I4dt*G%areaT(i,j)*(h(i,j,k)-GV%Angstrom_H),0.0)
+        enddo
+      enddo
 
-    do i=is-1,ie+1
-      Rml_av(i,j) = (g_Rho0*Rml_av(i,j)) / (htot(i,j) + h_neglect)
+      ! Convert the vertically integrated specific volume into a negative variable with units of density.
+      do i=is-1,ie+1
+        Rml_av(i,j) = (-GV%H_to_RZ*GV%g_Earth * SpV_int(i)) / (htot(i,j) + h_neglect)
+      enddo
     enddo
-  enddo
+  endif
 
 ! TO DO:
 !   1. Mixing extends below the mixing layer to the mixed layer.  Find it!
@@ -1161,26 +1318,26 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
 !   U - Component
   !$OMP do
   do j=js,je ; do I=is-1,ie
-    h_vel = 0.5*(htot(i,j) + htot(i+1,j)) * GV%H_to_Z
+    h_vel = 0.5*(htot(i,j) + htot(i+1,j))
 
     u_star = max(CS%ustar_min, 0.5*(U_star_2d(i,j) + U_star_2d(i+1,j)))
 
     absf = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
 
     ! NOTE: growth_time changes answers on some systems, see below.
-    ! timescale = growth_time(u_star, h_vel, absf, dz_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef)
+    ! timescale = growth_time(u_star, h_vel, absf, h_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef)
 
     ! peak ML visc: u_star * von_Karman * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2
     mom_mixrate = vonKar_x_pi2*u_star**2 / &
-                  (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
+                  (absf*h_vel**2 + 4.0*(h_vel+h_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
 
     timescale = timescale * CS%ml_restrat_coef
 !      timescale = timescale*(2?)*(L_def/L_MLI) * min(EKE/MKE,1.0 + (G%dyCv(i,j)/L_def)**2)
 
     uDml(I) = timescale * G%OBCmaskCu(I,j)*G%dyCu(I,j)*G%IdxCu(I,j) * &
-        (Rml_av(i+1,j)-Rml_av(i,j)) * (h_vel**2 * GV%Z_to_H)
+        (Rml_av(i+1,j)-Rml_av(i,j)) * (h_vel**2)
 
     if (uDml(I) == 0) then
       do k=1,nkml ; uhml(I,j,k) = 0.0 ; enddo
@@ -1212,26 +1369,26 @@ subroutine mixedlayer_restrat_BML(h, uhtr, vhtr, tv, forces, dt, G, GV, US, CS)
 !  V- component
   !$OMP do
   do J=js-1,je ; do i=is,ie
-    h_vel = 0.5*(htot(i,j) + htot(i,j+1)) * GV%H_to_Z
+    h_vel = 0.5*(htot(i,j) + htot(i,j+1))
 
     u_star = max(CS%ustar_min, 0.5*(U_star_2d(i,j) + U_star_2d(i,j+1)))
 
     absf = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
 
     ! NOTE: growth_time changes answers on some systems, see below.
-    ! timescale = growth_time(u_star, h_vel, absf, dz_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef)
+    ! timescale = growth_time(u_star, h_vel, absf, h_neglect, CS%vonKar, CS%Kv_restrat, CS%ml_restrat_coef)
 
     ! peak ML visc: u_star * von_Karman * (h_ml*u_star)/(absf*h_ml + 4.0*u_star)
     ! momentum mixing rate: pi^2*visc/h_ml^2
     mom_mixrate = vonKar_x_pi2*u_star**2 / &
-                  (absf*h_vel**2 + 4.0*(h_vel+dz_neglect)*u_star)
+                  (absf*h_vel**2 + 4.0*(h_vel+h_neglect)*u_star)
     timescale = 0.0625 * (absf + 2.0*mom_mixrate) / (absf**2 + mom_mixrate**2)
 
     timescale = timescale * CS%ml_restrat_coef
 !     timescale = timescale*(2?)*(L_def/L_MLI) * min(EKE/MKE,1.0 + (G%dyCv(i,j)/L_def)**2)
 
     vDml(i) = timescale * G%OBCmaskCv(i,J)*G%dxCv(i,J)*G%IdyCv(i,J) * &
-        (Rml_av(i,j+1)-Rml_av(i,j)) * (h_vel**2 * GV%Z_to_H)
+        (Rml_av(i,j+1)-Rml_av(i,j)) * (h_vel**2)
     if (vDml(i) == 0) then
       do k=1,nkml ; vhml(i,J,k) = 0.0 ; enddo
     else
@@ -1301,19 +1458,21 @@ end subroutine mixedlayer_restrat_BML
 
 !> Return the growth timescale for the submesoscale mixed layer eddies in [T ~> s]
 real function growth_time(u_star, hBL, absf, h_neg, vonKar, Kv_rest, restrat_coef)
-  real, intent(in) :: u_star   !< Surface friction velocity [Z T-1 ~> m s-1]
+  real, intent(in) :: u_star   !< Surface friction velocity in thickness-based units [H T-1 ~> m s-1 or kg m-2 s-1]
   real, intent(in) :: hBL      !< Boundary layer thickness including at least a neglible
-                               !! value to keep it positive definite [Z ~> m]
+                               !! value to keep it positive definite [H ~> m or kg m-2]
   real, intent(in) :: absf     !< Absolute value of the Coriolis parameter [T-1 ~> s-1]
-  real, intent(in) :: h_neg    !< A tiny thickness that is usually lost in roundoff so can be neglected [Z ~> m]
-  real, intent(in) :: Kv_rest  !< The background laminar vertical viscosity used for restratification [Z2 T-1 ~> m2 s-1]
+  real, intent(in) :: h_neg    !< A tiny thickness that is usually lost in roundoff so can be
+                               !! neglected [H ~> m or kg m-2]
+  real, intent(in) :: Kv_rest  !< The background laminar vertical viscosity used for restratification,
+                               !! rescaled into thickness-based units [H2 T-1 ~> m2 s-1 or kg2 m-4 s-1]
   real, intent(in) :: vonKar   !< The von Karman constant, used to scale the turbulent limits
                                !! on the restratification timescales [nondim]
   real, intent(in) :: restrat_coef !< An overall scaling factor for the restratification timescale [nondim]
 
   ! Local variables
   real :: mom_mixrate  ! rate at which momentum is homogenized within mixed layer [T-1 ~> s-1]
-  real :: Kv_eff       ! An effective overall viscosity [Z2 T-1 ~> m2 s-1]
+  real :: Kv_eff       ! An effective overall viscosity in thickness-based units [H2 T-1 ~> m2 s-1 or kg2 m-4 s-1]
   real :: pi2          ! A scaling constant that is approximately pi^2 [nondim]
 
   ! peak ML visc: u_star * von_Karman * (h_ml*u_star)/(absf*h_ml + 4.0*u_star) + Kv_water
@@ -1354,7 +1513,6 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   real :: ustar_min_dflt   ! The default value for RESTRAT_USTAR_MIN [Z T-1 ~> m s-1]
   real :: Stanley_coeff    ! Coefficient relating the temperature gradient and sub-gridscale
                            ! temperature variance [nondim]
-  real :: BLD_units        ! Set to either H_to_m or Z_to_m depending on scheme [m H-1 or m Z-1 ~> 1]
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   integer :: i, j
@@ -1429,7 +1587,7 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
              "a division-by-zero in the limit when u* and the buoyancy flux are zero.  "//&
              "The default is less than the molecular viscosity of water times the Coriolis "//&
              "parameter a micron away from the equator.", &
-             units="m2 s-2", default=1.0e-24)
+             units="m2 s-2", default=1.0e-24)   ! This parameter stays in MKS units.
     call get_param(param_file, mdl, "TAIL_DH", CS%MLE_tail_dh, &
              "Fraction by which to extend the mixed-layer restratification "//&
              "depth used for a smoother stream function at the base of "//&
@@ -1464,7 +1622,7 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
     call get_param(param_file, mdl, "USE_STANLEY_ML", CS%use_Stanley_ML, &
                    "If true, turn on Stanley SGS T variance parameterization "// &
                    "in ML restrat code.", default=.false.)
-    if (CS%use_stanley_ml) then
+    if (CS%use_Stanley_ML) then
       call get_param(param_file, mdl, "STANLEY_COEFF", Stanley_coeff, &
                    "Coefficient correlating the temperature gradient and SGS T variance.", &
                    units="nondim", default=-1.0, do_not_log=.true.)
@@ -1520,23 +1678,21 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
                  "A small viscosity that sets a floor on the momentum mixing rate during "//&
                  "restratification.  If this is positive, it will prevent some possible "//&
                  "divisions by zero even if ustar, RESTRAT_USTAR_MIN, and f are all 0.", &
-                 units="m2 s-1", default=0.0, scale=US%m2_s_to_Z2_T)
+                 units="m2 s-1", default=0.0, scale=GV%m2_s_to_HZ_T*(US%Z_to_m*GV%m_to_H))
     call get_param(param_file, mdl, "OMEGA", omega, &
                  "The rotation rate of the earth.", &
                  units="s-1", default=7.2921e-5, scale=US%T_to_s)
-    ustar_min_dflt = 2.0e-4 * omega * (GV%Angstrom_Z + GV%H_to_Z*GV%H_subroundoff)
+    ustar_min_dflt = 2.0e-4 * omega * (GV%Angstrom_Z + GV%dZ_subroundoff)
     call get_param(param_file, mdl, "RESTRAT_USTAR_MIN", CS%ustar_min, &
                  "The minimum value of ustar that will be used by the mixed layer "//&
                  "restratification module.  This can be tiny, but if this is greater than 0, "//&
                  "it will prevent divisions by zero when f and KV_RESTRAT are zero.", &
-                 units="m s-1", default=US%Z_to_m*US%s_to_T*ustar_min_dflt, scale=US%m_to_Z*US%T_to_s)
+                 units="m s-1", default=US%Z_to_m*US%s_to_T*ustar_min_dflt, scale=GV%m_to_H*US%T_to_s)
   endif
 
   CS%diag => diag
 
   flux_to_kg_per_s = GV%H_to_kg_m2 * US%L_to_m**2 * US%s_to_T
-  if (CS%use_Bodner) then; BLD_units = US%Z_to_m
-                     else; BLD_units = GV%H_to_m; endif
 
   CS%id_uhml = register_diag_field('ocean_model', 'uhml', diag%axesCuL, Time, &
       'Zonal Thickness Flux to Restratify Mixed Layer', &
@@ -1550,13 +1706,13 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
       'Mixed Layer Meridional Restratification Timescale', 's', conversion=US%T_to_s)
   CS%id_MLD = register_diag_field('ocean_model', 'MLD_restrat', diag%axesT1, Time, &
       'Mixed Layer Depth as used in the mixed-layer restratification parameterization', &
-      'm', conversion=BLD_units)
+      'm', conversion=GV%H_to_m)
   CS%id_BLD = register_diag_field('ocean_model', 'BLD_restrat', diag%axesT1, Time, &
       'Boundary Layer Depth as used in the mixed-layer restratification parameterization', &
-      'm', conversion=BLD_units)
+      'm', conversion=GV%H_to_m)
   CS%id_Rml = register_diag_field('ocean_model', 'ML_buoy_restrat', diag%axesT1, Time, &
       'Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization', &
-      'm s-2', conversion=US%m_to_Z*(US%L_T_to_m_s**2))
+      'm s-2', conversion=GV%m_to_H*(US%L_T_to_m_s**2))
   CS%id_uDml = register_diag_field('ocean_model', 'udml_restrat', diag%axesCu1, Time, &
       'Transport stream function amplitude for zonal restratification of mixed layer', &
       'm3 s-1', conversion=GV%H_to_m*(US%L_to_m**2)*US%s_to_T)
@@ -1572,7 +1728,7 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   if (CS%use_Bodner) then
     CS%id_wpup = register_diag_field('ocean_model', 'MLE_wpup', diag%axesT1, Time, &
         'Vertical turbulent momentum flux in Bodner mixed layer restratificiation parameterization', &
-        'm2 s-2', conversion=(US%Z_to_m*US%s_to_T)**2)
+        'm2 s-2', conversion=US%L_to_m*GV%H_to_m*US%s_to_T**2)
     CS%id_ustar = register_diag_field('ocean_model', 'MLE_ustar', diag%axesT1, Time, &
         'Surface turbulent friction velicity, u*, in Bodner mixed layer restratificiation parameterization', &
         'm s-1', conversion=(US%Z_to_m*US%s_to_T))
@@ -1598,6 +1754,7 @@ subroutine mixedlayer_restrat_register_restarts(HI, GV, US, param_file, CS, rest
   type(MOM_restart_CS),        intent(inout) :: restart_CS !< MOM restart control structure
 
   ! Local variables
+  character(len=64) :: mom_flux_units
   logical :: mixedlayer_restrat_init, use_Bodner
 
   ! Check to see if this module will be used
@@ -1623,14 +1780,15 @@ subroutine mixedlayer_restrat_register_restarts(HI, GV, US, param_file, CS, rest
     allocate(CS%MLD_filtered_slow(HI%isd:HI%ied,HI%jsd:HI%jed), source=0.)
     call register_restart_field(CS%MLD_filtered_slow, "MLD_MLE_filtered_slow", .false., restart_CS, &
                                 longname="Slower time-filtered MLD for use in MLE", &
-                                units=get_thickness_units(GV), conversion=GV%H_to_MKS) ! UNITS ARE WRONG -AJA
+                                units=get_thickness_units(GV), conversion=GV%H_to_MKS)
   endif
   if (use_Bodner) then
     ! CS%MLD_filtered_slow is used to keep a running mean of the PBL's seasonal or winter MLD.
+    mom_flux_units = "m2 s-2" ; if (.not.GV%Boussinesq) mom_flux_units = "kg m-1 s-2"
     allocate(CS%wpup_filtered(HI%isd:HI%ied,HI%jsd:HI%jed), source=0.)
     call register_restart_field(CS%wpup_filtered, "MLE_Bflux", .false., restart_CS, &
                                 longname="Time-filtered vertical turbulent momentum flux for use in MLE", &
-                                units='m2 s-2', conversion=(US%Z_to_m*US%s_to_T)**2 )
+                                units=mom_flux_units, conversion=US%L_to_m*GV%H_to_mks*US%s_to_T**2 )
   endif
 
 end subroutine mixedlayer_restrat_register_restarts


### PR DESCRIPTION
  Revised the code in MOM_mixed_layer_restrat.F90 to work internally with thickness-based units for the restratification timescale calculation and other internal calculations, which eliminates the dependence in this module on the value of the Boussinesq reference density in non-Boussinesq mode.  Several other minor issues (which might not change any answers in production runs) were also fixed.  The changes with this commit include:

 - When in non-Boussinesq mode, the mixed layer buoyancy gradients are determined from the average specific volume referenced to the surface pressure, rather than from the average potential density.

 - Use find_ustar to set the friction velocities in the appropriate units in the various mixed_layer_restrat routines.

 - A logical branch was added based on the correct mask for land or OBC points to avoid potentially ill-defined calculations of the magnitude of the Bodner parameterization streamfunction, some which were leading to NaNs.

 - Set a tiny but nonzero default value for MIN_WSTAR2 to avoid NaNs in some calculations of the streamfunction magnitude.

 - Within the function mu, the expression for dd was revised in a mathematically equivalent way to avoid any possibility of taking a fractional exponential power of a tiny negative number due to truncation errors, which was leading to NaNs in some cases while developing and debugging the other changes in this commit.  This does not appear to change any answers in the existing test cases, perhaps because the mixed layer restratification "tail" is not being activated by setting TAIL_DH to be larger than 0.

 - The addition of code to both mixedlayer_restrat_Bodner and mixedlayer_restrat_OM4 to determine the mixed layer thickness from its vertical extent when in non-Boussinesq mode.

  This commit includes changes to the units of the Kv_restrat, ustar_min and wpup_filtered elements in the mixedlayer_restrat_CS type and the units of four arguments to the private function growth_time.  CS%wpup_filtered also appears in the restart files generated with some mixed layer restratification settings, and it is rescaled to units of vertical distance or mass per unit area in the restart files depending on whether the model is Boussinesq.

  There are 17 new or renamed internal variables, while the units of 21 internal variables were changed.  19 rescaling factors were cancelled out or replaced. There are also comments where variable units were corrected or added.

  The rescaling of several chksum calls for thicknesses was modified to GV%H_to_mks to avoid any dependence on RHO_0 when non-Boussinesq.

  No public interfaces are changed.  All answers are bitwise identical in Boussinesq mode (at least when TAIL_DH=0.), but solutions will change in non-Boussinesq mode when mixed layer restratification is enabled, including changes to the units of a variable in the restart files.