### PR TITLE
*Fix non-Boussinesq Flather BT_OBC%dZ_v bug

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -3335,9 +3335,9 @@ subroutine set_up_BT_OBC(OBC, eta, SpV_avg, BT_OBC, BT_Domain, G, GV, US, CS, MS
           endif
         else
           if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) then
-            BT_OBC%dZ_v(i,J) = GV%H_to_Z*eta(i,j)
+            BT_OBC%dZ_v(i,J) = GV%H_to_RZ * eta(i,j) * SpV_avg(i,j)
           elseif (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) then
-            BT_OBC%dZ_v(i,J) = GV%H_to_Z*eta(i,j+1)
+            BT_OBC%dZ_v(i,J) = GV%H_to_RZ * eta(i,j+1) * SpV_avg(i,j+1)
           endif
         endif
         BT_OBC%Cg_v(i,J) = SQRT(dgeo_de_in * GV%g_prime(1) * BT_OBC%dZ_v(i,J))


### PR DESCRIPTION
  Corrected the non-Boussinesq calculation of the total depth used by the v-component of the Flather open boundary condition, making the v-component consistent with the u-component and correcting an oversight with a recent commit.  This commit could change answers in some non-Boussinesq cases with Flather open boundary conditions.