### PR TITLE
+*Non-Boussinesq tracer initialization in Z-units 

### DIFF
--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -3,20 +3,21 @@ module MOM_tracer_initialization_from_Z
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_debugging, only : hchksum
-use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
-use MOM_cpu_clock, only : CLOCK_ROUTINE, CLOCK_LOOP
-use MOM_domains, only : pass_var
+use MOM_debugging,     only : hchksum
+use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
+use MOM_cpu_clock,     only : CLOCK_ROUTINE, CLOCK_LOOP
+use MOM_domains,       only : pass_var
 use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
-use MOM_file_parser, only : get_param, param_file_type, log_version
-use MOM_grid, only : ocean_grid_type
+use MOM_file_parser,   only : get_param, param_file_type, log_version
+use MOM_grid,          only : ocean_grid_type
 use MOM_horizontal_regridding, only : myStats, horiz_interp_and_extrap_tracer
 use MOM_interface_heights, only : dz_to_thickness_simple
-use MOM_remapping, only : remapping_CS, initialize_remapping
-use MOM_unit_scaling, only : unit_scale_type
-use MOM_verticalGrid, only : verticalGrid_type
-use MOM_ALE, only : ALE_remap_scalar
+use MOM_regridding,    only : set_dz_neglect
+use MOM_remapping,     only : remapping_CS, initialize_remapping
+use MOM_unit_scaling,  only : unit_scale_type
+use MOM_verticalGrid,  only : verticalGrid_type
+use MOM_ALE,           only : ALE_remap_scalar
 
 implicit none ; private
 
@@ -36,12 +37,13 @@ contains
 !> Initializes a tracer from a z-space data file, including any lateral regridding that is needed.
 subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_nam, &
                           src_var_unit_conversion, src_var_record, homogenize, &
-                          useALEremapping, remappingScheme, src_var_gridspec )
+                          useALEremapping, remappingScheme, src_var_gridspec, h_in_Z_units )
   type(ocean_grid_type),      intent(inout) :: G   !< Ocean grid structure.
   type(verticalGrid_type),    intent(in)    :: GV  !< Ocean vertical grid structure.
   type(unit_scale_type),      intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                              intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
+                              intent(in)    :: h   !< Layer thicknesses, in [H ~> m or kg m-2] or
+                                                   !! [Z ~> m] depending on the value of h_in_Z_units.
   real, dimension(:,:,:),     pointer       :: tr  !< Pointer to array to be initialized [CU ~> conc]
   type(param_file_type),      intent(in)    :: PF  !< parameter file
   character(len=*),           intent(in)    :: src_file !< source filename
@@ -54,12 +56,18 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   character(len=*), optional, intent(in)    :: remappingScheme !< remapping scheme to use.
   character(len=*), optional, intent(in)    :: src_var_gridspec !< Source variable name in a gridspec file.
                                                                 !! This is not implemented yet.
+  logical,          optional, intent(in)    :: h_in_Z_units !< If present and true, the input grid
+                                                            !! thicknesses are in the units of height
+                                                            !! ([Z ~> m]) instead of the usual units of
+                                                            !! thicknesses ([H ~> m or kg m-2])
+
   ! Local variables
   real :: land_fill = 0.0  ! A value to use to replace missing values [CU ~> conc]
   real :: convert ! A conversion factor into the model's internal units [CU conc-1 ~> 1]
   integer            :: recnum
   character(len=64)  :: remapScheme
   logical            :: homog, useALE
+  logical            :: h_is_in_Z_units
 
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -84,6 +92,10 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   type(verticalGrid_type) :: GV_loc ! A temporary vertical grid structure
 
   real :: missing_value ! A value indicating that there is no valid input data at this point [CU ~> conc]
+  real :: dz_neglect              ! A negligibly small vertical layer extent used in
+                                  ! remapping cell reconstructions [Z ~> m]
+  real :: dz_neglect_edge         ! A negligibly small vertical layer extent used in
+                                  ! remapping edge value calculations [Z ~> m]
   integer :: nPoints    ! The number of valid input data points in a column
   integer :: id_clock_routine, id_clock_ALE
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
@@ -143,6 +155,8 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   convert = 1.0
   if (PRESENT(src_var_unit_conversion)) convert = src_var_unit_conversion
 
+  h_is_in_Z_units = .false. ; if (present(h_in_Z_units)) h_is_in_Z_units = h_in_Z_units
+
   call horiz_interp_and_extrap_tracer(src_file, src_var_nam, recnum, &
             G, tr_z, mask_z, z_in, z_edges_in, missing_value, &
             scale=convert, homogenize=homog, m_to_Z=US%m_to_Z, answer_date=hor_regrid_answer_date)
@@ -185,12 +199,18 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
       dzSrc(i,j,:) = h1(:)
     enddo ; enddo
 
-    ! Equation of state data is not available, so a simpler rescaling will have to suffice,
-    ! but it might be problematic in non-Boussinesq mode.
-    GV_loc = GV ; GV_loc%ke = kd
-    call dz_to_thickness_simple(dzSrc, hSrc, G, GV_loc, US)
+    if (h_is_in_Z_units) then
+      dz_neglect = set_dz_neglect(GV, US, remap_answer_date, dz_neglect_edge)
+      call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date, &
+                            H_neglect=dz_neglect, H_neglect_edge=dz_neglect_edge)
+    else
+      ! Equation of state data is not available, so a simpler rescaling will have to suffice,
+      ! but it might be problematic in non-Boussinesq mode.
+      GV_loc = GV ; GV_loc%ke = kd
+      call dz_to_thickness_simple(dzSrc, hSrc, G, GV_loc, US)
 
-    call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date )
+      call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date )
+    endif
 
     deallocate( hSrc )
     deallocate( dzSrc )

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -340,7 +340,7 @@ subroutine tracer_flow_control_init(restart, day, G, GV, US, h, param_file, diag
     call initialize_CFC_cap(restart, day, G, GV, US, h, diag, OBC, CS%CFC_cap_CSp)
 
   if (CS%use_MOM_generic_tracer) &
-    call initialize_MOM_generic_tracer(restart, day, G, GV, US, h, param_file, diag, OBC, &
+    call initialize_MOM_generic_tracer(restart, day, G, GV, US, h, tv, param_file, diag, OBC, &
                                 CS%MOM_generic_tracer_CSp, sponge_CSp, ALE_sponge_CSp)
   if (CS%use_pseudo_salt_tracer) &
     call initialize_pseudo_salt_tracer(restart, day, G, GV, US, h, diag, OBC, CS%pseudo_salt_tracer_CSp, &


### PR DESCRIPTION
  The series of 3 commits in this pull request adds the ability to remap and initialize tracers and similar scalars using input and output grids that are defined in depth space or other arbitrary vertical grids, rather than assuming that we are working with thicknesses (in H units).  The specific changes to enable this new capability include adding new optional arguments to `ALE_remap_scalar()` and `MOM_initialize_tracer_from_Z()`, along with the new functions `set_h_neglect()` and `set_dz_neglect()` in the `MOM_regridding` module.  This new capability is exercised for temperatures and salinities that are initialized with `MOM_temp_salt_initialize_from_Z()` when `Z_INIT_REMAP_GENERAL = False`.

  The MOM_generic tracer code was also revised to use `thickness_to_dz()` to convert the models grid and then initialize the generic tracers from a Z-space file working entirely with the layer vertical extents (in Z-units) rather than the layer thicknesses (in H-units).  Similar changes were also made to `MOM_generic_tracer_column_physics()` for the vertical layer extents that are used in calls to `generic_tracer_source()`.

  There are no changes in answers in Boussinesq mode, but when this new capability is used in fully non-Boussinesq mode it avoids using the Boussinesq reference density and it does change answers.  All answers in the existing regression test suite are bitwise identical.  There are two new publicly visible functions, a new mandatory argument to `initialize_MOM_generic_tracer()` and new optional arguments to 2 other routines.

  The commits in this PR include:

- NOAA-GFDL/MOM6@894646098 *+non-Boussinesq revisions to MOM_generic_tracer
- NOAA-GFDL/MOM6@037c4f1d7 (*)MOM_temp_salt_init_from_Z Z-unit tracer remap 
- NOAA-GFDL/MOM6@2b88cebee +ALE_remap_scalar with arbitrary thickness units
