### PR TITLE
makedep: Support externals alongside program units

### DIFF
--- a/ac/makedep
+++ b/ac/makedep
@@ -16,6 +16,13 @@ re_use = re.compile(r"^ *use +([a-z_0-9]+)")
 re_cpp_include = re.compile(r"^ *# *include *[<\"']([a-zA-Z_0-9\.]+)[>\"']")
 re_f90_include = re.compile(r"^ *include +[\"']([a-zA-Z_0-9\.]+)[\"']")
 re_program = re.compile(r"^ *[pP][rR][oO][gG][rR][aA][mM] +([a-zA-Z_0-9]+)")
+re_end = re.compile(r"^ *end *(module|procedure) ", re.IGNORECASE)
+# NOTE: This excludes comments and tokens with substrings containing `function`
+# or `subroutine`, but will fail if the keywords appear in other contexts.
+re_procedure = re.compile(
+    r"^[^!]*(?<![a-z_])(function|subroutine)(?![a-z_])",
+    re.IGNORECASE
+)
 
 
 def create_deps(src_dirs, makefile, debug, exec_target, fc_rule,
@@ -30,6 +37,7 @@ def create_deps(src_dirs, makefile, debug, exec_target, fc_rule,
     F90_files = [
         f for f in all_files
         if f.endswith('.f90') or f.endswith('.F90')
+        or f.endswith('.f') or f.endswith('.F')
     ]
     #  ... all C source
     c_files = [f for f in all_files if f.endswith('.c')]
@@ -58,7 +66,7 @@ def create_deps(src_dirs, makefile, debug, exec_target, fc_rule,
     o2mods, o2uses, o2h, o2inc, o2prg, prg2o, mod2o = {}, {}, {}, {}, {}, {}, {}
     externals, all_modules = [], []
     for f in F90_files:
-        mods, used, cpp, inc, prg = scan_fortran_file(f)
+        mods, used, cpp, inc, prg, has_externals = scan_fortran_file(f)
         # maps object file to modules produced
         o2mods[object_file(f)] = mods
         # maps module produced to object file
@@ -85,12 +93,12 @@ def create_deps(src_dirs, makefile, debug, exec_target, fc_rule,
                     o2prg[o] = ['[ignored %s]' % (p)]
                 else:
                     prg2o[p] = object_file(f)
-        if not mods and not prg:
+        if has_externals:
             externals.append(object_file(f))
         all_modules += mods
 
     for f in c_files:
-        _, _, cpp, inc, _ = scan_fortran_file(f)
+        _, _, cpp, inc, _, _ = scan_fortran_file(f)
         # maps object file to .h files included
         o2h[object_file(f)] = cpp
         externals.append(object_file(f))
@@ -238,7 +246,7 @@ def nested_inc(inc_files, f2F):
     def recur(hfile):
         if hfile not in f2F.keys():
             return
-        _, _, cpp, inc, _ = scan_fortran_file(f2F[hfile])
+        _, _, cpp, inc, _, _ = scan_fortran_file(f2F[hfile])
         if len(cpp) + len(inc) > 0:
             for h in cpp+inc:
                 if h not in hlst and h in f2F.keys():
@@ -258,25 +266,49 @@ def scan_fortran_file(src_file):
     module_decl, used_modules, cpp_includes, f90_includes, programs = [], [], [], [], []
     with io.open(src_file, 'r', errors='replace') as file:
         lines = file.readlines()
+
+        external_namespace = True
+
+        file_has_externals = False
+
         for line in lines:
             match = re_module.match(line.lower())
             if match:
                 if match.group(1) not in 'procedure':   # avoid "module procedure" statements
                     module_decl.append(match.group(1))
+                    external_namespace = False
+
             match = re_use.match(line.lower())
             if match:
                 used_modules.append(match.group(1))
+
             match = re_cpp_include.match(line)
             if match:
                 cpp_includes.append(match.group(1))
+
             match = re_f90_include.match(line)
             if match:
                 f90_includes.append(match.group(1))
+
             match = re_program.match(line)
             if match:
                 programs.append(match.group(1))
+                external_namespace = False
+
+            match = re_end.match(line)
+            if match:
+                external_namespace = True
+
+            # Check for any external procedures; if present, flag the file
+            # as a potential source of
+            # NOTE: This a very weak test that needs further modification
+            if external_namespace and not file_has_externals:
+                match = re_procedure.match(line)
+                if match:
+                    file_has_externals = True
+
     used_modules = [m for m in sorted(set(used_modules)) if m not in module_decl]
-    return add_suff(module_decl, '.mod'), add_suff(used_modules, '.mod'), cpp_includes, f90_includes, programs
+    return add_suff(module_decl, '.mod'), add_suff(used_modules, '.mod'), cpp_includes, f90_includes, programs, file_has_externals
     # return add_suff(module_decl, '.mod'), add_suff(sorted(set(used_modules)), '.mod'), cpp_includes, f90_includes, programs
 
 
@@ -297,8 +329,9 @@ def find_files(src_dirs):
             for file in f:
                 # TODO: use any()
                 if (file.endswith('.F90') or file.endswith('.f90')
+                        or file.endswith('.f') or file.endswith('.F')
                         or file.endswith('.h') or file.endswith('.inc')
-                        or file.endswith('.c')):
+                        or file.endswith('.c') or file.endswith('.H')):
                     files.append(p+'/'+file)
     return sorted(set(files))
 


### PR DESCRIPTION
The current version of makedep uses the existence of program units (module or program) to determine whether a file contains globally accessible external functions.  It incorrectly ignores files with externals it happens to contain both externals and a program unit.

We resolve this by tracking whether we are inside or outside of a program unit while parsing each line.  We ignore keywords which may appear in comments, as well as tokens which may contain `function` or `subroutine` as substrings.  This method is not perfect; there are cases which will incorrectly report entering a block, but this method appears sufficient for all of our known codebases.

This issue was detected when attempting to parse the AM2 source.  While still far from a general solution, it is sufficient to handle a few of the more challenging cases encountered in AM2.