### PR TITLE
Ice-shelf solo driver and MISMIP+ updates

### DIFF
--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -49,6 +49,7 @@ program MOM6
   use MOM_ice_shelf,       only : shelf_calc_flux, add_shelf_forces, ice_shelf_save_restart
   use MOM_ice_shelf,       only : initialize_ice_shelf_fluxes, initialize_ice_shelf_forces
   use MOM_ice_shelf,       only : ice_shelf_query
+  use MOM_ice_shelf_initialize, only : initialize_ice_SMB
   use MOM_interpolate,     only : time_interp_external_init
   use MOM_io,              only : file_exists, open_ASCII_file, close_file
   use MOM_io,              only : check_nml_error, io_infra_init, io_infra_end
@@ -134,7 +135,7 @@ program MOM6
   real :: dtdia                   ! The diabatic timestep [T ~> s]
   real :: t_elapsed_seg           ! The elapsed time in this run segment [T ~> s]
   integer :: n, ns, n_max, nts, n_last_thermo
-  logical :: diabatic_first, single_step_call
+  logical :: diabatic_first, single_step_call, initialize_smb
   type(time_type) :: Time2, time_chg ! Temporary time variables
 
   integer :: Restart_control    ! An integer that is bit-tested to determine whether
@@ -302,6 +303,9 @@ program MOM6
     call initialize_ice_shelf_forces(ice_shelf_CSp, grid, US, forces)
     call ice_shelf_query(ice_shelf_CSp, grid, data_override_shelf_fluxes=override_shelf_fluxes)
     if (override_shelf_fluxes) call data_override_init(Ocean_Domain_in=grid%domain%mpp_domain)
+    call get_param(param_file, mod_name, "INITIALIZE_ICE_SHEET_SMB", &
+                   initialize_smb, "Read in a constant SMB for the ice sheet", default=.false.)
+    if (initialize_smb) call initialize_ice_SMB(fluxes%shelf_sfc_mass_flux, grid, US, param_file)
   endif
 
 

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -47,7 +47,6 @@ public post_data_1d_k
 public safe_alloc_ptr, safe_alloc_alloc
 public enable_averaging, enable_averages, disable_averaging, query_averaging_enabled
 public diag_mediator_init, diag_mediator_end, set_diag_mediator_grid
-public solo_ice_shelf_diag_mediator_end
 public diag_mediator_infrastructure_init
 public diag_mediator_close_registration, get_diag_time_end
 public diag_axis_init, ocean_register_diag, register_static_field
@@ -3540,37 +3539,45 @@ subroutine diag_mediator_end(time, diag_CS, end_diag_manager)
   enddo
 
   call diag_grid_storage_end(diag_cs%diag_grid_temp)
-  deallocate(diag_cs%mask3dTL)
-  deallocate(diag_cs%mask3dBL)
-  deallocate(diag_cs%mask3dCuL)
-  deallocate(diag_cs%mask3dCvL)
-  deallocate(diag_cs%mask3dTi)
-  deallocate(diag_cs%mask3dBi)
-  deallocate(diag_cs%mask3dCui)
-  deallocate(diag_cs%mask3dCvi)
+  if (associated(diag_cs%mask3dTL))  deallocate(diag_cs%mask3dTL)
+  if (associated(diag_cs%mask3dBL))  deallocate(diag_cs%mask3dBL)
+  if (associated(diag_cs%mask3dCuL)) deallocate(diag_cs%mask3dCuL)
+  if (associated(diag_cs%mask3dCvL)) deallocate(diag_cs%mask3dCvL)
+  if (associated(diag_cs%mask3dTi))  deallocate(diag_cs%mask3dTi)
+  if (associated(diag_cs%mask3dBi))  deallocate(diag_cs%mask3dBi)
+  if (associated(diag_cs%mask3dCui)) deallocate(diag_cs%mask3dCui)
+  if (associated(diag_cs%mask3dCvi)) deallocate(diag_cs%mask3dCvi)
   do dl=2,MAX_DSAMP_LEV
-    deallocate(diag_cs%dsamp(dl)%mask2dT)
-    deallocate(diag_cs%dsamp(dl)%mask2dBu)
-    deallocate(diag_cs%dsamp(dl)%mask2dCu)
-    deallocate(diag_cs%dsamp(dl)%mask2dCv)
-    deallocate(diag_cs%dsamp(dl)%mask3dTL)
-    deallocate(diag_cs%dsamp(dl)%mask3dBL)
-    deallocate(diag_cs%dsamp(dl)%mask3dCuL)
-    deallocate(diag_cs%dsamp(dl)%mask3dCvL)
-    deallocate(diag_cs%dsamp(dl)%mask3dTi)
-    deallocate(diag_cs%dsamp(dl)%mask3dBi)
-    deallocate(diag_cs%dsamp(dl)%mask3dCui)
-    deallocate(diag_cs%dsamp(dl)%mask3dCvi)
+    if (associated(diag_cs%dsamp(dl)%mask2dT))   deallocate(diag_cs%dsamp(dl)%mask2dT)
+    if (associated(diag_cs%dsamp(dl)%mask2dBu))  deallocate(diag_cs%dsamp(dl)%mask2dBu)
+    if (associated(diag_cs%dsamp(dl)%mask2dCu))  deallocate(diag_cs%dsamp(dl)%mask2dCu)
+    if (associated(diag_cs%dsamp(dl)%mask2dCv))  deallocate(diag_cs%dsamp(dl)%mask2dCv)
+    if (associated(diag_cs%dsamp(dl)%mask3dTL))  deallocate(diag_cs%dsamp(dl)%mask3dTL)
+    if (associated(diag_cs%dsamp(dl)%mask3dBL))  deallocate(diag_cs%dsamp(dl)%mask3dBL)
+    if (associated(diag_cs%dsamp(dl)%mask3dCuL)) deallocate(diag_cs%dsamp(dl)%mask3dCuL)
+    if (associated(diag_cs%dsamp(dl)%mask3dCvL)) deallocate(diag_cs%dsamp(dl)%mask3dCvL)
+    if (associated(diag_cs%dsamp(dl)%mask3dTi))  deallocate(diag_cs%dsamp(dl)%mask3dTi)
+    if (associated(diag_cs%dsamp(dl)%mask3dBi))  deallocate(diag_cs%dsamp(dl)%mask3dBi)
+    if (associated(diag_cs%dsamp(dl)%mask3dCui)) deallocate(diag_cs%dsamp(dl)%mask3dCui)
+    if (associated(diag_cs%dsamp(dl)%mask3dCvi)) deallocate(diag_cs%dsamp(dl)%mask3dCvi)
 
     do i=1,diag_cs%num_diag_coords
-      deallocate(diag_cs%dsamp(dl)%remap_axesTL(i)%dsamp(dl)%mask3d)
-      deallocate(diag_cs%dsamp(dl)%remap_axesCuL(i)%dsamp(dl)%mask3d)
-      deallocate(diag_cs%dsamp(dl)%remap_axesCvL(i)%dsamp(dl)%mask3d)
-      deallocate(diag_cs%dsamp(dl)%remap_axesBL(i)%dsamp(dl)%mask3d)
-      deallocate(diag_cs%dsamp(dl)%remap_axesTi(i)%dsamp(dl)%mask3d)
-      deallocate(diag_cs%dsamp(dl)%remap_axesCui(i)%dsamp(dl)%mask3d)
-      deallocate(diag_cs%dsamp(dl)%remap_axesCvi(i)%dsamp(dl)%mask3d)
-      deallocate(diag_cs%dsamp(dl)%remap_axesBi(i)%dsamp(dl)%mask3d)
+      if (associated(diag_cs%dsamp(dl)%remap_axesTL(i)%dsamp(dl)%mask3d)) &
+        deallocate(diag_cs%dsamp(dl)%remap_axesTL(i)%dsamp(dl)%mask3d)
+      if (associated(diag_cs%dsamp(dl)%remap_axesCuL(i)%dsamp(dl)%mask3d)) &
+        deallocate(diag_cs%dsamp(dl)%remap_axesCuL(i)%dsamp(dl)%mask3d)
+      if (associated(diag_cs%dsamp(dl)%remap_axesCvL(i)%dsamp(dl)%mask3d)) &
+        deallocate(diag_cs%dsamp(dl)%remap_axesCvL(i)%dsamp(dl)%mask3d)
+      if (associated(diag_cs%dsamp(dl)%remap_axesBL(i)%dsamp(dl)%mask3d)) &
+        deallocate(diag_cs%dsamp(dl)%remap_axesBL(i)%dsamp(dl)%mask3d)
+      if (associated(diag_cs%dsamp(dl)%remap_axesTi(i)%dsamp(dl)%mask3d)) &
+        deallocate(diag_cs%dsamp(dl)%remap_axesTi(i)%dsamp(dl)%mask3d)
+      if (associated(diag_cs%dsamp(dl)%remap_axesCui(i)%dsamp(dl)%mask3d)) &
+        deallocate(diag_cs%dsamp(dl)%remap_axesCui(i)%dsamp(dl)%mask3d)
+      if (associated(diag_cs%dsamp(dl)%remap_axesCvi(i)%dsamp(dl)%mask3d)) &
+        deallocate(diag_cs%dsamp(dl)%remap_axesCvi(i)%dsamp(dl)%mask3d)
+      if (associated(diag_cs%dsamp(dl)%remap_axesBi(i)%dsamp(dl)%mask3d)) &
+        deallocate(diag_cs%dsamp(dl)%remap_axesBi(i)%dsamp(dl)%mask3d)
     enddo
   enddo
 
@@ -3630,100 +3637,6 @@ subroutine diag_mediator_end(time, diag_CS, end_diag_manager)
   endif
 
 end subroutine diag_mediator_end
-
-!> A copy of diag_mediator_end, but modified to be called from the ice shelf solo-driver by
-!! removing deallocation of fields that were never allocated
-subroutine solo_ice_shelf_diag_mediator_end(time, diag_CS, end_diag_manager)
-  type(time_type),   intent(in)  :: time !< The current model time
-  type(diag_ctrl), intent(inout) :: diag_CS !< Structure used to regulate diagnostic output
-  logical, optional, intent(in)  :: end_diag_manager !< If true, call diag_manager_end()
-
-  ! Local variables
-  type(diag_type), pointer :: diag, next_diag
-  integer :: i, dl
-
-  if (diag_CS%available_diag_doc_unit > -1) then
-    close(diag_CS%available_diag_doc_unit) ; diag_CS%available_diag_doc_unit = -3
-  endif
-  if (diag_CS%chksum_iounit > -1) then
-    close(diag_CS%chksum_iounit) ; diag_CS%chksum_iounit = -3
-  endif
-
-  do i=1, diag_cs%next_free_diag_id - 1
-    if (associated(diag_cs%diags(i)%next)) then
-      next_diag => diag_cs%diags(i)%next
-      do while (associated(next_diag))
-        diag => next_diag
-        next_diag => diag%next
-        deallocate(diag)
-      enddo
-    endif
-  enddo
-
-  deallocate(diag_cs%diags)
-
-  do i=1, diag_cs%num_diag_coords
-    call diag_remap_end(diag_cs%diag_remap_cs(i))
-  enddo
-
-  call diag_grid_storage_end(diag_cs%diag_grid_temp)
-
-  ! axes_grp masks may point to diag_cs masks, so do these after mask dealloc
-  do i=1, diag_cs%num_diag_coords
-    call axes_grp_end(diag_cs%remap_axesZL(i))
-    call axes_grp_end(diag_cs%remap_axesZi(i))
-    call axes_grp_end(diag_cs%remap_axesTL(i))
-    call axes_grp_end(diag_cs%remap_axesTi(i))
-    call axes_grp_end(diag_cs%remap_axesBL(i))
-    call axes_grp_end(diag_cs%remap_axesBi(i))
-    call axes_grp_end(diag_cs%remap_axesCuL(i))
-    call axes_grp_end(diag_cs%remap_axesCui(i))
-    call axes_grp_end(diag_cs%remap_axesCvL(i))
-    call axes_grp_end(diag_cs%remap_axesCvi(i))
-  enddo
-
-  if (diag_cs%num_diag_coords > 0) then
-    deallocate(diag_cs%remap_axesZL)
-    deallocate(diag_cs%remap_axesZi)
-    deallocate(diag_cs%remap_axesTL)
-    deallocate(diag_cs%remap_axesTi)
-    deallocate(diag_cs%remap_axesBL)
-    deallocate(diag_cs%remap_axesBi)
-    deallocate(diag_cs%remap_axesCuL)
-    deallocate(diag_cs%remap_axesCui)
-    deallocate(diag_cs%remap_axesCvL)
-    deallocate(diag_cs%remap_axesCvi)
-  endif
-
-  do dl=2,MAX_DSAMP_LEV
-    if (allocated(diag_cs%dsamp(dl)%remap_axesTL)) &
-      deallocate(diag_cs%dsamp(dl)%remap_axesTL)
-    if (allocated(diag_cs%dsamp(dl)%remap_axesTi)) &
-      deallocate(diag_cs%dsamp(dl)%remap_axesTi)
-    if (allocated(diag_cs%dsamp(dl)%remap_axesBL)) &
-      deallocate(diag_cs%dsamp(dl)%remap_axesBL)
-    if (allocated(diag_cs%dsamp(dl)%remap_axesBi)) &
-      deallocate(diag_cs%dsamp(dl)%remap_axesBi)
-    if (allocated(diag_cs%dsamp(dl)%remap_axesCuL)) &
-      deallocate(diag_cs%dsamp(dl)%remap_axesCuL)
-    if (allocated(diag_cs%dsamp(dl)%remap_axesCui)) &
-      deallocate(diag_cs%dsamp(dl)%remap_axesCui)
-    if (allocated(diag_cs%dsamp(dl)%remap_axesCvL)) &
-      deallocate(diag_cs%dsamp(dl)%remap_axesCvL)
-    if (allocated(diag_cs%dsamp(dl)%remap_axesCvi)) &
-      deallocate(diag_cs%dsamp(dl)%remap_axesCvi)
-  enddo
-
-
-#if defined(DEBUG) || defined(__DO_SAFETY_CHECKS__)
-  deallocate(diag_cs%h_old)
-#endif
-
-  if (present(end_diag_manager)) then
-    if (end_diag_manager) call MOM_diag_manager_end(time)
-  endif
-
-end subroutine solo_ice_shelf_diag_mediator_end
 
 !> Convert the first n elements (up to 3) of an integer array to an underscore delimited string.
 function i2s(a,n_in)

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -47,6 +47,7 @@ public post_data_1d_k
 public safe_alloc_ptr, safe_alloc_alloc
 public enable_averaging, enable_averages, disable_averaging, query_averaging_enabled
 public diag_mediator_init, diag_mediator_end, set_diag_mediator_grid
+public solo_ice_shelf_diag_mediator_end
 public diag_mediator_infrastructure_init
 public diag_mediator_close_registration, get_diag_time_end
 public diag_axis_init, ocean_register_diag, register_static_field
@@ -3629,6 +3630,100 @@ subroutine diag_mediator_end(time, diag_CS, end_diag_manager)
   endif
 
 end subroutine diag_mediator_end
+
+!> A copy of diag_mediator_end, but modified to be called from the ice shelf solo-driver by
+!! removing deallocation of fields that were never allocated
+subroutine solo_ice_shelf_diag_mediator_end(time, diag_CS, end_diag_manager)
+  type(time_type),   intent(in)  :: time !< The current model time
+  type(diag_ctrl), intent(inout) :: diag_CS !< Structure used to regulate diagnostic output
+  logical, optional, intent(in)  :: end_diag_manager !< If true, call diag_manager_end()
+
+  ! Local variables
+  type(diag_type), pointer :: diag, next_diag
+  integer :: i, dl
+
+  if (diag_CS%available_diag_doc_unit > -1) then
+    close(diag_CS%available_diag_doc_unit) ; diag_CS%available_diag_doc_unit = -3
+  endif
+  if (diag_CS%chksum_iounit > -1) then
+    close(diag_CS%chksum_iounit) ; diag_CS%chksum_iounit = -3
+  endif
+
+  do i=1, diag_cs%next_free_diag_id - 1
+    if (associated(diag_cs%diags(i)%next)) then
+      next_diag => diag_cs%diags(i)%next
+      do while (associated(next_diag))
+        diag => next_diag
+        next_diag => diag%next
+        deallocate(diag)
+      enddo
+    endif
+  enddo
+
+  deallocate(diag_cs%diags)
+
+  do i=1, diag_cs%num_diag_coords
+    call diag_remap_end(diag_cs%diag_remap_cs(i))
+  enddo
+
+  call diag_grid_storage_end(diag_cs%diag_grid_temp)
+
+  ! axes_grp masks may point to diag_cs masks, so do these after mask dealloc
+  do i=1, diag_cs%num_diag_coords
+    call axes_grp_end(diag_cs%remap_axesZL(i))
+    call axes_grp_end(diag_cs%remap_axesZi(i))
+    call axes_grp_end(diag_cs%remap_axesTL(i))
+    call axes_grp_end(diag_cs%remap_axesTi(i))
+    call axes_grp_end(diag_cs%remap_axesBL(i))
+    call axes_grp_end(diag_cs%remap_axesBi(i))
+    call axes_grp_end(diag_cs%remap_axesCuL(i))
+    call axes_grp_end(diag_cs%remap_axesCui(i))
+    call axes_grp_end(diag_cs%remap_axesCvL(i))
+    call axes_grp_end(diag_cs%remap_axesCvi(i))
+  enddo
+
+  if (diag_cs%num_diag_coords > 0) then
+    deallocate(diag_cs%remap_axesZL)
+    deallocate(diag_cs%remap_axesZi)
+    deallocate(diag_cs%remap_axesTL)
+    deallocate(diag_cs%remap_axesTi)
+    deallocate(diag_cs%remap_axesBL)
+    deallocate(diag_cs%remap_axesBi)
+    deallocate(diag_cs%remap_axesCuL)
+    deallocate(diag_cs%remap_axesCui)
+    deallocate(diag_cs%remap_axesCvL)
+    deallocate(diag_cs%remap_axesCvi)
+  endif
+
+  do dl=2,MAX_DSAMP_LEV
+    if (allocated(diag_cs%dsamp(dl)%remap_axesTL)) &
+      deallocate(diag_cs%dsamp(dl)%remap_axesTL)
+    if (allocated(diag_cs%dsamp(dl)%remap_axesTi)) &
+      deallocate(diag_cs%dsamp(dl)%remap_axesTi)
+    if (allocated(diag_cs%dsamp(dl)%remap_axesBL)) &
+      deallocate(diag_cs%dsamp(dl)%remap_axesBL)
+    if (allocated(diag_cs%dsamp(dl)%remap_axesBi)) &
+      deallocate(diag_cs%dsamp(dl)%remap_axesBi)
+    if (allocated(diag_cs%dsamp(dl)%remap_axesCuL)) &
+      deallocate(diag_cs%dsamp(dl)%remap_axesCuL)
+    if (allocated(diag_cs%dsamp(dl)%remap_axesCui)) &
+      deallocate(diag_cs%dsamp(dl)%remap_axesCui)
+    if (allocated(diag_cs%dsamp(dl)%remap_axesCvL)) &
+      deallocate(diag_cs%dsamp(dl)%remap_axesCvL)
+    if (allocated(diag_cs%dsamp(dl)%remap_axesCvi)) &
+      deallocate(diag_cs%dsamp(dl)%remap_axesCvi)
+  enddo
+
+
+#if defined(DEBUG) || defined(__DO_SAFETY_CHECKS__)
+  deallocate(diag_cs%h_old)
+#endif
+
+  if (present(end_diag_manager)) then
+    if (end_diag_manager) call MOM_diag_manager_end(time)
+  endif
+
+end subroutine solo_ice_shelf_diag_mediator_end
 
 !> Convert the first n elements (up to 3) of an integer array to an underscore delimited string.
 function i2s(a,n_in)

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -768,7 +768,7 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, ocean_mass, coupled
 
 ! call ice_shelf_temp(CS, ISS, G, US, time_step, ISS%water_flux, Time)
 
-  if (update_ice_vel) then
+  if (CS%elapsed_velocity_time >= CS%velocity_update_time_step) then
     call enable_averages(CS%elapsed_velocity_time, Time, CS%diag)
     if (CS%id_col_thick > 0) call post_data(CS%id_col_thick, CS%OD_av, CS%diag)
     if (CS%id_u_shelf > 0) call post_data(CS%id_u_shelf, CS%u_shelf, CS%diag)


### PR DESCRIPTION
-Several edits to the ice shelf solo driver so that it works with the rest of the current MOM6
-Added capability to initialize a surface mass balance (SMB) that is held contstant over time when running from the ice-shelf solo driver (see new subroutine initialize_ice_SMB). This is required for MISMIP+. A constant SMB can also be used from the MOM driver for coupled ice-shelf/ocean experiments (e.g. MISOMIP).
-The new, constant SMB is passed into solo_step_ice_shelf, where change_thickness_using_precip is called
-Added capability to save both non-time-stamped and time-stamped restart files when using the ice shelf solo driver. This is useful for debugging.
-slight reorganization to when ice shelf post_data calls are made