### PR TITLE
*Fix two bugs in convert_temp_salt_for_TEOS10

### DIFF
--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1703,7 +1703,7 @@ subroutine convert_temp_salt_for_TEOS10(T, S, HI, kd, mask_z, EOS)
   do k=1,kd ; do j=HI%jsc,HI%jec ; do i=HI%isc,HI%iec
     if (mask_z(i,j,k) >= 1.0) then
       S(i,j,k) = Sref_Sprac * S(i,j,k)
-      T(i,j,k) = EOS%degC_to_C*poTemp_to_consTemp(EOS%S_to_ppt*S(i,j,k), EOS%S_to_ppt*T(i,j,k))
+      T(i,j,k) = EOS%degC_to_C*poTemp_to_consTemp(EOS%C_to_degC*T(i,j,k), EOS%S_to_ppt*S(i,j,k))
     endif
   enddo ; enddo ; enddo
 end subroutine convert_temp_salt_for_TEOS10


### PR DESCRIPTION
  Fixed two bugs on a single line of `convert_temp_salt_for_TEOS10()`.  The first bug was a reversal in the order of the temperature and salinity arguments to `poTemp_to_consTemp()`, resulting in temperatures that closely approximate the salinities.  The second bug that was fixed on this line was temperatures being rescaled with a factor that is appropriate for salinities. This bug-fix will change answers dramatically for any cases that use the `ROQUET_RHO`, `ROQUET_SPV` and `TEOS10` equations of state and initialize the model with `INIT_LAYERS_FROM_Z_FILE = True`.