### PR TITLE
+Non-Boussinesq revisions to wave_interface

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -34,7 +34,7 @@ use MOM_error_handler,        only : MOM_error, MOM_mesg, FATAL, WARNING, is_roo
 use MOM_error_handler,        only : MOM_set_verbosity, callTree_showQuery
 use MOM_error_handler,        only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,          only : read_param, get_param, log_version, param_file_type
-use MOM_forcing_type,         only : forcing, mech_forcing
+use MOM_forcing_type,         only : forcing, mech_forcing, find_ustar
 use MOM_forcing_type,         only : MOM_forcing_chksum, MOM_mech_forcing_chksum
 use MOM_get_input,            only : Get_MOM_Input, directories
 use MOM_io,                   only : MOM_io_init, vardesc, var_desc
@@ -91,7 +91,7 @@ use MOM_grid,                  only : ocean_grid_type, MOM_grid_init, MOM_grid_e
 use MOM_grid,                  only : set_first_direction, rescale_grid_bathymetry
 use MOM_hor_index,             only : hor_index_type, hor_index_init
 use MOM_hor_index,             only : rotate_hor_index
-use MOM_interface_heights,     only : find_eta, calc_derived_thermo
+use MOM_interface_heights,     only : find_eta, calc_derived_thermo, thickness_to_dz
 use MOM_interface_filter,      only : interface_filter, interface_filter_init, interface_filter_end
 use MOM_interface_filter,      only : interface_filter_CS
 use MOM_lateral_mixing_coeffs, only : calc_slope_functions, VarMix_init, VarMix_end
@@ -545,7 +545,12 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   logical :: therm_reset ! If true, reset running sums of thermodynamic quantities.
   real :: cycle_time    ! The length of the coupled time-stepping cycle [T ~> s].
   real, dimension(SZI_(CS%G),SZJ_(CS%G)) :: &
+    U_star      ! The wind friction velocity, calculated using the Boussinesq reference density or
+                ! the time-evolving surface density in non-Boussinesq mode [Z T-1 ~> m s-1]
+  real, dimension(SZI_(CS%G),SZJ_(CS%G)) :: &
     ssh         ! sea surface height, which may be based on eta_av [Z ~> m]
+  real, dimension(SZI_(CS%G),SZJ_(CS%G),SZK_(CS%GV)) :: &
+    dz          ! Vertical distance across layers [Z ~> m]
 
   real, dimension(:,:,:), pointer :: &
     u => NULL(), & ! u : zonal velocity component [L T-1 ~> m s-1]
@@ -672,13 +677,18 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
     dt = time_interval / real(n_max)
     dt_therm = dt ; ntstep = 1
+
+    if (CS%UseWaves .and. associated(fluxes%ustar)) &
+      call pass_var(fluxes%ustar, G%Domain, clock=id_clock_pass, halo=1)
+    if (CS%UseWaves .and. associated(fluxes%tau_mag)) &
+      call pass_var(fluxes%tau_mag, G%Domain, clock=id_clock_pass, halo=1)
+
     if (associated(fluxes%p_surf)) p_surf => fluxes%p_surf
     CS%tv%p_surf => NULL()
     if (CS%use_p_surf_in_EOS .and. associated(fluxes%p_surf)) then
       CS%tv%p_surf => fluxes%p_surf
       if (allocated(CS%tv%SpV_avg)) call pass_var(fluxes%p_surf, G%Domain, clock=id_clock_pass)
     endif
-    if (CS%UseWaves) call pass_var(fluxes%ustar, G%Domain, clock=id_clock_pass)
   endif
 
   if (therm_reset) then
@@ -722,12 +732,16 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     if (CS%UseWaves) then
       ! Update wave information, which is presently kept static over each call to step_mom
       call enable_averages(time_interval, Time_start + real_to_time(US%T_to_s*time_interval), CS%diag)
-      call Update_Stokes_Drift(G, GV, US, Waves, h, forces%ustar, time_interval, do_dyn)
+      call find_ustar(forces, CS%tv, U_star, G, GV, US, halo=1)
+      call thickness_to_dz(h, CS%tv, dz, G, GV, US, halo_size=1)
+      call Update_Stokes_Drift(G, GV, US, Waves, dz, U_star, time_interval, do_dyn)
       call disable_averaging(CS%diag)
     endif
   else ! not do_dyn.
     if (CS%UseWaves) then ! Diagnostics are not enabled in this call.
-      call Update_Stokes_Drift(G, GV, US, Waves, h, fluxes%ustar, time_interval, do_dyn)
+      call find_ustar(fluxes, CS%tv, U_star, G, GV, US, halo=1)
+      call thickness_to_dz(h, CS%tv, dz, G, GV, US, halo_size=1)
+      call Update_Stokes_Drift(G, GV, US, Waves, dz, U_star, time_interval, do_dyn)
     endif
   endif
 
@@ -3261,7 +3275,7 @@ subroutine finish_MOM_initialization(Time, dirs, CS)
   ! Write initial conditions
   if (CS%write_IC) then
     allocate(restart_CSp_tmp)
-    restart_CSP_tmp = CS%restart_CS
+    restart_CSp_tmp = CS%restart_CS
     call restart_registry_lock(restart_CSp_tmp, unlocked=.true.)
     allocate(z_interface(SZI_(G),SZJ_(G),SZK_(GV)+1))
     call find_eta(CS%h, CS%tv, G, GV, US, z_interface, dZref=G%Z_ref)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -481,7 +481,8 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
     Use_Stokes_PGF = associated(Waves)
     if (Use_Stokes_PGF) Use_Stokes_PGF = Waves%Stokes_PGF
     if (Use_Stokes_PGF) then
-      call Stokes_PGF(G, GV, h, u, v, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
+      call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
+      call Stokes_PGF(G, GV, US, dz, u, v, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
 
       ! We are adding Stokes_PGF to hydrostatic PGF here.  The diag PFu/PFv
       ! will therefore report the sum total PGF and we avoid other
@@ -748,7 +749,8 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
       Use_Stokes_PGF = associated(Waves)
       if (Use_Stokes_PGF) Use_Stokes_PGF = Waves%Stokes_PGF
       if (Use_Stokes_PGF) then
-        call Stokes_PGF(G, GV, h, u, v, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
+        call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
+        call Stokes_PGF(G, GV, US, dz, u, v, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
         if (.not.Waves%Passive_Stokes_PGF) then
           do k=1,nz
             do j=js,je ; do I=Isq,Ieq

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -97,7 +97,7 @@ type, public :: wave_parameters_CS ; private
                        !! Horizontal -> V points
                        !! Vertical -> Mid-points
   real, allocatable, dimension(:,:,:), public :: &
-    KvS                !< Viscosity for Stokes Drift shear [Z2 T-1 ~> m2 s-1]
+    KvS                !< Viscosity for Stokes Drift shear [H Z T-1 ~> m2 s-1 or Pa s]
 
   ! The remainder of this control structure is private
   integer :: WaveMethod = -99 !< Options for including wave information
@@ -197,6 +197,8 @@ type, public :: wave_parameters_CS ; private
   real :: VonKar = -1.0 !< The von Karman coefficient as used in the MOM_wave_interface module [nondim]
   real :: rho_air  !< A typical density of air at sea level, as used in wave calculations [R ~> kg m-3]
   real :: nu_air   !< The viscosity of air, as used in wave calculations [Z2 T-1 ~> m2 s-1]
+  real :: rho_ocn  !< A typical surface density of seawater, as used in wave calculations in
+                   !! comparison with the density of air [R ~> kg m-3].  The default is RHO_0.
   real :: SWH_from_u10sq !< A factor for converting the square of the 10 m wind speed to the
                    !! significant wave height [Z T2 L-2 ~> s2 m-1]
   real :: Charnock_min !< The minimum value of the Charnock coefficient, which relates the square of
@@ -334,7 +336,7 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
 
   if (StatisticalWaves) then
     CS%WaveMethod = LF17
-    call set_LF17_wave_params(param_file, mdl, US, CS)
+    call set_LF17_wave_params(param_file, mdl, GV, US, CS)
     if (.not.use_waves) return
   else
     CS%WaveMethod = NULL_WaveMethod
@@ -500,7 +502,7 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
          "Flag to disable updating DHH85 Stokes drift.", default=.false.)
   case (LF17_STRING) !Li and Fox-Kemper 17 wind-sea Langmuir number
     CS%WaveMethod = LF17
-    call set_LF17_wave_params(param_file, mdl, US, CS)
+    call set_LF17_wave_params(param_file, mdl, GV, US, CS)
   case (EFACTOR_STRING) !Li and Fox-Kemper 16
     CS%WaveMethod = EFACTOR
   case default
@@ -578,9 +580,10 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
 end subroutine MOM_wave_interface_init
 
 !> Set the parameters that are used to determine the averaged Stokes drift and Langmuir numbers
-subroutine set_LF17_wave_params(param_file, mdl, US, CS)
+subroutine set_LF17_wave_params(param_file, mdl, GV, US, CS)
   type(param_file_type),   intent(in)    :: param_file !< Input parameter structure
   character(len=*),        intent(in)    :: mdl        !< A module name to use in the get_param calls
+  type(verticalGrid_type), intent(in)    :: GV         !< Vertical grid structure
   type(unit_scale_type),   intent(in)    :: US         !< A dimensional unit scaling type
   type(wave_parameters_CS), pointer      :: CS         !< Wave parameter control structure
 
@@ -596,6 +599,10 @@ subroutine set_LF17_wave_params(param_file, mdl, US, CS)
   call get_param(param_file, mdl, "RHO_AIR", CS%rho_air, &
                  "A typical density of air at sea level, as used in wave calculations", &
                  units="kg m-3", default=1.225, scale=US%kg_m3_to_R)
+  call get_param(param_file, mdl, "RHO_SFC_WAVES", CS%Rho_ocn, &
+                 "A typical surface density of seawater, as used in wave calculations in "//&
+                 "comparison with the density of air.  The default is RHO_0.", &
+                 units="kg m-3", default=GV%Rho0*US%R_to_kg_m3, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "WAVE_HEIGHT_SCALE_FACTOR", CS%SWH_from_u10sq, &
                  "A factor relating the square of the 10 m wind speed to the significant "//&
                  "wave height, with a default value based on the Pierson-Moskowitz spectrum.", &
@@ -713,13 +720,13 @@ end subroutine Update_Surface_Waves
 
 !> Constructs the Stokes Drift profile on the model grid based on
 !! desired coupling options
-subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar, dt, dynamics_step)
+subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
   type(wave_parameters_CS), pointer       :: CS    !< Wave parameter Control structure
   type(ocean_grid_type),    intent(inout) :: G     !< Grid structure
   type(verticalGrid_type),  intent(in)    :: GV    !< Vertical grid structure
   type(unit_scale_type),    intent(in)    :: US    !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                            intent(in)    :: h     !< Thickness [H ~> m or kg m-2]
+                            intent(in)    :: dz    !< Thickness in height units [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                             intent(in)    :: ustar !< Wind friction velocity [Z T-1 ~> m s-1].
   real, intent(in)                        :: dt    !< Time-step for computing Stokes-tendency [T ~> s]
@@ -728,7 +735,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar, dt, dynamics_step)
   ! Local Variables
   real    :: Top, MidPoint, Bottom ! Positions within the layer [Z ~> m]
   real    :: level_thick ! The thickness of each layer [Z ~> m]
-  real    :: DecayScale ! A vertical decay scale in the test profile [Z ~> m]
+  real    :: DecayScale ! A vertical decay scale in the test profile [Z-1 ~> m-1]
   real    :: CMN_FAC  ! A nondimensional factor [nondim]
   real    :: WN       ! Model wavenumber [Z-1 ~> m-1]
   real    :: UStokes  ! A Stokes drift velocity [L T-1 ~> m s-1]
@@ -755,8 +762,8 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar, dt, dynamics_step)
         MidPoint = 0.0
         do kk = 1,GV%ke
           Top = Bottom
-          MidPoint = Bottom - GV%H_to_Z*0.25*(h(II,jj,kk)+h(IIm1,jj,kk))
-          Bottom = Bottom - GV%H_to_Z*0.5*(h(II,jj,kk)+h(IIm1,jj,kk))
+          MidPoint = Bottom - 0.25*(dz(II,jj,kk)+dz(IIm1,jj,kk))
+          Bottom = Bottom - 0.5*(dz(II,jj,kk)+dz(IIm1,jj,kk))
           CS%Us_x(II,jj,kk) = CS%TP_STKX0*exp(MidPoint*DecayScale)
         enddo
       enddo
@@ -768,8 +775,8 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar, dt, dynamics_step)
         MidPoint = 0.0
         do kk = 1,GV%ke
           Top = Bottom
-          MidPoint = Bottom - GV%H_to_Z*0.25*(h(ii,JJ,kk)+h(ii,JJm1,kk))
-          Bottom = Bottom - GV%H_to_Z*0.5*(h(ii,JJ,kk)+h(ii,JJm1,kk))
+          MidPoint = Bottom - 0.25*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
+          Bottom = Bottom - 0.5*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
           CS%Us_y(ii,JJ,kk) = CS%TP_STKY0*exp(MidPoint*DecayScale)
         enddo
       enddo
@@ -796,7 +803,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar, dt, dynamics_step)
         do kk = 1,GV%ke
           Top = Bottom
           IIm1 = max(II-1,1)
-          level_thick = 0.5*GV%H_to_Z*(h(II,jj,kk)+h(IIm1,jj,kk))
+          level_thick = 0.5*(dz(II,jj,kk)+dz(IIm1,jj,kk))
           MidPoint = Top - 0.5*level_thick
           Bottom = Top - level_thick
 
@@ -854,7 +861,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar, dt, dynamics_step)
         do kk = 1,GV%ke
           Top = Bottom
           JJm1 = max(JJ-1,1)
-          level_thick = 0.5*GV%H_to_Z*(h(ii,JJ,kk)+h(ii,JJm1,kk))
+          level_thick = 0.5*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
           MidPoint = Top - 0.5*level_thick
           Bottom = Top - level_thick
 
@@ -908,8 +915,8 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar, dt, dynamics_step)
           do kk = 1,GV%ke
             Top = Bottom
             IIm1 = max(II-1,1)
-            MidPoint = Top - GV%H_to_Z*0.25*(h(II,jj,kk)+h(IIm1,jj,kk))
-            Bottom = Top - GV%H_to_Z*0.5*(h(II,jj,kk)+h(IIm1,jj,kk))
+            MidPoint = Top - 0.25*(dz(II,jj,kk)+dz(IIm1,jj,kk))
+            Bottom = Top - 0.5*(dz(II,jj,kk)+dz(IIm1,jj,kk))
             !bgr note that this is using a u-point ii on h-point ustar
             !    this code has only been previous used for uniform
             !    grid cases.  This needs fixed if DHH85 is used for non
@@ -926,8 +933,8 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar, dt, dynamics_step)
           do kk=1, GV%ke
             Top = Bottom
             JJm1 = max(JJ-1,1)
-            MidPoint = Bottom - GV%H_to_Z*0.25*(h(ii,JJ,kk)+h(ii,JJm1,kk))
-            Bottom = Bottom - GV%H_to_Z*0.5*(h(ii,JJ,kk)+h(ii,JJm1,kk))
+            MidPoint = Bottom - 0.25*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
+            Bottom = Bottom - 0.5*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
             !bgr note that this is using a v-point jj on h-point ustar
             !    this code has only been previous used for uniform
             !    grid cases.  This needs fixed if DHH85 is used for non
@@ -965,9 +972,8 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar, dt, dynamics_step)
   ! in the routine it is needed by (e.g. KPP or ePBL).
   do jj = G%jsc, G%jec
     do ii = G%isc,G%iec
-      Top = h(ii,jj,1)*GV%H_to_Z
-      call get_Langmuir_Number( La, G, GV, US, Top, ustar(ii,jj), ii, jj, &
-             h(ii,jj,:), CS, Override_MA=.false.)
+      call get_Langmuir_Number( La, G, GV, US, dz(ii,jj,1), ustar(ii,jj), ii, jj, &
+             dz(ii,jj,:), CS, Override_MA=.false.)
       CS%La_turb(ii,jj) = La
     enddo
   enddo
@@ -1138,7 +1144,7 @@ end subroutine Surface_Bands_by_data_override
 !! Note this can be called with an unallocated Waves pointer, which is okay if we
 !!  want the wind-speed only dependent Langmuir number.  Therefore, we need to be
 !!  careful about what we try to access here.
-subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, h, Waves, &
+subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, dz, Waves, &
                                 U_H, V_H, Override_MA )
   type(ocean_grid_type),     intent(in)  :: G     !< Ocean grid structure
   type(verticalGrid_type),   intent(in)  :: GV    !< Ocean vertical grid structure
@@ -1148,7 +1154,7 @@ subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, h, Waves, &
   real,                      intent(in)  :: ustar !< Friction velocity [Z T-1 ~> m s-1]
   integer,                   intent(in)  :: i     !< Meridional index of h-point
   integer,                   intent(in)  :: j     !< Zonal index of h-point
-  real, dimension(SZK_(GV)), intent(in)  :: h     !< Grid layer thickness [H ~> m or kg m-2]
+  real, dimension(SZK_(GV)), intent(in)  :: dz    !< Grid layer thickness [Z ~> m]
   type(Wave_parameters_CS),  pointer     :: Waves !< Surface wave control structure.
   real, dimension(SZK_(GV)), &
                    optional, intent(in)  :: U_H   !< Zonal velocity at H point [L T-1 ~> m s-1] or [m s-1]
@@ -1161,7 +1167,7 @@ subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, h, Waves, &
 
 
 !Local Variables
-  real :: Top, bottom, midpoint  ! Positions within each layer [Z ~> m]
+  real :: Top, Bottom, MidPoint  ! Positions within each layer [Z ~> m]
   real :: Dpt_LASL         ! Averaging depth for Stokes drift [Z ~> m]
   real :: ShearDirection   ! Shear angular direction from atan2 [radians]
   real :: WaveDirection    ! Wave angular direction from atan2 [radians]
@@ -1185,8 +1191,11 @@ subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, h, Waves, &
     bottom = 0.0
     do kk = 1,GV%ke
       Top = Bottom
-      MidPoint = Bottom + GV%H_to_Z*0.5*h(kk)
-      Bottom = Bottom + GV%H_to_Z*h(kk)
+      MidPoint = Bottom + 0.5*dz(kk)
+      Bottom = Bottom + dz(kk)
+      !### Given the sign convention that Dpt_LASL is negative, the next line seems to have a bug.
+      !    To correct this bug, this line should be changed to:
+      ! if (MidPoint > abs(Dpt_LASL) .and. (kk > 1) .and. ContinueLoop) then
       if (MidPoint > Dpt_LASL .and. kk > 1 .and. ContinueLoop) then
         ShearDirection = atan2(V_H(1)-V_H(kk),U_H(1)-U_H(kk))
         ContinueLoop = .false.
@@ -1199,8 +1208,8 @@ subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, h, Waves, &
       US_H(kk) = 0.5*(Waves%US_X(I,j,kk)+Waves%US_X(I-1,j,kk))
       VS_H(kk) = 0.5*(Waves%US_Y(i,J,kk)+Waves%US_Y(i,J-1,kk))
     enddo
-    call Get_SL_Average_Prof( GV, Dpt_LASL, h, US_H, LA_STKx)
-    call Get_SL_Average_Prof( GV, Dpt_LASL, h, VS_H, LA_STKy)
+    call Get_SL_Average_Prof( GV, Dpt_LASL, dz, US_H, LA_STKx)
+    call Get_SL_Average_Prof( GV, Dpt_LASL, dz, VS_H, LA_STKy)
     LA_STK = sqrt(LA_STKX*LA_STKX+LA_STKY*LA_STKY)
   elseif (Waves%WaveMethod==SURFBANDS) then
     allocate(StkBand_X(Waves%NumBands), StkBand_Y(Waves%NumBands))
@@ -1218,11 +1227,11 @@ subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, h, Waves, &
       US_H(kk) = 0.5*(Waves%US_X(I,j,kk)+Waves%US_X(I-1,j,kk))
       VS_H(kk) = 0.5*(Waves%US_Y(i,J,kk)+Waves%US_Y(i,J-1,kk))
     enddo
-    call Get_SL_Average_Prof( GV, Dpt_LASL, h, US_H, LA_STKx)
-    call Get_SL_Average_Prof( GV, Dpt_LASL, h, VS_H, LA_STKy)
+    call Get_SL_Average_Prof( GV, Dpt_LASL, dz, US_H, LA_STKx)
+    call Get_SL_Average_Prof( GV, Dpt_LASL, dz, VS_H, LA_STKy)
     LA_STK = sqrt(LA_STKX**2 + LA_STKY**2)
   elseif (Waves%WaveMethod==LF17) then
-    call get_StokesSL_LiFoxKemper(ustar, hbl*Waves%LA_FracHBL, GV, US, Waves, LA_STK, LA)
+    call get_StokesSL_LiFoxKemper(ustar, HBL*Waves%LA_FracHBL, GV, US, Waves, LA_STK, LA)
   elseif (Waves%WaveMethod==Null_WaveMethod) then
     call MOM_error(FATAL, "Get_Langmuir_number called without defining a WaveMethod. "//&
                           "Suggest to make sure USE_LT is set/overridden to False or choose "//&
@@ -1322,7 +1331,7 @@ subroutine get_StokesSL_LiFoxKemper(ustar, hbl, GV, US, CS, UStokes_SL, LA)
     ! This code should be revised to minimize the number of divisions and cancel out common factors.
 
     ! Computing u10 based on u_star and COARE 3.5 relationships
-    call ust_2_u10_coare3p5(ustar*sqrt(GV%Rho0/CS%rho_air), u10, GV, US, CS)
+    call ust_2_u10_coare3p5(ustar*sqrt(CS%rho_ocn/CS%rho_air), u10, GV, US, CS)
     ! surface Stokes drift
     UStokes = us_to_u10*u10
     !
@@ -1406,19 +1415,19 @@ subroutine get_StokesSL_LiFoxKemper(ustar, hbl, GV, US, CS, UStokes_SL, LA)
 end subroutine Get_StokesSL_LiFoxKemper
 
 !> Get SL Averaged Stokes drift from a Stokes drift Profile
-subroutine Get_SL_Average_Prof( GV, AvgDepth, H, Profile, Average )
+subroutine Get_SL_Average_Prof( GV, AvgDepth, dz, Profile, Average )
   type(verticalGrid_type),  &
        intent(in)   :: GV       !< Ocean vertical grid structure
-  real, intent(in)  :: AvgDepth !< Depth to average over (negative) [Z ~> m].
+  real, intent(in)  :: AvgDepth !< Depth to average over (negative) [Z ~> m]
   real, dimension(SZK_(GV)), &
-       intent(in)   :: H        !< Grid thickness [H ~> m or kg m-2]
+       intent(in)   :: dz       !< Grid thickness [Z ~> m]
   real, dimension(SZK_(GV)), &
        intent(in)   :: Profile  !< Profile of quantity to be averaged in arbitrary units [A]
                                 !! (used here for Stokes drift)
   real, intent(out) :: Average  !< Output quantity averaged over depth AvgDepth [A]
                                 !! (used here for Stokes drift)
   !Local variables
-  real :: top, midpoint, bottom ! Depths, negative downward [Z ~> m].
+  real :: Top, Bottom ! Depths, negative downward [Z ~> m]
   real :: Sum  ! The depth weighted vertical sum of a quantity [A Z ~> A m]
   integer :: kk
 
@@ -1429,10 +1438,9 @@ subroutine Get_SL_Average_Prof( GV, AvgDepth, H, Profile, Average )
   bottom = 0.0
   do kk = 1, GV%ke
     Top = Bottom
-    MidPoint = Bottom - GV%H_to_Z * 0.5*h(kk)
-    Bottom = Bottom - GV%H_to_Z * h(kk)
+    Bottom = Bottom - dz(kk)
     if (AvgDepth < Bottom) then ! The whole cell is within H_LA
-      Sum = Sum + Profile(kk) * (GV%H_to_Z * H(kk))
+      Sum = Sum + Profile(kk) * dz(kk)
     elseif (AvgDepth < Top) then ! A partial cell is within H_LA
       Sum = Sum + Profile(kk) * (Top-AvgDepth)
       exit
@@ -1546,7 +1554,7 @@ end subroutine DHH85_mid
 
 !> Explicit solver for Stokes mixing.
 !! Still in development do not use.
-subroutine StokesMixing(G, GV, dt, h, u, v, Waves )
+subroutine StokesMixing(G, GV, dt, h, dz, u, v, Waves )
   type(ocean_grid_type), &
        intent(in)    :: G     !< Ocean grid
   type(verticalGrid_type), &
@@ -1554,6 +1562,8 @@ subroutine StokesMixing(G, GV, dt, h, u, v, Waves )
   real, intent(in)   :: dt    !< Time step of MOM6 [T ~> s] for explicit solver
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
        intent(in)    :: h     !< Layer thicknesses [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+       intent(in)    :: dz    !< Vertical distance between interfaces around a layer [Z ~> m]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
        intent(inout) :: u     !< Velocity i-component [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
@@ -1561,8 +1571,9 @@ subroutine StokesMixing(G, GV, dt, h, u, v, Waves )
   type(Wave_parameters_CS), &
        pointer       :: Waves !< Surface wave related control structure.
   ! Local variables
-  real :: dTauUp, dTauDn ! Vertical momentum fluxes [Z L T-2 ~> m2 s-2]
-  real :: h_Lay  ! The layer thickness at a velocity point [Z ~> m].
+  real :: dTauUp, dTauDn ! Vertical momentum fluxes [H L T-2 ~> m2 s-2 or Pa]
+  real :: h_lay  ! The layer thickness at a velocity point [H ~> m or kg m-2]
+  real :: dz_lay ! The distance between interfaces at a velocity point [Z ~> m]
   integer :: i, j, k
 
 ! This is a template to think about down-Stokes mixing.
@@ -1571,18 +1582,19 @@ subroutine StokesMixing(G, GV, dt, h, u, v, Waves )
   do k = 1, GV%ke
     do j = G%jsc, G%jec
       do I = G%iscB, G%iecB
-        h_lay = GV%H_to_Z*0.5*(h(i,j,k)+h(i+1,j,k))
+        h_lay = 0.5*(h(i,j,k)+h(i+1,j,k))
+        dz_lay = 0.5*(dz(i,j,k)+dz(i+1,j,k))
         dTauUp = 0.0
         if (k > 1) &
-          dTauUp = 0.5*(waves%Kvs(i,j,k)+waves%Kvs(i+1,j,k)) * &
+          dTauUp = (0.5*(waves%Kvs(i,j,k)+waves%Kvs(i+1,j,k))) * &
                (waves%us_x(i,j,k-1)-waves%us_x(i,j,k)) / &
-               (0.5*(h_lay + GV%H_to_Z*0.5*(h(i,j,k-1)+h(i+1,j,k-1)) ))
+               (0.5*(dz_lay + 0.5*(dz(i,j,k-1)+dz(i+1,j,k-1)) ))
         dTauDn = 0.0
         if (k < GV%ke-1) &
-          dTauDn = 0.5*(waves%Kvs(i,j,k+1)+waves%Kvs(i+1,j,k+1)) * &
+          dTauDn = (0.5*(waves%Kvs(i,j,k+1)+waves%Kvs(i+1,j,k+1))) * &
                (waves%us_x(i,j,k)-waves%us_x(i,j,k+1)) / &
-               (0.5*(h_lay + GV%H_to_Z*0.5*(h(i,j,k+1)+h(i+1,j,k+1)) ))
-        u(i,j,k) = u(i,j,k) + dt * (dTauUp-dTauDn) / h_Lay
+               (0.5*(dz_lay + 0.5*(dz(i,j,k+1)+dz(i+1,j,k+1)) ))
+        u(i,j,k) = u(i,j,k) + dt * (dTauUp-dTauDn) / h_lay
       enddo
     enddo
   enddo
@@ -1590,18 +1602,19 @@ subroutine StokesMixing(G, GV, dt, h, u, v, Waves )
   do k = 1, GV%ke
     do J = G%jscB, G%jecB
       do i = G%isc, G%iec
-        h_Lay = GV%H_to_Z*0.5*(h(i,j,k)+h(i,j+1,k))
+        h_lay = 0.5*(h(i,j,k)+h(i,j+1,k))
+        dz_lay = 0.5*(dz(i,j,k)+dz(i,j+1,k))
         dTauUp = 0.
         if (k > 1) &
-          dTauUp = 0.5*(waves%Kvs(i,j,k)+waves%Kvs(i,j+1,k)) * &
+          dTauUp = (0.5*(waves%Kvs(i,j,k)+waves%Kvs(i,j+1,k))) * &
                (waves%us_y(i,j,k-1)-waves%us_y(i,j,k)) / &
-               (0.5*(h_lay + GV%H_to_Z*0.5*(h(i,j,k-1)+h(i,j+1,k-1)) ))
+               (0.5*(dz_lay + 0.5*(dz(i,j,k-1)+dz(i,j+1,k-1)) ))
         dTauDn = 0.0
         if (k < GV%ke-1) &
-          dTauDn =0.5*(waves%Kvs(i,j,k+1)+waves%Kvs(i,j+1,k+1)) * &
+          dTauDn = (0.5*(waves%Kvs(i,j,k+1)+waves%Kvs(i,j+1,k+1))) * &
                (waves%us_y(i,j,k)-waves%us_y(i,j,k+1)) / &
-               (0.5*(h_lay + GV%H_to_Z*0.5*(h(i,j,k+1)+h(i,j+1,k+1)) ))
-        v(i,J,k) = v(i,J,k) + dt * (dTauUp-dTauDn) / h_Lay
+               (0.5*(dz_lay + 0.5*(dz(i,j,k+1)+dz(i,j+1,k+1)) ))
+        v(i,J,k) = v(i,J,k) + dt * (dTauUp-dTauDn) / h_lay
       enddo
     enddo
   enddo
@@ -1658,13 +1671,15 @@ end subroutine CoriolisStokes
 !! including analytical integration of Stokes shear using multiple-exponential decay
 !! Stokes drift profile and vertical integration of the resulting pressure
 !! anomaly to the total pressure gradient force
-subroutine Stokes_PGF(G, GV, h, u, v, PFu_Stokes, PFv_Stokes, CS )
+subroutine Stokes_PGF(G, GV, US, dz, u, v, PFu_Stokes, PFv_Stokes, CS )
   type(ocean_grid_type), &
        intent(in)    :: G     !< Ocean grid
   type(verticalGrid_type), &
        intent(in)    :: GV    !< Ocean vertical grid
+  type(unit_scale_type), &
+       intent(in)    :: US    !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),&
-       intent(in)    :: h       !< Layer thicknesses [H ~> m or kg m-2]
+       intent(in)    :: dz      !< Layer thicknesses in height units [Z ~> m]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
        intent(in) :: u          !< Lagrangian Velocity i-component [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
@@ -1737,12 +1752,13 @@ subroutine Stokes_PGF(G, GV, h, u, v, PFu_Stokes, PFv_Stokes, CS )
       zi_l(1) = 0.0
       zi_r(1) = 0.0
       do k = 1, G%ke
-        h_l = h(i,j,k)*GV%H_to_Z
-        h_r = h(i+1,j,k)*GV%H_to_Z
+        h_l = dz(i,j,k)
+        h_r = dz(i+1,j,k)
         zi_l(k+1) = zi_l(k) - h_l
         zi_r(k+1) = zi_r(k) - h_r
-        Idz_l(k) = 1./max(0.1,h_l)
-        Idz_r(k) = 1./max(0.1,h_r)
+        !### If the code were properly refactored, the following hard-coded constants would be unnecessary.
+        Idz_l(k) = 1./max(0.1*US%m_to_Z, h_l)
+        Idz_r(k) = 1./max(0.1*US%m_to_Z, h_r)
       enddo
       do k = 1,G%ke
         ! Computing (left/right) Eulerian velocities assuming the velocity passed to this routine is the
@@ -1830,12 +1846,13 @@ subroutine Stokes_PGF(G, GV, h, u, v, PFu_Stokes, PFv_Stokes, CS )
       zi_l(1) = 0.0
       zi_r(1) = 0.0
       do k = 1, G%ke
-        h_l = h(i,j,k)*GV%H_to_Z
-        h_r = h(i,j+1,k)*GV%H_to_Z
+        h_l = dz(i,j,k)
+        h_r = dz(i,j+1,k)
         zi_l(k+1) = zi_l(k) - h_l
         zi_r(k+1) = zi_r(k) - h_r
-        Idz_l(k) = 1./max(0.1,h_l)
-        Idz_r(k) = 1./max(0.1,h_r)
+        !### If the code were properly refactored, the following hard-coded constants would be unnecessary.
+        Idz_l(k) = 1. / max(0.1*US%m_to_Z, h_l)
+        Idz_r(k) = 1. / max(0.1*US%m_to_Z, h_r)
       enddo
       do k = 1,G%ke
         ! Computing (left/right) Eulerian velocities assuming the velocity passed to this routine is the


### PR DESCRIPTION
  The surface gravity waves invariably work with depths in meters to match the units of the horizontal wavenumbers, even in non-Boussinesq mode, so several of the variables that are passed to or used in the MOM_wave_interface module have been revised to use units of [Z ~> m] and not [H ~> m or kg m-2].  There are changes to the names or units of a total of 8 arguments to Stokes_PGF, Update_Stokes_Drift, Get_StokesSL_LiFoxKemper, Get_SL_Average_Prof and get_Langmuir_Number, and a new argument to StokesMixing.  To accommodate these changes, there are now calls to thickness_to_dz that precede the Update_Stokes_Drift or Stokes_PGF calls and a new 3d array in step_MOM.

  Additionally, four hard-coded dimensional constants in Stokes_PGF were given the needed scaling factors to pass dimensional consistency testing.  This change also required the addition of a unit_scale_type argument to Stokes_PGF, and corresponding changes to the calls to this routine from step_MOM_dyn_split_RK2. Three comments pointing out probable bugs or instances of inaccurate algorithms were also added.  Incorrect units were also fixed in the comments describing one internal variable in Update_Stokes_Drift.

  Also added the new runtime parameter RHO_SFC_WAVES to set the surface seawater density that is used in comparison with the typical density of air set by RHO_AIR to estimate the 10-meter wind speed from the ocean friction velocity and the COARE 3.5 stress relationships inside of get_StokesSL_LiFoxKemper() when the Li and Fox-Kemper (2017) wave model (i.e. LF17) is used.  As a part of this change, there is a new verticalGrid_type argument to the internal routine set_LF17_wave_params().  By default, RHO_SFC_WAVES is set to RHO_0.

  Other specific changes include:

 - Changed the units of the publicly visible KvS element of the wave_parameters_CS from [Z2 T-1] to [H Z T-1]

 - Replaced the layer thickness argument (h with units of [H ~> m or kg m-2]) to Update_Stokes_Drift(), Get_SL_Average_Prof(), get_Langmuir_Number() and Stokes_PGF() with a vertical layer extent argument (dz in units of [Z ~> m])

 - Add a vertical layer extent argument (dz) to StokesMixing()

 - Add a unit_scale_type argument to Stokes_PGF()

 - Multiply a hard-coded length scale in Stokes_PGF by the correct unit scaling factor and added comments to highlight these hard-coded lengths

 - Corrected the unit description of the DecayScale internal variable

 - Changed the units of 3 internal variables and added 1 new internal variable in StokesMixing.

 - Added two new arrays to step_MOM for the layer vertical extent and friction velocity being set via thickness_to_dz and find_ustar and being passed to Update_Stokes_Drift

 - Added new arrays for the layer vertical extent and calls to thickness_to_dz in KPP_compute_BLD and energetic_PBL, as well as a new dz argument to ePBL_column to provide an altered argument to get_Langmuir_Number

 - Use find_ustar to set the friction velocity passed to Update_Stokes_Drift

 - Update fluxes%ustar or fluxes%tau_mag halos as necessary when the waves are in use

  A total of 28 unit conversion factors were eliminated with these changes.

  All answers are bitwise identical in Boussinesq mode, but they are changed in non-Boussinesq mode by the use of the layer specific volume to convert between thicknesses and vertical extents.  The units of several arguments to publicly visible routines are altered as is a publicly visible element in wave_parameters_CS and there is a new runtime parameter that appears in some MOM_parameter_doc files.