### PR TITLE
(*)Fix apply_topography_edits_from_file indexing

### DIFF
--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -256,8 +256,8 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
   call close_file_to_read(ncid, topo_edits_file)
 
   do n = 1, n_edits
-    i = ig(n) - G%isd_global + 2 ! +1 for python indexing and +1 for ig-isd_global+1
-    j = jg(n) - G%jsd_global + 2
+    i = ig(n) - G%idg_offset + 1 ! +1 for python indexing
+    j = jg(n) - G%jdg_offset + 1
     if (i>=G%isc .and. i<=G%iec .and. j>=G%jsc .and. j<=G%jec) then
       if (new_depth(n) /= mask_depth) then
         write(stdout,'(a,3i5,f8.2,a,f8.2,2i4)') &


### PR DESCRIPTION
  Corrected bugs in the horizontal indexing in `apply_topography_edits_from_file()` that led to differing answers depending on the value of `GLOBAL_INDEXING`.  This change gives identical results when `GLOBAL_INDEXING` is used, as can be seen by noting that `G%idg_offset = G%isd_global + G%isd` and that without global indexing `G%isd = 1`, but with global indexing the new expressions give the same answers as without them.  Because global indexing is not typically used, answers are not changed for any cases in the MOM6-examples test suite.