### PR TITLE
 Compute dz in the halo for OBC segments

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1436,8 +1436,11 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
                       CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
   if (CS%debug) call MOM_tracer_chksum("Post-diffuse ", CS%tracer_Reg, G)
   if (showCallTree) call callTree_waypoint("finished tracer advection/diffusion (step_MOM)")
-  call update_segment_tracer_reservoirs(G, GV, CS%uhtr, CS%vhtr, h, CS%OBC, &
+  if (associated(CS%OBC) .and. allocated(CS%uhtr) .and. allocated(CS%vhtr)) then
+    call pass_vector(CS%uhtr, CS%vhtr, G%Domain)
+    call update_segment_tracer_reservoirs(G, GV, CS%uhtr, CS%vhtr, h, CS%OBC, &
                      CS%t_dyn_rel_adv, CS%tracer_Reg)
+  endif
   call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
 
   call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1436,7 +1436,7 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
                       CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
   if (CS%debug) call MOM_tracer_chksum("Post-diffuse ", CS%tracer_Reg, G)
   if (showCallTree) call callTree_waypoint("finished tracer advection/diffusion (step_MOM)")
-  if (associated(CS%OBC) .and. allocated(CS%uhtr) .and. allocated(CS%vhtr)) then
+  if (associated(CS%OBC)) then
     call pass_vector(CS%uhtr, CS%vhtr, G%Domain)
     call update_segment_tracer_reservoirs(G, GV, CS%uhtr, CS%vhtr, h, CS%OBC, &
                      CS%t_dyn_rel_adv, CS%tracer_Reg)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -3883,7 +3883,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
   endif
 
   if (OBC%number_of_segments >= 1) then
-    call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=G%Domain%nihalo)
+    call thickness_to_dz(h, tv, dz, G, GV, US)
     call pass_var(dz, G%Domain)
   endif
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -3883,7 +3883,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
   endif
 
   if (OBC%number_of_segments >= 1) then
-    call thickness_to_dz(h, tv, dz, G, GV, US)
+    call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=G%Domain%nihalo)
     call pass_var(dz, G%Domain)
   endif
 

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -123,7 +123,8 @@ subroutine advect_tracer(h_end, uhtr, vhtr, OBC, dt, G, GV, US, CS, Reg, x_first
   x_first = (MOD(G%first_direction,2) == 0)
 
   ! increase stencil size for Colella & Woodward PPM
-  if (CS%usePPM .and. .not. CS%useHuynh) stencil = 3
+! if (CS%usePPM .and. .not. CS%useHuynh) stencil = 3
+  if (CS%usePPM) stencil = 3
 
   ntr = Reg%ntr
   Idt = 1.0 / dt


### PR DESCRIPTION
 - It was blowing up with "forrtl: error (65): floating invalid" when accessing dz in the halo at the boundary, but just sometimes. My default layout is trouble while my testing layout of 48 cores is not.