### PR TITLE
Pinning package requirements for readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,9 @@ six
 future
 # Old Sphinx requires an old Jinja2
 jinja2<3.1
+sphinxcontrib_applehelp<1.0.8
+sphinxcontrib_devhelp<1.0.6
+sphinxcontrib_htmlhelp<2.0.5
+sphinxcontrib_qthelp<1.0.7
+sphinxcontrib_serializinghtml<1.0.7
+alabaster<0.7.14


### PR DESCRIPTION
Minor version updates to multiple packages used in the generation of the documentation introduce dependencies needing Sphinx >= 5.0, which breaks the sphinx extensions we use in documenting the MOM6 APIs. I have added versions for all the packages needed to keep things working with Sphinx4 for now, but we really do need to find a way to work with the newer versions.

More pinningaof of requirements for readthedocs

More pinning of requirements for readthedocs