### PR TITLE
+*Non-Boussinesq revision of full_convection

### DIFF
--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -344,7 +344,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
     call cpu_clock_begin(id_clock_kappaShear)
     if (CS%Vertex_shear) then
       call full_convection(G, GV, US, h, tv, T_f, S_f, fluxes%p_surf, &
-                           GV%Z_to_H*kappa_dt_fill, halo=1)
+                           kappa_dt_fill, halo=1)
 
       call calc_kappa_shear_vertex(u, v, h, T_f, S_f, tv, fluxes%p_surf, visc%Kd_shear, &
                                    visc%TKE_turb, visc%Kv_shear_Bu, dt, G, GV, US, CS%kappaShear_CSp)


### PR DESCRIPTION
  This commit revises full_convection to avoid any dependency on the Boussinesq reference density when in non-Boussinesq mode.  Specifically, it changes the units of the Kddt_smooth argument to full_convection and its counterpart in smoothed_dRdT_dRdS to use units of [H Z ~> m2 or kg s-1], which becomes a mass based diffusivity when in non-Boussinesq mode.  This change also uses vertical distances for internal calculations in smoothed_dRdT_dRdS, and includes a call to thickness_to_dz in the full_convection routine.

  This commit also revises the unit conversion of the (absurdly large) mixing length in unstable points in full_convection and of the (tiny) added smoothing distance used in the denominators of some expressions in smoothed_dRdT_dRdS to avoid division by zero with massless layers so that they are both based on the density used in rescaling input parameters (RHO_KV_CONVERT), and do not depend directly on the Boussinesq reference density (RHO_0).  These parameters would have been set via get_param calls, but there is no control structure for full_convection parameters.

  All Boussinesq answers are bitwise identical, but non-Boussinesq answers are altered by the use of the layer specific volumes, rather than the Boussinesq reference density, to convert layer thicknesses into vertical distances.  This commit includes a change to the units of an argument (Kddt_smooth) to a publicly visible interface (full_convection).