### PR TITLE
Update default FMS to 2023.03 in ac/deps and CI testing

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -75,7 +75,7 @@ MAKEFLAGS += -R
 -include config.mk
 
 # Set the infra framework
-FRAMEWORK ?= fms1
+FRAMEWORK ?= fms2
 
 # Set the MPI launcher here
 # TODO: This needs more automated configuration

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -245,31 +245,26 @@ COV_LDFLAGS := LDFLAGS="$(LDFLAGS_COVERAGE) $(LDFLAGS_DEPS) $(LDFLAGS_USER)"
 
 
 # Environment variable configuration
-build/symmetric/Makefile: MOM_ENV=$(PATH_FMS) $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
-build/asymmetric/Makefile: MOM_ENV=$(PATH_FMS) $(ASYMMETRIC_FCFLAGS) $(MOM_LDFLAGS) \
+MOM_ENV := $(PATH_FMS)
+build/symmetric/Makefile: MOM_ENV += $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
+build/asymmetric/Makefile: MOM_ENV += $(ASYMMETRIC_FCFLAGS) $(MOM_LDFLAGS) \
   MOM_MEMORY=../../../config_src/memory/dynamic_nonsymmetric/MOM_memory.h
-build/repro/Makefile: MOM_ENV=$(PATH_FMS) $(REPRO_FCFLAGS) $(MOM_LDFLAGS)
-build/openmp/Makefile: MOM_ENV=$(PATH_FMS) $(OPENMP_FCFLAGS) $(MOM_LDFLAGS)
-build/target/Makefile: MOM_ENV=$(PATH_FMS) $(TARGET_FCFLAGS) $(MOM_LDFLAGS)
-build/opt/Makefile: MOM_ENV=$(PATH_FMS) $(OPT_FCFLAGS) $(MOM_LDFLAGS)
-build/opt_target/Makefile: MOM_ENV=$(PATH_FMS) $(OPT_FCFLAGS) $(MOM_LDFLAGS)
-build/coupled/Makefile: MOM_ENV=$(PATH_FMS) $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
-build/nuopc/Makefile: MOM_ENV=$(PATH_FMS) $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
-build/cov/Makefile: MOM_ENV=$(PATH_FMS) $(COV_FCFLAGS) $(COV_LDFLAGS)
-build/unit/Makefile: MOM_ENV=$(PATH_FMS) $(COV_FCFLAGS) $(COV_LDFLAGS)
+build/repro/Makefile: MOM_ENV += $(REPRO_FCFLAGS) $(MOM_LDFLAGS)
+build/openmp/Makefile: MOM_ENV += $(OPENMP_FCFLAGS) $(MOM_LDFLAGS)
+build/target/Makefile: MOM_ENV += $(TARGET_FCFLAGS) $(MOM_LDFLAGS)
+build/opt/Makefile: MOM_ENV += $(OPT_FCFLAGS) $(MOM_LDFLAGS)
+build/opt_target/Makefile: MOM_ENV += $(OPT_FCFLAGS) $(MOM_LDFLAGS)
+build/coupled/Makefile: MOM_ENV += $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
+build/nuopc/Makefile: MOM_ENV += $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
+build/cov/Makefile: MOM_ENV += $(COV_FCFLAGS) $(COV_LDFLAGS)
+build/unit/Makefile: MOM_ENV += $(COV_FCFLAGS) $(COV_LDFLAGS)
 
 # Configure script flags
-build/symmetric/Makefile: MOM_ACFLAGS=
-build/asymmetric/Makefile: MOM_ACFLAGS=
-build/repro/Makefile: MOM_ACFLAGS=
-build/openmp/Makefile: MOM_ACFLAGS=--enable-openmp
-build/target/Makefile: MOM_ACFLAGS=
-build/opt/Makefile: MOM_ACFLAGS=
-build/opt_target/Makefile: MOM_ACFLAGS=
-build/coupled/Makefile: MOM_ACFLAGS=--with-driver=FMS_cap
-build/nuopc/Makefile: MOM_ACFLAGS=--with-driver=nuopc_cap
-build/cov/Makefile: MOM_ACFLAGS=
-build/unit/Makefile: MOM_ACFLAGS=--with-driver=unit_tests
+MOM_ACFLAGS := --with-framework=$(FRAMEWORK)
+build/openmp/Makefile: MOM_ACFLAGS += --enable-openmp
+build/coupled/Makefile: MOM_ACFLAGS += --with-driver=FMS_cap
+build/nuopc/Makefile: MOM_ACFLAGS += --with-driver=nuopc_cap
+build/unit/Makefile: MOM_ACFLAGS += --with-driver=unit_tests
 
 # Fetch regression target source code
 build/target/Makefile: | $(TARGET_CODEBASE)
@@ -277,9 +272,6 @@ build/opt_target/Makefile: | $(TARGET_CODEBASE)
 
 
 # Define source code dependencies
-# NOTE: ./configure is too much, but Makefile is not enough!
-#   Ideally we only want to re-run both Makefile and mkmf, but the mkmf call
-#   is inside ./configure, so we must re-run ./configure as well.
 build/target_codebase/configure: $(TARGET_SOURCE)
 
 
@@ -295,8 +287,8 @@ build/%/MOM6: build/%/Makefile $(MOM_SOURCE)
 build/%/Makefile: ../ac/configure ../ac/Makefile.in deps/lib/libFMS.a
 	mkdir -p $(@D)
 	cd $(@D) \
-	  && $(MOM_ENV) ../../../ac/configure $(MOM_ACFLAGS) --with-framework=$(FRAMEWORK) \
-	  || (cat config.log && false)
+	&& $(MOM_ENV) ../../../ac/configure $(MOM_ACFLAGS) \
+	|| (cat config.log && false)
 
 
 ../ac/configure: ../ac/configure.ac ../ac/m4
@@ -308,8 +300,8 @@ build/target/Makefile build/opt_target/Makefile: \
   $(TARGET_CODEBASE)/ac/configure deps/lib/libFMS.a
 	mkdir -p $(@D)
 	cd $(@D) \
-	  && $(MOM_ENV) ../../$(TARGET_CODEBASE)/ac/configure $(MOM_ACFLAGS) \
-	  || (cat config.log && false)
+	&& $(MOM_ENV) ../../$(TARGET_CODEBASE)/ac/configure $(MOM_ACFLAGS) \
+	|| (cat config.log && false)
 
 
 $(TARGET_CODEBASE)/ac/configure: $(TARGET_CODEBASE)

--- a/ac/deps/Makefile
+++ b/ac/deps/Makefile
@@ -8,7 +8,7 @@ MAKEFLAGS += -R
 
 # FMS framework
 FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
-FMS_COMMIT ?= 2019.01.03
+FMS_COMMIT ?= 2023.03
 
 
 # List of source files to link this Makefile's dependencies to model Makefiles

--- a/ac/deps/Makefile.fms.in
+++ b/ac/deps/Makefile.fms.in
@@ -23,4 +23,4 @@ ARFLAGS = @ARFLAGS@
 .PHONY: depend
 depend: Makefile.dep
 Makefile.dep:
-	$(PYTHON) $(MAKEDEP) -o Makefile.dep -e -x libFMS.a @srcdir@
+	$(PYTHON) $(MAKEDEP) -o Makefile.dep -e -x libFMS.a -s @srcdir@/test_fms @srcdir@

--- a/ac/makedep
+++ b/ac/makedep
@@ -25,12 +25,12 @@ re_procedure = re.compile(
 )
 
 
-def create_deps(src_dirs, makefile, debug, exec_target, fc_rule,
+def create_deps(src_dirs, skip_dirs, makefile, debug, exec_target, fc_rule,
                 link_externals, script_path):
     """Create "makefile" after scanning "src_dis"."""
 
     # Scan everything Fortran related
-    all_files = find_files(src_dirs)
+    all_files = find_files(src_dirs, skip_dirs)
 
     # Lists of things
     #  ... all F90 source
@@ -332,9 +332,14 @@ def object_file(src_file):
     return os.path.splitext(os.path.basename(src_file))[0] + '.o'
 
 
-def find_files(src_dirs):
+def find_files(src_dirs, skip_dirs):
     """Return sorted list of all source files starting from each directory in
     the list "src_dirs"."""
+
+    if skip_dirs is not None:
+        skip = [os.path.normpath(s) for s in skip_dirs]
+    else:
+        skip = []
 
     # TODO: Make this a user-defined argument
     extensions = ('.f90', '.f', '.c', '.inc', '.h',  '.fh')
@@ -345,6 +350,8 @@ def find_files(src_dirs):
         if not os.path.isdir(path):
             raise ValueError("Directory '{}' was not found".format(path))
         for p, d, f in os.walk(os.path.normpath(path), followlinks=True):
+            d[:] = [s for s in d if os.path.join(p, s) not in skip]
+
             for file in f:
                 if any(file.lower().endswith(ext) for ext in extensions):
                     files.append(p+'/'+file)
@@ -392,8 +399,13 @@ parser.add_argument(
     action='store_true',
     help="Annotate the makefile with extra information."
 )
+parser.add_argument(
+    '-s', '--skip',
+    action='append',
+    help="Skip directory in source code search."
+)
 args = parser.parse_args()
 
 # Do the thing
-create_deps(args.path, args.makefile, args.debug, args.exec_target,
+create_deps(args.path, args.skip, args.makefile, args.debug, args.exec_target,
             args.fc_rule, args.link_externals, sys.argv[0])


### PR DESCRIPTION
This PR updates our default FMS to 2023.03 in our autoconf builds, which includes our CI testing used in GitHub Actions.

There is also an upgrade to makedep which excludes directories (using the `-s` flag, for "skip"; all other good letters were taken).  This was required to removed the programs in `test_fms` which require preprocessor macros.  While we could have included them, we don't want to become obliged to maintain a list of required macros.

It also fixes a bug in `.testing/Makefile` which prevented the "target" (or regression) build from using the FMS2 framework API.