### PR TITLE
*Corrected CFC diagnostics and non-Bous CFC fluxes

### DIFF
--- a/src/tracer/MOM_CFC_cap.F90
+++ b/src/tracer/MOM_CFC_cap.F90
@@ -361,7 +361,6 @@ subroutine CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, C
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
-  real :: flux_scale ! A dimensional rescaling factor for fluxes [H R-1 Z-1 ~> m3 kg-1 or nondim]
   integer :: i, j, k, is, ie, js, je, nz, m
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -371,13 +370,11 @@ subroutine CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, C
   ! Compute KPP nonlocal term if necessary
   if (present(KPP_CSp)) then
     if (associated(KPP_CSp) .and. present(nonLocalTrans)) then
-      flux_scale = GV%Z_to_H / GV%rho0
-
       do m=1,NTR
         call KPP_NonLocalTransport(KPP_CSp, G, GV, h_old, nonLocalTrans, &
                                    CS%CFC_data(m)%sfc_flux(:,:), dt, CS%diag, &
                                    CS%CFC_data(m)%tr_ptr, CS%CFC_data(m)%conc(:,:,:), &
-                                   flux_scale=flux_scale)
+                                   flux_scale=GV%RZ_to_H)
       enddo
     endif
   endif
@@ -404,8 +401,7 @@ subroutine CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, C
   ! If needed, write out any desired diagnostics from tracer sources & sinks here.
   do m=1,NTR
     if (CS%CFC_data(m)%id_cmor > 0) &
-      call post_data(CS%CFC_data(m)%id_cmor, &
-                     (GV%Rho0*US%R_to_kg_m3)*CS%CFC_data(m)%conc, CS%diag)
+      call post_data(CS%CFC_data(m)%id_cmor, CS%CFC_data(m)%conc, CS%diag)
 
     if (CS%CFC_data(m)%id_sfc_flux > 0) &
       call post_data(CS%CFC_data(m)%id_sfc_flux, CS%CFC_data(m)%sfc_flux, CS%diag)


### PR DESCRIPTION
  Removed the duplicative multiplication by the Boussinesq density and related unit conversion factors in the calculation of the diagnosed mole concentration of the "cfc11" and "cfc12" diagnostics.  This unit rescaling is duplicative of the conversion factors in the `register_diag_field()` calls for these diagnostics (at about line 263).  This will change these two diagnostics by a factor of RHO_0.  This bug arose from separate and independent changes coming from GFDL and NCAR to add the same missing rescaling factor, and it might have gone undetected because of the vast range of valid values for CFC concentrations or because all of our regression testing uses calendar dates that precede the invention and first release of CFCs in the 1930s.  Although this commit will correct the code that is on the dev/gfdl branch, care will have to be taken when merging in modified versions of this file from other branches that might have also corrected this bug to avoid reintroducing it (perhaps in reverse).

  Also replaced the expression for the CFC flux rescaling factor for use with `KPP_NonLocalTransport()` with `GV%RZ_to_H`, which is equivalent to the previous expression in Boussinesq mode but avoids a multiplication and division by the Boussinesq reference density in non-Boussinesq mode.  All Boussinesq answers are identical, but some non-Boussinesq CFCs could be altered in the last bits.

  This PR will change diagnostics of CFC concentrations by about 3 orders of magnitude. The internal representation of the CFCs is bitwise identical in all Boussinesq cases, but they may change at roundoff in non-Boussinesq cases that use KPP.