### PR TITLE
Add units to the descriptions of 115 variables

### DIFF
--- a/config_src/drivers/timing_tests/time_MOM_EOS.F90
+++ b/config_src/drivers/timing_tests/time_MOM_EOS.F90
@@ -28,9 +28,9 @@ integer, parameter :: nic=26, halo=4, nits=10000, nsamp=400
 integer, parameter :: nic=23, halo=4, nits=1000, nsamp=400
 #endif
 
-real :: times(nsamp) ! For observing the PDF
+real :: times(nsamp) ! CPU times for observing the PDF [seconds]
 
-! Arrays to hold timings:
+! Arrays to hold timings in [seconds]:
 !  first axis corresponds to the form of EOS
 !  second axis corresponds to the function being timed
 real, dimension(:,:), allocatable :: timings, tmean, tstd, tmin, tmax
@@ -100,14 +100,18 @@ subroutine run_suite(EOS_list, nic, halo, nits, timings)
   integer, intent(in)  :: nits         !< Number of calls to sample
                                        !! (large enough that the CPU timers can resolve
                                        !! the loop)
-  real,    intent(out) :: timings(n_eos,n_fns) !< The average time taken for nits calls
+  real,    intent(out) :: timings(n_eos,n_fns) !< The average time taken for nits calls [seconds]
                                        !! First index corresponds to EOS
                                        !! Second index: 1 = scalar args,
                                        !! 2 = array args without halo,
                                        !! 3 = array args with halo and "dom".
   type(EOS_type) :: EOS
   integer :: e, i, dom(2)
-  real :: start, finish, T, S, P, rho
+  real :: start, finish  ! CPU times [seconds]
+  real :: T  ! A potential or conservative temperature [degC]
+  real :: S  ! A practical salinity or absolute salinity [ppt]
+  real :: P  ! A pressure [Pa]
+  real :: rho ! A density [kg m-3] or specific volume [m3 kg-1]
   real, dimension(nic+2*halo) :: T1, S1, P1, rho1
 
   T = 10.
@@ -171,15 +175,18 @@ subroutine run_one(EOS_list, nic, halo, nits, timing)
   integer, intent(in)  :: nits         !< Number of calls to sample
                                        !! (large enough that the CPU timers can resolve
                                        !! the loop)
-  real,    intent(out) :: timing       !< The average time taken for nits calls
+  real,    intent(out) :: timing       !< The average time taken for nits calls [seconds]
                                        !! First index corresponds to EOS
                                        !! Second index: 1 = scalar args,
                                        !! 2 = array args without halo,
                                        !! 3 = array args with halo and "dom".
   type(EOS_type) :: EOS
   integer :: i, dom(2)
-  real :: start, finish
-  real, dimension(nic+2*halo) :: T1, S1, P1, rho1
+  real :: start, finish  ! CPU times [seconds]
+  real, dimension(nic+2*halo) :: T1   ! Potential or conservative temperatures [degC]
+  real, dimension(nic+2*halo) :: S1   ! A practical salinities or absolute salinities [ppt]
+  real, dimension(nic+2*halo) :: P1   ! Pressures [Pa]
+  real, dimension(nic+2*halo) :: rho1 ! Densities [kg m-3] or specific volumes [m3 kg-1]
 
   ! Time the scalar interface
   call EOS_manual_init(EOS, form_of_EOS=EOS_list(5), &

--- a/src/ALE/coord_adapt.F90
+++ b/src/ALE/coord_adapt.F90
@@ -93,10 +93,10 @@ subroutine set_adapt_params(CS, adaptTimeRatio, adaptAlpha, adaptZoom, adaptZoom
   type(adapt_CS),    pointer    :: CS  !< The control structure for this module
   real,    optional, intent(in) :: adaptTimeRatio !< Ratio of optimisation and diffusion timescales [nondim]
   real,    optional, intent(in) :: adaptAlpha     !< Nondimensional coefficient determining
-                                                  !! how much optimisation to apply
+                                                  !! how much optimisation to apply [nondim]
   real,    optional, intent(in) :: adaptZoom      !< Near-surface zooming depth [H ~> m or kg m-2]
   real,    optional, intent(in) :: adaptZoomCoeff !< Near-surface zooming coefficient [nondim]
-  real,    optional, intent(in) :: adaptBuoyCoeff !< Stratification-dependent diffusion coefficient
+  real,    optional, intent(in) :: adaptBuoyCoeff !< Stratification-dependent diffusion coefficient [nondim]
   real,    optional, intent(in) :: adaptDrho0  !< Reference density difference for
                                                !! stratification-dependent diffusion [R ~> kg m-3]
   logical, optional, intent(in) :: adaptDoMin  !< If true, form a HYCOM1-like mixed layer by

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -305,7 +305,7 @@ subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
 
   ! Local variables
   integer        :: k ! loop index
-  real           :: t ! current interface target density
+  real           :: t ! current interface target density [A]
 
   ! Make sure boundary coordinates of new grid coincide with boundary
   ! coordinates of previous grid
@@ -385,10 +385,10 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   ! Local variables
   real                        :: xi0         ! normalized target coordinate [nondim]
   real, dimension(DEGREE_MAX) :: a           ! polynomial coefficients [A]
-  real                        :: numerator
-  real                        :: denominator
+  real                        :: numerator   ! The numerator of an expression [A]
+  real                        :: denominator ! The denominator of an expression [A]
   real                        :: delta       ! Newton-Raphson increment [nondim]
-!   real                        :: x           ! global target coordinate
+!   real                        :: x           ! global target coordinate [nondim]
   real                        :: eps         ! offset used to get away from boundaries [nondim]
   real                        :: grad        ! gradient during N-R iterations [A]
   integer :: i, k, iter  ! loop indices

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -5028,7 +5028,7 @@ subroutine mask_outside_OBCs(G, US, param_file, OBC)
   integer, parameter :: cin = 3, cout = 4, cland = -1, cedge = -2
   character(len=256) :: mesg    ! Message for error messages.
   real, allocatable, dimension(:,:) :: color, color2  ! For sorting inside from outside,
-                                                      ! two different ways
+                                                      ! two different ways [nondim]
 
   if (.not. associated(OBC)) return
 
@@ -5136,7 +5136,7 @@ end subroutine mask_outside_OBCs
 !> flood the cin, cout values
 subroutine flood_fill(G, color, cin, cout, cland)
   type(dyn_horgrid_type), intent(inout) :: G      !< Ocean grid structure
-  real, dimension(:,:),   intent(inout) :: color  !< For sorting inside from outside
+  real, dimension(:,:),   intent(inout) :: color  !< For sorting inside from outside [nondim]
   integer, intent(in) :: cin    !< color for inside the domain
   integer, intent(in) :: cout   !< color for outside the domain
   integer, intent(in) :: cland  !< color for inside the land mask
@@ -5196,7 +5196,7 @@ end subroutine flood_fill
 !> flood the cin, cout values
 subroutine flood_fill2(G, color, cin, cout, cland)
   type(dyn_horgrid_type), intent(inout) :: G       !< Ocean grid structure
-  real, dimension(:,:),   intent(inout) :: color   !< For sorting inside from outside
+  real, dimension(:,:),   intent(inout) :: color   !< For sorting inside from outside [nondim]
   integer, intent(in) :: cin    !< color for inside the domain
   integer, intent(in) :: cout   !< color for outside the domain
   integer, intent(in) :: cland  !< color for inside the land mask
@@ -5394,7 +5394,10 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
                           ! For salinity the units would be [ppt S-1 ~> 1]
   integer :: i, j, k, m, n, ntr, nz, ntr_id, fd_id
   integer :: ishift, idir, jshift, jdir
-  real :: resrv_lfac_out, resrv_lfac_in
+  real :: resrv_lfac_out  ! The reservoir inverse length scale scaling factor for the outward
+                          ! direction per field [nondim]
+  real :: resrv_lfac_in   ! The reservoir inverse length scale scaling factor for the inward
+                          ! direction per field [nondim]
   real :: b_in, b_out     ! The 0 and 1 switch for tracer reservoirs
                           ! 1 if the length scale of reservoir is zero [nondim]
   real :: a_in, a_out     ! The 0 and 1(-1) switch for reservoir source weights

--- a/src/diagnostics/MOM_spatial_means.F90
+++ b/src/diagnostics/MOM_spatial_means.F90
@@ -166,7 +166,7 @@ function global_area_integral(var, G, scale, area, tmp_scale)
   ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
   ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
   real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! An unscaled cell integral [a m2]
-  real :: scalefac  ! An overall scaling factor for the areas and variable.
+  real :: scalefac  ! An overall scaling factor for the areas and variable, perhaps in [m2 a A-1 L-2 ~> 1]
   real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
   integer :: i, j, is, ie, js, je
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -493,7 +493,7 @@ subroutine global_j_mean(array, j_mean, G, mask, scale, tmp_scale)
                                                             !! arbitrary, possibly rescaled units [A ~> a]
   real, dimension(SZI_(G)),         intent(out)   :: j_mean !<  Global mean of array along its j-axis [a] or [A ~> a]
   real, dimension(SZI_(G),SZJ_(G)), &
-                          optional, intent(in)    :: mask  !< An array used for weighting the j-mean
+                          optional, intent(in)    :: mask  !< An array used for weighting the j-mean [nondim]
   real,                   optional, intent(in)    :: scale !< A rescaling factor for the output variable [a A-1 ~> 1]
                                                            !! that converts it back to unscaled (e.g., mks)
                                                            !! units to enable the use of the reproducing sums

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2973,7 +2973,7 @@ end subroutine smooth_x9_h
 !! input fields have valid values in the first two halo points upon entry.
 subroutine smooth_x9_uv(G, field_u, field_v, zero_land)
   type(ocean_grid_type),             intent(in)    :: G         !< Ocean grid
-  real, dimension(SZIB_(G),SZJ_(G)), intent(inout) :: field_u   !< u-point field to be smoothed[arbitrary]
+  real, dimension(SZIB_(G),SZJ_(G)), intent(inout) :: field_u   !< u-point field to be smoothed [arbitrary]
   real, dimension(SZI_(G),SZJB_(G)), intent(inout) :: field_v   !< v-point field to be smoothed [arbitrary]
   logical,                 optional, intent(in)    :: zero_land !< If present and false, return the average
                                                                 !! of the surrounding ocean points when

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -146,15 +146,20 @@ type, public :: int_tide_CS ; private
                         !< The internal wave energy density as a function of (i,j,angle,frequency,mode)
                         !! integrated within an angular and frequency band [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode1(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 1
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 1 [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode2(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 2
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 2 [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode3(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 3
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 3 [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode4(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 4
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 4 [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode5(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 5
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 5 [R Z3 T-2 ~> J m-2]
 
   real, allocatable, dimension(:) :: frequency  !< The frequency of each band [T-1 ~> s-1].
 
@@ -1795,9 +1800,9 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
   real, dimension(G%isd:G%ied,G%JsdB:G%JedB),      &
                            intent(in)    :: speed_y !< The magnitude of the group velocity at the
                                                !! Cv points [L T-1 ~> m s-1].
-  real, dimension(Nangle), intent(in)    :: Cgy_av !< The average y-projection in each angular band.
+  real, dimension(Nangle), intent(in)    :: Cgy_av !< The average y-projection in each angular band [nondim]
   real, dimension(Nangle), intent(in)    :: dCgy !< The difference in y-projections between the
-                                               !! edges of each angular band.
+                                               !! edges of each angular band [nondim]
   real,                    intent(in)    :: dt !< Time increment [T ~> s].
   type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   type(int_tide_CS),       intent(in)    :: CS !< Internal tide control structure
@@ -2425,7 +2430,7 @@ subroutine register_int_tide_restarts(G, US, param_file, CS, restart_CS)
   character(64) :: var_name, cfr
 
   type(axis_info) :: axes_inttides(2)
-  real, dimension(:), allocatable :: angles, freqs
+  real, dimension(:), allocatable :: angles, freqs ! Lables for angles and frequencies [nondim]
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1936,12 +1936,12 @@ end function mixedlayer_restrat_unit_tests
 !> Returns true if any cell of u and u_true are not identical. Returns false otherwise.
 logical function test_answer(verbose, u, u_true, label, tol)
   logical,            intent(in) :: verbose !< If true, write results to stdout
-  real,               intent(in) :: u      !< Values to test
-  real,               intent(in) :: u_true !< Values to test against (correct answer)
+  real,               intent(in) :: u      !< Values to test in arbitrary units [A]
+  real,               intent(in) :: u_true !< Values to test against (correct answer) [A]
   character(len=*),   intent(in) :: label  !< Message
-  real, optional,     intent(in) :: tol    !< The tolerance for differences between u and u_true
+  real, optional,     intent(in) :: tol    !< The tolerance for differences between u and u_true [A]
   ! Local variables
-  real :: tolerance ! The tolerance for differences between u and u_true
+  real :: tolerance ! The tolerance for differences between u and u_true [A]
   integer :: k
 
   tolerance = 0.0 ; if (present(tol)) tolerance = tol

--- a/src/parameterizations/stochastic/MOM_stochastics.F90
+++ b/src/parameterizations/stochastic/MOM_stochastics.F90
@@ -35,9 +35,9 @@ type, public:: stochastic_CS
   integer :: id_epbl2_wts = -1 !< Diagnostic id for epbl dissipation perturbation
   ! stochastic patterns
   real, allocatable :: sppt_wts(:,:)  !< Random pattern for ocean SPPT
-                                     !! tendencies with a number between 0 and 2
-  real, allocatable :: epbl1_wts(:,:) !< Random pattern for K.E. generation
-  real, allocatable :: epbl2_wts(:,:) !< Random pattern for K.E. dissipation
+                                      !! tendencies with a number between 0 and 2 [nondim]
+  real, allocatable :: epbl1_wts(:,:) !< Random pattern for K.E. generation [nondim]
+  real, allocatable :: epbl2_wts(:,:) !< Random pattern for K.E. dissipation [nondim]
   type(diag_ctrl), pointer :: diag   !< structure used to regulate timing of diagnostic output
   type(time_type), pointer :: Time !< Pointer to model time (needed for sponges)
 end type stochastic_CS

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -551,12 +551,12 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
 
 end subroutine vertFPmix
 
-!> Returns the empirical shape-function given sigma.
+!> Returns the empirical shape-function given sigma [nondim]
 real function G_sig(sigma)
-  real , intent(in) :: sigma   !< non-dimensional normalized boundary layer depth [m]
+  real , intent(in) :: sigma    !< Normalized boundary layer depth [nondim]
 
   ! local variables
-  real :: p1, c2, c3  !< parameters used to fit and match empirycal shape-functions.
+  real :: p1, c2, c3  !< Parameters used to fit and match empirical shape-functions [nondim]
 
   ! parabola
   p1 = 0.287

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -45,8 +45,8 @@ type, public :: ISOMIP_tracer_CS ; private
   character(len = 200) :: tracer_IC_file !< The full path to the IC file, or " " to initialize internally.
   type(time_type), pointer :: Time !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the MOM tracer registry
-  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in g m-3?
-  real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out.
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in [conc] (g m-3)?
+  real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out [conc].
   logical :: use_sponge    !< If true, sponges may be applied somewhere in the domain.
 
   integer, dimension(NTR) :: ind_tr !< Indices returned by atmos_ocn_coupler_flux
@@ -80,7 +80,7 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=200) :: inputdir
   character(len=48)  :: flux_units ! The units for tracer fluxes, usually
                             ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [conc]
   logical :: register_ISOMIP_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke

--- a/src/tracer/MOM_CFC_cap.F90
+++ b/src/tracer/MOM_CFC_cap.F90
@@ -95,7 +95,7 @@ function register_CFC_cap(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
-  real, dimension(:,:,:), pointer :: tr_ptr => NULL()
+  real, dimension(:,:,:), pointer :: tr_ptr => NULL() ! A pointer to a CFC tracer [mol kg-1]
   character(len=200) :: CFC_BC_file           ! filename with cfc11 and cfc12 data
   character(len=30)  :: CFC_BC_var_name       ! varname of field in CFC_BC_file
   character :: m2char
@@ -285,10 +285,11 @@ subroutine init_tracer_CFC(h, tr, name, land_val, IC_val, G, GV, US, CS)
   type(verticalGrid_type),                   intent(in)  :: GV       !< The ocean's vertical grid structure.
   type(unit_scale_type),                     intent(in)  :: US       !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h        !< Layer thicknesses [H ~> m or kg m-2]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: tr       !< The tracer concentration array
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: tr       !< The tracer concentration array [mol kg-1]
   character(len=*),                          intent(in)  :: name     !< The tracer name
-  real,                                      intent(in)  :: land_val !< A value the tracer takes over land
-  real,                                      intent(in)  :: IC_val   !< The initial condition value for the tracer
+  real,                                      intent(in)  :: land_val !< A value the tracer takes over land [mol kg-1]
+  real,                                      intent(in)  :: IC_val   !< The initial condition value for the
+                                                                     !! tracer [mol kg-1]
   type(CFC_cap_CS),                          pointer     :: CS       !< The control structure returned by a
                                                                      !! previous call to register_CFC_cap.
 
@@ -480,10 +481,10 @@ subroutine CFC_cap_set_forcing(sfc_state, fluxes, day_start, day_interval, G, US
                          ! (saturation concentration) [mol kg-1].
     cfc11_atm, &         ! CFC11 atm mole fraction [pico mol/mol]
     cfc12_atm            ! CFC12 atm mole fraction [pico mol/mol]
-  real :: cfc11_atm_nh   ! NH value for cfc11_atm
-  real :: cfc11_atm_sh   ! SH value for cfc11_atm
-  real :: cfc12_atm_nh   ! NH value for cfc12_atm
-  real :: cfc12_atm_sh   ! SH value for cfc12_atm
+  real :: cfc11_atm_nh   ! NH value for cfc11_atm [pico mol/mol]
+  real :: cfc11_atm_sh   ! SH value for cfc11_atm [pico mol/mol]
+  real :: cfc12_atm_nh   ! NH value for cfc12_atm [pico mol/mol]
+  real :: cfc12_atm_sh   ! SH value for cfc12_atm [pico mol/mol]
   real :: ta             ! Absolute sea surface temperature [hectoKelvin]
   real :: sal            ! Surface salinity [PSU].
   real :: alpha_11       ! The solubility of CFC 11 [mol kg-1 atm-1].
@@ -670,7 +671,9 @@ logical function CFC_cap_unit_tests(verbose)
                                  !! information for debugging unit tests
 
   ! Local variables
-  real               :: dummy1, dummy2, ta, sal
+  real :: dummy1, dummy2 ! Test values of Schmidt numbers [nondim] or solubilities [mol kg-1 atm-1] for CFC11 and CFC12
+  real :: ta  ! A test value of temperature [hectoKelvin]
+  real :: sal ! A test value of salinity [ppt]
   character(len=120) :: test_name ! Title of the unit test
 
   CFC_cap_unit_tests = .false.
@@ -716,12 +719,12 @@ end function CFC_cap_unit_tests
 logical function compare_values(verbose, test_name, calc, ans, limit)
   logical,             intent(in) :: verbose   !< If true, write results to stdout
   character(len=80),   intent(in) :: test_name !< Brief description of the unit test
-  real,                intent(in) :: calc      !< computed value
-  real,                intent(in) :: ans       !< correct value
-  real,                intent(in) :: limit     !< value above which test fails
+  real,                intent(in) :: calc      !< computed value in abitrary units [A]
+  real,                intent(in) :: ans       !< correct value [A]
+  real,                intent(in) :: limit     !< value above which test fails [A]
 
   ! Local variables
-  real :: diff
+  real :: diff  ! Difference in values [A]
 
   diff = ans - calc
 

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -102,7 +102,7 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  real, dimension(:,:,:), pointer :: tr_ptr => NULL()
+  real, dimension(:,:,:), pointer :: tr_ptr => NULL() ! A pointer to a CFC tracer [mol m-3]
   real :: a11_dflt(4), a12_dflt(4) ! Default values of the various coefficients
   real :: d11_dflt(4), d12_dflt(4) ! in the expressions for the solubility and
   real :: e11_dflt(3), e12_dflt(3) ! Schmidt numbers [various units by element].
@@ -359,10 +359,11 @@ subroutine init_tracer_CFC(h, tr, name, land_val, IC_val, G, GV, US, CS)
   type(verticalGrid_type),                   intent(in)  :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type),                     intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h    !< Layer thicknesses [H ~> m or kg m-2]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: tr   !< The tracer concentration array
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: tr   !< The CFC tracer concentration array [mol m-3]
   character(len=*),                          intent(in)  :: name !< The tracer name
-  real,                                      intent(in)  :: land_val !< A value the tracer takes over land
-  real,                                      intent(in)  :: IC_val !< The initial condition value for the tracer
+  real,                                      intent(in)  :: land_val !< A value the tracer takes over land [mol m-3]
+  real,                                      intent(in)  :: IC_val !< The initial condition value for
+                                                                 !! the CRC tracer [mol m-3]
   type(OCMIP2_CFC_CS),                       pointer     :: CS   !< The control structure returned by a
                                                                  !! previous call to register_OCMIP2_CFC.
 
@@ -439,7 +440,7 @@ subroutine OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     CFC11_flux, &    ! The fluxes of CFC11 and CFC12 into the ocean, in unscaled units of
-    CFC12_flux       ! CFC concentrations times meters per second [CU R Z T-1 ~> CU kg m-2 s-1]
+    CFC12_flux       ! CFC concentrations times a vertical mass flux [mol R Z m-3 T-1 ~> mol kg m-3 s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
   integer :: i, j, k, is, ie, js, je, nz, idim(4), jdim(4)
 
@@ -545,8 +546,8 @@ subroutine OCMIP2_CFC_surface_state(sfc_state, h, G, GV, US, CS)
   real :: SST       ! Sea surface temperature [degC].
   real :: alpha_11  ! The solubility of CFC 11 [mol m-3 pptv-1].
   real :: alpha_12  ! The solubility of CFC 12 [mol m-3 pptv-1].
-  real :: sc_11, sc_12 ! The Schmidt numbers of CFC 11 and CFC 12.
-  real :: sc_no_term   ! A term related to the Schmidt number.
+  real :: sc_11, sc_12 ! The Schmidt numbers of CFC 11 and CFC 12 [nondim].
+  real :: sc_no_term   ! A term related to the Schmidt number [nondim].
   integer :: i, j, is, ie, js, je, idim(4), jdim(4)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -1023,7 +1023,8 @@ subroutine compute_tapering_coeffs(ne, bld_l, bld_r, coeff_l, coeff_r, h_l, h_r)
   real, dimension(ne),   intent(inout) :: coeff_r  !< Tapering coefficient, right column           [nondim]
 
   ! Local variables
-  real :: min_bld, max_bld                       ! Min/Max boundary layer depth in two adjacent columns
+  real :: min_bld         ! Minimum of the boundary layer depth in two adjacent columns [H ~> m or kg m-2]
+  real :: max_bld         ! Maximum of the boundary layer depth in two adjacent columns [H ~> m or kg m-2]
   integer :: dummy1                              ! dummy integer
   real    :: dummy2                              ! dummy real [nondim]
   integer :: k_min_l, k_min_r, k_max_l, k_max_r  ! Min/max vertical indices in two adjacent columns

--- a/src/tracer/MOM_offline_aux.F90
+++ b/src/tracer/MOM_offline_aux.F90
@@ -783,7 +783,7 @@ subroutine update_offline_from_arrays(G, GV, nk_input, ridx_sum, mean_file, sum_
   real, dimension(:,:,:,:), allocatable,     intent(inout) :: salt_all  !< Salinity array [S ~> ppt]
 
   integer :: i, j, k, is, ie, js, je, nz
-  real, parameter :: fill_value = 0.
+  real, parameter :: fill_value = 0. ! The fill value for input arrays [various]
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   ! Check that all fields are allocated (this is a redundant check)

--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -872,10 +872,8 @@ subroutine offline_advection_layer(fluxes, Time_start, time_interval, G, GV, US,
 
   ! Local variables
 
-  ! Remaining zonal mass transports [H L2 ~> m3 or kg]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV))   :: uhtr_sub
-  ! Remaining meridional mass transports [H L2 ~> m3 or kg]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV))   :: vhtr_sub
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: uhtr_sub ! Remaining zonal mass transports [H L2 ~> m3 or kg]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vhtr_sub ! Remaining meridional mass transports [H L2 ~> m3 or kg]
 
   real, dimension(SZI_(G),SZJB_(G)) :: rem_col_flux ! The summed absolute value of the remaining
                          ! fluxes through the faces of a column or within a column, in mks units [kg]

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -74,11 +74,11 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
   type(vardesc),        optional, intent(in)    :: tr_desc      !< A structure with metadata about the tracer
 
   real,                 optional, intent(in)    :: OBC_inflow   !< the tracer for all inflows via OBC for which OBC_in_u
-                                                                !! or OBC_in_v are not specified (units of tracer CONC)
+                                                                !! or OBC_in_v are not specified [CU ~> conc]
   real, dimension(:,:,:), optional, pointer     :: OBC_in_u     !< tracer at inflows through u-faces of
-                                                                !! tracer cells (units of tracer CONC)
+                                                                !! tracer cells [CU ~> conc]
   real, dimension(:,:,:), optional, pointer     :: OBC_in_v     !< tracer at inflows through v-faces of
-                                                                !! tracer cells (units of tracer CONC)
+                                                                !! tracer cells [CU ~> conc]
 
   ! The following are probably not necessary if registry_diags is present and true.
   real, dimension(:,:,:), optional, pointer     :: ad_x         !< diagnostic x-advective flux
@@ -99,21 +99,24 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
                                                                 !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
 
   real, dimension(:,:,:), optional, pointer     :: advection_xy !< convergence of lateral advective tracer fluxes
+                                                                !! [CU H T-1 ~> conc m s-1 or conc kg m-2 s-1]
   logical,              optional, intent(in)    :: registry_diags !< If present and true, use the registry for
                                                                 !! the diagnostics of this tracer.
   real,                 optional, intent(in)    :: conc_scale   !< A scaling factor used to convert the concentration
-                                                                !! of this tracer to its desired units.
+                                                                !! of this tracer to its desired units [conc CU-1 ~> 1]
   character(len=*),     optional, intent(in)    :: flux_nameroot !< Short tracer name snippet used construct the
                                                                 !! names of flux diagnostics.
   character(len=*),     optional, intent(in)    :: flux_longname !< A word or phrase used construct the long
                                                                 !! names of flux diagnostics.
   character(len=*),     optional, intent(in)    :: flux_units   !< The units for the fluxes of this tracer.
   real,                 optional, intent(in)    :: flux_scale   !< A scaling factor used to convert the fluxes
-                                                                !! of this tracer to its desired units.
+                                                                !! of this tracer to its desired units
+                                                                !! [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   character(len=*),     optional, intent(in)    :: convergence_units !< The units for the flux convergence of
                                                                 !! this tracer.
   real,                 optional, intent(in)    :: convergence_scale !< A scaling factor used to convert the flux
                                                                 !! convergence of this tracer to its desired units.
+                                                                !! [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   character(len=*),     optional, intent(in)    :: cmor_tendprefix !< The CMOR name for the layer-integrated
                                                                 !! tendencies of this tracer.
   integer,              optional, intent(in)    :: diag_form    !< An integer (1 or 2, 1 by default) indicating the
@@ -296,7 +299,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
   character(len=120) :: cmor_longname ! The CMOR long name of that variable.
   character(len=120) :: var_lname      ! A temporary longname for a diagnostic.
   character(len=120) :: cmor_var_lname ! The temporary CMOR long name for a diagnostic
-  real :: conversion ! Temporary term while we address a bug
+  real :: conversion ! Temporary term while we address a bug [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   type(tracer_type), pointer :: Tr=>NULL()
   integer :: i, j, k, is, ie, js, je, nz, m, m2, nTr_in
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -633,7 +636,7 @@ subroutine postALE_tracer_diagnostics(Reg, G, GV, diag, dt)
   type(diag_ctrl),            intent(in) :: diag !< regulates diagnostic output
   real,                       intent(in) :: dt   !< total time interval for these diagnostics [T ~> s]
 
-  real    :: work(SZI_(G),SZJ_(G),SZK_(GV))
+  real    :: work(SZI_(G),SZJ_(G),SZK_(GV)) ! Variance decay [CU2 T-1 ~> conc2 s-1]
   real    :: Idt ! The inverse of the time step [T-1 ~> s-1]
   integer :: i, j, k, is, ie, js, je, nz, m, m2
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -665,8 +668,9 @@ subroutine post_tracer_diagnostics_at_sync(Reg, h, diag_prev, diag, G, GV, dt)
   type(diag_ctrl),            intent(inout) :: diag !< structure to regulate diagnostic output
   real,                       intent(in) :: dt   !< total time step for tracer updates [T ~> s]
 
-  real    :: work3d(SZI_(G),SZJ_(G),SZK_(GV))
-  real    :: work2d(SZI_(G),SZJ_(G))
+  real    :: work3d(SZI_(G),SZJ_(G),SZK_(GV)) ! The time tendency of a diagnostic [CU T-1 ~> conc s-1]
+  real    :: work2d(SZI_(G),SZJ_(G)) ! The vertically integrated time tendency of a diagnostic
+                                     ! in [CU H T-1 ~> conc m s-1 or conc kg m-2 s-1]
   real    :: Idt ! The inverse of the time step [T-1 ~> s-1]
   type(tracer_type), pointer :: Tr=>NULL()
   integer :: i, j, k, is, ie, js, je, nz, m
@@ -717,7 +721,8 @@ subroutine post_tracer_transport_diagnostics(G, GV, Reg, h_diag, diag)
   type(diag_ctrl),            intent(in) :: diag !< structure to regulate diagnostic output
 
   integer :: i, j, k, is, ie, js, je, nz, m
-  real    :: work2d(SZI_(G),SZJ_(G))
+  real    :: work2d(SZI_(G),SZJ_(G))      ! The vertically integrated convergence of lateral advective
+                                          ! tracer fluxes [CU H T-1 ~> conc m s-1 or conc kg m-2 s-1]
   type(tracer_type), pointer :: Tr=>NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke

--- a/src/tracer/MOM_tracer_types.F90
+++ b/src/tracer/MOM_tracer_types.F90
@@ -68,7 +68,7 @@ type, public :: tracer_type
   real                            :: conc_underflow = 0.0     !< A magnitude of tracer concentrations below
                                                               !! which values should be set to 0. [CU ~> conc]
   real                            :: conc_scale = 1.0         !< A scaling factor used to convert the concentrations
-                                                              !! of this tracer to its desired units.
+                                                              !! of this tracer to its desired units [conc CU ~> 1]
   character(len=64)               :: cmor_name                !< CMOR name of this tracer
   character(len=64)               :: cmor_units               !< CMOR physical dimensions of the tracer
   character(len=240)              :: cmor_longname            !< CMOR long name of the tracer
@@ -79,11 +79,13 @@ type, public :: tracer_type
   real                            :: flux_scale = 1.0         !< A scaling factor used to convert the fluxes
                                                               !! of this tracer to its desired units,
                                                               !! including a factor compensating for H scaling.
+                                                              !! [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   character(len=48)               :: flux_units = ""          !< The units for fluxes of this variable.
   character(len=48)               :: conv_units = ""          !< The units for the flux convergence of this tracer.
   real                            :: conv_scale = 1.0         !< A scaling factor used to convert the flux
                                                               !! convergence of this tracer to its desired units,
                                                               !! including a factor compensating for H scaling.
+                                                              !! [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   character(len=48)               :: cmor_tendprefix = ""     !< The CMOR variable prefix for tendencies of this
                                                               !! tracer, required because CMOR does not follow any
                                                               !! discernable pattern for these names.

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -41,13 +41,13 @@ type, public :: boundary_impulse_tracer_CS ; private
   logical :: coupled_tracers = .false. !< These tracers are not offered to the  coupler.
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
-  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine, in g m-3?
+  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine, in [CU ~> conc] (g m-3)?
   logical :: tracers_may_reinit  !< If true, boundary_impulse can be initialized if not found in restart file
   integer, dimension(NTR_MAX) :: ind_tr  !< Indices returned by atmos_ocn_coupler_flux if it is used and the
                                          !! surface tracer concentrations are to be provided to the coupler.
 
   integer :: nkml !< Number of layers in mixed layer
-  real, dimension(NTR_MAX)  :: land_val = -1.0 !< A value to use to fill in tracers over land
+  real, dimension(NTR_MAX)  :: land_val = -1.0 !< A value to use to fill in tracers over land [CU ~> conc]
   real :: remaining_source_time !< How much longer (same units as the timestep) to
                                 !! inject the tracer at the surface [T ~> s]
 
@@ -80,8 +80,8 @@ function register_boundary_impulse_tracer(HI, GV, US, param_file, CS, tr_Reg, re
                             ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  real, pointer :: tr_ptr(:,:,:) => NULL()
-  real, pointer :: rem_time_ptr => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [CU ~> conc]
+  real, pointer :: rem_time_ptr => NULL() ! The ramaining injection time [T ~> s]
   logical :: register_boundary_impulse_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
@@ -235,7 +235,7 @@ subroutine boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, 
 
   ! Local variables
   integer :: i, j, k, is, ie, js, je, nz, m
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -34,7 +34,7 @@ type, public :: dyed_obc_tracer_CS ; private
   character(len=200) :: tracer_IC_file !< The full path to the IC file, or " " to initialize internally.
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
-  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this subroutine, in g m-3?
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this subroutine in [conc]
 
   integer, allocatable, dimension(:) :: ind_tr !< Indices returned by atmos_ocn_coupler_flux if it is used and the
                                                !! surface tracer concentrations are to be provided to the coupler.
@@ -66,7 +66,7 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=200) :: inputdir
   character(len=48)  :: flux_units ! The units for tracer fluxes, usually
                             ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [conc]
   logical :: register_dyed_obc_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -91,7 +91,7 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=40)  :: mdl = "ideal_age_example" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [years]
   logical :: register_ideal_age_tracer
   logical :: do_ideal_age, do_vintage, do_ideal_age_dated, do_BL_residence
   integer :: isd, ied, jsd, jed, nz, m

--- a/src/tracer/nw2_tracers.F90
+++ b/src/tracer/nw2_tracers.F90
@@ -33,7 +33,7 @@ type, public :: nw2_tracers_CS ; private
   integer :: ntr = 0  !< The number of tracers that are actually used.
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
-  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in g m-3?
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in [conc] (g m-3)?
   real, allocatable , dimension(:) :: restore_rate !< The rate at which the tracer is damped toward
                                              !! its target profile [T-1 ~> s-1]
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
@@ -60,7 +60,7 @@ logical function register_nw2_tracers(HI, GV, US, param_file, CS, tr_Reg, restar
 # include "version_variable.h"
   character(len=40)  :: mdl = "nw2_tracers" ! This module's name.
   character(len=8)  :: var_name ! The variable's name.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [conc]
   integer :: isd, ied, jsd, jed, nz, m, ig
   integer :: n_groups ! Number of groups of three tracers (i.e. # tracers/3)
   real, allocatable, dimension(:) :: timescale_in_days ! Damping timescale [days]
@@ -216,7 +216,7 @@ subroutine nw2_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
   integer :: i, j, k, m
   real :: dt_x_rate ! dt * restoring rate [nondim]
   real :: rscl ! z* scaling factor [nondim]
-  real :: target_value ! tracer value
+  real :: target_value ! tracer target value for damping [conc]
 
 ! if (.not.associated(CS)) return
 

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -92,7 +92,7 @@ function register_oil_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   character(len=3)   :: name_tag ! String for creating identifying oils
   character(len=48) :: flux_units ! The units for tracer fluxes, here
                             ! kg(oil) s-1 or kg(oil) m-3 kg(water) s-1.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [kg m-3]
   logical :: register_oil_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -73,7 +73,7 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=48)  :: var_name ! The variable's name.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [ppt]
   logical :: register_pseudo_salt_tracer
   integer :: isd, ied, jsd, jed, nz
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke


### PR DESCRIPTION
  Added or corrected the units in comments describing about 115 real variables scattered across 14 tracer modules and 10 other modules.  All answers are bitwise identical, and only comments are changed.