### PR TITLE
Autoconf: Update deps m4 macros

### DIFF
--- a/ac/deps/m4/ax_fc_check_c_lib.m4
+++ b/ac/deps/m4/ax_fc_check_c_lib.m4
@@ -1,0 +1,45 @@
+dnl AX_FC_CHECK_C_LIB(LIBRARY, FUNCTION,
+dnl                   [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND],
+dnl                   [OTHER-LDFLAGS], [OTHER-LIBS])
+dnl
+dnl This macro checks if a C library can be referenced by a Fortran compiler.
+dnl
+dnl Results are cached in `ax_fc_cv_c_lib_LIBRARY_FUNCTION`.
+dnl
+dnl NOTE: Might be possible to rewrite this to use `AX_FC_CHECK_BIND_C`.
+dnl
+AC_DEFUN([AX_FC_CHECK_C_LIB], [
+  AS_VAR_PUSHDEF([ax_fc_C_Lib], [ax_fc_cv_c_lib_$1_$2])
+  m4_ifval([$5],
+    [ax_fc_c_lib_msg_LDFLAGS=" with $5"],
+    [ax_fc_c_lib_msg_LDFLAGS=""]
+  )
+  AC_CACHE_CHECK(
+    [for $2 in -l$1$ax_fc_c_lib_msg_LDFLAGS], [ax_fc_cv_c_lib_$1_$2], [
+      ax_fc_check_c_lib_save_LDFLAGS=$LDFLAGS
+      LDFLAGS="$6 $LDFLAGS"
+      ax_fc_check_c_lib_save_LIBS=$LIBS
+      LIBS="-l$1 $7 $LIBS"
+      AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([],[dnl
+dnl begin code block
+        interface
+        subroutine test() bind(c, name="$2")
+        end subroutine test
+        end interface
+        call test])
+dnl end code block
+        ],
+        [AS_VAR_SET([ax_fc_C_Lib], [yes])],
+        [AS_VAR_SET([ax_fc_C_Lib], [no])]
+      )
+      LDFLAGS=$ax_fc_check_c_lib_save_LDFLAGS
+      LIBS=$ax_fc_check_c_lib_save_LIBS
+    ]
+  )
+  AS_VAR_IF([ax_fc_C_Lib], [yes],
+    [m4_default([$3], [LIBS="-l$1 $LIBS"])],
+    [$4]
+  )
+  AS_VAR_POPDEF([ax_fc_C_Lib])
+])

--- a/ac/deps/m4/ax_fc_check_lib.m4
+++ b/ac/deps/m4/ax_fc_check_lib.m4
@@ -18,7 +18,7 @@ dnl    library with different -L flags, or perhaps other ld configurations.
 dnl
 dnl Results are cached in the ax_fc_cv_lib_LIBRARY_FUNCTION variable.
 dnl
-AC_DEFUN([AX_FC_CHECK_LIB],[dnl
+AC_DEFUN([AX_FC_CHECK_LIB],[
   AS_VAR_PUSHDEF([ax_fc_Lib], [ax_fc_cv_lib_$1_$2])
   m4_ifval([$6],
     [ax_fc_lib_msg_LDFLAGS=" with $6"],
@@ -29,14 +29,15 @@ AC_DEFUN([AX_FC_CHECK_LIB],[dnl
     LDFLAGS="$6 $LDFLAGS"
     ax_fc_check_lib_save_LIBS=$LIBS
     LIBS="-l$1 $7 $LIBS"
-    AS_IF([test -n $3],
+    AS_IF([test -n "$3"],
       [ax_fc_use_mod="use $3"],
       [ax_fc_use_mod=""])
-    AC_LINK_IFELSE([
-        AC_LANG_PROGRAM([], [dnl
+    AC_LINK_IFELSE([dnl
+dnl Begin 7-column code block
+AC_LANG_PROGRAM([], [dnl
         $ax_fc_use_mod
-        call $2]dnl
-        )
+        call $2])dnl
+dnl End code block
       ],
       [AS_VAR_SET([ax_fc_Lib], [yes])],
       [AS_VAR_SET([ax_fc_Lib], [no])]


### PR DESCRIPTION
This patch updates the macros used in the `ac/deps` directory.  It includes a bugfix in the library testing, and also bundles the macro for testing Fortran links to C libraries.  Both of these macros were already in `ac/m4` but unused by `ac/deps`.

No problems were observed in any recent FMS builds, although in principle they could have been affected by these errors.  The issues were only detected when the macros were used in an unrelated project (LM3 land model).

These issues are due to code duplication in `ac/m4` and `ac/deps/m4`. This separation was intended to draw a clear logical separation between MOM6 and its FMS dependency, and only provide what is required by each respective build.  But perhaps there are some flaws in this thinking, and may warrant further discussion.