### PR TITLE
MLE: Use default answer date outside of block

### DIFF
--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1616,6 +1616,9 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   CS%use_Bodner = .false.
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+      "This sets the default value for the various _ANSWER_DATE parameters.", &
+      default=99991231, do_not_log=.true.)
   call openParameterBlock(param_file,'MLE') ! Prepend MLE% to all parameters
   if (GV%nkml==0) then
     call get_param(param_file, mdl, "USE_BODNER23", CS%use_Bodner, &
@@ -1657,9 +1660,6 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
              "BLD, when the latter is shallower than the running mean. A value of 0 "//&
              "instantaneously sets the running mean to the current value filtered BLD.", &
              units="s", default=0., scale=US%s_to_T)
-    call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
-             "This sets the default value for the various _ANSWER_DATE parameters.", &
-             default=99991231)
     call get_param(param_file, mdl, "ML_RESTRAT_ANSWER_DATE", CS%answer_date, &
              "The vintage of the order of arithmetic and expressions in the mixed layer "//&
              "restrat calculations.  Values below 20240201 recover the answers from the end "//&


### PR DESCRIPTION
Inside the `MLE%` ... `%MLE` parameter block, the default answer date was being read while inside the block.  Since the namespaces inside blocks are not shared or inherited, this was creating a new parameter, `MLE%DEFAULT_ANSWER_DATE`, whose value differed from the global `DEFAULT_ANSWER_DATE`.  This was causing unintuitive behavior of `MLE%ML_RESTRAT_ANSWER_DATE`, which ignored this global answer date.

This patch reads `DEFAULT_ANSWER_DATE` outside of the block, so that `ML_RESTRAT_ANSWER_DATE` now defaults to the global value.