### PR TITLE
+(*)non-Boussinesq ALE_sponges work in Z units

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2958,7 +2958,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     endif
 
     if (associated(ALE_sponge_in_CSp)) then
-      call rotate_ALE_sponge(ALE_sponge_in_CSp, G_in, CS%ALE_sponge_CSp, G, GV, turns, param_file)
+      call rotate_ALE_sponge(ALE_sponge_in_CSp, G_in, CS%ALE_sponge_CSp, G, GV, US, turns, param_file)
       call update_ALE_sponge_field(CS%ALE_sponge_CSp, T_in, G, GV, CS%T)
       call update_ALE_sponge_field(CS%ALE_sponge_CSp, S_in, G, GV, CS%S)
     endif

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2073,9 +2073,9 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
 !  else
     ! Initialize sponges without supplying sponge grid
 !    if (sponge_uv) then
-!      call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, Idamp_u, Idamp_v)
+!      call initialize_ALE_sponge(Idamp, G, GV, US, param_file, ALE_CSp, Idamp_u, Idamp_v)
 !    else
-!      call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp)
+!      call initialize_ALE_sponge(Idamp, G, GV, US, param_file, ALE_CSp)
 !    endif
   endif
 
@@ -2117,9 +2117,11 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
       endif
 
       if (sponge_uv) then
-        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, h, nz_data, Idamp_u, Idamp_v)
+        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, dz, nz_data, Idamp_u, Idamp_v, &
+                                   data_h_is_Z=.true.)
       else
-        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, h, nz_data)
+        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, dz, nz_data, &
+                                   data_h_is_Z=.true.)
       endif
       if (use_temperature) then
         call set_up_ALE_sponge_field(tmp_T, G, GV, tv%T, ALE_CSp, 'temp', &
@@ -2146,9 +2148,9 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
     else
       ! Initialize sponges without supplying sponge grid
       if (sponge_uv) then
-        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, Idamp_u, Idamp_v)
+        call initialize_ALE_sponge(Idamp, G, GV, US, param_file, ALE_CSp, Idamp_u, Idamp_v)
       else
-        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp)
+        call initialize_ALE_sponge(Idamp, G, GV, US, param_file, ALE_CSp)
       endif
       ! The remaining calls to set_up_sponge_field can be in any order.
       if ( use_temperature) then

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1093,7 +1093,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
   ! Apply ALE sponge
   if (CS%use_sponge .and. associated(CS%ALE_sponge_CSp)) then
     call cpu_clock_begin(id_clock_sponge)
-    call apply_ALE_sponge(h, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
+    call apply_ALE_sponge(h, tv, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
     call cpu_clock_end(id_clock_sponge)
     if (CS%debug) then
       call MOM_state_chksum("apply_sponge ", u, v, h, G, GV, US, haloshift=0)
@@ -1616,7 +1616,7 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
   ! Apply ALE sponge
   if (CS%use_sponge .and. associated(CS%ALE_sponge_CSp)) then
     call cpu_clock_begin(id_clock_sponge)
-    call apply_ALE_sponge(h, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
+    call apply_ALE_sponge(h, tv, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
     call cpu_clock_end(id_clock_sponge)
     if (CS%debug) then
       call MOM_state_chksum("apply_sponge ", u, v, h, G, GV, US, haloshift=0)


### PR DESCRIPTION
  Revised the ALE_sponge code to convert the model's thicknesses (in thickness units of [H ~> m or kg m-2]) into layer vertical extents (in height units of [Z ~> m]) to match how the input datasets vertical grids are specified and to avoid using the Boussinesq reference density to do the opposite conversion when in non-Boussinesq mode.  The internal conversion in `apply_ALE_sponge()` between layer thicknesses and layer vertical extents matches those in `thickness_to_dz()`, and uses the layer-averaged specific volumes when in non-Boussinesq mode.

  As a part of these changes, 12 internal variables in MOM_ALE_sponge were renamed (e.g., from `data_h` to `data_dz`) to more clearly reflect that they are the layer vertical extents instead of thicknesses, and there are new 3-d variables `dz_model`, that is created from h when the sponges are applied to the velocities, and `data_dz` to handle the conversion of the input thicknesses or vertical extents in `initialize_ALE_sponge_fixed()`.

  This commit includes adding a new `thermo_var_type` argument to `apply_ALE_sponge()`, a new `unit_scale_type` argument to `rotate_ALE_sponge()` and `initialize_ALE_sponge_varying` and the new optional argument `data_h_is_Z` to `initialize_ALE_sponge_fixed()` to indicate that the in thicknesses arguments are vertical distances (in [Z ~> m]) and do not need to be rescaled inside of the ALE_sponge code, and similarly for the new optional argument `data_h_in_Z` to `get_ALE_sponge_thicknesses()`.

  This commit also adds halo size and `Omit_Corners` arguments to the `pass_var()` calls in the ALE_sponge code.

  There are new optional arguments to 2 publicly visible routines, and new mandatory arguments to 3 others, but by default the meaning and units of all previous arguments are the same, and answers will be bitwise identical in any Boussinesq cases.  However, answers will change in any non-Boussinesq cases that use the ALE_sponges.