### PR TITLE
Set up auxiliary domain for unrotated grid

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2901,6 +2901,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   if (CS%rotate_index) then
     G_in%ke = GV%ke
 
+    ! Allocate the auxiliary non-symmetric domain for debugging or I/O purposes.
+    if (CS%debug .or. G_in%symmetric) then
+      call clone_MOM_domain(G_in%Domain, G_in%Domain_aux, symmetric=.false.)
+    else ; G_in%Domain_aux => G_in%Domain ; endif
+
     allocate(u_in(G_in%IsdB:G_in%IedB, G_in%jsd:G_in%jed, nz), source=0.0)
     allocate(v_in(G_in%isd:G_in%ied, G_in%JsdB:G_in%JedB, nz), source=0.0)
     allocate(h_in(G_in%isd:G_in%ied, G_in%jsd:G_in%jed, nz), source=GV%Angstrom_H)


### PR DESCRIPTION
  When ROTATE_INDEX is true, the model keeps both its rotated internal grid and an unrotated grid for setting initialization and forcing.  When the model is run in symmetric memory mode, there is an auxiliary non-symmetric domain that is needed for reading in fields at velocity points.  The auxiliary domain in the unrotated grid (G_in) was not being set previously, causing the model to fail to run some cases when ROTATE_INDEX was true.  That auxiliary domain in the unrotated grid is now being set up properly.  All answers and output are bitwise identical for any cases that worked previously.