### PR TITLE
+Non-Boussinesq open boundary conditions

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -306,6 +306,7 @@ type, public :: barotropic_CS ; private
   type(group_pass_type) :: pass_ubt_Cor !< Handle for a group halo pass
   type(group_pass_type) :: pass_ubta_uhbta !< Handle for a group halo pass
   type(group_pass_type) :: pass_e_anom !< Handle for a group halo pass
+  type(group_pass_type) :: pass_SpV_avg !< Handle for a group halo pass
 
   !>@{ Diagnostic IDs
   integer :: id_PFu_bt = -1, id_PFv_bt = -1, id_Coru_bt = -1, id_Corv_bt = -1
@@ -422,7 +423,7 @@ contains
 subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, &
                   eta_PF_in, U_Cor, V_Cor, accel_layer_u, accel_layer_v, &
                   eta_out, uhbtav, vhbtav, G, GV, US, CS, &
-                  visc_rem_u, visc_rem_v, ADp, OBC, BT_cont, eta_PF_start, &
+                  visc_rem_u, visc_rem_v, SpV_avg, ADp, OBC, BT_cont, eta_PF_start, &
                   taux_bot, tauy_bot, uh0, vh0, u_uh0, v_vh0, etaav)
   type(ocean_grid_type),                   intent(inout) :: G       !< The ocean's grid structure.
   type(verticalGrid_type),                   intent(in)  :: GV      !< The ocean's vertical grid structure.
@@ -472,6 +473,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                                                          !! viscosity is applied, in the zonal direction [nondim].
                                                          !! Visc_rem_u is between 0 (at the bottom) and 1 (far above).
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)  :: visc_rem_v    !< Ditto for meridional direction [nondim].
+  real, dimension(SZI_(G),SZJ_(G)),           intent(in)  :: SpV_avg     !< The column average specific volume, used
+                                                         !! in non-Boussinesq OBC calculations [R-1 ~> m3 kg-1]
   type(accel_diag_ptrs),                      pointer    :: ADp          !< Acceleration diagnostic pointers
   type(ocean_OBC_type),                       pointer    :: OBC          !< The open boundary condition structure.
   type(BT_cont_type),                         pointer    :: BT_cont      !< A structure with elements that describe
@@ -614,6 +617,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                   ! from the thickness point [L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2].
                   ! (See Hallberg, J Comp Phys 1997 for a discussion.)
     eta_src, &    ! The source of eta per barotropic timestep [H ~> m or kg m-2].
+    SpV_col_avg, &  ! The column average specific volume [R-1 ~> m3 kg-1]
     dyn_coef_eta, & ! The coefficient relating the changes in eta to the
                   ! dynamic surface pressure under rigid ice
                   ! [L2 T-2 H-1 ~> m s-2 or m4 s-2 kg-1].
@@ -773,10 +777,6 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     apply_OBC_open = open_boundary_query(OBC, apply_open_OBC=.true.)
     apply_OBCs = open_boundary_query(OBC, apply_specified_OBC=.true.) .or. &
            apply_OBC_flather .or. apply_OBC_open
-
-    if (apply_OBC_flather .and. .not.GV%Boussinesq) call MOM_error(FATAL, &
-      "btstep: Flather open boundary conditions have not yet been "// &
-      "implemented for a non-Boussinesq model.")
   endif
 
   num_cycles = 1
@@ -866,6 +866,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     if (apply_OBC_open) &
       call create_group_pass(CS%pass_eta_ubt, uhbt_int, vhbt_int, CS%BT_Domain)
   endif
+  if (apply_OBC_flather .and. .not.GV%Boussinesq) &
+    call create_group_pass(CS%pass_SpV_avg, SpV_col_avg, CS%BT_domain)
 
   call create_group_pass(CS%pass_ubt_Cor, ubt_Cor, vbt_Cor, G%Domain)
   ! These passes occur at the end of the routine, as data is being readied to
@@ -978,6 +980,22 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     Cor_ref_v(i,J) = 0.0 ; BT_force_v(i,J) = 0.0 ; vbt(i,J) = 0.0
     Datv(i,J) = 0.0 ; bt_rem_v(i,J) = 0.0 ; vhbt0(i,J) = 0.0
   enddo ; enddo
+
+  if (apply_OBCs) then
+    SpV_col_avg(:,:) = 0.0
+    if (apply_OBC_flather .and. .not.GV%Boussinesq) then
+      ! Copy the column average specific volumes into a wide halo array
+      !$OMP parallel do default(shared)
+      do j=js,je ; do i=is,ie
+        SpV_col_avg(i,j) = Spv_avg(i,j)
+      enddo ; enddo
+      if (nonblock_setup) then
+        call start_group_pass(CS%pass_SpV_avg, CS%BT_domain)
+      else
+        call do_group_pass(CS%pass_SpV_avg, CS%BT_domain)
+      endif
+    endif
+  endif
 
   if (CS%linear_wave_drag) then
     !$OMP parallel do default(shared)
@@ -1125,12 +1143,15 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   ! Set up fields related to the open boundary conditions.
   if (apply_OBCs) then
+    if (nonblock_setup .and. apply_OBC_flather .and. .not.GV%Boussinesq) &
+      call complete_group_pass(CS%pass_SpV_avg, CS%BT_domain)
+
     if (CS%TIDAL_SAL_FLATHER) then
-       call set_up_BT_OBC(OBC, eta, CS%BT_OBC, CS%BT_Domain, G, GV, US, MS, ievf-ie, use_BT_cont, &
-            integral_BT_cont, dt, Datu, Datv, BTCL_u, BTCL_v, dgeo_de)
+      call set_up_BT_OBC(OBC, eta, SpV_col_avg, CS%BT_OBC, CS%BT_Domain, G, GV, US, CS, MS, ievf-ie, &
+                         use_BT_cont, integral_BT_cont, dt, Datu, Datv, BTCL_u, BTCL_v, dgeo_de)
     else
-       call set_up_BT_OBC(OBC, eta, CS%BT_OBC, CS%BT_Domain, G, GV, US, MS, ievf-ie, use_BT_cont, &
-            integral_BT_cont, dt, Datu, Datv, BTCL_u, BTCL_v)
+      call set_up_BT_OBC(OBC, eta, SpV_col_avg, CS%BT_OBC, CS%BT_Domain, G, GV, US, CS, MS, ievf-ie, &
+                         use_BT_cont, integral_BT_cont, dt, Datu, Datv, BTCL_u, BTCL_v)
     endif
   endif
 
@@ -2337,8 +2358,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
       !$OMP single
       call apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, &
-             ubt_trans, vbt_trans, eta, ubt_old, vbt_old, CS%BT_OBC, &
-             G, MS, GV, US, iev-ie, dtbt, bebt, use_BT_cont, integral_BT_cont, &
+             ubt_trans, vbt_trans, eta, SpV_col_avg, ubt_old, vbt_old, CS%BT_OBC, &
+             G, MS, GV, US, CS, iev-ie, dtbt, bebt, use_BT_cont, integral_BT_cont, &
              n*dtbt, Datu, Datv, BTCL_u, BTCL_v, uhbt0, vhbt0, &
              ubt_int_prev, vbt_int_prev, uhbt_int_prev, vhbt_int_prev)
       !$OMP end single
@@ -2907,8 +2928,8 @@ end subroutine set_dtbt
 !> The following 4 subroutines apply the open boundary conditions.
 !! This subroutine applies the open boundary conditions on barotropic
 !! velocities and mass transports, as developed by Mehmet Ilicak.
-subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, eta, &
-                               ubt_old, vbt_old, BT_OBC, G, MS, GV, US, halo, dtbt, bebt, &
+subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, eta, SpV_avg, &
+                               ubt_old, vbt_old, BT_OBC, G, MS, GV, US, CS, halo, dtbt, bebt, &
                                use_BT_cont, integral_BT_cont, dt_elapsed, Datu, Datv, &
                                BTCL_u, BTCL_v, uhbt0, vhbt0, ubt_int, vbt_int, uhbt_int, vhbt_int)
   type(ocean_OBC_type),                  pointer       :: OBC     !< An associated pointer to an OBC type.
@@ -2928,6 +2949,7 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
                                                                   !! transports [L T-1 ~> m s-1].
   real, dimension(SZIW_(MS),SZJW_(MS)),  intent(in)    :: eta     !< The barotropic free surface height anomaly or
                                                                   !! column mass anomaly [H ~> m or kg m-2].
+  real, dimension(SZIW_(MS),SZJW_(MS)),  intent(in)    :: SpV_avg !< The column average specific volume [R-1 ~> m3 kg-1]
   real, dimension(SZIBW_(MS),SZJW_(MS)), intent(in)    :: ubt_old !< The starting value of ubt in a barotropic
                                                                   !! step [L T-1 ~> m s-1].
   real, dimension(SZIW_(MS),SZJBW_(MS)), intent(in)    :: vbt_old !< The starting value of vbt in a barotropic
@@ -2937,6 +2959,7 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
                                                                   !! set by set_up_BT_OBC.
   type(verticalGrid_type),               intent(in)    :: GV      !< The ocean's vertical grid structure.
   type(unit_scale_type),                 intent(in)    :: US      !< A dimensional unit scaling type
+  type(barotropic_CS),                   intent(in)    :: CS      !< Barotropic control structure
   integer,                               intent(in)    :: halo    !< The extra halo size to use here.
   real,                                  intent(in)    :: dtbt    !< The time step [T ~> s].
   real,                                  intent(in)    :: bebt    !< The fractional weighting of the future velocity
@@ -2979,14 +3002,14 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
   real :: vel_prev    ! The previous velocity [L T-1 ~> m s-1].
   real :: vel_trans   ! The combination of the previous and current velocity
                       ! that does the mass transport [L T-1 ~> m s-1].
-  real :: dZ_u        ! The total vertical column extent at a u-point [Z ~> m]
-  real :: dZ_v        ! The total vertical column extent at a v-point [Z ~> m]
   real :: cfl         ! The CFL number at the point in question [nondim]
   real :: u_inlet     ! The zonal inflow velocity [L T-1 ~> m s-1]
   real :: v_inlet     ! The meridional inflow velocity [L T-1 ~> m s-1]
   real :: uhbt_int_new ! The updated time-integrated zonal transport [H L2 ~> m3]
   real :: vhbt_int_new ! The updated time-integrated meridional transport [H L2 ~> m3]
   real :: ssh_in      ! The inflow sea surface height [Z ~> m]
+  real :: ssh_1       ! The sea surface height in the interior cell adjacent to the an OBC face [Z ~> m]
+  real :: ssh_2       ! The sea surface height in the next cell inward from the OBC face [Z ~> m]
   real :: Idtbt       ! The inverse of the barotropic time step [T-1 ~> s-1]
   integer :: i, j, is, ie, js, je
   is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
@@ -3005,12 +3028,22 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
         if (OBC%segment(OBC%segnum_u(I,j))%Flather) then
           cfl = dtbt * BT_OBC%Cg_u(I,j) * G%IdxCu(I,j) ! CFL
           u_inlet = cfl*ubt_old(I-1,j) + (1.0-cfl)*ubt_old(I,j)  ! Valid for cfl<1
-          ssh_in = GV%H_to_Z*(eta(i,j) + (0.5-cfl)*(eta(i,j)-eta(i-1,j)))      ! internal
-          dZ_u = BT_OBC%dZ_u(I,j)
-          vel_prev = ubt(I,j)
-          ubt(I,j) = 0.5*((u_inlet + BT_OBC%ubt_outer(I,j)) + &
-              (BT_OBC%Cg_u(I,j)/dZ_u) * (ssh_in-BT_OBC%SSH_outer_u(I,j)))
-          vel_trans = (1.0-bebt)*vel_prev + bebt*ubt(I,j)
+          if (GV%Boussinesq) then
+            ssh_in = GV%H_to_Z*(eta(i,j) + (0.5-cfl)*(eta(i,j)-eta(i-1,j)))      ! internal
+          else
+            ssh_1 = GV%H_to_RZ * eta(i,j) * SpV_avg(i,j) - (CS%bathyT(i,j) + G%Z_ref)
+            ssh_2 = GV%H_to_RZ * eta(i-1,j) * SpV_avg(i-1,j) - (CS%bathyT(i-1,j) + G%Z_ref)
+            ssh_in = ssh_1 + (0.5-cfl)*(ssh_1-ssh_2)      ! internal
+          endif
+          if (BT_OBC%dZ_u(I,j) > 0.0) then
+            vel_prev = ubt(I,j)
+            ubt(I,j) = 0.5*((u_inlet + BT_OBC%ubt_outer(I,j)) + &
+                (BT_OBC%Cg_u(I,j)/BT_OBC%dZ_u(I,j)) * (ssh_in-BT_OBC%SSH_outer_u(I,j)))
+            vel_trans = (1.0-bebt)*vel_prev + bebt*ubt(I,j)
+          else  ! This point is now dry.
+            ubt(I,j) = 0.0
+            vel_trans = 0.0
+          endif
         elseif (OBC%segment(OBC%segnum_u(I,j))%gradient) then
           ubt(I,j) = ubt(I-1,j)
           vel_trans = ubt(I,j)
@@ -3019,14 +3052,23 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
         if (OBC%segment(OBC%segnum_u(I,j))%Flather) then
           cfl = dtbt * BT_OBC%Cg_u(I,j) * G%IdxCu(I,j) ! CFL
           u_inlet = cfl*ubt_old(I+1,j) + (1.0-cfl)*ubt_old(I,j)  ! Valid for cfl<1
-          ssh_in = GV%H_to_Z*(eta(i+1,j) + (0.5-cfl)*(eta(i+1,j)-eta(i+2,j)))  ! internal
+          if (GV%Boussinesq) then
+            ssh_in = GV%H_to_Z*(eta(i+1,j) + (0.5-cfl)*(eta(i+1,j)-eta(i+2,j)))  ! internal
+          else
+            ssh_1 = GV%H_to_RZ * eta(i+1,j) * SpV_avg(i+1,j) - (CS%bathyT(i+1,j) + G%Z_ref)
+            ssh_2 = GV%H_to_RZ * eta(i+2,j) * SpV_avg(i+2,j) - (CS%bathyT(i+2,j) + G%Z_ref)
+            ssh_in = ssh_1 + (0.5-cfl)*(ssh_1-ssh_2)      ! internal
+          endif
 
-          dZ_u = BT_OBC%dZ_u(I,j)
-          vel_prev = ubt(I,j)
-          ubt(I,j) = 0.5*((u_inlet + BT_OBC%ubt_outer(I,j)) + &
-              (BT_OBC%Cg_u(I,j)/dZ_u) * (BT_OBC%SSH_outer_u(I,j)-ssh_in))
-
-          vel_trans = (1.0-bebt)*vel_prev + bebt*ubt(I,j)
+          if (BT_OBC%dZ_u(I,j) > 0.0) then
+            vel_prev = ubt(I,j)
+            ubt(I,j) = 0.5*((u_inlet + BT_OBC%ubt_outer(I,j)) + &
+                (BT_OBC%Cg_u(I,j)/BT_OBC%dZ_u(I,j)) * (BT_OBC%SSH_outer_u(I,j)-ssh_in))
+            vel_trans = (1.0-bebt)*vel_prev + bebt*ubt(I,j)
+          else  ! This point is now dry.
+            ubt(I,j) = 0.0
+            vel_trans = 0.0
+          endif
         elseif (OBC%segment(OBC%segnum_u(I,j))%gradient) then
           ubt(I,j) = ubt(I+1,j)
           vel_trans = ubt(I,j)
@@ -3059,14 +3101,23 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
         if (OBC%segment(OBC%segnum_v(i,J))%Flather) then
           cfl = dtbt * BT_OBC%Cg_v(i,J) * G%IdyCv(i,J) ! CFL
           v_inlet = cfl*vbt_old(i,J-1) + (1.0-cfl)*vbt_old(i,J)  ! Valid for cfl<1
-          ssh_in = GV%H_to_Z*(eta(i,j) + (0.5-cfl)*(eta(i,j)-eta(i,j-1)))      ! internal
+          if (GV%Boussinesq) then
+            ssh_in = GV%H_to_Z*(eta(i,j) + (0.5-cfl)*(eta(i,j)-eta(i,j-1)))      ! internal
+          else
+            ssh_1 = GV%H_to_RZ * eta(i,j) * SpV_avg(i,j) - (CS%bathyT(i,j) + G%Z_ref)
+            ssh_2 = GV%H_to_RZ * eta(i,j-1) * SpV_avg(i,j-1) - (CS%bathyT(i,j-1) + G%Z_ref)
+            ssh_in = ssh_1 + (0.5-cfl)*(ssh_1-ssh_2)      ! internal
+          endif
 
-          dZ_v = BT_OBC%dZ_v(i,J)
-          vel_prev = vbt(i,J)
-          vbt(i,J) = 0.5*((v_inlet + BT_OBC%vbt_outer(i,J)) + &
-              (BT_OBC%Cg_v(i,J)/dZ_v) * (ssh_in-BT_OBC%SSH_outer_v(i,J)))
-
-          vel_trans = (1.0-bebt)*vel_prev + bebt*vbt(i,J)
+          if (BT_OBC%dZ_v(i,J) > 0.0) then
+            vel_prev = vbt(i,J)
+            vbt(i,J) = 0.5*((v_inlet + BT_OBC%vbt_outer(i,J)) + &
+                (BT_OBC%Cg_v(i,J)/BT_OBC%dZ_v(i,J)) * (ssh_in-BT_OBC%SSH_outer_v(i,J)))
+            vel_trans = (1.0-bebt)*vel_prev + bebt*vbt(i,J)
+          else  ! This point is now dry
+            vbt(i,J) = 0.0
+            vel_trans = 0.0
+          endif
         elseif (OBC%segment(OBC%segnum_v(i,J))%gradient) then
           vbt(i,J) = vbt(i,J-1)
           vel_trans = vbt(i,J)
@@ -3075,14 +3126,23 @@ subroutine apply_velocity_OBCs(OBC, ubt, vbt, uhbt, vhbt, ubt_trans, vbt_trans, 
         if (OBC%segment(OBC%segnum_v(i,J))%Flather) then
           cfl = dtbt * BT_OBC%Cg_v(i,J) * G%IdyCv(i,J) ! CFL
           v_inlet = cfl*vbt_old(i,J+1) + (1.0-cfl)*vbt_old(i,J)  ! Valid for cfl <1
-          ssh_in = GV%H_to_Z*(eta(i,j+1) + (0.5-cfl)*(eta(i,j+1)-eta(i,j+2)))  ! internal
+          if (GV%Boussinesq) then
+            ssh_in = GV%H_to_Z*(eta(i,j+1) + (0.5-cfl)*(eta(i,j+1)-eta(i,j+2)))  ! internal
+          else
+            ssh_1 = GV%H_to_RZ * eta(i,j+1) * SpV_avg(i,j+1) - (CS%bathyT(i,j+1) + G%Z_ref)
+            ssh_2 = GV%H_to_RZ * eta(i,j+2) * SpV_avg(i,j+2) - (CS%bathyT(i,j+2) + G%Z_ref)
+            ssh_in = ssh_1 + (0.5-cfl)*(ssh_1-ssh_2)      ! internal
+          endif
 
-          dZ_v = BT_OBC%dZ_v(i,J)
-          vel_prev = vbt(i,J)
-          vbt(i,J) = 0.5*((v_inlet + BT_OBC%vbt_outer(i,J)) + &
-              (BT_OBC%Cg_v(i,J)/dZ_v) * (BT_OBC%SSH_outer_v(i,J)-ssh_in))
-
-          vel_trans = (1.0-bebt)*vel_prev + bebt*vbt(i,J)
+          if (BT_OBC%dZ_v(i,J) > 0.0) then
+            vel_prev = vbt(i,J)
+            vbt(i,J) = 0.5*((v_inlet + BT_OBC%vbt_outer(i,J)) + &
+                (BT_OBC%Cg_v(i,J)/BT_OBC%dZ_v(i,J)) * (BT_OBC%SSH_outer_v(i,J)-ssh_in))
+            vel_trans = (1.0-bebt)*vel_prev + bebt*vbt(i,J)
+          else  ! This point is now dry
+            vbt(i,J) = 0.0
+            vel_trans = 0.0
+          endif
         elseif (OBC%segment(OBC%segnum_v(i,J))%gradient) then
           vbt(i,J) = vbt(i,J+1)
           vel_trans = vbt(i,J)
@@ -3109,13 +3169,14 @@ end subroutine apply_velocity_OBCs
 
 !> This subroutine sets up the private structure used to apply the open
 !! boundary conditions, as developed by Mehmet Ilicak.
-subroutine set_up_BT_OBC(OBC, eta, BT_OBC, BT_Domain, G, GV, US, MS, halo, use_BT_cont, &
+subroutine set_up_BT_OBC(OBC, eta, SpV_avg, BT_OBC, BT_Domain, G, GV, US, CS, MS, halo, use_BT_cont, &
                          integral_BT_cont, dt_baroclinic, Datu, Datv, BTCL_u, BTCL_v, dgeo_de)
   type(ocean_OBC_type), target,          intent(inout) :: OBC    !< An associated pointer to an OBC type.
   type(memory_size_type),                intent(in)    :: MS     !< A type that describes the memory sizes of the
                                                                  !! argument arrays.
   real, dimension(SZIW_(MS),SZJW_(MS)),  intent(in)    :: eta    !< The barotropic free surface height anomaly or
                                                                  !! column mass anomaly [H ~> m or kg m-2].
+  real, dimension(SZIW_(MS),SZJW_(MS)),  intent(in)    :: SpV_avg !< The column average specific volume [R-1 ~> m3 kg-1]
   type(BT_OBC_type),                     intent(inout) :: BT_OBC !< A structure with the private barotropic arrays
                                                                  !! related to the open boundary conditions,
                                                                  !! set by set_up_BT_OBC.
@@ -3123,6 +3184,7 @@ subroutine set_up_BT_OBC(OBC, eta, BT_OBC, BT_Domain, G, GV, US, MS, halo, use_B
   type(ocean_grid_type),                 intent(inout) :: G      !< The ocean's grid structure.
   type(verticalGrid_type),               intent(in)    :: GV     !< The ocean's vertical grid structure.
   type(unit_scale_type),                 intent(in)    :: US     !< A dimensional unit scaling type
+  type(barotropic_CS),                   intent(in)    :: CS     !< Barotropic control structure
   integer,                               intent(in)    :: halo   !< The extra halo size to use here.
   logical,                               intent(in)    :: use_BT_cont !< If true, use the BT_cont_types to calculate
                                                                  !! transports.
@@ -3141,7 +3203,7 @@ subroutine set_up_BT_OBC(OBC, eta, BT_OBC, BT_Domain, G, GV, US, MS, halo, use_B
   type(local_BT_cont_v_type), dimension(SZIW_(MS),SZJBW_(MS)), intent(in) :: BTCL_v !< Structure of information used
                                                                  !! for a dynamic estimate of the face areas at
                                                                  !! v-points.
-  real,                                  intent(in), optional  :: dgeo_de  !< The constant of proportionality between
+  real,                        optional, intent(in)    :: dgeo_de  !< The constant of proportionality between
                                                                  !! geopotential and sea surface height [nondim].
   ! Local variables
   real :: I_dt      ! The inverse of the time interval of this call [T-1 ~> s-1].
@@ -3213,15 +3275,15 @@ subroutine set_up_BT_OBC(OBC, eta, BT_OBC, BT_Domain, G, GV, US, MS, halo, use_B
       else  ! This is assuming Flather as only other option
         if (GV%Boussinesq) then
           if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) then
-            BT_OBC%dZ_u(I,j) = G%bathyT(i,j) + GV%H_to_Z*eta(i,j)
+            BT_OBC%dZ_u(I,j) = CS%bathyT(i,j) + GV%H_to_Z*eta(i,j)
           elseif (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) then
-            BT_OBC%dZ_u(I,j) = G%bathyT(i+1,j) + GV%H_to_Z*eta(i+1,j)
+            BT_OBC%dZ_u(I,j) = CS%bathyT(i+1,j) + GV%H_to_Z*eta(i+1,j)
           endif
         else
           if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) then
-            BT_OBC%dZ_u(I,j) = GV%H_to_Z*eta(i,j)
+            BT_OBC%dZ_u(I,j) = GV%H_to_RZ * eta(i,j) * SpV_avg(i,j)
           elseif (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) then
-            BT_OBC%dZ_u(I,j) = GV%H_to_Z*eta(i+1,j)
+            BT_OBC%dZ_u(I,j) = GV%H_to_RZ * eta(i+1,j) * SpV_avg(i+1,j)
           endif
         endif
         BT_OBC%Cg_u(I,j) = SQRT(dgeo_de_in *  GV%g_prime(1) * BT_OBC%dZ_u(i,j))
@@ -3267,9 +3329,9 @@ subroutine set_up_BT_OBC(OBC, eta, BT_OBC, BT_Domain, G, GV, US, MS, halo, use_B
       else  ! This is assuming Flather as only other option
         if (GV%Boussinesq) then
           if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) then
-            BT_OBC%dZ_v(i,J) = G%bathyT(i,j) + GV%H_to_Z*eta(i,j)
+            BT_OBC%dZ_v(i,J) = CS%bathyT(i,j) + GV%H_to_Z*eta(i,j)
           elseif (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) then
-            BT_OBC%dZ_v(i,J) = G%bathyT(i,j+1) + GV%H_to_Z*eta(i,j+1)
+            BT_OBC%dZ_v(i,J) = CS%bathyT(i,j+1) + GV%H_to_Z*eta(i,j+1)
           endif
         else
           if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) then

--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -156,7 +156,7 @@ subroutine update_OBC_data(OBC, G, GV, US, tv, h, CS, Time)
       call shelfwave_set_OBC_data(OBC, CS%shelfwave_OBC_CSp, G, GV, US, h, Time)
   if (CS%use_dyed_channel) &
       call dyed_channel_update_flow(OBC, CS%dyed_channel_OBC_CSp, G, GV, US, Time)
-  if (OBC%needs_IO_for_data .or. OBC%add_tide_constituents)  &
+  if (OBC%any_needs_IO_for_data .or. OBC%add_tide_constituents)  &
       call update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
 
 end subroutine update_OBC_data

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -19,7 +19,7 @@ implicit none ; private
 
 public find_eta, dz_to_thickness, thickness_to_dz, dz_to_thickness_simple
 public calc_derived_thermo
-public find_rho_bottom
+public find_rho_bottom, find_col_avg_SpV
 
 !> Calculates the heights of the free surface or all interfaces from layer thicknesses.
 interface find_eta
@@ -321,6 +321,74 @@ subroutine calc_derived_thermo(tv, h, G, GV, US, halo, debug)
   endif
 
 end subroutine calc_derived_thermo
+
+
+!> Determine the column average specific volumes.
+subroutine find_col_avg_SpV(h, SpV_avg, tv, G, GV, US, halo_size)
+  type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
+  type(verticalGrid_type),  intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                            intent(in)    :: h    !< Layer thicknesses [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                            intent(inout) :: SpV_avg !< Column average specific volume [R-1 ~> m3 kg-1]
+                                                  ! SpV_avg is intent inout to retain excess halo values.
+  type(thermo_var_ptrs),    intent(in)    :: tv   !< Structure containing pointers to any available
+                                                  !! thermodynamic fields.
+  integer,        optional, intent(in)    :: halo_size !< width of halo points on which to work
+
+  ! Local variables
+  real :: h_tot(SZI_(G))        ! Sum of the layer thicknesses [H ~> m or kg m-3]
+  real :: SpV_x_h_tot(SZI_(G))  ! Vertical sum of the layer average specific volume times
+                                ! the layer thicknesses [H R-1 ~> m4 kg-1 or m]
+  real :: I_rho                 ! The inverse of the Boussiensq reference density [R-1 ~> m3 kg-1]
+  real :: SpV_lay(SZK_(GV))     ! The inverse of the layer target potential densities [R-1 ~> m3 kg-1]
+  character(len=128) :: mesg    ! A string for error messages
+  integer i, j, k, is, ie, js, je, nz, halo
+
+  halo = 0 ; if (present(halo_size)) halo = max(0,halo_size)
+
+  is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
+  nz = GV%ke
+
+  if (GV%Boussinesq) then
+    I_rho = 1.0 / GV%Rho0
+    do j=js,je ; do i=is,ie
+      SpV_avg(i,j) = I_rho
+    enddo ; enddo
+  elseif (.not.allocated(tv%SpV_avg)) then
+    do k=1,nz ; Spv_lay(k) = 1.0 / GV%Rlay(k) ; enddo
+    do j=js,je
+      do i=is,ie ; SpV_x_h_tot(i) = 0.0 ; h_tot(i) = 0.0 ; enddo
+      do k=1,nz ; do i=is,ie
+        h_tot(i) = h_tot(i) + max(h(i,j,k), GV%H_subroundoff)
+        SpV_x_h_tot(i) = SpV_x_h_tot(i) + Spv_lay(k)*max(h(i,j,k), GV%H_subroundoff)
+      enddo ; enddo
+      do i=is,ie ; SpV_avg(i,j) = SpV_x_h_tot(i) / h_tot(i) ; enddo
+    enddo
+  else
+    ! Check that SpV_avg has been set.
+    if ((allocated(tv%SpV_avg)) .and. (tv%valid_SpV_halo < halo)) then
+      if (tv%valid_SpV_halo < 0) then
+        mesg = "invalid values of SpV_avg."
+      else
+        write(mesg, '("insufficiently large SpV_avg halos of width ", i2, " but ", i2," is needed.")') &
+                     tv%valid_SpV_halo, halo
+      endif
+      call MOM_error(FATAL, "find_col_avg_SpV called in fully non-Boussinesq mode with "//trim(mesg))
+    endif
+
+    do j=js,je
+      do i=is,ie ; SpV_x_h_tot(i) = 0.0 ; h_tot(i) = 0.0 ; enddo
+      do k=1,nz ; do i=is,ie
+        h_tot(i) = h_tot(i) + max(h(i,j,k), GV%H_subroundoff)
+        SpV_x_h_tot(i) = SpV_x_h_tot(i) + tv%SpV_avg(i,j,k)*max(h(i,j,k), GV%H_subroundoff)
+      enddo ; enddo
+      do i=is,ie ; SpV_avg(i,j) = SpV_x_h_tot(i) / h_tot(i) ; enddo
+    enddo
+  endif
+
+end subroutine find_col_avg_SpV
 
 
 !> Determine the in situ density averaged over a specified distance from the bottom,

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -1064,8 +1064,8 @@ real function scale_factor_from_name(name, GV, US, Tr_Reg)
     case ('Vamp') ; scale_factor_from_name = US%m_s_to_L_T
     case ('DVDX') ; scale_factor_from_name = US%T_to_s
     case ('DUDY') ; scale_factor_from_name = US%T_to_s
-    case ('SSH') ; scale_factor_from_name = GV%m_to_H
-    case ('SSHamp') ; scale_factor_from_name = GV%m_to_H
+    case ('SSH') ; scale_factor_from_name = US%m_to_Z
+    case ('SSHamp') ; scale_factor_from_name = US%m_to_Z
     case default ; scale_factor_from_name = 1.0
   end select
 
@@ -4376,13 +4376,12 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
               tidal_elev = 0.0
               if (OBC%add_tide_constituents) then
                 do c=1,OBC%n_tide_constituents
-                  tidal_elev = tidal_elev + (OBC%tide_fn(c) * &
-                      GV%H_to_Z*segment%field(segment%zamp_index)%buffer_dst(i,j,c)) * &
+                  tidal_elev = tidal_elev + (OBC%tide_fn(c) * segment%field(segment%zamp_index)%buffer_dst(i,j,c)) * &
                       cos((time_delta*OBC%tide_frequencies(c) - segment%field(segment%zphase_index)%buffer_dst(i,j,c)) &
                           + (OBC%tide_eq_phases(c) + OBC%tide_un(c)))
                 enddo
               endif
-              segment%SSH(i,j) = OBC%ramp_value * (GV%H_to_Z*segment%field(m)%buffer_dst(i,j,1) + tidal_elev)
+              segment%SSH(i,j) = OBC%ramp_value * (segment%field(m)%buffer_dst(i,j,1) + tidal_elev)
             enddo
           enddo
         else
@@ -4391,13 +4390,12 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
               tidal_elev = 0.0
               if (OBC%add_tide_constituents) then
                 do c=1,OBC%n_tide_constituents
-                  tidal_elev = tidal_elev + (OBC%tide_fn(c) * &
-                      GV%H_to_Z*segment%field(segment%zamp_index)%buffer_dst(i,j,c)) * &
+                  tidal_elev = tidal_elev + (OBC%tide_fn(c) * segment%field(segment%zamp_index)%buffer_dst(i,j,c)) * &
                       cos((time_delta*OBC%tide_frequencies(c) - segment%field(segment%zphase_index)%buffer_dst(i,j,c)) &
                           + (OBC%tide_eq_phases(c) + OBC%tide_un(c)))
                 enddo
               endif
-              segment%SSH(i,j) = (GV%H_to_Z*segment%field(m)%buffer_dst(i,j,1) + tidal_elev)
+              segment%SSH(i,j) = (segment%field(m)%buffer_dst(i,j,1) + tidal_elev)
             enddo
           enddo
         endif

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -18,6 +18,7 @@ use MOM_file_parser, only : log_version
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type, isPointInCell
 use MOM_interface_heights, only : find_eta, dz_to_thickness, dz_to_thickness_simple
+use MOM_interface_heights, only : calc_derived_thermo
 use MOM_io, only : file_exists, field_size, MOM_read_data, MOM_read_vector, slasher
 use MOM_open_boundary, only : ocean_OBC_type, open_boundary_init, set_tracer_data
 use MOM_open_boundary, only : OBC_NONE
@@ -607,8 +608,10 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
     call initialize_segment_data(G, GV, US, OBC, PF)
 !     call open_boundary_config(G, US, PF, OBC)
     ! Call this once to fill boundary arrays from fixed values
-    if (.not. OBC%needs_IO_for_data)  &
+    if (OBC%some_need_no_IO_for_data) then
+      call calc_derived_thermo(tv, h, G, GV, US)
       call update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
+    endif
 
     call get_param(PF, mdl, "OBC_USER_CONFIG", config, &
                  "A string that sets how the user code is invoked to set open boundary data: \n"//&

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -265,7 +265,7 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
           ! Use inside bathymetry
           cff = sqrt(GV%g_Earth * depth_tot(i+1,j) )
           val2 = mag_SSH * exp(- CS%F_0 * y / cff)
-          segment%eta(I,j) = GV%Z_to_H*val2 * cos(omega * time_sec)
+          segment%SSH(I,j) = val2 * cos(omega * time_sec)
           segment%normal_vel_bt(I,j) = val2 * (val1 * cff * cosa / depth_tot(i+1,j) )
           if (segment%nudged) then
             do k=1,nz
@@ -279,7 +279,7 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
           endif
         else
           ! Baroclinic, not rotated yet
-          segment%eta(I,j) = 0.0
+          segment%SSH(I,j) = 0.0
           segment%normal_vel_bt(I,j) = 0.0
           if (segment%nudged) then
             do k=1,nz
@@ -323,7 +323,7 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
         if (CS%mode == 0) then
           cff = sqrt(GV%g_Earth * depth_tot(i,j+1) )
           val2 = mag_SSH * exp(- 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J)) * y / cff)
-          segment%eta(I,j) = GV%Z_to_H*val2 * cos(omega * time_sec)
+          segment%SSH(I,j) = val2 * cos(omega * time_sec)
           segment%normal_vel_bt(I,j) = (val1 * cff * sina / depth_tot(i,j+1) ) * val2
           if (segment%nudged) then
             do k=1,nz
@@ -337,7 +337,7 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
           endif
         else
           ! Not rotated yet
-          segment%eta(i,J) = 0.0
+          segment%SSH(i,J) = 0.0
           segment%normal_vel_bt(i,J) = 0.0
           if (segment%nudged) then
             do k=1,nz

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -74,7 +74,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
 
   ! The following variables are used to set up the transport in the tidal_bay example.
   real :: time_sec    ! Elapsed model time [T ~> s]
-  real :: cff_eta     ! The total column thickness anomalies associated with the inflow [H ~> m or kg m-2]
+  real :: cff_eta     ! The sea surface height anomalies associated with the inflow [Z ~> m]
   real :: my_flux     ! The vlume flux through the face [L2 Z T-1 ~> m3 s-1]
   real :: total_area  ! The total face area of the OBCs [L Z ~> m2]
   real :: PI          ! The ratio of the circumference of a circle to its diameter [nondim]
@@ -97,7 +97,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   flux_scale = GV%H_to_m*US%L_to_m
 
   time_sec = US%s_to_T*time_type_to_real(Time)
-  cff_eta = CS%tide_ssh_amp*GV%Z_to_H * sin(2.0*PI*time_sec / CS%tide_period)
+  cff_eta = CS%tide_ssh_amp * sin(2.0*PI*time_sec / CS%tide_period)
   my_area = 0.0
   my_flux = 0.0
   segment => OBC%segment(1)
@@ -119,7 +119,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
     if (.not. segment%on_pe) cycle
 
     segment%normal_vel_bt(:,:) = my_flux / (US%m_to_Z*US%m_to_L*total_area)
-    segment%eta(:,:) = cff_eta
+    segment%SSH(:,:) = cff_eta
 
   enddo ! end segment loop
 


### PR DESCRIPTION
  This sequence of 5 commits extends the MOM6 open boundary condition capabilities to work in fully non-Boussinesq mode.  This includes the addition of the new subroutine find_col_avg_SpV, the addition or renaming of elements in the transparent OBC_segment_type to emphasize that they are always sea surface heights, and a change to the dimensional rescaling of variables in several user modules.  With this change, test cases that worked previously only in Boussinesq mode now also work in non-Boussinesq mode, while all Boussinesq solutions are bitwise identical.  The specific changes in this PR include:

 - Renamed OBC related variables to emphasize that they are sea surface heights,
and not sea surface heights or total column mass depending on the Boussinesq
approximation.  Also changed the units of these renamed variables to [Z ~> m]
instead of [H ~> m or kg m-2].

   - Renamed eta (in [H]) in the OBC_segment_type to SSH (in [Z])

   - Renamed 4 elements of the BT_OBC_type from H_[uv] and eta_outer_[uv] (in
     [H]) to dZ_[uv] and SSH_outer_[uv] (in [Z])
  
   - Replaced the internal variables H_[uv] and h_in in apply_velocity_OBCs (in
     [H]) with now dZ_[uv] and ssh_in (in [Z]).

   - Rescaled the dimensions of tidal_elev in update_OBC_segment_data from [H ~>
     m or kg m-2] to [Z ~> m]

   - Rescaled the dimensions of cff_eta in tidal_bay_set_OBC_data from [H ~> m
     or kg m-2] to [Z ~> m]

 - There is a new vertical grid type argument to apply_velocity_OBCs for use in
   changing the scaling of the SSH variables.

 - Read in open boundary condition SSH and SSHamp segment data directly in
   rescaled units of [Z ~> m] instead of [H ~> m or kg m-2], which would then
   have to undergo a subsequent conversion. 

 - Added the new subroutine find_col_avg_SpV to return the column-averaged
   specific volume based on the coordinate mode and the layer averaged specific
   volumes that are in tv%SpV_avg.

 - Revised the Flather open boundary conditions to work properly in
   non-Boussinesq mode.  This includes calculating the column-average specific
   volume in step_MOM_dyn_split_RK2 and passing it as a new argument to btstep.
   Inside of btstep, this is copied over into a wide halo array and then passed
   on to set_up_BT_OBC and apply_velocity_OBCs, where it is used to determine
   the free surface height or the vertical column extent (in [Z ~> m]) from eta
   for use in the Flather radiation open boundary conditions.  In addition,
   there are several places in MOM_barotropic related to the open boundary
   conditions where the usual G%bathyT needed to be replaced with its wide-halo
   counterpart, CS%bathyT.

 - A test was added for massless OBC columns in apply_velocity_OBCs, which are
   then assumed to be dry rather than dividing by zero.

 - A fatal error message that is triggered in the case of Flather open boundary
   conditions in non-Boussinesq mode was removed.

 - Add the new element dZtot to the OBC_segment_type to hold the total vertical
   extent of the water column, and use thickness_to_dz in
   update_OBC_segment_data to convert the layer thicknesses to the vertical
   layer extents used to set dZtot.

  A total of 17 factors of GV%H_to_Z or GV%Z_to_H were eliminated by these changes, although another 10 that are only used in Boussinesq mode were added along with 10 factors of GV%H_to_RZ that are only used in non-Boussinesq mode.

  With these changes, all Boussinesq answers are bitwise identical, but non-Boussinesq cases with Flather or other open boundary conditions are now working and giving answers that are qualitatively similar to the Boussinesq cases.
            