### PR TITLE
New treatment of ice shelf boundaries 

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -351,7 +351,7 @@ subroutine initialize_ice_shelf_boundary_channel(u_face_mask_bdry, v_face_mask_b
         hmask(i+1,j) = 3.0
         h_bdry_val(i+1,j) = h_shelf(i+1,j)
         thickness_bdry_val(i+1,j) = h_bdry_val(i+0*1,j)
-        u_face_mask_bdry(i+1,j) = 3.0
+        u_face_mask_bdry(i+1,j) = 5.0
         u_bdry_val(i+1,j) = input_vel*(1-16.0*((G%geoLatBu(i-1,j)/lenlat-0.5))**4) !velocity distribution
       endif
 


### PR DESCRIPTION
Previously, ice-shelf Dirichlet boundary conditions only allowed u-velocity and v-velocity to be set to the same value (which is enforced by setting the value of parameters u_face_mask or v_face_mask to 3). This functionality is retained here, but now setting u_face_mask or v_face_mask to 5 enforces a Dirichlet boundary for u-velocity only along the respective cell face. Similarly, setting u_face_mask or v_face_mask to 6 enforces the Dirichlet boundary for v-velocity only along the respective cell face. This functionality is required for most ice-sheet modeling configurations, e.g. the idealized MISMIP+ configuration requires setting v-velocity only to 0 along its lateral boundaries, but with free-slip conditions enforced for u-velocity. Adding this capability required changes throughout the ice-shelf code.

Further changes were needed for how driving stress and Neumann conditions at computational boundaries are calculated in subroutine calc_shelf_driving_stress, and calls to subroutine apply_boundary_values were eliminated because they were not justified and caused errors. The new boundary treatment was tested by comparing simulated and analytical solutions for 1-D ice shelf flow with free-slip lateral boundary conditions and steady inflow enforced at the upstream boundary. This test required the addition of a new parameter ADVECT_SHELF, which if false (as in the 1-D test case), turns off ice-shelf thickness evolution. By default, ADVECT_SHELF=True.

The new boundary treatment was also justified in 2-D by correctly simulating the expected MISMIP+ steady-state.