### PR TITLE
Remove some unused calculations if non-Boussinesq

### DIFF
--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -197,10 +197,10 @@ subroutine wave_speed(h, tv, G, GV, US, cg1, CS, halo_size, use_ebt_mode, mono_N
     enddo ; enddo ; enddo
   endif
 
-  g_Rho0 = GV%g_Earth*GV%H_to_Z / GV%Rho0
+  nonBous = .not.(GV%Boussinesq .or. GV%semi_Boussinesq)
   H_to_pres = GV%H_to_RZ * GV%g_Earth
   ! Note that g_Rho0 = H_to_pres / GV%Rho0**2
-  nonBous = .not.(GV%Boussinesq .or. GV%semi_Boussinesq)
+  if (.not.nonBous) g_Rho0 = GV%g_Earth*GV%H_to_Z / GV%Rho0
   use_EOS = associated(tv%eqn_of_state)
 
   better_est = CS%better_cg1_est
@@ -900,9 +900,9 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, w_struct, u_struct, u_s
     is = G%isc - halo ; ie = G%iec + halo ; js = G%jsc - halo ; je = G%jec + halo
   endif
 
-  g_Rho0 = GV%g_Earth * GV%H_to_Z / GV%Rho0
-  H_to_pres = GV%H_to_RZ * GV%g_Earth
   nonBous = .not.(GV%Boussinesq .or. GV%semi_Boussinesq)
+  H_to_pres = GV%H_to_RZ * GV%g_Earth
+  if (.not.nonBous) g_Rho0 = GV%g_Earth * GV%H_to_Z / GV%Rho0
   use_EOS = associated(tv%eqn_of_state)
 
   if (CS%c1_thresh < 0.0) &
@@ -1057,7 +1057,6 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, w_struct, u_struct, u_s
               enddo
             endif
           endif
-          cg1_est = g_Rho0 * drxh_sum
         else  ! Not use_EOS
           drxh_sum = 0.0 ; dSpVxh_sum = 0.0
           if (better_est) then

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -773,11 +773,10 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
   I4dt = 0.25 / dt
   I_slope_max2 = 1.0 / (CS%slope_max**2)
-  G_scale = GV%g_Earth * GV%H_to_Z
 
   h_neglect = GV%H_subroundoff ; h_neglect2 = h_neglect**2 ; hn_2 = 0.5*h_neglect
   dz_neglect = GV%dZ_subroundoff ; dz_neglect2 = dz_neglect**2
-  G_rho0 = GV%g_Earth / GV%Rho0
+  if (GV%Boussinesq) G_rho0 = GV%g_Earth / GV%Rho0
   N2_floor = CS%N2_floor * US%Z_to_L**2
 
   use_EOS = associated(tv%eqn_of_state)


### PR DESCRIPTION
  Eliminated some unused calculations in wave_speed and thickness_diffuse_full that would use the Boussinesq reference density when in non-Boussinesq mode, either by adding logical flags around the calculations so that they only occur in Boussinesq mode.  All answers are bitwise identical.