### PR TITLE
+Add get_netcdf_filename for a get_field_nc error

### DIFF
--- a/src/framework/MOM_io_file.F90
+++ b/src/framework/MOM_io_file.F90
@@ -34,6 +34,7 @@ use MOM_netcdf, only : write_netcdf_axis
 use MOM_netcdf, only : write_netcdf_attribute
 use MOM_netcdf, only : get_netcdf_size
 use MOM_netcdf, only : get_netcdf_fields
+use MOM_netcdf, only : get_netcdf_filename
 use MOM_netcdf, only : read_netcdf_field
 
 use MOM_error_handler, only : MOM_error, FATAL
@@ -1751,8 +1752,9 @@ subroutine get_field_nc(handle, label, values, rescale)
   ! NOTE: Data on face and vertex points is not yet supported.  This is a
   ! temporary check to detect such cases, but may be removed in the future.
   if (.not. (compute_domain .or. data_domain)) &
-    call MOM_error(FATAL, 'get_field_nc: Only compute and data domains ' // &
-        'are currently supported.')
+    call MOM_error(FATAL, 'get_field_nc trying to read '//trim(label)//' from '//&
+                   trim(get_netcdf_filename(handle%handle_nc))//&
+                   ': Only compute and data domains are currently supported.')
 
   field_nc = handle%fields%get(label)
 

--- a/src/framework/MOM_netcdf.F90
+++ b/src/framework/MOM_netcdf.F90
@@ -39,6 +39,7 @@ public :: write_netcdf_axis
 public :: write_netcdf_attribute
 public :: get_netcdf_size
 public :: get_netcdf_fields
+public :: get_netcdf_filename
 public :: read_netcdf_field
 
 
@@ -722,6 +723,14 @@ subroutine get_netcdf_fields(handle, axes, fields)
   fields(:) = vars(:nfields)
 end subroutine get_netcdf_fields
 
+!> Return the name of a file from a netCDF handle
+function get_netcdf_filename(handle)
+  type(netcdf_file_type), intent(in) :: handle !< A netCDF file handle
+  character(len=:), allocatable :: get_netcdf_filename !< The name of the file that this handle refers to.
+
+  get_netcdf_filename = handle%filename
+
+end function
 
 !> Read the values of a field from a netCDF file
 subroutine read_netcdf_field(handle, field, values, bounds)


### PR DESCRIPTION
   Add `get_netcdf_filename()` and use it to add useful details (the field and filenames in question) to a fatal error message in `get_field_nc()`.  All answers are bitwise identical, but there is a new public interface and some output is changed in cases where `get_field_nc()` is failing.