### PR TITLE
Bugfix in MLE for reproducible restarts with USE_BODNER23 = True

### DIFF
--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1584,6 +1584,7 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   ! If MLD_filtered is being used, we need to update halo regions after a restart
   if (allocated(CS%MLD_filtered)) call pass_var(CS%MLD_filtered, G%domain)
   if (allocated(CS%MLD_filtered_slow)) call pass_var(CS%MLD_filtered_slow, G%domain)
+  if (allocated(CS%wpup_filtered)) call pass_var(CS%wpup_filtered, G%domain)
 
 end function mixedlayer_restrat_init
 


### PR DESCRIPTION
- Update for missing halo update of field wpup_filtered in MOM_mixed_layer_restrat.F90 during initialization.
- The missing halo update caused the model to diverge when running from restart files.
- With the halo update the model now reproduces from restart files.