### PR TITLE
+Standardize input salinity units as "ppt"

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -1522,7 +1522,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
   endif
   call get_param(param_file, mdl, "SPEAR_DTFREEZE_DS", CS%SPEAR_dTf_dS, &
                  "The derivative of the freezing temperature with salinity.", &
-                 units="deg C PSU-1", default=-0.054, scale=US%degC_to_C*US%S_to_ppt, &
+                 units="degC ppt-1", default=-0.054, scale=US%degC_to_C*US%S_to_ppt, &
                  do_not_log=.not.CS%trestore_SPEAR_ECDA)
   call get_param(param_file, mdl, "RESTORE_FLUX_RHO", CS%rho_restore, &
                  "The density that is used to convert piston velocities into salt or heat "//&

--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -1907,19 +1907,19 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
       call get_param(param_file, mdl, "SST_NORTH", CS%T_north, &
                  "With buoy_config linear, the sea surface temperature "//&
                  "at the northern end of the domain toward which to "//&
-                 "to restore.", units="deg C", default=0.0, scale=US%degC_to_C)
+                 "to restore.", units="degC", default=0.0, scale=US%degC_to_C)
       call get_param(param_file, mdl, "SST_SOUTH", CS%T_south, &
                  "With buoy_config linear, the sea surface temperature "//&
                  "at the southern end of the domain toward which to "//&
-                 "to restore.", units="deg C", default=0.0, scale=US%degC_to_C)
+                 "to restore.", units="degC", default=0.0, scale=US%degC_to_C)
       call get_param(param_file, mdl, "SSS_NORTH", CS%S_north, &
                  "With buoy_config linear, the sea surface salinity "//&
                  "at the northern end of the domain toward which to "//&
-                 "to restore.", units="PSU", default=35.0, scale=US%ppt_to_S)
+                 "to restore.", units="ppt", default=35.0, scale=US%ppt_to_S)
       call get_param(param_file, mdl, "SSS_SOUTH", CS%S_south, &
                  "With buoy_config linear, the sea surface salinity "//&
                  "at the southern end of the domain toward which to "//&
-                 "to restore.", units="PSU", default=35.0, scale=US%ppt_to_S)
+                 "to restore.", units="ppt", default=35.0, scale=US%ppt_to_S)
     endif
     call get_param(param_file, mdl, "RESTORE_FLUX_RHO", CS%rho_restore, &
                  "The density that is used to convert piston velocities into salt or heat "//&

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1517,8 +1517,8 @@ subroutine EOS_init(param_file, EOS, US)
                  "temperature.", units="kg m-3 K-1", default=-0.2)
     call get_param(param_file, mdl, "DRHO_DS", EOS%dRho_dS, &
                  "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", "//&
-                 "this is the partial derivative of density with "//&
-                 "salinity.", units="kg m-3 PSU-1", default=0.8)
+                 "this is the partial derivative of density with salinity.", &
+                 units="kg m-3 ppt-1", default=0.8)
     call EOS_manual_init(EOS, form_of_EOS=EOS_LINEAR, Rho_T0_S0=EOS%Rho_T0_S0, dRho_dT=EOS%dRho_dT, dRho_dS=EOS%dRho_dS)
   endif
   if (EOS%form_of_EOS == EOS_WRIGHT) then
@@ -1563,17 +1563,17 @@ subroutine EOS_init(param_file, EOS, US)
     call get_param(param_file, mdl, "TFREEZE_S0_P0",EOS%TFr_S0_P0, &
                  "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", "//&
                  "this is the freezing potential temperature at "//&
-                 "S=0, P=0.", units="deg C", default=0.0)
+                 "S=0, P=0.", units="degC", default=0.0)
     call get_param(param_file, mdl, "DTFREEZE_DS",EOS%dTFr_dS, &
                  "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", "//&
                  "this is the derivative of the freezing potential "//&
                  "temperature with salinity.", &
-                 units="deg C PSU-1", default=-0.054)
+                 units="degC ppt-1", default=-0.054)
     call get_param(param_file, mdl, "DTFREEZE_DP",EOS%dTFr_dP, &
                  "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", "//&
                  "this is the derivative of the freezing potential "//&
                  "temperature with pressure.", &
-                 units="deg C Pa-1", default=0.0)
+                 units="degC Pa-1", default=0.0)
   endif
 
   if ((EOS%form_of_EOS == EOS_TEOS10 .or. EOS%form_of_EOS == EOS_ROQUET_RHO .or. &
@@ -1694,7 +1694,7 @@ subroutine convert_temp_salt_for_TEOS10(T, S, HI, kd, mask_z, EOS)
   type(EOS_type),        intent(in)    :: EOS !< Equation of state structure
 
   real, parameter :: Sref_Sprac = (35.16504/35.0) ! The TEOS 10 conversion factor to go from
-                                    ! practical salinity to reference salinity [nondim]
+                                    ! practical salinity to reference salinity [PSU ppt-1]
   integer :: i, j, k
 
   if ((EOS%form_of_EOS /= EOS_TEOS10) .and. (EOS%form_of_EOS /= EOS_ROQUET_RHO) .and. &
@@ -1808,20 +1808,20 @@ end subroutine pot_temp_to_cons_temp
 !! temperature uses this same scaling, but this can be replaced by the factor given by scale.
 subroutine abs_saln_to_prac_saln(S, prSaln, EOS, dom, scale)
   real, dimension(:), intent(in)    :: S        !< Absolute salinity [S ~> ppt]
-  real, dimension(:), intent(inout) :: prSaln   !< Practical salinity [S ~> ppt]
+  real, dimension(:), intent(inout) :: prSaln   !< Practical salinity [S ~> PSU]
   type(EOS_type),     intent(in)    :: EOS      !< Equation of state structure
   integer, dimension(2), optional, intent(in) :: dom  !< The domain of indices to work on, taking
                                                 !! into account that arrays start at 1.
   real,     optional, intent(in)    :: scale    !< A multiplicative factor by which to scale the output
-                                                !! practical in place of with scaling stored
+                                                !! practical salinities in place of with scaling stored
                                                 !! in EOS.  A value of 1.0 returns salinities in [PSU],
                                                 !! while the default is equivalent to EOS%ppt_to_S.
 
   ! Local variables
   real, dimension(size(S)) :: Sa    ! Salinity converted to [ppt]
-  real :: S_scale ! A factor to convert practical salinity from ppt to the desired units [S ppt-1 ~> 1]
+  real :: S_scale ! A factor to convert practical salinity from ppt to the desired units [S PSU-1 ~> 1]
   real, parameter :: Sprac_Sref = (35.0/35.16504) ! The TEOS 10 conversion factor to go from
-                                    ! reference salinity to practical salinity [nondim]
+                                    ! reference salinity to practical salinity [PSU ppt-1]
   integer :: i, is, ie
 
   if (present(dom)) then
@@ -1848,21 +1848,21 @@ end subroutine abs_saln_to_prac_saln
 !! use the dimensionally rescaling as specified within the EOS type.  The output potential
 !! temperature uses this same scaling, but this can be replaced by the factor given by scale.
 subroutine prac_saln_to_abs_saln(S, absSaln, EOS, dom, scale)
-  real, dimension(:), intent(in)    :: S        !< Practical salinity [S ~> ppt]
+  real, dimension(:), intent(in)    :: S        !< Practical salinity [S ~> PSU]
   real, dimension(:), intent(inout) :: absSaln  !< Absolute salinity [S ~> ppt]
   type(EOS_type),     intent(in)    :: EOS      !< Equation of state structure
   integer, dimension(2), optional, intent(in) :: dom  !< The domain of indices to work on, taking
                                                 !! into account that arrays start at 1.
   real,     optional, intent(in)    :: scale    !< A multiplicative factor by which to scale the output
-                                                !! practical in place of with scaling stored
-                                                !! in EOS.  A value of 1.0 returns salinities in [PSU],
+                                                !! absolute salnities in place of with scaling stored
+                                                !! in EOS.  A value of 1.0 returns salinities in [ppt],
                                                 !! while the default is equivalent to EOS%ppt_to_S.
 
   ! Local variables
   real, dimension(size(S)) :: Sp    ! Salinity converted to [ppt]
-  real :: S_scale ! A factor to convert practical salinity from ppt to the desired units [S ppt-1 ~> 1]
+  real :: S_scale ! A factor to convert absolute salinity from ppt to the desired units [S ppt-1 ~> 1]
   real, parameter :: Sref_Sprac = (35.16504/35.0) ! The TEOS 10 conversion factor to go from
-                                    ! practical salinity to reference salinity [nondim]
+                                    ! practical salinity to reference salinity [PSU ppt-1]
   integer :: i, is, ie
 
   if (present(dom)) then

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -59,7 +59,7 @@ contains
 real elemental function density_elem_linear(this, T, S, pressure)
   class(linear_EOS), intent(in) :: this     !< This EOS
   real, intent(in) :: T        !< Potential temperature relative to the surface [degC]
-  real, intent(in) :: S        !< Salinity [PSU]
+  real, intent(in) :: S        !< Salinity [ppt]
   real, intent(in) :: pressure !< Pressure [Pa]
 
   density_elem_linear = this%Rho_T0_S0 + this%dRho_dT*T + this%dRho_dS*S
@@ -73,7 +73,7 @@ end function density_elem_linear
 real elemental function density_anomaly_elem_linear(this, T, S, pressure, rho_ref)
   class(linear_EOS), intent(in) :: this     !< This EOS
   real, intent(in) :: T        !< Potential temperature relative to the surface [degC]
-  real, intent(in) :: S        !< Salinity [PSU]
+  real, intent(in) :: S        !< Salinity [ppt]
   real, intent(in) :: pressure !< Pressure [Pa]
   real, intent(in) :: rho_ref  !< A reference density [kg m-3]
 
@@ -87,9 +87,8 @@ end function density_anomaly_elem_linear
 !! scalar and array inputs.
 real elemental function spec_vol_elem_linear(this, T, S, pressure)
   class(linear_EOS), intent(in) :: this     !< This EOS
-  real,              intent(in) :: T        !< potential temperature relative to the surface
-                                            !! [degC].
-  real,              intent(in) :: S        !< Salinity [PSU].
+  real,              intent(in) :: T        !< Potential temperature relative to the surface [degC].
+  real,              intent(in) :: S        !< Salinity [ppt].
   real,              intent(in) :: pressure !< Pressure [Pa].
 
   spec_vol_elem_linear = 1.0 / ( this%Rho_T0_S0 + (this%dRho_dT*T + this%dRho_dS*S))
@@ -102,9 +101,8 @@ end function spec_vol_elem_linear
 !! scalar and array inputs.
 real elemental function spec_vol_anomaly_elem_linear(this, T, S, pressure, spv_ref)
   class(linear_EOS), intent(in) :: this     !< This EOS
-  real,              intent(in) :: T        !< potential temperature relative to the surface
-                                            !! [degC].
-  real,              intent(in) :: S        !< Salinity [PSU].
+  real,              intent(in) :: T        !< Potential temperature relative to the surface [degC].
+  real,              intent(in) :: S        !< Salinity [ppt].
   real,              intent(in) :: pressure !< Pressure [Pa].
   real,              intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1].
 
@@ -118,9 +116,8 @@ end function spec_vol_anomaly_elem_linear
 !! with potential temperature and salinity.
 elemental subroutine calculate_density_derivs_elem_linear(this,T, S, pressure, dRho_dT, dRho_dS)
   class(linear_EOS),    intent(in)   :: this     !< This EOS
-  real,    intent(in)  :: T        !< Potential temperature relative to the surface
-                                   !! [degC].
-  real,    intent(in)  :: S        !< Salinity [PSU].
+  real,    intent(in)  :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in)  :: S        !< Salinity [ppt].
   real,    intent(in)  :: pressure !< Pressure [Pa].
   real,    intent(out) :: drho_dT  !< The partial derivative of density with
                                    !! potential temperature [kg m-3 degC-1].
@@ -138,16 +135,16 @@ elemental subroutine calculate_density_second_derivs_elem_linear(this, T, S, pre
                                   drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP)
   class(linear_EOS), intent(in) :: this !< This EOS
   real, intent(in)    :: T           !< Potential temperature relative to the surface [degC].
-  real, intent(in)    :: S           !< Salinity [PSU].
+  real, intent(in)    :: S           !< Salinity [ppt].
   real, intent(in)    :: pressure    !< pressure [Pa].
   real, intent(inout) :: drho_dS_dS  !< The second derivative of density with
-                                     !! salinity [kg m-3 PSU-2].
+                                     !! salinity [kg m-3 ppt-2].
   real, intent(inout) :: drho_dS_dT  !< The second derivative of density with
                                      !! temperature and salinity [kg m-3 ppt-1 degC-1].
   real, intent(inout) :: drho_dT_dT  !< The second derivative of density with
                                      !! temperature [kg m-3 degC-2].
   real, intent(inout) :: drho_dS_dP  !< The second derivative of density with
-                                     !! salinity and pressure [kg m-3 PSU-1 Pa-1].
+                                     !! salinity and pressure [kg m-3 ppt-1 Pa-1].
   real, intent(inout) :: drho_dT_dP  !< The second derivative of density with
                                      !! temperature and pressure [kg m-3 degC-1 Pa-1].
 
@@ -163,10 +160,10 @@ end subroutine calculate_density_second_derivs_elem_linear
 elemental subroutine calculate_specvol_derivs_elem_linear(this, T, S, pressure, dSV_dT, dSV_dS)
   class(linear_EOS),  intent(in)    :: this     !< This EOS
   real,               intent(in)    :: T        !< Potential temperature [degC]
-  real,               intent(in)    :: S        !< Salinity [PSU]
+  real,               intent(in)    :: S        !< Salinity [ppt]
   real,               intent(in)    :: pressure !< pressure [Pa]
   real,               intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
-                                                !! salinity [m3 kg-1 PSU-1]
+                                                !! salinity [m3 kg-1 ppt-1]
   real,               intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
                                                 !! potential temperature [m3 kg-1 degC-1]
   ! Local variables
@@ -184,9 +181,8 @@ end subroutine calculate_specvol_derivs_elem_linear
 !! salinity, potential temperature, and pressure.
 elemental subroutine calculate_compress_elem_linear(this, T, S, pressure, rho, drho_dp)
   class(linear_EOS), intent(in)  :: this      !< This EOS
-  real,              intent(in)  :: T         !< Potential temperature relative to the surface
-                                              !! [degC].
-  real,              intent(in)  :: S         !< Salinity [PSU].
+  real,              intent(in)  :: T         !< Potential temperature relative to the surface [degC].
+  real,              intent(in)  :: S         !< Salinity [ppt].
   real,              intent(in)  :: pressure  !< pressure [Pa].
   real,              intent(out) :: rho       !< In situ density [kg m-3].
   real,              intent(out) :: drho_dp   !< The partial derivative of density with pressure
@@ -201,7 +197,7 @@ end subroutine calculate_compress_elem_linear
 !> Calculates the layer average specific volumes.
 subroutine avg_spec_vol_linear(T, S, p_t, dp, SpV_avg, start, npts, Rho_T0_S0, dRho_dT, dRho_dS)
   real, dimension(:), intent(in)    :: T         !< Potential temperature [degC]
-  real, dimension(:), intent(in)    :: S         !< Salinity [PSU]
+  real, dimension(:), intent(in)    :: S         !< Salinity [ppt]
   real, dimension(:), intent(in)    :: p_t       !< Pressure at the top of the layer [Pa]
   real, dimension(:), intent(in)    :: dp        !< Pressure change in the layer [Pa]
   real, dimension(:), intent(inout) :: SpV_avg   !< The vertical average specific volume
@@ -268,7 +264,7 @@ subroutine int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0_pres, G_e, HI, &
                         intent(in)  :: T         !< Potential temperature relative to the surface
                                                  !! [C ~> degC].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-                        intent(in)  :: S         !< Salinity [S ~> PSU].
+                        intent(in)  :: S         !< Salinity [S ~> ppt].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: z_t       !< Height at the top of the layer in depth units [Z ~> m].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
@@ -439,7 +435,7 @@ subroutine int_spec_vol_dp_linear(T, S, p_t, p_b, alpha_ref, HI, Rho_T0_S0, &
                         intent(in)  :: T         !< Potential temperature relative to the surface
                                                  !! [C ~> degC].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  &
-                        intent(in)  :: S         !< Salinity [S ~> PSU].
+                        intent(in)  :: S         !< Salinity [S ~> ppt].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  &
                         intent(in)  :: p_t       !< Pressure at the top of the layer [R L2 T-2 ~> Pa]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  &
@@ -614,7 +610,7 @@ end subroutine int_spec_vol_dp_linear
 subroutine calculate_density_array_linear(this, T, S, pressure, rho, start, npts, rho_ref)
   class(linear_EOS),  intent(in) :: this      !< This EOS
   real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
-  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: S        !< Salinity [ppt]
   real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
   real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
   integer,            intent(in)  :: start    !< The starting index for calculations
@@ -640,7 +636,7 @@ end subroutine calculate_density_array_linear
 subroutine calculate_spec_vol_array_linear(this, T, S, pressure, specvol, start, npts, spv_ref)
   class(linear_EOS),  intent(in) :: this      !< This EOS
   real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
-  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: S        !< Salinity [ppt]
   real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
   real, dimension(:), intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
   integer,            intent(in)  :: start    !< The starting index for calculations

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -235,7 +235,7 @@ subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, US, param_file, eqn_of_state
                  "The initial temperature of the lightest layer.", &
                  units="degC", scale=US%degC_to_C, fail_if_missing=.true.)
   call get_param(param_file, mdl, "S_REF", S_ref, &
-                 "The initial salinities.", units="PSU", default=35.0, scale=US%ppt_to_S)
+                 "The initial salinities.", units="ppt", default=35.0, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=GV%g_Earth*US%L_T_to_m_s**2*US%m_to_Z, scale=US%m_s_to_L_T**2*US%Z_to_m)
@@ -376,13 +376,13 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, US, param_file, eqn_of_sta
 
   call get_param(param_file, mdl, "S_REF", S_Ref, &
                  "The default initial salinities.", &
-                 units="PSU", default=35.0, scale=US%ppt_to_S)
+                 units="ppt", default=35.0, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_Light, &
                  "The initial lightest salinities when COORD_CONFIG is set to ts_range.", &
-                 units="PSU", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S)
+                 units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_Dense, &
                  "The initial densest salinities when COORD_CONFIG is set to ts_range.", &
-                 units="PSU", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S)
+                 units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S)
 
   call get_param(param_file, mdl, "TS_RANGE_RESOLN_RATIO", res_rat, &
                  "The ratio of density space resolution in the densest "//&

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1745,7 +1745,7 @@ subroutine initialize_temp_salt_fit(T, S, G, GV, US, param_file, eqn_of_state, P
                  units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_Ref, &
                  "A reference salinity used in initialization.", &
-                 units="PSU", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "FIT_SALINITY", fit_salin, &
                  "If true, accept the prescribed temperature and fit the "//&
                  "salinity; otherwise take salinity and fit temperature.", &
@@ -1829,10 +1829,10 @@ subroutine initialize_temp_salt_linear(T, S, G, GV, US, param_file, just_read)
                  units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_TOP", S_top, &
                  "Initial salinity of the top surface.", &
-                 units="PSU", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_RANGE", S_range, &
                  "Initial salinity difference (top-bottom).", &
-                 units="PSU", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -2645,7 +2645,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  units="degC", default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(PF, mdl, "LAND_FILL_SALIN", salt_land_fill, &
                  "A value to use to fill in ocean salinities on land points.", &
-                 units="1e-3", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(PF, mdl, "HORIZ_INTERP_TOL_TEMP", tol_temp, &
                  "The tolerance in temperature changes between iterations when interpolating "//&
                  "from an input dataset using horiz_interp_and_extrap_tracer.  This routine "//&
@@ -2655,7 +2655,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  "The tolerance in salinity changes between iterations when interpolating "//&
                  "from an input dataset using horiz_interp_and_extrap_tracer.  This routine "//&
                  "converges slowly, so an overly small tolerance can get expensive.", &
-                 units="1e-3", default=1.0e-3, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=1.0e-3, scale=US%ppt_to_S, do_not_log=just_read)
 
   if (just_read) then
     if ((.not.useALEremapping) .and. adjust_temperature) &

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -4026,14 +4026,14 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
                  "during detrainment.", units="K", default=0.5, scale=US%degC_to_C)
   call get_param(param_file, mdl, "ALLOWED_DETRAIN_SALT_CHG", CS%Allowed_S_chg, &
                  "The amount by which salinity is allowed to exceed previous values "//&
-                 "during detrainment.", units="PSU", default=0.1, scale=US%ppt_to_S)
+                 "during detrainment.", units="ppt", default=0.1, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "ML_DT_DS_WEIGHT", CS%dT_dS_wt, &
                  "When forced to extrapolate T & S to match the layer "//&
                  "densities, this factor (in deg C / PSU) is combined "//&
                  "with the derivatives of density with T & S to determine "//&
                  "what direction is orthogonal to density contours. It "//&
                  "should be a typical value of (dR/dS) / (dR/dT) in oceanic profiles.", &
-                 units="degC PSU-1", default=6.0, scale=US%degC_to_C*US%S_to_ppt)
+                 units="degC ppt-1", default=6.0, scale=US%degC_to_C*US%S_to_ppt)
   call get_param(param_file, mdl, "BUFFER_LAYER_EXTRAP_LIMIT", CS%BL_extrap_lim, &
                  "A limit on the density range over which extrapolation "//&
                  "can occur when detraining from the buffer layers, "//&

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -628,16 +628,16 @@ subroutine determine_temperature(temp, salt, R_tgt, EOS, p_ref, niter, k_start, 
                  units="degC", default=31.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_S_MIN", S_min, &
                  "The minimum salinity that can be found by determine_temperature.", &
-                 units="1e-3", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_S_MAX", S_max, &
                  "The maximum salinity that can be found by determine_temperature.", &
-                 units="1e-3", default=65.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=65.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_T_TOLERANCE", tol_T, &
                  "The convergence tolerance for temperature in determine_temperature.", &
                  units="degC", default=1.0e-4, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_S_TOLERANCE", tol_S, &
                  "The convergence tolerance for temperature in determine_temperature.", &
-                 units="1e-3", default=1.0e-4, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=1.0e-4, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_RHO_TOLERANCE", tol_rho, &
                  "The convergence tolerance for density in determine_temperature.", &
                  units="kg m-3", default=1.0e-4, scale=US%kg_m3_to_R, do_not_log=just_read)
@@ -645,10 +645,10 @@ subroutine determine_temperature(temp, salt, R_tgt, EOS, p_ref, niter, k_start, 
     ! By default 10 degC is weighted equivalently to 1 ppt when minimizing changes.
     call get_param(PF, mdl, "DETERMINE_TEMP_DT_DS_WEIGHT", dT_dS_gauge, &
                  "When extrapolating T & S to match the layer target densities, this "//&
-                 "factor (in deg C / PSU) is combined with the derivatives of density "//&
+                 "factor (in degC / ppt) is combined with the derivatives of density "//&
                  "with T & S to determine what direction is orthogonal to density contours.  "//&
                  "It could be based on a typical value of (dR/dS) / (dR/dT) in oceanic profiles.", &
-                 units="degC PSU-1", default=10.0, scale=US%degC_to_C*US%S_to_ppt)
+                 units="degC ppt-1", default=10.0, scale=US%degC_to_C*US%S_to_ppt)
   else
     call get_param(PF, mdl, "DETERMINE_TEMP_T_ADJ_RANGE", max_t_adj, &
                  "The maximum amount by which the initial layer temperatures can be "//&
@@ -657,7 +657,7 @@ subroutine determine_temperature(temp, salt, R_tgt, EOS, p_ref, niter, k_start, 
     call get_param(PF, mdl, "DETERMINE_TEMP_S_ADJ_RANGE", max_S_adj, &
                  "The maximum amount by which the initial layer salinities can be "//&
                  "modified in determine_temperature.", &
-                 units="1e-3", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
   endif
 
   if (just_read) return ! All run-time parameters have been read, so return.

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -261,15 +261,15 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, GV, US, param_fi
   call get_param(param_file, mdl, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
                  units="nondim", default=0.2, do_not_log=.true.)
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference temperature', &
                  units='degC', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_RANGE", S_range,' Initial salinity range', &
-                 units='1e-3', default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
                  units='degC', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "INITIAL_SSS", S_surf, "Initial surface salinity", &
-                 units="1e-3", default=34.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=34.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "DOME2D_T_BAY", T_bay, &
                  "Temperature in the inflow embayment in the DOME2d test case", &
                  units="degC", default=1.0, scale=US%degC_to_C, do_not_log=just_read)
@@ -440,10 +440,10 @@ subroutine DOME2d_initialize_sponges(G, GV, US, tv, depth_tot, param_file, use_A
   call get_param(param_file, mdl, "S_RANGE", S_range, units="ppt", default=2.0, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "T_RANGE", T_range, units="degC", default=0.0, scale=US%degC_to_C)
   call get_param(param_file, mdl, "INITIAL_SSS", S_surf, "Initial surface salinity", &
-                 units="1e-3", default=34.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=34.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "DOME2D_EAST_SPONGE_S_RANGE", S_range_sponge, &
                  "Range of salinities in the eastern sponge region in the DOME2D configuration", &
-                 units="1e-3", default=1.0, scale=US%ppt_to_S)
+                 units="ppt", default=1.0, scale=US%ppt_to_S)
 
   ! Set the sponge damping rate as a function of position
   Idamp(:,:) = 0.0

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -348,7 +348,7 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, depth_tot, G, GV, U
                   default=.false., do_not_log=just_read)
       call get_param(param_file, mdl, "DRHO_DS", drho_dS1, &
                   "Partial derivative of density with salinity.", &
-                  units="kg m-3 PSU-1", scale=US%kg_m3_to_R*US%S_to_ppt, &
+                  units="kg m-3 ppt-1", scale=US%kg_m3_to_R*US%S_to_ppt, &
                   fail_if_missing=.not.just_read, do_not_log=just_read)
       call get_param(param_file, mdl, "DRHO_DT", drho_dT1, &
                   "Partial derivative of density with temperature.", &
@@ -359,7 +359,7 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, depth_tot, G, GV, U
                   units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
       call get_param(param_file, mdl, "S_REF", S_Ref, &
                   "A reference salinity used in initialization.", &
-                  units="PSU", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                  units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
       if (just_read) return ! All run-time parameters have been read, so return.
 
       ! write(mesg,*) 'read drho_dS, drho_dT', drho_dS1, drho_dT1

--- a/src/user/Rossby_front_2d_initialization.F90
+++ b/src/user/Rossby_front_2d_initialization.F90
@@ -68,7 +68,7 @@ subroutine Rossby_front_initialize_thickness(h, G, GV, US, param_file, just_read
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
-                 units='C', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "DRHO_DT", dRho_dT, &
                  units="kg m-3 degC-1", default=-0.2, scale=US%kg_m3_to_R*US%C_to_degC, do_not_log=.true.)
   call get_param(param_file, mdl, "MAXIMUM_DEPTH", max_depth, &
@@ -155,11 +155,11 @@ subroutine Rossby_front_initialize_temperature_salinity(T, S, h, G, GV, US, &
   call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference temperature', &
-                 units='C', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
-                 units='C', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "MAXIMUM_DEPTH", max_depth, &
                  units="m", default=-1.e9, scale=GV%m_to_H, do_not_log=.true.)
 
@@ -231,11 +231,11 @@ subroutine Rossby_front_initialize_velocity(u, v, h, G, GV, US, param_file, just
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
-                 units='C', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=.true.)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference temperature', &
-                 units='C', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=.true.)
+                 units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=.true.)
   call get_param(param_file, mdl, "RHO_T0_S0", Rho_T0_S0, &
                  units="kg m-3", default=1000.0, scale=US%kg_m3_to_R, do_not_log=.true.)
   call get_param(param_file, mdl, "DRHO_DT", dRho_dT, &

--- a/src/user/SCM_CVMix_tests.F90
+++ b/src/user/SCM_CVMix_tests.F90
@@ -88,13 +88,13 @@ subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, US, param_file, just_read)
                  'Initial salt mixed layer depth', &
                  units='m', default=0.0, scale=US%m_to_Z, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L1_SALT", UpperLayerSalt, &
-                 'Layer 2 surface salinity', units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 'Layer 2 surface salinity', units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L1_TEMP", UpperLayerTemp, &
-                 'Layer 1 surface temperature', units='C', default=20.0, scale=US%degC_to_C, do_not_log=just_read)
+                 'Layer 1 surface temperature', units="degC", default=20.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_SALT", LowerLayerSalt, &
-                 'Layer 2 surface salinity', units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 'Layer 2 surface salinity', units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_TEMP", LowerLayerTemp, &
-                 'Layer 2 surface temperature', units='C', default=20.0, scale=US%degC_to_C, do_not_log=just_read)
+                 'Layer 2 surface temperature', units="degC", default=20.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_DTDZ", LowerLayerdTdZ,     &
                  'Initial temperature stratification in layer 2', &
                  units='C/m', default=0.0, scale=US%degC_to_C*US%Z_to_m, do_not_log=just_read)
@@ -102,7 +102,7 @@ subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, US, param_file, just_read)
                  'Initial salinity stratification in layer 2', &
                  units='PPT/m', default=0.0, scale=US%ppt_to_S*US%Z_to_m, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_MINTEMP",LowerLayerMinTemp, &
-                 'Layer 2 minimum temperature', units='C', default=4.0, scale=US%degC_to_C, do_not_log=just_read)
+                 'Layer 2 minimum temperature', units="degC", default=4.0, scale=US%degC_to_C, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -76,12 +76,12 @@ subroutine adjustment_initialize_thickness ( h, G, GV, US, param_file, just_read
   ! Parameters used by main model initialization
   if (.not.just_read) call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units='ppt', scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "MIN_THICKNESS", min_thickness, 'Minimum layer thickness', &
                  default=1.0e-3, units='m', scale=US%m_to_Z, do_not_log=just_read)
   call get_param(param_file, mdl, "DRHO_DS", dRho_dS, &
                  "The partial derivative of density with salinity with a linear equation of state.", &
-                 units="kg m-3 PSU-1", default=0.8, scale=US%kg_m3_to_R*US%S_to_ppt)
+                 units="kg m-3 ppt-1", default=0.8, scale=US%kg_m3_to_R*US%S_to_ppt)
 
   ! Parameters specific to this experiment configuration
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
@@ -91,10 +91,10 @@ subroutine adjustment_initialize_thickness ( h, G, GV, US, param_file, just_read
                  units=G%x_ax_unit_short, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "DELTA_S_STRAT", delta_S_strat,           &
                  "Top-to-bottom salinity difference of stratification",  &
-                 units="1e-3", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "ADJUSTMENT_DELTAS", adjustment_deltaS,   &
                  "Salinity difference across front",                     &
-                 units="1e-3", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "FRONT_WAVE_AMP", front_wave_amp,         &
                  "Amplitude of trans-frontal wave perturbation",         &
                  units=G%x_ax_unit_short, default=0., do_not_log=just_read)
@@ -239,11 +239,11 @@ subroutine adjustment_initialize_temperature_salinity(T, S, h, depth_tot, G, GV,
 
   ! Parameters used by main model initialization
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference temperature', &
-                 units='C', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_RANGE", S_range, 'Initial salinity range',  &
-                 default=2.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=2.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
                  default=1.0, units='degC', scale=US%degC_to_C, do_not_log=just_read)
   ! Parameters specific to this experiment configuration BUT logged in previous s/r
@@ -252,9 +252,9 @@ subroutine adjustment_initialize_temperature_salinity(T, S, h, depth_tot, G, GV,
   call get_param(param_file, mdl, "ADJUSTMENT_WIDTH", adjustment_width, &
                  units=G%x_ax_unit_short, fail_if_missing=.not.just_read, do_not_log=.true.)
   call get_param(param_file, mdl, "ADJUSTMENT_DELTAS", adjustment_deltaS, &
-                 units='1e-3', scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=.true.)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=.true.)
   call get_param(param_file, mdl, "DELTA_S_STRAT", delta_S_strat, &
-                 units='1e-3', scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=.true.)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=.true.)
   call get_param(param_file, mdl, "FRONT_WAVE_AMP", front_wave_amp, &
                  units=G%x_ax_unit_short, default=0., do_not_log=.true.)
   call get_param(param_file, mdl, "FRONT_WAVE_LENGTH", front_wave_length, &

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -142,7 +142,7 @@ subroutine benchmark_initialize_thickness(h, depth_tot, G, GV, US, param_file, e
                  units="degC", default=29.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_ref, &
                  "The uniform salinities used to initialize the benchmark test case.", &
-                 units="PSU", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
 
   if (just_read) return ! This subroutine has no run-time parameters.
 

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -122,11 +122,11 @@ subroutine dense_water_initialize_TS(G, GV, US, param_file, T, S, h, just_read)
        "Depth of unstratified mixed layer as a fraction of the water column.", &
        units="nondim", default=default_mld, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl,"T_REF", T_ref, 'Reference temperature', &
                 units='degC', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl,"S_RANGE", S_range, 'Initial salinity range', &
-                units='1e-3', default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
+                units="ppt", default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -204,7 +204,7 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
                  units="nondim", default=0.1)
   call get_param(param_file, mdl, "DENSE_WATER_EAST_SPONGE_SALT", S_dense, &
                  "Salt anomaly of the dense water being formed in the overflow region.", &
-                 units="1e-3", default=4.0, scale=US%ppt_to_S)
+                 units="ppt", default=4.0, scale=US%ppt_to_S)
 
   call get_param(param_file, mdl, "DENSE_WATER_MLD", mld, &
                  units="nondim", default=default_mld, do_not_log=.true.)
@@ -212,9 +212,9 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
                  units="nondim", default=default_sill, do_not_log=.true.)
 
   call get_param(param_file, mdl, "S_REF", S_ref, &
-                 units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "S_RANGE", S_range, &
-                 units='1e-3', default=2.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=2.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "T_REF", T_ref, &
                  units='degC', scale=US%degC_to_C, fail_if_missing=.true., do_not_log=.true.)
 

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -183,15 +183,15 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
 
   case ( REGRIDDING_RHO, REGRIDDING_HYCOM1) ! Initial thicknesses for isopycnal coordinates
     call get_param(param_file, mdl, "INITIAL_SSS", S_surf, &
-                   units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=34., scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "INITIAL_S_RANGE", S_range, &
-                   units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=2., scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "S_REF", S_ref, &
-                   units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, &
-                   units='1e-3', default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, &
-                   units='1e-3', default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "INTERFACE_IC_QUANTA", eta_IC_quanta, &
                    "The granularity of initial interface height values "//&
                    "per meter, to avoid sensivity to order-of-arithmetic changes.", &
@@ -291,10 +291,10 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
                  units='degC', default=20., scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "DUMBBELL_SREF", S_surf, &
                  'DUMBBELL REFERENCE SALINITY', &
-                 units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=34., scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "DUMBBELL_S_RANGE", S_range, &
                  'DUMBBELL salinity range (right-left)', &
-                 units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=2., scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "DUMBBELL_LEN", dblen, &
                  'Lateral Length scale for dumbbell ', &
                  units=G%x_ax_unit_short, default=600., do_not_log=just_read)
@@ -388,10 +388,10 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
                  units='degC', default=20., scale=US%degC_to_C, do_not_log=.true.)
   call get_param(param_file, mdl, "DUMBBELL_SREF", S_ref, &
                  'DUMBBELL REFERENCE SALINITY', &
-                 units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=34., scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "DUMBBELL_S_RANGE", S_range, &
                  'DUMBBELL salinity range (right-left)', &
-                 units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=2., scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl,"MIN_THICKNESS", min_thickness, &
                 'Minimum thickness for layer', &
                  units='m', default=1.0e-3, scale=US%m_to_Z, do_not_log=.true.)

--- a/src/user/dumbbell_surface_forcing.F90
+++ b/src/user/dumbbell_surface_forcing.F90
@@ -221,10 +221,10 @@ subroutine dumbbell_surface_forcing_init(Time, G, US, param_file, diag, CS)
                  default=.false., do_not_log=.true.)
   call get_param(param_file, mdl,"INITIAL_SSS", S_surf, &
                  "Initial surface salinity", &
-                 units="1e-3", default=34.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=34.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl,"INITIAL_S_RANGE", S_range, &
                  "Initial salinity range (bottom - surface)", &
-                 units="1e-3", default=2., scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=2., scale=US%ppt_to_S, do_not_log=.true.)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back "//&

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -233,16 +233,16 @@ subroutine seamount_initialize_temperature_salinity(T, S, h, G, GV, US, param_fi
                  'and "exponential".', default='linear', do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_SSS", S_surf, &
                  'Initial surface salinity', &
-                 units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=34., scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_SST", T_surf, &
                  'Initial surface temperature', &
-                 units='C', default=0., scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0., scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_S_RANGE", S_range, &
                  'Initial salinity range (bottom - surface)', &
-                 units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=2., scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_T_RANGE", T_range, &
                  'Initial temperature range (bottom - surface)', &
-                 units='C', default=0., scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0., scale=US%degC_to_C, do_not_log=just_read)
 
   select case ( coordinateMode(verticalCoordinate) )
     case ( REGRIDDING_LAYER ) ! Initial thicknesses for layer isopycnal coordinates
@@ -254,11 +254,11 @@ subroutine seamount_initialize_temperature_salinity(T, S, h, G, GV, US, param_fi
       call get_param(param_file, mdl, "TS_RANGE_T_DENSE", T_dense, &
                  units="degC", default=US%C_to_degC*T_Ref, scale=US%degC_to_C, do_not_log=.true.)
       call get_param(param_file, mdl, "S_REF", S_ref, &
-                 units="1e-3", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, &
-                 units="1e-3", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, &
-                 units="1e-3", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_RESOLN_RATIO", res_rat, &
                  units="nondim", default=1.0, do_not_log=.true.)
       if (just_read) return ! All run-time parameters have been read, so return.

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -201,17 +201,17 @@ subroutine sloshing_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference value for salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference value for temperature', &
                  units='degC', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
 
   ! The default is to assume an increase by 2 ppt for the salinity and a uniform temperature.
   call get_param(param_file, mdl, "S_RANGE", S_range, 'Initial salinity range.', &
-                 units='1e-3', default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
                  units='degC', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "INITIAL_SSS", S_surf, "Initial surface salinity", &
-                 units="1e-3", default=34.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=34.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "SLOSHING_T_PERT", T_pert, &
                  'A mid-column temperature perturbation in the sloshing test case', &
                  units='degC', default=1.0, scale=US%degC_to_C, do_not_log=just_read)


### PR DESCRIPTION
  Standardized the syntax for the units of salinities that are read via get_param calls to be uniformly 'units="ppt"' or similar units for derivatives with salinity.  The only exceptions are places where practical salinity is used specifically, which occurs for several arguments in the MOM_EOS code.  All answers are bitwise identical, but there are changes to a number of MOM_parameter_doc files.