### PR TITLE
Restore repro across restarts and layout in generic tracer runs with OBC

### DIFF
--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -414,7 +414,8 @@ contains
       endif
 
       call g_tracer_get_obc_segment_props(g_tracer,g_tracer_name,obc_has )
-      if(obc_has .and. g_tracer_is_prog(g_tracer)) call fill_obgc_segments(G, GV, OBC, tr_ptr, g_tracer_name)
+      if(obc_has .and. g_tracer_is_prog(g_tracer) .and. .not.restart) &
+             call fill_obgc_segments(G, GV, OBC, tr_ptr, g_tracer_name)
       !traverse the linked list till hit NULL
       call g_tracer_get_next(g_tracer, g_tracer_next)
       if (.NOT. associated(g_tracer_next)) exit


### PR DESCRIPTION
#520 has successfully addressed layout and restart reproducibility concerns in physics-only runs with OBC, resulting in a runtime increase of approximately `3%` in regional cases. Building on this progress, the PR further resolves reproducibility issues for generic tracer runs with OBC, ensuring tracer values at OBC are correctly read from restart files.

We also added a new RT case based on Northwest Atlantic configuration with generic CFC tracers, [NWA12.CFC](https://github.com/NOAA-GFDL/CEFI-regional-MOM6/actions/runs/8115574767/job/22184400255), to the [CEFI-regional-MOM6](https://github.com/NOAA-GFDL/CEFI-regional-MOM6/tree/bug/tracer_repro/exps/NWA12.CFC) repro.  The RT case consists of three steps::

1. A 2 hrs run with a 16x8 layout
2. A 1hr run with a 16x8 layout
3. A 1hr run with an 8x8 layout, with restart from 2.

The restarts from steps 1 and 3 are compared to ensure they are bitwise identical. 

It's important to note that this PR will change answers when OBC is used. Additionally, further investigation into the impact of stencil size changes (currently, the stencil size is only increased when OBC is used) may be necessary.