### PR TITLE
*Fix allocate_forcing_by_ref tau_mag_gustless bug

### DIFF
--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -3331,7 +3331,7 @@ subroutine allocate_forcing_by_ref(fluxes_ref, G, fluxes)
       do_shelf, do_iceberg, do_salt, do_heat_added, do_buoy)
 
   call allocate_forcing_type(G, fluxes, do_water, do_heat, do_ustar, &
-      do_press, do_shelf, do_iceberg, do_salt, do_taumag)
+      do_press, do_shelf, do_iceberg, do_salt, tau_mag=do_taumag)
 
   ! The following fluxes would typically be allocated by the driver
   call myAlloc(fluxes%sw_vis_dir, G%isd, G%ied, G%jsd, G%jed, &


### PR DESCRIPTION
  Added the name to the do_taumag argument in a call to allocate_forcing_type in allocate_forcing_by_ref to account for the fact that there are unused wave-related optional arguments in this interface.  When this was omitted in the current code, the wrong arrays are being allocated during rotation tests with resultant segmentation faults in those tests.  This commit corrects a bug that was recently added with MOM6 dev/gfdl PR #445.